### PR TITLE
Guard inputs

### DIFF
--- a/docs/collectivex.md
+++ b/docs/collectivex.md
@@ -51,6 +51,9 @@ Key invariants:
 - **"Latest" orders by `run_id`** (monotonic with run creation, matching the discovery
   walk) — not by completion time, where a long-failing older run would shadow a newer
   successful one.
+- **Vendor scope is explicit**: the shared reader accepts only `amd` and `nvidia`
+  result shards (case-insensitive). Other vendor values are omitted from chart series,
+  coverage, and SKU summaries; runs with no supported-vendor cases stay hidden.
 - **GitHub being down never takes the page down**: routes serve whatever the DB holds and
   only surface an error when there is no stored fallback.
 - **Run-list completeness is progressive**: `/api/v1/collectivex/runs` returns

--- a/packages/db/src/collectivex/reader.test.ts
+++ b/packages/db/src/collectivex/reader.test.ts
@@ -175,6 +175,31 @@ describe('CollectiveX artifact assembly', () => {
     expect(series.points).toHaveLength(10);
   });
 
+  it('displays only AMD and NVIDIA vendor cases', () => {
+    const dataset = buildDataset({
+      shards: [
+        makeRawShard(),
+        makeRawShard({ sku: 'mi355x', vendor: 'AMD' }),
+        makeRawShard({ sku: 'www', vendor: 'www' }),
+      ],
+    });
+
+    expect(dataset.series.map((series) => series.system.vendor).toSorted()).toEqual([
+      'amd',
+      'nvidia',
+    ]);
+    expect(dataset.series.map((series) => series.system.sku).toSorted()).toEqual([
+      'h200-dgxc',
+      'mi355x',
+    ]);
+    expect(dataset.coverage.map((row) => row.sku).toSorted()).toEqual(['h200-dgxc', 'mi355x']);
+    expect(dataset.run).toMatchObject({
+      requested_cases: 2,
+      measured_cases: 2,
+      covered_skus: ['h200-dgxc', 'mi355x'],
+    });
+  });
+
   it('derives a per-GPU payload bandwidth from total_logical_bytes', () => {
     const dispatch = makeCollectiveXSeries().points[0].components.dispatch;
     // total_logical_bytes (400000000) / ep (8) / p50 latency (417 µs) → GB/s.

--- a/packages/db/src/collectivex/reader.ts
+++ b/packages/db/src/collectivex/reader.ts
@@ -78,12 +78,24 @@ interface RawMatrix {
   }[];
 }
 
+type CollectiveXVendor = CollectiveXSeries['system']['vendor'];
+
+interface SupportedShard {
+  shard: RawShard;
+  vendor: CollectiveXVendor;
+}
+
 export interface CollectiveXNeutralRunMeta {
   run_id: string;
   run_attempt: number;
   generated_at: string;
   conclusion: string | null;
   source_sha: string;
+}
+
+function toSupportedVendor(raw: string): CollectiveXVendor | null {
+  const vendor = raw.trim().toLowerCase();
+  return vendor === 'amd' || vendor === 'nvidia' ? vendor : null;
 }
 
 function matrixOf(value: unknown): RawMatrix {
@@ -191,7 +203,7 @@ function topologyOf(kase: RawCase) {
   };
 }
 
-function buildSeries(shard: RawShard): CollectiveXSeries {
+function buildSeries({ shard, vendor }: SupportedShard): CollectiveXSeries {
   const kase = shard.identity.case_factors.case;
   return {
     series_id: shard.identity.case_id,
@@ -202,7 +214,7 @@ function buildSeries(shard: RawShard): CollectiveXSeries {
     system: {
       ...topologyOf(kase),
       sku: shard.identity.case_factors.sku,
-      vendor: shard.runtime.vendor === 'amd' ? 'amd' : 'nvidia',
+      vendor,
     },
     points: shard.measurement.rows.map((row) => mapPoint(row, kase.ep)),
   };
@@ -279,19 +291,33 @@ export function buildDatasetFromNeutral(
     if (shard.version !== matrix.version) throw new Error('CollectiveX version mismatch');
     return [shard];
   });
-  const successful = new Map<string, RawShard>();
-  const terminal = new Map<string, RawShard>();
-  for (const shard of shards) {
+  const supportedShards = shards.flatMap((shard): SupportedShard[] => {
+    const vendor = toSupportedVendor(shard.runtime.vendor);
+    return vendor ? [{ shard, vendor }] : [];
+  });
+  const supportedCaseIds = new Set(supportedShards.map(({ shard }) => shard.identity.case_id));
+  const hiddenCaseIds = new Set(
+    shards
+      .filter(
+        (shard) =>
+          !toSupportedVendor(shard.runtime.vendor) && !supportedCaseIds.has(shard.identity.case_id),
+      )
+      .map((shard) => shard.identity.case_id),
+  );
+  const successful = new Map<string, SupportedShard>();
+  const terminal = new Map<string, SupportedShard>();
+  for (const supported of supportedShards) {
+    const { shard } = supported;
     const target = shard.outcome.status === 'success' ? successful : terminal;
-    if (!target.has(shard.identity.case_id)) target.set(shard.identity.case_id, shard);
+    if (!target.has(shard.identity.case_id)) target.set(shard.identity.case_id, supported);
   }
 
   const coverage: CollectiveXCoverage[] = matrix.requested_cases.flatMap((requested) => {
     const kase = requested.case;
     const caseId = kase.case_id;
-    if (!caseId) return [];
-    const measured = successful.get(caseId);
-    const failed = terminal.get(caseId);
+    if (!caseId || hiddenCaseIds.has(caseId)) return [];
+    const measured = successful.get(caseId)?.shard;
+    const failed = terminal.get(caseId)?.shard;
     let outcome: CollectiveXOutcome;
     let reason: string | null;
     let points: CollectiveXCoveragePoint[];

--- a/packages/db/src/queries/collectivex.test.ts
+++ b/packages/db/src/queries/collectivex.test.ts
@@ -5,7 +5,9 @@ import type { DbClient } from '../connection.js';
 import {
   collectiveXDatasetFromRow,
   deleteCollectiveXRun,
+  getCollectiveXRun,
   getCollectiveXRunStates,
+  getLatestCollectiveXRun,
   insertCollectiveXRun,
   listCollectiveXRuns,
   refreshCollectiveXRunAttempt,
@@ -73,12 +75,18 @@ describe('getCollectiveXRunStates', () => {
 });
 
 describe('read queries', () => {
-  it('excludes tombstoned rows and orders newest-created first', async () => {
-    const { sql, calls } = fakeSql([[]]);
+  it('excludes tombstoned and unsupported-vendor-only rows', async () => {
+    const { sql, calls } = fakeSql([[], [], []]);
+    await getLatestCollectiveXRun(sql, 1);
+    await getCollectiveXRun(sql, 1, '160');
     await listCollectiveXRuns(sql, 1);
-    expect(calls[0].text).toContain('deleted_at IS NULL');
-    expect(calls[0].text).toContain('ORDER BY run_id DESC');
-    expect(calls[0].text).not.toContain('LIMIT');
+    for (const call of calls) {
+      expect(call.text).toContain('deleted_at IS NULL');
+      expect(call.text).toContain("summary->>'requested_cases'");
+    }
+    expect(calls[0].text).toContain('ORDER BY r.run_id DESC');
+    expect(calls[2].text).toContain('ORDER BY run_id DESC');
+    expect(calls[2].text).not.toContain('LIMIT');
   });
 });
 

--- a/packages/db/src/queries/collectivex.ts
+++ b/packages/db/src/queries/collectivex.ts
@@ -47,10 +47,11 @@ function toRunRow(row: Record<string, unknown>): CollectiveXRunRow {
 }
 
 /**
- * The most recent live run for a version. Ordered by run_id — GitHub run ids
- * increase monotonically with creation, matching lazy discovery's
- * newest-first walk (completion time would let a long-failing older run
- * shadow a newer successful one).
+ * The most recent visible live run for a version. Zero-case summaries contain
+ * no AMD/NVIDIA data and stay hidden. Ordered by run_id — GitHub run ids
+ * increase monotonically with creation, matching lazy discovery's newest-first
+ * walk (completion time would let a long-failing older run shadow a newer
+ * successful one).
  *
  * Row and documents come back in ONE query, with docs filtered to the row's
  * CURRENT run_attempt: a reader can never observe one attempt's metadata with
@@ -72,13 +73,17 @@ export async function getLatestCollectiveXRun(
       WHERE run_id = r.run_id AND run_attempt = r.run_attempt
     ) d ON true
     WHERE r.version = ${version} AND r.deleted_at IS NULL
+      AND COALESCE((r.summary->>'requested_cases')::int, 0) > 0
     ORDER BY r.run_id DESC
     LIMIT 1
   `;
   return rows.length === 0 ? null : toRunRow(rows[0]);
 }
 
-/** One specific live run by id, or null when absent, tombstoned, or on another version. */
+/**
+ * One specific visible live run by id, or null when absent, tombstoned, on
+ * another version, or carrying no supported-vendor cases.
+ */
 export async function getCollectiveXRun(
   sql: DbClient,
   version: number,
@@ -96,13 +101,15 @@ export async function getCollectiveXRun(
       WHERE run_id = r.run_id AND run_attempt = r.run_attempt
     ) d ON true
     WHERE r.version = ${version} AND r.run_id = ${runId} AND r.deleted_at IS NULL
+      AND COALESCE((r.summary->>'requested_cases')::int, 0) > 0
   `;
   return rows.length === 0 ? null : toRunRow(rows[0]);
 }
 
 /**
- * Every live run summary for a version, newest-first, straight from the
- * precomputed `summary` column — no document loading.
+ * Every visible live run summary for a version, newest-first, straight from
+ * the precomputed `summary` column — no document loading. Runs whose reader
+ * summary contains no AMD/NVIDIA cases stay hidden.
  */
 export async function listCollectiveXRuns(
   sql: DbClient,
@@ -112,6 +119,7 @@ export async function listCollectiveXRuns(
     SELECT summary
     FROM cx_runs
     WHERE version = ${version} AND deleted_at IS NULL
+      AND COALESCE((summary->>'requested_cases')::int, 0) > 0
     ORDER BY run_id DESC
   `;
   return rows.map((row) => row.summary as CollectiveXRunSummary);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes which ingested runs and benchmark cases appear in the UI and API; behavior depends on summary staying aligned with the reader at ingest time.
> 
> **Overview**
> CollectiveX **vendor handling is tightened** so only **AMD** and **NVIDIA** result shards (case-insensitive `runtime.vendor`) feed series, coverage, SKU lists, and run-level counts. Unknown vendors are dropped from charts; matrix cases that exist only on unsupported vendors are omitted from coverage, and run stats (`requested_cases`, `covered_skus`, etc.) reflect that filtered view instead of treating every shard as NVIDIA by default.
> 
> **Read APIs hide empty runs**: `getLatestCollectiveXRun`, `getCollectiveXRun`, and `listCollectiveXRuns` add `summary->>'requested_cases' > 0`, so sweeps with no AMD/NVIDIA cases never surface as “latest” or in the run explorer. Docs describe the explicit vendor scope invariant.
> 
> Tests cover mixed-vendor shard assembly and assert the new SQL predicates on read queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b8e38f95722a623e0dc2e644f7ca27c33d37ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->