### PR TITLE
chore(db): purge run 30405836523 (Kimi-K3 B300 AgentX non-DSpark) / 清理 run 30405836523（Kimi-K3 B300 AgentX 非 DSpark）

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -74,6 +74,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29881640438, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29882624421, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29912027293, // 2026-07-22 | Reason: accidental ingest while testing
+  30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
## Summary

Adds GitHub workflow run [30405836523](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30405836523) (2026-07-28, `Run Sweep - fix: recover PR 2371 ingest via sweep reuse`) to `PURGED_RUNS`, so ingest skips it and `bun run db:apply-overrides` (run automatically by the ingest workflows) deletes its rows — same pattern as #580 / #616.

**Reason for purge: No non-DSpark.** The run carries the 12 `kimik3-fp4-b300-vllm-agentic` AgentX points (TP8 GPU-resident and TP8 host-DRAM offload at conc 1/2/4/8/16/24). That recipe's search space has no `spec-decoding`, i.e. it is the non-DSpark arm, and Kimi-K3 agentic coding is published DSpark-only — the non-DSpark arm is deprecated from day 0 ([`MODELS.md`](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md)).

This run is the one the DB rows are attributed to: the agentic ingest for the [PR #2397](https://github.com/SemiAnalysisAI/InferenceX/pull/2397) merge ran with `SOURCE_RUN_ID: 30405836523` / `MERGE_RUN_ID: 30422239067`, and `ingest-ci-run.ts` records the *source* run id for sweep-reuse ingests.

Chart-data-only DB override; no frontend or application-logic changes, so unofficial run overlays are unaffected. `packages/db/src/etl/run-overrides.test.ts` (10 tests) and `tsc --noEmit` pass locally.

## 中文说明

将 GitHub workflow run [30405836523](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30405836523)（2026-07-28，`Run Sweep - fix: recover PR 2371 ingest via sweep reuse`）加入 `PURGED_RUNS`，使 ingest 跳过该 run，并由 ingest workflow 自动执行的 `bun run db:apply-overrides` 删除其数据库记录 —— 与 #580 / #616 采用相同模式。

**清理原因：不保留非 DSpark 数据。** 该 run 包含 12 个 `kimik3-fp4-b300-vllm-agentic` AgentX 数据点（TP8 GPU 常驻与 TP8 主机 DRAM 卸载，并发 1/2/4/8/16/24）。该配方的搜索空间未设置 `spec-decoding`，属于非 DSpark 分支；而 Kimi-K3 智能体编码仅发布 DSpark 结果，非 DSpark 分支自第 0 天起即弃用（见 `MODELS.md`）。

数据库记录正是归属于该 run：[PR #2397](https://github.com/SemiAnalysisAI/InferenceX/pull/2397) 合并后的 agentic ingest 使用 `SOURCE_RUN_ID: 30405836523` / `MERGE_RUN_ID: 30422239067`，而 `ingest-ci-run.ts` 对复用扫描的 ingest 记录的是**源** run id。

仅为图表数据层面的数据库 override，不涉及前端或应用逻辑改动，不影响 unofficial run overlay。本地 `packages/db/src/etl/run-overrides.test.ts`（10 项测试）与 `tsc --noEmit` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single ID added to an existing purge list; affects benchmark ETL/chart data only, not app or auth logic.
> 
> **Overview**
> Adds GitHub Actions run **30405836523** to `PURGED_RUNS` in `run-overrides.ts`, so ingest skips it and CI-driven `db:apply-overrides` removes any existing rows for that run.
> 
> The purge targets **non-DSpark** `kimik3-fp4-b300-vllm-agentic` AgentX points (B300 vLLM, no speculative decoding). Kimi-K3 agentic coding is published **DSpark-only**, so this data should not remain in chart-facing benchmark tables. The run is noted as the **source** run for the PR #2397 sweep-reuse ingest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6887be0049ff34f18e74c3037180e3ee0cefd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->