### PR TITLE
[codex] Fix maintenance mode tooltip copy

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -82,7 +82,7 @@ describe('Chart Selectors', () => {
         pointerType: 'mouse',
       });
 
-      cy.contains('Updated at a lower priority because these models are still relevant.').should(
+      cy.contains('Updated at a lower priority because these models are irrelevant.').should(
         'be.visible',
       );
     });

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -84,7 +84,7 @@ export function ModelSelector({
             header: (
               <CategorySectionTitle
                 label="Maintenance Mode"
-                reason="Updated at a lower priority because these models are still relevant."
+                reason="Updated at a lower priority because these models are irrelevant."
               />
             ),
             options: groups.maintenance.map((model) => ({


### PR DESCRIPTION
## Summary

- Change the Maintenance Mode tooltip to say these models are updated at a lower priority because they are irrelevant.
- Update the selector component test to assert the corrected wording.

## Why

The previous copy incorrectly said maintenance-mode models were still relevant, which inverted the intended explanation for their lower update priority.

## Testing

- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `cypress run --component --spec cypress/component/chart-selectors.cy.tsx` (7 tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in UI tooltip text and a test assertion; no logic or data handling.
> 
> **Overview**
> Fixes inverted wording in the **Maintenance Mode** info tooltip on the model chart selector: it now says models are updated at a lower priority because they are **irrelevant**, not because they are still relevant.
> 
> The Cypress component test for that tooltip is updated to match the new string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94504fbb156de7c163cf833f390cae508aca4acf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->