### PR TITLE
feat: add Kimi K2.7-Code to point-release grouping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 | DeepSeek-V4-Pro        | 1.6T  | 49B         | `deepseek-ai/DeepSeek-V4-Pro`       | HF model card                      |
 | Kimi-K2.5              | 1T    | 32B         | `moonshotai/Kimi-K2.5`              | HF model card                      |
 | Kimi-K2.6              | 1T    | 32B         | `moonshotai/Kimi-K2.6`              | HF model card                      |
+| Kimi-K2.7-Code         | 1T    | 32B         | `moonshotai/Kimi-K2.7-Code`         | HF model card                      |
 | Qwen3.5-397B-A17B      | 397B  | 17B         | `Qwen/Qwen3.5-397B-A17B`            | HF model card                      |
 | GLM-5                  | 744B  | 40B         | `zai-org/GLM-5`                     | HF model card                      |
 | GLM-5.1                | 744B  | 40B         | `zai-org/GLM-5.1-FP8`               | HF model card (same base as GLM-5) |
@@ -161,7 +162,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 - **GLM-5 ≠ 355B.** 355B is GLM-4.5. GLM-5 jumped to 744B / 40B active (256-expert MoE with DSA).
 - **MiniMax-M2.5/M2.7 ≠ 456B.** 456B is the older MiniMax-Text-01 / M1 (32 large experts). The M2 series is a different architecture: 230B / 10B active, 256 small experts.
 - **DeepSeek-R1 is 671B, not 685B.** HF metadata shows 685B because the bundled MTP head adds ~14B; the core MoE is 671B / 37B active.
