### PR TITLE
feat: improve local setup for dump workflow and database access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,13 +14,13 @@
 
 # Option B: TCP database (postgres.js — works with any Postgres instance)
 # DATABASE_READONLY_URL=postgresql://postgres:postgres@localhost:5432/postgres
-# DB_DRIVER=postgres
-# DB_SSL=false
+# DATABASE_DRIVER=postgres
+# DATABASE_SSL=false
 
 # Option C: HTTP database (Neon serverless driver — requires a Neon-hosted instance)
 # DATABASE_READONLY_URL=
-# DB_DRIVER=neon
-# DB_SSL=true
+# DATABASE_DRIVER=neon
+# DATABASE_SSL=true
 
 # GitHub PAT (optional) — improves rate limits for star count and workflow metadata
 # Create at: https://github.com/settings/personal-access-tokens
@@ -33,6 +33,8 @@
 # ╚══════════════════════════════════════════════════════════════════════════╝
 
 # DATABASE_READONLY_URL=
+# DATABASE_DRIVER=neon
+# DATABASE_SSL=true
 # BLOB_CACHE_PREFIX=
 # BLOB_READ_WRITE_TOKEN=
 # GITHUB_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,10 @@
 # ║  Choose ONE data source: JSON dump (easiest) or live database.           ║
 # ╚══════════════════════════════════════════════════════════════════════════╝
 
+# LAN / remote dev: allow this machine’s IP so the dev server accepts cross-origin requests
+# (comma-separated). Example: NEXT_DEV_ALLOWED_ORIGINS=10.112.9.49
+# NEXT_DEV_ALLOWED_ORIGINS=
+
 # Option A: JSON dump (no other credentials needed)
 # Download a DB dump release, unzip it, and point this to the directory.
 # See README for setup instructions.

--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,26 @@
 # ╔══════════════════════════════════════════════════════════════════════════╗
 # ║  Local development                                                       ║
 # ║                                                                          ║
-# ║  Choose ONE data source: JSON dump (easiest) or live database.           ║
+# ║  Choose ONE option: JSON dump, TCP database, or HTTP database.           ║
 # ╚══════════════════════════════════════════════════════════════════════════╝
 
-# LAN / remote dev: allow this machine’s IP so the dev server accepts cross-origin requests
-# (comma-separated). Example: NEXT_DEV_ALLOWED_ORIGINS=10.112.9.49
-# NEXT_DEV_ALLOWED_ORIGINS=
+# LAN / remote dev: set this machine's IP so the dev server accepts cross-origin requests
+# NEXT_DEV_ALLOWED_ORIGINS=10.112.9.49
 
-# Option A: JSON dump (no other credentials needed)
+# Option A: JSON dump (no database needed)
 # Download a DB dump release, unzip it, and point this to the directory.
 # See README for setup instructions.
 # DUMP_DIR=./inferencex-dump/inferencex-dump-2026-03-30
 
-# Option B: Live database (requires Vercel Blob credentials too)
+# Option B: TCP database (postgres.js — works with any Postgres instance)
+# DATABASE_READONLY_URL=postgresql://postgres:postgres@localhost:5432/postgres
+# DB_DRIVER=postgres
+# DB_SSL=false
+
+# Option C: HTTP database (Neon serverless driver — requires a Neon-hosted instance)
 # DATABASE_READONLY_URL=
-# BLOB_CACHE_PREFIX=
-# BLOB_READ_WRITE_TOKEN=
+# DB_DRIVER=neon
+# DB_SSL=true
 
 # GitHub PAT (optional) — improves rate limits for star count and workflow metadata
 # Create at: https://github.com/settings/personal-access-tokens

--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -1,6 +1,17 @@
 import type { NextConfig } from 'next';
 
