### PR TITLE
fix(inference): default DeepSeek V4 agentic charts to vLLM / 修复推理图表：DeepSeek V4 Agentic 场景默认选择 vLLM

### DIFF
--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -67,7 +67,10 @@ import {
   type XAxisMode,
 } from './hooks/useChartData';
 import { resolveComparisonEntries } from './utils/comparisonEntry';
-import { comparisonExclusion as resolveComparisonExclusion } from './utils/comparison-exclusion';
+import {
+  comparisonDefaultGroup,
+  comparisonExclusion as resolveComparisonExclusion,
+} from './utils/comparison-exclusion';
 import { resolveLabelState, serializeLabelState } from './utils/label-defaults';
 import {
   EMPTY_QUICK_FILTERS,
@@ -141,6 +144,10 @@ export function InferenceProvider({
     () => resolveComparisonExclusion(selectedModel, effectiveSequence, isUnofficialRun),
     [selectedModel, effectiveSequence, isUnofficialRun],
   );
+  const defaultExclusionGroup = useMemo(
+    () => comparisonDefaultGroup(selectedModel, effectiveSequence, isUnofficialRun),
+    [selectedModel, effectiveSequence, isUnofficialRun],
+  );
   const exclusionPolicy: ExclusionConflictPolicy =
     sequenceKind(effectiveSequence) === 'agentic' ? 'keep-sticky' : 'clear-all';
 
@@ -183,6 +190,7 @@ export function InferenceProvider({
       new Set(),
       exclusion,
       exclusionPolicy,
+      defaultExclusionGroup,
     );
     const selection = [...resolution.result];
     if (
@@ -195,7 +203,7 @@ export function InferenceProvider({
       selection,
       ...exclusionResolutionFamilies(selectedGpuState, resolution.result, exclusion),
     };
-  }, [selectedGpuState, sequenceResolved, exclusion, exclusionPolicy]);
+  }, [selectedGpuState, sequenceResolved, exclusion, exclusionPolicy, defaultExclusionGroup]);
   const selectedGPUs = selectedGpuResolution?.selection ?? selectedGpuState;
   useEffect(() => {
     if (!selectedGpuResolution) return;
@@ -816,6 +824,8 @@ export function InferenceProvider({
   exclusionRef.current = comparisonExclusion;
   const exclusionPolicyRef = useRef(exclusionPolicy);
   exclusionPolicyRef.current = exclusionPolicy;
+  const defaultExclusionGroupRef = useRef(defaultExclusionGroup);
+  defaultExclusionGroupRef.current = defaultExclusionGroup;
   const resolveHwSelection = useCallback((proposed: Set<string>, prev?: Set<string>) => {
     const currentExclusion = exclusionRef.current;
     if (!currentExclusion) {
@@ -826,6 +836,7 @@ export function InferenceProvider({
       prev ?? activeHwTypesRef.current,
       currentExclusion,
       exclusionPolicyRef.current,
+      defaultExclusionGroupRef.current,
     );
   }, []);
   const toggleComparisonSelection = useCallback(
@@ -841,6 +852,7 @@ export function InferenceProvider({
           toggleUniverse,
           currentExclusion,
           exclusionPolicyRef.current,
+          defaultExclusionGroupRef.current,
         );
         if (decision.kind === 'block') {
           setEngineConflict({

--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -1,11 +1,54 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveExclusionToggle } from '@/lib/exclusion';
+import { resolveExclusionGroups, resolveExclusionToggle } from '@/lib/exclusion';
 import { Model, Sequence } from '@/lib/data-mappings';
 
-import { comparisonExclusion } from './comparison-exclusion';
+import { comparisonDefaultGroup, comparisonExclusion } from './comparison-exclusion';
 
 describe('comparisonExclusion', () => {
+  it('defaults official DeepSeek V4 Pro Agentic charts to vLLM', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
+    const fallbackGroup = comparisonDefaultGroup(
+      Model.DeepSeek_V4_Pro,
+      Sequence.AgenticTraces,
+      false,
+    );
+    const resolved = resolveExclusionGroups(
+      new Set(['b200_sglang', 'b200_vllm']),
+      new Set(),
+      exclusion,
+      'keep-sticky',
+      fallbackGroup,
+    );
+
+    expect(fallbackGroup).toBe('vllm');
+    expect(resolved.result).toEqual(new Set(['b200_vllm']));
+    expect(resolved.droppedGroups).toEqual(['sglang']);
+  });
+
+  it.each([
+    {
+      name: 'fixed-sequence DeepSeek V4 Pro',
+      model: Model.DeepSeek_V4_Pro,
+      sequence: Sequence.EightK_OneK,
+      isUnofficialRun: false,
+    },
+    {
+      name: 'another Agentic model',
+      model: Model.DeepSeek_R1,
+      sequence: Sequence.AgenticTraces,
+      isUnofficialRun: false,
+    },
+    {
+      name: 'an unofficial DeepSeek V4 Pro Agentic preview',
+      model: Model.DeepSeek_V4_Pro,
+      sequence: Sequence.AgenticTraces,
+      isUnofficialRun: true,
+    },
+  ])('does not impose the vLLM default on $name', ({ model, sequence, isUnofficialRun }) => {
+    expect(comparisonDefaultGroup(model, sequence, isUnofficialRun)).toBeNull();
+  });
+
   it('keeps the engine-family guard for official Agentic Traces charts', () => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false);
 

--- a/packages/app/src/components/inference/utils/comparison-exclusion.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.ts
@@ -1,5 +1,20 @@
-import { getModelExclusion, getSequenceExclusion } from '@/lib/data-mappings';
+import { getModelExclusion, getSequenceExclusion, Model, Sequence } from '@/lib/data-mappings';
 import { buildExclusion, type Exclusion } from '@/lib/exclusion';
+
+/**
+ * Preferred engine group when an official comparison first encounters multiple
+ * valid groups and has no sticky user selection to preserve.
+ */
+export function comparisonDefaultGroup(
+  model: Parameters<typeof getModelExclusion>[0],
+  sequence: Parameters<typeof getSequenceExclusion>[0],
+  isUnofficialRun: boolean,
+): string | null {
+  if (!isUnofficialRun && model === Model.DeepSeek_V4_Pro && sequence === Sequence.AgenticTraces) {
+    return 'vllm';
+  }
+  return null;
+}
 
 /**
  * Resolve the production comparability guard for the current chart scope.

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -344,6 +344,22 @@ describe('pickStickyGroup', () => {
     expect(out.droppedGroups).toEqual(['vllm']);
   });
 
+  it('uses an available fallback group when there is no sticky selection', () => {
+    const proposed = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const out = pickStickyGroup(proposed, new Set(), ex, 'vllm');
+    expect(out.keptGroup).toBe('vllm');
+    expect([...out.result]).toEqual(['h100_vllm_mtp']);
+    expect(out.droppedGroups).toEqual(['sglang']);
+  });
+
+  it('keeps a sticky selection ahead of the fallback group', () => {
+    const proposed = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const out = pickStickyGroup(proposed, new Set(['gb300_sglang_mtp']), ex, 'vllm');
+    expect(out.keptGroup).toBe('sglang');
+    expect([...out.result]).toEqual(['gb300_sglang_mtp']);
+    expect(out.droppedGroups).toEqual(['vllm']);
+  });
+
   it('treats dynamo/mori variants as the same group', () => {
     const proposed = new Set(['h100_vllm_mtp', 'h100_dynamo-vllm_mtp', 'gb300_dynamo-sglang_mtp']);
     const out = pickStickyGroup(proposed, new Set(['h100_vllm_mtp']), ex);

--- a/packages/app/src/lib/exclusion.ts
+++ b/packages/app/src/lib/exclusion.ts
@@ -172,7 +172,8 @@ function activeFamilyInGroup(
  * multiple groups. Sticks to a group already present in `prev`; for a shared
  * scope with no direct prior key (for example the global MTP scope), also honors
  * a prior key from the same group on an overlapping hardware scope. Otherwise
- * falls back to the alphabetically-first group.
+ * uses `fallbackGroup` when that group is available, then falls back to the
+ * alphabetically-first group.
  *
  * If `proposed` has 0 or 1 groups, the input set is returned unchanged.
  */
@@ -180,6 +181,7 @@ export function pickStickyGroup(
   proposed: Set<string>,
   prev: Set<string>,
   ex: Exclusion,
+  fallbackGroup?: string | null,
 ): { result: Set<string>; keptGroup: string | null; droppedGroups: string[] } {
   const byScope = groupKeysByScope(proposed, ex);
   const allGroups = new Set([...byScope.values()].flatMap((byGroup) => [...byGroup.keys()]));
@@ -216,6 +218,7 @@ export function pickStickyGroup(
     const winner =
       groups.filter((group) => directPrevGroups.has(group)).toSorted()[0] ??
       groups.filter((group) => correlatedPrevGroups.has(group)).toSorted()[0] ??
+      (fallbackGroup && groups.includes(fallbackGroup) ? fallbackGroup : undefined) ??
       groups.toSorted()[0];
     winners.add(winner);
     for (const [group, keys] of byGroup) {
@@ -330,8 +333,9 @@ export function resolveExclusionGroups(
   prev: Set<string>,
   ex: Exclusion,
   policy: ExclusionConflictPolicy = 'clear-all',
+  fallbackGroup?: string | null,
 ): ExclusionResolution {
-  if (policy === 'keep-sticky') return pickStickyGroup(proposed, prev, ex);
+  if (policy === 'keep-sticky') return pickStickyGroup(proposed, prev, ex, fallbackGroup);
   const cleared = clearAllExclusionGroups(proposed, ex);
   return { ...cleared, keptGroup: null };
 }
@@ -384,6 +388,7 @@ export function resolveExclusionToggle(
   allItems: Set<string>,
   ex: Exclusion,
   policy: ExclusionConflictPolicy = 'clear-all',
+  fallbackGroup?: string | null,
 ): ExclusionToggleDecision {
   const proposed = computeToggle(prev, hw, allItems);
   const wasActive = prev.has(hw);
@@ -409,7 +414,7 @@ export function resolveExclusionToggle(
 
   // Other paths (e.g. solo→restore-all surfacing a hidden second group) are
   // normalized silently because the user didn't explicitly add a conflict.
-  const resolved = resolveExclusionGroups(proposed, prev, ex, policy);
+  const resolved = resolveExclusionGroups(proposed, prev, ex, policy, fallbackGroup);
   if (resolved.droppedGroups.length > 0) {
     return { kind: 'silent-resolve', result: resolved.result };
   }


### PR DESCRIPTION
## Summary

- Prefer vLLM when the official DeepSeek-V4-Pro Agentic Traces scenario first resolves a cross-engine selection.
- Preserve an explicit sticky SGLang selection instead of forcing the default after user interaction.
- Keep unofficial `?unofficialrun=` previews unchanged: they intentionally allow mixed engine families for diagnostics, and the regression tests cover this path.

## Validation

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm test:unit` (3,165 tests)
- Cypress component suite (183 tests)
- Focused exclusion tests (64 tests)

## 中文说明

- DeepSeek-V4-Pro Agentic Traces 官方场景首次处理跨引擎选择时，默认优先使用 vLLM。
- 用户明确选择 SGLang 后继续保留该选择，不会被默认值强制覆盖。
- 非官方 `?unofficialrun=` 预览保持现有行为：诊断模式仍允许混合展示不同引擎系列，回归测试已覆盖该路径。

## 验证

- `pnpm lint`
- `pnpm fmt`
- `pnpm typecheck`
- `pnpm test:unit`（3,165 项测试）
- Cypress 组件测试（183 项测试）
- 聚焦 exclusion 测试（64 项测试）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to exclusion tie-breaking and inference selection plumbing; sticky user choices still win, with broad unit test coverage.
> 
> **Overview**
> Adds a **scenario-specific default engine group** (`comparisonDefaultGroup` → `vllm`) for **official DeepSeek V4 Pro Agentic Traces**, and threads an optional **`fallbackGroup`** through `pickStickyGroup`, `resolveExclusionGroups`, and `resolveExclusionToggle` so it applies **after** sticky/correlated prior selection but **before** the old alphabetical tie-break.
> 
> **Inference** passes that fallback into GPU multi-select normalization, legend hardware resolution, and comparison toggles. Unofficial runs and other model/sequence combinations still get `null` (no new default). Regression tests cover the vLLM default, sticky-over-fallback behavior, and scoped negatives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70583e975c9c1079df41cc0fdd35ba5a7e839f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->