### PR TITLE
feat(compare): add MiniMax M3 to compare model registry

### DIFF
--- a/docs/adding-entities.md
+++ b/docs/adding-entities.md
@@ -71,6 +71,15 @@ Present what you inferred and get confirmation + category in a single step. Incl
 
 Everything else (`MODEL_OPTIONS`, `DEFAULT_MODELS`, `EXPERIMENTAL_MODELS`, `DEPRECATED_MODELS`, `MODEL_PREFIX_MAPPING`, `getModelLabel()`) is derived automatically.
 
+**`packages/app/src/lib/compare-slug.ts`** (easy to miss — the /compare and /compare-per-dollar pages do NOT derive from `MODEL_CONFIG`):
+
+- `COMPARE_MODEL_SLUGS` — add an entry with `{ slug, displayName, dbKeys, label }`. `displayName` must match the `Model` enum value; `dbKeys` lists the DB buckets to query. Place it per the ordering comment (Chinese-lab flagships first, newer family member leads). Without this entry the model is absent from /compare, /compare-per-dollar, the sitemap, and their OG images.
+- `COMPARE_MODEL_ALIASES` — only if a family-level or older-version slug should 308 to the new entry.
+
+**`packages/app/src/lib/compare-ssr.ts`**:
+
+- `KNOWN_MODELS` — add the display name so `?g_model=` URL overrides validate on compare pages.
+
 ---
 
 ## Featuring a Day-0 Model

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -43,6 +43,15 @@ describe('parseCompareSlug — new model-prefixed form', () => {
     expect(parsed?.b).toBe('gb200');
   });
 
