### PR TITLE
chore(overview): label the tier control SLO and enlarge the column headers / 档位控件标签改为 SLO 并放大列表头字号

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -387,6 +387,10 @@ describe('Overview page', () => {
           expect([...$headers].map((header) => header.textContent?.trim())).to.deep.equal(
             PLATFORM_HEADERS,
           );
+          // Column headers read at 14px, a step up from the 12px metadata.
+          for (const header of $headers) {
+            expect(getComputedStyle(header).fontSize).to.equal('14px');
+          }
         });
         // One row per curated (model, scenario) pair: six models, three of
         // which (DeepSeek, MiniMax, Qwen) carry a second AgentX row.

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -600,6 +600,11 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
+    // The tier control is labelled SLO, not "Service level".
+    cy.get('[data-testid="overview-tier-switcher"]')
+      .should('have.attr', 'aria-label', 'SLO')
+      .and('contain.text', 'SLO');
+    cy.get('body').should('not.contain.text', 'Service level');
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.get('[aria-current="page"]').should('have.text', '50');
       // 30 / 75 / 100 / 150 / 200 link out; the active 50 is inert text.
@@ -955,6 +960,10 @@ describe('Overview page', () => {
 
     cy.visit('/zh/overview?tier=100');
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
+    cy.get('[data-testid="overview-tier-switcher"]')
+      .should('have.attr', 'aria-label', 'SLO')
+      .and('contain.text', 'SLO');
+    cy.get('body').should('not.contain.text', '服务档位');
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.contains('a', '50').should('have.attr', 'href', '/zh/overview');
     });

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -478,7 +478,7 @@ export function DesktopOverviewMatrix({ models, locale, formatters, strings }: S
             sticky top-0, z-50), and z-10 keeps this under it. Opaque, or the
             scrolled rows show through. */}
         <thead className="sticky top-14 z-10 bg-card">
-          <tr className="border-b border-border/50 text-xs uppercase tracking-wider text-muted-foreground">
+          <tr className="border-b border-border/50 text-sm uppercase tracking-wider text-muted-foreground">
             <th scope="col" className="bg-card px-4 py-2 text-left font-semibold lg:px-6">
               {strings.modelHeader}
             </th>

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -19,15 +19,15 @@ export type OverviewLocale = 'en' | 'zh';
 export const OVERVIEW_STRINGS = {
   en: {
     title: 'Inference Cost per Million Tokens',
-    // The active tier is not repeated here — the Service level selector below
-    // already states it.
+    // The active tier is not repeated here — the SLO selector below already
+    // states it.
     scopeMetric: 'Hyperscaler cost',
     scopeDirection: '↓ Lower is better',
     // The unit is dropped from the visible line but kept for screen readers.
     scopeAria: 'Hyperscaler cost per one million total tokens. Lower is better.',
     sourcePrefix: 'Source: InferenceX & ',
     sourceLinkText: 'SemiAnalysis Market August 2025 AI Cloud TCO Model',
-    tierNavLabel: 'Service level',
+    tierNavLabel: 'SLO',
     tierUnit: 'tok/s/user',
     engineScopeNavLabel: 'Engine scope',
     engineScopeOptions: {
@@ -74,7 +74,7 @@ export const OVERVIEW_STRINGS = {
     scopeAria: '超大规模云（hyperscaler）每百万总 token 成本，越低越好。',
     sourcePrefix: '来源：InferenceX 与 ',
     sourceLinkText: 'SemiAnalysis Market August 2025 AI Cloud TCO Model',
-    tierNavLabel: '服务档位',
+    tierNavLabel: 'SLO',
     tierUnit: 'tok/s/用户',
     engineScopeNavLabel: '引擎范围',
     engineScopeOptions: {


### PR DESCRIPTION
## Summary

Two small `/overview` presentation changes, branched from `master`.

**1. The tier control is labelled `SLO`** (was `Service level`). The nav's `aria-label` follows the visible text. Tier values, links and behavior are unchanged.

The Chinese page uses `SLO` as well. It is the standard acronym in Chinese serving-infrastructure writing, and the translated phrase (服务等级目标) would be roughly three times as wide in a control that already has to fit six tiers on a 320px phone. Flagging it as a judgment call in case you'd rather carry the Chinese term.

**2. The matrix column headers move from 12px to 14px** — `Model · Scenario`, `B200 · Reference`, `MI355X`, `B300`, `GB200 NVL72`, `GB300 NVL72`. They were the same size as the per-cell configuration metadata they label; at 14px the row reads as a header again. The matrix still fits without clipping or horizontal scroll at 1280 and 1440.

## Testing

- `overview.cy.ts` against a local `E2E_FIXTURES=1` production build — **17/17 passing** in Chrome, with new assertions that the tier nav is labelled `SLO` in both locales (and that neither page still says "Service level" / 服务档位), and that every column header computes to 14px
- `bun run test:unit` — pass (436 tests); `typecheck`, `lint`, `fmt` — pass
- The existing desktop-fit spec still passes at 1280 and 1440, so the larger headers introduce no clipping

## 中文说明

两处 `/overview` 展示层改动，基于 `master` 分支。

**1. 档位控件标签改为 `SLO`**（原为 `Service level`），导航的 `aria-label` 与可见文本保持一致；档位数值、链接与行为均未改变。

中文页面同样使用 `SLO`：该缩写在中文服务基础设施文档中已是标准写法，而完整译名「服务等级目标」宽度约为其三倍——该控件在 320px 手机上还需容纳六个档位。此处为主观取舍，如更倾向使用中文译名请告知。

**2. 矩阵列表头字号由 12px 提升至 14px**——`Model · Scenario`、`B200 · Reference`、`MI355X`、`B300`、`GB200 NVL72`、`GB300 NVL72`。此前表头与其所标注的单元格配置信息同号，调整后恢复表头的层级感；矩阵在 1280 与 1440 宽度下仍不会裁剪或产生横向滚动。

**测试**：本地 `E2E_FIXTURES=1` 生产构建下 `overview.cy.ts` 17/17 通过，新增断言校验中英文页面的档位导航标签均为 `SLO`（且不再出现「Service level」/「服务档位」），以及所有列表头计算字号为 14px；`bun run test:unit`（436 项）、`typecheck`、`lint`、`fmt` 全部通过；桌面端适配用例在 1280 与 1440 下依旧通过，字号提升未造成裁剪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only copy and typography on the overview page; no data, routing, or pricing logic changes.
> 
> **Overview**
> Renames the `/overview` tier switcher label from **Service level** / **服务档位** to **`SLO`** in English and Chinese (`tierNavLabel` and matching `aria-label` on `overview-tier-switcher`). Tier values, links, and behavior are unchanged.
> 
> Bumps desktop matrix column header typography from **`text-xs` (12px)** to **`text-sm` (14px)** so platform headers read clearly above cell metadata.
> 
> Cypress **`overview.cy.ts`** now asserts **`SLO`** labeling on EN/ZH pages (and absence of the old strings) and that every `thead th` computes to **14px**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d5525dec7bbe36a5b6ed653a9f575a79d657d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->