### PR TITLE
chore(ci): bump claude workflows to opus 4.8

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -298,7 +298,7 @@ jobs:
             actions: read
 
           claude_args: |
-            --model 'claude-opus-4-7'
+            --model 'claude-opus-4-8'
             --mcp-config '${{ env.MCP_CONFIG }}'
             --allowedTools "${{ env.CLAUDE_TOOLS }}"
 
@@ -339,7 +339,7 @@ jobs:
           allowed_bots: ''
 
           claude_args: |
-            --model 'claude-opus-4-7'
+            --model 'claude-opus-4-8'
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
           prompt: |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only model identifier swap with no application or auth changes; only affects which model runs in GitHub Actions.
> 
> **Overview**
> Updates the Anthropic model passed to **claude-code-action** in `.github/workflows/claude.yml` from `claude-opus-4-7` to **`claude-opus-4-8`** in both jobs: **implement** (`@claude` / `@claude chrome`) and **review** (`@claude review` and auto review on PR open). Prompts, tools, and triggers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20bbd5c0d9a2347f8b136a8c56ac611e4b256e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->