+  it('parses the minimax-m3 slug as its own model, distinct from minimax-m27', () => {
+    const parsed = parseCompareSlug('minimax-m3-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('minimax-m3');
+    expect(parsed?.model.dbKeys).toEqual(['minimaxm3']);
+    expect(parsed?.a).toBe('h100');
+    expect(parsed?.b).toBe('h200');
+    expect(parsed?.isAliasModel).toBe(false);
+  });
+
   it('preserves non-canonical GPU order so caller can redirect', () => {
     const parsed = parseCompareSlug('kimi-k26-h200-vs-h100');
     expect(parsed?.a).toBe('h200');
@@ -257,6 +266,11 @@ describe('getCompareModelBySlug', () => {
     expect(getCompareModelBySlug('kimi')).toBe(KIMI_K26);
     expect(getCompareModelBySlug('kimi-k25')).toBe(KIMI_K26);
     expect(getCompareModelBySlug('glm-5')).toBe(GLM_51);
+  });
+
+  it('keeps the bare minimax alias on the M2 series, with minimax-m3 canonical', () => {
+    expect(getCompareModelBySlug('minimax')?.slug).toBe('minimax-m27');
+    expect(getCompareModelBySlug('minimax-m3')?.slug).toBe('minimax-m3');
   });
 
   it('returns null for unknown slugs', () => {

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -31,10 +31,12 @@ export interface CompareModelSlug {
 }
 
 // Order matches the master /compare and /compare-per-dollar index display:
-// DeepSeek V4 Pro → R1 → Kimi → GLM → MiniMax → Qwen → gpt-oss → Llama 70B.
-// Per product spec — flagship Chinese-developed models first, smaller open
-// US-developed models at the bottom. Qwen sits between MiniMax and gpt-oss to
-// keep the Chinese-lab cluster contiguous before the US transition.
+// DeepSeek V4 Pro → R1 → Kimi → GLM → MiniMax M3 → MiniMax M2 → Qwen →
+// gpt-oss → Llama 70B. Per product spec — flagship Chinese-developed models
+// first, smaller open US-developed models at the bottom. Qwen sits between
+// MiniMax and gpt-oss to keep the Chinese-lab cluster contiguous before the
+// US transition. Within a family the newer flagship leads (V4 Pro before R1,
+// M3 before M2.5/M2.7).
 export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'deepseek-v4',
@@ -68,6 +70,14 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     // uses the newer version name but the data pull covers both DB buckets.
     dbKeys: ['glm5.1', 'glm5'],
     label: 'GLM 5/5.1',
+  },
+  {
+    slug: 'minimax-m3',
+    displayName: 'MiniMax-M3',
+    // M3 is a new 428B architecture, not a point release of the M2 series, so
+    // it gets its own slug rather than joining the minimax-m27 dbKey group.
+    dbKeys: ['minimaxm3'],
+    label: 'MiniMax M3 428B',
   },
   {
     slug: 'minimax-m27',

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -68,6 +68,7 @@ export const KNOWN_MODELS = new Set([
   'Qwen-3.5-397B-A17B',
   'Kimi-K2.5',
   'MiniMax-M2.5',
+  'MiniMax-M3',
   'GLM-5',
   'DeepSeek-V4-Pro',
 ]);


### PR DESCRIPTION
MiniMax M3 was added to the dashboard model dropdown (#444, ordering in #450) but never to `COMPARE_MODEL_SLUGS` in `packages/app/src/lib/compare-slug.ts` — the hand-maintained registry that drives /compare, /compare-per-dollar, the sitemap, and their OG images. So M3 was absent from all compare surfaces. (/about needed no change — it derives from `DB_MODEL_TO_DISPLAY` and already lists MiniMax-M3.)

## Changes

- **`compare-slug.ts`**: add `minimax-m3` entry (`displayName: 'MiniMax-M3'`, `dbKeys: ['minimaxm3']`, label `MiniMax M3 428B`), placed before `minimax-m27` so the newer flagship leads within the family, mirroring DeepSeek V4 Pro before R1. The bare `minimax` alias stays on `minimax-m27` for backward compat (same pattern as `deepseek` → `deepseek-r1`). M3 is a distinct 428B architecture, not an M2 point release, so it gets its own slug rather than joining the M2 dbKey group.
- **`compare-ssr.ts`**: add `'MiniMax-M3'` to `KNOWN_MODELS` so `?g_model=` URL overrides validate.
- **`compare-slug.test.ts`**: new tests for parsing `minimax-m3-h100-vs-h200` and slug/alias resolution; the existing round-trip suites cover the new entry automatically (34 tests pass).
- **`docs/adding-entities.md`**: add the compare-slug registry and `KNOWN_MODELS` steps to the Adding a New Model checklist — they weren't listed, which is why M3 fell through.

## Notes

- Only B300 currently has `minimaxm3` benchmark rows (verified against the live availability API), so the /compare index won't render an M3 section until a second GPU has data — `getComparablePairsByModelSlug` requires both sides of a pair. The section, sitemap URLs, and OG images appear automatically once that happens; direct `/compare/minimax-m3-*` URLs render the standard empty state until then.
- Overlay support: not applicable — this changes the SSR compare-page model registry only, no inference/evaluation chart data paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and documentation-only changes to compare URL/metadata; no auth, ingest, or inference paths.
> 
> **Overview**
> **MiniMax M3** is wired into the hand-maintained compare registry so it can appear on `/compare`, `/compare-per-dollar`, sitemaps, and OG images—surfaces that do **not** follow `MODEL_CONFIG` from the dashboard.
> 
> A new **`minimax-m3`** entry in `COMPARE_MODEL_SLUGS` uses `dbKeys: ['minimaxm3']`, sits **before** `minimax-m27` (newer flagship first), and keeps the bare **`minimax`** alias on the M2 series for backward compatibility. **`MiniMax-M3`** is added to **`KNOWN_MODELS`** so `?g_model=` overrides validate on compare SSR pages.
> 
> Tests cover parsing `minimax-m3-*` URLs and slug resolution. **`docs/adding-entities.md`** now lists `compare-slug.ts` and `compare-ssr.ts` in the “add a model” checklist so future models don’t miss compare registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd63b9c0231e787d75903412e9c99858df1f93a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->