### PR TITLE
fix(agentic): parse SGLang KV pool capacity / 解析 SGLang KV 缓存容量

### DIFF
--- a/packages/app/src/components/inference/agentic-point/server-metric-cards.tsx
+++ b/packages/app/src/components/inference/agentic-point/server-metric-cards.tsx
@@ -416,7 +416,7 @@ export function InflightUniqueTokensCard({
 }: {
   phaseTimeline: RequestTimeline | null;
   timelineLoading: boolean;
-  /** KV-cache pool size in tokens (vLLM only) — drawn as a constant ceiling. */
+  /** KV-cache pool size in tokens (vLLM/SGLang) — drawn as a constant ceiling. */
   kvCachePoolTokens: number | null;
 }) {
   return (

--- a/packages/db/src/etl/server-log-metrics.test.ts
+++ b/packages/db/src/etl/server-log-metrics.test.ts
@@ -40,4 +40,29 @@ describe('kvCachePoolTokensFromServerLog', () => {
     const log = `INFO GPU KV cache size: 1,234,567 tokens`;
     expect(kvCachePoolTokensFromServerLog(log)).toBe(1_234_567);
   });
+
+  it('reads an SGLang single-scheduler pool size', () => {
+    const log = `
+[2026-07-08 15:44:52] server_args=ServerArgs(tp_size=8, dp_size=1, moe_dp_size=1)
+[2026-07-08 15:55:55 DP0 TP0 EP0] max_total_num_tokens=2,301,440, chunked_prefill_size=4096
+`;
+    expect(kvCachePoolTokensFromServerLog(log)).toBe(2_301_440);
+  });
+
+  it('multiplies an SGLang per-scheduler pool by data-parallel size', () => {
+    const log = `
+[2026-07-08 16:43:35] server_args=ServerArgs(tp_size=4, dp_size=4, moe_dp_size=1)
+[2026-07-08 16:49:59 DP0 TP0 EP0] max_total_num_tokens=3219456, chunked_prefill_size=4096
+`;
+    expect(kvCachePoolTokensFromServerLog(log)).toBe(3_219_456 * 4);
+  });
+
+  it('dedups repeated SGLang startup summaries', () => {
+    const log = `
+[2026-07-08 16:43:35] server_args=ServerArgs(dp_size=8, moe_dp_size=1)
+[2026-07-08 16:49:59 DP0 TP0 EP0] max_total_num_tokens=2301440
+[2026-07-08 16:49:59 DP0 TP0 EP0] max_total_num_tokens=2301440
+`;
+    expect(kvCachePoolTokensFromServerLog(log)).toBe(2_301_440 * 8);
+  });
 });

