### PR TITLE
fix: reduce feedback popup target to 2 distinct calendar days

### DIFF
--- a/packages/app/src/lib/visit-tracking.ts
+++ b/packages/app/src/lib/visit-tracking.ts
@@ -4,7 +4,7 @@ const FIRST_SEEN_KEY = 'inferencex-first-seen';
 const LAST_SEEN_KEY = 'inferencex-last-seen';
 const SESSION_KEY = 'inferencex-visit-counted';
 
-export const FEEDBACK_TARGET_VISIT = 4;
+export const FEEDBACK_TARGET_VISIT = 2;
 export const FEEDBACK_ELIGIBLE_EVENT = 'inferencex:feedback-eligible';
 
 function todayISO(): string {


### PR DESCRIPTION
Reduces `FEEDBACK_TARGET_VISIT` from 4 to 2 so the feedback popup fires after 2 distinct calendar days instead of 4.

Closes #349

Generated with [Claude Code](https://claude.ai/code)