### PR TITLE
Deprecate GLM-5/5.1 and 1K/1K in frontend

### DIFF
--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -167,6 +167,14 @@ describe('isModelDeprecated', () => {
     expect(isModelDeprecated(Model.GptOss)).toBe(true);
   });
 
+  it('returns true for deprecated GLM-5/5.1', () => {
+    expect(isModelDeprecated(Model.GLM_5)).toBe(true);
+  });
+
+  it('keeps GLM-5.2 active', () => {
+    expect(isModelDeprecated(Model.GLM_5_2)).toBe(false);
+  });
+
   it('returns false for non-deprecated model DeepSeek_R1', () => {
     expect(isModelDeprecated(Model.DeepSeek_R1)).toBe(false);
   });

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -203,8 +203,8 @@ describe('isSequenceDeprecated', () => {
     expect(isSequenceDeprecated(Sequence.OneK_EightK)).toBe(true);
   });
 
-  it('returns false for non-deprecated sequence OneK_OneK', () => {
-    expect(isSequenceDeprecated(Sequence.OneK_OneK)).toBe(false);
+  it('returns true for deprecated sequence OneK_OneK', () => {
+    expect(isSequenceDeprecated(Sequence.OneK_OneK)).toBe(true);
   });
 
   it('returns false for non-deprecated sequence EightK_OneK', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -232,7 +232,7 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
   [Sequence.OneK_OneK]: {
     label: '1K / 1K',
     compact: '1k1k',
-    category: 'default',
+    category: 'deprecated',
     kind: 'fixed-seq',
   },
   [Sequence.OneK_EightK]: {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -112,7 +112,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'dsr1',
     category: 'maintenance',
   },
-  [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'default' },
+  [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'deprecated' },
   [Model.GLM_5_2]: { label: 'GLM5.2', prefix: 'glm5.2', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },


### PR DESCRIPTION
## Summary
- move the grouped GLM-5/5.1 model option into the deprecated frontend section
- keep GLM-5.2 active in the default section
- move the 1K/1K sequence option into the deprecated frontend section

## Verification
- 41 focused unit tests passed
- `pnpm typecheck`
- formatting check on changed files
- refreshed local availability API returns the GLM-5.2 Agentic Traces row