### PR TITLE
fix(test): load app CSS in Cypress component tests / 修复 Cypress 组件测试未加载应用 CSS

### DIFF
--- a/packages/app/cypress/component/component-css.cy.tsx
+++ b/packages/app/cypress/component/component-css.cy.tsx
@@ -1,0 +1,19 @@
+describe('component CSS harness', () => {
+  it('loads Tailwind visibility and sizing utilities', () => {
+    cy.mount(
+      <button type="button" data-testid="css-probe" className="hidden size-11">
+        probe
+      </button>,
+    );
+
+    cy.get('[data-testid="css-probe"]').then(($probe) => {
+      const style = getComputedStyle($probe[0]);
+
+      expect({ display: style.display, width: style.width, height: style.height }).to.deep.equal({
+        display: 'none',
+        width: '44px',
+        height: '44px',
+      });
+    });
+  });
+});

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -72,10 +72,16 @@ describe('Header', () => {
 
   it('shows mobile hamburger menu on small viewports', () => {
     cy.viewport(375, 812);
-    cy.get('[data-testid="mobile-menu-toggle"]').should('be.visible');
-    cy.get('[data-testid="mobile-menu-toggle"]').click();
-    cy.contains('Dashboard').should('be.visible');
-    cy.contains('Comparisons').should('be.visible');
-    cy.contains('Supporters').should('be.visible');
+    cy.get('[data-testid="nav-link-dashboard"]').should('not.be.visible');
+    cy.get('[data-testid="mobile-menu-toggle"]')
+      .should('be.visible')
+      .and('have.attr', 'aria-expanded', 'false')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid="mobile-menu"]').within(() => {
+      cy.contains('a', 'Dashboard').should('be.visible').and('have.attr', 'href', '/inference');
+      cy.contains('a', 'Comparisons').should('be.visible').and('have.attr', 'href', '/compare');
+      cy.contains('a', 'Supporters').should('be.visible').and('have.attr', 'href', '/quotes');
+    });
   });
 });

--- a/packages/app/cypress/support/component-index.html
+++ b/packages/app/cypress/support/component-index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Components App</title>
+    <!-- Used by Next.js to inject CSS. -->
+    <noscript id="__next_css__DO_NOT_USE__"></noscript>
   </head>
   <body>
     <div data-cy-root></div>

--- a/packages/app/cypress/support/component.ts
+++ b/packages/app/cypress/support/component.ts
@@ -1,5 +1,7 @@
 import { mount } from 'cypress/react';
 
