### PR TITLE
Add submissions CTA to landing page

### DIFF
--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -76,4 +76,9 @@ describe('First-load navigation', () => {
     cy.contains('a', 'Open Dashboard').click();
     cy.location('pathname').should('eq', '/inference');
   });
+
+  it('navigates to submissions from the landing CTA', () => {
+    cy.get('[data-testid="landing-submissions-link"]').click();
+    cy.location('pathname').should('eq', '/submissions');
+  });
 });

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -105,7 +105,10 @@ export function LandingPage() {
               <Link
                 href="/submissions"
                 data-testid="landing-submissions-link"
-                onClick={() => track('landing_submissions_clicked')}
+                onClick={(e) => {
+                  track('landing_submissions_clicked');
+                  navigateInApp(e, router, '/submissions');
+                }}
                 className="inline-flex items-center gap-1.5 rounded-md bg-brand text-primary-foreground hover:bg-brand/90 px-3 py-1.5 transition-colors font-medium"
               >
                 Browse submissions

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -72,6 +72,12 @@ export function LandingPage() {
               full logs and artifacts are publicly viewable. Click any point on a chart to jump
               straight to the run that produced it. All reproducible, auditable, and open source.
             </p>
+            <p className="text-sm text-muted-foreground mb-4">
+              <span className="font-semibold text-foreground">
+                1,000+ new benchmark datapoints added per week on average.
+              </span>{' '}
+              Browse every new model, GPU, framework, and configuration as it lands.
+            </p>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
               <div className="rounded-md border border-border bg-card p-3">
                 <div className="text-sm font-semibold text-foreground">Public Actions runs</div>
@@ -96,12 +102,21 @@ export function LandingPage() {
               </div>
             </div>
             <div className="flex flex-wrap gap-3 text-sm">
+              <Link
+                href="/submissions"
+                data-testid="landing-submissions-link"
+                onClick={() => track('landing_submissions_clicked')}
+                className="inline-flex items-center gap-1.5 rounded-md bg-brand text-primary-foreground hover:bg-brand/90 px-3 py-1.5 transition-colors font-medium"
+              >
+                Browse submissions
+                <ArrowRight className="size-3.5" />
+              </Link>
               <a
                 href={`https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/actions?query=branch%3Amain+event%3Apush`}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={() => track('landing_reproducibility_actions_clicked')}
-                className="inline-flex items-center gap-1.5 rounded-md bg-brand text-primary-foreground hover:bg-brand/90 px-3 py-1.5 transition-colors font-medium"
+                className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 hover:bg-accent transition-colors"
               >
                 View benchmark runs on GitHub Actions
                 <ArrowRight className="size-3.5" />


### PR DESCRIPTION
## Summary
- Add a landing-page callout for 1,000+ new benchmark datapoints per week on average.
- Link the primary reproducibility CTA to `/submissions` and keep GitHub Actions as a secondary action.
- Add Cypress coverage for navigating from the landing CTA to Submissions.

## Testing
- `git diff --check`
- Not run: format, lint, typecheck, and Cypress could not start because the dependency install is incomplete and npm registry requests fail with `ENOTFOUND` in the Codex environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and CTA styling/navigation on the landing page only; no auth, API, or data pipeline changes.
> 
> **Overview**
> The landing **reproducibility** card now highlights **1,000+ new benchmark datapoints per week** and promotes **Browse submissions** as the primary action (brand button to `/submissions` with `landing_submissions_clicked` analytics). The **GitHub Actions** link is demoted to a secondary bordered style so submissions is the main in-app path for new data.
> 
> Cypress **first-load navigation** gains a test that clicks `landing-submissions-link` and expects `/submissions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00f1a4ab86779c2b1a660a25cb4e0b937b8a34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->