### PR TITLE
[codex] Ingest reused artifacts directly

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -206,6 +206,7 @@ jobs:
                       .name == "results_bmk" or
                       .name == "eval_results_all" or
                       .name == "run-stats" or
+                      .name == "reused-ingest-artifacts" or
                       (.name | startswith("bmk_")) or
                       (.name | startswith("eval_")) or
                       (.name | startswith("agentic_")) or

--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -31,9 +31,31 @@ on:
         required: true
         type: string
       run-attempt:
-        description: InferenceX Actions run attempt to ingest
+        description: Source InferenceX Actions run attempt to ingest
         required: false
         default: '1'
+        type: string
+      ingest-run-id:
+        description: Merge run ID that triggered a reused ingest
+        required: false
+        type: string
+      ingest-run-attempt:
+        description: Merge run attempt that triggered a reused ingest
+        required: false
+        default: '1'
+        type: string
+      source-pr-number:
+        description: PR number that produced reused artifacts
+        required: false
+        type: string
+      source-head-sha:
+        description: Commit that produced reused artifacts
+        required: false
+        type: string
+      validation-ref:
+        description: InferenceX ref containing the reuse validator
+        required: false
+        default: main
         type: string
       database-target:
         description: Database/cache target for the ingest
@@ -50,7 +72,7 @@ jobs:
     # Blob-heavy: uploading trace-replay sidecars for a ~20-point sweep takes
     # far longer than a fixed-seq-len ingest.
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:
@@ -59,6 +81,34 @@ jobs:
         run: sleep 300
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve source and ingest runs
+        id: runs
+        env:
+          SOURCE_RUN_ID: ${{ github.event.client_payload.run-id || inputs.run-id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.client_payload.run-attempt || inputs.run-attempt || '1' }}
+          INGEST_RUN_ID: ${{ github.event.client_payload.ingest-run-id || inputs.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ github.event.client_payload.ingest-run-attempt || inputs.ingest-run-attempt || '1' }}
+        run: |
+          ingest_run_id="${INGEST_RUN_ID:-$SOURCE_RUN_ID}"
+          if [ -n "$INGEST_RUN_ID" ]; then
+            ingest_run_attempt="$INGEST_RUN_ATTEMPT"
+          else
+            ingest_run_attempt="$SOURCE_RUN_ATTEMPT"
+          fi
+
+          {
+            echo "source-run-id=$SOURCE_RUN_ID"
+            echo "source-run-attempt=$SOURCE_RUN_ATTEMPT"
+            echo "ingest-run-id=$ingest_run_id"
+            echo "ingest-run-attempt=$ingest_run_attempt"
+            if [ "$SOURCE_RUN_ID" != "$ingest_run_id" ]; then
+              echo "reused=true"
+            else
+              echo "reused=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -113,42 +163,79 @@ jobs:
       - name: Download artifacts from InferenceX run
         env:
           GH_TOKEN: ${{ secrets.INFX_MAIN_PAT }}
-          RUN_ID: ${{ github.event.client_payload.run-id || inputs.run-id }}
+          SOURCE_RUN_ID: ${{ steps.runs.outputs.source-run-id }}
+          METADATA_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
           ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
         run: |
           mkdir -p "$ARTIFACTS_PATH"
 
-          # Download all artifacts for the run, deduplicated by name (keep latest).
-          gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${RUN_ID}/artifacts" --paginate \
+          download_artifact() {
+            local name="$1"
+            local url="$2"
+            local ok=false
+
+            echo "Downloading artifact: ${name}"
+            for attempt in 1 2 3; do
+              if gh api "${url}" > "$RUNNER_TEMP/artifact.zip"; then
+                ok=true
+                break
+              fi
+              echo "  Attempt ${attempt}/3 failed, retrying in ${attempt}s..."
+              sleep "$attempt"
+            done
+            if [ "$ok" = false ]; then
+              rm -f "$RUNNER_TEMP/artifact.zip"
+              return 1
+            fi
+
+            mkdir -p "${ARTIFACTS_PATH}/${name}"
+            if ! unzip -o "$RUNNER_TEMP/artifact.zip" -d "${ARTIFACTS_PATH}/${name}"; then
+              rm -rf "${ARTIFACTS_PATH:?}/${name}"
+              rm -f "$RUNNER_TEMP/artifact.zip"
+              return 1
+            fi
+            rm -f "$RUNNER_TEMP/artifact.zip"
+          }
+
+          # Select ingest artifacts before downloading. Retried runner jobs use
+          # different suffixes, so keep only the newest artifact per logical job.
+          gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100" --paginate --slurp \
             | jq -r '
