### PR TITLE
feat: add automated announcement banner for new benchmark data / 添加新基准测试数据自动公告横幅

### DIFF
--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -108,7 +108,7 @@ function buildRunInfo(data: WorkflowInfoResponse): Record<string, RunInfo> {
 }
 
 export function GlobalFilterProvider({ children }: { children: ReactNode }) {
-  const { hasUrlParam, getUrlParam, setUrlParams } = useUrlState();
+  const { hasUrlParam, getUrlParam, setUrlParams, latestParams } = useUrlState();
 
   // ── Core filter state ─────────────────────────────────────────────────────
   const [selectedModel, setSelectedModel] = useState<Model>(() => {
@@ -144,6 +144,38 @@ export function GlobalFilterProvider({ children }: { children: ReactNode }) {
   const [selectedRunDateRev, setSelectedRunDateRev] = useState(0);
 
   const [selectedRunId, setSelectedRunId] = useState<string>(() => getUrlParam('g_runid') || '');
+
+  // When true, keep the user's date if available; otherwise always use latest
+  const userPickedDateRef = useRef(Boolean(getUrlParam('g_rundate')));
+
+  // ── Apply URL params from client-side navigations (e.g. banner clicks) ───
+  const appliedParamsRef = useRef(latestParams);
+  useEffect(() => {
+    if (latestParams === appliedParamsRef.current) return;
+    appliedParamsRef.current = latestParams;
+
+    const model = latestParams.g_model;
+    if (model && Object.values(Model).includes(model as Model)) {
+      setSelectedModel(model as Model);
+    }
+    const seq = latestParams.i_seq;
+    if (seq && Object.values(Sequence).includes(seq as Sequence)) {
+      setSelectedSequence(seq as Sequence);
+    }
+    const prec = latestParams.i_prec;
+    if (prec) {
+      const precs = prec.split(',').filter((p) => PRECISION_OPTIONS.includes(p as Precision));
+      if (precs.length > 0) setSelectedPrecisions(precs);
+    }
+    const runDate = latestParams.g_rundate;
+    if (runDate) {
+      userPickedDateRef.current = true;
+      setSelectedRunDateBase(runDate);
+      setSelectedRunDateRev((v) => v + 1);
+    }
+    const runId = latestParams.g_runid;
+    if (runId) setSelectedRunId(runId);
+  }, [latestParams, setSelectedPrecisions]);
 
   // ── Availability data ─────────────────────────────────────────────────────
   const { data: availabilityRows } = useAvailability();
@@ -212,9 +244,6 @@ export function GlobalFilterProvider({ children }: { children: ReactNode }) {
     }
     return [...new Set(rows.map((r) => r.date))].toSorted();
   }, [availabilityRows, modelRows, effectiveSequence, effectivePrecisions]);
-
-  // When true, keep the user's date if available; otherwise always use latest
-  const userPickedDateRef = useRef(Boolean(getUrlParam('g_rundate')));
 
   const setSelectedRunDateManual = useCallback((date: string) => {
     userPickedDateRef.current = true;

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { ChevronRight, Megaphone, X } from 'lucide-react';
+
+import { track } from '@/lib/analytics';
+import { fetchAvailability, fetchWorkflowInfo } from '@/lib/api';
+import {
+  type BannerInfo,
+  buildBannerFromWorkflowInfo,
+  dismiss,
+  isDismissed,
+} from '@/lib/banner-data';
+
+export function AnnouncementBanner() {
+  const [banner, setBanner] = useState<BannerInfo | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const rows = await fetchAvailability();
+        if (cancelled || rows.length === 0) return;
+
+        // Find the most recent date across all models (normalize to YYYY-MM-DD)
+        const latestDate = rows
+          .reduce((max, r) => (r.date > max ? r.date : max), rows[0].date)
+          .slice(0, 10);
+        if (isDismissed(`changelog-${latestDate}`)) return;
+
+        const data = await fetchWorkflowInfo(latestDate);
+        if (cancelled) return;
+
+        const info = buildBannerFromWorkflowInfo(latestDate, data);
+        if (!info || isDismissed(info.id)) return;
+
+        setBanner(info);
+        track('banner_viewed', { banner_id: info.id });
+      } catch {
+        // Silently fail — banner is non-critical
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!banner) return null;
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dismiss(banner.id);
+    track('banner_dismissed', { banner_id: banner.id });
+    setBanner(null);
+  };
+
+  return (
+    <Link
+      href={banner.linkHref}
+      onClick={() => track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref })}
+      className="mb-2 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
+    >
+      <div className="flex items-center gap-3 min-w-0">
+        <Megaphone className="h-4 w-4 text-brand shrink-0" />
+        <span className="text-sm font-medium text-foreground truncate">{banner.message}</span>
+        <span className="text-xs text-muted-foreground whitespace-nowrap hidden sm:inline">
+          {banner.date}
+        </span>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <span className="text-xs text-brand font-medium hidden sm:inline">View</span>
+        <ChevronRight className="h-3.5 w-3.5 text-brand shrink-0" />
+        <button
+          onClick={handleDismiss}
+          className="p-1 hover:bg-brand/20 rounded transition-colors ml-1"
+          aria-label="Dismiss announcement"
+        >
+          <X className="h-4 w-4 text-muted-foreground" />
+        </button>
+      </div>
+    </Link>
+  );
+}

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -10,6 +10,7 @@ import {
   type BannerInfo,
   buildBannerFromWorkflowInfo,
   dismiss,
+  getHardcodedBanner,
   isDismissed,
 } from '@/lib/banner-data';
 
