### PR TITLE
Update CollectiveX run controls

### DIFF
--- a/docs/collectivex.md
+++ b/docs/collectivex.md
@@ -82,11 +82,13 @@ their combined series.
 
 Series ids are namespaced by GitHub Actions run id so the same matrix case from two runs remains
 independently toggleable. Configuration color stays consistent across runs; run identity is encoded
-as a stable, non-repeating line dash pattern shown in both the run table and legend, keeping run ids
-out of visible legend labels while retaining them in the legend item's accessible title.
+by the active selection order: the first checked run is solid and each additional checked run gets
+the next non-repeating dash pattern. Removing a run compacts those style slots, so a lone remaining
+run is always solid. Active patterns appear in both the run table and legend, keeping run ids out of
+visible legend labels while retaining them in the legend item's accessible title.
 The newest run with measured cases is checked by default; newer incomplete sweeps remain listed but
-cannot blank the initial explorer. Deletion is a row action in the run table and keeps the same
-tombstone semantics described above.
+cannot blank the initial explorer. Deletion is available per row or as one confirmed action for all
+currently shown runs; both paths keep the same tombstone semantics described above.
 
 ## The raw-rows exception
 

--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -228,10 +228,13 @@ describe('CollectiveX neutral run view', () => {
     );
     cy.get(
       `[data-testid="collectivex-run-line-style-${comparisonDataset.run.run_id}"] line`,
-    ).should('have.attr', 'stroke-dasharray', '9 4');
+    ).should('not.exist');
 
     cy.get(`[data-testid="collectivex-run-visible-${comparisonDataset.run.run_id}"]`).check();
     cy.wait('@comparisonRun');
