### PR TITLE
mockup: add curated landing page to reduce clicks-to-insight

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -28,7 +28,7 @@ describe('Header', () => {
 
   it('shows Dashboard nav link', () => {
     cy.get('[data-testid="nav-link-dashboard"]').should('be.visible');
-    cy.get('[data-testid="nav-link-dashboard"]').should('have.attr', 'href', '/');
+    cy.get('[data-testid="nav-link-dashboard"]').should('have.attr', 'href', '/inference');
   });
 
   it('shows Media nav link', () => {

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -52,11 +52,12 @@ describe('Header', () => {
     cy.get('[data-testid="theme-toggle"]').should('be.visible');
   });
 
-  it('shows mobile nav links on small viewports', () => {
+  it('shows mobile hamburger menu on small viewports', () => {
     cy.viewport(375, 812);
-    cy.get('[data-testid="mobile-nav"]').should('be.visible');
-    cy.get('[data-testid="mobile-nav"]').contains('Dashboard').should('be.visible');
-    cy.get('[data-testid="mobile-nav"]').contains('Media').should('be.visible');
-    cy.get('[data-testid="mobile-nav"]').contains('Supporters').should('be.visible');
+    cy.get('[data-testid="mobile-menu-toggle"]').should('be.visible');
+    cy.get('[data-testid="mobile-menu-toggle"]').click();
+    cy.contains('Dashboard').should('be.visible');
+    cy.contains('Media').should('be.visible');
+    cy.contains('Supporters').should('be.visible');
   });
 });

--- a/packages/app/cypress/e2e/csv-export.cy.ts
+++ b/packages/app/cypress/e2e/csv-export.cy.ts
@@ -3,7 +3,7 @@ describe('CSV Export', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="chart-figure"]').should('exist');
   });
 

--- a/packages/app/cypress/e2e/custom-user-values.cy.ts
+++ b/packages/app/cypress/e2e/custom-user-values.cy.ts
@@ -3,7 +3,7 @@ describe('Custom User Values', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="model-selector"]').should('be.visible');
   });
 

