### PR TITLE
feat: play minecraft click sound in all UI themes

### DIFF
--- a/packages/app/src/components/minecraft/minecraft-background.tsx
+++ b/packages/app/src/components/minecraft/minecraft-background.tsx
@@ -58,10 +58,10 @@ function getInitialMusicStart(): number {
 }
 
 /**
- * Renders the floating 3D Minecraft blocks background, plays
- * the classic button click sound on interactive element presses,
- * and streams background music from the Minecraft OST playlist.
- * Only active when the minecraft theme is enabled.
+ * Plays the classic Minecraft button click sound on interactive
+ * element presses in every theme. The floating 3D blocks background
+ * and the YouTube-streamed Minecraft OST are only active when the
+ * minecraft theme is enabled.
  */
 export function MinecraftBackground() {
   const [isMinecraft, setIsMinecraft] = useState(false);
@@ -96,7 +96,6 @@ export function MinecraftBackground() {
 
   // Preload the click sound into an AudioBuffer for instant playback
   useEffect(() => {
-    if (!isMinecraft) return;
     let cancelled = false;
     const ctx = new AudioContext();
     audioCtxRef.current = ctx;
@@ -113,11 +112,11 @@ export function MinecraftBackground() {
       audioCtxRef.current = null;
       bufferRef.current = null;
     };
-  }, [isMinecraft]);
+  }, []);
 
   // Play Minecraft click sound on any interactive element press
   useEffect(() => {
-    if (!isMinecraft || !soundEnabled) return;
+    if (!soundEnabled) return;
     function onPointerDown(e: PointerEvent) {
       const target = e.target as HTMLElement | null;
       if (!target?.closest(INTERACTIVE)) return;
@@ -133,7 +132,7 @@ export function MinecraftBackground() {
     }
     document.addEventListener('pointerdown', onPointerDown, true);
     return () => document.removeEventListener('pointerdown', onPointerDown, true);
-  }, [isMinecraft, soundEnabled]);
+  }, [soundEnabled]);
 
   // ── Background music (YouTube IFrame API) ──
   const [musicEnabled, setMusicEnabled] = useState(false);
@@ -324,7 +323,11 @@ export function MinecraftBackground() {
     };
   }, [showMusic]);
 
-  if (!isMinecraft) return null;
+  if (!isMinecraft) {
+    // Component must stay mounted so the click-sound effects keep running
+    // in every theme; only the 3D scene and music are minecraft-only.
+    return null;
+  }
 
   return (
     <>

--- a/packages/app/src/components/minecraft/minecraft-toggles.tsx
+++ b/packages/app/src/components/minecraft/minecraft-toggles.tsx
@@ -13,8 +13,8 @@ const toggleClasses = cn(
 );
 
 /**
- * Music and sound toggle buttons for Minecraft mode.
- * Only renders when the minecraft theme class is active on <html>.
+ * Header toggles for Minecraft audio. The click-sound toggle renders in every
+ * theme (the click sound plays everywhere); the music toggle is minecraft-only.
  */
 export function MinecraftToggles() {
   const [isMinecraft, setIsMinecraft] = useState(false);
@@ -46,8 +46,6 @@ export function MinecraftToggles() {
     };
   }, []);
 
-  if (!isMinecraft) return null;
-
   function toggleMusic() {
     const next = !musicOn;
     setMusicOn(next);
@@ -66,22 +64,24 @@ export function MinecraftToggles() {
 
   return (
     <>
-      <button
-        type="button"
-        className={toggleClasses}
-        onClick={toggleMusic}
-        title={musicOn ? 'Mute music' : 'Unmute music'}
-        aria-label={musicOn ? 'Mute music' : 'Unmute music'}
-      >
-        <span className="relative">
-          <Music className="w-[20px] h-[20px]" />
-          {!musicOn && (
-            <span className="absolute inset-0 flex items-center justify-center">
-              <span className="block w-[22px] h-[2px] bg-current rotate-45" />
-            </span>
-          )}
-        </span>
-      </button>
+      {isMinecraft && (
+        <button
+          type="button"
+          className={toggleClasses}
+          onClick={toggleMusic}
+          title={musicOn ? 'Mute music' : 'Unmute music'}
+          aria-label={musicOn ? 'Mute music' : 'Unmute music'}
+        >
+          <span className="relative">
+            <Music className="w-[20px] h-[20px]" />
+            {!musicOn && (
+              <span className="absolute inset-0 flex items-center justify-center">
+                <span className="block w-[22px] h-[2px] bg-current rotate-45" />
+              </span>
+            )}
+          </span>
+        </button>
+      )}
       <button
         type="button"
         className={toggleClasses}


### PR DESCRIPTION
## Summary
- Click sound now plays on every interactive element press in light, dark, and minecraft themes (previously minecraft-only).
- 3D block scene and YouTube OST stay minecraft-only — no change there.
- The click-sound mute toggle in the header is now visible in every theme; the music toggle stays minecraft-only.

## Implementation
- `minecraft-background.tsx` — dropped the `isMinecraft` dep from the audio preload and pointerdown effects so they run on mount in every theme. Component still returns `null` when not minecraft (keeping scene + music gated); React preserves the mounted instance, so the effects keep running.
- `minecraft-toggles.tsx` — lifted the top-level `isMinecraft` guard; wrapped only the music button in `{isMinecraft && …}`.

## Test plan
- [ ] Light theme: clicking buttons plays the minecraft click sound
- [ ] Dark theme: same
- [ ] Minecraft theme: click sound + music + 3D blocks all still work
- [ ] Header shows sound toggle in every theme; music toggle only in minecraft
- [ ] Muting the sound toggle silences clicks across all themes and persists across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)