### PR TITLE
chore(models): split GLM-5.2 into its own model, deprecate GLM 5/5.1 / 将 GLM-5.2 拆分为独立模型，并弃用 GLM 5/5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 | Qwen3.5-397B-A17B      | 397B  | 17B         | `Qwen/Qwen3.5-397B-A17B`            | HF model card                      |
 | GLM-5                  | 744B  | 40B         | `zai-org/GLM-5`                     | HF model card                      |
 | GLM-5.1                | 744B  | 40B         | `zai-org/GLM-5.1-FP8`               | HF model card (same base as GLM-5) |
+| GLM-5.2                | 743B  | 39B         | `zai-org/GLM-5.2`                   | HF config.json (see trap below)    |
 | MiniMax-M2.5           | 230B  | 10B         | `MiniMaxAI/MiniMax-M2.5`            | HF model card                      |
 | MiniMax-M2.7           | 230B  | 10B         | `MiniMaxAI/MiniMax-M2.7`            | NVIDIA M2.7 blog                   |
 | gpt-oss-120b           | 120B  | 5.1B        | `openai/gpt-oss-120b`               | HF model card                      |
@@ -184,6 +185,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 **Common mislabel traps** (have all bitten this repo at least once — do not repeat):
 
 - **GLM-5 ≠ 355B.** 355B is GLM-4.5. GLM-5 jumped to 744B / 40B active (256-expert MoE with DSA).
+- **GLM-5.2 is NOT a GLM-5 point release, and ≠ 753B.** Unlike 5.0 → 5.1, GLM-5.2 is a new architecture bucket (`glm_moe_dsa` with IndexShare sparse attention, 78 layers) — it maps to its own `GLM-5.2` display model; never group `glm5.2` with `glm5`/`glm5.1`. Its HF metadata shows 753B because the bundled MTP head (`num_nextn_predict_layers: 1`) adds ~10B; the core MoE is 743B / 39B active.
 - **MiniMax-M2.5/M2.7 ≠ 456B.** 456B is the older MiniMax-Text-01 / M1 (32 large experts). The M2 series is a different architecture: 230B / 10B active, 256 small experts.
 - **DeepSeek-R1 is 671B, not 685B.** HF metadata shows 685B because the bundled MTP head adds ~14B; the core MoE is 671B / 37B active.
 - **Kimi K2.5, K2.6, and K2.7-Code are post-training refinements**, not new pre-trained sizes. Same 1T / 32B / 384-expert backbone as the original K2. K2.7-Code is a coding-focused refinement of the same backbone.

