### PR TITLE
feat(agentic): Agent X cosmetic improvements / Agent X 外观改进

### DIFF
--- a/packages/app/cypress/e2e/agentic-point-time-series.cy.ts
+++ b/packages/app/cypress/e2e/agentic-point-time-series.cy.ts
@@ -222,7 +222,9 @@ const pointMeta = {
   date: '2026-06-23',
   run_url: null,
   server_gpu_cache_hit_rate: 0.5,
-  server_cpu_cache_hit_rate: null,
+  // Reproduces historical rows that retained a CPU hit metric after offload
+  // was disabled. The agentic point summary must suppress this stale value.
+  server_cpu_cache_hit_rate: 0.42,
 };
 
 const sourceSeries = (source: Record<string, unknown>, prompt: number, generation: number) => ({
@@ -297,6 +299,9 @@ describe('Agentic point orchestrator metric sources', () => {
   });
 
   it('switches every server chart to an orchestrator-normalized worker', () => {
+    cy.contains('GPU cache hit').should('be.visible');
+    cy.contains('CPU cache hit').should('not.exist');
+
     cy.get('[data-testid="metric-source-toolbar"]')
       .should('have.css', 'position', 'sticky')
       .and('have.css', 'top', '64px');

--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -108,10 +108,16 @@ const agenticBenchmarks = AGENTIC_HARDWARE.flatMap((g) =>
     isl: null,
     osl: null,
     conc,
-    offload_mode: 'off',
+    offload_mode: 'on',
     benchmark_type: 'agentic_traces',
     image: 'vllm/vllm-openai:v0.9.0',
-    metrics: agenticMetrics(conc),
+    metrics: {
+      ...agenticMetrics(conc),
+      kv_offloading: 'dram',
+      kv_offload_backend: 'mooncake',
+      kv_offload_backend_version: '0.3.11.post1',
+      server_gpu_cache_hit_rate: 0.875,
+    },
     workers: null,
     date: AGENTIC_DATE,
     run_url: null,
@@ -177,6 +183,11 @@ describe('GPU comparison agentic point detail', () => {
       });
 
     cy.get('[data-chart-tooltip]:visible').should('have.length', 1);
+    cy.get('[data-chart-tooltip]:visible')
+      .should('contain', 'Offload Type: DRAM')
+      .and('contain', 'Offload Backend: Mooncake 0.3.11.post1')
+      .and('contain', 'GPU Cache Hit Rate: 87.5%')
+      .and('not.contain', 'Offload Mode');
     cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]')
       .should('be.visible')
       .then(($link) => {

--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -116,6 +116,8 @@ const agenticBenchmarks = AGENTIC_HARDWARE.flatMap((g) =>
       kv_offloading: 'dram',
       kv_offload_backend: 'mooncake',
       kv_offload_backend_version: '0.3.11.post1',
+      router_name: 'vllm-router',
+      router_version: '0.1.14',
       server_gpu_cache_hit_rate: 0.875,
     },
     workers: null,
@@ -185,7 +187,8 @@ describe('GPU comparison agentic point detail', () => {
     cy.get('[data-chart-tooltip]:visible').should('have.length', 1);
     cy.get('[data-chart-tooltip]:visible')
       .should('contain', 'Offload Type: DRAM')
-      .and('contain', 'Offload Backend: Mooncake 0.3.11.post1')
+      .and('contain', 'KV Offload Engine: Mooncake 0.3.11.post1')
+      .and('contain', 'Router: vLLM Router 0.1.14')
       .and('contain', 'GPU Cache Hit Rate: 87.5%')
       .and('not.contain', 'Offload Mode');
     cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]')

--- a/packages/app/cypress/e2e/unofficial-watermark.cy.ts
+++ b/packages/app/cypress/e2e/unofficial-watermark.cy.ts
@@ -25,6 +25,8 @@ describe('Unofficial-run watermark', () => {
               kv_offloading: 'dram',
               kv_offload_backend: 'hicache',
               kv_p2p_transfer: 'nixl',
+              router_name: 'sglang-router',
+              router_version: '0.3.2',
               server_gpu_cache_hit_rate: 0.875,
             },
             run_url: runUrl,
@@ -74,8 +76,9 @@ describe('Unofficial-run watermark', () => {
         expect(tooltip).not.to.equal(null);
         expect(tooltip!.style.display).to.equal('block');
         expect(tooltip).to.contain.text('Offload Type: DRAM');
-        expect(tooltip).to.contain.text('Offload Backend: HiCache');
-        expect(tooltip).to.contain.text('KV Cache Transfer Engine: NIXL');
+        expect(tooltip).to.contain.text('KV Offload Engine: HiCache');
+        expect(tooltip).to.contain.text('KV Transfer Engine: NIXL');
+        expect(tooltip).to.contain.text('Router: SGLang Router 0.3.2');
         expect(tooltip).to.contain.text('GPU Cache Hit Rate: 87.5%');
       });
 

--- a/packages/app/cypress/e2e/unofficial-watermark.cy.ts
+++ b/packages/app/cypress/e2e/unofficial-watermark.cy.ts
@@ -19,6 +19,14 @@ describe('Unofficial-run watermark', () => {
           ],
           benchmarks: benchmarks.map((row: Record<string, unknown>) => ({
             ...row,
+            is_multinode: true,
+            metrics: {
+              ...(row.metrics as Record<string, unknown> | undefined),
+              kv_offloading: 'dram',
+              kv_offload_backend: 'hicache',
+              kv_p2p_transfer: 'nixl',
+              server_gpu_cache_hit_rate: 0.875,
+            },
             run_url: runUrl,
           })),
           evaluations: [],
@@ -56,6 +64,19 @@ describe('Unofficial-run watermark', () => {
       .each(($image) => {
         cy.wrap($image).should('have.attr', 'href', '/decorative/kanye-west.png');
         cy.wrap($image).parent('svg').find('.unofficial-watermark-image').should('have.length', 1);
+      });
+
+    cy.get('[data-testid="scatter-graph"] .unofficial-overlay-pt')
+      .first()
+      .then(($point) => {
+        $point[0].dispatchEvent(new MouseEvent('mouseenter'));
+        const tooltip = $point[0].ownerDocument.querySelector<HTMLElement>('[data-chart-tooltip]');
+        expect(tooltip).not.to.equal(null);
+        expect(tooltip!.style.display).to.equal('block');
+        expect(tooltip).to.contain.text('Offload Type: DRAM');
+        expect(tooltip).to.contain.text('Offload Backend: HiCache');
+        expect(tooltip).to.contain.text('KV Cache Transfer Engine: NIXL');
+        expect(tooltip).to.contain.text('GPU Cache Hit Rate: 87.5%');
       });
 
     cy.get('[data-testid="scatter-graph"]').first().scrollIntoView();

--- a/packages/app/src/components/inference/agentic-point/point-summary.test.ts
+++ b/packages/app/src/components/inference/agentic-point/point-summary.test.ts
@@ -1,0 +1,47 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import type { PointMeta } from '@/hooks/api/use-trace-server-metrics';
+
+import { PointSummary } from './point-summary';
+
+function meta(overrides: Partial<PointMeta> = {}): PointMeta {
+  return {
+    id: 206885,
+    hardware: 'gb200',
+    framework: 'dynamo-vllm',
+    model: 'deepseek-r1-0528',
+    precision: 'fp8',
+    spec_method: 'none',
+    disagg: true,
+    conc: 128,
+    offload_mode: 'off',
+    isl: null,
+    osl: null,
+    benchmark_type: 'agentic_traces',
+    date: '2026-06-23',
+    run_url: null,
+    server_gpu_cache_hit_rate: 0.5,
+    server_cpu_cache_hit_rate: 0.42,
+    ...overrides,
+  };
+}
+
+describe('PointSummary', () => {
+  it('hides a stale CPU cache hit rate when offload is disabled', () => {
+    const html = renderToStaticMarkup(createElement(PointSummary, { meta: meta() }));
+
+    expect(html).toContain('GPU cache hit');
+    expect(html).not.toContain('CPU cache hit');
+  });
+
+  it('shows the CPU cache hit rate when offload is enabled', () => {
+    const html = renderToStaticMarkup(
+      createElement(PointSummary, { meta: meta({ offload_mode: 'on' }) }),
+    );
+
+    expect(html).toContain('CPU cache hit');
+    expect(html).toContain('42.00%');
+  });
+});

--- a/packages/app/src/components/inference/agentic-point/point-summary.tsx
+++ b/packages/app/src/components/inference/agentic-point/point-summary.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 
 import type { PointMeta } from '@/hooks/api/use-trace-server-metrics';
+import { isKvOffloadEnabled } from '@/lib/kv-offload';
 
 const fmtPct = (v: number | null | undefined): string =>
   v === null || v === undefined || Number.isNaN(v) ? '—' : `${(v * 100).toFixed(2)}%`;
@@ -18,6 +19,8 @@ function MetaLine({ label, value }: { label: string; value: ReactNode }) {
 
 /** Selected-point header: config facts (offload, concurrency, cache hit rates, ISL/OSL). */
 export function PointSummary({ meta }: { meta: PointMeta }) {
+  const showCpuCacheHit = isKvOffloadEnabled(meta);
+
   return (
     <div className="mb-4">
       <div className="flex items-baseline justify-between gap-3 mb-2">
@@ -41,7 +44,9 @@ export function PointSummary({ meta }: { meta: PointMeta }) {
         <MetaLine label="Offload" value={(meta.offload_mode ?? 'off').toUpperCase()} />
         <MetaLine label="Concurrency" value={meta.conc} />
         <MetaLine label="GPU cache hit" value={fmtPct(meta.server_gpu_cache_hit_rate)} />
-        <MetaLine label="CPU cache hit" value={fmtPct(meta.server_cpu_cache_hit_rate)} />
+        {showCpuCacheHit && (
+          <MetaLine label="CPU cache hit" value={fmtPct(meta.server_cpu_cache_hit_rate)} />
+        )}
         {meta.isl !== null && <MetaLine label="ISL" value={meta.isl} />}
         {meta.osl !== null && <MetaLine label="OSL" value={meta.osl} />}
       </div>

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -201,6 +201,10 @@ export interface AggDataEntry {
   kv_offload_backend_version?: string;
   /** P2P engine used to move KV state between workers on multinode runs. */
   kv_p2p_transfer?: string;
+  /** Request router implementation, for example `vllm-router` or `sglang-router`. */
+  router_name?: string;
+  /** Version independently declared for the request router. */
+  router_version?: string;
   /** Actual server-observed GPU prefix-cache hit rate (0..1). */
   server_gpu_cache_hit_rate?: number;
   /** Actual server-observed CPU prefix-cache hit rate (0..1). */

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -190,9 +190,17 @@ export interface AggDataEntry {
   isl?: number | null;
   /** OSL in tokens — null for agentic_traces. */
   osl?: number | null;
-  // ── Agentic-only fields (populated from metrics JSONB for `agentic_traces` rows) ──
+  // ── Runtime cache metadata (populated from metrics JSONB when emitted) ──
   /** "on" | "off" — whether KV cache offload to CPU was enabled. */
   offload_mode?: string;
+  /** Offload tier/type, for example `dram` or `none`. */
+  kv_offloading?: string;
+  /** Offload implementation, for example `mooncake`, `lmcache`, or `hicache`. */
+  kv_offload_backend?: string;
+  /** Optional version independently declared for the offload backend. */
+  kv_offload_backend_version?: string;
+  /** P2P engine used to move KV state between workers on multinode runs. */
+  kv_p2p_transfer?: string;
   /** Actual server-observed GPU prefix-cache hit rate (0..1). */
   server_gpu_cache_hit_rate?: number;
   /** Actual server-observed CPU prefix-cache hit rate (0..1). */

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -853,6 +853,7 @@ const GPUGraph = React.memo(
               hardwareConfig,
               runUrl: d.run_url ? updateRepoUrl(d.run_url) : undefined,
               hasTrace: typeof d.id === 'number' ? traceAvailability?.[d.id] === true : false,
+              locale,
             }),
           getRulerX: (d, xScale) => (xScale as d3.ScaleLinear<number, number>)(d.x),
           getRulerY: (d, yScale) => (yScale as d3.ScaleLinear<number, number>)(d.y),

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2213,8 +2213,7 @@ const ScatterGraph = React.memo(
               // Overlay tooltip handlers
               const svgNode = ctx.layout.svg.node()!;
               const container = svgNode.parentElement as HTMLDivElement;
-              const tooltipDiv = svgNode.nextElementSibling as HTMLDivElement;
-              const tooltip = d3.select(tooltipDiv);
+              const tooltip = d3.select(ctx.tooltipElement);
 
               const createOverlayConfig = (d: InferenceData, pinned: boolean) => ({
                 data: d,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1204,6 +1204,7 @@ const ScatterGraph = React.memo(
             isTracked: trackedConfigIdsRef.current.has(buildPointConfigId(d)),
             runUrl: d.run_url ? updateRepoUrl(d.run_url) : undefined,
             hasTrace: typeof d.id === 'number' ? traceAvailability?.[d.id] === true : false,
+            locale,
           }),
         getRulerX: (d: InferenceData, xScale: any) => (xScale as ContinuousScale)(d.x),
         getRulerY: (d: InferenceData, yScale: any) => (yScale as ContinuousScale)(d.y),
@@ -1270,6 +1271,7 @@ const ScatterGraph = React.memo(
         // tooltip content closure (the "View charts" button), so rebuild the
         // config when the presence fetch resolves.
         traceAvailability,
+        locale,
       ],
     );
 
@@ -2222,6 +2224,7 @@ const ScatterGraph = React.memo(
                 selectedYAxisMetric,
                 hardwareConfig: overlayData.hardwareConfig,
                 overlayData,
+                locale,
               });
 
               overlayPoints

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2495,6 +2495,7 @@ const ScatterGraph = React.memo(
       yLabel,
       selectedYAxisMetric,
       chartDefinition,
+      locale,
     ]);
 
     // Layers handle for the decoration effect — lets it re-run individual

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -264,17 +264,42 @@ describe('generateTooltipContent', () => {
 
   it('keeps a clearly marked binary fallback for legacy agentic rows', () => {
     const enabled = generateTooltipContent(
-      tooltipConfig({ data: pt({ offload_mode: 'on', kv_offloading: undefined }) }),
+      tooltipConfig({
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          offload_mode: 'on',
+          kv_offloading: undefined,
+        }),
+      }),
     );
     const disabledZh = generateTooltipContent(
       tooltipConfig({
         locale: 'zh',
-        data: pt({ offload_mode: 'off', kv_offloading: undefined }),
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          offload_mode: 'off',
+          kv_offloading: undefined,
+        }),
       }),
     );
 
     expect(enabled).toContain('<strong>Offload Type:</strong> Enabled (legacy data)');
     expect(disabledZh).toContain('<strong>卸载类型:</strong> 已禁用（旧版数据）');
+  });
+
+  it('does not treat the fixed-sequence offload default as legacy metadata', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          benchmark_type: 'single_turn',
+          offload_mode: 'off',
+          kv_offloading: undefined,
+        }),
+      }),
+    );
+
+    expect(html).not.toContain('Offload Type');
+    expect(html).not.toContain('legacy data');
   });
 
   it('shows multinode KV transfer and cache-hit metadata for fixed-sequence points', () => {

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -376,11 +376,14 @@ describe('generateTooltipContent', () => {
     expect(html).toContain('<strong>路由器:</strong> vLLM Router 0.1.14');
   });
 
-  it('localizes an empty offload tier on /zh surfaces', () => {
-    const html = generateTooltipContent(
+  it('omits the offload type row when the canonical tier is none', () => {
+    const en = generateTooltipContent(tooltipConfig({ data: pt({ kv_offloading: 'none' }) }));
+    const zh = generateTooltipContent(
       tooltipConfig({ locale: 'zh', data: pt({ kv_offloading: 'none' }) }),
     );
-    expect(html).toContain('<strong>卸载类型:</strong> 无');
+
+    expect(en).not.toContain('Offload Type');
+    expect(zh).not.toContain('卸载类型');
   });
 
   it('falls back to hwKey when hardware config entry is missing', () => {
@@ -500,7 +503,7 @@ describe('generateOverlayTooltipContent', () => {
       }),
     );
 
-    expect(html).toContain('<strong>Offload Type:</strong> None');
+    expect(html).not.toContain('Offload Type');
     expect(html).not.toContain('CPU Cache Hit Rate');
   });
 });

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -258,7 +258,7 @@ describe('generateTooltipContent', () => {
       }),
     );
     expect(html).toContain('<strong>Offload Type:</strong> DRAM');
-    expect(html).toContain('<strong>Offload Backend:</strong> Mooncake 0.3.11.post1');
+    expect(html).toContain('<strong>KV Offload Engine:</strong> Mooncake 0.3.11.post1');
     expect(html).not.toContain('Offload Mode');
   });
 
@@ -273,7 +273,7 @@ describe('generateTooltipContent', () => {
         }),
       }),
     );
-    expect(html).toContain('<strong>KV Cache Transfer Engine:</strong> NIXL');
+    expect(html).toContain('<strong>KV Transfer Engine:</strong> NIXL');
     expect(html).toContain('<strong>GPU Cache Hit Rate:</strong> 87.5%');
   });
 
@@ -281,11 +281,17 @@ describe('generateTooltipContent', () => {
     const html = generateTooltipContent(
       tooltipConfig({
         locale: 'zh',
-        data: pt({ kv_offloading: 'dram', kv_offload_backend: 'lmcache' }),
+        data: pt({
+          kv_offloading: 'dram',
+          kv_offload_backend: 'lmcache',
+          router_name: 'vllm-router',
+          router_version: '0.1.14',
+        }),
       }),
     );
     expect(html).toContain('<strong>卸载类型:</strong> DRAM');
-    expect(html).toContain('<strong>卸载后端:</strong> LMCache');
+    expect(html).toContain('<strong>KV 卸载引擎:</strong> LMCache');
+    expect(html).toContain('<strong>路由器:</strong> vLLM Router 0.1.14');
   });
 
   it('localizes an empty offload tier on /zh surfaces', () => {
@@ -386,12 +392,17 @@ describe('generateOverlayTooltipContent', () => {
           benchmark_type: 'agentic_traces',
           kv_offloading: 'dram',
           kv_offload_backend: 'hicache',
+          kv_p2p_transfer: 'nixl',
+          router_name: 'sglang-router',
+          router_version: '0.3.2',
           server_cpu_cache_hit_rate: 0.42,
         }),
       }),
     );
     expect(html).toContain('<strong>Offload Type:</strong> DRAM');
