### PR TITLE
Fix landing accessibility and layout stability

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -1,0 +1,65 @@
+type LayoutShiftEntry = PerformanceEntry & {
+  hadRecentInput: boolean;
+  value: number;
+};
+
+type LayoutShiftWindow = Cypress.AUTWindow & {
+  __landingCls?: {
+    disconnect: () => void;
+    score: () => number;
+  };
+};
+
+function observeLayoutShifts(win: Cypress.AUTWindow) {
+  let clsScore = 0;
+  const observer = new win.PerformanceObserver((list) => {
+    for (const entry of list.getEntries() as LayoutShiftEntry[]) {
+      if (!entry.hadRecentInput) clsScore += entry.value;
+    }
+  });
+  observer.observe({ type: 'layout-shift', buffered: true });
+
+  (win as LayoutShiftWindow).__landingCls = {
+    disconnect: () => observer.disconnect(),
+    score: () => clsScore,
+  };
+}
+
+describe('Landing page performance', () => {
+  it('does not shift when client JavaScript hydrates after first paint', () => {
+    cy.viewport(412, 823);
+    cy.request('/').its('body').should('contain', 'See more supporters');
+
+    cy.intercept('GET', '**/_next/static/**/*.js', (request) => {
+      request.continue((response) => {
+        response.setDelay(1500);
+      });
+    });
+
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.removeItem('inferencex-minimax-m3-modal-dismissed');
+        win.localStorage.removeItem('inferencex-minimax-m3-banner-dismissed');
+        observeLayoutShifts(win);
+      },
+    });
+
+    cy.get('[data-testid="launch-banner"]').should('be.visible');
+    cy.get('[data-testid="intro-section"]').should('contain.text', 'See more supporters');
+
+    cy.window()
+      .then(
+        (win) =>
+          new Cypress.Promise<number>((resolve) => {
+            win.requestAnimationFrame(() => {
+              win.requestAnimationFrame(() => {
+                const measurement = (win as LayoutShiftWindow).__landingCls;
+                measurement?.disconnect();
+                resolve(measurement?.score() ?? Number.POSITIVE_INFINITY);
+              });
+            });
+          }),
+      )
+      .should('be.lessThan', 0.1);
+  });
+});

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -48,7 +48,9 @@ describe('Landing nudges — modals', () => {
     });
     // Banner (inline) and modal (overlay) occupy independent slots
     cy.get('[data-testid="launch-banner"]').should('be.visible');
-    cy.get('[data-testid="launch-modal"]').should('be.visible');
+    cy.get('[data-testid="launch-modal"]')
+      .should('be.visible')
+      .and('match', 'div[role="dialog"][aria-modal="false"]');
     // Only one overlay at a time — star modal should not appear
     cy.get('[data-testid="github-star-modal"]').should('not.exist');
   });

--- a/packages/app/src/components/nudge-engine.tsx
+++ b/packages/app/src/components/nudge-engine.tsx
@@ -358,7 +358,7 @@ function ModalRenderer({
   const centered = content.centered;
 
   const dialog = (
-    <aside
+    <div
       data-testid={content.testId}
       role="dialog"
       aria-modal={centered ? 'true' : 'false'}
@@ -417,7 +417,7 @@ function ModalRenderer({
           </div>
         </div>
       )}
-    </aside>
+    </div>
   );
 
   if (centered) {

--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { track } from '@/lib/analytics';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
@@ -30,15 +30,6 @@ export interface QuoteCarouselProps {
   intervalMs?: number;
 }
 
-function shuffleArray<T>(arr: T[]): T[] {
-  const shuffled = [...arr];
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-  }
-  return shuffled;
-}
-
 interface CompanyEntry {
   org: string;
   quote: CarouselQuote;
@@ -53,17 +44,17 @@ function buildCompanyQuotes(quotes: CarouselQuote[], order?: string[]): CompanyE
   }
   const entries = [...byCompany.entries()].map(([org, pool]) => ({
     org,
-    quote: pool[Math.floor(Math.random() * pool.length)],
+    quote: pool[0],
   }));
   if (order?.length) {
     const orderSet = new Set(order);
     const pinned = order
       .map((c) => entries.find((e) => e.org === c))
       .filter(Boolean) as CompanyEntry[];
-    const rest = shuffleArray(entries.filter((e) => !orderSet.has(e.org)));
+    const rest = entries.filter((e) => !orderSet.has(e.org));
     return [...pinned, ...rest];
   }
-  return shuffleArray(entries);
+  return entries;
 }
 
 function QuoteBlock({ quote }: { quote: CarouselQuote }) {
@@ -104,17 +95,13 @@ export function QuoteCarousel({
 }: QuoteCarouselProps) {
   const { order, labels = {} } = overrides;
 
-  const [entries, setEntries] = useState<CompanyEntry[]>([]);
+  // Keep the first render deterministic so SSR reserves the carousel's full height before hydration.
+  const entries = useMemo(() => buildCompanyQuotes(quotes, order), [quotes, order]);
   const [activeIndex, setActiveIndex] = useState(0);
   const [fading, setFading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const fadeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hovering = useRef(false);
-
-  // Build shuffled org order on mount (client only)
-  useEffect(() => {
-    setEntries(buildCompanyQuotes(quotes, order));
-  }, [quotes, order]);
 
   const advance = useCallback(() => {
     if (hovering.current) return;
@@ -155,8 +142,6 @@ export function QuoteCarousel({
     },
     [advance, intervalMs, entries, activeIndex],
   );
-
-  if (entries.length === 0) return null;
 
   return (
     <div


### PR DESCRIPTION
## Summary

- use a compatible `div` host for the launch popup's `role="dialog"`
- render the landing supporter carousel deterministically during SSR so its height is reserved before hydration
- add regression coverage for dialog semantics and mobile hydration CLS

## Root cause

The launch popup applied `role="dialog"` to an `aside`, which is not an allowed role for that element. Separately, the supporter carousel returned no content until a mount effect built its randomized entries. On slower clients, hydration inserted the carousel after first paint and shifted the rest of the landing page.

## Impact

The accessibility tree no longer contains the incompatible dialog role. The landing page now emits the carousel in server HTML and stays below the `0.1` good CLS threshold when JavaScript hydration is delayed at a 412 x 823 mobile viewport.

Measured CLS decreased from `0.2268` in the regression reproduction to `0.0941` in Lighthouse.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- `TZ=UTC NODE_OPTIONS='--no-experimental-webstorage' pnpm test:unit` (2,460 tests)
- `cypress run --spec cypress/e2e/nudge-system.cy.ts --browser chrome` (18 tests)
- `cypress run --spec cypress/e2e/landing-performance.cy.ts --browser chrome`
- Lighthouse accessibility audit: no incompatible ARIA role

Production build was not completed locally because `DATABASE_READONLY_URL` is unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI, a11y markup, and deterministic carousel ordering on landing; no auth, data, or API changes.
> 
> **Overview**
> Fixes **landing accessibility** by rendering launch nudges’ `role="dialog"` on a **`div`** instead of an incompatible **`aside`**, and tightens Cypress to expect `div[role="dialog"][aria-modal="false"]` for the launch modal.
> 
> Reduces **mobile layout shift on hydration** by making the supporter **quote carousel** deterministic on first paint: removes client-only shuffle/mount effect, builds entries with **`useMemo`** during SSR, and always renders the carousel (no empty initial render). Adds **`landing-performance.cy.ts`** to delay `_next` JS, measure CLS via `PerformanceObserver`, and assert score **&lt; 0.1** at a 412×823 viewport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524c5cdeb416504a12a710ef4167428eb6ff15b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->