### PR TITLE
feat: add bilingual AI inference glossary

### DIFF
--- a/packages/app/src/app/blog/page.tsx
+++ b/packages/app/src/app/blog/page.tsx
@@ -51,6 +51,13 @@ export default async function BlogPage({
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
               Insights on AI inference benchmarking, GPU performance, and ML infrastructure.
             </p>
+            <p className="text-sm text-muted-foreground">
+              New to the terminology?{' '}
+              <Link href="/glossary" className="font-medium text-brand hover:underline">
+                Browse the AI inference glossary
+              </Link>
+              .
+            </p>
             {allTags.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-4">
                 <Link

--- a/packages/app/src/app/glossary/[slug]/page.tsx
+++ b/packages/app/src/app/glossary/[slug]/page.tsx
@@ -163,16 +163,29 @@ export default async function GlossaryTermPage({ params }: Props) {
 
             <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_16rem]">
               <div className="px-5 py-8 md:px-10 md:py-12">
-                <section aria-labelledby="definition-heading">
+                <section
+                  aria-labelledby="plain-english-heading"
+                  className="rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+                >
                   <p
-                    id="definition-heading"
+                    id="plain-english-heading"
                     className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase"
                   >
-                    Definition
+                    In plain English
                   </p>
                   <p className="mt-3 text-xl leading-relaxed font-medium text-pretty md:text-2xl">
-                    {entry.definition}
+                    {entry.plainEnglish}
                   </p>
+                </section>
+
+                <section aria-labelledby="technical-definition-heading" className="mt-8">
+                  <h2
+                    id="technical-definition-heading"
+                    className="text-xl font-semibold tracking-tight"
+                  >
+                    Technical definition
+                  </h2>
+                  <p className="mt-3 leading-7 text-muted-foreground">{entry.definition}</p>
                 </section>
 
                 {entry.measurement && (
@@ -187,9 +200,9 @@ export default async function GlossaryTermPage({ params }: Props) {
                 )}
 
                 <div className="mt-10 space-y-10 border-t border-border/50 pt-10">
-                  <section aria-labelledby="how-it-works">
-                    <h2 id="how-it-works" className="text-xl font-semibold tracking-tight">
-                      How it works
+                  <section aria-labelledby="engineering-details">
+                    <h2 id="engineering-details" className="text-xl font-semibold tracking-tight">
+                      Engineering details
                     </h2>
                     <p className="mt-3 leading-7 text-muted-foreground">{entry.explanation}</p>
                   </section>

--- a/packages/app/src/app/glossary/[slug]/page.tsx
+++ b/packages/app/src/app/glossary/[slug]/page.tsx
@@ -1,0 +1,312 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getPostBySlug } from '@/lib/blog';
+import {
+  getAdjacentGlossaryEntries,
+  getAllGlossaryEntries,
+  getGlossaryEntry,
+  getRelatedGlossaryEntries,
+} from '@/lib/glossary';
+import { enAlternates } from '@/lib/i18n';
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+} from '@semianalysisai/inferencex-constants';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllGlossaryEntries().map((entry) => ({ slug: entry.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getGlossaryEntry(slug);
+  if (!entry) return {};
+
+  const title = `${entry.term}: AI Inference Definition`;
+  const url = `${SITE_URL}/glossary/${entry.slug}`;
+  const keywords = [
+    entry.term,
+    entry.abbreviation,
+    ...(entry.aliases ?? []),
+    'AI inference glossary',
+    'LLM inference',
+  ].filter((keyword): keyword is string => Boolean(keyword));
+
+  return {
+    title,
+    description: entry.definition,
+    keywords,
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: enAlternates(`/glossary/${entry.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description: entry.definition,
+      url,
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: entry.definition,
+      site: AUTHOR_HANDLE,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+export default async function GlossaryTermPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getGlossaryEntry(slug);
+  if (!entry) notFound();
+
+  const relatedTerms = getRelatedGlossaryEntries(entry);
+  const adjacent = getAdjacentGlossaryEntries(entry.slug);
+  const relatedArticles = entry.articleSlugs.flatMap((articleSlug) => {
+    const post = getPostBySlug(articleSlug);
+    return post
+      ? [{ slug: articleSlug, title: post.meta.title, subtitle: post.meta.subtitle }]
+      : [];
+  });
+  const termUrl = `${SITE_URL}/glossary/${entry.slug}`;
+  const glossaryUrl = `${SITE_URL}/glossary`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'DefinedTerm',
+        '@id': termUrl,
+        name: entry.term,
+        ...(entry.abbreviation && { termCode: entry.abbreviation }),
+        description: entry.definition,
+        url: termUrl,
+        inDefinedTermSet: {
+          '@type': 'DefinedTermSet',
+          '@id': glossaryUrl,
+          name: 'InferenceX AI Inference Glossary',
+          url: glossaryUrl,
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Glossary',
+            item: glossaryUrl,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: entry.term,
+            item: termUrl,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <Card className="overflow-hidden p-0">
+            <header className="relative border-b border-border/50 px-5 py-8 md:px-10 md:py-12">
+              <div
+                aria-hidden="true"
+                className="absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-brand/70 to-transparent"
+              />
+              <Link
+                href="/glossary"
+                className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+              >
+                <span
+                  aria-hidden="true"
+                  className="transition-transform group-hover:-translate-x-0.5"
+                >
+                  ←
+                </span>
+                AI inference glossary
+              </Link>
+              <div className="mt-8 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-brand/25 bg-brand/8 px-3 py-1 text-xs font-semibold tracking-[0.14em] text-brand uppercase">
+                  {entry.category}
+                </span>
+                {entry.abbreviation && (
+                  <span className="font-mono text-xs tracking-[0.16em] text-muted-foreground uppercase">
+                    {entry.abbreviation}
+                  </span>
+                )}
+              </div>
+              <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-6xl">
+                {entry.term}
+              </h1>
+              {entry.aliases && entry.aliases.length > 0 && (
+                <p className="mt-4 text-sm text-muted-foreground">
+                  Also known as {entry.aliases.join(', ')}
+                </p>
+              )}
+            </header>
+
+            <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_16rem]">
+              <div className="px-5 py-8 md:px-10 md:py-12">
+                <section aria-labelledby="definition-heading">
+                  <p
+                    id="definition-heading"
+                    className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase"
+                  >
+                    Definition
+                  </p>
+                  <p className="mt-3 text-xl leading-relaxed font-medium text-pretty md:text-2xl">
+                    {entry.definition}
+                  </p>
+                </section>
+
+                {entry.measurement && (
+                  <div className="mt-8 border-l-2 border-brand bg-brand/6 px-5 py-4">
+                    <p className="text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+                      {entry.measurement.label}
+                    </p>
+                    <p className="mt-1 font-mono text-sm leading-relaxed text-foreground">
+                      {entry.measurement.value}
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-10 space-y-10 border-t border-border/50 pt-10">
+                  <section aria-labelledby="how-it-works">
+                    <h2 id="how-it-works" className="text-xl font-semibold tracking-tight">
+                      How it works
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.explanation}</p>
+                  </section>
+                  <section aria-labelledby="why-it-matters">
+                    <h2 id="why-it-matters" className="text-xl font-semibold tracking-tight">
+                      Why it matters
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.significance}</p>
+                  </section>
+                  <section aria-labelledby="reading-inferencex">
+                    <h2 id="reading-inferencex" className="text-xl font-semibold tracking-tight">
+                      How to read it in InferenceX
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.benchmarkContext}</p>
+                  </section>
+                </div>
+              </div>
+
+              <aside className="border-t border-border/50 bg-muted/10 px-5 py-8 lg:border-t-0 lg:border-l lg:px-6 lg:py-12">
+                <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+                  Related terms
+                </p>
+                <nav aria-label="Related glossary terms" className="mt-4 flex flex-col">
+                  {relatedTerms.map((related) => (
+                    <Link
+                      key={related.slug}
+                      href={`/glossary/${related.slug}`}
+                      className="group border-b border-border/40 py-3 text-sm font-medium transition-colors last:border-b-0 hover:text-brand"
+                    >
+                      <span className="flex items-center justify-between gap-3">
+                        {related.term}
+                        <span
+                          aria-hidden="true"
+                          className="text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-brand"
+                        >
+                          →
+                        </span>
+                      </span>
+                    </Link>
+                  ))}
+                </nav>
+              </aside>
+            </div>
+          </Card>
+
+          {relatedArticles.length > 0 && (
+            <section aria-labelledby="further-reading" className="mt-4">
+              <Card>
+                <div className="flex flex-col gap-2 border-b border-border/50 pb-5 md:flex-row md:items-end md:justify-between">
+                  <div>
+                    <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+                      Source material
+                    </p>
+                    <h2 id="further-reading" className="mt-2 text-2xl font-semibold tracking-tight">
+                      See the concept in real benchmarks
+                    </h2>
+                  </div>
+                  <Link href="/blog" className="text-sm text-muted-foreground hover:text-brand">
+                    All articles →
+                  </Link>
+                </div>
+                <div className="divide-y divide-border/40">
+                  {relatedArticles.map((article) => (
+                    <Link
+                      key={article.slug}
+                      href={`/blog/${article.slug}`}
+                      className="group grid gap-2 py-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:gap-6"
+                    >
+                      <div>
+                        <h3 className="font-semibold leading-snug group-hover:text-brand group-hover:underline">
+                          {article.title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-sm leading-6 text-muted-foreground">
+                          {article.subtitle}
+                        </p>
+                      </div>
+                      <span
+                        aria-hidden="true"
+                        className="hidden text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-brand md:block"
+                      >
+                        →
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </Card>
+            </section>
+          )}
+
+          <nav aria-label="Glossary pagination" className="mt-4 grid gap-4 sm:grid-cols-2">
+            {adjacent.previous ? (
+              <Link
+                href={`/glossary/${adjacent.previous.slug}`}
+                className="rounded-xl border border-border/40 bg-background/20 p-5 backdrop-blur-[2px] transition-colors hover:border-brand/40 hover:bg-brand/5"
+              >
+                <span className="text-xs tracking-[0.14em] text-muted-foreground uppercase">
+                  ← Previous
+                </span>
+                <span className="mt-2 block font-semibold">{adjacent.previous.term}</span>
+              </Link>
+            ) : (
+              <div />
+            )}
+            {adjacent.next && (
+              <Link
+                href={`/glossary/${adjacent.next.slug}`}
+                className="rounded-xl border border-border/40 bg-background/20 p-5 text-right backdrop-blur-[2px] transition-colors hover:border-brand/40 hover:bg-brand/5"
+              >
+                <span className="text-xs tracking-[0.14em] text-muted-foreground uppercase">
+                  Next →
+                </span>
+                <span className="mt-2 block font-semibold">{adjacent.next.term}</span>
+              </Link>
+            )}
+          </nav>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/glossary/page.tsx
+++ b/packages/app/src/app/glossary/page.tsx
@@ -103,8 +103,8 @@ export default function GlossaryPage() {
                 </h1>
                 <p className="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
                   Definitions for the metrics, serving techniques, numerical formats, and
-                  distributed systems concepts used across InferenceX. Written from measured
-                  behavior—not vendor peak specifications.
+                  distributed systems concepts used across InferenceX. Based on measured behavior,
+                  not vendor peak specifications.
                 </p>
               </div>
 
@@ -142,12 +142,12 @@ export default function GlossaryPage() {
               Reading the benchmark
             </p>
             <h2 className="mt-3 text-2xl font-semibold tracking-tight">
-              Start with the tradeoff, not the peak.
+              The full curve tells the story.
             </h2>
             <p className="mt-3 leading-7 text-muted-foreground">
-              LLM serving balances per-user speed against aggregate throughput. Learn why InferenceX
-              uses full Pareto curves and matched-interactivity comparisons instead of ranking a GPU
-              by one maximum-throughput point.
+              LLM serving balances per-user speed against aggregate throughput. InferenceX uses full
+              Pareto curves and matched-interactivity comparisons to show that tradeoff across
+              operating points. One maximum-throughput point cannot rank the complete system.
             </p>
             <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
               <Link href="/glossary/interactivity" className="text-brand hover:underline">
@@ -170,9 +170,9 @@ export default function GlossaryPage() {
               Definitions connected to real recipes.
             </h2>
             <p className="mt-3 leading-7 text-muted-foreground">
-              Every term page links back to the InferenceX articles where the concept affects an
-              observed result—from MTP acceptance behavior to NVL72 wide-EP scaling and
-              software-only speedups on unchanged GPUs.
+              Every term page links to InferenceX articles where the concept changes a measured
+              result, including MTP acceptance behavior, NVL72 wide-EP scaling, and software-only
+              speedups on unchanged GPUs.
             </p>
             <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
               <Link href="/blog" className="text-brand hover:underline">

--- a/packages/app/src/app/glossary/page.tsx
+++ b/packages/app/src/app/glossary/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { GlossaryBrowser, type GlossaryBrowserEntry } from '@/components/glossary/glossary-browser';
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getAllPosts } from '@/lib/blog';
+import { GLOSSARY_CATEGORIES, getAllGlossaryEntries } from '@/lib/glossary';
+import { enAlternates } from '@/lib/i18n';
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+const title = 'AI Inference Glossary';
+const description =
+  'Clear, technically grounded definitions for LLM inference benchmarks, serving metrics, distributed parallelism, numerical precision, GPU hardware, and inference software.';
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    'AI inference glossary',
+    'LLM inference terms',
+    'GPU benchmark terminology',
+    'inference serving glossary',
+    'LLM performance metrics',
+    'distributed inference',
+  ],
+  alternates: enAlternates('/glossary'),
+  openGraph: {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    url: `${SITE_URL}/glossary`,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title,
+    description,
+  },
+};
+
+export default function GlossaryPage() {
+  const entries = getAllGlossaryEntries().toSorted((a, b) => a.term.localeCompare(b.term));
+  const articleCount = getAllPosts().length;
+  const browserEntries: GlossaryBrowserEntry[] = entries.map((entry) => ({
+    slug: entry.slug,
+    term: entry.term,
+    ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
+    ...(entry.aliases && { aliases: entry.aliases }),
+    category: entry.category,
+    definition: entry.definition,
+    searchText: [
+      entry.term,
+      entry.abbreviation,
+      ...(entry.aliases ?? []),
+      entry.category,
+      entry.definition,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLocaleLowerCase(),
+  }));
+  const glossaryUrl = `${SITE_URL}/glossary`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTermSet',
+    '@id': glossaryUrl,
+    name: 'InferenceX AI Inference Glossary',
+    description,
+    url: glossaryUrl,
+    creator: {
+      '@type': 'Organization',
+      name: AUTHOR_NAME,
+    },
+    hasDefinedTerm: entries.map((entry) => ({
+      '@type': 'DefinedTerm',
+      '@id': `${glossaryUrl}/${entry.slug}`,
+      name: entry.term,
+      ...(entry.abbreviation && { termCode: entry.abbreviation }),
+      description: entry.definition,
+      url: `${glossaryUrl}/${entry.slug}`,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <Card className="overflow-hidden p-0">
+          <header className="relative px-5 py-10 md:px-8 md:py-14 lg:px-12 lg:py-16">
+            <div
+              aria-hidden="true"
+              className="absolute top-0 left-1/2 h-px w-2/3 -translate-x-1/2 bg-linear-to-r from-transparent via-brand/75 to-transparent"
+            />
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-end">
+              <div>
+                <p className="font-mono text-xs font-semibold tracking-[0.2em] text-brand uppercase">
+                  Field guide / AI infrastructure
+                </p>
+                <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.045em] text-balance md:text-6xl lg:text-7xl">
+                  The language behind the inference curve.
+                </h1>
+                <p className="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
+                  Definitions for the metrics, serving techniques, numerical formats, and
+                  distributed systems concepts used across InferenceX. Written from measured
+                  behavior—not vendor peak specifications.
+                </p>
+              </div>
+
+              <dl className="grid grid-cols-3 gap-px overflow-hidden rounded-lg border border-border/50 bg-border/50 lg:grid-cols-1">
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    Terms
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">{entries.length}</dd>
+                </div>
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    Categories
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">
+                    {GLOSSARY_CATEGORIES.length}
+                  </dd>
+                </div>
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    Articles reviewed
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">{articleCount}</dd>
+                </div>
+              </dl>
+            </div>
+          </header>
+
+          <GlossaryBrowser entries={browserEntries} categories={GLOSSARY_CATEGORIES} />
+        </Card>
+
+        <section className="mt-4 grid gap-4 md:grid-cols-2">
+          <Card>
+            <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+              Reading the benchmark
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">
+              Start with the tradeoff, not the peak.
+            </h2>
+            <p className="mt-3 leading-7 text-muted-foreground">
+              LLM serving balances per-user speed against aggregate throughput. Learn why InferenceX
+              uses full Pareto curves and matched-interactivity comparisons instead of ranking a GPU
+              by one maximum-throughput point.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/glossary/interactivity" className="text-brand hover:underline">
+                Interactivity →
+              </Link>
+              <Link href="/glossary/pareto-frontier" className="text-brand hover:underline">
+                Pareto frontier →
+              </Link>
+              <Link href="/glossary/iso-interactivity" className="text-brand hover:underline">
+                Iso-interactivity →
+              </Link>
+            </div>
+          </Card>
+
+          <Card>
+            <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+              Grounded in measurements
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">
+              Definitions connected to real recipes.
+            </h2>
+            <p className="mt-3 leading-7 text-muted-foreground">
+              Every term page links back to the InferenceX articles where the concept affects an
+              observed result—from MTP acceptance behavior to NVL72 wide-EP scaling and
+              software-only speedups on unchanged GPUs.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/blog" className="text-brand hover:underline">
+                Browse technical articles →
+              </Link>
+              <Link href="/inference" className="text-brand hover:underline">
+                Explore live benchmark data →
+              </Link>
+            </div>
+          </Card>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/glossary/page.tsx
+++ b/packages/app/src/app/glossary/page.tsx
@@ -45,10 +45,8 @@ export default function GlossaryPage() {
     slug: entry.slug,
     term: entry.term,
     ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
-    ...(entry.aliases && { aliases: entry.aliases }),
     category: entry.category,
     plainEnglish: entry.plainEnglish,
-    definition: entry.definition,
     searchText: [
       entry.term,
       entry.abbreviation,

--- a/packages/app/src/app/glossary/page.tsx
+++ b/packages/app/src/app/glossary/page.tsx
@@ -47,12 +47,14 @@ export default function GlossaryPage() {
     ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
     ...(entry.aliases && { aliases: entry.aliases }),
     category: entry.category,
+    plainEnglish: entry.plainEnglish,
     definition: entry.definition,
     searchText: [
       entry.term,
       entry.abbreviation,
       ...(entry.aliases ?? []),
       entry.category,
+      entry.plainEnglish,
       entry.definition,
     ]
       .filter(Boolean)

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -11,6 +11,7 @@ import {
   canonicalPrecisionCompareSlug,
   canonicalSpecDecodeCompareSlug,
 } from '@/lib/compare-variant-slug';
+import { getAllGlossaryEntries } from '@/lib/glossary';
 import { languageAlternates, zhPath } from '@/lib/i18n';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -89,6 +90,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }),
     ...localizedPair('/datasets', { lastModified: now, changeFrequency: 'weekly', priority: 0.6 }),
     ...localizedPair('/blog', { lastModified: now, changeFrequency: 'weekly', priority: 0.8 }),
+    ...localizedPair('/glossary', {
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    }),
+    ...getAllGlossaryEntries().flatMap((entry) =>
+      localizedPair(`/glossary/${entry.slug}`, {
+        lastModified: now,
+        changeFrequency: 'monthly' as const,
+        priority: 0.6,
+      }),
+    ),
     ...getAllPosts().flatMap((post) => {
       const entry = {
         lastModified: new Date(`${post.modifiedDate ?? post.date}T00:00:00Z`).toISOString(),

--- a/packages/app/src/app/zh/blog/page.tsx
+++ b/packages/app/src/app/zh/blog/page.tsx
@@ -53,6 +53,13 @@ export default async function ZhBlogPage({
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
               关于 AI 推理基准测试、GPU 性能与 ML 基础设施的深度洞见。
             </p>
+            <p className="text-sm text-muted-foreground">
+              不熟悉相关概念？{' '}
+              <Link href="/zh/glossary" className="font-medium text-brand hover:underline">
+                浏览 AI 推理术语表
+              </Link>
+              。
+            </p>
             {allTags.length > 0 && (
               <div className="flex flex-wrap gap-2 mt-4">
                 <Link

--- a/packages/app/src/app/zh/glossary/[slug]/page.tsx
+++ b/packages/app/src/app/zh/glossary/[slug]/page.tsx
@@ -1,0 +1,316 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getPostBySlug } from '@/lib/blog';
+import {
+  GLOSSARY_CATEGORY_LABELS_ZH,
+  getAdjacentZhGlossaryEntries,
+  getAllZhGlossaryEntries,
+  getRelatedZhGlossaryEntries,
+  getZhGlossaryEntry,
+} from '@/lib/glossary-zh';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+} from '@semianalysisai/inferencex-constants';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllZhGlossaryEntries().map((entry) => ({ slug: entry.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getZhGlossaryEntry(slug);
+  if (!entry) return {};
+
+  const title = `${entry.term}：AI 推理定义`;
+  const url = `${SITE_URL}/zh/glossary/${entry.slug}`;
+  const keywords = [
+    entry.term,
+    entry.abbreviation,
+    ...(entry.aliases ?? []),
+    'AI 推理术语表',
+    'LLM 推理',
+  ].filter((keyword): keyword is string => Boolean(keyword));
+
+  return {
+    title,
+    description: entry.definition,
+    keywords,
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: zhAlternates(`/glossary/${entry.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description: entry.definition,
+      url,
+      locale: ZH_OG_LOCALE,
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description: entry.definition,
+      site: AUTHOR_HANDLE,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+export default async function ZhGlossaryTermPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getZhGlossaryEntry(slug);
+  if (!entry) notFound();
+
+  const relatedTerms = getRelatedZhGlossaryEntries(entry);
+  const adjacent = getAdjacentZhGlossaryEntries(entry.slug);
+  const relatedArticles = entry.articleSlugs.flatMap((articleSlug) => {
+    const post = getPostBySlug(articleSlug, 'zh');
+    return post
+      ? [{ slug: articleSlug, title: post.meta.title, subtitle: post.meta.subtitle }]
+      : [];
+  });
+  const termUrl = `${SITE_URL}/zh/glossary/${entry.slug}`;
+  const glossaryUrl = `${SITE_URL}/zh/glossary`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'DefinedTerm',
+        '@id': termUrl,
+        name: entry.term,
+        ...(entry.abbreviation && { termCode: entry.abbreviation }),
+        description: entry.definition,
+        url: termUrl,
+        inLanguage: ZH_LANG_TAG,
+        inDefinedTermSet: {
+          '@type': 'DefinedTermSet',
+          '@id': glossaryUrl,
+          name: 'InferenceX AI 推理术语表',
+          url: glossaryUrl,
+          inLanguage: ZH_LANG_TAG,
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: '术语表',
+            item: glossaryUrl,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: entry.term,
+            item: termUrl,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <Card className="overflow-hidden p-0">
+            <header className="relative border-b border-border/50 px-5 py-8 md:px-10 md:py-12">
+              <div
+                aria-hidden="true"
+                className="absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-brand/70 to-transparent"
+              />
+              <Link
+                href="/zh/glossary"
+                className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+              >
+                <span
+                  aria-hidden="true"
+                  className="transition-transform group-hover:-translate-x-0.5"
+                >
+                  ←
+                </span>
+                AI 推理术语表
+              </Link>
+              <div className="mt-8 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-brand/25 bg-brand/8 px-3 py-1 text-xs font-semibold tracking-[0.14em] text-brand uppercase">
+                  {GLOSSARY_CATEGORY_LABELS_ZH[entry.category]}
+                </span>
+                {entry.abbreviation && (
+                  <span className="font-mono text-xs tracking-[0.16em] text-muted-foreground uppercase">
+                    {entry.abbreviation}
+                  </span>
+                )}
+              </div>
+              <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-6xl">
+                {entry.term}
+              </h1>
+              {entry.aliases && entry.aliases.length > 0 && (
+                <p className="mt-4 text-sm text-muted-foreground">
+                  也称为 {entry.aliases.join('、')}
+                </p>
+              )}
+            </header>
+
+            <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_16rem]">
+              <div className="px-5 py-8 md:px-10 md:py-12">
+                <section aria-labelledby="definition-heading">
+                  <p
+                    id="definition-heading"
+                    className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase"
+                  >
+                    定义
+                  </p>
+                  <p className="mt-3 text-xl leading-relaxed font-medium text-pretty md:text-2xl">
+                    {entry.definition}
+                  </p>
+                </section>
+
+                {entry.measurement && (
+                  <div className="mt-8 border-l-2 border-brand bg-brand/6 px-5 py-4">
+                    <p className="text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+                      常用单位或关系
+                    </p>
+                    <p className="mt-1 font-mono text-sm leading-relaxed text-foreground">
+                      {entry.measurement.value}
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-10 space-y-10 border-t border-border/50 pt-10">
+                  <section aria-labelledby="how-it-works">
+                    <h2 id="how-it-works" className="text-xl font-semibold tracking-tight">
+                      工作原理
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.explanation}</p>
+                  </section>
+                  <section aria-labelledby="why-it-matters">
+                    <h2 id="why-it-matters" className="text-xl font-semibold tracking-tight">
+                      为什么重要
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.significance}</p>
+                  </section>
+                  <section aria-labelledby="reading-inferencex">
+                    <h2 id="reading-inferencex" className="text-xl font-semibold tracking-tight">
+                      如何在 InferenceX 中解读
+                    </h2>
+                    <p className="mt-3 leading-7 text-muted-foreground">{entry.benchmarkContext}</p>
+                  </section>
+                </div>
+              </div>
+
+              <aside className="border-t border-border/50 bg-muted/10 px-5 py-8 lg:border-t-0 lg:border-l lg:px-6 lg:py-12">
+                <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+                  相关术语
+                </p>
+                <nav aria-label="相关术语" className="mt-4 flex flex-col">
+                  {relatedTerms.map((related) => (
+                    <Link
+                      key={related.slug}
+                      href={`/zh/glossary/${related.slug}`}
+                      className="group border-b border-border/40 py-3 text-sm font-medium transition-colors last:border-b-0 hover:text-brand"
+                    >
+                      <span className="flex items-center justify-between gap-3">
+                        {related.term}
+                        <span
+                          aria-hidden="true"
+                          className="text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-brand"
+                        >
+                          →
+                        </span>
+                      </span>
+                    </Link>
+                  ))}
+                </nav>
+              </aside>
+            </div>
+          </Card>
+
+          {relatedArticles.length > 0 && (
+            <section aria-labelledby="further-reading" className="mt-4">
+              <Card>
+                <div className="flex flex-col gap-2 border-b border-border/50 pb-5 md:flex-row md:items-end md:justify-between">
+                  <div>
+                    <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+                      参考资料
+                    </p>
+                    <h2 id="further-reading" className="mt-2 text-2xl font-semibold tracking-tight">
+                      在真实基准中理解这一概念
+                    </h2>
+                  </div>
+                  <Link href="/zh/blog" className="text-sm text-muted-foreground hover:text-brand">
+                    全部文章 →
+                  </Link>
+                </div>
+                <div className="divide-y divide-border/40">
+                  {relatedArticles.map((article) => (
+                    <Link
+                      key={article.slug}
+                      href={`/zh/blog/${article.slug}`}
+                      className="group grid gap-2 py-5 md:grid-cols-[minmax(0,1fr)_auto] md:items-center md:gap-6"
+                    >
+                      <div>
+                        <h3 className="font-semibold leading-snug group-hover:text-brand group-hover:underline">
+                          {article.title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-sm leading-6 text-muted-foreground">
+                          {article.subtitle}
+                        </p>
+                      </div>
+                      <span
+                        aria-hidden="true"
+                        className="hidden text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-brand md:block"
+                      >
+                        →
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </Card>
+            </section>
+          )}
+
+          <nav aria-label="术语表翻页" className="mt-4 grid gap-4 sm:grid-cols-2">
+            {adjacent.previous ? (
+              <Link
+                href={`/zh/glossary/${adjacent.previous.slug}`}
+                className="rounded-xl border border-border/40 bg-background/20 p-5 backdrop-blur-[2px] transition-colors hover:border-brand/40 hover:bg-brand/5"
+              >
+                <span className="text-xs tracking-[0.14em] text-muted-foreground uppercase">
+                  ← 上一条
+                </span>
+                <span className="mt-2 block font-semibold">{adjacent.previous.term}</span>
+              </Link>
+            ) : (
+              <div />
+            )}
+            {adjacent.next && (
+              <Link
+                href={`/zh/glossary/${adjacent.next.slug}`}
+                className="rounded-xl border border-border/40 bg-background/20 p-5 text-right backdrop-blur-[2px] transition-colors hover:border-brand/40 hover:bg-brand/5"
+              >
+                <span className="text-xs tracking-[0.14em] text-muted-foreground uppercase">
+                  下一条 →
+                </span>
+                <span className="mt-2 block font-semibold">{adjacent.next.term}</span>
+              </Link>
+            )}
+          </nav>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/zh/glossary/[slug]/page.tsx
+++ b/packages/app/src/app/zh/glossary/[slug]/page.tsx
@@ -195,7 +195,7 @@ export default async function ZhGlossaryTermPage({ params }: Props) {
                 {entry.measurement && (
                   <div className="mt-8 border-l-2 border-brand bg-brand/6 px-5 py-4">
                     <p className="text-xs font-semibold tracking-[0.14em] text-muted-foreground uppercase">
-                      常用单位或关系
+                      {entry.measurement.label}
                     </p>
                     <p className="mt-1 font-mono text-sm leading-relaxed text-foreground">
                       {entry.measurement.value}

--- a/packages/app/src/app/zh/glossary/[slug]/page.tsx
+++ b/packages/app/src/app/zh/glossary/[slug]/page.tsx
@@ -167,16 +167,29 @@ export default async function ZhGlossaryTermPage({ params }: Props) {
 
             <div className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_16rem]">
               <div className="px-5 py-8 md:px-10 md:py-12">
-                <section aria-labelledby="definition-heading">
+                <section
+                  aria-labelledby="plain-language-heading"
+                  className="rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+                >
                   <p
-                    id="definition-heading"
+                    id="plain-language-heading"
                     className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase"
                   >
-                    定义
+                    先用大白话
                   </p>
                   <p className="mt-3 text-xl leading-relaxed font-medium text-pretty md:text-2xl">
-                    {entry.definition}
+                    {entry.plainEnglish}
                   </p>
+                </section>
+
+                <section aria-labelledby="technical-definition-heading" className="mt-8">
+                  <h2
+                    id="technical-definition-heading"
+                    className="text-xl font-semibold tracking-tight"
+                  >
+                    技术定义
+                  </h2>
+                  <p className="mt-3 leading-7 text-muted-foreground">{entry.definition}</p>
                 </section>
 
                 {entry.measurement && (
@@ -191,9 +204,9 @@ export default async function ZhGlossaryTermPage({ params }: Props) {
                 )}
 
                 <div className="mt-10 space-y-10 border-t border-border/50 pt-10">
-                  <section aria-labelledby="how-it-works">
-                    <h2 id="how-it-works" className="text-xl font-semibold tracking-tight">
-                      工作原理
+                  <section aria-labelledby="engineering-details">
+                    <h2 id="engineering-details" className="text-xl font-semibold tracking-tight">
+                      工程细节
                     </h2>
                     <p className="mt-3 leading-7 text-muted-foreground">{entry.explanation}</p>
                   </section>

--- a/packages/app/src/app/zh/glossary/page.tsx
+++ b/packages/app/src/app/zh/glossary/page.tsx
@@ -65,12 +65,14 @@ export default function ZhGlossaryPage() {
     ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
     ...(entry.aliases && { aliases: entry.aliases }),
     category: entry.category,
+    plainEnglish: entry.plainEnglish,
     definition: entry.definition,
     searchText: [
       entry.term,
       entry.abbreviation,
       ...(entry.aliases ?? []),
       GLOSSARY_CATEGORY_LABELS_ZH[entry.category],
+      entry.plainEnglish,
       entry.definition,
     ]
       .filter(Boolean)

--- a/packages/app/src/app/zh/glossary/page.tsx
+++ b/packages/app/src/app/zh/glossary/page.tsx
@@ -10,7 +10,11 @@ import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getAllPosts } from '@/lib/blog';
 import { GLOSSARY_CATEGORIES } from '@/lib/glossary';
-import { GLOSSARY_CATEGORY_LABELS_ZH, getAllZhGlossaryEntries } from '@/lib/glossary-zh';
+import {
+  GLOSSARY_CATEGORY_LABELS_ZH,
+  compareZhGlossaryEntries,
+  getAllZhGlossaryEntries,
+} from '@/lib/glossary-zh';
 import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -53,20 +57,14 @@ export const metadata: Metadata = {
 };
 
 export default function ZhGlossaryPage() {
-  const entries = getAllZhGlossaryEntries().toSorted((a, b) => {
-    const categoryOrder =
-      GLOSSARY_CATEGORIES.indexOf(a.category) - GLOSSARY_CATEGORIES.indexOf(b.category);
-    return categoryOrder || a.term.localeCompare(b.term, 'zh-CN');
-  });
+  const entries = getAllZhGlossaryEntries().toSorted(compareZhGlossaryEntries);
   const articleCount = getAllPosts('zh').length;
   const browserEntries: GlossaryBrowserEntry[] = entries.map((entry) => ({
     slug: entry.slug,
     term: entry.term,
     ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
-    ...(entry.aliases && { aliases: entry.aliases }),
     category: entry.category,
     plainEnglish: entry.plainEnglish,
-    definition: entry.definition,
     searchText: [
       entry.term,
       entry.abbreviation,

--- a/packages/app/src/app/zh/glossary/page.tsx
+++ b/packages/app/src/app/zh/glossary/page.tsx
@@ -167,10 +167,10 @@ export default function ZhGlossaryPage() {
             <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
               阅读基准曲线
             </p>
-            <h2 className="mt-3 text-2xl font-semibold tracking-tight">先看权衡，而不是峰值。</h2>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">完整曲线更能说明问题。</h2>
             <p className="mt-3 leading-7 text-muted-foreground">
-              LLM 服务需要在单用户速度与总吞吐量之间取舍。了解 InferenceX 为什么使用完整 Pareto
-              曲线和等交互性比较，而不是用单一最大吞吐点给 GPU 排名。
+              LLM 服务需要在单用户速度与总吞吐量之间取舍。InferenceX 使用完整 Pareto
+              曲线和等交互性比较，展示不同运行点上的真实权衡。单一最大吞吐点无法代表完整系统。
             </p>
             <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
               <Link href="/zh/glossary/interactivity" className="text-brand hover:underline">

--- a/packages/app/src/app/zh/glossary/page.tsx
+++ b/packages/app/src/app/zh/glossary/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import {
+  GlossaryBrowser,
+  type GlossaryBrowserEntry,
+  type GlossaryBrowserLabels,
+} from '@/components/glossary/glossary-browser';
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getAllPosts } from '@/lib/blog';
+import { GLOSSARY_CATEGORIES } from '@/lib/glossary';
+import { GLOSSARY_CATEGORY_LABELS_ZH, getAllZhGlossaryEntries } from '@/lib/glossary-zh';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+const title = 'AI 推理术语表';
+const description =
+  '清晰、技术严谨的 LLM 推理基准、服务指标、分布式并行、数值精度、GPU 硬件与推理软件术语定义。';
+const browserLabels: GlossaryBrowserLabels = {
+  searchLabel: '搜索 AI 推理术语表',
+  searchPlaceholder: '搜索 MTP、延迟、FP4…',
+  clearSearch: '清除术语搜索',
+  categoryFilterLabel: '按类别筛选术语',
+  letterFilterLabel: '按字母筛选术语',
+  allLetters: '全部',
+  termSingular: '个术语',
+  termPlural: '个术语',
+  clearFilters: '清除筛选',
+  noMatch: '没有匹配项',
+  noResultsTitle: '未找到相关术语',
+  noResultsDescription: '请尝试更宽泛的关键词，或清除当前筛选条件。',
+  showAllTerms: '显示全部术语',
+};
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: ['AI 推理术语表', 'LLM 推理术语', 'GPU 基准术语', '分布式推理', 'LLM 性能指标'],
+  alternates: zhAlternates('/glossary'),
+  openGraph: {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    url: `${SITE_URL}/zh/glossary`,
+    locale: ZH_OG_LOCALE,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title,
+    description,
+  },
+};
+
+export default function ZhGlossaryPage() {
+  const entries = getAllZhGlossaryEntries().toSorted((a, b) => {
+    const categoryOrder =
+      GLOSSARY_CATEGORIES.indexOf(a.category) - GLOSSARY_CATEGORIES.indexOf(b.category);
+    return categoryOrder || a.term.localeCompare(b.term, 'zh-CN');
+  });
+  const articleCount = getAllPosts('zh').length;
+  const browserEntries: GlossaryBrowserEntry[] = entries.map((entry) => ({
+    slug: entry.slug,
+    term: entry.term,
+    ...(entry.abbreviation && { abbreviation: entry.abbreviation }),
+    ...(entry.aliases && { aliases: entry.aliases }),
+    category: entry.category,
+    definition: entry.definition,
+    searchText: [
+      entry.term,
+      entry.abbreviation,
+      ...(entry.aliases ?? []),
+      GLOSSARY_CATEGORY_LABELS_ZH[entry.category],
+      entry.definition,
+    ]
+      .filter(Boolean)
+      .join(' ')
+      .toLocaleLowerCase(),
+  }));
+  const glossaryUrl = `${SITE_URL}/zh/glossary`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'DefinedTermSet',
+    '@id': glossaryUrl,
+    name: 'InferenceX AI 推理术语表',
+    description,
+    url: glossaryUrl,
+    inLanguage: ZH_LANG_TAG,
+    creator: {
+      '@type': 'Organization',
+      name: AUTHOR_NAME,
+    },
+    hasDefinedTerm: entries.map((entry) => ({
+      '@type': 'DefinedTerm',
+      '@id': `${glossaryUrl}/${entry.slug}`,
+      name: entry.term,
+      ...(entry.abbreviation && { termCode: entry.abbreviation }),
+      description: entry.definition,
+      url: `${glossaryUrl}/${entry.slug}`,
+      inLanguage: ZH_LANG_TAG,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <Card className="overflow-hidden p-0">
+          <header className="relative px-5 py-10 md:px-8 md:py-14 lg:px-12 lg:py-16">
+            <div
+              aria-hidden="true"
+              className="absolute top-0 left-1/2 h-px w-2/3 -translate-x-1/2 bg-linear-to-r from-transparent via-brand/75 to-transparent"
+            />
+            <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_18rem] lg:items-end">
+              <div>
+                <p className="font-mono text-xs font-semibold tracking-[0.2em] text-brand uppercase">
+                  技术指南 / AI 基础设施
+                </p>
+                <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.045em] text-balance md:text-6xl lg:text-7xl">
+                  读懂推理曲线背后的语言。
+                </h1>
+                <p className="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
+                  解释 InferenceX
+                  使用的性能指标、服务技术、数值格式和分布式系统概念。所有定义都来自实测行为，而非厂商峰值规格。
+                </p>
+              </div>
+
+              <dl className="grid grid-cols-3 gap-px overflow-hidden rounded-lg border border-border/50 bg-border/50 lg:grid-cols-1">
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    术语
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">{entries.length}</dd>
+                </div>
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    类别
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">
+                    {GLOSSARY_CATEGORIES.length}
+                  </dd>
+                </div>
+                <div className="bg-background/70 p-4">
+                  <dt className="font-mono text-[0.65rem] tracking-[0.16em] text-muted-foreground uppercase">
+                    参考文章
+                  </dt>
+                  <dd className="mt-1 text-2xl font-semibold tabular-nums">{articleCount}</dd>
+                </div>
+              </dl>
+            </div>
+          </header>
+
+          <GlossaryBrowser
+            entries={browserEntries}
+            categories={GLOSSARY_CATEGORIES}
+            labels={browserLabels}
+            categoryLabels={GLOSSARY_CATEGORY_LABELS_ZH}
+            groupBy="category"
+            basePath="/zh/glossary"
+          />
+        </Card>
+
+        <section className="mt-4 grid gap-4 md:grid-cols-2">
+          <Card>
+            <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+              阅读基准曲线
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">先看权衡，而不是峰值。</h2>
+            <p className="mt-3 leading-7 text-muted-foreground">
+              LLM 服务需要在单用户速度与总吞吐量之间取舍。了解 InferenceX 为什么使用完整 Pareto
+              曲线和等交互性比较，而不是用单一最大吞吐点给 GPU 排名。
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/zh/glossary/interactivity" className="text-brand hover:underline">
+                交互性 →
+              </Link>
+              <Link href="/zh/glossary/pareto-frontier" className="text-brand hover:underline">
+                Pareto 前沿 →
+              </Link>
+              <Link href="/zh/glossary/iso-interactivity" className="text-brand hover:underline">
+                等交互性 →
+              </Link>
+            </div>
+          </Card>
+
+          <Card>
+            <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+              基于实测数据
+            </p>
+            <h2 className="mt-3 text-2xl font-semibold tracking-tight">每个定义都连接真实方案。</h2>
+            <p className="mt-3 leading-7 text-muted-foreground">
+              每个术语页都会链接到该概念真正影响实测结果的 InferenceX 文章，包括 MTP 接受行为、NVL72
+              Wide EP 扩展，以及硬件不变时的软件性能提升。
+            </p>
+            <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/zh/blog" className="text-brand hover:underline">
+                浏览技术文章 →
+              </Link>
+              <Link href="/zh/inference" className="text-brand hover:underline">
+                查看实时基准数据 →
+              </Link>
+            </div>
+          </Card>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -26,6 +26,7 @@ const STRINGS = {
     more: 'More',
     gpuReliability: 'GPU Reliability',
     perfPerDollar: 'Performance per Dollar',
+    glossary: 'AI Inference Glossary',
     languageLink: '中文版',
     languageHref: '/zh',
     languageHrefLang: 'zh-CN',
@@ -49,6 +50,7 @@ const STRINGS = {
     more: '更多',
     gpuReliability: 'GPU 可靠性',
     perfPerDollar: '每美元性能',
+    glossary: 'AI 推理术语表',
     languageLink: 'English',
     languageHref: '/',
     languageHrefLang: 'en',
@@ -190,6 +192,13 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 {t.perfPerDollar}
+              </Link>
+              <Link
+                data-testid="footer-link-glossary"
+                href={`${prefix}/glossary`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.glossary}
               </Link>
               <Link
                 data-testid="footer-link-zh"

--- a/packages/app/src/components/glossary/glossary-browser.tsx
+++ b/packages/app/src/components/glossary/glossary-browser.tsx
@@ -267,7 +267,7 @@ export function GlossaryBrowser({
                         </p>
                       </div>
                       <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
-                        {entry.definition}
+                        {entry.plainEnglish}
                       </p>
                       <span
                         aria-hidden="true"

--- a/packages/app/src/components/glossary/glossary-browser.tsx
+++ b/packages/app/src/components/glossary/glossary-browser.tsx
@@ -7,7 +7,10 @@ import { useDeferredValue, useMemo, useState } from 'react';
 import type { GlossaryCategory, GlossaryPreview } from '@/lib/glossary';
 import { cn } from '@/lib/utils';
 
-export type GlossaryBrowserEntry = GlossaryPreview & { searchText: string };
+export type GlossaryBrowserEntry = Pick<
+  GlossaryPreview,
+  'slug' | 'term' | 'abbreviation' | 'category' | 'plainEnglish'
+> & { searchText: string };
 
 export interface GlossaryBrowserLabels {
   searchLabel: string;

--- a/packages/app/src/components/glossary/glossary-browser.tsx
+++ b/packages/app/src/components/glossary/glossary-browser.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import Link from 'next/link';
+import { Search, X } from 'lucide-react';
+import { useDeferredValue, useMemo, useState } from 'react';
+
+import type { GlossaryCategory, GlossaryPreview } from '@/lib/glossary';
+import { cn } from '@/lib/utils';
+
+export type GlossaryBrowserEntry = GlossaryPreview & { searchText: string };
+
+export interface GlossaryBrowserLabels {
+  searchLabel: string;
+  searchPlaceholder: string;
+  clearSearch: string;
+  categoryFilterLabel: string;
+  letterFilterLabel: string;
+  allLetters: string;
+  termSingular: string;
+  termPlural: string;
+  clearFilters: string;
+  noMatch: string;
+  noResultsTitle: string;
+  noResultsDescription: string;
+  showAllTerms: string;
+}
+
+interface GlossaryBrowserProps {
+  entries: readonly GlossaryBrowserEntry[];
+  categories: readonly GlossaryCategory[];
+  labels?: GlossaryBrowserLabels;
+  categoryLabels?: Partial<Record<GlossaryCategory, string>>;
+  groupBy?: 'initial' | 'category';
+  basePath?: string;
+}
+
+const DEFAULT_LABELS: GlossaryBrowserLabels = {
+  searchLabel: 'Search the AI inference glossary',
+  searchPlaceholder: 'Search MTP, latency, FP4…',
+  clearSearch: 'Clear glossary search',
+  categoryFilterLabel: 'Filter glossary by category',
+  letterFilterLabel: 'Filter by letter',
+  allLetters: 'ALL',
+  termSingular: 'term',
+  termPlural: 'terms',
+  clearFilters: 'Clear filters',
+  noMatch: 'No match',
+  noResultsTitle: 'No glossary terms found',
+  noResultsDescription: 'Try a broader keyword or clear the active filters.',
+  showAllTerms: 'Show all terms',
+};
+
+const LETTERS = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
+
+export function GlossaryBrowser({
+  entries,
+  categories,
+  labels = DEFAULT_LABELS,
+  categoryLabels,
+  groupBy = 'initial',
+  basePath = '/glossary',
+}: GlossaryBrowserProps) {
+  const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query.trim().toLocaleLowerCase());
+  const [category, setCategory] = useState<GlossaryCategory | null>(null);
+  const [letter, setLetter] = useState<string | null>(null);
+  const availableLetters = useMemo(
+    () =>
+      groupBy === 'initial'
+        ? new Set(entries.map((entry) => entry.term[0]?.toLocaleUpperCase()))
+        : new Set<string>(),
+    [entries, groupBy],
+  );
+  const filteredEntries = useMemo(
+    () =>
+      entries.filter(
+        (entry) =>
+          (!deferredQuery || entry.searchText.includes(deferredQuery)) &&
+          (!category || entry.category === category) &&
+          (!letter || entry.term.toLocaleUpperCase().startsWith(letter)),
+      ),
+    [category, deferredQuery, entries, letter],
+  );
+  const groupedEntries = useMemo(() => {
+    const groups: Record<string, GlossaryBrowserEntry[]> = {};
+    for (const entry of filteredEntries) {
+      const group =
+        groupBy === 'category' ? entry.category : (entry.term[0]?.toLocaleUpperCase() ?? '#');
+      (groups[group] ??= []).push(entry);
+    }
+    return Object.entries(groups).toSorted(([a], [b]) =>
+      groupBy === 'category'
+        ? categories.indexOf(a as GlossaryCategory) - categories.indexOf(b as GlossaryCategory)
+        : a.localeCompare(b),
+    );
+  }, [categories, filteredEntries, groupBy]);
+  const hasFilters = Boolean(query || category || letter);
+
+  const clearFilters = () => {
+    setQuery('');
+    setCategory(null);
+    setLetter(null);
+  };
+
+  return (
+    <div>
+      <div className="border-y border-border/50 bg-background/30 px-4 py-5 backdrop-blur-[2px] md:px-6">
+        <div className="grid gap-4 xl:grid-cols-[minmax(18rem,1fr)_auto] xl:items-center">
+          <label className="relative block">
+            <span className="sr-only">{labels.searchLabel}</span>
+            <Search
+              aria-hidden="true"
+              className="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={labels.searchPlaceholder}
+              className="h-12 w-full rounded-lg border border-border/70 bg-background/60 pr-11 pl-11 text-sm outline-none transition-[border-color,box-shadow] placeholder:text-muted-foreground focus:border-brand/60 focus:ring-2 focus:ring-brand/15"
+            />
+            {query && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                aria-label={labels.clearSearch}
+                className="absolute top-1/2 right-3 flex size-7 -translate-y-1/2 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <X aria-hidden="true" className="size-4" />
+              </button>
+            )}
+          </label>
+
+          <div className="flex flex-wrap gap-2" aria-label={labels.categoryFilterLabel}>
+            {categories.map((item) => (
+              <button
+                key={item}
+                type="button"
+                aria-pressed={category === item}
+                onClick={() => setCategory((current) => (current === item ? null : item))}
+                className={cn(
+                  'cursor-pointer rounded-full border px-3 py-1.5 text-xs font-medium transition-colors',
+                  category === item
+                    ? 'border-brand/45 bg-brand/12 text-brand'
+                    : 'border-border/60 bg-background/30 text-muted-foreground hover:border-foreground/25 hover:text-foreground',
+                )}
+              >
+                {categoryLabels?.[item] ?? item}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {groupBy === 'initial' && (
+          <div
+            className="mt-5 flex items-center gap-2 overflow-x-auto pb-1"
+            aria-label={labels.letterFilterLabel}
+          >
+            <button
+              type="button"
+              aria-pressed={letter === null}
+              onClick={() => setLetter(null)}
+              className={cn(
+                'flex h-8 min-w-10 cursor-pointer items-center justify-center rounded-md border px-2 font-mono text-xs transition-colors',
+                letter === null
+                  ? 'border-brand/45 bg-brand/12 text-brand'
+                  : 'border-border/50 text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {labels.allLetters}
+            </button>
+            {LETTERS.map((item) => {
+              const available = availableLetters.has(item);
+              return (
+                <button
+                  key={item}
+                  type="button"
+                  disabled={!available}
+                  aria-pressed={letter === item}
+                  onClick={() => setLetter((current) => (current === item ? null : item))}
+                  className={cn(
+                    'flex size-8 shrink-0 items-center justify-center rounded-md border font-mono text-xs transition-colors',
+                    available ? 'cursor-pointer' : 'cursor-not-allowed opacity-25',
+                    letter === item
+                      ? 'border-brand/45 bg-brand/12 text-brand'
+                      : 'border-border/50 text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {item}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="px-4 py-4 md:px-6">
+        <div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+          <p aria-live="polite">
+            <span className="font-mono text-foreground">{filteredEntries.length}</span>{' '}
+            {filteredEntries.length === 1 ? labels.termSingular : labels.termPlural}
+          </p>
+          {hasFilters && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="cursor-pointer font-medium text-brand hover:underline"
+            >
+              {labels.clearFilters}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {groupedEntries.length > 0 ? (
+        <div className="border-t border-border/50">
+          {groupedEntries.map(([groupKey, group], groupIndex) => {
+            const headingId = `glossary-group-${groupIndex}`;
+            const groupLabel =
+              groupBy === 'category'
+                ? (categoryLabels?.[groupKey as GlossaryCategory] ?? groupKey)
+                : groupKey;
+            return (
+              <section
+                key={groupKey}
+                aria-labelledby={headingId}
+                className={cn(
+                  'grid border-b border-border/50 last:border-b-0',
+                  groupBy === 'category'
+                    ? 'md:grid-cols-[8rem_minmax(0,1fr)]'
+                    : 'md:grid-cols-[6rem_minmax(0,1fr)]',
+                )}
+              >
+                <div className="border-b border-border/40 bg-muted/8 px-5 py-5 md:border-r md:border-b-0 md:px-6 md:py-7">
+                  <h2
+                    id={headingId}
+                    className={cn(
+                      'font-mono font-semibold text-brand md:sticky md:top-20',
+                      groupBy === 'category'
+                        ? 'text-base leading-6 tracking-normal'
+                        : 'text-3xl tracking-[-0.06em]',
+                    )}
+                  >
+                    {groupLabel}
+                  </h2>
+                </div>
+                <div className="divide-y divide-border/40">
+                  {group.map((entry) => (
+                    <Link
+                      key={entry.slug}
+                      href={`${basePath}/${entry.slug}`}
+                      className="group grid gap-3 px-5 py-6 transition-colors hover:bg-brand/5 md:grid-cols-[minmax(12rem,0.7fr)_minmax(0,1.3fr)_auto] md:items-start md:gap-8 md:px-8"
+                    >
+                      <div>
+                        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                          <h3 className="text-lg font-semibold tracking-tight group-hover:text-brand group-hover:underline">
+                            {entry.term}
+                          </h3>
+                          {entry.abbreviation && (
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {entry.abbreviation}
+                            </span>
+                          )}
+                        </div>
+                        <p className="mt-1 text-[0.68rem] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+                          {categoryLabels?.[entry.category] ?? entry.category}
+                        </p>
+                      </div>
+                      <p className="line-clamp-3 text-sm leading-6 text-muted-foreground">
+                        {entry.definition}
+                      </p>
+                      <span
+                        aria-hidden="true"
+                        className="hidden pt-1 text-muted-foreground transition-transform group-hover:translate-x-1 group-hover:text-brand md:block"
+                      >
+                        →
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="border-t border-border/50 px-6 py-20 text-center">
+          <p className="font-mono text-xs tracking-[0.18em] text-brand uppercase">
+            {labels.noMatch}
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold">{labels.noResultsTitle}</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{labels.noResultsDescription}</p>
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="mt-5 cursor-pointer rounded-md border border-brand/40 bg-brand/10 px-4 py-2 text-sm font-medium text-brand hover:bg-brand/15"
+          >
+            {labels.showAllTerms}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -1,0 +1,600 @@
+import { type GlossaryCategory, type GlossaryEntry, getAllGlossaryEntries } from './glossary';
+
+export const GLOSSARY_CATEGORY_LABELS_ZH: Readonly<Record<GlossaryCategory, string>> = {
+  'Benchmark metrics': '基准指标',
+  Serving: '推理服务',
+  Parallelism: '并行策略',
+  Hardware: '硬件',
+  'Numerical precision': '数值精度',
+  'Model architecture': '模型架构',
+  Software: '软件栈',
+};
+
+type GlossaryTranslation = Pick<
+  GlossaryEntry,
+  'term' | 'aliases' | 'definition' | 'explanation' | 'significance' | 'benchmarkContext'
+>;
+
+const translations: Readonly<Record<string, GlossaryTranslation>> = {
+  'ai-inference': {
+    term: 'AI 推理',
+    aliases: ['AI inference', 'LLM 推理', '模型服务'],
+    definition:
+      'AI 推理是使用已经训练好的模型处理新输入并生成输出的过程；对大语言模型而言，通常就是处理提示词并生成 token。',
+    explanation:
+      '训练阶段会更新模型权重，推理阶段则使用这些权重。生产系统还需要推理引擎负责调度请求、管理内存、合并批次，并在一个或多个加速器上执行内核。相同模型在不同软硬件栈上的表现可能相差数倍。',
+    significance:
+      '推理既是模型问题，也是系统问题。用户体验取决于延迟和交互性，运营成本则取决于吞吐量、利用率、功耗与硬件成本；只优化其中一个维度，往往会牺牲另一个维度。',
+    benchmarkContext:
+      'InferenceX 测试完整的推理方案，而不是只引用芯片峰值规格。每条曲线都对应明确的模型、引擎、精度、并行策略、GPU 系统、序列长度和并发扫描。',
+  },
+  'inference-engine': {
+    term: '推理引擎',
+    aliases: ['inference engine', '服务引擎', 'LLM 服务框架'],
+    definition: '推理引擎是将模型权重和用户请求转化为加速器上生成结果的软件运行时。',
+    explanation:
+      '它负责请求调度、连续批处理、KV 缓存分配、分布式执行、内核选择与 token 采样。vLLM、SGLang 和 TensorRT-LLM 即使运行同一模型和 GPU，也会因调度器、内核与分布式策略不同而产生不同曲线。',
+    significance:
+      '引擎版本和配置有时与 GPU 选择同样重要。一次调度器更新、融合注意力内核或模型专用路径修复，都可能在硬件不变时带来数倍性能变化。',
+    benchmarkContext:
+      'InferenceX 将引擎和容器镜像记录为可复现方案的一部分，因此历史视图能够区分软件进步与芯片代际进步。',
+  },
+  throughput: {
+    term: '吞吐量',
+    aliases: ['throughput', 'token 吞吐量', '总吞吐量'],
+    definition: '吞吐量是推理系统在所有活跃请求上生成 token 的总速率。',
+    explanation:
+      'InferenceX 通常使用每 GPU 每秒 token 数进行归一化，便于比较不同规模的系统。提高批大小或并发往往能摊薄权重读取和计算成本，从而提高总吞吐量，但单个用户收到 token 的速度可能下降。',
+    significance:
+      '最大吞吐量不是完整的性能结论。某个点即使拥有最高 tok/s，也可能因为交互性过低而不适合实时产品；有效比较应在符合业务需求的延迟或交互性目标下进行。',
+    benchmarkContext:
+      'InferenceX 将吞吐量与交互性放在完整并发扫描中共同展示，并用 Pareto 前沿剔除两个轴上都更差的运行点。',
+  },
+  interactivity: {
+    term: '交互性',
+    aliases: ['interactivity', '生成速度', '每用户 token 速率'],
+    definition: '交互性是解码阶段单个用户接收生成 token 的速率。',
+    explanation:
+      '在单位换算一致时，它是每输出 token 时间的倒数。50 tok/s/user 表示首个 token 之后大约每 20 毫秒输出一个新 token；它描述流式响应速度，而不是首 token 到达前的等待。',
+    significance:
+      '不同产品需要不同运行点。语音和交互式编程要求较高 token 速率，离线摘要则可以牺牲交互性换取更高总吞吐量；在交互性不一致时比较硬件很容易得出误导性结论。',
+    benchmarkContext:
+      'InferenceX 将 tok/s/user 与吞吐量或成本一起绘制，并在等交互性表格中沿各自 Pareto 前沿插值，以固定用户体验。',
+  },
+  latency: {
+    term: '延迟',
+    aliases: ['latency', '响应延迟', '推理延迟'],
+    definition:
+      '延迟是请求经历的时间；在流式 LLM 服务中，应区分首 token 等待时间与后续 token 间隔。',
+    explanation:
+      '首 token 时间包含排队和预填充，单 token 输出时间反映解码节奏。端到端延迟还受输出长度影响，因此一个汇总数字可能掩盖用户真正感知到的环节。',
+    significance:
+      '降低延迟通常需要更小批次或更多并行资源，这可能降低硬件利用率并提高成本。好的服务设计会先确定延迟服务等级，再在该约束内最大化吞吐量。',
+    benchmarkContext:
+      'InferenceX 强调解码交互性，并公开工作负载形状与并发量，避免把高吞吐批处理点误读为低延迟服务点。',
+  },
+  'time-to-first-token': {
+    term: '首 token 时间',
+    aliases: ['time to first token', '首字延迟'],
+    definition: '首 token 时间（TTFT）是从提交请求到收到第一个生成 token 的时间。',
+    explanation:
+      'TTFT 包含排队、提示词处理，以及解码开始前的路由或 KV 缓存传输。更长提示词通常增加预填充工作，系统过载也会在模型计算不变时增加排队时间。',
+    significance:
+      '用户会把 TTFT 感知为系统开始回答的速度。即使后续 token 流很快，只要排队或预填充等待过长，整体体验仍会显得迟缓。',
+    benchmarkContext:
+      '应将 TTFT 与输入序列长度、并发量以及是否采用预填充/解码分离一起阅读，这些因素解释了为何解码速度相近的方案仍可能有不同启动时间。',
+  },
+  'time-per-output-token': {
+    term: '每输出 token 时间',
+    aliases: ['time per output token', 'token 间延迟', 'ITL'],
+    definition: '每输出 token 时间（TPOT）是首 token 到达后，相邻生成 token 之间的平均时间。',
+    explanation:
+      'TPOT 描述流式响应的解码节奏。在忽略单位换算时，它是每用户 token 速率的倒数；20 毫秒/token 约等于 50 tok/s/user。',
+    significance:
+      'TPOT 单独刻画回答流是否顺畅。随着更多请求共享系统，TPOT 通常会变差，即便总吞吐量仍在上升。',
+    benchmarkContext:
+      'InferenceX 多使用其倒数 tok/s/user，便于让更高数值代表更好性能；在比较相同并发下的调度器或内核变化时，方案表也会直接列出 TPOT。',
+  },
+  concurrency: {
+    term: '并发量',
+    aliases: ['concurrency', '并发请求数'],
+    definition: '并发量是基准测试或部署中同时被服务的请求数量。',
+    explanation:
+      '提高并发能为调度器提供更多可批处理工作，通常提升加速器利用率和总吞吐量；代价是每个请求分到的计算与内存带宽减少，因此交互性往往下降。',
+    significance:
+      '单个并发值只代表一个运行点。生产流量持续变化，在低并发领先的方案，可能在大批次或通信占主导时被其他方案超越。',
+    benchmarkContext:
+      'InferenceX 扫描多个并发值以构建吞吐量—交互性曲线，曲线标签会标出每个点的请求数，并显示方案何时饱和或性能坍塌。',
+  },
+  batching: {
+    term: '批处理',
+    aliases: ['batching', '连续批处理', '动态批处理'],
+    definition: '批处理将多个请求的工作组合起来，使加速器能够一起处理它们的 token。',
+    explanation:
+      '大型矩阵运算比大量微小运算更能发挥 GPU 效率。现代推理引擎采用连续批处理，请求到达和结束时动态加入或退出，而不是等待固定批次全部完成。',
+    significance:
+      '批处理是吞吐量与延迟核心权衡的来源。更大的有效批次能摊薄权重读取和内核启动开销，但通常会增加每位用户的 token 间隔。',
+    benchmarkContext:
+      '并发量是批处理的输入，并不等同于某个固定内核批大小；并行策略、序列长度、请求完成时机和调度策略都会改变 GPU 实际看到的批形状。',
+  },
+  'pareto-frontier': {
+    term: 'Pareto 前沿',
+    aliases: ['Pareto frontier', '性能前沿', 'Pareto 最优曲线'],
+    definition: 'Pareto 前沿由不存在另一个测量点能在两个比较维度上都更好的运行点组成。',
+    explanation:
+      '在吞吐量与交互性图中，如果另一个点既能处理更多总 token，又能让每个用户更快收到 token，那么原点就被支配；删除所有被支配点后得到有效边界。',
+    significance:
+      '前沿能避免噪声点或调优较差的点扭曲比较，并展示真正的权衡。沿曲线仍不存在普适赢家，最佳点取决于用户最低交互性或最高成本目标。',
+    benchmarkContext:
+      'InferenceX 连接并发与配置扫描中的 Pareto 最优点，等交互性比较也沿这些前沿插值，而不是随意选择原始点。',
+  },
+  'iso-interactivity': {
+    term: '等交互性',
+    aliases: ['iso-interactivity', '匹配交互性', '相同 token 速率'],
+    definition: '等交互性是指在相同的每用户生成速度下比较不同系统。',
+    explanation:
+      '不同方案的并发点很少正好落在相同 tok/s/user。等交互性比较会在各自 Pareto 前沿上对共同目标插值，再比较该点的吞吐量、成本或效率。',
+    significance:
+      '固定用户体验可以避免常见基准错误：某系统只有在让每个请求更慢时才达到更高吞吐量，却被错误地称为更快。',
+    benchmarkContext:
+      'InferenceX 文章使用等交互性表格比较硬件、精度和软件；超出实测前沿的值会标记为不可达，而不会向观测区间之外外推。',
+  },
+  'input-output-sequence-length': {
+    term: '输入与输出序列长度',
+    aliases: ['input/output sequence length', '提示词长度', '生成长度', '8K/1K'],
+    definition:
+      '输入序列长度（ISL）是提示词 token 数，输出序列长度（OSL）是响应中生成的 token 数。',
+    explanation:
+      '两者共同定义工作负载形状。8K/1K 表示约 8,192 个输入 token 和 1,024 个输出 token；长输入增加预填充与 KV 缓存压力，长输出则在自回归解码循环中停留更久。',
+    significance:
+      '不同序列长度的结果不能直接互换。短聊天提示词上的最佳配置，在长上下文摘要或推理中可能排名不同，因为计算、容量与带宽压力都会变化。',
+    benchmarkContext:
+      'InferenceX 在图表标签与方案描述中列出 ISL/OSL。只有先匹配工作负载形状，才能把差异归因于硬件或软件。',
+  },
+  'cost-per-million-tokens': {
+    term: '每百万 token 成本',
+    aliases: ['cost per million tokens', '$/M tokens', 'token 成本'],
+    definition: '每百万 token 成本估算系统在某个实测运行点生成一百万 token 所需的基础设施成本。',
+    explanation:
+      'InferenceX 根据每小时总体拥有成本和实测 token 吞吐量计算该指标。它可能按总 token 报告，也可能区分输入和输出 token，因此比较前必须确认分母。',
+    significance:
+      '该指标把系统性能转化为服务经济性，但仍受工作负载、交互性、利用率、缓存命中和成本假设影响；离线低交互点不能直接与实时端点比较。',
+    benchmarkContext:
+      '成本曲线使用与吞吐曲线相同的并发扫描。在等交互性下，更低的 $/M 表示以更少建模成本提供相同流式体验。',
+  },
+  'performance-per-dollar': {
+    term: '每美元性能',
+    aliases: ['performance per dollar', 'perf/$', '成本效率'],
+    definition: '每美元性能表示系统每单位建模成本能够交付多少实测推理工作。',
+    explanation:
+      '在固定工作负载和交互性目标下，它是每 token 成本的倒数。2 倍 perf/$ 意味着在相同基础设施支出下，可生成约两倍可比 token。',
+    significance:
+      '芯片峰值 FLOPS 不能单独决定服务经济性；内存、网络、软件成熟度、数值精度和实际利用率都会影响最终比值。',
+    benchmarkContext:
+      'InferenceX 在匹配交互性时比较 perf/$，并明确使用的 TCO 输入。该比值不能跨模型、序列长度、精度或延迟区间直接套用。',
+  },
+  'total-cost-of-ownership': {
+    term: '总体拥有成本',
+    aliases: ['total cost of ownership', '全生命周期成本'],
+    definition: '总体拥有成本（TCO）是基础设施在使用寿命内采购、部署和运营的综合成本估算。',
+    explanation:
+      'GPU 采购价只是其中一项。TCO 模型还可包含主机、网络、供电、制冷、机房、融资、折旧、维护和预期利用率，并归一化为每 GPU 小时成本。',
+    significance:
+      'TCO 比标价更适合跨系统经济性比较，尤其是网络与电力基础设施不同的机架级产品；但它仍是模型，必须连同假设一起阅读。',
+    benchmarkContext:
+      'InferenceX 将 SemiAnalysis AI Cloud TCO 输入与实测 tok/s/GPU 结合，从而区分每小时系统成本和决定该小时 token 产出的软硬件行为。',
+  },
+  'tokens-per-megawatt': {
+    term: '每兆瓦 token 吞吐量',
+    aliases: ['tokens per megawatt', 'tokens/MW', '功率归一化吞吐量'],
+    definition: '每兆瓦 token 吞吐量衡量推理产出相对于数据中心电力预算的效率。',
+    explanation:
+      'InferenceX 使用全口径公用事业供电，而不只使用芯片 TDP。这个分母可包含为 IT 负载供电和制冷的开销，更适合设施级容量规划。',
+    significance:
+      '电力供应往往是新增 AI 部署的硬约束。每兆瓦生成更多 token 的系统，即使单个加速器功耗更高，也能在相同电力配额下服务更多需求。',
+    benchmarkContext:
+      '比较 tokens/MW 时必须匹配模型、工作负载、精度与交互性，否则高吞吐低交互点可能看似高效，却无法满足目标用户体验。',
+  },
+  prefill: {
+    term: '预填充',
+    aliases: ['prefill', '提示词处理', '上下文编码'],
+    definition: '预填充是推理的第一阶段：模型处理输入提示词并填充 KV 缓存，然后才开始生成。',
+    explanation:
+      '提示词 token 可以并行处理，形成大型矩阵运算，因此通常偏计算密集。预填充成本随输入长度增长，并显著影响首 token 时间。',
+    significance:
+      '预填充与解码的资源特征不同。两者共享工作节点时，大型提示词任务会打断解码批次，使流式延迟更不稳定。',
+    benchmarkContext:
+      '分离式方案将预填充放在独立 GPU 池。阅读结果时应检查预填充 TP、GPU 数、输入长度，以及 KV 状态是否需要跨网络传输到解码池。',
+  },
+  decode: {
+    term: '解码',
+    aliases: ['decode', '自回归生成', 'token 生成'],
+    definition: '解码是自回归生成输出 token 的阶段，通常每个模型步为每条序列接受一个 token。',
+    explanation:
+      '每个新 token 都依赖此前 token，因此时间维度无法完全并行。模型会反复读取权重与该序列的 KV 缓存，使解码对内存带宽、批处理和通信尤其敏感。',
+    significance:
+      '解码决定流式交互性，也常主导长输出成本。推测解码、MTP、量化和宽专家并行都试图减少每个有效 token 的工作量或耗时。',
+    benchmarkContext:
+      'InferenceX 用 tok/s/user 与总 tok/s/GPU 展示不同并发下的解码性能。公平比较必须匹配输出长度、批形状、精度和并行策略。',
+  },
+  'kv-cache': {
+    term: 'KV 缓存',
+    aliases: ['KV cache', '键值缓存', '注意力缓存'],
+    definition:
+      'KV 缓存保存已经处理过的 token 的注意力 key/value 状态，避免每个解码步重新计算它们。',
+    explanation:
+      '缓存大小随序列长度、批大小、层数以及注意力头数量和宽度增长；解码时会从加速器内存反复读取，因此容量与带宽都很重要。',
+    significance:
+      'KV 缓存压力限制并发与长上下文服务。缓存量化、分页分配、潜在注意力、前缀复用和分离式传输系统都在降低其容量或移动成本。',
+    benchmarkContext:
+      '除非方案另有说明，InferenceX 在随机数据比较中禁用前缀缓存，避免无关请求因偶然命中而获得不真实优势。',
+  },
+  'prefix-caching': {
+    term: '前缀缓存',
+    aliases: ['prefix caching', '提示词缓存', '自动前缀缓存'],
+    definition: '当前多个请求以相同 token 序列开头时，前缀缓存会复用已有 KV 缓存状态。',
+    explanation:
+      '重复系统提示词、共享文档或共同对话前缀在缓存仍可用时无需再次预填充。命中缓存可显著减少提示词计算与首 token 时间。',
+    significance:
+      '具有重复前缀的生产工作负载可能明显快于随机 token 基准；收益取决于命中率、缓存容量、淘汰策略与请求能否路由到持有所需状态的节点。',
+    benchmarkContext:
+      'InferenceX 通常在随机数据集上禁用前缀缓存，因为偶然复用会测量缓存策略而不是完整提示词处理；除非明确说明，应把结果视为无命中基线。',
+  },
+  'disaggregated-inference': {
+    term: '分离式推理',
+    aliases: ['disaggregated inference', 'PD 分离', '分离式预填充', 'disagg'],
+    definition: '分离式推理在不同工作池上运行预填充与解码，并在两者之间传输请求状态。',
+    explanation:
+      '预填充通常偏计算密集，解码则常受内存带宽和通信限制。分离后，两侧可以采用不同 GPU 数、并行度、批策略和扩缩容方式。',
+    significance:
+      '分离可隔离提示词峰值并提升吞吐量或 SLA 稳定性，但也增加路由与 KV 传输开销；网络薄弱或内核不成熟时，它可能反而慢于聚合式服务。',
+    benchmarkContext:
+      'InferenceX 中的 disagg 不是万能开关。应查看预填充/解码 world size、TP/EP 布局、框架、网络域，以及分离前沿真正领先的交互性区间。',
+  },
+  'speculative-decoding': {
+    term: '推测解码',
+    aliases: ['speculative decoding', '草稿—验证解码'],
+    definition:
+      '推测解码先以低成本提出多个未来 token，再由目标模型批量验证，从而减少昂贵的串行解码步数。',
+    explanation:
+      '草稿模型或内置预测头生成候选，目标模型在一次批量验证中评估这些候选并接受有效前缀；严格实现时不会改变目标分布。',
+    significance:
+      '加速取决于草稿 token 的接受数量，以及草稿与验证成本。稠密模型和 MoE 的表现可能不同，因为验证多个位置可能激活更多专家权重。',
+    benchmarkContext:
+      '应在真实接受率下比较推测方案并验证模型质量。InferenceX 分开展示开启和关闭 MTP 的曲线，因为收益会随并发与交互性变化。',
+  },
+  'multi-token-prediction': {
+    term: '多 token 预测',
+    aliases: ['multi-token prediction', '多 token 预测头'],
+    definition:
+      '多 token 预测（MTP）使用与主模型共同训练的辅助预测头，提出多个未来 token 供推测验证。',
+    explanation:
+      'MTP 不需要独立草稿模型，候选来自目标模型自身表示，因此分布更一致、部署也更简单；但它要求检查点包含兼容 MTP 模块，且推理引擎支持验证路径。',
+    significance:
+      'MTP 可用额外计算换取更少的内存受限解码步。草稿接受率高且验证能利用空闲计算时收益最大；大批次下额外工作可能减少优势。',
+    benchmarkContext:
+      'InferenceX 将 MTP 作为方案维度。把基准收益迁移到生产时，必须考虑接受率/长度、工作负载分布、数值质量检查与匹配交互性。',
+  },
+  eagle: {
+    term: 'EAGLE',
+    aliases: ['EAGLE 推测解码', 'EAGLE-3'],
+    definition:
+      'EAGLE 是一组推测解码方法：利用与目标语言模型相关的特征预测草稿序列，再由目标模型验证。',
+    explanation:
+      '推理框架通常通过推测步数、草稿 token 数和候选宽度等参数暴露 EAGLE。模型检查点、草稿组件与引擎实现必须匹配。',
+    significance:
+      'EAGLE 能提高每个目标模型步接受的 token 数，但结果依赖工作负载；接受行为、草稿开销、模型架构和批大小共同决定端到端收益。',
+    benchmarkContext:
+      '部分 InferenceX 曲线标注 MTP，是因为模型提供多 token 预测头，而引擎使用 EAGLE 风格管线。应查看方案参数与检查点细节，不能假设所有 MTP 曲线实现相同。',
+  },
+  'tensor-parallelism': {
+    term: '张量并行',
+    aliases: ['tensor parallelism', 'TP'],
+    definition: '张量并行（TP）把单个张量运算和模型权重矩阵切分到多个加速器上。',
+    explanation:
+      '每一层由多个 rank 协同执行，部分结果需要通过集体通信合并，常见方式是在并行矩阵乘之后执行 all-reduce。',
+    significance:
+      'TP 能让模型跨设备容纳，并在小批次下汇聚算力与内存带宽以提高交互性；但通信发生频繁，扩展最终受互连带宽和延迟限制。',
+    benchmarkContext:
+      'InferenceX 方案中的 TP=4 或 TP=8 表示张量并行组的 rank 数。应与 EP、DP、节点数和网络域一起比较。',
+  },
+  'expert-parallelism': {
+    term: '专家并行',
+    aliases: ['expert parallelism', 'EP'],
+    definition:
+      '专家并行（EP）把 MoE 模型的专家分布到不同加速器，并将 token 路由到持有所选专家的 rank。',
+    explanation:
+      'MoE 层对每个 token 只激活部分专家。EP 利用这种稀疏性，避免每张 GPU 存储和计算全部专家，但每个 MoE 层前后都要执行 dispatch 与 combine all-to-all。',
+    significance:
+      '更宽 EP 能减少每 GPU 专家权重占用，并改善解码批处理与容量；收益取决于路由均衡和互连能否足够快地移动 token。',
+    benchmarkContext:
+      'InferenceX 将 EP 宽度列为分布式方案的一部分。NVL72 可让远宽于传统八卡节点的专家组保持在 NVLink scale-up 域内。',
+  },
+  'data-parallelism': {
+    term: '数据并行',
+    aliases: ['data parallelism', 'DP'],
+    definition:
+      '数据并行（DP）在多个 rank 上运行复制的模型或层组，并把请求或 token 分配给这些副本。',
+    explanation:
+      '传统 DP 复制完整模型；LLM 服务也会使用 DP attention 等混合形式，让注意力复制而专家权重采用另一种分片。每个副本处理独立工作，逐层同步少于 TP。',
+    significance:
+      '权重能放入内存时，DP 可直接扩展总容量，但复制会消耗内存并重复权重读取；负载均衡与缓存局部性决定副本利用是否均匀。',
+    benchmarkContext:
+      'InferenceX 中的 DP 数必须结合 TP 和 EP 解读，因为现代 MoE 部署通常同时组合三种维度。',
+  },
+  'wide-expert-parallelism': {
+    term: '宽专家并行',
+    aliases: ['wide expert parallelism', 'Wide EP'],
+    definition: '宽专家并行使用大量加速器 rank 构成 MoE 模型的专家并行组。',
+    explanation:
+      '把数百个专家分散到更多 rank，可减少每张 GPU 需要存储和流式读取的专家权重；更大的同伴组也可形成更高效的专家批次，但 dispatch/combine 流量会扩展。',
+    significance:
+      'Wide EP 在高带宽 scale-up 网络中最有效。若流量跨越较慢的 scale-out 网络，同样的 all-to-all 可能成为瓶颈并抵消内存侧收益。',
+    benchmarkContext:
+      'InferenceX 在机架级分离式方案中使用 Wide EP。比较时必须同时查看 EP 宽度、解码池大小与网络，而不能只看图例中的 GPU 型号。',
+  },
+  'all-reduce': {
+    term: 'All-reduce',
+    aliases: ['全归约'],
+    definition:
+      'All-reduce 是一种集体通信操作：合并所有参与 rank 的值，并把归约结果返回给每个 rank。',
+    explanation:
+      '张量并行层使用 all-reduce 组合部分矩阵运算结果。集体操作可通过针对环、树或特定网络优化的算法完成求和等归约。',
+    significance:
+      'TP 可能在许多层、每个生成 token 上执行通信，因此 all-reduce 延迟和带宽会形成硬扩展上限；小解码批次对固定通信延迟尤其敏感。',
+    benchmarkContext:
+      '更高 TP 宽度增加计算与内存带宽，也扩大通信组。实测结果必须证明互连没有让更大的组得不偿失。',
+  },
+  'all-to-all': {
+    term: 'All-to-all',
+    aliases: ['全交换'],
+    definition: 'All-to-all 是每个参与 rank 向所有其他 rank 发送不同数据的集体通信模式。',
+    explanation:
+      '专家并行 MoE 层先用 all-to-all dispatch 把 token 发往所选专家，再用 combine 把专家输出送回；流量与不均衡程度取决于 token 路由。',
+    significance:
+      'All-to-all 比简单点对点传输更苛刻，EP 扩大后容易受网络限制。专用内核会重叠通信与计算并优化 token 打包。',
+    benchmarkContext:
+      '机架级 NVLink 可让 Wide EP 的 all-to-all 留在 scale-up 域内；跨节点 InfiniBand 或 RoCE 方案需要面对远低得多的每 GPU scale-out 带宽。',
+  },
+  'scale-up-vs-scale-out': {
+    term: 'Scale-up 与 scale-out 网络',
+    aliases: ['纵向扩展域', '横向扩展网络'],
+    definition:
+      'Scale-up 网络连接同一紧耦合系统内的加速器，scale-out 网络则把多个系统或机架连接成更大集群。',
+    explanation:
+      'NVLink 等 scale-up 网络为细粒度集体通信提供极高每 GPU 带宽和低延迟；InfiniBand 或 RoCE 等 scale-out 网络覆盖更多机器，但每加速器带宽通常更低。',
+    significance:
+      '分布式推理会跨越两个域。高频 TP/EP 集体通信尤其适合留在 scale-up 内，较粗粒度请求路由和部分预填充/解码传输则更能容忍 scale-out。',
+    benchmarkContext:
+      'GPU 名称本身不能描述通信域。八卡节点中的 B200 与 GB200 NVL72 使用相关芯片，却拥有完全不同的 scale-up 组规模。',
+  },
+  'high-bandwidth-memory': {
+    term: '高带宽内存',
+    aliases: ['high-bandwidth memory', 'HBM'],
+    definition: '高带宽内存（HBM）是靠近加速器堆叠的内存，其带宽远高于传统服务器内存。',
+    explanation:
+      'HBM 存储模型权重、激活、工作区与 KV 缓存。容量决定哪些模型、批大小和并行布局能放入；带宽决定内存受限内核能多快读取这些状态。',
+    significance:
+      'LLM 解码中，每个 token 往往读取的数据远多于计算量，因此 HBM 带宽是主要性能上限；额外容量也可能在峰值算力相近时解锁更高效的方案。',
+    benchmarkContext:
+      'InferenceX 硬件比较会区分 HBM 容量与带宽。例如 GB300 的更大容量可容纳 GB200 无法放入的更宽预填充/解码布局。',
+  },
+  'memory-bandwidth': {
+    term: '内存带宽',
+    aliases: ['memory bandwidth', 'HBM 带宽'],
+    definition: '内存带宽是数据在加速器内存与计算单元之间传输的速率。',
+    explanation:
+      '当移动所需字节比执行算术更耗时，内核就是内存带宽受限。LLM 解码经常处于该状态，因为每一步都要为较少的新 token 计算流式读取模型/专家权重和 KV 缓存。',
+    significance:
+      '已经在等待内存的内核不会因更多 tensor-core FLOPS 自动加速。量化、批处理、缓存压缩和专家分片可通过减少字节或摊薄权重读取改善性能。',
+    benchmarkContext:
+      '可谨慎结合并发曲线判断性能区间：小批次可能受启动或带宽限制，大批次则提高算术强度并接近计算饱和。',
+  },
+  nvlink: {
+    term: 'NVLink',
+    aliases: ['NVIDIA NVLink', 'GPU 高速互连'],
+    definition: 'NVLink 是 NVIDIA 用于 scale-up 域内 GPU 直接数据传输的高带宽加速器互连。',
+    explanation:
+      'NVSwitch 系统连接多个 NVLink 端点，使集体通信可覆盖八卡服务器，或在 NVL72 产品中覆盖 72 GPU 机架级域；该带宽不同于连接独立系统的 InfiniBand/Ethernet。',
+    significance:
+      '大型 TP，尤其是 Wide EP，会在每个生成 token 上交换数据。把通信留在 NVLink 上，可让机架级方案显著快于通过 scale-out 连接的相似 GPU 数量。',
+    benchmarkContext:
+      'InferenceX 同时比较节点级 GPU 与 NVL72。归因于单 GPU 算力前，应先理解系统拓扑与并行组宽度。',
+  },
+  quantization: {
+    term: '量化',
+    aliases: ['quantization', '低精度推理', '权重量化'],
+    definition: '量化使用比高精度基线更少的 bit 表示模型权重、激活或缓存值。',
+    explanation:
+      '更低精度减少内存占用与传输字节，并可使用更快的低精度 tensor-core 路径。完整方案必须说明量化对象、格式、缩放方式、内核支持和为稳定性保留的高精度运算。',
+    significance:
+      '标称格式不保证加速或质量不变；转换质量、校准、异常值、内核成熟度与硬件支持共同决定实际结果。',
+    benchmarkContext:
+      'InferenceX 把精度作为一级方案维度，并为代表性配置配套准确性检查。只有模型、工作负载、引擎和质量标准兼容时，FP8、FP4、NVFP4、MXFP4 与 INT4 才能公平比较。',
+  },
+  fp8: {
+    term: 'FP8',
+    aliases: ['8 位浮点'],
+    definition: 'FP8 是一组八位浮点格式，用于相对 FP16/BF16 降低模型存储、内存流量和计算成本。',
+    explanation:
+      '常见 FP8 编码在指数范围与尾数精度之间取舍。服务方案可能将 FP8 用于权重、激活、KV 缓存或部分内核，并配合缩放元数据和更高精度累加。',
+    significance:
+      'FP8 在新一代 NVIDIA 与 AMD 加速器上支持广泛，常作为稳定低精度基线；真实性能取决于端到端内核覆盖，回退操作会抹平理论收益。',
+    benchmarkContext:
+      'InferenceX 的 FP8 标签描述完整方案，而不只是检查点文件名。引擎、注意力后端、KV 缓存格式、GPU 代际和 MTP 设置都可能改变曲线。',
+  },
+  fp4: {
+    term: 'FP4',
+    aliases: ['4 位浮点'],
+    definition: 'FP4 指用于超低精度模型表示与矩阵运算加速的四位浮点格式。',
+    explanation:
+      '四位格式相对 FP8 再把权重存储与流量减半左右，但极小数值空间需要精心选择缩放和硬件专用内核；“FP4”可能指不同具体格式，而非统一编码。',
+    significance:
+      '对内存受限 LLM 推理，减少权重字节可带来巨大吞吐与容量收益；同时必须检查模型质量与不支持操作，避免精度损失或回退开销。',
+    benchmarkContext:
+      'InferenceX 尽可能标明 NVFP4、MXFP4 等具体格式，并验证代表性方案。不能把所有 FP4 曲线视为数值和运行方式完全相同。',
+  },
+  nvfp4: {
+    term: 'NVFP4',
+    aliases: ['NVIDIA FP4'],
+    definition: 'NVFP4 是 NVIDIA 为 Blackwell tensor core 推理设计的块缩放四位浮点量化格式。',
+    explanation:
+      '权重和激活使用紧凑 FP4 值，并为小块附加缩放信息。具体检查点、缩放方案和内核路径共同决定模型质量与吞吐量。',
+    significance:
+      'NVFP4 可减少权重带宽并启用 Blackwell FP4 计算路径，对大型 MoE 解码尤其有价值；只有引擎端到端支持模型注意力、路由和专家内核时才能兑现收益。',
+    benchmarkContext:
+      'InferenceX 文章在匹配交互性时比较 NVFP4 与 FP8/INT4，并明确模型、工作负载和成本假设，因为单一精度标签并不是公平基准。',
+  },
+  mxfp4: {
+    term: 'MXFP4',
+    aliases: ['微缩放 FP4', 'OCP MX FP4'],
+    definition: 'MXFP4 是一种微缩放四位浮点格式，由小块数值共享缩放因子。',
+    explanation:
+      '块级缩放让四位值在局部保有可用动态范围，同时维持紧凑存储与传输；硬件和软件必须就块布局、缩放表示与矩阵内核达成一致。',
+    significance:
+      'MXFP4 用于 AMD 及跨厂商低精度路径，实际结果取决于检查点制备与内核覆盖，而不只是标称 bit 数。',
+    benchmarkContext:
+      'InferenceX 把 MXFP4 记录为完整引擎和硬件方案的一部分。与 NVFP4 或 FP8 比较时，应匹配模型、序列长度、质量要求和交互性目标。',
+  },
+  'mixture-of-experts': {
+    term: '混合专家模型',
+    aliases: ['mixture of experts', 'MoE', '稀疏 MoE'],
+    definition: '混合专家模型包含大量前馈专家网络，但每个 token 只会被路由到其中一小部分。',
+    explanation:
+      '路由器为每个 token 计算专家分数，top-k 路由激活所选专家及共享专家。这让模型总参数可远大于每个 token 实际使用的计算量。',
+    significance:
+      'MoE 用算术稀疏性换取系统复杂度：专家权重仍占内存，路由可能不均衡，分布式部署还需要 all-to-all 完成 dispatch 与 combine。',
+    benchmarkContext:
+      'InferenceX 覆盖拥有数百专家的模型，并在相关位置同时报告总参数与激活参数。TP、EP、DP、精度和网络拓扑决定 MoE 稀疏性是否真正转化为服务优势。',
+  },
+  'multi-head-latent-attention': {
+    term: '多头潜在注意力',
+    aliases: ['multi-head latent attention', 'MLA'],
+    definition:
+      '多头潜在注意力把 attention key/value 状态压缩到更低维潜在表示，以减少 KV 缓存大小与内存流量。',
+    explanation:
+      'MLA 不为每个历史 token 存储完整的逐头 key/value，而是保存压缩状态，并通过模型专用投影重建或消费所需表示；实现需要专用注意力内核。',
+    significance:
+      '减少 KV 缓存字节可提高可用上下文长度和并发，并缓解解码带宽压力；内核形状支持与张量并行布局仍会造成巨大性能差异。',
+    benchmarkContext:
+      'InferenceX 中多个 DeepSeek 衍生模型使用 MLA。文章会追踪某注意力后端在一种 heads-per-rank 形状高效、另一种形状失败或回退的修复。',
+  },
+  'sparse-attention': {
+    term: '稀疏注意力',
+    aliases: ['sparse attention', 'DeepSeek Sparse Attention', 'DSA'],
+    definition: '稀疏注意力限制每个 query 可关注的历史 token，而不是对全部上下文执行完整注意力。',
+    explanation:
+      '稀疏模式可选择局部、压缩、索引或学习得到的上下文子集，降低长序列计算与内存移动；模型架构与运行时必须有匹配的索引器和注意力内核。',
+    significance:
+      '稀疏注意力可让超长上下文变得可行，但理论稀疏不保证快速推理；索引构建、不规则访问、内核融合和精度支持决定实际收益。',
+    benchmarkContext:
+      'InferenceX 跟踪 GLM-5 与 DeepSeek-V4 等模型专用稀疏注意力栈。支持快速变化，因此引擎版本与后端选择是结果的一部分。',
+  },
+  cuda: {
+    term: 'CUDA',
+    aliases: ['NVIDIA CUDA'],
+    definition: 'CUDA 是 NVIDIA 的 GPU 计算平台、编程模型、编译工具链与软件库生态。',
+    explanation:
+      'LLM 引擎使用 CUDA 内核和库执行矩阵乘、注意力、集体通信、图捕获、内存管理与融合操作；容器、驱动、CUDA 和 GPU 架构版本必须兼容。',
+    significance:
+      '服务性能取决于芯片之上的软件。新内核、CUDA Graph、编译器专用化和库版本都能在 GPU 不变时移动基准曲线。',
+    benchmarkContext:
+      'InferenceX 固定容器镜像，从而固定具体 CUDA 栈。历史比较可隔离仅更新引擎镜像对相同硬件与配置的影响。',
+  },
+  rocm: {
+    term: 'ROCm',
+    aliases: ['AMD ROCm'],
+    definition:
+      'ROCm 是 AMD 的开放 GPU 计算软件平台，包含运行时、编译器、通信库及优化数学和 AI 内核。',
+    explanation:
+      'vLLM 与 SGLang 通过 ROCm、AMD 专用库和内核项目在 Instinct 加速器上运行。模型支持取决于兼容的注意力、MoE、量化、集体通信与图执行路径。',
+    significance:
+      '软件成熟度可主导跨厂商推理结果。快速内核与引擎开发已在相同 MI355X 硬件上带来数倍提升，而缺失路径会让强大理论硬件无法发挥。',
+    benchmarkContext:
+      'InferenceX 保存引擎版本与运行日期，因此能测量 ROCm 随时间的改进；某个时间点的比较不能直接推广到后续软件版本。',
+  },
+  vllm: {
+    term: 'vLLM',
+    aliases: ['开源 LLM 推理引擎'],
+    definition:
+      'vLLM 是开源 LLM 推理与服务引擎，重点提供高吞吐调度、高效 KV 缓存管理和广泛模型/硬件支持。',
+    explanation:
+      '其运行时协调连续批处理、分布式 worker、注意力后端、量化内核和 OpenAI 兼容服务；生产方案也可把 vLLM worker 运行在 NVIDIA Dynamo 等编排层之下。',
+    significance:
+      'vLLM 版本与后端变化可显著改变性能。模型专用 MoE 内核、注意力 dispatch、Wide EP 通信与调度路径都会影响最终曲线。',
+    benchmarkContext:
+      'InferenceX 把 vLLM 作为一种引擎选择，并固定每个方案的具体镜像。应在模型、精度、工作负载与拓扑一致时比较，而不能把引擎名称当作固定性能等级。',
+  },
+  sglang: {
+    term: 'SGLang',
+    aliases: ['开源 LLM 服务引擎'],
+    definition: 'SGLang 是面向高性能 LLM 与多模态推理的开源服务引擎和语言模型编程系统。',
+    explanation:
+      '服务运行时包含连续批处理、前缀感知调度、分布式并行、推测解码，以及面向 NVIDIA/AMD GPU 的多种注意力和 MoE 内核后端。',
+    significance:
+      'SGLang 快速迭代的版本和模型专用内核可在硬件不变时显著改变吞吐量；低并发受调度开销影响，其他区间则由注意力、MoE 与通信内核主导。',
+    benchmarkContext:
+      'InferenceX 持续重跑固定版本的 SGLang 方案。跨版本曲线能显示改动落在性能曲线的哪个区间，而不是把发布简化成单一峰值数字。',
+  },
+  'tensorrt-llm': {
+    term: 'TensorRT-LLM',
+    aliases: ['TRT-LLM', 'TRTLLM'],
+    definition:
+      'TensorRT-LLM 是 NVIDIA 用于在 NVIDIA GPU 上编译、优化和服务大语言模型的推理软件栈。',
+    explanation:
+      '它提供 NVIDIA 优化内核、量化路径、分布式执行和模型专用优化；既可作为服务后端，也可通过集成让其他引擎使用其衍生内核。',
+    significance:
+      '紧密硬件集成可快速解锁 Blackwell 与 NVL72 功能，但模型支持和引擎兼容仍与版本相关，因此 TensorRT-LLM 标签必须对应具体容器与方案。',
+    benchmarkContext:
+      'InferenceX 同时包含直接 TensorRT-LLM、Dynamo TensorRT-LLM，以及 SGLang/vLLM 使用 TRT-LLM 衍生内核后端的配置。',
+  },
+  'nvidia-dynamo': {
+    term: 'NVIDIA Dynamo',
+    aliases: ['Dynamo', '分布式推理框架'],
+    definition:
+      'NVIDIA Dynamo 是用于编排请求路由、worker 池、KV 缓存移动和分离式服务的分布式推理框架。',
+    explanation:
+      'Dynamo 可把预填充与解码放在独立扩展的池中，并使用 vLLM 或 TensorRT-LLM 作为 worker 运行时；它管理引擎周围的数据与控制路径，而不是替代内部所有内核。',
+    significance:
+      '机架级服务不仅需要快速单 GPU 运行时。路由、缓存传输、拓扑感知与池大小决定 Wide EP 和分离式推理能否提升端到端性能。',
+    benchmarkContext:
+      'Dynamo vLLM、Dynamo TRT-LLM 标签同时标识编排层与执行引擎。InferenceX 文章还会明确预填充/解码拓扑，因为两种 Dynamo 配置可能表现完全不同。',
+  },
+};
+
+const entries = getAllGlossaryEntries().map((entry) => {
+  const translation = translations[entry.slug];
+  if (!translation) throw new Error(`Missing Chinese glossary translation: ${entry.slug}`);
+  return { ...entry, ...translation };
+});
+const entriesBySlug: Readonly<Record<string, GlossaryEntry>> = Object.fromEntries(
+  entries.map((entry) => [entry.slug, entry]),
+);
+
+export function getAllZhGlossaryEntries(): readonly GlossaryEntry[] {
+  return entries;
+}
+
+export function getZhGlossaryEntry(slug: string): GlossaryEntry | undefined {
+  return entriesBySlug[slug];
+}
+
+export function getRelatedZhGlossaryEntries(entry: GlossaryEntry): GlossaryEntry[] {
+  return entry.relatedTerms.flatMap((slug) => {
+    const related = entriesBySlug[slug];
+    return related ? [related] : [];
+  });
+}
+
+export function getAdjacentZhGlossaryEntries(slug: string): {
+  previous: GlossaryEntry | null;
+  next: GlossaryEntry | null;
+} {
+  const sorted = entries.toSorted((a, b) => a.term.localeCompare(b.term, 'zh-CN'));
+  const index = sorted.findIndex((entry) => entry.slug === slug);
+  if (index === -1) return { previous: null, next: null };
+  return {
+    previous: sorted[index - 1] ?? null,
+    next: sorted[index + 1] ?? null,
+  };
+}

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -1,4 +1,9 @@
-import { type GlossaryCategory, type GlossaryEntry, getAllGlossaryEntries } from './glossary';
+import {
+  GLOSSARY_CATEGORIES,
+  type GlossaryCategory,
+  type GlossaryEntry,
+  getAllGlossaryEntries,
+} from './glossary';
 
 export const GLOSSARY_CATEGORY_LABELS_ZH: Readonly<Record<GlossaryCategory, string>> = {
   'Benchmark metrics': '基准指标',
@@ -19,6 +24,7 @@ type GlossaryTranslation = Pick<
   | 'explanation'
   | 'significance'
   | 'benchmarkContext'
+  | 'measurement'
 >;
 
 const translations: Readonly<Record<string, GlossaryTranslation>> = {
@@ -59,6 +65,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '最大吞吐量不是完整的性能结论。某个点即使拥有最高 tok/s，也可能因为交互性过低而不适合实时产品；有效比较应在符合业务需求的延迟或交互性目标下进行。',
     benchmarkContext:
       'InferenceX 将吞吐量与交互性放在完整并发扫描中共同展示，并用 Pareto 前沿剔除两个轴上都更差的运行点。',
+    measurement: { label: '常用单位', value: 'token/秒/GPU（tok/s/GPU）' },
   },
   interactivity: {
     term: '交互性',
@@ -71,6 +78,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '不同产品需要不同运行点。语音和交互式编程要求较高 token 速率，离线摘要则可以牺牲交互性换取更高总吞吐量；在交互性不一致时比较硬件很容易得出误导性结论。',
     benchmarkContext:
       'InferenceX 将 tok/s/user 与吞吐量或成本一起绘制，并在等交互性表格中沿各自 Pareto 前沿插值，以固定用户体验。',
+    measurement: { label: '常用单位', value: 'token/秒/用户（tok/s/user）' },
   },
   latency: {
     term: '延迟',
@@ -96,6 +104,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '用户会把 TTFT 感知为系统开始回答的速度。即使后续 token 流很快，只要排队或预填充等待过长，整体体验仍会显得迟缓。',
     benchmarkContext:
       '应将 TTFT 与输入序列长度、并发量以及是否采用预填充/解码分离一起阅读，这些因素解释了为何解码速度相近的方案仍可能有不同启动时间。',
+    measurement: { label: '常用单位', value: '毫秒或秒' },
   },
   'time-per-output-token': {
     term: '每输出 token 时间',
@@ -108,6 +117,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       'TPOT 单独刻画回答流是否顺畅。随着更多请求共享系统，TPOT 通常会变差，即便总吞吐量仍在上升。',
     benchmarkContext:
       'InferenceX 多使用其倒数 tok/s/user，便于让更高数值代表更好性能；在比较相同并发下的调度器或内核变化时，方案表也会直接列出 TPOT。',
+    measurement: { label: '换算关系', value: '交互性 ≈ 1000 / TPOT（毫秒）' },
   },
   concurrency: {
     term: '并发量',
@@ -184,11 +194,15 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '该指标把系统性能转化为服务经济性，但仍受工作负载、交互性、利用率、缓存命中和成本假设影响；离线低交互点不能直接与实时端点比较。',
     benchmarkContext:
       '成本曲线使用与吞吐曲线相同的并发扫描。在等交互性下，更低的 $/M 表示以更少建模成本提供相同流式体验。',
+    measurement: {
+      label: 'InferenceX 计算式',
+      value: '$/M = TCO（$/GPU 小时）× 1,000,000 /（3600 × tok/s/GPU）',
+    },
   },
   'performance-per-dollar': {
     term: '每美元性能',
     aliases: ['performance per dollar', 'perf/$', '成本效率'],
-    plainEnglish: '每美元性能回答一个简单问题：花在运行系统上的每一美元，能换来多少有效 AI 输出？',
+    plainEnglish: '每美元性能表示每投入一美元运行系统，能够获得多少有效 AI 输出。',
     definition: '每美元性能表示系统每单位建模成本能够交付多少实测推理工作。',
     explanation:
       '在固定工作负载和交互性目标下，它是每 token 成本的倒数。2 倍 perf/$ 意味着在相同基础设施支出下，可生成约两倍可比 token。',
@@ -220,6 +234,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '电力供应往往是新增 AI 部署的硬约束。每兆瓦生成更多 token 的系统，即使单个加速器功耗更高，也能在相同电力配额下服务更多需求。',
     benchmarkContext:
       '比较 tokens/MW 时必须匹配模型、工作负载、精度与交互性，否则高吞吐低交互点可能看似高效，却无法满足目标用户体验。',
+    measurement: { label: '常用单位', value: '每单位配置市电兆瓦的 token/秒' },
   },
   prefill: {
     term: '预填充',
@@ -651,11 +666,17 @@ export function getRelatedZhGlossaryEntries(entry: GlossaryEntry): GlossaryEntry
   });
 }
 
+export function compareZhGlossaryEntries(a: GlossaryEntry, b: GlossaryEntry): number {
+  const categoryOrder =
+    GLOSSARY_CATEGORIES.indexOf(a.category) - GLOSSARY_CATEGORIES.indexOf(b.category);
+  return categoryOrder || a.term.localeCompare(b.term, 'zh-CN');
+}
+
 export function getAdjacentZhGlossaryEntries(slug: string): {
   previous: GlossaryEntry | null;
   next: GlossaryEntry | null;
 } {
-  const sorted = entries.toSorted((a, b) => a.term.localeCompare(b.term, 'zh-CN'));
+  const sorted = entries.toSorted(compareZhGlossaryEntries);
   const index = sorted.findIndex((entry) => entry.slug === slug);
   if (index === -1) return { previous: null, next: null };
   return {

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -12,13 +12,20 @@ export const GLOSSARY_CATEGORY_LABELS_ZH: Readonly<Record<GlossaryCategory, stri
 
 type GlossaryTranslation = Pick<
   GlossaryEntry,
-  'term' | 'aliases' | 'definition' | 'explanation' | 'significance' | 'benchmarkContext'
+  | 'term'
+  | 'aliases'
+  | 'plainEnglish'
+  | 'definition'
+  | 'explanation'
+  | 'significance'
+  | 'benchmarkContext'
 >;
 
 const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'ai-inference': {
     term: 'AI 推理',
     aliases: ['AI inference', 'LLM 推理', '模型服务'],
+    plainEnglish: '把提示词、图片或音频交给已经训练好的模型，它会利用学到的知识给出答案。',
     definition:
       'AI 推理是使用已经训练好的模型处理新输入并生成输出的过程；对大语言模型而言，通常就是处理提示词并生成 token。',
     explanation:
@@ -31,6 +38,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'inference-engine': {
     term: '推理引擎',
     aliases: ['inference engine', '服务引擎', 'LLM 服务框架'],
+    plainEnglish:
+      '推理引擎就像 AI 服务背后的交通调度员：它安排请求流转，并让 GPU 在正确时间执行正确任务。',
     definition: '推理引擎是将模型权重和用户请求转化为加速器上生成结果的软件运行时。',
     explanation:
       '它负责请求调度、连续批处理、KV 缓存分配、分布式执行、内核选择与 token 采样。vLLM、SGLang 和 TensorRT-LLM 即使运行同一模型和 GPU，也会因调度器、内核与分布式策略不同而产生不同曲线。',
@@ -42,6 +51,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   throughput: {
     term: '吞吐量',
     aliases: ['throughput', 'token 吞吐量', '总吞吐量'],
+    plainEnglish: '吞吐量就是整个系统每秒一共能完成多少工作。',
     definition: '吞吐量是推理系统在所有活跃请求上生成 token 的总速率。',
     explanation:
       'InferenceX 通常使用每 GPU 每秒 token 数进行归一化，便于比较不同规模的系统。提高批大小或并发往往能摊薄权重读取和计算成本，从而提高总吞吐量，但单个用户收到 token 的速度可能下降。',
@@ -53,6 +63,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   interactivity: {
     term: '交互性',
     aliases: ['interactivity', '生成速度', '每用户 token 速率'],
+    plainEnglish: '交互性表示模型开始回答后，单个用户看到新文字出现得有多快。',
     definition: '交互性是解码阶段单个用户接收生成 token 的速率。',
     explanation:
       '在单位换算一致时，它是每输出 token 时间的倒数。50 tok/s/user 表示首个 token 之后大约每 20 毫秒输出一个新 token；它描述流式响应速度，而不是首 token 到达前的等待。',
@@ -64,6 +75,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   latency: {
     term: '延迟',
     aliases: ['latency', '响应延迟', '推理延迟'],
+    plainEnglish: '延迟就是需要等待多久；流式回答既有开始前的等待，也有后续文字之间的停顿。',
     definition:
       '延迟是请求经历的时间；在流式 LLM 服务中，应区分首 token 等待时间与后续 token 间隔。',
     explanation:
@@ -76,6 +88,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'time-to-first-token': {
     term: '首 token 时间',
     aliases: ['time to first token', '首字延迟'],
+    plainEnglish: 'TTFT 就是发送提示词后，到看到答案第一个片段前的“思考中……”时间。',
     definition: '首 token 时间（TTFT）是从提交请求到收到第一个生成 token 的时间。',
     explanation:
       'TTFT 包含排队、提示词处理，以及解码开始前的路由或 KV 缓存传输。更长提示词通常增加预填充工作，系统过载也会在模型计算不变时增加排队时间。',
@@ -87,6 +100,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'time-per-output-token': {
     term: '每输出 token 时间',
     aliases: ['time per output token', 'token 间延迟', 'ITL'],
+    plainEnglish: 'TPOT 是流式回答每个新片段之间的间隔；间隔越短，回答看起来越快越顺畅。',
     definition: '每输出 token 时间（TPOT）是首 token 到达后，相邻生成 token 之间的平均时间。',
     explanation:
       'TPOT 描述流式响应的解码节奏。在忽略单位换算时，它是每用户 token 速率的倒数；20 毫秒/token 约等于 50 tok/s/user。',
@@ -98,6 +112,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   concurrency: {
     term: '并发量',
     aliases: ['concurrency', '并发请求数'],
+    plainEnglish: '并发量就是系统同一时间正在服务多少个人或请求。',
     definition: '并发量是基准测试或部署中同时被服务的请求数量。',
     explanation:
       '提高并发能为调度器提供更多可批处理工作，通常提升加速器利用率和总吞吐量；代价是每个请求分到的计算与内存带宽减少，因此交互性往往下降。',
@@ -109,6 +124,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   batching: {
     term: '批处理',
     aliases: ['batching', '连续批处理', '动态批处理'],
+    plainEnglish:
+      '批处理就像让多名乘客坐同一辆巴士：GPU 一次处理多个请求，让每趟计算完成更多有效工作。',
     definition: '批处理将多个请求的工作组合起来，使加速器能够一起处理它们的 token。',
     explanation:
       '大型矩阵运算比大量微小运算更能发挥 GPU 效率。现代推理引擎采用连续批处理，请求到达和结束时动态加入或退出，而不是等待固定批次全部完成。',
@@ -120,6 +137,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'pareto-frontier': {
     term: 'Pareto 前沿',
     aliases: ['Pareto frontier', '性能前沿', 'Pareto 最优曲线'],
+    plainEnglish:
+      'Pareto 前沿是一条“最佳权衡线”：线上的每个点都值得考虑，因为改善一项指标就必须牺牲另一项。',
     definition: 'Pareto 前沿由不存在另一个测量点能在两个比较维度上都更好的运行点组成。',
     explanation:
       '在吞吐量与交互性图中，如果另一个点既能处理更多总 token，又能让每个用户更快收到 token，那么原点就被支配；删除所有被支配点后得到有效边界。',
@@ -131,6 +150,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'iso-interactivity': {
     term: '等交互性',
     aliases: ['iso-interactivity', '匹配交互性', '相同 token 速率'],
+    plainEnglish: '等交互性就是让不同系统以相同速度向用户显示文字，再比较背后的硬件效率。',
     definition: '等交互性是指在相同的每用户生成速度下比较不同系统。',
     explanation:
       '不同方案的并发点很少正好落在相同 tok/s/user。等交互性比较会在各自 Pareto 前沿上对共同目标插值，再比较该点的吞吐量、成本或效率。',
@@ -142,6 +162,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'input-output-sequence-length': {
     term: '输入与输出序列长度',
     aliases: ['input/output sequence length', '提示词长度', '生成长度', '8K/1K'],
+    plainEnglish:
+      '输入长度是模型要读多少内容，输出长度是模型要写多少内容；8K/1K 表示长提示词配较短回答。',
     definition:
       '输入序列长度（ISL）是提示词 token 数，输出序列长度（OSL）是响应中生成的 token 数。',
     explanation:
@@ -154,6 +176,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'cost-per-million-tokens': {
     term: '每百万 token 成本',
     aliases: ['cost per million tokens', '$/M tokens', 'token 成本'],
+    plainEnglish: '它估算 AI 读取和生成一百万个 token 需要支付多少基础设施成本。',
     definition: '每百万 token 成本估算系统在某个实测运行点生成一百万 token 所需的基础设施成本。',
     explanation:
       'InferenceX 根据每小时总体拥有成本和实测 token 吞吐量计算该指标。它可能按总 token 报告，也可能区分输入和输出 token，因此比较前必须确认分母。',
@@ -165,6 +188,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'performance-per-dollar': {
     term: '每美元性能',
     aliases: ['performance per dollar', 'perf/$', '成本效率'],
+    plainEnglish: '每美元性能回答一个简单问题：花在运行系统上的每一美元，能换来多少有效 AI 输出？',
     definition: '每美元性能表示系统每单位建模成本能够交付多少实测推理工作。',
     explanation:
       '在固定工作负载和交互性目标下，它是每 token 成本的倒数。2 倍 perf/$ 意味着在相同基础设施支出下，可生成约两倍可比 token。',
@@ -176,6 +200,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'total-cost-of-ownership': {
     term: '总体拥有成本',
     aliases: ['total cost of ownership', '全生命周期成本'],
+    plainEnglish: 'TCO 是拥有和运行硬件的真实全口径成本，而不只是 GPU 发票上的价格。',
     definition: '总体拥有成本（TCO）是基础设施在使用寿命内采购、部署和运营的综合成本估算。',
     explanation:
       'GPU 采购价只是其中一项。TCO 模型还可包含主机、网络、供电、制冷、机房、融资、折旧、维护和预期利用率，并归一化为每 GPU 小时成本。',
@@ -187,6 +212,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'tokens-per-megawatt': {
     term: '每兆瓦 token 吞吐量',
     aliases: ['tokens per megawatt', 'tokens/MW', '功率归一化吞吐量'],
+    plainEnglish: '该指标衡量数据中心在固定电力额度下能产出多少 AI token。',
     definition: '每兆瓦 token 吞吐量衡量推理产出相对于数据中心电力预算的效率。',
     explanation:
       'InferenceX 使用全口径公用事业供电，而不只使用芯片 TDP。这个分母可包含为 IT 负载供电和制冷的开销，更适合设施级容量规划。',
@@ -198,6 +224,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   prefill: {
     term: '预填充',
     aliases: ['prefill', '提示词处理', '上下文编码'],
+    plainEnglish: '预填充就是模型先阅读并理解提示词，然后才开始写答案。',
     definition: '预填充是推理的第一阶段：模型处理输入提示词并填充 KV 缓存，然后才开始生成。',
     explanation:
       '提示词 token 可以并行处理，形成大型矩阵运算，因此通常偏计算密集。预填充成本随输入长度增长，并显著影响首 token 时间。',
@@ -209,6 +236,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   decode: {
     term: '解码',
     aliases: ['decode', '自回归生成', 'token 生成'],
+    plainEnglish: '解码就是模型读完提示词后，一个 token 接一个 token 地写出答案。',
     definition: '解码是自回归生成输出 token 的阶段，通常每个模型步为每条序列接受一个 token。',
     explanation:
       '每个新 token 都依赖此前 token，因此时间维度无法完全并行。模型会反复读取权重与该序列的 KV 缓存，使解码对内存带宽、批处理和通信尤其敏感。',
@@ -220,6 +248,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'kv-cache': {
     term: 'KV 缓存',
     aliases: ['KV cache', '键值缓存', '注意力缓存'],
+    plainEnglish: 'KV 缓存是模型对当前对话的工作记忆，让它生成新 token 时不必每次从头重读。',
     definition:
       'KV 缓存保存已经处理过的 token 的注意力 key/value 状态，避免每个解码步重新计算它们。',
     explanation:
@@ -232,6 +261,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'prefix-caching': {
     term: '前缀缓存',
     aliases: ['prefix caching', '提示词缓存', '自动前缀缓存'],
+    plainEnglish:
+      '前缀缓存会记住重复开头的处理结果，例如相同系统提示词，让模型下次可以跳过这部分工作。',
     definition: '当前多个请求以相同 token 序列开头时，前缀缓存会复用已有 KV 缓存状态。',
     explanation:
       '重复系统提示词、共享文档或共同对话前缀在缓存仍可用时无需再次预填充。命中缓存可显著减少提示词计算与首 token 时间。',
@@ -243,6 +274,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'disaggregated-inference': {
     term: '分离式推理',
     aliases: ['disaggregated inference', 'PD 分离', '分离式预填充', 'disagg'],
+    plainEnglish: '分离式推理把“读提示词”和“写答案”交给两组 GPU，让每组都能针对自己的任务优化。',
     definition: '分离式推理在不同工作池上运行预填充与解码，并在两者之间传输请求状态。',
     explanation:
       '预填充通常偏计算密集，解码则常受内存带宽和通信限制。分离后，两侧可以采用不同 GPU 数、并行度、批策略和扩缩容方式。',
@@ -254,6 +286,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'speculative-decoding': {
     term: '推测解码',
     aliases: ['speculative decoding', '草稿—验证解码'],
+    plainEnglish:
+      '推测解码让一个便宜的助手先起草多个 token，再由完整模型一次性审核，而不是逐个生成。',
     definition:
       '推测解码先以低成本提出多个未来 token，再由目标模型批量验证，从而减少昂贵的串行解码步数。',
     explanation:
@@ -266,6 +300,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'multi-token-prediction': {
     term: '多 token 预测',
     aliases: ['multi-token prediction', '多 token 预测头'],
+    plainEnglish: 'MTP 让模型一次猜测多个后续 token 并一起验证，从而减少缓慢的逐 token 步骤。',
     definition:
       '多 token 预测（MTP）使用与主模型共同训练的辅助预测头，提出多个未来 token 供推测验证。',
     explanation:
@@ -278,6 +313,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   eagle: {
     term: 'EAGLE',
     aliases: ['EAGLE 推测解码', 'EAGLE-3'],
+    plainEnglish: 'EAGLE 是一种为主模型起草多个可能后续 token 的方法，可让答案流式输出得更快。',
     definition:
       'EAGLE 是一组推测解码方法：利用与目标语言模型相关的特征预测草稿序列，再由目标模型验证。',
     explanation:
@@ -290,6 +326,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'tensor-parallelism': {
     term: '张量并行',
     aliases: ['tensor parallelism', 'TP'],
+    plainEnglish: '张量并行把一次大型计算拆给多张 GPU，让它们共同完成。',
     definition: '张量并行（TP）把单个张量运算和模型权重矩阵切分到多个加速器上。',
     explanation:
       '每一层由多个 rank 协同执行，部分结果需要通过集体通信合并，常见方式是在并行矩阵乘之后执行 all-reduce。',
@@ -301,6 +338,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'expert-parallelism': {
     term: '专家并行',
     aliases: ['expert parallelism', 'EP'],
+    plainEnglish: '专家并行把模型中的不同“专家”分配给不同 GPU，再把每个 token 送到需要的专家。',
     definition:
       '专家并行（EP）把 MoE 模型的专家分布到不同加速器，并将 token 路由到持有所选专家的 rank。',
     explanation:
@@ -313,6 +351,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'data-parallelism': {
     term: '数据并行',
     aliases: ['data parallelism', 'DP'],
+    plainEnglish: '数据并行复制多份相同模型并分摊请求，就像多开几条相同的收银通道。',
     definition:
       '数据并行（DP）在多个 rank 上运行复制的模型或层组，并把请求或 token 分配给这些副本。',
     explanation:
@@ -325,6 +364,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'wide-expert-parallelism': {
     term: '宽专家并行',
     aliases: ['wide expert parallelism', 'Wide EP'],
+    plainEnglish: '宽专家并行把模型专家铺到大量 GPU 上，让每张 GPU 需要保存和移动的专家数据更少。',
     definition: '宽专家并行使用大量加速器 rank 构成 MoE 模型的专家并行组。',
     explanation:
       '把数百个专家分散到更多 rank，可减少每张 GPU 需要存储和流式读取的专家权重；更大的同伴组也可形成更高效的专家批次，但 dispatch/combine 流量会扩展。',
@@ -336,6 +376,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'all-reduce': {
     term: 'All-reduce',
     aliases: ['全归约'],
+    plainEnglish: 'All-reduce 让每张 GPU 完成一部分计算，再合并结果并把完整答案发回所有 GPU。',
     definition:
       'All-reduce 是一种集体通信操作：合并所有参与 rank 的值，并把归约结果返回给每个 rank。',
     explanation:
@@ -348,6 +389,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'all-to-all': {
     term: 'All-to-all',
     aliases: ['全交换'],
+    plainEnglish: 'All-to-all 是一次有组织的交换：每张 GPU 都向其他每张 GPU 发送不同的数据包。',
     definition: 'All-to-all 是每个参与 rank 向所有其他 rank 发送不同数据的集体通信模式。',
     explanation:
       '专家并行 MoE 层先用 all-to-all dispatch 把 token 发往所选专家，再用 combine 把专家输出送回；流量与不均衡程度取决于 token 路由。',
@@ -359,6 +401,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'scale-up-vs-scale-out': {
     term: 'Scale-up 与 scale-out 网络',
     aliases: ['纵向扩展域', '横向扩展网络'],
+    plainEnglish: 'Scale-up 是同一套 GPU 系统内部的超高速网络，scale-out 则连接不同服务器或机架。',
     definition:
       'Scale-up 网络连接同一紧耦合系统内的加速器，scale-out 网络则把多个系统或机架连接成更大集群。',
     explanation:
@@ -371,6 +414,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'high-bandwidth-memory': {
     term: '高带宽内存',
     aliases: ['high-bandwidth memory', 'HBM'],
+    plainEnglish: 'HBM 是紧挨 GPU 的一小池超高速内存，推理时模型权重和工作数据都要放在这里。',
     definition: '高带宽内存（HBM）是靠近加速器堆叠的内存，其带宽远高于传统服务器内存。',
     explanation:
       'HBM 存储模型权重、激活、工作区与 KV 缓存。容量决定哪些模型、批大小和并行布局能放入；带宽决定内存受限内核能多快读取这些状态。',
@@ -382,6 +426,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'memory-bandwidth': {
     term: '内存带宽',
     aliases: ['memory bandwidth', 'HBM 带宽'],
+    plainEnglish: '内存带宽就像向 GPU 计算单元供给数据的管道宽度；管道越宽，计算单元越不容易空等。',
     definition: '内存带宽是数据在加速器内存与计算单元之间传输的速率。',
     explanation:
       '当移动所需字节比执行算术更耗时，内核就是内存带宽受限。LLM 解码经常处于该状态，因为每一步都要为较少的新 token 计算流式读取模型/专家权重和 KV 缓存。',
@@ -393,6 +438,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   nvlink: {
     term: 'NVLink',
     aliases: ['NVIDIA NVLink', 'GPU 高速互连'],
+    plainEnglish: 'NVLink 是 NVIDIA GPU 之间的高速公路，让多张 GPU 的协作远快于普通服务器网络。',
     definition: 'NVLink 是 NVIDIA 用于 scale-up 域内 GPU 直接数据传输的高带宽加速器互连。',
     explanation:
       'NVSwitch 系统连接多个 NVLink 端点，使集体通信可覆盖八卡服务器，或在 NVL72 产品中覆盖 72 GPU 机架级域；该带宽不同于连接独立系统的 InfiniBand/Ethernet。',
@@ -404,6 +450,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   quantization: {
     term: '量化',
     aliases: ['quantization', '低精度推理', '权重量化'],
+    plainEnglish:
+      '量化用更少 bit 保存模型数字，让模型更小、更容易搬运，通常会带来经过控制的精度损失。',
     definition: '量化使用比高精度基线更少的 bit 表示模型权重、激活或缓存值。',
     explanation:
       '更低精度减少内存占用与传输字节，并可使用更快的低精度 tensor-core 路径。完整方案必须说明量化对象、格式、缩放方式、内核支持和为稳定性保留的高精度运算。',
@@ -415,6 +463,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   fp8: {
     term: 'FP8',
     aliases: ['8 位浮点'],
+    plainEnglish: 'FP8 用紧凑的 8 位格式保存和计算模型数字，可减少内存占用并经常加快推理。',
     definition: 'FP8 是一组八位浮点格式，用于相对 FP16/BF16 降低模型存储、内存流量和计算成本。',
     explanation:
       '常见 FP8 编码在指数范围与尾数精度之间取舍。服务方案可能将 FP8 用于权重、激活、KV 缓存或部分内核，并配合缩放元数据和更高精度累加。',
@@ -426,6 +475,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   fp4: {
     term: 'FP4',
     aliases: ['4 位浮点'],
+    plainEnglish: 'FP4 只用 4 bit 表示模型数字，能让推理更小更快，但可保留的数值细节也更少。',
     definition: 'FP4 指用于超低精度模型表示与矩阵运算加速的四位浮点格式。',
     explanation:
       '四位格式相对 FP8 再把权重存储与流量减半左右，但极小数值空间需要精心选择缩放和硬件专用内核；“FP4”可能指不同具体格式，而非统一编码。',
@@ -437,6 +487,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   nvfp4: {
     term: 'NVFP4',
     aliases: ['NVIDIA FP4'],
+    plainEnglish:
+      'NVFP4 是针对 NVIDIA Blackwell 优化的 4 位模型数学格式，目标是少搬数据并利用最快的低精度硬件。',
     definition: 'NVFP4 是 NVIDIA 为 Blackwell tensor core 推理设计的块缩放四位浮点量化格式。',
     explanation:
       '权重和激活使用紧凑 FP4 值，并为小块附加缩放信息。具体检查点、缩放方案和内核路径共同决定模型质量与吞吐量。',
@@ -448,6 +500,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   mxfp4: {
     term: 'MXFP4',
     aliases: ['微缩放 FP4', 'OCP MX FP4'],
+    plainEnglish: 'MXFP4 让每小组 4 位数字拥有自己的缩放值，使极紧凑的数字仍保留足够可用范围。',
     definition: 'MXFP4 是一种微缩放四位浮点格式，由小块数值共享缩放因子。',
     explanation:
       '块级缩放让四位值在局部保有可用动态范围，同时维持紧凑存储与传输；硬件和软件必须就块布局、缩放表示与矩阵内核达成一致。',
@@ -459,6 +512,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'mixture-of-experts': {
     term: '混合专家模型',
     aliases: ['mixture of experts', 'MoE', '稀疏 MoE'],
+    plainEnglish:
+      '混合专家模型像一支大型专家团队：每个 token 只调用最合适的少数专家，而不是每次动用全员。',
     definition: '混合专家模型包含大量前馈专家网络，但每个 token 只会被路由到其中一小部分。',
     explanation:
       '路由器为每个 token 计算专家分数，top-k 路由激活所选专家及共享专家。这让模型总参数可远大于每个 token 实际使用的计算量。',
@@ -470,6 +525,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'multi-head-latent-attention': {
     term: '多头潜在注意力',
     aliases: ['multi-head latent attention', 'MLA'],
+    plainEnglish: 'MLA 会压缩模型对历史 token 的“笔记”，让长对话占用更少内存、继续生成的成本更低。',
     definition:
       '多头潜在注意力把 attention key/value 状态压缩到更低维潜在表示，以减少 KV 缓存大小与内存流量。',
     explanation:
@@ -482,6 +538,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'sparse-attention': {
     term: '稀疏注意力',
     aliases: ['sparse attention', 'DeepSeek Sparse Attention', 'DSA'],
+    plainEnglish: '稀疏注意力只回看长上下文中最有用的部分，而不是重新检查每个历史 token。',
     definition: '稀疏注意力限制每个 query 可关注的历史 token，而不是对全部上下文执行完整注意力。',
     explanation:
       '稀疏模式可选择局部、压缩、索引或学习得到的上下文子集，降低长序列计算与内存移动；模型架构与运行时必须有匹配的索引器和注意力内核。',
@@ -493,6 +550,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   cuda: {
     term: 'CUDA',
     aliases: ['NVIDIA CUDA'],
+    plainEnglish: 'CUDA 是让程序在 NVIDIA GPU 上运行的软件工具箱。',
     definition: 'CUDA 是 NVIDIA 的 GPU 计算平台、编程模型、编译工具链与软件库生态。',
     explanation:
       'LLM 引擎使用 CUDA 内核和库执行矩阵乘、注意力、集体通信、图捕获、内存管理与融合操作；容器、驱动、CUDA 和 GPU 架构版本必须兼容。',
@@ -504,6 +562,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   rocm: {
     term: 'ROCm',
     aliases: ['AMD ROCm'],
+    plainEnglish: 'ROCm 是让 AI 和高性能程序在 AMD GPU 上运行的软件工具箱。',
     definition:
       'ROCm 是 AMD 的开放 GPU 计算软件平台，包含运行时、编译器、通信库及优化数学和 AI 内核。',
     explanation:
@@ -516,6 +575,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   vllm: {
     term: 'vLLM',
     aliases: ['开源 LLM 推理引擎'],
+    plainEnglish: 'vLLM 是开源软件，通过组织请求和 GPU 内存，让语言模型高效服务大量用户。',
     definition:
       'vLLM 是开源 LLM 推理与服务引擎，重点提供高吞吐调度、高效 KV 缓存管理和广泛模型/硬件支持。',
     explanation:
@@ -528,6 +588,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   sglang: {
     term: 'SGLang',
     aliases: ['开源 LLM 服务引擎'],
+    plainEnglish:
+      'SGLang 是用于快速服务语言模型的开源软件，提供面向复杂 AI 工作负载的调度和优化功能。',
     definition: 'SGLang 是面向高性能 LLM 与多模态推理的开源服务引擎和语言模型编程系统。',
     explanation:
       '服务运行时包含连续批处理、前缀感知调度、分布式并行、推测解码，以及面向 NVIDIA/AMD GPU 的多种注意力和 MoE 内核后端。',
@@ -539,6 +601,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'tensorrt-llm': {
     term: 'TensorRT-LLM',
     aliases: ['TRT-LLM', 'TRTLLM'],
+    plainEnglish: 'TensorRT-LLM 是 NVIDIA 为自家 GPU 优化的 LLM 推理软件栈。',
     definition:
       'TensorRT-LLM 是 NVIDIA 用于在 NVIDIA GPU 上编译、优化和服务大语言模型的推理软件栈。',
     explanation:
@@ -551,6 +614,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'nvidia-dynamo': {
     term: 'NVIDIA Dynamo',
     aliases: ['Dynamo', '分布式推理框架'],
+    plainEnglish:
+      'NVIDIA Dynamo 协调大量 GPU worker，负责路由请求、移动模型记忆，并把读提示词和写答案分配给合适的资源池。',
     definition:
       'NVIDIA Dynamo 是用于编排请求路由、worker 池、KV 缓存移动和分离式服务的分布式推理框架。',
     explanation:

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -33,7 +33,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '推理既是模型问题，也是系统问题。用户体验取决于延迟和交互性，运营成本则取决于吞吐量、利用率、功耗与硬件成本；只优化其中一个维度，往往会牺牲另一个维度。',
     benchmarkContext:
-      'InferenceX 测试完整的推理方案，而不是只引用芯片峰值规格。每条曲线都对应明确的模型、引擎、精度、并行策略、GPU 系统、序列长度和并发扫描。',
+      'InferenceX 测试完整的推理方案，因为芯片峰值规格无法代表实际服务性能。每条曲线都对应明确的模型、引擎、精度、并行策略、GPU 系统、序列长度和并发扫描。',
   },
   'inference-engine': {
     term: '推理引擎',
@@ -66,7 +66,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     plainEnglish: '交互性表示模型开始回答后，单个用户看到新文字出现得有多快。',
     definition: '交互性是解码阶段单个用户接收生成 token 的速率。',
     explanation:
-      '在单位换算一致时，它是每输出 token 时间的倒数。50 tok/s/user 表示首个 token 之后大约每 20 毫秒输出一个新 token；它描述流式响应速度，而不是首 token 到达前的等待。',
+      '在单位换算一致时，它是每输出 token 时间的倒数。50 tok/s/user 表示首个 token 之后大约每 20 毫秒输出一个新 token；它描述流式响应速度，不包含首 token 到达前的等待。',
     significance:
       '不同产品需要不同运行点。语音和交互式编程要求较高 token 速率，离线摘要则可以牺牲交互性换取更高总吞吐量；在交互性不一致时比较硬件很容易得出误导性结论。',
     benchmarkContext:
@@ -119,7 +119,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '单个并发值只代表一个运行点。生产流量持续变化，在低并发领先的方案，可能在大批次或通信占主导时被其他方案超越。',
     benchmarkContext:
-      'InferenceX 扫描多个并发值以构建吞吐量—交互性曲线，曲线标签会标出每个点的请求数，并显示方案何时饱和或性能坍塌。',
+      'InferenceX 扫描多个并发值以构建吞吐量与交互性曲线，曲线标签会标出每个点的请求数，并显示方案何时饱和或性能坍塌。',
   },
   batching: {
     term: '批处理',
@@ -128,7 +128,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '批处理就像让多名乘客坐同一辆巴士：GPU 一次处理多个请求，让每趟计算完成更多有效工作。',
     definition: '批处理将多个请求的工作组合起来，使加速器能够一起处理它们的 token。',
     explanation:
-      '大型矩阵运算比大量微小运算更能发挥 GPU 效率。现代推理引擎采用连续批处理，请求到达和结束时动态加入或退出，而不是等待固定批次全部完成。',
+      '大型矩阵运算比大量微小运算更能发挥 GPU 效率。现代推理引擎采用连续批处理，请求到达和结束时动态加入或退出，无需等待固定批次全部完成。',
     significance:
       '批处理是吞吐量与延迟核心权衡的来源。更大的有效批次能摊薄权重读取和内核启动开销，但通常会增加每位用户的 token 间隔。',
     benchmarkContext:
@@ -145,7 +145,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '前沿能避免噪声点或调优较差的点扭曲比较，并展示真正的权衡。沿曲线仍不存在普适赢家，最佳点取决于用户最低交互性或最高成本目标。',
     benchmarkContext:
-      'InferenceX 连接并发与配置扫描中的 Pareto 最优点，等交互性比较也沿这些前沿插值，而不是随意选择原始点。',
+      'InferenceX 连接并发与配置扫描中的 Pareto 最优点，等交互性比较也沿这些前沿插值，避免用随意选择的原始点直接比较。',
   },
   'iso-interactivity': {
     term: '等交互性',
@@ -200,7 +200,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'total-cost-of-ownership': {
     term: '总体拥有成本',
     aliases: ['total cost of ownership', '全生命周期成本'],
-    plainEnglish: 'TCO 是拥有和运行硬件的真实全口径成本，而不只是 GPU 发票上的价格。',
+    plainEnglish: 'TCO 包含硬件采购，以及后续供电、制冷、网络和运维成本。',
     definition: '总体拥有成本（TCO）是基础设施在使用寿命内采购、部署和运营的综合成本估算。',
     explanation:
       'GPU 采购价只是其中一项。TCO 模型还可包含主机、网络、供电、制冷、机房、融资、折旧、维护和预期利用率，并归一化为每 GPU 小时成本。',
@@ -269,7 +269,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '具有重复前缀的生产工作负载可能明显快于随机 token 基准；收益取决于命中率、缓存容量、淘汰策略与请求能否路由到持有所需状态的节点。',
     benchmarkContext:
-      'InferenceX 通常在随机数据集上禁用前缀缓存，因为偶然复用会测量缓存策略而不是完整提示词处理；除非明确说明，应把结果视为无命中基线。',
+      'InferenceX 通常在随机数据集上禁用前缀缓存，避免把缓存策略混入完整提示词处理的测量。除非明确说明，应把结果视为无命中基线。',
   },
   'disaggregated-inference': {
     term: '分离式推理',
@@ -285,9 +285,9 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   },
   'speculative-decoding': {
     term: '推测解码',
-    aliases: ['speculative decoding', '草稿—验证解码'],
+    aliases: ['speculative decoding', '草稿与验证解码'],
     plainEnglish:
-      '推测解码让一个便宜的助手先起草多个 token，再由完整模型一次性审核，而不是逐个生成。',
+      '推测解码让一个便宜的助手先起草多个 token，再由完整模型一次性审核，省去部分逐个生成步骤。',
     definition:
       '推测解码先以低成本提出多个未来 token，再由目标模型批量验证，从而减少昂贵的串行解码步数。',
     explanation:
@@ -419,7 +419,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     explanation:
       'HBM 存储模型权重、激活、工作区与 KV 缓存。容量决定哪些模型、批大小和并行布局能放入；带宽决定内存受限内核能多快读取这些状态。',
     significance:
-      'LLM 解码中，每个 token 往往读取的数据远多于计算量，因此 HBM 带宽是主要性能上限；额外容量也可能在峰值算力相近时解锁更高效的方案。',
+      'LLM 解码中，每个 token 往往读取的数据远多于计算量，因此 HBM 带宽是主要性能上限；额外容量即使在峰值算力相近时也能支持更高效的方案。',
     benchmarkContext:
       'InferenceX 硬件比较会区分 HBM 容量与带宽。例如 GB300 的更大容量可容纳 GB200 无法放入的更宽预填充/解码布局。',
   },
@@ -470,7 +470,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       'FP8 在新一代 NVIDIA 与 AMD 加速器上支持广泛，常作为稳定低精度基线；真实性能取决于端到端内核覆盖，回退操作会抹平理论收益。',
     benchmarkContext:
-      'InferenceX 的 FP8 标签描述完整方案，而不只是检查点文件名。引擎、注意力后端、KV 缓存格式、GPU 代际和 MTP 设置都可能改变曲线。',
+      'InferenceX 的 FP8 标签覆盖完整方案，检查点文件名只是其中一项。引擎、注意力后端、KV 缓存格式、GPU 代际和 MTP 设置都可能改变曲线。',
   },
   fp4: {
     term: 'FP4',
@@ -505,7 +505,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     explanation:
       '块级缩放让四位值在局部保有可用动态范围，同时维持紧凑存储与传输；硬件和软件必须就块布局、缩放表示与矩阵内核达成一致。',
     significance:
-      'MXFP4 用于 AMD 及跨厂商低精度路径，实际结果取决于检查点制备与内核覆盖，而不只是标称 bit 数。',
+      'MXFP4 用于 AMD 及跨厂商低精度路径。实际结果由检查点制备与内核覆盖决定，标称 bit 数无法完整描述。',
     benchmarkContext:
       'InferenceX 把 MXFP4 记录为完整引擎和硬件方案的一部分。与 NVFP4 或 FP8 比较时，应匹配模型、序列长度、质量要求和交互性目标。',
   },
@@ -513,7 +513,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     term: '混合专家模型',
     aliases: ['mixture of experts', 'MoE', '稀疏 MoE'],
     plainEnglish:
-      '混合专家模型像一支大型专家团队：每个 token 只调用最合适的少数专家，而不是每次动用全员。',
+      '混合专家模型像一支大型专家团队：每个 token 只调用最合适的少数专家，无需每次动用全员。',
     definition: '混合专家模型包含大量前馈专家网络，但每个 token 只会被路由到其中一小部分。',
     explanation:
       '路由器为每个 token 计算专家分数，top-k 路由激活所选专家及共享专家。这让模型总参数可远大于每个 token 实际使用的计算量。',
@@ -538,8 +538,8 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   'sparse-attention': {
     term: '稀疏注意力',
     aliases: ['sparse attention', 'DeepSeek Sparse Attention', 'DSA'],
-    plainEnglish: '稀疏注意力只回看长上下文中最有用的部分，而不是重新检查每个历史 token。',
-    definition: '稀疏注意力限制每个 query 可关注的历史 token，而不是对全部上下文执行完整注意力。',
+    plainEnglish: '稀疏注意力只回看长上下文中最有用的部分，无需重新检查每个历史 token。',
+    definition: '稀疏注意力限制每个 query 可关注的历史 token，避免对全部上下文执行完整注意力。',
     explanation:
       '稀疏模式可选择局部、压缩、索引或学习得到的上下文子集，降低长序列计算与内存移动；模型架构与运行时必须有匹配的索引器和注意力内核。',
     significance:
@@ -596,7 +596,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       'SGLang 快速迭代的版本和模型专用内核可在硬件不变时显著改变吞吐量；低并发受调度开销影响，其他区间则由注意力、MoE 与通信内核主导。',
     benchmarkContext:
-      'InferenceX 持续重跑固定版本的 SGLang 方案。跨版本曲线能显示改动落在性能曲线的哪个区间，而不是把发布简化成单一峰值数字。',
+      'InferenceX 持续重跑固定版本的 SGLang 方案。跨版本曲线会保留改动对完整性能区间的影响。',
   },
   'tensorrt-llm': {
     term: 'TensorRT-LLM',
@@ -607,7 +607,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     explanation:
       '它提供 NVIDIA 优化内核、量化路径、分布式执行和模型专用优化；既可作为服务后端，也可通过集成让其他引擎使用其衍生内核。',
     significance:
-      '紧密硬件集成可快速解锁 Blackwell 与 NVL72 功能，但模型支持和引擎兼容仍与版本相关，因此 TensorRT-LLM 标签必须对应具体容器与方案。',
+      '紧密硬件集成可快速支持 Blackwell 与 NVL72 功能，但模型支持和引擎兼容仍与版本相关，因此 TensorRT-LLM 标签必须对应具体容器与方案。',
     benchmarkContext:
       'InferenceX 同时包含直接 TensorRT-LLM、Dynamo TensorRT-LLM，以及 SGLang/vLLM 使用 TRT-LLM 衍生内核后端的配置。',
   },
@@ -619,9 +619,9 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     definition:
       'NVIDIA Dynamo 是用于编排请求路由、worker 池、KV 缓存移动和分离式服务的分布式推理框架。',
     explanation:
-      'Dynamo 可把预填充与解码放在独立扩展的池中，并使用 vLLM 或 TensorRT-LLM 作为 worker 运行时；它管理引擎周围的数据与控制路径，而不是替代内部所有内核。',
+      'Dynamo 可把预填充与解码放在独立扩展的池中，并使用 vLLM 或 TensorRT-LLM 作为 worker 运行时。内核仍由这些引擎执行，Dynamo 负责外围数据与控制路径。',
     significance:
-      '机架级服务不仅需要快速单 GPU 运行时。路由、缓存传输、拓扑感知与池大小决定 Wide EP 和分离式推理能否提升端到端性能。',
+      '机架级性能由单 GPU 运行时、路由、缓存传输、拓扑感知与池大小共同决定。这些因素决定 Wide EP 和分离式推理能否提升端到端性能。',
     benchmarkContext:
       'Dynamo vLLM、Dynamo TRT-LLM 标签同时标识编排层与执行引擎。InferenceX 文章还会明确预填充/解码拓扑，因为两种 Dynamo 配置可能表现完全不同。',
   },

--- a/packages/app/src/lib/glossary.test.ts
+++ b/packages/app/src/lib/glossary.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAllPosts, getPostBySlug } from './blog';
+import {
+  GLOSSARY_CATEGORIES,
+  getAdjacentGlossaryEntries,
+  getAllGlossaryEntries,
+  getGlossaryEntry,
+  getRelatedGlossaryEntries,
+} from './glossary';
+import {
+  GLOSSARY_CATEGORY_LABELS_ZH,
+  getAdjacentZhGlossaryEntries,
+  getAllZhGlossaryEntries,
+  getRelatedZhGlossaryEntries,
+  getZhGlossaryEntry,
+} from './glossary-zh';
+
+describe('glossary content', () => {
+  it('provides unique, indexable entries with substantive explanations', () => {
+    const entries = getAllGlossaryEntries();
+    const slugs = entries.map((entry) => entry.slug);
+
+    expect(entries.length).toBeGreaterThanOrEqual(40);
+    expect(new Set(slugs).size).toBe(entries.length);
+
+    for (const entry of entries) {
+      expect(entry.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u);
+      expect(GLOSSARY_CATEGORIES).toContain(entry.category);
+      expect(entry.relatedTerms.length).toBeGreaterThanOrEqual(3);
+      expect(entry.articleSlugs.length).toBeGreaterThanOrEqual(1);
+
+      const renderedCopy = [
+        entry.definition,
+        entry.explanation,
+        entry.significance,
+        entry.benchmarkContext,
+      ].join(' ');
+      expect(renderedCopy.split(/\s+/u).length, entry.term).toBeGreaterThanOrEqual(90);
+    }
+  });
+
+  it('resolves every related term without self-links', () => {
+    for (const entry of getAllGlossaryEntries()) {
+      expect(entry.relatedTerms).not.toContain(entry.slug);
+      expect(getRelatedGlossaryEntries(entry).map((related) => related.slug)).toEqual(
+        entry.relatedTerms,
+      );
+    }
+  });
+
+  it('links every glossary source to a real article and covers the complete article library', () => {
+    const entries = getAllGlossaryEntries();
+    const referencedArticles = new Set(entries.flatMap((entry) => entry.articleSlugs));
+
+    for (const slug of referencedArticles) {
+      expect(getPostBySlug(slug), slug).not.toBeNull();
+    }
+
+    expect(referencedArticles).toEqual(new Set(getAllPosts().map((post) => post.slug)));
+  });
+});
+
+describe('Chinese glossary content', () => {
+  it('provides a substantive translation for every English entry', () => {
+    const englishEntries = getAllGlossaryEntries();
+    const zhEntries = getAllZhGlossaryEntries();
+
+    expect(zhEntries.map((entry) => entry.slug)).toEqual(englishEntries.map((entry) => entry.slug));
+    expect(Object.keys(GLOSSARY_CATEGORY_LABELS_ZH)).toEqual([...GLOSSARY_CATEGORIES]);
+
+    for (const entry of zhEntries) {
+      const renderedCopy = [
+        entry.definition,
+        entry.explanation,
+        entry.significance,
+        entry.benchmarkContext,
+      ].join('');
+      expect(
+        renderedCopy.match(/\p{Script=Han}/gu)?.length ?? 0,
+        entry.slug,
+      ).toBeGreaterThanOrEqual(100);
+      expect(getRelatedZhGlossaryEntries(entry).map((related) => related.slug)).toEqual(
+        entry.relatedTerms,
+      );
+      for (const articleSlug of entry.articleSlugs) {
+        expect(getPostBySlug(articleSlug, 'zh'), articleSlug).not.toBeNull();
+      }
+    }
+  });
+
+  it('resolves canonical slugs and walks the Chinese term order without gaps', () => {
+    expect(getZhGlossaryEntry('multi-token-prediction')?.term).toBe('多 token 预测');
+    expect(getZhGlossaryEntry('not-a-real-term')).toBeUndefined();
+
+    const sorted = getAllZhGlossaryEntries().toSorted((a, b) =>
+      a.term.localeCompare(b.term, 'zh-CN'),
+    );
+    for (const [index, entry] of sorted.entries()) {
+      expect(getAdjacentZhGlossaryEntries(entry.slug)).toEqual({
+        previous: sorted[index - 1] ?? null,
+        next: sorted[index + 1] ?? null,
+      });
+    }
+  });
+});
+
+describe('glossary navigation', () => {
+  it('returns entries by canonical slug', () => {
+    expect(getGlossaryEntry('multi-token-prediction')?.abbreviation).toBe('MTP');
+    expect(getGlossaryEntry('not-a-real-term')).toBeUndefined();
+  });
+
+  it('walks the complete alphabetized term list without gaps', () => {
+    const sorted = getAllGlossaryEntries().toSorted((a, b) => a.term.localeCompare(b.term));
+
+    for (const [index, entry] of sorted.entries()) {
+      expect(getAdjacentGlossaryEntries(entry.slug)).toEqual({
+        previous: sorted[index - 1] ?? null,
+        next: sorted[index + 1] ?? null,
+      });
+    }
+  });
+});

--- a/packages/app/src/lib/glossary.test.ts
+++ b/packages/app/src/lib/glossary.test.ts
@@ -29,6 +29,10 @@ describe('glossary content', () => {
       expect(GLOSSARY_CATEGORIES).toContain(entry.category);
       expect(entry.relatedTerms.length).toBeGreaterThanOrEqual(3);
       expect(entry.articleSlugs.length).toBeGreaterThanOrEqual(1);
+      const plainEnglishWords = entry.plainEnglish.split(/\s+/u);
+      expect(plainEnglishWords.length, entry.term).toBeGreaterThanOrEqual(8);
+      expect(plainEnglishWords.length, entry.term).toBeLessThanOrEqual(40);
+      expect(entry.plainEnglish).not.toBe(entry.definition);
 
       const renderedCopy = [
         entry.definition,
@@ -70,6 +74,10 @@ describe('Chinese glossary content', () => {
     expect(Object.keys(GLOSSARY_CATEGORY_LABELS_ZH)).toEqual([...GLOSSARY_CATEGORIES]);
 
     for (const entry of zhEntries) {
+      const plainLanguageCharacters = entry.plainEnglish.match(/\p{Script=Han}/gu)?.length ?? 0;
+      expect(plainLanguageCharacters, entry.slug).toBeGreaterThanOrEqual(8);
+      expect(plainLanguageCharacters, entry.slug).toBeLessThanOrEqual(60);
+      expect(entry.plainEnglish).not.toBe(entry.definition);
       const renderedCopy = [
         entry.definition,
         entry.explanation,

--- a/packages/app/src/lib/glossary.test.ts
+++ b/packages/app/src/lib/glossary.test.ts
@@ -33,6 +33,7 @@ describe('glossary content', () => {
       expect(plainEnglishWords.length, entry.term).toBeGreaterThanOrEqual(8);
       expect(plainEnglishWords.length, entry.term).toBeLessThanOrEqual(40);
       expect(entry.plainEnglish).not.toBe(entry.definition);
+      expect(JSON.stringify(entry), entry.term).not.toMatch(/[—–]/u);
 
       const renderedCopy = [
         entry.definition,
@@ -78,6 +79,7 @@ describe('Chinese glossary content', () => {
       expect(plainLanguageCharacters, entry.slug).toBeGreaterThanOrEqual(8);
       expect(plainLanguageCharacters, entry.slug).toBeLessThanOrEqual(60);
       expect(entry.plainEnglish).not.toBe(entry.definition);
+      expect(JSON.stringify(entry), entry.term).not.toMatch(/[—–]/u);
       const renderedCopy = [
         entry.definition,
         entry.explanation,

--- a/packages/app/src/lib/glossary.test.ts
+++ b/packages/app/src/lib/glossary.test.ts
@@ -10,6 +10,7 @@ import {
 } from './glossary';
 import {
   GLOSSARY_CATEGORY_LABELS_ZH,
+  compareZhGlossaryEntries,
   getAdjacentZhGlossaryEntries,
   getAllZhGlossaryEntries,
   getRelatedZhGlossaryEntries,
@@ -80,6 +81,12 @@ describe('Chinese glossary content', () => {
       expect(plainLanguageCharacters, entry.slug).toBeLessThanOrEqual(60);
       expect(entry.plainEnglish).not.toBe(entry.definition);
       expect(JSON.stringify(entry), entry.term).not.toMatch(/[—–]/u);
+      const englishMeasurement = getGlossaryEntry(entry.slug)?.measurement;
+      if (englishMeasurement) {
+        expect(entry.measurement, entry.term).toBeDefined();
+        expect(entry.measurement?.label, entry.term).not.toBe(englishMeasurement.label);
+        expect(entry.measurement?.value, entry.term).not.toBe(englishMeasurement.value);
+      }
       const renderedCopy = [
         entry.definition,
         entry.explanation,
@@ -103,9 +110,7 @@ describe('Chinese glossary content', () => {
     expect(getZhGlossaryEntry('multi-token-prediction')?.term).toBe('多 token 预测');
     expect(getZhGlossaryEntry('not-a-real-term')).toBeUndefined();
 
-    const sorted = getAllZhGlossaryEntries().toSorted((a, b) =>
-      a.term.localeCompare(b.term, 'zh-CN'),
-    );
+    const sorted = getAllZhGlossaryEntries().toSorted(compareZhGlossaryEntries);
     for (const [index, entry] of sorted.entries()) {
       expect(getAdjacentZhGlossaryEntries(entry.slug)).toEqual({
         previous: sorted[index - 1] ?? null,

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -16,6 +16,7 @@ export interface GlossaryEntry {
   abbreviation?: string;
   aliases?: readonly string[];
   category: GlossaryCategory;
+  plainEnglish: string;
   definition: string;
   explanation: string;
   significance: string;
@@ -49,6 +50,8 @@ const entries = [
     term: 'AI inference',
     aliases: ['LLM inference', 'model serving'],
     category: 'Serving',
+    plainEnglish:
+      'You give a trained model something new—a prompt, image, or audio—and it uses what it learned to produce an answer.',
     definition:
       'AI inference is the process of running a trained model on new input to produce an output. For a large language model, that usually means processing a prompt and generating tokens.',
     explanation:
@@ -65,6 +68,8 @@ const entries = [
     term: 'Inference engine',
     aliases: ['serving engine', 'LLM serving framework'],
     category: 'Serving',
+    plainEnglish:
+      'The inference engine is the traffic controller behind an AI service: it keeps incoming requests moving and makes sure the GPUs do the right work at the right time.',
     definition:
       'An inference engine is the software runtime that turns model weights and incoming requests into generated outputs on accelerators.',
     explanation:
@@ -81,6 +86,8 @@ const entries = [
     term: 'Throughput',
     aliases: ['token throughput', 'aggregate throughput'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Throughput is how much total work the system gets done each second across everyone using it.',
     definition:
       'Throughput is the total rate at which an inference system produces tokens across all active requests.',
     explanation:
@@ -98,6 +105,8 @@ const entries = [
     term: 'Interactivity',
     aliases: ['generation speed', 'per-user token rate'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Interactivity is how quickly one person sees new words appear after the model starts answering.',
     definition:
       'Interactivity is the rate at which an individual user receives generated tokens during the decode phase.',
     explanation:
@@ -115,6 +124,8 @@ const entries = [
     term: 'Latency',
     aliases: ['response latency', 'inference latency'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Latency is how long you wait. For a streamed answer, that includes both the wait before it starts and the pauses between later words.',
     definition:
       'Latency is elapsed time experienced by a request. In streaming LLM serving it must be decomposed because waiting for the first token and waiting between later tokens are different behaviors.',
     explanation:
@@ -131,6 +142,8 @@ const entries = [
     term: 'Time to first token',
     abbreviation: 'TTFT',
     category: 'Benchmark metrics',
+    plainEnglish:
+      'TTFT is the “thinking…” pause between sending your prompt and seeing the first piece of the answer.',
     definition:
       'Time to first token is the delay from submitting a request until the first generated token is returned.',
     explanation:
@@ -149,6 +162,8 @@ const entries = [
     abbreviation: 'TPOT',
     aliases: ['inter-token latency', 'ITL'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'TPOT is the gap between each new piece of a streamed answer. Smaller gaps make the response feel faster and smoother.',
     definition:
       'Time per output token is the average delay between generated tokens after the first token has arrived.',
     explanation:
@@ -166,6 +181,7 @@ const entries = [
     term: 'Concurrency',
     aliases: ['concurrent requests', 'batch concurrency'],
     category: 'Benchmark metrics',
+    plainEnglish: 'Concurrency is how many people or requests the system is serving at once.',
     definition:
       'Concurrency is the number of requests being served at the same time during a benchmark or deployment.',
     explanation:
@@ -182,6 +198,8 @@ const entries = [
     term: 'Batching',
     aliases: ['continuous batching', 'dynamic batching'],
     category: 'Serving',
+    plainEnglish:
+      'Batching is like putting several passengers on one bus: the GPU handles multiple requests together so each trip does more useful work.',
     definition:
       'Batching groups work from multiple requests so an accelerator can process their tokens together.',
     explanation:
@@ -198,6 +216,8 @@ const entries = [
     term: 'Pareto frontier',
     aliases: ['performance frontier', 'Pareto-optimal curve'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'The Pareto frontier is the line of best available tradeoffs. Every point on it is worth considering because improving one thing would require giving up something else.',
     definition:
       'A Pareto frontier contains the operating points for which no other measured point is better on both compared dimensions.',
     explanation:
@@ -214,6 +234,8 @@ const entries = [
     term: 'Iso-interactivity',
     aliases: ['matched interactivity', 'equal token rate'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Iso-interactivity means comparing systems while users see words appear at the same speed—an apples-to-apples comparison of the hardware behind the experience.',
     definition: 'Iso-interactivity means comparing systems at the same per-user generation rate.',
     explanation:
       'Benchmark runs rarely land at identical tok/s/user values because each recipe has different concurrency points. An iso-interactivity comparison interpolates each Pareto frontier at a shared target and then compares throughput, cost, or efficiency there.',
@@ -230,6 +252,8 @@ const entries = [
     abbreviation: 'ISL / OSL',
     aliases: ['prompt length', 'generation length', '8K/1K'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Input length is how much the model reads; output length is how much it writes. “8K/1K” means a long prompt followed by a shorter answer.',
     definition:
       'Input sequence length is the number of prompt tokens supplied to the model; output sequence length is the number of tokens generated in response.',
     explanation:
@@ -246,6 +270,8 @@ const entries = [
     term: 'Cost per million tokens',
     aliases: ['$/M tokens', 'token cost'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'This is the estimated infrastructure bill for producing one million tokens—the chunks of text an AI model reads and writes.',
     definition:
       'Cost per million tokens estimates the infrastructure cost of producing one million tokens at a measured operating point.',
     explanation:
@@ -271,6 +297,8 @@ const entries = [
     term: 'Performance per dollar',
     aliases: ['perf/$', 'cost efficiency'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Performance per dollar asks a simple question: how much useful AI output do you get for the money spent running the system?',
     definition:
       'Performance per dollar expresses how much measured inference work a system delivers for a unit of modeled cost.',
     explanation:
@@ -292,6 +320,8 @@ const entries = [
     term: 'Total cost of ownership',
     abbreviation: 'TCO',
     category: 'Benchmark metrics',
+    plainEnglish:
+      'TCO is the real all-in cost of owning and running the hardware, not just the price on the GPU invoice.',
     definition:
       'Total cost of ownership is an all-in estimate of the cost to provision and operate computing infrastructure over its useful life.',
     explanation:
@@ -313,6 +343,8 @@ const entries = [
     term: 'Tokens per megawatt',
     aliases: ['tokens per MW', 'power-normalized throughput'],
     category: 'Benchmark metrics',
+    plainEnglish:
+      'Tokens per megawatt asks how much AI output a data center can produce from a fixed amount of available power.',
     definition:
       'Tokens per megawatt measures useful inference throughput relative to a data center power budget.',
     explanation:
@@ -335,6 +367,8 @@ const entries = [
     term: 'Prefill',
     aliases: ['prompt processing', 'context encoding'],
     category: 'Serving',
+    plainEnglish:
+      'Prefill is the model reading and understanding your prompt before it begins writing the answer.',
     definition:
       'Prefill is the first inference phase, in which the model processes the input prompt and populates the KV cache before generation begins.',
     explanation:
@@ -351,6 +385,8 @@ const entries = [
     term: 'Decode',
     aliases: ['autoregressive generation', 'token generation'],
     category: 'Serving',
+    plainEnglish:
+      'Decode is the model writing its answer one token at a time after it has read the prompt.',
     definition:
       'Decode is the inference phase that generates output tokens autoregressively, normally one accepted token per sequence per model step.',
     explanation:
@@ -367,6 +403,8 @@ const entries = [
     term: 'KV cache',
     aliases: ['key-value cache', 'attention cache'],
     category: 'Serving',
+    plainEnglish:
+      'The KV cache is the model’s working memory for the current conversation. It keeps useful notes so the model does not reread everything for every new token.',
     definition:
       'The KV cache stores attention key and value states for tokens already processed so the model does not recompute them at every decode step.',
     explanation:
@@ -389,6 +427,8 @@ const entries = [
     term: 'Prefix caching',
     aliases: ['prompt caching', 'automatic prefix caching'],
     category: 'Serving',
+    plainEnglish:
+      'Prefix caching remembers the work for a repeated beginning—such as the same system prompt—so the model can skip doing that part again.',
     definition:
       'Prefix caching reuses KV-cache state when multiple requests begin with the same token sequence.',
     explanation:
@@ -406,6 +446,8 @@ const entries = [
     abbreviation: 'PD disaggregation',
     aliases: ['disaggregated prefill', 'disagg'],
     category: 'Serving',
+    plainEnglish:
+      'Disaggregated inference gives prompt reading and answer writing to separate GPU teams, so each team can be tuned for its own job.',
     definition:
       'Disaggregated inference runs prefill and decode on separate worker pools and transfers request state between them.',
     explanation:
@@ -422,6 +464,8 @@ const entries = [
     term: 'Speculative decoding',
     aliases: ['spec decode', 'draft-and-verify decoding'],
     category: 'Serving',
+    plainEnglish:
+      'Speculative decoding lets a cheaper helper draft several tokens ahead, then asks the full model to approve them together instead of generating each one separately.',
     definition:
       'Speculative decoding proposes several future tokens cheaply and verifies them together with the target model, reducing the number of expensive serial decode steps.',
     explanation:
@@ -439,6 +483,8 @@ const entries = [
     abbreviation: 'MTP',
     aliases: ['multi-token prediction heads'],
     category: 'Serving',
+    plainEnglish:
+      'MTP lets the model guess several upcoming tokens at once and then verify them, reducing the number of slow one-token-at-a-time steps.',
     definition:
       'Multi-token prediction uses auxiliary heads trained with the model to propose multiple future tokens for speculative verification.',
     explanation:
@@ -455,6 +501,8 @@ const entries = [
     term: 'EAGLE',
     aliases: ['EAGLE speculative decoding', 'EAGLE-3'],
     category: 'Serving',
+    plainEnglish:
+      'EAGLE is a particular way to draft several likely next tokens for the main model to check, which can make answers stream faster.',
     definition:
       'EAGLE is a family of speculative-decoding methods that predicts draft continuations from features associated with the target language model and then verifies them with the target model.',
     explanation:
@@ -471,6 +519,8 @@ const entries = [
     term: 'Tensor parallelism',
     abbreviation: 'TP',
     category: 'Parallelism',
+    plainEnglish:
+      'Tensor parallelism splits one large calculation across several GPUs so they solve it together.',
     definition:
       'Tensor parallelism shards individual tensor operations and model weight matrices across multiple accelerators.',
     explanation:
@@ -487,6 +537,8 @@ const entries = [
     term: 'Expert parallelism',
     abbreviation: 'EP',
     category: 'Parallelism',
+    plainEnglish:
+      'Expert parallelism gives different GPUs different specialist parts of a model, then sends each token to the specialists it needs.',
     definition:
       'Expert parallelism distributes the experts of a mixture-of-experts model across accelerators and routes tokens to the ranks holding their selected experts.',
     explanation:
@@ -508,6 +560,8 @@ const entries = [
     term: 'Data parallelism',
     abbreviation: 'DP',
     category: 'Parallelism',
+    plainEnglish:
+      'Data parallelism makes multiple copies of the model and divides incoming work among them, like opening more identical checkout lanes.',
     definition:
       'Data parallelism runs replicated model or layer groups on multiple ranks and distributes requests or tokens among those replicas.',
     explanation:
@@ -524,6 +578,8 @@ const entries = [
     term: 'Wide expert parallelism',
     abbreviation: 'Wide EP',
     category: 'Parallelism',
+    plainEnglish:
+      'Wide expert parallelism spreads a model’s specialists across many GPUs, giving each GPU less expert data to hold and move.',
     definition:
       'Wide expert parallelism uses a large number of accelerator ranks for the expert-parallel group of a mixture-of-experts model.',
     explanation:
@@ -544,6 +600,8 @@ const entries = [
     slug: 'all-reduce',
     term: 'All-reduce',
     category: 'Parallelism',
+    plainEnglish:
+      'All-reduce lets every GPU solve one piece of a calculation, combines those pieces, and gives the combined result back to everyone.',
     definition:
       'All-reduce is a collective communication operation that combines values from every participating rank and returns the reduced result to every rank.',
     explanation:
@@ -559,6 +617,8 @@ const entries = [
     slug: 'all-to-all',
     term: 'All-to-all',
     category: 'Parallelism',
+    plainEnglish:
+      'All-to-all is a coordinated exchange where every GPU sends a different package of data to every other GPU.',
     definition:
       'All-to-all is a collective pattern in which every participating rank sends distinct data to every other rank.',
     explanation:
@@ -580,6 +640,8 @@ const entries = [
     term: 'Scale-up vs. scale-out networking',
     aliases: ['scale-up domain', 'scale-out fabric'],
     category: 'Parallelism',
+    plainEnglish:
+      'Scale-up is the ultra-fast network inside one tightly connected GPU system; scale-out is the broader network connecting separate servers or racks.',
     definition:
       'Scale-up networking connects accelerators inside one tightly coupled system, while scale-out networking connects multiple systems or racks into a larger cluster.',
     explanation:
@@ -596,6 +658,8 @@ const entries = [
     term: 'High-bandwidth memory',
     abbreviation: 'HBM',
     category: 'Hardware',
+    plainEnglish:
+      'HBM is the GPU’s small pool of extremely fast nearby memory, where model weights and working data must fit while inference runs.',
     definition:
       'High-bandwidth memory is stacked memory placed close to an accelerator to provide much higher bandwidth than conventional server memory.',
     explanation:
@@ -612,6 +676,8 @@ const entries = [
     term: 'Memory bandwidth',
     aliases: ['HBM bandwidth'],
     category: 'Hardware',
+    plainEnglish:
+      'Memory bandwidth is the width of the pipe feeding data to the GPU’s compute units. A wider pipe keeps them from sitting idle.',
     definition:
       'Memory bandwidth is the rate at which data can be transferred between accelerator memory and the compute units.',
     explanation:
@@ -628,6 +694,8 @@ const entries = [
     term: 'NVLink',
     aliases: ['NVIDIA NVLink'],
     category: 'Hardware',
+    plainEnglish:
+      'NVLink is NVIDIA’s high-speed highway between GPUs, allowing them to cooperate much faster than over ordinary server networking.',
     definition:
       'NVLink is NVIDIA’s high-bandwidth accelerator interconnect for moving data directly among GPUs within a scale-up domain.',
     explanation:
@@ -644,6 +712,8 @@ const entries = [
     term: 'Quantization',
     aliases: ['low-precision inference', 'weight quantization'],
     category: 'Numerical precision',
+    plainEnglish:
+      'Quantization stores the model’s numbers with fewer bits, making it smaller and faster to move, usually with a carefully controlled loss of precision.',
     definition:
       'Quantization represents model weights, activations, or cache values with fewer bits than a higher-precision baseline.',
     explanation:
@@ -660,6 +730,8 @@ const entries = [
     term: 'FP8',
     aliases: ['8-bit floating point'],
     category: 'Numerical precision',
+    plainEnglish:
+      'FP8 is a compact 8-bit way to store and calculate with model numbers, reducing memory use and often speeding up inference.',
     definition:
       'FP8 is a family of eight-bit floating-point formats used to reduce model storage, memory traffic, and compute cost relative to FP16 or BF16.',
     explanation:
@@ -676,6 +748,8 @@ const entries = [
     term: 'FP4',
     aliases: ['4-bit floating point'],
     category: 'Numerical precision',
+    plainEnglish:
+      'FP4 compresses model numbers into just 4 bits. That can make inference much faster and smaller, but leaves less room for numerical detail.',
     definition:
       'FP4 refers to four-bit floating-point formats used for very low-precision model representation and accelerated matrix operations.',
     explanation:
@@ -692,6 +766,8 @@ const entries = [
     term: 'NVFP4',
     aliases: ['NVIDIA FP4'],
     category: 'Numerical precision',
+    plainEnglish:
+      'NVFP4 is NVIDIA’s Blackwell-optimized version of 4-bit model math, designed to move less data and use the GPU’s fastest low-precision hardware.',
     definition:
       'NVFP4 is NVIDIA’s block-scaled four-bit floating-point quantization format for Blackwell-generation tensor-core inference.',
     explanation:
@@ -708,6 +784,8 @@ const entries = [
     term: 'MXFP4',
     aliases: ['microscaling FP4', 'OCP MX FP4'],
     category: 'Numerical precision',
+    plainEnglish:
+      'MXFP4 is a 4-bit format that gives small groups of numbers their own scale, helping very compact values keep enough useful range.',
     definition:
       'MXFP4 is a microscaling four-bit floating-point format that shares a scale across small blocks of values.',
     explanation:
@@ -725,6 +803,8 @@ const entries = [
     abbreviation: 'MoE',
     aliases: ['sparse MoE'],
     category: 'Model architecture',
+    plainEnglish:
+      'A mixture-of-experts model is like a large team of specialists: it calls only the few experts best suited to each token instead of using the whole team every time.',
     definition:
       'A mixture-of-experts model contains many feed-forward expert networks but routes each token through only a selected subset.',
     explanation:
@@ -746,6 +826,8 @@ const entries = [
     term: 'Multi-head latent attention',
     abbreviation: 'MLA',
     category: 'Model architecture',
+    plainEnglish:
+      'MLA compresses the model’s notes about earlier tokens so long conversations use less memory and are cheaper to continue.',
     definition:
       'Multi-head latent attention compresses attention key and value state into a lower-dimensional latent representation to reduce KV-cache size and memory traffic.',
     explanation:
@@ -762,6 +844,8 @@ const entries = [
     term: 'Sparse attention',
     aliases: ['DeepSeek Sparse Attention', 'DSA'],
     category: 'Model architecture',
+    plainEnglish:
+      'Sparse attention lets the model look back at only the most useful parts of a long context instead of rereading every earlier token.',
     definition:
       'Sparse attention limits which prior tokens each query attends to instead of computing attention over the entire available context.',
     explanation:
@@ -778,6 +862,7 @@ const entries = [
     term: 'CUDA',
     aliases: ['NVIDIA CUDA'],
     category: 'Software',
+    plainEnglish: 'CUDA is NVIDIA’s software toolbox for making programs run on its GPUs.',
     definition:
       'CUDA is NVIDIA’s GPU computing platform, programming model, compiler toolchain, and library ecosystem.',
     explanation:
@@ -794,6 +879,8 @@ const entries = [
     term: 'ROCm',
     aliases: ['AMD ROCm'],
     category: 'Software',
+    plainEnglish:
+      'ROCm is AMD’s software toolbox for running AI and other high-performance programs on AMD GPUs.',
     definition:
       'ROCm is AMD’s open GPU computing software platform, including runtimes, compilers, communication libraries, and optimized math and AI kernels.',
     explanation:
@@ -809,6 +896,8 @@ const entries = [
     slug: 'vllm',
     term: 'vLLM',
     category: 'Software',
+    plainEnglish:
+      'vLLM is open-source software that organizes requests and GPU memory so language models can serve many users efficiently.',
     definition:
       'vLLM is an open-source LLM inference and serving engine focused on high-throughput scheduling, memory-efficient KV-cache management, and broad model and hardware support.',
     explanation:
@@ -824,6 +913,8 @@ const entries = [
     slug: 'sglang',
     term: 'SGLang',
     category: 'Software',
+    plainEnglish:
+      'SGLang is open-source software for serving language models quickly, with scheduling and optimization features for complex AI workloads.',
     definition:
       'SGLang is an open-source serving engine and language-model programming system optimized for high-performance LLM and multimodal inference.',
     explanation:
@@ -840,6 +931,8 @@ const entries = [
     term: 'TensorRT-LLM',
     aliases: ['TRT-LLM', 'TRTLLM'],
     category: 'Software',
+    plainEnglish:
+      'TensorRT-LLM is NVIDIA’s optimized software stack for getting high inference performance from NVIDIA GPUs.',
     definition:
       'TensorRT-LLM is NVIDIA’s inference stack for compiling, optimizing, and serving large language models on NVIDIA GPUs.',
     explanation:
@@ -856,6 +949,8 @@ const entries = [
     term: 'NVIDIA Dynamo',
     aliases: ['Dynamo'],
     category: 'Software',
+    plainEnglish:
+      'NVIDIA Dynamo coordinates many GPU workers—routing requests, moving model memory, and assigning prompt reading and answer generation to the right pools.',
     definition:
       'NVIDIA Dynamo is a distributed inference framework that orchestrates request routing, worker pools, KV-cache movement, and disaggregated serving.',
     explanation:
@@ -877,7 +972,7 @@ const entries = [
 
 export type GlossaryPreview = Pick<
   GlossaryEntry,
-  'slug' | 'term' | 'abbreviation' | 'aliases' | 'category' | 'definition'
+  'slug' | 'term' | 'abbreviation' | 'aliases' | 'category' | 'plainEnglish' | 'definition'
 >;
 
 const entriesBySlug: Readonly<Record<string, GlossaryEntry>> = Object.fromEntries(

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -51,15 +51,15 @@ const entries = [
     aliases: ['LLM inference', 'model serving'],
     category: 'Serving',
     plainEnglish:
-      'You give a trained model something new—a prompt, image, or audio—and it uses what it learned to produce an answer.',
+      'You give a trained model something new, such as a prompt, image, or audio. It uses what it learned to produce an answer.',
     definition:
       'AI inference is the process of running a trained model on new input to produce an output. For a large language model, that usually means processing a prompt and generating tokens.',
     explanation:
-      'Training changes model weights; inference uses those weights. A production inference system wraps the model in a serving engine that schedules requests, manages memory, batches work, and runs kernels on one or more accelerators. The same model can have radically different inference performance depending on that software and hardware stack.',
+      'Training changes model weights; inference uses those weights. A production inference system wraps the model in a serving engine that schedules requests, manages memory, batches work, and runs kernels on one or more accelerators. Performance can vary with the surrounding software and hardware stack.',
     significance:
-      'Inference is a systems problem as much as a model problem. User experience depends on latency and interactivity, while operator economics depend on throughput, utilization, power, and hardware cost. Optimizing only one of those dimensions can make another worse.',
+      'Inference performance depends on the system around the model. User experience depends on latency and interactivity, while operator economics depend on throughput, utilization, power, and hardware cost. Optimizing one dimension can make another worse.',
     benchmarkContext:
-      'InferenceX benchmarks complete serving recipes rather than quoting only peak chip specifications. Each curve captures a model, engine, numerical precision, parallelism strategy, GPU system, sequence length, and concurrency sweep.',
+      'InferenceX benchmarks complete serving recipes because peak chip specifications alone cannot describe serving performance. Each curve captures a model, engine, numerical precision, parallelism strategy, GPU system, sequence length, and concurrency sweep.',
     relatedTerms: ['inference-engine', 'prefill', 'decode', 'throughput', 'interactivity'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
   },
@@ -93,7 +93,7 @@ const entries = [
     explanation:
       'InferenceX commonly normalizes throughput as tokens per second per GPU so systems of different sizes can be compared. Higher batching or concurrency often raises aggregate throughput because weight reads and compute are amortized across more requests, but individual users may receive tokens more slowly.',
     significance:
-      'Maximum throughput alone is not a complete performance claim. A point can lead in tokens per second while operating at interactivity too low for a real-time product. The useful comparison is throughput at a latency or interactivity target appropriate to the workload.',
+      'Maximum throughput captures only one operating point. A system can lead in tokens per second while operating at interactivity too low for a real-time product. The useful comparison is throughput at a latency or interactivity target appropriate to the workload.',
     benchmarkContext:
       'On an InferenceX chart, throughput is read together with interactivity across the full concurrency sweep. The Pareto frontier removes operating points that are worse on both axes.',
     measurement: { label: 'Typical unit', value: 'tokens/second/GPU (tok/s/GPU)' },
@@ -133,7 +133,7 @@ const entries = [
     significance:
       'Low latency can require smaller batches or more parallel resources, which may reduce hardware utilization and increase cost. Good serving design chooses a latency service level and then maximizes throughput within it.',
     benchmarkContext:
-      'InferenceX emphasizes interactivity for decode responsiveness and exposes workload shape and concurrency so readers do not mistake a high-throughput batch point for a low-latency serving point.',
+      'InferenceX exposes workload shape and concurrency alongside interactivity. This keeps a high-throughput batch point from being mistaken for a low-latency serving point.',
     relatedTerms: ['time-to-first-token', 'time-per-output-token', 'interactivity', 'concurrency'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
   },
@@ -189,7 +189,7 @@ const entries = [
     significance:
       'A single concurrency value reveals only one operating point. Production traffic changes over time, and a recipe that looks best at low concurrency may be overtaken when batches become large or communication begins to dominate.',
     benchmarkContext:
-      'InferenceX sweeps concurrency to build a throughput–interactivity curve. Labels on the curve identify the request count behind each point and expose where a configuration saturates or collapses.',
+      'InferenceX sweeps concurrency to build a throughput-interactivity curve. Labels on the curve identify the request count behind each point and expose where a configuration saturates or collapses.',
     relatedTerms: ['throughput', 'interactivity', 'batching', 'pareto-frontier'],
     articleSlugs: [SGLANG_056, GB200_KIMI, MI355X_QWEN],
   },
@@ -203,11 +203,11 @@ const entries = [
     definition:
       'Batching groups work from multiple requests so an accelerator can process their tokens together.',
     explanation:
-      'Large matrix operations use GPUs more efficiently than many tiny operations. Modern serving engines continuously add and remove sequences as requests arrive and finish rather than waiting for a fixed batch to complete. The resulting batch shape changes throughout prefill and decode.',
+      'Large matrix operations use GPUs more efficiently than many tiny operations. Modern serving engines continuously add and remove sequences as requests arrive and finish, without waiting for a fixed batch to complete. The resulting batch shape changes throughout prefill and decode.',
     significance:
-      'Batching is the source of the core throughput–latency tradeoff. Larger effective batches amortize weight reads and launch overhead but generally increase the time between tokens for each user.',
+      'Batching creates the core throughput-latency tradeoff. Larger effective batches amortize weight reads and launch overhead but generally increase the time between tokens for each user.',
     benchmarkContext:
-      'Concurrency is an input to batching, not a guarantee of a particular kernel batch size. Parallelism, sequence lengths, request completion, and scheduler policy all affect the effective batch observed by the GPU.',
+      'Concurrency supplies work to the batcher. Parallelism, sequence lengths, request completion, and scheduler policy determine the effective batch observed by the GPU.',
     relatedTerms: ['concurrency', 'throughput', 'decode', 'interactivity'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2, SGLANG_056],
   },
@@ -217,7 +217,7 @@ const entries = [
     aliases: ['performance frontier', 'Pareto-optimal curve'],
     category: 'Benchmark metrics',
     plainEnglish:
-      'The Pareto frontier is the line of best available tradeoffs. Every point on it is worth considering because improving one thing would require giving up something else.',
+      'The Pareto frontier is the line of best available tradeoffs. Each point remains viable because improving one dimension would require giving up ground on another.',
     definition:
       'A Pareto frontier contains the operating points for which no other measured point is better on both compared dimensions.',
     explanation:
@@ -225,7 +225,7 @@ const entries = [
     significance:
       'The frontier prevents noisy or poorly tuned points from distorting comparisons and makes the real tradeoff visible. There is still no universal winner along the curve: the best point depends on the user’s minimum interactivity or maximum cost target.',
     benchmarkContext:
-      'InferenceX connects Pareto-optimal points from a concurrency and configuration sweep. Iso-interactivity comparisons interpolate along those frontiers rather than comparing arbitrarily selected raw points.',
+      'InferenceX connects Pareto-optimal points from a concurrency and configuration sweep. Iso-interactivity comparisons interpolate along those frontiers because direct comparisons of arbitrary raw points can mislead.',
     relatedTerms: ['throughput', 'interactivity', 'iso-interactivity', 'concurrency'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2, MI355X_GLM5],
   },
@@ -235,14 +235,14 @@ const entries = [
     aliases: ['matched interactivity', 'equal token rate'],
     category: 'Benchmark metrics',
     plainEnglish:
-      'Iso-interactivity means comparing systems while users see words appear at the same speed—an apples-to-apples comparison of the hardware behind the experience.',
+      'Iso-interactivity compares systems while users see words appear at the same speed. This provides an apples-to-apples view of the hardware behind the experience.',
     definition: 'Iso-interactivity means comparing systems at the same per-user generation rate.',
     explanation:
       'Benchmark runs rarely land at identical tok/s/user values because each recipe has different concurrency points. An iso-interactivity comparison interpolates each Pareto frontier at a shared target and then compares throughput, cost, or efficiency there.',
     significance:
       'Holding user experience constant avoids a common benchmark error: declaring a high-throughput system faster when it reaches that throughput only by serving every request more slowly.',
     benchmarkContext:
-      'InferenceX articles use iso-interactivity tables for hardware, precision, and software comparisons. Values outside a measured frontier are marked unreachable rather than extrapolated beyond observed data.',
+      'InferenceX articles use iso-interactivity tables for hardware, precision, and software comparisons. Values outside a measured frontier are marked unreachable and are not extrapolated beyond observed data.',
     relatedTerms: ['interactivity', 'pareto-frontier', 'throughput', 'performance-per-dollar'],
     articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, GB300_DSV4],
   },
@@ -271,13 +271,13 @@ const entries = [
     aliases: ['$/M tokens', 'token cost'],
     category: 'Benchmark metrics',
     plainEnglish:
-      'This is the estimated infrastructure bill for producing one million tokens—the chunks of text an AI model reads and writes.',
+      'This is the estimated infrastructure bill for producing one million tokens, the chunks of text an AI model reads and writes.',
     definition:
       'Cost per million tokens estimates the infrastructure cost of producing one million tokens at a measured operating point.',
     explanation:
       'InferenceX derives the metric from hourly total cost of ownership and measured token throughput. It may be reported for total tokens or separated into input and output tokens, so the denominator must be checked before comparing values.',
     significance:
-      'The metric converts systems performance into serving economics. It still depends on workload shape, interactivity, utilization, cache behavior, and cost assumptions; a low-throughput offline point is not directly comparable to a high-interactivity endpoint.',
+      'Workload shape, interactivity, utilization, cache behavior, and cost assumptions determine whether two values are comparable. A low-throughput offline point and a high-interactivity endpoint represent different operating regimes.',
     benchmarkContext:
       'Cost curves use the same concurrency sweep as throughput curves. At iso-interactivity, lower $/M means the system delivers the same streaming experience with less modeled infrastructure cost.',
     measurement: {
@@ -298,13 +298,13 @@ const entries = [
     aliases: ['perf/$', 'cost efficiency'],
     category: 'Benchmark metrics',
     plainEnglish:
-      'Performance per dollar asks a simple question: how much useful AI output do you get for the money spent running the system?',
+      'Performance per dollar measures how much useful AI output the system produces for each dollar spent running it.',
     definition:
       'Performance per dollar expresses how much measured inference work a system delivers for a unit of modeled cost.',
     explanation:
       'For a fixed workload and interactivity target, performance per dollar is the inverse of cost per token. A 2× perf/$ advantage means the system can produce about twice as many comparable tokens for the same infrastructure spend.',
     significance:
-      'Peak chip FLOPS do not determine serving economics by themselves. Memory, networking, software maturity, numerical precision, and achievable utilization all affect the measured output behind the ratio.',
+      'Peak chip FLOPS account for only part of serving economics. Memory, networking, software maturity, numerical precision, and achievable utilization all affect the measured output behind the ratio.',
     benchmarkContext:
       'InferenceX compares perf/$ at matched interactivity and names the TCO inputs used. Ratios should not be carried across different model, sequence-length, precision, or latency regimes.',
     relatedTerms: [
@@ -321,7 +321,7 @@ const entries = [
     abbreviation: 'TCO',
     category: 'Benchmark metrics',
     plainEnglish:
-      'TCO is the real all-in cost of owning and running the hardware, not just the price on the GPU invoice.',
+      'TCO covers the hardware purchase plus the cost of powering, cooling, networking, and operating it over time.',
     definition:
       'Total cost of ownership is an all-in estimate of the cost to provision and operate computing infrastructure over its useful life.',
     explanation:
@@ -348,7 +348,7 @@ const entries = [
     definition:
       'Tokens per megawatt measures useful inference throughput relative to a data center power budget.',
     explanation:
-      'InferenceX uses all-in provisioned utility power rather than chip thermal design power alone. That broader denominator can include the overhead required to deliver and cool the IT load, making the metric useful for capacity planning at facility scale.',
+      'InferenceX uses all-in provisioned utility power, including overhead for power delivery and cooling. Chip thermal design power covers only the accelerator, so it is less useful for facility-level capacity planning.',
     significance:
       'Power availability is often the binding constraint on new AI deployments. A system that produces more tokens per provisioned megawatt can serve more demand from the same utility allocation even if its individual accelerators draw more power.',
     benchmarkContext:
@@ -390,7 +390,7 @@ const entries = [
     definition:
       'Decode is the inference phase that generates output tokens autoregressively, normally one accepted token per sequence per model step.',
     explanation:
-      'Each new token depends on preceding tokens, so generation cannot be fully parallelized across time. The model repeatedly reads weights and the sequence’s KV cache, which makes decode especially sensitive to memory bandwidth, batching, and communication.',
+      'Each new token depends on preceding tokens, which limits parallelism across time. The model repeatedly reads weights and the sequence’s KV cache, making decode especially sensitive to memory bandwidth, batching, and communication.',
     significance:
       'Decode controls streaming interactivity and often dominates the cost of long outputs. Techniques such as speculative decoding, MTP, quantization, and wide expert parallelism aim to reduce the work or time required per accepted token.',
     benchmarkContext:
@@ -404,9 +404,9 @@ const entries = [
     aliases: ['key-value cache', 'attention cache'],
     category: 'Serving',
     plainEnglish:
-      'The KV cache is the model’s working memory for the current conversation. It keeps useful notes so the model does not reread everything for every new token.',
+      'The KV cache is the model’s working memory for the current conversation. It keeps useful notes and avoids rereading everything for every new token.',
     definition:
-      'The KV cache stores attention key and value states for tokens already processed so the model does not recompute them at every decode step.',
+      'The KV cache stores attention key and value states for tokens already processed, allowing each decode step to reuse them.',
     explanation:
       'The cache grows with sequence length, batch size, layer count, and the number and width of stored attention heads. During decode it is repeatedly read from accelerator memory, so both capacity and bandwidth matter.',
     significance:
@@ -428,15 +428,15 @@ const entries = [
     aliases: ['prompt caching', 'automatic prefix caching'],
     category: 'Serving',
     plainEnglish:
-      'Prefix caching remembers the work for a repeated beginning—such as the same system prompt—so the model can skip doing that part again.',
+      'Prefix caching remembers the work for a repeated beginning, such as the same system prompt, so the model can skip that work next time.',
     definition:
       'Prefix caching reuses KV-cache state when multiple requests begin with the same token sequence.',
     explanation:
-      'A repeated system prompt, shared document, or common conversation prefix does not need to be prefetched again if its cached states remain available. A cache hit can sharply reduce prompt computation and time to first token.',
+      'A repeated system prompt, shared document, or common conversation prefix can reuse cached states. A cache hit can reduce prompt computation and time to first token.',
     significance:
       'Production workloads with repeated prefixes may outperform synthetic random-token benchmarks. The benefit depends on hit rate, cache capacity, eviction policy, and whether requests route to workers that hold the needed state.',
     benchmarkContext:
-      'InferenceX generally disables prefix caching on random datasets because accidental reuse would measure the cache policy rather than full prompt processing. Treat benchmark cost as a no-hit baseline unless the recipe says otherwise.',
+      'InferenceX generally disables prefix caching on random datasets to isolate full prompt processing from cache policy. Treat benchmark cost as a no-hit baseline unless the recipe says otherwise.',
     relatedTerms: ['kv-cache', 'prefill', 'time-to-first-token', 'nvidia-dynamo'],
     articleSlugs: [INFERENCEX_V2, GB200_KIMI],
   },
@@ -455,7 +455,7 @@ const entries = [
     significance:
       'Disaggregation can isolate decode from prompt spikes and improve throughput or service-level predictability. It also adds routing and KV-transfer overhead, so weak networking or immature kernels can make it slower than aggregated serving.',
     benchmarkContext:
-      'An InferenceX disagg label is not a universal optimization switch. Read the prefill and decode world sizes, TP/EP layout, framework, network domain, and interactivity range where the disaggregated frontier actually leads.',
+      'A disagg label identifies the serving layout, not its performance. Judge it from the prefill and decode world sizes, TP/EP layout, framework, network domain, and the interactivity range where its frontier leads.',
     relatedTerms: ['prefill', 'decode', 'kv-cache', 'nvidia-dynamo', 'wide-expert-parallelism'],
     articleSlugs: [INFERENCEX_V2, GB200_R1, GB300_DSV4, GB200_KIMI],
   },
@@ -510,7 +510,7 @@ const entries = [
     significance:
       'EAGLE can raise accepted tokens per target-model step, but its result is workload dependent. Acceptance behavior, draft overhead, model architecture, and batch size determine whether the extra path improves end-to-end serving.',
     benchmarkContext:
-      'Some InferenceX curves label the feature MTP because the model supplies multi-token heads while the engine uses EAGLE-style speculative plumbing. Read the recipe flags and checkpoint details rather than assuming every MTP curve uses the same implementation.',
+      'Some InferenceX curves label the feature MTP because the model supplies multi-token heads while the engine uses EAGLE-style speculative plumbing. The recipe flags and checkpoint details identify the exact implementation.',
     relatedTerms: ['speculative-decoding', 'multi-token-prediction', 'decode', 'sglang'],
     articleSlugs: [B200_GLM5, DEEPSEEK_V4],
   },
@@ -569,7 +569,7 @@ const entries = [
     significance:
       'DP scales aggregate capacity cleanly when weights fit, but replication consumes memory and repeats weight reads. Load balancing and cache locality determine how evenly the replicas are used.',
     benchmarkContext:
-      'A DP count in an InferenceX recipe must be interpreted with TP and EP because modern MoE deployments combine all three dimensions rather than choosing only one.',
+      'Modern MoE deployments combine DP, TP, and EP. Read the DP count together with the other two dimensions.',
     relatedTerms: ['tensor-parallelism', 'expert-parallelism', 'batching', 'mixture-of-experts'],
     articleSlugs: [INFERENCEX_V2, MI355X_DSV4, GB200_KIMI],
   },
@@ -587,7 +587,7 @@ const entries = [
     significance:
       'Wide EP is most effective inside a high-bandwidth scale-up network. Crossing a slower scale-out fabric can turn the same all-to-all traffic into the bottleneck and erase the memory-side benefit.',
     benchmarkContext:
-      'InferenceX uses wide EP in rack-scale disaggregated recipes. Always compare the EP width, decode pool size, and fabric—not just the GPU model printed in the chart legend.',
+      'InferenceX uses wide EP in rack-scale disaggregated recipes. Compare the EP width, decode pool size, fabric, and GPU model together.',
     relatedTerms: [
       'expert-parallelism',
       'mixture-of-experts',
@@ -641,7 +641,7 @@ const entries = [
     aliases: ['scale-up domain', 'scale-out fabric'],
     category: 'Parallelism',
     plainEnglish:
-      'Scale-up is the ultra-fast network inside one tightly connected GPU system; scale-out is the broader network connecting separate servers or racks.',
+      'Scale-up is the ultra-fast network inside one tightly connected GPU system. Scale-out is the broader network connecting separate servers or racks.',
     definition:
       'Scale-up networking connects accelerators inside one tightly coupled system, while scale-out networking connects multiple systems or racks into a larger cluster.',
     explanation:
@@ -649,7 +649,7 @@ const entries = [
     significance:
       'Distributed inference crosses both domains. Frequent TP or EP collectives benefit disproportionately from staying inside scale-up, while coarser request routing and some prefill/decode transfers can tolerate scale-out.',
     benchmarkContext:
-      'The GPU name alone does not describe the communication domain. A B200 in an eight-GPU node and a GB200 NVL72 expose related silicon through radically different scale-up group sizes.',
+      'System topology determines the communication domain. A B200 in an eight-GPU node and a GB200 NVL72 expose related silicon through different scale-up group sizes.',
     relatedTerms: ['nvlink', 'wide-expert-parallelism', 'all-to-all', 'tensor-parallelism'],
     articleSlugs: [INFERENCEX_V2, GB200_R1, GB200_KIMI],
   },
@@ -665,9 +665,9 @@ const entries = [
     explanation:
       'HBM stores model weights, activations, workspace, and KV cache. Capacity determines which models, batch sizes, and parallel layouts fit; bandwidth determines how quickly memory-bound kernels can stream that state.',
     significance:
-      'LLM decode often reads far more data than it computes per token, making HBM bandwidth a primary performance limit. Extra capacity can also unlock a more efficient recipe even when nominal compute remains similar.',
+      'LLM decode often reads far more data than it computes per token, making HBM bandwidth a primary performance limit. Extra capacity can also enable a more efficient recipe even when nominal compute remains similar.',
     benchmarkContext:
-      'InferenceX hardware comparisons separate HBM capacity from bandwidth. GB300’s larger capacity, for example, can fit wider prefill/decode layouts that GB200 cannot, despite similar bandwidth per GPU.',
+      'InferenceX hardware comparisons separate HBM capacity from bandwidth. For example, GB300’s larger capacity fits wider prefill/decode layouts than GB200 despite similar bandwidth per GPU.',
     relatedTerms: ['memory-bandwidth', 'decode', 'kv-cache', 'quantization'],
     articleSlugs: [GB300_DSV4, B200_KIMI, MI355X_DSV4],
   },
@@ -683,7 +683,7 @@ const entries = [
     explanation:
       'A kernel is memory-bandwidth bound when moving its required bytes takes longer than performing its arithmetic. LLM decode frequently enters this regime because each step streams model or expert weights and KV-cache state for relatively little new-token computation.',
     significance:
-      'More tensor-core FLOPS do not speed up a kernel already waiting on memory. Quantization, batching, cache compression, and expert sharding can help by reducing bytes moved or amortizing each weight read across more tokens.',
+      'A kernel waiting on memory gains little from additional tensor-core FLOPS. Quantization, batching, cache compression, and expert sharding help by reducing bytes moved or amortizing each weight read across more tokens.',
     benchmarkContext:
       'Use the shape of the concurrency curve to infer regime changes carefully: low batches may be launch or bandwidth bound, while large batches can raise arithmetic intensity and approach compute saturation.',
     relatedTerms: ['high-bandwidth-memory', 'decode', 'quantization', 'wide-expert-parallelism'],
@@ -701,7 +701,7 @@ const entries = [
     explanation:
       'NVSwitch systems connect multiple NVLink endpoints so collectives can span an eight-GPU server or, in NVL72 products, a 72-GPU rack-scale domain. That bandwidth is distinct from the InfiniBand or Ethernet fabric connecting separate systems.',
     significance:
-      'Large TP and especially wide-EP groups exchange data at every generated token. Keeping those collectives on NVLink can make a rack-scale recipe substantially faster than a similar GPU count spread across scale-out links.',
+      'Large TP and especially wide-EP groups exchange data at every generated token. Keeping those collectives on NVLink can make a rack-scale recipe faster than a similar GPU count spread across scale-out links.',
     benchmarkContext:
       'InferenceX compares both node-level GPUs and NVL72 systems. Interpret the system topology and parallel group width before attributing the entire result to per-GPU compute.',
     relatedTerms: ['scale-up-vs-scale-out', 'all-to-all', 'all-reduce', 'wide-expert-parallelism'],
@@ -719,7 +719,7 @@ const entries = [
     explanation:
       'Lower precision reduces memory footprint and bytes transferred and can use faster low-precision tensor-core paths. A complete recipe must specify what is quantized, the format, scaling method, kernel support, and any higher-precision operations retained for stability.',
     significance:
-      'A nominal format does not guarantee a speedup or preserved quality. Conversion quality, model calibration, outliers, kernel maturity, and hardware support determine the real result.',
+      'A nominal format alone says little about speed or quality. Conversion quality, model calibration, outliers, kernel maturity, and hardware support determine the result.',
     benchmarkContext:
       'InferenceX treats precision as a first-class recipe dimension and pairs throughput measurements with accuracy checks. Compare FP8, FP4, NVFP4, MXFP4, and INT4 only when the model, workload, engine, and quality bar are compatible.',
     relatedTerms: ['fp8', 'fp4', 'nvfp4', 'mxfp4', 'high-bandwidth-memory'],
@@ -739,7 +739,7 @@ const entries = [
     significance:
       'FP8 is broadly supported on recent NVIDIA and AMD accelerators and often serves as a stable low-precision baseline. Actual performance depends on end-to-end kernel coverage; fallback operations can erase theoretical gains.',
     benchmarkContext:
-      'An InferenceX FP8 label describes a recipe, not just a checkpoint filename. Engine, attention backend, KV-cache format, GPU generation, and MTP setting can all change the curve.',
+      'An InferenceX FP8 label covers the complete recipe. The checkpoint filename, engine, attention backend, KV-cache format, GPU generation, and MTP setting can all change the curve.',
     relatedTerms: ['quantization', 'fp4', 'high-bandwidth-memory', 'rocm', 'cuda'],
     articleSlugs: [INFERENCEX_V2, MI355X_GLM5, B200_MINIMAX],
   },
@@ -753,11 +753,11 @@ const entries = [
     definition:
       'FP4 refers to four-bit floating-point formats used for very low-precision model representation and accelerated matrix operations.',
     explanation:
-      'Four-bit formats roughly halve weight storage and traffic again relative to FP8, but their tiny value space requires carefully chosen scaling and hardware-specific kernels. “FP4” may refer to different concrete formats rather than one universal encoding.',
+      'Four-bit formats roughly halve weight storage and traffic again relative to FP8, but their tiny value space requires carefully chosen scaling and hardware-specific kernels. The FP4 label covers several concrete formats.',
     significance:
       'For memory-bound LLM inference, reducing weight bytes can deliver large throughput and capacity gains. Model quality and unsupported operations must be checked because aggressive precision reduction can also introduce error or fallback overhead.',
     benchmarkContext:
-      'InferenceX identifies concrete recipe formats such as NVFP4 and MXFP4 where possible and validates representative configurations. Do not treat every line labeled FP4 as numerically or operationally identical.',
+      'InferenceX identifies concrete recipe formats such as NVFP4 and MXFP4 where possible and validates representative configurations. Each FP4 line still has its own numerical and operational behavior.',
     relatedTerms: ['quantization', 'nvfp4', 'mxfp4', 'fp8', 'memory-bandwidth'],
     articleSlugs: [INFERENCEX_V2, B200_KIMI, MI355X_DSV4, SGLANG_056],
   },
@@ -775,7 +775,7 @@ const entries = [
     significance:
       'NVFP4 can reduce weight bandwidth and activate Blackwell FP4 compute paths, which is especially valuable for large MoE decode. The gain appears only when the serving engine supports the model’s attention, routing, and expert kernels end to end.',
     benchmarkContext:
-      'InferenceX articles compare NVFP4 with FP8 or INT4 at matched interactivity. Those comparisons hold model workload and cost assumptions explicit because a precision label alone is not a fair benchmark.',
+      'InferenceX articles compare NVFP4 with FP8 or INT4 at matched interactivity. Model workload and cost assumptions stay explicit because a precision label alone cannot establish a fair benchmark.',
     relatedTerms: ['fp4', 'quantization', 'fp8', 'memory-bandwidth', 'cuda'],
     articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, SGLANG_056],
   },
@@ -791,7 +791,7 @@ const entries = [
     explanation:
       'Block-level scaling gives four-bit values a useful local dynamic range while keeping storage and movement compact. Hardware and software must agree on the block layout, scale representation, and supported matrix kernels.',
     significance:
-      'MXFP4 is used in AMD and cross-vendor low-precision inference paths. Its practical result depends on checkpoint preparation and kernel coverage rather than the nominal bit width alone.',
+      'MXFP4 is used in AMD and cross-vendor low-precision inference paths. Checkpoint preparation and kernel coverage determine the practical result; bit width alone does not capture it.',
     benchmarkContext:
       'InferenceX records MXFP4 as part of a complete engine and hardware recipe. Comparisons with NVFP4 or FP8 should use the same model, sequence length, quality requirements, and interactivity target.',
     relatedTerms: ['fp4', 'quantization', 'nvfp4', 'rocm', 'memory-bandwidth'],
@@ -851,7 +851,7 @@ const entries = [
     explanation:
       'The sparsity pattern may select local, compressed, indexed, or learned subsets of the context. This reduces work and memory movement for long sequences, but the model architecture and runtime need matching indexer and attention kernels.',
     significance:
-      'Sparse attention can make very long context practical, yet theoretical sparsity does not guarantee fast inference. Index construction, irregular access, kernel fusion, and precision support determine the realized speedup.',
+      'Sparse attention can make very long context practical, but theoretical sparsity alone says little about runtime. Index construction, irregular access, kernel fusion, and precision support determine the realized speedup.',
     benchmarkContext:
       'InferenceX tracks model-specific sparse-attention stacks such as DSA on GLM-5 and DeepSeek-V4. Engine versions and backend choices are part of the result because support has changed rapidly.',
     relatedTerms: ['multi-head-latent-attention', 'kv-cache', 'decode', 'inference-engine'],
@@ -903,9 +903,9 @@ const entries = [
     explanation:
       'Its runtime coordinates continuous batching, distributed workers, attention backends, quantized kernels, and OpenAI-compatible serving. Production recipes may also run vLLM workers beneath an orchestration layer such as NVIDIA Dynamo.',
     significance:
-      'vLLM release and backend changes can alter performance sharply. Model-specific MoE kernels, attention dispatch, wide-EP communication, and scheduler paths all contribute to the final curve.',
+      'vLLM releases and backend changes can alter performance across the curve. Model-specific MoE kernels, attention dispatch, wide-EP communication, and scheduler paths all contribute to the result.',
     benchmarkContext:
-      'InferenceX treats vLLM as one engine option and pins the exact image in each recipe. Compare vLLM results with the same model, precision, workload, and topology rather than treating the engine name as a fixed performance level.',
+      'InferenceX treats vLLM as one engine option and pins the exact image in each recipe. Engine name alone does not set a fixed performance level, so comparisons must match model, precision, workload, and topology.',
     relatedTerms: ['inference-engine', 'nvidia-dynamo', 'kv-cache', 'sglang', 'rocm'],
     articleSlugs: [MI355X_KIMI, GB200_KIMI, B200_MINIMAX, B200_KIMI],
   },
@@ -920,9 +920,9 @@ const entries = [
     explanation:
       'The serving runtime includes continuous batching, prefix-aware scheduling, distributed parallelism, speculative decoding, and multiple attention and MoE kernel backends across NVIDIA and AMD GPUs.',
     significance:
-      'SGLang’s fast-moving release and model-specific kernel work can change throughput substantially on the same hardware. Scheduler overhead matters at low concurrency, while attention, MoE, and communication kernels dominate other regions.',
+      'SGLang releases and model-specific kernel work can change throughput on the same hardware. Scheduler overhead matters at low concurrency, while attention, MoE, and communication kernels dominate other regions.',
     benchmarkContext:
-      'InferenceX continuously reruns pinned SGLang recipes. Version-to-version curves show where a change lands rather than reducing a release to one peak-throughput number.',
+      'InferenceX continuously reruns pinned SGLang recipes. Version-to-version curves show where a change affects performance across the operating range and reveal regressions or gains hidden by one peak point.',
     relatedTerms: ['inference-engine', 'eagle', 'vllm', 'rocm', 'cuda'],
     articleSlugs: [SGLANG_056, B200_GLM5, MI355X_DSV4, MI355X_GLM5, MI355X_QWEN],
   },
@@ -938,7 +938,7 @@ const entries = [
     explanation:
       'It provides NVIDIA-tuned kernels, quantization paths, distributed execution, and model-specific optimizations. It can run as a serving backend and its kernels can also appear inside other engines through integrations.',
     significance:
-      'Tight hardware integration can unlock Blackwell and NVL72 features quickly, but model support and engine compatibility remain version specific. A TensorRT-LLM label therefore needs a concrete container and recipe.',
+      'Tight hardware integration can expose Blackwell and NVL72 features quickly, but model support and engine compatibility remain version specific. A TensorRT-LLM label therefore needs a concrete container and recipe.',
     benchmarkContext:
       'InferenceX includes direct TensorRT-LLM and Dynamo TensorRT-LLM configurations and also tracks cases where SGLang or vLLM uses a TRT-LLM-derived kernel backend.',
     relatedTerms: ['inference-engine', 'cuda', 'nvidia-dynamo', 'nvfp4', 'sglang'],
@@ -950,13 +950,13 @@ const entries = [
     aliases: ['Dynamo'],
     category: 'Software',
     plainEnglish:
-      'NVIDIA Dynamo coordinates many GPU workers—routing requests, moving model memory, and assigning prompt reading and answer generation to the right pools.',
+      'NVIDIA Dynamo coordinates many GPU workers. It routes requests, moves model memory, and assigns prompt reading and answer generation to the right pools.',
     definition:
       'NVIDIA Dynamo is a distributed inference framework that orchestrates request routing, worker pools, KV-cache movement, and disaggregated serving.',
     explanation:
-      'Dynamo can place prefill and decode on separately scaled pools and use engines such as vLLM or TensorRT-LLM as worker runtimes. The orchestration layer handles the data and control path around those engines rather than replacing every kernel inside them.',
+      'Dynamo can place prefill and decode on separately scaled pools and use engines such as vLLM or TensorRT-LLM as worker runtimes. Kernels remain inside those engines while Dynamo handles the surrounding data and control paths.',
     significance:
-      'Rack-scale serving needs more than a fast single-GPU runtime. Routing, cache transfer, topology awareness, and pool sizing determine whether wide parallelism and disaggregation improve end-to-end performance.',
+      'Rack-scale performance depends on the single-GPU runtime plus routing, cache transfer, topology awareness, and pool sizing. Together they determine whether wide parallelism and disaggregation improve end-to-end performance.',
     benchmarkContext:
       'Labels such as Dynamo vLLM and Dynamo TRT-LLM identify both layers of the recipe. InferenceX articles specify the prefill/decode topology because two Dynamo configurations can have very different performance.',
     relatedTerms: [

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -1,0 +1,913 @@
+export const GLOSSARY_CATEGORIES = [
+  'Benchmark metrics',
+  'Serving',
+  'Parallelism',
+  'Hardware',
+  'Numerical precision',
+  'Model architecture',
+  'Software',
+] as const;
+
+export type GlossaryCategory = (typeof GLOSSARY_CATEGORIES)[number];
+
+export interface GlossaryEntry {
+  slug: string;
+  term: string;
+  abbreviation?: string;
+  aliases?: readonly string[];
+  category: GlossaryCategory;
+  definition: string;
+  explanation: string;
+  significance: string;
+  benchmarkContext: string;
+  measurement?: {
+    label: string;
+    value: string;
+  };
+  relatedTerms: readonly string[];
+  articleSlugs: readonly string[];
+}
+
+const INFERENCEMAX = 'inferencemax-open-source-inference-benchmarking';
+const INFERENCEX_V2 = 'inferencex-v2-nvidia-blackwell-vs-amd-vs-hopper';
+const DEEPSEEK_V4 = 'deepseekv4-16t-day-0-to-day-43-performance';
+const GB200_R1 = 'gb200-nvl72-vs-b200-disagg-deepseek-r1-fp4-dynamo-trt';
+const GB300_DSV4 = 'gb300-nvl72-vs-gb200-nvl72-dsv4-pro-vllm-fp4';
+const GB200_KIMI = 'gb200-nvl72-kimi-k2-5-vllm-wide-ep-3x-vs-b200';
+const MI355X_KIMI = 'mi355x-kimi-k2-5-vllm-aiter-7x-speedup';
+const MI355X_DSV4 = 'mi355x-deepseek-v4-pro-sglang-110x-in-26-days';
+const MI355X_GLM5 = 'mi355x-glm5-fp8-sglang-40-cheaper-than-b200';
+const MI355X_QWEN = 'mi355x-qwen3-5-sglang-v0-5-12-up-to-17x';
+const B200_GLM5 = 'b200-glm5-nvfp4-vs-h200-fp8-3-6x-perf-per-dollar';
+const B200_MINIMAX = 'b200-minimax-m2-5-vllm-nvfp4-vs-h100-fp8-perf-per-dollar';
+const B200_KIMI = 'b200-nvfp4-vs-h200-int4-kimi-k2-vllm-perf-per-dollar';
+const SGLANG_056 = 'sglang-0-5-6-b200-deepseek-r1-fp4-up-to-1-8x';
+
+const entries = [
+  {
+    slug: 'ai-inference',
+    term: 'AI inference',
+    aliases: ['LLM inference', 'model serving'],
+    category: 'Serving',
+    definition:
+      'AI inference is the process of running a trained model on new input to produce an output. For a large language model, that usually means processing a prompt and generating tokens.',
+    explanation:
+      'Training changes model weights; inference uses those weights. A production inference system wraps the model in a serving engine that schedules requests, manages memory, batches work, and runs kernels on one or more accelerators. The same model can have radically different inference performance depending on that software and hardware stack.',
+    significance:
+      'Inference is a systems problem as much as a model problem. User experience depends on latency and interactivity, while operator economics depend on throughput, utilization, power, and hardware cost. Optimizing only one of those dimensions can make another worse.',
+    benchmarkContext:
+      'InferenceX benchmarks complete serving recipes rather than quoting only peak chip specifications. Each curve captures a model, engine, numerical precision, parallelism strategy, GPU system, sequence length, and concurrency sweep.',
+    relatedTerms: ['inference-engine', 'prefill', 'decode', 'throughput', 'interactivity'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
+  },
+  {
+    slug: 'inference-engine',
+    term: 'Inference engine',
+    aliases: ['serving engine', 'LLM serving framework'],
+    category: 'Serving',
+    definition:
+      'An inference engine is the software runtime that turns model weights and incoming requests into generated outputs on accelerators.',
+    explanation:
+      'The engine owns request scheduling, batching, KV-cache allocation, distributed execution, kernel selection, and token sampling. vLLM, SGLang, and TensorRT-LLM can run the same model on the same GPU yet produce different curves because their schedulers, kernels, and distributed strategies differ.',
+    significance:
+      'Engine version and configuration can matter as much as GPU choice. A scheduler change, a fused attention kernel, or a corrected model-specific path can move throughput several-fold without any hardware change.',
+    benchmarkContext:
+      'InferenceX records the engine and container image as part of each reproducible recipe. Historical views are therefore useful for separating software gains from silicon gains.',
+    relatedTerms: ['ai-inference', 'vllm', 'sglang', 'tensorrt-llm', 'nvidia-dynamo'],
+    articleSlugs: [SGLANG_056, MI355X_KIMI, INFERENCEX_V2],
+  },
+  {
+    slug: 'throughput',
+    term: 'Throughput',
+    aliases: ['token throughput', 'aggregate throughput'],
+    category: 'Benchmark metrics',
+    definition:
+      'Throughput is the total rate at which an inference system produces tokens across all active requests.',
+    explanation:
+      'InferenceX commonly normalizes throughput as tokens per second per GPU so systems of different sizes can be compared. Higher batching or concurrency often raises aggregate throughput because weight reads and compute are amortized across more requests, but individual users may receive tokens more slowly.',
+    significance:
+      'Maximum throughput alone is not a complete performance claim. A point can lead in tokens per second while operating at interactivity too low for a real-time product. The useful comparison is throughput at a latency or interactivity target appropriate to the workload.',
+    benchmarkContext:
+      'On an InferenceX chart, throughput is read together with interactivity across the full concurrency sweep. The Pareto frontier removes operating points that are worse on both axes.',
+    measurement: { label: 'Typical unit', value: 'tokens/second/GPU (tok/s/GPU)' },
+    relatedTerms: ['interactivity', 'concurrency', 'pareto-frontier', 'iso-interactivity'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, SGLANG_056],
+  },
+  {
+    slug: 'interactivity',
+    term: 'Interactivity',
+    aliases: ['generation speed', 'per-user token rate'],
+    category: 'Benchmark metrics',
+    definition:
+      'Interactivity is the rate at which an individual user receives generated tokens during the decode phase.',
+    explanation:
+      'It is the reciprocal of time per output token when expressed in compatible units. A response at 50 tokens per second per user emits a new token about every 20 milliseconds after generation begins. Interactivity describes streaming responsiveness, not the delay before the first token.',
+    significance:
+      'Different products need different operating points. Voice and interactive coding demand high token rates, while offline summarization can trade interactivity for much more aggregate throughput. Comparing hardware at unmatched interactivity can therefore produce a misleading winner.',
+    benchmarkContext:
+      'InferenceX plots tokens per second per user against throughput or cost. Iso-interactivity tables interpolate each system’s Pareto frontier at the same token rate so the comparison holds user experience constant.',
+    measurement: { label: 'Typical unit', value: 'tokens/second/user (tok/s/user)' },
+    relatedTerms: ['time-per-output-token', 'throughput', 'iso-interactivity', 'latency'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, MI355X_KIMI],
+  },
+  {
+    slug: 'latency',
+    term: 'Latency',
+    aliases: ['response latency', 'inference latency'],
+    category: 'Benchmark metrics',
+    definition:
+      'Latency is elapsed time experienced by a request. In streaming LLM serving it must be decomposed because waiting for the first token and waiting between later tokens are different behaviors.',
+    explanation:
+      'Time to first token captures queueing and prefill delay. Time per output token captures decode cadence after streaming starts. End-to-end latency also depends on output length, so a single aggregate latency number can hide the part users actually notice.',
+    significance:
+      'Low latency can require smaller batches or more parallel resources, which may reduce hardware utilization and increase cost. Good serving design chooses a latency service level and then maximizes throughput within it.',
+    benchmarkContext:
+      'InferenceX emphasizes interactivity for decode responsiveness and exposes workload shape and concurrency so readers do not mistake a high-throughput batch point for a low-latency serving point.',
+    relatedTerms: ['time-to-first-token', 'time-per-output-token', 'interactivity', 'concurrency'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
+  },
+  {
+    slug: 'time-to-first-token',
+    term: 'Time to first token',
+    abbreviation: 'TTFT',
+    category: 'Benchmark metrics',
+    definition:
+      'Time to first token is the delay from submitting a request until the first generated token is returned.',
+    explanation:
+      'TTFT includes queueing, prompt processing, and any routing or KV-cache transfer before decode begins. Longer prompts generally increase prefill work, while overloaded schedulers can add queueing even when the model computation itself is unchanged.',
+    significance:
+      'Users interpret TTFT as how quickly the system begins responding. A system can stream tokens quickly after startup yet still feel slow if requests wait in a queue or prefill competes with decode work.',
+    benchmarkContext:
+      'Read TTFT alongside input sequence length, concurrency, and whether prefill is disaggregated. Those details explain why two recipes with similar decode interactivity may begin responses at different speeds.',
+    measurement: { label: 'Typical unit', value: 'milliseconds or seconds' },
+    relatedTerms: ['prefill', 'latency', 'time-per-output-token', 'disaggregated-inference'],
+    articleSlugs: [INFERENCEX_V2, INFERENCEMAX],
+  },
+  {
+    slug: 'time-per-output-token',
+    term: 'Time per output token',
+    abbreviation: 'TPOT',
+    aliases: ['inter-token latency', 'ITL'],
+    category: 'Benchmark metrics',
+    definition:
+      'Time per output token is the average delay between generated tokens after the first token has arrived.',
+    explanation:
+      'TPOT measures the decode cadence of a streaming response. Ignoring unit conversion, it is the inverse of per-user token rate: 20 ms per token corresponds to about 50 tokens per second per user.',
+    significance:
+      'TPOT isolates the part of latency that controls how fluid a streamed answer feels. It normally worsens as more requests share the system, even while aggregate throughput rises.',
+    benchmarkContext:
+      'InferenceX often presents the reciprocal measure, tok/s/user, because higher is visually better. Recipe tables may include TPOT directly, especially when comparing scheduler or kernel changes at matched concurrency.',
+    measurement: { label: 'Relationship', value: 'interactivity ≈ 1000 / TPOT(ms)' },
+    relatedTerms: ['interactivity', 'time-to-first-token', 'decode', 'concurrency'],
+    articleSlugs: [INFERENCEX_V2, SGLANG_056, MI355X_GLM5],
+  },
+  {
+    slug: 'concurrency',
+    term: 'Concurrency',
+    aliases: ['concurrent requests', 'batch concurrency'],
+    category: 'Benchmark metrics',
+    definition:
+      'Concurrency is the number of requests being served at the same time during a benchmark or deployment.',
+    explanation:
+      'Raising concurrency gives the scheduler more work to batch, which can improve accelerator utilization and aggregate throughput. The tradeoff is that each request receives a smaller share of compute and memory bandwidth, so interactivity usually falls.',
+    significance:
+      'A single concurrency value reveals only one operating point. Production traffic changes over time, and a recipe that looks best at low concurrency may be overtaken when batches become large or communication begins to dominate.',
+    benchmarkContext:
+      'InferenceX sweeps concurrency to build a throughput–interactivity curve. Labels on the curve identify the request count behind each point and expose where a configuration saturates or collapses.',
+    relatedTerms: ['throughput', 'interactivity', 'batching', 'pareto-frontier'],
+    articleSlugs: [SGLANG_056, GB200_KIMI, MI355X_QWEN],
+  },
+  {
+    slug: 'batching',
+    term: 'Batching',
+    aliases: ['continuous batching', 'dynamic batching'],
+    category: 'Serving',
+    definition:
+      'Batching groups work from multiple requests so an accelerator can process their tokens together.',
+    explanation:
+      'Large matrix operations use GPUs more efficiently than many tiny operations. Modern serving engines continuously add and remove sequences as requests arrive and finish rather than waiting for a fixed batch to complete. The resulting batch shape changes throughout prefill and decode.',
+    significance:
+      'Batching is the source of the core throughput–latency tradeoff. Larger effective batches amortize weight reads and launch overhead but generally increase the time between tokens for each user.',
+    benchmarkContext:
+      'Concurrency is an input to batching, not a guarantee of a particular kernel batch size. Parallelism, sequence lengths, request completion, and scheduler policy all affect the effective batch observed by the GPU.',
+    relatedTerms: ['concurrency', 'throughput', 'decode', 'interactivity'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, SGLANG_056],
+  },
+  {
+    slug: 'pareto-frontier',
+    term: 'Pareto frontier',
+    aliases: ['performance frontier', 'Pareto-optimal curve'],
+    category: 'Benchmark metrics',
+    definition:
+      'A Pareto frontier contains the operating points for which no other measured point is better on both compared dimensions.',
+    explanation:
+      'For throughput versus interactivity, a point is dominated if another point serves more total tokens and also streams faster to each user. Removing dominated points leaves the efficient boundary of the measured configurations.',
+    significance:
+      'The frontier prevents noisy or poorly tuned points from distorting comparisons and makes the real tradeoff visible. There is still no universal winner along the curve: the best point depends on the user’s minimum interactivity or maximum cost target.',
+    benchmarkContext:
+      'InferenceX connects Pareto-optimal points from a concurrency and configuration sweep. Iso-interactivity comparisons interpolate along those frontiers rather than comparing arbitrarily selected raw points.',
+    relatedTerms: ['throughput', 'interactivity', 'iso-interactivity', 'concurrency'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, MI355X_GLM5],
+  },
+  {
+    slug: 'iso-interactivity',
+    term: 'Iso-interactivity',
+    aliases: ['matched interactivity', 'equal token rate'],
+    category: 'Benchmark metrics',
+    definition: 'Iso-interactivity means comparing systems at the same per-user generation rate.',
+    explanation:
+      'Benchmark runs rarely land at identical tok/s/user values because each recipe has different concurrency points. An iso-interactivity comparison interpolates each Pareto frontier at a shared target and then compares throughput, cost, or efficiency there.',
+    significance:
+      'Holding user experience constant avoids a common benchmark error: declaring a high-throughput system faster when it reaches that throughput only by serving every request more slowly.',
+    benchmarkContext:
+      'InferenceX articles use iso-interactivity tables for hardware, precision, and software comparisons. Values outside a measured frontier are marked unreachable rather than extrapolated beyond observed data.',
+    relatedTerms: ['interactivity', 'pareto-frontier', 'throughput', 'performance-per-dollar'],
+    articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, GB300_DSV4],
+  },
+  {
+    slug: 'input-output-sequence-length',
+    term: 'Input and output sequence length',
+    abbreviation: 'ISL / OSL',
+    aliases: ['prompt length', 'generation length', '8K/1K'],
+    category: 'Benchmark metrics',
+    definition:
+      'Input sequence length is the number of prompt tokens supplied to the model; output sequence length is the number of tokens generated in response.',
+    explanation:
+      'The pair defines the workload shape. An 8K/1K test uses roughly 8,192 input tokens and generates 1,024 output tokens. Long inputs increase prefill work and KV-cache size, while long outputs spend more time in the autoregressive decode loop.',
+    significance:
+      'Results from different sequence lengths are not interchangeable. A configuration tuned for short chat prompts can rank differently on long-context summarization or reasoning because compute, memory capacity, and bandwidth pressure shift.',
+    benchmarkContext:
+      'InferenceX includes ISL and OSL in chart labels and recipe descriptions. Compare systems on the same workload shape before attributing a difference to hardware or software.',
+    relatedTerms: ['prefill', 'decode', 'kv-cache', 'time-to-first-token'],
+    articleSlugs: [INFERENCEMAX, B200_GLM5, GB300_DSV4],
+  },
+  {
+    slug: 'cost-per-million-tokens',
+    term: 'Cost per million tokens',
+    aliases: ['$/M tokens', 'token cost'],
+    category: 'Benchmark metrics',
+    definition:
+      'Cost per million tokens estimates the infrastructure cost of producing one million tokens at a measured operating point.',
+    explanation:
+      'InferenceX derives the metric from hourly total cost of ownership and measured token throughput. It may be reported for total tokens or separated into input and output tokens, so the denominator must be checked before comparing values.',
+    significance:
+      'The metric converts systems performance into serving economics. It still depends on workload shape, interactivity, utilization, cache behavior, and cost assumptions; a low-throughput offline point is not directly comparable to a high-interactivity endpoint.',
+    benchmarkContext:
+      'Cost curves use the same concurrency sweep as throughput curves. At iso-interactivity, lower $/M means the system delivers the same streaming experience with less modeled infrastructure cost.',
+    measurement: {
+      label: 'InferenceX form',
+      value: '$/M = TCO($/GPU-hour) × 1,000,000 / (3600 × tok/s/GPU)',
+    },
+    relatedTerms: [
+      'total-cost-of-ownership',
+      'throughput',
+      'iso-interactivity',
+      'performance-per-dollar',
+    ],
+    articleSlugs: [INFERENCEX_V2, B200_KIMI, B200_GLM5, GB300_DSV4],
+  },
+  {
+    slug: 'performance-per-dollar',
+    term: 'Performance per dollar',
+    aliases: ['perf/$', 'cost efficiency'],
+    category: 'Benchmark metrics',
+    definition:
+      'Performance per dollar expresses how much measured inference work a system delivers for a unit of modeled cost.',
+    explanation:
+      'For a fixed workload and interactivity target, performance per dollar is the inverse of cost per token. A 2× perf/$ advantage means the system can produce about twice as many comparable tokens for the same infrastructure spend.',
+    significance:
+      'Peak chip FLOPS do not determine serving economics by themselves. Memory, networking, software maturity, numerical precision, and achievable utilization all affect the measured output behind the ratio.',
+    benchmarkContext:
+      'InferenceX compares perf/$ at matched interactivity and names the TCO inputs used. Ratios should not be carried across different model, sequence-length, precision, or latency regimes.',
+    relatedTerms: [
+      'cost-per-million-tokens',
+      'total-cost-of-ownership',
+      'iso-interactivity',
+      'throughput',
+    ],
+    articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, MI355X_GLM5],
+  },
+  {
+    slug: 'total-cost-of-ownership',
+    term: 'Total cost of ownership',
+    abbreviation: 'TCO',
+    category: 'Benchmark metrics',
+    definition:
+      'Total cost of ownership is an all-in estimate of the cost to provision and operate computing infrastructure over its useful life.',
+    explanation:
+      'A GPU’s purchase price is only one input. TCO models can include host systems, networking, power delivery, cooling, facilities, financing, depreciation, maintenance, and expected utilization, then normalize the result to cost per GPU-hour.',
+    significance:
+      'Using TCO instead of list price makes cross-system economics more realistic, especially for rack-scale products whose networking and power infrastructure differ. The result remains a model and should be read with its assumptions.',
+    benchmarkContext:
+      'InferenceX combines SemiAnalysis AI Cloud TCO inputs with observed tok/s/GPU. This separates hourly system cost from the software and workload behavior that determines how many tokens that hour produces.',
+    relatedTerms: [
+      'cost-per-million-tokens',
+      'performance-per-dollar',
+      'tokens-per-megawatt',
+      'throughput',
+    ],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, GB200_R1],
+  },
+  {
+    slug: 'tokens-per-megawatt',
+    term: 'Tokens per megawatt',
+    aliases: ['tokens per MW', 'power-normalized throughput'],
+    category: 'Benchmark metrics',
+    definition:
+      'Tokens per megawatt measures useful inference throughput relative to a data center power budget.',
+    explanation:
+      'InferenceX uses all-in provisioned utility power rather than chip thermal design power alone. That broader denominator can include the overhead required to deliver and cool the IT load, making the metric useful for capacity planning at facility scale.',
+    significance:
+      'Power availability is often the binding constraint on new AI deployments. A system that produces more tokens per provisioned megawatt can serve more demand from the same utility allocation even if its individual accelerators draw more power.',
+    benchmarkContext:
+      'Compare tokens/MW at the same model, workload shape, precision, and interactivity. Otherwise a high-throughput low-interactivity point can appear efficient while failing the target user experience.',
+    measurement: { label: 'Typical unit', value: 'tokens/second per provisioned utility MW' },
+    relatedTerms: [
+      'throughput',
+      'interactivity',
+      'total-cost-of-ownership',
+      'performance-per-dollar',
+    ],
+    articleSlugs: [INFERENCEMAX, DEEPSEEK_V4],
+  },
+  {
+    slug: 'prefill',
+    term: 'Prefill',
+    aliases: ['prompt processing', 'context encoding'],
+    category: 'Serving',
+    definition:
+      'Prefill is the first inference phase, in which the model processes the input prompt and populates the KV cache before generation begins.',
+    explanation:
+      'Prompt tokens can be processed in parallel, producing large matrix operations that are usually compute intensive. Prefill cost grows with input length and contributes heavily to time to first token.',
+    significance:
+      'Prefill has a different resource profile from decode. When both share the same workers, large prompt jobs can interrupt decode batches and make streaming latency less predictable.',
+    benchmarkContext:
+      'Disaggregated recipes place prefill on a separately sized GPU pool. When reading a result, check the prefill tensor parallelism, GPU count, input length, and whether KV state must cross a network before decode.',
+    relatedTerms: ['decode', 'kv-cache', 'time-to-first-token', 'disaggregated-inference'],
+    articleSlugs: [INFERENCEX_V2, GB300_DSV4, GB200_KIMI],
+  },
+  {
+    slug: 'decode',
+    term: 'Decode',
+    aliases: ['autoregressive generation', 'token generation'],
+    category: 'Serving',
+    definition:
+      'Decode is the inference phase that generates output tokens autoregressively, normally one accepted token per sequence per model step.',
+    explanation:
+      'Each new token depends on preceding tokens, so generation cannot be fully parallelized across time. The model repeatedly reads weights and the sequence’s KV cache, which makes decode especially sensitive to memory bandwidth, batching, and communication.',
+    significance:
+      'Decode controls streaming interactivity and often dominates the cost of long outputs. Techniques such as speculative decoding, MTP, quantization, and wide expert parallelism aim to reduce the work or time required per accepted token.',
+    benchmarkContext:
+      'InferenceX decode performance appears as tok/s/user and aggregate tok/s/GPU across concurrency. Output sequence length, batch shape, precision, and parallelism must match for a fair comparison.',
+    relatedTerms: ['prefill', 'time-per-output-token', 'kv-cache', 'speculative-decoding'],
+    articleSlugs: [INFERENCEX_V2, GB300_DSV4, SGLANG_056],
+  },
+  {
+    slug: 'kv-cache',
+    term: 'KV cache',
+    aliases: ['key-value cache', 'attention cache'],
+    category: 'Serving',
+    definition:
+      'The KV cache stores attention key and value states for tokens already processed so the model does not recompute them at every decode step.',
+    explanation:
+      'The cache grows with sequence length, batch size, layer count, and the number and width of stored attention heads. During decode it is repeatedly read from accelerator memory, so both capacity and bandwidth matter.',
+    significance:
+      'KV-cache pressure limits concurrency and long-context serving. Cache quantization, paged allocation, latent attention, prefix reuse, and disaggregated transfer systems all target its capacity or movement cost.',
+    benchmarkContext:
+      'InferenceX disables prefix caching for random-data comparisons unless a recipe states otherwise. That keeps unrelated requests from receiving artificial cache hits and makes raw serving stacks easier to compare.',
+    relatedTerms: [
+      'prefill',
+      'decode',
+      'prefix-caching',
+      'multi-head-latent-attention',
+      'high-bandwidth-memory',
+    ],
+    articleSlugs: [INFERENCEX_V2, MI355X_KIMI, SGLANG_056],
+  },
+  {
+    slug: 'prefix-caching',
+    term: 'Prefix caching',
+    aliases: ['prompt caching', 'automatic prefix caching'],
+    category: 'Serving',
+    definition:
+      'Prefix caching reuses KV-cache state when multiple requests begin with the same token sequence.',
+    explanation:
+      'A repeated system prompt, shared document, or common conversation prefix does not need to be prefetched again if its cached states remain available. A cache hit can sharply reduce prompt computation and time to first token.',
+    significance:
+      'Production workloads with repeated prefixes may outperform synthetic random-token benchmarks. The benefit depends on hit rate, cache capacity, eviction policy, and whether requests route to workers that hold the needed state.',
+    benchmarkContext:
+      'InferenceX generally disables prefix caching on random datasets because accidental reuse would measure the cache policy rather than full prompt processing. Treat benchmark cost as a no-hit baseline unless the recipe says otherwise.',
+    relatedTerms: ['kv-cache', 'prefill', 'time-to-first-token', 'nvidia-dynamo'],
+    articleSlugs: [INFERENCEX_V2, GB200_KIMI],
+  },
+  {
+    slug: 'disaggregated-inference',
+    term: 'Disaggregated inference',
+    abbreviation: 'PD disaggregation',
+    aliases: ['disaggregated prefill', 'disagg'],
+    category: 'Serving',
+    definition:
+      'Disaggregated inference runs prefill and decode on separate worker pools and transfers request state between them.',
+    explanation:
+      'Prefill is usually compute heavy, while decode is often memory-bandwidth and communication heavy. Separating them lets each pool use different GPU counts, parallelism, batch policy, and scaling behavior instead of compromising on one shared configuration.',
+    significance:
+      'Disaggregation can isolate decode from prompt spikes and improve throughput or service-level predictability. It also adds routing and KV-transfer overhead, so weak networking or immature kernels can make it slower than aggregated serving.',
+    benchmarkContext:
+      'An InferenceX disagg label is not a universal optimization switch. Read the prefill and decode world sizes, TP/EP layout, framework, network domain, and interactivity range where the disaggregated frontier actually leads.',
+    relatedTerms: ['prefill', 'decode', 'kv-cache', 'nvidia-dynamo', 'wide-expert-parallelism'],
+    articleSlugs: [INFERENCEX_V2, GB200_R1, GB300_DSV4, GB200_KIMI],
+  },
+  {
+    slug: 'speculative-decoding',
+    term: 'Speculative decoding',
+    aliases: ['spec decode', 'draft-and-verify decoding'],
+    category: 'Serving',
+    definition:
+      'Speculative decoding proposes several future tokens cheaply and verifies them together with the target model, reducing the number of expensive serial decode steps.',
+    explanation:
+      'A draft model or built-in prediction heads generate candidates. The target model evaluates those candidates in a batched verification pass and accepts the valid prefix without changing the target distribution when the algorithm is implemented exactly.',
+    significance:
+      'The speedup depends on how many draft tokens are accepted and on the cost of drafting and verification. Dense and MoE models can behave differently because verifying several positions may activate more expert weights.',
+    benchmarkContext:
+      'Compare speculative recipes at realistic acceptance rates and verify model quality. InferenceX distinguishes MTP-enabled and disabled curves because the benefit changes across concurrency and interactivity.',
+    relatedTerms: ['multi-token-prediction', 'decode', 'batching', 'mixture-of-experts'],
+    articleSlugs: [INFERENCEX_V2, DEEPSEEK_V4, B200_GLM5],
+  },
+  {
+    slug: 'multi-token-prediction',
+    term: 'Multi-token prediction',
+    abbreviation: 'MTP',
+    aliases: ['multi-token prediction heads'],
+    category: 'Serving',
+    definition:
+      'Multi-token prediction uses auxiliary heads trained with the model to propose multiple future tokens for speculative verification.',
+    explanation:
+      'Unlike a separate draft model, MTP proposals come from the target model’s own representation. This can improve proposal alignment and simplify deployment, but it requires a checkpoint trained with compatible MTP modules and engine support for the verification path.',
+    significance:
+      'MTP can exchange otherwise underused compute for fewer memory-bound decode steps. Gains are largest when draft acceptance is high and verification fits into available compute; at large batches the extra work may provide less benefit.',
+    benchmarkContext:
+      'InferenceX reports MTP as a recipe dimension. Acceptance rate or acceptance length, workload distribution, numerical quality checks, and matched interactivity all matter when translating a benchmark gain to production.',
+    relatedTerms: ['speculative-decoding', 'decode', 'interactivity', 'eagle'],
+    articleSlugs: [INFERENCEX_V2, DEEPSEEK_V4, B200_GLM5, MI355X_GLM5],
+  },
+  {
+    slug: 'eagle',
+    term: 'EAGLE',
+    aliases: ['EAGLE speculative decoding', 'EAGLE-3'],
+    category: 'Serving',
+    definition:
+      'EAGLE is a family of speculative-decoding methods that predicts draft continuations from features associated with the target language model and then verifies them with the target model.',
+    explanation:
+      'Serving frameworks expose EAGLE through settings such as the number of speculative steps, draft tokens, and candidate width. Model checkpoints and draft components must match the engine implementation.',
+    significance:
+      'EAGLE can raise accepted tokens per target-model step, but its result is workload dependent. Acceptance behavior, draft overhead, model architecture, and batch size determine whether the extra path improves end-to-end serving.',
+    benchmarkContext:
+      'Some InferenceX curves label the feature MTP because the model supplies multi-token heads while the engine uses EAGLE-style speculative plumbing. Read the recipe flags and checkpoint details rather than assuming every MTP curve uses the same implementation.',
+    relatedTerms: ['speculative-decoding', 'multi-token-prediction', 'decode', 'sglang'],
+    articleSlugs: [B200_GLM5, DEEPSEEK_V4],
+  },
+  {
+    slug: 'tensor-parallelism',
+    term: 'Tensor parallelism',
+    abbreviation: 'TP',
+    category: 'Parallelism',
+    definition:
+      'Tensor parallelism shards individual tensor operations and model weight matrices across multiple accelerators.',
+    explanation:
+      'Each layer executes cooperatively across ranks. Partial results must be combined with collective communication, commonly all-reduce operations after parallel matrix multiplications.',
+    significance:
+      'TP lets a model fit across devices and can improve low-batch interactivity by pooling compute and memory bandwidth. Communication occurs frequently, so scaling eventually runs into the bandwidth and latency of the interconnect.',
+    benchmarkContext:
+      'InferenceX recipe labels such as TP=4 or TP=8 state how many ranks participate in each tensor-parallel group. Compare TP together with EP, DP, node count, and network domain.',
+    relatedTerms: ['expert-parallelism', 'data-parallelism', 'all-reduce', 'nvlink'],
+    articleSlugs: [INFERENCEX_V2, SGLANG_056, MI355X_QWEN],
+  },
+  {
+    slug: 'expert-parallelism',
+    term: 'Expert parallelism',
+    abbreviation: 'EP',
+    category: 'Parallelism',
+    definition:
+      'Expert parallelism distributes the experts of a mixture-of-experts model across accelerators and routes tokens to the ranks holding their selected experts.',
+    explanation:
+      'MoE layers activate only a subset of experts for each token. EP exploits that sparsity so every GPU need not store or compute every expert, but it introduces dispatch and combine all-to-all communication around each MoE layer.',
+    significance:
+      'Wider EP reduces the expert-weight footprint per GPU and can improve decode batching and capacity. Its benefit depends on balanced routing and an interconnect fast enough to move tokens among ranks.',
+    benchmarkContext:
+      'InferenceX reports EP width as part of distributed recipes. NVL72 systems can keep much wider groups inside the NVLink scale-up domain than conventional eight-GPU nodes.',
+    relatedTerms: [
+      'mixture-of-experts',
+      'wide-expert-parallelism',
+      'all-to-all',
+      'tensor-parallelism',
+    ],
+    articleSlugs: [INFERENCEX_V2, GB200_R1, GB200_KIMI],
+  },
+  {
+    slug: 'data-parallelism',
+    term: 'Data parallelism',
+    abbreviation: 'DP',
+    category: 'Parallelism',
+    definition:
+      'Data parallelism runs replicated model or layer groups on multiple ranks and distributes requests or tokens among those replicas.',
+    explanation:
+      'Classic DP duplicates the complete model. In LLM serving, hybrid forms such as data-parallel attention can replicate attention while expert weights use a different sharding strategy. Each replica handles separate work with less per-layer synchronization than TP.',
+    significance:
+      'DP scales aggregate capacity cleanly when weights fit, but replication consumes memory and repeats weight reads. Load balancing and cache locality determine how evenly the replicas are used.',
+    benchmarkContext:
+      'A DP count in an InferenceX recipe must be interpreted with TP and EP because modern MoE deployments combine all three dimensions rather than choosing only one.',
+    relatedTerms: ['tensor-parallelism', 'expert-parallelism', 'batching', 'mixture-of-experts'],
+    articleSlugs: [INFERENCEX_V2, MI355X_DSV4, GB200_KIMI],
+  },
+  {
+    slug: 'wide-expert-parallelism',
+    term: 'Wide expert parallelism',
+    abbreviation: 'Wide EP',
+    category: 'Parallelism',
+    definition:
+      'Wide expert parallelism uses a large number of accelerator ranks for the expert-parallel group of a mixture-of-experts model.',
+    explanation:
+      'Spreading hundreds of experts across more ranks reduces the number of expert weights stored and streamed by each GPU. Tokens from a larger peer group can also form more efficient expert batches, while dispatch and combine traffic grows across the group.',
+    significance:
+      'Wide EP is most effective inside a high-bandwidth scale-up network. Crossing a slower scale-out fabric can turn the same all-to-all traffic into the bottleneck and erase the memory-side benefit.',
+    benchmarkContext:
+      'InferenceX uses wide EP in rack-scale disaggregated recipes. Always compare the EP width, decode pool size, and fabric—not just the GPU model printed in the chart legend.',
+    relatedTerms: [
+      'expert-parallelism',
+      'mixture-of-experts',
+      'all-to-all',
+      'scale-up-vs-scale-out',
+    ],
+    articleSlugs: [GB200_KIMI, GB200_R1, INFERENCEX_V2, GB300_DSV4],
+  },
+  {
+    slug: 'all-reduce',
+    term: 'All-reduce',
+    category: 'Parallelism',
+    definition:
+      'All-reduce is a collective communication operation that combines values from every participating rank and returns the reduced result to every rank.',
+    explanation:
+      'Tensor-parallel layers use all-reduce to assemble partial matrix-operation results. The collective may sum or otherwise reduce values while moving data through an optimized ring, tree, or fabric-specific algorithm.',
+    significance:
+      'Because TP can require collectives at many layers for every generated token, all-reduce latency and bandwidth set a hard scaling limit. Small decode batches are especially sensitive to fixed communication latency.',
+    benchmarkContext:
+      'A higher TP width can add compute and memory bandwidth but also expands the collective group. Results must show whether the interconnect turns that larger group into a net gain.',
+    relatedTerms: ['tensor-parallelism', 'all-to-all', 'nvlink', 'scale-up-vs-scale-out'],
+    articleSlugs: [INFERENCEX_V2],
+  },
+  {
+    slug: 'all-to-all',
+    term: 'All-to-all',
+    category: 'Parallelism',
+    definition:
+      'All-to-all is a collective pattern in which every participating rank sends distinct data to every other rank.',
+    explanation:
+      'Expert-parallel MoE layers use an all-to-all dispatch to send tokens to their selected experts and another combine operation to return expert outputs. Traffic volume and imbalance depend on token routing.',
+    significance:
+      'All-to-all is more demanding than simple point-to-point transfers and can become network bound as EP grows. Specialized kernels overlap communication with compute and optimize token packing to keep the fabric busy.',
+    benchmarkContext:
+      'Rack-scale NVLink can keep wide-EP all-to-all traffic inside the scale-up domain. Multi-node recipes over InfiniBand or RoCE must overcome a much lower per-GPU scale-out bandwidth.',
+    relatedTerms: [
+      'expert-parallelism',
+      'wide-expert-parallelism',
+      'all-reduce',
+      'scale-up-vs-scale-out',
+    ],
+    articleSlugs: [GB200_R1, GB200_KIMI, INFERENCEX_V2],
+  },
+  {
+    slug: 'scale-up-vs-scale-out',
+    term: 'Scale-up vs. scale-out networking',
+    aliases: ['scale-up domain', 'scale-out fabric'],
+    category: 'Parallelism',
+    definition:
+      'Scale-up networking connects accelerators inside one tightly coupled system, while scale-out networking connects multiple systems or racks into a larger cluster.',
+    explanation:
+      'Scale-up fabrics such as NVLink offer very high per-GPU bandwidth and low latency for fine-grained collectives. Scale-out fabrics such as InfiniBand or RoCE reach more machines but usually provide much less bandwidth per accelerator.',
+    significance:
+      'Distributed inference crosses both domains. Frequent TP or EP collectives benefit disproportionately from staying inside scale-up, while coarser request routing and some prefill/decode transfers can tolerate scale-out.',
+    benchmarkContext:
+      'The GPU name alone does not describe the communication domain. A B200 in an eight-GPU node and a GB200 NVL72 expose related silicon through radically different scale-up group sizes.',
+    relatedTerms: ['nvlink', 'wide-expert-parallelism', 'all-to-all', 'tensor-parallelism'],
+    articleSlugs: [INFERENCEX_V2, GB200_R1, GB200_KIMI],
+  },
+  {
+    slug: 'high-bandwidth-memory',
+    term: 'High-bandwidth memory',
+    abbreviation: 'HBM',
+    category: 'Hardware',
+    definition:
+      'High-bandwidth memory is stacked memory placed close to an accelerator to provide much higher bandwidth than conventional server memory.',
+    explanation:
+      'HBM stores model weights, activations, workspace, and KV cache. Capacity determines which models, batch sizes, and parallel layouts fit; bandwidth determines how quickly memory-bound kernels can stream that state.',
+    significance:
+      'LLM decode often reads far more data than it computes per token, making HBM bandwidth a primary performance limit. Extra capacity can also unlock a more efficient recipe even when nominal compute remains similar.',
+    benchmarkContext:
+      'InferenceX hardware comparisons separate HBM capacity from bandwidth. GB300’s larger capacity, for example, can fit wider prefill/decode layouts that GB200 cannot, despite similar bandwidth per GPU.',
+    relatedTerms: ['memory-bandwidth', 'decode', 'kv-cache', 'quantization'],
+    articleSlugs: [GB300_DSV4, B200_KIMI, MI355X_DSV4],
+  },
+  {
+    slug: 'memory-bandwidth',
+    term: 'Memory bandwidth',
+    aliases: ['HBM bandwidth'],
+    category: 'Hardware',
+    definition:
+      'Memory bandwidth is the rate at which data can be transferred between accelerator memory and the compute units.',
+    explanation:
+      'A kernel is memory-bandwidth bound when moving its required bytes takes longer than performing its arithmetic. LLM decode frequently enters this regime because each step streams model or expert weights and KV-cache state for relatively little new-token computation.',
+    significance:
+      'More tensor-core FLOPS do not speed up a kernel already waiting on memory. Quantization, batching, cache compression, and expert sharding can help by reducing bytes moved or amortizing each weight read across more tokens.',
+    benchmarkContext:
+      'Use the shape of the concurrency curve to infer regime changes carefully: low batches may be launch or bandwidth bound, while large batches can raise arithmetic intensity and approach compute saturation.',
+    relatedTerms: ['high-bandwidth-memory', 'decode', 'quantization', 'wide-expert-parallelism'],
+    articleSlugs: [B200_KIMI, GB300_DSV4, SGLANG_056],
+  },
+  {
+    slug: 'nvlink',
+    term: 'NVLink',
+    aliases: ['NVIDIA NVLink'],
+    category: 'Hardware',
+    definition:
+      'NVLink is NVIDIA’s high-bandwidth accelerator interconnect for moving data directly among GPUs within a scale-up domain.',
+    explanation:
+      'NVSwitch systems connect multiple NVLink endpoints so collectives can span an eight-GPU server or, in NVL72 products, a 72-GPU rack-scale domain. That bandwidth is distinct from the InfiniBand or Ethernet fabric connecting separate systems.',
+    significance:
+      'Large TP and especially wide-EP groups exchange data at every generated token. Keeping those collectives on NVLink can make a rack-scale recipe substantially faster than a similar GPU count spread across scale-out links.',
+    benchmarkContext:
+      'InferenceX compares both node-level GPUs and NVL72 systems. Interpret the system topology and parallel group width before attributing the entire result to per-GPU compute.',
+    relatedTerms: ['scale-up-vs-scale-out', 'all-to-all', 'all-reduce', 'wide-expert-parallelism'],
+    articleSlugs: [GB200_R1, GB200_KIMI, INFERENCEX_V2],
+  },
+  {
+    slug: 'quantization',
+    term: 'Quantization',
+    aliases: ['low-precision inference', 'weight quantization'],
+    category: 'Numerical precision',
+    definition:
+      'Quantization represents model weights, activations, or cache values with fewer bits than a higher-precision baseline.',
+    explanation:
+      'Lower precision reduces memory footprint and bytes transferred and can use faster low-precision tensor-core paths. A complete recipe must specify what is quantized, the format, scaling method, kernel support, and any higher-precision operations retained for stability.',
+    significance:
+      'A nominal format does not guarantee a speedup or preserved quality. Conversion quality, model calibration, outliers, kernel maturity, and hardware support determine the real result.',
+    benchmarkContext:
+      'InferenceX treats precision as a first-class recipe dimension and pairs throughput measurements with accuracy checks. Compare FP8, FP4, NVFP4, MXFP4, and INT4 only when the model, workload, engine, and quality bar are compatible.',
+    relatedTerms: ['fp8', 'fp4', 'nvfp4', 'mxfp4', 'high-bandwidth-memory'],
+    articleSlugs: [INFERENCEX_V2, B200_KIMI, B200_GLM5, MI355X_DSV4],
+  },
+  {
+    slug: 'fp8',
+    term: 'FP8',
+    aliases: ['8-bit floating point'],
+    category: 'Numerical precision',
+    definition:
+      'FP8 is a family of eight-bit floating-point formats used to reduce model storage, memory traffic, and compute cost relative to FP16 or BF16.',
+    explanation:
+      'Common FP8 encodings trade exponent range against mantissa precision. Serving recipes may use FP8 for weights, activations, KV cache, or selected kernels, with scaling metadata and higher-precision accumulation where needed.',
+    significance:
+      'FP8 is broadly supported on recent NVIDIA and AMD accelerators and often serves as a stable low-precision baseline. Actual performance depends on end-to-end kernel coverage; fallback operations can erase theoretical gains.',
+    benchmarkContext:
+      'An InferenceX FP8 label describes a recipe, not just a checkpoint filename. Engine, attention backend, KV-cache format, GPU generation, and MTP setting can all change the curve.',
+    relatedTerms: ['quantization', 'fp4', 'high-bandwidth-memory', 'rocm', 'cuda'],
+    articleSlugs: [INFERENCEX_V2, MI355X_GLM5, B200_MINIMAX],
+  },
+  {
+    slug: 'fp4',
+    term: 'FP4',
+    aliases: ['4-bit floating point'],
+    category: 'Numerical precision',
+    definition:
+      'FP4 refers to four-bit floating-point formats used for very low-precision model representation and accelerated matrix operations.',
+    explanation:
+      'Four-bit formats roughly halve weight storage and traffic again relative to FP8, but their tiny value space requires carefully chosen scaling and hardware-specific kernels. “FP4” may refer to different concrete formats rather than one universal encoding.',
+    significance:
+      'For memory-bound LLM inference, reducing weight bytes can deliver large throughput and capacity gains. Model quality and unsupported operations must be checked because aggressive precision reduction can also introduce error or fallback overhead.',
+    benchmarkContext:
+      'InferenceX identifies concrete recipe formats such as NVFP4 and MXFP4 where possible and validates representative configurations. Do not treat every line labeled FP4 as numerically or operationally identical.',
+    relatedTerms: ['quantization', 'nvfp4', 'mxfp4', 'fp8', 'memory-bandwidth'],
+    articleSlugs: [INFERENCEX_V2, B200_KIMI, MI355X_DSV4, SGLANG_056],
+  },
+  {
+    slug: 'nvfp4',
+    term: 'NVFP4',
+    aliases: ['NVIDIA FP4'],
+    category: 'Numerical precision',
+    definition:
+      'NVFP4 is NVIDIA’s block-scaled four-bit floating-point quantization format for Blackwell-generation tensor-core inference.',
+    explanation:
+      'Weights and activations are represented with compact FP4 values plus scaling information for small blocks. The exact checkpoint, scaling recipe, and kernel path determine both model quality and achieved throughput.',
+    significance:
+      'NVFP4 can reduce weight bandwidth and activate Blackwell FP4 compute paths, which is especially valuable for large MoE decode. The gain appears only when the serving engine supports the model’s attention, routing, and expert kernels end to end.',
+    benchmarkContext:
+      'InferenceX articles compare NVFP4 with FP8 or INT4 at matched interactivity. Those comparisons hold model workload and cost assumptions explicit because a precision label alone is not a fair benchmark.',
+    relatedTerms: ['fp4', 'quantization', 'fp8', 'memory-bandwidth', 'cuda'],
+    articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, SGLANG_056],
+  },
+  {
+    slug: 'mxfp4',
+    term: 'MXFP4',
+    aliases: ['microscaling FP4', 'OCP MX FP4'],
+    category: 'Numerical precision',
+    definition:
+      'MXFP4 is a microscaling four-bit floating-point format that shares a scale across small blocks of values.',
+    explanation:
+      'Block-level scaling gives four-bit values a useful local dynamic range while keeping storage and movement compact. Hardware and software must agree on the block layout, scale representation, and supported matrix kernels.',
+    significance:
+      'MXFP4 is used in AMD and cross-vendor low-precision inference paths. Its practical result depends on checkpoint preparation and kernel coverage rather than the nominal bit width alone.',
+    benchmarkContext:
+      'InferenceX records MXFP4 as part of a complete engine and hardware recipe. Comparisons with NVFP4 or FP8 should use the same model, sequence length, quality requirements, and interactivity target.',
+    relatedTerms: ['fp4', 'quantization', 'nvfp4', 'rocm', 'memory-bandwidth'],
+    articleSlugs: [MI355X_KIMI, INFERENCEX_V2],
+  },
+  {
+    slug: 'mixture-of-experts',
+    term: 'Mixture of experts',
+    abbreviation: 'MoE',
+    aliases: ['sparse MoE'],
+    category: 'Model architecture',
+    definition:
+      'A mixture-of-experts model contains many feed-forward expert networks but routes each token through only a selected subset.',
+    explanation:
+      'A router scores experts for each token, and top-k routing activates the chosen experts plus any shared experts. This lets total parameter count grow much larger than the computation used for one token.',
+    significance:
+      'MoE inference trades arithmetic sparsity for systems complexity. Expert weights still consume memory, routing can become imbalanced, and distributed deployments require all-to-all communication for dispatch and combine.',
+    benchmarkContext:
+      'InferenceX covers models with hundreds of experts and reports both total and activated parameters where relevant. TP, EP, DP, precision, and network topology determine whether MoE sparsity becomes a real serving advantage.',
+    relatedTerms: [
+      'expert-parallelism',
+      'wide-expert-parallelism',
+      'all-to-all',
+      'speculative-decoding',
+    ],
+    articleSlugs: [GB300_DSV4, B200_KIMI, B200_MINIMAX, MI355X_KIMI],
+  },
+  {
+    slug: 'multi-head-latent-attention',
+    term: 'Multi-head latent attention',
+    abbreviation: 'MLA',
+    category: 'Model architecture',
+    definition:
+      'Multi-head latent attention compresses attention key and value state into a lower-dimensional latent representation to reduce KV-cache size and memory traffic.',
+    explanation:
+      'Instead of storing full per-head keys and values for every prior token, MLA stores compressed state and reconstructs or consumes the needed representations through model-specific projections. Implementations require specialized attention kernels.',
+    significance:
+      'Reducing KV-cache bytes increases feasible context length and concurrency and can lower decode bandwidth pressure. Kernel shape support and tensor-parallel layout can still create large performance differences.',
+    benchmarkContext:
+      'Several DeepSeek-derived models in InferenceX use MLA. Articles track fixes where an attention backend handled one heads-per-rank shape efficiently but failed or fell back on another.',
+    relatedTerms: ['kv-cache', 'decode', 'sparse-attention', 'tensor-parallelism'],
+    articleSlugs: [MI355X_KIMI, B200_GLM5, MI355X_DSV4, SGLANG_056],
+  },
+  {
+    slug: 'sparse-attention',
+    term: 'Sparse attention',
+    aliases: ['DeepSeek Sparse Attention', 'DSA'],
+    category: 'Model architecture',
+    definition:
+      'Sparse attention limits which prior tokens each query attends to instead of computing attention over the entire available context.',
+    explanation:
+      'The sparsity pattern may select local, compressed, indexed, or learned subsets of the context. This reduces work and memory movement for long sequences, but the model architecture and runtime need matching indexer and attention kernels.',
+    significance:
+      'Sparse attention can make very long context practical, yet theoretical sparsity does not guarantee fast inference. Index construction, irregular access, kernel fusion, and precision support determine the realized speedup.',
+    benchmarkContext:
+      'InferenceX tracks model-specific sparse-attention stacks such as DSA on GLM-5 and DeepSeek-V4. Engine versions and backend choices are part of the result because support has changed rapidly.',
+    relatedTerms: ['multi-head-latent-attention', 'kv-cache', 'decode', 'inference-engine'],
+    articleSlugs: [B200_GLM5, MI355X_DSV4, GB300_DSV4],
+  },
+  {
+    slug: 'cuda',
+    term: 'CUDA',
+    aliases: ['NVIDIA CUDA'],
+    category: 'Software',
+    definition:
+      'CUDA is NVIDIA’s GPU computing platform, programming model, compiler toolchain, and library ecosystem.',
+    explanation:
+      'LLM engines use CUDA kernels and libraries for matrix multiplication, attention, collectives, graph capture, memory management, and custom fused operations. Container, driver, CUDA, and GPU architecture versions must be compatible.',
+    significance:
+      'Serving performance depends on the software above the silicon. New kernels, CUDA Graph usage, compiler specialization, and library releases can move the benchmark curve without changing the GPU.',
+    benchmarkContext:
+      'InferenceX recipes pin container images and therefore a concrete CUDA stack. Historical comparisons can isolate the effect of an engine image bump on otherwise identical hardware and configuration.',
+    relatedTerms: ['inference-engine', 'nvfp4', 'nvlink', 'rocm', 'tensorrt-llm'],
+    articleSlugs: [SGLANG_056, B200_GLM5, INFERENCEX_V2],
+  },
+  {
+    slug: 'rocm',
+    term: 'ROCm',
+    aliases: ['AMD ROCm'],
+    category: 'Software',
+    definition:
+      'ROCm is AMD’s open GPU computing software platform, including runtimes, compilers, communication libraries, and optimized math and AI kernels.',
+    explanation:
+      'vLLM and SGLang use ROCm plus AMD-specific libraries and kernel projects to run on Instinct accelerators. Model support depends on compatible attention, MoE, quantization, collective, and graph-execution paths.',
+    significance:
+      'Software maturity can dominate cross-vendor inference results. Rapid kernel and engine work has produced multi-fold gains on unchanged MI355X hardware, while missing paths can leave strong theoretical silicon underused.',
+    benchmarkContext:
+      'InferenceX preserves engine versions and run dates so ROCm improvements can be measured over time. A point-in-time comparison should not be generalized to a later software release.',
+    relatedTerms: ['inference-engine', 'mxfp4', 'cuda', 'vllm', 'sglang'],
+    articleSlugs: [MI355X_KIMI, MI355X_DSV4, MI355X_QWEN, INFERENCEX_V2],
+  },
+  {
+    slug: 'vllm',
+    term: 'vLLM',
+    category: 'Software',
+    definition:
+      'vLLM is an open-source LLM inference and serving engine focused on high-throughput scheduling, memory-efficient KV-cache management, and broad model and hardware support.',
+    explanation:
+      'Its runtime coordinates continuous batching, distributed workers, attention backends, quantized kernels, and OpenAI-compatible serving. Production recipes may also run vLLM workers beneath an orchestration layer such as NVIDIA Dynamo.',
+    significance:
+      'vLLM release and backend changes can alter performance sharply. Model-specific MoE kernels, attention dispatch, wide-EP communication, and scheduler paths all contribute to the final curve.',
+    benchmarkContext:
+      'InferenceX treats vLLM as one engine option and pins the exact image in each recipe. Compare vLLM results with the same model, precision, workload, and topology rather than treating the engine name as a fixed performance level.',
+    relatedTerms: ['inference-engine', 'nvidia-dynamo', 'kv-cache', 'sglang', 'rocm'],
+    articleSlugs: [MI355X_KIMI, GB200_KIMI, B200_MINIMAX, B200_KIMI],
+  },
+  {
+    slug: 'sglang',
+    term: 'SGLang',
+    category: 'Software',
+    definition:
+      'SGLang is an open-source serving engine and language-model programming system optimized for high-performance LLM and multimodal inference.',
+    explanation:
+      'The serving runtime includes continuous batching, prefix-aware scheduling, distributed parallelism, speculative decoding, and multiple attention and MoE kernel backends across NVIDIA and AMD GPUs.',
+    significance:
+      'SGLang’s fast-moving release and model-specific kernel work can change throughput substantially on the same hardware. Scheduler overhead matters at low concurrency, while attention, MoE, and communication kernels dominate other regions.',
+    benchmarkContext:
+      'InferenceX continuously reruns pinned SGLang recipes. Version-to-version curves show where a change lands rather than reducing a release to one peak-throughput number.',
+    relatedTerms: ['inference-engine', 'eagle', 'vllm', 'rocm', 'cuda'],
+    articleSlugs: [SGLANG_056, B200_GLM5, MI355X_DSV4, MI355X_GLM5, MI355X_QWEN],
+  },
+  {
+    slug: 'tensorrt-llm',
+    term: 'TensorRT-LLM',
+    aliases: ['TRT-LLM', 'TRTLLM'],
+    category: 'Software',
+    definition:
+      'TensorRT-LLM is NVIDIA’s inference stack for compiling, optimizing, and serving large language models on NVIDIA GPUs.',
+    explanation:
+      'It provides NVIDIA-tuned kernels, quantization paths, distributed execution, and model-specific optimizations. It can run as a serving backend and its kernels can also appear inside other engines through integrations.',
+    significance:
+      'Tight hardware integration can unlock Blackwell and NVL72 features quickly, but model support and engine compatibility remain version specific. A TensorRT-LLM label therefore needs a concrete container and recipe.',
+    benchmarkContext:
+      'InferenceX includes direct TensorRT-LLM and Dynamo TensorRT-LLM configurations and also tracks cases where SGLang or vLLM uses a TRT-LLM-derived kernel backend.',
+    relatedTerms: ['inference-engine', 'cuda', 'nvidia-dynamo', 'nvfp4', 'sglang'],
+    articleSlugs: [GB200_R1, INFERENCEX_V2, B200_GLM5, B200_MINIMAX],
+  },
+  {
+    slug: 'nvidia-dynamo',
+    term: 'NVIDIA Dynamo',
+    aliases: ['Dynamo'],
+    category: 'Software',
+    definition:
+      'NVIDIA Dynamo is a distributed inference framework that orchestrates request routing, worker pools, KV-cache movement, and disaggregated serving.',
+    explanation:
+      'Dynamo can place prefill and decode on separately scaled pools and use engines such as vLLM or TensorRT-LLM as worker runtimes. The orchestration layer handles the data and control path around those engines rather than replacing every kernel inside them.',
+    significance:
+      'Rack-scale serving needs more than a fast single-GPU runtime. Routing, cache transfer, topology awareness, and pool sizing determine whether wide parallelism and disaggregation improve end-to-end performance.',
+    benchmarkContext:
+      'Labels such as Dynamo vLLM and Dynamo TRT-LLM identify both layers of the recipe. InferenceX articles specify the prefill/decode topology because two Dynamo configurations can have very different performance.',
+    relatedTerms: [
+      'disaggregated-inference',
+      'vllm',
+      'tensorrt-llm',
+      'kv-cache',
+      'wide-expert-parallelism',
+    ],
+    articleSlugs: [GB200_R1, GB300_DSV4, GB200_KIMI, INFERENCEX_V2],
+  },
+] as const satisfies readonly GlossaryEntry[];
+
+export type GlossaryPreview = Pick<
+  GlossaryEntry,
+  'slug' | 'term' | 'abbreviation' | 'aliases' | 'category' | 'definition'
+>;
+
+const entriesBySlug: Readonly<Record<string, GlossaryEntry>> = Object.fromEntries(
+  entries.map((entry) => [entry.slug, entry]),
+);
+
+export function getAllGlossaryEntries(): readonly GlossaryEntry[] {
+  return entries;
+}
+
+export function getGlossaryEntry(slug: string): GlossaryEntry | undefined {
+  return entriesBySlug[slug];
+}
+
+export function getRelatedGlossaryEntries(entry: GlossaryEntry): GlossaryEntry[] {
+  return entry.relatedTerms.flatMap((slug) => {
+    const related = entriesBySlug[slug];
+    return related ? [related] : [];
+  });
+}
+
+export function getAdjacentGlossaryEntries(slug: string): {
+  previous: GlossaryEntry | null;
+  next: GlossaryEntry | null;
+} {
+  const sorted = entries.toSorted((a, b) => a.term.localeCompare(b.term));
+  const index = sorted.findIndex((entry) => entry.slug === slug);
+  if (index === -1) return { previous: null, next: null };
+  return {
+    previous: sorted[index - 1] ?? null,
+    next: sorted[index + 1] ?? null,
+  };
+}

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -56,6 +56,7 @@ export const ZH_MIRRORED_ROUTES: readonly { path: string; exact?: boolean }[] = 
   { path: '/compare-precision' },
   { path: '/compare-spec-decode' },
   { path: '/blog' },
+  { path: '/glossary' },
   { path: '/datasets' },
 ];
 


### PR DESCRIPTION
## Summary
- add searchable English and Simplified Chinese AI inference glossary indexes
- add 48 statically generated term pages per locale with definitions, related concepts, and article sources
- add DefinedTerm structured data, canonical/hreflang metadata, sitemap entries, and internal links
- add translation, relationship, article-coverage, and navigation contract tests

## Verification
- `pnpm typecheck`
- `pnpm exec oxlint <touched files>`
- `vitest run src/lib/glossary.test.ts` (7 tests)
- `pnpm --filter @semianalysisai/inferencex-app build` (1,353 static pages)
- Playwright QA on English and Chinese desktop/mobile routes, search, structured data, and language switching

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new static marketing/content routes and data modules; no auth, payments, or core benchmark data paths. Build surface grows (~1,350 static pages) but behavior is read-only.
> 
> **Overview**
> Adds a **bilingual AI inference glossary** (English and Simplified Chinese) with searchable index pages, static term detail pages, and wiring into navigation and SEO.
> 
> **Glossary content and APIs:** New `glossary` and `glossary-zh` modules define dozens of terms (definitions, plain-language summaries, related terms, and links to blog articles), with Vitest checks for uniqueness, article coverage, and Chinese parity.
> 
> **UI:** `GlossaryBrowser` provides client-side search plus category (and letter on EN) filtering. Term pages show structured sections, related terms, linked articles, and prev/next navigation; Chinese routes reuse the same slugs with localized copy and category grouping.
> 
> **Discovery:** Blog intro lines and footer link to the glossary; `sitemap` and `i18n` mirrored routes include `/glossary` and per-slug URLs. Pages emit **DefinedTerm** / **DefinedTermSet** JSON-LD, canonical/hreflang metadata, and Open Graph/Twitter tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93f2209d8c142f7dd96eb83f3f27a9ef42d67b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->