### PR TITLE
fix(submissions): show compare button for model aliases

### DIFF
--- a/packages/app/src/components/submissions/submissions-utils.test.ts
+++ b/packages/app/src/components/submissions/submissions-utils.test.ts
@@ -295,4 +295,32 @@ describe('buildInferenceCompareUrl', () => {
     };
     expect(buildInferenceCompareUrl(current, previous)).toBeNull();
   });
+
+  it('handles DB prefixes that include point-release suffix (gptoss120b, glm5.1, llama70b)', () => {
+    const cases: [string, string][] = [
+      ['gptoss120b', 'gpt-oss-120b'],
+      ['glm5.1', 'GLM-5'],
+      ['llama70b', 'Llama-3.3-70B-Instruct-FP8'],
+      ['kimik2.6', 'Kimi-K2.5'],
+      ['minimaxm2.7', 'MiniMax-M2.5'],
+    ];
+    for (const [dbModel, expectedDisplay] of cases) {
+      const previous: SubmissionSummaryRow = {
+        ...base,
+        model: dbModel,
+        date: '2026-05-10',
+        image: 'img-a',
+      };
+      const current: SubmissionSummaryRow = {
+        ...base,
+        model: dbModel,
+        date: '2026-05-12',
+        image: 'img-b',
+      };
+      const url = buildInferenceCompareUrl(current, previous);
+      expect(url, `expected URL for ${dbModel}`).not.toBeNull();
+      const parsed = new URL(`https://example.com${url}`);
+      expect(parsed.searchParams.get('g_model')).toBe(expectedDisplay);
+    }
+  });
 });

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -1,7 +1,6 @@
-import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
+import { DB_MODEL_TO_DISPLAY, GPU_VENDORS } from '@semianalysisai/inferencex-constants';
 
 import { buildAvailabilityHwKey } from '@/lib/chart-utils';
-import { MODEL_PREFIX_MAPPING } from '@/lib/data-mappings';
 import type { SubmissionSummaryRow, SubmissionVolumeRow } from '@/lib/submissions-types';
 
 /** Get vendor name for a hardware key. */
@@ -80,7 +79,10 @@ export function buildInferenceCompareUrl(
   currentRow: SubmissionSummaryRow,
   previousRow: SubmissionSummaryRow,
 ): string | null {
-  const displayModel = MODEL_PREFIX_MAPPING[currentRow.model];
+  // DB_MODEL_TO_DISPLAY covers every DB prefix incl. point-release aliases
+  // (gptoss120b, glm5.1, kimik2.6, minimaxm2.7, llama70b). MODEL_PREFIX_MAPPING
+  // only has the single canonical prefix per Model enum and misses those rows.
+  const displayModel = DB_MODEL_TO_DISPLAY[currentRow.model];
   if (!displayModel) return null;
   const hwKey = buildAvailabilityHwKey(
     currentRow.hardware,


### PR DESCRIPTION
## Summary

The \"Compare {prev} → {new}\" button on `/submissions` only appeared for a subset of models. Root cause: `buildInferenceCompareUrl()` looked up the row's DB model prefix in `MODEL_PREFIX_MAPPING`, which only carries the **single canonical prefix per `Model` enum** (`gptoss`, `glm5`, `kimik2.5`, `minimaxm2.5`, `70b`). The DB actually stores the suffixed aliases for shipped releases:

| DB prefix     | Display name                  |
|---------------|-------------------------------|
| `gptoss120b`  | gpt-oss-120b                  |
| `glm5.1`      | GLM-5                         |
| `kimik2.6`    | Kimi-K2.5                     |
| `minimaxm2.7` | MiniMax-M2.5                  |
| `llama70b`    | Llama-3.3-70B-Instruct-FP8    |

For those prefixes the lookup returned `undefined`, the helper short-circuited to `null`, and the column silently rendered `—`. Switch to `DB_MODEL_TO_DISPLAY` from `@semianalysisai/inferencex-constants` — the source-of-truth map that covers every DB prefix including point-release aliases.

Verified against live `/api/v1/submissions`: this affects ~36 multi-run gptoss configs, ~14 multi-run glm5/glm5.1 configs, all llama70b rows, and the kimik2.6/minimaxm2.7 alias rows.

## Test plan

- [ ] `pnpm test:unit` (added a parametrized test covering `gptoss120b`, `glm5.1`, `llama70b`, `kimik2.6`, `minimaxm2.7`).
- [ ] On the deploy, expand a gpt-oss / llama 70B / kimi 2.6 row and confirm the compare button now appears + links to a populated `/inference` chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)