### PR TITLE
fix(inference): let unofficial run overlays win the cross-engine AgentX guard / 修复：让非官方 run 的 overlay 在跨引擎 AgentX 互斥中优先显示

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -341,7 +341,7 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-m3-eagle svg .line-label text').should('not.contain.text', 'MTP');
   });
 
-  it('removes a cross-engine AgentX STP overlay before rendering', () => {
+  it('prefers a cross-engine AgentX STP overlay over the conflicting official series', () => {
     const chartDefinition = createMockChartDefinition({
       chartType: 'interactivity',
       y_tpPerGpu_roofline: 'upper_left',
@@ -410,9 +410,97 @@ describe('ScatterGraph', () => {
       },
     );
 
-    cy.get('#test-scatter-agentx-engine-guard svg .roofline-path').should('exist');
-    cy.get('#test-scatter-agentx-engine-guard svg .overlay-roofline-path').should('not.exist');
-    cy.get('@setActiveOverlayHwTypes').should('have.been.called');
+    // The unofficial run was loaded to be seen: its engine family wins the
+    // cross-engine exclusion, so the overlay renders and the conflicting
+    // official SGLang series is deselected (restorable by dismissing the run).
+    // Official rooflines stay in the DOM when deselected — they hide via opacity.
+    cy.get('#test-scatter-agentx-engine-guard svg .overlay-roofline-path').should('exist');
+    cy.get('#test-scatter-agentx-engine-guard svg .roofline-path').should(
+      'have.css',
+      'opacity',
+      '0',
+    );
+    // No reconciliation write-back: the provider's overlay selection already
+    // matches the resolved selection.
+    cy.get('@setActiveOverlayHwTypes').should('not.have.been.called');
+  });
+
+  it('renders both official and overlay AgentX STP series from the same engine family', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const officialData = [8, 16, 32].map((x, index) =>
+      createMockInferenceData({
+        hwKey: 'b200_vllm',
+        x,
+        y: 320 - index * 40,
+        precision: Precision.FP4,
+      }),
+    );
+    const runUrl = 'https://github.com/x/y/actions/runs/agentx-vllm-same-family';
+    const overlayData = {
+      data: [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey: 'h100_vllm',
+          x,
+          y: 260 - index * 40,
+          precision: Precision.FP4,
+          run_url: runUrl,
+        }),
+      ),
+      hardwareConfig: hwConfig,
+      label: 'agentx-vllm-same-family',
+      runUrl,
+    };
+    const exclusion = buildExclusion([
+      { suffix: null, stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'] },
+    ]);
+    const namespacedExclusion = {
+      familyOf: (key: string) =>
+        exclusion.familyOf(key.startsWith('overlay:') ? key.slice('overlay:'.length) : key),
+      groupOf: (key: string) =>
+        exclusion.groupOf(key.startsWith('overlay:') ? key.slice('overlay:'.length) : key),
+    };
+
+    mountWithProviders(
+      <div style={{ width: 800, height: 600 }}>
+        <ScatterGraph
+          chartId="test-scatter-agentx-same-family"
+          modelLabel="DeepSeek V4 Pro"
+          data={officialData}
+          xLabel="Concurrency"
+          yLabel="Throughput / GPU (tok/s)"
+          chartDefinition={chartDefinition}
+          overlayData={overlayData}
+        />
+      </div>,
+      {
+        inference: {
+          hardwareConfig: hwConfig,
+          activeHwTypes: new Set(['b200_vllm']),
+          hwTypesWithData: new Set(['b200_vllm']),
+          selectedModel: Model.DeepSeek_V4_Pro,
+          selectedSequence: Sequence.AgenticTraces,
+          selectedPrecisions: [Precision.FP4],
+          showLineLabels: true,
+          resolveComparisonSelection: (proposed, prev = new Set()) =>
+            resolveExclusionGroups(proposed, prev, namespacedExclusion, 'keep-sticky'),
+        },
+        unofficial: {
+          activeOverlayHwTypes: new Set(['h100_vllm']),
+          allOverlayHwTypes: new Set(['h100_vllm']),
+        },
+      },
+    );
+
+    // Same engine family: no exclusion applies, both series render.
+    cy.get('#test-scatter-agentx-same-family svg .overlay-roofline-path').should('exist');
+    cy.get('#test-scatter-agentx-same-family svg .roofline-path').should(
+      'have.css',
+      'opacity',
+      '1',
+    );
   });
 });
 
