### PR TITLE
Replace overview SLO buttons with a six-stop slider / 将 Overview 页 SLO 按钮替换为六档滑块

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -399,6 +399,14 @@ describe('Overview page', () => {
       cy.window().then((after) => {
         expect(after.history.length - before, 'one entry for one selection').to.equal(1);
       });
+      // The unsuccessful stop stays retryable: activating it again re-requests
+      // without stacking another history entry for the byte-identical href.
+      selectOverviewTier(75);
+      cy.wait('@overviewJsonFailure');
+      cy.location('search').should('eq', '?tier=75');
+      cy.window().then((after) => {
+        expect(after.history.length - before, 'retry adds no history entry').to.equal(1);
+      });
     });
 
     cy.go('back');

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -43,16 +43,27 @@ const OVERVIEW_TIERS = [30, 50, 75, 100, 150, 200] as const;
 
 function selectOverviewTier(tier: (typeof OVERVIEW_TIERS)[number]) {
   const targetIndex = OVERVIEW_TIERS.indexOf(tier);
-  return cy.get<HTMLInputElement>('[data-testid="overview-tier-slider"]').then(([slider]) => {
+  // Unlike clicks, synthetic input events are not replayed by React, so a
+  // dispatch that lands before hydration finishes is silently dropped. The
+  // `.should` callback retries the whole dispatch until React has committed
+  // the selection, which only happens once the slider is interactive.
+  return cy.get<HTMLInputElement>('[data-testid="overview-tier-slider"]').should(([slider]) => {
     const view = slider.ownerDocument.defaultView;
     if (view === null) throw new Error('Slider has no window');
+    const tracker = (slider as { _valueTracker?: { setValue: (next: string) => void } })
+      ._valueTracker;
+    // React installs the value tracker when hydration commits the input.
+    expect(tracker, 'tier slider is hydrated').to.not.eq(undefined);
     const nativeValueSetter = Object.getOwnPropertyDescriptor(
       view.HTMLInputElement.prototype,
       'value',
     )?.set;
     if (nativeValueSetter === undefined) throw new Error('Range input has no native value setter');
     nativeValueSetter.call(slider, String(targetIndex));
+    // Desync the tracker so React always registers the dispatched input.
+    tracker?.setValue('');
     slider.dispatchEvent(new view.Event('input', { bubbles: true }));
+    expect(slider.dataset.tier, 'slider committed tier').to.eq(String(tier));
   });
 }
 
@@ -285,9 +296,9 @@ describe('Overview page', () => {
     // Keeps its explicit timeout because it waits on the real API through
     // `request.continue` plus the delay above — unlike the URL assertions
     // around it, which the click resolves synchronously.
-    cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]', {
+    cy.get('[data-testid="overview-tier-slider"]', {
       timeout: 15_000,
-    }).should('have.text', '75');
+    }).should('have.attr', 'data-tier', '75');
     cy.get('[data-overview-engine-scope="all"]').should('have.attr', 'aria-current', 'true');
     cy.location('search').should('eq', '?tier=75&engine=all');
   });
@@ -301,7 +312,7 @@ describe('Overview page', () => {
       });
     }).as('overviewJson');
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('exist');
     cy.wait('@overviewJson');
     cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('not.exist');
