### PR TITLE
fix(overview): hyperscaler cost per 1M total tokens + cell-state and header cleanup / 总览成本口径改为超大规模云每百万总 token，并清理单元格状态与页头

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -19,6 +19,9 @@ const PLATFORM_HEADERS = [
   'Details',
 ];
 
+const SCOPE_LINE = 'Hyperscaler cost / 1M total tokens · ↓ lower is better';
+const SCOPE_LINE_ZH = '超大规模云（hyperscaler）成本 / 每百万总 token · ↓ 越低越好';
+
 function expectNoHorizontalOverflow() {
   cy.document().then((doc) => {
     expect(doc.documentElement.scrollWidth).to.be.lte(doc.documentElement.clientWidth);
@@ -37,6 +40,20 @@ function expectNoHorizontalScroller(testId: string) {
       .map((el) => `${el.tagName} ${el.scrollWidth}>${el.clientWidth}`);
     expect(scrollers, `horizontally scrollable inside ${testId}`).to.deep.equal([]);
   });
+}
+
+/** Visible dates and snapshot framing must be gone; evidence stays in labels. */
+function expectNoVisibleDatesOrSnapshot() {
+  cy.get('[data-testid="overview-pair-evidence-date"]').should('not.exist');
+  cy.get('body')
+    .invoke('text')
+    .should((text) => {
+      expect(text).not.to.match(/Database snapshot/i);
+      expect(text).not.to.match(/快照/);
+      expect(text).not.to.match(/\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d/);
+      expect(text).not.to.match(/\d+月\d+日/);
+      expect(text).not.to.match(/20\d\d-\d\d-\d\d/);
+    });
 }
 
 function desktopModel(model: string) {
@@ -144,7 +161,7 @@ describe('Overview page', () => {
       cy.get('[data-testid="overview-pair-missing"]')
         .children('[aria-hidden="true"]')
         .should('have.length', 2)
-        .and('have.text', '∞∞');
+        .and('have.text', '——');
       platform('b200').should('contain.text', 'Standard decode');
       platform('mi355x').should('contain.text', 'Standard decode');
       platform('b300').should('contain.text', 'Standard decode');
@@ -153,15 +170,24 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-V4-Pro').within(() => {
       cy.contains('Spec decode (MTP)').should('exist');
       platform('b200').within(() => {
-        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
-          .should('have.attr', 'title', 'Estimated from validated benchmark runs.')
-          .and('not.have.attr', 'aria-label');
-        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
-          .find('.sr-only')
-          .should('have.text', 'Approximately $0.89. Estimated from validated benchmark runs.');
+        // The estimated cost is itself the evidence link; the run date lives in
+        // its hover/focus/screen-reader label, never as visible text.
+        cy.get(
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+        )
+          .should(
+            'have.attr',
+            'title',
+            'Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP',
+          )
+          .and(
+            'have.attr',
+            'aria-label',
+            'Approximately $0.067. Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP',
+          );
         cy.get(
           '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$0.89');
+        ).should('have.text', '≈$0.067');
         cy.get('[data-testid="overview-pair-missing"]').should('not.exist');
       });
       // GB300's two points are a single-node and a multi-node aggregate
@@ -185,7 +211,7 @@ describe('Overview page', () => {
     cy.get('body').should('not.contain.text', 'P90');
   });
 
-  it('color-grades the cost delta against B200 and omits it without a baseline', () => {
+  it('color-grades the cost delta against B200 and badges a missing baseline with a neutral ∞', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
@@ -193,6 +219,7 @@ describe('Overview page', () => {
       platform('b200').find('[data-testid="overview-cost-delta"]').should('not.exist');
       platform('mi355x')
         .find('[data-testid="overview-cost-delta"]')
+        .should('contain.text', '25%')
         .and('have.attr', 'data-cost-polarity', 'cheaper')
         .then(($badge) => {
           expect($badge.attr('style')).to.contain('rgb(16 185 129 /');
@@ -202,10 +229,10 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-V4-Pro').within(() => {
       platform('gb200')
         .find('[data-testid="overview-cost-delta"]')
-        .should('contain.text', '+71%')
+        .should('contain.text', '+80%')
         .and('have.attr', 'data-cost-polarity', 'pricier')
         .then(($badge) => {
-          // +71% saturates the alpha ramp; read the computed value so the
+          // +80% saturates the alpha ramp; read the computed value so the
           // assertion survives the browser normalizing `0.40` to `0.4`.
           expect(getComputedStyle($badge[0]).backgroundColor).to.equal('rgba(239, 68, 68, 0.4)');
         });
@@ -213,8 +240,29 @@ describe('Overview page', () => {
       platform('gb300').find('[data-testid="overview-cost-delta"]').should('not.exist');
     });
 
+    // Priced result with no B200 baseline: the relative badge shows a neutral
+    // gray ∞ — availability, not a good/bad judgment, so no red/green tint.
     desktopModel('MiniMax-M3').within(() => {
-      cy.get('[data-testid="overview-cost-delta"]').should('not.exist');
+      platform('gb300')
+        .find('[data-testid="overview-cost-delta"]')
+        .should('contain.text', '∞')
+        .and('have.attr', 'data-cost-polarity', 'no-baseline')
+        .and('have.attr', 'title', 'No B200 baseline to compare against')
+        .then(($badge) => {
+          expect($badge.attr('style') ?? '').not.to.contain('background');
+          const color = getComputedStyle($badge[0]).color;
+          const [r, g, b] = color.match(/\d+/g)!.map(Number);
+          // Neutral gray: no channel dominates the way the red/green ramps do.
+          expect(Math.max(r, g, b) - Math.min(r, g, b)).to.be.lessThan(30);
+        });
+    });
+
+    // Within the ±5% parity band the badge reads as even, not polarity.
+    desktopModel('Kimi-K2.5').within(() => {
+      platform('b300')
+        .find('[data-testid="overview-cost-delta"]')
+        .should('contain.text', '+2%')
+        .and('have.attr', 'data-cost-polarity', 'even');
     });
   });
 
@@ -233,23 +281,23 @@ describe('Overview page', () => {
       'Every active model across MI355X, B200, B300, GB200 and GB300 at a glance.',
     ).should('exist');
     cy.contains(
-      'Cost per million output tokens from each platform’s best observed serving envelope',
+      'Cost per million total tokens from each platform’s best observed serving envelope',
     ).should('exist');
     cy.get('[data-testid="overview-scope"]')
-      .should(
-        'have.text',
-        'GPU rental cost / 1M output tokens · @50 tok/s/user · ↓ lower is better',
-      )
+      .should('have.text', SCOPE_LINE)
+      .and('not.contain.text', 'tok/s/user')
       .and('not.contain.text', '8K→1K');
     cy.contains(
-      'Cost = 3-yr rental $/GPU/hr ÷ output tok/s per deployed GPU. All percentages compare against B200.',
+      'Cost = hyperscaler $/GPU/hr ÷ total tok/s per deployed GPU. Percentages compare against B200.',
     ).should('exist');
+    cy.contains('— = no result. ∞ = B200 baseline unavailable.').should('exist');
     cy.contains(
       'Disaggregated results include both prefill and decode GPUs in the denominator.',
     ).should('exist');
     cy.contains(
       'Tier values use the best observed platform serving envelope; ≈ marks estimates between validated runs. No extrapolation.',
     ).should('exist');
+    expectNoVisibleDatesOrSnapshot();
     cy.get('[data-testid="overview-pair-topology"]').should('not.exist');
     cy.get('body')
       .invoke('text')
@@ -257,7 +305,6 @@ describe('Overview page', () => {
     cy.get('body')
       .invoke('text')
       .should('not.match', /At 100, .+ leads/);
-    cy.contains('Database snapshot through Jul 18').should('exist');
     cy.get('[data-testid="overview-desktop-matrix"]')
       .should('be.visible')
       .within(() => {
@@ -287,67 +334,98 @@ describe('Overview page', () => {
     }
   });
 
-  it('shows per-cell best reads with precision badges, dates, and evidence links', () => {
+  it('keeps the title and metric definition on one desktop row and stacks them below xl', () => {
+    for (const width of [1280, 1440]) {
+      cy.viewport(width, 900);
+      cy.visit('/overview');
+      cy.contains('h1', 'Inference Cost Overview').then(([title]) => {
+        cy.get('[data-testid="overview-scope"]').then(([scope]) => {
+          const titleRect = title.getBoundingClientRect();
+          const scopeRect = scope.getBoundingClientRect();
+          expect((scopeRect.top + scopeRect.bottom) / 2, `same row at ${width}px`).to.be.closeTo(
+            (titleRect.top + titleRect.bottom) / 2,
+            8,
+          );
+          expect(scopeRect.left, `metric right of title at ${width}px`).to.be.greaterThan(
+            titleRect.right,
+          );
+        });
+      });
+      expectNoHorizontalOverflow();
+    }
+
+    for (const width of [320, 390, 768]) {
+      cy.viewport(width, 900);
+      cy.visit('/overview');
+      cy.contains('h1', 'Inference Cost Overview').then(([title]) => {
+        cy.get('[data-testid="overview-scope"]').then(([scope]) => {
+          expect(
+            scope.getBoundingClientRect().top,
+            `stacked below title at ${width}px`,
+          ).to.be.at.least(title.getBoundingClientRect().bottom - 1);
+        });
+      });
+      expectNoHorizontalOverflow();
+    }
+  });
+
+  it('links each cost to the raw source dashboard for exactly that configuration', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
     desktopModel('Qwen-3.5-397B-A17B').within(() => {
-      platform('b200').should('contain.text', '$1.10').and('contain.text', 'FP4');
       platform('mi355x').within(() => {
         cy.contains('SGLang · FP8').should('exist');
-        cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]')
-          .should('contain.text', '$0.77')
-          .find('a')
-          .should('not.exist');
-        cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"] a')
-          .should(
+        cy.get(
+          '[data-testid="overview-pair-value"][data-hardware="mi355x"] [data-testid="overview-cost-evidence-link"]',
+        )
+          .should('have.text', '$0.061')
+          .and(
             'have.attr',
             'title',
             'Open raw source dashboard for Jul 18: Qwen3.5 397B · MI355X · SGLang · FP8 · MTP',
           )
           .should('have.attr', 'href')
+          .and('include', '/inference?')
           .and('include', 'g_model=Qwen-3.5-397B-A17B')
+          .and('include', 'g_rundate=2026-07-18')
           .and('include', 'i_prec=fp8')
           .and('include', 'i_gpus=mi355x_sglang_mtp');
-        cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').should(
-          'have.text',
-          'Jul 18',
-        );
+      });
+      platform('b200').within(() => {
+        cy.get(
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+        )
+          .should('contain.text', '≈$0.082')
+          .should('have.attr', 'href')
+          .and('include', 'i_prec=fp4')
+          .and('include', 'i_gpus=b200_sglang_mtp');
       });
     });
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
-      platform('b200').within(() => {
-        cy.get('[data-testid="overview-pair-value"][data-hardware="b200"]')
-          .should('contain.text', '≈$0.89')
-          .find('[data-testid="overview-estimate-visible"]')
-          .should('have.text', '≈$0.89');
-        cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="b200"]').should(
-          'have.text',
-          'Jul 18',
-        );
-        cy.contains('FP4').should('exist');
-      });
-      // A cell without a read at the tier carries no evidence date either.
+      // A cell without a read at the tier carries no evidence link either.
       platform('gb300').within(() => {
-        cy.get('[data-testid="overview-pair-evidence-date"]').should('not.exist');
+        cy.get('[data-testid="overview-cost-evidence-link"]').should('not.exist');
       });
     });
+    expectNoVisibleDatesOrSnapshot();
   });
 
-  it('distinguishes per-platform and whole-row missing results without a percent', () => {
+  it('distinguishes per-platform and whole-row missing results with a plain dash', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
     desktopModel('DeepSeek-V4-Pro').within(() => {
       platform('mi355x').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="mi355x"]')
-          .should('contain.text', '∞')
+          .should('contain.text', '—')
+          .and('not.contain.text', '∞')
           .and('have.attr', 'title', 'no exact @50 result');
       });
       platform('gb300').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]')
-          .should('contain.text', '∞')
+          .should('contain.text', '—')
           .and('have.attr', 'title', 'no exact @50 result');
       });
       platform('b200').find('[data-testid="overview-estimate-visible"]').should('exist');
@@ -356,12 +434,17 @@ describe('Overview page', () => {
     desktopModel('MiniMax-M3').within(() => {
       platform('b200')
         .find('[data-testid="overview-pair-missing"]')
-        .should('contain.text', '∞')
+        .should('contain.text', '—')
         .and('have.attr', 'title', 'no data for this scenario');
       platform('gb300').within(() => {
         cy.get('[data-testid="overview-pair-value"][data-hardware="gb300"]').should(
           'contain.text',
-          '$1.57',
+          '$0.113',
+        );
+        cy.get('[data-testid="overview-cost-delta"][data-hardware="gb300"]').should(
+          'have.attr',
+          'data-cost-polarity',
+          'no-baseline',
         );
       });
     });
@@ -370,7 +453,11 @@ describe('Overview page', () => {
       cy.get('[data-testid="overview-pair-missing"]').should('have.length', 5);
       cy.get('[data-testid="overview-model-coverage-note"]').should('not.exist');
     });
-    cy.contains('∞ = no comparable result').should('exist');
+    // ∞ appears only inside relative badges, never as a cell value.
+    cy.get('[data-testid="overview-pair-missing"]').each(($cell) => {
+      expect($cell.text()).not.to.contain('∞');
+    });
+    cy.contains('— = no result. ∞ = B200 baseline unavailable.').should('exist');
     cy.get('body')
       .invoke('text')
       .should('not.match', /∞\s*%/);
@@ -388,26 +475,24 @@ describe('Overview page', () => {
     });
 
     cy.location('search').should('eq', '?tier=100');
-    cy.get('[data-testid="overview-scope"]').should(
-      'have.text',
-      'GPU rental cost / 1M output tokens · @100 tok/s/user · ↓ lower is better',
-    );
+    // The metric line never repeats the tier — the switcher states it.
+    cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE);
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.get('[aria-current="page"]').should('have.text', '100');
       cy.contains('a', '50').should('have.attr', 'href', '/overview');
     });
 
     desktopModel('Qwen-3.5-397B-A17B').within(() => {
-      platform('b200').should('contain.text', '$1.86').and('contain.text', 'FP8');
+      platform('b200').should('contain.text', '≈$0.139').and('contain.text', 'FP8');
       platform('mi355x').within(() => {
         cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').should(
           'contain.text',
-          '$0.92',
+          '≈$0.074',
         );
       });
       platform('b300').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="b300"]')
-          .should('contain.text', '∞')
+          .should('contain.text', '—')
           .and('have.attr', 'title', 'cannot reach @100');
       });
     });
@@ -416,29 +501,38 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-V4-Pro').within(() => {
       platform('b300').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="b300"]')
-          .should('contain.text', '∞')
+          .should('contain.text', '—')
           .and('have.attr', 'title', 'no exact @30 result');
       });
       platform('b200')
         .find('[data-testid="overview-pair-missing"]')
-        .should('contain.text', '∞')
+        .should('contain.text', '—')
         .and('have.attr', 'title', 'no exact @30 result');
+    });
+    // Exact @30 read priced without a B200 baseline: cost plus the ∞ badge.
+    desktopModel('Qwen-3.5-397B-A17B').within(() => {
+      platform('b300').within(() => {
+        cy.get('[data-testid="overview-pair-value"][data-hardware="b300"]').should(
+          'contain.text',
+          '$0.050',
+        );
+        cy.get('[data-testid="overview-cost-delta"][data-hardware="b300"]')
+          .should('contain.text', '∞')
+          .and('have.attr', 'data-cost-polarity', 'no-baseline');
+      });
     });
     cy.get('body')
       .invoke('text')
       .should('not.match', /∞\s*%/);
 
     cy.visit('/overview?tier=100');
