### PR TITLE
fix(inference): allow mixed engines in unofficial previews / 修复：允许非官方预览混合显示多个引擎

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -341,18 +341,20 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-m3-eagle svg .line-label text').should('not.contain.text', 'MTP');
   });
 
-  it('prefers a cross-engine AgentX STP overlay over the conflicting official series', () => {
+  it('renders cross-engine official and unofficial AgentX STP series together in preview mode', () => {
     const chartDefinition = createMockChartDefinition({
       chartType: 'interactivity',
       y_tpPerGpu_roofline: 'upper_left',
     });
-    const officialData = [8, 16, 32].map((x, index) =>
-      createMockInferenceData({
-        hwKey: 'b200_sglang',
-        x,
-        y: 320 - index * 40,
-        precision: Precision.FP4,
-      }),
+    const officialData = ['b200_sglang', 'h100_vllm'].flatMap((hwKey, hwIndex) =>
+      [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey,
+          x,
+          y: 320 - hwIndex * 20 - index * 40,
+          precision: Precision.FP4,
+        }),
+      ),
     );
     const runUrl = 'https://github.com/x/y/actions/runs/agentx-vllm';
     const overlayData = {
@@ -378,6 +380,7 @@ describe('ScatterGraph', () => {
       groupOf: (key: string) =>
         exclusion.groupOf(key.startsWith('overlay:') ? key.slice('overlay:'.length) : key),
     };
+    const blockedToggle = cy.stub().as('blockedComparisonToggle').returns(null);
 
     mountWithProviders(
       <div style={{ width: 800, height: 600 }}>
@@ -395,13 +398,14 @@ describe('ScatterGraph', () => {
         inference: {
           hardwareConfig: hwConfig,
           activeHwTypes: new Set(['b200_sglang']),
-          hwTypesWithData: new Set(['b200_sglang']),
+          hwTypesWithData: new Set(['b200_sglang', 'h100_vllm']),
           selectedModel: Model.DeepSeek_V4_Pro,
           selectedSequence: Sequence.AgenticTraces,
           selectedPrecisions: [Precision.FP4],
           showLineLabels: true,
           resolveComparisonSelection: (proposed, prev = new Set()) =>
             resolveExclusionGroups(proposed, prev, namespacedExclusion, 'keep-sticky'),
+          toggleComparisonSelection: blockedToggle,
         },
         unofficial: {
           activeOverlayHwTypes: new Set(['h100_vllm']),
@@ -410,19 +414,24 @@ describe('ScatterGraph', () => {
       },
     );
 
-    // The unofficial run was loaded to be seen: its engine family wins the
-    // cross-engine exclusion, so the overlay renders and the conflicting
-    // official SGLang series is deselected (restorable by dismissing the run).
-    // Official rooflines stay in the DOM when deselected — they hide via opacity.
+    // Preview mode is diagnostic, so cross-engine official and unofficial
+    // results remain visible together instead of choosing one engine family.
     cy.get('#test-scatter-agentx-engine-guard svg .overlay-roofline-path').should('exist');
-    cy.get('#test-scatter-agentx-engine-guard svg .roofline-path').should(
-      'have.css',
-      'opacity',
-      '0',
-    );
-    // No reconciliation write-back: the provider's overlay selection already
-    // matches the resolved selection.
+    cy.get(
+      '#test-scatter-agentx-engine-guard svg .roofline-path[data-hw-key="b200_sglang"]',
+    ).should('have.css', 'opacity', '1');
+    // The exclusion resolver must be bypassed rather than resolving in favor of
+    // either the official or overlay engine family.
     cy.get('@setActiveOverlayHwTypes').should('not.have.been.called');
+
+    // An additional official engine can also be selected while the preview is
+    // loaded; the production-only conflict toggle must not be consulted.
+    cy.get('label[for="checkbox-h100_vllm"]').click();
+    cy.get('@blockedComparisonToggle').should('not.have.been.called');
+    cy.get('@setLocalOfficialOverride').should((setOverride) => {
+      const selection = setOverride.lastCall.args[0] as Set<string>;
+      expect([...selection]).to.have.members(['b200_sglang', 'h100_vllm']);
+    });
   });
 
   it('renders both official and overlay AgentX STP series from the same engine family', () => {
@@ -554,7 +563,7 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
   });
 
-  it('keeps a cross-engine unofficial overlay in table mode and drops the conflicting official', () => {
+  it('keeps cross-engine official and unofficial rows together in preview table mode', () => {
     const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
     const sglangRow = createMockInferenceData({
       hwKey: 'b200_sglang',
@@ -627,11 +636,9 @@ describe('ChartDisplay engine comparison guard', () => {
     });
 
     cy.get('[data-testid="inference-table-view-btn"]').click();
-    // The unofficial run's engine family wins the cross-engine exclusion: the
-    // overlay row stays and the conflicting official SGLang row is dropped.
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
     cy.get('[data-testid="inference-results-table"] tbody').contains('vLLM').should('exist');
-    cy.get('[data-testid="inference-results-table"] tbody').contains('SGLang').should('not.exist');
+    cy.get('[data-testid="inference-results-table"] tbody').contains('SGLang').should('exist');
     // The reconciliation effect must not strip the run's hw types from the provider.
     cy.get('@setActiveOverlayHwTypes').should('not.have.been.called');
   });
@@ -793,9 +800,9 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
 
     cy.get('[data-testid="change-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 3);
     cy.get('[data-testid="rerender-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 3);
 
     cy.get('[data-testid="clear-overlay-scope"]').click();
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -255,7 +255,6 @@ export default function ChartDisplay() {
     selectedXAxisMode,
     setSelectedXAxisMode,
     quickFilters,
-    resolveComparisonSelection,
   } = useInference();
 
   const {
@@ -444,21 +443,6 @@ export default function ChartDisplay() {
     }
     return eligibleKeys;
   }, [overlayDataByChartType, selectedPrecisions, quickFilters]);
-  const officialScope = useMemo(() => {
-    const eligibleKeys = new Set<string>();
-    for (const graph of graphs) {
-      for (const point of graph.data) {
-        const key = String(point.hwKey);
-        if (
-          selectedPrecisions.includes(point.precision) &&
-          matchesQuickFilters(point, quickFilters)
-        ) {
-          eligibleKeys.add(key);
-        }
-      }
-    }
-    return eligibleKeys;
-  }, [graphs, selectedPrecisions, quickFilters]);
   const overlayRowsScopeKey = `${selectedModel}|${selectedSequence}|${selectedPrecisions.join(
     ',',
   )}|${unofficialRunInfos.map((run) => run.url).join(',')}`;
@@ -468,46 +452,18 @@ export default function ChartDisplay() {
     overlayRowsScopeChanged || localOfficialOverride === null
       ? activeHwTypes
       : localOfficialOverride;
-  const resolvedScopedOverlayHwTypes = useMemo(() => {
-    const activeOfficialKeys = new Set(
-      [...selectedOfficialHwTypes].filter((key) => officialScope.has(key)),
-    );
-    const officialKeys = activeOfficialKeys;
+  // Preview tables follow the same policy as ScatterGraph: preserve every
+  // active engine family instead of applying the production comparison guard.
+  const scopedActiveOverlayHwTypes = useMemo(() => {
     const activeScopedOverlayKeys = new Set(
       [...activeOverlayHwTypes].filter((key) => overlayScope.has(key)),
     );
-    const overlayKeys = overlayRowsScopeChanged ? overlayScope : activeScopedOverlayKeys;
-    const proposed = new Set(officialKeys);
-    overlayKeys.forEach((key) => proposed.add(`overlay:${key}`));
-    // Overlay-preferring sticky set (mirrors ScatterGraph's exclusionStickySet):
-    // an unofficial run loaded via `?unofficialrun=` exists to be seen, so its
-    // engine family wins cross-engine exclusion over the official selection.
-    // Otherwise this effect would strip the run's hw types from the provider
-    // before the chart ever renders them, with no legend affordance to recover.
-    const previous = new Set<string>();
-    if (overlayKeys.size > 0) {
-      overlayKeys.forEach((key) => previous.add(`overlay:${key}`));
-    } else {
-      activeOfficialKeys.forEach((key) => previous.add(key));
-    }
-    const resolved = resolveComparisonSelection(proposed, previous).result;
-    const overlay = new Set<string>();
-    for (const key of resolved) {
-      if (key.startsWith('overlay:')) overlay.add(key.slice('overlay:'.length));
-    }
-    return overlay;
-  }, [
-    selectedOfficialHwTypes,
-    activeOverlayHwTypes,
-    officialScope,
-    overlayScope,
-    overlayRowsScopeChanged,
-    resolveComparisonSelection,
-  ]);
+    return overlayRowsScopeChanged ? overlayScope : activeScopedOverlayKeys;
+  }, [activeOverlayHwTypes, overlayScope, overlayRowsScopeChanged]);
   useEffect(() => {
     const merged = new Set(activeOverlayHwTypes);
     overlayScope.forEach((key) => merged.delete(key));
-    resolvedScopedOverlayHwTypes.forEach((key) => merged.add(key));
+    scopedActiveOverlayHwTypes.forEach((key) => merged.add(key));
     let selectionChanged = merged.size !== activeOverlayHwTypes.size;
     if (!selectionChanged) {
       for (const key of merged) {
@@ -527,7 +483,7 @@ export default function ChartDisplay() {
     overlayRowsScopeKey,
     activeOverlayHwTypes,
     overlayScope,
-    resolvedScopedOverlayHwTypes,
+    scopedActiveOverlayHwTypes,
     setActiveOverlayHwTypes,
     localOfficialOverride,
     setLocalOfficialOverride,
@@ -552,36 +508,15 @@ export default function ChartDisplay() {
       );
       const officialKeys = activeOfficialKeys;
       const overlayKeys = new Set(
-        [...resolvedScopedOverlayHwTypes].filter((key) => availableOverlayKeys.has(key)),
+        [...scopedActiveOverlayHwTypes].filter((key) => availableOverlayKeys.has(key)),
       );
-      const proposed = new Set(officialKeys);
-      overlayKeys.forEach((key) => proposed.add(`overlay:${key}`));
-      // Same overlay-preferring sticky set as resolvedScopedOverlayHwTypes:
-      // while overlay rows are visible, the run's engine family wins. Built
-      // from the already-resolved overlayKeys (not the provider selection,
-      // which can lag by a render after a scope change).
-      const previous = new Set<string>();
-      if (overlayKeys.size > 0) {
-        overlayKeys.forEach((key) => previous.add(`overlay:${key}`));
-      } else {
-        activeOfficialKeys.forEach((key) => previous.add(key));
-      }
-      const resolved = resolveComparisonSelection(proposed, previous).result;
 
       return {
-        officialRows: eligibleOfficialRows.filter((point) => resolved.has(String(point.hwKey))),
-        overlayRows: eligibleOverlayRows.filter((point) =>
-          resolved.has(`overlay:${String(point.hwKey)}`),
-        ),
+        officialRows: eligibleOfficialRows.filter((point) => officialKeys.has(String(point.hwKey))),
+        overlayRows: eligibleOverlayRows.filter((point) => overlayKeys.has(String(point.hwKey))),
       };
     },
-    [
-      selectedPrecisions,
-      quickFilters,
-      selectedOfficialHwTypes,
-      resolvedScopedOverlayHwTypes,
-      resolveComparisonSelection,
-    ],
+    [selectedPrecisions, quickFilters, selectedOfficialHwTypes, scopedActiveOverlayHwTypes],
   );
 
   // Resolve x-axis field per chart type for trend data

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { GRADIENT_NUDGE_EVENT } from '@/lib/nudges/registry';
 import { useInference } from '@/components/inference/InferenceContext';
 import { useTraceAvailability } from '@/hooks/api/use-trace-availability';
+import { computeToggle } from '@/hooks/useTogglableSet';
 import { pointNearestX } from '@/components/inference/ui/line-label-anchor';
 import {
   labelOpacityForActiveState,
@@ -349,7 +350,6 @@ const ScatterGraph = React.memo(
       removeHwType,
       hwTypesWithData,
       resolveComparisonSelection,
-      toggleComparisonSelection,
       selectedPrecisions,
       selectedYAxisMetric,
       availableRuns,
@@ -453,22 +453,18 @@ const ScatterGraph = React.memo(
       rawOverlayHwTypes.forEach((key) => combined.add(`overlay:${key}`));
       return combined;
     }, [rawOfficialHwTypes, rawOverlayHwTypes]);
-    // Sticky preference for cross-engine exclusion resolution. An unofficial
-    // run loaded via `?unofficialrun=` exists to be seen, so when its configs
-    // conflict with the official engine family the run wins and the conflicting
-    // official series are deselected — the reverse would leave the overlay
-    // permanently hidden with no legend affordance to surface it (the run's
-    // legend entry is not a toggle). Officials stay restorable by dismissing
-    // the run. Without overlay points the official selection is sticky as before.
-    const exclusionStickySet = useMemo(() => {
-      if (rawOverlayHwTypes.size > 0) {
-        return new Set([...rawOverlayHwTypes].map((key) => `overlay:${key}`));
-      }
-      return rawOfficialHwTypes.size > 0 ? rawOfficialHwTypes : rawUnifiedSelection;
-    }, [rawOverlayHwTypes, rawOfficialHwTypes, rawUnifiedSelection]);
+    // Preview mode is diagnostic: official and unofficial runs may use different
+    // engines, and all of them must remain comparable on the same graph. Keep the
+    // production cross-engine guard only when no unofficial overlay is present.
     const resolvedUnifiedSelection = useMemo(
-      () => resolveComparisonSelection(rawUnifiedSelection, exclusionStickySet).result,
-      [rawUnifiedSelection, exclusionStickySet, resolveComparisonSelection],
+      () =>
+        overlayData
+          ? rawUnifiedSelection
+          : resolveComparisonSelection(
+              rawUnifiedSelection,
+              rawOfficialHwTypes.size > 0 ? rawOfficialHwTypes : rawUnifiedSelection,
+            ).result,
+      [overlayData, rawUnifiedSelection, rawOfficialHwTypes, resolveComparisonSelection],
     );
     const resolvedHwTypes = useMemo(() => {
       const official = new Set<string>();
@@ -541,19 +537,11 @@ const ScatterGraph = React.memo(
     const unifiedToggle = useCallback(
       (key: string, isOverlay: boolean) => {
         const prefixedKey = isOverlay ? `overlay:${key}` : key;
-        const next = toggleComparisonSelection(
-          resolvedUnifiedSelection,
-          prefixedKey,
-          allUnifiedHwTypes,
+        commitUnifiedSelection(
+          computeToggle(resolvedUnifiedSelection, prefixedKey, allUnifiedHwTypes),
         );
-        if (next) commitUnifiedSelection(next);
       },
-      [
-        resolvedUnifiedSelection,
-        allUnifiedHwTypes,
-        toggleComparisonSelection,
-        commitUnifiedSelection,
-      ],
+      [resolvedUnifiedSelection, allUnifiedHwTypes, commitUnifiedSelection],
     );
     const resetUnifiedSelection = useCallback(() => {
       selectAllHwTypes();
@@ -561,18 +549,12 @@ const ScatterGraph = React.memo(
         setLocalOfficialOverride(null);
         return;
       }
-      // Same sticky preference as the render-time resolution: keep the overlay
-      // run's engine family so a reset doesn't flip the chart back to the
-      // conflicting official family and re-hide the loaded run.
-      const resolved = resolveComparisonSelection(allUnifiedHwTypes, exclusionStickySet);
-      commitUnifiedSelection(resolved.result);
+      commitUnifiedSelection(allUnifiedHwTypes);
     }, [
       selectAllHwTypes,
       overlayData,
       setLocalOfficialOverride,
       allUnifiedHwTypes,
-      exclusionStickySet,
-      resolveComparisonSelection,
       commitUnifiedSelection,
     ]);
 


### PR DESCRIPTION
## Summary

Follow-up to #575. Unofficial-run preview mode is diagnostic, so it should allow results from multiple engine families to remain visible on the same graph.

- Bypass the production engine-family exclusion when `ScatterGraph` has unofficial overlay data.
- Keep official and unofficial series active together during rendering, legend toggles, and reset.
- Preserve mixed-engine official and overlay rows in table mode and across preview scope changes.
- Keep the existing cross-engine guard unchanged for official-only comparisons.

## Root cause

#575 changed the sticky engine family from the official selection to the unofficial overlay. That made the overlay visible, but it still resolved the combined selection down to one engine family and hid the conflicting official series. Preview mode needs to bypass that restriction rather than choose which side wins.

## Tests

- `tsc --noEmit`
- `oxlint` and `oxfmt` on changed files
- Vitest: 2,985 tests passed across app, constants, DB, and MCP packages
- Cypress component suite: 178 tests passed
- Focused `scatter-graph.cy.tsx`: 12 tests passed, including mixed-engine rendering, table rows, scope changes, legend selection, and the official-only guard
- Full local Cypress integration run: all inference and unofficial-overlay specs passed; 9 of 481 assertions failed in unrelated redirect/evaluation/feature-gate selector timing paths under the local webpack fallback

## Overlay support

This change applies specifically to `?unofficialrun=` / `?unofficialruns=` previews. It covers both official and overlay data paths, respects active overlay hardware filters, and keeps dismissal/reset behavior intact. Preview deployment verification with a real unofficial run will be added once the deployment is available.

## 中文说明

这是 #575 的后续修复。非官方 run 预览用于诊断和对比，因此同一图表应允许同时展示多个引擎家族的结果。

- 当 `ScatterGraph` 存在非官方 overlay 数据时，绕过生产环境的引擎家族互斥规则。
- 渲染、图例切换和重置时同时保留官方与非官方系列。
- 表格模式及预览范围切换后，继续展示跨引擎的官方行和 overlay 行。
- 纯官方对比仍保持现有的跨引擎限制，不改变生产对比行为。

### 根因

#575 只是将“粘性”引擎家族从官方选择改为非官方 overlay。这样虽然能显示 overlay，但合并后的选择仍会被压缩为单一引擎家族，冲突的官方系列会被隐藏。预览模式不应决定哪一方优先，而应完全绕过这项限制。

### 测试

- `tsc --noEmit`
- 对变更文件运行 `oxlint` 和 `oxfmt`
- Vitest：app、constants、DB 和 MCP 共 2,985 项测试通过
- Cypress 组件测试：178 项通过
- 聚焦的 `scatter-graph.cy.tsx`：12 项通过，覆盖跨引擎渲染、表格行、范围切换、图例选择及纯官方限制
- 本地完整 Cypress 集成测试中，所有 inference 和非官方 overlay 相关 spec 均通过；481 项断言中有 9 项在无关的重定向、evaluation 与功能开关选择器时序路径失败（本地使用 webpack 回退模式）

### Overlay 支持

本变更专门作用于 `?unofficialrun=` / `?unofficialruns=` 预览，同时覆盖官方与 overlay 数据路径，遵守启用中的 overlay 硬件过滤，并保持关闭 run 与重置行为不变。部署可用后，将使用真实非官方 run 补充预览环境验证结果。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes only when unofficial overlay data is loaded, but it affects legend selection, table rows, and overlay reconciliation—areas users rely on for comparing runs across engines.
> 
> **Overview**
> Unofficial-run preview (`?unofficialrun=`) is treated as **diagnostic**: official and overlay series from **different engine families** can stay on the same chart and table instead of being collapsed to one family.
> 
> **`ScatterGraph`** skips `resolveComparisonSelection` whenever `overlayData` is present, so rendering and legend state keep the full combined selection. Legend toggles use plain `computeToggle` instead of the production `toggleComparisonSelection` guard, and reset selects all scoped series without overlay-preferring sticky resolution. **Official-only** charts still run the existing cross-engine exclusion.
> 
> **`ChartDisplay`** aligns table/export row visibility with that policy: overlay scoping no longer runs the production comparison resolver, and `visibleComparisonRows` filters official and overlay rows by active keys only.
> 
> Cypress expectations are updated for mixed-engine preview (chart opacity, table row counts, scope changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd37863fc31b06487f52277b079b0b220e45f121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->