### PR TITLE
feat(submissions): show previous → current image diff in expanded row

### DIFF
--- a/packages/app/cypress/component/submissions-table.cy.tsx
+++ b/packages/app/cypress/component/submissions-table.cy.tsx
@@ -62,3 +62,57 @@ describe('SubmissionsTable — Spec Method column', () => {
     cy.get('tbody tr').should('have.length', 1).first().should('contain.text', 'B300');
   });
 });
+
+describe('SubmissionsTable — Image diff in expanded row', () => {
+  const OLD = 'lmsysorg/sglang:v0.5.9-cu130';
+  const NEW = 'lmsysorg/sglang:v0.5.11-cu130';
+  const diffRows: SubmissionSummaryRow[] = [
+    {
+      ...baseRow,
+      hardware: 'h200',
+      spec_method: 'mtp',
+      date: '2026-05-12',
+      image: OLD,
+    },
+    {
+      ...baseRow,
+      hardware: 'h200',
+      spec_method: 'mtp',
+      date: '2026-05-13',
+      image: NEW,
+    },
+    // Different config — no diff should be computed against the h200 rows.
+    {
+      ...baseRow,
+      hardware: 'b300',
+      spec_method: 'eagle',
+      date: '2026-05-13',
+      image: 'rocm/sgl-dev:rocm720',
+    },
+  ];
+
+  it('shows previous → current image on the bump-day row', () => {
+    cy.mount(<SubmissionsTable data={diffRows} />);
+    // Sort defaults to date desc, so the newest h200 row (image=NEW) is first.
+    cy.get('tbody tr').first().click(); // expand
+    cy.get('[data-testid="submissions-image-diff"]')
+      .should('be.visible')
+      .within(() => {
+        cy.contains(OLD).should('be.visible');
+        cy.contains('→').should('be.visible');
+        cy.contains(NEW).should('be.visible');
+      });
+  });
+
+  it('renders just the current image when there is no preceding run', () => {
+    cy.mount(<SubmissionsTable data={diffRows} />);
+    // Expand the b300 row (single-row config, no diff).
+    cy.contains('tbody tr', 'B300').click();
+    cy.contains('tbody tr', 'B300')
+      .next()
+      .within(() => {
+        cy.get('[data-testid="submissions-image-diff"]').should('not.exist');
+        cy.contains('rocm/sgl-dev:rocm720').should('be.visible');
+      });
+  });
+});

--- a/packages/app/src/components/submissions/SubmissionsTable.tsx
+++ b/packages/app/src/components/submissions/SubmissionsTable.tsx
@@ -14,7 +14,7 @@ import {
   TooltipContent,
 } from '@/components/ui/tooltip';
 
