### PR TITLE
fix(inference): tiebreak same-day runs

### DIFF
--- a/packages/db/src/json-provider.test.ts
+++ b/packages/db/src/json-provider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { compareBenchmarkRecency } from './json-provider.js';
+
+/**
+ * `compareBenchmarkRecency` is the shared dedup ordering used by both the SQL
+ * date-filtered query (ORDER BY br.date DESC, wr.run_started_at DESC NULLS LAST)
+ * and the JSON provider's getLatestBenchmarks. A negative result means `a` sorts
+ * before `b`, so `a` is the more-recent record kept by DISTINCT ON.
+ *
+ * Regression guard for the same-day multi-run bug: when a config is swept more
+ * than once on the same calendar day, the later sweep (greater run_started_at)
+ * must win — otherwise the earlier run's points shadow the re-sweep on the chart.
+ */
+describe('compareBenchmarkRecency', () => {
+  const later = '2026-06-14T06:43:25Z';
+  const earlier = '2026-06-14T04:08:16Z';
+
+  it('orders a more recent calendar day first regardless of run_started_at', () => {
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-13', earlier, later)).toBeLessThan(0);
+    expect(compareBenchmarkRecency('2026-06-13', '2026-06-14', later, earlier)).toBeGreaterThan(0);
+  });
+
+  it('tiebreaks same-day sweeps by run_started_at (latest sweep wins)', () => {
+    // a = later sweep → a should sort first (negative).
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', later, earlier)).toBeLessThan(0);
+    // a = earlier sweep → a should sort after (positive).
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', earlier, later)).toBeGreaterThan(0);
+  });
+
+  it('sorts a null run_started_at last on a same-day tie', () => {
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', null, earlier)).toBeGreaterThan(0);
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', earlier, null)).toBeLessThan(0);
+  });
+
+  it('treats equal date and equal run_started_at as a tie', () => {
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', later, later)).toBe(0);
+    expect(compareBenchmarkRecency('2026-06-14', '2026-06-14', null, null)).toBe(0);
+  });
+
+  it('keeps the latest sweep first when sorting a same-day candidate list', () => {
+    interface Row {
+      run: string;
+      started: string | null;
+    }
+    const rows: Row[] = [
+      { run: 'old', started: earlier },
+      { run: 'new', started: later },
+      { run: 'unknown', started: null },
+    ];
+    rows.sort((a, b) => compareBenchmarkRecency('2026-06-14', '2026-06-14', a.started, b.started));
+    expect(rows.map((r) => r.run)).toEqual(['new', 'old', 'unknown']);
+  });
+});

--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -328,6 +328,29 @@ const STRIP_HISTORY_KEYS = new Set([
   'mean_itl',
 ]);
 
+/**
+ * Comparator for DISTINCT ON (config, conc, isl, osl) selection: latest calendar
+ * day first, then — for sweeps on the same day — the latest workflow run first by
+ * `run_started_at` (NULLS LAST). Mirrors the SQL date-filtered query and the
+ * `latest_benchmarks` view (migration 003): a calendar day alone ties two same-day
+ * sweeps, so without this an older run's points can shadow a same-day re-sweep.
+ * `run_started_at` is an ISO-8601 string, so localeCompare orders it chronologically.
+ * Exported so the same-day tiebreak is unit-tested in parity with the SQL.
+ */
+export function compareBenchmarkRecency(
+  aDate: string,
+  bDate: string,
+  aStarted: string | null,
+  bStarted: string | null,
+): number {
+  const dateCmp = bDate.localeCompare(aDate);
+  if (dateCmp !== 0) return dateCmp;
+  if (aStarted === bStarted) return 0;
+  if (aStarted === null) return 1;
+  if (bStarted === null) return -1;
+  return bStarted.localeCompare(aStarted);
+}
+
 export function getLatestBenchmarks(
   modelKey: string | string[],
   date?: string,
@@ -350,10 +373,17 @@ export function getLatestBenchmarks(
     return true;
   });
 
-  // DISTINCT ON (config_id, conc, isl, osl) — keep the one with the latest date
+  // DISTINCT ON (config_id, conc, isl, osl) — keep the one with the latest date,
+  // tiebreaking same-day runs by run_started_at so the latest sweep wins.
   const seen = new Map<string, RawBenchmarkResult>();
-  // Sort by date DESC so first-seen wins
-  candidates.sort((a, b) => toDateString(b.date).localeCompare(toDateString(a.date)));
+  candidates.sort((a, b) =>
+    compareBenchmarkRecency(
+      toDateString(a.date),
+      toDateString(b.date),
+      s.latestRunsById.get(a.workflow_run_id)?.run_started_at ?? null,
+      s.latestRunsById.get(b.workflow_run_id)?.run_started_at ?? null,
+    ),
+  );
   for (const br of candidates) {
     const key = `${br.config_id}:${br.conc}:${br.isl}:${br.osl}`;
     if (!seen.has(key)) seen.set(key, br);

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -65,6 +65,10 @@ export async function getLatestBenchmarks(
     // Date-filtered: use base table with DISTINCT ON (the view only has the absolute latest)
     // exact=true: only return data from this exact date (for GPU comparison)
     // exact=false (default): return latest data as of this date (for main chart)
+    // Same-day tiebreak by wr.run_started_at (latest sweep wins), mirroring the
+    // latest_benchmarks view (migration 003). br.date is a calendar day, so two
+    // sweeps on the same day tie on date alone and Postgres would otherwise pick
+    // an arbitrary one — leaving an older run's points shadowing a same-day re-sweep.
     const dateFilter = exact ? sql`br.date = ${date}::date` : sql`br.date <= ${date}::date`;
     const rows = await sql`
       SELECT DISTINCT ON (br.config_id, br.conc, br.isl, br.osl)
@@ -99,7 +103,8 @@ export async function getLatestBenchmarks(
       WHERE c.model = ANY(${modelKeys})
         AND br.error IS NULL
         AND ${dateFilter}
-      ORDER BY br.config_id, br.conc, br.isl, br.osl, br.date DESC
+      ORDER BY br.config_id, br.conc, br.isl, br.osl,
+               br.date DESC, wr.run_started_at DESC NULLS LAST
     `;
     return rows as unknown as BenchmarkRow[];
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which benchmark row is returned for same-day re-sweeps (chart/API correctness), but scope is limited to latest-benchmark selection logic with explicit SQL/JSON parity tests.
> 
> **Overview**
> Fixes **same-day multi-sweep** dedup so charts show the latest sweep instead of an arbitrary earlier run when `br.date` ties.
> 
> **SQL** (`getLatestBenchmarks` with a date filter): `DISTINCT ON` ordering now includes `wr.run_started_at DESC NULLS LAST` after `br.date DESC`, matching migration 003’s `latest_benchmarks` view.
> 
> **JSON dump provider**: introduces exported `compareBenchmarkRecency` and uses it when picking the winning row per `(config_id, conc, isl, osl)` in `getLatestBenchmarks`, using each run’s `run_started_at` from `latestRunsById`.
> 
> **Tests**: new `compareBenchmarkRecency` cases cover date ordering, same-day tiebreak, null `run_started_at`, and sort order for a candidate list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69417a925bac980d4f901dc9fba320fa555dfb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->