### PR TITLE
feat(compare-per-dollar): add cost-per-million-tokens SSR sibling route

### DIFF
--- a/packages/app/cypress/e2e/compare-per-dollar-redirect.cy.ts
+++ b/packages/app/cypress/e2e/compare-per-dollar-redirect.cy.ts
@@ -1,0 +1,55 @@
+describe('Compare-per-dollar canonical slug redirect', () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    });
+  });
+
+  it('serves a fully canonical slug without redirecting', () => {
+    cy.visit('/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a non-canonical (reversed) GPU order to alphabetical canonical', () => {
+    cy.visit('/compare-per-dollar/deepseek-r1-h100-vs-gb200');
+    cy.location('pathname').should('eq', '/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a bare GPU pair (no model prefix) to the deepseek-r1 default', () => {
+    // Bare-slug fallback target must live under /compare-per-dollar/, not
+    // /compare/ — the per-dollar route handles its own redirect chain.
+    cy.visit('/compare-per-dollar/gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a bare reversed GPU pair through both normalizations in one hop', () => {
+    cy.visit('/compare-per-dollar/h100-vs-gb200');
+    cy.location('pathname').should('eq', '/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('redirects a family-level alias model slug to the canonical version slug', () => {
+    cy.visit('/compare-per-dollar/kimi-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/kimi-k26-gb200-vs-h100');
+  });
+
+  it('redirects an older-version alias slug to the latest-version canonical slug', () => {
+    cy.visit('/compare-per-dollar/kimi-k25-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/kimi-k26-gb200-vs-h100');
+  });
+
+  it('redirects glm-5 alias to glm-5-1 (same architecture)', () => {
+    cy.visit('/compare-per-dollar/glm-5-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/glm-5-1-gb200-vs-h100');
+  });
+
+  it('preserves query params across the bare-slug redirect', () => {
+    cy.visit('/compare-per-dollar/h100-vs-h200?i_seq=1k/1k');
+    cy.location('pathname').should('eq', '/compare-per-dollar/deepseek-r1-h100-vs-h200');
+    cy.location('search').should('contain', 'i_seq=1k%2F1k');
+  });
+
+  it('serves a non-deepseek canonical slug without redirecting', () => {
+    cy.visit('/compare-per-dollar/kimi-k26-gb200-vs-h100');
+    cy.location('pathname').should('eq', '/compare-per-dollar/kimi-k26-gb200-vs-h100');
+  });
+});

--- a/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
+++ b/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
@@ -20,16 +20,22 @@ describe('Compare-per-dollar slug page — slimmed table + cross-link', () => {
     cy.get('[data-testid="compare-interpolated-table"]').should('be.visible');
   });
 
-  it('shows only the Cost and Concurrency metric rows', () => {
-    // visibleMetricLabels filter on the per-dollar route narrows the four
-    // metric rows down to two.
+  it('shows only the Dollar-per-Million-Tokens and Concurrency metric rows', () => {
+    // visibleMetricLabels filter narrows the four METRICS down to two; the
+    // metricLabelOverrides prop renames "Cost ($/M tok)" to its full-English
+    // form so the cell reads in line with the page's "Performance per Dollar"
+    // framing. The original "Cost ($/M tok)" string must not appear.
     cy.get('[data-testid="compare-interpolated-table"] tbody').should(
       'contain.text',
-      'Cost ($/M tok)',
+      'Dollar per Million Tokens',
     );
     cy.get('[data-testid="compare-interpolated-table"] tbody').should(
       'contain.text',
       'Concurrency',
+    );
+    cy.get('[data-testid="compare-interpolated-table"] tbody').should(
+      'not.contain.text',
+      'Cost ($/M tok)',
     );
     cy.get('[data-testid="compare-interpolated-table"] tbody').should(
       'not.contain.text',

--- a/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
+++ b/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
@@ -1,0 +1,72 @@
+describe('Compare-per-dollar slug page — slimmed table + cross-link', () => {
+  before(() => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    });
+    // Visit the canonical model-prefixed URL directly so location assertions
+    // don't fight the 308 redirect.
+    cy.visit('/compare-per-dollar/deepseek-r1-gb200-vs-h100');
+    cy.get('[data-testid="compare-interpolated-table"]').should('exist');
+  });
+
+  beforeEach(() => {
+    cy.document().then((doc) => {
+      delete doc.body.dataset.scrollLocked;
+      doc.body.style.removeProperty('pointer-events');
+    });
+  });
+
+  it('renders the interpolated table', () => {
+    cy.get('[data-testid="compare-interpolated-table"]').should('be.visible');
+  });
+
+  it('shows only the Cost and Concurrency metric rows', () => {
+    // visibleMetricLabels filter on the per-dollar route narrows the four
+    // metric rows down to two.
+    cy.get('[data-testid="compare-interpolated-table"] tbody').should(
+      'contain.text',
+      'Cost ($/M tok)',
+    );
+    cy.get('[data-testid="compare-interpolated-table"] tbody').should(
+      'contain.text',
+      'Concurrency',
+    );
+    cy.get('[data-testid="compare-interpolated-table"] tbody').should(
+      'not.contain.text',
+      'Throughput (tok/s/gpu)',
+    );
+    cy.get('[data-testid="compare-interpolated-table"] tbody').should(
+      'not.contain.text',
+      'tok/s/MW',
+    );
+  });
+
+  it('exposes a "View full latency + throughput comparison" cross-link to /compare/', () => {
+    cy.contains('a', 'View full latency + throughput comparison').should(
+      'have.attr',
+      'href',
+      '/compare/deepseek-r1-gb200-vs-h100',
+    );
+  });
+
+  it('uses "Performance per Dollar" framing in the page header', () => {
+    cy.contains('Performance per Dollar').should('be.visible');
+  });
+});
+
+describe('Compare slug page — cross-link to per-dollar view', () => {
+  before(() => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    });
+    cy.visit('/compare/deepseek-r1-gb200-vs-h100');
+  });
+
+  it('renders a cross-link to /compare-per-dollar/<same-slug>', () => {
+    cy.contains('a', 'View performance-per-dollar view').should(
+      'have.attr',
+      'href',
+      '/compare-per-dollar/deepseek-r1-gb200-vs-h100',
+    );
+  });
+});

--- a/packages/app/src/app/compare-per-dollar/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/opengraph-image.tsx
@@ -1,0 +1,201 @@
+/**
+ * Per-dollar compare OG image — identical circuit tile sidebar layout to the
+ * /compare OG and the blog OG, but the eyebrow and bottom banner are swapped
+ * to surface the "Performance per Dollar" framing.
+ */
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { notFound } from 'next/navigation';
+import { ImageResponse } from 'next/og';
+
+import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
+import { canonicalCompareSlug, compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
+
+export const alt = 'GPU performance-per-dollar inference benchmark comparison';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const BLUE = '#0B86D1';
+const BG = '#131416';
+const PANEL_BG = '#0F1214';
+
+// Same tile grid as the /compare and blog OG so all three OG types read as a
+// family.
+const TILE_GRID: ({ file: string; rotate?: number } | null)[] = [
+  { file: 'teal-chevron.png', rotate: 180 },
+  { file: 'gold-diagonal.png' },
+  { file: 'teal-circuit.png' },
+  null,
+  { file: 'gold-wavy.png' },
+  { file: 'teal-chip.png' },
+  { file: 'teal-chevron.png', rotate: 90 },
+  { file: 'teal-organic.png' },
+  null,
+  { file: 'gold-circuit.png' },
+  { file: 'teal-circuit.png', rotate: 180 },
+  { file: 'teal-organic.png', rotate: 180 },
+];
+
+export async function generateStaticParams() {
+  const slugs = await getAllComparableCompareSlugs();
+  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
+}
+
+let logoSrcPromise: Promise<string | null> | undefined;
+function getLogoSrc(): Promise<string | null> {
+  if (!logoSrcPromise) {
+    logoSrcPromise = readFile(join(process.cwd(), 'public/brand/logo-color.png'))
+      .then((buf) => `data:image/png;base64,${buf.toString('base64')}`)
+      .catch(() => null);
+  }
+  return logoSrcPromise;
+}
+
+let tilesPromise: Promise<({ src: string; rotate?: number } | null)[]> | undefined;
+function getTiles(): Promise<({ src: string; rotate?: number } | null)[]> {
+  if (!tilesPromise) {
+    const uniqueFiles = [...new Set(TILE_GRID.filter(Boolean).map((t) => t!.file))];
+    tilesPromise = Promise.all(
+      uniqueFiles.map(async (f) => {
+        const src = await readFile(join(process.cwd(), 'public/brand/og-tiles', f))
+          .then((buf) => `data:image/png;base64,${buf.toString('base64')}`)
+          .catch(() => null);
+        return [f, src] as const;
+      }),
+    ).then((loaded) => {
+      const cache = Object.fromEntries(loaded);
+      return TILE_GRID.map((t) => {
+        if (!t) return null;
+        const src = cache[t.file];
+        return src ? { src, rotate: t.rotate } : null;
+      });
+    });
+  }
+  return tilesPromise;
+}
+
+export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const parsed = parseCompareSlug(slug);
+  if (!parsed) notFound();
+  const [logoSrc, tiles] = await Promise.all([getLogoSrc(), getTiles()]);
+
+  const title = compareDisplayLabel(parsed.a, parsed.b);
+  const eyebrow = `${parsed.model.label} · Performance per Dollar`;
+  const titleSize = title.length > 26 ? 80 : title.length > 18 ? 96 : 112;
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        width: '100%',
+        height: '100%',
+        backgroundColor: BG,
+        color: '#EAEBEC',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          width: 195,
+          height: '100%',
+          backgroundColor: PANEL_BG,
+          position: 'relative',
+        }}
+      >
+        {tiles.map((tile, i) => {
+          if (!tile) return null;
+          const row = Math.floor(i / 2);
+          const col = i % 2;
+          return (
+            <img
+              key={i}
+              src={tile.src}
+              style={{
+                position: 'absolute',
+                left: 12 + col * 90,
+                top: 12 + row * 104,
+                width: 78,
+                height: 86,
+                borderRadius: 4,
+                objectFit: 'cover',
+                ...(tile.rotate ? { transform: `rotate(${tile.rotate}deg)` } : {}),
+              }}
+            />
+          );
+        })}
+        <div
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            width: 3,
+            height: '100%',
+            backgroundColor: BLUE,
+            display: 'flex',
+          }}
+        />
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          flex: 1,
+          padding: '48px 55px 20px 55px',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+            flex: 1,
+            justifyContent: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontSize: 24,
+              color: '#9BA0A6',
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+              display: 'flex',
+            }}
+          >
+            {eyebrow}
+          </div>
+
+          <div
+            style={{
+              fontSize: titleSize,
+              fontWeight: 800,
+              color: '#FFFFFF',
+              lineHeight: 1.1,
+              display: 'flex',
+            }}
+          >
+            {title}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <span style={{ fontSize: 26, color: '#9BA0A6', display: 'flex' }}>
+            AI inference benchmark · cost per million tokens
+          </span>
+          {logoSrc && <img src={logoSrc} height={72} />}
+        </div>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -43,6 +43,13 @@ interface ComparePerDollarPageClientProps {
  *  metric rows (Throughput, tok/s/MW) live on the sibling /compare page. */
 const PER_DOLLAR_TABLE_METRICS = ['Cost ($/M tok)', 'Concurrency'];
 
+/** Rename "Cost ($/M tok)" to the full-English "Dollar per Million Tokens"
+ *  in the per-dollar table so the cell reads in line with the page's
+ *  "Performance per Dollar" framing and surfaces the SEO term verbatim. */
+const PER_DOLLAR_LABEL_OVERRIDES = {
+  'Cost ($/M tok)': 'Dollar per Million Tokens',
+};
+
 /** y_costh = Cost per Million Total Tokens (Owning - Hyperscaler). Defined in
  *  packages/app/src/components/inference/inference-chart-config.json. */
 const PER_DOLLAR_DEFAULT_Y_AXIS = 'y_costh';
@@ -198,6 +205,7 @@ function CompareTableSection({
       gpuDataPointsA={pointsA}
       gpuDataPointsB={pointsB}
       visibleMetricLabels={PER_DOLLAR_TABLE_METRICS}
+      metricLabelOverrides={PER_DOLLAR_LABEL_OVERRIDES}
     />
   );
 }

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -40,6 +40,11 @@ interface ComparePerDollarPageClientProps {
   bVendor: string;
   aArch: string;
   bArch: string;
+  /** Owning-hyperscaler $/GPU/hr for each GPU — sourced from HW_REGISTRY.costh
+   *  (the same input the per-dollar cost-per-token math uses). Rendered in the
+   *  header so readers can audit the pricing assumptions. */
+  aCostPerGpuHr: number;
+  bCostPerGpuHr: number;
 }
 
 /** Only show Cost + Concurrency in the interpolated table — the rest of the
@@ -88,6 +93,8 @@ export default function ComparePerDollarPageClient({
   bVendor,
   aArch,
   bArch,
+  aCostPerGpuHr,
+  bCostPerGpuHr,
 }: ComparePerDollarPageClientProps) {
   useEffect(() => {
     track('compare_per_dollar_page_view', { gpu_a: a, gpu_b: b, default_model: defaultModel });
@@ -137,6 +144,27 @@ export default function ComparePerDollarPageClient({
                   data-testid="compare-per-dollar-narrative"
                 >
                   {narrative}
+                </p>
+              )}
+              {(aCostPerGpuHr > 0 || bCostPerGpuHr > 0) && (
+                <p
+                  className="mt-2 text-xs text-muted-foreground max-w-3xl"
+                  data-testid="compare-per-dollar-pricing"
+                >
+                  GPU pricing (owning hyperscaler): <strong>{aLabel}</strong>{' '}
+                  {aCostPerGpuHr > 0 ? `$${aCostPerGpuHr.toFixed(2)}/GPU/hr` : '—'} ·{' '}
+                  <strong>{bLabel}</strong>{' '}
+                  {bCostPerGpuHr > 0 ? `$${bCostPerGpuHr.toFixed(2)}/GPU/hr` : '—'}. Source:{' '}
+                  <a
+                    href="https://newsletter.semianalysis.com/p/ai-cloud-economics"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-primary"
+                    onClick={() => track('compare_per_dollar_tco_source_clicked', { slug })}
+                  >
+                    SemiAnalysis Market August 2025 Pricing Surveys &amp; AI Cloud TCO Model
+                  </a>
+                  .
                 </p>
               )}
               <p className="mt-2 text-sm">

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -143,7 +143,12 @@ export default function ComparePerDollarPageClient({
                   className="mt-3 text-sm text-foreground/80 max-w-3xl"
                   data-testid="compare-per-dollar-narrative"
                 >
-                  {narrative}
+                  {narrative}{' '}
+                  <span className="text-muted-foreground italic">
+                    (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
+                    {defaultPrecision ?? 'precision'} selection for this URL — table and chart below
+                    update if you change sequence, precision, or model in the controls.)
+                  </span>
                 </p>
               )}
               {(aCostPerGpuHr > 0 || bCostPerGpuHr > 0) && (

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -19,16 +19,13 @@ interface SsrTableData {
   interactivityRange: { min: number; max: number };
 }
 
-interface ComparePageClientProps {
+interface ComparePerDollarPageClientProps {
   a: string;
   b: string;
   /** Canonical compare slug (e.g. `deepseek-r1-h100-vs-h200`). Used for the
-   *  cross-link to the sibling `/compare-per-dollar/<same-slug>` route. */
+   *  cross-link to the sibling `/compare/<same-slug>` route. */
   slug: string;
   label: string;
-  /** Human-readable model name from the slug — drives the eyebrow above the
-   *  H1 so the URL-grouping ("Kimi K2.6", "GLM 5.1", etc.) is legible without
-   *  scanning the URL bar. */
   modelLabel: string;
   defaultModel: string;
   defaultSequence: string | null;
@@ -41,6 +38,14 @@ interface ComparePageClientProps {
   aArch: string;
   bArch: string;
 }
+
+/** Only show Cost + Concurrency in the interpolated table — the rest of the
+ *  metric rows (Throughput, tok/s/MW) live on the sibling /compare page. */
+const PER_DOLLAR_TABLE_METRICS = ['Cost ($/M tok)', 'Concurrency'];
+
+/** y_costh = Cost per Million Total Tokens (Owning - Hyperscaler). Defined in
+ *  packages/app/src/components/inference/inference-chart-config.json. */
+const PER_DOLLAR_DEFAULT_Y_AXIS = 'y_costh';
 
 function toModel(value: string): Model | undefined {
   return Object.values(Model).includes(value as Model) ? (value as Model) : undefined;
@@ -56,7 +61,7 @@ function toPrecisions(value: string | null): string[] | undefined {
   return Object.values(Precision).includes(value as Precision) ? [value] : undefined;
 }
 
-export default function ComparePageClient({
+export default function ComparePerDollarPageClient({
   a,
   b,
   slug,
@@ -72,9 +77,9 @@ export default function ComparePageClient({
   bVendor,
   aArch,
   bArch,
-}: ComparePageClientProps) {
+}: ComparePerDollarPageClientProps) {
   useEffect(() => {
-    track('compare_page_view', { gpu_a: a, gpu_b: b, default_model: defaultModel });
+    track('compare_per_dollar_page_view', { gpu_a: a, gpu_b: b, default_model: defaultModel });
   }, [a, b, defaultModel]);
 
   const compareGpuPair = useMemo(() => [a, b] as const, [a, b]);
@@ -92,18 +97,20 @@ export default function ComparePageClient({
         activeTab="compare"
         initialActiveHwTypes={[a, b]}
         compareGpuPair={compareGpuPair}
+        initialYAxisMetric={PER_DOLLAR_DEFAULT_Y_AXIS}
       >
         <div className="flex flex-col gap-4">
           <Card className="flex flex-col gap-3">
             <header>
               <div className="text-xs uppercase tracking-wider text-muted-foreground">
-                {modelLabel} · GPU comparison
+                {modelLabel} · Performance per Dollar
               </div>
               <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mt-1">{label}</h1>
               <p className="mt-2 text-sm text-muted-foreground max-w-3xl">
-                Head-to-head AI inference benchmark comparison of <strong>{aLabel}</strong> (
-                {aVendor} {aArch}) and <strong>{bLabel}</strong> ({bVendor} {bArch}) on{' '}
-                <strong>{modelLabel}</strong>. Latency, throughput, and cost across LLM workloads.
+                Cost per million tokens of <strong>{aLabel}</strong> ({aVendor} {aArch}) versus{' '}
+                <strong>{bLabel}</strong> ({bVendor} {bArch}) on <strong>{modelLabel}</strong>.
+                Owning-hyperscaler TCO normalized by output tokens — performance per dollar across
+                LLM workloads. Pick the more cost-efficient SKU at every target interactivity level.
                 Use the chart controls below to switch sequences, precisions, and metrics — same
                 interactions as{' '}
                 <Link href="/" className="underline hover:text-primary">
@@ -113,11 +120,11 @@ export default function ComparePageClient({
               </p>
               <p className="mt-2 text-sm">
                 <Link
-                  href={`/compare-per-dollar/${slug}`}
+                  href={`/compare/${slug}`}
                   className="underline hover:text-primary text-muted-foreground"
-                  onClick={() => track('compare_cross_link_to_per_dollar', { slug })}
+                  onClick={() => track('compare_per_dollar_cross_link_to_full', { slug })}
                 >
-                  View performance-per-dollar view →
+                  View full latency + throughput comparison →
                 </Link>
               </p>
             </header>
@@ -159,15 +166,11 @@ function CompareTableSection({
     selectedRunDate,
   );
 
-  // Extract GPUDataPoint arrays for just the two GPUs in the pair.
-  // The group keys may be plain hwKeys or composite (hwKey__precision).
-  // Match prefix since keys include framework (e.g., "h200_sglang", "h100_dynamo-trt").
   const { pointsA, pointsB } = useMemo(() => {
     const pA: GPUDataPoint[] = [];
     const pB: GPUDataPoint[] = [];
     for (const [groupKey, points] of Object.entries(gpuDataByGroupKey)) {
-      // Match if groupKey starts with the base GPU key
-      const hwKey = groupKey.split('__')[0]; // Remove precision suffix if present
+      const hwKey = groupKey.split('__')[0];
       if (hwKey === a || hwKey.startsWith(`${a}_`)) pA.push(...points);
       else if (hwKey === b || hwKey.startsWith(`${b}_`)) pB.push(...points);
     }
@@ -179,8 +182,8 @@ function CompareTableSection({
   if (ssrTableData.defaultTargets.length === 0) {
     return (
       <div className="border border-border/50 rounded-md px-4 py-3 text-sm text-muted-foreground bg-muted/30">
-        No interpolated comparison data available for the default model. Use the chart controls
-        below to select a model with benchmark data for both GPUs.
+        No interpolated cost-per-token data available for the default model on this GPU pair. Use
+        the chart controls below to select a model and precision with benchmark data for both GPUs.
       </div>
     );
   }
@@ -194,6 +197,7 @@ function CompareTableSection({
       interactivityRange={clientRange}
       gpuDataPointsA={pointsA}
       gpuDataPointsB={pointsB}
+      visibleMetricLabels={PER_DOLLAR_TABLE_METRICS}
     />
   );
 }

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -31,6 +31,9 @@ interface ComparePerDollarPageClientProps {
   defaultSequence: string | null;
   defaultPrecision: string | null;
   ssrTableData: SsrTableData;
+  /** SSR-rendered plain-English summary of the dollar-per-million-tokens table
+   *  at the mid target. Null when there's no comparable data. */
+  narrative: string | null;
   aLabel: string;
   bLabel: string;
   aVendor: string;
@@ -78,6 +81,7 @@ export default function ComparePerDollarPageClient({
   defaultSequence,
   defaultPrecision,
   ssrTableData,
+  narrative,
   aLabel,
   bLabel,
   aVendor,
@@ -112,7 +116,9 @@ export default function ComparePerDollarPageClient({
               <div className="text-xs uppercase tracking-wider text-muted-foreground">
                 {modelLabel} · Performance per Dollar
               </div>
-              <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mt-1">{label}</h1>
+              <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mt-1">
+                {label} Performance per Dollar
+              </h1>
               <p className="mt-2 text-sm text-muted-foreground max-w-3xl">
                 Cost per million tokens of <strong>{aLabel}</strong> ({aVendor} {aArch}) versus{' '}
                 <strong>{bLabel}</strong> ({bVendor} {bArch}) on <strong>{modelLabel}</strong>.
@@ -125,6 +131,14 @@ export default function ComparePerDollarPageClient({
                 </Link>
                 .
               </p>
+              {narrative && (
+                <p
+                  className="mt-3 text-sm text-foreground/80 max-w-3xl"
+                  data-testid="compare-per-dollar-narrative"
+                >
+                  {narrative}
+                </p>
+              )}
               <p className="mt-2 text-sm">
                 <Link
                   href={`/compare/${slug}`}

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -156,7 +156,7 @@ export default function ComparePerDollarPageClient({
                   <strong>{bLabel}</strong>{' '}
                   {bCostPerGpuHr > 0 ? `$${bCostPerGpuHr.toFixed(2)}/GPU/hr` : '—'}. Source:{' '}
                   <a
-                    href="https://newsletter.semianalysis.com/p/ai-cloud-economics"
+                    href="https://semianalysis.com/ai-cloud-tco-model/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-primary"

--- a/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import {
   buildJsonLd,
+  compareTableNarrative,
   computeCompareTableData,
   getCachedBenchmarks,
   KNOWN_MODELS,
@@ -131,6 +132,16 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
   const label = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const aMeta = HW_REGISTRY[parsed.a];
   const bMeta = HW_REGISTRY[parsed.b];
+  const aLabel = aMeta?.label ?? parsed.a.toUpperCase();
+  const bLabel = bMeta?.label ?? parsed.b.toUpperCase();
+  const narrative = compareTableNarrative(
+    'per-dollar',
+    parsed.model.label,
+    aLabel,
+    bLabel,
+    ssrRows,
+    interactivityRange,
+  );
 
   return (
     <>
@@ -145,8 +156,9 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
         defaultSequence={effectiveSequence}
         defaultPrecision={effectivePrecision}
         ssrTableData={{ defaultTargets, ssrRows, interactivityRange }}
-        aLabel={aMeta?.label ?? parsed.a.toUpperCase()}
-        bLabel={bMeta?.label ?? parsed.b.toUpperCase()}
+        narrative={narrative}
+        aLabel={aLabel}
+        bLabel={bLabel}
         aVendor={aMeta?.vendor ?? ''}
         bVendor={bMeta?.vendor ?? ''}
         aArch={aMeta?.arch ?? ''}

--- a/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
@@ -12,6 +12,7 @@ import {
   parseCompareSlug,
 } from '@/lib/compare-slug';
 import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
+import { getGpuSpecs } from '@/lib/constants';
 import {
   buildJsonLd,
   compareTableNarrative,
@@ -142,6 +143,12 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
     ssrRows,
     interactivityRange,
   );
+  // Owning-hyperscaler $/GPU/hr — the same `costh` value the per-dollar math
+  // upstream uses to derive cost per million tokens. Rendered in the header
+  // so the reader can audit the underlying pricing inputs without leaving
+  // the page.
+  const aCostPerGpuHr = getGpuSpecs(parsed.a).costh;
+  const bCostPerGpuHr = getGpuSpecs(parsed.b).costh;
 
   return (
     <>
@@ -163,6 +170,8 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
         bVendor={bMeta?.vendor ?? ''}
         aArch={aMeta?.arch ?? ''}
         bArch={bMeta?.arch ?? ''}
+        aCostPerGpuHr={aCostPerGpuHr}
+        bCostPerGpuHr={bCostPerGpuHr}
       />
     </>
   );

--- a/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
@@ -23,7 +23,7 @@ import {
   summarize,
 } from '@/lib/compare-ssr';
 
-import ComparePageClient from './page-client';
+import ComparePerDollarPageClient from './page-client';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,9 +33,9 @@ interface Props {
 }
 
 export async function generateStaticParams() {
-  // Only enumerate (model, pair) combos with benchmark data on both sides.
-  // Direct URL hits to non-enumerated combos still render via the dynamic
-  // SSR path (with the empty-state fallback).
+  // Mirror the /compare route's static params — only (model, pair) combos with
+  // benchmark data on both sides. Direct URL hits to non-enumerated combos
+  // still render via the dynamic SSR path (with the empty-state fallback).
   const slugs = await getAllComparableCompareSlugs();
   return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
 }
@@ -46,44 +46,39 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!parsed) return {};
   const fullLabel = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const gpuLabel = compareDisplayLabel(parsed.a, parsed.b);
-  const url = `${SITE_URL}/compare/${canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b)}`;
-  const description = `Head-to-head GPU inference benchmark comparison for ${parsed.model.label}: ${gpuLabel}. Latency, throughput, and cost across LLM workloads.`;
+  const url = `${SITE_URL}/compare-per-dollar/${canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b)}`;
+  // Description weaves the user-named SEO terms — "performance per dollar",
+  // "performance normalized by cost", "dollars per million tokens" — without
+  // keyword-stuffing.
+  const description = `${parsed.model.label} cost per million tokens on ${gpuLabel}. Performance normalized by owning-hyperscaler TCO — see which GPU delivers more inference dollars-per-token at every interactivity level.`;
   return {
-    title: `${fullLabel} Inference Benchmark`,
+    title: `${fullLabel} — Performance per Dollar`,
     description,
     alternates: { canonical: url },
     openGraph: {
-      title: `${fullLabel} | ${SITE_NAME}`,
+      title: `${fullLabel} — Performance per Dollar | ${SITE_NAME}`,
       description,
       url,
       type: 'website',
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${fullLabel} Inference Benchmark`,
+      title: `${fullLabel} — Performance per Dollar`,
       description,
     },
   };
 }
 
-export default async function ComparePage({ params, searchParams }: Props) {
+export default async function ComparePerDollarPage({ params, searchParams }: Props) {
   const { slug } = await params;
   const parsed = parseCompareSlug(slug);
   if (!parsed) notFound();
 
-  // Await searchParams once so we can both preserve them on redirect and read
-  // them for URL-param overrides further down.
   const sp = await searchParams;
 
-  // One-hop redirect to the fully canonical URL. Handles all three normalization
-  // cases in a single 308:
-  //   - legacy bare slug:   `h100-vs-h200`              → `deepseek-r1-h100-vs-h200`
-  //   - alias model:        `kimi-h100-vs-h200`         → `kimi-k26-h100-vs-h200`
-  //   - non-canonical GPUs: `kimi-k26-h200-vs-h100`     → `kimi-k26-h100-vs-h200`
-  //   - any combination of the above
-  // Preserves the query string so `?i_seq=1k/1k&i_prec=fp8` etc. survive the
-  // redirect — the original PR #351 redirect dropped these, but with bare slugs
-  // now redirecting unconditionally we need to keep them.
+  // Same one-hop 308 normalization as /compare/[slug] — bare-slug fallback,
+  // alias model resolution, GPU alphabetical order — but redirect target lives
+  // under /compare-per-dollar/. Query string is preserved across the hop.
   const canonical = canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b);
   if (canonical !== slug) {
     const qs = Object.entries(sp)
@@ -94,11 +89,7 @@ export default async function ComparePage({ params, searchParams }: Props) {
       })
       .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
       .join('&');
-    // 308 (not 307): bare-slug, alias model, and non-canonical GPU order are
-    // all permanent decisions — using a permanent redirect lets search engines
-    // consolidate link equity onto the canonical URL instead of keeping the
-    // alias URL in the index alongside the canonical one.
-    permanentRedirect(`/compare/${canonical}${qs ? `?${qs}` : ''}`);
+    permanentRedirect(`/compare-per-dollar/${canonical}${qs ? `?${qs}` : ''}`);
   }
 
   const rows = await getCachedBenchmarks(parsed.model.dbKeys);
@@ -110,17 +101,11 @@ export default async function ComparePage({ params, searchParams }: Props) {
     parsed.b,
   );
 
-  // URL params win over slug-derived defaults; this baking-into-SSR avoids the
-  // hydration flash where the client upgrades seeded defaults to URL values.
-  // `sp` was already awaited above for the redirect-query-preservation path.
   const urlSeq = pickString(sp.i_seq);
   const urlPrec = pickString(sp.i_prec);
   const urlModel = pickString(sp.g_model);
   const effectiveSequence = urlSeq && KNOWN_SEQUENCES.has(urlSeq) ? urlSeq : pickedSequence;
   const effectivePrecision = urlPrec && KNOWN_PRECISIONS.has(urlPrec) ? urlPrec : pickedPrecision;
-  // `?g_model=` is honored only if it matches a known model — but the slug's
-  // model is the canonical default. Disregard URL param if user wants to
-  // explicitly override (rare).
   const effectiveModel =
     urlModel && KNOWN_MODELS.has(urlModel) ? urlModel : parsed.model.displayName;
 
@@ -132,9 +117,9 @@ export default async function ComparePage({ params, searchParams }: Props) {
     effectivePrecision,
   );
 
-  const url = `${SITE_URL}/compare/${canonical}`;
+  const url = `${SITE_URL}/compare-per-dollar/${canonical}`;
   const jsonLd = buildJsonLd(
-    'full',
+    'per-dollar',
     parsed.model,
     parsed.a,
     parsed.b,
@@ -150,7 +135,7 @@ export default async function ComparePage({ params, searchParams }: Props) {
   return (
     <>
       <JsonLd data={jsonLd} />
-      <ComparePageClient
+      <ComparePerDollarPageClient
         a={parsed.a}
         b={parsed.b}
         slug={canonical}

--- a/packages/app/src/app/compare-per-dollar/layout.tsx
+++ b/packages/app/src/app/compare-per-dollar/layout.tsx
@@ -1,0 +1,20 @@
+import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+
+/**
+ * Wraps `/compare-per-dollar/*` pages in UnofficialRunProvider but skips
+ * DashboardShell so we get a focused single-purpose page (no TabNav). Mirrors
+ * the structure of `/compare/layout.tsx` — the GlobalFilterProvider is mounted
+ * inside the page's client component so it can seed initial precision/sequence
+ * based on which combos actually have data for the GPU pair from the slug.
+ */
+export default function ComparePerDollarLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <UnofficialRunProvider>
+      <main className="relative">
+        <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-4 pb-8">
+          {children}
+        </div>
+      </main>
+    </UnofficialRunProvider>
+  );
+}

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -36,6 +36,17 @@ export const metadata: Metadata = {
   },
 };
 
+/** "A", "A and B", or "A, B, and C" — Oxford-comma serial join. Enumerated
+ *  in the lede instead of a bare count so search engines see every model name
+ *  in the indexable description. */
+function formatModelList(models: CompareModelSlug[]): string {
+  const labels = models.map((m) => m.label);
+  if (labels.length === 0) return 'no models';
+  if (labels.length === 1) return labels[0];
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
+}
+
 interface VendorGroup {
   heading: string;
   description: string;
@@ -121,9 +132,9 @@ export default async function ComparePerDollarIndexPage() {
           </h1>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} head-to-head cost-per-million-tokens comparisons across{' '}
-            {modelsWithPairs.length} models. Performance normalized by owning-hyperscaler TCO — each
-            page renders the cost-per-token chart and an interpolated dollars-per-million comparison
-            table so you can pick the cheaper SKU at any target interactivity level.
+            {formatModelList(modelsWithPairs)}. Performance normalized by owning-hyperscaler TCO —
+            each page renders the cost-per-token chart and an interpolated dollars-per-million
+            comparison table so you can pick the cheaper SKU at any target interactivity level.
           </p>
         </Card>
       </section>

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from 'next';
+
+import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
+import {
+  canonicalCompareSlug,
+  compareDisplayLabel,
+  type ComparePair,
+  COMPARE_MODEL_SLUGS,
+  type CompareModelSlug,
+} from '@/lib/compare-slug';
+
+export const dynamic = 'force-dynamic';
+
+const DESCRIPTION =
+  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek R1, Kimi K2.5/K2.6, GLM 5/5.1, Qwen 3.5, and more. Pick the cheapest SKU for your workload.';
+
+export const metadata: Metadata = {
+  title: 'GPU Performance per Dollar',
+  description: DESCRIPTION,
+  alternates: { canonical: `${SITE_URL}/compare-per-dollar` },
+  openGraph: {
+    title: `GPU Performance per Dollar | ${SITE_NAME}`,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/compare-per-dollar`,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `GPU Performance per Dollar | ${SITE_NAME}`,
+    description: DESCRIPTION,
+  },
+};
+
+interface VendorGroup {
+  heading: string;
+  description: string;
+  pairs: { a: string; b: string; slug: string; label: string }[];
+}
+
+function groupPairsByVendorForModel(
+  model: CompareModelSlug,
+  comparablePairs: ComparePair[],
+): VendorGroup[] {
+  const nvidia: VendorGroup['pairs'] = [];
+  const amd: VendorGroup['pairs'] = [];
+  const cross: VendorGroup['pairs'] = [];
+
+  for (const { a, b } of comparablePairs) {
+    const entry = {
+      a,
+      b,
+      slug: canonicalCompareSlug(model.slug, a, b),
+      label: compareDisplayLabel(a, b),
+    };
+    const vA = HW_REGISTRY[a]?.vendor;
+    const vB = HW_REGISTRY[b]?.vendor;
+    if (vA === 'NVIDIA' && vB === 'NVIDIA') nvidia.push(entry);
+    else if (vA === 'AMD' && vB === 'AMD') amd.push(entry);
+    else cross.push(entry);
+  }
+
+  const groups: VendorGroup[] = [];
+
+  if (cross.length > 0) {
+    groups.push({
+      heading: 'NVIDIA vs AMD',
+      description: 'Cross-vendor cost-per-token comparisons across architecture generations.',
+      pairs: cross,
+    });
+  }
+  if (nvidia.length > 0) {
+    groups.push({
+      heading: 'NVIDIA vs NVIDIA',
+      description: 'Hopper and Blackwell generation cost-per-token comparisons.',
+      pairs: nvidia,
+    });
+  }
+  if (amd.length > 0) {
+    groups.push({
+      heading: 'AMD vs AMD',
+      description: 'CDNA 3 and CDNA 4 generation cost-per-token comparisons.',
+      pairs: amd,
+    });
+  }
+
+  return groups;
+}
+
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  name: `GPU Performance per Dollar | ${SITE_NAME}`,
+  description: DESCRIPTION,
+  url: `${SITE_URL}/compare-per-dollar`,
+};
+
+export default async function ComparePerDollarIndexPage() {
+  // Server-side filter (Neon availability): only show (model, pair) combos
+  // where both GPUs have benchmark data for that model. Matches the /compare
+  // index's behavior — no empty-state cards in navigation. The page-level
+  // handler at /compare-per-dollar/[slug] still renders the empty-state for
+  // direct URL hits.
+  const comparablePairsByModel = await getComparablePairsByModelSlug();
+  const totalUrls = [...comparablePairsByModel.values()].reduce((s, p) => s + p.length, 0);
+  const modelsWithPairs = COMPARE_MODEL_SLUGS.filter(
+    (m) => (comparablePairsByModel.get(m.slug)?.length ?? 0) > 0,
+  );
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <section>
+        <Card>
+          <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">
+            GPU Performance per Dollar
+          </h1>
+          <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
+            {totalUrls.toLocaleString()} head-to-head cost-per-million-tokens comparisons across{' '}
+            {modelsWithPairs.length} models. Performance normalized by owning-hyperscaler TCO — each
+            page renders the cost-per-token chart and an interpolated dollars-per-million comparison
+            table so you can pick the cheaper SKU at any target interactivity level.
+          </p>
+        </Card>
+      </section>
+
+      {modelsWithPairs.map((model) => {
+        const pairs = comparablePairsByModel.get(model.slug) ?? [];
+        const groups = groupPairsByVendorForModel(model, pairs);
+        return (
+          <section key={model.slug} id={model.slug}>
+            <Card className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-xl lg:text-2xl font-bold tracking-tight">{model.label}</h2>
+                <p className="text-sm text-muted-foreground mt-1">
+                  {pairs.length} GPU pair{pairs.length === 1 ? '' : 's'} with cost-per-token
+                  benchmark data on {model.label}.
+                </p>
+              </div>
+              {groups.map((group) => (
+                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
+                  <div>
+                    <h3 className="text-base font-semibold">{group.heading}</h3>
+                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {group.pairs.map(({ slug, label, a, b }) => {
+                      const aMeta = HW_REGISTRY[a];
+                      const bMeta = HW_REGISTRY[b];
+                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
+                      return (
+                        <ComparePairCardLink
+                          key={slug}
+                          href={`/compare-per-dollar/${slug}`}
+                          slug={slug}
+                          label={label}
+                          archLine={archLine}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </Card>
+          </section>
+        );
+      })}
+    </>
+  );
+}

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -6,13 +6,8 @@ import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import {
-  canonicalCompareSlug,
-  compareDisplayLabel,
-  type ComparePair,
-  COMPARE_MODEL_SLUGS,
-  type CompareModelSlug,
-} from '@/lib/compare-slug';
+import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
+import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,17 +31,6 @@ export const metadata: Metadata = {
   },
 };
 
-/** "A", "A and B", or "A, B, and C" — Oxford-comma serial join. Enumerated
- *  in the lede instead of a bare count so search engines see every model name
- *  in the indexable description. */
-function formatModelList(models: CompareModelSlug[]): string {
-  const labels = models.map((m) => m.label);
-  if (labels.length === 0) return 'no models';
-  if (labels.length === 1) return labels[0];
-  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
-  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
-}
-
 interface VendorGroup {
   heading: string;
   description: string;
@@ -57,26 +41,8 @@ function groupPairsByVendorForModel(
   model: CompareModelSlug,
   comparablePairs: ComparePair[],
 ): VendorGroup[] {
-  const nvidia: VendorGroup['pairs'] = [];
-  const amd: VendorGroup['pairs'] = [];
-  const cross: VendorGroup['pairs'] = [];
-
-  for (const { a, b } of comparablePairs) {
-    const entry = {
-      a,
-      b,
-      slug: canonicalCompareSlug(model.slug, a, b),
-      label: compareDisplayLabel(a, b),
-    };
-    const vA = HW_REGISTRY[a]?.vendor;
-    const vB = HW_REGISTRY[b]?.vendor;
-    if (vA === 'NVIDIA' && vB === 'NVIDIA') nvidia.push(entry);
-    else if (vA === 'AMD' && vB === 'AMD') amd.push(entry);
-    else cross.push(entry);
-  }
-
+  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
   const groups: VendorGroup[] = [];
-
   if (cross.length > 0) {
     groups.push({
       heading: 'NVIDIA vs AMD',
@@ -98,7 +64,6 @@ function groupPairsByVendorForModel(
       pairs: amd,
     });
   }
-
   return groups;
 }
 

--- a/packages/app/src/app/compare/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare/[slug]/page-client.tsx
@@ -120,7 +120,12 @@ export default function ComparePageClient({
                   className="mt-3 text-sm text-foreground/80 max-w-3xl"
                   data-testid="compare-narrative"
                 >
-                  {narrative}
+                  {narrative}{' '}
+                  <span className="text-muted-foreground italic">
+                    (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
+                    {defaultPrecision ?? 'precision'} selection for this URL — table and chart below
+                    update if you change sequence, precision, or model in the controls.)
+                  </span>
                 </p>
               )}
               <p className="mt-2 text-sm">

--- a/packages/app/src/app/compare/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare/[slug]/page-client.tsx
@@ -34,6 +34,9 @@ interface ComparePageClientProps {
   defaultSequence: string | null;
   defaultPrecision: string | null;
   ssrTableData: SsrTableData;
+  /** SSR-rendered plain-English summary of the interpolated table (mid-target
+   *  operating point + headline ratio). Null when there's no comparable data. */
+  narrative: string | null;
   aLabel: string;
   bLabel: string;
   aVendor: string;
@@ -66,6 +69,7 @@ export default function ComparePageClient({
   defaultSequence,
   defaultPrecision,
   ssrTableData,
+  narrative,
   aLabel,
   bLabel,
   aVendor,
@@ -111,6 +115,14 @@ export default function ComparePageClient({
                 </Link>
                 .
               </p>
+              {narrative && (
+                <p
+                  className="mt-3 text-sm text-foreground/80 max-w-3xl"
+                  data-testid="compare-narrative"
+                >
+                  {narrative}
+                </p>
+              )}
               <p className="mt-2 text-sm">
                 <Link
                   href={`/compare-per-dollar/${slug}`}

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -14,6 +14,7 @@ import {
 import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import {
   buildJsonLd,
+  compareTableNarrative,
   computeCompareTableData,
   getCachedBenchmarks,
   KNOWN_MODELS,
@@ -146,6 +147,16 @@ export default async function ComparePage({ params, searchParams }: Props) {
   const label = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const aMeta = HW_REGISTRY[parsed.a];
   const bMeta = HW_REGISTRY[parsed.b];
+  const aLabel = aMeta?.label ?? parsed.a.toUpperCase();
+  const bLabel = bMeta?.label ?? parsed.b.toUpperCase();
+  const narrative = compareTableNarrative(
+    'full',
+    parsed.model.label,
+    aLabel,
+    bLabel,
+    ssrRows,
+    interactivityRange,
+  );
 
   return (
     <>
@@ -160,8 +171,9 @@ export default async function ComparePage({ params, searchParams }: Props) {
         defaultSequence={effectiveSequence}
         defaultPrecision={effectivePrecision}
         ssrTableData={{ defaultTargets, ssrRows, interactivityRange }}
-        aLabel={aMeta?.label ?? parsed.a.toUpperCase()}
-        bLabel={bMeta?.label ?? parsed.b.toUpperCase()}
+        narrative={narrative}
+        aLabel={aLabel}
+        bLabel={bLabel}
         aVendor={aMeta?.vendor ?? ''}
         bVendor={bMeta?.vendor ?? ''}
         aArch={aMeta?.arch ?? ''}

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -36,6 +36,17 @@ export const metadata: Metadata = {
   },
 };
 
+/** "A", "A and B", or "A, B, and C" — Oxford-comma serial join. Enumerated
+ *  in the lede instead of a bare count so search engines see every model name
+ *  in the indexable description. */
+function formatModelList(models: CompareModelSlug[]): string {
+  const labels = models.map((m) => m.label);
+  if (labels.length === 0) return 'no models';
+  if (labels.length === 1) return labels[0];
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
+}
+
 interface VendorGroup {
   heading: string;
   description: string;
@@ -119,7 +130,7 @@ export default async function CompareIndexPage() {
           <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">GPU Comparisons</h1>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons across{' '}
-            {modelsWithPairs.length} models. Each page includes interactive charts for latency,
+            {formatModelList(modelsWithPairs)}. Each page includes interactive charts for latency,
             throughput, and cost metrics, plus an interpolated comparison table.
           </p>
         </Card>

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -6,13 +6,8 @@ import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import {
-  canonicalCompareSlug,
-  compareDisplayLabel,
-  type ComparePair,
-  COMPARE_MODEL_SLUGS,
-  type CompareModelSlug,
-} from '@/lib/compare-slug';
+import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
+import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,17 +31,6 @@ export const metadata: Metadata = {
   },
 };
 
-/** "A", "A and B", or "A, B, and C" — Oxford-comma serial join. Enumerated
- *  in the lede instead of a bare count so search engines see every model name
- *  in the indexable description. */
-function formatModelList(models: CompareModelSlug[]): string {
-  const labels = models.map((m) => m.label);
-  if (labels.length === 0) return 'no models';
-  if (labels.length === 1) return labels[0];
-  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
-  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
-}
-
 interface VendorGroup {
   heading: string;
   description: string;
@@ -57,26 +41,8 @@ function groupPairsByVendorForModel(
   model: CompareModelSlug,
   comparablePairs: ComparePair[],
 ): VendorGroup[] {
-  const nvidia: VendorGroup['pairs'] = [];
-  const amd: VendorGroup['pairs'] = [];
-  const cross: VendorGroup['pairs'] = [];
-
-  for (const { a, b } of comparablePairs) {
-    const entry = {
-      a,
-      b,
-      slug: canonicalCompareSlug(model.slug, a, b),
-      label: compareDisplayLabel(a, b),
-    };
-    const vA = HW_REGISTRY[a]?.vendor;
-    const vB = HW_REGISTRY[b]?.vendor;
-    if (vA === 'NVIDIA' && vB === 'NVIDIA') nvidia.push(entry);
-    else if (vA === 'AMD' && vB === 'AMD') amd.push(entry);
-    else cross.push(entry);
-  }
-
+  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
   const groups: VendorGroup[] = [];
-
   if (cross.length > 0) {
     groups.push({
       heading: 'NVIDIA vs AMD',
@@ -98,7 +64,6 @@ function groupPairsByVendorForModel(
       pairs: amd,
     });
   }
-
   return groups;
 }
 

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -52,6 +52,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     },
     {
+      url: `${BASE_URL}/compare-per-dollar`,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
+    {
       url: `${BASE_URL}/blog`,
       lastModified: now,
       changeFrequency: 'weekly',
@@ -65,6 +71,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     })),
     ...compareSlugs.map(({ modelSlug, a, b }) => ({
       url: `${BASE_URL}/compare/${canonicalCompareSlug(modelSlug, a, b)}`,
+      lastModified: now,
+      changeFrequency: 'daily' as const,
+      priority: 0.7,
+    })),
+    // Per-dollar variant URLs — same (model, pair) availability filter as the
+    // /compare set, so the count matches exactly. Each is a distinct canonical
+    // URL with its own SSR metadata, JSON-LD, and OG image.
+    ...compareSlugs.map(({ modelSlug, a, b }) => ({
+      url: `${BASE_URL}/compare-per-dollar/${canonicalCompareSlug(modelSlug, a, b)}`,
       lastModified: now,
       changeFrequency: 'daily' as const,
       priority: 0.7,

--- a/packages/app/src/components/compare/compare-interpolated-table.tsx
+++ b/packages/app/src/components/compare/compare-interpolated-table.tsx
@@ -32,6 +32,11 @@ export interface CompareInterpolatedTableProps {
   interactivityRange: { min: number; max: number };
   gpuDataPointsA: GPUDataPoint[];
   gpuDataPointsB: GPUDataPoint[];
+  /** When set, only metric rows whose `label` is in this list are rendered.
+   *  Undefined (the default) shows all four metrics. The /compare-per-dollar
+   *  variant passes ['Cost ($/M tok)', 'Concurrency'] to slim the table down
+   *  to the cost-efficiency view; /compare omits the prop. */
+  visibleMetricLabels?: string[];
 }
 
 interface ColumnData {
@@ -84,7 +89,11 @@ export function CompareInterpolatedTable({
   interactivityRange,
   gpuDataPointsA,
   gpuDataPointsB,
+  visibleMetricLabels,
 }: CompareInterpolatedTableProps) {
+  const metricsToRender = visibleMetricLabels
+    ? METRICS.filter((m) => visibleMetricLabels.includes(m.label))
+    : METRICS;
   const [columns, setColumns] = useState<ColumnData[]>(() =>
     defaultTargets.map((target, i) => ({
       target,
@@ -277,7 +286,7 @@ export function CompareInterpolatedTable({
             </tr>
           </thead>
           <tbody>
-            {METRICS.map((metric) => (
+            {metricsToRender.map((metric) => (
               <MetricTableRow
                 key={metric.label}
                 metric={metric}

--- a/packages/app/src/components/compare/compare-interpolated-table.tsx
+++ b/packages/app/src/components/compare/compare-interpolated-table.tsx
@@ -37,6 +37,12 @@ export interface CompareInterpolatedTableProps {
    *  variant passes ['Cost ($/M tok)', 'Concurrency'] to slim the table down
    *  to the cost-efficiency view; /compare omits the prop. */
   visibleMetricLabels?: string[];
+  /** Per-route display-label overrides keyed by the metric's internal `label`.
+   *  Lets routes render a longer / more descriptive name in the cell without
+   *  forking the METRICS table. Example: /compare-per-dollar overrides
+   *  'Cost ($/M tok)' → 'Dollar per Million Tokens' so the page reads in full
+   *  English to match its "Performance per Dollar" framing. */
+  metricLabelOverrides?: Record<string, string>;
 }
 
 interface ColumnData {
@@ -90,10 +96,15 @@ export function CompareInterpolatedTable({
   gpuDataPointsA,
   gpuDataPointsB,
   visibleMetricLabels,
+  metricLabelOverrides,
 }: CompareInterpolatedTableProps) {
-  const metricsToRender = visibleMetricLabels
-    ? METRICS.filter((m) => visibleMetricLabels.includes(m.label))
-    : METRICS;
+  const metricsToRender = (
+    visibleMetricLabels ? METRICS.filter((m) => visibleMetricLabels.includes(m.label)) : METRICS
+  ).map((m) =>
+    metricLabelOverrides && metricLabelOverrides[m.label]
+      ? { ...m, label: metricLabelOverrides[m.label] }
+      : m,
+  );
   const [columns, setColumns] = useState<ColumnData[]>(() =>
     defaultTargets.map((target, i) => ({
       target,

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -41,6 +41,12 @@ const NAV_LINKS = [
     event: 'header_compare_clicked',
   },
   {
+    href: '/compare-per-dollar',
+    label: 'Per Dollar',
+    testId: 'nav-link-compare-per-dollar',
+    event: 'header_compare_per_dollar_clicked',
+  },
+  {
     href: '/quotes',
     label: 'Supporters',
     testId: 'nav-link-supporters',
@@ -53,7 +59,10 @@ const NAV_LINKS = [
 function isActive(pathname: string, href: string): boolean {
   if (href === '/') return pathname === '/';
   if (href === '/inference') return DASHBOARD_TABS.some((tab) => pathname.startsWith(tab));
-  return pathname.startsWith(href);
+  // Exact match or a child path under `<href>/...`. The bare `startsWith` would
+  // light up `/compare` when the user is on `/compare-per-dollar/...` since the
+  // latter starts with the literal string `/compare`.
+  return pathname === href || pathname.startsWith(`${href}/`);
 }
 
 export const Header = ({ starCount }: { starCount?: number | null }) => {

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -61,6 +61,7 @@ export function InferenceProvider({
   activeTab,
   initialActiveHwTypes,
   compareGpuPair,
+  initialYAxisMetric,
 }: {
   children: ReactNode;
   activeTab: string;
@@ -75,6 +76,14 @@ export function InferenceProvider({
    * registry GPU base keys so other hardware never appears on the legend or plots.
    */
   compareGpuPair?: readonly [string, string];
+  /**
+   * Initial y-axis metric key when the URL has no `?i_metric=` param. Used by
+   * `/compare-per-dollar/[slug]` to default the chart to
+   * `y_costh` (Cost per Million Total Tokens — Owning Hyperscaler) instead of
+   * the dashboard's default `y_tpPerGpu`. URL param still wins so existing
+   * shared links are unaffected.
+   */
+  initialYAxisMetric?: string;
 }) {
   const isActive =
     activeTab === 'inference' || activeTab === 'historical' || activeTab === 'compare';
@@ -125,7 +134,7 @@ export function InferenceProvider({
     return urlGpus ? urlGpus.split(',').filter(Boolean) : [];
   });
   const [selectedYAxisMetric, setSelectedYAxisMetric] = useState<string>(
-    () => getUrlParam('i_metric') || 'y_tpPerGpu',
+    () => getUrlParam('i_metric') || initialYAxisMetric || 'y_tpPerGpu',
   );
   const [selectedXAxisMetric, setSelectedXAxisMetric] = useState<string | null>(
     () => getUrlParam('i_xmetric') || 'p99_ttft',

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -30,18 +30,23 @@ export interface CompareModelSlug {
   label: string;
 }
 
+// Order matches the master /compare and /compare-per-dollar index display:
+// DeepSeek V4 Pro → R1 → Kimi → GLM → MiniMax → Qwen → gpt-oss → Llama 70B.
+// Per product spec — flagship Chinese-developed models first, smaller open
+// US-developed models at the bottom. Qwen sits between MiniMax and gpt-oss to
+// keep the Chinese-lab cluster contiguous before the US transition.
 export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
-  {
-    slug: 'deepseek-r1',
-    displayName: 'DeepSeek-R1-0528',
-    dbKeys: ['dsr1'],
-    label: 'DeepSeek R1',
-  },
   {
     slug: 'deepseek-v4',
     displayName: 'DeepSeek-V4-Pro',
     dbKeys: ['dsv4'],
     label: 'DeepSeek V4 Pro',
+  },
+  {
+    slug: 'deepseek-r1',
+    displayName: 'DeepSeek-R1-0528',
+    dbKeys: ['dsr1'],
+    label: 'DeepSeek R1',
   },
   {
     slug: 'kimi-k26',
@@ -54,12 +59,6 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     // Slug groups two point releases sharing one architecture — the header
     // surfaces both versions so the URL doesn't read as "only K2.6".
     label: 'Kimi K2.5/K2.6',
-  },
-  {
-    slug: 'qwen-3-5',
-    displayName: 'Qwen-3.5-397B-A17B',
-    dbKeys: ['qwen3.5'],
-    label: 'Qwen 3.5',
   },
   {
     slug: 'glm-5-1',
@@ -77,16 +76,22 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     label: 'MiniMax M2.5/M2.7',
   },
   {
-    slug: 'llama-3-3-70b',
-    displayName: 'Llama-3.3-70B-Instruct-FP8',
-    dbKeys: ['llama70b'],
-    label: 'Llama 3.3 70B',
+    slug: 'qwen-3-5',
+    displayName: 'Qwen-3.5-397B-A17B',
+    dbKeys: ['qwen3.5'],
+    label: 'Qwen 3.5',
   },
   {
     slug: 'gptoss-120b',
     displayName: 'gpt-oss-120b',
     dbKeys: ['gptoss120b'],
     label: 'gpt-oss 120B',
+  },
+  {
+    slug: 'llama-3-3-70b',
+    displayName: 'Llama-3.3-70B-Instruct-FP8',
+    dbKeys: ['llama70b'],
+    label: 'Llama 3.3 70B',
   },
 ];
 

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -1,0 +1,401 @@
+/**
+ * Server-side helpers shared between the `/compare` and `/compare-per-dollar`
+ * SSR routes. Extracted from `app/compare/[slug]/page.tsx` (PR #351, PR #382)
+ * when the second route was added so the two pages share:
+ *
+ *   - a single `getCachedBenchmarks` blob slot keyed by dbKeys (one cache
+ *     entry per model bucket regardless of which route triggered the fetch),
+ *   - the same FIXTURES_MODE / JSON_MODE / Neon ladder,
+ *   - the same summary, GPUDataPoint construction, interpolation pipeline,
+ *     and JSON-LD shape — with a `variant` knob that swaps the headline
+ *     framing between the latency+throughput view and the per-dollar view.
+ */
+import { HW_REGISTRY, sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
+import { FIXTURES_MODE, JSON_MODE, getDb } from '@semianalysisai/inferencex-db/connection';
+import * as jsonProvider from '@semianalysisai/inferencex-db/json-provider';
+import {
+  type BenchmarkRow,
+  getLatestBenchmarks,
+} from '@semianalysisai/inferencex-db/queries/benchmarks';
+
+import { interpolateForGPU } from '@/components/calculator/interpolation';
+import type { GPUDataPoint, InterpolatedResult } from '@/components/calculator/types';
+import { cachedQuery } from '@/lib/api-cache';
+import { rowToAggDataEntry } from '@/lib/benchmark-transform';
+import { getHardwareKey } from '@/lib/chart-utils';
+import { type CompareModelSlug, compareModelDisplayLabel } from '@/lib/compare-slug';
+import { getHardwareConfig, getGpuSpecs } from '@/lib/constants';
+import { loadFixture } from '@/lib/test-fixtures';
+
+// ---------------------------------------------------------------------------
+// Cached benchmark fetch
+// ---------------------------------------------------------------------------
+
+/** Cache slot is keyed on the dbKeys array. Both `/compare/<slug>` and
+ *  `/compare-per-dollar/<slug>` for the same model hit the same blob entry —
+ *  the per-dollar route doesn't duplicate the fetch or the cache. */
+export const getCachedBenchmarks = cachedQuery(
+  (dbModelKeys: string[]) => {
+    if (FIXTURES_MODE) return Promise.resolve(loadFixture<BenchmarkRow[]>('benchmarks'));
+    if (JSON_MODE) return Promise.resolve(jsonProvider.getLatestBenchmarks(dbModelKeys));
+    return getLatestBenchmarks(getDb(), dbModelKeys);
+  },
+  'benchmarks',
+  { blobOnly: true },
+);
+
+// ---------------------------------------------------------------------------
+// URL-param validators (shared by both routes' overrides)
+// ---------------------------------------------------------------------------
+
+export const KNOWN_MODELS = new Set([
+  'Llama-3.3-70B-Instruct-FP8',
+  'Llama-3.1-70B-Instruct-FP8-KV',
+  'DeepSeek-R1-0528',
+  'gpt-oss-120b',
+  'Qwen-3.5-397B-A17B',
+  'Kimi-K2.5',
+  'MiniMax-M2.5',
+  'GLM-5',
+  'DeepSeek-V4-Pro',
+]);
+export const KNOWN_SEQUENCES = new Set(['1k/1k', '1k/8k', '8k/1k']);
+export const KNOWN_PRECISIONS = new Set(['fp4', 'fp8', 'bf16', 'int4', 'nvfp4', 'mxfp4']);
+
+export function pickString(value: string | string[] | undefined): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return value[0];
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Pair summary (JSON-LD Product additionalProperty)
+// ---------------------------------------------------------------------------
+
+export interface PairSummary {
+  hardware: string;
+  configCount: number;
+  bestThroughputPerGpu: number | null;
+  bestMedianTtft: number | null;
+  bestMedianTpot: number | null;
+}
+
+export function summarize(rows: BenchmarkRow[], hw: string): PairSummary {
+  const hwRows = rows.filter((r) => r.hardware === hw);
+  let bestThroughput: number | null = null;
+  let bestTtft: number | null = null;
+  let bestTpot: number | null = null;
+  for (const row of hwRows) {
+    const m = row.metrics ?? {};
+    const tput = typeof m.tput_per_gpu === 'number' ? m.tput_per_gpu : null;
+    const ttft = typeof m.median_ttft === 'number' ? m.median_ttft : null;
+    const tpot = typeof m.median_tpot === 'number' ? m.median_tpot : null;
+    if (tput !== null && (bestThroughput === null || tput > bestThroughput)) bestThroughput = tput;
+    if (ttft !== null && (bestTtft === null || ttft < bestTtft)) bestTtft = ttft;
+    if (tpot !== null && (bestTpot === null || tpot < bestTpot)) bestTpot = tpot;
+  }
+  return {
+    hardware: hw,
+    configCount: hwRows.length,
+    bestThroughputPerGpu: bestThroughput,
+    bestMedianTtft: bestTtft,
+    bestMedianTpot: bestTpot,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GPUDataPoint construction + interpolation pipeline
+// ---------------------------------------------------------------------------
+
+/** Cost per million tokens: costPerHour / (tokPerSec * 3600 / 1_000_000) */
+const computeGpuCost = (costPerHour: number, tps: number) =>
+  costPerHour && tps > 0 ? costPerHour / ((tps * 3600) / 1_000_000) : 0;
+
+export interface SsrInterpolatedRow {
+  target: number;
+  a: InterpolatedResult | null;
+  b: InterpolatedResult | null;
+}
+
+function buildGpuDataPoints(
+  rows: BenchmarkRow[],
+  hw: string,
+  isl: number,
+  osl: number,
+  precision: string,
+): GPUDataPoint[] {
+  const points: GPUDataPoint[] = [];
+  for (const row of rows) {
+    if (row.hardware !== hw) continue;
+    if (row.isl !== isl || row.osl !== osl) continue;
+    if (row.precision !== precision) continue;
+
+    const entry = rowToAggDataEntry(row);
+    const hwKey = getHardwareKey(entry);
+    if (!getHardwareConfig(hwKey)) continue;
+
+    const m = row.metrics;
+    const tput = m.tput_per_gpu ?? 0;
+    const outputTput = m.output_tput_per_gpu ?? tput;
+    const inputTput = m.input_tput_per_gpu ?? 0;
+    const specs = getGpuSpecs(hwKey);
+    const power = specs.power;
+
+    points.push({
+      hwKey,
+      interactivity: m.median_intvty ?? 0,
+      throughput: tput,
+      outputThroughput: outputTput,
+      inputThroughput: inputTput,
+      concurrency: row.conc,
+      tp: row.decode_tp,
+      precision: row.precision,
+      ep: row.decode_ep,
+      dp_attention: row.decode_dp_attention,
+      disagg: row.disagg,
+      costh: computeGpuCost(specs.costh, tput),
+      costn: computeGpuCost(specs.costn, tput),
+      costr: computeGpuCost(specs.costr, tput),
+      costhi: computeGpuCost(specs.costh, inputTput),
+      costni: computeGpuCost(specs.costn, inputTput),
+      costri: computeGpuCost(specs.costr, inputTput),
+      costhOutput: computeGpuCost(specs.costh, outputTput),
+      costnOutput: computeGpuCost(specs.costn, outputTput),
+      costrOutput: computeGpuCost(specs.costr, outputTput),
+      tpPerMw: power && power > 0 ? (tput * 1000) / power : 0,
+      inputTpPerMw: power && power > 0 ? (inputTput * 1000) / power : 0,
+      outputTpPerMw: power && power > 0 ? (outputTput * 1000) / power : 0,
+    });
+  }
+  return points;
+}
+
+function interactivityRangeOf(pts: GPUDataPoint[]): { min: number; max: number } | null {
+  if (pts.length === 0) return null;
+  let min = Infinity;
+  let max = -Infinity;
+  for (const p of pts) {
+    if (p.interactivity < min) min = p.interactivity;
+    if (p.interactivity > max) max = p.interactivity;
+  }
+  return { min, max };
+}
+
+/** Pre-compute interpolated table data for the GPU pair at 3 interactivity
+ *  targets (25th, 50th, 75th percentile) within the overlapping range. */
+export function computeCompareTableData(
+  rows: BenchmarkRow[],
+  a: string,
+  b: string,
+  sequence: string | null,
+  precision: string | null,
+): {
+  defaultTargets: number[];
+  ssrRows: SsrInterpolatedRow[];
+  interactivityRange: { min: number; max: number };
+} {
+  const empty = { defaultTargets: [], ssrRows: [], interactivityRange: { min: 0, max: 100 } };
+  if (!sequence || !precision) return empty;
+
+  const islOsl = sequenceToIslOsl(sequence);
+  if (!islOsl) return empty;
+
+  const pointsA = buildGpuDataPoints(rows, a, islOsl.isl, islOsl.osl, precision);
+  const pointsB = buildGpuDataPoints(rows, b, islOsl.isl, islOsl.osl, precision);
+
+  if (pointsA.length === 0 && pointsB.length === 0) return empty;
+
+  const rangeA = interactivityRangeOf(pointsA);
+  const rangeB = interactivityRangeOf(pointsB);
+
+  let globalMin: number, globalMax: number;
+  if (rangeA && rangeB) {
+    globalMin = Math.max(rangeA.min, rangeB.min);
+    globalMax = Math.min(rangeA.max, rangeB.max);
+    if (globalMin >= globalMax) {
+      globalMin = Math.min(rangeA.min, rangeB.min);
+      globalMax = Math.max(rangeA.max, rangeB.max);
+    }
+  } else {
+    const r = rangeA ?? rangeB!;
+    globalMin = r.min;
+    globalMax = r.max;
+  }
+
+  const interactivityRange = {
+    min: Math.ceil(globalMin),
+    max: Math.floor(globalMax),
+  };
+
+  const span = globalMax - globalMin;
+  const defaultTargets =
+    span > 0
+      ? [
+          Math.round(globalMin + span * 0.25),
+          Math.round(globalMin + span * 0.5),
+          Math.round(globalMin + span * 0.75),
+        ]
+      : [Math.round(globalMin)];
+
+  const ssrRows: SsrInterpolatedRow[] = defaultTargets.map((target) => ({
+    target,
+    a:
+      pointsA.length > 0
+        ? interpolateForGPU(pointsA, target, 'interactivity_to_throughput', 'costh')
+        : null,
+    b:
+      pointsB.length > 0
+        ? interpolateForGPU(pointsB, target, 'interactivity_to_throughput', 'costh')
+        : null,
+  }));
+
+  return { defaultTargets, ssrRows, interactivityRange };
+}
+
+// ---------------------------------------------------------------------------
+// JSON-LD graph
+// ---------------------------------------------------------------------------
+
+function jsonLdEntryFor(key: string, summary: PairSummary, position: number) {
+  const meta = HW_REGISTRY[key];
+  const label = meta?.label ?? key.toUpperCase();
+  const props: { name: string; value: string | number }[] = [];
+  if (meta) {
+    props.push({ name: 'Vendor', value: meta.vendor });
+    props.push({ name: 'Architecture', value: meta.arch });
+    props.push({ name: 'TDP (W)', value: meta.tdp });
+  }
+  if (summary.bestThroughputPerGpu !== null) {
+    props.push({
+      name: 'Best Throughput per GPU (tok/s)',
+      value: Number(summary.bestThroughputPerGpu.toFixed(2)),
+    });
+  }
+  if (summary.bestMedianTtft !== null) {
+    props.push({
+      name: 'Best Median TTFT (s)',
+      value: Number(summary.bestMedianTtft.toFixed(3)),
+    });
+  }
+  if (summary.bestMedianTpot !== null) {
+    props.push({
+      name: 'Best Median TPOT (s)',
+      value: Number(summary.bestMedianTpot.toFixed(4)),
+    });
+  }
+  props.push({ name: 'Benchmark Configurations', value: summary.configCount });
+  return {
+    '@type': 'ListItem',
+    position,
+    item: {
+      '@type': 'Product',
+      name: label,
+      brand: { '@type': 'Brand', name: meta?.vendor ?? 'Unknown' },
+      category: 'GPU',
+      ...(props.length > 0 && {
+        additionalProperty: props.map((p) => ({
+          '@type': 'PropertyValue',
+          name: p.name,
+          value: p.value,
+        })),
+      }),
+    },
+  };
+}
+
+/** Variant determines the ItemList/Dataset headline framing in JSON-LD.
+ *  `'full'` is the /compare page's latency+throughput+cost framing.
+ *  `'per-dollar'` is the /compare-per-dollar page's cost-efficiency framing. */
+export type CompareJsonLdVariant = 'full' | 'per-dollar';
+
+export function buildJsonLd(
+  variant: CompareJsonLdVariant,
+  model: CompareModelSlug,
+  a: string,
+  b: string,
+  url: string,
+  summaryA: PairSummary,
+  summaryB: PairSummary,
+  ssrRows: SsrInterpolatedRow[],
+) {
+  const aLabel = HW_REGISTRY[a]?.label ?? a.toUpperCase();
+  const bLabel = HW_REGISTRY[b]?.label ?? b.toUpperCase();
+  const fullLabel = compareModelDisplayLabel(model, a, b);
+
+  const itemListName =
+    variant === 'per-dollar'
+      ? `${fullLabel} — Performance per Dollar`
+      : `${fullLabel} Inference Benchmark`;
+  const itemListDescription =
+    variant === 'per-dollar'
+      ? `Cost per million tokens of ${aLabel} versus ${bLabel} on ${model.label}. GPU performance normalized by owning-hyperscaler TCO across LLM workloads.`
+      : `Head-to-head AI inference benchmark comparison of ${aLabel} and ${bLabel} on ${model.label} across LLM workloads.`;
+  const datasetName =
+    variant === 'per-dollar'
+      ? `${aLabel} vs ${bLabel} (${model.label}) Performance-per-Dollar Comparison`
+      : `${aLabel} vs ${bLabel} (${model.label}) Interpolated Benchmark Comparison`;
+  const datasetDescription =
+    variant === 'per-dollar'
+      ? `Owning-hyperscaler cost per million tokens for ${aLabel} and ${bLabel} on ${model.label} at matched interactivity levels — dollar-normalized inference benchmark.`
+      : `Interpolated throughput, cost, power efficiency, and concurrency for ${aLabel} and ${bLabel} on ${model.label} at matched interactivity levels.`;
+
+  const comparisonRows = ssrRows
+    .filter((row) => row.a || row.b)
+    .map((row) => {
+      const metrics: { name: string; value: string }[] = [
+        { name: 'Model', value: model.displayName },
+        { name: 'Target Interactivity (tok/s/user)', value: String(row.target) },
+      ];
+      if (row.a) {
+        metrics.push(
+          { name: `${aLabel} Throughput (tok/s/gpu)`, value: row.a.value.toFixed(1) },
+          { name: `${aLabel} Cost ($/M tok)`, value: row.a.cost.toFixed(3) },
+          { name: `${aLabel} tok/s/MW`, value: row.a.tpPerMw.toFixed(0) },
+          { name: `${aLabel} Concurrency`, value: String(Math.round(row.a.concurrency)) },
+        );
+      }
+      if (row.b) {
+        metrics.push(
+          { name: `${bLabel} Throughput (tok/s/gpu)`, value: row.b.value.toFixed(1) },
+          { name: `${bLabel} Cost ($/M tok)`, value: row.b.cost.toFixed(3) },
+          { name: `${bLabel} tok/s/MW`, value: row.b.tpPerMw.toFixed(0) },
+          { name: `${bLabel} Concurrency`, value: String(Math.round(row.b.concurrency)) },
+        );
+      }
+      return {
+        '@type': 'Observation',
+        name: `${model.label} comparison at ${row.target} tok/s/user interactivity`,
+        variableMeasured: metrics.map((m) => ({
+          '@type': 'PropertyValue',
+          name: m.name,
+          value: m.value,
+        })),
+      };
+    });
+
+  return {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'ItemList',
+        name: itemListName,
+        description: itemListDescription,
+        url,
+        itemListOrder: 'https://schema.org/ItemListOrderAscending',
+        numberOfItems: 2,
+        itemListElement: [jsonLdEntryFor(a, summaryA, 1), jsonLdEntryFor(b, summaryB, 2)],
+      },
+      ...(comparisonRows.length > 0
+        ? [
+            {
+              '@type': 'Dataset',
+              name: datasetName,
+              description: datasetDescription,
+              url,
+              hasPart: comparisonRows,
+            },
+          ]
+        : []),
+    ],
+  };
+}

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -338,7 +338,16 @@ function fmtPctDelta(ratio: number): string {
  *  the points readers care about), or falls back to a single-GPU description
  *  at the mid row if there's no overlap. Template differs by variant —
  *  `'full'` mentions both cost and throughput; `'per-dollar'` focuses on cost
- *  and references the table for the rest. */
+ *  and references the table for the rest.
+ *
+ *  The returned prose anchors to the SSR'd default model / sequence /
+ *  precision — i.e. the slug's canonical operating point. The chart and
+ *  interpolated table beneath the narrative re-render on client-side filter
+ *  changes; the narrative does not. This is intentional: the URL slug *is*
+ *  the canonical view, and the narrative is the canonical view's prose
+ *  summary. The caller adds a small "(default configuration)" caveat after
+ *  the narrative so a reader who fiddles with the chart controls sees that
+ *  the narrative is fixed to the slug's defaults. */
 export function compareTableNarrative(
   variant: CompareJsonLdVariant,
   modelLabel: string,

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -308,6 +308,85 @@ function jsonLdEntryFor(key: string, summary: PairSummary, position: number) {
  *  `'per-dollar'` is the /compare-per-dollar page's cost-efficiency framing. */
 export type CompareJsonLdVariant = 'full' | 'per-dollar';
 
+// ---------------------------------------------------------------------------
+// Plain-English table narrative
+// ---------------------------------------------------------------------------
+
+/** Format cost as $X.XX or $X.X depending on magnitude. */
+function fmtCost(v: number): string {
+  if (v >= 10) return `$${v.toFixed(1)}`;
+  return `$${v.toFixed(2)}`;
+}
+
+/** Round a ratio (always ≥ 1) into a percentage delta, e.g. 1.3 → "30%". */
+function fmtPctDelta(ratio: number): string {
+  return `${Math.round((ratio - 1) * 100)}%`;
+}
+
+/** Per-route prose summary of the interpolated table. Server-rendered into
+ *  the page HTML so crawlers and screen-readers get a plain-English read of
+ *  the headline number alongside the table data. Returns null when there's
+ *  no comparable data to describe (caller falls back to the empty-state UI).
+ *
+ *  Picks the middle target where both GPUs have data (preferred), or the
+ *  middle target with data on either side, and describes that operating
+ *  point. Template differs by variant — `'full'` mentions both cost and
+ *  throughput; `'per-dollar'` focuses on cost and references the table for
+ *  the rest. */
+export function compareTableNarrative(
+  variant: CompareJsonLdVariant,
+  modelLabel: string,
+  aLabel: string,
+  bLabel: string,
+  ssrRows: SsrInterpolatedRow[],
+  interactivityRange: { min: number; max: number },
+): string | null {
+  if (ssrRows.length === 0) return null;
+
+  // Prefer the first row with data on BOTH sides — those are the comparison
+  // points readers care about. Fall back to the mid row if there's no overlap.
+  const both = ssrRows.find((r) => r.a && r.b);
+  const row = both ?? ssrRows[Math.floor(ssrRows.length / 2)];
+  const { target, a, b } = row;
+  if (!a && !b) return null;
+
+  const range = `${interactivityRange.min}–${interactivityRange.max} tok/s/user`;
+
+  if (variant === 'per-dollar') {
+    if (a && b) {
+      const aCheaper = a.cost < b.cost;
+      const cheaper = aCheaper ? aLabel : bLabel;
+      const pricier = aCheaper ? bLabel : aLabel;
+      const ratio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
+      // Within ~1% the cost is effectively tied — say so rather than rounding
+      // to "0% more cost-efficient" which reads wrong.
+      if (ratio < 1.01) {
+        return `On ${modelLabel}, ${aLabel} and ${bLabel} land within ~1% of each other on cost per million tokens at ${target} tok/s/user interactivity (${fmtCost(a.cost)} vs. ${fmtCost(b.cost)}). Across the ${range} interactivity range we benchmarked, see the interpolated table below for the points where one pulls ahead.`;
+      }
+      return `On ${modelLabel}, ${aLabel} costs ${fmtCost(a.cost)} per million tokens at ${target} tok/s/user interactivity; ${bLabel} costs ${fmtCost(b.cost)} per million tokens at the same target. ${cheaper} is ${fmtPctDelta(ratio)} more cost-efficient than ${pricier} at this operating point — across the ${range} interactivity range we benchmarked, see the interpolated table below for how the gap moves across the full Pareto frontier.`;
+    }
+    const present = (a ?? b)!;
+    const presentLabel = a ? aLabel : bLabel;
+    const missingLabel = a ? bLabel : aLabel;
+    return `On ${modelLabel}, ${presentLabel} costs ${fmtCost(present.cost)} per million tokens at ${target} tok/s/user interactivity. We don't have ${missingLabel} benchmark data at this exact operating point — see the interpolated table below for the targets where both GPUs are measurable.`;
+  }
+
+  // 'full' variant — mention cost AND throughput
+  if (a && b) {
+    const aCheaper = a.cost < b.cost;
+    const cheaper = aCheaper ? aLabel : bLabel;
+    const costRatio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
+    const aFaster = a.value > b.value;
+    const faster = aFaster ? aLabel : bLabel;
+    const tputRatio = aFaster ? a.value / b.value : b.value / a.value;
+    return `On ${modelLabel}, at ${target} tok/s/user interactivity (the middle of the ${range} range benchmarked), ${aLabel} delivers ${a.value.toFixed(0)} tok/s/GPU at ${fmtCost(a.cost)} per million tokens, while ${bLabel} delivers ${b.value.toFixed(0)} tok/s/GPU at ${fmtCost(b.cost)} per million tokens. ${cheaper} is ${fmtPctDelta(costRatio)} cheaper per token at this operating point; ${faster} delivers ${fmtPctDelta(tputRatio)} more tok/s/GPU — use the interpolated table below to see how the comparison shifts at higher and lower interactivity.`;
+  }
+  const present = (a ?? b)!;
+  const presentLabel = a ? aLabel : bLabel;
+  const missingLabel = a ? bLabel : aLabel;
+  return `On ${modelLabel}, ${presentLabel} delivers ${present.value.toFixed(0)} tok/s/GPU at ${fmtCost(present.cost)} per million tokens at ${target} tok/s/user interactivity. We don't have ${missingLabel} benchmark data at this exact operating point — see the interpolated table below for the targets where both GPUs are measurable.`;
+}
+
 export function buildJsonLd(
   variant: CompareJsonLdVariant,
   model: CompareModelSlug,

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -23,7 +23,13 @@ import type { GPUDataPoint, InterpolatedResult } from '@/components/calculator/t
 import { cachedQuery } from '@/lib/api-cache';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import { getHardwareKey } from '@/lib/chart-utils';
-import { type CompareModelSlug, compareModelDisplayLabel } from '@/lib/compare-slug';
+import {
+  canonicalCompareSlug,
+  compareDisplayLabel,
+  type ComparePair,
+  type CompareModelSlug,
+  compareModelDisplayLabel,
+} from '@/lib/compare-slug';
 import { getHardwareConfig, getGpuSpecs } from '@/lib/constants';
 import { loadFixture } from '@/lib/test-fixtures';
 
@@ -328,11 +334,11 @@ function fmtPctDelta(ratio: number): string {
  *  the headline number alongside the table data. Returns null when there's
  *  no comparable data to describe (caller falls back to the empty-state UI).
  *
- *  Picks the middle target where both GPUs have data (preferred), or the
- *  middle target with data on either side, and describes that operating
- *  point. Template differs by variant — `'full'` mentions both cost and
- *  throughput; `'per-dollar'` focuses on cost and references the table for
- *  the rest. */
+ *  Picks the first interactivity target where both GPUs have data (those are
+ *  the points readers care about), or falls back to a single-GPU description
+ *  at the mid row if there's no overlap. Template differs by variant —
+ *  `'full'` mentions both cost and throughput; `'per-dollar'` focuses on cost
+ *  and references the table for the rest. */
 export function compareTableNarrative(
   variant: CompareJsonLdVariant,
   modelLabel: string,
@@ -343,8 +349,6 @@ export function compareTableNarrative(
 ): string | null {
   if (ssrRows.length === 0) return null;
 
-  // Prefer the first row with data on BOTH sides — those are the comparison
-  // points readers care about. Fall back to the mid row if there's no overlap.
   const both = ssrRows.find((r) => r.a && r.b);
   const row = both ?? ssrRows[Math.floor(ssrRows.length / 2)];
   const { target, a, b } = row;
@@ -354,6 +358,12 @@ export function compareTableNarrative(
 
   if (variant === 'per-dollar') {
     if (a && b) {
+      // Guard against zero costs (HW_REGISTRY.costh == 0 or zero throughput
+      // upstream): the ratio math would emit Infinity / NaN. Fall through to
+      // a values-only summary instead of dividing.
+      if (!(a.cost > 0 && b.cost > 0)) {
+        return `On ${modelLabel}, ${aLabel} and ${bLabel} register cost-per-token values of ${fmtCost(a.cost)} and ${fmtCost(b.cost)} respectively at ${target} tok/s/user interactivity. At least one side has missing pricing or throughput data, so a like-for-like ratio isn't meaningful at this point — see the interpolated table below for targets with both inputs populated.`;
+      }
       const aCheaper = a.cost < b.cost;
       const cheaper = aCheaper ? aLabel : bLabel;
       const pricier = aCheaper ? bLabel : aLabel;
@@ -373,18 +383,92 @@ export function compareTableNarrative(
 
   // 'full' variant — mention cost AND throughput
   if (a && b) {
-    const aCheaper = a.cost < b.cost;
-    const cheaper = aCheaper ? aLabel : bLabel;
-    const costRatio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
-    const aFaster = a.value > b.value;
-    const faster = aFaster ? aLabel : bLabel;
-    const tputRatio = aFaster ? a.value / b.value : b.value / a.value;
-    return `On ${modelLabel}, at ${target} tok/s/user interactivity (the middle of the ${range} range benchmarked), ${aLabel} delivers ${a.value.toFixed(0)} tok/s/GPU at ${fmtCost(a.cost)} per million tokens, while ${bLabel} delivers ${b.value.toFixed(0)} tok/s/GPU at ${fmtCost(b.cost)} per million tokens. ${cheaper} is ${fmtPctDelta(costRatio)} cheaper per token at this operating point; ${faster} delivers ${fmtPctDelta(tputRatio)} more tok/s/GPU — use the interpolated table below to see how the comparison shifts at higher and lower interactivity.`;
+    // Two independent comparisons (cost, throughput): tie-handling and
+    // zero-guard applied separately so a tie on one dimension doesn't
+    // suppress the other side of the sentence.
+    const costPart = (() => {
+      if (!(a.cost > 0 && b.cost > 0)) return null;
+      const aCheaper = a.cost < b.cost;
+      const cheaper = aCheaper ? aLabel : bLabel;
+      const ratio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
+      if (ratio < 1.01) return 'cost per token is essentially tied';
+      return `${cheaper} is ${fmtPctDelta(ratio)} cheaper per token`;
+    })();
+    const tputPart = (() => {
+      if (!(a.value > 0 && b.value > 0)) return null;
+      const aFaster = a.value > b.value;
+      const faster = aFaster ? aLabel : bLabel;
+      const ratio = aFaster ? a.value / b.value : b.value / a.value;
+      if (ratio < 1.01) return 'throughput per GPU is essentially tied';
+      return `${faster} delivers ${fmtPctDelta(ratio)} more tok/s/GPU`;
+    })();
+    const summary = [costPart, tputPart].filter(Boolean).join('; ');
+    const summarySentence = summary
+      ? ` ${summary.charAt(0).toUpperCase() + summary.slice(1)} at this operating point — `
+      : ' ';
+    return `On ${modelLabel}, at ${target} tok/s/user interactivity (within the ${range} range benchmarked), ${aLabel} delivers ${a.value.toFixed(0)} tok/s/GPU at ${fmtCost(a.cost)} per million tokens, while ${bLabel} delivers ${b.value.toFixed(0)} tok/s/GPU at ${fmtCost(b.cost)} per million tokens.${summarySentence}use the interpolated table below to see how the comparison shifts at higher and lower interactivity.`;
   }
   const present = (a ?? b)!;
   const presentLabel = a ? aLabel : bLabel;
   const missingLabel = a ? bLabel : aLabel;
   return `On ${modelLabel}, ${presentLabel} delivers ${present.value.toFixed(0)} tok/s/GPU at ${fmtCost(present.cost)} per million tokens at ${target} tok/s/user interactivity. We don't have ${missingLabel} benchmark data at this exact operating point — see the interpolated table below for the targets where both GPUs are measurable.`;
+}
+
+// ---------------------------------------------------------------------------
+// Master-index helpers (shared by /compare and /compare-per-dollar)
+// ---------------------------------------------------------------------------
+
+/** "A", "A and B", or "A, B, and C" — Oxford-comma serial join. Used by the
+ *  master index ledes on both /compare and /compare-per-dollar so the
+ *  enumeration stays consistent if a model is added or removed. */
+export function formatModelList(models: CompareModelSlug[]): string {
+  const labels = models.map((m) => m.label);
+  if (labels.length === 0) return 'no models';
+  if (labels.length === 1) return labels[0];
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
+}
+
+export interface VendorBucketEntry {
+  a: string;
+  b: string;
+  slug: string;
+  label: string;
+}
+
+export interface VendorBuckets {
+  /** Cross-vendor pairs (NVIDIA × AMD). */
+  cross: VendorBucketEntry[];
+  /** Both sides NVIDIA. */
+  nvidia: VendorBucketEntry[];
+  /** Both sides AMD. */
+  amd: VendorBucketEntry[];
+}
+
+/** Split (a, b) GPU pairs into vendor buckets for the index grid. The caller
+ *  wraps these entries with its own group headings / descriptions / route
+ *  prefix — keeps the sorting + bucketing + slug-building in one place so the
+ *  two index pages can't drift on those mechanics. */
+export function bucketComparePairsByVendor(modelSlug: string, pairs: ComparePair[]): VendorBuckets {
+  const nvidia: VendorBucketEntry[] = [];
+  const amd: VendorBucketEntry[] = [];
+  const cross: VendorBucketEntry[] = [];
+
+  for (const { a, b } of pairs) {
+    const entry: VendorBucketEntry = {
+      a,
+      b,
+      slug: canonicalCompareSlug(modelSlug, a, b),
+      label: compareDisplayLabel(a, b),
+    };
+    const vA = HW_REGISTRY[a]?.vendor;
+    const vB = HW_REGISTRY[b]?.vendor;
+    if (vA === 'NVIDIA' && vB === 'NVIDIA') nvidia.push(entry);
+    else if (vA === 'AMD' && vB === 'AMD') amd.push(entry);
+    else cross.push(entry);
+  }
+
+  return { cross, nvidia, amd };
 }
 
 export function buildJsonLd(


### PR DESCRIPTION
## Summary

Adds `/compare-per-dollar/<model>-<a>-vs-<b>` as a perf-per-dollar SSR sibling to `/compare/<...>` (PR #351, PR #382). Same data, same slug parsing, same redirect chain, same availability filter — narrowed to the cost-efficiency view.

Each per-dollar slug page differs from `/compare/<same-slug>` only in:

- **Comparison table**: shows only `Cost ($/M tok)` + `Concurrency` rows (was 4 rows: Throughput, Cost, tok/s/MW, Concurrency)
- **Chart y-axis default**: `y_costh` (Cost per Million Total Tokens — Owning Hyperscaler) instead of `y_tpPerGpu`
- **Title / header / metadata / OG / JSON-LD**: \"Performance per Dollar\" framing — SEO terms: _performance per dollar_, _performance normalized by cost_, _dollars per million tokens_, _owning-hyperscaler TCO_, _cost-efficient GPU inference_

Both routes cross-link to each other in the slug page header so users (and crawlers) move freely between the two views.

## URL shape

| Form | Example | Behavior |
| --- | --- | --- |
| **Canonical** | \`/compare-per-dollar/kimi-k26-h100-vs-h200\` | 200, slimmed table + cost chart |
| **Bare slug** | \`/compare-per-dollar/h100-vs-h200\` | 308 → \`/compare-per-dollar/deepseek-r1-h100-vs-h200\` |
| **Family alias** | \`/compare-per-dollar/kimi-h100-vs-h200\` | 308 → \`/compare-per-dollar/kimi-k26-h100-vs-h200\` |
| **Older-version alias** | \`/compare-per-dollar/kimi-k25-h100-vs-h200\` | 308 → \`/compare-per-dollar/kimi-k26-h100-vs-h200\` |
| **Same-arch supersession** | \`/compare-per-dollar/glm-5-h100-vs-h200\` | 308 → \`/compare-per-dollar/glm-5-1-h100-vs-h200\` |
| **Non-canonical GPU order** | \`/compare-per-dollar/deepseek-r1-h200-vs-h100\` | 308 → \`/compare-per-dollar/deepseek-r1-h100-vs-h200\` |
| **Master index** | \`/compare-per-dollar\` | 200, 8 model sections × NVIDIA/AMD/cross-vendor sub-grids |

All redirects preserve the query string. The bare-slug fallback target lives under `/compare-per-dollar/`, not `/compare/` — the two routes have independent redirect chains.

## Shared SSR helpers (`@/lib/compare-ssr.ts`)

`getCachedBenchmarks`, `summarize` + `PairSummary`, `computeCompareTableData`, `buildJsonLd`, `KNOWN_MODELS`/`KNOWN_SEQUENCES`/`KNOWN_PRECISIONS` validators, and `pickString` extracted out of `compare/[slug]/page.tsx` into a new shared module. Three benefits:

1. **One cache slot per dbKey set** — `cachedQuery(fn, 'benchmarks', { blobOnly: true })` is now defined once, so `/compare/kimi-k26-...` and `/compare-per-dollar/kimi-k26-...` hit the same Vercel Blob entry. No duplicate fetches when both routes are crawled.
2. **No duplicated FIXTURES_MODE / JSON_MODE / Neon ladder.**
3. `buildJsonLd(variant: 'full' | 'per-dollar', ...)` swaps `ItemList.name` / `Dataset.name` / descriptions so structured-data signals match the page framing.

## Master index — availability-filtered

Mirrors `/compare`'s per-model card grid using `getComparablePairsByModelSlug()` from `@/lib/compare-availability`. Only (model, GPU-pair) combos with benchmark data on both sides become cards. Cardinality matches `/compare` exactly (165 cards).

## Sitemap

`packages/app/src/app/sitemap.ts` jumps from 184 → 350 URL entries:

- 165 `/compare/<canonical>` (unchanged)
- 165 `/compare-per-dollar/<canonical>` (new — same `getAllComparableCompareSlugs()` source)
- 1 standalone `/compare-per-dollar` index (priority 0.8)

## Component-level changes

- `CompareInterpolatedTable` gains an optional \`visibleMetricLabels?: string[]\` prop. When set, only metric rows whose `label` is in the list are rendered. Default (prop omitted) is unchanged — all four rows. `/compare` callers omit; per-dollar passes `['Cost ($/M tok)', 'Concurrency']`. Two-line change.
- `InferenceProvider` gains an optional \`initialYAxisMetric?: string\` prop. The state initializer becomes `getUrlParam('i_metric') || initialYAxisMetric || 'y_tpPerGpu'` — URL param still wins, so existing share-links are unaffected. `/compare-per-dollar` passes `y_costh`; everywhere else omits. One-line change.

## Verification

Local dev (Neon URL, blob vars unset to bypass the stale dev token):

\`\`\`
/compare                                              → 200
/compare-per-dollar                                   → 200, 8 model sections, all 165 cards
/compare/deepseek-r1-h100-vs-h200                     → 200, 4 metric rows
/compare-per-dollar/deepseek-r1-h100-vs-h200          → 200, 2 metric rows (Cost + Concurrency)
/compare-per-dollar/kimi-k26-mi300x-vs-mi355x         → 200
/compare-per-dollar/glm-5-1-h100-vs-mi355x            → 200
/compare-per-dollar/minimax-m27-mi300x-vs-mi355x      → 200
/sitemap.xml                                          → 200, 350 entries (165 + 165 + 20 other)
/compare-per-dollar/h100-vs-h200                      → 308 → /compare-per-dollar/deepseek-r1-h100-vs-h200
/compare-per-dollar/glm-5-h100-vs-h200                → 308 → /compare-per-dollar/glm-5-1-h100-vs-h200
/compare-per-dollar/minimax-m25-h100-vs-h200          → 308 → /compare-per-dollar/minimax-m27-h100-vs-h200
/compare-per-dollar/kimi-k25-h100-vs-h200             → 308 → /compare-per-dollar/kimi-k26-h100-vs-h200
/compare-per-dollar/deepseek-r1-h200-vs-h100          → 308 → /compare-per-dollar/deepseek-r1-h100-vs-h200
\`\`\`

Googlebot-UA SSR check on a slug page:

\`\`\`
<title>Kimi K2.5/K2.6 — MI300X vs MI355X — Performance per Dollar | InferenceX by SemiAnalysis</title>
<link rel="canonical" href="https://inferencex.semianalysis.com/compare-per-dollar/kimi-k26-mi300x-vs-mi355x"/>
<meta name="description" content="Kimi K2.5/K2.6 cost per million tokens on MI300X vs MI355X. Performance normalized by owning-hyperscaler TCO — see which GPU delivers more inference dollars-per-token at every interactivity level."/>
JSON-LD blocks: 2 (Organization/WebSite/SoftwareApplication graph + ItemList \"Kimi K2.5/K2.6 — MI300X vs MI355X — Performance per Dollar\" + Dataset \"...Performance-per-Dollar Comparison\")
Table tbody metric rows: ['Cost ($/M tok)', 'Concurrency']  ← filtered correctly
Cross-link to /compare/kimi-k26-mi300x-vs-mi355x: present
\`\`\`

Regression check on the existing `/compare` side:

\`\`\`
/compare/kimi-k26-mi300x-vs-mi355x table tbody: ['Throughput (tok/s/gpu)', 'Cost ($/M tok)', 'tok/s/MW', 'Concurrency']  ← unchanged
Cross-link to /compare-per-dollar/kimi-k26-mi300x-vs-mi355x: present
\`\`\`

44/44 unit tests pass (`compare-slug.test.ts` + `compare-interpolated-table.test.ts`). Pre-commit hook ran oxlint + oxfmt + tsc cleanly.

## Tests

- **\`cypress/e2e/compare-per-dollar-redirect.cy.ts\`** — 9 cases mirroring \`compare-redirect.cy.ts\`: canonical served direct, reversed GPU order, bare slug → deepseek-r1 default, bare + reversed in one hop, family alias, older-version alias (kimi-k25 → kimi-k26), same-arch alias (glm-5 → glm-5-1), query-param preservation, non-deepseek canonical. All redirect targets verified to land under \`/compare-per-dollar/\`, not \`/compare/\`.
- **\`cypress/e2e/compare-per-dollar-table.cy.ts\`** — asserts only Cost + Concurrency rows visible, Throughput/tok-MW absent, cross-link to \`/compare/<same-slug>\` present, \"Performance per Dollar\" framing in header. Also asserts the reciprocal cross-link from \`/compare\` to \`/compare-per-dollar\` exists.

## Test plan

- [ ] Click-through Vercel preview: visit \`/compare-per-dollar\` and confirm 8 model sections + 165 cards
- [ ] Visit \`/compare-per-dollar/deepseek-r1-h100-vs-h200\` → 2-row table, chart y-axis defaults to \"Cost per Million Total Tokens (Owning - Hyperscaler)\"
- [ ] Click cross-link from per-dollar → compare and back, confirm both directions work
- [ ] Visit \`/compare-per-dollar/h100-vs-h200\` and confirm the URL bar updates to the deepseek-r1 canonical
- [ ] \`curl /sitemap.xml | grep -c '/compare-per-dollar/'\` returns 166 (165 slugs + 1 index)
- [ ] OG image at \`/compare-per-dollar/<slug>/opengraph-image\` renders with \"Performance per Dollar\" eyebrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface area (new routes, sitemap doubling, shared SSR refactor) but behavior largely mirrors existing `/compare`; main risk is redirect/SEO duplication or cache/shared-helper regressions affecting both routes.
> 
> **Overview**
> Adds **`/compare-per-dollar`** as a cost-efficiency sibling to **`/compare`**: same slug parsing, 308 canonicalization (under its own path prefix), availability-filtered index, per-slug SSR, OG images, and **~165 new sitemap URLs** mirroring existing compare pairs.
> 
> Per-dollar slug pages narrow the UX to **performance per dollar**—default chart metric **`y_costh`**, interpolated table limited to **cost + concurrency** (with a friendlier cost row label), **owning-hyperscaler $/GPU/hr** in the header, and SEO copy/JSON-LD framed for cost per million tokens. **`/compare`** gains matching **SSR narratives**, **bidirectional cross-links** between the two views, and a **“Per Dollar”** nav item with fixed active-state so it doesn’t highlight **Comparisons** on per-dollar routes.
> 
> Shared compare SSR logic moves into **`@/lib/compare-ssr`** (single benchmark cache, table interpolation, narratives, vendor bucketing, variant-aware JSON-LD). **`CompareInterpolatedTable`** and **`InferenceProvider`** accept optional props for metric filtering and default Y-axis. **`COMPARE_MODEL_SLUGS`** display order is reordered. Cypress covers redirects, table rows, and cross-links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf6722919fdf12984e493841b7e96a193fccb57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->