### PR TITLE
fix(api): support agentic-only runs in unofficial-run previews / 修复 agentic 专属 run 的非官方预览

### DIFF
--- a/packages/app/src/app/api/unofficial-run/route.test.ts
+++ b/packages/app/src/app/api/unofficial-run/route.test.ts
@@ -65,6 +65,20 @@ function rawRow(overrides: Record<string, unknown> = {}): Record<string, unknown
   };
 }
 
+/** Minimal valid agentic row: scenario_type triggers the agentic path; `users` → conc. */
+function rawAgenticRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    infmax_model_prefix: 'dsv4',
+    hw: 'mi355x-amds',
+    framework: 'vllm',
+    precision: 'fp4',
+    scenario_type: 'agentic-coding',
+    users: 72,
+    tput_per_gpu: 20000,
+    ...overrides,
+  };
+}
+
 function rawEvalRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {
     hw: 'gb300-nv',
@@ -435,6 +449,158 @@ describe('GET /api/unofficial-run', () => {
     expect(body.benchmarks[0].hardware).toBe('h200');
     expect(body.benchmarks[0].run_url).toBe('http://github.com/run/123');
     expect(body.evaluations).toEqual([]);
+  });
+
+  it('falls back to per-config bmk_* artifacts when results_bmk is missing (agentic-only sweeps)', async () => {
+    // Run metadata
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 777,
+          name: 'agentic-run',
+          head_branch: 'amd/agentx',
+          head_sha: 'ccc',
+          created_at: '2026-07-07T00:00:00Z',
+          html_url: 'http://github.com/run/777',
+          conclusion: 'success',
+          status: 'completed',
+        }),
+    });
+    // Artifacts: no results_bmk — only per-config agentic artifacts (plus the
+    // big sibling `agentic_*` trace blobs the route must NOT download).
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          artifacts: [
+            { name: 'bmk_agentic_dsv4_conc72', id: 30, archive_download_url: 'http://dl-a' },
+            { name: 'bmk_agentic_dsv4_conc56', id: 31, archive_download_url: 'http://dl-b' },
+            { name: 'agentic_dsv4_conc72', id: 32, archive_download_url: 'http://dl-blob' },
+            { name: 'server_logs_dsv4_conc72', id: 33, archive_download_url: 'http://dl-log' },
+          ],
+        }),
+    });
+    // Two per-config downloads (Promise.all order matches artifact order)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
+    mockGetEntries
+      .mockReturnValueOnce([
+        {
+          entryName: 'dsv4_conc72.json',
+          getData: () => Buffer.from(JSON.stringify(rawAgenticRow())),
+        },
+      ])
+      .mockReturnValueOnce([
+        {
+          entryName: 'dsv4_conc56.json',
+          getData: () => Buffer.from(JSON.stringify(rawAgenticRow({ users: 56 }))),
+        },
+      ]);
+
+    const res = await GET(makeRequest('runId=777'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.benchmarks).toHaveLength(2);
+    expect(
+      body.benchmarks
+        .map((b: { conc: number }) => b.conc)
+        .toSorted((a: number, b: number) => a - b),
+    ).toEqual([56, 72]);
+    expect(body.benchmarks[0].benchmark_type).toBe('agentic_traces');
+    expect(body.benchmarks[0].hardware).toBe('mi355x');
+    expect(body.benchmarks[0].run_url).toBe('http://github.com/run/777');
+    // Only the two bmk_* artifacts were downloaded: run + artifacts + 2 downloads.
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not download per-config bmk_* artifacts when results_bmk exists', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 888,
+          head_branch: 'main',
+          html_url: 'http://github.com/run/888',
+          created_at: '2026-07-07T00:00:00Z',
+        }),
+    });
+    // Merged artifact alongside per-config ones (mixed fixed-seq + agentic
+    // sweep) — the merged artifact already contains the per-config rows.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          artifacts: [
+            { name: 'results_bmk', id: 40, archive_download_url: 'http://dl-merged' },
+            { name: 'bmk_agentic_dsv4_conc72', id: 41, archive_download_url: 'http://dl-a' },
+          ],
+        }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
+    mockGetEntries.mockReturnValueOnce([
+      {
+        entryName: 'agg_bmk.json',
+        getData: () => Buffer.from(JSON.stringify([rawRow(), rawAgenticRow()])),
+      },
+    ]);
+
+    const res = await GET(makeRequest('runId=888'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.benchmarks).toHaveLength(2);
+    // Exactly one download (the merged artifact) — per-config was skipped.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps only the newest per-config artifact when names repeat', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 999,
+          head_branch: 'feature/agentic',
+          html_url: 'http://github.com/run/999',
+          created_at: '2026-07-07T00:00:00Z',
+        }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          artifacts: [
+            { name: 'bmk_agentic_dsv4_conc72', id: 50, archive_download_url: 'http://dl-old' },
+            { name: 'bmk_agentic_dsv4_conc72', id: 51, archive_download_url: 'http://dl-new' },
+          ],
+        }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+    });
+    mockGetEntries.mockReturnValueOnce([
+      {
+        entryName: 'dsv4_conc72.json',
+        getData: () => Buffer.from(JSON.stringify(rawAgenticRow())),
+      },
+    ]);
+
+    const res = await GET(makeRequest('runId=999'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.benchmarks).toHaveLength(1);
+    // Three fetches total; the single download hit the newest artifact URL.
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch.mock.calls[2][0]).toBe('http://dl-new');
   });
 
   it('returns evaluations for eval-only runs', async () => {

--- a/packages/app/src/app/api/unofficial-run/route.ts
+++ b/packages/app/src/app/api/unofficial-run/route.ts
@@ -17,8 +17,16 @@ import {
   getGithubToken,
   getRunDate,
   normalizeGithubRunInfo,
+  type GithubArtifact,
   type GithubWorkflowRun,
 } from '@/lib/github-artifacts';
+
+/**
+ * Batch size for downloading per-config `bmk_*` artifacts. Big agentic sweeps
+ * upload one artifact per config (dozens per run); a bounded batch keeps us
+ * clear of GitHub's secondary rate limits while still parallelizing.
+ */
+const PER_CONFIG_DOWNLOAD_BATCH_SIZE = 8;
 
 /** Normalize raw artifact rows into the BenchmarkRow shape the frontend expects. */
 export function normalizeArtifactRows(
@@ -234,11 +242,32 @@ async function processSingleRun(
     .filter((a) => a.name === 'eval_results_all')
     .toSorted((a, b) => b.id - a.id)[0];
 
-  if (!bmkArtifact && !evalArtifact) {
+  // Agentic-only sweeps never run the collect-results merge job (run-sweep.yml
+  // only triggers it for fixed-seq sweeps), so they upload per-config
+  // `bmk_agentic_<config>` artifacts with no merged `results_bmk`. Fall back to
+  // downloading those directly. When `results_bmk` exists it already contains
+  // every `bmk_*` row (the merge job downloads the `bmk_*` pattern), so the
+  // fallback must stay off in that case — running both would double-count.
+  // Same-name re-uploads keep only the newest (highest id), mirroring the
+  // merged-artifact selection above.
+  const perConfigBmkArtifacts: GithubArtifact[] = bmkArtifact
+    ? []
+    : [
+        ...artifacts
+          .filter((a) => a.name.startsWith('bmk_'))
+          .reduce((byName, a) => {
+            const prev = byName.get(a.name);
+            if (!prev || a.id > prev.id) byName.set(a.name, a);
+            return byName;
+          }, new Map<string, GithubArtifact>())
+          .values(),
+      ];
+
+  if (!bmkArtifact && perConfigBmkArtifacts.length === 0 && !evalArtifact) {
     return {
       errorResponse: NextResponse.json(
         {
-          error: `No results_bmk or eval_results_all artifact found for runId ${runId}`,
+          error: `No results_bmk, per-config bmk_*, or eval_results_all artifact found for runId ${runId}`,
         },
         { status: 404 },
       ),
@@ -259,6 +288,19 @@ async function processSingleRun(
     );
     if (errorResponse) return { errorResponse };
     benchmarks = normalizeArtifactRows(rows, date, runUrl || null);
+  } else if (perConfigBmkArtifacts.length > 0) {
+    const rawRows: Record<string, unknown>[] = [];
+    for (let i = 0; i < perConfigBmkArtifacts.length; i += PER_CONFIG_DOWNLOAD_BATCH_SIZE) {
+      const batch = perConfigBmkArtifacts.slice(i, i + PER_CONFIG_DOWNLOAD_BATCH_SIZE);
+      const results = await Promise.all(
+        batch.map((a) => downloadArtifactRows(a.archive_download_url, githubToken)),
+      );
+      for (const result of results) {
+        if (result.errorResponse) return { errorResponse: result.errorResponse };
+        rawRows.push(...result.rows);
+      }
+    }
+    benchmarks = normalizeArtifactRows(rawRows, date, runUrl || null);
   }
 
   if (evalArtifact) {


### PR DESCRIPTION
## Summary

`?unofficialrun=<run-id>` chart overlay previews returned **404 for agentic-only sweeps**. Root cause: the benchmark repo's `run-sweep.yml` only triggers the `collect-results` merge job for fixed-seq (1k1k / 8k1k) sweeps, so agentic-only runs upload per-config `bmk_agentic_<config>` artifacts and never produce the merged `results_bmk` artifact that `/api/unofficial-run` exclusively looked for.

- When `results_bmk` is absent, the route now falls back to downloading every per-config `bmk_*` artifact (same-name re-uploads deduped, newest artifact id wins) and normalizes their rows through the existing `mapBenchmarkRow` path — which already handles agentic v2-flat/v3-nested agg schemas.
- The fallback stays **off** when `results_bmk` exists: the merge job downloads the `bmk_*` pattern, so the merged artifact already contains every per-config row and fetching both would double-count.
- Per-config downloads run in bounded batches of 8 to stay clear of GitHub secondary rate limits (big agentic sweeps upload dozens of artifacts).
- 404 error message now mentions the per-config `bmk_*` fallback.

No frontend changes were needed — the overlay pipeline (`buildChartData` → `transformBenchmarkRows` → `applyAgenticMetricAliases`, `processOverlayChartData` with `isAgentic`, legend/points-dialog/dismiss paths) already supports agentic rows; it just never received any.

## Overlay support

This IS the overlay path — verified manually against a real agentic run from [InferenceX PR #2109](https://github.com/SemiAnalysisAI/InferenceX/pull/2109): loaded `/inference?unofficialrun=28861274175` (DSv4 FP4 MI355X vLLM agentic sweep, kvnone + LMCache offload variants) on a local dev server and confirmed:

- NON-OFFICIAL banner shows the run's branch (`amd/agentx_dsv4_vllm`) with working dismiss
- Model auto-switches to DeepSeek V4 Pro, scenario **Agentic Traces**, latency-percentile selector active
- All 5 overlay points (conc 32/40/40/56/72, offload ON/OFF split) render as ✕ markers on both the Interactivity and E2E Latency charts alongside official series
- Legend entry with hide toggle + "show all data points" dialog lists the overlay rows with correct conc / parallelism / offload / tput / p50–p90 values matching the raw artifacts

## Test plan

- [x] 3 new route tests: per-config `bmk_*` fallback (agentic rows, correct conc mapping, sibling `agentic_*`/`server_logs_*` blobs NOT downloaded), fallback disabled when `results_bmk` exists, same-name dedupe keeps newest artifact
- [x] `pnpm test:unit` — 2539 app + 25 mcp tests pass
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm fmt` clean
- [x] Manual verification against live run 28861274175 (screenshots above description; API returns 5 agentic benchmark rows)

## 中文说明

`?unofficialrun=<run-id>` 图表叠加预览对 agentic 专属 sweep 一直返回 404。根本原因：基准测试仓库的 `run-sweep.yml` 仅在固定序列（1k1k / 8k1k）sweep 时触发 `collect-results` 合并任务，因此 agentic 专属 run 只上传按配置拆分的 `bmk_agentic_<config>` 产物，从不生成 `/api/unofficial-run` 唯一查找的合并产物 `results_bmk`。

- 当 `results_bmk` 缺失时，路由现在回退为下载所有按配置拆分的 `bmk_*` 产物（同名重复上传按最新 id 去重），并通过现有的 `mapBenchmarkRow` 路径归一化（该路径已支持 agentic v2 扁平 / v3 嵌套 agg schema）。
- `results_bmk` 存在时**不启用**回退：合并任务本身就下载 `bmk_*` 模式，合并产物已包含全部按配置行，两者都取会重复计数。
- 按配置产物以每批 8 个的有界批次下载，避免触发 GitHub 二级速率限制。
- 前端无需改动——叠加渲染管线已支持 agentic 行，此前只是拿不到数据。

已用 [InferenceX PR #2109](https://github.com/SemiAnalysisAI/InferenceX/pull/2109) 的真实 agentic run（28861274175，DSv4 FP4 MI355X vLLM）在本地手动验证：NON-OFFICIAL 横幅、模型自动切换、Agentic Traces 场景、5 个叠加点在 Interactivity 与 E2E Latency 图表上均正确渲染，图例开关与数据点弹窗数值与原始产物一致。单元测试（2539 + 25）、typecheck、lint、fmt 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds many parallel GitHub artifact downloads and changes benchmark resolution for a live API path, but behavior is gated on missing `results_bmk` and covered by new tests.
> 
> **Overview**
> Fixes **404 on `?unofficialrun=`** for agentic-only CI sweeps that never upload merged `results_bmk`.
> 
> When `results_bmk` is missing, `/api/unofficial-run` now collects **`bmk_*` per-config artifacts** (deduped by name, highest artifact id wins), downloads them in **batches of 8**, and normalizes rows through the existing mapper. The fallback is **skipped** if `results_bmk` is present to avoid double-counting. Non-`bmk_*` siblings (e.g. `agentic_*` trace blobs) are not fetched.
> 
> 404 copy now mentions the per-config fallback. **Three route tests** cover fallback behavior, merged-artifact precedence, and dedupe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274fc595b02a2dc015526e56bc3e96e5180032d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->