### PR TITLE
feat(landing): point launch banner and modal at Kimi K3 / 首页横幅与弹窗切换为 Kimi K3

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -58,8 +58,8 @@ describe('Landing page performance', () => {
 
     cy.visit('/', {
       onBeforeLoad(win) {
-        win.localStorage.removeItem('inferencex-minimax-m3-modal-dismissed');
-        win.localStorage.removeItem('inferencex-minimax-m3-banner-dismissed');
+        win.localStorage.removeItem('inferencex-kimi-k3-modal-dismissed');
+        win.localStorage.removeItem('inferencex-kimi-k3-banner-dismissed');
         observeLayoutShifts(win);
       },
     });
@@ -77,7 +77,7 @@ describe('Landing page performance', () => {
     cy.viewport(412, 823);
     cy.visit('/', {
       onBeforeLoad(win) {
-        win.localStorage.setItem('inferencex-minimax-m3-banner-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-banner-dismissed', '1');
         observeLayoutShifts(win);
       },
     });

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -50,8 +50,8 @@ describe('First-load navigation', () => {
       onBeforeLoad(win) {
         win.localStorage.removeItem('inferencex-starred');
         win.localStorage.removeItem('inferencex-star-modal-dismissed');
-        win.localStorage.removeItem('inferencex-minimax-m3-modal-dismissed');
-        win.localStorage.removeItem('inferencex-minimax-m3-banner-dismissed');
+        win.localStorage.removeItem('inferencex-kimi-k3-modal-dismissed');
+        win.localStorage.removeItem('inferencex-kimi-k3-banner-dismissed');
       },
     });
 

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -14,8 +14,8 @@ function clearAllNudgeStorage(win: Cypress.AUTWindow) {
   const keys = [
     'inferencex-starred',
     'inferencex-star-modal-dismissed',
-    'inferencex-minimax-m3-modal-dismissed',
-    'inferencex-minimax-m3-banner-dismissed',
+    'inferencex-kimi-k3-modal-dismissed',
+    'inferencex-kimi-k3-banner-dismissed',
     'inferencex-reproducibility-nudge-shown',
     'inferencex-star-nudge-shown',
     'inferencex-export-nudge-shown',
@@ -80,7 +80,7 @@ describe('Landing nudges — modals', () => {
     // path without needing to stub window.location.
     cy.get('[data-testid="launch-modal-action"]').click();
     cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-minimax-m3-modal-dismissed')).to.eq('1');
+      expect(win.localStorage.getItem('inferencex-kimi-k3-modal-dismissed')).to.eq('1');
     });
   });
 
@@ -88,7 +88,7 @@ describe('Landing nudges — modals', () => {
     cy.visit('/', {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-minimax-m3-modal-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-modal-dismissed', '1');
       },
     });
     cy.get('[data-testid="launch-modal"]').should('not.exist');
@@ -99,7 +99,7 @@ describe('Landing nudges — modals', () => {
     cy.visit('/', {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-minimax-m3-modal-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-modal-dismissed', '1');
       },
     });
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
@@ -117,7 +117,7 @@ describe('Landing nudges — modals', () => {
     cy.visit('/', {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-minimax-m3-modal-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-modal-dismissed', '1');
       },
     });
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
@@ -178,7 +178,7 @@ describe('Landing nudges — banner', () => {
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.window().then((win) => {
       // Only the X button should persist a dismissal — show alone must not.
-      expect(win.localStorage.getItem('inferencex-minimax-m3-banner-dismissed')).to.eq(null);
+      expect(win.localStorage.getItem('inferencex-kimi-k3-banner-dismissed')).to.eq(null);
     });
   });
 
@@ -193,7 +193,7 @@ describe('Landing nudges — banner', () => {
     // Body click must not write the dismissal key — the banner should still
     // render on a fresh visit to landing.
     cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-minimax-m3-banner-dismissed')).to.eq(null);
+      expect(win.localStorage.getItem('inferencex-kimi-k3-banner-dismissed')).to.eq(null);
     });
 
     cy.visit('/');
@@ -354,8 +354,8 @@ describe('Nudge scope isolation', () => {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
         // Dismiss all landing nudges so nothing blocks visibility checks
-        win.localStorage.setItem('inferencex-minimax-m3-modal-dismissed', '1');
-        win.localStorage.setItem('inferencex-minimax-m3-banner-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-modal-dismissed', '1');
+        win.localStorage.setItem('inferencex-kimi-k3-banner-dismissed', '1');
         win.localStorage.setItem('inferencex-starred', '1');
       },
     });

--- a/packages/app/src/components/favorites/favorite-presets.ts
+++ b/packages/app/src/components/favorites/favorite-presets.ts
@@ -142,7 +142,28 @@ export function findConfigChangeDates(
 }
 
 export const FAVORITE_PRESETS: FavoritePreset[] = [
-  // 0 — MiniMax M3 launch (all configs) — current day-0 featured model
+  // 0 — Kimi K3 launch (all configs) — current day-0 featured model
+  {
+    id: 'kimi-k3-launch',
+    title: 'Kimi K3 — First Look',
+    titleZh: 'Kimi K3 — 首发基准测试',
+    description:
+      'First benchmarks of Kimi K3 across every available GPU. New configurations appear here as they come online.',
+    descriptionZh: '涵盖所有可用 GPU 的 Kimi K3 首批基准测试结果。新配置上线后将在此同步更新。',
+    tags: ['Kimi', 'K3', 'New'],
+    category: 'comparison',
+    wide: true,
+    config: {
+      model: Model.Kimi_K3,
+      sequence: Sequence.EightK_OneK,
+      precisions: ['fp4', 'fp8'],
+      yAxisMetric: 'y_tpPerGpu',
+      hwFilter: ['h100', 'h200', 'b200', 'b300', 'gb200', 'gb300', 'mi300x', 'mi325x', 'mi355x'],
+    },
+  },
+  // Hidden — previous MiniMax M3 launch preset (all configs), retired when Kimi K3 became
+  // the day-0 model. Retained so prior ?preset=minimax-m3-launch links (banner, modal,
+  // external shares) keep working.
   {
     id: 'minimax-m3-launch',
     title: 'MiniMax M3 — First Look',
@@ -153,6 +174,7 @@ export const FAVORITE_PRESETS: FavoritePreset[] = [
     tags: ['MiniMax', 'M3', 'New'],
     category: 'comparison',
     wide: true,
+    hidden: true,
     config: {
       model: Model.MiniMax_M3,
       sequence: Sequence.EightK_OneK,

--- a/packages/app/src/lib/nudges/landing-banner.ts
+++ b/packages/app/src/lib/nudges/landing-banner.ts
@@ -1,2 +1,2 @@
-export const LANDING_BANNER_STORAGE_KEY = 'inferencex-minimax-m3-banner-dismissed';
+export const LANDING_BANNER_STORAGE_KEY = 'inferencex-kimi-k3-banner-dismissed';
 export const LANDING_BANNER_DISMISSED_ATTRIBUTE = 'data-landing-banner-dismissed';

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -68,8 +68,8 @@ describe('NUDGE_REGISTRY integrity', () => {
       'filter-hint',
       'github-star-modal',
       'gradient-label',
-      'minimax-m3-launch-banner',
-      'minimax-m3-launch-modal',
+      'kimi-k3-launch-banner',
+      'kimi-k3-launch-modal',
       'reproducibility',
       'star-nudge',
     ]);

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -284,22 +284,22 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
   // Landing modals
   // -------------------------------------------------------------------------
   {
-    id: 'minimax-m3-launch-modal',
+    id: 'kimi-k3-launch-modal',
     type: 'modal',
     trigger: { type: 'immediate' },
     dismissal: { type: 'permanent' },
-    storageKey: 'inferencex-minimax-m3-modal-dismissed',
+    storageKey: 'inferencex-kimi-k3-modal-dismissed',
     priority: 50,
     scope: 'landing',
     content: {
       icon: Sparkles,
       iconClassName: 'text-brand',
-      title: 'MiniMax M3 is live',
-      titleZh: 'MiniMax M3 已上线',
+      title: 'Kimi K3 is live',
+      titleZh: 'Kimi K3 已上线',
       description:
-        'Day-zero benchmarks for MiniMax M3 are now available across the latest NVIDIA and AMD GPUs. Results are experimental — see how the new model performs across hardware.',
+        'Day-zero benchmarks for Kimi K3 are now available across the latest NVIDIA and AMD GPUs. Results are experimental — see how the new model performs across hardware.',
       descriptionZh:
-        'MiniMax M3 的首日基准测试数据现已覆盖最新的 NVIDIA 和 AMD GPU。结果为实验性数据——来看看新模型在不同硬件上的表现。',
+        'Kimi K3 的首日基准测试数据现已覆盖最新的 NVIDIA 和 AMD GPU。结果为实验性数据——来看看新模型在不同硬件上的表现。',
       testId: 'launch-modal',
       containerClassName: 'border-brand/40',
       badge: 'New',
@@ -311,14 +311,14 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
         labelZh: '开始探索',
         icon: <ArrowRight className="size-4" />,
         onClick: () => {
-          window.location.href = '/inference?preset=minimax-m3-launch';
+          window.location.href = '/inference?preset=kimi-k3-launch';
         },
       },
     },
     analytics: {
-      shown: 'minimax_m3_modal_shown',
-      dismissed: 'minimax_m3_modal_dismissed',
-      action: 'minimax_m3_modal_explored',
+      shown: 'kimi_k3_modal_shown',
+      dismissed: 'kimi_k3_modal_dismissed',
+      action: 'kimi_k3_modal_explored',
     },
   },
   {
@@ -365,7 +365,7 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
   // Landing banner
   // -------------------------------------------------------------------------
   {
-    id: 'minimax-m3-launch-banner',
+    id: 'kimi-k3-launch-banner',
     type: 'banner',
     trigger: { type: 'immediate' },
     dismissal: { type: 'permanent' },
@@ -376,23 +376,23 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
     content: {
       icon: Sparkles,
       iconClassName: 'text-brand',
-      title: 'MiniMax M3 benchmarks are live',
-      titleZh: 'MiniMax M3 基准测试已上线',
+      title: 'Kimi K3 benchmarks are live',
+      titleZh: 'Kimi K3 基准测试已上线',
       description: 'First inference numbers across NVIDIA and AMD GPUs, click to explore.',
       descriptionZh: 'NVIDIA 和 AMD GPU 的首批推理数据，点击探索。',
       testId: 'launch-banner',
       badge: 'New',
       badgeZh: '最新',
-      href: '/inference?preset=minimax-m3-launch',
+      href: '/inference?preset=kimi-k3-launch',
       onLinkClick: () => {
-        window.location.href = '/inference?preset=minimax-m3-launch';
+        window.location.href = '/inference?preset=kimi-k3-launch';
       },
     },
     analytics: {
       shown: 'launch_banner_shown',
       dismissed: 'launch_banner_dismissed',
       action: 'launch_banner_clicked',
-      properties: { banner_id: 'minimax-m3-launch', preset_id: 'minimax-m3-launch' },
+      properties: { banner_id: 'kimi-k3-launch', preset_id: 'kimi-k3-launch' },
     },
   },
 ];


### PR DESCRIPTION
## Summary

Features **Kimi K3** as the day-0 model on the landing promotion surfaces, following the ["Featuring a Day-0 Model"](https://github.com/SemiAnalysisAI/InferenceX-app/blob/master/docs/adding-entities.md#featuring-a-day-0-model) workflow in `docs/adding-entities.md`:

- **Launch banner** → "Kimi K3 benchmarks are live", links to `/inference?preset=kimi-k3-launch` (analytics `banner_id`/`preset_id` updated to `kimi-k3-launch`)
- **Launch modal** → "Kimi K3 is live", Explore → `/inference?preset=kimi-k3-launch`, analytics `kimi_k3_modal_*`
- **Quick Comparisons preset** → new visible `kimi-k3-launch` "Kimi K3 — First Look" preset (`Model.Kimi_K3`, 8k/1k, fp4+fp8, broad hwFilter) prepended as the first entry
- **Retire-old pattern**: `minimax-m3-launch` preset kept but `hidden: true` so existing `?preset=minimax-m3-launch` links keep resolving; new dismissal storage keys `inferencex-kimi-k3-{banner,modal}-dismissed` so users who dismissed the MiniMax M3 nudges see the new ones
- `PARAM_DEFAULTS.g_model` unchanged (not a default-model swap, per the doc's guidance for non-flagship launches)

### Tests

- `registry.test.ts` expected-ids array updated to `kimi-k3-launch-banner`/`kimi-k3-launch-modal`
- `nudge-system.cy.ts`, `navigation.cy.ts`, `landing-performance.cy.ts` storage keys rotated to the new `kimi-k3` keys; testId selectors stay generic (`launch-banner`, `launch-modal`)
- `bun run typecheck && bun run lint && bun run fmt && bun run test:unit` all pass (3,287 unit tests)
- All UI strings ship with Chinese equivalents (`titleZh`/`descriptionZh`) — no new pages, so no `/zh` route changes needed

Overlay note: this change touches landing-page nudges and presets only — no inference/evaluation chart data path, so unofficial-run overlay support is not applicable.

## 中文说明

按照 `docs/adding-entities.md` 中"Featuring a Day-0 Model"流程，将首页推广位切换为 **Kimi K3**：

- **首页横幅**："Kimi K3 基准测试已上线"，链接到 `/inference?preset=kimi-k3-launch`
- **首页弹窗**："Kimi K3 已上线"，"开始探索"按钮跳转到同一预设，分析事件更名为 `kimi_k3_modal_*`
- **快捷对比预设**：新增可见的 `kimi-k3-launch`（"Kimi K3 — 首发基准测试"）预设，置于列表首位
- **旧模型退役模式**：`minimax-m3-launch` 预设保留为隐藏状态（`hidden: true`），既有链接继续可用；更换新的 dismissal 存储键，使此前关闭过 MiniMax M3 通知的用户仍能看到 Kimi K3 通知
- 未修改默认模型（`g_model`），符合文档中非旗舰发布的处理惯例

测试：更新了 `registry.test.ts` 的预期 ID 列表及三个 Cypress 端到端测试中的存储键；`typecheck`/`lint`/`fmt`/`test:unit`（3,287 项单元测试）全部通过。所有 UI 字符串均带有中文（`titleZh`/`descriptionZh`）。本改动仅涉及首页推广位，不涉及推理/评估图表数据路径，故无需非官方运行叠加层支持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/nudge and preset wiring only; no auth, data pipeline, or default model changes.
> 
> **Overview**
> **Kimi K3** replaces MiniMax M3 as the landing day-0 promotion: launch **banner** and **modal** copy, links, and analytics now target `/inference?preset=kimi-k3-launch`, with new dismissal keys `inferencex-kimi-k3-{banner,modal}-dismissed` so users who dismissed the old nudges still see the new ones.
> 
> A visible **`kimi-k3-launch`** Quick Comparison preset (`Model.Kimi_K3`, 8k/1k, fp4/fp8) is added first in the list; **`minimax-m3-launch`** stays routable but is **`hidden: true`**. Nudge registry IDs move to `kimi-k3-launch-banner` / `kimi-k3-launch-modal`; unit and Cypress specs update expected IDs and storage keys (generic `launch-banner` / `launch-modal` test IDs unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305af76bea98728779bbed00138cade5108dc0c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->