### PR TITLE
fix(inference): preserve mixed engines across preview scopes / 修复推理预览切换范围后混合引擎丢失问题

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -783,6 +783,7 @@ describe('ChartDisplay engine comparison guard', () => {
 
     function OverlayScopeHarness() {
       const [secondScope, setSecondScope] = useState(false);
+      const [secondScopeLoaded, setSecondScopeLoaded] = useState(false);
       const [activeOverlayKeys, setActiveOverlayKeys] = useState(new Set(['h100_sglang']));
       const [officialOverride, setOfficialOverride] = useState<Set<string> | null>(null);
       const [, setRenderVersion] = useState(0);
@@ -791,13 +792,16 @@ describe('ChartDisplay engine comparison guard', () => {
       const overlayKeys = secondScope
         ? ['b200_vllm', 'h200_sglang']
         : ['h100_sglang', 'h200_sglang'];
-      const officialRows = officialKeys.map((hwKey) =>
-        createMockInferenceData({
-          hwKey,
-          model,
-          precision: Precision.FP4,
-        }),
-      );
+      const officialRows =
+        secondScope && !secondScopeLoaded
+          ? []
+          : officialKeys.map((hwKey) =>
+              createMockInferenceData({
+                hwKey,
+                model,
+                precision: Precision.FP4,
+              }),
+            );
       const overlayRows = overlayKeys.map((hwKey, index) =>
         createMockInferenceData({
           hwKey,
@@ -817,6 +821,7 @@ describe('ChartDisplay engine comparison guard', () => {
             data: officialRows,
           },
         ],
+        loading: secondScope && !secondScopeLoaded,
         selectedModel: model,
         selectedSequence: Sequence.AgenticTraces,
         selectedXAxisMode: 'interactivity' as const,
@@ -852,6 +857,9 @@ describe('ChartDisplay engine comparison guard', () => {
               <button data-testid="change-overlay-scope" onClick={() => setSecondScope(true)}>
                 Change scope
               </button>
+              <button data-testid="load-official-scope" onClick={() => setSecondScopeLoaded(true)}>
+                Load official scope
+              </button>
               <button
                 data-testid="clear-overlay-scope"
                 onClick={() => setActiveOverlayKeys(new Set())}
@@ -876,6 +884,10 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
 
     cy.get('[data-testid="change-overlay-scope"]').click();
+    // The new overlay scope can arrive before the official query. Its empty
+    // graph must not be persisted as an intentional empty official selection.
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
+    cy.get('[data-testid="load-official-scope"]').click();
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);
     cy.get('[data-testid="rerender-overlay-scope"]').click();
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -511,6 +511,79 @@ describe('ScatterGraph', () => {
       '1',
     );
   });
+
+  it('removes unofficial marks when the last preview run is dismissed', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const officialData = [8, 16, 32].map((x, index) =>
+      createMockInferenceData({
+        hwKey: 'b200_sglang',
+        x,
+        y: 320 - index * 40,
+        precision: Precision.FP4,
+      }),
+    );
+    const runUrl = 'https://github.com/x/y/actions/runs/dismissed-preview';
+    const overlayData = {
+      data: [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey: 'h100_vllm',
+          x,
+          y: 260 - index * 40,
+          precision: Precision.FP4,
+          run_url: runUrl,
+        }),
+      ),
+      hardwareConfig: hwConfig,
+      label: 'dismissed-preview',
+      runUrl,
+    };
+
+    function DismissOverlayHarness() {
+      const [showOverlay, setShowOverlay] = useState(true);
+      return (
+        <div style={{ width: 800, height: 600 }}>
+          <button data-testid="dismiss-preview" onClick={() => setShowOverlay(false)}>
+            Dismiss preview
+          </button>
+          <ScatterGraph
+            chartId="test-scatter-dismiss-preview"
+            modelLabel="DeepSeek V4 Pro"
+            data={officialData}
+            xLabel="Concurrency"
+            yLabel="Throughput / GPU (tok/s)"
+            chartDefinition={chartDefinition}
+            overlayData={showOverlay ? overlayData : undefined}
+          />
+        </div>
+      );
+    }
+
+    mountWithProviders(<DismissOverlayHarness />, {
+      inference: {
+        hardwareConfig: hwConfig,
+        activeHwTypes: new Set(['b200_sglang']),
+        hwTypesWithData: new Set(['b200_sglang']),
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedPrecisions: [Precision.FP4],
+      },
+      unofficial: {
+        isUnofficialRun: true,
+        activeOverlayHwTypes: new Set(['h100_vllm']),
+        allOverlayHwTypes: new Set(['h100_vllm']),
+      },
+    });
+
+    cy.get('#test-scatter-dismiss-preview svg .unofficial-overlay-pt').should('have.length', 3);
+    cy.get('#test-scatter-dismiss-preview svg .overlay-roofline-path').should('exist');
+
+    cy.get('[data-testid="dismiss-preview"]').click();
+    cy.get('#test-scatter-dismiss-preview svg .unofficial-overlay-pt').should('not.exist');
+    cy.get('#test-scatter-dismiss-preview svg .overlay-roofline-path').should('not.exist');
+  });
 });
 
 describe('ChartDisplay engine comparison guard', () => {

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -663,6 +663,78 @@ describe('ScatterGraph', () => {
 });
 
 describe('ChartDisplay engine comparison guard', () => {
+  it('keeps official table rows synchronized with legend state after a scope change', () => {
+    const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
+    const baseInference = createMockInferenceContext();
+    const baseGlobalFilters = createMockGlobalFilterContext();
+
+    function OfficialRowsScopeHarness() {
+      const [secondScope, setSecondScope] = useState(false);
+      const [activeKeys, setActiveKeys] = useState(new Set(['b200_sglang']));
+      const model = secondScope ? Model.DeepSeek_R1 : Model.DeepSeek_V4_Pro;
+      const rows = (secondScope ? ['b200_sglang', 'h100_vllm'] : ['b200_sglang']).map((hwKey) =>
+        createMockInferenceData({
+          hwKey,
+          model,
+          precision: Precision.FP4,
+        }),
+      );
+      const inference = {
+        ...baseInference,
+        graphs: [
+          {
+            model,
+            sequence: Sequence.AgenticTraces,
+            chartDefinition,
+            data: rows,
+          },
+        ],
+        selectedModel: model,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedXAxisMode: 'interactivity' as const,
+        activeHwTypes: activeKeys,
+        hwTypesWithData: new Set(rows.map((row) => String(row.hwKey))),
+      };
+      const globalFilters = {
+        ...baseGlobalFilters,
+        selectedModel: model,
+        selectedSequence: Sequence.AgenticTraces,
+        effectiveSequence: Sequence.AgenticTraces,
+      };
+
+      return (
+        <GlobalFilterContext.Provider value={globalFilters}>
+          <InferenceContext.Provider value={inference}>
+            <button data-testid="change-official-table-scope" onClick={() => setSecondScope(true)}>
+              Change scope
+            </button>
+            <button
+              data-testid="select-official-vllm"
+              onClick={() => setActiveKeys(new Set(['h100_vllm']))}
+            >
+              Select vLLM
+            </button>
+            <ChartDisplay />
+          </InferenceContext.Provider>
+        </GlobalFilterContext.Provider>
+      );
+    }
+
+    mountWithProviders(<OfficialRowsScopeHarness />, { unofficial: {} });
+    cy.get('[data-testid="inference-table-view-btn"]').click();
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+
+    cy.get('[data-testid="change-official-table-scope"]').click();
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody').contains('SGLang').should('exist');
+
+    cy.get('[data-testid="select-official-vllm"]').click();
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody').contains('vLLM').should('exist');
+    cy.get('[data-testid="inference-results-table"] tbody').contains('SGLang').should('not.exist');
+    cy.get('@setLocalOfficialOverride').should('not.have.been.called');
+  });
+
   it('keeps cross-engine AgentX STP rows out of table mode', () => {
     const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
     const sglangRow = createMockInferenceData({
@@ -821,7 +893,7 @@ describe('ChartDisplay engine comparison guard', () => {
         selectedSequence: Sequence.AgenticTraces,
         effectiveSequence: Sequence.AgenticTraces,
       },
-      unofficial: { localOfficialOverride: new Set() },
+      unofficial: { isUnofficialRun: true, localOfficialOverride: new Set() },
     });
 
     cy.get('[data-testid="inference-table-view-btn"]').click();

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -711,19 +711,20 @@ describe('ChartDisplay engine comparison guard', () => {
     function OverlayScopeHarness() {
       const [secondScope, setSecondScope] = useState(false);
       const [activeOverlayKeys, setActiveOverlayKeys] = useState(new Set(['h100_sglang']));
+      const [officialOverride, setOfficialOverride] = useState<Set<string> | null>(null);
       const [, setRenderVersion] = useState(0);
       const model = secondScope ? Model.DeepSeek_R1 : Model.DeepSeek_V4_Pro;
-      const officialKey = secondScope ? 'h100_vllm' : 'b200_sglang';
+      const officialKeys = secondScope ? ['h100_vllm', 'b200_sglang'] : ['b200_sglang'];
       const overlayKeys = secondScope
         ? ['b200_vllm', 'h200_sglang']
         : ['h100_sglang', 'h200_sglang'];
-      const officialRows = [
+      const officialRows = officialKeys.map((hwKey) =>
         createMockInferenceData({
-          hwKey: officialKey,
+          hwKey,
           model,
           precision: Precision.FP4,
         }),
-      ];
+      );
       const overlayRows = overlayKeys.map((hwKey, index) =>
         createMockInferenceData({
           hwKey,
@@ -747,8 +748,8 @@ describe('ChartDisplay engine comparison guard', () => {
         selectedSequence: Sequence.AgenticTraces,
         selectedXAxisMode: 'interactivity' as const,
         selectedXAxisMetric: 'p90_ttft',
-        activeHwTypes: new Set([officialKey]),
-        hwTypesWithData: new Set([officialKey]),
+        activeHwTypes: new Set([officialKeys[0]]),
+        hwTypesWithData: new Set(officialKeys),
         resolveComparisonSelection: resolveSelection,
       };
       const globalFilters = {
@@ -767,6 +768,8 @@ describe('ChartDisplay engine comparison guard', () => {
         activeOverlayHwTypes: activeOverlayKeys,
         setActiveOverlayHwTypes: setActiveOverlayKeys,
         allOverlayHwTypes: new Set(['h100_sglang', 'h200_sglang', 'b200_vllm']),
+        localOfficialOverride: officialOverride,
+        setLocalOfficialOverride: setOfficialOverride,
       };
 
       return (
@@ -800,14 +803,14 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
 
     cy.get('[data-testid="change-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 3);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);
     cy.get('[data-testid="rerender-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 3);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);
 
     cy.get('[data-testid="clear-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
     cy.get('[data-testid="rerender-overlay-scope"]').click();
-    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 1);
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 2);
     cy.get('[data-testid="inference-chart-view-btn"]').click();
     cy.get('#chart-0 svg .unofficial-overlay-pt').should('not.exist');
   });

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -123,6 +123,82 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-points svg .visible-shape').should('have.length.greaterThan', 0);
   });
 
+  it('keeps official-only legend toggles active after a scope change', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const officialData = ['b200_sglang', 'h100_vllm'].flatMap((hwKey, hwIndex) =>
+      [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey,
+          x,
+          y: 320 - hwIndex * 20 - index * 40,
+          precision: Precision.FP4,
+        }),
+      ),
+    );
+    const baseInference = createMockInferenceContext();
+
+    function OfficialScopeHarness() {
+      const [secondScope, setSecondScope] = useState(false);
+      const activeHwTypes = new Set([secondScope ? 'h100_vllm' : 'b200_sglang']);
+      const selectedModel = secondScope ? Model.DeepSeek_R1 : Model.DeepSeek_V4_Pro;
+      const inference = {
+        ...baseInference,
+        hardwareConfig: hwConfig,
+        activeHwTypes,
+        hwTypesWithData: new Set(['b200_sglang', 'h100_vllm']),
+        selectedModel,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedPrecisions: [Precision.FP4],
+      };
+
+      return (
+        <InferenceContext.Provider value={inference}>
+          <button data-testid="change-official-scope" onClick={() => setSecondScope(true)}>
+            Change official scope
+          </button>
+          <div style={{ width: 800, height: 600 }}>
+            <ScatterGraph
+              chartId="test-scatter-official-scope"
+              modelLabel={selectedModel}
+              data={officialData}
+              xLabel="Concurrency"
+              yLabel="Throughput / GPU (tok/s)"
+              chartDefinition={chartDefinition}
+            />
+          </div>
+        </InferenceContext.Provider>
+      );
+    }
+
+    mountWithProviders(<OfficialScopeHarness />, { unofficial: {} });
+
+    cy.get('#test-scatter-official-scope svg .roofline-path[data-hw-key="b200_sglang"]').should(
+      'have.css',
+      'opacity',
+      '1',
+    );
+    cy.get('#test-scatter-official-scope svg .roofline-path[data-hw-key="h100_vllm"]').should(
+      'have.css',
+      'opacity',
+      '0',
+    );
+
+    cy.get('[data-testid="change-official-scope"]').click();
+    cy.get('#test-scatter-official-scope svg .roofline-path[data-hw-key="b200_sglang"]').should(
+      'have.css',
+      'opacity',
+      '0',
+    );
+    cy.get('#test-scatter-official-scope svg .roofline-path[data-hw-key="h100_vllm"]').should(
+      'have.css',
+      'opacity',
+      '1',
+    );
+  });
+
   it('renders legend with hardware items', () => {
     const data = [
       createMockInferenceData({ hwKey: 'b200_trt', x: 64, y: 320, precision: Precision.FP4 }),

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -199,6 +199,116 @@ describe('ScatterGraph', () => {
     );
   });
 
+  it('keeps a preview scope pending until official data arrives', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const baseInference = createMockInferenceContext();
+    const baseUnofficial = createMockUnofficialRunContext();
+
+    function DelayedOfficialScopeHarness() {
+      const [secondScope, setSecondScope] = useState(false);
+      const [secondScopeLoaded, setSecondScopeLoaded] = useState(false);
+      const [activeOverlayKeys, setActiveOverlayKeys] = useState(new Set(['h100_vllm']));
+      const [officialOverride, setOfficialOverride] = useState<Set<string> | null>(
+        new Set(['h100_sglang']),
+      );
+      const model = secondScope ? Model.DeepSeek_R1 : Model.DeepSeek_V4_Pro;
+      const officialKeys = secondScope ? ['b200_sglang', 'h100_vllm'] : ['h100_sglang'];
+      const visibleOfficialKeys = secondScope && !secondScopeLoaded ? [] : officialKeys;
+      const officialRows = visibleOfficialKeys.flatMap((hwKey, hwIndex) =>
+        [8, 16, 32].map((x, index) =>
+          createMockInferenceData({
+            hwKey,
+            model,
+            x,
+            y: 320 - hwIndex * 20 - index * 40,
+            precision: Precision.FP4,
+          }),
+        ),
+      );
+      const overlayKey = secondScope ? 'b200_vllm' : 'h100_vllm';
+      const overlayData = {
+        data: [8, 16, 32].map((x, index) =>
+          createMockInferenceData({
+            hwKey: overlayKey,
+            model,
+            x,
+            y: 260 - index * 40,
+            precision: Precision.FP4,
+          }),
+        ),
+        hardwareConfig: hwConfig,
+        label: 'delayed-official-scope',
+      };
+      const inference = {
+        ...baseInference,
+        hardwareConfig: hwConfig,
+        activeHwTypes: new Set([officialKeys[0]]),
+        hwTypesWithData: new Set(visibleOfficialKeys),
+        loading: secondScope && !secondScopeLoaded,
+        selectedModel: model,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedPrecisions: [Precision.FP4],
+      };
+      const unofficial = {
+        ...baseUnofficial,
+        isUnofficialRun: true,
+        activeOverlayHwTypes: activeOverlayKeys,
+        setActiveOverlayHwTypes: setActiveOverlayKeys,
+        allOverlayHwTypes: new Set(['h100_vllm', 'b200_vllm']),
+        localOfficialOverride: officialOverride,
+        setLocalOfficialOverride: setOfficialOverride,
+      };
+
+      return (
+        <UnofficialRunContext.Provider value={unofficial}>
+          <InferenceContext.Provider value={inference}>
+            <button data-testid="change-delayed-chart-scope" onClick={() => setSecondScope(true)}>
+              Change scope
+            </button>
+            <button
+              data-testid="load-delayed-chart-scope"
+              onClick={() => {
+                setOfficialOverride(new Set(officialKeys));
+                setSecondScopeLoaded(true);
+              }}
+            >
+              Load official data
+            </button>
+            <output data-testid="official-preview-override">
+              {officialOverride === null ? 'none' : [...officialOverride].join(',')}
+            </output>
+            <div style={{ width: 800, height: 600 }}>
+              <ScatterGraph
+                chartId="test-scatter-delayed-official-scope"
+                modelLabel={model}
+                data={officialRows}
+                xLabel="Concurrency"
+                yLabel="Throughput / GPU (tok/s)"
+                chartDefinition={chartDefinition}
+                overlayData={overlayData}
+              />
+            </div>
+          </InferenceContext.Provider>
+        </UnofficialRunContext.Provider>
+      );
+    }
+
+    mountWithProviders(<DelayedOfficialScopeHarness />);
+    cy.get('[data-testid="change-delayed-chart-scope"]').click();
+    cy.get('[data-testid="official-preview-override"]').should('have.text', 'h100_sglang');
+
+    cy.get('[data-testid="load-delayed-chart-scope"]').click();
+    cy.get(
+      '#test-scatter-delayed-official-scope svg .roofline-path[data-hw-key="b200_sglang"]',
+    ).should('have.css', 'opacity', '1');
+    cy.get(
+      '#test-scatter-delayed-official-scope svg .roofline-path[data-hw-key="h100_vllm"]',
+    ).should('have.css', 'opacity', '1');
+  });
+
   it('renders legend with hardware items', () => {
     const data = [
       createMockInferenceData({ hwKey: 'b200_trt', x: 64, y: 320, precision: Precision.FP4 }),

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/favorites/favorite-presets';
 
 import { useGlobalFilters } from '@/components/GlobalFilterContext';
+import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import type {
   InferenceChartContextType,
   InferenceData,
@@ -45,18 +46,12 @@ import { useUrlState } from '@/hooks/useUrlState';
 import { computeToggle } from '@/hooks/useTogglableSet';
 import { buildAvailabilityHwKey } from '@/lib/chart-utils';
 import { getHardwareConfig, getModelSortIndex, isKnownGpu, TABLEAU_10 } from '@/lib/constants';
-import {
-  getModelExclusion,
-  getSequenceExclusion,
-  MODEL_PREFIX_MAPPING,
-  sequenceKind,
-} from '@/lib/data-mappings';
+import { MODEL_PREFIX_MAPPING, sequenceKind } from '@/lib/data-mappings';
 import {
   EngineComparisonConflictToast,
   type EngineComparisonConflictDetail,
 } from '@/components/engine-comparison-conflict-toast';
 import {
-  buildExclusion,
   effectiveLegendItems,
   exclusionResolutionFamilies,
   resolveExclusionGroups,
@@ -72,6 +67,7 @@ import {
   type XAxisMode,
 } from './hooks/useChartData';
 import { resolveComparisonEntries } from './utils/comparisonEntry';
+import { comparisonExclusion as resolveComparisonExclusion } from './utils/comparison-exclusion';
 import { resolveLabelState, serializeLabelState } from './utils/label-defaults';
 import {
   EMPTY_QUICK_FILTERS,
@@ -137,17 +133,14 @@ export function InferenceProvider({
     availableRuns,
     workflowError,
   } = useGlobalFilters();
+  const { isUnofficialRun } = useUnofficialRun();
 
   const { getUrlParam, setUrlParam } = useUrlState();
 
-  const exclusion = useMemo(() => {
-    const modelSpecs = getModelExclusion(selectedModel);
-    const sequenceSpecs = getSequenceExclusion(effectiveSequence);
-    if (modelSpecs.length === 0 && sequenceSpecs.length === 0) return null;
-    if (modelSpecs.length === 0) return buildExclusion(sequenceSpecs);
-    if (sequenceSpecs.length === 0) return buildExclusion(modelSpecs);
-    return buildExclusion([...modelSpecs, ...sequenceSpecs]);
-  }, [selectedModel, effectiveSequence]);
+  const exclusion = useMemo(
+    () => resolveComparisonExclusion(selectedModel, effectiveSequence, isUnofficialRun),
+    [selectedModel, effectiveSequence, isUnofficialRun],
+  );
   const exclusionPolicy: ExclusionConflictPolicy =
     sequenceKind(effectiveSequence) === 'agentic' ? 'keep-sticky' : 'clear-all';
 
@@ -170,6 +163,9 @@ export function InferenceProvider({
   // --- Cross-engine comparison conflict toast state ---
   const [engineConflict, setEngineConflict] = useState<EngineComparisonConflictDetail | null>(null);
   const dismissEngineConflict = useCallback(() => setEngineConflict(null), []);
+  useEffect(() => {
+    if (isUnofficialRun) setEngineConflict(null);
+  }, [isUnofficialRun]);
 
   // ── Inference-specific filter state ─────────────────────────────────────────
   // Defer URL restoration until after mount so the first client render matches SSR.
@@ -988,6 +984,9 @@ export function InferenceProvider({
   // reset commits as soon as data for the new model arrives — without this, switching models
   // bails on the empty-data tick and never re-fires, leaving the legend at the prior intersection.
   const precisionsKey = effectivePrecisions.join(',');
+  const hwResetKey = `${selectedModel}|${effectiveSequence}|${precisionsKey}|${
+    isUnofficialRun ? 'preview' : 'official'
+  }`;
   const lastHwResetKeyRef = useRef('');
 
   // Restore legend-active selection from URL on first availability of
@@ -1023,7 +1022,7 @@ export function InferenceProvider({
       }
     }
     setActiveHwTypes(restored);
-    lastHwResetKeyRef.current = `${selectedModel}|${effectiveSequence}|${precisionsKey}`;
+    lastHwResetKeyRef.current = hwResetKey;
     setPendingActiveHwTypes(null);
   }, [
     pendingActiveHwTypes,
@@ -1032,6 +1031,7 @@ export function InferenceProvider({
     selectedModel,
     effectiveSequence,
     precisionsKey,
+    hwResetKey,
     resolveHwSelection,
     setActiveHwTypes,
   ]);
@@ -1040,9 +1040,8 @@ export function InferenceProvider({
     if (pendingHwFilterRef.current) return;
     if (pendingActiveHwTypes) return;
     if (hwTypesWithData.size === 0) return;
-    const key = `${selectedModel}|${effectiveSequence}|${precisionsKey}`;
-    if (lastHwResetKeyRef.current === key) return;
-    lastHwResetKeyRef.current = key;
+    if (lastHwResetKeyRef.current === hwResetKey) return;
+    lastHwResetKeyRef.current = hwResetKey;
     const presetFilter = presetHwFilterRef.current;
     if (presetFilter) {
       const filtered = new Set(
@@ -1074,6 +1073,7 @@ export function InferenceProvider({
     selectedModel,
     effectiveSequence,
     precisionsKey,
+    hwResetKey,
     hwTypesWithData,
     exclusion,
     pendingActiveHwTypes,
@@ -1530,7 +1530,10 @@ export function InferenceProvider({
   return (
     <InferenceContext.Provider value={value}>
       {children}
-      <EngineComparisonConflictToast detail={engineConflict} onDismiss={dismissEngineConflict} />
+      <EngineComparisonConflictToast
+        detail={isUnofficialRun ? null : engineConflict}
+        onDismiss={dismissEngineConflict}
+      />
       <Dialog open={showDateRangeDialog} onOpenChange={setShowDateRangeDialog}>
         <DialogContent>
           <DialogHeader>

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -489,7 +489,9 @@ export default function ChartDisplay() {
       }
     }
     if (selectionChanged) setActiveOverlayHwTypes(merged);
-    if (overlayRowsScopeChanged) {
+    // A scope change can render once before its official graphs arrive. Do not
+    // persist that transient empty set as an intentional legend selection.
+    if (overlayRowsScopeChanged && (!loading || officialScope.size > 0)) {
       setLocalOfficialOverride(officialScope);
       setAppliedOverlayRowsScopeKey(overlayRowsScopeKey);
     }
@@ -497,6 +499,7 @@ export default function ChartDisplay() {
     overlayRowsScopeChanged,
     overlayRowsScopeKey,
     activeOverlayHwTypes,
+    loading,
     officialScope,
     overlayScope,
     scopedActiveOverlayHwTypes,

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -461,12 +461,13 @@ export default function ChartDisplay() {
     ',',
   )}|${unofficialRunInfos.map((run) => run.url).join(',')}`;
   const [appliedOverlayRowsScopeKey, setAppliedOverlayRowsScopeKey] = useState(overlayRowsScopeKey);
-  const overlayRowsScopeChanged = appliedOverlayRowsScopeKey !== overlayRowsScopeKey;
+  const overlayRowsScopeChanged =
+    isUnofficialRun && appliedOverlayRowsScopeKey !== overlayRowsScopeKey;
   const selectedOfficialHwTypes = overlayRowsScopeChanged
     ? officialScope
-    : localOfficialOverride === null
-      ? activeHwTypes
-      : localOfficialOverride;
+    : isUnofficialRun
+      ? (localOfficialOverride ?? activeHwTypes)
+      : activeHwTypes;
   // Preview tables follow the same policy as ScatterGraph: preserve every
   // active engine family instead of applying the production comparison guard.
   const scopedActiveOverlayHwTypes = useMemo(() => {

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -443,13 +443,28 @@ export default function ChartDisplay() {
     }
     return eligibleKeys;
   }, [overlayDataByChartType, selectedPrecisions, quickFilters]);
+  const officialScope = useMemo(() => {
+    const eligibleKeys = new Set<string>();
+    for (const graph of graphs) {
+      for (const point of graph.data) {
+        if (
+          selectedPrecisions.includes(point.precision) &&
+          matchesQuickFilters(point, quickFilters)
+        ) {
+          eligibleKeys.add(String(point.hwKey));
+        }
+      }
+    }
+    return eligibleKeys;
+  }, [graphs, selectedPrecisions, quickFilters]);
   const overlayRowsScopeKey = `${selectedModel}|${selectedSequence}|${selectedPrecisions.join(
     ',',
   )}|${unofficialRunInfos.map((run) => run.url).join(',')}`;
   const [appliedOverlayRowsScopeKey, setAppliedOverlayRowsScopeKey] = useState(overlayRowsScopeKey);
   const overlayRowsScopeChanged = appliedOverlayRowsScopeKey !== overlayRowsScopeKey;
-  const selectedOfficialHwTypes =
-    overlayRowsScopeChanged || localOfficialOverride === null
+  const selectedOfficialHwTypes = overlayRowsScopeChanged
+    ? officialScope
+    : localOfficialOverride === null
       ? activeHwTypes
       : localOfficialOverride;
   // Preview tables follow the same policy as ScatterGraph: preserve every
@@ -474,18 +489,18 @@ export default function ChartDisplay() {
       }
     }
     if (selectionChanged) setActiveOverlayHwTypes(merged);
-    if (overlayRowsScopeChanged && localOfficialOverride !== null) {
-      setLocalOfficialOverride(null);
+    if (overlayRowsScopeChanged) {
+      setLocalOfficialOverride(officialScope);
+      setAppliedOverlayRowsScopeKey(overlayRowsScopeKey);
     }
-    if (overlayRowsScopeChanged) setAppliedOverlayRowsScopeKey(overlayRowsScopeKey);
   }, [
     overlayRowsScopeChanged,
     overlayRowsScopeKey,
     activeOverlayHwTypes,
+    officialScope,
     overlayScope,
     scopedActiveOverlayHwTypes,
     setActiveOverlayHwTypes,
-    localOfficialOverride,
     setLocalOfficialOverride,
   ]);
 

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -383,6 +383,7 @@ const ScatterGraph = React.memo(
       selectedSequence,
       selectedModel,
       quickFilters,
+      loading,
     } = useInference();
     const locale = useLocale();
     const legendT = SCATTER_STRINGS[locale];
@@ -507,7 +508,13 @@ const ScatterGraph = React.memo(
 
     useEffect(() => {
       if (!overlayData) return;
-      previousOverlayScopeRef.current = overlayScopeKey;
+      // Keep the scope pending while the official query is between scopes.
+      // ChartDisplay uses the same readiness rule before seeding the full
+      // mixed-engine override, so a rerender from overlay reconciliation cannot
+      // fall back to the production-filtered active set in the meantime.
+      if (!overlayScopeChanged || !loading || hwTypesWithData.size > 0) {
+        previousOverlayScopeRef.current = overlayScopeKey;
+      }
       // ChartDisplay seeds the new preview scope with every eligible official
       // series. Avoid replacing it with the production-filtered active set while
       // that parent update is being committed.
@@ -528,6 +535,8 @@ const ScatterGraph = React.memo(
       overlayData,
       overlayScopeKey,
       overlayScopeChanged,
+      loading,
+      hwTypesWithData,
       localOfficialOverride,
       localOfficialOverrideIsStale,
       effectiveOfficialHwTypes,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2654,6 +2654,16 @@ const ScatterGraph = React.memo(
       gradientColorByPoint,
     ]);
 
+    // D3 custom layers are keyed additions, so removing the overlay layer from
+    // the config does not delete DOM that the previous render created. Clear
+    // those marks explicitly when the last unofficial run is dismissed.
+    useLayoutEffect(() => {
+      if (overlayData) return;
+      const svg = chartRef.current?.getSvgElement?.();
+      if (!svg) return;
+      d3.select(svg).selectAll('.unofficial-overlay-pt, .overlay-roofline-path').remove();
+    }, [overlayData]);
+
     // Dismiss tooltip on filter changes
     useEffect(() => {
       chartRef.current?.dismissTooltip();

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -429,11 +429,19 @@ const ScatterGraph = React.memo(
       return true;
     }, [localOfficialOverride, overlayScopeChanged, hwTypesWithData]);
     const rawOfficialHwTypes = useMemo(() => {
-      const source = localOfficialOverrideIsStale
-        ? activeHwTypes
-        : (localOfficialOverride ?? activeHwTypes);
+      const source = overlayScopeChanged
+        ? hwTypesWithData
+        : localOfficialOverrideIsStale
+          ? activeHwTypes
+          : (localOfficialOverride ?? activeHwTypes);
       return new Set([...source].filter((key) => hwTypesWithData.has(key)));
-    }, [activeHwTypes, hwTypesWithData, localOfficialOverride, localOfficialOverrideIsStale]);
+    }, [
+      activeHwTypes,
+      hwTypesWithData,
+      localOfficialOverride,
+      localOfficialOverrideIsStale,
+      overlayScopeChanged,
+    ]);
     const rawOverlayHwTypes = useMemo(
       () =>
         overlayScopeChanged
@@ -496,9 +504,13 @@ const ScatterGraph = React.memo(
     useEffect(() => {
       if (!overlayData) return;
       previousOverlayScopeRef.current = overlayScopeKey;
-      if (localOfficialOverrideIsStale) {
+      // ChartDisplay seeds the new preview scope with every eligible official
+      // series. Avoid replacing it with the production-filtered active set while
+      // that parent update is being committed.
+      if (localOfficialOverrideIsStale && !overlayScopeChanged) {
         setLocalOfficialOverride(null);
       } else if (
+        !overlayScopeChanged &&
         localOfficialOverride !== null &&
         !setsEqual(localOfficialOverride, effectiveOfficialHwTypes)
       ) {
@@ -511,6 +523,7 @@ const ScatterGraph = React.memo(
     }, [
       overlayData,
       overlayScopeKey,
+      overlayScopeChanged,
       localOfficialOverride,
       localOfficialOverrideIsStale,
       effectiveOfficialHwTypes,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -417,7 +417,11 @@ const ScatterGraph = React.memo(
     }, [overlayData, selectedPrecisions, quickFilters]);
     const overlayScopeKey = `${selectedModel}|${selectedSequence}|${selectedPrecisions.join(',')}`;
     const previousOverlayScopeRef = useRef(overlayScopeKey);
-    const overlayScopeChanged = previousOverlayScopeRef.current !== overlayScopeKey;
+    // Scope seeding is preview-only. Official charts have no overlay lifecycle
+    // to commit the ref below, so treating their key changes as pending would
+    // bypass subsequent activeHwTypes legend toggles indefinitely.
+    const overlayScopeChanged =
+      Boolean(overlayData) && previousOverlayScopeRef.current !== overlayScopeKey;
 
     const localOfficialOverrideIsStale = useMemo(() => {
       if (localOfficialOverride === null) return false;

--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { Model, Sequence } from '@/lib/data-mappings';
+
+import { comparisonExclusion } from './comparison-exclusion';
+
+describe('comparisonExclusion', () => {
+  it('keeps the engine-family guard for official Agentic Traces charts', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false);
+
+    expect(exclusion?.familyOf('b200_vllm')).toBe('vllm');
+    expect(exclusion?.familyOf('b200_sglang')).toBe('sglang');
+  });
+
+  it('disables the engine-family guard for unofficial previews', () => {
+    expect(comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, true)).toBeNull();
+  });
+});

--- a/packages/app/src/components/inference/utils/comparison-exclusion.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.ts
@@ -1,0 +1,22 @@
+import { getModelExclusion, getSequenceExclusion } from '@/lib/data-mappings';
+import { buildExclusion, type Exclusion } from '@/lib/exclusion';
+
+/**
+ * Resolve the production comparability guard for the current chart scope.
+ * Unofficial previews are diagnostic and intentionally allow engine families
+ * to share a graph, even when the corresponding official view does not.
+ */
+export function comparisonExclusion(
+  model: Parameters<typeof getModelExclusion>[0],
+  sequence: Parameters<typeof getSequenceExclusion>[0],
+  isUnofficialRun: boolean,
+): Exclusion | null {
+  if (isUnofficialRun) return null;
+
+  const modelSpecs = getModelExclusion(model);
+  const sequenceSpecs = getSequenceExclusion(sequence);
+  if (modelSpecs.length === 0 && sequenceSpecs.length === 0) return null;
+  if (modelSpecs.length === 0) return buildExclusion(sequenceSpecs);
+  if (sequenceSpecs.length === 0) return buildExclusion(modelSpecs);
+  return buildExclusion([...modelSpecs, ...sequenceSpecs]);
+}


### PR DESCRIPTION
## Summary

- Disable the production engine-family exclusion throughout `InferenceProvider` while an unofficial run preview is loaded.
- Preserve every eligible official and unofficial engine series when the preview changes model, sequence, or precision scope.
- Seed preview-only chart and table selections from the full new scope instead of the production-filtered `activeHwTypes` set.
- Suppress stale production conflict notices in preview mode and remove D3 overlay marks when the last unofficial run is dismissed.
- Keep the production engine-family restriction unchanged when no unofficial run is loaded.

Follow-up to #575 and #576. This addresses the post-merge Bugbot finding in https://github.com/SemiAnalysisAI/InferenceX-app/pull/576#discussion_r3575247628.

## Root cause

#576 stored preview-only mixed official selections in `localOfficialOverride`, while `InferenceProvider` continued applying the production exclusion to `activeHwTypes`. Scope changes and provider resets could therefore drop engine families or show a false restriction notice. Dismissing the last run also removed the React overlay data without deleting the previous custom D3 layer's DOM.

## Validation

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- Unit suites: 2,987 tests passed
- Cypress component suite: 182/182 tests passed
- Real-run browser verification with `?unofficialrun=29272097721`: Agentic Traces rendered 10 unofficial points with 3 vLLM and 3 SGLang official rooflines, no engine-conflict toast, and dismissing the run removed all unofficial points and rooflines
- Vercel deployment passed: https://inferencemax-app-git-agent-unofficial-pre-f700e9-semianalysisai.vercel.app (team SSO-protected; interactive real-run verification performed against the same branch locally)

Works for both official runs and `?unofficialrun=` overlays. Official-only views retain the production comparability guard; preview views allow mixed engines across chart, legend, reset, table, scope changes, and run dismissal.

## 中文说明

- 加载非官方运行预览时，在 `InferenceProvider` 全链路停用正式环境的引擎系列互斥规则。
- 预览切换模型、序列或精度范围时，保留所有符合条件的官方与非官方引擎系列。
- 图表和表格在进入新的预览范围时，会基于该范围内的完整数据初始化选择，不再回退到受正式环境互斥规则限制的 `activeHwTypes`。
- 预览模式下不再显示过期的正式环境冲突提示；移除最后一个非官方运行时，也会同步清理 D3 叠加标记。
- 未加载非官方运行时，正式环境原有的引擎系列限制保持不变。

这是 #575 和 #576 的后续修复，并处理了 #576 合并后 Bugbot 指出的回归问题：https://github.com/SemiAnalysisAI/InferenceX-app/pull/576#discussion_r3575247628。

## 根因

#576 通过 `localOfficialOverride` 保存仅用于预览的混合官方引擎选择，但 `InferenceProvider` 仍会对 `activeHwTypes` 应用正式环境的互斥规则。因此，切换范围或 Provider 重置时仍可能丢失部分引擎系列，或错误显示限制提示。移除最后一个运行时，React 侧虽然清除了叠加数据，但之前创建的 D3 自定义图层 DOM 没有同步删除。

## 验证

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- 单元测试：2,987 项全部通过
- Cypress 组件测试：182/182 项全部通过
- 使用 `?unofficialrun=29272097721` 进行真实运行浏览器验证：Agentic Traces 同时渲染 10 个非官方数据点、3 条 vLLM 与 3 条 SGLang 官方 roofline，未出现引擎冲突提示；移除该运行后，所有非官方数据点和 roofline 均被清理
- Vercel 部署已通过：https://inferencemax-app-git-agent-unofficial-pre-f700e9-semianalysisai.vercel.app（受团队 SSO 保护；交互式真实运行验证在同一分支的本地环境完成）

官方运行和 `?unofficialrun=` 叠加路径均受支持。仅官方数据的视图继续保留正式环境兼容性限制；预览视图则在图表、图例、重置、表格、范围切换和运行移除等路径中允许混合引擎。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference legend, table filtering, and exclusion logic on chart/table paths; behavior is split between official and preview modes but covered by expanded Cypress and unit tests.
> 
> **Overview**
> Fixes preview (`?unofficialrun=`) charts losing mixed engine families or showing wrong legend/table rows when model, sequence, or precision changes, or when official data loads after overlays.
> 
> **Unofficial preview** now skips the production engine-family exclusion via `comparisonExclusion` in `InferenceProvider`, so `activeHwTypes` resets and legend toggles are not filtered by the Agentic comparability guard. Engine conflict toasts are suppressed while a preview is loaded.
> 
> **Scope transitions** in `ScatterGraph` and `ChartDisplay` treat overlay scope changes as preview-only, wait out `loading` with empty official graphs before committing `localOfficialOverride`, and seed selections from the full eligible **official** scope instead of production-filtered `activeHwTypes`. Official-only charts no longer get stuck ignoring legend toggles after a scope key change.
> 
> **Dismissal**: when overlay data is removed, a `useLayoutEffect` strips leftover D3 `.unofficial-overlay-pt` and `.overlay-roofline-path` nodes.
> 
> Cypress and unit tests cover delayed official fetch, table/chart sync, and overlay dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5f6073e2693d4071762d894500d6363e70e7e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->