### PR TITLE
fix(compare): reject non-canonical slugs in variant OG image routes / 对比页 OG 图片路由拒绝非规范化 slug

### DIFF
--- a/packages/app/src/app/compare-precision/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-precision/[slug]/opengraph-image.tsx
@@ -30,7 +30,16 @@ export async function generateStaticParams() {
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const parsed = parsePrecisionCompareSlug(slug);
-  if (!parsed) notFound();
+  // Reject non-canonical slugs (reversed order, aliases, mixed case) so OG
+  // URLs can't render labels that disagree with the canonical page — same
+  // strictness as the sibling PNG route.
+  if (
+    !parsed ||
+    canonicalPrecisionCompareSlug(parsed.model.slug, parsed.gpu, parsed.precA, parsed.precB) !==
+      slug.toLowerCase()
+  ) {
+    notFound();
+  }
   const [logoSrc, tiles] = await Promise.all([getLogoSrc(), getTiles()]);
 
   const gpuMeta = HW_REGISTRY[parsed.gpu];

--- a/packages/app/src/app/compare-spec-decode/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-spec-decode/[slug]/opengraph-image.tsx
@@ -31,7 +31,20 @@ export async function generateStaticParams() {
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params;
   const parsed = parseSpecDecodeCompareSlug(slug);
-  if (!parsed) notFound();
+  // Reject non-canonical slugs (reversed order, aliases, mixed case) so OG
+  // URLs can't render labels that disagree with the canonical page — same
+  // strictness as the sibling PNG route.
+  if (
+    !parsed ||
+    canonicalSpecDecodeCompareSlug(
+      parsed.model.slug,
+      parsed.gpu,
+      parsed.precision,
+      parsed.method,
+    ) !== slug.toLowerCase()
+  ) {
+    notFound();
+  }
   const [logoSrc, tiles] = await Promise.all([getLogoSrc(), getTiles()]);
 
   const gpuMeta = HW_REGISTRY[parsed.gpu];


### PR DESCRIPTION
## Summary

Follow-up to #526 (the finding was flagged by Cursor just before the merge): the two new variant-compare Open Graph image handlers rendered any parseable slug — reversed precision order, alias model prefixes, mixed case — producing OG labels that could disagree with the canonical HTML page and hero PNG. They now `notFound()` on non-canonical slugs via the same case-insensitive canonical comparison their sibling PNG routes use.

## Test plan

- `pnpm typecheck` / `pnpm lint` clean
- Canonical OG URLs render unchanged (build-time `generateStaticParams` only emits canonical slugs)

## 中文说明

#526 的后续修复（Cursor 在合并前刚提出）：新增对比页面族的 OG 图片路由此前会渲染任何可解析的 slug（顺序颠倒、模型别名、混合大小写），可能生成与规范页面不一致的标签；现与同页 PNG 路由口径一致，对非规范化 slug 返回 404。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard change on OG image routes only; canonical URLs behave as before and invalid slugs return 404 instead of misleading images.
> 
> **Overview**
> **Precision** and **spec-decode** compare Open Graph image handlers no longer render any slug that merely parses. After parsing, each route recomputes the canonical slug and calls `notFound()` when it does not match `slug.toLowerCase()`, mirroring the sibling hero PNG routes.
> 
> That blocks OG URLs built from reversed precision order, model alias prefixes, or other non-canonical forms from showing titles that could disagree with the canonical HTML page. Build-time `generateStaticParams` still only emits canonical slugs, so valid share previews are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd40a98936796e5badf88aa9d4069e4ab4b0a510. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->