### PR TITLE
fix(replay): stamp frame points with the playhead date so series render as one line / 修复回放图表中同一系列分裂成多条曲线的问题

### DIFF
--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -17,6 +17,9 @@ const baseTemplate = {
   precision: 'fp8',
   tp: 8,
   conc: 64,
+  // Deliberately NOT one of the timeline dates: templates carry each config's
+  // first-observation date, which buildFrameData must override per frame.
+  date: '2025-08-15',
 } as unknown as InferenceData;
 
 function makeTimeline(): ReplayTimeline {
@@ -38,7 +41,7 @@ function makeTimeline(): ReplayTimeline {
         configId: 'b',
         hwKey: 'h100',
         precision: 'fp8',
-        template: { ...baseTemplate, hwKey: 'h100' } as InferenceData,
+        template: { ...baseTemplate, hwKey: 'h100', date: '2025-08-20' } as InferenceData,
         // Stays invisible across the first two steps so a true "omits invisible
         // configs" assertion is meaningful — `interpolateAtStep` pops a config
         // in for the *whole* invisible→visible segment, so we need both
@@ -241,6 +244,22 @@ describe('buildFrameData', () => {
       expect(d.tp).toBe(8);
       expect(d.conc).toBe(64);
     }
+  });
+
+  // Regression: ScatterGraph scopes Pareto frontiers and line paths per
+  // point.date, so a frame mixing template (first-observation) dates renders
+  // one hardware series as several same-colored lines with duplicate labels.
+  it('stamps every point with the playhead date, not the template first-observation date', () => {
+    const t = makeTimeline();
+    const atStart = buildFrameData(t, 0);
+    expect(atStart.length).toBeGreaterThan(0);
+    for (const d of atStart) expect(d.date).toBe('2025-09-01');
+
+    const atEnd = buildFrameData(t, 1);
+    // Both configs are visible at the last step and carry distinct template
+    // dates — the frame must still present a single uniform date.
+    expect(atEnd).toHaveLength(2);
+    for (const d of atEnd) expect(d.date).toBe('2025-09-03');
   });
 
   it('returns empty when the timeline has zero configs', () => {

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -5,11 +5,17 @@ import { interpolateAtStep } from './interpolateAtTime';
 
 export function buildFrameData(timeline: ReplayTimeline, fraction: number): InferenceData[] {
   const idxFloat = stepFloatAtFraction(fraction, timeline.dates.length);
+  // A replay frame is a single point in time, so every point gets the
+  // playhead's date. Each template keeps its config's first-observation date,
+  // and ScatterGraph scopes Pareto frontiers and line paths per date — leaving
+  // mixed template dates in one frame splits a hardware series into several
+  // same-colored lines (with duplicated line labels) mid-replay.
+  const frameDate = dateAtFraction(timeline, fraction);
   const out: InferenceData[] = [];
   for (const c of timeline.configs) {
     const r = interpolateAtStep(c.stepValues, idxFloat);
     if (!r.visible) continue;
-    out.push({ ...c.template, x: r.x, y: r.y });
+    out.push({ ...c.template, x: r.x, y: r.y, date: frameDate });
   }
   return out;
 }


### PR DESCRIPTION
## Summary

In the "Replay over time" panel (opened via chart export → Download MP4), a single hardware series could render as **multiple same-colored lines with duplicated line labels** — e.g. "MI355X (SGLang)" on DeepSeek V4 Pro FP4 (8k/1k) visibly "diverges" into two (sometimes three) red lines mid-replay, and the exported MP4 faithfully records the broken frames.

### Root cause

`ScatterGraph` intentionally scopes Pareto-frontier computation and line-path drawing **per `point.date`** ("points from different dates can never share a frontier" — needed for the comparison-date overlay). Replay frames, however, were built as `{ ...config.template, x, y }`, where each template is the config's **first observation** — so its `date` is whenever that config first appeared in benchmark history. For MI355X SGLang FP4 on DeepSeek V4 (8k/1k), the 24 configs first appear across six different dates (2026-05-02 → 2026-06-16). Within one replay frame those points landed in different date buckets, so the chart computed several independent frontiers and drew them as separate same-colored paths, each with its own pinned label. The moment the playhead crossed a newer config's first-observation date, a second line materialized — the "divergence".

### Fix

`buildFrameData` now stamps every emitted point with the **playhead's current date** (`dateAtFraction`). A replay frame is a single point in time, so all of a series' points belong in one date bucket → one frontier, one path, one label per (hw, precision).

### Verification

- Reproduced before the fix (dev + production, Chromium): at 2026-06-02–06-12, `mi355x_sglang_fp4` rendered 2–3 `roofline-mi355x_sglang_fp4__<date>` sub-paths with duplicated "MI355X (SGLang)" labels.
- After the fix (verified on `localhost:3100` with the real DB): every series has exactly **one** `roofline-<key>` path (no `__<date>` suffixes) and each line label appears exactly once, at every scrub position; replay playback and MP4 export render a single continuous line per series.
- New regression unit test: `buildFrameData` must stamp a uniform playhead date even when config templates carry distinct first-observation dates. Full suite: 145 files / 2729 tests pass, plus `oxlint`, `oxfmt --check`, `tsc --noEmit`.

### Overlay support note

The replay panel operates exclusively on official benchmark history (`useBenchmarkHistory` → `/api/v1/benchmarks/history`); unofficial-run overlays (`?unofficialrun=…`) do not render inside the replay dialog, so the overlay data path is not applicable to this change. The `ScatterGraph` per-date frontier logic used by overlays and the comparison-date feature is untouched — only the replay frame data it consumes changed.

### Known related issue (not addressed here)

The timeline's sticky-last rule carries configs forward even after they stop being benchmarked — e.g. four 64-GPU MI355X SGLang configs observed only on 2026-05-02 persist as a flat low-throughput frontier branch to the end of the replay. That is a separate product decision (expire vs. carry forward) and is left unchanged.

## 中文说明

### 问题

在"时间回放（Replay over time）"面板中，同一硬件系列可能被绘制成**多条同色曲线，且曲线标签重复**。例如 DeepSeek V4 Pro FP4（8k/1k）下的 "MI355X (SGLang)"，在回放中途会"分叉"成两到三条红色曲线，导出的 MP4 也如实记录了这些错误帧。

### 根因

`ScatterGraph` 有意按 `point.date` 对 Pareto 前沿计算和曲线路径绘制进行分桶（不同日期的点不能共享同一前沿——这是对比日期叠加功能所需）。但回放帧数据是 `{ ...config.template, x, y }` 构造的，模板取自该 config 的**首次观测点**，其 `date` 即该 config 首次出现在基准测试历史中的日期。以 MI355X SGLang FP4 为例，24 个 config 的首次观测日期横跨 6 个不同日期（2026-05-02 → 2026-06-16），导致单帧内的点被分进不同日期桶，图表因此计算出多条独立前沿并分别绘制成同色路径、各带一个标签。播放头一越过较新 config 的首次观测日期，第二条曲线就会出现——即用户看到的"分叉"。

### 修复

`buildFrameData` 现在将每帧所有数据点统一标记为播放头当前日期（`dateAtFraction`）。回放帧本质上是单一时间点，因此同一系列的所有点应归入同一日期桶 → 每个（硬件、精度）系列只有一条前沿、一条路径、一个标签。

### 验证

- 修复前（dev 与生产环境，Chromium）可复现：`mi355x_sglang_fp4` 渲染出 2–3 条带 `__<date>` 后缀的 roofline 子路径及重复标签。
- 修复后（`localhost:3100` 连真实数据库验证）：任意播放位置下每个系列仅有**一条** `roofline-<key>` 路径（无 `__<date>` 后缀），每个曲线标签只出现一次；回放与 MP4 导出均为每系列一条连续曲线。
- 新增回归单元测试：即使 config 模板携带不同的首次观测日期，`buildFrameData` 也必须输出统一的播放头日期。全量测试 145 个文件 / 2729 个用例通过，`oxlint`、`oxfmt --check`、`tsc --noEmit` 均通过。

### Overlay（非官方 run 叠加）说明

回放面板仅使用官方基准测试历史数据（`useBenchmarkHistory` → `/api/v1/benchmarks/history`），`?unofficialrun=…` 叠加不会在回放对话框内渲染，因此本改动不涉及 overlay 数据路径。overlay 与对比日期功能依赖的 `ScatterGraph` 按日期分桶前沿逻辑未做任何修改——仅改变了回放喂给它的帧数据。

### 相关已知问题（本 PR 不处理）

时间线的 sticky-last 规则会把停止测试的 config 一直延续到回放结尾——例如仅在 2026-05-02 观测过一次的四个 64-GPU MI355X SGLang config，会以一条低吞吐量的平坦前沿分支持续到最后。是否让此类 config 过期属于独立的产品决策，本 PR 未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to replay frame assembly with a targeted regression test; ScatterGraph per-date logic is unchanged.
> 
> **Overview**
> **Replay frames** now assign every visible point the **playhead date** from `dateAtFraction`, overriding each config template’s first-observation `date`. Previously those mixed dates caused `ScatterGraph` to bucket Pareto frontiers and roofline paths per date, so one hardware series could split into multiple same-colored lines with duplicate labels during replay and MP4 export.
> 
> Tests use non-timeline template dates and add a regression case that asserts a **uniform** playhead date at fraction 0 and 1 when templates differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793de5d41751469cb827a2e7749e46db0eda09ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->