+    cy.get(
+      `[data-testid="collectivex-run-line-style-${comparisonDataset.run.run_id}"] line`,
+    ).should('have.attr', 'stroke-dasharray', '9 4');
     cy.get('[data-testid="collectivex-explorer-chart"] .line-path')
       .should('have.length', 2)
       .then(($lines) => {
@@ -254,7 +257,26 @@ describe('CollectiveX neutral run view', () => {
       'contain.text',
       `#${comparisonDataset.run.run_id}`,
     );
-    cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 1);
+    cy.get(`[data-testid="collectivex-run-line-style-${runId}"]`).should('not.exist');
+    cy.get(
+      `[data-testid="collectivex-run-line-style-${comparisonDataset.run.run_id}"] line`,
+    ).should('not.have.attr', 'stroke-dasharray');
+    cy.get('[data-testid="collectivex-explorer-chart"] .line-path')
+      .should('have.length', 1)
+      .and('have.attr', 'stroke-dasharray', 'none');
+    cy.get('[data-testid="chart-legend"] [data-testid="legend-line-swatch"] line')
+      .should('have.length', 1)
+      .and('not.have.attr', 'stroke-dasharray');
+
+    // Re-selecting a run assigns it the next active slot instead of restoring a
+    // permanent run-specific pattern.
+    cy.get(`[data-testid="collectivex-run-visible-${runId}"]`).check();
+    cy.get('[data-testid="collectivex-explorer-chart"] .line-path')
+      .should('have.length', 2)
+      .then(($lines) => {
+        expect($lines.eq(0)).to.have.attr('stroke-dasharray', 'none');
+        expect($lines.eq(1)).to.have.attr('stroke-dasharray', '9 4');
+      });
   });
 
   it('defaults to the newest measured run when a newer incomplete run has no series', () => {
@@ -320,6 +342,51 @@ describe('CollectiveX run deletion', () => {
     cy.get(`[data-testid="collectivex-run-row-${runId}"]`).should('not.exist');
     cy.window().then((win) => {
       expect(win.localStorage.getItem(ADMIN_TOKEN_KEY)).to.eq('test-token');
+    });
+  });
+
+  it('deletes every shown run with one confirmation and one token prompt', () => {
+    const deletedRunIds = new Set<string>();
+    cy.intercept('GET', '/api/v1/collectivex/runs?*', (request) => {
+      request.reply({
+        body: {
+          version: 1,
+          runs: [dataset, comparisonDataset]
+            .filter((item) => !deletedRunIds.has(item.run.run_id))
+            .map(buildRunSummary),
+          discovery_complete: true,
+        },
+      });
+    }).as('runsAfterBulkDelete');
+    installRun(comparisonDataset, 'comparisonRunForDelete');
+    cy.intercept('DELETE', '/api/v1/collectivex/runs/*', (request) => {
+      expect(request.headers.authorization).to.eq('Bearer bulk-test-token');
+      deletedRunIds.add(request.url.split('/').at(-1) ?? '');
+      request.reply({ deleted: true });
+    }).as('deleteShownRun');
+
+    cy.reload();
+    cy.wait('@runsAfterBulkDelete');
+    cy.wait('@run');
+    cy.get(`[data-testid="collectivex-run-visible-${comparisonDataset.run.run_id}"]`).check();
+    cy.wait('@comparisonRunForDelete');
+    cy.window().then((win) => {
+      win.localStorage.removeItem(ADMIN_TOKEN_KEY);
+      cy.stub(win, 'confirm').as('bulkDeleteConfirm').returns(true);
+      cy.stub(win, 'prompt').as('bulkDeletePrompt').returns('bulk-test-token');
+    });
+
+    cy.get('[data-testid="collectivex-delete-shown-runs"]').click();
+    cy.wait('@deleteShownRun');
+    cy.wait('@deleteShownRun');
+    cy.get(`[data-testid="collectivex-run-row-${runId}"]`).should('not.exist');
+    cy.get(`[data-testid="collectivex-run-row-${comparisonDataset.run.run_id}"]`).should(
+      'not.exist',
+    );
+    cy.get('@bulkDeleteConfirm').should('have.been.calledOnce');
+    cy.get('@bulkDeletePrompt').should('have.been.calledOnce');
+    cy.then(() => {
+      expect(deletedRunIds).to.deep.eq(new Set([runId, comparisonDataset.run.run_id]));
     });
   });
 

--- a/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BookOpen, ExternalLink, Loader2, RefreshCw } from 'lucide-react';
+import { BookOpen, ExternalLink, Loader2, RefreshCw, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -128,11 +128,17 @@ const STRINGS = {
     payloadBandwidthNote:
       'Payload bandwidth is the full logical payload (incl. FP8 scale bytes) ÷ latency, per GPU — a derived rate over logical bytes, not physical link bandwidth. The tooltip β/α is a least-squares fit of latency vs bytes across the ladder (β = per-GPU bandwidth term, α = fixed overhead).',
     deleteRun: 'Delete run',
+    deleteShownRuns: 'Delete shown runs',
+    deletingShownRuns: 'Deleting shown runs…',
     deleteConfirm: (id: string) =>
       `Delete run #${id} from the dashboard database? This cannot be undone.`,
+    deleteShownConfirm: (ids: readonly string[]) =>
+      `Delete ${ids.length} shown ${ids.length === 1 ? 'run' : 'runs'} from the dashboard database? This cannot be undone.\n\n${ids.map((id) => `#${id}`).join('\n')}`,
     deleteTokenPrompt: 'Admin token required to delete runs:',
     deleteUnauthorized: 'Invalid admin token.',
     deleteFailed: 'Deleting the run failed. Try again.',
+    deleteShownFailed: (deleted: number, total: number) =>
+      `Deleted ${deleted} of ${total} shown runs before the operation failed. Try again.`,
   },
   zh: {
     operation: {
@@ -269,12 +275,17 @@ const STRINGS = {
     attemptLabel: 'Attempt',
     matrixLabel: 'Matrix',
     sourceBundles: '源产物包',
-    deleteRun: 'Delete run',
-    deleteConfirm: (id: string) =>
-      `Delete run #${id} from the dashboard database? This cannot be undone.`,
-    deleteTokenPrompt: 'Admin token required to delete runs:',
-    deleteUnauthorized: 'Invalid admin token.',
-    deleteFailed: 'Deleting the run failed. Try again.',
+    deleteRun: '删除运行',
+    deleteShownRuns: '删除已显示的运行',
+    deletingShownRuns: '正在删除已显示的运行…',
+    deleteConfirm: (id: string) => `从仪表板数据库中删除运行 #${id}？此操作无法撤销。`,
+    deleteShownConfirm: (ids: readonly string[]) =>
+      `从仪表板数据库中删除当前显示的 ${ids.length} 个运行？此操作无法撤销。\n\n${ids.map((id) => `#${id}`).join('\n')}`,
+    deleteTokenPrompt: '删除运行需要管理员令牌：',
+    deleteUnauthorized: '管理员令牌无效。',
+    deleteFailed: '删除运行失败，请重试。',
+    deleteShownFailed: (deleted: number, total: number) =>
+      `操作失败前已删除 ${total} 个已显示运行中的 ${deleted} 个，请重试。`,
   },
 } as const;
 const CONCLUSION_CLASSES: Record<string, string> = {
@@ -312,21 +323,22 @@ export default function CollectiveXDisplay() {
   const t = STRINGS[locale];
   const [version, setVersion] = useState<CollectiveXVersion>(COLLECTIVEX_DEFAULT_VERSION);
   const [visibleRunIds, setVisibleRunIds] = useState<Set<string>>(new Set());
+  const [bulkDeletingRunIds, setBulkDeletingRunIds] = useState<Set<string>>(new Set());
   const initializedVersionRef = useRef<CollectiveXVersion | null>(null);
   const runsQuery = useCollectiveXRuns(version);
   const runList = runsQuery.data?.runs ?? [];
-  const orderedVisibleRunIds = useMemo(
-    () => runList.filter((run) => visibleRunIds.has(run.run_id)).map((run) => run.run_id),
-    [runList, visibleRunIds],
-  );
+  const orderedVisibleRunIds = useMemo(() => {
+    const liveRunIds = new Set(runList.map((run) => run.run_id));
+    return [...visibleRunIds].filter((runId) => liveRunIds.has(runId));
+  }, [runList, visibleRunIds]);
   const runQueries = useCollectiveXRunDatasets(version, orderedVisibleRunIds);
   const datasets = useMemo(
     () => runQueries.flatMap((query) => (query.data ? [query.data] : [])),
     [runQueries],
   );
-  const runIndexById = useMemo(
-    () => new Map(runList.map((run, index) => [run.run_id, index])),
-    [runList],
+  const selectedRunIndexById = useMemo(
+    () => new Map(orderedVisibleRunIds.map((runId, index) => [runId, index])),
+    [orderedVisibleRunIds],
   );
   const combinedSeries = useMemo<CollectiveXRunSeries[]>(
     () =>
@@ -334,10 +346,10 @@ export default function CollectiveXDisplay() {
         collectiveXSeriesForRun(
           dataset.series,
           dataset.run.run_id,
-          runIndexById.get(dataset.run.run_id) ?? 0,
+          selectedRunIndexById.get(dataset.run.run_id) ?? 0,
         ),
       ),
-    [datasets, runIndexById],
+    [datasets, selectedRunIndexById],
   );
   const loadingRunIds = useMemo(
     () =>
@@ -568,6 +580,11 @@ export default function CollectiveXDisplay() {
     for (const query of runQueries) void query.refetch();
   }, [runQueries, runsQuery]);
   const deleteRun = useDeleteCollectiveXRun();
+  const deletingRunIds = useMemo(() => {
+    if (bulkDeletingRunIds.size > 0) return bulkDeletingRunIds;
+    const runId = deleteRun.isPending ? deleteRun.variables?.runId : undefined;
+    return new Set(runId ? [runId] : []);
+  }, [bulkDeletingRunIds, deleteRun.isPending, deleteRun.variables?.runId]);
   const handleVisibleRunChange = useCallback((runId: string, visible: boolean) => {
     setVisibleRunIds((previous) => {
       const next = new Set(previous);
@@ -605,6 +622,53 @@ export default function CollectiveXDisplay() {
     },
     [deleteRun, t],
   );
+  const handleDeleteShownRuns = useCallback(async () => {
+    const runIds = [...orderedVisibleRunIds];
+    if (runIds.length === 0) return;
+    track('collectivex_shown_runs_delete_prompted', { count: runIds.length, runs: runIds });
+    if (!window.confirm(t.deleteShownConfirm(runIds))) return;
+    const stored = localStorage.getItem(ADMIN_TOKEN_STORAGE_KEY) ?? '';
+    const token = stored || (window.prompt(t.deleteTokenPrompt)?.trim() ?? '');
+    if (!token) return;
+
+    setBulkDeletingRunIds(new Set(runIds));
+    let deletedCount = 0;
+    try {
+      for (const runId of runIds) {
+        const deleted = await deleteRun.mutateAsync({ runId, token });
+        if (!deleted) {
+          localStorage.removeItem(ADMIN_TOKEN_STORAGE_KEY);
+          track('collectivex_shown_runs_delete_failed', {
+            count: runIds.length,
+            deleted: deletedCount,
+            reason: 'unauthorized',
+          });
+          window.alert(t.deleteUnauthorized);
+          return;
+        }
+        deletedCount += 1;
+        setVisibleRunIds((previous) => {
+          const next = new Set(previous);
+          next.delete(runId);
+          return next;
+        });
+      }
+      localStorage.setItem(ADMIN_TOKEN_STORAGE_KEY, token);
+      track('collectivex_shown_runs_delete_confirmed', {
+        count: runIds.length,
+        runs: runIds,
+      });
+    } catch {
+      track('collectivex_shown_runs_delete_failed', {
+        count: runIds.length,
+        deleted: deletedCount,
+        reason: 'error',
+      });
+      window.alert(t.deleteShownFailed(deletedCount, runIds.length));
+    } finally {
+      setBulkDeletingRunIds(new Set());
+    }
+  }, [deleteRun, orderedVisibleRunIds, t]);
 
   if (runsQuery.isLoading) {
     return (
@@ -729,25 +793,42 @@ export default function CollectiveXDisplay() {
             <h2 className="text-lg font-semibold">{t.runsHeading}</h2>
             <p className="mt-1 text-sm text-muted-foreground">{t.runsDescription}</p>
           </div>
-          <div className="w-full md:w-44">
-            <SelectControl
-              label={t.version}
-              testId="collectivex-version-select"
-              value={version}
-              options={versionOptions}
-              onChange={(value) => {
-                setVersion(value);
-                track('collectivex_version_changed', { version: value });
-              }}
-            />
+          <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-end md:w-auto">
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              data-testid="collectivex-delete-shown-runs"
+              disabled={visibleRunIds.size === 0 || deletingRunIds.size > 0}
+              onClick={() => void handleDeleteShownRuns()}
+            >
+              {bulkDeletingRunIds.size > 0 ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Trash2 className="size-4" />
+              )}
+              {bulkDeletingRunIds.size > 0 ? t.deletingShownRuns : t.deleteShownRuns}
+            </Button>
+            <div className="w-full sm:w-44">
+              <SelectControl
+                label={t.version}
+                testId="collectivex-version-select"
+                value={version}
+                options={versionOptions}
+                onChange={(value) => {
+                  setVersion(value);
+                  track('collectivex_version_changed', { version: value });
+                }}
+              />
+            </div>
           </div>
         </div>
         <CollectiveXRunsTable
           runs={runList}
-          runIndexById={runIndexById}
+          selectedRunIndexById={selectedRunIndexById}
           visibleRunIds={visibleRunIds}
           loadingRunIds={loadingRunIds}
-          deletingRunId={deleteRun.isPending ? (deleteRun.variables?.runId ?? null) : null}
+          deletingRunIds={deletingRunIds}
           onVisibleChange={handleVisibleRunChange}
           onDelete={(runId) => void handleDeleteRun(runId)}
         />

--- a/packages/app/src/components/collectivex/CollectiveXRunsTable.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXRunsTable.tsx
@@ -12,10 +12,10 @@ import type { CollectiveXRunSummary } from './types';
 
 interface CollectiveXRunsTableProps {
   runs: CollectiveXRunSummary[];
-  runIndexById: ReadonlyMap<string, number>;
+  selectedRunIndexById: ReadonlyMap<string, number>;
   visibleRunIds: ReadonlySet<string>;
   loadingRunIds: ReadonlySet<string>;
-  deletingRunId: string | null;
+  deletingRunIds: ReadonlySet<string>;
   onVisibleChange: (runId: string, visible: boolean) => void;
   onDelete: (runId: string) => void;
 }
@@ -73,10 +73,10 @@ function formatDate(value: string, locale: 'en' | 'zh'): string {
 
 export function CollectiveXRunsTable({
   runs,
-  runIndexById,
+  selectedRunIndexById,
   visibleRunIds,
   loadingRunIds,
-  deletingRunId,
+  deletingRunIds,
   onVisibleChange,
   onDelete,
 }: CollectiveXRunsTableProps) {
@@ -109,9 +109,11 @@ export function CollectiveXRunsTable({
           {runs.map((run) => {
             const visible = visibleRunIds.has(run.run_id);
             const loading = loadingRunIds.has(run.run_id);
-            const deleting = deletingRunId === run.run_id;
+            const deleting = deletingRunIds.has(run.run_id);
             const conclusion = run.conclusion ?? t.pending;
-            const lineDasharray = collectiveXRunDasharray(runIndexById.get(run.run_id) ?? 0);
+            const selectedRunIndex = selectedRunIndexById.get(run.run_id);
+            const lineDasharray =
+              selectedRunIndex === undefined ? null : collectiveXRunDasharray(selectedRunIndex);
             return (
               <tr
                 key={run.run_id}
@@ -126,6 +128,7 @@ export function CollectiveXRunsTable({
                     <input
                       type="checkbox"
                       checked={visible}
+                      disabled={deletingRunIds.size > 0}
                       aria-label={t.showRun(run.run_id)}
                       data-testid={`collectivex-run-visible-${run.run_id}`}
                       onChange={(event) => {
@@ -143,24 +146,28 @@ export function CollectiveXRunsTable({
                 </td>
                 <td className="px-3 py-1.5 font-mono text-xs">
                   <div className="flex items-center gap-2">
-                    <svg
-                      width="24"
-                      height="10"
-                      viewBox="0 0 24 10"
-                      aria-label={t.lineStyle(run.run_id)}
-                      data-testid={`collectivex-run-line-style-${run.run_id}`}
-                      className="shrink-0 text-foreground"
-                    >
-                      <line
-                        x1="1"
-                        y1="5"
-                        x2="23"
-                        y2="5"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeDasharray={lineDasharray === 'none' ? undefined : lineDasharray}
-                      />
-                    </svg>
+                    {lineDasharray === null ? (
+                      <span aria-hidden className="block h-[10px] w-6 shrink-0" />
+                    ) : (
+                      <svg
+                        width="24"
+                        height="10"
+                        viewBox="0 0 24 10"
+                        aria-label={t.lineStyle(run.run_id)}
+                        data-testid={`collectivex-run-line-style-${run.run_id}`}
+                        className="shrink-0 text-foreground"
+                      >
+                        <line
+                          x1="1"
+                          y1="5"
+                          x2="23"
+                          y2="5"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeDasharray={lineDasharray === 'none' ? undefined : lineDasharray}
+                        />
+                      </svg>
+                    )}
                     <a
                       href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${run.run_id}`}
                       target="_blank"
@@ -205,7 +212,7 @@ export function CollectiveXRunsTable({
                     size="icon"
                     aria-label={t.deleteRun(run.run_id)}
                     data-testid={`collectivex-delete-run-${run.run_id}`}
-                    disabled={deletingRunId !== null}
+                    disabled={deletingRunIds.size > 0}
                     onClick={() => onDelete(run.run_id)}
                     className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                   >

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -124,7 +124,7 @@ describe('collectiveXSeriesForRun', () => {
 });
 
 describe('collectiveXRunDasharray', () => {
-  it('uses a solid line for the newest run and distinct patterns for following runs', () => {
+  it('uses a solid line for the first selected run and distinct patterns for following runs', () => {
     expect(collectiveXRunDasharray(0)).toBe('none');
     expect(collectiveXRunDasharray(1)).toBe('9 4');
     expect(collectiveXRunDasharray(2)).toBe('3 3');

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -67,7 +67,7 @@ export function collectiveXColorKey(series: CollectiveXSeries | CollectiveXRunSe
   return `${series.system.vendor}_${series.system.sku}_${series.backend}_ep${series.system.ep_size}_${series.mode}_${series.phase}_${series.precision}`;
 }
 
-/** Namespace series ids and attach the run's stable visual-style index. */
+/** Namespace series ids and attach the run's current selection-order style index. */
 export function collectiveXSeriesForRun(
   series: readonly CollectiveXSeries[],
   runId: string,

--- a/packages/app/src/components/collectivex/types.ts
+++ b/packages/app/src/components/collectivex/types.ts
@@ -53,7 +53,7 @@ export interface CollectiveXChartPoint {
   point: CollectiveXPoint;
 }
 
-/** A stored run's series with namespaced identity and visual-style index. */
+/** A stored run's series with namespaced identity and selection-order visual-style index. */
 export type CollectiveXRunSeries = CollectiveXSeries & {
   run_id: string;
   run_index: number;


### PR DESCRIPTION
Use selection-order line styles and add bulk deletion for shown runs.

Tests: lint, format, typecheck, unit, CollectiveX E2E.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes are confined to CollectiveX UI and reuse existing authenticated DELETE endpoints, but bulk delete increases blast radius if misused and alters multi-run comparison visuals that users may rely on.
> 
> **Overview**
> **Multi-run chart styling** now follows **checkbox selection order**, not fixed table position: the first checked run is solid, each additional checked run gets the next dash pattern, and patterns **compact** when runs are unchecked (a single remaining run is always solid). Unchecked runs no longer show a line-style swatch in the runs table; re-checking a run picks the next active slot instead of restoring a permanent per-run pattern. Legend and chart behavior stay aligned with this model.
> 
> **Bulk deletion** adds a **Delete shown runs** control that tombstones every currently checked run after one confirm dialog and one admin token prompt, reusing the existing per-run DELETE API sequentially with partial-failure messaging. While any delete is in progress, run visibility checkboxes and row delete actions are disabled; Chinese copy for delete flows is filled in where it was previously English placeholders.
> 
> Documentation (`docs/collectivex.md`) and Cypress coverage are updated for the new styling rules and bulk-delete flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c597485a192a36a2df54885cd6b3874826058696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->