### PR TITLE
fix(inference): reorder model dropdown

### DIFF
--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -66,7 +66,6 @@ const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
 // already part of the canonical name (Llama 3.3 70B, gpt-oss 120B) so no
 // duplication needed.
 const MODEL_CONFIG: Record<Model, ModelConfig> = {
-  [Model.DeepSeek_R1]: { label: 'DeepSeek R1 0528 671B', prefix: 'dsr1', category: 'default' },
   [Model.DeepSeek_V4_Pro]: {
     label: 'DeepSeek V4 Pro 1.6T',
     prefix: 'dsv4',
@@ -87,8 +86,9 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'minimaxm3',
     category: 'default',
   },
-  [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
+  [Model.DeepSeek_R1]: { label: 'DeepSeek R1 0528 671B', prefix: 'dsr1', category: 'default' },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
+  [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
     label: 'MiniMax M2.5/2.7 230B',


### PR DESCRIPTION
Reorders the `MODEL_CONFIG` key order in `packages/app/src/lib/data-mappings.ts`, which drives the model dropdown ordering via `MODEL_OPTIONS`.

New order:
1. DeepSeek V4 Pro 1.6T (default)
2. Kimi K2.5/2.6/2.7-Code 1T
3. MiniMax M3 428B
4. DeepSeek R1 0528 671B
5. GLM5/5.1 744B
6. Qwen3.5 397B
7. MiniMax M2.5/2.7 230B
8. gpt-oss 120B
9. Llama 3.3 70B (deprecated), Llama 3.1 70B (hidden) — unchanged at the end

Pure key reorder — no label, prefix, or category changes. Existing tests assert label lookups only, not order; `data-mappings.test.ts` passes (33/33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only ordering change in one config object; no routing, API, or metadata changes.
> 
> **Overview**
> Reorders entries in **`MODEL_CONFIG`** so the inference model picker lists models in a new priority order (DeepSeek V4 Pro first, then Kimi, MiniMax M3, DeepSeek R1, GLM5, Qwen3.5, MiniMax M2.5, gpt-oss, with Llama entries still last).
> 
> Because **`MODEL_OPTIONS`** is built from **`Object.keys(MODEL_CONFIG)`**, only declaration order changes—labels, prefixes, categories, and exclusion rules are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3c9c8811ec59890e67855283c28d8b927e08ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->