### PR TITLE
fix(agentic): Deduplicate phase-scoped KV rank series / 修复分阶段 KV rank 序列重复

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -68,6 +68,12 @@ AIPerf defines the `server_metrics_export.json` envelope, but labels such as wor
 
 Adapters are selected from the benchmark's canonical framework, and per-worker series are only emitted for disaggregated configs with a recognized adapter. Unknown orchestrators and non-disaggregated configs retain their aggregate-only series; roles are never guessed from ports or metric names. The frontend only consumes the canonical source identity and never interprets orchestrator-native labels.
 
+### Canonical Agentic Chart Series
+
+`agentic_trace_replay.chart_series` is canonical materialized DB data, not a chain of application-versioned cache formats. The ingest path writes the current representation, API readers trust any non-null stored value, and the raw compressed server-metrics blob is only opened when the materialized column is missing.
+
+When extraction behavior changes, use an explicit expand/migrate/contract rollout: deploy a reader compatible with the canonical shape, backfill every maintained Neon branch, purge the API/Blob cache through `/api/v1/invalidate`, and then remove temporary migration compatibility. The `--force` option on `db:backfill-chart-series` deliberately recomputes all rows when needed. Keeping migration state in the operational workflow instead of every JSONB payload prevents historical version branches from accumulating on the request path.
+
 ### Agentic Dataset Provenance
 
 AIPerf exports public-dataset provenance in `metadata.dataset`, including the Hugging Face dataset ID. InferenceX preserves that object as `dataset` on each agentic aggregate benchmark row. During benchmark ingest, `ingest-ci-run.ts` derives the dashboard slug from `hf_dataset_name` (for example, `semianalysisai/cc-traces-weka-062126` becomes `cc-traces-weka-062126`) and upserts `run_datasets` for the workflow run.

--- a/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
+++ b/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
@@ -1,11 +1,7 @@
 /**
- * Guards that every agentic blob-cache key is DERIVED from the version constant
- * that governs its payload — not a hand-written string. `blobSet` is write-once
- * and nothing purges the blob cache after a backfill, so an unversioned (or
- * hand-bumped) key would serve stale data forever after a payload-version bump.
- * Deriving the key from the constant means a future bump rolls the cache
- * namespace automatically; these tests fail loudly if a route drifts back to a
- * literal string.
+ * Versioned derived payloads roll their cache namespace with their format.
+ * chart_series is instead canonical DB data under a stable key; ingest and
+ * backfill operations explicitly purge Blob storage through the invalidate API.
  */
 
 import { describe, expect, it, vi } from 'vitest';
@@ -26,7 +22,6 @@ vi.mock('@/lib/api-cache', () => ({
 }));
 
 import { STATS_VERSION } from '@semianalysisai/inferencex-db/queries/agentic-aggregates';
-import { CHART_SERIES_VERSION } from '@semianalysisai/inferencex-db/etl/compute-chart-series';
 import { REQUEST_TIMELINE_VERSION } from '@semianalysisai/inferencex-db/etl/compute-request-timeline';
 
 import { CACHE_KEY_PREFIX as derivedAgenticMetricsKey } from './derived-agentic-metrics/route';
@@ -35,7 +30,7 @@ import { CACHE_KEY_PREFIX as requestTimelineKey } from './request-timeline/route
 import { CACHE_KEY_PREFIX as traceServerMetricsKey } from './trace-server-metrics/route';
 import { CACHE_KEY_PREFIX as traceHistogramsKey } from './trace-histograms/route';
 
