### PR TITLE
fix(blog): remove inline backticks and add indexed per-dollar images

### DIFF
--- a/packages/app/cypress/e2e/blog.cy.ts
+++ b/packages/app/cypress/e2e/blog.cy.ts
@@ -49,4 +49,20 @@ describe('Blog', () => {
       cy.get('a[href="/blog"]').should('exist');
     });
   });
+
+  describe('Inline code styling', () => {
+    before(() => {
+      cy.visit('/blog/b200-glm5-nvfp4-vs-h200-fp8-3-6x-perf-per-dollar');
+    });
+
+    it('does not render generated backticks around inline code', () => {
+      cy.contains('article.prose code', 'zai-org/GLM-5-FP8')
+        .first()
+        .should(($code) => {
+          expect($code.text()).to.equal('zai-org/GLM-5-FP8');
+          expect(getComputedStyle($code[0], '::before').content).to.equal('none');
+          expect(getComputedStyle($code[0], '::after').content).to.equal('none');
+        });
+    });
+  });
 });

--- a/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
+++ b/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
@@ -58,6 +58,19 @@ describe('Compare-per-dollar slug page — slimmed table + cross-link', () => {
   it('uses "Performance per Dollar" framing in the page header', () => {
     cy.contains('Performance per Dollar').should('be.visible');
   });
+
+  it('renders an indexable comparison PNG with descriptive alt text', () => {
+    cy.get('[data-testid="compare-per-dollar-indexed-image"] img')
+      .should('be.visible')
+      .and('have.attr', 'src')
+      .and(
+        'match',
+        /\/compare-per-dollar\/deepseek-r1-gb200-vs-h100\/performance-per-dollar\.png$/u,
+      );
+    cy.get('[data-testid="compare-per-dollar-indexed-image"] img')
+      .should('have.attr', 'alt')
+      .and('contain', 'cost per million tokens at matched interactivity levels');
+  });
 });
 
 describe('Compare slug page — cross-link to per-dollar view', () => {

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -48,6 +48,8 @@ interface ComparePerDollarPageClientProps {
    *  header so readers can audit the pricing assumptions. */
   aCostPerGpuHr: number;
   bCostPerGpuHr: number;
+  /** Crawlable data graphic generated for the canonical default comparison. */
+  heroImageSrc: string;
 }
 
 /** Only show Cost + Concurrency in the interpolated table — the rest of the
@@ -98,6 +100,7 @@ export default function ComparePerDollarPageClient({
   bArch,
   aCostPerGpuHr,
   bCostPerGpuHr,
+  heroImageSrc,
 }: ComparePerDollarPageClientProps) {
   useEffect(() => {
     track('compare_per_dollar_page_view', { gpu_a: a, gpu_b: b, default_model: defaultModel });
@@ -121,7 +124,7 @@ export default function ComparePerDollarPageClient({
         initialYAxisMetric={PER_DOLLAR_DEFAULT_Y_AXIS}
       >
         <div className="flex flex-col gap-4">
-          <Card className="flex flex-col gap-3">
+          <Card className="flex w-full min-w-0 flex-col gap-3">
             <header>
               <div className="text-xs uppercase tracking-wider text-muted-foreground">
                 {modelLabel} · Performance per Dollar
@@ -129,7 +132,7 @@ export default function ComparePerDollarPageClient({
               <h1 className="text-2xl lg:text-3xl font-bold tracking-tight mt-1">
                 {label} Performance per Dollar
               </h1>
-              <p className="mt-2 text-sm text-muted-foreground max-w-3xl">
+              <p className="mt-2 text-sm text-muted-foreground">
                 Cost per million tokens of <strong>{aLabel}</strong> ({aVendor} {aArch}) versus{' '}
                 <strong>{bLabel}</strong> ({bVendor} {bArch}) on <strong>{modelLabel}</strong>.
                 Owning-hyperscaler TCO normalized by output tokens — performance per dollar across
@@ -143,7 +146,7 @@ export default function ComparePerDollarPageClient({
               </p>
               {narrative.length > 0 && (
                 <div
-                  className="mt-3 flex flex-col gap-2 max-w-3xl"
+                  className="mt-3 flex flex-col gap-2"
                   data-testid="compare-per-dollar-narrative"
                 >
                   {narrative.map((para, i) => (
@@ -166,7 +169,7 @@ export default function ComparePerDollarPageClient({
               )}
               {(aCostPerGpuHr > 0 || bCostPerGpuHr > 0) && (
                 <p
-                  className="mt-2 text-xs text-muted-foreground max-w-3xl"
+                  className="mt-2 text-xs text-muted-foreground"
                   data-testid="compare-per-dollar-pricing"
                 >
                   GPU pricing (owning hyperscaler): <strong>{aLabel}</strong>{' '}
@@ -195,6 +198,24 @@ export default function ComparePerDollarPageClient({
                 </Link>
               </p>
             </header>
+            <figure
+              className="mt-2 flex flex-col gap-2"
+              data-testid="compare-per-dollar-indexed-image"
+            >
+              <img
+                src={heroImageSrc}
+                alt={`${modelLabel}: ${aLabel} versus ${bLabel} cost per million tokens at matched interactivity levels`}
+                width={1200}
+                height={675}
+                loading="eager"
+                fetchPriority="high"
+                className="w-full rounded-lg border border-border/50"
+              />
+              <figcaption className="text-xs text-muted-foreground">
+                {aLabel} versus {bLabel} cost per million tokens for this comparison's canonical
+                default workload. Lower cost indicates better performance per dollar.
+              </figcaption>
+            </figure>
             <CompareTableSection
               a={a}
               b={b}

--- a/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
@@ -120,6 +120,7 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
   );
 
   const url = `${SITE_URL}/compare-per-dollar/${canonical}`;
+  const imageUrl = `${url}/performance-per-dollar.png`;
   const jsonLd = buildJsonLd(
     'per-dollar',
     parsed.model,
@@ -129,6 +130,7 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
     summaryA,
     summaryB,
     ssrRows,
+    imageUrl,
   );
   const label = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const aMeta = HW_REGISTRY[parsed.a];
@@ -172,6 +174,7 @@ export default async function ComparePerDollarPage({ params, searchParams }: Pro
         bArch={bMeta?.arch ?? ''}
         aCostPerGpuHr={aCostPerGpuHr}
         bCostPerGpuHr={bCostPerGpuHr}
+        heroImageSrc={`/compare-per-dollar/${canonical}/performance-per-dollar.png`}
       />
     </>
   );

--- a/packages/app/src/app/compare-per-dollar/[slug]/performance-per-dollar.png/route.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/performance-per-dollar.png/route.tsx
@@ -1,0 +1,394 @@
+import { ImageResponse } from 'next/og';
+
+import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
+
+import { pickPairDefaults } from '@/lib/compare-pair-defaults';
+import { canonicalCompareSlug, parseCompareSlug } from '@/lib/compare-slug';
+import {
+  computeCompareImageRows,
+  computeCompareTableData,
+  getCachedBenchmarks,
+} from '@/lib/compare-ssr';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const DISPLAY_SIZE = { width: 1200, height: 675 };
+const IMAGE_SCALE = 2;
+const SIZE = {
+  width: DISPLAY_SIZE.width * IMAGE_SCALE,
+  height: DISPLAY_SIZE.height * IMAGE_SCALE,
+};
+const CHART_FRAME = { left: 0, top: 18, width: 746, height: 382 };
+const CHART = { left: 96, top: 42, width: 630, height: 272 };
+const COLORS = {
+  background: '#0d1117',
+  panel: '#121a23',
+  border: '#23303d',
+  muted: '#9aa7b5',
+  text: '#f3f7fb',
+  a: '#38d9a9',
+  b: '#f7b041',
+  grid: '#263544',
+  blue: '#0b86d1',
+};
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+function money(value: number): string {
+  if (value >= 10) return `$${value.toFixed(1)}`;
+  if (value >= 1) return `$${value.toFixed(2)}`;
+  return `$${value.toFixed(3)}`;
+}
+
+function pointsPath(points: Point[]): string {
+  return points.map((point, index) => `${index === 0 ? 'M' : 'L'} ${point.x} ${point.y}`).join(' ');
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ slug: string }> },
+): Promise<Response> {
+  const { slug } = await params;
+  const parsed = parseCompareSlug(slug);
+  if (!parsed || canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b) !== slug) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const rows = await getCachedBenchmarks(parsed.model.dbKeys);
+  const { sequence, precision } = pickPairDefaults(rows, parsed.a, parsed.b);
+  const { ssrRows, interactivityRange } = computeCompareTableData(
+    rows,
+    parsed.a,
+    parsed.b,
+    sequence,
+    precision,
+  );
+  const plottedRows = ssrRows.filter((row) => row.a || row.b);
+  const imageRows = computeCompareImageRows(
+    rows,
+    parsed.a,
+    parsed.b,
+    sequence,
+    precision,
+    interactivityRange,
+  ).filter((row) => row.a || row.b);
+  const curveRows = imageRows.length > 0 ? imageRows : plottedRows;
+
+  const aLabel = HW_REGISTRY[parsed.a]?.label ?? parsed.a.toUpperCase();
+  const bLabel = HW_REGISTRY[parsed.b]?.label ?? parsed.b.toUpperCase();
+  const costs = curveRows
+    .flatMap((row) => [row.a?.cost, row.b?.cost])
+    .filter((cost): cost is number => typeof cost === 'number' && Number.isFinite(cost));
+  const costMin = costs.length > 0 ? Math.min(...costs) : 0;
+  const costMax = costs.length > 0 ? Math.max(...costs) : 1;
+  const costPadding = Math.max((costMax - costMin) * 0.18, costMax * 0.08, 0.02);
+  const yMin = Math.max(0, costMin - costPadding);
+  const yMax = costMax + costPadding;
+  const xMin = curveRows.at(0)?.target ?? 0;
+  const xMax = curveRows.at(-1)?.target ?? 100;
+  const scaleX = (value: number) =>
+    CHART.left + (xMax === xMin ? CHART.width / 2 : ((value - xMin) / (xMax - xMin)) * CHART.width);
+  const scaleY = (value: number) =>
+    CHART.top +
+    CHART.height -
+    (yMax === yMin ? CHART.height / 2 : ((value - yMin) / (yMax - yMin)) * CHART.height);
+
+  const aPoints = curveRows
+    .filter((row) => row.a)
+    .map((row) => ({ x: scaleX(row.target), y: scaleY(row.a!.cost) }));
+  const bPoints = curveRows
+    .filter((row) => row.b)
+    .map((row) => ({ x: scaleX(row.target), y: scaleY(row.b!.cost) }));
+  const aHighlightPoints = plottedRows
+    .filter((row) => row.a)
+    .map((row) => ({ x: scaleX(row.target), y: scaleY(row.a!.cost) }));
+  const bHighlightPoints = plottedRows
+    .filter((row) => row.b)
+    .map((row) => ({ x: scaleX(row.target), y: scaleY(row.b!.cost) }));
+  const yTicks = Array.from({ length: 4 }, (_, index) => yMin + ((yMax - yMin) * index) / 3);
+  const workload = [sequence, precision?.toUpperCase()].filter(Boolean).join(' / ');
+
+  return new ImageResponse(
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        width: DISPLAY_SIZE.width,
+        height: DISPLAY_SIZE.height,
+        padding: '38px 46px 26px',
+        background: COLORS.background,
+        color: COLORS.text,
+        fontFamily: 'Arial, sans-serif',
+        transform: `scale(${IMAGE_SCALE})`,
+        transformOrigin: 'top left',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
+          <div
+            style={{
+              display: 'flex',
+              fontSize: 19,
+              fontWeight: 700,
+              letterSpacing: '0.13em',
+              textTransform: 'uppercase',
+              color: COLORS.blue,
+            }}
+          >
+            InferenceX Performance per Dollar
+          </div>
+          <div style={{ display: 'flex', fontSize: 41, fontWeight: 800 }}>{parsed.model.label}</div>
+          <div style={{ display: 'flex', fontSize: 25, color: COLORS.muted }}>
+            {aLabel} vs {bLabel} | Cost per Million Tokens
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-end',
+            border: `1px solid ${COLORS.border}`,
+            borderRadius: 12,
+            padding: '13px 17px',
+            background: COLORS.panel,
+            gap: 5,
+          }}
+        >
+          <div style={{ display: 'flex', fontSize: 14, color: COLORS.muted }}>DEFAULT WORKLOAD</div>
+          <div style={{ display: 'flex', fontSize: 21, fontWeight: 700 }}>
+            {workload || 'Default comparison'}
+          </div>
+          <div style={{ display: 'flex', fontSize: 14, color: COLORS.muted }}>
+            Lower cost is better
+          </div>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', flex: 1, gap: 34, marginTop: 22 }}>
+        <div style={{ display: 'flex', position: 'relative', width: 760, height: 406 }}>
+          <svg
+            width="760"
+            height="406"
+            viewBox="0 0 760 406"
+            style={{ position: 'absolute', left: 0, top: 0 }}
+          >
+            <rect
+              x={CHART_FRAME.left}
+              y={CHART_FRAME.top}
+              width={CHART_FRAME.width}
+              height={CHART_FRAME.height}
+              rx="13"
+              fill={COLORS.panel}
+              stroke={COLORS.border}
+            />
+            {yTicks.map((tick) => {
+              const y = scaleY(tick);
+              return (
+                <line
+                  key={tick}
+                  x1={CHART.left}
+                  x2={CHART.left + CHART.width}
+                  y1={y}
+                  y2={y}
+                  stroke={COLORS.grid}
+                  strokeWidth="2"
+                />
+              );
+            })}
+            {aPoints.length > 1 && (
+              <path
+                d={pointsPath(aPoints)}
+                fill="none"
+                stroke={COLORS.a}
+                strokeWidth="9"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            )}
+            {bPoints.length > 1 && (
+              <path
+                d={pointsPath(bPoints)}
+                fill="none"
+                stroke={COLORS.b}
+                strokeWidth="9"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              />
+            )}
+            {aHighlightPoints.map((point, index) => (
+              <circle
+                key={`a-${index}`}
+                cx={point.x}
+                cy={point.y}
+                r="10"
+                fill={COLORS.a}
+                stroke={COLORS.background}
+                strokeWidth="4"
+              />
+            ))}
+            {bHighlightPoints.map((point, index) => (
+              <circle
+                key={`b-${index}`}
+                cx={point.x}
+                cy={point.y}
+                r="10"
+                fill={COLORS.b}
+                stroke={COLORS.background}
+                strokeWidth="4"
+              />
+            ))}
+          </svg>
+          {yTicks.map((tick) => (
+            <div
+              key={`y-label-${tick}`}
+              style={{
+                display: 'flex',
+                position: 'absolute',
+                left: CHART_FRAME.left + 14,
+                top: scaleY(tick) - 9,
+                width: CHART.left - CHART_FRAME.left - 28,
+                justifyContent: 'flex-end',
+                color: COLORS.muted,
+                fontSize: 15,
+              }}
+            >
+              {money(tick)}
+            </div>
+          ))}
+          {plottedRows.map((row) => (
+            <div
+              key={`x-label-${row.target}`}
+              style={{
+                display: 'flex',
+                position: 'absolute',
+                left: scaleX(row.target) - 32,
+                top: CHART.top + CHART.height + 15,
+                width: 64,
+                justifyContent: 'center',
+                color: COLORS.muted,
+                fontSize: 16,
+                fontWeight: 600,
+              }}
+            >
+              {row.target}
+            </div>
+          ))}
+          <div
+            style={{
+              display: 'flex',
+              position: 'absolute',
+              left: CHART.left,
+              top: CHART.top + CHART.height + 43,
+              width: CHART.width,
+              justifyContent: 'center',
+              color: COLORS.muted,
+              fontSize: 15,
+              fontWeight: 600,
+            }}
+          >
+            Interactivity (tok/s/user)
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            gap: 17,
+            paddingTop: 18,
+          }}
+        >
+          <div style={{ display: 'flex', fontSize: 18, fontWeight: 700 }}>
+            Matched Interactivity
+          </div>
+          <div style={{ display: 'flex', gap: 20, fontSize: 15, color: COLORS.muted }}>
+            <span style={{ display: 'flex', gap: 7, alignItems: 'center' }}>
+              <span
+                style={{
+                  display: 'flex',
+                  width: 19,
+                  height: 6,
+                  borderRadius: 3,
+                  background: COLORS.a,
+                }}
+              />
+              {aLabel}
+            </span>
+            <span style={{ display: 'flex', gap: 7, alignItems: 'center' }}>
+              <span
+                style={{
+                  display: 'flex',
+                  width: 19,
+                  height: 6,
+                  borderRadius: 3,
+                  background: COLORS.b,
+                }}
+              />
+              {bLabel}
+            </span>
+          </div>
+          {plottedRows.length > 0 ? (
+            plottedRows.map((row) => (
+              <div
+                key={`row-${row.target}`}
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 6,
+                  border: `1px solid ${COLORS.border}`,
+                  borderRadius: 10,
+                  padding: '11px 13px',
+                  background: COLORS.panel,
+                }}
+              >
+                <div style={{ display: 'flex', color: COLORS.muted, fontSize: 13 }}>
+                  {row.target} tok/s/user
+                </div>
+                <div style={{ display: 'flex', gap: 15, fontSize: 19, fontWeight: 700 }}>
+                  <span style={{ display: 'flex', color: COLORS.a }}>
+                    {row.a ? money(row.a.cost) : 'N/A'}
+                  </span>
+                  <span style={{ display: 'flex', color: COLORS.b }}>
+                    {row.b ? money(row.b.cost) : 'N/A'}
+                  </span>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div style={{ display: 'flex', fontSize: 18, color: COLORS.muted }}>
+              No matched cost data available.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          paddingTop: 9,
+          fontSize: 15,
+          color: COLORS.muted,
+        }}
+      >
+        <span style={{ display: 'flex' }}>
+          Owning-hyperscaler TCO | interpolated from benchmark results
+        </span>
+        <span style={{ display: 'flex', color: COLORS.text, fontWeight: 700 }}>
+          inferencex.semianalysis.com
+        </span>
+      </div>
+    </div>,
+    {
+      ...SIZE,
+      headers: {
+        'Cache-Control': 'public, s-maxage=3600, stale-while-revalidate=86400',
+      },
+    },
+  );
+}

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -28,6 +28,12 @@
   min-width: 100%;
 }
 
+/* Inline code is already distinguished visually; omit Typography's generated backticks. */
+.blog-prose code::before,
+.blog-prose code::after {
+  content: none;
+}
+
 /* Remove auto-inserted curly quotes from blockquotes in blog prose */
 .blog-prose blockquote p:first-of-type::before,
 .blog-prose blockquote p:last-of-type::after {

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -75,14 +75,17 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily' as const,
       priority: 0.7,
     })),
