### PR TITLE
feat(tco-feed): serve the tier-weighted per-hardware score via view=scores / tco-feed 新增 view=scores，直接输出按层级加权的单芯片分数

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,9 +72,9 @@ API routes (`packages/app/src/app/api/v1/`):
 - `evaluations` — raw `EvalRow[]`
 - `server-log` — retrieve benchmark runtime logs
 - `invalidate` — invalidate API cache (admin)
-- `tco-feed?model=dsv4&workloads=1024x1024,8192x1024&tiers=30,50,75,100&format=csv` — per-hardware Pareto-frontier output-throughput reads at fixed interactivity tiers, for external spreadsheet TCO models (Excel Power Query)
+- `tco-feed?model=dsv4&workloads=1024x1024,8192x1024&tiers=30,50,75,100&format=csv` — per-hardware Pareto-frontier output-throughput reads at fixed interactivity tiers, for external spreadsheet TCO models (Excel Power Query); `view=scores` (optional `weights`, `workload_weights`, `alpha`) folds them into one tier-weighted, workload-blended, output-equivalent score per hardware
 
-**API routes return raw DB data** — no presentation logic. Frontend handles all transformations. Sole exception: `tco-feed`, which runs the calculator's frontier interpolation server-side because its consumers (spreadsheets) cannot execute the TS transforms; it serves reads only — weights/assumptions stay with the consumer.
+**API routes return raw DB data** — no presentation logic. Frontend handles all transformations. Sole exception: `tco-feed`, which runs the calculator's frontier interpolation server-side because its consumers (spreadsheets) cannot execute the TS transforms; its assumptions (tier weights, workload mix, α) enter only as explicit query params with documented defaults, so a published sheet's URL fully records its methodology.
 
 Static content routes (no DB):
 

