### PR TITLE
feat(overview): bottom toggle to show deprecated & maintenance models / feat(overview)：底部新增开关显示已弃用与维护模式模型

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -213,6 +213,57 @@ describe('Overview page', () => {
     cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
   });
 
+  it('reveals deprecated and maintenance models via the bottom toggle', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+    cy.get('[data-testid="overview-desktop-model"][data-model="gpt-oss-120b"]').should('not.exist');
+
+    cy.get('[data-testid="overview-model-scope-toggle"]')
+      .find('[data-overview-model-scope="all"]')
+      .click();
+    cy.location('search').should('eq', '?models=all');
+
+    desktopModel('gpt-oss-120b')
+      .find('[data-testid="overview-model-category-badge"]')
+      .should('have.attr', 'data-category', 'deprecated')
+      .and('contain.text', 'Deprecated');
+    desktopModel('DeepSeek-R1-0528')
+      .find('[data-testid="overview-model-category-badge"]')
+      .should('have.attr', 'data-category', 'maintenance');
+    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN)
+      .find('[data-testid="overview-model-category-badge"]')
+      .should('not.exist');
+    cy.get('[data-testid="overview-desktop-model"]').then(([...rows]) => {
+      const models = rows.map((row) => row.dataset.model);
+      expect(models.indexOf('gpt-oss-120b')).to.be.greaterThan(
+        models.lastIndexOf('Qwen-3.5-397B-A17B'),
+      );
+    });
+
+    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    cy.location('search').should('eq', '?tier=75&models=all');
+    cy.get('[data-testid="overview-desktop-model"][data-model="gpt-oss-120b"]').should('exist');
+
+    cy.get('[data-testid="overview-model-scope-toggle"]')
+      .find('[data-overview-model-scope="default"]')
+      .click();
+    cy.location('search').should('eq', '?tier=75');
+    cy.get('[data-testid="overview-desktop-model"][data-model="gpt-oss-120b"]').should('not.exist');
+  });
+
+  it('localizes the model scope toggle and badges on the Chinese route', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/zh/overview?models=all');
+
+    cy.get('[data-testid="overview-model-scope-toggle"]').should(
+      'contain.text',
+      '隐藏已弃用与维护模式模型',
+    );
+    desktopModel('gpt-oss-120b')
+      .find('[data-testid="overview-model-category-badge"]')
+      .should('contain.text', '已弃用');
+  });
+
   it('uses a selectable hardware reference and preserves it across overview controls', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');

--- a/packages/app/src/app/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/(dashboard)/overview/page.tsx
@@ -7,6 +7,7 @@ import { enAlternates } from '@/lib/i18n';
 import {
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewModelScope,
   resolveOverviewReferenceHardware,
   resolveOverviewTier,
 } from '@/lib/overview-data';
@@ -45,6 +46,7 @@ export default async function OverviewPage({ searchParams }: Props) {
     resolveOverviewEngineScope(sp.engine),
     resolveOverviewComparisonMode(sp.compare),
     resolveOverviewReferenceHardware(sp.ref),
+    resolveOverviewModelScope(sp.models),
   );
   return <OverviewPageContent data={data} locale="en" />;
 }

