### PR TITLE
fix: update db backup release notes

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -53,5 +53,5 @@ jobs:
           # $DUMP_GLOB is intentionally unquoted so the shell expands it to every part file.
           gh release create "$TAG" $DUMP_GLOB \
             --title "DB Dump $(date -u +%Y-%m-%d)" \
-            --notes "Weekly full database dump (xz-compressed, split into <2 GiB parts). Reassemble: cat *.tar.xz.part* | xz -d | tar -x" \
+            --notes "Weekly full database dump (xz-compressed, split into <2 GiB parts). Reassemble: `cat *.tar.xz.part* | xz -d | tar -x`" \
             --latest=false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic change to release note text in an existing workflow; no database or application runtime impact.
> 
> **Overview**
> Updates the **Create release** step in the database backup workflow so the reassembly shell one-liner in `gh release create --notes` is wrapped in backticks for GitHub-flavored markdown (inline code in the release body).
> 
> No changes to dump, compress, split, or upload behavior—only the text shown on weekly DB dump releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84fcc7c85c7e2e5835dcff5e7961000289648c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->