### PR TITLE
fix(inference): lock y-axis during scatter & GPU-graph pan/zoom / 散点图与 GPU 图表平移缩放时锁定 Y 轴

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -652,17 +652,24 @@ const GPUGraph = React.memo(
         ]}
         zoom={{
           enabled: true,
-          axes: 'both',
+          // X-only: GPU time-series is a date-axis exploration. Vertical pan
+          // caused the y-axis to drift on drag, making tick labels look wrong
+          // relative to the visible data.
+          axes: 'x',
           scaleExtent: [1, 20],
           resetEventName: `gpu_timeseries_zoom_reset_${chartId}`,
           onReset: () => {
             track('interactivity_zoom_reset');
           },
           onZoom: (_event, ctx: ZoomContext) => {
+            // y-axis is locked with axes: 'x' (newYScale === yScale), but the
+            // framework re-renders axes on every zoom with the configured
+            // tickFormat. For log scale the tickFormat is `undefined` in this
+            // component, so re-apply `logTickFormat` here to preserve labels.
             if (logScale) {
-              const newYScale = ctx.newYScale as d3.ScaleLogarithmic<number, number>;
+              const yScale = ctx.yScale as d3.ScaleLogarithmic<number, number>;
               ctx.layout.yAxisGroup.call(
-                d3.axisLeft(newYScale).ticks(10).tickFormat(logTickFormat(newYScale)) as any,
+                d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)) as any,
               );
             }
           },

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -592,7 +592,11 @@ const ScatterGraph = React.memo(
     const zoomConfig = useMemo(
       () => ({
         enabled: true,
-        axes: 'both' as const,
+        // X-only: the scatter chart is fundamentally an X-axis exploration
+        // (Interactivity / TTFT). Allowing vertical pan caused the y-axis tick
+        // labels to drift on drag ("sliding around"), making them look wrong
+        // relative to the visible data. Matches the TrendChart zoom behavior.
+        axes: 'x' as const,
         scaleExtent: [0.7, 20] as [number, number],
         resetEventName: zoomResetEventName,
         onReset: () => {
@@ -600,17 +604,13 @@ const ScatterGraph = React.memo(
         },
         constrain: (transform: d3.ZoomTransform, extent: [[number, number], [number, number]]) => {
           const width = extent[1][0];
-          const height = extent[1][1];
           let tx = transform.x;
-          let ty = transform.y;
           const k = transform.k;
           const maxTx = 0;
           const minTx = Math.min(0, width - width * k);
-          const minTy = height * (1 - k);
-          const maxTy = Math.max(minTy, 0);
           tx = Math.max(minTx, Math.min(maxTx, tx));
-          ty = Math.max(minTy, Math.min(maxTy, ty));
-          return d3.zoomIdentity.translate(tx, ty).scale(k);
+          // Lock y-translation to 0 — y-axis stays fixed during pan/zoom.
+          return d3.zoomIdentity.translate(tx, 0).scale(k);
         },
         onZoom: (_event: d3.D3ZoomEvent<SVGSVGElement, unknown>, ctx: ZoomContext) => {
           if (xScaleConfig._isLog) {
@@ -619,10 +619,14 @@ const ScatterGraph = React.memo(
               d3.axisBottom(newXS).ticks(10).tickFormat(logTickFormat(newXS)) as any,
             );
           }
+          // With axes: 'x' the y-scale doesn't change, but the framework still
+          // re-renders the y-axis on each zoom with the configured tickFormat.
+          // For log scale, tickFormat is `undefined` (see yAxisConfig above),
+          // so re-apply `logTickFormat` here to preserve the labels.
           if (yScaleConfig.type === 'log') {
-            const newYS = ctx.newYScale as d3.ScaleLogarithmic<number, number>;
+            const yScale = ctx.yScale as d3.ScaleLogarithmic<number, number>;
             ctx.layout.yAxisGroup.call(
-              d3.axisLeft(newYS).ticks(10).tickFormat(logTickFormat(newYS)) as any,
+              d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)) as any,
             );
           }
         },


### PR DESCRIPTION
## Fixes

Reported by @JordanNanos 

> y axis is wrong on some interactivities when sliding around

## Diagnosis

The Inference scatter chart (`Token Throughput per GPU vs. Interactivity / TTFT`) and the GPU time-series chart on the same page were configured with `axes: 'both'` for d3-zoom. When a user dragged to pan horizontally along the x-axis to explore different Interactivity ranges, the d3 zoom transform was applied to both axes — the y-axis ticks drifted as a side effect of the y-translation component of the drag, even when the intended interaction was purely horizontal sliding.

Repro on the live site (https://inferencex.semianalysis.com/inference):
1. Shift+Scroll on the scatter chart to zoom in.
2. Drag horizontally to slide along the x-axis.
3. Y-axis tick labels drift to numbers that don't match the data scale.

The Historical Trends `TrendChart` on the same page already uses `axes: 'x'` and is unaffected — that's the pattern we adopt here.

## Fix

Switch both `ScatterGraph` and `GPUGraph` to `axes: 'x'`. Y-scale stays fixed during pan/zoom; only the x-axis rescales.

The framework (`useD3ChartRenderer`) still re-renders the y-axis on each zoom with the configured `tickFormat`, so the log-scale tick-format override stays in both `onZoom` callbacks (the linear case is handled automatically by `yAxisConfig.tickFormat = formatLargeNumber`).

Also simplified `ScatterGraph`'s `constrain` to drop the now-unused y-translation clamping and pin `ty` to 0.

## Files changed
- `packages/app/src/components/inference/ui/ScatterGraph.tsx`
- `packages/app/src/components/inference/ui/GPUGraph.tsx`

## Overlay support
Both code paths are zoom-config-only — they apply uniformly to official runs and `?unofficialrun=` overlays. No data-path branching changed.

## Testing
- Manual verification on https://inferencex.semianalysis.com/inference after deploy: zoom in via Shift+Scroll, drag horizontally, confirm y-axis ticks stay fixed at the original data extent.
- Existing Cypress component tests (`scatter-graph.cy.tsx`, `gpu-graph.cy.tsx`) continue to mount and render without changes — zoom behavior is asserted at the integration level via the live preview.

## 中文说明
修复推理页面散点图和 GPU 时序图在水平平移时 Y 轴刻度漂移的问题。根因：d3-zoom 配置为 `axes: 'both'`，水平拖拽时 Y 轴平移分量被错误应用。修复方法：将 `ScatterGraph` 和 `GPUGraph` 的缩放轴改为 `axes: 'x'`，Y 轴在平移/缩放时保持固定。同时简化了 `ScatterGraph` 的 `constrain` 逻辑，将 `ty` 固定为 0。