--- a/packages/app/src/app/api/v1/overview/route.test.ts
+++ b/packages/app/src/app/api/v1/overview/route.test.ts
@@ -36,20 +36,30 @@ describe('GET /api/v1/overview', () => {
     };
     mockGetOverviewPageData.mockResolvedValueOnce(data);
 
-    const response = await GET(request('/api/v1/overview?tier=75&engine=all&compare=30d&ref=b300'));
+    const response = await GET(
+      request('/api/v1/overview?tier=75&engine=all&compare=30d&ref=b300&models=all'),
+    );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(data);
-    expect(mockGetOverviewPageData).toHaveBeenCalledWith(75, 'all', 'history', 'b300');
+    expect(mockGetOverviewPageData).toHaveBeenCalledWith(75, 'all', 'history', 'b300', 'all');
     expect(mockCachedJson).toHaveBeenCalledWith(data);
   });
 
   it('normalizes unsupported query values to overview defaults', async () => {
     mockGetOverviewPageData.mockResolvedValueOnce({ models: [] });
 
-    await GET(request('/api/v1/overview?tier=999&engine=vendor&compare=weekly&ref=h100'));
+    await GET(
+      request('/api/v1/overview?tier=999&engine=vendor&compare=weekly&ref=h100&models=inactive'),
+    );
 
-    expect(mockGetOverviewPageData).toHaveBeenCalledWith(50, 'community', 'hardware', 'b200');
+    expect(mockGetOverviewPageData).toHaveBeenCalledWith(
+      50,
+      'community',
+      'hardware',
+      'b200',
+      'default',
+    );
   });
 
   it('returns 500 when overview assembly fails', async () => {

--- a/packages/app/src/app/api/v1/overview/route.ts
+++ b/packages/app/src/app/api/v1/overview/route.ts
@@ -4,6 +4,7 @@ import { cachedJson } from '@/lib/api-cache';
 import {
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewModelScope,
   resolveOverviewReferenceHardware,
   resolveOverviewTier,
 } from '@/lib/overview-data';
@@ -20,6 +21,7 @@ export async function GET(request: NextRequest) {
       resolveOverviewEngineScope(params.get('engine') ?? undefined),
       resolveOverviewComparisonMode(params.get('compare') ?? undefined),
       resolveOverviewReferenceHardware(params.get('ref') ?? undefined),
+      resolveOverviewModelScope(params.get('models') ?? undefined),
     );
     return cachedJson(data);
   } catch (error) {

--- a/packages/app/src/app/zh/(dashboard)/overview/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/overview/page.tsx
@@ -7,6 +7,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import {
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewModelScope,
   resolveOverviewReferenceHardware,
   resolveOverviewTier,
 } from '@/lib/overview-data';
@@ -46,6 +47,7 @@ export default async function ZhOverviewPage({ searchParams }: Props) {
     resolveOverviewEngineScope(sp.engine),
     resolveOverviewComparisonMode(sp.compare),
     resolveOverviewReferenceHardware(sp.ref),
+    resolveOverviewModelScope(sp.models),
   );
   return <OverviewPageContent data={data} locale="zh" />;
 }

--- a/packages/app/src/components/overview/overview-nav-link.tsx
+++ b/packages/app/src/components/overview/overview-nav-link.tsx
@@ -8,7 +8,7 @@ import type { OverviewSearchKey } from '@/lib/overview-links';
 import { useOverviewNavigation } from './overview-navigation';
 
 interface OverviewNavAnalytics {
-  control: 'comparison' | 'engine' | 'tier';
+  control: 'comparison' | 'engine' | 'models' | 'tier';
   value: string;
 }
 

--- a/packages/app/src/components/overview/overview-navigation.test.tsx
+++ b/packages/app/src/components/overview/overview-navigation.test.tsx
@@ -29,6 +29,7 @@ function pageData(tier: OverviewTier): OverviewPageData {
     engineScope: 'community',
     comparisonMode: 'hardware',
     referenceHardware: 'b200',
+    modelScope: 'default',
     historicalWindow: null,
   };
 }

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -11,6 +11,7 @@ import {
   OverviewComparisonSwitcher,
   OverviewEngineScopeSwitcher,
   OverviewMethodology,
+  OverviewModelScopeToggle,
   OverviewTierSwitcher,
   overviewFormatters,
   OVERVIEW_STRINGS,
@@ -36,6 +37,7 @@ export function OverviewPageContent({ data, locale }: OverviewPageProps) {
         data.engineScope,
         data.comparisonMode,
         data.referenceHardware,
+        data.modelScope,
       )}
     >
       <OverviewPageBody locale={locale} />
@@ -102,6 +104,7 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
               engineScope={data.engineScope}
               comparisonMode={data.comparisonMode}
               referenceHardware={data.referenceHardware}
+              modelScope={data.modelScope}
               locale={locale}
               strings={strings}
             />
@@ -110,6 +113,7 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
               tier={data.tier}
               comparisonMode={data.comparisonMode}
               referenceHardware={data.referenceHardware}
+              modelScope={data.modelScope}
               locale={locale}
               strings={strings}
             />
@@ -122,6 +126,7 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
         engineScope={data.engineScope}
         tier={data.tier}
         referenceHardware={data.referenceHardware}
+        modelScope={data.modelScope}
         locale={locale}
         strings={strings}
       />
@@ -150,6 +155,15 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
           strings={strings}
           comparisonMode={data.comparisonMode}
           referenceHardware={data.referenceHardware}
