### PR TITLE
Fix DeepSeek V4 agentic calculator support / 修复 DeepSeek V4 智能体计算器支持

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -102,4 +102,22 @@ The reset's early-out guards on the **merged** list, not the official one. An em
 - **Clamped values.** `interpolateForGPU` clamps the target into each series' measured range and always returns a value, so a bar can be showing its nearest edge point rather than an interpolation. This is pre-existing across GPUs with different ranges, but widening the slider to cover overlay operating points makes it reachable for every official bar at once — which would turn a side-by-side overlay delta into a real-vs-clamped comparison. Results carry a `clamped` flag and the tooltip says so. (Narrowing the slider back is not the fix: it only moves the clamping onto the overlay bars, and an overlay-only model loses its bounds entirely.)
 - **Escaping.** The tooltip is a hand-built HTML string injected with `.html()`, and branch names and run URLs come from the GitHub API for whatever run id the user pasted. Everything untrusted goes through `escapeHtml` (`lib/utils`). The y-axis tick labels render the same branch but go through d3 `.text()`, and the legend entry is React — both already safe.
 
-Note the calculator only supports fixed-sequence data (`sequenceToIslOsl`: 1k/1k, 1k/8k, 8k/1k). Agentic-traces rows carry null isl/osl and are invisible here for official and unofficial data alike. E2E fixtures therefore use `singleTurnRows` from `cypress/support/overlay-fixtures.ts`, not the agentic `b300Rows` the inference specs use.
+The calculator supports both fixed-sequence and Agentic Traces scenarios through
+the shared `rowToSequence` classifier. Agentic rows carry null `isl`/`osl`, so
+filtering them by numeric sequence lengths would silently drop every point.
+
+Agentic interactivity follows the same definition as the main inference chart:
+
+- P90 by default, with P75 selectable and shareable through `i_pctl`
+- interactivity derived as `1 / ITL`, never trusted from a potentially stale
+  artifact-supplied `*_intvty` field
+- interpolation seeded only by points that also win on the selected
+  percentile's end-to-end-latency Pareto frontier, preventing a configuration
+  from winning the calculator by improving interactivity while degrading the
+  full session
+- official and unofficial-run agentic frontiers remain separate, just like
+  their fixed-sequence counterparts
+
+`b300Rows` in `cypress/support/overlay-fixtures.ts` covers the agentic calculator
+path; `singleTurnRows` remains the fixture for fixed-sequence visibility and
+sequence-switching behavior.

--- a/packages/app/cypress/e2e/calculator-overlay.cy.ts
+++ b/packages/app/cypress/e2e/calculator-overlay.cy.ts
@@ -7,12 +7,13 @@
  * official-only by design — mixing unmerged-branch numbers into an exported
  * sheet or a fleet projection would be silently misleading.
  *
