### PR TITLE
chore: add @adibarra as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @adibarra


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` granting repo-wide review ownership to @adibarra.

## Test plan
- [ ] CODEOWNERS auto-requests @adibarra on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change; no application code, auth, or runtime behavior is affected.
> 
> **Overview**
> Adds a new **`.github/CODEOWNERS`** file so GitHub automatically requests **@adibarra** as a reviewer on pull requests that touch any path (`*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c545070f731c9ff3918b547d0cb6e92d5fd85aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->