### PR TITLE
fix(db): build each chart line from a single run, no cross-run/date stitching

### DIFF
--- a/packages/db/migrations/007_latest_benchmarks_single_run_per_line.sql
+++ b/packages/db/migrations/007_latest_benchmarks_single_run_per_line.sql
@@ -1,0 +1,46 @@
+-- ============================================================
+-- LATEST_BENCHMARKS — one run per line (no cross-run stitching)
+-- ============================================================
+--
+-- Previously the view did `distinct on (config_id, conc, isl, osl)` ordered by
+-- date desc — resolved INDEPENDENTLY per concurrency. So if a newer run
+-- re-measured only some concurrencies (a partial re-sweep), the concurrencies it
+-- skipped fell back to an older run that did measure them, and a single chart line
+-- ended up stitched from points produced by different runs on different dates.
+--
+-- A line is one config + sequence (config_id, benchmark_type, isl, osl) plotted
+-- across concurrencies, and it must come from a SINGLE workflow run. We pick the
+-- newest run per line (newest date, then latest sweep by run_started_at, then
+-- highest workflow_run_id so exactly one run wins even on a same-day / null tie),
+-- then keep EVERY concurrency that one run measured. A partial re-sweep therefore
+-- truncates the line to its own concurrencies rather than borrowing an older run's.
+
+drop materialized view if exists latest_benchmarks;
+
+create materialized view latest_benchmarks as
+with winners as (
+  select distinct on (br.config_id, br.benchmark_type, br.isl, br.osl)
+         br.config_id, br.benchmark_type, br.isl, br.osl,
+         br.workflow_run_id as winning_run_id
+  from benchmark_results br
+  join latest_workflow_runs wr on wr.id = br.workflow_run_id
+  where br.error is null
+  order by br.config_id, br.benchmark_type, br.isl, br.osl,
+           br.date desc, wr.run_started_at desc nulls last, br.workflow_run_id desc
+)
+select br.*
+from benchmark_results br
+join winners w
+  on  w.config_id      = br.config_id
+  and w.benchmark_type = br.benchmark_type
+  and w.isl is not distinct from br.isl
+  and w.osl is not distinct from br.osl
+  and w.winning_run_id = br.workflow_run_id
+where br.error is null;
+
+-- Unique key now includes benchmark_type (part of the line key). One run per line
+-- guarantees one row per concurrency, so this stays unique and keeps
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY working.
+create unique index latest_benchmarks_pk
+  on latest_benchmarks (config_id, conc, isl, osl, benchmark_type);
+create index latest_benchmarks_model_idx on latest_benchmarks (config_id);

