### PR TITLE
feat(nav): move Per Dollar from top-level header to /compare CTA + footer

### DIFF
--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -99,14 +99,16 @@ export default async function CompareIndexPage() {
             {formatModelList(modelsWithPairs)}. Each page includes interactive charts for latency,
             throughput, and cost metrics, plus an interpolated comparison table.
           </p>
-          <div className="mt-4">
+          <div className="mt-6">
             <Link
               data-testid="compare-index-per-dollar-link"
               href="/compare-per-dollar"
-              className="inline-flex items-center gap-2 rounded-md bg-brand/10 px-3 py-1.5 text-sm font-medium text-brand hover:bg-brand/15 transition-colors"
+              className="inline-flex items-center gap-2 rounded-md bg-brand px-5 py-3 text-base lg:text-lg font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
             >
               Compare GPU performance per dollar
-              <span aria-hidden="true">→</span>
+              <span aria-hidden="true" className="text-lg lg:text-xl">
+                →
+              </span>
             </Link>
           </div>
         </Card>

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
 
 import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -98,6 +99,16 @@ export default async function CompareIndexPage() {
             {formatModelList(modelsWithPairs)}. Each page includes interactive charts for latency,
             throughput, and cost metrics, plus an interpolated comparison table.
           </p>
+          <div className="mt-4">
+            <Link
+              data-testid="compare-index-per-dollar-link"
+              href="/compare-per-dollar"
+              className="inline-flex items-center gap-2 rounded-md bg-brand/10 px-3 py-1.5 text-sm font-medium text-brand hover:bg-brand/15 transition-colors"
+            >
+              Compare GPU performance per dollar
+              <span aria-hidden="true">→</span>
+            </Link>
+          </div>
         </Card>
       </section>
 

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -126,6 +126,13 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => (
             >
               GPU Reliability
             </Link>
+            <Link
+              data-testid="footer-link-compare-per-dollar"
+              href="/compare-per-dollar"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Performance per Dollar
+            </Link>
           </div>
         </div>
 

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -41,12 +41,6 @@ const NAV_LINKS = [
     event: 'header_compare_clicked',
   },
   {
-    href: '/compare-per-dollar',
-    label: 'Per Dollar',
-    testId: 'nav-link-compare-per-dollar',
-    event: 'header_compare_per_dollar_clicked',
-  },
-  {
     href: '/quotes',
     label: 'Supporters',
     testId: 'nav-link-supporters',


### PR DESCRIPTION
## Summary

- **Drop `/compare-per-dollar` from the top-level header nav.** It was getting crowded competing with Home / Dashboard / Comparisons / Supporters / Articles / About, and "Per Dollar" alone was an opaque label for what's really a sub-comparison of the broader `/compare` flow.
- **Add a brand-color CTA inside the `/compare` intro Card** linking to `/compare-per-dollar`. Anyone landing on the comparisons index now sees the per-dollar variant one click away, contextually next to the comparison browser instead of buried in the chrome.
- **Add "Performance per Dollar" to the footer's "More" section** alongside GPU Reliability so the route stays reachable from every page.

Three file edits, +18 / -6 LOC.

## Before / after navigation

| Surface              | Before                              | After                                            |
| -------------------- | ----------------------------------- | ------------------------------------------------ |
| Top-level header     | "Per Dollar" nav link               | _removed_                                        |
| /compare intro card  | (no per-dollar mention)             | Brand-color CTA: "Compare GPU performance per dollar →" |
| Footer "More" column | "GPU Reliability"                   | "GPU Reliability" + "Performance per Dollar"    |

## Cleanup notes

- The dropped `nav-link-compare-per-dollar` test ID and `header_compare_per_dollar_clicked` analytics event were only ever referenced by `header.tsx` itself (grepped both `packages/app/src/` and `cypress/`). No tests broken, no analytics consumers stranded.
- Two new test IDs added: `compare-index-per-dollar-link` (on the CTA button) and `footer-link-compare-per-dollar` (on the footer link) so the same paths can be E2E-asserted from the new locations if needed.

## Test plan

- [ ] `pnpm dev` and load `/` — confirm "Per Dollar" no longer in desktop header or mobile hamburger menu
- [ ] Visit `/compare` — confirm the new brand-color CTA renders inside the intro Card, hover state works, clicking lands on `/compare-per-dollar`
- [ ] Footer on any page — confirm "Performance per Dollar" appears under "More" and links to `/compare-per-dollar`
- [ ] Direct URL navigation to `/compare-per-dollar` still works (no route changes, just navigation refactor)
- [ ] Sitemap + OG images for `/compare-per-dollar` slugs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only changes with no route or data logic; removed header analytics event has no other consumers.
> 
> **Overview**
> **Per Dollar** is removed from the top-level header (desktop and mobile) to reduce nav clutter and avoid the opaque standalone label.
> 
> On **`/compare`**, a prominent brand CTA in the intro card links to **`/compare-per-dollar`** with copy *Compare GPU performance per dollar*, plus test id `compare-index-per-dollar-link`.
> 
> The footer **More** column gains **Performance per Dollar** (`footer-link-compare-per-dollar`) so the route stays discoverable site-wide. Routes and behavior of `/compare-per-dollar` are unchanged—only entry points moved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f7e9c1af5adc36764a5f6e77f629eecda7c8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->