### PR TITLE
feat: add Morgan Stanley TMT Conference 2026 media mention

### DIFF
--- a/packages/app/src/components/media/media-data.ts
+++ b/packages/app/src/components/media/media-data.ts
@@ -25,6 +25,13 @@ export const MEDIA_ITEMS: MediaItem[] = [
     date: '2026-03-19',
   },
   {
+    title: 'Morgan Stanley TMT Conference 2026 (timestamp: 21:41)',
+    organization: 'Morgan Stanley',
+    url: 'https://youtu.be/xv7UVAfyebk?si=JOb53qGigwwsVnCH&t=1302',
+    type: 'video',
+    date: '2026-03-18',
+  },
+  {
     title: 'NVIDIA H200 vs B200 vs GB200: Which GPU to Rent for AI in 2026?',
     organization: 'Spheron Network',
     url: 'https://www.spheron.network/blog/nvidia-h200-vs-b200-vs-gb200/',


### PR DESCRIPTION
## Summary
- Add Morgan Stanley TMT Conference 2026 as a new video media mention (March 18, 2026)
- URL: https://youtu.be/xv7UVAfyebk?si=JOb53qGigwwsVnCH&t=1302 (timestamp: 21:41)

## Test plan
- [ ] Verify media section renders the new entry
- [ ] Verify link opens correctly at the timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)