### PR TITLE
Show selected percentile in agentic x-axis titles for Interactivity / E2E Latency / 智能体场景 Interactivity 与 E2E Latency x 轴标题显示所选百分位

### DIFF
--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -163,6 +163,11 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       .should('be.visible')
       .and('have.attr', 'aria-selected', 'true');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+    // Agentic plots percentile fields (p90_intvty), so the axis label carries it.
+    cy.get('[data-testid="chart-figure"] svg').should(
+      'contain.text',
+      'P90 Interactivity (tok/s/user)',
+    );
   });
 
   it('defaults to parallelism labels without line labels for the agentic view', () => {
@@ -195,6 +200,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     cy.get('[data-testid="x-axis-mode-e2e"]').click();
     cy.get('[data-testid="x-axis-mode-e2e"]').should('have.attr', 'aria-selected', 'true');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'End-to-end Latency');
+    cy.get('[data-testid="chart-figure"] svg').should('contain.text', 'P90 End-to-end Latency (s)');
   });
 
   it('switches to request-level normalized E2E at 400 output tokens', () => {
@@ -231,6 +237,11 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       'true',
     );
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+    // Percentile was switched to p75 in the previous test — the axis label follows.
+    cy.get('[data-testid="chart-figure"] svg').should(
+      'contain.text',
+      'P75 Interactivity (tok/s/user)',
+    );
   });
 });
 
@@ -246,6 +257,9 @@ describe('Default scenario', () => {
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
+    // Fixed-seq plots the mean field — no percentile prefix on the axis label.
+    cy.get('[data-testid="chart-figure"] svg').should('contain.text', 'Interactivity (tok/s/user)');
+    cy.get('[data-testid="chart-figure"] svg').should('not.contain.text', 'P90 Interactivity');
   });
 });
 
@@ -355,6 +369,11 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
     // The unofficial-run pattern watermark appears when isUnofficialRun is true.
     cy.get('[data-testid="inference-chart-display"] svg pattern[id^="unofficial-pattern-"]').should(
       'exist',
+    );
+    // Overlay shares the chartDefinition label — the percentile prefix applies here too.
+    cy.get('[data-testid="chart-figure"] svg').should(
+      'contain.text',
+      'P90 Interactivity (tok/s/user)',
     );
   });
 

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -13,6 +13,8 @@ const interceptDerivedMetrics = () => {
             p90_prefill_tps_per_user: 100 + index,
             p75_normalized_e2e_400_s: 8 + index,
             p90_normalized_e2e_400_s: 12 + index,
+            p75_osl_per_e2el: 40 + index,
+            p90_osl_per_e2el: 25 + index,
           },
         ]),
       ),
