### PR TITLE
Promote Overview to top-level navigation / 将总览提升至顶层导航

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,13 @@ See `.env.example`. Key vars: `GITHUB_TOKEN`, `DATABASE_READONLY_URL`, `DATABASE
 
 See [Testing](./docs/testing.md) for full requirements, quality standards, and pre-commit checklist. Tests are **mandatory** — missing/low-quality tests are 🔴 BLOCKING on PR review.
 
+### E2E Runtime and PR Workflow
+
+- Prefer focused Cypress specs while iterating, and create the draft PR before starting a full local E2E run so CI and review setup can proceed in parallel.
+- A warm local `bun run test:e2e` typically takes about **4–6 minutes** because the component and integration suites run sequentially on one machine; cold dependency/browser setup can take longer.
+- GitHub Actions is usually faster in wall-clock time: integration specs run across **four shards per browser** for Chrome and Firefox (eight parallel E2E jobs), while component tests run in a separate job. Recent successful workflows complete in roughly **3–5 minutes**.
+- Local targeted tests remain the fastest feedback loop. The sharded GitHub run is the authoritative broad browser check; do not spend time emulating all CI shards serially before opening the PR.
+
 ## Analytics Requirement
 
 All interactive elements should have `track()` from `@/lib/analytics` (autocapture provides baseline coverage).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,6 +23,12 @@ bun run test:unit
 bun run test:e2e
 ```
 
+## Runtime and CI Sharding
+
+A warm local `bun run test:e2e` typically takes about **4–6 minutes** because Cypress component tests and integration tests run sequentially on one machine. Cold dependency or browser setup can take longer, so use focused `--spec` runs while iterating and open the draft PR before starting the full local suite.
+
+GitHub Actions runs integration specs across **four shards per browser** for Chrome and Firefox, for eight parallel E2E jobs, with component tests in a separate job. Recent successful workflows finish in roughly **3–5 minutes** wall-clock. The sharded CI run is the authoritative broad browser check and is substantially faster than reproducing both browsers and every shard serially on a local machine.
+
 ## Quality Standards
 
 1. **No tautological tests** — every test must verify a real transformation

--- a/packages/app/cypress/component/footer.cy.tsx
+++ b/packages/app/cypress/component/footer.cy.tsx
@@ -54,6 +54,18 @@ describe('Footer', () => {
       .and('include', 'github.com/SemiAnalysisAI/InferenceX-app');
   });
 
