### PR TITLE
Fix remaining landing CLS and mobile LCP

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -25,10 +25,30 @@ function observeLayoutShifts(win: Cypress.AUTWindow) {
   };
 }
 
+function expectLowCls() {
+  cy.window()
+    .then(
+      (win) =>
+        new Cypress.Promise<number>((resolve) => {
+          win.requestAnimationFrame(() => {
+            win.requestAnimationFrame(() => {
+              const measurement = (win as LayoutShiftWindow).__landingCls;
+              measurement?.disconnect();
+              resolve(measurement?.score() ?? Number.POSITIVE_INFINITY);
+            });
+          });
+        }),
+    )
+    .should('be.lessThan', 0.01);
+}
+
 describe('Landing page performance', () => {
   it('does not shift when client JavaScript hydrates after first paint', () => {
     cy.viewport(412, 823);
-    cy.request('/').its('body').should('contain', 'See more supporters');
+    cy.request('/')
+      .its('body')
+      .should('contain', 'See more supporters')
+      .and('contain', 'data-testid="launch-banner"');
 
     cy.intercept('GET', '**/_next/static/**/*.js', (request) => {
       request.continue((response) => {
@@ -46,20 +66,38 @@ describe('Landing page performance', () => {
 
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.get('[data-testid="intro-section"]').should('contain.text', 'See more supporters');
+    cy.get('[data-testid="quote-carousel-more-row"]')
+      .should('have.class', 'justify-end')
+      .find('a')
+      .should('have.text', 'See more supporters →');
+    expectLowCls();
+  });
 
-    cy.window()
-      .then(
-        (win) =>
-          new Cypress.Promise<number>((resolve) => {
-            win.requestAnimationFrame(() => {
-              win.requestAnimationFrame(() => {
-                const measurement = (win as LayoutShiftWindow).__landingCls;
-                measurement?.disconnect();
-                resolve(measurement?.score() ?? Number.POSITIVE_INFINITY);
-              });
-            });
-          }),
-      )
-      .should('be.lessThan', 0.1);
+  it('hides a dismissed server-rendered banner before paint without shifting content', () => {
+    cy.viewport(412, 823);
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-minimax-m3-banner-dismissed', '1');
+        observeLayoutShifts(win);
+      },
+    });
+
+    cy.get('html').should('have.attr', 'data-landing-banner-dismissed');
+    cy.get('[data-testid="launch-banner"]').should('not.exist');
+    cy.get('[data-testid="intro-section"]').should('contain.text', 'See more supporters');
+    expectLowCls();
+  });
+
+  it('does not load the decorative circuit mask on mobile', () => {
+    cy.viewport(412, 823);
+    cy.visit('/');
+
+    cy.get('.circuit-bg').should('have.css', 'display', 'none');
+    cy.window().then((win) => {
+      const loadedPattern = win.performance
+        .getEntriesByType('resource')
+        .some((entry) => entry.name.includes('/brand/left-pattern-full.svg'));
+      expect(loadedPattern).to.eq(false);
+    });
   });
 });

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -28,6 +28,10 @@ import { fetchStarCount } from '@/lib/github-stars.server';
 import { QueryProvider } from '@/providers/query-provider';
 import { PostHogProvider, PostHogPageView } from '@/providers/posthog-provider';
 import { VisitTracker } from '@/providers/visit-tracker';
+import {
+  LANDING_BANNER_DISMISSED_ATTRIBUTE,
+  LANDING_BANNER_STORAGE_KEY,
+} from '@/lib/nudges/landing-banner';
 
 const dm_sans = DM_Sans({
   subsets: ['latin'],
@@ -165,6 +169,13 @@ const jsonLd = {
   ],
 };
 
+const landingBannerPrepaintScript = `try{if(localStorage.getItem(${JSON.stringify(
+  LANDING_BANNER_STORAGE_KEY,
+)})){document.documentElement.setAttribute(${JSON.stringify(
+  LANDING_BANNER_DISMISSED_ATTRIBUTE,
+)},'')}}catch{}`;
+const landingBannerPrepaintStyle = `html[${LANDING_BANNER_DISMISSED_ATTRIBUTE}] [data-initial-banner]{display:none}`;
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -174,11 +185,26 @@ export default async function RootLayout({
   return (
     <html lang="en" className={monocraft.variable} suppressHydrationWarning>
       <head>
-        <link rel="preload" as="image" href="/brand/left-pattern-full.svg" fetchPriority="high" />
+        <link
+          rel="preload"
+          as="image"
+          href="/brand/left-pattern-full.svg"
+          fetchPriority="high"
+          media="(min-width: 640px)"
+        />
         <link rel="preconnect" href="https://us-assets.i.posthog.com" />
         <link rel="dns-prefetch" href="https://us-assets.i.posthog.com" />
       </head>
       <body className={`${dm_sans.variable} antialiased relative min-h-screen flex flex-col`}>
+        <style
+          id="landing-banner-prepaint-style"
+          dangerouslySetInnerHTML={{ __html: landingBannerPrepaintStyle }}
+        />
+        <script
+          id="landing-banner-prepaint"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: landingBannerPrepaintScript }}
+        />
         <CircuitBackground />
         <MinecraftBackgroundLazy />
         <MinecraftDecorations />

--- a/packages/app/src/components/circuit-background.tsx
+++ b/packages/app/src/components/circuit-background.tsx
@@ -1,10 +1,10 @@
 import { cn } from '@/lib/utils';
 
 const PATTERN_CLASSES = cn(
-  'pointer-events-none fixed -z-10 block',
+  'pointer-events-none fixed -z-10 hidden sm:block',
   'bg-muted/50 dark:bg-muted',
-  "mask-[url('/brand/left-pattern-full.svg')]",
-  'mask-no-repeat mask-position-[top_right] mask-size-[100%]',
+  "sm:mask-[url('/brand/left-pattern-full.svg')]",
+  'sm:mask-no-repeat sm:mask-position-[top_right] sm:mask-size-[100%]',
   'w-full sm:w-3/4 md:w-1/2 lg:w-1/3 h-screen',
 );
 

--- a/packages/app/src/components/nudge-engine.tsx
+++ b/packages/app/src/components/nudge-engine.tsx
@@ -14,6 +14,7 @@ import {
 import { dismissesOnAction } from '@/lib/nudges/policy';
 import { NUDGE_REGISTRY } from '@/lib/nudges/registry';
 import type { NudgeDefinition, NudgeTrigger } from '@/lib/nudges/types';
+import { LANDING_BANNER_DISMISSED_ATTRIBUTE } from '@/lib/nudges/landing-banner';
 import { BottomToast } from '@/components/ui/bottom-toast';
 import { Button } from '@/components/ui/button';
 
@@ -53,7 +54,17 @@ interface NudgeEngineProps {
 export function NudgeEngine({ scope }: NudgeEngineProps) {
   const scopeNudges = useMemo(() => NUDGE_REGISTRY.filter((n) => n.scope === scope), [scope]);
 
-  const [activeBannerId, setActiveBannerId] = useState<string | null>(null);
+  const [activeBannerId, setActiveBannerId] = useState<string | null>(() => {
+    const initialBanner = scopeNudges
+      .filter((nudge) => {
+        if (nudge.type !== 'banner' || !nudge.renderOnInitialLoad) return false;
+        if (!isWithinSchedule(nudge.schedule)) return false;
+        const triggers = Array.isArray(nudge.trigger) ? nudge.trigger : [nudge.trigger];
+        return triggers.some((trigger) => trigger.type === 'immediate');
+      })
+      .toSorted((a, b) => b.priority - a.priority)[0];
+    return initialBanner?.id ?? null;
+  });
   const [activeOverlayId, setActiveOverlayId] = useState<string | null>(null);
   const bannerShownRef = useRef(false);
   const overlayShownRef = useRef(false);
@@ -86,6 +97,9 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
     if (!activeBanner) return;
     trackNudgeEvent(activeBanner, 'dismissed');
     markDismissed(activeBanner.storageKey, activeBanner.dismissal);
+    if (activeBanner.renderOnInitialLoad) {
+      document.documentElement.setAttribute(LANDING_BANNER_DISMISSED_ATTRIBUTE, '');
+    }
     sessionDismissedRef.current.add(activeBanner.id);
     setActiveBannerId(null);
     bannerShownRef.current = false;
@@ -109,6 +123,9 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
     // `bannerShownRef`/`activeBannerId` set — the slot is still occupied.
     if (!dismissesOnAction(activeBanner)) return;
     markDismissed(activeBanner.storageKey, activeBanner.dismissal);
+    if (activeBanner.renderOnInitialLoad) {
+      document.documentElement.setAttribute(LANDING_BANNER_DISMISSED_ATTRIBUTE, '');
+    }
     sessionDismissedRef.current.add(activeBanner.id);
     setActiveBannerId(null);
     bannerShownRef.current = false;
@@ -137,6 +154,12 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
   // -------------------------------------------------------------------------
 
   useEffect(() => {
+    if (activeBanner && !isEligible(activeBanner)) {
+      setActiveBannerId(null);
+      bannerShownRef.current = false;
+      return;
+    }
+
     const cleanups: (() => void)[] = [];
     const sorted = [...scopeNudges].toSorted((a, b) => b.priority - a.priority);
 
@@ -462,7 +485,10 @@ function BannerRenderer({
   };
 
   return (
-    <section className="container mx-auto px-4 lg:px-8 mb-6 lg:mb-4">
+    <section
+      className="container mx-auto px-4 lg:px-8 mb-6 lg:mb-4"
+      data-initial-banner={def.renderOnInitialLoad ? '' : undefined}
+    >
       <a
         href={content.href ?? '#'}
         onClick={handleClick}

--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -169,40 +169,37 @@ export function QuoteCarousel({
         ))}
       </div>
 
-      {/* Fading quote stack (left) + constant link pinned to the footer baseline (right).
-          items-end keeps every quote's footer on the same bottom line so the link,
-          which lives outside the fading stack, stays aligned with it. */}
-      <div className="flex items-end gap-4">
-        {/* All quotes stacked in same grid cell — tallest sets height */}
-        <div className="grid items-end min-w-0 flex-1">
-          {entries.map((e, i) => {
-            const isActive = i === activeIndex;
-            return (
-              <div
-                key={e.org}
-                className={`col-start-1 row-start-1 ${
-                  isActive
-                    ? `transition-opacity duration-300 ease-in-out ${fading ? 'opacity-0' : 'opacity-100'}`
-                    : 'opacity-0 invisible pointer-events-none'
-                }`}
-                aria-hidden={!isActive}
-              >
-                <QuoteBlock quote={e.quote} />
-              </div>
-            );
-          })}
-        </div>
+      {/* All quotes stacked in same grid cell — tallest sets height */}
+      <div className="grid items-center">
+        {entries.map((e, i) => {
+          const isActive = i === activeIndex;
+          return (
+            <div
+              key={e.org}
+              className={`col-start-1 row-start-1 ${
+                isActive
+                  ? `transition-opacity duration-300 ease-in-out ${fading ? 'opacity-0' : 'opacity-100'}`
+                  : 'opacity-0 invisible pointer-events-none'
+              }`}
+              aria-hidden={!isActive}
+            >
+              <QuoteBlock quote={e.quote} />
+            </div>
+          );
+        })}
+      </div>
 
-        {moreHref && (
+      {moreHref && (
+        <div className="flex justify-end" data-testid="quote-carousel-more-row">
           <Link
             href={moreHref}
-            className="shrink-0 whitespace-nowrap text-xs font-bold text-brand hover:underline"
+            className="text-xs font-bold text-brand hover:underline"
             onClick={() => track('quote_carousel_see_more_clicked')}
           >
             See more supporters &rarr;
           </Link>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app/src/lib/nudges/landing-banner.ts
+++ b/packages/app/src/lib/nudges/landing-banner.ts
@@ -1,0 +1,2 @@
+export const LANDING_BANNER_STORAGE_KEY = 'inferencex-minimax-m3-banner-dismissed';
+export const LANDING_BANNER_DISMISSED_ATTRIBUTE = 'data-landing-banner-dismissed';

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -79,4 +79,18 @@ describe('NUDGE_REGISTRY integrity', () => {
       expect(nudge.content.testId).toBeTruthy();
     }
   });
+
+  it('only server-renders deterministic immediate banners', () => {
+    const initialNudges = NUDGE_REGISTRY.filter((nudge) => nudge.renderOnInitialLoad);
+
+    expect(initialNudges).toHaveLength(1);
+    for (const nudge of initialNudges) {
+      const triggers = Array.isArray(nudge.trigger) ? nudge.trigger : [nudge.trigger];
+      expect(nudge.type).toBe('banner');
+      expect(triggers.some((trigger) => trigger.type === 'immediate')).toBe(true);
+      expect(nudge.conditions).toBeUndefined();
+      expect(nudge.permanentSuppressKey).toBeUndefined();
+      expect(nudge.schedule).toBeUndefined();
+    }
+  });
 });

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -12,6 +12,7 @@ import dynamic from 'next/dynamic';
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
 
 import { FEEDBACK_SUBMITTED_EVENT } from '@/components/feedback-modal';
+import { LANDING_BANNER_STORAGE_KEY } from '@/lib/nudges/landing-banner';
 
 // Keep the ~210-line FeedbackForm out of the landing/dashboard initial JS.
 const FeedbackForm = dynamic(
@@ -298,9 +299,10 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
     type: 'banner',
     trigger: { type: 'immediate' },
     dismissal: { type: 'permanent' },
-    storageKey: 'inferencex-minimax-m3-banner-dismissed',
+    storageKey: LANDING_BANNER_STORAGE_KEY,
     priority: 60,
     scope: 'landing',
+    renderOnInitialLoad: true,
     content: {
       icon: Sparkles,
       iconClassName: 'text-brand',

--- a/packages/app/src/lib/nudges/types.ts
+++ b/packages/app/src/lib/nudges/types.ts
@@ -123,6 +123,11 @@ export interface NudgeDefinition {
   priority: number;
   /** Which NudgeEngine instance manages this nudge. */
   scope: 'dashboard' | 'landing' | 'evaluation';
+  /**
+   * Render an immediate banner in the server response so hydration cannot
+   * insert it above existing content and cause a layout shift.
+   */
+  renderOnInitialLoad?: boolean;
 
   // Scheduling (time-bound campaigns)
   schedule?: {


### PR DESCRIPTION
## Summary

- Server-render the immediate launch banner and hide dismissed state before first paint, preventing hydration from moving landing content.
- Keep the decorative circuit SVG out of the mobile critical path.
- Restore the supporter-link layout from before #489 while retaining the deterministic server-rendered carousel behavior from #495.
- Add browser regressions for fresh and dismissed banner CLS, the restored quote layout, and mobile resource loading.

## Root cause

The launch banner was inserted only after hydration, which shifted the page on fresh visits. On mobile, the hidden decorative circuit mask was still preloaded and requested, and Lighthouse selected it as the LCP element. PR #489 also moved the supporter link onto the attribution line; this selectively restores the prior layout without bringing back the client-only randomized carousel that caused layout instability.

## Impact

Saved PageSpeed reports showed desktop lab CLS of 0.216 and mobile performance of 82 with a 4.4 s LCP. Directional local Lighthouse runs after the fix report:

- Mobile: performance 93, CLS 0, LCP 2.3 s, and no `left-pattern-full.svg` request.
- Desktop: performance 100, CLS 0, LCP 0.7 s.

CrUX field data is trailing data and will take time to reflect a deployment.

## Validation

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- Focused Vitest coverage: 15 passed
- `landing-performance.cy.ts`: 3 passed
- `nudge-system.cy.ts`: 18 passed
- Cypress component suite: 152 passed
- Local mobile and desktop Lighthouse runs

DB-backed Cypress integration tests require `DATABASE_READONLY_URL`, which is not available locally. The full Vitest command also encounters two existing Node 26 storage-spy failures in `chunk-load-recovery.test.ts`; those files are unchanged from `master`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to landing layout, performance, and nudge presentation; no auth or data-path changes, with regression coverage in Cypress and Vitest.
> 
> **Overview**
> Addresses landing **CLS** and **mobile LCP** by keeping the launch banner in the first paint and keeping decorative assets off the mobile critical path.
> 
> The immediate MiniMax launch banner is **server-rendered on first paint** via `renderOnInitialLoad` and matching initial `NudgeEngine` state, with a root **pre-paint script and inline CSS** that reads dismissal from `localStorage` and hides `[data-initial-banner]` before paint. Dismissal also sets `data-landing-banner-dismissed` on `<html>` so later visits stay stable.
> 
> **Mobile** no longer loads the circuit mask: `CircuitBackground` is `hidden` below `sm`, mask classes are `sm:`-scoped, and the SVG **preload** uses `media="(min-width: 640px)"`.
> 
> The quote carousel **“See more supporters”** link moves back to its own right-aligned row (`quote-carousel-more-row`) instead of sitting beside the quote stack.
> 
> **Cypress** extracts `expectLowCls()` (threshold **0.01**), asserts SSR banner markup, dismissed-banner behavior, quote row layout, and that mobile does not fetch `left-pattern-full.svg`. Registry tests constrain `renderOnInitialLoad` to a single deterministic immediate banner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9c7e38170e9534620574cafc3cf2a43b45b4096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->