### PR TITLE
[port] fix(agentic): Align changelog configs with legend / 统一 Agentic 变更记录与图例配置名称

### DIFF
--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -81,6 +81,7 @@ import {
   renderKnownIssueAnnotations,
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchesQuickFilters } from '@/components/inference/utils/quickFilters';
+import { changelogConfigToHwKey } from '@/components/inference/utils/changelogFormatters';
 
 // Greedy label-collision avoidance.
 // Each candidate is the y-position of the FIRST baseline (relative to point
@@ -634,16 +635,17 @@ const ScatterGraph = React.memo(
 
     // --- Changelog ---
     const changelog = availableRuns ? availableRuns[selectedRunId]?.changelog || null : null;
-    const highlightConfigSuffixes = useMemo(() => {
+    const highlightedHwKeys = useMemo(() => {
       if (availableRuns) {
         const cl = availableRuns[selectedRunId]?.changelog;
         if (cl) {
-          const suffixes = cl.entries.flatMap((entry: any) =>
+          const hwKeys = cl.entries.flatMap((entry: any) =>
             (entry.config_keys ?? entry['config-keys'] ?? [])
               .filter((key: string) => selectedPrecisions.includes(key.split('-')[1]))
-              .map((key: string) => key.split('-').slice(2).join('-')),
+              .map(changelogConfigToHwKey)
+              .filter((key: string | null): key is string => key !== null),
           );
-          return new Set(suffixes);
+          return new Set(hwKeys);
         }
       }
       return new Set<string>();
@@ -2913,7 +2915,7 @@ const ScatterGraph = React.memo(
                     label: getDisplayLabel(hwConfig),
                     color: resolveColor(key),
                     title: hwConfig.gpu,
-                    isHighlighted: highlightConfigSuffixes.has(key.replaceAll('_', '-')),
+                    isHighlighted: highlightedHwKeys.has(key),
                     hw: key,
                     isActive: showAllHardwareTypes ? true : effectiveOfficialHwTypes.has(key),
                     onClick: showAllHardwareTypes

--- a/packages/app/src/components/inference/utils/changelogFormatters.test.ts
+++ b/packages/app/src/components/inference/utils/changelogFormatters.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { configKeyMatchesHwKey, formatConfigKeys } from './changelogFormatters';
+import {
+  changelogConfigToHwKey,
+  configKeyMatchesHwKey,
+  formatConfigKeys,
+} from './changelogFormatters';
 
 describe('formatConfigKeys', () => {
   it('formats a standard config key', () => {
@@ -43,6 +47,26 @@ describe('formatConfigKeys', () => {
     expect(result).toContain('TRTLLM');
     expect(result).toContain('FP4');
   });
+
+  it('uses the legend framework label for an agentic HiCache config', () => {
+    expect(formatConfigKeys('dsv4-fp4-mi355x-mori-sglang-agentic-hicache')).toBe(
+      'MI355X (MoRI SGLang) DeepSeek-V4-Pro FP4',
+    );
+  });
+});
+
+describe('changelogConfigToHwKey', () => {
+  it('strips agentic scenario and cache-backend suffixes from the legend identity', () => {
+    expect(changelogConfigToHwKey('dsv4-fp4-mi355x-mori-sglang-agentic-hicache')).toBe(
+      'mi355x_mori-sglang',
+    );
+  });
+
+  it('keeps a trailing MTP spec method while dropping agentic metadata', () => {
+    expect(changelogConfigToHwKey('dsv4-fp4-mi355x-sglang-agentic-hicache-mtp')).toBe(
+      'mi355x_sglang_mtp',
+    );
+  });
 });
 
 describe('configKeyMatchesHwKey', () => {
@@ -66,6 +90,12 @@ describe('configKeyMatchesHwKey', () => {
 
   it('matches old sglang-disagg keys to mori-sglang hwKey', () => {
     expect(configKeyMatchesHwKey('dsr1-fp8-mi355x-sglang-disagg', 'mi355x_mori-sglang')).toBe(true);
+  });
+
+  it('matches an agentic HiCache changelog key to the framework-only legend key', () => {
+    expect(
+      configKeyMatchesHwKey('dsv4-fp4-mi355x-mori-sglang-agentic-hicache', 'mi355x_mori-sglang'),
+    ).toBe(true);
   });
 
   it('matches sglang framework', () => {

--- a/packages/app/src/components/inference/utils/changelogFormatters.tsx
+++ b/packages/app/src/components/inference/utils/changelogFormatters.tsx
@@ -1,10 +1,40 @@
 import {
-  resolveFrameworkAliasesInString,
+  FRAMEWORK_ALIASES,
+  FW_REGISTRY,
+  resolveFrameworkAlias,
   resolveFrameworkPartLabel,
 } from '@semianalysisai/inferencex-constants';
 
 import { type Precision, MODEL_PREFIX_MAPPING, getPrecisionLabel } from '@/lib/data-mappings';
-import { getFrameworkLabel } from '@/lib/utils';
+import { getHardwareConfig } from '@/lib/constants';
+import { getDisplayLabel } from '@/lib/utils';
+
+const CHANGELOG_FRAMEWORK_KEYS = [
+  ...Object.keys(FW_REGISTRY),
+  ...Object.keys(FRAMEWORK_ALIASES),
+].toSorted((a, b) => b.length - a.length);
+
+/**
+ * Convert a changelog config key into the canonical hardware key used by chart
+ * points and the legend. Agentic config keys append scenario details such as
+ * `agentic`, `hicache`, and `pcp` after the serving framework; those are not
+ * framework labels and must not become part of the legend identity.
+ */
+export function changelogConfigToHwKey(configKey: string): string | null {
+  const parts = configKey.toLowerCase().split('-');
+  const gpu = parts[2];
+  const remainder = parts.slice(3).join('-');
+  if (!gpu || !remainder) return null;
+
+  const framework = CHANGELOG_FRAMEWORK_KEYS.find(
+    (candidate) => remainder === candidate || remainder.startsWith(`${candidate}-`),
+  );
+  if (!framework) return null;
+
+  const trailingParts = remainder.slice(framework.length).split('-').filter(Boolean);
+  const specSuffix = trailingParts.includes('mtp') ? '_mtp' : '';
+  return `${gpu}_${resolveFrameworkAlias(framework)}${specSuffix}`;
+}
 
 export function formatChangelogDescription(desc: string | string[]) {
   if (typeof desc === 'string') {
@@ -33,23 +63,26 @@ export function formatChangelogDescription(desc: string | string[]) {
  * Normalizes both to hyphen-separated form for comparison.
  */
 export function configKeyMatchesHwKey(configKey: string, hwKey: string): boolean {
-  const gpuAndFramework = resolveFrameworkAliasesInString(configKey.split('-').slice(2).join('-'));
-  const normalizedHwKey = hwKey.replaceAll('_', '-');
-  return gpuAndFramework === normalizedHwKey;
+  return changelogConfigToHwKey(configKey) === hwKey;
 }
 
 export function formatConfigKeys(key: string) {
   const parts = key.split('-');
   const model = parts[0];
   const precision = parts[1];
-  const gpu = parts[2];
-  const framework = parts.slice(3).join('-');
-  // Strip -mtp suffix before lookup; MTP is shown separately
-  const isMtp = framework.endsWith('-mtp');
-  const baseFramework = isMtp ? framework.slice(0, -4) : framework;
-  const baseLabel = getFrameworkLabel(baseFramework);
-  // M3's `mtp` spec token renders as "EAGLE"; every other model keeps "MTP".
-  const mtpLabel = resolveFrameworkPartLabel(MODEL_PREFIX_MAPPING[model], 'mtp');
-  const frameworkLabel = isMtp ? `${baseLabel}, ${mtpLabel}` : baseLabel;
-  return `${gpu.toUpperCase()} (${frameworkLabel}) ${MODEL_PREFIX_MAPPING[model]} ${getPrecisionLabel(precision as Precision)}`;
+  const modelLabel = MODEL_PREFIX_MAPPING[model];
+  const hwKey = changelogConfigToHwKey(key);
+
+  if (!hwKey) {
+    const gpu = parts[2]?.toUpperCase() ?? '';
+    const framework = parts.slice(3).join('-');
+    const frameworkLabel = resolveFrameworkPartLabel(modelLabel, framework);
+    return `${gpu} (${frameworkLabel}) ${modelLabel} ${getPrecisionLabel(precision as Precision)}`;
+  }
+
+  // Use the same hardware entry builder and display combiner as the legend so
+  // aliases, compound framework names, and model-specific spec labels cannot
+  // drift between the two surfaces.
+  const hardwareLabel = getDisplayLabel(getHardwareConfig(hwKey, modelLabel));
+  return `${hardwareLabel} ${modelLabel} ${getPrecisionLabel(precision as Precision)}`;
 }


### PR DESCRIPTION
## Port note

Ports the exact three-file patch from [#603](https://github.com/SemiAnalysisAI/InferenceX-app/pull/603) onto `master`. #603 was merged only into the now-defunct `feat/agentx` branch and therefore was not included in the separate #604 → #607 port.

## Summary

- Parse Agentic changelog config keys into the same canonical hardware key used by chart points and the legend.
- Render “Updated Configs” with the legend’s shared hardware-label builder.
- Use the canonical key for modified-config highlighting, restoring the red legend state for Agentic configs.
- Preserve existing fixed-sequence changelog behavior.

## Root cause and impact

Agentic changelog keys append scenario metadata such as `agentic-hicache` after the framework. The old formatter treated those suffixes as part of the framework name, producing labels such as `VLLM AGENTIC`, and the highlight path failed to match the legend key.

After this change, the changelog uses the same canonical label as the legend and highlights the corresponding modified configuration correctly.

## Validation

- Verified the normalized three-file patch matches #603 exactly: 86 insertions and 21 deletions.
- `git diff --check`
- Tests were not rerun for this mechanical port. Original #603 validation recorded 2,544 passing app unit tests plus typecheck, lint, and format.

## 中文说明

## 移植说明

将 [#603](https://github.com/SemiAnalysisAI/InferenceX-app/pull/603) 的完整三文件补丁移植到 `master`。#603 仅合并到了现已弃用的 `feat/agentx` 分支，因此未包含在另一个 #604 → #607 移植中。

## 概要

- 将 Agentic 变更记录中的 config key 解析为图表数据点和图例共用的规范化硬件 key。
- “Updated Configs” 改用图例的统一硬件名称生成逻辑。
- 修改配置的红色高亮使用同一规范化 key，恢复 Agentic 配置的图例高亮。
- 保持现有固定序列长度变更记录行为不变。

## 根因与影响

Agentic 变更记录的 config key 会在 framework 后附加 `agentic-hicache` 等场景元数据。旧 formatter 将这些后缀误当作 framework 名称的一部分，因此产生 `VLLM AGENTIC` 等标签，并且高亮逻辑无法匹配图例 key。

本次改动后，变更记录会使用与图例一致的规范化名称，并正确高亮对应的已修改配置。

## 验证

- 已确认规范化后的三文件补丁与 #603 完全一致：新增 86 行，删除 21 行。
- `git diff --check`
- 本次机械移植未重新运行测试。原 #603 的验证记录包括 2,544 项 app 单元测试通过，以及 typecheck、lint 和 format 通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized changelog/legend formatting and highlight logic with new unit tests; no auth, data, or API changes.
> 
> **Overview**
> Agentic changelog config keys append scenario metadata (e.g. `agentic-hicache`) after the serving framework. The PR introduces **`changelogConfigToHwKey`** to map those keys to the same canonical `hwKey` the scatter chart and legend use, stripping scenario suffixes while preserving **`mtp`** when present.
> 
> **Changelog UI** now builds “Updated Configs” labels via **`getHardwareConfig`** / **`getDisplayLabel`** (same as the legend) instead of treating trailing tokens as framework names. **`configKeyMatchesHwKey`** delegates to the new parser, so comparison changelog GPU filtering stays consistent.
> 
> **Scatter legend highlighting** for modified configs switches from hyphen-suffix matching to a **`Set`** of canonical hw keys derived from changelog entries, restoring red highlight for agentic configs that previously failed to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872f34b0bf5b9b8f782c826ab8ccc3dffcf6b8ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->