### PR TITLE
feat: add a endpoint; correct GPU power & spec data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,9 @@ API routes (`packages/app/src/app/api/v1/`):
 - `evaluations` — raw `EvalRow[]`
 - `server-log` — retrieve benchmark runtime logs
 - `invalidate` — invalidate API cache (admin)
+- `tco-feed?model=dsv4&workloads=1024x1024,8192x1024&tiers=30,50,75,100&format=csv` — per-hardware Pareto-frontier output-throughput reads at fixed interactivity tiers, for external spreadsheet TCO models (Excel Power Query)
 
-**API routes return raw DB data** — no presentation logic. Frontend handles all transformations.
+**API routes return raw DB data** — no presentation logic. Frontend handles all transformations. Sole exception: `tco-feed`, which runs the calculator's frontier interpolation server-side because its consumers (spreadsheets) cannot execute the TS transforms; it serves reads only — weights/assumptions stay with the consumer.
 
 Static content routes (no DB):
 

--- a/packages/app/src/app/api/v1/tco-feed/route.ts
+++ b/packages/app/src/app/api/v1/tco-feed/route.ts
@@ -1,0 +1,127 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { DB_MODEL_TO_DISPLAY, DISPLAY_MODEL_TO_DB } from '@semianalysisai/inferencex-constants';
+import { FIXTURES_MODE, getDb } from '@semianalysisai/inferencex-db/connection';
+
+import { getLatestBenchmarks } from '@semianalysisai/inferencex-db/queries/benchmarks';
+
+import { cachedJson, cachedQuery, cachedText } from '@/lib/api-cache';
+import { loadFixture } from '@/lib/test-fixtures';
+
+import {
+  computeTcoFeed,
+  parseTiers,
+  parseWorkloads,
+  tcoFeedToCsv,
+  type TcoFeedRow,
+  type TcoFeedSourceRow,
+  type TcoFeedWorkload,
+} from '@/lib/tco-feed';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/v1/tco-feed
+ *
+ * Per-hardware Pareto-frontier throughput reads at fixed interactivity
+ * tiers, for external spreadsheet TCO models (Excel Power Query and
+ * similar consumers that cannot run the frontend's TS transforms).
+ *
+ * This route is a DOCUMENTED EXCEPTION to the "/api/v1 returns raw DB
+ * data" convention: it applies the dashboard's frontier interpolation
+ * (calculator/interpolation.ts) server-side so external consumers get
+ * numbers identical to what the chart renders, without reimplementing —
+ * and inevitably drifting from — the spline. Keep all *assumptions*
+ * (tier weights, workload mix, token-value ratios) out of this route;
+ * it serves reads, consumers apply weights.
+ *
+ * Query params (all optional):
+ * - model     — DB key (`dsv4`) or display name (`DeepSeek-V4-Pro`).
+ *               Default `dsv4`.
+ * - workloads — `<isl>x<osl>` pairs, comma-separated.
+ *               Default `1024x1024,8192x1024`.
+ * - tiers     — interactivity read points (tok/s/user), comma-separated.
+ *               Default `30,50,75,100`.
+ * - date      — `YYYY-MM-DD`; reads use data as of this date
+ *               (reproducibility of published sheets). Default: latest.
+ * - format    — `json` (default) or `csv` (one-line Power Query import).
+ */
+
+const getCachedTcoFeed = cachedQuery(
+  async (
+    dbModelKeys: string[],
+    date: string | undefined,
+    workloads: TcoFeedWorkload[],
+    tiers: number[],
+  ): Promise<TcoFeedRow[]> => {
+    const rows = await getLatestBenchmarks(getDb(), dbModelKeys, date);
+    return computeTcoFeed(rows, workloads, tiers);
+  },
+  'tco-feed',
+);
+
+/** Resolve a `model` param that may be a DB key or a display name. */
+function resolveModelKeys(model: string): string[] | undefined {
+  const fromDisplay = DISPLAY_MODEL_TO_DB[model];
+  if (fromDisplay && fromDisplay.length > 0) return fromDisplay;
+  if (DB_MODEL_TO_DISPLAY[model]) return [model];
+  return undefined;
+}
+
+export async function GET(request: NextRequest) {
+  const params = request.nextUrl.searchParams;
+
+  const model = params.get('model') ?? 'dsv4';
+  const dbModelKeys = resolveModelKeys(model);
+  if (!dbModelKeys) {
+    return NextResponse.json({ error: 'Unknown model' }, { status: 400 });
+  }
+
+  const workloads = parseWorkloads(params.get('workloads'));
+  if (!workloads) {
+    return NextResponse.json(
+      { error: 'Invalid workloads — expected comma-separated <isl>x<osl> pairs' },
+      { status: 400 },
+    );
+  }
+
+  const tiers = parseTiers(params.get('tiers'));
+  if (!tiers) {
+    return NextResponse.json(
+      { error: 'Invalid tiers — expected comma-separated positive numbers' },
+      { status: 400 },
+    );
+  }
+
+  const dateParam = params.get('date');
+  if (dateParam !== null && !/^\d{4}-\d{2}-\d{2}$/u.test(dateParam)) {
+    return NextResponse.json({ error: 'Invalid date — expected YYYY-MM-DD' }, { status: 400 });
+  }
+  const date = dateParam ?? undefined;
+
+  const format = params.get('format') ?? 'json';
+  if (format !== 'json' && format !== 'csv') {
+    return NextResponse.json({ error: 'Invalid format — expected json or csv' }, { status: 400 });
+  }
+
+  try {
+    const rows = FIXTURES_MODE
+      ? computeTcoFeed(loadFixture<TcoFeedSourceRow[]>('benchmarks'), workloads, tiers)
+      : await getCachedTcoFeed(dbModelKeys, date, workloads, tiers);
+
+    if (format === 'csv') {
+      return cachedText(tcoFeedToCsv(rows), 'text/csv; charset=utf-8');
+    }
+    return cachedJson({
+      model,
+      db_model_keys: dbModelKeys,
+      date: date ?? null,
+      workloads: workloads.map((w) => `${w.isl}x${w.osl}`),
+      tiers,
+      rows,
+    });
+  } catch (error) {
+    console.error('Error computing tco-feed:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/packages/app/src/lib/api-cache.ts
+++ b/packages/app/src/lib/api-cache.ts
@@ -61,6 +61,19 @@ function cdnHeaders(): Record<string, string> {
   };
 }
 
+/**
+ * CDN-cached plain-text response (e.g. CSV) with the same cache headers and
+ * purge tag as cachedJson. Uncompressed — use only for small payloads.
+ */
+export function cachedText(data: string, contentType: string): Response {
+  return new Response(data, {
+    headers: {
+      'Content-Type': contentType,
+      ...cdnHeaders(),
+    },
+  });
+}
+
 /** CDN-cached streamed + gzip-compressed JSON response — supports up to 20 MB on Vercel CDN. */
 export function cachedJson<T>(data: T): Response {
   const bytes = new TextEncoder().encode(JSON.stringify(data));

--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -196,7 +196,7 @@ describe('getHardwareConfig', () => {
 describe('getGpuSpecs', () => {
   it('returns specs for a base GPU key', () => {
     const specs = getGpuSpecs('h100');
-    expect(specs.power).toBe(1.73);
+    expect(specs.power).toBe(1.37);
     expect(specs.costh).toBe(1.3);
     expect(specs.costn).toBe(1.69);
     expect(specs.costr).toBe(1.3);
@@ -204,12 +204,12 @@ describe('getGpuSpecs', () => {
 
   it('extracts base from compound key (e.g. h100_vllm)', () => {
     const specs = getGpuSpecs('h100_vllm');
-    expect(specs.power).toBe(1.73);
+    expect(specs.power).toBe(1.37);
   });
 
   it('extracts base from dash-separated key (e.g. h200-dynamo-trt)', () => {
     const specs = getGpuSpecs('h200-dynamo-trt');
-    expect(specs.power).toBe(1.73);
+    expect(specs.power).toBe(1.37);
     expect(specs.costh).toBe(1.41);
   });
 

--- a/packages/app/src/lib/gpu-specs.test.ts
+++ b/packages/app/src/lib/gpu-specs.test.ts
@@ -81,8 +81,8 @@ describe('GPU_SPECS', () => {
     expect(findGpu('GB200 NVL72').memory).toBe('192 GB');
   });
 
-  it('B300 SXM and GB300 NVL72 have different memory capacities', () => {
-    expect(findGpu('B300 SXM').memory).toBe('268 GB');
+  it('B300 SXM and GB300 NVL72 both carry 288 GB (Blackwell Ultra HBM3e)', () => {
+    expect(findGpu('B300 SXM').memory).toBe('288 GB');
     expect(findGpu('GB300 NVL72').memory).toBe('288 GB');
   });
 
@@ -191,10 +191,10 @@ describe('GPU_SPECS', () => {
     expect(findGpu('GB200 NVL72').scaleUpBandwidth).toBe('900 GB/s');
     expect(findGpu('GB300 NVL72').scaleUpBandwidth).toBe('900 GB/s');
 
-    // AMD Infinity Fabric: MI300X/MI325X = 448 GB/s, MI355X = 576 GB/s (5th Gen IF)
+    // AMD Infinity Fabric: MI300X/MI325X = 448 GB/s, MI355X = 538 GB/s (5th Gen IF)
     expect(findGpu('MI300X').scaleUpBandwidth).toBe('448 GB/s');
     expect(findGpu('MI325X').scaleUpBandwidth).toBe('448 GB/s');
-    expect(findGpu('MI355X').scaleUpBandwidth).toBe('576 GB/s');
+    expect(findGpu('MI355X').scaleUpBandwidth).toBe('538 GB/s');
   });
 
   it('MI355X has higher scale-up bandwidth than MI300X/MI325X (5th Gen IF)', () => {
@@ -377,8 +377,8 @@ describe('getScaleUpDomainMemory', () => {
   });
 
   it('computes B300 SXM domain memory correctly', () => {
-    const spec = { memory: '268 GB', scaleUpWorldSize: 8 } as GpuSpec;
-    expect(getScaleUpDomainMemory(spec)).toBe('2.14 TB');
+    const spec = { memory: '288 GB', scaleUpWorldSize: 8 } as GpuSpec;
+    expect(getScaleUpDomainMemory(spec)).toBe('2.3 TB');
   });
 
   it('computes GB300 NVL72 domain memory correctly', () => {
@@ -609,7 +609,7 @@ describe('getScaleUpTopologyConfig', () => {
     const config = getScaleUpTopologyConfig(mi355);
     expect(config.type).toBe('mesh');
     expect(config.techName).toBe('5th Gen Infinity Fabric');
-    expect(config.totalBandwidth).toBe('576 GB/s');
+    expect(config.totalBandwidth).toBe('538 GB/s');
   });
 
   it('all GPUs return a valid scale-up topology config', () => {
@@ -754,7 +754,7 @@ describe('GPU_CHART_METRICS', () => {
     const mi355x = GPU_SPECS.find((s) => s.name === 'MI355X')!;
     expect(metric.getValue(h100)).toBe(450);
     expect(metric.getValue(b200)).toBe(900);
-    expect(metric.getValue(mi355x)).toBe(576);
+    expect(metric.getValue(mi355x)).toBe(538);
   });
 
   it('all metrics return a number (not null) for at least some GPUs', () => {

--- a/packages/app/src/lib/gpu-specs.ts
+++ b/packages/app/src/lib/gpu-specs.ts
@@ -112,7 +112,7 @@ export const GPU_SPECS: GpuSpec[] = [
   {
     name: 'B300 SXM',
     vendor: 'nvidia',
-    memory: '268 GB',
+    memory: '288 GB',
     memoryType: 'HBM3e',
     memoryBandwidth: '8 TB/s',
     fp4: 13500,
@@ -219,7 +219,7 @@ export const GPU_SPECS: GpuSpec[] = [
     fp8: 5033,
     bf16: 2516,
     scaleUpTech: '5th Gen Infinity Fabric',
-    scaleUpBandwidth: '576 GB/s',
+    scaleUpBandwidth: '538 GB/s',
     scaleUpWorldSize: 8,
     scaleOutBandwidth: '400 Gbit/s',
     scaleOutTech: 'RoCEv2 Ethernet',

--- a/packages/app/src/lib/tco-feed.test.ts
+++ b/packages/app/src/lib/tco-feed.test.ts
@@ -107,22 +107,27 @@ describe('computeTcoFeed — frontier reads', () => {
     expect(low.frontier_max_interactivity).toBe(80);
   });
 
-  it('derives interactivity from median_itl only — stored intvty values are never trusted', () => {
+  it('uses stored median_intvty (chart parity), falling back to 1/median_itl', () => {
     const rows = computeTcoFeed(
       [
-        // Bogus stored median_intvty must be ignored; itl says iv = 50.
+        // Stored intvty wins — it is what the chart plots for single_turn
+        // rows — even when 1/median_itl disagrees (here itl implies iv 40).
         makeRow({
-          metrics: { median_itl: 1 / 50, output_tput_per_gpu: 600, median_intvty: 9999 },
+          metrics: { median_intvty: 50, median_itl: 1 / 40, output_tput_per_gpu: 600 },
         }),
-        // No itl at all → row dropped even though intvty is present.
-        makeRow({ metrics: { median_intvty: 50, output_tput_per_gpu: 5000 } }),
+        // Legacy row without intvty → derived from itl (iv 20, higher tput,
+        // so it lands on the frontier as the low-iv knot).
+        makeRow({ metrics: { median_itl: 1 / 20, output_tput_per_gpu: 900 } }),
+        // Neither metric valid → row dropped.
+        makeRow({ metrics: { output_tput_per_gpu: 5000 } }),
       ],
       WORKLOAD_8K1K,
-      [50],
+      [20, 50],
     );
-    expect(rows).toHaveLength(1);
-    expect(rows[0].output_tput_per_gpu).toBe(600);
-    expect(rows[0].frontier_points).toBe(1);
+    expect(rows).toHaveLength(2);
+    expect(findRow(rows, 'gb200', '8192x1024', 50)?.output_tput_per_gpu).toBe(600);
+    expect(findRow(rows, 'gb200', '8192x1024', 20)?.output_tput_per_gpu).toBe(900);
+    expect(rows[0].frontier_points).toBe(2);
   });
 
   it('treats rows without a benchmark_type (legacy fixtures) as single_turn', () => {

--- a/packages/app/src/lib/tco-feed.test.ts
+++ b/packages/app/src/lib/tco-feed.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeTcoFeed,
+  DEFAULT_TIERS,
+  DEFAULT_WORKLOADS,
+  parseTiers,
+  parseWorkloads,
+  tcoFeedToCsv,
+  type TcoFeedRow,
+  type TcoFeedSourceRow,
+} from './tco-feed';
+
+/** Build a single_turn source row: interactivity = 1/itl, output tput = otput. */
+function makeRow(overrides: Partial<TcoFeedSourceRow> & { itl?: number; otput?: number } = {}) {
+  const { itl = 0.02, otput = 500, ...rest } = overrides;
+  return {
+    hardware: 'gb200',
+    benchmark_type: 'single_turn',
+    isl: 8192,
+    osl: 1024,
+    metrics: { median_itl: itl, output_tput_per_gpu: otput },
+    date: '2026-07-10',
+    ...rest,
+  };
+}
+
+const WORKLOAD_8K1K = [{ isl: 8192, osl: 1024 }];
+
+/** Three-knot frontier: (iv 20 → 1000), (iv 50 → 400), (iv 100 → 100). */
+function threeKnotRows(): TcoFeedSourceRow[] {
+  return [
+    makeRow({ itl: 1 / 20, otput: 1000 }),
+    makeRow({ itl: 1 / 50, otput: 400 }),
+    makeRow({ itl: 1 / 100, otput: 100 }),
+  ];
+}
+
+function findRow(rows: TcoFeedRow[], hardware: string, workload: string, tier: number) {
+  return rows.find((r) => r.hardware === hardware && r.workload === workload && r.tier === tier);
+}
+
+describe('computeTcoFeed — frontier reads', () => {
+  it('returns exact values at frontier knots and interpolates between them', () => {
+    const rows = computeTcoFeed(threeKnotRows(), WORKLOAD_8K1K, [20, 35, 50, 100]);
+    expect(rows).toHaveLength(4);
+
+    // Exact knots read exactly.
+    expect(findRow(rows, 'gb200', '8192x1024', 20)?.output_tput_per_gpu).toBe(1000);
+    expect(findRow(rows, 'gb200', '8192x1024', 50)?.output_tput_per_gpu).toBe(400);
+    expect(findRow(rows, 'gb200', '8192x1024', 100)?.output_tput_per_gpu).toBe(100);
+
+    // Between knots: strictly inside the neighboring knots' range.
+    const mid = findRow(rows, 'gb200', '8192x1024', 35)!;
+    expect(mid.boundary).toBe('interpolated');
+    expect(mid.output_tput_per_gpu).toBeGreaterThan(400);
+    expect(mid.output_tput_per_gpu).toBeLessThan(1000);
+  });
+
+  it('excludes Pareto-dominated points from the frontier and from provenance dates', () => {
+    const rows = computeTcoFeed(
+      [
+        ...threeKnotRows(),
+        // Dominated: iv 40 / 300 sits below the 20→1000 / 50→400 frontier —
+        // and carries a NEWER date that must not leak into provenance.
+        makeRow({ itl: 1 / 40, otput: 300, date: '2026-09-09' }),
+      ],
+      WORKLOAD_8K1K,
+      [40],
+    );
+    const read = findRow(rows, 'gb200', '8192x1024', 40)!;
+    expect(read.frontier_points).toBe(3);
+    // Interpolates the 20→1000 / 50→400 segment, unaffected by the 300 point.
+    expect(read.output_tput_per_gpu).toBeGreaterThan(400);
+    expect(read.latest_date).toBe('2026-07-10');
+  });
+
+  it('builds the frontier as the envelope across configs of the same hardware', () => {
+    const rows = computeTcoFeed(
+      [
+        makeRow({ itl: 1 / 50, otput: 400 }), // config A
+        makeRow({ itl: 1 / 50, otput: 900 }), // config B dominates at the same iv
+      ],
+      WORKLOAD_8K1K,
+      [50],
+    );
+    expect(findRow(rows, 'gb200', '8192x1024', 50)?.output_tput_per_gpu).toBe(900);
+  });
+
+  it('clamps below the sweep floor and zeroes above the capability ceiling', () => {
+    // Frontier spans iv 40 → 80.
+    const source = [makeRow({ itl: 1 / 40, otput: 800 }), makeRow({ itl: 1 / 80, otput: 200 })];
+    const rows = computeTcoFeed(source, WORKLOAD_8K1K, [30, 60, 100]);
+
+    const low = findRow(rows, 'gb200', '8192x1024', 30)!;
+    expect(low.boundary).toBe('clamped_low');
+    expect(low.output_tput_per_gpu).toBe(800); // min-iv knot = highest measured tput
+
+    const mid = findRow(rows, 'gb200', '8192x1024', 60)!;
+    expect(mid.boundary).toBe('interpolated');
+
+    const high = findRow(rows, 'gb200', '8192x1024', 100)!;
+    expect(high.boundary).toBe('unreachable');
+    expect(high.output_tput_per_gpu).toBe(0);
+
+    expect(low.frontier_min_interactivity).toBe(40);
+    expect(low.frontier_max_interactivity).toBe(80);
+  });
+
+  it('derives interactivity from median_itl only — stored intvty values are never trusted', () => {
+    const rows = computeTcoFeed(
+      [
+        // Bogus stored median_intvty must be ignored; itl says iv = 50.
+        makeRow({
+          metrics: { median_itl: 1 / 50, output_tput_per_gpu: 600, median_intvty: 9999 },
+        }),
+        // No itl at all → row dropped even though intvty is present.
+        makeRow({ metrics: { median_intvty: 50, output_tput_per_gpu: 5000 } }),
+      ],
+      WORKLOAD_8K1K,
+      [50],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].output_tput_per_gpu).toBe(600);
+    expect(rows[0].frontier_points).toBe(1);
+  });
+
+  it('treats rows without a benchmark_type (legacy fixtures) as single_turn', () => {
+    const legacy = makeRow({ itl: 1 / 50, otput: 700 });
+    delete (legacy as { benchmark_type?: string | null }).benchmark_type;
+    const rows = computeTcoFeed([legacy], WORKLOAD_8K1K, [50]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].output_tput_per_gpu).toBe(700);
+  });
+
+  it('filters out agentic rows, other workloads, and invalid metrics', () => {
+    const rows = computeTcoFeed(
+      [
+        makeRow({ itl: 1 / 50, otput: 400 }),
+        makeRow({
+          benchmark_type: 'agentic_traces',
+          isl: null,
+          osl: null,
+          itl: 1 / 50,
+          otput: 9000,
+        }),
+        makeRow({ isl: 1024, osl: 1024, itl: 1 / 50, otput: 9000 }), // different workload
+        makeRow({ itl: 0, otput: 9000 }), // invalid itl
+        makeRow({ itl: 1 / 50, otput: 0 }), // invalid tput
+      ],
+      WORKLOAD_8K1K,
+      [50],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].output_tput_per_gpu).toBe(400);
+  });
+
+  it('tracks newest and oldest frontier-knot dates for freshness', () => {
+    const rows = computeTcoFeed(
+      [
+        makeRow({ itl: 1 / 20, otput: 1000, date: '2026-04-25' }),
+        makeRow({ itl: 1 / 80, otput: 300, date: '2026-07-12' }),
+      ],
+      WORKLOAD_8K1K,
+      [50],
+    );
+    expect(rows[0].latest_date).toBe('2026-07-12');
+    expect(rows[0].oldest_frontier_date).toBe('2026-04-25');
+  });
+
+  it('groups by workload and hardware, sorted by hardware key', () => {
+    const rows = computeTcoFeed(
+      [
+        makeRow({ hardware: 'gb300', itl: 1 / 50, otput: 5000 }),
+        makeRow({ hardware: 'b200', itl: 1 / 50, otput: 500 }),
+        makeRow({ hardware: 'b200', isl: 1024, osl: 1024, itl: 1 / 50, otput: 1300 }),
+      ],
+      [
+        { isl: 1024, osl: 1024 },
+        { isl: 8192, osl: 1024 },
+      ],
+      [50],
+    );
+    expect(rows.map((r) => `${r.hardware}:${r.workload}`)).toEqual([
+      'b200:1024x1024',
+      'b200:8192x1024',
+      'gb300:8192x1024',
+    ]);
+    expect(findRow(rows, 'b200', '1024x1024', 50)?.output_tput_per_gpu).toBe(1300);
+    expect(findRow(rows, 'gb300', '8192x1024', 50)?.output_tput_per_gpu).toBe(5000);
+  });
+
+  it('returns an empty feed for empty input', () => {
+    expect(computeTcoFeed([], WORKLOAD_8K1K, [50])).toEqual([]);
+  });
+});
+
+describe('parseTiers', () => {
+  it('defaults when absent or blank', () => {
+    expect(parseTiers(null)).toEqual([...DEFAULT_TIERS]);
+    expect(parseTiers('  ')).toEqual([...DEFAULT_TIERS]);
+  });
+
+  it('parses valid lists including decimals and whitespace', () => {
+    expect(parseTiers('30,50')).toEqual([30, 50]);
+    expect(parseTiers(' 12.5 , 100 ')).toEqual([12.5, 100]);
+  });
+
+  it('rejects non-positive, non-numeric, oversized, and malformed entries', () => {
+    expect(parseTiers('0,50')).toBeNull();
+    expect(parseTiers('-5')).toBeNull();
+    expect(parseTiers('abc')).toBeNull();
+    expect(parseTiers('30,,50')).toBeNull();
+    expect(parseTiers('10001')).toBeNull();
+    expect(parseTiers(Array.from({ length: 21 }, (_, i) => String(i + 1)).join(','))).toBeNull();
+  });
+});
+
+describe('parseWorkloads', () => {
+  it('defaults when absent or blank', () => {
+    expect(parseWorkloads(null)).toEqual([...DEFAULT_WORKLOADS]);
+    expect(parseWorkloads('')).toEqual([...DEFAULT_WORKLOADS]);
+  });
+
+  it('parses valid <isl>x<osl> lists', () => {
+    expect(parseWorkloads('8192x1024')).toEqual([{ isl: 8192, osl: 1024 }]);
+    expect(parseWorkloads('1024x1024, 8192x1024')).toEqual([
+      { isl: 1024, osl: 1024 },
+      { isl: 8192, osl: 1024 },
+    ]);
+  });
+
+  it('rejects malformed pairs, zero lengths, and oversized lists', () => {
+    expect(parseWorkloads('8192X1024')).toBeNull(); // uppercase separator
+    expect(parseWorkloads('axb')).toBeNull();
+    expect(parseWorkloads('0x1024')).toBeNull();
+    expect(parseWorkloads('8192x')).toBeNull();
+    expect(parseWorkloads(Array.from({ length: 9 }, () => '1024x1024').join(','))).toBeNull();
+  });
+});
+
+describe('tcoFeedToCsv', () => {
+  it('serializes header plus one line per row, newline-terminated', () => {
+    const feed = computeTcoFeed(threeKnotRows(), WORKLOAD_8K1K, [50, 200]);
+    const csv = tcoFeedToCsv(feed);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe(
+      'hardware,workload,tier,output_tput_per_gpu,boundary,frontier_points,' +
+        'frontier_min_interactivity,frontier_max_interactivity,latest_date,oldest_frontier_date',
+    );
+    expect(lines).toHaveLength(4); // header + 2 rows + trailing newline
+    expect(lines[1]).toBe('gb200,8192x1024,50,400,interpolated,3,20,100,2026-07-10,2026-07-10');
+    expect(lines[2]).toBe('gb200,8192x1024,200,0,unreachable,3,20,100,2026-07-10,2026-07-10');
+    expect(csv.endsWith('\n')).toBe(true);
+  });
+});

--- a/packages/app/src/lib/tco-feed.ts
+++ b/packages/app/src/lib/tco-feed.ts
@@ -138,14 +138,23 @@ export function computeTcoFeed(
       // match below excludes anyway).
       if ((row.benchmark_type ?? 'single_turn') !== 'single_turn') continue;
       if (row.isl !== workload.isl || row.osl !== workload.osl) continue;
-      // Interactivity is ALWAYS derived as 1/median_itl. Stored `*_intvty`
-      // values have drifted across harness versions and are never trusted —
-      // same rule as benchmark-transform.ts on the chart path.
+      // Chart parity: for single_turn rows the inference chart plots the
+      // STORED median_intvty on the x-axis (the ingest mapper's 1/itl
+      // invariant only rewrites agentic rows), so prefer the stored value
+      // and fall back to 1/median_itl only for legacy rows/fixtures that
+      // predate the intvty key.
+      const storedIv = row.metrics.median_intvty;
       const itl = row.metrics.median_itl;
+      const interactivity =
+        Number.isFinite(storedIv) && storedIv > 0
+          ? storedIv
+          : Number.isFinite(itl) && itl > 0
+            ? 1 / itl
+            : undefined;
       const otput = row.metrics.output_tput_per_gpu;
-      if (!Number.isFinite(itl) || itl <= 0) continue;
+      if (interactivity === undefined) continue;
       if (!Number.isFinite(otput) || otput <= 0) continue;
-      const point = { interactivity: 1 / itl, throughput: otput, date: row.date };
+      const point = { interactivity, throughput: otput, date: row.date };
       const bucket = byHardware.get(row.hardware);
       if (bucket) bucket.push(point);
       else byHardware.set(row.hardware, [point]);

--- a/packages/app/src/lib/tco-feed.ts
+++ b/packages/app/src/lib/tco-feed.ts
@@ -1,0 +1,235 @@
+/**
+ * TCO feed — per-hardware Pareto-frontier throughput reads at fixed
+ * interactivity tiers, consumed by external spreadsheet TCO models
+ * (Excel / Power Query) via /api/v1/tco-feed.
+ *
+ * Reuses the calculator's frontier + monotone-spline code (interpolation.ts)
+ * so every number matches what the dashboard chart renders at the same
+ * interactivity. Boundary semantics deliberately differ from the chart,
+ * which refuses to read outside the frontier on both sides:
+ *
+ * - tier BELOW the frontier's min interactivity → the min-knot's throughput
+ *   (`clamped_low`). The low end of a sweep is a coverage artifact — the
+ *   chip can serve at least that much when batched deeper — so a null here
+ *   would understate chips whose concurrency sweep stopped early.
+ * - tier ABOVE the frontier's max interactivity → 0 (`unreachable`). The
+ *   high end is a genuine capability limit: the chip cannot serve that SLA,
+ *   and 0 is the honest "can't serve this segment" for a weighted-average
+ *   consumer (a blank cell would silently become a stale pasted number).
+ */
+
+import {
+  hermiteInterpolate,
+  monotoneSlopes,
+  paretoFrontUpperLeft,
+} from '@/components/calculator/interpolation';
+
+/** Minimal structural slice of a BenchmarkRow the feed computation reads. */
+export interface TcoFeedSourceRow {
+  hardware: string;
+  /** Absent on rows predating the column — treated as single_turn. */
+  benchmark_type?: string | null;
+  isl: number | null;
+  osl: number | null;
+  metrics: Record<string, number>;
+  date: string;
+}
+
+export interface TcoFeedWorkload {
+  isl: number;
+  osl: number;
+}
+
+export type TcoTierBoundary = 'interpolated' | 'clamped_low' | 'unreachable';
+
+export interface TcoFeedRow {
+  hardware: string;
+  /** `<isl>x<osl>`, e.g. `8192x1024`. */
+  workload: string;
+  /** Interactivity read point (tok/s/user). */
+  tier: number;
+  /** Output tokens/s per GPU on the frontier at `tier`; 0 when unreachable. */
+  output_tput_per_gpu: number;
+  boundary: TcoTierBoundary;
+  /** Number of Pareto-frontier knots backing this hardware × workload. */
+  frontier_points: number;
+  frontier_min_interactivity: number;
+  frontier_max_interactivity: number;
+  /** Newest benchmark date among the frontier knots (freshness). */
+  latest_date: string;
+  /** Oldest benchmark date among the frontier knots (staleness flag). */
+  oldest_frontier_date: string;
+}
+
+export const DEFAULT_TIERS: readonly number[] = [30, 50, 75, 100];
+export const DEFAULT_WORKLOADS: readonly TcoFeedWorkload[] = [
+  { isl: 1024, osl: 1024 },
+  { isl: 8192, osl: 1024 },
+];
+
+const MAX_TIERS = 20;
+const MAX_TIER_VALUE = 10_000;
+const MAX_WORKLOADS = 8;
+
+/**
+ * Parse `tiers=30,50,75,100`. Absent/blank → defaults; any invalid entry →
+ * null (caller responds 400).
+ */
+export function parseTiers(raw: string | null): number[] | null {
+  if (raw === null || raw.trim() === '') return [...DEFAULT_TIERS];
+  const parts = raw.split(',').map((s) => s.trim());
+  if (parts.length > MAX_TIERS) return null;
+  const tiers: number[] = [];
+  for (const part of parts) {
+    const value = Number(part);
+    if (part === '' || !Number.isFinite(value) || value <= 0 || value > MAX_TIER_VALUE) {
+      return null;
+    }
+    tiers.push(value);
+  }
+  return tiers;
+}
+
+/**
+ * Parse `workloads=1024x1024,8192x1024` (lowercase `x` separator).
+ * Absent/blank → defaults; any invalid entry → null (caller responds 400).
+ */
+export function parseWorkloads(raw: string | null): TcoFeedWorkload[] | null {
+  if (raw === null || raw.trim() === '') return [...DEFAULT_WORKLOADS];
+  const parts = raw.split(',').map((s) => s.trim());
+  if (parts.length > MAX_WORKLOADS) return null;
+  const workloads: TcoFeedWorkload[] = [];
+  for (const part of parts) {
+    const match = /^(?<isl>\d{1,7})x(?<osl>\d{1,7})$/u.exec(part);
+    if (!match?.groups) return null;
+    const isl = Number(match.groups.isl);
+    const osl = Number(match.groups.osl);
+    if (isl <= 0 || osl <= 0) return null;
+    workloads.push({ isl, osl });
+  }
+  return workloads;
+}
+
+interface FrontierPoint {
+  interactivity: number;
+  throughput: number;
+  date: string;
+}
+
+const round3 = (v: number): number => Math.round(v * 1000) / 1000;
+
+/**
+ * Compute the feed: for each (workload, hardware), build the
+ * (interactivity, output tok/s/GPU) Pareto frontier across every config —
+ * frameworks, precisions, spec-decode, disagg — and read it at each tier.
+ */
+export function computeTcoFeed(
+  rows: readonly TcoFeedSourceRow[],
+  workloads: readonly TcoFeedWorkload[] = DEFAULT_WORKLOADS,
+  tiers: readonly number[] = DEFAULT_TIERS,
+): TcoFeedRow[] {
+  const out: TcoFeedRow[] = [];
+
+  for (const workload of workloads) {
+    const byHardware = new Map<string, FrontierPoint[]>();
+    for (const row of rows) {
+      // Rows predating the benchmark_type column are fixed-seq by definition
+      // (agentic rows are newer and carry isl/osl = null, which the workload
+      // match below excludes anyway).
+      if ((row.benchmark_type ?? 'single_turn') !== 'single_turn') continue;
+      if (row.isl !== workload.isl || row.osl !== workload.osl) continue;
+      // Interactivity is ALWAYS derived as 1/median_itl. Stored `*_intvty`
+      // values have drifted across harness versions and are never trusted —
+      // same rule as benchmark-transform.ts on the chart path.
+      const itl = row.metrics.median_itl;
+      const otput = row.metrics.output_tput_per_gpu;
+      if (!Number.isFinite(itl) || itl <= 0) continue;
+      if (!Number.isFinite(otput) || otput <= 0) continue;
+      const point = { interactivity: 1 / itl, throughput: otput, date: row.date };
+      const bucket = byHardware.get(row.hardware);
+      if (bucket) bucket.push(point);
+      else byHardware.set(row.hardware, [point]);
+    }
+
+    const workloadKey = `${workload.isl}x${workload.osl}`;
+    const hardwareKeys = [...byHardware.keys()].toSorted((a, b) => a.localeCompare(b));
+    for (const hardware of hardwareKeys) {
+      const frontier = paretoFrontUpperLeft(
+        byHardware.get(hardware)!,
+        (p) => p.interactivity,
+        (p) => p.throughput,
+      ).toSorted((a, b) => a.interactivity - b.interactivity);
+      if (frontier.length === 0) continue;
+
+      const xs = frontier.map((p) => p.interactivity);
+      const ys = frontier.map((p) => p.throughput);
+      const slopes = monotoneSlopes(xs, ys);
+      const minIv = xs[0];
+      const maxIv = xs.at(-1)!;
+      // Clamp bounds against spline overshoot, mirroring interpolateForGPU.
+      const yLo = Math.min(...ys);
+      const yHi = Math.max(...ys);
+      // 'YYYY-MM-DD' compares chronologically as a string.
+      let latest = frontier[0].date;
+      let oldest = frontier[0].date;
+      for (const p of frontier) {
+        if (p.date > latest) latest = p.date;
+        if (p.date < oldest) oldest = p.date;
+      }
+
+      for (const tier of tiers) {
+        let value: number;
+        let boundary: TcoTierBoundary;
+        if (tier > maxIv) {
+          value = 0;
+          boundary = 'unreachable';
+        } else if (tier < minIv) {
+          value = ys[0];
+          boundary = 'clamped_low';
+        } else {
+          const raw = hermiteInterpolate(xs, ys, slopes, tier);
+          value = Math.max(yLo, Math.min(yHi, raw));
+          boundary = 'interpolated';
+        }
+        out.push({
+          hardware,
+          workload: workloadKey,
+          tier,
+          output_tput_per_gpu: round3(value),
+          boundary,
+          frontier_points: frontier.length,
+          frontier_min_interactivity: round3(minIv),
+          frontier_max_interactivity: round3(maxIv),
+          latest_date: latest,
+          oldest_frontier_date: oldest,
+        });
+      }
+    }
+  }
+
+  return out;
+}
+
+const CSV_COLUMNS = [
+  'hardware',
+  'workload',
+  'tier',
+  'output_tput_per_gpu',
+  'boundary',
+  'frontier_points',
+  'frontier_min_interactivity',
+  'frontier_max_interactivity',
+  'latest_date',
+  'oldest_frontier_date',
+] as const;
+
+/**
+ * Serialize feed rows as CSV for one-line Power Query consumption.
+ * Every value is a number, ISO date, or enum-like token (hardware keys,
+ * `<isl>x<osl>`, boundary) — none can contain commas/quotes/newlines, so no
+ * field quoting is needed.
+ */
+export function tcoFeedToCsv(rows: readonly TcoFeedRow[]): string {
+  const lines = rows.map((row) => CSV_COLUMNS.map((col) => String(row[col])).join(','));
+  return `${[CSV_COLUMNS.join(','), ...lines].join('\n')}\n`;
+}

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -9,7 +9,8 @@ export interface HwEntry {
   sort: number;
   /** Thermal design power in watts */
   tdp: number;
-  /** kW per GPU (for energy calculations) */
+  /** All-in kW per GPU (chip + per-GPU share of host/NICs) — SemiAnalysis AI Cloud
+   * TCO Model, "Chip Specifications" sheet, Power → "All-In (W)" column */
   power: number;
   /** $/GPU/hr — hyperscaler tier */
   costh: number;
@@ -27,7 +28,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'H100',
     sort: 7,
     tdp: 700,
-    power: 1.73,
+    power: 1.37,
     costh: 1.3,
     costn: 1.69,
     costr: 1.3,
@@ -38,7 +39,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'H200',
     sort: 5,
     tdp: 700,
-    power: 1.73,
+    power: 1.37,
     costh: 1.41,
     costn: 1.74,
     costr: 1.6,
@@ -49,7 +50,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'B200',
     sort: 3,
     tdp: 1000,
-    power: 2.17,
+    power: 1.71,
     costh: 1.95,
     costn: 2.34,
     costr: 2.9,
@@ -61,7 +62,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'B300',
     sort: 2,
     tdp: 1200,
-    power: 2.17,
+    power: 1.9,
     costh: 2.34,
     costn: 2.808,
     costr: 3.48,
@@ -72,7 +73,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'GB200 NVL72',
     sort: 1,
     tdp: 1200,
-    power: 2.1,
+    power: 1.87,
     costh: 2.21,
     costn: 2.75,
     costr: 3.3,
@@ -84,7 +85,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'GB300 NVL72',
     sort: 0,
     tdp: 1400,
-    power: 2.1,
+    power: 2.12,
     costh: 2.652,
     costn: 3.3,
     costr: 3.96,
@@ -95,7 +96,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'MI300X',
     sort: 8,
     tdp: 750,
-    power: 1.79,
+    power: 1.39,
     costh: 1.12,
     costn: 1.4,
     costr: 1.55,
@@ -106,7 +107,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'MI325X',
     sort: 6,
     tdp: 1000,
-    power: 2.18,
+    power: 1.69,
     costh: 1.28,
     costn: 1.59,
     costr: 1.8,
@@ -117,7 +118,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     label: 'MI355X',
     sort: 4,
     tdp: 1400,
-    power: 2.65,
+    power: 2.09,
     costh: 1.48,
     costn: 1.9,
     costr: 2.1,


### PR DESCRIPTION
## Summary

Two changes:

### 1. New endpoint: `GET /api/v1/tco-feed`

Per-hardware Pareto-frontier **output tok/s/GPU** reads at fixed interactivity tiers, for external spreadsheet TCO models (Excel Power Query) that cannot run the frontend's TS transforms.

- Params: `model` (DB key or display name, default `dsv4`), `workloads` (default `1024x1024,8192x1024`), `tiers` (default `30,50,75,100` tok/s/user), `date` (as-of, for reproducible published sheets), `format=json|csv`.
- Computed with the calculator's own `paretoFrontUpperLeft` + Steffen monotone spline (`interpolation.ts`, unmodified — no `iso_interactivity.py` sync required), so numbers are identical to the dashboard chart at the same interactivity. Interactivity is always derived as `1/median_itl`, matching the chart pipeline's rule.
- Asymmetric boundary semantics (documented in `tco-feed.ts`): a tier below the frontier's minimum interactivity clamps to the lowest-knot throughput (`clamped_low` — sweep-coverage artifact, not a capability limit); a tier above the maximum returns 0 (`unreachable` — genuine capability limit). No spline extrapolation.
- Each row carries provenance (`frontier_points`, min/max interactivity, newest/oldest frontier dates) so consumers can flag stale anchors.
- This is a **documented exception** to the "API routes return raw DB data" convention (noted in AGENTS.md): it serves reads only — tier weights, workload mix, and token-value assumptions stay with the consumer.
- Cached via `cachedQuery`; new small `cachedText` helper in `api-cache.ts` for the CSV response (same CDN cache/purge tag as `cachedJson`). Works in fixtures mode.

**Overlay support:** not applicable — this is a data-export API endpoint over official latest-per-config DB data, not an inference/evaluation chart feature; there is no unofficial-run rendering path involved.

### 2. GPU spec corrections (`HW_REGISTRY` / `GPU_SPECS`)

- **All-in power per GPU** synced to the SemiAnalysis AI Cloud TCO Model, "Chip Specifications" sheet, Power → "All-In (W)" column: H100/H200 1.73→1.37, B200 2.17→1.71, B300 2.17→1.9, GB200 2.1→1.87, GB300 2.1→2.12, MI300X 1.79→1.39, MI325X 2.18→1.69, MI355X 2.65→2.09 kW. Affects per-MW chart metrics, calculator energy math, compare-page narratives, and chart footnotes (all data-driven).
- **B300 SXM memory** 268→288 GB (Blackwell Ultra HBM3e, same as GB300).
- **MI355X Infinity Fabric scale-up bandwidth** 576→538 GB/s unidirectional (1075.2 GB/s bidirectional), consistent with the unidirectional convention used for the other chips (e.g. H100 450 GB/s).

## Testing

- 17 new unit tests for `tco-feed` (exact-knot reads, dominated-point exclusion incl. provenance, cross-config envelope, both boundary rules, `1/median_itl` derivation, legacy rows without `benchmark_type`, filtering, ordering, CSV shape).
- Endpoint smoke-tested end-to-end against a local dev server in fixtures mode: JSON + CSV both serve correct rows; all five invalid-param paths return 400.
- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` pass; affected test files (`tco-feed`, `gpu-specs`, `constants`) 145/145 pass. (Pre-existing failures in `visit-tracking`/`chunk-load-recovery`/`use-feature-gate` reproduce on clean master and are unrelated.)

## 中文说明

本 PR 包含两项改动：

**1. 新增接口 `GET /api/v1/tco-feed`**：按固定交互性档位（默认 30/50/75/100 tok/s/user）输出各硬件在 1k1k 与 8k1k 工作负载下的 Pareto 前沿单 GPU 输出吞吐量读数，供外部电子表格 TCO 模型（Excel Power Query）使用。复用计算器的前沿构建与 Steffen 单调样条插值（`interpolation.ts` 未改动），数值与仪表板图表完全一致；交互性一律按 `1/median_itl` 推导。边界语义为非对称设计：档位低于前沿最小交互性时钳制到最低节点吞吐量（`clamped_low`，属采样覆盖不足而非能力上限）；高于最大交互性时返回 0（`unreachable`，属真实能力上限），不做样条外推。每行附带前沿节点数、交互性范围及最新/最旧基准测试日期，便于识别过期数据。该接口是「API 仅返回原始数据」约定的唯一例外（已在 AGENTS.md 注明）：接口只提供读数，权重与工作负载假设保留在消费方。支持 `format=json|csv`、as-of 日期与自定义档位/工作负载；通过 `cachedQuery` 缓存，`api-cache.ts` 新增 `cachedText` 辅助函数用于 CSV 响应。

**关于 unofficial run overlay**：不适用 —— 本接口是面向官方最新数据的导出 API，不属于推理/评估图表功能，不涉及 overlay 渲染路径。

**2. GPU 规格数据修正**：将 `HW_REGISTRY` 各 GPU 的整机功耗（all-in power）与 SemiAnalysis AI Cloud TCO 模型 "Chip Specifications" 表的 Power → "All-In (W)" 列对齐（H100/H200 1.37、B200 1.71、B300 1.9、GB200 1.87、GB300 2.12、MI300X 1.39、MI325X 1.69、MI355X 2.09 kW）；修正 B300 SXM 显存为 288 GB（Blackwell Ultra HBM3e，与 GB300 相同）；修正 MI355X Infinity Fabric scale-up 带宽为单向 538 GB/s（双向 1075.2 GB/s），与其他芯片的单向口径一致。影响每 MW 吞吐量指标、计算器能耗计算、对比页叙述与图表脚注（均为数据驱动，自动生效）。

**测试**：新增 17 个 `tco-feed` 单元测试；接口已在 fixtures 模式下对本地 dev server 做端到端冒烟验证（JSON/CSV 正常返回，5 类非法参数均返回 400）；`typecheck`/`lint`/`fmt` 全部通过，受影响的测试文件 145/145 通过（`visit-tracking` 等 3 个文件的失败在干净 master 上即可复现，与本 PR 无关）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new endpoint computes derived numbers consumers may treat as authoritative for TCO, and all-in power changes propagate to calculator energy and per-MW metrics site-wide.
> 
> **Overview**
> Adds **`GET /api/v1/tco-feed`** so spreadsheet TCO models (e.g. Excel Power Query) can pull **per-hardware Pareto-frontier output tok/s/GPU** at fixed interactivity tiers, with optional **`format=csv`**, **`date`**, **`workloads`**, and **`tiers`**. The route is documented as the sole exception to “API returns raw DB data”: it runs the same **`interpolation.ts`** frontier + monotone spline as the dashboard, with spreadsheet-oriented boundary rules (**`clamped_low`** below the sweep floor, **`0` / `unreachable`** above the cap) and provenance fields on each row. **`cachedText`** mirrors **`cachedJson`** CDN headers for CSV; **`AGENTS.md`** documents the endpoint.
> 
> **GPU metadata** is updated in **`HW_REGISTRY`** (all-in **kW/GPU** aligned to the SemiAnalysis TCO model) and **`GPU_SPECS`** (**B300** memory **288 GB**, **MI355X** scale-up **538 GB/s**), with matching test expectation updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2bf1f1b85e940dc6d3a80009167bfb5b9c8604b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->