### PR TITLE
chore(charts): remove experimental model support disclaimer

### DIFF
--- a/packages/app/src/components/evaluation/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/evaluation/ui/ChartDisplay.tsx
@@ -12,12 +12,7 @@ import { ChartSection } from '@/components/ui/chart-section';
 import { UnofficialDomainNotice } from '@/components/ui/unofficial-domain-notice';
 import { type SegmentedToggleOption, SegmentedToggle } from '@/components/ui/segmented-toggle';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
-import {
-  type Model,
-  type Precision,
-  getPrecisionLabel,
-  isModelExperimental,
-} from '@/lib/data-mappings';
+import { type Precision, getPrecisionLabel } from '@/lib/data-mappings';
 import { exportToCsv } from '@/lib/csv-export';
 import { evaluationChartToCsv } from '@/lib/csv-export-helpers';
 
@@ -93,19 +88,6 @@ export default function EvaluationChartDisplay() {
           </>
         )}
       </p>
-      <div
-        className={`overflow-hidden transition-all duration-200 ease-in-out ${
-          selectedModel && isModelExperimental(selectedModel as Model)
-            ? 'max-h-20 opacity-100'
-            : 'max-h-0 opacity-0'
-        }`}
-      >
-        <p className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1">
-          <strong>Note:</strong> We at SemiAnalysis InferenceX™ are still in very early stages of
-          adding support for this model. Please keep that in mind that these InferenceX numbers are
-          experimental.
-        </p>
-      </div>
       <UnofficialDomainNotice />
     </>
   );

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -39,7 +39,6 @@ import {
   getModelLabel,
   getPrecisionLabel,
   getSequenceLabel,
-  isModelExperimental,
 } from '@/lib/data-mappings';
 import { useComparisonChangelogs } from '@/hooks/api/use-comparison-changelogs';
 import { useTrendData } from '@/components/inference/hooks/useTrendData';
@@ -467,21 +466,6 @@ export default function ChartDisplay() {
                       </p>
                       <MetricAssumptionNotes selectedYAxisMetric={selectedYAxisMetric} />
                       <UnofficialDomainNotice />
-                      <div
-                        className={`overflow-hidden transition-all duration-200 ease-in-out ${
-                          isModelExperimental(selectedModel)
-                            ? 'max-h-20 opacity-100'
-                            : 'max-h-0 opacity-0'
-                        }`}
-                      >
-                        <p className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1">
-                          <strong>Note:</strong> At SemiAnalysis InferenceX™, we're still in the
-                          early stages of adding support for this model. Please note that these
-                          InferenceX™ results are experimental. If a GPU SKU is currently missing,
-                          it does not necessarily mean the model is unsupported; it simply means
-                          InferenceX™ has not added that SKU yet. Additional support is coming soon.
-                        </p>
-                      </div>
                     </>
                   );
 

--- a/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
+++ b/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
@@ -27,7 +27,6 @@ import {
   getModelLabel,
   getPrecisionLabel,
   getSequenceLabel,
-  isModelExperimental,
 } from '@/lib/data-mappings';
 import { getDisplayLabel } from '@/lib/utils';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -313,21 +312,6 @@ export default function HistoricalTrendsDisplay() {
                       includePowerThroughputCaveat={false}
                     />
                     <UnofficialDomainNotice />
-                    <div
-                      className={`overflow-hidden transition-all duration-200 ease-in-out ${
-                        isModelExperimental(selectedModel)
-                          ? 'max-h-20 opacity-100'
-                          : 'max-h-0 opacity-0'
-                      }`}
-                    >
-                      <p className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1">
-                        <strong>Note:</strong> At SemiAnalysis InferenceX™, we're still in the early
-                        stages of adding support for this model. Please note that these InferenceX™
-                        results are experimental. If a GPU SKU is currently missing, it does not
-                        necessarily mean the model is unsupported; it simply means InferenceX™ has
-                        not added that SKU yet. Additional support is coming soon.
-                      </p>
-                    </div>
                   </>
                 }
                 trendLines={trendLines}


### PR DESCRIPTION
## Summary
- Removes the amber "still in early stages of adding support for this model" banner from the inference chart, historical trends chart, and evaluation chart displays.
- Drops the now-unused `isModelExperimental` imports (and unused `Model` type import in evaluation `ChartDisplay`) at the three call sites. The helper itself remains exported from `@/lib/data-mappings` since it sits alongside `isModelDefault` / `isModelDeprecated`.

## Test plan
- [ ] Open an experimental model on the Inference tab — no amber disclaimer below the chart caption.
- [ ] Open an experimental model on the Historical Trends tab — no amber disclaimer.
- [ ] Open an experimental model on the Evaluation tab — no amber disclaimer.
- [ ] Non-experimental models render unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)