-                [.artifacts[]]
-                | group_by(.name) | map(sort_by(.created_at) | last)[]
+                [.[].artifacts[]
+                  | select(
+                      .name == "results_bmk" or
+                      .name == "eval_results_all" or
+                      .name == "run-stats" or
+                      (.name | startswith("bmk_")) or
+                      (.name | startswith("eval_")) or
+                      (.name | startswith("agentic_")) or
+                      (.name | startswith("server_logs_")) or
+                      (.name | startswith("multinode_server_logs_"))
+                    )
+                  | . + {logical_name: (.name | sub("_[A-Za-z][A-Za-z0-9.-]*_[0-9]+$"; ""))}
+                ]
+                | group_by(.logical_name) | map(sort_by(.created_at) | last)[]
                 | "\(.name)\t\(.archive_download_url)"' \
             | while IFS=$'\t' read -r name url; do
-                echo "Downloading artifact: ${name}"
-                ok=false
-                for attempt in 1 2 3; do
-                  if gh api "${url}" > artifact.zip; then
-                    ok=true
-                    break
-                  fi
-                  echo "  Attempt ${attempt}/3 failed, retrying in ${attempt}s..."
-                  sleep "$attempt"
-                done
-                if [ "$ok" = false ]; then
+                if ! download_artifact "$name" "$url"; then
                   echo "::warning::Failed to download artifact after 3 attempts: ${name} — skipping"
-                  rm -f artifact.zip
-                  echo "$name" >> "$ARTIFACTS_PATH/.failures"
-                  continue
-                fi
-                mkdir -p "${ARTIFACTS_PATH}/${name}"
-                if ! unzip -o artifact.zip -d "${ARTIFACTS_PATH}/${name}"; then
-                  echo "::warning::Failed to extract artifact: ${name} — skipping"
-                  rm -rf "${ARTIFACTS_PATH:?}/${name}"
                   echo "$name" >> "$ARTIFACTS_PATH/.failures"
                 fi
-                rm -f artifact.zip
               done
+
+          # Changelog metadata belongs to the merge run, while benchmark rows
+          # and public links continue to point at the source PR sweep.
+          changelog=$(gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${METADATA_RUN_ID}/artifacts?per_page=100" --paginate --slurp \
+            | jq -r '[.[].artifacts[] | select(.name == "changelog-metadata")] | sort_by(.created_at) | last | "\(.name)\t\(.archive_download_url)"')
+          if [ -z "$changelog" ] || [ "$changelog" = $'null\tnull' ]; then
+            echo "::error::No changelog-metadata artifact found on run ${METADATA_RUN_ID}"
+            exit 1
+          fi
+          IFS=$'\t' read -r changelog_name changelog_url <<< "$changelog"
+          if ! download_artifact "$changelog_name" "$changelog_url"; then
+            echo "::error::Failed to download changelog metadata from run ${METADATA_RUN_ID}"
+            exit 1
+          fi
 
           if [ -f "$ARTIFACTS_PATH/.failures" ]; then
             count=$(wc -l < "$ARTIFACTS_PATH/.failures")
@@ -160,15 +247,62 @@ jobs:
           ls "$ARTIFACTS_PATH/"
 
           if [ -z "$(ls -A "$ARTIFACTS_PATH")" ]; then
-            echo "::error::No artifacts could be downloaded from run ${RUN_ID}"
+            echo "::error::No artifacts could be downloaded from run ${SOURCE_RUN_ID}"
             exit 1
           fi
+
+      - name: Record reused source run
+        if: steps.runs.outputs.reused == 'true'
+        env:
+          SOURCE_RUN_ID: ${{ steps.runs.outputs.source-run-id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.runs.outputs.source-run-attempt }}
+          INGEST_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ steps.runs.outputs.ingest-run-attempt }}
+          SOURCE_PR_NUMBER: ${{ github.event.client_payload.source-pr-number || inputs.source-pr-number }}
+          SOURCE_HEAD_SHA: ${{ github.event.client_payload.source-head-sha || inputs.source-head-sha }}
+          ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+        run: |
+          mkdir -p "$ARTIFACTS_PATH/reused-ingest-metadata"
+          jq -n \
+            --arg source_run_id "$SOURCE_RUN_ID" \
+            --arg source_run_attempt "$SOURCE_RUN_ATTEMPT" \
+            --arg source_run_url "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/$SOURCE_RUN_ID" \
+            --arg source_pr_number "$SOURCE_PR_NUMBER" \
+            --arg source_head_sha "$SOURCE_HEAD_SHA" \
+            --arg ingest_run_id "$INGEST_RUN_ID" \
+            --arg ingest_run_attempt "$INGEST_RUN_ATTEMPT" \
+            --arg ingest_run_url "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/$INGEST_RUN_ID" \
+            '{
+              source_run_id: $source_run_id,
+              source_run_attempt: $source_run_attempt,
+              source_run_url: $source_run_url,
+              source_pr_number: $source_pr_number,
+              source_head_sha: $source_head_sha,
+              ingest_run_id: $ingest_run_id,
+              ingest_run_attempt: $ingest_run_attempt,
+              ingest_run_url: $ingest_run_url
+            }' > "$ARTIFACTS_PATH/reused-ingest-metadata/reuse_source_run.json"
+
+      - name: Checkout InferenceX validator
+        if: steps.runs.outputs.reused == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: SemiAnalysisAI/InferenceX
+          ref: ${{ github.event.client_payload.validation-ref || inputs.validation-ref || 'main' }}
+          token: ${{ secrets.INFX_MAIN_PAT }}
+          path: inferencex-source
+
+      - name: Validate reusable artifacts
+        if: steps.runs.outputs.reused == 'true'
+        run: |
+          python3 inferencex-source/utils/validate_reusable_sweep_artifacts.py \
+            --artifacts-dir "${{ github.workspace }}/artifacts"
 
       - name: Ingest results to DB
         env:
           GITHUB_TOKEN: ${{ secrets.INFX_MAIN_PAT }}
