### PR TITLE
feat(inference): add "Measured J per Token" metric (input + output)

### DIFF
--- a/packages/app/src/components/inference/inference-chart-config.json
+++ b/packages/app/src/components/inference/inference-chart-config.json
@@ -95,6 +95,10 @@
     "y_measuredJPerOutputToken_label": "Measured J per Output Token (J/tok)",
     "y_measuredJPerOutputToken_title": "Measured Joules per Output Token",
     "y_measuredJPerOutputToken_roofline": "lower_right",
+    "y_measuredJPerTotalToken": "measuredJPerTotalToken.y",
+    "y_measuredJPerTotalToken_label": "Measured J per Token (J/tok)",
+    "y_measuredJPerTotalToken_title": "Measured Joules per Token (input + output)",
+    "y_measuredJPerTotalToken_roofline": "lower_right",
     "y_cost_limit": 5,
     "y_latency_limit": 60
   },
@@ -193,6 +197,10 @@
     "y_measuredJPerOutputToken_label": "Measured J per Output Token (J/tok)",
     "y_measuredJPerOutputToken_title": "Measured Joules per Output Token",
     "y_measuredJPerOutputToken_roofline": "lower_left",
+    "y_measuredJPerTotalToken": "measuredJPerTotalToken.y",
+    "y_measuredJPerTotalToken_label": "Measured J per Token (J/tok)",
+    "y_measuredJPerTotalToken_title": "Measured Joules per Token (input + output)",
+    "y_measuredJPerTotalToken_roofline": "lower_left",
     "y_cost_limit": 5,
     "y_latency_limit": 60
   }

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -68,9 +68,10 @@ export interface AggDataEntry {
   std_e2el: number;
   p99_e2el: number;
   // Measured GPU telemetry (emitted by runner's aggregate_power.py).
-  // Optional because historical runs predate the field.
+  // Optional because historical runs predate the fields.
   avg_power_w?: number;
   joules_per_output_token?: number;
+  joules_per_total_token?: number;
   disagg: boolean;
   num_prefill_gpu: number;
   num_decode_gpu: number;
@@ -162,6 +163,7 @@ export interface InferenceData extends Partial<Omit<AggDataEntry, AggDataConflic
   // emit these fields.
   measuredAvgPower?: { y: number; roof: boolean };
   measuredJPerOutputToken?: { y: number; roof: boolean };
+  measuredJPerTotalToken?: { y: number; roof: boolean };
 }
 
 /**
@@ -189,7 +191,8 @@ export type YAxisMetricKey =
   | 'jOutput'
   | 'jInput'
   | 'measuredAvgPower'
-  | 'measuredJPerOutputToken';
+  | 'measuredJPerOutputToken'
+  | 'measuredJPerTotalToken';
 
 /**
  * Defines the configuration and labels for a specific chart.
@@ -302,6 +305,10 @@ export interface ChartDefinition {
   y_measuredJPerOutputToken_label?: string;
   y_measuredJPerOutputToken_title?: string;
   y_measuredJPerOutputToken_roofline?: 'upper_right' | 'upper_left' | 'lower_left' | 'lower_right';
+  y_measuredJPerTotalToken?: string;
+  y_measuredJPerTotalToken_label?: string;
+  y_measuredJPerTotalToken_title?: string;
+  y_measuredJPerTotalToken_roofline?: 'upper_right' | 'upper_left' | 'lower_left' | 'lower_right';
   y_cost_limit?: number;
   y_latency_limit?: number;
 }

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -56,7 +56,7 @@ const METRIC_GROUPS: { label: string; metrics: string[]; gated?: boolean }[] = [
   { label: 'All-in Provisioned Energy per Token', metrics: ['y_jTotal', 'y_jOutput', 'y_jInput'] },
   {
     label: 'Measured Energy',
-    metrics: ['y_measuredAvgPower', 'y_measuredJPerOutputToken'],
+    metrics: ['y_measuredAvgPower', 'y_measuredJPerOutputToken', 'y_measuredJPerTotalToken'],
     gated: true,
   },
   { label: 'Custom User Values', metrics: ['y_costUser', 'y_powerUser'] },

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -54,6 +54,7 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     // "no measurement" from "0 W" via createChartDataPoint's typeof guard.
     avg_power_w: m.avg_power_w,
     joules_per_output_token: m.joules_per_output_token,
+    joules_per_total_token: m.joules_per_total_token,
     disagg: row.disagg,
     num_prefill_gpu: row.num_prefill_gpu,
     num_decode_gpu: row.num_decode_gpu,

--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -1265,6 +1265,33 @@ describe('createChartDataPoint measured power fields', () => {
     expect(point.measuredAvgPower).toBeDefined();
     expect(point.measuredAvgPower!.y).toBe(0);
   });
+
+  it('emits measuredJPerTotalToken when joules_per_total_token is present', () => {
+    const e = entry({ joules_per_total_token: 0.93 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredJPerTotalToken).toBeDefined();
+    expect(point.measuredJPerTotalToken!.y).toBe(0.93);
+    expect(point.measuredJPerTotalToken!.roof).toBe(false);
+  });
+
+  it('emits J/output and J/total independently — different denominators', () => {
+    // 8k1k workload: J/output ≈ 9 × J/total (input is ~8x output, so output/total ≈ 1/9).
+    const e = entry({ joules_per_output_token: 2.04, joules_per_total_token: 0.23 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredJPerOutputToken!.y).toBe(2.04);
+    expect(point.measuredJPerTotalToken!.y).toBe(0.23);
+  });
+
+  it('omits measuredJPerTotalToken on rows that predate the field', () => {
+    // Rows ingested before joules_per_total_token was added still have avg_power_w
+    // and joules_per_output_token. The new field must be absent (not 0) so the
+    // chart correctly drops them from the J/total view rather than plotting fake data.
+    const e = entry({ avg_power_w: 458, joules_per_output_token: 2.04 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredAvgPower).toBeDefined();
+    expect(point.measuredJPerOutputToken).toBeDefined();
+    expect(point.measuredJPerTotalToken).toBeUndefined();
+  });
 });
 
 // ===========================================================================

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -152,6 +152,7 @@ export const Y_AXIS_METRICS = [
   // distinct from the spec-sheet TDP-derived jTotal/jOutput/jInput above).
   'y_measuredAvgPower',
   'y_measuredJPerOutputToken',
+  'y_measuredJPerTotalToken',
 ] as const;
 
 export type YAxisMetric = (typeof Y_AXIS_METRICS)[number];
@@ -403,6 +404,9 @@ export function createChartDataPoint(
     ...(typeof entry.joules_per_output_token === 'number'
       ? { measuredJPerOutputToken: { y: entry.joules_per_output_token, roof: false } }
       : {}),
+    ...(typeof entry.joules_per_total_token === 'number'
+      ? { measuredJPerTotalToken: { y: entry.joules_per_total_token, roof: false } }
+      : {}),
   };
 }
 
@@ -565,7 +569,8 @@ export const calculateRoofline = (
     | `jOutput.y`
     | `jInput.y`
     | `measuredAvgPower.y`
-    | `measuredJPerOutputToken.y`,
+    | `measuredJPerOutputToken.y`
+    | `measuredJPerTotalToken.y`,
   rooflineDirection: 'upper_right' | 'upper_left' | 'lower_left' | 'lower_right',
 ): InferenceData[] => {
   const pointsForRoofline = points.map((p) => {
@@ -637,7 +642,8 @@ export function computeAllRooflines(
             | `jOutput.y`
             | `jInput.y`
             | `measuredAvgPower.y`
-            | `measuredJPerOutputToken.y`,
+            | `measuredJPerOutputToken.y`
+            | `measuredJPerTotalToken.y`,
           rooflineDirection,
         );
       }
@@ -683,6 +689,7 @@ export function markRooflinePoints(
       if (newPoint.jInput) newPoint.jInput.roof = false;
       if (newPoint.measuredAvgPower) newPoint.measuredAvgPower.roof = false;
       if (newPoint.measuredJPerOutputToken) newPoint.measuredJPerOutputToken.roof = false;
+      if (newPoint.measuredJPerTotalToken) newPoint.measuredJPerTotalToken.roof = false;
 
       for (const chartDefYKey of Y_AXIS_METRICS) {
         const rooflinePoints = computedRooflines[hwKey]?.[chartDefYKey];
@@ -749,6 +756,8 @@ export function markRooflinePoints(
           newPoint.measuredJPerOutputToken
         ) {
           newPoint.measuredJPerOutputToken.roof = onCurrentRoofline;
+        } else if (chartDefYKey === 'y_measuredJPerTotalToken' && newPoint.measuredJPerTotalToken) {
+          newPoint.measuredJPerTotalToken.roof = onCurrentRoofline;
         }
       }
       finalProcessedData.push(newPoint);

--- a/packages/constants/src/metric-keys.ts
+++ b/packages/constants/src/metric-keys.ts
@@ -44,8 +44,11 @@ export const METRIC_KEYS = new Set([
   'p99.9_intvty',
   'std_intvty',
   // measured power / energy (emitted by runner's aggregate_power.py)
-  // avg_power_w: mean per-GPU draw (W) during the load window
+  // avg_power_w:             mean per-GPU draw (W) during the load window
   // joules_per_output_token: avg_power_w * num_gpus * duration / total_output_tokens
+  // joules_per_total_token:  avg_power_w * num_gpus * duration / (total_input + total_output)
+  //                          — workload-shape-fair view that doesn't treat prompt as free
   'avg_power_w',
   'joules_per_output_token',
+  'joules_per_total_token',
 ]);


### PR DESCRIPTION
## Summary

Adds a third option to the gated **Measured Energy** dropdown:

- **Measured J per Token** — joules / (input_tokens + output_tokens). Workload-shape-fair: doesn't treat the prompt as free.

Existing **Measured J per Output Token** stays — it's still a useful framing for "what does it cost to *generate* a token." The new metric answers a different question: "what does it cost to *handle* a token end-to-end."

## Why the distinction matters

For an 8k1k workload (8K input, 1K output) the same system energy gets divided by 1024 tokens (output) vs 9216 tokens (total). J/output-token is ~9x higher than J/total-token despite identical real-world cost. Datacenter operators usually bill per total tokens handled, so J/total-token maps more cleanly to dollars-per-token.

For balanced workloads (1k1k) the ratio is closer to 2x.

## Companion runner change

[semianalysisai/InferenceX@363e49c4](https://github.com/SemiAnalysisAI/InferenceX/commit/363e49c4) on PR #1558 emits `joules_per_total_token` in every `agg_<run>.json` alongside the existing `avg_power_w` and `joules_per_output_token`.

## Wiring

Same pattern as the existing measured-power fields:

| File | Change |
|---|---|
| `packages/constants/src/metric-keys.ts` | Register `joules_per_total_token` |
| `packages/app/src/lib/benchmark-transform.ts` | Pass through (left `undefined` for legacy rows) |
| `packages/app/src/components/inference/types.ts` | Extend `AggDataEntry`, `InferenceData`, `YAxisMetricKey`, `ChartDefinition` |
| `packages/app/src/lib/chart-utils.ts` | Extend `Y_AXIS_METRICS`, `createChartDataPoint`, `calculateRoofline`/`computeAllRooflines` yKey union, `markRooflinePoints` |
| `packages/app/src/components/inference/inference-chart-config.json` | Add `y_measuredJPerTotalToken` to both `chartType`s (roofline `lower_right` on interactivity, `lower_left` on e2e) |
| `packages/app/src/components/inference/ui/ChartControls.tsx` | Add to the Measured Energy gated group |

## Graceful degradation

Same `typeof === 'number'` gate as the other measured-power fields:
- Rows ingested before the runner-side change have `joules_per_total_token` absent → those rows don't show on the J/total chart (correct)
- Rows from the next sweep onward will have it populated automatically

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` / `pnpm fmt` — clean (pre-commit hook passes)
- [x] `pnpm test:unit` — 1944/1944 passing (+3 new tests covering the new field's presence, independence from J/output-token, graceful absence on legacy rows)
- [ ] After companion runner PR merges + ingest: verify production chart renders the new option with real data

## Note on overlay path

Per CLAUDE.md's overlay requirement: the new metric works on the `?unofficialrun=` overlay path automatically because `transformBenchmarkRows` is shared between the official and overlay code paths. Once runner PR #1558 merges and a sweep produces an artifact with the new field, the overlay URL will display the new metric immediately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI and data plumbing for an optional telemetry field; no auth, billing, or breaking API changes. Main risk is empty charts until runner/ingest populates the new metric.
> 
> **Overview**
> Adds **Measured J per Token** (`joules_per_total_token` → `measuredJPerTotalToken`) as a third option in the gated **Measured Energy** Y-axis group, alongside avg power and J per output token. The value uses total tokens handled (input + output), which better matches billing-style “cost per token” than output-only J/tok on long-prompt workloads.
> 
> The change threads the field from `METRIC_KEYS` through `benchmark-transform`, inference types, `createChartDataPoint` (only when `typeof joules_per_total_token === 'number'`), roofline unions/marking, and both interactivity/e2e entries in `inference-chart-config.json`. Legacy rows without the field stay off the new chart view; unit tests cover presence, independence from J/output, and graceful omission.
> 
> **Depends on** runner emitting `joules_per_total_token` in aggregated JSON; until ingest has that field, the UI option exists but most historical points won’t plot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42fdf80787e39c09797bc085cfe722e200d7bd7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->