### PR TITLE
fix(etl): map AMD Kimi-K2.7-Code identifiers to kimik2.7-code / 修复:将 AMD Kimi-K2.7-Code 标识映射到 kimik2.7-code

### DIFF
--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -135,6 +135,21 @@ describe('resolveModelKey', () => {
     expect(resolveModelKey({ infmax_model_prefix: 'dsv4pro-fp8' })).toBe('dsv4');
   });
 
+  it('resolves AMD Kimi-K2.7-Code identifiers to the canonical kimik2.7-code key', () => {
+    // AMD AgentX sweeps emit the bare prefix `kimik2.7` (no `-code`) and the
+    // MXFP4 model path `amd/Kimi-K2.7-Code-MXFP4`; both must fold into the
+    // canonical `kimik2.7-code` DB bucket. Regression for GitHub Actions run
+    // 29975243963, whose overlay rendered nothing because every row was skipped
+    // as an unmapped model.
+    expect(resolveModelKey({ infmax_model_prefix: 'kimik2.7' })).toBe('kimik2.7-code');
+    expect(resolveModelKey({ infmax_model_prefix: 'kimik2.7-fp4' })).toBe('kimik2.7-code');
+    expect(resolveModelKey({ model_prefix: 'kimik2.7' })).toBe('kimik2.7-code');
+    expect(resolveModelKey({ model: 'amd/Kimi-K2.7-Code-MXFP4' })).toBe('kimik2.7-code');
+    // Canonical identifiers still resolve to the same bucket.
+    expect(resolveModelKey({ infmax_model_prefix: 'kimik2.7-code' })).toBe('kimik2.7-code');
+    expect(resolveModelKey({ model: 'moonshotai/Kimi-K2.7-Code' })).toBe('kimik2.7-code');
+  });
+
   it('falls back to MODEL_TO_KEY when prefix not present', () => {
     expect(resolveModelKey({ model: 'deepseek-ai/DeepSeek-R1' })).toBe('dsr1');
     expect(resolveModelKey({ model: 'nvidia/Llama-3.3-70B-Instruct-FP8' })).toBe('llama70b');

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -45,6 +45,10 @@ const PRECISION_SUFFIX = /-(?:fp4|fp8|mxfp4|nvfp4)(?:-.*)?$/iu;
 const PREFIX_ALIASES: Record<string, string> = {
   gptoss: 'gptoss120b',
   dsv4pro: 'dsv4',
+  // AMD AgentX sweeps emit the bare prefix `kimik2.7` instead of the canonical
+  // `kimik2.7-code` DB key; alias it so those rows resolve (and precision-suffixed
+  // forms like `kimik2.7-fp4` fold in via PRECISION_SUFFIX stripping too).
+  'kimik2.7': 'kimik2.7-code',
 };
 
 function resolvePrefixToKey(prefix: string): string | null {
@@ -94,6 +98,7 @@ export const MODEL_TO_KEY: Record<string, string> = {
   'moonshotai/Kimi-K2.5': 'kimik2.5',
   'moonshotai/Kimi-K2.6': 'kimik2.6',
   'moonshotai/Kimi-K2.7-Code': 'kimik2.7-code',
+  'amd/Kimi-K2.7-Code-MXFP4': 'kimik2.7-code',
   // MiniMax-M2.5
   'MiniMaxAI/MiniMax-M2.5': 'minimaxm2.5',
   // MiniMax-M3 (428B, distinct architecture from the M2 series)


### PR DESCRIPTION
## Summary

AMD AgentX sweeps label the model with the **bare prefix `kimik2.7`** (no `-code`) and the MXFP4 model path **`amd/Kimi-K2.7-Code-MXFP4`**. Neither was registered in `PREFIX_ALIASES` or `MODEL_TO_KEY`, so `resolveModelKey` (`packages/db/src/etl/normalizers.ts`) returned `null` and both `mapBenchmarkRow` and the eval mapper skipped **every** row as `unmappedModel`.

**Symptom:** the unofficial-run overlay for such a run — e.g. [`runs/29975243963`](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29975243963) (`[AMD][AgentX] Add Kimi-K2.7 MI355X vLLM agentic MTP`) — fetched its artifacts fine but the `/api/unofficial-run` response contained **0 benchmarks and 0 evaluations**, so `?unofficialrun=…` rendered nothing. Official ingest would drop the same rows for the same reason.

I confirmed the root cause by running the real `resolveModelKey` against the exact values in the run's artifacts (`infmax_model_prefix: "kimik2.7"`, `model: "amd/Kimi-K2.7-Code-MXFP4"`, eval `model_prefix: "kimik2.7"`) — all returned `null`, while the canonical `kimik2.7-code` / `moonshotai/Kimi-K2.7-Code` resolved correctly.

## Fix

Two mapping additions in `normalizers.ts`, both folding into the canonical `kimik2.7-code` DB bucket:

- `PREFIX_ALIASES`: `'kimik2.7' → 'kimik2.7-code'` — also covers precision-suffixed forms like `kimik2.7-fp4` via existing `PRECISION_SUFFIX` stripping.
- `MODEL_TO_KEY`: `'amd/Kimi-K2.7-Code-MXFP4' → 'kimik2.7-code'` — consistent with existing `amd/…-MXFP4` entries (`amd/GLM-5.1-MXFP4`, `amd/Llama-3.3-70B-Instruct-MXFP4-Preview`).

## Tests

Added a regression case to `resolveModelKey` covering the bare prefix, the precision-suffixed prefix, the eval `model_prefix`, the AMD MXFP4 path, and the canonical identifiers. `pnpm test:unit` (db package), `pnpm lint`, `pnpm fmt`, `pnpm typecheck` all pass.

## Scope / caveats

- Pure data-mapping change in the `db` ETL layer — no chart/UI code, so no overlay-path or `/zh` work applies.
- This unblocks *rendering* for AMD K2.7-Code runs. It does **not** make run `29975243963` itself worth ingesting officially: that run's `agentic eval` gate failed with `em_strict: 0.0` on swebench_lite and only 552/1920 requests succeeded — its data is genuinely broken. The mapping fix simply ensures well-formed AMD K2.7-Code runs resolve going forward.

## 中文说明

AMD AgentX 基准测试(benchmark)的产物(artifact)用**裸前缀 `kimik2.7`**(不带 `-code`)和 MXFP4 模型路径 **`amd/Kimi-K2.7-Code-MXFP4`** 标注模型。二者都未在 `PREFIX_ALIASES` 或 `MODEL_TO_KEY` 中注册,导致 `resolveModelKey`(`packages/db/src/etl/normalizers.ts`)返回 `null`,`mapBenchmarkRow` 与评估(evaluation)映射器把**每一行**都当作未映射模型(`unmappedModel`)跳过。

**现象:** 此类运行的非官方运行(unofficial run)叠加层——例如 [`runs/29975243963`](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29975243963)——能正常拉取产物,但 `/api/unofficial-run` 返回 **0 条基准、0 条评估**,因此 `?unofficialrun=…` 页面空白;官方摄取(ingest)也会因同样原因丢弃这些行。我用运行产物中的真实取值调用 `resolveModelKey` 验证了根因:上述标识均返回 `null`,而规范形式 `kimik2.7-code` / `moonshotai/Kimi-K2.7-Code` 能正确解析。

**修复:** 在 `normalizers.ts` 中新增两条映射,统一归入规范的 `kimik2.7-code` 数据桶:

- `PREFIX_ALIASES`:`'kimik2.7' → 'kimik2.7-code'`——经既有 `PRECISION_SUFFIX` 去后缀后,也覆盖 `kimik2.7-fp4` 等带精度后缀的形式。
- `MODEL_TO_KEY`:`'amd/Kimi-K2.7-Code-MXFP4' → 'kimik2.7-code'`——与既有 `amd/…-MXFP4` 条目(`amd/GLM-5.1-MXFP4`、`amd/Llama-3.3-70B-Instruct-MXFP4-Preview`)保持一致。

**测试:** 为 `resolveModelKey` 增加回归用例,覆盖裸前缀、带精度后缀的前缀、评估用 `model_prefix`、AMD MXFP4 路径以及规范标识。`pnpm test:unit`(db 包)、`pnpm lint`、`pnpm fmt`、`pnpm typecheck` 全部通过。

**范围/注意事项:** 这是 `db` ETL 层的纯数据映射改动,不涉及图表/UI 代码,故不适用叠加层(overlay)路径或 `/zh` 相关工作。此修复解除了 AMD K2.7-Code 运行的**渲染**阻塞,但并不意味着 `29975243963` 这一运行值得官方摄取:该运行的 `agentic eval` 质量门以 swebench_lite `em_strict: 0.0` 失败,且仅 552/1920 个请求成功,数据本身有问题。本修复只是保证今后格式正确的 AMD K2.7-Code 运行能够正常解析。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to static model-key aliases in the db ETL normalizers; no auth, API, or UI behavior changes beyond correctly ingesting/rendering rows that were previously skipped.
> 
> **Overview**
> **Fixes AMD AgentX Kimi-K2.7-Code runs being dropped as unmapped models** during benchmark/eval ETL and unofficial-run overlays.
> 
> `resolveModelKey` now maps the bare prefix **`kimik2.7`** (and precision-suffixed variants like **`kimik2.7-fp4`**) to the canonical **`kimik2.7-code`** bucket via **`PREFIX_ALIASES`**, and maps the model path **`amd/Kimi-K2.7-Code-MXFP4`** via **`MODEL_TO_KEY`**—matching other AMD MXFP4 entries.
> 
> A regression test covers prefix, eval `model_prefix`, AMD path, and existing canonical identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f876a126a4f11c23a51e6211bfa55c95a125b6d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->