+/** Comma-separated hostnames or IPs (e.g. `10.112.9.49,192.168.1.10`). Only used in dev. */
+function allowedDevOriginsFromEnv(): string[] {
+  const raw = process.env.NEXT_DEV_ALLOWED_ORIGINS;
+  if (!raw?.trim()) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 const nextConfig: NextConfig = {
+  allowedDevOrigins: allowedDevOriginsFromEnv(),
   transpilePackages: ['@semianalysisai/inferencex-constants'],
   serverExternalPackages: ['shiki'],
   images: {

--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -1,14 +1,5 @@
 import type { NextConfig } from 'next';
-
-/** Comma-separated hostnames or IPs (e.g. `10.112.9.49,192.168.1.10`). Only used in dev. */
-function allowedDevOriginsFromEnv(): string[] {
-  const raw = process.env.NEXT_DEV_ALLOWED_ORIGINS;
-  if (!raw?.trim()) return [];
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
+import { allowedDevOriginsFromEnv } from './src/lib/allowed-dev-origins';
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: allowedDevOriginsFromEnv(),

--- a/packages/app/src/lib/allowed-dev-origins.test.ts
+++ b/packages/app/src/lib/allowed-dev-origins.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { allowedDevOriginsFromEnv } from './allowed-dev-origins';
+
+describe('allowedDevOriginsFromEnv', () => {
+  it('returns an empty list for unset or blank values', () => {
+    expect(allowedDevOriginsFromEnv(undefined)).toEqual([]);
+    expect(allowedDevOriginsFromEnv('')).toEqual([]);
+    expect(allowedDevOriginsFromEnv('   ')).toEqual([]);
+  });
+
+  it('trims whitespace and removes empty entries', () => {
+    expect(
+      allowedDevOriginsFromEnv(' 10.112.9.49 , , local-origin.dev , *.local-origin.dev '),
+    ).toEqual(['10.112.9.49', 'local-origin.dev', '*.local-origin.dev']);
+  });
+});

--- a/packages/app/src/lib/allowed-dev-origins.ts
+++ b/packages/app/src/lib/allowed-dev-origins.ts
@@ -1,0 +1,8 @@
+/** Comma-separated hostnames or IPs (e.g. `10.112.9.49,192.168.1.10`). Only used in dev. */
+export function allowedDevOriginsFromEnv(raw = process.env.NEXT_DEV_ALLOWED_ORIGINS): string[] {
+  if (!raw?.trim()) return [];
+  return raw
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}

--- a/packages/db/src/connection.test.ts
+++ b/packages/db/src/connection.test.ts
@@ -11,13 +11,13 @@ describe('shouldUseNeon', () => {
     expect(shouldUseNeon('postgres://user:pass@db.example.com/app')).toBe(false);
   });
 
-  it('honors DB_DRIVER=postgres override', () => {
+  it('honors DATABASE_DRIVER=postgres override', () => {
     expect(
       shouldUseNeon('postgres://user:pass@ep-test-123.us-east-1.aws.neon.tech/db', 'postgres'),
     ).toBe(false);
   });
 
-  it('honors DB_DRIVER=neon override', () => {
+  it('honors DATABASE_DRIVER=neon override', () => {
     expect(shouldUseNeon('postgres://user:pass@db.example.com/app', 'neon')).toBe(true);
   });
 });
@@ -48,14 +48,14 @@ describe('postgresOptionsForUrl', () => {
     });
   });
 
-  it('honors DB_SSL=false override for remote hosts', () => {
+  it('honors DATABASE_SSL=false override for remote hosts', () => {
     expect(postgresOptionsForUrl('postgres://user:pass@db.example.com/app', 'false')).toEqual({
       max: 5,
       ssl: false,
     });
   });
 
-  it('honors DB_SSL=true override for loopback hosts', () => {
+  it('honors DATABASE_SSL=true override for loopback hosts', () => {
     expect(postgresOptionsForUrl('postgres://user:pass@localhost:5432/app', 'true')).toEqual({
       max: 5,
       ssl: 'require',

--- a/packages/db/src/connection.test.ts
+++ b/packages/db/src/connection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { postgresOptionsForUrl, shouldUseNeon } from './connection';
+
+describe('shouldUseNeon', () => {
+  it('defaults to Neon for neon.tech URLs', () => {
+    expect(shouldUseNeon('postgres://user:pass@ep-test-123.us-east-1.aws.neon.tech/db')).toBe(true);
+  });
+
+  it('defaults to postgres.js for non-Neon URLs', () => {
+    expect(shouldUseNeon('postgres://user:pass@db.example.com/app')).toBe(false);
+  });
+
+  it('honors DB_DRIVER=postgres override', () => {
+    expect(
+      shouldUseNeon('postgres://user:pass@ep-test-123.us-east-1.aws.neon.tech/db', 'postgres'),
+    ).toBe(false);
+  });
+
+  it('honors DB_DRIVER=neon override', () => {
+    expect(shouldUseNeon('postgres://user:pass@db.example.com/app', 'neon')).toBe(true);
+  });
+});
+
+describe('postgresOptionsForUrl', () => {
+  it('keeps TLS enabled for remote non-Neon hosts', () => {
+    expect(postgresOptionsForUrl('postgres://user:pass@db.example.com/app')).toEqual({
+      max: 5,
+      ssl: 'require',
+    });
+  });
+
+  it('disables TLS for localhost', () => {
+    expect(postgresOptionsForUrl('postgres://user:pass@localhost:5432/app')).toEqual({
+      max: 5,
+      ssl: false,
+    });
+  });
+
+  it('disables TLS for loopback IPv4 and IPv6 URLs', () => {
+    expect(postgresOptionsForUrl('postgres://user:pass@127.0.0.1:5432/app')).toEqual({
+      max: 5,
+      ssl: false,
+    });
+    expect(postgresOptionsForUrl('postgres://user:pass@[::1]:5432/app')).toEqual({
+      max: 5,
+      ssl: false,
+    });
+  });
+
+  it('honors DB_SSL=false override for remote hosts', () => {
+    expect(postgresOptionsForUrl('postgres://user:pass@db.example.com/app', 'false')).toEqual({
+      max: 5,
+      ssl: false,
+    });
+  });
+
+  it('honors DB_SSL=true override for loopback hosts', () => {
+    expect(postgresOptionsForUrl('postgres://user:pass@localhost:5432/app', 'true')).toEqual({
+      max: 5,
+      ssl: 'require',
+    });
+  });
+});

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -10,24 +10,64 @@ export type DbClient = (
   ...values: unknown[]
 ) => Promise<Record<string, unknown>[]>;
 
-/** @deprecated Alias for DbClient — kept for backward compat with existing query files. */
-export type NeonClient = DbClient;
-
 /** True when running off a JSON dump directory instead of a live database (local dev only). */
 export const JSON_MODE = !process.env.DATABASE_READONLY_URL && !!process.env.DUMP_DIR;
 
-let cached: DbClient | null = null;
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+type PostgresConnectionOptions = {
+  max: number;
+  ssl: false | 'require';
+};
+
+function getDbHostname(url: string): string | null {
+  try {
+    return new URL(url).hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1');
+  } catch {
+    return null;
+  }
+}
 
 /**
  * DB_DRIVER=neon  → @neondatabase/serverless HTTP driver (default for *.neon.tech URLs)
  * DB_DRIVER=postgres → postgres.js TCP driver  (default for everything else)
  */
-function shouldUseNeon(url: string): boolean {
-  const driver = process.env.DB_DRIVER?.toLowerCase();
-  if (driver === 'postgres') return false;
-  if (driver === 'neon') return true;
-  return url.includes('.neon.tech');
+export function shouldUseNeon(url: string, driver = process.env.DB_DRIVER): boolean {
+  const normalizedDriver = driver?.toLowerCase();
+  const hostname = getDbHostname(url);
+
+  if (normalizedDriver === 'postgres') return false;
+  if (normalizedDriver === 'neon') return true;
+  return hostname?.endsWith('.neon.tech') ?? url.includes('.neon.tech');
 }
+
+/**
+ * DB_SSL=false disables TLS unconditionally.
+ * Otherwise: loopback → no TLS, remote → TLS required.
+ */
+export function postgresOptionsForUrl(
+  url: string,
+  sslEnv = process.env.DB_SSL,
+): PostgresConnectionOptions {
+  const ssl = sslEnv?.toLowerCase();
+  if (ssl === 'false') return { max: 5, ssl: false };
+  if (ssl === 'true') return { max: 5, ssl: 'require' };
+  const hostname = getDbHostname(url);
+  return {
+    max: 5,
+    ssl: hostname && LOOPBACK_HOSTS.has(hostname) ? false : 'require',
+  };
+}
+
+/** Wrap postgres.js Sql instance to match DbClient signature. */
+function wrapPostgres(sql: postgres.Sql): DbClient {
+  return ((strings: TemplateStringsArray, ...values: unknown[]) =>
+    sql(strings, ...(values as postgres.ParameterOrFragment<never>[]))) as DbClient;
+}
+
+// Survive Next.js HMR — without globalThis the module re-evaluates on each
+// hot reload, leaking the previous postgres.js TCP connection pool.
+const g = globalThis as unknown as { __dbClient?: DbClient };
 
 /**
  * Read-only SQL client for API routes.
@@ -35,13 +75,13 @@ function shouldUseNeon(url: string): boolean {
  * should skip this and use the json-provider instead.
  */
 export function getDb(): DbClient {
-  if (cached) return cached;
+  if (g.__dbClient) return g.__dbClient;
   const url = process.env.DATABASE_READONLY_URL;
   if (!url) throw new Error('DATABASE_READONLY_URL is not set');
 
-  cached = shouldUseNeon(url)
+  g.__dbClient = shouldUseNeon(url)
     ? (neon(url) as DbClient)
-    : (postgres(url, { ssl: false, max: 5 }) as unknown as DbClient);
+    : wrapPostgres(postgres(url, postgresOptionsForUrl(url)));
 
-  return cached;
+  return g.__dbClient;
 }

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -29,10 +29,10 @@ function getDbHostname(url: string): string | null {
 }
 
 /**
- * DB_DRIVER=neon  → @neondatabase/serverless HTTP driver (default for *.neon.tech URLs)
- * DB_DRIVER=postgres → postgres.js TCP driver  (default for everything else)
+ * DATABASE_DRIVER=neon  → @neondatabase/serverless HTTP driver (default for *.neon.tech URLs)
+ * DATABASE_DRIVER=postgres → postgres.js TCP driver  (default for everything else)
  */
-export function shouldUseNeon(url: string, driver = process.env.DB_DRIVER): boolean {
+export function shouldUseNeon(url: string, driver = process.env.DATABASE_DRIVER): boolean {
   const normalizedDriver = driver?.toLowerCase();
   const hostname = getDbHostname(url);
 
@@ -42,12 +42,12 @@ export function shouldUseNeon(url: string, driver = process.env.DB_DRIVER): bool
 }
 
 /**
- * DB_SSL=false disables TLS unconditionally.
+ * DATABASE_SSL=false disables TLS unconditionally.
  * Otherwise: loopback → no TLS, remote → TLS required.
  */
 export function postgresOptionsForUrl(
   url: string,
-  sslEnv = process.env.DB_SSL,
+  sslEnv = process.env.DATABASE_SSL,
 ): PostgresConnectionOptions {
   const ssl = sslEnv?.toLowerCase();
   if (ssl === 'false') return { max: 5, ssl: false };

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -1,21 +1,47 @@
 import { neon } from '@neondatabase/serverless';
+import postgres from 'postgres';
 
-export type NeonClient = ReturnType<typeof neon>;
+/**
+ * Tagged-template SQL callable — runtime-compatible between neon() and postgres().
+ * Both drivers support `sql\`SELECT ...\`` and return Promise<Row[]>.
+ */
+export type DbClient = (
+  strings: TemplateStringsArray,
+  ...values: unknown[]
+) => Promise<Record<string, unknown>[]>;
+
+/** @deprecated Alias for DbClient — kept for backward compat with existing query files. */
+export type NeonClient = DbClient;
 
 /** True when running off a JSON dump directory instead of a live database (local dev only). */
 export const JSON_MODE = !process.env.DATABASE_READONLY_URL && !!process.env.DUMP_DIR;
 
-let cached: NeonClient | null = null;
+let cached: DbClient | null = null;
 
 /**
- * Read-only Neon HTTP SQL client for API routes.
+ * DB_DRIVER=neon  → @neondatabase/serverless HTTP driver (default for *.neon.tech URLs)
+ * DB_DRIVER=postgres → postgres.js TCP driver  (default for everything else)
+ */
+function shouldUseNeon(url: string): boolean {
+  const driver = process.env.DB_DRIVER?.toLowerCase();
+  if (driver === 'postgres') return false;
+  if (driver === 'neon') return true;
+  return url.includes('.neon.tech');
+}
+
+/**
+ * Read-only SQL client for API routes.
  * Throws if DATABASE_READONLY_URL is not set — callers in JSON_MODE
  * should skip this and use the json-provider instead.
  */
-export function getDb(): NeonClient {
+export function getDb(): DbClient {
   if (cached) return cached;
   const url = process.env.DATABASE_READONLY_URL;
   if (!url) throw new Error('DATABASE_READONLY_URL is not set');
-  cached = neon(url);
+
+  cached = shouldUseNeon(url)
+    ? (neon(url) as DbClient)
+    : (postgres(url, { ssl: false, max: 5 }) as unknown as DbClient);
+
   return cached;
 }

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -1,4 +1,4 @@
-import type { NeonClient } from '../connection.js';
+import type { DbClient } from '../connection.js';
 
 export interface BenchmarkRow {
   hardware: string;
@@ -36,7 +36,7 @@ export interface BenchmarkRow {
  * switching sequences — the data is already cached by React Query.
  */
 export async function getLatestBenchmarks(
-  sql: NeonClient,
+  sql: DbClient,
   modelKey: string,
   date?: string,
   exact?: boolean,
@@ -125,7 +125,7 @@ export async function getLatestBenchmarks(
  * Used by Historical Trends and Performance Over Time features.
  */
 export async function getAllBenchmarksForHistory(
-  sql: NeonClient,
+  sql: DbClient,
   modelKey: string,
   isl: number,
   osl: number,

--- a/packages/db/src/queries/evaluations.ts
+++ b/packages/db/src/queries/evaluations.ts
@@ -1,4 +1,4 @@
-import type { NeonClient } from '../connection.js';
+import type { DbClient } from '../connection.js';
 
 export interface EvalRow {
   config_id: number;
@@ -19,7 +19,7 @@ export interface EvalRow {
 }
 
 /** Get all evaluation results (latest attempt only). */
-export async function getAllEvalResults(sql: NeonClient): Promise<EvalRow[]> {
+export async function getAllEvalResults(sql: DbClient): Promise<EvalRow[]> {
   const rows = await sql`
     SELECT
       er.config_id,

--- a/packages/db/src/queries/reliability.ts
+++ b/packages/db/src/queries/reliability.ts
@@ -1,4 +1,4 @@
-import type { NeonClient } from '../connection.js';
+import type { DbClient } from '../connection.js';
 
 export interface ReliabilityRow {
   hardware: string;
@@ -8,7 +8,7 @@ export interface ReliabilityRow {
 }
 
 /** Get all run_stats rows for reliability aggregation (latest attempt only). */
-export async function getReliabilityStats(sql: NeonClient): Promise<ReliabilityRow[]> {
+export async function getReliabilityStats(sql: DbClient): Promise<ReliabilityRow[]> {
   const rows = await sql`
     SELECT rs.hardware, rs.date::text, rs.n_success, rs.total
     FROM run_stats rs

--- a/packages/db/src/queries/server-logs.ts
+++ b/packages/db/src/queries/server-logs.ts
@@ -1,10 +1,10 @@
-import type { NeonClient } from '../connection.js';
+import type { DbClient } from '../connection.js';
 
 /**
  * Fetch a server log by benchmark_result_id. Returns null if not found.
  */
 export async function getServerLog(
-  sql: NeonClient,
+  sql: DbClient,
   benchmarkResultId: number,
 ): Promise<string | null> {
   const rows = (await sql`

--- a/packages/db/src/queries/workflow-info.ts
+++ b/packages/db/src/queries/workflow-info.ts
@@ -1,4 +1,4 @@
-import type { NeonClient } from '../connection.js';
+import type { DbClient } from '../connection.js';
 
 export interface WorkflowRunRow {
   github_run_id: number;
@@ -33,7 +33,7 @@ export interface DateConfigRow {
 
 /** Get benchmark workflow runs for a specific date (latest attempt per run, any completed conclusion). */
 export async function getWorkflowRunsByDate(
-  sql: NeonClient,
+  sql: DbClient,
   date: string,
 ): Promise<WorkflowRunRow[]> {
   const rows = await sql`
@@ -47,7 +47,7 @@ export async function getWorkflowRunsByDate(
 }
 
 /** Get changelog entries for a set of workflow run DB IDs. */
-export async function getChangelogByDate(sql: NeonClient, date: string): Promise<ChangelogRow[]> {
+export async function getChangelogByDate(sql: DbClient, date: string): Promise<ChangelogRow[]> {
   const rows = await sql`
     SELECT
       wr.github_run_id as workflow_run_id,
@@ -66,7 +66,7 @@ export async function getChangelogByDate(sql: NeonClient, date: string): Promise
 }
 
 /** Get distinct model/sequence/precision/hardware combos for a date. */
-export async function getDateConfigs(sql: NeonClient, date: string): Promise<DateConfigRow[]> {
+export async function getDateConfigs(sql: DbClient, date: string): Promise<DateConfigRow[]> {
   const rows = await sql`
     SELECT DISTINCT
       c.model,
@@ -99,7 +99,7 @@ export interface AvailabilityRow {
 }
 
 /** Get available (model, ISL/OSL, precision, hardware, framework, spec_method, date) combos for the availability API. */
-export async function getAvailabilityData(sql: NeonClient): Promise<AvailabilityRow[]> {
+export async function getAvailabilityData(sql: DbClient): Promise<AvailabilityRow[]> {
   const rows = await sql`
     SELECT a.model, a.isl, a.osl, a.precision, a.hardware, a.framework, a.spec_method, a.disagg, a.date::text
     FROM availability a


### PR DESCRIPTION
- .env.example: document NEXT_DEV_ALLOWED_ORIGINS for LAN / remote dev when the browser origin is not localhost (comma-separated IPs or hostnames).
- next.config: set allowedDevOrigins from NEXT_DEV_ALLOWED_ORIGINS instead of a hardcoded IP so each developer can configure without editing the repo.
- packages/db connection: select read client by URL or DB_DRIVER — use Neon serverless HTTP for *.neon.tech (default), otherwise postgres.js TCP with ssl:false and a small pool; DB_DRIVER=neon|postgres forces either driver. Introduce DbClient tagged-template type; keep NeonClient as a deprecated alias.

Fixes: https://github.com/SemiAnalysisAI/InferenceX-app/issues/128