### PR TITLE
feat(inference): show pipeline parallelism (PP) in chart labels & tooltips / 推理图表标签与提示框支持流水线并行（PP）

### DIFF
--- a/packages/app/src/app/api/unofficial-run/route.test.ts
+++ b/packages/app/src/app/api/unofficial-run/route.test.ts
@@ -144,6 +144,33 @@ describe('normalizeArtifactRows', () => {
     expect(m.mean_e2el).toBe(1.5);
   });
 
+  it('surfaces pipeline-parallelism fields in metrics (auto-capture)', () => {
+    // pp has no configs-table column: the frontend reads it from the metrics
+    // JSONB (rowToAggDataEntry), so the overlay route must keep passing it
+    // through. Field shape matches run 30314948116 (Kimi-K3 TP8 PP2).
+    const rows = normalizeArtifactRows(
+      [
+        rawRow({
+          prefill_tp: 8,
+          prefill_ep: 1,
+          prefill_pp: 2,
+          prefill_dp_attention: 'false',
+          prefill_num_workers: 1,
+          num_prefill_gpu: 16,
+          decode_tp: 8,
+          decode_ep: 1,
+          decode_pp: 2,
+          decode_dp_attention: 'false',
+          decode_num_workers: 1,
+          num_decode_gpu: 16,
+        }),
+      ],
+      '2026-03-01',
+    );
+    expect(rows[0].metrics.prefill_pp).toBe(2);
+    expect(rows[0].metrics.decode_pp).toBe(2);
+  });
+
   it('normalizes spec_method from spec_decoding', () => {
     const rows = normalizeArtifactRows([rawRow({ spec_decoding: 'eagle' })], '2026-03-01');
     expect(rows[0].spec_method).toBe('eagle');

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -168,14 +168,25 @@ export interface AggDataEntry {
   num_decode_gpu: number;
   spec_decoding: string;
   ep?: number;
+  /**
+   * Pipeline parallelism (decode-side, mirroring how `ep` mirrors decode_ep).
+   * Sourced from the metrics JSONB (`decode_pp`) — the configs table has no
+   * pp columns — so it's only present on rows whose artifacts emitted it
+   * (2026-07+). Undefined ⇒ treated as pp=1 everywhere (no label suffix).
+   */
+  pp?: number;
   dp_attention?: boolean | string;
   is_multinode?: boolean;
   prefill_tp?: number;
   prefill_ep?: number;
+  /** Prefill-side pipeline parallelism — see {@link AggDataEntry.pp}. */
+  prefill_pp?: number;
   prefill_dp_attention?: boolean | string;
   prefill_num_workers?: number;
   decode_tp?: number;
   decode_ep?: number;
+  /** Decode-side pipeline parallelism — see {@link AggDataEntry.pp}. */
+  decode_pp?: number;
   decode_dp_attention?: boolean | string;
   decode_num_workers?: number;
   image?: string;

--- a/packages/app/src/components/inference/utils/parallelism-label.test.ts
+++ b/packages/app/src/components/inference/utils/parallelism-label.test.ts
@@ -18,6 +18,19 @@ describe('configSegmentLabel', () => {
     expect(configSegmentLabel(8, undefined, false)).toBe('TP8');
     expect(configSegmentLabel(8, 1, true)).toBe('DPATP8');
   });
+
+  it('appends PP suffix only when pp > 1', () => {
+    expect(configSegmentLabel(8, 1, false, 2)).toBe('TP8PP2');
+    expect(configSegmentLabel(8, 8, false, 2)).toBe('TEP8PP2');
+    expect(configSegmentLabel(8, 8, true, 4)).toBe('DEP8PP4');
+    expect(configSegmentLabel(4, 16, true, 2)).toBe('DPAEP16PP2');
+  });
+
+  it('renders no PP part when pp is 1, 0, or absent', () => {
+    expect(configSegmentLabel(8, 1, false, 1)).toBe('TP8');
+    expect(configSegmentLabel(8, 1, false, 0)).toBe('TP8');
+    expect(configSegmentLabel(8, 1, false, undefined)).toBe('TP8');
+  });
 });
 
 describe('parallelismLabel', () => {
@@ -54,5 +67,104 @@ describe('parallelismLabel', () => {
     expect(
       parallelismLabel({ tp: 8, ep: 8, dpAttention: false, disagg: true, isMultinode: false }),
     ).toBe('TEP8');
+  });
+
+  it('includes PP in a single-segment config only when > 1', () => {
+    expect(parallelismLabel({ tp: 8, ep: 1, pp: 2 })).toBe('TP8PP2');
+    expect(parallelismLabel({ tp: 8, ep: 1, pp: 1 })).toBe('TP8');
+    expect(parallelismLabel({ tp: 8, ep: 1, pp: 0 })).toBe('TP8');
+  });
+
+  it('applies per-role PP to multinode-disagg segments', () => {
+    expect(
+      parallelismLabel({
+        tp: 8,
+        ep: 1,
+        disagg: true,
+        isMultinode: true,
+        prefillTp: 8,
+        prefillEp: 1,
+        prefillPp: 2,
+        prefillNumWorkers: 2,
+        decodeTp: 8,
+        decodeEp: 1,
+        decodePp: 1,
+        decodeNumWorkers: 1,
+      }),
+    ).toBe('2xTP8PP2+1xTP8');
+  });
+
+  it('drops the decode segment when the decode pool is absent (0 workers, tp 0)', () => {
+    // Prefill-only agentic multinode runs (e.g. Kimi-K3 TP8 PP2 on b200-dgxc)
+    // emit decode_num_workers=0 / decode_tp=0 — the label is just the active
+    // side, without the 1x multiplier: "TP8PP2", not "1xTP8PP2+0xTP0".
+    expect(
+      parallelismLabel({
+        tp: 0,
+        ep: 0,
+        disagg: true,
+        isMultinode: true,
+        prefillTp: 8,
+        prefillEp: 1,
+        prefillPp: 2,
+        prefillNumWorkers: 1,
+        decodeTp: 0,
+        decodeEp: 0,
+        decodePp: 1,
+        decodeNumWorkers: 0,
+      }),
+    ).toBe('TP8PP2');
+  });
+
+  it('keeps the Nx multiplier on a lone segment with multiple workers', () => {
+    expect(
+      parallelismLabel({
+        tp: 0,
+        ep: 0,
+        disagg: true,
+        isMultinode: true,
+        prefillTp: 8,
+        prefillEp: 1,
+        prefillPp: 2,
+        prefillNumWorkers: 2,
+        decodeTp: 0,
+        decodeEp: 0,
+        decodeNumWorkers: 0,
+      }),
+    ).toBe('2xTP8PP2');
+  });
+
+  it('drops the prefill segment when the prefill pool is absent', () => {
+    expect(
+      parallelismLabel({
+        tp: 8,
+        ep: 8,
+        disagg: true,
+        isMultinode: true,
+        prefillTp: 0,
+        prefillEp: 0,
+        prefillNumWorkers: 0,
+        decodeTp: 8,
+        decodeEp: 8,
+        decodeNumWorkers: 1,
+      }),
+    ).toBe('TEP8');
+  });
+
+  it('keeps zero-worker segments whose tp is set (pool exists, worker count unknown)', () => {
+    expect(
+      parallelismLabel({
+        tp: 8,
+        ep: 4,
+        disagg: true,
+        isMultinode: true,
+        prefillTp: 4,
+        prefillEp: 4,
+        prefillNumWorkers: 0,
+        decodeTp: 8,
+        decodeEp: 8,
+        decodeNumWorkers: 1,
+      }),
+    ).toBe('0xTEP4+1xTEP8');
   });
 });

--- a/packages/app/src/components/inference/utils/parallelism-label.ts
+++ b/packages/app/src/components/inference/utils/parallelism-label.ts
@@ -13,33 +13,41 @@
  * - tp == ep and dp-attn true: "DEP{N}"
  * - ep > 1 (tp != ep): "EP{ep}" or "DPAEP{ep}"
  * - ep <= 1 (or no EP): "TP{tp}" or "DPATP{tp}"
+ * - pp > 1 appends a "PP{pp}" suffix (e.g. "TP8PP2"); pp <= 1 or absent
+ *   renders nothing so pre-PP labels stay byte-identical.
  */
 export const configSegmentLabel = (
   tp: number,
   ep: number | undefined,
   dpAttention: boolean | undefined,
+  pp?: number,
 ): string => {
+  const ppSuffix = pp !== null && pp !== undefined && pp > 1 ? `PP${pp}` : '';
   if (ep !== null && ep !== undefined && ep > 1 && tp === ep) {
-    return dpAttention ? `DEP${tp}` : `TEP${tp}`;
+    return `${dpAttention ? 'DEP' : 'TEP'}${tp}${ppSuffix}`;
   }
   const dpaPrefix = dpAttention ? 'DPA' : '';
-  if (ep === null || ep === undefined || ep <= 1) return `${dpaPrefix}TP${tp}`;
-  return `${dpaPrefix}EP${ep}`;
+  if (ep === null || ep === undefined || ep <= 1) return `${dpaPrefix}TP${tp}${ppSuffix}`;
+  return `${dpaPrefix}EP${ep}${ppSuffix}`;
 };
 
 /** Parallelism params for one benchmark config, framework-agnostic. */
 export interface ParallelismFields {
   tp: number;
   ep?: number;
+  /** Pipeline parallelism. Only rendered when > 1. */
+  pp?: number;
   dpAttention?: boolean;
   disagg?: boolean;
   isMultinode?: boolean;
   prefillTp?: number;
   prefillEp?: number;
+  prefillPp?: number;
   prefillDpAttention?: boolean;
   prefillNumWorkers?: number;
   decodeTp?: number;
   decodeEp?: number;
+  decodePp?: number;
   decodeDpAttention?: boolean;
   decodeNumWorkers?: number;
 }
@@ -48,8 +56,11 @@ export interface ParallelismFields {
  * Returns the short parallelism label for a config.
  * - No EP data (old rows): falls back to the bare tp value (e.g. "8").
  * - Multinode disagg: per-role segments with worker counts,
- *   e.g. "2xEP4+1xDPAEP32".
- * - Otherwise: a single segment from (tp, ep, dpAttention).
+ *   e.g. "2xEP4+1xDPAEP32". A role with zero workers AND zero TP (prefill-only
+ *   agentic multinode runs emit decode_num_workers=0 / decode_tp=0) doesn't
+ *   exist — only the active side is rendered, without the "Nx" multiplier
+ *   when it has a single worker (e.g. "TP8PP2", not "1xTP8PP2+0xTP0").
+ * - Otherwise: a single segment from (tp, ep, dpAttention, pp).
  */
 export const parallelismLabel = (f: ParallelismFields): string => {
   if (
@@ -64,16 +75,22 @@ export const parallelismLabel = (f: ParallelismFields): string => {
       f.prefillTp ?? f.tp,
       f.prefillEp ?? f.ep,
       f.prefillDpAttention ?? f.dpAttention,
+      f.prefillPp ?? f.pp,
     );
     const decodeLabel = configSegmentLabel(
       f.decodeTp ?? f.tp,
       f.decodeEp ?? f.ep,
       f.decodeDpAttention ?? f.dpAttention,
+      f.decodePp ?? f.pp,
     );
     const pw = f.prefillNumWorkers ?? 1;
     const dw = f.decodeNumWorkers ?? 1;
+    const prefillAbsent = pw === 0 && (f.prefillTp ?? f.tp) === 0;
+    const decodeAbsent = dw === 0 && (f.decodeTp ?? f.tp) === 0;
+    if (decodeAbsent && !prefillAbsent) return pw > 1 ? `${pw}x${prefillLabel}` : prefillLabel;
+    if (prefillAbsent && !decodeAbsent) return dw > 1 ? `${dw}x${decodeLabel}` : decodeLabel;
     return `${pw}x${prefillLabel}+${dw}x${decodeLabel}`;
   }
 
-  return configSegmentLabel(f.tp, f.ep, f.dpAttention);
+  return configSegmentLabel(f.tp, f.ep, f.dpAttention, f.pp);
 };

--- a/packages/app/src/components/inference/utils/tooltip-parallelism.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-parallelism.test.ts
@@ -102,6 +102,25 @@ describe('tooltip parallelism — standard (ep field present)', () => {
     expect(html).toContain('True');
   });
 
+  it('shows Pipeline Parallelism when pp > 1', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ tp: 16, decode_tp: 8, ep: 1, pp: 2, dp_attention: false }) }),
+    );
+    expect(html).toContain('Pipeline Parallelism');
+    // The Tensor Parallelism line shows the raw TP width, not the pp-folded
+    // total GPU count.
+    expect(html).toMatch(/Tensor Parallelism:<\/strong> 8/u);
+  });
+
+  it('hides Pipeline Parallelism when pp is 1, 0, or absent', () => {
+    for (const pp of [1, 0, undefined]) {
+      const html = generateTooltipContent(
+        tooltipConfig({ data: pt({ tp: 8, ep: 1, pp, dp_attention: false }) }),
+      );
+      expect(html).not.toContain('Pipeline Parallelism');
+    }
+  });
+
   it('omits Expert Parallelism line when ep is null', () => {
     const d = pt({ tp: 4 });
     (d as any).ep = null;
@@ -170,6 +189,32 @@ describe('tooltip parallelism — multinode disagg', () => {
     expect(html).toContain('Workers: 1');
   });
 
+  it('shows per-role PP in prefill/decode lines only when > 1', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          tp: 8,
+          ep: 1,
+          is_multinode: true,
+          disagg: true,
+          prefill_tp: 8,
+          prefill_ep: 1,
+          prefill_pp: 2,
+          decode_tp: 8,
+          decode_ep: 1,
+          decode_pp: 1,
+          prefill_num_workers: 1,
+          decode_num_workers: 1,
+          num_prefill_gpu: 16,
+          num_decode_gpu: 8,
+        }),
+      }),
+    );
+    // prefill line carries PP: 2; decode line (pp=1) has no PP part
+    expect(html).toContain('PP: 2');
+    expect(html).not.toContain('PP: 1');
+  });
+
   it('shows "?" for missing GPU count fields', () => {
     const html = generateTooltipContent(
       tooltipConfig({
@@ -206,6 +251,48 @@ describe('tooltip parallelism — multinode disagg', () => {
     expect(html).toContain('Decode:');
     expect(html).toContain('8 GPUs');
     expect(html).toContain('16 GPUs');
+  });
+});
+
+// ===========================================================================
+// zh locale
+// ===========================================================================
+describe('tooltip parallelism — zh locale', () => {
+  it('localizes the standard parallelism labels', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({ tp: 16, decode_tp: 8, ep: 1, pp: 2, dp_attention: false }),
+        locale: 'zh',
+      }),
+    );
+    expect(html).toContain('张量并行 (TP)');
+    expect(html).toContain('流水线并行 (PP)');
+    expect(html).not.toContain('Tensor Parallelism');
+  });
+
+  it('localizes the old-data parallelism strategy line', () => {
+    const html = generateTooltipContent(tooltipConfig({ data: pt({ tp: 4 }), locale: 'zh' }));
+    expect(html).toContain('并行策略');
+    expect(html).toContain('4 个 GPU');
+  });
+
+  it('localizes the multinode disagg role headers', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          tp: 8,
+          ep: 4,
+          is_multinode: true,
+          disagg: true,
+          num_prefill_gpu: 16,
+          num_decode_gpu: 24,
+        }),
+        locale: 'zh',
+      }),
+    );
+    expect(html).toContain('预填充:');
+    expect(html).toContain('解码:');
+    expect(html).toContain('16 个 GPU');
   });
 });
 

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -62,17 +62,23 @@ const asBool = (v: boolean | string | undefined): boolean | undefined =>
  */
 export const getPointLabel = (d: InferenceData): string =>
   parallelismLabel({
-    tp: d.tp,
+    // InferenceData.tp is the TOTAL GPU count (createChartDataPoint folds pp
+    // into it for aggregated rows) — the label wants the actual TP width, so
+    // prefer the raw decode_tp and keep d.tp only as a legacy fallback.
+    tp: d.decode_tp ?? d.tp,
     ep: d.ep,
+    pp: d.pp,
     dpAttention: asBool(d.dp_attention),
     disagg: d.disagg,
     isMultinode: d.is_multinode,
     prefillTp: d.prefill_tp,
     prefillEp: d.prefill_ep,
+    prefillPp: d.prefill_pp,
     prefillDpAttention: asBool(d.prefill_dp_attention),
     prefillNumWorkers: d.prefill_num_workers,
     decodeTp: d.decode_tp,
     decodeEp: d.decode_ep,
+    decodePp: d.decode_pp,
     decodeDpAttention: asBool(d.decode_dp_attention),
     decodeNumWorkers: d.decode_num_workers,
   });
