### PR TITLE
fix(inference): guard only vLLM and SGLang on 8K/1K / 8K/1K 仅约束 vLLM 与 SGLang

### DIFF
--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -120,6 +120,7 @@ describe('comparisonExclusion', () => {
         'b200_sglang',
         'b200_vllm',
         'b200_trt',
+        'b200_trt_mtp',
         'mi355x_atom',
         'mi355x_atom_mtp',
         'mi355x_sglang',
@@ -132,10 +133,12 @@ describe('comparisonExclusion', () => {
       comparisonDefaultGroup(Sequence.EightK_OneK, false),
     );
 
-    // TRTLLM STP and ATOM (STP and MTP alike) sit outside the 8K/1K rules, so
-    // they survive next to the kept vLLM configs — only SGLang is dropped.
+    // TRTLLM and ATOM sit outside the 8K/1K rules entirely — standard-token and
+    // MTP alike — so they survive next to the kept vLLM configs. Only SGLang,
+    // the one other guarded family, is dropped.
     expect([...resolved.result].toSorted()).toEqual([
       'b200_trt',
+      'b200_trt_mtp',
       'b200_vllm',
       'mi355x_atom',
       'mi355x_atom_mtp',
@@ -158,27 +161,31 @@ describe('comparisonExclusion', () => {
     expect([...resolved.result].toSorted()).toEqual(['b200_sglang', 'mi355x_vllm']);
   });
 
-  it('leaves non-participating 8K/1K engine families unguarded', () => {
+  it.each([
+    'b200_trt',
+    'b200_trt_mtp',
+    'gb300_dynamo-trt',
+    'gb300_dynamo-trt_mtp',
+    'mi355x_atom',
+    'mi355x_atom_mtp',
+    'mi355x_mooncake-atom',
+    'mi355x_mooncake-atom_mtp',
+  ])('leaves %s unguarded on the 8K/1K chart', (key) => {
+    // Only vLLM and SGLang are guarded here, on standard-token and MTP alike.
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
 
-    expect(exclusion.familyOf('b200_trt')).toBeNull();
-    expect(exclusion.familyOf('gb300_dynamo-trt')).toBeNull();
-    // ATOM is exempt from every 8K/1K rule — standard-token AND MTP.
-    expect(exclusion.familyOf('mi355x_atom')).toBeNull();
-    expect(exclusion.familyOf('mi355x_mooncake-atom')).toBeNull();
-    expect(exclusion.groupOf('mi355x_mooncake-atom')).toBeNull();
-    expect(exclusion.familyOf('mi355x_atom_mtp')).toBeNull();
-    expect(exclusion.groupOf('mi355x_atom_mtp')).toBeNull();
-    expect(exclusion.groupOf('mi355x_mooncake-atom_mtp')).toBeNull();
-    // TRTLLM keeps the pre-existing MTP guard; only its STP keys are free.
-    expect(exclusion.groupOf('b200_trt_mtp')).toBe('trt');
+    expect(exclusion.familyOf(key)).toBeNull();
+    expect(exclusion.groupOf(key)).toBeNull();
+    expect(exclusion.scopesOf(key)).toEqual([]);
   });
 
-  it('keeps ATOM grouped with SGLang on the Agentic chart', () => {
+  it('keeps ATOM and TRTLLM guarded on the Agentic chart', () => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
 
     expect(exclusion.groupOf('mi355x_atom')).toBe('sglang');
     expect(exclusion.groupOf('mi355x_atom_mtp')).toBe('sglang');
+    expect(exclusion.groupOf('b200_trt')).toBe('trt');
+    expect(exclusion.groupOf('b200_trt_mtp')).toBe('trt');
   });
 
   it('guards only the literal vLLM and SGLang families on the 8K/1K chart', () => {
@@ -334,17 +341,45 @@ describe('comparisonExclusion', () => {
       expected: 'block',
     },
     {
-      name: 'still blocks 8K/1K TRTLLM MTP against vLLM MTP',
+      name: 'allows 8K/1K TRTLLM MTP next to vLLM MTP',
       sequence: Sequence.EightK_OneK,
       active: 'b200_trt_mtp',
       candidate: 'b200_vllm_mtp',
-      expected: 'block',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K TRTLLM MTP next to SGLang MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang_mtp',
+      candidate: 'b200_trt_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K TRTLLM MTP next to ATOM MTP',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_atom_mtp',
+      candidate: 'gb300_dynamo-trt_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows 8K/1K TRTLLM next to ATOM',
+      sequence: Sequence.EightK_OneK,
+      active: 'mi355x_atom',
+      candidate: 'b200_trt',
+      expected: 'fallthrough',
     },
     {
       name: 'keeps the Agentic ATOM MTP guard untouched',
       sequence: Sequence.AgenticTraces,
       active: 'mi355x_atom_mtp',
       candidate: 'mi355x_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'keeps the Agentic TRTLLM guard untouched',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_trt',
+      candidate: 'b200_vllm',
       expected: 'block',
     },
     {

--- a/packages/app/src/components/inference/utils/comparison-exclusion.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.ts
@@ -2,7 +2,7 @@ import {
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
   getSequenceExclusion,
-  getSequenceExclusionExemptFamilies,
+  getSequenceExclusionFamilies,
   getSequenceExclusionPolicy,
 } from '@/lib/data-mappings';
 import { buildExclusion, type Exclusion, type ExclusionConflictPolicy } from '@/lib/exclusion';
@@ -37,10 +37,10 @@ export function comparisonExclusionPolicy(
  * Unofficial previews are diagnostic and intentionally allow engine families
  * to share a graph, even when the corresponding official view does not.
  *
- * The scenario's exempt families are composed onto the model specs too, so a
- * family the scenario declares comparable (8K/1K ATOM) escapes the model-level
- * variant rule as well — otherwise its MTP configs would still be grouped and
- * blocked.
+ * A scenario's `exclusionFamilies` allowlist narrows the model's variant specs
+ * as well as the sequence's own, so a family the scenario leaves out (8K/1K
+ * TRTLLM, ATOM) escapes the model-level MTP rule too — otherwise its MTP
+ * configs would still be grouped and blocked.
  */
 export function comparisonExclusion(
   model: Parameters<typeof getModelExclusion>[0],
@@ -52,9 +52,16 @@ export function comparisonExclusion(
   const specs = [...getModelExclusion(model), ...getSequenceExclusion(sequence)];
   if (specs.length === 0) return null;
 
-  const exempt = getSequenceExclusionExemptFamilies(sequence);
-  if (exempt.length === 0) return buildExclusion(specs);
+  const families = getSequenceExclusionFamilies(sequence);
+  if (!families) return buildExclusion(specs);
   return buildExclusion(
-    specs.map((spec) => ({ ...spec, exemptFamilies: [...(spec.exemptFamilies ?? []), ...exempt] })),
+    specs.map((spec) => ({
+      ...spec,
+      // Intersect rather than replace: a spec that already narrows itself keeps
+      // its own limit, and the scenario can only ever narrow further.
+      participatingFamilies: spec.participatingFamilies
+        ? spec.participatingFamilies.filter((family) => families.includes(family))
+        : families,
+    })),
   );
 }

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -7,7 +7,7 @@ import {
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
   getSequenceExclusion,
-  getSequenceExclusionExemptFamilies,
+  getSequenceExclusionFamilies,
   getSequenceExclusionPolicy,
   getSequenceLabel,
   getPrecisionLabel,
@@ -228,20 +228,21 @@ describe('comparison exclusions', () => {
     expect(getSequenceExclusion(Sequence.OneK_EightK)).toEqual([]);
   });
 
-  it('limits the 8K/1K STP rule to the literal vLLM and SGLang families', () => {
-    expect(
-      getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.participatingFamilies),
-    ).toEqual([['vllm', 'sglang']]);
+  it('guards only vLLM and SGLang on 8K/1K, every family on Agentic', () => {
+    expect(getSequenceExclusionFamilies(Sequence.EightK_OneK)).toEqual(['vllm', 'sglang']);
     // Agentic keeps every engine family exclusive while the benchmark is new.
-    expect(
-      getSequenceExclusion(Sequence.AgenticTraces).map((spec) => spec.participatingFamilies),
-    ).toEqual([undefined]);
+    expect(getSequenceExclusionFamilies(Sequence.AgenticTraces)).toBeNull();
+    expect(getSequenceExclusionFamilies(Sequence.OneK_OneK)).toBeNull();
   });
 
-  it('exempts ATOM from every 8K/1K rule but not from the Agentic ones', () => {
-    expect(getSequenceExclusionExemptFamilies(Sequence.EightK_OneK)).toEqual(['atom']);
-    expect(getSequenceExclusionExemptFamilies(Sequence.AgenticTraces)).toEqual([]);
-    expect(getSequenceExclusionExemptFamilies(Sequence.OneK_OneK)).toEqual([]);
+  it('shares one STP spec between the scenarios that carry it', () => {
+    // The scenarios differ only in which families they guard, not in the rule.
+    expect(getSequenceExclusion(Sequence.EightK_OneK)).toEqual(
+      getSequenceExclusion(Sequence.AgenticTraces),
+    );
+    expect(
+      getSequenceExclusion(Sequence.EightK_OneK).map((spec) => spec.participatingFamilies),
+    ).toEqual([undefined]);
   });
 
   it('keeps one engine group on the scenarios that restrict STP engines', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -69,39 +69,34 @@ const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
 ];
 
 /**
- * Base STP exclusion: unsuffixed standard-token configs for the same hardware
- * SKU can't mix engine families. Different hardware may use different engines
- * on one graph.
- */
-const STP_ENGINE_EXCLUSION_BASE = {
-  suffix: null,
-  stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
-  groupAliases: { atom: 'sglang' },
-  scope: 'hardware',
-} as const satisfies ExclusionSpec;
-
-/**
- * AgentX STP exclusion: every engine family is its own comparability group
- * (ATOM aliased onto SGLang) while the agentic benchmark is new.
- */
-const AGENTIC_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [STP_ENGINE_EXCLUSION_BASE];
-
-/**
- * Fixed-sequence STP exclusion: vLLM and SGLang tune their standard-token runs
- * against engine-specific serving paths, so their unsuffixed numbers aren't
- * directly comparable on one graph — same rule the MTP configs and the agentic
- * chart already enforce.
+ * STP exclusion: unsuffixed standard-token configs for the same hardware SKU
+ * can't mix engine families, because each engine tunes its serving path
+ * differently. Different hardware may use different engines on one graph.
  *
- * Unlike the agentic rule this one covers ONLY the literal vLLM and SGLang
- * families (with their `dynamo-`/`mori-`/`llmd-` deployment variants). Every
- * other engine — ATOM and Mooncake ATOMesh included, despite the SGLang group
- * alias the MTP rule relies on — stays freely selectable next to either of
- * them. `participatingFamilies` is matched before `groupAliases` precisely so
- * ATOM escapes here while still sharing SGLang's MTP comparability group.
+ * Which families this covers is per-scenario: AgentX applies it to every engine
+ * family while the agentic benchmark is new, whereas 8K/1K narrows it (and its
+ * MTP sibling) to vLLM and SGLang via `exclusionFamilies` below.
  */
-const FIXED_SEQ_STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
-  { ...STP_ENGINE_EXCLUSION_BASE, participatingFamilies: ['vllm', 'sglang'] },
+const STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
+  {
+    suffix: null,
+    stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
+    groupAliases: { atom: 'sglang' },
+    scope: 'hardware',
+  },
 ];
+
+/**
+ * Engine families guarded on the 8K/1K chart. vLLM and SGLang tune their runs
+ * against engine-specific serving paths, so their numbers aren't directly
+ * comparable on one graph — for standard-token and MTP configs alike.
+ *
+ * Every other engine is comparable with everything here: TRTLLM, ATOM, and
+ * Mooncake ATOMesh stay freely selectable next to either engine and next to
+ * each other. Because the list is matched before `groupAliases`, ATOM escapes
+ * even though the MTP rule folds it into SGLang's comparability group.
+ */
+const EIGHTK_ONEK_EXCLUSION_FAMILIES = ['vllm', 'sglang'] as const;
 
 // Total parameter counts appended to each label so users can compare model
 // scale at a glance in the dropdown. For Llama and gpt-oss the count is
@@ -269,12 +264,12 @@ interface SequenceConfig {
    */
   defaultExclusionGroup?: string;
   /**
-   * Engine families exempt from EVERY exclusion rule on this scenario —
-   * composed onto the model specs as well as this sequence's own. Use it when a
-   * family's numbers are comparable with everything in one scenario but still
-   * need grouping elsewhere.
+   * The only engine families guarded on this scenario, narrowing EVERY rule in
+   * scope — the model's variant specs as well as this sequence's own. Families
+   * outside the list are comparable with everything here. Omit to let each spec
+   * decide (by default: every family participates).
    */
-  exclusionExemptFamilies?: readonly string[];
+  exclusionFamilies?: readonly string[];
 }
 
 const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
@@ -298,13 +293,10 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     compact: '8k1k',
     category: 'default',
     kind: 'fixed-seq',
-    exclusion: FIXED_SEQ_STP_ENGINE_EXCLUSION,
+    exclusion: STP_ENGINE_EXCLUSION,
     exclusionPolicy: 'keep-sticky',
     defaultExclusionGroup: 'vllm',
-    // ATOM stays comparable with both vLLM and SGLang here — for its MTP
-    // configs as well, which the model-level rule would otherwise fold into
-    // SGLang's group. Only vLLM and SGLang block each other on 8K/1K.
-    exclusionExemptFamilies: ['atom'],
+    exclusionFamilies: EIGHTK_ONEK_EXCLUSION_FAMILIES,
   },
   [Sequence.AgenticTraces]: {
     label: 'Agentic Traces',
@@ -312,7 +304,7 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     compact: 'agentic',
     category: 'default',
     kind: 'agentic',
-    exclusion: AGENTIC_STP_ENGINE_EXCLUSION,
+    exclusion: STP_ENGINE_EXCLUSION,
     exclusionPolicy: 'keep-sticky',
     defaultExclusionGroup: 'vllm',
   },
@@ -342,12 +334,15 @@ export function getSequenceDefaultExclusionGroup(
   return SEQUENCE_CONFIG[sequence as Sequence]?.defaultExclusionGroup ?? null;
 }
 
-/** Engine families exempt from every exclusion rule on a sequence. */
-export function getSequenceExclusionExemptFamilies(
+/**
+ * The only engine families guarded on a sequence, or null when the sequence
+ * doesn't narrow its rules.
+ */
+export function getSequenceExclusionFamilies(
   sequence: Sequence | string | null | undefined,
-): readonly string[] {
-  if (!sequence) return [];
-  return SEQUENCE_CONFIG[sequence as Sequence]?.exclusionExemptFamilies ?? [];
+): readonly string[] | null {
+  if (!sequence) return null;
+  return SEQUENCE_CONFIG[sequence as Sequence]?.exclusionFamilies ?? null;
 }
 
 export const SEQUENCE_OPTIONS = Object.keys(SEQUENCE_CONFIG) as Sequence[];

--- a/packages/app/src/lib/exclusion.test.ts
+++ b/packages/app/src/lib/exclusion.test.ts
@@ -367,78 +367,112 @@ describe('participatingFamilies', () => {
     },
   );
 
-  it('falls through to a later spec when a family is excluded from an earlier one', () => {
-    // The 8K/1K chart layers the model MTP rule (all families, ATOM aliased onto
-    // SGLang) over the STP rule (vLLM/SGLang only), so TRTLLM stays guarded for
-    // `_mtp` keys while its unsuffixed keys are free.
-    const fixedSeqEx = buildExclusion([
-      ...MTP_SPEC,
-      { ...STP_SPEC[0], participatingFamilies: ['vllm', 'sglang'] },
-    ]);
-    expect(fixedSeqEx.groupOf('b200_trt_mtp')).toBe('trt');
+  it('narrows a layered rule set when composed onto every spec', () => {
+    // The 8K/1K composition: the scenario's allowlist lands on the model MTP
+    // rule as well as the STP rule, so TRTLLM and ATOM are free for both.
+    const fixedSeqEx = buildExclusion(
+      [...MTP_SPEC, ...STP_SPEC].map((spec) => ({
+        ...spec,
+        participatingFamilies: ['vllm', 'sglang'],
+      })),
+    );
+    expect(fixedSeqEx.groupOf('b200_vllm_mtp')).toBe('vllm');
+    expect(fixedSeqEx.groupOf('b200_sglang_mtp')).toBe('sglang');
+    expect(fixedSeqEx.groupOf('b200_trt_mtp')).toBeNull();
     expect(fixedSeqEx.groupOf('b200_trt')).toBeNull();
+    expect(fixedSeqEx.groupOf('mi355x_atom_mtp')).toBeNull();
+    expect(fixedSeqEx.groupOf('mi355x_atom')).toBeNull();
+    expect(fixedSeqEx.groupOf('mi355x_mooncake-atom_mtp')).toBeNull();
   });
 });
 
-describe('exemptFamilies', () => {
-  // The 8K/1K composition: every spec carries the scenario's ATOM exemption, so
-  // ATOM escapes the MTP rule too — including the `atom → sglang` group alias.
-  const exemptEx = buildExclusion(
-    [...MTP_SPEC, { ...STP_SPEC[0], participatingFamilies: ['vllm', 'sglang'] }].map((spec) => ({
+describe('scenario-narrowed rule set', () => {
+  // The 8K/1K composition: the scenario's allowlist is applied to every spec, so
+  // only vLLM and SGLang are guarded — on standard-token AND MTP keys.
+  const narrowedEx = buildExclusion(
+    [...MTP_SPEC, ...STP_SPEC].map((spec) => ({
       ...spec,
-      exemptFamilies: ['atom'],
+      participatingFamilies: ['vllm', 'sglang'],
     })),
   );
 
-  it('removes the family from every rule it is composed onto', () => {
-    expect(exemptEx.familyOf('mi355x_atom')).toBeNull();
-    expect(exemptEx.familyOf('mi355x_atom_mtp')).toBeNull();
-    expect(exemptEx.groupOf('mi355x_atom_mtp')).toBeNull();
-    expect(exemptEx.groupOf('mi355x_mooncake-atom_mtp')).toBeNull();
-    expect(exemptEx.scopesOf('mi355x_atom_mtp')).toEqual([]);
+  it('frees an omitted family from every rule, variants included', () => {
+    for (const key of [
+      'mi355x_atom',
+      'mi355x_atom_mtp',
+      'mi355x_mooncake-atom',
+      'mi355x_mooncake-atom_mtp',
+      'b200_trt',
+      'b200_trt_mtp',
+      'gb300_dynamo-trt_mtp',
+    ]) {
+      expect(narrowedEx.familyOf(key)).toBeNull();
+      expect(narrowedEx.groupOf(key)).toBeNull();
+      expect(narrowedEx.scopesOf(key)).toEqual([]);
+    }
   });
 
-  it('leaves the other families guarded', () => {
-    expect(exemptEx.groupOf('mi355x_vllm_mtp')).toBe('vllm');
-    expect(exemptEx.groupOf('mi355x_sglang_mtp')).toBe('sglang');
-    expect(exemptEx.groupOf('b200_trt_mtp')).toBe('trt');
-    expect(exemptEx.groupOf('mi355x_mori-sglang')).toBe('sglang');
+  it('keeps guarding the listed families on both suffixes', () => {
+    expect(narrowedEx.groupOf('mi355x_vllm')).toBe('vllm');
+    expect(narrowedEx.groupOf('mi355x_vllm_mtp')).toBe('vllm');
+    expect(narrowedEx.groupOf('mi355x_sglang_mtp')).toBe('sglang');
+    expect(narrowedEx.groupOf('mi355x_mori-sglang')).toBe('sglang');
+    expect(narrowedEx.groupOf('gb300_dynamo-sglang_mtp')).toBe('sglang');
   });
 
-  it('lets an exempt family sit on the same graph as both engines', () => {
-    const all = new Set(['mi355x_vllm_mtp', 'mi355x_sglang_mtp', 'mi355x_atom_mtp']);
+  it.each([
+    ['mi355x_atom', 'mi355x_vllm'],
+    ['mi355x_atom', 'mi355x_sglang'],
+    ['mi355x_atom_mtp', 'mi355x_vllm_mtp'],
+    ['mi355x_atom_mtp', 'mi355x_sglang_mtp'],
+    ['b200_trt', 'b200_vllm'],
+    ['b200_trt', 'b200_sglang'],
+    ['b200_trt_mtp', 'b200_vllm_mtp'],
+    ['b200_trt_mtp', 'b200_sglang_mtp'],
+    ['b200_trt', 'mi355x_atom'],
+    ['b200_trt_mtp', 'mi355x_atom_mtp'],
+  ])('lets %s and %s share a graph in either order', (a, b) => {
+    const all = new Set([a, b]);
+    expect(resolveExclusionToggle(new Set([a]), b, all, narrowedEx)).toEqual({
+      kind: 'fallthrough',
+    });
+    expect(resolveExclusionToggle(new Set([b]), a, all, narrowedEx)).toEqual({
+      kind: 'fallthrough',
+    });
+  });
+
+  it('still blocks the two guarded engines against each other', () => {
+    const stp = new Set(['mi355x_vllm', 'mi355x_sglang']);
     expect(
-      resolveExclusionToggle(new Set(['mi355x_vllm_mtp']), 'mi355x_atom_mtp', all, exemptEx),
-    ).toEqual({ kind: 'fallthrough' });
+      resolveExclusionToggle(new Set(['mi355x_vllm']), 'mi355x_sglang', stp, narrowedEx),
+    ).toEqual({ kind: 'block', attempted: 'sglang', existing: 'vllm' });
+
+    const mtp = new Set(['b200_vllm_mtp', 'mi355x_sglang_mtp']);
     expect(
-      resolveExclusionToggle(new Set(['mi355x_atom_mtp']), 'mi355x_vllm_mtp', all, exemptEx),
-    ).toEqual({ kind: 'fallthrough' });
-    // ...but the two guarded engines still block each other.
-    expect(
-      resolveExclusionToggle(
-        new Set(['mi355x_atom_mtp', 'mi355x_vllm_mtp']),
-        'mi355x_sglang_mtp',
-        all,
-        exemptEx,
-      ),
+      resolveExclusionToggle(new Set(['b200_vllm_mtp']), 'mi355x_sglang_mtp', mtp, narrowedEx),
     ).toEqual({ kind: 'block', attempted: 'sglang', existing: 'vllm' });
   });
 
-  it('survives a resolution pass without dropping the exempt keys', () => {
+  it('survives a resolution pass without dropping the freed keys', () => {
     const proposed = new Set([
+      'b200_trt',
+      'b200_trt_mtp',
       'mi355x_atom',
       'mi355x_atom_mtp',
       'mi355x_sglang',
       'mi355x_vllm',
       'mi355x_vllm_mtp',
     ]);
-    const sticky = pickStickyGroup(proposed, new Set(), exemptEx, 'vllm');
+    const sticky = pickStickyGroup(proposed, new Set(), narrowedEx, 'vllm');
     expect([...sticky.result].toSorted()).toEqual([
+      'b200_trt',
+      'b200_trt_mtp',
       'mi355x_atom',
       'mi355x_atom_mtp',
       'mi355x_vllm',
       'mi355x_vllm_mtp',
     ]);
+    expect(sticky.droppedGroups).toEqual(['sglang']);
   });
 });
 

--- a/packages/app/src/lib/exclusion.ts
+++ b/packages/app/src/lib/exclusion.ts
@@ -48,18 +48,13 @@ export interface ExclusionSpec {
    * Matching before the aliases is what lets a rule cover vLLM vs SGLang
    * (including `dynamo-`/`mori-` variants) while leaving ATOM — which is
    * aliased into SGLang's group for the rules that do cover it — unrestricted.
+   *
+   * A scenario can narrow every one of its rules at once by composing its own
+   * allowlist onto each spec (see `comparisonExclusion`), which is how 8K/1K
+   * guards only vLLM and SGLang while the same model-level MTP rule keeps
+   * covering every family on other scenarios.
    */
   participatingFamilies?: readonly string[];
-  /**
-   * Literal engine families removed from the rule, matched at the same point as
-   * `participatingFamilies` (after `stripPrefixes`, before `groupAliases`).
-   * Applied on top of `participatingFamilies` when both are set.
-   *
-   * Scenario-level exemptions are composed onto every spec of a chart, which is
-   * how a family can be declared comparable with everything on one scenario
-   * (8K/1K ATOM) while still being grouped by the same rules elsewhere.
-   */
-  exemptFamilies?: readonly string[];
   /**
    * Restrict mutual exclusion to configs on the same hardware SKU. Different
    * hardware may use different engine groups on the same graph.
@@ -92,9 +87,8 @@ function groupForFamily(family: string, spec: ExclusionSpec): string {
  * Extract the literal engine family for `hwKey` under a single spec: strip the
  * configured variant suffix (or require an unsuffixed STP key), drop the leading
  * GPU segment, then strip any configured engine-family prefix. Returns null if
- * the key doesn't participate — because the suffix doesn't match, because the
- * family is outside the spec's `participatingFamilies`, or because it is listed
- * in `exemptFamilies`.
+ * the key doesn't participate — either because the suffix doesn't match or
+ * because the family is outside the spec's `participatingFamilies`.
  */
 function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
   let head: string;
@@ -116,7 +110,6 @@ function familyForSpec(hwKey: string, spec: ExclusionSpec): string | null {
   }
   if (!framework) return null;
   if (spec.participatingFamilies && !spec.participatingFamilies.includes(framework)) return null;
-  if (spec.exemptFamilies?.includes(framework)) return null;
   return framework;
 }
 


### PR DESCRIPTION
Follow-up to #681 and #682. TRTLLM and ATOM are still blocked in places on 8K/1K — TRTLLM MTP against vLLM/SGLang MTP (the model-level rule covers every engine family), and #682 only freed ATOM. The intent is narrower: on 8K/1K exactly one pair is incomparable, **vLLM vs SGLang**, for standard-token and MTP configs alike.

## Change

Replaces the ATOM denylist from #682 with a scenario allowlist: `SequenceConfig.exclusionFamilies`, composed onto **every** spec of the chart — the model's MTP rule as well as the sequence's own standard-token rule — as `participatingFamilies`. 8K/1K declares `['vllm', 'sglang']`.

Because the allowlist now lives on the scenario rather than the rule, the two STP specs collapse back into one shared `STP_ENGINE_EXCLUSION`, and the `exemptFamilies` field added in #682 is gone. The scenarios differ only in which families they guard, not in the rule itself.

## 8K/1K behavior after this PR

| Pair (same SKU) | Standard-token | MTP |
| --- | --- | --- |
| vLLM ↔ SGLang | blocked | blocked |
| TRTLLM ↔ vLLM | allowed | **allowed** (was blocked) |
| TRTLLM ↔ SGLang | allowed | **allowed** (was blocked) |
| TRTLLM ↔ ATOM | allowed | **allowed** (was blocked) |
| ATOM ↔ vLLM or SGLang | allowed | allowed |

Deployment variants follow their engine: `dynamo-vllm` / `llmd-vllm` are vLLM, `dynamo-sglang` / `mori-sglang` are SGLang and stay blocked against vLLM, `dynamo-trt` is TRTLLM and is free, `mooncake-atom` is ATOM and is free.

Agentic Traces is unchanged — it declares no allowlist, so every engine family stays exclusive there (ATOM still aliased into SGLang's group, TRTLLM still its own group).

## Verification

Ran the real exclusion pipeline over the live DeepSeek V4 Pro 8K/1K rows (fresh load, no prior selection). Every TRTLLM and ATOM key is kept — `b200_trt`, `b200_trt_mtp`, `b300_trt`, `b300_trt_mtp`, `gb300_dynamo-trt`, `gb300_dynamo-trt_mtp`, `mi355x_atom`, `mi355x_atom_mtp`, `mi355x_mooncake-atom` — alongside the vLLM configs; only SGLang drops. Agentic output was unchanged from master.

- `bun run typecheck`, `bun run lint`, `bun run fmt` — pass
- `bun run test:unit` — all pass, with the TRTLLM/ATOM allow-pairs (STP and MTP, both toggle orders), the retained vLLM↔SGLang blocks, and the untouched Agentic guards covered

## 中文说明

这是 #681 与 #682 的后续修复。TRTLLM 与 ATOM 在 8K/1K 上仍有部分组合被拦截——TRTLLM MTP 与 vLLM/SGLang MTP 互斥（模型级规则覆盖所有引擎系列），而 #682 只放开了 ATOM。实际意图更窄：在 8K/1K 上只有 **vLLM 与 SGLang** 这一对不可比较，且标准 token 与 MTP 配置皆然。

### 改动

以场景级白名单取代 #682 的 ATOM 黑名单：新增 `SequenceConfig.exclusionFamilies`，并将其作为 `participatingFamilies` 作用于该图表的**每一条**规则——既包括模型级 MTP 规则，也包括场景自身的标准 token 规则。8K/1K 声明为 `['vllm', 'sglang']`。

由于白名单下沉到场景层，两份 STP 规则重新合并为共用的 `STP_ENGINE_EXCLUSION`，#682 引入的 `exemptFamilies` 字段随之移除。各场景的差异只在于约束哪些引擎系列，而非规则本身。

### 本 PR 后的 8K/1K 行为

| 组合（同一 SKU） | 标准 token | MTP |
| --- | --- | --- |
| vLLM ↔ SGLang | 拦截 | 拦截 |
| TRTLLM ↔ vLLM | 允许 | **允许**（此前拦截） |
| TRTLLM ↔ SGLang | 允许 | **允许**（此前拦截） |
| TRTLLM ↔ ATOM | 允许 | **允许**（此前拦截） |
| ATOM ↔ vLLM 或 SGLang | 允许 | 允许 |

部署变体归属其引擎：`dynamo-vllm` / `llmd-vllm` 属于 vLLM；`dynamo-sglang` / `mori-sglang` 属于 SGLang，仍与 vLLM 互斥；`dynamo-trt` 属于 TRTLLM，不受约束；`mooncake-atom` 属于 ATOM，不受约束。

智能体轨迹（Agentic Traces）场景不受影响——它不声明白名单，所有引擎系列在该场景下仍然互斥（ATOM 仍归入 SGLang 分组，TRTLLM 仍自成一组）。

### 验证

以线上 DeepSeek V4 Pro 的 8K/1K 数据跑通了完整的互斥流程（首次加载、无历史选择）：所有 TRTLLM 与 ATOM 配置均被保留——`b200_trt`、`b200_trt_mtp`、`b300_trt`、`b300_trt_mtp`、`gb300_dynamo-trt`、`gb300_dynamo-trt_mtp`、`mi355x_atom`、`mi355x_atom_mtp`、`mi355x_mooncake-atom`——与 vLLM 配置同时显示，仅 SGLang 被移除；智能体轨迹的结果与 master 一致。

- `bun run typecheck`、`bun run lint`、`bun run fmt` — 通过
- `bun run test:unit` — 全部通过，覆盖了 TRTLLM/ATOM 的放行组合（标准 token 与 MTP，两种切换顺序）、仍需保留的 vLLM↔SGLang 拦截，以及未受影响的智能体轨迹约束

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which engine configs can be selected together on official 8K/1K comparison charts (UI behavior), but scope is limited to exclusion/comparability logic with broad unit test coverage; Agentic and unofficial previews are unchanged.
> 
> **Overview**
> **8K/1K** chart comparability is narrowed so the only mutually exclusive pair is **vLLM ↔ SGLang**, for standard-token and MTP configs. **TRTLLM**, **ATOM**, and related variants can appear on the same graph with vLLM/SGLang and with each other, including cases that were still blocked when the model-level MTP rule applied to every engine family.
> 
> Scenario config switches from an ATOM-focused **denylist** (`exclusionExemptFamilies` / `exemptFamilies`) to a scenario **allowlist** (`exclusionFamilies`). `comparisonExclusion` applies that list to **every** exclusion spec on the chart (sequence STP rules and model MTP rules) by setting `participatingFamilies`, intersecting with any per-spec limits. **8K/1K** sets `['vllm', 'sglang']`; **Agentic Traces** omits the list so all engine families stay exclusive as before.
> 
> Shared STP rules are unified into one `STP_ENGINE_EXCLUSION`; per-scenario behavior differs only via `exclusionFamilies`, not duplicate STP spec definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927b91c30abca9634e710a603c5fc9478de270da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->