### PR TITLE
chore(db): purge run 29741710665 (GLM-5.2 B300 SGLang AgentX non-MTP) / 清理 run 29741710665（GLM-5.2 B300 SGLang AgentX 非 MTP 分支）

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -63,6 +63,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29654139122, // 2026-07-18 | Reason: accidental ingest while testing
   29660737166, // 2026-07-18 | Reason: accidental ingest while testing
   29702212452, // 2026-07-19 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch feat/glm52-mi325x-agentx-full-context)
+  29741710665, // 2026-07-20 | Reason: No non-MTP AgentX — glm5.2-fp4-b300-sglang-agentic runs without speculative decoding, and GLM-5.2 agentic coding is published MTP-only per MODELS.md; the replacement arm glm5.2-fp4-b300-sglang-agentic-mtp landed in #2447 (source run of the PR #2281 DEP/conc-64 sweep)
   29811350508, // 2026-07-21 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-pp-pareto)
   29819261957, // 2026-07-21 | Reason: accidental ingest while testing (e2e Test dsv4-fp4-mi355x-sglang-disagg-agentic-hicache, branch amd/agentx-v1.0-th-hicon)
   29820102138, // 2026-07-21 | Reason: accidental ingest while testing (e2e Test GLM-5.2 AgentX, branch explore/glm52-h200-agentx-pp-pareto)


### PR DESCRIPTION
## Summary

Adds GitHub workflow run [`29741710665`](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29741710665) to `PURGED_RUNS` in `packages/db/src/etl/run-overrides.ts`, so ingest skips it and `db:apply-overrides` deletes its rows from production.

