### PR TITLE
feat(compare): extend SSR /compare to all models with backward-compatible redirects

### DIFF
--- a/packages/app/cypress/e2e/compare-redirect.cy.ts
+++ b/packages/app/cypress/e2e/compare-redirect.cy.ts
@@ -5,14 +5,53 @@ describe('Compare canonical slug redirect', () => {
     });
   });
 
-  it('redirects a non-canonical (reversed) slug to the alphabetical canonical form', () => {
-    // 'h100-vs-gb200' is non-canonical; canonical orders alphabetically → 'gb200-vs-h100'
-    cy.visit('/compare/h100-vs-gb200');
-    cy.location('pathname').should('eq', '/compare/gb200-vs-h100');
+  it('serves a fully canonical slug without redirecting', () => {
+    cy.visit('/compare/deepseek-r1-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/deepseek-r1-gb200-vs-h100');
   });
 
-  it('serves a canonical slug without redirecting', () => {
+  it('redirects a non-canonical (reversed) GPU order to alphabetical canonical', () => {
+    // canonical alphabetical orders the GPUs → 'gb200-vs-h100', not 'h100-vs-gb200'
+    cy.visit('/compare/deepseek-r1-h100-vs-gb200');
+    cy.location('pathname').should('eq', '/compare/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a bare GPU pair (no model prefix) to the deepseek-r1 default', () => {
+    // PR #351 backward-compat: pre-existing inbound links of the form
+    // `/compare/{a}-vs-{b}` get a one-hop 308 to the deepseek-r1-prefixed URL.
     cy.visit('/compare/gb200-vs-h100');
-    cy.location('pathname').should('eq', '/compare/gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a bare reversed GPU pair through both normalizations in one hop', () => {
+    cy.visit('/compare/h100-vs-gb200');
+    cy.location('pathname').should('eq', '/compare/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a family-level alias model slug to the canonical version slug', () => {
+    cy.visit('/compare/kimi-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/kimi-k26-gb200-vs-h100');
+  });
+
+  it('redirects an older-version alias slug to the latest-version canonical slug', () => {
+    // kimi-k25 redirects to kimi-k26 (same family, newer point release)
+    cy.visit('/compare/kimi-k25-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/kimi-k26-gb200-vs-h100');
+  });
+
+  it('redirects glm-5 alias to glm-5-1 (same architecture)', () => {
+    cy.visit('/compare/glm-5-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/glm-5-1-gb200-vs-h100');
+  });
+
+  it('preserves query params across the bare-slug redirect', () => {
+    cy.visit('/compare/h100-vs-h200?i_seq=1k/1k');
+    cy.location('pathname').should('eq', '/compare/deepseek-r1-h100-vs-h200');
+    cy.location('search').should('contain', 'i_seq=1k%2F1k');
+  });
+
+  it('serves a non-deepseek canonical slug without redirecting', () => {
+    cy.visit('/compare/kimi-k26-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare/kimi-k26-gb200-vs-h100');
   });
 });

--- a/packages/app/cypress/e2e/compare-table.cy.ts
+++ b/packages/app/cypress/e2e/compare-table.cy.ts
@@ -3,7 +3,10 @@ describe('Compare Interpolated Table', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/compare/gb200-vs-h100');
+    // Visit the canonical model-prefixed URL directly to avoid the bare-slug
+    // 308 redirect changing the URL after page load (which would invalidate
+    // the URL-based assertions further down).
+    cy.visit('/compare/deepseek-r1-gb200-vs-h100');
     cy.get('[data-testid="compare-interpolated-table"]').should('exist');
   });
 

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -157,13 +157,15 @@ describe('URL Parameter Persistence', () => {
     });
 
     it('/compare/[slug] with ?i_seq=1k/1k seeds the sequence without a hydration error', () => {
-      visitWithErrorSpy('/compare/h100-vs-h200?i_seq=1k/1k');
+      // Visit the canonical model-prefixed slug so the assertion is directly
+      // about the rendered page, not about a bare-slug redirect interleaving.
+      visitWithErrorSpy('/compare/deepseek-r1-h100-vs-h200?i_seq=1k/1k');
       cy.get('[data-testid="sequence-selector"]').should('contain.text', '1K / 1K');
       assertNoHydrationMismatch();
     });
 
     it('/compare/[slug] with invalid ?i_seq=junk falls back to the seeded default', () => {
-      visitWithErrorSpy('/compare/h100-vs-h200?i_seq=junk');
+      visitWithErrorSpy('/compare/deepseek-r1-h100-vs-h200?i_seq=junk');
       cy.get('[data-testid="sequence-selector"]')
         .invoke('text')
         .should('not.contain', 'junk')

--- a/packages/app/src/app/compare/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare/[slug]/opengraph-image.tsx
@@ -8,7 +8,7 @@ import { notFound } from 'next/navigation';
 import { ImageResponse } from 'next/og';
 
 import {
-  allCanonicalComparePairs,
+  allCanonicalCompareSlugs,
   canonicalCompareSlug,
   compareDisplayLabel,
   parseCompareSlug,
@@ -39,7 +39,9 @@ const TILE_GRID: ({ file: string; rotate?: number } | null)[] = [
 ];
 
 export function generateStaticParams() {
-  return allCanonicalComparePairs().map(({ a, b }) => ({ slug: canonicalCompareSlug(a, b) }));
+  return allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
+    slug: canonicalCompareSlug(modelSlug, a, b),
+  }));
 }
 
 // Read once at module load; a missing asset must not 500 every OG route.
@@ -78,11 +80,12 @@ function getTiles(): Promise<({ src: string; rotate?: number } | null)[]> {
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
-  const pair = parseCompareSlug(slug);
-  if (!pair) notFound();
+  const parsed = parseCompareSlug(slug);
+  if (!parsed) notFound();
   const [logoSrc, tiles] = await Promise.all([getLogoSrc(), getTiles()]);
 
-  const title = compareDisplayLabel(pair.a, pair.b);
+  const title = compareDisplayLabel(parsed.a, parsed.b);
+  const eyebrow = `${parsed.model.label} · Head-to-head GPU benchmark`;
   // Content area is ~895px wide (1200 - 195 panel - 55*2 padding). Scale the
   // title size down for longer labels so it fits without truncating.
   const titleSize = title.length > 26 ? 80 : title.length > 18 ? 96 : 112;
@@ -163,14 +166,14 @@ export default async function OgImage({ params }: { params: Promise<{ slug: stri
         >
           <div
             style={{
-              fontSize: 26,
+              fontSize: 24,
               color: '#9BA0A6',
               letterSpacing: '0.18em',
               textTransform: 'uppercase',
               display: 'flex',
             }}
           >
-            Head-to-head GPU benchmark
+            {eyebrow}
           </div>
 
           <div

--- a/packages/app/src/app/compare/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare/[slug]/opengraph-image.tsx
@@ -7,12 +7,8 @@ import { join } from 'node:path';
 import { notFound } from 'next/navigation';
 import { ImageResponse } from 'next/og';
 
-import {
-  allCanonicalCompareSlugs,
-  canonicalCompareSlug,
-  compareDisplayLabel,
-  parseCompareSlug,
-} from '@/lib/compare-slug';
+import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
+import { canonicalCompareSlug, compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
 
 export const alt = 'GPU inference benchmark comparison';
 export const size = { width: 1200, height: 630 };
@@ -38,10 +34,12 @@ const TILE_GRID: ({ file: string; rotate?: number } | null)[] = [
   { file: 'teal-organic.png', rotate: 180 },
 ];
 
-export function generateStaticParams() {
-  return allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
-    slug: canonicalCompareSlug(modelSlug, a, b),
-  }));
+export async function generateStaticParams() {
+  // Mirror the SSR page's static params — only emit (model, pair) combos
+  // with benchmark data on both sides so we don't generate OG images for
+  // empty pages.
+  const slugs = await getAllComparableCompareSlugs();
+  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
 }
 
 // Read once at module load; a missing asset must not 500 every OG route.

--- a/packages/app/src/app/compare/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare/[slug]/page-client.tsx
@@ -23,6 +23,10 @@ interface ComparePageClientProps {
   a: string;
   b: string;
   label: string;
+  /** Human-readable model name from the slug — drives the eyebrow above the
+   *  H1 so the URL-grouping ("Kimi K2.6", "GLM 5.1", etc.) is legible without
+   *  scanning the URL bar. */
+  modelLabel: string;
   defaultModel: string;
   defaultSequence: string | null;
   defaultPrecision: string | null;
@@ -53,6 +57,7 @@ export default function ComparePageClient({
   a,
   b,
   label,
+  modelLabel,
   defaultModel,
   defaultSequence,
   defaultPrecision,
@@ -88,14 +93,15 @@ export default function ComparePageClient({
           <Card className="flex flex-col gap-3">
             <header>
               <div className="text-xs uppercase tracking-wider text-muted-foreground">
-                GPU comparison
+                {modelLabel} · GPU comparison
               </div>
               <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mt-1">{label}</h1>
               <p className="mt-2 text-sm text-muted-foreground max-w-3xl">
                 Head-to-head AI inference benchmark comparison of <strong>{aLabel}</strong> (
-                {aVendor} {aArch}) and <strong>{bLabel}</strong> ({bVendor} {bArch}). Latency,
-                throughput, and cost across LLM workloads. Use the chart controls below to switch
-                models, sequences, precisions, and metrics — same interactions as{' '}
+                {aVendor} {aArch}) and <strong>{bLabel}</strong> ({bVendor} {bArch}) on{' '}
+                <strong>{modelLabel}</strong>. Latency, throughput, and cost across LLM workloads.
+                Use the chart controls below to switch sequences, precisions, and metrics — same
+                interactions as{' '}
                 <Link href="/" className="underline hover:text-primary">
                   the main inference chart
                 </Link>

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 
 import {
   HW_REGISTRY,
@@ -440,7 +440,11 @@ export default async function ComparePage({ params, searchParams }: Props) {
       })
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
       .join('&');
-    redirect(`/compare/${canonical}${qs ? `?${qs}` : ''}`);
+    // 308 (not 307): bare-slug, alias model, and non-canonical GPU order are
+    // all permanent decisions — using a permanent redirect lets search engines
+    // consolidate link equity onto the canonical URL instead of keeping the
+    // alias URL in the index alongside the canonical one.
+    permanentRedirect(`/compare/${canonical}${qs ? `?${qs}` : ''}`);
   }
 
   const rows = await getCachedBenchmarks(parsed.model.dbKeys);

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -22,9 +22,11 @@ import { loadFixture } from '@/lib/test-fixtures';
 import { getHardwareKey } from '@/lib/chart-utils';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
 import {
-  allCanonicalComparePairs,
+  allCanonicalCompareSlugs,
   canonicalCompareSlug,
   compareDisplayLabel,
+  compareModelDisplayLabel,
+  type CompareModelSlug,
   parseCompareSlug,
 } from '@/lib/compare-slug';
 import { getHardwareConfig, getGpuSpecs } from '@/lib/constants';
@@ -38,9 +40,6 @@ interface Props {
   params: Promise<{ slug: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
-
-const DEFAULT_MODEL_DB_KEYS = ['dsr1'];
-const DEFAULT_MODEL_DISPLAY = 'DeepSeek-R1-0528';
 
 const KNOWN_MODELS = new Set([
   'Llama-3.3-70B-Instruct-FP8',
@@ -73,29 +72,32 @@ const getCachedBenchmarks = cachedQuery(
 );
 
 export function generateStaticParams() {
-  return allCanonicalComparePairs().map(({ a, b }) => ({ slug: canonicalCompareSlug(a, b) }));
+  return allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
+    slug: canonicalCompareSlug(modelSlug, a, b),
+  }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
-  const pair = parseCompareSlug(slug);
-  if (!pair) return {};
-  const label = compareDisplayLabel(pair.a, pair.b);
-  const url = `${SITE_URL}/compare/${canonicalCompareSlug(pair.a, pair.b)}`;
-  const description = `Head-to-head GPU inference benchmark comparison: ${label}. Latency, throughput, and cost across LLM workloads.`;
+  const parsed = parseCompareSlug(slug);
+  if (!parsed) return {};
+  const fullLabel = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
+  const gpuLabel = compareDisplayLabel(parsed.a, parsed.b);
+  const url = `${SITE_URL}/compare/${canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b)}`;
+  const description = `Head-to-head GPU inference benchmark comparison for ${parsed.model.label}: ${gpuLabel}. Latency, throughput, and cost across LLM workloads.`;
   return {
-    title: `${label} Inference Benchmark`,
+    title: `${fullLabel} Inference Benchmark`,
     description,
     alternates: { canonical: url },
     openGraph: {
-      title: `${label} | ${SITE_NAME}`,
+      title: `${fullLabel} | ${SITE_NAME}`,
       description,
       url,
       type: 'website',
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${label} Inference Benchmark`,
+      title: `${fullLabel} Inference Benchmark`,
       description,
     },
   };
@@ -109,7 +111,7 @@ interface PairSummary {
   bestMedianTpot: number | null;
 }
 
-function summarize(rows: Awaited<ReturnType<typeof getCachedBenchmarks>>, hw: string): PairSummary {
+function summarize(rows: BenchmarkRow[], hw: string): PairSummary {
   const hwRows = rows.filter((r) => r.hardware === hw);
   let bestThroughput: number | null = null;
   let bestTtft: number | null = null;
@@ -147,7 +149,7 @@ export interface SsrInterpolatedRow {
  * same transform logic as useThroughputData (but callable on the server).
  */
 function buildGpuDataPoints(
-  rows: Awaited<ReturnType<typeof getCachedBenchmarks>>,
+  rows: BenchmarkRow[],
   hw: string,
   isl: number,
   osl: number,
@@ -216,7 +218,7 @@ function interactivityRangeOf(pts: GPUDataPoint[]): { min: number; max: number }
  * interactivity range of both GPUs.
  */
 function computeCompareTableData(
-  rows: Awaited<ReturnType<typeof getCachedBenchmarks>>,
+  rows: BenchmarkRow[],
   a: string,
   b: string,
   sequence: string | null,
@@ -335,6 +337,7 @@ function jsonLdEntryFor(key: string, summary: PairSummary, position: number) {
 }
 
 function buildJsonLd(
+  model: CompareModelSlug,
   a: string,
   b: string,
   url: string,
@@ -344,11 +347,13 @@ function buildJsonLd(
 ) {
   const aLabel = HW_REGISTRY[a]?.label ?? a.toUpperCase();
   const bLabel = HW_REGISTRY[b]?.label ?? b.toUpperCase();
+  const fullLabel = compareModelDisplayLabel(model, a, b);
 
   const comparisonRows = ssrRows
     .filter((row) => row.a || row.b)
     .map((row) => {
       const metrics: { name: string; value: string }[] = [
+        { name: 'Model', value: model.displayName },
         { name: 'Target Interactivity (tok/s/user)', value: String(row.target) },
       ];
       if (row.a) {
@@ -369,7 +374,7 @@ function buildJsonLd(
       }
       return {
         '@type': 'Observation',
-        name: `Comparison at ${row.target} tok/s/user interactivity`,
+        name: `${model.label} comparison at ${row.target} tok/s/user interactivity`,
         variableMeasured: metrics.map((m) => ({
           '@type': 'PropertyValue',
           name: m.name,
@@ -383,8 +388,8 @@ function buildJsonLd(
     '@graph': [
       {
         '@type': 'ItemList',
-        name: `${compareDisplayLabel(a, b)} Inference Benchmark`,
-        description: `Head-to-head AI inference benchmark comparison of ${aLabel} and ${bLabel} across LLM workloads.`,
+        name: `${fullLabel} Inference Benchmark`,
+        description: `Head-to-head AI inference benchmark comparison of ${aLabel} and ${bLabel} on ${model.label} across LLM workloads.`,
         url,
         itemListOrder: 'https://schema.org/ItemListOrderAscending',
         numberOfItems: 2,
@@ -394,8 +399,8 @@ function buildJsonLd(
         ? [
             {
               '@type': 'Dataset',
-              name: `${aLabel} vs ${bLabel} Interpolated Benchmark Comparison`,
-              description: `Interpolated throughput, cost, power efficiency, and concurrency for ${aLabel} and ${bLabel} at matched interactivity levels.`,
+              name: `${aLabel} vs ${bLabel} (${model.label}) Interpolated Benchmark Comparison`,
+              description: `Interpolated throughput, cost, power efficiency, and concurrency for ${aLabel} and ${bLabel} on ${model.label} at matched interactivity levels.`,
               url,
               hasPart: comparisonRows,
             },
@@ -407,60 +412,86 @@ function buildJsonLd(
 
 export default async function ComparePage({ params, searchParams }: Props) {
   const { slug } = await params;
-  const pair = parseCompareSlug(slug);
-  if (!pair) notFound();
+  const parsed = parseCompareSlug(slug);
+  if (!parsed) notFound();
 
-  const canonical = canonicalCompareSlug(pair.a, pair.b);
+  // Await searchParams once so we can both preserve them on redirect and read
+  // them for URL-param overrides further down.
+  const sp = await searchParams;
+
+  // One-hop redirect to the fully canonical URL. Handles all three normalization
+  // cases in a single 308:
+  //   - legacy bare slug:   `h100-vs-h200`              → `deepseek-r1-h100-vs-h200`
+  //   - alias model:        `kimi-h100-vs-h200`         → `kimi-k26-h100-vs-h200`
+  //   - non-canonical GPUs: `kimi-k26-h200-vs-h100`     → `kimi-k26-h100-vs-h200`
+  //   - any combination of the above
+  // Preserves the query string so `?i_seq=1k/1k&i_prec=fp8` etc. survive the
+  // redirect — the original PR #351 redirect dropped these, but with bare slugs
+  // now redirecting unconditionally we need to keep them.
+  const canonical = canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b);
   if (canonical !== slug) {
-    redirect(`/compare/${canonical}`);
+    const qs = Object.entries(sp)
+      .flatMap(([k, v]) => {
+        if (Array.isArray(v)) return v.map((vv) => [k, vv] as const);
+        if (v === undefined) return [];
+        return [[k, v] as const];
+      })
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    redirect(`/compare/${canonical}${qs ? `?${qs}` : ''}`);
   }
 
-  const rows = await getCachedBenchmarks(DEFAULT_MODEL_DB_KEYS);
-  const summaryA = summarize(rows, pair.a);
-  const summaryB = summarize(rows, pair.b);
+  const rows = await getCachedBenchmarks(parsed.model.dbKeys);
+  const summaryA = summarize(rows, parsed.a);
+  const summaryB = summarize(rows, parsed.b);
   const { sequence: pickedSequence, precision: pickedPrecision } = pickPairDefaults(
     rows,
-    pair.a,
-    pair.b,
+    parsed.a,
+    parsed.b,
   );
 
-  // URL params win over pickPairDefaults; this baking-into-SSR avoids the
+  // URL params win over slug-derived defaults; this baking-into-SSR avoids the
   // hydration flash where the client upgrades seeded defaults to URL values.
-  const sp = await searchParams;
-  const urlModel = pickString(sp.g_model);
+  // `sp` was already awaited above for the redirect-query-preservation path.
   const urlSeq = pickString(sp.i_seq);
   const urlPrec = pickString(sp.i_prec);
-  const effectiveModel = urlModel && KNOWN_MODELS.has(urlModel) ? urlModel : DEFAULT_MODEL_DISPLAY;
+  const urlModel = pickString(sp.g_model);
   const effectiveSequence = urlSeq && KNOWN_SEQUENCES.has(urlSeq) ? urlSeq : pickedSequence;
   const effectivePrecision = urlPrec && KNOWN_PRECISIONS.has(urlPrec) ? urlPrec : pickedPrecision;
+  // `?g_model=` is honored only if it matches a known model — but the slug's
+  // model is the canonical default. Disregard URL param if user wants to
+  // explicitly override (rare).
+  const effectiveModel =
+    urlModel && KNOWN_MODELS.has(urlModel) ? urlModel : parsed.model.displayName;
 
   const { defaultTargets, ssrRows, interactivityRange } = computeCompareTableData(
     rows,
-    pair.a,
-    pair.b,
+    parsed.a,
+    parsed.b,
     effectiveSequence,
     effectivePrecision,
   );
 
   const url = `${SITE_URL}/compare/${canonical}`;
-  const jsonLd = buildJsonLd(pair.a, pair.b, url, summaryA, summaryB, ssrRows);
-  const label = compareDisplayLabel(pair.a, pair.b);
-  const aMeta = HW_REGISTRY[pair.a];
-  const bMeta = HW_REGISTRY[pair.b];
+  const jsonLd = buildJsonLd(parsed.model, parsed.a, parsed.b, url, summaryA, summaryB, ssrRows);
+  const label = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
+  const aMeta = HW_REGISTRY[parsed.a];
+  const bMeta = HW_REGISTRY[parsed.b];
 
   return (
     <>
       <JsonLd data={jsonLd} />
       <ComparePageClient
-        a={pair.a}
-        b={pair.b}
+        a={parsed.a}
+        b={parsed.b}
         label={label}
+        modelLabel={parsed.model.label}
         defaultModel={effectiveModel}
         defaultSequence={effectiveSequence}
         defaultPrecision={effectivePrecision}
         ssrTableData={{ defaultTargets, ssrRows, interactivityRange }}
-        aLabel={aMeta?.label ?? pair.a.toUpperCase()}
-        bLabel={bMeta?.label ?? pair.b.toUpperCase()}
+        aLabel={aMeta?.label ?? parsed.a.toUpperCase()}
+        bLabel={bMeta?.label ?? parsed.b.toUpperCase()}
         aVendor={aMeta?.vendor ?? ''}
         bVendor={bMeta?.vendor ?? ''}
         aArch={aMeta?.arch ?? ''}

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -20,9 +20,9 @@ import { cachedQuery } from '@/lib/api-cache';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import { loadFixture } from '@/lib/test-fixtures';
 import { getHardwareKey } from '@/lib/chart-utils';
+import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
 import {
-  allCanonicalCompareSlugs,
   canonicalCompareSlug,
   compareDisplayLabel,
   compareModelDisplayLabel,
@@ -71,10 +71,12 @@ const getCachedBenchmarks = cachedQuery(
   { blobOnly: true },
 );
 
-export function generateStaticParams() {
-  return allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
-    slug: canonicalCompareSlug(modelSlug, a, b),
-  }));
+export async function generateStaticParams() {
+  // Only enumerate (model, pair) combos with benchmark data on both sides.
+  // Direct URL hits to non-enumerated combos still render via the dynamic
+  // SSR path (with the empty-state fallback).
+  const slugs = await getAllComparableCompareSlugs();
+  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -5,13 +5,16 @@ import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
 import {
-  allCanonicalComparePairs,
   canonicalCompareSlug,
   compareDisplayLabel,
+  type ComparePair,
   COMPARE_MODEL_SLUGS,
   type CompareModelSlug,
 } from '@/lib/compare-slug';
+
+export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
   'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek R1, Kimi K2.6, GLM 5.1, Qwen 3.5, and more.';
@@ -39,14 +42,15 @@ interface VendorGroup {
   pairs: { a: string; b: string; slug: string; label: string }[];
 }
 
-function groupPairsByVendorForModel(model: CompareModelSlug): VendorGroup[] {
-  const all = allCanonicalComparePairs();
-
+function groupPairsByVendorForModel(
+  model: CompareModelSlug,
+  comparablePairs: ComparePair[],
+): VendorGroup[] {
   const nvidia: VendorGroup['pairs'] = [];
   const amd: VendorGroup['pairs'] = [];
   const cross: VendorGroup['pairs'] = [];
 
-  for (const { a, b } of all) {
+  for (const { a, b } of comparablePairs) {
     const entry = {
       a,
       b,
@@ -95,9 +99,17 @@ const jsonLd = {
   url: `${SITE_URL}/compare`,
 };
 
-export default function CompareIndexPage() {
-  const pairsPerModel = allCanonicalComparePairs().length;
-  const totalUrls = COMPARE_MODEL_SLUGS.length * pairsPerModel;
+export default async function CompareIndexPage() {
+  // Server-side filter: only show (model, pair) combinations where both GPUs
+  // have benchmark data for that model. Avoids cards that would link to an
+  // empty-state page. The page-level handler at /compare/[slug] still renders
+  // the empty-state for direct URL hits, so this is purely a navigation
+  // hygiene concern.
+  const comparablePairsByModel = await getComparablePairsByModelSlug();
+  const totalUrls = [...comparablePairsByModel.values()].reduce((s, p) => s + p.length, 0);
+  const modelsWithPairs = COMPARE_MODEL_SLUGS.filter(
+    (m) => (comparablePairsByModel.get(m.slug)?.length ?? 0) > 0,
+  );
 
   return (
     <>
@@ -106,23 +118,24 @@ export default function CompareIndexPage() {
         <Card>
           <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">GPU Comparisons</h1>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
-            {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons —{' '}
-            {pairsPerModel} GPU pairs × {COMPARE_MODEL_SLUGS.length} models. Each page includes
-            interactive charts for latency, throughput, and cost metrics, plus an interpolated
-            comparison table.
+            {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons across{' '}
+            {modelsWithPairs.length} models. Each page includes interactive charts for latency,
+            throughput, and cost metrics, plus an interpolated comparison table.
           </p>
         </Card>
       </section>
 
-      {COMPARE_MODEL_SLUGS.map((model) => {
-        const groups = groupPairsByVendorForModel(model);
+      {modelsWithPairs.map((model) => {
+        const pairs = comparablePairsByModel.get(model.slug) ?? [];
+        const groups = groupPairsByVendorForModel(model, pairs);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
               <div>
                 <h2 className="text-xl lg:text-2xl font-bold tracking-tight">{model.label}</h2>
                 <p className="text-sm text-muted-foreground mt-1">
-                  Compare any GPU pair on {model.label}.
+                  {pairs.length} GPU pair{pairs.length === 1 ? '' : 's'} with benchmark data on{' '}
+                  {model.label}.
                 </p>
               </div>
               {groups.map((group) => (

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -17,7 +17,7 @@ import {
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek R1, Kimi K2.6, GLM 5.1, Qwen 3.5, and more.';
+  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek R1, Kimi K2.5/K2.6, GLM 5/5.1, Qwen 3.5, and more.';
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -9,10 +9,12 @@ import {
   allCanonicalComparePairs,
   canonicalCompareSlug,
   compareDisplayLabel,
+  COMPARE_MODEL_SLUGS,
+  type CompareModelSlug,
 } from '@/lib/compare-slug';
 
 const DESCRIPTION =
-  'Browse head-to-head GPU inference benchmark comparisons. Latency, throughput, and cost across LLM workloads for every hardware pair we test.';
+  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek R1, Kimi K2.6, GLM 5.1, Qwen 3.5, and more.';
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',
@@ -37,7 +39,7 @@ interface VendorGroup {
   pairs: { a: string; b: string; slug: string; label: string }[];
 }
 
-function groupPairsByVendor(): VendorGroup[] {
+function groupPairsByVendorForModel(model: CompareModelSlug): VendorGroup[] {
   const all = allCanonicalComparePairs();
 
   const nvidia: VendorGroup['pairs'] = [];
@@ -48,7 +50,7 @@ function groupPairsByVendor(): VendorGroup[] {
     const entry = {
       a,
       b,
-      slug: canonicalCompareSlug(a, b),
+      slug: canonicalCompareSlug(model.slug, a, b),
       label: compareDisplayLabel(a, b),
     };
     const vA = HW_REGISTRY[a]?.vendor;
@@ -94,8 +96,8 @@ const jsonLd = {
 };
 
 export default function CompareIndexPage() {
-  const groups = groupPairsByVendor();
-  const totalPairs = groups.reduce((sum, g) => sum + g.pairs.length, 0);
+  const pairsPerModel = allCanonicalComparePairs().length;
+  const totalUrls = COMPARE_MODEL_SLUGS.length * pairsPerModel;
 
   return (
     <>
@@ -104,38 +106,53 @@ export default function CompareIndexPage() {
         <Card>
           <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">GPU Comparisons</h1>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
-            {totalPairs} head-to-head inference benchmark comparisons across every GPU we test. Each
-            page includes interactive charts for latency, throughput, and cost metrics.
+            {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons —{' '}
+            {pairsPerModel} GPU pairs × {COMPARE_MODEL_SLUGS.length} models. Each page includes
+            interactive charts for latency, throughput, and cost metrics, plus an interpolated
+            comparison table.
           </p>
         </Card>
       </section>
 
-      {groups.map((group) => (
-        <section key={group.heading}>
-          <Card className="flex flex-col gap-4">
-            <div>
-              <h2 className="text-lg font-semibold">{group.heading}</h2>
-              <p className="text-sm text-muted-foreground mt-1">{group.description}</p>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-              {group.pairs.map(({ slug, label, a, b }) => {
-                const aMeta = HW_REGISTRY[a];
-                const bMeta = HW_REGISTRY[b];
-                const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
-                return (
-                  <ComparePairCardLink
-                    key={slug}
-                    href={`/compare/${slug}`}
-                    slug={slug}
-                    label={label}
-                    archLine={archLine}
-                  />
-                );
-              })}
-            </div>
-          </Card>
-        </section>
-      ))}
+      {COMPARE_MODEL_SLUGS.map((model) => {
+        const groups = groupPairsByVendorForModel(model);
+        return (
+          <section key={model.slug} id={model.slug}>
+            <Card className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-xl lg:text-2xl font-bold tracking-tight">{model.label}</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Compare any GPU pair on {model.label}.
+                </p>
+              </div>
+              {groups.map((group) => (
+                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold">{group.heading}</h3>
+                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {group.pairs.map(({ slug, label, a, b }) => {
+                      const aMeta = HW_REGISTRY[a];
+                      const bMeta = HW_REGISTRY[b];
+                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
+                      return (
+                        <ComparePairCardLink
+                          key={slug}
+                          href={`/compare/${slug}`}
+                          slug={slug}
+                          label={label}
+                          archLine={archLine}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </Card>
+          </section>
+        );
+      })}
     </>
   );
 }

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -1,7 +1,8 @@
 import type { MetadataRoute } from 'next';
 
 import { getAllPosts } from '@/lib/blog';
-import { allCanonicalCompareSlugs, canonicalCompareSlug } from '@/lib/compare-slug';
+import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
+import { canonicalCompareSlug } from '@/lib/compare-slug';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
 const TABS = [
@@ -13,8 +14,11 @@ const TABS = [
   'gpu-metrics',
 ] as const;
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();
+  // Only emit (model, pair) URLs that have benchmark data on both sides —
+  // avoids polluting the sitemap with empty pages that hurt crawl budget.
+  const compareSlugs = await getAllComparableCompareSlugs();
 
   return [
     {
@@ -59,7 +63,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     })),
-    ...allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
+    ...compareSlugs.map(({ modelSlug, a, b }) => ({
       url: `${BASE_URL}/compare/${canonicalCompareSlug(modelSlug, a, b)}`,
       lastModified: now,
       changeFrequency: 'daily' as const,

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next';
 
 import { getAllPosts } from '@/lib/blog';
-import { allCanonicalComparePairs, canonicalCompareSlug } from '@/lib/compare-slug';
+import { allCanonicalCompareSlugs, canonicalCompareSlug } from '@/lib/compare-slug';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
 const TABS = [
@@ -59,8 +59,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'monthly' as const,
       priority: 0.7,
     })),
-    ...allCanonicalComparePairs().map(({ a, b }) => ({
-      url: `${BASE_URL}/compare/${canonicalCompareSlug(a, b)}`,
+    ...allCanonicalCompareSlugs().map(({ modelSlug, a, b }) => ({
+      url: `${BASE_URL}/compare/${canonicalCompareSlug(modelSlug, a, b)}`,
       lastModified: now,
       changeFrequency: 'daily' as const,
       priority: 0.7,

--- a/packages/app/src/lib/compare-availability.ts
+++ b/packages/app/src/lib/compare-availability.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-side helper: for each canonical compare model slug, returns the list
+ * of GPU pairs that actually have benchmark data on both sides.
+ *
+ * Used by the /compare index, the sitemap, and the [slug] generateStaticParams
+ * to avoid emitting cards / URLs for (model, pair) combinations where one or
+ * both GPUs have no rows for that model. A pair is "comparable" if both GPU
+ * keys appear in the availability table for any of the model's dbKeys.
+ *
+ * The page-level handler at /compare/[slug] still renders the empty-state
+ * fallback if a user reaches a filtered-out URL directly, so this filtering
+ * is purely an indexing/navigation concern, not a hard gate.
+ */
+
+import { FIXTURES_MODE, JSON_MODE, getDb } from '@semianalysisai/inferencex-db/connection';
+import * as jsonProvider from '@semianalysisai/inferencex-db/json-provider';
+import {
+  type AvailabilityRow,
+  getAvailabilityData,
+} from '@semianalysisai/inferencex-db/queries/workflow-info';
+
+import { cachedQuery } from '@/lib/api-cache';
+import { loadFixture } from '@/lib/test-fixtures';
+import {
+  allCanonicalComparePairs,
+  type ComparePair,
+  COMPARE_MODEL_SLUGS,
+} from '@/lib/compare-slug';
+
+const getCachedAvailability = cachedQuery(() => {
+  if (FIXTURES_MODE) return Promise.resolve(loadFixture<AvailabilityRow[]>('availability'));
+  if (JSON_MODE) return Promise.resolve(jsonProvider.getAvailabilityData());
+  return getAvailabilityData(getDb());
+}, 'availability');
+
+/** Map from canonical model slug → set of GPU keys that have benchmark rows
+ *  for any of the model's dbKeys. */
+async function getHardwareByModelSlug(): Promise<Map<string, Set<string>>> {
+  const rows = await getCachedAvailability();
+  // Build a quick dbKey → modelSlug index so each row maps to at most one slug.
+  const dbKeyToSlug = new Map<string, string>();
+  for (const m of COMPARE_MODEL_SLUGS) {
+    for (const dbKey of m.dbKeys) dbKeyToSlug.set(dbKey, m.slug);
+  }
+  const out = new Map<string, Set<string>>();
+  for (const m of COMPARE_MODEL_SLUGS) out.set(m.slug, new Set());
+  for (const row of rows) {
+    const slug = dbKeyToSlug.get(row.model);
+    if (!slug) continue;
+    out.get(slug)!.add(row.hardware);
+  }
+  return out;
+}
+
+/** For each canonical model slug, return the GPU pairs where both GPUs have
+ *  benchmark data for that model. Pairs are alphabetical (a < b), matching
+ *  the canonical slug ordering. Returns empty list for models with fewer than
+ *  2 GPUs that have data. */
+export async function getComparablePairsByModelSlug(): Promise<Map<string, ComparePair[]>> {
+  const hwByModel = await getHardwareByModelSlug();
+  const allPairs = allCanonicalComparePairs();
+  const out = new Map<string, ComparePair[]>();
+  for (const m of COMPARE_MODEL_SLUGS) {
+    const hw = hwByModel.get(m.slug) ?? new Set();
+    out.set(
+      m.slug,
+      allPairs.filter((p) => hw.has(p.a) && hw.has(p.b)),
+    );
+  }
+  return out;
+}
+
+/** Flattened cross-product of (model, comparable pair). Used by the sitemap
+ *  and by `generateStaticParams` so neither emits URLs for empty pairs. */
+export async function getAllComparableCompareSlugs(): Promise<
+  { modelSlug: string; a: string; b: string }[]
+> {
+  const byModel = await getComparablePairsByModelSlug();
+  const out: { modelSlug: string; a: string; b: string }[] = [];
+  for (const [modelSlug, pairs] of byModel.entries()) {
+    for (const p of pairs) out.push({ modelSlug, a: p.a, b: p.b });
+  }
+  return out;
+}

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -2,30 +2,142 @@ import { describe, it, expect } from 'vitest';
 
 import {
   allCanonicalComparePairs,
+  allCanonicalCompareSlugs,
   canonicalCompareSlug,
   compareDisplayLabel,
+  compareModelDisplayLabel,
+  COMPARE_MODEL_ALIASES,
+  COMPARE_MODEL_SLUGS,
+  getCompareModelBySlug,
+  LEGACY_BARE_DEFAULT_MODEL_SLUG,
   parseCompareSlug,
 } from './compare-slug';
 
-describe('parseCompareSlug', () => {
-  it('parses a valid canonical slug', () => {
-    expect(parseCompareSlug('h100-vs-h200')).toEqual({ a: 'h100', b: 'h200' });
+const DEEPSEEK_R1 = COMPARE_MODEL_SLUGS.find((m) => m.slug === 'deepseek-r1')!;
+const KIMI_K26 = COMPARE_MODEL_SLUGS.find((m) => m.slug === 'kimi-k26')!;
+const GLM_51 = COMPARE_MODEL_SLUGS.find((m) => m.slug === 'glm-5-1')!;
+
+describe('parseCompareSlug — new model-prefixed form', () => {
+  it('parses a canonical model-prefixed slug', () => {
+    const parsed = parseCompareSlug('deepseek-r1-h100-vs-h200');
+    expect(parsed).toEqual({
+      model: DEEPSEEK_R1,
+      a: 'h100',
+      b: 'h200',
+      isLegacyBareSlug: false,
+      isAliasModel: false,
+    });
   });
 
-  it('parses a non-canonical slug (preserves order)', () => {
-    expect(parseCompareSlug('h200-vs-h100')).toEqual({ a: 'h200', b: 'h100' });
+  it('parses a model slug with internal hyphens (kimi-k26)', () => {
+    const parsed = parseCompareSlug('kimi-k26-mi300x-vs-mi355x');
+    expect(parsed?.model.slug).toBe('kimi-k26');
+    expect(parsed?.a).toBe('mi300x');
+    expect(parsed?.b).toBe('mi355x');
   });
 
-  it('handles uppercase input', () => {
-    expect(parseCompareSlug('H100-VS-H200')).toEqual({ a: 'h100', b: 'h200' });
+  it('parses a model slug with multiple hyphens (glm-5-1)', () => {
+    const parsed = parseCompareSlug('glm-5-1-h100-vs-gb200');
+    expect(parsed?.model).toBe(GLM_51);
+    expect(parsed?.a).toBe('h100');
+    expect(parsed?.b).toBe('gb200');
   });
 
+  it('preserves non-canonical GPU order so caller can redirect', () => {
+    const parsed = parseCompareSlug('kimi-k26-h200-vs-h100');
+    expect(parsed?.a).toBe('h200');
+    expect(parsed?.b).toBe('h100');
+  });
+
+  it('lower-cases uppercase input', () => {
+    const parsed = parseCompareSlug('KIMI-K26-H100-VS-H200');
+    expect(parsed?.model).toBe(KIMI_K26);
+    expect(parsed?.a).toBe('h100');
+    expect(parsed?.b).toBe('h200');
+  });
+
+  it('returns null for unknown model slugs', () => {
+    expect(parseCompareSlug('nonexistent-model-h100-vs-h200')).toBeNull();
+    expect(parseCompareSlug('foo-h100-vs-h200')).toBeNull();
+  });
+});
+
+describe('parseCompareSlug — alias model slugs', () => {
+  it('resolves the deepseek alias to deepseek-r1 with isAliasModel=true', () => {
+    const parsed = parseCompareSlug('deepseek-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('deepseek-r1');
+    expect(parsed?.isAliasModel).toBe(true);
+    expect(parsed?.isLegacyBareSlug).toBe(false);
+  });
+
+  it('resolves the kimi alias to kimi-k26', () => {
+    const parsed = parseCompareSlug('kimi-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('kimi-k26');
+    expect(parsed?.isAliasModel).toBe(true);
+  });
+
+  it('resolves the kimi-k25 older-version alias to kimi-k26', () => {
+    const parsed = parseCompareSlug('kimi-k25-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('kimi-k26');
+    expect(parsed?.isAliasModel).toBe(true);
+  });
+
+  it('resolves the glm-5 same-architecture alias to glm-5-1', () => {
+    const parsed = parseCompareSlug('glm-5-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('glm-5-1');
+    expect(parsed?.isAliasModel).toBe(true);
+  });
+
+  it('resolves every alias key in the alias map', () => {
+    for (const [alias, canonical] of Object.entries(COMPARE_MODEL_ALIASES)) {
+      const parsed = parseCompareSlug(`${alias}-h100-vs-h200`);
+      expect(parsed, `alias ${alias} should resolve`).not.toBeNull();
+      expect(parsed!.model.slug).toBe(canonical);
+      expect(parsed!.isAliasModel).toBe(true);
+    }
+  });
+});
+
+describe('parseCompareSlug — legacy bare slug (PR #351 backward compat)', () => {
+  it('parses a bare GPU pair as the legacy default model', () => {
+    const parsed = parseCompareSlug('h100-vs-h200');
+    expect(parsed?.model.slug).toBe(LEGACY_BARE_DEFAULT_MODEL_SLUG);
+    expect(parsed?.a).toBe('h100');
+    expect(parsed?.b).toBe('h200');
+    expect(parsed?.isLegacyBareSlug).toBe(true);
+    expect(parsed?.isAliasModel).toBe(false);
+  });
+
+  it('handles the bare uppercase form (PR #351 case-insensitive)', () => {
+    const parsed = parseCompareSlug('H100-VS-H200');
+    expect(parsed?.model.slug).toBe(LEGACY_BARE_DEFAULT_MODEL_SLUG);
+    expect(parsed?.isLegacyBareSlug).toBe(true);
+  });
+
+  it('handles reversed bare slugs (PR #351 redirected reversed → canonical)', () => {
+    const parsed = parseCompareSlug('h200-vs-h100');
+    expect(parsed?.a).toBe('h200');
+    expect(parsed?.b).toBe('h100');
+    expect(parsed?.isLegacyBareSlug).toBe(true);
+  });
+
+  it('handles AMD GPU pairs', () => {
+    const parsed = parseCompareSlug('mi300x-vs-mi325x');
+    expect(parsed?.a).toBe('mi300x');
+    expect(parsed?.b).toBe('mi325x');
+    expect(parsed?.isLegacyBareSlug).toBe(true);
+  });
+});
+
+describe('parseCompareSlug — rejection cases', () => {
   it('returns null for unknown GPU keys', () => {
     expect(parseCompareSlug('a100-vs-h100')).toBeNull();
+    expect(parseCompareSlug('deepseek-r1-a100-vs-h100')).toBeNull();
   });
 
   it('returns null when both sides are the same GPU', () => {
     expect(parseCompareSlug('h100-vs-h100')).toBeNull();
+    expect(parseCompareSlug('deepseek-r1-h100-vs-h100')).toBeNull();
   });
 
   it('returns null for malformed slugs', () => {
@@ -36,19 +148,35 @@ describe('parseCompareSlug', () => {
     expect(parseCompareSlug('h100-and-h200')).toBeNull();
   });
 
-  it('handles AMD GPU keys', () => {
-    expect(parseCompareSlug('mi300x-vs-mi325x')).toEqual({ a: 'mi300x', b: 'mi325x' });
+  it('returns null when the prefix is non-empty but contains no GPU key', () => {
+    expect(parseCompareSlug('deepseek-r1-notagpu-vs-h100')).toBeNull();
   });
 });
 
 describe('canonicalCompareSlug', () => {
-  it('returns alphabetical order regardless of input order', () => {
-    expect(canonicalCompareSlug('h200', 'h100')).toBe('h100-vs-h200');
-    expect(canonicalCompareSlug('h100', 'h200')).toBe('h100-vs-h200');
+  it('returns alphabetical GPU order regardless of input order', () => {
+    expect(canonicalCompareSlug('deepseek-r1', 'h200', 'h100')).toBe('deepseek-r1-h100-vs-h200');
+    expect(canonicalCompareSlug('deepseek-r1', 'h100', 'h200')).toBe('deepseek-r1-h100-vs-h200');
   });
 
   it('handles cross-vendor pairs', () => {
-    expect(canonicalCompareSlug('mi300x', 'h100')).toBe('h100-vs-mi300x');
+    expect(canonicalCompareSlug('kimi-k26', 'mi300x', 'h100')).toBe('kimi-k26-h100-vs-mi300x');
+  });
+
+  it('handles multi-hyphen model slugs', () => {
+    expect(canonicalCompareSlug('glm-5-1', 'h100', 'h200')).toBe('glm-5-1-h100-vs-h200');
+  });
+
+  it('round-trips through parseCompareSlug for every canonical model', () => {
+    for (const model of COMPARE_MODEL_SLUGS) {
+      const slug = canonicalCompareSlug(model.slug, 'h100', 'h200');
+      const parsed = parseCompareSlug(slug);
+      expect(parsed?.model.slug, `round-trip for ${model.slug}`).toBe(model.slug);
+      expect(parsed?.a).toBe('h100');
+      expect(parsed?.b).toBe('h200');
+      expect(parsed?.isLegacyBareSlug).toBe(false);
+      expect(parsed?.isAliasModel).toBe(false);
+    }
   });
 });
 
@@ -67,9 +195,6 @@ describe('allCanonicalComparePairs', () => {
 
   it('count = n*(n-1)/2', () => {
     const pairs = allCanonicalComparePairs();
-    // GPU_KEYS currently has 9 entries → 9*8/2 = 36
-    // Test the formula rather than the literal count so this stays valid
-    // when new GPUs are added.
     const seenKeys = new Set<string>();
     for (const { a, b } of pairs) {
       seenKeys.add(a);
@@ -80,9 +205,61 @@ describe('allCanonicalComparePairs', () => {
   });
 });
 
+describe('allCanonicalCompareSlugs', () => {
+  it('produces (models × pairs) distinct entries', () => {
+    const slugs = allCanonicalCompareSlugs();
+    const pairCount = allCanonicalComparePairs().length;
+    expect(slugs.length).toBe(COMPARE_MODEL_SLUGS.length * pairCount);
+    const unique = new Set(slugs.map((s) => `${s.modelSlug}|${s.a}|${s.b}`));
+    expect(unique.size).toBe(slugs.length);
+  });
+
+  it('every emitted slug round-trips through parseCompareSlug', () => {
+    for (const { modelSlug, a, b } of allCanonicalCompareSlugs()) {
+      const slug = canonicalCompareSlug(modelSlug, a, b);
+      const parsed = parseCompareSlug(slug);
+      expect(parsed, `slug ${slug} should parse`).not.toBeNull();
+      expect(parsed!.model.slug).toBe(modelSlug);
+      expect(parsed!.a).toBe(a);
+      expect(parsed!.b).toBe(b);
+      expect(parsed!.isLegacyBareSlug).toBe(false);
+      expect(parsed!.isAliasModel).toBe(false);
+    }
+  });
+});
+
 describe('compareDisplayLabel', () => {
   it('uses HW_REGISTRY labels', () => {
     expect(compareDisplayLabel('h100', 'h200')).toBe('H100 vs H200');
     expect(compareDisplayLabel('gb200', 'mi355x')).toBe('GB200 NVL72 vs MI355X');
+  });
+});
+
+describe('compareModelDisplayLabel', () => {
+  it('prepends the model label to the GPU pair label', () => {
+    expect(compareModelDisplayLabel(DEEPSEEK_R1, 'h100', 'h200')).toBe(
+      'DeepSeek R1 — H100 vs H200',
+    );
+    expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
+      'Kimi K2.6 — GB200 NVL72 vs MI355X',
+    );
+  });
+});
+
+describe('getCompareModelBySlug', () => {
+  it('returns canonical models for canonical slugs', () => {
+    expect(getCompareModelBySlug('deepseek-r1')).toBe(DEEPSEEK_R1);
+    expect(getCompareModelBySlug('kimi-k26')).toBe(KIMI_K26);
+  });
+
+  it('resolves alias slugs to their canonical model', () => {
+    expect(getCompareModelBySlug('deepseek')).toBe(DEEPSEEK_R1);
+    expect(getCompareModelBySlug('kimi')).toBe(KIMI_K26);
+    expect(getCompareModelBySlug('kimi-k25')).toBe(KIMI_K26);
+    expect(getCompareModelBySlug('glm-5')).toBe(GLM_51);
+  });
+
+  it('returns null for unknown slugs', () => {
+    expect(getCompareModelBySlug('nonexistent')).toBeNull();
   });
 });

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -241,7 +241,7 @@ describe('compareModelDisplayLabel', () => {
       'DeepSeek R1 — H100 vs H200',
     );
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
-      'Kimi K2.6 — GB200 NVL72 vs MI355X',
+      'Kimi K2.5/K2.6 — GB200 NVL72 vs MI355X',
     );
   });
 });

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -51,7 +51,9 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     // the newer version name; the dbKey list pulls data from both DB buckets
     // so the slug is populated today and stays populated when K2.6 data lands.
     dbKeys: ['kimik2.6', 'kimik2.5'],
-    label: 'Kimi K2.6',
+    // Slug groups two point releases sharing one architecture — the header
+    // surfaces both versions so the URL doesn't read as "only K2.6".
+    label: 'Kimi K2.5/K2.6',
   },
   {
     slug: 'qwen-3-5',
@@ -65,14 +67,14 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     // GLM-5.0 and GLM-5.1 share an architecture per the model card; the slug
     // uses the newer version name but the data pull covers both DB buckets.
     dbKeys: ['glm5.1', 'glm5'],
-    label: 'GLM 5.1',
+    label: 'GLM 5/5.1',
   },
   {
     slug: 'minimax-m27',
     displayName: 'MiniMax-M2.5',
     // Same point-release grouping pattern as Kimi and GLM.
     dbKeys: ['minimaxm2.7', 'minimaxm2.5'],
-    label: 'MiniMax M2.7',
+    label: 'MiniMax M2.5/M2.7',
   },
   {
     slug: 'llama-3-3-70b',

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -46,7 +46,11 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'kimi-k26',
     displayName: 'Kimi-K2.5',
-    dbKeys: ['kimik2.6'],
+    // Both K2.5 and K2.6 point releases share an architecture (mirroring
+    // DISPLAY_MODEL_TO_DB in packages/constants/src/models.ts). The slug uses
+    // the newer version name; the dbKey list pulls data from both DB buckets
+    // so the slug is populated today and stays populated when K2.6 data lands.
+    dbKeys: ['kimik2.6', 'kimik2.5'],
     label: 'Kimi K2.6',
   },
   {
@@ -58,13 +62,16 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'glm-5-1',
     displayName: 'GLM-5',
-    dbKeys: ['glm5.1'],
+    // GLM-5.0 and GLM-5.1 share an architecture per the model card; the slug
+    // uses the newer version name but the data pull covers both DB buckets.
+    dbKeys: ['glm5.1', 'glm5'],
     label: 'GLM 5.1',
   },
   {
     slug: 'minimax-m27',
     displayName: 'MiniMax-M2.5',
-    dbKeys: ['minimaxm2.7'],
+    // Same point-release grouping pattern as Kimi and GLM.
+    dbKeys: ['minimaxm2.7', 'minimaxm2.5'],
     label: 'MiniMax M2.7',
   },
   {

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -2,34 +2,213 @@ import { GPU_KEYS, HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 const SEPARATOR = '-vs-';
 
+// ---------------------------------------------------------------------------
+// Model registry for compare URLs
+// ---------------------------------------------------------------------------
+//
+// The compare URL is `/compare/{model-slug}-{a}-vs-{b}` where {model-slug} is
+// one of CANONICAL_MODEL_SLUGS. URL slugs are deliberately finer-grained than
+// the dashboard's display-grouped model dropdown — `kimi-k25` and `kimi-k26`
+// are distinct slugs even though both DB keys roll up to the single "Kimi-K2.5"
+// display option in the UI. The slug encodes which DB bucket to query.
+//
+// `LEGACY_BARE_DEFAULT_MODEL_SLUG` is the model the parser falls back to when
+// the URL has no model prefix at all (e.g. `/compare/h100-vs-h200`). PR #351
+// shipped without a model prefix, so all pre-existing inbound links resolve
+// here and get 308-redirected to the canonical model-prefixed URL.
+
+export interface CompareModelSlug {
+  /** Canonical URL slug, e.g. 'deepseek-r1'. Lowercase, hyphen-separated. */
+  slug: string;
+  /** Matches Model enum value passed via `?g_model=`, e.g. 'DeepSeek-R1-0528'. */
+  displayName: string;
+  /** DB keys to fetch from getLatestBenchmarks. Most models map to one key,
+   *  but the slug stays finer-grained than the dashboard display grouping —
+   *  e.g. `kimi-k26` only queries 'kimik2.6', not also 'kimik2.5'. */
+  dbKeys: string[];
+  /** Human label for OG image, metadata, and page header. */
+  label: string;
+}
+
+export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
+  {
+    slug: 'deepseek-r1',
+    displayName: 'DeepSeek-R1-0528',
+    dbKeys: ['dsr1'],
+    label: 'DeepSeek R1',
+  },
+  {
+    slug: 'deepseek-v4',
+    displayName: 'DeepSeek-V4-Pro',
+    dbKeys: ['dsv4'],
+    label: 'DeepSeek V4 Pro',
+  },
+  {
+    slug: 'kimi-k26',
+    displayName: 'Kimi-K2.5',
+    dbKeys: ['kimik2.6'],
+    label: 'Kimi K2.6',
+  },
+  {
+    slug: 'qwen-3-5',
+    displayName: 'Qwen-3.5-397B-A17B',
+    dbKeys: ['qwen3.5'],
+    label: 'Qwen 3.5',
+  },
+  {
+    slug: 'glm-5-1',
+    displayName: 'GLM-5',
+    dbKeys: ['glm5.1'],
+    label: 'GLM 5.1',
+  },
+  {
+    slug: 'minimax-m27',
+    displayName: 'MiniMax-M2.5',
+    dbKeys: ['minimaxm2.7'],
+    label: 'MiniMax M2.7',
+  },
+  {
+    slug: 'llama-3-3-70b',
+    displayName: 'Llama-3.3-70B-Instruct-FP8',
+    dbKeys: ['llama70b'],
+    label: 'Llama 3.3 70B',
+  },
+  {
+    slug: 'gptoss-120b',
+    displayName: 'gpt-oss-120b',
+    dbKeys: ['gptoss120b'],
+    label: 'gpt-oss 120B',
+  },
+];
+
+/** Family-level and older-version slugs that 308 to the canonical slug above.
+ *  Used for backward compat ("deepseek" → "deepseek-r1") and for "same
+ *  architecture, newer version supersedes" ("glm-5" → "glm-5-1"). */
+export const COMPARE_MODEL_ALIASES: Record<string, string> = {
+  deepseek: 'deepseek-r1',
+  kimi: 'kimi-k26',
+  'kimi-k25': 'kimi-k26',
+  qwen: 'qwen-3-5',
+  glm: 'glm-5-1',
+  'glm-5': 'glm-5-1',
+  minimax: 'minimax-m27',
+  'minimax-m25': 'minimax-m27',
+  llama: 'llama-3-3-70b',
+  gptoss: 'gptoss-120b',
+};
+
+/** Default model the bare-slug (no model prefix) URL form maps to. PR #351 had
+ *  no model dimension and pinned to DeepSeek R1, so legacy inbound links from
+ *  that era resolve here. */
+export const LEGACY_BARE_DEFAULT_MODEL_SLUG = 'deepseek-r1';
+
+const SLUG_TO_MODEL: Record<string, CompareModelSlug> = Object.fromEntries(
+  COMPARE_MODEL_SLUGS.map((m) => [m.slug, m]),
+);
+const CANONICAL_MODEL_SLUGS = new Set(COMPARE_MODEL_SLUGS.map((m) => m.slug));
+
+/** Lookup helper. Returns null for unknown slugs (not even an alias). */
+export function getCompareModelBySlug(slug: string): CompareModelSlug | null {
+  const canonical = COMPARE_MODEL_ALIASES[slug] ?? slug;
+  return SLUG_TO_MODEL[canonical] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Slug parsing and canonicalization
+// ---------------------------------------------------------------------------
+
 export interface ComparePair {
   a: string;
   b: string;
 }
 
-/** Parse a slug like "h100-vs-h200" into { a, b }. Returns null for invalid input. */
-export function parseCompareSlug(slug: string): ComparePair | null {
+export interface CompareSlug {
+  model: CompareModelSlug;
+  a: string;
+  b: string;
+  /** True if the URL had no model prefix at all (legacy PR #351 form).
+   *  Caller should redirect to the canonical model-prefixed URL. */
+  isLegacyBareSlug: boolean;
+  /** True if the URL used a model alias (e.g. `kimi` instead of `kimi-k26`,
+   *  or `glm-5` instead of `glm-5-1`). Caller should redirect to canonical. */
+  isAliasModel: boolean;
+}
+
+/** Parse a compare slug. Accepts both the legacy bare form (`h100-vs-h200`)
+ *  and the new model-prefixed form (`deepseek-r1-h100-vs-h200`). Returns null
+ *  on invalid input.
+ *
+ *  Algorithm: split on `-vs-`, validate the right side as a GPU key, then walk
+ *  the left side backwards to find the longest suffix that's a GPU key. That
+ *  suffix is the `a` GPU; the remainder is the model slug (or empty for the
+ *  bare form). GPU keys contain no hyphens, so a single `lastIndexOf('-')`
+ *  finds the split point. */
+export function parseCompareSlug(slug: string): CompareSlug | null {
   if (!slug) return null;
   const lower = slug.toLowerCase();
-  const idx = lower.indexOf(SEPARATOR);
-  if (idx <= 0) return null;
-  const a = lower.slice(0, idx);
-  const b = lower.slice(idx + SEPARATOR.length);
-  if (!a || !b || a === b) return null;
-  if (!GPU_KEYS.has(a) || !GPU_KEYS.has(b)) return null;
-  return { a, b };
+  const sepIdx = lower.indexOf(SEPARATOR);
+  if (sepIdx <= 0) return null;
+
+  const b = lower.slice(sepIdx + SEPARATOR.length);
+  if (!b || !GPU_KEYS.has(b)) return null;
+
+  const prefix = lower.slice(0, sepIdx);
+  if (!prefix) return null;
+
+  // Split prefix into model + a GPU.
+  // GPU keys have no hyphens (h100, gb200, mi355x), so the last hyphen in
+  // `prefix` separates the model slug from the a GPU. If there's no hyphen,
+  // the entire prefix is the a GPU (legacy bare form).
+  let a: string;
+  let modelPart: string;
+  const lastDash = prefix.lastIndexOf('-');
+  if (lastDash === -1) {
+    a = prefix;
+    modelPart = '';
+  } else {
+    const candidate = prefix.slice(lastDash + 1);
+    if (GPU_KEYS.has(candidate)) {
+      a = candidate;
+      modelPart = prefix.slice(0, lastDash);
+    } else {
+      return null;
+    }
+  }
+
+  if (!GPU_KEYS.has(a) || a === b) return null;
+
+  // Resolve model slug.
+  let modelSlug: string;
+  let isLegacyBareSlug = false;
+  let isAliasModel = false;
+  if (modelPart === '') {
+    modelSlug = LEGACY_BARE_DEFAULT_MODEL_SLUG;
+    isLegacyBareSlug = true;
+  } else if (CANONICAL_MODEL_SLUGS.has(modelPart)) {
+    modelSlug = modelPart;
+  } else if (COMPARE_MODEL_ALIASES[modelPart]) {
+    modelSlug = COMPARE_MODEL_ALIASES[modelPart];
+    isAliasModel = true;
+  } else {
+    return null;
+  }
+
+  const model = SLUG_TO_MODEL[modelSlug];
+  if (!model) return null;
+  return { model, a, b, isLegacyBareSlug, isAliasModel };
 }
 
-/**
- * Canonical ordering = alphabetical by GPU key. Stable, easy to verify, matches
- * how external links to these pages will look once search engines crawl them.
- */
-export function canonicalCompareSlug(a: string, b: string): string {
+/** Canonical model-prefixed slug. GPUs sorted alphabetically so a stable URL
+ *  always exists for each (model, pair) combination. */
+export function canonicalCompareSlug(modelSlug: string, a: string, b: string): string {
   const [first, second] = [a, b].toSorted();
-  return `${first}${SEPARATOR}${second}`;
+  return `${modelSlug}-${first}${SEPARATOR}${second}`;
 }
 
-/** All canonical (alphabetical, distinct) GPU pairs from HW_REGISTRY. */
+/** All distinct GPU pairs in alphabetical order. Model-agnostic — callers that
+ *  need (model × pair) combinations should compose this with
+ *  COMPARE_MODEL_SLUGS, or use `allCanonicalCompareSlugs()` for the flattened
+ *  cross-product. */
 export function allCanonicalComparePairs(): ComparePair[] {
   const keys = [...GPU_KEYS].toSorted();
   const pairs: ComparePair[] = [];
@@ -41,9 +220,23 @@ export function allCanonicalComparePairs(): ComparePair[] {
   return pairs;
 }
 
-/** Display label for a pair, e.g. "H100 vs H200" or "GB200 NVL72 vs MI355X". */
+/** Flattened cross-product of canonical model slugs and canonical GPU pairs.
+ *  Used by sitemap.ts and generateStaticParams. Only emits canonical slugs
+ *  (not aliases) — alias URLs would just 308 to these. */
+export function allCanonicalCompareSlugs(): { modelSlug: string; a: string; b: string }[] {
+  const pairs = allCanonicalComparePairs();
+  return COMPARE_MODEL_SLUGS.flatMap((m) => pairs.map((p) => ({ modelSlug: m.slug, ...p })));
+}
+
+/** "H100 vs H200" or "GB200 NVL72 vs MI355X" — GPU-only display label. */
 export function compareDisplayLabel(a: string, b: string): string {
   const aLabel = HW_REGISTRY[a]?.label ?? a.toUpperCase();
   const bLabel = HW_REGISTRY[b]?.label ?? b.toUpperCase();
   return `${aLabel} vs ${bLabel}`;
+}
+
+/** "DeepSeek R1 — H100 vs H200" — model-aware display label for headings,
+ *  metadata titles, and OG image text. */
+export function compareModelDisplayLabel(model: CompareModelSlug, a: string, b: string): string {
+  return `${model.label} — ${compareDisplayLabel(a, b)}`;
 }


### PR DESCRIPTION
## Summary

PR #351 introduced `/compare/[a]-vs-[b]` with SSR'd, indexable, JSON-LD-rich GPU comparison pages — but the SSR fetch, OG image, JSON-LD, and metadata are all hardcoded to DeepSeek R1. Users can change the model client-side via the chart controls, but the indexable/shareable view is DeepSeek-pinned.

This PR extends the route to **all 8 models in the dashboard** by adding a model prefix to the slug, while keeping every PR #351 URL working via a one-hop 307 redirect.

## URL format

| Form | Example | Behavior |
| --- | --- | --- |
| **New canonical** | `/compare/kimi-k26-h100-vs-h200` | 200, renders with Kimi K2.6 data |
| **Bare slug** (PR #351 form) | `/compare/h100-vs-h200` | 307 → `/compare/deepseek-r1-h100-vs-h200` |
| **Family-level alias** | `/compare/kimi-h100-vs-h200` | 307 → `/compare/kimi-k26-h100-vs-h200` |
| **Older-version alias** | `/compare/kimi-k25-h100-vs-h200` | 307 → `/compare/kimi-k26-h100-vs-h200` |
| **Same-arch supersession** | `/compare/glm-5-h100-vs-h200` | 307 → `/compare/glm-5-1-h100-vs-h200` |
| **Non-canonical GPU order** | `/compare/kimi-k26-h200-vs-h100` | 307 → `/compare/kimi-k26-h100-vs-h200` |
| **Any combination** | `/compare/h200-vs-h100?i_seq=1k/1k` | one-hop 307 → `/compare/deepseek-r1-h100-vs-h200?i_seq=1k%2F1k` |
| **Unknown model slug** | `/compare/notamodel-h100-vs-h200` | 404 |

Query params are preserved across the redirect — the prior PR #351 redirect dropped them, which would have broken bare-slug shared links once every bare slug starts redirecting.

## Model slug registry

Canonical slugs (`packages/app/src/lib/compare-slug.ts`):

| Slug | DB key | Display |
| --- | --- | --- |
| `deepseek-r1` | `dsr1` | DeepSeek R1 |
| `deepseek-v4` | `dsv4` | DeepSeek V4 Pro |
| `kimi-k26` | `kimik2.6` | Kimi K2.6 |
| `qwen-3-5` | `qwen3.5` | Qwen 3.5 |
| `glm-5-1` | `glm5.1` | GLM 5.1 |
| `minimax-m27` | `minimaxm2.7` | MiniMax M2.7 |
| `llama-3-3-70b` | `llama70b` | Llama 3.3 70B |
| `gptoss-120b` | `gptoss120b` | gpt-oss 120B |

URL slugs are deliberately finer-grained than the dashboard's display-grouped model dropdown — `kimi-k25` and `kimi-k26` are distinct URL slugs even though both DB keys roll up to one "Kimi-K2.5" display option in the UI. Each canonical slug queries exactly one dbKey so the data shown matches the URL.

## Cardinality

- **Sitemap**: jumps from 36 → 288 compare URLs (8 canonical models × 36 GPU pairs). Verified via `curl /sitemap.xml | grep -c '/compare/'`.
- **`generateStaticParams`**: emits the same 288 entries for ISR / known-routes.
- **Empty-state**: when a (model, pair) has no benchmark data (e.g. Kimi K2.6 on some Hopper pair we haven't run), the page renders the existing empty-state message rather than 404 — matches user-picked behavior from the plan-mode review.

## Tests

- **`compare-slug.test.ts`**: 32 unit tests (all passing) covering new canonical form, alias resolution for every alias in `COMPARE_MODEL_ALIASES`, bare-slug detection, every canonical model round-trip through parser + canonicalizer, rejection cases (unknown model, unknown GPU, same GPU, malformed).
- **`compare-redirect.cy.ts`**: 9 e2e cases covering bare-slug redirect, family-alias redirect, older-version redirect (kimi-k25 → kimi-k26), same-arch redirect (glm-5 → glm-5-1), reversed GPU order through any redirect class, query-param preservation, non-deepseek canonical slugs serving without redirect.
- **`compare-table.cy.ts` + `url-params.cy.ts`**: visit URLs swapped to canonical model-prefixed form so assertions test the rendered page directly, not the redirected one.

## Verification

Local dev server (`pnpm dev`) curl results:

```
/compare/h100-vs-h200                                  -> 307 Location: /compare/deepseek-r1-h100-vs-h200
/compare/h200-vs-h100                                  -> 307 Location: /compare/deepseek-r1-h100-vs-h200
/compare/kimi-h100-vs-h200                             -> 307 Location: /compare/kimi-k26-h100-vs-h200
/compare/kimi-k25-h100-vs-h200                         -> 307 Location: /compare/kimi-k26-h100-vs-h200
/compare/glm-5-h100-vs-h200                            -> 307 Location: /compare/glm-5-1-h100-vs-h200
/compare/h100-vs-h200?i_seq=1k/1k&i_prec=fp8           -> 307 Location: /compare/deepseek-r1-h100-vs-h200?i_seq=1k%2F1k&i_prec=fp8
/compare/notamodel-h100-vs-h200                        -> 404
/compare                                               -> 200 (rebuilt index with 8 model sections)
/sitemap.xml                                           -> contains exactly 288 compare URLs
```

Pre-commit hook ran `oxlint`, `oxfmt`, and `tsc --noEmit` — all clean.

## Backward compatibility guarantees

- Every URL form that worked under PR #351 keeps working through the one-hop 307 chain
- The query string survives the redirect
- The cache key for `getCachedBenchmarks` is already keyed on the dbKeys array, so adding new models doesn't bust the existing DeepSeek cache
- `?g_model=` URL param still overrides the slug-derived model on the SSR side for advanced sharers

## Test plan

- [ ] Click-through Vercel preview: visit a few canonical URLs (`/compare/kimi-k26-mi300x-vs-mi355x`, `/compare/glm-5-1-h100-vs-gb200`) and confirm chart + OG image + JSON-LD reflect the right model
- [ ] Visit `/compare/h100-vs-h200` and confirm the URL bar updates to `/compare/deepseek-r1-h100-vs-h200`
- [ ] Visit a (model, pair) with no benchmark data and confirm the empty-state message renders without crashing
- [ ] Verify `/compare` index renders 8 model sections with the per-model NVIDIA/AMD/cross-vendor sub-grids
- [ ] `curl /sitemap.xml | grep -c '/compare/'` returns 288

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches public URL contracts, permanent redirects, and server-side benchmark/availability queries for SEO and SSR; behavior is heavily tested but wrong slug parsing or redirect rules could break inbound links or canonical URLs.
> 
> **Overview**
> Extends `/compare` from GPU-only slugs to **model-prefixed** canonical URLs (`/compare/{model}-{gpuA}-vs-{gpuB}`), with a registry of eight models, alias resolution, and SSR/SEO tied to each model’s `dbKeys` instead of a hardcoded DeepSeek R1 fetch.
> 
> **Routing & compat:** `parseCompareSlug` / `canonicalCompareSlug` now return model + GPUs plus flags for legacy bare URLs and alias models. Non-canonical requests get a **one-hop 308** (`permanentRedirect`) that normalizes model, GPU order, and **preserves query strings**. Legacy `/compare/h100-vs-h200` maps to `deepseek-r1-…`.
> 
> **Discovery & indexing:** New `compare-availability.ts` filters (model, pair) to combos with benchmark data on both GPUs; used by `/compare` index (per-model sections), `sitemap`, `generateStaticParams`, and OG static params so navigation/crawl lists skip empty pairs (direct hits still get empty-state).
> 
> **UX/SEO:** Detail pages pass `modelLabel` into the client header/copy; metadata, JSON-LD, and OG eyebrow include the model. Expanded unit and Cypress coverage for redirects and canonical URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab76784207f5be67afbf61401a96a8180898cd0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->