### PR TITLE
fix: update precision for known issue warning

### DIFF
--- a/packages/app/src/lib/known-issues.test.ts
+++ b/packages/app/src/lib/known-issues.test.ts
@@ -47,8 +47,8 @@ describe('matchKnownConfigIssues', () => {
 
   it('returns each issue at most once even with many matching points', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
       { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(2);

--- a/packages/app/src/lib/known-issues.test.ts
+++ b/packages/app/src/lib/known-issues.test.ts
@@ -5,17 +5,17 @@ import { KNOWN_CONFIG_ISSUES, knownIssueCsvNote, matchKnownConfigIssues } from '
 const DSR1 = 'DeepSeek-R1-0528';
 
 describe('matchKnownConfigIssues', () => {
-  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP4', () => {
+  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP8', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
     ]);
     expect(issues).toHaveLength(1);
     expect(issues[0].url).toBe('https://github.com/NVIDIA/srt-slurm/issues/51');
   });
 
-  it('does not match GB300 Dynamo TRT MTP for non-FP4 precisions', () => {
+  it('does not match GB300 Dynamo TRT MTP for non-FP8 precisions', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(0);
   });

--- a/packages/app/src/lib/known-issues.ts
+++ b/packages/app/src/lib/known-issues.ts
@@ -29,7 +29,7 @@ export const KNOWN_CONFIG_ISSUES: KnownConfigIssue[] = [
   {
     hwKey: 'gb300_dynamo-trt_mtp',
     model: Model.DeepSeek_R1,
-    precisions: ['fp4'],
+    precisions: ['fp8'],
     summary: 'Accuracy issues',
     filed: 'Apr 21, 2026',
     url: 'https://github.com/NVIDIA/srt-slurm/issues/51',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small data correction in known-issue matching and tests only; no auth, security, or runtime behavior beyond which precision shows the warning.
> 
> **Overview**
> Corrects which precision triggers the known upstream warning for **GB300 Dynamo TRT MTP** + **DeepSeek R1**: `KNOWN_CONFIG_ISSUES` now lists **`fp8`** instead of **`fp4`**, so chart warnings and CSV notes align with the actual affected configuration.
> 
> Unit tests in `known-issues.test.ts` were updated to expect a match on `fp8` and no match on `fp4` for that entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e696cd402c93a36a14fd5f9b335488194bb293c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->