### PR TITLE
perf: reduce mobile landing startup work

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -111,27 +111,43 @@ describe('Landing page performance', () => {
 
   it('preloads only the default font and initially visible supporter logo', () => {
     cy.request('/').then((response) => {
-      // Next emits resource preloads as a `Link` response header when `/` renders
-      // dynamically (the dev server), but inlines them as <link rel="preload">
-      // tags in the document <head> when `/` is statically prerendered — which is
-      // how CI builds the page (`pnpm build` with E2E_FIXTURES=1). Collect from
-      // whichever source is present so the assertion holds in both render modes.
+      // Next emits resource preloads as a `Link` response header (when `/` renders
+      // dynamically) and/or as inlined <link rel="preload"> tags in the document
+      // <head> (when `/` is statically prerendered) — and a production build can
+      // surface the same resource in BOTH places at once. Collect a deduplicated
+      // set of preloaded URLs per `as` type, keyed by URL, so the assertion holds
+      // in every render mode and never double-counts a resource listed twice.
       const linkHeader = String(response.headers.link ?? '');
       const body = String(response.body ?? '');
-      const bodyPreloads = body.match(/<link\b[^>]*\brel="preload"[^>]*>/gu) ?? [];
 
-      const fontPreloads = [
-        ...(linkHeader.match(/rel=preload; as="font"/gu) ?? []),
-        ...bodyPreloads.filter((tag) => /\bas="font"/u.test(tag)),
-      ];
-      const logoPreloads = [
-        ...(linkHeader.match(/<\/logos\/[^>]+>; rel=preload; as="image"/gu) ?? []),
-        ...bodyPreloads.filter((tag) => /\bas="image"/u.test(tag) && /href="\/logos\//u.test(tag)),
-      ];
+      const fonts = new Set<string>();
+      const logos = new Set<string>();
+      const add = (as: string | undefined, url: string | undefined) => {
+        if (!url) return;
+        if (as === 'font') fonts.add(url);
+        else if (as === 'image' && url.startsWith('/logos/')) logos.add(url);
+      };
 
-      expect(fontPreloads).to.have.length(1);
-      expect(logoPreloads).to.have.length(1);
-      expect(`${linkHeader}${body}`).to.contain('/logos/openai.svg');
+      // `Link` header entries: <url>; rel=preload; as="font"|"image"; ...
+      for (const entry of linkHeader.split(',')) {
+        if (!/\brel=preload\b/u.test(entry)) continue;
+        add(
+          entry.match(/\bas="(?<as>[^"]+)"/u)?.groups?.as,
+          entry.match(/<(?<url>[^>]+)>/u)?.groups?.url,
+        );
+      }
+
+      // Inlined <link rel="preload"> tags.
+      for (const tag of body.match(/<link\b[^>]*\brel="preload"[^>]*>/gu) ?? []) {
+        add(
+          tag.match(/\bas="(?<as>[^"]+)"/u)?.groups?.as,
+          tag.match(/\bhref="(?<href>[^"]+)"/u)?.groups?.href,
+        );
+      }
+
+      expect([...fonts]).to.have.length(1);
+      expect([...logos]).to.have.length(1);
+      expect([...logos][0]).to.eq('/logos/openai.svg');
     });
   });
 

