### PR TITLE
fix(agentic): Show runtime metadata in point details / 在 Agentic 数据点详情中展示运行时元数据

### DIFF
--- a/packages/app/cypress/e2e/agentic-point-time-series.cy.ts
+++ b/packages/app/cypress/e2e/agentic-point-time-series.cy.ts
@@ -215,15 +215,19 @@ const pointMeta = {
   spec_method: 'none',
   disagg: true,
   conc: 128,
-  offload_mode: 'off',
+  offload_mode: 'on',
+  kv_offloading: 'dram',
+  kv_offload_backend: 'lmcache',
+  kv_offload_backend_version: '0.5.1',
+  kv_p2p_transfer: 'mooncake',
+  router_name: 'vllm-router',
+  router_version: '0.1.14',
   isl: null,
   osl: null,
   benchmark_type: 'agentic_traces',
   date: '2026-06-23',
   run_url: null,
   server_gpu_cache_hit_rate: 0.5,
-  // Reproduces historical rows that retained a CPU hit metric after offload
-  // was disabled. The agentic point summary must suppress this stale value.
   server_cpu_cache_hit_rate: 0.42,
 };
 
@@ -299,8 +303,17 @@ describe('Agentic point orchestrator metric sources', () => {
   });
 
   it('switches every server chart to an orchestrator-normalized worker', () => {
-    cy.contains('GPU cache hit').should('be.visible');
-    cy.contains('CPU cache hit').should('not.exist');
+    cy.get('[data-testid="point-summary"]')
+      .should('contain.text', 'Offload Type')
+      .and('contain.text', 'DRAM')
+      .and('contain.text', 'KV Offload Engine')
+      .and('contain.text', 'LMCache 0.5.1')
+      .and('contain.text', 'KV Transfer Engine')
+      .and('contain.text', 'Mooncake')
+      .and('contain.text', 'Router')
+      .and('contain.text', 'vLLM Router 0.1.14')
+      .and('contain.text', 'GPU cache hit')
+      .and('contain.text', 'CPU cache hit');
 
     cy.get('[data-testid="metric-source-toolbar"]')
       .should('have.css', 'position', 'sticky')

--- a/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
+++ b/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
@@ -25,8 +25,8 @@ vi.mock('@/lib/api-cache', () => ({
 }));
 
 import { STATS_VERSION } from '@semianalysisai/inferencex-db/queries/agentic-aggregates';
-import { CHART_SERIES_VERSION } from '@semianalysisai/inferencex-db/etl/compute-chart-series';
 import { REQUEST_TIMELINE_VERSION } from '@semianalysisai/inferencex-db/etl/compute-request-timeline';
+import { TRACE_SERVER_METRICS_VERSION } from '@semianalysisai/inferencex-db/queries/trace-server-metrics';
 
 import { CACHE_KEY_PREFIX as derivedAgenticMetricsKey } from './derived-agentic-metrics/route';
 import { CACHE_KEY_PREFIX as agenticAggregatesKey } from './agentic-aggregates/route';
@@ -47,8 +47,8 @@ describe('agentic blob-cache keys are version-derived', () => {
     expect(requestTimelineKey).toBe(`request-timeline-v${REQUEST_TIMELINE_VERSION}`);
   });
 
-  it('trace-server-metrics key embeds CHART_SERIES_VERSION', () => {
-    expect(traceServerMetricsKey).toBe(`trace-server-metrics-v${CHART_SERIES_VERSION}`);
+  it('trace-server-metrics key embeds its composite response version', () => {
+    expect(traceServerMetricsKey).toBe(`trace-server-metrics-v${TRACE_SERVER_METRICS_VERSION}`);
   });
 
   it('trace-histograms key embeds REQUEST_TIMELINE_VERSION (its payload is read from request_timeline)', () => {

--- a/packages/app/src/app/api/v1/trace-server-metrics/route.ts
+++ b/packages/app/src/app/api/v1/trace-server-metrics/route.ts
@@ -1,8 +1,8 @@
-import { CHART_SERIES_VERSION } from '@semianalysisai/inferencex-db/etl/compute-chart-series';
 import { getDb } from '@semianalysisai/inferencex-db/connection';
 
 import {
   getTraceServerMetrics,
+  TRACE_SERVER_METRICS_VERSION,
   type TraceServerMetrics,
 } from '@semianalysisai/inferencex-db/queries/trace-server-metrics';
 
@@ -12,12 +12,13 @@ import { idQueryRoute } from '../id-routes';
 
 export const dynamic = 'force-dynamic';
 
-// Key derived from CHART_SERIES_VERSION (governs the `chart_series` payload).
+// Key derived from TRACE_SERVER_METRICS_VERSION (governs chart_series plus
+// the separately queried point-metadata payload).
 // The blob cache is write-once with no post-backfill purge, so the
 // version-derived key is what rolls the namespace on a bump — a hand-written
 // string would serve stale blob-cached series forever.
 /** Version-derived blob-cache key namespace (exported for the key-derivation test). */
-export const CACHE_KEY_PREFIX = `trace-server-metrics-v${CHART_SERIES_VERSION}`;
+export const CACHE_KEY_PREFIX = `trace-server-metrics-v${TRACE_SERVER_METRICS_VERSION}`;
 
 const getCachedTraceServerMetrics = cachedQuery(
   (id: number): Promise<TraceServerMetrics | null> => getTraceServerMetrics(getDb(), id),

--- a/packages/app/src/components/inference/agentic-point/point-summary.test.ts
+++ b/packages/app/src/components/inference/agentic-point/point-summary.test.ts
@@ -1,6 +1,11 @@
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+const localeState = vi.hoisted(() => ({ pathname: '/inference/agentic/206885' }));
+vi.mock('next/navigation', () => ({
+  usePathname: () => localeState.pathname,
+}));
 
 import type { PointMeta } from '@/hooks/api/use-trace-server-metrics';
 
@@ -17,6 +22,12 @@ function meta(overrides: Partial<PointMeta> = {}): PointMeta {
     disagg: true,
     conc: 128,
     offload_mode: 'off',
+    kv_offloading: null,
+    kv_offload_backend: null,
+    kv_offload_backend_version: null,
+    kv_p2p_transfer: null,
+    router_name: null,
+    router_version: null,
     isl: null,
     osl: null,
     benchmark_type: 'agentic_traces',
@@ -43,5 +54,51 @@ describe('PointSummary', () => {
 
     expect(html).toContain('CPU cache hit');
     expect(html).toContain('42.00%');
+  });
+
+  it('shows runtime component names and independently reported versions', () => {
+    const html = renderToStaticMarkup(
+      createElement(PointSummary, {
+        meta: meta({
+          offload_mode: 'on',
+          kv_offloading: 'dram',
+          kv_offload_backend: 'lmcache',
+          kv_offload_backend_version: '0.5.1',
+          kv_p2p_transfer: 'mooncake',
+          router_name: 'vllm-router',
+          router_version: '0.1.14',
+        }),
+      }),
+    );
+
+    expect(html).toContain('Offload Type');
+    expect(html).toContain('DRAM');
+    expect(html).toContain('KV Offload Engine');
+    expect(html).toContain('LMCache 0.5.1');
+    expect(html).toContain('KV Transfer Engine');
+    expect(html).toContain('Mooncake');
+    expect(html).toContain('Router');
+    expect(html).toContain('vLLM Router 0.1.14');
+  });
+
+  it('renders runtime metadata labels in Simplified Chinese on /zh', () => {
+    localeState.pathname = '/zh/inference/agentic/206885';
+    const html = renderToStaticMarkup(
+      createElement(PointSummary, {
+        meta: meta({
+          kv_offloading: 'dram',
+          kv_offload_backend: 'hicache',
+          router_name: 'sglang-router',
+          router_version: '0.3.2',
+        }),
+      }),
+    );
+    localeState.pathname = '/inference/agentic/206885';
+
+    expect(html).toContain('卸载类型');
+    expect(html).toContain('KV 卸载引擎');
+    expect(html).toContain('HiCache');
+    expect(html).toContain('路由器');
+    expect(html).toContain('SGLang Router 0.3.2');
   });
 });

--- a/packages/app/src/components/inference/agentic-point/point-summary.tsx
+++ b/packages/app/src/components/inference/agentic-point/point-summary.tsx
@@ -3,7 +3,46 @@
 import type { ReactNode } from 'react';
 
 import type { PointMeta } from '@/hooks/api/use-trace-server-metrics';
+import type { Locale } from '@/lib/i18n';
 import { isKvOffloadEnabled } from '@/lib/kv-offload';
+import { useLocale } from '@/lib/use-locale';
+import {
+  offloadTypeLabel,
+  versionedComponentLabel,
+} from '@/components/inference/utils/runtime-metadata-labels';
+
+const STRINGS = {
+  en: {
+    selectedPoint: 'Selected point',
+    disagg: 'disagg',
+    githubRun: 'GitHub Actions run →',
+    offloadType: 'Offload Type',
+    offloadBackend: 'KV Offload Engine',
+    transferEngine: 'KV Transfer Engine',
+    router: 'Router',
+    concurrency: 'Concurrency',
+    gpuCacheHit: 'GPU cache hit',
+    cpuCacheHit: 'CPU cache hit',
+    enabledLegacy: 'Enabled (legacy data)',
+    disabledLegacy: 'Disabled (legacy data)',
+    none: 'None',
+  },
+  zh: {
+    selectedPoint: '已选数据点',
+    disagg: '解耦',
+    githubRun: 'GitHub Actions 运行 →',
+    offloadType: '卸载类型',
+    offloadBackend: 'KV 卸载引擎',
+    transferEngine: 'KV 传输引擎',
+    router: '路由器',
+    concurrency: '并发数',
+    gpuCacheHit: 'GPU Cache 命中率',
+    cpuCacheHit: 'CPU Cache 命中率',
+    enabledLegacy: '已启用（旧版数据）',
+    disabledLegacy: '已禁用（旧版数据）',
+    none: '无',
+  },
+} as const;
 
 const fmtPct = (v: number | null | undefined): string =>
   v === null || v === undefined || Number.isNaN(v) ? '—' : `${(v * 100).toFixed(2)}%`;
@@ -17,16 +56,32 @@ function MetaLine({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-/** Selected-point header: config facts (offload, concurrency, cache hit rates, ISL/OSL). */
+function offloadDisplay(meta: PointMeta, locale: Locale): string {
+  const t = STRINGS[locale];
+  const type = meta.kv_offloading?.trim();
+  if (type) return type.toLowerCase() === 'none' ? t.none : offloadTypeLabel(type);
+  if (!meta.offload_mode) return t.none;
+  return meta.offload_mode.toLowerCase() === 'on' ? t.enabledLegacy : t.disabledLegacy;
+}
+
+/** Selected-point header: runtime components, concurrency, cache hit rates, and ISL/OSL. */
 export function PointSummary({ meta }: { meta: PointMeta }) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
   const showCpuCacheHit = isKvOffloadEnabled(meta);
+  const offloadBackend = versionedComponentLabel(
+    meta.kv_offload_backend,
+    meta.kv_offload_backend_version,
+  );
+  const transferEngine = versionedComponentLabel(meta.kv_p2p_transfer, null);
+  const router = versionedComponentLabel(meta.router_name, meta.router_version);
 
   return (
-    <div className="mb-4">
+    <div className="mb-4" data-testid="point-summary">
       <div className="flex items-baseline justify-between gap-3 mb-2">
         <p className="text-sm text-muted-foreground">
-          Selected point
-          {meta.disagg ? ' · disagg' : ''}
+          {t.selectedPoint}
+          {meta.disagg ? ` · ${t.disagg}` : ''}
           {meta.spec_method && meta.spec_method !== 'none' ? ` · spec=${meta.spec_method}` : ''}
         </p>
         {meta.run_url && (
@@ -36,16 +91,19 @@ export function PointSummary({ meta }: { meta: PointMeta }) {
             rel="noopener noreferrer"
             className="text-xs text-muted-foreground hover:text-foreground underline"
           >
-            GitHub Actions run →
+            {t.githubRun}
           </a>
         )}
       </div>
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
-        <MetaLine label="Offload" value={(meta.offload_mode ?? 'off').toUpperCase()} />
-        <MetaLine label="Concurrency" value={meta.conc} />
-        <MetaLine label="GPU cache hit" value={fmtPct(meta.server_gpu_cache_hit_rate)} />
+        <MetaLine label={t.offloadType} value={offloadDisplay(meta, locale)} />
+        {offloadBackend && <MetaLine label={t.offloadBackend} value={offloadBackend} />}
+        {transferEngine && <MetaLine label={t.transferEngine} value={transferEngine} />}
+        {router && <MetaLine label={t.router} value={router} />}
+        <MetaLine label={t.concurrency} value={meta.conc} />
+        <MetaLine label={t.gpuCacheHit} value={fmtPct(meta.server_gpu_cache_hit_rate)} />
         {showCpuCacheHit && (
-          <MetaLine label="CPU cache hit" value={fmtPct(meta.server_cpu_cache_hit_rate)} />
+          <MetaLine label={t.cpuCacheHit} value={fmtPct(meta.server_cpu_cache_hit_rate)} />
         )}
         {meta.isl !== null && <MetaLine label="ISL" value={meta.isl} />}
         {meta.osl !== null && <MetaLine label="OSL" value={meta.osl} />}

--- a/packages/app/src/components/inference/utils/runtime-metadata-labels.test.ts
+++ b/packages/app/src/components/inference/utils/runtime-metadata-labels.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cacheImplementationLabel,
+  offloadTypeLabel,
+  versionedComponentLabel,
+} from './runtime-metadata-labels';
+
+describe('runtime metadata labels', () => {
+  it('normalizes known component names and preserves unknown names', () => {
+    expect(cacheImplementationLabel('vllm-simple')).toBe('vLLM Simple');
+    expect(cacheImplementationLabel('MOONCAKE')).toBe('Mooncake');
+    expect(cacheImplementationLabel('custom-engine')).toBe('custom-engine');
+  });
+
+  it('combines independently reported component versions', () => {
+    expect(versionedComponentLabel('lmcache', '0.5.1')).toBe('LMCache 0.5.1');
+    expect(versionedComponentLabel('hicache', null)).toBe('HiCache');
+    expect(versionedComponentLabel(null, 'ignored')).toBeNull();
+  });
+
+  it('formats DRAM and other offload types consistently', () => {
+    expect(offloadTypeLabel('dram')).toBe('DRAM');
+    expect(offloadTypeLabel('cpu')).toBe('CPU');
+  });
+});

--- a/packages/app/src/components/inference/utils/runtime-metadata-labels.ts
+++ b/packages/app/src/components/inference/utils/runtime-metadata-labels.ts
@@ -1,0 +1,31 @@
+const CACHE_IMPLEMENTATION_LABELS: Record<string, string> = {
+  hicache: 'HiCache',
+  lmcache: 'LMCache',
+  mooncake: 'Mooncake',
+  mori: 'MoRI',
+  moriio: 'MoRI-IO',
+  'mori-io': 'MoRI-IO',
+  nixl: 'NIXL',
+  atomesh: 'AtoMesh',
+  'vllm-native': 'vLLM Native',
+  'vllm-router': 'vLLM Router',
+  'vllm-simple': 'vLLM Simple',
+  'sglang-router': 'SGLang Router',
+};
+
+export const cacheImplementationLabel = (value: string): string =>
+  CACHE_IMPLEMENTATION_LABELS[value.toLowerCase()] ?? value;
+
+export const offloadTypeLabel = (value: string): string => {
+  if (value.toLowerCase() === 'dram') return 'DRAM';
+  return value.toUpperCase();
+};
+
+export const versionedComponentLabel = (
+  name: string | null | undefined,
+  version: string | null | undefined,
+): string | null => {
+  if (!name) return null;
+  const label = cacheImplementationLabel(name);
+  return version ? `${label} ${version}` : label;
+};

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -5,6 +5,11 @@ import { isKvOffloadEnabled } from '@/lib/kv-offload';
 
 import type { HardwareConfig, InferenceData, OverlayData } from '@/components/inference/types';
 import { parallelismLabel } from '@/components/inference/utils/parallelism-label';
+import {
+  cacheImplementationLabel,
+  offloadTypeLabel,
+  versionedComponentLabel,
+} from '@/components/inference/utils/runtime-metadata-labels';
 
 export interface TooltipConfig {
   /** The data point to display */
@@ -119,29 +124,6 @@ const CACHE_STRINGS = {
   },
 } as const;
 
-const CACHE_IMPLEMENTATION_LABELS: Record<string, string> = {
-  hicache: 'HiCache',
-  lmcache: 'LMCache',
-  mooncake: 'Mooncake',
-  mori: 'MoRI',
-  moriio: 'MoRI-IO',
-  'mori-io': 'MoRI-IO',
-  nixl: 'NIXL',
-  atomesh: 'AtoMesh',
-  'vllm-native': 'vLLM Native',
-  'vllm-router': 'vLLM Router',
-  'vllm-simple': 'vLLM Simple',
-  'sglang-router': 'SGLang Router',
-};
-
-const cacheImplementationLabel = (value: string): string =>
-  CACHE_IMPLEMENTATION_LABELS[value.toLowerCase()] ?? value;
-
-const offloadTypeLabel = (value: string): string => {
-  if (value.toLowerCase() === 'dram') return 'DRAM';
-  return value.toUpperCase();
-};
-
 /**
  * Cache configuration and hit-rate rows shared by fixed-sequence, agentic,
  * official, comparison, and unofficial-run tooltips.
@@ -157,17 +139,18 @@ const generateCacheMetadataHTML = (d: InferenceData, locale: Locale): string => 
     parts.push(tooltipLine(t.offloadType, enabled ? t.legacyEnabled : t.legacyDisabled));
   }
   if (d.kv_offload_backend) {
-    const backend = cacheImplementationLabel(d.kv_offload_backend);
-    const version = d.kv_offload_backend_version ? ` ${d.kv_offload_backend_version}` : '';
-    parts.push(tooltipLine(t.offloadBackend, `${backend}${version}`));
+    parts.push(
+      tooltipLine(
+        t.offloadBackend,
+        versionedComponentLabel(d.kv_offload_backend, d.kv_offload_backend_version)!,
+      ),
+    );
   }
   if (d.kv_p2p_transfer) {
     parts.push(tooltipLine(t.transferEngine, cacheImplementationLabel(d.kv_p2p_transfer)));
   }
   if (d.router_name) {
-    const router = cacheImplementationLabel(d.router_name);
-    const version = d.router_version ? ` ${d.router_version}` : '';
-    parts.push(tooltipLine(t.router, `${router}${version}`));
+    parts.push(tooltipLine(t.router, versionedComponentLabel(d.router_name, d.router_version)!));
   }
 
   const gpuHit = formatPct(d.server_gpu_cache_hit_rate);

--- a/packages/app/src/hooks/api/use-trace-server-metrics.ts
+++ b/packages/app/src/hooks/api/use-trace-server-metrics.ts
@@ -21,6 +21,12 @@ export interface PointMeta {
   disagg: boolean;
   conc: number;
   offload_mode: string | null;
+  kv_offloading: string | null;
+  kv_offload_backend: string | null;
+  kv_offload_backend_version: string | null;
+  kv_p2p_transfer: string | null;
+  router_name: string | null;
+  router_version: string | null;
   isl: number | null;
   osl: number | null;
   benchmark_type: string;

--- a/packages/db/src/backfill-runtime-metadata.ts
+++ b/packages/db/src/backfill-runtime-metadata.ts
@@ -117,6 +117,7 @@ async function main(): Promise<void> {
   let missing = 0;
   let empty = 0;
   let unmapped = 0;
+  // oxlint-disable-next-line no-unreachable-loop -- runs are intentionally processed sequentially
   for (const [index, run] of runs.entries()) {
     const runId = Number(run.github_run_id);
     const repository = repositoryFromRunUrl(run.html_url) ?? REPO;

--- a/packages/db/src/queries/trace-server-metrics.test.ts
+++ b/packages/db/src/queries/trace-server-metrics.test.ts
@@ -41,6 +41,12 @@ function metaRow(overrides: Record<string, unknown> = {}) {
     disagg: true,
     conc: 128,
     offload_mode: 'off',
+    kv_offloading: null,
+    kv_offload_backend: null,
+    kv_offload_backend_version: null,
+    kv_p2p_transfer: null,
+    router_name: null,
+    router_version: null,
     isl: null,
     osl: null,
     benchmark_type: 'agentic_traces',
@@ -65,13 +71,33 @@ function mockSql(queue: unknown[][]): { sql: DbClient; calls: string[] } {
 
 describe('getTraceServerMetrics', () => {
   it('returns current precomputed series without selecting the raw blob', async () => {
-    const { sql, calls } = mockSql([[metaRow()]]);
+    const { sql, calls } = mockSql([
+      [
+        metaRow({
+          kv_offloading: 'dram',
+          kv_offload_backend: 'lmcache',
+          kv_offload_backend_version: '0.5.1',
+          kv_p2p_transfer: 'mooncake',
+          router_name: 'vllm-router',
+          router_version: '0.1.14',
+        }),
+      ],
+    ]);
 
     const result = await getTraceServerMetrics(sql, 42);
 
     expect(result?.prefillTps).toEqual([{ t: 0, value: 100 }]);
+    expect(result?.meta).toMatchObject({
+      kv_offloading: 'dram',
+      kv_offload_backend: 'lmcache',
+      kv_offload_backend_version: '0.5.1',
+      kv_p2p_transfer: 'mooncake',
+      router_name: 'vllm-router',
+      router_version: '0.1.14',
+    });
     expect(calls).toHaveLength(1);
     expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
+    expect(calls[0]).toContain("br.metrics ->> 'kv_offload_backend'");
   });
 
   it('fetches and computes the raw blob only when chart_series is stale', async () => {

--- a/packages/db/src/queries/trace-server-metrics.ts
+++ b/packages/db/src/queries/trace-server-metrics.ts
@@ -24,6 +24,12 @@ import { writeBackTraceReplayJsonb } from './agentic-shared';
 
 export type { TimeSeriesPoint, QueueDepthPoint } from '../etl/compute-chart-series';
 
+// The endpoint payload combines chart_series with separately queried point
+// metadata. Keep a composite response version so metadata-shape changes roll
+// the blob-cache namespace without forcing an expensive chart_series backfill.
+const POINT_META_VERSION = 2;
+export const TRACE_SERVER_METRICS_VERSION = CHART_SERIES_VERSION * 100 + POINT_META_VERSION;
+
 export interface PointMeta {
   id: number;
   hardware: string;
@@ -34,6 +40,12 @@ export interface PointMeta {
   disagg: boolean;
   conc: number;
   offload_mode: string | null;
+  kv_offloading: string | null;
+  kv_offload_backend: string | null;
+  kv_offload_backend_version: string | null;
+  kv_p2p_transfer: string | null;
+  router_name: string | null;
+  router_version: string | null;
   isl: number | null;
   osl: number | null;
   benchmark_type: string;
@@ -114,6 +126,12 @@ function buildMeta(row: RawMetaRow): PointMeta {
     disagg: row.disagg,
     conc: row.conc,
     offload_mode: row.offload_mode,
+    kv_offloading: row.kv_offloading,
+    kv_offload_backend: row.kv_offload_backend,
+    kv_offload_backend_version: row.kv_offload_backend_version,
+    kv_p2p_transfer: row.kv_p2p_transfer,
+    router_name: row.router_name,
+    router_version: row.router_version,
     isl: row.isl,
     osl: row.osl,
     benchmark_type: row.benchmark_type,
@@ -167,6 +185,12 @@ export async function getTraceServerMetrics(
       br.conc, br.offload_mode, br.isl, br.osl, br.benchmark_type,
       br.date::text,
       case when wr.html_url is not null then wr.html_url || '/attempts/' || wr.run_attempt else null end as run_url,
+      nullif(br.metrics ->> 'kv_offloading', '') as kv_offloading,
+      nullif(br.metrics ->> 'kv_offload_backend', '') as kv_offload_backend,
+      nullif(br.metrics ->> 'kv_offload_backend_version', '') as kv_offload_backend_version,
+      nullif(br.metrics ->> 'kv_p2p_transfer', '') as kv_p2p_transfer,
+      nullif(br.metrics ->> 'router_name', '') as router_name,
+      nullif(br.metrics ->> 'router_version', '') as router_version,
       (br.metrics ->> 'server_gpu_cache_hit_rate')::numeric as server_gpu_cache_hit_rate,
       (br.metrics ->> 'server_cpu_cache_hit_rate')::numeric as server_cpu_cache_hit_rate,
       (br.metrics ->> 'kv_cache_pool_tokens')::numeric as kv_cache_pool_tokens


### PR DESCRIPTION
## Summary

- expose `kv_offloading`, `kv_offload_backend`, `kv_offload_backend_version`, `kv_p2p_transfer`, `router_name`, and `router_version` from the Agentic trace point-detail query
- show offload type, KV offload engine/version, transfer engine, and router/version in the selected-point summary
- share runtime-component display-name formatting with the existing hover tooltip
- version the composite trace-server-metrics response so existing blob-cached metadata is invalidated without forcing a chart-series backfill
- add complete English and Simplified Chinese labels

## Root cause

The chart hover tooltip already received runtime metadata, but the Agentic point-detail endpoint omitted those fields from its separately queried point metadata. Consequently the detail page could not render the metadata even though it existed in `benchmark_runs.metrics`.

## Validation

- `pnpm test:unit` — 3,158 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- targeted Cypress spec — 10/10 passed
- browser-verified `/inference/agentic/436423` and `/zh/inference/agentic/436423` against production data; both render DRAM and vLLM Simple with no console errors
- real API response for point `436423` returns `kv_offloading: "dram"` and `kv_offload_backend: "vllm-simple"`

Unofficial-run overlays are not applicable to persisted point-detail routes, which require an official benchmark ID. Runtime metadata in hover tooltips remains supported for both official and unofficial-run data paths.

## 中文说明

- 在 Agentic 追踪数据点详情查询中返回 `kv_offloading`、`kv_offload_backend`、`kv_offload_backend_version`、`kv_p2p_transfer`、`router_name` 和 `router_version`
- 在已选数据点摘要中展示卸载类型、KV 卸载引擎及版本、传输引擎、路由器及版本
- 与现有悬停提示共用运行时组件名称格式化逻辑
- 为组合后的 trace-server-metrics 响应增加版本号，使已有 Blob 缓存中的旧元数据失效，同时避免重新回填成本较高的图表序列
- 补齐英文和简体中文界面文案

## 根因

图表悬停提示已经能收到运行时元数据，但 Agentic 数据点详情接口在单独查询数据点元数据时遗漏了这些字段。因此，即使 `benchmark_runs.metrics` 中已有相关数据，详情页面仍无法展示。

## 验证

- `pnpm test:unit`：3,158 项测试通过
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt`
- 定向 Cypress 规范：10/10 通过
- 使用生产数据在浏览器中验证 `/inference/agentic/436423` 和 `/zh/inference/agentic/436423`；两者均正确显示 DRAM 和 vLLM Simple，且控制台无报错
- 数据点 `436423` 的真实 API 响应返回 `kv_offloading: "dram"` 和 `kv_offload_backend: "vllm-simple"`

非官方运行（`?unofficialrun=`）叠加层不适用于需要正式 benchmark ID 的持久化数据点详情路由。官方与非官方运行数据路径的悬停提示仍继续支持运行时元数据。