@@ -144,6 +146,10 @@ const interceptFixedSequenceData = () => {
 describe('X-Axis Mode Toggle (inference chart)', () => {
   before(() => {
     interceptAgenticData();
+    // Stub derived metrics before the visit: if the agentic DEFAULT x-axis mode
+    // is (or becomes) a derived mode that fetches /derived-agentic-metrics on
+    // mount, the chart must not sit on its loading skeleton.
+    interceptDerivedMetrics();
     cy.visit('/inference?i_seq=agentic-traces', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
@@ -163,6 +169,16 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       .should('be.visible')
       .and('have.attr', 'aria-selected', 'true');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+  });
+
+  it('shows the selected percentile in the Interactivity axis label', () => {
+    // Explicitly select the mode — do not rely on the agentic default mode.
+    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
+      'have.attr',
+      'aria-selected',
+      'true',
+    );
     // Agentic plots percentile fields (p90_intvty), so the axis label carries it.
     cy.get('[data-testid="chart-figure"] svg').should(
       'contain.text',
@@ -354,6 +370,9 @@ const interceptAgenticDataWithOverlay = () => {
 describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', () => {
   before(() => {
     interceptAgenticDataWithOverlay();
+    // Same as the main suite: keep the visit independent of the agentic default
+    // x-axis mode (a derived default fetches /derived-agentic-metrics on mount).
+    interceptDerivedMetrics();
     cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces`, {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
@@ -366,6 +385,13 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
   });
 
   it('shows overlay (unofficial-run) watermark SVG when an overlay is loaded', () => {
+    // Explicitly select Interactivity — do not rely on the agentic default mode.
+    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
+      'have.attr',
+      'aria-selected',
+      'true',
+    );
     // The unofficial-run pattern watermark appears when isUnofficialRun is true.
     cy.get('[data-testid="inference-chart-display"] svg pattern[id^="unofficial-pattern-"]').should(
       'exist',

--- a/packages/app/src/components/inference/hooks/useChartData.test.ts
+++ b/packages/app/src/components/inference/hooks/useChartData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  applyAgenticPercentileToXLabel,
   buildComparisonDates,
   dedupeRowsToLatestPerConfig,
   filterByGPU,
@@ -136,6 +137,54 @@ describe('filterByGPU', () => {
 
   it('excludes when neither key nor alias matches', () => {
     expect(filterByGPU([{ hwKey: 'unknown' }], ['h100'], {})).toHaveLength(0);
+  });
+});
+
+describe('applyAgenticPercentileToXLabel', () => {
+  it('prefixes the percentile when the interactivity label has no statistic word', () => {
+    expect(applyAgenticPercentileToXLabel('Interactivity (tok/s/user)', 'P90')).toBe(
+      'P90 Interactivity (tok/s/user)',
+    );
+  });
+
+  it('prefixes the percentile when the e2e latency label has no statistic word', () => {
+    expect(applyAgenticPercentileToXLabel('End-to-end Latency (s)', 'P90')).toBe(
+      'P90 End-to-end Latency (s)',
+    );
+  });
+
+  it('follows the selected percentile (p75)', () => {
+    expect(applyAgenticPercentileToXLabel('Interactivity (tok/s/user)', 'P75')).toBe(
+      'P75 Interactivity (tok/s/user)',
+    );
+  });
+
+  it('replaces an existing percentile prefix instead of doubling it', () => {
+    expect(applyAgenticPercentileToXLabel('P90 Time To First Token (s)', 'P75')).toBe(
+      'P75 Time To First Token (s)',
+    );
+  });
+
+  it('replaces Median/Mean statistic prefixes', () => {
+    expect(applyAgenticPercentileToXLabel('Median Time To First Token (s)', 'P90')).toBe(
+      'P90 Time To First Token (s)',
+    );
+    expect(applyAgenticPercentileToXLabel('Mean Interactivity (tok/s/user)', 'P75')).toBe(
+      'P75 Interactivity (tok/s/user)',
+    );
+  });
+
+  it('is a no-op when the label already carries the selected percentile', () => {
+    expect(applyAgenticPercentileToXLabel('P90 Interactivity (tok/s/user)', 'P90')).toBe(
+      'P90 Interactivity (tok/s/user)',
+    );
+  });
+
+  it('does not touch mid-label statistic words', () => {
+    // Only a LEADING statistic word is a prefix; words later in the label are content.
+    expect(applyAgenticPercentileToXLabel('Normalized E2E @ 400 output tokens (s)', 'P90')).toBe(
+      'P90 Normalized E2E @ 400 output tokens (s)',
+    );
   });
 });
 

--- a/packages/app/src/components/inference/hooks/useChartData.ts
+++ b/packages/app/src/components/inference/hooks/useChartData.ts
@@ -139,6 +139,25 @@ export function flipRooflineDirection(dir: RooflineDirection): RooflineDirection
   return FLIP_MAP[dir];
 }
 
+// Statistic words that may already prefix an x-axis label (from chart config
+// or the TTFT override label). Trailing whitespace is consumed so a replace
+// never doubles the separator space.
+const X_LABEL_STAT_PREFIX_RE = /^(?:Median|Mean|P75|P90|P95|P99(?:\.9)?)\b\s*/iu;
+
+/**
+ * Agentic sequences plot percentile fields (e.g. `p90_intvty`, `p75_e2el`),
+ * so the x-axis label must carry the selected percentile. Replaces an
+ * existing leading statistic word (e.g. the TTFT override's "P90 Time To
+ * First Token (s)") or prefixes the percentile when the configured label has
+ * none (e.g. "Interactivity (tok/s/user)" → "P90 Interactivity (tok/s/user)").
+ * Only call for agentic sequences — fixed-seq labels must stay untouched.
+ */
+export function applyAgenticPercentileToXLabel(label: string, pctlWord: string): string {
+  return X_LABEL_STAT_PREFIX_RE.test(label)
+    ? label.replace(X_LABEL_STAT_PREFIX_RE, `${pctlWord} `)
+    : `${pctlWord} ${label}`;
+}
+
 /** The dedup key fields a chart series is identified by. */
 interface DedupeRow {
   hardware: string;
@@ -409,13 +428,15 @@ export function useChartData(
 
         // Agentic: relabel to the chosen percentile (the resolver already
         // rewrote the field) — xAxisLabel still carries the raw chartDef
-        // prefix. The chart heading ("vs. <latency>") is also rewritten so the
-        // title above the plot reflects what's drawn.
+        // prefix (or none: the base Interactivity / E2E Latency config labels
+        // have no statistic word, so the percentile is prefixed). The chart
+        // heading ("vs. <latency>") is also rewritten so the title above the
+        // plot reflects what's drawn.
         const headingKey = `${selectedYAxisMetric}_heading` as keyof ChartDefinition;
         let chartHeading = (chartDef[headingKey] as string) || chartDef.heading;
         if (isAgentic) {
           const pctlWord = selectedPercentile.toUpperCase();
-          xAxisLabel = xAxisLabel.replace(/^(?:Median|Mean|P75|P90|P95|P99(?:\.9)?)\b/iu, pctlWord);
+          xAxisLabel = applyAgenticPercentileToXLabel(xAxisLabel, pctlWord);
           chartHeading = chartHeading.replace(
             /^(?<vsPrefix>vs\.\s+)(?:(?:Median|Mean|P75|P90|P95|P99(?:\.9)?)\s+)?/iu,
             `$1${pctlWord} `,


### PR DESCRIPTION
## What changed

- On **agentic scenarios only**, the x-axis titles for the regular **Interactivity** and **E2E Latency** x-axis modes now carry the selected latency percentile — e.g. "P90 Interactivity (tok/s/user)", "P75 End-to-end Latency (s)".
- Extracted the agentic label rewrite in `useChartData.stableChartDefinitions` into an exported pure helper `applyAgenticPercentileToXLabel(label, pctlWord)`: it **prefixes** the percentile when the configured label has no leading statistic word, and still **replaces** an existing prefix (e.g. the TTFT override label "P90 Time To First Token (s)" → "P75 …") without double-prefixing.
- Unit tests (`useChartData.test.ts`): prefix on interactivity/e2e labels, p75 switch, replace-not-double on existing prefixes, Median/Mean replacement, no-op when already correct, mid-label statistic words untouched.
- Cypress (`ttft-x-axis-toggle.cy.ts`): asserts "P90 Interactivity (tok/s/user)" and "P90 End-to-end Latency (s)" render in the chart SVG on agentic, "P75 Interactivity (tok/s/user)" after switching the percentile selector, no percentile prefix on the fixed-seq default scenario, and the same "P90 Interactivity (tok/s/user)" label with an `?unofficialrun=` overlay loaded.

## Why

- Agentic scenarios plot percentile fields (`p75_intvty`/`p90_intvty`, `p75_e2el`/`p90_e2el`). The chart heading, the TTFT mode label, and the derived-mode labels already show the percentile, but the base Interactivity / E2E Latency axis titles rendered the raw config labels ("Interactivity (tok/s/user)") because the previous rewrite only replaced an existing leading percentile word — the base config labels have none, so nothing was added.
- Fixed-sequence (non-agentic) labels are unchanged (`isAgentic` guard at the call site).
- **Overlay support**: works for both official runs and `?unofficialrun=` overlays — the overlay path renders on the same base chart and `ChartDisplay` passes `graph.chartDefinition.x_label` from the same `stableChartDefinitions` output, so one fix covers both; verified with a Cypress overlay assertion. `/zh` pages reuse the English axis label for these modes (technical terms with units, same as the existing TTFT label behavior), so no zh-side change is needed.

## 中文说明

- 仅在**智能体（agentic）场景**下，常规 **Interactivity** 与 **E2E Latency** x 轴模式的坐标轴标题现在会带上所选延迟百分位，例如 "P90 Interactivity (tok/s/user)"、"P75 End-to-end Latency (s)"。
- 将 `useChartData.stableChartDefinitions` 中的标签改写逻辑提取为导出的纯函数 `applyAgenticPercentileToXLabel(label, pctlWord)`：配置标签没有统计词前缀时**补上**所选百分位；已有前缀（如 TTFT 覆盖标签 "P90 Time To First Token (s)" → "P75 …"）时**替换**而不重复叠加。
- 单元测试（`useChartData.test.ts`）覆盖：interactivity/e2e 标签加前缀、切换到 p75、已有前缀时替换不重复、Median/Mean 替换、标签已正确时不变、标签中间的统计词不受影响。
- Cypress（`ttft-x-axis-toggle.cy.ts`）断言：agentic 下图表 SVG 渲染 "P90 Interactivity (tok/s/user)" 与 "P90 End-to-end Latency (s)"；切换百分位后显示 "P75 Interactivity (tok/s/user)"；固定序列默认场景不带百分位前缀；加载 `?unofficialrun=` 叠加时同样显示带百分位的标签。
- 原因：agentic 场景绘制的是百分位字段（`p75_intvty`/`p90_intvty`、`p75_e2el`/`p90_e2el`），图表标题、TTFT 模式及派生模式的标签均已显示百分位，唯独这两个基础模式的轴标题仍是原始配置标签——原有改写只替换已存在的前缀，而基础标签没有前缀，因此未生效。固定序列标签保持不变。叠加路径复用同一 `chartDefinition` 标签，一处修复同时覆盖官方与非官方运行；`/zh` 页面沿用英文轴标签（含单位的技术术语，与现有 TTFT 标签行为一致），无需额外改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label logic gated to agentic sequences; fixed-seq and data plumbing are untouched.
> 
> **Overview**
> **Agentic** Interactivity and E2E Latency x-axis titles now include the selected latency percentile (e.g. **P90 Interactivity (tok/s/user)**), matching the percentile fields actually plotted. Fixed-sequence scenarios are unchanged.
> 
> The prior inline label rewrite only replaced an existing leading statistic word, so base config labels without a prefix never got a percentile. That logic is extracted into **`applyAgenticPercentileToXLabel`**, which prefixes when needed and still replaces Median/Mean/P90-style prefixes without doubling.
> 
> **Tests:** Vitest covers the helper; Cypress asserts SVG axis text for agentic modes, p75 after percentile change, no prefix on fixed-seq default, and the same labels with unofficial-run overlays. Derived-metrics stubs were extended and wired earlier in suite setup to avoid loading skeletons when defaults fetch derived metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf6a8e0ab5c22aaa11c02b8c978d1097ffe0bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->