-    cy.get('[data-testid="overview-scope"]').should(
-      'have.text',
-      'GPU rental cost / 1M output tokens · @100 tok/s/user · ↓ lower is better',
-    );
+    cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE);
     cy.get('[data-testid="language-toggle"]')
       .should('have.attr', 'href', '/zh/overview?tier=100')
       .click();
     cy.location('pathname').should('eq', '/zh/overview');
     cy.location('search').should('eq', '?tier=100');
-    cy.contains('GPU 租赁成本 / 每百万输出 token · @100 tok/s/用户 · ↓ 越低越好').should('exist');
+    cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
   });
 
   it('uses the same cell semantics on mobile and fits both 390px and 320px widths', () => {
@@ -459,22 +553,22 @@ describe('Overview page', () => {
       mobileModel('Qwen-3.5-397B-A17B').within(() => {
         cy.get('[data-testid="overview-platform"]').should('have.length', 5);
         platform('mi355x').within(() => {
-          cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').should(
-            'contain.text',
-            '$0.77',
-          );
+          cy.get(
+            '[data-testid="overview-pair-value"][data-hardware="mi355x"] [data-testid="overview-cost-evidence-link"]',
+          ).should('have.text', '$0.061');
         });
       });
       mobileModel('DeepSeek-V4-Pro').within(() => {
         cy.get(
           '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$0.89');
+        ).should('have.text', '≈$0.067');
         cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]').should(
           'have.attr',
           'title',
           'no exact @50 result',
         );
       });
+      expectNoVisibleDatesOrSnapshot();
       expectNoHorizontalOverflow();
       expectNoHorizontalScroller('overview-mobile-list');
       expectNoHorizontalScroller('overview-engine-scope-switcher');
@@ -505,10 +599,6 @@ describe('Overview page', () => {
         cy.get('[data-testid="overview-pair-value"]').then(($values) => {
           const lefts = [...$values].map((value) => textRect(value).left);
           expect(Math.max(...lefts) - Math.min(...lefts)).to.be.at.most(1);
-        });
-        cy.get('[data-testid="overview-pair-evidence-date"]').then(($dates) => {
-          const rights = [...$dates].map((date) => textRect(date).right);
-          expect(Math.max(...rights) - Math.min(...rights)).to.be.at.most(1);
         });
       });
     }
