### PR TITLE
fix: map dsv4pro benchmark prefix to dsv4 DB key

### DIFF
--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -116,6 +116,11 @@ describe('resolveModelKey', () => {
     expect(resolveModelKey({ infmax_model_prefix: 'gptoss' })).toBe('gptoss120b');
   });
 
+  it('resolves dsv4pro alias from prefix', () => {
+    expect(resolveModelKey({ infmax_model_prefix: 'dsv4pro' })).toBe('dsv4');
+    expect(resolveModelKey({ infmax_model_prefix: 'dsv4pro-fp8' })).toBe('dsv4');
+  });
+
   it('falls back to MODEL_TO_KEY when prefix not present', () => {
     expect(resolveModelKey({ model: 'deepseek-ai/DeepSeek-R1' })).toBe('dsr1');
     expect(resolveModelKey({ model: 'nvidia/Llama-3.3-70B-Instruct-FP8' })).toBe('llama70b');

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -52,6 +52,7 @@ const PRECISION_SUFFIX = /-(?:fp4|fp8|mxfp4|nvfp4)(?:-.*)?$/i;
 /** Explicit aliases for prefixes that don't match any DB key after suffix stripping. */
 const PREFIX_ALIASES: Record<string, string> = {
   gptoss: 'gptoss120b',
+  dsv4pro: 'dsv4',
 };
 
 function resolvePrefixToKey(prefix: string): string | null {


### PR DESCRIPTION
## Summary

Benchmark artifacts for DeepSeek-V4-Pro runs emit `infmax_model_prefix: "dsv4pro"` but the canonical DB key is `dsv4`. The prefix resolver in \`packages/db/src/etl/normalizers.ts\` tries direct match → alias table → precision-suffix strip; none of those turn \`dsv4pro\` into \`dsv4\`, so every row was dropped as \`unmappedModel\` and the unofficial-run API returned an empty benchmark set for these runs.

Adds \`dsv4pro: 'dsv4'\` to \`PREFIX_ALIASES\`, alongside the existing \`gptoss\` alias.

Example failing run: [24884703163](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24884703163) (DeepSeek-V4-Pro FP8 MI355X SGLang).

## Test plan

- [x] \`pnpm --filter @semianalysisai/inferencex-db test:unit\` — 164 passed (was 163)
- [x] New unit test: \`resolveModelKey({ infmax_model_prefix: 'dsv4pro' })\` → \`'dsv4'\`; suffix-stripped variant also resolves
- [x] \`pnpm lint\`, \`pnpm fmt\`, \`pnpm typecheck\` — clean (pre-commit hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)