--- a/packages/app/src/app/api/v1/tco-feed/route.ts
+++ b/packages/app/src/app/api/v1/tco-feed/route.ts
@@ -10,9 +10,14 @@ import { loadFixture } from '@/lib/test-fixtures';
 
 import {
   computeTcoFeed,
+  computeTcoScores,
+  parseAlpha,
   parseTiers,
+  parseTierWeights,
   parseWorkloads,
+  parseWorkloadWeights,
   tcoFeedToCsv,
+  tcoScoresToCsv,
   type TcoFeedRow,
   type TcoFeedSourceRow,
   type TcoFeedWorkload,
@@ -31,9 +36,11 @@ export const dynamic = 'force-dynamic';
  * data" convention: it applies the dashboard's frontier interpolation
  * (calculator/interpolation.ts) server-side so external consumers get
  * numbers identical to what the chart renders, without reimplementing —
- * and inevitably drifting from — the spline. Keep all *assumptions*
- * (tier weights, workload mix, token-value ratios) out of this route;
- * it serves reads, consumers apply weights.
+ * and inevitably drifting from — the spline. Assumptions (tier weights,
+ * workload mix, the α token-value ratio) enter ONLY as query params on the
+ * `scores` view, never as hidden constants beyond the documented defaults —
+ * a published sheet's URL fully records its methodology, and `view=scores`
+ * is exactly SUMPRODUCT over the `points` view, reproducible by hand.
  *
  * Query params (all optional):
  * - model     — DB key (`dsv4`) or display name (`DeepSeek-V4-Pro`).
@@ -45,6 +52,21 @@ export const dynamic = 'force-dynamic';
  * - date      — `YYYY-MM-DD`; reads use data as of this date
  *               (reproducibility of published sheets). Default: latest.
  * - format    — `json` (default) or `csv` (one-line Power Query import).
+ * - view      — `points` (default): one row per hardware × workload × tier.
+ *               `scores`: one row per hardware — tier-weighted, workload-
+ *               blended, output-equivalent tok/s/GPU (the single number a
+ *               TCO sheet consumes per chip).
+ *
+ * `scores`-only params (400 with `view=points`):
+ * - weights          — per-tier traffic-mix weights, comma-separated,
+ *                      normalized to sum 1. Default `0.35,0.4,0.2,0.05`
+ *                      for the default tiers, equal weights otherwise.
+ * - workload_weights — per-workload blend weights, normalized to sum 1.
+ *                      Default: equal split. Renormalized over covered
+ *                      workloads when a chip lacks data for one.
+ * - alpha            — input-token value ratio in the output-equivalent
+ *                      conversion `out × (1 + α × ISL/OSL)`. Default 0.25;
+ *                      `alpha=0` scores plain output throughput.
  */
 
 const getCachedTcoFeed = cachedQuery(
@@ -104,10 +126,74 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid format — expected json or csv' }, { status: 400 });
   }
 
+  const view = params.get('view') ?? 'points';
+  if (view !== 'points' && view !== 'scores') {
+    return NextResponse.json(
+      { error: 'Invalid view — expected points or scores' },
+      { status: 400 },
+    );
+  }
+
+  const rawWeights = params.get('weights');
+  const rawWorkloadWeights = params.get('workload_weights');
+  const rawAlpha = params.get('alpha');
+  if (view === 'points' && (rawWeights ?? rawWorkloadWeights ?? rawAlpha) !== null) {
+    // Reject rather than ignore — a consumer passing weights to the points
+    // view would silently get unweighted numbers.
+    return NextResponse.json(
+      { error: 'weights, workload_weights, and alpha require view=scores' },
+      { status: 400 },
+    );
+  }
+
+  const tierWeights = parseTierWeights(rawWeights, tiers);
+  if (!tierWeights) {
+    return NextResponse.json(
+      { error: 'Invalid weights — expected one non-negative number per tier, sum > 0' },
+      { status: 400 },
+    );
+  }
+
+  const workloadWeights = parseWorkloadWeights(rawWorkloadWeights, workloads);
+  if (!workloadWeights) {
+    return NextResponse.json(
+      {
+        error: 'Invalid workload_weights — expected one non-negative number per workload, sum > 0',
+      },
+      { status: 400 },
+    );
+  }
+
+  const alpha = parseAlpha(rawAlpha);
+  if (alpha === null) {
+    return NextResponse.json(
+      { error: 'Invalid alpha — expected a number in [0, 10]' },
+      { status: 400 },
+    );
+  }
+
   try {
     const rows = FIXTURES_MODE
       ? computeTcoFeed(loadFixture<TcoFeedSourceRow[]>('benchmarks'), workloads, tiers)
       : await getCachedTcoFeed(dbModelKeys, date, workloads, tiers);
+
+    if (view === 'scores') {
+      const scores = computeTcoScores(rows, workloads, tiers, tierWeights, workloadWeights, alpha);
+      if (format === 'csv') {
+        return cachedText(tcoScoresToCsv(scores, workloads), 'text/csv; charset=utf-8');
+      }
+      return cachedJson({
+        model,
+        db_model_keys: dbModelKeys,
+        date: date ?? null,
+        workloads: workloads.map((w) => `${w.isl}x${w.osl}`),
+        tiers,
+        weights: tierWeights,
+        workload_weights: workloadWeights,
+        alpha,
+        rows: scores,
+      });
+    }
 
     if (format === 'csv') {
       return cachedText(tcoFeedToCsv(rows), 'text/csv; charset=utf-8');

--- a/packages/app/src/lib/tco-feed.test.ts
+++ b/packages/app/src/lib/tco-feed.test.ts
@@ -2,11 +2,18 @@ import { describe, expect, it } from 'vitest';
 
 import {
   computeTcoFeed,
+  computeTcoScores,
+  DEFAULT_ALPHA,
+  DEFAULT_TIER_WEIGHTS,
   DEFAULT_TIERS,
   DEFAULT_WORKLOADS,
+  parseAlpha,
   parseTiers,
+  parseTierWeights,
   parseWorkloads,
+  parseWorkloadWeights,
   tcoFeedToCsv,
+  tcoScoresToCsv,
   type TcoFeedRow,
   type TcoFeedSourceRow,
 } from './tco-feed';
@@ -242,6 +249,68 @@ describe('parseWorkloads', () => {
     expect(parseWorkloads('8192x')).toBeNull();
     expect(parseWorkloads(Array.from({ length: 9 }, () => '1024x1024').join(','))).toBeNull();
   });
+
+  it('rejects duplicate workloads (would double-count in the scores view)', () => {
+    expect(parseWorkloads('8192x1024,8192x1024')).toBeNull();
+  });
+});
+
+describe('parseTierWeights', () => {
+  it('defaults to the traffic-mix weights for the default tiers', () => {
+    expect(parseTierWeights(null, DEFAULT_TIERS)).toEqual([...DEFAULT_TIER_WEIGHTS]);
+    expect(parseTierWeights('  ', [30, 50, 75, 100])).toEqual([...DEFAULT_TIER_WEIGHTS]);
+  });
+
+  it('defaults to equal weights for custom tiers', () => {
+    expect(parseTierWeights(null, [20, 60])).toEqual([0.5, 0.5]);
+  });
+
+  it('normalizes provided weights to sum 1', () => {
+    expect(parseTierWeights('2,2,4,2', [30, 50, 75, 100])).toEqual([0.2, 0.2, 0.4, 0.2]);
+  });
+
+  it('rejects count mismatch, negatives, zero sums, and non-numbers', () => {
+    expect(parseTierWeights('0.5,0.5', [30, 50, 75])).toBeNull();
+    expect(parseTierWeights('-1,2', [30, 50])).toBeNull();
+    expect(parseTierWeights('0,0', [30, 50])).toBeNull();
+    expect(parseTierWeights('a,b', [30, 50])).toBeNull();
+    expect(parseTierWeights('0.5,,0.5', [30, 50, 75])).toBeNull();
+  });
+});
+
+describe('parseWorkloadWeights', () => {
+  it('defaults to an equal split', () => {
+    expect(parseWorkloadWeights(null, [...DEFAULT_WORKLOADS])).toEqual([0.5, 0.5]);
+  });
+
+  it('normalizes provided weights to sum 1', () => {
+    expect(parseWorkloadWeights('3,1', [...DEFAULT_WORKLOADS])).toEqual([0.75, 0.25]);
+  });
+
+  it('rejects count mismatch, negatives, and zero sums', () => {
+    expect(parseWorkloadWeights('1', [...DEFAULT_WORKLOADS])).toBeNull();
+    expect(parseWorkloadWeights('1,-1', [...DEFAULT_WORKLOADS])).toBeNull();
+    expect(parseWorkloadWeights('0,0', [...DEFAULT_WORKLOADS])).toBeNull();
+  });
+});
+
+describe('parseAlpha', () => {
+  it('defaults when absent or blank', () => {
+    expect(parseAlpha(null)).toBe(DEFAULT_ALPHA);
+    expect(parseAlpha(' ')).toBe(DEFAULT_ALPHA);
+  });
+
+  it('parses valid values including 0 (plain output throughput)', () => {
+    expect(parseAlpha('0')).toBe(0);
+    expect(parseAlpha('0.5')).toBe(0.5);
+    expect(parseAlpha('10')).toBe(10);
+  });
+
+  it('rejects negatives, out-of-range, and non-numbers', () => {
+    expect(parseAlpha('-0.1')).toBeNull();
+    expect(parseAlpha('10.1')).toBeNull();
+    expect(parseAlpha('abc')).toBeNull();
+  });
 });
 
 describe('tcoFeedToCsv', () => {
@@ -256,6 +325,117 @@ describe('tcoFeedToCsv', () => {
     expect(lines).toHaveLength(4); // header + 2 rows + trailing newline
     expect(lines[1]).toBe('gb200,8192x1024,50,400,interpolated,3,20,100,2026-07-10,2026-07-10');
     expect(lines[2]).toBe('gb200,8192x1024,200,0,unreachable,3,20,100,2026-07-10,2026-07-10');
+    expect(csv.endsWith('\n')).toBe(true);
+  });
+});
+
+const BOTH_WORKLOADS = [
+  { isl: 1024, osl: 1024 },
+  { isl: 8192, osl: 1024 },
+];
+
+/**
+ * b200 covers both workloads (single-knot frontiers read exactly at tier
+ * 50); gb300 covers only 8k1k.
+ */
+function twoWorkloadRows(): TcoFeedSourceRow[] {
+  return [
+    makeRow({
+      hardware: 'b200',
+      isl: 1024,
+      osl: 1024,
+      itl: 1 / 50,
+      otput: 1000,
+      date: '2026-05-01',
+    }),
+    makeRow({ hardware: 'b200', itl: 1 / 50, otput: 400, date: '2026-07-01' }),
+    makeRow({ hardware: 'gb300', itl: 1 / 50, otput: 5000 }),
+  ];
+}
+
+describe('computeTcoScores', () => {
+  it('is exactly the weighted sum over the points view, times the output-equivalent factor', () => {
+    // Knots at iv 20/50/100 read exactly at those tiers: 1000/400/100.
+    const tiers = [20, 50, 100];
+    const feed = computeTcoFeed(threeKnotRows(), WORKLOAD_8K1K, tiers);
+    const scores = computeTcoScores(feed, WORKLOAD_8K1K, tiers, [0.5, 0.3, 0.2], [1], 0.25);
+    expect(scores).toHaveLength(1);
+    // 0.5·1000 + 0.3·400 + 0.2·100 = 640, ×(1 + 0.25·8192/1024) = ×3.
+    expect(scores[0].workload_scores['8192x1024']).toBe(640);
+    expect(scores[0].score).toBe(1920);
+    // alpha=0 scores plain output throughput.
+    const plain = computeTcoScores(feed, WORKLOAD_8K1K, tiers, [0.5, 0.3, 0.2], [1], 0);
+    expect(plain[0].score).toBe(640);
+  });
+
+  it('unreachable tiers contribute 0 at full weight; clamped tiers contribute the clamp', () => {
+    // Frontier spans iv 40 → 80.
+    const source = [makeRow({ itl: 1 / 40, otput: 800 }), makeRow({ itl: 1 / 80, otput: 200 })];
+    const tiers = [30, 40, 100];
+    const feed = computeTcoFeed(source, WORKLOAD_8K1K, tiers);
+    const scores = computeTcoScores(feed, WORKLOAD_8K1K, tiers, [0.25, 0.5, 0.25], [1], 0);
+    // 0.25·800 (clamped) + 0.5·800 + 0.25·0 (unreachable) = 600 — the
+    // unreachable tier's weight is NOT redistributed to reachable tiers.
+    expect(scores[0].score).toBe(600);
+    expect(scores[0].unreachable_tiers).toBe(1);
+    expect(scores[0].clamped_tiers).toBe(1);
+  });
+
+  it('blends workloads and renormalizes over covered ones for partial coverage', () => {
+    const feed = computeTcoFeed(twoWorkloadRows(), BOTH_WORKLOADS, [50]);
+    const scores = computeTcoScores(feed, BOTH_WORKLOADS, [50], [1], [0.5, 0.5], 0);
+    expect(scores.map((s) => s.hardware)).toEqual(['b200', 'gb300']);
+
+    const b200 = scores[0];
+    expect(b200.workload_scores).toEqual({ '1024x1024': 1000, '8192x1024': 400 });
+    expect(b200.score).toBe(700); // 0.5·1000 + 0.5·400
+    expect(b200.workloads_covered).toBe(2);
+
+    // gb300 lacks 1k1k → its weight renormalizes onto 8k1k alone.
+    const gb300 = scores[1];
+    expect(gb300.workload_scores).toEqual({ '1024x1024': null, '8192x1024': 5000 });
+    expect(gb300.score).toBe(5000);
+    expect(gb300.workloads_covered).toBe(1);
+  });
+
+  it('applies per-workload output-equivalent factors before blending', () => {
+    const feed = computeTcoFeed(twoWorkloadRows(), BOTH_WORKLOADS, [50]);
+    const scores = computeTcoScores(feed, BOTH_WORKLOADS, [50], [1], [0.5, 0.5], 0.25);
+    // 0.5·1000·(1 + 0.25·1) + 0.5·400·(1 + 0.25·8) = 625 + 600.
+    expect(scores[0].score).toBe(1225);
+  });
+
+  it('scores 0 when the only covered workloads carry zero weight', () => {
+    const feed = computeTcoFeed(twoWorkloadRows(), BOTH_WORKLOADS, [50]);
+    const scores = computeTcoScores(feed, BOTH_WORKLOADS, [50], [1], [1, 0], 0);
+    const gb300 = scores.find((s) => s.hardware === 'gb300')!;
+    expect(gb300.score).toBe(0);
+  });
+
+  it('carries the newest latest_date and oldest frontier date across covered workloads', () => {
+    const feed = computeTcoFeed(twoWorkloadRows(), BOTH_WORKLOADS, [50]);
+    const scores = computeTcoScores(feed, BOTH_WORKLOADS, [50], [1], [0.5, 0.5], 0);
+    expect(scores[0].latest_date).toBe('2026-07-01');
+    expect(scores[0].oldest_frontier_date).toBe('2026-05-01');
+  });
+
+  it('returns an empty list for an empty feed', () => {
+    expect(computeTcoScores([], BOTH_WORKLOADS, [50], [1], [0.5, 0.5], 0)).toEqual([]);
+  });
+});
+
+describe('tcoScoresToCsv', () => {
+  it('emits one score_<workload> column per requested workload, blank when uncovered', () => {
+    const feed = computeTcoFeed(twoWorkloadRows(), BOTH_WORKLOADS, [50]);
+    const scores = computeTcoScores(feed, BOTH_WORKLOADS, [50], [1], [0.5, 0.5], 0);
+    const csv = tcoScoresToCsv(scores, BOTH_WORKLOADS);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe(
+      'hardware,score,score_1024x1024,score_8192x1024,workloads_covered,' +
+        'unreachable_tiers,clamped_tiers,latest_date,oldest_frontier_date',
+    );
+    expect(lines[1]).toBe('b200,700,1000,400,2,0,0,2026-07-01,2026-05-01');
+    expect(lines[2]).toBe('gb300,5000,,5000,1,0,0,2026-07-10,2026-07-10');
     expect(csv.endsWith('\n')).toBe(true);
   });
 });

--- a/packages/app/src/lib/tco-feed.test.ts
+++ b/packages/app/src/lib/tco-feed.test.ts
@@ -226,6 +226,11 @@ describe('parseTiers', () => {
     expect(parseTiers('10001')).toBeNull();
     expect(parseTiers(Array.from({ length: 21 }, (_, i) => String(i + 1)).join(','))).toBeNull();
   });
+
+  it('rejects duplicate tiers (would double-count in the scores view)', () => {
+    expect(parseTiers('50,50')).toBeNull();
+    expect(parseTiers('50,50.0')).toBeNull(); // same numeric value
+  });
 });
 
 describe('parseWorkloads', () => {

--- a/packages/app/src/lib/tco-feed.ts
+++ b/packages/app/src/lib/tco-feed.ts
@@ -1,7 +1,9 @@
 /**
  * TCO feed — per-hardware Pareto-frontier throughput reads at fixed
  * interactivity tiers, consumed by external spreadsheet TCO models
- * (Excel / Power Query) via /api/v1/tco-feed.
+ * (Excel / Power Query) via /api/v1/tco-feed. The scores view
+ * (computeTcoScores) folds those per-tier reads into a single tier-weighted,
+ * workload-blended, output-equivalent number per chip.
  *
  * Reuses the calculator's frontier + monotone-spline code (interpolation.ts)
  * so every number matches what the dashboard chart renders at the same
@@ -66,10 +68,23 @@ export const DEFAULT_WORKLOADS: readonly TcoFeedWorkload[] = [
   { isl: 1024, osl: 1024 },
   { isl: 8192, osl: 1024 },
 ];
+/**
+ * Traffic-mix weights for DEFAULT_TIERS: most tokens are served in the
+ * 30–75 tok/s/user band; 100+ is a premium sliver. Only used when the
+ * request keeps the default tiers — custom tiers default to equal weights.
+ */
+export const DEFAULT_TIER_WEIGHTS: readonly number[] = [0.35, 0.4, 0.2, 0.05];
+/**
+ * Default input-token value ratio for the output-equivalent conversion
+ * `out × (1 + α × ISL/OSL)` — prefill work is worth ~25% of decode work
+ * per token, consistent with prevailing API input:output pricing.
+ */
+export const DEFAULT_ALPHA = 0.25;
 
 const MAX_TIERS = 20;
 const MAX_TIER_VALUE = 10_000;
 const MAX_WORKLOADS = 8;
+const MAX_ALPHA = 10;
 
 /**
  * Parse `tiers=30,50,75,100`. Absent/blank → defaults; any invalid entry →
@@ -92,22 +107,84 @@ export function parseTiers(raw: string | null): number[] | null {
 
 /**
  * Parse `workloads=1024x1024,8192x1024` (lowercase `x` separator).
- * Absent/blank → defaults; any invalid entry → null (caller responds 400).
+ * Absent/blank → defaults; any invalid or duplicate entry → null (caller
+ * responds 400 — duplicates would double-count in the scores view).
  */
 export function parseWorkloads(raw: string | null): TcoFeedWorkload[] | null {
   if (raw === null || raw.trim() === '') return [...DEFAULT_WORKLOADS];
   const parts = raw.split(',').map((s) => s.trim());
   if (parts.length > MAX_WORKLOADS) return null;
   const workloads: TcoFeedWorkload[] = [];
+  const seen = new Set<string>();
   for (const part of parts) {
     const match = /^(?<isl>\d{1,7})x(?<osl>\d{1,7})$/u.exec(part);
     if (!match?.groups) return null;
     const isl = Number(match.groups.isl);
     const osl = Number(match.groups.osl);
     if (isl <= 0 || osl <= 0) return null;
+    const key = `${isl}x${osl}`;
+    if (seen.has(key)) return null;
+    seen.add(key);
     workloads.push({ isl, osl });
   }
   return workloads;
+}
+
+/**
+ * Parse a comma-separated non-negative weight list of exactly `expected`
+ * entries, normalized to sum to 1. Any invalid entry or a zero sum → null.
+ */
+function parseWeightList(raw: string, expected: number): number[] | null {
+  const parts = raw.split(',').map((s) => s.trim());
+  if (parts.length !== expected) return null;
+  const weights: number[] = [];
+  for (const part of parts) {
+    const value = Number(part);
+    if (part === '' || !Number.isFinite(value) || value < 0) return null;
+    weights.push(value);
+  }
+  const sum = weights.reduce((a, b) => a + b, 0);
+  if (sum <= 0) return null;
+  return weights.map((w) => w / sum);
+}
+
+/**
+ * Parse `weights=0.35,0.4,0.2,0.05` (one per tier, normalized to sum 1).
+ * Absent/blank → DEFAULT_TIER_WEIGHTS when the tiers are exactly
+ * DEFAULT_TIERS, equal weights otherwise; invalid → null (caller 400s).
+ */
+export function parseTierWeights(raw: string | null, tiers: readonly number[]): number[] | null {
+  if (raw === null || raw.trim() === '') {
+    const isDefaultTiers =
+      tiers.length === DEFAULT_TIERS.length && tiers.every((t, i) => t === DEFAULT_TIERS[i]);
+    if (isDefaultTiers) return [...DEFAULT_TIER_WEIGHTS];
+    return tiers.map(() => 1 / tiers.length);
+  }
+  return parseWeightList(raw, tiers.length);
+}
+
+/**
+ * Parse `workload_weights=0.5,0.5` (one per workload, normalized to sum 1).
+ * Absent/blank → equal split; invalid → null (caller 400s).
+ */
+export function parseWorkloadWeights(
+  raw: string | null,
+  workloads: readonly TcoFeedWorkload[],
+): number[] | null {
+  if (raw === null || raw.trim() === '') return workloads.map(() => 1 / workloads.length);
+  return parseWeightList(raw, workloads.length);
+}
+
+/**
+ * Parse `alpha=0.25` — the input-token value ratio in the score view's
+ * output-equivalent conversion. Absent/blank → DEFAULT_ALPHA; invalid
+ * (non-finite, negative, > 10) → null (caller 400s).
+ */
+export function parseAlpha(raw: string | null): number | null {
+  if (raw === null || raw.trim() === '') return DEFAULT_ALPHA;
+  const value = Number(raw.trim());
+  if (!Number.isFinite(value) || value < 0 || value > MAX_ALPHA) return null;
+  return value;
 }
 
 interface FrontierPoint {
@@ -241,4 +318,144 @@ const CSV_COLUMNS = [
 export function tcoFeedToCsv(rows: readonly TcoFeedRow[]): string {
   const lines = rows.map((row) => CSV_COLUMNS.map((col) => String(row[col])).join(','));
   return `${[CSV_COLUMNS.join(','), ...lines].join('\n')}\n`;
+}
+
+export interface TcoScoreRow {
+  hardware: string;
+  /**
+   * Tier-weighted, workload-blended, output-equivalent throughput
+   * (tok/s/GPU) — the single per-chip number a TCO sheet consumes.
+   */
+  score: number;
+  /**
+   * Tier-weighted output tok/s/GPU per requested workload key, BEFORE the
+   * output-equivalent factor and workload blend; null = no benchmark data
+   * for that workload (as opposed to 0 = every tier unreachable).
+   */
+  workload_scores: Record<string, number | null>;
+  workloads_covered: number;
+  /** Tier reads (across covered workloads) above the capability ceiling. */
+  unreachable_tiers: number;
+  /** Tier reads (across covered workloads) below the sweep floor. */
+  clamped_tiers: number;
+  /** Newest frontier-knot date across covered workloads. */
+  latest_date: string;
+  /** Oldest frontier-knot date across covered workloads. */
+  oldest_frontier_date: string;
+}
+
+/**
+ * Aggregate per-tier feed rows into one score per hardware:
+ *
+ *   score = Σ_covered workloads [ wWeight × (Σ_tiers tierWeight × tput) × (1 + α × ISL/OSL) ]
+ *
+ * - Unreachable tiers contribute 0 at full weight — the chip genuinely
+ *   cannot serve that traffic segment (matches the feed's boundary docs).
+ * - Workloads with no data are EXCLUDED and the workload weights are
+ *   renormalized over covered ones — absence of a sweep is a coverage gap,
+ *   not a capability limit; `workloads_covered` flags the reduced basis.
+ * - Aggregates from the already-rounded feed values, so a consumer can
+ *   reproduce `score` exactly by SUMPRODUCT over the `points` view.
+ */
+export function computeTcoScores(
+  feedRows: readonly TcoFeedRow[],
+  workloads: readonly TcoFeedWorkload[],
+  tiers: readonly number[],
+  tierWeights: readonly number[],
+  workloadWeights: readonly number[],
+  alpha: number,
+): TcoScoreRow[] {
+  const byHardware = new Map<string, TcoFeedRow[]>();
+  for (const row of feedRows) {
+    const bucket = byHardware.get(row.hardware);
+    if (bucket) bucket.push(row);
+    else byHardware.set(row.hardware, [row]);
+  }
+
+  const out: TcoScoreRow[] = [];
+  for (const hardware of [...byHardware.keys()].toSorted((a, b) => a.localeCompare(b))) {
+    const hwRows = byHardware.get(hardware)!;
+    const workloadScores: Record<string, number | null> = {};
+    let unreachable = 0;
+    let clamped = 0;
+    let latest = '';
+    let oldest = '';
+    let coveredWeight = 0;
+    let blended = 0;
+
+    for (const [w, workload] of workloads.entries()) {
+      const key = `${workload.isl}x${workload.osl}`;
+      // computeTcoFeed emits per-workload rows in `tiers` order.
+      const tierRows = hwRows.filter((r) => r.workload === key);
+      if (tierRows.length !== tiers.length) {
+        workloadScores[key] = null;
+        continue;
+      }
+      let weighted = 0;
+      for (const [i, row] of tierRows.entries()) {
+        weighted += tierWeights[i] * row.output_tput_per_gpu;
+        if (row.boundary === 'unreachable') unreachable += 1;
+        if (row.boundary === 'clamped_low') clamped += 1;
+      }
+      workloadScores[key] = round3(weighted);
+      coveredWeight += workloadWeights[w];
+      blended += workloadWeights[w] * weighted * (1 + (alpha * workload.isl) / workload.osl);
+      // 'YYYY-MM-DD' compares chronologically as a string.
+      if (latest === '' || tierRows[0].latest_date > latest) latest = tierRows[0].latest_date;
+      if (oldest === '' || tierRows[0].oldest_frontier_date < oldest) {
+        oldest = tierRows[0].oldest_frontier_date;
+      }
+    }
+
+    // Every hardware in feedRows covers ≥1 workload, so coveredWeight can
+    // only be 0 when the caller zero-weighted all its covered workloads.
+    const covered = Object.values(workloadScores).filter((v) => v !== null).length;
+    out.push({
+      hardware,
+      score: coveredWeight > 0 ? round3(blended / coveredWeight) : 0,
+      workload_scores: workloadScores,
+      workloads_covered: covered,
+      unreachable_tiers: unreachable,
+      clamped_tiers: clamped,
+      latest_date: latest,
+      oldest_frontier_date: oldest,
+    });
+  }
+  return out;
+}
+
+/**
+ * Serialize score rows as CSV. One `score_<isl>x<osl>` column per requested
+ * workload, in request order; an uncovered workload is an empty field.
+ * Same no-quoting invariant as tcoFeedToCsv — every value is a number, ISO
+ * date, hardware key, or `<digits>x<digits>` workload key.
+ */
+export function tcoScoresToCsv(
+  rows: readonly TcoScoreRow[],
+  workloads: readonly TcoFeedWorkload[],
+): string {
+  const workloadKeys = workloads.map((w) => `${w.isl}x${w.osl}`);
+  const header = [
+    'hardware',
+    'score',
+    ...workloadKeys.map((k) => `score_${k}`),
+    'workloads_covered',
+    'unreachable_tiers',
+    'clamped_tiers',
+    'latest_date',
+    'oldest_frontier_date',
+  ];
+  const lines = rows.map((row) =>
+    [
+      row.hardware,
+      row.score,
+      ...workloadKeys.map((k) => row.workload_scores[k] ?? ''),
+      row.workloads_covered,
+      row.unreachable_tiers,
+      row.clamped_tiers,
+      row.latest_date,
+      row.oldest_frontier_date,
+    ].join(','),
+  );
+  return `${[header.join(','), ...lines].join('\n')}\n`;
 }

--- a/packages/app/src/lib/tco-feed.ts
+++ b/packages/app/src/lib/tco-feed.ts
@@ -87,8 +87,9 @@ const MAX_WORKLOADS = 8;
 const MAX_ALPHA = 10;
 
 /**
- * Parse `tiers=30,50,75,100`. Absent/blank → defaults; any invalid entry →
- * null (caller responds 400).
+ * Parse `tiers=30,50,75,100`. Absent/blank → defaults; any invalid or
+ * duplicate entry → null (caller responds 400 — duplicates would
+ * double-count in the scores view).
  */
 export function parseTiers(raw: string | null): number[] | null {
   if (raw === null || raw.trim() === '') return [...DEFAULT_TIERS];
@@ -100,6 +101,7 @@ export function parseTiers(raw: string | null): number[] | null {
     if (part === '' || !Number.isFinite(value) || value <= 0 || value > MAX_TIER_VALUE) {
       return null;
     }
+    if (tiers.includes(value)) return null;
     tiers.push(value);
   }
   return tiers;


### PR DESCRIPTION
## Summary

The `points` view of `/api/v1/tco-feed` serves per-tier frontier reads and leaves the weighted aggregation to spreadsheet SUMPRODUCT wiring. This PR adds **`view=scores`**: one row per hardware carrying the single number a TCO sheet consumes per chip — tier-weighted, workload-blended, output-equivalent tok/s/GPU — so the sheet's "InferenceMAX score" column becomes one Power Query fetch plus an XLOOKUP, replacing the old single-point read at 100 tok/s/user.

**Methodology (all consumer-overridable query params; a published sheet's URL fully records its assumptions):**
- `weights` — per-tier traffic-mix weights, normalized to sum 1. Default `0.35,0.4,0.2,0.05` on the default tiers `30,50,75,100`; equal weights on custom tiers.
- `workload_weights` — per-workload blend weights, default equal split. Renormalized over covered workloads when a chip lacks a sweep — a missing workload is a flagged coverage gap (`workloads_covered`, blank `score_<workload>` column), not a zero.
- `alpha` — input-token value ratio in the output-equivalent conversion `out × (1 + α × ISL/OSL)`. Default `0.25`; `alpha=0` scores plain output throughput.

**Semantics:**
- Unreachable tiers contribute 0 at full weight (chip genuinely can't serve that traffic segment), matching the points view's documented boundary behavior; `unreachable_tiers`/`clamped_tiers` columns surface how much of a score rests on boundary handling.
- Scores aggregate the **already-rounded** points-view values, so `view=scores` is exactly SUMPRODUCT over `view=points` — reproducible by hand (verified: b200 8k1k `2992.49` both ways on fixtures).
- Provenance: `latest_date` / `oldest_frontier_date` carried as max/min across covered workloads.

**Validation hardening:**
- Duplicate `workloads` entries now 400 (they'd double-count in the blend).
- `weights`/`workload_weights`/`alpha` passed with `view=points` → 400 rather than silently ignored.
- New 400s for weight-count mismatch, negative weights, zero sums, alpha outside [0, 10].

`view=points` output is byte-identical to before (the duplicate-workloads rejection is the only behavior change).

## Testing

- 19 new unit tests in `tco-feed.test.ts` (36 total): parse defaults/normalization/rejections for the three new params, exact weighted-sum arithmetic at frontier knots, unreachable-at-full-weight, clamp inclusion, partial-coverage renormalization, α factors per workload, zero-covered-weight guard, provenance dates, dynamic-column CSV shape with blank uncovered fields.
- End-to-end on the `E2E_FIXTURES=1` dev server: scores JSON/CSV, custom `tiers/weights/alpha`, all six invalid-param 400 cases, and the SUMPRODUCT-reproducibility cross-check against `view=points`.
- `pnpm typecheck` / `lint` / `fmt` clean; unit-suite failures are the three known environment-specific files (`visit-tracking`, `chunk-load-recovery`, `use-feature-gate`) that pass in CI, untouched here.

Overlay-run support: N/A — API-only change with no chart surface; both views are computed from official-run DB rows only.

## 中文说明

`/api/v1/tco-feed` 的 `points` 视图只提供逐层级的前沿读数，加权聚合此前要靠电子表格里的 SUMPRODUCT 公式完成。本 PR 新增 **`view=scores`** 视图：每款硬件一行，直接给出 TCO 表格所需的单一数值——按 interactivity 层级加权、跨 workload 混合、经输出等效换算的 tok/s/GPU——表格中的 "InferenceMAX score" 列从此只需一次 Power Query 拉取加一个 XLOOKUP，取代旧的 100 tok/s/user 单点读数。

**方法论（全部为消费方可覆盖的查询参数，已发布表格的 URL 完整记录其全部假设）：**
- `weights` — 逐层级流量组合权重，归一化为和 1。默认层级 `30,50,75,100` 下默认为 `0.35,0.4,0.2,0.05`，自定义层级默认均分。
- `workload_weights` — 跨 workload 混合权重，默认均分。当某款芯片缺少某个 workload 的数据时，仅在有数据的 workload 上重新归一化——缺失的 sweep 是被明确标记的覆盖缺口（`workloads_covered` 列、空白的 `score_<workload>` 列），而不是记零分。
- `alpha` — 输出等效换算 `out × (1 + α × ISL/OSL)` 中的输入 token 价值比。默认 `0.25`；`alpha=0` 即纯输出吞吐量。

**语义：**
- 不可达层级按全权重计 0（芯片确实无法服务该流量段），与 points 视图既有的边界语义一致；`unreachable_tiers`/`clamped_tiers` 列展示分数中有多少依赖边界处理。
- 分数基于 points 视图**已舍入**的数值聚合，因此 `view=scores` 与对 `view=points` 做 SUMPRODUCT 完全一致，可手工复算（已在 fixtures 上验证：b200 8k1k 两种算法均为 `2992.49`）。
- 溯源信息：`latest_date` / `oldest_frontier_date` 取有数据 workload 的最大/最小值。

**参数校验加强：**
- 重复的 `workloads` 现在返回 400（否则会在混合中重复计数）。
- 在 `view=points` 上传入 `weights`/`workload_weights`/`alpha` 返回 400，而非被静默忽略。
- 权重个数不匹配、负权重、权重和为零、alpha 超出 [0, 10] 均返回 400。

`view=points` 的输出与之前逐字节一致（唯一的行为变化是拒绝重复 workload）。

**测试：** `tco-feed.test.ts` 新增 19 个单元测试（合计 36 个），覆盖三个新参数的默认值/归一化/拒绝路径、前沿节点处的精确加权求和、不可达层级全权重计零、钳位值纳入、部分覆盖时的重新归一化、逐 workload 的 α 系数、零覆盖权重防护、溯源日期以及动态列 CSV 结构；并在 `E2E_FIXTURES=1` 开发服务器上端到端验证了 JSON/CSV、自定义参数、全部六种非法参数 400 以及与 points 视图的 SUMPRODUCT 一致性。

叠加运行（overlay）支持：不适用——本改动仅涉及 API，无图表界面；两个视图均只基于官方运行的数据库行计算。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> API-only change to the documented tco-feed exception path, with extensive unit tests and stricter validation; default points view behavior is preserved except rejecting duplicate workloads.
> 
> **Overview**
> Adds **`view=scores`** to `/api/v1/tco-feed`: one row per hardware with a single tier-weighted, workload-blended, output-equivalent tok/s/GPU for spreadsheet TCO models, instead of wiring SUMPRODUCT over `view=points`.
> 
> Scoring assumptions are explicit query params—`weights`, `workload_weights`, and `alpha` (with documented defaults)—and are echoed in JSON responses so a published Power Query URL records methodology. `computeTcoScores` aggregates rounded point values (SUMPRODUCT-equivalent), handles unreachable tiers as zero at full weight, and renormalizes workload weights when a chip lacks a sweep.
> 
> **Validation:** duplicate `tiers`/`workloads` now 400; score-only params with `view=points` return 400 instead of being ignored. `view=points` output is unchanged aside from duplicate-workload rejection.
> 
> Docs in `AGENTS.md` and route comments are updated; unit tests cover parsers, scoring math, and CSV shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cb8f6a36cbc26c4b0a4fcd070525b2e2926c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->