### PR TITLE
fix(agentic): label KV series by DP rank / 按 DP rank 标注 KV 序列

### DIFF
--- a/packages/db/src/etl/compute-chart-series.test.ts
+++ b/packages/db/src/etl/compute-chart-series.test.ts
@@ -253,6 +253,12 @@ describe('computeChartSeries', () => {
       { t: 0, value: 0.25 },
       { t: 1, value: 0.5 },
     ]);
+    expect(cs!.kvCacheUsageByEngine.map(({ engineLabel }) => engineLabel)).toEqual([
+      '0',
+      '1',
+      '2',
+      '3',
+    ]);
     // prefillTps = Σ rates = 4 × 100 = 400; then 4 × 200 = 800
     expect(cs!.prefillTps).toEqual([
       { t: 0, value: 400 },
@@ -261,6 +267,29 @@ describe('computeChartSeries', () => {
     expect(cs!.decodeTps).toEqual([
       { t: 0, value: 200 },
       { t: 1, value: 300 },
+    ]);
+  });
+
+  it('uses dp_rank when engine labels repeat across DEP ranks', async () => {
+    const engines = [0, 1, 2, 3].map((dpRank) => ({
+      labels: { engine: '0', dp_rank: String(dpRank) },
+      timeslices: [{ start_ns: 0, end_ns: 1e9, avg: 0.1 + dpRank * 0.1 }],
+    }));
+    const blob = gzipSync(
+      Buffer.from(
+        JSON.stringify({
+          metrics: { 'vllm:kv_cache_usage_perc': { series: engines } },
+        }),
+      ),
+    );
+
+    const series = await computeChartSeries(blob);
+
+    expect(series?.kvCacheUsageByEngine.map(({ engineLabel }) => engineLabel)).toEqual([
+      '0',
+      '1',
+      '2',
+      '3',
     ]);
   });
 

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -67,8 +67,12 @@ import {
  * warmup block are unaffected. (v11 was a short-lived, since-reverted attempt to
  * carry kvCachePoolTokens in chart_series; that value now lives in
  * benchmark_results.metrics, derived from the server log — unrelated to this.)
+ *
+ * v13: prefer `dp_rank` over the per-rank-local `engine` label when naming
+ * KV-cache series. Some DEP exports report engine=0 for every rank, which
+ * made every legend entry read "DP 0" despite distinct dp_rank labels.
  */
-export const CHART_SERIES_VERSION = 12;
+export const CHART_SERIES_VERSION = 13;
 
 export interface TimeSeriesPoint {
   /** Seconds from benchmark start. */
@@ -348,11 +352,11 @@ function buildSeriesFromMetrics(
   // the cluster-average line.
   const kvCacheUsageByEngine: { engineLabel: string; points: TimeSeriesPoint[] }[] = [];
   if (kvSeries && kvSeries.length > 1) {
-    // Sort by numeric engine label when present so rank 0..N renders in
-    // order; fall back to series-array index otherwise.
+    // Sort by numeric DP rank when present so rank 0..N renders in order;
+    // fall back to the engine label, then series-array index otherwise.
     const decorated = kvSeries.map((s, idx) => {
       const raw =
-        s.labels?.['engine'] ?? s.labels?.['engine_idx'] ?? s.labels?.['dp_rank'] ?? String(idx);
+        s.labels?.['dp_rank'] ?? s.labels?.['engine'] ?? s.labels?.['engine_idx'] ?? String(idx);
       const numeric = Number(raw);
       return { series: s, idx, label: raw, sortKey: Number.isFinite(numeric) ? numeric : idx };
     });


### PR DESCRIPTION
## Root cause
KV-cache series extraction preferred the rank-local `engine` label over `dp_rank`. DEP exports where every rank reports `engine=0` therefore produced repeated `DP 0` legend entries.

## Fix
Prefer `dp_rank`, retain `engine`/`engine_idx` as fallbacks, and bump `CHART_SERIES_VERSION` so stored series are recomputed.

## Validation
- `pnpm test:unit` (2,996 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

## 中文说明
### 根因
KV Cache 序列提取逻辑优先使用各 rank 内部的 `engine` 标签，而非 `dp_rank`。当 DEP 导出中每个 rank 都上报 `engine=0` 时，图例便会重复显示 `DP 0`。

### 修复
优先使用 `dp_rank`，并保留 `engine`/`engine_idx` 作为回退；同时递增 `CHART_SERIES_VERSION`，确保已存储序列重新计算。

### 验证
- `pnpm test:unit`（2,996 项测试）
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ETL labeling change in chart-series extraction with a version bump for recompute; no auth, persistence schema, or runtime inference path changes.
> 
> **Overview**
> Fixes **duplicate "DP 0" legends** on the agentic KV cache chart when DEP metrics export the same `engine` label on every data-parallel rank.
> 
> `computeChartSeries` now names and sorts `kvCacheUsageByEngine` series using **`dp_rank` first**, then `engine` / `engine_idx`, then the series index. **`CHART_SERIES_VERSION` is bumped to 13** so stored `chart_series` rows are recomputed on backfill and API cache keys stay aligned with the new extraction logic.
> 
> Tests cover distinct labels in the normal multi-engine case and the DEP case where every rank reports `engine=0` but distinct `dp_rank` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6f30487fa94485f5e6e2d583a26d462a242ac11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->