### PR TITLE
fix: further improve db backup

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -29,15 +29,23 @@ jobs:
         run: |
           set -euo pipefail
           DUMP_DIR="inferencex-dump-$(date -u +%Y-%m-%d)"
+          ( s=0; while sleep 30; do s=$((s + 30)); sz=$(du -sh "packages/db/$DUMP_DIR" 2>/dev/null | cut -f1); printf '  [dump] running %dm%02ds, %s written...\n' $((s / 60)) $((s % 60)) "${sz:-0B}"; done ) &
+          trap 'kill %1 2>/dev/null || true' EXIT
           pnpm admin:db:dump "$DUMP_DIR"
-          # Keep every table intact: tar the dump, compress with xz/lzma2, and split into
-          # <2 GiB parts to stay under GitHub's per-release-asset cap (even as data grows).
+          echo "DUMP_DIR=${DUMP_DIR}" >> "$GITHUB_ENV"
+          echo "TAG=db-dump/$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
+      - name: Compress and split dump
+        run: |
+          set -euo pipefail
+          ( s=0; while sleep 30; do s=$((s + 30)); sz=$(du -ch "${GITHUB_WORKSPACE}/${DUMP_DIR}".tar.xz.part* 2>/dev/null | tail -1 | cut -f1); printf '  [compress] running %dm%02ds, %s written...\n' $((s / 60)) $((s % 60)) "${sz:-0B}"; done ) &
+          trap 'kill %1 2>/dev/null || true' EXIT
           ( cd packages/db
             tar -cf - "$DUMP_DIR" \
-              | xz -T0 --lzma2=preset=9e,dict=192MiB \
+              | xz -v -T0 --memlimit-compress=95% --lzma2=preset=9e,dict=192MiB \
               | split -b 1900m -d -a 2 - "${GITHUB_WORKSPACE}/${DUMP_DIR}.tar.xz.part" )
           echo "DUMP_GLOB=${DUMP_DIR}.tar.xz.part*" >> "$GITHUB_ENV"
-          echo "TAG=db-dump/$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes only affect the scheduled GitHub Actions backup pipeline, not runtime app or database access patterns.
> 
> **Overview**
> Splits the weekly DB backup workflow so **dump** and **compress/split** run as separate steps, with `DUMP_DIR` / `TAG` exported after the dump and compression moved into its own job step.
> 
> Both long-running steps now spawn a **30s heartbeat** background loop (elapsed time + bytes written) and clean it up with an `EXIT` trap so logs stay visible on slow runs.
> 
> Compression uses **`xz -v`** and **`--memlimit-compress=95%`** alongside the existing LZMA2 settings, aiming for safer memory use on the large runner during tar→xz→split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86ee1641893a58721ee2e76c0b9ea4a3e265def8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->