### PR TITLE
feat(submissions): add Spec Method column to submissions table

### DIFF
--- a/packages/app/cypress/component/submissions-table.cy.tsx
+++ b/packages/app/cypress/component/submissions-table.cy.tsx
@@ -1,0 +1,64 @@
+import SubmissionsTable from '@/components/submissions/SubmissionsTable';
+import type { SubmissionSummaryRow } from '@/lib/submissions-types';
+
+const baseRow: Omit<SubmissionSummaryRow, 'spec_method' | 'hardware' | 'date'> = {
+  model: 'dsr1',
+  framework: 'vllm',
+  precision: 'fp8',
+  disagg: false,
+  is_multinode: false,
+  num_prefill_gpu: 4,
+  num_decode_gpu: 4,
+  prefill_tp: 4,
+  prefill_ep: 1,
+  decode_tp: 4,
+  decode_ep: 1,
+  total_datapoints: 10,
+  distinct_sequences: 2,
+  distinct_concurrencies: 5,
+  max_concurrency: 64,
+  image: null,
+};
+
+const rows: SubmissionSummaryRow[] = [
+  { ...baseRow, hardware: 'h200', spec_method: 'mtp', date: '2026-05-13' },
+  { ...baseRow, hardware: 'b300', spec_method: 'eagle', date: '2026-05-12' },
+  { ...baseRow, hardware: 'mi355x', spec_method: 'none', date: '2026-05-11' },
+];
+
+describe('SubmissionsTable — Spec Method column', () => {
+  it('renders a Spec Method column header', () => {
+    cy.mount(<SubmissionsTable data={rows} />);
+    cy.contains('th', 'Spec Method').should('be.visible');
+  });
+
+  it('renders spec_method values uppercased and shows an em-dash for "none"', () => {
+    cy.mount(<SubmissionsTable data={rows} />);
+    // CSS uppercases the value; the DOM text remains lowercase.
+    cy.contains('td', 'mtp').should('be.visible').and('have.class', 'uppercase');
+    cy.contains('td', 'eagle').should('be.visible').and('have.class', 'uppercase');
+    // The "none" row renders an em-dash placeholder instead of literal "none".
+    // Hardware text is rendered uppercase via .toUpperCase().
+    cy.contains('tbody tr', 'MI355X').within(() => {
+      cy.contains('—').should('be.visible');
+    });
+  });
+
+  it('sorts by spec_method when the header is clicked', () => {
+    cy.mount(<SubmissionsTable data={rows} />);
+    // Desc alphabetical: 'none' (mi355x) → 'mtp' (h200) → 'eagle' (b300).
+    cy.contains('th', 'Spec Method').click();
+    cy.get('tbody tr').first().should('contain.text', 'MI355X');
+    cy.get('tbody tr').last().should('contain.text', 'B300');
+    // Asc alphabetical: 'eagle' (b300) → 'mtp' (h200) → 'none' (mi355x).
+    cy.contains('th', 'Spec Method').click();
+    cy.get('tbody tr').first().should('contain.text', 'B300');
+    cy.get('tbody tr').last().should('contain.text', 'MI355X');
+  });
+
+  it('filters rows when the search query matches a spec_method', () => {
+    cy.mount(<SubmissionsTable data={rows} />);
+    cy.get('input[placeholder="Search configs..."]').type('eagle');
+    cy.get('tbody tr').should('have.length', 1).first().should('contain.text', 'B300');
+  });
+});

--- a/packages/app/src/components/submissions/SubmissionsTable.tsx
+++ b/packages/app/src/components/submissions/SubmissionsTable.tsx
@@ -41,7 +41,14 @@ function DetailItem({
   );
 }
 
-type SortKey = 'hardware' | 'model' | 'precision' | 'framework' | 'date' | 'total_datapoints';
+type SortKey =
+  | 'hardware'
+  | 'model'
+  | 'precision'
+  | 'spec_method'
+  | 'framework'
+  | 'date'
+  | 'total_datapoints';
 type SortDir = 'asc' | 'desc';
 
 interface SubmissionsTableProps {
@@ -86,6 +93,7 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
         row.model.includes(q) ||
         row.framework.includes(q) ||
         row.precision.includes(q) ||
+        row.spec_method.includes(q) ||
         getVendor(row.hardware).toLowerCase().includes(q) ||
         getModelDisplayName(row.model).toLowerCase().includes(q),
     );
@@ -149,6 +157,7 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
               <SortHeader label="GPU" field="hardware" />
               <SortHeader label="Model" field="model" />
               <SortHeader label="Precision" field="precision" />
+              <SortHeader label="Spec Method" field="spec_method" />
               <SortHeader label="Framework" field="framework" />
               <SortHeader label="Date" field="date" />
               <SortHeader label="Datapoints" field="total_datapoints" />
@@ -169,7 +178,7 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
             })}
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
+                <td colSpan={8} className="px-3 py-8 text-center text-muted-foreground">
                   {search ? 'No matching submissions found.' : 'No submission data available.'}
                 </td>
               </tr>
@@ -212,6 +221,13 @@ function SubmissionRow({
         </td>
         <td className="px-3 py-2">{getModelDisplayName(row.model)}</td>
         <td className="px-3 py-2 uppercase">{row.precision}</td>
+        <td className="px-3 py-2 uppercase">
+          {row.spec_method && row.spec_method !== 'none' ? (
+            row.spec_method
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </td>
         <td className="px-3 py-2">{getFrameworkLabel(row.framework)}</td>
         <td className="px-3 py-2 tabular-nums">{row.date}</td>
         <td className="px-3 py-2 tabular-nums">{row.total_datapoints.toLocaleString()}</td>
@@ -219,7 +235,7 @@ function SubmissionRow({
       {isExpanded && (
         <tr className="bg-muted/20">
           <td />
-          <td colSpan={6} className="px-3 py-3">
+          <td colSpan={7} className="px-3 py-3">
             <TooltipProvider>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-x-8 gap-y-2 text-sm">
                 <DetailItem label="Vendor:" tip="GPU manufacturer">


### PR DESCRIPTION
## Summary

- Adds a sortable **Spec Method** column to the `/submissions` table, between Precision and Framework, so the speculative decoding method (MTP, Eagle, etc.) is visible at a glance rather than hidden inside the expand panel.
- Renders `'none'`/empty spec methods as a muted em-dash (`—`) to keep the column visually quiet for the common case.
- Extends the search filter to match `spec_method` so users can quickly narrow to e.g. `mtp` configs.

## Before / After

| Before | After |
| --- | --- |
| GPU · Model · Precision · Framework · Date · Datapoints | GPU · Model · Precision · **Spec Method** · Framework · Date · Datapoints |

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm fmt` — passes
- [x] `pnpm exec oxlint packages/app/src/components/submissions/ packages/app/cypress/component/submissions-table.cy.tsx` — 0 warnings, 0 errors
- [x] `pnpm exec vitest run src/components/submissions/` — 10/10 passing
- [x] New Cypress component test `submissions-table.cy.tsx` — 4/4 passing (header renders, em-dash for "none", desc/asc sort, search filter)
- [x] Visually verified at `http://localhost:3000/submissions` (E2E_FIXTURES=1) — column lines up correctly with MTP / em-dash values

🤖 Generated with [Claude Code](https://claude.com/claude-code)