### PR TITLE
fix(inference): restore fixed-seq interactivity Pareto frontier + label/tab defaults

### DIFF
--- a/packages/app/cypress/e2e/line-labels.cy.ts
+++ b/packages/app/cypress/e2e/line-labels.cy.ts
@@ -15,11 +15,11 @@ describe('Line Labels Toggle', () => {
     cy.get('label[for="scatter-line-labels"]').should('contain.text', 'Line Labels');
   });
 
-  it('Line Labels toggle is off by default', () => {
-    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
+  it('Line Labels toggle is on by default', () => {
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
 
-    // No line labels render without interaction
-    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length', 0);
+    // Line labels render on load without interaction
+    cy.get('[data-testid="scatter-graph"] svg g.line-label').should('have.length.greaterThan', 0);
   });
 
   it('toggling Line Labels on then back off adds and removes label elements', () => {

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -245,14 +245,13 @@ export function InferenceProvider({
 
   const [hideNonOptimal, setHideNonOptimal] = useState(() => getUrlParam('i_optimal') !== '0');
   const [showPointLabels, setShowPointLabels] = useState(() => {
-    // Legacy `?i_nolabel=1` from before the rename: keep hiding point labels
-    // explicitly so the share link's intent survives future default changes.
+    // Legacy `?i_nolabel=1` from before the rename: keep hiding point labels.
     if (getUrlParam('i_nolabel') === '1') return false;
     if (getUrlParam('i_label') === '0') return false;
     if (getUrlParam('i_label') === '1') return true;
-    // Default on: point labels (TP + concurrency, or the fuller parallelism
-    // breakdown when Parallelism Labels is toggled on) are useful either way.
-    return true;
+    // Default off: per-point labels (TP + concurrency) clutter the chart; the
+    // per-line hardware labels (on by default) are the primary annotation.
+    return false;
   });
   const [logScale, setLogScale] = useState(() => getUrlParam('i_log') === '1');
   // Parallelism labels default off (?i_advlabel=1 overrides on).
@@ -262,8 +261,8 @@ export function InferenceProvider({
   const [showGradientLabels, setShowGradientLabels] = useState(
     () => getUrlParam('i_gradlabel') === '1',
   );
-  // Line labels default off (?i_linelabel=1 overrides on).
-  const [showLineLabels, setShowLineLabels] = useState(() => getUrlParam('i_linelabel') === '1');
+  // Line labels default on (?i_linelabel=0 overrides off).
+  const [showLineLabels, setShowLineLabels] = useState(() => getUrlParam('i_linelabel') !== '0');
   const [showSpeedOverlay, setShowSpeedOverlay] = useState(() => getUrlParam('i_speed') === '1');
   const [showMinecraftOverlay, setShowMinecraftOverlay] = useState(
     () => getUrlParam('i_mc') === '1',
@@ -1039,7 +1038,7 @@ export function InferenceProvider({
       i_dstart: selectedDateRange.startDate,
       i_dend: selectedDateRange.endDate,
       i_optimal: hideNonOptimal ? '' : '0',
-      i_label: showPointLabels ? '' : '0',
+      i_label: showPointLabels ? '1' : '',
       i_hc: highContrast ? '1' : '',
       i_log: logScale ? '1' : '',
       i_xmetric: selectedXAxisMetric || '',
@@ -1049,7 +1048,7 @@ export function InferenceProvider({
       i_legend: isLegendExpanded ? '' : '0',
       i_advlabel: useAdvancedLabels ? '1' : '',
       i_gradlabel: showGradientLabels ? '1' : '',
-      i_linelabel: showLineLabels ? '1' : '',
+      i_linelabel: showLineLabels ? '' : '0',
       i_speed: showSpeedOverlay ? '1' : '',
       i_mc: showMinecraftOverlay ? '1' : '',
       i_active: iActiveStr,

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -170,7 +170,7 @@ export function InferenceProvider({
   // value (if any) in a post-mount effect — keeps server + client first render
   // identical and avoids "didn't match" hydration warnings when the URL holds
   // a non-default mode.
-  const [selectedXAxisMode, setSelectedXAxisMode] = useState<XAxisMode>('ttft');
+  const [selectedXAxisMode, setSelectedXAxisMode] = useState<XAxisMode>('interactivity');
   const xAxisModeFromUrlRef = useRef(false);
   useEffect(() => {
     if (xAxisModeFromUrlRef.current) return;

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -249,6 +249,11 @@ export function InferenceProvider({
     if (getUrlParam('i_nolabel') === '1') return false;
     if (getUrlParam('i_label') === '0') return false;
     if (getUrlParam('i_label') === '1') return true;
+    // Advanced (parallelism) labels are a richer form of point label; a share
+    // link that requests them must auto-enable point labels so they actually
+    // render (mirrors the runtime toggle coupling in ScatterGraph). A later
+    // explicit i_nolabel=1 still wins — it is checked first above.
+    if (getUrlParam('i_advlabel') === '1') return true;
     // Default off: per-point labels (TP + concurrency) clutter the chart; the
     // per-line hardware labels (on by default) are the primary annotation.
     return false;

--- a/packages/app/src/components/inference/hooks/useChartData.ts
+++ b/packages/app/src/components/inference/hooks/useChartData.ts
@@ -400,9 +400,19 @@ export function useChartData(
         const metricKey = selectedYAxisMetric.replace('y_', '') as YAxisMetricKey;
 
         // Default x-axis = chart's natural latency metric, percentile-adjusted
-        // for the agentic case (median_e2el → p99_e2el etc.). For non-agentic
-        // scenarios `withPercentile` is a no-op when percentile === 'median'.
-        const naturalX = withPercentile(chartDef.x, selectedPercentile) as keyof AggDataEntry;
+        // for the agentic case (median_e2el → p99_e2el etc.). Percentiles only
+        // exist for agentic scenarios; fixed-seq benchmarks have no p90_/p99_
+        // columns, and the percentile selector is hidden for them — but its
+        // state persists at the 'p90' default across mode/sequence switches.
+        // Applying that stale percentile to a fixed-seq metric yields a null
+        // column (e.g. p90_intvty), which renders as x=0/NaN and drops the
+        // point from the chart. Force median for non-agentic so the natural
+        // metric (median_intvty / median_e2el) is used.
+        const isAgentic = selectedSequence === Sequence.AgenticTraces;
+        const naturalX = withPercentile(
+          chartDef.x,
+          isAgentic ? selectedPercentile : 'median',
+        ) as keyof AggDataEntry;
         let xAxisField: keyof AggDataEntry = naturalX;
         let xAxisLabel = chartDef.x_label;
 
@@ -423,8 +433,6 @@ export function useChartData(
           : 'p90';
         const ttftPctlWord = ttftPctl === 'median' ? 'Median' : ttftPctl.toUpperCase();
         const ttftLabel = `${ttftPctlWord} Time To First Token (s)`;
-
-        const isAgentic = selectedSequence === Sequence.AgenticTraces;
 
         if (
           effectiveXMetric &&

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -83,10 +83,10 @@ import WorkflowInfoDisplay from './WorkflowInfoDisplay';
 type InferenceViewMode = 'chart' | 'table';
 
 const X_AXIS_MODE_BUTTONS: { value: XAxisMode; label: string }[] = [
+  { value: 'interactivity', label: 'Interactivity' },
   { value: 'ttft', label: 'TTFT' },
   { value: 'e2e', label: 'E2E Latency' },
   { value: 'normalized-e2e', label: 'Normalized E2E' },
-  { value: 'interactivity', label: 'Interactivity' },
   { value: 'session-time', label: 'Session Time' },
   { value: 'prefill-tps', label: 'Prefill TPS / user' },
 ];

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -84,8 +84,8 @@ type InferenceViewMode = 'chart' | 'table';
 
 const X_AXIS_MODE_BUTTONS: { value: XAxisMode; label: string }[] = [
   { value: 'interactivity', label: 'Interactivity' },
-  { value: 'ttft', label: 'TTFT' },
   { value: 'e2e', label: 'E2E Latency' },
+  { value: 'ttft', label: 'TTFT' },
   { value: 'normalized-e2e', label: 'Normalized E2E' },
   { value: 'session-time', label: 'Session Time' },
   { value: 'prefill-tps', label: 'Prefill TPS / user' },

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -30,6 +30,7 @@ import {
   POINT_SIZE,
 } from '@/lib/chart-rendering';
 import {
+  isFrontierEligible,
   paretoFrontLowerLeft,
   paretoFrontLowerRight,
   paretoFrontUpperLeft,
@@ -230,14 +231,17 @@ const GPUGraph = React.memo(
         | 'lower_right'
         | undefined;
       for (const key of Object.keys(groupedData)) {
+        // Exclude degenerate x <= 0 points (interactivity = 0, etc.) from the
+        // frontier so they are never drawn as optimal.
+        const eligible = groupedData[key].filter(isFrontierEligible);
         result[key] =
           dir === 'upper_right'
-            ? paretoFrontUpperRight(groupedData[key])
+            ? paretoFrontUpperRight(eligible)
             : dir === 'upper_left'
-              ? paretoFrontUpperLeft(groupedData[key])
+              ? paretoFrontUpperLeft(eligible)
               : dir === 'lower_left'
-                ? paretoFrontLowerLeft(groupedData[key])
-                : paretoFrontLowerRight(groupedData[key]);
+                ? paretoFrontLowerLeft(eligible)
+                : paretoFrontLowerRight(eligible);
       }
       return result;
     }, [groupedData, selectedYAxisMetric, chartDefinition]);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -51,7 +51,11 @@ import {
   getShapeKeyForPrecision,
 } from '@/lib/chart-rendering';
 import { useThemeColors } from '@/hooks/useThemeColors';
-import { paretoFrontForDirection, type ParetoDirection } from '@/lib/chart-utils';
+import {
+  isFrontierEligible,
+  paretoFrontForDirection,
+  type ParetoDirection,
+} from '@/lib/chart-utils';
 import { type RooflineDirection, getSpeedOverlayCorners } from '@/lib/speed-overlay';
 import type {
   ChartDefinition,
@@ -482,9 +486,9 @@ const ScatterGraph = React.memo(
           // before paretoing (otherwise we'd recompute a fresh frontier
           // on the swapped x axis and reintroduce the benchmark hack).
           const flagged = datePoints.some((p) => p.isOnE2eFrontier !== undefined);
-          const seedPoints = flagged
-            ? datePoints.filter((p) => p.isOnE2eFrontier === true)
-            : datePoints;
+          const seedPoints = (
+            flagged ? datePoints.filter((p) => p.isOnE2eFrontier === true) : datePoints
+          ).filter(isFrontierEligible);
           if (seedPoints.length === 0) continue;
           combined.push(...frontierFn(seedPoints));
         }
@@ -603,7 +607,7 @@ const ScatterGraph = React.memo(
       const frontierFn = paretoFrontForDirection(dir ?? 'lower_right');
       const result: Record<string, Entry> = {};
       for (const [key, group] of Object.entries(grouped)) {
-        const front = frontierFn(group.points);
+        const front = frontierFn(group.points.filter(isFrontierEligible));
         front.sort((a, b) => a.x - b.x);
         result[key] = { hwKey: group.hwKey, runIndex: group.runIndex, points: front };
       }

--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -542,6 +542,32 @@ describe('calculateRoofline', () => {
     expect(front[1].y).toBe(8);
   });
 
+  it('excludes x <= 0 points (e.g. interactivity = 0) from the frontier', () => {
+    // A degenerate x=0 point with the highest tpPerGpu would otherwise anchor the
+    // upper_right front as its leftmost point and show up as "optimal".
+    const points = [
+      pt(0, 999, 'h100', { tpPerGpuY: 999 }), // interactivity = 0 → degenerate
+      pt(1, 999, 'h100', { tpPerGpuY: 50 }),
+      pt(2, 999, 'h100', { tpPerGpuY: 80 }),
+    ];
+    const front = calculateRoofline(points, 'tpPerGpu.y', 'upper_right');
+    expect(front.every((p) => p.x > 0)).toBe(true);
+    expect(front.some((p) => p.x === 0)).toBe(false);
+    // real front is the two positive-x points
+    expect(front.map((p) => p.y)).toEqual([50, 80]);
+  });
+
+  it('excludes non-finite / negative x from the frontier', () => {
+    const points = [
+      pt(Number.NaN, 999, 'h100', { tpPerGpuY: 999 }),
+      pt(-1, 999, 'h100', { tpPerGpuY: 999 }),
+      pt(3, 999, 'h100', { tpPerGpuY: 40 }),
+    ];
+    const front = calculateRoofline(points, 'tpPerGpu.y', 'upper_right');
+    expect(front).toHaveLength(1);
+    expect(front[0].x).toBe(3);
+  });
+
   it.each([
     ['upper_right', 2], // A(1,50) and B(2,80) both on front
     ['upper_left', 1], // B(2,80) dominates A(1,50) → only B kept

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -475,6 +475,17 @@ export const getNestedYValue = <T extends InferenceData>(point: T, key: string):
 };
 
 /**
+ * Whether a point may sit on the Pareto frontier / "optimal" set. Points with a
+ * non-positive or non-finite x (e.g. interactivity = 0 when ITL is missing/zero,
+ * or a 0/negative latency) are degenerate — no real config runs there — so they
+ * must never be marked optimal. Apply this to a frontier function's INPUT; the
+ * points still render in the show-all view, they just lose roofline eligibility.
+ * NOTE: filter at the call site, not inside the paretoFront* functions — those are
+ * kept 1:1 with the calculator's Python port (iso_interactivity.py).
+ */
+export const isFrontierEligible = (p: { x: number }): boolean => Number.isFinite(p.x) && p.x > 0;
+
+/**
  * Calculates the Pareto front (upper right) for a given set of points.
  */
 export const paretoFrontUpperRight = (points: InferenceData[]): InferenceData[] => {
@@ -639,7 +650,9 @@ export const calculateRoofline = (
     | `measuredJPerInputToken.y`,
   rooflineDirection: 'upper_right' | 'upper_left' | 'lower_left' | 'lower_right',
 ): InferenceData[] => {
-  const pointsForRoofline = points.map((p) => {
+  // Exclude degenerate x <= 0 points (see isFrontierEligible) so they never
+  // anchor a roofline or show up in the optimal-only view.
+  const pointsForRoofline = points.filter(isFrontierEligible).map((p) => {
     const yValue = getNestedYValue(p, yKey);
     return { ...p, y: yValue };
   });


### PR DESCRIPTION
## What & why

The interactivity chart's Pareto frontier regressed after agentx (#348): points that shouldn't exist collapsed onto **x = 0** and, for some models (e.g. Llama-3.3-70B), the entire optimal set vanished.

**Root cause.** agentx introduced a latency-percentile system that rewrites the chart x-axis via `withPercentile(chartDef.x, selectedPercentile)` — applied **unconditionally**. Percentiles only exist for agentic scenarios; fixed-seq (8k/1k) benchmarks have no `p90_`/`p99_` columns (their `p90_intvty` is stored as `0`). The percentile selector is hidden for fixed-seq, but its state stays at the `'p90'` default and nothing resets it — so every fixed-seq interactivity chart silently asked for `p90_intvty = 0`, piling all points onto x = 0.

## Changes

- **`fix`: use median (not stale p90) for fixed-seq x-axis** (`useChartData.ts`) — force `median` for non-agentic in the x-metric resolution. This restores the pre-agentx frontier and brings the official path into alignment with the overlay path (`processOverlayChartData`), which already used `median_intvty` for fixed-seq. Agentic percentile selection is untouched.
- **`fix`: exclude interactivity = 0 / x ≤ 0 points from the frontier** — new `isFrontierEligible` predicate applied in `calculateRoofline`, both `ScatterGraph` frontier paths (official + `?unofficialrun=` overlay), and `GPUGraph`. Defensive guard so genuinely degenerate rows can never anchor a roofline. +2 unit tests.
- **`feat`: interactivity is the default x-axis mode** and the **first** tab.
- **`feat`: reorder x-axis tabs** → Interactivity, E2E Latency, TTFT, then the agentic-only (feature-gated) modes.
- **`feat`: point labels OFF by default, line labels ON by default** — per-line hardware names replace per-point TP/concurrency clutter as the default annotation. Share-link serializers flipped to match so the non-default state survives a shared URL.

## Overlay support (`?unofficialrun=`)

- x ≤ 0 guard is applied to both the official (`ScatterGraph.tsx:491`) and overlay (`ScatterGraph.tsx:610`) frontier paths, plus `GPUGraph`.
- The percentile fix is official-path only; the overlay path (`processOverlayChartData`) never applied the percentile, so it already rendered `median_intvty` correctly for fixed-seq — this change makes the two paths consistent.
- Label/tab/default changes are shared context state and apply to both paths.

## Verification

Playwright against the live read-only prod DB (interactivity, optimal-only, default settings):

| Model | Optimal points | median_intvty range | x ≤ 0 | x tracks median_intvty |
| --- | --- | --- | --- | --- |
| Llama-3.3-70B (was **0**) | 64 | 15.5–148 | 0 | yes (0 inversions) |
| GLM-5 | 167 | 5.5–147 | 0 | yes |
| DeepSeek-R1 | 540 | 5.1–351 | 0 | yes |

For Llama, `p90_intvty = 0` on every row (proving the pre-fix x = 0 collapse); post-fix the 64 points spread across 57 distinct screen-x positions, monotonic with `median_intvty`.

## Test plan

- `pnpm typecheck && pnpm lint && pnpm fmt` — green (pre-commit hook).
- `pnpm test:unit` — includes 2 new `chart-utils` frontier-eligibility tests.
- e2e `ttft-x-axis-toggle.cy.ts` selects tabs by `data-testid` (order-agnostic) and is agentic-scoped; label component tests pass `showLineLabels` explicitly — none assert the old defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chart x-axis resolution and Pareto/optimal logic used across inference views; behavior and share-link defaults change for all users, though agentic paths are largely preserved.
> 
> **Overview**
> Fixes a **regression** where fixed-sequence interactivity charts collapsed onto **x = 0** and could show **no optimal points** (e.g. Llama-3.3-70B). The chart pipeline was applying the agentic **p90** percentile to fixed-seq x metrics even though those columns don’t exist (`p90_intvty` → 0); **`useChartData`** now forces **median** for non-agentic natural x-axis resolution while agentic percentile behavior is unchanged.
> 
> Adds **`isFrontierEligible`** so points with **x ≤ 0** or non-finite x never anchor Pareto rooflines or “optimal” highlighting in **`ScatterGraph`**, **`GPUGraph`**, and **`calculateRoofline`**, with new unit tests.
> 
> **UX / share-link defaults:** default x-axis mode is **Interactivity** (first tab); **point labels off**, **line labels on**; URL sync flips to `i_label=1` when on and `i_linelabel=0` when off. Cypress line-label expectations updated for line labels on by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f700c9cc91542172726fef8976ca75beef2eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->