### PR TITLE
perf: defer Minecraft theme assets

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -100,4 +100,28 @@ describe('Landing page performance', () => {
       expect(loadedPattern).to.eq(false);
     });
   });
+
+  it('loads Minecraft assets only after the theme is activated', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('theme', 'dark');
+        win.localStorage.setItem('minecraft-music', 'false');
+      },
+    });
+
+    cy.get('html').should('have.class', 'dark');
+    cy.window().then((win) => {
+      const resourceNames = win.performance.getEntriesByType('resource').map((entry) => entry.name);
+      expect(resourceNames.some((name) => name.includes('/minecraft-click.mp3'))).to.eq(false);
+      expect(resourceNames.some((name) => name.includes('/Monocraft-'))).to.eq(false);
+    });
+
+    cy.get('[data-testid="theme-toggle"]').click();
+    cy.get('html').should('have.class', 'minecraft');
+    cy.window().should((win) => {
+      const resourceNames = win.performance.getEntriesByType('resource').map((entry) => entry.name);
+      expect(resourceNames.some((name) => name.includes('/minecraft-click.mp3'))).to.eq(true);
+      expect(resourceNames.some((name) => name.includes('/Monocraft-'))).to.eq(true);
+    });
+  });
 });

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -43,6 +43,7 @@ const monocraft = localFont({
   src: './fonts/Monocraft.woff2',
   variable: '--font-minecraft',
   display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {

--- a/packages/app/src/components/minecraft/minecraft-background-lazy.tsx
+++ b/packages/app/src/components/minecraft/minecraft-background-lazy.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { useEffect, useState } from 'react';
 
 const MinecraftBackground = dynamic(
   () => import('./minecraft-background').then((mod) => mod.MinecraftBackground),
@@ -8,5 +9,18 @@ const MinecraftBackground = dynamic(
 );
 
 export function MinecraftBackgroundLazy() {
-  return <MinecraftBackground />;
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const checkTheme = () => {
+      setActive(document.documentElement.classList.contains('minecraft'));
+    };
+
+    checkTheme();
+    const observer = new MutationObserver(checkTheme);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return active ? <MinecraftBackground /> : null;
 }


### PR DESCRIPTION
## Summary

- stop preloading Monocraft for light and dark themes
- mount the Minecraft background runtime only while the root theme class is `minecraft`
- keep theme switching functional by observing root class changes
- verify that Minecraft assets are absent by default and load after activation

## Root cause

The Minecraft background component mounted for every visitor, even when the active theme was light or dark. Its effects initialized an `AudioContext`, fetched and decoded the click sound, and caused the Monocraft font to preload.

## Performance

Controlled mobile Lighthouse comparison using three-run medians:

| Metric | Before | After |
| --- | ---: | ---: |
| Performance | 85 | 90 |
| Total Blocking Time | 205 ms | 0 ms |
| Main-thread work | 0.93 s | 0.47 s |
| Largest Contentful Paint | 3.81 s | 3.60 s |
| Transfer | 509 KB | 473 KB |
| Requests | 50 | 47 |

This removes approximately 37 KB and three default-theme requests. Lighthouse results vary between runs, so the table uses medians.

## Validation

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `cypress/e2e/landing-performance.cy.ts` against a production compile
- mobile production Lighthouse profile: no Minecraft requests, 0 ms TBT, 0 CLS

The full data-generating build requires `DATABASE_READONLY_URL`; the Next.js production compile completed successfully.

## Related work

This is the standalone Minecraft-specific subset of #498. The Legacy JavaScript warning is separate: #498 reduces it from approximately 42 KB to 13 KB by deferring PostHog, while the remainder is Next.js shared runtime compatibility code.
