### PR TITLE
fix(overview): refine responsive comparison layout / 优化总览页响应式对比布局

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -454,6 +454,57 @@ describe('Overview page', () => {
     }
   });
 
+  it('aligns every platform to the same compact row axes on phones', () => {
+    for (const width of [390, 320]) {
+      cy.viewport(width, 844);
+      cy.visit('/overview');
+
+      mobileModel('DeepSeek-V4-Pro').within(() => {
+        cy.get('[data-testid="overview-mobile-platform-row"]')
+          .should('have.length', 5)
+          .then(($rows) => {
+            const rows = [...$rows];
+            const rects = rows.map((row) => row.getBoundingClientRect());
+            for (let index = 1; index < rects.length; index += 1) {
+              expect(rects[index - 1].bottom).to.be.at.most(rects[index].top + 1);
+            }
+            expect(rows.every((row) => row.getBoundingClientRect().height <= 88)).to.equal(true);
+          });
+
+        cy.get('[data-testid="overview-mobile-hardware"]').then(($labels) => {
+          const lefts = [...$labels].map((label) => label.getBoundingClientRect().left);
+          expect(Math.max(...lefts) - Math.min(...lefts)).to.be.at.most(1);
+        });
+        cy.get('[data-testid="overview-pair-value"]').then(($values) => {
+          const lefts = [...$values].map((value) => textRect(value).left);
+          expect(Math.max(...lefts) - Math.min(...lefts)).to.be.at.most(1);
+        });
+        cy.get('[data-testid="overview-pair-evidence-date"]').then(($dates) => {
+          const rights = [...$dates].map((date) => textRect(date).right);
+          expect(Math.max(...rights) - Math.min(...rights)).to.be.at.most(1);
+        });
+      });
+    }
+  });
+
+  it('keeps the two-plus-three comparison grouping on tablet widths', () => {
+    cy.viewport(768, 900);
+    cy.visit('/overview');
+
+    mobileModel('DeepSeek-V4-Pro').within(() => {
+      cy.get('[data-testid="overview-mobile-platform-row"]').then(($rows) => {
+        const rows = [...$rows];
+        expect(rows).to.have.length(5);
+
+        const [b200, mi355x, b300, gb200, gb300] = rows.map((row) => row.getBoundingClientRect());
+        expect(b200.top).to.be.closeTo(mi355x.top, 1);
+        expect(b300.top).to.be.closeTo(gb200.top, 1);
+        expect(gb200.top).to.be.closeTo(gb300.top, 1);
+        expect(b300.top).to.be.greaterThan(Math.max(b200.bottom, mi355x.bottom));
+      });
+    });
+  });
+
   it('keeps the value and evidence date aligned above configuration metadata', () => {
     cy.viewport(390, 844);
     cy.visit('/overview');

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -477,6 +477,7 @@ describe('Overview page', () => {
             const metadataRect = textRect(metadata);
 
             expect(metadataRect.top).to.be.at.least(valueRect.bottom);
+            expect(getComputedStyle(metadata).fontSize).to.equal('11px');
           });
         });
       });

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -70,11 +70,11 @@ describe('Overview page', () => {
         cy.get('[data-overview-engine-scope="community"]')
           .should('have.attr', 'aria-current', 'true')
           .and('match', 'span')
-          .and('have.text', 'Community')
+          .and('have.text', 'Open Source Community Engines (vLLM/SGLang)')
           .and('not.have.attr', 'href');
         cy.get('[data-overview-engine-scope="all"]')
           .should('have.attr', 'href', '/overview?engine=all')
-          .and('have.text', 'All engines');
+          .and('have.text', 'All Platforms');
       });
 
     cy.get('[data-testid="overview-tier-switcher"]').then(([tier]) => {
@@ -117,9 +117,12 @@ describe('Overview page', () => {
       cy.get('[data-overview-engine-scope="all"]')
         .should('have.attr', 'aria-current', 'true')
         .and('match', 'span')
-        .and('have.text', '全部引擎')
+        .and('have.text', '所有平台')
         .and('not.have.attr', 'href');
-      cy.get('[data-overview-engine-scope="community"]').should('have.text', '社区');
+      cy.get('[data-overview-engine-scope="community"]').should(
+        'have.text',
+        '开源社区引擎（vLLM/SGLang）',
+      );
     });
   });
 

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -487,22 +487,56 @@ describe('Overview page', () => {
     }
   });
 
