### PR TITLE
chore(nav): move CollectiveX into the Hidden tab menu / 将 CollectiveX 移入隐藏标签菜单

### DIFF
--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -72,11 +72,6 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
       'href',
       '/submissions?unofficialruns=12345',
     );
-    cy.get('[data-testid="tab-trigger-collectivex"]').should(
-      'have.attr',
-      'href',
-      '/collectivex?unofficialruns=12345',
-    );
     cy.get('[data-testid="tab-trigger-historical"]').should(
       'have.attr',
       'href',
@@ -116,11 +111,11 @@ describe('TabNav — Hidden popover for gated tabs', () => {
     mountTabNav({});
     cy.get('[data-testid="tab-trigger-inference"]').should('exist');
     cy.get('[data-testid="tab-trigger-gpu-specs"]').should('exist');
-    cy.get('[data-testid="tab-trigger-collectivex"]').should('exist');
     cy.get('[data-testid="tab-trigger-submissions"]').should('exist');
     cy.get('[data-testid="tab-trigger-hidden"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-feedback"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('not.exist');
+    cy.get('[data-testid="tab-trigger-collectivex"]').should('not.exist');
   });
 
   it('renders the Hidden trigger when unlocked; popover reveals gated links', () => {
@@ -129,9 +124,11 @@ describe('TabNav — Hidden popover for gated tabs', () => {
     cy.get('[data-testid="tab-trigger-hidden"]').should('be.visible').and('contain.text', 'Hidden');
     // Gated links are inside the closed popover, so they're not yet in the DOM.
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('not.exist');
+    cy.get('[data-testid="tab-trigger-collectivex"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-submissions"]').should('have.attr', 'href', '/submissions');
     cy.get('[data-testid="tab-trigger-hidden"]').click();
     cy.get('[data-testid="tab-hidden-popover"]').should('be.visible');
+    cy.get('[data-testid="tab-trigger-collectivex"]').should('have.attr', 'href', '/collectivex');
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('have.attr', 'href', '/ai-chart');
     cy.get('[data-testid="tab-trigger-gpu-metrics"]').should('have.attr', 'href', '/gpu-metrics');
     cy.get('[data-testid="tab-hidden-popover"]')
@@ -149,11 +146,22 @@ describe('TabNav — Hidden popover for gated tabs', () => {
       'href',
       '/feedback?unofficialruns=42',
     );
+    cy.get('[data-testid="tab-trigger-collectivex"]').should(
+      'have.attr',
+      'href',
+      '/collectivex?unofficialruns=42',
+    );
   });
 
   it('highlights the Hidden trigger when the current path is one of the gated tabs', () => {
     cy.window().then((win) => win.localStorage.setItem('inferencex-feature-gate', '1'));
     mountTabNav({ pathname: '/feedback' });
+    cy.get('[data-testid="tab-trigger-hidden"]').should('have.class', 'border-secondary');
+  });
+
+  it('highlights the Hidden trigger on /collectivex, which is now gated', () => {
+    cy.window().then((win) => win.localStorage.setItem('inferencex-feature-gate', '1'));
+    mountTabNav({ pathname: '/collectivex' });
     cy.get('[data-testid="tab-trigger-hidden"]').should('have.class', 'border-secondary');
   });
 

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -31,11 +31,11 @@ const VISIBLE_TABS = [
   { href: '/historical', label: 'Historical Trends', testId: 'tab-trigger-historical' },
   { href: '/calculator', label: 'TCO Calculator', testId: 'tab-trigger-calculator' },
   { href: '/gpu-specs', label: 'Chip Specs', testId: 'tab-trigger-gpu-specs' },
-  { href: '/collectivex', label: 'CollectiveX', testId: 'tab-trigger-collectivex' },
   { href: '/submissions', label: 'Submissions', testId: 'tab-trigger-submissions' },
 ] as const;
 
 const GATED_TABS = [
+  { href: '/collectivex', label: 'CollectiveX', testId: 'tab-trigger-collectivex' },
   { href: '/ai-chart', label: 'AI Chart', testId: 'tab-trigger-ai-chart' },
   { href: '/gpu-metrics', label: 'PowerX', testId: 'tab-trigger-gpu-metrics' },
   {


### PR DESCRIPTION
## Summary

Moves the **CollectiveX** dashboard tab out of the always-visible tab row and into the feature-gated **Hidden** popover, next to AI Chart, PowerX, Images, and Feedback.

- `packages/app/src/components/tab-nav.tsx` — `/collectivex` moves from `VISIBLE_TABS` to `GATED_TABS` (placed first in the menu). This covers both nav surfaces at once, since desktop (`HiddenTabsPopover`) and mobile (the `Hidden` `SelectGroup`) both render from the same arrays.
- The entry now appears only after the ↑↑↓↓ konami unlock (`useFeatureGate`), and `/collectivex` now highlights the **Hidden** trigger instead of its own tab.

## What deliberately did NOT change

The `/collectivex` route itself is untouched — it stays reachable by URL, keeps its `/zh/collectivex` sibling, stays in `ZH_MIRRORED_ROUTES` / `sitemap.ts`, and keeps its `TAB_META` / `TAB_META_ZH` entries. This matches how PowerX (`/gpu-metrics`) is already handled: gated in the nav, still indexable. Only the navigation entry moved, so there is no SEO or routing change.

`DASHBOARD_TABS` in `header/header.tsx` already lists gated tabs (`/gpu-metrics`, `/current-inferencex-image`), so `/collectivex` continues to highlight the "Dashboard" header link.

## Tests

`packages/app/cypress/component/tab-nav.cy.tsx` updated for the new placement:

- gate locked → `tab-trigger-collectivex` must **not** exist (was asserting it did)
- gate unlocked, popover closed → not in the DOM; popover open → `href="/collectivex"`
- `?unofficialruns=42` is forwarded onto the CollectiveX link inside the popover
- new case: on `/collectivex`, the **Hidden** trigger carries the active `border-secondary` class

`cypress/e2e/collectivex.cy.ts` needs no change — it reaches the page via `cy.visit('/collectivex')`, not the tab.

Overlay note: this is nav chrome, not chart data, so there is no official/overlay code split to handle. The `unofficialruns` param preservation that `tab-nav` does for every tab is covered by the test above.

## 中文说明

将 **CollectiveX** 标签从常驻标签行移入受功能开关控制的 **Hidden**（隐藏）下拉菜单，与 AI Chart、PowerX、Images、Feedback 并列。

- `packages/app/src/components/tab-nav.tsx` — `/collectivex` 从 `VISIBLE_TABS` 移至 `GATED_TABS`（置于菜单首位）。桌面端（`HiddenTabsPopover`）与移动端（`Hidden` 分组的 `SelectGroup`）共用同一数组，因此一处改动即可覆盖两种导航形态。
- 该入口现在仅在 ↑↑↓↓ konami 解锁后（`useFeatureGate`）显示；访问 `/collectivex` 时高亮的是 **Hidden** 触发器，而非独立标签。

**刻意保持不变的部分：** `/collectivex` 路由本身未作改动——仍可通过 URL 访问，保留 `/zh/collectivex` 中文页面，继续留在 `ZH_MIRRORED_ROUTES` 与 `sitemap.ts` 中，`TAB_META` / `TAB_META_ZH` 条目也照旧。这与 PowerX（`/gpu-metrics`）现有的处理方式一致：导航中隐藏，但仍可被索引。此次仅移动导航入口，不涉及 SEO 或路由变更。`header/header.tsx` 中的 `DASHBOARD_TABS` 本就包含隐藏标签，因此 `/collectivex` 仍会高亮页头的 "Dashboard" 链接。

**测试：** `tab-nav.cy.tsx` 已按新位置更新——开关锁定时 `tab-trigger-collectivex` 不应存在；解锁后弹层关闭时不在 DOM 中、展开后 `href="/collectivex"`；`?unofficialruns=42` 正确透传到弹层内的 CollectiveX 链接；新增用例验证在 `/collectivex` 页面上 **Hidden** 触发器带有 `border-secondary` 激活样式。`cypress/e2e/collectivex.cy.ts` 无需改动，因为它通过 `cy.visit('/collectivex')` 直接访问页面，不经过标签导航。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only change with no routing or auth impact; behavior is covered by updated component tests.
> 
> **Overview**
> **CollectiveX** is no longer a top-level tab; it now lives in the feature-gated **Hidden** menu (konami unlock), first among AI Chart, PowerX, Images, and Feedback. Desktop popover and mobile **Hidden** select group both read from `GATED_TABS`, so one array change covers both.
> 
> When the gate is locked, the CollectiveX nav trigger is absent; when unlocked, it appears only inside **Hidden**, and visiting `/collectivex` activates the **Hidden** trigger instead of a dedicated tab. The `/collectivex` route and direct URLs are unchanged.
> 
> Cypress `tab-nav` tests were updated for locked vs unlocked behavior, popover links, `unofficialruns` forwarding, and active styling on `/collectivex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d38937e8d31596eaa862e33fedd341a56e34ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->