### PR TITLE
fix: rename Meta MSL to Meta Superintelligence Labs

### DIFF
--- a/packages/app/src/components/intro-section.tsx
+++ b/packages/app/src/components/intro-section.tsx
@@ -66,7 +66,7 @@ export function IntroSection() {
                 'WEKA',
                 'Stanford',
                 'Core42',
-                'Meta MSL',
+                'Meta Superintelligence Labs',
               ].includes(q.org),
             )}
             overrides={{

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -282,7 +282,7 @@ export const QUOTES: Quote[] = [
     text: 'PyTorch was built on the belief that open tools accelerate the entire AI ecosystem. InferenceX\u2122 embodies that same philosophy\u2014open, reproducible, and vendor-neutral benchmarks that give the community real data on real hardware. As inference workloads scale to serve billions of users, having a continuously updated, transparent performance baseline across accelerators is essential for practitioners and platform teams making critical infrastructure decisions.',
     name: 'Joseph Spisak',
     title: 'Product Director, Meta Super Intelligence Lab',
-    org: 'Meta MSL',
+    org: 'Meta Superintelligence Labs',
     logo: 'meta.svg',
     link: 'https://www.linkedin.com/in/jspisak',
   },


### PR DESCRIPTION
## Summary
- Rename org from "Meta MSL" to "Meta Superintelligence Labs" in Joseph Spisak's supporter quote and homepage carousel whitelist

## Test plan
- [ ] Verify quote on `/quotes` page shows "Meta Superintelligence Labs"
- [ ] Verify homepage carousel label shows "Meta Superintelligence Labs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)