### PR TITLE
feat(current-inferencex-image): tint whole row by age, not just the Days cell

### DIFF
--- a/packages/app/src/components/latest-image/latest-image-content.tsx
+++ b/packages/app/src/components/latest-image/latest-image-content.tsx
@@ -118,6 +118,21 @@ function ageColorStyle(days: number): React.CSSProperties | undefined {
   return { color: `oklch(${L.toFixed(3)} ${C.toFixed(3)} 25)` };
 }
 
+/**
+ * Companion to `ageColorStyle` for the whole row's background tint — same
+ * 1d → 60d ramp but expressed as a low-alpha fill so the row content stays
+ * readable. 0-day rows return `undefined` so the row falls back to its
+ * hover-only class background.
+ */
+function ageRowStyle(days: number): React.CSSProperties | undefined {
+  if (days < 1) return undefined;
+  const t = Math.min(AGE_MAX_RED_DAYS, days) / AGE_MAX_RED_DAYS;
+  // Alpha tops out around 0.28 — enough that 60d+ rows are unmistakably
+  // tinted without drowning out the text or competing with hover affordance.
+  const alpha = (0.04 + 0.24 * t).toFixed(3);
+  return { backgroundColor: `oklch(0.60 0.22 25 / ${alpha})` };
+}
+
 /** Check if the image tag is outdated or uses an unstable/dev image. */
 function isOutdated(image: string, actualLatest: string | null): boolean {
   const lower = image.toLowerCase();
@@ -422,13 +437,15 @@ export function CurrentImageContent() {
                 const outdated = isOutdated(row.image, actualLatest);
                 const ageDays = daysSince(row.date, today);
                 const ageStyle = ageColorStyle(ageDays);
+                const rowStyle = ageRowStyle(ageDays);
 
                 return (
                   <tr
                     key={`${row.model}-${row.hardware}-${row.isl}-${row.osl}-${row.spec_method}-${i}`}
                     className={`border-b border-border last:border-b-0 transition-colors ${
-                      outdated ? 'bg-red-500/10 hover:bg-red-500/15' : 'hover:bg-muted/30'
+                      rowStyle ? 'hover:brightness-110' : 'hover:bg-muted/30'
                     }`}
+                    style={rowStyle}
                   >
                     <td className="px-4 py-3 text-sm font-medium">{displayModel}</td>
                     <td className="px-4 py-3 text-sm uppercase">{row.precision}</td>


### PR DESCRIPTION
## Summary

Extend the OKLCH age ramp from the Days-Since-Update cell to the **entire row background** so a stale config reads as urgent at a glance from any column. Alpha climbs from \`0.04\` at 1 day to \`0.28\` at 60+ days — visible across the full row but light enough that code-tag chips and dark text stay readable.

| Age | Row tint |
|-----|----------|
| 0d | none (hover-only \`bg-muted/30\`) |
| 1d | barely-there pink |
| 30d | clearly tinted |
| 60d | unmistakable red |
| 60+ d | clamps to same max |

- Drops the old binary \`outdated ? bg-red-500/10\` row class since the gradient now subsumes it.
- Image-tag chip still gets its own \`bg-red-500/20\` fill when \`outdated\` is true so the tag-mismatch signal is preserved independent of age.
- Hover on aged rows swaps to \`brightness-110\` (instead of \`bg-muted/30\`) so the inline background isn't clobbered on hover.

## Test plan

- [ ] Preview, oldest-first sort: top rows are visibly red across the whole width, fading row-by-row as you scroll
- [ ] 0-day rows show no tint until hover
- [ ] Hover on a tinted row brightens it slightly instead of wiping the color
- [ ] Code chips (image tag / actual-latest tag) remain readable on the darkest rows
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm fmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)