### PR TITLE
[codex] Move gpt-oss to maintenance mode

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -15,7 +15,13 @@ function ModelSelectorHarness() {
       <ModelSelector
         value={value}
         onChange={setValue}
-        availableModels={[Model.DeepSeek_R1, Model.Qwen3_5, Model.MiniMax_M2_5, Model.Llama3_3_70B]}
+        availableModels={[
+          Model.DeepSeek_R1,
+          Model.GptOss,
+          Model.Qwen3_5,
+          Model.MiniMax_M2_5,
+          Model.Llama3_3_70B,
+        ]}
         data-testid="model-selector"
       />
     </TooltipProvider>
@@ -72,6 +78,7 @@ describe('Chart Selectors', () => {
 
       cy.contains('Maintenance Mode').should('be.visible');
       cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').should('be.visible');
+      cy.contains('[role="option"]', 'gpt-oss 120B').should('be.visible');
       cy.contains('Deprecated').should('be.visible');
       cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').should('be.visible');
     });

--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -49,6 +49,7 @@ describe('Dropdown one-click switching', () => {
 
     cy.contains('Maintenance Mode').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').scrollIntoView().should('be.visible');
+    cy.contains('[role="option"]', 'gpt-oss 120B').scrollIntoView().should('be.visible');
     cy.contains('Deprecated').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').scrollIntoView().should('be.visible');
   });

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -169,8 +169,9 @@ describe('isModelDeprecated', () => {
 // isModelMaintenance
 // ===========================================================================
 describe('isModelMaintenance', () => {
-  it('returns true for the DeepSeek R1 maintenance-mode family', () => {
+  it('returns true for maintenance-mode models', () => {
     expect(isModelMaintenance(Model.DeepSeek_R1)).toBe(true);
+    expect(isModelMaintenance(Model.GptOss)).toBe(true);
   });
 
   it('keeps deprecated and default models out of maintenance mode', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -94,7 +94,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
-  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'default' },
+  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'maintenance' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
     // Superseded by MiniMax M3, so it's deprecated (no longer actively benchmarked).


### PR DESCRIPTION
## Summary
- Move `gpt-oss-120b` from the default model group into Maintenance Mode.
- Keep DeepSeek R1 in Maintenance Mode and the existing deprecated models unchanged.
- Add unit, component, and browser regression coverage for the new grouping.

## Why
`gpt-oss-120b` should be surfaced as a lower-priority model rather than alongside actively maintained default models.

## User impact
The model remains selectable, but now appears under the Maintenance Mode heading and uses the existing maintenance-status tooltip.

## Testing
- `pnpm test:unit` (114 files, 2,163 tests)
- `pnpm --filter @semianalysisai/inferencex-app exec cypress run --component --spec cypress/component/chart-selectors.cy.tsx` (7 passed)
- `CYPRESS_BASE_URL=http://127.0.0.1:3000 pnpm --filter @semianalysisai/inferencex-app exec cypress run --spec cypress/e2e/dropdown-switching.cy.ts` (5 passed)
- `pnpm typecheck`
- `pnpm lint`
- scoped `oxfmt --check` for changed files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata category change in data-mappings with no auth, API, or data-pipeline impact; behavior is limited to dropdown grouping and labels.
> 
> **Overview**
> **gpt-oss 120B** is reclassified from the default model group to **Maintenance Mode** in `MODEL_CONFIG`, so it groups with DeepSeek R1 under the Maintenance heading and the existing maintenance tooltip instead of active default models.
> 
> Unit coverage for `isModelMaintenance` now expects **GptOss** to be maintenance. Component and e2e model-selector tests include **gpt-oss 120B** in the maintenance section alongside DeepSeek R1, separate from deprecated models.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8d1922caf290616bbfd9b3a16688c4e321192c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->