@@ -340,10 +351,7 @@ describe('Overview page', () => {
         'have.text',
         'Could not load the selected comparison. Showing the last successfully loaded data.',
       );
-    cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]').should(
-      'have.text',
-      '50',
-    );
+    cy.get('[data-testid="overview-tier-slider"]').should('have.attr', 'data-tier', '50');
     cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('not.exist');
     cy.location('search').should('eq', '?tier=75&ref=b300');
     cy.get<number>('@overviewHistoryLength').then((expectedHistoryLength) => {
@@ -366,7 +374,7 @@ describe('Overview page', () => {
       }).as('emptyOverview');
       cy.visit('/zh/overview');
 
-      cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+      selectOverviewTier(75);
       cy.wait('@emptyOverview');
       cy.get('[data-testid="overview-empty-state"]')
         .should('have.attr', 'role', 'status')
@@ -384,7 +392,7 @@ describe('Overview page', () => {
 
     cy.window().then((win) => {
       const before = win.history.length;
-      cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+      selectOverviewTier(75);
       cy.wait('@overviewJsonFailure');
       cy.location('search').should('eq', '?tier=75');
       // A plain `.should` would be satisfied by the transient extra entry.
@@ -407,26 +415,27 @@ describe('Overview page', () => {
       jsonRequests += 1;
     }).as('overviewJson');
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').trigger('pointerover');
+    cy.get('[data-testid="overview-engine-scope-switcher"]')
+      .find('[data-overview-engine-scope="all"]')
+      .trigger('pointerover');
     cy.wait('@overviewJson');
     cy.location('search').should('eq', '');
     cy.then(() => {
       expect(jsonRequests, 'hover warms exactly one response').to.equal(1);
     });
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
-    cy.location('search').should('eq', '?tier=100');
-    cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]').should(
-      'have.text',
-      '100',
-    );
+    cy.get('[data-testid="overview-engine-scope-switcher"]')
+      .find('[data-overview-engine-scope="all"]')
+      .click();
+    cy.location('search').should('eq', '?engine=all');
+    cy.get('[data-overview-engine-scope="all"]').should('have.attr', 'aria-current', 'true');
     cy.then(() => {
       expect(jsonRequests, 'the click reuses the warmed response').to.equal(1);
     });
 
     cy.get('[data-testid="overview-reference-select"]').click();
     cy.get('[data-overview-reference="b300"]').click();
-    cy.location('search').should('eq', '?tier=100&ref=b300');
+    cy.location('search').should('eq', '?engine=all&ref=b300');
     cy.get('[data-overview-comparison="hardware"]').should('contain.text', 'vs B300');
     cy.then(() => {
       expect(jsonRequests, 'a reference change is derived, not fetched').to.equal(1);
@@ -665,7 +674,7 @@ describe('Overview page', () => {
     cy.location('search').should('eq', '?tier=75&present=1&utm_source=deck');
     cy.location('hash').should('eq', '#matrix');
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
+    selectOverviewTier(100);
     cy.location('search').should('eq', '?tier=100&present=1&utm_source=deck');
     cy.get('[data-testid="overview-presentation-surface"]').should(
       'have.attr',
@@ -701,7 +710,7 @@ describe('Overview page', () => {
     cy.visit('/overview?tier=75', { onBeforeLoad: stubFullscreenApi });
 
     // A selector push creates a real same-document history entry.
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
+    selectOverviewTier(100);
     cy.location('search').should('eq', '?tier=100');
     cy.get('[data-testid="overview-present-toggle"]').click();
     cy.location('search').should('eq', '?tier=100&present=1');
@@ -1826,7 +1835,8 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.get('[data-testid="overview-tier-slider"]')
         .should('have.attr', 'data-tier', '100')
-        .and('have.attr', 'aria-valuetext', '100 tok/s/用户');
+        // tok/s/user is a protected unit that stays untranslated on the zh route.
+        .and('have.attr', 'aria-valuetext', '100 tok/s/user');
       cy.get('[data-tier-option]').should('have.length', 6);
     });
   });

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -39,6 +39,22 @@ const SCOPE_LINE = `${SCOPE_METRIC} · ${SCOPE_DIRECTION} · ${SOURCE_NOTE}`;
 const SCOPE_METRIC_ZH = '超大规模云厂商成本';
 const SCOPE_DIRECTION_ZH = '↓ 越低越好';
 const SCOPE_LINE_ZH = `${SCOPE_METRIC_ZH} · ${SCOPE_DIRECTION_ZH} · ${SOURCE_NOTE_ZH}`;
+const OVERVIEW_TIERS = [30, 50, 75, 100, 150, 200] as const;
+
+function selectOverviewTier(tier: (typeof OVERVIEW_TIERS)[number]) {
+  const targetIndex = OVERVIEW_TIERS.indexOf(tier);
+  return cy.get<HTMLInputElement>('[data-testid="overview-tier-slider"]').then(([slider]) => {
+    const view = slider.ownerDocument.defaultView;
+    if (view === null) throw new Error('Slider has no window');
+    const nativeValueSetter = Object.getOwnPropertyDescriptor(
+      view.HTMLInputElement.prototype,
+      'value',
+    )?.set;
+    if (nativeValueSetter === undefined) throw new Error('Range input has no native value setter');
+    nativeValueSetter.call(slider, String(targetIndex));
+    slider.dispatchEvent(new view.Event('input', { bubbles: true }));
+  });
+}
 
 function expectNoHorizontalOverflow() {
   cy.document().then((doc) => {
@@ -188,14 +204,14 @@ describe('Overview page', () => {
         'preserved';
     });
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.wait('@overviewJson');
     cy.location('search').should('eq', '?tier=75');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '50').click();
+    selectOverviewTier(50);
     cy.location('search').should('eq', '');
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.location('search').should('eq', '?tier=75');
     cy.then(() => {
       expect(jsonRequests, 'one request; both visited selections are cached').to.equal(1);
@@ -226,7 +242,7 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
     cy.intercept('GET', '**/api/v1/overview*').as('overviewJson');
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.wait('@overviewJson');
     cy.location('search').should('eq', '?tier=75');
 
@@ -259,7 +275,7 @@ describe('Overview page', () => {
       });
     }).as('overviewJson');
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.get('[data-testid="overview-engine-scope-switcher"]')
       .find('[data-overview-engine-scope="all"]')
       .click();
@@ -460,7 +476,7 @@ describe('Overview page', () => {
       );
     });
 
-    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+    selectOverviewTier(75);
     cy.location('search').should('eq', '?tier=75&models=all');
     cy.get('[data-testid="overview-desktop-model"][data-model="gpt-oss-120b"]').should('exist');
 
@@ -507,22 +523,21 @@ describe('Overview page', () => {
       platform('b200').find('[data-testid="overview-cost-delta"]').should('exist');
     });
 
-    cy.get('[data-testid="overview-tier-switcher"]')
-      .contains('a', '100')
-      .should('have.attr', 'href', '/overview?tier=100&ref=b300');
+    selectOverviewTier(100);
+    cy.location('search').should('eq', '?tier=100&ref=b300');
     cy.get('[data-testid="overview-engine-scope-switcher"]')
       .find('[data-overview-engine-scope="all"]')
-      .should('have.attr', 'href', '/overview?engine=all&ref=b300');
+      .should('have.attr', 'href', '/overview?tier=100&engine=all&ref=b300');
     cy.get('[data-overview-comparison="30d"]').should(
       'have.attr',
       'href',
-      '/overview?ref=b300&compare=30d',
+      '/overview?tier=100&ref=b300&compare=30d',
     );
     cy.get('[data-testid="language-toggle"]')
-      .should('have.attr', 'href', '/zh/overview?ref=b300')
+      .should('have.attr', 'href', '/zh/overview?tier=100&ref=b300')
       .click();
     cy.location('pathname').should('eq', '/zh/overview');
-    cy.location('search').should('eq', '?ref=b300');
+    cy.location('search').should('eq', '?tier=100&ref=b300');
     cy.get('[data-overview-comparison="hardware"]').should('contain.text', '对比 B300');
   });
 
@@ -593,17 +608,16 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-desktop-matrix"] thead').should('contain.text', 'B200');
     cy.get('[data-testid="overview-desktop-matrix"] thead').should('not.contain.text', 'Reference');
 
-    cy.get('[data-testid="overview-tier-switcher"]')
-      .contains('a', '100')
-      .should('have.attr', 'href', '/overview?tier=100&compare=30d');
+    selectOverviewTier(100);
+    cy.location('search').should('eq', '?tier=100&compare=30d');
     cy.get('[data-testid="overview-engine-scope-switcher"]')
       .find('[data-overview-engine-scope="all"]')
-      .should('have.attr', 'href', '/overview?engine=all&compare=30d');
+      .should('have.attr', 'href', '/overview?tier=100&engine=all&compare=30d');
     cy.get('[data-testid="language-toggle"]')
-      .should('have.attr', 'href', '/zh/overview?compare=30d')
+      .should('have.attr', 'href', '/zh/overview?tier=100&compare=30d')
       .click();
     cy.location('pathname').should('eq', '/zh/overview');
-    cy.location('search').should('eq', '?compare=30d');
+    cy.location('search').should('eq', '?tier=100&compare=30d');
     cy.get('[data-testid="overview-comparison-switcher"]')
       .should('have.attr', 'aria-label', '对比方式')
       .within(() => {
@@ -1000,10 +1014,7 @@ describe('Overview page', () => {
     ).click();
     cy.location('search').should('eq', '?engine=all');
     desktopModel('GLM-5.2').find('[data-testid="overview-pair-missing"]').should('have.length', 5);
-    cy.get('[data-testid="overview-tier-switcher"]')
-      .contains('a', '100')
-      .should('have.attr', 'href', '/overview?tier=100&engine=all')
-      .click();
+    selectOverviewTier(100);
     cy.location('search').should('eq', '?tier=100&engine=all');
 
     cy.get('[data-testid="overview-engine-scope-switcher"]')
@@ -1422,7 +1433,7 @@ describe('Overview page', () => {
       .should('not.match', /∞\s*%/);
   });
 
-  it('re-renders the whole matrix at the service level the URL names, via plain links', () => {
+  it('re-renders the whole matrix from the six-stop SLO slider', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
@@ -1432,22 +1443,35 @@ describe('Overview page', () => {
       .and('contain.text', 'SLO');
     cy.get('body').should('not.contain.text', 'Service level');
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
-      cy.get('[aria-current="page"]').should('have.text', '50');
-      // 30 / 75 / 100 / 150 / 200 link out; the active 50 is inert text.
-      cy.get('a').should('have.length', 5);
-      cy.contains('a', '30').should('have.attr', 'href', '/overview?tier=30');
-      cy.contains('a', '150').should('have.attr', 'href', '/overview?tier=150');
-      cy.contains('a', '200').should('have.attr', 'href', '/overview?tier=200');
-      cy.contains('a', '100').should('have.attr', 'href', '/overview?tier=100').click();
+      cy.get('a, button').should('not.exist');
+      cy.get('[data-tier-option]').should('have.length', 6);
+      cy.get('[data-tier-option="50"]').should('have.attr', 'data-selected', 'true');
+      cy.get('[data-testid="overview-tier-slider"]')
+        .should('have.attr', 'min', '0')
+        .and('have.attr', 'max', '5')
+        .and('have.attr', 'step', '1')
+        .and('have.value', '1')
+        .and('have.attr', 'data-tier', '50')
+        .and('have.attr', 'aria-valuetext', '50 tok/s/user');
     });
+
+    selectOverviewTier(100);
 
     cy.location('search').should('eq', '?tier=100');
     // The metric line never repeats the tier — the switcher states it.
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE);
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
-      cy.get('[aria-current="page"]').should('have.text', '100');
-      cy.contains('a', '50').should('have.attr', 'href', '/overview');
+      cy.get('[data-tier-option="100"]').should('have.attr', 'data-selected', 'true');
+      cy.get('[data-testid="overview-tier-slider"]')
+        .should('have.attr', 'type', 'range')
+        .should('have.value', '3')
+        .and('have.attr', 'data-tier', '100')
+        .and('have.attr', 'aria-valuetext', '100 tok/s/user');
     });
+    selectOverviewTier(75);
+    cy.location('search').should('eq', '?tier=75');
+    selectOverviewTier(100);
+    cy.location('search').should('eq', '?tier=100');
 
     desktopModel('Qwen-3.5-397B-A17B', SINGLE_TURN).within(() => {
       platform('b200').should('contain.text', '$0.124').and('contain.text', 'FP8');
@@ -1793,7 +1817,10 @@ describe('Overview page', () => {
       .and('contain.text', 'SLO');
     cy.get('body').should('not.contain.text', '服务档位');
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
-      cy.contains('a', '50').should('have.attr', 'href', '/zh/overview');
+      cy.get('[data-testid="overview-tier-slider"]')
+        .should('have.attr', 'data-tier', '100')
+        .and('have.attr', 'aria-valuetext', '100 tok/s/用户');
+      cy.get('[data-tier-option]').should('have.length', 6);
     });
   });
 });

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -1446,6 +1446,10 @@ describe('Overview page', () => {
       cy.get('a, button').should('not.exist');
       cy.get('[data-tier-option]').should('have.length', 6);
       cy.get('[data-tier-option="50"]').should('have.attr', 'data-selected', 'true');
+      cy.get('[data-testid="overview-tier-ridge"]').should('have.length', 6);
+      cy.get('[data-tier-ridge="30"]').should('have.attr', 'data-state', 'filled');
+      cy.get('[data-tier-ridge="50"]').should('have.attr', 'data-state', 'selected');
+      cy.get('[data-tier-ridge="75"]').should('have.attr', 'data-state', 'unfilled');
       cy.get('[data-testid="overview-tier-slider"]')
         .should('have.attr', 'min', '0')
         .and('have.attr', 'max', '5')
@@ -1462,6 +1466,9 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE);
     cy.get('[data-testid="overview-tier-switcher"]').within(() => {
       cy.get('[data-tier-option="100"]').should('have.attr', 'data-selected', 'true');
+      cy.get('[data-tier-ridge="75"]').should('have.attr', 'data-state', 'filled');
+      cy.get('[data-tier-ridge="100"]').should('have.attr', 'data-state', 'selected');
+      cy.get('[data-tier-ridge="150"]').should('have.attr', 'data-state', 'unfilled');
       cy.get('[data-testid="overview-tier-slider"]')
         .should('have.attr', 'type', 'range')
         .should('have.value', '3')

--- a/packages/app/src/components/overview/overview-page.test.tsx
+++ b/packages/app/src/components/overview/overview-page.test.tsx
@@ -78,13 +78,15 @@ describe('OverviewPageContent failure states', () => {
       window.history.replaceState({}, '', locale === 'zh' ? '/zh/overview' : '/overview');
       renderPage(locale);
 
-      const tierLink = [...container.querySelectorAll<HTMLAnchorElement>('a')].find(
-        (link) => link.textContent === '75',
+      // The tier control is a slider, not a link, so the failed navigation is
+      // driven through the engine scope link instead.
+      const scopeLink = container.querySelector<HTMLAnchorElement>(
+        'a[data-overview-engine-scope="all"]',
       );
-      expect(tierLink).toBeDefined();
+      expect(scopeLink).not.toBeNull();
 
       await act(async () => {
-        tierLink?.click();
+        scopeLink?.click();
         await Promise.resolve();
         await Promise.resolve();
       });

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -9,7 +9,6 @@ import {
   OVERVIEW_HARDWARE,
   OVERVIEW_HISTORY_WINDOW_DAYS,
   OVERVIEW_HISTORY_WINDOWS,
-  OVERVIEW_TIERS,
   overviewHardwareLabel,
   type OverviewComparisonMode,
   type OverviewEngineScope,
@@ -28,7 +27,6 @@ import {
   detailHref,
   overviewEngineScopeHref,
   overviewHref,
-  overviewTierHref,
 } from '@/lib/overview-links';
 
 import { OverviewDetailLink } from './overview-detail-link';
@@ -38,6 +36,7 @@ import { OverviewNavLink } from './overview-nav-link';
 import { type OverviewNavControl, useOverviewNavigation } from './overview-navigation';
 import { OverviewReferenceSelect } from './overview-reference-select';
 import { type OverviewLocale, type OverviewStrings } from './overview-strings';
+import { OverviewTierSlider } from './overview-tier-slider';
 
 interface Formatters {
   cost: Intl.NumberFormat;
@@ -783,8 +782,7 @@ function ActiveSwitcherOption({
   );
 }
 
-/** Every option remains a copyable server-rendered URL; ordinary clicks use a
- *  soft App Router transition and the displayed tier is never a self-link. */
+/** The six benchmarked service levels are exposed as discrete slider stops. */
 export function OverviewTierSwitcher({
   tier,
   engineScope,
@@ -806,50 +804,19 @@ export function OverviewTierSwitcher({
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
-  const optionClass =
-    'inline-flex min-h-11 items-center px-3 tabular-nums focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring';
   return (
-    <nav
-      data-testid="overview-tier-switcher"
-      aria-label={strings.tierNavLabel}
-      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
-    >
-      <span className="text-muted-foreground">{strings.tierNavLabel}</span>
-      <div className="flex divide-x divide-border/60 overflow-hidden rounded-md border border-border/60">
-        {OVERVIEW_TIERS.map((option) =>
-          option === tier ? (
-            <ActiveSwitcherOption
-              key={option}
-              control="tier"
-              aria-current="page"
-              className={`${optionClass} bg-muted font-semibold text-foreground`}
-            >
-              {option}
-            </ActiveSwitcherOption>
-          ) : (
-            <OverviewNavLink
-              key={option}
-              href={overviewTierHref(
-                locale,
-                option,
-                engineScope,
-                comparisonMode,
-                referenceHardware,
-                modelScope,
-                rowScope,
-                hardwareRowScope,
-              )}
-              analytics={{ control: 'tier', value: String(option) }}
-              searchKeys={['tier']}
-              className={`${optionClass} text-muted-foreground transition-colors hover:text-foreground`}
-            >
-              {option}
-            </OverviewNavLink>
-          ),
-        )}
-      </div>
-      <span className="text-muted-foreground">{strings.tierUnit}</span>
-    </nav>
+    <OverviewTierSlider
+      tier={tier}
+      engineScope={engineScope}
+      comparisonMode={comparisonMode}
+      referenceHardware={referenceHardware}
+      modelScope={modelScope}
+      rowScope={rowScope}
+      hardwareRowScope={hardwareRowScope}
+      locale={locale}
+      label={strings.tierNavLabel}
+      unit={strings.tierUnit}
+    />
   );
 }
 

--- a/packages/app/src/components/overview/overview-switcher-focus.test.tsx
+++ b/packages/app/src/components/overview/overview-switcher-focus.test.tsx
@@ -4,7 +4,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { OverviewPageData, OverviewTier } from '@/lib/overview-data';
+import type { OverviewEngineScope, OverviewPageData } from '@/lib/overview-data';
 
 const routerStub = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
 
@@ -13,7 +13,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 import { OverviewNavigationProvider, useOverviewData } from './overview-navigation';
-import { OverviewTierSwitcher } from './overview-scorecard';
+import { OverviewEngineScopeSwitcher } from './overview-scorecard';
 import { OVERVIEW_STRINGS } from './overview-strings';
 
 declare global {
@@ -25,11 +25,11 @@ globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 let container: HTMLDivElement;
 let root: Root;
 
-function pageData(tier: OverviewTier): OverviewPageData {
+function pageData(engineScope: OverviewEngineScope): OverviewPageData {
   return {
     models: [],
-    tier,
-    engineScope: 'community',
+    tier: 50,
+    engineScope,
     comparisonMode: 'hardware',
     referenceHardware: 'b200',
     modelScope: 'default',
@@ -41,14 +41,14 @@ function pageData(tier: OverviewTier): OverviewPageData {
   };
 }
 
-/** Mirrors the real page: the tier comes from the payload in context, so the
+/** Mirrors the real page: the scope comes from the payload in context, so the
  *  active option moves when the response lands. */
 function Body() {
   const data = useOverviewData();
   return (
-    <OverviewTierSwitcher
-      tier={data.tier}
+    <OverviewEngineScopeSwitcher
       engineScope={data.engineScope}
+      tier={data.tier}
       comparisonMode={data.comparisonMode}
       referenceHardware={data.referenceHardware}
       modelScope={data.modelScope}
@@ -60,21 +60,19 @@ function Body() {
   );
 }
 
-function renderSwitcher(tier: OverviewTier, href: string) {
+function renderSwitcher(engineScope: OverviewEngineScope, href: string) {
   act(() => {
     root.render(
-      <OverviewNavigationProvider initialData={pageData(tier)} initialHref={href}>
+      <OverviewNavigationProvider initialData={pageData(engineScope)} initialHref={href}>
         <Body />
       </OverviewNavigationProvider>,
     );
   });
 }
 
-function tierOption(label: string): HTMLElement {
-  const match = [...container.querySelectorAll<HTMLElement>('a, span')].find(
-    (element) => element.textContent === label && element.tagName !== 'NAV',
-  );
-  if (match === undefined) throw new Error(`no tier option labelled ${label}`);
+function scopeOption(scope: OverviewEngineScope): HTMLElement {
+  const match = container.querySelector<HTMLElement>(`[data-overview-engine-scope="${scope}"]`);
+  if (match === null) throw new Error(`no engine scope option ${scope}`);
   return match;
 }
 
@@ -95,11 +93,11 @@ afterEach(() => {
 
 describe('overview switcher focus', () => {
   it('moves focus to the option that replaces the activated link', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(pageData(75))));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(pageData('all'))));
 
-    renderSwitcher(50, '/overview');
+    renderSwitcher('community', '/overview');
 
-    const link = tierOption('75');
+    const link = scopeOption('all');
     expect(link.tagName).toBe('A');
     link.focus();
     expect(document.activeElement).toBe(link);
@@ -111,22 +109,22 @@ describe('overview switcher focus', () => {
 
     // The activated anchor is gone — React swapped in the active <span> — and
     // without the focus handoff the browser drops focus to <body>.
-    const active = tierOption('75');
+    const active = scopeOption('all');
     expect(active.tagName).toBe('SPAN');
-    expect(active.getAttribute('aria-current')).toBe('page');
+    expect(active.getAttribute('aria-current')).toBe('true');
     expect(document.activeElement).not.toBe(document.body);
     expect(document.activeElement).toBe(active);
   });
 
   it('leaves focus alone when the click did not come from the focused element', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(pageData(75))));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(pageData('all'))));
 
-    renderSwitcher(50, '/overview');
+    renderSwitcher('community', '/overview');
 
     // A pointer click never focuses the anchor first in jsdom, so there is no
     // focus to restore and the active option must not steal it.
     await act(async () => {
-      tierOption('75').dispatchEvent(
+      scopeOption('all').dispatchEvent(
         new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }),
       );
       await Promise.resolve();

--- a/packages/app/src/components/overview/overview-tier-slider.tsx
+++ b/packages/app/src/components/overview/overview-tier-slider.tsx
@@ -98,33 +98,65 @@ export function OverviewTierSlider({
     >
       <span className="shrink-0 text-muted-foreground">{label}</span>
       <div className="w-[min(18rem,calc(100vw-8.5rem))] min-w-0 pt-1">
-        <input
-          data-testid="overview-tier-slider"
-          type="range"
-          min={0}
-          max={OVERVIEW_TIERS.length - 1}
-          step={1}
-          value={selectedIndex}
-          aria-label={label}
-          aria-valuetext={`${selectedTier} ${unit}`}
-          data-tier={selectedTier}
-          onChange={handleChange}
-          onPointerDown={() => {
-            pointerActive.current = true;
-          }}
-          onPointerUp={(event) => {
-            pointerActive.current = false;
-            commit(Number(event.currentTarget.value));
-          }}
-          onPointerCancel={() => {
-            pointerActive.current = false;
-            setSelectedIndex(tierIndex(tier));
-          }}
-          className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&::-moz-range-progress]:h-1.5 [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-foreground [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:cursor-grab [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:shadow-sm [&::-moz-range-thumb]:active:cursor-grabbing [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:cursor-grab [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:shadow-sm [&::-webkit-slider-thumb]:active:cursor-grabbing"
-          style={{
-            background: `linear-gradient(to right, var(--foreground) 0%, var(--foreground) ${progress}%, var(--border) ${progress}%, var(--border) 100%)`,
-          }}
-        />
+        <div className="relative h-4">
+          <input
+            data-testid="overview-tier-slider"
+            type="range"
+            min={0}
+            max={OVERVIEW_TIERS.length - 1}
+            step={1}
+            value={selectedIndex}
+            aria-label={label}
+            aria-valuetext={`${selectedTier} ${unit}`}
+            data-tier={selectedTier}
+            onChange={handleChange}
+            onPointerDown={() => {
+              pointerActive.current = true;
+            }}
+            onPointerUp={(event) => {
+              pointerActive.current = false;
+              commit(Number(event.currentTarget.value));
+            }}
+            onPointerCancel={() => {
+              pointerActive.current = false;
+              setSelectedIndex(tierIndex(tier));
+            }}
+            className="absolute top-1/2 z-10 h-1.5 w-full -translate-y-1/2 cursor-pointer appearance-none rounded-full bg-border accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&::-moz-range-progress]:h-1.5 [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-foreground [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:cursor-grab [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:shadow-sm [&::-moz-range-thumb]:active:cursor-grabbing [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:cursor-grab [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:shadow-sm [&::-webkit-slider-thumb]:active:cursor-grabbing"
+            style={{
+              background: `linear-gradient(to right, var(--foreground) 0%, var(--foreground) ${progress}%, var(--border) ${progress}%, var(--border) 100%)`,
+            }}
+          />
+          <div
+            data-testid="overview-tier-ridges"
+            className="pointer-events-none absolute inset-0 z-20"
+            aria-hidden="true"
+          >
+            {OVERVIEW_TIERS.map((option, index) => {
+              const state =
+                index === selectedIndex
+                  ? 'selected'
+                  : index < selectedIndex
+                    ? 'filled'
+                    : 'unfilled';
+              return (
+                <span
+                  key={option}
+                  data-testid="overview-tier-ridge"
+                  data-tier-ridge={option}
+                  data-state={state}
+                  className={`absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2 rounded-full ${
+                    state === 'selected'
+                      ? 'opacity-0'
+                      : state === 'filled'
+                        ? 'bg-background/70'
+                        : 'bg-foreground/35'
+                  }`}
+                  style={{ left: `${(index / (OVERVIEW_TIERS.length - 1)) * 100}%` }}
+                />
+              );
+            })}
+          </div>
+        </div>
         <div className="relative mt-1 h-4 tabular-nums" aria-hidden="true">
           {OVERVIEW_TIERS.map((option, index) => (
             <span

--- a/packages/app/src/components/overview/overview-tier-slider.tsx
+++ b/packages/app/src/components/overview/overview-tier-slider.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { type ChangeEvent, useEffect, useRef, useState } from 'react';
+
+import { track } from '@/lib/analytics';
+import {
+  OVERVIEW_TIERS,
+  type OverviewComparisonMode,
+  type OverviewEngineScope,
+  type OverviewHardwareRowScope,
+  type OverviewModelScope,
+  type OverviewReferenceHardware,
+  type OverviewRowScope,
+  type OverviewTier,
+} from '@/lib/overview-data';
+import { overviewTierHref } from '@/lib/overview-links';
+
+import { useOverviewNavigation } from './overview-navigation';
+
+interface OverviewTierSliderProps {
+  tier: OverviewTier;
+  engineScope: OverviewEngineScope;
+  comparisonMode: OverviewComparisonMode;
+  referenceHardware: OverviewReferenceHardware;
+  modelScope: OverviewModelScope;
+  rowScope: OverviewRowScope;
+  hardwareRowScope: OverviewHardwareRowScope;
+  locale: 'en' | 'zh';
+  label: string;
+  unit: string;
+}
+
+function tierIndex(tier: OverviewTier): number {
+  return OVERVIEW_TIERS.indexOf(tier);
+}
+
+export function OverviewTierSlider({
+  tier,
+  engineScope,
+  comparisonMode,
+  referenceHardware,
+  modelScope,
+  rowScope,
+  hardwareRowScope,
+  locale,
+  label,
+  unit,
+}: OverviewTierSliderProps) {
+  const navigation = useOverviewNavigation();
+  const pointerActive = useRef(false);
+  const committedIndex = useRef(tierIndex(tier));
+  const [selectedIndex, setSelectedIndex] = useState(() => tierIndex(tier));
+
+  useEffect(() => {
+    const index = tierIndex(tier);
+    committedIndex.current = index;
+    setSelectedIndex(index);
+  }, [tier]);
+
+  const selectedTier = OVERVIEW_TIERS[selectedIndex];
+  const progress = (selectedIndex / (OVERVIEW_TIERS.length - 1)) * 100;
+
+  const commit = (index: number) => {
+    const nextTier = OVERVIEW_TIERS[index];
+    if (index === committedIndex.current) return;
+    committedIndex.current = index;
+
+    track('overview_selector_changed', {
+      control: 'tier',
+      value: String(nextTier),
+    });
+    navigation.push(
+      overviewTierHref(
+        locale,
+        nextTier,
+        engineScope,
+        comparisonMode,
+        referenceHardware,
+        modelScope,
+        rowScope,
+        hardwareRowScope,
+      ),
+      ['tier'],
+    );
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextIndex = Number(event.currentTarget.value);
+    setSelectedIndex(nextIndex);
+    if (!pointerActive.current) commit(nextIndex);
+  };
+
+  return (
+    <nav
+      data-testid="overview-tier-switcher"
+      aria-label={label}
+      className="flex min-w-0 items-center gap-3 text-xs"
+    >
+      <span className="shrink-0 text-muted-foreground">{label}</span>
+      <div className="w-[min(18rem,calc(100vw-8.5rem))] min-w-0 pt-1">
+        <input
+          data-testid="overview-tier-slider"
+          type="range"
+          min={0}
+          max={OVERVIEW_TIERS.length - 1}
+          step={1}
+          value={selectedIndex}
+          aria-label={label}
+          aria-valuetext={`${selectedTier} ${unit}`}
+          data-tier={selectedTier}
+          onChange={handleChange}
+          onPointerDown={() => {
+            pointerActive.current = true;
+          }}
+          onPointerUp={(event) => {
+            pointerActive.current = false;
+            commit(Number(event.currentTarget.value));
+          }}
+          onPointerCancel={() => {
+            pointerActive.current = false;
+            setSelectedIndex(tierIndex(tier));
+          }}
+          className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-border accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&::-moz-range-progress]:h-1.5 [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-foreground [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:cursor-grab [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:bg-foreground [&::-moz-range-thumb]:shadow-sm [&::-moz-range-thumb]:active:cursor-grabbing [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:cursor-grab [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-foreground [&::-webkit-slider-thumb]:shadow-sm [&::-webkit-slider-thumb]:active:cursor-grabbing"
+          style={{
+            background: `linear-gradient(to right, var(--foreground) 0%, var(--foreground) ${progress}%, var(--border) ${progress}%, var(--border) 100%)`,
+          }}
+        />
+        <div className="relative mt-1 h-4 tabular-nums" aria-hidden="true">
+          {OVERVIEW_TIERS.map((option, index) => (
+            <span
+              key={option}
+              data-tier-option={option}
+              data-selected={option === selectedTier ? 'true' : undefined}
+              className={`absolute -translate-x-1/2 ${
+                option === selectedTier ? 'font-semibold text-foreground' : 'text-muted-foreground'
+              }`}
+              style={{ left: `${(index / (OVERVIEW_TIERS.length - 1)) * 100}%` }}
+            >
+              {option}
+            </span>
+          ))}
+        </div>
+      </div>
+      <span className="shrink-0 text-muted-foreground">{unit}</span>
+    </nav>
+  );
+}

--- a/packages/app/src/components/overview/overview-tier-slider.tsx
+++ b/packages/app/src/components/overview/overview-tier-slider.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/lib/overview-data';
 import { overviewTierHref } from '@/lib/overview-links';
 
-import { useOverviewNavigation } from './overview-navigation';
+import { useOverviewNavigation, useOverviewNavigationError } from './overview-navigation';
 
 interface OverviewTierSliderProps {
   tier: OverviewTier;
@@ -47,6 +47,7 @@ export function OverviewTierSlider({
   unit,
 }: OverviewTierSliderProps) {
   const navigation = useOverviewNavigation();
+  const navigationError = useOverviewNavigationError();
   const pointerActive = useRef(false);
   const committedIndex = useRef(tierIndex(tier));
   const [selectedIndex, setSelectedIndex] = useState(() => tierIndex(tier));
@@ -54,8 +55,17 @@ export function OverviewTierSlider({
   useEffect(() => {
     const index = tierIndex(tier);
     committedIndex.current = index;
-    setSelectedIndex(index);
+    // A payload settling mid-drag must not yank the thumb away from the stop
+    // the pointer is choosing; the gesture's own pointerup/cancel settles it.
+    if (!pointerActive.current) setSelectedIndex(index);
   }, [tier]);
+
+  useEffect(() => {
+    // A failed load leaves the settled tier behind while the thumb and URL
+    // stay on the unsuccessful stop. Re-open the guard so activating that
+    // same stop again retries the navigation instead of returning early.
+    if (navigationError) committedIndex.current = tierIndex(tier);
+  }, [navigationError, tier]);
 
   const selectedTier = OVERVIEW_TIERS[selectedIndex];
   const progress = (selectedIndex / (OVERVIEW_TIERS.length - 1)) * 100;


### PR DESCRIPTION
## Summary

- Replaces the six SLO buttons on `/overview` with one discrete range slider for 30, 50, 75, 100, 150, and 200 tok/s/user.
- Preserves the existing cached JSON navigation, canonical URL query, pending filter state, and `overview_selector_changed` analytics.
- Adds a selected-track treatment and contrasting ridges at all six stops, plus accessible English/Chinese value text, while retaining native keyboard, pointer, and touch behavior.
- Updates the overview E2E suite to exercise slider selection, ridge states, cache reuse, filter preservation, responsive layout, and the `/zh/overview` sibling.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- Focused overview unit tests: 102 passed
- Fixture-backed `overview.cy.ts`: 28 passed
- Live browser verification at `/overview` and `/zh/overview` for SLO 50 and 100, including filled/selected/unfilled ridges; no console errors
- `bun run test:unit`: 3,705 app/constants/database tests passed; the unrelated MCP package then failed 25 tests during mocked server setup because `z.enum` was undefined

## 中文说明

- 将 `/overview` 原有的六个 SLO 按钮替换为离散滑块，可选择 30、50、75、100、150、200 tok/s/user 六档。
- 保留现有的 JSON 缓存导航、规范化 URL 查询参数、待提交筛选状态与 `overview_selector_changed` 埋点。
- 增加已选区间样式及六个档位的对比刻度脊线，并提供中英文无障碍数值说明，同时继续使用原生键盘、指针与触控交互。
- 更新 Overview E2E 测试，覆盖滑块选择、刻度状态、缓存复用、筛选条件保留、响应式布局及 `/zh/overview` 中文页面。

## 验证结果

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- Overview 相关单元测试：102 项通过
- 基于 fixture 的 `overview.cy.ts`：28 项通过
- 在 `/overview` 与 `/zh/overview` 上对 SLO 50、100 完成浏览器实测（包括已填充、当前选中与未填充刻度），控制台无报错
- `bun run test:unit`：App、Constants、Database 共 3,705 项测试通过；随后与本次改动无关的 MCP package 在 mock server 初始化阶段因 `z.enum` 为 undefined 导致 25 项失败

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the primary overview filter control and its navigation edge cases (drag, errors, history), though behavior is heavily covered by E2E and unit tests.
> 
> **Overview**
> Replaces the **six discrete SLO tier links** on `/overview` with a **single six-stop range slider** (30–200 tok/s/user). `OverviewTierSwitcher` now renders the new `OverviewTierSlider` instead of anchor-based options—tier changes go through the same client `navigation.push` + `overviewTierHref` flow, `overview_selector_changed` analytics, and `?tier=` URL semantics as before.
> 
> The slider adds **visual ridges**, a filled track, and **`aria-valuetext`** for accessibility; commits on **pointer release** (drag) or **keyboard change**, with guards so mid-drag API updates do not move the thumb and **failed loads can be retried** without extra history entries. Tier is no longer chosen via copyable per-tier links inside the SLO control (other switchers still use hrefs).
> 
> **Tests** add a Cypress `selectOverviewTier` helper (hydration-safe range input), retarget assertions to `data-tier` / ridge states, extend the failed-request retry case, and move some unit/focus scenarios to **engine scope** links where tier is no longer a link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410ad979ee60e1ac22c37edac45df6c969ca11d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->