### PR TITLE
fix(db): tolerate missing workers column in benchmark read queries / 基准测试读取查询兼容缺失的 workers 列

### DIFF
--- a/packages/db/src/queries/benchmarks.test.ts
+++ b/packages/db/src/queries/benchmarks.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DbClient } from '../connection.js';
+import { getAllBenchmarksForHistory, getLatestBenchmarks } from './benchmarks.js';
+
+/**
+ * A {@link DbClient} stand-in that records every SQL template it is handed and
+ * resolves to an empty result set. Lets us assert on the *generated SQL* without
+ * a live database — in particular that the read path never names the optional
+ * `workers` column directly.
+ *
+ * Joining the template's static segments with a ` ? ` placeholder reconstructs
+ * the literal SQL (interpolated values like model keys / dates become `?`),
+ * which is all we need to substring-match the column selection.
+ */
+function makeRecordingSql(): { sql: DbClient; sqlText: () => string } {
+  const queries: string[] = [];
+  const sql = ((strings: TemplateStringsArray, ..._values: unknown[]) => {
+    queries.push(strings.join(' ? '));
+    return Promise.resolve([]);
+  }) as DbClient;
+  return { sql, sqlText: () => queries.join('\n') };
+}
+
+/**
+ * Regression guard for the #405 fallout: the read queries must surface `workers`
+ * via `to_jsonb(row) -> 'workers'`, NOT a bare `br.workers` / `lb.workers`. A bare
+ * column reference fails to plan ("column \"workers\" does not exist") when migration
+ * 006 hasn't been applied, which 500s every cache-miss request to /api/v1/benchmarks.
+ * The to_jsonb form returns null for the absent column and lets the endpoint keep
+ * serving everything else.
+ */
+describe('benchmark read queries — workers column tolerance', () => {
+  it('getLatestBenchmarks (no-date / materialized-view branch) does not reference lb.workers directly', async () => {
+    const { sql, sqlText } = makeRecordingSql();
+    await getLatestBenchmarks(sql, 'dsr1');
+    const text = sqlText();
+    expect(text).toContain("to_jsonb(lb) -> 'workers'");
+    expect(text).not.toMatch(/\blb\.workers\b/u);
+  });
+
+  it('getLatestBenchmarks (date-filtered / base-table branch) does not reference br.workers directly', async () => {
+    const { sql, sqlText } = makeRecordingSql();
+    await getLatestBenchmarks(sql, 'dsr1', '2026-01-01');
+    const text = sqlText();
+    expect(text).toContain("to_jsonb(br) -> 'workers'");
+    expect(text).not.toMatch(/\bbr\.workers\b/u);
+  });
+
+  it('getAllBenchmarksForHistory does not reference br.workers directly', async () => {
+    const { sql, sqlText } = makeRecordingSql();
+    await getAllBenchmarksForHistory(sql, 'dsr1', 1024, 1024);
+    const text = sqlText();
+    expect(text).toContain("to_jsonb(br) -> 'workers'");
+    expect(text).not.toMatch(/\bbr\.workers\b/u);
+  });
+});

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -90,7 +90,11 @@ export async function getLatestBenchmarks(
         br.conc,
         br.image,
         br.metrics,
-        br.workers,
+        -- Read workers via to_jsonb(row)->'workers' rather than a bare column ref so the
+        -- query still plans (and returns null) if migration 006 has not been applied yet.
+        -- A bare column reference throws "column does not exist" at parse time and 500s the
+        -- whole endpoint. See migration 006_benchmark_results_workers.sql.
+        to_jsonb(br) -> 'workers' AS workers,
         br.date::text,
         CASE WHEN wr.html_url IS NOT NULL THEN wr.html_url || '/attempts/' || wr.run_attempt ELSE NULL END AS run_url
       FROM benchmark_results br
@@ -129,7 +133,8 @@ export async function getLatestBenchmarks(
       lb.conc,
       lb.image,
       lb.metrics,
-      lb.workers,
+      -- to_jsonb(row)->'workers' guard: tolerate a pre-migration-006 view (see date branch above).
+      to_jsonb(lb) -> 'workers' AS workers,
       lb.date::text,
       CASE WHEN wr.html_url IS NOT NULL THEN wr.html_url || '/attempts/' || wr.run_attempt ELSE NULL END AS run_url
     FROM latest_benchmarks lb
@@ -176,7 +181,8 @@ export async function getAllBenchmarksForHistory(
       br.osl,
       br.conc,
       br.metrics - '{std_ttft,std_tpot,std_e2el,std_intvty,std_itl,mean_ttft,mean_tpot,mean_e2el,mean_intvty,mean_itl}'::text[] as metrics,
-      br.workers,
+      -- to_jsonb(row)->'workers' guard: tolerate a pre-migration-006 base table (see getLatestBenchmarks).
+      to_jsonb(br) -> 'workers' AS workers,
       br.date::text,
       CASE WHEN wr.html_url IS NOT NULL THEN wr.html_url || '/attempts/' || wr.run_attempt ELSE NULL END AS run_url
     FROM configs c


### PR DESCRIPTION
## Problem

Production error rate on **`/api/v1/benchmarks`** spiked to ~63% immediately after **#405** merged ([Vercel error chart](#)). Root cause:

- #405 changed the read queries to `SELECT ... br.workers / lb.workers` — a column added by **migration `006_benchmark_results_workers.sql`**.
- Migrations in this repo are applied **manually** (`pnpm admin:db:migrate`), **separately** from the Vercel app deploy. The app deploy shipped the new query, but migration 006 was not applied to prod, so the column doesn't exist there.
- Postgres fails to *plan* a query that names a non-existent column (`column "workers" does not exist`), so the statement throws and the route returns **500**.

**Why ~63% and not 100%:** `/api/v1/benchmarks` is wrapped in `cachedQuery({ blobOnly: true })`. Cache **hits** return pre-#405 blobs (200); only cache **misses** run the SQL → 500. The Neon panel shows 0% connection errors because the *connection* succeeds — only the *query* fails.

## Fix

Read `workers` via **`to_jsonb(row) -> 'workers'`** in all three read paths:
- `getLatestBenchmarks` — base-table (date) branch
- `getLatestBenchmarks` — materialized-view (no-date) branch
- `getAllBenchmarksForHistory`

A JSON key lookup is a **runtime** operation that returns `NULL` for an absent key, instead of failing at **parse** time like a bare column reference. So the endpoint keeps serving every other field whether or not migration 006 has been applied. Behavior is identical once the column exists (jsonb in → jsonb out).

This makes the read path **resilient to migration/deploy ordering** — a forgotten or not-yet-run migration degrades to "workers is null" instead of taking down the endpoint.

## Note on the operational fix

This PR stops the 500s on its own. Migration 006 should **still** be applied to prod (`pnpm admin:db:migrate`) so the measured-power `workers` data is actually populated — and the cache purged afterward. This change just removes the hard dependency on migration-before-deploy ordering.

## Tests

- New `packages/db/src/queries/benchmarks.test.ts` — recording-mock `DbClient` asserts none of the three read queries reference the `workers` column directly (regression guard).
- `pnpm typecheck`, `pnpm lint`, `pnpm fmt`, and full db suite (226 tests) pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted SQL selection change on read-only benchmark queries plus unit tests; no auth or write-path changes, with identical results once migration 006 exists.
> 
> **Overview**
> Fixes production **500s on `/api/v1/benchmarks`** when the app ships before migration **006** adds the `workers` column: bare `br.workers` / `lb.workers` in `SELECT` fails at **plan** time, while **`to_jsonb(row) -> 'workers'`** still plans and yields **null** until the column exists.
> 
> All three benchmark **read** paths in `packages/db/src/queries/benchmarks.ts` are updated—`getLatestBenchmarks` (date-filtered base table and materialized-view branches) and `getAllBenchmarksForHistory`. Behavior is unchanged once migration 006 is applied.
> 
> Adds **`benchmarks.test.ts`** with a recording mock `DbClient` so generated SQL must use the `to_jsonb` form and must not match `\b(br|lb)\.workers\b`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f2a93ea87f1e134a612ae86b5a0d973afcee10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## 中文说明
修复 #405 合并后 `/api/v1/benchmarks` 约 63% 请求返回 500 的问题。根因：新查询引用了 Migration 006 添加的 `workers` 列，但该迁移尚未在生产环境执行，Postgres 在查询规划阶段即报错。修复方法：在三个读取路径中改用 `to_jsonb(row) -> 'workers'`，该操作在列不存在时返回 NULL 而非报错，从而解耦迁移与部署顺序。新增回归测试确保读取查询不直接引用 `workers` 列。