-- **Kimi K2.5 and K2.6 are post-training refinements**, not new pre-trained sizes. Same 1T / 32B / 384-expert backbone as the original K2.
+- **Kimi K2.5, K2.6, and K2.7-Code are post-training refinements**, not new pre-trained sizes. Same 1T / 32B / 384-expert backbone as the original K2. K2.7-Code is a coding-focused refinement of the same backbone.
 
 ## Common Development Tasks
 

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -12,7 +12,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more. Pick the cheapest SKU for your workload.';
+  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6/K2.7-Code 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more. Pick the cheapest SKU for your workload.';
 
 export const metadata: Metadata = {
   title: 'GPU Performance per Dollar',

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -13,7 +13,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more.';
+  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6/K2.7-Code 1T, GLM 5/5.1, Qwen 3.5 397B-A17B, and more.';
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',

--- a/packages/app/src/components/about/faq-data.ts
+++ b/packages/app/src/components/about/faq-data.ts
@@ -37,6 +37,7 @@ const gpusByVendor = [...GPU_KEYS].reduce<Record<string, string[]>>((acc, key) =
 const modelNames = Object.values({
   ...DB_MODEL_TO_DISPLAY,
   'kimik2.6': 'Kimi-K2.6',
+  'kimik2.7-code': 'Kimi-K2.7-Code',
   'minimaxm2.7': 'MiniMax-M2.7',
   'glm5.1': 'GLM-5.1',
 });

--- a/packages/app/src/components/submissions/submissions-utils.test.ts
+++ b/packages/app/src/components/submissions/submissions-utils.test.ts
@@ -302,6 +302,7 @@ describe('buildInferenceCompareUrl', () => {
       ['glm5.1', 'GLM-5'],
       ['llama70b', 'Llama-3.3-70B-Instruct-FP8'],
       ['kimik2.6', 'Kimi-K2.5'],
+      ['kimik2.7-code', 'Kimi-K2.5'],
       ['minimaxm2.7', 'MiniMax-M2.5'],
     ];
     for (const [dbModel, expectedDisplay] of cases) {

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -80,8 +80,9 @@ export function buildInferenceCompareUrl(
   previousRow: SubmissionSummaryRow,
 ): string | null {
   // DB_MODEL_TO_DISPLAY covers every DB prefix incl. point-release aliases
-  // (gptoss120b, glm5.1, kimik2.6, minimaxm2.7, llama70b). MODEL_PREFIX_MAPPING
-  // only has the single canonical prefix per Model enum and misses those rows.
+  // (gptoss120b, glm5.1, kimik2.6, kimik2.7-code, minimaxm2.7, llama70b).
+  // MODEL_PREFIX_MAPPING only has the single canonical prefix per Model enum
+  // and misses those rows.
   const displayModel = DB_MODEL_TO_DISPLAY[currentRow.model];
   if (!displayModel) return null;
   const hwKey = buildAvailabilityHwKey(

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -241,7 +241,7 @@ describe('compareModelDisplayLabel', () => {
       'DeepSeek R1 — H100 vs H200',
     );
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
-      'Kimi K2.5/K2.6 1T — GB200 NVL72 vs MI355X',
+      'Kimi K2.5/K2.6/K2.7-Code 1T — GB200 NVL72 vs MI355X',
     );
   });
 });

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -51,15 +51,15 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'kimi-k26',
     displayName: 'Kimi-K2.5',
-    // Both K2.5 and K2.6 point releases share an architecture (mirroring
+    // K2.5, K2.6, and K2.7-Code point releases share an architecture (mirroring
     // DISPLAY_MODEL_TO_DB in packages/constants/src/models.ts). The slug uses
-    // the newer version name; the dbKey list pulls data from both DB buckets
-    // so the slug is populated today and stays populated when K2.6 data lands.
-    dbKeys: ['kimik2.6', 'kimik2.5'],
-    // Slug groups two point releases sharing one architecture — the header
-    // surfaces both versions so the URL doesn't read as "only K2.6". Param
+    // the K2.6 version name for URL stability; the dbKey list pulls data from
+    // all three DB buckets so the slug stays populated across point releases.
+    dbKeys: ['kimik2.7-code', 'kimik2.6', 'kimik2.5'],
+    // Slug groups three point releases sharing one architecture — the header
+    // surfaces every version so the URL doesn't read as "only K2.6". Param
     // count appended so the label conveys model scale alongside the version.
-    label: 'Kimi K2.5/K2.6 1T',
+    label: 'Kimi K2.5/K2.6/K2.7-Code 1T',
   },
   {
     slug: 'glm-5-1',

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -188,7 +188,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.DeepSeek_V4_Pro)).toBe('DeepSeek V4 Pro 1.6T');
     expect(getModelLabel(Model.GptOss)).toBe('gpt-oss 120B');
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
-    expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6 1T');
+    expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
     expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -73,11 +73,11 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     exclusion: MTP_ENGINE_EXCLUSION,
   },
   [Model.Kimi_K2_5]: {
-    // K2.5 and K2.6 share an architecture, so the dropdown surfaces both
-    // versions joined with a slash — matches the GLM5/5.1 pattern. The
+    // K2.5, K2.6, and K2.7-Code share an architecture, so the dropdown surfaces
+    // all versions joined with a slash — matches the GLM5/5.1 pattern. The
     // hyphenated `Model.Kimi_K2_5` enum value stays as-is for internal
     // routing / DB key mapping.
-    label: 'Kimi K2.5/2.6 1T',
+    label: 'Kimi K2.5/2.6/2.7-Code 1T',
     prefix: 'kimik2.5',
     category: 'default',
   },

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -18,7 +18,7 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
   it('groups point-release DB keys under the same display name', () => {
     expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
     expect(DISPLAY_MODEL_TO_DB['Kimi-K2.5']).toEqual(
-      expect.arrayContaining(['kimik2.5', 'kimik2.6']),
+      expect.arrayContaining(['kimik2.5', 'kimik2.6', 'kimik2.7-code']),
     );
     expect(DISPLAY_MODEL_TO_DB['MiniMax-M2.5']).toEqual(
       expect.arrayContaining(['minimaxm2.5', 'minimaxm2.7']),

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -13,6 +13,7 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   'qwen3.5': 'Qwen-3.5-397B-A17B',
   'kimik2.5': 'Kimi-K2.5',
   'kimik2.6': 'Kimi-K2.5',
+  'kimik2.7-code': 'Kimi-K2.5',
   'minimaxm2.5': 'MiniMax-M2.5',
   'minimaxm2.7': 'MiniMax-M2.5',
   glm5: 'GLM-5',

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -86,8 +86,10 @@ export const MODEL_TO_KEY: Record<string, string> = {
   // Qwen3.5
   'Qwen/Qwen3.5-397B-A17B': 'qwen3.5',
   'Qwen/Qwen3.5-397B-A17B-FP8': 'qwen3.5',
-  // Kimi-K2.5
+  // Kimi-K2.5 / K2.6 / K2.7-Code (same architecture, distinct DB buckets)
   'moonshotai/Kimi-K2.5': 'kimik2.5',
+  'moonshotai/Kimi-K2.6': 'kimik2.6',
+  'moonshotai/Kimi-K2.7-Code': 'kimik2.7-code',
   // MiniMax-M2.5
   'MiniMaxAI/MiniMax-M2.5': 'minimaxm2.5',
   // GLM-5


### PR DESCRIPTION
Adds `kimik2.7-code` as a third DB key under the `Kimi-K2.5` display name, mirroring the existing K2.5/K2.6 point-release grouping (same pattern as GLM-5/5.1 and MiniMax-M2.5/M2.7).

Verified: dropdown label, /about FAQ, compare page title, all app unit tests (2039/2039), typecheck, lint, fmt.

Closes #448

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Label and DB-key mapping changes only; no inference chart logic, auth, or schema migrations beyond ingest path aliases.
> 
> **Overview**
> Adds **Kimi K2.7-Code** as a third Kimi point release on the same 1T / 32B backbone, grouped with K2.5 and K2.6 under the single **`Kimi-K2.5`** display name (same pattern as GLM-5/5.1 and MiniMax M2.5/M2.7).
> 
> The new DB key `kimik2.7-code` is wired through **`DB_MODEL_TO_DISPLAY`**, compare **`dbKeys`** on the `kimi-k26` slug, **`MODEL_CONFIG`** / dropdown labels (`Kimi K2.5/2.6/2.7-Code 1T`), ETL **`MODEL_TO_KEY`** for `moonshotai/Kimi-K2.7-Code`, and copy on compare index pages, About FAQ, and **`AGENTS.md`**. Unit tests are updated for mappings, compare labels, and submission compare URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d71ce0a8d2446792e59f7fe217d893f2ea319653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->