### PR TITLE
Keep overflow labels within chart bounds / 确保越界标签不被图表边界截断

### DIFF
--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -89,7 +89,10 @@ import {
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchesQuickFilters } from '@/components/inference/utils/quickFilters';
 import { changelogConfigToHwKey } from '@/components/inference/utils/changelogFormatters';
-import { buildFrontierContinuations } from '@/components/inference/utils/overflowContinuations';
+import {
+  buildFrontierContinuations,
+  fitContinuationLabelBaseline,
+} from '@/components/inference/utils/overflowContinuations';
 
 // Greedy label-collision avoidance.
 // Each candidate is the y-position of the FIRST baseline (relative to point
@@ -2756,7 +2759,7 @@ const ScatterGraph = React.memo(
             .attr('display', null)
             .attr('data-testid', 'overflow-continuation-label')
             .attr('x', geometry.x2 + (labelToRight ? 12 : -12))
-            .attr('y', Math.max(12, geometry.y2 + 18))
+            .attr('y', fitContinuationLabelBaseline(geometry.y2, ctx.height))
             .attr('text-anchor', labelToRight ? 'start' : 'end')
             .attr('fill', color)
             .attr('stroke', ir.getCssColor('--background'))

--- a/packages/app/src/components/inference/utils/overflowContinuations.test.ts
+++ b/packages/app/src/components/inference/utils/overflowContinuations.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { ClippedInferenceData, InferenceData } from '../types';
-import { buildFrontierContinuations } from './overflowContinuations';
+import { buildFrontierContinuations, fitContinuationLabelBaseline } from './overflowContinuations';
 
 const point = (x: number, y: number): InferenceData =>
   ({
@@ -21,6 +21,13 @@ const point = (x: number, y: number): InferenceData =>
     costni: { y, roof: false },
     costri: { y, roof: false },
   }) as InferenceData;
+
+describe('fitContinuationLabelBaseline', () => {
+  it('keeps labels inside the plot while preferring below-arrow placement', () => {
+    expect(fitContinuationLabelBaseline(413.4, 500)).toBe(431.4);
+    expect(fitContinuationLabelBaseline(500.13, 500)).toBe(488.13);
+  });
+});
 
 describe('buildFrontierContinuations', () => {
   it('returns both crossings when one visible point sits between two clipped frontier regions', () => {

--- a/packages/app/src/components/inference/utils/overflowContinuations.ts
+++ b/packages/app/src/components/inference/utils/overflowContinuations.ts
@@ -10,6 +10,12 @@ export interface FrontierContinuation {
   reasons: ClippedInferenceData['reasons'];
   hiddenPointCount: number;
 }
+export function fitContinuationLabelBaseline(endpointY: number, height: number): number {
+  const below = endpointY + 18;
+  return below <= height - 4
+    ? Math.max(12, below)
+    : Math.max(12, Math.min(height - 4, endpointY - 12));
+}
 
 /**
  * Find transitions where a complete Pareto frontier crosses from a visible


### PR DESCRIPTION
## Summary
- Keep overflow labels below their arrow when space permits.
- Move labels above arrows near the plot bottom so the chart clip path cannot truncate them.
- Add regression coverage for both placement cases.

## Verification
- `bun --env-file=../../.env vitest run src/components/inference/utils/overflowContinuations.test.ts`
- `bunx cypress run --spec cypress/e2e/chart-overflow-continuation.cy.ts`
- `bun run typecheck`
- Manually verified the Kimi-K2.5 TTFT chart from the reported URL.

## 中文说明
- 空间充足时，越界标签继续显示在箭头下方。
- 当箭头接近图表底部时，将标签移到箭头上方，避免被图表裁剪路径截断。
- 为两种标签位置补充回归测试。

## 验证
- `bun --env-file=../../.env vitest run src/components/inference/utils/overflowContinuations.test.ts`
- `bunx cypress run --spec cypress/e2e/chart-overflow-continuation.cy.ts`
- `bun run typecheck`
- 已使用问题报告中的 Kimi-K2.5 TTFT 图表完成手动验证。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart label layout only; no API, auth, or data-path changes, with focused unit tests.
> 
> **Overview**
> **Overflow continuation labels** on inference scatter charts no longer get clipped at the bottom edge.
> 
> Label vertical position now goes through **`fitContinuationLabelBaseline`**: labels stay **18px below** the arrow when there is room (`endpointY + 18` within `height - 4`), and flip **above** the arrow (`endpointY - 12`, still respecting top/bottom padding) when the arrow sits near the plot bottom. **`ScatterGraph`** uses this instead of a fixed below-arrow offset.
> 
> **Regression tests** cover both below-arrow and above-arrow cases in `overflowContinuations.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f90c2140c287ca45620c3a750f778d8c8d4a0ef0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->