### PR TITLE
Add bilingual Chinese content rules to AGENTS.md (and CLAUDE.md via @AGENTS.md) / 在 AGENTS.md 中新增中英双语内容规则（CLAUDE.md 经 @AGENTS.md 引用生效）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 For detailed subsystem docs, see [docs/index.md](./docs/index.md).
 
+> **PR and GitHub-issue titles & descriptions must be bilingual — include a Simplified Chinese version in addition to English.** Title format: `<English title> / <中文标题>` (keep bracket prefixes at the front untranslated). In the PR/issue body, follow the English content with a `## 中文说明` section mirroring the summary; don't translate code blocks, logs, or stack traces — summarize around them. **Commit messages must include a Chinese translation too**: keep the subject line in English (conventional-commit style) and include the Chinese translation of the subject and key points in the commit body (e.g. a trailing `中文：<translation>` paragraph); squash-merge commits inherit the bilingual PR title, which satisfies the subject requirement automatically.
+
+> **Translation quality bar:** write natural technical Chinese, not word-for-word machine translation (style reference: [`vllm-project/vllm-ascend` `README.zh.md`](https://github.com/vllm-project/vllm-ascend/blob/main/README.zh.md)). Preserve product names, hardware SKUs, framework/library names (Next.js, React Query, D3.js, Tailwind ...), flags, and code identifiers in English. Use parenthetical English clarification for acronyms on first use. Preferred terms: benchmark 基准测试, dashboard 仪表板, chart 图表, config 配置, throughput 吞吐量, latency 延迟, single-node/multi-node 单节点/多节点, evaluation 评估, artifact 产物.
+
 ## Project Overview
 
 InferenceX App — Next.js 16 dashboard for ML inference benchmark data. DB-backed with Neon PostgreSQL, React Query for data fetching, D3.js for charts.


### PR DESCRIPTION
## Summary
- Adds the bilingual content rules to `AGENTS.md`: PR/issue titles as `<English title> / <中文标题>`, bodies with a `## 中文说明` section (code blocks/logs untranslated), and commit messages with an English subject plus Chinese translation in the body.
- Includes the translation quality bar (vllm-ascend `README.zh.md` style; product/framework names and code identifiers stay in English) with dashboard-domain preferred terms (仪表板/dashboard, 图表/chart, ...).
- `CLAUDE.md` is `@AGENTS.md`, so the rules take effect through both entry points without duplication.
- Mirrors the convention already adopted in SemiAnalysisAI/InferenceX and SemiAnalysisAI/ClusterMAX-internal.

## 中文说明
- 在 `AGENTS.md` 中新增中英双语内容规则：PR/issue 标题采用 `<English title> / <中文标题>` 格式，正文附 `## 中文说明` 部分（代码块与日志不翻译），提交信息主题行保持英文、正文附中文翻译。
- 包含翻译质量标准（参照 vllm-ascend `README.zh.md` 风格；产品/框架名与代码标识符保留英文），并附仪表板领域的常用术语对照（dashboard 仪表板、chart 图表等）。
- `CLAUDE.md` 内容为 `@AGENTS.md` 引用，规则经两个入口同时生效，无需重复维护。
- 与 SemiAnalysisAI/InferenceX 及 SemiAnalysisAI/ClusterMAX-internal 已采用的规范保持一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Agent/contributor documentation only; no production code, data paths, or deployment impact.
> 
> **Overview**
> **Documentation-only change** to `AGENTS.md`: two new blockquotes before **Project Overview** define how agents and contributors should write GitHub-facing text.
> 
> The first blockquote requires **bilingual English + Simplified Chinese** for PR and issue titles (`<English title> / <中文标题>`), bodies (English plus a mirroring `## 中文说明`; code blocks, logs, and stack traces stay untranslated), and commits (English conventional subject with Chinese translation of the subject and key points in the body; squash merges can rely on the bilingual PR title).
> 
> The second blockquote sets a **translation quality bar** (natural technical Chinese, style reference to vllm-ascend `README.zh.md`), keeps product/framework names and code identifiers in English, and lists preferred dashboard-domain terms (e.g. 仪表板, 图表, 吞吐量).
> 
> No application code, APIs, or runtime behavior change; `CLAUDE.md` already includes `@AGENTS.md`, so the rules apply to both agent entry points without duplicating content in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f6ce16956e7dc685db99d941993f005d072833d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->