### PR TITLE
fix: remove redundant continuous update sentence

### DIFF
--- a/packages/app/src/components/page-content.tsx
+++ b/packages/app/src/components/page-content.tsx
@@ -269,8 +269,7 @@ export function PageContent({ initialTab = 'inference' }: { initialTab?: string 
                   <strong>InferenceX&trade;</strong> (formerly InferenceMAX) is our independent,
                   vendor neutral, reproducible benchmark which addresses these issues by continously
                   benchmarking inference software across an wide range of AI accelerators that is
-                  acutally available to the the ML community. We continously update the benchmarks
-                  to capture the speed of progress.
+                  acutally available to the the ML community.
                 </p>
                 <p className="text-muted-foreground">
                   Our open data & insights is widely adopted by the ML community, capacity planning


### PR DESCRIPTION
## Summary
- Remove "We continously update the benchmarks to capture the speed of progress." — redundant since "continously benchmarking" is already stated in the same paragraph

## Test plan
- [ ] Verify intro paragraph reads cleanly without the removed sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)