### PR TITLE
fix: minecraft music persists across navigation + random song start

### DIFF
--- a/packages/app/cypress/e2e/first-load-navigation.cy.ts
+++ b/packages/app/cypress/e2e/first-load-navigation.cy.ts
@@ -1,0 +1,16 @@
+describe('First-load navigation', () => {
+  it('navigates with one click while the GitHub star prompt is visible', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.removeItem('inferencex-starred');
+        win.localStorage.removeItem('inferencex-star-modal-dismissed');
+      },
+    });
+
+    cy.get('[data-testid="github-star-modal"]').should('be.visible');
+    cy.get('body').should('not.have.attr', 'data-scroll-locked');
+
+    cy.get('[data-testid="nav-link-blog"]').click();
+    cy.location('pathname').should('eq', '/blog');
+  });
+});

--- a/packages/app/cypress/e2e/first-load-navigation.cy.ts
+++ b/packages/app/cypress/e2e/first-load-navigation.cy.ts
@@ -1,5 +1,5 @@
 describe('First-load navigation', () => {
-  it('navigates with one click while the GitHub star prompt is visible', () => {
+  beforeEach(() => {
     cy.visit('/', {
       onBeforeLoad(win) {
         win.localStorage.removeItem('inferencex-starred');
@@ -9,8 +9,20 @@ describe('First-load navigation', () => {
 
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
     cy.get('body').should('not.have.attr', 'data-scroll-locked');
+  });
 
+  it('navigates to articles with one click while the GitHub star prompt is visible', () => {
     cy.get('[data-testid="nav-link-blog"]').click();
     cy.location('pathname').should('eq', '/blog');
+  });
+
+  it('navigates to dashboard from the header with one click', () => {
+    cy.get('[data-testid="nav-link-dashboard"]').click();
+    cy.location('pathname').should('eq', '/inference');
+  });
+
+  it('navigates to dashboard from the landing CTA with one click', () => {
+    cy.contains('a', 'Open Dashboard').click();
+    cy.location('pathname').should('eq', '/inference');
   });
 });

--- a/packages/app/cypress/e2e/minecraft-music-navigation.cy.ts
+++ b/packages/app/cypress/e2e/minecraft-music-navigation.cy.ts
@@ -1,0 +1,101 @@
+describe('Minecraft music navigation', () => {
+  it('keeps the music player mounted across same-site header navigation', () => {
+    let documentLoads = 0;
+
+    cy.intercept('GET', 'https://www.youtube.com/iframe_api', {
+      statusCode: 200,
+      body: '',
+    });
+
+    cy.on('window:before:load', (win) => {
+      documentLoads++;
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      win.localStorage.setItem('theme', 'minecraft');
+      win.localStorage.setItem('minecraft-music', 'true');
+
+      interface PlayerConfig {
+        videoId?: string;
+        playerVars?: Record<string, string | number>;
+        events?: {
+          onReady?: (event: { target: FakePlayer }) => void;
+          onStateChange?: (event: { target: FakePlayer; data: number }) => void;
+        };
+      }
+
+      type MinecraftTestWindow = Window & {
+        __minecraftPlayerCreates: number;
+        __minecraftPlayerDestroys: number;
+        __minecraftPlayerConfig?: PlayerConfig;
+      };
+
+      class FakePlayer {
+        private readonly config: PlayerConfig;
+
+        constructor(_el: HTMLElement, config: PlayerConfig) {
+          const testWin = win as unknown as MinecraftTestWindow;
+          testWin.__minecraftPlayerCreates++;
+          testWin.__minecraftPlayerConfig = config;
+          this.config = config;
+          setTimeout(() => config.events?.onReady?.({ target: this }), 0);
+        }
+
+        setVolume() {
+          return undefined;
+        }
+
+        getCurrentTime() {
+          return 12;
+        }
+
+        seekTo() {
+          return undefined;
+        }
+
+        playVideo() {
+          this.config.events?.onStateChange?.({ target: this, data: 1 });
+        }
+
+        destroy() {
+          (win as unknown as MinecraftTestWindow).__minecraftPlayerDestroys++;
+        }
+      }
+
+      const testWin = win as unknown as MinecraftTestWindow;
+      testWin.__minecraftPlayerCreates = 0;
+      testWin.__minecraftPlayerDestroys = 0;
+      (testWin as MinecraftTestWindow & { YT: { Player: typeof FakePlayer } }).YT = {
+        Player: FakePlayer,
+      };
+    });
+
+    cy.visit('/');
+    cy.get('html').should('have.class', 'minecraft');
+    cy.window().its('__minecraftPlayerCreates').should('eq', 1);
+    cy.window().then((win) => {
+      const config = (win as any).__minecraftPlayerConfig;
+      expect(config.videoId).to.eq('bIOiV4d1SVI');
+      expect(config.playerVars.playlist).to.eq('bIOiV4d1SVI');
+      expect(config.playerVars.list).to.eq(undefined);
+      expect(config.playerVars.listType).to.eq(undefined);
+      expect([0, 207, 370, 572, 817, 1099, 1146, 1233, 1418, 1631]).to.include(
+        config.playerVars.start,
+      );
+    });
+
+    cy.get('[data-testid="nav-link-blog"]').click();
+    cy.location('pathname').should('eq', '/blog');
+    cy.window().then((win) => {
+      expect(documentLoads).to.eq(1);
+      expect((win as any).__minecraftPlayerCreates).to.eq(1);
+      expect((win as any).__minecraftPlayerDestroys).to.eq(0);
+    });
+
+    cy.get('[data-testid="nav-link-home"]').click();
+    cy.location('pathname').should('eq', '/');
+    cy.window().then((win) => {
+      expect(documentLoads).to.eq(1);
+      expect((win as any).__minecraftPlayerCreates).to.eq(1);
+      expect((win as any).__minecraftPlayerDestroys).to.eq(0);
+    });
+  });
+});

--- a/packages/app/src/components/github-star-modal.tsx
+++ b/packages/app/src/components/github-star-modal.tsx
@@ -9,19 +9,11 @@ import {
   saveDismissTimestamp,
   saveStarred,
 } from '@/lib/star-storage';
-import { Star } from 'lucide-react';
+import { Star, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
 import { Button } from '@/components/ui/button';
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from '@/components/ui/dialog';
 
 const GITHUB_REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
 
@@ -80,45 +72,62 @@ export function GitHubStarModal() {
   return (
     <>
       {ready && <span data-testid="star-modal-ready" hidden aria-hidden="true" />}
-      <Dialog open={open} onOpenChange={(value) => !value && handleDismiss()}>
-        <DialogContent data-testid="github-star-modal" className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Star className="h-5 w-5 text-yellow-500 fill-yellow-500" />
-              Star InferenceX on GitHub
-            </DialogTitle>
-            <DialogDescription>
-              Star InferenceX on GitHub to get notified when we publish new benchmark data. We
-              update GPU performance comparisons regularly — starring is the easiest way to stay in
-              the loop and help the project grow.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="flex-row gap-2 sm:gap-0">
-            <Button
-              variant="outline"
-              onClick={handleDismiss}
-              data-testid="github-star-modal-dismiss"
-            >
-              Maybe Later
-            </Button>
-            <Button
-              onClick={handleStar}
-              data-testid="github-star-modal-star"
-              className="star-button-glow"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 16 16"
-                fill="currentColor"
-                className="w-4 h-4"
+      {open && (
+        <aside
+          data-testid="github-star-modal"
+          role="dialog"
+          aria-modal="false"
+          aria-labelledby="github-star-title"
+          aria-describedby="github-star-description"
+          className="fixed bottom-4 right-4 z-50 w-[calc(100vw-2rem)] max-w-md rounded-lg border bg-background p-6 shadow-lg"
+        >
+          <button
+            type="button"
+            onClick={handleDismiss}
+            className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <div className="flex flex-col gap-4">
+            <div className="space-y-1.5 pr-6">
+              <h2 id="github-star-title" className="flex items-center gap-2 text-lg font-semibold">
+                <Star className="h-5 w-5 text-yellow-500 fill-yellow-500" />
+                Star InferenceX on GitHub
+              </h2>
+              <p id="github-star-description" className="text-sm text-muted-foreground">
+                Star InferenceX on GitHub to get notified when we publish new benchmark data. We
+                update GPU performance comparisons regularly — starring is the easiest way to stay
+                in the loop and help the project grow.
+              </p>
+            </div>
+            <div className="flex flex-row justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={handleDismiss}
+                data-testid="github-star-modal-dismiss"
               >
-                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-              </svg>
-              Star on GitHub
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+                Maybe Later
+              </Button>
+              <Button
+                onClick={handleStar}
+                data-testid="github-star-modal-star"
+                className="star-button-glow"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 16 16"
+                  fill="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+                </svg>
+                Star on GitHub
+              </Button>
+            </div>
+          </div>
+        </aside>
+      )}
     </>
   );
 }

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -2,12 +2,13 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 
 import { ModeToggle } from '@/components/ui/mode-toggle';
 import { MinecraftToggles } from '@/components/minecraft/minecraft-toggles';
+import { navigateInApp } from '@/lib/client-navigation';
 import { cn } from '@/lib/utils';
 
 import { GitHubStars } from './GithubStars';
@@ -50,6 +51,7 @@ function isActive(pathname: string, href: string): boolean {
 
 export const Header = ({ starCount }: { starCount?: number | null }) => {
   const pathname = usePathname() ?? '/';
+  const router = useRouter();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
@@ -118,7 +120,10 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                     ? 'text-brand bg-brand/10'
                     : 'text-muted-foreground hover:text-foreground hover:bg-muted',
                 )}
-                onClick={() => track(event)}
+                onClick={(e) => {
+                  track(event);
+                  if (href === '/inference') navigateInApp(e, router, href);
+                }}
               >
                 {label}
               </Link>
@@ -168,7 +173,10 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                           ? 'text-brand bg-brand/10'
                           : 'text-muted-foreground hover:text-foreground hover:bg-muted',
                       )}
-                      onClick={() => track(event)}
+                      onClick={(e) => {
+                        track(event);
+                        if (href === '/inference') navigateInApp(e, router, href);
+                      }}
                     >
                       {label}
                     </Link>

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -116,7 +116,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
       <div className="container mx-auto px-4 lg:px-8">
         <div className="flex h-14 items-center gap-6">
           {/* Brand */}
-          <a href="/" className="flex items-center gap-2 shrink-0">
+          <Link href="/" className="flex items-center gap-2 shrink-0">
             <span className="text-lg font-bold tracking-tight">InferenceX</span>
             <span className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground">
               by
@@ -129,7 +129,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                 priority
               />
             </span>
-          </a>
+          </Link>
 
           {/* Desktop nav */}
           <nav className="hidden lg:flex items-center gap-1">

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -48,32 +48,6 @@ function isActive(pathname: string, href: string): boolean {
   return pathname.startsWith(href);
 }
 
-/**
- * Layout group for a path. Next.js soft navigation breaks when crossing
- * layout boundaries, so we use plain <a> tags for those transitions.
- */
-function layoutGroup(path: string): 'dashboard' | 'blog' | 'root' {
-  if (DASHBOARD_TABS.some((tab) => path.startsWith(tab))) return 'dashboard';
-  if (path.startsWith('/blog')) return 'blog';
-  return 'root';
-}
-
-/**
- * Use Next.js Link for same-layout-group navigation (soft nav),
- * plain <a> when crossing layout boundaries (full page nav)
- * to work around Next.js soft navigation bugs between route groups.
- */
-function NavLink({
-  href,
-  currentPath,
-  ...props
-}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; currentPath: string }) {
-  if (layoutGroup(currentPath) === layoutGroup(href)) {
-    return <Link href={href} {...props} />;
-  }
-  return <a href={href} {...props} />;
-}
-
 export const Header = ({ starCount }: { starCount?: number | null }) => {
   const pathname = usePathname() ?? '/';
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -134,11 +108,10 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
           {/* Desktop nav */}
           <nav className="hidden lg:flex items-center gap-1">
             {NAV_LINKS.map(({ href, label, testId, event }) => (
-              <NavLink
+              <Link
                 key={href}
                 data-testid={testId}
                 href={href}
-                currentPath={pathname}
                 className={cn(
                   'px-3 py-1.5 rounded-md text-sm font-medium transition-colors',
                   isActive(pathname, href)
@@ -148,7 +121,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                 onClick={() => track(event)}
               >
                 {label}
-              </NavLink>
+              </Link>
             ))}
           </nav>
 
@@ -186,10 +159,9 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
               {mobileMenuOpen && (
                 <div className="absolute right-0 top-full mt-2 z-50 flex flex-col rounded-lg border border-border bg-background p-1.5 shadow-lg min-w-40">
                   {NAV_LINKS.map(({ href, label, event }) => (
-                    <NavLink
+                    <Link
                       key={href}
                       href={href}
-                      currentPath={pathname}
                       className={cn(
                         'px-3 py-2 rounded-md text-sm font-medium transition-colors',
                         isActive(pathname, href)
@@ -199,7 +171,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                       onClick={() => track(event)}
                     >
                       {label}
-                    </NavLink>
+                    </Link>
                   ))}
                 </div>
               )}

--- a/packages/app/src/components/landing/curated-view-card.tsx
+++ b/packages/app/src/components/landing/curated-view-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
 
 import { Badge } from '@/components/ui/badge';
 import { track } from '@/lib/analytics';
@@ -8,7 +9,7 @@ import type { FavoritePreset } from '@/components/favorites/favorite-presets';
 
 export function CuratedViewCard({ preset }: { preset: FavoritePreset }) {
   return (
-    <a
+    <Link
       href={`/inference?preset=${preset.id}`}
       onClick={() =>
         track('landing_curated_view_clicked', {
@@ -40,6 +41,6 @@ export function CuratedViewCard({ preset }: { preset: FavoritePreset }) {
           </Badge>
         ))}
       </div>
-    </a>
+    </Link>
   );
 }

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowRight, BarChart3, Sparkles } from 'lucide-react';
+import Link from 'next/link';
 import { useEffect } from 'react';
 
 import { Card } from '@/components/ui/card';
@@ -38,14 +39,14 @@ export function LandingPage() {
               gpt-oss, Llama, Qwen, and other models.
             </p>
             <div className="mt-auto">
-              <a
+              <Link
                 href="/inference"
                 onClick={() => track('landing_full_dashboard_clicked')}
                 className="inline-flex items-center justify-center gap-2 rounded-md text-sm sm:text-base font-medium h-12 px-8 bg-brand text-primary-foreground hover:bg-brand/90 transition-colors"
               >
                 Open Dashboard
                 <ArrowRight className="h-4 w-4" />
-              </a>
+              </Link>
             </div>
           </Card>
 

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowRight, BarChart3, Sparkles } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 import { Card } from '@/components/ui/card';
@@ -10,8 +11,11 @@ import { IntroSection } from '@/components/intro-section';
 import { CuratedViewCard } from '@/components/landing/curated-view-card';
 import { FAVORITE_PRESETS } from '@/components/favorites/favorite-presets';
 import { track } from '@/lib/analytics';
+import { navigateInApp } from '@/lib/client-navigation';
 
 export function LandingPage() {
+  const router = useRouter();
+
   useEffect(() => {
     track('landing_page_viewed');
   }, []);
@@ -41,7 +45,10 @@ export function LandingPage() {
             <div className="mt-auto">
               <Link
                 href="/inference"
-                onClick={() => track('landing_full_dashboard_clicked')}
+                onClick={(e) => {
+                  track('landing_full_dashboard_clicked');
+                  navigateInApp(e, router, '/inference');
+                }}
                 className="inline-flex items-center justify-center gap-2 rounded-md text-sm sm:text-base font-medium h-12 px-8 bg-brand text-primary-foreground hover:bg-brand/90 transition-colors"
               >
                 Open Dashboard

--- a/packages/app/src/components/minecraft/minecraft-background.tsx
+++ b/packages/app/src/components/minecraft/minecraft-background.tsx
@@ -12,6 +12,33 @@ const INTERACTIVE =
   'button, a, [role="button"], [role="tab"], [role="switch"], [role="checkbox"], [role="link"], input[type="checkbox"], input[type="radio"], summary';
 
 /**
+ * Track whether the user has interacted with the page.
+ * Once true, stays true for the session — browsers remember the gesture.
+ */
+let userHasInteracted = false;
+if (typeof document !== 'undefined') {
+  const markInteracted = () => {
+    userHasInteracted = true;
+  };
+  document.addEventListener('pointerdown', markInteracted, { capture: true, once: true });
+  document.addEventListener('keydown', markInteracted, { capture: true, once: true });
+}
+
+/** Song start timestamps (in seconds) within the Minecraft OST compilation video. */
+const SONGS = [
+  { name: 'Subwoofer Lullaby', start: 0 },
+  { name: 'Living Mice', start: 207 },
+  { name: 'Haggstrom', start: 370 },
+  { name: 'Minecraft', start: 572 },
+  { name: 'Mice on Venus', start: 817 },
+  { name: 'Dry Hands', start: 1099 },
+  { name: 'Wet Hands', start: 1146 },
+  { name: 'Clark', start: 1233 },
+  { name: 'Sweden', start: 1418 },
+  { name: 'Danny', start: 1631 },
+];
+
+/**
  * Renders the floating 3D Minecraft blocks background, plays
  * the classic button click sound on interactive element presses,
  * and streams background music from the Minecraft OST playlist.
@@ -124,12 +151,8 @@ export function MinecraftBackground() {
       if (!player) return;
       try {
         const time = player.getCurrentTime();
-        const index = player.getPlaylistIndex();
         if (time > 0) {
-          sessionStorage.setItem(
-            'minecraft-music-pos',
-            JSON.stringify({ time, index, ts: Date.now() }),
-          );
+          sessionStorage.setItem('minecraft-music-pos', JSON.stringify({ time, ts: Date.now() }));
         }
       } catch {
         /* player may not be ready */
@@ -146,12 +169,8 @@ export function MinecraftBackground() {
       if (!player) return;
       try {
         const time = player.getCurrentTime();
-        const index = player.getPlaylistIndex();
         if (time > 0) {
-          sessionStorage.setItem(
-            'minecraft-music-pos',
-            JSON.stringify({ time, index, ts: Date.now() }),
-          );
+          sessionStorage.setItem('minecraft-music-pos', JSON.stringify({ time, ts: Date.now() }));
         }
       } catch {
         /* player may not be ready */
@@ -190,42 +209,26 @@ export function MinecraftBackground() {
         document.removeEventListener('keydown', nudge, true);
         nudgeRef.current = null;
 
-        // Resume from saved position if recent (< 30s ago), otherwise random
-        let savedPos: { time: number; index: number; ts: number } | null = null;
+        // Resume from saved position if recent (< 30s ago), otherwise pick a random song
+        let resumeTime: number | null = null;
         try {
           const raw = sessionStorage.getItem('minecraft-music-pos');
           if (raw) {
             const parsed = JSON.parse(raw);
-            if (Date.now() - parsed.ts < 30_000) {
-              savedPos = parsed;
+            if (Date.now() - parsed.ts < 30_000 && typeof parsed.time === 'number') {
+              resumeTime = parsed.time;
             }
           }
         } catch {
           /* ignore parse errors */
         }
 
-        if (savedPos) {
-          // Resume: jump to saved playlist track, then seek within it
-          if (typeof savedPos.index === 'number' && savedPos.index >= 0) {
-            player.playVideoAt(savedPos.index);
-          }
-          // Delay seekTo so playVideoAt has time to load the track
-          setTimeout(() => {
-            if (typeof savedPos.time === 'number' && savedPos.time > 0) {
-              player.seekTo(savedPos.time, true);
-            }
-          }, 500);
+        if (resumeTime !== null && resumeTime > 0) {
+          player.seekTo(resumeTime, true);
         } else {
-          // Fresh session — pick a random track and random position
-          // The playlist has ~20 tracks; pick a random index
-          const randomIndex = Math.floor(Math.random() * 20);
-          player.playVideoAt(randomIndex);
-          setTimeout(() => {
-            const duration = player.getDuration();
-            if (duration > 0) {
-              player.seekTo(Math.random() * duration, true);
-            }
-          }, 500);
+          // Fresh session — seek to the start of a random song
+          const song = SONGS[Math.floor(Math.random() * SONGS.length)];
+          player.seekTo(song.start, true);
         }
       }
 
@@ -251,6 +254,19 @@ export function MinecraftBackground() {
               // actually starts (onStateChange fires PLAYING).
               document.addEventListener('pointerdown', nudge, true);
               document.addEventListener('keydown', nudge, true);
+              // If the user already interacted (e.g. clicked the theme
+              // toggle), aggressively retry playVideo on short intervals
+              // so music starts as soon as the browser allows it.
+              if (userHasInteracted) {
+                let retries = 0;
+                const retry = setInterval(() => {
+                  if (started || retries++ > 10) {
+                    clearInterval(retry);
+                    return;
+                  }
+                  playerRef.current?.playVideo();
+                }, 300);
+              }
             },
             onStateChange: (e: YT.PlayerEvent & { data: number }) => {
               // YT.PlayerState.PLAYING === 1

--- a/packages/app/src/components/minecraft/minecraft-background.tsx
+++ b/packages/app/src/components/minecraft/minecraft-background.tsx
@@ -25,10 +25,12 @@ if (typeof document !== 'undefined') {
 }
 
 /** Song start timestamps (in seconds) within the Minecraft OST compilation video. */
+const MINECRAFT_OST_VIDEO_ID = 'bIOiV4d1SVI';
+
 const SONGS = [
   { name: 'Subwoofer Lullaby', start: 0 },
   { name: 'Living Mice', start: 207 },
-  { name: 'Haggstrom', start: 370 },
+  { name: 'Haggstorm', start: 370 },
   { name: 'Minecraft', start: 572 },
   { name: 'Mice on Venus', start: 817 },
   { name: 'Dry Hands', start: 1099 },
@@ -37,6 +39,23 @@ const SONGS = [
   { name: 'Sweden', start: 1418 },
   { name: 'Danny', start: 1631 },
 ];
+
+function getInitialMusicStart(): number {
+  try {
+    const raw = sessionStorage.getItem('minecraft-music-pos');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (Date.now() - parsed.ts < 30_000 && typeof parsed.time === 'number' && parsed.time > 0) {
+        return Math.floor(parsed.time);
+      }
+    }
+  } catch {
+    /* ignore parse errors */
+  }
+
+  const song = SONGS[Math.floor(Math.random() * SONGS.length)];
+  return song.start;
+}
 
 /**
  * Renders the floating 3D Minecraft blocks background, plays
@@ -198,49 +217,30 @@ export function MinecraftBackground() {
       wrapperRef.current.append(el);
 
       let started = false;
+      const startSeconds = getInitialMusicStart();
+
       function nudge() {
         if (started) return;
         playerRef.current?.playVideo();
       }
       nudgeRef.current = nudge;
-      function onStarted(player: YT.Player) {
+      function onStarted() {
         started = true;
         document.removeEventListener('pointerdown', nudge, true);
         document.removeEventListener('keydown', nudge, true);
         nudgeRef.current = null;
-
-        // Resume from saved position if recent (< 30s ago), otherwise pick a random song
-        let resumeTime: number | null = null;
-        try {
-          const raw = sessionStorage.getItem('minecraft-music-pos');
-          if (raw) {
-            const parsed = JSON.parse(raw);
-            if (Date.now() - parsed.ts < 30_000 && typeof parsed.time === 'number') {
-              resumeTime = parsed.time;
-            }
-          }
-        } catch {
-          /* ignore parse errors */
-        }
-
-        if (resumeTime !== null && resumeTime > 0) {
-          player.seekTo(resumeTime, true);
-        } else {
-          // Fresh session — seek to the start of a random song
-          const song = SONGS[Math.floor(Math.random() * SONGS.length)];
-          player.seekTo(song.start, true);
-        }
       }
 
       try {
         playerRef.current = new YT.Player(el, {
           height: '1',
           width: '1',
+          videoId: MINECRAFT_OST_VIDEO_ID,
           playerVars: {
-            list: 'RDbIOiV4d1SVI',
-            listType: 'playlist',
             autoplay: 1,
             loop: 1,
+            playlist: MINECRAFT_OST_VIDEO_ID,
+            start: startSeconds,
             controls: 0,
             disablekb: 1,
             modestbranding: 1,
@@ -270,8 +270,8 @@ export function MinecraftBackground() {
             },
             onStateChange: (e: YT.PlayerEvent & { data: number }) => {
               // YT.PlayerState.PLAYING === 1
-              if (e.data === 1 && !started) onStarted(e.target);
-              // YT.PlayerState.ENDED === 0 — loop the playlist
+              if (e.data === 1 && !started) onStarted();
+              // YT.PlayerState.ENDED === 0 — loop the single allowed video
               if (e.data === 0) e.target.playVideo();
             },
           },
@@ -311,12 +311,8 @@ export function MinecraftBackground() {
       if (player) {
         try {
           const time = player.getCurrentTime();
-          const index = player.getPlaylistIndex();
           if (time > 0) {
-            sessionStorage.setItem(
-              'minecraft-music-pos',
-              JSON.stringify({ time, index, ts: Date.now() }),
-            );
+            sessionStorage.setItem('minecraft-music-pos', JSON.stringify({ time, ts: Date.now() }));
           }
         } catch {
           /* ignore */

--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { track } from '@/lib/analytics';
@@ -205,13 +206,13 @@ export function QuoteCarousel({
 
       {moreHref && (
         <div className="flex justify-end">
-          <a
+          <Link
             href={moreHref}
             className="text-xs font-bold text-brand hover:underline"
             onClick={() => track('quote_carousel_see_more_clicked')}
           >
             See more supporters &rarr;
-          </a>
+          </Link>
         </div>
       )}
     </div>

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -1,0 +1,34 @@
+'use client';
+
+import type { MouseEvent } from 'react';
+
+interface RouterLike {
+  push(href: string): void;
+}
+
+/**
+ * The first dashboard transition can request the route without committing the
+ * URL change. Repeating the same app-router push after the route payload has
+ * been requested preserves same-document navigation and avoids a music restart.
+ */
+export function navigateInApp(
+  event: MouseEvent<HTMLAnchorElement>,
+  router: RouterLike,
+  href: string,
+) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey ||
+    event.currentTarget.target
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  router.push(href);
+  window.setTimeout(() => router.push(href), 250);
+}


### PR DESCRIPTION
## Summary

- **Fix music pause on navigation**: Switch all header NavLink to Next.js `Link` (soft nav) instead of plain `<a>` tags for cross-layout-group routes. The root layout stays mounted so the YouTube music player is never destroyed when switching between pages.
- **Random song selection**: Replace playlist-index-based seeking with timestamp-based song selection. On fresh sessions, picks a random song from the 10-track Minecraft OST compilation (Subwoofer Lullaby, Living Mice, Haggstrom, Minecraft, Mice on Venus, Dry Hands, Wet Hands, Clark, Sweden, Danny) and seeks to its start timestamp. On resume within 30s, continues from the saved playback position.

## Test plan

- [ ] Music continues uninterrupted when navigating Home → Dashboard → Supporters → Articles → About
- [ ] On first visit with minecraft mode, music starts at the beginning of a random song
- [ ] On page refresh, music resumes from where it left off (within 30s)
- [ ] All navigation links still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)