### PR TITLE
chore: bump mem limit and remove progress for db backup

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -38,7 +38,7 @@ jobs:
           set -euo pipefail
           ( cd packages/db
             tar -cf - "$DUMP_DIR" \
-              | xz -v -T0 --memlimit-compress=95% --lzma2=preset=9e,dict=192MiB \
+              | xz -v -T0 --memlimit-compress=99% --lzma2=preset=9e,dict=192MiB \
               | split -b 1900m -d -a 2 - "${GITHUB_WORKSPACE}/${DUMP_DIR}.tar.xz.part" )
           echo "DUMP_GLOB=${DUMP_DIR}.tar.xz.part*" >> "$GITHUB_ENV"
 

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -29,8 +29,6 @@ jobs:
         run: |
           set -euo pipefail
           DUMP_DIR="inferencex-dump-$(date -u +%Y-%m-%d)"
-          ( s=0; while sleep 30; do s=$((s + 30)); sz=$(du -sh "packages/db/$DUMP_DIR" 2>/dev/null | cut -f1); printf '  [dump] running %dm%02ds, %s written...\n' $((s / 60)) $((s % 60)) "${sz:-0B}"; done ) &
-          trap 'kill %1 2>/dev/null || true' EXIT
           pnpm admin:db:dump "$DUMP_DIR"
           echo "DUMP_DIR=${DUMP_DIR}" >> "$GITHUB_ENV"
           echo "TAG=db-dump/$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
@@ -38,8 +36,6 @@ jobs:
       - name: Compress and split dump
         run: |
           set -euo pipefail
-          ( s=0; while sleep 30; do s=$((s + 30)); sz=$(du -ch "${GITHUB_WORKSPACE}/${DUMP_DIR}".tar.xz.part* 2>/dev/null | tail -1 | cut -f1); printf '  [compress] running %dm%02ds, %s written...\n' $((s / 60)) $((s % 60)) "${sz:-0B}"; done ) &
-          trap 'kill %1 2>/dev/null || true' EXIT
           ( cd packages/db
             tar -cf - "$DUMP_DIR" \
               | xz -v -T0 --memlimit-compress=95% --lzma2=preset=9e,dict=192MiB \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no app or data-path logic; slightly higher runner memory use during compression is the only operational tradeoff.
> 
> **Overview**
> Simplifies the weekly **Database Dump** GitHub Actions workflow by dropping the 30-second background progress loggers on the dump and compress steps (and their `trap` cleanup).
> 
> Raises **xz** compression memory from `--memlimit-compress=95%` to **99%** on the same `lzma2=preset=9e,dict=192MiB` pipeline before splitting into ~1.9 GiB parts for release upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21c7a3c1149d5f4c4d183f8777b5b0589b89257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->