### PR TITLE
Fix trace replay JSONB metric merge

### DIFF
--- a/packages/db/src/etl/trace-replay-ingest.test.ts
+++ b/packages/db/src/etl/trace-replay-ingest.test.ts
@@ -65,7 +65,10 @@ function mockSqlWithTransaction(lockedRows: { id: number }[]): {
     if (text.includes('insert into agentic_trace_replay')) return Promise.resolve([{ id: 123 }]);
     return Promise.resolve([]);
   };
-  const tx = Object.assign(execute, { array: (values: unknown[]) => values });
+  const tx = Object.assign(execute, {
+    array: (values: unknown[]) => values,
+    json: (value: unknown) => value,
+  });
   const sql = Object.assign(execute, {
     array: (values: unknown[]) => values,
     begin: (operation: (transaction: typeof tx) => Promise<void>) => operation(tx),
@@ -158,6 +161,9 @@ describe('persistPreparedTraceReplay', () => {
     const metricUpdate = calls.find((call) =>
       call.text.includes("not (metrics ? 'median_full_response_itl')"),
     );
-    expect(metricUpdate?.values).toContain(JSON.stringify(preparedFixture().fullResponseMetrics));
+    expect(metricUpdate?.values).toContainEqual(preparedFixture().fullResponseMetrics);
+    expect(metricUpdate?.values).not.toContain(
+      JSON.stringify(preparedFixture().fullResponseMetrics),
+    );
   });
 });

--- a/packages/db/src/etl/trace-replay-ingest.ts
+++ b/packages/db/src/etl/trace-replay-ingest.ts
@@ -375,7 +375,7 @@ export async function persistPreparedTraceReplay(
     if (Object.keys(fullResponseMetrics).length > 0) {
       await tx`
         update benchmark_results
-        set metrics = metrics || ${JSON.stringify(fullResponseMetrics)}::jsonb
+        set metrics = metrics || ${tx.json(fullResponseMetrics)}
         where id = any(${tx.array(unlinked.map((row) => row.id))}::bigint[])
           and not (metrics ? 'median_full_response_itl')
       `;


### PR DESCRIPTION
## What changed

- Bind reconstructed full-response metrics as a JSONB object instead of a string.
- Update the trace replay regression test to require an object parameter and reject double encoding.

## Why

Historical AgentX artifacts need full-response metrics reconstructed from retained profiles. Passing the patch through `JSON.stringify` stored it as a JSON string; PostgreSQL JSONB concatenation then converted `benchmark_results.metrics` from an object into an array, causing chart metrics to fall back to zero.

This preserves backward compatibility for historical artifacts while leaving current artifacts unchanged.

## Validation

Further testing was skipped at request for a quick PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ETL SQL binding change in trace replay ingest with a focused regression test; no auth or broad API surface.
> 
> **Overview**
> **Fixes corrupted `benchmark_results.metrics` when trace replay backfills full-response ITL/interactivity from historical AIPerf profiles.**
> 
> `persistPreparedTraceReplay` now passes reconstructed metrics through **`tx.json(fullResponseMetrics)`** instead of **`JSON.stringify(...)`** before the `metrics || …` update. That keeps the bind as a JSON object so PostgreSQL merges into the existing JSONB document instead of treating the patch as a string and turning `metrics` into an array (which made charts read zeros).
> 
> The trace replay ingest test mock adds **`tx.json`**, and the persistence test now requires the metric patch in query values as a plain object and explicitly rejects a stringified duplicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e41a4f3170d62d03abb4bd680a615bb0b9987df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->