### PR TITLE
Hide branded watermarks on unofficial domains / 在非官方域名隐藏品牌水印

### DIFF
--- a/packages/app/cypress/e2e/gpu-specs.cy.ts
+++ b/packages/app/cypress/e2e/gpu-specs.cy.ts
@@ -162,48 +162,29 @@ describe('GPU Specs Tab', () => {
     cy.get('body').type('{esc}');
   });
 
-  it('scale-out topology diagrams have logo watermark', () => {
-    cy.get('[data-testid="topology-h200-sxm"] svg')
-      .should('exist')
-      .within(() => {
-        cy.get('defs pattern[id^="logo-scaleout-"]').should('exist');
-        cy.get('defs pattern[id^="logo-scaleout-"] image')
-          .should('have.attr', 'href', '/brand/logo-color.webp')
-          .and('have.attr', 'opacity', '0.1');
-      });
+  it('hides scale-out topology logos with the unofficial-domain notice', () => {
+    cy.contains('This deployment is not hosted at').should('be.visible');
+    cy.get('[data-testid="topology-h200-sxm"] defs pattern[id^="logo-scaleout-"]').should(
+      'not.exist',
+    );
   });
 
-  it('scale-up switched topology diagrams have logo watermark', () => {
-    cy.get('[data-testid="scaleup-topology-h200-sxm"] svg')
-      .should('exist')
-      .within(() => {
-        cy.get('defs pattern[id^="logo-scaleup-sw-"]').should('exist');
-        cy.get('defs pattern[id^="logo-scaleup-sw-"] image')
-          .should('have.attr', 'href', '/brand/logo-color.webp')
-          .and('have.attr', 'opacity', '0.1');
-      });
+  it('hides switched scale-up topology logos on unofficial domains', () => {
+    cy.get('[data-testid="scaleup-topology-h200-sxm"] defs pattern[id^="logo-scaleup-sw-"]').should(
+      'not.exist',
+    );
   });
 
-  it('scale-up mesh topology diagrams have logo watermark', () => {
-    cy.get('[data-testid="scaleup-topology-mi300x"] svg')
-      .should('exist')
-      .within(() => {
-        cy.get('defs pattern[id^="logo-scaleup-mesh-"]').should('exist');
-        cy.get('defs pattern[id^="logo-scaleup-mesh-"] image')
-          .should('have.attr', 'href', '/brand/logo-color.webp')
-          .and('have.attr', 'opacity', '0.1');
-      });
+  it('hides mesh scale-up topology logos on unofficial domains', () => {
+    cy.get('[data-testid="scaleup-topology-mi300x"] defs pattern[id^="logo-scaleup-mesh-"]').should(
+      'not.exist',
+    );
   });
 
-  it('scale-up NVL72 topology diagrams have logo watermark', () => {
-    cy.get('[data-testid="scaleup-topology-gb200-nvl72"] svg')
-      .should('exist')
-      .within(() => {
-        cy.get('defs pattern[id^="logo-scaleup-nvl72-"]').should('exist');
-        cy.get('defs pattern[id^="logo-scaleup-nvl72-"] image')
-          .should('have.attr', 'href', '/brand/logo-color.webp')
-          .and('have.attr', 'opacity', '0.1');
-      });
+  it('hides NVL72 scale-up topology logos on unofficial domains', () => {
+    cy.get(
+      '[data-testid="scaleup-topology-gb200-nvl72"] defs pattern[id^="logo-scaleup-nvl72-"]',
+    ).should('not.exist');
   });
 });
 
@@ -356,15 +337,11 @@ describe('GPU Specs Radar Chart View', () => {
     });
   });
 
-  it('radar chart has logo watermark', () => {
-    cy.get('[data-testid="gpu-specs-radar-chart"] svg')
-      .first()
-      .within(() => {
-        cy.get('defs pattern[id^="logo-pattern"]').should('exist');
-        cy.get('defs pattern[id^="logo-pattern"] image')
-          .should('have.attr', 'href', '/brand/logo-color.webp')
-          .and('have.attr', 'opacity', '0.1');
-      });
+  it('hides the radar chart logo on unofficial domains', () => {
+    cy.contains('This deployment is not hosted at').should('be.visible');
+    cy.get('[data-testid="gpu-specs-radar-chart"] defs pattern[id^="logo-pattern"]').should(
+      'not.exist',
+    );
   });
 
   it('normalization note is visible', () => {

--- a/packages/app/cypress/e2e/inference-chart.cy.ts
+++ b/packages/app/cypress/e2e/inference-chart.cy.ts
@@ -23,6 +23,13 @@ describe('Inference Chart', () => {
     cy.get('[data-testid="scatter-graph"]').first().find('svg').should('exist');
   });
 
+  it('hides the logo watermark when the unofficial-domain notice is shown', () => {
+    cy.contains('This deployment is not hosted at').should('be.visible');
+    cy.get('[data-testid="inference-chart-display"] pattern[id^="logo-pattern-"]').should(
+      'not.exist',
+    );
+  });
+
   it('SVG contains data point circles', () => {
     cy.get('[data-testid="scatter-graph"]')
       .first()

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -231,6 +231,13 @@ describe('TCO Calculator', () => {
       cy.get('[data-testid="calculator-bar-chart"]').should('not.exist');
     });
 
+    it('hides the table logo with the unofficial-domain notice', () => {
+      cy.contains('This deployment is not hosted at').should('be.visible');
+      cy.get('[data-testid="calculator-results-table"] img[src="/brand/logo-color.webp"]').should(
+        'not.exist',
+      );
+    });
+
     it('results table contains expected column headers', () => {
       cy.get('[data-testid="calculator-results-table"]').within(() => {
         cy.get('thead').should('contain.text', 'GPU');

--- a/packages/app/src/components/gpu-specs/scale-up-topology-diagram.tsx
+++ b/packages/app/src/components/gpu-specs/scale-up-topology-diagram.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useSta
 import * as d3 from 'd3';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { track } from '@/lib/analytics';
+import { isUnofficialHostname } from '@/lib/unofficial-domain';
 
 import {
   Dialog,
@@ -264,28 +265,30 @@ function renderSwitchedTopology(
     .attr('role', 'img')
     .attr('aria-label', `${spec.name} ${spec.scaleUpTopology} scale-up topology diagram`);
 
-  // Add background logo watermark
-  const patternId = `logo-scaleup-sw-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
-  svg
-    .append('defs')
-    .append('pattern')
-    .attr('id', patternId)
-    .attr('patternUnits', 'userSpaceOnUse')
-    .attr('width', totalW)
-    .attr('height', viewBoxH)
-    .append('image')
-    .attr('href', '/brand/logo-color.webp')
-    .attr('width', totalW * 0.3)
-    .attr('height', viewBoxH * 0.3)
-    .attr('x', (totalW - totalW * 0.3) / 2)
-    .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
-    .attr('opacity', 0.1);
+  if (!isUnofficialHostname(window.location.hostname)) {
+    // Add background logo watermark
+    const patternId = `logo-scaleup-sw-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
+    svg
+      .append('defs')
+      .append('pattern')
+      .attr('id', patternId)
+      .attr('patternUnits', 'userSpaceOnUse')
+      .attr('width', totalW)
+      .attr('height', viewBoxH)
+      .append('image')
+      .attr('href', '/brand/logo-color.webp')
+      .attr('width', totalW * 0.3)
+      .attr('height', viewBoxH * 0.3)
+      .attr('x', (totalW - totalW * 0.3) / 2)
+      .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
+      .attr('opacity', 0.1);
 
-  svg
-    .insert('rect', ':first-child')
-    .attr('width', totalW)
-    .attr('height', viewBoxH)
-    .attr('fill', `url(#${patternId})`);
+    svg
+      .insert('rect', ':first-child')
+      .attr('width', totalW)
+      .attr('height', viewBoxH)
+      .attr('fill', `url(#${patternId})`);
+  }
 
   // Connections: each GPU → each NVSwitch
   const conns = svg.append('g').attr('class', 'connections');
@@ -417,28 +420,30 @@ function renderMeshTopology(
     .attr('role', 'img')
     .attr('aria-label', `${spec.name} ${spec.scaleUpTopology} scale-up topology diagram`);
 
-  // Add background logo watermark
-  const patternId = `logo-scaleup-mesh-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
-  svg
-    .append('defs')
-    .append('pattern')
-    .attr('id', patternId)
-    .attr('patternUnits', 'userSpaceOnUse')
-    .attr('width', totalW)
-    .attr('height', totalH)
-    .append('image')
-    .attr('href', '/brand/logo-color.webp')
-    .attr('width', totalW * 0.3)
-    .attr('height', totalH * 0.3)
-    .attr('x', (totalW - totalW * 0.3) / 2)
-    .attr('y', (totalH - totalH * 0.3) / 2)
-    .attr('opacity', 0.1);
+  if (!isUnofficialHostname(window.location.hostname)) {
+    // Add background logo watermark
+    const patternId = `logo-scaleup-mesh-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
+    svg
+      .append('defs')
+      .append('pattern')
+      .attr('id', patternId)
+      .attr('patternUnits', 'userSpaceOnUse')
+      .attr('width', totalW)
+      .attr('height', totalH)
+      .append('image')
+      .attr('href', '/brand/logo-color.webp')
+      .attr('width', totalW * 0.3)
+      .attr('height', totalH * 0.3)
+      .attr('x', (totalW - totalW * 0.3) / 2)
+      .attr('y', (totalH - totalH * 0.3) / 2)
+      .attr('opacity', 0.1);
 
-  svg
-    .insert('rect', ':first-child')
-    .attr('width', totalW)
-    .attr('height', totalH)
-    .attr('fill', `url(#${patternId})`);
+    svg
+      .insert('rect', ':first-child')
+      .attr('width', totalW)
+      .attr('height', totalH)
+      .attr('fill', `url(#${patternId})`);
+  }
 
   // Mesh connections
   const meshConns = svg.append('g').attr('class', 'mesh-connections');
@@ -585,28 +590,30 @@ function renderSwitchedNvl72Topology(
     .attr('role', 'img')
     .attr('aria-label', `${spec.name} ${spec.scaleUpTopology} scale-up topology diagram`);
 
-  // Add background logo watermark
-  const patternId = `logo-scaleup-nvl72-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
-  svg
-    .append('defs')
-    .append('pattern')
-    .attr('id', patternId)
-    .attr('patternUnits', 'userSpaceOnUse')
-    .attr('width', totalW)
-    .attr('height', viewBoxH)
-    .append('image')
-    .attr('href', '/brand/logo-color.webp')
-    .attr('width', totalW * 0.3)
-    .attr('height', viewBoxH * 0.3)
-    .attr('x', (totalW - totalW * 0.3) / 2)
-    .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
-    .attr('opacity', 0.1);
+  if (!isUnofficialHostname(window.location.hostname)) {
+    // Add background logo watermark
+    const patternId = `logo-scaleup-nvl72-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
+    svg
+      .append('defs')
+      .append('pattern')
+      .attr('id', patternId)
+      .attr('patternUnits', 'userSpaceOnUse')
+      .attr('width', totalW)
+      .attr('height', viewBoxH)
+      .append('image')
+      .attr('href', '/brand/logo-color.webp')
+      .attr('width', totalW * 0.3)
+      .attr('height', viewBoxH * 0.3)
+      .attr('x', (totalW - totalW * 0.3) / 2)
+      .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
+      .attr('opacity', 0.1);
 
-  svg
-    .insert('rect', ':first-child')
-    .attr('width', totalW)
-    .attr('height', viewBoxH)
-    .attr('fill', `url(#${patternId})`);
+    svg
+      .insert('rect', ':first-child')
+      .attr('width', totalW)
+      .attr('height', viewBoxH)
+      .attr('fill', `url(#${patternId})`);
+  }
 
   // Connections: each GPU → each visible NVSwitch
   const gpuSwConns = svg.append('g').attr('class', 'gpu-switch-connections');

--- a/packages/app/src/components/gpu-specs/topology-diagram.tsx
+++ b/packages/app/src/components/gpu-specs/topology-diagram.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useSta
 import * as d3 from 'd3';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { track } from '@/lib/analytics';
+import { isUnofficialHostname } from '@/lib/unofficial-domain';
 
 import {
   Dialog,
@@ -407,28 +408,30 @@ function TopologyD3({ spec, config, compact }: TopologyD3Props) {
       .attr('role', 'img')
       .attr('aria-label', `${spec.name} ${spec.scaleOutTopology} scale-out topology diagram`);
 
-    // Add background logo watermark
-    const patternId = `logo-scaleout-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
-    svg
-      .append('defs')
-      .append('pattern')
-      .attr('id', patternId)
-      .attr('patternUnits', 'userSpaceOnUse')
-      .attr('width', totalW)
-      .attr('height', viewBoxH)
-      .append('image')
-      .attr('href', '/brand/logo-color.webp')
-      .attr('width', totalW * 0.3)
-      .attr('height', viewBoxH * 0.3)
-      .attr('x', (totalW - totalW * 0.3) / 2)
-      .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
-      .attr('opacity', 0.1);
+    if (!isUnofficialHostname(window.location.hostname)) {
+      // Add background logo watermark
+      const patternId = `logo-scaleout-${spec.name.replaceAll(/\s+/gu, '-')}-${compact ? 'c' : 'e'}`;
+      svg
+        .append('defs')
+        .append('pattern')
+        .attr('id', patternId)
+        .attr('patternUnits', 'userSpaceOnUse')
+        .attr('width', totalW)
+        .attr('height', viewBoxH)
+        .append('image')
+        .attr('href', '/brand/logo-color.webp')
+        .attr('width', totalW * 0.3)
+        .attr('height', viewBoxH * 0.3)
+        .attr('x', (totalW - totalW * 0.3) / 2)
+        .attr('y', (viewBoxH - viewBoxH * 0.3) / 2)
+        .attr('opacity', 0.1);
 
-    svg
-      .insert('rect', ':first-child')
-      .attr('width', totalW)
-      .attr('height', viewBoxH)
-      .attr('fill', `url(#${patternId})`);
+      svg
+        .insert('rect', ':first-child')
+        .attr('width', totalW)
+        .attr('height', viewBoxH)
+        .attr('fill', `url(#${patternId})`);
+    }
 
     // === Connections (drawn first, behind boxes) ===
 

--- a/packages/app/src/components/ui/data-table.test.tsx
+++ b/packages/app/src/components/ui/data-table.test.tsx
@@ -1,0 +1,22 @@
+import { renderToString } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DataTable } from './data-table';
+
+vi.mock('@/lib/use-locale', () => ({
+  useLocale: () => 'en',
+}));
+
+describe('DataTable watermark', () => {
+  it('omits branded markup until the client confirms the official hostname', () => {
+    const html = renderToString(
+      <DataTable
+        data={[{ name: 'H100 SXM' }]}
+        columns={[{ header: 'GPU', cell: (row) => row.name }]}
+      />,
+    );
+
+    expect(html).toContain('H100 SXM');
+    expect(html).not.toContain('/brand/logo-color.webp');
+  });
+});

--- a/packages/app/src/components/ui/data-table.tsx
+++ b/packages/app/src/components/ui/data-table.tsx
@@ -205,7 +205,7 @@ export function DataTable<T>({
       </div>
 
       <div className="overflow-x-auto relative">
-        {watermark && !isUnofficialDomain && (
+        {watermark && isUnofficialDomain === false && (
           <div
             className="absolute inset-0 pointer-events-none flex items-center justify-center"
             aria-hidden="true"

--- a/packages/app/src/components/ui/data-table.tsx
+++ b/packages/app/src/components/ui/data-table.tsx
@@ -11,6 +11,7 @@ import {
   X,
 } from 'lucide-react';
 
+import { useUnofficialDomain } from '@/hooks/useUnofficialDomain';
 import { track } from '@/lib/analytics';
 import { useLocale } from '@/lib/use-locale';
 import {
@@ -106,6 +107,7 @@ export function DataTable<T>({
 }: DataTableProps<T>) {
   const locale = useLocale();
   const t = STRINGS[locale];
+  const isUnofficialDomain = useUnofficialDomain();
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState<number>(10);
   const [sort, setSort] = useState<SortState>({ columnIndex: -1, dir: null });
@@ -203,7 +205,7 @@ export function DataTable<T>({
       </div>
 
       <div className="overflow-x-auto relative">
-        {watermark && (
+        {watermark && !isUnofficialDomain && (
           <div
             className="absolute inset-0 pointer-events-none flex items-center justify-center"
             aria-hidden="true"

--- a/packages/app/src/components/ui/unofficial-domain-notice.tsx
+++ b/packages/app/src/components/ui/unofficial-domain-notice.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useUnofficialDomain } from '@/hooks/useUnofficialDomain';
 
 import { SITE_URL } from '@semianalysisai/inferencex-constants';
 import { useLocale } from '@/lib/use-locale';
-
-const OFFICIAL_HOSTNAME = new URL(SITE_URL).hostname;
+import { OFFICIAL_HOSTNAME } from '@/lib/unofficial-domain';
 
 const STRINGS = {
   en: {
@@ -21,12 +20,8 @@ const STRINGS = {
 } as const;
 
 export function UnofficialDomainNotice() {
-  const [isUnofficial, setIsUnofficial] = useState(false);
+  const isUnofficial = useUnofficialDomain();
   const t = STRINGS[useLocale()];
-
-  useEffect(() => {
-    setIsUnofficial(window.location.hostname !== OFFICIAL_HOSTNAME);
-  }, []);
 
   if (!isUnofficial) return null;
 

--- a/packages/app/src/hooks/useUnofficialDomain.ts
+++ b/packages/app/src/hooks/useUnofficialDomain.ts
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react';
 
 import { isUnofficialHostname } from '@/lib/unofficial-domain';
 
-export function useUnofficialDomain(): boolean {
-  const [isUnofficial, setIsUnofficial] = useState(false);
+export function useUnofficialDomain(): boolean | null {
+  const [isUnofficial, setIsUnofficial] = useState<boolean | null>(null);
 
   useEffect(() => {
     setIsUnofficial(isUnofficialHostname(window.location.hostname));

--- a/packages/app/src/hooks/useUnofficialDomain.ts
+++ b/packages/app/src/hooks/useUnofficialDomain.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { isUnofficialHostname } from '@/lib/unofficial-domain';
+
+export function useUnofficialDomain(): boolean {
+  const [isUnofficial, setIsUnofficial] = useState(false);
+
+  useEffect(() => {
+    setIsUnofficial(isUnofficialHostname(window.location.hostname));
+  }, []);
+
+  return isUnofficial;
+}

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useRef } from 'react';
 import * as d3 from 'd3';
+import { getDomainAwareChartWatermark } from '@/lib/unofficial-domain';
 
 import { computeTooltipPosition } from '../layers/scatter-points';
 import { setupChartStructure } from '../chart-setup';
@@ -139,7 +140,7 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
         containerWidth: dimensions.width,
         containerHeight: dimensions.height,
         margin,
-        watermark,
+        watermark: getDomainAwareChartWatermark(watermark, window.location.hostname),
         xLabel: xAxisConfig?.label,
         yLabel: yAxisConfig?.label,
         clipContent,

--- a/packages/app/src/lib/unofficial-domain.test.ts
+++ b/packages/app/src/lib/unofficial-domain.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getDomainAwareChartWatermark,
+  isUnofficialHostname,
+  OFFICIAL_HOSTNAME,
+} from './unofficial-domain';
+
+describe('unofficial domain branding', () => {
+  it('keeps the logo watermark on the official hostname', () => {
+    expect(isUnofficialHostname(OFFICIAL_HOSTNAME)).toBe(false);
+    expect(getDomainAwareChartWatermark('logo', OFFICIAL_HOSTNAME)).toBe('logo');
+  });
+
+  it('removes the logo watermark wherever the domain notice applies', () => {
+    expect(isUnofficialHostname('localhost')).toBe(true);
+    expect(getDomainAwareChartWatermark('logo', 'localhost')).toBe('none');
+  });
+
+  it('preserves non-logo watermark modes on unofficial domains', () => {
+    expect(getDomainAwareChartWatermark('unofficial', 'preview.example.com')).toBe('unofficial');
+    expect(getDomainAwareChartWatermark('none', 'preview.example.com')).toBe('none');
+  });
+});

--- a/packages/app/src/lib/unofficial-domain.ts
+++ b/packages/app/src/lib/unofficial-domain.ts
@@ -1,0 +1,16 @@
+import { SITE_URL } from '@semianalysisai/inferencex-constants';
+
+export const OFFICIAL_HOSTNAME = new URL(SITE_URL).hostname;
+
+type ChartWatermark = 'logo' | 'unofficial' | 'none';
+
+export function isUnofficialHostname(hostname: string): boolean {
+  return hostname !== OFFICIAL_HOSTNAME;
+}
+
+export function getDomainAwareChartWatermark(
+  watermark: ChartWatermark,
+  hostname: string,
+): ChartWatermark {
+  return watermark === 'logo' && isUnofficialHostname(hostname) ? 'none' : watermark;
+}


### PR DESCRIPTION
## Summary

- Use one official-hostname policy for the domain notice and branded chart surfaces.
- Hide the SemiAnalysis logo watermark on unofficial domains across shared D3 charts, shared data tables, and custom GPU topology diagrams.
- Preserve the separate red unofficial-run warning watermark.

## Overlay support

Works for both official runs and `?unofficialrun=` overlays. The red unofficial-run watermark remains visible on unofficial domains and was verified with `unofficial-watermark.cy.ts`.

## Verification

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `env DATABASE_DRIVER= DATABASE_SSL= bun run test:unit`, 3,274 tests passed
- Full Cypress component suite, 190 tests passed
- Cypress integration suite, 534 of 535 tests passed. The unchanged `overview.cy.ts` typography assertion is 1.5 px outside its 1 px local tolerance and also failed when rerun alone.
- Browser smoke checks confirmed the warning rendered with zero logo patterns across inference charts, calculator tables, and 16 GPU topology SVGs.

## 中文说明

- 统一使用官方 hostname 判断逻辑，确保域名提示与品牌水印行为一致。
- 在非官方域名下隐藏共享 D3 图表、共享数据表格及 GPU 拓扑图中的 SemiAnalysis Logo 水印。
- 保留独立的红色非官方运行警告水印。

### 非官方运行覆盖

同时支持官方运行和 `?unofficialrun=` 叠加数据。已通过 `unofficial-watermark.cy.ts` 验证，非官方域名下仍会显示红色非官方运行警告水印。

### 验证结果

- lint、格式检查和 TypeScript 类型检查通过。
- 单元测试共 3,274 项，全部通过。
- Cypress 组件测试共 190 项，全部通过。
- Cypress 集成测试 535 项中 534 项通过。未修改的 `overview.cy.ts` 排版断言在本地超出 1 px 容差 1.5 px，单独重跑仍失败。
- 浏览器冒烟检查确认域名提示正常显示，推理图表、计算器表格及 16 个 GPU 拓扑 SVG 中均无 Logo 水印。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Branding and presentation-only changes with centralized hostname checks; no auth, data, or API behavior changes.
> 
> **Overview**
> Introduces a shared **official hostname** policy (`unofficial-domain` + `useUnofficialDomain`) and uses it for the unofficial-domain notice and branded surfaces.
> 
> On non-official hosts, **SemiAnalysis logo watermarks** are suppressed in shared D3 charts (`getDomainAwareChartWatermark`), `DataTable` (watermark only when `isUnofficialDomain === false`), and GPU scale-out/scale-up topology SVGs (`isUnofficialHostname`). The separate **`unofficial` chart watermark** mode is unchanged.
> 
> Cypress specs flip from asserting logo patterns to asserting they are absent alongside the deployment notice; unit tests cover hostname helpers and SSR-safe `DataTable` markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ededccbdacd8a0b779daf411d6fbb2cedd5e1af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->