**What the run is:** the Run Sweep for [InferenceX#2281](https://github.com/SemiAnalysisAI/InferenceX/pull/2281) — *"Convert GLM-5.2 NVFP4 B300 SGLang high-throughput arm to DEP (EP8), cap conc at 64"* (branch `glm5.2-b300-dep-throughput-arm`, 2026-07-20). It benchmarks `glm5.2-fp4-b300-sglang-agentic` via `benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh` — the **non-MTP** agentic-coding arm, i.e. the one that runs without speculative decoding.

## Why — the AgentX spec-decode policy

Per [MODELS.md](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md):

> Going forward we no longer benchmark non-spec-decode versus spec-decode as an A/B. The non-spec-decode arm existed as a neutral baseline back when acceptance length wasn't standardized. That is now solved: `golden_al_distribution/` commits one golden acceptance-length curve per model, thinking mode, and draft length, measured on the SPEED-Bench `coding` category, and AgentX pins every submission to that curve through synthetic acceptance (vLLM `synthetic_acceptance_length`, SGLang `SGLANG_SIMULATE_ACC_LEN`, TensorRT-LLM `TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS`, etc). With a fair, engine-independent acceptance target in place, spec-decode results are directly comparable on their own and a separate non-spec-decode track is redundant. Agentic coding recipes are therefore run and published with speculative decoding enabled only — MTP, EAGLE/EAGLE3, DSpark, or whatever draft method the model ships — and the non-spec-decode arm is neither run nor published. New models are onboarded that way from day 0, as Kimi-K3 is.

MODELS.md's deprecation table lists GLM-5.2 explicitly: deprecated arm *Agentic coding, non-MTP*; published arm *Agentic coding, MTP*.

**Why it is safe to enact now.** MODELS.md gated this retirement on the replacement existing — *"Removing them today would leave MiniMax-M3 and GLM-5.2 with no active config at all."* That blocker is cleared: `glm5.2-fp4-b300-sglang-agentic-mtp` landed upstream in [InferenceX#2447](https://github.com/SemiAnalysisAI/InferenceX/pull/2447) (merged 2026-08-07), so GLM-5.2 B300 keeps an active agentic config after this purge.

This follows the precedent set by `30405836523` (Kimi-K3 B300 AgentX non-DSpark), the entry directly above the tail of the list.

## Tests

`packages/db/src/etl/run-overrides.test.ts` asserts structural invariants over the registries (positive integers, no overlap between `PURGED_RUNS` / `PURGED_RUN_ATTEMPTS` / `CONCLUSION_OVERRIDES` / `PURGED_BENCHMARK_POINTS`) rather than per-run membership, so a new entry needs no test change and is covered by the existing suite. **16/16 pass**, plus `typecheck`, `lint`, and `fmt` clean.

The entry is inserted in ascending run-id order between `29702212452` and `29811350508`, matching the file's existing convention.

## 中文说明

将 GitHub workflow run [`29741710665`](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29741710665) 加入 `packages/db/src/etl/run-overrides.ts` 的 `PURGED_RUNS`，使 ingest 跳过该 run，并由 `db:apply-overrides` 从生产数据库删除其记录。

**该 run 是什么：** [InferenceX#2281](https://github.com/SemiAnalysisAI/InferenceX/pull/2281) 的 Run Sweep——"将 GLM-5.2 NVFP4 B300 SGLang 高吞吐分支改为 DEP(EP8) 并将并发上限设为 64"（分支 `glm5.2-b300-dep-throughput-arm`，2026-07-20）。它通过 `benchmarks/single_node/agentic/glm5.2_fp4_b300_sglang.sh` 测试 `glm5.2-fp4-b300-sglang-agentic`，即**不启用投机解码**的非 MTP 智能体编码分支。

**原因——AgentX 投机解码政策：** 根据 MODELS.md，我们不再以 A/B 方式对比"非投机解码"与"投机解码"。非投机解码分支原本是在接受长度（acceptance length）尚未标准化时的中性基线；现在 `golden_al_distribution/` 为每个模型、思考模式与草稿长度提交一条基于 SPEED-Bench `coding` 类别测得的黄金接受长度曲线，AgentX 通过合成接受率（vLLM `synthetic_acceptance_length`、SGLang `SGLANG_SIMULATE_ACC_LEN`、TensorRT-LLM `TLLM_SPEC_DECODE_FORCE_NUM_ACCEPTED_TOKENS` 等）将每份提交都对齐到该曲线。有了公平且与引擎无关的接受率目标后，投机解码结果本身即可直接横向对比，单独的非投机解码轨道已属冗余。因此智能体编码配方一律仅在启用投机解码（MTP、EAGLE/EAGLE3、DSpark 或该模型自带的草稿方法）的情况下运行与发布，非投机解码分支既不运行也不发布；新模型从第 0 天起即按此方式接入，Kimi-K3 便是如此。

**为何现在可以执行：** MODELS.md 原本要求先有替代分支才能下线——否则会使 GLM-5.2 完全没有可用配置。该前置条件现已满足：`glm5.2-fp4-b300-sglang-agentic-mtp` 已通过 [InferenceX#2447](https://github.com/SemiAnalysisAI/InferenceX/pull/2447)（2026-08-07 合入）进入上游，因此本次清理后 GLM-5.2 B300 仍保有可用的智能体配置。本次改动沿用 `30405836523`（Kimi-K3 B300 AgentX 非 DSpark）的先例。

**测试：** `run-overrides.test.ts` 校验的是各注册表的结构性不变量（正整数、四个注册表之间互不重叠），而非逐个 run 的成员关系，因此新增条目无需改动测试，现有用例即可覆盖。16/16 通过，`typecheck`、`lint`、`fmt` 均通过。新条目按文件既有约定，以 run id 升序插入于 `29702212452` 与 `29811350508` 之间。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single registry entry for intentional data removal; no ingest logic changes and the published MTP replacement config is already in place.
> 
> **Overview**
> Adds GitHub Actions run **`29741710665`** to **`PURGED_RUNS`** in `run-overrides.ts` (sorted by run id), so ingest skips it and **`db:apply-overrides`** / post-merge CI remove any existing benchmark rows for that sweep.
> 
> The run is the **non-MTP** `glm5.2-fp4-b300-sglang-agentic` AgentX sweep from PR #2281; it is retired under the **AgentX spec-decode policy** in MODELS.md (agentic coding is published MTP-only), with **`glm5.2-fp4-b300-sglang-agentic-mtp`** already landed in #2447.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1631d746e8ef7feaae7aa085f0fa10784d8663ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->