### PR TITLE
feat(inference): line labels for unofficial run rooflines + AGENTS rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,20 @@ All interactive elements should have `track()` from `@/lib/analytics` (autocaptu
 
 Order: `inference` → `evaluation` → `historical` → `calculator` → `reliability` → `gpu-specs` (defined in `page-content.tsx` `VALID_TABS`). Tab value = URL hash.
 
+## Unofficial Run Support — Mandatory for Inference / Evaluation Features
+
+Any new feature that operates on inference or evaluation chart data **must** also work for unofficial run overlays — not just the official run rendering path. The overlay path is a separate code branch (`overlayData`, `processedOverlayData`, `overlayRooflines`, `activeOverlayHwTypes`, `overlayRunColor`/`overlayRunIndex` from `@/lib/overlay-run-style`, `useUnofficialRun()` from `@/components/unofficial-run-provider`) that is easy to forget — features that only handle the official path silently degrade for users who load an unofficial run via `?unofficialrun=…`.
+
+When adding a chart feature (toggle, label, overlay, filter, export, share-link param, tooltip enrichment, …):
+
+1. Implement it for both official and overlay data paths. Use `overlayRunColor(runIndex)` for overlay strokes / labels so they match the legend swatches; do **not** reuse the hw-derived color helper (`getCssColor(resolveColor(hw))`) for overlay items.
+2. Respect overlay visibility filters: `activeOverlayHwTypes` (hw toggles) and any per-run dismissal in `unofficialRunInfos`. Don't draw overlay items the user has hidden.
+3. Verify it manually with an unofficial run loaded — paste a `?unofficialrun=<github-actions-run-id>` URL and confirm the new feature renders for overlay rooflines / points / rows, animates with zoom, and survives a per-run dismiss.
+4. Add at least one E2E or unit test that exercises the overlay path. The mock helper `createMockUnofficialRunContext` (cypress/support/mock-data.ts) and the `cypress/e2e/inference-chart.cy.ts` overlay setup are good starting points.
+5. Note overlay support explicitly in the PR description so reviewers can verify it ("works for both official runs and `?unofficialrun=` overlays — verified at <preview-url>").
+
+If the feature genuinely cannot apply to overlays (e.g., it depends on data only ingested for official runs), say so explicitly in code comments and the PR description. Default to "must support overlays."
+
 ## Common Development Tasks
 
 ### Modify chart appearance/behavior

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -209,6 +209,19 @@ describe('ScatterGraph', () => {
           activeOverlayHwTypes: new Set(['b200_trt']),
           allOverlayHwTypes: new Set(['b200_trt']),
           runIndexByUrl: { 'https://github.com/x/y/actions/runs/12345': 0, '12345': 0 },
+          unofficialRunInfos: [
+            {
+              id: 12345,
+              name: 'CI run',
+              branch: 'feature-branch',
+              sha: 'abc123',
+              createdAt: '2026-05-01T00:00:00Z',
+              url: 'https://github.com/x/y/actions/runs/12345',
+              conclusion: 'success',
+              status: 'completed',
+              isNonMainBranch: true,
+            },
+          ],
         },
       },
     );
@@ -227,5 +240,10 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-overlay-labels svg .line-label')
       .filter('[data-line-key]:not([data-line-key^="overlay-"])')
       .should('have.length.greaterThan', 0);
+    // Overlay label text is the run's branch name (matching the overlay legend),
+    // not the hw label.
+    cy.get('#test-scatter-overlay-labels svg .line-label[data-line-key^="overlay-"]')
+      .find('text')
+      .should('contain.text', 'feature-branch');
   });
 });

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -145,4 +145,87 @@ describe('ScatterGraph', () => {
     cy.get('.sidebar-legend').should('exist');
     cy.get('.sidebar-legend label').should('have.length.greaterThan', 0);
   });
