### PR TITLE
fix(overview): stop the service-level switcher overflowing on phones / 修复总览页服务档位切换器在手机端溢出

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -708,6 +708,40 @@ describe('Overview page', () => {
       expectNoHorizontalOverflow();
       expectNoHorizontalScroller('overview-mobile-list');
       expectNoHorizontalScroller('overview-engine-scope-switcher');
+      // Six tiers must fit the phone: the group is overflow-hidden, so any
+      // overflow silently clips the last option instead of scrolling to it.
+      expectNoHorizontalScroller('overview-tier-switcher');
+    }
+  });
+
+  it('keeps every service level reachable on the narrowest phones', () => {
+    // 320 is the floor; 360/375/414 are the common Android and iPhone widths.
+    for (const width of [320, 360, 375, 414]) {
+      cy.viewport(width, 844);
+      cy.visit('/overview');
+
+      expectNoHorizontalOverflow();
+      expectNoHorizontalScroller('overview-tier-switcher');
+      cy.get('[data-testid="overview-tier-switcher"]').within(() => {
+        // Every tier is rendered, inside the switcher's box, and tappable.
+        cy.get('a, [aria-current="page"]')
+          .filter((_, el) => /^\d+$/.test(el.textContent?.trim() ?? ''))
+          .should('have.length', 6);
+      });
+      cy.get('[data-testid="overview-tier-switcher"]').then(([nav]) => {
+        const navRect = nav.getBoundingClientRect();
+        cy.get('[data-testid="overview-tier-switcher"]')
+          .find('a, [aria-current="page"]')
+          .filter((_, el) => /^\d+$/.test(el.textContent?.trim() ?? ''))
+          .each(($option) => {
+            const rect = $option[0].getBoundingClientRect();
+            expect(
+              rect.right,
+              `tier ${$option.text()} inside the switcher at ${width}px`,
+            ).to.be.at.most(navRect.right + 1);
+            expect(rect.height, `tier ${$option.text()} stays tappable`).to.be.at.least(44);
+          });
+      });
     }
   });
 

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -612,7 +612,10 @@ export function OverviewTierSwitcher({
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
-  const optionClass = 'inline-flex min-h-11 items-center px-3 tabular-nums';
+  // Six tiers no longer fit one 320px row at px-3: the group clipped its last
+  // option. Tighter padding on phones, and wrapping as the safety net for
+  // larger system fonts — never a clipped or horizontally scrolling control.
+  const optionClass = 'inline-flex min-h-11 items-center px-2 tabular-nums sm:px-3';
   return (
     <nav
       data-testid="overview-tier-switcher"
@@ -620,7 +623,7 @@ export function OverviewTierSwitcher({
       className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
     >
       <span className="text-muted-foreground">{strings.tierNavLabel}</span>
-      <div className="flex divide-x divide-border/60 overflow-hidden rounded-md border border-border/60">
+      <div className="flex flex-wrap divide-x divide-border/60 overflow-hidden rounded-md border border-border/60">
         {OVERVIEW_TIERS.map((option) =>
           option === tier ? (
             <span


### PR DESCRIPTION
## Summary

`/overview` overflows horizontally on phones. The cause is the service-level switcher: with six tiers (30/50/75/100/150/200, added in #654) the option group no longer fits one row at `px-3`.

Measured on a 320px viewport, before this PR:

```
tier option group: scrollWidth 256  clientWidth 252
```

The group is `overflow-hidden`, so the overflow does not scroll — the last tier is silently **clipped and unreachable**. On devices whose system font is larger than the default, the same group is wide enough to push the page itself into horizontal scrolling.

## Fix

- Option padding is `px-2` on phones, `px-3` from `sm` up. At 320px the group now measures **208px in a 208px box**.
- The group is `flex-wrap`, so on a device with a larger font it wraps to a second row rather than clipping or scrolling. Tap targets keep their 44px minimum height (`min-h-11`).

No behavior or copy changes — the same six tiers, the same links.

## Why the tests missed it

`uses the same cell semantics on mobile...` already asserted no horizontal scroller inside `overview-mobile-list` and `overview-engine-scope-switcher`, but never inside `overview-tier-switcher`, so a clipped control passed. Two additions:

- that test now also runs `expectNoHorizontalScroller('overview-tier-switcher')`;
- a new spec, `keeps every service level reachable on the narrowest phones`, walks 320 / 360 / 375 / 414 and asserts the page has no horizontal overflow, the switcher has no internal scroller, and all six tiers render inside the switcher's box at a tappable height.

Both assertions fail against the pre-fix markup (256 > 252 at 320px) and pass after it.

## Testing

- `overview.cy.ts` against a local `E2E_FIXTURES=1` production build — **18/18 passing** in Chrome
- `bun run test:unit` — pass (436 tests); `typecheck`, `lint`, `fmt` — pass
- `zh-pages.cy.ts`, `navigation.cy.ts` — pass. The Chinese sibling uses the same component, so it is fixed by the same change.

## 中文说明

`/overview` 在手机端出现横向滚动，根因是服务档位切换器：#654 新增至六个档位（30/50/75/100/150/200）后，选项组在 `px-3` 下已无法排入一行。

在 320px 视口下实测（修复前）：选项组内容宽度 256px，容器宽度 252px。由于该组为 `overflow-hidden`，超出部分不会滚动，而是把最后一个档位**直接裁掉且无法点击**；在系统字体较大的设备上，该组还会把页面整体撑出横向滚动。

**修复**：手机端选项内边距改为 `px-2`，`sm` 及以上恢复 `px-3`，320px 下选项组变为 208px（容器同为 208px）；同时该组改为 `flex-wrap`，字体更大时换行而非裁剪或滚动，点按区域仍保持 44px 最小高度（`min-h-11`）。档位数量与链接行为均未改变。

**测试为何遗漏**：原有移动端用例只检查了 `overview-mobile-list` 与 `overview-engine-scope-switcher` 内部是否存在横向滚动，未覆盖 `overview-tier-switcher`，因此被裁剪的控件仍能通过。现补充两处：该用例增加对档位切换器的检查；新增用例「keeps every service level reachable on the narrowest phones」在 320 / 360 / 375 / 414 四种宽度下断言页面无横向溢出、切换器内部无滚动，且六个档位均渲染在切换器边界内并保持可点按高度。两处断言在修复前均会失败（320px 下 256 > 252），修复后通过。

**测试结果**：本地 `E2E_FIXTURES=1` 生产构建下 `overview.cy.ts` 18/18 通过；`bun run test:unit`（436 项）、`typecheck`、`lint`、`fmt` 全部通过；`zh-pages.cy.ts`、`navigation.cy.ts` 通过。中文页面复用同一组件，同一改动一并修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Responsive CSS and E2E assertions only; no routing, data, or tier behavior changes.
> 
> **Overview**
> Fixes **horizontal overflow and clipped tier options** on `/overview` when six service levels no longer fit one row at default padding.
> 
> **`OverviewTierSwitcher`** uses **`px-2` on phones** (`sm:px-3` on larger breakpoints) and **`flex-wrap`** on the bordered option group so tiers wrap instead of being cut off by `overflow-hidden`. Tap targets stay at **`min-h-11`**.
> 
> **Cypress** now asserts no horizontal scroller inside **`overview-tier-switcher`** in the existing mobile semantics test, and adds **`keeps every service level reachable on the narrowest phones`** (320–414px): no page overflow, all six tiers in bounds, and ≥44px height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6b445893b9fd8f9dddc49b449679e09988403d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->