### PR TITLE
fix: react-doctor sweep — accessibility, correctness, perf & key fixes

### DIFF
--- a/packages/app/src/app/blog/[slug]/og-image-render.tsx
+++ b/packages/app/src/app/blog/[slug]/og-image-render.tsx
@@ -102,6 +102,7 @@ export async function renderOgImage(meta: BlogPostMeta) {
             <img
               key={i}
               src={tile.src}
+              alt=""
               style={{
                 position: 'absolute',
                 left: 12 + col * 90,
@@ -180,7 +181,7 @@ export async function renderOgImage(meta: BlogPostMeta) {
               timeZone: 'UTC',
             })}
           </span>
-          <img src={logoSrc} height={80} />
+          <img src={logoSrc} height={80} alt="SemiAnalysis" />
         </div>
       </div>
     </div>,

--- a/packages/app/src/app/error.tsx
+++ b/packages/app/src/app/error.tsx
@@ -21,6 +21,7 @@ export default function Error({
       <p className="text-lg mb-4">An unexpected error has occurred.</p>
       <p className="text-md text-red-500 mb-8">{error.message}</p>
       <button
+        type="button"
         className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
         onClick={() => {
           track('error_page_retry');

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -604,6 +604,7 @@ export default function ReplayPanel({
         >
           <span className="flex-1">MP4 export failed: {exportError}</span>
           <button
+            type="button"
             onClick={() => setExportError(null)}
             className="text-destructive/70 hover:text-destructive cursor-pointer"
             aria-label="Dismiss"

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -76,6 +76,7 @@ function E2eXAxisDropdown({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
+          type="button"
           className="inline-flex items-center gap-1 hover:opacity-70 transition-opacity cursor-pointer"
           onClick={(e) => e.stopPropagation()}
         >
@@ -86,6 +87,7 @@ function E2eXAxisDropdown({
       <PopoverContent className="w-48 p-1" align="start">
         {xAxisOptions.map((opt) => (
           <button
+            type="button"
             key={opt.label}
             className={`w-full text-left px-3 py-1.5 text-sm rounded hover:bg-accent transition-colors ${
               (opt.value === null && !selectedValue) || opt.value === selectedValue
@@ -680,6 +682,7 @@ export default function ChartDisplay() {
                 />
                 {config.label}
                 <button
+                  type="button"
                   className="ml-1 hover:opacity-70"
                   onClick={() => {
                     removeTrackedConfig(config.id);

--- a/packages/app/src/components/submissions/SubmissionsTable.tsx
+++ b/packages/app/src/components/submissions/SubmissionsTable.tsx
@@ -71,6 +71,34 @@ function getModelDisplayName(dbModel: string): string {
   return dbModel;
 }
 
+function SortHeader({
+  label,
+  field,
+  sortKey,
+  sortDir,
+  onSort,
+}: {
+  label: string;
+  field: SortKey;
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (field: SortKey) => void;
+}) {
+  return (
+    <th
+      className="px-3 py-2 text-left text-xs font-medium text-muted-foreground cursor-pointer hover:text-foreground select-none"
+      onClick={() => onSort(field)}
+    >
+      <span className="flex items-center gap-1">
+        {label}
+        {sortKey === field && (
+          <span className="text-foreground">{sortDir === 'asc' ? '↑' : '↓'}</span>
+        )}
+      </span>
+    </th>
+  );
+}
+
 export default function SubmissionsTable({ data }: SubmissionsTableProps) {
   const [sortKey, setSortKey] = useState<SortKey>('date');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
@@ -147,20 +175,6 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
     });
   }, []);
 
-  const SortHeader = ({ label, field }: { label: string; field: SortKey }) => (
-    <th
-      className="px-3 py-2 text-left text-xs font-medium text-muted-foreground cursor-pointer hover:text-foreground select-none"
-      onClick={() => handleSort(field)}
-    >
-      <span className="flex items-center gap-1">
-        {label}
-        {sortKey === field && (
-          <span className="text-foreground">{sortDir === 'asc' ? '↑' : '↓'}</span>
-        )}
-      </span>
-    </th>
-  );
-
   return (
     <div className="flex flex-col gap-3">
       <input
@@ -178,13 +192,26 @@ export default function SubmissionsTable({ data }: SubmissionsTableProps) {
           <thead className="bg-muted/50">
             <tr>
               <th className="w-8 px-2" />
-              <SortHeader label="GPU" field="hardware" />
-              <SortHeader label="Model" field="model" />
-              <SortHeader label="Precision" field="precision" />
-              <SortHeader label="Spec Method" field="spec_method" />
-              <SortHeader label="Framework" field="framework" />
-              <SortHeader label="Date" field="date" />
-              <SortHeader label="Datapoints" field="total_datapoints" />
+              {(
+                [
+                  ['GPU', 'hardware'],
+                  ['Model', 'model'],
+                  ['Precision', 'precision'],
+                  ['Spec Method', 'spec_method'],
+                  ['Framework', 'framework'],
+                  ['Date', 'date'],
+                  ['Datapoints', 'total_datapoints'],
+                ] as [string, SortKey][]
+              ).map(([label, field]) => (
+                <SortHeader
+                  key={field}
+                  label={label}
+                  field={field}
+                  sortKey={sortKey}
+                  sortDir={sortDir}
+                  onSort={handleSort}
+                />
+              ))}
               <th
                 className="px-3 py-2 text-left text-xs font-medium text-muted-foreground select-none"
                 scope="col"

--- a/packages/app/src/components/ui/bottom-toast.tsx
+++ b/packages/app/src/components/ui/bottom-toast.tsx
@@ -77,6 +77,7 @@ export function BottomToast({
     >
       <div className="relative flex items-start gap-3 rounded-lg border border-border bg-card p-4 shadow-lg">
         <button
+          type="button"
           onClick={dismiss}
           className="absolute top-2 right-2 text-muted-foreground hover:text-foreground transition-colors"
           aria-label="Dismiss"
@@ -91,6 +92,7 @@ export function BottomToast({
           <p className="text-xs text-muted-foreground">{description}</p>
           {action && (
             <button
+              type="button"
               onClick={handleAction}
               className="flex items-center gap-1.5 self-end px-3 py-1.5 rounded-md text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
             >

--- a/packages/app/src/components/ui/calendar-picker-utils.tsx
+++ b/packages/app/src/components/ui/calendar-picker-utils.tsx
@@ -280,6 +280,7 @@ export function CalendarMonthPanel({
 
           return (
             <button
+              type="button"
               key={formatCalendarDate(day)}
               onClick={() => !disabled && !isDisabled && onDateClick(day)}
               onMouseEnter={() => !isDisabled && onDateHover?.(day)}

--- a/packages/app/src/components/ui/chart-buttons.tsx
+++ b/packages/app/src/components/ui/chart-buttons.tsx
@@ -110,6 +110,7 @@ export function ChartButtons({
           </PopoverTrigger>
           <PopoverContent align="end" className="w-44 p-1">
             <button
+              type="button"
               data-testid="export-png-button"
               data-ph-capture-attribute-export-type="png"
               data-ph-capture-attribute-chart={chartId}
@@ -122,6 +123,7 @@ export function ChartButtons({
             </button>
             {onExportCsv && (
               <button
+                type="button"
                 data-testid="export-csv-button"
                 data-ph-capture-attribute-export-type="csv"
                 data-ph-capture-attribute-chart={chartId}
@@ -134,6 +136,7 @@ export function ChartButtons({
             )}
             {onExportMp4 && (
               <button
+                type="button"
                 data-testid="export-mp4-button"
                 data-ph-capture-attribute-export-type="mp4"
                 data-ph-capture-attribute-chart={chartId}

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -237,6 +237,7 @@ export default function ChartLegend({
           />
           {searchQuery && (
             <button
+              type="button"
               onClick={() => {
                 track('inference_legend_search_cleared');
                 setSearchQuery('');
@@ -283,6 +284,7 @@ export default function ChartLegend({
       <div className="w-full no-export flex flex-wrap gap-x-3 gap-y-1">
         {actions.map((action) => (
           <button
+            type="button"
             key={action.id}
             data-testid={action.id}
             onClick={action.onClick}
@@ -318,6 +320,7 @@ export default function ChartLegend({
   const expandButton = hasLongText ? (
     <div className="hidden lg:block mt-2 no-export">
       <button
+        type="button"
         onClick={handleLegendExpand}
         className="text-xs text-accent-foreground hover:text-foreground flex items-center gap-1"
         aria-label={isLegendExpanded ? 'Collapse legend' : 'Expand legend'}

--- a/packages/app/src/components/ui/data-table.tsx
+++ b/packages/app/src/components/ui/data-table.tsx
@@ -160,6 +160,7 @@ export function DataTable<T>({
         />
         {search && (
           <button
+            type="button"
             onClick={() => {
               setSearch('');
               setPage(0);
@@ -286,6 +287,7 @@ export function DataTable<T>({
         </div>
         <div className="flex items-center gap-1">
           <button
+            type="button"
             onClick={() => {
               setPage((p) => Math.max(0, p - 1));
               track(`${analyticsPrefix}_page_changed`, { direction: 'prev' });
@@ -300,6 +302,7 @@ export function DataTable<T>({
             {safePage + 1} / {totalPages}
           </span>
           <button
+            type="button"
             onClick={() => {
               setPage((p) => Math.min(totalPages - 1, p + 1));
               track(`${analyticsPrefix}_page_changed`, { direction: 'next' });

--- a/packages/app/src/components/ui/multi-date-picker.tsx
+++ b/packages/app/src/components/ui/multi-date-picker.tsx
@@ -179,6 +179,7 @@ export function MultiDatePicker({
                     >
                       {formatDisplayDate(dateStr)}
                       <button
+                        type="button"
                         onClick={(e) => {
                           e.stopPropagation();
                           handleRemoveTempDate(dateStr);

--- a/packages/app/src/components/ui/multi-select.tsx
+++ b/packages/app/src/components/ui/multi-select.tsx
@@ -62,6 +62,7 @@ function MultiSelect({
 }: MultiSelectProps) {
   const [internalIsOpen, setInternalIsOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
+  const listboxId = React.useId();
   const searchStateRef = React.useRef(search);
   searchStateRef.current = search;
   const searchableRef = React.useRef(searchable);
@@ -245,6 +246,7 @@ function MultiSelect({
         role="combobox"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        aria-controls={listboxId}
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         data-slot="select-trigger"
@@ -327,6 +329,7 @@ function MultiSelect({
       {isOpen && (
         <div
           ref={contentRef}
+          id={listboxId}
           tabIndex={-1}
           data-slot="select-content"
           className={cn(

--- a/packages/app/src/components/ui/searchable-select.tsx
+++ b/packages/app/src/components/ui/searchable-select.tsx
@@ -44,6 +44,7 @@ export function SearchableSelect({
 }: SearchableSelectProps) {
   const [isOpen, setIsOpen] = React.useState(false);
   const [search, setSearch] = React.useState('');
+  const listboxId = React.useId();
   // Defer the trigger label until the component has mounted on the client.
   // The selected value derives from URL params / persisted state which only
   // resolve client-side, so SSR would otherwise lock in the default label and
@@ -125,6 +126,7 @@ export function SearchableSelect({
         role="combobox"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        aria-controls={listboxId}
         onClick={() => !disabled && setIsOpen(!isOpen)}
         disabled={disabled}
         className={cn(
@@ -188,7 +190,11 @@ export function SearchableSelect({
               )}
             </div>
           )}
-          <div className="p-1 max-h-72 overflow-y-auto custom-scrollbar">
+          <div
+            id={listboxId}
+            role="listbox"
+            className="p-1 max-h-72 overflow-y-auto custom-scrollbar"
+          >
             {filteredGroups.length === 0 && (
               <div className="text-muted-foreground px-2 py-1.5 text-sm text-center">
                 No results

--- a/packages/app/src/components/ui/unofficial-banner.tsx
+++ b/packages/app/src/components/ui/unofficial-banner.tsx
@@ -62,6 +62,7 @@ export function UnofficialBanner({ runs, onDismissRun, onDismissAll }: Unofficia
         </div>
         {multiple && onDismissAll && (
           <button
+            type="button"
             onClick={() => {
               track('unofficial_banner_dismissed_all', { count: runs.length });
               onDismissAll();
@@ -107,6 +108,7 @@ function RunChip({
       </a>
       {onDismiss && (
         <button
+          type="button"
           onClick={() => {
             track('unofficial_banner_run_dismissed', { branch: run.branch });
             onDismiss();


### PR DESCRIPTION
## What

Ran `npx react-doctor@latest` (https://react.doctor) against the app and worked the findings down across two commits. The initial scan reported **616 issues / 45→100 (Critical)**; this PR brings it to **415 issues / 63→100 (Needs work)** — **201 issues resolved**, all **behavior-preserving**.

| | Issues | Score |
| --- | --- | --- |
| Before | 616 | 45 (Critical) |
| After | 415 | 63 (Needs work) |

### Commit 1 — blocking errors (a11y + correctness)
- `no-nested-component-definition`: hoisted `SortHeader` out of `SubmissionsTable` to module scope (stable identity instead of remount-per-render).
- `alt-text` (2), `role-has-required-aria-props` (2): OG-image alt text; `aria-controls` on combobox triggers.
- `button-has-type` (20): explicit `type="button"` on chart/UI buttons.

### Commit 2 — warning sweep (~187 fixes, 83 files)
Run as a **15-agent parallel workflow** partitioned by file (each file owned by exactly one agent — no edit collisions). Every agent fetched the canonical fix recipe per rule and stayed strictly behavior-preserving.
- **Perf**: `js-combine-iterations` (48), `js-set-map-lookups` (10), `js-flatmap-filter` (7), `js-index-maps` (5), `js-hoist-intl` (2), `js-batch-dom-css` (2) — single-pass loops / Set lookups, identical output.
- **Design (visually identical)**: `design-no-space-on-flex-children` (21, space-y/x → gap), `design-no-redundant-size-axes` (4, h-4 w-4 → size-4), `design-no-redundant-padding-axes` (3).
- **React 19**: `no-react19-deprecated-apis` (17, e.g. `useContext` → `use`).
- **Deps**: `exhaustive-deps` (12) — added stable setters/callbacks (no-op) or genuinely missing deps; removed unused deps.
- **A11y**: `control-has-associated-label` (9), `click-events-have-key-events` (5), `interactive-supports-focus` (4), `prefer-tag-over-role` (3), `label-has-associated-control` (2), `no-static-element-interactions` (1).
- **Keys**: `no-array-index-key` (10), `no-array-index-as-key` (7) → stable data-derived keys.
- **State**: date-picker / multi-date-picker `no-derived-state-effect` + `no-chain-state-updates` — moved `setError('')` from an effect into the open-change handler.
- **Misc**: `client-localstorage-no-version` (3), `rerender-memo-with-default-value` (2), `no-usememo-simple-expression` (2), `no-generic-handler-names` (2), `prefer-module-scope-static-value` (1), `rendering-hydration-mismatch-time` (1).

## Deliberately NOT changed (387 findings skipped, each with a recorded reason)

- **26 State & Effects errors + most of that category**: many are **false positives** (e.g. `no-event-handler` firing on `useChartData` hook args) or carry **real behavior risk** in the inference/eval/global context providers and the D3 render/zoom lifecycle. react-doctor itself warns against blindly adding deps — these are left for targeted human review.
- **`nextjs-no-img-element`**: the agents converted 4 `<img>` → `next/image`; **I reverted all 4**. The logos are SVGs with varied aspect ratios and the watermark is 552×228 — `next/image` forces a single width/height (distortion) and SVG needs `dangerouslyAllowSVG`. Kept raw `<img>`; the rule is a perf nicety, not correctness.
- **Visible-copy rules** (em-dash, ellipsis, vague-button-label), **giant-component splits**, and **cross-file export moves** (`only-export-components`) — out of scope; need a content or architecture decision.

## Verification

- `pnpm typecheck` ✅ · `pnpm lint` (app src, 0/0) ✅ · `pnpm fmt` ✅
- `pnpm test:unit` ✅ — **2201 tests pass** (1944 app + 212 db + 25 mcp + 20 constants)
- Pre-commit hooks (lint/format/typecheck) green on both commits.
- Spot-checked the highest-risk applied changes (the 48 `js-combine-iterations` rewrites preserve order/output; the 16 effect/dep changes are no-ops or genuinely-missing deps).

## Overlay support

The touched code is shared UI primitives, perf/a11y cleanups, and context plumbing used by **both** the official and `?unofficialrun=` paths — no inference/eval chart-data feature was added or branched, so overlay behavior is unchanged. Verified via the existing overlay unit/E2E tests (all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
