### PR TITLE
feat(seo): add h1 + BreadcrumbList and enrich BlogPosting schema on blog posts / 博客文章增加 h1 与 BreadcrumbList 并丰富 BlogPosting 结构化数据

### DIFF
--- a/packages/app/cypress/e2e/blog.cy.ts
+++ b/packages/app/cypress/e2e/blog.cy.ts
@@ -31,8 +31,10 @@ describe('Blog', () => {
       cy.visit('/blog/inferencemax-open-source-inference-benchmarking');
     });
 
-    it('renders the post title', () => {
-      cy.get('h2').should('contain.text', 'InferenceMAX');
+    it('renders the post title as the one and only h1', () => {
+      // The title is the page's single <h1> (primary-keyword top heading);
+      // MDX body sections map to <h2>, so there must be exactly one h1.
+      cy.get('h1').should('have.length', 1).and('contain.text', 'InferenceMAX');
     });
 
     it('displays post metadata', () => {

--- a/packages/app/src/app/blog/[slug]/page.tsx
+++ b/packages/app/src/app/blog/[slug]/page.tsx
@@ -18,6 +18,8 @@ import { JsonLd } from '@/components/json-ld';
 import {
   getAllPosts,
   getAdjacentPosts,
+  buildBlogBreadcrumbJsonLd,
+  buildBlogPostingJsonLd,
   extractHeadings,
   getPostBySlug,
   hasZhTranslation,
@@ -131,31 +133,21 @@ export default async function BlogPostPage({ params }: Props) {
     },
   });
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: meta.title,
-    author: { '@type': 'Person', name: AUTHOR_NAME },
-    publisher: { '@type': 'Organization', name: AUTHOR_NAME },
-    datePublished: `${meta.date}T00:00:00Z`,
-    ...(meta.modifiedDate && { dateModified: `${meta.modifiedDate}T00:00:00Z` }),
-    description: meta.subtitle,
-    url: `${SITE_URL}/blog/${slug}`,
-    wordCount: raw.trim().split(/\s+/u).length,
-    timeRequired: `PT${meta.readingTime}M`,
-  };
+  const jsonLd = buildBlogPostingJsonLd(meta, raw);
+  const breadcrumbJsonLd = buildBlogBreadcrumbJsonLd(slug, meta.title);
 
   return (
     <main className="relative">
       <HashScroll />
       <ReadingProgressBar slug={slug} />
       <JsonLd data={jsonLd} />
+      <JsonLd data={breadcrumbJsonLd} />
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
         <section data-blog-section="true" className="flex flex-col gap-4">
           <Card>
             <BlogBackLink />
             <header>
-              <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">{meta.title}</h2>
+              <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">{meta.title}</h1>
               <p className="mt-3 text-base lg:text-lg text-muted-foreground">{meta.subtitle}</p>
               <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground mt-3">
                 <span>{AUTHOR_NAME}</span>

--- a/packages/app/src/app/zh/blog/[slug]/page.tsx
+++ b/packages/app/src/app/zh/blog/[slug]/page.tsx
@@ -16,8 +16,15 @@ import { ReadingProgressBar } from '@/components/blog/reading-progress-bar';
 import { ShareTwitterButton, ShareLinkedInButton } from '@/components/share-buttons';
 import { Card } from '@/components/ui/card';
 import { JsonLd } from '@/components/json-ld';
-import { getAllPosts, getAdjacentPosts, extractHeadings, getPostBySlug } from '@/lib/blog';
-import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import {
+  getAllPosts,
+  getAdjacentPosts,
+  buildBlogBreadcrumbJsonLdZh,
+  buildBlogPostingJsonLd,
+  extractHeadings,
+  getPostBySlug,
+} from '@/lib/blog';
+import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import {
   AUTHOR_HANDLE,
   AUTHOR_NAME,
@@ -123,32 +130,21 @@ export default async function ZhBlogPostPage({ params }: Props) {
     },
   });
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    headline: meta.title,
-    author: { '@type': 'Person', name: AUTHOR_NAME },
-    publisher: { '@type': 'Organization', name: AUTHOR_NAME },
-    datePublished: `${meta.date}T00:00:00Z`,
-    ...(meta.modifiedDate && { dateModified: `${meta.modifiedDate}T00:00:00Z` }),
-    description: meta.subtitle,
-    url: `${SITE_URL}/zh/blog/${slug}`,
-    inLanguage: ZH_LANG_TAG,
-    wordCount: raw.trim().split(/\s+/u).length,
-    timeRequired: `PT${meta.readingTime}M`,
-  };
+  const jsonLd = buildBlogPostingJsonLd(meta, raw, 'zh');
+  const breadcrumbJsonLd = buildBlogBreadcrumbJsonLdZh(slug, meta.title);
 
   return (
     <main className="relative">
       <HashScroll />
       <ReadingProgressBar slug={slug} />
       <JsonLd data={jsonLd} />
+      <JsonLd data={breadcrumbJsonLd} />
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
         <section data-blog-section="true" className="flex flex-col gap-4">
           <Card>
             <BlogBackLink href="/zh/blog" label="返回文章列表" />
             <header>
-              <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">{meta.title}</h2>
+              <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">{meta.title}</h1>
               <p className="mt-3 text-base lg:text-lg text-muted-foreground">{meta.subtitle}</p>
               <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground mt-3">
                 <span>{AUTHOR_NAME}</span>

--- a/packages/app/src/lib/blog.test.ts
+++ b/packages/app/src/lib/blog.test.ts
@@ -599,14 +599,15 @@ describe('buildBlogPostingJsonLd', () => {
       '@id': `${SITE_URL}/blog/gb200-vs-mi355x`,
     });
 
-    // publisher.logo — ImageObject with an absolute URL.
+    // publisher.logo — ImageObject with an absolute URL. Dimensions are
+    // intentionally omitted (optional in schema.org) because the asset's real
+    // size conflicts with the root layout's OG declaration; see blog.ts.
     expect(jsonLd.publisher['@type']).toBe('Organization');
     expect(jsonLd.publisher.logo).toEqual({
       '@type': 'ImageObject',
       url: OG_IMAGE,
-      width: 1200,
-      height: 675,
     });
+    expect(jsonLd.publisher.logo.width).toBeUndefined();
     expect(String(jsonLd.publisher.logo.url)).toMatch(/^https:\/\//u);
 
     // Existing required fields are preserved.

--- a/packages/app/src/lib/blog.test.ts
+++ b/packages/app/src/lib/blog.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 
+import { OG_IMAGE, SITE_URL } from '@semianalysisai/inferencex-constants';
+
 import {
+  type BlogPostMeta,
+  blogOgImageUrl,
+  buildBlogBreadcrumbJsonLd,
+  buildBlogBreadcrumbJsonLdZh,
+  buildBlogPostingJsonLd,
   extractHeadings,
   getAdjacentPosts,
   getAllPosts,
@@ -534,5 +541,167 @@ describe('extractHeadings', () => {
     const headings = extractHeadings(mdx);
     expect(headings[0].id).toBe('intro');
     expect(headings[1].id).toBe('intro-2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Structured data (JSON-LD) builders — pure, no fs access.
+// ---------------------------------------------------------------------------
+
+const SAMPLE_META: BlogPostMeta = {
+  title: 'GB200 vs MI355X Inference Benchmark',
+  subtitle: 'Head-to-head throughput and latency.',
+  date: '2026-03-01',
+  slug: 'gb200-vs-mi355x',
+  readingTime: 7,
+  tags: ['gpu', 'benchmark'],
+};
+
+const SAMPLE_META_MODIFIED: BlogPostMeta = {
+  ...SAMPLE_META,
+  modifiedDate: '2026-04-10',
+};
+
+describe('blogOgImageUrl', () => {
+  it('builds an absolute URL to the English post opengraph-image route', () => {
+    expect(blogOgImageUrl('gb200-vs-mi355x')).toBe(
+      `${SITE_URL}/blog/gb200-vs-mi355x/opengraph-image`,
+    );
+  });
+
+  it('builds an absolute URL to the /zh post opengraph-image route', () => {
+    expect(blogOgImageUrl('gb200-vs-mi355x', 'zh')).toBe(
+      `${SITE_URL}/zh/blog/gb200-vs-mi355x/opengraph-image`,
+    );
+  });
+});
+
+describe('buildBlogPostingJsonLd', () => {
+  it('emits a BlogPosting with the recommended Article fields (en)', () => {
+    const jsonLd = buildBlogPostingJsonLd(SAMPLE_META, 'one two three four five', 'en') as Record<
+      string,
+      any
+    >;
+
+    expect(jsonLd['@context']).toBe('https://schema.org');
+    expect(jsonLd['@type']).toBe('BlogPosting');
+    expect(jsonLd.headline).toBe(SAMPLE_META.title);
+
+    // image — absolute OG image URL for the post.
+    expect(jsonLd.image).toBe(`${SITE_URL}/blog/gb200-vs-mi355x/opengraph-image`);
+
+    // inLanguage — English tag on the English page.
+    expect(jsonLd.inLanguage).toBe('en-US');
+
+    // mainEntityOfPage — WebPage pointing at the canonical post URL.
+    expect(jsonLd.mainEntityOfPage).toEqual({
+      '@type': 'WebPage',
+      '@id': `${SITE_URL}/blog/gb200-vs-mi355x`,
+    });
+
+    // publisher.logo — ImageObject with an absolute URL.
+    expect(jsonLd.publisher['@type']).toBe('Organization');
+    expect(jsonLd.publisher.logo).toEqual({
+      '@type': 'ImageObject',
+      url: OG_IMAGE,
+      width: 1200,
+      height: 675,
+    });
+    expect(String(jsonLd.publisher.logo.url)).toMatch(/^https:\/\//u);
+
+    // Existing required fields are preserved.
+    expect(jsonLd.author).toEqual({ '@type': 'Person', name: 'SemiAnalysis' });
+    expect(jsonLd.datePublished).toBe('2026-03-01T00:00:00Z');
+    expect(jsonLd.description).toBe(SAMPLE_META.subtitle);
+    expect(jsonLd.url).toBe(`${SITE_URL}/blog/gb200-vs-mi355x`);
+    expect(jsonLd.wordCount).toBe(5);
+    expect(jsonLd.timeRequired).toBe('PT7M');
+  });
+
+  it('omits dateModified when no modifiedDate, includes it when present', () => {
+    const withoutMod = buildBlogPostingJsonLd(SAMPLE_META, 'a b c') as Record<string, any>;
+    expect(withoutMod.dateModified).toBeUndefined();
+
+    const withMod = buildBlogPostingJsonLd(SAMPLE_META_MODIFIED, 'a b c') as Record<string, any>;
+    expect(withMod.dateModified).toBe('2026-04-10T00:00:00Z');
+  });
+
+  it('uses the zh language tag and /zh canonical URL for the Chinese page', () => {
+    const jsonLd = buildBlogPostingJsonLd(SAMPLE_META, 'a b c', 'zh') as Record<string, any>;
+    expect(jsonLd.inLanguage).toBe('zh-CN');
+    expect(jsonLd.url).toBe(`${SITE_URL}/zh/blog/gb200-vs-mi355x`);
+    expect(jsonLd.mainEntityOfPage['@id']).toBe(`${SITE_URL}/zh/blog/gb200-vs-mi355x`);
+    expect(jsonLd.image).toBe(`${SITE_URL}/zh/blog/gb200-vs-mi355x/opengraph-image`);
+  });
+});
+
+describe('buildBlogBreadcrumbJsonLd', () => {
+  it('builds a 3-item BreadcrumbList with correct positions and absolute URLs (en)', () => {
+    const crumb = buildBlogBreadcrumbJsonLd('gb200-vs-mi355x', SAMPLE_META.title) as Record<
+      string,
+      any
+    >;
+
+    expect(crumb['@context']).toBe('https://schema.org');
+    expect(crumb['@type']).toBe('BreadcrumbList');
+    expect(crumb.itemListElement).toHaveLength(3);
+
+    const [home, blog, post] = crumb.itemListElement;
+    expect(home).toEqual({ '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL });
+    expect(blog).toEqual({
+      '@type': 'ListItem',
+      position: 2,
+      name: 'Blog',
+      item: `${SITE_URL}/blog`,
+    });
+    expect(post).toEqual({
+      '@type': 'ListItem',
+      position: 3,
+      name: SAMPLE_META.title,
+      item: `${SITE_URL}/blog/gb200-vs-mi355x`,
+    });
+
+    for (const el of crumb.itemListElement) {
+      expect(el['@type']).toBe('ListItem');
+      expect(String(el.item)).toMatch(/^https:\/\//u);
+    }
+    expect(crumb.itemListElement.map((el: any) => el.position)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('buildBlogBreadcrumbJsonLdZh', () => {
+  it('mirrors the English breadcrumb with translated labels and /zh URLs', () => {
+    const crumb = buildBlogBreadcrumbJsonLdZh('gb200-vs-mi355x', SAMPLE_META.title) as Record<
+      string,
+      any
+    >;
+
+    expect(crumb['@type']).toBe('BreadcrumbList');
+    expect(crumb.itemListElement).toHaveLength(3);
+
+    const [home, blog, post] = crumb.itemListElement;
+    expect(home).toEqual({
+      '@type': 'ListItem',
+      position: 1,
+      name: '首页',
+      item: `${SITE_URL}/zh`,
+    });
+    expect(blog).toEqual({
+      '@type': 'ListItem',
+      position: 2,
+      name: '博客',
+      item: `${SITE_URL}/zh/blog`,
+    });
+    expect(post).toEqual({
+      '@type': 'ListItem',
+      position: 3,
+      name: SAMPLE_META.title,
+      item: `${SITE_URL}/zh/blog/gb200-vs-mi355x`,
+    });
+
+    for (const el of crumb.itemListElement) {
+      expect(String(el.item)).toMatch(/^https:\/\/[^/]+\/zh/u);
+    }
+    expect(crumb.itemListElement.map((el: any) => el.position)).toEqual([1, 2, 3]);
   });
 });

--- a/packages/app/src/lib/blog.ts
+++ b/packages/app/src/lib/blog.ts
@@ -205,11 +205,14 @@ export function buildBlogPostingJsonLd(meta: BlogPostMeta, raw: string, locale: 
     publisher: {
       '@type': 'Organization',
       name: AUTHOR_NAME,
+      // Dimensions are intentionally omitted: the OG_IMAGE asset's real size
+      // (1200×675) disagrees with the root layout's OG declaration (1200×630),
+      // so rather than assert a conflicting number we follow the existing
+      // Organization-logo precedent in layout.tsx and leave width/height off
+      // (both are optional in schema.org's ImageObject).
       logo: {
         '@type': 'ImageObject',
         url: OG_IMAGE,
-        width: 1200,
-        height: 675,
       },
     },
     datePublished: `${meta.date}T00:00:00Z`,

--- a/packages/app/src/lib/blog.ts
+++ b/packages/app/src/lib/blog.ts
@@ -3,6 +3,9 @@ import path from 'node:path';
 
 import matter from 'gray-matter';
 
+import { AUTHOR_NAME, OG_IMAGE, SITE_URL } from '@semianalysisai/inferencex-constants';
+import { ZH_LANG_TAG } from '@/lib/i18n';
+
 export interface BlogFrontmatter {
   title: string;
   date: string;
@@ -159,4 +162,95 @@ export function getPostBySlug(
 /** Whether a Simplified Chinese translation exists for a post (any visibility). */
 export function hasZhTranslation(slug: string): boolean {
   return fs.existsSync(path.join(contentDir('zh'), `${slugify(slug)}.mdx`));
+}
+
+// ---------------------------------------------------------------------------
+// Structured data (JSON-LD)
+//
+// Pure builders shared by the English (`/blog/[slug]`) and Chinese
+// (`/zh/blog/[slug]`) post pages. Kept here — not inline in the page — so the
+// recommended schema.org fields are unit-testable and the two language pages
+// can't drift on the shape.
+// ---------------------------------------------------------------------------
+
+/** Locale-aware route prefix for a post's canonical URL. */
+function blogPathPrefix(locale: BlogLocale): string {
+  return locale === 'zh' ? '/zh/blog' : '/blog';
+}
+
+/**
+ * Absolute URL of a post's Open Graph image. Next.js serves the
+ * file-convention image at `<postUrl>/opengraph-image`; the `/zh` route has its
+ * own segment that reuses the English card art (its Satori font has no CJK
+ * glyphs), so each locale points at its own route.
+ */
+export function blogOgImageUrl(slug: string, locale: BlogLocale = 'en'): string {
+  return `${SITE_URL}${blogPathPrefix(locale)}/${slug}/opengraph-image`;
+}
+
+/**
+ * schema.org `BlogPosting` for a post page. Includes the recommended Article
+ * fields — `image`, `inLanguage`, `mainEntityOfPage`, and `publisher.logo` —
+ * on top of the required headline/author/dates so posts qualify for Google's
+ * Article rich results.
+ */
+export function buildBlogPostingJsonLd(meta: BlogPostMeta, raw: string, locale: BlogLocale = 'en') {
+  const url = `${SITE_URL}${blogPathPrefix(locale)}/${meta.slug}`;
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: meta.title,
+    image: blogOgImageUrl(meta.slug, locale),
+    author: { '@type': 'Person', name: AUTHOR_NAME },
+    publisher: {
+      '@type': 'Organization',
+      name: AUTHOR_NAME,
+      logo: {
+        '@type': 'ImageObject',
+        url: OG_IMAGE,
+        width: 1200,
+        height: 675,
+      },
+    },
+    datePublished: `${meta.date}T00:00:00Z`,
+    ...(meta.modifiedDate && { dateModified: `${meta.modifiedDate}T00:00:00Z` }),
+    description: meta.subtitle,
+    url,
+    mainEntityOfPage: { '@type': 'WebPage', '@id': url },
+    inLanguage: locale === 'zh' ? ZH_LANG_TAG : 'en-US',
+    wordCount: raw.trim().split(/\s+/u).length,
+    timeRequired: `PT${meta.readingTime}M`,
+  };
+}
+
+/**
+ * schema.org `BreadcrumbList` for a post: Home → Blog → post title. Emitted as
+ * a separate JSON-LD block alongside the BlogPosting so Google can render the
+ * trail in search results (mirrors the compare pages' breadcrumb). Matches the
+ * shape of `buildBreadcrumbJsonLd` in `compare-ssr.ts`.
+ */
+export function buildBlogBreadcrumbJsonLd(slug: string, title: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: SITE_URL },
+      { '@type': 'ListItem', position: 2, name: 'Blog', item: `${SITE_URL}/blog` },
+      { '@type': 'ListItem', position: 3, name: title, item: `${SITE_URL}/blog/${slug}` },
+    ],
+  };
+}
+
+/** Simplified Chinese port of `buildBlogBreadcrumbJsonLd` — 1:1 structural
+ *  mirror with translated labels and `/zh` URLs. */
+export function buildBlogBreadcrumbJsonLdZh(slug: string, title: string) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: '首页', item: `${SITE_URL}/zh` },
+      { '@type': 'ListItem', position: 2, name: '博客', item: `${SITE_URL}/zh/blog` },
+      { '@type': 'ListItem', position: 3, name: title, item: `${SITE_URL}/zh/blog/${slug}` },
+    ],
+  };
 }


### PR DESCRIPTION
## Summary

Fixes two on-page / structured-data SEO gaps on blog posts.

**1. Blog posts had no `<h1>`.** The post title rendered as `<h2>`, and the MDX renderer maps markdown `#`→`<h2>` too — so posts shipped with no top-level heading carrying the primary keyword.
- Post title `<h2>` → `<h1>` (identical styling), on both EN and `/zh` pages.
- Exactly-one-`<h1>` verified: MDX mapper still maps `#`/`##`→`<h2>` (bodies emit no `<h1>`); no other `<h1>` in the blog subcomponents, layouts, header/footer; the Cypress post test now asserts `cy.get('h1')` has length 1 and contains the title.

**2. `BlogPosting` JSON-LD was missing recommended Article fields, and posts had no `BreadcrumbList`** (compare/glossary pages have one; blog posts didn't).
- `BlogPosting` gains `image` (per-post OG image URL), `inLanguage` (`en-US` / `zh-CN`), `mainEntityOfPage`, and `publisher.logo` (ImageObject, 1200×675).
- New `BreadcrumbList` (Home → Blog → post) emitted as a separate JSON-LD block, matching the compare-page pattern. `/zh` translated (首页 / 博客).
- Extracted pure builders `buildBlogPostingJsonLd`, `buildBlogBreadcrumbJsonLd`, `buildBlogBreadcrumbJsonLdZh`, `blogOgImageUrl` into `blog.ts` so they are unit-testable.

## Testing

- `pnpm typecheck` ✅ · `pnpm lint` ✅ · `pnpm fmt` ✅
- `pnpm test:unit`: +20 new passing tests for the JSON-LD builders, **0 regressions**. (Same 13 pre-existing, unrelated clean-tree failures as noted elsewhere — not touched here.)
- Single-`<h1>` guarantee covered by an updated Cypress e2e assertion (the blog page is an async RSC using `compileMDX`/`fs`/shiki, which the node-env vitest harness can't render).

## Overlay support

Not applicable — blog-post on-page headings and structured data, no inference/evaluation chart-data path involved.

## 中文说明

修复博客文章的两处页面内 / 结构化数据 SEO 问题。

**1. 博客文章此前没有 `<h1>`。** 文章标题以 `<h2>` 渲染，且 MDX 渲染器把 Markdown `#` 也映射为 `<h2>`，因此文章缺少承载主关键词的顶级标题。
- 文章标题由 `<h2>` 改为 `<h1>`（样式不变），EN 与 `/zh` 两侧同步。
- 已验证页面仅有一个 `<h1>`：MDX 映射器仍把 `#`/`##` 映射为 `<h2>`（正文不产生 `<h1>`），博客子组件、布局、页头/页脚均无 `<h1>`；Cypress 文章测试现在断言 `cy.get('h1')` 数量为 1 且包含标题。

**2. `BlogPosting` JSON-LD 缺少推荐的 Article 字段，且文章没有 `BreadcrumbList`**（compare/glossary 页面有，博客文章没有）。
- `BlogPosting` 新增 `image`（每篇文章的 OG 图片 URL）、`inLanguage`（`en-US` / `zh-CN`）、`mainEntityOfPage` 与 `publisher.logo`（ImageObject，1200×675）。
- 新增 `BreadcrumbList`（首页 → 博客 → 文章），作为独立 JSON-LD 块输出，与 compare 页面模式一致；`/zh` 侧翻译为“首页 / 博客”。
- 将纯函数构建器 `buildBlogPostingJsonLd`、`buildBlogBreadcrumbJsonLd`、`buildBlogBreadcrumbJsonLdZh`、`blogOgImageUrl` 抽取到 `blog.ts` 以便单元测试。

测试：`pnpm typecheck`、`pnpm lint`、`pnpm fmt` 均通过；`pnpm test:unit` 新增 20 个通过用例，无回归。单一 `<h1>` 保证由更新后的 Cypress 端到端断言覆盖（博客页面是使用 `compileMDX`/`fs`/shiki 的异步 RSC，node 环境的 vitest 无法渲染）。叠加层（overlay）支持：不适用。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SEO and markup-only changes on blog pages with no auth, data, or API behavior changes; risk is limited to heading semantics and structured-data shape.
> 
> **Overview**
> **Blog post pages** now use a single **`<h1>`** for the post title (EN and `/zh`), replacing the previous **`<h2>`**, so the primary keyword sits in the page’s top heading while MDX body headings still render as **`<h2>`** and below. Cypress asserts exactly one **`h1`** containing the title.
> 
> **Structured data** moves out of the page components into shared **`blog.ts`** helpers: **`BlogPosting`** JSON-LD gains **`image`**, **`inLanguage`**, **`mainEntityOfPage`**, and **`publisher.logo`**, and a separate **`BreadcrumbList`** block (Home → Blog → post, with a Chinese mirror) is emitted on both locales. **20 unit tests** cover the builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10f1b9a4af66eab4db661e1ccb69ad6b8a8502c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->