### PR TITLE
fix(seo): clean up the compare pages seo

### DIFF
--- a/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 
-import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  HW_REGISTRY,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
@@ -42,10 +47,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const fullLabel = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const gpuLabel = compareDisplayLabel(parsed.a, parsed.b);
   const url = `${SITE_URL}/compare-per-dollar/${canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b)}`;
-  // Description weaves the user-named SEO terms — "performance per dollar",
-  // "performance normalized by cost", "dollars per million tokens" — without
-  // keyword-stuffing.
-  const description = `${parsed.model.label} cost per million tokens on ${gpuLabel}. Performance normalized by owning-hyperscaler TCO — see which GPU delivers more inference dollars-per-token at every interactivity level.`;
+  // Description leads with the searched GPU pair + model, then the trust
+  // signals (verified/reproducible, what InferenceX is, named supporters)
+  // before weaving the per-dollar SEO terms ("performance per dollar", "cost
+  // per million tokens", "TCO-normalized") without keyword-stuffing.
+  const description = `${gpuLabel} performance per dollar on ${parsed.model.label}: verified, reproducible cost-per-million-token results from InferenceX, the independent open-source benchmark by SemiAnalysis, normalized by hyperscaler TCO. ${SUPPORTERS_LINE} See which GPU is cheaper at every interactivity level.`;
   return {
     title: `${fullLabel} — Performance per Dollar`,
     description,

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -1,6 +1,11 @@
 import type { Metadata } from 'next';
 
-import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  HW_REGISTRY,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
 
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
@@ -11,8 +16,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION =
-  'GPU performance per dollar — head-to-head cost per million tokens across every model and hardware pair we benchmark. Performance normalized by owning-hyperscaler TCO for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6/K2.7-Code 1T, MiniMax M3 428B, GLM 5/5.1, Qwen 3.5 397B-A17B, and more. Pick the cheapest SKU for your workload.';
+const DESCRIPTION = `Which GPU delivers more inference performance per dollar? InferenceX is the independent, open-source benchmark from SemiAnalysis, with verified, reproducible results. ${SUPPORTERS_LINE} Compare cost per million tokens, normalized by hyperscaler TCO, across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
 
 export const metadata: Metadata = {
   title: 'GPU Performance per Dollar',

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 
-import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  HW_REGISTRY,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
@@ -41,7 +46,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const fullLabel = compareModelDisplayLabel(parsed.model, parsed.a, parsed.b);
   const gpuLabel = compareDisplayLabel(parsed.a, parsed.b);
   const url = `${SITE_URL}/compare/${canonicalCompareSlug(parsed.model.slug, parsed.a, parsed.b)}`;
-  const description = `Head-to-head GPU inference benchmark comparison for ${parsed.model.label}: ${gpuLabel}. Latency, throughput, and cost across LLM workloads.`;
+  const description = `${gpuLabel} inference benchmark on ${parsed.model.label}: verified, reproducible head-to-head results from InferenceX, the independent open-source GPU benchmark by SemiAnalysis. ${SUPPORTERS_LINE} Compare latency, throughput & cost.`;
   return {
     title: `${fullLabel} Inference Benchmark`,
     description,

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  HW_REGISTRY,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
 
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
@@ -12,8 +17,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION =
-  'Browse head-to-head GPU inference benchmark comparisons across every model and hardware pair we test. Latency, throughput, and cost for DeepSeek V4 Pro 1.6T, DeepSeek R1, Kimi K2.5/K2.6/K2.7-Code 1T, MiniMax M3 428B, GLM 5/5.1, Qwen 3.5 397B-A17B, and more.';
+const DESCRIPTION = `InferenceX is the independent, open-source GPU inference benchmark from SemiAnalysis, with verified, reproducible nightly results. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',

--- a/packages/constants/src/seo.ts
+++ b/packages/constants/src/seo.ts
@@ -6,4 +6,12 @@ export const AUTHOR_HANDLE = '@SemiAnalysis_';
 export const SITE_TITLE = `${SITE_NAME} by ${AUTHOR_NAME} — AI Inference Benchmark`;
 export const DESCRIPTION =
   'InferenceX is the open-source AI inference benchmark that matches the rapid pace of modern AI development. Powered by one of the largest open-source GPU CI/CD fleets with NVIDIA GB200, AMD MI355X & many more.';
+/**
+ * Social-proof line woven into page meta descriptions to lift search CTR. The
+ * named supporters mirror the published /quotes supporters page so the copy
+ * stays accurate (see packages/app/src/app/quotes/page.tsx). Vendors being
+ * benchmarked (NVIDIA, AMD) are deliberately omitted here to preserve the
+ * "independent, vendor-neutral" framing.
+ */
+export const SUPPORTERS_LINE = 'Supported by OpenAI, Microsoft & the PyTorch Foundation.';
 export const OG_IMAGE = `${SITE_URL}/og-image.png`;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy-only SEO metadata changes with no runtime logic, routing, or data handling.
> 
> **Overview**
> **Compare routes** (`/compare`, `/compare/[slug]`, `/compare-per-dollar`, `/compare-per-dollar/[slug]`) get rewritten **meta `description`** strings (and matching Open Graph/Twitter where applicable) for search snippets.
> 
> A shared **`SUPPORTERS_LINE`** is added in `packages/constants/src/seo.ts` and interpolated into those descriptions so supporter names stay consistent with `/quotes` and vendor-neutral framing.
> 
> **Index pages** lead with InferenceX positioning (independent, open-source, verified/reproducible) plus the supporters line, then benchmark scope. **Slug pages** lead with the GPU pair and model, then trust signals and **`SUPPORTERS_LINE`**, with per-dollar pages still weaving TCO/cost-per-token terms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53ae9807a1afb9debea53324c26e957224e7ecc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->