-describe('agentic blob-cache keys are version-derived', () => {
+describe('agentic blob-cache keys match their storage contracts', () => {
   it('derived-agentic-metrics key embeds STATS_VERSION', () => {
     expect(derivedAgenticMetricsKey).toBe(`derived-agentic-metrics-v${STATS_VERSION}`);
   });
@@ -48,20 +43,19 @@ describe('agentic blob-cache keys are version-derived', () => {
     expect(requestTimelineKey).toBe(`request-timeline-v${REQUEST_TIMELINE_VERSION}`);
   });
 
-  it('trace-server-metrics key embeds CHART_SERIES_VERSION', () => {
-    expect(traceServerMetricsKey).toBe(`trace-server-metrics-v${CHART_SERIES_VERSION}`);
+  it('trace-server-metrics uses the canonical chart-series namespace', () => {
+    expect(traceServerMetricsKey).toBe('trace-server-metrics');
   });
 
   it('trace-histograms key embeds REQUEST_TIMELINE_VERSION (its payload is read from request_timeline)', () => {
     expect(traceHistogramsKey).toBe(`trace-histograms-v${REQUEST_TIMELINE_VERSION}`);
   });
 
-  it('every key actually contains a version segment (no unversioned literals)', () => {
+  it('keeps versioned namespaces for the remaining versioned derived payloads', () => {
     for (const key of [
       derivedAgenticMetricsKey,
       agenticAggregatesKey,
       requestTimelineKey,
-      traceServerMetricsKey,
       traceHistogramsKey,
     ]) {
       expect(key).toMatch(/-v\d+$/u);

--- a/packages/app/src/app/api/v1/trace-server-metrics/route.ts
+++ b/packages/app/src/app/api/v1/trace-server-metrics/route.ts
@@ -1,4 +1,3 @@
-import { CHART_SERIES_VERSION } from '@semianalysisai/inferencex-db/etl/compute-chart-series';
 import { JSON_MODE, getDb } from '@semianalysisai/inferencex-db/connection';
 import * as jsonProvider from '@semianalysisai/inferencex-db/json-provider';
 import {
@@ -12,12 +11,9 @@ import { idQueryRoute } from '../id-routes';
 
 export const dynamic = 'force-dynamic';
 
-// Key derived from CHART_SERIES_VERSION (governs the `chart_series` payload).
-// The blob cache is write-once with no post-backfill purge, so the
-// version-derived key is what rolls the namespace on a bump — a hand-written
-// string would serve stale blob-cached series forever.
-/** Version-derived blob-cache key namespace (exported for the key-derivation test). */
-export const CACHE_KEY_PREFIX = `trace-server-metrics-v${CHART_SERIES_VERSION}`;
+// chart_series is canonical DB data. Ingest/backfill operations purge Blob and
+// Next.js caches through /api/v1/invalidate after changing it.
+export const CACHE_KEY_PREFIX = 'trace-server-metrics';
 
 const getCachedTraceServerMetrics = cachedQuery(
   (id: number): Promise<TraceServerMetrics | null> => {

--- a/packages/app/src/components/inference/agentic-point/phase-slice.test.ts
+++ b/packages/app/src/components/inference/agentic-point/phase-slice.test.ts
@@ -151,6 +151,26 @@ describe('sliceServerSeriesByPhase', () => {
     expect(out.series.kvCacheUsageByEngine[0]!.engineLabel).toBe('e0');
   });
 
+  it('drops per-engine series with no points in the selected phase', () => {
+    const s = makeSeries([0, 1, 2, 3]);
+    s.kvCacheUsageByEngine = [
+      { engineLabel: 'warmup-only', points: s.kvCacheUsage.filter((p) => p.t < 2) },
+      { engineLabel: 'profiling-only', points: s.kvCacheUsage.filter((p) => p.t >= 2) },
+    ];
+
+    const out = sliceServerSeriesByPhase(s, 'profiling', 2, 4);
+
+    expect(out.series.kvCacheUsageByEngine).toEqual([
+      {
+        engineLabel: 'profiling-only',
+        points: [
+          { t: 0, value: 20 },
+          { t: 1, value: 30 },
+        ],
+      },
+    ]);
+  });
+
   it('does not mutate the input series', () => {
     const s = makeSeries([0, 1, 2]);
     const before = s.kvCacheUsage.map((p) => p.t);

--- a/packages/app/src/components/inference/agentic-point/phase-slice.ts
+++ b/packages/app/src/components/inference/agentic-point/phase-slice.ts
@@ -136,10 +136,12 @@ export function sliceServerSeriesByPhase<S extends ServerSeriesLike>(
     decodeTps: sliceTs(series.decodeTps),
     prefixCacheHitsTps: sliceTs(series.prefixCacheHitsTps),
     hostKvCacheUsage: sliceTs(series.hostKvCacheUsage),
-    kvCacheUsageByEngine: series.kvCacheUsageByEngine.map((e) => ({
-      engineLabel: e.engineLabel,
-      points: sliceTs(e.points),
-    })),
+    kvCacheUsageByEngine: series.kvCacheUsageByEngine
+      .map((e) => ({
+        engineLabel: e.engineLabel,
+        points: sliceTs(e.points),
+      }))
+      .filter(({ points }) => points.length > 0),
   };
 
   const durationS = phase === 'warmup' ? b : Math.max(1, fullDurationS - b);

--- a/packages/db/src/backfill-chart-series.ts
+++ b/packages/db/src/backfill-chart-series.ts
@@ -1,11 +1,9 @@
 /**
- * Backfill `agentic_trace_replay.chart_series` for rows that are missing it
- * or were computed by an older `CHART_SERIES_VERSION`.
+ * Backfill `agentic_trace_replay.chart_series` for rows that are missing it.
  *
  * The ingest path now computes the time-series inline, but existing rows
- * (and rows whose computation logic has since changed) still need this
- * pass. Run after the agentic schema migration and any time `CHART_SERIES_VERSION`
- * bumps.
+ * Existing rows whose extraction logic has changed can be deliberately
+ * recomputed with `--force`; chart_series itself carries no format version.
  *
  * Strategy:
  *   - Stream rows one at a time (server_metrics_json_gz can decompress
@@ -23,7 +21,7 @@
  */
 
 import { hasNoSslFlag } from './cli-utils.js';
-import { CHART_SERIES_VERSION, computeChartSeries } from './etl/compute-chart-series.js';
+import { computeChartSeries } from './etl/compute-chart-series.js';
 import { createAdminSql } from './etl/db-utils.js';
 import {
   confirmProceed,
@@ -43,7 +41,6 @@ const sql = createAdminSql({
 
 async function main(): Promise<void> {
   console.log('=== backfill-chart-series ===');
-  console.log(`  CHART_SERIES_VERSION = ${CHART_SERIES_VERSION}`);
   console.log(`  force = ${flags.force}`);
   console.log(`  limit = ${flags.limit ?? 'none'}`);
 
@@ -64,10 +61,7 @@ async function main(): Promise<void> {
         select id
         from agentic_trace_replay
         where server_metrics_json_gz is not null
-          and (
-            chart_series is null
-            or coalesce((chart_series->>'version')::int, -1) <> ${CHART_SERIES_VERSION}
-          )
+          and chart_series is null
         order by id
         ${flags.limit ? sql`limit ${flags.limit}` : sql``}
       `;

--- a/packages/db/src/etl/compute-chart-series.test.ts
+++ b/packages/db/src/etl/compute-chart-series.test.ts
@@ -119,6 +119,19 @@ function buildDynamoSeries(
   };
 }
 
+function buildPhaseKvSeries(startNs: number, baseValue: number) {
+  return Array.from({ length: 8 }, (_, dpRank) => ({
+    labels: { engine: '0', dp_rank: String(dpRank) },
+    timeslices: [
+      {
+        start_ns: startNs,
+        end_ns: startNs + 1e9,
+        avg: baseValue + dpRank / 100,
+      },
+    ],
+  }));
+}
+
 describe('computeChartSeries', () => {
   it('returns null when the blob is null', async () => {
     expect(await computeChartSeries(null)).toBeNull();
@@ -179,6 +192,43 @@ describe('computeChartSeries', () => {
       { t: 10, value: 0.8 },
       { t: 11, value: 0.9 },
     ]);
+  });
+
+  it('coalesces each DP rank across warmup and profiling instead of duplicating it', async () => {
+    const blob = gzipSync(
+      Buffer.from(
+        JSON.stringify({
+          warmup_metrics: {
+            'vllm:kv_cache_usage_perc': { series: buildPhaseKvSeries(0, 0.1) },
+          },
+          metrics: {
+            'vllm:kv_cache_usage_perc': { series: buildPhaseKvSeries(10e9, 0.2) },
+          },
+        }),
+      ),
+    );
+
+    const series = await computeChartSeries(blob);
+
+    expect(series?.kvCacheUsageByEngine).toHaveLength(8);
+    expect(series?.kvCacheUsageByEngine.map(({ engineLabel }) => engineLabel)).toEqual([
+      '0',
+      '1',
+      '2',
+      '3',
+      '4',
+      '5',
+      '6',
+      '7',
+    ]);
+    expect(series?.kvCacheUsageByEngine.every(({ points }) => points.length === 2)).toBe(true);
+    expect(series?.kvCacheUsageByEngine[0]).toEqual({
+      engineLabel: '0',
+      points: [
+        { t: 0, value: 0.1 },
+        { t: 10, value: 0.2 },
+      ],
+    });
   });
 
   it('computes prefixCacheHitRate as hits.rate / queries.rate', async () => {

--- a/packages/db/src/etl/compute-chart-series.test.ts
+++ b/packages/db/src/etl/compute-chart-series.test.ts
@@ -2,7 +2,7 @@ import { gzipSync } from 'node:zlib';
 
 import { describe, expect, it } from 'vitest';
 
-import { CHART_SERIES_VERSION, computeChartSeries } from './compute-chart-series.js';
+import { computeChartSeries } from './compute-chart-series.js';
 
 /**
  * Build a minimal server_metrics_json blob covering the metrics the chart
@@ -137,9 +137,9 @@ describe('computeChartSeries', () => {
     expect(await computeChartSeries(null)).toBeNull();
   });
 
-  it('returns the current CHART_SERIES_VERSION in the bundle', async () => {
+  it('returns a canonical bundle without embedded version metadata', async () => {
     const series = await computeChartSeries(makeBlob());
-    expect(series?.version).toBe(CHART_SERIES_VERSION);
+    expect(series).not.toHaveProperty('version');
   });
 
   it('extracts kvCacheUsage points with t=seconds-from-start', async () => {

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -77,6 +77,7 @@ import {
  * every DP rank twice, leaving one empty duplicate in each phase-filtered view.
  */
 export const CHART_SERIES_VERSION = 14;
+const ENGINE_FIRST_CHART_SERIES_VERSION = 12;
 const PHASE_DUPLICATED_CHART_SERIES_VERSION = 13;
 
 export interface TimeSeriesPoint {
@@ -153,24 +154,47 @@ export interface MetricSourceSeries {
 }
 
 /**
- * Coalesce the v13 warmup/profile duplicates using the DP label retained in
- * the stored chart series. The raw source identity is no longer available at
- * this layer, but v13 guarantees DP-rank-first labels, so equal labels are the
- * same rank split across the two non-overlapping phase windows.
+ * Coalesce warmup/profile duplicates using the rank label retained in stored
+ * chart series. v12 labels are only safe when equal-label entries occupy
+ * non-overlapping time ranges; overlap means multiple ranks shared a local
+ * engine label and their DP identities cannot be recovered without raw data.
  */
 function coalesceStoredKvSeries(
   series: { engineLabel: string; points: TimeSeriesPoint[] }[],
-): { engineLabel: string; points: TimeSeriesPoint[] }[] {
-  const pointsByLabel = new Map<string, TimeSeriesPoint[]>();
+  rejectOverlappingLabels: boolean,
+): { engineLabel: string; points: TimeSeriesPoint[] }[] | null {
+  const entriesByLabel = new Map<string, TimeSeriesPoint[][]>();
   for (const entry of series) {
-    const points = pointsByLabel.get(entry.engineLabel) ?? [];
-    points.push(...entry.points);
-    pointsByLabel.set(entry.engineLabel, points);
+    const entries = entriesByLabel.get(entry.engineLabel) ?? [];
+    entries.push(entry.points);
+    entriesByLabel.set(entry.engineLabel, entries);
   }
-  return [...pointsByLabel].map(([engineLabel, points]) => ({
-    engineLabel,
-    points: points.toSorted((a, b) => a.t - b.t),
-  }));
+
+  const result: { engineLabel: string; points: TimeSeriesPoint[] }[] = [];
+  for (const [engineLabel, entries] of entriesByLabel) {
+    if (rejectOverlappingLabels && entries.length > 1) {
+      const ranges = entries
+        .filter((points) => points.length > 0)
+        .map((points) => {
+          let min = Number.POSITIVE_INFINITY;
+          let max = Number.NEGATIVE_INFINITY;
+          for (const point of points) {
+            min = Math.min(min, point.t);
+            max = Math.max(max, point.t);
+          }
+          return { min, max };
+        })
+        .toSorted((a, b) => a.min - b.min);
+      for (let i = 1; i < ranges.length; i += 1) {
+        if (ranges[i]!.min <= ranges[i - 1]!.max) return null;
+      }
+    }
+    result.push({
+      engineLabel,
+      points: entries.flat().toSorted((a, b) => a.t - b.t),
+    });
+  }
+  return result;
 }
 
 /**
@@ -180,14 +204,33 @@ function coalesceStoredKvSeries(
  * reconstructed from stored chart data alone.
  */
 export function upgradeStoredChartSeries(series: ChartSeries): ChartSeries | null {
-  if (Number(series.version) === CHART_SERIES_VERSION) return series;
-  if (Number(series.version) !== PHASE_DUPLICATED_CHART_SERIES_VERSION) return null;
+  const storedVersion = Number(series.version);
+  if (storedVersion === CHART_SERIES_VERSION) return series;
+  if (
+    storedVersion !== ENGINE_FIRST_CHART_SERIES_VERSION &&
+    storedVersion !== PHASE_DUPLICATED_CHART_SERIES_VERSION
+  ) {
+    return null;
+  }
+  const rejectOverlappingLabels = storedVersion === ENGINE_FIRST_CHART_SERIES_VERSION;
 
-  const kvCacheUsageByEngine = coalesceStoredKvSeries(series.kvCacheUsageByEngine ?? []);
-  const metricSources = (series.metricSources ?? []).map((metricSource) => ({
-    ...metricSource,
-    kvCacheUsageByEngine: coalesceStoredKvSeries(metricSource.kvCacheUsageByEngine ?? []),
-  }));
+  const kvCacheUsageByEngine = coalesceStoredKvSeries(
+    series.kvCacheUsageByEngine ?? [],
+    rejectOverlappingLabels,
+  );
+  if (!kvCacheUsageByEngine) return null;
+  const metricSources: MetricSourceSeries[] = [];
+  for (const metricSource of series.metricSources ?? []) {
+    const sourceKvCacheUsageByEngine = coalesceStoredKvSeries(
+      metricSource.kvCacheUsageByEngine ?? [],
+      rejectOverlappingLabels,
+    );
+    if (!sourceKvCacheUsageByEngine) return null;
+    metricSources.push({
+      ...metricSource,
+      kvCacheUsageByEngine: sourceKvCacheUsageByEngine,
+    });
+  }
   const timeslicesCount = Math.max(
     series.timeslicesCount,
     series.kvCacheUsage.length,

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -4,8 +4,9 @@
  * request. The output lands in `agentic_trace_replay.chart_series` and is
  * read directly by `getTraceServerMetrics`.
  *
- * Versioned so the backfill script knows which rows are stale — bump
- * `CHART_SERIES_VERSION` whenever the extraction algorithm changes.
+ * The stored JSONB is the canonical representation. Extraction changes must
+ * be followed by an explicit DB backfill and API-cache invalidation rather
+ * than accumulating request-time payload-version branches.
  */
 
 import { gunzipSync } from 'node:zlib';
@@ -16,69 +17,6 @@ import {
   type MetricSource,
   type ServerMetricsContext,
 } from './server-metrics-adapters';
-
-/**
- * Bump when the extraction algorithm changes — backfill recomputes anything
- * older.
- *
- * v2: aggregate vllm gauges/counters across all engine series (was reading
- * only series[0], which under-counted by Nx on multi-engine DP/PP
- * deployments — most visible as a request-queue-depth chart that maxed out
- * at ~3 when the timeline clearly showed 20+ in-flight).
- *
- * v3: extract `prefixCacheHitsTps` so the detail page can derive cumulative
- * unique input tokens as cumsum(prefillTps - prefixCacheHitsTps).
- *
- * v4: extract sglang:* metrics too (fallback chain in each picker), so
- * SGLang runs populate the chart_series the same way vllm runs do.
- *
- * v5: map sglang:realtime_tokens (mode={prefill_cache,prefill_compute,decode})
- * into promptTokensBySource so the cumulative prompt-token-source-breakdown
- * chart shows useful splits for SGLang runs (filtered to prefill_* modes).
- *
- * v6: for SGLang, swap the coarse "prefill_cache" bucket for per-cache_source
- * breakdown from sglang:cached_tokens — current runs always have one
- * cache_source ("device" / HBM) but hicache (CPU offload) runs would
- * split into "device" + "host" automatically once ingested.
- *
- * v7: extract sglang:hicache_host_{used,total}_tokens into a new
- * hostKvCacheUsage series so the KV cache utilization chart can plot
- * the CPU offload pool's usage alongside the on-GPU HBM line.
- *
- * v8: keep the per-engine dimension on kv_cache_usage_perc as
- * `kvCacheUsageByEngine` (one entry per DP rank). The cluster-average
- * line hides load skew on DEP configs; the detail page overlays the
- * per-rank lines so a hot rank is visible at a glance.
- *
- * v9: retain orchestrator-normalized per-source series. Dynamo labels are
- * mapped to canonical router/prefill/decode roles, allowing the frontend to
- * inspect individual workers without interpreting Dynamo-native labels.
- *
- * v10: only emit per-source series for disaggregated configs with a recognized
- * orchestrator adapter. Non-disaggregated and unsupported configs retain the
- * existing aggregate-only behavior.
- *
- * v12: also consume the `warmup_metrics` block from the server-metrics blob and
- * merge its scrapes into the same series as the profiling `metrics` block.
- * Warmup and profiling timeslices carry their own absolute `start_ns` and never
- * overlap in time, so the merged series is continuous (warmup at lower t,
- * profiling after). This lets the agentic detail page slice `chart_series` into
- * warmup vs profiling at the request-derived boundary; older blobs without a
- * warmup block are unaffected. (v11 was a short-lived, since-reverted attempt to
- * carry kvCachePoolTokens in chart_series; that value now lives in
- * benchmark_results.metrics, derived from the server log — unrelated to this.)
- *
- * v13: prefer `dp_rank` over the per-rank-local `engine` label when naming
- * KV-cache series. Some DEP exports report engine=0 for every rank, which
- * made every legend entry read "DP 0" despite distinct dp_rank labels.
- *
- * v14: coalesce warmup and profiling metric series by source identity before
- * concatenating their timeslices. Concatenating the phase-level arrays emitted
- * every DP rank twice, leaving one empty duplicate in each phase-filtered view.
- */
-export const CHART_SERIES_VERSION = 14;
-const ENGINE_FIRST_CHART_SERIES_VERSION = 12;
-const PHASE_DUPLICATED_CHART_SERIES_VERSION = 13;
 
 export interface TimeSeriesPoint {
   /** Seconds from benchmark start. */
@@ -94,7 +32,6 @@ export interface QueueDepthPoint {
 }
 
 export interface ChartSeries {
-  version: number;
   /** ns wall-clock of the first window's start; for debugging only. */
   startNs: number;
   /** ns wall-clock of the last window's end. */
@@ -151,108 +88,6 @@ export interface MetricSourceSeries {
   prefixCacheHitsTps: TimeSeriesPoint[];
   hostKvCacheUsage: TimeSeriesPoint[];
   kvCacheUsageByEngine: { engineLabel: string; points: TimeSeriesPoint[] }[];
-}
-
-/**
- * Coalesce warmup/profile duplicates using the rank label retained in stored
- * chart series. v12 labels are only safe when equal-label entries occupy
- * non-overlapping time ranges; overlap means multiple ranks shared a local
- * engine label and their DP identities cannot be recovered without raw data.
- */
-function coalesceStoredKvSeries(
-  series: { engineLabel: string; points: TimeSeriesPoint[] }[],
-  rejectOverlappingLabels: boolean,
-): { engineLabel: string; points: TimeSeriesPoint[] }[] | null {
-  const entriesByLabel = new Map<string, TimeSeriesPoint[][]>();
-  for (const entry of series) {
-    const entries = entriesByLabel.get(entry.engineLabel) ?? [];
-    entries.push(entry.points);
-    entriesByLabel.set(entry.engineLabel, entries);
-  }
-
-  const result: { engineLabel: string; points: TimeSeriesPoint[] }[] = [];
-  for (const [engineLabel, entries] of entriesByLabel) {
-    if (rejectOverlappingLabels && entries.length > 1) {
-      const ranges = entries
-        .filter((points) => points.length > 0)
-        .map((points) => {
-          let min = Number.POSITIVE_INFINITY;
-          let max = Number.NEGATIVE_INFINITY;
-          for (const point of points) {
-            min = Math.min(min, point.t);
-            max = Math.max(max, point.t);
-          }
-          return { min, max };
-        })
-        .toSorted((a, b) => a.min - b.min);
-      for (let i = 1; i < ranges.length; i += 1) {
-        if (ranges[i]!.min <= ranges[i - 1]!.max) return null;
-      }
-    }
-    result.push({
-      engineLabel,
-      points: entries.flat().toSorted((a, b) => a.t - b.t),
-    });
-  }
-  return result;
-}
-
-/**
- * Upgrade the immediately previous chart-series representation without
- * reopening the potentially multi-hundred-MB raw server-metrics blob.
- * Returns null for older versions whose missing transformations cannot be
- * reconstructed from stored chart data alone.
- */
-export function upgradeStoredChartSeries(series: ChartSeries): ChartSeries | null {
-  const storedVersion = Number(series.version);
-  if (storedVersion === CHART_SERIES_VERSION) return series;
-  if (
-    storedVersion !== ENGINE_FIRST_CHART_SERIES_VERSION &&
-    storedVersion !== PHASE_DUPLICATED_CHART_SERIES_VERSION
-  ) {
-    return null;
-  }
-  const rejectOverlappingLabels = storedVersion === ENGINE_FIRST_CHART_SERIES_VERSION;
-
-  const kvCacheUsageByEngine = coalesceStoredKvSeries(
-    series.kvCacheUsageByEngine ?? [],
-    rejectOverlappingLabels,
-  );
-  if (!kvCacheUsageByEngine) return null;
-  const metricSources: MetricSourceSeries[] = [];
-  for (const metricSource of series.metricSources ?? []) {
-    const sourceKvCacheUsageByEngine = coalesceStoredKvSeries(
-      metricSource.kvCacheUsageByEngine ?? [],
-      rejectOverlappingLabels,
-    );
-    if (!sourceKvCacheUsageByEngine) return null;
-    metricSources.push({
-      ...metricSource,
-      kvCacheUsageByEngine: sourceKvCacheUsageByEngine,
-    });
-  }
-  const timeslicesCount = Math.max(
-    series.timeslicesCount,
-    series.kvCacheUsage.length,
-    series.prefixCacheHitRate.length,
-    series.queueDepth.length,
-    series.prefillTps.length,
-    series.decodeTps.length,
-    series.prefixCacheHitsTps?.length ?? 0,
-    series.hostKvCacheUsage?.length ?? 0,
-    ...kvCacheUsageByEngine.map(({ points }) => points.length),
-    ...metricSources.flatMap((source) =>
-      source.kvCacheUsageByEngine.map(({ points }) => points.length),
-    ),
-  );
-
-  return {
-    ...series,
-    version: CHART_SERIES_VERSION,
-    timeslicesCount,
-    kvCacheUsageByEngine,
-    metricSources,
-  };
 }
 
 // ── Raw blob shapes (subset we read) ────────────────────────────────────
@@ -699,7 +534,6 @@ function buildSeriesFromMetrics(
     );
   }
   return {
-    version: CHART_SERIES_VERSION,
     startNs,
     endNs,
     durationS: endNs > startNs ? (endNs - startNs) / 1e9 : 0,

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -71,8 +71,12 @@ import {
  * v13: prefer `dp_rank` over the per-rank-local `engine` label when naming
  * KV-cache series. Some DEP exports report engine=0 for every rank, which
  * made every legend entry read "DP 0" despite distinct dp_rank labels.
+ *
+ * v14: coalesce warmup and profiling metric series by source identity before
+ * concatenating their timeslices. Concatenating the phase-level arrays emitted
+ * every DP rank twice, leaving one empty duplicate in each phase-filtered view.
  */
-export const CHART_SERIES_VERSION = 13;
+export const CHART_SERIES_VERSION = 14;
 
 export interface TimeSeriesPoint {
   /** Seconds from benchmark start. */
@@ -197,19 +201,49 @@ const CHART_METRIC_KEYS = new Set([
 ]);
 
 /**
- * Merge a warmup phase metric map into the profiling one by concatenating each
- * metric's `series`. The two phases' timeslices carry their own absolute
- * `start_ns` and never overlap in time, so `buildSeriesFromMetrics` (which keys
- * by `start_ns`) yields one continuous series — warmup scrapes at lower t,
- * profiling after. No-ops when either side is empty (older blobs have no warmup).
+ * Stable identity for pairing the same exported series across phases.
+ */
+function phaseSeriesBaseIdentity(series: RawSeries): string {
+  const labels = Object.entries(series.labels ?? {}).toSorted(([a], [b]) => a.localeCompare(b));
+  return JSON.stringify([series.endpoint_url ?? null, labels]);
+}
+
+/**
+ * Merge warmup and profiling metric maps into continuous source series. Each
+ * source keeps one entry whose timeslices span both phases, so phase slicing in
+ * the frontend cannot leave duplicate, empty DP-rank legend entries behind.
  */
 function mergePhaseMetrics(profiling: MetricsMap, warmup: MetricsMap): MetricsMap {
   if (Object.keys(warmup).length === 0) return profiling;
   if (Object.keys(profiling).length === 0) return warmup;
   const out: MetricsMap = {};
   for (const name of new Set([...Object.keys(profiling), ...Object.keys(warmup)])) {
+    const merged = new Map<string, RawSeries>();
+    for (const phaseSeries of [warmup[name]?.series ?? [], profiling[name]?.series ?? []]) {
+      const occurrences = new Map<string, number>();
+      for (const series of phaseSeries) {
+        const baseIdentity = phaseSeriesBaseIdentity(series);
+        const occurrence = occurrences.get(baseIdentity) ?? 0;
+        occurrences.set(baseIdentity, occurrence + 1);
+        // The occurrence suffix preserves distinct series when an exporter
+        // omits labels or repeats a label set; phase-local order pairs them.
+        const identity = JSON.stringify([baseIdentity, occurrence]);
+        const existing = merged.get(identity);
+        if (existing) {
+          existing.timeslices = [...(existing.timeslices ?? []), ...(series.timeslices ?? [])];
+        } else {
+          merged.set(identity, { ...series, timeslices: [...(series.timeslices ?? [])] });
+        }
+      }
+    }
     out[name] = {
-      series: [...(profiling[name]?.series ?? []), ...(warmup[name]?.series ?? [])],
+      series: [...merged.values()].map((series) => ({
+        ...series,
+        timeslices: (series.timeslices ?? []).toSorted(
+          (a, b) =>
+            (a.start_ns ?? Number.POSITIVE_INFINITY) - (b.start_ns ?? Number.POSITIVE_INFINITY),
+        ),
+      })),
     };
   }
   return out;

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -77,6 +77,7 @@ import {
  * every DP rank twice, leaving one empty duplicate in each phase-filtered view.
  */
 export const CHART_SERIES_VERSION = 14;
+const PHASE_DUPLICATED_CHART_SERIES_VERSION = 13;
 
 export interface TimeSeriesPoint {
   /** Seconds from benchmark start. */
@@ -149,6 +150,66 @@ export interface MetricSourceSeries {
   prefixCacheHitsTps: TimeSeriesPoint[];
   hostKvCacheUsage: TimeSeriesPoint[];
   kvCacheUsageByEngine: { engineLabel: string; points: TimeSeriesPoint[] }[];
+}
+
+/**
+ * Coalesce the v13 warmup/profile duplicates using the DP label retained in
+ * the stored chart series. The raw source identity is no longer available at
+ * this layer, but v13 guarantees DP-rank-first labels, so equal labels are the
+ * same rank split across the two non-overlapping phase windows.
+ */
+function coalesceStoredKvSeries(
+  series: { engineLabel: string; points: TimeSeriesPoint[] }[],
+): { engineLabel: string; points: TimeSeriesPoint[] }[] {
+  const pointsByLabel = new Map<string, TimeSeriesPoint[]>();
+  for (const entry of series) {
+    const points = pointsByLabel.get(entry.engineLabel) ?? [];
+    points.push(...entry.points);
+    pointsByLabel.set(entry.engineLabel, points);
+  }
+  return [...pointsByLabel].map(([engineLabel, points]) => ({
+    engineLabel,
+    points: points.toSorted((a, b) => a.t - b.t),
+  }));
+}
+
+/**
+ * Upgrade the immediately previous chart-series representation without
+ * reopening the potentially multi-hundred-MB raw server-metrics blob.
+ * Returns null for older versions whose missing transformations cannot be
+ * reconstructed from stored chart data alone.
+ */
+export function upgradeStoredChartSeries(series: ChartSeries): ChartSeries | null {
+  if (Number(series.version) === CHART_SERIES_VERSION) return series;
+  if (Number(series.version) !== PHASE_DUPLICATED_CHART_SERIES_VERSION) return null;
+
+  const kvCacheUsageByEngine = coalesceStoredKvSeries(series.kvCacheUsageByEngine ?? []);
+  const metricSources = (series.metricSources ?? []).map((metricSource) => ({
+    ...metricSource,
+    kvCacheUsageByEngine: coalesceStoredKvSeries(metricSource.kvCacheUsageByEngine ?? []),
+  }));
+  const timeslicesCount = Math.max(
+    series.timeslicesCount,
+    series.kvCacheUsage.length,
+    series.prefixCacheHitRate.length,
+    series.queueDepth.length,
+    series.prefillTps.length,
+    series.decodeTps.length,
+    series.prefixCacheHitsTps?.length ?? 0,
+    series.hostKvCacheUsage?.length ?? 0,
+    ...kvCacheUsageByEngine.map(({ points }) => points.length),
+    ...metricSources.flatMap((source) =>
+      source.kvCacheUsageByEngine.map(({ points }) => points.length),
+    ),
+  );
+
+  return {
+    ...series,
+    version: CHART_SERIES_VERSION,
+    timeslicesCount,
+    kvCacheUsageByEngine,
+    metricSources,
+  };
 }
 
 // ── Raw blob shapes (subset we read) ────────────────────────────────────

--- a/packages/db/src/json-provider.agentic-datasets.test.ts
+++ b/packages/db/src/json-provider.agentic-datasets.test.ts
@@ -5,6 +5,7 @@ import { gzipSync } from 'node:zlib';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { CHART_SERIES_VERSION, type ChartSeries } from './etl/compute-chart-series.js';
 import { REQUEST_TIMELINE_VERSION } from './etl/compute-request-timeline.js';
 import { STATS_VERSION } from './queries/agentic-shared.js';
 import type * as JsonProvider from './json-provider.js';
@@ -128,6 +129,30 @@ const CURRENT_TIMELINE = {
       cancelled: false,
     },
   ],
+};
+
+const PREVIOUS_CHART_SERIES: ChartSeries = {
+  version: CHART_SERIES_VERSION - 1,
+  startNs: 0,
+  endNs: 11e9,
+  durationS: 11,
+  timeslicesCount: 1,
+  kvCacheUsage: [
+    { t: 0, value: 0.1 },
+    { t: 10, value: 0.2 },
+  ],
+  prefixCacheHitRate: [],
+  queueDepth: [],
+  promptTokensBySource: {},
+  prefillTps: [],
+  decodeTps: [],
+  prefixCacheHitsTps: [],
+  hostKvCacheUsage: [],
+  kvCacheUsageByEngine: [
+    { engineLabel: '0', points: [{ t: 10, value: 0.2 }] },
+    { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
+  ],
+  metricSources: [],
 };
 
 let jp: typeof JsonProvider;
@@ -260,7 +285,8 @@ beforeAll(async () => {
     ]),
   );
 
-  // agentic_trace_replay: 100 = current JSONB, 200 = stale JSONB (force blob).
+  // agentic_trace_replay: 100 = current stats/timeline, 200 = stale stats/timeline
+  // plus directly-upgradable chart series.
   writeFileSync(
     join(dir, 'agentic_trace_replay.json'),
     JSON.stringify([
@@ -286,7 +312,7 @@ beforeAll(async () => {
         server_metrics_json_gz: byteaJson(SERVER_GZ),
         server_metrics_json_uncompressed_size: SERVER_JSON.length,
         aggregate_stats: { version: 1 }, // stale → force profile-blob fallback
-        chart_series: { version: 1 }, // stale → force server-blob fallback
+        chart_series: PREVIOUS_CHART_SERIES,
         request_timeline: { version: 1 }, // stale → force profile-blob fallback
         created_at: '2026-06-14T04:00:00Z',
       },
@@ -468,6 +494,21 @@ describe('trace server metrics mirror', () => {
     expect(m?.meta.hardware).toBe('h100');
     expect(m?.meta.run_url).toBe('https://github.com/x/runs/555/attempts/1');
     expect(m?.kvCacheUsage.length).toBeGreaterThan(0);
+  });
+
+  it('upgrades the previous chart series without recomputing the server blob', async () => {
+    const m = await jp.getTraceServerMetrics(2);
+
+    expect(m?.kvCacheUsageByEngine).toEqual([
+      {
+        engineLabel: '0',
+        points: [
+          { t: 0, value: 0.1 },
+          { t: 10, value: 0.2 },
+        ],
+      },
+    ]);
+    expect(m?.timeslicesCount).toBe(2);
   });
 
   it('returns null for an id without a trace_replay blob', async () => {

--- a/packages/db/src/json-provider.agentic-datasets.test.ts
+++ b/packages/db/src/json-provider.agentic-datasets.test.ts
@@ -5,7 +5,7 @@ import { gzipSync } from 'node:zlib';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { CHART_SERIES_VERSION, type ChartSeries } from './etl/compute-chart-series.js';
+import type { ChartSeries } from './etl/compute-chart-series.js';
 import { REQUEST_TIMELINE_VERSION } from './etl/compute-request-timeline.js';
 import { STATS_VERSION } from './queries/agentic-shared.js';
 import type * as JsonProvider from './json-provider.js';
@@ -132,7 +132,7 @@ const CURRENT_TIMELINE = {
 };
 
 const PREVIOUS_CHART_SERIES: ChartSeries = {
-  version: CHART_SERIES_VERSION - 1,
+  version: 12,
   startNs: 0,
   endNs: 11e9,
   durationS: 11,

--- a/packages/db/src/json-provider.agentic-datasets.test.ts
+++ b/packages/db/src/json-provider.agentic-datasets.test.ts
@@ -18,10 +18,9 @@ import type * as JsonProvider from './json-provider.js';
  * directory, point DUMP_DIR at it, and dynamically import the module once.
  *
  * Coverage per mirror:
- *  - fast path: precomputed JSONB (aggregate_stats / chart_series /
- *    request_timeline) at the CURRENT version is served verbatim.
- *  - blob fallback: a STALE version forces a re-derive from the (dumped) blob
- *    using the same pure helper the SQL path uses.
+ *  - fast path: precomputed JSONB is served directly when canonical/current.
+ *  - blob fallback: missing chart_series or stale aggregate/timeline payloads
+ *    force a re-derive using the same helper as the SQL path.
  *  - bytea round-trip: blobs are stored as {type:'Buffer',data:[…]} (what
  *    dump-db emits) and must gunzip cleanly.
  */
@@ -131,12 +130,11 @@ const CURRENT_TIMELINE = {
   ],
 };
 
-const PREVIOUS_CHART_SERIES: ChartSeries = {
-  version: 12,
+const STORED_CHART_SERIES: ChartSeries = {
   startNs: 0,
   endNs: 11e9,
   durationS: 11,
-  timeslicesCount: 1,
+  timeslicesCount: 2,
   kvCacheUsage: [
     { t: 0, value: 0.1 },
     { t: 10, value: 0.2 },
@@ -149,8 +147,13 @@ const PREVIOUS_CHART_SERIES: ChartSeries = {
   prefixCacheHitsTps: [],
   hostKvCacheUsage: [],
   kvCacheUsageByEngine: [
-    { engineLabel: '0', points: [{ t: 10, value: 0.2 }] },
-    { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
+    {
+      engineLabel: '0',
+      points: [
+        { t: 0, value: 0.1 },
+        { t: 10, value: 0.2 },
+      ],
+    },
   ],
   metricSources: [],
 };
@@ -285,8 +288,8 @@ beforeAll(async () => {
     ]),
   );
 
-  // agentic_trace_replay: 100 = current stats/timeline, 200 = stale stats/timeline
-  // plus directly-upgradable chart series.
+  // agentic_trace_replay: 100 = current stats/timeline, 200 = stale
+  // stats/timeline plus canonical chart series.
   writeFileSync(
     join(dir, 'agentic_trace_replay.json'),
     JSON.stringify([
@@ -312,7 +315,7 @@ beforeAll(async () => {
         server_metrics_json_gz: byteaJson(SERVER_GZ),
         server_metrics_json_uncompressed_size: SERVER_JSON.length,
         aggregate_stats: { version: 1 }, // stale → force profile-blob fallback
-        chart_series: PREVIOUS_CHART_SERIES,
+        chart_series: STORED_CHART_SERIES,
         request_timeline: { version: 1 }, // stale → force profile-blob fallback
         created_at: '2026-06-14T04:00:00Z',
       },
@@ -496,7 +499,7 @@ describe('trace server metrics mirror', () => {
     expect(m?.kvCacheUsage.length).toBeGreaterThan(0);
   });
 
-  it('upgrades the previous chart series without recomputing the server blob', async () => {
+  it('serves canonical stored chart series without recomputing the server blob', async () => {
     const m = await jp.getTraceServerMetrics(2);
 
     expect(m?.kvCacheUsageByEngine).toEqual([

--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -16,8 +16,8 @@ import { fileURLToPath } from 'node:url';
 // convention in etl/queries here), NOT the `.js` type-only style below — the
 // app bundler (Turbopack) resolves the former but not a `.js` on a value import.
 import {
-  CHART_SERIES_VERSION,
   computeChartSeries,
+  upgradeStoredChartSeries,
   type ChartSeries,
 } from './etl/compute-chart-series';
 import {
@@ -1112,9 +1112,10 @@ export function getRequestTimeline(benchmarkResultId: number): RequestTimeline |
 
 /**
  * Mirror of {@link import('./queries/trace-server-metrics.js').getTraceServerMetrics}.
- * Fast path: chart_series at CHART_SERIES_VERSION. Fallback: computeChartSeries
- * over the server blob (same helper as the SQL path). Returns null when the point
- * has no server_metrics blob, matching the SQL `has_blob` gate.
+ * Fast path: current or directly-upgradable chart_series. Fallback:
+ * computeChartSeries over the server blob (same helpers as the SQL path).
+ * Returns null when the point has no server_metrics blob, matching the SQL
+ * `has_blob` gate.
  */
 export async function getTraceServerMetrics(
   benchmarkResultId: number,
@@ -1174,7 +1175,8 @@ export async function getTraceServerMetrics(
   });
 
   const stored = tr.chart_series as (ChartSeries & { version?: number }) | null;
-  if (stored && Number(stored.version) === CHART_SERIES_VERSION) return merge(stored);
+  const storedSeries = stored ? upgradeStoredChartSeries(stored) : null;
+  if (storedSeries) return merge(storedSeries);
 
   const series = await computeChartSeries(bufferFromJson(tr.server_metrics_json_gz), {
     framework: c.framework,

--- a/packages/db/src/json-provider.ts
+++ b/packages/db/src/json-provider.ts
@@ -15,11 +15,7 @@ import { fileURLToPath } from 'node:url';
 // Runtime-value cross-module imports use extensionless relative paths (the
 // convention in etl/queries here), NOT the `.js` type-only style below — the
 // app bundler (Turbopack) resolves the former but not a `.js` on a value import.
-import {
-  computeChartSeries,
-  upgradeStoredChartSeries,
-  type ChartSeries,
-} from './etl/compute-chart-series';
+import { computeChartSeries, type ChartSeries } from './etl/compute-chart-series';
 import {
   REQUEST_TIMELINE_VERSION,
   computeRequestTimeline,
@@ -955,15 +951,13 @@ export function getServerLog(benchmarkResultId: number): string | null {
 // Agentic per-point mirrors (blob-backed; lazy trace_replay)
 //
 // Parity strategy: the SQL fast path reads the precomputed JSONB column
-// (aggregate_stats / chart_series / request_timeline) when its inner `version`
-// matches the current constant, else it re-derives from the gzipped blob using
+// (aggregate_stats / request_timeline) when its inner `version` matches the
+// current constant; chart_series is canonical DB data and is served whenever
+// present. Missing derived data is re-derived from the gzipped blob using
 // a shared pure helper (computeChartSeries / computeRequestTimeline /
 // extract*+percentilesOf / computeDerivedFromBlob). These mirrors take the
-// same two branches so dump mode yields the same payloads: serve the stored
-// JSONB at the current version, otherwise gunzip the dumped blob and reuse the
-// identical helper (the blobs ARE in the dump). Only if a stale/missing JSONB
-// row also has no usable blob do we fall through to null — exactly as the SQL
-// path does. No version-gated payload is ever served blindly.
+// same branches so dump mode yields the same payloads. Only if missing JSONB
+// also has no usable blob do we fall through to null, matching the SQL path.
 // ---------------------------------------------------------------------------
 
 function blankAggregate(id: number): AgenticAggregate {
@@ -1112,8 +1106,8 @@ export function getRequestTimeline(benchmarkResultId: number): RequestTimeline |
 
 /**
  * Mirror of {@link import('./queries/trace-server-metrics.js').getTraceServerMetrics}.
- * Fast path: current or directly-upgradable chart_series. Fallback:
- * computeChartSeries over the server blob (same helpers as the SQL path).
+ * Fast path: canonical stored chart_series. Fallback: computeChartSeries over
+ * the server blob (same helper as the SQL path).
  * Returns null when the point has no server_metrics blob, matching the SQL
  * `has_blob` gate.
  */
@@ -1174,9 +1168,8 @@ export async function getTraceServerMetrics(
     metricSources: series.metricSources ?? [],
   });
 
-  const stored = tr.chart_series as (ChartSeries & { version?: number }) | null;
-  const storedSeries = stored ? upgradeStoredChartSeries(stored) : null;
-  if (storedSeries) return merge(storedSeries);
+  const stored = tr.chart_series as ChartSeries | null;
+  if (stored) return merge(stored);
 
   const series = await computeChartSeries(bufferFromJson(tr.server_metrics_json_gz), {
     framework: c.framework,

--- a/packages/db/src/queries/agentic-shared.test.ts
+++ b/packages/db/src/queries/agentic-shared.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 describe('writeBackTraceReplayJsonb', () => {
   it('issues a fixed-column UPDATE binding the payload as ::jsonb + the id', () => {
     const { sql, calls } = mockSql();
-    writeBackTraceReplayJsonb(sql, 'chart_series', 870, { version: 12, foo: 'bar' });
+    writeBackTraceReplayJsonb(sql, 'chart_series', 870, { foo: 'bar' });
 
     expect(calls).toHaveLength(1);
     expect(calls[0]!.text).toContain('update agentic_trace_replay set chart_series');
@@ -37,7 +37,7 @@ describe('writeBackTraceReplayJsonb', () => {
     // The payload OBJECT is bound directly (not JSON.stringify'd — that would
     // double-encode into a JSONB string), followed by the id. Only the value +
     // id are interpolated; the column name is fully static in the SQL text.
-    expect(calls[0]!.values).toEqual([{ version: 12, foo: 'bar' }, 870]);
+    expect(calls[0]!.values).toEqual([{ foo: 'bar' }, 870]);
   });
 
   it('targets the requested column verbatim (no cross-talk between columns)', () => {

--- a/packages/db/src/queries/trace-server-metrics.test.ts
+++ b/packages/db/src/queries/trace-server-metrics.test.ts
@@ -2,7 +2,11 @@ import { gzipSync } from 'node:zlib';
 
 import { describe, expect, it } from 'vitest';
 
-import { CHART_SERIES_VERSION, type ChartSeries } from '../etl/compute-chart-series';
+import {
+  CHART_SERIES_VERSION,
+  upgradeStoredChartSeries,
+  type ChartSeries,
+} from '../etl/compute-chart-series';
 import type { DbClient } from '../connection.js';
 
 import { getTraceServerMetrics } from './trace-server-metrics';
@@ -27,10 +31,10 @@ function currentSeries(): ChartSeries {
   };
 }
 
-function previousSeries(): ChartSeries {
+function previousSeries(version = 13): ChartSeries {
   return {
     ...currentSeries(),
-    version: CHART_SERIES_VERSION - 1,
+    version,
     timeslicesCount: 1,
     kvCacheUsageByEngine: [
       { engineLabel: '0', points: [{ t: 10, value: 0.2 }] },
@@ -86,24 +90,37 @@ describe('getTraceServerMetrics', () => {
     expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
   });
 
-  it('upgrades the previous chart series without selecting the raw blob', async () => {
-    const { sql, calls } = mockSql([[metaRow({ chart_series: previousSeries() })], []]);
+  it.each([12, 13])(
+    'upgrades an unambiguous v%s chart series without selecting the raw blob',
+    async (version) => {
+      const { sql, calls } = mockSql([[metaRow({ chart_series: previousSeries(version) })], []]);
 
-    const result = await getTraceServerMetrics(sql, 42);
+      const result = await getTraceServerMetrics(sql, 42);
 
-    expect(result?.kvCacheUsageByEngine).toEqual([
-      {
-        engineLabel: '0',
-        points: [
-          { t: 0, value: 0.1 },
-          { t: 10, value: 0.2 },
-        ],
-      },
-    ]);
-    expect(result?.timeslicesCount).toBe(2);
-    expect(calls).toHaveLength(2);
-    expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
-    expect(calls[1]).toContain('update agentic_trace_replay set chart_series');
+      expect(result?.kvCacheUsageByEngine).toEqual([
+        {
+          engineLabel: '0',
+          points: [
+            { t: 0, value: 0.1 },
+            { t: 10, value: 0.2 },
+          ],
+        },
+      ]);
+      expect(result?.timeslicesCount).toBe(2);
+      expect(calls).toHaveLength(2);
+      expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
+      expect(calls[1]).toContain('update agentic_trace_replay set chart_series');
+    },
+  );
+
+  it('rejects v12 labels whose time ranges overlap', () => {
+    const ambiguous = previousSeries(12);
+    ambiguous.kvCacheUsageByEngine = [
+      { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
+      { engineLabel: '0', points: [{ t: 0, value: 0.2 }] },
+    ];
+
+    expect(upgradeStoredChartSeries(ambiguous)).toBeNull();
   });
 
   it('fetches and computes the raw blob only when chart_series is stale', async () => {
@@ -118,7 +135,7 @@ describe('getTraceServerMetrics', () => {
         }),
       ),
     );
-    const stale = { ...currentSeries(), version: CHART_SERIES_VERSION - 2 };
+    const stale = { ...currentSeries(), version: 11 };
     const { sql, calls } = mockSql([[metaRow({ chart_series: stale })], [{ blob: raw }]]);
 
     const result = await getTraceServerMetrics(sql, 42);

--- a/packages/db/src/queries/trace-server-metrics.test.ts
+++ b/packages/db/src/queries/trace-server-metrics.test.ts
@@ -2,18 +2,13 @@ import { gzipSync } from 'node:zlib';
 
 import { describe, expect, it } from 'vitest';
 
-import {
-  CHART_SERIES_VERSION,
-  upgradeStoredChartSeries,
-  type ChartSeries,
-} from '../etl/compute-chart-series';
+import type { ChartSeries } from '../etl/compute-chart-series';
 import type { DbClient } from '../connection.js';
 
 import { getTraceServerMetrics } from './trace-server-metrics';
 
 function currentSeries(): ChartSeries {
   return {
-    version: CHART_SERIES_VERSION,
     startNs: 0,
     endNs: 1e9,
     durationS: 1,
@@ -28,18 +23,6 @@ function currentSeries(): ChartSeries {
     hostKvCacheUsage: [],
     kvCacheUsageByEngine: [],
     metricSources: [],
-  };
-}
-
-function previousSeries(version = 13): ChartSeries {
-  return {
-    ...currentSeries(),
-    version,
-    timeslicesCount: 1,
-    kvCacheUsageByEngine: [
-      { engineLabel: '0', points: [{ t: 10, value: 0.2 }] },
-      { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
-    ],
   };
 }
 
@@ -90,40 +73,7 @@ describe('getTraceServerMetrics', () => {
     expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
   });
 
-  it.each([12, 13])(
-    'upgrades an unambiguous v%s chart series without selecting the raw blob',
-    async (version) => {
-      const { sql, calls } = mockSql([[metaRow({ chart_series: previousSeries(version) })], []]);
-
-      const result = await getTraceServerMetrics(sql, 42);
-
-      expect(result?.kvCacheUsageByEngine).toEqual([
-        {
-          engineLabel: '0',
-          points: [
-            { t: 0, value: 0.1 },
-            { t: 10, value: 0.2 },
-          ],
-        },
-      ]);
-      expect(result?.timeslicesCount).toBe(2);
-      expect(calls).toHaveLength(2);
-      expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
-      expect(calls[1]).toContain('update agentic_trace_replay set chart_series');
-    },
-  );
-
-  it('rejects v12 labels whose time ranges overlap', () => {
-    const ambiguous = previousSeries(12);
-    ambiguous.kvCacheUsageByEngine = [
-      { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
-      { engineLabel: '0', points: [{ t: 0, value: 0.2 }] },
-    ];
-
-    expect(upgradeStoredChartSeries(ambiguous)).toBeNull();
-  });
-
-  it('fetches and computes the raw blob only when chart_series is stale', async () => {
+  it('fetches and computes the raw blob only when chart_series is missing', async () => {
     const raw = gzipSync(
       Buffer.from(
         JSON.stringify({
@@ -135,14 +85,13 @@ describe('getTraceServerMetrics', () => {
         }),
       ),
     );
-    const stale = { ...currentSeries(), version: 11 };
-    const { sql, calls } = mockSql([[metaRow({ chart_series: stale })], [{ blob: raw }]]);
+    const { sql, calls } = mockSql([[metaRow({ chart_series: null })], [{ blob: raw }]]);
 
     const result = await getTraceServerMetrics(sql, 42);
 
     expect(result?.prefillTps).toEqual([{ t: 0, value: 321 }]);
     // 3 calls: meta read, blob read, then the fire-and-forget chart_series
-    // write-back that self-heals the stale precomputed series.
+    // write-back that self-heals the missing precomputed series.
     expect(calls).toHaveLength(3);
     expect(calls[1]).toContain('server_metrics_json_gz as blob');
     expect(calls[2]).toContain('update agentic_trace_replay set chart_series');

--- a/packages/db/src/queries/trace-server-metrics.test.ts
+++ b/packages/db/src/queries/trace-server-metrics.test.ts
@@ -27,6 +27,18 @@ function currentSeries(): ChartSeries {
   };
 }
 
+function previousSeries(): ChartSeries {
+  return {
+    ...currentSeries(),
+    version: CHART_SERIES_VERSION - 1,
+    timeslicesCount: 1,
+    kvCacheUsageByEngine: [
+      { engineLabel: '0', points: [{ t: 10, value: 0.2 }] },
+      { engineLabel: '0', points: [{ t: 0, value: 0.1 }] },
+    ],
+  };
+}
+
 function metaRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 42,
@@ -74,6 +86,26 @@ describe('getTraceServerMetrics', () => {
     expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
   });
 
+  it('upgrades the previous chart series without selecting the raw blob', async () => {
+    const { sql, calls } = mockSql([[metaRow({ chart_series: previousSeries() })], []]);
+
+    const result = await getTraceServerMetrics(sql, 42);
+
+    expect(result?.kvCacheUsageByEngine).toEqual([
+      {
+        engineLabel: '0',
+        points: [
+          { t: 0, value: 0.1 },
+          { t: 10, value: 0.2 },
+        ],
+      },
+    ]);
+    expect(result?.timeslicesCount).toBe(2);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
+    expect(calls[1]).toContain('update agentic_trace_replay set chart_series');
+  });
+
   it('fetches and computes the raw blob only when chart_series is stale', async () => {
     const raw = gzipSync(
       Buffer.from(
@@ -86,7 +118,7 @@ describe('getTraceServerMetrics', () => {
         }),
       ),
     );
-    const stale = { ...currentSeries(), version: CHART_SERIES_VERSION - 1 };
+    const stale = { ...currentSeries(), version: CHART_SERIES_VERSION - 2 };
     const { sql, calls } = mockSql([[metaRow({ chart_series: stale })], [{ blob: raw }]]);
 
     const result = await getTraceServerMetrics(sql, 42);

--- a/packages/db/src/queries/trace-server-metrics.ts
+++ b/packages/db/src/queries/trace-server-metrics.ts
@@ -6,13 +6,13 @@
  * Backed by `agentic_trace_replay.chart_series` (pre-computed at ingest
  * time, see `etl/compute-chart-series.ts`). The fast path is a single SQL
  * row read; the slow path re-computes from `server_metrics_json_gz` and is
- * only taken when the column is missing or the stored
- * `CHART_SERIES_VERSION` is stale (the backfill script should drain that).
+ * only taken when the column is missing or too old for an in-memory upgrade
+ * (the backfill script should drain that).
  */
 
 import {
-  CHART_SERIES_VERSION,
   computeChartSeries,
+  upgradeStoredChartSeries,
   type ChartSeries,
   type MetricSourceSeries,
   type QueueDepthPoint,
@@ -183,9 +183,15 @@ export async function getTraceServerMetrics(
   const kvCachePoolTokens =
     row.kv_cache_pool_tokens === null ? null : Number(row.kv_cache_pool_tokens);
 
-  // Fast path: pre-computed chart_series at the current version.
-  if (row.chart_series && Number(row.chart_series.version) === CHART_SERIES_VERSION) {
-    return merge(meta, row.chart_series, kvCachePoolTokens);
+  // Fast path: serve current chart_series directly, or upgrade v13 → v14 from
+  // the stored points. Reopening some raw blobs exceeds Vercel function memory,
+  // while this representation already contains everything v14 needs.
+  const storedSeries = row.chart_series ? upgradeStoredChartSeries(row.chart_series) : null;
+  if (storedSeries) {
+    if (storedSeries !== row.chart_series) {
+      writeBackTraceReplayJsonb(sql, 'chart_series', row.trace_replay_id, storedSeries);
+    }
+    return merge(meta, storedSeries, kvCachePoolTokens);
   }
 
   // Slow path only: fetch the large raw blob after establishing that the

--- a/packages/db/src/queries/trace-server-metrics.ts
+++ b/packages/db/src/queries/trace-server-metrics.ts
@@ -6,13 +6,11 @@
  * Backed by `agentic_trace_replay.chart_series` (pre-computed at ingest
  * time, see `etl/compute-chart-series.ts`). The fast path is a single SQL
  * row read; the slow path re-computes from `server_metrics_json_gz` and is
- * only taken when the column is missing or too old for an in-memory upgrade
- * (the backfill script should drain that).
+ * only taken when the canonical DB column is missing.
  */
 
 import {
   computeChartSeries,
-  upgradeStoredChartSeries,
   type ChartSeries,
   type MetricSourceSeries,
   type QueueDepthPoint,
@@ -183,15 +181,10 @@ export async function getTraceServerMetrics(
   const kvCachePoolTokens =
     row.kv_cache_pool_tokens === null ? null : Number(row.kv_cache_pool_tokens);
 
-  // Fast path: serve current chart_series directly, or upgrade v13 → v14 from
-  // the stored points. Reopening some raw blobs exceeds Vercel function memory,
-  // while this representation already contains everything v14 needs.
-  const storedSeries = row.chart_series ? upgradeStoredChartSeries(row.chart_series) : null;
-  if (storedSeries) {
-    if (storedSeries !== row.chart_series) {
-      writeBackTraceReplayJsonb(sql, 'chart_series', row.trace_replay_id, storedSeries);
-    }
-    return merge(meta, storedSeries, kvCachePoolTokens);
+  // chart_series is canonicalized during ingest/backfill. The request path
+  // deliberately has no format-version or migration logic.
+  if (row.chart_series) {
+    return merge(meta, row.chart_series, kvCachePoolTokens);
   }
 
   // Slow path only: fetch the large raw blob after establishing that the
@@ -216,9 +209,8 @@ export async function getTraceServerMetrics(
   if (!series) return null;
 
   // Self-heal the stored chart_series so the next request takes the fast path
-  // instead of re-decompressing this (tens-of-MB) blob. `series` is complete
-  // and stamped at CHART_SERIES_VERSION here; fire-and-forget and best-effort
-  // (no-ops on a read-only replica). trace_replay_id is non-null on this path.
+  // instead of re-decompressing this (tens-of-MB) blob. Fire-and-forget and
+  // best-effort (no-ops on a read-only replica). trace_replay_id is non-null.
   writeBackTraceReplayJsonb(sql, 'chart_series', row.trace_replay_id, series);
 
   return merge(meta, series, kvCachePoolTokens);


### PR DESCRIPTION
## Summary

- Pair matching warm-up and profiling server-metric series by stable endpoint and labels before building chart data, producing one continuous series per DP rank.
- Filter rank series that have no points in the selected phase so stale cached/dump payloads cannot render empty duplicate legend entries.
- Treat `agentic_trace_replay.chart_series` as canonical materialized DB data and remove all chart-series format versioning from the application:
  - no `CHART_SERIES_VERSION`
  - no embedded `version` field on new payloads
  - no request-time v12/v13 upgrader
  - no version-derived trace-server-metrics cache key
- Make extraction changes an explicit operational workflow: backfill every maintained Neon branch, then purge Blob and Next.js caches through `/api/v1/invalidate`.
- Update the chart-series backfill so missing rows are filled by default and intentional extraction changes use `--force`.

## Root cause

`mergePhaseMetrics()` concatenated the warm-up and profiling `series` arrays. A run with eight DP ranks therefore produced 16 entries (`0,0,1,1,…,7,7`). Phase slicing removed points from the inactive half but retained the empty series objects, so the chart rendered duplicate legend entries.

The initial attempted fix bumped the stored chart-series version. That exposed a second problem: run `436103` still had a valid but older materialized row, so the preview rejected it and reopened the 18.8 MB compressed raw metrics blob. Decompression and parsing took 122 seconds and could exhaust Vercel function memory.

## Why remove chart-series versioning

`chart_series` is not an external interchange format. It is a materialized DB representation fully controlled in the three maintained Neon branches: `main`, `staging`, and `private`. Keeping historical format branches in every API request made a bounded DB migration permanent application complexity.

The canonical-data model is simpler:

1. Ingest writes the current representation.
2. API readers trust a non-null stored row.
3. Missing rows alone use the raw-blob fallback and best-effort write-back.
4. Extraction changes use an explicit expand/migrate/contract backfill.
5. The existing invalidate endpoint purges both Blob storage and the Next.js data cache.

This also avoids accidentally sending a large historical blob through a latency- and memory-sensitive request merely because a metadata integer changed.

## Database standardization

A read-only preflight checked every stored row across all three branches. No duplicate same-label series had overlapping time ranges, including nested `metricSources`, so all affected rows were directly recoverable without opening raw blobs.

- `main`: 153 rows normalized; duplicate-row count is now 0
- `staging`: 153 rows normalized; duplicate-row count is now 0
- `private`: already canonical; duplicate-row count was and remains 0
- Run `436103`: 16 entries became 8 ranks (`0`–`7`), each retaining all 5,182 points
- Production API/Blob cache was purged and warmed successfully

The old numeric `version` key remains temporarily on existing DB JSONB objects only for deployment compatibility: the currently deployed production reader is still v12 and would otherwise reject those rows and reopen raw blobs. The code in this PR ignores extra legacy metadata and emits no version on new rows. After the versionless reader reaches each environment, the final contract step is:

```sql
update agentic_trace_replay
set chart_series = chart_series - 'version'
where chart_series ? 'version';
```

This ordering removes the field without creating a production fallback window. No version logic remains in the merged application.

## Impact

Warm-up and Profile views show one line per DP rank. Existing canonical materialized rows load directly, avoiding request-time raw decompression. The cluster-average calculation is unchanged.

Unofficial-run overlays do not apply to this per-point detail route because it requires a persisted benchmark-result ID; the shared inference overlay rendering path is unchanged.

## Verification

- Live production API for `436103`: HTTP 200, 0.21 s TTFB / 0.37 s total
- Live response: exactly eight labels (`0`–`7`), 5,182 points per rank
- Neon verification: zero duplicated rank rows on `main`, `staging`, and `private`
- Full integrity audit: all 456 stored chart rows and 20,966,919 chart points scanned; zero malformed arrays/points, missing labels, duplicate labels/timestamps, empty rank series, or out-of-order timestamps
- All 456 compressed raw metric blobs remain present (6,214,006,301 bytes total across the three branches); no chart row is detached from its source blob
- Cache Refresh workflow: passed (purge and warm-up)
- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm test:unit` — 2,994 tests passed across app, DB, constants, and MCP workspaces

## 中文说明

- 在生成图表数据前，按稳定的 endpoint 与 labels 配对 warm-up 和 profiling 阶段中对应的服务端指标序列，使每个 DP rank 只生成一条连续序列。
- 过滤当前阶段内没有数据点的 rank 序列，避免旧缓存或 dump payload 继续渲染空的重复图例项。
- 将 `agentic_trace_replay.chart_series` 作为数据库中的规范化物化数据，并从应用中彻底移除图表序列格式版本机制：
  - 删除 `CHART_SERIES_VERSION`
  - 新 payload 不再写入 `version` 字段
  - 删除请求链路中的 v12/v13 升级逻辑
  - trace-server-metrics 缓存键不再由版本号派生
- 后续提取逻辑变更采用显式运维流程：回填所有维护中的 Neon 分支，再通过 `/api/v1/invalidate` 清理 Blob 与 Next.js 缓存。
- 调整图表序列回填脚本：默认仅补齐缺失行；提取逻辑发生变化时显式使用 `--force`。

## 根因

`mergePhaseMetrics()` 直接拼接 warm-up 与 profiling 的 `series` 数组。包含 8 个 DP rank 的运行因此产生 16 个条目（`0,0,1,1,…,7,7`）。阶段切片虽然会移除非当前阶段的数据点，却保留空序列对象，最终导致图表渲染重复图例。

最初的修复尝试升级了已存储图表序列的版本号，但这又暴露了第二个问题：运行 `436103` 已有可用但版本较旧的物化数据，预览环境却将其拒绝并重新读取 18.8 MB 的压缩原始指标 Blob。解压与解析耗时 122 秒，并可能耗尽 Vercel 函数内存。

## 为什么移除图表序列版本机制

`chart_series` 并不是对外交换格式，而是由我们完全控制的数据库物化数据。目前只需维护三个 Neon 分支：`main`、`staging` 和 `private`。为了有限范围的数据库迁移，在每次 API 请求中永久保留历史格式分支，会造成不必要的长期复杂度。

规范化数据模型更直接：

1. ingest 写入当前规范结构。
2. API 直接信任非空的已存储数据。
3. 仅在数据缺失时读取原始 Blob，并尽力回写。
4. 提取逻辑变化时采用显式的 expand/migrate/contract 回填流程。
5. 现有失效接口同时清理 Blob storage 与 Next.js data cache。

这样也能避免仅因一个元数据整数发生变化，就在延迟和内存敏感的请求链路中重新处理大型历史 Blob。

## 数据库规范化

只读预检覆盖了三个分支中的全部已存储数据。顶层及嵌套 `metricSources` 中均不存在时间范围重叠的同名重复序列，因此所有受影响行都可以直接修复，无需打开原始 Blob。

- `main`：规范化 153 行，重复行数现为 0
- `staging`：规范化 153 行，重复行数现为 0
- `private`：原本已符合规范，重复行数始终为 0
- 运行 `436103`：16 个条目合并为 8 个 rank（`0`–`7`），每个 rank 均保留全部 5,182 个数据点
- 已成功清理并预热生产 API/Blob 缓存

现有 DB JSONB 对象暂时保留旧的数字 `version` key，仅用于安全发布：当前生产 reader 仍是 v12，若提前删除该 key，它会拒绝这些行并重新读取原始 Blob。本 PR 的代码会忽略额外的旧元数据，新写入的数据也不再包含版本号。待无版本 reader 部署到对应环境后，执行上方 SQL 作为最终 contract 步骤。

这一顺序可以在不制造生产回退窗口的情况下删除字段。合并后的应用代码中不会保留任何图表序列版本逻辑。

## 影响

Warm-up 和 Profile 视图现在每个 DP rank 只显示一条曲线。已有规范化物化数据会被直接读取，避免在请求链路中解压原始数据。集群平均值计算保持不变。

非官方运行（unofficial run）overlay 不适用于此详情路由，因为该页面依赖已持久化的 benchmark-result ID；共享 inference overlay 渲染路径未作修改。

## 验证

- 运行 `436103` 的线上 API：HTTP 200，TTFB 0.21 秒，总耗时 0.37 秒
- 线上响应仅包含 8 个标签（`0`–`7`），每个 rank 5,182 个数据点
- Neon 校验：`main`、`staging` 和 `private` 的重复 rank 行数均为 0
- 完整性审计：扫描全部 456 行已存储图表数据及 20,966,919 个图表数据点；未发现 malformed array/point、标签缺失、标签或时间戳重复、空 rank 序列或时间戳乱序
- 三个分支中的 456 个压缩原始指标 Blob 均完整保留（合计 6,214,006,301 bytes）；所有图表数据仍与其来源 Blob 正确关联
- Cache Refresh workflow：清理与预热均通过
- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm test:unit` — app、DB、constants 和 MCP 工作区共 2,994 项测试全部通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agentic chart ETL, API read paths, and caching for a latency-sensitive route; incorrect rollout could still serve stale Blob data or trigger expensive blob recomputation on missing rows.
> 
> **Overview**
> **Fixes duplicate DP-rank KV cache legends** on the agentic detail page when switching between warmup and profiling. Warmup and profiling server-metric series are now **paired by stable endpoint/labels** in `mergePhaseMetrics()` so each rank is one continuous series instead of two concatenated entries, and **phase slicing drops per-engine series with no points** in the selected window.
> 
> **Treats `agentic_trace_replay.chart_series` as canonical materialized data**: removes `CHART_SERIES_VERSION`, embedded `version` on new payloads, and stale-row rejection on the API/SQL/json-provider paths. Any non-null stored row is served directly; the large `server_metrics_json_gz` blob is only read when the column is missing. The trace-server-metrics Blob cache uses a **stable key** (`trace-server-metrics`), with extraction changes expected to use **`db:backfill-chart-series`** (default missing rows, `--force` for full recompute) plus **`/api/v1/invalidate`**. Docs describe this operational rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3420eb4528f8635af4675faf3d7e21306b72e42f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->