### PR TITLE
fix(inference): link single-run changelog to its producing run, not the date

### DIFF
--- a/packages/app/src/components/inference/ui/ComparisonChangelog.tsx
+++ b/packages/app/src/components/inference/ui/ComparisonChangelog.tsx
@@ -16,6 +16,36 @@ import { dataRunsForDate } from '@/components/inference/utils/runEnumeration';
 import { getHardwareConfig } from '@/lib/constants';
 import { getDisplayLabel, updateRepoUrl } from '@/lib/utils';
 
+/** Git Commit and Workflow Run external links for a run, each shown when known. */
+function renderRunLinks(headRef?: string, runUrl?: string) {
+  return (
+    <>
+      {headRef && (
+        <a
+          href={`https://github.com/SemiAnalysisAI/InferenceX/commit/${headRef}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm hover:underline text-foreground underline"
+        >
+          Git Commit
+          <ExternalLinkIcon />
+        </a>
+      )}
+      {runUrl && (
+        <a
+          href={updateRepoUrl(runUrl)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm hover:underline text-foreground underline"
+        >
+          Workflow Run
+          <ExternalLinkIcon />
+        </a>
+      )}
+    </>
+  );
+}
+
 /** One changelog entry's description. The GPU and run # are shown in the entry title. */
 function renderDescription(
   entry: { config_keys: string[]; description: string },
@@ -262,28 +292,7 @@ export default function ComparisonChangelog({
                           {gpuLabel ? ` ${gpuLabel}` : ''} #{idx + 1}
                         </span>
                         <span className="text-muted-foreground">&mdash;</span>
-                        {run.headRef && (
-                          <a
-                            href={`https://github.com/SemiAnalysisAI/InferenceX/commit/${run.headRef}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sm hover:underline text-foreground underline"
-                          >
-                            Git Commit
-                            <ExternalLinkIcon />
-                          </a>
-                        )}
-                        {run.runUrl && (
-                          <a
-                            href={updateRepoUrl(run.runUrl)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sm hover:underline text-foreground underline"
-                          >
-                            Workflow Run
-                            <ExternalLinkIcon />
-                          </a>
-                        )}
+                        {renderRunLinks(run.headRef, run.runUrl)}
                         {onChart ? (
                           <button
                             type="button"
@@ -328,7 +337,11 @@ export default function ComparisonChangelog({
                 });
               }
 
-              // Single (or no) matching run → one block keyed by the date.
+              // Single (or no) matching run → one block keyed by the date. Link to
+              // the run that produced this config's data so a date with unrelated
+              // same-day runs never borrows another run's commit/run links. No
+              // matching run (e.g. a pinned endpoint) → no links.
+              const { headRef, runUrl } = runs[0] ?? {};
               const dateGpuLabel = gpuLabelsFor(item.entries);
               return (
                 <div key={item.date} className="flex flex-col gap-1">
@@ -337,31 +350,10 @@ export default function ComparisonChangelog({
                       {item.date}
                       {dateGpuLabel ? ` ${dateGpuLabel}` : ''}
                     </span>
-                    {item.entries.length > 0 && (
+                    {item.entries.length > 0 && (headRef || runUrl) && (
                       <>
                         <span className="text-muted-foreground">&mdash;</span>
-                        {item.headRef && (
-                          <a
-                            href={`https://github.com/SemiAnalysisAI/InferenceX/commit/${item.headRef}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sm hover:underline text-foreground underline"
-                          >
-                            Git Commit
-                            <ExternalLinkIcon />
-                          </a>
-                        )}
-                        {item.runUrl && (
-                          <a
-                            href={updateRepoUrl(item.runUrl)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-sm hover:underline text-foreground underline"
-                          >
-                            Workflow Run
-                            <ExternalLinkIcon />
-                          </a>
-                        )}
+                        {renderRunLinks(headRef, runUrl)}
                       </>
                     )}
                     {datesOnChart.has(item.date) ? (

--- a/packages/app/src/components/inference/utils/runEnumeration.test.ts
+++ b/packages/app/src/components/inference/utils/runEnumeration.test.ts
@@ -88,6 +88,8 @@ describe('dataRunsForDate', () => {
   });
 
   it('carries run url and head sha through', () => {
+    // The single-run changelog block links off these per-run fields (#408), so a
+    // date with unrelated same-day runs cannot borrow another run's commit/run links.
     const rows = [
       rc({
         github_run_id: 7,

--- a/packages/app/src/hooks/api/use-comparison-changelogs.ts
+++ b/packages/app/src/hooks/api/use-comparison-changelogs.ts
@@ -26,8 +26,6 @@ export interface ComparisonRun {
 
 export interface ComparisonChangelog {
   date: string;
-  headRef?: string;
-  runUrl?: string;
   /** All of the date's changelog entries (flattened across runs). */
   entries: ComparisonChangelogEntry[];
   /** Individual runs on this date, in chronological order (earliest first). */
@@ -117,8 +115,6 @@ export function useComparisonChangelogs(
 
       results.push({
         date: datesToQuery[i],
-        headRef: data.changelogs.at(-1)?.head_ref,
-        runUrl: data.runs.at(-1)?.html_url ?? undefined,
         entries: data.changelogs.map((c: ChangelogRow) => ({
           config_keys: c.config_keys,
           description: c.description,


### PR DESCRIPTION
Fixes #408.

## Problem

On the inference page's Config Changelog, the "Git Commit" and "Workflow Run" links for a single-run date could point to a completely unrelated run. Reproduced on dsv4-pro 1k1k b200 vllm fp4: the 2026-06-05 entry shows the correct description ("Enable EPLB for DEP configs", PR SemiAnalysisAI/InferenceX#1655) but links to the Qwen3.5 run and commit (PR SemiAnalysisAI/InferenceX#1669) that merged ~30 minutes later the same day.

Root cause: the single-run render branch sourced its links from date-level aggregates in `useComparisonChangelogs`: `data.changelogs.at(-1)?.head_ref` and `data.runs.at(-1)?.html_url`. Those are the last changelog entry and last run on the calendar date, with no regard for which config produced the point. When two unrelated PRs merge the same day, the later one wins those fields. The description is correctly filtered per config, so the right note shows next to the wrong commit/run.

## Fix

- Drive the single-run links off the run that actually produced the selected config's data (`runs[0]` from `dataRunsForDate`, the same per-(run, config) source the multi-run branch already uses).
- Delete the date-level `headRef`/`runUrl` fields from `ComparisonChangelog` entirely so the config-blind aggregate cannot be used again. Nothing else read them.
- Factor the duplicated Git Commit / Workflow Run anchor JSX into a shared `renderRunLinks` helper used by both branches.
- Render the single-run separator only when a link exists, so a changelog entry whose benchmark run errored no longer leaves a dangling separator.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` clean.
- Full app unit suite passes (`pnpm --filter @semianalysisai/inferencex-app exec vitest run`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped inference changelog UI and hook typing; no auth, data writes, or API changes—main risk is incorrect links if run enumeration regresses.
> 
> **Overview**
> Fixes **wrong Git Commit / Workflow Run links** on single-run Config Changelog rows when multiple unrelated workflows landed the same calendar day. Descriptions were already config-filtered, but links came from date-level “last changelog / last run” aggregates.
> 
> **Data model:** `ComparisonChangelog` no longer exposes date-level `headRef` / `runUrl`; `useComparisonChangelogs` stops populating them. Per-run metadata stays on `ComparisonRun` and benchmark `runConfigs`.
> 
> **UI:** The single-run branch takes `headRef` / `runUrl` from the run that produced the selected config (`runs[0]` via `runMetaFor` / `dataRunsForDate`), matching the multi-run path. Shared `renderRunLinks` replaces duplicated anchor JSX. The em dash and link block render only when at least one link exists (avoids a dangling separator when the producing run has no URL/SHA).
> 
> **Tests:** Comment on `dataRunsForDate` clarifies why per-run `html_url` / `head_sha` must flow through for this fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9388a7d9f2bdcfbb768c36a629819cad02d81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->