### PR TITLE
fix(inference): resolve framework aliases in getHardwareKey

### DIFF
--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -933,6 +933,20 @@ describe('getHardwareKey', () => {
   it('handles hw with no dashes', () => {
     expect(getHardwareKey(entry({ hw: 'h100', framework: '' }))).toBe('h100');
   });
+
+  it('resolves aliased frameworks to canonical keys (atom-disagg → mooncake-atom)', () => {
+    // Must match the canonical key buildAvailabilityHwKey builds for the GPU filter,
+    // otherwise disagg ATOMesh points are filtered out of the chart.
+    expect(getHardwareKey(entry({ hw: 'mi355x', framework: 'atom-disagg', disagg: true }))).toBe(
+      'mi355x_mooncake-atom',
+    );
+  });
+
+  it('keeps the non-aliased atom framework distinct from atom-disagg', () => {
+    expect(getHardwareKey(entry({ hw: 'mi355x', framework: 'atom', disagg: true }))).toBe(
+      'mi355x_atom',
+    );
+  });
 });
 
 // ===========================================================================

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -187,12 +187,15 @@ export type YAxisMetric = (typeof Y_AXIS_METRICS)[number];
 export const getHardwareKey = (entry: AggDataEntry): string => {
   let normalizedHwName = entry.hw.split('-')[0];
   if (entry.framework) {
+    // Resolve legacy/aliased framework names (e.g. atom-disagg → mooncake-atom) so chart
+    // point keys match the canonical keys built by buildAvailabilityHwKey for the GPU filter.
+    const fw = resolveFrameworkAlias(entry.framework);
     // Try framework as-is first, then disagg variant if it exists
-    const candidateDirect = `${normalizedHwName}_${entry.framework}`;
+    const candidateDirect = `${normalizedHwName}_${fw}`;
     if (isKnownGpu(candidateDirect)) {
       normalizedHwName = candidateDirect;
     } else if (entry.disagg) {
-      const candidateDisagg = `${normalizedHwName}_${entry.framework}-disagg`;
+      const candidateDisagg = `${normalizedHwName}_${fw}-disagg`;
       normalizedHwName = isKnownGpu(candidateDisagg) ? candidateDisagg : candidateDirect;
     } else {
       normalizedHwName = candidateDirect;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to chart key normalization, consistent with existing alias handling elsewhere in chart-utils; low risk beyond inference chart filtering behavior.
> 
> **Overview**
> **`getHardwareKey`** now runs aggregated benchmark framework strings through **`resolveFrameworkAlias`** before building GPU keys, matching **`buildAvailabilityHwKey`** used for the chart GPU filter.
> 
> That fixes **disaggregated ATOMesh** runs that still report **`atom-disagg`**: chart points resolve to keys like **`mi355x_mooncake-atom`** instead of mismatched raw names, so they are no longer dropped from the chart. Plain **`atom`** stays separate from the aliased disagg name. Tests cover the alias and the non-aliased case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db90fecbc2f61e523265b8c9f4ac487b5416a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->