### PR TITLE
feat(compare): replace index card walls with GPU pair selection matrices

### DIFF
--- a/packages/app/cypress/e2e/compare-index-matrix.cy.ts
+++ b/packages/app/cypress/e2e/compare-index-matrix.cy.ts
@@ -1,0 +1,67 @@
+describe('Compare index matrix', () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    });
+  });
+
+  it('renders one matrix per model section with linked + ghost cells on /compare', () => {
+    cy.visit('/compare');
+    cy.get('[data-testid="compare-pair-matrix"]').should('have.length.greaterThan', 0);
+
+    // Every model section renders exactly one matrix.
+    cy.get('section[id]').then(($sections) => {
+      const withMatrix = $sections.filter(
+        (_, s) => s.querySelector('[data-testid="compare-pair-matrix"]') !== null,
+      );
+      cy.get('[data-testid="compare-pair-matrix"]').should('have.length', withMatrix.length);
+    });
+
+    // Available pairs are real links under /compare/<model>-<a>-vs-<b>.
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .should('have.length.greaterThan', 0)
+      .first()
+      .should('have.attr', 'href')
+      .and('match', /^\/compare\/[a-z0-9-]+-[a-z0-9]+-vs-[a-z0-9]+$/u);
+
+    // Pairs without benchmark data render as non-link ghost cells (the
+    // fixtures' availability is sparse, so ghosts always exist).
+    cy.get('[data-testid="compare-matrix-empty-cell"]').should('have.length.greaterThan', 0);
+
+    // Anchor text (sr-only) carries the pair name for crawlers.
+    cy.get('a[data-testid="compare-matrix-cell"]').first().invoke('text').should('match', /vs/u);
+  });
+
+  it('navigates to the pair page when a cell is clicked', () => {
+    cy.visit('/compare');
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .first()
+      .then(($a) => {
+        const href = $a.attr('href')!;
+        cy.wrap($a).click();
+        cy.location('pathname').should('eq', href);
+      });
+  });
+
+  it('shows the focused pair in the readout line (same path as hover)', () => {
+    cy.visit('/compare');
+    // React's onMouseEnter is delegated and unreachable via cy.trigger — the
+    // keyboard focus handler updates the same readout state, so exercise that.
+    cy.get('a[data-testid="compare-matrix-cell"]').first().focus();
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .first()
+      .invoke('attr', 'title')
+      .then((label) => {
+        cy.get('[data-testid="compare-matrix-readout"]').first().should('contain.text', label);
+      });
+  });
+
+  it('renders per-dollar matrices with /compare-per-dollar cell hrefs', () => {
+    cy.visit('/compare-per-dollar');
+    cy.get('[data-testid="compare-pair-matrix"]').should('have.length.greaterThan', 0);
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .first()
+      .should('have.attr', 'href')
+      .and('match', /^\/compare-per-dollar\//u);
+  });
+});

--- a/packages/app/cypress/e2e/compare-index-matrix.cy.ts
+++ b/packages/app/cypress/e2e/compare-index-matrix.cy.ts
@@ -64,4 +64,23 @@ describe('Compare index matrix', () => {
       .should('have.attr', 'href')
       .and('match', /^\/compare-per-dollar\//u);
   });
+
+  it('renders the zh matrices with /zh hrefs and Chinese legend strings', () => {
+    cy.visit('/zh/compare');
+    cy.get('[data-testid="compare-pair-matrix"]').should('have.length.greaterThan', 0);
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .first()
+      .should('have.attr', 'href')
+      .and('match', /^\/zh\/compare\//u);
+    cy.contains('暂无基准测试数据').should('exist');
+    cy.contains('点击单元格查看对比').should('exist');
+  });
+
+  it('renders the zh per-dollar matrices with /zh/compare-per-dollar hrefs', () => {
+    cy.visit('/zh/compare-per-dollar');
+    cy.get('a[data-testid="compare-matrix-cell"]')
+      .first()
+      .should('have.attr', 'href')
+      .and('match', /^\/zh\/compare-per-dollar\//u);
+  });
 });

--- a/packages/app/src/app/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/compare-per-dollar/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE,
-} from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE } from '@semianalysisai/inferencex-constants';
 
 import { enAlternates } from '@/lib/i18n';
 
-import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
+import { ComparePairMatrix } from '@/components/compare/compare-pair-matrix';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
-import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { buildCompareMatrix } from '@/lib/compare-matrix';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,42 +33,6 @@ export const metadata: Metadata = {
     description: DESCRIPTION,
   },
 };
