### PR TITLE
fix(landing): expand dashboard hardware + model list

### DIFF
--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -30,8 +30,8 @@ export function LandingPage() {
             </p>
             <p className="text-sm text-muted-foreground mb-6">
               Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X,
-              MI300X and soon Vera Rubin UALoE72, AMD MI455X UALoE72, TPUv7, etc across DeepSeekv4
-              Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.
+              MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7, etc across DeepSeekv4 Pro,
+              Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.
             </p>
             <div className="mt-auto">
               <LandingTrackedLink

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -29,8 +29,9 @@ export function LandingPage() {
               with date ranges, concurrency sweeps, and raw data export.
             </p>
             <p className="text-sm text-muted-foreground mb-6">
-              Compare NVIDIA B200, H200, H100, AMD MI355X, MI325X, MI300X and more across DeepSeek,
-              gpt-oss, Llama, Qwen, and other models.
+              Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X,
+              MI300X and soon Vera Rubin UALoE72, AMD MI455X UALoE72, TPUv7, etc across DeepSeekv4
+              Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.
             </p>
             <div className="mt-auto">
               <LandingTrackedLink

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -30,8 +30,8 @@ export function LandingPage() {
             </p>
             <p className="text-sm text-muted-foreground mb-6">
               Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X,
-              MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7, etc across DeepSeekv4 Pro,
-              Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.
+              MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7 Ironwood, etc across DeepSeekv4
+              Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.
             </p>
             <div className="mt-auto">
               <LandingTrackedLink


### PR DESCRIPTION
## Summary

Updates the **Full Dashboard** blurb on the landing page (`landing-page.tsx`) to reflect the current and upcoming hardware and the full model lineup.

**Before:**
> Compare NVIDIA B200, H200, H100, AMD MI355X, MI325X, MI300X and more across DeepSeek, gpt-oss, Llama, Qwen, and other models.

**After:**
> Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X, MI300X and soon Vera Rubin UALoE72, AMD MI455X UALoE72, TPUv7, etc across DeepSeekv4 Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.

## Notes

- Added a comma in "GLM, MiniMax" (separate models) and kept "gpt-oss" canonical casing (matches the rest of the site) instead of "GPTOSS".
- The SEO meta descriptions in `lib/tab-meta.ts` are separate strings and were left unchanged (not part of this request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing copy only in one landing component; no behavior, auth, or data paths.
> 
> **Overview**
> Updates the **Full Dashboard** card copy on the landing page so the hardware and model examples match the current benchmark lineup and near-term roadmap.
> 
> The paragraph now names **GB300/GB200 NVL72**, **B300**, and upcoming **VR200 NVL72**, **AMD MI455X UALoE72**, and **TPUv7 Ironwood**, and broadens the model list to **DeepSeekv4 Pro**, **Kimi**, **GLM**, **MiniMax**, and others (still alongside gpt-oss, Llama, Qwen). No routing, analytics, or layout changes—text only in `landing-page.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0edf2e555c6716a9efc03ac00900acdc37e3f1a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->