+
+  it('renders line labels for both official and overlay (unofficial) rooflines', () => {
+    const interactivityChartDef = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const officialData = [
+      createMockInferenceData({ hwKey: 'h100', x: 8, y: 240, precision: Precision.FP4 }),
+      createMockInferenceData({ hwKey: 'h100', x: 16, y: 200, precision: Precision.FP4 }),
+      createMockInferenceData({ hwKey: 'h100', x: 32, y: 150, precision: Precision.FP4 }),
+    ];
+    const overlayData = {
+      data: [
+        createMockInferenceData({
+          hwKey: 'b200_trt',
+          x: 8,
+          y: 320,
+          precision: Precision.FP4,
+          run_url: 'https://github.com/x/y/actions/runs/12345',
+        }),
+        createMockInferenceData({
+          hwKey: 'b200_trt',
+          x: 16,
+          y: 280,
+          precision: Precision.FP4,
+          run_url: 'https://github.com/x/y/actions/runs/12345',
+        }),
+        createMockInferenceData({
+          hwKey: 'b200_trt',
+          x: 32,
+          y: 220,
+          precision: Precision.FP4,
+          run_url: 'https://github.com/x/y/actions/runs/12345',
+        }),
+      ],
+      hardwareConfig: hwConfig,
+      label: 'feature-branch',
+      runUrl: 'https://github.com/x/y/actions/runs/12345',
+    };
+
+    mountWithProviders(
+      <div style={{ width: 800, height: 600 }}>
+        <ScatterGraph
+          chartId="test-scatter-overlay-labels"
+          modelLabel="DeepSeek R1"
+          data={officialData}
+          xLabel="Concurrency"
+          yLabel="Throughput / GPU (tok/s)"
+          chartDefinition={interactivityChartDef}
+          overlayData={overlayData}
+        />
+      </div>,
+      {
+        inference: {
+          hardwareConfig: hwConfig,
+          activeHwTypes: new Set(['h100']),
+          hwTypesWithData: new Set(['h100']),
+          selectedPrecisions: [Precision.FP4],
+          showLineLabels: true,
+        },
+        unofficial: {
+          activeOverlayHwTypes: new Set(['b200_trt']),
+          allOverlayHwTypes: new Set(['b200_trt']),
+          runIndexByUrl: { 'https://github.com/x/y/actions/runs/12345': 0, '12345': 0 },
+        },
+      },
+    );
+
+    // Both the official roofline and the overlay (unofficial) roofline render.
+    cy.get('#test-scatter-overlay-labels svg .roofline-path').should('have.length.greaterThan', 0);
+    cy.get('#test-scatter-overlay-labels svg .overlay-roofline-path').should(
+      'have.length.greaterThan',
+      0,
+    );
+    // Both an official-keyed and an overlay-keyed line label should render.
+    cy.get('#test-scatter-overlay-labels svg .line-label').should('have.length.greaterThan', 0);
+    cy.get('#test-scatter-overlay-labels svg .line-label')
+      .filter('[data-line-key^="overlay-"]')
+      .should('have.length.greaterThan', 0);
+    cy.get('#test-scatter-overlay-labels svg .line-label')
+      .filter('[data-line-key]:not([data-line-key^="overlay-"])')
+      .should('have.length.greaterThan', 0);
+  });
 });

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -997,9 +997,15 @@ const ScatterGraph = React.memo(
               }
 
               // Overlay (unofficial run) rooflines also get line labels using the
-              // run-palette color so they match the legend swatches. Each
-              // (hw, runIndex) pair is a separate label — same hw across runs
-              // intentionally repeats so the user can read run identity from color.
+              // run-palette color so they match the legend swatches. The label
+              // text mirrors the overlay legend ("✕ <branch>" — falls back to the
+              // hw label if run metadata isn't available, e.g. legacy callers).
+              const overlayLabelText = (runIndex: number, hwKey: string): string => {
+                const info = unofficialRunInfos[runIndex];
+                if (!info) return parseHwKeyToLabel(hwKey).label;
+                const branch = info.branch || `run ${info.id}`;
+                return `✕ ${branch}`;
+              };
               const sortedOverlay = Object.entries(overlayRooflines)
                 .filter(
                   ([, group]) => activeOverlayHwTypes.has(group.hwKey) && group.points.length >= 2,
@@ -1015,7 +1021,7 @@ const ScatterGraph = React.memo(
                   pts[Math.max(0, Math.floor((pts.length * 2) / 3))],
                   pts.at(-1)!,
                 ];
-                const { label } = parseHwKeyToLabel(group.hwKey);
+                const label = overlayLabelText(group.runIndex, group.hwKey);
                 let placedOverlay = false;
                 for (const pt of candidates) {
                   const px = xScale(pt.x);
@@ -1066,16 +1072,20 @@ const ScatterGraph = React.memo(
                   visible: entry.visible,
                 });
               }
