### PR TITLE
fix(tab-nav): preserve unofficialrun(s) URL param across tab navigation

### DIFF
--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -89,5 +89,4 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
       '/evaluation?unofficialruns=999',
     );
   });
-
 });

--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -1,0 +1,93 @@
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+
+import { TabNav } from '@/components/tab-nav';
+import { UnofficialRunContext } from '@/components/unofficial-run-provider';
+import { createMockUnofficialRunContext } from '../support/mock-data';
+
+function createMockRouter() {
+  return {
+    push: cy.stub(),
+    replace: cy.stub(),
+    refresh: cy.stub(),
+    back: cy.stub(),
+    forward: cy.stub(),
+    prefetch: cy.stub().resolves(),
+  };
+}
+
+/**
+ * Mount TabNav with the provided URL search string written into the window
+ * via history.replaceState. The component reads `window.location.search` in a
+ * useEffect, so the URL must be set before mount.
+ */
+function mountTabNav(opts: { pathname?: string; search?: string }) {
+  const { pathname = '/inference', search = '' } = opts;
+  cy.window().then((win) => {
+    win.history.replaceState(null, '', `${pathname}${search}`);
+  });
+  const router = createMockRouter();
+  const ctxValue = createMockUnofficialRunContext();
+
+  cy.mount(
+    <AppRouterContext.Provider value={router}>
+      <PathnameContext.Provider value={pathname}>
+        <UnofficialRunContext.Provider value={ctxValue}>
+          <TabNav />
+        </UnofficialRunContext.Provider>
+      </PathnameContext.Provider>
+    </AppRouterContext.Provider>,
+  );
+}
+
+describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
+  afterEach(() => {
+    // Reset URL between specs so leftover query strings don't leak.
+    cy.window().then((win) => win.history.replaceState(null, '', '/'));
+  });
+
+  it('renders bare hrefs when the URL has no unofficialrun param', () => {
+    mountTabNav({});
+    cy.get('[data-testid="tab-trigger-evaluation"]').should('have.attr', 'href', '/evaluation');
+    cy.get('[data-testid="tab-trigger-historical"]').should('have.attr', 'href', '/historical');
+    cy.get('[data-testid="tab-trigger-calculator"]').should('have.attr', 'href', '/calculator');
+  });
+
+  it('appends unofficialruns to every tab href when the URL has the param', () => {
+    mountTabNav({ search: '?unofficialruns=12345' });
+    cy.get('[data-testid="tab-trigger-evaluation"]').should(
+      'have.attr',
+      'href',
+      '/evaluation?unofficialruns=12345',
+    );
+    cy.get('[data-testid="tab-trigger-inference"]').should(
+      'have.attr',
+      'href',
+      '/inference?unofficialruns=12345',
+    );
+    cy.get('[data-testid="tab-trigger-historical"]').should(
+      'have.attr',
+      'href',
+      '/historical?unofficialruns=12345',
+    );
+  });
+
+  it('preserves a comma-separated list of run ids verbatim', () => {
+    mountTabNav({ search: '?unofficialruns=111,222,333' });
+    cy.get('[data-testid="tab-trigger-evaluation"]').should(
+      'have.attr',
+      'href',
+      '/evaluation?unofficialruns=111,222,333',
+    );
+  });
+
+  it('accepts the singular alias `unofficialrun` and forwards it under `unofficialruns`', () => {
+    mountTabNav({ search: '?unofficialrun=999' });
+    cy.get('[data-testid="tab-trigger-evaluation"]').should(
+      'have.attr',
+      'href',
+      '/evaluation?unofficialruns=999',
+    );
+  });
+
+});

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 
 import { track } from '@/lib/analytics';
 import { Card } from '@/components/ui/card';
@@ -14,6 +14,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { UnofficialRunContext } from '@/components/unofficial-run-provider';
 import { cn } from '@/lib/utils';
 
 const FEATURE_GATE_KEY = 'inferencex-feature-gate';
@@ -89,10 +90,38 @@ export function TabNav() {
   const current = activeTab(pathname);
   const selectedTab = TAB_VALUES.has(current) ? current : '';
 
+  // Preserve the `unofficialrun(s)` URL param across tab navigation so an
+  // overlay loaded on /inference doesn't get dropped when switching to
+  // /evaluation, etc. The URL is the source of truth (it's still set during
+  // the in-flight fetch and even when the fetch fails), so we read it from
+  // window.location and re-sync on pathname change, context update
+  // (dismiss/clear writes via history.pushState), and popstate.
+  const unofficialCtx = useContext(UnofficialRunContext);
+  const ctxRunInfos = unofficialCtx?.unofficialRunInfos;
+  const [unofficialIds, setUnofficialIds] = useState('');
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const sync = () => {
+      const sp = new URLSearchParams(window.location.search);
+      for (const [k, v] of sp) {
+        if (/^unofficialruns?$/i.test(k) && v) {
+          setUnofficialIds(v);
+          return;
+        }
+      }
+      setUnofficialIds('');
+    };
+    sync();
+    window.addEventListener('popstate', sync);
+    return () => window.removeEventListener('popstate', sync);
+  }, [pathname, ctxRunInfos]);
+  const tabHref = (path: string) =>
+    unofficialIds ? `${path}?unofficialruns=${unofficialIds}` : path;
+
   const handleMobileChange = (value: string) => {
     window.dispatchEvent(new CustomEvent('inferencex:tab-change'));
     track('tab_changed', { tab: value });
-    router.push(`/${value}`);
+    router.push(tabHref(`/${value}`));
   };
 
   const handleDesktopClick = (tab: string) => {
@@ -140,7 +169,7 @@ export function TabNav() {
               return (
                 <Link
                   key={tab.href}
-                  href={tab.href}
+                  href={tabHref(tab.href)}
                   data-testid={tab.testId}
                   data-ph-capture-attribute-tab={tab.href.slice(1)}
                   onClick={() => handleDesktopClick(tab.href.slice(1))}


### PR DESCRIPTION
Fixes #319.

Tab links used bare hrefs (`/evaluation`, `/historical`, …), so clicking a tab while on `/inference?unofficialruns=xyz` dropped the query string and unloaded the unofficial-run overlay. The fix reads the `unofficialrun(s)` param from `window.location` inside `TabNav` and appends it to every tab href, kept in sync with:

- `pathname` changes
- `unofficialRunInfos` context updates (`dismissRun` / `clearUnofficialRun` write via `history.pushState`)
- `popstate` (browser back/forward)

Both the desktop `<Link>` hrefs and the mobile `<Select>` `router.push` go through the same `tabHref()` helper.

## Test plan
- [x] `pnpm typecheck` ✅
- [x] `pnpm lint` ✅
- [x] `pnpm fmt` ✅
- [x] `pnpm test:unit` ✅ (1731/1731 app)
- [x] New Cypress component test `tab-nav.cy.tsx` — 4/4 passing
- [x] Playwright verified at `/inference?unofficialruns=99999999` → click `Accuracy Evals` → lands at `/evaluation?unofficialruns=99999999`

🤖 Generated with [Claude Code](https://claude.ai/code)