### PR TITLE
feat: add line labels toggle to scatter chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@
 
 # wsl shenanigans
 C:*
+.vercel

--- a/packages/app/cypress/e2e/line-labels.cy.ts
+++ b/packages/app/cypress/e2e/line-labels.cy.ts
@@ -1,0 +1,81 @@
+describe('Line Labels Toggle', () => {
+  before(() => {
+    cy.visit('/inference', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    // Wait for chart to load
+    cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    cy.get('.sidebar-legend').first().should('be.visible');
+  });
+
+  it('Line Labels toggle exists in the legend', () => {
+    cy.get('#scatter-line-labels').should('exist');
+    cy.get('label[for="scatter-line-labels"]').should('contain.text', 'Line Labels');
+  });
+
+  it('Line Labels toggle is off by default', () => {
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
+  });
+
+  it('toggling Line Labels on renders label elements on the chart', () => {
+    cy.get('#scatter-line-labels').click();
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+
+    // Line label groups should appear in the SVG
+    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length.greaterThan', 0);
+  });
+
+  it('line labels have colored background rects and text', () => {
+    // Each line label group should contain a background rect and text
+    cy.get('[data-testid="scatter-graph"] svg g.line-label .ll-bg').should(
+      'have.length.greaterThan',
+      0,
+    );
+    cy.get('[data-testid="scatter-graph"] svg g.line-label .ll-text').should(
+      'have.length.greaterThan',
+      0,
+    );
+  });
+
+  it('toggling Line Labels off removes label elements', () => {
+    cy.get('#scatter-line-labels').click();
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
+
+    // Line label groups should no longer exist
+    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length', 0);
+  });
+
+  it('Line Labels can be enabled alongside Gradient Labels', () => {
+    cy.get('#scatter-line-labels').click();
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+
+    cy.get('#scatter-gradient-labels').click();
+    cy.get('#scatter-gradient-labels').should('have.attr', 'data-state', 'checked');
+
+    // Both should be checked
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+    cy.get('#scatter-gradient-labels').should('have.attr', 'data-state', 'checked');
+
+    // Line labels should still render
+    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length.greaterThan', 0);
+
+    // Reset
+    cy.get('#scatter-line-labels').click();
+    cy.get('#scatter-gradient-labels').click();
+  });
+
+  it('URL param i_linelabel=1 enables line labels on load', () => {
+    cy.visit('/inference?i_linelabel=1', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+
+    // Labels should be rendered
+    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length.greaterThan', 0);
+  });
+});

--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -209,6 +209,8 @@ export function createMockInferenceContext(
     setUseAdvancedLabels: namedStub('setUseAdvancedLabels'),
     showGradientLabels: false,
     setShowGradientLabels: namedStub('setShowGradientLabels'),
+    showLineLabels: false,
+    setShowLineLabels: namedStub('setShowLineLabels'),
     selectedGPUs: [],
     setSelectedGPUs: namedStub('setSelectedGPUs'),
     availableGPUs: [

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -127,6 +127,7 @@ export function InferenceProvider({
   const [showGradientLabels, setShowGradientLabels] = useState(
     () => getUrlParam('i_gradlabel') === '1',
   );
+  const [showLineLabels, setShowLineLabels] = useState(() => getUrlParam('i_linelabel') === '1');
   const [userCosts, setUserCosts] = useState<{ [gpuKey: string]: number | undefined } | null>(null);
   const [userPowers, setUserPowers] = useState<{ [gpuKey: string]: number | undefined } | null>(
     null,
@@ -603,6 +604,7 @@ export function InferenceProvider({
       i_legend: isLegendExpanded ? '' : '0',
       i_advlabel: useAdvancedLabels ? '1' : '',
       i_gradlabel: showGradientLabels ? '1' : '',
+      i_linelabel: showLineLabels ? '1' : '',
     },
     [
       selectedYAxisMetric,
@@ -619,6 +621,7 @@ export function InferenceProvider({
       isLegendExpanded,
       useAdvancedLabels,
       showGradientLabels,
+      showLineLabels,
     ],
   );
 
@@ -812,6 +815,8 @@ export function InferenceProvider({
       setUseAdvancedLabels,
       showGradientLabels,
       setShowGradientLabels,
+      showLineLabels,
+      setShowLineLabels,
       trackedConfigs,
       addTrackedConfig,
       removeTrackedConfig,
@@ -863,6 +868,7 @@ export function InferenceProvider({
       isLegendExpanded,
       useAdvancedLabels,
       showGradientLabels,
+      showLineLabels,
       userCosts,
       userPowers,
       trackedConfigs,

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -491,6 +491,8 @@ export interface InferenceChartContextType {
   setUseAdvancedLabels: (useAdvancedLabels: boolean) => void;
   showGradientLabels: boolean;
   setShowGradientLabels: (showGradientLabels: boolean) => void;
+  showLineLabels: boolean;
+  setShowLineLabels: (showLineLabels: boolean) => void;
   selectedGPUs: string[];
   setSelectedGPUs: (gpus: string[]) => void;
   availableGPUs: { value: string; label: string }[];

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -109,6 +109,8 @@ const ScatterGraph = React.memo(
       setUseAdvancedLabels,
       showGradientLabels,
       setShowGradientLabels,
+      showLineLabels,
+      setShowLineLabels,
       trackedConfigs,
       addTrackedConfig,
       removeTrackedConfig,
@@ -516,6 +518,15 @@ const ScatterGraph = React.memo(
             if (!isRooflineVisible(this)) return 0;
             return this.getAttribute('data-hw-key') === hwKey ? null : '0.15';
           });
+        root
+          .selectAll<SVGGElement, unknown>('.parallelism-label, .line-label')
+          .transition('legend-hover')
+          .duration(150)
+          .style('opacity', function () {
+            const hw = (this as SVGGElement).getAttribute('data-hw-key');
+            if (!hw) return 0;
+            return hw === hwKey ? 1 : 0;
+          });
       },
       [isPointVisible, isRooflineVisible],
     );
@@ -536,7 +547,19 @@ const ScatterGraph = React.memo(
         .style('opacity', function () {
           return isRooflineVisible(this) ? 1 : 0;
         });
-    }, [isPointVisible, isRooflineVisible]);
+      root
+        .selectAll<SVGGElement, unknown>('.parallelism-label, .line-label')
+        .transition('legend-hover')
+        .duration(150)
+        .style('opacity', function () {
+          const hw = (this as SVGGElement).getAttribute('data-hw-key');
+          const prec = (this as SVGGElement).getAttribute('data-precision');
+          if (!hw) return 0;
+          // Line labels have no precision attr — always visible if hw is active
+          if (!prec) return effectiveActiveHwTypes.has(hw) ? 1 : 0;
+          return effectiveActiveHwTypes.has(hw) && selectedPrecisions.includes(prec) ? 1 : 0;
+        });
+    }, [isPointVisible, isRooflineVisible, effectiveActiveHwTypes, selectedPrecisions]);
 
     // --- Zoom config ---
     const eventPrefix = chartDefinition.chartType === 'e2e' ? 'latency' : 'interactivity';
@@ -845,6 +868,192 @@ const ScatterGraph = React.memo(
                 .attr('height', bbox.height + py * 2)
                 .attr('fill', d.color);
             });
+
+          // ── Line labels (run name along each roofline) ──
+          type LineLabel = {
+            key: string;
+            hw: string;
+            label: string;
+            color: string;
+            x: number;
+            y: number;
+            visible: boolean;
+          };
+          const lineLabels: LineLabel[] = [];
+
+          if (showLineLabels) {
+            const isInteractivity = chartDefinition.chartType === 'interactivity';
+            const LABEL_H = 18;
+            const LABEL_W = 120; // approximate label width for overlap check
+
+            if (isInteractivity) {
+              // Greedy placement: try top-left → midpoint → right-side → hide
+              const placed: { x: number; y: number }[] = [];
+
+              const collides = (cx: number, cy: number) =>
+                placed.some((p) => Math.abs(p.y - cy) < LABEL_H && Math.abs(p.x - cx) < LABEL_W);
+
+              // Deduplicate by hw key — pick the roofline with most points per hw
+              const bestByHw = new Map<string, (typeof entries)[0]>();
+              for (const e of entries) {
+                if (!e.visible || e.points.length < 2) continue;
+                const prev = bestByHw.get(e.hw);
+                if (!prev || e.points.length > prev.points.length) bestByHw.set(e.hw, e);
+              }
+
+              // Sort entries by highest y-value first (top of chart) for priority
+              const sorted = [...bestByHw.values()].sort((a, b) => {
+                const ay = yScale(a.points[0].y);
+                const by = yScale(b.points[0].y);
+                return ay - by; // smaller pixel y = higher on chart
+              });
+
+              for (const entry of sorted) {
+                const pts = entry.points;
+                const candidates = [
+                  pts[Math.min(1, pts.length - 1)], // top-left (near start)
+                  pts[Math.floor(pts.length / 2)], // midpoint
+                  pts[Math.max(0, Math.floor((pts.length * 2) / 3))], // right-third
+                  pts[pts.length - 1], // endpoint
+                ];
+
+                const { label } = parseHwKeyToLabel(entry.hw);
+                let foundPlacement = false;
+                for (const pt of candidates) {
+                  const px = xScale(pt.x);
+                  const py = yScale(pt.y);
+                  if (!collides(px, py)) {
+                    lineLabels.push({
+                      key: entry.key,
+                      hw: entry.hw,
+                      label,
+                      color: getCssColor(resolveColor(entry.hw)),
+                      x: px,
+                      y: py,
+                      visible: true,
+                    });
+                    placed.push({ x: px, y: py });
+                    foundPlacement = true;
+                    break;
+                  }
+                }
+                // If all candidates collide, hide this label
+                if (!foundPlacement) {
+                  const pt = pts[0];
+                  lineLabels.push({
+                    key: entry.key,
+                    hw: entry.hw,
+                    label,
+                    color: getCssColor(resolveColor(entry.hw)),
+                    x: xScale(pt.x),
+                    y: yScale(pt.y),
+                    visible: false,
+                  });
+                }
+              }
+
+              // Also add hidden entries for non-visible hw (so D3 data-join is clean)
+              const labeledHw = new Set(lineLabels.map((l) => l.hw));
+              for (const entry of entries) {
+                if (entry.points.length >= 2 && !labeledHw.has(entry.hw)) {
+                  const { label } = parseHwKeyToLabel(entry.hw);
+                  lineLabels.push({
+                    key: entry.key,
+                    hw: entry.hw,
+                    label,
+                    color: getCssColor(resolveColor(entry.hw)),
+                    x: xScale(entry.points[0].x),
+                    y: yScale(entry.points[0].y),
+                    visible: false,
+                  });
+                  labeledHw.add(entry.hw);
+                }
+              }
+            } else {
+              // TTFT / E2EL: endpoint labels, one per hw key
+              const seenHw = new Set<string>();
+              for (const entry of entries) {
+                if (entry.points.length < 2 || seenHw.has(entry.hw)) continue;
+                seenHw.add(entry.hw);
+                const pt = entry.points[entry.points.length - 1];
+                const { label } = parseHwKeyToLabel(entry.hw);
+                lineLabels.push({
+                  key: entry.key,
+                  hw: entry.hw,
+                  label,
+                  color: getCssColor(resolveColor(entry.hw)),
+                  x: xScale(pt.x),
+                  y: yScale(pt.y),
+                  visible: entry.visible,
+                });
+              }
+              const visible = lineLabels.filter((l) => l.visible);
+              if (visible.length > 1) {
+                const yRange = yScale.range();
+                const top = Math.min(yRange[0], yRange[1]) + LABEL_H;
+                const bottom = Math.max(yRange[0], yRange[1]) - LABEL_H;
+                visible.sort((a, b) => a.y - b.y);
+                for (let pass = 0; pass < 5; pass++) {
+                  for (let i = 1; i < visible.length; i++) {
+                    const overlap = visible[i - 1].y + LABEL_H - visible[i].y;
+                    if (overlap > 0) {
+                      const half = overlap / 2;
+                      visible[i - 1].y -= half;
+                      visible[i].y += half;
+                    }
+                  }
+                  for (const l of visible) {
+                    l.y = Math.max(top, Math.min(bottom, l.y));
+                  }
+                }
+              }
+            }
+          }
+
+          zoomGroup
+            .selectAll<SVGGElement, LineLabel>('.line-label')
+            .data(lineLabels, (d) => d.key)
+            .join(
+              (enter) => {
+                const g = enter
+                  .append('g')
+                  .attr('class', 'line-label')
+                  .style('pointer-events', 'none')
+                  .attr('transform', (d) => `translate(${d.x},${d.y})`);
+                g.append('rect')
+                  .attr('class', 'll-bg')
+                  .attr('rx', 4)
+                  .attr('ry', 4)
+                  .attr('opacity', 0.95);
+                g.append('text')
+                  .attr('class', 'll-text')
+                  .attr('text-anchor', 'start')
+                  .attr('dominant-baseline', 'central')
+                  .attr('fill', 'white')
+                  .attr('font-size', '10px')
+                  .attr('font-weight', '600');
+                return g;
+              },
+              (update) => update,
+              (exit) => exit.remove(),
+            )
+            .attr('data-line-key', (d) => d.key)
+            .attr('data-hw-key', (d) => d.hw)
+            .attr('transform', (d) => `translate(${d.x + 8},${d.y - 14})`)
+            .style('opacity', (d) => (d.visible ? 1 : 0))
+            .each(function (d) {
+              const g = d3.select(this);
+              const text = g.select<SVGTextElement>('.ll-text').text(d.label);
+              const bbox = (text.node() as SVGTextElement).getBBox();
+              const px = 5;
+              const py = 3;
+              g.select('.ll-bg')
+                .attr('x', bbox.x - px)
+                .attr('y', bbox.y - py)
+                .attr('width', bbox.width + px * 2)
+                .attr('height', bbox.height + py * 2)
+                .attr('fill', d.color);
+            });
         },
         onZoom: (zoomGroup, ctx) => {
           const newXScale = ctx.newXScale as ContinuousScale;
@@ -912,6 +1121,114 @@ const ScatterGraph = React.memo(
                 }
               });
             });
+          }
+
+          // Update line label positions on zoom
+          if (showLineLabels) {
+            const isInteractivity = chartDefinition.chartType === 'interactivity';
+            const LABEL_H = 18;
+            const LABEL_W = 120;
+
+            if (isInteractivity) {
+              // Re-run greedy placement with zoomed scales
+              const placed: { x: number; y: number }[] = [];
+              const collides = (cx: number, cy: number) =>
+                placed.some((p) => Math.abs(p.y - cy) < LABEL_H && Math.abs(p.x - cx) < LABEL_W);
+
+              // Deduplicate by hw key — pick roofline with most points per hw
+              const bestByHw = new Map<string, [string, InferenceData[]]>();
+              for (const [key, pts] of Object.entries(rooflines)) {
+                if (pts.length < 2) continue;
+                const hw = key.split('_').slice(0, -1).join('_');
+                const prec = key.split('_').pop()!;
+                if (!effectiveActiveHwTypes.has(hw) || !selectedPrecisions.includes(prec)) continue;
+                const prev = bestByHw.get(hw);
+                if (!prev || pts.length > prev[1].length) bestByHw.set(hw, [key, pts]);
+              }
+              const visibleEntries = [...bestByHw.values()].sort(
+                ([, a], [, b]) => newYScale(a[0].y) - newYScale(b[0].y),
+              );
+
+              const zoomResults = new Map<string, { x: number; y: number; vis: boolean }>();
+              for (const [key, pts] of visibleEntries) {
+                const candidates = [
+                  pts[Math.min(1, pts.length - 1)],
+                  pts[Math.floor(pts.length / 2)],
+                  pts[Math.max(0, Math.floor((pts.length * 2) / 3))],
+                  pts[pts.length - 1],
+                ];
+                let found = false;
+                for (const pt of candidates) {
+                  const px = newXScale(pt.x);
+                  const py = newYScale(pt.y);
+                  if (!collides(px, py)) {
+                    zoomResults.set(key, { x: px, y: py, vis: true });
+                    placed.push({ x: px, y: py });
+                    found = true;
+                    break;
+                  }
+                }
+                if (!found) {
+                  zoomResults.set(key, {
+                    x: newXScale(pts[0].x),
+                    y: newYScale(pts[0].y),
+                    vis: false,
+                  });
+                }
+              }
+
+              zoomGroup.selectAll<SVGGElement, unknown>('.line-label').each(function () {
+                const el = d3.select(this);
+                const k = el.attr('data-line-key');
+                const zl = zoomResults.get(k);
+                if (zl) {
+                  el.attr('transform', `translate(${zl.x + 8},${zl.y - 14})`);
+                  el.style('opacity', zl.vis ? 1 : 0);
+                } else {
+                  el.style('opacity', 0);
+                }
+              });
+            } else {
+              // TTFT / E2EL: endpoint with bidirectional nudge, one per hw
+              type ZoomLabel = { key: string; x: number; y: number };
+              const zoomLabels: ZoomLabel[] = [];
+              const seenHw = new Set<string>();
+              Object.entries(rooflines).forEach(([key, pts]) => {
+                if (pts.length < 2) return;
+                const hw = key.split('_').slice(0, -1).join('_');
+                if (seenHw.has(hw)) return;
+                seenHw.add(hw);
+                const pt = pts[pts.length - 1];
+                zoomLabels.push({ key, x: newXScale(pt.x), y: newYScale(pt.y) });
+              });
+              if (zoomLabels.length > 1) {
+                const yRange = newYScale.range();
+                const top = Math.min(yRange[0], yRange[1]) + LABEL_H;
+                const bottom = Math.max(yRange[0], yRange[1]) - LABEL_H;
+                zoomLabels.sort((a, b) => a.y - b.y);
+                for (let pass = 0; pass < 5; pass++) {
+                  for (let i = 1; i < zoomLabels.length; i++) {
+                    const overlap = zoomLabels[i - 1].y + LABEL_H - zoomLabels[i].y;
+                    if (overlap > 0) {
+                      const half = overlap / 2;
+                      zoomLabels[i - 1].y -= half;
+                      zoomLabels[i].y += half;
+                    }
+                  }
+                  for (const l of zoomLabels) {
+                    l.y = Math.max(top, Math.min(bottom, l.y));
+                  }
+                }
+              }
+              for (const zl of zoomLabels) {
+                const labelGroup = zoomGroup.select<SVGGElement>(
+                  `.line-label[data-line-key="${zl.key}"]`,
+                );
+                if (!labelGroup.empty()) {
+                  labelGroup.attr('transform', `translate(${zl.x + 8},${zl.y - 14})`);
+                }
+              }
+            }
           }
         },
       };
@@ -1147,6 +1464,7 @@ const ScatterGraph = React.memo(
       rooflines,
       allPointLabelsByKey,
       showGradientLabels,
+      showLineLabels,
       gradientColorByPoint,
       chartId,
       effectiveActiveHwTypes,
@@ -1165,6 +1483,7 @@ const ScatterGraph = React.memo(
       xLabel,
       yLabel,
       selectedYAxisMetric,
+      chartDefinition.chartType,
     ]);
 
     // --- onRender: tracked rings, CSS transitions, log tick formatting, dblclick ---
@@ -1487,6 +1806,15 @@ const ScatterGraph = React.memo(
                 onCheckedChange: (checked: boolean) => {
                   setShowGradientLabels(checked);
                   track('latency_gradient_labels_toggled', { enabled: checked });
+                },
+              },
+              {
+                id: 'scatter-line-labels',
+                label: 'Line Labels',
+                checked: showLineLabels,
+                onCheckedChange: (checked: boolean) => {
+                  setShowLineLabels(checked);
+                  track('latency_line_labels_toggled', { enabled: checked });
                 },
               },
             ]}

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -36,6 +36,7 @@ const URL_STATE_KEYS = [
   'i_legend',
   'i_advlabel',
   'i_gradlabel',
+  'i_linelabel',
   // Evaluation
   'e_rundate',
   'e_bench',
@@ -74,6 +75,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   i_legend: '',
   i_advlabel: '',
   i_gradlabel: '',
+  i_linelabel: '',
   e_rundate: '',
   e_bench: '',
   e_hc: '',


### PR DESCRIPTION
## Summary
- Adds a **Line Labels** toggle in the legend sidebar that displays the hardware config name as a colored pill badge on each roofline curve
- **Interactivity chart**: greedy placement tries top-left → midpoint → right-third → endpoint positions, hiding labels that still collide with already-placed ones
- **TTFT/E2EL charts**: endpoint placement with bidirectional collision nudge
- Labels deduplicated by hardware key (one label per hardware config, even with multiple precisions)
- Legend hover: non-matching labels fully disappear (opacity 0), matching label stays visible
- URL-persisted via `i_linelabel` param
- E2E test coverage for toggle state, SVG rendering, coexistence with gradient labels, and URL param

## Test plan
- [ ] Toggle "Line Labels" on interactivity chart — labels appear at spread positions along rooflines
- [ ] Toggle on TTFT/E2EL charts — labels appear at line endpoints with collision avoidance
- [ ] Hover legend items — only the hovered hw label stays, others disappear
- [ ] Zoom/pan — labels reposition correctly
- [ ] Multiple precisions selected — no duplicate labels per hardware
- [ ] `?i_linelabel=1` in URL enables toggle on load
- [ ] Run `pnpm test:e2e --spec packages/app/cypress/e2e/line-labels.cy.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)