--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -50,6 +50,7 @@ describe('Dropdown one-click switching', () => {
     cy.contains('Maintenance Mode').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'DeepSeek R1 0528 671B').scrollIntoView().should('be.visible');
     cy.contains('Deprecated').scrollIntoView().should('be.visible');
+    cy.contains('[role="option"]', 'GLM5/5.1 744B').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'gpt-oss 120B').scrollIntoView().should('be.visible');
     cy.contains('[role="option"]', 'Llama 3.3 70B Instruct').scrollIntoView().should('be.visible');
   });

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -19,7 +19,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `Which GPU delivers more inference performance per dollar? InferenceX is the independent, open-source benchmark from SemiAnalysis, with verified, reproducible results. ${SUPPORTERS_LINE} Compare cost per million tokens, normalized by hyperscaler TCO, across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
+const DESCRIPTION = `Which GPU delivers more inference performance per dollar? InferenceX is the independent, open-source benchmark from SemiAnalysis, with verified, reproducible results. ${SUPPORTERS_LINE} Compare cost per million tokens, normalized by hyperscaler TCO, across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5.2, Qwen 3.5 & more.`;
 
 export const metadata: Metadata = {
   title: 'GPU Performance per Dollar',

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -19,7 +19,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX is the independent, open-source GPU inference benchmark from SemiAnalysis, with verified, reproducible nightly results. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
+const DESCRIPTION = `InferenceX is the independent, open-source GPU inference benchmark from SemiAnalysis, with verified, reproducible nightly results. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5.2, Qwen 3.5 & more.`;
 
 export const metadata: Metadata = {
   title: 'GPU Comparisons',

--- a/packages/app/src/app/zh/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/zh/compare-per-dollar/page.tsx
@@ -18,7 +18,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `哪款 GPU 每美元推理性能最高？InferenceX 是 SemiAnalysis 推出的独立开源基准测试平台，提供经过验证的、可复现的测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5、Qwen 3.5 等模型基于云服务商 TCO 归一化的每百万 token 成本。`;
+const DESCRIPTION = `哪款 GPU 每美元推理性能最高？InferenceX 是 SemiAnalysis 推出的独立开源基准测试平台，提供经过验证的、可复现的测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5.2、Qwen 3.5 等模型基于云服务商 TCO 归一化的每百万 token 成本。`;
 
 export const metadata: Metadata = {
   title: 'GPU 每美元性能',

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -18,7 +18,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX 是 SemiAnalysis 推出的独立开源 GPU 推理基准测试平台，提供经过验证的、可复现的每夜测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5、Qwen 3.5 等模型的延迟、吞吐量与成本。`;
+const DESCRIPTION = `InferenceX 是 SemiAnalysis 推出的独立开源 GPU 推理基准测试平台，提供经过验证的、可复现的每夜测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5.2、Qwen 3.5 等模型的延迟、吞吐量与成本。`;
 
 export const metadata: Metadata = {
   title: 'GPU 对比',

--- a/packages/app/src/components/inference/agentic-point/sibling-nav.tsx
+++ b/packages/app/src/components/inference/agentic-point/sibling-nav.tsx
@@ -33,6 +33,7 @@ const MODEL_LABELS: Record<string, string> = {
   dsv4: 'DeepSeek V4 Pro',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5.1',
+  'glm5.2': 'GLM-5.2',
   gptoss120b: 'gpt-oss 120B',
   kimik2: 'Kimi K2',
   'kimik2.5': 'Kimi K2.5',

--- a/packages/app/src/components/submissions/submissions-utils.test.ts
+++ b/packages/app/src/components/submissions/submissions-utils.test.ts
@@ -300,6 +300,7 @@ describe('buildInferenceCompareUrl', () => {
     const cases: [string, string][] = [
       ['gptoss120b', 'gpt-oss-120b'],
       ['glm5.1', 'GLM-5'],
+      ['glm5.2', 'GLM-5.2'],
       ['llama70b', 'Llama-3.3-70B-Instruct-FP8'],
       ['kimik2.6', 'Kimi-K2.5'],
       ['kimik2.7-code', 'Kimi-K2.5'],

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -80,7 +80,7 @@ export function buildInferenceCompareUrl(
   previousRow: SubmissionSummaryRow,
 ): string | null {
   // DB_MODEL_TO_DISPLAY covers every DB prefix incl. point-release aliases
-  // (gptoss120b, glm5.1, kimik2.6, kimik2.7-code, minimaxm2.7, llama70b).
+  // (gptoss120b, glm5.1, glm5.2, kimik2.6, kimik2.7-code, minimaxm2.7, llama70b).
   // MODEL_PREFIX_MAPPING only has the single canonical prefix per Model enum
   // and misses those rows.
   const displayModel = DB_MODEL_TO_DISPLAY[currentRow.model];

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -43,6 +43,13 @@ describe('parseCompareSlug — new model-prefixed form', () => {
     expect(parsed?.b).toBe('gb200');
   });
 
+  it('parses the glm-5-2 slug as its own model, distinct from glm-5-1', () => {
+    const parsed = parseCompareSlug('glm-5-2-h100-vs-h200');
+    expect(parsed?.model.slug).toBe('glm-5-2');
+    expect(parsed?.model.dbKeys).toEqual(['glm5.2']);
+    expect(parsed?.isAliasModel).toBe(false);
+  });
+
   it('parses the minimax-m3 slug as its own model, distinct from minimax-m27', () => {
     const parsed = parseCompareSlug('minimax-m3-h100-vs-h200');
     expect(parsed?.model.slug).toBe('minimax-m3');
@@ -252,7 +259,7 @@ describe('compareModelDisplayLabel', () => {
     expect(compareModelDisplayLabel(KIMI_K26, 'gb200', 'mi355x')).toBe(
       'Kimi K2.5/K2.6/K2.7-Code 1T — GB200 NVL72 vs MI355X',
     );
-    expect(compareModelDisplayLabel(GLM_51, 'h100', 'h200')).toBe('GLM 5/5.1/5.2 — H100 vs H200');
+    expect(compareModelDisplayLabel(GLM_51, 'h100', 'h200')).toBe('GLM 5/5.1 — H100 vs H200');
   });
 });
 

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -35,8 +35,9 @@ export interface CompareModelSlug {
 // gpt-oss → Llama 70B. Per product spec — flagship Chinese-developed models
 // first, smaller open US-developed models at the bottom. Qwen sits between
 // MiniMax and gpt-oss to keep the Chinese-lab cluster contiguous before the
-// US transition. The two MiniMax entries stay adjacent with the newer M3
-// flagship leading the older M2 series.
+// US transition. The two GLM entries and the two MiniMax entries each stay
+// adjacent with the newer flagship (GLM 5.2, MiniMax M3) leading the older
+// series.
 export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'deepseek-v4',
@@ -64,12 +65,21 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     label: 'Kimi K2.5/K2.6/K2.7-Code 1T',
   },
   {
+    slug: 'glm-5-2',
+    displayName: 'GLM-5.2',
+    // GLM-5.2 is a new 743B architecture (IndexShare sparse attention), not a
+    // point release of the GLM-5/5.1 family, so it gets its own slug and dbKey
+    // rather than joining the glm-5-1 group.
+    dbKeys: ['glm5.2'],
+    label: 'GLM 5.2 743B',
+  },
+  {
     slug: 'glm-5-1',
     displayName: 'GLM-5',
-    // GLM-5 point releases share the same base architecture. Keep the existing
-    // canonical slug for URL stability while querying every DB bucket.
-    dbKeys: ['glm5.2', 'glm5.1', 'glm5'],
-    label: 'GLM 5/5.1/5.2',
+    // GLM-5.0 and GLM-5.1 share an architecture per the model card; the slug
+    // uses the newer version name but the data pull covers both DB buckets.
+    dbKeys: ['glm5.1', 'glm5'],
+    label: 'GLM 5/5.1',
   },
   {
     slug: 'minimax-m3',

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -70,6 +70,7 @@ export const KNOWN_MODELS = new Set([
   'MiniMax-M2.5',
   'MiniMax-M3',
   'GLM-5',
+  'GLM-5.2',
   'DeepSeek-V4-Pro',
 ]);
 export const KNOWN_SEQUENCES = new Set(['1k/1k', '1k/8k', '8k/1k']);

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -57,6 +57,16 @@ describe('getModelAndSequence', () => {
     expect(result).toEqual({ model: Model.Kimi_K2_5, sequence: Sequence.OneK_OneK });
   });
 
+  it('parses glm5.2 artifact names as GLM_5_2, not GLM_5 (substring collision)', () => {
+    const result = getModelAndSequence('results_glm5.2_1k1k');
+    expect(result).toEqual({ model: Model.GLM_5_2, sequence: Sequence.OneK_OneK });
+  });
+
+  it('still parses plain glm5 artifact names as GLM_5', () => {
+    const result = getModelAndSequence('results_glm5_8k1k');
+    expect(result).toEqual({ model: Model.GLM_5, sequence: Sequence.EightK_OneK });
+  });
+
   it('returns undefined for unrecognized model prefix', () => {
     expect(getModelAndSequence('results_unknown_1k1k')).toBeUndefined();
   });
@@ -127,6 +137,15 @@ describe('getModelAndSequenceFromArtifact', () => {
     expect(result).toEqual({ model: Model.Kimi_K2_5, sequence: Sequence.EightK_OneK });
   });
 
+  it('parses structured artifact with glm5.2 prefix as GLM_5_2', () => {
+    const result = getModelAndSequenceFromArtifact({
+      infmax_model_prefix: 'glm5.2',
+      isl: 1024,
+      osl: 1024,
+    });
+    expect(result).toEqual({ model: Model.GLM_5_2, sequence: Sequence.OneK_OneK });
+  });
+
   it('returns undefined for unknown model prefix', () => {
     const result = getModelAndSequenceFromArtifact({
       infmax_model_prefix: 'unknown',
@@ -162,8 +181,16 @@ describe('isModelDeprecated', () => {
     expect(isModelDeprecated(Model.GptOss)).toBe(true);
   });
 
+  it('returns true for deprecated model GLM_5 (superseded by GLM-5.2)', () => {
+    expect(isModelDeprecated(Model.GLM_5)).toBe(true);
+  });
+
   it('returns false for non-deprecated model DeepSeek_R1', () => {
     expect(isModelDeprecated(Model.DeepSeek_R1)).toBe(false);
+  });
+
+  it('returns false for non-deprecated model GLM_5_2', () => {
+    expect(isModelDeprecated(Model.GLM_5_2)).toBe(false);
   });
 });
 
@@ -224,7 +251,8 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.GptOss)).toBe('gpt-oss 120B');
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
-    expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1/5.2 744B');
+    expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
+    expect(getModelLabel(Model.GLM_5_2)).toBe('GLM5.2 743B');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -10,6 +10,7 @@ export enum Model {
   MiniMax_M2_5 = 'MiniMax-M2.5',
   MiniMax_M3 = 'MiniMax-M3',
   GLM_5 = 'GLM-5',
+  GLM_5_2 = 'GLM-5.2',
   DeepSeek_V4_Pro = 'DeepSeek-V4-Pro',
 }
 
@@ -111,8 +112,25 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'dsr1',
     category: 'maintenance',
   },
-  [Model.GLM_5]: { label: 'GLM5/5.1/5.2 744B', prefix: 'glm5', category: 'default' },
+  [Model.GLM_5_2]: {
+    // GLM-5.2 is a new architecture bucket (743B core MoE / 39B active with
+    // IndexShare DSA; HF metadata shows 753B because of the bundled MTP head),
+    // NOT a point release of GLM-5/5.1 — so it gets its own entry instead of
+    // joining the GLM_5 grouping. Keep this entry above GLM_5:
+    // MODEL_PREFIX_MAPPING matches artifact names by substring in insertion
+    // order, and 'glm5.2' artifact names also contain 'glm5'.
+    label: 'GLM5.2 743B',
+    prefix: 'glm5.2',
+    category: 'default',
+  },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
+  [Model.GLM_5]: {
+    // Superseded by GLM-5.2 (a different architecture bucket, split into its
+    // own entry above), so it's deprecated (no longer actively benchmarked).
+    label: 'GLM5/5.1 744B',
+    prefix: 'glm5',
+    category: 'deprecated',
+  },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.

--- a/packages/app/src/lib/models-mapping.test.ts
+++ b/packages/app/src/lib/models-mapping.test.ts
@@ -31,9 +31,12 @@ describe('DISPLAY_MODEL_TO_DB', () => {
   });
 
   it('groups point-release DB keys under one display', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
-      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
-    );
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
+  });
+
+  it('keeps glm5.2 in its own GLM-5.2 display bucket (new architecture)', () => {
+    expect(DISPLAY_MODEL_TO_DB['GLM-5.2']).toEqual(['glm5.2']);
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).not.toContain('glm5.2');
   });
 });
 

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -16,9 +16,7 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
   });
 
   it('groups point-release DB keys under the same display name', () => {
-    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(
-      expect.arrayContaining(['glm5', 'glm5.1', 'glm5.2']),
-    );
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).toEqual(expect.arrayContaining(['glm5', 'glm5.1']));
     expect(DISPLAY_MODEL_TO_DB['Kimi-K2.5']).toEqual(
       expect.arrayContaining(['kimik2.5', 'kimik2.6', 'kimik2.7-code']),
     );
@@ -29,6 +27,11 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
 
   it('maps minimaxm3 to its own MiniMax-M3 display name', () => {
     expect(DISPLAY_MODEL_TO_DB['MiniMax-M3']).toEqual(['minimaxm3']);
+  });
+
+  it('maps glm5.2 to its own GLM-5.2 display name (new architecture, not a GLM-5 point release)', () => {
+    expect(DISPLAY_MODEL_TO_DB['GLM-5.2']).toEqual(['glm5.2']);
+    expect(DISPLAY_MODEL_TO_DB['GLM-5']).not.toContain('glm5.2');
   });
 });
 

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -19,7 +19,10 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   minimaxm3: 'MiniMax-M3',
   glm5: 'GLM-5',
   'glm5.1': 'GLM-5',
