### PR TITLE
fix: suppress early staging Slack alerts / 禁止 staging 早期失败触发 Slack 告警

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -98,6 +98,8 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
+    env:
+      REQUESTED_DATABASE_TARGET: ${{ github.event.client_payload.database-target || inputs.database-target || 'production' }}
     steps:
       - name: Wait for source run to finish
         if: >-
@@ -120,7 +122,6 @@ jobs:
 
       - name: Select ingest target
         env:
-          REQUESTED_DATABASE_TARGET: ${{ github.event.client_payload.database-target || inputs.database-target || 'production' }}
           DATABASE_WRITE_URL_PRODUCTION: ${{ secrets.DATABASE_WRITE_URL }}
           DATABASE_WRITE_URL_DEV: ${{ secrets.DATABASE_DEV_WRITE_URL }}
           DATABASE_WRITE_URL_STAGING: ${{ secrets.DATABASE_STAGING_WRITE_URL }}
@@ -289,7 +290,7 @@ jobs:
           fi
 
       - name: Notify Slack on unmapped entities
-        if: steps.unmapped.outputs.found == 'true' && env.INGEST_DATABASE_TARGET != 'staging'
+        if: steps.unmapped.outputs.found == 'true' && env.REQUESTED_DATABASE_TARGET != 'staging'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -300,7 +301,7 @@ jobs:
             }
 
       - name: Notify Slack on failure
-        if: failure() && env.INGEST_DATABASE_TARGET != 'staging'
+        if: failure() && env.REQUESTED_DATABASE_TARGET != 'staging'
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- Gate both staging Slack notifications on the workflow input, which is available before checkout and setup.
- Prevent failures before the target-selection step from accidentally notifying Slack.
- Follow up on the Bugbot finding from #568.

## Validation

- Pre-commit lint and format
- Typecheck
- `actionlint` (excluding the repository custom-runner label warning)

## 中文说明

- 两个 staging Slack 通知条件改为读取工作流输入，该输入在 checkout 与环境准备之前就已存在。
- 即使目标选择步骤之前发生失败，也不会意外发送 Slack 告警。
- 修复 Bugbot 在 #568 中指出的边界情况。

## 验证

- pre-commit lint 与 format
- typecheck
- `actionlint`（忽略仓库自定义 runner 标签的已知警告）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change to notification conditions; no application or ingest logic changes.
> 
> **Overview**
> **Staging Slack noise and false alerts** for the agentic ingest workflow are fixed by defining `REQUESTED_DATABASE_TARGET` at the **job** `env` (from dispatch payload / workflow inputs) instead of only on the “Select ingest target” step.
> 
> The **unmapped-entities** and **failure** Slack steps now check `env.REQUESTED_DATABASE_TARGET != 'staging'` instead of `INGEST_DATABASE_TARGET`, so staging ingests stay quiet even when the run fails **before** target selection writes `INGEST_DATABASE_TARGET` to `GITHUB_ENV`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c52d728ac37b6835a26e0ee3ffa27e8ed275e2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->