### PR TITLE
chore(footer): add Meta to trillion-dollar AI infra operators list

### DIFF
--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -32,7 +32,7 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => (
           >
             Continuous open-source inference benchmarking. Real-world, reproducible, auditable
             performance data trusted by trillion dollar AI infrastructure operators like OpenAI,
-            Oracle, Microsoft, etc.
+            Meta, Oracle, Microsoft, etc.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Add Meta to the footer brand description list of operators (now reads "OpenAI, Meta, Oracle, Microsoft, etc.")

## Test plan
- [ ] Verify footer copy renders updated list on home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)