### PR TITLE
feat: add minimaxm3 model mapping (MiniMax M3 428B)

### DIFF
--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -8,6 +8,7 @@ export enum Model {
   Qwen3_5 = 'Qwen-3.5-397B-A17B',
   Kimi_K2_5 = 'Kimi-K2.5',
   MiniMax_M2_5 = 'MiniMax-M2.5',
+  MiniMax_M3 = 'MiniMax-M3',
   GLM_5 = 'GLM-5',
   DeepSeek_V4_Pro = 'DeepSeek-V4-Pro',
 }
@@ -87,6 +88,11 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
     label: 'MiniMax M2.5/2.7 230B',
     prefix: 'minimaxm2.5',
+    category: 'default',
+  },
+  [Model.MiniMax_M3]: {
+    label: 'MiniMax M3 428B',
+    prefix: 'minimaxm3',
     category: 'default',
   },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -24,6 +24,10 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
       expect.arrayContaining(['minimaxm2.5', 'minimaxm2.7']),
     );
   });
+
+  it('maps minimaxm3 to its own MiniMax-M3 display name', () => {
+    expect(DISPLAY_MODEL_TO_DB['MiniMax-M3']).toEqual(['minimaxm3']);
+  });
 });
 
 describe('sequenceToIslOsl', () => {

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -15,6 +15,7 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   'kimik2.6': 'Kimi-K2.5',
   'minimaxm2.5': 'MiniMax-M2.5',
   'minimaxm2.7': 'MiniMax-M2.5',
+  minimaxm3: 'MiniMax-M3',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5',
   dsv4: 'DeepSeek-V4-Pro',


### PR DESCRIPTION
Adds the `minimaxm3` DB key → `MiniMax-M3` display mapping and the `MiniMax M3 428B` model config entry, with a unit test for the new mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only model registration and mapping changes with no auth, data migration, or runtime logic changes.
> 
> **Overview**
> Adds **MiniMax M3** (`MiniMax-M3` / DB key `minimaxm3`) across the app model registry and shared DB↔display mappings so benchmark data for that bucket shows up in the UI like other default models.
> 
> In `data-mappings.ts`, introduces `Model.MiniMax_M3` with label **MiniMax M3 428B** and prefix `minimaxm3` in the default category. In `packages/constants/src/models.ts`, maps `minimaxm3` to `MiniMax-M3` (its own display name, not grouped with M2.5/M2.7). A unit test asserts `DISPLAY_MODEL_TO_DB['MiniMax-M3']` is `['minimaxm3']`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998eb8460386ec0a32197b86fe0b694c11341b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->