### PR TITLE
feat: override Meta Superintelligence Labs → Meta in carousel

### DIFF
--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -347,4 +347,5 @@ export const CAROUSEL_ORGS = [
 export const CAROUSEL_LABELS: Record<string, string> = {
   'Together AI': 'Tri Dao',
   'PyTorch Foundation': 'PyTorch',
+  'Meta Superintelligence Labs': 'Meta',
 };


### PR DESCRIPTION
## Summary
- Adds a display label override so "Meta Superintelligence Labs" shows as "Meta" in the landing page carousel

## Test plan
- [ ] Verify the carousel on the landing page displays "Meta" instead of "Meta Superintelligence Labs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)