### PR TITLE
fix(inference): default scenario to 8K/1K instead of Agentic Traces / 默认场景改为 8K/1K，不再是 Agentic Traces

### DIFF
--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -4,10 +4,10 @@ import { unlockAgenticGate } from '../support/e2e';
 // Spec-scoped fixture helpers
 //
 // The shared cypress/fixtures/api/*.json files contain ZERO agentic_traces rows
-// (by design — adding them flips the bare /inference default to the agentic
-// scenario and regresses other specs). This spec therefore injects minimal
-// agentic data via spec-scoped cy.intercept overrides that shadow the fixture
-// server, following the same pattern used in ttft-x-axis-toggle.cy.ts.
+// (by design — agentic coverage is injected per-spec so fixed-seq specs stay
+// lean). This spec therefore injects minimal agentic data via spec-scoped
+// cy.intercept overrides that shadow the fixture server, following the same
+// pattern used in ttft-x-axis-toggle.cy.ts.
 // ---------------------------------------------------------------------------
 
 const DEFAULT_MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -22,12 +22,12 @@ const interceptDerivedMetrics = () => {
 
 // This spec exercises the agentic x-axis modes, which only exist when the
 // selected model resolves to the Agentic Traces scenario. The default e2e
-// fixtures (cypress/fixtures/api/*.json) have NO agentic rows for any model, so
-// after the availability-gated effectiveSequence fix the bare-/inference default
-// correctly resolves to a fixed-seq scenario. We therefore inject agentic
-// availability + benchmark rows for the default model VIA SPEC-SCOPED INTERCEPTS
-// (not the shared fixtures) so this test — and only this test — sees the agentic
-// view. Scoping to intercepts keeps every other spec's default fixed-seq.
+// fixtures (cypress/fixtures/api/*.json) have NO agentic rows for any model, and
+// the app default scenario is 8K/1K, so bare /inference always resolves to a
+// fixed-seq scenario. We therefore inject agentic availability + benchmark rows
+// for the default model VIA SPEC-SCOPED INTERCEPTS (not the shared fixtures) and
+// visit with an explicit ?i_seq=agentic-traces so this test — and only this
+// test — sees the agentic view.
 const DEFAULT_MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro is the default model
 const AGENTIC_DATE = '2026-06-12';
 
@@ -66,8 +66,8 @@ const agenticGpus = [
   { hardware: 'b300', framework: 'vllm', disagg: false },
 ];
 
-// Availability: default model has BOTH agentic and fixed-seq, so the default
-// resolves to agentic (the product-intended, agentic-preferred behavior).
+// Availability: default model has BOTH agentic and fixed-seq. The agentic view
+// is selected explicitly via ?i_seq=agentic-traces (the app default is 8K/1K).
 const agenticAvailability = [
   ...agenticGpus.map((g) => ({
     model: DEFAULT_MODEL_DB_KEY,
@@ -144,7 +144,7 @@ const interceptFixedSequenceData = () => {
 describe('X-Axis Mode Toggle (inference chart)', () => {
   before(() => {
     interceptAgenticData();
-    cy.visit('/inference', {
+    cy.visit('/inference?i_seq=agentic-traces', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         unlockAgenticGate(win);
@@ -173,7 +173,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
 
   it('honors explicit label URL overrides for the agentic view', () => {
     interceptAgenticData();
-    cy.visit('/inference?i_label=0&i_advlabel=0&i_linelabel=1', {
+    cy.visit('/inference?i_seq=agentic-traces&i_label=0&i_advlabel=0&i_linelabel=1', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         unlockAgenticGate(win);
@@ -231,6 +231,21 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       'true',
     );
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+  });
+});
+
+describe('Default scenario', () => {
+  it('bare /inference defaults to 8K / 1K even when the model has agentic data', () => {
+    // Availability contains BOTH agentic and fixed-seq rows for the default
+    // model; the default selection must still resolve to 8K/1K, not agentic.
+    interceptFixedSequenceData();
+    cy.visit('/inference', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
   });
 });
 
@@ -325,7 +340,7 @@ const interceptAgenticDataWithOverlay = () => {
 describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', () => {
   before(() => {
     interceptAgenticDataWithOverlay();
-    cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}`, {
+    cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces`, {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         unlockAgenticGate(win);

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -45,8 +45,8 @@ const RUNID_RE = /^[A-Za-z0-9_-]{1,64}$/u;
 // before availability has loaded. It must be a fixed-seq scenario — never
 // AgenticTraces — so the scenario selector doesn't flash "Agentic Traces" for a
 // fixed-seq-only model while the chart shows its loading skeleton. `8k/1k` is
-// the pre-agentic default for non-agentic models. Consumers that must not act on
-// an unresolved sequence gate on `sequenceResolved` instead.
+// the app default scenario. Consumers that must not act on an unresolved
+// sequence gate on `sequenceResolved` instead.
 // (Declared after the import block so it never references `Sequence` above its import.)
 const PRE_AVAILABILITY_SEQUENCE = Sequence.EightK_OneK;
 
@@ -170,9 +170,9 @@ export function GlobalFilterProvider({
     if (initialSequence) return initialSequence;
     const urlSeq = getUrlParam('i_seq');
     if (urlSeq && Object.values(Sequence).includes(urlSeq as Sequence)) return urlSeq as Sequence;
-    // Prefer Agentic Traces by default when the selected model has it; the
-    // effectiveSequence fallback below handles models without agentic data.
-    return Sequence.AgenticTraces;
+    // Default to the 8K/1K fixed-seq scenario; the effectiveSequence fallback
+    // below handles models that lack it (e.g. agentic-only models).
+    return Sequence.EightK_OneK;
   });
 
   const initialValidPrecisions = useMemo(
@@ -311,9 +311,10 @@ export function GlobalFilterProvider({
   // may arrive from the DB (`availabilityRows`) OR from a loaded unofficial run
   // (`unofficialAvailable` for this model) — either source lets us resolve a
   // trustworthy effectiveSequence. Until then `availableSequences` is the static
-  // SEQUENCE_OPTIONS fallback (which contains AgenticTraces), so resolving
-  // eagerly would fetch + label an agentic scenario for fixed-seq-only models,
-  // then snap once availability lands (flash + wasted request).
+  // SEQUENCE_OPTIONS fallback (which contains every scenario), so resolving
+  // eagerly would honor a selection the model may not have (e.g. agentic-traces
+  // from a shared link on a fixed-seq-only model), fetch it, then snap once
+  // availability lands (flash + wasted request).
   const availabilityLoaded = useMemo(
     () =>
       availabilityRows !== undefined || unofficialAvailable.some((a) => a.model === selectedModel),

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -469,10 +469,10 @@ export function InferenceProvider({
     userPowers,
     effectiveRunDate,
     // Gate benchmark fetching on sequenceResolved: before availability loads we
-    // don't yet know the model's real sequence, and the selectedSequence default
-    // is AgenticTraces. Fetching now would fire the agentic data path for a
-    // fixed-seq-only model, then refetch once availability snaps the sequence.
-    // The chart's normal loading state covers this brief window.
+    // don't yet know the model's real sequence, and the selection (e.g. an
+    // agentic `?i_seq=` link) may be a scenario the model doesn't have. Fetching
+    // now would fire the wrong data path, then refetch once availability snaps
+    // the sequence. The chart's normal loading state covers this brief window.
     isActive && sequenceResolved,
     latestDate,
     selectedPercentile,

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -315,7 +315,8 @@ export function ScenarioSelector({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          {/* Agentic first — preferred default scenario when available. */}
+          {/* Agentic group listed first when available (display order only —
+              the app default scenario is 8K/1K). */}
           {agentic.length > 0 && (
             <SelectGroup>
               <SelectLabel>Agentic</SelectLabel>

--- a/packages/app/src/lib/default-sequence.test.ts
+++ b/packages/app/src/lib/default-sequence.test.ts
@@ -36,8 +36,8 @@ describe('resolveEffectiveSequence', () => {
 
   describe('honors a valid selection (rule 2a)', () => {
     it('keeps AgenticTraces when the model actually has agentic data (dsr1 case)', () => {
-      // DeepSeek-R1 in the seeded DB has both agentic and 8k/1k — the agentic
-      // default must survive so the PR intent (agentic-preferred) holds.
+      // DeepSeek-R1 in the seeded DB has both agentic and 8k/1k — an explicit
+      // agentic selection (e.g. a shared ?i_seq= link) must survive.
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.AgenticTraces,
@@ -59,8 +59,8 @@ describe('resolveEffectiveSequence', () => {
   });
 
   describe('fallback ordering when the selection is unavailable (rule 2b/2c)', () => {
-    it('for a fixed-seq-only model, agentic default falls back to 8k/1k, not the raw first entry (llama70b case)', () => {
-      // Llama-3.3-70B has only 8k/1k in the seeded DB. The agentic default is
+    it('for a fixed-seq-only model, an agentic selection falls back to 8k/1k, not the raw first entry (llama70b case)', () => {
+      // Llama-3.3-70B has only 8k/1k in the seeded DB. An agentic selection is
       // unavailable, so it must resolve to a fixed-seq scenario — here the sole
       // available one.
       expect(
@@ -73,8 +73,8 @@ describe('resolveEffectiveSequence', () => {
     });
 
     it('prefers 8k/1k over availableSequences[0] when both 1k/1k and 8k/1k exist', () => {
-      // DB row order can surface 1k/1k first. Master defaulted non-agentic
-      // models to 8k/1k, so prefer it rather than snapping to 1k/1k.
+      // DB row order can surface 1k/1k first. 8k/1k is the app default
+      // scenario, so prefer it rather than snapping to 1k/1k.
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.AgenticTraces,

--- a/packages/app/src/lib/default-sequence.ts
+++ b/packages/app/src/lib/default-sequence.ts
@@ -3,29 +3,30 @@ import { Sequence } from './data-mappings';
 /**
  * Effective-sequence resolution.
  *
- * `selectedSequence` defaults to {@link Sequence.AgenticTraces} (a deliberate
- * product choice — agentic-preferred), but not every model has agentic data.
- * This helper turns the raw user/default selection into the sequence the chart
- * should actually render, given what the selected model offers.
+ * `selectedSequence` defaults to {@link Sequence.EightK_OneK}, but the user may
+ * have selected a scenario the model doesn't offer (e.g. Agentic Traces via a
+ * shared `?i_seq=` link on a fixed-seq-only model). This helper turns the raw
+ * user/default selection into the sequence the chart should actually render,
+ * given what the selected model offers.
  *
  * Two rules, in order:
  *
  * 1. **Availability gate.** Until availability rows have loaded we do NOT know
  *    which sequences the model has. Resolving eagerly here would pick the static
- *    fallback list (which contains AgenticTraces) and make the page fetch + label
- *    an agentic scenario for fixed-seq-only models (e.g. Llama-3.3-70B), then
- *    snap to a fixed-seq scenario once availability arrives — a visible flash of
- *    "Agentic Traces" plus a wasted request. When `availabilityLoaded` is false
- *    we return `null`; callers gate data fetching and selector display on a
- *    non-null result (a loading skeleton covers this window, which is short).
+ *    fallback list (which contains every scenario) and make the page fetch +
+ *    label a scenario the model may not have — e.g. an agentic `?i_seq=` link on
+ *    Llama-3.3-70B — then snap to an available scenario once availability
+ *    arrives: a visible flash plus a wasted request. When `availabilityLoaded`
+ *    is false we return `null`; callers gate data fetching and selector display
+ *    on a non-null result (a loading skeleton covers this window, which is
+ *    short).
  *
  * 2. **Fallback ordering.** Once availability is known: keep the user's
  *    `selectedSequence` if the model has it. Otherwise fall back to a sensible
  *    fixed-seq scenario. `availableSequences[0]` follows DB row order, which can
- *    surface `1k/1k` even when `8k/1k` exists — but `8k/1k` was the pre-agentic
- *    default for non-agentic models, so prefer it when present to match that
- *    long-standing behavior. Only if neither the selection nor `8k/1k` is
- *    available do we fall to `availableSequences[0]`.
+ *    surface `1k/1k` even when `8k/1k` exists — but `8k/1k` is the app default
+ *    scenario, so prefer it when present. Only if neither the selection nor
+ *    `8k/1k` is available do we fall to `availableSequences[0]`.
  */
 export function resolveEffectiveSequence({
   selectedSequence,
@@ -42,8 +43,8 @@ export function resolveEffectiveSequence({
   // Rule 2a: honor the user's / default selection when the model supports it.
   if (availableSequences.includes(selectedSequence)) return selectedSequence;
 
-  // Rule 2b: prefer 8k/1k (the pre-agentic default for non-agentic models) over
-  // whatever availableSequences[0] happens to be (DB row order can yield 1k/1k).
+  // Rule 2b: prefer 8k/1k (the app default scenario) over whatever
+  // availableSequences[0] happens to be (DB row order can yield 1k/1k).
   if (availableSequences.includes(Sequence.EightK_OneK)) return Sequence.EightK_OneK;
 
   // Rule 2c: last resort — first available, or the selection itself if the model

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -31,10 +31,11 @@ describe('PARAM_DEFAULTS', () => {
   });
 
   it('has an EMPTY default for i_seq so the selected scenario is always written', async () => {
-    // The UI default scenario (gate-unlocked) is AgenticTraces, not 8k/1k. An
-    // '8k/1k' default would strip an explicit 8K/1K selection from the URL, which
-    // then resolves back to the agentic default on reload/share. Empty means no
-    // scenario value ever matches the default, so it's always persisted.
+    // Per-route `initialSequence` seeds (e.g. /compare pages) make the no-param
+    // resolution route-dependent. An '8k/1k' default would strip an explicit
+    // 8K/1K selection from the URL, which then resolves back to the route's
+    // seeded scenario on reload/share. Empty means no scenario value ever
+    // matches the default, so it's always persisted.
     const { PARAM_DEFAULTS } = await import('@/lib/url-state');
     expect(PARAM_DEFAULTS.i_seq).toBe('');
   });
@@ -190,8 +191,9 @@ describe('writeUrlParams + buildShareUrl', () => {
     setupWindow('', '/inference');
     const { writeUrlParams, buildShareUrl } = await import('@/lib/url-state');
 
-    // Picking the fixed-seq scenario must survive into the share URL; before the
-    // fix this matched the '8k/1k' default and was dropped, reverting to agentic.
+    // Picking the fixed-seq scenario must survive into the share URL; on routes
+    // seeded with a different initialSequence (e.g. /compare pages), stripping
+    // it would revert the pick back to the seeded scenario on reload.
     writeUrlParams({ i_seq: '8k/1k' });
     await vi.advanceTimersByTimeAsync(200);
 

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -74,12 +74,13 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   g_model: 'DeepSeek-V4-Pro',
   g_rundate: '',
   g_runid: '',
-  // No strippable default: the UI default scenario (gate-unlocked) is
-  // AgenticTraces, not 8k/1k, so an '8k/1k' default here would strip an explicit
-  // 8K/1K selection from the URL — on reload the empty i_seq resolves back to the
-  // agentic default. Empty means the resolved scenario is ALWAYS written
-  // explicitly (effectiveSequence is never ''), so a shared/reloaded link keeps
-  // whatever the user picked. The no-param case still resolves via availability.
+  // No strippable default: per-route `initialSequence` seeds (e.g. the /compare
+  // pages) make the no-param resolution route-dependent, so stripping '8k/1k'
+  // (the global default) would revert an explicit 8K/1K pick back to the route's
+  // seeded scenario on reload. Empty means the resolved scenario is ALWAYS
+  // written explicitly (effectiveSequence is never ''), so a shared/reloaded
+  // link keeps whatever the user picked. The no-param case still resolves via
+  // availability.
   i_seq: '',
   // No strippable default: precision is only written to the URL once chosen
   // explicitly, so an explicit FP4 selection must survive (not be stripped as a


### PR DESCRIPTION
## Summary

- `/inference` (and any page without an explicit `?i_seq=`) now defaults the **Scenario** selector to **8K / 1K** instead of **Agentic Traces**: the `selectedSequence` default in `GlobalFilterContext.tsx` flips from `Sequence.AgenticTraces` to `Sequence.EightK_OneK`.
- Everything else is unchanged by design:
  - Explicit `?i_seq=` share links still win (including `agentic-traces`).
  - Per-route `initialSequence` seeds (`/compare` pages) still win.
  - The availability fallback ordering in `resolveEffectiveSequence` (keep selection → prefer `8k/1k` → first available) is untouched, so agentic-only models still resolve to their agentic scenario.
  - `PARAM_DEFAULTS.i_seq` stays `''` (not a strippable `'8k/1k'`): per-route `initialSequence` seeds make the no-param resolution route-dependent, so stripping an explicit 8K/1K pick would revert it to the route's seeded scenario on reload.
- Updated all comments that justified behavior by the old agentic-preferred default (`default-sequence.ts`, `InferenceContext.tsx`, `url-state.ts`, `chart-selectors.tsx`, test comments). The scenario dropdown's group order (Agentic listed first) is unchanged — display order only.

## Tests

- New e2e: `bare /inference defaults to 8K / 1K even when the model has agentic data` (ttft-x-axis-toggle.cy.ts) — availability contains both agentic and fixed-seq rows, and the selector must still land on 8K/1K.
- The agentic x-axis e2e suites previously relied on the bare `/inference` default resolving to agentic; they now pin `?i_seq=agentic-traces` explicitly (including the overlay-path suite).
- Verified locally: `pnpm typecheck`, `pnpm lint`, `pnpm fmt`, `pnpm test:unit` (2560 passed), and e2e specs `ttft-x-axis-toggle` (13/13), `inference-chart`, `gpu-compare-agentic-detail`, `agentic-point-time-series` against an `E2E_FIXTURES=1` server.

## Overlay support

Works for both official runs and `?unofficialrun=` overlays: the default applies before any data loads, and unofficial-run availability still participates in `availableSequences`/auto-switch exactly as before. The overlay-path e2e suite passes with the explicit `i_seq=agentic-traces` pin.

## 中文说明

- `/inference`（以及所有未携带 `?i_seq=` 参数的页面）的 **Scenario** 选择器默认值从 **Agentic Traces** 改为 **8K / 1K**：`GlobalFilterContext.tsx` 中 `selectedSequence` 的默认值由 `Sequence.AgenticTraces` 改为 `Sequence.EightK_OneK`。
- 其余行为刻意保持不变：
  - 显式 `?i_seq=` 分享链接仍然优先（包括 `agentic-traces`）。
  - `/compare` 页面的 `initialSequence` 预设仍然优先。
  - `resolveEffectiveSequence` 的可用性回退顺序（保留用户选择 → 优先 `8k/1k` → 第一个可用项）未改动，因此仅有 agentic 数据的模型仍会解析到 agentic 场景。
  - `PARAM_DEFAULTS.i_seq` 保持为 `''`：由于各路由的 `initialSequence` 预设不同，若把 `'8k/1k'` 作为可剥离默认值，显式选择 8K/1K 后重新加载会回退到路由预设场景。
- 更新了所有以"agentic 优先默认"为依据的代码注释；场景下拉菜单的分组顺序（Agentic 组在前）不变，仅为显示顺序。

**测试**：新增 E2E 用例验证即使模型有 agentic 数据，裸 `/inference` 默认仍为 8K/1K；原依赖默认 agentic 的 E2E 套件改为显式指定 `?i_seq=agentic-traces`（含 unofficial-run overlay 套件）。本地已通过 `pnpm typecheck`、`pnpm lint`、`pnpm fmt`、`pnpm test:unit`（2560 个用例）及相关 E2E 测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default scenario affects first paint, benchmark fetches, and share-link behavior on `/inference`, though explicit URL/route seeds and availability resolution are preserved; regression risk is mainly UX and wrong data path on load.
> 
> **Overview**
> **Bare `/inference` (no `?i_seq=`) now opens on 8K / 1K** instead of Agentic Traces. The main behavioral change is in `GlobalFilterContext`: `selectedSequence` initializes to `Sequence.EightK_OneK` rather than `Sequence.AgenticTraces`. Explicit `?i_seq=`, per-route `initialSequence`, and `resolveEffectiveSequence` fallback rules are unchanged.
> 
> Comments and docs across `default-sequence.ts`, `InferenceContext`, `url-state`, and `chart-selectors` now describe **8K/1K as the app default** (Agentic still listed first in the dropdown for display only). `PARAM_DEFAULTS.i_seq` stays empty so share URLs keep explicit scenario picks.
> 
> **E2E:** Agentic x-axis and overlay suites visit with `?i_seq=agentic-traces` instead of relying on the old default. A new test asserts bare `/inference` shows **8K / 1K** even when availability includes both agentic and fixed-seq data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014bf305fcfbf238e9430e8a0fb9eaab1104c0d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->