### PR TITLE
chore(ci): remove retired agentx-v1 database as an ingest target / 移除已退役的 agentx-v1 数据库入库目标

### DIFF
--- a/.claude/agents/ingest.md
+++ b/.claude/agents/ingest.md
@@ -1,10 +1,10 @@
 ---
 name: ingest
-description: Ingest a benchmark run from GitHub Actions into the Neon DB used by the feat/agentx deployment. The target DB write URL must be provided in the invocation. Handles standard ingest, delete+reingest, and changelog entries. Invoke when the user asks to ingest a workflow run URL.
+description: Ingest a benchmark run from GitHub Actions into the Neon DB backing this dashboard. The target DB write URL must be provided in the invocation. Handles standard ingest, delete+reingest, and changelog entries. Invoke when the user asks to ingest a workflow run URL.
 tools: Bash, Read, Edit, Write
 ---
 
-You ingest benchmark runs from `SemiAnalysisAI/InferenceX` GitHub Actions into the Neon branch used by the `feat/agentx` deployment of this dashboard. Operate on `/Users/quilicic/InferenceX-app`.
+You ingest benchmark runs from `SemiAnalysisAI/InferenceX` GitHub Actions into the Neon DB backing this dashboard. All benchmark types — including agentic — live in the main production DB (the separate agentx-v1 staging DB was retired on 2026-07-10 after its data was migrated to production). Operate on `/Users/quilicic/InferenceX-app`.
 
 ## Environment
 
@@ -13,7 +13,7 @@ You ingest benchmark runs from `SemiAnalysisAI/InferenceX` GitHub Actions into t
   - Use the **direct (non-pooled)** host for ingest/migrations — no `-pooler` in the hostname.
   - For psql diagnostics you may use the same URL directly: `psql "$DATABASE_WRITE_URL" -c "..."`.
 - **Local dev server**: usually `http://localhost:3002` (port 3000 is a different project on this machine — never purge port 3000)
-- **Preview URL**: `https://inferencemax-app-git-feat-agentx-semianalysisai.vercel.app`
+- **Production URL**: `https://inferencex.semianalysis.com`
 - **INVALIDATE_SECRET** lives in repo root `.env` under that key.
 - **GitHub auth**: `gh auth token` for `gh` calls and the GITHUB_TOKEN env var.
 
