### PR TITLE
claude code vibe fix(export): render Monocraft font in minecraft mode PNG export / 修复 minecraft 模式下 PNG 导出的 Monocraft 字体渲染

### DIFF
--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -95,21 +95,6 @@ function resolveCssVarsForExport(root: HTMLElement) {
   }
 }
 
-/** Collect @font-face rules from all accessible stylesheets */
-function getFontEmbedCSS(): string {
-  const fontFaces: string[] = [];
-  for (const sheet of document.styleSheets) {
-    try {
-      for (const rule of sheet.cssRules || []) {
-        if (rule instanceof CSSFontFaceRule) fontFaces.push(rule.cssText);
-      }
-    } catch {
-      // skip CORS-restricted stylesheets
-    }
-  }
-  return fontFaces.join('\n');
-}
-
 /** Wait for a React re-render to flush */
 function waitForRender(): Promise<void> {
   return new Promise((resolve) => {
@@ -369,7 +354,9 @@ export function useChartExport({
         });
       }
 
-      // Capture chart image
+      // Don't pass `fontEmbedCSS`: raw `@font-face` rules keep relative URLs that
+      // can't resolve inside an SVG data URL. Letting html-to-image run its own
+      // `getWebFontCSS` inlines the woff2 as a data URL, so Monocraft renders.
       const { toPng } = await htmlToImagePromise;
       const chartDataUrl = await toPng(exportElement, {
         quality: 1,
@@ -377,7 +364,6 @@ export function useChartExport({
         backgroundColor: bgColor,
         cacheBust: true,
         skipFonts: false,
-        fontEmbedCSS: getFontEmbedCSS(),
         preferredFontFormat: 'woff2',
         filter: (node) => !node.classList?.contains('no-export'),
         style: {


### PR DESCRIPTION
Fixes #282.

## Root cause
`useChartExport.ts` pre-supplied `fontEmbedCSS` to `html-to-image` by raw-dumping every `@font-face` rule from `document.styleSheets`. Those rules contain stylesheet-relative font URLs (e.g. `url("../media/Monocraft-...woff2")`) that can't resolve once embedded inside an SVG data URL. The browser silently fell back to Arial — which in minecraft mode replaced Monocraft with sans-serif Arial, exactly the bug reported.

## Fix
Drop the manual `fontEmbedCSS` and the now-unused `getFontEmbedCSS()` helper, letting `html-to-image`'s built-in `getWebFontCSS` resolve each font URL against its parent stylesheet's `href` and inline the woff2 as a data URL.

## Verification
- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `packages/app` unit tests: 1731/1731 pass
- Playwright MCP: PNG export verified across minecraft/dark/light themes

Generated with [Claude Code](https://claude.ai/code)

## 中文说明
修复 minecraft 模式下 PNG 导出时 Monocraft 字体无法渲染的问题。根因是 `useChartExport.ts` 手动提取的 `@font-face` 规则包含相对路径的字体 URL，嵌入 SVG data URL 后无法解析，浏览器静默回退到 Arial。修复方案：移除手动字体嵌入，改用 `html-to-image` 内置的 `getWebFontCSS`，自动解析并内联字体文件。