### PR TITLE
fix: auto-add unofficial-run precision so ATOM/MTP overlay renders

### DIFF
--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -36,7 +36,10 @@ import {
   Sequence,
   SEQUENCE_OPTIONS,
 } from '@/lib/data-mappings';
-import { computeAutoSwitchDecision } from '@/lib/unofficial-run-auto-switch';
+import {
+  computeAutoAddPrecisionDecision,
+  computeAutoSwitchDecision,
+} from '@/lib/unofficial-run-auto-switch';
 import type { AvailabilityRow, WorkflowInfoResponse } from '@/lib/api';
 
 interface RunInfo {
@@ -300,6 +303,28 @@ export function GlobalFilterProvider({
     if (valid.length > 0) return valid;
     return availablePrecisions.length > 0 ? [availablePrecisions[0]] : selectedPrecisions;
   }, [selectedPrecisions, availablePrecisions]);
+
+  // Auto-add a run precision to the user's selection when an unofficial run
+  // is loaded whose precisions don't intersect the current `selectedPrecisions`.
+  // Without this, e.g. an fp8-only ATOM/MTP overlay is silently filtered out
+  // because the default `i_prec` is `fp4` — the chart loads, model is
+  // auto-switched, but no overlay points render. Same dedupe-ref pattern as
+  // the model auto-switch so manual deselects after the fact aren't undone.
+  const lastAutoAddPrecKeyRef = useRef<string>('');
+  useEffect(() => {
+    const decision = computeAutoAddPrecisionDecision(
+      unofficialAvailable,
+      getUrlParam('i_prec'),
+      selectedPrecisions,
+      selectedModel,
+      effectiveSequence,
+      lastAutoAddPrecKeyRef.current,
+    );
+    lastAutoAddPrecKeyRef.current = decision.nextKey;
+    if (decision.precisionToAdd !== null) {
+      setSelectedPrecisionsRaw([...new Set([...selectedPrecisions, decision.precisionToAdd])]);
+    }
+  }, [unofficialAvailable, selectedModel, effectiveSequence, selectedPrecisions, getUrlParam]);
 
   // Dates available for selected model + sequence + precisions
   const availableDates = useMemo(() => {

--- a/packages/app/src/lib/unofficial-run-auto-switch.test.ts
+++ b/packages/app/src/lib/unofficial-run-auto-switch.test.ts
@@ -3,10 +3,17 @@ import { describe, expect, it } from 'vitest';
 import type { AvailableModelSequence } from '@/components/unofficial-run-provider';
 import { Model, Sequence } from '@/lib/data-mappings';
 
-import { computeAutoSwitchDecision } from './unofficial-run-auto-switch';
+import {
+  computeAutoAddPrecisionDecision,
+  computeAutoSwitchDecision,
+} from './unofficial-run-auto-switch';
 
-function entry(model: Model, sequence: Sequence): AvailableModelSequence {
-  return { model, sequence, precisions: [] };
+function entry(
+  model: Model,
+  sequence: Sequence,
+  precisions: string[] = [],
+): AvailableModelSequence {
+  return { model, sequence, precisions };
 }
 
 describe('computeAutoSwitchDecision', () => {
@@ -109,6 +116,165 @@ describe('computeAutoSwitchDecision', () => {
     const a = computeAutoSwitchDecision(orderA, undefined, Model.DeepSeek_R1, '');
     const b = computeAutoSwitchDecision(orderB, undefined, Model.DeepSeek_R1, '');
     expect(a.modelToSet).toBe(b.modelToSet);
+    expect(a.nextKey).toBe(b.nextKey);
+  });
+});
+
+describe('computeAutoAddPrecisionDecision', () => {
+  it('returns no-op and resets the key when no unofficial run is loaded', () => {
+    expect(
+      computeAutoAddPrecisionDecision(
+        [],
+        undefined,
+        ['fp4'],
+        Model.DeepSeek_R1,
+        Sequence.EightK_OneK,
+        'stale-key',
+      ),
+    ).toEqual({ nextKey: '', precisionToAdd: null });
+  });
+
+  it('adds the run precision when the user filter does not intersect it (ATOM/MTP case)', () => {
+    // Regression for issue #412: an ATOM/MTP run is fp8-only, default i_prec is fp4,
+    // so the overlay points are silently filtered out by ScatterGraph.
+    const run = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp8'])];
+    const decision = computeAutoAddPrecisionDecision(
+      run,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    expect(decision.precisionToAdd).toBe('fp8');
+    expect(decision.nextKey).toBe(`${Model.DeepSeek_R1}|${Sequence.EightK_OneK}|fp8`);
+  });
+
+  it('respects an explicit i_prec URL pin without advancing the dedupe key', () => {
+    const run = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp8'])];
+    const decision = computeAutoAddPrecisionDecision(
+      run,
+      'fp4',
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    expect(decision.precisionToAdd).toBeNull();
+    // Ref must NOT be advanced — if the URL pin is later removed we still want
+    // the auto-add to fire on the same overlay set.
+    expect(decision.nextKey).toBe('');
+  });
+
+  it('does nothing when the user already has at least one run precision selected', () => {
+    const run = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp4', 'fp8'])];
+    const decision = computeAutoAddPrecisionDecision(
+      run,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    expect(decision.precisionToAdd).toBeNull();
+    // Key still advances so we don't keep re-evaluating on every render.
+    expect(decision.nextKey).toBe(`${Model.DeepSeek_R1}|${Sequence.EightK_OneK}|fp4,fp8`);
+  });
+
+  it('does nothing when the run has no precisions for the current model+sequence', () => {
+    // Overlay is for a different model — auto-add must not pick precisions
+    // from an unrelated entry. (e.g. multi-run overlay where the user has
+    // navigated to a model only some runs cover.)
+    const run = [entry(Model.Kimi_K2_5, Sequence.EightK_OneK, ['fp8'])];
+    const decision = computeAutoAddPrecisionDecision(
+      run,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      'prev-key',
+    );
+    expect(decision.precisionToAdd).toBeNull();
+    expect(decision.nextKey).toBe('prev-key');
+  });
+
+  it('does not re-fire after the user removes the auto-added precision', () => {
+    // Simulate the post-auto-add state: ref already holds the run's key,
+    // user manually removed fp8 from their selection. We must NOT re-add it.
+    const run = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp8'])];
+    const lastKey = `${Model.DeepSeek_R1}|${Sequence.EightK_OneK}|fp8`;
+    const decision = computeAutoAddPrecisionDecision(
+      run,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      lastKey,
+    );
+    expect(decision.precisionToAdd).toBeNull();
+    expect(decision.nextKey).toBe(lastKey);
+  });
+
+  it('re-arms after the overlay set is cleared so a subsequent load can add again', () => {
+    // Step 1: a run loads, fp8 auto-added.
+    const run = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp8'])];
+    const first = computeAutoAddPrecisionDecision(
+      run,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    expect(first.precisionToAdd).toBe('fp8');
+
+    // Step 2: user dismisses the run, overlay set goes empty — ref resets.
+    const cleared = computeAutoAddPrecisionDecision(
+      [],
+      undefined,
+      ['fp4', 'fp8'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      first.nextKey,
+    );
+    expect(cleared).toEqual({ nextKey: '', precisionToAdd: null });
+
+    // Step 3: a new run loads with a precision still not in the user's filter.
+    const run2 = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['bf16'])];
+    const second = computeAutoAddPrecisionDecision(
+      run2,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      cleared.nextKey,
+    );
+    expect(second.precisionToAdd).toBe('bf16');
+  });
+
+  it('picks the first precision deterministically when the run has multiple', () => {
+    // Same set of precisions in two different orders should auto-add the same
+    // target. `parseAvailableModelsAndSequences` builds precisions from a
+    // `Set`, so insertion order is not guaranteed across renders.
+    const orderA = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['fp8', 'bf16', 'int4'])];
+    const orderB = [entry(Model.DeepSeek_R1, Sequence.EightK_OneK, ['int4', 'fp8', 'bf16'])];
+    const a = computeAutoAddPrecisionDecision(
+      orderA,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    const b = computeAutoAddPrecisionDecision(
+      orderB,
+      undefined,
+      ['fp4'],
+      Model.DeepSeek_R1,
+      Sequence.EightK_OneK,
+      '',
+    );
+    expect(a.precisionToAdd).toBe(b.precisionToAdd);
     expect(a.nextKey).toBe(b.nextKey);
   });
 });

--- a/packages/app/src/lib/unofficial-run-auto-switch.ts
+++ b/packages/app/src/lib/unofficial-run-auto-switch.ts
@@ -1,11 +1,22 @@
 import type { AvailableModelSequence } from '@/components/unofficial-run-provider';
-import type { Model } from '@/lib/data-mappings';
+import type { Model, Sequence } from '@/lib/data-mappings';
 
 export interface AutoSwitchDecision {
   /** New value the caller should write into the dedupe ref. */
   nextKey: string;
   /** Model to switch to, or null when no switch is needed. */
   modelToSet: Model | null;
+}
+
+export interface AutoAddPrecisionDecision {
+  /** New value the caller should write into the dedupe ref. */
+  nextKey: string;
+  /**
+   * Precision the caller should add to the user's `selectedPrecisions` set,
+   * or null when no addition is needed. Always a single key picked
+   * deterministically from the run's precisions.
+   */
+  precisionToAdd: string | null;
 }
 
 /**
@@ -45,4 +56,67 @@ export function computeAutoSwitchDecision(
     return { nextKey: key, modelToSet: null };
   }
   return { nextKey: key, modelToSet: sortedModels[0] };
+}
+
+/**
+ * Pure decision helper for auto-adding an unofficial-run precision into the
+ * user's `selectedPrecisions` set. Companion to `computeAutoSwitchDecision` —
+ * model auto-switch handles the case where the run's model differs from the
+ * current selection, this handles the case where the run's *precision* for
+ * the current (model, sequence) is not in the user's filter.
+ *
+ * Without this, navigating to `?unofficialrun=<id>` for a run whose precision
+ * is outside the default (`fp4`) leaves the overlay invisible: `ScatterGraph`
+ * filters overlay points by `selectedPrecisions`, so an fp8-only ATOM/MTP
+ * run renders no points despite the data being loaded.
+ *
+ * Behavior:
+ * - Empty overlay set → reset the dedupe key so a subsequent load re-arms.
+ * - `urlPrec` pinned (user pinned `i_prec=...` in the URL) → no-op; respect
+ *   intent. The key is *not* advanced so a later URL clear can still re-fire.
+ * - If the run has no precisions for the current (model, sequence) → no-op
+ *   (the user has navigated to a model/seq the run doesn't cover; nothing
+ *   to add).
+ * - If `selectedPrecisions` already intersects the run's precisions → no-op
+ *   but advance the dedupe key so we don't keep re-evaluating.
+ * - Otherwise: return the alphabetically-first run precision so the caller
+ *   can merge it into `selectedPrecisions`. Picked from a sorted list to
+ *   stay deterministic across insertion orders.
+ *
+ * The dedupe key includes model, sequence, and the sorted set of run
+ * precisions so a manual change to any of those re-evaluates the decision,
+ * while incidental re-renders (e.g. unrelated state changes) do not.
+ */
+export function computeAutoAddPrecisionDecision(
+  unofficialAvailable: AvailableModelSequence[],
+  urlPrec: string | undefined,
+  selectedPrecisions: readonly string[],
+  selectedModel: Model,
+  effectiveSequence: Sequence,
+  lastKey: string,
+): AutoAddPrecisionDecision {
+  if (unofficialAvailable.length === 0) {
+    return { nextKey: '', precisionToAdd: null };
+  }
+  if (urlPrec) {
+    return { nextKey: lastKey, precisionToAdd: null };
+  }
+  const runPrecisions = [
+    ...new Set(
+      unofficialAvailable
+        .filter((a) => a.model === selectedModel && a.sequence === effectiveSequence)
+        .flatMap((a) => a.precisions),
+    ),
+  ].toSorted();
+  if (runPrecisions.length === 0) {
+    return { nextKey: lastKey, precisionToAdd: null };
+  }
+  const key = `${selectedModel}|${effectiveSequence}|${runPrecisions.join(',')}`;
+  if (lastKey === key) {
+    return { nextKey: lastKey, precisionToAdd: null };
+  }
+  if (selectedPrecisions.some((p) => runPrecisions.includes(p))) {
+    return { nextKey: key, precisionToAdd: null };
+  }
+  return { nextKey: key, precisionToAdd: runPrecisions[0] };
 }


### PR DESCRIPTION
Fixes #412.

## Summary

When `?unofficialrun=<id>` loaded a run whose precision was outside the default `i_prec=fp4`, `ScatterGraph` silently filtered every overlay point out. The ATOM/MTP nightly run 26744033059 is fp8-only on mi355x, which is why this surfaced now.

Added `computeAutoAddPrecisionDecision` to augment `selectedPrecisions` with the first run precision when the user's filter doesn't intersect the overlay's. Mirrors the existing `computeAutoSwitchDecision` for model. URL-pinned `i_prec` is respected.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm fmt && pnpm test:unit` clean
- [x] 7 new unit tests for the helper (no-op, auto-add, URL pin, intersect, no-data, post-deselect, re-arm, deterministic order)
- [x] Verified locally with Playwright MCP at `/inference?unofficialRun=26744033059` - overlay now renders with FP4+FP8 both active
- [x] `&i_prec=fp4` correctly suppresses the auto-add (URL intent respected)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side filter UX only; mirrors existing unofficial model auto-switch with URL respect and dedupe, covered by unit tests.
> 
> **Overview**
> Fixes unofficial-run overlays disappearing when the loaded run’s precision doesn’t match the active filter (e.g. default **`fp4`** while the run is **`fp8`**-only), so chart points were filtered out even after model auto-switch.
> 
> Adds **`computeAutoAddPrecisionDecision`** alongside the existing model auto-switch helper: when an unofficial run is active for the current model/sequence and **`selectedPrecisions`** doesn’t overlap the run’s precisions, it picks one run precision (sorted, deterministic) for the UI to merge in. URL-pinned **`i_prec`**, empty overlays, no matching model/seq, and post-deselect dedupe behave like the model path.
> 
> **`GlobalFilterContext`** wires a new effect with a dedupe ref so auto-add runs once per overlay set and doesn’t undo manual precision removal. Unit tests cover the regression and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d6820d5bee9e49811ae401b43425af91b0b2fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->