### PR TITLE
chore(db): purge MiniMax M3 AMD run 30346826643 / 清理 MiniMax M3 AMD 运行 30346826643

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -74,6 +74,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29881640438, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29882624421, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29912027293, // 2026-07-22 | Reason: accidental ingest while testing
+  30346826643, // 2026-07-28 | Initial AMD submission for MiniMax M3, used incorrect AgentX harness. Will update after harness updates.
   30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
 ]);
 

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -74,7 +74,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29881640438, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29882624421, // 2026-07-22 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-tuning-round2)
   29912027293, // 2026-07-22 | Reason: accidental ingest while testing
-  30346826643, // 2026-07-28 | Initial AMD submission for MiniMax M3, used incorrect AgentX harness. Will update after harness updates.
+  30346826643, // 2026-07-28 | Initial AMD submission for MiniMax M3 used incorrect AgentX harness; MTP/spec decode is AgentX-only. Will update after harness updates.
   30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
 ]);
 


### PR DESCRIPTION
## Summary

- Add InferenceX workflow run `30346826643` to `PURGED_RUNS`.
- Remove the initial AMD MiniMax M3 results because they used the incorrect AgentX harness and because MTP/speculative decoding is AgentX-only.
- Allow updated results to be published after the harness changes.

After merge, the run-override workflow will remove this run from the production database and prevent it from being re-ingested. The original GitHub Actions run and artifacts are unaffected.

## Validation

- `bun run --cwd packages/db test:unit -- src/etl/run-overrides.test.ts`
- Pre-commit formatting, lint, and TypeScript checks

## 中文说明

- 将 InferenceX 工作流运行 `30346826643` 加入 `PURGED_RUNS`。
- 清理初始 AMD MiniMax M3 结果，因为该运行使用了错误的 AgentX 测试工具，且 MTP/推测解码仅适用于 AgentX。
- 待测试工具更新后再发布新结果。

合并后，运行覆盖工作流会从生产数据库中删除该运行，并阻止其被重新摄取。原始 GitHub Actions 运行及其产物不受影响。

## 验证

- `bun run --cwd packages/db test:unit -- src/etl/run-overrides.test.ts`
- 提交前格式、lint 和 TypeScript 检查

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single run-ID entry in an existing purge list; production impact is limited to removing one benchmark run’s data, with no changes to auth, APIs, or core ingest behavior.
> 
> **Overview**
> Adds InferenceX workflow run **`30346826643`** to **`PURGED_RUNS`** in `run-overrides.ts`, with a note that the initial AMD MiniMax M3 submission used the wrong AgentX harness (MTP/spec decode is AgentX-only).
> 
> After merge, CI’s run-override flow will **delete** any data already ingested for that run and **skip** it on future ingest, so corrected results can be published once the harness is fixed. No ingest or purge logic changes beyond this new ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98cd2a9dae50ef1913a1543c298a0acab8d2a9cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->