-    expect(html).toContain('<strong>Offload Backend:</strong> HiCache');
+    expect(html).toContain('<strong>KV Offload Engine:</strong> HiCache');
+    expect(html).toContain('<strong>KV Transfer Engine:</strong> NIXL');
+    expect(html).toContain('<strong>Router:</strong> SGLang Router 0.3.2');
     expect(html).toContain('<strong>CPU Cache Hit Rate:</strong> 42.0%');
   });
 });

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -317,6 +317,48 @@ describe('generateTooltipContent', () => {
     expect(html).toContain('<strong>GPU Cache Hit Rate:</strong> 87.5%');
   });
 
+  it('hides stale CPU cache hits when offload is disabled', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          kv_offloading: 'none',
+          offload_mode: 'on',
+          server_gpu_cache_hit_rate: 0.8,
+          server_cpu_cache_hit_rate: 0.42,
+          theoretical_cache_hit_rate: 0.9,
+        }),
+      }),
+    );
+
+    expect(html).not.toContain('CPU Cache Hit Rate');
+    expect(html).toContain('<strong>GPU Cache Hit Rate:</strong> 80.0%');
+    expect(html).toContain('<strong>Theoretical Cache Hit Rate:</strong> 90.0%');
+  });
+
+  it('uses legacy offload mode to gate CPU cache hits when no descriptor exists', () => {
+    const disabled = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          kv_offloading: undefined,
+          offload_mode: 'off',
+          server_cpu_cache_hit_rate: 0.42,
+        }),
+      }),
+    );
+    const enabled = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          kv_offloading: undefined,
+          offload_mode: 'on',
+          server_cpu_cache_hit_rate: 0.42,
+        }),
+      }),
+    );
+
+    expect(disabled).not.toContain('CPU Cache Hit Rate');
+    expect(enabled).toContain('<strong>CPU Cache Hit Rate:</strong> 42.0%');
+  });
+
   it('uses Chinese labels for new cache metadata on /zh surfaces', () => {
     const html = generateTooltipContent(
       tooltipConfig({
@@ -444,6 +486,22 @@ describe('generateOverlayTooltipContent', () => {
     expect(html).toContain('<strong>KV Transfer Engine:</strong> NIXL');
     expect(html).toContain('<strong>Router:</strong> SGLang Router 0.3.2');
     expect(html).toContain('<strong>CPU Cache Hit Rate:</strong> 42.0%');
+  });
+
+  it('hides stale CPU cache hits for unofficial overlays without offload', () => {
+    const html = generateOverlayTooltipContent(
+      overlayConfig({
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          kv_offloading: 'none',
+          offload_mode: 'off',
+          server_cpu_cache_hit_rate: 0.42,
+        }),
+      }),
+    );
+
+    expect(html).toContain('<strong>Offload Type:</strong> None');
+    expect(html).not.toContain('CPU Cache Hit Rate');
   });
 });
 

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -245,6 +245,56 @@ describe('generateTooltipContent', () => {
     expect(html).toContain('FP8');
   });
 
+  it('shows offload type, backend, and version instead of the binary offload mode', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          offload_mode: 'on',
+          kv_offloading: 'dram',
+          kv_offload_backend: 'mooncake',
+          kv_offload_backend_version: '0.3.11.post1',
+        }),
+      }),
+    );
+    expect(html).toContain('<strong>Offload Type:</strong> DRAM');
+    expect(html).toContain('<strong>Offload Backend:</strong> Mooncake 0.3.11.post1');
+    expect(html).not.toContain('Offload Mode');
+  });
+
+  it('shows multinode KV transfer and cache-hit metadata for fixed-sequence points', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          benchmark_type: 'single_turn',
+          is_multinode: true,
+          kv_p2p_transfer: 'nixl',
+          server_gpu_cache_hit_rate: 0.875,
+        }),
+      }),
+    );
+    expect(html).toContain('<strong>KV Cache Transfer Engine:</strong> NIXL');
+    expect(html).toContain('<strong>GPU Cache Hit Rate:</strong> 87.5%');
+  });
+
+  it('uses Chinese labels for new cache metadata on /zh surfaces', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        locale: 'zh',
+        data: pt({ kv_offloading: 'dram', kv_offload_backend: 'lmcache' }),
+      }),
+    );
+    expect(html).toContain('<strong>卸载类型:</strong> DRAM');
+    expect(html).toContain('<strong>卸载后端:</strong> LMCache');
+  });
+
+  it('localizes an empty offload tier on /zh surfaces', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ locale: 'zh', data: pt({ kv_offloading: 'none' }) }),
+    );
+    expect(html).toContain('<strong>卸载类型:</strong> 无');
+  });
+
   it('falls back to hwKey when hardware config entry is missing', () => {
     const html = generateTooltipContent(tooltipConfig({ data: pt({ hwKey: 'unknown_gpu' }) }));
     expect(html).toContain('unknown_gpu');
@@ -327,6 +377,22 @@ describe('generateOverlayTooltipContent', () => {
     const html = generateOverlayTooltipContent(overlayConfig());
     expect(html).toContain('Concurrency');
     expect(html).toContain('64');
+  });
+
+  it('shows cache metadata for unofficial agentic overlays', () => {
+    const html = generateOverlayTooltipContent(
+      overlayConfig({
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          kv_offloading: 'dram',
+          kv_offload_backend: 'hicache',
+          server_cpu_cache_hit_rate: 0.42,
+        }),
+      }),
+    );
+    expect(html).toContain('<strong>Offload Type:</strong> DRAM');
+    expect(html).toContain('<strong>Offload Backend:</strong> HiCache');
+    expect(html).toContain('<strong>CPU Cache Hit Rate:</strong> 42.0%');
   });
 });
 

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -262,6 +262,21 @@ describe('generateTooltipContent', () => {
     expect(html).not.toContain('Offload Mode');
   });
 
