### PR TITLE
feat: add EE Times GTC 2026 Inference King media mention

### DIFF
--- a/.claude/commands/add-media.md
+++ b/.claude/commands/add-media.md
@@ -1,0 +1,37 @@
+---
+allowed-tools: Read, Edit, Glob, Grep, WebFetch, Bash(git *), Bash(gh *), AskUserQuestion
+description: Add a new "In the Media" mention to InferenceX
+---
+
+Add a new media mention to the InferenceX media page.
+
+## Step 1: Gather details
+
+The user will provide a URL. If not provided via $ARGUMENTS, ask for it.
+
+## Step 2: Extract article info
+
+- Fetch the URL with WebFetch to get the **title**, **organization/publisher**, **date**, and **type** (article or video)
+- If WebFetch fails/times out, infer from the URL slug and ask the user to confirm
+- YouTube/video URLs → type `video`, all others → type `article`
+
+## Step 3: Confirm with user
+
+Show the extracted details and ask the user to confirm or correct:
+
+- **Title**: extracted title
+- **Organization**: publisher name
+- **Date**: publication date (YYYY-MM-DD)
+- **Type**: article or video
+
+## Step 4: Add to media-data.ts
+
+- Read `packages/app/src/components/media/media-data.ts`
+- Insert the new entry in **date-sorted order** (newest first)
+- Find the right position by comparing dates
+
+## Step 5: Create branch and PR
+
+- If not already on a feature branch, create one from `origin/master`: `feat/add-{org-slug}-media-mention`
+- Commit with message: `feat: add {Org} {title snippet} media mention`
+- Push and create a PR

--- a/packages/app/src/components/media/media-data.ts
+++ b/packages/app/src/components/media/media-data.ts
@@ -10,6 +10,13 @@ export interface MediaItem {
 
 export const MEDIA_ITEMS: MediaItem[] = [
   {
+    title: 'GTC 2026 Keynote: Long Live the Inference King',
+    organization: 'EE Times',
+    url: 'https://www.eetimes.com/gtc-2026-keynote-long-live-the-inference-king/',
+    type: 'article',
+    date: '2026-03-20',
+  },
+  {
     title:
       '\u82F1\u4F1F\u8FBE\u70ED\u70B9\u5C0F\u65F6\u62A5: \u6570\u636E\u4E2D\u5FC3\u5C31\u662FToken\u5DE5\u5382 \u2014 Jensen Huang GTC 2026',
     organization: 'Sina Tech',


### PR DESCRIPTION
## Summary
- Add EE Times article "GTC 2026 Keynote: Long Live the Inference King" to media mentions (March 20, 2026)

## Test plan
- [ ] Verify media section renders the new entry
- [ ] Verify link opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)