### PR TITLE
Add land acknowledgement page

### DIFF
--- a/packages/app/cypress/e2e/land-acknowledgement.cy.ts
+++ b/packages/app/cypress/e2e/land-acknowledgement.cy.ts
@@ -1,0 +1,21 @@
+describe('Land acknowledgement', () => {
+  it('navigates from the footer to the land acknowledgement page', () => {
+    cy.visit('/');
+
+    cy.get('[data-testid="footer-link-land-acknowledgement"]').scrollIntoView().click();
+
+    cy.location('pathname').should('eq', '/land-acknowledgement');
+    cy.get('[data-testid="land-acknowledgement-page"]').within(() => {
+      cy.get('h1').should('contain.text', 'Indigenous homelands');
+      cy.get('[data-testid="land-acknowledgement-san-jose"]').should(
+        'contain.text',
+        'Muwekma Ohlone Tribe',
+      );
+      cy.get('[data-testid="land-acknowledgement-los-angeles"]').should('contain.text', 'Tongva');
+      cy.get('[data-testid="land-acknowledgement-chicago"]').should(
+        'contain.text',
+        'Council of the Three Fires',
+      );
+    });
+  });
+});

--- a/packages/app/cypress/e2e/land-acknowledgement.cy.ts
+++ b/packages/app/cypress/e2e/land-acknowledgement.cy.ts
@@ -1,6 +1,10 @@
 describe('Land acknowledgement', () => {
   it('navigates from the footer to the land acknowledgement page', () => {
-    cy.visit('/');
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
 
     cy.get('[data-testid="footer-link-land-acknowledgement"]').scrollIntoView().click();
 

--- a/packages/app/src/app/land-acknowledgement/page.tsx
+++ b/packages/app/src/app/land-acknowledgement/page.tsx
@@ -1,0 +1,100 @@
+import type { Metadata } from 'next';
+
+import { Card } from '@/components/ui/card';
+import { SITE_URL } from '@semianalysisai/inferencex-constants';
+
+const REGIONAL_ACKNOWLEDGEMENTS = [
+  {
+    region: 'San Jose',
+    peoples: 'Muwekma Ohlone Tribe',
+    acknowledgement:
+      'Our San Jose-area benchmark infrastructure operates on the unceded ancestral homelands of the Muwekma Ohlone Tribe of the San Francisco Bay Area.',
+  },
+  {
+    region: 'Los Angeles',
+    peoples: 'Tongva, Tataviam, Serrano, Kizh, and Chumash Peoples',
+    acknowledgement:
+      'Our Los Angeles-area benchmark infrastructure operates on land originally and still inhabited and cared for by the Tongva, Tataviam, Serrano, Kizh, and Chumash Peoples.',
+  },
+  {
+    region: 'Chicago',
+    peoples:
+      'Council of the Three Fires, Illinois Confederacy, Miami, Ho-Chunk, Menominee, Fox, and Sac Peoples',
+    acknowledgement:
+      'Our Chicago-area benchmark infrastructure operates on land stewarded by the Council of the Three Fires (Ojibwe, Odawa, and Potawatomi Nations), the Illinois Confederacy, and many other Native Nations including the Miami, Ho-Chunk, Menominee, Fox, and Sac Peoples.',
+  },
+];
+
+export const metadata: Metadata = {
+  title: 'Land Acknowledgement',
+  description:
+    'A land acknowledgement for the Indigenous peoples and homelands connected to InferenceX US benchmark clusters in San Jose, Los Angeles, and Chicago.',
+  alternates: { canonical: `${SITE_URL}/land-acknowledgement` },
+  openGraph: {
+    title: 'Land Acknowledgement | InferenceX',
+    description:
+      'A land acknowledgement for the Indigenous peoples and homelands connected to InferenceX US benchmark clusters in San Jose, Los Angeles, and Chicago.',
+    url: `${SITE_URL}/land-acknowledgement`,
+  },
+  twitter: {
+    title: 'Land Acknowledgement | InferenceX',
+    description:
+      'A land acknowledgement for the Indigenous peoples and homelands connected to InferenceX US benchmark clusters in San Jose, Los Angeles, and Chicago.',
+  },
+};
+
+export default function LandAcknowledgementPage() {
+  return (
+    <main data-testid="land-acknowledgement-page" className="relative">
+      <div className="container mx-auto px-4 lg:px-8 pb-8">
+        <Card className="gap-10">
+          <header className="max-w-3xl">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.32em] text-brand">
+              Land Acknowledgement
+            </p>
+            <h1 className="text-4xl font-semibold tracking-[-0.04em] text-foreground md:text-5xl">
+              We recognize the Indigenous homelands connected to our US infrastructure.
+            </h1>
+            <p className="mt-4 text-sm leading-6 text-muted-foreground md:text-base">
+              InferenceX benchmark clusters serve traffic from several regions. This page focuses on
+              our US sites in San Jose, Los Angeles, and Chicago, and acknowledges the Indigenous
+              peoples who have stewarded these lands across generations and continue to do so today.
+            </p>
+          </header>
+
+          <section
+            data-testid="land-acknowledgement-regions"
+            className="grid gap-4 lg:grid-cols-3"
+            aria-label="Regional land acknowledgements"
+          >
+            {REGIONAL_ACKNOWLEDGEMENTS.map((entry) => (
+              <article
+                key={entry.region}
+                data-testid={`land-acknowledgement-${entry.region
+                  .toLowerCase()
+                  .replaceAll(' ', '-')}`}
+                className="rounded-2xl border border-border/40 bg-background/20 p-5"
+              >
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+                  {entry.region}
+                </p>
+                <h2 className="mt-3 text-xl font-semibold tracking-[-0.04em] text-foreground">
+                  {entry.peoples}
+                </h2>
+                <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                  {entry.acknowledgement}
+                </p>
+              </article>
+            ))}
+          </section>
+
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground">
+            Acknowledgement is only a starting point. We share this statement with respect for
+            Native sovereignty, history, and ongoing community presence, and we welcome corrections
+            if our wording should be improved.
+          </p>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -35,6 +35,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
+      url: `${BASE_URL}/land-acknowledgement`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.4,
+    },
+    {
       url: `${BASE_URL}/blog`,
       lastModified: now,
       changeFrequency: 'weekly',

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -74,6 +74,13 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
             </div>
             <div data-testid="footer-links-legal" className="flex flex-col gap-2.5">
               <span className="text-sm font-medium text-foreground">Legal</span>
+              <Link
+                data-testid="footer-link-land-acknowledgement"
+                href="/land-acknowledgement"
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Land Acknowledgement
+              </Link>
               <a
                 data-testid="footer-link-privacy"
                 href="https://semianalysis.com/privacy-policy/"


### PR DESCRIPTION
## Summary\n- add a land acknowledgement page for San Jose, Los Angeles, and Chicago cluster regions\n- link the new page from the footer Legal section\n- include the page in the sitemap\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm test:unit\n- Cypress not run per request