### PR TITLE
fix(submissions): force hard nav on compare-runs link

### DIFF
--- a/packages/app/src/components/submissions/SubmissionsTable.tsx
+++ b/packages/app/src/components/submissions/SubmissionsTable.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { ChevronDown, ChevronRight, GitCompare, Info } from 'lucide-react';
-import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { track } from '@/lib/analytics';
@@ -296,7 +295,7 @@ function SubmissionRow({
                     className="h-7 px-2 gap-1"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <Link
+                    <a
                       href={compareUrl}
                       data-testid="submissions-compare-runs-link-inline"
                       onClick={() => {
@@ -314,7 +313,7 @@ function SubmissionRow({
                     >
                       <GitCompare className="size-3.5" />
                       <span className="hidden lg:inline">vs prev</span>
-                    </Link>
+                    </a>
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="left" collisionPadding={10}>
@@ -426,7 +425,7 @@ function SubmissionRow({
                 {compareUrl && previousRun && (
                   <div className="col-span-2 md:col-span-4 flex justify-end">
                     <Button asChild variant="outline" size="sm">
-                      <Link
+                      <a
                         href={compareUrl}
                         data-testid="submissions-compare-runs-link"
                         onClick={() => {
@@ -444,7 +443,7 @@ function SubmissionRow({
                       >
                         <GitCompare className="size-3.5" />
                         Compare {previousRun.date} → {row.date} on chart
-                      </Link>
+                      </a>
                     </Button>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

User reported: shift-clicking *vs prev* opens \`/inference\` with the comparison correctly applied; normal same-tab click lands on the same URL but the chart still shows the prior page's state.

**Cause:** \`next/link\` does client-side navigation, which keeps the dashboard layout's \`GlobalFilterProvider\` mounted across \`/submissions\` → \`/inference\`. Its \`useState\` initializers for \`g_model\` and \`g_rundate\` only fire on mount, so the URL params on the destination were never re-read — the chart inherited whatever model / run date the user had selected on \`/submissions\`. Shift-click worked because the browser opens a fresh tab where every provider mounts from scratch and reads the URL.

**Fix:** swap both compare buttons (inline + expanded-row) from \`<Link>\` to plain \`<a>\` so normal click also triggers a hard navigation, guaranteeing every provider re-initializes from the deep-link URL.

## Test plan

- [ ] On preview: same-tab click on *vs prev* lands on \`/inference\` with the chart correctly filtered to the compare-pair (model + GPU + dstart/dend match the link)
- [ ] Shift-click still works (browser opens new tab as before)
- [ ] Click on the expanded-row *Compare {prev} → {new} on chart* button has the same behavior
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm fmt\` / submissions unit tests clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)