### PR TITLE
fix(agentic): Align changelog configs with legend / 统一 Agentic 变更记录与图例配置名称

### DIFF
--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -84,6 +84,7 @@ import {
   renderKnownIssueAnnotations,
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchesQuickFilters } from '@/components/inference/utils/quickFilters';
+import { changelogConfigToHwKey } from '@/components/inference/utils/changelogFormatters';
 
 // Greedy label-collision avoidance.
 // Each candidate is the y-position of the FIRST baseline (relative to point
@@ -465,16 +466,17 @@ const ScatterGraph = React.memo(
 
     // --- Changelog ---
     const changelog = availableRuns ? availableRuns[selectedRunId]?.changelog || null : null;
-    const highlightConfigSuffixes = useMemo(() => {
+    const highlightedHwKeys = useMemo(() => {
       if (availableRuns) {
         const cl = availableRuns[selectedRunId]?.changelog;
         if (cl) {
-          const suffixes = cl.entries.flatMap((entry: any) =>
+          const hwKeys = cl.entries.flatMap((entry: any) =>
             (entry.config_keys ?? entry['config-keys'] ?? [])
               .filter((key: string) => selectedPrecisions.includes(key.split('-')[1]))
-              .map((key: string) => key.split('-').slice(2).join('-')),
+              .map(changelogConfigToHwKey)
+              .filter((key: string | null): key is string => key !== null),
           );
-          return new Set(suffixes);
+          return new Set(hwKeys);
         }
       }
       return new Set<string>();
@@ -2675,7 +2677,7 @@ const ScatterGraph = React.memo(
                     label: getDisplayLabel(hwConfig),
                     color: resolveColor(key),
                     title: hwConfig.gpu,
-                    isHighlighted: highlightConfigSuffixes.has(key.replaceAll('_', '-')),
+                    isHighlighted: highlightedHwKeys.has(key),
                     hw: key,
                     isActive: showAllHardwareTypes ? true : effectiveOfficialHwTypes.has(key),
                     onClick: showAllHardwareTypes

--- a/packages/app/src/components/inference/utils/changelogFormatters.test.ts
+++ b/packages/app/src/components/inference/utils/changelogFormatters.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { configKeyMatchesHwKey, formatConfigKeys } from './changelogFormatters';
+import {
+  changelogConfigToHwKey,
+  configKeyMatchesHwKey,
+  formatConfigKeys,
+} from './changelogFormatters';
 
 describe('formatConfigKeys', () => {
   it('formats a standard config key', () => {
@@ -43,6 +47,26 @@ describe('formatConfigKeys', () => {
     expect(result).toContain('TRTLLM');
     expect(result).toContain('FP4');
   });
+
+  it('uses the legend framework label for an agentic HiCache config', () => {
+    expect(formatConfigKeys('dsv4-fp4-mi355x-mori-sglang-agentic-hicache')).toBe(
+      'MI355X (MoRI SGLang) DeepSeek-V4-Pro FP4',
+    );
+  });
+});
+
+describe('changelogConfigToHwKey', () => {
+  it('strips agentic scenario and cache-backend suffixes from the legend identity', () => {
+    expect(changelogConfigToHwKey('dsv4-fp4-mi355x-mori-sglang-agentic-hicache')).toBe(
+      'mi355x_mori-sglang',
+    );
+  });
+
+  it('keeps a trailing MTP spec method while dropping agentic metadata', () => {
+    expect(changelogConfigToHwKey('dsv4-fp4-mi355x-sglang-agentic-hicache-mtp')).toBe(
+      'mi355x_sglang_mtp',
+    );
+  });
 });
 
 describe('configKeyMatchesHwKey', () => {
@@ -66,6 +90,12 @@ describe('configKeyMatchesHwKey', () => {
 
   it('matches old sglang-disagg keys to mori-sglang hwKey', () => {
     expect(configKeyMatchesHwKey('dsr1-fp8-mi355x-sglang-disagg', 'mi355x_mori-sglang')).toBe(true);
+  });
+
+  it('matches an agentic HiCache changelog key to the framework-only legend key', () => {
+    expect(
+      configKeyMatchesHwKey('dsv4-fp4-mi355x-mori-sglang-agentic-hicache', 'mi355x_mori-sglang'),
+    ).toBe(true);
   });
 
   it('matches sglang framework', () => {

--- a/packages/app/src/components/inference/utils/changelogFormatters.tsx
+++ b/packages/app/src/components/inference/utils/changelogFormatters.tsx
@@ -1,10 +1,40 @@
 import {
-  resolveFrameworkAliasesInString,
+  FRAMEWORK_ALIASES,
+  FW_REGISTRY,
+  resolveFrameworkAlias,
   resolveFrameworkPartLabel,
 } from '@semianalysisai/inferencex-constants';
 
 import { type Precision, MODEL_PREFIX_MAPPING, getPrecisionLabel } from '@/lib/data-mappings';
-import { getFrameworkLabel } from '@/lib/utils';
+import { getHardwareConfig } from '@/lib/constants';
+import { getDisplayLabel } from '@/lib/utils';
+
+const CHANGELOG_FRAMEWORK_KEYS = [
+  ...Object.keys(FW_REGISTRY),
+  ...Object.keys(FRAMEWORK_ALIASES),
+].toSorted((a, b) => b.length - a.length);
+
+/**
+ * Convert a changelog config key into the canonical hardware key used by chart
+ * points and the legend. Agentic config keys append scenario details such as
+ * `agentic`, `hicache`, and `pcp` after the serving framework; those are not
+ * framework labels and must not become part of the legend identity.
+ */
+export function changelogConfigToHwKey(configKey: string): string | null {
+  const parts = configKey.toLowerCase().split('-');
+  const gpu = parts[2];
+  const remainder = parts.slice(3).join('-');
+  if (!gpu || !remainder) return null;
+
+  const framework = CHANGELOG_FRAMEWORK_KEYS.find(
+    (candidate) => remainder === candidate || remainder.startsWith(`${candidate}-`),
+  );
+  if (!framework) return null;
+
+  const trailingParts = remainder.slice(framework.length).split('-').filter(Boolean);
+  const specSuffix = trailingParts.includes('mtp') ? '_mtp' : '';
+  return `${gpu}_${resolveFrameworkAlias(framework)}${specSuffix}`;
+}
 
 export function formatChangelogDescription(desc: string | string[]) {
   if (typeof desc === 'string') {
@@ -33,23 +63,26 @@ export function formatChangelogDescription(desc: string | string[]) {
  * Normalizes both to hyphen-separated form for comparison.
  */
 export function configKeyMatchesHwKey(configKey: string, hwKey: string): boolean {
-  const gpuAndFramework = resolveFrameworkAliasesInString(configKey.split('-').slice(2).join('-'));
-  const normalizedHwKey = hwKey.replaceAll('_', '-');
-  return gpuAndFramework === normalizedHwKey;
+  return changelogConfigToHwKey(configKey) === hwKey;
 }
 
 export function formatConfigKeys(key: string) {
   const parts = key.split('-');
   const model = parts[0];
   const precision = parts[1];
-  const gpu = parts[2];
-  const framework = parts.slice(3).join('-');
-  // Strip -mtp suffix before lookup; MTP is shown separately
-  const isMtp = framework.endsWith('-mtp');
-  const baseFramework = isMtp ? framework.slice(0, -4) : framework;
-  const baseLabel = getFrameworkLabel(baseFramework);
-  // M3's `mtp` spec token renders as "EAGLE"; every other model keeps "MTP".
-  const mtpLabel = resolveFrameworkPartLabel(MODEL_PREFIX_MAPPING[model], 'mtp');
-  const frameworkLabel = isMtp ? `${baseLabel}, ${mtpLabel}` : baseLabel;
-  return `${gpu.toUpperCase()} (${frameworkLabel}) ${MODEL_PREFIX_MAPPING[model]} ${getPrecisionLabel(precision as Precision)}`;
+  const modelLabel = MODEL_PREFIX_MAPPING[model];
+  const hwKey = changelogConfigToHwKey(key);
+
+  if (!hwKey) {
+    const gpu = parts[2]?.toUpperCase() ?? '';
+    const framework = parts.slice(3).join('-');
+    const frameworkLabel = resolveFrameworkPartLabel(modelLabel, framework);
+    return `${gpu} (${frameworkLabel}) ${modelLabel} ${getPrecisionLabel(precision as Precision)}`;
+  }
+
+  // Use the same hardware entry builder and display combiner as the legend so
+  // aliases, compound framework names, and model-specific spec labels cannot
+  // drift between the two surfaces.
+  const hardwareLabel = getDisplayLabel(getHardwareConfig(hwKey, modelLabel));
+  return `${hardwareLabel} ${modelLabel} ${getPrecisionLabel(precision as Precision)}`;
 }


### PR DESCRIPTION
## Summary

- Parse changelog config keys into the same canonical hardware key used by chart points and the legend.
- Render “Updated Configs” with the legend’s shared hardware-label builder.
- Use that canonical key for modified-config highlighting, restoring the red legend state for agentic configs.
- Add regression coverage for the exact `dsv4-fp4-mi355x-mori-sglang-agentic-hicache` shape.

## Root cause

Agentic changelog keys append scenario metadata after the framework, for example `agentic-hicache`. The changelog formatter treated every suffix after the GPU as part of the framework, producing “MoRI SGLang Agentic HiCache”. The highlight path compared the same unparsed suffix against the legend’s canonical `mi355x_mori-sglang` key, so it never matched.

The shared parser now identifies the longest registered framework/alias, preserves a real `mtp` spec suffix, and discards scenario-only metadata before calling the same `getHardwareConfig()` and `getDisplayLabel()` path as the legend.

## Impact

The changelog now shows `MI355X (MoRI SGLang) DeepSeek-V4-Pro FP4`, matching the legend, and the corresponding agentic legend entry is highlighted red when modified. Existing fixed-sequence changelog behavior remains intact.

## Verification

- 2,544 app unit tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

## 中文说明

- 将变更记录中的 config key 解析为图表数据点和图例共用的规范化硬件 key。
- “Updated Configs” 改用图例的统一硬件名称生成逻辑。
- 修改配置的红色高亮也基于同一规范化 key，修复 Agentic 配置无法高亮的问题。
- 为 `dsv4-fp4-mi355x-mori-sglang-agentic-hicache` 这一实际触发格式新增回归测试。

## 根因

Agentic 变更记录的 config key 会在 framework 后附加 `agentic-hicache` 等场景元数据。原 formatter 将 GPU 之后的所有字段都视为 framework，因此错误显示为 “MoRI SGLang Agentic HiCache”；高亮逻辑也拿这段未解析的后缀与图例中的规范 key `mi355x_mori-sglang` 比较，导致永远无法匹配。

新的共享解析逻辑会匹配最长的已注册 framework 或 alias，保留真正的 `mtp` spec 后缀，并在调用图例同款的 `getHardwareConfig()` 与 `getDisplayLabel()` 前移除仅属于场景的元数据。

## 影响

变更记录现在显示 `MI355X (MoRI SGLang) DeepSeek-V4-Pro FP4`，与图例完全一致；对应 Agentic 图例项在被修改时也会恢复红色高亮。现有固定序列长度变更记录行为保持不变。

## 验证

- 2,544 项 app 单元测试通过
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Inference UI changelog formatting and legend highlighting only; behavior is covered by new unit tests with no auth or data-path changes.
> 
> **Overview**
> **Agentic changelog config keys** (e.g. `…-mori-sglang-agentic-hicache`) are no longer treated as part of the framework name. A shared **`changelogConfigToHwKey`** parser matches the longest registered framework/alias, keeps only a real **`mtp`** spec suffix, and drops scenario-only tokens before building the same canonical **`hwKey`** the chart and legend use.
> 
> **Changelog display and highlighting** now share that path: **`formatConfigKeys`** uses **`getHardwareConfig`** / **`getDisplayLabel`** like the legend, and **`ScatterGraph`** highlights modified legend entries with **`highlightedHwKeys.has(key)`** instead of comparing raw config suffixes. **`configKeyMatchesHwKey`** delegates to the same parser (comparison changelog filtering benefits too).
> 
> Regression tests cover agentic HiCache formatting, key normalization, and matching against **`mi355x_mori-sglang`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6abb99779e0bebdba39dfa1a40c07bb35ddd970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->