### PR TITLE
fix: recognize GLM-5.2 ingest results

### DIFF
--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -252,6 +252,7 @@ describe('compareModelDisplayLabel', () => {
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
       'Kimi K2.5/K2.6/K2.7-Code 1T — GB200 NVL72 vs MI355X',
     );
+    expect(compareModelDisplayLabel(GLM_51, 'h100', 'h200')).toBe('GLM 5/5.1/5.2 — H100 vs H200');
   });
 });
 

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -66,10 +66,10 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'glm-5-1',
     displayName: 'GLM-5',
-    // GLM-5.0 and GLM-5.1 share an architecture per the model card; the slug
-    // uses the newer version name but the data pull covers both DB buckets.
-    dbKeys: ['glm5.1', 'glm5'],
-    label: 'GLM 5/5.1',
+    // GLM-5 point releases share the same base architecture. Keep the existing
+    // canonical slug for URL stability while querying every DB bucket.
+    dbKeys: ['glm5.2', 'glm5.1', 'glm5'],
+    label: 'GLM 5/5.1/5.2',
   },
   {
     slug: 'minimax-m3',

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -224,7 +224,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.GptOss)).toBe('gpt-oss 120B');
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
-    expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
+    expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1/5.2 744B');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -111,7 +111,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'dsr1',
     category: 'maintenance',
   },
-  [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
+  [Model.GLM_5]: { label: 'GLM5/5.1/5.2 744B', prefix: 'glm5', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {

--- a/packages/app/src/lib/models-mapping.test.ts
+++ b/packages/app/src/lib/models-mapping.test.ts
@@ -31,7 +31,9 @@ describe('DISPLAY_MODEL_TO_DB', () => {
   });
 
   it('groups point-release DB keys under one display', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
+      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
+    );
   });
 });
 

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -16,7 +16,9 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
   });
 
   it('groups point-release DB keys under the same display name', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
+      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
+    );
     expect(DISPLAY_MODEL_TO_DB['Kimi-K2.5']).toEqual(
       expect.arrayContaining(['kimik2.5', 'kimik2.6', 'kimik2.7-code']),
     );

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -19,6 +19,7 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   minimaxm3: 'MiniMax-M3',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5',
+  'glm5.2': 'GLM-5',
   dsv4: 'DeepSeek-V4-Pro',
 };
 

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -171,13 +171,16 @@ describe('resolveModelKey', () => {
     expect(resolveModelKey({ model: 'moonshotai/Kimi-K2.5' })).toBe('kimik2.5');
     expect(resolveModelKey({ model: 'MiniMaxAI/MiniMax-M2.5' })).toBe('minimaxm2.5');
     expect(resolveModelKey({ model: 'zai-org/GLM-5-FP8' })).toBe('glm5');
+    expect(resolveModelKey({ model: 'zai-org/GLM-5.2-FP8' })).toBe('glm5.2');
   });
 
   it('resolves point-release variants to their own DB key (faithful to submitted data)', () => {
     expect(resolveModelKey({ infmax_model_prefix: 'glm5.1' })).toBe('glm5.1');
+    expect(resolveModelKey({ infmax_model_prefix: 'glm5.2' })).toBe('glm5.2');
     expect(resolveModelKey({ infmax_model_prefix: 'kimik2.6' })).toBe('kimik2.6');
     expect(resolveModelKey({ infmax_model_prefix: 'minimaxm2.7' })).toBe('minimaxm2.7');
     expect(resolveModelKey({ model: 'amd/GLM-5.1-MXFP4' })).toBe('glm5.1');
+    expect(resolveModelKey({ model: 'zai-org/GLM-5.2-FP8' })).toBe('glm5.2');
   });
 });
 

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -101,6 +101,7 @@ export const MODEL_TO_KEY: Record<string, string> = {
   // GLM-5
   'zai-org/GLM-5-FP8': 'glm5',
   'amd/GLM-5.1-MXFP4': 'glm5.1',
+  'zai-org/GLM-5.2-FP8': 'glm5.2',
   // DeepSeek-V4-Pro
   'deepseek-ai/DeepSeek-V4-Pro': 'dsv4',
 };


### PR DESCRIPTION
## Summary
- recognize the `glm5.2` DB key and `zai-org/GLM-5.2-FP8` model path
- group GLM-5.2 with the existing GLM-5 display family
- include GLM-5.2 in compare queries and labels

## Verification
- direct `resolveModelKey` smoke check resolves the run payload to `glm5.2`
- DB normalizer tests: 64 passed
- constants tests: 11 passed
- frontend mapping tests: 85 passed
- changed files pass oxlint and oxfmt

After deployment, re-ingest source run 29654139122 to recover the previously skipped rows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive model-key and label updates with no auth or query-behavior changes beyond including the new bucket; re-ingest is noted for recovering skipped rows.
> 
> **Overview**
> Adds **GLM-5.2** as a first-class benchmark bucket so ingest no longer drops runs that report `glm5.2` or `zai-org/GLM-5.2-FP8`. ETL maps those inputs to the `glm5.2` DB key; shared constants fold `glm5.2` into the existing **GLM-5** display family alongside `glm5` and `glm5.1`.
> 
> Compare pages keep the `glm-5-1` slug but now query all three buckets and show labels as **GLM 5/5.1/5.2** (dashboard model label updated to **GLM5/5.1/5.2 744B**). Tests cover the new mappings end to end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5efdf35d8e815f545bfd38403d877b38ea31cfa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->