-              // Endpoint labels for overlay rooflines too (one per (hw, runIndex)).
+              // Endpoint labels for overlay rooflines too (one per (hw, runIndex)),
+              // labeled with the run's branch name to mirror the overlay legend.
               for (const [ovKey, group] of Object.entries(overlayRooflines)) {
                 if (group.points.length < 2 || !activeOverlayHwTypes.has(group.hwKey)) continue;
+                const info = unofficialRunInfos[group.runIndex];
+                const labelText = info
+                  ? `✕ ${info.branch || `run ${info.id}`}`
+                  : parseHwKeyToLabel(group.hwKey).label;
                 const labelKey = `overlay-${ovKey}`;
                 const pt = group.points.at(-1)!;
-                const { label } = parseHwKeyToLabel(group.hwKey);
                 lineLabels.push({
                   key: labelKey,
                   hw: group.hwKey,
-                  label,
+                  label: labelText,
                   color: overlayRunColor(group.runIndex),
                   x: xScale(pt.x),
                   y: yScale(pt.y),
@@ -1679,6 +1689,7 @@ const ScatterGraph = React.memo(
       processedOverlayData,
       overlayRooflines,
       activeOverlayHwTypes,
+      unofficialRunInfos,
       runIndexByUrl,
       hardwareConfig,
       xLabel,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -995,6 +995,59 @@ const ScatterGraph = React.memo(
                   labeledHw.add(entry.hw);
                 }
               }
+
+              // Overlay (unofficial run) rooflines also get line labels using the
+              // run-palette color so they match the legend swatches. Each
+              // (hw, runIndex) pair is a separate label — same hw across runs
+              // intentionally repeats so the user can read run identity from color.
+              const sortedOverlay = Object.entries(overlayRooflines)
+                .filter(
+                  ([, group]) => activeOverlayHwTypes.has(group.hwKey) && group.points.length >= 2,
+                )
+                .toSorted(([, a], [, b]) => yScale(a.points[0].y) - yScale(b.points[0].y));
+
+              for (const [ovKey, group] of sortedOverlay) {
+                const labelKey = `overlay-${ovKey}`;
+                const pts = group.points;
+                const candidates = [
+                  pts[Math.min(1, pts.length - 1)],
+                  pts[Math.floor(pts.length / 2)],
+                  pts[Math.max(0, Math.floor((pts.length * 2) / 3))],
+                  pts.at(-1)!,
+                ];
+                const { label } = parseHwKeyToLabel(group.hwKey);
+                let placedOverlay = false;
+                for (const pt of candidates) {
+                  const px = xScale(pt.x);
+                  const py = yScale(pt.y);
+                  if (!collides(px, py)) {
+                    lineLabels.push({
+                      key: labelKey,
+                      hw: group.hwKey,
+                      label,
+                      color: overlayRunColor(group.runIndex),
+                      x: px,
+                      y: py,
+                      visible: true,
+                    });
+                    placed.push({ x: px, y: py });
+                    placedOverlay = true;
+                    break;
+                  }
+                }
+                if (!placedOverlay) {
+                  const pt = pts[0];
+                  lineLabels.push({
+                    key: labelKey,
+                    hw: group.hwKey,
+                    label,
+                    color: overlayRunColor(group.runIndex),
+                    x: xScale(pt.x),
+                    y: yScale(pt.y),
+                    visible: false,
+                  });
+                }
+              }
             } else {
               // TTFT / E2EL: endpoint labels, one per hw key
               const seenHw = new Set<string>();
@@ -1011,6 +1064,22 @@ const ScatterGraph = React.memo(
                   x: xScale(pt.x),
                   y: yScale(pt.y),
                   visible: entry.visible,
+                });
+              }
+              // Endpoint labels for overlay rooflines too (one per (hw, runIndex)).
+              for (const [ovKey, group] of Object.entries(overlayRooflines)) {
+                if (group.points.length < 2 || !activeOverlayHwTypes.has(group.hwKey)) continue;
+                const labelKey = `overlay-${ovKey}`;
+                const pt = group.points.at(-1)!;
+                const { label } = parseHwKeyToLabel(group.hwKey);
+                lineLabels.push({
+                  key: labelKey,
+                  hw: group.hwKey,
+                  label,
+                  color: overlayRunColor(group.runIndex),
+                  x: xScale(pt.x),
+                  y: yScale(pt.y),
+                  visible: true,
                 });
               }
               const visible = lineLabels.filter((l) => l.visible);
@@ -1203,6 +1272,43 @@ const ScatterGraph = React.memo(
                 }
               }
 
