### PR TITLE
feat(constants): render atom-disagg as Mooncake ATOM framework

### DIFF
--- a/packages/constants/src/framework-aliases.test.ts
+++ b/packages/constants/src/framework-aliases.test.ts
@@ -2,13 +2,28 @@ import { describe, expect, it } from 'vitest';
 
 import {
   FRAMEWORK_ALIASES,
+  FRAMEWORK_LABELS,
   resolveFrameworkAlias,
   resolveFrameworkAliasesInString,
 } from './framework-aliases';
 
+describe('FRAMEWORK_LABELS', () => {
+  it('labels the canonical mooncake-atom framework "Mooncake ATOM¹"', () => {
+    expect(FRAMEWORK_LABELS['mooncake-atom']).toBe('Mooncake ATOM¹');
+  });
+
+  it('labels the atom-disagg alias with its canonical label', () => {
+    expect(FRAMEWORK_LABELS['atom-disagg']).toBe('Mooncake ATOM¹');
+  });
+});
+
 describe('FRAMEWORK_ALIASES', () => {
   it('maps sglang-disagg to mori-sglang with disagg=true', () => {
     expect(FRAMEWORK_ALIASES['sglang-disagg']).toEqual({ canonical: 'mori-sglang', disagg: true });
+  });
+
+  it('maps atom-disagg to mooncake-atom with disagg=true', () => {
+    expect(FRAMEWORK_ALIASES['atom-disagg']).toEqual({ canonical: 'mooncake-atom', disagg: true });
   });
 
   it('maps trtllm to trt', () => {
@@ -27,6 +42,10 @@ describe('resolveFrameworkAlias', () => {
 
   it('resolves dynamo-trtllm to dynamo-trt', () => {
     expect(resolveFrameworkAlias('dynamo-trtllm')).toBe('dynamo-trt');
+  });
+
+  it('resolves atom-disagg to mooncake-atom', () => {
+    expect(resolveFrameworkAlias('atom-disagg')).toBe('mooncake-atom');
   });
 
   it('is case-insensitive', () => {
@@ -51,6 +70,12 @@ describe('resolveFrameworkAliasesInString', () => {
   it('replaces dynamo-trtllm in a config key', () => {
     expect(resolveFrameworkAliasesInString('gptoss-fp8-gb200-dynamo-trtllm')).toBe(
       'gptoss-fp8-gb200-dynamo-trt',
+    );
+  });
+
+  it('replaces atom-disagg in a config key', () => {
+    expect(resolveFrameworkAliasesInString('dsv4-fp4-mi355x-atom-disagg')).toBe(
+      'dsv4-fp4-mi355x-mooncake-atom',
     );
   });
 

--- a/packages/constants/src/framework-aliases.ts
+++ b/packages/constants/src/framework-aliases.ts
@@ -9,6 +9,7 @@ export const FW_REGISTRY: Record<string, FwEntry> = {
   'dynamo-sglang': { label: 'Dynamo SGLang' },
   'dynamo-trt': { label: 'Dynamo TRT' },
   'dynamo-vllm': { label: 'Dynamo vLLM' },
+  'mooncake-atom': { label: 'Mooncake ATOM¹' },
   'mori-sglang': { label: 'MoRI SGLang' },
   sglang: { label: 'SGLang' },
   trt: { label: 'TRT' },
@@ -26,6 +27,7 @@ export const SPEC_METHOD_KEYS = new Set(['mtp', 'none']);
  * Single source of truth — consumed by ETL, frontend, and changelog processing.
  */
 export const FRAMEWORK_ALIASES: Record<string, { canonical: string; disagg?: boolean }> = {
+  'atom-disagg': { canonical: 'mooncake-atom', disagg: true },
   'sglang-disagg': { canonical: 'mori-sglang', disagg: true },
   trtllm: { canonical: 'trt' },
   'dynamo-trtllm': { canonical: 'dynamo-trt' },

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -204,6 +204,17 @@ describe('normalizeFramework', () => {
     });
   });
 
+  it('normalizes atom-disagg to mooncake-atom + disagg=true', () => {
+    expect(normalizeFramework('atom-disagg', false)).toEqual({
+      framework: 'mooncake-atom',
+      disagg: true,
+    });
+    expect(normalizeFramework('ATOM-DISAGG', false)).toEqual({
+      framework: 'mooncake-atom',
+      disagg: true,
+    });
+  });
+
   it('renames dynamo-trtllm to dynamo-trt and forces disagg=true (framework implies it)', () => {
     expect(normalizeFramework('dynamo-trtllm', false)).toEqual({
       framework: 'dynamo-trt',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small constants-only change with tests; ETL and UI pick up aliases automatically with no auth or data-schema changes.
> 
> **Overview**
> Adds **`mooncake-atom`** to the shared framework registry with display label **Mooncake ATOM¹**, and maps the legacy **`atom-disagg`** identifier to that canonical key with **`disagg: true`** in `FRAMEWORK_ALIASES` (same pattern as `sglang-disagg` → `mori-sglang`).
> 
> Because ETL `normalizeFramework` and UI label resolution already read these constants, `atom-disagg` in artifacts and config keys (e.g. `dsv4-fp4-mi355x-atom-disagg`) now normalize to `mooncake-atom` and show as Mooncake ATOM¹. Coverage is extended in `framework-aliases` and ETL normalizer tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35789e4decfd8be115b1f5273933339982f2952a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->