### PR TITLE
fix(json-provider): resolve DUMP_DIR when Turbopack strips import.met…

### DIFF
--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -9,7 +9,8 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { BenchmarkRow } from './queries/benchmarks.js';
 import type { EvalRow } from './queries/evaluations.js';
@@ -168,7 +169,11 @@ function getStore(): Store {
 
   // Resolve relative paths from the monorepo root (packages/db/../../), not CWD,
   // since Next.js runs from packages/app/ but .env paths are repo-root-relative.
-  const pkgRoot = resolve(import.meta.dirname, '..');
+  // import.meta.dirname is undefined under Turbopack bundling — derive from
+  // import.meta.url instead, which Turbopack rewrites to a usable file URL.
+  // oxlint-disable-next-line unicorn/prefer-import-meta-properties -- import.meta.dirname is undefined under Turbopack; this is the fallback.
+  const thisDir = import.meta.dirname ?? dirname(fileURLToPath(import.meta.url));
+  const pkgRoot = resolve(thisDir, '..');
   const monoRoot = resolve(pkgRoot, '../..');
   const resolvedDir = existsSync(resolve(dir)) ? resolve(dir) : resolve(monoRoot, dir);
 


### PR DESCRIPTION
fix(json-provider): resolve DUMP_DIR when Turbopack strips import.meta.dirname

Bundler removing variable that defines where dump folder lives

`import.meta.dirname` is undefined in workspace-package code that Next.js 16 + Turbopack bundles into server chunks, so the `resolve(import.meta.dirname, '..')` in getStore() threw ERR_INVALID_ARG_TYPE on every API route that touched the JSON dump path (Option A in the README). Pages rendered but every /api/v1/* call 500'd.

`import.meta.url` is preserved correctly by Turbopack and still points at the original source file, so fall back to `dirname(fileURLToPath(import.meta.url))` when `import.meta.dirname` is unavailable. Behavior is identical for tsx, plain Node ESM, and vitest, where `import.meta.dirname` is defined and the ?? short- circuits.

No production impact: Vercel uses DATABASE_READONLY_URL, never DUMP_DIR, so getStore() is unreachable in prod.