### PR TITLE
feat(current-inferencex-image): gradient-red Days-Since cell from 1d → 60d

### DIFF
--- a/packages/app/src/components/latest-image/latest-image-content.tsx
+++ b/packages/app/src/components/latest-image/latest-image-content.tsx
@@ -99,6 +99,25 @@ function daysSince(dateStr: string, today: Date): number {
   return Math.max(0, Math.floor(ms / 86_400_000));
 }
 
+/** Age past which the cell is rendered at max red — anything older looks identical. */
+const AGE_MAX_RED_DAYS = 60;
+
+/**
+ * Returns inline style for the Days-Since-Update cell so older rows scream
+ * louder visually. Ramps from a subtle red at 1 day to deep red at 60 days
+ * (then clamps); 0-day rows return `undefined` so the cell falls back to the
+ * muted-foreground class.
+ */
+function ageColorStyle(days: number): React.CSSProperties | undefined {
+  if (days < 1) return undefined;
+  const t = Math.min(AGE_MAX_RED_DAYS, days) / AGE_MAX_RED_DAYS; // 0.017 … 1
+  // Perceptually-uniform OKLCH ramp at hue 25 (red): lightness drops as
+  // chroma rises, so the cell goes from light pink to saturated dark red.
+  const L = 0.78 - 0.28 * t;
+  const C = 0.12 + 0.12 * t;
+  return { color: `oklch(${L.toFixed(3)} ${C.toFixed(3)} 25)` };
+}
+
 /** Check if the image tag is outdated or uses an unstable/dev image. */
 function isOutdated(image: string, actualLatest: string | null): boolean {
   const lower = image.toLowerCase();
@@ -402,7 +421,7 @@ export function CurrentImageContent() {
                 const actualLatest = getActualLatestTag(row.framework, releases);
                 const outdated = isOutdated(row.image, actualLatest);
                 const ageDays = daysSince(row.date, today);
-                const ageStale = ageDays >= 7;
+                const ageStyle = ageColorStyle(ageDays);
 
                 return (
                   <tr
@@ -441,9 +460,10 @@ export function CurrentImageContent() {
                     </td>
                     <td
                       className={`px-4 py-3 text-sm tabular-nums whitespace-nowrap ${
-                        ageStale ? 'text-red-400 font-medium' : 'text-muted-foreground'
+                        ageStyle ? 'font-medium' : 'text-muted-foreground'
                       }`}
-                      title={`Last submission: ${row.date}`}
+                      style={ageStyle}
+                      title={`Last submission: ${row.date}${ageDays >= AGE_MAX_RED_DAYS ? ` (≥${AGE_MAX_RED_DAYS}d clamps to max red)` : ''}`}
                     >
                       {ageDays}d
                     </td>


### PR DESCRIPTION
## Summary

The Days-Since-Update cell used a binary \`>=7d ? text-red-400 : muted\` rule, which loses signal once any row tips over the threshold — a 7-day-old row and a 90-day-old row looked identical.

Replace with a smooth **OKLCH lightness + chroma ramp** that escalates urgency as configs age:

| Age | Visual |
|-----|--------|
| 0d | muted (no red) |
| 1d | subtle pink tint |
| 30d | medium red |
| 60d | saturated deep red |
| 60+ d | clamps to same max red — past that point, exact age stops mattering |

Inline \`oklch()\` so the interpolation is perceptually uniform across both lightness and chroma. Tailwind's discrete red-100…red-900 ramp would band noticeably across 60 steps; OKLCH gradients cleanly.

Tooltip on cells ≥60 days now notes the clamp so it's discoverable.

## Test plan

- [ ] On preview, scroll the table (sorted oldest-first) — the top rows should be deep red, progressively lightening as you scan down
- [ ] A fresh (0-day) row uses the muted-foreground color (no red)
- [ ] Two rows both ≥60 days old render the exact same red shade
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm fmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)