### PR TITLE
Theme InferenceX wordmark gradient for Disability Pride Month

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -43,15 +43,16 @@
 /* Pride theme for the InferenceX wordmark — celebrating July Disability Pride Month.
    Paints the brand text with the Disability Pride flag's 5 stripe colors via a
    clipped diagonal gradient (Ann Magill's 2021 revised, low-sensitivity palette):
-   red = physical, gold = neurodivergent, white = invisible/undiagnosed,
-   blue = psychiatric, green = sensory. */
+   red = physical, gold = neurodivergent, gray = invisible/undiagnosed,
+   blue = psychiatric, green = sensory. The flag's white stripe is darkened to a
+   readable slate here so the clipped wordmark stays legible on the light header. */
 .pride-wordmark {
   background-image: linear-gradient(
     135deg,
     #cf7280 0%,
-    #eede77 25%,
-    #e8e8e8 50%,
-    #7bc2e0 75%,
+    #d9ad2e 28%,
+    #8a8f99 50%,
+    #4aa6cf 72%,
     #3aa660 100%
   );
   background-clip: text;

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -40,17 +40,19 @@
   content: none;
 }
 
-/* Pride theme for the InferenceX wordmark — celebrating June Pride Month.
-   Paints the brand text with the 6-stripe rainbow flag via a clipped gradient. */
+/* Pride theme for the InferenceX wordmark — celebrating July Disability Pride Month.
+   Paints the brand text with the Disability Pride flag's 5 stripe colors via a
+   clipped diagonal gradient (Ann Magill's 2021 revised, low-sensitivity palette):
+   red = physical, gold = neurodivergent, white = invisible/undiagnosed,
+   blue = psychiatric, green = sensory. */
 .pride-wordmark {
   background-image: linear-gradient(
-    90deg,
-    #e40303 0%,
-    #ff8c00 20%,
-    #ffed00 40%,
-    #008026 60%,
-    #004dff 80%,
-    #750787 100%
+    135deg,
+    #cf7280 0%,
+    #eede77 25%,
+    #e8e8e8 50%,
+    #7bc2e0 75%,
+    #3aa660 100%
   );
   background-clip: text;
   -webkit-background-clip: text;


### PR DESCRIPTION
## Summary
June was Pride Month; July is **Disability Pride Month**. This updates the `.pride-wordmark` gradient (the clipped text gradient on the **InferenceX** wordmark in the header) from the 6-stripe rainbow flag to the **Disability Pride flag** palette.

## Details
- Swaps the `linear-gradient` in `packages/app/src/app/globals.css` to the Disability Pride flag's 5 stripe colors (Ann Magill's 2021 revised, low-visual-sensitivity palette):
  - Red `#cf7280` — physical disabilities
  - Gold `#eede77` — neurodivergence
  - White `#e8e8e8` — invisible & undiagnosed disabilities
  - Blue `#7bc2e0` — psychiatric disabilities
  - Green `#3aa660` — sensory disabilities
- Angle changed to `135deg` to evoke the flag's diagonal stripes (representing cutting across barriers).
- Updated the comment to reflect July / Disability Pride Month.

## Notes
- No component/markup changes — only the CSS gradient behind the existing `.pride-wordmark` class used in `header.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic CSS-only change to a decorative header gradient; no logic, auth, or data impact.
> 
> **Overview**
> Updates the header **InferenceX** `.pride-wordmark` clipped-text gradient from the June rainbow palette to **Disability Pride Month** (July): a **135°** diagonal **five-color** gradient using Ann Magill’s revised flag colors, with the white stripe rendered as **slate gray** (`#8a8f99`) for contrast on the light header.
> 
> The block comment in `globals.css` is rewritten to document July, the palette meanings, and the legibility tweak. **No** markup or component changes—only the existing CSS class used in `header.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8b7274f97ce4e2fcfa89168537f82a50377f9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->