### PR TITLE
Fix inference CSV latency units and overlay export / 修复推理 CSV 延迟单位与叠加数据导出

### DIFF
--- a/packages/app/cypress/e2e/csv-export-overlay.cy.ts
+++ b/packages/app/cypress/e2e/csv-export-overlay.cy.ts
@@ -1,0 +1,72 @@
+import { unlockAgenticGate } from '../support/e2e';
+import {
+  interceptOverlayRun,
+  OVERLAY_RUN_BRANCH,
+  OVERLAY_RUN_ID,
+  OVERLAY_RUN_URL,
+} from '../support/overlay-fixtures';
+
+type CsvCaptureWindow = Cypress.AUTWindow & {
+  __capturedCsvBlob?: Blob;
+};
+
+function captureCsvDownloads(win: Cypress.AUTWindow): void {
+  const captureWindow = win as CsvCaptureWindow;
+  win.URL.createObjectURL = (object: Blob | MediaSource) => {
+    if (object instanceof win.Blob) captureWindow.__capturedCsvBlob = object;
+    return 'blob:csv-export-test';
+  };
+  win.HTMLAnchorElement.prototype.click = () => {};
+}
+
+function exportFirstChart(): void {
+  cy.get('[data-testid="export-button"]').first().click();
+  cy.get('[data-testid="export-csv-button"]').click();
+}
+
+function readCapturedCsv(): Cypress.Chainable<string> {
+  return cy.window().then((win) => {
+    const blob = (win as CsvCaptureWindow).__capturedCsvBlob;
+    expect(blob, 'captured CSV Blob').to.be.instanceOf(win.Blob);
+    return blob!.text();
+  });
+}
+
+describe('Inference CSV export with an unofficial-run overlay', () => {
+  before(() => {
+    interceptOverlayRun();
+    cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces&i_pctl=p90`, {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        unlockAgenticGate(win);
+        captureCsvDownloads(win);
+      },
+    });
+    cy.wait('@unofficialRun');
+    cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should('exist');
+  });
+
+  it('exports second-based latency headers and only currently visible overlay rows', () => {
+    exportFirstChart();
+    readCapturedCsv().then((csv) => {
+      expect(csv).to.include('Mean TTFT (s)');
+      expect(csv).to.include('Mean TPOT (s)');
+      expect(csv).to.not.include('Mean TTFT (ms)');
+      expect(csv).to.include('Run URL');
+      expect(csv).to.include(OVERLAY_RUN_URL);
+    });
+
+    cy.get(`[aria-label="Dismiss ${OVERLAY_RUN_BRANCH}"]`).click();
+    cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(
+      'not.exist',
+    );
+    cy.window().then((win) => {
+      delete (win as CsvCaptureWindow).__capturedCsvBlob;
+    });
+
+    exportFirstChart();
+    readCapturedCsv().then((csv) => {
+      expect(csv).to.not.include(OVERLAY_RUN_URL);
+    });
+  });
+});

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -80,6 +80,8 @@ export interface WorkerPower {
  * @property {number} p99_e2el - 99th percentile of End-to-End Latency.
  */
 export interface AggDataEntry {
+  /** Metric keys present in the source row before missing values are normalized to zero. */
+  rawMetricKeys?: string[];
   /** Stable per-point id from benchmark_results — for trace_replay lookups. */
   id?: number;
   hw: string;

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -621,6 +621,7 @@ export default function ChartDisplay() {
                       visibleData,
                       graph.model,
                       graph.sequence,
+                      visibleOverlayRowsForExport,
                     );
                     // Match warnings against the same series the chart annotates,
                     // including visible unofficial-run overlay series.

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -89,12 +89,14 @@ describe('rowToAggDataEntry', () => {
     expect(entry.median_ttft).toBe(0.15);
     expect(entry.p99_e2el).toBe(3.1);
     expect(entry.median_intvty).toBe(12.5);
+    expect(entry.rawMetricKeys).toContain('median_ttft');
   });
 
   it('defaults missing metrics to 0', () => {
     const entry = rowToAggDataEntry(makeRow({ metrics: {} }));
     expect(entry.tput_per_gpu).toBe(0);
     expect(entry.median_ttft).toBe(0);
+    expect(entry.rawMetricKeys).toEqual([]);
   });
 
   it('maps disagg and GPU count fields', () => {

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -93,6 +93,7 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
   // emitting `?ids=NaN` or an `/inference/agentic/NaN` link.
   const numericId = typeof row.id === 'number' ? row.id : Number(row.id);
   return {
+    rawMetricKeys: Object.keys(m),
     id: isPersistedBenchmarkId(numericId) ? numericId : undefined,
     hw: row.hardware,
     framework: row.framework,

--- a/packages/app/src/lib/csv-export-helpers.test.ts
+++ b/packages/app/src/lib/csv-export-helpers.test.ts
@@ -23,26 +23,26 @@ const makePoint = (overrides: Partial<InferenceData> = {}): InferenceData => ({
   tput_per_gpu: 4800,
   output_tput_per_gpu: 3200,
   input_tput_per_gpu: 1600,
-  mean_ttft: 120,
-  median_ttft: 110,
-  p99_ttft: 250,
-  std_ttft: 30,
-  mean_tpot: 15,
-  median_tpot: 14,
-  p99_tpot: 28,
-  std_tpot: 4,
+  mean_ttft: 0.12,
+  median_ttft: 0.11,
+  p99_ttft: 0.25,
+  std_ttft: 0.03,
+  mean_tpot: 0.015,
+  median_tpot: 0.014,
+  p99_tpot: 0.028,
+  std_tpot: 0.004,
   mean_intvty: 66,
   median_intvty: 71,
   p99_intvty: 35,
   std_intvty: 12,
-  mean_itl: 16,
-  median_itl: 15,
-  p99_itl: 30,
-  std_itl: 5,
-  mean_e2el: 5000,
-  median_e2el: 4800,
-  p99_e2el: 8000,
-  std_e2el: 1200,
+  mean_itl: 0.016,
+  median_itl: 0.015,
+  p99_itl: 0.03,
+  std_itl: 0.005,
+  mean_e2el: 5,
+  median_e2el: 4.8,
+  p99_e2el: 8,
+  std_e2el: 1.2,
   tpPerGpu: { y: 1200, roof: false },
   tpPerMw: { y: 694, roof: false },
   costh: { y: 0.5, roof: false },
@@ -55,20 +55,22 @@ const makePoint = (overrides: Partial<InferenceData> = {}): InferenceData => ({
 });
 
 describe('inferenceChartToCsv', () => {
-  it('exports all raw benchmark fields', () => {
+  it('exports benchmark summary fields', () => {
     const data = [makePoint()];
     const { headers, rows } = inferenceChartToCsv(data, 'llama-3.1-405b', '1k/1k');
 
     // Should have all metric columns
     expect(headers).toContain('Throughput/GPU (tok/s)');
-    expect(headers).toContain('Mean TTFT (ms)');
-    expect(headers).toContain('P99 TTFT (ms)');
+    expect(headers).toContain('Mean TTFT (s)');
+    expect(headers).toContain('P99 TTFT (s)');
     expect(headers).toContain('Mean Interactivity (tok/s/user)');
-    expect(headers).toContain('Mean E2E Latency (ms)');
+    expect(headers).toContain('Mean E2E Latency (s)');
     expect(headers).toContain('Disaggregated');
     expect(headers).toContain('EP');
     expect(headers).toContain('DP Attention');
+    expect(headers).toContain('Run URL');
     expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveLength(headers.length);
   });
 
   it('includes Model, ISL, and OSL columns from model and sequence', () => {
@@ -92,11 +94,74 @@ describe('inferenceChartToCsv', () => {
     const tputIdx = headers.indexOf('Throughput/GPU (tok/s)');
     expect(row[tputIdx]).toBe(4800);
 
-    const ttftIdx = headers.indexOf('Mean TTFT (ms)');
-    expect(row[ttftIdx]).toBe(120);
+    const ttftIdx = headers.indexOf('Mean TTFT (s)');
+    expect(row[ttftIdx]).toBe(0.12);
 
     const p99IntIdx = headers.indexOf('P99 Interactivity (tok/s/user)');
     expect(row[p99IntIdx]).toBe(35);
+  });
+
+  it('labels raw latency statistics as seconds without changing their values', () => {
+    const issueMetrics = {
+      mean_ttft: 1.615576321,
+      median_ttft: 0.403875659,
+      p99_ttft: 20.67356789,
+      std_ttft: 3.964372301,
+      mean_tpot: 0.048823025,
+      median_tpot: 0.0490139,
+      p99_tpot: 0.061919564,
+      std_tpot: 0.005588959,
+      mean_itl: 0.048892513,
+      median_itl: 0.02832133,
+      p99_itl: 0.190448091,
+      std_itl: 0.091604103,
+      mean_e2el: 46.55299096,
+      median_e2el: 45.77583359,
+      p99_e2el: 75.47229264,
+      std_e2el: 8.356892074,
+    };
+    const { headers, rows } = inferenceChartToCsv(
+      [makePoint(issueMetrics)],
+      'llama-3.1-405b',
+      '1k/1k',
+    );
+    const row = rows[0];
+
+    for (const [metric, value] of Object.entries(issueMetrics)) {
+      const [stat, ...nameParts] = metric.split('_');
+      const metricName =
+        nameParts.join('_') === 'e2el' ? 'E2E Latency' : nameParts.join('_').toUpperCase();
+      const statName = stat === 'std' ? 'Std' : `${stat[0].toUpperCase()}${stat.slice(1)}`;
+      const header = `${statName} ${metricName} (s)`;
+
+      expect(headers).toContain(header);
+      expect(row[headers.indexOf(header)]).toBe(value);
+    }
+
+    expect(headers.filter((header) => header.endsWith('(ms)'))).toEqual([]);
+  });
+
+  it('exports visible unofficial-run rows with their provenance', () => {
+    const official = makePoint({
+      hwKey: 'h100-sxm-sglang',
+      run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/100',
+    });
+    const overlay = makePoint({
+      hwKey: 'b200-sxm-vllm',
+      hw: 'B200 SXM (vLLM)',
+      framework: 'vllm',
+      mean_tpot: 0.048823025,
+      run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/2405',
+    });
+    const { headers, rows } = inferenceChartToCsv([official], 'llama-3.1-405b', '1k/1k', [overlay]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.length === headers.length)).toBe(true);
+    expect(rows[1][headers.indexOf('Hardware Key')]).toBe('b200-sxm-vllm');
+    expect(rows[1][headers.indexOf('Mean TPOT (s)')]).toBe(0.048823025);
+    expect(rows[1][headers.indexOf('Run URL')]).toBe(
+      'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/2405',
+    );
   });
 
   it('filters out hidden data points', () => {
@@ -203,6 +268,20 @@ describe('inferenceChartToCsv', () => {
     expect(row[headers.indexOf('Framework')]).toBe('');
     expect(row[headers.indexOf('Throughput/GPU (tok/s)')]).toBe('');
     expect(row[headers.indexOf('EP')]).toBe('');
+  });
+
+  it('exports missing source metrics as blank while preserving a measured zero', () => {
+    const data = [
+      makePoint({
+        rawMetricKeys: ['median_ttft'],
+        mean_ttft: 0,
+        median_ttft: 0,
+      }),
+    ];
+    const { headers, rows } = inferenceChartToCsv(data, 'llama-3.1-405b', '1k/1k');
+
+    expect(rows[0][headers.indexOf('Mean TTFT (s)')]).toBe('');
+    expect(rows[0][headers.indexOf('Median TTFT (s)')]).toBe(0);
   });
 });
 

--- a/packages/app/src/lib/csv-export-helpers.ts
+++ b/packages/app/src/lib/csv-export-helpers.ts
@@ -3,8 +3,8 @@
  * These functions convert chart-specific data structures into
  * { headers, rows } suitable for csv-export.ts.
  *
- * Inference export dumps ALL raw benchmark fields from the DB,
- * not just the currently plotted x/y axes.
+ * Inference export includes benchmark summary fields beyond the currently
+ * plotted x/y axes.
  */
 
 import type { InferenceData, TrendDataPoint } from '@/components/inference/types';
@@ -17,15 +17,23 @@ interface CsvData {
   rows: (string | number | boolean | null | undefined)[][];
 }
 
+/** Preserve a real zero while leaving source metrics that were not measured blank. */
+function benchmarkMetric(point: InferenceData, key: string): number | '' {
+  if (point.rawMetricKeys && !point.rawMetricKeys.includes(key)) return '';
+  const value = point[key as keyof InferenceData];
+  return typeof value === 'number' ? value : '';
+}
+
 /**
  * Generate CSV data from inference scatter/GPU chart data points.
- * Exports all raw benchmark metrics so the user gets a full data dump,
- * regardless of which axes are currently plotted.
+ * Exports benchmark summary metrics regardless of which axes are currently
+ * plotted. Visible unofficial-run rows are appended after official rows.
  */
 export function inferenceChartToCsv(
   data: InferenceData[],
   model: string,
   sequence: string,
+  overlayData: InferenceData[] = [],
 ): CsvData {
   const islOsl = sequenceToIslOsl(sequence);
   const headers = [
@@ -44,30 +52,30 @@ export function inferenceChartToCsv(
     'Output Throughput/GPU (tok/s)',
     'Input Throughput/GPU (tok/s)',
     // Latency — TTFT
-    'Mean TTFT (ms)',
-    'Median TTFT (ms)',
-    'P99 TTFT (ms)',
-    'Std TTFT (ms)',
+    'Mean TTFT (s)',
+    'Median TTFT (s)',
+    'P99 TTFT (s)',
+    'Std TTFT (s)',
     // Latency — TPOT
-    'Mean TPOT (ms)',
-    'Median TPOT (ms)',
-    'P99 TPOT (ms)',
-    'Std TPOT (ms)',
+    'Mean TPOT (s)',
+    'Median TPOT (s)',
+    'P99 TPOT (s)',
+    'Std TPOT (s)',
     // Interactivity
     'Mean Interactivity (tok/s/user)',
     'Median Interactivity (tok/s/user)',
     'P99 Interactivity (tok/s/user)',
     'Std Interactivity (tok/s/user)',
     // ITL
-    'Mean ITL (ms)',
-    'Median ITL (ms)',
-    'P99 ITL (ms)',
-    'Std ITL (ms)',
+    'Mean ITL (s)',
+    'Median ITL (s)',
+    'P99 ITL (s)',
+    'Std ITL (s)',
     // E2E Latency
-    'Mean E2E Latency (ms)',
-    'Median E2E Latency (ms)',
-    'P99 E2E Latency (ms)',
-    'Std E2E Latency (ms)',
+    'Mean E2E Latency (s)',
+    'Median E2E Latency (s)',
+    'P99 E2E Latency (s)',
+    'Std E2E Latency (s)',
     // Disaggregated
     'Disaggregated',
     'Num Prefill GPUs',
@@ -77,9 +85,11 @@ export function inferenceChartToCsv(
     'EP',
     'DP Attention',
     'Is Multinode',
+    // Provenance (especially important when unofficial-run rows are included)
+    'Run URL',
   ];
 
-  const rows = data
+  const rows = [...data, ...overlayData]
     .filter((d) => !d.hidden)
     .map((d) => [
       model,
@@ -92,29 +102,29 @@ export function inferenceChartToCsv(
       d.tp,
       d.conc,
       d.date,
-      d.tput_per_gpu ?? '',
-      d.output_tput_per_gpu ?? '',
-      d.input_tput_per_gpu ?? '',
-      d.mean_ttft ?? '',
-      d.median_ttft ?? '',
-      d.p99_ttft ?? '',
-      d.std_ttft ?? '',
-      d.mean_tpot ?? '',
-      d.median_tpot ?? '',
-      d.p99_tpot ?? '',
-      d.std_tpot ?? '',
-      d.mean_intvty ?? '',
-      d.median_intvty ?? '',
-      d.p99_intvty ?? '',
-      d.std_intvty ?? '',
-      d.mean_itl ?? '',
-      d.median_itl ?? '',
-      d.p99_itl ?? '',
-      d.std_itl ?? '',
-      d.mean_e2el ?? '',
-      d.median_e2el ?? '',
-      d.p99_e2el ?? '',
-      d.std_e2el ?? '',
+      benchmarkMetric(d, 'tput_per_gpu'),
+      benchmarkMetric(d, 'output_tput_per_gpu'),
+      benchmarkMetric(d, 'input_tput_per_gpu'),
+      benchmarkMetric(d, 'mean_ttft'),
+      benchmarkMetric(d, 'median_ttft'),
+      benchmarkMetric(d, 'p99_ttft'),
+      benchmarkMetric(d, 'std_ttft'),
+      benchmarkMetric(d, 'mean_tpot'),
+      benchmarkMetric(d, 'median_tpot'),
+      benchmarkMetric(d, 'p99_tpot'),
+      benchmarkMetric(d, 'std_tpot'),
+      benchmarkMetric(d, 'mean_intvty'),
+      benchmarkMetric(d, 'median_intvty'),
+      benchmarkMetric(d, 'p99_intvty'),
+      benchmarkMetric(d, 'std_intvty'),
+      benchmarkMetric(d, 'mean_itl'),
+      benchmarkMetric(d, 'median_itl'),
+      benchmarkMetric(d, 'p99_itl'),
+      benchmarkMetric(d, 'std_itl'),
+      benchmarkMetric(d, 'mean_e2el'),
+      benchmarkMetric(d, 'median_e2el'),
+      benchmarkMetric(d, 'p99_e2el'),
+      benchmarkMetric(d, 'std_e2el'),
       d.disagg ?? false,
       d.num_prefill_gpu ?? '',
       d.num_decode_gpu ?? '',
@@ -122,6 +132,7 @@ export function inferenceChartToCsv(
       d.ep ?? '',
       d.dp_attention ?? '',
       d.is_multinode ?? '',
+      d.run_url ?? '',
     ]);
 
   return { headers, rows };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are limited to CSV generation and export wiring; latency header relabeling may surprise downstream consumers who assumed milliseconds, but values were already in seconds.
> 
> **Overview**
> Fixes **inference chart CSV export** so latency columns are labeled **seconds** `(s)` instead of milliseconds, matching how values are already stored internally—numeric values are unchanged.
> 
> Export now includes a **`Run URL`** column and appends **visible unofficial-run overlay** points (same legend/filter rules as the chart) after official rows. **`ChartDisplay`** passes `visibleOverlayRowsForExport` into `inferenceChartToCsv`.
> 
> **`rawMetricKeys`** is recorded when transforming benchmark rows so CSV can leave metrics that were never in the source **blank** while still exporting a real **0** when it was measured. Unit tests and a **Cypress** flow cover overlay dismiss behavior and second-based headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8188e68d4e0b1398dd1d79ad95b82c6a13909950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->