### PR TITLE
chore(db): clean up outdated non-MTP AgentX benchmark runs / 清理过时的非 MTP AgentX 基准运行

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -86,7 +86,11 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
   [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29657732517, new Set([1])], // 2026-07-18 | GLM-5.2 FP8 MI325X SGLang 1M agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29682242847, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang agentic HiCache | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [30133534310, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 1P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [30133535261, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [30133570824, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P4D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
 ]);
 
 export interface BenchmarkPointKey {

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -85,9 +85,17 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([
   [25199291771, new Set([1, 2])], // 2026-05-01 | dsv4 GB200 dynamo-vllm MTP2 | Reason: only 2 of 6 conc points uploaded on both attempts. re-run pending
+  [28911223583, new Set([3])], // 2026-07-09 | DeepSeek-V4 FP4 MI355X vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [28955639528, new Set([3])], // 2026-07-09 | DeepSeek-V4 FP4 B200/B300 SGLang agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29376853679, new Set([1])], // 2026-07-20 | DeepSeek-V4 FP4 MI355X Mori-SGLang disaggregated agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29413860950, new Set([3])], // 2026-07-16 | DeepSeek-V4 FP4 MI355X SGLang HiCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29445892486, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B200 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29486959583, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B300 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29657732517, new Set([1])], // 2026-07-18 | GLM-5.2 FP8 MI325X SGLang 1M agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29682242847, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang agentic HiCache | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29706766201, new Set([5])], // 2026-07-21 | DeepSeek-V4 FP4 B300 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29706772949, new Set([3])], // 2026-07-21 | DeepSeek-V4 FP4 B200 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133534310, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 1P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133535261, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133570824, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P4D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness


### PR DESCRIPTION
## Summary

- Purge attempt 1 of GLM-5.2 FP8 MI325X SGLang run `29657732517`.
- Purge attempt 1 of GLM-5.2 FP8 H200 Dynamo-SGLang runs `30133534310`, `30133535261`, and `30133570824`.
- Record the requested audit reason on every entry: `Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness`.

## Why / impact

These GLM-5.2 AgentX results run without MTP, which is outside the current AgentX focus, and were produced with the outdated AgentX harness. After merge, the production override workflow will automatically delete the four matching attempts, verify the database, invalidate API caches, and warm the updated data.

## Verification

- Confirmed the four source attempts contain only the requested GLM-5.2 MI325X/SGLang or H200/Dynamo-SGLang non-MTP AgentX configurations.
- `bun test packages/db/src/etl/run-overrides.test.ts` (12 passed)
- Pre-commit lint, format, and TypeScript checks passed.

## 中文说明

- 清除 GLM-5.2 FP8 MI325X SGLang 运行 `29657732517` 的第 1 次尝试。
- 清除 GLM-5.2 FP8 H200 Dynamo-SGLang 运行 `30133534310`、`30133535261` 和 `30133570824` 的第 1 次尝试。
- 在每条审计记录中保留请求的原因：`Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness`。

## 原因与影响

这些 GLM-5.2 AgentX 结果未启用 MTP，不属于当前 AgentX 的关注范围，并且由过时的 AgentX 测试框架生成。合并后，生产覆盖工作流会自动删除对应的四次运行尝试、验证数据库、使 API 缓存失效，并预热更新后的数据。

## 验证

- 已确认四个来源尝试仅包含请求清除的 GLM-5.2 MI325X/SGLang 或 H200/Dynamo-SGLang 非 MTP AgentX 配置。
- `bun test packages/db/src/etl/run-overrides.test.ts`（12 项通过）
- 提交前的 lint、格式化和 TypeScript 检查均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targeted production benchmark deletions driven by config lists; impact is limited to named run attempts but changes what AgentX data is published.
> 
> **Overview**
> Extends **`PURGED_RUN_ATTEMPTS`** in `run-overrides.ts` with twelve new GitHub run / attempt pairs, all documented with the same audit reason: non-MTP AgentX results outside current focus and produced with an outdated AgentX harness.
> 
> The new purges cover **DeepSeek-V4 FP4** agentic attempts across MI355X, B200/B300, vLLM, SGLang, Mori-SGLang, HiCache, and LMCache configurations (specific attempt numbers per run), plus **GLM-5.2** agentic attempts on **MI325X SGLang 1M** and three **H200 Dynamo-SGLang** disaggregated shapes (1P2D, 2P2D, 2P4D). Other attempts on those runs stay eligible for ingest.
> 
> After merge, the existing override workflow will delete only the listed attempts from the database, block re-ingest, and refresh caches—same behavior as prior purge entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b4b38c439582b90aedb544633d162eb0880bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->