### PR TITLE
fix: increase timeout for db-backup

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backup:
-    timeout-minutes: 30
+    timeout-minutes: 120
     runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
       contents: write


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single CI timeout tweak with no application or data-path logic changes.
> 
> **Overview**
> Raises the **`backup` job** timeout in **`.github/workflows/db-backup.yml`** from **30** to **120** minutes so the weekly scheduled dump (export, xz compression, split, and release upload) can finish without GitHub Actions canceling the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2680b9d740b38f5885861acd8c8d1b238e2ed4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->