### PR TITLE
feat(inference): add dismissible filter-hint CTA nudge / 新增可关闭的图表筛选提示 CTA

### DIFF
--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -21,6 +21,7 @@ function clearAllNudgeStorage(win: Cypress.AUTWindow) {
     'inferencex-export-nudge-shown',
     'inferencex-gradient-nudge-shown',
     'inferencex-eval-samples-nudge-dismissed',
+    'inferencex-filter-hint-nudge-dismissed',
   ];
   for (const key of keys) {
     win.localStorage.removeItem(key);
@@ -231,6 +232,50 @@ describe('Dashboard nudges — reproducibility toast', () => {
         null,
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Dashboard — filter-hint toast (inference tab only, permanent dismissal)
+// ---------------------------------------------------------------------------
+
+// Only one overlay toast shows at a time and reproducibility (1.5s timer) wins
+// the slot on a fresh session. Suppress the competing dashboard toasts so the
+// filter-hint toast (2.5s timer) deterministically claims the overlay slot.
+function suppressCompetingDashboardToasts(win: Cypress.AUTWindow) {
+  clearAllNudgeStorage(win);
+  win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
+  win.sessionStorage.setItem('inferencex-star-nudge-shown', '1');
+}
+
+describe('Dashboard nudges — filter-hint toast', () => {
+  it('shows the filter-hint nudge on the inference tab after a short delay', () => {
+    cy.visit('/inference', { onBeforeLoad: suppressCompetingDashboardToasts });
+    cy.get('[data-testid="filter-hint-nudge"]').should('not.exist');
+    cy.get('[data-testid="filter-hint-nudge"]', { timeout: 5000 }).should('be.visible');
+  });
+
+  it('does not show the filter-hint nudge outside the inference tab', () => {
+    cy.visit('/evaluation', { onBeforeLoad: suppressCompetingDashboardToasts });
+    cy.wait(3500);
+    cy.get('[data-testid="filter-hint-nudge"]').should('not.exist');
+  });
+
+  it('dismissal persists to localStorage and the nudge stays gone after reload', () => {
+    cy.visit('/inference', { onBeforeLoad: suppressCompetingDashboardToasts });
+    cy.get('[data-testid="filter-hint-nudge"]', { timeout: 5000 }).should('be.visible');
+
+    cy.get('[data-testid="filter-hint-nudge"] button[aria-label]').first().click();
+    // The toast's exit animation delays the persisted write by ~300ms.
+    cy.wait(400);
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('inferencex-filter-hint-nudge-dismissed')).to.eq('1');
+    });
+
+    // Keep the persisted dismissal but re-suppress competitors on reload.
+    cy.reload();
+    cy.wait(3500);
+    cy.get('[data-testid="filter-hint-nudge"]').should('not.exist');
   });
 });
 

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -65,6 +65,7 @@ describe('NUDGE_REGISTRY integrity', () => {
       'eval-samples',
       'export',
       'feedback-modal',
+      'filter-hint',
       'github-star-modal',
       'gradient-label',
       'minimax-m3-launch-banner',

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -4,6 +4,7 @@ import {
   MessageSquareText,
   Palette,
   ShieldCheck,
+  SlidersHorizontal,
   Sparkles,
   Star,
 } from 'lucide-react';
@@ -30,6 +31,17 @@ const GITHUB_REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
  * Exported so the dispatch site can import a stable constant.
  */
 export const GRADIENT_NUDGE_EVENT = 'inferencex:parallelism-label-enabled';
+
+/**
+ * The inference chart lives at `/`, `/inference`, and their `/zh` siblings.
+ * Used to scope the filter-hint nudge so it only fires on the inference tab.
+ */
+function isOnInferenceTab(): boolean {
+  if (typeof window === 'undefined') return false;
+  const segments = window.location.pathname.split('/').filter(Boolean);
+  if (segments[0] === 'zh') segments.shift();
+  return (segments[0] ?? 'inference') === 'inference';
+}
 
 // ---------------------------------------------------------------------------
 // Registry — every engagement nudge in one place
@@ -165,6 +177,37 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       shown: 'gradient_nudge_shown',
       dismissed: 'gradient_nudge_dismissed',
       action: 'gradient_nudge_accepted',
+    },
+  },
+
+  {
+    id: 'filter-hint',
+    type: 'toast',
+    // Show shortly after landing on the inference tab, and re-attempt on tab
+    // switches so users who arrive via another tab still see it once.
+    trigger: [
+      { type: 'timer', delayMs: 2500 },
+      { type: 'event', event: 'inferencex:tab-change', delayMs: 800 },
+    ],
+    dismissal: { type: 'permanent' },
+    storageKey: 'inferencex-filter-hint-nudge-dismissed',
+    conditions: [{ check: isOnInferenceTab, listenEvent: 'inferencex:tab-change' }],
+    priority: 12,
+    scope: 'dashboard',
+    content: {
+      icon: SlidersHorizontal,
+      iconClassName: 'text-brand',
+      title: 'Too much on the chart?',
+      titleZh: '图表太拥挤？',
+      description:
+        'Use the legend filters on the right to focus — toggle NVIDIA vs AMD vendors, disaggregated vs aggregated (disagg/agg) serving, precision (FP8/FP4), and more to compare just what you care about.',
+      descriptionZh:
+        '使用右侧图例筛选器聚焦对比——切换 NVIDIA 与 AMD 厂商、分离式与聚合式 (disagg/agg) 服务模式、精度 (FP8/FP4) 等，只查看您关心的内容。',
+      testId: 'filter-hint-nudge',
+    },
+    analytics: {
+      shown: 'filter_hint_nudge_shown',
+      dismissed: 'filter_hint_nudge_dismissed',
     },
   },
 


