### PR TITLE
fix(cache): bound Blob keys for bulk API requests / 限制批量 API 请求的 Blob 缓存键长度

### DIFF
--- a/packages/app/src/lib/api-cache.test.ts
+++ b/packages/app/src/lib/api-cache.test.ts
@@ -126,6 +126,39 @@ describe('cachedQuery', () => {
       expect(mockBlobSet).toHaveBeenCalledWith('bench:llama:2025-01-01', ['llama', '2025-01-01']);
     });
 
+    it('hashes oversized argument lists into a bounded deterministic key', async () => {
+      mockBlobGet.mockResolvedValue(null);
+      mockBlobSet.mockResolvedValue(undefined);
+      const fn = vi.fn((ids: number[]) => Promise.resolve(ids.length));
+      const wrapped = cachedQuery(fn, 'derived-agentic-metrics-v7', { blobOnly: true });
+      const ids = Array.from({ length: 200 }, (_, index) => 434_388 + index);
+
+      await wrapped(ids);
+      await wrapped(ids);
+
+      const firstKey = mockBlobGet.mock.calls[0]![0];
+      const secondKey = mockBlobGet.mock.calls[1]![0];
+      expect(firstKey).toBe(secondKey);
+      expect(firstKey).toMatch(/^derived-agentic-metrics-v7:sha256:[a-f0-9]{64}$/u);
+      expect(firstKey.length).toBeLessThan(128);
+      expect(mockBlobSet).toHaveBeenCalledWith(firstKey, 200);
+    });
+
+    it('serves a successful query result when the blob write fails', async () => {
+      mockBlobGet.mockResolvedValue(null);
+      mockBlobSet.mockRejectedValue(new Error('pathname is too long'));
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const fn = vi.fn((_ids: number[]) => Promise.resolve({ answer: 42 }));
+      const wrapped = cachedQuery(fn, 'derived-agentic-metrics-v7', { blobOnly: true });
+
+      await expect(wrapped([1, 2, 3])).resolves.toEqual({ answer: 42 });
+      expect(warn).toHaveBeenCalledWith(
+        '[blob cache] could not persist derived-agentic-metrics-v7; serving uncached result. pathname is too long',
+      );
+
+      warn.mockRestore();
+    });
+
     it('uses bare prefix when no args are passed', async () => {
       mockBlobGet.mockResolvedValue('cached');
       const fn = vi.fn(() => Promise.resolve('fresh'));

--- a/packages/app/src/lib/api-cache.ts
+++ b/packages/app/src/lib/api-cache.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import { revalidateTag, unstable_cache } from 'next/cache';
 import { blobGet, blobPurge, blobSet } from './blob-cache';
 
@@ -52,6 +54,21 @@ interface CachedQueryOptions {
   tag?: string;
 }
 
+// Leave room for BLOB_CACHE_PREFIX and the `.json` suffix in the final Vercel
+// Blob pathname. Short keys keep their existing human-readable form (and warm
+// cache entries); large argument lists use a fixed-size digest instead.
+const MAX_INLINE_BLOB_KEY_BYTES = 512;
+
+function blobKeyForArgs(keyPrefix: string, args: unknown[]): string {
+  if (args.length === 0) return keyPrefix;
+
+  const inlineKey = `${keyPrefix}:${args.join(':')}`;
+  if (Buffer.byteLength(inlineKey, 'utf8') <= MAX_INLINE_BLOB_KEY_BYTES) return inlineKey;
+
+  const digest = createHash('sha256').update(JSON.stringify(args)).digest('hex');
+  return `${keyPrefix}:sha256:${digest}`;
+}
+
 /**
  * Cache a function's result using unstable_cache (fast, local).
  * Set `blobOnly: true` for payloads known to exceed Next.js's 2MB unstable_cache limit.
@@ -63,13 +80,24 @@ export function cachedQuery<T, Args extends unknown[]>(
 ): (...args: Args) => Promise<T> {
   if (options?.blobOnly) {
     return async (...args: Args): Promise<T> => {
-      const blobKey = args.length > 0 ? `${keyPrefix}:${args.join(':')}` : keyPrefix;
+      const blobKey = blobKeyForArgs(keyPrefix, args);
 
       const cached = await blobGet<T>(blobKey);
       if (cached) return cached;
 
       const result = await fn(...args);
-      await blobSet(blobKey, result);
+      try {
+        await blobSet(blobKey, result);
+      } catch (error) {
+        // Blob storage is an optimization, not part of the data contract. A
+        // cache outage or rejected pathname must not turn a successful DB read
+        // into an API 500.
+        console.warn(
+          `[blob cache] could not persist ${keyPrefix}; serving uncached result. ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
       return result;
     };
   }


### PR DESCRIPTION
## Summary

- hash Blob cache keys when serialized arguments exceed 512 UTF-8 bytes, keeping existing short keys and warm entries unchanged
- treat Blob cache writes as best-effort so a storage/pathname error cannot turn a successful database read into an API 500
- add regression coverage for deterministic bounded keys with 200 benchmark IDs and for non-fatal cache-write failures

## Root cause

Bulk AgentX endpoints pass sorted benchmark ID arrays to `cachedQuery(..., { blobOnly: true })`. The cache helper embedded the entire comma-separated array in the Vercel Blob pathname. A 200-ID DeepSeek V4 request produced an oversized pathname: the database query succeeded, but `blobSet` threw and the route returned 500.

The shared fix also protects `agentic-aggregates` and `trace-histograms`, which accept the same 200-ID request size.

## Impact

The failing `derived-agentic-metrics` request now uses a fixed-size SHA-256 cache key. If Blob storage is unavailable for any reason, clients still receive the freshly queried result.

No database migration or aggregate-stat backfill is required.

## Validation

- `bun run test:unit -- src/lib/api-cache.test.ts` — 26 passed
- `bun run test:unit` — 3,632 passed across all workspaces
- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- pre-commit lint, format, and typecheck

## 中文说明

- 当序列化参数超过 512 个 UTF-8 字节时，对 Blob 缓存键进行 SHA-256 哈希；现有短键及其热缓存保持不变
- 将 Blob 缓存写入改为尽力而为，避免存储或路径名错误把成功的数据库查询变成 API 500
- 新增回归测试，覆盖包含 200 个 benchmark ID 的固定长度确定性缓存键，以及缓存写入失败时仍正常返回查询结果

### 根因

批量 AgentX 接口将排序后的 benchmark ID 数组传给 `cachedQuery(..., { blobOnly: true })`。缓存辅助函数此前会把完整的逗号分隔数组直接拼进 Vercel Blob 路径名。DeepSeek V4 的 200-ID 请求因此生成超长路径：数据库查询已经成功，但 `blobSet` 抛错，路由最终返回 500。

该共享修复也覆盖同样允许 200 个 ID 的 `agentic-aggregates` 与 `trace-histograms` 接口。

### 影响

失败的 `derived-agentic-metrics` 请求现在使用固定长度的 SHA-256 缓存键。即使 Blob 存储不可用，客户端仍会收到刚完成的查询结果。

无需数据库迁移或 aggregate stats 回填。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to blob-only caching in api-cache; improves reliability without altering query logic or auth.
> 
> **Overview**
> Fixes bulk AgentX routes that use `cachedQuery(..., { blobOnly: true })` with large benchmark ID arrays: oversized Vercel Blob pathnames no longer cause API 500s after successful DB reads.
> 
> **Blob key sizing:** `blobKeyForArgs` keeps the existing `prefix:arg1:arg2` form when the UTF-8 key is ≤512 bytes; longer argument lists use a deterministic `prefix:sha256:<hex>` digest so pathnames stay bounded. Short keys and warm entries are unchanged.
> 
> **Resilience:** `blobSet` runs in a try/catch; failures log a warning and the handler still returns the fresh query result.
> 
> Tests cover 200-ID deterministic hashed keys and successful responses when blob persistence fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad4600709d5635dce0ad872094a9d5897e73ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->