### PR TITLE
Merge master into feat/agentx for Blacksmith ingest

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -50,7 +50,7 @@ jobs:
     # Blob-heavy: uploading trace-replay sidecars for a ~20-point sweep takes
     # far longer than a fixed-seq-len ingest.
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

Merge `master` into `feat/agentx` so the AgentX ingestion workflow uses the Blacksmith runner from #540.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow runner label swap with no changes to ingest logic, credentials, or database behavior.
> 
> **Overview**
> The **Ingest Agentic Benchmark Results** workflow’s `ingest` job now runs on **`blacksmith-4vcpu-ubuntu-2404`** instead of **`ubuntu-latest`**, matching the Blacksmith runner pattern used elsewhere (e.g. e2e tests, db backup).
> 
> Ingest steps, secrets, timeouts, and alerting are unchanged; only the GitHub Actions runner label changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeae4520f9802c5348bcba965b0e0e8b0788bfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->