### PR TITLE
fix(staging): preserve staged benchmark runs / 修复预发布基准测试运行持久化

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -32,6 +32,11 @@ on:
         description: Existing InferenceX acknowledgment comment to update
         required: false
         type: string
+      reset-staging-database:
+        description: Replace all staged runs by restoring the database from production before ingest
+        required: false
+        default: false
+        type: boolean
 
 permissions: {}
 
@@ -50,6 +55,7 @@ jobs:
       pr-number: ${{ steps.request.outputs.pr-number }}
       requested-by: ${{ steps.request.outputs.requested-by }}
       comment-id: ${{ steps.request.outputs.comment-id }}
+      reset-staging-database: ${{ steps.request.outputs.reset-staging-database }}
     steps:
       - name: Validate request payload
         id: request
@@ -60,6 +66,7 @@ jobs:
           PR_NUMBER: ${{ github.event.client_payload.pr-number || inputs.pr-number }}
           REQUESTED_BY: ${{ github.event.client_payload.requested-by || inputs.requested-by }}
           COMMENT_ID: ${{ github.event.client_payload.comment-id || inputs.comment-id }}
+          RESET_STAGING_DATABASE: ${{ inputs.reset-staging-database || false }}
           SOURCE_REPOSITORY: ${{ github.event.client_payload.source-repository || 'SemiAnalysisAI/InferenceX' }}
         run: |
           if [[ ! "$RUN_ID" =~ ^[0-9]+$ ]]; then
@@ -86,6 +93,10 @@ jobs:
             echo "::error::comment-id must be numeric when provided"
             exit 1
           fi
+          if [[ ! "$RESET_STAGING_DATABASE" =~ ^(true|false)$ ]]; then
+            echo "::error::reset-staging-database must be true or false"
+            exit 1
+          fi
           if [ "$SOURCE_REPOSITORY" != "SemiAnalysisAI/InferenceX" ]; then
             echo "::error::Unsupported source repository: $SOURCE_REPOSITORY"
             exit 1
@@ -98,6 +109,7 @@ jobs:
             echo "pr-number=$PR_NUMBER"
             echo "requested-by=$REQUESTED_BY"
             echo "comment-id=$COMMENT_ID"
+            echo "reset-staging-database=$RESET_STAGING_DATABASE"
           } >> "$GITHUB_OUTPUT"
 
   sync-staging-branch:
@@ -143,15 +155,22 @@ jobs:
             }
             core.notice(`staging now points to ${sha}`);
 
-  refresh-staging-database:
-    name: Refresh Neon staging branch
+  prepare-staging-database:
+    name: Prepare Neon staging branch
     needs: [validate, sync-staging-branch]
     runs-on: ubuntu-latest
-    env:
-      NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
-      NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
     steps:
+      - name: Preserve accumulated staged runs
+        if: needs.validate.outputs.reset-staging-database != 'true'
+        run: |
+          echo "Preserving the existing Neon staging branch."
+          echo "The ingest is idempotent for this run ID and does not remove other staged runs."
+
       - name: Restore staging from production head
+        if: needs.validate.outputs.reset-staging-database == 'true'
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
         run: |
           if [ -z "$NEON_API_KEY" ] || [ -z "$NEON_PROJECT_ID" ]; then
             echo "::error::NEON_API_KEY and NEON_PROJECT_ID are required"
@@ -179,8 +198,8 @@ jobs:
           fi
 
           payload=$(jq -cn --arg source_branch_id "$source_branch_id" '{source_branch_id: $source_branch_id}')
-          # This destructive refresh removes the previous unofficial staging ingest.
-          # Every request therefore starts with production data and replaces the shared staged run.
+          # This is an explicit maintenance operation. Normal staging requests preserve
+          # accumulated runs and rely on idempotent run-keyed ingestion.
           curl --retry 3 --retry-all-errors -sSf -X POST \
             -H "Authorization: Bearer $NEON_API_KEY" \
             -H "Content-Type: application/json" \
@@ -206,7 +225,7 @@ jobs:
 
   ingest:
     name: Ingest selected run
