### PR TITLE
chore(models): move gpt-oss 120B to deprecated / 将 gpt-oss 120B 移至弃用类别

### DIFF
--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -49,8 +49,8 @@ describe('Dropdown one-click switching', () => {
 
     cy.contains('Maintenance Mode').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').scrollIntoView().should('be.visible');
-    cy.contains('[role="option"]', 'gpt-oss 120B').scrollIntoView().should('be.visible');
     cy.contains('Deprecated').scrollIntoView().should('be.visible');
+    cy.contains('[role="option"]', 'gpt-oss 120B').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').scrollIntoView().should('be.visible');
   });
 

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -156,12 +156,12 @@ describe('isModelDeprecated', () => {
     expect(isModelDeprecated(Model.MiniMax_M2_5)).toBe(true);
   });
 
-  it('returns false for non-deprecated model DeepSeek_R1', () => {
-    expect(isModelDeprecated(Model.DeepSeek_R1)).toBe(false);
+  it('returns true for deprecated model GptOss', () => {
+    expect(isModelDeprecated(Model.GptOss)).toBe(true);
   });
 
-  it('returns false for non-deprecated model GptOss', () => {
-    expect(isModelDeprecated(Model.GptOss)).toBe(false);
+  it('returns false for non-deprecated model DeepSeek_R1', () => {
+    expect(isModelDeprecated(Model.DeepSeek_R1)).toBe(false);
   });
 });
 
@@ -171,12 +171,12 @@ describe('isModelDeprecated', () => {
 describe('isModelMaintenance', () => {
   it('returns true for maintenance-mode models', () => {
     expect(isModelMaintenance(Model.DeepSeek_R1)).toBe(true);
-    expect(isModelMaintenance(Model.GptOss)).toBe(true);
   });
 
   it('keeps deprecated and default models out of maintenance mode', () => {
     expect(isModelMaintenance(Model.Llama3_3_70B)).toBe(false);
     expect(isModelMaintenance(Model.MiniMax_M2_5)).toBe(false);
+    expect(isModelMaintenance(Model.GptOss)).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -94,7 +94,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
-  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'maintenance' },
+  [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
     // Superseded by MiniMax M3, so it's deprecated (no longer actively benchmarked).


### PR DESCRIPTION
## Summary

- Recategorize `Model.GptOss` from `'maintenance'` to `'deprecated'` in `MODEL_CONFIG` (`packages/app/src/lib/data-mappings.ts`). This is the single source of truth, so the model-selector dropdown grouping, `DEPRECATED_MODELS`/`MAINTENANCE_MODELS` sets, and `isModelDeprecated`/`isModelMaintenance` all pick it up automatically.
- Update `data-mappings.test.ts` category assertions: gpt-oss now expects `isModelDeprecated → true` and is asserted out of maintenance mode alongside Llama 3.3 and MiniMax M2.5.
- Update the `dropdown-switching.cy.ts` e2e so gpt-oss is listed under the **Deprecated** dropdown group instead of **Maintenance Mode**.

No overlay-path changes needed — this is a category recategorization in the shared model registry, not a chart-data feature; official and `?unofficialrun=` overlay rendering paths are unaffected.

## Test plan

- `pnpm typecheck` passes
- `pnpm vitest run src/lib/data-mappings.test.ts` — 36/36 pass
- Pre-commit hook (lint / format / typecheck) passes

## 中文说明

- 在 `MODEL_CONFIG`（`packages/app/src/lib/data-mappings.ts`）中将 `Model.GptOss` 的类别从 `'maintenance'` 调整为 `'deprecated'`。该配置是模型元数据的唯一数据源，模型下拉选择器分组、`DEPRECATED_MODELS`/`MAINTENANCE_MODELS` 集合以及 `isModelDeprecated`/`isModelMaintenance` 判断均自动生效。
- 同步更新 `data-mappings.test.ts` 中的类别断言：gpt-oss 现在期望 `isModelDeprecated → true`，并与 Llama 3.3、MiniMax M2.5 一同断言不属于维护模式。
- 更新 `dropdown-switching.cy.ts` e2e 测试，使 gpt-oss 出现在下拉框的"已弃用"分组而非"维护模式"分组。

无需修改 overlay 路径——本次变更仅为共享模型注册表中的类别调整，不涉及图表数据功能，官方运行与 `?unofficialrun=` overlay 渲染路径均不受影响。

测试：`pnpm typecheck` 通过；`data-mappings` 单元测试 36/36 通过；pre-commit 钩子（lint / format / typecheck）通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only category change with no auth, data, or chart overlay logic touched.
> 
> **Overview**
> **gpt-oss 120B** is reclassified in `MODEL_CONFIG` from `maintenance` to `deprecated`, so it leaves the Maintenance Mode bucket and appears with other retired models in the inference model selector (via `DEPRECATED_MODELS` / `isModelDeprecated`).
> 
> Unit tests for `isModelDeprecated` and `isModelMaintenance` and the Cypress check that maintenance vs deprecated groups stay separate are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e26675b299078c57e270c464e24009ff4ec8b5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->