### PR TITLE
Use 16 vCPU Blacksmith runner for agentic ingest / Agentic ingest 改用 Blacksmith 16 vCPU runner

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -98,7 +98,7 @@ jobs:
     # High-concurrency rows also precompute request timelines from GiB-scale
     # artifacts, so retain enough headroom for a complete recovered sweep.
     timeout-minutes: 180
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     permissions:
       contents: read
     env:


### PR DESCRIPTION
## Summary

- Move the agentic benchmark ingestion job from `blacksmith-8vcpu-ubuntu-2404` to `blacksmith-16vcpu-ubuntu-2404`.
- Increase advertised runner storage from 160 GB to 750 GB.

## Why

Staging run `30944659802` successfully downloaded and extracted the outer GitHub artifacts on the 8 vCPU runner, then ran out of disk during `Ingest results to DB` while unpacking nested `multinode_server_logs.tar.gz` archives.

The complete measured artifact footprint is approximately:

- 102.039 GB from the outer GitHub artifacts
- 99.643 GB from nested archive extraction
- 201.683 GB total (187.832 GiB), before dependencies and runner-image overhead

The 8 vCPU runner provides only 160 GB total storage. The 16 vCPU runner provides 750 GB and leaves sufficient headroom for this ingestion path.

## Validation

- `lefthook` pre-commit checks
  - lint
  - format
  - typecheck
- Confirmed `blacksmith-16vcpu-ubuntu-2404` provides 750 GB storage.

## 中文说明

### 变更摘要

- 将 agentic 基准测试摄取任务从 `blacksmith-8vcpu-ubuntu-2404` 调整为 `blacksmith-16vcpu-ubuntu-2404`。
- Runner 标称存储空间从 160 GB 提升至 750 GB。

### 变更原因

Staging run `30944659802` 在 8 vCPU runner 上成功下载并解压了外层 GitHub 产物，但在 `Ingest results to DB` 阶段解压嵌套的 `multinode_server_logs.tar.gz` 时耗尽磁盘空间。

完整产物路径的实测磁盘占用约为：

- 外层 GitHub 产物：102.039 GB
- 嵌套归档解压：99.643 GB
- 合计：201.683 GB（187.832 GiB），尚未计入依赖和 runner 镜像开销

8 vCPU runner 总存储空间仅为 160 GB。16 vCPU runner 提供 750 GB，可为该摄取流程保留充足余量。

### 验证

- 通过 `lefthook` pre-commit 检查
  - lint
  - format
  - typecheck
- 已确认 `blacksmith-16vcpu-ubuntu-2404` 提供 750 GB 存储空间。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI runner label change with no application or database logic touched; main effect is higher runner cost and more disk headroom.
> 
> **Overview**
> The **Ingest agentic benchmark results** job now runs on **`blacksmith-16vcpu-ubuntu-2404`** instead of **`blacksmith-8vcpu-ubuntu-2404`**. No other workflow steps, timeouts, or ingest logic change.
> 
> This addresses staging failures where outer artifacts downloaded successfully but **`Ingest results to DB`** ran out of disk while unpacking nested archives (on the order of ~200 GB total footprint vs 160 GB on the 8 vCPU runner). The 16 vCPU label provides **750 GB** storage for the blob-heavy agentic path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef44939d2683b23f8bd0aaa425fb564de1562d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->