### PR TITLE
fix(etl): strip -cw runner-pool suffix in hwToGpuKey

### DIFF
--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -73,6 +73,10 @@ describe('hwToGpuKey', () => {
     expect(hwToGpuKey('B200-DSV4')).toBe('b200');
   });
 
+  it('strips -cw suffix', () => {
+    expect(hwToGpuKey('gb300-cw')).toBe('gb300');
+  });
+
   it('strips runner index suffix before other suffixes', () => {
     expect(hwToGpuKey('mi355x-amd_0')).toBe('mi355x');
     expect(hwToGpuKey('mi355x-amd_2')).toBe('mi355x');

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -35,6 +35,7 @@ export function hwToGpuKey(hw: string): string | null {
     .replace(/-dgxc$/, '')
     .replace(/-nb$/, '')
     .replace(/-dsv4$/, '')
+    .replace(/-cw$/, '')
     .replace(/-nv$/, '');
   return GPU_KEYS.has(base) ? base : null;
 }


### PR DESCRIPTION
## Summary

- `hwToGpuKey()` now strips the `-cw` (CoreWeave) suffix, so `gb300-cw` resolves to `gb300`
- Fixes unofficial run view for [run 24950012745](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/24950012745) (`dsv4-fp4-gb300-dynamo-vllm` sweep on CoreWeave GB300s) — all benchmark rows were silently dropped as `unmappedHw`
- Same pattern as #245 (`-dsv4` suffix)

## Test plan

- [x] New unit test: `hwToGpuKey('gb300-cw')` → `'gb300'`
- [x] All 1897 existing tests pass
- [ ] Verify `?unofficialRun=24950012745` renders GB300 data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)