-import { getVendor } from './submissions-utils';
+import { computePreviousImages, getVendor, submissionRowKey } from './submissions-utils';
 
 function DetailItem({
   label,
@@ -62,14 +62,13 @@ function getModelDisplayName(dbModel: string): string {
   return dbModel;
 }
 
-const submissionRowKey = (row: SubmissionSummaryRow) =>
-  `${row.model}_${row.hardware}_${row.framework}_${row.precision}_${row.spec_method}_${row.disagg}_${row.is_multinode}_${row.num_prefill_gpu}_${row.num_decode_gpu}_${row.prefill_tp}_${row.prefill_ep}_${row.decode_tp}_${row.decode_ep}_${row.date}`;
-
 export default function SubmissionsTable({ data }: SubmissionsTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [search, setSearch] = useState('');
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+
+  const previousImages = useMemo(() => computePreviousImages(data), [data]);
 
   const handleSort = useCallback(
     (key: SortKey) => {
@@ -172,6 +171,7 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
                   key={key}
                   row={row}
                   isExpanded={isExpanded}
+                  previousImage={previousImages.get(key) ?? null}
                   onToggle={() => toggleRow(key)}
                 />
               );
@@ -197,10 +197,12 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
 function SubmissionRow({
   row,
   isExpanded,
+  previousImage,
   onToggle,
 }: {
   row: SubmissionSummaryRow;
   isExpanded: boolean;
+  previousImage: string | null;
   onToggle: () => void;
 }) {
   const vendor = getVendor(row.hardware);
@@ -304,9 +306,26 @@ function SubmissionRow({
                 <div className="col-span-2 md:col-span-4">
                   <DetailItem
                     label="Image:"
-                    tip="Container image used for this benchmark configuration"
+                    tip={
+                      previousImage
+                        ? 'Container image used for this benchmark configuration. The previous run of this config used a different image — shown on the left.'
+                        : 'Container image used for this benchmark configuration'
+                    }
                   >
-                    <span className="font-mono text-xs break-all">{row.image ?? '—'}</span>
+                    {previousImage ? (
+                      <span
+                        data-testid="submissions-image-diff"
+                        className="font-mono text-xs break-all"
+                      >
+                        <span className="text-muted-foreground">{previousImage}</span>
+                        <span className="mx-2 text-muted-foreground" aria-label="changed to">
+                          →
+                        </span>
+                        <span>{row.image}</span>
+                      </span>
+                    ) : (
+                      <span className="font-mono text-xs break-all">{row.image ?? '—'}</span>
+                    )}
                   </DetailItem>
                 </div>
               </div>

--- a/packages/app/src/components/submissions/submissions-utils.test.ts
+++ b/packages/app/src/components/submissions/submissions-utils.test.ts
@@ -4,10 +4,12 @@ import type { SubmissionVolumeRow, SubmissionSummaryRow } from '@/lib/submission
 
 import {
   computeCumulative,
+  computePreviousImages,
   computeTotalStats,
   getVendor,
   groupVolumeByWeek,
   isNonNvidia,
+  submissionRowKey,
 } from './submissions-utils';
 
 describe('getVendor', () => {
@@ -130,5 +132,62 @@ describe('computeTotalStats', () => {
     expect(stats.totalConfigs).toBe(2);
     expect(stats.uniqueModels).toBe(1);
     expect(stats.uniqueGpus).toBe(2);
+  });
+});
+
+describe('computePreviousImages', () => {
+  const base: Omit<SubmissionSummaryRow, 'date' | 'image'> = {
+    model: 'dsr1',
+    hardware: 'h200',
+    framework: 'sglang',
+    precision: 'fp8',
+    spec_method: 'mtp',
+    disagg: false,
+    is_multinode: false,
+    num_prefill_gpu: 8,
+    num_decode_gpu: 8,
+    prefill_tp: 8,
+    prefill_ep: 1,
+    decode_tp: 8,
+    decode_ep: 1,
+    total_datapoints: 10,
+    distinct_sequences: 2,
+    distinct_concurrencies: 5,
+    max_concurrency: 64,
+  };
+
+  it('flags the row where the image changed, not the steady-state rows', () => {
+    const oldImg = 'lmsysorg/sglang:v0.5.9-cu130';
+    const newImg = 'lmsysorg/sglang:v0.5.11-cu130';
+    const rows: SubmissionSummaryRow[] = [
+      { ...base, date: '2026-05-10', image: oldImg },
+      { ...base, date: '2026-05-11', image: oldImg },
+      { ...base, date: '2026-05-12', image: newImg }, // bump day
+      { ...base, date: '2026-05-13', image: newImg },
+    ];
+    const map = computePreviousImages(rows);
+    expect(map.size).toBe(1);
+    expect(map.get(submissionRowKey(rows[2]))).toBe(oldImg);
+  });
+
+  it('does not cross config boundaries', () => {
+    const rows: SubmissionSummaryRow[] = [
+      { ...base, hardware: 'h200', date: '2026-05-10', image: 'img-a' },
+      { ...base, hardware: 'b300', date: '2026-05-11', image: 'img-b' },
+    ];
+    expect(computePreviousImages(rows).size).toBe(0);
+  });
+
+  it('ignores rows missing image data', () => {
+    const rows: SubmissionSummaryRow[] = [
+      { ...base, date: '2026-05-10', image: null },
+      { ...base, date: '2026-05-11', image: 'img-new' },
+    ];
+    expect(computePreviousImages(rows).size).toBe(0);
+  });
+
+  it('returns empty for a single-row config', () => {
+    const rows: SubmissionSummaryRow[] = [{ ...base, date: '2026-05-10', image: 'img-a' }];
+    expect(computePreviousImages(rows).size).toBe(0);
   });
 });

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -7,6 +7,42 @@ export function getVendor(hardware: string): string {
   return GPU_VENDORS[hardware] ?? 'Unknown';
 }
 
+/** Unique key for a (config, date) row. */
+export const submissionRowKey = (row: SubmissionSummaryRow): string =>
+  `${row.model}_${row.hardware}_${row.framework}_${row.precision}_${row.spec_method}_${row.disagg}_${row.is_multinode}_${row.num_prefill_gpu}_${row.num_decode_gpu}_${row.prefill_tp}_${row.prefill_ep}_${row.decode_tp}_${row.decode_ep}_${row.date}`;
+
+/** Stable key for a benchmark config across dates (everything except date/image). */
+const submissionConfigKey = (row: SubmissionSummaryRow): string =>
+  `${row.model}|${row.hardware}|${row.framework}|${row.precision}|${row.spec_method}|${row.disagg}|${row.is_multinode}|${row.num_prefill_gpu}|${row.num_decode_gpu}|${row.prefill_tp}|${row.prefill_ep}|${row.decode_tp}|${row.decode_ep}`;
+
+/**
+ * For each row, returns the image used by the immediately preceding run of
+ * the same config IF that image differed (i.e. this row is a version bump).
+ * Rows with no earlier run, or whose preceding run used the same image, are
+ * absent from the map so the caller can fall back to a single-image label.
+ */
+export function computePreviousImages(data: SubmissionSummaryRow[]): Map<string, string> {
+  const byConfig = new Map<string, SubmissionSummaryRow[]>();
+  for (const row of data) {
+    const k = submissionConfigKey(row);
+    const list = byConfig.get(k);
+    if (list) list.push(row);
+    else byConfig.set(k, [row]);
+  }
+  const result = new Map<string, string>();
+  for (const rows of byConfig.values()) {
+    const sorted = [...rows].toSorted((a, b) => a.date.localeCompare(b.date));
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const cur = sorted[i];
+      if (prev.image && cur.image && prev.image !== cur.image) {
+        result.set(submissionRowKey(cur), prev.image);
+      }
+    }
+  }
+  return result;
+}
+
 /** Check if hardware is non-NVIDIA. */
 export function isNonNvidia(hardware: string): boolean {
   return getVendor(hardware) !== 'NVIDIA';


### PR DESCRIPTION
## Summary

In the `/submissions` expanded-row detail, the **Image:** field now shows a **previous → current** diff whenever the immediately preceding run of the same config used a different container image — e.g. \`lmsysorg/sglang:v0.5.9-cu130 → lmsysorg/sglang:v0.5.11-cu130\`. Steady-state rows (no preceding run, or preceding run used the same image) keep rendering a single image as before.

Why: users currently have to scroll the full history to figure out *when* a version bump landed. Surfacing the diff inline on the bump-day row turns the table into a lightweight changelog.

## Implementation

- `submissions-utils.ts`: new `computePreviousImages(data)` pure function that groups rows by a config key (everything except `date`/`image`), walks each group chronologically, and emits `rowKey → previousImage` only on the row where the image actually changed. `submissionRowKey` is hoisted from the table component for reuse and testing.
- `SubmissionsTable.tsx`: memoizes the previous-image map and passes the per-row `previousImage` to `SubmissionRow`, which renders the diff with the old image muted, an arrow, and the new image foregrounded. Tooltip on **Image:** is updated to explain the diff when present.

## Test plan
- [x] `pnpm typecheck` — passes
- [x] `pnpm fmt` — passes
- [x] `pnpm exec oxlint packages/app/src/components/submissions/ packages/app/cypress/component/submissions-table.cy.tsx` — 0 warnings, 0 errors
- [x] `pnpm exec vitest run src/components/submissions/` — 14/14 passing (4 new tests for `computePreviousImages`: bump-day detection, config-boundary isolation, null-image handling, single-row no-op)
- [x] Cypress component test — 6/6 passing (2 new tests: bump-day row shows diff, single-row config shows just the current image)
- [x] Visually verified against `/submissions` with fixture data (E2E_FIXTURES=1) — bump days in `dsv4/mi355x/sglang` and `dsv4/b300/vllm` configs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)