--- a/packages/app/cypress/e2e/drill-down-trend.cy.ts
+++ b/packages/app/cypress/e2e/drill-down-trend.cy.ts
@@ -8,7 +8,7 @@ describe('Drill-Down Trend Chart Modal', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     // Wait for scatter graph to render with data points
     cy.get('[data-testid="scatter-graph"]')
       .first()

--- a/packages/app/cypress/e2e/favorite-presets.cy.ts
+++ b/packages/app/cypress/e2e/favorite-presets.cy.ts
@@ -1,6 +1,6 @@
 describe('Favorite Presets', () => {
   before(() => {
-    cy.visit('/', {
+    cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },

--- a/packages/app/cypress/e2e/favorite-presets.cy.ts
+++ b/packages/app/cypress/e2e/favorite-presets.cy.ts
@@ -18,8 +18,8 @@ describe('Favorite Presets', () => {
     cy.get('[data-testid="favorites-panel"]').should('be.visible');
   });
 
-  it('shows all 6 preset cards', () => {
-    cy.get('[data-testid^="favorite-preset-"]').should('have.length', 6);
+  it('shows all 9 preset cards', () => {
+    cy.get('[data-testid^="favorite-preset-"]').should('have.length', 9);
   });
 
   it('each preset card has a title and description', () => {

--- a/packages/app/cypress/e2e/gpu-power.cy.ts
+++ b/packages/app/cypress/e2e/gpu-power.cy.ts
@@ -5,7 +5,7 @@ function unlockPowerX() {
 
 describe('PowerX', () => {
   beforeEach(() => {
-    cy.visit('/', {
+    cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
@@ -32,7 +32,7 @@ describe('PowerX', () => {
 
   describe('(unlocked)', () => {
     beforeEach(() => {
-      cy.visit('/', {
+      cy.visit('/inference', {
         onBeforeLoad(win) {
           win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
           win.localStorage.setItem('inferencex-powerx-unlocked', '1');

--- a/packages/app/cypress/e2e/gpu-specs.cy.ts
+++ b/packages/app/cypress/e2e/gpu-specs.cy.ts
@@ -371,7 +371,7 @@ describe('GPU Specs Radar Chart View', () => {
 
 describe('GPU Specs Navigation', () => {
   it('tab switcher activates GPU Specs', () => {
-    cy.visit('/');
+    cy.visit('/inference');
     // Wait for tabs to be rendered and page to be interactive
     cy.get('[role="tablist"]').should('be.visible');
     // Use force:true to handle potential pointer-events:none from modals/overlays

--- a/packages/app/cypress/e2e/gradient-labels.cy.ts
+++ b/packages/app/cypress/e2e/gradient-labels.cy.ts
@@ -1,6 +1,6 @@
 describe('Gradient Labels Toggle', () => {
   before(() => {
-    cy.visit('/', {
+    cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
@@ -117,7 +117,7 @@ describe('Gradient Labels with non-default Y-axis metrics', () => {
   };
 
   before(() => {
-    cy.visit('/', {
+    cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },

--- a/packages/app/cypress/e2e/high-contrast.cy.ts
+++ b/packages/app/cypress/e2e/high-contrast.cy.ts
@@ -3,7 +3,7 @@ describe('High Contrast Mode', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="scatter-graph"]').should('exist');
   });
 

--- a/packages/app/cypress/e2e/inference-chart.cy.ts
+++ b/packages/app/cypress/e2e/inference-chart.cy.ts
@@ -3,7 +3,7 @@ describe('Inference Chart', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
   });
 
   it('renders the inference chart display wrapper', () => {

--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -2,7 +2,7 @@ describe('Model Architecture Diagram', () => {
   before(() => {
     // Use desktop viewport to ensure all UI elements are visible
     cy.viewport(1280, 800);
-    cy.visit('/', {
+    cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },

--- a/packages/app/cypress/e2e/performance.cy.ts
+++ b/packages/app/cypress/e2e/performance.cy.ts
@@ -1,7 +1,7 @@
 describe('Performance', () => {
   it('page loads quickly', () => {
     const startTime = Date.now();
-    cy.visit('/');
+    cy.visit('/inference');
     cy.document().then(() => {
       const loadTime = Date.now() - startTime;
       const threshold = 5_000;
@@ -18,7 +18,7 @@ describe('Performance', () => {
   });
 
   it('no excessive layout shift issues', () => {
-    cy.visit('/');
+    cy.visit('/inference');
     cy.wait(5000);
 
     // Measure CLS using PerformanceObserver

--- a/packages/app/cypress/e2e/sanity.cy.ts
+++ b/packages/app/cypress/e2e/sanity.cy.ts
@@ -31,8 +31,8 @@ describe('Page Load & Navigation', () => {
   it('page loads without 404 errors', () => {
     cy.visit('/inference');
     cy.get('[data-testid="scatter-graph"]').should('exist');
-    cy.get('h1').should('not.contain.text', '404');
-    cy.get('h1').should('not.contain.text', 'Not Found');
+    cy.contains('404').should('not.exist');
+    cy.contains('Not Found').should('not.exist');
   });
 });
 

--- a/packages/app/cypress/e2e/sanity.cy.ts
+++ b/packages/app/cypress/e2e/sanity.cy.ts
@@ -3,7 +3,7 @@
 
 describe('Page Load & Navigation', () => {
   before(() => {
-    cy.visit('/');
+    cy.visit('/inference');
   });
 
   it('page loads with correct title', () => {
@@ -23,13 +23,13 @@ describe('Page Load & Navigation', () => {
     });
 
     // Re-visit to capture errors from a fresh load
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="scatter-graph"]').should('exist');
     cy.wrap(errors).should('have.length', 0);
   });
 
   it('page loads without 404 errors', () => {
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="scatter-graph"]').should('exist');
     cy.get('h1').should('not.contain.text', '404');
     cy.get('h1').should('not.contain.text', 'Not Found');
@@ -45,7 +45,7 @@ describe('Theme Toggle', () => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       win.localStorage.setItem('theme', 'light');
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="theme-toggle"]').click();
     cy.get('html').should('have.class', 'dark');
     cy.reload();

--- a/packages/app/cypress/e2e/tabs.cy.ts
+++ b/packages/app/cypress/e2e/tabs.cy.ts
@@ -3,7 +3,7 @@ describe('Chart Section Tabs — E2E', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
   });
 
   it('updates the URL path when switching tabs', () => {
@@ -28,7 +28,7 @@ describe('Chart Section Tabs — E2E', () => {
 
   it('shows mobile chart select dropdown on small viewport', () => {
     cy.viewport(375, 812);
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="mobile-chart-select"]').should('be.visible');
   });
 });

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -8,7 +8,7 @@ describe('TCO Calculator', () => {
       cy.window().then((win) => {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       });
-      cy.visit('/');
+      cy.visit('/inference');
     });
 
     it('shows the TCO Calculator tab trigger', () => {

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -3,7 +3,7 @@ describe('TTFT X-Axis Toggle (E2E chart)', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 2);
   });
 

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -39,7 +39,7 @@ describe('URL Parameter Persistence', () => {
     });
 
     it('changing Y-axis metric via dropdown updates SVG axis label', () => {
-      cy.visit('/');
+      cy.visit('/inference');
 
       cy.get('[data-testid="scatter-graph"]')
         .first()
@@ -59,7 +59,7 @@ describe('URL Parameter Persistence', () => {
     });
 
     it('selecting a Y-axis metric updates the displayed value', () => {
-      cy.visit('/');
+      cy.visit('/inference');
       cy.get('[data-testid="yaxis-metric-selector"]').click();
       cy.get('[role="option"]')
         .eq(1)
@@ -73,7 +73,7 @@ describe('URL Parameter Persistence', () => {
     });
 
     it('switching to energy metric updates SVG axis label to joules', () => {
-      cy.visit('/');
+      cy.visit('/inference');
       cy.get('[data-testid="scatter-graph"]').first().should('be.visible');
 
       cy.get('[data-testid="yaxis-metric-selector"]').click();

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -11,7 +11,7 @@ describe('URL Parameter Persistence', () => {
   });
 
   it('page loads without error with unknown params', () => {
-    cy.visit('/?unknown_param=test');
+    cy.visit('/inference?unknown_param=test');
     cy.get('[data-testid="inference-chart-display"]').should('exist');
   });
 

--- a/packages/app/cypress/e2e/yaxis-metrics-render.cy.ts
+++ b/packages/app/cypress/e2e/yaxis-metrics-render.cy.ts
@@ -32,7 +32,7 @@ describe('Y-Axis Metrics All Render Data', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/');
+    cy.visit('/inference');
     cy.get('[data-testid="scatter-graph"]')
       .first()
       .find('svg .dot-group')

--- a/packages/app/src/app/[[...tab]]/page.tsx
+++ b/packages/app/src/app/[[...tab]]/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 
+import { LandingPage } from '@/components/landing/landing-page';
 import { PageContent } from '@/components/page-content';
-import { TAB_META, VALID_TABS } from '@/lib/tab-meta';
+import { LANDING_META, TAB_META, VALID_TABS } from '@/lib/tab-meta';
 import { SITE_URL } from '@semianalysisai/inferencex-constants';
 
 export const dynamicParams = true;
@@ -17,11 +18,30 @@ export async function generateMetadata({
   params: Promise<{ tab?: string[] }>;
 }): Promise<Metadata> {
   const { tab } = await params;
-  const activeTab = tab?.[0] ?? 'inference';
+
+  // Landing page metadata
+  if (!tab || tab.length === 0) {
+    return {
+      title: LANDING_META.title,
+      description: LANDING_META.description,
+      alternates: { canonical: SITE_URL },
+      openGraph: {
+        title: LANDING_META.title,
+        description: LANDING_META.description,
+        url: SITE_URL,
+      },
+      twitter: {
+        title: LANDING_META.title,
+        description: LANDING_META.description,
+      },
+    };
+  }
+
+  const activeTab = tab[0];
   const meta = TAB_META[activeTab as keyof typeof TAB_META];
   if (!meta) return {};
 
-  const url = activeTab === 'inference' ? SITE_URL : `${SITE_URL}/${activeTab}`;
+  const url = `${SITE_URL}/${activeTab}`;
 
   return {
     title: meta.title,
@@ -39,11 +59,36 @@ export async function generateMetadata({
   };
 }
 
-export default async function Page({ params }: { params: Promise<{ tab?: string[] }> }) {
+export default async function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ tab?: string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   const { tab } = await params;
-  const activeTab = tab?.[0] ?? 'inference';
 
-  if (!VALID_TABS.includes(activeTab as (typeof VALID_TABS)[number]) || (tab && tab.length > 1)) {
+  // Landing page at /
+  if (!tab || tab.length === 0) {
+    // Backward compat: if / has chart query params, redirect to /inference with them
+    const search = await searchParams;
+    const hasChartParams = Object.keys(search).some(
+      (k) => k.startsWith('g_') || k.startsWith('i_') || k.startsWith('e_') || k.startsWith('r_'),
+    );
+    if (hasChartParams) {
+      const qs = new URLSearchParams(
+        Object.entries(search).flatMap(([k, v]) =>
+          Array.isArray(v) ? v.map((val) => [k, val]) : v != null ? [[k, v]] : [],
+        ),
+      ).toString();
+      redirect(`/inference?${qs}`);
+    }
+    return <LandingPage />;
+  }
+
+  const activeTab = tab[0];
+
+  if (!VALID_TABS.includes(activeTab as (typeof VALID_TABS)[number]) || tab.length > 1) {
     notFound();
   }
 

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -353,3 +353,18 @@
 .star-button-glow {
   animation: star-glow 2s ease-in-out infinite;
 }
+
+/* CTA button glow animation - brand colored */
+@keyframes cta-glow {
+  0%,
+  100% {
+    box-shadow: none;
+  }
+  50% {
+    box-shadow: 0 0 12px 3px var(--color-brand, oklch(65% 0.15 250)) / 50%;
+  }
+}
+
+.cta-button-glow {
+  animation: cta-glow 2s ease-in-out infinite;
+}

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -361,7 +361,7 @@
     box-shadow: none;
   }
   50% {
-    box-shadow: 0 0 12px 3px oklch(65% 0.15 250 / 50%);
+    box-shadow: 0 0 20px 6px oklch(65% 0.18 250 / 60%);
   }
 }
 

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -361,7 +361,7 @@
     box-shadow: none;
   }
   50% {
-    box-shadow: 0 0 12px 3px var(--color-brand, oklch(65% 0.15 250)) / 50%;
+    box-shadow: 0 0 12px 3px oklch(65% 0.15 250 / 50%);
   }
 }
 

--- a/packages/app/src/components/favorites/FavoritePresetsDropdown.tsx
+++ b/packages/app/src/components/favorites/FavoritePresetsDropdown.tsx
@@ -2,6 +2,7 @@
 
 import { track } from '@/lib/analytics';
 import { ChevronDown, Star } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
@@ -189,6 +190,25 @@ export default function FavoritePresetsDropdown() {
     },
     [activePresetId, applyPreset, clearPreset],
   );
+
+  // Auto-apply preset from URL param (e.g., /inference?g_preset=gb200-vs-b200)
+  const searchParams = useSearchParams();
+  const urlPresetAppliedRef = useRef(false);
+  useEffect(() => {
+    if (urlPresetAppliedRef.current) return;
+    const presetId = searchParams.get('g_preset');
+    if (!presetId) return;
+    const preset = FAVORITE_PRESETS.find((p) => p.id === presetId);
+    if (preset) {
+      urlPresetAppliedRef.current = true;
+      applyPreset(preset);
+      track('preset_applied_from_url', { preset_id: presetId });
+      // Strip g_preset from URL to keep it clean
+      const url = new URL(window.location.href);
+      url.searchParams.delete('g_preset');
+      window.history.replaceState(null, '', url.pathname + url.search);
+    }
+  }, [searchParams, applyPreset]);
 
   const activePreset = activePresetId
     ? FAVORITE_PRESETS.find((p) => p.id === activePresetId)

--- a/packages/app/src/components/favorites/FavoritePresetsDropdown.tsx
+++ b/packages/app/src/components/favorites/FavoritePresetsDropdown.tsx
@@ -2,7 +2,6 @@
 
 import { track } from '@/lib/analytics';
 import { ChevronDown, Star } from 'lucide-react';
-import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
@@ -192,11 +191,11 @@ export default function FavoritePresetsDropdown() {
   );
 
   // Auto-apply preset from URL param (e.g., /inference?g_preset=gb200-vs-b200)
-  const searchParams = useSearchParams();
   const urlPresetAppliedRef = useRef(false);
   useEffect(() => {
     if (urlPresetAppliedRef.current) return;
-    const presetId = searchParams.get('g_preset');
+    const params = new URLSearchParams(window.location.search);
+    const presetId = params.get('g_preset');
     if (!presetId) return;
     const preset = FAVORITE_PRESETS.find((p) => p.id === presetId);
     if (preset) {
@@ -204,11 +203,11 @@ export default function FavoritePresetsDropdown() {
       applyPreset(preset);
       track('preset_applied_from_url', { preset_id: presetId });
       // Strip g_preset from URL to keep it clean
-      const url = new URL(window.location.href);
-      url.searchParams.delete('g_preset');
-      window.history.replaceState(null, '', url.pathname + url.search);
+      params.delete('g_preset');
+      const qs = params.toString();
+      window.history.replaceState(null, '', window.location.pathname + (qs ? `?${qs}` : ''));
     }
-  }, [searchParams, applyPreset]);
+  }, [applyPreset]);
 
   const activePreset = activePresetId
     ? FAVORITE_PRESETS.find((p) => p.id === activePresetId)

--- a/packages/app/src/components/favorites/favorite-presets.ts
+++ b/packages/app/src/components/favorites/favorite-presets.ts
@@ -219,4 +219,62 @@ export const FAVORITE_PRESETS: FavoritePreset[] = [
       dateRangeMonths: 2,
     },
   },
+  // 7 — NVIDIA Generations
+  {
+    id: 'nvidia-generations',
+    title: 'H100 → H200 → B200 — NVIDIA Generations',
+    description:
+      'Three generations of NVIDIA datacenter GPUs compared on DeepSeek R1 (1k/8k) at FP8.',
+    tags: ['DeepSeek', 'H100', 'H200', 'B200', 'FP8'],
+    category: 'comparison',
+    config: {
+      model: Model.DeepSeek_R1,
+      sequence: Sequence.OneK_EightK,
+      precisions: ['fp8'],
+      yAxisMetric: 'y_tpPerGpu',
+      hwFilter: ['h100', 'h200', 'b200'],
+    },
+  },
+  // 8 — GB300 vs GB200
+  {
+    id: 'gb300-vs-gb200',
+    title: 'GB300 vs GB200 — NVL72 Comparison',
+    description:
+      'GB300 NVL72 vs GB200 NVL72 disaggregated multi-node performance on DeepSeek R1 (1k/1k) at FP4.',
+    tags: ['DeepSeek', 'GB300', 'GB200', 'NVL72', 'FP4'],
+    category: 'comparison',
+    config: {
+      model: Model.DeepSeek_R1,
+      sequence: Sequence.OneK_OneK,
+      precisions: ['fp4'],
+      yAxisMetric: 'y_tpPerGpu',
+      hwFilter: ['gb300', 'gb200'],
+    },
+  },
+  // 9 — Cross-vendor: GB200 vs MI355X
+  {
+    id: 'gb200-vs-mi355x',
+    title: 'GB200 NVL72 vs MI355X — NVIDIA vs AMD',
+    description:
+      'Cross-vendor flagship comparison on DeepSeek R1 (1k/8k) at FP8. Multi-node NVL72 vs single-node MI355X.',
+    tags: ['DeepSeek', 'GB200', 'MI355X', 'FP8', 'NVL72'],
+    category: 'comparison',
+    config: {
+      model: Model.DeepSeek_R1,
+      sequence: Sequence.OneK_EightK,
+      precisions: ['fp8'],
+      yAxisMetric: 'y_tpPerGpu',
+      hwFilter: ['gb200', 'mi355x'],
+    },
+  },
+];
+
+/** Curated presets shown on the landing page. */
+export const LANDING_PRESETS: FavoritePreset[] = [
+  FAVORITE_PRESETS.find((p) => p.id === 'nvidia-generations')!,
+  FAVORITE_PRESETS.find((p) => p.id === 'amd-generations')!,
+  FAVORITE_PRESETS.find((p) => p.id === 'gb300-vs-gb200')!,
+  FAVORITE_PRESETS.find((p) => p.id === 'gb200-vs-mi355x')!,
+  FAVORITE_PRESETS.find((p) => p.id === 'gb200-vs-b200')!,
+  FAVORITE_PRESETS.find((p) => p.id === 'b200-vs-h200')!,
 ];

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -12,7 +12,7 @@ import { GitHubStars } from './GithubStars';
 
 const NAV_LINKS = [
   {
-    href: '/',
+    href: '/inference',
     label: 'Dashboard',
     testId: 'nav-link-dashboard',
     event: 'header_dashboard_clicked',
@@ -28,12 +28,12 @@ const NAV_LINKS = [
 ] as const;
 
 function isActive(pathname: string, href: string): boolean {
-  if (href === '/')
+  if (href === '/inference')
     return (
-      pathname === '/' ||
-      (!pathname.startsWith('/media') &&
-        !pathname.startsWith('/quotes') &&
-        !pathname.startsWith('/blog'))
+      pathname !== '/' &&
+      !pathname.startsWith('/media') &&
+      !pathname.startsWith('/quotes') &&
+      !pathname.startsWith('/blog')
     );
   return pathname.startsWith(href);
 }
@@ -72,9 +72,11 @@ export const Header = () => {
         <div className="flex flex-col gap-2 p-4 lg:p-8">
           <div className="flex flex-row gap-4 lg:gap-8">
             <div className="flex flex-col justify-center">
-              <h1 className="scroll-m-20 text-2xl md:text-3xl lg:text-5xl font-bold tracking-tight text-balance">
-                InferenceX
-              </h1>
+              <Link href="/" className="hover:opacity-80 transition-opacity w-fit">
+                <h1 className="scroll-m-20 text-2xl md:text-3xl lg:text-5xl font-bold tracking-tight text-balance">
+                  InferenceX
+                </h1>
+              </Link>
               <p className="text-xs md:text-sm text-muted-foreground italic pl-2">
                 (formerly InferenceMAX)
               </p>

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 
 import { ModeToggle } from '@/components/ui/mode-toggle';
@@ -38,97 +39,132 @@ function isActive(pathname: string, href: string): boolean {
   return pathname.startsWith(href);
 }
 
-const baseClasses =
-  'items-center px-3 py-1.5 rounded-md border transition-colors text-sm font-medium';
-const inactiveClasses =
-  'border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800';
-const activeClasses = 'bg-brand/10 border-brand/50 text-brand';
-
 export const Header = () => {
   const pathname = usePathname() ?? '/';
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close menu on route change
+  useEffect(() => {
+    setMobileMenuOpen(false);
+  }, [pathname]);
+
+  // Close menu on click outside
+  useEffect(() => {
+    if (!mobileMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMobileMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [mobileMenuOpen]);
+
+  const toggleMenu = useCallback(() => {
+    setMobileMenuOpen((prev) => !prev);
+    track('header_mobile_menu_toggled');
+  }, []);
 
   return (
-    <header
-      data-testid="header"
-      className={cn(
-        'before:absolute',
-        'before:bg-muted/50',
-        'dark:before:bg-muted',
-        'before:bottom-0',
-        'before:content-[""]',
-        'before:hidden lg:before:block',
-        'before:top-0',
-        'before:w-1/2',
-        'before:h-full',
-        'before:left-0',
-        "before:mask-[url('/brand/left-pattern-full.svg')]",
-        'before:mask-no-repeat',
-        'before:mask-position-[top_right]',
-        'before:mask-size-[100%]',
-        'before:-z-10',
-      )}
-    >
-      <div className="container mx-auto py-4 lg:p-8">
-        <div className="flex flex-col gap-2 p-4 lg:p-8">
-          <div className="flex flex-row gap-4 lg:gap-8">
-            <div className="flex flex-col justify-center">
-              <Link href="/" className="hover:opacity-80 transition-opacity w-fit">
-                <h1 className="scroll-m-20 text-2xl md:text-3xl lg:text-5xl font-bold tracking-tight text-balance">
-                  InferenceX
-                </h1>
-              </Link>
-              <p className="text-xs md:text-sm text-muted-foreground italic pl-2">
-                (formerly InferenceMAX)
-              </p>
-              <div className="flex flex-row gap-2 text-sm lg:text-base items-center pl-25 md:pl-28 lg:pl-45 -mt-1 md:-mt-2 lg:-mt-9">
-                By
-                <Link className="hover:underline" target="_blank" href="https://semianalysis.com/">
-                  <Image
-                    src="/brand/logo-color.webp"
-                    alt="SemiAnalysis logo"
-                    width={128}
-                    height={53}
-                    className="inline w-[64px] md:w-[96px] lg:w-[128px]"
-                    priority
-                  />
-                </Link>
-              </div>
-            </div>
-            <div className="ml-auto flex items-center gap-2">
-              {NAV_LINKS.map(({ href, label, testId, event }) => (
-                <Link
-                  key={href}
-                  data-testid={testId}
-                  href={href}
-                  className={cn(
-                    'hidden md:flex',
-                    baseClasses,
-                    isActive(pathname, href) ? activeClasses : inactiveClasses,
-                  )}
-                  onClick={() => track(event)}
-                >
-                  {label}
-                </Link>
-              ))}
-              <GitHubStars owner="SemiAnalysisAI" repo="InferenceX" />
-              <ModeToggle />
-            </div>
-          </div>
-          <div data-testid="mobile-nav" className="flex md:hidden items-center gap-2 mt-8">
-            {NAV_LINKS.map(({ href, label, event }) => (
+    <header data-testid="header" className="border-b border-border/40">
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="flex h-14 items-center gap-6">
+          {/* Brand */}
+          <Link href="/" className="flex items-center gap-2 shrink-0">
+            <span className="text-lg font-bold tracking-tight">InferenceX</span>
+            <span className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground">
+              by
+              <Image
+                src="/brand/logo-color.webp"
+                alt="SemiAnalysis logo"
+                width={64}
+                height={27}
+                className="inline w-[48px]"
+                priority
+              />
+            </span>
+          </Link>
+
+          {/* Desktop nav */}
+          <nav className="hidden md:flex items-center gap-1">
+            {NAV_LINKS.map(({ href, label, testId, event }) => (
               <Link
                 key={href}
+                data-testid={testId}
                 href={href}
                 className={cn(
-                  'flex',
-                  baseClasses,
-                  isActive(pathname, href) ? activeClasses : inactiveClasses,
+                  'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
+                  isActive(pathname, href)
+                    ? 'text-brand bg-brand/10'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted',
                 )}
                 onClick={() => track(event)}
               >
                 {label}
               </Link>
             ))}
+          </nav>
+
+          {/* Right side */}
+          <div className="ml-auto flex items-center gap-2">
+            <GitHubStars owner="SemiAnalysisAI" repo="InferenceX" />
+            <ModeToggle />
+
+            {/* Mobile hamburger */}
+            <div ref={menuRef} className="relative md:hidden">
+              <button
+                type="button"
+                data-testid="mobile-menu-toggle"
+                onClick={toggleMenu}
+                className="flex items-center justify-center w-9 h-9 rounded-md transition-colors hover:bg-muted cursor-pointer"
+                aria-expanded={mobileMenuOpen}
+                aria-label="Navigation menu"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  {mobileMenuOpen ? (
+                    <>
+                      <line x1="18" y1="6" x2="6" y2="18" />
+                      <line x1="6" y1="6" x2="18" y2="18" />
+                    </>
+                  ) : (
+                    <>
+                      <line x1="4" y1="6" x2="20" y2="6" />
+                      <line x1="4" y1="12" x2="20" y2="12" />
+                      <line x1="4" y1="18" x2="20" y2="18" />
+                    </>
+                  )}
+                </svg>
+              </button>
+              {mobileMenuOpen && (
+                <div className="absolute right-0 top-full mt-2 z-50 flex flex-col rounded-lg border border-border bg-background p-1.5 shadow-lg min-w-[160px]">
+                  {NAV_LINKS.map(({ href, label, event }) => (
+                    <Link
+                      key={href}
+                      href={href}
+                      className={cn(
+                        'px-3 py-2 rounded-md text-sm font-medium transition-colors',
+                        isActive(pathname, href)
+                          ? 'text-brand bg-brand/10'
+                          : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+                      )}
+                      onClick={() => track(event)}
+                    >
+                      {label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -73,6 +73,10 @@ export const Header = () => {
           {/* Brand */}
           <Link href="/" className="flex items-center gap-2 shrink-0">
             <span className="text-lg font-bold tracking-tight">InferenceX</span>
+            <span className="hidden lg:inline text-xs text-muted-foreground">
+              Open Source Continuous Inference Benchmark trusted by Operators of Trillion Dollar
+              GigaWatt Scale Token Factories
+            </span>
             <span className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground">
               by
               <Image

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -73,10 +73,6 @@ export const Header = () => {
           {/* Brand */}
           <Link href="/" className="flex items-center gap-2 shrink-0">
             <span className="text-lg font-bold tracking-tight">InferenceX</span>
-            <span className="hidden lg:inline text-xs text-muted-foreground">
-              Open Source Continuous Inference Benchmark trusted by Operators of Trillion Dollar
-              GigaWatt Scale Token Factories
-            </span>
             <span className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground">
               by
               <Image

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -42,7 +42,8 @@ export function LandingPage() {
         <section>
           <Card data-testid="landing-hero">
             <h2 className="text-lg font-semibold mb-2">
-              Open Source Continuous Inference Benchmark
+              Open Source Continuous Inference Benchmark trusted by Operators of Trillion Dollar
+              GigaWatt Scale Token Factories
             </h2>
             <p className="text-muted-foreground text-sm">
               Independent, vendor-neutral benchmarks comparing AI inference performance across GPUs

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -72,7 +72,7 @@ export function LandingPage() {
           <Button
             asChild
             size="lg"
-            className="text-base px-8 py-6 font-semibold"
+            className="text-base px-8 py-6 font-semibold bg-brand text-white hover:bg-brand/90"
             data-testid="landing-cta"
           >
             <Link href="/inference" onClick={() => track('landing_explore_clicked')}>

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -37,7 +37,7 @@ const LANDING_QUOTES = QUOTES.filter((q) =>
 export function LandingPage() {
   return (
     <main className="relative">
-      <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-8 pb-8">
+      <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-3 pb-8">
         {/* Hero */}
         <section>
           <Card data-testid="landing-hero">

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -72,7 +72,7 @@ export function LandingPage() {
           <Button
             asChild
             size="lg"
-            className="text-base px-8 py-6 font-semibold bg-brand text-white hover:bg-brand/90"
+            className="cta-button-glow text-base px-8 py-6 font-semibold bg-brand text-white hover:bg-brand/90"
             data-testid="landing-cta"
           >
             <Link href="/inference" onClick={() => track('landing_explore_clicked')}>
@@ -85,7 +85,7 @@ export function LandingPage() {
         {/* Curated Views */}
         <section>
           <h3 className="text-base font-semibold mb-3">Popular Comparisons</h3>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
             {LANDING_PRESETS.map((preset) => (
               <PresetCard key={preset.id} preset={preset} />
             ))}

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -46,7 +46,7 @@ export function LandingPage() {
             </h2>
             <p className="text-muted-foreground text-sm">
               Independent, vendor-neutral benchmarks comparing AI inference performance across GPUs
-              and frameworks. Trusted by operators of trillion-dollar-scale token factories.
+              and frameworks.
             </p>
 
             {/* Quote Carousel */}

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import { LANDING_PRESETS } from '@/components/favorites/favorite-presets';
+import { PresetCard } from '@/components/landing/preset-card';
+import { QuoteCarousel } from '@/components/quote-carousel';
+import { QUOTES } from '@/components/quotes/quotes-data';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { track } from '@/lib/analytics';
+
+const LANDING_QUOTES = QUOTES.filter((q) =>
+  [
+    'OpenAI',
+    'Microsoft',
+    'Together AI',
+    'vLLM',
+    'GPU Mode',
+    'PyTorch Foundation',
+    'Oracle',
+    'CoreWeave',
+    'Nebius',
+    'Crusoe',
+    'TensorWave',
+    'SGLang',
+    'WEKA',
+    'Stanford',
+    'Core42',
+    'Meta Superintelligence Labs',
+    'Hugging Face',
+    'UC Berkeley',
+  ].includes(q.org),
+);
+
+export function LandingPage() {
+  return (
+    <main className="relative">
+      <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-8 pb-8">
+        {/* Hero */}
+        <section>
+          <Card data-testid="landing-hero">
+            <h2 className="text-lg font-semibold mb-2">
+              Open Source Continuous Inference Benchmark
+            </h2>
+            <p className="text-muted-foreground text-sm">
+              Independent, vendor-neutral benchmarks comparing AI inference performance across GPUs
+              and frameworks. Trusted by operators of trillion-dollar-scale token factories.
+            </p>
+
+            {/* Quote Carousel */}
+            <div className="mt-4 pt-4 border-t border-foreground">
+              <QuoteCarousel
+                quotes={LANDING_QUOTES}
+                overrides={{
+                  order: ['OpenAI'],
+                  labels: {
+                    'Together AI': 'Tri Dao',
+                    'PyTorch Foundation': 'PyTorch',
+                  },
+                }}
+                moreHref="/quotes"
+              />
+            </div>
+          </Card>
+        </section>
+
+        {/* CTA */}
+        <section className="flex justify-center">
+          <Button
+            asChild
+            size="lg"
+            className="text-base px-8 py-6 font-semibold"
+            data-testid="landing-cta"
+          >
+            <Link href="/inference" onClick={() => track('landing_explore_clicked')}>
+              Explore Full Dashboard
+              <ArrowRight className="ml-1 h-4 w-4" />
+            </Link>
+          </Button>
+        </section>
+
+        {/* Curated Views */}
+        <section>
+          <h3 className="text-base font-semibold mb-3">Popular Comparisons</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {LANDING_PRESETS.map((preset) => (
+              <PresetCard key={preset.id} preset={preset} />
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/components/landing/preset-card.tsx
+++ b/packages/app/src/components/landing/preset-card.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+
+import type { FavoritePreset } from '@/components/favorites/favorite-presets';
+import { Badge } from '@/components/ui/badge';
+import { track } from '@/lib/analytics';
+
+export function PresetCard({ preset }: { preset: FavoritePreset }) {
+  return (
+    <Link
+      href={`/inference?g_preset=${preset.id}`}
+      data-testid={`landing-preset-${preset.id}`}
+      onClick={() =>
+        track('landing_preset_clicked', {
+          preset_id: preset.id,
+          preset_title: preset.title,
+        })
+      }
+      className="group flex flex-col rounded-xl border border-border bg-card/90 p-4 md:p-5 transition-all duration-200 hover:border-brand/50 hover:bg-card"
+    >
+      <p className="font-semibold text-sm leading-tight mb-1.5">{preset.title}</p>
+      <p className="text-xs text-muted-foreground leading-snug mb-3 line-clamp-2">
+        {preset.description}
+      </p>
+      <div className="flex flex-wrap gap-1 mt-auto">
+        {preset.tags.map((tag) => (
+          <Badge key={tag} variant="outline" className="text-[10px] px-1.5 py-0 leading-tight">
+            {tag}
+          </Badge>
+        ))}
+      </div>
+      <div className="flex items-center gap-1 mt-3 text-xs text-brand opacity-0 group-hover:opacity-100 transition-opacity">
+        View comparison
+        <ArrowRight className="h-3 w-3" />
+      </div>
+    </Link>
+  );
+}

--- a/packages/app/src/components/page-content.tsx
+++ b/packages/app/src/components/page-content.tsx
@@ -3,7 +3,6 @@
 import { ChartTabs } from '@/components/chart-tabs';
 import { ExportNudge } from '@/components/export-nudge';
 import { GitHubStarModal } from '@/components/github-star-modal';
-import { IntroSection } from '@/components/intro-section';
 import { StarNudge } from '@/components/star-nudge';
 import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
 
@@ -16,7 +15,6 @@ export function PageContent({ initialTab = 'inference' }: { initialTab?: string 
       <UnofficialRunProvider>
         <main className="relative">
           <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-4">
-            <IntroSection />
             <ChartTabs initialTab={initialTab} />
           </div>
         </main>

--- a/packages/app/src/lib/tab-meta.ts
+++ b/packages/app/src/lib/tab-meta.ts
@@ -50,6 +50,12 @@ export const TAB_META: Record<TabKey, { title: string; description: string }> = 
   },
 };
 
+export const LANDING_META = {
+  title: `${SITE_NAME} — Open Source AI Inference Benchmark by ${AUTHOR_NAME}`,
+  description:
+    'Compare AI inference performance across NVIDIA and AMD GPUs. Open-source benchmark covering GB300, B200, MI355X, and more.',
+};
+
 const TITLE_SUFFIX = `${SITE_NAME} by ${AUTHOR_NAME}`;
 
 export function isValidTab(value: string): value is TabKey {


### PR DESCRIPTION
## Summary

- Adds a new landing page at `/` with curated preset cards that let users gain insights in 1 click instead of 10-30
- Dashboard moves from `/` to `/inference` — advanced users just need 1 extra click
- 6 curated comparison cards: NVIDIA generations, AMD generations, GB300 vs GB200, GB200 vs MI355X, GB200 vs B200, B200 vs H200
- `g_preset` URL param auto-applies presets when navigating from landing page to dashboard
- Backward-compatible: existing share links with chart params (`/?g_model=...`) auto-redirect to `/inference?g_model=...`
- Removes the 3-paragraph intro wall of text from the dashboard view

## Test plan

- [ ] `/` shows landing page with hero, quote carousel, CTA button, and 6 preset cards
- [ ] Clicking a preset card navigates to `/inference?g_preset=<id>` and auto-applies the preset (correct model, GPUs filtered)
- [ ] "Explore Full Dashboard" CTA navigates to `/inference` with default view
- [ ] Header "Dashboard" link goes to `/inference`, "InferenceX" title links to `/`
- [ ] Existing share links like `/?g_model=DeepSeek-R1-0528&i_prec=fp8` redirect to `/inference?...`
- [ ] All unit tests pass (1805/1805)
- [ ] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)