### PR TITLE
chore(pricing): update RTX PRO 6000 hyperscaler and neocloud $/GPU/hr / 更新 RTX PRO 6000 hyperscaler 与 neocloud 每 GPU 小时单价

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -152,17 +152,28 @@ describe('Overview page', () => {
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
       cy.contains('Spec decode (MTP)').should('exist');
-      platform('gb300').within(() => {
-        cy.get('[data-testid="overview-pair-value"][data-hardware="gb300"]')
+      platform('b200').within(() => {
+        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
           .should('have.attr', 'title', 'Estimated from validated benchmark runs.')
           .and('not.have.attr', 'aria-label');
-        cy.get('[data-testid="overview-pair-value"][data-hardware="gb300"]')
+        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
           .find('.sr-only')
-          .should('have.text', 'Approximately $1.19. Estimated from validated benchmark runs.');
+          .should('have.text', 'Approximately $0.89. Estimated from validated benchmark runs.');
         cy.get(
-          '[data-testid="overview-pair-value"][data-hardware="gb300"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$1.19');
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
+        ).should('have.text', '≈$0.89');
         cy.get('[data-testid="overview-pair-missing"]').should('not.exist');
+      });
+      // GB300's two points are a single-node and a multi-node aggregate
+      // deployment. They are separate serving series, so neither interpolates
+      // to the tier and the cell stays empty instead of blending them.
+      platform('gb300').within(() => {
+        cy.get('[data-testid="overview-pair-value"]').should('not.exist');
+        cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]').should(
+          'have.attr',
+          'title',
+          'no exact @50 result',
+        );
       });
     });
     desktopModel('MiniMax-M3').within(() => {
@@ -189,13 +200,17 @@ describe('Overview page', () => {
     });
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
-      platform('gb300')
+      platform('gb200')
         .find('[data-testid="overview-cost-delta"]')
-        .should('contain.text', '+33%')
+        .should('contain.text', '+71%')
         .and('have.attr', 'data-cost-polarity', 'pricier')
         .then(($badge) => {
-          expect($badge.attr('style')).to.contain('rgb(239 68 68 / 0.29)');
+          // +71% saturates the alpha ramp; read the computed value so the
+          // assertion survives the browser normalizing `0.40` to `0.4`.
+          expect(getComputedStyle($badge[0]).backgroundColor).to.equal('rgba(239, 68, 68, 0.4)');
         });
+      // No read at the tier means no delta to grade.
+      platform('gb300').find('[data-testid="overview-cost-delta"]').should('not.exist');
     });
 
     desktopModel('MiniMax-M3').within(() => {
@@ -302,15 +317,20 @@ describe('Overview page', () => {
     });
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
-      platform('b200').should('contain.text', '≈$0.89').and('contain.text', 'FP4');
-      platform('gb300').within(() => {
-        cy.get(
-          '[data-testid="overview-pair-value"][data-hardware="gb300"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$1.19');
-        cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="gb300"]').should(
+      platform('b200').within(() => {
+        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
+          .should('contain.text', '≈$0.89')
+          .find('[data-testid="overview-estimate-visible"]')
+          .should('have.text', '≈$0.89');
+        cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="b200"]').should(
           'have.text',
           'Jul 18',
         );
+        cy.contains('FP4').should('exist');
+      });
+      // A cell without a read at the tier carries no evidence date either.
+      platform('gb300').within(() => {
+        cy.get('[data-testid="overview-pair-evidence-date"]').should('not.exist');
       });
     });
   });
@@ -325,9 +345,12 @@ describe('Overview page', () => {
           .should('contain.text', '∞')
           .and('have.attr', 'title', 'no exact @50 result');
       });
-      platform('gb300')
-        .find('[data-testid="overview-estimate-visible"]')
-        .should('have.text', '≈$1.19');
+      platform('gb300').within(() => {
+        cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]')
+          .should('contain.text', '∞')
+          .and('have.attr', 'title', 'no exact @50 result');
+      });
+      platform('b200').find('[data-testid="overview-estimate-visible"]').should('exist');
     });
 
     desktopModel('MiniMax-M3').within(() => {
@@ -442,11 +465,16 @@ describe('Overview page', () => {
           );
         });
       });
-      mobileModel('DeepSeek-V4-Pro')
-        .find(
-          '[data-testid="overview-pair-value"][data-hardware="gb300"] [data-testid="overview-estimate-visible"]',
-        )
-        .should('have.text', '≈$1.19');
+      mobileModel('DeepSeek-V4-Pro').within(() => {
+        cy.get(
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
+        ).should('have.text', '≈$0.89');
+        cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]').should(
+          'have.attr',
+          'title',
+          'no exact @50 result',
+        );
+      });
       expectNoHorizontalOverflow();
       expectNoHorizontalScroller('overview-mobile-list');
       expectNoHorizontalScroller('overview-engine-scope-switcher');
