### PR TITLE
Explain offload halo in chart legends

### DIFF
--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import LegendPointsDialog from '@/components/inference/ui/LegendPointsDialog';
+import { OffloadHaloLegendKey } from '@/components/inference/ui/OffloadHaloLegendKey';
 import type { InferenceData } from '@/components/inference/types';
 import { buildLegendPointsRows } from '@/components/inference/utils/legend-points-table';
 import ChartLegend, { type CommonLegendItemProps } from '@/components/ui/chart-legend';
@@ -125,6 +126,29 @@ describe('ChartLegend (sidebar variant)', () => {
 
   it('renders no points-table icon when items have no onShowPoints handler', () => {
     cy.get('[data-testid^="legend-points-"]').should('not.exist');
+  });
+
+  it('renders an exportable key explaining the agentic offload halo', () => {
+    cy.mount(
+      <ChartLegend
+        legendItems={MOCK_ITEMS}
+        isLegendExpanded={true}
+        onExpandedChange={() => {}}
+        variant="sidebar"
+        keyIndicators={<OffloadHaloLegendKey />}
+      />,
+    );
+
+    cy.get('[data-testid="offload-halo-key"]')
+      .should('be.visible')
+      .and('contain.text', 'Dashed halo:')
+      .and('contain.text', 'KV offload ON')
+      .and('not.have.class', 'no-export');
+    cy.get('[data-testid="offload-halo-key"] circle[stroke-dasharray="3 2"]').should('exist');
+    cy.get('[data-testid="chart-legend"]').then(($legend) => {
+      const exportClone = $legend[0].cloneNode(true) as HTMLElement;
+      expect(exportClone.querySelector('[data-testid="offload-halo-key"]')).not.to.equal(null);
+    });
   });
 });
 

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -115,7 +115,9 @@ const agenticBenchmarks = agenticGpus.flatMap((g) =>
     isl: null,
     osl: null,
     conc,
-    offload_mode: 'off',
+    // Keep both visual variants in the fixture: the middle point gets the
+    // dashed offload halo while the others remain plain.
+    offload_mode: conc === 64 ? 'on' : 'off',
     benchmark_type: 'agentic_traces',
     image: 'vllm/vllm-openai:v0.9.0',
     metrics: agenticMetrics(conc),
@@ -169,6 +171,40 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       .should('be.visible')
       .and('have.attr', 'aria-selected', 'true');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+  });