-    needs: [validate, refresh-staging-database]
+    needs: [validate, prepare-staging-database]
     permissions:
       contents: read
     uses: ./.github/workflows/ingest-agentic-results.yml
@@ -223,7 +242,7 @@ jobs:
   report:
     name: Report staging result
     if: ${{ always() && needs.validate.result == 'success' }}
-    needs: [validate, sync-staging-branch, refresh-staging-database, ingest]
+    needs: [validate, sync-staging-branch, prepare-staging-database, ingest]
     runs-on: ubuntu-latest
     permissions: {}
     steps:
@@ -235,7 +254,7 @@ jobs:
           PR_NUMBER: ${{ needs.validate.outputs.pr-number }}
           REQUESTED_BY: ${{ needs.validate.outputs.requested-by }}
           COMMENT_ID: ${{ needs.validate.outputs.comment-id }}
-          STAGE_SUCCEEDED: ${{ needs['sync-staging-branch'].result == 'success' && needs['refresh-staging-database'].result == 'success' && needs.ingest.result == 'success' }}
+          STAGE_SUCCEEDED: ${{ needs['sync-staging-branch'].result == 'success' && needs['prepare-staging-database'].result == 'success' && needs.ingest.result == 'success' }}
         with:
           github-token: ${{ secrets.PAT }}
           script: |


### PR DESCRIPTION
## Summary

- Preserve previously staged benchmark runs when `/stage-results` ingests another run.
- Keep staging requests globally serialized so database writes cannot overlap.
- Continue using the existing idempotent run-keyed ingestion, so staging the same run ID updates that run without removing other staged runs.
- Add a manual-only `reset-staging-database` option for intentionally restoring Neon staging from production before an ingest.

## Why

The staging workflow currently restores the Neon staging branch from production before every ingest. That makes staging a single replaceable slot: staging run B deletes staged run A. Staging is intended to accumulate independently addressable runs, with replacement scoped to the same run ID.

## Companion PR

[InferenceX PR #2412](https://github.com/SemiAnalysisAI/InferenceX/pull/2412) updates `/stage-results` acknowledgment and completion messages to describe the persistent behavior.

## Validation

- `actionlint .github/workflows/stage-results.yml`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 3,441 tests passed

## 中文说明

### 变更概述

- `/stage-results` 写入新运行时，继续保留此前已发布的基准测试运行。
- 保留全局串行机制，避免多个预发布数据库写入并发执行。
- 继续使用现有的按运行键幂等写入逻辑；重复发布同一运行 ID 时只更新该运行，不会移除其他已发布运行。
- 新增仅供手动触发的 `reset-staging-database` 选项，需要明确选择后才会在写入前从生产环境恢复 Neon staging。

### 背景

当前预发布工作流会在每次写入前将 Neon staging 分支恢复到生产数据库状态，因此预发布环境实际上只有一个可替换槽位：发布运行 B 会删除此前发布的运行 A。预发布环境应能累积多个可独立访问的运行，且替换范围仅限相同的运行 ID。

### 配套 PR

[InferenceX PR #2412](https://github.com/SemiAnalysisAI/InferenceX/pull/2412) 会更新 `/stage-results` 的请求确认与完成提示，使其准确说明运行持久化语义。

### 验证

- `actionlint .github/workflows/stage-results.yml`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 3,441 项测试通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared staging DB semantics (data persistence vs full reset) and keeps a destructive Neon restore path behind an explicit flag; ingest concurrency is unchanged.
> 
> **Overview**
> **Staging no longer wipes the Neon staging database on every `/stage-results` ingest.** The job formerly named `refresh-staging-database` is now `prepare-staging-database`: by default it skips the Neon restore and relies on idempotent, run-keyed ingestion so new runs accumulate and re-staging the same run ID only updates that run.
> 
> **Opt-in reset:** `workflow_dispatch` gains a `reset-staging-database` boolean (default `false`). When `true`, behavior matches the old path—restore staging from production before ingest—and validation passes the flag through job outputs. The `report` job’s success gate and `needs` list were updated for the renamed prepare job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4170af046561bf3b456369727f652acc1cfc8334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->