-  'glm5.2': 'GLM-5',
+  // GLM-5.2 is a new architecture bucket (743B core MoE with IndexShare DSA),
+  // not a point release of GLM-5/5.1 (744B) — it renders as its own display
+  // model instead of joining the GLM-5 grouping.
+  'glm5.2': 'GLM-5.2',
   dsv4: 'DeepSeek-V4-Pro',
 };
 

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -98,9 +98,10 @@ export const MODEL_TO_KEY: Record<string, string> = {
   'MiniMaxAI/MiniMax-M2.5': 'minimaxm2.5',
   // MiniMax-M3 (428B, distinct architecture from the M2 series)
   'MiniMaxAI/MiniMax-M3': 'minimaxm3',
-  // GLM-5
+  // GLM-5 / 5.1 (same architecture, grouped under one display)
   'zai-org/GLM-5-FP8': 'glm5',
   'amd/GLM-5.1-MXFP4': 'glm5.1',
+  // GLM-5.2 (new architecture — its own display bucket, not a GLM-5 point release)
   'zai-org/GLM-5.2-FP8': 'glm5.2',
   // DeepSeek-V4-Pro
   'deepseek-ai/DeepSeek-V4-Pro': 'dsv4',


### PR DESCRIPTION
## Summary

GLM-5.2 is **not** a point release of GLM-5/5.1 — it is a new architecture bucket (`glm_moe_dsa` with IndexShare sparse attention, 78 layers; 743B core MoE / 39B active — the 753B HF metadata figure includes the bundled ~10B MTP head, same trap as DeepSeek-R1's 685B). PR #588 folded `glm5.2` into the `GLM-5` display grouping by mistake. This PR:

- **Splits `glm5.2` into its own `GLM-5.2` display model**
  - `DB_MODEL_TO_DISPLAY`: `'glm5.2' → 'GLM-5.2'` (own bucket; no re-ingest needed — DB rows were always stored under the `glm5.2` key, only the display mapping changes)
  - New `Model.GLM_5_2` enum + `MODEL_CONFIG` entry `GLM5.2 743B` (category `default`). Placed **above** `GLM_5` because `MODEL_PREFIX_MAPPING` matches artifact names by substring in insertion order and `glm5.2` artifact names also contain `glm5` — covered by new unit tests
  - New `/compare` + `/compare-per-dollar` slug `glm-5-2` (`dbKeys: ['glm5.2']`); the `glm-5-1` slug reverts to `['glm5.1', 'glm5']` with label `GLM 5/5.1`. Existing `glm`/`glm-5` aliases stay on `glm-5-1`, mirroring how the bare `minimax` alias stayed on the M2 series when M3 (different architecture) split out
  - `KNOWN_MODELS`, agentic sibling-nav label, and submissions display-mapping pick up `GLM-5.2`; `/about` FAQ model list derives from `DB_MODEL_TO_DISPLAY` automatically
- **Moves GLM 5/5.1 (`Model.GLM_5`) to the Deprecated dropdown group** (label reverts to `GLM5/5.1 744B`) — no longer actively benchmarked, following the gpt-oss precedent in #535
- **AGENTS.md**: adds the GLM-5.2 row (743B / 39B, `zai-org/GLM-5.2`) to the verified parameter table and a mislabel-trap bullet (not-a-point-release + 753B-includes-MTP-head)
- Updates compare-page SEO blurbs (EN + ZH) from "GLM 5" to "GLM 5.2"

## Chinese pages (/zh)

Both `/zh/compare` and `/zh/compare-per-dollar` SEO blurbs updated in the same PR. No new page/tab/post — the new compare slug pages are generated from shared templates that already have their `/zh` mirrors (`compare-ssr-zh.ts` untouched because the English narrative templates are unchanged).

## Overlay-run support

N/A — this is a model-category/display-mapping change, not a chart feature. Overlay rendering resolves model labels through the same `MODEL_CONFIG` / `DB_MODEL_TO_DISPLAY` maps, so `?unofficialrun=` overlays pick up the split automatically.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` — pass
- `pnpm test:unit` — 3,063 tests pass, including new coverage: `glm5.2` prefix-collision parsing (`getModelAndSequence` / `getModelAndSequenceFromArtifact`), `GLM-5.2` own display bucket (constants + app), `isModelDeprecated(GLM_5)`, `glm-5-2` compare-slug parsing, submissions `glm5.2 → GLM-5.2`
- `dropdown-switching.cy.ts` grouping e2e updated: `GLM5/5.1 744B` now asserted under **Deprecated**

## 中文说明

GLM-5.2 **并非** GLM-5/5.1 的小版本更新，而是全新架构分桶（`glm_moe_dsa`，采用 IndexShare 稀疏注意力，78 层；核心 MoE 743B / 激活 39B —— HF 元数据显示的 753B 包含约 10B 的 MTP 头，与 DeepSeek-R1 685B 是同类陷阱）。PR #588 误将 `glm5.2` 并入 `GLM-5` 显示分组。本 PR：

- **将 `glm5.2` 拆分为独立的 `GLM-5.2` 显示模型**：`DB_MODEL_TO_DISPLAY` 映射为独立分桶（无需重新摄取数据，DB 行本就存储在 `glm5.2` 键下，仅显示映射变更）；新增 `Model.GLM_5_2` 枚举与 `MODEL_CONFIG` 条目 `GLM5.2 743B`（默认分类），且置于 `GLM_5` 之上以保证产物名前缀子串匹配的正确性（已补充单元测试）；新增 `/compare` 与 `/compare-per-dollar` 的 `glm-5-2` slug，`glm-5-1` slug 恢复为仅查询 `['glm5.1', 'glm5']`
- **将 GLM 5/5.1（`Model.GLM_5`）移入下拉框"已弃用"分组**（标签恢复为 `GLM5/5.1 744B`），不再进行日常基准测试，沿用 #535 弃用 gpt-oss 的先例
- **AGENTS.md**：在权威参数表中新增 GLM-5.2（743B / 39B）行，并补充参数量陷阱说明
- 同步更新中英文 compare 页面的 SEO 描述（"GLM 5" → "GLM 5.2"）

测试：`pnpm typecheck` / `pnpm lint` / `pnpm fmt` / `pnpm test:unit`（3,063 个测试）全部通过；新增前缀冲突解析、独立显示分桶、弃用分类与 compare slug 的测试覆盖；已更新下拉分组 e2e。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide but coordinated model-taxonomy changes (dropdown categories, compare slugs, prefix parsing); regressions could mis-route benchmarks, though new tests target the main collision and mapping paths.
> 
> **Overview**
> Treats **GLM-5.2** as its own architecture and display model instead of folding `glm5.2` into the GLM-5/5.1 bucket. **`glm5.2` → `GLM-5.2`** in shared DB/display maps; new **`Model.GLM_5_2`** with default dropdown label **`GLM5.2 743B`**, placed **above** `GLM_5` so artifact prefix matching does not treat `glm5.2` as `glm5`.
> 
> **GLM 5/5.1** (`Model.GLM_5`) moves to **Deprecated** (`GLM5/5.1 744B`); compare **`glm-5-1`** only queries `glm5` / `glm5.1` and a new **`glm-5-2`** slug targets `glm5.2` alone. EN/ZH compare SEO copy highlights GLM 5.2; **AGENTS.md** adds parameter counts and a mislabel trap.
> 
> Tests cover prefix collision, slug parsing, deprecation, submissions URLs, and Cypress expects **`GLM5/5.1 744B`** under Deprecated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1531596b6f9d216f1e1961c813bbf1519eccb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->