### PR TITLE
feat: accept GLM-5.2 AgentX results / 支持接收 GLM-5.2 AgentX 结果

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 | Qwen3.5-397B-A17B      | 397B  | 17B         | `Qwen/Qwen3.5-397B-A17B`            | HF model card                      |
 | GLM-5                  | 744B  | 40B         | `zai-org/GLM-5`                     | HF model card                      |
 | GLM-5.1                | 744B  | 40B         | `zai-org/GLM-5.1-FP8`               | HF model card (same base as GLM-5) |
+| GLM-5.2                | 744B  | 40B         | `zai-org/GLM-5.2-FP8`               | HF model card (same base as GLM-5) |
 | MiniMax-M2.5           | 230B  | 10B         | `MiniMaxAI/MiniMax-M2.5`            | HF model card                      |
 | MiniMax-M2.7           | 230B  | 10B         | `MiniMaxAI/MiniMax-M2.7`            | NVIDIA M2.7 blog                   |
 | gpt-oss-120b           | 120B  | 5.1B        | `openai/gpt-oss-120b`               | HF model card                      |

--- a/packages/app/src/app/api/unofficial-run/route.test.ts
+++ b/packages/app/src/app/api/unofficial-run/route.test.ts
@@ -128,6 +128,39 @@ describe('normalizeArtifactRows', () => {
     expect(rows[0].model).toBe('gptoss120b');
   });
 
