### PR TITLE
Extend agentic ingest timeout

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -49,7 +49,9 @@ jobs:
   ingest:
     # Blob-heavy: uploading trace-replay sidecars for a ~20-point sweep takes
     # far longer than a fixed-seq-len ingest.
-    timeout-minutes: 60
+    # Large recovered sweeps can spend ~20m extracting artifacts and ~40m
+    # ingesting trace-replay sidecars, so one hour is not enough.
+    timeout-minutes: 180
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
The recovered AgentX ingest reached 63/67 configs and was cancelled by the workflow’s 60-minute timeout.

This extends the timeout to three hours. The ingest is idempotent, so the recovery rerun can skip already-linked traces and finish verification/cache invalidation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes CI job duration and comments; no application, auth, or data-path logic is modified.
> 
> **Overview**
> Raises the **`ingest` job timeout** in `ingest-agentic-results.yml` from **60 to 180 minutes** so large AgentX trace-replay sweeps can finish artifact extraction and sidecar uploads without GitHub Actions cancelling the run mid-ingest.
> 
> Adds a short comment noting that recovered sweeps can take on the order of ~20m on extraction and ~40m on trace-replay sidecars, which exceeded the previous one-hour cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4e9ab1c041646df5dd6dd58d6020769df2cd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->