### PR TITLE
feat(header): pride rainbow theme for InferenceX wordmark

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -40,6 +40,24 @@
   content: none;
 }
 
+/* Pride theme for the InferenceX wordmark — celebrating June Pride Month.
+   Paints the brand text with the 6-stripe rainbow flag via a clipped gradient. */
+.pride-wordmark {
+  background-image: linear-gradient(
+    90deg,
+    #e40303 0%,
+    #ff8c00 20%,
+    #ffed00 40%,
+    #008026 60%,
+    #004dff 80%,
+    #750787 100%
+  );
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+
 /* Shiki dual-theme: light by default, dark when .dark class is active */
 .shiki,
 .shiki span {

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -103,7 +103,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
         <div className="flex h-14 items-center gap-6">
           {/* Brand */}
           <Link href="/" className="flex items-center gap-2 shrink-0">
-            <span className="text-lg font-bold tracking-tight">InferenceX</span>
+            <span className="pride-wordmark text-lg font-bold tracking-tight">InferenceX</span>
             <span className="hidden sm:flex items-center gap-1.5 text-xs text-muted-foreground">
               by
               <Image


### PR DESCRIPTION
## Summary

Celebrate **June Pride Month** 🏳️‍🌈 by painting the "InferenceX" wordmark in the header with a 6-stripe rainbow flag gradient.

- Adds a `.pride-wordmark` utility in `globals.css` that clips a 6-color rainbow gradient (red → orange → yellow → green → blue → purple) to the text.
- Applies it to the "InferenceX" wordmark `<span>` in the header brand link.
- Uses fixed flag colors (not theme tokens), so it renders legibly in light, dark, and minecraft modes.

The SemiAnalysis partner logo image is left untouched.

## Verification

Ran the dev server and captured the header in both modes — the gradient renders cleanly and the wordmark stays legible:

- ✅ Light mode
- ✅ Dark / minecraft mode

Pre-commit `lint`, `format`, and `typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic header/CSS only; no auth, data, or API behavior changes.
> 
> **Overview**
> Adds a **June Pride Month** rainbow treatment to the header **InferenceX** wordmark only.
> 
> A new `.pride-wordmark` rule in `globals.css` uses a fixed six-stripe horizontal gradient with `background-clip: text` so the label reads as rainbow in light, dark, and minecraft themes. The header brand `<span>` picks up that class; the SemiAnalysis partner image is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35fc38935319b1d341d86c8c0e3a4da7710a9bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->