### PR DESCRIPTION
## Summary

The inference performance chart (Token Throughput per GPU vs. Interactivity) is very dense — dozens of overlapping labels across vendors, engines, and precisions. Many users don't realize the right-side legend can filter the chart down to just the comparisons they care about.

This PR adds a **dismissible CTA toast** that nudges users toward the filters.

- **What it does:** shows a bottom-right toast titled *"Too much on the chart?"* suggesting the legend filters as a way to declutter — explicitly naming NVIDIA vs AMD vendors, disaggregated vs aggregated (disagg/agg) serving, and precision (FP8/FP4) as examples.
- **Where it appears:** the inference tab only. Implemented as a `dashboard`-scope entry in the existing `NUDGE_REGISTRY`, gated by a `conditions` check (`isOnInferenceTab`) so it never fires on other dashboard tabs. It shows ~2.5s after landing on the tab, and re-attempts on `inferencex:tab-change` so users arriving from another tab still see it once.
- **Dismissal persistence:** uses the registry's `dismissal: { type: 'permanent' }` strategy. Clicking the X writes `inferencex-filter-hint-nudge-dismissed` to `localStorage` via the shared `markDismissed` helper, so once dismissed it never appears again across reloads/sessions. This is the same persistence mechanism every other nudge uses — no bespoke storage code.
- **Design:** renders through the existing `BottomToast` / `NudgeEngine` renderer, so it inherits the app's card styling, dark/light theming, spacing, and typography. It looks native because it *is* the native nudge component.
- **Bilingual:** `titleZh` / `descriptionZh` are provided per the repo's bilingual UI requirement; the `NudgeEngine` renders the Chinese copy on `/zh` pages via `useLocale()`.

No new page/tab/blog post is introduced, so no `/zh` sibling page is required — the CTA is a UI overlay handled by the locale-aware engine.

## Testing

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- `pnpm fmt` ✅
- `pnpm test:unit` ✅ (2566 tests; includes the updated `registry.test.ts` integrity check that now expects the `filter-hint` id)
- Added 3 Cypress E2E cases in `nudge-system.cy.ts`: shows on the inference tab, does **not** show on `/evaluation`, and dismissal persists to `localStorage` and stays gone after reload. The e2e suite needs a live read-only DB + dev server, which isn't available in this sandbox, so it was not executed here — the CI `tests-*` workflow covers it.

## 中文说明

推理性能图表（每 GPU 令牌吞吐量 vs. 交互性）非常拥挤——数十个标签在不同厂商、引擎和精度之间相互重叠。许多用户并未意识到右侧图例可以将图表筛选到自己真正关心的对比项。

本 PR 新增一个**可关闭的 CTA 提示条**，引导用户使用筛选器。

- **功能：** 在右下角显示标题为"图表太拥挤？"的 toast 提示，建议使用图例筛选器来精简视图，并以 NVIDIA 与 AMD 厂商、分离式与聚合式 (disagg/agg) 服务模式、精度 (FP8/FP4) 作为示例。
- **显示位置：** 仅在 inference 标签页。作为现有 `NUDGE_REGISTRY` 中的 `dashboard` 范围条目实现，通过 `conditions`（`isOnInferenceTab`）限定，因此不会在其他仪表板标签页触发。进入标签页约 2.5 秒后显示，并在 `inferencex:tab-change` 时重试，确保从其他标签页进入的用户也能看到一次。
- **关闭持久化：** 采用注册表的 `dismissal: { type: 'permanent' }` 策略。点击关闭按钮会通过共享的 `markDismissed` 将 `inferencex-filter-hint-nudge-dismissed` 写入 `localStorage`，因此关闭后在刷新和跨会话时都不会再次出现。这与其他所有提示条使用完全相同的持久化机制，没有额外的存储代码。
- **设计：** 通过现有的 `BottomToast` / `NudgeEngine` 渲染器呈现，因此继承了应用的卡片样式、深色/浅色主题、间距和排版，外观原生一致。
- **双语：** 按照仓库的双语 UI 要求提供了 `titleZh` / `descriptionZh`；`NudgeEngine` 会在 `/zh` 页面通过 `useLocale()` 渲染中文文案。

本次未新增页面/标签页/博客文章，因此无需 `/zh` 兄弟页面——该 CTA 是由具备语言感知能力的引擎处理的 UI 浮层。

---
🤖 *Generated by Computer*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Engagement-only UI overlay wired through the existing NudgeEngine; no auth, data, or API changes.
> 
> **Overview**
> Adds a new **`filter-hint`** dashboard toast in `NUDGE_REGISTRY` that points users at the right-side legend filters when the inference chart feels crowded. It fires after ~2.5s on the inference tab (including `/` and `/zh` paths via `isOnInferenceTab`) and re-attempts on `inferencex:tab-change`; dismissal is **permanent** via `inferencex-filter-hint-nudge-dismissed` in `localStorage`, with bilingual copy and analytics events.
> 
> Cypress coverage extends `nudge-system.cy.ts` with three cases (show on inference, hide on evaluation, persisted dismiss after reload), using a helper to suppress competing dashboard toasts. The registry integrity test now expects the `filter-hint` id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ff335024fbc490f4e53bee1ab579d798ae37601. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->