### PR TITLE
fix: finish staging ingest callbacks / 修复暂存摄取回调收尾流程

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -53,9 +53,6 @@ on:
       VERCEL_INVALIDATE_SECRET:
         description: Production and development cache invalidation bearer token
         required: false
-      VERCEL_STAGING_INVALIDATE_SECRET:
-        description: Staging cache invalidation bearer token
-        required: true
       VERCEL_STAGING_BYPASS_SECRET:
         description: Vercel protection automation bypass token
         required: true
@@ -128,7 +125,6 @@ jobs:
           DATABASE_WRITE_URL_DEV: ${{ secrets.DATABASE_DEV_WRITE_URL }}
           DATABASE_WRITE_URL_STAGING: ${{ secrets.DATABASE_STAGING_WRITE_URL }}
           INVALIDATE_SECRET_DEFAULT: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
-          INVALIDATE_SECRET_STAGING: ${{ secrets.VERCEL_STAGING_INVALIDATE_SECRET }}
           PROTECTION_BYPASS_SECRET_STAGING: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
           STAGING_SITE_URL: ${{ vars.STAGING_SITE_URL || 'https://inferencemax-app-git-staging-semianalysisai.vercel.app' }}
         run: |
@@ -146,7 +142,6 @@ jobs:
             staging)
               database_write_url="$DATABASE_WRITE_URL_STAGING"
               cache_invalidate_url="${STAGING_SITE_URL%/}/api/v1/invalidate"
-              cache_invalidate_secret="$INVALIDATE_SECRET_STAGING"
               protection_bypass_secret="$PROTECTION_BYPASS_SECRET_STAGING"
               ;;
             *)
@@ -159,7 +154,7 @@ jobs:
             echo "::error::Database secret is empty for target: $REQUESTED_DATABASE_TARGET"
             exit 1
           fi
-          if [ -z "$cache_invalidate_secret" ]; then
+          if [ "$REQUESTED_DATABASE_TARGET" != "staging" ] && [ -z "$cache_invalidate_secret" ]; then
             echo "::error::Cache invalidation secret is empty for target: $REQUESTED_DATABASE_TARGET"
             exit 1
           fi
@@ -169,7 +164,9 @@ jobs:
           fi
 
           echo "::add-mask::$database_write_url"
-          echo "::add-mask::$cache_invalidate_secret"
+          if [ -n "$cache_invalidate_secret" ]; then
+            echo "::add-mask::$cache_invalidate_secret"
+          fi
           if [ -n "$protection_bypass_secret" ]; then
             echo "::add-mask::$protection_bypass_secret"
           fi
@@ -259,8 +256,7 @@ jobs:
       - name: Invalidate Vercel cache
         run: |
           if [ "$INGEST_DATABASE_TARGET" = "staging" ]; then
-            curl --retry 12 --retry-delay 10 --retry-all-errors -sSf -X POST "$CACHE_INVALIDATE_URL" \
-              -H "Authorization: Bearer $CACHE_INVALIDATE_SECRET" \
+            curl --retry 3 --retry-delay 2 --retry-connrefused -sSf -X POST "$CACHE_INVALIDATE_URL" \
               -H "x-vercel-protection-bypass: $CACHE_PROTECTION_BYPASS_SECRET"
           else
             curl -sSf -X POST "$CACHE_INVALIDATE_URL" \
@@ -293,7 +289,7 @@ jobs:
           fi
 
       - name: Notify Slack on unmapped entities
-        if: steps.unmapped.outputs.found == 'true'
+        if: steps.unmapped.outputs.found == 'true' && env.INGEST_DATABASE_TARGET != 'staging'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -304,7 +300,7 @@ jobs:
             }
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() && env.INGEST_DATABASE_TARGET != 'staging'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -216,7 +216,6 @@ jobs:
       database-target: staging
     secrets:
       DATABASE_STAGING_WRITE_URL: ${{ secrets.DATABASE_STAGING_WRITE_URL }}