+        />
+        <OverviewModelScopeToggle
+          modelScope={data.modelScope}
+          tier={data.tier}
+          engineScope={data.engineScope}
+          comparisonMode={data.comparisonMode}
+          referenceHardware={data.referenceHardware}
+          locale={locale}
+          strings={strings}
         />
       </Card>
     </section>

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -6,6 +6,7 @@ import {
   type OverviewComparisonMode,
   type OverviewEngineScope,
   type OverviewHistoricalComparison,
+  type OverviewModelScope,
   type OverviewModelSummary,
   type OverviewPlatformResult,
   type OverviewReferenceHardware,
@@ -93,6 +94,14 @@ export const OVERVIEW_STRINGS = {
       `About the same cost as this platform’s ${baselineDate} result`,
     historyCellStateLegend: 'Platforms without a valid 30-day comparison show current cost only.',
     referenceHeader: 'Reference',
+    modelScopeNavLabel: 'Inactive models',
+    modelScopeShow: 'Show deprecated & maintenance-mode models',
+    modelScopeHide: 'Hide deprecated & maintenance-mode models',
+    categoryBadges: {
+      maintenance: 'Maintenance',
+      deprecated: 'Deprecated',
+    } as Partial<Record<string, string>>,
+    categoryBadgeTitle: 'Model is no longer actively benchmarked.',
   },
   zh: {
     title: '推理每百万 token 成本',
@@ -152,6 +161,14 @@ export const OVERVIEW_STRINGS = {
     historicalEvenAria: (baselineDate: string) => `与该平台 ${baselineDate} 的结果成本基本持平`,
     historyCellStateLegend: '缺少有效 30 天对比的平台仅显示当前成本。',
     referenceHeader: '基准',
+    modelScopeNavLabel: '非活跃模型',
+    modelScopeShow: '显示已弃用与维护模式模型',
+    modelScopeHide: '隐藏已弃用与维护模式模型',
+    categoryBadges: {
+      maintenance: '维护模式',
+      deprecated: '已弃用',
+    } as Partial<Record<string, string>>,
+    categoryBadgeTitle: '该模型已不再进行活跃基准测试。',
   },
 } as const;
 
@@ -585,9 +602,22 @@ function PlatformCell(props: {
 }
 
 function ModelName({ model, strings }: { model: OverviewModelSummary; strings: OverviewStrings }) {
+  const badge = strings.categoryBadges[model.category];
   return (
     <div>
-      <h2 className="text-sm font-semibold leading-snug">{model.modelLabel}</h2>
+      <h2 className="text-sm font-semibold leading-snug">
+        {model.modelLabel}
+        {badge === undefined ? null : (
+          <span
+            data-testid="overview-model-category-badge"
+            data-category={model.category}
+            title={strings.categoryBadgeTitle}
+            className="ml-1.5 inline-block rounded-sm border border-border/60 px-1 py-px align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+          >
+            {badge}
+          </span>
+        )}
+      </h2>
       <p
         data-testid="overview-model-scenario"
         className="mt-0.5 text-[11px] font-normal leading-tight text-muted-foreground"
@@ -780,6 +810,7 @@ export function OverviewTierSwitcher({
   engineScope,
   comparisonMode,
   referenceHardware,
+  modelScope,
   locale,
   strings,
 }: {
@@ -787,6 +818,7 @@ export function OverviewTierSwitcher({
   engineScope: OverviewEngineScope;
   comparisonMode: OverviewComparisonMode;
   referenceHardware: OverviewReferenceHardware;
+  modelScope: OverviewModelScope;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
@@ -817,6 +849,7 @@ export function OverviewTierSwitcher({
                 engineScope,
                 comparisonMode,
                 referenceHardware,
+                modelScope,
               )}
               analytics={{ control: 'tier', value: String(option) }}
               searchKeys={['tier']}
@@ -838,6 +871,7 @@ export function OverviewEngineScopeSwitcher({
   tier,
   comparisonMode,
   referenceHardware,
+  modelScope,
   locale,
   strings,
 }: {
@@ -845,6 +879,7 @@ export function OverviewEngineScopeSwitcher({
   tier: OverviewTier;
   comparisonMode: OverviewComparisonMode;
   referenceHardware: OverviewReferenceHardware;
+  modelScope: OverviewModelScope;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
@@ -879,6 +914,7 @@ export function OverviewEngineScopeSwitcher({
                 tier,
                 comparisonMode,
                 referenceHardware,
+                modelScope,
               )}
               analytics={{ control: 'engine', value: option }}
               searchKeys={['engine']}
@@ -898,6 +934,7 @@ export function OverviewComparisonSwitcher({
   engineScope,
   tier,
   referenceHardware,
+  modelScope,
   locale,
   strings,
 }: {
@@ -905,6 +942,7 @@ export function OverviewComparisonSwitcher({
   engineScope: OverviewEngineScope;
   tier: OverviewTier;
   referenceHardware: OverviewReferenceHardware;
+  modelScope: OverviewModelScope;
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
@@ -913,7 +951,7 @@ export function OverviewComparisonSwitcher({
   const referenceOptions = OVERVIEW_HARDWARE.map((hardware) => ({
     value: hardware,
     label: overviewHardwareLabel(hardware),
-    href: overviewHref(locale, tier, engineScope, 'hardware', hardware),
+    href: overviewHref(locale, tier, engineScope, 'hardware', hardware, modelScope),
   }));
   const optionClass =
     'relative inline-flex min-h-11 min-w-[130px] items-center justify-center whitespace-nowrap border-b-2 border-transparent px-4 py-2 text-sm font-semibold text-muted-foreground transition-colors duration-200 hover:border-muted-foreground/30 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring sm:min-w-[140px]';
@@ -952,7 +990,7 @@ export function OverviewComparisonSwitcher({
           <OverviewNavLink
             key={option}
             data-overview-comparison={option}
-            href={overviewHref(locale, tier, engineScope, option, referenceHardware)}
+            href={overviewHref(locale, tier, engineScope, option, referenceHardware, modelScope)}
             analytics={{ control: 'comparison', value: option }}
             searchKeys={['compare']}
             className={optionClass}
@@ -961,6 +999,43 @@ export function OverviewComparisonSwitcher({
           </OverviewNavLink>
         );
       })}
+    </nav>
+  );
+}
+
+export function OverviewModelScopeToggle({
+  modelScope,
+  tier,
+  engineScope,
+  comparisonMode,
+  referenceHardware,
+  locale,
+  strings,
+}: {
+  modelScope: OverviewModelScope;
+  tier: OverviewTier;
+  engineScope: OverviewEngineScope;
+  comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
+  locale: OverviewLocale;
+  strings: OverviewStrings;
+}) {
+  const target: OverviewModelScope = modelScope === 'all' ? 'default' : 'all';
+  return (
+    <nav
+      data-testid="overview-model-scope-toggle"
+      aria-label={strings.modelScopeNavLabel}
+      className="border-t border-border/50 px-4 text-xs lg:px-6"
+    >
+      <OverviewNavLink
+        data-overview-model-scope={target}
+        href={overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware, target)}
+        analytics={{ control: 'models', value: target }}
+        searchKeys={['models']}
+        className="inline-flex min-h-11 items-center text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground hover:decoration-solid"
+      >
+        {modelScope === 'all' ? strings.modelScopeHide : strings.modelScopeShow}
+      </OverviewNavLink>
     </nav>
   );
 }

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { BenchmarkRow } from './api';
+import { DISPLAY_MODEL_TO_DB } from '@semianalysisai/inferencex-constants';
+
 import { Model, Precision } from './data-mappings';
 import type { OverviewPageData } from './overview-data';
 
@@ -185,5 +187,72 @@ describe('getOverviewPageData engine scope forwarding', () => {
     expect(loadFixture).toHaveBeenCalledWith('overview-history-rows');
     expect(getCachedBenchmarks).not.toHaveBeenCalled();
     expect(getCachedBenchmarksAsOf).not.toHaveBeenCalled();
+  });
+});
+
+describe('getOverviewPageData model scope forwarding', () => {
+  it('queries deprecated and maintenance models only under the all scope', async () => {
+    const getCachedBenchmarks = vi.fn(() => Promise.resolve(rows));
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({
+      getCachedBenchmarks,
+      getCachedBenchmarksAsOf: vi.fn(),
+    }));
+    vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
+
+    const { getOverviewPageData } = await import('./overview-data.server');
+    const gptOssKeys = DISPLAY_MODEL_TO_DB[Model.GptOss] ?? [];
+    expect(gptOssKeys.length).toBeGreaterThan(0);
+
+    const defaultPage = await getOverviewPageData(50, 'community', 'hardware', 'b200', 'default');
+    const queriedByDefault = getCachedBenchmarks.mock.calls.flat(2);
+    expect(defaultPage.modelScope).toBe('default');
+    expect(defaultPage.models.some((m) => m.model === Model.GptOss)).toBe(false);
+    expect(queriedByDefault).not.toEqual(expect.arrayContaining(gptOssKeys));
+
+    getCachedBenchmarks.mockClear();
+    const allPage = await getOverviewPageData(50, 'community', 'hardware', 'b200', 'all');
+    const queriedByAll = getCachedBenchmarks.mock.calls.flat(2);
+    expect(allPage.modelScope).toBe('all');
+    expect(allPage.models.some((m) => m.model === Model.GptOss)).toBe(true);
+    expect(queriedByAll).toEqual(expect.arrayContaining(gptOssKeys));
+  });
+
+  it('anchors the history window to default models even under the all scope', async () => {
+    const gptOssKeys = DISPLAY_MODEL_TO_DB[Model.GptOss] ?? [];
+    const getCachedBenchmarks = vi.fn((keys: string[]) =>
+      Promise.resolve(
+        keys.some((key) => gptOssKeys.includes(key))
+          ? [row('b200', 'sglang', 900, '2026-07-28')]
+          : rows,
+      ),
+    );
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({
+      getCachedBenchmarks,
+      getCachedBenchmarksAsOf: vi.fn(() => Promise.resolve([])),
+    }));
+    vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
+
+    const { getOverviewPageData } = await import('./overview-data.server');
+    const page = await getOverviewPageData(50, 'community', 'history', 'b200', 'all');
+
+    expect(page.historicalWindow?.snapshotDate).toBe('2026-07-20');
+  });
+
+  it('forwards the all scope through history mode', async () => {
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({
+      getCachedBenchmarks: vi.fn(() => Promise.resolve(rows)),
+      getCachedBenchmarksAsOf: vi.fn(() => Promise.resolve([])),
+    }));
+    vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
+
+    const { getOverviewPageData } = await import('./overview-data.server');
+    const page = await getOverviewPageData(50, 'community', 'history', 'b200', 'all');
+
+    expect(page.comparisonMode).toBe('history');
+    expect(page.modelScope).toBe('all');
+    expect(page.models.some((m) => m.model === Model.GptOss)).toBe(true);
   });
 });

--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -3,17 +3,20 @@ import { FIXTURES_MODE } from '@semianalysisai/inferencex-db/connection';
 
 import type { BenchmarkRow } from '@/lib/api';
 import { getCachedBenchmarks, getCachedBenchmarksAsOf } from '@/lib/benchmark-data.server';
-import { DEFAULT_MODELS } from '@/lib/data-mappings';
+import type { Model } from '@/lib/data-mappings';
 import {
   assembleOverviewHistoricalPageData,
   assembleOverviewPageData,
   OVERVIEW_DEFAULT_COMPARISON_MODE,
+  OVERVIEW_DEFAULT_MODEL_SCOPE,
   OVERVIEW_PRIMARY_TIER,
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   overviewHistoricalWindow,
+  overviewModelsForScope,
   overviewSnapshotDate,
   type OverviewComparisonMode,
   type OverviewEngineScope,
+  type OverviewModelScope,
   type OverviewPageData,
   type OverviewReferenceHardware,
   type OverviewTier,
@@ -21,10 +24,11 @@ import {
 import { loadFixture } from '@/lib/test-fixtures';
 
 async function loadRowsByModel(
+  models: readonly Model[],
   loader: (keys: string[]) => Promise<BenchmarkRow[]>,
 ): Promise<Record<string, BenchmarkRow[]>> {
   const entries = await Promise.all(
-    [...DEFAULT_MODELS].map(async (model) => {
+    models.map(async (model) => {
       const keys = DISPLAY_MODEL_TO_DB[model] ?? [];
       const rows = keys.length > 0 ? await loader(keys) : [];
       return [model, rows] as const;
@@ -38,20 +42,47 @@ export async function getOverviewPageData(
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): Promise<OverviewPageData> {
+  const models = overviewModelsForScope(modelScope);
   // Synthetic rows go through the same assemblers as the live path, so a
   // contract drift breaks fixture tests instead of stranding the page.
   const currentRowsByModel = FIXTURES_MODE
     ? loadFixture<Record<string, BenchmarkRow[]>>('overview-rows')
-    : await loadRowsByModel(getCachedBenchmarks);
+    : await loadRowsByModel(models, getCachedBenchmarks);
   if (comparisonMode === 'hardware') {
-    return assembleOverviewPageData(currentRowsByModel, tier, engineScope, referenceHardware);
+    return assembleOverviewPageData(
+      currentRowsByModel,
+      tier,
+      engineScope,
+      referenceHardware,
+      modelScope,
+    );
   }
 
-  const snapshotDate = overviewSnapshotDate(currentRowsByModel, engineScope);
+  // Note (wenyao): the 30-day window must not move when inactive models are
+  // revealed — a maintenance model can still post occasional runs, and a newer
+  // one would silently shift the cost deltas already shown on default rows.
+  // Anchor the snapshot to the default models in every scope.
+  const snapshotRows =
+    modelScope === 'all'
+      ? Object.fromEntries(
+          overviewModelsForScope('default').map((model) => [
+            model,
+            currentRowsByModel[model] ?? [],
+          ]),
+        )
+      : currentRowsByModel;
+  const snapshotDate = overviewSnapshotDate(snapshotRows, engineScope);
   if (snapshotDate === null) {
     return {
-      ...assembleOverviewPageData(currentRowsByModel, tier, engineScope, referenceHardware),
+      ...assembleOverviewPageData(
+        currentRowsByModel,
+        tier,
+        engineScope,
+        referenceHardware,
+        modelScope,
+      ),
       comparisonMode: 'history',
     };
   }
@@ -59,7 +90,7 @@ export async function getOverviewPageData(
   const window = overviewHistoricalWindow(snapshotDate);
   const unboundedBaselineRows = FIXTURES_MODE
     ? loadFixture<Record<string, BenchmarkRow[]>>('overview-history-rows')
-    : await loadRowsByModel((keys) => getCachedBenchmarksAsOf(keys, window.targetDate));
+    : await loadRowsByModel(models, (keys) => getCachedBenchmarksAsOf(keys, window.targetDate));
   const baselineRowsByModel = Object.fromEntries(
     Object.entries(unboundedBaselineRows).map(([model, rows]) => [
       model,
@@ -74,5 +105,6 @@ export async function getOverviewPageData(
     tier,
     engineScope,
     referenceHardware,
+    modelScope,
   );
 }

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -5,7 +5,13 @@ import overviewRowsFixture from '../../cypress/fixtures/api/overview-rows.json';
 import { dedupeRowsToLatestPerConfig } from '@/components/inference/hooks/useChartData';
 
 import type { BenchmarkRow } from './api';
-import { DEFAULT_MODELS, Model, Precision } from './data-mappings';
+import {
+  DEFAULT_MODELS,
+  DEPRECATED_MODELS,
+  MAINTENANCE_MODELS,
+  Model,
+  Precision,
+} from './data-mappings';
 import {
   assembleOverviewHistoricalPageData,
   assembleOverviewPageData,
@@ -17,6 +23,7 @@ import {
   overviewTierEvidenceDate,
   resolveOverviewComparisonMode,
   resolveOverviewEngineScope,
+  resolveOverviewModelScope,
   resolveOverviewReferenceHardware,
   resolveOverviewTier,
   type OverviewModelSummary,
@@ -1391,5 +1398,54 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     const communityGlmB300 = headlinePairOf(communityGlm, 'b300-vs-b200')!;
     expect(communityGlmB300.candidate.read.value).toBeNull();
     expect(communityGlmB300.candidate.missingReason).toBe('no_scenario_data');
+  });
+});
+
+describe('overview model scope', () => {
+  it('resolves valid model scopes and defaults invalid values to default', () => {
+    expect(resolveOverviewModelScope('all')).toBe('all');
+    expect(resolveOverviewModelScope(['all', 'default'])).toBe('all');
+    expect(resolveOverviewModelScope('default')).toBe('default');
+    expect(resolveOverviewModelScope('deprecated')).toBe('default');
+    expect(resolveOverviewModelScope('')).toBe('default');
+    expect(resolveOverviewModelScope(undefined)).toBe('default');
+  });
+
+  it('renders only default-category models under the default scope', () => {
+    const page = assembleOverviewPageData({});
+    expect(new Set(page.models.map((m) => m.model))).toEqual(new Set(DEFAULT_MODELS));
+    expect(page.modelScope).toBe('default');
+  });
+
+  it("appends maintenance then deprecated rows after defaults under scope 'all'", () => {
+    const page = assembleOverviewPageData({}, 50, 'community', 'b200', 'all');
+    const orderedUniqueModels = [...new Set(page.models.map((m) => m.model))];
+    expect(orderedUniqueModels).toEqual([
+      ...DEFAULT_MODELS,
+      ...MAINTENANCE_MODELS,
+      ...DEPRECATED_MODELS,
+    ]);
+    expect(page.modelScope).toBe('all');
+  });
+
+  it('stamps each model summary with its category', () => {
+    const page = assembleOverviewPageData({}, 50, 'community', 'b200', 'all');
+    const categoryOf = (model: Model) => page.models.find((m) => m.model === model)?.category;
+    expect(categoryOf(Model.DeepSeek_V4_Pro)).toBe('default');
+    expect(categoryOf(Model.DeepSeek_R1)).toBe('maintenance');
+    expect(categoryOf(Model.GLM_5)).toBe('deprecated');
+    expect(categoryOf(Model.GptOss)).toBe('deprecated');
+  });
+
+  it('forwards the model scope through the historical assembler', () => {
+    const window = overviewHistoricalWindow('2026-07-20');
+    const page = assembleOverviewHistoricalPageData({}, {}, window, 50, 'community', 'b200', 'all');
+    const orderedUniqueModels = [...new Set(page.models.map((m) => m.model))];
+    expect(orderedUniqueModels).toEqual([
+      ...DEFAULT_MODELS,
+      ...MAINTENANCE_MODELS,
+      ...DEPRECATED_MODELS,
+    ]);
+    expect(page.modelScope).toBe('all');
   });
 });

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -5,7 +5,16 @@ import type { BenchmarkRow } from './api';
 import { rowToAggDataEntry } from './benchmark-transform';
 import { buildAvailabilityHwKey } from './chart-utils';
 import { getGpuSpecs, getHardwareConfig } from './constants';
-import { DEFAULT_MODELS, getModelLabel, Model, Precision } from './data-mappings';
+import {
+  DEFAULT_MODELS,
+  DEPRECATED_MODELS,
+  getModelCategory,
+  getModelLabel,
+  MAINTENANCE_MODELS,
+  Model,
+  Precision,
+  type CategoryTag,
+} from './data-mappings';
 import { frameworkFamily } from './framework-family';
 import {
   computeTierReads,
@@ -25,6 +34,8 @@ export const OVERVIEW_DEFAULT_REFERENCE_HARDWARE: OverviewReferenceHardware = 'b
 export type OverviewEngineScope = 'all' | 'community';
 export type OverviewComparisonMode = 'hardware' | 'history';
 export const OVERVIEW_DEFAULT_COMPARISON_MODE: OverviewComparisonMode = 'hardware';
+export type OverviewModelScope = 'default' | 'all';
+export const OVERVIEW_DEFAULT_MODEL_SCOPE: OverviewModelScope = 'default';
 export type OverviewScenario = 'single_turn_8k1k' | 'agentx';
 /** Row order within a model: the single-turn workload first, AgentX below it. */
 export const OVERVIEW_SCENARIOS = ['single_turn_8k1k', 'agentx'] as const;
@@ -51,6 +62,22 @@ export function resolveOverviewComparisonMode(
 ): OverviewComparisonMode {
   const candidate = Array.isArray(raw) ? raw[0] : raw;
   return candidate === '30d' ? 'history' : OVERVIEW_DEFAULT_COMPARISON_MODE;
+}
+
+export function resolveOverviewModelScope(
+  raw: string | readonly string[] | undefined,
+): OverviewModelScope {
+  const candidate = Array.isArray(raw) ? raw[0] : raw;
+  return candidate === 'all' ? 'all' : OVERVIEW_DEFAULT_MODEL_SCOPE;
+}
+
+// Note (wenyao): row order is a contract — defaults, then maintenance, then
+// deprecated, each in MODEL_CONFIG declaration order; the overview e2e asserts
+// inactive rows always sit below the default rows.
+export function overviewModelsForScope(scope: OverviewModelScope): Model[] {
+  return scope === 'all'
+    ? [...DEFAULT_MODELS, ...MAINTENANCE_MODELS, ...DEPRECATED_MODELS]
+    : [...DEFAULT_MODELS];
 }
 
 export function resolveOverviewTier(raw: string | string[] | undefined): OverviewTier {
@@ -140,6 +167,7 @@ export interface OverviewPlatformResult {
 export interface OverviewModelSummary {
   model: Model;
   modelLabel: string;
+  category: CategoryTag;
   scenario: OverviewScenario;
   platforms: OverviewPlatformResult[];
 }
@@ -150,6 +178,7 @@ export interface OverviewPageData {
   engineScope: OverviewEngineScope;
   comparisonMode: OverviewComparisonMode;
   referenceHardware: OverviewReferenceHardware;
+  modelScope: OverviewModelScope;
   historicalWindow: OverviewHistoricalWindow | null;
 }
 
@@ -649,6 +678,7 @@ export function buildOverviewModelSummary(
   return {
     model,
     modelLabel: getModelLabel(model),
+    category: getModelCategory(model),
     scenario,
     platforms: buildPlatformResults(model, scenario, scenarioRows, tier, referenceHardware),
   };
@@ -664,8 +694,12 @@ export function assembleOverviewPageData(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): OverviewPageData {
-  const perModel = [...DEFAULT_MODELS].map((model) => ({ model, rows: rowsByModel[model] ?? [] }));
+  const perModel = overviewModelsForScope(modelScope).map((model) => ({
+    model,
+    rows: rowsByModel[model] ?? [],
+  }));
   return {
     models: perModel.flatMap(({ model, rows }) =>
       overviewScenariosForModel(model, rows).map((scenario) =>
@@ -676,6 +710,7 @@ export function assembleOverviewPageData(
     engineScope,
     comparisonMode: OVERVIEW_DEFAULT_COMPARISON_MODE,
     referenceHardware,
+    modelScope,
     historicalWindow: null,
   };
 }
@@ -694,18 +729,21 @@ export function assembleOverviewHistoricalPageData(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   engineScope: OverviewEngineScope = 'community',
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): OverviewPageData {
   const current = assembleOverviewPageData(
     currentRowsByModel,
     tier,
     engineScope,
     referenceHardware,
+    modelScope,
   );
   const baseline = assembleOverviewPageData(
     baselineRowsByModel,
     tier,
     engineScope,
     referenceHardware,
+    modelScope,
   );
   const baselineByKey = new Map(
     baseline.models.flatMap((model) =>

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -58,6 +58,7 @@ function summary(overrides: Partial<OverviewModelSummary> = {}): OverviewModelSu
   return {
     model: Model.Qwen3_5,
     modelLabel: 'Qwen 3.5',
+    category: 'default',
     scenario: 'single_turn_8k1k',
     platforms: [],
     ...overrides,
@@ -325,6 +326,40 @@ describe('overview switch links', () => {
   it('preserves the selected reference when changing engine scope', () => {
     expect(overviewEngineScopeHref('en', 'all', 50, 'hardware', 'gb300')).toBe(
       '/overview?engine=all&ref=gb300',
+    );
+  });
+});
+
+describe('overview model scope links', () => {
+  it('appends models=all last and omits the default scope', () => {
+    expect(overviewHref('en', 50, 'community', 'hardware', 'b200', 'default')).toBe('/overview');
+    expect(overviewHref('en', 50, 'community', 'hardware', 'b200', 'all')).toBe(
+      '/overview?models=all',
+    );
+    expect(overviewHref('en', 100, 'all', 'history', 'b300', 'all')).toBe(
+      '/overview?tier=100&engine=all&ref=b300&compare=30d&models=all',
+    );
+    expect(overviewHref('zh', 50, 'community', 'hardware', 'b200', 'all')).toBe(
+      '/zh/overview?models=all',
+    );
+  });
+
+  it('preserves the model scope when changing tiers and engine scope', () => {
+    expect(overviewTierHref('en', 75, 'community', 'hardware', 'b200', 'all')).toBe(
+      '/overview?tier=75&models=all',
+    );
+    expect(overviewEngineScopeHref('en', 'all', 50, 'hardware', 'b200', 'all')).toBe(
+      '/overview?engine=all&models=all',
+    );
+  });
+
+  it('merges the models control into pending overview URLs', () => {
+    const tierHref = mergeOverviewControlHref('/overview?models=all', '/overview?tier=75', [
+      'tier',
+    ]);
+    expect(tierHref).toBe('/overview?tier=75&models=all');
+    expect(mergeOverviewControlHref(tierHref, '/overview?tier=75', ['models'])).toBe(
+      '/overview?tier=75',
     );
   });
 });

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -1,19 +1,27 @@
 import { runIdFromRunUrl } from './known-issues';
 import {
   OVERVIEW_DEFAULT_COMPARISON_MODE,
+  OVERVIEW_DEFAULT_MODEL_SCOPE,
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   OVERVIEW_PRIMARY_TIER,
   type OverviewComparisonMode,
   type OverviewConfigResult,
   type OverviewEngineScope,
+  type OverviewModelScope,
   type OverviewModelSummary,
   type OverviewReferenceHardware,
   type OverviewTier,
 } from './overview-data';
 
-export type OverviewSearchKey = 'tier' | 'engine' | 'ref' | 'compare';
+export type OverviewSearchKey = 'tier' | 'engine' | 'ref' | 'compare' | 'models';
 
-const OVERVIEW_SEARCH_ORDER: readonly OverviewSearchKey[] = ['tier', 'engine', 'ref', 'compare'];
+const OVERVIEW_SEARCH_ORDER: readonly OverviewSearchKey[] = [
+  'tier',
+  'engine',
+  'ref',
+  'compare',
+  'models',
+];
 
 /** Apply one control's destination to the latest pending overview URL.
  * This prevents a second, fast selection from rebuilding from stale server
@@ -179,6 +187,7 @@ export function overviewHref(
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): string {
   const base = locale === 'zh' ? '/zh/overview' : '/overview';
   const query = new URLSearchParams();
@@ -188,6 +197,7 @@ export function overviewHref(
     query.set('ref', referenceHardware);
   }
   if (comparisonMode === 'history') query.set('compare', '30d');
+  if (modelScope !== OVERVIEW_DEFAULT_MODEL_SCOPE) query.set('models', modelScope);
   const search = query.toString();
   return search === '' ? base : `${base}?${search}`;
 }
@@ -199,8 +209,9 @@ export function overviewTierHref(
   engineScope: OverviewEngineScope = 'community',
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): string {
-  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware);
+  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware, modelScope);
 }
 
 /** Engine-scope switch preserving the active service tier. */
@@ -210,6 +221,7 @@ export function overviewEngineScopeHref(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
   comparisonMode: OverviewComparisonMode = OVERVIEW_DEFAULT_COMPARISON_MODE,
   referenceHardware: OverviewReferenceHardware = OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  modelScope: OverviewModelScope = OVERVIEW_DEFAULT_MODEL_SCOPE,
 ): string {
-  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware);
+  return overviewHref(locale, tier, engineScope, comparisonMode, referenceHardware, modelScope);
 }


### PR DESCRIPTION
## Summary

Per user feedback, `/overview` now has an option at the bottom of the matrix to reveal models that are no longer actively benchmarked.

- New `?models=all` URL search param, resolved server-side like `tier`/`engine`/`ref`/`compare`; the toggle is a plain server-rendered link at the bottom of the matrix card, so it works without JS and stays copyable.
- Scope `all` appends **maintenance** (DeepSeek R1, Kimi K2.5) and **deprecated** (GLM5/5.1, gpt-oss, MiniMax M2.5/2.7, Llama 3.3 70B) rows below the default models, each with a category badge on the model name (tooltip: "Model is no longer actively benchmarked.").
- The scope is preserved across every other overview control (SLO tier, engine scope, comparison mode, reference hardware) and the language toggle; default view is byte-identical to before.
- Server loader only queries the extra models' benchmark rows when the scope is `all`.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` clean
- `bun run test:unit`: 3216 passed (new cases for scope resolution, assembler ordering/category, server forwarding, href canonicalization)
- Cypress `overview.cy.ts`: 26/26 passed locally in fixtures mode, incl. 2 new tests (toggle round-trip + zh localization)

## 中文说明

根据用户反馈，`/overview` 页面矩阵底部新增一个选项，用于显示不再进行活跃基准测试的模型。

- 新增 `?models=all` URL 参数，与 `tier`/`engine` 等控件同样在服务端解析；开关为服务端渲染的普通链接，无 JS 也可用。
- `all` 范围会在默认模型下方追加**维护模式**（DeepSeek R1、Kimi K2.5）与**已弃用**（GLM5/5.1、gpt-oss、MiniMax M2.5/2.7、Llama 3.3 70B）模型行，模型名旁带类别标签。
- 该范围在切换 SLO 档位、引擎范围、对比方式、基准硬件及中英文页面时均会保留；默认视图与之前完全一致。
- 单元测试 3216 通过，Cypress overview 26/26 通过（含 2 个新测试）。

https://claude.ai/code/session_01CG933HwZmCDoo9Bb1STs5Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive overview UX and query param with default behavior unchanged; main nuance is history snapshot anchoring, which is explicitly tested.
> 
> **Overview**
> The overview gains an optional **model scope** (`default` vs `all`) driven by the `?models=all` query param, resolved on the server and API like existing overview filters.
> 
> With scope `all`, the matrix **appends** maintenance and deprecated models below the active set (fixed order), shows **Deprecated** / **Maintenance** badges on those rows, and the server **only loads extra benchmark data** when that scope is selected. A **server-rendered link** at the bottom of the matrix toggles show/hide; the choice is **carried through** tier, engine, comparison, reference hardware, and zh/en URLs.
> 
> In **30-day history** mode, revealing inactive models no longer shifts the snapshot window—history anchoring still uses **default models only**, so deltas on active rows stay stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37dc6c259e228f0f692d762ba3934516c1c5a500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->