--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -111,12 +111,27 @@ describe('Landing page performance', () => {
 
   it('preloads only the default font and initially visible supporter logo', () => {
     cy.request('/').then((response) => {
+      // Next emits resource preloads as a `Link` response header when `/` renders
+      // dynamically (the dev server), but inlines them as <link rel="preload">
+      // tags in the document <head> when `/` is statically prerendered — which is
+      // how CI builds the page (`pnpm build` with E2E_FIXTURES=1). Collect from
+      // whichever source is present so the assertion holds in both render modes.
       const linkHeader = String(response.headers.link ?? '');
-      const fontPreloads = linkHeader.match(/rel=preload; as="font"/gu) ?? [];
-      const logoPreloads = linkHeader.match(/<\/logos\/[^>]+>; rel=preload; as="image"/gu) ?? [];
+      const body = String(response.body ?? '');
+      const bodyPreloads = body.match(/<link\b[^>]*\brel="preload"[^>]*>/gu) ?? [];
+
+      const fontPreloads = [
+        ...(linkHeader.match(/rel=preload; as="font"/gu) ?? []),
+        ...bodyPreloads.filter((tag) => /\bas="font"/u.test(tag)),
+      ];
+      const logoPreloads = [
+        ...(linkHeader.match(/<\/logos\/[^>]+>; rel=preload; as="image"/gu) ?? []),
+        ...bodyPreloads.filter((tag) => /\bas="image"/u.test(tag) && /href="\/logos\//u.test(tag)),
+      ];
+
       expect(fontPreloads).to.have.length(1);
       expect(logoPreloads).to.have.length(1);
-      expect(linkHeader).to.contain('</logos/openai.svg>; rel=preload; as="image"');
+      expect(`${linkHeader}${body}`).to.contain('/logos/openai.svg');
     });
   });
 

--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -94,10 +94,45 @@ describe('Landing page performance', () => {
 
     cy.get('.circuit-bg').should('have.css', 'display', 'none');
     cy.window().then((win) => {
-      const loadedPattern = win.performance
-        .getEntriesByType('resource')
-        .some((entry) => entry.name.includes('/brand/left-pattern-full.svg'));
-      expect(loadedPattern).to.eq(false);
+      const resourceNames = win.performance.getEntriesByType('resource').map((entry) => entry.name);
+      expect(resourceNames.some((name) => name.includes('/brand/left-pattern-full.svg'))).to.eq(
+        false,
+      );
+      expect(resourceNames.some((name) => name.includes('/minecraft-click.mp3'))).to.eq(false);
+      expect(resourceNames.some((name) => name.includes('/Monocraft-'))).to.eq(false);
+      expect(resourceNames.some((name) => name.includes('/logos/huggingface.svg'))).to.eq(false);
+      expect(
+        resourceNames.some(
+          (name) => name.includes('/brand/logo-color.webp') && name.includes('w=128'),
+        ),
+      ).to.eq(false);
+    });
+  });
+
+  it('preloads only the default font and initially visible supporter logo', () => {
+    cy.request('/').then((response) => {
+      const linkHeader = String(response.headers.link ?? '');
+      const fontPreloads = linkHeader.match(/rel=preload; as="font"/gu) ?? [];
+      const logoPreloads = linkHeader.match(/<\/logos\/[^>]+>; rel=preload; as="image"/gu) ?? [];
+      expect(fontPreloads).to.have.length(1);
+      expect(logoPreloads).to.have.length(1);
+      expect(linkHeader).to.contain('</logos/openai.svg>; rel=preload; as="image"');
+    });
+  });
+
+  it('loads Minecraft assets after the theme is activated', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('theme', 'dark');
+        win.localStorage.setItem('minecraft-music', 'false');
+      },
+    });
+
+    cy.get('[data-testid="theme-toggle"]').click();
+    cy.get('html').should('have.class', 'minecraft');
+    cy.window().should((win) => {
+      const resourceNames = win.performance.getEntriesByType('resource').map((entry) => entry.name);
+      expect(resourceNames.some((name) => name.includes('/minecraft-click.mp3'))).to.eq(true);
     });
   });
 });

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -35,7 +35,7 @@ import {
 
 const dm_sans = DM_Sans({
   subsets: ['latin'],
-  display: 'swap',
+  display: 'optional',
   variable: '--font-dm-sans',
 });
 
@@ -43,6 +43,7 @@ const monocraft = localFont({
   src: './fonts/Monocraft.woff2',
   variable: '--font-minecraft',
   display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -192,8 +193,6 @@ export default async function RootLayout({
           fetchPriority="high"
           media="(min-width: 640px)"
         />
-        <link rel="preconnect" href="https://us-assets.i.posthog.com" />
-        <link rel="dns-prefetch" href="https://us-assets.i.posthog.com" />
       </head>
       <body className={`${dm_sans.variable} antialiased relative min-h-screen flex flex-col`}>
         <style

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -112,7 +112,6 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                 width={64}
                 height={27}
                 className="inline h-auto lg:w-20"
-                priority
               />
             </span>
           </Link>

--- a/packages/app/src/components/landing/landing-analytics.tsx
+++ b/packages/app/src/components/landing/landing-analytics.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { track } from '@/lib/analytics';
+import { navigateInApp } from '@/lib/client-navigation';
+
+export function LandingPageAnalytics() {
+  useEffect(() => {
+    track('landing_page_viewed');
+  }, []);
+
+  return null;
+}
+
+interface LandingTrackedLinkProps extends Omit<React.ComponentProps<typeof Link>, 'href'> {
+  href: string;
+  analyticsEvent: string;
+  appNavigation?: boolean;
+}
+
+export function LandingTrackedLink({
+  href,
+  analyticsEvent,
+  appNavigation = false,
+  onClick,
+  ...props
+}: LandingTrackedLinkProps) {
+  const router = useRouter();
+
+  return (
+    <Link
+      {...props}
+      href={href}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        track(analyticsEvent);
+        if (appNavigation) navigateInApp(event, router, href);
+      }}
+    />
+  );
+}

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -1,28 +1,17 @@
-'use client';
-
 import { ArrowRight, BarChart3, ShieldCheck, Sparkles } from 'lucide-react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
 
 import { Card } from '@/components/ui/card';
 import { IntroSection } from '@/components/intro-section';
+import { LandingPageAnalytics, LandingTrackedLink } from '@/components/landing/landing-analytics';
 import { CuratedViewCard } from '@/components/landing/curated-view-card';
 import { NudgeEngine } from '@/components/nudge-engine';
 import { FAVORITE_PRESETS } from '@/components/favorites/favorite-presets';
-import { track } from '@/lib/analytics';
-import { navigateInApp } from '@/lib/client-navigation';
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
 
 export function LandingPage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    track('landing_page_viewed');
-  }, []);
-
   return (
     <main className="relative">
+      <LandingPageAnalytics />
       <NudgeEngine scope="landing" />
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-4">
         <IntroSection />
@@ -44,17 +33,15 @@ export function LandingPage() {
               gpt-oss, Llama, Qwen, and other models.
             </p>
             <div className="mt-auto">
-              <Link
+              <LandingTrackedLink
                 href="/inference"
-                onClick={(e) => {
-                  track('landing_full_dashboard_clicked');
-                  navigateInApp(e, router, '/inference');
-                }}
+                analyticsEvent="landing_full_dashboard_clicked"
+                appNavigation
                 className="inline-flex items-center justify-center gap-2 rounded-md text-sm sm:text-base font-medium h-12 px-8 bg-brand text-primary-foreground hover:bg-brand/90 transition-colors"
               >
                 Open Dashboard
                 <ArrowRight className="size-4" />
-              </Link>
+              </LandingTrackedLink>
             </div>
           </Card>
 
@@ -102,35 +89,33 @@ export function LandingPage() {
               </div>
             </div>
             <div className="flex flex-wrap gap-3 text-sm">
-              <Link
+              <LandingTrackedLink
                 href="/submissions"
                 data-testid="landing-submissions-link"
-                onClick={(e) => {
-                  track('landing_submissions_clicked');
-                  navigateInApp(e, router, '/submissions');
-                }}
+                analyticsEvent="landing_submissions_clicked"
+                appNavigation
                 className="inline-flex items-center gap-1.5 rounded-md bg-brand text-primary-foreground hover:bg-brand/90 px-3 py-1.5 transition-colors font-medium"
               >
                 Browse submissions
                 <ArrowRight className="size-3.5" />
-              </Link>
-              <a
+              </LandingTrackedLink>
+              <LandingTrackedLink
                 href={`https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/actions?query=branch%3Amain+event%3Apush`}
                 target="_blank"
                 rel="noopener noreferrer"
-                onClick={() => track('landing_reproducibility_actions_clicked')}
+                analyticsEvent="landing_reproducibility_actions_clicked"
                 className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 hover:bg-accent transition-colors"
               >
                 View benchmark runs on GitHub Actions
                 <ArrowRight className="size-3.5" />
-              </a>
-              <Link
+              </LandingTrackedLink>
+              <LandingTrackedLink
                 href="/about#reproducibility"
-                onClick={() => track('landing_reproducibility_about_clicked')}
+                analyticsEvent="landing_reproducibility_about_clicked"
                 className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 hover:bg-accent transition-colors"
               >
                 How it works
-              </Link>
+              </LandingTrackedLink>
             </div>
           </Card>
 

--- a/packages/app/src/components/minecraft/minecraft-background-lazy.tsx
+++ b/packages/app/src/components/minecraft/minecraft-background-lazy.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 
 const MinecraftBackground = dynamic(
   () => import('./minecraft-background').then((mod) => mod.MinecraftBackground),
@@ -8,5 +9,17 @@ const MinecraftBackground = dynamic(
 );
 
 export function MinecraftBackgroundLazy() {
-  return <MinecraftBackground />;
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      setActive(document.documentElement.classList.contains('minecraft'));
+    };
+    check();
+    const observer = new MutationObserver(check);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return active ? <MinecraftBackground /> : null;
 }

--- a/packages/app/src/components/quote-carousel.tsx
+++ b/packages/app/src/components/quote-carousel.tsx
@@ -57,14 +57,18 @@ function buildCompanyQuotes(quotes: CarouselQuote[], order?: string[]): CompanyE
   return entries;
 }
 
-function QuoteBlock({ quote }: { quote: CarouselQuote }) {
+function QuoteBlock({ quote, renderLogo }: { quote: CarouselQuote; renderLogo: boolean }) {
   return (
     <blockquote className="w-full">
       <p className="text-sm lg:text-base leading-relaxed text-muted-foreground italic">
         &ldquo;{highlightBrand(quote.text)}&rdquo;
       </p>
       <footer className="mt-3 flex items-center gap-3">
-        <CompanyLogo org={quote.org} logo={quote.logo} />
+        {renderLogo ? (
+          <CompanyLogo org={quote.org} logo={quote.logo} />
+        ) : (
+          <div aria-hidden="true" className="size-10 shrink-0" />
+        )}
         <div className="h-12 w-0.5 bg-brand" />
         <div className="text-sm">
           {quote.link ? (
@@ -183,7 +187,7 @@ export function QuoteCarousel({
               }`}
               aria-hidden={!isActive}
             >
-              <QuoteBlock quote={e.quote} />
+              <QuoteBlock quote={e.quote} renderLogo={isActive} />
             </div>
           );
         })}
@@ -193,6 +197,7 @@ export function QuoteCarousel({
         <div className="flex justify-end" data-testid="quote-carousel-more-row">
           <Link
             href={moreHref}
+            prefetch={false}
             className="text-xs font-bold text-brand hover:underline"
             onClick={() => track('quote_carousel_see_more_clicked')}
           >

--- a/packages/app/src/lib/analytics.test.ts
+++ b/packages/app/src/lib/analytics.test.ts
@@ -1,15 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const captureMock = vi.fn();
-
-vi.mock('posthog-js', () => ({
-  default: { capture: captureMock },
-}));
-
-import { track } from './analytics';
-
 describe('track', () => {
+  const captureMock = vi.fn();
+
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     vi.stubGlobal('window', {});
   });
@@ -18,22 +13,52 @@ describe('track', () => {
     vi.unstubAllGlobals();
   });
 
-  it('sends event to PostHog with properties', async () => {
-    track('test_event', { key: 'value' });
-    await vi.dynamicImportSettled();
+  it('sends event to the registered client with properties', async () => {
+    const analytics = await import('./analytics');
+    analytics.registerAnalyticsClient({ capture: captureMock });
+    analytics.track('test_event', { key: 'value' });
     expect(captureMock).toHaveBeenCalledWith('test_event', { key: 'value' });
   });
 
   it('sends event without properties', async () => {
-    track('test_event');
-    await vi.dynamicImportSettled();
+    const analytics = await import('./analytics');
+    analytics.registerAnalyticsClient({ capture: captureMock });
+    analytics.track('test_event');
     expect(captureMock).toHaveBeenCalledWith('test_event', undefined);
   });
 
   it('does not call capture when window is undefined', async () => {
+    const analytics = await import('./analytics');
+    analytics.registerAnalyticsClient({ capture: captureMock });
     vi.unstubAllGlobals();
-    track('test_event');
-    await vi.dynamicImportSettled();
+    analytics.track('test_event');
     expect(captureMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerAnalyticsClient', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('flushes events queued before the client is ready', async () => {
+    vi.stubGlobal('window', {});
+    const capture = vi.fn();
+    const analytics = await import('./analytics');
+
+    analytics.track('first_event', { order: 1 });
+    analytics.track('second_event');
+    expect(capture).not.toHaveBeenCalled();
+
+    analytics.registerAnalyticsClient({ capture });
+
+    expect(capture.mock.calls).toEqual([
+      ['first_event', { order: 1 }],
+      ['second_event', undefined],
+    ]);
   });
 });

--- a/packages/app/src/lib/analytics.ts
+++ b/packages/app/src/lib/analytics.ts
@@ -1,19 +1,31 @@
+interface AnalyticsClient {
+  capture: (eventName: string, properties?: Record<string, unknown>) => void;
+}
+
+interface PendingEvent {
+  eventName: string;
+  properties?: Record<string, unknown>;
+}
+
+const pendingEvents: PendingEvent[] = [];
+let analyticsClient: AnalyticsClient | null = null;
+
+export function registerAnalyticsClient(client: AnalyticsClient): void {
+  analyticsClient = client;
+  for (const event of pendingEvents.splice(0)) {
+    client.capture(event.eventName, event.properties);
+  }
+}
+
 /**
- * Track an analytics event via PostHog.
- * Drop-in replacement for the old `import { track } from '@vercel/analytics'`.
- *
- * PostHog is lazy-loaded — the first call triggers the dynamic import,
- * subsequent calls resolve instantly from the module cache.
- *
- * @param eventName - Event name following [section]_[action] convention
- * @param properties - Optional event properties
+ * Track an analytics event via PostHog. Events emitted before PostHog finishes
+ * its deferred initialization are queued and flushed in order.
  */
 export function track(eventName: string, properties?: Record<string, unknown>): void {
-  if (typeof window !== 'undefined') {
-    import('posthog-js')
-      .then(({ default: posthog }) => {
-        posthog.capture(eventName, properties);
-      })
-      .catch(() => {});
+  if (typeof window === 'undefined') return;
+  if (analyticsClient) {
+    analyticsClient.capture(eventName, properties);
+    return;
   }
+  pendingEvents.push({ eventName, properties });
 }

--- a/packages/app/src/providers/posthog-provider.tsx
+++ b/packages/app/src/providers/posthog-provider.tsx
@@ -3,33 +3,70 @@
 import type { PostHog } from 'posthog-js';
 import { Suspense, createContext, useContext, useEffect, useState } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
+import { registerAnalyticsClient } from '@/lib/analytics';
 import { installChunkLoadRecovery } from '@/lib/chunk-load-recovery';
 
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
 
 const PostHogCtx = createContext<PostHog | null>(null);
+const disabledAnalyticsClient = { capture: () => undefined };
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const [client, setClient] = useState<PostHog | null>(null);
 
   useEffect(() => {
     installChunkLoadRecovery();
-    if (!POSTHOG_KEY || process.env.NODE_ENV !== 'production') return;
-    import('posthog-js')
-      .then(({ default: posthog }) => {
-        posthog.init(POSTHOG_KEY, {
-          api_host: POSTHOG_HOST,
-          person_profiles: 'identified_only',
-          capture_pageview: false,
-          capture_pageleave: true,
-          autocapture: true,
-          capture_dead_clicks: true,
-          capture_performance: { network_timing: true, web_vitals: true },
+    if (!POSTHOG_KEY || process.env.NODE_ENV !== 'production') {
+      registerAnalyticsClient(disabledAnalyticsClient);
+      return;
+    }
+
+    let disposed = false;
+    let idleId: number | undefined;
+    let fallbackId: ReturnType<typeof setTimeout> | undefined;
+
+    const initialize = () => {
+      import('posthog-js')
+        .then(({ default: posthog }) => {
+          if (disposed) return;
+          posthog.init(POSTHOG_KEY, {
+            api_host: POSTHOG_HOST,
+            person_profiles: 'identified_only',
+            capture_pageview: false,
+            capture_pageleave: true,
+            autocapture: true,
+            capture_dead_clicks: true,
+            capture_performance: { network_timing: true, web_vitals: true },
+          });
+          registerAnalyticsClient(posthog);
+          setClient(posthog);
+        })
+        .catch(() => {
+          if (!disposed) registerAnalyticsClient(disabledAnalyticsClient);
         });
-        setClient(posthog);
-      })
-      .catch(() => {});
+    };
+
+    const scheduleInitialization = () => {
+      if ('requestIdleCallback' in window) {
+        idleId = window.requestIdleCallback(initialize, { timeout: 5_000 });
+      } else {
+        fallbackId = globalThis.setTimeout(initialize, 1_000);
+      }
+    };
+
+    if (document.readyState === 'complete') {
+      scheduleInitialization();
+    } else {
+      window.addEventListener('load', scheduleInitialization, { once: true });
+    }
+
+    return () => {
+      disposed = true;
+      window.removeEventListener('load', scheduleInitialization);
+      if (idleId !== undefined) window.cancelIdleCallback(idleId);
+      if (fallbackId !== undefined) window.clearTimeout(fallbackId);
+    };
   }, []);
 
   return <PostHogCtx.Provider value={client}>{children}</PostHogCtx.Provider>;


### PR DESCRIPTION
## Summary

- keep the landing page shell server-rendered and isolate only tracked links/page-view logic as client code
- defer PostHog until after `load` and an idle period while queueing early analytics events
- load Minecraft code, audio, and Monocraft only when the Minecraft theme is active
- render only the active supporter logo and stop prefetching the supporters route on first paint
- avoid a late DM Sans swap and remove the hidden mobile header-logo preload

## Root cause

The mobile landing page was doing substantial non-critical work before the first quote could settle:

- PostHog immediately loaded surveys and session-recording code
- every hidden carousel quote caused its logo to preload
- Minecraft audio and font assets loaded for the default theme
- the entire landing page was a client component
- DM Sans could repaint the quote late enough for Lighthouse to record it as the LCP

## Performance

Supplied mobile report:

- Performance: 78
- FCP: 1.0 s
- LCP: 4.8 s
- TBT: 230 ms
- CLS: 0
- Speed Index: 2.7 s

Optimized local production profile:

- Performance: 95
- FCP: 0.9 s
- LCP: 3.0 s
- TBT: 0 ms
- CLS: 0
- Speed Index: 0.9 s
- Initial requests: 68 -> 21
- Initial transfer: about 613 KB -> 322 KB

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- 52 focused Vitest tests
- 5 landing performance Cypress tests
- Next.js production compile

The full data-generating build requires `DATABASE_READONLY_URL`, which is not available in the local checkout.

The Vercel preview deployed successfully but requires project SSO, so the Lighthouse figures above use the local production profile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-focused front-end changes with analytics queuing to avoid lost early events; minor risk of delayed or missing PostHog captures if init fails, mitigated by a disabled client fallback.
> 
> **Overview**
> Cuts **mobile landing startup** by deferring analytics, theme-only assets, and extra client JS while keeping the main page **server-rendered**.
> 
> **Landing shell:** `LandingPage` is no longer a client component; page-view and link tracking live in a small `landing-analytics` client module (`LandingPageAnalytics`, `LandingTrackedLink`).
> 
> **PostHog:** Initialization waits until after `load` and an idle callback (with timeout fallback). Early `track()` calls are **queued** via `registerAnalyticsClient` and flushed when PostHog is ready. PostHog asset **preconnect/dns-prefetch** links were removed from the root layout.
> 
> **Fonts & images:** DM Sans uses `display: 'optional'`; Monocraft has `preload: false`. Header SemiAnalysis logo no longer uses `priority`. Quote carousel renders **only the active** supporter logo (placeholders for hidden slides). “See more supporters” uses `prefetch={false}`.
> 
> **Minecraft:** Background chunk mounts only when `html` has the `minecraft` class (MutationObserver). Cypress asserts Minecraft audio/fonts/logos are absent on default mobile load and load after theme activation.
> 
> **Tests:** Landing performance e2e expanded for mobile resource checks, preload deduplication (Link header + `<link rel="preload">`), and Minecraft lazy loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afaa21ca508035c8d0d4a639cdb073fa0bad9f2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->