@@ -624,15 +652,18 @@ describe('Overview page', () => {
       '各档位数值采用最佳观测平台服务包络线；≈ 表示根据已验证运行结果估算。不会外推。',
     ).should('exist');
     desktopModel('DeepSeek-V4-Pro')
-      .find('[data-testid="overview-pair-value"][data-hardware="gb300"]')
-      .as('estimatedGb300')
+      .find('[data-testid="overview-pair-value"][data-hardware="b200"]')
+      .as('estimatedB200')
       .should('have.attr', 'title', '根据已验证的基准运行结果估算。')
       .and('not.have.attr', 'aria-label');
-    cy.get('@estimatedGb300')
+    cy.get('@estimatedB200')
       .find('[data-testid="overview-estimate-visible"]')
-      .should('have.text', '≈$1.19')
+      .should('have.text', '≈$0.89')
       .siblings('.sr-only')
-      .should('have.text', '约 $1.19。根据已验证的基准运行结果估算。');
+      .should('have.text', '约 $0.89。根据已验证的基准运行结果估算。');
+    desktopModel('DeepSeek-V4-Pro')
+      .find('[data-testid="overview-pair-missing"][data-hardware="gb300"]')
+      .should('have.attr', 'title', '无精确 @50 结果');
     cy.get('body')
       .invoke('text')
       .should('not.match', /回退/);

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -134,8 +134,8 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     sort: 9,
     tdp: 600,
     power: 0.975,
-    costh: 0.43,
-    costn: 0.676,
+    costh: 0.677,
+    costn: 0.746,
     costr: 0.52,
   },
 };


### PR DESCRIPTION
## Summary

Refreshes the RTX PRO 6000 Blackwell Server Edition rental rates in `HW_REGISTRY` (`packages/constants/src/gpu-keys.ts`) from the SemiAnalysis AI Cloud TCO model:

| Tier | Field | Before | After |
| --- | --- | --- | --- |
| Hyperscaler | `costh` | $0.430 /GPU/hr | **$0.677 /GPU/hr** |
| Neocloud | `costn` | $0.676 /GPU/hr | **$0.746 /GPU/hr** |
| 3-year rental | `costr` | $0.52 /GPU/hr | unchanged |

`HW_REGISTRY` is the single source of truth for cost tiers, so this propagates automatically to every surface that reads it: the inference chart's `y_costh` / `y_costn` metrics, the throughput calculator's Hyperscaler / Neocloud pricing tiers, the per-dollar compare pages (`/compare-per-dollar/*`, which display the owning-hyperscaler $/GPU/hr directly), and the `tco-feed` API. No other files hardcode these numbers.

**Note for reviewers:** with this change the RTX PRO 6000's 3-year rental rate ($0.52) now sits *below* both its hyperscaler and neocloud rates, an ordering inversion relative to every other GPU in the registry (where `costh ≤ costr`). That's out of scope for this PR — flagging in case `costr` should be refreshed from the same TCO model revision.

## Also: unblocks the Overview E2E suite (pre-existing master failure)

Six `overview.cy.ts` specs have been failing on **master** since #650 merged, so they fail on any PR touching `packages/app` — including this one. Not caused by the pricing change; fixed here so this PR can go green.

#650 made a non-disaggregated multi-node deployment its own serving series. The GB300 fixture rows for DeepSeek-V4-Pro are one single-node point (45 tok/s/user) and one multi-node aggregate point (60 tok/s/user), so they no longer blend into a single curve and the cell has **no read at @50**. #650 updated `overview-data.test.ts` for exactly this (`dsGb300.candidate.read.value` → `null`, `missingReason` → `no_exact_at_tier`) but not the Cypress spec, which still expected the old interpolated `≈$1.19` estimate.

The spec now asserts the current behavior:

- estimate / evidence-date / mobile / Chinese-sibling assertions point at cells that still carry a read — B200 `≈$0.89`, including the zh `sr-only` text — so ≈-estimate rendering stays covered;
- the cost-delta grading case moves to GB200 `+71%`, read from the computed background color because the browser re-serializes the saturated `0.40` alpha as `0.4`;
- GB300 gets explicit assertions for its new outcome: a missing cell titled `no exact @50 result`, with no evidence date and no delta badge.

No product code changed for this — only test expectations.

## Testing

