### PR TITLE
Show submissions tab in main navigation

### DIFF
--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -65,6 +65,11 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
       'href',
       '/inference?unofficialruns=12345',
     );
+    cy.get('[data-testid="tab-trigger-submissions"]').should(
+      'have.attr',
+      'href',
+      '/submissions?unofficialruns=12345',
+    );
     cy.get('[data-testid="tab-trigger-historical"]').should(
       'have.attr',
       'href',
@@ -104,22 +109,26 @@ describe('TabNav — Hidden popover for gated tabs', () => {
     mountTabNav({});
     cy.get('[data-testid="tab-trigger-inference"]').should('exist');
     cy.get('[data-testid="tab-trigger-gpu-specs"]').should('exist');
+    cy.get('[data-testid="tab-trigger-submissions"]').should('exist');
     cy.get('[data-testid="tab-trigger-hidden"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-feedback"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('not.exist');
   });
 
-  it('renders the Hidden trigger when unlocked; popover reveals all 4 gated links', () => {
+  it('renders the Hidden trigger when unlocked; popover reveals gated links', () => {
     cy.window().then((win) => win.localStorage.setItem('inferencex-feature-gate', '1'));
     mountTabNav({});
     cy.get('[data-testid="tab-trigger-hidden"]').should('be.visible').and('contain.text', 'Hidden');
     // Gated links are inside the closed popover, so they're not yet in the DOM.
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('not.exist');
+    cy.get('[data-testid="tab-trigger-submissions"]').should('have.attr', 'href', '/submissions');
     cy.get('[data-testid="tab-trigger-hidden"]').click();
     cy.get('[data-testid="tab-hidden-popover"]').should('be.visible');
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('have.attr', 'href', '/ai-chart');
     cy.get('[data-testid="tab-trigger-gpu-metrics"]').should('have.attr', 'href', '/gpu-metrics');
-    cy.get('[data-testid="tab-trigger-submissions"]').should('have.attr', 'href', '/submissions');
+    cy.get('[data-testid="tab-hidden-popover"]')
+      .find('[data-testid="tab-trigger-submissions"]')
+      .should('not.exist');
     cy.get('[data-testid="tab-trigger-feedback"]').should('have.attr', 'href', '/feedback');
   });
 

--- a/packages/app/src/components/submissions/SubmissionsDisplay.tsx
+++ b/packages/app/src/components/submissions/SubmissionsDisplay.tsx
@@ -1,11 +1,8 @@
 'use client';
 
-import { Lock } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { track } from '@/lib/analytics';
-import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ChartButtons } from '@/components/ui/chart-buttons';
 import { ChartShareActions } from '@/components/ui/chart-display-helpers';
@@ -13,7 +10,6 @@ import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/seg
 import { exportToCsv } from '@/lib/csv-export';
 import { submissionsVolumeToCsv } from '@/lib/csv-export-helpers';
 import { useSubmissions } from '@/hooks/api/use-submissions';
-import { relockFeatureGate } from '@/lib/use-feature-gate';
 
 import SubmissionsChart, { type ChartMode } from './SubmissionsChart';
 import SubmissionsTable from './SubmissionsTable';
@@ -27,7 +23,6 @@ const SUBMISSIONS_CHART_MODE_OPTIONS: SegmentedToggleOption<ChartMode>[] = [
 ];
 
 export default function SubmissionsDisplay() {
-  const router = useRouter();
   const { data, isLoading, error } = useSubmissions();
   const [chartMode, setChartMode] = useState<ChartMode>('weekly');
 
@@ -73,20 +68,6 @@ export default function SubmissionsDisplay() {
               </p>
             </div>
             <div className="flex items-center gap-1.5">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-7 gap-1.5 text-xs text-muted-foreground"
-                onClick={() => {
-                  relockFeatureGate();
-                  track('submissions_relocked');
-                  router.push('/inference');
-                }}
-                title="Re-lock feature gate"
-              >
-                <Lock className="size-3" />
-                Re-lock feature gate
-              </Button>
               <ChartShareActions />
             </div>
           </div>

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -29,12 +29,12 @@ const VISIBLE_TABS = [
   { href: '/historical', label: 'Historical Trends', testId: 'tab-trigger-historical' },
   { href: '/calculator', label: 'TCO Calculator', testId: 'tab-trigger-calculator' },
   { href: '/gpu-specs', label: 'GPU Specs', testId: 'tab-trigger-gpu-specs' },
+  { href: '/submissions', label: 'Submissions', testId: 'tab-trigger-submissions' },
 ] as const;
 
 const GATED_TABS = [
   { href: '/ai-chart', label: 'AI Chart', testId: 'tab-trigger-ai-chart' },
   { href: '/gpu-metrics', label: 'PowerX', testId: 'tab-trigger-gpu-metrics' },
-  { href: '/submissions', label: 'Submissions', testId: 'tab-trigger-submissions' },
   {
     href: '/current-inferencex-image',
     label: 'Images',

--- a/packages/app/src/lib/use-feature-gate.ts
+++ b/packages/app/src/lib/use-feature-gate.ts
@@ -16,9 +16,9 @@ const UNLOCK_SEQUENCE = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown'];
  * (FEATURE_GATE_UNLOCKED_EVENT / FEATURE_GATE_LOCKED_EVENT) so all
  * consumers flip together without each owning a keyboard listener.
  *
- * Used by tab-nav (GATED_TABS), gpu-power, submissions, feedback,
- * and any chart surface that should be visible only to insiders
- * until the underlying data is stable.
+ * Used by tab-nav (GATED_TABS), gpu-power, feedback, and any chart
+ * surface that should be visible only to insiders until the underlying
+ * data is stable.
  */
 /**
  * Re-lock the feature gate from any client surface. Owns the localStorage write


### PR DESCRIPTION
## Summary
- Move Submissions out of the Hidden gated tab popover and into the normal dashboard tab navigation.
- Update TabNav component coverage to assert Submissions is visible without the feature gate and absent from the Hidden popover.
- Refresh the feature-gate comment now that Submissions is no longer gated.

## Testing
- git diff --check
- Not run: focused Cypress component spec could not start in this fresh worktree because dependencies were not installed and pnpm registry/policy checks failed with ENOTFOUND for registry.npmjs.org.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and visibility-only changes; no auth, API, or data-handling changes.
> 
> **Overview**
> **Submissions** is now a first-class dashboard tab instead of living only behind the Konami-style **Hidden** popover.
> 
> `tab-nav` moves `/submissions` from `GATED_TABS` to `VISIBLE_TABS`, so it shows on desktop and mobile without unlocking the feature gate. The Hidden popover no longer lists Submissions when the gate is unlocked. Cypress coverage now expects Submissions in the main nav (including `unofficialruns` on its href) and absent from the popover.
> 
> `SubmissionsDisplay` drops the **Re-lock feature gate** control and related analytics/navigation, since the page is no longer treated as insider-only. The `use-feature-gate` doc comment no longer mentions submissions as a gated surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd31aa8e2c3d1336b12d181a249a465acc16fb1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->