--- a/packages/db/src/etl/server-log-metrics.ts
+++ b/packages/db/src/etl/server-log-metrics.ts
@@ -1,5 +1,5 @@
 /**
- * Derive server-side scalars from the captured vLLM server log
+ * Derive server-side scalars from the captured inference-server log
  * (`server_logs.server_log`). These come from startup log lines rather than the
  * scraped Prometheus `/metrics`, because for MLA / sparse-attention models the
  * `vllm:cache_config_info` labels (num_gpu_blocks × block_size) do NOT
@@ -20,8 +20,11 @@
  *   (EngineCore_DP0 pid=…)  GPU KV cache size: 11,577,333 tokens   ┐
  *   (EngineCore_DP1 pid=…)  GPU KV cache size: 11,577,333 tokens   ┘ → ×8 = total
  *
- * Returns null when the log has no such line (non-vLLM frameworks, or a log
- * that didn't capture engine startup).
+ * SGLang prints `max_total_num_tokens=N` for one data-parallel scheduler. Its
+ * deployment-wide total is that value multiplied by `dp_size` from the
+ * authoritative `ServerArgs` line.
+ *
+ * Returns null when the log has neither framework's startup capacity line.
  */
 export function kvCachePoolTokensFromServerLog(serverLog: string | null): number | null {
   if (!serverLog) return null;
@@ -37,23 +40,39 @@ export function kvCachePoolTokensFromServerLog(serverLog: string | null): number
   // sum across data-parallel ranks.
   const tagRe = /\((?<tag>EngineCore(?:_DP\d+)?)\s+pid=\d+\)/u;
   const sizeRe = /GPU KV cache size:\s*(?<tokens>[\d,]+)\s*tokens/u;
+  const sglangSizeRe = /\bmax_total_num_tokens=(?<tokens>[\d,]+)/u;
+  const sglangDpSizeRe = /\bdp_size=(?<size>\d+)\b/u;
   const perEngine = new Map<string, number>();
+  const sglangPerSchedulerSizes = new Set<number>();
+  let sglangDpSize = 1;
   let bareTotal = 0;
   let bareFound = false;
   for (const line of serverLog.split('\n')) {
-    if (!line.includes('GPU KV cache size')) continue;
-    const sizeMatch = sizeRe.exec(line);
-    if (!sizeMatch) continue;
-    const tokens = Number(sizeMatch.groups!.tokens!.replaceAll(',', ''));
-    if (!Number.isFinite(tokens) || tokens <= 0) continue;
-    const tagMatch = tagRe.exec(line);
-    if (tagMatch) {
-      perEngine.set(tagMatch.groups!.tag!, tokens);
-    } else {
-      // Fallback for logs without the engine-core prefix: count each occurrence
-      // (one per engine when there are no reprints). Best-effort only.
-      bareTotal += tokens;
-      bareFound = true;
+    if (line.includes('GPU KV cache size')) {
+      const sizeMatch = sizeRe.exec(line);
+      if (!sizeMatch) continue;
+      const tokens = Number(sizeMatch.groups!.tokens!.replaceAll(',', ''));
+      if (!Number.isFinite(tokens) || tokens <= 0) continue;
+      const tagMatch = tagRe.exec(line);
+      if (tagMatch) {
+        perEngine.set(tagMatch.groups!.tag!, tokens);
+      } else {
+        // Fallback for logs without the engine-core prefix: count each occurrence
+        // (one per engine when there are no reprints). Best-effort only.
+        bareTotal += tokens;
+        bareFound = true;
+      }
+      continue;
+    }
+
+    if (line.includes('server_args=ServerArgs')) {
+      const dpSizeMatch = sglangDpSizeRe.exec(line);
+      if (dpSizeMatch) sglangDpSize = Number(dpSizeMatch.groups!.size!);
+    } else if (line.includes('max_total_num_tokens=')) {
+      const sizeMatch = sglangSizeRe.exec(line);
+      if (!sizeMatch) continue;
+      const tokens = Number(sizeMatch.groups!.tokens!.replaceAll(',', ''));
+      if (Number.isFinite(tokens) && tokens > 0) sglangPerSchedulerSizes.add(tokens);
     }
   }
   if (perEngine.size > 0) {
@@ -61,5 +80,9 @@ export function kvCachePoolTokensFromServerLog(serverLog: string | null): number
     for (const v of perEngine.values()) total += v;
     return total;
   }
-  return bareFound ? bareTotal : null;
+  if (bareFound) return bareTotal;
+  if (sglangPerSchedulerSizes.size !== 1 || !Number.isInteger(sglangDpSize) || sglangDpSize <= 0) {
+    return null;
+  }
+  return [...sglangPerSchedulerSizes][0]! * sglangDpSize;
 }


### PR DESCRIPTION
## Summary
- Root cause: agentic ingest only parsed vLLM's `GPU KV cache size` startup line, so SGLang rows kept `metrics.kv_cache_pool_tokens` null.
- Fix: parse SGLang's per-scheduler `max_total_num_tokens` and multiply by `dp_size`; retain existing vLLM behavior.

## Validation
- `pnpm --filter @semianalysisai/inferencex-db test:unit` — 402 tests passed.
- `pnpm lint && pnpm fmt && pnpm typecheck` — passed.
- Real linked logs parse to `12,877,824` (row `432019`) and `18,411,520` (row `432054`); both backfilled values were verified after commit.

## 中文说明
- 根因：agentic 数据导入仅解析 vLLM 的 `GPU KV cache size` 启动日志，导致 SGLang 记录的 `metrics.kv_cache_pool_tokens` 为 null。
- 修复：解析 SGLang 每个 scheduler 的 `max_total_num_tokens`，并乘以 `dp_size`；现有 vLLM 行为保持不变。
- 验证：DB 单元测试共 402 项通过，lint、格式检查和类型检查均通过；真实日志计算及回填后的两条数值也已核验。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized ETL parsing and UI comment change; vLLM path is preserved and new behavior is covered by unit tests.
> 
> **Overview**
> **Agentic ingest** previously left `metrics.kv_cache_pool_tokens` null for SGLang runs because `kvCachePoolTokensFromServerLog` only understood vLLM’s `GPU KV cache size` startup lines.
> 
> The parser now also handles **SGLang**: it reads `max_total_num_tokens` from scheduler startup lines, takes `dp_size` from `server_args=ServerArgs(...)`, deduplicates repeated summaries, and returns **per-scheduler tokens × dp_size** as the deployment-wide ceiling. **vLLM** behavior (per-engine tags, summing DP ranks, bare-line fallback) is unchanged; vLLM still wins when those lines are present.
> 
> Unit tests cover single-scheduler, multi-DP, and dedup cases. The **Unique input tokens in flight** chart prop docs now note the ceiling applies to **vLLM and SGLang**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717675e3c35dbad308f2662c42a3aa693a04299a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->