### PR TITLE
feat(inference): time-travel chart data to the selected run

### DIFF
--- a/packages/app/src/app/api/v1/benchmarks/route.test.ts
+++ b/packages/app/src/app/api/v1/benchmarks/route.test.ts
@@ -59,6 +59,7 @@ describe('GET /api/v1/benchmarks', () => {
       ['dsr1'],
       undefined,
       undefined,
+      undefined,
     );
   });
 
@@ -72,6 +73,7 @@ describe('GET /api/v1/benchmarks', () => {
       ['dsr1'],
       '2026-03-01',
       undefined,
+      undefined,
     );
   });
 
@@ -82,7 +84,45 @@ describe('GET /api/v1/benchmarks', () => {
       req('/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-03-01&exact=true'),
     );
     expect(res.status).toBe(200);
-    expect(mockGetLatestBenchmarks).toHaveBeenCalledWith('mock-sql', ['dsr1'], '2026-03-01', true);
+    expect(mockGetLatestBenchmarks).toHaveBeenCalledWith(
+      'mock-sql',
+      ['dsr1'],
+      '2026-03-01',
+      true,
+      undefined,
+    );
+  });
+
+  it('passes a numeric runId through to the query', async () => {
+    mockGetLatestBenchmarks.mockResolvedValueOnce([]);
+
+    const res = await GET(
+      req('/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-03-01&runId=27489075807'),
+    );
+    expect(res.status).toBe(200);
+    expect(mockGetLatestBenchmarks).toHaveBeenCalledWith(
+      'mock-sql',
+      ['dsr1'],
+      '2026-03-01',
+      undefined,
+      '27489075807',
+    );
+  });
+
+  it('ignores a non-numeric runId (treated as latest)', async () => {
+    mockGetLatestBenchmarks.mockResolvedValueOnce([]);
+
+    const res = await GET(
+      req('/api/v1/benchmarks?model=DeepSeek-R1-0528&date=2026-03-01&runId=not-a-run'),
+    );
+    expect(res.status).toBe(200);
+    expect(mockGetLatestBenchmarks).toHaveBeenCalledWith(
+      'mock-sql',
+      ['dsr1'],
+      '2026-03-01',
+      undefined,
+      undefined,
+    );
   });
 
   it('returns 500 when query throws', async () => {

--- a/packages/app/src/app/api/v1/benchmarks/route.ts
+++ b/packages/app/src/app/api/v1/benchmarks/route.ts
@@ -11,10 +11,10 @@ import { loadFixture } from '@/lib/test-fixtures';
 export const dynamic = 'force-dynamic';
 
 const getCachedBenchmarks = cachedQuery(
-  (dbModelKeys: string[], date?: string, exact?: boolean) => {
+  (dbModelKeys: string[], date?: string, exact?: boolean, runId?: string) => {
     if (JSON_MODE)
-      return Promise.resolve(jsonProvider.getLatestBenchmarks(dbModelKeys, date, exact));
-    return getLatestBenchmarks(getDb(), dbModelKeys, date, exact);
+      return Promise.resolve(jsonProvider.getLatestBenchmarks(dbModelKeys, date, exact, runId));
+    return getLatestBenchmarks(getDb(), dbModelKeys, date, exact, runId);
   },
   'benchmarks',
   { blobOnly: true },
@@ -25,6 +25,9 @@ export async function GET(request: NextRequest) {
   const model = params.get('model') ?? '';
   const date = params.get('date') ?? undefined;
   const exact = params.get('exact') === 'true';
+  // Numeric GitHub run id only — anything else is ignored (treated as "latest").
+  const runIdParam = params.get('runId');
+  const runId = runIdParam && /^\d+$/u.test(runIdParam) ? runIdParam : undefined;
   const dbModelKeys = DISPLAY_MODEL_TO_DB[model];
   if (!dbModelKeys || dbModelKeys.length === 0) {
     return NextResponse.json({ error: 'Unknown model' }, { status: 400 });
@@ -32,7 +35,7 @@ export async function GET(request: NextRequest) {
   if (FIXTURES_MODE) return cachedJson(loadFixture('benchmarks'));
 
   try {
-    const rows = await getCachedBenchmarks(dbModelKeys, date, exact || undefined);
+    const rows = await getCachedBenchmarks(dbModelKeys, date, exact || undefined, runId);
     return cachedJson(rows);
   } catch (error) {
     console.error('Error fetching benchmarks:', error);

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -202,6 +202,43 @@ export function InferenceProvider({
   // ── Data fetching (gated by isActive) ──────────────────────────────────────
   const latestDate = availableDates.length > 0 ? availableDates.at(-1) : undefined;
 
+  // Runs available for the current model selection, and which one is selected.
+  // Computed here (above useChartData) so the chart can query "as of" the selected
+  // run. Re-exposed on the context value below.
+  const modelPrefixes = useMemo(
+    () =>
+      Object.entries(MODEL_PREFIX_MAPPING)
+        .filter(([, model]) => model === selectedModel)
+        .map(([prefix]) => prefix),
+    [selectedModel],
+  );
+
+  const filteredAvailableRuns = useMemo(
+    () => filterRunsByModel(availableRuns, modelPrefixes, [...effectivePrecisions]),
+    [availableRuns, modelPrefixes, effectivePrecisions],
+  );
+
+  const effectiveSelectedRunId = useMemo(() => {
+    if (!filteredAvailableRuns) return selectedRunId;
+    const filteredRunIds = Object.keys(filteredAvailableRuns);
+    if (filteredRunIds.length === 0 || filteredRunIds.includes(selectedRunId)) return selectedRunId;
+    return filteredRunIds.reduce((max, id) => (id > max ? id : max), filteredRunIds[0]);
+  }, [filteredAvailableRuns, selectedRunId]);
+
+  // The latest run for this model on the selected date. GitHub run ids increase
+  // monotonically with time, so the lexicographically-greatest id is the newest run.
+  const latestRunIdForModel = useMemo(() => {
+    const ids = filteredAvailableRuns ? Object.keys(filteredAvailableRuns) : [];
+    return ids.length > 0 ? ids.reduce((max, id) => (id > max ? id : max), ids[0]) : '';
+  }, [filteredAvailableRuns]);
+
+  // Only constrain the query when an earlier-than-latest run is selected; otherwise
+  // the chart shows the full latest view (and reuses the materialized-view fast path).
+  const asOfRunId =
+    effectiveSelectedRunId && latestRunIdForModel && effectiveSelectedRunId !== latestRunIdForModel
+      ? effectiveSelectedRunId
+      : undefined;
+
   const {
     graphs,
     loading: chartDataLoading,
@@ -223,6 +260,7 @@ export function InferenceProvider({
     isActive,
     latestDate,
     compareGpuPair ?? null,
+    asOfRunId,
   );
 
   // For GPU comparison date picker — use shared availability data from global filters
@@ -699,14 +737,6 @@ export function InferenceProvider({
       setUserPowers((prev) => (prev === null ? prev : null));
   }, [selectedModel, effectiveSequence, effectivePrecisions, selectedYAxisMetric]);
 
-  const modelPrefixes = useMemo(
-    () =>
-      Object.entries(MODEL_PREFIX_MAPPING)
-        .filter(([, model]) => model === selectedModel)
-        .map(([prefix]) => prefix),
-    [selectedModel],
-  );
-
   // ── Debounced GPU selection tracking ─────────────────────────────────────
   // Fire after 3s of no changes so we capture the "settled" selection.
   // Skip the first render (initial data load) to avoid noise.
@@ -922,19 +952,9 @@ export function InferenceProvider({
   }, [applyPreset]);
 
   // ── Filtered runs ─────────────────────────────────────────────────────────
-
-  const filteredAvailableRuns = useMemo(
-    () => filterRunsByModel(availableRuns, modelPrefixes, [...effectivePrecisions]),
-    [availableRuns, modelPrefixes, effectivePrecisions],
-  );
-
-  const effectiveSelectedRunId = useMemo(() => {
-    if (!filteredAvailableRuns) return selectedRunId;
-    const filteredRunIds = Object.keys(filteredAvailableRuns);
-    if (filteredRunIds.length === 0 || filteredRunIds.includes(selectedRunId)) return selectedRunId;
-    return filteredRunIds.reduce((max, id) => (id > max ? id : max), filteredRunIds[0]);
-  }, [filteredAvailableRuns, selectedRunId]);
-
+  // filteredAvailableRuns / effectiveSelectedRunId are computed above the data
+  // fetch (so the chart can query "as of" the selected run).
+  //
   // NOTE: We intentionally do NOT sync effectiveSelectedRunId back to
   // GlobalFilterContext (setSelectedRunId). That would cause a full tree
   // re-render on every precision change because filteredAvailableRuns

--- a/packages/app/src/components/inference/hooks/useChartData.ts
+++ b/packages/app/src/components/inference/hooks/useChartData.ts
@@ -85,12 +85,22 @@ export function useChartData(
   latestAvailableDate?: string,
   /** When set, only series for these two registry GPU keys are shown (compare pages). */
   compareGpuPair?: readonly [string, string] | null,
+  /**
+   * GitHub run id for the "as of run" view. Set only when an earlier-than-latest
+   * run is selected; the chart then shows the data as it stood at that run.
+   */
+  asOfRunId?: string,
 ) {
   // When the selected date is the latest available, use '' (empty string) to match
   // the initial no-date query key, reusing the eagerly-fetched benchmarks from the
   // materialized view instead of firing a redundant second fetch with identical data.
-  const queryDate =
-    selectedRunDate && latestAvailableDate && selectedRunDate === latestAvailableDate
+  //
+  // The '' shortcut hits the materialized view, which has no run-level filter, so it
+  // is only valid for the latest run. When an earlier run is selected (asOfRunId set)
+  // we must query the date-filtered path so the run cutoff applies.
+  const queryDate = asOfRunId
+    ? (selectedRunDate ?? '')
+    : selectedRunDate && latestAvailableDate && selectedRunDate === latestAvailableDate
       ? ''
       : selectedRunDate;
 
@@ -98,7 +108,7 @@ export function useChartData(
     data: allRows,
     isLoading: queryLoading,
     error: queryError,
-  } = useBenchmarks(selectedModel, queryDate, enabled);
+  } = useBenchmarks(selectedModel, queryDate, enabled, asOfRunId);
 
   // GPU comparison: fetch data for each additional comparison date
   const comparisonDates = useMemo(

--- a/packages/app/src/hooks/api/use-benchmarks.test.ts
+++ b/packages/app/src/hooks/api/use-benchmarks.test.ts
@@ -5,12 +5,41 @@ import { benchmarkQueryOptions } from '@/hooks/api/use-benchmarks';
 describe('benchmarkQueryOptions', () => {
   it('builds query key from model and date', () => {
     const opts = benchmarkQueryOptions('DeepSeek-R1-0528', '2026-03-01');
-    expect(opts.queryKey).toEqual(['benchmarks', 'DeepSeek-R1-0528', '2026-03-01', 'latest']);
+    expect(opts.queryKey).toEqual([
+      'benchmarks',
+      'DeepSeek-R1-0528',
+      '2026-03-01',
+      'latest',
+      'all',
+    ]);
   });
 
   it('builds exact query key when exact=true', () => {
     const opts = benchmarkQueryOptions('DeepSeek-R1-0528', '2026-03-01', true, true);
-    expect(opts.queryKey).toEqual(['benchmarks', 'DeepSeek-R1-0528', '2026-03-01', 'exact']);
+    expect(opts.queryKey).toEqual(['benchmarks', 'DeepSeek-R1-0528', '2026-03-01', 'exact', 'all']);
+  });
+
+  it('includes the runId in the query key for the as-of-run view', () => {
+    const opts = benchmarkQueryOptions(
+      'DeepSeek-R1-0528',
+      '2026-03-01',
+      true,
+      false,
+      '27489075807',
+    );
+    expect(opts.queryKey).toEqual([
+      'benchmarks',
+      'DeepSeek-R1-0528',
+      '2026-03-01',
+      'latest',
+      '27489075807',
+    ]);
+  });
+
+  it('produces distinct keys for different runIds (no cache collision)', () => {
+    const a = benchmarkQueryOptions('m', '2026-03-01', true, false, '100');
+    const b = benchmarkQueryOptions('m', '2026-03-01', true, false, '101');
+    expect(a.queryKey).not.toEqual(b.queryKey);
   });
 
   it('produces distinct keys for different models', () => {

--- a/packages/app/src/hooks/api/use-benchmarks.ts
+++ b/packages/app/src/hooks/api/use-benchmarks.ts
@@ -8,14 +8,17 @@ export function benchmarkQueryOptions(
   date: string,
   enabled = true,
   exact?: boolean,
+  /** GitHub run id for the "as of run" view (main chart only). */
+  runId?: string,
 ) {
   return {
-    queryKey: ['benchmarks', model, date, exact ? 'exact' : 'latest'] as const,
-    queryFn: ({ signal }: { signal: AbortSignal }) => fetchBenchmarks(model, date, exact, signal),
+    queryKey: ['benchmarks', model, date, exact ? 'exact' : 'latest', runId ?? 'all'] as const,
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      fetchBenchmarks(model, date, exact, signal, runId),
     enabled: enabled && Boolean(model),
   };
 }
 
-export function useBenchmarks(model: string, date?: string, enabled = true) {
-  return useQuery(benchmarkQueryOptions(model, date ?? 'latest', enabled));
+export function useBenchmarks(model: string, date?: string, enabled = true, runId?: string) {
+  return useQuery(benchmarkQueryOptions(model, date ?? 'latest', enabled, undefined, runId));
 }

--- a/packages/app/src/lib/api.ts
+++ b/packages/app/src/lib/api.ts
@@ -126,10 +126,12 @@ export function fetchBenchmarks(
   date?: string,
   exact?: boolean,
   signal?: AbortSignal,
+  runId?: string,
 ) {
   const params = new URLSearchParams({ model });
   if (date) params.set('date', date);
   if (exact) params.set('exact', 'true');
+  if (runId) params.set('runId', runId);
   return fetchJson<BenchmarkRow[]>(`/api/v1/benchmarks?${params}`, signal);
 }
 

--- a/packages/db/src/json-provider.asof.test.ts
+++ b/packages/db/src/json-provider.asof.test.ts
@@ -1,0 +1,167 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { getLatestBenchmarks as GetLatestBenchmarks } from './json-provider.js';
+
+/**
+ * Integration test for the "as of run" time-travel filter in the JSON provider's
+ * getLatestBenchmarks (the in-memory mirror of the SQL date-filtered query).
+ *
+ * Scenario: one config swept three times on the same day by three separate runs
+ * (all attempt 1) plus an older config from a prior date whose run predates the
+ * run_started_at column (NULL). Selecting an earlier run must show that run's data
+ * and hide later same-day runs, while never dropping the NULL-timestamped history.
+ */
+
+const cfg = (id: number, spec_method = 'none') => ({
+  id,
+  hardware: 'h100',
+  framework: 'vllm',
+  model: 'testm',
+  precision: 'fp8',
+  spec_method,
+  disagg: false,
+  is_multinode: false,
+  prefill_tp: 1,
+  prefill_ep: 1,
+  prefill_dp_attention: false,
+  prefill_num_workers: 1,
+  decode_tp: 1,
+  decode_ep: 1,
+  decode_dp_attention: false,
+  decode_num_workers: 1,
+  num_prefill_gpu: 0,
+  num_decode_gpu: 8,
+});
+
+const run = (id: number, githubId: number, startedAt: string | null, date: string) => ({
+  id,
+  github_run_id: githubId,
+  run_attempt: 1,
+  name: `run ${githubId}`,
+  status: 'completed',
+  conclusion: 'success',
+  head_sha: 'sha',
+  head_branch: 'main',
+  html_url: `https://github.com/x/runs/${githubId}`,
+  created_at: startedAt ?? `${date}T00:00:00Z`,
+  run_started_at: startedAt,
+  date,
+});
+
+const result = (id: number, runDbId: number, configId: number, date: string, tpot: number) => ({
+  id,
+  workflow_run_id: runDbId,
+  config_id: configId,
+  benchmark_type: 'latency',
+  date,
+  isl: 1024,
+  osl: 1024,
+  conc: 1,
+  image: null,
+  metrics: { median_tpot: tpot },
+  error: null,
+  server_log_id: null,
+});
+
+const D = '2026-06-14';
+let getLatestBenchmarks: typeof GetLatestBenchmarks;
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'infx-asof-'));
+  writeFileSync(join(dir, 'configs.json'), JSON.stringify([cfg(1), cfg(2, 'mtp')]));
+  writeFileSync(
+    join(dir, 'workflow_runs.json'),
+    JSON.stringify([
+      run(10, 100, `${D}T04:00:00Z`, D), // run A (earliest same-day)
+      run(11, 101, `${D}T05:00:00Z`, D), // run B
+      run(12, 102, `${D}T06:00:00Z`, D), // run C (latest same-day)
+      run(9, 99, null, '2026-06-10'), // older run, no run_started_at
+    ]),
+  );
+  writeFileSync(
+    join(dir, 'benchmark_results.json'),
+    JSON.stringify([
+      result(1000, 10, 1, D, 0.1), // config 1 from run A
+      result(1001, 11, 1, D, 0.2), // config 1 from run B (re-sweep)
+      result(1002, 12, 1, D, 0.3), // config 1 from run C (re-sweep)
+      result(1003, 9, 2, '2026-06-10', 0.9), // config 2, prior date, NULL run_started_at
+    ]),
+  );
+  process.env.DUMP_DIR = dir;
+  const mod = await import('./json-provider.js');
+  getLatestBenchmarks = mod.getLatestBenchmarks;
+});
+
+afterAll(() => {
+  delete process.env.DUMP_DIR;
+});
+
+/** median_tpot of the (single) config-1 row, plus its run url, for terse assertions. */
+function config1(
+  rows: { config_id?: number; metrics: Record<string, number>; run_url: string | null }[],
+) {
+  // config_id isn't returned; identify config 1 by the run url set we control.
+  const row = rows.find((r) => r.run_url?.match(/runs\/(?:100|101|102)\//u));
+  return row ? { tpot: row.metrics.median_tpot, runUrl: row.run_url } : null;
+}
+
+describe('getLatestBenchmarks — as-of-run time travel', () => {
+  it('without a run id, picks the latest same-day sweep (run C)', () => {
+    const rows = getLatestBenchmarks('testm', D, false);
+    expect(config1(rows)).toEqual({
+      tpot: 0.3,
+      runUrl: 'https://github.com/x/runs/102/attempts/1',
+    });
+    // older NULL-timestamp config still present
+    expect(rows.some((r) => r.run_url === 'https://github.com/x/runs/99/attempts/1')).toBe(true);
+  });
+
+  it('as of run A (earliest) shows run A data, hiding later same-day runs', () => {
+    const rows = getLatestBenchmarks('testm', D, false, '100');
+    expect(config1(rows)).toEqual({
+      tpot: 0.1,
+      runUrl: 'https://github.com/x/runs/100/attempts/1',
+    });
+  });
+
+  it('as of run B shows run B data (A superseded, C not yet)', () => {
+    const rows = getLatestBenchmarks('testm', D, false, '101');
+    expect(config1(rows)).toEqual({
+      tpot: 0.2,
+      runUrl: 'https://github.com/x/runs/101/attempts/1',
+    });
+  });
+
+  it('as of run C (latest) is identical to no filter', () => {
+    const rows = getLatestBenchmarks('testm', D, false, '102');
+    expect(config1(rows)).toEqual({
+      tpot: 0.3,
+      runUrl: 'https://github.com/x/runs/102/attempts/1',
+    });
+  });
+
+  it('preserves NULL-run_started_at history even when an earlier run is selected', () => {
+    const rows = getLatestBenchmarks('testm', D, false, '100');
+    expect(rows.some((r) => r.run_url === 'https://github.com/x/runs/99/attempts/1')).toBe(true);
+  });
+
+  it('treats an unknown run id as no-op (shows latest)', () => {
+    const rows = getLatestBenchmarks('testm', D, false, '999999');
+    expect(config1(rows)).toEqual({
+      tpot: 0.3,
+      runUrl: 'https://github.com/x/runs/102/attempts/1',
+    });
+  });
+
+  it('does not apply the run filter on the exact path', () => {
+    const rows = getLatestBenchmarks('testm', D, true, '100');
+    expect(config1(rows)).toEqual({
+      tpot: 0.3,
+      runUrl: 'https://github.com/x/runs/102/attempts/1',
+    });
+  });
+});

--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -355,10 +355,17 @@ export function getLatestBenchmarks(
   modelKey: string | string[],
   date?: string,
   exact?: boolean,
+  asOfRunId?: string,
 ): BenchmarkRow[] {
   const s = getStore();
   const dateStr = date ? toDateString(date) : undefined;
   const modelKeys = new Set(Array.isArray(modelKey) ? modelKey : [modelKey]);
+
+  // "As of run" cutoff (main chart only): the selected run's start time. Mirrors the
+  // SQL runFilter — results from runs that started after this are excluded. Null/unknown
+  // means no cutoff (a no-op, matching the SQL COALESCE-to-infinity behavior).
+  const asOfStartedAt =
+    !exact && asOfRunId ? (s.latestRuns.get(Number(asOfRunId))?.run_started_at ?? null) : null;
 
   // Filter to successful benchmarks for this model with a valid latest workflow run
   const candidates = s.benchmarks.filter((br) => {
@@ -366,6 +373,12 @@ export function getLatestBenchmarks(
     const c = s.configs.get(br.config_id);
     if (!c || !modelKeys.has(c.model)) return false;
     if (!s.latestRunsById.has(br.workflow_run_id)) return false;
+    if (asOfStartedAt) {
+      // Keep NULL run_started_at (old history) so it never blanks out; drop runs
+      // that started after the selected one.
+      const started = s.latestRunsById.get(br.workflow_run_id)?.run_started_at ?? null;
+      if (started !== null && started > asOfStartedAt) return false;
+    }
     if (dateStr) {
       const brDate = toDateString(br.date);
       return exact ? brDate === dateStr : brDate <= dateStr;

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -59,6 +59,14 @@ export async function getLatestBenchmarks(
   modelKey: string | string[],
   date?: string,
   exact?: boolean,
+  /**
+   * GitHub run id to view the chart "as of" — restricts results to runs that
+   * started no later than this one, so selecting an earlier same-day run shows
+   * the state of the data at that point in time (later runs don't render yet).
+   * No-op when this is the latest run (the filter then includes everything).
+   * Only applied on the date-filtered (non-`exact`) path used by the main chart.
+   */
+  asOfRunId?: string,
 ): Promise<BenchmarkRow[]> {
   const modelKeys = Array.isArray(modelKey) ? modelKey : [modelKey];
   if (date) {
@@ -70,6 +78,21 @@ export async function getLatestBenchmarks(
     // sweeps on the same day tie on date alone and Postgres would otherwise pick
     // an arbitrary one — leaving an older run's points shadowing a same-day re-sweep.
     const dateFilter = exact ? sql`br.date = ${date}::date` : sql`br.date <= ${date}::date`;
+    // "As of run" filter (main chart only): keep results whose run started no later
+    // than the selected run. run_started_at is an absolute timestamp, so this also
+    // naturally includes all earlier-date runs. NULLs (pre-migration-003 runs that
+    // lack the timestamp) are kept so old history doesn't blank out; COALESCE to
+    // infinity makes an unknown asOfRunId a no-op rather than excluding everything.
+    const runFilter =
+      !exact && asOfRunId
+        ? sql`AND (
+            wr.run_started_at IS NULL
+            OR wr.run_started_at <= COALESCE(
+              (SELECT lwr.run_started_at FROM latest_workflow_runs lwr WHERE lwr.github_run_id = ${Number(asOfRunId)}),
+              'infinity'::timestamptz
+            )
+          )`
+        : sql``;
     const rows = await sql`
       SELECT DISTINCT ON (br.config_id, br.conc, br.isl, br.osl)
         c.hardware,
@@ -103,6 +126,7 @@ export async function getLatestBenchmarks(
       WHERE c.model = ANY(${modelKeys})
         AND br.error IS NULL
         AND ${dateFilter}
+        ${runFilter}
       ORDER BY br.config_id, br.conc, br.isl, br.osl,
                br.date DESC, wr.run_started_at DESC NULLS LAST
     `;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core benchmark fetch and SQL filtering used by the main chart; behavior is covered by new tests but wrong cutoff logic could show stale or missing points.
> 
> **Overview**
> The inference chart can now show benchmark data **as of a selected GitHub workflow run**, not only the latest sweep for a day.
> 
> **Backend:** `GET /api/v1/benchmarks` accepts an optional numeric `runId`. SQL and JSON `getLatestBenchmarks` apply a run cutoff on the main chart’s date-filtered path (`run_started_at` ≤ selected run), while keeping rows with null timestamps and skipping the filter for `exact=true` GPU-comparison queries.
> 
> **Frontend:** Run selection is resolved before chart fetch; `asOfRunId` is sent only when the user picks an earlier run than the latest for the model. That forces the dated query path (not the materialized-view shortcut) and extends React Query keys so per-run views don’t collide in cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d047d0f7fbb35b38c4e72c5b8d0d9c6f746ad9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->