+import '@/app/globals.css';
+
 declare global {
   namespace Cypress {
     interface Chainable {

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -215,7 +215,10 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                 </svg>
               </button>
               {mobileMenuOpen && (
-                <div className="absolute right-0 top-full mt-2 z-50 flex flex-col rounded-lg border border-border bg-background p-1.5 shadow-lg min-w-40">
+                <div
+                  data-testid="mobile-menu"
+                  className="absolute right-0 top-full mt-2 z-50 flex flex-col rounded-lg border border-border bg-background p-1.5 shadow-lg min-w-40"
+                >
                   {navLinks.map(({ href, displayHref, label, event }) => (
                     <Link
                       key={href}

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -77,7 +77,7 @@ function CategorySectionTitle({ label, reason }: { label: string; reason: string
             data-testid={`selector-category-${label.toLowerCase().replaceAll(' ', '-')}-info`}
           />
         </TooltipTrigger>
-        <TooltipContent side="top" collisionPadding={10}>
+        <TooltipContent side="top" collisionPadding={10} className="z-[130]">
           <span>{reason}</span>
         </TooltipContent>
       </TooltipRoot>


### PR DESCRIPTION
## Summary

- load `src/app/globals.css` from the shared Cypress component support file
- add Next.js's CSS insertion anchor to the component test document
- add a regression test for Tailwind visibility and sizing utilities
- scope Header mobile-navigation assertions to a stable `mobile-menu` test seam
- keep selector-category tooltips above the open MultiSelect panel

Closes #612.

## Root cause

Cypress component tests mount React components without the application root layout, so `globals.css` was never loaded. As a result, Tailwind utilities such as `hidden`, responsive visibility classes, and sizing utilities were not applied, allowing visibility assertions to pass against an unstyled DOM.

Importing the stylesheet alone is insufficient because Next.js's development style loader also requires the `#__next_css__DO_NOT_USE__` insertion anchor.

Once the component harness loaded the real application CSS, it exposed two previously hidden failures:

1. The Header mobile-navigation test selected the earlier, correctly hidden desktop link instead of the mobile link.
2. Selector-category tooltips used `z-50`, below the open MultiSelect panel at `z-[120]`.

## Why these changes are in one PR

The Header and tooltip failures are direct consequences of correcting the Cypress CSS environment. Landing only the harness change would leave the component suite red, while keeping the old assertions would preserve false-positive coverage.

The work remains separated into three reviewable commits:

1. load application CSS and add the regression probe
2. correct the Header mobile-navigation assertions
3. fix the tooltip stacking defect exposed by real CSS

## Verification

- [x] Regression probe failed before the harness fix with `inline-block` and `50.0938 × 21.5px`
- [x] Regression probe passed after the fix with `display: none` and `44 × 44px`
- [x] Electron component suite — 27 specs, 183/183 passing, `retries=0`
- [x] Chrome component suite — 27 specs, 183/183 passing, `retries=0`
- [x] Header component tests — 8/8 passing
- [x] Chart selector component tests — 7/7 passing
- [x] `pnpm fmt`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] confirmed `globals.css` is imported only once by the shared Cypress support file



## 中文说明

### 概述

- 在共享 Cypress component support file 中加载 `src/app/globals.css`
- 在组件测试文档中加入 Next.js CSS 插入锚点
- 增加 Tailwind 可见性及尺寸工具类的回归测试
- 通过稳定的 `mobile-menu` 测试入口限定 Header 移动端导航断言
- 确保 selector 分类 Tooltip 显示在已打开的 MultiSelect 面板上方

### 根因

Cypress 组件测试只挂载 React 组件，不会挂载应用根布局，因此此前从未加载 `globals.css`。这导致 `hidden`、响应式可见性和尺寸等 Tailwind 工具类没有生效，使部分可见性断言在未应用样式的 DOM 上错误通过。

仅导入样式表仍然不够，因为 Next.js development style loader 还需要 `#__next_css__DO_NOT_USE__` CSS 插入锚点。

启用真实应用 CSS 后，测试暴露了两个此前被隐藏的问题：

1. Header 移动端测试选中了 DOM 中位置更靠前、但实际上已经隐藏的桌面导航链接。
2. selector 分类 Tooltip 使用 `z-50`，低于使用 `z-[120]` 的 MultiSelect 面板。

### 为什么放在同一个 PR

Header 和 Tooltip 失败都是修正 Cypress CSS 环境后直接暴露出来的结果。如果只合入测试环境修复，组件测试套件会保持失败；如果保留原有断言，则会继续产生 false positive。

本 PR 仍通过三个独立 commit 保持清晰的 review 和 bisect 边界：

1. 加载应用 CSS 并增加回归 probe
2. 修正 Header 移动端导航断言
3. 修复真实 CSS 暴露的 Tooltip 层级问题

### 验证

- [x] 修复前 regression probe 为 `inline-block`、`50.0938 × 21.5px`
- [x] 修复后 regression probe 为 `display: none`、`44 × 44px`
- [x] Electron component suite — 27 specs，183/183 通过，`retries=0`
- [x] Chrome component suite — 27 specs，183/183 通过，`retries=0`
- [x] Header component tests — 8/8 通过
- [x] Chart selector component tests — 7/7 通过
- [x] `pnpm fmt`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] 确认 Cypress 仅在共享 support file 中加载一次 `globals.css`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test harness and assertion fixes plus a small z-index tweak on tooltips; no auth, data, or core business-logic changes.
> 
> **Overview**
> **Cypress component tests now mount with real app styles**, fixing false-positive visibility checks that passed on an unstyled DOM.
> 
> The shared component support imports `globals.css` and the component `index.html` adds Next.js’s `#__next_css__DO_NOT_USE__` anchor so Tailwind utilities apply in the harness. A new **component CSS probe** asserts `hidden` and `size-11` resolve to `display: none` and 44×44px.
> 
> With CSS enabled, **Header mobile-nav tests** are tightened: desktop dashboard links are expected hidden on small viewports, the hamburger asserts `aria-expanded`, and links are scoped inside `data-testid="mobile-menu"`. The mobile dropdown gains that test id in `header.tsx`.
> 
> **Selector category tooltips** get `z-[130]` on `TooltipContent` so they stack above the open `MultiSelect` panel (`z-[120]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbd46856ba7841eea07c5a50ee43fd8b0332f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->