-          INGEST_RUN_ID: ${{ github.event.client_payload.run-id || inputs.run-id }}
-          INGEST_RUN_ATTEMPT: ${{ github.event.client_payload.run-attempt || inputs.run-attempt }}
+          INGEST_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ steps.runs.outputs.ingest-run-attempt }}
           INGEST_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
           INGEST_REPO: SemiAnalysisAI/InferenceX
           UNMAPPED_ENTITIES_OUTPUT: ${{ github.workspace }}/unmapped-entities.json

--- a/.github/workflows/ingest-results.yml
+++ b/.github/workflows/ingest-results.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ingest:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -15,6 +15,34 @@ jobs:
         run: sleep 300
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Resolve source and ingest runs
+        id: runs
+        env:
+          SOURCE_RUN_ID: ${{ github.event.client_payload.run-id }}
+          SOURCE_RUN_ATTEMPT: ${{ github.event.client_payload.run-attempt || '1' }}
+          INGEST_RUN_ID: ${{ github.event.client_payload.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ github.event.client_payload.ingest-run-attempt || '1' }}
+        run: |
+          ingest_run_id="${INGEST_RUN_ID:-$SOURCE_RUN_ID}"
+          if [ -n "$INGEST_RUN_ID" ]; then
+            ingest_run_attempt="$INGEST_RUN_ATTEMPT"
+          else
+            ingest_run_attempt="$SOURCE_RUN_ATTEMPT"
+          fi
+
+          {
+            echo "source-run-id=$SOURCE_RUN_ID"
+            echo "source-run-attempt=$SOURCE_RUN_ATTEMPT"
+            echo "ingest-run-id=$ingest_run_id"
+            echo "ingest-run-attempt=$ingest_run_attempt"
+            if [ "$SOURCE_RUN_ID" != "$ingest_run_id" ]; then
+              echo "reused=true"
+            else
+              echo "reused=false"
+            fi
+          } >> "$GITHUB_OUTPUT"
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -33,42 +61,80 @@ jobs:
       - name: Download artifacts from InferenceX run
         env:
           GH_TOKEN: ${{ secrets.INFX_MAIN_PAT }}
-          RUN_ID: ${{ github.event.client_payload.run-id }}
+          SOURCE_RUN_ID: ${{ steps.runs.outputs.source-run-id }}
+          METADATA_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
           ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
         run: |
           mkdir -p "$ARTIFACTS_PATH"
 
