### PR TITLE
fix(db): honor explicit Dynamo disagg state / 尊重 Dynamo 显式 disagg 状态

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -135,7 +135,9 @@ All normalizer logic lives in `packages/db/src/etl/normalizers.ts`. The function
 1. Look up `fw.toLowerCase()` in `FRAMEWORK_ALIASES` (defined in `packages/constants/src/framework-aliases.ts`).
 2. If a match exists, use `alias.canonical` as the framework name and `alias.disagg` as the disagg flag. Example: `sglang-disagg` → `{ framework: 'mori-sglang', disagg: true }`.
 3. If no alias exists, the lowercased raw string is used as-is.
-4. The disagg flag falls back to the raw `disaggField` from the artifact (coerced via `parseBool`, accepting `true`, `"true"`, `"True"`).
+4. An explicit `disagg` field is authoritative for canonical `dynamo-*` frameworks because Dynamo can orchestrate either a disaggregated deployment or one distributed server. Boolean and lowercase/Python-style string values are accepted.
+5. Legacy `dynamo-*` artifacts that omit or do not provide a recognizable `disagg` value fall back to `true`. Canonical `mori-*` frameworks remain intrinsically disaggregated.
+6. Mapper-level topology validation still marks a deployment as disaggregated when it has a non-zero decode worker pool, preserving older genuinely disaggregated Dynamo artifacts that incorrectly emitted `disagg: false`.
 
 `FRAMEWORK_ALIASES` keys are sorted longest-first in `SORTED_ALIASES` (used by `resolveFrameworkAliasesInString`) to prevent substring conflicts — `dynamo-trtllm` must be matched before `trtllm`.
 

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -338,11 +338,44 @@ describe('mapBenchmarkRow', () => {
       expect(result!.config.disagg).toBe(true);
     });
 
