### PR TITLE
fix: update release notes format in db backup workflow

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -49,5 +49,5 @@ jobs:
           # $DUMP_GLOB is intentionally unquoted so the shell expands it to every part file.
           gh release create "$TAG" $DUMP_GLOB \
             --title "DB Dump $(date -u +%Y-%m-%d)" \
-            --notes "Weekly full database dump (xz-compressed, split into <2 GiB parts). Reassemble: `cat *.tar.xz.part* | xz -d | tar -x`" \
+            --notes 'Weekly full database dump (xz-compressed, split into parts under 2 GiB). Reassemble: `cat *.tar.xz.part* | xz -d | tar -x`' \
             --latest=false


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only changes release note string quoting and wording in a scheduled workflow; no dump, upload, or database logic changes.
> 
> **Overview**
> Fixes how the weekly DB backup workflow sets **GitHub release notes** when publishing split dump artifacts.
> 
> The `gh release create --notes` value is switched from **double quotes to single quotes** so the shell does not interpret metacharacters (e.g. `<` in size text or backticks in the reassemble example). The note text is slightly reworded: “split into **parts under 2 GiB**” instead of “&lt;2 GiB parts”; the documented reassemble command is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2833fcddaaf7faed07aeea7a3c6ec9162e1a0ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->