### PR TITLE
feat(compare): 3 narrative paragraphs per slug page with templated variety

### DIFF
--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -31,9 +31,12 @@ interface ComparePerDollarPageClientProps {
   defaultSequence: string | null;
   defaultPrecision: string | null;
   ssrTableData: SsrTableData;
-  /** SSR-rendered plain-English summary of the dollar-per-million-tokens table
-   *  at the mid target. Null when there's no comparable data. */
-  narrative: string | null;
+  /** One SSR-rendered prose paragraph per interpolated-table row (default
+   *  interactivity target). Each paragraph picks a template variant
+   *  deterministically from the slug so prose stays stable across renders
+   *  but varies across pages in the catalog. Empty array when there's no
+   *  comparable data. */
+  narrative: string[];
   aLabel: string;
   bLabel: string;
   aVendor: string;
@@ -138,18 +141,28 @@ export default function ComparePerDollarPageClient({
                 </Link>
                 .
               </p>
-              {narrative && (
-                <p
-                  className="mt-3 text-sm text-foreground/80 max-w-3xl"
+              {narrative.length > 0 && (
+                <div
+                  className="mt-3 flex flex-col gap-2 max-w-3xl"
                   data-testid="compare-per-dollar-narrative"
                 >
-                  {narrative}{' '}
-                  <span className="text-muted-foreground italic">
-                    (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
-                    {defaultPrecision ?? 'precision'} selection for this URL — table and chart below
-                    update if you change sequence, precision, or model in the controls.)
-                  </span>
-                </p>
+                  {narrative.map((para, i) => (
+                    <p key={i} className="text-sm text-foreground/80">
+                      {para}
+                      {i === narrative.length - 1 && (
+                        <>
+                          {' '}
+                          <span className="text-muted-foreground italic">
+                            (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
+                            {defaultPrecision ?? 'precision'} selection for this URL — table and
+                            chart below update if you change sequence, precision, or model in the
+                            controls.)
+                          </span>
+                        </>
+                      )}
+                    </p>
+                  ))}
+                </div>
               )}
               {(aCostPerGpuHr > 0 || bCostPerGpuHr > 0) && (
                 <p

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -12,7 +12,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek R1, Kimi K2.5/K2.6, GLM 5/5.1, Qwen 3.5, and more. Pick the cheapest SKU for your workload.';
+  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more. Pick the cheapest SKU for your workload.';
 
 export const metadata: Metadata = {
   title: 'GPU Performance per Dollar',

--- a/packages/app/src/app/compare/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare/[slug]/page-client.tsx
@@ -34,9 +34,12 @@ interface ComparePageClientProps {
   defaultSequence: string | null;
   defaultPrecision: string | null;
   ssrTableData: SsrTableData;
-  /** SSR-rendered plain-English summary of the interpolated table (mid-target
-   *  operating point + headline ratio). Null when there's no comparable data. */
-  narrative: string | null;
+  /** One SSR-rendered prose paragraph per interpolated-table row (default
+   *  interactivity target). Each paragraph picks a template variant
+   *  deterministically from the slug so prose stays stable across renders
+   *  but varies across pages in the catalog. Empty array when there's no
+   *  comparable data. */
+  narrative: string[];
   aLabel: string;
   bLabel: string;
   aVendor: string;
@@ -115,18 +118,25 @@ export default function ComparePageClient({
                 </Link>
                 .
               </p>
-              {narrative && (
-                <p
-                  className="mt-3 text-sm text-foreground/80 max-w-3xl"
-                  data-testid="compare-narrative"
-                >
-                  {narrative}{' '}
-                  <span className="text-muted-foreground italic">
-                    (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
-                    {defaultPrecision ?? 'precision'} selection for this URL — table and chart below
-                    update if you change sequence, precision, or model in the controls.)
-                  </span>
-                </p>
+              {narrative.length > 0 && (
+                <div className="mt-3 flex flex-col gap-2 max-w-3xl" data-testid="compare-narrative">
+                  {narrative.map((para, i) => (
+                    <p key={i} className="text-sm text-foreground/80">
+                      {para}
+                      {i === narrative.length - 1 && (
+                        <>
+                          {' '}
+                          <span className="text-muted-foreground italic">
+                            (Numbers reflect the default {defaultSequence ?? 'sequence'} ·{' '}
+                            {defaultPrecision ?? 'precision'} selection for this URL — table and
+                            chart below update if you change sequence, precision, or model in the
+                            controls.)
+                          </span>
+                        </>
+                      )}
+                    </p>
+                  ))}
+                </div>
               )}
               <p className="mt-2 text-sm">
                 <Link

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -12,7 +12,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek R1, Kimi K2.5/K2.6, GLM 5/5.1, Qwen 3.5, and more.';
+  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more.';
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -241,7 +241,7 @@ describe('compareModelDisplayLabel', () => {
       'DeepSeek R1 — H100 vs H200',
     );
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
-      'Kimi K2.5/K2.6 — GB200 NVL72 vs MI355X',
+      'Kimi K2.5/K2.6 1T — GB200 NVL72 vs MI355X',
     );
   });
 });

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -40,7 +40,7 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     slug: 'deepseek-v4',
     displayName: 'DeepSeek-V4-Pro',
     dbKeys: ['dsv4'],
-    label: 'DeepSeek V4 Pro',
+    label: 'DeepSeek V4 Pro 1.6T',
   },
   {
     slug: 'deepseek-r1',
@@ -57,8 +57,9 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     // so the slug is populated today and stays populated when K2.6 data lands.
     dbKeys: ['kimik2.6', 'kimik2.5'],
     // Slug groups two point releases sharing one architecture — the header
-    // surfaces both versions so the URL doesn't read as "only K2.6".
-    label: 'Kimi K2.5/K2.6',
+    // surfaces both versions so the URL doesn't read as "only K2.6". Param
+    // count appended so the label conveys model scale alongside the version.
+    label: 'Kimi K2.5/K2.6 1T',
   },
   {
     slug: 'glm-5-1',
@@ -79,7 +80,8 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     slug: 'qwen-3-5',
     displayName: 'Qwen-3.5-397B-A17B',
     dbKeys: ['qwen3.5'],
-    label: 'Qwen 3.5',
+    // 397B total parameters, 17B active per forward pass (MoE).
+    label: 'Qwen 3.5 397B-A17B',
   },
   {
     slug: 'gptoss-120b',

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -329,25 +329,209 @@ function fmtPctDelta(ratio: number): string {
   return `${Math.round((ratio - 1) * 100)}%`;
 }
 
-/** Per-route prose summary of the interpolated table. Server-rendered into
- *  the page HTML so crawlers and screen-readers get a plain-English read of
- *  the headline number alongside the table data. Returns null when there's
- *  no comparable data to describe (caller falls back to the empty-state UI).
+/** Deterministic 32-bit-ish string hash. Used to pick a template variant
+ *  per (page, row) without `Math.random()` so SSR + hydration agree and the
+ *  same URL renders the same prose every request. */
+function hashStr(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = Math.trunc(Math.imul(31, h) + (s.codePointAt(i) ?? 0));
+  }
+  return Math.abs(h);
+}
+
+/** Bucket the target into low / middle / high segment of the benchmarked
+ *  range. Used by templates that say things like "Near the low end" or
+ *  "At the upper edge" so the same prose array doesn't all read identically. */
+function bandFor(target: number, range: { min: number; max: number }): 'low' | 'middle' | 'high' {
+  const span = range.max - range.min;
+  if (span <= 0) return 'middle';
+  const t = (target - range.min) / span;
+  if (t < 1 / 3) return 'low';
+  if (t > 2 / 3) return 'high';
+  return 'middle';
+}
+
+interface PerDollarBoth {
+  modelLabel: string;
+  aLabel: string;
+  bLabel: string;
+  cheaper: string;
+  pricier: string;
+  cheaperCost: number;
+  pricierCost: number;
+  ratio: number;
+  target: number;
+  aCost: number;
+  bCost: number;
+  range: string;
+  band: 'low' | 'middle' | 'high';
+}
+
+interface FullBoth {
+  modelLabel: string;
+  aLabel: string;
+  bLabel: string;
+  cheaper: string;
+  faster: string;
+  costRatio: number | null; // null when tied or zero-guarded
+  tputRatio: number | null;
+  costTied: boolean;
+  tputTied: boolean;
+  target: number;
+  aCost: number;
+  bCost: number;
+  aValue: number;
+  bValue: number;
+  range: string;
+  band: 'low' | 'middle' | 'high';
+}
+
+const BAND_PHRASE: Record<'low' | 'middle' | 'high', string> = {
+  low: 'near the low end',
+  middle: 'around the middle',
+  high: 'toward the upper edge',
+};
+
+// ---------------------------------------------------------------------------
+// /compare-per-dollar variant — both GPUs, no tie, non-zero costs
+// ---------------------------------------------------------------------------
+
+const PER_DOLLAR_BOTH_TEMPLATES: ((i: PerDollarBoth) => string)[] = [
+  (i) =>
+    `At ${i.target} tok/s/user on ${i.modelLabel}, ${i.aLabel} costs ${fmtCost(i.aCost)} per million tokens; ${i.bLabel} costs ${fmtCost(i.bCost)}. ${i.cheaper} is ${fmtPctDelta(i.ratio)} more cost-efficient at this operating point.`,
+  (i) =>
+    `${i.cheaper} edges ${i.pricier} at ${i.target} tok/s/user on ${i.modelLabel} — ${fmtCost(i.cheaperCost)} per million tokens versus ${fmtCost(i.pricierCost)}, a ${fmtPctDelta(i.ratio)} cost-per-token gap.`,
+  (i) =>
+    `Push ${i.modelLabel} to ${i.target} tok/s/user and ${i.aLabel} lands at ${fmtCost(i.aCost)} per million tokens against ${i.bLabel}'s ${fmtCost(i.bCost)} — ${i.cheaper} pulls ahead by ${fmtPctDelta(i.ratio)}.`,
+  (i) =>
+    `${i.aLabel}: ${fmtCost(i.aCost)} per million tokens. ${i.bLabel}: ${fmtCost(i.bCost)}. Both at ${i.target} tok/s/user on ${i.modelLabel}, with ${i.cheaper} ${fmtPctDelta(i.ratio)} cheaper.`,
+  (i) =>
+    `${BAND_PHRASE[i.band].charAt(0).toUpperCase() + BAND_PHRASE[i.band].slice(1)} of the ${i.range} interactivity band — at ${i.target} tok/s/user — ${i.aLabel} runs ${fmtCost(i.aCost)} per million tokens on ${i.modelLabel} while ${i.bLabel} runs ${fmtCost(i.bCost)}. ${i.cheaper} is the cheaper choice by ${fmtPctDelta(i.ratio)}.`,
+  (i) =>
+    `On ${i.modelLabel} at ${i.target} tok/s/user, the per-million math comes out to ${fmtCost(i.aCost)} for ${i.aLabel} and ${fmtCost(i.bCost)} for ${i.bLabel}; ${i.cheaper} delivers ${fmtPctDelta(i.ratio)} more output per dollar.`,
+];
+
+const PER_DOLLAR_TIED_TEMPLATES: ((i: PerDollarBoth) => string)[] = [
+  (i) =>
+    `At ${i.target} tok/s/user on ${i.modelLabel}, ${i.aLabel} and ${i.bLabel} land within ~1% on cost per million tokens (${fmtCost(i.aCost)} vs ${fmtCost(i.bCost)}) — call it a tie at this operating point.`,
+  (i) =>
+    `${i.aLabel} ${fmtCost(i.aCost)} and ${i.bLabel} ${fmtCost(i.bCost)} per million tokens at ${i.target} tok/s/user on ${i.modelLabel}: effectively the same cost.`,
+  (i) =>
+    `Cost-per-million is essentially even between ${i.aLabel} (${fmtCost(i.aCost)}) and ${i.bLabel} (${fmtCost(i.bCost)}) at ${i.target} tok/s/user on ${i.modelLabel}.`,
+];
+
+const PER_DOLLAR_ZERO_TEMPLATES: ((args: {
+  modelLabel: string;
+  aLabel: string;
+  bLabel: string;
+  target: number;
+  aCost: number;
+  bCost: number;
+}) => string)[] = [
+  (i) =>
+    `At ${i.target} tok/s/user on ${i.modelLabel}, ${i.aLabel} and ${i.bLabel} register ${fmtCost(i.aCost)} and ${fmtCost(i.bCost)} per million tokens — one side has missing pricing or throughput, so a like-for-like ratio isn't meaningful here.`,
+  (i) =>
+    `${i.aLabel} (${fmtCost(i.aCost)}) and ${i.bLabel} (${fmtCost(i.bCost)}) per million tokens at ${i.target} tok/s/user on ${i.modelLabel}: at least one input is zero, so the gap can't be expressed as a ratio.`,
+];
+
+const PER_DOLLAR_SINGLE_TEMPLATES: ((args: {
+  modelLabel: string;
+  presentLabel: string;
+  missingLabel: string;
+  target: number;
+  presentCost: number;
+}) => string)[] = [
+  (i) =>
+    `${i.presentLabel} costs ${fmtCost(i.presentCost)} per million tokens at ${i.target} tok/s/user on ${i.modelLabel}; we have no ${i.missingLabel} benchmark data at this exact target.`,
+  (i) =>
+    `At ${i.target} tok/s/user on ${i.modelLabel}, ${i.presentLabel} comes in at ${fmtCost(i.presentCost)} per million tokens. ${i.missingLabel} hasn't been benchmarked at this operating point.`,
+  (i) =>
+    `Only ${i.presentLabel} has cost data at ${i.target} tok/s/user on ${i.modelLabel} — ${fmtCost(i.presentCost)} per million tokens. ${i.missingLabel} is unmeasured at this target.`,
+];
+
+// ---------------------------------------------------------------------------
+// /compare 'full' variant — both GPUs, mentions cost AND throughput
+// ---------------------------------------------------------------------------
+
+function fullSummary(i: FullBoth): string {
+  const costPart = i.costTied
+    ? 'cost per token is essentially tied'
+    : i.costRatio === null
+      ? null
+      : `${i.cheaper} is ${fmtPctDelta(i.costRatio)} cheaper per token`;
+  const tputPart = i.tputTied
+    ? 'throughput per GPU is essentially tied'
+    : i.tputRatio === null
+      ? null
+      : `${i.faster} delivers ${fmtPctDelta(i.tputRatio)} more tok/s/GPU`;
+  const both = [costPart, tputPart].filter(Boolean).join('; ');
+  return both.length > 0
+    ? `${both.charAt(0).toUpperCase()}${both.slice(1)}`
+    : 'numbers are too close to call';
+}
+
+const FULL_BOTH_TEMPLATES: ((i: FullBoth) => string)[] = [
+  (i) =>
+    `At ${i.target} tok/s/user interactivity on ${i.modelLabel}, ${i.aLabel} delivers ${i.aValue.toFixed(0)} tok/s/GPU at ${fmtCost(i.aCost)} per million tokens; ${i.bLabel} delivers ${i.bValue.toFixed(0)} tok/s/GPU at ${fmtCost(i.bCost)}. ${fullSummary(i)} at this point.`,
+  (i) =>
+    `${i.aLabel} posts ${i.aValue.toFixed(0)} tok/s/GPU for ${fmtCost(i.aCost)} per million tokens at ${i.target} tok/s/user on ${i.modelLabel}; ${i.bLabel} posts ${i.bValue.toFixed(0)} tok/s/GPU for ${fmtCost(i.bCost)}. ${fullSummary(i)}.`,
+  (i) =>
+    `Throughput at ${i.target} tok/s/user on ${i.modelLabel}: ${i.aLabel} hits ${i.aValue.toFixed(0)} tok/s/GPU, ${i.bLabel} hits ${i.bValue.toFixed(0)}. Per-million costs land at ${fmtCost(i.aCost)} and ${fmtCost(i.bCost)} respectively. ${fullSummary(i)}.`,
+  (i) =>
+    `${i.aLabel} / ${i.bLabel} on ${i.modelLabel} at ${i.target} tok/s/user: ${i.aValue.toFixed(0)} / ${i.bValue.toFixed(0)} tok/s/GPU, ${fmtCost(i.aCost)} / ${fmtCost(i.bCost)} per million tokens. ${fullSummary(i)}.`,
+  (i) =>
+    `${BAND_PHRASE[i.band].charAt(0).toUpperCase() + BAND_PHRASE[i.band].slice(1)} of the ${i.range} interactivity band, at ${i.target} tok/s/user on ${i.modelLabel}: ${i.aLabel} runs ${i.aValue.toFixed(0)} tok/s/GPU at ${fmtCost(i.aCost)}/M tokens, ${i.bLabel} runs ${i.bValue.toFixed(0)} at ${fmtCost(i.bCost)}/M. ${fullSummary(i)}.`,
+  (i) =>
+    `Setting ${i.target} tok/s/user as the target on ${i.modelLabel}, ${i.aLabel} produces ${i.aValue.toFixed(0)} tok/s/GPU (${fmtCost(i.aCost)} per million tokens) and ${i.bLabel} produces ${i.bValue.toFixed(0)} (${fmtCost(i.bCost)}). ${fullSummary(i)}.`,
+];
+
+const FULL_SINGLE_TEMPLATES: ((args: {
+  modelLabel: string;
+  presentLabel: string;
+  missingLabel: string;
+  target: number;
+  presentValue: number;
+  presentCost: number;
+}) => string)[] = [
+  (i) =>
+    `At ${i.target} tok/s/user on ${i.modelLabel}, ${i.presentLabel} delivers ${i.presentValue.toFixed(0)} tok/s/GPU at ${fmtCost(i.presentCost)} per million tokens; ${i.missingLabel} hasn't been benchmarked at this target.`,
+  (i) =>
+    `${i.presentLabel} hits ${i.presentValue.toFixed(0)} tok/s/GPU for ${fmtCost(i.presentCost)} per million tokens at ${i.target} tok/s/user on ${i.modelLabel}. No ${i.missingLabel} data at this operating point.`,
+  (i) =>
+    `${i.presentLabel}: ${i.presentValue.toFixed(0)} tok/s/GPU, ${fmtCost(i.presentCost)} per million tokens at ${i.target} tok/s/user on ${i.modelLabel}. ${i.missingLabel} is unmeasured here.`,
+];
+
+/** Pick template `rowIndex` in the rotation starting from a per-page hash
+ *  offset. Within a single page, paragraphs 0/1/2 always pick three
+ *  *consecutive* templates from the pool (never repeating each other), while
+ *  the page-level seed picks where in the rotation to start — so different
+ *  pages get different starting templates. Avoids the birthday-problem
+ *  collisions that pickTemplate alone produces when sampling N times from a
+ *  pool of size M near N. */
+function pickRotated<T>(arr: T[], pageSeed: string, rowIndex: number): T {
+  const start = hashStr(pageSeed) % arr.length;
+  return arr[(start + rowIndex) % arr.length];
+}
+
+/** Per-route prose summary of the interpolated table — one paragraph per
+ *  default interactivity target. Server-rendered into the page HTML so
+ *  crawlers and screen-readers get a plain-English read of every operating
+ *  point. Returns an empty array when there's no data (caller falls back to
+ *  the empty-state UI).
  *
- *  Picks the first interactivity target where both GPUs have data (those are
- *  the points readers care about), or falls back to a single-GPU description
- *  at the mid row if there's no overlap. Template differs by variant —
- *  `'full'` mentions both cost and throughput; `'per-dollar'` focuses on cost
- *  and references the table for the rest.
+ *  Template selection is deterministic: the same (model, GPU pair, row index,
+ *  variant) seed always picks the same template, so SSR and any subsequent
+ *  render agree on prose. Different pages pick different templates from the
+ *  pool, so the catalog reads with variety instead of repeating the same
+ *  sentence shape on every URL.
  *
  *  The returned prose anchors to the SSR'd default model / sequence /
  *  precision — i.e. the slug's canonical operating point. The chart and
  *  interpolated table beneath the narrative re-render on client-side filter
- *  changes; the narrative does not. This is intentional: the URL slug *is*
- *  the canonical view, and the narrative is the canonical view's prose
- *  summary. The caller adds a small "(default configuration)" caveat after
- *  the narrative so a reader who fiddles with the chart controls sees that
- *  the narrative is fixed to the slug's defaults. */
+ *  changes; the narrative does not. The caller adds a "(default selection)"
+ *  caveat after the last paragraph so a reader who fiddles with the chart
+ *  controls sees that the narrative is fixed to the slug's defaults. */
 export function compareTableNarrative(
   variant: CompareJsonLdVariant,
   modelLabel: string,
@@ -355,72 +539,128 @@ export function compareTableNarrative(
   bLabel: string,
   ssrRows: SsrInterpolatedRow[],
   interactivityRange: { min: number; max: number },
-): string | null {
-  if (ssrRows.length === 0) return null;
-
-  const both = ssrRows.find((r) => r.a && r.b);
-  const row = both ?? ssrRows[Math.floor(ssrRows.length / 2)];
-  const { target, a, b } = row;
-  if (!a && !b) return null;
+): string[] {
+  if (ssrRows.length === 0) return [];
 
   const range = `${interactivityRange.min}–${interactivityRange.max} tok/s/user`;
+  // Page-level seed: stable across renders, varies by (route variant, model,
+  // GPU pair). Template selection rotates by rowIndex from this seed so the
+  // 3 paragraphs on a single page never duplicate templates with each other,
+  // and different pages pick different starting points in the rotation.
+  const pageSeed = `${variant}|${modelLabel}|${aLabel}|${bLabel}`;
+  const paragraphs: string[] = [];
 
-  if (variant === 'per-dollar') {
+  for (const [rowIndex, row] of ssrRows.entries()) {
+    const { target, a, b } = row;
+    if (!a && !b) continue;
+    const band = bandFor(target, interactivityRange);
+
+    if (variant === 'per-dollar') {
+      if (a && b) {
+        if (!(a.cost > 0 && b.cost > 0)) {
+          paragraphs.push(
+            pickRotated(
+              PER_DOLLAR_ZERO_TEMPLATES,
+              pageSeed,
+              rowIndex,
+            )({
+              modelLabel,
+              aLabel,
+              bLabel,
+              target,
+              aCost: a.cost,
+              bCost: b.cost,
+            }),
+          );
+          continue;
+        }
+        const aCheaper = a.cost < b.cost;
+        const cheaper = aCheaper ? aLabel : bLabel;
+        const pricier = aCheaper ? bLabel : aLabel;
+        const ratio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
+        const inputs: PerDollarBoth = {
+          modelLabel,
+          aLabel,
+          bLabel,
+          cheaper,
+          pricier,
+          cheaperCost: aCheaper ? a.cost : b.cost,
+          pricierCost: aCheaper ? b.cost : a.cost,
+          ratio,
+          target,
+          aCost: a.cost,
+          bCost: b.cost,
+          range,
+          band,
+        };
+        const pool = ratio < 1.01 ? PER_DOLLAR_TIED_TEMPLATES : PER_DOLLAR_BOTH_TEMPLATES;
+        paragraphs.push(pickRotated(pool, pageSeed, rowIndex)(inputs));
+        continue;
+      }
+      const present = (a ?? b)!;
+      paragraphs.push(
+        pickRotated(
+          PER_DOLLAR_SINGLE_TEMPLATES,
+          pageSeed,
+          rowIndex,
+        )({
+          modelLabel,
+          presentLabel: a ? aLabel : bLabel,
+          missingLabel: a ? bLabel : aLabel,
+          target,
+          presentCost: present.cost,
+        }),
+      );
+      continue;
+    }
+
+    // 'full' variant
     if (a && b) {
-      // Guard against zero costs (HW_REGISTRY.costh == 0 or zero throughput
-      // upstream): the ratio math would emit Infinity / NaN. Fall through to
-      // a values-only summary instead of dividing.
-      if (!(a.cost > 0 && b.cost > 0)) {
-        return `On ${modelLabel}, ${aLabel} and ${bLabel} register cost-per-token values of ${fmtCost(a.cost)} and ${fmtCost(b.cost)} respectively at ${target} tok/s/user interactivity. At least one side has missing pricing or throughput data, so a like-for-like ratio isn't meaningful at this point — see the interpolated table below for targets with both inputs populated.`;
-      }
+      const costOk = a.cost > 0 && b.cost > 0;
+      const tputOk = a.value > 0 && b.value > 0;
       const aCheaper = a.cost < b.cost;
-      const cheaper = aCheaper ? aLabel : bLabel;
-      const pricier = aCheaper ? bLabel : aLabel;
-      const ratio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
-      // Within ~1% the cost is effectively tied — say so rather than rounding
-      // to "0% more cost-efficient" which reads wrong.
-      if (ratio < 1.01) {
-        return `On ${modelLabel}, ${aLabel} and ${bLabel} land within ~1% of each other on cost per million tokens at ${target} tok/s/user interactivity (${fmtCost(a.cost)} vs. ${fmtCost(b.cost)}). Across the ${range} interactivity range we benchmarked, see the interpolated table below for the points where one pulls ahead.`;
-      }
-      return `On ${modelLabel}, ${aLabel} costs ${fmtCost(a.cost)} per million tokens at ${target} tok/s/user interactivity; ${bLabel} costs ${fmtCost(b.cost)} per million tokens at the same target. ${cheaper} is ${fmtPctDelta(ratio)} more cost-efficient than ${pricier} at this operating point — across the ${range} interactivity range we benchmarked, see the interpolated table below for how the gap moves across the full Pareto frontier.`;
+      const aFaster = a.value > b.value;
+      const costRatio = costOk ? (aCheaper ? b.cost / a.cost : a.cost / b.cost) : null;
+      const tputRatio = tputOk ? (aFaster ? a.value / b.value : b.value / a.value) : null;
+      const inputs: FullBoth = {
+        modelLabel,
+        aLabel,
+        bLabel,
+        cheaper: aCheaper ? aLabel : bLabel,
+        faster: aFaster ? aLabel : bLabel,
+        costRatio,
+        tputRatio,
+        costTied: costOk && costRatio !== null && costRatio < 1.01,
+        tputTied: tputOk && tputRatio !== null && tputRatio < 1.01,
+        target,
+        aCost: a.cost,
+        bCost: b.cost,
+        aValue: a.value,
+        bValue: b.value,
+        range,
+        band,
+      };
+      paragraphs.push(pickRotated(FULL_BOTH_TEMPLATES, pageSeed, rowIndex)(inputs));
+      continue;
     }
     const present = (a ?? b)!;
-    const presentLabel = a ? aLabel : bLabel;
-    const missingLabel = a ? bLabel : aLabel;
-    return `On ${modelLabel}, ${presentLabel} costs ${fmtCost(present.cost)} per million tokens at ${target} tok/s/user interactivity. We don't have ${missingLabel} benchmark data at this exact operating point — see the interpolated table below for the targets where both GPUs are measurable.`;
+    paragraphs.push(
+      pickRotated(
+        FULL_SINGLE_TEMPLATES,
+        pageSeed,
+        rowIndex,
+      )({
+        modelLabel,
+        presentLabel: a ? aLabel : bLabel,
+        missingLabel: a ? bLabel : aLabel,
+        target,
+        presentValue: present.value,
+        presentCost: present.cost,
+      }),
+    );
   }
 
-  // 'full' variant — mention cost AND throughput
-  if (a && b) {
-    // Two independent comparisons (cost, throughput): tie-handling and
-    // zero-guard applied separately so a tie on one dimension doesn't
-    // suppress the other side of the sentence.
-    const costPart = (() => {
-      if (!(a.cost > 0 && b.cost > 0)) return null;
-      const aCheaper = a.cost < b.cost;
-      const cheaper = aCheaper ? aLabel : bLabel;
-      const ratio = aCheaper ? b.cost / a.cost : a.cost / b.cost;
-      if (ratio < 1.01) return 'cost per token is essentially tied';
-      return `${cheaper} is ${fmtPctDelta(ratio)} cheaper per token`;
-    })();
-    const tputPart = (() => {
-      if (!(a.value > 0 && b.value > 0)) return null;
-      const aFaster = a.value > b.value;
-      const faster = aFaster ? aLabel : bLabel;
-      const ratio = aFaster ? a.value / b.value : b.value / a.value;
-      if (ratio < 1.01) return 'throughput per GPU is essentially tied';
-      return `${faster} delivers ${fmtPctDelta(ratio)} more tok/s/GPU`;
-    })();
-    const summary = [costPart, tputPart].filter(Boolean).join('; ');
-    const summarySentence = summary
-      ? ` ${summary.charAt(0).toUpperCase() + summary.slice(1)} at this operating point — `
-      : ' ';
-    return `On ${modelLabel}, at ${target} tok/s/user interactivity (within the ${range} range benchmarked), ${aLabel} delivers ${a.value.toFixed(0)} tok/s/GPU at ${fmtCost(a.cost)} per million tokens, while ${bLabel} delivers ${b.value.toFixed(0)} tok/s/GPU at ${fmtCost(b.cost)} per million tokens.${summarySentence}use the interpolated table below to see how the comparison shifts at higher and lower interactivity.`;
-  }
-  const present = (a ?? b)!;
-  const presentLabel = a ? aLabel : bLabel;
-  const missingLabel = a ? bLabel : aLabel;
-  return `On ${modelLabel}, ${presentLabel} delivers ${present.value.toFixed(0)} tok/s/GPU at ${fmtCost(present.cost)} per million tokens at ${target} tok/s/user interactivity. We don't have ${missingLabel} benchmark data at this exact operating point — see the interpolated table below for the targets where both GPUs are measurable.`;
+  return paragraphs;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SSR'd table on each \`/compare/<slug>\` and \`/compare-per-dollar/<slug>\` page has 3 default interactivity targets (25th / 50th / 75th percentile). Before this PR, the narrative above the table only described the *first* overlapping target — leaving the other two undescribed and the prose feeling thin.

Now: **one narrative paragraph per interactivity target** (3 paragraphs per page), each picked from a pool of templates so the catalog reads with variety instead of repeating one sentence shape.

Example on \`/compare-per-dollar/deepseek-v4-b200-vs-mi355x\`:

> Push DeepSeek V4 Pro to 17 tok/s/user and B200 lands at \$0.21 per million tokens against MI355X's \$0.25 — B200 pulls ahead by 20%.
>
> B200: \$0.38 per million tokens. MI355X: \$1.32. Both at 30 tok/s/user on DeepSeek V4 Pro, with B200 248% cheaper.
>
> Toward the upper edge of the 5–54 tok/s/user interactivity band — at 42 tok/s/user — B200 runs \$0.40 per million tokens on DeepSeek V4 Pro while MI355X runs \$2.78. B200 is the cheaper choice by 587%. _(Numbers reflect the default 1k/1k · fp4 selection for this URL — table and chart below update if you change sequence, precision, or model in the controls.)_

Example on \`/compare-per-dollar/kimi-k26-mi300x-vs-mi355x\` (different starting template, different rotation):

> At 21 tok/s/user on Kimi K2.5/K2.6, MI300X costs \$2.56 per million tokens; MI355X costs \$3.78. MI300X is 48% more cost-efficient at this operating point.
>
> MI300X edges MI355X at 28 tok/s/user on Kimi K2.5/K2.6 — \$2.83 per million tokens versus \$6.14, a 117% cost-per-token gap.
>
> Push Kimi K2.5/K2.6 to 36 tok/s/user and MI300X lands at \$3.75 per million tokens against MI355X's \$8.46 — MI300X pulls ahead by 126%. _(default selection caveat)_

## Template pools

| Variant | Pool | Templates |
|---|---|---|
| per-dollar | both GPUs, non-tied, non-zero | 6 |
| per-dollar | near-tie (≤1% cost gap) | 3 |
| per-dollar | zero-cost edge case | 2 |
| per-dollar | single-GPU row | 3 |
| full (/compare) | both GPUs, non-tied, non-zero | 6 |
| full | single-GPU row | 3 |

## SSR-deterministic selection

Template selection uses \`pickRotated(pool, pageSeed, rowIndex)\`:

1. \`pageSeed\` = \`\`\`\`\${variant}|\${modelLabel}|\${aLabel}|\${bLabel}\`\`\`\`\` — stable across renders, varies per page
2. \`start = hashStr(pageSeed) % pool.length\` — different pages start at different points in the rotation
3. \`templateIndex = (start + rowIndex) % pool.length\` — within a page, 3 paragraphs use 3 *consecutive* templates (always distinct)

**Why rotation and not random sampling?** Sampling 3 times from a pool of 6 has ~50% chance of collision (birthday problem). Rotation guarantees zero within-page collisions while still varying across pages.

**SEO stability:** Same URL → same prose every request → crawlers see consistent content. No \`Math.random()\`, no \`Date.now()\`, no client state.

## Files

- \`packages/app/src/lib/compare-ssr.ts\` — \`compareTableNarrative\` now returns \`string[]\` instead of \`string\`. Adds \`hashStr\`, \`bandFor\`, \`pickRotated\`, the 6 template pools, and helper input types.
- \`packages/app/src/app/compare/[slug]/page-client.tsx\` — renders array of \`<p>\`, caveat appended to last one
- \`packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx\` — same change for per-dollar route
- (Both \`page.tsx\` callers unchanged structurally — \`compareTableNarrative\` returns \`string[]\` now, prop type changed accordingly.)

## Verification

Local dev (Neon URL, blob tokens stripped to bypass dev-only cache issue):

\`\`\`
/compare-per-dollar/deepseek-v4-b200-vs-mi355x → 3 paragraphs at 17/30/42 tok/s/user, all distinct templates
/compare-per-dollar/kimi-k26-mi300x-vs-mi355x  → 3 paragraphs at 21/28/36 tok/s/user, starts at a different template
/compare/deepseek-v4-b200-vs-mi355x            → 3 paragraphs in 'full' variant (cost + throughput per paragraph)
\`\`\`

Lint, format, typecheck all green via pre-commit.

## Test plan

- [ ] Click-through Vercel preview: visit a few slug pages on both \`/compare\` and \`/compare-per-dollar\`, confirm 3 distinct prose paragraphs above each table
- [ ] Pages for different (model, GPU pair) combos pick different starting templates → catalog reads with variety
- [ ] Same page hard-refreshed renders the same 3 paragraphs (deterministic, no flicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and SEO copy only; benchmark math and routing are unchanged aside from narrative shape and display labels.
> 
> **Overview**
> Compare slug pages now ship **one SSR narrative paragraph per default interactivity row** (typically three) instead of a single headline blurb. `compareTableNarrative` returns `string[]` and builds prose from template pools for `/compare` (cost + throughput) and `/compare-per-dollar` (cost-focused), with tie, zero-cost, and single-GPU branches. **Deterministic** `hashStr` + `pickRotated` picks distinct consecutive templates per page and stable copy per URL for SEO/hydration.
> 
> **UI:** `/compare` and `/compare-per-dollar` slug clients render a stacked block of paragraphs; the default sequence/precision caveat stays on the **last** paragraph only.
> 
> **Copy/labels:** `COMPARE_MODEL_SLUGS` labels and index metadata strings add scale hints (e.g. **1.6T**, **1T**, **397B-A17B**); one test expectation updated for Kimi.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847bffe34c1fdbc058c5239429d715462ee69639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->