@@ -35,13 +35,8 @@ Then refresh the materialized view (the script's auto-refresh sometimes races):
 SECRET=$(grep "^INVALIDATE_SECRET" /Users/quilicic/InferenceX-app/.env | cut -d= -f2 | tr -d '"')
 # Localhost (port 3002, NOT 3000)
 curl -s -X POST -H "Authorization: Bearer $SECRET" http://localhost:3002/api/v1/invalidate
-# Preview
-mkdir -p /tmp/vp && cd /tmp/vp \
-  && vercel link --project inferencemax-app --scope semianalysisai --yes >/dev/null 2>&1 \
-  && vercel curl /api/v1/invalidate \
-       --deployment https://inferencemax-app-git-feat-agentx-semianalysisai.vercel.app \
-       --yes -- -sS -X POST -H "Authorization: Bearer $SECRET"
-rm -rf /tmp/vp
+# Production
+curl -sS -X POST -H "Authorization: Bearer $SECRET" https://inferencex.semianalysis.com/api/v1/invalidate
 ```
 
 ## Delete + reingest (use only when user explicitly says "delete and reingest" OR when the run supersedes prior data with the same (model, hw, framework, precision))
@@ -171,7 +166,7 @@ If the user doesn't specify a description, DO NOT skip the entry and DO NOT bloc
 3. **Ingest** via the standard path. Do NOT use AIPerf tagging unless the user explicitly asks for a separate legend line.
 4. **Refresh materialized view**.
 5. **Add changelog entry — ALWAYS, MANDATORY.** Every ingest gets exactly one changelog entry (see "Adding a perf changelog entry — MANDATORY"). Use the user's text if given (substituting `<SKU>`); otherwise derive one from the run name and add it anyway. Never skip this step.
-6. **Purge both caches** (localhost 3002 + preview — never port 3000).
+6. **Purge both caches** (localhost 3002 + production — never port 3000).
 7. **Report** the row count, date, hardware, run id, and the changelog id (always present).
 
 ## Related: ingesting agentic _datasets_ (not benchmark runs)

--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -43,7 +43,6 @@ on:
         options:
           - production
           - dev
-          - agentx-v1
 
 jobs:
   ingest:
@@ -74,7 +73,6 @@ jobs:
           REQUESTED_DATABASE_TARGET: ${{ github.event.client_payload.database-target || inputs.database-target || 'production' }}
           DATABASE_WRITE_URL_PRODUCTION: ${{ secrets.DATABASE_WRITE_URL }}
           DATABASE_WRITE_URL_DEV: ${{ secrets.DATABASE_DEV_WRITE_URL }}
-          DATABASE_WRITE_URL_AGENTX_V1: ${{ secrets.DATABASE_AGENTX_V1_WRITE_URL }}
         run: |
           case "$REQUESTED_DATABASE_TARGET" in
             production)
@@ -83,10 +81,6 @@ jobs:
               ;;
             dev)
               database_write_url="$DATABASE_WRITE_URL_DEV"
-              cache_invalidate_url="https://inferencemax-app-git-feat-agentx-semianalysisai.vercel.app/api/v1/invalidate"
-              ;;
-            agentx-v1)
-              database_write_url="$DATABASE_WRITE_URL_AGENTX_V1"
               cache_invalidate_url="https://inferencemax-app-git-feat-agentx-semianalysisai.vercel.app/api/v1/invalidate"
               ;;
             *)


### PR DESCRIPTION
## Summary

The agentx-v1 staging Neon database held agentic-traces benchmark results separately from production during the AgentX rollout. That separation is retired: the agentic data was migrated into the main production DB on **2026-07-10**, and from now on all benchmark results — including agentic — are ingested directly into the production database.

- **`.github/workflows/ingest-agentic-results.yml`** — remove the `agentx-v1` `database-target` choice, the `DATABASE_WRITE_URL_AGENTX_V1` env wiring (`secrets.DATABASE_AGENTX_V1_WRITE_URL`), and the `agentx-v1` case branch. The `production` (default) and `dev` targets are unchanged; agentic ingests keep using this dedicated workflow (blob-heavy artifacts, longer timeout) but now write to the same production DB (`secrets.DATABASE_WRITE_URL`) as `ingest-results.yml`.
- **`.claude/agents/ingest.md`** — reframe the manual-ingest agent doc around the production DB: production URL + production cache-invalidate endpoint instead of the `feat/agentx` Vercel preview. The safety rule that the DB write URL must be explicitly provided by the invoker is unchanged.

No behavior change for TypeScript code — this is pure removal of dead CI config + doc updates, so existing tests cover it (lint / format / typecheck pass locally via the pre-commit hook).

### Follow-ups requiring GitHub / Neon settings (cannot be done in code)

- Delete the `DATABASE_AGENTX_V1_WRITE_URL` secret from this repo's Actions secrets.
- Decommission the agentx-v1 Neon project/branch once nothing references it.
- Retire the `feat/agentx` branch + its Vercel preview deployment. Note: the `dev` target's cache-invalidate URL still points at the `feat-agentx` preview (`inferencemax-app-git-feat-agentx-...vercel.app`) — left as-is here since the dev DB is a separate concern, but it will need a new home when that preview is torn down (the invalidate step is `|| true`-guarded, so it degrades gracefully).

The companion PR in `SemiAnalysisAI/InferenceX` switches the agentic ingest dispatches to `ref=master` + `database-target=production`; this PR merges first so that workflow state is already on `master`.

## 中文说明

agentx-v1 暂存 Neon 数据库曾在 AgentX 上线期间独立于生产库存放 agentic-traces 基准测试结果。该隔离方案现已退役：agentic 数据已于 **2026-07-10** 迁移至主生产数据库，此后所有基准测试结果（包括 agentic）均直接写入生产数据库。

- **`.github/workflows/ingest-agentic-results.yml`** — 删除 `agentx-v1` 目标选项、`DATABASE_WRITE_URL_AGENTX_V1` secret 接线及对应 case 分支；`production`（默认）与 `dev` 目标保持不变。agentic 入库仍使用该专用工作流（产物体积大、超时时间更长），但现在与 `ingest-results.yml` 一样写入生产数据库（`secrets.DATABASE_WRITE_URL`）。
- **`.claude/agents/ingest.md`** — 手动入库 agent 文档改为面向生产数据库：使用生产 URL 与生产缓存失效端点，替代 `feat/agentx` Vercel 预览部署。"写库 URL 必须由调用方显式提供"的安全规则保持不变。

纯删除无效 CI 配置 + 文档更新，不涉及 TypeScript 行为变更；lint / format / typecheck 本地均通过。

**后续人工操作**：在仓库 Actions secrets 中删除 `DATABASE_AGENTX_V1_WRITE_URL`；下线 agentx-v1 Neon 项目；退役 `feat/agentx` 分支及其 Vercel 预览部署（`dev` 目标的缓存失效 URL 仍指向该预览，属独立事项，拆除预览时需另行处理）。

`SemiAnalysisAI/InferenceX` 的配套 PR 会将 agentic 入库调度切换为 `ref=master` + `database-target=production`；本 PR 需先合并。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc and dead CI wiring removal only; production/dev ingest paths are unchanged aside from eliminating an unused third target.
> 
> **Overview**
> Retires the **agentx-v1** staging Neon DB as an ingest destination now that agentic data lives in production (migrated 2026-07-10).
> 
> **`ingest-agentic-results.yml`** drops the `agentx-v1` `database-target` option, `DATABASE_AGENTX_V1_WRITE_URL` secret wiring, and its case branch. **`production`** and **`dev`** are unchanged; agentic ingests still use this workflow but default to the same production write URL as other ingests.
> 
> **`.claude/agents/ingest.md`** reframes manual ingest around the production dashboard (`inferencex.semianalysis.com`) and documents that all benchmark types—including agentic—use the main DB. Post-ingest cache purge now hits **production** directly instead of the `feat/agentx` Vercel preview via `vercel curl`.
> 
> No application/TypeScript behavior changes—CI config and agent docs only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd9d8095889977b9430f6d81529dbcf53ae6242c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->