### PR TITLE
fix(inference): swap known-issue precisions back (GB300 FP8, MI355X FP4)

### DIFF
--- a/packages/app/src/lib/known-issues.test.ts
+++ b/packages/app/src/lib/known-issues.test.ts
@@ -5,32 +5,32 @@ import { KNOWN_CONFIG_ISSUES, knownIssueCsvNote, matchKnownConfigIssues } from '
 const DSR1 = 'DeepSeek-R1-0528';
 
 describe('matchKnownConfigIssues', () => {
-  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP4', () => {
+  it('matches the GB300 Dynamo TRT MTP entry for DeepSeek R1 FP8', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
     ]);
     expect(issues).toHaveLength(1);
     expect(issues[0].url).toBe('https://github.com/NVIDIA/srt-slurm/issues/51');
   });
 
-  it('does not match GB300 Dynamo TRT MTP for non-FP4 precisions', () => {
+  it('does not match GB300 Dynamo TRT MTP for non-FP8 precisions', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(0);
   });
 
-  it('matches the MI355X MoRI SGLang MTP entry for DeepSeek R1 FP8', () => {
+  it('matches the MI355X MoRI SGLang MTP entry for DeepSeek R1 FP4', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp8' },
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(1);
     expect(issues[0].url).toBe('https://github.com/sgl-project/sglang/issues/27194');
   });
 
-  it('does not match MI355X MoRI SGLang MTP for non-FP8 precisions', () => {
+  it('does not match MI355X MoRI SGLang MTP for non-FP4 precisions', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp8' },
     ]);
     expect(issues).toHaveLength(0);
   });
@@ -54,9 +54,9 @@ describe('matchKnownConfigIssues', () => {
 
   it('returns each issue at most once even with many matching points', () => {
     const issues = matchKnownConfigIssues(DSR1, [
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
-      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp4' },
-      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'gb300_dynamo-trt_mtp', precision: 'fp8' },
+      { hwKey: 'mi355x_mori-sglang_mtp', precision: 'fp4' },
     ]);
     expect(issues).toHaveLength(2);
   });

--- a/packages/app/src/lib/known-issues.ts
+++ b/packages/app/src/lib/known-issues.ts
@@ -29,7 +29,7 @@ export const KNOWN_CONFIG_ISSUES: KnownConfigIssue[] = [
   {
     hwKey: 'gb300_dynamo-trt_mtp',
     model: Model.DeepSeek_R1,
-    precisions: ['fp4'],
+    precisions: ['fp8'],
     summary: 'Accuracy issues',
     filed: 'Apr 21, 2026',
     url: 'https://github.com/NVIDIA/srt-slurm/issues/51',
@@ -38,7 +38,7 @@ export const KNOWN_CONFIG_ISSUES: KnownConfigIssue[] = [
   {
     hwKey: 'mi355x_mori-sglang_mtp',
     model: Model.DeepSeek_R1,
-    precisions: ['fp8'],
+    precisions: ['fp4'],
     summary: 'Accuracy issues',
     filed: 'Jun 4, 2026',
     url: 'https://github.com/sgl-project/sglang/issues/27194',


### PR DESCRIPTION
## Summary

#441 applied the precision swap to the wrong entries — it set GB300 Dynamo TRT MTP to FP4 and MI355X MoRI SGLang MTP to FP8, which is backwards. This PR sets the correct precisions:

- **GB300 Dynamo TRT MTP** → **FP8** (NVIDIA/srt-slurm#51)
- **MI355X MoRI SGLang MTP** → **FP4** (sgl-project/sglang#27194)

## Testing

- All 39 tests pass across `known-issues.test.ts`, `knownIssueAnnotations.test.ts`, and `csv-export.test.ts`; tests updated to assert the corrected precisions.
- Data-only change to the `KNOWN_CONFIG_ISSUES` registry — no matching-logic or rendering changes, so the official and `?unofficialrun=` overlay annotation paths are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only precision strings in `KNOWN_CONFIG_ISSUES` with no matching or UI logic changes; only which benchmark points show known-issue warnings is affected.
> 
> **Overview**
> Corrects **known-config issue** precision filters that were swapped in a prior change: **GB300 Dynamo TRT MTP** now matches **FP8** (NVIDIA/srt-slurm#51), and **MI355X MoRI SGLang MTP** matches **FP4** (sgl-project/sglang#27194).
> 
> `known-issues.test.ts` is updated so positive/negative match cases and the deduplication scenario use those precisions. Matching, chart warnings, and CSV notes still use the same `matchKnownConfigIssues` logic—only which `(hwKey, precision)` pairs trigger warnings changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7afd522fd3ffefb6971da516214508d230f686f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->