### PR TITLE
fix(charts): scope the disagg cost caveat to per-token-type cost / 分离式成本提示限定为按 token 类型的成本指标

### DIFF
--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -509,12 +509,31 @@ describe('TCO Calculator', () => {
       );
     });
 
-    it('shows disaggregated cost disclaimer when cost metric is selected', () => {
+    // A disagg config's input/output cost is attributed to only its prefill or
+    // decode chips, so those token types carry the caveat. The total-token cost
+    // divides by the whole chip count — the same denominator an aggregated
+    // config uses — so it must not.
+    it('shows the disaggregated cost disclaimer only for per-token-type cost', () => {
+      cy.visit('/calculator');
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length.greaterThan', 0);
       cy.get('[data-testid="calculator-metric-cost"]').click();
-      cy.get('[data-testid="calculator-chart-section"]').should(
-        'contain.text',
-        'cost per decode chip',
-      );
+
+      // Token type defaults to Total Tokens.
+      cy.get('[data-testid="calculator-disagg-cost-note"]').should('not.be.visible');
+
+      for (const tokenType of ['Output Tokens', 'Input Tokens']) {
+        cy.get('[data-testid="calc-cost-type-selector"]').click();
+        cy.contains('[role="option"]', tokenType).click();
+        cy.get('body').type('{esc}');
+        cy.get('[data-testid="calculator-disagg-cost-note"]')
+          .should('be.visible')
+          .and('contain.text', 'cost per decode chip');
+      }
+
+      cy.get('[data-testid="calc-cost-type-selector"]').click();
+      cy.contains('[role="option"]', 'Total Tokens').click();
+      cy.get('body').type('{esc}');
+      cy.get('[data-testid="calculator-disagg-cost-note"]').should('not.be.visible');
     });
 
     it('shows disaggregated throughput disclaimer for power metric', () => {

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -1147,12 +1147,22 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                           </p>
                         </>
                       )}
+                      {/* Per-token-type cost only: the input- and output-token
+                          costs are attributed to one side of a disagg config's
+                          prefill/decode split, while the total-token cost uses
+                          the whole chip count — the same denominator an
+                          aggregated config uses — so it needs no caveat. */}
                       <div
                         className={`overflow-hidden transition-all duration-200 ease-in-out ${
-                          barMetric === 'cost' ? 'max-h-20 opacity-100' : 'max-h-0 opacity-0'
+                          barMetric === 'cost' && costType !== 'total'
+                            ? 'max-h-20 opacity-100'
+                            : 'max-h-0 opacity-0'
                         }`}
                       >
-                        <p className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1">
+                        <p
+                          data-testid="calculator-disagg-cost-note"
+                          className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1"
+                        >
                           <strong>{t.note}</strong>
                           {t.disaggCost}
                         </p>

--- a/packages/app/src/components/ui/chart-display-helpers.test.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.test.tsx
@@ -90,6 +90,36 @@ describe('MetricAssumptionNotes', () => {
     expect(getVisibleCaveatText()).toContain('calculate cost per decode chip or per prefill chip');
   });
 
+  // The prefill/decode split only skews the per-token-type costs; the
+  // total-token cost divides by the whole chip count, exactly as an aggregated
+  // config does, so it must not carry the caveat.
+  it.each(['y_costhOutput', 'y_costnOutput', 'y_costrOutput', 'y_costhi', 'y_costni', 'y_costri'])(
+    'shows the cost disaggregation caveat for per-token-type cost metric %s',
+    (metric) => {
+      renderUi(<MetricAssumptionNotes selectedYAxisMetric={metric} />);
+
+      expect(getVisibleCaveatText()).toContain(
+        'calculate cost per decode chip or per prefill chip',
+      );
+    },
+  );
+
+  it.each(['y_costh', 'y_costn', 'y_costr'])(
+    'hides the cost disaggregation caveat for total-token cost metric %s',
+    (metric) => {
+      renderUi(<MetricAssumptionNotes selectedYAxisMetric={metric} />);
+
+      // The TCO badges and source attribution still belong on a cost chart.
+      expect(getVisibleText()).toContain('TCO $/chip/hr:');
+      expect(getVisibleText()).toContain(
+        'SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model',
+      );
+      expect(getVisibleCaveatText()).not.toContain(
+        'calculate cost per decode chip or per prefill chip',
+      );
+    },
+  );
+
   it('renders metric-specific throughput caveats and preserves Joules wording semantics', () => {
     renderUi(<MetricAssumptionNotes selectedYAxisMetric="y_inputTputPerGpu" />);
 

--- a/packages/app/src/components/ui/chart-display-helpers.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.tsx
@@ -154,6 +154,13 @@ export function MetricAssumptionNotes({
   const showInputCostSource = INPUT_COST_METRICS.has(selectedYAxisMetric);
   const showInputThroughputCaveat = selectedYAxisMetric === 'y_inputTputPerGpu';
   const showOutputThroughputCaveat = selectedYAxisMetric === 'y_outputTputPerGpu';
+  // Per-token-type cost only. A disagg config's prefill and decode chips are
+  // counted separately, so the input- and output-token costs are attributed to
+  // one side of the split and can't be lined up against an aggregated config.
+  // The total-token cost divides by the whole chip count, which is the same
+  // denominator an aggregated config uses, so it needs no caveat — the same
+  // split the throughput caveats above already make (input/output, not total).
+  const showCostCaveat = showOutputCostSource || showInputCostSource;
   const showJouleSource = selectedYAxisMetric.startsWith('y_j');
 
   const costValues =
@@ -186,11 +193,7 @@ export function MetricAssumptionNotes({
           </SourceLink>
         </>
       )}
-      <DisaggCaveat
-        visible={selectedYAxisMetric.startsWith('y_cost')}
-        calculationNoun="cost"
-        locale={locale}
-      />
+      <DisaggCaveat visible={showCostCaveat} calculationNoun="cost" locale={locale} />
       <DisaggCaveat
         visible={showInputThroughputCaveat}
         calculationNoun="input throughput"


### PR DESCRIPTION
## Summary

The disaggregated-inference cost caveat —

> **Note:** Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) calculate cost per decode chip or per prefill chip, rather than per total chip count. This makes direct cost comparison with aggregated configs not an apples-to-apples comparison.

— fired for **every** cost metric, because it was gated on `selectedYAxisMetric.startsWith('y_cost')`. It now shows only for **Cost per Million Output Tokens** and **Cost per Million Input Tokens**, and no longer for **Cost per Million Total Tokens**.

## Why total-token cost doesn't need it

A disagg config counts its prefill and decode chips separately. The input-token cost is therefore attributed to only its prefill chips and the output-token cost to only its decode chips — neither lines up against an aggregated config. The total-token cost divides by the **whole** chip count, which is the same denominator an aggregated config uses, so it is already apples-to-apples and the warning is noise there.

This also brings cost in line with throughput in the same component, where the caveat already fires for `y_inputTputPerGpu` and `y_outputTputPerGpu` but **never** for total throughput. The cost gate was the odd one out.

## Changes

**`chart-display-helpers.tsx`** (inference / historical-trends charts) — replaces the `startsWith('y_cost')` gate with `showOutputCostSource || showInputCostSource`, reusing the `OUTPUT_COST_METRICS` / `INPUT_COST_METRICS` sets already defined in the file for source attribution. `TOTAL_COST_METRICS` (`y_costh`, `y_costn`, `y_costr`) is excluded.

**`ThroughputCalculatorDisplay.tsx`** — the calculator renders the *same* disclaimer text with its own total/input/output **Token Type** selector, and had the same problem (gated on `barMetric === 'cost'` alone). Now also requires `costType !== 'total'`. **Flagging this as slightly beyond the literal ask** — the request quoted the shared disclaimer text rather than a location, and fixing only the chart would leave the identical wrong disclaimer on the calculator. Easy to drop if you'd rather keep this PR to the chart alone.

Unaffected: the TCO `$/chip/hr` badges and the cost source attribution link. A total-token cost chart keeps both — it just loses the caveat. The Chinese copy needs no change; only the visibility condition moved, and the `zh` string is rendered from the same component.

## Tests

- **`chart-display-helpers.test.tsx`** — two new `it.each` blocks: the caveat shows for all six per-token-type cost metrics (`y_costhOutput`, `y_costnOutput`, `y_costrOutput`, `y_costhi`, `y_costni`, `y_costri`) and is hidden for all three total-token metrics (`y_costh`, `y_costn`, `y_costr`), while TCO badges and source attribution stay present. **14/14 pass.**
- **`throughput-calculator.cy.ts`** — the old test asserted `contain.text` on the section, which passes even when the caveat is collapsed (it stays in the DOM behind `max-h-0 opacity-0`), so it would not have caught this either way. Replaced with a real visibility assertion that walks Total → Output → Input → Total. Needed a `data-testid="calculator-disagg-cost-note"` on the paragraph to target it. **66/66 pass locally.**
- `bun run test:unit` — **3,755 passed**, 0 failed. `typecheck`, `lint`, `fmt` clean.

Overlay note: this is caption/annotation logic driven by the selected Y-axis metric, shared by the official and `?unofficialrun=` overlay paths alike — `MetricAssumptionNotes` reads only `selectedYAxisMetric`, so there is no separate overlay branch to handle.

## 中文说明

分离式推理（disaggregated inference）成本提示此前对**所有**成本指标都会显示，因为其判定条件是 `selectedYAxisMetric.startsWith('y_cost')`。现改为仅在**每百万输出 token 成本**与**每百万输入 token 成本**下显示，不再出现在**每百万总 token 成本**下。

**为何总 token 成本无需该提示：** 分离式配置的预填充（prefill）与解码（decode）Chip 分别计数，因此输入 token 成本仅归属于其预填充 Chip、输出 token 成本仅归属于其解码 Chip，两者都无法与聚合（aggregated）配置直接对比；而总 token 成本按 **Chip 总数**计算，与聚合配置使用相同的分母，本身即为等价对比，此处的提示属于干扰信息。此改动也使成本与同一组件中吞吐量的处理保持一致——吞吐量提示本就只在 `y_inputTputPerGpu` 与 `y_outputTputPerGpu` 下显示，从不在总吞吐量下显示，此前成本的判定条件是唯一的例外。

**改动内容：** `chart-display-helpers.tsx`（推理／历史趋势图表）将 `startsWith('y_cost')` 判定替换为 `showOutputCostSource || showInputCostSource`，复用文件中已有的 `OUTPUT_COST_METRICS` / `INPUT_COST_METRICS` 集合，排除 `TOTAL_COST_METRICS`。`ThroughputCalculatorDisplay.tsx`（TCO 计算器）渲染的是**同一段**提示文案，并拥有自己的总／输入／输出 **Token 类型**选择器，此前同样存在该问题（仅以 `barMetric === 'cost'` 判定），现追加要求 `costType !== 'total'`。**需说明：** 此项略超出字面请求范围——原请求引用的是共享的提示文案而非具体位置，若仅修改图表侧，计算器上仍会显示同样错误的提示；如希望本 PR 仅覆盖图表，可随时移除该项。TCO `$/chip/hr` 徽章与成本来源链接不受影响：总 token 成本图表仍保留两者，仅不再显示该提示。中文文案无需改动，仅可见性条件发生变化。

**测试：** `chart-display-helpers.test.tsx` 新增两组 `it.each`，分别验证六个按 token 类型划分的成本指标会显示提示、三个总 token 成本指标不显示提示且 TCO 徽章与来源标注仍在（14/14 通过）。`throughput-calculator.cy.ts` 原用例使用 `contain.text` 断言，即便提示被折叠（仍存在于 DOM 中，仅 `max-h-0 opacity-0`）也会通过，因此无论如何都无法捕获此问题；现替换为真实的可见性断言，按 总→输出→输入→总 的顺序切换验证，并为该段落添加 `data-testid="calculator-disagg-cost-note"` 以便定位（本地 66/66 通过）。`bun run test:unit` 3,755 项全部通过；`typecheck`、`lint`、`fmt` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility logic for chart captions and calculator disclaimers; no changes to cost calculation, APIs, or auth.
> 
> **Overview**
> **Limits when the disaggregated-inference cost disclaimer appears** so it no longer shows for **total-token** cost views, where the math already uses whole-chip denominators like aggregated configs.
> 
> On **inference / historical-trend charts** (`MetricAssumptionNotes`), the caveat gate moves from any `y_cost*` metric to **input/output cost metrics only** (`showOutputCostSource || showInputCostSource`), excluding `y_costh`, `y_costn`, and `y_costr`. TCO badges and source links are unchanged.
> 
> The **TCO calculator** applies the same rule: the amber note is visible only when **Cost** is selected **and** token type is **Input** or **Output**, not **Total Tokens**. A `data-testid` was added for reliable Cypress visibility checks.
> 
> **Tests** add unit coverage for all six per-token-type vs three total cost metrics, and replace a flaky `contain.text` E2E assertion with explicit show/hide checks across token-type switches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a87d052c5dc3771e4d3de093a46737a68d4b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->