### PR TITLE
feat(quotes): move "See more supporters" link onto the attribution line

### DIFF
--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -66,7 +66,7 @@ function buildCompanyQuotes(quotes: CarouselQuote[], order?: string[]): CompanyE
   return shuffleArray(entries);
 }
 
-function QuoteBlock({ quote }: { quote: CarouselQuote }) {
+function QuoteBlock({ quote, moreHref }: { quote: CarouselQuote; moreHref?: string }) {
   return (
     <blockquote className="w-full">
       <p className="text-sm lg:text-base leading-relaxed text-muted-foreground italic">
@@ -91,6 +91,15 @@ function QuoteBlock({ quote }: { quote: CarouselQuote }) {
           )}
           <span className="block text-muted-foreground text-xs">{quote.title}</span>
         </div>
+        {moreHref && (
+          <Link
+            href={moreHref}
+            className="ml-auto shrink-0 whitespace-nowrap text-xs font-bold text-brand hover:underline"
+            onClick={() => track('quote_carousel_see_more_clicked')}
+          >
+            See more supporters &rarr;
+          </Link>
+        )}
       </footer>
     </blockquote>
   );
@@ -198,23 +207,11 @@ export function QuoteCarousel({
               }`}
               aria-hidden={!isActive}
             >
-              <QuoteBlock quote={e.quote} />
+              <QuoteBlock quote={e.quote} moreHref={moreHref} />
             </div>
           );
         })}
       </div>
-
-      {moreHref && (
-        <div className="flex justify-end">
-          <Link
-            href={moreHref}
-            className="text-xs font-bold text-brand hover:underline"
-            onClick={() => track('quote_carousel_see_more_clicked')}
-          >
-            See more supporters &rarr;
-          </Link>
-        </div>
-      )}
     </div>
   );
 }

--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -66,7 +66,7 @@ function buildCompanyQuotes(quotes: CarouselQuote[], order?: string[]): CompanyE
   return shuffleArray(entries);
 }
 
-function QuoteBlock({ quote, moreHref }: { quote: CarouselQuote; moreHref?: string }) {
+function QuoteBlock({ quote }: { quote: CarouselQuote }) {
   return (
     <blockquote className="w-full">
       <p className="text-sm lg:text-base leading-relaxed text-muted-foreground italic">
@@ -91,15 +91,6 @@ function QuoteBlock({ quote, moreHref }: { quote: CarouselQuote; moreHref?: stri
           )}
           <span className="block text-muted-foreground text-xs">{quote.title}</span>
         </div>
-        {moreHref && (
-          <Link
-            href={moreHref}
-            className="ml-auto shrink-0 whitespace-nowrap text-xs font-bold text-brand hover:underline"
-            onClick={() => track('quote_carousel_see_more_clicked')}
-          >
-            See more supporters &rarr;
-          </Link>
-        )}
       </footer>
     </blockquote>
   );
@@ -193,24 +184,39 @@ export function QuoteCarousel({
         ))}
       </div>
 
-      {/* All quotes stacked in same grid cell — tallest sets height */}
-      <div className="grid items-center">
-        {entries.map((e, i) => {
-          const isActive = i === activeIndex;
-          return (
-            <div
-              key={e.org}
-              className={`col-start-1 row-start-1 ${
-                isActive
-                  ? `transition-opacity duration-300 ease-in-out ${fading ? 'opacity-0' : 'opacity-100'}`
-                  : 'opacity-0 invisible pointer-events-none'
-              }`}
-              aria-hidden={!isActive}
-            >
-              <QuoteBlock quote={e.quote} moreHref={moreHref} />
-            </div>
-          );
-        })}
+      {/* Fading quote stack (left) + constant link pinned to the footer baseline (right).
+          items-end keeps every quote's footer on the same bottom line so the link,
+          which lives outside the fading stack, stays aligned with it. */}
+      <div className="flex items-end gap-4">
+        {/* All quotes stacked in same grid cell — tallest sets height */}
+        <div className="grid items-end min-w-0 flex-1">
+          {entries.map((e, i) => {
+            const isActive = i === activeIndex;
+            return (
+              <div
+                key={e.org}
+                className={`col-start-1 row-start-1 ${
+                  isActive
+                    ? `transition-opacity duration-300 ease-in-out ${fading ? 'opacity-0' : 'opacity-100'}`
+                    : 'opacity-0 invisible pointer-events-none'
+                }`}
+                aria-hidden={!isActive}
+              >
+                <QuoteBlock quote={e.quote} />
+              </div>
+            );
+          })}
+        </div>
+
+        {moreHref && (
+          <Link
+            href={moreHref}
+            className="shrink-0 whitespace-nowrap text-xs font-bold text-brand hover:underline"
+            onClick={() => track('quote_carousel_see_more_clicked')}
+          >
+            See more supporters &rarr;
+          </Link>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What

Moves the **See more supporters →** link from its own right-aligned row below the supporter quote up into the quote's attribution footer, so it sits on the same line as the supporter name/affiliation (right-aligned).

## Why

The link previously occupied a separate row beneath the quote block, leaving the attribution line visually unbalanced. Inlining it tightens the layout and puts the call-to-action on the same baseline as the attribution.

## How

- `QuoteBlock` now accepts an optional `moreHref` and renders the link at the end of the `<footer>`, pushed right with `ml-auto shrink-0 whitespace-nowrap`.
- Removed the separate bottom `flex justify-end` row; `moreHref` is passed into `QuoteBlock` instead.

## Notes

- The link now renders once per stacked quote, but only the active quote is visible and interactive (inactive blocks are `invisible pointer-events-none`), so click handling, the `quote_carousel_see_more_clicked` analytics event, and tab order are unaffected.
- On narrow viewports the footer now packs logo + divider + attribution + link onto one line. The link won't wrap (`whitespace-nowrap`); a long attribution title could get cramped. Can make it responsive (drop below on mobile, inline on `md+`) if desired.

## Testing

- `pnpm lint`, `pnpm fmt`, `pnpm typecheck` pass (also enforced by pre-commit hook).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change in the quote carousel component with no auth, data, or API impact.
> 
> **Overview**
> **See more supporters →** is no longer on its own full-width row under the carousel. It sits in a horizontal `flex items-end` row beside the fading quote stack so it lines up with the attribution footer baseline while quotes still cross-fade in a stacked grid.
> 
> The quote grid uses `items-end`, `min-w-0`, and `flex-1`; the link keeps `shrink-0 whitespace-nowrap` and the same analytics click handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a6f15e2ff92d96711416463aa9c4efaf20e72d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->