@@ -543,20 +633,15 @@ describe('Overview page', () => {
           cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
             cy.get('[data-testid="overview-cost-delta"][data-hardware="mi355x"]').then(
               ([badge]) => {
-                cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').then(
-                  ([date]) => {
-                    const valueRect = value.getBoundingClientRect();
-                    const badgeRect = badge.getBoundingClientRect();
-                    const badgeText = badge.querySelector('[aria-hidden="true"]');
-                    expect(badgeText).not.to.equal(null);
+                const valueRect = value.getBoundingClientRect();
+                const badgeRect = badge.getBoundingClientRect();
+                const badgeText = badge.querySelector('[aria-hidden="true"]');
+                expect(badgeText).not.to.equal(null);
 
-                    expect(badgeRect.left - valueRect.right).to.be.at.most(8);
-                    expect(textRect(badgeText as Element).bottom).to.be.closeTo(
-                      textRect(value).bottom,
-                      1,
-                    );
-                    expect(textRect(date).bottom).to.be.closeTo(textRect(value).bottom, 1);
-                  },
+                expect(badgeRect.left - valueRect.right).to.be.at.most(8);
+                expect(textRect(badgeText as Element).bottom).to.be.closeTo(
+                  textRect(value).bottom,
+                  1,
                 );
               },
             );
@@ -566,23 +651,12 @@ describe('Overview page', () => {
     }
   });
 
-  it('keeps the value and evidence date aligned above configuration metadata', () => {
+  it('keeps the cost value aligned above configuration metadata', () => {
     cy.viewport(390, 844);
     cy.visit('/overview');
 
     mobileModel('Qwen-3.5-397B-A17B').within(() => {
       platform('mi355x').within(() => {
-        cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
-          cy.get('[data-testid="overview-pair-evidence-date"][data-hardware="mi355x"]').then(
-            ([date]) => {
-              const valueRect = textRect(value);
-              const dateRect = textRect(date);
-
-              expect(dateRect.bottom).to.be.closeTo(valueRect.bottom, 1);
-            },
-          );
-        });
-
         cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').then(([value]) => {
           cy.contains('div', 'SGLang · FP8')
             .should('contain.text', 'Spec decode (MTP)')
@@ -598,34 +672,37 @@ describe('Overview page', () => {
     });
   });
 
-  it('fits the full matrix without overlap or clipping at the narrowest desktop width', () => {
-    cy.viewport(1280, 900);
-    cy.visit('/overview');
+  it('fits the full matrix without overlap or clipping at desktop widths', () => {
+    for (const width of [1280, 1440]) {
+      cy.viewport(width, 900);
+      cy.visit('/overview');
 
-    cy.get('[data-testid="overview-desktop-matrix"]').should('be.visible');
-    cy.get('[data-testid="overview-desktop-matrix"]').then(([table]) => {
-      const wrapper = table.parentElement as HTMLElement;
-      expect(wrapper.scrollWidth, 'matrix scrolls horizontally').to.be.at.most(
-        wrapper.clientWidth + 1,
-      );
-    });
-    cy.get('[data-testid="overview-cost-delta"]').then(($badges) => {
-      const problems: string[] = [];
-      $badges.each((_, badge) => {
-        const badgeRect = badge.getBoundingClientRect();
-        if (badgeRect.width === 0) return;
-        const cell = badge.parentElement as HTMLElement;
-        const value = cell.querySelector('[data-testid="overview-pair-value"]');
-        const hardware = badge.dataset.hardware;
-        if (value) {
-          const valueRect = value.getBoundingClientRect();
-          if (valueRect.right > badgeRect.left + 0.5) {
-            problems.push(`${hardware}: cost overlaps delta badge`);
-          }
-        }
+      cy.get('[data-testid="overview-desktop-matrix"]').should('be.visible');
+      cy.get('[data-testid="overview-desktop-matrix"]').then(([table]) => {
+        const wrapper = table.parentElement as HTMLElement;
+        expect(wrapper.scrollWidth, `matrix scrolls horizontally at ${width}px`).to.be.at.most(
+          wrapper.clientWidth + 1,
+        );
       });
-      expect(problems, problems.join(' | ')).to.have.length(0);
-    });
+      expectNoHorizontalOverflow();
+      cy.get('[data-testid="overview-cost-delta"]').then(($badges) => {
+        const problems: string[] = [];
+        $badges.each((_, badge) => {
+          const badgeRect = badge.getBoundingClientRect();
+          if (badgeRect.width === 0) return;
+          const cell = badge.parentElement as HTMLElement;
+          const value = cell.querySelector('[data-testid="overview-pair-value"]');
+          const hardware = badge.dataset.hardware;
+          if (value) {
+            const valueRect = value.getBoundingClientRect();
+            if (valueRect.right > badgeRect.left + 0.5) {
+              problems.push(`${hardware}: cost overlaps delta badge`);
+            }
+          }
+        });
+        expect(problems, problems.join(' | ')).to.have.length(0);
+      });
+    }
   });
 
   it('renders the Chinese sibling with equivalent matrix copy and semantics', () => {
@@ -639,31 +716,41 @@ describe('Overview page', () => {
     cy.contains('一眼对比各活跃模型在 MI355X、B200、B300、GB200 与 GB300 上的表现。').should(
       'exist',
     );
-    cy.contains('按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万输出 token 成本').should(
+    cy.contains('按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本').should(
       'exist',
     );
-    cy.get('[data-testid="overview-scope"]').should(
-      'have.text',
-      'GPU 租赁成本 / 每百万输出 token · @50 tok/s/用户 · ↓ 越低越好',
-    );
-    cy.contains('成本 = 3 年期租赁 $/GPU/小时 ÷ 每张已部署 GPU 的输出 tok/s。').should('exist');
+    cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
+    cy.contains(
+      '成本 = 超大规模云（hyperscaler）$/GPU/小时 ÷ 每张已部署 GPU 的总 tok/s。百分比均相对 B200。',
+    ).should('exist');
+    cy.contains('— = 无结果。∞ = 缺少 B200 基线。').should('exist');
     cy.contains('分离式结果的分母同时计入预填充与解码 GPU。').should('exist');
     cy.contains(
       '各档位数值采用最佳观测平台服务包络线；≈ 表示根据已验证运行结果估算。不会外推。',
     ).should('exist');
+    expectNoVisibleDatesOrSnapshot();
     desktopModel('DeepSeek-V4-Pro')
-      .find('[data-testid="overview-pair-value"][data-hardware="b200"]')
+      .find(
+        '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+      )
       .as('estimatedB200')
-      .should('have.attr', 'title', '根据已验证的基准运行结果估算。')
-      .and('not.have.attr', 'aria-label');
+      .invoke('attr', 'title')
+      .should('include', '根据已验证的基准运行结果估算。')
+      .and('include', '原始数据仪表板：DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP');
+    cy.get('@estimatedB200')
+      .invoke('attr', 'aria-label')
+      .should('include', '约 $0.067。根据已验证的基准运行结果估算。');
     cy.get('@estimatedB200')
       .find('[data-testid="overview-estimate-visible"]')
-      .should('have.text', '≈$0.89')
-      .siblings('.sr-only')
-      .should('have.text', '约 $0.89。根据已验证的基准运行结果估算。');
+      .should('have.text', '≈$0.067');
+    cy.get('@estimatedB200')
+      .should('have.attr', 'href')
+      .and('include', '/zh/inference?')
+      .and('include', 'g_model=DeepSeek-V4-Pro');
     desktopModel('DeepSeek-V4-Pro')
       .find('[data-testid="overview-pair-missing"][data-hardware="gb300"]')
-      .should('have.attr', 'title', '无精确 @50 结果');
+      .should('contain.text', '—')
+      .and('have.attr', 'title', '无精确 @50 结果');
     cy.get('body')
       .invoke('text')
       .should('not.match', /回退/);
@@ -679,6 +766,13 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-V4-Pro').within(() => {
       platform('b200').should('contain.text', '推测解码（MTP）');
     });
+    desktopModel('MiniMax-M3').within(() => {
+      platform('gb300')
+        .find('[data-testid="overview-cost-delta"]')
+        .should('contain.text', '∞')
+        .and('have.attr', 'data-cost-polarity', 'no-baseline')
+        .and('have.attr', 'title', '缺少可比较的 B200 基线');
+    });
     desktopModel('GLM-5.2').within(() => {
       cy.get('[data-testid="overview-model-scenario"]').should('have.text', 'AgentX');
       cy.get('[data-testid="overview-pair-missing"]').should('have.length', 5);
@@ -689,10 +783,9 @@ describe('Overview page', () => {
     cy.contains('优先顺序：推测解码 FP4 → 推测解码 FP8 → 标准解码 FP4 → 标准解码 FP8。').should(
       'exist',
     );
-    cy.contains('∞ = 无可比结果').should('exist');
 
     cy.visit('/zh/overview?tier=100');
-    cy.contains('GPU 租赁成本 / 每百万输出 token · @100 tok/s/用户 · ↓ 越低越好').should('exist');
+    cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.contains('a', '50').should('have.attr', 'href', '/zh/overview');
     });

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -19,8 +19,12 @@ const PLATFORM_HEADERS = [
   'Details',
 ];
 
-const SCOPE_LINE = 'Hyperscaler cost / 1M total tokens · ↓ lower is better';
-const SCOPE_LINE_ZH = '超大规模云（hyperscaler）成本 / 每百万总 token · ↓ 越低越好';
+const SCOPE_METRIC = 'Hyperscaler cost · $/1M total tokens';
+const SCOPE_DIRECTION = '↓ Lower is better';
+const SCOPE_LINE = `${SCOPE_METRIC} ${SCOPE_DIRECTION}`;
+const SCOPE_METRIC_ZH = '超大规模云（hyperscaler）成本 · $/1M 总 token';
+const SCOPE_DIRECTION_ZH = '↓ 越低越好';
+const SCOPE_LINE_ZH = `${SCOPE_METRIC_ZH} ${SCOPE_DIRECTION_ZH}`;
 
 function expectNoHorizontalOverflow() {
   cy.document().then((doc) => {
@@ -335,6 +339,22 @@ describe('Overview page', () => {
   });
 
   it('keeps the title and metric definition on one desktop row and stacks them below xl', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+    cy.get('[data-testid="overview-scope-metric"]')
+      .should('have.text', SCOPE_METRIC)
+      .and('have.css', 'font-size', '16px')
+      .and('have.css', 'font-weight', '600');
+    cy.get('[data-testid="overview-scope-direction"]')
+      .should('have.text', SCOPE_DIRECTION)
+      .and('have.css', 'font-size', '14px')
+      .and('have.css', 'font-weight', '400');
+    cy.get('[data-testid="overview-scope-metric"]').then(([metric]) => {
+      cy.get('[data-testid="overview-scope-direction"]').then(([direction]) => {
+        expect(getComputedStyle(direction).color).not.to.equal(getComputedStyle(metric).color);
+      });
+    });
+
     for (const width of [1280, 1440]) {
       cy.viewport(width, 900);
       cy.visit('/overview');

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -178,6 +178,9 @@ describe('Overview page', () => {
         // its hover/focus/screen-reader label, never as visible text.
         cy.get(
           '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+        ).should('have.text', '$0.067');
+        cy.get(
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
         )
           .should(
             'have.attr',
@@ -189,9 +192,6 @@ describe('Overview page', () => {
             'aria-label',
             'Approximately $0.067. Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP',
           );
-        cy.get(
-          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$0.067');
         cy.get('[data-testid="overview-pair-missing"]').should('not.exist');
       });
       // GB300's two points are a single-node and a multi-node aggregate
@@ -299,8 +299,9 @@ describe('Overview page', () => {
       'Disaggregated results include both prefill and decode GPUs in the denominator.',
     ).should('exist');
     cy.contains(
-      'Tier values use the best observed platform serving envelope; ≈ marks estimates between validated runs. No extrapolation.',
+      'Tier values use the best observed platform serving envelope and may be estimated between validated runs. No extrapolation.',
     ).should('exist');
+    cy.get('body').should('not.contain.text', '≈');
     expectNoVisibleDatesOrSnapshot();
     cy.get('[data-testid="overview-pair-topology"]').should('not.exist');
     cy.get('body')
@@ -416,7 +417,7 @@ describe('Overview page', () => {
         cy.get(
           '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
         )
-          .should('contain.text', '≈$0.082')
+          .should('contain.text', '$0.082')
           .should('have.attr', 'href')
           .and('include', 'i_prec=fp4')
           .and('include', 'i_gpus=b200_sglang_mtp');
@@ -448,7 +449,10 @@ describe('Overview page', () => {
           .should('contain.text', '—')
           .and('have.attr', 'title', 'no exact @50 result');
       });
-      platform('b200').find('[data-testid="overview-estimate-visible"]').should('exist');
+      platform('b200')
+        .find('[data-testid="overview-cost-evidence-link"]')
+        .should('have.attr', 'title')
+        .and('include', 'Estimated from validated benchmark runs.');
     });
 
     desktopModel('MiniMax-M3').within(() => {
@@ -503,11 +507,11 @@ describe('Overview page', () => {
     });
 
     desktopModel('Qwen-3.5-397B-A17B').within(() => {
-      platform('b200').should('contain.text', '≈$0.139').and('contain.text', 'FP8');
+      platform('b200').should('contain.text', '$0.139').and('contain.text', 'FP8');
       platform('mi355x').within(() => {
         cy.get('[data-testid="overview-pair-value"][data-hardware="mi355x"]').should(
           'contain.text',
-          '≈$0.074',
+          '$0.074',
         );
       });
       platform('b300').within(() => {
@@ -580,8 +584,8 @@ describe('Overview page', () => {
       });
       mobileModel('DeepSeek-V4-Pro').within(() => {
         cy.get(
-          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-estimate-visible"]',
-        ).should('have.text', '≈$0.067');
+          '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+        ).should('have.text', '$0.067');
         cy.get('[data-testid="overview-pair-missing"][data-hardware="gb300"]').should(
           'have.attr',
           'title',
@@ -746,8 +750,9 @@ describe('Overview page', () => {
     cy.contains('— = 无结果。∞ = 缺少 B200 基线。').should('exist');
     cy.contains('分离式结果的分母同时计入预填充与解码 GPU。').should('exist');
     cy.contains(
-      '各档位数值采用最佳观测平台服务包络线；≈ 表示根据已验证运行结果估算。不会外推。',
+      '各档位数值采用最佳观测平台服务包络线，可能根据已验证运行结果估算。不会外推。',
     ).should('exist');
+    cy.get('body').should('not.contain.text', '≈');
     expectNoVisibleDatesOrSnapshot();
     desktopModel('DeepSeek-V4-Pro')
       .find(
@@ -760,9 +765,7 @@ describe('Overview page', () => {
     cy.get('@estimatedB200')
       .invoke('attr', 'aria-label')
       .should('include', '约 $0.067。根据已验证的基准运行结果估算。');
-    cy.get('@estimatedB200')
-      .find('[data-testid="overview-estimate-visible"]')
-      .should('have.text', '≈$0.067');
+    cy.get('@estimatedB200').should('have.text', '$0.067');
     cy.get('@estimatedB200')
       .should('have.attr', 'href')
       .and('include', '/zh/inference?')

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -50,7 +50,13 @@ function expectNoHorizontalScroller(testId: string) {
 function expectNoVisibleDatesOrSnapshot() {
   cy.get('[data-testid="overview-pair-evidence-date"]').should('not.exist');
   cy.get('body')
-    .invoke('text')
+    .then(([body]) => {
+      // Next.js RSC payload scripts retain evidence dates for reproducibility.
+      // Assert only against rendered page text, not serialized script/style data.
+      const clone = body.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll('script, style').forEach((node) => node.remove());
+      return clone.textContent ?? '';
+    })
     .should((text) => {
       expect(text).not.to.match(/Database snapshot/i);
       expect(text).not.to.match(/快照/);
@@ -405,6 +411,11 @@ describe('Overview page', () => {
             'have.attr',
             'title',
             'Open raw source dashboard for Jul 18: Qwen3.5 397B · MI355X · SGLang · FP8 · MTP',
+          )
+          .and(
+            'have.attr',
+            'aria-label',
+            '$0.061. Open raw source dashboard for Jul 18: Qwen3.5 397B · MI355X · SGLang · FP8 · MTP',
           )
           .should('have.attr', 'href')
           .and('include', '/inference?')

--- a/packages/app/cypress/fixtures/api/overview-rows.json
+++ b/packages/app/cypress/fixtures/api/overview-rows.json
@@ -25,7 +25,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "output_tput_per_gpu": 1300 },
+      "metrics": { "median_intvty": 30, "tput_per_gpu": 11700, "output_tput_per_gpu": 1300 },
       "date": "2026-06-24",
       "run_url": null
     },
@@ -54,7 +54,7 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "output_tput_per_gpu": 1000 },
+      "metrics": { "median_intvty": 70, "tput_per_gpu": 9000, "output_tput_per_gpu": 1000 },
       "date": "2026-07-04",
       "run_url": null
     },
@@ -83,7 +83,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 40, "output_tput_per_gpu": 1050 },
+      "metrics": { "median_intvty": 40, "tput_per_gpu": 9450, "output_tput_per_gpu": 1050 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -112,7 +112,7 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 110, "output_tput_per_gpu": 300 },
+      "metrics": { "median_intvty": 110, "tput_per_gpu": 2700, "output_tput_per_gpu": 300 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -141,7 +141,7 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 60, "output_tput_per_gpu": 760 },
+      "metrics": { "median_intvty": 60, "tput_per_gpu": 6840, "output_tput_per_gpu": 760 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -170,7 +170,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 45, "output_tput_per_gpu": 1050 },
+      "metrics": { "median_intvty": 45, "tput_per_gpu": 9450, "output_tput_per_gpu": 1050 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -199,7 +199,7 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 60, "output_tput_per_gpu": 750 },
+      "metrics": { "median_intvty": 60, "tput_per_gpu": 6750, "output_tput_per_gpu": 750 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -228,7 +228,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "output_tput_per_gpu": 800 },
+      "metrics": { "median_intvty": 30, "tput_per_gpu": 7200, "output_tput_per_gpu": 800 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -257,7 +257,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 600 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 5100, "output_tput_per_gpu": 600 },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -288,7 +288,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 800 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 7200, "output_tput_per_gpu": 800 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -317,7 +317,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 1000 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 8600, "output_tput_per_gpu": 1000 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -346,7 +346,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 700 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 6300, "output_tput_per_gpu": 700 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -375,7 +375,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 900 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 8460, "output_tput_per_gpu": 900 },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -406,7 +406,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "output_tput_per_gpu": 1400 },
+      "metrics": { "median_intvty": 30, "tput_per_gpu": 12880, "output_tput_per_gpu": 1400 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -435,7 +435,7 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "output_tput_per_gpu": 980 },
+      "metrics": { "median_intvty": 70, "tput_per_gpu": 9016, "output_tput_per_gpu": 980 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -464,7 +464,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 40, "output_tput_per_gpu": 800 },
+      "metrics": { "median_intvty": 40, "tput_per_gpu": 7200, "output_tput_per_gpu": 800 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -493,7 +493,7 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 80, "output_tput_per_gpu": 600 },
+      "metrics": { "median_intvty": 80, "tput_per_gpu": 5400, "output_tput_per_gpu": 600 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -522,7 +522,7 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 900 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 8100, "output_tput_per_gpu": 900 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -551,7 +551,7 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 760 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 6688, "output_tput_per_gpu": 760 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -580,7 +580,7 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 120, "output_tput_per_gpu": 300 },
+      "metrics": { "median_intvty": 120, "tput_per_gpu": 2700, "output_tput_per_gpu": 300 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -609,7 +609,7 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 120, "output_tput_per_gpu": 600 },
+      "metrics": { "median_intvty": 120, "tput_per_gpu": 5280, "output_tput_per_gpu": 600 },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -640,7 +640,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 777 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 6993, "output_tput_per_gpu": 777 },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -671,7 +671,7 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "output_tput_per_gpu": 820 },
+      "metrics": { "median_intvty": 30, "tput_per_gpu": 7380, "output_tput_per_gpu": 820 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -700,7 +700,7 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "output_tput_per_gpu": 560 },
+      "metrics": { "median_intvty": 70, "tput_per_gpu": 5040, "output_tput_per_gpu": 560 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -729,7 +729,7 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 650 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 5785, "output_tput_per_gpu": 650 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -758,7 +758,7 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 600 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 5400, "output_tput_per_gpu": 600 },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -787,7 +787,7 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "output_tput_per_gpu": 700 },
+      "metrics": { "median_intvty": 50, "tput_per_gpu": 6510, "output_tput_per_gpu": 700 },
       "date": "2026-07-18",
       "run_url": null
     }

--- a/packages/app/src/app/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/(dashboard)/overview/page.tsx
@@ -10,7 +10,7 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Compare cost per million output tokens across MI355X, B200, B300, GB200 and GB300 using the scenario shown for each active model.';
+  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200 and GB300 using the scenario shown for each active model.';
 
 export const metadata: Metadata = {
   title: 'Inference Cost Overview',

--- a/packages/app/src/app/zh/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/overview/page.tsx
@@ -10,7 +10,7 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  '按各活跃模型标注的场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万输出 token 成本。';
+  '按各活跃模型标注的场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
 
 export const metadata: Metadata = {
   title: '推理成本总览',

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -20,26 +20,23 @@ interface OverviewPageProps {
 export function OverviewPageContent({ data, locale }: OverviewPageProps) {
   const strings = OVERVIEW_STRINGS[locale];
   const formatters = overviewFormatters(locale);
-  const snapshot =
-    data.datasetThroughDate === null
-      ? null
-      : strings.snapshot(formatters.shortDate(data.datasetThroughDate));
 
   return (
     <section className="flex flex-col gap-4">
       <Card>
-        <header className="max-w-4xl">
-          <h1 className="text-lg font-semibold mb-2">{strings.title}</h1>
-          <p className="max-w-3xl text-sm text-muted-foreground">{strings.purpose}</p>
-          <p
-            data-testid="overview-scope"
-            className="mt-1.5 max-w-4xl text-xs leading-snug text-muted-foreground"
-          >
-            {strings.scope(data.tier)}
-          </p>
-          {snapshot === null ? null : (
-            <p className="mt-1 text-xs text-muted-foreground/80 tabular-nums">{snapshot}</p>
-          )}
+        <header>
+          {/* Desktop: title and metric definition share the first row; phones
+              and tablets stack the metric under the title. */}
+          <div className="flex flex-col gap-x-6 gap-y-1 xl:flex-row xl:items-baseline xl:justify-between">
+            <h1 className="text-lg font-semibold">{strings.title}</h1>
+            <p
+              data-testid="overview-scope"
+              className="text-sm font-semibold leading-snug text-foreground"
+            >
+              {strings.scope}
+            </p>
+          </div>
+          <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{strings.purpose}</p>
           <div className="mt-3 flex flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center lg:gap-x-6">
             <OverviewTierSwitcher
               tier={data.tier}

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -31,9 +31,21 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
             <h1 className="text-lg font-semibold">{strings.title}</h1>
             <p
               data-testid="overview-scope"
-              className="text-sm font-semibold leading-snug text-foreground"
+              aria-label={strings.scopeAria}
+              className="inline-flex flex-wrap items-baseline gap-x-2 leading-snug"
             >
-              {strings.scope}
+              <span
+                data-testid="overview-scope-metric"
+                className="text-base font-semibold text-foreground"
+              >
+                {strings.scopeMetric}
+              </span>{' '}
+              <span
+                data-testid="overview-scope-direction"
+                className="text-sm font-normal text-muted-foreground"
+              >
+                {strings.scopeDirection}
+              </span>
             </p>
           </div>
           <p className="mt-2 max-w-3xl text-sm text-muted-foreground">{strings.purpose}</p>

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -69,7 +69,7 @@ export const OVERVIEW_STRINGS = {
     normalizationNote:
       'Disaggregated results include both prefill and decode GPUs in the denominator.',
     interpolationNote:
-      'Tier values use the best observed platform serving envelope; ≈ marks estimates between validated runs. No extrapolation.',
+      'Tier values use the best observed platform serving envelope and may be estimated between validated runs. No extrapolation.',
     comparabilityNote:
       'Each row compares platforms within the scenario shown with that model; dates, engines, precisions and speculative methods may differ.',
   },
@@ -120,7 +120,7 @@ export const OVERVIEW_STRINGS = {
     referenceHeader: '基准',
     normalizationNote: '分离式结果的分母同时计入预填充与解码 GPU。',
     interpolationNote:
-      '各档位数值采用最佳观测平台服务包络线；≈ 表示根据已验证运行结果估算。不会外推。',
+      '各档位数值采用最佳观测平台服务包络线，可能根据已验证运行结果估算。不会外推。',
     comparabilityNote: '每行均在该模型标注的场景内比较各平台；日期、引擎、精度与推测方法可能不同。',
   },
 } as const;
@@ -326,15 +326,7 @@ function CellValue({
     config === null || stack === null
       ? null
       : strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack);
-  const costText =
-    estimateExplanation === undefined ? (
-      formattedValue
-    ) : (
-      <span data-testid="overview-estimate-visible" aria-hidden="true">
-        {'≈'}
-        {formattedValue}
-      </span>
-    );
+  const costText = formattedValue;
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
       {/* Fixed cost | delta grids keep comparisons scannable on desktop and phones;

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -22,7 +22,9 @@ export const OVERVIEW_STRINGS = {
     purpose: 'Every active model across MI355X, B200, B300, GB200 and GB300 at a glance.',
     // The active tier is not repeated here — the Service level selector below
     // already states it.
-    scope: 'Hyperscaler cost / 1M total tokens · ↓ lower is better',
+    scopeMetric: 'Hyperscaler cost · $/1M total tokens',
+    scopeDirection: '↓ Lower is better',
+    scopeAria: 'Hyperscaler cost per one million total tokens. Lower is better.',
     tierNavLabel: 'Service level',
     tierUnit: 'tok/s/user',
     engineScopeNavLabel: 'Engine scope',
@@ -74,7 +76,9 @@ export const OVERVIEW_STRINGS = {
   zh: {
     title: '推理成本总览',
     purpose: '一眼对比各活跃模型在 MI355X、B200、B300、GB200 与 GB300 上的表现。',
-    scope: '超大规模云（hyperscaler）成本 / 每百万总 token · ↓ 越低越好',
+    scopeMetric: '超大规模云（hyperscaler）成本 · $/1M 总 token',
+    scopeDirection: '↓ 越低越好',
+    scopeAria: '超大规模云（hyperscaler）每百万总 token 成本，越低越好。',
     tierNavLabel: '服务档位',
     tierUnit: 'tok/s/用户',
     engineScopeNavLabel: '引擎范围',

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -20,8 +20,9 @@ export const OVERVIEW_STRINGS = {
   en: {
     title: 'Inference Cost Overview',
     purpose: 'Every active model across MI355X, B200, B300, GB200 and GB300 at a glance.',
-    scope: (tier: number) =>
-      `GPU rental cost / 1M output tokens · @${tier} tok/s/user · ↓ lower is better`,
+    // The active tier is not repeated here — the Service level selector below
+    // already states it.
+    scope: 'Hyperscaler cost / 1M total tokens · ↓ lower is better',
     tierNavLabel: 'Service level',
     tierUnit: 'tok/s/user',
     engineScopeNavLabel: 'Engine scope',
@@ -29,9 +30,8 @@ export const OVERVIEW_STRINGS = {
       all: 'All Platforms',
       community: 'Open Source Community Engines (vLLM/SGLang)',
     },
-    snapshot: (through: string) => `Database snapshot through ${through}`,
     caption:
-      'Cost per million output tokens from each platform’s best observed serving envelope for the scenario shown with each model.',
+      'Cost per million total tokens from each platform’s best observed serving envelope for the scenario shown with each model.',
     modelHeader: 'Model · Scenario',
     scenarioLabels: {
       single_turn_8k1k: 'Single-turn · 8K→1K',
@@ -47,7 +47,7 @@ export const OVERVIEW_STRINGS = {
         ? 'Estimated from validated benchmark runs.'
         : `Estimated from validated ${topologies.join(' and ')} runs.`,
     estimatedAria: (value: string, explanation: string) => `Approximately ${value}. ${explanation}`,
-    infinityLegend: '∞ = no comparable result',
+    cellStateLegend: '— = no result. ∞ = B200 baseline unavailable.',
     missingReasons: (tier: number): Record<string, string> => ({
       int4_bf16_only: 'INT4/BF16 only',
       no_scenario_data: 'no data for this scenario',
@@ -58,10 +58,11 @@ export const OVERVIEW_STRINGS = {
     standardDecodeLabel: 'Standard decode',
     methodologyNote: 'Priority: speculative FP4 → speculative FP8 → standard FP4 → standard FP8.',
     costNote:
-      'Cost = 3-yr rental $/GPU/hr ÷ output tok/s per deployed GPU. All percentages compare against B200.',
+      'Cost = hyperscaler $/GPU/hr ÷ total tok/s per deployed GPU. Percentages compare against B200.',
     costDeltaAria: (pct: string, cheaper: boolean) =>
       `${pct} ${cheaper ? 'cheaper' : 'more expensive'} than B200`,
     costDeltaEvenAria: 'About the same cost as B200',
+    noBaselineAria: 'No B200 baseline to compare against',
     referenceHeader: 'Reference',
     normalizationNote:
       'Disaggregated results include both prefill and decode GPUs in the denominator.',
@@ -73,7 +74,7 @@ export const OVERVIEW_STRINGS = {
   zh: {
     title: '推理成本总览',
     purpose: '一眼对比各活跃模型在 MI355X、B200、B300、GB200 与 GB300 上的表现。',
-    scope: (tier: number) => `GPU 租赁成本 / 每百万输出 token · @${tier} tok/s/用户 · ↓ 越低越好`,
+    scope: '超大规模云（hyperscaler）成本 / 每百万总 token · ↓ 越低越好',
     tierNavLabel: '服务档位',
     tierUnit: 'tok/s/用户',
     engineScopeNavLabel: '引擎范围',
@@ -81,8 +82,7 @@ export const OVERVIEW_STRINGS = {
       all: '所有平台',
       community: '开源社区引擎（vLLM/SGLang）',
     },
-    snapshot: (through: string) => `数据库快照截至 ${through}`,
-    caption: '按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万输出 token 成本。',
+    caption: '按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本。',
     modelHeader: '模型 · 场景',
     scenarioLabels: {
       single_turn_8k1k: '单轮 · 8K→1K',
@@ -98,7 +98,7 @@ export const OVERVIEW_STRINGS = {
         ? '根据已验证的基准运行结果估算。'
         : `根据已验证的 ${topologies.join(' 与 ')} 运行结果估算。`,
     estimatedAria: (value: string, explanation: string) => `约 ${value}。${explanation}`,
-    infinityLegend: '∞ = 无可比结果',
+    cellStateLegend: '— = 无结果。∞ = 缺少 B200 基线。',
     missingReasons: (tier: number): Record<string, string> => ({
       int4_bf16_only: '仅 INT4/BF16',
       no_scenario_data: '该场景暂无数据',
@@ -108,9 +108,11 @@ export const OVERVIEW_STRINGS = {
     speculativeDecodeLabel: (method: string) => `推测解码（${method}）`,
     standardDecodeLabel: '标准解码',
     methodologyNote: '优先顺序：推测解码 FP4 → 推测解码 FP8 → 标准解码 FP4 → 标准解码 FP8。',
-    costNote: '成本 = 3 年期租赁 $/GPU/小时 ÷ 每张已部署 GPU 的输出 tok/s。所有百分比均相对 B200。',
+    costNote:
+      '成本 = 超大规模云（hyperscaler）$/GPU/小时 ÷ 每张已部署 GPU 的总 tok/s。百分比均相对 B200。',
     costDeltaAria: (pct: string, cheaper: boolean) => `比 B200 ${cheaper ? '便宜' : '昂贵'} ${pct}`,
     costDeltaEvenAria: '与 B200 成本基本持平',
+    noBaselineAria: '缺少可比较的 B200 基线',
     referenceHeader: '基准',
     normalizationNote: '分离式结果的分母同时计入预填充与解码 GPU。',
     interpolationNote:
@@ -136,11 +138,13 @@ export function overviewFormatters(locale: OverviewLocale): Formatters {
     timeZone: 'UTC',
   });
   return {
+    // Three decimals: at hyperscaler $/GPU/hr over TOTAL tokens, real platforms
+    // land in the $0.0x–$0.1x band, which two decimals would collapse.
     cost: new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
+      minimumFractionDigits: 3,
+      maximumFractionDigits: 3,
     }),
     percent: new Intl.NumberFormat(tag, {
       style: 'percent',
@@ -170,6 +174,7 @@ function missingReasonCopy(platform: OverviewPlatformResult, strings: OverviewSt
 const RAW_SOURCE_LINK_CLASS =
   'inline-flex min-h-11 items-center rounded-sm underline decoration-dotted underline-offset-4 hover:decoration-solid focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50';
 
+/** No result for this GPU. The reason survives as hover/focus/SR text only. */
 function CellMissing({ hardware, reason }: { hardware: string; reason: string }) {
   return (
     <span
@@ -178,7 +183,7 @@ function CellMissing({ hardware, reason }: { hardware: string; reason: string })
       title={reason}
       className="inline-flex items-baseline gap-1 text-muted-foreground"
     >
-      <span aria-hidden="true">{'∞'}</span>
+      <span aria-hidden="true">{'—'}</span>
       <span className="sr-only">{reason}</span>
     </span>
   );
@@ -188,10 +193,13 @@ function CellMissing({ hardware, reason }: { hardware: string; reason: string })
 const COST_DELTA_NEUTRAL_BAND = 0.05;
 /** Magnitudes at or beyond this saturate the shade ramp. */
 const COST_DELTA_SATURATION = 0.5;
+// `no-baseline` (∞) is neutral gray, never red/green: a missing B200 baseline
+// is not a better/worse judgment.
 const COST_DELTA_CLASS = {
   cheaper: 'text-emerald-700 dark:text-emerald-400',
   pricier: 'text-red-700 dark:text-red-400',
   even: 'bg-muted text-muted-foreground',
+  'no-baseline': 'text-muted-foreground',
 } as const;
 const COST_DELTA_HUE = { cheaper: '16 185 129', pricier: '239 68 68' } as const;
 
@@ -209,6 +217,8 @@ function costDeltaAlpha(pct: number): string {
   return (0.08 + strength * 0.32).toFixed(2);
 }
 
+/** Relative-to-B200 badge. `pct === null` means the row's B200 baseline is
+ *  unavailable: the badge shows a neutral `∞` instead of a percentage. */
 function CostDeltaBadge({
   pct,
   hardware,
@@ -216,17 +226,22 @@ function CostDeltaBadge({
   strings,
   phoneRow,
 }: {
-  pct: number;
+  pct: number | null;
   hardware: string;
   formatters: Formatters;
   strings: OverviewStrings;
   phoneRow: boolean;
 }) {
-  const polarity = costDeltaPolarity(pct);
+  const polarity: CostDeltaPolarity = pct === null ? 'no-baseline' : costDeltaPolarity(pct);
   const aria =
-    polarity === 'even'
-      ? strings.costDeltaEvenAria
-      : strings.costDeltaAria(formatters.percentAbs.format(Math.abs(pct)), polarity === 'cheaper');
+    pct === null
+      ? strings.noBaselineAria
+      : polarity === 'even'
+        ? strings.costDeltaEvenAria
+        : strings.costDeltaAria(
+            formatters.percentAbs.format(Math.abs(pct)),
+            polarity === 'cheaper',
+          );
   return (
     <span
       data-testid="overview-cost-delta"
@@ -234,7 +249,7 @@ function CostDeltaBadge({
       data-cost-polarity={polarity}
       title={aria}
       style={
-        polarity === 'even'
+        pct === null || polarity === 'even' || polarity === 'no-baseline'
           ? undefined
           : { backgroundColor: `rgb(${COST_DELTA_HUE[polarity]} / ${costDeltaAlpha(pct)})` }
       }
@@ -242,7 +257,7 @@ function CostDeltaBadge({
         phoneRow ? 'col-start-2 justify-self-start' : 'xl:col-start-2 xl:justify-self-end'
       } ${COST_DELTA_CLASS[polarity]}`}
     >
-      <span aria-hidden="true">{formatters.percent.format(pct)}</span>
+      <span aria-hidden="true">{pct === null ? '∞' : formatters.percent.format(pct)}</span>
       <span className="sr-only">{aria}</span>
     </span>
   );
@@ -301,38 +316,69 @@ function CellValue({
   const estimateExplanation = member.read.estimated
     ? strings.estimatedTooltip(evidenceTopologies)
     : undefined;
+  // No visible date, but the evidence link's hover/focus/SR label keeps the
+  // run date so the number stays reproducible.
+  const evidenceAria =
+    config === null || stack === null
+      ? null
+      : strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack);
+  const costText =
+    estimateExplanation === undefined ? (
+      formattedValue
+    ) : (
+      <span data-testid="overview-estimate-visible" aria-hidden="true">
+        {'≈'}
+        {formattedValue}
+      </span>
+    );
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
-      {/* Fixed cost | delta | date grids keep comparisons scannable on desktop and phones;
+      {/* Fixed cost | delta grids keep comparisons scannable on desktop and phones;
           the delta slot is reserved even on B200 so numbers align across rows. */}
       <div
         className={
           phoneRow
-            ? 'grid grid-cols-[max-content_max-content_minmax(0,1fr)] items-baseline gap-x-1.5 gap-y-0.5'
-            : 'flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem_auto]'
+            ? 'grid grid-cols-[max-content_minmax(0,1fr)] items-baseline gap-x-1.5 gap-y-0.5'
+            : 'flex flex-wrap items-baseline gap-x-1.5 gap-y-0.5 xl:grid xl:grid-cols-[minmax(max-content,1fr)_3.5rem]'
         }
       >
         <span
           data-testid="overview-pair-value"
           data-hardware={member.hardware}
-          title={estimateExplanation}
           className="whitespace-nowrap font-semibold tabular-nums"
         >
-          {estimateExplanation === undefined ? (
-            formattedValue
+          {evidenceAria === null || config === null ? (
+            <span title={estimateExplanation}>
+              {estimateExplanation === undefined ? null : (
+                <span className="sr-only">
+                  {strings.estimatedAria(formattedValue, estimateExplanation)}
+                </span>
+              )}
+              {costText}
+            </span>
           ) : (
-            <>
-              <span className="sr-only">
-                {strings.estimatedAria(formattedValue, estimateExplanation)}
-              </span>
-              <span data-testid="overview-estimate-visible" aria-hidden="true">
-                {'≈'}
-                {formattedValue}
-              </span>
-            </>
+            /* The cost itself is the evidence entry point into the filtered
+               dashboard for exactly this configuration. */
+            <a
+              data-testid="overview-cost-evidence-link"
+              href={buildOverviewDashboardHref(locale, model, config)}
+              title={
+                estimateExplanation === undefined
+                  ? evidenceAria
+                  : `${estimateExplanation} ${evidenceAria}`
+              }
+              aria-label={
+                estimateExplanation === undefined
+                  ? evidenceAria
+                  : `${strings.estimatedAria(formattedValue, estimateExplanation)} ${evidenceAria}`
+              }
+              className={RAW_SOURCE_LINK_CLASS}
+            >
+              {costText}
+            </a>
           )}
         </span>
-        {member.costVsB200Pct === null ? null : (
+        {member.hardware === 'b200' ? null : (
           <CostDeltaBadge
             pct={member.costVsB200Pct}
             hardware={member.hardware}
@@ -340,28 +386,6 @@ function CellValue({
             strings={strings}
             phoneRow={phoneRow}
           />
-        )}
-        {evidenceDate === null ? null : (
-          <span
-            data-testid="overview-pair-evidence-date"
-            data-hardware={member.hardware}
-            className={`whitespace-nowrap text-[11px] text-muted-foreground/80 tabular-nums ${
-              phoneRow ? 'col-start-3 justify-self-end' : 'xl:col-start-3 xl:justify-self-end'
-            }`}
-          >
-            {config === null || stack === null ? (
-              evidenceDateLabel
-            ) : (
-              <a
-                href={buildOverviewDashboardHref(locale, model, config)}
-                title={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                aria-label={strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack)}
-                className={RAW_SOURCE_LINK_CLASS}
-              >
-                {evidenceDateLabel}
-              </a>
-            )}
-          </span>
         )}
       </div>
       {member.precision === null ? null : (
@@ -651,11 +675,11 @@ export function OverviewEngineScopeSwitcher({
 export function OverviewMethodology({ strings }: { strings: OverviewStrings }) {
   return (
     <div className="space-y-1 border-t border-border/50 px-4 py-3 text-xs leading-snug text-muted-foreground lg:px-6">
-      <p>{strings.methodologyNote}</p>
       <p>{strings.costNote}</p>
+      <p>{strings.cellStateLegend}</p>
+      <p>{strings.methodologyNote}</p>
       <p>{strings.comparabilityNote}</p>
       <p>{strings.normalizationNote}</p>
-      <p>{strings.infinityLegend}</p>
       <p>{strings.interpolationNote}</p>
     </div>
   );

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -365,7 +365,7 @@ function CellValue({
               }
               aria-label={
                 estimateExplanation === undefined
-                  ? evidenceAria
+                  ? `${formattedValue}. ${evidenceAria}`
                   : `${strings.estimatedAria(formattedValue, estimateExplanation)} ${evidenceAria}`
               }
               className={RAW_SOURCE_LINK_CLASS}

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -4,6 +4,8 @@ import type { BenchmarkRow } from './api';
 import { Model, Precision } from './data-mappings';
 import type { OverviewPageData } from './overview-data';
 
+/** `throughput` is TOTAL tok/s per GPU — the overview's cost basis. The
+ *  output metric is a decoy so a regression to output pricing surfaces here. */
 function row(hardware: string, framework: string, throughput: number): BenchmarkRow {
   return {
     id: throughput,
@@ -30,7 +32,7 @@ function row(hardware: string, framework: string, throughput: number): Benchmark
     conc: 1,
     offload_mode: 'off',
     image: null,
-    metrics: { median_intvty: 50, output_tput_per_gpu: throughput },
+    metrics: { median_intvty: 50, tput_per_gpu: throughput, output_tput_per_gpu: 123 },
     date: '2026-07-20',
     run_url: null,
   };

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -9,6 +9,7 @@ import { DEFAULT_MODELS, Model, Precision } from './data-mappings';
 import {
   assembleOverviewPageData,
   buildOverviewModelSummary,
+  overviewCostPerMtok,
   overviewScenarioForModel,
   resolveOverviewEngineScope,
   resolveOverviewTier,
@@ -17,6 +18,9 @@ import {
 
 let nextId = 1;
 
+// `output_tput_per_gpu` is deliberately a constant decoy on most rows: the
+// overview's cost basis is TOTAL tokens (`tput_per_gpu`), so any expectation
+// below would collapse to the 123 decoy if the code read output tokens.
 function row(overrides: Partial<BenchmarkRow> = {}): BenchmarkRow {
   return {
     id: nextId++,
@@ -43,28 +47,28 @@ function row(overrides: Partial<BenchmarkRow> = {}): BenchmarkRow {
     conc: 16,
     offload_mode: 'off',
     image: null,
-    metrics: { median_intvty: 50, output_tput_per_gpu: 1000 },
+    metrics: { median_intvty: 50, tput_per_gpu: 8700, output_tput_per_gpu: 123 },
     date: '2026-07-20',
     run_url: null,
     ...overrides,
   };
 }
 
-/** One frontier point per tier for a single configuration. */
+/** One frontier point per tier for a single configuration (total tok/s/GPU). */
 function frontier(
-  throughputs: [number, number, number, number],
+  totals: [number, number, number, number],
   overrides: Partial<BenchmarkRow> = {},
 ): BenchmarkRow[] {
   return [30, 50, 75, 100].map((tier, index) =>
     row({
       conc: index + 1,
-      metrics: { median_intvty: tier, output_tput_per_gpu: throughputs[index] },
+      metrics: { median_intvty: tier, tput_per_gpu: totals[index], output_tput_per_gpu: 123 },
       ...overrides,
     }),
   );
 }
 
-/** Frontier at explicit [interactivity, throughput] knots — for clamped/unreachable tiers. */
+/** Frontier at explicit [interactivity, total tput] knots — for clamped/unreachable tiers. */
 function frontierAt(
   points: [number, number][],
   overrides: Partial<BenchmarkRow> = {},
@@ -72,10 +76,34 @@ function frontierAt(
   return points.map(([intvty, tput], index) =>
     row({
       conc: index + 1,
-      metrics: { median_intvty: intvty, output_tput_per_gpu: tput },
+      metrics: { median_intvty: intvty, tput_per_gpu: tput, output_tput_per_gpu: 123 },
       ...overrides,
     }),
   );
+}
+
+/** AgentX trace-replay row: tier axis is P90 interactivity (1/p90_itl). */
+function agenticRow(
+  p90Interactivity: number,
+  p90E2eLatency: number,
+  totalTput: number,
+  outputTput: number,
+  overrides: Partial<BenchmarkRow> = {},
+): BenchmarkRow {
+  return row({
+    model: 'glm5.2',
+    benchmark_type: 'agentic_traces',
+    isl: null,
+    osl: null,
+    precision: Precision.FP4,
+    metrics: {
+      p90_itl: 1 / p90Interactivity,
+      p90_ttlt: p90E2eLatency,
+      tput_per_gpu: totalTput,
+      output_tput_per_gpu: outputTput,
+    },
+    ...overrides,
+  });
 }
 
 function headlinePairOf(summary: OverviewModelSummary, id: string) {
@@ -96,24 +124,11 @@ describe('overview engine scope and scenario selection', () => {
   });
 
   it('prefers single-turn 8K/1K rows and otherwise falls back to AgentX', () => {
-    const singleTurn = frontier([1200, 1000, 800, 600], {
+    const singleTurn = frontier([10800, 9000, 7200, 5400], {
       model: 'glm5.2',
       hardware: 'b200',
     });
-    const agentx = [
-      row({
-        model: 'glm5.2',
-        hardware: 'b200',
-        benchmark_type: 'agentic_traces',
-        isl: null,
-        osl: null,
-        metrics: {
-          p90_itl: 1 / 50,
-          p90_ttlt: 25,
-          output_tput_per_gpu: 850,
-        },
-      }),
-    ];
+    const agentx = [agenticRow(50, 25, 7650, 850, { hardware: 'b200' })];
 
     expect(buildOverviewModelSummary(Model.GLM_5_2, [...agentx, ...singleTurn]).scenario).toBe(
       'single_turn_8k1k',
@@ -135,21 +150,32 @@ describe('overview engine scope and scenario selection', () => {
     expect(resolveOverviewEngineScope(undefined)).toBe('community');
   });
 
-  it('derives cost per Mtok from retail rental $/GPU/hr and compares against B200', () => {
+  it('prices from HW_REGISTRY costh — not the retail costr tier', () => {
+    // b200: costh 1.95 vs costr 2.90 — the two tiers disagree, so a costr
+    // regression cannot pass this assertion.
+    expect(overviewCostPerMtok('b200', 7200)).toBeCloseTo(1_950_000 / (7200 * 3600), 9);
+    expect(overviewCostPerMtok('b200', 7200)).not.toBeCloseTo(2_900_000 / (7200 * 3600), 9);
+    expect(overviewCostPerMtok('mi355x', 9000)).toBeCloseTo(1_480_000 / (9000 * 3600), 9);
+    expect(overviewCostPerMtok('b200', null)).toBeNull();
+    expect(overviewCostPerMtok('b200', 0)).toBeNull();
+    expect(overviewCostPerMtok('b200', -100)).toBeNull();
+  });
+
+  it('derives cost per Mtok from hyperscaler $/GPU/hr over total tokens and compares against B200', () => {
     const rows = [
-      ...frontier([1200, 800, 700, 600], { hardware: 'b200', precision: Precision.FP4 }),
-      ...frontier([1400, 1000, 900, 800], { hardware: 'mi355x', precision: Precision.FP4 }),
-      ...frontier([1300, 900, 800, 700], { hardware: 'gb300', precision: Precision.FP4 }),
+      ...frontier([10800, 7200, 6300, 5400], { hardware: 'b200', precision: Precision.FP4 }),
+      ...frontier([12600, 9000, 8100, 7200], { hardware: 'mi355x', precision: Precision.FP4 }),
+      ...frontier([11700, 8100, 7200, 6300], { hardware: 'gb300', precision: Precision.FP4 }),
     ];
     const summary = buildOverviewModelSummary(Model.Qwen3_5, rows, 50, 'community');
     const byHardware = Object.fromEntries(summary.platforms.map((p) => [p.hardware, p]));
 
-    // Note (wenyao): expected $/GPU/hr from HW_REGISTRY costr — b200 2.90, mi355x 2.10, gb300 3.96.
-    expect(byHardware.b200.costPerMtok).toBeCloseTo(2_900_000 / (800 * 3600), 6);
+    // Expected $/GPU/hr from HW_REGISTRY costh — b200 1.95, mi355x 1.48, gb300 2.652.
+    expect(byHardware.b200.costPerMtok).toBeCloseTo(1_950_000 / (7200 * 3600), 6);
     expect(byHardware.b200.costVsB200Pct).toBeNull();
-    expect(byHardware.mi355x.costPerMtok).toBeCloseTo(2_100_000 / (1000 * 3600), 6);
+    expect(byHardware.mi355x.costPerMtok).toBeCloseTo(1_480_000 / (9000 * 3600), 6);
     expect(byHardware.mi355x.costVsB200Pct).toBeCloseTo(
-      2_100_000 / (1000 * 3600) / (2_900_000 / (800 * 3600)) - 1,
+      1_480_000 / (9000 * 3600) / (1_950_000 / (7200 * 3600)) - 1,
       6,
     );
     expect(byHardware.mi355x.costVsB200Pct).toBeLessThan(0);
@@ -158,34 +184,48 @@ describe('overview engine scope and scenario selection', () => {
     expect(byHardware.b300.costVsB200Pct).toBeNull();
   });
 
+  it('keeps a platform cost without a B200 baseline so the UI can badge it ∞', () => {
+    const summary = buildOverviewModelSummary(
+      Model.Qwen3_5,
+      frontier([12600, 9000, 8100, 7200], { hardware: 'gb300', precision: Precision.FP4 }),
+      50,
+      'community',
+    );
+    const gb300 = summary.platforms.find((p) => p.hardware === 'gb300')!;
+
+    expect(gb300.costPerMtok).toBeCloseTo(2_652_000 / (9000 * 3600), 6);
+    expect(gb300.costVsB200Pct).toBeNull();
+    expect(summary.platforms.find((p) => p.hardware === 'b200')?.costPerMtok).toBeNull();
+  });
+
   it('includes vLLM and SGLang wrapper families in community scope and excludes ATOM/TRTLLM', () => {
     const rows = [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         hardware: 'mi355x',
         framework: 'dynamo-vllm',
         precision: Precision.FP4,
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         framework: 'llmd-vllm',
         precision: Precision.FP4,
       }),
-      ...frontier([1150, 950, 750, 550], {
+      ...frontier([10350, 8550, 6750, 4950], {
         hardware: 'gb300',
         framework: 'dynamo-sglang',
         precision: Precision.FP4,
       }),
-      ...frontier([1050, 850, 650, 450], {
+      ...frontier([9450, 7650, 5850, 4050], {
         hardware: 'b200',
         framework: 'mori-sglang',
         precision: Precision.FP4,
       }),
-      ...frontier([1500, 1300, 1100, 900], {
+      ...frontier([13500, 11700, 9900, 8100], {
         hardware: 'mi355x',
         framework: 'atom',
         precision: Precision.FP4,
       }),
-      ...frontier([1400, 1200, 1000, 800], {
+      ...frontier([12600, 10800, 9000, 7200], {
         hardware: 'b200',
         framework: 'trtllm',
         precision: Precision.FP4,
@@ -208,7 +248,7 @@ describe('overview engine scope and scenario selection', () => {
     );
   });
 
-  it('stamps community scope and dates the dataset from community rows only', () => {
+  it('stamps community scope without a dataset date field', () => {
     const page = assembleOverviewPageData(
       {
         [Model.Qwen3_5]: [
@@ -221,7 +261,29 @@ describe('overview engine scope and scenario selection', () => {
     );
 
     expect(page.engineScope).toBe('community');
-    expect(page.datasetThroughDate).toBe('2026-07-20');
+    expect(page).not.toHaveProperty('datasetThroughDate');
+  });
+
+  it('ranks same-bucket configs by total throughput even when output ranking disagrees', () => {
+    const summary = buildOverviewModelSummary(Model.Qwen3_5, [
+      row({
+        hardware: 'b200',
+        framework: 'dynamo-vllm',
+        precision: Precision.FP4,
+        metrics: { median_intvty: 50, tput_per_gpu: 8000, output_tput_per_gpu: 2000 },
+      }),
+      row({
+        hardware: 'b200',
+        framework: 'llmd-vllm',
+        precision: Precision.FP4,
+        metrics: { median_intvty: 50, tput_per_gpu: 9900, output_tput_per_gpu: 900 },
+      }),
+    ]);
+    const b200 = summary.platforms.find((p) => p.hardware === 'b200')!;
+
+    expect(b200.read.config?.framework).toBe('llmd-vllm');
+    expect(b200.read.value).toBe(9900);
+    expect(b200.costPerMtok).toBeCloseTo(1_950_000 / (9900 * 3600), 6);
   });
 
   it('builds one serving-series frontier across topology variants', () => {
@@ -232,7 +294,7 @@ describe('overview engine scope and scenario selection', () => {
         decode_tp: 4,
         decode_num_workers: 1,
         num_decode_gpu: 4,
-        metrics: { median_intvty: 40, output_tput_per_gpu: 1200 },
+        metrics: { median_intvty: 40, tput_per_gpu: 10800, output_tput_per_gpu: 123 },
       }),
       row({
         hardware: 'gb300',
@@ -240,16 +302,16 @@ describe('overview engine scope and scenario selection', () => {
         decode_tp: 16,
         decode_num_workers: 2,
         num_decode_gpu: 16,
-        metrics: { median_intvty: 60, output_tput_per_gpu: 800 },
+        metrics: { median_intvty: 60, tput_per_gpu: 7200, output_tput_per_gpu: 123 },
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         precision: Precision.FP4,
       }),
     ]);
 
     expect(headlinePairOf(summary, 'gb300-vs-b200')?.candidate.read).toMatchObject({
-      value: 962.5,
+      value: 8662.5,
       boundary: 'interpolated',
       estimated: true,
     });
@@ -257,18 +319,18 @@ describe('overview engine scope and scenario selection', () => {
 
   it('marks a target tier backed by an observed frontier knot as exact', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         hardware: 'gb300',
         precision: Precision.FP4,
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         precision: Precision.FP4,
       }),
     ]);
 
     expect(headlinePairOf(summary, 'gb300-vs-b200')?.candidate.read).toMatchObject({
-      value: 1000,
+      value: 9000,
       boundary: 'interpolated',
       estimated: false,
     });
@@ -283,7 +345,7 @@ describe('overview engine scope and scenario selection', () => {
         is_multinode: true,
         num_prefill_gpu: 4,
         num_decode_gpu: 8,
-        metrics: { median_intvty: 40, output_tput_per_gpu: 1800 },
+        metrics: { median_intvty: 40, tput_per_gpu: 16200, output_tput_per_gpu: 123 },
       }),
       row({
         hardware: 'gb300',
@@ -292,9 +354,9 @@ describe('overview engine scope and scenario selection', () => {
         is_multinode: true,
         num_prefill_gpu: 4,
         num_decode_gpu: 8,
-        metrics: { median_intvty: 60, output_tput_per_gpu: 1200 },
+        metrics: { median_intvty: 60, tput_per_gpu: 10800, output_tput_per_gpu: 123 },
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         precision: Precision.FP4,
       }),
@@ -306,7 +368,7 @@ describe('overview engine scope and scenario selection', () => {
     });
   });
 
-  it('normalizes disaggregated output throughput by all deployed GPUs before interpolation', () => {
+  it('normalizes disaggregated total throughput by all deployed GPUs before interpolation', () => {
     const summary = buildOverviewModelSummary(Model.DeepSeek_V4_Pro, [
       row({
         hardware: 'gb300',
@@ -319,7 +381,8 @@ describe('overview engine scope and scenario selection', () => {
         num_decode_gpu: 8,
         metrics: {
           median_intvty: 44.117923723301274,
-          output_tput_per_gpu: 5169.251003712194,
+          tput_per_gpu: 5169.251003712194,
+          output_tput_per_gpu: 123,
         },
       }),
       row({
@@ -333,10 +396,11 @@ describe('overview engine scope and scenario selection', () => {
         num_decode_gpu: 8,
         metrics: {
           median_intvty: 68.267004773066,
-          output_tput_per_gpu: 3248.972986719746,
+          tput_per_gpu: 3248.972986719746,
+          output_tput_per_gpu: 123,
         },
       }),
-      ...frontier([1050, 900, 700, 500], {
+      ...frontier([9450, 8100, 6300, 4500], {
         hardware: 'b200',
         model: 'dsv4',
         precision: Precision.FP4,
@@ -352,7 +416,7 @@ describe('overview engine scope and scenario selection', () => {
 
   it('does not normalize aggregated multinode rows with duplicated P/D counts', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         hardware: 'gb300',
         precision: Precision.FP4,
         disagg: false,
@@ -363,14 +427,14 @@ describe('overview engine scope and scenario selection', () => {
     ]);
 
     expect(headlinePairOf(summary, 'gb300-vs-b200')?.candidate.read).toMatchObject({
-      value: 1000,
+      value: 9000,
       evidenceTopologies: [],
     });
   });
 
   it('normalizes disaggregated rows even when they run on one node', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1800, 1500, 1200, 900], {
+      ...frontier([16200, 13500, 10800, 8100], {
         hardware: 'gb300',
         precision: Precision.FP4,
         disagg: true,
@@ -381,7 +445,7 @@ describe('overview engine scope and scenario selection', () => {
     ]);
 
     expect(headlinePairOf(summary, 'gb300-vs-b200')?.candidate.read).toMatchObject({
-      value: 1000,
+      value: 9000,
       evidenceTopologies: ['4P+8D'],
     });
   });
@@ -393,7 +457,7 @@ describe('overview engine scope and scenario selection', () => {
       date: '2026-07-19',
       decode_tp: 4,
       num_decode_gpu: 4,
-      metrics: { median_intvty: 40, output_tput_per_gpu: 1200 },
+      metrics: { median_intvty: 40, tput_per_gpu: 10800, output_tput_per_gpu: 123 },
     });
     const newerTopology = row({
       hardware: 'gb300',
@@ -401,7 +465,7 @@ describe('overview engine scope and scenario selection', () => {
       date: '2026-07-20',
       decode_tp: 16,
       num_decode_gpu: 16,
-      metrics: { median_intvty: 60, output_tput_per_gpu: 800 },
+      metrics: { median_intvty: 60, tput_per_gpu: 7200, output_tput_per_gpu: 123 },
     });
 
     expect(dedupeRowsToLatestPerConfig([olderTopology, newerTopology])).toEqual([newerTopology]);
@@ -409,7 +473,7 @@ describe('overview engine scope and scenario selection', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
       olderTopology,
       newerTopology,
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         precision: Precision.FP4,
       }),
@@ -435,15 +499,15 @@ describe('overview engine scope and scenario selection', () => {
       row({
         hardware: 'gb300',
         precision: Precision.FP4,
-        metrics: { median_intvty: 40, output_tput_per_gpu: 1200 },
+        metrics: { median_intvty: 40, tput_per_gpu: 10800, output_tput_per_gpu: 123 },
       }),
       row({
         hardware: 'gb300',
         precision: Precision.FP4,
-        metrics: { median_intvty: 60, output_tput_per_gpu: 800 },
+        metrics: { median_intvty: 60, tput_per_gpu: 7200, output_tput_per_gpu: 123 },
         ...secondOverrides,
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'b200',
         precision: Precision.FP4,
       }),
@@ -454,34 +518,34 @@ describe('overview engine scope and scenario selection', () => {
 
   it('uses speculative FP4, speculative FP8, standard FP4, then standard FP8', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([900, 700, 500, 300], { hardware: 'b200', precision: Precision.FP4 }),
-      ...frontier([1400, 1200, 1000, 800], {
+      ...frontier([8100, 6300, 4500, 2700], { hardware: 'b200', precision: Precision.FP4 }),
+      ...frontier([12600, 10800, 9000, 7200], {
         hardware: 'b200',
         precision: Precision.FP4,
         spec_method: 'none',
       }),
-      ...frontier([1100, 900, 700, 500], { hardware: 'mi355x', precision: Precision.FP8 }),
-      ...frontier([1500, 1300, 1100, 900], {
+      ...frontier([9900, 8100, 6300, 4500], { hardware: 'mi355x', precision: Precision.FP8 }),
+      ...frontier([13500, 11700, 9900, 8100], {
         hardware: 'mi355x',
         precision: Precision.FP4,
         spec_method: 'none',
       }),
-      ...frontier([1300, 1100, 900, 700], {
+      ...frontier([11700, 9900, 8100, 6300], {
         hardware: 'b300',
         precision: Precision.FP4,
         spec_method: 'none',
       }),
-      ...frontier([1500, 1300, 1100, 900], {
+      ...frontier([13500, 11700, 9900, 8100], {
         hardware: 'b300',
         precision: Precision.FP8,
         spec_method: 'none',
       }),
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         hardware: 'gb200',
         precision: Precision.FP8,
         spec_method: 'none',
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'gb300',
         precision: Precision.FP4,
         spec_method: '',
@@ -495,11 +559,11 @@ describe('overview engine scope and scenario selection', () => {
         value: read.value,
       })),
     ).toEqual([
-      { hardware: 'b200', precision: Precision.FP4, value: 700 },
-      { hardware: 'mi355x', precision: Precision.FP8, value: 900 },
-      { hardware: 'b300', precision: Precision.FP4, value: 1100 },
-      { hardware: 'gb200', precision: Precision.FP8, value: 1000 },
-      { hardware: 'gb300', precision: Precision.FP4, value: 900 },
+      { hardware: 'b200', precision: Precision.FP4, value: 6300 },
+      { hardware: 'mi355x', precision: Precision.FP8, value: 8100 },
+      { hardware: 'b300', precision: Precision.FP4, value: 9900 },
+      { hardware: 'gb200', precision: Precision.FP8, value: 9000 },
+      { hardware: 'gb300', precision: Precision.FP4, value: 8100 },
     ]);
   });
 });
@@ -509,19 +573,19 @@ describe('overview platform selection', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
       ...frontierAt(
         [
-          [60, 900],
-          [70, 800],
-          [80, 700],
-          [90, 600],
+          [60, 8100],
+          [70, 7200],
+          [80, 6300],
+          [90, 5400],
         ],
         { hardware: 'mi355x', precision: Precision.FP4 },
       ),
       ...frontierAt(
         [
-          [20, 500],
-          [30, 450],
-          [40, 400],
-          [45, 350],
+          [20, 4500],
+          [30, 4050],
+          [40, 3600],
+          [45, 3150],
         ],
         { hardware: 'b200', precision: Precision.FP4 },
       ),
@@ -546,36 +610,36 @@ describe('overview platform selection', () => {
 
   it('keeps an exact side and marks an unreachable side missing', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         hardware: 'mi355x',
         precision: Precision.FP4,
       }),
       ...frontierAt(
         [
-          [20, 500],
-          [30, 450],
-          [40, 400],
-          [45, 350],
+          [20, 4500],
+          [30, 4050],
+          [40, 3600],
+          [45, 3150],
         ],
         { hardware: 'b200', precision: Precision.FP4 },
       ),
     ]);
 
     const pair = headlinePairOf(summary, 'mi355x-vs-b200');
-    expect(pair?.candidate.read).toMatchObject({ value: 1000, boundary: 'interpolated' });
+    expect(pair?.candidate.read).toMatchObject({ value: 9000, boundary: 'interpolated' });
     expect(pair?.baseline.read).toMatchObject({ value: null, boundary: 'unreachable' });
     expect(pair?.baseline.missingReason).toBe('cannot_reach_at_tier');
   });
 
   it('shows each platform’s independently selected release', () => {
     const summary = buildOverviewModelSummary(Model.Kimi_K2_5, [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         model: 'kimik2.5',
         hardware: 'b200',
         precision: Precision.FP4,
         date: '2026-07-10',
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         model: 'kimik2.7-code',
         hardware: 'mi355x',
         precision: Precision.FP4,
@@ -590,22 +654,22 @@ describe('overview platform selection', () => {
 
   it('selects each platform’s best release independently', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1200, 1000, 800, 600], {
+      ...frontier([10800, 9000, 7200, 5400], {
         model: 'qwen3.5-a',
         hardware: 'mi355x',
         precision: Precision.FP4,
       }),
-      ...frontier([700, 500, 400, 300], {
+      ...frontier([6300, 4500, 3600, 2700], {
         model: 'qwen3.5-a',
         hardware: 'b200',
         precision: Precision.FP4,
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         model: 'qwen3.5-b',
         hardware: 'mi355x',
         precision: Precision.FP4,
       }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([9900, 8100, 6300, 4500], {
         model: 'qwen3.5-b',
         hardware: 'b200',
         precision: Precision.FP4,
@@ -613,25 +677,25 @@ describe('overview platform selection', () => {
     ]);
 
     expect(headlinePairOf(summary, 'mi355x-vs-b200')).toMatchObject({
-      candidate: { read: { value: 1000, config: { dbModel: 'qwen3.5-a' } } },
-      baseline: { read: { value: 900, config: { dbModel: 'qwen3.5-b' } } },
+      candidate: { read: { value: 9000, config: { dbModel: 'qwen3.5-a' } } },
+      baseline: { read: { value: 8100, config: { dbModel: 'qwen3.5-b' } } },
     });
   });
 
   it('claims cannot-reach only when every speculative bucket is unreachable', () => {
     const unreachable: [number, number][] = [
-      [20, 500],
-      [30, 450],
-      [40, 400],
-      [45, 350],
+      [20, 4500],
+      [30, 4050],
+      [40, 3600],
+      [45, 3150],
     ];
     const underSwept: [number, number][] = [
-      [60, 900],
-      [70, 800],
-      [80, 700],
-      [90, 600],
+      [60, 8100],
+      [70, 7200],
+      [80, 6300],
+      [90, 5400],
     ];
-    const baseline = frontier([1200, 1000, 800, 600], {
+    const baseline = frontier([10800, 9000, 7200, 5400], {
       hardware: 'b200',
       precision: Precision.FP4,
     });
@@ -657,8 +721,8 @@ describe('overview platform selection', () => {
 
   it('falls back to standard decode and still flags unsupported precision coverage', () => {
     const summary = buildOverviewModelSummary(Model.Qwen3_5, [
-      ...frontier([1200, 1000, 800, 600], { hardware: 'b200', precision: Precision.FP4 }),
-      ...frontier([1100, 900, 700, 500], {
+      ...frontier([10800, 9000, 7200, 5400], { hardware: 'b200', precision: Precision.FP4 }),
+      ...frontier([9900, 8100, 6300, 4500], {
         hardware: 'mi355x',
         precision: Precision.FP8,
         spec_method: 'none',
@@ -669,27 +733,33 @@ describe('overview platform selection', () => {
     expect(headlinePairOf(summary, 'mi355x-vs-b200')?.candidate).toMatchObject({
       missingReason: null,
       precision: Precision.FP8,
-      read: { value: 900, config: { specMethod: 'none' } },
+      read: { value: 8100, config: { specMethod: 'none' } },
     });
     expect(headlinePairOf(summary, 'b300-vs-b200')?.candidate.missingReason).toBe('int4_bf16_only');
   });
 
-  it('falls back to standard decode for AgentX when no speculative result exists', () => {
-    const agentxRows = [40, 50, 60].map((interactivity, index) =>
+  it('drops single-turn rows without a total-throughput metric instead of pricing them', () => {
+    const summary = buildOverviewModelSummary(Model.Qwen3_5, [
       row({
-        model: 'glm5.2',
-        hardware: 'b300',
-        benchmark_type: 'agentic_traces',
-        isl: null,
-        osl: null,
+        hardware: 'b200',
         precision: Precision.FP4,
+        metrics: { median_intvty: 50, output_tput_per_gpu: 1000 },
+      }),
+    ]);
+
+    expect(summary.platforms.find(({ hardware }) => hardware === 'b200')).toMatchObject({
+      read: { value: null },
+      costPerMtok: null,
+      missingReason: 'no_scenario_data',
+    });
+  });
+
+  it('falls back to standard decode for AgentX when no speculative result exists', () => {
+    const agentxRows = [0, 1, 2].map((index) =>
+      agenticRow(40 + index * 10, 30 - index * 5, 9000 - index * 900, 1000 - index * 100, {
+        hardware: 'b300',
         spec_method: 'none',
         conc: index + 1,
-        metrics: {
-          p90_itl: 1 / interactivity,
-          p90_ttlt: 30 - index * 5,
-          output_tput_per_gpu: 1000 - index * 100,
-        },
       }),
     );
 
@@ -698,68 +768,38 @@ describe('overview platform selection', () => {
     expect(summary.platforms.find(({ hardware }) => hardware === 'b300')).toMatchObject({
       missingReason: null,
       precision: Precision.FP4,
-      read: { value: 900, config: { specMethod: 'none' } },
+      read: { value: 8100, config: { specMethod: 'none' } },
     });
   });
 
-  it('reads AgentX at the chart-default P90 contract without exposing P90 as the scenario', () => {
+  it('reads AgentX at the chart-default P90 contract and prices total tokens', () => {
     const summary = buildOverviewModelSummary(Model.GLM_5_2, [
-      row({
-        model: 'glm5.2',
-        hardware: 'b200',
-        benchmark_type: 'agentic_traces',
-        isl: null,
-        osl: null,
-        precision: Precision.FP4,
-        spec_method: 'mtp',
-        conc: 8,
-        metrics: {
-          p90_itl: 1 / 40,
-          p90_ttlt: 30,
-          tput_per_gpu: 1400,
-          output_tput_per_gpu: 1200,
-        },
-      }),
-      row({
-        model: 'glm5.2',
-        hardware: 'b200',
-        benchmark_type: 'agentic_traces',
-        isl: null,
-        osl: null,
-        precision: Precision.FP4,
-        spec_method: 'mtp',
-        conc: 12,
-        metrics: {
-          p90_itl: 1 / 50,
-          p90_ttlt: 25,
-          tput_per_gpu: 900,
-          output_tput_per_gpu: 850,
-        },
-      }),
-      row({
-        model: 'glm5.2',
-        hardware: 'b200',
-        benchmark_type: 'agentic_traces',
-        isl: null,
-        osl: null,
-        precision: Precision.FP4,
-        spec_method: 'mtp',
-        conc: 16,
-        metrics: {
-          p90_itl: 1 / 60,
-          p90_ttlt: 20,
-          tput_per_gpu: 1000,
-          output_tput_per_gpu: 800,
-        },
-      }),
+      agenticRow(40, 30, 12600, 1200, { hardware: 'b200', conc: 8 }),
+      agenticRow(50, 25, 10800, 850, { hardware: 'b200', conc: 12 }),
+      agenticRow(60, 20, 9000, 800, { hardware: 'b200', conc: 16 }),
     ]);
 
     expect(summary.scenario).toBe('agentx');
-    expect(summary.platforms.find(({ hardware }) => hardware === 'b200')?.read).toMatchObject({
-      value: 850,
+    const b200 = summary.platforms.find(({ hardware }) => hardware === 'b200')!;
+    expect(b200.read).toMatchObject({
+      value: 10800,
       boundary: 'interpolated',
       estimated: false,
     });
+    expect(b200.costPerMtok).toBeCloseTo(1_950_000 / (10800 * 3600), 6);
+  });
+
+  it('restricts AgentX points to the E2E frontier on total throughput', () => {
+    // The slower-E2E point wins on output tokens but loses on total tokens, so
+    // the total-token frontier drops it and the tier read becomes unreachable.
+    const summary = buildOverviewModelSummary(Model.GLM_5_2, [
+      agenticRow(40, 20, 9000, 500, { hardware: 'b200', conc: 8 }),
+      agenticRow(50, 25, 8100, 900, { hardware: 'b200', conc: 12 }),
+    ]);
+
+    const b200 = summary.platforms.find(({ hardware }) => hardware === 'b200')!;
+    expect(b200.read.value).toBeNull();
+    expect(b200.missingReason).toBe('cannot_reach_at_tier');
   });
 
   it('reports scenario-level missing coverage when AgentX rows lack usable P90 metrics', () => {
@@ -773,6 +813,7 @@ describe('overview platform selection', () => {
         precision: Precision.FP4,
         spec_method: 'mtp',
         metrics: {
+          tput_per_gpu: 10800,
           output_tput_per_gpu: 1200,
         },
       }),
@@ -821,8 +862,8 @@ describe('tier-parameterized overview', () => {
     const page = assembleOverviewPageData(
       {
         [Model.Qwen3_5]: [
-          ...frontier([1000, 800, 600, 400], { hardware: 'mi355x', precision: Precision.FP4 }),
-          ...frontier([1200, 1000, 800, 600], { hardware: 'b200', precision: Precision.FP4 }),
+          ...frontier([9000, 7200, 5400, 3600], { hardware: 'mi355x', precision: Precision.FP4 }),
+          ...frontier([10800, 9000, 7200, 5400], { hardware: 'b200', precision: Precision.FP4 }),
         ],
       },
       100,
@@ -832,19 +873,19 @@ describe('tier-parameterized overview', () => {
       page.models.find((m) => m.model === Model.Qwen3_5)!,
       'mi355x-vs-b200',
     );
-    expect(pair?.candidate.read).toMatchObject({ tier: 100, value: 400 });
-    expect(pair?.baseline.read).toMatchObject({ tier: 100, value: 600 });
+    expect(pair?.candidate.read).toMatchObject({ tier: 100, value: 3600 });
+    expect(pair?.baseline.read).toMatchObject({ tier: 100, value: 5400 });
   });
 
   it('turns an unreachable @50 side into an exact read on the 30 view', () => {
     const rows = [
-      ...frontier([1200, 1000, 800, 600], { hardware: 'mi355x', precision: Precision.FP4 }),
+      ...frontier([10800, 9000, 7200, 5400], { hardware: 'mi355x', precision: Precision.FP4 }),
       ...frontierAt(
         [
-          [20, 500],
-          [30, 450],
-          [40, 400],
-          [45, 350],
+          [20, 4500],
+          [30, 4050],
+          [40, 3600],
+          [45, 3150],
         ],
         { hardware: 'b200', precision: Precision.FP4 },
       ),
@@ -864,7 +905,7 @@ describe('tier-parameterized overview', () => {
       )!,
       'mi355x-vs-b200',
     );
-    expect(at30?.baseline.read).toMatchObject({ tier: 30, value: 450 });
+    expect(at30?.baseline.read).toMatchObject({ tier: 30, value: 4050 });
     expect(at30?.baseline.missingReason).toBeNull();
   });
 
@@ -873,9 +914,12 @@ describe('tier-parameterized overview', () => {
       assembleOverviewPageData(
         {
           [Model.Qwen3_5]: [
-            ...frontier([1200, 1000, 800, 400], { hardware: 'mi355x', precision: Precision.FP4 }),
-            ...frontier([1100, 900, 850, 700], { hardware: 'mi355x', precision: Precision.FP8 }),
-            ...frontier([1200, 1000, 800, 600], { hardware: 'b200', precision: Precision.FP8 }),
+            ...frontier([10800, 9000, 7200, 3600], {
+              hardware: 'mi355x',
+              precision: Precision.FP4,
+            }),
+            ...frontier([9900, 8100, 7650, 6300], { hardware: 'mi355x', precision: Precision.FP8 }),
+            ...frontier([10800, 9000, 7200, 5400], { hardware: 'b200', precision: Precision.FP8 }),
           ],
         },
         tier,
@@ -883,15 +927,15 @@ describe('tier-parameterized overview', () => {
 
     const at50 = headlinePairOf(page(), 'mi355x-vs-b200');
     expect(at50?.candidate.precision).toBe(Precision.FP4);
-    expect(at50?.candidate.read.value).toBe(1000);
+    expect(at50?.candidate.read.value).toBe(9000);
     expect(at50?.baseline.precision).toBe(Precision.FP8);
-    expect(at50?.baseline.read.value).toBe(1000);
+    expect(at50?.baseline.read.value).toBe(9000);
 
     const at100 = headlinePairOf(page(100), 'mi355x-vs-b200');
     expect(at100?.candidate.precision).toBe(Precision.FP4);
-    expect(at100?.candidate.read.value).toBe(400);
+    expect(at100?.candidate.read.value).toBe(3600);
     expect(at100?.baseline.precision).toBe(Precision.FP8);
-    expect(at100?.baseline.read.value).toBe(600);
+    expect(at100?.baseline.read.value).toBe(5400);
   });
 });
 
@@ -904,7 +948,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     );
 
     expect(page.models).toHaveLength(DEFAULT_MODELS.size);
-    expect(page.datasetThroughDate).toBe('2026-07-18');
+    expect(page).not.toHaveProperty('datasetThroughDate');
     expect(page.tier).toBe(50);
 
     // DeepSeek: only each series' latest-date sweep survives. B300 and MI355X
@@ -913,12 +957,15 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     // they must not be interpolated into one synthetic serving curve.
     const deepseek = page.models.find((m) => m.model === Model.DeepSeek_V4_Pro)!;
     const dsB300 = headlinePairOf(deepseek, 'b300-vs-b200')!;
-    expect(dsB300.baseline.read.value).toBeCloseTo(900.219);
+    expect(dsB300.baseline.read.value).toBeCloseTo(8101.968);
+    expect(dsB300.baseline.costPerMtok).toBeCloseTo(1_950_000 / (8101.968 * 3600), 6);
     expect(dsB300.candidate.read.value).toBeNull();
+    expect(dsB300.candidate.costPerMtok).toBeNull();
     expect(dsB300.candidate.missingReason).toBe('no_exact_at_tier');
     const dsGb200 = headlinePairOf(deepseek, 'gb200-vs-b200')!;
     expect(dsGb200.candidate.precision).toBe(Precision.FP8);
-    expect(dsGb200.candidate.read.value).toBe(600);
+    expect(dsGb200.candidate.read.value).toBe(5100);
+    expect(dsGb200.candidate.costPerMtok).toBeCloseTo(2_210_000 / (5100 * 3600), 6);
     expect(headlinePairOf(deepseek, 'mi355x-vs-b200')?.candidate.missingReason).toBe(
       'no_exact_at_tier',
     );
@@ -927,43 +974,51 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     expect(dsGb300.candidate.read.evidenceTopologies).toEqual([]);
     expect(dsGb300.candidate.missingReason).toBe('no_exact_at_tier');
 
-    // MiniMax: the platform result remains visible when B200 has no 8K/1K data.
+    // MiniMax: the platform result remains visible when B200 has no 8K/1K data
+    // — priced, but with no percentage baseline (the UI's ∞ badge state).
     const minimax = page.models.find((m) => m.model === Model.MiniMax_M3)!;
     const mmGb300 = headlinePairOf(minimax, 'gb300-vs-b200')!;
     expect(mmGb300.baseline.missingReason).toBe('no_scenario_data');
-    expect(mmGb300.candidate.read.value).toBe(700);
+    expect(mmGb300.candidate.read.value).toBe(6510);
+    expect(mmGb300.candidate.costPerMtok).toBeCloseTo(2_652_000 / (6510 * 3600), 6);
+    expect(mmGb300.candidate.costVsB200Pct).toBeNull();
 
     // Qwen: MI355X independently falls back to FP8 while B200 and B300 use FP4.
     const qwen = page.models.find((m) => m.model === Model.Qwen3_5)!;
     const qwenMi = headlinePairOf(qwen, 'mi355x-vs-b200')!;
     expect(qwenMi.candidate.precision).toBe(Precision.FP8);
-    expect(qwenMi.candidate.read.value).toBe(760);
+    expect(qwenMi.candidate.read.value).toBe(6688);
+    expect(qwenMi.candidate.costPerMtok).toBeCloseTo(1_480_000 / (6688 * 3600), 6);
     expect(qwenMi.baseline.precision).toBe(Precision.FP4);
-    expect(qwenMi.baseline.read.value).toBeCloseTo(733.594);
+    expect(qwenMi.baseline.read.value).toBeCloseTo(6602.344);
+    expect(qwenMi.candidate.costVsB200Pct).toBeCloseTo(
+      1_480_000 / (6688 * 3600) / (1_950_000 / (6602.344 * 3600)) - 1,
+      6,
+    );
     const qwenB300 = headlinePairOf(qwen, 'b300-vs-b200')!;
     expect(qwenB300.candidate.precision).toBe(Precision.FP4);
-    expect(qwenB300.candidate.read.value).toBeCloseTo(1150.625);
+    expect(qwenB300.candidate.read.value).toBeCloseTo(10585.75);
     expect(qwenB300.baseline.precision).toBe(Precision.FP4);
-    expect(qwenB300.baseline.read.value).toBeCloseTo(733.594);
+    expect(qwenB300.baseline.read.value).toBeCloseTo(6602.344);
 
     // Kimi: standard-only rows remain visible as explicitly labelled fallbacks.
     const kimi = page.models.find((m) => m.model === Model.Kimi_K2_5)!;
     const kimiMi = headlinePairOf(kimi, 'mi355x-vs-b200')!;
     expect(kimiMi.candidate.precision).toBe(Precision.FP4);
     expect(kimiMi.candidate.read).toMatchObject({
-      value: 1000,
+      value: 8600,
       config: { specMethod: 'none' },
     });
     expect(kimiMi.candidate.missingReason).toBeNull();
     expect(kimiMi.baseline.precision).toBe(Precision.FP4);
     expect(kimiMi.baseline.read).toMatchObject({
-      value: 800,
+      value: 7200,
       config: { specMethod: 'none' },
     });
     const kimiB300 = headlinePairOf(kimi, 'b300-vs-b200')!;
     expect(kimiB300.candidate.precision).toBe(Precision.FP8);
     expect(kimiB300.candidate.read).toMatchObject({
-      value: 900,
+      value: 8460,
       config: { specMethod: 'none' },
     });
     expect(kimiB300.candidate.missingReason).toBeNull();

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -8,10 +8,11 @@ import { getGpuSpecs, getHardwareConfig } from './constants';
 import { DEFAULT_MODELS, getModelLabel, Model, Precision } from './data-mappings';
 import { frameworkFamily } from './framework-family';
 import {
-  computeTcoFeed,
   computeTierReads,
+  singleTurnInteractivity,
   type TcoTierBoundary,
   type TcoTierPoint,
+  type TcoTierRead,
 } from './tco-feed';
 
 export const OVERVIEW_WORKLOAD = { isl: 8192, osl: 1024 } as const;
@@ -35,6 +36,8 @@ export function resolveOverviewTier(raw: string | string[] | undefined): Overvie
 
 export interface OverviewTierValue {
   tier: number;
+  /** Total (input + output) tok/s per DEPLOYED GPU on the frontier at `tier` —
+   *  the overview's cost basis; null when the tier is not comparable. */
   value: number | null;
   boundary: TcoTierBoundary;
   /** True only when the tier value falls between observed frontier knots. */
@@ -92,7 +95,8 @@ export interface OverviewPlatformResult {
   precision: string | null;
   read: OverviewTierRead;
   missingReason: OverviewMissingReason | null;
-  /** $ per million output tokens at the retail-rental $/GPU/hr tier. */
+  /** $ per million TOTAL (input + output) tokens at the hyperscaler $/GPU/hr
+   *  tier (`HW_REGISTRY.costh`). */
   costPerMtok: number | null;
   /** Cost delta vs this row's B200 cell; negative = cheaper. Null on the B200
    *  cell itself and whenever either cost is unavailable. */
@@ -108,7 +112,6 @@ export interface OverviewModelSummary {
 
 export interface OverviewPageData {
   models: OverviewModelSummary[];
-  datasetThroughDate: string | null;
   tier: OverviewTier;
   engineScope: OverviewEngineScope;
 }
@@ -173,15 +176,6 @@ function overviewScenarioRows(
       row.benchmark_type === 'single_turn' &&
       row.isl === OVERVIEW_WORKLOAD.isl &&
       row.osl === OVERVIEW_WORKLOAD.osl,
-  );
-}
-
-/** Deliberately from raw scenario rows, not retained winners: an unranked
- * precision or engine still dates the dataset it was measured in. */
-function latestOverviewDate(rows: readonly BenchmarkRow[]): string | null {
-  return rows.reduce<string | null>(
-    (latest, row) => (latest === null || row.date > latest ? row.date : latest),
-    null,
   );
 }
 
@@ -338,14 +332,24 @@ function missingReasonForPlatform(
     : 'no_exact_at_tier';
 }
 
+/**
+ * The overview's cost contract:
+ *
+ *   $ / 1M total tokens = HW_REGISTRY.costh × 1,000,000
+ *                       ÷ (total tok/s per deployed GPU × 3,600)
+ *
+ * `costh` is the HYPERSCALER $/GPU/hr tier (not neocloud `costn` or retail
+ * `costr`), and the denominator counts TOTAL (input + output) tokens over
+ * every deployed GPU — prefill + decode for disaggregated serving.
+ */
 export function overviewCostPerMtok(
   hardware: string,
-  outputTputPerGpu: number | null,
+  totalTputPerGpu: number | null,
 ): number | null {
-  if (outputTputPerGpu === null || outputTputPerGpu <= 0) return null;
-  const costPerGpuHour = getGpuSpecs(hardware).costr;
+  if (totalTputPerGpu === null || totalTputPerGpu <= 0) return null;
+  const costPerGpuHour = getGpuSpecs(hardware).costh;
   if (costPerGpuHour <= 0) return null;
-  return (costPerGpuHour * 1_000_000) / (outputTputPerGpu * 3600);
+  return (costPerGpuHour * 1_000_000) / (totalTputPerGpu * 3600);
 }
 
 function buildPlatformResults(
@@ -402,23 +406,24 @@ function topologyEvidence(row: BenchmarkRow): string | undefined {
 
 interface OverviewAgenticTierPoint extends TcoTierPoint {
   e2eLatency: number;
-  throughput: number;
 }
 
-function buildAgenticTierReads(rows: readonly BenchmarkRow[]) {
+/** AgentX: the tier axis stays P90 interactivity (the chart's SLA contract);
+ *  the throughput read at the tier is total tok/s per deployed GPU. */
+function buildAgenticTierReads(rows: readonly BenchmarkRow[]): TcoTierRead[] {
   const points = rows.flatMap((row): OverviewAgenticTierPoint[] => {
     const entry = rowToAggDataEntry(row);
     const factor = deployedGpuFactor(row);
     const interactivity = entry.p90_intvty;
     const e2eLatency = entry.p90_e2el;
-    const outputThroughput = entry.output_tput_per_gpu * factor;
+    const totalThroughput = entry.tput_per_gpu * factor;
     if (
       !Number.isFinite(interactivity) ||
       interactivity <= 0 ||
       !Number.isFinite(e2eLatency) ||
       e2eLatency <= 0 ||
-      !Number.isFinite(outputThroughput) ||
-      outputThroughput <= 0
+      !Number.isFinite(totalThroughput) ||
+      totalThroughput <= 0
     ) {
       return [];
     }
@@ -426,14 +431,34 @@ function buildAgenticTierReads(rows: readonly BenchmarkRow[]) {
       {
         interactivity,
         e2eLatency,
-        throughput: outputThroughput,
-        outputThroughput,
+        throughput: totalThroughput,
         date: row.date,
         evidenceLabel: topologyEvidence(row),
       },
     ];
   });
   return computeTierReads(restrictAgenticPointsToE2eFrontier(points), OVERVIEW_TIERS);
+}
+
+/** Single-turn 8K/1K: frontier points at the chart's stored interactivity,
+ *  valued in total (input + output) tok/s per DEPLOYED GPU. Rows without a
+ *  usable total-throughput metric are dropped — the overview cannot price
+ *  them, so they must not shape the frontier either. */
+function buildSingleTurnTierReads(rows: readonly BenchmarkRow[]): TcoTierRead[] {
+  const points = rows.flatMap((row): TcoTierPoint[] => {
+    const interactivity = singleTurnInteractivity(row.metrics);
+    const totalTput = row.metrics.tput_per_gpu;
+    if (interactivity === undefined || !Number.isFinite(totalTput) || totalTput <= 0) return [];
+    return [
+      {
+        interactivity,
+        throughput: totalTput * deployedGpuFactor(row),
+        date: row.date,
+        evidenceLabel: topologyEvidence(row),
+      },
+    ];
+  });
+  return computeTierReads(points, OVERVIEW_TIERS);
 }
 
 function buildConfigResult(
@@ -443,26 +468,7 @@ function buildConfigResult(
   key: string,
   rows: BenchmarkRow[],
 ): OverviewConfigResult | null {
-  const feed =
-    scenario === 'agentx'
-      ? buildAgenticTierReads(rows)
-      : computeTcoFeed(
-          rows.map((row) => {
-            const outputTputPerGpu = row.metrics.output_tput_per_gpu;
-            return {
-              ...row,
-              metrics: {
-                ...row.metrics,
-                output_tput_per_gpu: Number.isFinite(outputTputPerGpu)
-                  ? outputTputPerGpu * deployedGpuFactor(row)
-                  : outputTputPerGpu,
-              },
-              evidence_label: topologyEvidence(row),
-            };
-          }),
-          [OVERVIEW_WORKLOAD],
-          OVERVIEW_TIERS,
-        );
+  const feed = scenario === 'agentx' ? buildAgenticTierReads(rows) : buildSingleTurnTierReads(rows);
   if (feed.length === 0) return null;
 
   const first = rows[0];
@@ -485,9 +491,9 @@ function buildConfigResult(
     sourceRunUrls,
     tierValues: feed.map((row) => {
       const value =
-        row.boundary === 'unreachable' && row.output_tput_per_gpu === 0
+        row.boundary === 'unreachable' && row.throughput_per_gpu === 0
           ? null
-          : row.output_tput_per_gpu;
+          : row.throughput_per_gpu;
       return {
         tier: row.tier,
         value,
@@ -529,12 +535,6 @@ export function assembleOverviewPageData(
   return {
     models: perModel.map(({ model, rows }) =>
       buildOverviewModelSummary(model, rows, tier, engineScope),
-    ),
-    datasetThroughDate: latestOverviewDate(
-      perModel.flatMap(({ model, rows }) => {
-        const scenario = overviewScenarioForModel(model, rows);
-        return overviewScenarioRows(scenario, overviewEngineRows(rows, engineScope));
-      }),
     ),
     tier,
     engineScope,

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -20,7 +20,7 @@ const RUN_URL = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26714
 /** Query the default fixture produces: one source run, so the run is pinned. */
 const PINNED_QUERY =
   'g_model=Qwen-3.5-397B-A17B&g_rundate=2026-07-18&g_runid=26714221123&i_seq=8k%2F1k' +
-  '&i_prec=fp4&i_metric=y_outputTputPerGpu&i_gpus=b200_sglang_mtp&i_spec=mtp&i_disagg=single-node' +
+  '&i_prec=fp4&i_metric=y_costh&i_gpus=b200_sglang_mtp&i_spec=mtp&i_disagg=single-node' +
   '&i_optimal=1&i_advlabel=1';
 
 function config(overrides: Partial<OverviewConfigResult> = {}): OverviewConfigResult {
@@ -78,7 +78,7 @@ describe('buildOverviewDashboardHref', () => {
 
     expect(href).toBe(
       '/inference?g_model=Qwen-3.5-397B-A17B&g_rundate=2026-07-18&g_runid=26714221123' +
-        '&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_outputTputPerGpu' +
+        '&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_costh' +
         '&i_gpus=gb200_dynamo-trt-disagg_mtp&i_spec=mtp&i_disagg=disagg' +
         '&i_optimal=1&i_advlabel=1',
     );

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -137,13 +137,13 @@ describe('buildOverviewDashboardHref', () => {
 describe('detailHref', () => {
   it('keeps the model drilldown precision-neutral because headline pairs may differ', () => {
     expect(detailHref('en', summary())).toBe(
-      '/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k%2F1k&i_optimal=1',
+      '/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k%2F1k&i_metric=y_costh&i_optimal=1',
     );
   });
 
   it('opens AgentX rows in the Agentic Traces dashboard scenario', () => {
     expect(detailHref('en', summary({ model: Model.GLM_5_2, scenario: 'agentx' }))).toBe(
-      '/inference?g_model=GLM-5.2&i_seq=agentic-traces&i_optimal=1',
+      '/inference?g_model=GLM-5.2&i_seq=agentic-traces&i_metric=y_costh&i_optimal=1',
     );
   });
 });

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -60,7 +60,7 @@ export function buildOverviewDashboardHref(
     g_runid: soleSourceRun(config)?.id,
     i_seq: overviewSequence(model),
     i_prec: config.precision,
-    i_metric: 'y_outputTputPerGpu',
+    i_metric: 'y_costh',
     i_gpus: config.hwKey,
     i_spec: dashboardSpecMode(config.specMethod),
     i_disagg: config.disagg ? 'disagg' : config.isMultinode ? 'multi-node' : 'single-node',

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -83,6 +83,7 @@ export function detailHref(locale: 'en' | 'zh', model: OverviewModelSummary): st
   const query = new URLSearchParams({
     g_model: model.model,
     i_seq: overviewSequence(model),
+    i_metric: 'y_costh',
     i_optimal: '1',
   });
   return `${inferenceRoute(locale)}?${query}`;

--- a/packages/app/src/lib/tco-feed.test.ts
+++ b/packages/app/src/lib/tco-feed.test.ts
@@ -12,6 +12,7 @@ import {
   parseTierWeights,
   parseWorkloads,
   parseWorkloadWeights,
+  singleTurnInteractivity,
   tcoFeedToCsv,
   tcoScoresToCsv,
   type TcoFeedRow,
@@ -261,6 +262,23 @@ describe('computeTcoFeed — frontier reads', () => {
 
   it('returns an empty feed for empty input', () => {
     expect(computeTcoFeed([], WORKLOAD_8K1K, [50])).toEqual([]);
+  });
+});
+
+describe('singleTurnInteractivity', () => {
+  it('prefers the stored median_intvty over the 1/median_itl fallback', () => {
+    expect(singleTurnInteractivity({ median_intvty: 42, median_itl: 0.02 })).toBe(42);
+  });
+
+  it('falls back to 1/median_itl for legacy rows that predate the intvty key', () => {
+    expect(singleTurnInteractivity({ median_itl: 0.02 })).toBe(50);
+  });
+
+  it('returns undefined when neither metric is usable', () => {
+    expect(singleTurnInteractivity({})).toBeUndefined();
+    expect(singleTurnInteractivity({ median_intvty: 0, median_itl: 0 })).toBeUndefined();
+    expect(singleTurnInteractivity({ median_intvty: -5, median_itl: -1 })).toBeUndefined();
+    expect(singleTurnInteractivity({ median_intvty: Number.NaN })).toBeUndefined();
   });
 });
 

--- a/packages/app/src/lib/tco-feed.ts
+++ b/packages/app/src/lib/tco-feed.ts
@@ -83,12 +83,18 @@ export interface TcoFeedRow {
 
 export interface TcoTierPoint {
   interactivity: number;
-  outputThroughput: number;
+  /** Serving throughput (tok/s per GPU) in the CALLER-CHOSEN metric: the
+   *  external feed reads output tokens, the Overview total (input + output)
+   *  tokens per deployed GPU. The frontier math is metric-agnostic. */
+  throughput: number;
   date: string;
   evidenceLabel?: string;
 }
 
-export type TcoTierRead = Omit<TcoFeedRow, 'hardware' | 'workload'>;
+export type TcoTierRead = Omit<TcoFeedRow, 'hardware' | 'workload' | 'output_tput_per_gpu'> & {
+  /** Frontier read at `tier` in the caller's throughput metric; 0 when unreachable. */
+  throughput_per_gpu: number;
+};
 
 export const DEFAULT_TIERS: readonly number[] = [30, 50, 75, 100];
 export const DEFAULT_WORKLOADS: readonly TcoFeedWorkload[] = [
@@ -245,7 +251,8 @@ function bracketKnots(frontier: TcoTierPoint[], tier: number): [TcoTierPoint, Tc
   return [frontier[lo], frontier[lo + 1]];
 }
 
-/** Read fixed service tiers from an output-throughput serving frontier. */
+/** Read fixed service tiers from a serving-throughput frontier (the
+ *  throughput metric is whatever the caller put in `TcoTierPoint.throughput`). */
 export function computeTierReads(
   points: readonly TcoTierPoint[],
   tiers: readonly number[],
@@ -253,12 +260,12 @@ export function computeTierReads(
   const frontier = paretoFrontUpperLeft(
     [...points],
     (point) => point.interactivity,
-    (point) => point.outputThroughput,
+    (point) => point.throughput,
   ).toSorted((a, b) => a.interactivity - b.interactivity);
   if (frontier.length === 0) return [];
 
   const xs = frontier.map((point) => point.interactivity);
-  const ys = frontier.map((point) => point.outputThroughput);
+  const ys = frontier.map((point) => point.throughput);
   const slopes = monotoneSlopes(xs, ys);
   const minIv = xs[0];
   const maxIv = xs.at(-1)!;
@@ -297,7 +304,7 @@ export function computeTierReads(
     }
     return {
       tier,
-      output_tput_per_gpu: round3(value),
+      throughput_per_gpu: round3(value),
       boundary,
       is_interpolated: isInterpolated,
       frontier_points: frontier.length,
@@ -309,6 +316,20 @@ export function computeTierReads(
       ...(tierEvidenceLabels === undefined ? {} : { evidence_labels: tierEvidenceLabels }),
     };
   });
+}
+
+/**
+ * Chart parity: for single_turn rows the inference chart plots the STORED
+ * median_intvty on the x-axis (the ingest mapper's 1/itl invariant only
+ * rewrites agentic rows), so prefer the stored value and fall back to
+ * 1/median_itl only for legacy rows/fixtures that predate the intvty key.
+ * Shared by the feed and the Overview so both read the same x-axis.
+ */
+export function singleTurnInteractivity(metrics: Record<string, number>): number | undefined {
+  const storedIv = metrics.median_intvty;
+  if (Number.isFinite(storedIv) && storedIv > 0) return storedIv;
+  const itl = metrics.median_itl;
+  return Number.isFinite(itl) && itl > 0 ? 1 / itl : undefined;
 }
 
 /**
@@ -331,25 +352,13 @@ export function computeTcoFeed(
       // match below excludes anyway).
       if ((row.benchmark_type ?? 'single_turn') !== 'single_turn') continue;
       if (row.isl !== workload.isl || row.osl !== workload.osl) continue;
-      // Chart parity: for single_turn rows the inference chart plots the
-      // STORED median_intvty on the x-axis (the ingest mapper's 1/itl
-      // invariant only rewrites agentic rows), so prefer the stored value
-      // and fall back to 1/median_itl only for legacy rows/fixtures that
-      // predate the intvty key.
-      const storedIv = row.metrics.median_intvty;
-      const itl = row.metrics.median_itl;
-      const interactivity =
-        Number.isFinite(storedIv) && storedIv > 0
-          ? storedIv
-          : Number.isFinite(itl) && itl > 0
-            ? 1 / itl
-            : undefined;
+      const interactivity = singleTurnInteractivity(row.metrics);
       const otput = row.metrics.output_tput_per_gpu;
       if (interactivity === undefined) continue;
       if (!Number.isFinite(otput) || otput <= 0) continue;
       const point = {
         interactivity,
-        outputThroughput: otput,
+        throughput: otput,
         date: row.date,
         evidenceLabel: row.evidence_label,
       };
@@ -362,10 +371,13 @@ export function computeTcoFeed(
     const hardwareKeys = [...byHardware.keys()].toSorted((a, b) => a.localeCompare(b));
     for (const hardware of hardwareKeys) {
       for (const read of computeTierReads(byHardware.get(hardware)!, tiers)) {
+        // The feed's contract names the metric it serves: output tokens.
+        const { throughput_per_gpu: outputTputPerGpu, ...rest } = read;
         out.push({
           hardware,
           workload: workloadKey,
-          ...read,
+          output_tput_per_gpu: outputTputPerGpu,
+          ...rest,
         });
       }
     }


### PR DESCRIPTION
## What changed

- **Cost semantics** (the core of Task 8.8 — display copy and the real computation switch together): `cost / 1M total tokens = HW_REGISTRY.costh × 1,000,000 ÷ (total tok/s per deployed GPU × 3,600)`.
  - `costr` (retail) → `costh` (hyperscaler) in `overviewCostPerMtok`, with the contract documented on the function.
  - Tier reads are now valued in `tput_per_gpu` (input + output total tokens) instead of `output_tput_per_gpu`, so config selection, interpolation, and pricing all use the same total-token basis.
  - Disaggregated runs keep prefill + decode GPUs in the denominator (`deployedGpuFactor` unchanged, applied to totals).
  - AgentX still selects the serving tier by P90 interactivity; only the priced throughput switched to total tokens (incl. the E2E-frontier restriction).
- **Three cell states**: no result → `—`; result + B200 baseline → cost + `% vs B200`; result without B200 baseline → cost + neutral gray `∞` relative badge (availability, not a good/bad judgment — no red/green).
- **Dates removed, evidence kept**: no visible dates or `Database snapshot through …` line. The cost number itself is now the evidence link into the corresponding filtered dashboard; hover/focus/screen-reader labels keep the run date + stack for reproducibility.
- **Header hierarchy**: desktop first row is `Inference Cost Overview` + `Hyperscaler cost / 1M total tokens · ↓ lower is better` (larger, heavier metric label, right-aligned); phones/tablets stack it under the title. The tier is not repeated in the metric line — the Service level selector states it.
- **Methodology**: `Cost = hyperscaler $/GPU/hr ÷ total tok/s per deployed GPU. Percentages compare against B200.` and `— = no result. ∞ = B200 baseline unavailable.` (zh mirrors updated).
- **Dead code**: `datasetThroughDate`, `latestOverviewDate()`, the snapshot formatter, and the visible-date layout slot are deleted.
- Supporting refactor: `computeTierReads` kernel in `tco-feed.ts` is now metric-neutral (`TcoTierPoint.throughput`, `TcoTierRead.throughput_per_gpu`); the external `/api/v1/tco-feed` contract still emits `output_tput_per_gpu` unchanged. `singleTurnInteractivity` is extracted so the feed and the overview share one chart-parity x-axis rule.
- Cost renders with 3 decimals: at hyperscaler $/GPU/hr over total tokens, real platforms land in the $0.0x band that 2 decimals would collapse.

## Why

Overview previously labeled and computed cost as retail $/GPU/hr over output tokens. Per review feedback the intended metric is hyperscaler cost over total (input + output) tokens per deployed GPU — this PR moves both the math and every piece of copy to that contract, and cleans up the `∞`/date noise flagged in the same review.

## Validation

- `bun run typecheck`, `bun run lint`, `bun run fmt` — pass.
- `bun run test:unit` — pass (158 files / 2992 tests in app + all other workspaces).
  - New tests prove `costh` (not `costr`) is priced, use fixtures with `tput_per_gpu !== output_tput_per_gpu` (constant decoy outputs) so an output-token regression fails, cover ranking by total when output ranking disagrees, the AgentX P90 + total-cost contract, and the `— / finite % / ∞` state triplet.
  - Fixture drift-guard expectations are engine-derived (assembler run over the updated `overview-rows.json`).
- `E2E_FIXTURES=1 bun run build` — pass.

## Overlay support

N/A — Overview is a server-rendered summary page, not an inference/evaluation chart feature; it has no `?unofficialrun=` overlay path.

## 中文说明

- **成本口径**：`成本 / 每百万总 token = HW_REGISTRY.costh × 1,000,000 ÷ (每张已部署 GPU 的总 tok/s × 3,600)`；`costr`（零售）→ `costh`（超大规模云）；吞吐从 `output_tput_per_gpu` 切换为 `tput_per_gpu`（输入 + 输出总 token），配置选择、插值与定价统一使用总 token 口径；分离式（disaggregated）运行继续把 prefill + decode GPU 全部计入分母；AgentX 仍按 P90 interactivity 选择服务档位，仅计价吞吐改为总 token。
- **单元格三态**：无结果 → `—`；有结果且有 B200 基线 → 成本 + 相对 B200 百分比；有结果但缺 B200 基线 → 成本 + 中性灰 `∞` 徽标（表示可用性，不是好坏判断，故不用红绿）。
- **删除日期、保留证据入口**：页面不再显示任何日期与「数据库快照」行；成本数字本身成为进入对应筛选仪表板的证据链接，hover / 焦点 / 读屏标签保留运行日期与配置栈，保证可复现性。
- **页头层级**：桌面端第一行为标题 + 「超大规模云（hyperscaler）成本 / 每百万总 token · ↓ 越低越好」（加大加粗、右对齐）；手机与平板自动堆叠；metric 行不再重复档位（下方服务档位选择器已表达）。
- **Methodology** 更新为成本公式 + 百分比说明 + `— / ∞` 图例；中英文同步。
- **清理**：删除 `datasetThroughDate`、`latestOverviewDate()`、快照格式化与可见日期布局槽；`computeTierReads` 内核改为指标中立（外部 `/api/v1/tco-feed` 契约不变）；成本改为 3 位小数。


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core overview pricing and displayed dollar values change (cost tier + throughput basis), which affects user-facing comparisons; risk is mitigated by extensive unit and Cypress coverage and an unchanged external TCO feed API shape.
> 
> **Overview**
> Overview **redefines inference cost** end-to-end: pricing uses **hyperscaler `costh`** and **`tput_per_gpu` (total tokens per deployed GPU)** instead of retail `costr` and output throughput. Tier selection, interpolation, AgentX reads, and B200 deltas all follow that basis; costs show **three decimals**.
> 
> **UI and copy** move to hyperscaler “$/1M total tokens,” drop the database snapshot and visible dates, and use a clearer header (title + metric on one row at xl). Cells are **`—` (no result)**, **cost + % vs B200**, or **cost + neutral gray `∞` (no B200 baseline)**; the **cost value is the dashboard evidence link** (dates stay in title/aria). Missing cells no longer use `∞`; **`≈` estimates are removed** from visible text.
> 
> Supporting changes: **`datasetThroughDate` removed**; `computeTierReads` is metric-neutral while the TCO feed API still exposes `output_tput_per_gpu`; overview/detail links default to **`i_metric=y_costh`**. Cypress fixtures gain `tput_per_gpu`; unit/e2e expectations are updated for the new numbers and semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80cfc4855d0b77651a253f33fd9f5d478829512e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->