### PR TITLE
Fix large agentic detail charts / 修复大型 agentic 详情图表

### DIFF
--- a/packages/app/src/components/inference/agentic-point/time-series-chart.tsx
+++ b/packages/app/src/components/inference/agentic-point/time-series-chart.tsx
@@ -6,7 +6,7 @@ import type { TimeSeriesPoint } from '@/hooks/api/use-trace-server-metrics';
 
 import { ChartHover, type HoverItem } from './chart-hover';
 import { CHART_PAD, ChartEmpty, fmtCount, fmtSeconds } from './chart-shared';
-import { interpAt, type ChartSeries } from './time-series-math';
+import { interpAt, maxTimeSeriesValue, type ChartSeries } from './time-series-math';
 
 // Historical entry point: the pure data-shaping helpers lived in this module
 // before being extracted; re-export them so both import paths stay valid.
@@ -59,9 +59,9 @@ export function TimeSeriesChart({
     const xMax = Math.max(durationS, 1);
     // Fold reference-line values into the auto max so a ceiling above the data
     // (e.g. KV-cache pool >> working set) still renders inside the plot.
-    const refMax = refLines.length > 0 ? Math.max(...refLines.map((r) => r.value)) : 0;
-    const yMax =
-      yMaxOpt ?? Math.max(1e-9, refMax, ...series.flatMap((s) => s.data.map((d) => d.value)));
+    let refMax = 0;
+    for (const refLine of refLines) refMax = Math.max(refMax, refLine.value);
+    const yMax = yMaxOpt ?? maxTimeSeriesValue(series, Math.max(1e-9, refMax));
     const xScale = (t: number) => PAD.left + (t / xMax) * innerW;
     const yScale = (v: number) => PAD.top + (1 - v / yMax) * innerH;
     return { innerW, innerH, xMax, yMax, xScale, yScale };

--- a/packages/app/src/components/inference/agentic-point/time-series-math.test.ts
+++ b/packages/app/src/components/inference/agentic-point/time-series-math.test.ts
@@ -12,11 +12,44 @@ import {
   cumulativeUniqueInputTokens,
   inflightUniqueTokens,
   interpAt,
+  maxTimeSeriesValue,
   rollingAverage,
   rollingRequestMetric,
   timeRollingAverage,
   toggleThroughputSeries,
 } from './time-series-math';
+
+describe('maxTimeSeriesValue', () => {
+  it('finds the maximum across more samples than browsers accept as function arguments', () => {
+    const series = [
+      {
+        name: 'P90 interactivity',
+        color: '#3b82f6',
+        data: Array.from({ length: 40_000 }, (_, index) => ({ t: index, value: index })),
+      },
+      {
+        name: 'Cumulative P90 interactivity',
+        color: '#10b981',
+        data: Array.from({ length: 40_000 }, (_, index) => ({
+          t: index,
+          value: 80_000 - index,
+        })),
+      },
+    ];
+
+    expect(maxTimeSeriesValue(series, 1e-9)).toBe(80_000);
+  });
+
+  it('keeps the supplied floor for empty and negative-only series', () => {
+    expect(maxTimeSeriesValue([], 1e-9)).toBe(1e-9);
+    expect(
+      maxTimeSeriesValue(
+        [{ name: 'Negative', color: '#000000', data: [{ t: 0, value: -1 }] }],
+        1e-9,
+      ),
+    ).toBe(1e-9);
+  });
+});
 
 const request = (
   endS: number,

--- a/packages/app/src/components/inference/agentic-point/time-series-math.ts
+++ b/packages/app/src/components/inference/agentic-point/time-series-math.ts
@@ -25,6 +25,22 @@ export interface ChartSeries {
   hideFromHover?: boolean;
 }
 
+/**
+ * Find the largest plotted value without spreading the full dataset into a
+ * variadic call. Agentic runs can contain tens of thousands of request samples,
+ * which exceeds browser argument limits when passed to `Math.max(...values)`.
+ */
+export function maxTimeSeriesValue(
+  series: readonly ChartSeries[],
+  initialValue = Number.NEGATIVE_INFINITY,
+): number {
+  let maximum = initialValue;
+  for (const chartSeries of series) {
+    for (const point of chartSeries.data) maximum = Math.max(maximum, point.value);
+  }
+  return maximum;
+}
+
 export type RequestMetric = 'interactivity' | 'ttft' | 'e2e';
 export type RequestPercentile = 'p75' | 'p90';
 export type ThroughputSeriesKey = 'input' | 'decode';

--- a/packages/app/src/components/inference/agentic-point/timeline-rows.ts
+++ b/packages/app/src/components/inference/agentic-point/timeline-rows.ts
@@ -401,7 +401,9 @@ export function buildRequestTimelineRows(
       // Union of primary stream requests for collapsed-view bars. Aux lanes
       // stay separate so their overlap remains visible as parallel work.
       const allReqs: RequestRecord[] = [];
-      for (const reqs of lanes.streams.values()) allReqs.push(...reqs);
+      for (const reqs of lanes.streams.values()) {
+        for (const request of reqs) allReqs.push(request);
+      }
       allReqs.sort((a, b) => a.start - b.start);
       const streamCount = lanes.streams.size;
       rows.push({


### PR DESCRIPTION
## Summary

- replace the agentic time-series chart's unbounded variadic maximum with an iterative scan
- preserve reference-line auto-scaling while avoiding large temporary flattened arrays
- harden collapsed timeline lane merging against the same argument-limit failure class
- add an 80,000-point regression test, larger than the approximately 76,568 values on staging benchmark 434994

## Root cause

The staging detail page passed every request-derived chart value as an individual argument to Math.max. Chrome exceeded its variadic argument limit and raised Maximum call stack size exceeded before rendering the page.

Unofficial-run overlays are unaffected: agentic point-detail pages read ingested benchmark data, and the fix is applied in their shared time-series chart.

## Testing

- pnpm test:unit (all workspace unit tests pass; 2,568 app tests)
- pnpm typecheck
- pnpm lint
- pnpm fmt
- pnpm test:e2e:component (176 tests)
- pnpm test:e2e:integration (478 tests)

## 中文说明

- 将 agentic 时间序列图表中参数数量不受限制的最大值计算改为迭代扫描
- 保留参考线参与 Y 轴自动缩放的行为，同时避免创建大型临时扁平数组
- 对折叠时间线泳道的合并逻辑做同类加固，避免再次触发参数数量上限
- 新增包含 80,000 个数据点的回归测试，规模超过 staging 基准测试 434994 的约 76,568 个图表值

## 根因

staging 详情页把所有由请求生成的图表值逐一作为参数传给 Math.max。Chrome 因超过可变参数数量上限，在页面渲染前抛出 Maximum call stack size exceeded。

该修复不影响 unofficial-run overlay：agentic 单点详情页读取已经写入数据库的基准测试数据，本次修改位于其共享时间序列图表中。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized rendering/math helpers with behavior-preserving refactors and regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes agentic point-detail pages that crashed on large benchmarks when Chrome hit **Maximum call stack size exceeded** while computing Y-axis auto-scale from tens of thousands of chart points.
> 
> **Time-series chart:** Y-max no longer uses `Math.max(...all point values)` or a flattened spread. A new **`maxTimeSeriesValue`** helper scans series iteratively; reference-line ceilings are folded in via a small loop, preserving auto-scale when a ceiling sits above the data.
> 
> **Timeline rows:** Collapsed subagent lane merging no longer uses `push(...reqs)` on large request arrays, avoiding the same variadic-argument failure class.
> 
> Adds unit tests with **80,000** samples (above the ~76k staging repro) plus empty/negative floor behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b157f217640d1c9ac3b7cf031fd48f5d5bf5df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->