### PR TITLE
ci: remove workflow cache warnings / CI：消除工作流缓存警告

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -51,8 +51,8 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           CYPRESS_INSTALL_BINARY: '0'
-      - name: Cache Cypress binary
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Restore Cypress binary cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-binary-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: '0'
       - name: Cache Cypress binary
-        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-binary-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -90,8 +90,9 @@ jobs:
       # the incremental fetch cache), per
       # https://nextjs.org/docs/pages/guides/ci-build-caching#github-actions.
       # Runs before `pnpm install` so hashFiles never scans node_modules.
-      - name: Cache Next.js build
-        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.1.0
+      - name: Restore Next.js build cache
+        id: nextjs-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: packages/app/.next/cache
           # New cache whenever packages or source files change; fall back to
@@ -105,8 +106,9 @@ jobs:
         run: pnpm install --frozen-lockfile
         env:
           CYPRESS_INSTALL_BINARY: '0'
-      - name: Cache Cypress binary
-        uses: useblacksmith/cache@c5fe29eb0efdf1cf4186b9f7fcbbcbc0cf025662 # v5.1.0
+      - name: Restore Cypress binary cache
+        id: cypress-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/Cypress
           key: cypress-binary-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -115,10 +117,22 @@ jobs:
       - name: Install Cypress binary if missing
         working-directory: packages/app
         run: pnpm exec cypress verify || pnpm exec cypress install
+      - name: Save Cypress binary cache
+        if: ${{ matrix.browser == 'chrome' && matrix.shard == 1 && steps.cypress-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/Cypress
+          key: ${{ steps.cypress-cache.outputs.cache-primary-key }}
       - name: Build app
         run: pnpm build
         env:
           E2E_FIXTURES: '1'
+      - name: Save Next.js build cache
+        if: ${{ matrix.browser == 'chrome' && matrix.shard == 1 && steps.nextjs-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: packages/app/.next/cache
+          key: ${{ steps.nextjs-cache.outputs.cache-primary-key }}
       - name: Run integration tests
         uses: cypress-io/github-action@fa4a118725a8f001170d49631ea89e5d66fee626 # v7.4.1
         with:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -36,7 +36,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
-          cache: pnpm
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm store
+        id: pnpm-store-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-${{ runner.arch }}-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
         env:
@@ -80,7 +90,17 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
-          cache: pnpm
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm store
+        id: pnpm-store-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-store-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-${{ runner.arch }}-
       - uses: browser-actions/setup-firefox@0bc507ddf224827e3b1af68e014d5e42ab93e795 # v1.7.2
         if: matrix.browser == 'firefox'
         with:
@@ -123,6 +143,14 @@ jobs:
         with:
           path: ~/.cache/Cypress
           key: ${{ steps.cypress-cache.outputs.cache-primary-key }}
+      # The component job only restores this cache. One E2E shard writes it, avoiding
+      # concurrent cache reservations across the nine parallel test jobs.
+      - name: Save pnpm store
+        if: ${{ matrix.browser == 'chrome' && matrix.shard == 1 && steps.pnpm-store-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.pnpm-store-cache.outputs.cache-primary-key }}
       - name: Build app
         run: pnpm build
         env:

--- a/packages/app/src/test/setup-local-storage.ts
+++ b/packages/app/src/test/setup-local-storage.ts
@@ -1,3 +1,10 @@
+// React requires this flag for warnings about updates outside `act()` to be meaningful.
+Object.defineProperty(globalThis, 'IS_REACT_ACT_ENVIRONMENT', {
+  configurable: true,
+  writable: true,
+  value: true,
+});
+
 class MemoryStorage implements Storage {
   readonly #values = new Map<string, string>();
 


### PR DESCRIPTION
## Summary
- replace deprecated `useblacksmith/cache` with the Node 24-based `actions/cache` v6.1.0
- restore pnpm, Cypress, and Next.js caches in every E2E shard, then save each cache only from the primary Chrome shard on a cache miss to eliminate concurrent cache-write warnings
- let component tests restore the pnpm store without racing E2E cache writers
- define a writable React `act()` environment flag for unit tests

## Verification
- `pnpm --filter @semianalysisai/inferencex-app test:unit`
- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`

## 中文说明
- 将已弃用的 `useblacksmith/cache` 替换为基于 Node 24 的 `actions/cache` v6.1.0。
- 所有 E2E 分片均可恢复 pnpm、Cypress 和 Next.js 缓存，仅主 Chrome 分片会在缓存未命中时保存各缓存，从而消除并发写入缓存的警告。
- 组件测试仅恢复 pnpm store，避免与 E2E 缓存写入器产生竞争。
- 为单元测试设置可写的 React `act()` 环境标志。

## 验证
- `pnpm --filter @semianalysisai/inferencex-app test:unit`
- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions caching strategy and Vitest test setup; no application runtime or security-sensitive logic is modified.
> 
> **Overview**
> **CI caching** drops `useblacksmith/cache` and `setup-node`’s built-in pnpm cache in favor of **`actions/cache` v6** with explicit **restore** steps for the pnpm store, Cypress binary, and Next.js `.next/cache`, plus **save** steps that run only on **Chrome shard 1** when the restore missed—so parallel E2E shards and the component job no longer race to write the same cache keys.
> 
> The **component** job restores pnpm (and Cypress) but does not save the pnpm store; **one** E2E shard owns writes for pnpm, Cypress, and Next.js caches.
> 
> **Unit tests:** `setup-local-storage.ts` now defines a **writable** `globalThis.IS_REACT_ACT_ENVIRONMENT` so React’s `act()` warnings behave correctly under Vitest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6cd93235a6e378dfd971ecc8a2077056548a8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->