### PR TITLE
[codex] Run AgentX ingest on Blacksmith

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -50,7 +50,7 @@ jobs:
     # Blob-heavy: uploading trace-replay sidecars for a ~20-point sweep takes
     # far longer than a fixed-seq-len ingest.
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Run the AgentX ingestion workflow on the Blacksmith 4-vCPU runner so its 80 GB disk can hold the extracted trace artifacts.

No ingestion logic changes.

## Validation

- `actionlint .github/workflows/ingest-agentic-results.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the GitHub Actions runner label changes; ingestion and database behavior are untouched, with minor operational risk if the Blacksmith runner is unavailable or misconfigured.
> 
> **Overview**
> Switches the **AgentX ingest** job in `ingest-agentic-results.yml` from `ubuntu-latest` to **`blacksmith-4vcpu-ubuntu-2404`**, so blob-heavy trace-replay artifact download/extract runs on a runner with more disk (per PR intent: ~80 GB). **No changes** to ingest steps, scripts, secrets, or timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a17f058c480ce0485396b608655668754919eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->