### PR TITLE
chore(specs): set real RTX PRO 6000 all-in power and cost tiers / 设置 RTX PRO 6000 的正式整机功耗与成本档位

### DIFF
--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -125,21 +125,18 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
   },
   // NVIDIA RTX PRO 6000 Blackwell Server Edition (GB202, PCIe Gen5, 96 GB GDDR7).
   // A workstation-class PCIe card benchmarked in 8× TP configs (no NVLink/NVSwitch);
-  // sorts last, after the datacenter SXM/OAM parts.
-  // TODO: power (all-in kW/GPU) and cost tiers are placeholders (9.99) pending the
-  // official values from the SemiAnalysis AI Cloud TCO model. TDP is the datasheet
-  // 600 W max board power. Until real numbers land, $/token and per-MW metrics for
-  // this SKU are not meaningful.
+  // sorts last, after the datacenter SXM/OAM parts. TDP is the datasheet 600 W max
+  // board power; power and cost tiers are from the SemiAnalysis AI Cloud TCO model.
   rtx6000pro: {
     vendor: 'NVIDIA',
     arch: 'Blackwell',
     label: 'RTX PRO 6000',
     sort: 9,
     tdp: 600,
-    power: 9.99,
-    costh: 9.99,
-    costn: 9.99,
-    costr: 9.99,
+    power: 0.975,
+    costh: 0.43,
+    costn: 0.676,
+    costr: 0.52,
   },
 };
 


### PR DESCRIPTION
## Summary

Replaces the `9.99` placeholder values for the NVIDIA RTX PRO 6000 Blackwell Server Edition in `HW_REGISTRY` (`packages/constants/src/gpu-keys.ts`) with the official values from the SemiAnalysis AI Cloud TCO model:

| Field | Meaning | Old | New |
| --- | --- | --- | --- |
| `power` | All-in kW per GPU | 9.99 | **0.975** |
| `costh` | Owning – Hyperscaler ($/GPU/hr) | 9.99 | **0.43** |
| `costn` | Owning – Neocloud Giant ($/GPU/hr) | 9.99 | **0.676** |
| `costr` | 3 Year Rental ($/GPU/hr) | 9.99 | **0.52** |

With real numbers in place, $/token and per-MW metrics for this SKU are now meaningful, so the placeholder TODO comment is removed. TDP stays at the datasheet 600 W max board power.

No presentation/UI code changes — `HW_REGISTRY` is the single source of truth and all cost/power metrics derive from it at render time, for both official runs and `?unofficialrun=` overlays (the overlay path reads the same registry, so no separate overlay work applies).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt` — pass
- `pnpm test:unit` — 2810 tests pass (no test pinned the placeholder values)

## 中文说明

将 `HW_REGISTRY`（`packages/constants/src/gpu-keys.ts`）中 NVIDIA RTX PRO 6000 Blackwell Server Edition 的 `9.99` 占位值替换为 SemiAnalysis AI Cloud TCO 模型的正式数值：

| 字段 | 含义 | 旧值 | 新值 |
| --- | --- | --- | --- |
| `power` | 每 GPU 整机功耗 (kW) | 9.99 | **0.975** |
| `costh` | 自有 – Hyperscaler ($/GPU/hr) | 9.99 | **0.43** |
| `costn` | 自有 – Neocloud Giant ($/GPU/hr) | 9.99 | **0.676** |
| `costr` | 3 年租赁 ($/GPU/hr) | 9.99 | **0.52** |

正式数值就位后，该 SKU 的 $/token 与每 MW 指标随之有效，因此移除了占位 TODO 注释。TDP 保持数据手册标称的 600 W 最大板卡功耗。

不涉及展示层/UI 代码改动 —— `HW_REGISTRY` 是唯一数据源，所有成本/功耗指标（包括官方运行与 `?unofficialrun=` 覆盖层）都在渲染时从同一注册表推导，无需单独的覆盖层适配。

测试：`pnpm typecheck`、`pnpm lint`、`pnpm fmt` 通过；`pnpm test:unit` 2810 个测试全部通过（无测试固定占位值）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-registry data update with no logic changes; only RTX PRO 6000 derived metrics change.
> 
> **Overview**
> Updates **`rtx6000pro`** in `HW_REGISTRY` so RTX PRO 6000 Blackwell metrics use SemiAnalysis AI Cloud TCO values instead of **`9.99`** placeholders.
> 
> **`power`** is now **0.975** kW/GPU (all-in); **`costh`**, **`costn`**, and **`costr`** are **0.43**, **0.676**, and **0.52** $/GPU/hr respectively. **`tdp`** stays **600** W. The TODO about pending TCO numbers is removed and the block comment now states that power and costs come from the TCO model.
> 
> Because everything that derives $/token and per-MW figures reads this registry, RTX PRO 6000 comparisons and overlays pick up the new economics without separate UI changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca59df288deddda3e3457a7fb9bdbd5ab10ee64e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->