-  it('keeps the two-plus-three comparison grouping on tablet widths', () => {
-    cy.viewport(768, 900);
-    cy.visit('/overview');
+  it('uses the same five-row comparison layout on phones and tablets', () => {
+    for (const width of [320, 390, 768, 1024, 1279]) {
+      cy.viewport(width, 900);
+      cy.visit('/overview');
 
-    mobileModel('DeepSeek-V4-Pro').within(() => {
-      cy.get('[data-testid="overview-mobile-platform-row"]').then(($rows) => {
-        const rows = [...$rows];
-        expect(rows).to.have.length(5);
+      mobileModel('DeepSeek-V4-Pro').within(() => {
+        cy.get('[data-testid="overview-mobile-platform-row"]').then(($rows) => {
+          const rows = [...$rows];
+          expect(rows).to.have.length(5);
 
-        const [b200, mi355x, b300, gb200, gb300] = rows.map((row) => row.getBoundingClientRect());
-        expect(b200.top).to.be.closeTo(mi355x.top, 1);
-        expect(b300.top).to.be.closeTo(gb200.top, 1);
-        expect(gb200.top).to.be.closeTo(gb300.top, 1);
-        expect(b300.top).to.be.greaterThan(Math.max(b200.bottom, mi355x.bottom));
+          const rects = rows.map((row) => row.getBoundingClientRect());
+          for (let index = 1; index < rects.length; index += 1) {
+            expect(rects[index - 1].bottom).to.be.at.most(rects[index].top + 1);
+          }
+        });
       });
-    });
+    }
+  });
+
+  it('keeps percentage badges beside the value and typographically aligned below desktop', () => {
+    for (const width of [320, 390, 768, 1024, 1279]) {
+      cy.viewport(width, 900);
+      cy.visit('/overview');
+
+      mobileModel('Qwen-3.5-397B-A17B').within(() => {
+        platform('mi355x').within(() => {
+          cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
+            cy.get('[data-testid="overview-cost-delta"][data-hardware="mi355x"]').then(
+              ([badge]) => {
+                cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').then(
+                  ([date]) => {
+                    const valueRect = value.getBoundingClientRect();
+                    const badgeRect = badge.getBoundingClientRect();
+                    const badgeText = badge.querySelector('[aria-hidden="true"]');
+                    expect(badgeText).not.to.equal(null);
+
+                    expect(badgeRect.left - valueRect.right).to.be.at.most(8);
+                    expect(textRect(badgeText as Element).bottom).to.be.closeTo(
+                      textRect(value).bottom,
+                      1,
+                    );
+                    expect(textRect(date).bottom).to.be.closeTo(textRect(value).bottom, 1);
+                  },
+                );
+              },
+            );
+          });
+        });
+      });
+    }
   });
 
   it('keeps the value and evidence date aligned above configuration metadata', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -454,7 +454,7 @@ describe('Overview page', () => {
     }
   });
 
-  it('keeps the evidence date beside configuration metadata below the value', () => {
+  it('keeps the value and evidence date aligned above configuration metadata', () => {
     cy.viewport(390, 844);
     cy.visit('/overview');
 
@@ -466,20 +466,18 @@ describe('Overview page', () => {
               const valueRect = textRect(value);
               const dateRect = textRect(date);
 
-              expect(dateRect.top).to.be.at.least(valueRect.bottom);
+              expect(dateRect.bottom).to.be.closeTo(valueRect.bottom, 1);
             },
           );
         });
 
-        cy.contains('span', 'SGLang · FP4 · Standard decode').then(([metadata]) => {
-          cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').then(
-            ([date]) => {
-              const metadataRect = textRect(metadata);
-              const dateRect = textRect(date);
+        cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
+          cy.contains('div', 'SGLang · FP4 · Standard decode').then(([metadata]) => {
+            const valueRect = textRect(value);
+            const metadataRect = textRect(metadata);
 
-              expect(dateRect.top).to.be.at.least(metadataRect.top);
-            },
-          );
+            expect(metadataRect.top).to.be.at.least(valueRect.bottom);
+          });
         });
       });
     });

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -454,7 +454,7 @@ describe('Overview page', () => {
     }
   });
 