+  it('keeps a clearly marked binary fallback for legacy agentic rows', () => {
+    const enabled = generateTooltipContent(
+      tooltipConfig({ data: pt({ offload_mode: 'on', kv_offloading: undefined }) }),
+    );
+    const disabledZh = generateTooltipContent(
+      tooltipConfig({
+        locale: 'zh',
+        data: pt({ offload_mode: 'off', kv_offloading: undefined }),
+      }),
+    );
+
+    expect(enabled).toContain('<strong>Offload Type:</strong> Enabled (legacy data)');
+    expect(disabledZh).toContain('<strong>卸载类型:</strong> 已禁用（旧版数据）');
+  });
+
   it('shows multinode KV transfer and cache-hit metadata for fixed-sequence points', () => {
     const html = generateTooltipContent(
       tooltipConfig({

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -153,7 +153,7 @@ const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => 
   const parts: string[] = [];
   if (d.kv_offloading) {
     parts.push(tooltipLine(t.offloadType, offloadTypeLabel(d.kv_offloading, locale)));
-  } else if (d.offload_mode) {
+  } else if (d.benchmark_type === 'agentic_traces' && d.offload_mode) {
     const enabled = d.offload_mode.toLowerCase() === 'on';
     parts.push(tooltipLine(t.offloadType, enabled ? t.legacyEnabled : t.legacyDisabled));
   }

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -96,8 +96,9 @@ export const fmt = (v: number): string => {
 const CACHE_STRINGS = {
   en: {
     offloadType: 'Offload Type',
-    offloadBackend: 'Offload Backend',
-    transferEngine: 'KV Cache Transfer Engine',
+    offloadBackend: 'KV Offload Engine',
+    transferEngine: 'KV Transfer Engine',
+    router: 'Router',
     gpuHitRate: 'GPU Cache Hit Rate',
     cpuHitRate: 'CPU Cache Hit Rate',
     theoreticalHitRate: 'Theoretical Cache Hit Rate',
@@ -105,8 +106,9 @@ const CACHE_STRINGS = {
   },
   zh: {
     offloadType: '卸载类型',
-    offloadBackend: '卸载后端',
-    transferEngine: 'KV Cache 传输引擎',
+    offloadBackend: 'KV 卸载引擎',
+    transferEngine: 'KV 传输引擎',
+    router: '路由器',
     gpuHitRate: 'GPU Cache 命中率',
     cpuHitRate: 'CPU Cache 命中率',
     theoreticalHitRate: '理论 Cache 命中率',
@@ -122,8 +124,11 @@ const CACHE_IMPLEMENTATION_LABELS: Record<string, string> = {
   moriio: 'MoRI-IO',
   'mori-io': 'MoRI-IO',
   nixl: 'NIXL',
+  atomesh: 'AtoMesh',
   'vllm-native': 'vLLM Native',
+  'vllm-router': 'vLLM Router',
   'vllm-simple': 'vLLM Simple',
+  'sglang-router': 'SGLang Router',
 };
 
 const cacheImplementationLabel = (value: string): string =>
@@ -150,8 +155,13 @@ const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => 
     const version = d.kv_offload_backend_version ? ` ${d.kv_offload_backend_version}` : '';
     parts.push(tooltipLine(t.offloadBackend, `${backend}${version}`));
   }
-  if (d.is_multinode && d.kv_p2p_transfer) {
+  if (d.kv_p2p_transfer) {
     parts.push(tooltipLine(t.transferEngine, cacheImplementationLabel(d.kv_p2p_transfer)));
+  }
+  if (d.router_name) {
+    const router = cacheImplementationLabel(d.router_name);
+    const version = d.router_version ? ` ${d.router_version}` : '';
+    parts.push(tooltipLine(t.router, `${router}${version}`));
   }
 
   const gpuHit = formatPct(d.server_gpu_cache_hit_rate);

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -103,6 +103,8 @@ const CACHE_STRINGS = {
     cpuHitRate: 'CPU Cache Hit Rate',
     theoreticalHitRate: 'Theoretical Cache Hit Rate',
     none: 'None',
+    legacyEnabled: 'Enabled (legacy data)',
+    legacyDisabled: 'Disabled (legacy data)',
   },
   zh: {
     offloadType: '卸载类型',
@@ -113,6 +115,8 @@ const CACHE_STRINGS = {
     cpuHitRate: 'CPU Cache 命中率',
     theoreticalHitRate: '理论 Cache 命中率',
     none: '无',
+    legacyEnabled: '已启用（旧版数据）',
+    legacyDisabled: '已禁用（旧版数据）',
   },
 } as const;
 
@@ -149,6 +153,9 @@ const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => 
   const parts: string[] = [];
   if (d.kv_offloading) {
     parts.push(tooltipLine(t.offloadType, offloadTypeLabel(d.kv_offloading, locale)));
+  } else if (d.offload_mode) {
+    const enabled = d.offload_mode.toLowerCase() === 'on';
+    parts.push(tooltipLine(t.offloadType, enabled ? t.legacyEnabled : t.legacyDisabled));
   }
   if (d.kv_offload_backend) {
     const backend = cacheImplementationLabel(d.kv_offload_backend);

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -1,6 +1,7 @@
 import { formatNumber, getDisplayLabel } from '@/lib/utils';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import type { Locale } from '@/lib/i18n';
+import { isKvOffloadEnabled } from '@/lib/kv-offload';
 
 import type { HardwareConfig, InferenceData, OverlayData } from '@/components/inference/types';
 import { parallelismLabel } from '@/components/inference/utils/parallelism-label';
@@ -175,7 +176,7 @@ const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => 
   const cpuHit = formatPct(d.server_cpu_cache_hit_rate);
   const theoreticalHit = formatPct(d.theoretical_cache_hit_rate);
   if (gpuHit) parts.push(tooltipLine(t.gpuHitRate, gpuHit));
-  if (cpuHit) parts.push(tooltipLine(t.cpuHitRate, cpuHit));
+  if (cpuHit && isKvOffloadEnabled(d)) parts.push(tooltipLine(t.cpuHitRate, cpuHit));
   if (theoreticalHit) parts.push(tooltipLine(t.theoreticalHitRate, theoreticalHit));
   return parts.join('');
 };

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -103,7 +103,6 @@ const CACHE_STRINGS = {
     gpuHitRate: 'GPU Cache Hit Rate',
     cpuHitRate: 'CPU Cache Hit Rate',
     theoreticalHitRate: 'Theoretical Cache Hit Rate',
-    none: 'None',
     legacyEnabled: 'Enabled (legacy data)',
     legacyDisabled: 'Disabled (legacy data)',
   },
@@ -115,7 +114,6 @@ const CACHE_STRINGS = {
     gpuHitRate: 'GPU Cache 命中率',
     cpuHitRate: 'CPU Cache 命中率',
     theoreticalHitRate: '理论 Cache 命中率',
-    none: '无',
     legacyEnabled: '已启用（旧版数据）',
     legacyDisabled: '已禁用（旧版数据）',
   },
@@ -139,9 +137,8 @@ const CACHE_IMPLEMENTATION_LABELS: Record<string, string> = {
 const cacheImplementationLabel = (value: string): string =>
   CACHE_IMPLEMENTATION_LABELS[value.toLowerCase()] ?? value;
 
-const offloadTypeLabel = (value: string, locale: Locale): string => {
+const offloadTypeLabel = (value: string): string => {
   if (value.toLowerCase() === 'dram') return 'DRAM';
-  if (value.toLowerCase() === 'none') return CACHE_STRINGS[locale].none;
   return value.toUpperCase();
 };
 
@@ -152,9 +149,10 @@ const offloadTypeLabel = (value: string, locale: Locale): string => {
 const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => {
   const t = CACHE_STRINGS[locale];
   const parts: string[] = [];
-  if (d.kv_offloading) {
-    parts.push(tooltipLine(t.offloadType, offloadTypeLabel(d.kv_offloading, locale)));
-  } else if (d.benchmark_type === 'agentic_traces' && d.offload_mode) {
+  const offloadType = d.kv_offloading?.trim();
+  if (offloadType && offloadType.toLowerCase() !== 'none') {
+    parts.push(tooltipLine(t.offloadType, offloadTypeLabel(offloadType)));
+  } else if (!offloadType && d.benchmark_type === 'agentic_traces' && d.offload_mode) {
     const enabled = d.offload_mode.toLowerCase() === 'on';
     parts.push(tooltipLine(t.offloadType, enabled ? t.legacyEnabled : t.legacyDisabled));
   }

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -1,5 +1,6 @@
 import { formatNumber, getDisplayLabel } from '@/lib/utils';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
+import type { Locale } from '@/lib/i18n';
 
 import type { HardwareConfig, InferenceData, OverlayData } from '@/components/inference/types';
 import { parallelismLabel } from '@/components/inference/utils/parallelism-label';
@@ -29,6 +30,8 @@ export interface TooltipConfig {
    * call so we don't ship megabytes of profile JSONL just for this check).
    */
   hasTrace?: boolean;
+  /** Page locale for tooltip metadata labels. Defaults to English. */
+  locale?: Locale;
 }
 
 export interface OverlayTooltipConfig extends TooltipConfig {
@@ -90,24 +93,84 @@ export const fmt = (v: number): string => {
   return String(rounded);
 };
 
+const CACHE_STRINGS = {
+  en: {
+    offloadType: 'Offload Type',
+    offloadBackend: 'Offload Backend',
+    transferEngine: 'KV Cache Transfer Engine',
+    gpuHitRate: 'GPU Cache Hit Rate',
+    cpuHitRate: 'CPU Cache Hit Rate',
+    theoreticalHitRate: 'Theoretical Cache Hit Rate',
+    none: 'None',
+  },
+  zh: {
+    offloadType: '卸载类型',
+    offloadBackend: '卸载后端',
+    transferEngine: 'KV Cache 传输引擎',
+    gpuHitRate: 'GPU Cache 命中率',
+    cpuHitRate: 'CPU Cache 命中率',
+    theoreticalHitRate: '理论 Cache 命中率',
+    none: '无',
+  },
+} as const;
+
+const CACHE_IMPLEMENTATION_LABELS: Record<string, string> = {
+  hicache: 'HiCache',
+  lmcache: 'LMCache',
+  mooncake: 'Mooncake',
+  mori: 'MoRI',
+  moriio: 'MoRI-IO',
+  'mori-io': 'MoRI-IO',
+  nixl: 'NIXL',
+  'vllm-native': 'vLLM Native',
+  'vllm-simple': 'vLLM Simple',
+};
+
+const cacheImplementationLabel = (value: string): string =>
+  CACHE_IMPLEMENTATION_LABELS[value.toLowerCase()] ?? value;
+
+const offloadTypeLabel = (value: string, locale: Locale): string => {
+  if (value.toLowerCase() === 'dram') return 'DRAM';
+  if (value.toLowerCase() === 'none') return CACHE_STRINGS[locale].none;
+  return value.toUpperCase();
+};
+
 /**
- * Agentic-only tooltip rows: offload mode, KV cache hit rates, request
- * success, token totals. Returns an empty string for non-agentic rows.
+ * Cache configuration and hit-rate rows shared by fixed-sequence, agentic,
+ * official, comparison, and unofficial-run tooltips.
+ */
+const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => {
+  const t = CACHE_STRINGS[locale];
+  const parts: string[] = [];
+  if (d.kv_offloading) {
+    parts.push(tooltipLine(t.offloadType, offloadTypeLabel(d.kv_offloading, locale)));
+  }
+  if (d.kv_offload_backend) {
+    const backend = cacheImplementationLabel(d.kv_offload_backend);
+    const version = d.kv_offload_backend_version ? ` ${d.kv_offload_backend_version}` : '';
+    parts.push(tooltipLine(t.offloadBackend, `${backend}${version}`));
+  }
+  if (d.is_multinode && d.kv_p2p_transfer) {
+    parts.push(tooltipLine(t.transferEngine, cacheImplementationLabel(d.kv_p2p_transfer)));
+  }
+
+  const gpuHit = formatPct(d.server_gpu_cache_hit_rate);
+  const cpuHit = formatPct(d.server_cpu_cache_hit_rate);
+  const theoreticalHit = formatPct(d.theoretical_cache_hit_rate);
+  if (gpuHit) parts.push(tooltipLine(t.gpuHitRate, gpuHit));
+  if (cpuHit) parts.push(tooltipLine(t.cpuHitRate, cpuHit));
+  if (theoreticalHit) parts.push(tooltipLine(t.theoreticalHitRate, theoreticalHit));
+  return parts.join('');
+};
+
+/**
+ * Agentic-only request success and token totals. Cache metadata is rendered
+ * separately because fixed-sequence rows can carry it too.
  */
 const generateAgenticHTML = (d: InferenceData): string => {
   if (d.benchmark_type !== 'agentic_traces') return '';
 
   const parts: string[] = [];
-  if (d.offload_mode) {
-    parts.push(tooltipLine('Offload Mode', d.offload_mode.toUpperCase()));
-  }
-
-  const gpuHit = formatPct(d.server_gpu_cache_hit_rate);
-  const cpuHit = formatPct(d.server_cpu_cache_hit_rate);
-  const theoHit = formatPct(d.theoretical_cache_hit_rate);
-  if (gpuHit) parts.push(tooltipLine('GPU Cache Hit Rate', gpuHit));
-  if (cpuHit) parts.push(tooltipLine('CPU Cache Hit Rate', cpuHit));
-  if (theoHit) parts.push(tooltipLine('Theoretical Cache Hit Rate', theoHit));
 
   if (d.num_requests_total !== undefined && d.num_requests_successful !== undefined) {
     const successPct =
@@ -212,6 +275,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
     runUrl,
     hasTrace,
   } = config;
+  const locale = config.locale ?? 'en';
 
   return `
     <div style="background: var(--popover); border: 1px solid var(--border); border-radius: 8px; padding: 12px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); user-select: ${isPinned ? 'text' : 'none'};">
@@ -258,6 +322,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Precision:</strong> ${d.precision.toUpperCase()}
       </div>
+      ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d)}
       ${runLinkHTML(runUrl)}
       ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id)}
@@ -283,6 +348,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
  */
 export const generateOverlayTooltipContent = (config: OverlayTooltipConfig): string => {
   const { data: d, isPinned, xLabel, yLabel, overlayData } = config;
+  const locale = config.locale ?? 'en';
   const hwConfig = overlayData.hardwareConfig[d.hwKey];
   const perRow = overlayData.getRunForRow?.(d);
   const branch = perRow?.branch ?? overlayData.label;
@@ -316,6 +382,7 @@ export const generateOverlayTooltipContent = (config: OverlayTooltipConfig): str
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Precision:</strong> ${d.precision.toUpperCase()}
       </div>
+      ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d)}
     </div>
   `;
@@ -339,6 +406,7 @@ export const generateGPUGraphTooltipContent = (config: TooltipConfig): string =>
     runUrl,
     hasTrace,
   } = config;
+  const locale = config.locale ?? 'en';
 
   return `
     <div style="background: var(--popover); border: 1px solid var(--border); border-radius: 8px; padding: 12px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); user-select: ${isPinned ? 'text' : 'none'};">
@@ -385,6 +453,7 @@ export const generateGPUGraphTooltipContent = (config: TooltipConfig): string =>
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Precision:</strong> ${d.precision.toUpperCase()}
       </div>
+      ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d)}
       ${runLinkHTML(runUrl)}
       ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id)}

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -123,6 +123,24 @@ describe('rowToAggDataEntry', () => {
     expect(entryNull.image).toBeUndefined();
   });
 
+  it('passes runtime cache metadata through to chart points', () => {
+    const entry = rowToAggDataEntry(
+      makeRow({
+        metrics: {
+          kv_offloading: 'dram',
+          kv_offload_backend: 'mooncake',
+          kv_offload_backend_version: '0.3.11.post1',
+          kv_p2p_transfer: 'nixl',
+        } as unknown as BenchmarkRow['metrics'],
+      }),
+    );
+
+    expect(entry.kv_offloading).toBe('dram');
+    expect(entry.kv_offload_backend).toBe('mooncake');
+    expect(entry.kv_offload_backend_version).toBe('0.3.11.post1');
+    expect(entry.kv_p2p_transfer).toBe('nixl');
+  });
+
   it('passes through measured power telemetry fields when present', () => {
     const entry = rowToAggDataEntry(
       makeRow({

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -131,6 +131,8 @@ describe('rowToAggDataEntry', () => {
           kv_offload_backend: 'mooncake',
           kv_offload_backend_version: '0.3.11.post1',
           kv_p2p_transfer: 'nixl',
+          router_name: 'vllm-router',
+          router_version: '0.1.14',
         } as unknown as BenchmarkRow['metrics'],
       }),
     );
@@ -139,6 +141,8 @@ describe('rowToAggDataEntry', () => {
     expect(entry.kv_offload_backend).toBe('mooncake');
     expect(entry.kv_offload_backend_version).toBe('0.3.11.post1');
     expect(entry.kv_p2p_transfer).toBe('nixl');
+    expect(entry.router_name).toBe('vllm-router');
+    expect(entry.router_version).toBe('0.1.14');
   });
 
   it('passes through measured power telemetry fields when present', () => {

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -168,6 +168,8 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     kv_offload_backend: stringMetric('kv_offload_backend'),
     kv_offload_backend_version: stringMetric('kv_offload_backend_version'),
     kv_p2p_transfer: stringMetric('kv_p2p_transfer'),
+    router_name: stringMetric('router_name'),
+    router_version: stringMetric('router_version'),
     server_gpu_cache_hit_rate: m.server_gpu_cache_hit_rate,
     server_cpu_cache_hit_rate: m.server_cpu_cache_hit_rate,
     theoretical_cache_hit_rate: m.theoretical_cache_hit_rate,

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -56,6 +56,10 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
   const offloadMode =
     row.offload_mode ??
     (typeof rawMetrics.offload_mode === 'string' ? rawMetrics.offload_mode : undefined);
+  const stringMetric = (key: string): string | undefined => {
+    const value = rawMetrics[key];
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+  };
   // Postgres bigint comes through the SQL client as a string; coerce it. Overlay
   // rows (transformed live from raw artifacts) carry no id, so `Number(undefined)`
   // is NaN — collapse any non-persisted value to undefined so downstream link /
@@ -160,6 +164,10 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     isl: row.isl,
     osl: row.osl,
     offload_mode: offloadMode,
+    kv_offloading: stringMetric('kv_offloading'),
+    kv_offload_backend: stringMetric('kv_offload_backend'),
+    kv_offload_backend_version: stringMetric('kv_offload_backend_version'),
+    kv_p2p_transfer: stringMetric('kv_p2p_transfer'),
     server_gpu_cache_hit_rate: m.server_gpu_cache_hit_rate,
     server_cpu_cache_hit_rate: m.server_cpu_cache_hit_rate,
     theoretical_cache_hit_rate: m.theoretical_cache_hit_rate,

--- a/packages/app/src/lib/d3-chart/D3Chart/types.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/types.ts
@@ -197,6 +197,8 @@ export interface TooltipConfig<T = any> {
 
 export interface RenderContext {
   layout: ChartLayout;
+  /** Portaled tooltip node owned by the chart wrapper. */
+  tooltipElement: HTMLDivElement;
   xScale: AnyScale | d3.ScaleTime<number, number>;
   yScale: AnyScale | d3.ScaleTime<number, number>;
   width: number;

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
@@ -182,6 +182,7 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
       // ── Render context ──
       const ctx: RenderContext = {
         layout,
+        tooltipElement: tooltipRef.current,
         xScale,
         yScale,
         width,

--- a/packages/app/src/lib/kv-offload.test.ts
+++ b/packages/app/src/lib/kv-offload.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKvOffloadEnabled } from './kv-offload';
+
+describe('isKvOffloadEnabled', () => {
+  it.each([
+    [{ kv_offloading: 'dram', offload_mode: 'off' }, true],
+    [{ kv_offloading: 'none', offload_mode: 'on' }, false],
+    [{ kv_offloading: ' DRAM ' }, true],
+    [{ offload_mode: 'on' }, true],
+    [{ offload_mode: 'off' }, false],
+    [{}, false],
+  ] as const)('resolves %o to %s', (state, expected) => {
+    expect(isKvOffloadEnabled(state)).toBe(expected);
+  });
+});

--- a/packages/app/src/lib/kv-offload.ts
+++ b/packages/app/src/lib/kv-offload.ts
@@ -1,0 +1,20 @@
+/** Runtime fields that describe whether KV cache offloading is enabled. */
+export interface KvOffloadState {
+  /** Canonical offload tier/type, for example `dram` or `none`. */
+  kv_offloading?: string | null;
+  /** Legacy binary fallback used by older agentic rows. */
+  offload_mode?: string | null;
+}
+
+/**
+ * Resolve the canonical KV-offload state used by cache-related UI.
+ *
+ * Current rows describe the tier (`none` means disabled; any other non-empty
+ * descriptor means enabled). Historical rows only carry `offload_mode`, so
+ * retain that as a fallback without allowing it to override current metadata.
+ */
+export function isKvOffloadEnabled(state: KvOffloadState): boolean {
+  const descriptor = state.kv_offloading?.trim().toLowerCase();
+  if (descriptor) return descriptor !== 'none';
+  return state.offload_mode?.trim().toLowerCase() === 'on';
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -23,6 +23,7 @@
     "db:backfill-chart-series": "dotenv -e ../../.env -- tsx src/backfill-chart-series.ts",
     "db:backfill-dataset-stats": "dotenv -e ../../.env -- tsx src/backfill-dataset-stats.ts",
     "db:backfill-request-timeline": "dotenv -e ../../.env -- tsx src/backfill-request-timeline.ts",
+    "db:backfill-runtime-metadata": "dotenv -e ../../.env -- tsx src/backfill-runtime-metadata.ts",
     "db:reset": "dotenv -e ../../.env -- tsx src/reset-db.ts",
     "db:verify": "dotenv -e ../../.env -- tsx src/verify-db.ts",
     "test:unit": "vitest run",

--- a/packages/db/src/backfill-runtime-metadata.ts
+++ b/packages/db/src/backfill-runtime-metadata.ts
@@ -1,0 +1,160 @@
+/**
+ * Restore runtime component metadata that older app ingest versions dropped.
+ *
+ * The benchmark producer began emitting nested router/offload component objects
+ * and `kv_p2p_transfer` on 2026-07-13. The raw GitHub Actions benchmark
+ * artifacts remain authoritative, so this script downloads only the small
+ * benchmark-result artifacts and merges those metadata keys into matching DB
+ * rows. It never replaces measured metrics or topology/config data.
+ *
+ * Usage:
+ *   pnpm --filter @semianalysisai/inferencex-db db:backfill-runtime-metadata
+ *   pnpm --filter @semianalysisai/inferencex-db db:backfill-runtime-metadata --yes
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { hasNoSslFlag } from './cli-utils.js';
+import { mapBenchmarkRow } from './etl/benchmark-mapper.js';
+import { createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
+import { createSkipTracker } from './etl/skip-tracker.js';
+import { downloadArtifact, listRunArtifacts } from './lib/github-artifacts.js';
+import { confirmProceed, runBackfillMain } from './lib/backfill-runner.js';
+import {
+  repositoryFromRunUrl,
+  selectBenchmarkArtifacts,
+} from './lib/runtime-metadata-artifacts.js';
+
+const REPO = 'SemiAnalysisAI/InferenceX';
+const FIRST_METADATA_DATE = '2026-07-14';
+const RUNTIME_KEYS = [
+  'kv_offloading',
+  'kv_offload_backend',
+  'kv_offload_backend_version',
+  'kv_p2p_transfer',
+  'router_name',
+  'router_version',
+] as const;
+
+const sql = createAdminSql({ noSsl: hasNoSslFlag(), max: 2, onnotice: () => {} });
+
+function findJsonFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const pathname = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...findJsonFiles(pathname));
+    else if (entry.isFile() && entry.name.endsWith('.json')) files.push(pathname);
+  }
+  return files;
+}
+
+async function backfillRawRow(githubRunId: number, rawRow: Record<string, unknown>) {
+  const mapped = mapBenchmarkRow(rawRow, createSkipTracker());
+  if (!mapped) return 'unmapped' as const;
+
+  const metadata = Object.fromEntries(
+    RUNTIME_KEYS.flatMap((key) =>
+      mapped.metrics[key] === undefined ? [] : [[key, mapped.metrics[key]]],
+    ),
+  );
+  if (Object.keys(metadata).length === 0) return 'empty' as const;
+
+  const c = mapped.config;
+  const updated = await sql<{ id: number }[]>`
+    update benchmark_results br
+    set metrics = br.metrics || ${sql.json(metadata)}
+    from workflow_runs wr, configs cfg
+    where br.workflow_run_id = wr.id
+      and br.config_id = cfg.id
+      and wr.github_run_id = ${githubRunId}
+      and cfg.hardware = ${c.hardware}
+      and cfg.framework = ${c.framework}
+      and cfg.model = ${c.model}
+      and cfg.precision = ${c.precision}
+      and cfg.spec_method = ${c.specMethod}
+      and cfg.disagg = ${c.disagg}
+      and cfg.is_multinode = ${c.isMultinode}
+      and cfg.prefill_tp = ${c.prefillTp}
+      and cfg.prefill_ep = ${c.prefillEp}
+      and cfg.prefill_dp_attention = ${c.prefillDpAttn}
+      and cfg.prefill_num_workers = ${c.prefillNumWorkers}
+      and cfg.decode_tp = ${c.decodeTp}
+      and cfg.decode_ep = ${c.decodeEp}
+      and cfg.decode_dp_attention = ${c.decodeDpAttn}
+      and cfg.decode_num_workers = ${c.decodeNumWorkers}
+      and cfg.num_prefill_gpu = ${c.numPrefillGpu}
+      and cfg.num_decode_gpu = ${c.numDecodeGpu}
+      and br.benchmark_type = ${mapped.benchmarkType}
+      and br.isl is not distinct from ${mapped.isl}
+      and br.osl is not distinct from ${mapped.osl}
+      and br.conc = ${mapped.conc}
+      and br.offload_mode = ${mapped.offloadMode}
+    returning br.id
+  `;
+  return updated.length > 0 ? ('updated' as const) : ('missing' as const);
+}
+
+async function main(): Promise<void> {
+  console.log('=== backfill-runtime-metadata ===');
+  const runs = await sql<{ github_run_id: number; html_url: string | null }[]>`
+    select distinct wr.github_run_id, wr.html_url
+    from workflow_runs wr
+    join benchmark_results br on br.workflow_run_id = wr.id
+    where wr.date >= ${FIRST_METADATA_DATE}::date
+    order by wr.github_run_id
+  `;
+  if (runs.length === 0) {
+    console.log('  Nothing to do.');
+    return;
+  }
+  if (!(await confirmProceed(`${runs.length} workflow run(s) may contain runtime metadata.`))) {
+    return;
+  }
+
+  let updated = 0;
+  let missing = 0;
+  let empty = 0;
+  let unmapped = 0;
+  for (const [index, run] of runs.entries()) {
+    const runId = Number(run.github_run_id);
+    const repository = repositoryFromRunUrl(run.html_url) ?? REPO;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `runtime-metadata-${runId}-`));
+    try {
+      const artifacts = selectBenchmarkArtifacts(listRunArtifacts(repository, String(runId)));
+      let files = 0;
+      for (const artifact of artifacts) {
+        const artifactDir = downloadArtifact(artifact, tempDir);
+        for (const file of findJsonFiles(artifactDir)) {
+          files++;
+          const parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as unknown;
+          const rawRows = Array.isArray(parsed) ? parsed : [parsed];
+          for (const raw of rawRows) {
+            if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+            const result = await backfillRawRow(runId, raw as Record<string, unknown>);
+            if (result === 'updated') updated++;
+            else if (result === 'missing') missing++;
+            else if (result === 'empty') empty++;
+            else unmapped++;
+          }
+        }
+      }
+      console.log(
+        `  [${index + 1}/${runs.length}] ${repository} run ${runId}: ` +
+          `${artifacts.length} artifact(s), ${files} file(s)`,
+      );
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  await refreshLatestBenchmarks(sql);
+  console.log(
+    `  Rows: ${updated} updated, ${empty} without runtime metadata, ` +
+      `${unmapped} unmapped, ${missing} missing DB match`,
+  );
+  if (missing > 0) process.exitCode = 1;
+}
+
+runBackfillMain('backfill-runtime-metadata', sql, main);

--- a/packages/db/src/backfill-runtime-metadata.ts
+++ b/packages/db/src/backfill-runtime-metadata.ts
@@ -28,7 +28,7 @@ import {
 } from './lib/runtime-metadata-artifacts.js';
 
 const REPO = 'SemiAnalysisAI/InferenceX';
-const FIRST_METADATA_DATE = '2026-07-14';
+const FIRST_METADATA_DATE = '2026-07-13';
 const RUNTIME_KEYS = [
   'kv_offloading',
   'kv_offload_backend',

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -136,6 +136,17 @@ describe('mapBenchmarkRow', () => {
 
       expect((result!.metrics as Record<string, unknown>).kv_p2p_transfer).toBe('nixl');
     });
+
+    it('flattens router metadata for fixed-sequence rows', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV1Row({ router: { name: 'sglang-router', version: '0.3.2' } }),
+        tracker,
+      );
+
+      expect((result!.metrics as Record<string, unknown>).router_name).toBe('sglang-router');
+      expect((result!.metrics as Record<string, unknown>).router_version).toBe('0.3.2');
+    });
   });
 
   describe('v2 schema', () => {
@@ -878,6 +889,17 @@ describe('mapBenchmarkRow — v3 agentic nested agg schema', () => {
     const metrics = result!.metrics as Record<string, unknown>;
     expect(metrics.kv_offload_backend).toBe('lmcache');
     expect(metrics.kv_offload_backend_version).toBe('0.5.1');
+  });
+
+  it('flattens agentic router metadata and preserves its version', () => {
+    const tracker = createSkipTracker();
+    const result = mapBenchmarkRow(
+      makeV3AgenticRow({ router: { name: 'vllm-router', version: '0.1.14' } }),
+      tracker,
+    );
+    const metrics = result!.metrics as Record<string, unknown>;
+    expect(metrics.router_name).toBe('vllm-router');
+    expect(metrics.router_version).toBe('0.1.14');
   });
 
   it('still applies the failed-run guard to v3 rows', () => {

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -126,6 +126,16 @@ describe('mapBenchmarkRow', () => {
       expect(result!.metrics).not.toHaveProperty('tp');
       expect(result!.metrics).not.toHaveProperty('ep');
     });
+
+    it('preserves the KV transfer engine for fixed-sequence multinode rows', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV1Row({ is_multinode: true, kv_p2p_transfer: 'nixl' }),
+        tracker,
+      );
+
+      expect((result!.metrics as Record<string, unknown>).kv_p2p_transfer).toBe('nixl');
+    });
   });
 
   describe('v2 schema', () => {
@@ -854,6 +864,20 @@ describe('mapBenchmarkRow — v3 agentic nested agg schema', () => {
     expect(result!.offloadMode).toBe('on');
     expect((result!.metrics as Record<string, unknown>).kv_offloading).toBe('dram');
     expect((result!.metrics as Record<string, unknown>).kv_offload_backend).toBe('mooncake');
+  });
+
+  it('flattens current backend metadata and preserves its independent version', () => {
+    const tracker = createSkipTracker();
+    const result = mapBenchmarkRow(
+      makeV3AgenticRow({
+        kv_offloading: 'dram',
+        kv_offload_backend: { name: 'lmcache', version: '0.5.1' },
+      }),
+      tracker,
+    );
+    const metrics = result!.metrics as Record<string, unknown>;
+    expect(metrics.kv_offload_backend).toBe('lmcache');
+    expect(metrics.kv_offload_backend_version).toBe('0.5.1');
   });
 
   it('still applies the failed-run guard to v3 rows', () => {

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -18,6 +18,7 @@ import {
   parseNum,
   parseInt2,
 } from './normalizers';
+import { extractRuntimeMetadata } from './runtime-metadata';
 
 export { flattenAgenticAggRow };
 
@@ -66,6 +67,7 @@ const NON_METRIC_KEYS = new Set([
   'kv_offloading',
   'kv_offload_backend',
   'kv_p2p_transfer',
+  'router',
   // v3 agentic nested containers — flattened by flattenAgenticAggRow before
   // the auto-capture loop runs; the raw objects themselves are not metrics.
   'request_metrics',
@@ -89,22 +91,6 @@ export type BenchmarkType = 'single_turn' | 'agentic_traces';
 /** Reduce an offload descriptor ('none'|'dram'|…) to the binary on/off. */
 function descriptorToOnOff(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? (v === 'none' ? 'off' : 'on') : null;
-}
-
-function nonEmptyString(v: unknown): string | undefined {
-  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
-}
-
-/** Normalize legacy string and current `{ name, version? }` backend metadata. */
-function kvOffloadBackendMetadata(raw: unknown): { name?: string; version?: string } {
-  const legacyName = nonEmptyString(raw);
-  if (legacyName) return { name: legacyName };
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
-  const metadata = raw as Record<string, unknown>;
-  return {
-    name: nonEmptyString(metadata.name),
-    version: nonEmptyString(metadata.version),
-  };
 }
 
 /**
@@ -256,17 +242,7 @@ export function mapBenchmarkRow(
   if (isAgentic) {
     (metrics as Record<string, unknown>).offload_mode = offloadModeRaw;
   }
-  const kvOffloading = nonEmptyString(row.kv_offloading);
-  if (kvOffloading) (metrics as Record<string, unknown>).kv_offloading = kvOffloading;
-  const backend = kvOffloadBackendMetadata(row.kv_offload_backend);
-  if (backend.name) (metrics as Record<string, unknown>).kv_offload_backend = backend.name;
-  if (backend.version) {
-    (metrics as Record<string, unknown>).kv_offload_backend_version = backend.version;
-  }
-  const kvP2pTransfer = nonEmptyString(row.kv_p2p_transfer);
-  if (kvP2pTransfer) {
-    (metrics as Record<string, unknown>).kv_p2p_transfer = kvP2pTransfer;
-  }
+  Object.assign(metrics, extractRuntimeMetadata(row));
 
   // Slow-tail interactivity invariant. Agentic artifacts ship `*_intvty`, but the
   // definition has drifted across harness versions: some emit `1/p(ITL)`

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -65,6 +65,7 @@ const NON_METRIC_KEYS = new Set([
   // to offloadMode / stringified metrics explicitly in mapBenchmarkRow.
   'kv_offloading',
   'kv_offload_backend',
+  'kv_p2p_transfer',
   // v3 agentic nested containers — flattened by flattenAgenticAggRow before
   // the auto-capture loop runs; the raw objects themselves are not metrics.
   'request_metrics',
@@ -88,6 +89,22 @@ export type BenchmarkType = 'single_turn' | 'agentic_traces';
 /** Reduce an offload descriptor ('none'|'dram'|…) to the binary on/off. */
 function descriptorToOnOff(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? (v === 'none' ? 'off' : 'on') : null;
+}
+
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+}
+
+/** Normalize legacy string and current `{ name, version? }` backend metadata. */
+function kvOffloadBackendMetadata(raw: unknown): { name?: string; version?: string } {
+  const legacyName = nonEmptyString(raw);
+  if (legacyName) return { name: legacyName };
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const metadata = raw as Record<string, unknown>;
+  return {
+    name: nonEmptyString(metadata.name),
+    version: nonEmptyString(metadata.version),
+  };
 }
 
 /**
@@ -233,17 +250,22 @@ export function mapBenchmarkRow(
   const metrics = captureNumericMetrics(row);
 
   // Agentic rows emit `offload_mode: "on" | "off"` (or older `offloading: "none"|...`)
-  // — preserve as a stringified metric so the frontend can expose it in tooltips.
-  // v3 rows additionally carry the offload tier + backend ('dram'/'mooncake');
-  // keep them so the UI can say *what kind* of offload, not just on/off.
+  // — preserve as a stringified metric for legacy readers. Runtime cache
+  // descriptors are kept for every benchmark type so fixed-sequence multinode
+  // rows can expose their P2P transfer engine alongside agentic offload details.
   if (isAgentic) {
     (metrics as Record<string, unknown>).offload_mode = offloadModeRaw;
-    if (typeof row.kv_offloading === 'string' && row.kv_offloading.length > 0) {
-      (metrics as Record<string, unknown>).kv_offloading = row.kv_offloading;
-    }
-    if (typeof row.kv_offload_backend === 'string' && row.kv_offload_backend.length > 0) {
-      (metrics as Record<string, unknown>).kv_offload_backend = row.kv_offload_backend;
-    }
+  }
+  const kvOffloading = nonEmptyString(row.kv_offloading);
+  if (kvOffloading) (metrics as Record<string, unknown>).kv_offloading = kvOffloading;
+  const backend = kvOffloadBackendMetadata(row.kv_offload_backend);
+  if (backend.name) (metrics as Record<string, unknown>).kv_offload_backend = backend.name;
+  if (backend.version) {
+    (metrics as Record<string, unknown>).kv_offload_backend_version = backend.version;
+  }
+  const kvP2pTransfer = nonEmptyString(row.kv_p2p_transfer);
+  if (kvP2pTransfer) {
+    (metrics as Record<string, unknown>).kv_p2p_transfer = kvP2pTransfer;
   }
 
   // Slow-tail interactivity invariant. Agentic artifacts ship `*_intvty`, but the

--- a/packages/db/src/etl/runtime-metadata.test.ts
+++ b/packages/db/src/etl/runtime-metadata.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractRuntimeMetadata } from './runtime-metadata';
+
+describe('extractRuntimeMetadata', () => {
+  it('normalizes current component objects and preserves versions', () => {
+    expect(
+      extractRuntimeMetadata({
+        kv_offloading: ' dram ',
+        kv_offload_backend: { name: 'mooncake', version: '0.3.11.post1' },
+        kv_p2p_transfer: 'mori',
+        router: { name: 'sglang-router', version: '0.3.2' },
+      }),
+    ).toEqual({
+      kv_offloading: 'dram',
+      kv_offload_backend: 'mooncake',
+      kv_offload_backend_version: '0.3.11.post1',
+      kv_p2p_transfer: 'mori',
+      router_name: 'sglang-router',
+      router_version: '0.3.2',
+    });
+  });
+
+  it('accepts legacy backend strings and ignores empty or malformed components', () => {
+    expect(
+      extractRuntimeMetadata({
+        kv_offload_backend: 'hicache',
+        kv_p2p_transfer: '',
+        router: { name: '', version: '0.1.14' },
+      }),
+    ).toEqual({
+      kv_offload_backend: 'hicache',
+      router_version: '0.1.14',
+    });
+  });
+});

--- a/packages/db/src/etl/runtime-metadata.test.ts
+++ b/packages/db/src/etl/runtime-metadata.test.ts
@@ -28,9 +28,6 @@ describe('extractRuntimeMetadata', () => {
         kv_p2p_transfer: '',
         router: { name: '', version: '0.1.14' },
       }),
-    ).toEqual({
-      kv_offload_backend: 'hicache',
-      router_version: '0.1.14',
-    });
+    ).toEqual({ kv_offload_backend: 'hicache' });
   });
 });

--- a/packages/db/src/etl/runtime-metadata.ts
+++ b/packages/db/src/etl/runtime-metadata.ts
@@ -1,0 +1,44 @@
+export interface RuntimeMetadata {
+  kv_offloading?: string;
+  kv_offload_backend?: string;
+  kv_offload_backend_version?: string;
+  kv_p2p_transfer?: string;
+  router_name?: string;
+  router_version?: string;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+/** Normalize legacy strings and current `{ name, version? }` component metadata. */
+function componentMetadata(raw: unknown): { name?: string; version?: string } {
+  const legacyName = nonEmptyString(raw);
+  if (legacyName) return { name: legacyName };
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const metadata = raw as Record<string, unknown>;
+  return {
+    name: nonEmptyString(metadata.name),
+    version: nonEmptyString(metadata.version),
+  };
+}
+
+/** Extract runtime components into the flat metrics representation consumed by the app. */
+export function extractRuntimeMetadata(row: Record<string, unknown>): RuntimeMetadata {
+  const metadata: RuntimeMetadata = {};
+  const kvOffloading = nonEmptyString(row.kv_offloading);
+  if (kvOffloading) metadata.kv_offloading = kvOffloading;
+
+  const backend = componentMetadata(row.kv_offload_backend);
+  if (backend.name) metadata.kv_offload_backend = backend.name;
+  if (backend.version) metadata.kv_offload_backend_version = backend.version;
+
+  const transfer = nonEmptyString(row.kv_p2p_transfer);
+  if (transfer) metadata.kv_p2p_transfer = transfer;
+
+  const router = componentMetadata(row.router);
+  if (router.name) metadata.router_name = router.name;
+  if (router.version) metadata.router_version = router.version;
+
+  return metadata;
+}

--- a/packages/db/src/etl/runtime-metadata.ts
+++ b/packages/db/src/etl/runtime-metadata.ts
@@ -30,15 +30,19 @@ export function extractRuntimeMetadata(row: Record<string, unknown>): RuntimeMet
   if (kvOffloading) metadata.kv_offloading = kvOffloading;
 
   const backend = componentMetadata(row.kv_offload_backend);
-  if (backend.name) metadata.kv_offload_backend = backend.name;
-  if (backend.version) metadata.kv_offload_backend_version = backend.version;
+  if (backend.name) {
+    metadata.kv_offload_backend = backend.name;
+    if (backend.version) metadata.kv_offload_backend_version = backend.version;
+  }
 
   const transfer = nonEmptyString(row.kv_p2p_transfer);
   if (transfer) metadata.kv_p2p_transfer = transfer;
 
   const router = componentMetadata(row.router);
-  if (router.name) metadata.router_name = router.name;
-  if (router.version) metadata.router_version = router.version;
+  if (router.name) {
+    metadata.router_name = router.name;
+    if (router.version) metadata.router_version = router.version;
+  }
 
   return metadata;
 }

--- a/packages/db/src/lib/runtime-metadata-artifacts.test.ts
+++ b/packages/db/src/lib/runtime-metadata-artifacts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ArtifactMeta } from './github-artifacts';
+import { repositoryFromRunUrl, selectBenchmarkArtifacts } from './runtime-metadata-artifacts';
+
+const artifact = (name: string, created_at = '2026-07-16T00:00:00Z'): ArtifactMeta => ({
+  name,
+  created_at,
+  archive_download_url: `https://example.com/${name}`,
+});
+
+describe('repositoryFromRunUrl', () => {
+  it('extracts public and private GitHub repositories', () => {
+    expect(
+      repositoryFromRunUrl(
+        'https://github.com/SemiAnalysisAI/InferenceX-Private/actions/runs/29357450774',
+      ),
+    ).toBe('SemiAnalysisAI/InferenceX-Private');
+  });
+
+  it('returns null for missing or unrelated URLs', () => {
+    expect(repositoryFromRunUrl(null)).toBeNull();
+    expect(repositoryFromRunUrl('https://example.com/actions/runs/1')).toBeNull();
+  });
+});
+
+describe('selectBenchmarkArtifacts', () => {
+  it('prefers the compact aggregate benchmark artifact', () => {
+    expect(
+      selectBenchmarkArtifacts([
+        artifact('bmk_agentic_config_a_01'),
+        artifact('results_bmk'),
+        artifact('server_logs_config_a'),
+      ]).map((entry) => entry.name),
+    ).toEqual(['results_bmk']);
+  });
+
+  it('falls back to deduplicated per-config benchmark artifacts', () => {
+    expect(
+      selectBenchmarkArtifacts([
+        artifact('bmk_agentic_config_a_runner_01', '2026-07-16T00:00:00Z'),
+        artifact('bmk_agentic_config_a_runner_02', '2026-07-16T01:00:00Z'),
+        artifact('server_logs_config_a'),
+      ]).map((entry) => entry.name),
+    ).toEqual(['bmk_agentic_config_a_runner_02']);
+  });
+});

--- a/packages/db/src/lib/runtime-metadata-artifacts.ts
+++ b/packages/db/src/lib/runtime-metadata-artifacts.ts
@@ -1,0 +1,16 @@
+import { dedupeArtifactsByLogicalName, type ArtifactMeta } from './github-artifacts.js';
+
+/** Prefer the compact aggregate; otherwise retain the latest per-config benchmark artifacts. */
+export function selectBenchmarkArtifacts(artifacts: readonly ArtifactMeta[]): ArtifactMeta[] {
+  const deduped = dedupeArtifactsByLogicalName(artifacts);
+  const aggregate = deduped.get('results_bmk');
+  if (aggregate) return [aggregate];
+  return [...deduped.values()].filter((artifact) => artifact.name.startsWith('bmk_'));
+}
+
+export function repositoryFromRunUrl(url: string | null): string | null {
+  const match = url?.match(
+    /^https:\/\/github\.com\/(?<repository>[^/]+\/[^/]+)\/actions\/runs\/\d+/u,
+  );
+  return match?.groups?.repository ?? null;
+}


### PR DESCRIPTION
## Port note

This PR ports the exact feature patch from [#604](https://github.com/SemiAnalysisAI/InferenceX-app/pull/604) onto `master`. PR #604 was accidentally merged into the now-defunct `feat/agentx` branch, so its changes never reached production. No additional feature scope is included here.

## Summary

- Replace the binary `Offload Mode: ON/OFF` tooltip row with the actual KV offload type, omitting the row when the type is `none`.
- Show KV offload engine/version, KV transfer engine, and router name/version when reported by the benchmark artifact.
- Show GPU and theoretical Cache hit rates; show CPU Cache hit rate only when KV offloading is enabled.
- Preserve nested runtime component metadata during ingest and render it consistently across official scatter plots, GPU comparison plots, fixed-sequence and Agentic data, and `?unofficialrun=` overlays.
- Restore unofficial-run hover tooltips by passing the portaled tooltip node through the shared D3 render context.
- Add an artifact-backed operational backfill that merges only runtime metadata keys into historical rows.
- Keep English and Simplified Chinese tooltip labels in sync.

## Why

The benchmark producer emits structured runtime-component metadata, but the previous mapper discarded nested offload-engine versions, KV-transfer values, and router objects before data reached the database. This change centralizes extraction in the ingest layer, preserves a canonical flattened representation, and displays only fields actually declared by the source artifact.

The historical-data backfill is deliberately narrow: it merges only runtime metadata keys and does not rewrite measured latency, throughput, Cache hit rates, topology, config identity, trace blobs, or row IDs.

## Validation

- Verified that the port has the same 24-file patch content and the same `821 insertions / 27 deletions` as #604; only hunk line numbers differ because the target is the newer `master` branch.
- `git diff --check`
- Tests were not rerun for this mechanical port, per request. The original #604 validation recorded 3,027 passing unit tests, typecheck, lint, format, and the relevant Cypress specs.

## 中文说明

## 移植说明

本 PR 将 [#604](https://github.com/SemiAnalysisAI/InferenceX-app/pull/604) 的完整功能补丁移植到 `master`。#604 误合并到了现已弃用的 `feat/agentx` 分支，因此相关改动从未进入生产环境。本 PR 不包含额外功能范围。

## 概要

- 将提示卡中的二元 `Offload Mode: ON/OFF` 改为真实的 KV 卸载类型；类型为 `none` 时隐藏该行。
- 在基准测试产物提供数据时，展示 KV 卸载引擎及版本、KV 传输引擎以及路由器名称和版本。
- 展示 GPU 和理论 Cache 命中率；仅在启用 KV 卸载时展示 CPU Cache 命中率。
- 在摄取流程中保留嵌套运行时组件元数据，并在正式运行散点图、GPU 对比图、固定序列长度及 Agentic 数据和 `?unofficialrun=` 覆盖层中统一展示。
- 通过共享 D3 渲染上下文传递 Portal 中的提示卡节点，恢复非正式运行覆盖层的悬停提示卡。
- 新增基于原始产物的运维回填工具，只向历史数据合并运行时元数据字段。
- 保持英文和简体中文提示卡标签同步。

## 原因

基准测试生产端会上报结构化运行时组件元数据，但旧版映射器会在数据写入数据库前丢弃嵌套卸载引擎版本、KV 传输值和路由器对象。本次改动在摄取层集中提取这些字段，保留统一的展开表示，并且只展示源产物明确声明的字段。

历史数据回填的范围受到严格限制：仅合并运行时元数据字段，不会改写实测延迟、吞吐量、Cache 命中率、拓扑、配置标识、trace blob 或数据行 ID。

## 验证

- 已确认本次移植与 #604 具有相同的 24 个文件补丁内容，以及相同的 `821 行新增 / 27 行删除`；由于目标是更新后的 `master` 分支，仅补丁块行号不同。
- `git diff --check`
- 按要求，本次机械移植未重新运行测试。原 #604 的验证记录包括 3,027 项单元测试通过，以及 typecheck、lint、format 和相关 Cypress 测试通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ingest mapping, chart tooltips, and an operational DB backfill; scope is display/metadata-only with no measured-metric rewrites, but backfill mis-matches could leave gaps (script exits non-zero on missing rows).
> 
> **Overview**
> Inference charts and the agentic point header now show **structured KV/runtime metadata** from benchmark artifacts instead of a bare **Offload Mode** flag, with **CPU cache hit** hidden when offloading is not actually enabled.
> 
> **Ingest and data model:** The DB mapper flattens `kv_offloading`, offload backend (with version), `kv_p2p_transfer`, and router (with version) for **all** benchmark types—not only agentic rows—and chart points pick up the same fields via `benchmark-transform`. A new **`db:backfill-runtime-metadata`** job re-downloads benchmark JSON from GitHub Actions and **JSONB-merges only those keys** into matching historical rows.
> 
> **UI:** Shared `isKvOffloadEnabled` drives CPU hit visibility in tooltips and `PointSummary`. Tooltip copy adds offload type/engine, transfer engine, router, and GPU/theoretical hits, with **en/zh** labels and **legacy agentic** fallbacks when tier metadata is missing. Scatter, GPU compare, and unofficial overlays pass **locale**; unofficial overlay hovers use the chart’s **portaled tooltip element** from D3 `RenderContext` so tooltips render again.
> 
> **Tests:** Vitest and Cypress cover stale CPU suppression, new tooltip rows, and overlay hover content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a388a95e97d07cd75adc88e3e622c57d5b2c4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->