- * Fixtures are fixed-sequence (1k/1k): the calculator resolves the selected
- * sequence through `sequenceToIslOsl` and filters rows on isl/osl, so the
- * agentic overlay fixtures used by the inference specs never reach it.
+ * Most fixtures are fixed-sequence (1k/1k) to cover sequence switching and
+ * overlay-only hardware. A dedicated agentic case verifies trace-replay rows
+ * follow the same separate-frontier overlay path.
  */
 import {
   ALT_SEQUENCE_LABEL,
+  interceptOverlayRun,
   interceptCalculatorMultiRunOverlay,
   interceptCalculatorOverlayRun,
   OVERLAY_ONLY_HARDWARE,
@@ -55,6 +56,30 @@ const visitCalculatorWithOverlay = () => {
 };
 
 describe('TCO calculator — unofficial run overlay', () => {
+  describe('agentic trace overlay', () => {
+    it('renders official and unofficial DeepSeek V4 agentic calculations separately', () => {
+      interceptOverlayRun();
+      cy.visit(
+        `/calculator?unofficialrun=${OVERLAY_RUN_ID}&i_seq=${encodeURIComponent(
+          'agentic-traces',
+        )}&i_prec=fp4`,
+        {
+          onBeforeLoad(win) {
+            win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+          },
+        },
+      );
+      cy.wait('@unofficialRun');
+
+      cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+      cy.get(BARS).should('have.length', 2);
+      cy.get(Y_TICKS).should('contain.text', OVERLAY_RUN_BRANCH);
+      cy.get('[data-testid="calculator-chart-section"] h2')
+        .first()
+        .should('contain.text', 'P90 Interactivity');
+    });
+  });
+
   describe('rendering', () => {
     before(visitCalculatorWithOverlay);
 

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -1,3 +1,8 @@
+import {
+  availability as agenticAvailability,
+  b300Rows as agenticB300Rows,
+} from '../support/overlay-fixtures';
+
 describe('TCO Calculator', () => {
   // ---------------------------------------------------------------------------
   // Tab navigation (must start from /inference to test tab switching)
@@ -544,6 +549,58 @@ describe('TCO Calculator', () => {
       });
       cy.visit('/calculator?g_model=DeepSeek-V4-Pro');
       cy.get('[data-testid="calc-model-selector"]').should('contain.text', 'DeepSeek V4 Pro 1.6T');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // DeepSeek V4 agentic trace calculations
+  // ---------------------------------------------------------------------------
+
+  describe('DeepSeek V4 agentic calculations', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as(
+        'agenticAvailability',
+      );
+      cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticB300Rows(null) }).as(
+        'agenticBenchmarks',
+      );
+      cy.visit('/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        },
+      });
+      cy.wait('@agenticBenchmarks');
+    });
+
+    it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Traces');
+      cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+      cy.get('[data-testid="calculator-no-data"]').should('not.exist');
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+      cy.get('[data-testid="calculator-chart-section"] h2')
+        .first()
+        .should('contain.text', 'P90 Interactivity');
+
+      cy.get('[data-testid="calculator-metric-cost"]').click();
+      cy.get('[data-testid="calculator-bar-chart"] svg .value-label')
+        .first()
+        .should('contain.text', '$');
+    });
+
+    it('recalculates agentic results at P75 and includes it in the share link', () => {
+      cy.get('[data-testid="calc-percentile-selector"]').click();
+      cy.get('[role="option"]').contains('p75').click();
+
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+      cy.get('[data-testid="calculator-chart-section"] h2')
+        .first()
+        .should('contain.text', 'P75 Interactivity');
+      cy.get('[data-testid="calculator-controls"]').should(
+        'contain.text',
+        'Target P75 Interactivity',
+      );
+      cy.get('[data-testid="share-button"]').click();
+      cy.get('[data-testid="share-url-input"]').invoke('val').should('include', 'i_pctl=p75');
     });
   });
 

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -558,10 +558,18 @@ describe('TCO Calculator', () => {
 
   describe('DeepSeek V4 agentic calculations', () => {
     beforeEach(() => {
-      cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as(
-        'agenticAvailability',
-      );
-      cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticB300Rows(null) }).as(
+      const b300Rows = agenticB300Rows(null);
+      const b200Rows = agenticB300Rows(null).map((row) => ({
+        ...row,
+        hardware: 'b200',
+      }));
+      cy.intercept('GET', '/api/v1/availability', {
+        body: [
+          ...agenticAvailability,
+          ...agenticAvailability.map((row) => ({ ...row, hardware: 'b200' })),
+        ],
+      }).as('agenticAvailability');
+      cy.intercept('GET', '/api/v1/benchmarks*', { body: [...b300Rows, ...b200Rows] }).as(
         'agenticBenchmarks',
       );
       cy.visit('/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
@@ -576,7 +584,7 @@ describe('TCO Calculator', () => {
       cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Traces');
       cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
-      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()
         .should('contain.text', 'P90 Interactivity');
@@ -591,7 +599,7 @@ describe('TCO Calculator', () => {
       cy.get('[data-testid="calc-percentile-selector"]').click();
       cy.get('[role="option"]').contains('p75').click();
 
-      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()
         .should('contain.text', 'P75 Interactivity');
@@ -601,6 +609,21 @@ describe('TCO Calculator', () => {
       );
       cy.get('[data-testid="share-button"]').click();
       cy.get('[data-testid="share-url-input"]').invoke('val').should('include', 'i_pctl=p75');
+    });
+
+    it('preserves a soloed GPU when the agentic percentile changes', () => {
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
+
+      cy.get('.sidebar-legend label').first().click();
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+
+      cy.get('[data-testid="calc-percentile-selector"]').click();
+      cy.get('[role="option"]').contains('p75').click();
+
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 1);
+      cy.get('[data-testid="calculator-chart-section"] h2')
+        .first()
+        .should('contain.text', 'P75 Interactivity');
     });
   });
 

--- a/packages/app/cypress/support/overlay-fixtures.ts
+++ b/packages/app/cypress/support/overlay-fixtures.ts
@@ -24,9 +24,11 @@ export const REAL_CONFIGS: [number, number, number, number][] = [
 export const metricsFor = (intvty: number, tput: number, e2el: number): Record<string, number> => ({
   // intvty is ALWAYS derived as 1/itl by the agentic aliases — feed itl.
   median_itl: 1 / (intvty * 1.2),
+  p75_itl: 1 / (intvty * 1.1),
   p90_itl: 1 / intvty,
   p99_itl: 1 / (intvty * 0.8),
   median_e2el: e2el * 0.8,
+  p75_e2el: e2el * 0.9,
   p90_e2el: e2el,
   p99_e2el: e2el * 1.3,
   median_ttft: 0.5,
@@ -108,13 +110,12 @@ export const countVisible = ($els: JQuery<HTMLElement>): number =>
   [...$els].filter((el) => getComputedStyle(el).opacity !== '0').length;
 
 // ---------------------------------------------------------------------------
-// Single-turn (fixed-sequence) overlay fixtures — for the TCO calculator
+// Single-turn (fixed-sequence) overlay fixtures — for fixed-sequence calculator specs
 // ---------------------------------------------------------------------------
 //
-// The agentic rows above are invisible to the calculator: it resolves the
-// selected sequence through `sequenceToIslOsl`, which only maps 1k/1k, 1k/8k
-// and 8k/1k, then filters rows on `row.isl`/`row.osl`. Agentic rows carry
-// null isl/osl, so they never match. Calculator specs need fixed-sequence rows.
+// The calculator supports the agentic rows above as well. These fixtures remain
+// useful for fixed-sequence coverage and for hardware/sequence combinations
+// tailored to the calculator overlay visibility tests.
 
 export const SINGLE_TURN_DATE = '2026-07-19';
 export const SINGLE_TURN_ISL = 1024;

--- a/packages/app/src/components/calculator/ThroughputBarChart.test.ts
+++ b/packages/app/src/components/calculator/ThroughputBarChart.test.ts
@@ -333,6 +333,18 @@ describe('getChartTitle', () => {
     expect(title).toBe('Total Token Throughput per GPU at 30 tok/s/user Interactivity');
   });
 
+  it('includes the selected percentile in an agentic interactivity title', () => {
+    const title = getChartTitle(
+      'throughput',
+      'interactivity_to_throughput',
+      30,
+      'total',
+      undefined,
+      'p90',
+    );
+    expect(title).toBe('Total Token Throughput per GPU at 30 tok/s/user P90 Interactivity');
+  });
+
   it('returns input throughput title when costType is input', () => {
     const title = getChartTitle('throughput', 'interactivity_to_throughput', 30, 'input');
     expect(title).toBe('Input Token Throughput per GPU at 30 tok/s/user Interactivity');

--- a/packages/app/src/components/calculator/ThroughputBarChart.tsx
+++ b/packages/app/src/components/calculator/ThroughputBarChart.tsx
@@ -161,10 +161,14 @@ export function getChartTitle(
   targetValue: number,
   costType: CostType,
   costProvider?: CostProvider,
+  interactivityPercentile?: string,
 ): string {
+  const percentilePrefix = interactivityPercentile
+    ? `${interactivityPercentile.toUpperCase()} `
+    : '';
   const targetLabel =
     mode === 'interactivity_to_throughput'
-      ? `${targetValue} tok/s/user Interactivity`
+      ? `${targetValue} tok/s/user ${percentilePrefix}Interactivity`
       : `${targetValue} tok/s/gpu Throughput`;
 
   const tokenTypeLabel =

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -389,13 +389,13 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   // selection itself PLUS the official hardware list — the selection so an
   // overlay-only model/sequence (where the official list is empty and stays
   // empty) still reseeds, the official list so anything else that changes which
-  // GPUs have data still reseeds. Deliberately NOT keyed on the merged list: an
-  // unofficial run is fetched separately and usually lands after the
-  // benchmarks, so a late arrival — or a run dismissal — would otherwise wipe
-  // GPU filters the user had already set.
-  const selectionKey = `${selectedModel}|${selectedSequence}|${selectedPercentile}|${[
-    ...selectedPrecisions,
-  ]
+  // GPUs have data still reseeds. Percentile is deliberately excluded: it
+  // recalculates agentic values, but should preserve the user's GPU filters
+  // whenever the available hardware set is unchanged. Also deliberately NOT
+  // keyed on the merged list: an unofficial run is fetched separately and
+  // usually lands after the benchmarks, so a late arrival — or a run dismissal
+  // — would otherwise wipe GPU filters the user had already set.
+  const selectionKey = `${selectedModel}|${selectedSequence}|${[...selectedPrecisions]
     .toSorted()
     .join(',')}|${selectedRunDate}|${[...availableHwKeys].toSorted().join(',')}`;
   useEffect(() => {

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -17,8 +17,9 @@ import ChartLegend from '@/components/ui/chart-legend';
 import { ChartShareActions } from '@/components/ui/chart-display-helpers';
 import {
   ModelSelector,
-  SequenceSelector,
+  PercentileSelector,
   PrecisionSelector,
+  ScenarioSelector,
 } from '@/components/ui/chart-selectors';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { Input } from '@/components/ui/input';
@@ -31,9 +32,10 @@ import { MultiSelect } from '@/components/ui/multi-select';
 import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/segmented-toggle';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
+  Percentile,
+  Sequence,
   type Model,
   type Precision,
-  type Sequence,
   getModelLabel,
   getPrecisionLabel,
   getSequenceLabel,
@@ -41,6 +43,7 @@ import {
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { useUrlState } from '@/hooks/useUrlState';
 
 import { getDisplayLabel } from '@/lib/utils';
 import { exportToCsv } from '@/lib/csv-export';
@@ -119,6 +122,9 @@ const STRINGS = {
     targetLabel: 'Target Interactivity (tok/s/user)',
     targetTooltip:
       'The interactivity operating point used for interpolation. Adjust the slider to compare GPU throughput, cost, and power efficiency at different interactivity levels.',
+    targetAgenticLabel: (percentile: string) => `Target ${percentile} Interactivity (tok/s/user)`,
+    targetAgenticTooltip: (percentile: string) =>
+      `The ${percentile} interactivity operating point used for agentic trace interpolation. Adjust the slider to compare GPU throughput, cost, and power efficiency.`,
     metricThroughput: 'Throughput',
     metricCost: 'Cost',
     viewChart: 'Chart',
@@ -165,6 +171,9 @@ const STRINGS = {
     targetLabel: '目标交互性 (tok/s/user)',
     targetTooltip:
       '用于插值的交互性操作点。调整滑块以比较不同交互性级别下 GPU 的吞吐量、成本和能效。',
+    targetAgenticLabel: (percentile: string) => `目标 ${percentile} 交互性 (tok/s/user)`,
+    targetAgenticTooltip: (percentile: string) =>
+      `用于智能体轨迹插值的 ${percentile} 交互性操作点。调整滑块以比较 GPU 的吞吐量、成本和能效。`,
     metricThroughput: '吞吐量',
     metricCost: '成本',
     viewChart: '图表',
@@ -202,10 +211,14 @@ function getChartTitleZh(
   targetValue: number,
   costType: CostType,
   costProvider?: CostProvider,
+  interactivityPercentile?: string,
 ): string {
+  const percentilePrefix = interactivityPercentile
+    ? `${interactivityPercentile.toUpperCase()} `
+    : '';
   const targetLabel =
     mode === 'interactivity_to_throughput'
-      ? `${targetValue} tok/s/user 交互性`
+      ? `${targetValue} tok/s/user ${percentilePrefix}交互性`
       : `${targetValue} tok/s/gpu 吞吐量`;
   const tokenTypeLabel = costType === 'input' ? '输入' : costType === 'output' ? '输出' : '总';
   switch (barMetric) {
@@ -225,6 +238,9 @@ function getChartTitleZh(
 }
 
 export default function ThroughputCalculatorDisplay({ urlSeed }: { urlSeed?: CalculatorUrlSeed }) {
+  const inner = (
+    <ThroughputCalculatorInner initialPercentile={urlSeed?.percentile ?? Percentile.P90} />
+  );
   if (urlSeed && (urlSeed.model || urlSeed.sequence || urlSeed.precisions)) {
     return (
       <GlobalFilterProvider
@@ -232,16 +248,17 @@ export default function ThroughputCalculatorDisplay({ urlSeed }: { urlSeed?: Cal
         initialSequence={urlSeed.sequence}
         initialPrecisions={urlSeed.precisions}
       >
-        <ThroughputCalculatorInner />
+        {inner}
       </GlobalFilterProvider>
     );
   }
-  return <ThroughputCalculatorInner />;
+  return inner;
 }
 
-function ThroughputCalculatorInner() {
+function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: Percentile }) {
   const locale = useLocale();
   const t = STRINGS[locale];
+  const { setUrlParam } = useUrlState();
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const handleDropdownOpenChange = (dropdownKey: string) => (isOpen: boolean) => {
     if (isOpen) {
@@ -271,6 +288,7 @@ function ThroughputCalculatorInner() {
   const [targetValue, setTargetValue] = useState<number>(35);
   const [inputValue, setInputValue] = useState<string>('35');
   const [barMetric, setBarMetric] = useState<BarMetric>('throughput');
+  const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
   const [visibleHwKeys, setVisibleHwKeys] = useState<Set<string>>(new Set());
   const [selectedBars, setSelectedBars] = useState<Set<string>>(new Set());
   const [isLegendExpanded, setIsLegendExpanded] = useState(true);
@@ -324,7 +342,11 @@ function ThroughputCalculatorInner() {
     selectedPrecisions,
     selectedRunDate,
     overlayInput,
+    selectedPercentile,
   );
+
+  const isAgenticSequence = selectedSequence === Sequence.AgenticTraces;
+  const percentileLabel = selectedPercentile.toUpperCase();
 
   /**
    * Hardware listed in the legend: official hardware, plus hardware that only
@@ -371,7 +393,9 @@ function ThroughputCalculatorInner() {
   // unofficial run is fetched separately and usually lands after the
   // benchmarks, so a late arrival — or a run dismissal — would otherwise wipe
   // GPU filters the user had already set.
-  const selectionKey = `${selectedModel}|${selectedSequence}|${[...selectedPrecisions]
+  const selectionKey = `${selectedModel}|${selectedSequence}|${selectedPercentile}|${[
+    ...selectedPrecisions,
+  ]
     .toSorted()
     .join(',')}|${selectedRunDate}|${[...availableHwKeys].toSorted().join(',')}`;
   useEffect(() => {
@@ -528,6 +552,15 @@ function ThroughputCalculatorInner() {
       track('calculator_precision_selected', { precision: value.join(',') });
     },
     [setSelectedPrecisions],
+  );
+
+  const handlePercentileChange = useCallback(
+    (value: Percentile) => {
+      setSelectedPercentile(value);
+      setUrlParam('i_pctl', value);
+      track('calculator_percentile_selected', { percentile: value });
+    },
+    [setUrlParam],
   );
 
   const handleBarMetricChange = useCallback((value: BarMetric) => {
@@ -781,7 +814,11 @@ function ThroughputCalculatorInner() {
 
             {/* Controls — grid layout matching inference chart controls */}
             <TooltipProvider delayDuration={0}>
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-4">
+              <div
+                className={`grid grid-cols-1 md:grid-cols-2 gap-4 ${
+                  isAgenticSequence ? 'lg:grid-cols-7' : 'lg:grid-cols-6'
+                }`}
+              >
                 <ModelSelector
                   id="calc-model"
                   data-testid="calc-model-selector"
@@ -791,7 +828,7 @@ function ThroughputCalculatorInner() {
                   onOpenChange={handleDropdownOpenChange('model')}
                   availableModels={availableModels}
                 />
-                <SequenceSelector
+                <ScenarioSelector
                   id="calc-sequence"
                   data-testid="calc-sequence-selector"
                   value={selectedSequence}
@@ -800,6 +837,14 @@ function ThroughputCalculatorInner() {
                   onOpenChange={handleDropdownOpenChange('sequence')}
                   availableSequences={availableSequences}
                 />
+                {isAgenticSequence && (
+                  <PercentileSelector
+                    id="calc-percentile"
+                    data-testid="calc-percentile-selector"
+                    value={selectedPercentile}
+                    onChange={handlePercentileChange}
+                  />
+                )}
                 <PrecisionSelector
                   id="calc-precision"
                   data-testid="calc-precision-selector"
@@ -908,8 +953,12 @@ function ThroughputCalculatorInner() {
                 <div className="space-y-2">
                   <LabelWithTooltip
                     htmlFor="calc-target"
-                    label={t.targetLabel}
-                    tooltip={t.targetTooltip}
+                    label={
+                      isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
+                    }
+                    tooltip={
+                      isAgenticSequence ? t.targetAgenticTooltip(percentileLabel) : t.targetTooltip
+                    }
                   />
                   <div className="flex items-center gap-4">
                     <div className="flex-1">
@@ -996,8 +1045,22 @@ function ThroughputCalculatorInner() {
                       <div className="flex items-start justify-between gap-4">
                         <h2 className="text-lg font-semibold">
                           {locale === 'zh'
-                            ? getChartTitleZh(barMetric, mode, targetValue, costType, costProvider)
-                            : getChartTitle(barMetric, mode, targetValue, costType, costProvider)}
+                            ? getChartTitleZh(
+                                barMetric,
+                                mode,
+                                targetValue,
+                                costType,
+                                costProvider,
+                                isAgenticSequence ? selectedPercentile : undefined,
+                              )
+                            : getChartTitle(
+                                barMetric,
+                                mode,
+                                targetValue,
+                                costType,
+                                costProvider,
+                                isAgenticSequence ? selectedPercentile : undefined,
+                              )}
                         </h2>
                         <SegmentedToggle
                           value={viewMode}
@@ -1012,7 +1075,8 @@ function ThroughputCalculatorInner() {
                         {selectedPrecisions
                           .map((p) => getPrecisionLabel(p as Precision))
                           .join(', ')}{' '}
-                        • {getSequenceLabel(selectedSequence)} • {t.source}SemiAnalysis InferenceX™
+                        • {getSequenceLabel(selectedSequence, locale)} • {t.source}SemiAnalysis
+                        InferenceX™
                         {selectedRunDate && (
                           <>
                             {t.updated}

--- a/packages/app/src/components/calculator/types.ts
+++ b/packages/app/src/components/calculator/types.ts
@@ -9,6 +9,14 @@ export type BarMetric = 'throughput' | 'power' | 'cost';
 export interface GPUDataPoint {
   hwKey: string;
   interactivity: number; // tokens/sec/user (median_intvty = x in interactivity chart)
+  /**
+   * End-to-end latency at the selected percentile. Agentic calculator groups
+   * use this to keep only the same anti-benchmark-hacking Pareto winners as the
+   * main interactivity chart before interpolation.
+   */
+  e2eLatency?: number;
+  /** Run date used to keep agentic end-to-end frontiers date-scoped. */
+  date?: string;
   throughput: number; // tokens/sec/gpu total (tput_per_gpu = y in interactivity chart)
   outputThroughput: number; // output tokens/sec/gpu
   inputThroughput: number; // input tokens/sec/gpu

--- a/packages/app/src/components/calculator/url-seed.test.ts
+++ b/packages/app/src/components/calculator/url-seed.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { resolveCalculatorUrlSeed } from './url-seed';
-import { Model, Precision, Sequence } from '@/lib/data-mappings';
+import { Model, Percentile, Precision, Sequence } from '@/lib/data-mappings';
 
 describe('resolveCalculatorUrlSeed', () => {
   it('returns the model when g_model is a known enum value', () => {
@@ -30,17 +30,29 @@ describe('resolveCalculatorUrlSeed', () => {
     expect(resolveCalculatorUrlSeed({ i_prec: 'garbage' })).toEqual({});
   });
 
+  it('returns the agentic latency percentile when i_pctl is known', () => {
+    expect(resolveCalculatorUrlSeed({ i_pctl: 'p75' })).toEqual({
+      percentile: Percentile.P75,
+    });
+  });
+
+  it('ignores an unknown agentic latency percentile', () => {
+    expect(resolveCalculatorUrlSeed({ i_pctl: 'p99' })).toEqual({});
+  });
+
   it('combines model, sequence, and precisions from the same URL', () => {
     expect(
       resolveCalculatorUrlSeed({
         g_model: 'DeepSeek-V4-Pro',
         i_seq: '1k/8k',
         i_prec: 'fp4,fp8',
+        i_pctl: 'p75',
       }),
     ).toEqual({
       model: Model.DeepSeek_V4_Pro,
       sequence: Sequence.OneK_EightK,
       precisions: [Precision.FP4, Precision.FP8],
+      percentile: Percentile.P75,
     });
   });
 

--- a/packages/app/src/components/calculator/url-seed.ts
+++ b/packages/app/src/components/calculator/url-seed.ts
@@ -1,6 +1,8 @@
 import {
   Model,
   MODEL_OPTIONS,
+  Percentile,
+  PERCENTILE_OPTIONS,
   Precision,
   PRECISION_OPTIONS,
   Sequence,
@@ -11,6 +13,7 @@ export interface CalculatorUrlSeed {
   model?: Model;
   sequence?: Sequence;
   precisions?: string[];
+  percentile?: Percentile;
 }
 
 function pickString(value: string | string[] | undefined): string | undefined {
@@ -49,8 +52,13 @@ export function resolveCalculatorUrlSeed(
     if (precs.length > 0) seed.precisions = precs;
   }
 
+  const percentileParam = pickString(sp.i_pctl);
+  if (percentileParam && (PERCENTILE_OPTIONS as readonly string[]).includes(percentileParam)) {
+    seed.percentile = percentileParam as Percentile;
+  }
+
   return seed;
 }
 
 // Re-export Model/Precision/Sequence for callers that already import this module.
-export { Model, Precision, Sequence };
+export { Model, Percentile, Precision, Sequence };

--- a/packages/app/src/components/calculator/useThroughputData.test.ts
+++ b/packages/app/src/components/calculator/useThroughputData.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { BenchmarkRow } from '@/lib/api';
+import { Percentile, Sequence } from '@/lib/data-mappings';
 import { overlayRunIndex } from '@/lib/overlay-run-style';
 
 import type { GPUDataPoint } from './types';
@@ -1022,7 +1023,7 @@ function makeRow(overrides: Partial<BenchmarkRow> = {}): BenchmarkRow {
 const singlePrecisionClassify = (hwKey: string) => ({ key: hwKey, meta: { hwKey } });
 
 describe('buildGpuGroups', () => {
-  const shared = { isl: 1024, osl: 1024, precisions: ['fp4'] };
+  const shared = { sequence: Sequence.OneK_OneK, precisions: ['fp4'] };
 
   it('groups rows by the caller-supplied key and derives cost + power metrics', () => {
     const { grouped, groupMeta, hwConfigMap } = buildGpuGroups(
@@ -1077,8 +1078,7 @@ describe('buildGpuGroups', () => {
     const { grouped, groupMeta } = buildGpuGroups(
       [makeRow({ precision: 'fp4' }), makeRow({ precision: 'fp8' })],
       {
-        isl: 1024,
-        osl: 1024,
+        sequence: Sequence.OneK_OneK,
         precisions: ['fp4', 'fp8'],
         classify: (hwKey, row) => ({
           key: `${hwKey}__${row.precision}`,
@@ -1136,6 +1136,130 @@ describe('buildGpuGroups', () => {
     const overlayHw = Object.values(overlay.groupMeta)[0].hwKey;
     // Legend visibility is keyed on hwKey, so the two must agree.
     expect(overlayHw).toBe(officialHw);
+  });
+
+  it('calculates agentic groups from null-ISL/OSL rows at the selected percentile', () => {
+    const agenticMetrics = {
+      p75_itl: 0.02,
+      p75_ttlt: 12,
+      p90_itl: 0.05,
+      p90_ttlt: 20,
+      // Deliberately wrong artifact values: rowToAggDataEntry must derive
+      // interactivity as 1 / ITL for official and overlay parity.
+      p75_intvty: 999,
+      p90_intvty: 999,
+      tput_per_gpu: 900,
+      output_tput_per_gpu: 300,
+      input_tput_per_gpu: 600,
+    };
+    const rows = [
+      makeRow({
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        metrics: agenticMetrics,
+      }),
+    ];
+
+    const p90 = buildGpuGroups(rows, {
+      sequence: Sequence.AgenticTraces,
+      precisions: ['fp4'],
+      percentile: Percentile.P90,
+      classify: singlePrecisionClassify,
+    });
+    const p75 = buildGpuGroups(rows, {
+      sequence: Sequence.AgenticTraces,
+      precisions: ['fp4'],
+      percentile: Percentile.P75,
+      classify: singlePrecisionClassify,
+    });
+
+    expect(Object.values(p90.grouped)[0][0]).toMatchObject({
+      interactivity: 20,
+      e2eLatency: 20,
+    });
+    expect(Object.values(p75.grouped)[0][0]).toMatchObject({
+      interactivity: 50,
+      e2eLatency: 12,
+    });
+  });
+
+  it('restricts agentic interpolation to the same date-scoped e2e Pareto winners as the chart', () => {
+    const agenticRow = (
+      conc: number,
+      interactivity: number,
+      e2eLatency: number,
+      throughput: number,
+      date = '2026-07-19',
+    ) =>
+      makeRow({
+        id: conc,
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc,
+        date,
+        metrics: {
+          p90_itl: 1 / interactivity,
+          p90_ttlt: e2eLatency,
+          tput_per_gpu: throughput,
+          output_tput_per_gpu: throughput * 0.3,
+          input_tput_per_gpu: throughput * 0.7,
+        },
+      });
+
+    const { grouped } = buildGpuGroups(
+      [
+        agenticRow(1, 100, 20, 900),
+        agenticRow(2, 80, 30, 800), // e2e-dominated by concurrency 1
+        agenticRow(4, 60, 40, 1200),
+        // A different date gets its own e2e frontier and must survive.
+        agenticRow(8, 40, 50, 700, '2026-07-20'),
+      ],
+      {
+        sequence: Sequence.AgenticTraces,
+        precisions: ['fp4'],
+        percentile: Percentile.P90,
+        classify: singlePrecisionClassify,
+      },
+    );
+
+    const points = Object.values(grouped)[0];
+    expect(points.map((point) => point.concurrency).toSorted()).toEqual([1, 4, 8]);
+  });
+
+  it('keeps agentic overlay frontiers isolated per unofficial run', () => {
+    const runA = 'https://github.com/org/repo/actions/runs/111';
+    const runB = 'https://github.com/org/repo/actions/runs/222';
+    const rows = [
+      makeRow({
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        run_url: runA,
+        metrics: { p90_itl: 0.02, p90_ttlt: 50, tput_per_gpu: 500 },
+      }),
+      makeRow({
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        run_url: runB,
+        metrics: { p90_itl: 0.01, p90_ttlt: 20, tput_per_gpu: 1000 },
+      }),
+    ];
+
+    const { grouped } = buildGpuGroups(rows, {
+      sequence: Sequence.AgenticTraces,
+      precisions: ['fp4'],
+      percentile: Percentile.P90,
+      classify: (hwKey, row) => {
+        const runIndex = overlayRunIndex(row.run_url, { [runA]: 0, [runB]: 1 });
+        return { key: `${hwKey}__run${runIndex}`, meta: { hwKey, runIndex } };
+      },
+    });
+
+    expect(Object.keys(grouped)).toHaveLength(2);
+    expect(Object.values(grouped).map((points) => points.length)).toEqual([1, 1]);
   });
 });
 

--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -2,15 +2,15 @@
 
 import { useCallback, useMemo } from 'react';
 
-import { DB_MODEL_TO_DISPLAY, sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
+import { DB_MODEL_TO_DISPLAY, rowToSequence } from '@semianalysisai/inferencex-constants';
 
-import type { HardwareConfig } from '@/components/inference/types';
+import type { AggDataEntry, HardwareConfig, InferenceData } from '@/components/inference/types';
 import { useBenchmarks } from '@/hooks/api/use-benchmarks';
 import type { BenchmarkRow } from '@/lib/api';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
-import { getHardwareKey } from '@/lib/chart-utils';
+import { getHardwareKey, paretoFrontUpperRight } from '@/lib/chart-utils';
 import { getModelSortIndex, getHardwareConfig, getGpuSpecs } from '@/lib/constants';
-import type { Model, Sequence } from '@/lib/data-mappings';
+import { Percentile, Sequence, type Model } from '@/lib/data-mappings';
 import { overlayRunIndex } from '@/lib/overlay-run-style';
 
 import {
@@ -52,6 +52,59 @@ export interface OverlayGroupMeta extends GroupMeta {
   runIndex: number;
 }
 
+interface AgenticFrontierPoint {
+  x: number;
+  y: number;
+  orig: GPUDataPoint;
+}
+
+/**
+ * Match the main agentic interactivity chart's anti-benchmark-hacking seed:
+ * within each date, only points that also win on the (end-to-end latency,
+ * total throughput) upper-right Pareto frontier may feed interpolation.
+ *
+ * The chart's shared Pareto helper operates on `InferenceData.x/y` only, so
+ * minimal projections keep this path aligned without running the full chart
+ * transformation pipeline.
+ */
+export function restrictAgenticPointsToE2eFrontier(points: GPUDataPoint[]): GPUDataPoint[] {
+  const byDate = new Map<string, AgenticFrontierPoint[]>();
+
+  for (const point of points) {
+    if (
+      typeof point.e2eLatency !== 'number' ||
+      !Number.isFinite(point.e2eLatency) ||
+      !Number.isFinite(point.throughput)
+    ) {
+      continue;
+    }
+    const date = point.date ?? '';
+    let bucket = byDate.get(date);
+    if (!bucket) {
+      bucket = [];
+      byDate.set(date, bucket);
+    }
+    bucket.push({ x: point.e2eLatency, y: point.throughput, orig: point });
+  }
+
+  const winners = new Set<GPUDataPoint>();
+  for (const bucket of byDate.values()) {
+    for (const winner of paretoFrontUpperRight(bucket as unknown as InferenceData[])) {
+      winners.add((winner as unknown as AgenticFrontierPoint).orig);
+    }
+  }
+  return points.filter((point) => winners.has(point));
+}
+
+function getAgenticMetric(
+  entry: AggDataEntry,
+  percentile: Percentile,
+  suffix: 'intvty' | 'e2el',
+): number {
+  const value = entry[`${percentile}_${suffix}` as keyof AggDataEntry];
+  return typeof value === 'number' ? value : 0;
+}
+
 /**
  * Build `GPUDataPoint` groups from raw benchmark rows.
  *
@@ -62,9 +115,10 @@ export interface OverlayGroupMeta extends GroupMeta {
 export function buildGpuGroups<M extends GroupMeta>(
   rows: BenchmarkRow[],
   options: {
-    isl: number;
-    osl: number;
+    sequence: Sequence;
     precisions: string[];
+    /** Agentic x/e2e latency percentile. Fixed-sequence rows keep the median. */
+    percentile?: Percentile;
     /** Derive a row's group key + metadata. Return null to drop the row. */
     classify: (hwKey: string, row: BenchmarkRow) => { key: string; meta: M } | null;
   },
@@ -73,13 +127,13 @@ export function buildGpuGroups<M extends GroupMeta>(
   groupMeta: Record<string, M>;
   hwConfigMap: HardwareConfig;
 } {
-  const { isl, osl, precisions, classify } = options;
+  const { sequence, precisions, percentile = Percentile.P90, classify } = options;
   const grouped: Record<string, GPUDataPoint[]> = {};
   const groupMeta: Record<string, M> = {};
   const hwConfigMap: HardwareConfig = {};
 
   for (const row of rows) {
-    if (row.isl !== isl || row.osl !== osl) continue;
+    if (rowToSequence(row) !== sequence) continue;
     if (!precisions.includes(row.precision)) continue;
 
     const entry = rowToAggDataEntry(row);
@@ -105,7 +159,16 @@ export function buildGpuGroups<M extends GroupMeta>(
 
     grouped[groupKey].push({
       hwKey,
-      interactivity: m.median_intvty ?? 0,
+      interactivity:
+        sequence === Sequence.AgenticTraces
+          ? getAgenticMetric(entry, percentile, 'intvty')
+          : entry.median_intvty,
+      ...(sequence === Sequence.AgenticTraces
+        ? {
+            e2eLatency: getAgenticMetric(entry, percentile, 'e2el'),
+            date: row.date,
+          }
+        : {}),
       throughput: tput,
       outputThroughput: outputTput,
       inputThroughput: inputTput,
@@ -130,6 +193,18 @@ export function buildGpuGroups<M extends GroupMeta>(
     });
   }
 
+  if (sequence === Sequence.AgenticTraces) {
+    for (const groupKey of Object.keys(grouped)) {
+      const restricted = restrictAgenticPointsToE2eFrontier(grouped[groupKey]);
+      if (restricted.length === 0) {
+        delete grouped[groupKey];
+        delete groupMeta[groupKey];
+      } else {
+        grouped[groupKey] = restricted;
+      }
+    }
+  }
+
   return { grouped, groupMeta, hwConfigMap };
 }
 
@@ -151,6 +226,7 @@ export function useThroughputData(
   selectedPrecisions: string[],
   selectedRunDate: string,
   overlay?: OverlayInput,
+  selectedPercentile: Percentile = Percentile.P90,
 ) {
   // Reuse the same API + React Query cache as the inference charts
   const {
@@ -186,14 +262,12 @@ export function useThroughputData(
       hasOverlayData: false,
     };
     if (!allRows) return empty;
-    const seqIslOsl = sequenceToIslOsl(selectedSequence);
-    if (!seqIslOsl) return empty;
 
     const multiPrecision = selectedPrecisions.length > 1;
     const shared = {
-      isl: seqIslOsl.isl,
-      osl: seqIslOsl.osl,
+      sequence: selectedSequence,
       precisions: selectedPrecisions,
+      percentile: selectedPercentile,
     };
 
     const official = buildGpuGroups<GroupMeta>(allRows, {
@@ -241,7 +315,15 @@ export function useThroughputData(
       hasData: Object.keys(official.grouped).length > 0,
       hasOverlayData: Object.keys(overlayGroups.grouped).length > 0,
     };
-  }, [allRows, selectedModel, selectedSequence, selectedPrecisions, overlayRows, runIndexByUrl]);
+  }, [
+    allRows,
+    selectedModel,
+    selectedSequence,
+    selectedPrecisions,
+    selectedPercentile,
+    overlayRows,
+    runIndexByUrl,
+  ]);
 
   // All available GPU hardware keys from data, ordered by hardwareConfig (HARDWARE_CONFIG order)
   // This returns unique GPU-level hwKeys (not composite keys) for the legend

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -48,6 +48,11 @@ const STRINGS = {
     precision: 'Precision',
     precisionTooltip:
       "Numerical precision used for model weights. Lower precision like 'FP4' uses less memory and increases throughput but may slightly reduce accuracy compared to higher precisions like 'FP8'.",
+    agenticGroup: 'Agentic',
+    fixedSequenceLength: 'Fixed Sequence Length',
+    deprecated: 'Deprecated',
+    deprecatedSequenceReason:
+      'CI capacity was reallocated to agentic coding and multi-turn chat scenarios.',
   },
   zh: {
     model: '模型',
@@ -63,6 +68,10 @@ const STRINGS = {
     precision: '精度',
     precisionTooltip:
       '模型权重的数值精度。FP4 等低精度占用更少显存并提高吞吐量，但与 FP8 等高精度相比可能略微降低准确度。',
+    agenticGroup: '智能体',
+    fixedSequenceLength: '固定序列长度',
+    deprecated: '已弃用',
+    deprecatedSequenceReason: 'CI 容量已重新分配给智能体编程和多轮对话场景。',
   },
 } as const;
 
@@ -211,14 +220,15 @@ export function SequenceSelector({
   availableSequences,
   'data-testid': testId,
 }: SequenceSelectorProps) {
-  const t = STRINGS[useLocale()];
+  const locale = useLocale();
+  const t = STRINGS[locale];
   const groups = groupByCategory(availableSequences, (s) => getSequenceCategory(s as Sequence));
   const sections = [
     {
       id: 'default',
       options: groups.default.map((seq) => ({
         value: seq,
-        label: getSequenceLabel(seq as Sequence),
+        label: getSequenceLabel(seq as Sequence, locale),
       })),
     },
     ...(groups.deprecated.length > 0
@@ -233,7 +243,7 @@ export function SequenceSelector({
             ),
             options: groups.deprecated.map((seq) => ({
               value: seq,
-              label: getSequenceLabel(seq as Sequence),
+              label: getSequenceLabel(seq as Sequence, locale),
             })),
           },
         ]
@@ -294,7 +304,8 @@ export function ScenarioSelector({
   availableSequences,
   'data-testid': testId,
 }: ScenarioSelectorProps) {
-  const t = STRINGS[useLocale()];
+  const locale = useLocale();
+  const t = STRINGS[locale];
   const fixedSeq = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'fixed-seq');
   const agentic = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'agentic');
   const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
@@ -319,33 +330,33 @@ export function ScenarioSelector({
               the app default scenario is 8K/1K). */}
           {agentic.length > 0 && (
             <SelectGroup>
-              <SelectLabel>Agentic</SelectLabel>
+              <SelectLabel>{t.agenticGroup}</SelectLabel>
               {agentic.map((seq) => (
                 <SelectItem key={seq} value={seq}>
-                  {getSequenceLabel(seq as Sequence)}
+                  {getSequenceLabel(seq as Sequence, locale)}
                 </SelectItem>
               ))}
             </SelectGroup>
           )}
           {fixedSeq.length > 0 && (
             <SelectGroup>
-              <SelectLabel>Fixed Sequence Length</SelectLabel>
+              <SelectLabel>{t.fixedSequenceLength}</SelectLabel>
               {fixedGroups.default.map((seq) => (
                 <SelectItem key={seq} value={seq}>
-                  {getSequenceLabel(seq as Sequence)}
+                  {getSequenceLabel(seq as Sequence, locale)}
                 </SelectItem>
               ))}
               {fixedGroups.deprecated.length > 0 && (
                 <>
                   <SelectLabel>
                     <CategorySectionTitle
-                      label="Deprecated"
-                      reason="CI capacity was reallocated to agentic coding and multi-turn chat scenarios."
+                      label={t.deprecated}
+                      reason={t.deprecatedSequenceReason}
                     />
                   </SelectLabel>
                   {fixedGroups.deprecated.map((seq) => (
                     <SelectItem key={seq} value={seq}>
-                      {getSequenceLabel(seq as Sequence)}
+                      {getSequenceLabel(seq as Sequence, locale)}
                     </SelectItem>
                   ))}
                 </>

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -256,6 +256,11 @@ describe('getSequenceLabel', () => {
     expect(getSequenceLabel(Sequence.OneK_OneK)).toBe('1K / 1K');
     expect(getSequenceLabel(Sequence.OneK_EightK)).toBe('1K / 8K');
     expect(getSequenceLabel(Sequence.EightK_OneK)).toBe('8K / 1K');
+    expect(getSequenceLabel(Sequence.AgenticTraces)).toBe('Agentic Traces');
+  });
+
+  it('returns the Chinese agentic scenario label for the zh locale', () => {
+    expect(getSequenceLabel(Sequence.AgenticTraces, 'zh')).toBe('智能体轨迹');
   });
 
   it('falls back to the sequence value for unknown sequence', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -230,6 +230,7 @@ export function sequenceKind(seq: Sequence): ScenarioKind {
 
 interface SequenceConfig {
   label: string;
+  labelZh: string;
   compact: string;
   category: CategoryTag;
   kind: ScenarioKind;
@@ -239,24 +240,28 @@ interface SequenceConfig {
 const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
   [Sequence.OneK_OneK]: {
     label: '1K / 1K',
+    labelZh: '1K / 1K',
     compact: '1k1k',
     category: 'deprecated',
     kind: 'fixed-seq',
   },
   [Sequence.OneK_EightK]: {
     label: '1K / 8K',
+    labelZh: '1K / 8K',
     compact: '1k8k',
     category: 'deprecated',
     kind: 'fixed-seq',
   },
   [Sequence.EightK_OneK]: {
     label: '8K / 1K',
+    labelZh: '8K / 1K',
     compact: '8k1k',
     category: 'default',
     kind: 'fixed-seq',
   },
   [Sequence.AgenticTraces]: {
     label: 'Agentic Traces',
+    labelZh: '智能体轨迹',
     compact: 'agentic',
     category: 'default',
     kind: 'agentic',
@@ -310,8 +315,10 @@ export function getSequenceCategory(sequence: Sequence): CategoryTag {
   return SEQUENCE_CONFIG[sequence]?.category ?? 'default';
 }
 
-export function getSequenceLabel(sequence: Sequence): string {
-  return SEQUENCE_CONFIG[sequence]?.label ?? sequence;
+export function getSequenceLabel(sequence: Sequence, locale: 'en' | 'zh' = 'en'): string {
+  const config = SEQUENCE_CONFIG[sequence];
+  if (!config) return sequence;
+  return locale === 'zh' ? config.labelZh : config.label;
 }
 
 const SEQUENCE_PREFIX_MAPPING: Record<string, Sequence> = Object.fromEntries(

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -318,6 +318,7 @@ describe('buildShareUrl tab filtering', () => {
     writeUrlParams({
       g_model: 'x',
       i_seq: 'y',
+      i_pctl: 'p75',
       c_mw: '10',
       c_costcap: '0.5',
       r_range: 'last-7-days',
@@ -327,6 +328,7 @@ describe('buildShareUrl tab filtering', () => {
     const url = buildShareUrl();
     expect(url).toContain('g_model=x');
     expect(url).toContain('i_seq=y');
+    expect(url).toContain('i_pctl=p75');
     expect(url).toContain('c_mw=10');
     expect(url).toContain('c_costcap=0.5');
     expect(url).not.toContain('r_range');


### PR DESCRIPTION
## Summary

- include DeepSeek V4 `Agentic Traces` rows whose ISL/OSL fields are null instead of filtering them out of the throughput calculator
- add P75/P90 agentic interactivity selection using inverse ITL and persist the choice in shared URLs through `i_pctl`
- restrict agentic points to the end-to-end latency Pareto frontier per date, hardware, precision, and run
- add complete Simplified Chinese labels for the new calculator controls and scenario metadata
- document the agentic calculation pipeline and add unit/E2E regression coverage

## Root cause

The calculator assumed every supported sequence mapped to fixed ISL/OSL values. `Agentic Traces` intentionally has no fixed sequence lengths, so the data path returned early and excluded all 237 available DeepSeek V4 agentic rows.

## User impact

DeepSeek V4 users can now select `Agentic Traces`, choose P75 or P90 interactivity, and receive throughput and cost calculations. The feature works for both official runs and `?unofficialrun=` overlays; overlay visibility and per-run isolation are covered by Cypress fixtures and local browser verification.

## Validation

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `TZ=UTC bun run test:unit` — 3,278 tests passed
- `bun run build` — production build passed, including `/calculator` and `/zh/calculator`
- calculator and overlay Cypress suites — 81 tests passed
- production API smoke calculation — 237 agentic rows produced calculations for 11 hardware groups

## 中文说明

### 变更摘要

- 将 ISL/OSL 为空的 DeepSeek V4 `Agentic Traces` 数据纳入吞吐量计算器，不再错误过滤
- 新增 P75/P90 智能体交互性选择，以 ITL 的倒数计算交互性，并通过 `i_pctl` 将选项写入分享链接
- 按日期、硬件、精度和运行分别筛选端到端延迟 Pareto 前沿，避免不同运行之间互相影响
- 为新增的计算器控件和场景元数据补齐简体中文界面文案
- 补充智能体计算流程文档以及单元测试和 E2E 回归测试

### 根因

计算器原先假设所有受支持场景都能映射到固定 ISL/OSL。`Agentic Traces` 本身没有固定序列长度，因此数据处理流程提前返回，导致现有 237 条 DeepSeek V4 智能体数据全部被排除。

### 用户影响

DeepSeek V4 用户现在可以选择 `Agentic Traces`，使用 P75 或 P90 交互性计算吞吐量和成本。该功能同时支持正式运行和 `?unofficialrun=` 非正式运行叠加层；Cypress fixtures 与本地浏览器验证覆盖了叠加层可见性和逐运行隔离行为。

### 验证

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `TZ=UTC bun run test:unit` — 3,278 项测试通过
- `bun run build` — 生产构建通过，包含 `/calculator` 和 `/zh/calculator`
- 计算器与叠加层 Cypress 测试 — 81 项测试通过
- 生产 API 冒烟计算 — 237 条智能体数据成功生成 11 个硬件组的计算结果

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core calculator data grouping and Pareto logic for a new scenario type; behavior is heavily tested but miscalculation would affect published TCO comparisons for agentic workloads.
> 
> **Overview**
> **Agentic Traces** are no longer dropped in the TCO calculator: row filtering uses `rowToSequence` instead of fixed ISL/OSL, so DeepSeek V4 agentic benchmark rows with null sequence lengths produce bars and cost/throughput math.
> 
> For **agentic** scenarios the calculator aligns with the main inference chart: **P90** by default, **P75** via a new percentile control, interactivity from **1/ITL** (not artifact `*_intvty`), and interpolation points limited to **date-scoped e2e-latency Pareto winners** before the existing interactivity Pareto/spline path. Official and unofficial-run overlays stay on **separate frontiers**; changing percentile **does not reset** GPU legend filters.
> 
> **UI/URL:** `SequenceSelector` becomes **`ScenarioSelector`** on the calculator; agentic mode shows **`PercentileSelector`**, percentile-aware chart titles and target labels, and **`i_pctl`** in URL seeding and share links. **zh** labels extend to agentic scenario text and selector groupings.
> 
> **Tests/docs:** Unit tests for agentic grouping/frontiers, Cypress for agentic calculator + overlay, fixture `p75_*` metrics, and `docs/tco-calculator.md` updated for the agentic pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59f9d5303592c241808911237b11a4c196f69e97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->