### PR TITLE
chore: rename "Mooncake ATOM" framework label to "ATOMesh"

### DIFF
--- a/packages/constants/src/framework-aliases.test.ts
+++ b/packages/constants/src/framework-aliases.test.ts
@@ -8,12 +8,12 @@ import {
 } from './framework-aliases';
 
 describe('FRAMEWORK_LABELS', () => {
-  it('labels the canonical mooncake-atom framework "Mooncake ATOM¹"', () => {
-    expect(FRAMEWORK_LABELS['mooncake-atom']).toBe('Mooncake ATOM¹');
+  it('labels the canonical mooncake-atom framework "ATOMesh¹"', () => {
+    expect(FRAMEWORK_LABELS['mooncake-atom']).toBe('ATOMesh¹');
   });
 
   it('labels the atom-disagg alias with its canonical label', () => {
-    expect(FRAMEWORK_LABELS['atom-disagg']).toBe('Mooncake ATOM¹');
+    expect(FRAMEWORK_LABELS['atom-disagg']).toBe('ATOMesh¹');
   });
 });
 

--- a/packages/constants/src/framework-aliases.ts
+++ b/packages/constants/src/framework-aliases.ts
@@ -9,7 +9,7 @@ export const FW_REGISTRY: Record<string, FwEntry> = {
   'dynamo-sglang': { label: 'Dynamo SGLang' },
   'dynamo-trt': { label: 'Dynamo TRT' },
   'dynamo-vllm': { label: 'Dynamo vLLM' },
-  'mooncake-atom': { label: 'Mooncake ATOM¹' },
+  'mooncake-atom': { label: 'ATOMesh¹' },
   'mori-sglang': { label: 'MoRI SGLang' },
   sglang: { label: 'SGLang' },
   trt: { label: 'TRT' },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic label-only change in shared constants; no routing, aliases, or data keys affected.
> 
> **Overview**
> Updates the human-readable label for the **`mooncake-atom`** framework (and the **`atom-disagg`** alias, which inherits that label) from **Mooncake ATOM¹** to **ATOMesh¹** in `FW_REGISTRY` / `FRAMEWORK_LABELS`.
> 
> Unit tests in `framework-aliases.test.ts` are aligned with the new string. Framework keys, aliases, and resolution logic are unchanged—only chart/tooltip display text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 613ffadd065bd5c44e298493d195866dc0e5c544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->