### PR TITLE
fix(db): exclude eval_samples/server_logs from dump to fit GitHub 2 GiB cap / 排除 eval_samples 和 server_logs 以适应 GitHub 2 GiB 上传限制

### DIFF
--- a/packages/db/src/dump-db.ts
+++ b/packages/db/src/dump-db.ts
@@ -9,7 +9,7 @@
 import { createWriteStream, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { TABLE_INSERT_ORDER } from '@semianalysisai/inferencex-constants';
+import { TABLE_INSERT_ORDER, TABLE_NAMES } from '@semianalysisai/inferencex-constants';
 
 import { hasNoSslFlag } from './cli-utils';
 import { createAdminSql } from './etl/db-utils';
@@ -17,6 +17,24 @@ import { createAdminSql } from './etl/db-utils';
 const sql = createAdminSql({ noSsl: hasNoSslFlag(), readonly: true, max: 1 });
 
 const CURSOR_BATCH = 100;
+
+/**
+ * Tables excluded from the dump by default.
+ *
+ * The weekly public dump is published as a GitHub release asset, which is
+ * hard-capped at 2 GiB (2_147_483_648 bytes). These two tables dominate the
+ * archive — eval_samples (~1.7 GB compressed) + server_logs (~345 MB) are
+ * ~99% of the zip — while the analytically useful tables are tiny
+ * (benchmark_results is only ~20 MB). Including them pushed the archive past
+ * the cap, so every dump since 2026-05-18 failed with
+ * `size must be less than 2147483648`. Excluding them drops the zip from
+ * ~2.07 GB to ~0.36 GB and unblocks the weekly release.
+ *
+ * Set DUMP_INCLUDE_ALL=1 for a complete backup (e.g. when writing somewhere
+ * without the 2 GiB asset limit).
+ */
+const DEFAULT_SKIP = new Set<string>([TABLE_NAMES.evalSamples, TABLE_NAMES.serverLogs]);
+const SKIP = process.env.DUMP_INCLUDE_ALL === '1' ? new Set<string>() : DEFAULT_SKIP;
 
 /** Stream a table to a JSON file using a cursor, writing row-by-row. */
 async function streamTable(table: string, outPath: string): Promise<number> {
@@ -54,6 +72,10 @@ async function dump(): Promise<void> {
   console.log(`  Output: ${outDir}\n`);
 
   for (const table of TABLE_INSERT_ORDER) {
+    if (SKIP.has(table)) {
+      console.log(`  ${table}... skipped (excluded from dump; set DUMP_INCLUDE_ALL=1 to include)`);
+      continue;
+    }
     process.stdout.write(`  ${table}...`);
     const outPath = resolve(outDir, `${table}.json`);
     const count = await streamTable(table, outPath);


### PR DESCRIPTION
## Problem

The weekly public DB dump (`db-backup.yml`, cron Mondays `0 0 * * 1`) publishes a zip as a **GitHub release asset**, which is hard-capped at **2 GiB** (`2_147_483_648` bytes).

Every dump since **2026-05-18** has failed during `gh release create` with:

```
size must be less than 2147483648
```

The 2026-05-11 archive (the last good one) was already **2.072 GB** — 96.5% of the cap. The next week tipped over.

## Root cause

Two tables dominate the archive and are ~99% of its size:

| table | compressed | share |
|---|---|---|
| `eval_samples` | ~1.7 GB | ~82% |
| `server_logs` | ~345 MB | ~17% |
| `benchmark_results` (the analytically useful one) | ~20 MB | ~1% |

## Fix

Exclude `eval_samples` and `server_logs` from the dump by default. This drops the zip from **~2.07 GB → ~0.36 GB**, well under the cap, and unblocks the weekly release.

- Opt back in to a **full backup** with `DUMP_INCLUDE_ALL=1`.
- `load-dump.ts` already skips missing table files (`skip <table> (file not found)`), so restores round-trip cleanly without these two files.
- No change to `benchmark_results` / `configs` / `workflow_runs` / `run_stats` etc. — all still dumped.

## Verification

- [ ] Manually trigger `db-backup.yml` (`workflow_dispatch`) on this branch and confirm the asset uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 中文说明
数据库每周公开备份因 `eval_samples`（压缩后约 1.7 GB，占 82%）和 `server_logs`（约 345 MB，占 17%）导致压缩包超过 GitHub Release 资产的 2 GiB 上限，自 2026-05-18 起持续失败。修复方法：将这两个表从默认导出中排除，压缩包从约 2.07 GB 降至约 0.36 GB。可通过 `DUMP_INCLUDE_ALL=1` 恢复完整备份。`benchmark_results` 等分析核心表不受影响。
