### PR TITLE
Use 8 vCPU Blacksmith runner for agentic ingest / Agentic ingest 改用 Blacksmith 8 vCPU runner

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -98,7 +98,7 @@ jobs:
     # High-concurrency rows also precompute request timelines from GiB-scale
     # artifacts, so retain enough headroom for a complete recovered sweep.
     timeout-minutes: 180
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
     env:


### PR DESCRIPTION
## Summary

- Move the agentic benchmark ingestion job from `blacksmith-4vcpu-ubuntu-2404` to `blacksmith-8vcpu-ubuntu-2404`.
- Increase the runner's advertised storage from 80 GB to 160 GB.

## Why

Staging run `30941098639` failed while preparing artifacts because the runner ran out of disk space. The selected artifacts are 3.064 GB compressed but expand to 102.039 GB (95.032 GiB), with a measured artifact-only peak of 95.050 GiB. The current 4 vCPU runner provides only 80 GB total storage, so this ingest cannot fit even before checkout and dependency overhead.

## Validation

- `lefthook` pre-commit checks
  - lint
  - format
  - typecheck
- Confirmed `blacksmith-8vcpu-ubuntu-2404` is a supported Blacksmith runner with 160 GB storage.

## 中文说明

### 变更摘要

- 将 agentic 基准测试摄取任务从 `blacksmith-4vcpu-ubuntu-2404` 调整为 `blacksmith-8vcpu-ubuntu-2404`。
- Runner 标称存储空间从 80 GB 提升至 160 GB。

### 变更原因

Staging run `30941098639` 在准备产物时因磁盘空间耗尽而失败。所选产物压缩后为 3.064 GB，解压后达到 102.039 GB（95.032 GiB），仅产物的实测峰值占用为 95.050 GiB。当前 4 vCPU runner 总存储空间仅为 80 GB，因此即使尚未计入代码检出和依赖安装的额外空间，该摄取任务也无法完成。

### 验证

- 通过 `lefthook` pre-commit 检查
  - lint
  - format
  - typecheck
- 已确认 `blacksmith-8vcpu-ubuntu-2404` 是 Blacksmith 支持的 runner，提供 160 GB 存储空间。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `runs-on` label change in one workflow; ingest behavior is unchanged and the 8 vCPU runner is already used elsewhere in CI.
> 
> **Overview**
> The agentic benchmark ingest job in `ingest-agentic-results.yml` now runs on **`blacksmith-8vcpu-ubuntu-2404`** instead of **`blacksmith-4vcpu-ubuntu-2404`**. No other workflow steps, timeouts, or ingest logic change.
> 
> That swap roughly doubles runner disk (about 160 GB vs 80 GB on the 4 vCPU label), which is needed because agentic ingests download and expand GiB-scale trace-replay artifacts during **Prepare artifacts from InferenceX**—staging had already failed on disk during that step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f21a17bdf8a8b1e6074a74b0af1a8d3ebd4df992. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->