+  it('contains the destinations moved out of the primary navigation', () => {
+    cy.get('[data-testid="footer-link-supporters"]')
+      .should('contain.text', 'Supporters')
+      .and('have.attr', 'href', '/quotes');
+    cy.get('[data-testid="footer-link-datasets"]')
+      .should('contain.text', 'Datasets')
+      .and('have.attr', 'href', '/datasets');
+    cy.get('[data-testid="footer-link-articles"]')
+      .should('contain.text', 'Articles')
+      .and('have.attr', 'href', '/blog');
+  });
+
   it('all external links open in a new tab', () => {
     cy.get('[data-testid="footer-links"]')
       .find('a[target="_blank"]')

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -37,8 +37,10 @@ function rectOf(selector: string) {
 }
 
 describe('Header', () => {
+  let mockRouter: ReturnType<typeof createMockRouter>;
+
   beforeEach(() => {
-    const mockRouter = createMockRouter();
+    mockRouter = createMockRouter();
     cy.mount(
       <AppRouterContext.Provider value={mockRouter}>
         <PathnameContext.Provider value="/">
@@ -64,6 +66,14 @@ describe('Header', () => {
     cy.get('[data-testid="nav-link-overview"]')
       .should('be.visible')
       .and('have.attr', 'href', '/overview');
+  });
+
+  it('uses resilient app navigation for the desktop Overview link', () => {
+    cy.clock();
+    cy.get('[data-testid="nav-link-overview"]').click();
+    cy.wrap(mockRouter.push).should('have.been.calledOnceWith', '/overview');
+    cy.tick(250);
+    cy.wrap(mockRouter.push).should('have.been.calledTwice');
   });
 
   it('shows Dashboard nav link', () => {
@@ -109,6 +119,16 @@ describe('Header', () => {
       cy.contains('a', 'Datasets').should('not.exist');
       cy.contains('a', 'Articles').should('not.exist');
     });
+  });
+
+  it('uses resilient app navigation for the mobile Overview link', () => {
+    cy.clock();
+    cy.viewport(375, 812);
+    cy.get('[data-testid="mobile-menu-toggle"]').click();
+    cy.get('[data-testid="mobile-menu"]').contains('a', 'Overview').click();
+    cy.wrap(mockRouter.push).should('have.been.calledOnceWith', '/overview');
+    cy.tick(250);
+    cy.wrap(mockRouter.push).should('have.been.calledTwice');
   });
 
   describe('at 320x700', () => {

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -60,6 +60,12 @@ describe('Header', () => {
     cy.get('[data-testid="header"]').find('img[alt="SemiAnalysis logo"]').should('exist');
   });
 
+  it('shows Overview as a top-level nav link', () => {
+    cy.get('[data-testid="nav-link-overview"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/overview');
+  });
+
   it('shows Dashboard nav link', () => {
     cy.get('[data-testid="nav-link-dashboard"]').should('be.visible');
     cy.get('[data-testid="nav-link-dashboard"]').should('have.attr', 'href', '/inference');
@@ -70,9 +76,10 @@ describe('Header', () => {
     cy.get('[data-testid="nav-link-compare"]').should('have.attr', 'href', '/compare');
   });
 
-  it('shows Supporters nav link', () => {
-    cy.get('[data-testid="nav-link-supporters"]').should('be.visible');
-    cy.get('[data-testid="nav-link-supporters"]').should('have.attr', 'href', '/quotes');
+  it('keeps footer destinations out of the primary nav', () => {
+    cy.get('[data-testid="nav-link-supporters"]').should('not.exist');
+    cy.get('[data-testid="nav-link-datasets"]').should('not.exist');
+    cy.get('[data-testid="nav-link-blog"]').should('not.exist');
   });
 
   it('shows the GitHub stars button linking to the correct repo', () => {
@@ -95,9 +102,12 @@ describe('Header', () => {
       .click()
       .should('have.attr', 'aria-expanded', 'true');
     cy.get('[data-testid="mobile-menu"]').within(() => {
+      cy.contains('a', 'Overview').should('be.visible').and('have.attr', 'href', '/overview');
       cy.contains('a', 'Dashboard').should('be.visible').and('have.attr', 'href', '/inference');
       cy.contains('a', 'Comparisons').should('be.visible').and('have.attr', 'href', '/compare');
-      cy.contains('a', 'Supporters').should('be.visible').and('have.attr', 'href', '/quotes');
+      cy.contains('a', 'Supporters').should('not.exist');
+      cy.contains('a', 'Datasets').should('not.exist');
+      cy.contains('a', 'Articles').should('not.exist');
     });
   });
 
@@ -156,11 +166,12 @@ describe('Header', () => {
       cy.get('[data-testid="mobile-menu-toggle"]').click();
       cy.get('[data-testid="mobile-menu"]').should('be.visible');
       cy.get('[data-testid="mobile-menu"]').within(() => {
-        ['Home', 'Dashboard', 'Comparisons', 'Supporters', 'Datasets', 'Articles', 'About'].forEach(
-          (label) => {
-            cy.contains('a', label).should('be.visible');
-          },
-        );
+        ['Home', 'Overview', 'Dashboard', 'Comparisons', 'About'].forEach((label) => {
+          cy.contains('a', label).should('be.visible');
+        });
+        ['Supporters', 'Datasets', 'Articles'].forEach((label) => {
+          cy.contains('a', label).should('not.exist');
+        });
       });
       cy.get('[data-testid="mobile-menu"] a').each(($link) => {
         const rect = $link[0].getBoundingClientRect();

--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -48,7 +48,7 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
 
   it('renders bare hrefs when the URL has no unofficialrun param', () => {
     mountTabNav({});
-    cy.get('[data-testid="tab-trigger-overview"]').should('have.attr', 'href', '/overview');
+    cy.get('[data-testid="tab-trigger-overview"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-evaluation"]').should('have.attr', 'href', '/evaluation');
     cy.get('[data-testid="tab-trigger-historical"]').should('have.attr', 'href', '/historical');
     cy.get('[data-testid="tab-trigger-calculator"]').should('have.attr', 'href', '/calculator');
@@ -56,11 +56,7 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
 
   it('appends unofficialruns to every tab href when the URL has the param', () => {
     mountTabNav({ search: '?unofficialruns=12345' });
-    cy.get('[data-testid="tab-trigger-overview"]').should(
-      'have.attr',
-      'href',
-      '/overview?unofficialruns=12345',
-    );
+    cy.get('[data-testid="tab-trigger-overview"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-evaluation"]').should(
       'have.attr',
       'href',

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -10,9 +10,6 @@ describe('Chart Section Tabs — E2E', () => {
   });
 
   it('updates the URL path when switching tabs', () => {
-    cy.get('[data-testid="tab-trigger-overview"]').click();
-    cy.url().should('include', '/overview');
-
     cy.get('[data-testid="tab-trigger-evaluation"]').click();
     cy.url().should('include', '/evaluation');
 
@@ -60,9 +57,14 @@ describe('First-load navigation', () => {
     cy.get('body').should('not.have.attr', 'data-scroll-locked');
   });
 
-  it('navigates to articles with one click while the launch modal is visible', () => {
-    cy.get('[data-testid="nav-link-blog"]').click();
+  it('navigates to articles from the footer while the launch modal is visible', () => {
+    cy.get('[data-testid="footer-link-articles"]').scrollIntoView().click();
     cy.location('pathname').should('eq', '/blog');
+  });
+
+  it('navigates to overview from the top-level header link', () => {
+    cy.get('[data-testid="nav-link-overview"]').click();
+    cy.location('pathname').should('eq', '/overview');
   });
 
   it('navigates to dashboard from the header with one click', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -330,11 +330,11 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
-    cy.get('[data-testid="chart-section-tabs"]').should('be.visible');
-    cy.get('[data-testid="tab-trigger-overview"]')
+    cy.get('[data-testid="chart-section-tabs"]').should('not.exist');
+    cy.get('[data-testid="nav-link-overview"]')
       .should('have.attr', 'href', '/overview')
-      .and('have.class', 'border-secondary');
-    cy.get('[data-testid="nav-link-dashboard"]').should('have.class', 'text-brand');
+      .and('have.class', 'text-brand');
+    cy.get('[data-testid="nav-link-dashboard"]').should('not.have.class', 'text-brand');
 
     cy.contains('h1', PAGE_TITLE).should('exist');
     cy.contains(
@@ -878,7 +878,8 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/zh/overview');
 
-    cy.get('[data-testid="tab-trigger-overview"]')
+    cy.get('[data-testid="chart-section-tabs"]').should('not.exist');
+    cy.get('[data-testid="nav-link-overview"]')
       .should('have.attr', 'href', '/zh/overview')
       .and('contain.text', '总览');
     cy.contains('h1', PAGE_TITLE_ZH).should('exist');

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -680,7 +680,7 @@ describe('Overview page', () => {
       cy.viewport(width, 844);
       cy.visit('/overview');
 
-      cy.get('[data-testid="mobile-chart-select"]').should('be.visible');
+      cy.get('[data-testid="mobile-chart-select"]').should('not.exist');
       cy.get('[data-testid="overview-mobile-list"]').should('be.visible');
       cy.get('[data-testid="overview-tier-switcher"]').should('be.visible');
       cy.get('[data-testid="overview-engine-scope-switcher"]')

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -29,6 +29,15 @@ describe('Chinese (/zh) pages', () => {
 
     it('footer renders in Chinese with zh-internal links', () => {
       cy.get('[data-testid="footer-brand-description"]').should('contain.text', '开源推理基准测试');
+      cy.get('[data-testid="footer-link-supporters"]')
+        .should('contain.text', '支持者')
+        .and('have.attr', 'href', '/zh/quotes');
+      cy.get('[data-testid="footer-link-datasets"]')
+        .should('contain.text', '数据集')
+        .and('have.attr', 'href', '/zh/datasets');
+      cy.get('[data-testid="footer-link-articles"]')
+        .should('contain.text', '文章')
+        .and('have.attr', 'href', '/zh/blog');
       cy.get('[data-testid="footer-link-land-acknowledgement"]').should(
         'have.attr',
         'href',

--- a/packages/app/src/components/dashboard-shell.tsx
+++ b/packages/app/src/components/dashboard-shell.tsx
@@ -8,10 +8,11 @@ import { usePathname } from 'next/navigation';
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const showTabNav = pathname !== '/overview' && pathname !== '/zh/overview';
   const content = (
     <main className="relative">
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
-        <TabNav />
+        {showTabNav && <TabNav />}
         {children}
       </div>
     </main>
@@ -23,7 +24,7 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       <UnofficialRunProvider>
         <main className="relative">
           <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
-            <TabNav />
+            {showTabNav && <TabNav />}
             <GlobalFilterProvider>{children}</GlobalFilterProvider>
           </div>
         </main>

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { ShareTwitterButton, ShareLinkedInButton } from '@/components/share-buttons';
+import { track } from '@/lib/analytics';
 import { useLocale } from '@/lib/use-locale';
 
 import { StarButton } from './footer-star-cta';
@@ -24,6 +25,9 @@ const STRINGS = {
     benchmarks: 'Benchmarks',
     frontend: 'Frontend',
     more: 'More',
+    supporters: 'Supporters',
+    datasets: 'Datasets',
+    articles: 'Articles',
     gpuReliability: 'GPU Reliability',
     perfPerDollar: 'Performance per Dollar',
     glossary: 'AI Inference Glossary',
@@ -48,6 +52,9 @@ const STRINGS = {
     benchmarks: '基准测试仓库',
     frontend: '前端仓库',
     more: '更多',
+    supporters: '支持者',
+    datasets: '数据集',
+    articles: '文章',
     gpuReliability: 'GPU 可靠性',
     perfPerDollar: '每美元性能',
     glossary: 'AI 推理术语表',
@@ -179,6 +186,30 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
             </div>
             <div data-testid="footer-links-more" className="flex flex-col gap-2.5">
               <span className="text-sm font-medium text-foreground">{t.more}</span>
+              <Link
+                data-testid="footer-link-supporters"
+                href={`${prefix}/quotes`}
+                onClick={() => track('footer_supporters_clicked')}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.supporters}
+              </Link>
+              <Link
+                data-testid="footer-link-datasets"
+                href={`${prefix}/datasets`}
+                onClick={() => track('footer_datasets_clicked')}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.datasets}
+              </Link>
+              <Link
+                data-testid="footer-link-articles"
+                href={`${prefix}/blog`}
+                onClick={() => track('footer_articles_clicked')}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.articles}
+              </Link>
               <Link
                 data-testid="footer-link-reliability"
                 href={`${prefix}/reliability`}

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -17,7 +17,6 @@ import { GitHubStars } from './GithubStars';
 
 /** Dashboard tab paths that should highlight the "Dashboard" nav link. */
 const DASHBOARD_TABS = [
-  '/overview',
   '/inference',
   '/evaluation',
   '/historical',
@@ -33,6 +32,12 @@ const DASHBOARD_TABS = [
 const NAV_LINKS = [
   { href: '/', label: 'Home', testId: 'nav-link-home', event: 'header_home_clicked' },
   {
+    href: '/overview',
+    label: 'Overview',
+    testId: 'nav-link-overview',
+    event: 'header_overview_clicked',
+  },
+  {
     href: '/inference',
     label: 'Dashboard',
     testId: 'nav-link-dashboard',
@@ -44,19 +49,6 @@ const NAV_LINKS = [
     testId: 'nav-link-compare',
     event: 'header_compare_clicked',
   },
-  {
-    href: '/quotes',
-    label: 'Supporters',
-    testId: 'nav-link-supporters',
-    event: 'header_supporters_clicked',
-  },
-  {
-    href: '/datasets',
-    label: 'Datasets',
-    testId: 'nav-link-datasets',
-    event: 'header_datasets_clicked',
-  },
-  { href: '/blog', label: 'Articles', testId: 'nav-link-blog', event: 'header_blog_clicked' },
   { href: '/about', label: 'About', testId: 'nav-link-about', event: 'header_about_clicked' },
 ] as const;
 

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -190,7 +190,9 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                 )}
                 onClick={(e) => {
                   track(event);
-                  if (href === '/inference') navigateInApp(e, router, displayHref);
+                  if (href === '/overview' || href === '/inference') {
+                    navigateInApp(e, router, displayHref);
+                  }
                 }}
               >
                 {label}
@@ -253,7 +255,9 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
                       )}
                       onClick={(e) => {
                         track(event);
-                        if (href === '/inference') navigateInApp(e, router, displayHref);
+                        if (href === '/overview' || href === '/inference') {
+                          navigateInApp(e, router, displayHref);
+                        }
                       }}
                     >
                       {label}

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -26,7 +26,6 @@ import { TAB_LABELS_ZH } from '@/lib/tab-meta-zh';
 import { cn } from '@/lib/utils';
 
 const VISIBLE_TABS = [
-  { href: '/overview', label: 'Overview', testId: 'tab-trigger-overview' },
   { href: '/inference', label: 'Inference Performance', testId: 'tab-trigger-inference' },
   { href: '/evaluation', label: 'Accuracy Evals', testId: 'tab-trigger-evaluation' },
   { href: '/historical', label: 'Historical Trends', testId: 'tab-trigger-historical' },

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -140,11 +140,9 @@ export const TAB_LABELS_ZH: Record<string, string> = {
 /** Chinese labels for the site header nav on /zh pages, keyed by English href. */
 export const NAV_LABELS_ZH: Record<string, string> = {
   '/': '首页',
+  '/overview': '总览',
   '/inference': '仪表板',
   '/compare': 'GPU 对比',
-  '/quotes': '支持者',
-  '/datasets': '数据集',
-  '/blog': '文章',
   '/about': '关于',
 };
 


### PR DESCRIPTION
## Summary

- promote `/overview` from the dashboard tab bar to its own top-level Overview navigation item
- keep Dashboard linked to `/inference`, and reduce the primary header to Home, Overview, Dashboard, Comparisons, and About
- move Supporters, Datasets, and Articles into the localized English/Chinese footer with analytics events
- hide the dashboard tab bar on the English and Chinese overview pages
- document approximate local E2E duration and the faster four-shard-per-browser GitHub Actions setup

## Validation

- `oxfmt` on all changed files
- Cypress component specs: 33 passing across header, footer, and tab navigation
- focused navigation and Chinese-page E2E specs passed during iteration
- full overview E2E is deferred: the local environment has no `DATABASE_READONLY_URL`
- pre-commit typecheck/lint could not run through Lefthook because Bun is unavailable in the desktop runtime; the existing `node_modules` is also stale after the large master fast-forward

The PR is intentionally a draft before the broad E2E run. Marking it ready triggers the sharded Chrome/Firefox GitHub Actions suite.

## 中文说明

- 将 `/overview` 从仪表板标签栏提升为独立的顶层“总览”导航项
- “仪表板”继续链接到 `/inference`，主导航精简为“首页、总览、仪表板、GPU 对比、关于”
- 将“支持者、数据集、文章”移至中英文页脚，并保留独立的 analytics 事件
- 在英文和中文总览页面隐藏仪表板标签栏
- 补充本地 E2E 大致耗时，以及 GitHub Actions 每个浏览器四分片并行运行、墙钟时间更短的说明

## 验证

- 对全部改动文件运行 `oxfmt`
- Cypress 组件测试：header、footer 与 tab navigation 共 33 项通过
- 迭代期间，聚焦的导航与中文页面 E2E 测试通过
- 完整 overview E2E 暂缓：本地环境未配置 `DATABASE_READONLY_URL`
- 桌面运行环境未安装 Bun，因此 Lefthook 无法执行 pre-commit typecheck/lint；此外，大幅同步 master 后现有 `node_modules` 仍是旧版本

该 PR 按计划先以草稿形式创建。切换为 Ready 后会触发 GitHub Actions 中 Chrome/Firefox 的分片 E2E 测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Global navigation and routing entry points change across EN/zh; risk is moderate but mitigated by broad Cypress coverage and no auth or data-layer changes.
> 
> **Overview**
> **Overview** moves out of the dashboard tab bar into its own header item (`nav-link-overview`), with **Dashboard** still pointing at `/inference` and the primary nav trimmed to Home, Overview, Dashboard, Comparisons, and About.
> 
> **Supporters**, **Datasets**, and **Articles** leave the header and appear under the footer **More** section (localized EN/zh) with `footer_*_clicked` analytics. On `/overview` and `/zh/overview`, `DashboardShell` hides `TabNav` so the cost matrix is not wrapped in chart tabs; `/overview` is no longer in `DASHBOARD_TABS` or `VISIBLE_TABS`, and Overview uses the same `navigateInApp` path as Dashboard.
> 
> Tests and docs follow the new IA (header/footer/tab-nav/overview/navigation/zh-pages) and add **E2E runtime / CI sharding** guidance in `AGENTS.md` and `docs/testing.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fb9f43155b55dad44623dc6c7fce3768ae3dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->