### PR TITLE
chore: purge run 29427827757 (PR #2158 sweep-reuse recovery) / 清理 run 29427827757（PR #2158 sweep 复用恢复）

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -49,6 +49,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   28507173993, // 2026-07-01 | Reason: cross-layer indexer top-k sharing (--hf-overrides index_topk_freq=4); skips FLOPs
   29089300938, // 2026-07-10 | Reason: reverting due to rule to disallow any patching
   29425167775, // 2026-07-15 | Reason: reverting per rule that recipes PRs must merge before the InferenceX PR; also used the wrong draft model
+  29427827757, // 2026-07-15 | Reason: sweep-reuse recovery of the run above (PR #2158) — reverted for the same reason
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
## Summary

Follow-up to #580. Adds GitHub workflow run [29427827757](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29427827757) (2026-07-15, "Recover PR #2158 database ingest via sweep reuse") to `PURGED_RUNS`, so ingest skips it and `pnpm db:apply-overrides` (run automatically by the ingest workflows) removes any of its rows from the DB.

**Reason for purge:** this run re-ingested the same Kimi K2.6 NVFP4 B300 EAGLE3 AgentX data as run 29425167775 (purged in #580), so it is purged for the same reason — the work is being reverted per the rule that recipes PRs must merge before the InferenceX PR merges, and the wrong draft model was used.

No frontend changes; chart-data-only DB override, so unofficial run overlays are unaffected.

## 中文说明

作为 #580 的后续，将 GitHub workflow run [29427827757](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29427827757)（2026-07-15，"Recover PR #2158 database ingest via sweep reuse"）加入 `PURGED_RUNS`，使 ingest 跳过该 run，并由 ingest workflow 自动执行的 `pnpm db:apply-overrides` 清除其数据库记录。

**清理原因：** 该 run 通过 sweep 复用重新摄取了与 run 29425167775（已在 #580 中清理）相同的 Kimi K2.6 NVFP4 B300 EAGLE3 AgentX 数据，因此以相同原因一并清理 — 按照 recipes PR 必须先于 InferenceX PR 合并的规则回退该改动，且使用了错误的 draft model。

不涉及前端改动；仅为数据库层面的 override，不影响 unofficial run overlay。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single run ID added to an existing purge list; no application logic or auth changes, only ETL ingest enforcement.
> 
> **Overview**
> Adds GitHub Actions run **29427827757** to `PURGED_RUNS` in `run-overrides.ts`, extending the cleanup from run **29425167775** (#580).
> 
> That run was a sweep-reuse recovery for PR #2158 and re-ingested the same Kimi K2.6 NVFP4 B300 EAGLE3 AgentX data, so it is excluded for the same reasons (recipes/InferenceX merge order and wrong draft model). Ingest will skip it, and CI/`pnpm db:apply-overrides` will remove any existing rows for that run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445f16b9728635341ec69bdd25242b8eb95524cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->