### PR TITLE
fix(changelog): use legend framework labels for updated-config entries / 修复 changelog 下拉框 Updated Configs 使用与图例一致的框架名映射

### DIFF
--- a/packages/app/src/components/inference/utils/changelogFormatters.test.ts
+++ b/packages/app/src/components/inference/utils/changelogFormatters.test.ts
@@ -43,6 +43,26 @@ describe('formatConfigKeys', () => {
     expect(result).toContain('TRTLLM');
     expect(result).toContain('FP4');
   });
+
+  it('uses the legend framework label for keys with trailing descriptors', () => {
+    expect(formatConfigKeys('dsv4-fp4-b200-sglang-agentic-hicache')).toBe(
+      'B200 (SGLang, Agentic, Hicache) DeepSeek-V4-Pro FP4',
+    );
+  });
+
+  it('keeps multi-token frameworks intact ahead of descriptors', () => {
+    const result = formatConfigKeys('dsv4-fp4-gb200-llmd-vllm-agentic');
+    expect(result).toContain('llm-d vLLM');
+    expect(result).toContain('Agentic');
+    expect(result).not.toContain('LLMD');
+  });
+
+  it('still renders M3 mtp as EAGLE after a descriptor split', () => {
+    const result = formatConfigKeys('minimaxm3-fp8-h100-vllm-agentic-mtp');
+    expect(result).toContain('vLLM');
+    expect(result).toContain('Agentic');
+    expect(result).toContain('EAGLE');
+  });
 });
 
 describe('configKeyMatchesHwKey', () => {

--- a/packages/app/src/components/inference/utils/changelogFormatters.tsx
+++ b/packages/app/src/components/inference/utils/changelogFormatters.tsx
@@ -1,4 +1,5 @@
 import {
+  FRAMEWORK_LABELS,
   resolveFrameworkAliasesInString,
   resolveFrameworkPartLabel,
 } from '@semianalysisai/inferencex-constants';
@@ -43,13 +44,28 @@ export function formatConfigKeys(key: string) {
   const model = parts[0];
   const precision = parts[1];
   const gpu = parts[2];
-  const framework = parts.slice(3).join('-');
-  // Strip -mtp suffix before lookup; MTP is shown separately
-  const isMtp = framework.endsWith('-mtp');
-  const baseFramework = isMtp ? framework.slice(0, -4) : framework;
-  const baseLabel = getFrameworkLabel(baseFramework);
-  // M3's `mtp` spec token renders as "EAGLE"; every other model keeps "MTP".
-  const mtpLabel = resolveFrameworkPartLabel(MODEL_PREFIX_MAPPING[model], 'mtp');
-  const frameworkLabel = isMtp ? `${baseLabel}, ${mtpLabel}` : baseLabel;
+  // Canonicalize legacy framework substrings first (sglang-disagg → mori-sglang, …)
+  // so the tail matches the same FRAMEWORK_LABELS mapping the legend uses.
+  const tokens = resolveFrameworkAliasesInString(parts.slice(3).join('-')).split('-');
+  // Config-key tails can carry extra descriptors after the framework
+  // (e.g. `sglang-agentic-hicache`), and frameworks themselves can be
+  // multi-token (`dynamo-sglang`, `llmd-vllm`). Greedy longest-prefix match
+  // against the known framework labels splits the two apart.
+  // No prefix match → treat the whole tail as the framework (legacy fallback).
+  let fwTokens = tokens.length;
+  for (let n = tokens.length; n >= 1; n--) {
+    if (FRAMEWORK_LABELS[tokens.slice(0, n).join('-')]) {
+      fwTokens = n;
+      break;
+    }
+  }
+  const baseLabel = getFrameworkLabel(tokens.slice(0, fwTokens).join('-'));
+  // Trailing descriptors keep their spec-method labels (M3's `mtp` renders as
+  // "EAGLE"); anything unknown is title-cased instead of shouted in caps.
+  const suffixLabels = tokens.slice(fwTokens).map((t) => {
+    if (t === 'mtp') return resolveFrameworkPartLabel(MODEL_PREFIX_MAPPING[model], 'mtp');
+    return FRAMEWORK_LABELS[t] ?? t.charAt(0).toUpperCase() + t.slice(1);
+  });
+  const frameworkLabel = [baseLabel, ...suffixLabels].join(', ');
   return `${gpu.toUpperCase()} (${frameworkLabel}) ${MODEL_PREFIX_MAPPING[model]} ${getPrecisionLabel(precision as Precision)}`;
 }


### PR DESCRIPTION
## Summary

The changelog dropdown's **Updated Configs** list formatted the framework segment of each config key with its own broken mapping: everything after the GPU token was treated as a single framework id, so keys with trailing descriptors (`dsv4-fp4-b200-sglang-agentic-hicache`) missed the `FRAMEWORK_LABELS` lookup and fell back to per-token uppercase — rendering as **"B200 (SGLANG AGENTIC HICACHE)"** instead of using the same framework labels shown in the chart legend.

`formatConfigKeys` now:

- canonicalizes legacy aliases first (`sglang-disagg` → `mori-sglang`), then **greedy-matches the longest known framework prefix against `FRAMEWORK_LABELS`** — the exact mapping the legend uses — so multi-token frameworks (`dynamo-sglang`, `llmd-vllm`, `mori-sglang`) resolve correctly ahead of any descriptors
- renders leftover descriptor tokens title-cased and comma-separated: **"B200 (SGLang, Agentic, Hicache) DeepSeek-V4-Pro FP4"**
- keeps the per-model spec-method labels (M3's `mtp` still renders as "EAGLE") and now applies them in any descriptor position, not just a trailing `-mtp`

No behavior change for plain keys (`…-b200-vllm`, `…-h200-sglang-mtp`, `…-b200-dynamo-sglang` render exactly as before — covered by the existing tests).

Tests: 3 new cases (descriptor split, multi-token framework + descriptor, EAGLE after descriptor); all 17 pass. `tsc --noEmit`, oxlint, oxfmt clean.

## 中文说明

changelog 下拉框的 **Updated Configs** 列表此前使用一套独立且有误的框架名映射：GPU 之后的全部片段被当作单个框架 id，带描述符的 config key（如 `dsv4-fp4-b200-sglang-agentic-hicache`）无法命中 `FRAMEWORK_LABELS`，回退为逐词全大写（显示为 "B200 (SGLANG AGENTIC HICACHE)"），与图例中的框架显示不一致。

`formatConfigKeys` 现在：

- 先规范化旧别名（`sglang-disagg` → `mori-sglang`），再按 **图例所用的同一 `FRAMEWORK_LABELS` 映射做最长前缀匹配**，确保多段框架名（`dynamo-sglang`、`llmd-vllm`、`mori-sglang`）优先于描述符正确解析
- 剩余描述符 token 首字母大写、逗号分隔显示："B200 (SGLang, Agentic, Hicache) DeepSeek-V4-Pro FP4"
- 保留按模型的投机解码标签（MiniMax-M3 的 `mtp` 仍显示为 "EAGLE"），且不再局限于末尾 `-mtp` 位置

普通 config key 的显示不变（现有测试覆盖）。新增 3 个单元测试，17 个测试全部通过；`tsc --noEmit`、oxlint、oxfmt 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatter change in changelog UI with targeted tests and no API or data-path changes.
> 
> **Overview**
> Fixes **Updated Configs** in the changelog dropdown so framework names match the chart legend instead of shouting unknown tail tokens.
> 
> **`formatConfigKeys`** no longer treats everything after the GPU as one framework id. It canonicalizes legacy aliases, then **greedy longest-prefix matches** against **`FRAMEWORK_LABELS`** so multi-token frameworks (`llmd-vllm`, `dynamo-sglang`) resolve before descriptors like `agentic` / `hicache`, which are comma-separated and title-cased. Model-specific **`mtp`** labels (e.g. M3 → **EAGLE**) still apply in any suffix position, not only a trailing `-mtp`.
> 
> Three unit tests cover descriptor splits, multi-token frameworks + descriptors, and EAGLE after descriptors; plain keys stay unchanged per existing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15aab6d016ad701a4325027f94df6d37b7d22fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->