### PR TITLE
fix(inference): block cross-engine STP comparisons at 8K/1K / 8K/1K 场景禁止跨引擎标准 token 对比

### DIFF
--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -69,6 +69,7 @@ import {
 import { resolveComparisonEntries } from './utils/comparisonEntry';
 import {
   comparisonDefaultGroup,
+  comparisonExclusionPolicy,
   comparisonExclusion as resolveComparisonExclusion,
 } from './utils/comparison-exclusion';
 import { resolveLabelState, serializeLabelState } from './utils/label-defaults';
@@ -146,11 +147,10 @@ export function InferenceProvider({
     [selectedModel, effectiveSequence, isUnofficialRun],
   );
   const defaultExclusionGroup = useMemo(
-    () => comparisonDefaultGroup(selectedModel, effectiveSequence, isUnofficialRun),
-    [selectedModel, effectiveSequence, isUnofficialRun],
+    () => comparisonDefaultGroup(effectiveSequence, isUnofficialRun),
+    [effectiveSequence, isUnofficialRun],
   );
-  const exclusionPolicy: ExclusionConflictPolicy =
-    sequenceKind(effectiveSequence) === 'agentic' ? 'keep-sticky' : 'clear-all';
+  const exclusionPolicy: ExclusionConflictPolicy = comparisonExclusionPolicy(effectiveSequence);
 
   // ── GPU comparison state (owned by inference, not global) ─────────────────
   const [selectedDates, setSelectedDates] = useState<string[]>(() => {
@@ -1083,8 +1083,9 @@ export function InferenceProvider({
     }
     if (exclusion) {
       // Automatic resets must never surface multiple incomparable engine groups.
-      // AgentX keeps one sticky group so its chart remains useful; variant-only
-      // rules retain the existing clear-all behavior.
+      // Scenarios that restrict standard-token engines (8K/1K, AgentX) keep one
+      // sticky group so their charts remain useful; variant-only rules retain
+      // the existing clear-all behavior.
       const { result, droppedGroups } = resolveHwSelection(hwTypesWithData);
       setActiveHwTypes(result);
       if (droppedGroups.length > 0) {

--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -3,16 +3,16 @@ import { describe, expect, it } from 'vitest';
 import { resolveExclusionGroups, resolveExclusionToggle } from '@/lib/exclusion';
 import { Model, Sequence } from '@/lib/data-mappings';
 
-import { comparisonDefaultGroup, comparisonExclusion } from './comparison-exclusion';
+import {
+  comparisonDefaultGroup,
+  comparisonExclusion,
+  comparisonExclusionPolicy,
+} from './comparison-exclusion';
 
 describe('comparisonExclusion', () => {
   it('defaults official DeepSeek V4 Pro Agentic charts to vLLM', () => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
-    const fallbackGroup = comparisonDefaultGroup(
-      Model.DeepSeek_V4_Pro,
-      Sequence.AgenticTraces,
-      false,
-    );
+    const fallbackGroup = comparisonDefaultGroup(Sequence.AgenticTraces, false);
     const resolved = resolveExclusionGroups(
       new Set(['b200_sglang', 'b200_vllm']),
       new Set(),
@@ -26,10 +26,10 @@ describe('comparisonExclusion', () => {
     expect(resolved.droppedGroups).toEqual(['sglang']);
   });
 
-  it('keeps the vLLM default when arriving from a fixed-sequence chart', () => {
-    // The dashboard lands on 8K/1K, where per-hardware STP keys are unrestricted,
-    // so both engines are active before the user picks Agentic Traces. That prior
-    // selection names both groups and must not out-vote the chart's vLLM default.
+  it('keeps the vLLM default when arriving from an unrestricted chart', () => {
+    // 1K/1K leaves per-hardware STP keys unrestricted, so both engines are active
+    // before the user picks Agentic Traces. That prior selection names both groups
+    // and must not out-vote the chart's vLLM default.
     const fixedSeqSelection = new Set([
       'b200_sglang',
       'b200_vllm',
@@ -53,7 +53,7 @@ describe('comparisonExclusion', () => {
       fixedSeqSelection,
       exclusion,
       'keep-sticky',
-      comparisonDefaultGroup(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false),
+      comparisonDefaultGroup(Sequence.AgenticTraces, false),
     );
 
     expect([...resolved.result].toSorted()).toEqual([
@@ -73,7 +73,7 @@ describe('comparisonExclusion', () => {
       new Set(['b200_sglang']),
       exclusion,
       'keep-sticky',
-      comparisonDefaultGroup(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false),
+      comparisonDefaultGroup(Sequence.AgenticTraces, false),
     );
 
     expect([...resolved.result]).toEqual(['b200_sglang']);
@@ -81,26 +81,74 @@ describe('comparisonExclusion', () => {
   });
 
   it.each([
+    { name: 'the 8K/1K chart', sequence: Sequence.EightK_OneK, isUnofficialRun: false },
+    { name: 'the Agentic chart', sequence: Sequence.AgenticTraces, isUnofficialRun: false },
+  ])('defaults $name to vLLM', ({ sequence, isUnofficialRun }) => {
+    expect(comparisonDefaultGroup(sequence, isUnofficialRun)).toBe('vllm');
+    expect(comparisonExclusionPolicy(sequence)).toBe('keep-sticky');
+  });
+
+  it.each([
     {
-      name: 'fixed-sequence DeepSeek V4 Pro',
-      model: Model.DeepSeek_V4_Pro,
+      name: 'a deprecated fixed sequence',
+      sequence: Sequence.OneK_OneK,
+      isUnofficialRun: false,
+    },
+    {
+      name: 'an unofficial 8K/1K preview',
       sequence: Sequence.EightK_OneK,
-      isUnofficialRun: false,
+      isUnofficialRun: true,
     },
     {
-      name: 'another Agentic model',
-      model: Model.DeepSeek_R1,
-      sequence: Sequence.AgenticTraces,
-      isUnofficialRun: false,
-    },
-    {
-      name: 'an unofficial DeepSeek V4 Pro Agentic preview',
-      model: Model.DeepSeek_V4_Pro,
+      name: 'an unofficial Agentic preview',
       sequence: Sequence.AgenticTraces,
       isUnofficialRun: true,
     },
-  ])('does not impose the vLLM default on $name', ({ model, sequence, isUnofficialRun }) => {
-    expect(comparisonDefaultGroup(model, sequence, isUnofficialRun)).toBeNull();
+  ])('does not impose the vLLM default on $name', ({ sequence, isUnofficialRun }) => {
+    expect(comparisonDefaultGroup(sequence, isUnofficialRun)).toBeNull();
+  });
+
+  it('leaves deprecated fixed sequences on the clear-all policy', () => {
+    expect(comparisonExclusionPolicy(Sequence.OneK_OneK)).toBe('clear-all');
+    expect(comparisonExclusionPolicy(Sequence.OneK_EightK)).toBe('clear-all');
+  });
+
+  it('defaults an official 8K/1K chart to vLLM per hardware SKU', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
+    const resolved = resolveExclusionGroups(
+      new Set(['b200_sglang', 'b200_vllm', 'b200_trt', 'mi355x_atom', 'mi355x_vllm']),
+      new Set(),
+      exclusion,
+      comparisonExclusionPolicy(Sequence.EightK_OneK),
+      comparisonDefaultGroup(Sequence.EightK_OneK, false),
+    );
+
+    // TRTLLM sits outside the rule, so it survives next to the kept vLLM configs.
+    expect([...resolved.result].toSorted()).toEqual(['b200_trt', 'b200_vllm', 'mi355x_vllm']);
+    expect(resolved.droppedGroups).toEqual(['sglang']);
+  });
+
+  it('keeps a per-SKU SGLang choice on the 8K/1K chart', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
+    const resolved = resolveExclusionGroups(
+      new Set(['b200_sglang', 'b200_vllm', 'mi355x_sglang', 'mi355x_vllm']),
+      new Set(['b200_sglang', 'mi355x_vllm']),
+      exclusion,
+      comparisonExclusionPolicy(Sequence.EightK_OneK),
+      comparisonDefaultGroup(Sequence.EightK_OneK, false),
+    );
+
+    expect([...resolved.result].toSorted()).toEqual(['b200_sglang', 'mi355x_vllm']);
+  });
+
+  it('leaves non-participating 8K/1K engine families unguarded', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
+
+    expect(exclusion.familyOf('b200_trt')).toBeNull();
+    expect(exclusion.familyOf('gb300_dynamo-trt')).toBeNull();
+    expect(exclusion.familyOf('b200_vllm')).toBe('vllm');
+    expect(exclusion.familyOf('mi355x_mooncake-atom')).toBe('atom');
+    expect(exclusion.groupOf('mi355x_mooncake-atom')).toBe('sglang');
   });
 
   it('keeps the engine-family guard for official Agentic Traces charts', () => {
@@ -158,6 +206,62 @@ describe('comparisonExclusion', () => {
       sequence: Sequence.AgenticTraces,
       active: 'b200_sglang_mtp',
       candidate: 'mi355x_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'blocks 8K/1K STP engines on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang',
+      candidate: 'b200_vllm',
+      expected: 'block',
+    },
+    {
+      name: 'blocks 8K/1K STP engines behind a deployment prefix on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'gb300_dynamo-sglang',
+      candidate: 'gb300_dynamo-vllm',
+      expected: 'block',
+    },
+    {
+      name: 'blocks 8K/1K ATOM against vLLM on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_atom',
+      candidate: 'mi355x_vllm',
+      expected: 'block',
+    },
+    {
+      name: 'allows 8K/1K STP engines on different SKUs',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang',
+      candidate: 'mi355x_vllm',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K TRTLLM next to vLLM on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_vllm',
+      candidate: 'b200_trt',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K TRTLLM next to SGLang on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang',
+      candidate: 'b200_trt',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K STP and MTP from the same engine',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_vllm',
+      candidate: 'b200_vllm_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'blocks 8K/1K MTP added to cross-engine STP on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang',
+      candidate: 'b200_vllm_mtp',
       expected: 'block',
     },
     {

--- a/packages/app/src/components/inference/utils/comparison-exclusion.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.ts
@@ -1,19 +1,34 @@
-import { getModelExclusion, getSequenceExclusion, Model, Sequence } from '@/lib/data-mappings';
-import { buildExclusion, type Exclusion } from '@/lib/exclusion';
+import {
+  getModelExclusion,
+  getSequenceDefaultExclusionGroup,
+  getSequenceExclusion,
+  getSequenceExclusionPolicy,
+} from '@/lib/data-mappings';
+import { buildExclusion, type Exclusion, type ExclusionConflictPolicy } from '@/lib/exclusion';
 
 /**
  * Preferred engine group when an official comparison first encounters multiple
- * valid groups and has no sticky user selection to preserve.
+ * valid groups and has no sticky user selection to preserve. Unofficial
+ * previews impose no guard, so they have no default either.
  */
 export function comparisonDefaultGroup(
-  model: Parameters<typeof getModelExclusion>[0],
   sequence: Parameters<typeof getSequenceExclusion>[0],
   isUnofficialRun: boolean,
 ): string | null {
-  if (!isUnofficialRun && model === Model.DeepSeek_V4_Pro && sequence === Sequence.AgenticTraces) {
-    return 'vllm';
-  }
-  return null;
+  if (isUnofficialRun) return null;
+  return getSequenceDefaultExclusionGroup(sequence);
+}
+
+/**
+ * How the current scenario resolves a multi-group selection. Scenarios that
+ * restrict standard-token engines keep one group so the chart still renders on
+ * load; variant-only rules (e.g. fixed-seq MTP alone) clear every conflicting
+ * group so those configs stay deselected until the user picks one.
+ */
+export function comparisonExclusionPolicy(
+  sequence: Parameters<typeof getSequenceExclusion>[0],
+): ExclusionConflictPolicy {
+  return getSequenceExclusionPolicy(sequence);
 }
 
 /**

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -5,7 +5,9 @@ import {
   getModelAndSequenceFromArtifact,
   getModelLabel,
   getModelExclusion,
+  getSequenceDefaultExclusionGroup,
   getSequenceExclusion,
+  getSequenceExclusionPolicy,
   getSequenceLabel,
   getPrecisionLabel,
   getEvalBenchmarkLabel,
@@ -218,10 +220,30 @@ describe('comparison exclusions', () => {
     expect(getModelExclusion(Model.DeepSeek_R1)).toEqual([]);
   });
 
-  it('applies the unsuffixed STP rule only to Agentic Traces', () => {
+  it('applies the unsuffixed STP rule to Agentic Traces and 8K/1K only', () => {
     expect(getSequenceExclusion(Sequence.AgenticTraces).map((spec) => spec.suffix)).toEqual([null]);
-    expect(getSequenceExclusion(Sequence.EightK_OneK)).toEqual([]);
+    expect(getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.suffix)).toEqual([null]);
     expect(getSequenceExclusion(Sequence.OneK_OneK)).toEqual([]);
+    expect(getSequenceExclusion(Sequence.OneK_EightK)).toEqual([]);
+  });
+
+  it('limits the 8K/1K STP rule to vLLM and SGLang', () => {
+    expect(
+      getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.participatingGroups),
+    ).toEqual([['vllm', 'sglang']]);
+    // Agentic keeps every engine family exclusive while the benchmark is new.
+    expect(
+      getSequenceExclusion(Sequence.AgenticTraces).map((spec) => spec.participatingGroups),
+    ).toEqual([undefined]);
+  });
+
+  it('keeps one engine group on the scenarios that restrict STP engines', () => {
+    expect(getSequenceExclusionPolicy(Sequence.EightK_OneK)).toBe('keep-sticky');
+    expect(getSequenceExclusionPolicy(Sequence.AgenticTraces)).toBe('keep-sticky');
+    expect(getSequenceExclusionPolicy(Sequence.OneK_OneK)).toBe('clear-all');
+    expect(getSequenceDefaultExclusionGroup(Sequence.EightK_OneK)).toBe('vllm');
+    expect(getSequenceDefaultExclusionGroup(Sequence.AgenticTraces)).toBe('vllm');
+    expect(getSequenceDefaultExclusionGroup(Sequence.OneK_OneK)).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -1,4 +1,4 @@
-import type { ExclusionSpec } from './exclusion';
+import type { ExclusionConflictPolicy, ExclusionSpec } from './exclusion';
 
 export enum Model {
   Llama3_3_70B = 'Llama-3.3-70B-Instruct-FP8',
@@ -69,18 +69,33 @@ const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
 ];
 
 /**
- * AgentX STP exclusion: unsuffixed standard-token configs for the same hardware
+ * Base STP exclusion: unsuffixed standard-token configs for the same hardware
  * SKU can't mix engine families. Different hardware may use different engines
- * on one graph. Fixed-sequence STP comparisons remain available; this rule is
- * attached only to the Agentic Traces sequence.
+ * on one graph.
  */
-const AGENTIC_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
-  {
-    suffix: null,
-    stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
-    groupAliases: { atom: 'sglang' },
-    scope: 'hardware',
-  },
+const STP_ENGINE_EXCLUSION_BASE = {
+  suffix: null,
+  stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
+  groupAliases: { atom: 'sglang' },
+  scope: 'hardware',
+} as const satisfies ExclusionSpec;
+
+/**
+ * AgentX STP exclusion: every engine family is its own comparability group
+ * (ATOM aliased onto SGLang) while the agentic benchmark is new.
+ */
+const AGENTIC_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [STP_ENGINE_EXCLUSION_BASE];
+
+/**
+ * Fixed-sequence STP exclusion: vLLM and SGLang tune their standard-token
+ * runs against engine-specific serving paths, so their unsuffixed numbers
+ * aren't directly comparable on one graph — same rule the MTP configs and the
+ * agentic chart already enforce. Unlike the agentic rule this one is limited to
+ * those two groups, so TRTLLM (and any other family) stays freely selectable
+ * next to either of them.
+ */
+const FIXED_SEQ_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
+  { ...STP_ENGINE_EXCLUSION_BASE, participatingGroups: ['vllm', 'sglang'] },
 ];
 
 // Total parameter counts appended to each label so users can compare model
@@ -235,6 +250,19 @@ interface SequenceConfig {
   category: CategoryTag;
   kind: ScenarioKind;
   exclusion?: ExclusionSpec[];
+  /**
+   * How this scenario resolves a selection that spans several comparability
+   * groups. `clear-all` (the default) deselects every conflicting group so the
+   * user opts into one; `keep-sticky` keeps a single group so the chart still
+   * renders data on load.
+   */
+  exclusionPolicy?: ExclusionConflictPolicy;
+  /**
+   * Comparability group preferred when `keep-sticky` has to choose and the
+   * user has no prior selection to honor. Without it the tie-break is
+   * alphabetical, which would silently land on a different engine.
+   */
+  defaultExclusionGroup?: string;
 }
 
 const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
@@ -258,6 +286,9 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     compact: '8k1k',
     category: 'default',
     kind: 'fixed-seq',
+    exclusion: FIXED_SEQ_STP_ENGINE_EXCLUSION,
+    exclusionPolicy: 'keep-sticky',
+    defaultExclusionGroup: 'vllm',
   },
   [Sequence.AgenticTraces]: {
     label: 'Agentic Traces',
@@ -266,6 +297,8 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     category: 'default',
     kind: 'agentic',
     exclusion: AGENTIC_STP_ENGINE_EXCLUSION,
+    exclusionPolicy: 'keep-sticky',
+    defaultExclusionGroup: 'vllm',
   },
 };
 
@@ -275,6 +308,22 @@ export function getSequenceExclusion(
 ): ExclusionSpec[] {
   if (!sequence) return [];
   return SEQUENCE_CONFIG[sequence as Sequence]?.exclusion ?? [];
+}
+
+/** Multi-group conflict policy for a sequence. Defaults to `clear-all`. */
+export function getSequenceExclusionPolicy(
+  sequence: Sequence | string | null | undefined,
+): ExclusionConflictPolicy {
+  if (!sequence) return 'clear-all';
+  return SEQUENCE_CONFIG[sequence as Sequence]?.exclusionPolicy ?? 'clear-all';
+}
+
+/** Preferred comparability group for a sequence, or null when unconfigured. */
+export function getSequenceDefaultExclusionGroup(
+  sequence: Sequence | string | null | undefined,
+): string | null {
+  if (!sequence) return null;
+  return SEQUENCE_CONFIG[sequence as Sequence]?.defaultExclusionGroup ?? null;
 }
 
 export const SEQUENCE_OPTIONS = Object.keys(SEQUENCE_CONFIG) as Sequence[];

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -310,6 +310,49 @@ describe('ATOM/SGLang comparability group', () => {
   });
 });
 
+describe('participatingGroups', () => {
+  // The fixed-sequence STP rule: only vLLM and SGLang (incl. ATOM) block each
+  // other; every other engine family sits outside the rule entirely.
+  const limitedEx = buildExclusion([{ ...STP_SPEC[0], participatingGroups: ['vllm', 'sglang'] }]);
+
+  it('ignores keys whose group is outside the list', () => {
+    expect(limitedEx.familyOf('b200_trt')).toBeNull();
+    expect(limitedEx.groupOf('b200_trt')).toBeNull();
+    expect(limitedEx.scopesOf('b200_trt')).toEqual([]);
+    expect(limitedEx.familyOf('gb300_dynamo-trt')).toBeNull();
+  });
+
+  it('still classifies listed groups, including aliased families', () => {
+    expect(limitedEx.groupOf('b200_vllm')).toBe('vllm');
+    expect(limitedEx.groupOf('gb300_dynamo-vllm')).toBe('vllm');
+    expect(limitedEx.groupOf('mi355x_atom')).toBe('sglang');
+    expect(limitedEx.groupOf('mi355x_mooncake-atom')).toBe('sglang');
+    expect(limitedEx.familyOf('mi355x_mooncake-atom')).toBe('atom');
+  });
+
+  it('leaves non-participating families selectable alongside either group', () => {
+    const proposed = new Set(['b200_vllm', 'b200_sglang', 'b200_trt']);
+    const sticky = pickStickyGroup(proposed, new Set(), limitedEx, 'vllm');
+    expect([...sticky.result].toSorted()).toEqual(['b200_trt', 'b200_vllm']);
+    expect(sticky.droppedGroups).toEqual(['sglang']);
+
+    expect(resolveExclusionToggle(new Set(['b200_vllm']), 'b200_trt', proposed, limitedEx)).toEqual(
+      { kind: 'fallthrough' },
+    );
+  });
+
+  it('falls through to a later spec when a group is excluded from an earlier one', () => {
+    // The 8K/1K chart layers the model MTP rule (all families) over the STP rule
+    // (vLLM/SGLang only), so TRTLLM stays guarded for `_mtp` keys.
+    const fixedSeqEx = buildExclusion([
+      ...MTP_SPEC,
+      { ...STP_SPEC[0], participatingGroups: ['vllm', 'sglang'] },
+    ]);
+    expect(fixedSeqEx.groupOf('b200_trt_mtp')).toBe('trt');
+    expect(fixedSeqEx.groupOf('b200_trt')).toBeNull();
+  });
+});
+
 describe('pickStickyGroup', () => {
   it('passes through when no participating keys present', () => {
     const set = new Set(['h100_vllm', 'gb300_sglang']);

--- a/packages/app/src/lib/exclusion.ts
+++ b/packages/app/src/lib/exclusion.ts
@@ -40,6 +40,14 @@ export interface ExclusionSpec {
    */
   groupAliases?: Record<string, string>;
   /**
+   * Restrict the rule to these comparability groups (ids AFTER `groupAliases`).
+   * A key whose group falls outside the list does not participate at all, so it
+   * may share a graph with anything. Omit to make every engine family
+   * participate. (e.g. `['vllm', 'sglang']` — TRTLLM stays freely selectable
+   * while vLLM and SGLang block each other.)
+   */
+  participatingGroups?: readonly string[];
+  /**
    * Restrict mutual exclusion to configs on the same hardware SKU. Different
    * hardware may use different engine groups on the same graph.
    */
@@ -62,11 +70,17 @@ const ACTIVE_SPEC_SUFFIXES = [...SPEC_METHOD_KEYS]
 
 const GLOBAL_SCOPE = '*';
 
+/** Comparability-group id for a raw engine family under a single spec. */
+function groupForFamily(family: string, spec: ExclusionSpec): string {
+  return spec.groupAliases?.[family] ?? family;
+}
+
 /**
  * Extract the literal engine family for `hwKey` under a single spec: strip the
  * configured variant suffix (or require an unsuffixed STP key), drop the leading
  * GPU segment, then strip any configured engine-family prefix. Returns null if
- * the key doesn't participate.
+ * the key doesn't participate — either because the suffix doesn't match or
+ * because the resolved group is outside the spec's `participatingGroups`.
  */
 function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
   let head: string;
@@ -86,7 +100,14 @@ function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
       break;
     }
   }
-  return framework || null;
+  if (!framework) return null;
+  if (
+    spec.participatingGroups &&
+    !spec.participatingGroups.includes(groupForFamily(framework, spec))
+  ) {
+    return null;
+  }
+  return framework;
 }
 
 /**
@@ -106,7 +127,7 @@ export function buildExclusion(specs: readonly ExclusionSpec[]): Exclusion {
     groupOf(hwKey: string): string | null {
       for (const spec of specs) {
         const fam = familyForSpec(hwKey, spec);
-        if (fam) return spec.groupAliases?.[fam] ?? fam;
+        if (fam) return groupForFamily(fam, spec);
       }
       return null;
     },


### PR DESCRIPTION
## Summary

At 8K/1K you could put vLLM and SGLang standard-token (non-MTP) configs on the same graph, even though their MTP counterparts — and every config on the Agentic Traces chart — are already mutually exclusive. This applies the same per-hardware engine guard to 8K/1K.

- **Rule**: on 8K/1K, a hardware SKU may show vLLM **or** SGLang standard-token configs, not both. Deployment prefixes resolve to their engine (`gb300_dynamo-vllm` → vLLM, `mi355x_mori-sglang` / `mi355x_atom` / `mi355x_mooncake-atom` → SGLang). Different SKUs may still use different engines, exactly like the agentic rule.
- **TRTLLM is unaffected**: unlike the agentic rule (where every family is its own group), the 8K/1K rule participates only in the vLLM and SGLang groups, so `b200_trt` / `gb300_dynamo-trt` stay freely selectable next to either engine. This is a new `participatingGroups` field on `ExclusionSpec` — keys whose group falls outside the list don't participate at all.
- **MTP is unchanged in kind**: `*_mtp` keys keep the existing chart-wide, all-families model rule. Adding vLLM MTP while SGLang standard-token is active on the same SKU is blocked, as on the agentic chart.
- **Default selection**: the conflict policy and preferred group move from a hardcoded `sequenceKind === 'agentic'` check into `SEQUENCE_CONFIG` — 8K/1K and Agentic Traces are both `keep-sticky` + `vllm`. A fresh 8K/1K load therefore keeps vLLM per SKU instead of emptying every conflicting SKU (`clear-all`) or landing on SGLang via the alphabetical tie-break.
- Explicitly adding a conflicting engine is blocked with the existing bilingual `EngineComparisonConflictToast`; reset / select-all / preset / URL-restore paths resolve silently to one group. No new user-visible strings, so no `/zh` changes are required.

### Behavior changes worth flagging

1. **The 8K/1K default view now shows one engine per SKU.** With DeepSeek V4 Pro, SKUs that publish both engines (b200, b300, gb200, gb300, h200, mi355x) default to their vLLM configs; SGLang stays one legend click away, and TRTLLM still renders alongside.
2. **The vLLM default is now sequence-driven, not model-gated.** It previously applied only to DeepSeek V4 Pro on Agentic Traces. Any model hitting a conflict on 8K/1K or Agentic Traces now defaults to vLLM instead of the alphabetical tie-break.
3. Deprecated fixed sequences (1K/1K, 1K/8K) are untouched: no standard-token rule, `clear-all` policy.
4. Unofficial `?unofficialrun=` previews are unchanged — they still disable the guard entirely so official and preview engines stay comparable, and they get no default group.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` — pass
- `bun run test:unit` — 3150 app tests pass, including new coverage for `participatingGroups` (`exclusion.test.ts`), the sequence config (`data-mappings.test.ts`), and the 8K/1K block / allow matrix and default resolution (`comparison-exclusion.test.ts`)
- `bun run test:e2e` — see the check runs on this PR
- Manual verification on a local dev server against the read-only DB

## 中文说明

在 8K/1K 场景下，vLLM 与 SGLang 的标准 token（非 MTP）配置此前可以显示在同一张图上，而它们的 MTP 配置以及智能体轨迹（Agentic Traces）图表上的所有配置早已互斥。本 PR 为 8K/1K 补上同样的按硬件引擎约束。

- **规则**：在 8K/1K 下，同一硬件 SKU 只能显示 vLLM **或** SGLang 的标准 token 配置。部署前缀会归并到对应引擎（`gb300_dynamo-vllm` → vLLM，`mi355x_mori-sglang` / `mi355x_atom` / `mi355x_mooncake-atom` → SGLang）。不同 SKU 仍可分别使用不同引擎，与智能体轨迹规则一致。
- **不影响 TRTLLM**：与智能体轨迹规则（每个引擎系列各成一组）不同，8K/1K 规则只作用于 vLLM 与 SGLang 两个分组，因此 `b200_trt` / `gb300_dynamo-trt` 仍可与任一引擎同图显示。这由 `ExclusionSpec` 新增的 `participatingGroups` 字段实现：分组不在列表内的配置完全不参与该规则。
- **MTP 规则性质不变**：`*_mtp` 配置沿用原有的、覆盖所有引擎系列的模型级全图规则。在同一 SKU 上已启用 SGLang 标准 token 时再添加 vLLM MTP 仍会被拦截，与智能体轨迹图表一致。
- **默认选择**：冲突处理策略与首选分组从硬编码的 `sequenceKind === 'agentic'` 判断下沉到 `SEQUENCE_CONFIG`——8K/1K 与智能体轨迹均为 `keep-sticky` + `vllm`。因此首次加载 8K/1K 时会按 SKU 保留 vLLM，而不是清空所有存在冲突的 SKU（`clear-all`），也不会按字母顺序选中 SGLang。
- 用户主动添加冲突引擎时，仍由现有的双语 `EngineComparisonConflictToast` 提示拦截；重置、全选、预设与 URL 恢复等路径则静默收敛到单一分组。本次未新增任何用户可见文案，因此无需改动 `/zh` 页面。

### 需要留意的行为变化

1. **8K/1K 默认视图现在每个 SKU 只显示一个引擎。** 以 DeepSeek V4 Pro 为例，同时提供两种引擎的 SKU（b200、b300、gb200、gb300、h200、mi355x）默认展示 vLLM 配置；SGLang 只需在图例中点击一次即可切换，TRTLLM 仍会同时显示。
2. **vLLM 默认值改由场景决定，不再仅限特定模型。** 此前仅对智能体轨迹下的 DeepSeek V4 Pro 生效；现在任何模型在 8K/1K 或智能体轨迹下遇到冲突时，都会默认选择 vLLM，而非按字母顺序决定。
3. 已弃用的固定序列场景（1K/1K、1K/8K）保持不变：不启用标准 token 规则，仍使用 `clear-all` 策略。
4. 非官方运行预览（`?unofficialrun=`）行为不变——仍完全关闭该约束，以便官方与预览运行的引擎可以对比，且不设默认分组。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default legend behavior on 8K/1K (one engine per SKU) and centralizes exclusion policy in sequence config; logic is heavily tested but affects core chart comparison UX.
> 
> **Overview**
> **8K/1K** now uses the same per-SKU standard-token (STP) engine guard as Agentic Traces: vLLM and SGLang cannot share one graph on the same hardware, while different SKUs may still differ. The 8K/1K rule is narrower—only those two groups participate—so **TRTLLM** and other families stay selectable next to either engine.
> 
> `ExclusionSpec` gains **`participatingGroups`** so rules can ignore non-listed comparability groups. Default conflict policy and preferred engine (**vLLM**, **keep-sticky**) move from hardcoded Agentic / model checks into **`SEQUENCE_CONFIG`** for both 8K/1K and Agentic Traces, so any model gets the same defaults on those scenarios. **`InferenceContext`** reads policy and defaults via **`comparisonExclusionPolicy`** / sequence-only **`comparisonDefaultGroup`**.
> 
> Deprecated fixed sequences and unofficial preview runs are unchanged (no STP rule / no guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18a9f968c3da958f60921e2f2a0a3b30d494246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->