--- a/packages/db/src/json-provider.line-single-run.test.ts
+++ b/packages/db/src/json-provider.line-single-run.test.ts
@@ -1,0 +1,181 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import type { getLatestBenchmarks as GetLatestBenchmarks } from './json-provider.js';
+
+/**
+ * A chart line is one config + sequence (config_id, benchmark_type, isl, osl) plotted across
+ * concurrencies, and it must come from a SINGLE workflow run. getLatestBenchmarks picks the
+ * newest run per line (date, then run_started_at, then workflow_run_id) and returns EVERY
+ * concurrency that one run measured — never stitching skipped concurrencies from an older run.
+ *
+ * These fixtures exercise the multi-concurrency cases the as-of test can't (it is single-conc):
+ * a partial re-sweep that must truncate the line, per-sequence line independence, and the
+ * same-day workflow_run_id tiebreak.
+ */
+
+const cfg = (id: number) => ({
+  id,
+  hardware: 'h100',
+  framework: 'vllm',
+  model: 'testm',
+  precision: 'fp8',
+  spec_method: 'none',
+  disagg: false,
+  is_multinode: false,
+  prefill_tp: 1,
+  prefill_ep: 1,
+  prefill_dp_attention: false,
+  prefill_num_workers: 1,
+  decode_tp: 1,
+  decode_ep: 1,
+  decode_dp_attention: false,
+  decode_num_workers: 1,
+  num_prefill_gpu: 0,
+  num_decode_gpu: 8,
+});
+
+const run = (id: number, githubId: number, startedAt: string | null, date: string) => ({
+  id,
+  github_run_id: githubId,
+  run_attempt: 1,
+  name: `run ${githubId}`,
+  status: 'completed',
+  conclusion: 'success',
+  head_sha: 'sha',
+  head_branch: 'main',
+  html_url: `https://github.com/x/runs/${githubId}`,
+  created_at: startedAt ?? `${date}T00:00:00Z`,
+  run_started_at: startedAt,
+  date,
+});
+
+let nextResultId = 1000;
+const result = (
+  runDbId: number,
+  configId: number,
+  date: string,
+  conc: number,
+  tpot: number,
+  isl = 1024,
+  osl = 1024,
+) => ({
+  id: nextResultId++,
+  workflow_run_id: runDbId,
+  config_id: configId,
+  benchmark_type: 'latency',
+  date,
+  isl,
+  osl,
+  conc,
+  image: null,
+  metrics: { median_tpot: tpot },
+  error: null,
+  server_log_id: null,
+});
+
+const OLD = '2026-06-10';
+const NEW = '2026-06-14';
+let getLatestBenchmarks: typeof GetLatestBenchmarks;
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'infx-line-'));
+  writeFileSync(join(dir, 'configs.json'), JSON.stringify([cfg(1), cfg(2)]));
+  writeFileSync(
+    join(dir, 'workflow_runs.json'),
+    JSON.stringify([
+      run(10, 100, `${OLD}T04:00:00Z`, OLD), // run A: older full sweep
+      run(11, 101, `${NEW}T05:00:00Z`, NEW), // run B: newer partial re-sweep
+      run(20, 200, `${NEW}T07:00:00Z`, NEW), // run E: same-day, lower run id
+      run(21, 201, `${NEW}T07:00:00Z`, NEW), // run F: same-day, SAME timestamp, higher run id
+    ]),
+  );
+  writeFileSync(
+    join(dir, 'benchmark_results.json'),
+    JSON.stringify([
+      // config 1, seq (1024,1024): run A full sweep, run B partial re-sweep.
+      result(10, 1, OLD, 1, 0.1),
+      result(10, 1, OLD, 8, 0.18),
+      result(10, 1, OLD, 64, 0.5),
+      result(11, 1, NEW, 1, 0.09),
+      result(11, 1, NEW, 8, 0.16),
+      // config 1, seq (8192,1024): only run A measured it (run B skipped this sequence).
+      result(10, 1, OLD, 1, 0.2, 8192, 1024),
+      result(10, 1, OLD, 8, 0.3, 8192, 1024),
+      // config 2, seq (1024,1024): two same-day runs with identical run_started_at.
+      result(20, 2, NEW, 1, 0.5),
+      result(20, 2, NEW, 8, 0.6),
+      result(20, 2, NEW, 64, 0.7),
+      result(21, 2, NEW, 1, 0.4),
+      result(21, 2, NEW, 8, 0.45),
+    ]),
+  );
+  process.env.DUMP_DIR = dir;
+  const mod = await import('./json-provider.js');
+  getLatestBenchmarks = mod.getLatestBenchmarks;
+});
+
+afterAll(() => {
+  delete process.env.DUMP_DIR;
+});
+
+/** Concurrencies + their run urls for one (config sequence) line, sorted by conc. */
+function line(
+  rows: { isl: number | null; osl: number | null; conc: number; run_url: string | null }[],
+  configRunUrlRe: RegExp,
+  isl: number,
+  osl: number,
+) {
+  return rows
+    .filter((r) => r.isl === isl && r.osl === osl && r.run_url?.match(configRunUrlRe))
+    .toSorted((a, b) => a.conc - b.conc)
+    .map((r) => ({ conc: r.conc, runUrl: r.run_url }));
+}
+
+describe('getLatestBenchmarks — one run per line', () => {
+  it('truncates a line to the newest run: a partial re-sweep hides the older run’s extra concs', () => {
+    const rows = getLatestBenchmarks('testm', NEW, false);
+    // config 1 / seq (1024,1024): run B (101) measured only conc 1 & 8. conc 64 from run A is gone.
+    const seq = line(rows, /runs\/(?:100|101)\//u, 1024, 1024);
+    expect(seq).toEqual([
+      { conc: 1, runUrl: 'https://github.com/x/runs/101/attempts/1' },
+      { conc: 8, runUrl: 'https://github.com/x/runs/101/attempts/1' },
+    ]);
+    expect(seq.some((p) => p.conc === 64)).toBe(false);
+  });
+
+  it('keeps a different sequence of the same config on its own winning run', () => {
+    const rows = getLatestBenchmarks('testm', NEW, false);
+    // seq (8192,1024) was only in run A; run B winning the other sequence must not erase it.
+    const seq = line(rows, /runs\/100\//u, 8192, 1024);
+    expect(seq).toEqual([
+      { conc: 1, runUrl: 'https://github.com/x/runs/100/attempts/1' },
+      { conc: 8, runUrl: 'https://github.com/x/runs/100/attempts/1' },
+    ]);
+  });
+
+  it('breaks a same-day, same-timestamp tie by workflow_run_id (higher id wins the whole line)', () => {
+    const rows = getLatestBenchmarks('testm', NEW, false);
+    // config 2: run E (200, id 20) and run F (201, id 21) share run_started_at; F wins by id.
+    const seq = line(rows, /runs\/(?:200|201)\//u, 1024, 1024);
+    expect(seq).toEqual([
+      { conc: 1, runUrl: 'https://github.com/x/runs/201/attempts/1' },
+      { conc: 8, runUrl: 'https://github.com/x/runs/201/attempts/1' },
+    ]);
+    // run E's extra conc 64 must not bleed into run F's line.
+    expect(seq.some((p) => p.conc === 64)).toBe(false);
+  });
+
+  it('as of the older run, shows that run’s full sweep (no truncation by a later run)', () => {
+    const rows = getLatestBenchmarks('testm', NEW, false, '100');
+    const seq = line(rows, /runs\/100\//u, 1024, 1024);
+    expect(seq).toEqual([
+      { conc: 1, runUrl: 'https://github.com/x/runs/100/attempts/1' },
+      { conc: 8, runUrl: 'https://github.com/x/runs/100/attempts/1' },
+      { conc: 64, runUrl: 'https://github.com/x/runs/100/attempts/1' },
+    ]);
+  });
+});

--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -330,12 +330,11 @@ const STRIP_HISTORY_KEYS = new Set([
 ]);
 
 /**
- * Comparator for DISTINCT ON (config, conc, isl, osl) selection: latest calendar
- * day first, then — for sweeps on the same day — the latest workflow run first by
- * `run_started_at` (NULLS LAST). Mirrors the SQL date-filtered query and the
- * `latest_benchmarks` view (migration 003): a calendar day alone ties two same-day
- * sweeps, so without this an older run's points can shadow a same-day re-sweep.
- * `run_started_at` is an ISO-8601 string, so localeCompare orders it chronologically.
+ * Run-recency comparator used to pick the newest run per line: latest calendar day first,
+ * then — for sweeps on the same day — the latest workflow run first by `run_started_at`
+ * (NULLS LAST). Mirrors the `br.date DESC, wr.run_started_at DESC NULLS LAST` portion of the
+ * SQL ORDER BY; callers apply a `workflow_run_id` DESC final tiebreak on top so exactly one
+ * run wins. `run_started_at` is an ISO-8601 string, so localeCompare orders it chronologically.
  * Exported so the same-day tiebreak is unit-tested in parity with the SQL.
  */
 export function compareBenchmarkRecency(
@@ -351,6 +350,10 @@ export function compareBenchmarkRecency(
   if (bStarted === null) return -1;
   return bStarted.localeCompare(aStarted);
 }
+
+/** Chart-line identity: one config + sequence. All concurrencies of a line come from one run. */
+const lineKey = (br: RawBenchmarkResult): string =>
+  `${br.config_id}:${br.benchmark_type}:${br.isl}:${br.osl}`;
 
 export function getLatestBenchmarks(
   modelKey: string | string[],
@@ -387,27 +390,32 @@ export function getLatestBenchmarks(
     return true;
   });
 
-  // DISTINCT ON (config_id, conc, isl, osl) — keep the one with the latest date,
-  // tiebreaking same-day runs by run_started_at so the latest sweep wins.
-  const seen = new Map<string, RawBenchmarkResult>();
-  candidates.sort((a, b) =>
-    compareBenchmarkRecency(
+  // Single run per LINE (config_id, benchmark_type, isl, osl): pick the newest run that
+  // produced data for the line, then keep EVERY concurrency that one run measured. Sort by
+  // recency (date, then run_started_at) with a final workflow_run_id DESC tiebreak so exactly
+  // one run wins even when run_started_at is equal/null — matching the SQL ORDER BY.
+  candidates.sort((a, b) => {
+    const recency = compareBenchmarkRecency(
       toDateString(a.date),
       toDateString(b.date),
       s.latestRunsById.get(a.workflow_run_id)?.run_started_at ?? null,
       s.latestRunsById.get(b.workflow_run_id)?.run_started_at ?? null,
-    ),
-  );
+    );
+    return recency === 0 ? b.workflow_run_id - a.workflow_run_id : recency;
+  });
+  const winningRun = new Map<string, number>();
   for (const br of candidates) {
-    const key = `${br.config_id}:${br.conc}:${br.isl}:${br.osl}`;
-    if (!seen.has(key)) seen.set(key, br);
+    const key = lineKey(br);
+    if (!winningRun.has(key)) winningRun.set(key, br.workflow_run_id);
   }
 
-  return [...seen.values()].map((br) => {
-    const c = s.configs.get(br.config_id)!;
-    const wr = s.latestRunsById.get(br.workflow_run_id)!;
-    return toBenchmarkRow(br, c, wr);
-  });
+  return candidates
+    .filter((br) => winningRun.get(lineKey(br)) === br.workflow_run_id)
+    .map((br) => {
+      const c = s.configs.get(br.config_id)!;
+      const wr = s.latestRunsById.get(br.workflow_run_id)!;
+      return toBenchmarkRow(br, c, wr);
+    });
 }
 
 /** In-memory mirror of {@link import('./queries/benchmarks.js').getBenchmarksForRun}. */

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -47,9 +47,14 @@ export interface BenchmarkRow {
 /**
  * Fetch the latest benchmark results for one or more model DB keys across ALL sequences,
  * up to a given date. Multiple keys support point-release grouping — e.g. passing
- * `['glm5', 'glm5.1']` unions both buckets under the one display. Returns the most recent
- * result per (config, concurrency, isl, osl) — so every GPU/framework + sequence combo
- * that has been benchmarked appears, with the newest data winning.
+ * `['glm5', 'glm5.1']` unions both buckets under the one display.
+ *
+ * Selection unit is the LINE, not the point: for each line
+ * `(config_id, benchmark_type, isl, osl)` we pick the single newest workflow run that
+ * produced data for it (newest date, then latest sweep, then highest run id) and return
+ * EVERY concurrency that one run measured — and nothing from any other run. A partial
+ * re-sweep therefore truncates the line to its own concurrencies rather than stitching the
+ * skipped ones from an older run. This guarantees a line never mixes runs/dates.
  *
  * The frontend filters by sequence client-side. This eliminates API round-trips when
  * switching sequences — the data is already cached by React Query.
@@ -70,13 +75,8 @@ export async function getLatestBenchmarks(
 ): Promise<BenchmarkRow[]> {
   const modelKeys = Array.isArray(modelKey) ? modelKey : [modelKey];
   if (date) {
-    // Date-filtered: use base table with DISTINCT ON (the view only has the absolute latest)
-    // exact=true: only return data from this exact date (for GPU comparison)
-    // exact=false (default): return latest data as of this date (for main chart)
-    // Same-day tiebreak by wr.run_started_at (latest sweep wins), mirroring the
-    // latest_benchmarks view (migration 003). br.date is a calendar day, so two
-    // sweeps on the same day tie on date alone and Postgres would otherwise pick
-    // an arbitrary one — leaving an older run's points shadowing a same-day re-sweep.
+    // Date-filtered: use the base table (the view only has the absolute latest).
+    // exact=true: only this exact date (GPU comparison); exact=false (default): as of this date.
     const dateFilter = exact ? sql`br.date = ${date}::date` : sql`br.date <= ${date}::date`;
     // "As of run" filter (main chart only): keep results whose run started no later
     // than the selected run. run_started_at is an absolute timestamp, so this also
@@ -93,8 +93,28 @@ export async function getLatestBenchmarks(
             )
           )`
         : sql``;
+    // winners: the single newest run per LINE (config_id, benchmark_type, isl, osl) under the
+    // date/run cutoff. br.date is a calendar day, so two same-day sweeps tie on date — break
+    // by wr.run_started_at (latest sweep wins), then br.workflow_run_id so exactly one run wins
+    // even when run_started_at is equal/null. The outer join then pulls EVERY concurrency that
+    // winning run measured for the line, so the line is built from one run only (no carry-forward
+    // of concurrencies a partial re-sweep skipped).
     const rows = await sql`
-      SELECT DISTINCT ON (br.config_id, br.conc, br.isl, br.osl)
+      WITH winners AS (
+        SELECT DISTINCT ON (br.config_id, br.benchmark_type, br.isl, br.osl)
+          br.config_id, br.benchmark_type, br.isl, br.osl,
+          br.workflow_run_id AS winning_run_id
+        FROM benchmark_results br
+        JOIN configs c ON c.id = br.config_id
+        JOIN latest_workflow_runs wr ON wr.id = br.workflow_run_id
+        WHERE c.model = ANY(${modelKeys})
+          AND br.error IS NULL
+          AND ${dateFilter}
+          ${runFilter}
+        ORDER BY br.config_id, br.benchmark_type, br.isl, br.osl,
+                 br.date DESC, wr.run_started_at DESC NULLS LAST, br.workflow_run_id DESC
+      )
+      SELECT
         c.hardware,
         c.framework,
         c.model,
@@ -123,12 +143,14 @@ export async function getLatestBenchmarks(
       FROM benchmark_results br
       JOIN configs c ON c.id = br.config_id
       JOIN latest_workflow_runs wr ON wr.id = br.workflow_run_id
-      WHERE c.model = ANY(${modelKeys})
-        AND br.error IS NULL
-        AND ${dateFilter}
-        ${runFilter}
-      ORDER BY br.config_id, br.conc, br.isl, br.osl,
-               br.date DESC, wr.run_started_at DESC NULLS LAST
+      JOIN winners w
+        ON w.config_id = br.config_id
+        AND w.benchmark_type = br.benchmark_type
+        AND w.isl IS NOT DISTINCT FROM br.isl
+        AND w.osl IS NOT DISTINCT FROM br.osl
+        AND w.winning_run_id = br.workflow_run_id
+      WHERE br.error IS NULL
+      ORDER BY br.config_id, br.conc, br.isl, br.osl
     `;
     return rows as unknown as BenchmarkRow[];
   }


### PR DESCRIPTION
> [!NOTE]
> **Medium Risk**
> Changes core benchmark read paths and chart semantics (lines may lose concurrencies after partial re-sweeps); matview behavior lags until migration 007 is applied in prod.
> 
> **Overview**
> **Fixes “frankenlines”** where one chart line mixed concurrencies from different workflow runs when a newer partial re-sweep skipped some concurrencies.
> 
> **`getLatestBenchmarks`** now treats a line as `(config_id, benchmark_type, isl, osl)`: pick the newest run (`date`, then `run_started_at`, then `workflow_run_id`) and return **only** that run’s concurrencies—partial re-sweeps shorten the line instead of backfilling from older runs. The date-filtered SQL path uses a **winners CTE + join** instead of `DISTINCT ON (…, conc, …)`; **`json-provider`** mirrors the same logic for dump/test mode.
> 
> **Migration 007** rebuilds the **`latest_benchmarks`** matview with the same rule and adds **`benchmark_type`** to the unique index. Until prod runs this migration, the no-date “latest” path can still serve the old matview while the date path is already fixed.
> 
> New unit tests cover truncation, per-sequence independence, same-day tiebreaks, and as-of-run behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391102d6691b19f4fd1df8157caded83b070e739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->