### PR TITLE
chore(db): purge run 29912027293 — accidental ingest

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -52,6 +52,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29427827757, // 2026-07-15 | Reason: sweep-reuse recovery of the run above (PR #2158) — reverted for the same reason
   29654139122, // 2026-07-18 | Reason: accidental ingest while testing
   29660737166, // 2026-07-18 | Reason: accidental ingest while testing
+  29912027293, // 2026-07-22 | Reason: accidental ingest while testing
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
## Summary

Adds GitHub Actions run **[29912027293](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29912027293)** (`e2e Test - dsv4-fp4-mi355x-sglang-disagg-agentic-hicache`, branch `amd/agentx-v1.0-th-hicon-dpa`) to `PURGED_RUNS` in `run-overrides.ts`.

The run was **accidentally ingested while testing**. It is currently the *sole* run backing this line on the dashboard:

- **DeepSeek-V4-Pro / MI355X / mori-sglang / FP4 / disagg / `agentic_traces` / offload=on**, concurrencies 48 / 64 / 96 / 128 (`benchmark_results` 436604–436607).

## Effect on merge

`.github/workflows/apply-run-overrides.yml` triggers on any change to `run-overrides.ts` pushed to `master` and runs `pnpm admin:db:apply-overrides --yes`, which transactionally deletes the run's rows (benchmarks, server logs, run stats, evals, changelogs, **`agentic_trace_replay` sidecars**, and orphaned `availability` rows), verifies the DB, then invalidates and warms the production cache. The entry also causes `isRunAttemptPurged` to skip the run on any future re-ingest.

Whole-run purge (all attempts), consistent with the existing 2026-07-18 accidental-ingest entries (`29654139122`, `29660737166`).

## Verification

- Confirmed via the production API (`/api/v1/benchmarks?...&exactRun=true&runId=29912027293`) that the run produced 4 `agentic_traces` points and is the winning/latest run for its line.
- `pnpm lint` / `pnpm fmt` / `pnpm typecheck` pass (pre-commit hook green).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single run-ID addition to an existing purge list; operational data cleanup with no auth or core logic changes.
> 
> **Overview**
> Adds GitHub Actions run **29912027293** to `PURGED_RUNS` in `run-overrides.ts` because it was **accidentally ingested during testing** (same pattern as the 2026-07-18 accidental-ingest entries).
> 
> On merge, CI’s `apply-run-overrides` flow will **delete that run’s production benchmark data** and **`isRunAttemptPurged`** will **block any future re-ingest** of the run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c608e91736c7715c7552231ddef5666dd0bb86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->