### PR TITLE
chore: rename "ATOMesh" framework label to "Mooncake ATOMesh"

### DIFF
--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -936,7 +936,7 @@ describe('getHardwareKey', () => {
 
   it('resolves aliased frameworks to canonical keys (atom-disagg → mooncake-atom)', () => {
     // Must match the canonical key buildAvailabilityHwKey builds for the GPU filter,
-    // otherwise disagg ATOMesh points are filtered out of the chart.
+    // otherwise disagg Mooncake ATOMesh points are filtered out of the chart.
     expect(getHardwareKey(entry({ hw: 'mi355x', framework: 'atom-disagg', disagg: true }))).toBe(
       'mi355x_mooncake-atom',
     );

--- a/packages/constants/src/framework-aliases.test.ts
+++ b/packages/constants/src/framework-aliases.test.ts
@@ -10,12 +10,12 @@ import {
 } from './framework-aliases';
 
 describe('FRAMEWORK_LABELS', () => {
-  it('labels the canonical mooncake-atom framework "ATOMesh¹"', () => {
-    expect(FRAMEWORK_LABELS['mooncake-atom']).toBe('ATOMesh¹');
+  it('labels the canonical mooncake-atom framework "Mooncake ATOMesh¹"', () => {
+    expect(FRAMEWORK_LABELS['mooncake-atom']).toBe('Mooncake ATOMesh¹');
   });
 
   it('labels the atom-disagg alias with its canonical label', () => {
-    expect(FRAMEWORK_LABELS['atom-disagg']).toBe('ATOMesh¹');
+    expect(FRAMEWORK_LABELS['atom-disagg']).toBe('Mooncake ATOMesh¹');
   });
 });
 

--- a/packages/constants/src/framework-aliases.ts
+++ b/packages/constants/src/framework-aliases.ts
@@ -9,7 +9,7 @@ export const FW_REGISTRY: Record<string, FwEntry> = {
   'dynamo-sglang': { label: 'Dynamo SGLang' },
   'dynamo-trt': { label: 'Dynamo TRT' },
   'dynamo-vllm': { label: 'Dynamo vLLM' },
-  'mooncake-atom': { label: 'ATOMesh¹' },
+  'mooncake-atom': { label: 'Mooncake ATOMesh¹' },
   'mori-sglang': { label: 'MoRI SGLang' },
   sglang: { label: 'SGLang' },
   trt: { label: 'TRT' },


### PR DESCRIPTION
## Summary

Renames the `mooncake-atom` framework display label from **ATOMesh¹** to **Mooncake ATOMesh¹**.

This builds on #463 (which renamed "Mooncake ATOM" → "ATOMesh"); the label is now "Mooncake ATOMesh". The footnote superscript (`¹`) is preserved, and the `atom-disagg` alias continues to resolve to the same canonical label.

The separate `atom` framework (`ATOM¹`) is intentionally untouched.

## Changes

- `packages/constants/src/framework-aliases.ts` — `mooncake-atom` label `ATOMesh¹` → `Mooncake ATOMesh¹`
- `packages/constants/src/framework-aliases.test.ts` — updated label expectations
- `packages/app/src/lib/chart-utils.test.ts` — updated comment for consistency

## Testing

- `pnpm test:unit` (framework-aliases + chart-utils) — all pass
- Pre-commit lint / format / typecheck — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label change in shared constants with no logic or key changes; risk is limited to chart/tooltip copy.
> 
> **Overview**
> Updates the human-readable label for the **`mooncake-atom`** framework (and the **`atom-disagg`** alias, which inherits it) from **ATOMesh¹** to **Mooncake ATOMesh¹** in `FW_REGISTRY` / `FRAMEWORK_LABELS`. Framework keys, alias resolution, and the separate **`atom`** (**ATOM¹**) entry are unchanged.
> 
> Unit tests in `framework-aliases.test.ts` were updated to match; a comment in `chart-utils.test.ts` was aligned with the new wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9cf266715423956a0646a5b922d58250574aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->