-          # Download all artifacts for the run, deduplicated by name (keep latest).
-          gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${RUN_ID}/artifacts" --paginate \
+          download_artifact() {
+            local name="$1"
+            local url="$2"
+            local ok=false
+
+            echo "Downloading artifact: ${name}"
+            for attempt in 1 2 3; do
+              if gh api "${url}" > "$RUNNER_TEMP/artifact.zip"; then
+                ok=true
+                break
+              fi
+              echo "  Attempt ${attempt}/3 failed, retrying in ${attempt}s..."
+              sleep "$attempt"
+            done
+            if [ "$ok" = false ]; then
+              rm -f "$RUNNER_TEMP/artifact.zip"
+              return 1
+            fi
+
+            mkdir -p "${ARTIFACTS_PATH}/${name}"
+            if ! unzip -o "$RUNNER_TEMP/artifact.zip" -d "${ARTIFACTS_PATH}/${name}"; then
+              rm -rf "${ARTIFACTS_PATH:?}/${name}"
+              rm -f "$RUNNER_TEMP/artifact.zip"
+              return 1
+            fi
+            rm -f "$RUNNER_TEMP/artifact.zip"
+          }
+
+          # Select ingest artifacts before downloading. Retried runner jobs use
+          # different suffixes, so keep only the newest artifact per logical job.
+          gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${SOURCE_RUN_ID}/artifacts?per_page=100" --paginate --slurp \
             | jq -r '
-                [.artifacts[]]
-                | group_by(.name) | map(sort_by(.created_at) | last)[]
+                [.[].artifacts[]
+                  | select(
+                      .name == "results_bmk" or
+                      .name == "eval_results_all" or
+                      .name == "run-stats" or
+                      .name == "reused-ingest-artifacts" or
+                      (.name | startswith("bmk_")) or
+                      (.name | startswith("eval_")) or
+                      (.name | startswith("agentic_")) or
+                      (.name | startswith("server_logs_")) or
+                      (.name | startswith("multinode_server_logs_"))
+                    )
+                  | . + {logical_name: (.name | sub("_[A-Za-z][A-Za-z0-9.-]*_[0-9]+$"; ""))}
+                ]
+                | group_by(.logical_name) | map(sort_by(.created_at) | last)[]
                 | "\(.name)\t\(.archive_download_url)"' \
             | while IFS=$'\t' read -r name url; do
-                echo "Downloading artifact: ${name}"
-                ok=false
-                for attempt in 1 2 3; do
-                  if gh api "${url}" > artifact.zip; then
-                    ok=true
-                    break
-                  fi
-                  echo "  Attempt ${attempt}/3 failed, retrying in ${attempt}s..."
-                  sleep "$attempt"
-                done
-                if [ "$ok" = false ]; then
+                if ! download_artifact "$name" "$url"; then
                   echo "::warning::Failed to download artifact after 3 attempts: ${name} — skipping"
-                  rm -f artifact.zip
-                  echo "$name" >> "$ARTIFACTS_PATH/.failures"
-                  continue
-                fi
-                mkdir -p "${ARTIFACTS_PATH}/${name}"
-                if ! unzip -o artifact.zip -d "${ARTIFACTS_PATH}/${name}"; then
-                  echo "::warning::Failed to extract artifact: ${name} — skipping"
-                  rm -rf "${ARTIFACTS_PATH:?}/${name}"
                   echo "$name" >> "$ARTIFACTS_PATH/.failures"
                 fi
-                rm -f artifact.zip
               done
+
+          # Changelog metadata belongs to the merge run, while benchmark rows
+          # and public links continue to point at the source PR sweep.
+          changelog=$(gh api "repos/SemiAnalysisAI/InferenceX/actions/runs/${METADATA_RUN_ID}/artifacts?per_page=100" --paginate --slurp \
+            | jq -r '[.[].artifacts[] | select(.name == "changelog-metadata")] | sort_by(.created_at) | last | "\(.name)\t\(.archive_download_url)"')
+          if [ -z "$changelog" ] || [ "$changelog" = $'null\tnull' ]; then
+            echo "::error::No changelog-metadata artifact found on run ${METADATA_RUN_ID}"
+            exit 1
+          fi
+          IFS=$'\t' read -r changelog_name changelog_url <<< "$changelog"
+          if ! download_artifact "$changelog_name" "$changelog_url"; then
+            echo "::error::Failed to download changelog metadata from run ${METADATA_RUN_ID}"
+            exit 1
+          fi
 
           if [ -f "$ARTIFACTS_PATH/.failures" ]; then
             count=$(wc -l < "$ARTIFACTS_PATH/.failures")
@@ -80,7 +146,7 @@ jobs:
           ls "$ARTIFACTS_PATH/"
 
           if [ -z "$(ls -A "$ARTIFACTS_PATH")" ]; then