+
+  it('explains the offload halo in the legend and distinguishes it from plain points', () => {
+    cy.get('#chart-0 [data-testid="offload-halo-key"]')
+      .should('be.visible')
+      .and('contain.text', 'Dashed halo:')
+      .and('contain.text', 'KV offload ON');
+    cy.get('#chart-0 .offload-halo').should('have.length.at.least', 1);
+    cy.get('#chart-0 .dot-group').then(($points) => {
+      cy.get('#chart-0 .offload-halo').should(($halos) => {
+        expect($halos.length).to.be.lessThan($points.length);
+      });
+    });
+  });
+
+  it('keeps the offload halo explanation in the PNG export clone', () => {
+    cy.window().then((win) => {
+      const exportContainer = win.document.querySelector('#chart-0-export');
+      expect(exportContainer).not.to.equal(null);
+      const state = { seen: false };
+      const observer = new win.MutationObserver(() => {
+        if (exportContainer?.querySelector('[data-testid="offload-halo-key"]')) {
+          state.seen = true;
+          observer.disconnect();
+        }
+      });
+      observer.observe(exportContainer!, { childList: true, subtree: true });
+      (win as typeof win & { __offloadHaloExportState: typeof state }).__offloadHaloExportState =
+        state;
+    });
+
+    cy.get('[data-testid="chart-figure"]').first().find('[data-testid="export-button"]').click();
+    cy.get('[data-testid="export-png-button"]').click();
+    cy.window().its('__offloadHaloExportState.seen').should('eq', true);
   });
 
   it('shows the selected percentile in the Interactivity axis label', () => {
@@ -335,7 +371,7 @@ const overlayBenchmarkRow = {
   isl: null,
   osl: null,
   conc: 32,
-  offload_mode: 'off',
+  offload_mode: 'on',
   benchmark_type: 'agentic_traces',
   image: 'vllm/vllm-openai:v0.9.0',
   metrics: agenticMetrics(32),
@@ -345,7 +381,12 @@ const overlayBenchmarkRow = {
 };
 
 const interceptAgenticDataWithOverlay = () => {
-  interceptAgenticData();
+  cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as('availability');
+  // The official path has no halo in this suite, so the legend key below can
+  // only be activated by the offloaded unofficial-run point.
+  cy.intercept('GET', '/api/v1/benchmarks*', {
+    body: agenticBenchmarks.map((row) => ({ ...row, offload_mode: 'off' })),
+  }).as('benchmarks');
   cy.intercept('GET', '/api/unofficial-run*', {
     body: {
       runInfos: [
@@ -401,6 +442,10 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
       'contain.text',
       'P90 Interactivity (tok/s/user)',
     );
+    cy.get('#chart-0 [data-testid="offload-halo-key"]')
+      .should('be.visible')
+      .and('contain.text', 'Dashed halo:')
+      .and('contain.text', 'KV offload ON');
   });
 
   it('switches to ttft x-axis mode and renders SVG with overlay points', () => {

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -28,7 +28,6 @@ import {
   formatLargeNumber,
   getShapeKeyForPrecision,
   logTickFormat,
-  POINT_SIZE,
 } from '@/lib/chart-rendering';
 import {
   isFrontierEligible,
@@ -58,6 +57,12 @@ import {
   renderKnownIssueAnnotations,
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchKnownConfigIssues, pointMatchesIssue } from '@/lib/known-issues';
+import {
+  OFFLOAD_HALO_DASHARRAY,
+  OFFLOAD_HALO_RADIUS,
+  OFFLOAD_HALO_STROKE_WIDTH,
+  OffloadHaloLegendKey,
+} from '@/components/inference/ui/OffloadHaloLegendKey';
 
 const CHART_MARGIN = { top: 24, right: 10, bottom: 60, left: 60 };
 
@@ -135,6 +140,7 @@ const GPUGraph = React.memo(
     const legendT = GPU_STRINGS[locale];
     const { resolvedTheme } = useTheme();
     const chartRef = useRef<D3ChartHandle>(null);
+    const hasOffloadHalo = useMemo(() => data.some((point) => point.offload_mode === 'on'), [data]);
 
     // Shared date+GPU pairs. `dates` holds comparison-series entries (plain dates
     // and/or specific-run entries); a same-day range endpoint is dropped when that
@@ -930,11 +936,11 @@ const GPUGraph = React.memo(
                 .data(showHalo ? [true] : [])
                 .join('circle')
                 .attr('class', 'offload-halo')
-                .attr('r', POINT_SIZE + 4)
+                .attr('r', OFFLOAD_HALO_RADIUS)
                 .attr('fill', 'none')
                 .attr('stroke', 'var(--foreground)')
-                .attr('stroke-width', 1.5)
-                .attr('stroke-dasharray', '3 2')
+                .attr('stroke-width', OFFLOAD_HALO_STROKE_WIDTH)
+                .attr('stroke-dasharray', OFFLOAD_HALO_DASHARRAY)
                 .attr('opacity', 0.9)
                 .attr('pointer-events', 'none');
             });
@@ -1036,6 +1042,7 @@ const GPUGraph = React.memo(
               },
             ]}
             precisionIndicators={selectedPrecisions}
+            keyIndicators={hasOffloadHalo ? <OffloadHaloLegendKey /> : undefined}
           />
         }
       />

--- a/packages/app/src/components/inference/ui/OffloadHaloLegendKey.tsx
+++ b/packages/app/src/components/inference/ui/OffloadHaloLegendKey.tsx
@@ -1,0 +1,43 @@
+import { POINT_SIZE } from '@/lib/chart-rendering';
+
+export const OFFLOAD_HALO_RADIUS = POINT_SIZE + 4;
+export const OFFLOAD_HALO_STROKE_WIDTH = 1.5;
+export const OFFLOAD_HALO_DASHARRAY = '3 2';
+
+/**
+ * Legend key for the dashed ring drawn around agentic points that use KV-cache
+ * offload. This stays outside `no-export` content so the chart export clone
+ * carries the same explanation into downloaded PNGs.
+ */
+export function OffloadHaloLegendKey() {
+  return (
+    <div
+      data-testid="offload-halo-key"
+      className="mt-2 flex w-full items-center gap-2 px-1 pr-2 text-xs text-muted-foreground"
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 20 20"
+        className="shrink-0"
+        style={{ maxWidth: 16 }}
+        aria-hidden="true"
+      >
+        <circle cx="10" cy="10" r={POINT_SIZE} fill="currentColor" opacity="0.45" />
+        <circle
+          cx="10"
+          cy="10"
+          r={OFFLOAD_HALO_RADIUS}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={OFFLOAD_HALO_STROKE_WIDTH}
+          strokeDasharray={OFFLOAD_HALO_DASHARRAY}
+        />
+      </svg>
+      <span className="min-w-0 leading-tight">
+        <span className="block">Dashed halo:</span>
+        <span className="block">KV offload ON</span>
+      </span>
+    </div>
+  );
+}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -66,6 +66,12 @@ import {
   getPointLabel,
 } from '@/components/inference/utils/tooltipUtils';
 import LegendPointsDialog from '@/components/inference/ui/LegendPointsDialog';
+import {
+  OFFLOAD_HALO_DASHARRAY,
+  OFFLOAD_HALO_RADIUS,
+  OFFLOAD_HALO_STROKE_WIDTH,
+  OffloadHaloLegendKey,
+} from '@/components/inference/ui/OffloadHaloLegendKey';
 import { buildLegendPointsRows } from '@/components/inference/utils/legend-points-table';
 import {
   type ParetoPointLabel,
@@ -838,6 +844,12 @@ const ScatterGraph = React.memo(
 
     // All official points for rendering (unfiltered — visibility via opacity)
     const pointsData = useMemo(() => Object.values(groupedData).flat(), [groupedData]);
+    const hasOffloadHalo = useMemo(
+      () =>
+        pointsData.some((point) => point.offload_mode === 'on') ||
+        processedOverlayData.some((point) => point.offload_mode === 'on'),
+      [pointsData, processedOverlayData],
+    );
 
     // Bulk presence lookup for agentic points: which ids have a stored
     // trace_replay blob → controls the "View charts" button in the pinned
@@ -2541,11 +2553,11 @@ const ScatterGraph = React.memo(
             .data(showHalo ? [true] : [])
             .join('circle')
             .attr('class', 'offload-halo')
-            .attr('r', POINT_SIZE + 4)
+            .attr('r', OFFLOAD_HALO_RADIUS)
             .attr('fill', 'none')
             .attr('stroke', 'var(--foreground)')
-            .attr('stroke-width', 1.5)
-            .attr('stroke-dasharray', '3 2')
+            .attr('stroke-width', OFFLOAD_HALO_STROKE_WIDTH)
+            .attr('stroke-dasharray', OFFLOAD_HALO_DASHARRAY)
             .attr('opacity', 0.9)
             .attr('pointer-events', 'none');
         });
@@ -3080,6 +3092,7 @@ const ScatterGraph = React.memo(
                   : []
               }
               precisionIndicators={selectedPrecisions}
+              keyIndicators={hasOffloadHalo ? <OffloadHaloLegendKey /> : undefined}
               enableTooltips={true}
             />
           }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only legend and test fixture changes; no API or data-model changes beyond reusing existing offload_mode.
> 
> **Overview**
> Adds a **legend key** that explains the dashed ring on agentic points when **KV offload is ON**, so users can tell halo-marked series apart from plain points without guessing.
> 
> The key is rendered through `ChartLegend`'s existing `keyIndicators` slot on **ScatterGraph** and **GPUGraph** only when at least one visible point (including unofficial-run overlays on scatter) has `offload_mode === 'on'`. Halo drawing on the chart reuses shared constants from a new `OffloadHaloLegendKey` module so the legend icon matches the SVG rings.
> 
> The legend key is kept **outside** `no-export` content so **PNG exports** include the same explanation. Cypress component and e2e coverage assert copy, halo vs plain point counts, overlay activation, and export-clone presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df2bbc6ff951e4c85b10b454e5d9b2a61cc80059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->