@@ -221,40 +227,71 @@ const imageTooltipLine = (image: string) =>
         <strong>Image:</strong> <span style="display: inline-block; vertical-align: top; overflow-wrap: anywhere;">${shortenSha(image.trim()).replace(/\s+/u, '<br />')}</span>
       </div>`;
 
+const PARALLELISM_STRINGS = {
+  en: {
+    strategy: 'Parallelism Strategy',
+    gpuCount: (n: number) => `${n} GPU${n > 1 ? 's' : ''}`,
+    prefill: 'Prefill',
+    decode: 'Decode',
+    gpusUnit: 'GPUs',
+    tensorParallelism: 'Tensor Parallelism',
+    expertParallelism: 'Expert Parallelism',
+    pipelineParallelism: 'Pipeline Parallelism',
+    dpAttention: 'DP Attention',
+  },
+  zh: {
+    strategy: '并行策略',
+    gpuCount: (n: number) => `${n} 个 GPU`,
+    prefill: '预填充',
+    decode: '解码',
+    gpusUnit: '个 GPU',
+    tensorParallelism: '张量并行 (TP)',
+    expertParallelism: '专家并行 (EP)',
+    pipelineParallelism: '流水线并行 (PP)',
+    dpAttention: 'DP Attention',
+  },
+} as const;
+
 /**
  * Generates HTML for the parallelism configuration section of a tooltip.
  * Falls back to GPU count for old data without parallelism fields.
+ * Pipeline parallelism is only rendered when > 1 (pp of 0/1 means "no PP",
+ * matching the point-label rule in {@link parallelismLabel}).
  */
-const generateParallelismHTML = (d: InferenceData): string => {
+const generateParallelismHTML = (d: InferenceData, locale: Locale = 'en'): string => {
+  const t = PARALLELISM_STRINGS[locale];
   if (
     (d.ep === null || d.ep === undefined) &&
     (d.prefill_ep === null || d.prefill_ep === undefined)
   ) {
-    return tooltipLine('Parallelism Strategy', `${d.tp} GPU${d.tp > 1 ? 's' : ''}`);
+    return tooltipLine(t.strategy, t.gpuCount(d.tp));
   }
 
   if (d.is_multinode && d.disagg) {
     const ptp = d.prefill_tp ?? d.tp;
     const pep = d.prefill_ep ?? d.ep ?? 0;
+    const ppp = d.prefill_pp ?? d.pp ?? 1;
     const pdpa = d.prefill_dp_attention ?? d.dp_attention ?? false;
     const dtp = d.decode_tp ?? d.tp;
     const dep = d.decode_ep ?? d.ep ?? 0;
+    const dpp = d.decode_pp ?? d.pp ?? 1;
     const ddpa = d.decode_dp_attention ?? d.dp_attention ?? false;
     const pw = d.prefill_num_workers ?? 1;
     const dw = d.decode_num_workers ?? 1;
     return `
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
-        <strong>Prefill:</strong> ${d.num_prefill_gpu ?? '?'} GPUs, TP: ${ptp}, EP: ${pep}, DPA: ${pdpa ? 'True' : 'False'}, Workers: ${pw}
+        <strong>${t.prefill}:</strong> ${d.num_prefill_gpu ?? '?'} ${t.gpusUnit}, TP: ${ptp}, ${ppp > 1 ? `PP: ${ppp}, ` : ''}EP: ${pep}, DPA: ${pdpa ? 'True' : 'False'}, Workers: ${pw}
       </div>
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
-        <strong>Decode:</strong> ${d.num_decode_gpu ?? '?'} GPUs, TP: ${dtp}, EP: ${dep}, DPA: ${ddpa ? 'True' : 'False'}, Workers: ${dw}
+        <strong>${t.decode}:</strong> ${d.num_decode_gpu ?? '?'} ${t.gpusUnit}, TP: ${dtp}, ${dpp > 1 ? `PP: ${dpp}, ` : ''}EP: ${dep}, DPA: ${ddpa ? 'True' : 'False'}, Workers: ${dw}
       </div>`;
   }
 
   return `
