### PR TITLE
fix(current-inferencex-image): only tint by age when the row is outdated

### DIFF
--- a/packages/app/src/components/latest-image/latest-image-content.tsx
+++ b/packages/app/src/components/latest-image/latest-image-content.tsx
@@ -436,8 +436,11 @@ export function CurrentImageContent() {
                 const actualLatest = getActualLatestTag(row.framework, releases);
                 const outdated = isOutdated(row.image, actualLatest);
                 const ageDays = daysSince(row.date, today);
-                const ageStyle = ageColorStyle(ageDays);
-                const rowStyle = ageRowStyle(ageDays);
+                // Only tint by age when the row is actually outdated (image lags
+                // upstream latest, or uses an unstable tag). Up-to-date configs
+                // shouldn't look alarming just because a day passed.
+                const ageStyle = outdated ? ageColorStyle(ageDays) : undefined;
+                const rowStyle = outdated ? ageRowStyle(ageDays) : undefined;
 
                 return (
                   <tr


### PR DESCRIPTION
## Summary

Spotted by the user: a row like \`gpt-oss-120b · fp4 · H100 · Off · vllm/vllm-openai:v0.21.0 · v0.21.0 · 1d\` was rendering with a pink tint just because the last benchmark submission was a day old — but the deployed image **is** the upstream latest, so flagging it is misleading.

Gate \`ageColorStyle\` and \`ageRowStyle\` behind the existing \`isOutdated()\` check so the age gradient only applies when the image either (a) lags the upstream latest tag we resolve from GitHub, or (b) uses a known unstable pattern (\`nightly\`, \`rocm/sgl-dev\`, \`sglang-rocm\`). Up-to-date rows revert to the default un-tinted styling, regardless of how recent the submission is.

## Test plan

- [ ] Preview, oldest-first sort: only rows whose image differs from the *Actual Latest Tag* column get tinted; matching rows are neutral
- [ ] \`nightly\` / \`rocm/sgl-dev\` rows are still flagged regardless of age
- [ ] A 1-day-old row with the latest tag no longer shows pink
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm fmt\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)