@@ -17,13 +18,21 @@ export function AnnouncementBanner() {
   const [banner, setBanner] = useState<BannerInfo | null>(null);
 
   useEffect(() => {
+    // Check hardcoded announcements first (sync, no fetch)
+    const hardcoded = getHardcodedBanner();
+    if (hardcoded) {
+      setBanner(hardcoded);
+      track('banner_viewed', { banner_id: hardcoded.id });
+      return;
+    }
+
+    // Fall back to automated changelog banner
     let cancelled = false;
     (async () => {
       try {
         const rows = await fetchAvailability();
         if (cancelled || rows.length === 0) return;
 
-        // Find the most recent date across all models (normalize to YYYY-MM-DD)
         const latestDate = rows
           .reduce((max, r) => (r.date > max ? r.date : max), rows[0].date)
           .slice(0, 10);
@@ -56,26 +65,27 @@ export function AnnouncementBanner() {
     setBanner(null);
   };
 
-  return (
-    <Link
-      href={banner.linkHref}
-      onClick={() => {
-        dismiss(banner.id);
-        track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
-        setBanner(null);
-      }}
-      className="bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
-    >
+  const className =
+    'bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25';
+
+  const content = (
+    <>
       <div className="flex items-center gap-3 min-w-0">
         <Megaphone className="h-4 w-4 text-brand shrink-0" />
         <span className="text-sm font-medium text-foreground truncate">{banner.message}</span>
-        <span className="text-xs text-muted-foreground whitespace-nowrap hidden sm:inline">
-          {banner.date}
-        </span>
+        {banner.date && (
+          <span className="text-xs text-muted-foreground whitespace-nowrap hidden sm:inline">
+            {banner.date}
+          </span>
+        )}
       </div>
       <div className="flex items-center gap-1 shrink-0">
-        <span className="text-xs text-brand font-medium hidden sm:inline">View</span>
-        <ChevronRight className="h-3.5 w-3.5 text-brand shrink-0" />
+        {banner.linkHref && (
+          <>
+            <span className="text-xs text-brand font-medium hidden sm:inline">View</span>
+            <ChevronRight className="h-3.5 w-3.5 text-brand shrink-0" />
+          </>
+        )}
         <button
           onClick={handleDismiss}
           className="p-1 hover:bg-brand/20 rounded transition-colors ml-1"
@@ -84,6 +94,24 @@ export function AnnouncementBanner() {
           <X className="h-4 w-4 text-muted-foreground" />
         </button>
       </div>
-    </Link>
+    </>
   );
+
+  if (banner.linkHref) {
+    return (
+      <Link
+        href={banner.linkHref}
+        onClick={() => {
+          dismiss(banner.id);
+          track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
+          setBanner(null);
+        }}
+        className={className}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return <div className={className}>{content}</div>;
 }

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -36,7 +36,6 @@ export function AnnouncementBanner() {
         const latestDate = rows
           .reduce((max, r) => (r.date > max ? r.date : max), rows[0].date)
           .slice(0, 10);
-        if (isDismissed(`changelog-${latestDate}`)) return;
 
         const data = await fetchWorkflowInfo(latestDate);
         if (cancelled) return;
@@ -66,7 +65,7 @@ export function AnnouncementBanner() {
   };
 
   const className =
-    'bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25';
+    'animate-in fade-in slide-in-from-top-2 duration-300 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25';
 
   const content = (
     <>

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -64,7 +64,7 @@ export function AnnouncementBanner() {
         track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
         setBanner(null);
       }}
-      className="-mb-4 lg:mb-0 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
+      className="bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Megaphone className="h-4 w-4 text-brand shrink-0" />

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -59,7 +59,11 @@ export function AnnouncementBanner() {
   return (
     <Link
       href={banner.linkHref}
-      onClick={() => track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref })}
+      onClick={() => {
+        dismiss(banner.id);
+        track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
+        setBanner(null);
+      }}
       className="mb-2 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
     >
       <div className="flex items-center gap-3 min-w-0">

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -64,7 +64,7 @@ export function AnnouncementBanner() {
         track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
         setBanner(null);
       }}
-      className="-mb-2 lg:mb-0 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
+      className="-mb-4 lg:mb-0 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Megaphone className="h-4 w-4 text-brand shrink-0" />

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -64,7 +64,7 @@ export function AnnouncementBanner() {
         track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
         setBanner(null);
       }}
-      className="bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
+      className="-mb-2 lg:mb-0 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Megaphone className="h-4 w-4 text-brand shrink-0" />

--- a/packages/app/src/components/announcement-banner.tsx
+++ b/packages/app/src/components/announcement-banner.tsx
@@ -64,7 +64,7 @@ export function AnnouncementBanner() {
         track('banner_clicked', { banner_id: banner.id, link_href: banner.linkHref });
         setBanner(null);
       }}
-      className="mb-2 bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
+      className="bg-brand/15 border border-brand/30 rounded-lg px-4 py-2.5 flex items-center justify-between gap-3 transition-colors hover:bg-brand/25"
     >
       <div className="flex items-center gap-3 min-w-0">
         <Megaphone className="h-4 w-4 text-brand shrink-0" />

--- a/packages/app/src/components/dashboard-shell.tsx
+++ b/packages/app/src/components/dashboard-shell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AnnouncementBanner } from '@/components/announcement-banner';
 import { ExportNudge } from '@/components/export-nudge';
 import { GlobalFilterProvider } from '@/components/GlobalFilterContext';
 import { GradientLabelNudge } from '@/components/gradient-label-nudge';
@@ -16,6 +17,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       <UnofficialRunProvider>
         <main className="relative">
           <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
+            <AnnouncementBanner />
             <TabNav />
             <GlobalFilterProvider>{children}</GlobalFilterProvider>
           </div>

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -465,9 +465,15 @@ export function InferenceProvider({
   // When a preset is still active (presetHwFilterRef), re-apply the filter instead of resetting
   // to all GPUs — this handles deferred effectivePrecisions changes from late availability data.
   const precisionsKey = effectivePrecisions.join(',');
+  const needsHwResetRef = useRef(false);
   useEffect(() => {
+    needsHwResetRef.current = true;
+  }, [selectedModel, effectiveSequence, precisionsKey]);
+  useEffect(() => {
+    if (!needsHwResetRef.current) return;
     if (pendingHwFilterRef.current) return;
     if (hwTypesWithData.size === 0) return;
+    needsHwResetRef.current = false;
     const presetFilter = presetHwFilterRef.current;
     if (presetFilter) {
       const filterSet = new Set(presetFilter);
@@ -478,7 +484,12 @@ export function InferenceProvider({
       }
     }
     setActiveHwTypes(hwTypesWithData);
-  }, [selectedModel, effectiveSequence, precisionsKey]);
+  }, [selectedModel, effectiveSequence, precisionsKey, hwTypesWithData]);
+
+  // Reset selected GPUs when model changes (comparison configs are model-specific)
+  useEffect(() => {
+    setSelectedGPUs((prev) => (prev.length > 0 ? [] : prev));
+  }, [selectedModel]);
 
   // Remove selected GPUs that no longer have data for current filters
   useEffect(() => {

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -102,8 +102,7 @@ export function TabNav() {
   return (
     <>
       {/* Mobile: Dropdown */}
-      <div className="lg:hidden mb-4">
-        <div className="w-full pb-6" />
+      <div className="lg:hidden">
         <Card>
           <div className="space-y-2">
             <Label htmlFor="chart-select">Select Chart</Label>
@@ -128,7 +127,7 @@ export function TabNav() {
       </div>
 
       {/* Desktop: Nav links */}
-      <div className="hidden lg:flex flex-col mb-4">
+      <div className="hidden lg:flex flex-col">
         <Card className="overflow-x-auto py-6 md:py-6">
           <nav
             data-testid="chart-section-tabs"

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,18 +1,19 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   type UrlStateKey,
   type UrlStateParams,
   readUrlParams,
+  refreshUrlParams,
   writeUrlParams,
 } from '@/lib/url-state';
 
 /**
  * React hook for URL state synchronization.
- * Reads URL params once on mount (cached in ref), and provides
- * functions to write params back to the URL.
+ * Reads URL params on mount and on client-side navigations (pushState / popstate),
+ * clears them from the URL bar, and exposes fresh values via `latestParams`.
  */
 export function useUrlState() {
   const initialParams = useRef<UrlStateParams | null>(null);
@@ -21,6 +22,33 @@ export function useUrlState() {
   if (initialParams.current === null) {
     initialParams.current = readUrlParams();
   }
+
+  const [latestParams, setLatestParams] = useState<UrlStateParams>(initialParams.current);
+
+  useEffect(() => {
+    // pushState handler: params already read & cleared centrally, just apply the result
+    const pushHandler = (e: Event) => {
+      const fresh = (e as CustomEvent<UrlStateParams>).detail;
+      if (fresh && Object.keys(fresh).length > 0) {
+        initialParams.current = { ...initialParams.current, ...fresh };
+        setLatestParams((prev) => ({ ...prev, ...fresh }));
+      }
+    };
+    // popstate handler: browser back/forward — need to read & clear ourselves
+    const popHandler = () => {
+      const fresh = refreshUrlParams();
+      if (Object.keys(fresh).length > 0) {
+        initialParams.current = { ...initialParams.current, ...fresh };
+        setLatestParams((prev) => ({ ...prev, ...fresh }));
+      }
+    };
+    window.addEventListener('urlparamschange', pushHandler);
+    window.addEventListener('popstate', popHandler);
+    return () => {
+      window.removeEventListener('urlparamschange', pushHandler);
+      window.removeEventListener('popstate', popHandler);
+    };
+  }, []);
 
   const hasUrlParam = useCallback((key: UrlStateKey): boolean => {
     const value = initialParams.current?.[key];
@@ -42,6 +70,7 @@ export function useUrlState() {
 
   return {
     initialParams: initialParams.current,
+    latestParams,
     hasUrlParam,
     getUrlParam,
     setUrlParam,

--- a/packages/app/src/lib/banner-data.test.ts
+++ b/packages/app/src/lib/banner-data.test.ts
@@ -85,6 +85,32 @@ describe('buildBannerFromWorkflowInfo', () => {
     expect(banner!.linkHref).toContain('g_model=DeepSeek-R1-0528');
   });
 
+  it('links to /evaluation for eval-related changelogs', () => {
+    const data: WorkflowInfoResponse = {
+      runs: [],
+      changelogs: [
+        {
+          workflow_run_id: 1,
+          date: '2026-03-28',
+          base_ref: 'a',
+          head_ref: 'b',
+          config_keys: ['qwen3.5-fp8-b200-sglang'],
+          description: 'Redo qwen eval',
+          pr_link: null,
+        },
+      ],
+      configs: [],
+    };
+    const banner = buildBannerFromWorkflowInfo('2026-03-28', data);
+    expect(banner!.linkHref).toMatch(/^\/evaluation\?/);
+    expect(banner!.linkHref).not.toContain('i_prec');
+  });
+
+  it('links to /inference for non-eval changelogs', () => {
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', MOCK_WORKFLOW);
+    expect(banner!.linkHref).toMatch(/^\/inference\?/);
+  });
+
   it('includes count when multiple changelogs exist', () => {
     const data: WorkflowInfoResponse = {
       runs: [],

--- a/packages/app/src/lib/banner-data.test.ts
+++ b/packages/app/src/lib/banner-data.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { WorkflowInfoResponse } from '@/lib/api';
+
+import { buildBannerFromWorkflowInfo, isDismissed, dismiss } from './banner-data';
+
+const MOCK_WORKFLOW: WorkflowInfoResponse = {
+  runs: [],
+  changelogs: [
+    {
+      workflow_run_id: 1,
+      date: '2026-04-07',
+      base_ref: 'abc',
+      head_ref: 'def',
+      config_keys: ['kimik2.5-fp4-gb200-dynamo-vllm'],
+      description:
+        'Add Kimi K2.5 NVFP4 GB200 disaggregated multinode vLLM benchmark via Dynamo frontend\nImage: vllm/vllm-openai:v0.18.0',
+      pr_link: null,
+    },
+  ],
+  configs: [],
+};
+
+describe('buildBannerFromWorkflowInfo', () => {
+  it('builds a banner from a changelog entry', () => {
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', MOCK_WORKFLOW);
+    expect(banner).not.toBeNull();
+    expect(banner!.id).toBe('changelog-2026-04-07');
+    expect(banner!.message).toMatch(/^New data: /);
+    expect(banner!.message).toContain('Kimi-K2.5');
+    expect(banner!.linkHref).toContain('/inference');
+    expect(banner!.linkHref).toContain('g_model=Kimi-K2.5');
+    expect(banner!.linkHref).toContain('g_rundate=2026-04-07');
+    expect(banner!.linkHref).toContain('i_prec=fp4');
+    expect(banner!.date).toMatch(/Apr 7, 2026/);
+  });
+
+  it('returns null when there are no changelogs', () => {
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', {
+      runs: [],
+      changelogs: [],
+      configs: [],
+    });
+    expect(banner).toBeNull();
+  });
+
+  it('returns null when changelog has no config keys', () => {
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', {
+      runs: [],
+      changelogs: [
+        {
+          workflow_run_id: 1,
+          date: '2026-04-07',
+          base_ref: 'a',
+          head_ref: 'b',
+          config_keys: [],
+          description: 'Empty',
+          pr_link: null,
+        },
+      ],
+      configs: [],
+    });
+    expect(banner).toBeNull();
+  });
+
+  it('always uses "New run:" prefix with formatted config label', () => {
+    const data: WorkflowInfoResponse = {
+      runs: [],
+      changelogs: [
+        {
+          workflow_run_id: 1,
+          date: '2026-04-07',
+          base_ref: 'a',
+          head_ref: 'b',
+          config_keys: ['dsr1-fp8-b200-sglang'],
+          description: 'Add DeepSeek R1 FP8 B200 SGLang',
+          pr_link: null,
+        },
+      ],
+      configs: [],
+    };
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', data);
+    expect(banner!.message).toMatch(/^New data: /);
+    expect(banner!.message).toContain('B200');
+    expect(banner!.linkHref).toContain('g_model=DeepSeek-R1-0528');
+  });
+
+  it('includes count when multiple changelogs exist', () => {
+    const data: WorkflowInfoResponse = {
+      runs: [],
+      changelogs: [
+        {
+          workflow_run_id: 1,
+          date: '2026-04-07',
+          base_ref: 'a',
+          head_ref: 'b',
+          config_keys: ['dsr1-fp8-b200-sglang'],
+          description:
+            'This is a very long description that exceeds one hundred characters and should fall back to the formatted config key label instead of using the raw description text',
+          pr_link: null,
+        },
+        {
+          workflow_run_id: 2,
+          date: '2026-04-07',
+          base_ref: 'c',
+          head_ref: 'd',
+          config_keys: ['dsr1-fp4-h200-sglang'],
+          description: 'Another change',
+          pr_link: null,
+        },
+      ],
+      configs: [],
+    };
+    const banner = buildBannerFromWorkflowInfo('2026-04-07', data);
+    expect(banner!.message).toContain('+1 more');
+  });
+});
+
+describe('isDismissed / dismiss', () => {
+  let storage: Record<string, string>;
+
+  beforeEach(() => {
+    storage = {};
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage[key] ?? null,
+      setItem: (key: string, value: string) => {
+        storage[key] = value;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false for a banner that has not been dismissed', () => {
+    expect(isDismissed('changelog-2026-04-07')).toBe(false);
+  });
+
+  it('returns true after dismissing a banner', () => {
+    dismiss('changelog-2026-04-07');
+    expect(isDismissed('changelog-2026-04-07')).toBe(true);
+  });
+
+  it('does not affect other banners when one is dismissed', () => {
+    dismiss('changelog-2026-04-07');
+    expect(isDismissed('changelog-2026-04-06')).toBe(false);
+  });
+});

--- a/packages/app/src/lib/banner-data.test.ts
+++ b/packages/app/src/lib/banner-data.test.ts
@@ -25,7 +25,7 @@ describe('buildBannerFromWorkflowInfo', () => {
   it('builds a banner from a changelog entry', () => {
     const banner = buildBannerFromWorkflowInfo('2026-04-07', MOCK_WORKFLOW);
     expect(banner).not.toBeNull();
-    expect(banner!.id).toBe('changelog-2026-04-07');
+    expect(banner!.id).toBe('changelog-1');
     expect(banner!.message).toMatch(/^New data: /);
     expect(banner!.message).toContain('Kimi-K2.5');
     expect(banner!.linkHref).toContain('/inference');

--- a/packages/app/src/lib/banner-data.ts
+++ b/packages/app/src/lib/banner-data.ts
@@ -92,7 +92,7 @@ export function dismiss(id: string): void {
 }
 
 export interface BannerInfo {
-  /** Dismiss key — e.g. "changelog-2026-04-07" */
+  /** Dismiss key — e.g. "changelog-12345" (workflow run ID) */
   id: string;
   /** Human-readable summary, e.g. "New data: Kimi-K2.5 FP4 GB200 (Dynamo vLLM)" */
   message: string;
@@ -154,7 +154,7 @@ export function buildBannerFromWorkflowInfo(
   });
 
   return {
-    id: `changelog-${date}`,
+    id: `changelog-${entry.workflow_run_id}`,
     message: `New data: ${label}${extra}`,
     date: displayDate,
     linkHref: `/${tab}?${search}`,

--- a/packages/app/src/lib/banner-data.ts
+++ b/packages/app/src/lib/banner-data.ts
@@ -1,0 +1,95 @@
+/**
+ * Announcement banner helpers.
+ *
+ * The banner is fully automated — it fetches the latest changelog entry from the
+ * workflow-info API and displays it. No manual configuration needed.
+ *
+ * Dismissals are tracked per changelog date in localStorage so users see each
+ * new day's announcements once.
+ */
+
+import { DB_MODEL_TO_DISPLAY } from '@semianalysisai/inferencex-constants';
+
+import type { ChangelogRow, WorkflowInfoResponse } from '@/lib/api';
+import { type Precision, MODEL_PREFIX_MAPPING, getPrecisionLabel } from '@/lib/data-mappings';
+import { getFrameworkLabel } from '@/lib/utils';
+
+const DISMISS_KEY_PREFIX = 'banner-dismissed-';
+
+/** Check if a banner has been dismissed by the user. */
+export function isDismissed(id: string): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(`${DISMISS_KEY_PREFIX}${id}`) === '1';
+}
+
+/** Mark a banner as dismissed. */
+export function dismiss(id: string): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(`${DISMISS_KEY_PREFIX}${id}`, '1');
+}
+
+export interface BannerInfo {
+  /** Dismiss key — e.g. "changelog-2026-04-07" */
+  id: string;
+  /** Human-readable summary, e.g. "New data: Kimi-K2.5 FP4 GB200 (Dynamo vLLM)" */
+  message: string;
+  /** Display date, e.g. "Apr 7, 2026" */
+  date: string;
+  /** Deep-link to the inference tab with the relevant model/precision pre-selected. */
+  linkHref: string;
+}
+
+/**
+ * Extract a banner from a workflow-info response.
+ * Takes the most recent changelog entry and builds a human-readable message.
+ */
+export function buildBannerFromWorkflowInfo(
+  date: string,
+  data: WorkflowInfoResponse,
+): BannerInfo | null {
+  if (!data.changelogs || data.changelogs.length === 0) return null;
+
+  // Take the most recent entry (last in the array)
+  const entry: ChangelogRow = data.changelogs.at(-1)!;
+  const configKey = entry.config_keys[0];
+  if (!configKey) return null;
+
+  // Parse config key: model-precision-gpu-framework[-variant]
+  const parts = configKey.split('-');
+  const modelPrefix = parts[0] ?? '';
+  const precision = parts[1] ?? '';
+  const gpu = parts[2] ?? '';
+  const framework = parts.slice(3).join('-');
+  const displayModel = DB_MODEL_TO_DISPLAY[modelPrefix];
+
+  // Build human-readable label: Model | Precision | GPU | Framework
+  const model = MODEL_PREFIX_MAPPING[modelPrefix] ?? modelPrefix;
+  const precLabel = getPrecisionLabel(precision as Precision);
+  const isMtp = framework.endsWith('-mtp');
+  const baseFramework = isMtp ? framework.slice(0, -4) : framework;
+  const fwLabel = isMtp
+    ? `${getFrameworkLabel(baseFramework)}, MTP`
+    : getFrameworkLabel(baseFramework);
+  const label = `${model} ${precLabel} ${gpu.toUpperCase()} (${fwLabel})`;
+  const extra = data.changelogs.length > 1 ? ` (+${data.changelogs.length - 1} more)` : '';
+
+  const linkParams = new URLSearchParams();
+  if (displayModel) linkParams.set('g_model', displayModel);
+  linkParams.set('g_rundate', date);
+  if (precision) linkParams.set('i_prec', precision);
+  const search = linkParams.toString();
+
+  // Format date as "Apr 7, 2026"
+  const displayDate = new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return {
+    id: `changelog-${date}`,
+    message: `New data: ${label}${extra}`,
+    date: displayDate,
+    linkHref: `/inference?${search}`,
+  };
+}

--- a/packages/app/src/lib/banner-data.ts
+++ b/packages/app/src/lib/banner-data.ts
@@ -1,11 +1,26 @@
 /**
  * Announcement banner helpers.
  *
- * The banner is fully automated — it fetches the latest changelog entry from the
- * workflow-info API and displays it. No manual configuration needed.
+ * Two banner sources, checked in order (first non-dismissed match wins):
  *
- * Dismissals are tracked per changelog date in localStorage so users see each
- * new day's announcements once.
+ * 1. **Hardcoded announcements** — `ANNOUNCEMENTS` array below. Add entries via PR.
+ *    Shown when `new Date()` falls within [startDate, endDate].
+ *    Omit `endDate` to show until dismissed. Omit `startDate` to show immediately.
+ *
+ * 2. **Automated changelog** — fetched from the workflow-info API at runtime.
+ *    Shows the most recent benchmark submission automatically.
+ *
+ * @example
+ * ```ts
+ * // Hardcoded announcement (add to ANNOUNCEMENTS, newest first):
+ * {
+ *   id: 'clustermax-launch-2026-04',
+ *   message: 'ClusterMax is now live — compare inference API providers!',
+ *   linkHref: 'https://www.clustermax.ai/',
+ *   startDate: '2026-04-01',
+ *   endDate: '2026-04-30',
+ * }
+ * ```
  */
 
 import { DB_MODEL_TO_DISPLAY } from '@semianalysisai/inferencex-constants';
@@ -13,6 +28,54 @@ import { DB_MODEL_TO_DISPLAY } from '@semianalysisai/inferencex-constants';
 import type { ChangelogRow, WorkflowInfoResponse } from '@/lib/api';
 import { type Precision, MODEL_PREFIX_MAPPING, getPrecisionLabel } from '@/lib/data-mappings';
 import { getFrameworkLabel } from '@/lib/utils';
+
+// ─── Hardcoded Announcements ────────────────────────────────────────────────
+// Add new announcements here, newest first. These take priority over automated
+// changelog banners. Only the first active, non-dismissed entry is shown.
+
+interface Announcement {
+  /** Unique identifier — used as localStorage key for dismissal state. */
+  id: string;
+  /** Banner text. */
+  message: string;
+  /** Optional link href (internal path or external URL). */
+  linkHref?: string;
+  /** ISO date string (YYYY-MM-DD). Hidden before this date. */
+  startDate?: string;
+  /** ISO date string (YYYY-MM-DD). Hidden after this date. */
+  endDate?: string;
+}
+
+export const ANNOUNCEMENTS: Announcement[] = [
+  // Example:
+  // {
+  //   id: 'clustermax-launch-2026-04',
+  //   message: 'ClusterMax is now live — compare inference API providers!',
+  //   linkHref: 'https://www.clustermax.ai/',
+  //   startDate: '2026-04-01',
+  //   endDate: '2026-04-30',
+  // },
+];
+
+/** Get the first active hardcoded announcement (within date range, not dismissed). */
+export function getHardcodedBanner(
+  now = new Date(),
+  announcements: Announcement[] = ANNOUNCEMENTS,
+): BannerInfo | null {
+  const today = now.toISOString().slice(0, 10);
+  for (const a of announcements) {
+    if (a.startDate && today < a.startDate) continue;
+    if (a.endDate && today > a.endDate) continue;
+    if (isDismissed(a.id)) continue;
+    return {
+      id: a.id,
+      message: a.message,
+      date: '',
+      linkHref: a.linkHref ?? '',
+    };
+  }
+  return null;
+}
 
 const DISMISS_KEY_PREFIX = 'banner-dismissed-';
 

--- a/packages/app/src/lib/banner-data.ts
+++ b/packages/app/src/lib/banner-data.ts
@@ -73,10 +73,14 @@ export function buildBannerFromWorkflowInfo(
   const label = `${model} ${precLabel} ${gpu.toUpperCase()} (${fwLabel})`;
   const extra = data.changelogs.length > 1 ? ` (+${data.changelogs.length - 1} more)` : '';
 
+  // Detect eval-only changelogs by description text
+  const isEval = entry.description.toLowerCase().includes('eval');
+  const tab = isEval ? 'evaluation' : 'inference';
+
   const linkParams = new URLSearchParams();
   if (displayModel) linkParams.set('g_model', displayModel);
   linkParams.set('g_rundate', date);
-  if (precision) linkParams.set('i_prec', precision);
+  if (!isEval && precision) linkParams.set('i_prec', precision);
   const search = linkParams.toString();
 
   // Format date as "Apr 7, 2026"
@@ -90,6 +94,6 @@ export function buildBannerFromWorkflowInfo(
     id: `changelog-${date}`,
     message: `New data: ${label}${extra}`,
     date: displayDate,
-    linkHref: `/inference?${search}`,
+    linkHref: `/${tab}?${search}`,
   };
 }

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -118,11 +118,59 @@ if (typeof window !== 'undefined') {
     const s = sp.toString();
     window.history.replaceState(null, '', `${window.location.pathname}${s ? `?${s}` : ''}`);
   }, 0);
+
+  // Intercept pushState so client-side navigations (e.g. Next.js <Link>)
+  // read, clear, and broadcast any share-link params in the new URL.
+  if (typeof history !== 'undefined' && history.pushState) {
+    const origPushState = history.pushState.bind(history);
+    history.pushState = (...args: Parameters<typeof history.pushState>) => {
+      origPushState(...args);
+      // Defer so the event fires after Next.js's useInsertionEffect completes
+      setTimeout(() => {
+        const fresh = refreshUrlParams();
+        if (Object.keys(fresh).length > 0) {
+          window.dispatchEvent(new CustomEvent('urlparamschange', { detail: fresh }));
+        }
+      }, 0);
+    };
+  }
 }
 
 /** Returns the share-link params that were in the URL at page load. */
 export function readUrlParams(): UrlStateParams {
   return _initialParams;
+}
+
+/**
+ * Re-read share-link params from the current URL, update internal state,
+ * clear them from the URL bar, and return the fresh params.
+ * Use this to pick up params from client-side navigations.
+ */
+export function refreshUrlParams(): UrlStateParams {
+  if (typeof window === 'undefined') return {};
+  const searchParams = new URLSearchParams(window.location.search);
+  const fresh: UrlStateParams = {};
+  let found = false;
+  for (const key of URL_STATE_KEYS) {
+    const value = searchParams.get(key);
+    if (value !== null) {
+      fresh[key] = value;
+      currentState[key] = value;
+      found = true;
+    }
+  }
+  if (!found) return {};
+
+  // Update cached initial params so getUrlParam() returns fresh values
+  Object.assign(_initialParams, fresh);
+
+  // Clear share-link params from URL
+  const sp = new URLSearchParams(window.location.search);
+  for (const key of URL_STATE_KEYS) sp.delete(key);
+  const s = sp.toString();
+  window.history.replaceState(null, '', `${window.location.pathname}${s ? `?${s}` : ''}`);
+
+  return fresh;
 }
 
 /** Check whether the current URL has any share-link params. */


### PR DESCRIPTION
Fixes https://github.com/SemiAnalysisAI/frontend-issue-tracker/issues/588

## 中文说明
添加新基准测试数据的自动公告横幅。当有新的基准测试数据导入时，自动在页面顶部显示通知横幅，提醒用户查看最新结果。