-    ${tooltipLine('Tensor Parallelism', d.tp)}
-    ${d.ep !== null && d.ep !== undefined ? tooltipLine('Expert Parallelism', d.ep) : ''}
-    ${tooltipLine('DP Attention', d.dp_attention ? 'True' : 'False')}`;
+    ${tooltipLine(t.tensorParallelism, d.decode_tp ?? d.tp)}
+    ${d.pp !== null && d.pp !== undefined && d.pp > 1 ? tooltipLine(t.pipelineParallelism, d.pp) : ''}
+    ${d.ep !== null && d.ep !== undefined ? tooltipLine(t.expertParallelism, d.ep) : ''}
+    ${tooltipLine(t.dpAttention, d.dp_attention ? 'True' : 'False')}`;
 };
 
 /**
@@ -314,7 +351,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
           : ''
       }
       ${tooltipLine('Total GPUs', d.tp)}
-      ${generateParallelismHTML(d)}
+      ${generateParallelismHTML(d, locale)}
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Concurrency:</strong> ${d.conc}
       </div>
@@ -374,7 +411,7 @@ export const generateOverlayTooltipContent = (config: OverlayTooltipConfig): str
         <strong>${yLabel}:</strong> ${fmt(d.y)}
       </div>
       ${tooltipLine('Total GPUs', d.tp)}
-      ${generateParallelismHTML(d)}
+      ${generateParallelismHTML(d, locale)}
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Concurrency:</strong> ${d.conc}
       </div>
@@ -445,7 +482,7 @@ export const generateGPUGraphTooltipContent = (config: TooltipConfig): string =>
           : ''
       }
       ${tooltipLine('Total GPUs', d.tp)}
-      ${generateParallelismHTML(d)}
+      ${generateParallelismHTML(d, locale)}
       <div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;">
         <strong>Concurrency:</strong> ${d.conc}
       </div>

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 
+import { getPointLabel } from '@/components/inference/utils/tooltipUtils';
 import type { BenchmarkRow } from '@/lib/api';
 
 import {
@@ -113,6 +114,23 @@ describe('rowToAggDataEntry', () => {
   it('maps decode_tp to tp', () => {
     const entry = rowToAggDataEntry(makeRow({ decode_tp: 4 }));
     expect(entry.tp).toBe(4);
+  });
+
+  it('surfaces pipeline parallelism from the metrics JSONB', () => {
+    const base = makeRow();
+    const entry = rowToAggDataEntry(
+      makeRow({ metrics: { ...base.metrics, prefill_pp: 2, decode_pp: 2 } }),
+    );
+    expect(entry.pp).toBe(2);
+    expect(entry.prefill_pp).toBe(2);
+    expect(entry.decode_pp).toBe(2);
+  });
+
+  it('leaves pp undefined for rows predating the field', () => {
+    const entry = rowToAggDataEntry(makeRow());
+    expect(entry.pp).toBeUndefined();
+    expect(entry.prefill_pp).toBeUndefined();
+    expect(entry.decode_pp).toBeUndefined();
   });
 
   it('maps image field', () => {
@@ -330,6 +348,27 @@ describe('transformBenchmarkRows', () => {
     const { hardwareConfig } = transformBenchmarkRows(rows);
     const hwKeys = Object.keys(hardwareConfig);
     expect(hwKeys.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('folds pp into the total GPU count and the point label (overlay path)', () => {
+    // This is the same pipeline `?unofficialrun=` overlays run through
+    // (buildChartData → transformBenchmarkRows), so it exercises the overlay
+    // rendering path for PP configs end to end.
+    const base = makeRow();
+    const rows = [makeRow({ metrics: { ...base.metrics, prefill_pp: 2, decode_pp: 2 } })];
+    const { chartData } = transformBenchmarkRows(rows);
+    const point = chartData.find((d) => d.length > 0)![0];
+    // tp8 × pp2 = 16 total GPUs
+    expect(point.tp).toBe(16);
+    expect(point.pp).toBe(2);
+    expect(getPointLabel(point)).toBe('TP8PP2');
+  });
+
+  it('keeps total GPU count and label unchanged when pp is absent', () => {
+    const { chartData } = transformBenchmarkRows([makeRow()]);
+    const point = chartData.find((d) => d.length > 0)![0];
+    expect(point.tp).toBe(8);
+    expect(getPointLabel(point)).toBe('TP8');
   });
 
   it('labels M3 mtp configs with the "M3 EAGLE" suffix', () => {

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -146,14 +146,21 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     num_decode_gpu: row.num_decode_gpu,
     spec_decoding: row.spec_method,
     ep: row.decode_ep,
+    // Pipeline parallelism has no configs-table column — the ingest mapper
+    // auto-captures the artifact's prefill_pp/decode_pp into the metrics
+    // JSONB, so both official DB rows and live-transformed overlay rows read
+    // it from there. Undefined for artifacts predating the field.
+    pp: m.decode_pp,
     dp_attention: row.decode_dp_attention,
     is_multinode: row.is_multinode,
     prefill_tp: row.prefill_tp,
     prefill_ep: row.prefill_ep,
+    prefill_pp: m.prefill_pp,
     prefill_dp_attention: row.prefill_dp_attention,
     prefill_num_workers: row.prefill_num_workers,
     decode_tp: row.decode_tp,
     decode_ep: row.decode_ep,
+    decode_pp: m.decode_pp,
     decode_dp_attention: row.decode_dp_attention,
     decode_num_workers: row.decode_num_workers,
     image: row.image ?? undefined,

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -323,7 +323,12 @@ export function createChartDataPoint(
     x: xValue,
     y: yValue,
     hwKey: currentHwKey,
-    tp: entry.disagg ? entry.num_prefill_gpu + entry.num_decode_gpu : entry.tp,
+    // Total GPU count. Disagg rows carry explicit per-role GPU counts; for
+    // aggregated rows the world size is tp × pp (pp undefined/≤1 ⇒ ×1, so
+    // pre-PP rows are unchanged).
+    tp: entry.disagg
+      ? entry.num_prefill_gpu + entry.num_decode_gpu
+      : entry.tp * (entry.pp && entry.pp > 1 ? entry.pp : 1),
     image: entry.image ?? undefined,
 
     // Narrow boolean | string fields to boolean

--- a/packages/constants/src/metric-keys.ts
+++ b/packages/constants/src/metric-keys.ts
@@ -145,4 +145,16 @@ export const METRIC_KEYS = new Set([
   'peak_temp_c',
   'avg_util_pct',
   'avg_mem_used_mb',
+  // extended parallelism dimensions (2026-07+ artifacts): pipeline parallelism
+  // and decode/prefill context parallelism per role. These are config
+  // dimensions, not measurements, but the configs table has no columns for
+  // them — they ride along in the metrics JSONB via the mapper's auto-capture
+  // and the frontend reads pp from here for point labels / tooltips
+  // (rowToAggDataEntry in benchmark-transform.ts).
+  'prefill_pp',
+  'decode_pp',
+  'prefill_dcp_size',
+  'decode_dcp_size',
+  'prefill_pcp_size',
+  'decode_pcp_size',
 ]);


### PR DESCRIPTION
## Summary

Pipeline-parallel deployments now show their PP degree in the frontend. For `?unofficialrun=30314948116` (Kimi-K3, `prefill-tp8-pp2` on B200 DGXC) the chart point label previously rendered `1xTP8+0xTP0` (read as "TP8") — it now renders **`TP8PP2`**. When `pp` is 0 or 1, no PP part is shown, so every existing label stays byte-identical.

### What changed

- **`parallelism-label.ts`** — `configSegmentLabel` takes an optional `pp` and appends a `PP{n}` suffix only when `pp > 1` (`TP8PP2`, `TEP8PP2`, `DPAEP16PP2`, …). Multinode-disagg labels drop a role whose pool doesn't exist (0 workers **and** tp 0 — the prefill-only agentic multinode shape), so the label is the active segment alone instead of a dangling `+0xTP0` tail.
- **Data flow** — `pp` has no `configs`-table column; the ingest mapper already auto-captures `prefill_pp` / `decode_pp` into the `metrics` JSONB for **both** official DB rows and live-transformed overlay rows. `rowToAggDataEntry` now surfaces `pp` / `prefill_pp` / `decode_pp` from `metrics`, and the new artifact keys (plus `dcp`/`pcp` sizes) are documented in `METRIC_KEYS` so the one-time ingest warning stops firing.
- **Total GPUs** — `createChartDataPoint` folds `pp` into the aggregated-row GPU count (`tp × pp`); `getPointLabel` and the tooltip "Tensor Parallelism" line switch to the raw `decode_tp` so a TP8 PP2 run doesn't mislabel as `TP16PP2`.
- **Tooltips** — per-role `PP: n` in the Prefill/Decode lines and a "Pipeline Parallelism" line for aggregated rows, hidden when `pp ≤ 1`. The parallelism block is now locale-aware on `/zh` pages (预填充/解码/张量并行/流水线并行…), matching the already-localized cache block; English output is byte-identical.

### Overlay support (mandatory checklist)

Works for both official runs and `?unofficialrun=` overlays — the label/tooltip changes live in the shared `getPointLabel` / `generateParallelismHTML` used by both paths, and `pp` is read from `metrics` which both `rowToAggDataEntry` (official) and `normalizeArtifactRows` → `transformBenchmarkRows` (overlay) carry. Verified:

- Ran the real `bmk_agentic_kimik3_…tp8-pp2…` artifact row from run 30314948116 through `normalizeArtifactRows` → `transformBenchmarkRows` → `getPointLabel`: label = `TP8PP2`, total GPUs = 16.
- Hit the live `/api/unofficial-run?runId=30314948116` on a local dev server: all 4 rows return `metrics.prefill_pp = 2`.
- Overlay-path tests added: `benchmark-transform.test.ts` ("overlay path" pp label test) and `route.test.ts` (pp survives artifact normalization). Overlay visibility filters are untouched (no new drawn elements — existing labels/tooltips only).

### Tests

- `parallelism-label.test.ts`: PP suffix on all segment shapes; hidden for pp ∈ {0, 1, undefined}; per-role PP; zero-worker segment dropping (incl. the exact run-30314948116 shape) and the conservative keep when tp is set.
- `tooltip-parallelism.test.ts`: PP line shown/hidden by the pp>1 rule, per-role `PP:` parts, raw-TP-width assertion, zh-locale rendering.
- `benchmark-transform.test.ts`: pp surfaced from metrics; undefined for pre-PP rows; tp×pp folding; labels unchanged without pp.
- Full suite: 149 files / 2837 tests pass; `lint`, `fmt`, `typecheck` clean.

Not covered (intentionally): evaluation-tab tooltips and CSV export gain no PP column yet — no eval PP configs exist; can follow up if needed. No interpolation code touched (no `iso_interactivity.py` sync required).

## 中文说明

流水线并行（PP）部署现在会在前端显示 PP 维度。对于 `?unofficialrun=30314948116`（Kimi-K3，B200 DGXC 上的 `prefill-tp8-pp2`），图表点标签之前显示为 `1xTP8+0xTP0`，现在显示 **`TP8PP2`**。当 `pp` 为 0 或 1 时不显示 PP 部分，因此所有既有标签保持逐字节一致。

- **标签**：`configSegmentLabel` 新增可选 `pp` 参数，仅在 `pp > 1` 时追加 `PP{n}` 后缀；多节点 disagg 标签在某一角色池不存在（worker 数为 0 且 TP 为 0）时仅渲染有效一侧。
- **数据链路**：`pp` 没有 configs 表列 — ingest mapper 已将 `prefill_pp` / `decode_pp` 自动捕获进 metrics JSONB（官方 DB 行与 `?unofficialrun=` 覆盖行走同一路径），`rowToAggDataEntry` 从 metrics 读取并透传到图表数据。
- **总 GPU 数**：聚合行按 `tp × pp` 折算；标签与提示框的 TP 行改用原始 `decode_tp`，避免 TP8 PP2 被误标为 `TP16PP2`。
- **提示框**：Prefill/Decode 行新增 `PP: n`（仅 pp > 1 时），聚合行新增"流水线并行"一行；并行配置块补充了中文本地化（与已本地化的缓存块一致），英文输出保持逐字节一致。
- **测试**：新增标签、提示框、transform 与 overlay 路径单元测试；全量 2837 个测试通过，lint / fmt / typecheck 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and transform-layer changes only; extensive tests and no pp≤1 label changes limit regression risk.
> 
> **Overview**
> Inference charts and tooltips now surface **pipeline parallelism (PP)** when artifacts emit `prefill_pp` / `decode_pp` in metrics JSONB (no configs-table columns). Chart point labels append a `PP{n}` suffix only when `pp > 1` (e.g. **`TP8PP2`** instead of misleading multinode strings like `1xTP8+0xTP0`); `pp` absent or ≤1 leaves existing labels unchanged.
> 
> **Data path:** `rowToAggDataEntry` maps `decode_pp` / `prefill_pp` from metrics; `createChartDataPoint` sets total GPUs to `tp × pp` on aggregated rows while `getPointLabel` and tooltip TP lines use raw `decode_tp` so PP2 is not misread as `TP16PP2`. `METRIC_KEYS` documents the new keys for ingest.
> 
> **Labels:** Multinode-disagg `parallelismLabel` omits a role with 0 workers and 0 TP (prefill-only agentic runs) and applies per-role PP in segment strings.
> 
> **Tooltips:** Optional pipeline-parallelism row and per-role `PP:` in Prefill/Decode blocks; parallelism copy is localized for `zh` (English strings unchanged).
> 
> Tests cover normalization, transform/overlay path, labels, and tooltips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99b66979600df98b2a1dfe7f8385355ae3d484eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->