### PR TITLE
fix(db): Stream GiB-scale trace inputs / 流式处理 GiB 级 trace 输入

### DIFF
--- a/packages/db/src/etl/trace-replay-ingest.test.ts
+++ b/packages/db/src/etl/trace-replay-ingest.test.ts
@@ -1,8 +1,14 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync } from 'node:zlib';
+
 import type postgres from 'postgres';
 import { describe, expect, it } from 'vitest';
 
 import {
   TRACE_REPLAY_UPLOAD_CHUNK_BYTES,
+  gzipTraceReplayInput,
   uploadTraceReplayPayloadChunks,
 } from './trace-replay-ingest';
 
@@ -53,5 +59,24 @@ describe('uploadTraceReplayPayloadChunks', () => {
 
     await expect(uploadTraceReplayPayloadChunks(sql, 'chart_series', null)).resolves.toBe(0);
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe('gzipTraceReplayInput', () => {
+  it('streams a file-backed trace and preserves its uncompressed bytes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'trace-replay-stream-test-'));
+    const file = join(dir, 'server_metrics_export.json');
+    const raw = Buffer.alloc(2 * 1024 * 1024, 171);
+
+    try {
+      await writeFile(file, raw);
+      const prepared = await gzipTraceReplayInput(file);
+
+      expect(prepared.sourceSize).toBe(raw.length);
+      expect(prepared.data).not.toBeNull();
+      expect(gunzipSync(prepared.data!)).toEqual(raw);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/db/src/etl/trace-replay-ingest.ts
+++ b/packages/db/src/etl/trace-replay-ingest.ts
@@ -8,7 +8,9 @@
  * duplicate the sibling blob.
  */
 
-import { gzipSync } from 'node:zlib';
+import { createReadStream } from 'node:fs';
+import { readFile, stat } from 'node:fs/promises';
+import { createGzip, gzipSync } from 'node:zlib';
 
 import type postgres from 'postgres';
 
@@ -18,6 +20,13 @@ import { computeRequestTimeline } from './compute-request-timeline.js';
 import type { ServerMetricsContext } from './server-metrics-adapters';
 
 type Sql = ReturnType<typeof postgres>;
+
+export type TraceReplayInput = Buffer | string | null;
+
+export interface PreparedTraceReplayInput {
+  data: Buffer | null;
+  sourceSize: number | null;
+}
 
 /**
  * Keep each postgres.js Bind message comfortably below the large payload that
@@ -59,6 +68,36 @@ function jsonBuffer(value: unknown | null): Buffer | null {
 }
 
 /**
+ * Gzip a trace input without materializing file-backed GiB-scale exports in
+ * Node's heap. Buffer inputs remain supported for callers and unit tests.
+ */
+export async function gzipTraceReplayInput(
+  input: TraceReplayInput,
+): Promise<PreparedTraceReplayInput> {
+  if (input === null) return { data: null, sourceSize: null };
+  if (Buffer.isBuffer(input)) {
+    return { data: gzipSync(input), sourceSize: input.length };
+  }
+
+  const { size } = await stat(input);
+  const chunks: Buffer[] = [];
+  const stream = createReadStream(input, { highWaterMark: 1024 * 1024 }).pipe(
+    createGzip({ chunkSize: 1024 * 1024 }),
+  );
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return { data: Buffer.concat(chunks), sourceSize: size };
+}
+
+async function readTraceReplayInput(input: TraceReplayInput): Promise<PreparedTraceReplayInput> {
+  if (input === null) return { data: null, sourceSize: null };
+  if (Buffer.isBuffer(input)) return { data: input, sourceSize: input.length };
+  const data = await readFile(input);
+  return { data, sourceSize: data.length };
+}
+
+/**
  * Upload one trace-replay value as bounded binary parameters. The caller must
  * create `pg_temp.trace_replay_upload_parts` in the same transaction first.
  */
@@ -89,22 +128,22 @@ export async function uploadTraceReplayPayloadChunks(
  *                            the same `bmk_agentic_<suffix>` artifact whose
  *                            sibling `agentic_<suffix>` directory holds these
  *                            trace files.
- * @param profileExportJsonl  Raw bytes of `profile_export.jsonl`, or null.
- *                            Gzipped before storage.
- * @param serverMetricsCsv    Raw bytes of `server_metrics_export.csv`, or null.
+ * @param profileExportJsonl  Raw bytes or a file path for `profile_export.jsonl`.
+ *                            Gzipped before storage; file paths stream from disk.
+ * @param serverMetricsCsv    Raw bytes or a file path for `server_metrics_export.csv`.
  *                            Stored as-is.
- * @param serverMetricsJson   Raw bytes of `server_metrics_export.json` —
+ * @param serverMetricsJson   Raw bytes or a file path for `server_metrics_export.json` —
  *                            per-scrape time-series of every Prometheus metric.
- *                            Optional, gzipped before storage (~42x ratio).
+ *                            Optional, streamed and gzipped before storage (~42x ratio).
  * @param options             Canonical framework/disagg context plus optional
  *                            progress label for CI logs.
  */
 export async function insertTraceReplay(
   sql: Sql,
   benchmarkResultIds: number[],
-  profileExportJsonl: Buffer | null,
-  serverMetricsCsv: Buffer | null,
-  serverMetricsJson: Buffer | null = null,
+  profileExportJsonl: TraceReplayInput,
+  serverMetricsCsv: TraceReplayInput,
+  serverMetricsJson: TraceReplayInput = null,
   options: TraceReplayIngestOptions = {},
 ): Promise<void> {
   const { metricsContext = {}, progressLabel } = options;
@@ -131,19 +170,23 @@ export async function insertTraceReplay(
   }
 
   const gzipStart = Date.now();
+  log('reading and compressing trace inputs');
+  const [profile, csv, metricsJson] = await Promise.all([
+    gzipTraceReplayInput(profileExportJsonl),
+    readTraceReplayInput(serverMetricsCsv),
+    gzipTraceReplayInput(serverMetricsJson),
+  ]);
+  const profileGz = profile.data;
+  const profileSize = profile.sourceSize;
+  const serverMetricsCsvData = csv.data;
+  const csvSize = csv.sourceSize;
+  const metricsJsonGz = metricsJson.data;
+  const metricsJsonSize = metricsJson.sourceSize;
   log(
-    `compressing profile=${formatBytes(profileExportJsonl?.length)}, ` +
-      `server_csv=${formatBytes(serverMetricsCsv?.length)}, ` +
-      `server_json=${formatBytes(serverMetricsJson?.length)}`,
-  );
-  const profileGz = profileExportJsonl ? gzipSync(profileExportJsonl) : null;
-  const profileSize = profileExportJsonl ? profileExportJsonl.length : null;
-  const csvSize = serverMetricsCsv ? serverMetricsCsv.length : null;
-  const metricsJsonGz = serverMetricsJson ? gzipSync(serverMetricsJson) : null;
-  const metricsJsonSize = serverMetricsJson ? serverMetricsJson.length : null;
-  log(
-    `compressed profile=${formatBytes(profileGz?.length)}, ` +
-      `server_json=${formatBytes(metricsJsonGz?.length)} (${elapsed(gzipStart)})`,
+    `compressed profile=${formatBytes(profileSize)} -> ${formatBytes(profileGz?.length)}, ` +
+      `server_csv=${formatBytes(csvSize)}, ` +
+      `server_json=${formatBytes(metricsJsonSize)} -> ${formatBytes(metricsJsonGz?.length)} ` +
+      `(${elapsed(gzipStart)})`,
   );
 
   // Pre-compute aggregate stats + chart-ready time-series + per-request
@@ -180,7 +223,7 @@ export async function insertTraceReplay(
 
     const payloads: [TraceReplayUploadField, Buffer | null][] = [
       ['profile_export_jsonl_gz', profileGz],
-      ['server_metrics_csv', serverMetricsCsv],
+      ['server_metrics_csv', serverMetricsCsvData],
       ['server_metrics_json_gz', metricsJsonGz],
       ['aggregate_stats', aggregateStatsJson],
       ['chart_series', chartSeriesJson],

--- a/packages/db/src/ingest-ci-run.ts
+++ b/packages/db/src/ingest-ci-run.ts
@@ -549,20 +549,20 @@ async function main(): Promise<void> {
                     `server_csv=${formatBytes(fileSize(trace.serverMetricsCsv))}, ` +
                     `server_json=${formatBytes(fileSize(trace.serverMetricsJson))}`,
                 );
-                const profile = trace.profileJsonl ? fs.readFileSync(trace.profileJsonl) : null;
-                const metrics = trace.serverMetricsCsv
-                  ? fs.readFileSync(trace.serverMetricsCsv)
-                  : null;
-                const metricsJson = trace.serverMetricsJson
-                  ? fs.readFileSync(trace.serverMetricsJson)
-                  : null;
-                await insertTraceReplay(sql, insertedIds, profile, metrics, metricsJson, {
-                  metricsContext: {
-                    framework: toInsert[0]?.config.framework,
-                    disagg: toInsert[0]?.config.disagg,
+                await insertTraceReplay(
+                  sql,
+                  insertedIds,
+                  trace.profileJsonl,
+                  trace.serverMetricsCsv,
+                  trace.serverMetricsJson,
+                  {
+                    metricsContext: {
+                      framework: toInsert[0]?.config.framework,
+                      disagg: toInsert[0]?.config.disagg,
+                    },
+                    progressLabel: suffix,
                   },
-                  progressLabel: suffix,
-                });
+                );
                 totalTraceReplayLinked += insertedIds.length;
                 console.log(`    trace_replay ${suffix}: done (${elapsed(traceStart)})`);
               } catch (error: any) {


### PR DESCRIPTION
## Summary

- Pass trace-replay artifact paths into the ETL instead of loading every source file with `readFileSync`.
- Stream and gzip profile/server-metrics exports from disk with 1 MiB zlib chunks.
- Preserve Buffer inputs for compatibility and add a file-backed round-trip regression test.

## Root cause

The 4 MiB database upload fix in #570 prevents a single oversized PostgreSQL Bind message, but a fresh full ingest still loaded each raw trace into the long-lived async ingest loop. High-concurrency points include a 145 MiB profile plus a 1.1 GiB server-metrics JSON file. The live end-to-end run recovered from the old Bind failure but showed multi-minute client/GC pauses between completed 4 MiB database chunks after processing several points.

File-backed streaming removes the GiB-scale raw Buffers from the ingest loop before derived-metric computation and database upload.

## Validation

- Exact item-8 source files from InferenceX run `29181694248`: 1,352,749,205 source bytes streamed and compressed in 3.56s
- Output sizes matched the original ingest: 22,992,290-byte profile gzip and 49,891,135-byte metrics gzip
- Peak sampled RSS: 375.9 MiB
- DB unit suite: 359 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

No frontend behavior changes; unofficial-run overlay requirements do not apply.

## 中文说明

## 摘要

- ETL 直接接收 trace-replay 产物路径，不再通过 `readFileSync` 将每个源文件完整载入内存。
- 使用 1 MiB zlib 分块，从磁盘流式读取并压缩 profile 与 server metrics 产物。
- 保留 Buffer 输入兼容性，并添加文件输入的往返回归测试。

## 根因

#570 的 4 MiB 数据库分块上传修复避免了单个超大 PostgreSQL Bind 消息，但全新完整摄取仍会在长期运行的异步循环中读取并保留每个原始 trace。高并发点包含 145 MiB profile 和 1.1 GiB server metrics JSON。当前端到端运行已避开原来的 Bind 卡死，但在处理多个点后，仍会在已完成的 4 MiB 数据库分块之间出现数分钟的客户端/GC 暂停。

文件流式处理会在派生指标计算和数据库上传前消除摄取循环中的 GiB 级原始 Buffer。

## 验证

- 使用 InferenceX 运行 `29181694248` 的实际第 8 项文件：在 3.56 秒内流式读取并压缩 1,352,749,205 字节源数据
- 输出大小与原摄取结果一致：profile gzip 为 22,992,290 字节，metrics gzip 为 49,891,135 字节
- 采样峰值 RSS：375.9 MiB
- DB 单元测试：359 项全部通过
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

本 PR 不修改前端行为，因此 unofficial-run overlay 要求不适用。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CI trace-replay ETL memory path for very large artifacts; behavior should match prior outputs but compressed payloads are still held in memory after streaming.
> 
> **Overview**
> **Trace replay ingest no longer loads full raw trace files into the Node heap before compression and upload.** `insertTraceReplay` now takes `Buffer | file path | null` for profile JSONL, server metrics CSV, and server metrics JSON. CI ingest passes artifact paths straight through instead of `readFileSync` on each sibling file.
> 
> **New `gzipTraceReplayInput`** gzips buffer inputs synchronously (unchanged for tests/callers) and, for paths, pipes a 1 MiB `createReadStream` through `createGzip` so large exports are not fully materialized as raw buffers first. `insertTraceReplay` prepares inputs in parallel and logs source vs compressed sizes. CSV paths still go through `readFile` when needed for storage as-is.
> 
> **Regression test** writes a 2 MiB temp file and asserts streamed gzip round-trips to the original bytes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e38253500d477752064125e21016daf0af65c8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->