-            echo "::error::No artifacts could be downloaded from run ${RUN_ID}"
+            echo "::error::No artifacts could be downloaded from run ${SOURCE_RUN_ID}"
             exit 1
           fi
 
@@ -112,12 +178,59 @@ jobs:
           echo "Artifacts after flattening:"
           ls "$ARTIFACTS_PATH/"
 
+      - name: Record reused source run
+        if: steps.runs.outputs.reused == 'true'
+        env:
+          SOURCE_RUN_ID: ${{ steps.runs.outputs.source-run-id }}
+          SOURCE_RUN_ATTEMPT: ${{ steps.runs.outputs.source-run-attempt }}
+          INGEST_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ steps.runs.outputs.ingest-run-attempt }}
+          SOURCE_PR_NUMBER: ${{ github.event.client_payload.source-pr-number }}
+          SOURCE_HEAD_SHA: ${{ github.event.client_payload.source-head-sha }}
+          ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+        run: |
+          mkdir -p "$ARTIFACTS_PATH/reused-ingest-metadata"
+          jq -n \
+            --arg source_run_id "$SOURCE_RUN_ID" \
+            --arg source_run_attempt "$SOURCE_RUN_ATTEMPT" \
+            --arg source_run_url "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/$SOURCE_RUN_ID" \
+            --arg source_pr_number "$SOURCE_PR_NUMBER" \
+            --arg source_head_sha "$SOURCE_HEAD_SHA" \
+            --arg ingest_run_id "$INGEST_RUN_ID" \
+            --arg ingest_run_attempt "$INGEST_RUN_ATTEMPT" \
+            --arg ingest_run_url "https://github.com/SemiAnalysisAI/InferenceX/actions/runs/$INGEST_RUN_ID" \
+            '{
+              source_run_id: $source_run_id,
+              source_run_attempt: $source_run_attempt,
+              source_run_url: $source_run_url,
+              source_pr_number: $source_pr_number,
+              source_head_sha: $source_head_sha,
+              ingest_run_id: $ingest_run_id,
+              ingest_run_attempt: $ingest_run_attempt,
+              ingest_run_url: $ingest_run_url
+            }' > "$ARTIFACTS_PATH/reused-ingest-metadata/reuse_source_run.json"
+
+      - name: Checkout InferenceX validator
+        if: steps.runs.outputs.reused == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: SemiAnalysisAI/InferenceX
+          ref: ${{ github.event.client_payload.validation-ref || 'main' }}
+          token: ${{ secrets.INFX_MAIN_PAT }}
+          path: inferencex-source
+
+      - name: Validate reusable artifacts
+        if: steps.runs.outputs.reused == 'true'
+        run: |
+          python3 inferencex-source/utils/validate_reusable_sweep_artifacts.py \
+            --artifacts-dir "${{ github.workspace }}/artifacts"
+
       - name: Ingest results to DB
         env:
           DATABASE_WRITE_URL: ${{ secrets.DATABASE_WRITE_URL }}
           GITHUB_TOKEN: ${{ secrets.INFX_MAIN_PAT }}
-          INGEST_RUN_ID: ${{ github.event.client_payload.run-id }}
-          INGEST_RUN_ATTEMPT: ${{ github.event.client_payload.run-attempt }}
+          INGEST_RUN_ID: ${{ steps.runs.outputs.ingest-run-id }}
+          INGEST_RUN_ATTEMPT: ${{ steps.runs.outputs.ingest-run-attempt }}
           INGEST_ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
           INGEST_REPO: SemiAnalysisAI/InferenceX
           UNMAPPED_ENTITIES_OUTPUT: ${{ github.workspace }}/unmapped-entities.json


### PR DESCRIPTION
## Summary

Download reused fixed-sequence, eval, and agentic artifacts directly from the source sweep instead of copying them through the merge run.

Validation now happens in the production or AgentX ingest job. Source-run links and merge-run changelog metadata are preserved, and older bundled reuse runs remain supported.

Companion InferenceX PR: https://github.com/SemiAnalysisAI/InferenceX/pull/2133

## Validation

- `actionlint .github/workflows/ingest-results.yml .github/workflows/ingest-agentic-results.yml`
- Verified fixed-sequence run `28999997980` selects 80 latest ingest artifacts and its changelog metadata
- Verified agentic run `28955639528` selects 201 latest ingest artifacts
- Verified the existing bundled reuse path remains in the allowlist
