### PR TITLE
feat: automate run overrides

### DIFF
--- a/.claude/agents/ingest.md
+++ b/.claude/agents/ingest.md
@@ -29,7 +29,12 @@ pnpm exec tsx src/ingest-ci-run.ts --download <RUN_ID> SemiAnalysisAI/InferenceX
 Then refresh the materialized view (the script's auto-refresh sometimes races):
 `REFRESH MATERIALIZED VIEW latest_benchmarks;`
 
-## Cache purge (always do after any DB mutation)
+## Cache refresh
+
+For manual ingests or direct DB mutations, purge localhost and production after the write. For
+registry-only changes to `packages/db/src/etl/run-overrides.ts`, do not apply the production
+override or refresh production manually: after merge, CI applies the overrides, verifies the
+database, invalidates production, and warms production automatically.
 
 ```bash
 SECRET=$(grep "^INVALIDATE_SECRET" /Users/quilicic/InferenceX-app/.env | cut -d= -f2 | tr -d '"')
@@ -166,7 +171,7 @@ If the user doesn't specify a description, DO NOT skip the entry and DO NOT bloc
 3. **Ingest** via the standard path. Do NOT use AIPerf tagging unless the user explicitly asks for a separate legend line.
 4. **Refresh materialized view**.
 5. **Add changelog entry — ALWAYS, MANDATORY.** Every ingest gets exactly one changelog entry (see "Adding a perf changelog entry — MANDATORY"). Use the user's text if given (substituting `<SKU>`); otherwise derive one from the run name and add it anyway. Never skip this step.
-6. **Purge both caches** (localhost 3002 + production — never port 3000).
+6. **Refresh both caches for manual ingests** (localhost 3002 + production — never port 3000). Override-only commits are handled by CI after merge.
 7. **Report** the row count, date, hardware, run id, and the changelog id (always present).
 
 ## Related: ingesting agentic _datasets_ (not benchmark runs)

--- a/.github/workflows/apply-run-overrides.yml
+++ b/.github/workflows/apply-run-overrides.yml
@@ -1,0 +1,57 @@
+name: Apply Run Overrides
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - 'packages/db/src/etl/run-overrides.ts'
+      - '.github/workflows/apply-run-overrides.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: apply-run-overrides-production
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply production run overrides
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+          cache: pnpm
+      - name: Install dependencies
+        run: >-
+          pnpm install --frozen-lockfile
+          --filter @semianalysisai/inferencex-db...
+          --filter @semianalysisai/inferencex-app...
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+
+      - name: Apply run overrides
+        env:
+          DATABASE_WRITE_URL: ${{ secrets.DATABASE_WRITE_URL }}
+        run: pnpm admin:db:apply-overrides --yes
+
+      - name: Verify database
+        env:
+          DATABASE_WRITE_URL: ${{ secrets.DATABASE_WRITE_URL }}
+        run: pnpm admin:db:verify
+
+      - name: Invalidate production cache
+        env:
+          INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
+        run: pnpm admin:cache:invalidate https://inferencex.semianalysis.com
+
+      - name: Warm production cache
+        run: pnpm admin:cache:warmup https://inferencex.semianalysis.com

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
     "catmull",
     "CDNA",
     "chenglou",
+    "cooldown",
     "costh",
     "costhi",
     "costn",
@@ -88,6 +89,7 @@
     "vllm",
     "worktrees",
     "yaxis",
+    "zizmor",
     "zoomable"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -119,18 +119,20 @@ Some of these may require additional setup or environment variables.
 These are meant to be used for database and cache management and maintenance tasks, and should not be necessary during regular development.
 However, using `pnpm admin:cache:invalidate` pointed at your local development server can be useful to test after making changes to the database or API routes.
 
-| Script                              | Description                            |
-| ----------------------------------- | -------------------------------------- |
-| `pnpm admin:db:migrate`             | Run database migrations                |
-| `pnpm admin:db:ingest:run`          | Ingest benchmark data from GitHub runs |
-| `pnpm admin:db:ingest:ci`           | Ingest benchmark data (CI mode)        |
-| `pnpm admin:db:ingest:gcs`          | Ingest benchmark data from GCS         |
-| `pnpm admin:db:ingest:supplemental` | Ingest supplemental data               |
-| `pnpm admin:db:apply-overrides`     | Apply data overrides                   |
-| `pnpm admin:db:reset`               | Reset the database                     |
-| `pnpm admin:db:verify`              | Verify database integrity              |
-| `pnpm admin:cache:invalidate`       | Invalidate API cache                   |
-| `pnpm admin:cache:warmup`           | Warm up API cache                      |
+Changes to `packages/db/src/etl/run-overrides.ts` that reach `main` or `master` are applied to the production database automatically by CI, followed by database verification, cache invalidation, and cache warmup. The override command remains available for local previews and manual recovery.
+
+| Script                              | Description                              |
+| ----------------------------------- | ---------------------------------------- |
+| `pnpm admin:db:migrate`             | Run database migrations                  |
+| `pnpm admin:db:ingest:run`          | Ingest benchmark data from GitHub runs   |
+| `pnpm admin:db:ingest:ci`           | Ingest benchmark data (CI mode)          |
+| `pnpm admin:db:ingest:gcs`          | Ingest benchmark data from GCS           |
+| `pnpm admin:db:ingest:supplemental` | Ingest supplemental data                 |
+| `pnpm admin:db:apply-overrides`     | Preview or apply data overrides manually |
+| `pnpm admin:db:reset`               | Reset the database                       |
+| `pnpm admin:db:verify`              | Verify database integrity                |
+| `pnpm admin:cache:invalidate`       | Invalidate API cache                     |
+| `pnpm admin:cache:warmup`           | Warm up API cache                        |
 
 ## Deployment
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -119,6 +119,8 @@ pnpm dev
 以下脚本用于数据库与缓存的管理维护，常规开发中一般不需要。
 不过在改动数据库或 API 路由后，将 `pnpm admin:cache:invalidate` 指向本地开发服务器进行测试会很有用。
 
+合并到 `main` 或 `master` 的 `packages/db/src/etl/run-overrides.ts` 变更会由 CI 自动应用到生产数据库，随后执行数据库校验、缓存失效和缓存预热。覆盖命令仍可用于本地预览和手动恢复。
+
 | 脚本                                | 说明                           |
 | ----------------------------------- | ------------------------------ |
 | `pnpm admin:db:migrate`             | 运行数据库迁移                 |
@@ -126,7 +128,7 @@ pnpm dev
 | `pnpm admin:db:ingest:ci`           | 摄取基准测试数据（CI 模式）    |
 | `pnpm admin:db:ingest:gcs`          | 从 GCS 摄取基准测试数据        |
 | `pnpm admin:db:ingest:supplemental` | 摄取补充数据                   |
-| `pnpm admin:db:apply-overrides`     | 应用数据覆盖                   |
+| `pnpm admin:db:apply-overrides`     | 手动预览或应用数据覆盖         |
 | `pnpm admin:db:reset`               | 重置数据库                     |
 | `pnpm admin:db:verify`              | 校验数据库完整性               |
 | `pnpm admin:cache:invalidate`       | 失效 API 缓存                  |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ Vercel-Cache-Tag: db
 
 ### /api/v1/invalidate
 
-`POST /api/v1/invalidate` requires a `Bearer {INVALIDATE_SECRET}` header (compared with `timingSafeEqual` to prevent timing attacks). On success it calls `purgeAll()` — which clears blob storage, bumps the cache-version timestamp, and revalidates the `'db'` tag — then returns `{ invalidated: true, blobsDeleted: N }`. This endpoint is called by the CI ingest pipeline after each benchmark run completes.
+`POST /api/v1/invalidate` requires a `Bearer {INVALIDATE_SECRET}` header (compared with `timingSafeEqual` to prevent timing attacks). On success it calls `purgeAll()` — which clears blob storage, bumps the cache-version timestamp, and revalidates the `'db'` tag — then returns `{ invalidated: true, blobsDeleted: N }`. This endpoint is called by the CI ingest pipelines after benchmark runs and by the run-override pipeline after it applies and verifies merged override changes.
 
 ## React Query Configuration
 

--- a/packages/app/scripts/warmup-cache.ts
+++ b/packages/app/scripts/warmup-cache.ts
@@ -127,6 +127,9 @@ async function warmupCaches() {
 
   const elapsed = ((performance.now() - start) / 1000).toFixed(1);
   console.log(`\nDone: ${ok}/${total} succeeded, ${failed} failed (${elapsed}s)`);
+  if (failed > 0) {
+    throw new Error(`${failed} cache warmup request${failed === 1 ? '' : 's'} failed`);
+  }
 }
 
 warmupCaches().catch((error) => {

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -9,6 +9,9 @@
  * Usage:
  *   pnpm db:apply-overrides            # preview + confirm
  *   pnpm db:apply-overrides --yes      # skip confirmation
+ *
+ * Commits to run-overrides.ts are applied to production automatically after merge.
+ * Use this command directly only for local preview or manual recovery.
  */
 
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
@@ -328,7 +331,8 @@ async function main(): Promise<void> {
   await refreshLatestBenchmarks(sql);
 
   console.log('\n=== apply-overrides complete ===');
-  console.log('  Invalidate API cache: pnpm admin:cache:invalidate');
+  console.log('  Manual runs: invalidate the API cache with pnpm admin:cache:invalidate');
+  console.log('  Merged run-overrides changes: production cache refresh is handled by CI.');
 }
 
 main()

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -1,7 +1,9 @@
 /**
  * Per-run overrides and special cases for the ingest pipeline.
  *
- * All are applied at ingest time. Run `pnpm db:apply-overrides` to patch existing DB rows.
+ * Entries are enforced at ingest time. Changes merged to main or master are also applied
+ * automatically to production by CI, followed by database verification, cache invalidation,
+ * and cache warmup. Use `pnpm db:apply-overrides` only for local preview or manual recovery.
  *
  * CONCLUSION_OVERRIDES — force the conclusion for a run (e.g. 'success' when
  *   the benchmark ran fine but CI failed on a non-benchmark step).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The workflow writes to production via `DATABASE_WRITE_URL` and purges CDN cache; mis-merged override entries could delete or patch live benchmark data until reverted.
> 
> **Overview**
> Adds a **GitHub Actions workflow** that runs when `packages/db/src/etl/run-overrides.ts` (or the workflow file) lands on `main`/`master`: it applies overrides with `pnpm admin:db:apply-overrides --yes`, runs `admin:db:verify`, then **invalidates and warms** production cache via the existing admin scripts.
> 
> **Docs and operator guidance** now say registry-only `run-overrides.ts` changes should **not** be applied or cache-purged manually on production—CI owns that path after merge. The ingest agent, README (EN/ZH), `run-overrides.ts`, `apply-overrides.ts`, and architecture notes were updated accordingly; `admin:db:apply-overrides` is described as manual preview/recovery.
> 
> **`warmup-cache.ts`** now **fails the process** if any warmup request fails, so CI can detect a bad cache warm. Minor `.vscode` cSpell additions (`cooldown`, `zizmor`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c6f04070dc06d5bc1de164ae0ccb5110330fa4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->