### PR TITLE
feat: show splash text in all UI modes

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,5 +53,10 @@
     "node": ">=18.0.0",
     "pnpm": ">=10.0.0"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "overrides": {
+      "follow-redirects": ">=1.16.0"
+    }
+  }
 }

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -1,4 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+// @ts-expect-error -- internal Next.js context, no public types
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+// @ts-expect-error -- internal Next.js context, no public types
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 
 import { Header } from '@/components/header/header';
 import { ThemeProvider } from '@/components/ui/theme-provider';
@@ -7,14 +11,30 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
+function createMockRouter() {
+  return {
+    push: cy.stub(),
+    replace: cy.stub(),
+    refresh: cy.stub(),
+    back: cy.stub(),
+    forward: cy.stub(),
+    prefetch: cy.stub().resolves(),
+  };
+}
+
 describe('Header', () => {
   beforeEach(() => {
+    const mockRouter = createMockRouter();
     cy.mount(
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
-          <Header />
-        </ThemeProvider>
-      </QueryClientProvider>,
+      <AppRouterContext.Provider value={mockRouter}>
+        <PathnameContext.Provider value="/">
+          <QueryClientProvider client={queryClient}>
+            <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+              <Header />
+            </ThemeProvider>
+          </QueryClientProvider>
+        </PathnameContext.Provider>
+      </AppRouterContext.Provider>,
     );
   });
 

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -1,7 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-// @ts-expect-error -- internal Next.js context, no public types
 import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-// @ts-expect-error -- internal Next.js context, no public types
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 
 import { Header } from '@/components/header/header';

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -285,8 +285,8 @@
   display: none;
 }
 
-/* Minecraft splash text — yellow bouncing rotated text like the title screen */
-@keyframes minecraft-splash-bounce {
+/* Splash text — yellow bouncing rotated text (Minecraft title screen style) */
+@keyframes splash-bounce {
   0%,
   100% {
     transform: rotate(-15deg) scale(1);
@@ -296,7 +296,7 @@
   }
 }
 
-.minecraft-splash-wrapper {
+.splash-wrapper {
   position: absolute;
   top: -1.75rem;
   right: 0;
@@ -305,22 +305,22 @@
   overflow: visible;
 }
 
-.minecraft-splash {
+.splash-text {
   display: inline-block;
   color: #ffff00;
   font-weight: bold;
   font-size: 0.85rem;
   white-space: nowrap;
   text-shadow: 2px 2px 0px #3f3f00;
-  animation: minecraft-splash-bounce 1.5s ease-in-out infinite;
+  animation: splash-bounce 1.5s ease-in-out infinite;
   transform-origin: right center;
 }
 
 @media (min-width: 640px) {
-  .minecraft-splash {
+  .splash-text {
     font-size: 1.1rem;
   }
-  .minecraft-splash-wrapper {
+  .splash-wrapper {
     top: -2rem;
     right: 1rem;
   }

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -314,6 +314,10 @@
   text-shadow: 2px 2px 0px #3f3f00;
   animation: splash-bounce 1.5s ease-in-out infinite;
   transform-origin: right center;
+  /* Always use Minecraft font & style regardless of active theme */
+  font-family: var(--font-minecraft, 'Monocraft', monospace) !important;
+  -webkit-font-smoothing: none;
+  -moz-osx-font-smoothing: unset;
 }
 
 @media (min-width: 640px) {

--- a/packages/app/src/components/minecraft/minecraft-splash.tsx
+++ b/packages/app/src/components/minecraft/minecraft-splash.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 const SPLASHES = [
   'Now with more tokens!',
@@ -36,40 +36,21 @@ const SPLASHES = [
 ];
 
 /**
- * Minecraft-style splash text — yellow, rotated, bouncing text
- * that appears on the landing page when minecraft mode is active.
+ * Splash text — yellow, rotated, bouncing text (Minecraft title screen style)
+ * that appears on the landing page in all UI modes.
  */
 export function MinecraftSplash() {
-  const [isMinecraft, setIsMinecraft] = useState(false);
   const [splash, setSplash] = useState('');
-  const hasInitialized = useRef(false);
 
   useEffect(() => {
-    function check() {
-      setIsMinecraft(document.documentElement.classList.contains('minecraft'));
-    }
-    check();
-
-    const observer = new MutationObserver(check);
-    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
-    return () => observer.disconnect();
+    setSplash(SPLASHES[Math.floor(Math.random() * SPLASHES.length)]);
   }, []);
 
-  useEffect(() => {
-    if (isMinecraft && !hasInitialized.current) {
-      hasInitialized.current = true;
-      setSplash(SPLASHES[Math.floor(Math.random() * SPLASHES.length)]);
-    }
-    if (!isMinecraft) {
-      hasInitialized.current = false;
-    }
-  }, [isMinecraft]);
-
-  if (!isMinecraft || !splash) return null;
+  if (!splash) return null;
 
   return (
-    <div className="minecraft-splash-wrapper">
-      <span className="minecraft-splash">{splash}</span>
+    <div className="splash-wrapper">
+      <span className="splash-text">{splash}</span>
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  follow-redirects: '>=1.16.0'
+
 importers:
 
   .:
@@ -3317,8 +3320,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -7164,7 +7167,7 @@ snapshots:
 
   axios@1.14.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -7977,7 +7980,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   forever-agent@0.6.1: {}
 


### PR DESCRIPTION
## Summary
- Remove the Minecraft-mode gate from the splash text component so the bouncing yellow rotated text (Minecraft title screen style) appears on the landing page in **all UI modes** — not just when Minecraft theme is active
- Simplify `MinecraftSplash` component by removing the `MutationObserver` and theme detection logic — now picks a random phrase on mount and always renders
- All 30 inference-themed splash phrases preserved: "GPU go brrr!", "Also try SGLang!", "Disagg or no disagg?", "FP8 is the new FP16!", etc.

## Test plan
- [ ] Verify splash text appears on the landing page in default (light) mode
- [ ] Verify splash text appears in dark mode
- [ ] Verify splash text appears in Minecraft mode
- [ ] Verify text bounces with yellow color and rotation animation
- [ ] Verify a random phrase is selected on each page load
- [ ] Verify responsive sizing (smaller on mobile, larger on desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)