### PR TITLE
feat: add AMD Inference King Champion Belt media mention

### DIFF
--- a/packages/app/src/components/media/media-data.ts
+++ b/packages/app/src/components/media/media-data.ts
@@ -18,6 +18,13 @@ export const MEDIA_ITEMS: MediaItem[] = [
     date: '2026-03-20',
   },
   {
+    title: 'AMD Head of AI Product, Ramine Roane, shows his Inference King Champion Belt',
+    organization: 'AMD',
+    url: 'https://x.com/roaner/status/2034700440173154368',
+    type: 'video',
+    date: '2026-03-19',
+  },
+  {
     title: 'NVIDIA H200 vs B200 vs GB200: Which GPU to Rent for AI in 2026?',
     organization: 'Spheron Network',
     url: 'https://www.spheron.network/blog/nvidia-h200-vs-b200-vs-gb200/',


### PR DESCRIPTION
## Summary
- Add AMD Head of AI Product Ramine Roane's "Inference King Champion Belt" video post to media mentions
- Dated 2026-03-19, type: video

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)