### PR TITLE
hi

### DIFF
--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -26,6 +26,60 @@ describe('comparisonExclusion', () => {
     expect(resolved.droppedGroups).toEqual(['sglang']);
   });
 
+  it('keeps the vLLM default when arriving from a fixed-sequence chart', () => {
+    // The dashboard lands on 8K/1K, where per-hardware STP keys are unrestricted,
+    // so both engines are active before the user picks Agentic Traces. That prior
+    // selection names both groups and must not out-vote the chart's vLLM default.
+    const fixedSeqSelection = new Set([
+      'b200_sglang',
+      'b200_vllm',
+      'b300_sglang',
+      'b300_vllm',
+      'gb300_dynamo-sglang',
+      'gb300_dynamo-vllm',
+    ]);
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
+    const resolved = resolveExclusionGroups(
+      new Set([
+        'b200_sglang',
+        'b200_vllm',
+        'b200_vllm_mtp',
+        'b300_sglang',
+        'b300_vllm',
+        'b300_vllm_mtp',
+        'gb300_dynamo-sglang_mtp',
+        'gb300_dynamo-vllm_mtp',
+      ]),
+      fixedSeqSelection,
+      exclusion,
+      'keep-sticky',
+      comparisonDefaultGroup(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false),
+    );
+
+    expect([...resolved.result].toSorted()).toEqual([
+      'b200_vllm',
+      'b200_vllm_mtp',
+      'b300_vllm',
+      'b300_vllm_mtp',
+      'gb300_dynamo-vllm_mtp',
+    ]);
+    expect(resolved.droppedGroups).toEqual(['sglang']);
+  });
+
+  it('still honors an SGLang-only selection carried into the Agentic chart', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
+    const resolved = resolveExclusionGroups(
+      new Set(['b200_sglang', 'b200_vllm', 'b200_vllm_mtp']),
+      new Set(['b200_sglang']),
+      exclusion,
+      'keep-sticky',
+      comparisonDefaultGroup(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false),
+    );
+
+    expect([...resolved.result]).toEqual(['b200_sglang']);
+    expect(resolved.droppedGroups).toEqual(['vllm']);
+  });
+
   it.each([
     {
       name: 'fixed-sequence DeepSeek V4 Pro',

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -360,6 +360,36 @@ describe('pickStickyGroup', () => {
     expect(out.droppedGroups).toEqual(['vllm']);
   });
 
+  it('prefers the fallback group when prev names several candidate groups', () => {
+    // `prev` carried over from a laxer scope (both engines active), so it is not
+    // an engine choice — the fallback decides instead of the alphabetical order.
+    const proposed = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const prev = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const out = pickStickyGroup(proposed, prev, ex, 'vllm');
+    expect(out.keptGroup).toBe('vllm');
+    expect([...out.result]).toEqual(['h100_vllm_mtp']);
+    expect(out.droppedGroups).toEqual(['sglang']);
+  });
+
+  it('still tie-breaks alphabetically on an ambiguous prev with no fallback', () => {
+    const proposed = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const prev = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const out = pickStickyGroup(proposed, prev, ex);
+    expect(out.keptGroup).toBe('sglang');
+    expect([...out.result]).toEqual(['gb300_sglang_mtp']);
+    expect(out.droppedGroups).toEqual(['vllm']);
+  });
+
+  it('prefers the fallback group when the correlated prev is ambiguous', () => {
+    // Global MTP scope with no direct prior key: both groups correlate through a
+    // hardware-scoped prev key, so the fallback breaks the tie.
+    const proposed = new Set(['h100_vllm_mtp', 'gb300_sglang_mtp']);
+    const prev = new Set(['h100_vllm', 'gb300_sglang']);
+    const out = pickStickyGroup(proposed, prev, agenticEx, 'vllm');
+    expect(out.keptGroup).toBe('vllm');
+    expect([...out.result]).toEqual(['h100_vllm_mtp']);
+  });
+
   it('treats dynamo/mori variants as the same group', () => {
     const proposed = new Set(['h100_vllm_mtp', 'h100_dynamo-vllm_mtp', 'gb300_dynamo-sglang_mtp']);
     const out = pickStickyGroup(proposed, new Set(['h100_vllm_mtp']), ex);

--- a/packages/app/src/lib/exclusion.ts
+++ b/packages/app/src/lib/exclusion.ts
@@ -175,6 +175,14 @@ function activeFamilyInGroup(
  * uses `fallbackGroup` when that group is available, then falls back to the
  * alphabetically-first group.
  *
+ * Stickiness only counts as a user's engine choice when `prev` names ONE of the
+ * candidate groups. When `prev` spans several of them the prior selection is
+ * ambiguous — it was carried over from a scope with laxer rules (e.g. switching
+ * a fixed-seq chart, where both engines may be active per hardware, over to
+ * Agentic Traces) — so `fallbackGroup` decides instead of the alphabetical
+ * tie-break, which would otherwise silently pick a different engine than the
+ * one a fresh load of the same chart shows.
+ *
  * If `proposed` has 0 or 1 groups, the input set is returned unchanged.
  */
 export function pickStickyGroup(
@@ -188,6 +196,15 @@ export function pickStickyGroup(
   const result = new Set(proposed);
   const winners = new Set<string>();
   const dropped = new Set<string>();
+
+  // A single sticky candidate is an unambiguous prior choice and wins outright;
+  // several candidates mean `prev` didn't choose between them, so defer to the
+  // configured default before the alphabetical tie-break.
+  const stickyWinner = (candidates: string[]): string | undefined => {
+    if (candidates.length <= 1) return candidates[0];
+    if (fallbackGroup && candidates.includes(fallbackGroup)) return fallbackGroup;
+    return candidates.toSorted()[0];
+  };
 
   for (const [scope, byGroup] of byScope) {
     if (byGroup.size <= 1) continue;
@@ -216,8 +233,8 @@ export function pickStickyGroup(
       }
     }
     const winner =
-      groups.filter((group) => directPrevGroups.has(group)).toSorted()[0] ??
-      groups.filter((group) => correlatedPrevGroups.has(group)).toSorted()[0] ??
+      stickyWinner(groups.filter((group) => directPrevGroups.has(group))) ??
+      stickyWinner(groups.filter((group) => correlatedPrevGroups.has(group))) ??
       (fallbackGroup && groups.includes(fallbackGroup) ? fallbackGroup : undefined) ??
       groups.toSorted()[0];
     winners.add(winner);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes shared legend/exclusion resolution used across comparison charts; behavior is narrowed with tests but affects which engine series stay visible on navigation.
> 
> **Overview**
> Fixes **engine-family resolution** when switching inference comparison charts (e.g. fixed-sequence 8K/1K → Agentic Traces) while the carried-over legend still has **both vLLM and SGLang** active.
> 
> `pickStickyGroup` now treats stickiness as a real user choice only when `prev` points at **one** candidate group. If `prev` names several groups, resolution uses **`fallbackGroup`** (e.g. the chart’s vLLM default) before the alphabetical tie-break, so navigation matches a fresh load of the same chart. **Single-engine** prior selections (e.g. SGLang-only) are unchanged.
> 
> Tests cover `pickStickyGroup` tie cases and Agentic Traces comparison resolution when arriving from a fixed-sequence selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc07fbfdea65f85ccf62ab425e222529620cf4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->