### PR TITLE
chore(db): purge accidentally ingested GLM-5.2 test runs

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -50,6 +50,8 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29089300938, // 2026-07-10 | Reason: reverting due to rule to disallow any patching
   29425167775, // 2026-07-15 | Reason: reverting per rule that recipes PRs must merge before the InferenceX PR; also used the wrong draft model
   29427827757, // 2026-07-15 | Reason: sweep-reuse recovery of the run above (PR #2158) — reverted for the same reason
+  29654139122, // 2026-07-18 | Reason: accidental ingest while testing
+  29660737166, // 2026-07-18 | Reason: accidental ingest while testing
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only ETL override with no runtime or auth changes; only affects exclusion of two known-bad runs from the database.
> 
> **Overview**
> Adds two GitHub Actions run IDs to **`PURGED_RUNS`** in `run-overrides.ts` so the ingest pipeline **skips** them on future ingest and **removes** any data already loaded for those runs.
> 
> Both entries are dated 2026-07-18 and documented as **accidental ingest while testing** (GLM-5.2 test runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab890f52d1a15ef3179aa737fd313424a66be0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->