### PR TITLE
fix(inference): correct known-issue precisions

### DIFF
--- a/packages/app/src/lib/known-issues.test.ts
+++ b/packages/app/src/lib/known-issues.test.ts
@@ -5,27 +5,34 @@ import { KNOWN_CONFIG_ISSUES, knownIssueCsvNote, matchKnownConfigIssues } from '
 const DSR1 = 'DeepSeek-R1-0528';
 
 describe('matchKnownConfigIssues', () => {
-  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP8', () => {
+  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP4', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(1);
     expect(issues[0].url).toBe('https://github.com/NVIDIA/srt-slurm/issues/51');
   });
 
-  it('does not match GB300 Dynamo TRT MTP for non-FP8 precisions', () => {
+  it('does not match GB300 Dynamo TRT MTP for non-FP4 precisions', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
     ]);
     expect(issues).toHaveLength(0);
   });
 
-  it('matches the MI355X MoRI SGLang MTP entry regardless of precision', () => {
-    for (const precision of ['fp4', 'fp8']) {
-      const issues = matchKnownConfigIssues(DSR1, [{ hwKey: 'mi355x_mori-sglang_mtp', precision }]);
-      expect(issues).toHaveLength(1);
-      expect(issues[0].url).toBe('https://github.com/sgl-project/sglang/issues/27194');
-    }
+  it('matches the MI355X MoRI SGLang MTP entry for DeepSeek R1 FP8', () => {
+    const issues = matchKnownConfigIssues(DSR1, [
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp8' },
+    ]);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].url).toBe('https://github.com/sgl-project/sglang/issues/27194');
+  });
+
+  it('does not match MI355X MoRI SGLang MTP for non-FP8 precisions', () => {
+    const issues = matchKnownConfigIssues(DSR1, [
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
+    ]);
+    expect(issues).toHaveLength(0);
   });
 
   it('does not match other models', () => {
@@ -47,9 +54,9 @@ describe('matchKnownConfigIssues', () => {
 
   it('returns each issue at most once even with many matching points', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
-      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp8' },
     ]);
     expect(issues).toHaveLength(2);
   });

--- a/packages/app/src/lib/known-issues.ts
+++ b/packages/app/src/lib/known-issues.ts
@@ -29,7 +29,7 @@ export const KNOWN_CONFIG_ISSUES: KnownConfigIssue[] = [
   {
     hwKey: 'gb300_dynamo-trt_mtp',
     model: Model.DeepSeek_R1,
-    precisions: ['fp8'],
+    precisions: ['fp4'],
     summary: 'Accuracy issues',
     filed: 'Apr 21, 2026',
     url: 'https://github.com/NVIDIA/srt-slurm/issues/51',
@@ -38,6 +38,7 @@ export const KNOWN_CONFIG_ISSUES: KnownConfigIssue[] = [
   {
     hwKey: 'mi355x_mori-sglang_mtp',
     model: Model.DeepSeek_R1,
+    precisions: ['fp8'],
     summary: 'Accuracy issues',
     filed: 'Jun 4, 2026',
     url: 'https://github.com/sgl-project/sglang/issues/27194',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small data-only change to warning metadata; wrong precisions would mislabel charts but does not affect inference execution or auth.
> 
> **Overview**
> Corrects which **DeepSeek R1** benchmark precisions trigger known-issue warnings on inference charts and in CSV exports.
> 
> **GB300 Dynamo TRT MTP** (`NVIDIA/srt-slurm#51`) is now limited to **fp4** instead of fp8. **MI355X MoRI SGLang MTP** (`sgl-project/sglang#27194`) is now limited to **fp8** instead of matching every precision. `known-issues.test.ts` is updated so each entry has positive and negative precision cases aligned with those rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d786dbdf00a5815f3eed5acaa62cf4df17f60868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->