### PR TITLE
Remove stage results concurrency lock

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -40,10 +40,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: inferencex-shared-staging
-  cancel-in-progress: false
-
 jobs:
   validate:
     name: Validate staging request


### PR DESCRIPTION
Removes the shared workflow-level concurrency group from `stage-results.yml` so staging requests can run independently.

Tests were intentionally skipped for this workflow-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Overlapping runs can race on the shared Git `staging` branch fast-forward and Neon staging DB ingest/optional restore, which could interleave or clash on shared staging infrastructure.
> 
> **Overview**
> Removes the workflow-level **`concurrency`** block (`inferencex-shared-staging`, `cancel-in-progress: false`) from **Stage InferenceX Results**, so new staging dispatches are no longer queued behind an in-flight run.
> 
> **Effect:** multiple `stage-results` workflows can run at the same time instead of one-at-a-time serialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e30be5e08a2f5edfdcd22ad923b7f51bbcb95f90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->