-
-interface VendorGroup {
-  heading: string;
-  description: string;
-  pairs: { a: string; b: string; slug: string; label: string }[];
-}
-
-function groupPairsByVendorForModel(
-  model: CompareModelSlug,
-  comparablePairs: ComparePair[],
-): VendorGroup[] {
-  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
-  const groups: VendorGroup[] = [];
-  if (cross.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs AMD',
-      description: 'Cross-vendor cost-per-token comparisons across architecture generations.',
-      pairs: cross,
-    });
-  }
-  if (nvidia.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs NVIDIA',
-      description: 'Hopper and Blackwell generation cost-per-token comparisons.',
-      pairs: nvidia,
-    });
-  }
-  if (amd.length > 0) {
-    groups.push({
-      heading: 'AMD vs AMD',
-      description: 'CDNA 3 and CDNA 4 generation cost-per-token comparisons.',
-      pairs: amd,
-    });
-  }
-  return groups;
-}
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -145,7 +105,6 @@ export default async function ComparePerDollarIndexPage() {
 
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
-        const groups = groupPairsByVendorForModel(model, pairs);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -156,30 +115,11 @@ export default async function ComparePerDollarIndexPage() {
                   benchmark data on {model.label}.
                 </p>
               </div>
-              {groups.map((group) => (
-                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
-                  <div>
-                    <h3 className="text-base font-semibold">{group.heading}</h3>
-                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {group.pairs.map(({ slug, label, a, b }) => {
-                      const aMeta = HW_REGISTRY[a];
-                      const bMeta = HW_REGISTRY[b];
-                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
-                      return (
-                        <ComparePairCardLink
-                          key={slug}
-                          href={`/compare-per-dollar/${slug}`}
-                          slug={slug}
-                          label={label}
-                          archLine={archLine}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
+              <ComparePairMatrix
+                matrix={buildCompareMatrix(model.slug, pairs)}
+                hrefPrefix="/compare-per-dollar"
+                modelLabel={model.label}
+              />
             </Card>
           </section>
         );

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE,
-} from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE } from '@semianalysisai/inferencex-constants';
 
 import { enAlternates } from '@/lib/i18n';
 
-import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
+import { ComparePairMatrix } from '@/components/compare/compare-pair-matrix';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
-import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { buildCompareMatrix } from '@/lib/compare-matrix';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
@@ -37,42 +33,6 @@ export const metadata: Metadata = {
     description: DESCRIPTION,
   },
 };
-
-interface VendorGroup {
-  heading: string;
-  description: string;
-  pairs: { a: string; b: string; slug: string; label: string }[];
-}
-
-function groupPairsByVendorForModel(
-  model: CompareModelSlug,
-  comparablePairs: ComparePair[],
-): VendorGroup[] {
-  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
-  const groups: VendorGroup[] = [];
-  if (cross.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs AMD',
-      description: 'Cross-vendor comparisons across architecture generations.',
-      pairs: cross,
-    });
-  }
-  if (nvidia.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs NVIDIA',
-      description: 'Hopper and Blackwell generation comparisons.',
-      pairs: nvidia,
-    });
-  }
-  if (amd.length > 0) {
-    groups.push({
-      heading: 'AMD vs AMD',
-      description: 'CDNA 3 and CDNA 4 generation comparisons.',
-      pairs: amd,
-    });
-  }
-  return groups;
-}
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -142,7 +102,6 @@ export default async function CompareIndexPage() {
 
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
-        const groups = groupPairsByVendorForModel(model, pairs);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -153,30 +112,11 @@ export default async function CompareIndexPage() {
                   {model.label}.
                 </p>
               </div>
-              {groups.map((group) => (
-                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
-                  <div>
-                    <h3 className="text-base font-semibold">{group.heading}</h3>
-                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {group.pairs.map(({ slug, label, a, b }) => {
-                      const aMeta = HW_REGISTRY[a];
-                      const bMeta = HW_REGISTRY[b];
-                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
-                      return (
-                        <ComparePairCardLink
-                          key={slug}
-                          href={`/compare/${slug}`}
-                          slug={slug}
-                          label={label}
-                          archLine={archLine}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
+              <ComparePairMatrix
+                matrix={buildCompareMatrix(model.slug, pairs)}
+                hrefPrefix="/compare"
+                modelLabel={model.label}
+              />
             </Card>
           </section>
         );

--- a/packages/app/src/app/zh/compare-per-dollar/page.tsx
+++ b/packages/app/src/app/zh/compare-per-dollar/page.tsx
@@ -1,19 +1,15 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE_ZH,
-} from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
 
-import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
+import { ComparePairMatrix } from '@/components/compare/compare-pair-matrix';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
-import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { buildCompareMatrix } from '@/lib/compare-matrix';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { formatModelList } from '@/lib/compare-ssr';
 import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
@@ -37,42 +33,6 @@ export const metadata: Metadata = {
     description: DESCRIPTION,
   },
 };
-
-interface VendorGroup {
-  heading: string;
-  description: string;
-  pairs: { a: string; b: string; slug: string; label: string }[];
-}
-
-function groupPairsByVendorForModel(
-  model: CompareModelSlug,
-  comparablePairs: ComparePair[],
-): VendorGroup[] {
-  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
-  const groups: VendorGroup[] = [];
-  if (cross.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs AMD',
-      description: '跨厂商的不同架构代际每 token 成本对比。',
-      pairs: cross,
-    });
-  }
-  if (nvidia.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs NVIDIA',
-      description: 'Hopper 与 Blackwell 代际每 token 成本对比。',
-      pairs: nvidia,
-    });
-  }
-  if (amd.length > 0) {
-    groups.push({
-      heading: 'AMD vs AMD',
-      description: 'CDNA 3 与 CDNA 4 代际每 token 成本对比。',
-      pairs: amd,
-    });
-  }
-  return groups;
-}
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -139,7 +99,6 @@ export default async function ComparePerDollarIndexPageZh() {
 
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
-        const groups = groupPairsByVendorForModel(model, pairs);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -149,30 +108,11 @@ export default async function ComparePerDollarIndexPageZh() {
                   {pairs.length} 组 GPU 对比具有 {model.label} 的每 token 成本基准测试数据。
                 </p>
               </div>
-              {groups.map((group) => (
-                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
-                  <div>
-                    <h3 className="text-base font-semibold">{group.heading}</h3>
-                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {group.pairs.map(({ slug, label, a, b }) => {
-                      const aMeta = HW_REGISTRY[a];
-                      const bMeta = HW_REGISTRY[b];
-                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
-                      return (
-                        <ComparePairCardLink
-                          key={slug}
-                          href={`/zh/compare-per-dollar/${slug}`}
-                          slug={slug}
-                          label={label}
-                          archLine={archLine}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
+              <ComparePairMatrix
+                matrix={buildCompareMatrix(model.slug, pairs)}
+                hrefPrefix="/zh/compare-per-dollar"
+                modelLabel={model.label}
+              />
             </Card>
           </section>
         );

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -1,19 +1,15 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE_ZH,
-} from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
 
-import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
+import { ComparePairMatrix } from '@/components/compare/compare-pair-matrix';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
-import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
-import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { buildCompareMatrix } from '@/lib/compare-matrix';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { formatModelList } from '@/lib/compare-ssr';
 import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
@@ -37,42 +33,6 @@ export const metadata: Metadata = {
     description: DESCRIPTION,
   },
 };
-
-interface VendorGroup {
-  heading: string;
-  description: string;
-  pairs: { a: string; b: string; slug: string; label: string }[];
-}
-
-function groupPairsByVendorForModel(
-  model: CompareModelSlug,
-  comparablePairs: ComparePair[],
-): VendorGroup[] {
-  const { cross, nvidia, amd } = bucketComparePairsByVendor(model.slug, comparablePairs);
-  const groups: VendorGroup[] = [];
-  if (cross.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs AMD',
-      description: '跨厂商的不同架构代际对比。',
-      pairs: cross,
-    });
-  }
-  if (nvidia.length > 0) {
-    groups.push({
-      heading: 'NVIDIA vs NVIDIA',
-      description: 'Hopper 与 Blackwell 代际对比。',
-      pairs: nvidia,
-    });
-  }
-  if (amd.length > 0) {
-    groups.push({
-      heading: 'AMD vs AMD',
-      description: 'CDNA 3 与 CDNA 4 代际对比。',
-      pairs: amd,
-    });
-  }
-  return groups;
-}
 
 const jsonLd = {
   '@context': 'https://schema.org',
@@ -138,7 +98,6 @@ export default async function CompareIndexPageZh() {
 
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
-        const groups = groupPairsByVendorForModel(model, pairs);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -148,30 +107,11 @@ export default async function CompareIndexPageZh() {
                   {pairs.length} 组 GPU 对比具有 {model.label} 的基准测试数据。
                 </p>
               </div>
-              {groups.map((group) => (
-                <div key={`${model.slug}__${group.heading}`} className="flex flex-col gap-3">
-                  <div>
-                    <h3 className="text-base font-semibold">{group.heading}</h3>
-                    <p className="text-xs text-muted-foreground mt-1">{group.description}</p>
-                  </div>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                    {group.pairs.map(({ slug, label, a, b }) => {
-                      const aMeta = HW_REGISTRY[a];
-                      const bMeta = HW_REGISTRY[b];
-                      const archLine = `${aMeta?.arch ?? '—'} · ${bMeta?.arch ?? '—'}`;
-                      return (
-                        <ComparePairCardLink
-                          key={slug}
-                          href={`/zh/compare/${slug}`}
-                          slug={slug}
-                          label={label}
-                          archLine={archLine}
-                        />
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
+              <ComparePairMatrix
+                matrix={buildCompareMatrix(model.slug, pairs)}
+                hrefPrefix="/zh/compare"
+                modelLabel={model.label}
+              />
             </Card>
           </section>
         );

--- a/packages/app/src/components/compare/compare-pair-matrix.tsx
+++ b/packages/app/src/components/compare/compare-pair-matrix.tsx
@@ -55,12 +55,13 @@ interface ComparePairMatrixProps {
 }
 
 /**
- * Upper-triangle GPU×GPU selection matrix for the compare index pages. Each
+ * Lower-triangle GPU×GPU selection matrix for the compare index pages. Each
  * available pair is a real server-rendered `<a>` (SEO: all pair links stay in
- * the HTML with the pair name as sr-only anchor text); pairs without benchmark
- * data render as ghost cells so coverage gaps are visible at a glance. The
- * vendor blocks make the cross-vendor region a contiguous rectangle, which
- * gets the brand tint — same-vendor triangles stay neutral.
+ * the HTML with the pair name as sr-only anchor text) carrying a visible ↗
+ * glyph so linked cells read as clickable next to the empty ghosts; pairs
+ * without benchmark data render as ghost cells so coverage gaps are visible
+ * at a glance. The vendor blocks make the cross-vendor region a contiguous
+ * rectangle, which gets the brand tint — same-vendor triangles stay neutral.
  */
 export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePairMatrixProps) {
   const locale = useLocale();
@@ -73,8 +74,10 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
   const active = hoveredCell ?? focusedCell;
 
   const { gpus, cells } = matrix;
-  const rows = gpus.slice(0, -1);
-  const cols = gpus.slice(1);
+  // Lower triangle: the first GPU never appears as a row (nothing precedes
+  // it), the last never as a column (nothing follows it).
+  const rows = gpus.slice(1);
+  const cols = gpus.slice(0, -1);
 
   // Consecutive same-vendor column runs → the colSpan group bars on top.
   const colGroups: { vendor: string; count: number }[] = [];
@@ -153,8 +156,10 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                   </div>
                 </th>
                 {cols.map((colGpu, jIdx) => {
-                  // cols is gpus[1..]; display index of this column is jIdx+1.
-                  if (jIdx + 1 <= i) {
+                  // rows is gpus[1..], so this row's display index is i+1;
+                  // cols is gpus[0..n-2], so the column's display index is
+                  // jIdx. Cells exist below the diagonal (col before row).
+                  if (jIdx > i) {
                     return <td key={colGpu.key} className="p-0" aria-hidden="true" />;
                   }
                   const cell = cells[rowGpu.key][colGpu.key];
@@ -198,13 +203,24 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                         }
                         onBlur={() => setFocusedCell(null)}
                         className={cn(
-                          'block h-8 w-full rounded-md transition-all duration-150 lg:h-9',
+                          'group flex h-8 w-full items-center justify-center rounded-md transition-all duration-150 lg:h-9',
                           'hover:scale-105 focus-visible:ring-2 focus-visible:ring-brand focus-visible:outline-none',
                           cell.cross
                             ? 'bg-brand/20 ring-1 ring-brand/40 ring-inset hover:bg-brand/45'
                             : 'bg-foreground/15 hover:bg-foreground/30',
                         )}
                       >
+                        {/* Visible link affordance — ghost cells stay empty,
+                            so the glyph doubles as the clickable/not marker. */}
+                        <span
+                          aria-hidden="true"
+                          className={cn(
+                            'text-xs transition-opacity group-hover:opacity-100',
+                            cell.cross ? 'text-brand opacity-70' : 'text-foreground opacity-40',
+                          )}
+                        >
+                          ↗
+                        </span>
                         <span className="sr-only">{cell.label}</span>
                       </a>
                     </td>

--- a/packages/app/src/components/compare/compare-pair-matrix.tsx
+++ b/packages/app/src/components/compare/compare-pair-matrix.tsx
@@ -4,17 +4,37 @@ import { useState } from 'react';
 
 import { track } from '@/lib/analytics';
 import type { CompareMatrix } from '@/lib/compare-matrix';
+import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 
 const STRINGS = {
-  hint: 'Click a cell to open the comparison.',
-  crossLegend: 'NVIDIA vs AMD',
-  sameLegend: 'Same vendor',
-  emptyLegend: 'No benchmark data yet',
-  matrixAria: (model: string) => `${model} GPU comparison matrix`,
-  cellAria: (model: string, pair: string) => `${model}: ${pair} benchmark comparison`,
-  emptyTitle: (pair: string) => `${pair} — no benchmark data yet`,
+  en: {
+    hint: 'Click a cell to open the comparison.',
+    crossLegend: 'NVIDIA vs AMD',
+    sameLegend: 'Same vendor',
+    emptyLegend: 'No benchmark data yet',
+    matrixAria: (model: string) => `${model} GPU comparison matrix`,
+    cellAria: (model: string, pair: string) => `${model}: ${pair} benchmark comparison`,
+    emptyTitle: (pair: string) => `${pair} — no benchmark data yet`,
+  },
+  zh: {
+    hint: '点击单元格查看对比。',
+    crossLegend: 'NVIDIA vs AMD',
+    sameLegend: '同厂商',
+    emptyLegend: '暂无基准测试数据',
+    matrixAria: (model: string) => `${model} GPU 对比矩阵`,
+    cellAria: (model: string, pair: string) => `${model}：${pair} 基准测试对比`,
+    emptyTitle: (pair: string) => `${pair} — 暂无基准测试数据`,
+  },
 } as const;
+
+/** A row/column cell coordinate plus its display label, tracked for the
+ *  hover/focus highlight and readout. */
+interface ActiveCell {
+  row: string;
+  col: string;
+  label: string;
+}
 
 const VENDOR_HEADER_CLASS: Record<string, string> = {
   NVIDIA: 'border-emerald-500/60 text-emerald-700 dark:text-emerald-400',
@@ -43,8 +63,14 @@ interface ComparePairMatrixProps {
  * gets the brand tint — same-vendor triangles stay neutral.
  */
 export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePairMatrixProps) {
-  const t = STRINGS;
-  const [hovered, setHovered] = useState<{ row: string; col: string; label: string } | null>(null);
+  const locale = useLocale();
+  const t = STRINGS[locale];
+  // Hover and keyboard focus are tracked separately so a pointer entering and
+  // leaving a still-focused cell doesn't wipe the focus highlight. Hover takes
+  // precedence while present; when the pointer leaves, a focused cell persists.
+  const [hoveredCell, setHoveredCell] = useState<ActiveCell | null>(null);
+  const [focusedCell, setFocusedCell] = useState<ActiveCell | null>(null);
+  const active = hoveredCell ?? focusedCell;
 
   const { gpus, cells } = matrix;
   const rows = gpus.slice(0, -1);
@@ -91,7 +117,7 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                       title={`${gpu.label} (${gpu.arch})`}
                       className={cn(
                         'rotate-180 text-[10px] font-medium tracking-wide whitespace-nowrap transition-colors [writing-mode:vertical-rl]',
-                        hovered?.col === gpu.key ? 'text-foreground' : 'text-muted-foreground',
+                        active?.col === gpu.key ? 'text-foreground' : 'text-muted-foreground',
                       )}
                     >
                       {gpu.shortLabel}
@@ -108,7 +134,7 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                   <div
                     className={cn(
                       'flex h-8 flex-col justify-center rounded-md py-0.5 pr-3 pl-1 transition-colors lg:h-9',
-                      hovered?.row === rowGpu.key && 'bg-foreground/5',
+                      active?.row === rowGpu.key && 'bg-foreground/5',
                     )}
                   >
                     <span className="flex items-center gap-1.5 text-xs leading-tight font-medium whitespace-nowrap">
@@ -164,13 +190,13 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                           window.location.href = href;
                         }}
                         onMouseEnter={() =>
-                          setHovered({ row: rowGpu.key, col: colGpu.key, label: cell.label })
+                          setHoveredCell({ row: rowGpu.key, col: colGpu.key, label: cell.label })
                         }
-                        onMouseLeave={() => setHovered(null)}
+                        onMouseLeave={() => setHoveredCell(null)}
                         onFocus={() =>
-                          setHovered({ row: rowGpu.key, col: colGpu.key, label: cell.label })
+                          setFocusedCell({ row: rowGpu.key, col: colGpu.key, label: cell.label })
                         }
-                        onBlur={() => setHovered(null)}
+                        onBlur={() => setFocusedCell(null)}
                         className={cn(
                           'block size-8 rounded-md transition-all duration-150 lg:size-9',
                           'hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand focus-visible:outline-none',
@@ -192,7 +218,7 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
 
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px] text-muted-foreground">
         <span data-testid="compare-matrix-readout" className="min-w-40 font-medium">
-          {hovered ? <span className="text-foreground">{hovered.label} →</span> : t.hint}
+          {active ? <span className="text-foreground">{active.label} →</span> : t.hint}
         </span>
         <span className="inline-flex items-center gap-1.5">
           <span

--- a/packages/app/src/components/compare/compare-pair-matrix.tsx
+++ b/packages/app/src/components/compare/compare-pair-matrix.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useState } from 'react';
+
+import { track } from '@/lib/analytics';
+import type { CompareMatrix } from '@/lib/compare-matrix';
+import { cn } from '@/lib/utils';
+
+const STRINGS = {
+  hint: 'Click a cell to open the comparison.',
+  crossLegend: 'NVIDIA vs AMD',
+  sameLegend: 'Same vendor',
+  emptyLegend: 'No benchmark data yet',
+  matrixAria: (model: string) => `${model} GPU comparison matrix`,
+  cellAria: (model: string, pair: string) => `${model}: ${pair} benchmark comparison`,
+  emptyTitle: (pair: string) => `${pair} — no benchmark data yet`,
+} as const;
+
+const VENDOR_HEADER_CLASS: Record<string, string> = {
+  NVIDIA: 'border-emerald-500/60 text-emerald-700 dark:text-emerald-400',
+  AMD: 'border-red-500/60 text-red-700 dark:text-red-400',
+};
+
+const VENDOR_DOT_CLASS: Record<string, string> = {
+  NVIDIA: 'bg-emerald-500/80',
+  AMD: 'bg-red-500/80',
+};
+
+interface ComparePairMatrixProps {
+  matrix: CompareMatrix;
+  /** Route prefix cells link under, e.g. "/compare" or "/zh/compare-per-dollar". */
+  hrefPrefix: string;
+  /** Model label for accessible names and the analytics payload context. */
+  modelLabel: string;
+}
+
+/**
+ * Upper-triangle GPU×GPU selection matrix for the compare index pages. Each
+ * available pair is a real server-rendered `<a>` (SEO: all pair links stay in
+ * the HTML with the pair name as sr-only anchor text); pairs without benchmark
+ * data render as ghost cells so coverage gaps are visible at a glance. The
+ * vendor blocks make the cross-vendor region a contiguous rectangle, which
+ * gets the brand tint — same-vendor triangles stay neutral.
+ */
+export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePairMatrixProps) {
+  const t = STRINGS;
+  const [hovered, setHovered] = useState<{ row: string; col: string; label: string } | null>(null);
+
+  const { gpus, cells } = matrix;
+  const rows = gpus.slice(0, -1);
+  const cols = gpus.slice(1);
+
+  // Consecutive same-vendor column runs → the colSpan group bars on top.
+  const colGroups: { vendor: string; count: number }[] = [];
+  for (const gpu of cols) {
+    const last = colGroups.at(-1);
+    if (last && last.vendor === gpu.vendor) last.count++;
+    else colGroups.push({ vendor: gpu.vendor, count: 1 });
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="overflow-x-auto pb-1">
+        <table
+          data-testid="compare-pair-matrix"
+          aria-label={t.matrixAria(modelLabel)}
+          className="border-separate border-spacing-[3px]"
+        >
+          <thead>
+            <tr>
+              <th className="sticky left-0 z-10 bg-background p-0" aria-hidden="true" />
+              {colGroups.map((group) => (
+                <th key={group.vendor} colSpan={group.count} scope="colgroup" className="p-0 px-1">
+                  <div
+                    className={cn(
+                      'border-b-2 pb-1 text-center text-[10px] font-semibold uppercase tracking-wider',
+                      VENDOR_HEADER_CLASS[group.vendor] ?? 'border-border text-muted-foreground',
+                    )}
+                  >
+                    {group.vendor}
+                  </div>
+                </th>
+              ))}
+            </tr>
+            <tr>
+              <th className="sticky left-0 z-10 bg-background p-0" aria-hidden="true" />
+              {cols.map((gpu) => (
+                <th key={gpu.key} scope="col" className="p-0 align-bottom">
+                  <div className="flex h-14 items-end justify-center pb-1.5">
+                    <span
+                      title={`${gpu.label} (${gpu.arch})`}
+                      className={cn(
+                        'rotate-180 text-[10px] font-medium tracking-wide whitespace-nowrap transition-colors [writing-mode:vertical-rl]',
+                        hovered?.col === gpu.key ? 'text-foreground' : 'text-muted-foreground',
+                      )}
+                    >
+                      {gpu.shortLabel}
+                    </span>
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((rowGpu, i) => (
+              <tr key={rowGpu.key}>
+                <th scope="row" className="sticky left-0 z-10 bg-background p-0 text-left">
+                  <div
+                    className={cn(
+                      'flex h-8 flex-col justify-center rounded-md py-0.5 pr-3 pl-1 transition-colors lg:h-9',
+                      hovered?.row === rowGpu.key && 'bg-foreground/5',
+                    )}
+                  >
+                    <span className="flex items-center gap-1.5 text-xs leading-tight font-medium whitespace-nowrap">
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          'size-1.5 shrink-0 rounded-full',
+                          VENDOR_DOT_CLASS[rowGpu.vendor] ?? 'bg-muted-foreground',
+                        )}
+                      />
+                      {rowGpu.label}
+                    </span>
+                    <span className="pl-3 text-[10px] leading-tight text-muted-foreground">
+                      {rowGpu.arch}
+                    </span>
+                  </div>
+                </th>
+                {cols.map((colGpu, jIdx) => {
+                  // cols is gpus[1..]; display index of this column is jIdx+1.
+                  if (jIdx + 1 <= i) {
+                    return <td key={colGpu.key} className="p-0" aria-hidden="true" />;
+                  }
+                  const cell = cells[rowGpu.key][colGpu.key];
+                  if (!cell.available) {
+                    return (
+                      <td key={colGpu.key} className="p-0">
+                        <div
+                          data-testid="compare-matrix-empty-cell"
+                          title={t.emptyTitle(cell.label)}
+                          aria-hidden="true"
+                          className="size-8 rounded-md border border-dashed border-border/50 lg:size-9"
+                        />
+                      </td>
+                    );
+                  }
+                  const href = `${hrefPrefix}/${cell.slug}`;
+                  return (
+                    <td key={colGpu.key} className="p-0">
+                      <a
+                        href={href}
+                        data-testid="compare-matrix-cell"
+                        aria-label={t.cellAria(modelLabel, cell.label)}
+                        title={cell.label}
+                        onClick={(e) => {
+                          if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+                            return;
+                          }
+                          e.preventDefault();
+                          track('compare_index_pair_clicked', {
+                            slug: cell.slug,
+                            label: cell.label,
+                          });
+                          window.location.href = href;
+                        }}
+                        onMouseEnter={() =>
+                          setHovered({ row: rowGpu.key, col: colGpu.key, label: cell.label })
+                        }
+                        onMouseLeave={() => setHovered(null)}
+                        onFocus={() =>
+                          setHovered({ row: rowGpu.key, col: colGpu.key, label: cell.label })
+                        }
+                        onBlur={() => setHovered(null)}
+                        className={cn(
+                          'block size-8 rounded-md transition-all duration-150 lg:size-9',
+                          'hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand focus-visible:outline-none',
+                          cell.cross
+                            ? 'bg-brand/20 ring-1 ring-brand/40 ring-inset hover:bg-brand/45'
+                            : 'bg-foreground/15 hover:bg-foreground/30',
+                        )}
+                      >
+                        <span className="sr-only">{cell.label}</span>
+                      </a>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px] text-muted-foreground">
+        <span data-testid="compare-matrix-readout" className="min-w-40 font-medium">
+          {hovered ? <span className="text-foreground">{hovered.label} →</span> : t.hint}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="size-3 rounded-[4px] bg-brand/20 ring-1 ring-brand/40 ring-inset"
+          />
+          {t.crossLegend}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span aria-hidden="true" className="size-3 rounded-[4px] bg-foreground/15" />
+          {t.sameLegend}
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span
+            aria-hidden="true"
+            className="size-3 rounded-[4px] border border-dashed border-border/60"
+          />
+          {t.emptyLegend}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/compare/compare-pair-matrix.tsx
+++ b/packages/app/src/components/compare/compare-pair-matrix.tsx
@@ -90,11 +90,13 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
         <table
           data-testid="compare-pair-matrix"
           aria-label={t.matrixAria(modelLabel)}
-          className="border-separate border-spacing-[3px]"
+          className="w-full min-w-[600px] table-fixed border-separate border-spacing-[3px]"
         >
           <thead>
             <tr>
-              <th className="sticky left-0 z-10 bg-background p-0" aria-hidden="true" />
+              {/* Fixed-layout table: this corner cell sets the row-header
+                  column width; the 9 GPU columns share the remaining space. */}
+              <th className="sticky left-0 z-10 w-36 bg-background p-0" aria-hidden="true" />
               {colGroups.map((group) => (
                 <th key={group.vendor} colSpan={group.count} scope="colgroup" className="p-0 px-1">
                   <div
@@ -111,18 +113,16 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
             <tr>
               <th className="sticky left-0 z-10 bg-background p-0" aria-hidden="true" />
               {cols.map((gpu) => (
-                <th key={gpu.key} scope="col" className="p-0 align-bottom">
-                  <div className="flex h-14 items-end justify-center pb-1.5">
-                    <span
-                      title={`${gpu.label} (${gpu.arch})`}
-                      className={cn(
-                        'rotate-180 text-[10px] font-medium tracking-wide whitespace-nowrap transition-colors [writing-mode:vertical-rl]',
-                        active?.col === gpu.key ? 'text-foreground' : 'text-muted-foreground',
-                      )}
-                    >
-                      {gpu.shortLabel}
-                    </span>
-                  </div>
+                <th key={gpu.key} scope="col" className="p-0 pb-1 align-bottom">
+                  <span
+                    title={`${gpu.label} (${gpu.arch})`}
+                    className={cn(
+                      'block text-center text-[10px] font-medium tracking-wide whitespace-nowrap transition-colors',
+                      active?.col === gpu.key ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                  >
+                    {gpu.shortLabel}
+                  </span>
                 </th>
               ))}
             </tr>
@@ -165,7 +165,7 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                           data-testid="compare-matrix-empty-cell"
                           title={t.emptyTitle(cell.label)}
                           aria-hidden="true"
-                          className="size-8 rounded-md border border-dashed border-border/50 lg:size-9"
+                          className="h-8 w-full rounded-md border border-dashed border-border/50 lg:h-9"
                         />
                       </td>
                     );
@@ -198,8 +198,8 @@ export function ComparePairMatrix({ matrix, hrefPrefix, modelLabel }: ComparePai
                         }
                         onBlur={() => setFocusedCell(null)}
                         className={cn(
-                          'block size-8 rounded-md transition-all duration-150 lg:size-9',
-                          'hover:scale-110 focus-visible:ring-2 focus-visible:ring-brand focus-visible:outline-none',
+                          'block h-8 w-full rounded-md transition-all duration-150 lg:h-9',
+                          'hover:scale-105 focus-visible:ring-2 focus-visible:ring-brand focus-visible:outline-none',
                           cell.cross
                             ? 'bg-brand/20 ring-1 ring-brand/40 ring-inset hover:bg-brand/45'
                             : 'bg-foreground/15 hover:bg-foreground/30',

--- a/packages/app/src/lib/compare-matrix.test.ts
+++ b/packages/app/src/lib/compare-matrix.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { GPU_KEYS, HW_REGISTRY } from '@semianalysisai/inferencex-constants';
+
+import { buildCompareMatrix, compareMatrixGpuOrder } from './compare-matrix';
+import { canonicalCompareSlug } from './compare-slug';
+
+describe('compareMatrixGpuOrder', () => {
+  it('includes every registry GPU exactly once', () => {
+    const order = compareMatrixGpuOrder();
+    expect(order.map((g) => g.key).toSorted()).toEqual([...GPU_KEYS].toSorted());
+  });
+
+  it('keeps vendors contiguous with NVIDIA first', () => {
+    const vendors = compareMatrixGpuOrder().map((g) => g.vendor);
+    // Once the vendor changes, the earlier vendor must never reappear —
+    // contiguous blocks are what make the cross-vendor region a rectangle.
+    const blocks = vendors.filter((v, i) => i === 0 || v !== vendors[i - 1]);
+    expect(blocks).toEqual(['NVIDIA', 'AMD']);
+  });
+
+  it('orders each vendor block oldest→newest (registry sort descending)', () => {
+    const order = compareMatrixGpuOrder();
+    for (let i = 1; i < order.length; i++) {
+      if (order[i].vendor !== order[i - 1].vendor) continue;
+      expect(HW_REGISTRY[order[i].key].sort).toBeLessThan(HW_REGISTRY[order[i - 1].key].sort);
+    }
+    // Pin the NVIDIA generational read so a registry sort change is caught.
+    expect(order.slice(0, 2).map((g) => g.key)).toEqual(['h100', 'h200']);
+  });
+
+  it('uses the registry label for rows and the uppercased key for columns', () => {
+    const gb200 = compareMatrixGpuOrder().find((g) => g.key === 'gb200')!;
+    expect(gb200.label).toBe('GB200 NVL72');
+    expect(gb200.shortLabel).toBe('GB200');
+  });
+});
+
+describe('buildCompareMatrix', () => {
+  const PAIRS = [
+    { a: 'h100', b: 'h200' },
+    { a: 'h100', b: 'mi300x' },
+    { a: 'mi300x', b: 'mi325x' },
+  ];
+
+  it('defines cells only for the upper triangle of the display order', () => {
+    const { gpus, cells } = buildCompareMatrix('deepseek-r1', PAIRS);
+    const index = new Map(gpus.map((g, i) => [g.key, i]));
+    for (const [rowKey, row] of Object.entries(cells)) {
+      for (const colKey of Object.keys(row)) {
+        expect(index.get(colKey)!).toBeGreaterThan(index.get(rowKey)!);
+      }
+    }
+    // Every above-diagonal position is present, even when unavailable.
+    const cellCount = Object.values(cells).reduce((s, r) => s + Object.keys(r).length, 0);
+    expect(cellCount).toBe((gpus.length * (gpus.length - 1)) / 2);
+  });
+
+  it('marks exactly the provided pairs as available', () => {
+    const { cells, availableCount } = buildCompareMatrix('deepseek-r1', PAIRS);
+    expect(availableCount).toBe(PAIRS.length);
+    expect(cells['h100']['h200'].available).toBe(true);
+    expect(cells['h100']['mi300x'].available).toBe(true);
+    expect(cells['mi300x']['mi325x'].available).toBe(true);
+    expect(cells['h100']['b200'].available).toBe(false);
+  });
+
+  it('builds canonical alphabetical slugs regardless of display order', () => {
+    const { cells } = buildCompareMatrix('deepseek-r1', PAIRS);
+    // Display order puts h100 before b200, but the slug sorts alphabetically.
+    expect(cells['h100']['b200'].slug).toBe(canonicalCompareSlug('deepseek-r1', 'b200', 'h100'));
+    expect(cells['h100']['b200'].slug).toBe('deepseek-r1-b200-vs-h100');
+  });
+
+  it('labels cells in display (row vs column) order', () => {
+    const { cells } = buildCompareMatrix('deepseek-r1', PAIRS);
+    expect(cells['h100']['b200'].label).toBe('H100 vs B200');
+    expect(cells['gb200']['mi355x'].label).toBe('GB200 NVL72 vs MI355X');
+  });
+
+  it('flags cross-vendor cells and only those', () => {
+    const { gpus, cells } = buildCompareMatrix('deepseek-r1', PAIRS);
+    const vendorOf = new Map(gpus.map((g) => [g.key, g.vendor]));
+    for (const [rowKey, row] of Object.entries(cells)) {
+      for (const [colKey, cell] of Object.entries(row)) {
+        expect(cell.cross).toBe(vendorOf.get(rowKey) !== vendorOf.get(colKey));
+      }
+    }
+  });
+
+  it('returns an all-ghost matrix for a model with no pairs', () => {
+    const { cells, availableCount } = buildCompareMatrix('glm-5-1', []);
+    expect(availableCount).toBe(0);
+    expect(Object.values(cells).every((r) => Object.values(r).every((c) => !c.available))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/app/src/lib/compare-matrix.test.ts
+++ b/packages/app/src/lib/compare-matrix.test.ts
@@ -45,15 +45,15 @@ describe('buildCompareMatrix', () => {
     { a: 'mi300x', b: 'mi325x' },
   ];
 
-  it('defines cells only for the upper triangle of the display order', () => {
+  it('defines cells only for the lower triangle of the display order', () => {
     const { gpus, cells } = buildCompareMatrix('deepseek-r1', PAIRS);
     const index = new Map(gpus.map((g, i) => [g.key, i]));
     for (const [rowKey, row] of Object.entries(cells)) {
       for (const colKey of Object.keys(row)) {
-        expect(index.get(colKey)!).toBeGreaterThan(index.get(rowKey)!);
+        expect(index.get(colKey)!).toBeLessThan(index.get(rowKey)!);
       }
     }
-    // Every above-diagonal position is present, even when unavailable.
+    // Every below-diagonal position is present, even when unavailable.
     const cellCount = Object.values(cells).reduce((s, r) => s + Object.keys(r).length, 0);
     expect(cellCount).toBe((gpus.length * (gpus.length - 1)) / 2);
   });
@@ -61,27 +61,27 @@ describe('buildCompareMatrix', () => {
   it('marks exactly the provided pairs as available', () => {
     const { cells, availableCount } = buildCompareMatrix('deepseek-r1', PAIRS);
     expect(availableCount).toBe(PAIRS.length);
-    expect(cells['h100']['h200'].available).toBe(true);
-    expect(cells['h100']['mi300x'].available).toBe(true);
-    expect(cells['mi300x']['mi325x'].available).toBe(true);
-    expect(cells['h100']['b200'].available).toBe(false);
+    expect(cells['h200']['h100'].available).toBe(true);
+    expect(cells['mi300x']['h100'].available).toBe(true);
+    expect(cells['mi325x']['mi300x'].available).toBe(true);
+    expect(cells['b200']['h100'].available).toBe(false);
   });
 
   it('builds canonical alphabetical slugs regardless of display order', () => {
     const { cells } = buildCompareMatrix('deepseek-r1', PAIRS);
     // Display order puts h100 before b200, but the slug sorts alphabetically.
-    expect(cells['h100']['b200'].slug).toBe(canonicalCompareSlug('deepseek-r1', 'b200', 'h100'));
-    expect(cells['h100']['b200'].slug).toBe('deepseek-r1-b200-vs-h100');
+    expect(cells['b200']['h100'].slug).toBe(canonicalCompareSlug('deepseek-r1', 'b200', 'h100'));
+    expect(cells['b200']['h100'].slug).toBe('deepseek-r1-b200-vs-h100');
   });
 
   it('labels cells in canonical alphabetical order to match the destination page', () => {
     const { cells } = buildCompareMatrix('deepseek-r1', PAIRS);
-    // Display order puts h100 (row) before b200 (col), but the label sorts
+    // Display puts h100 (col) before b200 (row), and the label also sorts
     // alphabetically so it matches the destination page title and the
     // analytics payload ("deepseek-r1-b200-vs-h100" → "B200 vs H100").
-    expect(cells['h100']['b200'].label).toBe('B200 vs H100');
+    expect(cells['b200']['h100'].label).toBe('B200 vs H100');
     // Display and alphabetical order coincide here, so the label is unchanged.
-    expect(cells['gb200']['mi355x'].label).toBe('GB200 NVL72 vs MI355X');
+    expect(cells['mi355x']['gb200'].label).toBe('GB200 NVL72 vs MI355X');
   });
 
   it('flags cross-vendor cells and only those', () => {

--- a/packages/app/src/lib/compare-matrix.test.ts
+++ b/packages/app/src/lib/compare-matrix.test.ts
@@ -15,6 +15,8 @@ describe('compareMatrixGpuOrder', () => {
     const vendors = compareMatrixGpuOrder().map((g) => g.vendor);
     // Once the vendor changes, the earlier vendor must never reappear —
     // contiguous blocks are what make the cross-vendor region a rectangle.
+    // NVIDIA-first is pinned by VENDOR_BLOCK_ORDER, not derived from registry
+    // sort, so a future low-sort AMD flagship can't silently flip the axis.
     const blocks = vendors.filter((v, i) => i === 0 || v !== vendors[i - 1]);
     expect(blocks).toEqual(['NVIDIA', 'AMD']);
   });

--- a/packages/app/src/lib/compare-matrix.test.ts
+++ b/packages/app/src/lib/compare-matrix.test.ts
@@ -72,9 +72,13 @@ describe('buildCompareMatrix', () => {
     expect(cells['h100']['b200'].slug).toBe('deepseek-r1-b200-vs-h100');
   });
 
-  it('labels cells in display (row vs column) order', () => {
+  it('labels cells in canonical alphabetical order to match the destination page', () => {
     const { cells } = buildCompareMatrix('deepseek-r1', PAIRS);
-    expect(cells['h100']['b200'].label).toBe('H100 vs B200');
+    // Display order puts h100 (row) before b200 (col), but the label sorts
+    // alphabetically so it matches the destination page title and the
+    // analytics payload ("deepseek-r1-b200-vs-h100" → "B200 vs H100").
+    expect(cells['h100']['b200'].label).toBe('B200 vs H100');
+    // Display and alphabetical order coincide here, so the label is unchanged.
     expect(cells['gb200']['mi355x'].label).toBe('GB200 NVL72 vs MI355X');
   });
 

--- a/packages/app/src/lib/compare-matrix.ts
+++ b/packages/app/src/lib/compare-matrix.ts
@@ -4,7 +4,7 @@
  *
  * The index used to render one card per comparable pair — ~36 cards per model
  * across 9+ model sections stopped scaling as a navigation surface. The matrix
- * replaces the card walls with one upper-triangle GPU×GPU grid per model:
+ * replaces the card walls with one lower-triangle GPU×GPU grid per model:
  * every possible pair is a cell, cells with benchmark data on both sides are
  * links, cells without data render as ghosts so coverage gaps are visible.
  *
@@ -54,8 +54,8 @@ export interface CompareMatrix {
   /** Full GPU axis in display order — identical for every model so the nine
    *  matrices line up and coverage is comparable across sections. */
   gpus: CompareMatrixGpu[];
-  /** cells[rowKey][colKey], defined only for column display-index > row
-   *  display-index (upper triangle). */
+  /** cells[rowKey][colKey], defined only for column display-index < row
+   *  display-index (lower triangle). */
   cells: Record<string, Record<string, CompareMatrixCell>>;
   availableCount: number;
 }
@@ -123,22 +123,22 @@ export function buildCompareMatrix(
   const cells: Record<string, Record<string, CompareMatrixCell>> = {};
   let availableCount = 0;
 
-  for (let i = 0; i < gpus.length; i++) {
+  for (let j = 1; j < gpus.length; j++) {
     const row: Record<string, CompareMatrixCell> = {};
-    for (let j = i + 1; j < gpus.length; j++) {
-      const a = gpus[i];
-      const b = gpus[j];
-      const [first, second] = [a.key, b.key].toSorted();
+    for (let i = 0; i < j; i++) {
+      const col = gpus[i];
+      const rowGpu = gpus[j];
+      const [first, second] = [col.key, rowGpu.key].toSorted();
       const available = availableKeys.has(`${first}__${second}`);
       if (available) availableCount++;
-      row[b.key] = {
-        slug: canonicalCompareSlug(modelSlug, a.key, b.key),
+      row[col.key] = {
+        slug: canonicalCompareSlug(modelSlug, col.key, rowGpu.key),
         label: compareDisplayLabel(first, second),
         available,
-        cross: a.vendor !== b.vendor,
+        cross: col.vendor !== rowGpu.vendor,
       };
     }
-    cells[gpus[i].key] = row;
+    cells[gpus[j].key] = row;
   }
 
   return { gpus, cells, availableCount };

--- a/packages/app/src/lib/compare-matrix.ts
+++ b/packages/app/src/lib/compare-matrix.ts
@@ -37,7 +37,9 @@ export interface CompareMatrixGpu {
 export interface CompareMatrixCell {
   /** Canonical compare slug (alphabetical GPU order), e.g. "deepseek-r1-b200-vs-h100". */
   slug: string;
-  /** Display-ordered pair label matching the cell position, e.g. "H100 vs B200". */
+  /** Canonical alphabetical pair label — matches the destination page title
+   *  and the pre-matrix `compare_index_pair_clicked` analytics payload, e.g.
+   *  "B200 vs H100" (not the display row-vs-column order). */
   label: string;
   /** True when both GPUs have benchmark data for the model — cell is a link. */
   available: boolean;
@@ -112,7 +114,7 @@ export function buildCompareMatrix(
       if (available) availableCount++;
       row[b.key] = {
         slug: canonicalCompareSlug(modelSlug, a.key, b.key),
-        label: compareDisplayLabel(a.key, b.key),
+        label: compareDisplayLabel(first, second),
         available,
         cross: a.vendor !== b.vendor,
       };

--- a/packages/app/src/lib/compare-matrix.ts
+++ b/packages/app/src/lib/compare-matrix.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure helpers for the GPU-pair selection matrices on the `/compare` and
+ * `/compare-per-dollar` index pages.
+ *
+ * The index used to render one card per comparable pair — ~36 cards per model
+ * across 9+ model sections stopped scaling as a navigation surface. The matrix
+ * replaces the card walls with one upper-triangle GPU×GPU grid per model:
+ * every possible pair is a cell, cells with benchmark data on both sides are
+ * links, cells without data render as ghosts so coverage gaps are visible.
+ *
+ * Axis ordering is derived from HW_REGISTRY rather than hardcoded:
+ *
+ *   - Vendors form contiguous blocks (NVIDIA, then AMD) so the three vendor
+ *     regions of the old index — NVIDIA×NVIDIA, cross-vendor, AMD×AMD — appear
+ *     as contiguous areas of the triangle instead of separate card groups.
+ *     Vendor blocks are ordered by each vendor's best (lowest) registry sort
+ *     value, which matches the NVIDIA-first ordering used across the site.
+ *   - Within a vendor, GPUs sort by registry `sort` DESCENDING. The registry
+ *     sorts newest-first for chart legends, so descending here reads
+ *     oldest→newest along the axis (H100 → H200 → B200 → B300 → GB200 → GB300),
+ *     the natural left-to-right direction for a generational table.
+ */
+import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
+
+import { canonicalCompareSlug, compareDisplayLabel, type ComparePair } from '@/lib/compare-slug';
+
+export interface CompareMatrixGpu {
+  key: string;
+  /** Full display label for row headers, e.g. "GB200 NVL72". */
+  label: string;
+  /** Compact label for the vertical column headers, e.g. "GB200". */
+  shortLabel: string;
+  arch: string;
+  vendor: string;
+}
+
+export interface CompareMatrixCell {
+  /** Canonical compare slug (alphabetical GPU order), e.g. "deepseek-r1-b200-vs-h100". */
+  slug: string;
+  /** Display-ordered pair label matching the cell position, e.g. "H100 vs B200". */
+  label: string;
+  /** True when both GPUs have benchmark data for the model — cell is a link. */
+  available: boolean;
+  /** True for NVIDIA×AMD pairs — the cross-vendor region gets the brand tint. */
+  cross: boolean;
+}
+
+export interface CompareMatrix {
+  /** Full GPU axis in display order — identical for every model so the nine
+   *  matrices line up and coverage is comparable across sections. */
+  gpus: CompareMatrixGpu[];
+  /** cells[rowKey][colKey], defined only for column display-index > row
+   *  display-index (upper triangle). */
+  cells: Record<string, Record<string, CompareMatrixCell>>;
+  availableCount: number;
+}
+
+/** Shared axis order for every model's matrix. See module docblock. */
+export function compareMatrixGpuOrder(): CompareMatrixGpu[] {
+  const entries = Object.entries(HW_REGISTRY).map(([key, meta]) => ({
+    key,
+    label: meta.label,
+    shortLabel: key.toUpperCase(),
+    arch: meta.arch,
+    vendor: meta.vendor,
+    sort: meta.sort,
+  }));
+
+  const vendorRank = new Map<string, number>();
+  for (const e of entries) {
+    const best = vendorRank.get(e.vendor);
+    if (best === undefined || e.sort < best) vendorRank.set(e.vendor, e.sort);
+  }
+
+  entries.sort((x, y) => {
+    if (x.vendor !== y.vendor) {
+      return (vendorRank.get(x.vendor) ?? 0) - (vendorRank.get(y.vendor) ?? 0);
+    }
+    return y.sort - x.sort;
+  });
+
+  return entries.map(({ key, label, shortLabel, arch, vendor }) => ({
+    key,
+    label,
+    shortLabel,
+    arch,
+    vendor,
+  }));
+}
+
+/** Build one model's matrix from the pairs that actually have benchmark data
+ *  on both sides (`getComparablePairsByModelSlug()` output — canonical
+ *  alphabetical a < b). Fully serializable: built in the server page, rendered
+ *  by the ComparePairMatrix client component. */
+export function buildCompareMatrix(
+  modelSlug: string,
+  availablePairs: ComparePair[],
+): CompareMatrix {
+  const gpus = compareMatrixGpuOrder();
+  const availableKeys = new Set(availablePairs.map((p) => `${p.a}__${p.b}`));
+
+  const cells: Record<string, Record<string, CompareMatrixCell>> = {};
+  let availableCount = 0;
+
+  for (let i = 0; i < gpus.length; i++) {
+    const row: Record<string, CompareMatrixCell> = {};
+    for (let j = i + 1; j < gpus.length; j++) {
+      const a = gpus[i];
+      const b = gpus[j];
+      const [first, second] = [a.key, b.key].toSorted();
+      const available = availableKeys.has(`${first}__${second}`);
+      if (available) availableCount++;
+      row[b.key] = {
+        slug: canonicalCompareSlug(modelSlug, a.key, b.key),
+        label: compareDisplayLabel(a.key, b.key),
+        available,
+        cross: a.vendor !== b.vendor,
+      };
+    }
+    cells[gpus[i].key] = row;
+  }
+
+  return { gpus, cells, availableCount };
+}

--- a/packages/app/src/lib/compare-matrix.ts
+++ b/packages/app/src/lib/compare-matrix.ts
@@ -13,8 +13,11 @@
  *   - Vendors form contiguous blocks (NVIDIA, then AMD) so the three vendor
  *     regions of the old index — NVIDIA×NVIDIA, cross-vendor, AMD×AMD — appear
  *     as contiguous areas of the triangle instead of separate card groups.
- *     Vendor blocks are ordered by each vendor's best (lowest) registry sort
- *     value, which matches the NVIDIA-first ordering used across the site.
+ *     Block order is pinned by VENDOR_BLOCK_ORDER (NVIDIA first, the site-wide
+ *     convention) rather than derived from registry sort: a future AMD flagship
+ *     with a lower sort than GB300 would otherwise silently flip the whole axis
+ *     to AMD-first. Any unlisted vendor sorts after the pinned blocks, ordered
+ *     by its best (lowest) registry sort value.
  *   - Within a vendor, GPUs sort by registry `sort` DESCENDING. The registry
  *     sorts newest-first for chart legends, so descending here reads
  *     oldest→newest along the axis (H100 → H200 → B200 → B300 → GB200 → GB300),
@@ -57,6 +60,12 @@ export interface CompareMatrix {
   availableCount: number;
 }
 
+/** Pinned vendor block order for the matrix axes — NVIDIA first per the
+ *  site-wide convention. Vendors not listed here (a future third vendor)
+ *  sort after the pinned blocks, ordered by their best registry sort, so
+ *  new registry entries can never silently reorder the existing axes. */
+const VENDOR_BLOCK_ORDER = ['NVIDIA', 'AMD'];
+
 /** Shared axis order for every model's matrix. See module docblock. */
 export function compareMatrixGpuOrder(): CompareMatrixGpu[] {
   const entries = Object.entries(HW_REGISTRY).map(([key, meta]) => ({
@@ -76,6 +85,16 @@ export function compareMatrixGpuOrder(): CompareMatrixGpu[] {
 
   entries.sort((x, y) => {
     if (x.vendor !== y.vendor) {
+      const ix = VENDOR_BLOCK_ORDER.indexOf(x.vendor);
+      const iy = VENDOR_BLOCK_ORDER.indexOf(y.vendor);
+      // Both pinned → pinned order. One pinned → it sorts first. Neither pinned
+      // → best registry sort, so a future third vendor still orders
+      // deterministically without disturbing the pinned NVIDIA→AMD blocks.
+      if (ix !== -1 || iy !== -1) {
+        if (ix === -1) return 1;
+        if (iy === -1) return -1;
+        return ix - iy;
+      }
       return (vendorRank.get(x.vendor) ?? 0) - (vendorRank.get(y.vendor) ?? 0);
     }
     return y.sort - x.sort;

--- a/packages/app/src/lib/compare-matrix.ts
+++ b/packages/app/src/lib/compare-matrix.ts
@@ -1,6 +1,6 @@
 /**
  * Pure helpers for the GPU-pair selection matrices on the `/compare` and
- * `/compare-per-dollar` index pages.
+ * `/compare-per-dollar` index pages (and their /zh siblings).
  *
  * The index used to render one card per comparable pair — ~36 cards per model
  * across 9+ model sections stopped scaling as a navigation surface. The matrix

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -31,9 +31,7 @@ import { cachedQuery } from '@/lib/api-cache';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import { getHardwareKey } from '@/lib/chart-utils';
 import {
-  canonicalCompareSlug,
   compareDisplayLabel,
-  type ComparePair,
   type CompareModelSlug,
   compareModelDisplayLabel,
   compareModelSeoName,
@@ -885,48 +883,6 @@ export function formatModelList(models: CompareModelSlug[]): string {
   if (labels.length === 1) return labels[0];
   if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
   return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
-}
-
-export interface VendorBucketEntry {
-  a: string;
-  b: string;
-  slug: string;
-  label: string;
-}
-
-export interface VendorBuckets {
-  /** Cross-vendor pairs (NVIDIA × AMD). */
-  cross: VendorBucketEntry[];
-  /** Both sides NVIDIA. */
-  nvidia: VendorBucketEntry[];
-  /** Both sides AMD. */
-  amd: VendorBucketEntry[];
-}
-
-/** Split (a, b) GPU pairs into vendor buckets for the index grid. The caller
- *  wraps these entries with its own group headings / descriptions / route
- *  prefix — keeps the sorting + bucketing + slug-building in one place so the
- *  two index pages can't drift on those mechanics. */
-export function bucketComparePairsByVendor(modelSlug: string, pairs: ComparePair[]): VendorBuckets {
-  const nvidia: VendorBucketEntry[] = [];
-  const amd: VendorBucketEntry[] = [];
-  const cross: VendorBucketEntry[] = [];
-
-  for (const { a, b } of pairs) {
-    const entry: VendorBucketEntry = {
-      a,
-      b,
-      slug: canonicalCompareSlug(modelSlug, a, b),
-      label: compareDisplayLabel(a, b),
-    };
-    const vA = HW_REGISTRY[a]?.vendor;
-    const vB = HW_REGISTRY[b]?.vendor;
-    if (vA === 'NVIDIA' && vB === 'NVIDIA') nvidia.push(entry);
-    else if (vA === 'AMD' && vB === 'AMD') amd.push(entry);
-    else cross.push(entry);
-  }
-
-  return { cross, nvidia, amd };
 }
 
 /** Breadcrumb trail for a compare slug page. Emitted alongside the main


### PR DESCRIPTION
## Summary

The `/compare` and `/compare-per-dollar` index pages rendered one card per comparable GPU pair — ~258 cards across 9+ model sections, split into three vendor groups each. Finding a specific pair meant linearly scanning a card wall, and pairs *without* data were invisible.

Each model section now renders a single upper-triangle GPU×GPU selection matrix:

- **Full 9-GPU axis on every matrix** (identical across models) so benchmark coverage is comparable between sections. Axis order is derived from `HW_REGISTRY`, not hardcoded: contiguous vendor blocks (NVIDIA, then AMD), oldest→newest within a vendor (H100 → H200 → B200 → B300 → GB200 → GB300 / MI300X → MI325X → MI355X).
- **Three cell states**, distinct in both light and dark themes: brand-tinted ringed squares for cross-vendor pairs, neutral fills for same-vendor pairs, dashed-outline ghosts for pairs with no benchmark data (with a legend below each matrix).
- **Vendor group bars** span the column headers (green NVIDIA / red AMD) and row labels carry vendor dots plus an architecture subline — replacing the old three per-vendor card groups, since the vendor regions are now contiguous areas of the triangle.
- **Interaction**: hover/keyboard-focus highlights the cell's row + column headers and prints the pair name in a readout line; cells scale slightly on hover and get a brand focus ring; native `title` tooltips.
- **Mobile**: the matrix scrolls horizontally with a sticky GPU-label column.

## SEO / behavior preserved

- Every available pair remains a real server-rendered `<a>` (no client-side model switching), with the pair name as sr-only anchor text and a full accessible label ("DeepSeek R1: H100 vs H200 benchmark comparison").
- The `compare_index_pair_clicked` analytics event fires with the same `{slug, label}` payload as the old cards.
- Page h1s, descriptions, CTA buttons, per-model `id` anchors, and JSON-LD are untouched.
- `ComparePairCardLink` stays — the `/compare-precision` and `/compare-spec-decode` indexes still use it.

## Notes for review

- **`/zh` index pages are intentionally unchanged in this PR** — they keep the existing card UI (which is why `bucketComparePairsByVendor` remains in `compare-ssr.ts`). The matrix can be ported to the zh siblings in a follow-up.
- Unofficial-run overlay support: N/A — these are index navigation pages with no chart data path.

## Testing

- New unit suite `compare-matrix.test.ts` (10 tests): axis ordering invariants, upper-triangle completeness, availability marking, canonical slug construction, cross-vendor flags.
- New e2e spec `compare-index-matrix.cy.ts`: matrix renders per model section, cell hrefs are canonical for both routes, click navigates to the pair page, ghost cells render for missing pairs, focus updates the readout.
- `pnpm typecheck`, `lint`, `fmt`, production build, and the `compare-precision` / `compare-redirect` e2e specs all pass against the fixtures server.
- Visually verified via screenshots: light + dark themes, desktop + 375px mobile (including sticky-column horizontal scroll), and cell focus state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large navigation/UI change on SEO-heavy compare index routes; mitigated by preserving server-rendered link URLs, analytics payloads, and new unit/e2e coverage.
> 
> **Overview**
> Replaces the vendor-grouped **card grids** on `/compare`, `/compare-per-dollar`, and their **`/zh`** index pages with one **GPU×GPU lower-triangle matrix** per model section, built server-side via `buildCompareMatrix` and rendered by the new client `ComparePairMatrix` component.
> 
> **Navigation UX:** Every registry GPU appears on a shared axis (NVIDIA then AMD, oldest→newest within vendor). Cells with benchmark data stay **real `<a>` links** (sr-only pair text, same `compare_index_pair_clicked` analytics); missing pairs show as **ghost cells** so coverage gaps are visible. Cross-vendor cells get brand styling; hover/focus drives a readout and row/column highlights.
> 
> **Cleanup:** Per-page `groupPairsByVendorForModel` and `bucketComparePairsByVendor` in `compare-ssr.ts` are removed. `ComparePairCardLink` is unchanged for precision/spec-decode indexes.
> 
> **Tests:** New `compare-matrix.test.ts` (ordering, slugs, availability) and Cypress `compare-index-matrix.cy.ts` (matrices, hrefs, ghosts, focus readout, en/zh routes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c49d6bbb3bc4fbc20d6455f973e0960bd4edf90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->