- `bun run typecheck` — pass
- `bun run test:unit` — pass (436 tests)
- `bun run lint` / `bun run fmt` — pass
- `overview.cy.ts` against a local `E2E_FIXTURES=1` production build — 14/14 passing in Chrome (Firefox isn't installed locally; CI covers it)

The pricing change is a data-only constant edit; no UI, i18n, or overlay code paths touched, so no new `/zh` page is required.

## 中文说明

依据 SemiAnalysis AI Cloud TCO 模型，更新 `HW_REGISTRY`（`packages/constants/src/gpu-keys.ts`）中 RTX PRO 6000 Blackwell Server Edition 的租用单价：

| 层级 | 字段 | 变更前 | 变更后 |
| --- | --- | --- | --- |
| Hyperscaler | `costh` | $0.430 /GPU/hr | **$0.677 /GPU/hr** |
| Neocloud | `costn` | $0.676 /GPU/hr | **$0.746 /GPU/hr** |
| 3 年租赁 | `costr` | $0.52 /GPU/hr | 保持不变 |

`HW_REGISTRY` 是各成本层级的唯一数据来源，因此该修改会自动同步到所有读取它的界面：推理图表的 `y_costh` / `y_costn` 指标、吞吐量计算器的 Hyperscaler / Neocloud 定价层级、每美元性能对比页面（`/compare-per-dollar/*`，会直接展示 owning-hyperscaler 的 $/GPU/hr），以及 `tco-feed` API。仓库中没有其他位置硬编码这两个数值。

**给评审的提示**：此次改动后，RTX PRO 6000 的 3 年租赁价（$0.52）低于其 hyperscaler 与 neocloud 价格，与注册表中其他 GPU 的排序惯例（`costh ≤ costr`）相反。这不在本 PR 范围内，仅作提示——如需按同一版 TCO 模型一并更新 `costr`，请告知。

### 附带修复：解除 Overview E2E 阻塞（master 上已存在的失败）

自 #650 合并以来，`overview.cy.ts` 中有 6 个用例在 **master** 上持续失败，因此任何改动 `packages/app` 的 PR 都会失败，本 PR 也不例外。该失败与定价改动无关，在此一并修复以使本 PR 通过 CI。

#650 将非分离式多节点部署独立为单独的服务序列。DeepSeek-V4-Pro 的 GB300 夹具数据包含一个单节点点位（45 tok/s/用户）和一个多节点聚合点位（60 tok/s/用户），二者不再合并为同一条曲线，因此该单元格在 @50 档位下**没有结果**。#650 已相应更新 `overview-data.test.ts`（`dsGb300.candidate.read.value` → `null`，`missingReason` → `no_exact_at_tier`），但未同步 Cypress 用例，后者仍期望旧的插值估算值 `≈$1.19`。

现将用例改为断言当前行为：

- 估算值、证据日期、移动端与中文页面的断言改为指向仍有结果的单元格——B200 `≈$0.89`（含中文 `sr-only` 文案），从而保留 ≈ 估算值的渲染覆盖；
- 成本差异色阶的断言改用 GB200 `+71%`，并读取计算后的背景色，因为浏览器会将达到上限的 alpha 值 `0.40` 重新序列化为 `0.4`；
- 为 GB300 显式补充新表现的断言：标题为 `no exact @50 result` 的缺失单元格，且没有证据日期与差异标签。

此项仅修改测试预期，未改动任何产品代码。

测试：`bun run typecheck`、`bun run test:unit`（436 项全部通过）、`bun run lint`、`bun run fmt` 均通过；在本地 `E2E_FIXTURES=1` 生产构建下运行 `overview.cy.ts`，Chrome 环境 14/14 通过（本地未安装 Firefox，由 CI 覆盖）。定价改动为纯数据常量修改，未涉及 UI、i18n 或 overlay 代码路径，因此无需新增 `/zh` 页面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry constant refresh plus test-only overview assertions; no auth or runtime logic changes, though RTX 3-year `costr` now sits below hyperscaler/neocloud (noted in PR description).
> 
> **Overview**
> **Updates RTX PRO 6000 hyperscaler and neocloud $/GPU/hr** in `HW_REGISTRY` (`costh` 0.43→**0.677**, `costn` 0.676→**0.746**; `costr` unchanged at 0.52), so every consumer of `HW_REGISTRY` picks up the new SemiAnalysis TCO rates automatically.
> 
> **Realigns Overview Cypress specs** with current matrix behavior for **DeepSeek-V4-Pro**: estimated cost and evidence on **B200** (≈$0.89) instead of GB300; **GB300** cells assert missing @50 (`∞`, no blended estimate) because single- vs multi-node series do not interpolate to the tier; **GB200** cost-delta expectations move to **+71%** with a computed-style background-color assertion; mobile and `/zh` flows mirror the same semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0421d75a0dccf9c932a77a4e1deda390a42e0ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->