### PR TITLE
feat: add zizmor and resolve alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    cooldown:
+      default-days: 1
     open-pull-requests-limit: 2
     labels:
       - 'type/dependencies'
@@ -28,6 +30,8 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    cooldown:
+      default-days: 1
     open-pull-requests-limit: 2
     labels:
       - 'type/dependencies'

--- a/.github/workflows/cache-refresh.yml
+++ b/.github/workflows/cache-refresh.yml
@@ -3,14 +3,23 @@ name: Cache Refresh
 on:
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   refresh:
+    name: Refresh cache
     timeout-minutes: 5
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
 
+permissions: {}
+
 # Single source of truth for the models. Bumping either is a one-line change.
 env:
   CLAUDE_MODEL: claude-opus-4-8
@@ -155,11 +157,11 @@ jobs:
       DATABASE_DRIVER: neon
       DATABASE_SSL: 'true'
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      actions: read
-      id-token: write
+      contents: write # Commit and push implementation changes
+      pull-requests: write # Update pull requests and progress
+      issues: write # Update issue comments and progress
+      actions: read # Inspect workflow runs and checks
+      id-token: write # Authenticate the Claude Code action with OIDC
     # Serialize @claude runs on the same issue/PR (incl. reviews — shared group with the
     # review job) so back-to-back triggers don't clobber each other.
     concurrency:
@@ -172,6 +174,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
+          # The implementation agent commits and pushes its changes.
+          persist-credentials: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
@@ -358,9 +362,9 @@ jobs:
       DATABASE_SSL: 'true'
     permissions:
       contents: read
-      pull-requests: write
-      actions: read
-      id-token: write
+      pull-requests: write # Post pull-request review comments
+      actions: read # Inspect workflow runs and checks
+      id-token: write # Authenticate the Claude Code action with OIDC
     concurrency:
       group: claude-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -5,14 +5,23 @@ on:
     - cron: '0 0 * * 1' # Every Monday at midnight UTC
   workflow_dispatch:
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   backup:
+    name: Back up database
     timeout-minutes: 120
     runs-on: blacksmith-32vcpu-ubuntu-2404
     permissions:
-      contents: write
+      contents: write # Create the database dump release
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -44,8 +44,15 @@ on:
           - production
           - dev
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.client_payload.run-id || inputs.run-id }}
+  cancel-in-progress: false
+
 jobs:
   ingest:
+    name: Ingest agentic benchmark results
     # Blob-heavy: uploading trace-replay sidecars for a ~20-point sweep takes
     # far longer than a fixed-seq-len ingest.
     timeout-minutes: 60
@@ -58,6 +65,8 @@ jobs:
         run: sleep 300
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -184,8 +193,10 @@ jobs:
       - name: Check for unmapped entities
         if: always()
         id: unmapped
+        env:
+          UNMAPPED_ENTITIES_FILE: ${{ github.workspace }}/unmapped-entities.json
         run: |
-          f="${{ github.workspace }}/unmapped-entities.json"
+          f="$UNMAPPED_ENTITIES_FILE"
           if [ -f "$f" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             models=$(jq -r '.models // [] | join(", ")' "$f")

--- a/.github/workflows/ingest-results.yml
+++ b/.github/workflows/ingest-results.yml
@@ -4,8 +4,15 @@ on:
   repository_dispatch:
     types: [ingest-results]
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.client_payload.run-id }}
+  cancel-in-progress: false
+
 jobs:
   ingest:
+    name: Ingest benchmark results
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
@@ -15,6 +22,8 @@ jobs:
         run: sleep 300
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -143,8 +152,10 @@ jobs:
       - name: Check for unmapped entities
         if: always()
         id: unmapped
+        env:
+          UNMAPPED_ENTITIES_FILE: ${{ github.workspace }}/unmapped-entities.json
         run: |
-          f="${{ github.workspace }}/unmapped-entities.json"
+          f="$UNMAPPED_ENTITIES_FILE"
           if [ -f "$f" ]; then
             echo "found=true" >> "$GITHUB_OUTPUT"
             models=$(jq -r '.models // [] | join(", ")' "$f")

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -14,8 +14,15 @@ on:
       - 'pnpm-workspace.yaml'
       - 'tsconfig.json'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   component-tests:
+    name: Component tests
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 15
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -23,6 +30,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
@@ -49,6 +58,7 @@ jobs:
           CI: true
 
   cypress:
+    name: E2E (${{ matrix.browser }}, shard ${{ matrix.shard }})
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 15
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -64,6 +74,8 @@ jobs:
         shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -14,8 +14,15 @@ on:
       - 'pnpm-workspace.yaml'
       - 'tsconfig.json'
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   vitest:
+    name: Typecheck and unit tests
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 10
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -23,6 +30,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,9 +1,16 @@
-name: 'Lint & Format'
+name: Zizmor
 
 on:
   pull_request:
     branches: [main, master]
     types: [opened, synchronize, ready_for_review]
+    paths:
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - 'action.yml'
+      - 'action.yaml'
 
 permissions: {}
 
@@ -12,8 +19,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  oxc:
-    name: Lint and format
+  zizmor:
+    name: Audit GitHub Actions
     if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     runs-on: ubuntu-latest
@@ -23,16 +30,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '24'
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        env:
-          CYPRESS_INSTALL_BINARY: '0'
-      - name: Lint
-        run: pnpm lint
-      - name: Format check
-        run: pnpm fmt
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+      - name: Audit workflows
+        run: uvx --exclude-newer P1D zizmor@latest --strict-collection --pedantic --no-ignores .

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  dependabot-cooldown:
+    config:
+      # Match pnpm-workspace.yaml's minimumReleaseAge of 1,440 minutes.
+      days: 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CI/Dependabot configuration; Claude implement still needs write permissions and persisted credentials by design.
> 
> **Overview**
> Adds **zizmor** as a PR check (`.github/workflows/zizmor.yml`) that audits workflows with strict/pedantic flags when `.github/**` or action manifests change, plus `.github/zizmor.yml` configuring the dependabot-cooldown rule to **1 day** (aligned with pnpm `minimumReleaseAge`).
> 
> **Dependabot** now sets `cooldown.default-days: 1` for both npm and GitHub Actions ecosystems.
> 
> **Workflow hardening** across cache-refresh, lint, tests, ingest, db-backup, and Claude jobs: workflow-level `permissions: {}`, explicit **concurrency** groups (cancel in-flight on PR workflows where appropriate), `actions/checkout` with **`persist-credentials: false`** everywhere except Claude **implement** (still `true` so the agent can push), clearer job **names**, and permission comments on sensitive jobs. Ingest workflows pass **`UNMAPPED_ENTITIES_FILE`** via `env` instead of embedding `${{ github.workspace }}` in shell scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d87f139533fd8c6a45eff21ef1ad54898614ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->