### PR TITLE
fix(db): purge agentic availability rows (NULL-safe) / 修复：清理 agentic availability 行（NULL 安全）

### DIFF
--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -200,11 +200,14 @@ async function purge(wrIds: number[]): Promise<void> {
       `;
     }
 
-    // Orphaned availability rows
+    // Orphaned availability rows. NULL-safe on isl/osl (`IS NOT DISTINCT FROM`)
+    // so agentic rows are matched too: agentic_traces availability has isl/osl
+    // NULL, and a row-value `IN` / `=` never matches NULL — which previously
+    // left agentic availability rows behind after a purge.
     if (availKeys.length > 0) {
       const models = availKeys.map((r) => r.model as string);
-      const isls = availKeys.map((r) => r.isl as number);
-      const osls = availKeys.map((r) => r.osl as number);
+      const isls = availKeys.map((r) => r.isl as number | null);
+      const osls = availKeys.map((r) => r.osl as number | null);
       const precisions = availKeys.map((r) => r.precision as string);
       const hardwares = availKeys.map((r) => r.hardware as string);
       const frameworks = availKeys.map((r) => r.framework as string);
@@ -214,20 +217,27 @@ async function purge(wrIds: number[]): Promise<void> {
 
       await tx`
         DELETE FROM availability a
-        WHERE (a.model, a.isl, a.osl, a.precision, a.hardware, a.framework, a.spec_method, a.disagg, a.date)
-          IN (
-            SELECT t.model, t.isl::int, t.osl::int, t.precision, t.hardware,
-                   t.framework, t.spec_method, t.disagg::boolean, t.date::date
-            FROM unnest(
-              ${models}::text[], ${isls}::int[], ${osls}::int[],
-              ${precisions}::text[], ${hardwares}::text[], ${frameworks}::text[],
-              ${specMethods}::text[], ${disaggs}::text[], ${dates}::text[]
-            ) AS t(model, isl, osl, precision, hardware, framework, spec_method, disagg, date)
-          )
+        USING (
+          SELECT t.model, t.isl::int AS isl, t.osl::int AS osl, t.precision, t.hardware,
+                 t.framework, t.spec_method, t.disagg::boolean AS disagg, t.date::date AS date
+          FROM unnest(
+            ${models}::text[], ${isls}::int[], ${osls}::int[],
+            ${precisions}::text[], ${hardwares}::text[], ${frameworks}::text[],
+            ${specMethods}::text[], ${disaggs}::text[], ${dates}::text[]
+          ) AS t(model, isl, osl, precision, hardware, framework, spec_method, disagg, date)
+        ) k
+        WHERE a.model = k.model
+          AND a.isl IS NOT DISTINCT FROM k.isl
+          AND a.osl IS NOT DISTINCT FROM k.osl
+          AND a.precision = k.precision AND a.hardware = k.hardware
+          AND a.framework = k.framework AND a.spec_method = k.spec_method
+          AND a.disagg = k.disagg AND a.date = k.date
           AND NOT EXISTS (
             SELECT 1 FROM benchmark_results br
             JOIN configs c ON c.id = br.config_id
-            WHERE c.model = a.model AND br.isl = a.isl AND br.osl = a.osl
+            WHERE c.model = a.model
+              AND br.isl IS NOT DISTINCT FROM a.isl
+              AND br.osl IS NOT DISTINCT FROM a.osl
               AND c.precision = a.precision AND c.hardware = a.hardware
               AND c.framework = a.framework AND c.spec_method = a.spec_method
               AND c.disagg = a.disagg AND br.date = a.date AND br.error IS NULL


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes destructive purge SQL in the admin override path; behavior is more correct for NULL keys but still deletes availability when no matching benchmarks remain.
> 
> **Overview**
> Fixes orphaned **`availability`** cleanup during `purge()` in **`apply-overrides`**, which could leave **agentic** rows behind because **`isl`/`osl`** are **NULL** for `agentic_traces` and row-value **`IN`/`=`** never matches NULL.
> 
> The delete now joins keys via **`USING` + `unnest`** and matches **`isl`/`osl`** with **`IS NOT DISTINCT FROM`** on both the **`availability`** row and the **`NOT EXISTS`** check against surviving **`benchmark_results`**. Key arrays are typed to allow **`number | null`** for those columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7384b0580425ddeb742ada4f39af1f8ac595e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->