### PR TITLE
fix(dsv4): treat default MTP-deselected legend as "all selected"

### DIFF
--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -48,7 +48,7 @@ import {
   MtpEngineConflictToast,
   type MtpEngineConflictDetail,
 } from '@/components/mtp-engine-conflict-toast';
-import { clearAllMtpFamilies, resolveMtpToggle } from '@/lib/mtp-exclusion';
+import { clearAllMtpFamilies, effectiveLegendItems, resolveMtpToggle } from '@/lib/mtp-exclusion';
 import { filterRunsByModel, getDisplayLabel } from '@/lib/utils';
 
 import { useChartData } from './hooks/useChartData';
@@ -444,8 +444,15 @@ export function InferenceProvider({
   const mtpExclusion = hasMtpEngineExclusion(selectedModel);
   const toggleHwType = useCallback(
     (hw: string) => {
+      // Under MTP exclusion, hide MTP keys from inactive families when
+      // computing the toggle "universe". This makes the default-deselected
+      // state (DSv4 on first load) count as "all selected", so clicking a
+      // legend entry solos it instead of just removing it.
+      const toggleUniverse = mtpExclusion
+        ? effectiveLegendItems(hwTypesWithData, activeHwTypes)
+        : hwTypesWithData;
       if (mtpExclusion) {
-        const decision = resolveMtpToggle(activeHwTypes, hw, hwTypesWithData);
+        const decision = resolveMtpToggle(activeHwTypes, hw, toggleUniverse);
         if (decision.kind === 'block') {
           setMtpConflict({
             kind: 'blocked',
@@ -461,7 +468,7 @@ export function InferenceProvider({
           return;
         }
       }
-      toggleHwRaw(hw, hwTypesWithData);
+      toggleHwRaw(hw, toggleUniverse);
       setActivePresetId(null);
       presetHwFilterRef.current = null;
     },

--- a/packages/app/src/lib/mtp-exclusion.test.ts
+++ b/packages/app/src/lib/mtp-exclusion.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
+import { computeToggle } from '@/hooks/useTogglableSet';
+
 import {
   clearAllMtpFamilies,
+  effectiveLegendItems,
   getMtpEngineFamily,
   pickStickyMtpFamily,
   resolveMtpToggle,
@@ -92,6 +95,58 @@ describe('clearAllMtpFamilies', () => {
     const out = clearAllMtpFamilies(proposed);
     expect([...out.result].toSorted()).toEqual(['gb300_sglang', 'h100_vllm']);
     expect(out.droppedFamilies.toSorted()).toEqual(['sglang', 'vllm']);
+  });
+});
+
+describe('effectiveLegendItems', () => {
+  it('returns the input set unchanged when no MTP keys present', () => {
+    const all = new Set(['h100_vllm', 'gb300_sglang']);
+    const active = new Set(['h100_vllm']);
+    const out = effectiveLegendItems(all, active);
+    expect([...out].toSorted()).toEqual(['gb300_sglang', 'h100_vllm']);
+  });
+
+  it('drops MTP keys whose family is not active (default DSv4 state)', () => {
+    const all = new Set(['h100_vllm', 'gb300_sglang', 'h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const active = new Set(['h100_vllm', 'gb300_sglang']); // no MTP active
+    const out = effectiveLegendItems(all, active);
+    expect([...out].toSorted()).toEqual(['gb300_sglang', 'h100_vllm']);
+  });
+
+  it('keeps MTP keys for active families and drops the rest', () => {
+    const all = new Set([
+      'h100_vllm',
+      'gb300_sglang',
+      'h100_vllm_mtp',
+      'h200_vllm_mtp',
+      'gb300_sglang_mtp',
+    ]);
+    const active = new Set(['h100_vllm', 'gb300_sglang', 'h100_vllm_mtp']);
+    const out = effectiveLegendItems(all, active);
+    expect([...out].toSorted()).toEqual([
+      'gb300_sglang',
+      'h100_vllm',
+      'h100_vllm_mtp',
+      'h200_vllm_mtp',
+    ]);
+  });
+
+  it('treats dynamo-/mori- variants as the same family', () => {
+    const all = new Set(['h100_vllm', 'h100_dynamo-vllm_mtp', 'h100_vllm_mtp', 'h100_sglang_mtp']);
+    const active = new Set(['h100_vllm', 'h100_vllm_mtp']);
+    const out = effectiveLegendItems(all, active);
+    expect([...out].toSorted()).toEqual(['h100_dynamo-vllm_mtp', 'h100_vllm', 'h100_vllm_mtp']);
+  });
+
+  it('makes computeToggle solo on click in the default-deselected state', () => {
+    // Default DSv4 state: all non-MTP active, MTP keys exist in data but
+    // are deselected. The effective universe matches active → computeToggle
+    // soloes the clicked item.
+    const all = new Set(['h100_vllm', 'gb300_sglang', 'h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const active = new Set(['h100_vllm', 'gb300_sglang']);
+    const effective = effectiveLegendItems(all, active);
+    const out = computeToggle(active, 'h100_vllm', effective);
+    expect(out).toEqual(new Set(['h100_vllm']));
   });
 });
 

--- a/packages/app/src/lib/mtp-exclusion.ts
+++ b/packages/app/src/lib/mtp-exclusion.ts
@@ -81,6 +81,27 @@ export function pickStickyMtpFamily(
 }
 
 /**
+ * Compute the effective legend universe for solo/restore-all toggle semantics
+ * under MTP engine-family exclusion. MTP keys whose family is not currently
+ * active are dropped, so the default-deselected MTP state (e.g. DSv4 on first
+ * load) counts as "all selected" — clicking an entry then solos it instead of
+ * just removing it.
+ */
+export function effectiveLegendItems(allItems: Set<string>, active: Set<string>): Set<string> {
+  const activeFamilies = new Set<string>();
+  for (const k of active) {
+    const fam = getMtpEngineFamily(k);
+    if (fam) activeFamilies.add(fam);
+  }
+  const result = new Set<string>();
+  for (const k of allItems) {
+    const fam = getMtpEngineFamily(k);
+    if (!fam || activeFamilies.has(fam)) result.add(k);
+  }
+  return result;
+}
+
+/**
  * Drop MTP keys for ALL families when `proposed` contains keys from more than
  * one family. Used for auto-reset / select-all paths so the user has to opt
  * into MTP explicitly (and only one engine at a time).


### PR DESCRIPTION
## Summary

- DSv4 auto-deselects MTP keys on load (cross-engine MTP isn't directly comparable). That made the active set strictly smaller than `hwTypesWithData`, so the legend's "all selected → click solos" path never fired — clicking just removed items instead of soloing.
- Added `effectiveLegendItems(allItems, active)` in `mtp-exclusion.ts`: drops MTP keys whose family isn't currently active, so the default-deselected state counts as "all selected".
- `toggleHwType` now feeds this filtered universe into both `resolveMtpToggle` and `toggleHwRaw`, restoring solo/restore-all click semantics for DSv4.
- Non-DSv4 models are unaffected (gated by `mtpExclusion`). Cross-family MTP block toast still fires when the user explicitly tries to add a conflicting MTP key.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` — all 1717 app tests pass (5 new for `effectiveLegendItems`)
- [x] `pnpm lint` / `pnpm fmt` clean
- [ ] Manually verify on DSv4: clicking a legend entry in the default state solos it; clicking it again restores the default (non-MTP) set; explicit MTP opt-in + cross-family block toast still work