### PR TITLE
fix(inference): exempt ATOM from the 8K/1K engine guard / 8K/1K 引擎互斥规则豁免 ATOM

### DIFF
--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -116,15 +116,32 @@ describe('comparisonExclusion', () => {
   it('defaults an official 8K/1K chart to vLLM per hardware SKU', () => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
     const resolved = resolveExclusionGroups(
-      new Set(['b200_sglang', 'b200_vllm', 'b200_trt', 'mi355x_atom', 'mi355x_vllm']),
+      new Set([
+        'b200_sglang',
+        'b200_vllm',
+        'b200_trt',
+        'mi355x_atom',
+        'mi355x_atom_mtp',
+        'mi355x_sglang',
+        'mi355x_vllm',
+        'mi355x_vllm_mtp',
+      ]),
       new Set(),
       exclusion,
       comparisonExclusionPolicy(Sequence.EightK_OneK),
       comparisonDefaultGroup(Sequence.EightK_OneK, false),
     );
 
-    // TRTLLM sits outside the rule, so it survives next to the kept vLLM configs.
-    expect([...resolved.result].toSorted()).toEqual(['b200_trt', 'b200_vllm', 'mi355x_vllm']);
+    // TRTLLM STP and ATOM (STP and MTP alike) sit outside the 8K/1K rules, so
+    // they survive next to the kept vLLM configs — only SGLang is dropped.
+    expect([...resolved.result].toSorted()).toEqual([
+      'b200_trt',
+      'b200_vllm',
+      'mi355x_atom',
+      'mi355x_atom_mtp',
+      'mi355x_vllm',
+      'mi355x_vllm_mtp',
+    ]);
     expect(resolved.droppedGroups).toEqual(['sglang']);
   });
 
@@ -146,9 +163,33 @@ describe('comparisonExclusion', () => {
 
     expect(exclusion.familyOf('b200_trt')).toBeNull();
     expect(exclusion.familyOf('gb300_dynamo-trt')).toBeNull();
-    expect(exclusion.familyOf('b200_vllm')).toBe('vllm');
-    expect(exclusion.familyOf('mi355x_mooncake-atom')).toBe('atom');
-    expect(exclusion.groupOf('mi355x_mooncake-atom')).toBe('sglang');
+    // ATOM is exempt from every 8K/1K rule — standard-token AND MTP.
+    expect(exclusion.familyOf('mi355x_atom')).toBeNull();
+    expect(exclusion.familyOf('mi355x_mooncake-atom')).toBeNull();
+    expect(exclusion.groupOf('mi355x_mooncake-atom')).toBeNull();
+    expect(exclusion.familyOf('mi355x_atom_mtp')).toBeNull();
+    expect(exclusion.groupOf('mi355x_atom_mtp')).toBeNull();
+    expect(exclusion.groupOf('mi355x_mooncake-atom_mtp')).toBeNull();
+    // TRTLLM keeps the pre-existing MTP guard; only its STP keys are free.
+    expect(exclusion.groupOf('b200_trt_mtp')).toBe('trt');
+  });
+
+  it('keeps ATOM grouped with SGLang on the Agentic chart', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
+
+    expect(exclusion.groupOf('mi355x_atom')).toBe('sglang');
+    expect(exclusion.groupOf('mi355x_atom_mtp')).toBe('sglang');
+  });
+
+  it('guards only the literal vLLM and SGLang families on the 8K/1K chart', () => {
+    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
+
+    expect(exclusion.groupOf('b200_vllm')).toBe('vllm');
+    expect(exclusion.groupOf('gb300_dynamo-vllm')).toBe('vllm');
+    expect(exclusion.groupOf('gb200_llmd-vllm')).toBe('vllm');
+    expect(exclusion.groupOf('b200_sglang')).toBe('sglang');
+    expect(exclusion.groupOf('gb300_dynamo-sglang')).toBe('sglang');
+    expect(exclusion.groupOf('mi355x_mori-sglang')).toBe('sglang');
   });
 
   it('keeps the engine-family guard for official Agentic Traces charts', () => {
@@ -223,10 +264,87 @@ describe('comparisonExclusion', () => {
       expected: 'block',
     },
     {
-      name: 'blocks 8K/1K ATOM against vLLM on the same SKU',
+      name: 'allows 8K/1K ATOM next to vLLM on the same SKU',
       sequence: Sequence.EightK_OneK,
       active: 'mi355x_atom',
       candidate: 'mi355x_vllm',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K vLLM next to ATOM on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_vllm',
+      candidate: 'mi355x_atom',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K ATOM next to SGLang on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_sglang',
+      candidate: 'mi355x_atom',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K Mooncake ATOMesh next to vLLM on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_vllm',
+      candidate: 'mi355x_mooncake-atom',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'blocks 8K/1K MoRI SGLang against vLLM on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_mori-sglang',
+      candidate: 'mi355x_vllm',
+      expected: 'block',
+    },
+    {
+      name: 'allows 8K/1K ATOM MTP next to vLLM MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_atom_mtp',
+      candidate: 'mi355x_vllm_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K vLLM MTP next to ATOM MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_vllm_mtp',
+      candidate: 'mi355x_atom_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K ATOM MTP next to SGLang MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_sglang_mtp',
+      candidate: 'mi355x_atom_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K ATOM MTP next to vLLM STP on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_vllm',
+      candidate: 'mi355x_atom_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'still blocks 8K/1K cross-engine MTP globally',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang_mtp',
+      candidate: 'mi355x_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'still blocks 8K/1K TRTLLM MTP against vLLM MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_trt_mtp',
+      candidate: 'b200_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'keeps the Agentic ATOM MTP guard untouched',
+      sequence: Sequence.AgenticTraces,
+      active: 'mi355x_atom_mtp',
+      candidate: 'mi355x_vllm_mtp',
       expected: 'block',
     },
     {

--- a/packages/app/src/components/inference/utils/comparison-exclusion.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.ts
@@ -2,6 +2,7 @@ import {
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
   getSequenceExclusion,
+  getSequenceExclusionExemptFamilies,
   getSequenceExclusionPolicy,
 } from '@/lib/data-mappings';
 import { buildExclusion, type Exclusion, type ExclusionConflictPolicy } from '@/lib/exclusion';
@@ -35,6 +36,11 @@ export function comparisonExclusionPolicy(
  * Resolve the production comparability guard for the current chart scope.
  * Unofficial previews are diagnostic and intentionally allow engine families
  * to share a graph, even when the corresponding official view does not.
+ *
+ * The scenario's exempt families are composed onto the model specs too, so a
+ * family the scenario declares comparable (8K/1K ATOM) escapes the model-level
+ * variant rule as well — otherwise its MTP configs would still be grouped and
+ * blocked.
  */
 export function comparisonExclusion(
   model: Parameters<typeof getModelExclusion>[0],
@@ -43,10 +49,12 @@ export function comparisonExclusion(
 ): Exclusion | null {
   if (isUnofficialRun) return null;
 
-  const modelSpecs = getModelExclusion(model);
-  const sequenceSpecs = getSequenceExclusion(sequence);
-  if (modelSpecs.length === 0 && sequenceSpecs.length === 0) return null;
-  if (modelSpecs.length === 0) return buildExclusion(sequenceSpecs);
-  if (sequenceSpecs.length === 0) return buildExclusion(modelSpecs);
-  return buildExclusion([...modelSpecs, ...sequenceSpecs]);
+  const specs = [...getModelExclusion(model), ...getSequenceExclusion(sequence)];
+  if (specs.length === 0) return null;
+
+  const exempt = getSequenceExclusionExemptFamilies(sequence);
+  if (exempt.length === 0) return buildExclusion(specs);
+  return buildExclusion(
+    specs.map((spec) => ({ ...spec, exemptFamilies: [...(spec.exemptFamilies ?? []), ...exempt] })),
+  );
 }

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -7,6 +7,7 @@ import {
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
   getSequenceExclusion,
+  getSequenceExclusionExemptFamilies,
   getSequenceExclusionPolicy,
   getSequenceLabel,
   getPrecisionLabel,
@@ -227,14 +228,20 @@ describe('comparison exclusions', () => {
     expect(getSequenceExclusion(Sequence.OneK_EightK)).toEqual([]);
   });
 
-  it('limits the 8K/1K STP rule to vLLM and SGLang', () => {
+  it('limits the 8K/1K STP rule to the literal vLLM and SGLang families', () => {
     expect(
-      getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.participatingGroups),
+      getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.participatingFamilies),
     ).toEqual([['vllm', 'sglang']]);
     // Agentic keeps every engine family exclusive while the benchmark is new.
     expect(
-      getSequenceExclusion(Sequence.AgenticTraces).map((spec) => spec.participatingGroups),
+      getSequenceExclusion(Sequence.AgenticTraces).map((spec) => spec.participatingFamilies),
     ).toEqual([undefined]);
+  });
+
+  it('exempts ATOM from every 8K/1K rule but not from the Agentic ones', () => {
+    expect(getSequenceExclusionExemptFamilies(Sequence.EightK_OneK)).toEqual(['atom']);
+    expect(getSequenceExclusionExemptFamilies(Sequence.AgenticTraces)).toEqual([]);
+    expect(getSequenceExclusionExemptFamilies(Sequence.OneK_OneK)).toEqual([]);
   });
 
   it('keeps one engine group on the scenarios that restrict STP engines', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -87,15 +87,20 @@ const STP_ENGINE_EXCLUSION_BASE = {
 const AGENTIC_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [STP_ENGINE_EXCLUSION_BASE];
 
 /**
- * Fixed-sequence STP exclusion: vLLM and SGLang tune their standard-token
- * runs against engine-specific serving paths, so their unsuffixed numbers
- * aren't directly comparable on one graph — same rule the MTP configs and the
- * agentic chart already enforce. Unlike the agentic rule this one is limited to
- * those two groups, so TRTLLM (and any other family) stays freely selectable
- * next to either of them.
+ * Fixed-sequence STP exclusion: vLLM and SGLang tune their standard-token runs
+ * against engine-specific serving paths, so their unsuffixed numbers aren't
+ * directly comparable on one graph — same rule the MTP configs and the agentic
+ * chart already enforce.
+ *
+ * Unlike the agentic rule this one covers ONLY the literal vLLM and SGLang
+ * families (with their `dynamo-`/`mori-`/`llmd-` deployment variants). Every
+ * other engine — ATOM and Mooncake ATOMesh included, despite the SGLang group
+ * alias the MTP rule relies on — stays freely selectable next to either of
+ * them. `participatingFamilies` is matched before `groupAliases` precisely so
+ * ATOM escapes here while still sharing SGLang's MTP comparability group.
  */
 const FIXED_SEQ_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
-  { ...STP_ENGINE_EXCLUSION_BASE, participatingGroups: ['vllm', 'sglang'] },
+  { ...STP_ENGINE_EXCLUSION_BASE, participatingFamilies: ['vllm', 'sglang'] },
 ];
 
 // Total parameter counts appended to each label so users can compare model
@@ -263,6 +268,13 @@ interface SequenceConfig {
    * alphabetical, which would silently land on a different engine.
    */
   defaultExclusionGroup?: string;
+  /**
+   * Engine families exempt from EVERY exclusion rule on this scenario —
+   * composed onto the model specs as well as this sequence's own. Use it when a
+   * family's numbers are comparable with everything in one scenario but still
+   * need grouping elsewhere.
+   */
+  exclusionExemptFamilies?: readonly string[];
 }
 
 const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
@@ -289,6 +301,10 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     exclusion: FIXED_SEQ_STP_ENGINE_EXCLUSION,
     exclusionPolicy: 'keep-sticky',
     defaultExclusionGroup: 'vllm',
+    // ATOM stays comparable with both vLLM and SGLang here — for its MTP
+    // configs as well, which the model-level rule would otherwise fold into
+    // SGLang's group. Only vLLM and SGLang block each other on 8K/1K.
+    exclusionExemptFamilies: ['atom'],
   },
   [Sequence.AgenticTraces]: {
     label: 'Agentic Traces',
@@ -324,6 +340,14 @@ export function getSequenceDefaultExclusionGroup(
 ): string | null {
   if (!sequence) return null;
   return SEQUENCE_CONFIG[sequence as Sequence]?.defaultExclusionGroup ?? null;
+}
+
+/** Engine families exempt from every exclusion rule on a sequence. */
+export function getSequenceExclusionExemptFamilies(
+  sequence: Sequence | string | null | undefined,
+): readonly string[] {
+  if (!sequence) return [];
+  return SEQUENCE_CONFIG[sequence as Sequence]?.exclusionExemptFamilies ?? [];
 }
 
 export const SEQUENCE_OPTIONS = Object.keys(SEQUENCE_CONFIG) as Sequence[];

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -310,30 +310,40 @@ describe('ATOM/SGLang comparability group', () => {
   });
 });
 
-describe('participatingGroups', () => {
-  // The fixed-sequence STP rule: only vLLM and SGLang (incl. ATOM) block each
-  // other; every other engine family sits outside the rule entirely.
-  const limitedEx = buildExclusion([{ ...STP_SPEC[0], participatingGroups: ['vllm', 'sglang'] }]);
+describe('participatingFamilies', () => {
+  // The fixed-sequence STP rule: only the literal vLLM and SGLang families block
+  // each other. Every other engine — ATOM included, even though the spec aliases
+  // it onto SGLang's group — sits outside the rule entirely.
+  const limitedEx = buildExclusion([{ ...STP_SPEC[0], participatingFamilies: ['vllm', 'sglang'] }]);
 
-  it('ignores keys whose group is outside the list', () => {
+  it('ignores keys whose family is outside the list', () => {
     expect(limitedEx.familyOf('b200_trt')).toBeNull();
     expect(limitedEx.groupOf('b200_trt')).toBeNull();
     expect(limitedEx.scopesOf('b200_trt')).toEqual([]);
     expect(limitedEx.familyOf('gb300_dynamo-trt')).toBeNull();
   });
 
-  it('still classifies listed groups, including aliased families', () => {
+  it('matches before groupAliases, so an aliased family stays unrestricted', () => {
+    expect(limitedEx.familyOf('mi355x_atom')).toBeNull();
+    expect(limitedEx.groupOf('mi355x_atom')).toBeNull();
+    expect(limitedEx.scopesOf('mi355x_atom')).toEqual([]);
+    expect(limitedEx.familyOf('mi355x_mooncake-atom')).toBeNull();
+    expect(limitedEx.groupOf('mi355x_mooncake-atom')).toBeNull();
+  });
+
+  it('still classifies the listed families, including deployment variants', () => {
     expect(limitedEx.groupOf('b200_vllm')).toBe('vllm');
     expect(limitedEx.groupOf('gb300_dynamo-vllm')).toBe('vllm');
-    expect(limitedEx.groupOf('mi355x_atom')).toBe('sglang');
-    expect(limitedEx.groupOf('mi355x_mooncake-atom')).toBe('sglang');
-    expect(limitedEx.familyOf('mi355x_mooncake-atom')).toBe('atom');
+    expect(limitedEx.groupOf('gb200_llmd-vllm')).toBe('vllm');
+    expect(limitedEx.groupOf('b200_sglang')).toBe('sglang');
+    expect(limitedEx.groupOf('gb300_dynamo-sglang')).toBe('sglang');
+    expect(limitedEx.groupOf('mi355x_mori-sglang')).toBe('sglang');
   });
 
   it('leaves non-participating families selectable alongside either group', () => {
-    const proposed = new Set(['b200_vllm', 'b200_sglang', 'b200_trt']);
+    const proposed = new Set(['b200_vllm', 'b200_sglang', 'b200_trt', 'mi355x_atom']);
     const sticky = pickStickyGroup(proposed, new Set(), limitedEx, 'vllm');
-    expect([...sticky.result].toSorted()).toEqual(['b200_trt', 'b200_vllm']);
+    expect([...sticky.result].toSorted()).toEqual(['b200_trt', 'b200_vllm', 'mi355x_atom']);
     expect(sticky.droppedGroups).toEqual(['sglang']);
 
     expect(resolveExclusionToggle(new Set(['b200_vllm']), 'b200_trt', proposed, limitedEx)).toEqual(
@@ -341,15 +351,94 @@ describe('participatingGroups', () => {
     );
   });
 
-  it('falls through to a later spec when a group is excluded from an earlier one', () => {
-    // The 8K/1K chart layers the model MTP rule (all families) over the STP rule
-    // (vLLM/SGLang only), so TRTLLM stays guarded for `_mtp` keys.
+  it.each(['mi355x_atom', 'mi355x_mooncake-atom'])(
+    'allows %s next to either engine on the same SKU',
+    (atomKey) => {
+      const all = new Set(['mi355x_vllm', 'mi355x_sglang', atomKey]);
+      expect(resolveExclusionToggle(new Set(['mi355x_vllm']), atomKey, all, limitedEx)).toEqual({
+        kind: 'fallthrough',
+      });
+      expect(resolveExclusionToggle(new Set([atomKey]), 'mi355x_vllm', all, limitedEx)).toEqual({
+        kind: 'fallthrough',
+      });
+      expect(resolveExclusionToggle(new Set([atomKey]), 'mi355x_sglang', all, limitedEx)).toEqual({
+        kind: 'fallthrough',
+      });
+    },
+  );
+
+  it('falls through to a later spec when a family is excluded from an earlier one', () => {
+    // The 8K/1K chart layers the model MTP rule (all families, ATOM aliased onto
+    // SGLang) over the STP rule (vLLM/SGLang only), so TRTLLM stays guarded for
+    // `_mtp` keys while its unsuffixed keys are free.
     const fixedSeqEx = buildExclusion([
       ...MTP_SPEC,
-      { ...STP_SPEC[0], participatingGroups: ['vllm', 'sglang'] },
+      { ...STP_SPEC[0], participatingFamilies: ['vllm', 'sglang'] },
     ]);
     expect(fixedSeqEx.groupOf('b200_trt_mtp')).toBe('trt');
     expect(fixedSeqEx.groupOf('b200_trt')).toBeNull();
+  });
+});
+
+describe('exemptFamilies', () => {
+  // The 8K/1K composition: every spec carries the scenario's ATOM exemption, so
+  // ATOM escapes the MTP rule too — including the `atom → sglang` group alias.
+  const exemptEx = buildExclusion(
+    [...MTP_SPEC, { ...STP_SPEC[0], participatingFamilies: ['vllm', 'sglang'] }].map((spec) => ({
+      ...spec,
+      exemptFamilies: ['atom'],
+    })),
+  );
+
+  it('removes the family from every rule it is composed onto', () => {
+    expect(exemptEx.familyOf('mi355x_atom')).toBeNull();
+    expect(exemptEx.familyOf('mi355x_atom_mtp')).toBeNull();
+    expect(exemptEx.groupOf('mi355x_atom_mtp')).toBeNull();
+    expect(exemptEx.groupOf('mi355x_mooncake-atom_mtp')).toBeNull();
+    expect(exemptEx.scopesOf('mi355x_atom_mtp')).toEqual([]);
+  });
+
+  it('leaves the other families guarded', () => {
+    expect(exemptEx.groupOf('mi355x_vllm_mtp')).toBe('vllm');
+    expect(exemptEx.groupOf('mi355x_sglang_mtp')).toBe('sglang');
+    expect(exemptEx.groupOf('b200_trt_mtp')).toBe('trt');
+    expect(exemptEx.groupOf('mi355x_mori-sglang')).toBe('sglang');
+  });
+
+  it('lets an exempt family sit on the same graph as both engines', () => {
+    const all = new Set(['mi355x_vllm_mtp', 'mi355x_sglang_mtp', 'mi355x_atom_mtp']);
+    expect(
+      resolveExclusionToggle(new Set(['mi355x_vllm_mtp']), 'mi355x_atom_mtp', all, exemptEx),
+    ).toEqual({ kind: 'fallthrough' });
+    expect(
+      resolveExclusionToggle(new Set(['mi355x_atom_mtp']), 'mi355x_vllm_mtp', all, exemptEx),
+    ).toEqual({ kind: 'fallthrough' });
+    // ...but the two guarded engines still block each other.
+    expect(
+      resolveExclusionToggle(
+        new Set(['mi355x_atom_mtp', 'mi355x_vllm_mtp']),
+        'mi355x_sglang_mtp',
+        all,
+        exemptEx,
+      ),
+    ).toEqual({ kind: 'block', attempted: 'sglang', existing: 'vllm' });
+  });
+
+  it('survives a resolution pass without dropping the exempt keys', () => {
+    const proposed = new Set([
+      'mi355x_atom',
+      'mi355x_atom_mtp',
+      'mi355x_sglang',
+      'mi355x_vllm',
+      'mi355x_vllm_mtp',
+    ]);
+    const sticky = pickStickyGroup(proposed, new Set(), exemptEx, 'vllm');
+    expect([...sticky.result].toSorted()).toEqual([
+      'mi355x_atom',
+      'mi355x_atom_mtp',
+      'mi355x_vllm',
+      'mi355x_vllm_mtp',
+    ]);
   });
 });
 

--- a/packages/app/src/lib/exclusion.ts
+++ b/packages/app/src/lib/exclusion.ts
@@ -40,13 +40,26 @@ export interface ExclusionSpec {
    */
   groupAliases?: Record<string, string>;
   /**
-   * Restrict the rule to these comparability groups (ids AFTER `groupAliases`).
-   * A key whose group falls outside the list does not participate at all, so it
-   * may share a graph with anything. Omit to make every engine family
-   * participate. (e.g. `['vllm', 'sglang']` — TRTLLM stays freely selectable
-   * while vLLM and SGLang block each other.)
+   * Restrict the rule to these literal engine families, matched AFTER
+   * `stripPrefixes` but BEFORE `groupAliases`. A key whose family falls outside
+   * the list does not participate at all, so it may share a graph with
+   * anything. Omit to make every engine family participate.
+   *
+   * Matching before the aliases is what lets a rule cover vLLM vs SGLang
+   * (including `dynamo-`/`mori-` variants) while leaving ATOM — which is
+   * aliased into SGLang's group for the rules that do cover it — unrestricted.
    */
-  participatingGroups?: readonly string[];
+  participatingFamilies?: readonly string[];
+  /**
+   * Literal engine families removed from the rule, matched at the same point as
+   * `participatingFamilies` (after `stripPrefixes`, before `groupAliases`).
+   * Applied on top of `participatingFamilies` when both are set.
+   *
+   * Scenario-level exemptions are composed onto every spec of a chart, which is
+   * how a family can be declared comparable with everything on one scenario
+   * (8K/1K ATOM) while still being grouped by the same rules elsewhere.
+   */
+  exemptFamilies?: readonly string[];
   /**
    * Restrict mutual exclusion to configs on the same hardware SKU. Different
    * hardware may use different engine groups on the same graph.
@@ -79,8 +92,9 @@ function groupForFamily(family: string, spec: ExclusionSpec): string {
  * Extract the literal engine family for `hwKey` under a single spec: strip the
  * configured variant suffix (or require an unsuffixed STP key), drop the leading
  * GPU segment, then strip any configured engine-family prefix. Returns null if
- * the key doesn't participate — either because the suffix doesn't match or
- * because the resolved group is outside the spec's `participatingGroups`.
+ * the key doesn't participate — because the suffix doesn't match, because the
+ * family is outside the spec's `participatingFamilies`, or because it is listed
+ * in `exemptFamilies`.
  */
 function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
   let head: string;
@@ -101,12 +115,8 @@ function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
     }
   }
   if (!framework) return null;
-  if (
-    spec.participatingGroups &&
-    !spec.participatingGroups.includes(groupForFamily(framework, spec))
-  ) {
-    return null;
-  }
+  if (spec.participatingFamilies && !spec.participatingFamilies.includes(framework)) return null;
+  if (spec.exemptFamilies?.includes(framework)) return null;
   return framework;
 }
 


### PR DESCRIPTION
Follow-up to #681. That PR blocked ATOM against vLLM on 8K/1K, which was never the intent — only vLLM and SGLang should block each other there.

## What was wrong

`participatingGroups` matched **after** `groupAliases`, so the spec's `{ atom: 'sglang' }` alias made ATOM read as SGLang and inherit the block. ATOM is a distinct engine; it shares SGLang's comparability group only so the MTP acceptance-rate-forcing rule can treat the two together.

## Fix

- **`participatingFamilies` replaces `participatingGroups`** and matches the literal engine family after `stripPrefixes` but **before** `groupAliases`. The 8K/1K standard-token rule therefore covers vLLM and SGLang — including their `dynamo-` / `mori-` / `llmd-` deployment variants — and leaves ATOM out.
- **New `exemptFamilies` on `ExclusionSpec`, plus `exclusionExemptFamilies` on the sequence config**, composed onto the model specs as well as the sequence's own. 8K/1K sets `['atom']`, which frees ATOM from the model-level MTP rule too, so **ATOM MTP no longer blocks vLLM MTP or SGLang MTP**.

## 8K/1K behavior after this PR

| Pair (same SKU) | Standard-token | MTP |
| --- | --- | --- |
| vLLM ↔ SGLang | blocked | blocked |
| ATOM / Mooncake ATOMesh ↔ vLLM | allowed | allowed |
| ATOM / Mooncake ATOMesh ↔ SGLang | allowed | allowed |
| TRTLLM ↔ vLLM or SGLang | allowed | blocked (pre-existing chart-wide MTP rule) |

`mori-sglang` and `dynamo-sglang` are SGLang and stay blocked against vLLM. Agentic Traces is untouched — ATOM remains in SGLang's group there.

## Verification

Ran the real exclusion pipeline over the live DeepSeek V4 Pro 8K/1K rows (fresh load, no prior selection). `mi355x_atom`, `mi355x_atom_mtp`, and `mi355x_mooncake-atom` are all kept alongside `mi355x_vllm` / `mi355x_vllm_mtp`; only the SGLang configs drop. Agentic output was unchanged from master.

- `bun run typecheck`, `bun run lint`, `bun run fmt` — pass
- `bun run test:unit` — all pass, with new cases for `exemptFamilies`, ATOM STP/MTP allow-pairs on 8K/1K, and the retained vLLM↔SGLang / TRTLLM-MTP blocks

## 中文说明

这是 #681 的后续修复。该 PR 在 8K/1K 上错误地拦截了 ATOM 与 vLLM 的组合，而这并非预期行为——该场景下只应让 vLLM 与 SGLang 互斥。

### 问题原因

`participatingGroups` 是在 `groupAliases` **之后**匹配的，因此规则中的 `{ atom: 'sglang' }` 别名会把 ATOM 识别为 SGLang 并一并拦截。ATOM 是独立引擎，之所以与 SGLang 共用同一可比性分组，仅仅是为了让 MTP 接受率强制规则能够将两者一并处理。

### 修复方式

- **以 `participatingFamilies` 取代 `participatingGroups`**，在 `stripPrefixes` 之后、`groupAliases` **之前**匹配字面引擎系列。因此 8K/1K 的标准 token 规则覆盖 vLLM 与 SGLang（含 `dynamo-` / `mori-` / `llmd-` 部署变体），不再包含 ATOM。
- **在 `ExclusionSpec` 上新增 `exemptFamilies`，并在场景配置上新增 `exclusionExemptFamilies`**，二者会一并作用于模型级规则与场景自身的规则。8K/1K 配置为 `['atom']`，使 ATOM 同样不受模型级 MTP 规则约束，因此 **ATOM MTP 不再拦截 vLLM MTP 或 SGLang MTP**。

### 本 PR 后的 8K/1K 行为

| 组合（同一 SKU） | 标准 token | MTP |
| --- | --- | --- |
| vLLM ↔ SGLang | 拦截 | 拦截 |
| ATOM / Mooncake ATOMesh ↔ vLLM | 允许 | 允许 |
| ATOM / Mooncake ATOMesh ↔ SGLang | 允许 | 允许 |
| TRTLLM ↔ vLLM 或 SGLang | 允许 | 拦截（沿用原有的全图 MTP 规则） |

`mori-sglang` 与 `dynamo-sglang` 属于 SGLang，仍会与 vLLM 互斥。智能体轨迹（Agentic Traces）场景不受影响，ATOM 在该场景下仍归入 SGLang 分组。

### 验证

以线上 DeepSeek V4 Pro 的 8K/1K 数据跑通了完整的互斥流程（首次加载、无历史选择）：`mi355x_atom`、`mi355x_atom_mtp` 与 `mi355x_mooncake-atom` 均与 `mi355x_vllm` / `mi355x_vllm_mtp` 同时保留，仅 SGLang 配置被移除；智能体轨迹的结果与 master 一致。

- `bun run typecheck`、`bun run lint`、`bun run fmt` — 通过
- `bun run test:unit` — 全部通过，新增了 `exemptFamilies`、8K/1K 上 ATOM 标准 token 与 MTP 的放行组合，以及仍需保留的 vLLM↔SGLang、TRTLLM MTP 拦截等用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference chart legend/selection rules for DeepSeek V4 Pro 8K/1K; logic is well-tested but wrong mapping would show incompatible engines on one graph.
> 
> **Overview**
> Corrects a regression where **8K/1K** treated ATOM like SGLang and blocked it against vLLM. The intent is **vLLM ↔ SGLang only** on that scenario; TRTLLM and ATOM (STP and MTP, including Mooncake variants) should remain selectable alongside either engine.
> 
> **Exclusion engine:** `participatingGroups` is replaced by **`participatingFamilies`**, evaluated on the literal engine family **before** `groupAliases`, so ATOM is no longer pulled into the limited STP rule via the `atom → sglang` alias. **`exemptFamilies`** on specs plus **`exclusionExemptFamilies: ['atom']`** on the 8K/1K sequence config are merged onto model and sequence specs in `comparisonExclusion`, so ATOM also skips the model-level MTP rule on 8K/1K. **Agentic Traces** behavior is unchanged (ATOM still groups with SGLang there).
> 
> Default chart resolution and tests are updated so ATOM/MTP keys survive next to vLLM while SGLang still drops on conflict; vLLM↔SGLang and cross-engine MTP blocks stay enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac53d11a324a6f19f4a6f69834e9b862126a9e8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->