@@ -464,6 +552,88 @@ describe('ChartDisplay engine comparison guard', () => {
 
     cy.get('[data-testid="inference-table-view-btn"]').click();
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+  });
+
+  it('keeps a cross-engine unofficial overlay in table mode and drops the conflicting official', () => {
+    const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
+    const sglangRow = createMockInferenceData({
+      hwKey: 'b200_sglang',
+      hw: 'Official SGLang',
+      model: Model.DeepSeek_V4_Pro,
+      precision: Precision.FP4,
+    });
+    const runUrl = 'https://github.com/x/y/actions/runs/456';
+    const overlayRow = createMockInferenceData({
+      hwKey: 'h100_vllm',
+      hw: 'Unofficial vLLM',
+      model: Model.DeepSeek_V4_Pro,
+      precision: Precision.FP4,
+      run_url: runUrl,
+    });
+    const exclusion = buildExclusion([
+      { suffix: null, stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'] },
+    ]);
+    const namespacedExclusion = {
+      familyOf: (key: string) =>
+        exclusion.familyOf(key.startsWith('overlay:') ? key.slice('overlay:'.length) : key),
+      groupOf: (key: string) =>
+        exclusion.groupOf(key.startsWith('overlay:') ? key.slice('overlay:'.length) : key),
+    };
+    const resolveSelection = (proposed: Set<string>, prev = new Set<string>()) =>
+      resolveExclusionGroups(proposed, prev, namespacedExclusion, 'keep-sticky');
+    const runInfo = {
+      id: 456,
+      name: 'agentx-vllm-overlay',
+      branch: 'agentx-vllm-overlay',
+      sha: 'def456',
+      createdAt: '2026-07-10T00:00:00Z',
+      url: runUrl,
+      conclusion: 'success',
+      status: 'completed',
+      isNonMainBranch: true,
+    };
+
+    mountWithProviders(<ChartDisplay />, {
+      inference: {
+        graphs: [
+          {
+            model: Model.DeepSeek_V4_Pro,
+            sequence: Sequence.AgenticTraces,
+            chartDefinition,
+            data: [sglangRow],
+          },
+        ],
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedXAxisMode: 'interactivity',
+        activeHwTypes: new Set(['b200_sglang']),
+        hwTypesWithData: new Set(['b200_sglang']),
+        resolveComparisonSelection: resolveSelection,
+      },
+      globalFilters: {
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        effectiveSequence: Sequence.AgenticTraces,
+      },
+      unofficial: {
+        isUnofficialRun: true,
+        unofficialRunInfo: runInfo,
+        unofficialRunInfos: [runInfo],
+        runIndexByUrl: { [runUrl]: 0, '456': 0 },
+        getOverlayData: () => ({ data: [overlayRow], hardwareConfig: hwConfig }),
+        activeOverlayHwTypes: new Set(['h100_vllm']),
+        allOverlayHwTypes: new Set(['h100_vllm']),
+      },
+    });
+
+    cy.get('[data-testid="inference-table-view-btn"]').click();
+    // The unofficial run's engine family wins the cross-engine exclusion: the
+    // overlay row stays and the conflicting official SGLang row is dropped.
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody').contains('vLLM').should('exist');
+    cy.get('[data-testid="inference-results-table"] tbody').contains('SGLang').should('not.exist');
+    // The reconciliation effect must not strip the run's hw types from the provider.
+    cy.get('@setActiveOverlayHwTypes').should('not.have.been.called');
   });
 
   it('keeps an explicitly empty official legend out of table mode', () => {

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -550,9 +550,6 @@ export default function ChartDisplay() {
       const activeOfficialKeys = new Set(
         [...selectedOfficialHwTypes].filter((key) => availableOfficialKeys.has(key)),
       );
-      const activeScopedOverlayKeys = new Set(
-        [...activeOverlayHwTypes].filter((key) => availableOverlayKeys.has(key)),
-      );
       const officialKeys = activeOfficialKeys;
       const overlayKeys = new Set(
         [...resolvedScopedOverlayHwTypes].filter((key) => availableOverlayKeys.has(key)),
@@ -560,10 +557,12 @@ export default function ChartDisplay() {
       const proposed = new Set(officialKeys);
       overlayKeys.forEach((key) => proposed.add(`overlay:${key}`));
       // Same overlay-preferring sticky set as resolvedScopedOverlayHwTypes:
-      // while overlay rows are active, the run's engine family wins.
+      // while overlay rows are visible, the run's engine family wins. Built
+      // from the already-resolved overlayKeys (not the provider selection,
+      // which can lag by a render after a scope change).
       const previous = new Set<string>();
-      if (activeScopedOverlayKeys.size > 0) {
-        activeScopedOverlayKeys.forEach((key) => previous.add(`overlay:${key}`));
+      if (overlayKeys.size > 0) {
+        overlayKeys.forEach((key) => previous.add(`overlay:${key}`));
       } else {
         activeOfficialKeys.forEach((key) => previous.add(key));
       }
@@ -580,7 +579,6 @@ export default function ChartDisplay() {
       selectedPrecisions,
       quickFilters,
       selectedOfficialHwTypes,
-      activeOverlayHwTypes,
       resolvedScopedOverlayHwTypes,
       resolveComparisonSelection,
     ],

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -479,8 +479,17 @@ export default function ChartDisplay() {
     const overlayKeys = overlayRowsScopeChanged ? overlayScope : activeScopedOverlayKeys;
     const proposed = new Set(officialKeys);
     overlayKeys.forEach((key) => proposed.add(`overlay:${key}`));
-    const previous = new Set(activeOfficialKeys);
-    activeScopedOverlayKeys.forEach((key) => previous.add(`overlay:${key}`));
+    // Overlay-preferring sticky set (mirrors ScatterGraph's exclusionStickySet):
+    // an unofficial run loaded via `?unofficialrun=` exists to be seen, so its
+    // engine family wins cross-engine exclusion over the official selection.
+    // Otherwise this effect would strip the run's hw types from the provider
+    // before the chart ever renders them, with no legend affordance to recover.
+    const previous = new Set<string>();
+    if (overlayKeys.size > 0) {
+      overlayKeys.forEach((key) => previous.add(`overlay:${key}`));
+    } else {
+      activeOfficialKeys.forEach((key) => previous.add(key));
+    }
     const resolved = resolveComparisonSelection(proposed, previous).result;
     const overlay = new Set<string>();
     for (const key of resolved) {
@@ -550,8 +559,14 @@ export default function ChartDisplay() {
       );
       const proposed = new Set(officialKeys);
       overlayKeys.forEach((key) => proposed.add(`overlay:${key}`));
-      const previous = new Set(activeOfficialKeys);
-      activeScopedOverlayKeys.forEach((key) => previous.add(`overlay:${key}`));
+      // Same overlay-preferring sticky set as resolvedScopedOverlayHwTypes:
+      // while overlay rows are active, the run's engine family wins.
+      const previous = new Set<string>();
+      if (activeScopedOverlayKeys.size > 0) {
+        activeScopedOverlayKeys.forEach((key) => previous.add(`overlay:${key}`));
+      } else {
+        activeOfficialKeys.forEach((key) => previous.add(key));
+      }
       const resolved = resolveComparisonSelection(proposed, previous).result;
 
       return {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -453,13 +453,22 @@ const ScatterGraph = React.memo(
       rawOverlayHwTypes.forEach((key) => combined.add(`overlay:${key}`));
       return combined;
     }, [rawOfficialHwTypes, rawOverlayHwTypes]);
+    // Sticky preference for cross-engine exclusion resolution. An unofficial
+    // run loaded via `?unofficialrun=` exists to be seen, so when its configs
+    // conflict with the official engine family the run wins and the conflicting
+    // official series are deselected — the reverse would leave the overlay
+    // permanently hidden with no legend affordance to surface it (the run's
+    // legend entry is not a toggle). Officials stay restorable by dismissing
+    // the run. Without overlay points the official selection is sticky as before.
+    const exclusionStickySet = useMemo(() => {
+      if (rawOverlayHwTypes.size > 0) {
+        return new Set([...rawOverlayHwTypes].map((key) => `overlay:${key}`));
+      }
+      return rawOfficialHwTypes.size > 0 ? rawOfficialHwTypes : rawUnifiedSelection;
+    }, [rawOverlayHwTypes, rawOfficialHwTypes, rawUnifiedSelection]);
     const resolvedUnifiedSelection = useMemo(
-      () =>
-        resolveComparisonSelection(
-          rawUnifiedSelection,
-          rawOfficialHwTypes.size > 0 ? rawOfficialHwTypes : rawUnifiedSelection,
-        ).result,
-      [rawUnifiedSelection, rawOfficialHwTypes, resolveComparisonSelection],
+      () => resolveComparisonSelection(rawUnifiedSelection, exclusionStickySet).result,
+      [rawUnifiedSelection, exclusionStickySet, resolveComparisonSelection],
     );
     const resolvedHwTypes = useMemo(() => {
       const official = new Set<string>();
@@ -552,14 +561,17 @@ const ScatterGraph = React.memo(
         setLocalOfficialOverride(null);
         return;
       }
-      const resolved = resolveComparisonSelection(allUnifiedHwTypes, effectiveOfficialHwTypes);
+      // Same sticky preference as the render-time resolution: keep the overlay
+      // run's engine family so a reset doesn't flip the chart back to the
+      // conflicting official family and re-hide the loaded run.
+      const resolved = resolveComparisonSelection(allUnifiedHwTypes, exclusionStickySet);
       commitUnifiedSelection(resolved.result);
     }, [
       selectAllHwTypes,
       overlayData,
       setLocalOfficialOverride,
       allUnifiedHwTypes,
-      effectiveOfficialHwTypes,
+      exclusionStickySet,
       resolveComparisonSelection,
       commitUnifiedSelection,
     ]);

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -153,17 +153,31 @@ describe('AgentX STP engine exclusion', () => {
     });
   });
 
-  it('keeps the official engine when an automatic overlay load conflicts', () => {
+  it('keeps whichever engine family the sticky set names when a load conflicts', () => {
     const proposed = new Set(['b300_sglang', 'overlay:b300_vllm']);
-    const resolved = resolveExclusionGroups(
+
+    // Official-sticky prev: the official engine wins, overlay dropped.
+    const officialSticky = resolveExclusionGroups(
       proposed,
       new Set(['b300_sglang']),
       namespacedAgenticEx,
       'keep-sticky',
     );
-    expect([...resolved.result]).toEqual(['b300_sglang']);
-    expect(resolved.keptGroup).toBe('sglang');
-    expect(resolved.droppedGroups).toEqual(['vllm']);
+    expect([...officialSticky.result]).toEqual(['b300_sglang']);
+    expect(officialSticky.keptGroup).toBe('sglang');
+    expect(officialSticky.droppedGroups).toEqual(['vllm']);
+
+    // Overlay-sticky prev (what ScatterGraph passes while an unofficial run is
+    // loaded): the run's engine wins and the official series is dropped.
+    const overlaySticky = resolveExclusionGroups(
+      proposed,
+      new Set(['overlay:b300_vllm']),
+      namespacedAgenticEx,
+      'keep-sticky',
+    );
+    expect([...overlaySticky.result]).toEqual(['overlay:b300_vllm']);
+    expect(overlaySticky.keptGroup).toBe('vllm');
+    expect(overlaySticky.droppedGroups).toEqual(['sglang']);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes `?unofficialrun=<id>` overlays never rendering on agentic (AgentX) charts when the run's engine family conflicts with the active official selection — reported for run [29272097721](https://inferencex.semianalysis.com/inference?unofficialRun=29272097721) (benchmark PR [SemiAnalysisAI/InferenceX#2153](https://github.com/SemiAnalysisAI/InferenceX/pull/2153), `lmcache/agentix`, vLLM).

### Root cause

The cross-engine AgentX STP exclusion (#549) resolves engine-family conflicts with a **sticky set** (`resolveExclusionGroups(proposed, prev, …, 'keep-sticky')`), and both resolution sites passed the *official* selection as `prev`:

1. **`ChartDisplay`** — `resolvedScopedOverlayHwTypes` resolved with officials-first `previous`, and its reconciliation effect then **stripped the run's hw types from the `UnofficialRunProvider`** (`setActiveOverlayHwTypes`), so the overlay was gone before the chart rendered.
2. **`ScatterGraph`** — the unified official+overlay selection used `rawOfficialHwTypes` as the sticky set, dropping `overlay:*` keys at render time.

The run's legend entry is not a toggle, so there was **no UI affordance to recover** — the loaded run was permanently invisible (its "Points" dialog reported "No visible points for this series under the current filters").

### Fix

An unofficial run is loaded to be seen: whenever overlay hw types are in scope, use **the run's engine family as the sticky set** in both resolution sites, falling back to the official selection otherwise. Consequences:

- The overlay renders on load; conflicting official series deselect (dim in the legend).
- Same-family officials can be re-enabled with a normal legend click (fallthrough, verified).
- Clicking a *conflicting* dim official still hits the existing block toast explaining engine-specific benchmark implementations (verified).
- Dismissing the run restores the official selection (mechanism unchanged).
- With no overlay in scope, behavior is byte-identical to before (officials-sticky).

### Tests

- `exclusion.test.ts`: extended the sticky-resolution unit test to cover both official-sticky and overlay-sticky `prev` (documents the new caller contract).
- `scatter-graph.cy.tsx` component specs:
  - flipped the #549 guard test — the cross-engine overlay roofline now renders and the conflicting official hides (`opacity: 0`), with no reconciliation write-back;
  - new same-engine-family test — official and overlay both render;
  - new `ChartDisplay` table-mode test — the overlay row survives, the conflicting official row drops, and `setActiveOverlayHwTypes` is **not** called (guards the provider-strip regression).

`tsc --noEmit`, `oxlint`, `oxfmt`, vitest (2568 tests), and the full Cypress component suite (178 tests) all pass locally.

### Overlay support

This change is entirely about the `?unofficialrun=` overlay path — verified manually against a local dev server with the real run `?unofficialrun=29272097721`: the `lmcache/agentix` vLLM roofline renders on the DeepSeek V4 Pro agentic chart, same-family official re-enable works, conflicting-family click shows the block toast. Will re-verify on the Vercel preview once it builds.

## 中文说明

修复当非官方 run（`?unofficialrun=<id>`）的引擎家族与当前官方选择冲突时，agentic（AgentX）图表上 overlay 永远不渲染的问题——由 run [29272097721](https://inferencex.semianalysis.com/inference?unofficialRun=29272097721)（基准测试 PR [SemiAnalysisAI/InferenceX#2153](https://github.com/SemiAnalysisAI/InferenceX/pull/2153)，`lmcache/agentix` 分支，vLLM）报告。

**根因**：#549 引入的跨引擎 AgentX STP 互斥规则在解析冲突时以官方选择作为粘性集合。`ChartDisplay` 的同步 effect 会把 run 的硬件类型从 provider 中剥离，`ScatterGraph` 的统一选择解析也会在渲染时丢弃 `overlay:*` 键；而 run 的图例项不是开关，用户没有任何方式恢复显示。

**修复**：只要 overlay 硬件类型在作用域内，两处解析均以 run 的引擎家族作为粘性集合，否则回退到官方选择。overlay 加载后立即渲染；冲突的官方系列被取消选择（图例中变暗），同家族官方配置可通过点击图例恢复，点击冲突家族仍会触发原有的拦截提示；关闭 run 即可恢复官方选择。无 overlay 时行为与之前完全一致。

**测试**：扩展了 `exclusion.test.ts` 的粘性解析单元测试；翻转了 #549 的组件测试预期并新增同家族用例；新增 `ChartDisplay` 表格模式测试，验证 overlay 行保留、冲突官方行剔除、且不会向 provider 写回剥离后的选择。本地 `tsc`、`oxlint`、`oxfmt`、vitest（2568 项）与 Cypress 组件套件（178 项）全部通过，并已用真实 run `?unofficialrun=29272097721` 在本地手动验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes legend/comparison selection and provider sync on agentic charts with unofficial overlays; behavior is unchanged when no overlay is in scope, but cross-engine conflicts now prefer overlays over officials.
> 
> **Overview**
> Fixes **unofficial run overlays never showing** on agentic charts when the loaded run’s engine family conflicts with the active official selection (e.g. vLLM overlay vs SGLang official).
> 
> **`ScatterGraph`** adds `exclusionStickySet`: if any overlay hw types are in scope, `resolveComparisonSelection` uses `overlay:*` keys as the sticky `prev` instead of the official selection, so the run’s family wins and conflicting officials are deselected (dimmed) rather than dropping the overlay. **Reset filter** uses the same sticky preference so it does not flip back to officials and hide the run.
> 
> **`ChartDisplay`** mirrors that logic in `resolvedScopedOverlayHwTypes` and `visibleComparisonRows`, preventing the reconciliation effect from calling `setActiveOverlayHwTypes` to strip overlay keys before render. Table mode follows the same resolution (overlay row kept, conflicting official dropped).
> 
> **Tests**: `exclusion.test.ts` documents both official-sticky and overlay-sticky `prev`; Cypress specs flip the cross-engine guard expectation, add same-family coexistence, and guard the provider write-back regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986e3554a3512fa476b6522da1c101ce277102b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->