### PR TITLE
fix(inference): move MiniMax M3 between Kimi and Qwen in model dropdown

### DIFF
--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -82,17 +82,17 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'kimik2.5',
     category: 'default',
   },
+  [Model.MiniMax_M3]: {
+    label: 'MiniMax M3 428B',
+    prefix: 'minimaxm3',
+    category: 'default',
+  },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
     label: 'MiniMax M2.5/2.7 230B',
     prefix: 'minimaxm2.5',
-    category: 'default',
-  },
-  [Model.MiniMax_M3]: {
-    label: 'MiniMax M3 428B',
-    prefix: 'minimaxm3',
     category: 'default',
   },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },


### PR DESCRIPTION
Moves the `Model.MiniMax_M3` entry in `MODEL_CONFIG` (packages/app/src/lib/data-mappings.ts) so the model dropdown lists MiniMax M3 428B between Kimi K2.5/2.6/2.7-Code 1T and Qwen3.5 397B. Dropdown order is derived from `MODEL_CONFIG` key order via `MODEL_OPTIONS`, so this is a pure key reorder — no label, prefix, or category changes.

No test changes needed: existing tests only assert label lookups, not dropdown order (`data-mappings.test.ts` passes, 33/33). Overlay path unaffected — this changes selector ordering only, not chart data handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI ordering-only change in `data-mappings.ts` with no routing, API, or model metadata changes.
> 
> **Overview**
> **Reorders the model dropdown** by moving the `Model.MiniMax_M3` block in `MODEL_CONFIG` so **MiniMax M3 428B** lists between **Kimi K2.5/2.6/2.7-Code 1T** and **Qwen3.5 397B** (previously after MiniMax M2.5/2.7).
> 
> Selector order comes from `Object.keys(MODEL_CONFIG)` via `MODEL_OPTIONS`; **labels, prefixes, and categories are unchanged**—only key order in the config object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2048ec5a27e1cc04696b33c6a9c382a266a95c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->