-      VERCEL_STAGING_INVALIDATE_SECRET: ${{ secrets.VERCEL_STAGING_INVALIDATE_SECRET }}
       VERCEL_STAGING_BYPASS_SECRET: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
       INFX_MAIN_PAT: ${{ secrets.INFX_MAIN_PAT }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -238,7 +237,7 @@ jobs:
           COMMENT_ID: ${{ needs.validate.outputs.comment-id }}
           STAGE_SUCCEEDED: ${{ needs['sync-staging-branch'].result == 'success' && needs['refresh-staging-database'].result == 'success' && needs.ingest.result == 'success' }}
         with:
-          github-token: ${{ secrets.INFX_MAIN_PAT }}
+          github-token: ${{ secrets.PAT }}
           script: |
             await github.rest.repos.createDispatchEvent({
               owner: 'SemiAnalysisAI',

--- a/packages/app/src/app/api/v1/invalidate/route.test.ts
+++ b/packages/app/src/app/api/v1/invalidate/route.test.ts
@@ -11,11 +11,17 @@ vi.mock('@/lib/api-cache', () => ({
 import { POST } from './route';
 
 let origSecret: string | undefined;
+let origVercelEnv: string | undefined;
+let origVercelGitCommitRef: string | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
   origSecret = process.env.INVALIDATE_SECRET;
+  origVercelEnv = process.env.VERCEL_ENV;
+  origVercelGitCommitRef = process.env.VERCEL_GIT_COMMIT_REF;
   process.env.INVALIDATE_SECRET = 'test-secret-123';
+  delete process.env.VERCEL_ENV;
+  delete process.env.VERCEL_GIT_COMMIT_REF;
 });
 
 afterEach(() => {
@@ -23,6 +29,16 @@ afterEach(() => {
     delete process.env.INVALIDATE_SECRET;
   } else {
     process.env.INVALIDATE_SECRET = origSecret;
+  }
+  if (origVercelEnv === undefined) {
+    delete process.env.VERCEL_ENV;
+  } else {
+    process.env.VERCEL_ENV = origVercelEnv;
+  }
+  if (origVercelGitCommitRef === undefined) {
+    delete process.env.VERCEL_GIT_COMMIT_REF;
+  } else {
+    process.env.VERCEL_GIT_COMMIT_REF = origVercelGitCommitRef;
   }
 });
 
@@ -56,6 +72,38 @@ describe('POST /api/v1/invalidate', () => {
   it('returns 401 for length mismatch (timing-safe)', async () => {
     const res = await POST(postReq({ Authorization: 'Bearer short' }));
     expect(res.status).toBe(401);
+  });
+
+  it('allows the Vercel-protected staging branch with an automation bypass', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_GIT_COMMIT_REF = 'staging';
+    mockPurgeAll.mockResolvedValueOnce(4);
+
+    const res = await POST(postReq({ 'x-vercel-protection-bypass': 'opaque-bypass' }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ invalidated: true, blobsDeleted: 4 });
+    expect(mockPurgeAll).toHaveBeenCalledOnce();
+  });
+
+  it('still requires app auth for non-staging preview branches', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_GIT_COMMIT_REF = 'feature-branch';
+
+    const res = await POST(postReq({ 'x-vercel-protection-bypass': 'opaque-bypass' }));
+
+    expect(res.status).toBe(401);
+    expect(mockPurgeAll).not.toHaveBeenCalled();
+  });
+
+  it('still requires app auth when staging has no automation bypass header', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_GIT_COMMIT_REF = 'staging';
+
+    const res = await POST(postReq());
+
+    expect(res.status).toBe(401);
+    expect(mockPurgeAll).not.toHaveBeenCalled();
   });
 
   it('invalidates cache with correct auth', async () => {

--- a/packages/app/src/app/api/v1/invalidate/route.ts
+++ b/packages/app/src/app/api/v1/invalidate/route.ts
@@ -8,11 +8,21 @@ export async function POST(request: Request) {
   const secret = process.env.INVALIDATE_SECRET;
   const authHeader = request.headers.get('Authorization') ?? '';
   const expected = `Bearer ${secret}`;
+  // The shared staging deployment is already protected by Vercel. Its CI
+  // caller must present the project-scoped automation bypass before Vercel
+  // forwards this header to the route, so a second app secret is redundant.
+  // Keep this exception branch-specific; production and every other preview
+  // continue to require INVALIDATE_SECRET below.
+  const isProtectedStagingRequest =
+    process.env.VERCEL_ENV === 'preview' &&
+    process.env.VERCEL_GIT_COMMIT_REF === 'staging' &&
+    Boolean(request.headers.get('x-vercel-protection-bypass'));
 
   if (
-    !secret ||
-    authHeader.length !== expected.length ||
-    !timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected))
+    !isProtectedStagingRequest &&
+    (!secret ||
+      authHeader.length !== expected.length ||
+      !timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected)))
   ) {
     return new NextResponse('Unauthorized', { status: 401 });
   }


### PR DESCRIPTION
## Summary

- Let the Vercel-protected `staging` preview invalidate its cache with the project-scoped automation bypass instead of a second branch-scoped app secret.
- Stop retrying ordinary authorization failures, while retaining short retries for connection-refused failures.
- Suppress both failure and unmapped-entity Slack notifications for staging ingests.
- Send the completion callback with the broader repository PAT so InferenceX can update the existing PR acknowledgment comment.
- Add regression tests proving the exception is limited to the protected `staging` preview and does not weaken production or other preview branches.

## Root cause

The staging ingest itself completed successfully, but cache invalidation returned 401 because the GitHub copy of the sensitive branch-scoped invalidation secret did not match the deployed Vercel value. The callback then returned 403 because `INFX_MAIN_PAT` could read artifacts but could not dispatch an event to InferenceX.

## Validation

- Focused invalidate route tests: 9/9
- Full unit suites: app 2,566; DB 356; constants 33; MCP 25
- Typecheck, lint, format, and actionlint
- Cypress component tests: 176/176
- Cypress E2E tests: 478/478

## 中文说明

- 受 Vercel 保护的 `staging` 预览部署现在使用项目级自动化绕过凭据刷新缓存，不再依赖第二个分支级应用密钥。
- 普通鉴权失败不再重复重试；连接被拒绝时仍会进行少量短重试。
- staging 摄取发生失败或未映射实体时均不再发送 Slack 通知。
- 完成回调改用权限更完整的仓库 PAT，使 InferenceX 能原位更新 PR 中已有的确认评论。
- 新增回归测试，确保该例外仅适用于受保护的 `staging` 预览分支，不会放宽 production 或其他预览分支的鉴权。

## 根因

暂存数据库摄取本身已经成功，但 GitHub 中保存的敏感分支级缓存刷新密钥与 Vercel 部署值不一致，导致缓存刷新返回 401。随后，`INFX_MAIN_PAT` 虽可读取产物，却无权向 InferenceX 发送 repository dispatch，因此回调返回 403。

## 验证

- invalidate 路由专项测试：9/9
- 完整单元测试：app 2,566；DB 356；constants 33；MCP 25
- typecheck、lint、format 与 actionlint
- Cypress 组件测试：176/176
- Cypress E2E 测试：478/478

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth on a cache-purge API and CI secrets/tokens; scope is limited to staging preview plus PAT for cross-repo dispatch, with tests guarding the bypass.
> 
> **Overview**
> Fixes staging ingest **post-ingest** steps: cache purge and the InferenceX completion callback.
> 
> **Cache invalidation** no longer uses a separate `VERCEL_STAGING_INVALIDATE_SECRET`. Staging CI calls `POST /api/v1/invalidate` with only `x-vercel-protection-bypass`, matching Vercel’s protection on the shared staging preview. The route now accepts that path **only** when `VERCEL_ENV` is `preview`, `VERCEL_GIT_COMMIT_REF` is `staging`, and the bypass header is present; production and other previews still need `INVALIDATE_SECRET`. Workflows drop the staging invalidate secret, relax secret validation/masking for staging, and use shorter `curl` retries on connection refused (no long retries on auth failures).
> 
> **Staging noise** is reduced: Slack alerts for unmapped entities and workflow failure are skipped when `INGEST_DATABASE_TARGET` is staging.
> 
> **Completion callback** in `stage-results` uses `secrets.PAT` instead of `INFX_MAIN_PAT` so repository dispatch to InferenceX can update the PR acknowledgment comment.
> 
> Regression tests cover the staging-only bypass and that other branches stay locked down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acdceb1d29e8e72b7776f370ce54d0751748edb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->