### PR TITLE
feat(inference): default to DeepSeek-V4-Pro model

### DIFF
--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -2,7 +2,10 @@ describe('Model Architecture Diagram', () => {
   before(() => {
     // Use desktop viewport to ensure all UI elements are visible
     cy.viewport(1280, 800);
-    cy.visit('/inference', {
+    // Pin to DeepSeek R1 — it has a rich architecture diagram (MoE + dense blocks)
+    // that the tests below exercise. The app's default model is DeepSeek V4 Pro,
+    // which has no architecture entry, so we select R1 explicitly via URL.
+    cy.visit('/inference?g_model=DeepSeek-R1-0528', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
@@ -11,7 +14,7 @@ describe('Model Architecture Diagram', () => {
     cy.get('[data-testid="inference-chart-display"]').should('be.visible');
   });
 
-  it('architecture toggle renders for default model (DeepSeek R1) with MoE badges', () => {
+  it('architecture toggle renders for DeepSeek R1 with MoE badges', () => {
     cy.get('[data-testid="model-architecture-toggle"]').should('be.visible');
     cy.get('[data-testid="model-architecture-toggle"]').should(
       'contain.text',

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -141,7 +141,7 @@ export function GlobalFilterProvider({
 
   // ── Core filter state ─────────────────────────────────────────────────────
   const [selectedModel, setSelectedModel] = useState<Model>(
-    () => initialModel ?? Model.DeepSeek_R1,
+    () => initialModel ?? Model.DeepSeek_V4_Pro,
   );
 
   const [selectedSequence, setSelectedSequence] = useState<Sequence>(() => {

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -27,7 +27,7 @@ describe('PARAM_DEFAULTS', () => {
 
   it('has expected default for g_model', async () => {
     const { PARAM_DEFAULTS } = await import('@/lib/url-state');
-    expect(PARAM_DEFAULTS.g_model).toBe('DeepSeek-R1-0528');
+    expect(PARAM_DEFAULTS.g_model).toBe('DeepSeek-V4-Pro');
   });
 
   it('has expected default for i_seq', async () => {
@@ -164,7 +164,7 @@ describe('writeUrlParams + buildShareUrl', () => {
     const { writeUrlParams, buildShareUrl } = await import('@/lib/url-state');
 
     // write default value, should be omitted
-    writeUrlParams({ g_model: 'DeepSeek-R1-0528' });
+    writeUrlParams({ g_model: 'DeepSeek-V4-Pro' });
     await vi.advanceTimersByTimeAsync(200);
 
     const url = buildShareUrl();
@@ -375,14 +375,14 @@ describe('buildShareUrl unofficialrun handling', () => {
   });
 
   it('preserves unofficialruns alongside other in-memory share params', async () => {
-    setupWindow('?unofficialruns=111&g_model=DeepSeek-R1-0528', '/inference');
+    setupWindow('?unofficialruns=111&g_model=DeepSeek-V4-Pro', '/inference');
     const { writeUrlParams, buildShareUrl } = await import('@/lib/url-state');
 
-    writeUrlParams({ g_model: 'DeepSeek-V4-Pro' });
+    writeUrlParams({ g_model: 'DeepSeek-R1-0528' });
     await vi.advanceTimersByTimeAsync(200);
 
     const url = buildShareUrl();
-    expect(url).toContain('g_model=DeepSeek-V4-Pro');
+    expect(url).toContain('g_model=DeepSeek-R1-0528');
     expect(url).toContain('unofficialruns=111');
   });
 

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -60,7 +60,7 @@ export type UrlStateParams = Partial<Record<UrlStateKey, string>>;
 
 /** Default values for each parameter. Params matching their default are omitted from share URLs. */
 export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
-  g_model: 'DeepSeek-R1-0528',
+  g_model: 'DeepSeek-V4-Pro',
   g_rundate: '',
   g_runid: '',
   i_seq: '8k/1k',


### PR DESCRIPTION
## What

Changes the default selected model on page load from **DeepSeek-R1-0528** to **DeepSeek-V4-Pro** (1.6T / 49B active).

## Changes

- **`GlobalFilterContext.tsx`** — initial `selectedModel` now defaults to `Model.DeepSeek_V4_Pro` (still overridable via `initialModel` prop / `?g_model=` URL param).
- **`url-state.ts`** — `PARAM_DEFAULTS.g_model` → `'DeepSeek-V4-Pro'`, so the new default is omitted from share URLs (and the old R1 value is now serialized when explicitly selected).
- **`url-state.test.ts`** — assert the new default; swap the omit/preserve fixtures so they still test the intended behavior against the new default.
- **`model-architecture.cy.ts`** — pin the architecture-diagram suite to `?g_model=DeepSeek-R1-0528` explicitly. Those tests exercise R1's MoE + dense block diagram; DSv4-Pro has no entry in `MODEL_ARCHITECTURES`, so the diagram (correctly) renders nothing for it. Decoupling the suite from the app default keeps it valid.

## Notes

- Backward-compat fallbacks left intentionally unchanged: `LEGACY_BARE_DEFAULT_MODEL_SLUG` (`compare-slug.ts`) and the AI-chart invalid-input fallback still reference R1, so existing shared `/compare` links keep resolving.
- DSv4-Pro is already a visible, non-deprecated `default`-category model with data ingested, so it's a valid landing model.

## Verification

- `pnpm typecheck` ✅
- `pnpm fmt` ✅
- `vitest run src/lib/url-state.test.ts` — 35 passed ✅
- Pre-commit hook (lint/format/typecheck on changed files) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized default-model and URL-serialization change with no auth or data-path edits; legacy compare fallbacks for R1 are intentionally unchanged.
> 
> **Overview**
> **Inference now lands on DeepSeek V4 Pro** instead of DeepSeek R1 when no `?g_model=` or `initialModel` is set. The same default is wired in **`GlobalFilterContext`** (`Model.DeepSeek_V4_Pro`) and **`PARAM_DEFAULTS.g_model`** in `url-state.ts`, so share URLs omit `g_model` for V4 Pro and include it when users explicitly pick R1.
> 
> **Tests** follow the new default: Vitest asserts `DeepSeek-V4-Pro` and updates omit/preserve share-URL fixtures. The **model architecture Cypress suite** visits `/inference?g_model=DeepSeek-R1-0528` so MoE/diagram coverage stays on R1, which still has architecture data—V4 Pro does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61f766f9eaa7dae5ad321dca60dcaa544b554267. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->