### PR TITLE
fix(overview): clarify speculative decode labels / 明确总览页推测解码标签

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -151,7 +151,7 @@ describe('Overview page', () => {
     });
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
-      cy.contains('MTP').should('exist');
+      cy.contains('Spec decode (MTP)').should('exist');
       platform('gb300').within(() => {
         cy.get('[data-testid="overview-pair-value"][data-hardware="gb300"]')
           .should('have.attr', 'title', 'Estimated from validated benchmark runs.')
@@ -164,6 +164,9 @@ describe('Overview page', () => {
         ).should('have.text', '≈$1.19');
         cy.get('[data-testid="overview-pair-missing"]').should('not.exist');
       });
+    });
+    desktopModel('MiniMax-M3').within(() => {
+      platform('gb300').should('contain.text', 'Spec decode (M3 EAGLE)');
     });
     cy.contains(
       'Priority: speculative FP4 → speculative FP8 → standard FP4 → standard FP8.',
@@ -553,13 +556,15 @@ describe('Overview page', () => {
         });
 
         cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
-          cy.contains('div', 'SGLang · FP8 · MTP').then(([metadata]) => {
-            const valueRect = textRect(value);
-            const metadataRect = textRect(metadata);
+          cy.contains('div', 'SGLang · FP8')
+            .should('contain.text', 'Spec decode (MTP)')
+            .then(([metadata]) => {
+              const valueRect = textRect(value);
+              const metadataRect = textRect(metadata);
 
-            expect(metadataRect.top).to.be.at.least(valueRect.bottom);
-            expect(getComputedStyle(metadata).fontSize).to.equal('11px');
-          });
+              expect(metadataRect.top).to.be.at.least(valueRect.bottom);
+              expect(getComputedStyle(metadata).fontSize).to.equal('11px');
+            });
         });
       });
     });
@@ -639,6 +644,9 @@ describe('Overview page', () => {
       cy.get('[data-testid="overview-pair-missing"]').should('have.length', 2);
       platform('b200').should('contain.text', '标准解码');
       platform('b200').find('[data-testid="overview-cost-delta"]').should('not.exist');
+    });
+    desktopModel('DeepSeek-V4-Pro').within(() => {
+      platform('b200').should('contain.text', '推测解码（MTP）');
     });
     desktopModel('GLM-5.2').within(() => {
       cy.get('[data-testid="overview-model-scenario"]').should('have.text', 'AgentX');

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -54,6 +54,7 @@ export const OVERVIEW_STRINGS = {
       cannot_reach_at_tier: `cannot reach @${tier}`,
       no_exact_at_tier: `no exact @${tier} result`,
     }),
+    speculativeDecodeLabel: (method: string) => `Spec decode (${method})`,
     standardDecodeLabel: 'Standard decode',
     methodologyNote: 'Priority: speculative FP4 → speculative FP8 → standard FP4 → standard FP8.',
     costNote:
@@ -104,6 +105,7 @@ export const OVERVIEW_STRINGS = {
       cannot_reach_at_tier: `无法达到 @${tier}`,
       no_exact_at_tier: `无精确 @${tier} 结果`,
     }),
+    speculativeDecodeLabel: (method: string) => `推测解码（${method}）`,
     standardDecodeLabel: '标准解码',
     methodologyNote: '优先顺序：推测解码 FP4 → 推测解码 FP8 → 标准解码 FP4 → 标准解码 FP8。',
     costNote: '成本 = 3 年期租赁 $/GPU/小时 ÷ 每张已部署 GPU 的输出 tok/s。所有百分比均相对 B200。',
@@ -266,26 +268,32 @@ function CellValue({
     return <CellMissing hardware={member.hardware} reason={missingReasonCopy(member, strings)} />;
   }
   const precisionLabel = config?.precision.toUpperCase() ?? member.precision?.toUpperCase() ?? null;
-  const specLabel =
+  const evidenceSpecLabel =
     config === null
       ? null
       : config.specMethod === 'none' || config.specMethod === ''
         ? strings.standardDecodeLabel
         : config.specLabel;
-  const stackBadge =
-    config === null || precisionLabel === null || specLabel === null
+  const decodeLabel =
+    config === null || evidenceSpecLabel === null
       ? null
-      : [config.frameworkLabel, precisionLabel, specLabel]
-          .filter((part): part is string => part !== null)
-          .join(' · ');
+      : config.specMethod === 'none' || config.specMethod === ''
+        ? evidenceSpecLabel
+        : strings.speculativeDecodeLabel(evidenceSpecLabel);
+  const stackPrefix =
+    config === null || precisionLabel === null
+      ? null
+      : [config.frameworkLabel, precisionLabel].join(' · ');
+  const stackBadge =
+    stackPrefix === null || decodeLabel === null ? null : [stackPrefix, decodeLabel].join(' · ');
   const stack =
-    config === null
+    config === null || evidenceSpecLabel === null
       ? null
       : [
           member.hardwareLabel,
           config.frameworkLabel,
           config.precision.toUpperCase(),
-          specLabel,
+          evidenceSpecLabel,
         ].join(' · ');
   const evidenceDateLabel =
     evidenceDate === null ? '' : formatEvidenceDate(formatters, evidenceDate);
@@ -358,7 +366,16 @@ function CellValue({
       </div>
       {member.precision === null ? null : (
         <div className="min-w-0 text-[11px] leading-tight font-normal uppercase tracking-wider text-muted-foreground/70">
-          {config === null ? member.precision.toUpperCase() : stackBadge}
+          {config === null ? (
+            member.precision.toUpperCase()
+          ) : phoneRow && stackPrefix !== null && decodeLabel !== null ? (
+            <>
+              <span className="block">{stackPrefix}</span>
+              <span className="block">{decodeLabel}</span>
+            </>
+          ) : (
+            stackBadge
+          )}
         </div>
       )}
     </div>
@@ -501,7 +518,7 @@ export function MobileOverviewList({ models, locale, formatters, strings }: Surf
                   key={platform.hardware}
                   data-testid="overview-mobile-platform-row"
                   data-hardware={platform.hardware}
-                  className="grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-2.5 last:border-b-0"
+                  className="grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-1.5 last:border-b-0"
                 >
                   <span
                     data-testid="overview-mobile-hardware"


### PR DESCRIPTION
## Summary
- label speculative results as `Spec decode (<method>)`
- keep `Standard decode` for non-speculative fallback results and preserve method-specific evidence links
- split engine/precision and decode metadata into two compact lines on mobile and tablet

## Validation
- Chrome Overview E2E: 14/14
- Firefox Overview E2E: 14/14
- production build, typecheck, lint, and format

## 中文说明
- 将推测解码结果标记为 `推测解码（具体方法）`
- 标准解码回退结果继续显示“标准解码”，原始证据链接保留具体方法
- 手机和平板将引擎/精度与解码信息拆成紧凑的两行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only copy and layout in the overview scorecard with matching E2E updates; no auth, data, or API behavior changes.
> 
> **Overview**
> Overview matrix cells now distinguish **speculative** vs **standard** decoding in the UI copy instead of showing bare method names (e.g. **Spec decode (MTP)** / **推测解码（MTP）**), while **Standard decode** / **标准解码** stays for non-speculative reads.
> 
> Desktop metadata still uses a single `engine · precision · decode` line; on **mobile/tablet** rows, engine/precision and decode labels render as **two compact lines**, with slightly tighter row padding. Raw evidence link titles continue to use the underlying method name in the stack string.
> 
> Cypress overview specs were updated for the new labels (including MiniMax M3 EAGLE and zh locale).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85774b0ba84a6a811145e8f8bdaccb6ea1f3a019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->