### PR TITLE
Add audited benchmark point purges / 添加可审计的基准测试点删除机制

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -33,6 +33,27 @@ Every INSERT uses `ON CONFLICT DO UPDATE` or `DO NOTHING`. This means:
 
 The unique constraints match natural keys (e.g., `(workflow_run_id, config_id, isl, osl, conc)` for benchmarks), not surrogate keys.
 
+### Audited Point Purges
+
+`packages/db/src/etl/run-overrides.ts` is the durable audit record for exceptional
+data removal. Use `PURGED_BENCHMARK_POINTS` when a valid workflow run contains a
+specific invalid result, such as a server hang. Each record names `githubRunId`,
+`runAttempt`, `configId`, `benchmarkType`, `isl`, `osl`, `conc`, and `offloadMode`,
+with a dated reason comment. The full identity is required because one run can
+contain multiple serving configurations at the same sequence lengths and concurrency.
+
+`bun run db:apply-overrides` previews every matching row and requires confirmation
+before deleting it in a transaction. It also removes unreferenced server logs and
+trace-replay sidecars, clears availability entries that no remaining successful row
+supports, and refreshes `latest_benchmarks`. The override remains in source control,
+so future CI and GCS ingests skip the point instead of restoring it.
+
+CI ingests match the run attempt exactly. If a GCS backup cannot retrieve GitHub run
+metadata, it matches the same run and full point identity across attempts. This
+conservative fallback prevents a failed GitHub lookup from restoring a suppressed
+point. It can only suppress an identical point from another attempt while that
+attempt remains unknown.
+
 ### Why Two Connection Types
 
 | Connection                      | Library     | Use Case                             | Why                                                                                                  |

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -3,7 +3,7 @@
  *   1. Patch conclusions for CONCLUSION_OVERRIDES
  *   2. Purge runs listed in PURGED_RUNS
  *   3. Purge specific attempts listed in PURGED_RUN_ATTEMPTS
- *
+ *   4. Purge individual benchmark points listed in PURGED_BENCHMARK_POINTS
  * Previews changes (read-only), then confirms before writing.
  *
  * Usage:
