### PR TITLE
feat: add Jensen GTC 2026 Inference King media mention

### DIFF
--- a/packages/app/src/components/media/media-data.ts
+++ b/packages/app/src/components/media/media-data.ts
@@ -54,6 +54,13 @@ export const MEDIA_ITEMS: MediaItem[] = [
     date: '2026-03-17',
   },
   {
+    title: 'GTC 2026: Jensen announces that he is one of the Inference King',
+    organization: 'NVIDIA',
+    url: 'https://x.com/dylan522p/status/2034501674711302339',
+    type: 'video',
+    date: '2026-03-16',
+  },
+  {
     title: 'How NVIDIA Dynamo 1.0 Powers Multi-Node Inference at Production Scale',
     organization: 'NVIDIA Developer Blog',
     url: 'https://developer.nvidia.com/blog/nvidia-dynamo-1-production-ready/',


### PR DESCRIPTION
## Summary
- Add Jensen Huang's GTC 2026 "Inference King" announcement video to media mentions
- Dated 2026-03-16, organization: NVIDIA, type: video

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)