### PR TITLE
fix: allow staging reusable workflow checkout / 允许预发布可复用工作流检出代码

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -196,6 +196,8 @@ jobs:
   ingest:
     name: Ingest selected run
     needs: [validate, refresh-staging-database]
+    permissions:
+      contents: read
     uses: ./.github/workflows/ingest-agentic-results.yml
     with:
       run-id: ${{ needs.validate.outputs.run-id }}


### PR DESCRIPTION
## Summary

- grant the staging caller contents read permission for the reusable ingest job
- allow the called workflow to request its existing contents read permission
- fix the repository_dispatch startup failure that occurred before any staging job ran

## Root cause

The top-level staging workflow defaulted all GITHUB_TOKEN permissions to none. Its reusable ingest workflow requests contents read for checkout, but reusable workflows cannot elevate permissions beyond their caller. GitHub therefore rejected the workflow graph with startup_failure.

## Validation

- actionlint .github/workflows/stage-results.yml
- git diff --check
- zizmor .github/workflows/stage-results.yml

## 中文说明

- 为预发布调用方的可复用写入任务授予 contents 读取权限
- 允许被调用工作流申请其已有的 contents 读取权限
- 修复 repository_dispatch 在任何预发布任务启动前出现的 startup_failure

根因是顶层预发布工作流将 GITHUB_TOKEN 权限默认为 none，而可复用写入工作流需要 contents 读取权限来检出代码。可复用工作流不能超出调用方的权限上限，因此 GitHub 在构建工作流任务图时直接拒绝启动。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission wiring with no application, auth, or data-path changes.
> 
> **Overview**
> The staging workflow sets **`permissions: {}`** at the top level, so jobs start with no `GITHUB_TOKEN` scopes. The **`ingest`** job invokes reusable **`ingest-agentic-results.yml`**, whose ingest job needs **`contents: read`** for **`actions/checkout`**. Reusable workflows cannot exceed the caller’s permissions, so GitHub rejected the workflow graph with **`startup_failure`** before any staging job ran.
> 
> This change adds **`permissions: contents: read`** on the **`ingest`** job in **`stage-results.yml`**, matching what the called workflow already requests and unblocking **`repository_dispatch`** staging runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f6de30cb1364518d9a91fb090286b6b5013225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->