@@ -16,7 +16,13 @@
 
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
 import { type Sql, createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
-import { CONCLUSION_OVERRIDES, PURGED_RUN_ATTEMPTS, PURGED_RUNS } from './etl/run-overrides.js';
+import {
+  type PurgedBenchmarkPoint,
+  CONCLUSION_OVERRIDES,
+  PURGED_BENCHMARK_POINTS,
+  PURGED_RUN_ATTEMPTS,
+  PURGED_RUNS,
+} from './etl/run-overrides.js';
 
 const sql = createAdminSql({
   noSsl: hasNoSslFlag(),
@@ -144,6 +150,95 @@ async function previewPurge(
 }
 
 /**
+ * Delete benchmark results and any sidecars or availability rows left orphaned by
+ * the deletion. The result IDs may come from a whole run or selected points.
+ */
+async function purgeBenchmarkResults(tx: Sql, resultIds: number[]): Promise<void> {
+  if (resultIds.length === 0) return;
+
+  const availKeys = await tx`
+    SELECT DISTINCT c.model, br.isl, br.osl, c.precision, c.hardware,
+           c.framework, c.spec_method, c.disagg, br.date::text AS date
+    FROM benchmark_results br
+    JOIN configs c ON c.id = br.config_id
+    WHERE br.id = ANY(${resultIds})
+  `;
+  const logRows = await tx`
+    SELECT DISTINCT server_log_id AS id FROM benchmark_results
+    WHERE id = ANY(${resultIds}) AND server_log_id IS NOT NULL
+  `;
+  const traceRows = await tx`
+    SELECT DISTINCT trace_replay_id AS id FROM benchmark_results
+    WHERE id = ANY(${resultIds}) AND trace_replay_id IS NOT NULL
+  `;
+
+  await tx`DELETE FROM benchmark_results WHERE id = ANY(${resultIds})`;
+
+  const sIds = logRows.map((r) => r.id as number);
+  if (sIds.length > 0) {
+    await tx`
+      DELETE FROM server_logs
+      WHERE id = ANY(${sIds})
+        AND NOT EXISTS (
+          SELECT 1 FROM benchmark_results br WHERE br.server_log_id = server_logs.id
+        )
+    `;
+  }
+
+  const trIds = traceRows.map((r) => r.id as number);
+  if (trIds.length > 0) {
+    await tx`
+      DELETE FROM agentic_trace_replay
+      WHERE id = ANY(${trIds})
+        AND NOT EXISTS (
+          SELECT 1 FROM benchmark_results br WHERE br.trace_replay_id = agentic_trace_replay.id
+        )
+    `;
+  }
+
+  if (availKeys.length > 0) {
+    const models = availKeys.map((r) => r.model as string);
+    const isls = availKeys.map((r) => r.isl as number | null);
+    const osls = availKeys.map((r) => r.osl as number | null);
+    const precisions = availKeys.map((r) => r.precision as string);
+    const hardwares = availKeys.map((r) => r.hardware as string);
+    const frameworks = availKeys.map((r) => r.framework as string);
+    const specMethods = availKeys.map((r) => r.spec_method as string);
+    const disaggs = availKeys.map((r) => String(r.disagg));
+    const dates = availKeys.map((r) => r.date as string);
+
+    await tx`
+      DELETE FROM availability a
+      USING (
+        SELECT t.model, t.isl::int AS isl, t.osl::int AS osl, t.precision, t.hardware,
+               t.framework, t.spec_method, t.disagg::boolean AS disagg, t.date::date AS date
+        FROM unnest(
+          ${models}::text[], ${isls}::int[], ${osls}::int[],
+          ${precisions}::text[], ${hardwares}::text[], ${frameworks}::text[],
+          ${specMethods}::text[], ${disaggs}::text[], ${dates}::text[]
+        ) AS t(model, isl, osl, precision, hardware, framework, spec_method, disagg, date)
+      ) k
+      WHERE a.model = k.model
+        AND a.isl IS NOT DISTINCT FROM k.isl
+        AND a.osl IS NOT DISTINCT FROM k.osl
+        AND a.precision = k.precision AND a.hardware = k.hardware
+        AND a.framework = k.framework AND a.spec_method = k.spec_method
+        AND a.disagg = k.disagg AND a.date = k.date
+        AND NOT EXISTS (
+          SELECT 1 FROM benchmark_results br
+          JOIN configs c ON c.id = br.config_id
+          WHERE c.model = a.model
+            AND br.isl IS NOT DISTINCT FROM a.isl
+            AND br.osl IS NOT DISTINCT FROM a.osl
+            AND c.precision = a.precision AND c.hardware = a.hardware
+            AND c.framework = a.framework AND c.spec_method = a.spec_method
+            AND c.disagg = a.disagg AND br.date = a.date AND br.error IS NULL
+        )
+    `;
+  }
+}
+
+/**
  * Delete data for the given workflow_run rows (one or more attempts) in a transaction.
  * `wrIds` is the set of `workflow_runs.id` values to remove; sibling attempts of the
  * same `github_run_id` that aren't in `wrIds` are left intact.
@@ -153,100 +248,18 @@ async function purge(wrIds: number[]): Promise<void> {
   await sql.begin(async (_tx) => {
     const tx = _tx as unknown as Sql;
 
-    // Capture availability keys + server_log_ids before deleting benchmarks
-    const availKeys = await tx`
-      SELECT DISTINCT c.model, br.isl, br.osl, c.precision, c.hardware,
-             c.framework, c.spec_method, c.disagg, br.date::text AS date
-      FROM benchmark_results br
-      JOIN configs c ON c.id = br.config_id
-      WHERE br.workflow_run_id = ANY(${wrIds})
+    const resultRows = await tx`
+      SELECT id FROM benchmark_results WHERE workflow_run_id = ANY(${wrIds})
     `;
-    const logRows = await tx`
-      SELECT DISTINCT server_log_id AS id FROM benchmark_results
-      WHERE workflow_run_id = ANY(${wrIds}) AND server_log_id IS NOT NULL
-    `;
-    const traceRows = await tx`
-      SELECT DISTINCT trace_replay_id AS id FROM benchmark_results
-      WHERE workflow_run_id = ANY(${wrIds}) AND trace_replay_id IS NOT NULL
-    `;
+    await purgeBenchmarkResults(
+      tx,
+      resultRows.map((row) => row.id as number),
+    );
 
     // Children first
-    await tx`DELETE FROM benchmark_results WHERE workflow_run_id = ANY(${wrIds})`;
     await tx`DELETE FROM run_stats WHERE workflow_run_id = ANY(${wrIds})`;
     await tx`DELETE FROM eval_results WHERE workflow_run_id = ANY(${wrIds})`;
     await tx`DELETE FROM changelog_entries WHERE workflow_run_id = ANY(${wrIds})`;
-
-    // Orphaned server_logs
-    const sIds = logRows.map((r) => r.id as number);
-    if (sIds.length > 0) {
-      await tx`
-        DELETE FROM server_logs
-        WHERE id = ANY(${sIds})
-          AND NOT EXISTS (
-            SELECT 1 FROM benchmark_results br WHERE br.server_log_id = server_logs.id
-          )
-      `;
-    }
-
-    // Orphaned agentic_trace_replay sidecars (profile-export + server-metrics
-    // blobs). benchmark_results.trace_replay_id has no ON DELETE cascade, so
-    // deleting the run's rows above leaves these behind — clear any that are no
-    // longer referenced by a surviving benchmark_results row.
-    const trIds = traceRows.map((r) => r.id as number);
-    if (trIds.length > 0) {
-      await tx`
-        DELETE FROM agentic_trace_replay
-        WHERE id = ANY(${trIds})
-          AND NOT EXISTS (
-            SELECT 1 FROM benchmark_results br WHERE br.trace_replay_id = agentic_trace_replay.id
-          )
-      `;
-    }
-
-    // Orphaned availability rows. NULL-safe on isl/osl (`IS NOT DISTINCT FROM`)
-    // so agentic rows are matched too: agentic_traces availability has isl/osl
-    // NULL, and a row-value `IN` / `=` never matches NULL — which previously
-    // left agentic availability rows behind after a purge.
-    if (availKeys.length > 0) {
-      const models = availKeys.map((r) => r.model as string);
-      const isls = availKeys.map((r) => r.isl as number | null);
-      const osls = availKeys.map((r) => r.osl as number | null);
-      const precisions = availKeys.map((r) => r.precision as string);
-      const hardwares = availKeys.map((r) => r.hardware as string);
-      const frameworks = availKeys.map((r) => r.framework as string);
-      const specMethods = availKeys.map((r) => r.spec_method as string);
-      const disaggs = availKeys.map((r) => String(r.disagg));
-      const dates = availKeys.map((r) => r.date as string);
-
-      await tx`
-        DELETE FROM availability a
-        USING (
-          SELECT t.model, t.isl::int AS isl, t.osl::int AS osl, t.precision, t.hardware,
-                 t.framework, t.spec_method, t.disagg::boolean AS disagg, t.date::date AS date
-          FROM unnest(
-            ${models}::text[], ${isls}::int[], ${osls}::int[],
-            ${precisions}::text[], ${hardwares}::text[], ${frameworks}::text[],
-            ${specMethods}::text[], ${disaggs}::text[], ${dates}::text[]
-          ) AS t(model, isl, osl, precision, hardware, framework, spec_method, disagg, date)
-        ) k
-        WHERE a.model = k.model
-          AND a.isl IS NOT DISTINCT FROM k.isl
-          AND a.osl IS NOT DISTINCT FROM k.osl
-          AND a.precision = k.precision AND a.hardware = k.hardware
-          AND a.framework = k.framework AND a.spec_method = k.spec_method
-          AND a.disagg = k.disagg AND a.date = k.date
-          AND NOT EXISTS (
-            SELECT 1 FROM benchmark_results br
-            JOIN configs c ON c.id = br.config_id
-            WHERE c.model = a.model
-              AND br.isl IS NOT DISTINCT FROM a.isl
-              AND br.osl IS NOT DISTINCT FROM a.osl
-              AND c.precision = a.precision AND c.hardware = a.hardware
-              AND c.framework = a.framework AND c.spec_method = a.spec_method
-              AND c.disagg = a.disagg AND br.date = a.date AND br.error IS NULL
-          )
-      `;
-    }
 
     // Parent last (target the specific workflow_runs rows so partial purges
     // leave sibling attempts of the same github_run_id intact)
@@ -254,6 +267,46 @@ async function purge(wrIds: number[]): Promise<void> {
   });
 
   console.log(`    deleted.`);
+}
+
+interface BenchmarkPointPurgeTarget {
+  resultIds: number[];
+}
+
+/** Preview exact benchmark rows selected by an audited point override. */
+async function previewBenchmarkPointPurge(
+  point: PurgedBenchmarkPoint,
+): Promise<BenchmarkPointPurgeTarget | null> {
+  console.log(`  ${point.githubRunId} (attempt ${point.runAttempt})`);
+  const rows = await sql`
+    SELECT br.id
+    FROM benchmark_results br
+    JOIN workflow_runs wr ON wr.id = br.workflow_run_id
+    WHERE wr.github_run_id = ${point.githubRunId}
+      AND wr.run_attempt = ${point.runAttempt}
+      AND br.config_id = ${point.configId}
+      AND br.benchmark_type = ${point.benchmarkType}
+      AND br.isl IS NOT DISTINCT FROM ${point.isl}
+      AND br.osl IS NOT DISTINCT FROM ${point.osl}
+      AND br.conc = ${point.conc}
+      AND br.offload_mode = ${point.offloadMode}
+  `;
+  const description =
+    `config ${point.configId}, ${point.benchmarkType}, isl ${point.isl}, ` +
+    `osl ${point.osl}, conc ${point.conc}, offload ${point.offloadMode}`;
+  if (rows.length === 0) {
+    console.log(`    ${description}, not in DB, skipping.`);
+    return null;
+  }
+  console.log(`    ${description}, ${rows.length} benchmark row(s).`);
+  return { resultIds: rows.map((row) => row.id as number) };
+}
+
+async function purgeBenchmarkPoints(resultIds: number[]): Promise<void> {
+  await sql.begin(async (_tx) => {
+    await purgeBenchmarkResults(_tx as unknown as Sql, resultIds);
+  });
+  console.log(`    deleted ${resultIds.length} benchmark point(s).`);
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -300,6 +353,26 @@ async function main(): Promise<void> {
   }
   if (found.length > 0) hasWork = true;
 
+  const pointTargets: BenchmarkPointPurgeTarget[] = [];
+  if (PURGED_BENCHMARK_POINTS.length > 0) {
+    console.log(`\n  Benchmark point purge targets (${PURGED_BENCHMARK_POINTS.length}):`);
+    for (const point of PURGED_BENCHMARK_POINTS) {
+      if (PURGED_RUNS.has(point.githubRunId)) {
+        console.log(`  ${point.githubRunId}, already in PURGED_RUNS, skipping point purge.`);
+        continue;
+      }
+      if (PURGED_RUN_ATTEMPTS.get(point.githubRunId)?.has(point.runAttempt)) {
+        console.log(
+          `  ${point.githubRunId} attempt ${point.runAttempt}, already purged, skipping point purge.`,
+        );
+        continue;
+      }
+      const result = await previewBenchmarkPointPurge(point);
+      if (result) pointTargets.push(result);
+    }
+  }
+  if (pointTargets.length > 0) hasWork = true;
+
   if (!hasWork) {
     console.log('\n  Nothing to do.');
     return;
@@ -324,6 +397,13 @@ async function main(): Promise<void> {
     console.log('\n  Purging runs...');
     for (const { wrIds } of found) {
       await purge(wrIds);
+    }
+  }
+
+  if (pointTargets.length > 0) {
+    console.log('\n  Purging benchmark points...');
+    for (const { resultIds } of pointTargets) {
+      await purgeBenchmarkPoints(resultIds);
     }
   }
 

--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -158,6 +158,8 @@ describe('isBenchmarkPointPurged', () => {
 
     try {
       expect(isBenchmarkPointPurged(point.githubRunId, point.runAttempt, point)).toBe(true);
+      expect(isBenchmarkPointPurged(point.githubRunId, undefined, point)).toBe(true);
+      expect(isBenchmarkPointPurged(point.githubRunId, null, point)).toBe(true);
       expect(isBenchmarkPointPurged(point.githubRunId, 2, point)).toBe(false);
       expect(isBenchmarkPointPurged(2, point.runAttempt, point)).toBe(false);
       expect(

--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+  type PurgedBenchmarkPoint,
   CONCLUSION_OVERRIDES,
+  PURGED_BENCHMARK_POINTS,
   PURGED_RUN_ATTEMPTS,
   PURGED_RUNS,
+  isBenchmarkPointPurged,
   isRunAttemptPurged,
 } from './run-overrides';
 
@@ -72,6 +75,42 @@ describe('PURGED_RUN_ATTEMPTS', () => {
   });
 });
 
+describe('PURGED_BENCHMARK_POINTS', () => {
+  it('uses complete, valid point identities and no run-level purge overlaps', () => {
+    const unique = new Set<string>();
+    for (const point of PURGED_BENCHMARK_POINTS) {
+      expect(point.githubRunId).toBeGreaterThan(0);
+      expect(Number.isInteger(point.githubRunId)).toBe(true);
+      expect(point.runAttempt).toBeGreaterThan(0);
+      expect(Number.isInteger(point.runAttempt)).toBe(true);
+      expect(PURGED_RUNS.has(point.githubRunId)).toBe(false);
+      expect(CONCLUSION_OVERRIDES.has(point.githubRunId)).toBe(false);
+      expect(PURGED_RUN_ATTEMPTS.get(point.githubRunId)?.has(point.runAttempt) ?? false).toBe(
+        false,
+      );
+      expect(point.configId).toBeGreaterThan(0);
+      expect(Number.isInteger(point.configId)).toBe(true);
+      expect(point.benchmarkType).not.toBe('');
+      expect(point.isl === null || point.isl > 0).toBe(true);
+      expect(point.osl === null || point.osl > 0).toBe(true);
+      expect(point.conc).toBeGreaterThan(0);
+      expect(point.offloadMode).not.toBe('');
+      const identity = [
+        point.githubRunId,
+        point.runAttempt,
+        point.configId,
+        point.benchmarkType,
+        point.isl,
+        point.osl,
+        point.conc,
+        point.offloadMode,
+      ].join('|');
+      expect(unique.has(identity), `duplicate point override: ${identity}`).toBe(false);
+      unique.add(identity);
+    }
+  });
+});
+
 describe('isRunAttemptPurged', () => {
   it('returns true for runs in PURGED_RUNS regardless of attempt', () => {
     const [first] = PURGED_RUNS;
@@ -99,5 +138,39 @@ describe('isRunAttemptPurged', () => {
   it('returns false for runs that are not purged', () => {
     expect(isRunAttemptPurged(1, 1)).toBe(false);
     expect(isRunAttemptPurged(1)).toBe(false);
+  });
+});
+
+describe('isBenchmarkPointPurged', () => {
+  it('matches the full point identity within the selected run attempt', () => {
+    const point: PurgedBenchmarkPoint = {
+      githubRunId: 1,
+      runAttempt: 1,
+      configId: 1,
+      benchmarkType: 'single_turn',
+      isl: 1024,
+      osl: 1024,
+      conc: 1,
+      offloadMode: 'none',
+    };
+    const registry = PURGED_BENCHMARK_POINTS as PurgedBenchmarkPoint[];
+    registry.push(point);
+
+    try {
+      expect(isBenchmarkPointPurged(point.githubRunId, point.runAttempt, point)).toBe(true);
+      expect(isBenchmarkPointPurged(point.githubRunId, 2, point)).toBe(false);
+      expect(isBenchmarkPointPurged(2, point.runAttempt, point)).toBe(false);
+      expect(
+        isBenchmarkPointPurged(point.githubRunId, point.runAttempt, { ...point, conc: 2 }),
+      ).toBe(false);
+      expect(
+        isBenchmarkPointPurged(point.githubRunId, point.runAttempt, {
+          ...point,
+          offloadMode: 'cpu',
+        }),
+      ).toBe(false);
+    } finally {
+      registry.splice(registry.indexOf(point), 1);
+    }
   });
 });

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -15,6 +15,10 @@
  *   Use this when a single attempt produced bad data but a later attempt is expected to succeed
  *   (or has already succeeded), so we can't nuke the entire run.
  *
+ * PURGED_BENCHMARK_POINTS, purge individual benchmark rows from an otherwise valid
+ * run attempt and skip them on every future ingest. Each entry uses the row's durable
+ * database natural key, which can be queried from the linked dashboard point.
+ *
  * Note: GitHub deletes old workflow runs over time so these overrides may not be applicable forever,
  *       but we should keep them around for historical reference. You can find these on github (if available) by filling
  *       in the run id into the following link: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/{run_id_here}
@@ -80,6 +84,46 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
 ]);
+
+export interface BenchmarkPointKey {
+  configId: number;
+  benchmarkType: string;
+  isl: number | null;
+  osl: number | null;
+  conc: number;
+  offloadMode: string;
+}
+
+export interface PurgedBenchmarkPoint extends BenchmarkPointKey {
+  githubRunId: number;
+  runAttempt: number;
+}
+
+/**
+ * Individual benchmark rows to skip on ingest and delete from the DB.
+ * Keep a dated reason comment beside every entry for auditability:
+ * `{ githubRunId, runAttempt, configId, benchmarkType, isl, osl, conc, offloadMode }`.
+ */
+export const PURGED_BENCHMARK_POINTS: readonly PurgedBenchmarkPoint[] = [];
+
+/** True when this exact benchmark result is suppressed for a run attempt. */
+export function isBenchmarkPointPurged(
+  githubRunId: number,
+  runAttempt: number,
+  point: BenchmarkPointKey,
+): boolean {
+  return PURGED_BENCHMARK_POINTS.some(
+    (candidate) =>
+      candidate.githubRunId === githubRunId &&
+      candidate.runAttempt === runAttempt &&
+      candidate.configId === point.configId &&
+      candidate.benchmarkType === point.benchmarkType &&
+      candidate.isl === point.isl &&
+      candidate.osl === point.osl &&
+      candidate.conc === point.conc &&
+      candidate.offloadMode === point.offloadMode,
+  );
+}
 
 /**
  * True when the (run, attempt) pair should be skipped on ingest. Pass `runAttempt`

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -106,16 +106,19 @@ export interface PurgedBenchmarkPoint extends BenchmarkPointKey {
  */
 export const PURGED_BENCHMARK_POINTS: readonly PurgedBenchmarkPoint[] = [];
 
-/** True when this exact benchmark result is suppressed for a run attempt. */
+/**
+ * True when this exact benchmark result is suppressed. When an ingest source
+ * cannot determine the attempt, match the point across every attempt of its run.
+ */
 export function isBenchmarkPointPurged(
   githubRunId: number,
-  runAttempt: number,
+  runAttempt: number | null | undefined,
   point: BenchmarkPointKey,
 ): boolean {
   return PURGED_BENCHMARK_POINTS.some(
     (candidate) =>
       candidate.githubRunId === githubRunId &&
-      candidate.runAttempt === runAttempt &&
+      (runAttempt === null || runAttempt === undefined || candidate.runAttempt === runAttempt) &&
       candidate.configId === point.configId &&
       candidate.benchmarkType === point.benchmarkType &&
       candidate.isl === point.isl &&

--- a/packages/db/src/ingest-ci-run.ts
+++ b/packages/db/src/ingest-ci-run.ts
@@ -35,7 +35,7 @@ import {
   listRunArtifacts,
 } from './lib/github-artifacts';
 import { createAdminSql, refreshLatestBenchmarks } from './etl/db-utils';
-import { isRunAttemptPurged } from './etl/run-overrides';
+import { isBenchmarkPointPurged, isRunAttemptPurged } from './etl/run-overrides';
 import { createSkipTracker } from './etl/skip-tracker';
 import { createConfigCache } from './etl/config-cache';
 import { createWorkflowRunServices } from './etl/workflow-run';
@@ -466,6 +466,22 @@ async function main(): Promise<void> {
       for (const row of rows) {
         try {
           const configId = await getOrCreateConfig(row.config);
+          if (
+            isBenchmarkPointPurged(runIdNum, runAttemptNum, {
+              configId,
+              benchmarkType: row.benchmarkType,
+              isl: row.isl,
+              osl: row.osl,
+              conc: row.conc,
+              offloadMode: row.offloadMode,
+            })
+          ) {
+            console.log(
+              `    skipped purged benchmark point: config ${configId}, ${row.benchmarkType}, ` +
+                `isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, offload ${row.offloadMode}`,
+            );
+            continue;
+          }
           toInsert.push({ ...row, configId });
         } catch (error: any) {
           tracker.recordDbError(`config for ${path.basename(file)}`, error);

--- a/packages/db/src/ingest-gcs-backup.ts
+++ b/packages/db/src/ingest-gcs-backup.ts
@@ -32,7 +32,7 @@ import path from 'path';
 
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils';
 import { createAdminSql, refreshLatestBenchmarks } from './etl/db-utils';
-import { PURGED_RUNS } from './etl/run-overrides';
+import { isBenchmarkPointPurged, PURGED_RUNS } from './etl/run-overrides';
 import { createSkipTracker, type Skips } from './etl/skip-tracker';
 import { GPU_KEYS, parseIslOsl } from './etl/normalizers';
 import { createConfigCache } from './etl/config-cache';
@@ -581,12 +581,31 @@ async function main(): Promise<void> {
     });
     if (workflowRunId === null) return wr;
 
+    const runAttempt = result.ghInfo?.runAttempt ?? 0;
+
     const allInserted: (BenchmarkParams & { configId: number })[] = [];
     for (const { zipFile, rows, serverLogPath } of result.bmkZips) {
       const toInsert: (BenchmarkParams & { configId: number })[] = [];
       for (const row of rows) {
         try {
           const configId = await getOrCreateConfig(row.config);
+          if (
+            isBenchmarkPointPurged(result.githubRunId, runAttempt, {
+              configId,
+              benchmarkType: row.benchmarkType,
+              isl: row.isl,
+              osl: row.osl,
+              conc: row.conc,
+              offloadMode: row.offloadMode,
+            })
+          ) {
+            console.log(
+              `  [${result.dateDir}] skipped purged benchmark point: config ${configId}, ` +
+                `${row.benchmarkType}, isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, ` +
+                `offload ${row.offloadMode}`,
+            );
+            continue;
+          }
           toInsert.push({ ...row, configId });
         } catch (error: any) {
           tracker.recordDbError(`config for ${zipFile}`, error);

--- a/packages/db/src/ingest-gcs-backup.ts
+++ b/packages/db/src/ingest-gcs-backup.ts
@@ -581,8 +581,6 @@ async function main(): Promise<void> {
     });
     if (workflowRunId === null) return wr;
 
-    const runAttempt = result.ghInfo?.runAttempt ?? 0;
-
     const allInserted: (BenchmarkParams & { configId: number })[] = [];
     for (const { zipFile, rows, serverLogPath } of result.bmkZips) {
       const toInsert: (BenchmarkParams & { configId: number })[] = [];
@@ -590,7 +588,7 @@ async function main(): Promise<void> {
         try {
           const configId = await getOrCreateConfig(row.config);
           if (
-            isBenchmarkPointPurged(result.githubRunId, runAttempt, {
+            isBenchmarkPointPurged(result.githubRunId, result.ghInfo?.runAttempt, {
               configId,
               benchmarkType: row.benchmarkType,
               isl: row.isl,


### PR DESCRIPTION
## Summary
- add an auditable, exact-match registry for individual benchmark point purges
- delete selected rows, orphaned sidecars, and stale availability entries through `db:apply-overrides`
- prevent CI and GCS re-ingestion from restoring suppressed points
- add no purge entries and make no database mutation

## Verification
- `bunx oxfmt --check packages/db/src/etl/run-overrides.ts packages/db/src/etl/run-overrides.test.ts packages/db/src/ingest-ci-run.ts packages/db/src/ingest-gcs-backup.ts packages/db/src/apply-overrides.ts`
- `bun run typecheck`
- `bunx vitest run packages/db/src/etl/run-overrides.test.ts` (22 tests)

## 中文说明
- 新增可审计的精确匹配 registry，用于删除单个 benchmark 点
- 通过 `db:apply-overrides` 删除选定记录、孤立 sidecar 和过期 availability 条目
- 阻止 CI 与 GCS 重跑时重新写入已删除的点
- 本 PR 未添加任何删除条目，也未执行数据库写入

## 验证
- 已通过上述格式检查、TypeScript 类型检查和 22 个 override 单元测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark data deletion and ingest filtering paths; mistakes could drop valid points or leave availability inconsistent, though preview/confirm, transactions, and an empty initial registry limit immediate blast radius.
> 
> **Overview**
> Introduces **granular benchmark point suppression** alongside existing whole-run and per-attempt purges. Operators record removals in `PURGED_BENCHMARK_POINTS` using the full natural key (`githubRunId`, `runAttempt`, `configId`, `benchmarkType`, `isl`, `osl`, `conc`, `offloadMode`); the list ships **empty** in this PR.
> 
> **`db:apply-overrides`** gains a fourth phase: preview and delete matching `benchmark_results` rows via shared **`purgeBenchmarkResults`** (orphaned server logs, trace-replay sidecars, and stale `availability` when no successful row remains). Whole-run purge reuses that helper instead of inlined delete logic.
> 
> **CI ingest** (`ingest-ci-run`) and **GCS backfill** (`ingest-gcs-backup`) call **`isBenchmarkPointPurged`** after config resolution so suppressed points are not re-inserted. GCS uses exact attempt when GitHub metadata is available; when attempt is unknown, the same point identity can match across attempts (documented conservative behavior).
> 
> Tests cover registry invariants and `isBenchmarkPointPurged` matching; **`docs/data-pipeline.md`** documents the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6185627057750a86274a34289dbb9271ea223d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->