### PR TITLE
chore(db): purge GLM-5.2 B300 SGLang HiCache attempt / 清除 GLM-5.2 B300 SGLang HiCache 尝试

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -85,7 +85,6 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
-  [28955639528, new Set([3])], // 2026-08-07 | DeepSeek-V4 FP4 B200/B300 SGLang agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29682242847, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang agentic HiCache | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
 ]);

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -85,7 +85,9 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
+  [28955639528, new Set([3])], // 2026-08-07 | DeepSeek-V4 FP4 B200/B300 SGLang agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29682242847, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang agentic HiCache | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
 ]);
 
 export interface BenchmarkPointKey {


### PR DESCRIPTION
## Summary

- Purge attempt 1 of InferenceX run `29682242847` (GLM-5.2 NVFP4 B300 SGLang AgentX with HiCache).
- Record the requested audit reason verbatim: `Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness`.

## Why / impact

This non-MTP GLM-5.2 AgentX result is outside the current AgentX focus and was produced with the outdated AgentX harness. Merging this override causes the production workflow to delete the matching attempt, invalidate caches, and warm the updated API data.

## Verification

- `bun test packages/db/src/etl/run-overrides.test.ts` (12 passed)
- Pre-commit lint, format, and TypeScript checks passed.

## 中文摘要

- 清除 InferenceX 运行 `29682242847` 的第 1 次尝试（GLM-5.2 NVFP4 B300 SGLang AgentX，启用 HiCache）。
- 原样记录请求的审计原因：`Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness`。

## 原因与影响

该非 MTP GLM-5.2 AgentX 结果不属于当前 AgentX 的关注范围，并且由过时的 AgentX 测试框架生成。合并后，生产工作流会删除对应运行尝试、使缓存失效并重新预热 API 数据。

## 验证

- `bun test packages/db/src/etl/run-overrides.test.ts`（12 项通过）
- 提交前的 lint、格式化和 TypeScript 检查均通过。
