### PR TITLE
feat(models): add Kimi-K3 as its own model bucket / 新增 Kimi-K3 独立模型分桶

### DIFF
--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -217,12 +217,15 @@ describe('GPU comparison agentic point detail', () => {
       },
     );
 
+    // Official DeepSeek-V4-Pro agentic charts prefer vLLM when they first resolve
+    // a cross-engine conflict with no sticky selection (comparisonDefaultGroup,
+    // PR #632). Before that the winner was the alphabetically-first group, SGLang.
     cy.get('[data-testid="engine-comparison-conflict-toast"]')
       .should('be.visible')
-      .and('contain.text', 'Kept SGLang and removed vLLM configs');
+      .and('contain.text', 'Kept vLLM and removed SGLang configs');
     cy.get('[data-testid="gpu-multiselect"] [data-slot="select-trigger"]')
-      .should('contain.text', 'SGLang')
-      .and('not.contain.text', 'vLLM');
+      .should('contain.text', 'vLLM')
+      .and('not.contain.text', 'SGLang');
     cy.contains('button', 'Jun 12, 2026').should('be.visible');
   });
 });

--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -518,6 +518,9 @@ describe('Model Architecture Diagram', () => {
       cy.get('[data-testid="model-architecture-svg"]')
         .contains('Top-16 of 896 routed + 2 shared')
         .should('exist');
+      // Same count drives the Experts figure in the specs bar: 16 routed + 2
+      // shared active out of 898, not the assumed "+1".
+      cy.get('[data-testid="model-architecture-svg"]').contains('16+2/898').should('exist');
     });
 
     it('shows Kimi K3 features and developer info', () => {

--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -446,12 +446,34 @@ describe('Model Architecture Diagram', () => {
 
   describe('Hybrid Attention Blocks (MoE model - Kimi K3)', () => {
     before(() => {
-      cy.document().then((doc) => {
-        delete doc.body.dataset.scrollLocked;
-        doc.body.style.removeProperty('pointer-events');
+      // The model dropdown only lists models that have availability rows, and the
+      // shared fixtures carry none for kimik3 (nothing ingested yet). Append one
+      // so K3 is selectable, then re-visit with the intercept in place. This block
+      // runs last in the spec, so no earlier block sees the patched availability.
+      cy.fixture('api/availability.json').then((rows: unknown[]) => {
+        cy.intercept('GET', '/api/v1/availability', {
+          body: [
+            ...rows,
+            {
+              model: 'kimik3',
+              isl: 8192,
+              osl: 1024,
+              precision: 'fp4',
+              hardware: 'mi355x',
+              framework: 'vllm',
+              spec_method: 'none',
+              disagg: false,
+              date: '2026-07-18',
+            },
+          ],
+        }).as('availability');
       });
-      cy.get('[role="combobox"]').filter(':visible').first().click();
-      cy.get('[role="option"]').contains('Kimi K3').click();
+      cy.visit('/inference?g_model=Kimi-K3', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        },
+      });
+      cy.get('[data-testid="inference-chart-display"]').should('be.visible');
 
       cy.get('[data-testid="model-architecture-toggle"]').should('be.visible');
       cy.get('body').then(($body) => {
@@ -473,6 +495,13 @@ describe('Model Architecture Diagram', () => {
       cy.get('[data-testid="expand-altBlock1"]').should('exist');
       cy.get('[data-testid="alternating-indicator"]').should('exist');
       cy.get('[data-testid="model-architecture-svg"]').contains('KDA').should('exist');
+      // K3 is a 68:24 split, not the 1:1 interleave the default caption implies.
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains('gated MLA every 4th layer')
+        .should('exist');
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains('alternating every layer')
+        .should('not.exist');
     });
 
     it('keeps attention static — no CSA/HCA drill-down or union-softmax caption', () => {
@@ -483,8 +512,12 @@ describe('Model Architecture Diagram', () => {
       cy.get('[data-testid="collapse-altBlock0"]').should('exist');
       cy.get('[data-testid="expand-altAttention0"]').should('not.exist');
       cy.get('[data-testid="hybrid-attention-note"]').should('not.exist');
-      // The MoE expert grid inside the block is still expandable.
-      cy.get('[data-testid="expand-altExperts0"]').should('exist');
+      // The MoE expert grid inside the block is still expandable, and its router
+      // line reports K3's own two shared experts rather than an assumed one.
+      cy.get('[data-testid="expand-altExperts0"]').should('exist').click({ force: true });
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains('Top-16 of 896 routed + 2 shared')
+        .should('exist');
     });
 
     it('shows Kimi K3 features and developer info', () => {

--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -443,4 +443,54 @@ describe('Model Architecture Diagram', () => {
       cy.contains('Released by DeepSeek').should('be.visible');
     });
   });
+
+  describe('Hybrid Attention Blocks (MoE model - Kimi K3)', () => {
+    before(() => {
+      cy.document().then((doc) => {
+        delete doc.body.dataset.scrollLocked;
+        doc.body.style.removeProperty('pointer-events');
+      });
+      cy.get('[role="combobox"]').filter(':visible').first().click();
+      cy.get('[role="option"]').contains('Kimi K3').click();
+
+      cy.get('[data-testid="model-architecture-toggle"]').should('be.visible');
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-testid="model-architecture-svg"]:visible').length === 0) {
+          cy.get('[data-testid="model-architecture-toggle"]').click();
+        }
+      });
+      cy.get('[data-testid="model-architecture-svg"]').should('be.visible');
+    });
+
+    it('shows MoE and Hybrid badges for Kimi K3', () => {
+      cy.get('[data-testid="model-architecture-toggle"]').should('contain.text', 'MoE');
+      cy.get('[data-testid="model-architecture-toggle"]').should('contain.text', 'Hybrid');
+      cy.get('[data-testid="model-architecture-toggle"]').should('contain.text', '2.8T');
+    });
+
+    it('renders the KDA and gated-MLA layer categories as two alternating blocks', () => {
+      cy.get('[data-testid="expand-altBlock0"]').should('exist');
+      cy.get('[data-testid="expand-altBlock1"]').should('exist');
+      cy.get('[data-testid="alternating-indicator"]').should('exist');
+      cy.get('[data-testid="model-architecture-svg"]').contains('KDA').should('exist');
+    });
+
+    it('keeps attention static — no CSA/HCA drill-down or union-softmax caption', () => {
+      // K3's hybrid is KDA + gated MLA, not DeepSeek V4's local/compressed CSA-HCA
+      // pair, so `alternatingAttentionExpandable: false` must suppress both the
+      // drill-down and the caption that explains it. DeepSeek V4 keeps both.
+      cy.get('[data-testid="expand-altBlock0"]').click({ force: true });
+      cy.get('[data-testid="collapse-altBlock0"]').should('exist');
+      cy.get('[data-testid="expand-altAttention0"]').should('not.exist');
+      cy.get('[data-testid="hybrid-attention-note"]').should('not.exist');
+      // The MoE expert grid inside the block is still expandable.
+      cy.get('[data-testid="expand-altExperts0"]').should('exist');
+    });
+
+    it('shows Kimi K3 features and developer info', () => {
+      cy.contains('Kimi Delta Attention (KDA linear attention)').should('be.visible');
+      cy.contains('Stable LatentMoE (3584-dim latent)').should('be.visible');
+      cy.contains('Released by Moonshot AI').should('be.visible');
+    });
+  });
 });

--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -508,7 +508,13 @@ describe('Model Architecture Diagram', () => {
       // K3's hybrid is KDA + gated MLA, not DeepSeek V4's local/compressed CSA-HCA
       // pair, so `alternatingAttentionExpandable: false` must suppress both the
       // drill-down and the caption that explains it. DeepSeek V4 keeps both.
-      cy.get('[data-testid="expand-altBlock0"]').click({ force: true });
+      // Retries re-run this test with the block already expanded, so expand
+      // only when it is still collapsed.
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-testid="expand-altBlock0"]').length > 0) {
+          cy.get('[data-testid="expand-altBlock0"]').click({ force: true });
+        }
+      });
       cy.get('[data-testid="collapse-altBlock0"]').should('exist');
       cy.get('[data-testid="expand-altAttention0"]').should('not.exist');
       cy.get('[data-testid="hybrid-attention-note"]').should('not.exist');
@@ -521,6 +527,28 @@ describe('Model Architecture Diagram', () => {
       // Same count drives the Experts figure in the specs bar: 16 routed + 2
       // shared active out of 898, not the assumed "+1".
       cy.get('[data-testid="model-architecture-svg"]').contains('16+2/898').should('exist');
+      // K3's FFN is SiTU-GLU, so the drill-down must not claim SwiGLU/SiLU.
+      // The flow caption renders uppercased, so match case-insensitively.
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains(/expert ffn \(situ-glu\)/iu)
+        .should('exist');
+      cy.get('[data-testid="model-architecture-svg"]').contains('SiTU Activation').should('exist');
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains(/swiglu|silu/iu)
+        .should('not.exist');
+    });
+
+    it('labels the dense prefix block KDA rather than the model-wide hybrid type', () => {
+      // Layer 1 is the dense-FFN layer and a KDA layer, so "Hybrid Attention"
+      // would misdescribe it next to correctly labelled KDA/MLA blocks.
+      cy.get('[data-testid="expand-denseTransformer"]').should('exist').click({ force: true });
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains('Kimi Delta Attention (KDA)')
+        .should('exist');
+      cy.get('[data-testid="model-architecture-svg"]')
+        .contains('Hybrid Attention')
+        .should('not.exist');
+      cy.get('[data-testid="collapse-denseTransformer"]').click({ force: true });
     });
 
     it('shows Kimi K3 features and developer info', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -1,10 +1,18 @@
+// Order mirrors DEFAULT_MODELS (MODEL_CONFIG insertion order), which fixes the
+// matrix row order.
 const MODEL_LABELS = [
   'DeepSeek V4 Pro 1.6T',
+  'Kimi K3 2.8T',
   'Kimi K2.5/2.6/2.7-Code 1T',
   'MiniMax M3 428B',
   'GLM5.2',
   'Qwen3.5 397B',
 ];
+
+// Models whose row collapses to a coverage note instead of 5 platform cells:
+// GLM5.2 (fixtures carry no 8K/1K rows) and Kimi K3 (no fixture rows at all —
+// nothing ingested yet).
+const ZERO_COVERAGE_MODELS = 2;
 
 const PLATFORM_HEADERS = [
   'Model',
@@ -261,10 +269,10 @@ describe('Overview page', () => {
           );
         });
         cy.get('[data-testid="overview-desktop-model"]').should('have.length', MODEL_LABELS.length);
-        // GLM's zero-coverage row collapses to a single note instead of 5 cells.
+        // Zero-coverage rows collapse to a single note instead of 5 cells.
         cy.get('[data-testid="overview-platform"]').should(
           'have.length',
-          (MODEL_LABELS.length - 1) * 5,
+          (MODEL_LABELS.length - ZERO_COVERAGE_MODELS) * 5,
         );
         cy.get('details, summary, button').should('not.exist');
         cy.contains(/PRIMARY|Ranked results/).should('not.exist');

--- a/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
+++ b/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
@@ -19,6 +19,8 @@ import {
   getAttentionLabel,
   getAttentionSubBlocks,
   getFFNSubBlocks,
+  denseLayerAttentionLabel,
+  ffnVariantLabel,
   getHybridAttentionSubBlocks,
   getModelArchitecture,
   sharedExpertCount,
@@ -118,6 +120,7 @@ function renderDiagram(
   // Shared experts are counted inside `numExperts`; read the model's own count
   // rather than assuming the DeepSeek-style single shared expert.
   const sharedExperts = sharedExpertCount(arch);
+  const ffnVariant = ffnVariantLabel(arch);
   const hasDenseLayers = isMoE && (arch.denseFFNLayers ?? 0) > 0;
   const denseLayerCount = arch.denseFFNLayers ?? 0;
   const moeLayerCount = (arch.numLayers ?? 0) - denseLayerCount;
@@ -1526,7 +1529,7 @@ function renderDiagram(
       drawArrow(denseNorm1Y + smallH, denseAttnY);
 
       // Attention (expandable only for non-MLA types)
-      const denseAttnLabel = getAttentionLabel(arch.attentionType);
+      const denseAttnLabel = denseLayerAttentionLabel(arch);
       const denseHeadSub = arch.numHeads ? `${arch.numHeads} heads` : undefined;
       if (isAttnExpandable) {
         drawExpandableBlock(
@@ -1575,7 +1578,7 @@ function renderDiagram(
       );
 
       if (denseFFNExpanded && denseFFNFlow) {
-        drawFlow(denseFFNFlow, denseFFNExpandedStartY, innerX, innerW, 'SwiGLU FFN');
+        drawFlow(denseFFNFlow, denseFFNExpandedStartY, innerX, innerW, `${ffnVariant} FFN`);
       }
 
       const denseFFNBottom = denseFFNExpanded
@@ -1738,7 +1741,7 @@ function renderDiagram(
       });
 
     if (isExpExpanded) {
-      drawFlow(ffnFlow, expandedStartY, innerX, innerW, 'Expert FFN (SwiGLU)');
+      drawFlow(ffnFlow, expandedStartY, innerX, innerW, `Expert FFN (${ffnVariant})`);
     }
 
     const expertBottom = isExpExpanded ? expandedStartY + expandedH : eY + expertGridH;
@@ -2123,7 +2126,7 @@ function renderDiagram(
       // === FFN (expandable) for dense models ===
       const ffnSub = arch.ffnDim
         ? `intermediate = ${arch.ffnDim.toLocaleString()}`
-        : 'SwiGLU activation';
+        : `${ffnVariant} activation`;
       drawExpandableBlock(
         innerX,
         ffnY,
@@ -2137,7 +2140,7 @@ function renderDiagram(
       );
 
       if (ffnExpanded) {
-        drawFlow(ffnFlow, ffnExpandedStartY, innerX, innerW, 'SwiGLU Details');
+        drawFlow(ffnFlow, ffnExpandedStartY, innerX, innerW, `${ffnVariant} Details`);
       }
 
       const ffnBottom = ffnExpanded ? ffnExpandedStartY + ffnExpandedH : ffnY + blockH;

--- a/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
+++ b/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
@@ -15,6 +15,7 @@ import {
   type ModelArchitecture,
   formatContextWindow,
   formatParamCount,
+  expertRouterSummary,
   getAttentionLabel,
   getAttentionSubBlocks,
   getFFNSubBlocks,
@@ -1617,10 +1618,7 @@ function renderDiagram(
     routerLabel = 'MoE Router',
     routerSubOverride?: string,
   ) {
-    const routedCount = arch.hasSharedExpert ? (arch.numExperts || 0) - 1 : arch.numExperts;
-    const routerSub =
-      routerSubOverride ??
-      `Top-${arch.activeExperts} of ${routedCount} routed${arch.hasSharedExpert ? ' + 1 shared' : ''}`;
+    const routerSub = routerSubOverride ?? expertRouterSummary(arch);
     const rY = n2Y + smallH + arrowH;
     drawBlock(innerX, rY, innerW, blockH, 'router', routerLabel, routerSub);
     drawArrow(rY + blockH, rY + blockH + arrowH);
@@ -1988,7 +1986,7 @@ function renderDiagram(
 
         // Opaque background rect behind the label so it doesn't overlap the arrow
         const cardBg = isDark ? '#131416' : '#eaebec';
-        const labelText = '\u21C5 alternating every layer';
+        const labelText = `\u21C5 ${arch.alternatingNote ?? 'alternating every layer'}`;
         const labelPadX = 6;
         const labelPadY = 4;
         const labelFontSize = 10;

--- a/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
+++ b/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
@@ -155,8 +155,16 @@ function renderDiagram(
   // Hybrid models (DeepSeek V4) expose an expandable attention drill-down inside
   // each alternating block, revealing the sliding-window branch as an explicit
   // block alongside the compressed branch. gpt-oss (AlternatingSinkGQA) keeps a
-  // static attention block.
-  const altAttnExpandable = hasAlternatingLayers && arch.attentionType === 'Hybrid';
+  // static attention block. `getHybridAttentionSubBlocks` draws the specific
+  // local/compressed CSA-HCA flow, so hybrids built from other layer types
+  // (Kimi K3: KDA + gated MLA) opt out via alternatingAttentionExpandable and
+  // keep static attention blocks too. Note this is independent of
+  // `attentionExpandable`, which governs the single-block (non-alternating)
+  // drill-down — V4 disables that one while keeping this one.
+  const altAttnExpandable =
+    hasAlternatingLayers &&
+    arch.attentionType === 'Hybrid' &&
+    arch.alternatingAttentionExpandable !== false;
   const altAttnExpanded = [
     altAttnExpandable && expandedBlocks.has('altAttention0'),
     altAttnExpandable && expandedBlocks.has('altAttention1'),
@@ -2365,7 +2373,11 @@ export default function ModelArchitectureDiagram({
               the caption on the parent too — collapsing the parent leaves the child
               id in expandedBlocks (state is restored on re-expand), and the caption
               must not outlive the drawing it explains. */}
+          {/* Mirrors `altAttnExpandable` in renderDiagram: the caption describes the
+              CSA/HCA local-vs-compressed drill-down, so hybrids that opt out of that
+              drill-down must not show it either. */}
           {arch.attentionType === 'Hybrid' &&
+            arch.alternatingAttentionExpandable !== false &&
             [0, 1].some(
               (i) => expandedBlocks.has(`altBlock${i}`) && expandedBlocks.has(`altAttention${i}`),
             ) && (

--- a/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
+++ b/packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx
@@ -21,6 +21,7 @@ import {
   getFFNSubBlocks,
   getHybridAttentionSubBlocks,
   getModelArchitecture,
+  sharedExpertCount,
 } from '@/lib/model-architectures';
 
 interface ModelArchitectureDiagramProps {
@@ -114,6 +115,9 @@ function renderDiagram(
 
   // Architecture flags
   const isMoE = arch.architectureType === 'moe';
+  // Shared experts are counted inside `numExperts`; read the model's own count
+  // rather than assuming the DeepSeek-style single shared expert.
+  const sharedExperts = sharedExpertCount(arch);
   const hasDenseLayers = isMoE && (arch.denseFFNLayers ?? 0) > 0;
   const denseLayerCount = arch.denseFFNLayers ?? 0;
   const moeLayerCount = (arch.numLayers ?? 0) - denseLayerCount;
@@ -1820,8 +1824,9 @@ function renderDiagram(
       drawArrow(hashNorm2Y + smallH, hashNorm2Y + smallH + arrowH);
 
       // Hash Router + Expert grid (token-id → fixed experts, not a learned gate)
-      const hashRoutedCount = arch.hasSharedExpert ? (arch.numExperts || 0) - 1 : arch.numExperts;
-      const hashRouterSub = `token-id → ${arch.activeExperts} of ${hashRoutedCount}${arch.hasSharedExpert ? ' + 1 shared' : ''}`;
+      const hashShared = sharedExpertCount(arch);
+      const hashRoutedCount = (arch.numExperts ?? 0) - hashShared;
+      const hashRouterSub = `token-id → ${arch.activeExperts} of ${hashRoutedCount}${hashShared > 0 ? ` + ${hashShared} shared` : ''}`;
       drawExpertGrid(
         hashExpertY,
         hashExpertsExpanded,
@@ -2192,9 +2197,10 @@ function renderDiagram(
       ? [
           {
             label: 'Experts',
-            // Active per token = routed top-k + the always-on shared expert, so
-            // show "6+1/385" (not "6/385"): the shared expert is active too.
-            value: `${arch.activeExperts}${arch.hasSharedExpert ? '+1' : ''}/${arch.numExperts}`,
+            // Active per token = routed top-k + the always-on shared experts, so
+            // show "6+1/385" (not "6/385"): the shared experts are active too.
+            // Count them from the model (Kimi K3 has 2), never assume one.
+            value: `${arch.activeExperts}${sharedExperts > 0 ? `+${sharedExperts}` : ''}/${arch.numExperts}`,
           },
         ]
       : []),

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -266,6 +266,7 @@ describe('compareModelSeoName', () => {
   const EXPECTED: Record<string, string> = {
     'deepseek-v4': 'DeepSeek V4 Pro',
     'deepseek-r1': 'DeepSeek R1',
+    'kimi-k3': 'Kimi K3',
     'kimi-k26': 'Kimi K2.6',
     'glm-5-1': 'GLM-5',
     'glm-5-2': 'GLM-5.2',
@@ -341,6 +342,18 @@ describe('getCompareModelBySlug', () => {
   it('keeps the bare minimax alias on the M2 series, with minimax-m3 canonical', () => {
     expect(getCompareModelBySlug('minimax')?.slug).toBe('minimax-m27');
     expect(getCompareModelBySlug('minimax-m3')?.slug).toBe('minimax-m3');
+  });
+
+  it('keeps the bare kimi alias on the K2 series, with kimi-k3 canonical and separate', () => {
+    // K3 is a distinct architecture, not a K2 point release: it must not join
+    // the kimi-k26 dbKey group, and the family alias stays where it was so
+    // existing /compare/kimi-* links keep resolving to K2.
+    expect(getCompareModelBySlug('kimi')?.slug).toBe('kimi-k26');
+    const k3 = getCompareModelBySlug('kimi-k3');
+    expect(k3?.slug).toBe('kimi-k3');
+    expect(k3?.dbKeys).toEqual(['kimik3']);
+    expect(k3?.displayName).toBe('Kimi-K3');
+    expect(KIMI_K26.dbKeys).not.toContain('kimik3');
   });
 
   it('returns null for unknown slugs', () => {

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -43,7 +43,8 @@ export interface CompareModelSlug {
 // first, smaller open US-developed models at the bottom. Qwen sits between
 // MiniMax and gpt-oss to keep the Chinese-lab cluster contiguous before the
 // US transition. The two MiniMax entries stay adjacent with the newer M3
-// flagship leading the older M2 series.
+// flagship leading the older M2 series; the two Kimi entries follow the same
+// rule, with K3 leading the K2.5/K2.6/K2.7-Code group.
 export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
   {
     slug: 'deepseek-v4',
@@ -58,6 +59,16 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     dbKeys: ['dsr1'],
     label: 'DeepSeek R1',
     seoName: 'DeepSeek R1',
+  },
+  {
+    slug: 'kimi-k3',
+    displayName: 'Kimi-K3',
+    // K3 is a new 2.8T architecture (Kimi Delta Attention + gated MLA), not a
+    // point release of the K2 series, so it gets its own slug and dbKey rather
+    // than joining the kimi-k26 group — same treatment as minimax-m3.
+    dbKeys: ['kimik3'],
+    label: 'Kimi K3 2.8T',
+    seoName: 'Kimi K3',
   },
   {
     slug: 'kimi-k26',

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -48,6 +48,7 @@ export const KNOWN_MODELS = new Set([
   'gpt-oss-120b',
   'Qwen-3.5-397B-A17B',
   'Kimi-K2.5',
+  'Kimi-K3',
   'MiniMax-M2.5',
   'MiniMax-M3',
   'GLM-5',

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -7,6 +7,7 @@ export enum Model {
   GptOss = 'gpt-oss-120b',
   Qwen3_5 = 'Qwen-3.5-397B-A17B',
   Kimi_K2_5 = 'Kimi-K2.5',
+  Kimi_K3 = 'Kimi-K3',
   MiniMax_M2_5 = 'MiniMax-M2.5',
   MiniMax_M3 = 'MiniMax-M3',
   GLM_5 = 'GLM-5',
@@ -92,6 +93,13 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     prefix: 'dsv4',
     category: 'default',
     exclusion: MTP_ENGINE_EXCLUSION,
+  },
+  [Model.Kimi_K3]: {
+    // K3 is a separate 2.8T KDA/MLA-hybrid architecture, not a K2 point release,
+    // so it stays out of the K2.5/2.6/2.7-Code grouping below.
+    label: 'Kimi K3 2.8T',
+    prefix: 'kimik3',
+    category: 'default',
   },
   [Model.Kimi_K2_5]: {
     // K2.5, K2.6, and K2.7-Code share an architecture, so the dropdown surfaces

--- a/packages/app/src/lib/model-architectures.test.ts
+++ b/packages/app/src/lib/model-architectures.test.ts
@@ -24,6 +24,7 @@ describe('MODEL_ARCHITECTURES', () => {
       Model.DeepSeek_V4_Pro,
       Model.GptOss,
       Model.Kimi_K2_5,
+      Model.Kimi_K3,
       Model.MiniMax_M2_5,
       Model.MiniMax_M3,
     ];
@@ -246,6 +247,49 @@ describe('getModelArchitecture', () => {
     expect(arch?.contextWindow).toBe(262144);
     expect(arch?.developer).toBe('Moonshot AI');
     expect(arch?.vocabSize).toBe(163840);
+  });
+
+  it('returns architecture for Kimi K3 with hybrid KDA/MLA and LatentMoE details', () => {
+    const arch = getModelArchitecture(Model.Kimi_K3);
+    expect(arch).toBeDefined();
+    expect(arch?.totalParams).toBe(2800);
+    expect(arch?.activeParams).toBe(104);
+    expect(arch?.architectureType).toBe('moe');
+    expect(arch?.attentionType).toBe('Hybrid');
+    // KDA + gated MLA is not the DeepSeek V4 CSA/HCA hybrid, so neither the
+    // single-block nor the per-alternating-block attention drill-down applies
+    // (see ModelArchitectureDiagram). V4 keeps the latter, K3 does not.
+    expect(arch?.attentionExpandable).toBe(false);
+    expect(arch?.alternatingAttentionExpandable).toBe(false);
+    expect(getModelArchitecture(Model.DeepSeek_V4_Pro)?.alternatingAttentionExpandable).not.toBe(
+      false,
+    );
+    expect(arch?.numLayers).toBe(93);
+    expect(arch?.hiddenSize).toBe(7168);
+    expect(arch?.numHeads).toBe(96);
+    expect(arch?.ffnDim).toBe(3072);
+    expect(arch?.numExperts).toBe(898); // 896 routed + 2 shared
+    expect(arch?.activeExperts).toBe(16);
+    expect(arch?.hasSharedExpert).toBe(true);
+    expect(arch?.denseFFNLayers).toBe(1);
+    expect(arch?.denseFFNDim).toBe(33792);
+    expect(arch?.contextWindow).toBe(1048576);
+    expect(arch?.vocabSize).toBe(163840);
+    expect(arch?.developer).toBe('Moonshot AI');
+  });
+
+  it('Kimi K3 alternating KDA/MLA layer counts sum to numLayers', () => {
+    const arch = getModelArchitecture(Model.Kimi_K3);
+    expect(arch?.alternatingLayers).toHaveLength(2);
+    const [kda, mla] = arch!.alternatingLayers!;
+    expect(kda.count).toBe(69);
+    expect(mla.count).toBe(24);
+    const totalAlternating = arch!.alternatingLayers!.reduce((sum, l) => sum + l.count, 0);
+    expect(totalAlternating).toBe(arch!.numLayers);
+    // Neither KDA nor gated MLA uses a sliding window.
+    for (const spec of arch!.alternatingLayers!) {
+      expect(spec.slidingWindow).toBeUndefined();
+    }
   });
 
   it('returns architecture for MiniMax M2.5 with MoE and GQA details', () => {

--- a/packages/app/src/lib/model-architectures.test.ts
+++ b/packages/app/src/lib/model-architectures.test.ts
@@ -12,7 +12,10 @@ import {
   getFFNSubBlocks,
   getHybridAttentionSubBlocks,
   getModelArchitecture,
+  denseLayerAttentionLabel,
   expertRouterSummary,
+  ffnGateActivationLabel,
+  ffnVariantLabel,
   sharedExpertCount,
   MODEL_ARCHITECTURES,
 } from './model-architectures';
@@ -328,6 +331,33 @@ describe('getModelArchitecture', () => {
     );
     // gpt-oss has no shared expert — no suffix, no subtraction.
     expect(expertRouterSummary(getModelArchitecture(Model.GptOss)!)).toBe('Top-4 of 128 routed');
+  });
+
+  it('names K3’s FFN SiTU-GLU and leaves every other model on SwiGLU', () => {
+    const k3 = getModelArchitecture(Model.Kimi_K3)!;
+    expect(ffnVariantLabel(k3)).toBe('SiTU-GLU');
+    expect(ffnGateActivationLabel(k3)).toBe('SiTU');
+    const k3Ffn = getFFNSubBlocks(k3);
+    expect(k3Ffn.layout).toBe('parallel');
+    if (k3Ffn.layout !== 'parallel') throw new Error('expected a parallel FFN flow');
+    expect(k3Ffn.leftPath[1]?.name).toBe('SiTU Activation');
+    for (const arch of Object.values(MODEL_ARCHITECTURES)) {
+      if (!arch || arch.model === Model.Kimi_K3) continue;
+      expect(ffnVariantLabel(arch), `ffn variant for ${arch.model}`).toBe('SwiGLU');
+      expect(ffnGateActivationLabel(arch), `gate activation for ${arch.model}`).toBe('SiLU');
+    }
+  });
+
+  it('labels K3’s dense prefix block KDA, not the model-wide hybrid type', () => {
+    // The dense-FFN layer is layer 1, which config.json lists under kda_layers,
+    // so the model-wide "Hybrid Attention" label would misdescribe that block.
+    expect(denseLayerAttentionLabel(getModelArchitecture(Model.Kimi_K3)!)).toBe(
+      'Kimi Delta Attention (KDA)',
+    );
+    // Uniform-attention models keep falling back to their attention type.
+    expect(denseLayerAttentionLabel(getModelArchitecture(Model.DeepSeek_R1)!)).toBe(
+      'Multi-head Latent Attention',
+    );
   });
 
   it('defaults the shared-expert count to 1 and to 0 without a shared expert', () => {

--- a/packages/app/src/lib/model-architectures.test.ts
+++ b/packages/app/src/lib/model-architectures.test.ts
@@ -12,6 +12,8 @@ import {
   getFFNSubBlocks,
   getHybridAttentionSubBlocks,
   getModelArchitecture,
+  expertRouterSummary,
+  sharedExpertCount,
   MODEL_ARCHITECTURES,
 } from './model-architectures';
 
@@ -269,6 +271,7 @@ describe('getModelArchitecture', () => {
     expect(arch?.numHeads).toBe(96);
     expect(arch?.ffnDim).toBe(3072);
     expect(arch?.numExperts).toBe(898); // 896 routed + 2 shared
+    expect(arch?.sharedExperts).toBe(2);
     expect(arch?.activeExperts).toBe(16);
     expect(arch?.hasSharedExpert).toBe(true);
     expect(arch?.denseFFNLayers).toBe(1);
@@ -278,18 +281,59 @@ describe('getModelArchitecture', () => {
     expect(arch?.developer).toBe('Moonshot AI');
   });
 
-  it('Kimi K3 alternating KDA/MLA layer counts sum to numLayers', () => {
+  it('Kimi K3 alternating + dense layer counts sum to numLayers', () => {
     const arch = getModelArchitecture(Model.Kimi_K3);
     expect(arch?.alternatingLayers).toHaveLength(2);
     const [kda, mla] = arch!.alternatingLayers!;
-    expect(kda.count).toBe(69);
+    // The diagram stacks the dense prefix above both alternating blocks, so the
+    // dense-FFN layer (a KDA layer) is carved out of the KDA count: the model
+    // has 69 KDA layers, 68 of which appear in the alternating block.
+    expect(kda.count).toBe(68);
     expect(mla.count).toBe(24);
     const totalAlternating = arch!.alternatingLayers!.reduce((sum, l) => sum + l.count, 0);
-    expect(totalAlternating).toBe(arch!.numLayers);
+    expect(totalAlternating + (arch!.denseFFNLayers ?? 0)).toBe(arch!.numLayers);
     // Neither KDA nor gated MLA uses a sliding window.
     for (const spec of arch!.alternatingLayers!) {
       expect(spec.slidingWindow).toBeUndefined();
     }
+    // The 1:1 "alternating every layer" default would misdescribe a 68:24 split.
+    expect(arch?.alternatingNote).toBe('gated MLA every 4th layer');
+    expect(getModelArchitecture(Model.DeepSeek_V4_Pro)?.alternatingNote).toBeUndefined();
+  });
+
+  it('never renders more layer blocks than the model has layers', () => {
+    for (const arch of Object.values(MODEL_ARCHITECTURES)) {
+      if (!arch?.alternatingLayers?.length || arch.numLayers === undefined) continue;
+      const stacked =
+        arch.alternatingLayers.reduce((sum, l) => sum + l.count, 0) +
+        (arch.denseFFNLayers ?? 0) +
+        (arch.hashRoutedLayers ?? 0);
+      expect(stacked, `stacked layer blocks for ${arch.model}`).toBe(arch.numLayers);
+    }
+  });
+
+  it('subtracts the model’s own shared-expert count from the routed figure', () => {
+    // The expert grid renders this string; assuming a single shared expert
+    // would show K3 as "897 routed + 1 shared" against a model card that says
+    // 896 + 2.
+    expect(expertRouterSummary(getModelArchitecture(Model.Kimi_K3)!)).toBe(
+      'Top-16 of 896 routed + 2 shared',
+    );
+    // Unchanged for the DeepSeek-style single-shared-expert models.
+    expect(expertRouterSummary(getModelArchitecture(Model.Kimi_K2_5)!)).toBe(
+      'Top-8 of 384 routed + 1 shared',
+    );
+    expect(expertRouterSummary(getModelArchitecture(Model.DeepSeek_R1)!)).toBe(
+      'Top-8 of 256 routed + 1 shared',
+    );
+    // gpt-oss has no shared expert — no suffix, no subtraction.
+    expect(expertRouterSummary(getModelArchitecture(Model.GptOss)!)).toBe('Top-4 of 128 routed');
+  });
+
+  it('defaults the shared-expert count to 1 and to 0 without a shared expert', () => {
+    expect(sharedExpertCount(getModelArchitecture(Model.Kimi_K3)!)).toBe(2);
+    expect(sharedExpertCount(getModelArchitecture(Model.DeepSeek_R1)!)).toBe(1);
+    expect(sharedExpertCount(getModelArchitecture(Model.GptOss)!)).toBe(0);
   });
 
   it('returns architecture for MiniMax M2.5 with MoE and GQA details', () => {

--- a/packages/app/src/lib/model-architectures.ts
+++ b/packages/app/src/lib/model-architectures.ts
@@ -107,6 +107,18 @@ export interface ModelArchitecture {
    * that aren't CSA/HCA-shaped (Kimi K3's KDA + gated MLA stack).
    */
   alternatingAttentionExpandable?: boolean;
+  /**
+   * Number of shared experts included in `numExperts`. Defaults to 1 when
+   * `hasSharedExpert` is set — the DeepSeek-style single shared expert every
+   * other MoE model here uses. Kimi K3's LatentMoE has 2.
+   */
+  sharedExperts?: number;
+  /**
+   * Override the caption on the arrow between the two alternating blocks.
+   * Defaults to "alternating every layer", which is only true for an even 1:1
+   * interleave (gpt-oss, DeepSeek V4). Set it when the split is uneven.
+   */
+  alternatingNote?: string;
 }
 
 /**
@@ -337,16 +349,22 @@ export const MODEL_ARCHITECTURES: Partial<Record<Model, ModelArchitecture>> = {
     vocabSize: 163840,
     ffnDim: 3072, // moe_intermediate_size (per-expert FFN)
     numExperts: 898, // 896 routed + 2 shared
+    sharedExperts: 2,
     activeExperts: 16,
     hasSharedExpert: true,
     denseFFNLayers: 1, // first_k_dense_replace
     denseFFNDim: 33792, // intermediate_size (dense layer FFN)
+    // The dense-FFN layer (layer 1) is a KDA layer, and the diagram stacks the
+    // dense prefix block above both alternating blocks — so it is carved out of
+    // the KDA count here (68 + 24 + 1 dense = 93), the same partition DeepSeek
+    // V4 uses for its hash-routed prefix. Full layer composition is 69 KDA + 24
+    // gated MLA.
     alternatingLayers: [
       {
         label: 'Kimi Delta Attention (KDA)',
         description:
-          'Linear-attention layers with a gated delta-rule state update — constant-size recurrent state instead of a growing KV cache.',
-        count: 69,
+          'Linear-attention layers with a gated delta-rule state update — constant-size recurrent state instead of a growing KV cache. 69 KDA layers total; the first is the dense-FFN layer shown above.',
+        count: 68,
         colorKey: 'attention',
       },
       {
@@ -357,6 +375,9 @@ export const MODEL_ARCHITECTURES: Partial<Record<Model, ModelArchitecture>> = {
         colorKey: 'norm',
       },
     ],
+    // Not a 1:1 interleave — full attention lands on layers 4, 8, … 92 plus the
+    // final layer 93.
+    alternatingNote: 'gated MLA every 4th layer',
     contextWindow: 1048576, // 1M
     features: [
       'Kimi Delta Attention (KDA linear attention)',
@@ -460,6 +481,25 @@ export function getArchitectureSummary(arch: ModelArchitecture): string {
     return `MoE ${formatParamCount(arch.totalParams)} (${formatParamCount(arch.activeParams)} active)`;
   }
   return `Dense ${formatParamCount(arch.totalParams)}`;
+}
+
+/** Shared experts counted inside `numExperts`. Zero when the model has none. */
+export function sharedExpertCount(arch: ModelArchitecture): number {
+  if (!arch.hasSharedExpert) return 0;
+  return arch.sharedExperts ?? 1;
+}
+
+/**
+ * Router sub-label for a MoE expert grid, e.g. `Top-8 of 384 routed + 1 shared`.
+ * `numExperts` counts routed *and* shared experts, so the shared ones are
+ * subtracted out of the routed figure — with the model's own shared count, not
+ * an assumed 1 (Kimi K3 has 2).
+ */
+export function expertRouterSummary(arch: ModelArchitecture): string {
+  const shared = sharedExpertCount(arch);
+  const routed = (arch.numExperts ?? 0) - shared;
+  const sharedSuffix = shared > 0 ? ` + ${shared} shared` : '';
+  return `Top-${arch.activeExperts} of ${routed} routed${sharedSuffix}`;
 }
 
 /**

--- a/packages/app/src/lib/model-architectures.ts
+++ b/packages/app/src/lib/model-architectures.ts
@@ -98,6 +98,15 @@ export interface ModelArchitecture {
   sourceUrl?: string;
   /** Override whether the attention block is expandable in diagrams. If not set, determined by attentionType. */
   attentionExpandable?: boolean;
+  /**
+   * Override whether the attention block *inside each alternating layer block*
+   * drills down to the hybrid local/compressed flow (`getHybridAttentionSubBlocks`).
+   * Defaults to expandable for `Hybrid` attention. Independent of
+   * `attentionExpandable`, which governs the single non-alternating block:
+   * DeepSeek V4 disables that one but keeps this one. Set false for hybrids
+   * that aren't CSA/HCA-shaped (Kimi K3's KDA + gated MLA stack).
+   */
+  alternatingAttentionExpandable?: boolean;
 }
 
 /**
@@ -111,6 +120,7 @@ export interface ModelArchitecture {
  * - https://github.com/deepseek-ai/DeepSeek-V3
  * - https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro (config.json, inference/model.py, DeepSeek_V4.pdf)
  * - https://huggingface.co/moonshotai/Kimi-K2.5/blob/main/config.json
+ * - https://huggingface.co/moonshotai/Kimi-K3/blob/main/config.json (+ model card)
  * - https://huggingface.co/openai/gpt-oss-120b/blob/main/config.json
  * - https://huggingface.co/MiniMaxAI/MiniMax-M2/blob/main/config.json
  * - https://huggingface.co/MiniMaxAI/MiniMax-M3/blob/main/config.json
@@ -308,6 +318,59 @@ export const MODEL_ARCHITECTURES: Partial<Record<Model, ModelArchitecture>> = {
     releaseDate: '2026-01-27',
     developer: 'Moonshot AI',
     sourceUrl: 'https://huggingface.co/moonshotai/Kimi-K2.5',
+  },
+  [Model.Kimi_K3]: {
+    model: Model.Kimi_K3,
+    totalParams: 2800, // 2.8T
+    activeParams: 104,
+    architectureType: 'moe',
+    // 69 Kimi Delta Attention (linear) layers interleaved with 24 gated-MLA
+    // layers. Neither the GQA drill-down nor the DeepSeek V4 CSA/HCA hybrid
+    // drill-down describes this stack, so both layer categories render as
+    // static attention blocks.
+    attentionType: 'Hybrid',
+    attentionExpandable: false,
+    alternatingAttentionExpandable: false,
+    numLayers: 93,
+    hiddenSize: 7168,
+    numHeads: 96,
+    vocabSize: 163840,
+    ffnDim: 3072, // moe_intermediate_size (per-expert FFN)
+    numExperts: 898, // 896 routed + 2 shared
+    activeExperts: 16,
+    hasSharedExpert: true,
+    denseFFNLayers: 1, // first_k_dense_replace
+    denseFFNDim: 33792, // intermediate_size (dense layer FFN)
+    alternatingLayers: [
+      {
+        label: 'Kimi Delta Attention (KDA)',
+        description:
+          'Linear-attention layers with a gated delta-rule state update — constant-size recurrent state instead of a growing KV cache.',
+        count: 69,
+        colorKey: 'attention',
+      },
+      {
+        label: 'Gated MLA',
+        description:
+          'Multi-head Latent Attention (512-dim compressed KV latent, NoPE) with an output gate, placed every fourth layer to carry full-context recall.',
+        count: 24,
+        colorKey: 'norm',
+      },
+    ],
+    contextWindow: 1048576, // 1M
+    features: [
+      'Kimi Delta Attention (KDA linear attention)',
+      'Gated MLA (every 4th layer, NoPE)',
+      'Attention Residuals (AttnRes)',
+      'Stable LatentMoE (3584-dim latent)',
+      'MoE (896 routed + 2 shared experts, 16 active)',
+      'SiTU-GLU Activation',
+      'Native Multimodality (text/image/video)',
+      'MXFP4 Quantization',
+    ],
+    releaseDate: '2026-06-13',
+    developer: 'Moonshot AI',
+    sourceUrl: 'https://huggingface.co/moonshotai/Kimi-K3',
   },
   [Model.MiniMax_M2_5]: {
     model: Model.MiniMax_M2_5,

--- a/packages/app/src/lib/model-architectures.ts
+++ b/packages/app/src/lib/model-architectures.ts
@@ -119,6 +119,17 @@ export interface ModelArchitecture {
    * interleave (gpt-oss, DeepSeek V4). Set it when the split is uneven.
    */
   alternatingNote?: string;
+  /**
+   * Attention label for the dense-FFN prefix block, when that layer's mechanism
+   * differs from the model-wide `attentionType`. Only matters for hybrids whose
+   * dense layer belongs to one specific category — Kimi K3's dense layer is a
+   * KDA layer, so the model-wide "Hybrid Attention" label would misdescribe it.
+   */
+  denseLayerAttentionLabel?: string;
+  /** GLU variant of the FFN / expert blocks. Defaults to `SwiGLU`. */
+  ffnVariant?: string;
+  /** Elementwise activation applied to the gate projection. Defaults to `SiLU`. */
+  ffnGateActivation?: string;
 }
 
 /**
@@ -378,6 +389,13 @@ export const MODEL_ARCHITECTURES: Partial<Record<Model, ModelArchitecture>> = {
     // Not a 1:1 interleave — full attention lands on layers 4, 8, … 92 plus the
     // final layer 93.
     alternatingNote: 'gated MLA every 4th layer',
+    // The dense-FFN prefix is layer 1, which config.json lists under
+    // `kda_layers` — the model-wide "Hybrid Attention" label would be wrong for
+    // that single block.
+    denseLayerAttentionLabel: 'Kimi Delta Attention (KDA)',
+    // hidden_act = "situ"; the model card calls the FFN SiTU-GLU.
+    ffnVariant: 'SiTU-GLU',
+    ffnGateActivation: 'SiTU',
     contextWindow: 1048576, // 1M
     features: [
       'Kimi Delta Attention (KDA linear attention)',
@@ -481,6 +499,25 @@ export function getArchitectureSummary(arch: ModelArchitecture): string {
     return `MoE ${formatParamCount(arch.totalParams)} (${formatParamCount(arch.activeParams)} active)`;
   }
   return `Dense ${formatParamCount(arch.totalParams)}`;
+}
+
+/** GLU variant of the FFN / expert blocks, e.g. `SwiGLU` or K3's `SiTU-GLU`. */
+export function ffnVariantLabel(arch: ModelArchitecture): string {
+  return arch.ffnVariant ?? 'SwiGLU';
+}
+
+/** Elementwise activation on the gate projection, e.g. `SiLU` or K3's `SiTU`. */
+export function ffnGateActivationLabel(arch: ModelArchitecture): string {
+  return arch.ffnGateActivation ?? 'SiLU';
+}
+
+/**
+ * Attention label for the dense-FFN prefix block. Falls back to the model-wide
+ * attention type, which is right for every uniform-attention model; hybrids
+ * whose dense layer is one specific category override it.
+ */
+export function denseLayerAttentionLabel(arch: ModelArchitecture): string {
+  return arch.denseLayerAttentionLabel ?? getAttentionLabel(arch.attentionType);
 }
 
 /** Shared experts counted inside `numExperts`. Zero when the model has none. */
@@ -683,7 +720,7 @@ export function getFFNSubBlocks(
         type: 'projection',
       },
       {
-        name: 'SiLU Activation',
+        name: `${ffnGateActivationLabel(arch)} Activation`,
         detail: 'Applied to gate output',
         type: 'activation',
       },

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -29,6 +29,11 @@ describe('DB_MODEL_TO_DISPLAY / DISPLAY_MODEL_TO_DB consistency', () => {
   it('maps minimaxm3 to its own MiniMax-M3 display name', () => {
     expect(DISPLAY_MODEL_TO_DB['MiniMax-M3']).toEqual(['minimaxm3']);
   });
+
+  it('keeps kimik3 out of the grouped Kimi-K2.5 display bucket', () => {
+    expect(DISPLAY_MODEL_TO_DB['Kimi-K3']).toEqual(['kimik3']);
+    expect(DISPLAY_MODEL_TO_DB['Kimi-K2.5']).not.toContain('kimik3');
+  });
 });
 
 describe('sequenceToIslOsl', () => {

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -14,6 +14,9 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   'kimik2.5': 'Kimi-K2.5',
   'kimik2.6': 'Kimi-K2.5',
   'kimik2.7-code': 'Kimi-K2.5',
+  // K3 is a new architecture (Kimi Delta Attention + Attention Residuals, 2.8T),
+  // not a K2 point release, so it gets its own display bucket.
+  kimik3: 'Kimi-K3',
   'minimaxm2.5': 'MiniMax-M2.5',
   'minimaxm2.7': 'MiniMax-M2.5',
   minimaxm3: 'MiniMax-M3',

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -194,6 +194,16 @@ describe('resolveModelKey', () => {
     expect(resolveModelKey({ model: 'zai-org/GLM-5.2-FP8' })).toBe('glm5.2');
   });
 
+  it('resolves Kimi-K3 identifiers to the kimik3 key, not the K2 buckets', () => {
+    // K3 is a distinct architecture, so it must land in its own DB bucket.
+    // AMD AgentX sweeps emit the bare `kimik3` prefix; the MXFP4 checkpoint is
+    // published under the plain moonshotai path. GitHub Actions run 30298924344.
+    expect(resolveModelKey({ infmax_model_prefix: 'kimik3' })).toBe('kimik3');
+    expect(resolveModelKey({ infmax_model_prefix: 'kimik3-fp4' })).toBe('kimik3');
+    expect(resolveModelKey({ model_prefix: 'kimik3' })).toBe('kimik3');
+    expect(resolveModelKey({ model: 'moonshotai/Kimi-K3' })).toBe('kimik3');
+  });
+
   it('resolves point-release variants to their own DB key (faithful to submitted data)', () => {
     expect(resolveModelKey({ infmax_model_prefix: 'glm5.1' })).toBe('glm5.1');
     expect(resolveModelKey({ infmax_model_prefix: 'glm5.2' })).toBe('glm5.2');

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -99,6 +99,8 @@ export const MODEL_TO_KEY: Record<string, string> = {
   'moonshotai/Kimi-K2.6': 'kimik2.6',
   'moonshotai/Kimi-K2.7-Code': 'kimik2.7-code',
   'amd/Kimi-K2.7-Code-MXFP4': 'kimik2.7-code',
+  // Kimi-K3 (2.8T KDA/MLA hybrid — distinct architecture from the K2 series)
+  'moonshotai/Kimi-K3': 'kimik3',
   // MiniMax-M2.5
   'MiniMaxAI/MiniMax-M2.5': 'minimaxm2.5',
   // MiniMax-M3 (428B, distinct architecture from the M2 series)


### PR DESCRIPTION
Adds **Kimi-K3** (`moonshotai/Kimi-K3`) to the dashboard, from [InferenceX run 30298924344](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30298924344) (`kimik3`, `fp4`, vLLM, MI355X, agentic traces — PR SemiAnalysisAI/InferenceX#2351).

K3 is a **new architecture**, not a K2 point release: 2.8T total / 104B active, built on Kimi Delta Attention (KDA) + gated MLA, 896 routed + 2 shared experts (16 active), 1M context. So it gets its own DB bucket, dropdown option and compare slug rather than folding into the `Kimi-K2.5` display group — the same treatment MiniMax M3 got relative to the M2 series.

Only the model is new: `mi355x`, `fp4`, `vllm` and the agentic-traces scenario are all already registered.

## Changes

| File | Change |
| --- | --- |
| `packages/constants/src/models.ts` | `DB_MODEL_TO_DISPLAY`: `kimik3` → `Kimi-K3` |
| `packages/db/src/etl/normalizers.ts` | `MODEL_TO_KEY`: `moonshotai/Kimi-K3` → `kimik3`. No `PREFIX_ALIASES` entry needed — the artifact prefix `kimik3` matches the DB key, and `kimik3-fp4` folds in via `PRECISION_SUFFIX` stripping |
| `packages/app/src/lib/data-mappings.ts` | `Model.Kimi_K3` enum + `MODEL_CONFIG` entry (`Kimi K3 2.8T`, `default` category) |
| `packages/app/src/lib/compare-slug.ts` | `kimi-k3` slug (`dbKeys: ['kimik3']`), placed ahead of `kimi-k26` per the "newer family member leads" ordering |
| `packages/app/src/lib/compare-ssr.ts` | `KNOWN_MODELS` += `Kimi-K3` so `?g_model=Kimi-K3` validates |
| `packages/app/src/lib/model-architectures.ts` | K3 architecture entry + new `alternatingAttentionExpandable` flag |
| `packages/app/src/components/inference/ui/ModelArchitectureDiagram.tsx` | Honour the new flag for the per-alternating-block attention drill-down and its caption |

### The `kimi` alias stays on K2

`COMPARE_MODEL_ALIASES['kimi']` still resolves to `kimi-k26`. Same precedent as `minimax` → `minimax-m27` after M3 shipped: existing inbound `/compare/kimi-*` links keep pointing at the model they were written about.

### Architecture diagram: why a new flag

K3's attention is `Hybrid`, but a *different* hybrid from DeepSeek V4's. `getHybridAttentionSubBlocks` draws V4's specific local-vs-compressed CSA/HCA flow, and the drill-down was gated on `attentionType === 'Hybrid'` alone — which would have rendered sliding-window / lightning-indexer blocks for a KDA + gated-MLA stack that has neither.

The existing `attentionExpandable: false` could not be reused: V4 already sets it (to suppress the *single-block* GQA drill-down) while deliberately keeping the alternating-block drill-down. Confirmed by the e2e suite — an earlier attempt to reuse the flag failed 2 DeepSeek V4 specs. Hence a separate `alternatingAttentionExpandable`, which only K3 sets to `false`; V4 is untouched and its 45 existing specs still pass.

Architecture values are from the [HF `config.json`](https://huggingface.co/moonshotai/Kimi-K3/blob/main/config.json) and model card: 93 layers (69 KDA + 24 gated MLA, 1 dense), hidden 7168, 96 heads, `moe_intermediate_size` 3072, dense FFN 33792, vocab 163840, 1M context.

## Not included

- **No `/zh` work needed** — `/zh/compare/[slug]` and `/zh/compare-per-dollar/[slug]` are driven by the shared `COMPARE_MODEL_SLUGS` registry and the zh prose templates take the model label from it, so the Chinese compare pages, hreflang pairs, and sitemap entries pick K3 up automatically. `/about`'s model list derives from `DB_MODEL_TO_DISPLAY` on both sides. No new user-visible UI string was introduced (model names stay English per the translation bar).
- **The `/compare` + `/compare-per-dollar` meta `DESCRIPTION` blurbs** still read "Kimi K2". Changing them means editing the `/zh` mirrors in lockstep; happy to do it in a follow-up (or here) if we want K3 named in the catalog SEO copy.
- **No ingest run yet** — mappings must be deployed before the first ingest of a run containing `kimik3`, otherwise those rows are silently skipped. Can ingest + invalidate cache once this merges.
- **Overlay paths** are unaffected: this is model registration only, no chart-feature branch.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean
- `bun run test:unit` — new coverage in `normalizers.test.ts` (K3 prefix/path resolution, incl. `kimik3-fp4`, and that it does not land in a K2 bucket), `models.test.ts` (own display bucket), `compare-slug.test.ts` (`kimi-k3` slug + `kimi` alias unchanged), `model-architectures.test.ts` (full K3 spec, layer counts sum to 93, both drill-down flags)
- `cypress/e2e/model-architecture.cy.ts` — new "Hybrid Attention Blocks (MoE model - Kimi K3)" block verifying the badges (`MoE`, `Hybrid`, `2.8T`), the two alternating KDA/MLA blocks, that `expand-altAttention0` and `hybrid-attention-note` do **not** appear, and the features list. 49/49 pass, including the 45 pre-existing DeepSeek V4 / gpt-oss / R1 specs. The block also asserts the corrected expert-router string and alternation caption. Verified against a local `E2E_FIXTURES` build, matching how CI runs.

## Review + CI follow-ups (48a014e, fdf6946)

Cursor Bugbot raised 3 issues on the first commit; all three were real and are fixed:

1. **Dense layer double-counted** — the diagram stacks the dense-FFN prefix above both alternating blocks, so 69 KDA + 24 MLA + 1 dense drew 94 layer badges for a 93-layer model. Layer 1 is both a KDA layer and the dense layer, so it is carved out of the KDA count (68 + 24 + 1), the partition DeepSeek V4 already uses for `hashRoutedLayers`. Added a suite-wide invariant test: alternating counts + `denseFFNLayers` + `hashRoutedLayers` must equal `numLayers` for every model.
2. **Shared-expert count** — `drawExpertGrid` subtracted exactly one shared expert, so K3 read `897 routed + 1 shared` against a model card saying 896 + 2. Added optional `sharedExperts` (defaults to 1) and moved the router label into an exported `expertRouterSummary` so it is unit-testable. Every existing model's string is byte-identical, asserted in the test.
3. **Alternation caption** — `alternating every layer` is only true of a 1:1 interleave. Added `alternatingNote`; K3 reads `gated MLA every 4th layer`, gpt-oss and V4 keep the default.

Two E2E failures on the first commit were mine and are fixed:

- `overview.cy.ts` expected 5 matrix rows. The overview renders one row per `DEFAULT_MODELS` entry, so a new default-category model adds a sixth — K3 collapses to a "No 8K/1K results" note exactly like GLM5.2 until data is ingested.
- The new K3 architecture spec picked the model from the dropdown, which only lists models with availability rows; the shared fixtures have none for `kimik3`. It now injects one availability row and visits `?g_model=Kimi-K3` directly.

**One failure was not mine** — `gpu-compare-agentic-detail.cy.ts` → "surfaces automatic resolution of conflicting GPU URL state" fails on `master` too (reproduced by rebuilding this same tree at `origin/master`). #632 made official DeepSeek-V4-Pro agentic charts prefer vLLM on first cross-engine resolution but left this spec asserting the old alphabetical winner, SGLang. Verified against a local `E2E_FIXTURES` build that the toast reads "Kept vLLM and removed SGLang configs" with the selector on "B200 (vLLM)" — i.e. #632's intended behaviour — so `fdf6946` updates the stale expectation. The original "element never found" error was just the toast auto-dismissing while the stale text assertion retried. Happy to split that commit out if the author of #632 would rather fix it there.

## 中文说明

新增 **Kimi-K3**（`moonshotai/Kimi-K3`），数据来源为 [InferenceX run 30298924344](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30298924344)（`kimik3`、`fp4`、vLLM、MI355X、agentic traces）。

K3 是**全新架构**而非 K2 的小版本更新：2.8T 总参数 / 104B 激活参数，基于 Kimi Delta Attention（KDA）与 gated MLA，896 个路由专家 + 2 个共享专家（每 token 激活 16 个），1M 上下文长度。因此它单独建立 DB bucket、下拉选项和 compare slug，而不并入 `Kimi-K2.5` 显示分组——与 MiniMax M3 相对 M2 系列的处理方式一致。本次只有模型是新增的，`mi355x`、`fp4`、`vllm` 以及 agentic traces 场景均已注册。

主要改动：`DB_MODEL_TO_DISPLAY` 新增 `kimik3` → `Kimi-K3`；`MODEL_TO_KEY` 新增 `moonshotai/Kimi-K3`（`kimik3` 前缀与 DB key 一致，`kimik3-fp4` 通过 `PRECISION_SUFFIX` 剥离即可归并，无需 alias）；新增 `Model.Kimi_K3` 枚举与 `MODEL_CONFIG` 条目；compare 页新增 `kimi-k3` slug 并加入 `KNOWN_MODELS`；架构图新增 K3 条目。裸 `kimi` alias 仍指向 `kimi-k26`，与 M3 上线后 `minimax` 保持指向 M2 的做法相同，确保既有站外链接语义不变。

架构图部分新增了 `alternatingAttentionExpandable` 标志：K3 的注意力同样标记为 `Hybrid`，但与 DeepSeek V4 的 CSA/HCA 混合不同，`getHybridAttentionSubBlocks` 绘制的是 V4 特有的 local/compressed 流程，直接复用会给 KDA + gated MLA 层错误地画出 sliding window 与 lightning indexer 模块。已有的 `attentionExpandable: false` 无法复用——V4 已使用该标志关闭单模块下钻，同时刻意保留交替层内的下钻（复用该标志的初版改动导致 2 个 V4 用例失败）。因此新增独立标志，仅 K3 设为 `false`，V4 行为保持不变。架构数值取自 HF `config.json` 与模型卡：93 层（69 KDA + 24 gated MLA，其中 1 层 dense）、hidden 7168、96 个注意力头、`moe_intermediate_size` 3072、dense FFN 33792、词表 163840、1M 上下文。

`/zh` 页面无需改动：`/zh/compare/[slug]` 等页面由共享的 `COMPARE_MODEL_SLUGS` 注册表驱动，中文文案模板直接取用其中的模型名称，因此中文 compare 页、hreflang 与 sitemap 会自动收录 K3；`/about` 的模型列表两侧均由 `DB_MODEL_TO_DISPLAY` 派生。本次未引入新的用户可见 UI 字符串（模型名称按翻译规范保持英文）。`/compare` 与 `/compare-per-dollar` 的 meta 描述目前仍写作 "Kimi K2"，改动需同步中英两侧，可按需在本 PR 或后续 PR 处理。

测试：`typecheck`、`lint`、`fmt` 全部通过；单元测试新增 K3 的 normalizer 解析、显示分桶、compare slug 与架构条目覆盖；`model-architecture.cy.ts` 新增 Kimi K3 用例块（徽章、两个交替层模块、确认不出现 CSA/HCA 下钻与说明文字、features 列表），49/49 通过，其中包含 45 个既有 V4 / gpt-oss / R1 用例。

## 复审与 CI 后续修复（48a014e、fdf6946）

Cursor Bugbot 在首个提交上提出 3 个问题，均属实且已修复：（1）dense 层被重复计数——架构图会在两个交替层模块之上再堆叠 dense 前缀模块，69 KDA + 24 MLA + 1 dense 会为 93 层的模型画出 94 层徽章；第 1 层既是 KDA 层也是 dense 层，故从 KDA 计数中扣除（68 + 24 + 1），与 DeepSeek V4 处理 `hashRoutedLayers` 的方式一致，并新增覆盖全部模型的不变量测试。（2）共享专家数——`drawExpertGrid` 固定减 1，K3 显示为 `897 routed + 1 shared`，与模型卡的 896 + 2 不符；新增 `sharedExperts` 字段（默认 1），并抽出可单元测试的 `expertRouterSummary`，其余模型输出逐字不变。（3）交替层说明文字——`alternating every layer` 仅适用于 1:1 交替；新增 `alternatingNote`，K3 显示 `gated MLA every 4th layer`。

首个提交引入的两个 E2E 失败已修复：`overview.cy.ts` 原断言 5 行矩阵，而 overview 按 `DEFAULT_MODELS` 每个模型渲染一行，新增 default 类别模型后应为 6 行（K3 在数据入库前与 GLM5.2 一样折叠为覆盖率提示）；新增的 K3 架构用例原本从下拉框选择模型，而下拉框只列出有 availability 数据的模型，共享 fixture 中没有 kimik3，现改为注入一条 availability 记录并直接访问 `?g_model=Kimi-K3`。

另有一个失败并非本分支引入：`gpu-compare-agentic-detail.cy.ts` 在 master 上同样失败（已通过在同一工作区检出 `origin/master` 重新构建复现）。#632 让官方 DeepSeek-V4-Pro agentic 图表在首次跨引擎解析时默认选择 vLLM，但未更新该用例，其仍断言此前按字母序选出的 SGLang。已在本地 `E2E_FIXTURES` 构建中确认提示条实际显示「Kept vLLM and removed SGLang configs」、选择器显示「B200 (vLLM)」，即 #632 的预期行为，因此 fdf6946 更新了该过期断言；原报错显示「找不到元素」，是因为过期断言重试 6 秒期间提示条已自动消失。如更适合在 #632 一侧处理，可将该提交拆分出去。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared model registries, ETL normalizers, and architecture rendering used by multiple models; behavior for existing models is heavily tested but diagram logic is complex.
> 
> **Overview**
> Adds **Kimi-K3** as its own product surface (`kimik3` DB key, `Model.Kimi_K3`, `kimi-k3` compare slug, SSR `KNOWN_MODELS`) separate from the grouped Kimi K2 display bucket—the bare `kimi` compare alias still resolves to K2.
> 
> Registers ETL resolution for `moonshotai/Kimi-K3` and `kimik3` prefixes, and ships a full **model architecture** spec (KDA + gated MLA hybrid, 2 shared experts, SiTU-GLU FFN, 68:24 layer split). The architecture diagram gains per-model overrides (`alternatingAttentionExpandable`, `sharedExperts`, `alternatingNote`, `denseLayerAttentionLabel`, `ffnVariant`) plus helpers like `expertRouterSummary` so K3 does not show DeepSeek V4’s CSA/HCA drill-down or wrong “+1 shared” / SwiGLU labels.
> 
> **Overview** matrix expectations add a sixth default model row (K3 shows zero-coverage until ingest). **E2E** adds a Kimi K3 architecture block and updates the agentic GPU conflict toast to expect **vLLM** kept over SGLang (aligns with PR #632).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9ccc15be323c672a136d787e39292372e594e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->