### PR TITLE
chore: tweak timing for feedback modal

### DIFF
--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -197,7 +197,7 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
     trigger: { type: 'immediate' },
     dismissal: {
       type: 'timed',
-      durationMs: 24 * 60 * 60 * 1000,
+      durationMs: 3 * 24 * 60 * 60 * 1000,
       cooldownStartsOnShow: true,
     },
     storageKey: 'inferencex-feedback-modal-snoozed',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single constant change in nudge timing with no auth, data, or API impact.
> 
> **Overview**
> Extends the dashboard **feedback modal** snooze/cooldown from **1 day** to **3 days** by updating `dismissal.durationMs` on the `feedback-modal` nudge in the registry.
> 
> Behavior is unchanged otherwise: timed dismissal still starts when the modal is shown (`cooldownStartsOnShow`), and submitting feedback still permanently suppresses it via `permanentSuppressKey` / `FEEDBACK_SUBMITTED_EVENT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20f971e839e9a34135d348ff5abf89b0927c1103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->