### PR TITLE
feat(overview): add soft navigation and selectable reference / 总览页支持软导航与可选硬件基准

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -123,18 +123,33 @@ describe('Overview page', () => {
     });
 
     cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
-    cy.location('search').should('eq', '?tier=75');
+    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
     cy.get('[data-testid="overview-engine-scope-switcher"]')
       .find('[data-overview-engine-scope="all"]')
       .click();
-    cy.location('search').should('eq', '?tier=75&engine=all');
+    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
     cy.get('[data-overview-comparison="history"]').click();
-    cy.location('search').should('eq', '?tier=75&engine=all&compare=30d');
+    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all&compare=30d');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
+
+    cy.go('back');
+    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
+  });
+
+  it('preserves pending selections when controls are changed rapidly', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+
+    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    cy.get('[data-testid="overview-engine-scope-switcher"]')
+      .find('[data-overview-engine-scope="all"]')
+      .click();
+
+    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
   });
 
   it('uses a selectable hardware reference and preserves it across overview controls', () => {
@@ -174,6 +189,14 @@ describe('Overview page', () => {
     cy.location('pathname').should('eq', '/zh/overview');
     cy.location('search').should('eq', '?ref=b300');
     cy.get('[data-overview-comparison="hardware"]').should('contain.text', '对比 B300');
+  });
+
+  it('uses rack SKU labels when GB200 or GB300 is the comparison reference', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview?ref=gb200');
+
+    cy.get('[data-overview-comparison="hardware"]').should('contain.text', 'vs GB200 NVL72');
+    cy.get('[data-testid="overview-methodology"]').should('contain.text', 'GB200 NVL72 baseline');
   });
 
   it('switches between B200 and 30-day comparison without losing page state', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -114,6 +114,68 @@ function textRect(element: Element) {
 }
 
 describe('Overview page', () => {
+  it('updates overview selectors with a soft URL transition instead of reloading the document', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+    cy.window().then((win) => {
+      (win as Window & { __overviewNavigationSentinel?: string }).__overviewNavigationSentinel =
+        'preserved';
+    });
+
+    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    cy.location('search').should('eq', '?tier=75');
+    cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
+
+    cy.get('[data-testid="overview-engine-scope-switcher"]')
+      .find('[data-overview-engine-scope="all"]')
+      .click();
+    cy.location('search').should('eq', '?tier=75&engine=all');
+    cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
+
+    cy.get('[data-overview-comparison="history"]').click();
+    cy.location('search').should('eq', '?tier=75&engine=all&compare=30d');
+    cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
+  });
+
+  it('uses a selectable hardware reference and preserves it across overview controls', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+
+    cy.get('[data-testid="overview-reference-select"]').click();
+    cy.get('[data-overview-reference="b300"]').click();
+    cy.location('search').should('eq', '?ref=b300');
+
+    cy.get('[data-overview-comparison="hardware"]')
+      .should('have.attr', 'aria-current', 'true')
+      .and('contain.text', 'vs B300');
+    cy.get('[data-testid="overview-desktop-matrix"] thead').within(() => {
+      cy.contains('th', 'B300 · Reference').should('exist');
+      cy.contains('th', 'B200 · Reference').should('not.exist');
+    });
+    desktopModel('Qwen-3.5-397B-A17B', SINGLE_TURN).within(() => {
+      platform('b300').find('[data-testid="overview-cost-delta"]').should('not.exist');
+      platform('b200').find('[data-testid="overview-cost-delta"]').should('exist');
+    });
+
+    cy.get('[data-testid="overview-tier-switcher"]')
+      .contains('a', '100')
+      .should('have.attr', 'href', '/overview?tier=100&ref=b300');
+    cy.get('[data-testid="overview-engine-scope-switcher"]')
+      .find('[data-overview-engine-scope="all"]')
+      .should('have.attr', 'href', '/overview?engine=all&ref=b300');
+    cy.get('[data-overview-comparison="history"]').should(
+      'have.attr',
+      'href',
+      '/overview?ref=b300&compare=30d',
+    );
+    cy.get('[data-testid="language-toggle"]')
+      .should('have.attr', 'href', '/zh/overview?ref=b300')
+      .click();
+    cy.location('pathname').should('eq', '/zh/overview');
+    cy.location('search').should('eq', '?ref=b300');
+    cy.get('[data-overview-comparison="hardware"]').should('contain.text', '对比 B300');
+  });
+
   it('switches between B200 and 30-day comparison without losing page state', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');

--- a/packages/app/src/app/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/(dashboard)/overview/page.tsx
@@ -7,6 +7,7 @@ import { enAlternates } from '@/lib/i18n';
 import {
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewReferenceHardware,
   resolveOverviewTier,
 } from '@/lib/overview-data';
 import { getOverviewPageData } from '@/lib/overview-data.server';
@@ -43,6 +44,7 @@ export default async function OverviewPage({ searchParams }: Props) {
     resolveOverviewTier(sp.tier),
     resolveOverviewEngineScope(sp.engine),
     resolveOverviewComparisonMode(sp.compare),
+    resolveOverviewReferenceHardware(sp.ref),
   );
   return <OverviewPageContent data={data} locale="en" />;
 }

--- a/packages/app/src/app/zh/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/overview/page.tsx
@@ -7,6 +7,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import {
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewReferenceHardware,
   resolveOverviewTier,
 } from '@/lib/overview-data';
 import { getOverviewPageData } from '@/lib/overview-data.server';
@@ -44,6 +45,7 @@ export default async function ZhOverviewPage({ searchParams }: Props) {
     resolveOverviewTier(sp.tier),
     resolveOverviewEngineScope(sp.engine),
     resolveOverviewComparisonMode(sp.compare),
+    resolveOverviewReferenceHardware(sp.ref),
   );
   return <OverviewPageContent data={data} locale="zh" />;
 }

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -8,7 +8,7 @@ import { track } from '@/lib/analytics';
 
 import { ModeToggle } from '@/components/ui/mode-toggle';
 import { MinecraftToggles } from '@/components/minecraft/minecraft-toggles';
-import { navigateInApp } from '@/lib/client-navigation';
+import { CLIENT_SEARCH_CHANGE_EVENT, navigateInApp } from '@/lib/client-navigation';
 import { hasZhSibling, isZhPathname, switchLocalePath, ZH_PREFIX, zhPath } from '@/lib/i18n';
 import { NAV_LABELS_ZH } from '@/lib/tab-meta-zh';
 import { cn } from '@/lib/utils';
@@ -78,14 +78,25 @@ function LanguageToggle({
 }) {
   const isZh = isZhPathname(pathname);
   const target = switchLocalePath(pathname);
-  // The href carries the query too, so modified clicks and copied links keep
-  // shareable state (e.g. the overview's ?tier=) — same sync as TabNav's.
+  // The root layout is reused for search-only App Router transitions, so keep
+  // this persistent link synchronized with both browser history and the app's
+  // explicit soft-navigation signal.
   const [search, setSearch] = useState('');
   useEffect(() => {
-    const sync = () => setSearch(window.location.search);
-    sync();
+    const sync = (event: Event) => {
+      setSearch(
+        event instanceof CustomEvent && typeof event.detail === 'string'
+          ? event.detail
+          : window.location.search,
+      );
+    };
+    sync(new Event('initial'));
     window.addEventListener('popstate', sync);
-    return () => window.removeEventListener('popstate', sync);
+    window.addEventListener(CLIENT_SEARCH_CHANGE_EVENT, sync);
+    return () => {
+      window.removeEventListener('popstate', sync);
+      window.removeEventListener(CLIENT_SEARCH_CHANGE_EVENT, sync);
+    };
   }, [pathname]);
   return (
     <Link
@@ -95,7 +106,7 @@ function LanguageToggle({
       className="inline-flex items-center min-h-11 px-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors whitespace-nowrap"
       onClick={(event) => {
         track('header_language_toggled', { to: isZh ? 'en' : 'zh' });
-        navigateInApp(event, router, target + window.location.search);
+        navigateInApp(event, router, target + search);
       }}
     >
       {isZh ? 'EN' : '中文'}

--- a/packages/app/src/components/overview/overview-nav-link.tsx
+++ b/packages/app/src/components/overview/overview-nav-link.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { startTransition, type ComponentPropsWithoutRef, type MouseEvent } from 'react';
+import { type ComponentPropsWithoutRef, type MouseEvent } from 'react';
 
 import { track } from '@/lib/analytics';
-import { notifyClientSearchChange } from '@/lib/client-navigation';
+import type { OverviewSearchKey } from '@/lib/overview-links';
+
+import { useOverviewNavigation } from './overview-navigation';
 
 interface OverviewNavAnalytics {
   control: 'comparison' | 'engine' | 'tier';
@@ -14,6 +15,7 @@ interface OverviewNavAnalytics {
 interface OverviewNavLinkProps extends ComponentPropsWithoutRef<'a'> {
   href: string;
   analytics: OverviewNavAnalytics;
+  searchKeys: readonly OverviewSearchKey[];
 }
 
 /**
@@ -24,14 +26,16 @@ interface OverviewNavLinkProps extends ComponentPropsWithoutRef<'a'> {
 export function OverviewNavLink({
   href,
   analytics,
+  searchKeys,
   onClick,
   onFocus,
   onPointerEnter,
   ...props
 }: OverviewNavLinkProps) {
-  const router = useRouter();
+  const navigation = useOverviewNavigation();
+  const resolvedHref = navigation.resolve(href, searchKeys);
 
-  const prefetch = () => router.prefetch(href);
+  const prefetch = () => navigation.prefetch(href, searchKeys);
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     onClick?.(event);
     if (
@@ -51,14 +55,13 @@ export function OverviewNavLink({
       control: analytics.control,
       value: analytics.value,
     });
-    notifyClientSearchChange(href);
-    startTransition(() => router.replace(href, { scroll: false }));
+    navigation.push(href, searchKeys);
   };
 
   return (
     <a
       {...props}
-      href={href}
+      href={resolvedHref}
       onClick={handleClick}
       onFocus={(event) => {
         onFocus?.(event);

--- a/packages/app/src/components/overview/overview-nav-link.tsx
+++ b/packages/app/src/components/overview/overview-nav-link.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition, type ComponentPropsWithoutRef, type MouseEvent } from 'react';
+
+import { track } from '@/lib/analytics';
+import { notifyClientSearchChange } from '@/lib/client-navigation';
+
+interface OverviewNavAnalytics {
+  control: 'comparison' | 'engine' | 'tier';
+  value: string;
+}
+
+interface OverviewNavLinkProps extends ComponentPropsWithoutRef<'a'> {
+  href: string;
+  analytics: OverviewNavAnalytics;
+}
+
+/**
+ * Keeps overview controls as real links while upgrading ordinary clicks to an
+ * App Router transition. Modified clicks, copied URLs and no-JS navigation keep
+ * the anchor's native behavior.
+ */
+export function OverviewNavLink({
+  href,
+  analytics,
+  onClick,
+  onFocus,
+  onPointerEnter,
+  ...props
+}: OverviewNavLinkProps) {
+  const router = useRouter();
+
+  const prefetch = () => router.prefetch(href);
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.currentTarget.target
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    track('overview_selector_changed', {
+      control: analytics.control,
+      value: analytics.value,
+    });
+    notifyClientSearchChange(href);
+    startTransition(() => router.replace(href, { scroll: false }));
+  };
+
+  return (
+    <a
+      {...props}
+      href={href}
+      onClick={handleClick}
+      onFocus={(event) => {
+        onFocus?.(event);
+        if (!event.defaultPrevented) prefetch();
+      }}
+      onPointerEnter={(event) => {
+        onPointerEnter?.(event);
+        if (!event.defaultPrevented) prefetch();
+      }}
+    />
+  );
+}

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+
+import { notifyClientSearchChange } from '@/lib/client-navigation';
+import { mergeOverviewControlHref, type OverviewSearchKey } from '@/lib/overview-links';
+
+interface OverviewNavigationValue {
+  prefetch: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
+  resolve: (targetHref: string, keys: readonly OverviewSearchKey[]) => string;
+  push: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
+}
+
+const OverviewNavigationContext = createContext<OverviewNavigationValue | null>(null);
+
+export function OverviewNavigationProvider({
+  initialHref,
+  children,
+}: {
+  initialHref: string;
+  children: ReactNode;
+}) {
+  const router = useRouter();
+  const [pendingHref, setPendingHref] = useState(initialHref);
+  const pendingHrefRef = useRef(initialHref);
+  const [isPending, startTransition] = useTransition();
+
+  const resetToLocation = useCallback(() => {
+    const href = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    pendingHrefRef.current = href;
+    setPendingHref(href);
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('popstate', resetToLocation);
+    return () => window.removeEventListener('popstate', resetToLocation);
+  }, [resetToLocation]);
+
+  useEffect(() => {
+    if (isPending) return;
+    pendingHrefRef.current = initialHref;
+    setPendingHref(initialHref);
+  }, [initialHref, isPending]);
+
+  const resolve = useCallback(
+    (targetHref: string, keys: readonly OverviewSearchKey[]) =>
+      mergeOverviewControlHref(pendingHref, targetHref, keys),
+    [pendingHref],
+  );
+
+  const value = useMemo<OverviewNavigationValue>(
+    () => ({
+      resolve,
+      prefetch: (targetHref, keys) => {
+        router.prefetch(mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys));
+      },
+      push: (targetHref, keys) => {
+        const href = mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys);
+        pendingHrefRef.current = href;
+        setPendingHref(href);
+        notifyClientSearchChange(href);
+        startTransition(() => router.push(href, { scroll: false }));
+      },
+    }),
+    [resolve, router],
+  );
+
+  return (
+    <OverviewNavigationContext.Provider value={value}>
+      {children}
+    </OverviewNavigationContext.Provider>
+  );
+}
+
+export function useOverviewNavigation(): OverviewNavigationValue {
+  const value = useContext(OverviewNavigationContext);
+  if (value === null) throw new Error('Overview controls require OverviewNavigationProvider');
+  return value;
+}

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@/components/ui/card';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import type { OverviewPageData } from '@/lib/overview-data';
+import { overviewHref } from '@/lib/overview-links';
 
 import {
   DesktopOverviewMatrix,
@@ -13,6 +14,7 @@ import {
   OVERVIEW_STRINGS,
   type OverviewLocale,
 } from './overview-scorecard';
+import { OverviewNavigationProvider } from './overview-navigation';
 
 /** The SemiAnalysis AI Cloud TCO model behind `HW_REGISTRY.costh`. */
 const OVERVIEW_SOURCE_HREF = 'https://semianalysis.com/ai-cloud-tco-model/';
@@ -27,109 +29,119 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
   const formatters = overviewFormatters(locale);
 
   return (
-    <section data-testid="overview-page" className="flex flex-col gap-4">
-      <Card>
-        <header>
-          {/* Two rows at every width: the title, then the metric it is
+    <OverviewNavigationProvider
+      initialHref={overviewHref(
+        locale,
+        data.tier,
+        data.engineScope,
+        data.comparisonMode,
+        data.referenceHardware,
+      )}
+    >
+      <section data-testid="overview-page" className="flex flex-col gap-4">
+        <Card>
+          <header>
+            {/* Two rows at every width: the title, then the metric it is
               measured in and where that measure comes from. */}
-          <div className="flex flex-col gap-y-1">
-            <h1 className="text-lg font-semibold">{strings.title}</h1>
-            {/* Metric, direction and provenance read as one line: the numbers
+            <div className="flex flex-col gap-y-1">
+              <h1 className="text-lg font-semibold">{strings.title}</h1>
+              {/* Metric, direction and provenance read as one line: the numbers
                 and the model they are priced from belong together. */}
-            <p
-              data-testid="overview-scope"
-              aria-label={strings.scopeAria}
-              className="inline-flex flex-wrap items-baseline gap-x-2 leading-snug"
-            >
-              <span
-                data-testid="overview-scope-metric"
-                className="text-base font-semibold text-foreground"
+              <p
+                data-testid="overview-scope"
+                aria-label={strings.scopeAria}
+                className="inline-flex flex-wrap items-baseline gap-x-2 leading-snug"
               >
-                {strings.scopeMetric}
-              </span>{' '}
-              <span aria-hidden="true" className="text-sm text-muted-foreground">
-                ·
-              </span>{' '}
-              <span
-                data-testid="overview-scope-direction"
-                className="text-sm font-normal text-muted-foreground"
-              >
-                {strings.scopeDirection}
-              </span>{' '}
-              <span aria-hidden="true" className="text-sm text-muted-foreground">
-                ·
-              </span>{' '}
-              <span className="text-sm font-normal text-muted-foreground">
-                {strings.sourcePrefix}
-                <a
-                  data-testid="overview-source-link"
-                  href={OVERVIEW_SOURCE_HREF}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group rounded-sm underline decoration-dotted underline-offset-4 hover:decoration-solid focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                <span
+                  data-testid="overview-scope-metric"
+                  className="text-base font-semibold text-foreground"
                 >
-                  {strings.sourceLinkText}
-                  <ExternalLinkIcon />
-                </a>
-              </span>
-            </p>
-          </div>
-          <div className="mt-3 flex flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center lg:gap-x-6">
-            <OverviewTierSwitcher
-              tier={data.tier}
-              engineScope={data.engineScope}
-              comparisonMode={data.comparisonMode}
-              referenceHardware={data.referenceHardware}
-              locale={locale}
-              strings={strings}
-            />
-            <OverviewEngineScopeSwitcher
-              engineScope={data.engineScope}
-              tier={data.tier}
-              comparisonMode={data.comparisonMode}
-              referenceHardware={data.referenceHardware}
-              locale={locale}
-              strings={strings}
-            />
-          </div>
-        </header>
-      </Card>
+                  {strings.scopeMetric}
+                </span>{' '}
+                <span aria-hidden="true" className="text-sm text-muted-foreground">
+                  ·
+                </span>{' '}
+                <span
+                  data-testid="overview-scope-direction"
+                  className="text-sm font-normal text-muted-foreground"
+                >
+                  {strings.scopeDirection}
+                </span>{' '}
+                <span aria-hidden="true" className="text-sm text-muted-foreground">
+                  ·
+                </span>{' '}
+                <span className="text-sm font-normal text-muted-foreground">
+                  {strings.sourcePrefix}
+                  <a
+                    data-testid="overview-source-link"
+                    href={OVERVIEW_SOURCE_HREF}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group rounded-sm underline decoration-dotted underline-offset-4 hover:decoration-solid focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                  >
+                    {strings.sourceLinkText}
+                    <ExternalLinkIcon />
+                  </a>
+                </span>
+              </p>
+            </div>
+            <div className="mt-3 flex flex-col gap-2 lg:flex-row lg:flex-wrap lg:items-center lg:gap-x-6">
+              <OverviewTierSwitcher
+                tier={data.tier}
+                engineScope={data.engineScope}
+                comparisonMode={data.comparisonMode}
+                referenceHardware={data.referenceHardware}
+                locale={locale}
+                strings={strings}
+              />
+              <OverviewEngineScopeSwitcher
+                engineScope={data.engineScope}
+                tier={data.tier}
+                comparisonMode={data.comparisonMode}
+                referenceHardware={data.referenceHardware}
+                locale={locale}
+                strings={strings}
+              />
+            </div>
+          </header>
+        </Card>
 
-      <OverviewComparisonSwitcher
-        comparisonMode={data.comparisonMode}
-        engineScope={data.engineScope}
-        tier={data.tier}
-        referenceHardware={data.referenceHardware}
-        locale={locale}
-        strings={strings}
-      />
+        <OverviewComparisonSwitcher
+          comparisonMode={data.comparisonMode}
+          engineScope={data.engineScope}
+          tier={data.tier}
+          referenceHardware={data.referenceHardware}
+          locale={locale}
+          strings={strings}
+        />
 
-      {/* Official-only summary; uploaded runs remain in the linked dashboard. */}
-      {/* Clipped on phones for the rounded corners; visible from xl so the
+        {/* Official-only summary; uploaded runs remain in the linked dashboard. */}
+        {/* Clipped on phones for the rounded corners; visible from xl so the
           desktop matrix header can stick to the page as it scrolls. */}
-      <Card className="overflow-hidden p-0 md:p-0 xl:overflow-visible">
-        <DesktopOverviewMatrix
-          models={data.models}
-          locale={locale}
-          formatters={formatters}
-          strings={strings}
-          comparisonMode={data.comparisonMode}
-          referenceHardware={data.referenceHardware}
-        />
-        <MobileOverviewList
-          models={data.models}
-          locale={locale}
-          formatters={formatters}
-          strings={strings}
-          comparisonMode={data.comparisonMode}
-          referenceHardware={data.referenceHardware}
-        />
-        <OverviewMethodology
-          strings={strings}
-          comparisonMode={data.comparisonMode}
-          referenceHardware={data.referenceHardware}
-        />
-      </Card>
-    </section>
+        <Card className="overflow-hidden p-0 md:p-0 xl:overflow-visible">
+          <DesktopOverviewMatrix
+            models={data.models}
+            locale={locale}
+            formatters={formatters}
+            strings={strings}
+            comparisonMode={data.comparisonMode}
+            referenceHardware={data.referenceHardware}
+          />
+          <MobileOverviewList
+            models={data.models}
+            locale={locale}
+            formatters={formatters}
+            strings={strings}
+            comparisonMode={data.comparisonMode}
+            referenceHardware={data.referenceHardware}
+          />
+          <OverviewMethodology
+            strings={strings}
+            comparisonMode={data.comparisonMode}
+            referenceHardware={data.referenceHardware}
+          />
+        </Card>
+      </section>
+    </OverviewNavigationProvider>
   );
 }

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -79,6 +79,7 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
               tier={data.tier}
               engineScope={data.engineScope}
               comparisonMode={data.comparisonMode}
+              referenceHardware={data.referenceHardware}
               locale={locale}
               strings={strings}
             />
@@ -86,6 +87,7 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
               engineScope={data.engineScope}
               tier={data.tier}
               comparisonMode={data.comparisonMode}
+              referenceHardware={data.referenceHardware}
               locale={locale}
               strings={strings}
             />
@@ -97,6 +99,7 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
         comparisonMode={data.comparisonMode}
         engineScope={data.engineScope}
         tier={data.tier}
+        referenceHardware={data.referenceHardware}
         locale={locale}
         strings={strings}
       />
@@ -111,6 +114,7 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
           formatters={formatters}
           strings={strings}
           comparisonMode={data.comparisonMode}
+          referenceHardware={data.referenceHardware}
         />
         <MobileOverviewList
           models={data.models}
@@ -118,8 +122,13 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
           formatters={formatters}
           strings={strings}
           comparisonMode={data.comparisonMode}
+          referenceHardware={data.referenceHardware}
         />
-        <OverviewMethodology strings={strings} comparisonMode={data.comparisonMode} />
+        <OverviewMethodology
+          strings={strings}
+          comparisonMode={data.comparisonMode}
+          referenceHardware={data.referenceHardware}
+        />
       </Card>
     </section>
   );

--- a/packages/app/src/components/overview/overview-reference-select.tsx
+++ b/packages/app/src/components/overview/overview-reference-select.tsx
@@ -1,8 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { startTransition } from 'react';
-
 import {
   Select,
   SelectContent,
@@ -11,8 +8,9 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { track } from '@/lib/analytics';
-import { notifyClientSearchChange } from '@/lib/client-navigation';
 import type { OverviewReferenceHardware } from '@/lib/overview-data';
+
+import { useOverviewNavigation } from './overview-navigation';
 
 interface ReferenceOption {
   href: string;
@@ -29,20 +27,19 @@ export function OverviewReferenceSelect({
   options: readonly ReferenceOption[];
   value: OverviewReferenceHardware;
 }) {
-  const router = useRouter();
+  const navigation = useOverviewNavigation();
 
   return (
     <Select
       value={value}
       onOpenChange={(open) => {
-        if (open) options.forEach((option) => router.prefetch(option.href));
+        if (open) options.forEach((option) => navigation.prefetch(option.href, ['ref']));
       }}
       onValueChange={(next: OverviewReferenceHardware) => {
         const option = options.find((candidate) => candidate.value === next);
         if (option === undefined || next === value) return;
         track('overview_reference_changed', { from: value, to: next });
-        notifyClientSearchChange(option.href);
-        startTransition(() => router.replace(option.href, { scroll: false }));
+        navigation.push(option.href, ['ref']);
       }}
     >
       <SelectTrigger

--- a/packages/app/src/components/overview/overview-reference-select.tsx
+++ b/packages/app/src/components/overview/overview-reference-select.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { startTransition } from 'react';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { track } from '@/lib/analytics';
+import { notifyClientSearchChange } from '@/lib/client-navigation';
+import type { OverviewReferenceHardware } from '@/lib/overview-data';
+
+interface ReferenceOption {
+  href: string;
+  label: string;
+  value: OverviewReferenceHardware;
+}
+
+export function OverviewReferenceSelect({
+  ariaLabel,
+  options,
+  value,
+}: {
+  ariaLabel: string;
+  options: readonly ReferenceOption[];
+  value: OverviewReferenceHardware;
+}) {
+  const router = useRouter();
+
+  return (
+    <Select
+      value={value}
+      onOpenChange={(open) => {
+        if (open) options.forEach((option) => router.prefetch(option.href));
+      }}
+      onValueChange={(next: OverviewReferenceHardware) => {
+        const option = options.find((candidate) => candidate.value === next);
+        if (option === undefined || next === value) return;
+        track('overview_reference_changed', { from: value, to: next });
+        notifyClientSearchChange(option.href);
+        startTransition(() => router.replace(option.href, { scroll: false }));
+      }}
+    >
+      <SelectTrigger
+        data-testid="overview-reference-select"
+        aria-label={ariaLabel}
+        size="sm"
+        className="h-8 border-0 bg-transparent px-1.5 text-sm font-semibold shadow-none hover:bg-muted/60 focus-visible:ring-2"
+      >
+        <SelectValue>{options.find((option) => option.value === value)?.label}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="center">
+        {options.map((option) => (
+          <SelectItem
+            key={option.value}
+            value={option.value}
+            data-overview-reference={option.value}
+          >
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -2,6 +2,7 @@ import {
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   OVERVIEW_HARDWARE,
   OVERVIEW_TIERS,
+  overviewHardwareLabel,
   type OverviewComparisonMode,
   type OverviewEngineScope,
   type OverviewHistoricalComparison,
@@ -593,7 +594,7 @@ export function DesktopOverviewMatrix({
   referenceHardware,
 }: SurfaceProps) {
   const platforms = models[0]?.platforms ?? [];
-  const referenceLabel = referenceHardware.toUpperCase();
+  const referenceLabel = overviewHardwareLabel(referenceHardware);
   return (
     <div className="hidden xl:block">
       <table data-testid="overview-desktop-matrix" className="w-full border-collapse text-sm">
@@ -687,7 +688,7 @@ export function MobileOverviewList({
   comparisonMode,
   referenceHardware,
 }: SurfaceProps) {
-  const referenceLabel = referenceHardware.toUpperCase();
+  const referenceLabel = overviewHardwareLabel(referenceHardware);
   return (
     <ul data-testid="overview-mobile-list" className="divide-y divide-border/50 xl:hidden">
       {models.map((model) => (
@@ -792,6 +793,7 @@ export function OverviewTierSwitcher({
                 referenceHardware,
               )}
               analytics={{ control: 'tier', value: String(option) }}
+              searchKeys={['tier']}
               className={`${optionClass} text-muted-foreground transition-colors hover:bg-muted hover:text-foreground`}
             >
               {option}
@@ -853,6 +855,7 @@ export function OverviewEngineScopeSwitcher({
                 referenceHardware,
               )}
               analytics={{ control: 'engine', value: option }}
+              searchKeys={['engine']}
               className={`${optionClass} text-muted-foreground transition-colors hover:bg-muted hover:text-foreground`}
             >
               {strings.engineScopeOptions[option]}
@@ -880,10 +883,10 @@ export function OverviewComparisonSwitcher({
   strings: OverviewStrings;
 }) {
   const options: OverviewComparisonMode[] = ['hardware', 'history'];
-  const referenceLabel = referenceHardware.toUpperCase();
+  const referenceLabel = overviewHardwareLabel(referenceHardware);
   const referenceOptions = OVERVIEW_HARDWARE.map((hardware) => ({
     value: hardware,
-    label: hardware.toUpperCase(),
+    label: overviewHardwareLabel(hardware),
     href: overviewHref(locale, tier, engineScope, 'hardware', hardware),
   }));
   const optionClass =
@@ -925,6 +928,7 @@ export function OverviewComparisonSwitcher({
             data-overview-comparison={option}
             href={overviewHref(locale, tier, engineScope, option, referenceHardware)}
             analytics={{ control: 'comparison', value: option }}
+            searchKeys={['compare']}
             className={optionClass}
           >
             {label}
@@ -944,7 +948,7 @@ export function OverviewMethodology({
   comparisonMode: OverviewComparisonMode;
   referenceHardware: OverviewReferenceHardware;
 }) {
-  const referenceLabel = referenceHardware.toUpperCase();
+  const referenceLabel = overviewHardwareLabel(referenceHardware);
   return (
     <div
       data-testid="overview-methodology"

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -1,10 +1,13 @@
 import {
+  OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  OVERVIEW_HARDWARE,
   OVERVIEW_TIERS,
   type OverviewComparisonMode,
   type OverviewEngineScope,
   type OverviewHistoricalComparison,
   type OverviewModelSummary,
   type OverviewPlatformResult,
+  type OverviewReferenceHardware,
   type OverviewTier,
 } from '@/lib/overview-data';
 import {
@@ -16,6 +19,8 @@ import {
 } from '@/lib/overview-links';
 
 import { OverviewDetailLink } from './overview-detail-link';
+import { OverviewNavLink } from './overview-nav-link';
+import { OverviewReferenceSelect } from './overview-reference-select';
 
 export type OverviewLocale = 'en' | 'zh';
 
@@ -39,9 +44,10 @@ export const OVERVIEW_STRINGS = {
     },
     comparisonNavLabel: 'Compare',
     comparisonOptions: {
-      hardware: 'vs B200',
       history: '30-day change',
     },
+    hardwareComparisonLabel: (reference: string) => `vs ${reference}`,
+    referenceSelectorAria: 'Reference hardware',
     caption:
       'Cost per million total tokens from each platform’s best observed serving envelope for the scenario shown with each model.',
     historyCaption:
@@ -61,7 +67,7 @@ export const OVERVIEW_STRINGS = {
         ? 'Estimated from validated benchmark runs.'
         : `Estimated from validated ${topologies.join(' and ')} runs.`,
     estimatedAria: (value: string, explanation: string) => `Approximately ${value}. ${explanation}`,
-    cellStateLegend: '— = no result. ∞ = B200 baseline unavailable.',
+    cellStateLegend: (reference: string) => `— = no result. ∞ = ${reference} baseline unavailable.`,
     missingReasons: (tier: number): Record<string, string> => ({
       int4_bf16_only: 'INT4/BF16 only',
       no_scenario_data: 'no data for this scenario',
@@ -71,10 +77,10 @@ export const OVERVIEW_STRINGS = {
     standardDecodeLabel: 'STP',
     methodologyNote:
       'If a chip does not have FP4 spec decoding available, the next best available configuration is used.',
-    costDeltaAria: (pct: string, cheaper: boolean) =>
-      `${pct} ${cheaper ? 'cheaper' : 'more expensive'} than B200`,
-    costDeltaEvenAria: 'About the same cost as B200',
-    noBaselineAria: 'No B200 baseline to compare against',
+    costDeltaAria: (pct: string, cheaper: boolean, reference: string) =>
+      `${pct} ${cheaper ? 'cheaper' : 'more expensive'} than ${reference}`,
+    costDeltaEvenAria: (reference: string) => `About the same cost as ${reference}`,
+    noBaselineAria: (reference: string) => `No ${reference} baseline to compare against`,
     historicalDeltaAria: (pct: string, cheaper: boolean, baselineDate: string) =>
       `${pct} ${cheaper ? 'cheaper' : 'more expensive'} than this platform’s ${baselineDate} result`,
     historicalEvenAria: (baselineDate: string) =>
@@ -98,9 +104,10 @@ export const OVERVIEW_STRINGS = {
     },
     comparisonNavLabel: '对比方式',
     comparisonOptions: {
-      hardware: '对比 B200',
       history: '30 天变化',
     },
+    hardwareComparisonLabel: (reference: string) => `对比 ${reference}`,
+    referenceSelectorAria: '基准硬件',
     caption: '按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本。',
     historyCaption: '当前成本及其相对 30–60 天前最近一次有效平台结果的变化。',
     modelHeader: '模型 · 场景',
@@ -118,7 +125,7 @@ export const OVERVIEW_STRINGS = {
         ? '根据已验证的基准运行结果估算。'
         : `根据已验证的 ${topologies.join(' 与 ')} 运行结果估算。`,
     estimatedAria: (value: string, explanation: string) => `约 ${value}。${explanation}`,
-    cellStateLegend: '— = 无结果。∞ = 缺少 B200 基线。',
+    cellStateLegend: (reference: string) => `— = 无结果。∞ = 缺少 ${reference} 基线。`,
     missingReasons: (tier: number): Record<string, string> => ({
       int4_bf16_only: '仅 INT4/BF16',
       no_scenario_data: '该场景暂无数据',
@@ -127,9 +134,10 @@ export const OVERVIEW_STRINGS = {
     }),
     standardDecodeLabel: 'STP',
     methodologyNote: '若某款芯片不支持 FP4 推测解码，则采用次优的可用配置。',
-    costDeltaAria: (pct: string, cheaper: boolean) => `比 B200 ${cheaper ? '便宜' : '昂贵'} ${pct}`,
-    costDeltaEvenAria: '与 B200 成本基本持平',
-    noBaselineAria: '缺少可比较的 B200 基线',
+    costDeltaAria: (pct: string, cheaper: boolean, reference: string) =>
+      `比 ${reference} ${cheaper ? '便宜' : '昂贵'} ${pct}`,
+    costDeltaEvenAria: (reference: string) => `与 ${reference} 成本基本持平`,
+    noBaselineAria: (reference: string) => `缺少可比较的 ${reference} 基线`,
     historicalDeltaAria: (pct: string, cheaper: boolean, baselineDate: string) =>
       `比该平台 ${baselineDate} 的结果${cheaper ? '便宜' : '昂贵'} ${pct}`,
     historicalEvenAria: (baselineDate: string) => `与该平台 ${baselineDate} 的结果成本基本持平`,
@@ -239,6 +247,7 @@ interface DisplayedComparison {
 function displayedComparison(
   platform: OverviewPlatformResult,
   comparisonMode: OverviewComparisonMode,
+  referenceHardware: OverviewReferenceHardware,
 ): DisplayedComparison | null {
   if (platform.costPerMtok === null) return null;
   if (comparisonMode === 'history') {
@@ -251,10 +260,10 @@ function displayedComparison(
         }
       : null;
   }
-  if (platform.hardware === 'b200') return null;
+  if (platform.hardware === referenceHardware) return null;
   return {
-    status: platform.costVsB200Pct === null ? 'no_baseline' : 'comparable',
-    pct: platform.costVsB200Pct,
+    status: platform.costVsReferencePct === null ? 'no_baseline' : 'comparable',
+    pct: platform.costVsReferencePct,
     baselineDate: null,
   };
 }
@@ -276,16 +285,18 @@ function comparisonAria(
   polarity: CostDeltaPolarity,
   formatters: Formatters,
   strings: OverviewStrings,
+  referenceLabel: string,
 ): string {
   if (comparison.status === 'no_baseline' || comparison.pct === null) {
-    return strings.noBaselineAria;
+    return strings.noBaselineAria(referenceLabel);
   }
   if (comparisonMode === 'hardware') {
     return polarity === 'even'
-      ? strings.costDeltaEvenAria
+      ? strings.costDeltaEvenAria(referenceLabel)
       : strings.costDeltaAria(
           formatters.percentAbs.format(Math.abs(comparison.pct)),
           polarity === 'cheaper',
+          referenceLabel,
         );
   }
 
@@ -315,8 +326,9 @@ function costDeltaAlpha(pct: number): string {
 export function costDeltaCellStyle(
   platform: OverviewPlatformResult,
   comparisonMode: OverviewComparisonMode = 'hardware',
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): { backgroundColor: string } | undefined {
-  const comparison = displayedComparison(platform, comparisonMode);
+  const comparison = displayedComparison(platform, comparisonMode, referenceHardware);
   if (comparison === null) return undefined;
   const { pct } = comparison;
   const polarity = comparisonPolarity(comparison);
@@ -325,14 +337,15 @@ export function costDeltaCellStyle(
   return { backgroundColor: `rgb(${COST_DELTA_HUE[polarity]} / ${alpha})` };
 }
 
-/** Relative comparison badge. Missing B200 evidence stays neutral and uses
- *  `∞` instead of manufacturing a percentage. */
+/** Relative comparison badge. Missing reference evidence stays neutral and
+ *  uses `∞` instead of manufacturing a percentage. */
 function CostDeltaBadge({
   comparison,
   comparisonMode,
   hardware,
   formatters,
   strings,
+  referenceLabel,
   phoneRow,
 }: {
   comparison: DisplayedComparison;
@@ -340,11 +353,19 @@ function CostDeltaBadge({
   hardware: string;
   formatters: Formatters;
   strings: OverviewStrings;
+  referenceLabel: string;
   phoneRow: boolean;
 }) {
   const { pct, status } = comparison;
   const polarity = comparisonPolarity(comparison);
-  const aria = comparisonAria(comparison, comparisonMode, polarity, formatters, strings);
+  const aria = comparisonAria(
+    comparison,
+    comparisonMode,
+    polarity,
+    formatters,
+    strings,
+    referenceLabel,
+  );
   return (
     <span
       data-testid="overview-cost-delta"
@@ -371,6 +392,8 @@ function CellValue({
   formatters,
   strings,
   comparisonMode,
+  referenceHardware,
+  referenceLabel,
   phoneRow = false,
 }: {
   locale: OverviewLocale;
@@ -379,6 +402,8 @@ function CellValue({
   formatters: Formatters;
   strings: OverviewStrings;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
+  referenceLabel: string;
   phoneRow?: boolean;
 }) {
   const { value, config, evidenceDate, evidenceTopologies } = member.read;
@@ -430,11 +455,11 @@ function CellValue({
       ? null
       : strings.rawDashboardAria(evidenceDateLabel, model.modelLabel, stack);
   const costText = formattedValue;
-  const comparison = displayedComparison(member, comparisonMode);
+  const comparison = displayedComparison(member, comparisonMode, referenceHardware);
   return (
     <div className="min-w-0 space-y-0.5 text-sm">
       {/* Fixed cost | delta grids keep comparisons scannable on desktop and phones;
-          the delta slot is reserved even on B200 so numbers align across rows. */}
+          the delta slot is reserved on the reference too, aligning every row. */}
       <div
         className={
           phoneRow
@@ -485,6 +510,7 @@ function CellValue({
             hardware={member.hardware}
             formatters={formatters}
             strings={strings}
+            referenceLabel={referenceLabel}
             phoneRow={phoneRow}
           />
         )}
@@ -514,6 +540,8 @@ function PlatformCell(props: {
   formatters: Formatters;
   strings: OverviewStrings;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
+  referenceLabel: string;
   phoneRow?: boolean;
 }) {
   return (
@@ -525,6 +553,8 @@ function PlatformCell(props: {
         formatters={props.formatters}
         strings={props.strings}
         comparisonMode={props.comparisonMode}
+        referenceHardware={props.referenceHardware}
+        referenceLabel={props.referenceLabel}
         phoneRow={props.phoneRow}
       />
     </div>
@@ -551,6 +581,7 @@ interface SurfaceProps {
   formatters: Formatters;
   strings: OverviewStrings;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
 }
 
 export function DesktopOverviewMatrix({
@@ -559,8 +590,10 @@ export function DesktopOverviewMatrix({
   formatters,
   strings,
   comparisonMode,
+  referenceHardware,
 }: SurfaceProps) {
   const platforms = models[0]?.platforms ?? [];
+  const referenceLabel = referenceHardware.toUpperCase();
   return (
     <div className="hidden xl:block">
       <table data-testid="overview-desktop-matrix" className="w-full border-collapse text-sm">
@@ -586,9 +619,9 @@ export function DesktopOverviewMatrix({
               <th
                 key={platform.hardware}
                 scope="col"
-                className={`px-3 py-2 text-left font-semibold ${comparisonMode === 'hardware' && platform.hardware === 'b200' ? 'bg-muted' : 'bg-card'}`}
+                className={`px-3 py-2 text-left font-semibold ${comparisonMode === 'hardware' && platform.hardware === referenceHardware ? 'bg-muted' : 'bg-card'}`}
               >
-                {comparisonMode === 'hardware' && platform.hardware === 'b200'
+                {comparisonMode === 'hardware' && platform.hardware === referenceHardware
                   ? `${platform.hardwareLabel} · ${strings.referenceHeader}`
                   : platform.hardwareLabel}
               </th>
@@ -623,8 +656,8 @@ export function DesktopOverviewMatrix({
               {model.platforms.map((platform) => (
                 <td
                   key={platform.hardware}
-                  style={costDeltaCellStyle(platform, comparisonMode)}
-                  className={`px-3 py-4 align-top ${comparisonMode === 'hardware' && platform.hardware === 'b200' ? 'bg-muted/30' : ''}`}
+                  style={costDeltaCellStyle(platform, comparisonMode, referenceHardware)}
+                  className={`px-3 py-4 align-top ${comparisonMode === 'hardware' && platform.hardware === referenceHardware ? 'bg-muted/30' : ''}`}
                 >
                   <PlatformCell
                     locale={locale}
@@ -633,6 +666,8 @@ export function DesktopOverviewMatrix({
                     formatters={formatters}
                     strings={strings}
                     comparisonMode={comparisonMode}
+                    referenceHardware={referenceHardware}
+                    referenceLabel={referenceLabel}
                   />
                 </td>
               ))}
@@ -650,7 +685,9 @@ export function MobileOverviewList({
   formatters,
   strings,
   comparisonMode,
+  referenceHardware,
 }: SurfaceProps) {
+  const referenceLabel = referenceHardware.toUpperCase();
   return (
     <ul data-testid="overview-mobile-list" className="divide-y divide-border/50 xl:hidden">
       {models.map((model) => (
@@ -668,7 +705,7 @@ export function MobileOverviewList({
                   key={platform.hardware}
                   data-testid="overview-mobile-platform-row"
                   data-hardware={platform.hardware}
-                  style={costDeltaCellStyle(platform, comparisonMode)}
+                  style={costDeltaCellStyle(platform, comparisonMode, referenceHardware)}
                   className="grid min-w-0 grid-cols-[4.25rem_minmax(0,1fr)] gap-x-3 border-b border-border/30 py-1.5 last:border-b-0"
                 >
                   <span
@@ -684,6 +721,8 @@ export function MobileOverviewList({
                     formatters={formatters}
                     strings={strings}
                     comparisonMode={comparisonMode}
+                    referenceHardware={referenceHardware}
+                    referenceLabel={referenceLabel}
                     phoneRow
                   />
                 </div>
@@ -707,18 +746,20 @@ export function MobileOverviewList({
   );
 }
 
-/** Plain links so every view is a copyable server-rendered URL; the displayed
- *  tier is inert `aria-current` text, never a self-link. */
+/** Every option remains a copyable server-rendered URL; ordinary clicks use a
+ *  soft App Router transition and the displayed tier is never a self-link. */
 export function OverviewTierSwitcher({
   tier,
   engineScope,
   comparisonMode,
+  referenceHardware,
   locale,
   strings,
 }: {
   tier: OverviewTier;
   engineScope: OverviewEngineScope;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
@@ -741,13 +782,20 @@ export function OverviewTierSwitcher({
               {option}
             </span>
           ) : (
-            <a
+            <OverviewNavLink
               key={option}
-              href={overviewTierHref(locale, option, engineScope, comparisonMode)}
+              href={overviewTierHref(
+                locale,
+                option,
+                engineScope,
+                comparisonMode,
+                referenceHardware,
+              )}
+              analytics={{ control: 'tier', value: String(option) }}
               className={`${optionClass} text-muted-foreground transition-colors hover:bg-muted hover:text-foreground`}
             >
               {option}
-            </a>
+            </OverviewNavLink>
           ),
         )}
       </div>
@@ -756,17 +804,19 @@ export function OverviewTierSwitcher({
   );
 }
 
-/** Plain server links keep scope selection copyable and preserve the active tier. */
+/** Scope links keep their native href while preserving the other controls. */
 export function OverviewEngineScopeSwitcher({
   engineScope,
   tier,
   comparisonMode,
+  referenceHardware,
   locale,
   strings,
 }: {
   engineScope: OverviewEngineScope;
   tier: OverviewTier;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
@@ -792,14 +842,21 @@ export function OverviewEngineScopeSwitcher({
               {strings.engineScopeOptions[option]}
             </span>
           ) : (
-            <a
+            <OverviewNavLink
               key={option}
               data-overview-engine-scope={option}
-              href={overviewEngineScopeHref(locale, option, tier, comparisonMode)}
+              href={overviewEngineScopeHref(
+                locale,
+                option,
+                tier,
+                comparisonMode,
+                referenceHardware,
+              )}
+              analytics={{ control: 'engine', value: option }}
               className={`${optionClass} text-muted-foreground transition-colors hover:bg-muted hover:text-foreground`}
             >
               {strings.engineScopeOptions[option]}
-            </a>
+            </OverviewNavLink>
           ),
         )}
       </div>
@@ -811,16 +868,24 @@ export function OverviewComparisonSwitcher({
   comparisonMode,
   engineScope,
   tier,
+  referenceHardware,
   locale,
   strings,
 }: {
   comparisonMode: OverviewComparisonMode;
   engineScope: OverviewEngineScope;
   tier: OverviewTier;
+  referenceHardware: OverviewReferenceHardware;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
   const options: OverviewComparisonMode[] = ['hardware', 'history'];
+  const referenceLabel = referenceHardware.toUpperCase();
+  const referenceOptions = OVERVIEW_HARDWARE.map((hardware) => ({
+    value: hardware,
+    label: hardware.toUpperCase(),
+    href: overviewHref(locale, tier, engineScope, 'hardware', hardware),
+  }));
   const optionClass =
     'relative inline-flex min-h-11 min-w-[130px] items-center justify-center whitespace-nowrap border-b-2 border-transparent px-4 py-2 text-sm font-semibold text-muted-foreground transition-colors duration-200 hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring sm:min-w-[140px]';
   return (
@@ -829,27 +894,43 @@ export function OverviewComparisonSwitcher({
       aria-label={strings.comparisonNavLabel}
       className="flex flex-wrap justify-center gap-x-1 gap-y-1.5 sm:gap-x-1.5"
     >
-      {options.map((option) =>
-        option === comparisonMode ? (
+      {options.map((option) => {
+        const label =
+          option === 'hardware'
+            ? strings.hardwareComparisonLabel(referenceLabel)
+            : strings.comparisonOptions.history;
+        return option === comparisonMode ? (
           <span
             key={option}
             data-overview-comparison={option}
             aria-current="true"
             className={`${optionClass} border-secondary text-secondary dark:border-primary dark:text-primary`}
           >
-            {strings.comparisonOptions[option]}
+            {option === 'hardware' ? (
+              <span className="inline-flex items-center gap-0.5">
+                <span>{locale === 'zh' ? '对比 ' : 'vs '}</span>
+                <OverviewReferenceSelect
+                  ariaLabel={strings.referenceSelectorAria}
+                  options={referenceOptions}
+                  value={referenceHardware}
+                />
+              </span>
+            ) : (
+              label
+            )}
           </span>
         ) : (
-          <a
+          <OverviewNavLink
             key={option}
             data-overview-comparison={option}
-            href={overviewHref(locale, tier, engineScope, option)}
+            href={overviewHref(locale, tier, engineScope, option, referenceHardware)}
+            analytics={{ control: 'comparison', value: option }}
             className={optionClass}
           >
-            {strings.comparisonOptions[option]}
-          </a>
-        ),
-      )}
+            {label}
+          </OverviewNavLink>
+        );
+      })}
     </nav>
   );
 }
@@ -857,10 +938,13 @@ export function OverviewComparisonSwitcher({
 export function OverviewMethodology({
   strings,
   comparisonMode,
+  referenceHardware,
 }: {
   strings: OverviewStrings;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
 }) {
+  const referenceLabel = referenceHardware.toUpperCase();
   return (
     <div
       data-testid="overview-methodology"
@@ -868,7 +952,9 @@ export function OverviewMethodology({
     >
       {comparisonMode === 'history' ? <p>{strings.historyCaption}</p> : null}
       <p>
-        {comparisonMode === 'history' ? strings.historyCellStateLegend : strings.cellStateLegend}
+        {comparisonMode === 'history'
+          ? strings.historyCellStateLegend
+          : strings.cellStateLegend(referenceLabel)}
       </p>
       <p>{strings.methodologyNote}</p>
     </div>

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -6,6 +6,15 @@ interface RouterLike {
   push: (href: string) => void;
 }
 
+export const CLIENT_SEARCH_CHANGE_EVENT = 'inferencex:client-search-change';
+
+/** Keep persistent layout controls in sync when an App Router transition only
+ *  changes search params and therefore reuses the root layout. */
+export function notifyClientSearchChange(href: string): void {
+  const search = new URL(href, window.location.origin).search;
+  window.dispatchEvent(new CustomEvent(CLIENT_SEARCH_CHANGE_EVENT, { detail: search }));
+}
+
 /**
  * The first dashboard transition can request the route without committing the
  * URL change. Repeating the same app-router push after the route payload has

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -69,6 +69,19 @@ afterEach(() => {
 });
 
 describe('getOverviewPageData engine scope forwarding', () => {
+  it('forwards the selected hardware reference through fixture mode', async () => {
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: true }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({ getCachedBenchmarks: vi.fn() }));
+    vi.doMock('@/lib/test-fixtures', () => ({
+      loadFixture: vi.fn(() => ({ [Model.Qwen3_5]: rows })),
+    }));
+
+    const { getOverviewPageData } = await import('./overview-data.server');
+    const page = await getOverviewPageData(50, 'community', 'hardware', 'b300');
+
+    expect(page.referenceHardware).toBe('b300');
+  });
+
   it('forwards community scope through fixture mode', async () => {
     const getCachedBenchmarks = vi.fn();
     vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: true }));

--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -9,11 +9,13 @@ import {
   assembleOverviewPageData,
   OVERVIEW_DEFAULT_COMPARISON_MODE,
   OVERVIEW_PRIMARY_TIER,
+  OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   overviewHistoricalWindow,
   overviewSnapshotDate,
   type OverviewComparisonMode,
   type OverviewEngineScope,
   type OverviewPageData,
+  type OverviewReferenceHardware,
   type OverviewTier,
 } from '@/lib/overview-data';
 import { loadFixture } from '@/lib/test-fixtures';
@@ -35,6 +37,7 @@ export async function getOverviewPageData(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): Promise<OverviewPageData> {
   // Synthetic rows go through the same assemblers as the live path, so a
   // contract drift breaks fixture tests instead of stranding the page.
@@ -42,13 +45,13 @@ export async function getOverviewPageData(
     ? loadFixture<Record<string, BenchmarkRow[]>>('overview-rows')
     : await loadRowsByModel(getCachedBenchmarks);
   if (comparisonMode === 'hardware') {
-    return assembleOverviewPageData(currentRowsByModel, tier, engineScope);
+    return assembleOverviewPageData(currentRowsByModel, tier, engineScope, referenceHardware);
   }
 
   const snapshotDate = overviewSnapshotDate(currentRowsByModel, engineScope);
   if (snapshotDate === null) {
     return {
-      ...assembleOverviewPageData(currentRowsByModel, tier, engineScope),
+      ...assembleOverviewPageData(currentRowsByModel, tier, engineScope, referenceHardware),
       comparisonMode: 'history',
     };
   }
@@ -70,5 +73,6 @@ export async function getOverviewPageData(
     window,
     tier,
     engineScope,
+    referenceHardware,
   );
 }

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -17,6 +17,7 @@ import {
   overviewTierEvidenceDate,
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewReferenceHardware,
   resolveOverviewTier,
   type OverviewModelSummary,
   type OverviewPageData,
@@ -138,6 +139,13 @@ function platformFor(
 }
 
 describe('overview engine scope and scenario selection', () => {
+  it('accepts only supported hardware references and defaults invalid input to B200', () => {
+    expect(resolveOverviewReferenceHardware('b300')).toBe('b300');
+    expect(resolveOverviewReferenceHardware(['mi355x', 'b200'])).toBe('mi355x');
+    expect(resolveOverviewReferenceHardware('not-a-gpu')).toBe('b200');
+    expect(resolveOverviewReferenceHardware(undefined)).toBe('b200');
+  });
+
   it.each([
     [undefined, 'hardware'],
     ['hardware', 'hardware'],
@@ -216,22 +224,57 @@ describe('overview engine scope and scenario selection', () => {
       (JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / (7200 * 3600),
       6,
     );
-    expect(byHardware.b200.costVsB200Pct).toBeNull();
+    expect(byHardware.b200.costVsReferencePct).toBeNull();
     expect(byHardware.mi355x.costPerMtok).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) / (9000 * 3600),
       6,
     );
-    expect(byHardware.mi355x.costVsB200Pct).toBeCloseTo(
+    expect(byHardware.mi355x.costVsReferencePct).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) /
         (9000 * 3600) /
         ((JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / (7200 * 3600)) -
         1,
       6,
     );
-    expect(byHardware.mi355x.costVsB200Pct).toBeLessThan(0);
-    expect(byHardware.gb300.costVsB200Pct).toBeGreaterThan(0);
+    expect(byHardware.mi355x.costVsReferencePct).toBeLessThan(0);
+    expect(byHardware.gb300.costVsReferencePct).toBeGreaterThan(0);
     expect(byHardware.b300.costPerMtok).toBeNull();
-    expect(byHardware.b300.costVsB200Pct).toBeNull();
+    expect(byHardware.b300.costVsReferencePct).toBeNull();
+  });
+
+  it('computes hardware deltas against the selected reference instead of always using B200', () => {
+    const rows = [
+      ...frontier([10800, 7200, 6300, 5400], {
+        hardware: 'b200',
+        precision: Precision.FP4,
+      }),
+      ...frontier([11700, 8100, 7200, 6300], {
+        hardware: 'b300',
+        precision: Precision.FP4,
+      }),
+      ...frontier([12600, 9000, 8100, 7200], {
+        hardware: 'mi355x',
+        precision: Precision.FP4,
+      }),
+    ];
+    const summary = buildOverviewModelSummary(
+      Model.Qwen3_5,
+      rows,
+      50,
+      'community',
+      'single_turn_8k1k',
+      'b300',
+    );
+    const byHardware = Object.fromEntries(
+      summary.platforms.map((platform) => [platform.hardware, platform]),
+    );
+    const b200Cost = byHardware.b200.costPerMtok!;
+    const b300Cost = byHardware.b300.costPerMtok!;
+    const mi355xCost = byHardware.mi355x.costPerMtok!;
+
+    expect(byHardware.b300.costVsReferencePct).toBeNull();
+    expect(byHardware.b200.costVsReferencePct).toBeCloseTo(b200Cost / b300Cost - 1, 6);
+    expect(byHardware.mi355x.costVsReferencePct).toBeCloseTo(mi355xCost / b300Cost - 1, 6);
   });
 
   it('keeps a platform cost without a B200 baseline so the UI can badge it ∞', () => {
@@ -247,7 +290,7 @@ describe('overview engine scope and scenario selection', () => {
       (JULY_2026_HYPERSCALER_TCO.gb300 * 1e6) / (9000 * 3600),
       6,
     );
-    expect(gb300.costVsB200Pct).toBeNull();
+    expect(gb300.costVsReferencePct).toBeNull();
     expect(summary.platforms.find((p) => p.hardware === 'b200')?.costPerMtok).toBeNull();
   });
 
@@ -1268,7 +1311,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     expect(dsxB200.read.value).not.toBeCloseTo(8101.968, 3);
     const dsxMi355x = deepseekAgentx.platforms.find((p) => p.hardware === 'mi355x')!;
     expect(dsxMi355x.read.value).toBe(6000);
-    expect(dsxMi355x.costVsB200Pct).toBeCloseTo(
+    expect(dsxMi355x.costVsReferencePct).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) /
         6000 /
         ((JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / 7500) -
@@ -1291,7 +1334,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       (JULY_2026_HYPERSCALER_TCO.gb300 * 1e6) / (6510 * 3600),
       6,
     );
-    expect(mmGb300.candidate.costVsB200Pct).toBeNull();
+    expect(mmGb300.candidate.costVsReferencePct).toBeNull();
 
     // Qwen: MI355X independently falls back to FP8 while B200 and B300 use FP4.
     const qwen = page.models.find((m) => m.model === Model.Qwen3_5)!;
@@ -1304,7 +1347,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     );
     expect(qwenMi.baseline.precision).toBe(Precision.FP4);
     expect(qwenMi.baseline.read.value).toBeCloseTo(6602.344);
-    expect(qwenMi.candidate.costVsB200Pct).toBeCloseTo(
+    expect(qwenMi.candidate.costVsReferencePct).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) /
         (6688 * 3600) /
         ((JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / (6602.344 * 3600)) -

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -19,6 +19,9 @@ export const OVERVIEW_WORKLOAD = { isl: 8192, osl: 1024 } as const;
 export const OVERVIEW_TIERS = [30, 50, 75, 100, 150, 200] as const;
 export type OverviewTier = (typeof OVERVIEW_TIERS)[number];
 export const OVERVIEW_PRIMARY_TIER = 50;
+export const OVERVIEW_HARDWARE = ['b200', 'mi355x', 'b300', 'gb200', 'gb300'] as const;
+export type OverviewReferenceHardware = (typeof OVERVIEW_HARDWARE)[number];
+export const OVERVIEW_DEFAULT_REFERENCE_HARDWARE: OverviewReferenceHardware = 'b200';
 export type OverviewEngineScope = 'all' | 'community';
 export type OverviewComparisonMode = 'hardware' | 'history';
 export const OVERVIEW_DEFAULT_COMPARISON_MODE: OverviewComparisonMode = 'hardware';
@@ -31,6 +34,16 @@ export function resolveOverviewEngineScope(
 ): OverviewEngineScope {
   const candidate = Array.isArray(raw) ? raw[0] : raw;
   return candidate === 'all' ? 'all' : 'community';
+}
+
+export function resolveOverviewReferenceHardware(
+  raw: string | readonly string[] | undefined,
+): OverviewReferenceHardware {
+  const candidate = Array.isArray(raw) ? raw[0] : raw;
+  return (
+    OVERVIEW_HARDWARE.find((hardware) => hardware === candidate) ??
+    OVERVIEW_DEFAULT_REFERENCE_HARDWARE
+  );
 }
 
 export function resolveOverviewComparisonMode(
@@ -107,8 +120,6 @@ export interface OverviewHistoricalComparison {
   baselineDate: string | null;
 }
 
-export const OVERVIEW_HARDWARE = ['b200', 'mi355x', 'b300', 'gb200', 'gb300'] as const;
-
 export interface OverviewPlatformResult {
   hardware: string;
   hardwareLabel: string;
@@ -118,9 +129,9 @@ export interface OverviewPlatformResult {
   /** $ per million TOTAL (input + output) tokens at the hyperscaler $/GPU/hr
    *  tier (`HW_REGISTRY.costh`). */
   costPerMtok: number | null;
-  /** Cost delta vs this row's B200 cell; negative = cheaper. Null on the B200
-   *  cell itself and whenever either cost is unavailable. */
-  costVsB200Pct: number | null;
+  /** Cost delta vs this row's selected reference cell; negative = cheaper.
+   *  Null on the reference cell itself and whenever either cost is unavailable. */
+  costVsReferencePct: number | null;
   historicalComparison: OverviewHistoricalComparison | null;
 }
 
@@ -136,6 +147,7 @@ export interface OverviewPageData {
   tier: OverviewTier;
   engineScope: OverviewEngineScope;
   comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
   historicalWindow: OverviewHistoricalWindow | null;
 }
 
@@ -462,6 +474,7 @@ function buildPlatformResults(
   scenario: OverviewScenario,
   scenarioRows: readonly BenchmarkRow[],
   tier: OverviewTier,
+  referenceHardware: OverviewReferenceHardware,
 ): OverviewPlatformResult[] {
   const configs = buildConfigs(model, scenario, scenarioRows);
   const readsForHardware = (hardware: string): OverviewTierRead[] =>
@@ -486,13 +499,16 @@ function buildPlatformResults(
     };
   });
 
-  const b200Cost = platforms.find((platform) => platform.hardware === 'b200')?.costPerMtok ?? null;
+  const referenceCost =
+    platforms.find((platform) => platform.hardware === referenceHardware)?.costPerMtok ?? null;
   return platforms.map((platform) => ({
     ...platform,
-    costVsB200Pct:
-      platform.hardware === 'b200' || b200Cost === null || platform.costPerMtok === null
+    costVsReferencePct:
+      platform.hardware === referenceHardware ||
+      referenceCost === null ||
+      platform.costPerMtok === null
         ? null
-        : platform.costPerMtok / b200Cost - 1,
+        : platform.costPerMtok / referenceCost - 1,
     historicalComparison: null,
   }));
 }
@@ -619,6 +635,7 @@ export function buildOverviewModelSummary(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
   scenario: OverviewScenario = overviewScenarioForModel(model, rows),
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): OverviewModelSummary {
   const scopedRows = overviewEngineRows(rows, engineScope);
   const scenarioRows = overviewScenarioRows(scenario, scopedRows);
@@ -626,7 +643,7 @@ export function buildOverviewModelSummary(
     model,
     modelLabel: getModelLabel(model),
     scenario,
-    platforms: buildPlatformResults(model, scenario, scenarioRows, tier),
+    platforms: buildPlatformResults(model, scenario, scenarioRows, tier, referenceHardware),
   };
 }
 
@@ -639,17 +656,19 @@ export function assembleOverviewPageData(
   rowsByModel: Record<string, BenchmarkRow[]>,
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): OverviewPageData {
   const perModel = [...DEFAULT_MODELS].map((model) => ({ model, rows: rowsByModel[model] ?? [] }));
   return {
     models: perModel.flatMap(({ model, rows }) =>
       overviewScenariosForModel(model, rows).map((scenario) =>
-        buildOverviewModelSummary(model, rows, tier, engineScope, scenario),
+        buildOverviewModelSummary(model, rows, tier, engineScope, scenario, referenceHardware),
       ),
     ),
     tier,
     engineScope,
     comparisonMode: OVERVIEW_DEFAULT_COMPARISON_MODE,
+    referenceHardware,
     historicalWindow: null,
   };
 }
@@ -667,9 +686,20 @@ export function assembleOverviewHistoricalPageData(
   window: OverviewHistoricalWindow,
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): OverviewPageData {
-  const current = assembleOverviewPageData(currentRowsByModel, tier, engineScope);
-  const baseline = assembleOverviewPageData(baselineRowsByModel, tier, engineScope);
+  const current = assembleOverviewPageData(
+    currentRowsByModel,
+    tier,
+    engineScope,
+    referenceHardware,
+  );
+  const baseline = assembleOverviewPageData(
+    baselineRowsByModel,
+    tier,
+    engineScope,
+    referenceHardware,
+  );
   const baselineByKey = new Map(
     baseline.models.flatMap((model) =>
       model.platforms.map((platform) => [overviewPlatformKey(model, platform), platform] as const),

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -212,7 +212,7 @@ const OVERVIEW_SLICE_PRIORITY = [
 const OVERVIEW_PRECISIONS: readonly string[] = [Precision.FP4, Precision.FP8];
 /** The registry label verbatim, rack SKU included — the matrix says
  *  "GB200 NVL72", not "GB200", so a rack part is never read as a board. */
-function overviewHardwareLabel(hardware: string, model: Model): string {
+export function overviewHardwareLabel(hardware: string, model?: Model): string {
   return getHardwareConfig(hardware, model).label;
 }
 

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
   buildOverviewDashboardHref,
   detailHref,
+  mergeOverviewControlHref,
   overviewEngineScopeHref,
   overviewHref,
   overviewTierHref,
@@ -194,6 +195,24 @@ describe('overviewHref', () => {
 });
 
 describe('overview switch links', () => {
+  it('merges rapid control changes into the latest pending overview URL', () => {
+    const tierHref = mergeOverviewControlHref('/overview', '/overview?tier=75', ['tier']);
+    const engineHref = mergeOverviewControlHref(tierHref, '/overview?engine=all', ['engine']);
+    const referenceHref = mergeOverviewControlHref(engineHref, '/overview?ref=gb200', ['ref']);
+
+    expect(referenceHref).toBe('/overview?tier=75&engine=all&ref=gb200');
+  });
+
+  it('removes defaulted control params without dropping other pending selections', () => {
+    expect(
+      mergeOverviewControlHref(
+        '/zh/overview?tier=75&engine=all&ref=gb300&compare=30d',
+        '/zh/overview?tier=75&ref=gb300&compare=30d',
+        ['engine'],
+      ),
+    ).toBe('/zh/overview?tier=75&ref=gb300&compare=30d');
+  });
+
   it.each([
     ['en', 100, 'community', '/overview?tier=100'],
     ['en', 100, 'all', '/overview?tier=100&engine=all'],

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -180,6 +180,17 @@ describe('overviewHref', () => {
       '/zh/overview?tier=100&engine=all&compare=30d',
     );
   });
+
+  it('omits the B200 default reference and preserves a non-default reference in every mode', () => {
+    expect(overviewHref('en', 50, 'community', 'hardware', 'b200')).toBe('/overview');
+    expect(overviewHref('en', 50, 'community', 'hardware', 'b300')).toBe('/overview?ref=b300');
+    expect(overviewHref('en', 100, 'all', 'history', 'b300')).toBe(
+      '/overview?tier=100&engine=all&ref=b300&compare=30d',
+    );
+    expect(overviewHref('zh', 50, 'community', 'history', 'b300')).toBe(
+      '/zh/overview?ref=b300&compare=30d',
+    );
+  });
 });
 
 describe('overview switch links', () => {
@@ -202,6 +213,12 @@ describe('overview switch links', () => {
     );
   });
 
+  it('preserves the selected reference when changing tiers', () => {
+    expect(overviewTierHref('en', 75, 'all', 'hardware', 'b300')).toBe(
+      '/overview?tier=75&engine=all&ref=b300',
+    );
+  });
+
   it.each([
     ['en', 'all', 50, '/overview?engine=all'],
     ['en', 'all', 100, '/overview?tier=100&engine=all'],
@@ -218,6 +235,12 @@ describe('overview switch links', () => {
   it('preserves historical comparison when changing engine scope', () => {
     expect(overviewEngineScopeHref('en', 'all', 50, 'history')).toBe(
       '/overview?engine=all&compare=30d',
+    );
+  });
+
+  it('preserves the selected reference when changing engine scope', () => {
+    expect(overviewEngineScopeHref('en', 'all', 50, 'hardware', 'gb300')).toBe(
+      '/overview?engine=all&ref=gb300',
     );
   });
 });

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -10,6 +10,42 @@ import {
   type OverviewReferenceHardware,
   type OverviewTier,
 } from './overview-data';
+
+export type OverviewSearchKey = 'tier' | 'engine' | 'ref' | 'compare';
+
+const OVERVIEW_SEARCH_ORDER: readonly OverviewSearchKey[] = ['tier', 'engine', 'ref', 'compare'];
+
+/** Apply one control's destination to the latest pending overview URL.
+ * This prevents a second, fast selection from rebuilding from stale server
+ * props while the first App Router transition is still in flight. */
+export function mergeOverviewControlHref(
+  currentHref: string,
+  targetHref: string,
+  keys: readonly OverviewSearchKey[],
+): string {
+  const origin = 'https://inferencex.local';
+  const current = new URL(currentHref, origin);
+  const target = new URL(targetHref, origin);
+
+  current.pathname = target.pathname;
+  for (const key of keys) {
+    const value = target.searchParams.get(key);
+    if (value === null) current.searchParams.delete(key);
+    else current.searchParams.set(key, value);
+  }
+
+  const ordered = new URLSearchParams();
+  for (const key of OVERVIEW_SEARCH_ORDER) {
+    const value = current.searchParams.get(key);
+    if (value !== null) ordered.set(key, value);
+  }
+  for (const [key, value] of current.searchParams) {
+    if (!OVERVIEW_SEARCH_ORDER.includes(key as OverviewSearchKey)) ordered.append(key, value);
+  }
+
+  const search = ordered.toString();
+  return `${current.pathname}${search === '' ? '' : `?${search}`}${target.hash}`;
+}
 import type { UrlStateParams } from './url-state';
 
 function overviewSequence(model: OverviewModelSummary): '8k/1k' | 'agentic-traces' {

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -1,11 +1,13 @@
 import { runIdFromRunUrl } from './known-issues';
 import {
   OVERVIEW_DEFAULT_COMPARISON_MODE,
+  OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   OVERVIEW_PRIMARY_TIER,
   type OverviewComparisonMode,
   type OverviewConfigResult,
   type OverviewEngineScope,
   type OverviewModelSummary,
+  type OverviewReferenceHardware,
   type OverviewTier,
 } from './overview-data';
 import type { UrlStateParams } from './url-state';
@@ -97,11 +99,15 @@ export function overviewHref(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): string {
   const base = locale === 'zh' ? '/zh/overview' : '/overview';
   const query = new URLSearchParams();
   if (tier !== OVERVIEW_PRIMARY_TIER) query.set('tier', String(tier));
   if (engineScope !== 'community') query.set('engine', engineScope);
+  if (referenceHardware !== OVERVIEW_DEFAULT_REFERENCE_HARDWARE) {
+    query.set('ref', referenceHardware);
+  }
   if (comparisonMode === 'history') query.set('compare', '30d');
   const search = query.toString();
   return search === '' ? base : `${base}?${search}`;
@@ -113,8 +119,9 @@ export function overviewTierHref(
   tier: OverviewTier,
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): string {
-  return overviewHref(locale, tier, engineScope, comparisonMode);
+  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware);
 }
 
 /** Engine-scope switch preserving the active service tier. */
@@ -123,6 +130,7 @@ export function overviewEngineScopeHref(
   engineScope: OverviewEngineScope,
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
+  referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
 ): string {
-  return overviewHref(locale, tier, engineScope, comparisonMode);
+  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware);
 }


### PR DESCRIPTION
## Summary

- switch overview selectors through App Router transitions without full-page reloads
- support B200, MI355X, B300, GB200, and GB300 as the comparison reference
- preserve the selected reference across SLO, engine scope, history mode, and locale URLs
- update deltas, reference styling, legends, and accessible labels against the selected hardware

Unofficial-run overlay: N/A. `/overview` is server-rendered and does not consume unofficial overlays.

## Validation

- 3,638 workspace unit tests
- 195 Cypress component tests
- 587 Cypress integration tests
- Overview E2E: 22/22 in Chrome and Firefox
- typecheck, lint, format, production fixture build

## 中文说明

- Overview 筛选项改用 App Router 软导航，切换时不再整页刷新
- 支持选择 B200、MI355X、B300、GB200 或 GB300 作为对比基准
- 在 SLO、引擎范围、历史对比和中英文 URL 间保留所选基准
- 根据所选硬件动态更新成本差异、基准列样式、图例和无障碍文案

非官方运行覆盖层：不适用。`/overview` 由服务端渲染，不读取非官方运行覆盖层。

验证：3,638 个 workspace 单元测试、195 个 Cypress 组件测试、587 个 Cypress 集成测试，以及 Chrome/Firefox 各 22 个 Overview E2E 均通过；typecheck、lint、format 与 production fixture build 通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core overview pricing/delta assembly and client navigation state; behavior is well covered by unit and E2E tests but URL merging and transition timing could still cause edge-case desync.
> 
> **Overview**
> The overview page now changes **tier, engine scope, comparison mode, and reference hardware** through **App Router soft navigation** (`router.push` with `scroll: false`) instead of full document reloads. Controls stay real links for shareability; ordinary clicks go through `OverviewNavLink` / `OverviewNavigationProvider`, which merge pending query params via `mergeOverviewControlHref` so rapid successive changes don’t lose state while transitions are in flight. The header **language toggle** listens for `CLIENT_SEARCH_CHANGE_EVENT` so `?tier=`, `?ref=`, etc. stay correct when only search params change.
> 
> **Hardware comparison** is no longer fixed to B200: a new **`?ref=`** param (default B200) lets users pick among supported platforms. Server pages resolve `ref` and pass it into `getOverviewPageData`; cost deltas use **`costVsReferencePct`**, and the matrix highlights the reference column, updates legends/ARIA (∞ baseline), and embeds an **`OverviewReferenceSelect`** in the active “vs …” tab. Canonical URLs omit default `ref=b200`; other controls preserve `ref` across tier, engine, history mode, and locale links.
> 
> Cypress coverage adds scenarios for preserved window state on soft nav, rapid control changes, reference selection end-to-end, and rack SKU labels (e.g. GB200 NVL72).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46a81537f9cae3f4fba8337af7de8e7215a7d24e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->