-    // Per-dollar variant URLs — same (model, pair) availability filter as the
-    // /compare set, so the count matches exactly. Each is a distinct canonical
-    // URL with its own SSR metadata, JSON-LD, and OG image.
-    ...compareSlugs.map(({ modelSlug, a, b }) => ({
-      url: `${BASE_URL}/compare-per-dollar/${canonicalCompareSlug(modelSlug, a, b)}`,
-      lastModified: now,
-      changeFrequency: 'daily' as const,
-      priority: 0.7,
-    })),
+    // Every indexed per-dollar landing page has a stable data graphic so image
+    // crawlers discover the PNG alongside the canonical comparison URL.
+    ...compareSlugs.map(({ modelSlug, a, b }) => {
+      const url = `${BASE_URL}/compare-per-dollar/${canonicalCompareSlug(modelSlug, a, b)}`;
+      return {
+        url,
+        images: [`${url}/performance-per-dollar.png`],
+        lastModified: now,
+        changeFrequency: 'daily' as const,
+        priority: 0.7,
+      };
+    }),
   ];
 }

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -258,6 +258,44 @@ export function computeCompareTableData(
   return { defaultTargets, ssrRows, interactivityRange };
 }
 
+/** Sample the same interpolated cost curve used for the comparison table for
+ * server-rendered image assets. More samples make the static PNG read like the
+ * interactive roofline without requiring browser-based chart capture. */
+export function computeCompareImageRows(
+  rows: BenchmarkRow[],
+  a: string,
+  b: string,
+  sequence: string | null,
+  precision: string | null,
+  interactivityRange: { min: number; max: number },
+): SsrInterpolatedRow[] {
+  if (!sequence || !precision || interactivityRange.max <= interactivityRange.min) return [];
+
+  const islOsl = sequenceToIslOsl(sequence);
+  if (!islOsl) return [];
+
+  const pointsA = buildGpuDataPoints(rows, a, islOsl.isl, islOsl.osl, precision);
+  const pointsB = buildGpuDataPoints(rows, b, islOsl.isl, islOsl.osl, precision);
+  if (pointsA.length === 0 && pointsB.length === 0) return [];
+
+  const sampleCount = 17;
+  const span = interactivityRange.max - interactivityRange.min;
+  return Array.from({ length: sampleCount }, (_, index) => {
+    const target = interactivityRange.min + (span * index) / (sampleCount - 1);
+    return {
+      target,
+      a:
+        pointsA.length > 0
+          ? interpolateForGPU(pointsA, target, 'interactivity_to_throughput', 'costh')
+          : null,
+      b:
+        pointsB.length > 0
+          ? interpolateForGPU(pointsB, target, 'interactivity_to_throughput', 'costh')
+          : null,
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // JSON-LD graph
 // ---------------------------------------------------------------------------
@@ -729,6 +767,7 @@ export function buildJsonLd(
   summaryA: PairSummary,
   summaryB: PairSummary,
   ssrRows: SsrInterpolatedRow[],
+  imageUrl?: string,
 ) {
   const aLabel = HW_REGISTRY[a]?.label ?? a.toUpperCase();
   const bLabel = HW_REGISTRY[b]?.label ?? b.toUpperCase();
@@ -793,6 +832,7 @@ export function buildJsonLd(
         name: itemListName,
         description: itemListDescription,
         url,
+        ...(imageUrl && { image: imageUrl }),
         itemListOrder: 'https://schema.org/ItemListOrderAscending',
         numberOfItems: 2,
         itemListElement: [jsonLdEntryFor(a, summaryA, 1), jsonLdEntryFor(b, summaryB, 2)],
@@ -804,6 +844,13 @@ export function buildJsonLd(
               name: datasetName,
               description: datasetDescription,
               url,
+              ...(imageUrl && {
+                image: {
+                  '@type': 'ImageObject',
+                  contentUrl: imageUrl,
+                  caption: datasetName,
+                },
+              }),
               hasPart: comparisonRows,
             },
           ]


### PR DESCRIPTION
## Summary
- remove Tailwind Typography-generated backticks from inline code within blog prose
- add an automatically generated, crawlable performance-per-dollar PNG for every indexed `/compare-per-dollar/<slug>` page
- expose each PNG through a visible image, sitemap image entry, and JSON-LD metadata
- render high-resolution chart graphics with heavy series lines, in-chart axis labels, and series-colored summary values

## Implementation
`getAllComparableCompareSlugs()` remains the shared comparable-pair inventory. Its per-dollar sitemap consumer now maps every returned canonical slug to `/performance-per-dollar.png`, while the dynamic PNG route generates the image from the same SSR interpolated cost data as the page. This covers all current and future comparable per-dollar pages without client-side chart-export automation.

## Root Causes
- Blog content is rendered inside Tailwind Typography `prose`, which adds visible `::before` and `::after` delimiters to inline `<code>` elements.
- The existing interactive chart export is browser-only DOM capture and cannot provide stable crawlable image URLs for Google Images.

## Impact
- Inline model identifiers render as monospace text without duplicate visible backticks.
- Every indexed per-dollar comparison page has a stable chart PNG suitable for image discovery and page display.

## Validation
- `pnpm fmt`
- `pnpm typecheck`
- `E2E_FIXTURES=1 pnpm build`
- rendered and visually inspected a representative PNG locally (`2400x1350`)
- no test suite run locally, per request