-  it('keeps the value and evidence date aligned above configuration metadata', () => {
+  it('keeps the evidence date beside configuration metadata below the value', () => {
     cy.viewport(390, 844);
     cy.visit('/overview');
 
@@ -466,28 +466,36 @@ describe('Overview page', () => {
               const valueRect = textRect(value);
               const dateRect = textRect(date);
 
-              expect(dateRect.bottom).to.be.closeTo(valueRect.bottom, 1);
+              expect(dateRect.top).to.be.at.least(valueRect.bottom);
             },
           );
         });
 
-        cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
-          cy.contains('div', 'SGLang · FP4 · Standard decode').then(([metadata]) => {
-            const valueRect = textRect(value);
-            const metadataRect = textRect(metadata);
+        cy.contains('span', 'SGLang · FP4 · Standard decode').then(([metadata]) => {
+          cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').then(
+            ([date]) => {
+              const metadataRect = textRect(metadata);
+              const dateRect = textRect(date);
 
-            expect(metadataRect.top).to.be.at.least(valueRect.bottom);
-          });
+              expect(dateRect.top).to.be.at.least(metadataRect.top);
+            },
+          );
         });
       });
     });
   });
 
-  it('never overlaps cost, delta, and date at the narrowest desktop width', () => {
+  it('fits the full matrix without overlap or clipping at the narrowest desktop width', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
     cy.get('[data-testid="overview-desktop-matrix"]').should('be.visible');
+    cy.get('[data-testid="overview-desktop-matrix"]').then(([table]) => {
+      const wrapper = table.parentElement as HTMLElement;
+      expect(wrapper.scrollWidth, 'matrix scrolls horizontally').to.be.at.most(
+        wrapper.clientWidth + 1,
+      );
+    });
     cy.get('[data-testid="overview-cost-delta"]').then(($badges) => {
       const problems: string[] = [];
       $badges.each((_, badge) => {
@@ -495,21 +503,11 @@ describe('Overview page', () => {
         if (badgeRect.width === 0) return;
         const cell = badge.parentElement as HTMLElement;
         const value = cell.querySelector('[data-testid="overview-pair-value"]');
-        const date = cell.querySelector('[data-testid="overview-pair-evidence-date"]');
         const hardware = badge.dataset.hardware;
         if (value) {
           const valueRect = value.getBoundingClientRect();
           if (valueRect.right > badgeRect.left + 0.5) {
             problems.push(`${hardware}: cost overlaps delta badge`);
-          }
-        }
-        if (date) {
-          const dateRect = date.getBoundingClientRect();
-          if (badgeRect.right > dateRect.left + 0.5) {
-            problems.push(`${hardware}: delta badge overlaps date`);
-          }
-          if (dateRect.top >= badgeRect.bottom) {
-            problems.push(`${hardware}: date wrapped below delta badge`);
           }
         }
       });

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -27,10 +27,9 @@ export const OVERVIEW_STRINGS = {
     tierUnit: 'tok/s/user',
     engineScopeNavLabel: 'Engine scope',
     engineScopeOptions: {
-      all: 'All engines',
-      community: 'Community',
+      all: 'All Platforms',
+      community: 'Open Source Community Engines (vLLM/SGLang)',
     },
-    engineScopeHint: 'Community = vLLM/SGLang',
     snapshot: (through: string) => `Database snapshot through ${through}`,
     caption:
       "Cost per million output tokens from the best observed platform serving envelopes for every active model across today's key platforms, prioritizing speculative decode and FP4.",
@@ -77,10 +76,9 @@ export const OVERVIEW_STRINGS = {
     tierUnit: 'tok/s/用户',
     engineScopeNavLabel: '引擎范围',
     engineScopeOptions: {
-      all: '全部引擎',
-      community: '社区',
+      all: '所有平台',
+      community: '开源社区引擎（vLLM/SGLang）',
     },
-    engineScopeHint: '社区 = vLLM/SGLang',
     snapshot: (through: string) => `数据库快照截至 ${through}`,
     caption:
       '基于最佳观测平台服务包络线计算的各活跃模型每百万输出 token 成本；优先采用推测解码与 FP4。',
@@ -646,7 +644,6 @@ export function OverviewEngineScopeSwitcher({
           ),
         )}
       </div>
-      <span className="text-muted-foreground/80">{strings.engineScopeHint}</span>
     </nav>
   );
 }

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -12,7 +12,6 @@ import {
   overviewTierHref,
 } from '@/lib/overview-links';
 
-import { ExternalLinkIcon } from '../ui/external-link-icon';
 import { OverviewDetailLink } from './overview-detail-link';
 
 export type OverviewLocale = 'en' | 'zh';
@@ -285,9 +284,9 @@ function CellValue({
     : undefined;
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
-      {/* Fixed cost | delta grid on desktop keeps every column scannable;
+      {/* Fixed cost | delta | date grid on desktop keeps every column scannable;
           the delta slot is reserved even on B200 so numbers align across rows. */}
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.75rem]">
+      <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem_auto]">
         <span
           data-testid="overview-pair-value"
           data-hardware={member.hardware}
@@ -316,33 +315,30 @@ function CellValue({
             strings={strings}
           />
         )}
+        {evidenceDate === null ? null : (
+          <span
+            data-testid="overview-pair-evidence-date"
+            data-hardware={member.hardware}
+            className="whitespace-nowrap text-[11px] text-muted-foreground/80 tabular-nums xl:col-start-3 xl:justify-self-end"
+          >
+            {config === null || stack === null ? (
+              evidenceDateLabel
+            ) : (
+              <a
+                href={buildOverviewDashboardHref(locale, model, config)}
+                title={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
+                aria-label={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
+                className={RAW_SOURCE_LINK_CLASS}
+              >
+                {evidenceDateLabel}
+              </a>
+            )}
+          </span>
+        )}
       </div>
-      {member.precision === null && evidenceDate === null ? null : (
-        <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[10px] leading-tight font-semibold uppercase tracking-wider text-muted-foreground">
-          {member.precision === null ? null : (
-            <span>{config === null ? member.precision.toUpperCase() : stackBadge}</span>
-          )}
-          {evidenceDate === null ? null : (
-            <span
-              data-testid="overview-pair-evidence-date"
-              data-hardware={member.hardware}
-              className="whitespace-nowrap font-normal normal-case tracking-normal text-muted-foreground/80 tabular-nums"
-            >
-              {config === null || stack === null ? (
-                evidenceDateLabel
-              ) : (
-                <a
-                  href={buildOverviewDashboardHref(locale, model, config)}
-                  title={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                  aria-label={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                  className={RAW_SOURCE_LINK_CLASS}
-                >
-                  {evidenceDateLabel}
-                  <ExternalLinkIcon aria-hidden="true" />
-                </a>
-              )}
-            </span>
-          )}
+      {member.precision === null ? null : (
+        <div className="min-w-0 text-[10px] leading-tight font-semibold uppercase tracking-wider text-muted-foreground">
+          {config === null ? member.precision.toUpperCase() : stackBadge}
         </div>
       )}
     </div>
@@ -422,7 +418,7 @@ export function DesktopOverviewMatrix({ models, locale, formatters, strings }: S
               <th
                 key={platform.hardware}
                 scope="col"
-                className={`px-4 py-2 text-left font-semibold ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
+                className={`px-3 py-2 text-left font-semibold ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
               >
                 {platform.hardware === 'b200'
                   ? `${platform.hardwareLabel} · ${strings.referenceHeader}`
@@ -453,7 +449,7 @@ export function DesktopOverviewMatrix({ models, locale, formatters, strings }: S
                 model.platforms.map((platform) => (
                   <td
                     key={platform.hardware}
-                    className={`px-4 py-3 align-top ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
+                    className={`px-3 py-3 align-top ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
                   >
                     <PlatformCell
                       locale={locale}

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -209,11 +209,13 @@ function CostDeltaBadge({
   hardware,
   formatters,
   strings,
+  phoneRow,
 }: {
   pct: number;
   hardware: string;
   formatters: Formatters;
   strings: OverviewStrings;
+  phoneRow: boolean;
 }) {
   const polarity = costDeltaPolarity(pct);
   const aria =
@@ -231,7 +233,11 @@ function CostDeltaBadge({
           ? undefined
           : { backgroundColor: `rgb(${COST_DELTA_HUE[polarity]} / ${costDeltaAlpha(pct)})` }
       }
-      className={`inline-flex items-center whitespace-nowrap rounded-sm px-1 py-0.5 text-[10px] font-semibold tabular-nums xl:col-start-2 xl:justify-self-end ${COST_DELTA_CLASS[polarity]}`}
+      className={`inline-flex items-center whitespace-nowrap rounded-sm px-1 py-0.5 text-[10px] font-semibold tabular-nums ${
+        phoneRow
+          ? 'col-start-2 justify-self-end sm:col-auto sm:justify-self-auto'
+          : 'xl:col-start-2 xl:justify-self-end'
+      } ${COST_DELTA_CLASS[polarity]}`}
     >
       <span aria-hidden="true">{formatters.percent.format(pct)}</span>
       <span className="sr-only">{aria}</span>
@@ -245,12 +251,14 @@ function CellValue({
   member,
   formatters,
   strings,
+  phoneRow = false,
 }: {
   locale: OverviewLocale;
   model: OverviewModelSummary;
   member: OverviewPlatformResult;
   formatters: Formatters;
   strings: OverviewStrings;
+  phoneRow?: boolean;
 }) {
   const { value, config, evidenceDate, evidenceTopologies } = member.read;
   if (member.missingReason !== null || value === null || member.costPerMtok === null) {
@@ -284,9 +292,15 @@ function CellValue({
     : undefined;
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
-      {/* Fixed cost | delta | date grid on desktop keeps every column scannable;
+      {/* Fixed cost | delta | date grids keep comparisons scannable on desktop and phones;
           the delta slot is reserved even on B200 so numbers align across rows. */}
-      <div className="flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem_auto]">
+      <div
+        className={
+          phoneRow
+            ? 'grid grid-cols-[minmax(max-content,1fr)_3.5rem_auto] items-baseline gap-x-1.5 gap-y-0.5 sm:flex sm:flex-wrap'
+            : 'flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem_auto]'
+        }
+      >
         <span
           data-testid="overview-pair-value"
           data-hardware={member.hardware}
@@ -313,13 +327,18 @@ function CellValue({
             hardware={member.hardware}
             formatters={formatters}
             strings={strings}
+            phoneRow={phoneRow}
           />
         )}
         {evidenceDate === null ? null : (
           <span
             data-testid="overview-pair-evidence-date"
             data-hardware={member.hardware}
-            className="whitespace-nowrap text-[11px] text-muted-foreground/80 tabular-nums xl:col-start-3 xl:justify-self-end"
+            className={`whitespace-nowrap text-[11px] text-muted-foreground/80 tabular-nums ${
+              phoneRow
+                ? 'col-start-3 justify-self-end sm:col-auto sm:justify-self-auto'
+                : 'xl:col-start-3 xl:justify-self-end'
+            }`}
           >
             {config === null || stack === null ? (
               evidenceDateLabel
@@ -351,6 +370,7 @@ function PlatformCell(props: {
   platform: OverviewPlatformResult;
   formatters: Formatters;
   strings: OverviewStrings;
+  phoneRow?: boolean;
 }) {
   return (
     <div data-testid="overview-platform" data-hardware={props.platform.hardware}>
@@ -360,6 +380,7 @@ function PlatformCell(props: {
         member={props.platform}
         formatters={props.formatters}
         strings={props.strings}
+        phoneRow={props.phoneRow}
       />
     </div>
   );
@@ -492,48 +513,38 @@ export function MobileOverviewList({ models, locale, formatters, strings }: Surf
             {hasNo8k1kResult(model) ? (
               <CoverageNote strings={strings} />
             ) : (
-              <>
-                <div className="grid grid-cols-2 gap-x-3 gap-y-1">
-                  {model.platforms
-                    .filter(
-                      (platform) => platform.hardware === 'b200' || platform.hardware === 'mi355x',
-                    )
-                    .map((platform) => (
-                      <div key={platform.hardware} className="min-w-0 space-y-0.5">
-                        <span className="text-xs font-medium text-muted-foreground">
-                          {platform.hardwareLabel}
-                        </span>
-                        <PlatformCell
-                          locale={locale}
-                          model={model}
-                          platform={platform}
-                          formatters={formatters}
-                          strings={strings}
-                        />
-                      </div>
-                    ))}
-                </div>
-                <div className="grid grid-cols-3 gap-x-3 gap-y-1 border-t border-border/40 pt-2">
-                  {model.platforms
-                    .filter(
-                      (platform) => platform.hardware !== 'b200' && platform.hardware !== 'mi355x',
-                    )
-                    .map((platform) => (
-                      <div key={platform.hardware} className="min-w-0 space-y-0.5">
-                        <span className="text-[11px] font-medium text-muted-foreground/80">
-                          {platform.hardwareLabel}
-                        </span>
-                        <PlatformCell
-                          locale={locale}
-                          model={model}
-                          platform={platform}
-                          formatters={formatters}
-                          strings={strings}
-                        />
-                      </div>
-                    ))}
-                </div>
-              </>
+              <div className="grid grid-cols-1 sm:grid-cols-6 sm:gap-x-3 sm:gap-y-1">
+                {model.platforms.map((platform) => {
+                  const isPrimary = platform.hardware === 'b200' || platform.hardware === 'mi355x';
+                  return (
+                    <div
+                      key={platform.hardware}
+                      data-testid="overview-mobile-platform-row"
+                      data-hardware={platform.hardware}
+                      className={`grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-2.5 last:border-b-0 sm:block sm:space-y-0.5 sm:border-b-0 sm:py-0 ${
+                        isPrimary
+                          ? 'sm:col-span-3'
+                          : 'sm:col-span-2 sm:border-t sm:border-border/40 sm:pt-2'
+                      }`}
+                    >
+                      <span
+                        data-testid="overview-mobile-hardware"
+                        className="pt-0.5 text-xs font-medium text-muted-foreground sm:pt-0"
+                      >
+                        {platform.hardwareLabel}
+                      </span>
+                      <PlatformCell
+                        locale={locale}
+                        model={model}
+                        platform={platform}
+                        formatters={formatters}
+                        strings={strings}
+                        phoneRow
+                      />
+                    </div>
+                  );
+                })}
+              </div>
             )}
             <OverviewDetailLink
               href={detailHref(locale, model)}

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -337,7 +337,7 @@ function CellValue({
         )}
       </div>
       {member.precision === null ? null : (
-        <div className="min-w-0 text-[10px] leading-tight font-semibold uppercase tracking-wider text-muted-foreground">
+        <div className="min-w-0 text-[10px] leading-tight font-normal uppercase tracking-wider text-muted-foreground/70">
           {config === null ? member.precision.toUpperCase() : stackBadge}
         </div>
       )}
@@ -438,18 +438,18 @@ export function DesktopOverviewMatrix({ models, locale, formatters, strings }: S
               data-model={model.model}
               className="border-b border-border/50 align-top last:border-b-0"
             >
-              <th scope="row" className="px-4 py-3 text-left align-top font-normal lg:px-6">
+              <th scope="row" className="px-4 py-4 text-left align-top font-normal lg:px-6">
                 <ModelName model={model} />
               </th>
               {hasNo8k1kResult(model) ? (
-                <td colSpan={model.platforms.length} className="px-4 py-3 align-top">
+                <td colSpan={model.platforms.length} className="px-4 py-4 align-top">
                   <CoverageNote strings={strings} />
                 </td>
               ) : (
                 model.platforms.map((platform) => (
                   <td
                     key={platform.hardware}
-                    className={`px-3 py-3 align-top ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
+                    className={`px-3 py-4 align-top ${platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
                   >
                     <PlatformCell
                       locale={locale}
@@ -461,7 +461,7 @@ export function DesktopOverviewMatrix({ models, locale, formatters, strings }: S
                   </td>
                 ))
               )}
-              <td className="px-4 py-3 align-top">
+              <td className="px-4 py-4 align-top">
                 <OverviewDetailLink
                   href={detailHref(locale, model)}
                   model={model.model}

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -337,7 +337,7 @@ function CellValue({
         )}
       </div>
       {member.precision === null ? null : (
-        <div className="min-w-0 text-[10px] leading-tight font-normal uppercase tracking-wider text-muted-foreground/70">
+        <div className="min-w-0 text-[11px] leading-tight font-normal uppercase tracking-wider text-muted-foreground/70">
           {config === null ? member.precision.toUpperCase() : stackBadge}
         </div>
       )}

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -234,9 +234,7 @@ function CostDeltaBadge({
           : { backgroundColor: `rgb(${COST_DELTA_HUE[polarity]} / ${costDeltaAlpha(pct)})` }
       }
       className={`inline-flex items-center whitespace-nowrap rounded-sm px-1 py-0.5 text-[10px] font-semibold tabular-nums ${
-        phoneRow
-          ? 'col-start-2 justify-self-end sm:col-auto sm:justify-self-auto'
-          : 'xl:col-start-2 xl:justify-self-end'
+        phoneRow ? 'col-start-2 justify-self-start' : 'xl:col-start-2 xl:justify-self-end'
       } ${COST_DELTA_CLASS[polarity]}`}
     >
       <span aria-hidden="true">{formatters.percent.format(pct)}</span>
@@ -297,7 +295,7 @@ function CellValue({
       <div
         className={
           phoneRow
-            ? 'grid grid-cols-[minmax(max-content,1fr)_3.5rem_auto] items-baseline gap-x-1.5 gap-y-0.5 sm:flex sm:flex-wrap'
+            ? 'grid grid-cols-[max-content_max-content_minmax(0,1fr)] items-baseline gap-x-1.5 gap-y-0.5'
             : 'flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem_auto]'
         }
       >
@@ -335,9 +333,7 @@ function CellValue({
             data-testid="overview-pair-evidence-date"
             data-hardware={member.hardware}
             className={`whitespace-nowrap text-[11px] text-muted-foreground/80 tabular-nums ${
-              phoneRow
-                ? 'col-start-3 justify-self-end sm:col-auto sm:justify-self-auto'
-                : 'xl:col-start-3 xl:justify-self-end'
+              phoneRow ? 'col-start-3 justify-self-end' : 'xl:col-start-3 xl:justify-self-end'
             }`}
           >
             {config === null || stack === null ? (
@@ -513,37 +509,30 @@ export function MobileOverviewList({ models, locale, formatters, strings }: Surf
             {hasNo8k1kResult(model) ? (
               <CoverageNote strings={strings} />
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-6 sm:gap-x-3 sm:gap-y-1">
-                {model.platforms.map((platform) => {
-                  const isPrimary = platform.hardware === 'b200' || platform.hardware === 'mi355x';
-                  return (
-                    <div
-                      key={platform.hardware}
-                      data-testid="overview-mobile-platform-row"
-                      data-hardware={platform.hardware}
-                      className={`grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-2.5 last:border-b-0 sm:block sm:space-y-0.5 sm:border-b-0 sm:py-0 ${
-                        isPrimary
-                          ? 'sm:col-span-3'
-                          : 'sm:col-span-2 sm:border-t sm:border-border/40 sm:pt-2'
-                      }`}
+              <div className="grid grid-cols-1">
+                {model.platforms.map((platform) => (
+                  <div
+                    key={platform.hardware}
+                    data-testid="overview-mobile-platform-row"
+                    data-hardware={platform.hardware}
+                    className="grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-2.5 last:border-b-0"
+                  >
+                    <span
+                      data-testid="overview-mobile-hardware"
+                      className="pt-0.5 text-xs font-medium text-muted-foreground"
                     >
-                      <span
-                        data-testid="overview-mobile-hardware"
-                        className="pt-0.5 text-xs font-medium text-muted-foreground sm:pt-0"
-                      >
-                        {platform.hardwareLabel}
-                      </span>
-                      <PlatformCell
-                        locale={locale}
-                        model={model}
-                        platform={platform}
-                        formatters={formatters}
-                        strings={strings}
-                        phoneRow
-                      />
-                    </div>
-                  );
-                })}
+                      {platform.hardwareLabel}
+                    </span>
+                    <PlatformCell
+                      locale={locale}
+                      model={model}
+                      platform={platform}
+                      formatters={formatters}
+                      strings={strings}
+                      phoneRow
+                    />
+                  </div>
+                ))}
               </div>
             )}
             <OverviewDetailLink

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -285,9 +285,9 @@ function CellValue({
     : undefined;
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
-      {/* Fixed cost | delta | date grid on desktop keeps every column scannable;
+      {/* Fixed cost | delta grid on desktop keeps every column scannable;
           the delta slot is reserved even on B200 so numbers align across rows. */}
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.75rem_auto]">
+      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.75rem]">
         <span
           data-testid="overview-pair-value"
           data-hardware={member.hardware}
@@ -316,31 +316,33 @@ function CellValue({
             strings={strings}
           />
         )}
-        {evidenceDate === null ? null : (
-          <span
-            data-testid="overview-pair-evidence-date"
-            data-hardware={member.hardware}
-            className="whitespace-nowrap text-xs text-muted-foreground/80 tabular-nums xl:col-start-3 xl:justify-self-end"
-          >
-            {config === null || stack === null ? (
-              evidenceDateLabel
-            ) : (
-              <a
-                href={buildOverviewDashboardHref(locale, model, config)}
-                title={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                aria-label={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                className={RAW_SOURCE_LINK_CLASS}
-              >
-                {evidenceDateLabel}
-                <ExternalLinkIcon aria-hidden="true" />
-              </a>
-            )}
-          </span>
-        )}
       </div>
-      {member.precision === null ? null : (
-        <div className="min-w-0 text-[10px] leading-tight font-semibold uppercase tracking-wider text-muted-foreground">
-          {config === null ? member.precision.toUpperCase() : stackBadge}
+      {member.precision === null && evidenceDate === null ? null : (
+        <div className="flex min-w-0 flex-wrap items-baseline gap-x-1.5 gap-y-0.5 text-[10px] leading-tight font-semibold uppercase tracking-wider text-muted-foreground">
+          {member.precision === null ? null : (
+            <span>{config === null ? member.precision.toUpperCase() : stackBadge}</span>
+          )}
+          {evidenceDate === null ? null : (
+            <span
+              data-testid="overview-pair-evidence-date"
+              data-hardware={member.hardware}
+              className="whitespace-nowrap font-normal normal-case tracking-normal text-muted-foreground/80 tabular-nums"
+            >
+              {config === null || stack === null ? (
+                evidenceDateLabel
+              ) : (
+                <a
+                  href={buildOverviewDashboardHref(locale, model, config)}
+                  title={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
+                  aria-label={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
+                  className={RAW_SOURCE_LINK_CLASS}
+                >
+                  {evidenceDateLabel}
+                  <ExternalLinkIcon aria-hidden="true" />
+                </a>
+              )}
+            </span>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Follow-up to #621.

## Summary

- Restore the full engine-scope labels: “Open Source Community Engines (vLLM/SGLang)” and “All Platforms”.
- Keep the complete desktop comparison matrix visible without normal horizontal scrolling at 1280px and above.
- Use the same five-row platform comparison layout on phones and tablets.
- Keep each cost delta beside its value, align value/delta/date typographically, and retain right-aligned evidence dates.
- Improve configuration metadata readability while keeping it visually secondary.

## Verification

- `pnpm fmt`
- `pnpm lint`
- `pnpm typecheck`
- `E2E_FIXTURES=1 pnpm --dir packages/app build`
- Overview E2E: Chrome 14/14 and Firefox 14/14
- GitHub unit, component, Chrome/Firefox E2E, CodeQL, Cursor Bugbot, Claude review, and Vercel checks pass

## 中文说明

这是 #621 的后续改进。

- 恢复完整的引擎范围标签：“Open Source Community Engines (vLLM/SGLang)”和“All Platforms”。
- 桌面端在 1280px 及以上宽度完整展示对比矩阵，正常浏览时无需横向滚动。
- 手机和平板统一采用五行平台对比布局。
- 成本差值紧邻对应数值，数值、差值和日期按文字基线对齐，同时保持证据日期右对齐。
- 提升配置元数据的可读性，同时保持次要视觉层级。

验证已覆盖格式、lint、类型检查、production build，以及 Chrome 和 Firefox 的 Overview E2E；GitHub CI、CodeQL、Cursor Bugbot、Claude review 和 Vercel 检查均通过。
