### PR TITLE
fix(inference): rename J/total-token title to avoid input-metric heuristic

### DIFF
--- a/packages/app/src/components/inference/inference-chart-config.json
+++ b/packages/app/src/components/inference/inference-chart-config.json
@@ -97,7 +97,7 @@
     "y_measuredJPerOutputToken_roofline": "lower_right",
     "y_measuredJPerTotalToken": "measuredJPerTotalToken.y",
     "y_measuredJPerTotalToken_label": "Measured J per Token (J/tok)",
-    "y_measuredJPerTotalToken_title": "Measured Joules per Token (input + output)",
+    "y_measuredJPerTotalToken_title": "Measured Joules per Token (incl. prompt)",
     "y_measuredJPerTotalToken_roofline": "lower_right",
     "y_cost_limit": 5,
     "y_latency_limit": 60
@@ -199,7 +199,7 @@
     "y_measuredJPerOutputToken_roofline": "lower_left",
     "y_measuredJPerTotalToken": "measuredJPerTotalToken.y",
     "y_measuredJPerTotalToken_label": "Measured J per Token (J/tok)",
-    "y_measuredJPerTotalToken_title": "Measured Joules per Token (input + output)",
+    "y_measuredJPerTotalToken_title": "Measured Joules per Token (incl. prompt)",
     "y_measuredJPerTotalToken_roofline": "lower_left",
     "y_cost_limit": 5,
     "y_latency_limit": 60


### PR DESCRIPTION
## Summary

Hot-fix on top of [#393](https://github.com/SemiAnalysisAI/InferenceX-app/pull/393): rename the Measured J per Token chart title so it doesn't accidentally trigger the input-metric X-axis swap.

## What was wrong

The inference scatter chart has a heuristic in `ChartControls.tsx`:

```typescript
const isInputMetric = title.toLowerCase().includes('input');
if (isInputMetric) {
  // swap X-axis from interactivity → P99 TTFT
}
```

This is correct behavior for true input-only metrics (input throughput, input cost) — but my title for the new J/total-token metric was `"Measured Joules per Token (input + output)"`, which contained the word "input" and tripped the heuristic incorrectly.

Visible symptom: selecting "Measured J per Token" auto-changed the X-axis to P99 TTFT instead of staying on interactivity.

## Fix

Renamed the title from `"Measured Joules per Token (input + output)"` → `"Measured Joules per Token (incl. prompt)"`. Same meaning, no "input" trigger word.

## Why not patch the heuristic instead

The substring check is intentional — it's how the codebase routes metrics into the right X-axis. Changing it would require either:
- adding a more specific flag to chart config (`_isInputMetric: true`)
- or rewriting the routing logic

Both are bigger changes than this hot-fix needs. Renaming one title string keeps the diff minimal and preserves the existing convention.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test:unit` 1944/1944 passing (no test changes needed)
- [ ] After deploy: select "Measured J per Token" → X-axis stays on interactivity (not P99 TTFT)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only chart config label changes with no logic, API, or data-path impact.
> 
> **Overview**
> Renames the **Measured J per Token** chart title in `inference-chart-config.json` from *"(input + output)"* to *"(incl. prompt)"* for both interactivity and e2e chart definitions.
> 
> The wording still describes total-token energy (prompt + generation), but drops the substring **"input"** so it no longer matches the existing `isInputMetric` title heuristic that swaps the interactivity chart X-axis to TTFT. **Measured J per Token** should keep the default interactivity X-axis instead of jumping to P99 TTFT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9ceca4f168f6884a6a1785bd238789c2b284fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->