-    it('normalizes dynamo-trtllm to dynamo-trt and forces disagg=true (framework implies it)', () => {
+    it('normalizes legacy Dynamo rows without a disagg field to disagg=true', () => {
       const tracker = createSkipTracker();
       const result = mapBenchmarkRow(makeV1Row({ framework: 'dynamo-trtllm' }), tracker);
 
       expect(result!.config.framework).toBe('dynamo-trt');
+      expect(result!.config.disagg).toBe(true);
+    });
+
+    it('preserves explicit disagg=false for a multi-node Dynamo server', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV2Row({
+          framework: 'dynamo-vllm',
+          disagg: false,
+          is_multinode: true,
+          prefill_num_workers: 1,
+          decode_num_workers: 0,
+        }),
+        tracker,
+      );
+
+      expect(result!.config.framework).toBe('dynamo-vllm');
+      expect(result!.config.disagg).toBe(false);
+      expect(result!.config.isMultinode).toBe(true);
+    });
+
+    it('keeps legacy disagg=false Dynamo artifacts disaggregated when decode workers exist', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV2Row({
+          framework: 'dynamo-vllm',
+          disagg: false,
+          prefill_num_workers: 1,
+          decode_num_workers: 1,
+        }),
+        tracker,
+      );
+
       expect(result!.config.disagg).toBe(true);
     });
   });

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -224,7 +224,10 @@ export function mapBenchmarkRow(
       ? row.offload_mode
       : (descriptorToOnOff(row.kv_offloading) ?? descriptorToOnOff(row.offloading) ?? 'off');
 
-  const { framework, disagg } = normalizeFramework(String(row.framework ?? ''), row.disagg);
+  const { framework, disagg: frameworkDisagg } = normalizeFramework(
+    String(row.framework ?? ''),
+    row.disagg,
+  );
   const isMultinode = parseBool(row.is_multinode);
   const precision = normalizePrecision(String(row.precision ?? ''));
   if (!PRECISION_KEYS.has(precision)) {
@@ -233,6 +236,11 @@ export function mapBenchmarkRow(
   const specMethod = normalizeSpecMethod(row.spec_decoding);
 
   const parallelism = resolveParallelism(row);
+  // An explicit non-disagg Dynamo artifact is authoritative for direct
+  // deployments such as one distributed vLLM server. A non-zero decode worker
+  // pool, however, is structural proof of disaggregation and preserves older
+  // Dynamo artifacts that incorrectly emitted disagg=false.
+  const disagg = frameworkDisagg || parallelism.decodeNumWorkers > 0;
   const metrics = captureNumericMetrics(row);
 
   // Agentic rows emit `offload_mode: "on" | "off"` (or older `offloading: "none"|...`)

--- a/packages/db/src/etl/eval-mapper.test.ts
+++ b/packages/db/src/etl/eval-mapper.test.ts
@@ -409,6 +409,25 @@ describe('mapAggEvalRow', () => {
       expect(result!.config.disagg).toBe(true);
     });
 
+    it('preserves explicit disagg=false for a multi-node Dynamo eval', () => {
+      const tracker = createSkipTracker();
+      const result = mapAggEvalRow(
+        makeV2Row({ disagg: false, prefill_num_workers: 1, decode_num_workers: 0 }),
+        tracker,
+      );
+
+      expect(result!.config.framework).toBe('dynamo-trt');
+      expect(result!.config.disagg).toBe(false);
+      expect(result!.config.isMultinode).toBe(true);
+    });
+
+    it('treats a decode worker pool as disaggregated despite a legacy false field', () => {
+      const tracker = createSkipTracker();
+      const result = mapAggEvalRow(makeV2Row({ disagg: false }), tracker);
+
+      expect(result!.config.disagg).toBe(true);
+    });
+
     it('keeps disagg=false for a non-dynamo/mori framework with zero workers / not multinode', () => {
       const tracker = createSkipTracker();
       const result = mapAggEvalRow(

--- a/packages/db/src/etl/eval-mapper.ts
+++ b/packages/db/src/etl/eval-mapper.ts
@@ -15,6 +15,7 @@ import {
   normalizePrecision,
   normalizeSpecMethod,
   parseBool,
+  parseOptionalBool,
   parseNum,
   parseInt2,
   parseIslOsl,
@@ -213,11 +214,10 @@ export function mapAggEvalRow(row: Record<string, any>, tracker: SkipTracker): E
  *   with `prefill_num_workers`/`decode_num_workers` and `is_multinode`. Presence of
  *   `prefill_tp` on the source selects the v2 branch.
  *
- * `disagg` is true if the framework alias forced it (e.g. `sglang-disagg`), or if
- * the row carries `is_multinode: true`, or if either side has workers > 0 —
- * this keeps disagg eval configs from collapsing onto non-disagg ones via the
- * natural key (which would otherwise merge them because eval-mapper used to
- * copy v1 `tp`/`ep` into both prefill and decode slots).
+ * An explicit `disagg: false` on a Dynamo row is authoritative for a direct
+ * deployment unless a non-zero decode worker pool proves disaggregation.
+ * When the field is absent, the framework, multi-node marker, and worker
+ * topology retain the legacy inference behavior.
  */
 function buildEvalConfig(
   src: Record<string, any>,
@@ -263,7 +263,11 @@ function buildEvalConfig(
     numDecodeGpu = tp * ep;
   }
 
-  const disagg = disaggFromFw || isMultinode || prefillNumWorkers > 0 || decodeNumWorkers > 0;
+  const explicitDisagg = parseOptionalBool(src.disagg);
+  const disagg =
+    disaggFromFw ||
+    decodeNumWorkers > 0 ||
+    (explicitDisagg === undefined && (isMultinode || prefillNumWorkers > 0));
 
   return {
     hardware,

--- a/packages/db/src/etl/normalizers.test.ts
+++ b/packages/db/src/etl/normalizers.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeFramework,
   normalizeSpecMethod,
   parseBool,
+  parseOptionalBool,
   parseNum,
   parseInt2,
   parseIslOsl,
@@ -253,8 +254,12 @@ describe('normalizeFramework', () => {
     });
   });
 
-  it('renames dynamo-trtllm to dynamo-trt and forces disagg=true (framework implies it)', () => {
+  it('renames dynamo-trtllm while preserving an explicit non-disagg value', () => {
     expect(normalizeFramework('dynamo-trtllm', false)).toEqual({
+      framework: 'dynamo-trt',
+      disagg: false,
+    });
+    expect(normalizeFramework('dynamo-trtllm', undefined)).toEqual({
       framework: 'dynamo-trt',
       disagg: true,
     });
@@ -276,13 +281,17 @@ describe('normalizeFramework', () => {
     });
   });
 
-  it('forces disagg=true for dynamo-* canonicals regardless of disaggField', () => {
+  it('honors explicit Dynamo disagg values and only infers true when absent', () => {
     expect(normalizeFramework('dynamo-trt', false)).toEqual({
       framework: 'dynamo-trt',
-      disagg: true,
+      disagg: false,
     });
     expect(normalizeFramework('dynamo-sglang', 'false')).toEqual({
       framework: 'dynamo-sglang',
+      disagg: false,
+    });
+    expect(normalizeFramework('dynamo-vllm', true)).toEqual({
+      framework: 'dynamo-vllm',
       disagg: true,
     });
     expect(normalizeFramework('dynamo-vllm', null)).toEqual({
@@ -344,6 +353,22 @@ describe('parseBool', () => {
     expect(parseBool(1)).toBe(false);
     expect(parseBool('1')).toBe(false);
     expect(parseBool('TRUE')).toBe(false);
+  });
+});
+
+describe('parseOptionalBool', () => {
+  it('preserves explicit true and false values', () => {
+    expect(parseOptionalBool(true)).toBe(true);
+    expect(parseOptionalBool('True')).toBe(true);
+    expect(parseOptionalBool(false)).toBe(false);
+    expect(parseOptionalBool('False')).toBe(false);
+  });
+
+  it('returns undefined for absent or unrecognized values', () => {
+    expect(parseOptionalBool(null)).toBeUndefined();
+    expect(parseOptionalBool(undefined)).toBeUndefined();
+    expect(parseOptionalBool('TRUE')).toBeUndefined();
+    expect(parseOptionalBool(1)).toBeUndefined();
   });
 });
 

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -138,14 +138,14 @@ export function resolveModelKey(row: Record<string, any>): string | null {
  * Handles special cases: `sglang-disagg` is normalized to `mori-sglang` + `disagg=true`;
  * `dynamo-trtllm` is renamed to `dynamo-trt`.
  *
- * Framework name carries disagg semantics: any canonical framework starting
- * with `dynamo-` or `mori-` implies disagg, regardless of what the artifact
- * wrote in its `disagg` field. Older artifacts (pre-2026-04) sometimes set
- * `disagg=false` under these frameworks, which produced mixed-date legend
- * lines in the frontend — see migration 002.
+ * An explicit `disagg` value from the artifact is authoritative for Dynamo:
+ * Dynamo can orchestrate a non-disaggregated server. Legacy Dynamo artifacts
+ * that omit the field still fall back to `disagg=true`, preserving their
+ * historical classification. Canonical `mori-*` frameworks and aliases that
+ * explicitly declare `disagg: true` remain intrinsically disaggregated.
  *
  * @param fw - Raw framework value from the artifact (e.g. `"sglang"`, `"sglang-disagg"` → `"mori-sglang"`).
- * @param disaggField - Raw disagg field from the artifact (boolean or string `"True"`/`"true"`).
+ * @param disaggField - Raw disagg field from the artifact (boolean or string true/false).
  * @returns An object with the canonical `framework` string and the `disagg` boolean flag.
  */
 export function normalizeFramework(
@@ -155,9 +155,10 @@ export function normalizeFramework(
   const lower = fw.toLowerCase();
   const alias = FRAMEWORK_ALIASES[lower];
   const canonical = alias?.canonical ?? lower;
-  const rawDisagg =
-    alias?.disagg ?? (disaggField === true || disaggField === 'True' || disaggField === 'true');
-  const disagg = rawDisagg || canonical.startsWith('dynamo-') || canonical.startsWith('mori-');
+  const explicitDisagg = parseOptionalBool(disaggField);
+  const disagg =
+    alias?.disagg ??
+    (canonical.startsWith('mori-') ? true : (explicitDisagg ?? canonical.startsWith('dynamo-')));
   return { framework: canonical, disagg };
 }
 
@@ -189,6 +190,19 @@ export function normalizeSpecMethod(spec: unknown): string {
 }
 
 /**
+ * Parse an explicitly provided, loosely typed boolean.
+ * Accepts JS booleans and lowercase/Python-style string booleans.
+ *
+ * @param v - Value to parse.
+ * @returns The parsed boolean, or `undefined` when the value is absent or unrecognized.
+ */
+export function parseOptionalBool(v: unknown): boolean | undefined {
+  if (v === true || v === 'true' || v === 'True') return true;
+  if (v === false || v === 'false' || v === 'False') return false;
+  return undefined;
+}
+
+/**
  * Coerce a loosely-typed value to a boolean.
  * Accepts JS `true`, the string `'true'`, and the Python-style string `'True'`.
  *
@@ -196,7 +210,7 @@ export function normalizeSpecMethod(spec: unknown): string {
  * @returns `true` if the value is one of the recognized truthy forms, `false` otherwise.
  */
 export function parseBool(v: unknown): boolean {
-  return v === true || v === 'true' || v === 'True';
+  return parseOptionalBool(v) ?? false;
 }
 
 /**

--- a/packages/db/src/ingest-supplemental.ts
+++ b/packages/db/src/ingest-supplemental.ts
@@ -98,7 +98,7 @@ async function ingestSupplementalEvals(
       skipped++; // oxlint-disable-line no-useless-assignment -- used after loop
       continue;
     }
-    const { framework, disagg } = normalizeFramework(entry.framework, false);
+    const { framework, disagg } = normalizeFramework(entry.framework, undefined);
     const specMethod = normalizeSpecMethod(entry.spec_decoding);
     const dpAttn = parseBool(entry.dp_attention);
 
@@ -245,11 +245,11 @@ async function ingestSupplementalBmk(
 
       const { framework, disagg: frameworkDisagg } = normalizeFramework(
         entry.framework,
-        entry.disagg ?? false,
+        entry.disagg,
       );
       const specMethod = normalizeSpecMethod(entry.spec_decoding);
       const dpAttn = parseBool(entry.dp_attention);
-      const disagg = entry.disagg ?? frameworkDisagg;
+      const disagg = frameworkDisagg || (entry.decode_num_workers ?? 0) > 0;
 
       const configId = await getOrCreateConfig({
         hardware: hw,
@@ -311,7 +311,10 @@ async function ingestSupplementalBmk(
       const modelKey = resolveModelKey({ model: entry.model, infmax_model_prefix: undefined });
       const hw = hwToGpuKey(entry.hw);
       if (!modelKey || !hw) continue;
-      const { framework, disagg } = normalizeFramework(entry.framework, entry.disagg ?? false);
+      const { framework, disagg: frameworkDisagg } = normalizeFramework(
+        entry.framework,
+        entry.disagg,
+      );
       const specMethod = normalizeSpecMethod(entry.spec_decoding);
       availRows.push({
         model: modelKey,
@@ -321,7 +324,7 @@ async function ingestSupplementalBmk(
         hardware: hw,
         framework,
         specMethod,
-        disagg,
+        disagg: frameworkDisagg || (entry.decode_num_workers ?? 0) > 0,
         benchmarkType: 'single_turn',
       });
     }


### PR DESCRIPTION
## Summary

- Honor explicit `disagg: false` on Dynamo artifacts so a distributed server orchestrated by Dynamo is not mislabeled as disaggregated serving.
- Preserve legacy classification when `disagg` is absent, and treat a non-zero decode worker pool as structural proof of disaggregation.
- Keep supplemental benchmark/eval ingestion consistent with the same three-state behavior.

## Data impact

No schema migration is required. Existing incorrectly classified rows are not rewritten by this PR because `disagg` is part of the config natural key and the database does not retain enough source information to safely distinguish every historical direct Dynamo deployment with a generic SQL update.

Known affected rows, including benchmark result `437314` from workflow run `30385435921`, should receive a targeted data repair or artifact re-ingest after this change is deployed.

## Validation

- `bun run test:unit` — 3,454 tests passed across all workspaces
- `bun run --cwd packages/db test:unit` — 419 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`

## 中文说明

- 尊重 Dynamo 产物中明确设置的 `disagg: false`，避免把由 Dynamo 编排的单个分布式服务误标为分离式推理。
- 当产物缺少 `disagg` 字段时保留旧版推断逻辑；若存在非零解码工作进程池，则仍将其视为分离式部署。
- 让补充基准测试与评估数据的导入路径采用相同的三态处理逻辑。

本 PR 不需要数据库结构迁移。由于 `disagg` 属于配置自然键，且数据库没有保留足够的源信息来通过通用 SQL 安全区分所有历史 Dynamo 直连部署，本 PR 不会自动重写现有误分类数据。

已知受影响的数据（包括工作流运行 `30385435921` 中的基准测试结果 `437314`）应在本变更部署后执行定向数据修复或基于原始产物重新导入。

验证：

- `bun run test:unit` — 所有工作区共 3,454 项测试通过
- `bun run --cwd packages/db test:unit` — 419 项测试通过
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config identity and disagg classification for Dynamo benchmarks/evals at ingest time; wrong historical rows remain until targeted repair or re-ingest.
> 
> **Overview**
> Fixes **misclassification of Dynamo-orchestrated distributed servers** as disaggregated serving by changing how the `disagg` config flag is derived during ingest.
> 
> **`normalizeFramework`** no longer forces `disagg=true` for all `dynamo-*` frameworks. It uses a new **`parseOptionalBool`** helper so explicit artifact values (`false`, `'false'`, etc.) win; missing `disagg` on legacy Dynamo rows still defaults to **`true`**, and **`mori-*`** stays intrinsically disaggregated.
> 
> **Benchmark and eval mappers** combine framework-level `disagg` with a topology rule: **`decode_num_workers > 0`** still forces disaggregated, so older Dynamo artifacts with wrong `disagg: false` stay classified correctly.
> 
> **Supplemental ingest** passes through raw `disagg` (not coerced to `false`) and applies the same decode-worker override for configs and availability.
> 
> Docs in **`data-pipeline.md`** describe the updated three-state behavior. **Existing DB rows are not rewritten** by this change because `disagg` is part of the config natural key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878a9a191f0e5b118d5224750a062a907e5f329c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->