### PR TITLE
feat(gpu): render RTX PRO 6000 Blackwell benchmark data / 新增 RTX PRO 6000 Blackwell GPU SKU 渲染支持

### DIFF
--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -123,6 +123,24 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     costn: 1.9,
     costr: 2.1,
   },
+  // NVIDIA RTX PRO 6000 Blackwell Server Edition (GB202, PCIe Gen5, 96 GB GDDR7).
+  // A workstation-class PCIe card benchmarked in 8× TP configs (no NVLink/NVSwitch);
+  // sorts last, after the datacenter SXM/OAM parts.
+  // TODO: power (all-in kW/GPU) and cost tiers are placeholders (9.99) pending the
+  // official values from the SemiAnalysis AI Cloud TCO model. TDP is the datasheet
+  // 600 W max board power. Until real numbers land, $/token and per-MW metrics for
+  // this SKU are not meaningful.
+  rtx6000pro: {
+    vendor: 'NVIDIA',
+    arch: 'Blackwell',
+    label: 'RTX PRO 6000',
+    sort: 9,
+    tdp: 600,
+    power: 9.99,
+    costh: 9.99,
+    costn: 9.99,
+    costr: 9.99,
+  },
 };
 
 /** Canonical set of GPU key strings used across all packages. */

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -82,6 +82,11 @@ describe('hwToGpuKey', () => {
     expect(hwToGpuKey('gb300-cw')).toBe('gb300');
   });
 
