### PR TITLE
chore(inference): move MiniMax M2.5/2.7 to Deprecated

### DIFF
--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -151,6 +151,10 @@ describe('isModelDeprecated', () => {
     expect(isModelDeprecated(Model.Llama3_3_70B)).toBe(true);
   });
 
+  it('returns true for deprecated model MiniMax_M2_5 (superseded by M3)', () => {
+    expect(isModelDeprecated(Model.MiniMax_M2_5)).toBe(true);
+  });
+
   it('returns false for non-deprecated model DeepSeek_R1', () => {
     expect(isModelDeprecated(Model.DeepSeek_R1)).toBe(false);
   });

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -89,13 +89,14 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   [Model.DeepSeek_R1]: { label: 'DeepSeek R1 0528 671B', prefix: 'dsr1', category: 'default' },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
+  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
+    // Superseded by MiniMax M3, so it's deprecated (no longer actively benchmarked).
     label: 'MiniMax M2.5/2.7 230B',
     prefix: 'minimaxm2.5',
-    category: 'default',
+    category: 'deprecated',
   },
-  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },
   [Model.Llama3_3_70B]: { label: 'Llama 3.3 70B Instruct', prefix: '70b', category: 'deprecated' },
   [Model.Llama3_1_70B]: { label: 'Llama 3.1 70B Instruct', prefix: '', category: 'hidden' },
 };


### PR DESCRIPTION
## What

Moves **MiniMax M2.5/2.7 230B** from the active model list into the **Deprecated** section of the Model dropdown, alongside Llama 3.3 70B Instruct.

## Why

MiniMax M2.5/2.7 is superseded by **MiniMax M3 428B**, which is now the actively-benchmarked MiniMax model. M2.5/2.7 is no longer actively benchmarked, so it belongs under Deprecated ("Model is no longer actively benchmarked.").

## How

Single source of truth: flip the `category` for `Model.MiniMax_M2_5` from `default` → `deprecated` in `MODEL_CONFIG` (`packages/app/src/lib/data-mappings.ts`). The selector already partitions models by category via `groupByCategory` + the deprecated section in `chart-selectors.tsx`, so no UI changes are needed. Also moved the entry next to the other deprecated model for readability.

The default-model fallback uses `deepseek-r1` (`LEGACY_BARE_DEFAULT_MODEL_SLUG`), not MiniMax, so the initial model selection is unaffected.

## Tests

- Added a unit test asserting `isModelDeprecated(Model.MiniMax_M2_5) === true`.
- `pnpm test:unit`, `pnpm typecheck`, and `pnpm fmt` pass; changed files lint clean.

## Overlay support

N/A — this is a dropdown categorization change in shared model metadata; it applies identically to official and `?unofficialrun=` overlay paths (both read `MODEL_CONFIG`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only categorization in `data-mappings.ts`; dropdown behavior is already driven by category, with no auth, data, or API changes.
> 
> **Overview**
> **MiniMax M2.5/2.7 230B** is reclassified from active (`default`) to **deprecated** in `MODEL_CONFIG`, so it appears in the Model dropdown’s Deprecated section (with Llama 3.3 70B) instead of the main list. A comment notes it’s superseded by **MiniMax M3**, which stays active.
> 
> `MODEL_CONFIG` entry order is adjusted slightly (e.g. `GptOss` grouped with default models; M2.5 sits with other deprecated entries). A unit test asserts `isModelDeprecated(Model.MiniMax_M2_5)` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0332c2271af8ebab2774dee36249fb96bd9bec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->