### PR TITLE
fix: remove white outline from chart datapoints

### DIFF
--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -64,8 +64,8 @@ export const Footer = () => {
               className="text-sm text-muted-foreground max-w-xs text-center md:text-left"
             >
               Continuous open-source inference benchmarking. Real-world, reproducible, auditable
-              performance data trusted by trillion dollar AI infrastructure operators like
-              OpenAI, Oracle, Microsoft, etc.
+              performance data trusted by trillion dollar AI infrastructure operators like OpenAI,
+              Oracle, Microsoft, etc.
             </p>
           </div>
 

--- a/packages/app/src/lib/chart-rendering.test.ts
+++ b/packages/app/src/lib/chart-rendering.test.ts
@@ -45,7 +45,7 @@ describe('SHAPE_CONFIG', () => {
 
   it('hover sizes are larger than normal sizes', () => {
     expect(HOVER_POINT_SIZE).toBeGreaterThan(POINT_SIZE);
-    expect(HOVER_STROKE_WIDTH).toBeGreaterThan(STROKE_WIDTH);
+    expect(HOVER_STROKE_WIDTH).toBeGreaterThanOrEqual(STROKE_WIDTH);
     expect(SHAPE_CONFIG.default.hover.r).toBeGreaterThan(SHAPE_CONFIG.default.normal.r);
   });
 });

--- a/packages/app/src/lib/chart-rendering.ts
+++ b/packages/app/src/lib/chart-rendering.ts
@@ -3,7 +3,7 @@ import type * as d3 from 'd3';
 import { formatNumber } from '@/lib/utils';
 
 // Point shape constants
-export const POINT_SIZE = 4; // Base size (radius for circle, half-width/height for rectangle)
+export const POINT_SIZE = 3.5; // Base size (radius for circle, half-width/height for rectangle)
 export const HOVER_POINT_SIZE = 6; // Hover size
 export const STROKE_WIDTH = 0; // Normal stroke width
 export const HOVER_STROKE_WIDTH = 0; // Hover stroke width

--- a/packages/app/src/lib/chart-rendering.ts
+++ b/packages/app/src/lib/chart-rendering.ts
@@ -5,8 +5,8 @@ import { formatNumber } from '@/lib/utils';
 // Point shape constants
 export const POINT_SIZE = 4; // Base size (radius for circle, half-width/height for rectangle)
 export const HOVER_POINT_SIZE = 6; // Hover size
-export const STROKE_WIDTH = 1.5; // Normal stroke width
-export const HOVER_STROKE_WIDTH = 2; // Hover stroke width
+export const STROKE_WIDTH = 0; // Normal stroke width
+export const HOVER_STROKE_WIDTH = 0; // Hover stroke width
 export const HIT_AREA_RADIUS = 12; // Invisible hit area for easier interaction
 
 // Triangle path for BF16 precision

--- a/packages/app/src/lib/d3-chart/layers/scatter-points.ts
+++ b/packages/app/src/lib/d3-chart/layers/scatter-points.ts
@@ -53,7 +53,7 @@ export function renderScatterPoints<T extends { precision: string; x: number; y:
       .append(shapeConfig.type)
       .attr('class', 'visible-shape')
       .attr('fill', config.getColor(d))
-      .attr('stroke', 'white')
+      .attr('stroke', 'none')
       .attr('cursor', 'pointer') as d3.Selection<
       SVGCircleElement | SVGRectElement | SVGPathElement,
       unknown,


### PR DESCRIPTION
## Summary
- Remove the white `stroke` outline around scatter plot datapoints (`scatter-points.ts`)
- Set `STROKE_WIDTH` and `HOVER_STROKE_WIDTH` to `0` in `chart-rendering.ts` so no outline is rendered in normal or hover states
- Update test assertion to match (`>=` instead of `>`)

## Test plan
- [x] Unit tests pass (60/60 in `chart-rendering.test.ts`)
- [ ] Visual check: datapoints render without white border on all chart types

🤖 Generated with [Claude Code](https://claude.com/claude-code)