### PR TITLE
chore(db): purge attempt 1 of run 29651235293 / 清理运行 29651235293 的第 1 次尝试

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -84,6 +84,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
+  [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
 ]);
 
 export interface BenchmarkPointKey {


### PR DESCRIPTION
## Summary

- Add [InferenceX workflow run 29651235293, attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29651235293/attempts/1) to `PURGED_RUN_ATTEMPTS`.
- Preserve the removal in the durable run-override audit record so merged CI applies it to production and future ingests do not restore it.

## Why

This attempt is non-MTP, which is outside the current AgentX focus, and it used an outdated AgentX harness. Scoping the override to attempt 1 keeps any future rerun under the same workflow run ID eligible for ingestion.

## Impact

After merge, `apply-run-overrides.yml` automatically removes data associated with attempt 1, verifies the production database, invalidates the production cache, and warms it again. No other run or attempt is affected.

## Validation

- `bun test packages/db/src/etl/run-overrides.test.ts` (12 passed)
- Pre-commit `oxlint`, `oxfmt`, and `tsc --noEmit`

## 中文说明

### 概要

- 将 [InferenceX workflow run 29651235293 的第 1 次尝试](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29651235293/attempts/1)加入 `PURGED_RUN_ATTEMPTS`。
- 将本次删除保留在持久化的 run override 审计记录中，确保合并后的 CI 自动应用到生产环境，且后续数据摄取不会恢复该数据。

### 原因

该尝试未启用 MTP，不属于当前 AgentX 的重点范围，且使用了过时的 AgentX harness。按第 1 次尝试的范围记录 override，可使同一 workflow run ID 未来可能产生的重跑仍可正常摄取。

### 影响

合并后，`apply-run-overrides.yml` 将自动删除第 1 次尝试关联的数据、验证生产数据库、使生产缓存失效并重新预热。其他运行或尝试不受影响。

### 验证

- `bun test packages/db/src/etl/run-overrides.test.ts`（12 项通过）
- pre-commit `oxlint`、`oxfmt` 与 `tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single audited ETL override using the existing purge pipeline; production impact is limited to one workflow attempt’s benchmark rows.
> 
> **Overview**
> Adds workflow run **29651235293**, **attempt 1** to `PURGED_RUN_ATTEMPTS` in `run-overrides.ts` so ingest skips that attempt and merged CI removes its benchmark data from production.
> 
> The override is scoped to attempt 1 only (non-MTP AgentX run with an outdated harness), so other attempts under the same run ID can still be ingested later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd8ce615a0aa8b3d3e71e1422b6a923dd0e4dff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->