### PR TITLE
[codex] Add maintenance mode model category

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -6,6 +6,7 @@ import {
   PrecisionSelector,
 } from '@/components/ui/chart-selectors';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { Model } from '@/lib/data-mappings';
 
 function ModelSelectorHarness() {
   const [value, setValue] = useState('DeepSeek-R1-0528');
@@ -14,7 +15,7 @@ function ModelSelectorHarness() {
       <ModelSelector
         value={value}
         onChange={setValue}
-        availableModels={['DeepSeek-R1-0528', 'Llama-4-Maverick', 'Qwen3-235B']}
+        availableModels={[Model.DeepSeek_R1, Model.Qwen3_5, Model.MiniMax_M2_5, Model.Llama3_3_70B]}
         data-testid="model-selector"
       />
     </TooltipProvider>
@@ -62,8 +63,28 @@ describe('Chart Selectors', () => {
 
     it('selecting an option updates the displayed value', () => {
       cy.get('[data-testid="model-selector"]').click();
-      cy.get('[role="option"]').contains('Qwen3-235B').click();
-      cy.get('[data-testid="model-selector"]').should('contain', 'Qwen3-235B');
+      cy.get('[role="option"]').contains('Qwen3.5 397B').click();
+      cy.get('[data-testid="model-selector"]').should('contain', 'Qwen3.5 397B');
+    });
+
+    it('groups maintenance models separately from deprecated models', () => {
+      cy.get('[data-testid="model-selector"]').click();
+
+      cy.contains('Maintenance Mode').should('be.visible');
+      cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').should('be.visible');
+      cy.contains('Deprecated').should('be.visible');
+      cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').should('be.visible');
+    });
+
+    it('explains maintenance mode in a tooltip', () => {
+      cy.get('[data-testid="model-selector"]').click();
+      cy.get('[data-testid="selector-category-maintenance-mode-info"]').trigger('pointermove', {
+        pointerType: 'mouse',
+      });
+
+      cy.contains('Updated at a lower priority because these models are still relevant.').should(
+        'be.visible',
+      );
     });
   });
 

--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -44,6 +44,15 @@ describe('Dropdown one-click switching', () => {
     cy.get('[data-slot="select-content"]').should('not.exist');
   });
 
+  it('separates maintenance-mode models from deprecated models', () => {
+    cy.get('[data-testid="model-selector"]').click();
+
+    cy.contains('Maintenance Mode').scrollIntoView().should('be.visible');
+    cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').scrollIntoView().should('be.visible');
+    cy.contains('Deprecated').scrollIntoView().should('be.visible');
+    cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').scrollIntoView().should('be.visible');
+  });
+
   it('Escape closes the Y-axis SearchableSelect dropdown', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click();
     cy.get('[data-testid="yaxis-metric-selector"]').should('have.attr', 'aria-expanded', 'true');

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -18,13 +18,16 @@ import {
   groupByCategory,
 } from '@/lib/data-mappings';
 
-function DeprecatedSectionTitle({ reason }: { reason: string }) {
+function CategorySectionTitle({ label, reason }: { label: string; reason: string }) {
   return (
     <span className="flex items-center gap-1">
-      Deprecated
+      {label}
       <TooltipRoot>
         <TooltipTrigger asChild>
-          <Info className="size-3 text-muted-foreground cursor-help" />
+          <Info
+            className="size-3 text-muted-foreground cursor-help"
+            data-testid={`selector-category-${label.toLowerCase().replaceAll(' ', '-')}-info`}
+          />
         </TooltipTrigger>
         <TooltipContent side="top" collisionPadding={10}>
           <span>{reason}</span>
@@ -74,11 +77,33 @@ export function ModelSelector({
           },
         ]
       : []),
+    ...(groups.maintenance.length > 0
+      ? [
+          {
+            id: 'maintenance',
+            header: (
+              <CategorySectionTitle
+                label="Maintenance Mode"
+                reason="Updated at a lower priority because these models are still relevant."
+              />
+            ),
+            options: groups.maintenance.map((model) => ({
+              value: model,
+              label: getModelLabel(model as Model),
+            })),
+          },
+        ]
+      : []),
     ...(groups.deprecated.length > 0
       ? [
           {
             id: 'deprecated',
-            header: <DeprecatedSectionTitle reason="Model is no longer actively benchmarked." />,
+            header: (
+              <CategorySectionTitle
+                label="Deprecated"
+                reason="Model is no longer actively benchmarked."
+              />
+            ),
             options: groups.deprecated.map((model) => ({
               value: model,
               label: getModelLabel(model as Model),
@@ -155,7 +180,10 @@ export function SequenceSelector({
           {
             id: 'deprecated',
             header: (
-              <DeprecatedSectionTitle reason="CI capacity was reallocated to agentic coding and multi-turn chat scenarios." />
+              <CategorySectionTitle
+                label="Deprecated"
+                reason="CI capacity was reallocated to agentic coding and multi-turn chat scenarios."
+              />
             ),
             options: groups.deprecated.map((seq) => ({
               value: seq,

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -8,6 +8,7 @@ import {
   getPrecisionLabel,
   getEvalBenchmarkLabel,
   isModelDeprecated,
+  isModelMaintenance,
   isSequenceDeprecated,
   Model,
   Sequence,
@@ -161,6 +162,20 @@ describe('isModelDeprecated', () => {
 
   it('returns false for non-deprecated model GptOss', () => {
     expect(isModelDeprecated(Model.GptOss)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// isModelMaintenance
+// ===========================================================================
+describe('isModelMaintenance', () => {
+  it('returns true for the DeepSeek R1 maintenance-mode family', () => {
+    expect(isModelMaintenance(Model.DeepSeek_R1)).toBe(true);
+  });
+
+  it('keeps deprecated and default models out of maintenance mode', () => {
+    expect(isModelMaintenance(Model.Llama3_3_70B)).toBe(false);
+    expect(isModelMaintenance(Model.MiniMax_M2_5)).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -13,7 +13,7 @@ export enum Model {
   DeepSeek_V4_Pro = 'DeepSeek-V4-Pro',
 }
 
-export type CategoryTag = 'default' | 'experimental' | 'deprecated' | 'hidden';
+export type CategoryTag = 'default' | 'experimental' | 'maintenance' | 'deprecated' | 'hidden';
 
 /**
  * Partition a list of values by their category using a classifier function.
@@ -25,6 +25,7 @@ export function groupByCategory<T>(
   const groups: Record<CategoryTag, T[]> = {
     default: [],
     experimental: [],
+    maintenance: [],
     deprecated: [],
     hidden: [],
   };
@@ -86,7 +87,11 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'minimaxm3',
     category: 'default',
   },
-  [Model.DeepSeek_R1]: { label: 'DeepSeek R1 0528 671B', prefix: 'dsr1', category: 'default' },
+  [Model.DeepSeek_R1]: {
+    label: 'DeepSeek R1 0528 671B',
+    prefix: 'dsr1',
+    category: 'maintenance',
+  },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },
@@ -114,6 +119,7 @@ export const MODEL_OPTIONS = (Object.keys(MODEL_CONFIG) as Model[]).filter(
 );
 
 export const DEFAULT_MODELS: ReadonlySet<Model> = modelsByCategory('default');
+export const MAINTENANCE_MODELS: ReadonlySet<Model> = modelsByCategory('maintenance');
 export const DEPRECATED_MODELS: ReadonlySet<Model> = modelsByCategory('deprecated');
 export const EXPERIMENTAL_MODELS: ReadonlySet<Model> = modelsByCategory('experimental');
 
@@ -122,6 +128,9 @@ export function isModelDefault(model: Model): boolean {
 }
 export function isModelDeprecated(model: Model): boolean {
   return DEPRECATED_MODELS.has(model);
+}
+export function isModelMaintenance(model: Model): boolean {
+  return MAINTENANCE_MODELS.has(model);
 }
 export function isModelExperimental(model: Model): boolean {
   return EXPERIMENTAL_MODELS.has(model);


### PR DESCRIPTION
## Summary

- Add a first-class `maintenance` model category to the shared model metadata.
- Move the available DeepSeek V3/R1 family entry, **DeepSeek R1 0528**, into a new **Maintenance Mode** selector section.
- Preserve MiniMax M2.5/2.7 and Llama 3.3 under **Deprecated**.
- Add an info tooltip explaining that maintenance-mode models are updated at a lower priority because they remain relevant.
- Add unit, Cypress component, and Cypress E2E coverage for category membership, model grouping, and tooltip copy.

## Why

The DeepSeek V3/R1 family remains useful and continues receiving lower-priority updates, so grouping it with models that are no longer actively benchmarked gives users the wrong lifecycle signal.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `pnpm test:unit` (2,437 tests passed)
- `pnpm test:e2e` (152 component tests and 421 E2E tests passed)

## Rebase

Rebased onto `origin/master` at `88477fe`, including the upstream MiniMax M2.5/2.7 deprecation change from PR #482.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/metadata classification and selector grouping only; no auth, data pipeline, or benchmark logic changes.
> 
> **Overview**
> Introduces a **`maintenance`** model lifecycle category so still-relevant models are not lumped in with **Deprecated**.
> 
> **DeepSeek R1 0528** is reclassified from default to `maintenance` in shared `MODEL_CONFIG`, with `MAINTENANCE_MODELS` / `isModelMaintenance()` and `groupByCategory` support. The model dropdown now renders a **Maintenance Mode** section (with an info tooltip about lower-priority updates) ahead of **Deprecated**; section headers share a renamed `CategorySectionTitle` helper with stable `data-testid`s for tooltips.
> 
> Unit tests cover `isModelMaintenance`; Cypress component and E2E tests assert grouping and tooltip copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816d4e32b2c3efe0f375c7fa2e8f436f94c14f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->