+  it('strips -lat suffix for RTX PRO 6000 (latency-optimized PCIe SKU)', () => {
+    expect(hwToGpuKey('rtx6000pro-lat')).toBe('rtx6000pro');
+    expect(hwToGpuKey('rtx6000pro')).toBe('rtx6000pro');
+  });
+
   it('strips runner index suffix before other suffixes', () => {
     expect(hwToGpuKey('mi355x-amd_0')).toBe('mi355x');
     expect(hwToGpuKey('mi355x-amd_2')).toBe('mi355x');


### PR DESCRIPTION
## Summary

Adds the **NVIDIA RTX PRO 6000 Blackwell Server Edition** (GB202, PCIe Gen5, 96 GB GDDR7) as a new GPU SKU so the MiniMax-M3 benchmark from [`SemiAnalysisAI/InferenceX` run 29987453043](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29987453043) renders on the dashboard. Artifact hardware id: `rtx6000pro-lat`.

The only structural change is a single `HW_REGISTRY` entry (the single source of truth). Display labels, chart colors, legend sort order, dropdowns, and cost/power lookups all derive from it automatically — so the point renders across the inference, evaluation, and calculator charts (and the `?unofficialrun=` overlay path, which resolves hardware through the same registry) with no other frontend edits.

### Changes
- **`packages/constants/src/gpu-keys.ts`** — new `rtx6000pro` entry: vendor `NVIDIA`, arch `Blackwell`, label `RTX PRO 6000`, `sort: 9` (sorts last, after the datacenter SXM/OAM parts), `tdp: 600` (datasheet max board power).
- **`packages/db/src/etl/normalizers.test.ts`** — test locking in `hwToGpuKey('rtx6000pro-lat') → rtx6000pro`. No normalizer *source* change was needed: `hwToGpuKey` already takes the first segment before `-`, so the `-lat` suffix is stripped automatically.

### Known follow-ups (intentionally deferred)
- **TCO values are `9.99` placeholders** (flagged with a `// TODO`). All-in power (kW/GPU) and the three `$/GPU/hr` cost tiers await official numbers from the SemiAnalysis AI Cloud TCO model. Latency/throughput/interactivity charts are unaffected; **`$/token` and per-MW metrics for this SKU are not meaningful until real numbers land.**
- **GPU Specs tab (`GPU_SPECS`) entry not added.** It needs scale-out cluster-fabric fields that aren't defined for a single-node 8×PCIe box, plus a `getScaleUpTopologyConfig` PCIe branch and updates to the hardcoded `gpu-specs.test.ts` assertions.
- **Run not yet ingested** — the point appears once `29987453043` is ingested + cache invalidated.

No `/zh` page changes: this adds a hardware SKU to a data registry, not an indexable page/tab/post, and the label is a hardware SKU name (stays English per the translation rules).

## Test plan
- `pnpm typecheck` ✅
- `pnpm lint` / `pnpm fmt` ✅ (also via pre-commit hook)
- db unit tests: 373 passed ✅ (incl. new `-lat` normalizer case)
- app GPU/constants tests: passed ✅

## 中文说明

新增 **NVIDIA RTX PRO 6000 Blackwell Server Edition**（GB202，PCIe Gen5，96 GB GDDR7）作为新的 GPU SKU，使 [`SemiAnalysisAI/InferenceX` run 29987453043](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29987453043) 的 MiniMax-M3 基准测试能在仪表板中渲染。产物硬件标识为 `rtx6000pro-lat`。

唯一的结构性改动是在 `HW_REGISTRY`（单一事实来源）中新增一个条目。展示标签、图表配色、图例排序、下拉选项以及成本/功耗查询均由其自动派生——因此该数据点可在推理、评估与计算器（calculator）图表中正常渲染（`?unofficialrun=` 叠加路径也通过同一注册表解析硬件），无需改动其他前端代码。

### 改动
- **`packages/constants/src/gpu-keys.ts`** — 新增 `rtx6000pro` 条目：vendor `NVIDIA`、arch `Blackwell`、label `RTX PRO 6000`、`sort: 9`（排在数据中心 SXM/OAM 产品之后）、`tdp: 600`（数据手册最大板卡功耗）。
- **`packages/db/src/etl/normalizers.test.ts`** — 固化 `hwToGpuKey('rtx6000pro-lat') → rtx6000pro` 的测试。无需改动 normalizer 源码：`hwToGpuKey` 已取 `-` 前的首段，`-lat` 后缀会被自动剥离。

### 已知的后续事项（有意暂缓）
- **TCO 数值为 `9.99` 占位**（已用 `// TODO` 标注）。全能耗（kW/GPU）与三档 `$/GPU/hr` 成本等待 SemiAnalysis AI Cloud TCO 模型的官方数值。延迟/吞吐量/交互性图表不受影响；**在真实数值补齐前，该 SKU 的 `$/token` 与 per-MW 指标无实际意义。**
- **未新增 GPU Specs 标签页（`GPU_SPECS`）条目。** 单节点 8×PCIe 机型缺少 scale-out 集群网络（cluster-fabric）字段，且需要为 `getScaleUpTopologyConfig` 增加 PCIe 分支并更新 `gpu-specs.test.ts` 中的硬编码断言。
- **该 run 尚未 ingest** — 待 `29987453043` 完成 ingest 并使缓存失效后，数据点才会出现。

无 `/zh` 页面改动：本次仅向数据注册表新增硬件 SKU，并非可索引的页面/标签页/文章，且标签为硬件 SKU 名称（按翻译规范保持英文）。

## 测试
- `pnpm typecheck` ✅
- `pnpm lint` / `pnpm fmt` ✅（并经 pre-commit 钩子验证）
- db 单元测试：373 通过 ✅（含新增的 `-lat` normalizer 用例）
- app GPU/constants 测试：通过 ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry and test-only change; placeholder cost/power may mislead cost charts until real TCO values replace 9.99.
> 
> **Overview**
> Adds **`rtx6000pro`** to `HW_REGISTRY` so benchmark hardware ids like `rtx6000pro-lat` resolve to a known NVIDIA Blackwell PCIe SKU (label **RTX PRO 6000**, `sort: 9`, `tdp: 600`). Labels, chart ordering, and cost/power lookups pick it up from the registry without other UI changes.
> 
> **Power and all three `$/GPU/hr` tiers are `9.99` placeholders** (documented with a TODO) until SemiAnalysis TCO numbers land—**`$/token` and per-MW views for this SKU are not meaningful yet.**
> 
> Adds a unit test asserting `hwToGpuKey('rtx6000pro-lat')` → `rtx6000pro`; no normalizer code change (existing “first segment before `-`” behavior already strips `-lat`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79b003f83e73a80ae72fb391f78370b319dd7d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->