### PR TITLE
[codex] Hide novelty overlays in Advanced controls

### DIFF
--- a/packages/app/cypress/e2e/speed-overlay.cy.ts
+++ b/packages/app/cypress/e2e/speed-overlay.cy.ts
@@ -1,3 +1,6 @@
+const advancedToggle = () =>
+  cy.contains('figure', 'vs. Interactivity').find('[data-testid="legend-advanced-toggle"]');
+
 describe('Bus / Race Car Speed Overlay', () => {
   before(() => {
     cy.visit('/inference', {
@@ -9,7 +12,12 @@ describe('Bus / Race Car Speed Overlay', () => {
     cy.get('.sidebar-legend').first().should('be.visible');
   });
 
-  it('toggle exists in the legend and is off by default', () => {
+  it('toggle is hidden in the collapsed Advanced drawer and is off by default', () => {
+    advancedToggle().should('be.visible').and('have.attr', 'aria-expanded', 'false');
+    cy.get('#scatter-speed-overlay').should('not.exist');
+
+    advancedToggle().click();
+    advancedToggle().should('have.attr', 'aria-expanded', 'true');
     cy.get('#scatter-speed-overlay').should('exist');
     cy.get('label[for="scatter-speed-overlay"]').should('contain.text', 'Bus / Race Car');
     cy.get('#scatter-speed-overlay').should('have.attr', 'data-state', 'unchecked');
@@ -59,6 +67,7 @@ describe('Bus / Race Car Speed Overlay', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    advancedToggle().click();
     cy.get('#scatter-speed-overlay').should('have.attr', 'data-state', 'checked');
     cy.get('[data-testid="speed-overlay-bus"]').should('exist');
     cy.get('[data-testid="speed-overlay-car"]').should('exist');
@@ -76,7 +85,11 @@ describe('Donkey / Elytra Minecraft Overlay', () => {
     cy.get('.sidebar-legend').first().should('be.visible');
   });
 
-  it('toggle exists in the legend and is independent of the bus/car toggle', () => {
+  it('toggle is hidden in the Advanced drawer and is independent of the bus/car toggle', () => {
+    advancedToggle().should('have.attr', 'aria-expanded', 'false');
+    cy.get('#scatter-minecraft-overlay').should('not.exist');
+
+    advancedToggle().click();
     cy.get('#scatter-minecraft-overlay').should('exist');
     cy.get('label[for="scatter-minecraft-overlay"]').should('contain.text', 'Donkey / Elytra');
     cy.get('#scatter-minecraft-overlay').should('have.attr', 'data-state', 'unchecked');
@@ -133,6 +146,7 @@ describe('Donkey / Elytra Minecraft Overlay', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    advancedToggle().click();
     cy.get('#scatter-minecraft-overlay').should('have.attr', 'data-state', 'checked');
     cy.get('[data-testid="speed-overlay-minecraft-slow"]').should('exist');
     cy.get('[data-testid="speed-overlay-minecraft-fast"]').should('exist');

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2431,6 +2431,7 @@ const ScatterGraph = React.memo(
               {
                 id: 'scatter-speed-overlay',
                 label: 'Bus / Race Car',
+                advanced: true,
                 checked: showSpeedOverlay,
                 onCheckedChange: (checked: boolean) => {
                   setShowSpeedOverlay(checked);
@@ -2440,6 +2441,7 @@ const ScatterGraph = React.memo(
               {
                 id: 'scatter-minecraft-overlay',
                 label: 'Donkey / Elytra',
+                advanced: true,
                 checked: showMinecraftOverlay,
                 onCheckedChange: (checked: boolean) => {
                   setShowMinecraftOverlay(checked);
@@ -2447,6 +2449,9 @@ const ScatterGraph = React.memo(
                 },
               },
             ]}
+            onAdvancedExpandedChange={(expanded) => {
+              track('latency_advanced_controls_toggled', { expanded });
+            }}
             actions={
               effectiveOfficialHwTypes.size < hwTypesWithData.size ||
               activeOverlayHwTypes.size < allOverlayHwTypes.size

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -4,13 +4,15 @@ import { track } from '@/lib/analytics';
 import {
   ArrowLeftToLine,
   ArrowRightToLine,
+  ChevronDown,
+  ChevronRight,
   Circle,
   Diamond,
   Square,
   Triangle,
   X,
 } from 'lucide-react';
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { SHAPE_ORDER, type ShapeKey, getShapeKeyForPrecision } from '@/lib/chart-rendering';
 import { type Precision, getPrecisionLabel } from '@/lib/data-mappings';
@@ -36,6 +38,7 @@ export interface LegendSwitchConfig {
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  advanced?: boolean;
 }
 
 export interface LegendActionConfig {
@@ -69,6 +72,7 @@ export interface ChartLegendProps {
   onItemHover?: (id: string) => void;
   onItemHoverEnd?: () => void;
   onItemRemove?: (name: string) => void;
+  onAdvancedExpandedChange?: (expanded: boolean) => void;
 }
 
 export default function ChartLegend({
@@ -88,12 +92,15 @@ export default function ChartLegend({
   onItemHover,
   onItemHoverEnd,
   onItemRemove,
+  onAdvancedExpandedChange,
 }: ChartLegendProps) {
   const isSidebar = variant === 'sidebar';
   const [hasLongText, setHasLongText] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
+  const advancedControlsId = useId();
 
   const effectiveExpanded = isLegendExpanded;
   const activeCount = useMemo(
@@ -252,15 +259,13 @@ export default function ChartLegend({
       </div>
     ) : null;
 
-  const switchElements =
-    switches && switches.length > 0 ? (
-      <div
-        className={cn(
-          grouped ? 'w-full space-y-0' : 'w-full md:w-auto flex flex-wrap gap-2',
-          'no-export',
-        )}
-      >
-        {switches.map((sw) => (
+  const standardSwitches = switches?.filter((sw) => !sw.advanced) ?? [];
+  const advancedSwitches = switches?.filter((sw) => sw.advanced) ?? [];
+
+  const renderSwitches = (items: LegendSwitchConfig[]) =>
+    items.length > 0 ? (
+      <div className={cn(grouped ? 'w-full space-y-0' : 'w-full md:w-auto flex flex-wrap gap-2')}>
+        {items.map((sw) => (
           <div key={sw.id} className="mt-2 flex items-center gap-2">
             <Switch
               id={sw.id}
@@ -276,6 +281,41 @@ export default function ChartLegend({
             </Label>
           </div>
         ))}
+      </div>
+    ) : null;
+
+  const switchElements =
+    switches && switches.length > 0 ? (
+      <div className="w-full no-export">
+        {renderSwitches(standardSwitches)}
+        {advancedSwitches.length > 0 && (
+          <div className="mt-2">
+            <button
+              type="button"
+              data-testid="legend-advanced-toggle"
+              aria-expanded={isAdvancedExpanded}
+              aria-controls={advancedControlsId}
+              onClick={() => {
+                const expanded = !isAdvancedExpanded;
+                setIsAdvancedExpanded(expanded);
+                onAdvancedExpandedChange?.(expanded);
+              }}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {isAdvancedExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              Advanced
+            </button>
+            {isAdvancedExpanded && (
+              <div
+                id={advancedControlsId}
+                data-testid="legend-advanced-controls"
+                className="ml-1 pl-3 border-l border-border"
+              >
+                {renderSwitches(advancedSwitches)}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     ) : null;
 


### PR DESCRIPTION
## Summary
- Add a collapsed-by-default Advanced disclosure to the shared chart legend.
- Move Bus / Race Car and Donkey / Elytra toggles into the Advanced section.
- Track Advanced expand/collapse interactions and preserve existing overlay state, URL parameters, and rendering behavior.
- Update Cypress coverage for the collapsed drawer, both overlays, and URL-driven activation.

## Why
The novelty overlays are useful but visually compete with the primary chart controls. Keeping them available under Advanced makes the default legend easier to scan without removing functionality.

## Testing
- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` (2,434 tests passed)
- `pnpm exec cypress run --e2e --spec cypress/e2e/speed-overlay.cy.ts --browser chrome` (15 tests passed)
- Manual desktop and 390px responsive visual inspection

No chart data-path changes; official and `?unofficialrun=` rendering behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Legend UI and E2E test updates only; no changes to chart data, URL overlay logic, or rendering paths.
> 
> **Overview**
> The shared **ChartLegend** now supports an optional **`advanced`** flag on legend switches and renders a **collapsed-by-default “Advanced”** disclosure (`legend-advanced-toggle`) for those entries, with **`aria-expanded`** / **`aria-controls`** and an **`onAdvancedExpandedChange`** hook.
> 
> On the inference scatter chart, **Bus / Race Car** and **Donkey / Elytra** novelty overlays are marked **`advanced: true`**, so their toggles stay hidden until Advanced is expanded; expand/collapse is tracked as **`latency_advanced_controls_toggled`**. Overlay state, URL params (`i_speed`, `i_mc`), and chart rendering are unchanged.
> 
> Cypress **`speed-overlay.cy.ts`** now opens the Advanced drawer before asserting or clicking overlay switches, including on URL-driven loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd15c57269fabff8da1ec65648510b25d60d2eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->