+              // Overlay (unofficial) rooflines: same greedy placement against
+              // the same `placed` array so they stay non-overlapping with the
+              // official labels post-zoom.
+              const overlayVisible = Object.entries(overlayRooflines)
+                .filter(
+                  ([, group]) => activeOverlayHwTypes.has(group.hwKey) && group.points.length >= 2,
+                )
+                .toSorted(([, a], [, b]) => newYScale(a.points[0].y) - newYScale(b.points[0].y));
+              for (const [ovKey, group] of overlayVisible) {
+                const labelKey = `overlay-${ovKey}`;
+                const pts = group.points;
+                const candidates = [
+                  pts[Math.min(1, pts.length - 1)],
+                  pts[Math.floor(pts.length / 2)],
+                  pts[Math.max(0, Math.floor((pts.length * 2) / 3))],
+                  pts.at(-1)!,
+                ];
+                let found = false;
+                for (const pt of candidates) {
+                  const px = newXScale(pt.x);
+                  const py = newYScale(pt.y);
+                  if (!collides(px, py)) {
+                    zoomResults.set(labelKey, { x: px, y: py, vis: true });
+                    placed.push({ x: px, y: py });
+                    found = true;
+                    break;
+                  }
+                }
+                if (!found) {
+                  zoomResults.set(labelKey, {
+                    x: newXScale(pts[0].x),
+                    y: newYScale(pts[0].y),
+                    vis: false,
+                  });
+                }
+              }
+
               zoomGroup.selectAll<SVGGElement, unknown>('.line-label').each(function () {
                 const el = d3.select(this);
                 const k = el.attr('data-line-key');
@@ -1231,6 +1337,16 @@ const ScatterGraph = React.memo(
                 const pt = pts.at(-1)!;
                 zoomLabels.push({ key, x: newXScale(pt.x), y: newYScale(pt.y) });
               });
+              // Overlay rooflines: per-(hw, runIndex) endpoint labels.
+              for (const [ovKey, group] of Object.entries(overlayRooflines)) {
+                if (group.points.length < 2 || !activeOverlayHwTypes.has(group.hwKey)) continue;
+                const pt = group.points.at(-1)!;
+                zoomLabels.push({
+                  key: `overlay-${ovKey}`,
+                  x: newXScale(pt.x),
+                  y: newYScale(pt.y),
+                });
+              }
               if (zoomLabels.length > 1) {
                 const yRange = newYScale.range();
                 const top = Math.min(yRange[0], yRange[1]) + LABEL_H;
@@ -1562,6 +1678,7 @@ const ScatterGraph = React.memo(
       overlayData,
       processedOverlayData,
       overlayRooflines,
+      activeOverlayHwTypes,
       runIndexByUrl,
       hardwareConfig,
       xLabel,


### PR DESCRIPTION
## Summary
1. **Overlay line labels.** The existing "Line Labels" legend toggle now labels overlay (unofficial run) rooflines too. Each `(hwKey, runIndex)` pair gets its own label using the run-palette color so it visually matches the overlay legend swatches. Labels share the same greedy collision-avoidance pass as official labels so they never overlap, and the zoom handler updates them in lockstep.
2. **Both placement modes covered.** Interactivity-chart placement (try start → midpoint → 2/3-along → endpoint) and TTFT/E2EL endpoint placement both add overlay labels. Overlay rooflines are filtered by `activeOverlayHwTypes` so labels disappear when the user hides an overlay hw in the legend.
3. **AGENTS.md guardrail.** Adds a new "Unofficial Run Support — Mandatory" section: any new inference/evaluation chart feature must implement both the official and the overlay code path, respect `activeOverlayHwTypes`, ship at least one test covering the overlay branch, and be manually verified with a `?unofficialrun=…` URL. PR descriptions should call out overlay support explicitly.

## Test plan
- [ ] Load `/inference` with an unofficial run via `?unofficialrun=<run-id>`.
- [ ] Toggle "Line Labels" — both official (color-by-hw) and overlay (color-by-run) rooflines get labels.
- [ ] Hide an overlay hw via the legend — its label disappears alongside its roofline.
- [ ] Zoom in/out — overlay labels reposition along with official ones, no overlap.
- [ ] Switch to a metric that puts the chart in TTFT/E2EL endpoint mode — overlay endpoint labels render at the right edge.
- [ ] Component test `scatter-graph.cy.tsx` "renders line labels for both official and overlay…" passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)