### PR TITLE
feat(current-inferencex-image): sort oldest-first + Days Since Update column

### DIFF
--- a/packages/app/src/components/latest-image/latest-image-content.tsx
+++ b/packages/app/src/components/latest-image/latest-image-content.tsx
@@ -65,6 +65,13 @@ function getActualLatestTag(framework: string, releases: FrameworkReleases | und
 
 const UNSTABLE_PATTERNS = ['nightly', 'rocm/sgl-dev', 'sglang-rocm'];
 
+/** Whole-day delta between today (UTC) and an ISO date string (YYYY-MM-DD). */
+function daysSince(dateStr: string, today: Date): number {
+  const submitted = new Date(`${dateStr}T00:00:00Z`).getTime();
+  const ms = today.getTime() - submitted;
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
 /** Check if the image tag is outdated or uses an unstable/dev image. */
 function isOutdated(image: string, actualLatest: string | null): boolean {
   const lower = image.toLowerCase();
@@ -85,9 +92,13 @@ export function CurrentImageContent() {
 
   const options = useMemo(() => (data ? deriveOptions(data) : null), [data]);
 
+  // Stable "today" per render — recomputed on each mount, which is fine for the
+  // page's read-only display (no need to tick every minute).
+  const today = useMemo(() => new Date(), []);
+
   const filtered = useMemo(() => {
     if (!data) return [];
-    return data.filter((row) => {
+    const rows = data.filter((row) => {
       if (selectedModel !== 'all') {
         const displayModel = DB_MODEL_TO_DISPLAY[row.model] ?? row.model;
         if (displayModel !== selectedModel) return false;
@@ -99,6 +110,9 @@ export function CurrentImageContent() {
       if (selectedHardware !== 'all' && row.hardware !== selectedHardware) return false;
       return true;
     });
+    // Sort oldest-image first so the most stale entries surface at the top —
+    // users primarily care about "what hasn't been refreshed in a while".
+    return rows.toSorted((a, b) => a.date.localeCompare(b.date));
   }, [
     data,
     selectedModel,
@@ -282,6 +296,12 @@ export function CurrentImageContent() {
                   Current InferenceX Image Tag
                 </th>
                 <th className="px-4 py-3 text-left text-sm font-semibold">Actual Latest Tag</th>
+                <th
+                  className="px-4 py-3 text-left text-sm font-semibold whitespace-nowrap"
+                  title="Whole days between today and the most recent benchmark submission for this config"
+                >
+                  Days Since Update
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -290,6 +310,8 @@ export function CurrentImageContent() {
                 const gpuLabel = row.hardware.toUpperCase();
                 const actualLatest = getActualLatestTag(row.framework, releases);
                 const outdated = isOutdated(row.image, actualLatest);
+                const ageDays = daysSince(row.date, today);
+                const ageStale = ageDays >= 7;
 
                 return (
                   <tr
@@ -325,6 +347,14 @@ export function CurrentImageContent() {
                       ) : (
                         <span className="text-muted-foreground">-</span>
                       )}
+                    </td>
+                    <td
+                      className={`px-4 py-3 text-sm tabular-nums whitespace-nowrap ${
+                        ageStale ? 'text-red-400 font-medium' : 'text-muted-foreground'
+                      }`}
+                      title={`Last submission: ${row.date}`}
+                    >
+                      {ageDays}d
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## Summary

The point of `/current-inferencex-image` is spotting stale deployed images, but the table renders in API order (model × hardware) so users have to scan every row looking for old ones.

- **Sort by submission date ascending** so the oldest images surface at the top of the table.
- **Add a *Days Since Update* column** computed as `today − row.date` (whole UTC days). Rows aged ≥7 days are tinted red + bold so they stand out at a glance; the title attribute shows the exact submission date on hover.

Uses each row's submission date (already in the API response) rather than GitHub release metadata — InferenceX image tags don't always map cleanly to upstream GitHub releases (dev / nightly tags, vendored ROCm builds, etc.), and the submission timestamp is what actually tells us how stale the deployed config is.

## Test plan

- [ ] On preview, the topmost row is the oldest submission and the bottom is the most recent
- [ ] *Days Since Update* renders as `Nd`, with rows ≥7 days old shown in red/bold
- [ ] Hovering the cell shows `Last submission: YYYY-MM-DD`
- [ ] Filtering by GPU SKU still works and the sort holds within the filtered subset
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)