### PR TITLE
chore: purge run 29425167775 (Kimi K2.6 B300 EAGLE3 AgentX) / 清理 run 29425167775（Kimi K2.6 B300 EAGLE3 AgentX）

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -48,6 +48,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   28505258231, // 2026-07-01 | Reason: cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4); skips FLOPs
   28507173993, // 2026-07-01 | Reason: cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4); skips FLOPs
   29089300938, // 2026-07-10 | Reason: reverting due to rule to disallow any patching
+  29425167775, // 2026-07-15 | Reason: reverting per rule that recipes PRs must merge before the InferenceX PR; also used the wrong draft model
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
## Summary

Adds GitHub workflow run [29425167775](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29425167775) (2026-07-15, "Add Kimi K2.6 NVFP4 B300 EAGLE3 AgentX benchmark") to `PURGED_RUNS`, so ingest skips it and `pnpm db:apply-overrides` (run automatically by the ingest workflows) removes any of its rows from the DB — same pattern as #553.

**Reason for purge:** the run is being reverted per the rule that recipes PRs must merge before the InferenceX PR merges, and it also used the wrong draft model.

No frontend changes; chart-data-only DB override, so unofficial run overlays are unaffected.

## 中文说明

将 GitHub workflow run [29425167775](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29425167775)（2026-07-15，"Add Kimi K2.6 NVFP4 B300 EAGLE3 AgentX benchmark"）加入 `PURGED_RUNS`，使 ingest 跳过该 run，并由 ingest workflow 自动执行的 `pnpm db:apply-overrides` 清除其数据库记录 — 与 #553 采用相同模式。

**清理原因：** 按照 recipes PR 必须先于 InferenceX PR 合并的规则回退该改动，且该 run 使用了错误的 draft model。

不涉及前端改动；仅为数据库层面的 override，不影响 unofficial run overlay。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single ID added to an ETL override list; no application logic or auth changes, only excluding one benchmark run from the database.
> 
> **Overview**
> Adds workflow run **29425167775** (2026-07-15, Kimi K2.6 B300 EAGLE3 AgentX benchmark) to `PURGED_RUNS` in `run-overrides.ts`, matching the existing purge pattern used for other bad or reverted benchmark runs.
> 
> Ingest will skip this run via `isRunAttemptPurged`, and CI/local `pnpm db:apply-overrides` will delete any rows already stored for that run ID. Documented reason: revert per recipes-before-InferenceX merge rule and wrong draft model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891cd4e8dc71c2d571f3538bd7bb261892cbc344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->