### PR TITLE
fix(inference): use agentic label defaults / 修正 agentic 标签默认值

### DIFF
--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -152,6 +152,12 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
   });
 
+  it('defaults to parallelism labels without line labels for the agentic view', () => {
+    cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
+    cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'checked');
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
+  });
+
   it('switches the x-axis to TTFT and updates the heading', () => {
     cy.get('[data-testid="x-axis-mode-ttft"]').click();
     cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -123,9 +123,22 @@ const agenticBenchmarks = agenticGpus.flatMap((g) =>
   })),
 );
 
+const fixedSequenceBenchmarks = agenticBenchmarks.map((row, index) => ({
+  ...row,
+  id: 910000 + index,
+  isl: 8192,
+  osl: 1024,
+  benchmark_type: 'single_turn',
+}));
+
 const interceptAgenticData = () => {
   cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as('availability');
   cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticBenchmarks }).as('benchmarks');
+};
+
+const interceptFixedSequenceData = () => {
+  cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as('availability');
+  cy.intercept('GET', '/api/v1/benchmarks*', { body: fixedSequenceBenchmarks }).as('benchmarks');
 };
 
 describe('X-Axis Mode Toggle (inference chart)', () => {
@@ -156,6 +169,20 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
+  });
+
+  it('honors explicit label URL overrides for the agentic view', () => {
+    interceptAgenticData();
+    cy.visit('/inference?i_label=0&i_advlabel=0&i_linelabel=1', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        unlockAgenticGate(win);
+      },
+    });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
+    cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
   });
 
   it('switches the x-axis to TTFT and updates the heading', () => {
@@ -204,6 +231,34 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       'true',
     );
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+  });
+});
+
+describe('Label defaults for fixed-sequence scenarios', () => {
+  it('keeps parallelism labels off and line labels on by default', () => {
+    interceptFixedSequenceData();
+    cy.visit('/inference?i_seq=8k%2F1k', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
+    cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+  });
+
+  it('honors explicit label URL overrides', () => {
+    interceptFixedSequenceData();
+    cy.visit('/inference?i_seq=8k%2F1k&i_label=1&i_advlabel=1&i_linelabel=0', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
+    cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'checked');
+    cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
   });
 });
 

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -64,6 +64,7 @@ import {
   type XAxisMode,
 } from './hooks/useChartData';
 import { resolveComparisonEntries } from './utils/comparisonEntry';
+import { resolveLabelState, serializeLabelState } from './utils/label-defaults';
 import {
   EMPTY_QUICK_FILTERS,
   type DisaggMode,
@@ -244,30 +245,24 @@ export function InferenceProvider({
   });
 
   const [hideNonOptimal, setHideNonOptimal] = useState(() => getUrlParam('i_optimal') !== '0');
-  const [showPointLabels, setShowPointLabels] = useState(() => {
-    // Legacy `?i_nolabel=1` from before the rename: keep hiding point labels.
-    if (getUrlParam('i_nolabel') === '1') return false;
-    if (getUrlParam('i_label') === '0') return false;
-    if (getUrlParam('i_label') === '1') return true;
-    // Advanced (parallelism) labels are a richer form of point label; a share
-    // link that requests them must auto-enable point labels so they actually
-    // render (mirrors the runtime toggle coupling in ScatterGraph). A later
-    // explicit i_nolabel=1 still wins — it is checked first above.
-    if (getUrlParam('i_advlabel') === '1') return true;
-    // Default off: per-point labels (TP + concurrency) clutter the chart; the
-    // per-line hardware labels (on by default) are the primary annotation.
-    return false;
-  });
-  const [logScale, setLogScale] = useState(() => getUrlParam('i_log') === '1');
-  // Parallelism labels default off (?i_advlabel=1 overrides on).
-  const [useAdvancedLabels, setUseAdvancedLabels] = useState(
-    () => getUrlParam('i_advlabel') === '1',
+  const labelScenarioKind = sequenceKind(effectiveSequence);
+  const initialLabelState = useMemo(
+    () =>
+      resolveLabelState('fixed-seq', {
+        i_label: getUrlParam('i_label'),
+        i_nolabel: getUrlParam('i_nolabel'),
+        i_advlabel: getUrlParam('i_advlabel'),
+        i_linelabel: getUrlParam('i_linelabel'),
+      }),
+    [getUrlParam],
   );
+  const [showPointLabels, setShowPointLabels] = useState(initialLabelState.showPointLabels);
+  const [logScale, setLogScale] = useState(() => getUrlParam('i_log') === '1');
+  const [useAdvancedLabels, setUseAdvancedLabels] = useState(initialLabelState.useAdvancedLabels);
   const [showGradientLabels, setShowGradientLabels] = useState(
     () => getUrlParam('i_gradlabel') === '1',
   );
-  // Line labels default on (?i_linelabel=0 overrides off).
-  const [showLineLabels, setShowLineLabels] = useState(() => getUrlParam('i_linelabel') !== '0');
+  const [showLineLabels, setShowLineLabels] = useState(initialLabelState.showLineLabels);
   const [showSpeedOverlay, setShowSpeedOverlay] = useState(() => getUrlParam('i_speed') === '1');
   const [showMinecraftOverlay, setShowMinecraftOverlay] = useState(
     () => getUrlParam('i_mc') === '1',
@@ -539,6 +534,19 @@ export function InferenceProvider({
   useEffect(() => {
     setTrackedConfigs((prev) => (prev.length > 0 ? [] : prev));
   }, [selectedModel, effectiveSequence, effectivePrecisions, selectedYAxisMetric]);
+
+  useEffect(() => {
+    if (!sequenceResolved) return;
+    const labelState = resolveLabelState(labelScenarioKind, {
+      i_label: getUrlParam('i_label'),
+      i_nolabel: getUrlParam('i_nolabel'),
+      i_advlabel: getUrlParam('i_advlabel'),
+      i_linelabel: getUrlParam('i_linelabel'),
+    });
+    setShowPointLabels(labelState.showPointLabels);
+    setUseAdvancedLabels(labelState.useAdvancedLabels);
+    setShowLineLabels(labelState.showLineLabels);
+  }, [labelScenarioKind, sequenceResolved, getUrlParam]);
 
   // Reconcile the x-axis mode with the scenario kind:
   //  - On mount with no `i_xmode` URL param: snap to the kind's natural default
@@ -1034,6 +1042,12 @@ export function InferenceProvider({
     return [...activeHwTypes].toSorted().join(',');
   }, [activeHwTypes, hwTypesWithData]);
 
+  const serializedLabelState = serializeLabelState(labelScenarioKind, {
+    showPointLabels,
+    useAdvancedLabels,
+    showLineLabels,
+  });
+
   useUrlStateSync(
     {
       i_metric: selectedYAxisMetric,
@@ -1043,7 +1057,7 @@ export function InferenceProvider({
       i_dstart: selectedDateRange.startDate,
       i_dend: selectedDateRange.endDate,
       i_optimal: hideNonOptimal ? '' : '0',
-      i_label: showPointLabels ? '1' : '',
+      i_label: serializedLabelState.i_label,
       i_hc: highContrast ? '1' : '',
       i_log: logScale ? '1' : '',
       i_xmetric: selectedXAxisMetric || '',
@@ -1051,9 +1065,9 @@ export function InferenceProvider({
       i_xmode: selectedXAxisMode,
       i_scale: scaleType,
       i_legend: isLegendExpanded ? '' : '0',
-      i_advlabel: useAdvancedLabels ? '1' : '',
+      i_advlabel: serializedLabelState.i_advlabel,
       i_gradlabel: showGradientLabels ? '1' : '',
-      i_linelabel: showLineLabels ? '' : '0',
+      i_linelabel: serializedLabelState.i_linelabel,
       i_speed: showSpeedOverlay ? '1' : '',
       i_mc: showMinecraftOverlay ? '1' : '',
       i_active: iActiveStr,

--- a/packages/app/src/components/inference/utils/label-defaults.test.ts
+++ b/packages/app/src/components/inference/utils/label-defaults.test.ts
@@ -56,4 +56,23 @@ describe('serializeLabelState', () => {
       i_linelabel: '1',
     });
   });
+
+  it('preserves fixed-sequence defaults and serializes their deviations', () => {
+    expect(serializeLabelState('fixed-seq', resolveLabelState('fixed-seq', {}))).toEqual({
+      i_label: '',
+      i_advlabel: '',
+      i_linelabel: '',
+    });
+    expect(
+      serializeLabelState('fixed-seq', {
+        showPointLabels: true,
+        useAdvancedLabels: true,
+        showLineLabels: false,
+      }),
+    ).toEqual({
+      i_label: '1',
+      i_advlabel: '1',
+      i_linelabel: '0',
+    });
+  });
 });

--- a/packages/app/src/components/inference/utils/label-defaults.test.ts
+++ b/packages/app/src/components/inference/utils/label-defaults.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveLabelState, serializeLabelState } from './label-defaults';
+
+describe('resolveLabelState', () => {
+  it('uses uncluttered fixed-sequence defaults', () => {
+    expect(resolveLabelState('fixed-seq', {})).toEqual({
+      showPointLabels: false,
+      useAdvancedLabels: false,
+      showLineLabels: true,
+    });
+  });
+
+  it('uses parallelism labels instead of line labels for agentic scenarios', () => {
+    expect(resolveLabelState('agentic', {})).toEqual({
+      showPointLabels: true,
+      useAdvancedLabels: true,
+      showLineLabels: false,
+    });
+  });
+
+  it('preserves explicit and legacy URL overrides', () => {
+    expect(
+      resolveLabelState('agentic', {
+        i_nolabel: '1',
+        i_advlabel: '0',
+        i_linelabel: '1',
+      }),
+    ).toEqual({
+      showPointLabels: false,
+      useAdvancedLabels: false,
+      showLineLabels: true,
+    });
+  });
+});
+
+describe('serializeLabelState', () => {
+  it('omits the scenario defaults', () => {
+    expect(serializeLabelState('agentic', resolveLabelState('agentic', {}))).toEqual({
+      i_label: '',
+      i_advlabel: '',
+      i_linelabel: '',
+    });
+  });
+
+  it('serializes deviations from agentic defaults', () => {
+    expect(
+      serializeLabelState('agentic', {
+        showPointLabels: false,
+        useAdvancedLabels: false,
+        showLineLabels: true,
+      }),
+    ).toEqual({
+      i_label: '0',
+      i_advlabel: '0',
+      i_linelabel: '1',
+    });
+  });
+});

--- a/packages/app/src/components/inference/utils/label-defaults.ts
+++ b/packages/app/src/components/inference/utils/label-defaults.ts
@@ -1,0 +1,45 @@
+import type { ScenarioKind } from '@/lib/data-mappings';
+
+export interface LabelState {
+  showPointLabels: boolean;
+  useAdvancedLabels: boolean;
+  showLineLabels: boolean;
+}
+
+type LabelUrlParams = Partial<
+  Record<'i_label' | 'i_nolabel' | 'i_advlabel' | 'i_linelabel', string>
+>;
+
+export function resolveLabelState(kind: ScenarioKind, params: LabelUrlParams): LabelState {
+  const agentic = kind === 'agentic';
+
+  let showPointLabels = agentic;
+  if (params.i_nolabel === '1' || params.i_label === '0') showPointLabels = false;
+  else if (params.i_label === '1') showPointLabels = true;
+  else if (params.i_advlabel === '1') showPointLabels = true;
+
+  return {
+    showPointLabels,
+    useAdvancedLabels:
+      params.i_advlabel === '1' ? true : params.i_advlabel === '0' ? false : agentic,
+    showLineLabels:
+      params.i_linelabel === '1' ? true : params.i_linelabel === '0' ? false : !agentic,
+  };
+}
+
+export function serializeLabelState(kind: ScenarioKind, state: LabelState): LabelUrlParams {
+  const defaults = resolveLabelState(kind, {});
+
+  return {
+    i_label:
+      state.showPointLabels === defaults.showPointLabels ? '' : state.showPointLabels ? '1' : '0',
+    i_advlabel:
+      state.useAdvancedLabels === defaults.useAdvancedLabels
+        ? ''
+        : state.useAdvancedLabels
+          ? '1'
+          : '0',
+    i_linelabel:
+      state.showLineLabels === defaults.showLineLabels ? '' : state.showLineLabels ? '1' : '0',
+  };
+}


### PR DESCRIPTION
## Summary

- Agentic scenarios now default Parallelism Labels on and Line Labels off.
- Fixed-sequence defaults and explicit/legacy URL overrides remain unchanged.

## Validation

- Label-default unit tests: 6 passed, covering both scenario defaults and URL serialization
- Targeted Cypress spec: 12 passed, covering agentic/fixed defaults, URL overrides, and overlays
- Typecheck, targeted lint, and formatting passed

## 中文说明

- Agentic 场景现在默认开启「并行配置标签」，并关闭「曲线标签」。
- 固定序列场景的默认值及显式/旧版 URL 覆盖保持不变。

## 验证

- 标签默认值单元测试：6 项通过，覆盖两类场景默认值及 URL 序列化
- 定向 Cypress 测试：12 项通过，覆盖 agentic/固定序列默认值、URL 覆盖及叠加层
- 类型检查、定向 lint 和格式检查通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only chart annotation defaults and URL serialization; behavior is covered by unit and Cypress tests with no auth or data-path changes.
> 
> **Overview**
> **Agentic** inference charts now default to **parallelism / point labels on** and **line labels off**; **fixed-sequence** scenarios keep the prior “uncluttered” defaults (line labels on, point and parallelism labels off).
> 
> Label toggles are driven by a new `resolveLabelState` / `serializeLabelState` helper in `label-defaults.ts`. `InferenceContext` uses it for initial state, reapplies when the scenario kind changes after availability resolves, and writes share URLs so `i_label`, `i_advlabel`, and `i_linelabel` are only present when they differ from that scenario’s defaults (legacy `i_nolabel` still honored).
> 
> Cypress coverage adds agentic and 8K/1K fixed-seq cases for default toggles and explicit URL overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab79cf687dab0f4fcf6bf54d0cfdb58473aea9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->