+  it('normalizes the GLM-5.2 H200 AgentX HiCache overlay path', () => {
+    const rows = normalizeArtifactRows(
+      [
+        rawAgenticRow({
+          infmax_model_prefix: 'glm5.2',
+          model: 'zai-org/GLM-5.2-FP8',
+          hw: 'cluster:h200-dgxc',
+          framework: 'sglang',
+          precision: 'fp8',
+          users: 32,
+          kv_offloading: 'dram',
+          kv_offload_backend: 'hicache',
+        }),
+      ],
+      '2026-07-18',
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      model: 'glm5.2',
+      hardware: 'h200',
+      framework: 'sglang',
+      precision: 'fp8',
+      benchmark_type: 'agentic_traces',
+      offload_mode: 'on',
+      conc: 32,
+    });
+    expect(rows[0].metrics).toMatchObject({
+      kv_offloading: 'dram',
+      kv_offload_backend: 'hicache',
+    });
+  });
+
   it('falls back to model path when prefix is absent', () => {
     const rows = normalizeArtifactRows(
       [rawRow({ infmax_model_prefix: undefined, model: 'deepseek-ai/DeepSeek-R1-0528' })],

--- a/packages/app/src/components/about/faq-data-zh.ts
+++ b/packages/app/src/components/about/faq-data-zh.ts
@@ -25,6 +25,7 @@ const modelNames = Object.values({
   'kimik2.7-code': 'Kimi-K2.7-Code',
   'minimaxm2.7': 'MiniMax-M2.7',
   'glm5.1': 'GLM-5.1',
+  'glm5.2': 'GLM-5.2',
 });
 
 const frameworkNames = [...new Set(Object.values(FRAMEWORK_LABELS))].map((n) =>

--- a/packages/app/src/components/about/faq-data.ts
+++ b/packages/app/src/components/about/faq-data.ts
@@ -40,6 +40,7 @@ const modelNames = Object.values({
   'kimik2.7-code': 'Kimi-K2.7-Code',
   'minimaxm2.7': 'MiniMax-M2.7',
   'glm5.1': 'GLM-5.1',
+  'glm5.2': 'GLM-5.2',
 });
 
 const frameworkNames = [...new Set(Object.values(FRAMEWORK_LABELS))].map((n) =>

--- a/packages/app/src/components/inference/agentic-point/sibling-nav.tsx
+++ b/packages/app/src/components/inference/agentic-point/sibling-nav.tsx
@@ -33,6 +33,7 @@ const MODEL_LABELS: Record<string, string> = {
   dsv4: 'DeepSeek V4 Pro',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5.1',
+  'glm5.2': 'GLM-5.2',
   gptoss120b: 'gpt-oss 120B',
   kimik2: 'Kimi K2',
   'kimik2.5': 'Kimi K2.5',

--- a/packages/app/src/components/submissions/submissions-utils.test.ts
+++ b/packages/app/src/components/submissions/submissions-utils.test.ts
@@ -296,10 +296,11 @@ describe('buildInferenceCompareUrl', () => {
     expect(buildInferenceCompareUrl(current, previous)).toBeNull();
   });
 
-  it('handles DB prefixes that include point-release suffix (gptoss120b, glm5.1, llama70b)', () => {
+  it('handles DB prefixes that include point-release suffix (gptoss120b, glm5.1/5.2, llama70b)', () => {
     const cases: [string, string][] = [
       ['gptoss120b', 'gpt-oss-120b'],
       ['glm5.1', 'GLM-5'],
+      ['glm5.2', 'GLM-5'],
       ['llama70b', 'Llama-3.3-70B-Instruct-FP8'],
       ['kimik2.6', 'Kimi-K2.5'],
       ['kimik2.7-code', 'Kimi-K2.5'],

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -80,7 +80,7 @@ export function buildInferenceCompareUrl(
   previousRow: SubmissionSummaryRow,
 ): string | null {
   // DB_MODEL_TO_DISPLAY covers every DB prefix incl. point-release aliases
-  // (gptoss120b, glm5.1, kimik2.6, kimik2.7-code, minimaxm2.7, llama70b).
+  // (gptoss120b, glm5.1, glm5.2, kimik2.6, kimik2.7-code, minimaxm2.7, llama70b).
   // MODEL_PREFIX_MAPPING only has the single canonical prefix per Model enum
   // and misses those rows.
   const displayModel = DB_MODEL_TO_DISPLAY[currentRow.model];

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -39,6 +39,7 @@ describe('parseCompareSlug — new model-prefixed form', () => {
   it('parses a model slug with multiple hyphens (glm-5-1)', () => {
     const parsed = parseCompareSlug('glm-5-1-h100-vs-gb200');
     expect(parsed?.model).toBe(GLM_51);
+    expect(parsed?.model.dbKeys).toEqual(['glm5.2', 'glm5.1', 'glm5']);
     expect(parsed?.a).toBe('h100');
     expect(parsed?.b).toBe('gb200');
   });
@@ -252,6 +253,7 @@ describe('compareModelDisplayLabel', () => {
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
       'Kimi K2.5/K2.6/K2.7-Code 1T — GB200 NVL72 vs MI355X',
     );
+    expect(compareModelDisplayLabel(GLM_51, 'h100', 'h200')).toBe('GLM 5/5.1/5.2 — H100 vs H200');
   });
 });
 

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -66,10 +66,10 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'glm-5-1',
     displayName: 'GLM-5',
-    // GLM-5.0 and GLM-5.1 share an architecture per the model card; the slug
-    // uses the newer version name but the data pull covers both DB buckets.
-    dbKeys: ['glm5.1', 'glm5'],
-    label: 'GLM 5/5.1',
+    // GLM-5, GLM-5.1, and GLM-5.2 share an architecture. Keep the existing
+    // canonical slug for URL stability while querying every point-release bucket.
+    dbKeys: ['glm5.2', 'glm5.1', 'glm5'],
+    label: 'GLM 5/5.1/5.2',
   },
   {
     slug: 'minimax-m3',

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -224,7 +224,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.GptOss)).toBe('gpt-oss 120B');
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
-    expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
+    expect(getModelLabel(Model.GLM_5)).toBe('GLM-5/5.1/5.2 744B');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -94,7 +94,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   },
   [Model.Kimi_K2_5]: {
     // K2.5, K2.6, and K2.7-Code share an architecture, so the dropdown surfaces
-    // all versions joined with a slash — matches the GLM5/5.1 pattern. The
+    // all versions joined with a slash — matches the GLM-5/5.1/5.2 pattern. The
     // hyphenated `Model.Kimi_K2_5` enum value stays as-is for internal
     // routing / DB key mapping.
     label: 'Kimi K2.5/2.6/2.7-Code 1T',
@@ -111,11 +111,11 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'dsr1',
     category: 'maintenance',
   },
-  [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
+  [Model.GLM_5]: { label: 'GLM-5/5.1/5.2 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {
-    // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.
+    // M2.5 and M2.7 share an architecture — same GLM-5/5.1/5.2 pattern as Kimi.
     // Superseded by MiniMax M3, so it's deprecated (no longer actively benchmarked).
     label: 'MiniMax M2.5/2.7 230B',
     prefix: 'minimaxm2.5',

--- a/packages/app/src/lib/models-mapping.test.ts
+++ b/packages/app/src/lib/models-mapping.test.ts
@@ -31,7 +31,9 @@ describe('DISPLAY_MODEL_TO_DB', () => {
   });
 
   it('groups point-release DB keys under one display', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
+      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
+    );
   });
 });
 

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -16,7 +16,9 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
   });
 
   it('groups point-release DB keys under the same display name', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
+      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
+    );
     expect(DISPLAY_MODEL_TO_DB['Kimi-K2.5']).toEqual(
       expect.arrayContaining(['kimik2.5', 'kimik2.6', 'kimik2.7-code']),
     );

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -2,8 +2,8 @@
  * DB model key → frontend display name (Model enum value).
  *
  * Multiple DB keys may map to the same display name. This is how point releases
- * are grouped for display: the DB stores `glm5` and `glm5.1` as distinct buckets
- * (faithful to the submitted data), but both render under the single "GLM-5"
+ * are grouped for display: the DB stores `glm5`, `glm5.1`, and `glm5.2` as distinct buckets
+ * (faithful to the submitted data), but all render under the single "GLM-5"
  * display option in the UI. See `DISPLAY_MODEL_TO_DB` for the inverse mapping.
  */
 export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
@@ -19,6 +19,7 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   minimaxm3: 'MiniMax-M3',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5',
+  'glm5.2': 'GLM-5',
   dsv4: 'DeepSeek-V4-Pro',
 };
 

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -175,9 +175,11 @@ describe('resolveModelKey', () => {
 
   it('resolves point-release variants to their own DB key (faithful to submitted data)', () => {
     expect(resolveModelKey({ infmax_model_prefix: 'glm5.1' })).toBe('glm5.1');
+    expect(resolveModelKey({ infmax_model_prefix: 'glm5.2' })).toBe('glm5.2');
     expect(resolveModelKey({ infmax_model_prefix: 'kimik2.6' })).toBe('kimik2.6');
     expect(resolveModelKey({ infmax_model_prefix: 'minimaxm2.7' })).toBe('minimaxm2.7');
     expect(resolveModelKey({ model: 'amd/GLM-5.1-MXFP4' })).toBe('glm5.1');
+    expect(resolveModelKey({ model: 'zai-org/GLM-5.2-FP8' })).toBe('glm5.2');
   });
 });
 

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -98,9 +98,10 @@ export const MODEL_TO_KEY: Record<string, string> = {
   'MiniMaxAI/MiniMax-M2.5': 'minimaxm2.5',
   // MiniMax-M3 (428B, distinct architecture from the M2 series)
   'MiniMaxAI/MiniMax-M3': 'minimaxm3',
-  // GLM-5
+  // GLM-5 / 5.1 / 5.2 (same architecture, distinct DB buckets)
   'zai-org/GLM-5-FP8': 'glm5',
   'amd/GLM-5.1-MXFP4': 'glm5.1',
+  'zai-org/GLM-5.2-FP8': 'glm5.2',
   // DeepSeek-V4-Pro
   'deepseek-ai/DeepSeek-V4-Pro': 'dsv4',
 };

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -51,7 +51,7 @@ export interface BenchmarkRow {
 /**
  * Fetch the latest benchmark results for one or more model DB keys across ALL sequences,
  * up to a given date. Multiple keys support point-release grouping — e.g. passing
- * `['glm5', 'glm5.1']` unions both buckets under the one display.
+ * `['glm5', 'glm5.1', 'glm5.2']` unions all point-release buckets under one display.
  *
  * Selection unit is the LINE, not the point: for each line
  * `(config_id, benchmark_type, isl, osl, offload_mode)` we pick the single newest workflow run that


### PR DESCRIPTION
## Summary

- Register `glm5.2` and `zai-org/GLM-5.2-FP8` as a distinct database bucket while grouping the bucket under the existing `GLM-5` dashboard model.
- Rename dashboard and comparison labels to GLM-5/5.1/5.2 while preserving the stable `glm-5-1` comparison slug.
- Add regression coverage for the H200 + SGLang FP8 + AgentX + DRAM HiCache unofficial-run path from [InferenceX run 29648586946](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29648586946).
- Works for both official ingested results and `?unofficialrun=` overlays; overlay normalization is covered by the API route test.

## Deployment order

Deploy these mappings before ingesting run 29648586946. If ingestion happens first, reingest the run after deployment so `glm5.2` rows are retained.

## Testing

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit` (3,056 passed)
- `pnpm test:e2e`: component suite passed (182/182); DB-backed browser specs could not complete because the local database is behind the repository schema (`benchmark_type` and `offload_mode` columns are missing).

## 中文说明

### 概要

- 将 `glm5.2` 和 `zai-org/GLM-5.2-FP8` 注册为独立数据库分桶，同时归入现有 `GLM-5` 仪表板模型。
- 将仪表板和对比页标签更新为 GLM-5/5.1/5.2，并保留稳定的 `glm-5-1` 对比页 slug。
- 针对 [InferenceX 运行 29648586946](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29648586946) 的 H200 + SGLang FP8 + AgentX + DRAM HiCache 非官方运行路径补充回归测试。
- 官方入库结果和 `?unofficialrun=` 叠加层均受支持；API route 测试已覆盖叠加层归一化逻辑。

### 部署顺序

请先部署本 PR 的映射，再摄取运行 29648586946。如果已经提前摄取，需要在部署后重新摄取，确保 `glm5.2` 数据行不会被跳过。

### 测试

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:unit`（3,056 项通过）
- `pnpm test:e2e`：component suite 全部通过（182/182）；由于本地数据库落后于仓库 schema，缺少 `benchmark_type` 和 `offload_mode` 列，依赖数据库的 browser specs 无法完成。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model mappings and label updates with broad unit test coverage; deploy mappings before ingesting GLM-5.2 runs to avoid dropped rows.
> 
> **Overview**
> Adds **GLM-5.2** as its own DB bucket (`glm5.2`, HF `zai-org/GLM-5.2-FP8`) while keeping it grouped under the existing **GLM-5** dashboard model, following the same point-release pattern as `glm5` / `glm5.1`.
> 
> **Mappings and ingest:** `DB_MODEL_TO_DISPLAY` / inverse grouping now include `glm5.2`; ETL `MODEL_TO_KEY` and `resolveModelKey` resolve the `glm5.2` prefix and HF path. Compare pages keep the stable `glm-5-1` slug but query `glm5.2` plus older buckets and show **GLM 5/5.1/5.2** in headers and dropdown labels.
> 
> **Regression test:** Unofficial-run normalization is covered for the H200 + SGLang FP8 AgentX + DRAM HiCache overlay path (`cluster:h200-dgxc`, `kv_offload_backend: hicache`). **AGENTS.md** documents GLM-5.2 parameter counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47422ba32135d0206f1ee60ca4b21d3945cc64ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->