### PR TITLE
ci: cap browser e2e shards at four

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -58,7 +58,10 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chrome, firefox]
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
+        # Cap at four shards per browser. Every shard repeats checkout, dependency
+        # installation, Cypress setup, and a full app build; beyond four, that
+        # duplicated fixed cost dominates and yields sharply diminishing returns.
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -117,11 +120,11 @@ jobs:
           CI: true
           E2E_FIXTURES: '1'
           # cypress-split picks the subset of specs for this shard.
-          # SPLIT_INDEX1 is 1-based to match matrix.shard values [1..16].
+          # SPLIT_INDEX1 is 1-based to match matrix.shard values [1..4].
           # SPLIT_FILE seeds the balance from observed timings;
           # SPLIT_OUTPUT_FILE redirects on-disk updates to a throwaway path
           # so CI never tries to mutate the committed timings.json.
-          SPLIT: 16
+          SPLIT: 4
           SPLIT_INDEX1: ${{ matrix.shard }}
           SPLIT_FILE: timings.json
           SPLIT_OUTPUT_FILE: /tmp/cypress-split-out.json

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -1,27 +1,156 @@
 {
   "durations": [
-    { "spec": "cypress/e2e/blog.cy.ts", "duration": 3900 },
-    { "spec": "cypress/e2e/csv-export.cy.ts", "duration": 7000 },
-    { "spec": "cypress/e2e/custom-user-values.cy.ts", "duration": 16300 },
-    { "spec": "cypress/e2e/drill-down-trend.cy.ts", "duration": 10700 },
-    { "spec": "cypress/e2e/dropdown-switching.cy.ts", "duration": 2500 },
-    { "spec": "cypress/e2e/evaluation-chart.cy.ts", "duration": 3600 },
-    { "spec": "cypress/e2e/gpu-power.cy.ts", "duration": 6500 },
-    { "spec": "cypress/e2e/gpu-specs.cy.ts", "duration": 10700 },
-    { "spec": "cypress/e2e/gradient-labels.cy.ts", "duration": 7300 },
-    { "spec": "cypress/e2e/historical-trends.cy.ts", "duration": 11700 },
-    { "spec": "cypress/e2e/inference-chart.cy.ts", "duration": 1600 },
-    { "spec": "cypress/e2e/line-labels.cy.ts", "duration": 4100 },
-    { "spec": "cypress/e2e/model-architecture.cy.ts", "duration": 5900 },
-    { "spec": "cypress/e2e/navigation.cy.ts", "duration": 6200 },
-    { "spec": "cypress/e2e/nudge-system.cy.ts", "duration": 17000 },
-    { "spec": "cypress/e2e/performance.cy.ts", "duration": 3900 },
-    { "spec": "cypress/e2e/reliability-chart.cy.ts", "duration": 2600 },
-    { "spec": "cypress/e2e/sanity.cy.ts", "duration": 3200 },
-    { "spec": "cypress/e2e/speed-overlay.cy.ts", "duration": 4700 },
-    { "spec": "cypress/e2e/throughput-calculator.cy.ts", "duration": 11600 },
-    { "spec": "cypress/e2e/ttft-x-axis-toggle.cy.ts", "duration": 1800 },
-    { "spec": "cypress/e2e/url-params.cy.ts", "duration": 12300 },
-    { "spec": "cypress/e2e/yaxis-metrics-render.cy.ts", "duration": 4200 }
+    {
+      "spec": "cypress/e2e/agentic-point-time-series.cy.ts",
+      "duration": 2248
+    },
+    {
+      "spec": "cypress/e2e/blog.cy.ts",
+      "duration": 1073
+    },
+    {
+      "spec": "cypress/e2e/compare-per-dollar-redirect.cy.ts",
+      "duration": 1884
+    },
+    {
+      "spec": "cypress/e2e/compare-per-dollar-table.cy.ts",
+      "duration": 510
+    },
+    {
+      "spec": "cypress/e2e/compare-precision.cy.ts",
+      "duration": 1049
+    },
+    {
+      "spec": "cypress/e2e/compare-redirect.cy.ts",
+      "duration": 1537
+    },
+    {
+      "spec": "cypress/e2e/compare-spec-decode.cy.ts",
+      "duration": 798
+    },
+    {
+      "spec": "cypress/e2e/compare-table.cy.ts",
+      "duration": 1260
+    },
+    {
+      "spec": "cypress/e2e/csv-export.cy.ts",
+      "duration": 1679
+    },
+    {
+      "spec": "cypress/e2e/custom-user-values.cy.ts",
+      "duration": 11837
+    },
+    {
+      "spec": "cypress/e2e/datasets-distributions.cy.ts",
+      "duration": 338
+    },
+    {
+      "spec": "cypress/e2e/datasets-flamegraph-time.cy.ts",
+      "duration": 313
+    },
+    {
+      "spec": "cypress/e2e/drill-down-trend.cy.ts",
+      "duration": 3779
+    },
+    {
+      "spec": "cypress/e2e/dropdown-switching.cy.ts",
+      "duration": 1368
+    },
+    {
+      "spec": "cypress/e2e/evaluation-chart.cy.ts",
+      "duration": 1051
+    },
+    {
+      "spec": "cypress/e2e/gpu-compare-agentic-detail.cy.ts",
+      "duration": 1041
+    },
+    {
+      "spec": "cypress/e2e/gpu-power.cy.ts",
+      "duration": 3402
+    },
+    {
+      "spec": "cypress/e2e/gpu-specs.cy.ts",
+      "duration": 4894
+    },
+    {
+      "spec": "cypress/e2e/gradient-labels.cy.ts",
+      "duration": 3466
+    },
+    {
+      "spec": "cypress/e2e/historical-trends.cy.ts",
+      "duration": 4183
+    },
+    {
+      "spec": "cypress/e2e/inference-chart.cy.ts",
+      "duration": 614
+    },
+    {
+      "spec": "cypress/e2e/inference-replay.cy.ts",
+      "duration": 3596
+    },
+    {
+      "spec": "cypress/e2e/landing-performance.cy.ts",
+      "duration": 5602
+    },
+    {
+      "spec": "cypress/e2e/line-labels.cy.ts",
+      "duration": 8824
+    },
+    {
+      "spec": "cypress/e2e/measured-power-overlay.cy.ts",
+      "duration": 1055
+    },
+    {
+      "spec": "cypress/e2e/model-architecture.cy.ts",
+      "duration": 4494
+    },
+    {
+      "spec": "cypress/e2e/navigation.cy.ts",
+      "duration": 2713
+    },
+    {
+      "spec": "cypress/e2e/nudge-system.cy.ts",
+      "duration": 12785
+    },
+    {
+      "spec": "cypress/e2e/performance.cy.ts",
+      "duration": 1538
+    },
+    {
+      "spec": "cypress/e2e/reliability-chart.cy.ts",
+      "duration": 1613
+    },
+    {
+      "spec": "cypress/e2e/sanity.cy.ts",
+      "duration": 782
+    },
+    {
+      "spec": "cypress/e2e/speed-overlay.cy.ts",
+      "duration": 3142
+    },
+    {
+      "spec": "cypress/e2e/throughput-calculator.cy.ts",
+      "duration": 5441
+    },
+    {
+      "spec": "cypress/e2e/ttft-x-axis-toggle.cy.ts",
+      "duration": 1283
+    },
+    {
+      "spec": "cypress/e2e/unofficial-watermark.cy.ts",
+      "duration": 848
+    },
+    {
+      "spec": "cypress/e2e/url-params.cy.ts",
+      "duration": 5910
+    },
+    {
+      "spec": "cypress/e2e/yaxis-metrics-render.cy.ts",
+      "duration": 2690
+    },
+    {
+      "spec": "cypress/e2e/zh-pages.cy.ts",
+      "duration": 1458
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- cap Chrome and Firefox Cypress matrices at four shards each
- document why fixed per-shard setup costs outweigh further parallelism
- refresh timings for all 38 current E2E specs

## Verification
- full Chrome E2E timing run: 38/38 specs passed
- four-way predicted shard durations: 28.077s, 28.011s, 28.011s, 27.999s
- workflow and timing-file formatting checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and timing data changes; no application runtime behavior is modified, though E2E coverage still runs across fewer parallel jobs per browser.
> 
> **Overview**
> Reduces Cypress E2E parallelism from **16 shards to 4** per browser (Chrome and Firefox) in `tests-e2e.yml`, with inline rationale that each shard repeats checkout, install, Cypress setup, and a full app build, so extra shards add fixed cost with diminishing speedup.
> 
> Aligns **cypress-split** by setting `SPLIT` to `4` and updating shard comments to `[1..4]`.
> 
> Refreshes **`packages/app/timings.json`** for all **38** current E2E specs with updated per-spec durations so load balancing stays even across the four shards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0519028a67e28eae76b45ed9383d6dfb86d3c1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->