### PR TITLE
feat(calculator): default-hide over-limit SKUs / 默认开启计算器超限 SKU 隐藏

### DIFF
--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -27,6 +27,7 @@ import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { UnofficialDomainNotice } from '@/components/ui/unofficial-domain-notice';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import { overlayRunColor } from '@/lib/overlay-run-style';
+import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MultiSelect } from '@/components/ui/multi-select';
 import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/segmented-toggle';
@@ -150,6 +151,9 @@ const STRINGS = {
     compMetricThroughput: 'throughput',
     compMetricCost: 'cost efficiency',
     compMetricPower: 'tok/s/MW',
+    hideSkuAboveConfigLimitLabel: 'Hide if target exceeds config range',
+    hideSkuAboveConfigLimitHelp:
+      'When enabled, SKUs whose measured interactivity range ends below the target are hidden instead of being projected from the max edge.',
     unofficialRun: 'UNOFFICIAL RUN',
     branch: 'Branch',
     viewRun: 'View workflow run',
@@ -199,6 +203,9 @@ const STRINGS = {
     compMetricThroughput: '吞吐量',
     compMetricCost: '成本效率',
     compMetricPower: 'tok/s/MW',
+    hideSkuAboveConfigLimitLabel: '隐藏超出配置上限的型号',
+    hideSkuAboveConfigLimitHelp:
+      '开启后，若目标交互性高于某个配置的实测上限，不再显示该 SKU，避免把结果投射到该配置最大边界。',
     unofficialRun: '非官方运行',
     branch: '分支',
     viewRun: '查看工作流运行',
@@ -294,6 +301,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   const [isLegendExpanded, setIsLegendExpanded] = useState(true);
   const [highContrast, setHighContrast] = useState(false);
   const [viewMode, setViewMode] = useState<CalculatorViewMode>('chart');
+  const [hideSkuAboveConfigLimit, setHideSkuAboveConfigLimit] = useState(true);
 
   const costTypeLabels: Record<CostType, string> = useMemo(
     () => ({ total: t.totalTokens, input: t.inputTokens, output: t.outputTokens }),
@@ -455,8 +463,16 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
 
   const results: InterpolatedResult[] = useMemo(() => {
     if (!hasData) return [];
-    return getResults(targetValue, mode, costProvider, visibleHwKeys);
-  }, [hasData, targetValue, mode, costProvider, getResults, visibleHwKeys]);
+    return getResults(targetValue, mode, costProvider, visibleHwKeys, hideSkuAboveConfigLimit);
+  }, [
+    hasData,
+    targetValue,
+    mode,
+    costProvider,
+    getResults,
+    visibleHwKeys,
+    hideSkuAboveConfigLimit,
+  ]);
 
   /** Branch + URL per run index, stamped onto overlay results for labels/tooltips. */
   const runInfoByIndex = useMemo(() => {
@@ -469,7 +485,14 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
 
   const overlayResults: InterpolatedResult[] = useMemo(() => {
     if (!hasOverlayData) return [];
-    return getOverlayResults(targetValue, mode, costProvider, visibleHwKeys, runInfoByIndex);
+    return getOverlayResults(
+      targetValue,
+      mode,
+      costProvider,
+      visibleHwKeys,
+      runInfoByIndex,
+      hideSkuAboveConfigLimit,
+    );
   }, [
     hasOverlayData,
     targetValue,
@@ -478,6 +501,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
     getOverlayResults,
     visibleHwKeys,
     runInfoByIndex,
+    hideSkuAboveConfigLimit,
   ]);
 
   /**
@@ -618,6 +642,11 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   const handleViewModeChange = useCallback((value: CalculatorViewMode) => {
     setViewMode(value);
     track('calculator_view_changed', { view: value });
+  }, []);
+
+  const handleHideSkuAboveLimitChange = useCallback((checked: boolean) => {
+    setHideSkuAboveConfigLimit(checked);
+    track('calculator_hide_over_limit_toggled', { enabled: checked });
   }, []);
 
   const handleResetGpus = useCallback(() => {
@@ -1004,6 +1033,19 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                       onBlur={handleInputBlur}
                       className="w-24 h-9"
                       min={0}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between gap-3 pt-1">
+                    <LabelWithTooltip
+                      htmlFor="calc-hide-over-limit"
+                      label={t.hideSkuAboveConfigLimitLabel}
+                      tooltip={t.hideSkuAboveConfigLimitHelp}
+                    />
+                    <Switch
+                      id="calc-hide-over-limit"
+                      checked={hideSkuAboveConfigLimit}
+                      onCheckedChange={handleHideSkuAboveLimitChange}
+                      className="shrink-0"
                     />
                   </div>
                 </div>

--- a/packages/app/src/components/calculator/interpolation.ts
+++ b/packages/app/src/components/calculator/interpolation.ts
@@ -265,12 +265,14 @@ export function interpolateForGPU(
 
   // Clamp target value to the data range to avoid null returns and prevent extrapolation
   const clampedTarget = Math.max(minInput, Math.min(maxInput, targetValue));
+  const clampedBelow = targetValue < minInput;
+  const clampedAbove = targetValue > maxInput;
   // Surfaced on the result so callers can tell the user this series was NOT
   // measured at the requested target — it is showing its nearest edge point.
   // Series can have different ranges (and an unofficial run can widen the
   // slider past every official point), so a clamped bar sitting next to an
   // unclamped one is a comparison the user needs to be able to see.
-  const clamped = targetValue < minInput || targetValue > maxInput;
+  const clamped = clampedBelow || clampedAbove;
 
   if (sorted.length === 1) {
     return {
@@ -288,6 +290,8 @@ export function interpolateForGPU(
       concurrency: sorted[0].concurrency,
       nearestPoints: [sorted[0]],
       clamped,
+      clampedAbove,
+      clampedBelow,
     };
   }
 
@@ -340,5 +344,7 @@ export function interpolateForGPU(
     concurrency,
     nearestPoints: [sorted[lowerIdx], sorted[upperIdx]],
     clamped,
+    clampedAbove,
+    clampedBelow,
   };
 }

--- a/packages/app/src/components/calculator/types.ts
+++ b/packages/app/src/components/calculator/types.ts
@@ -62,6 +62,16 @@ export interface InterpolatedResult {
    */
   clamped?: boolean;
   /**
+   * True when the target is above the frontier's max x (config cannot operate at
+   * this interactivity, so the bar is projected from the max edge).
+   */
+  clampedAbove?: boolean;
+  /**
+   * True when the target is below the frontier's min x (the bar is projected from
+   * the min edge).
+   */
+  clampedBelow?: boolean;
+  /**
    * True when this result was interpolated from an unofficial-run overlay
    * (`?unofficialrun=…`) rather than official DB data. Overlay results are
    * rendered in the run's palette color and never mixed into the official

--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -353,6 +353,7 @@ export function useThroughputData(
       mode: 'interactivity_to_throughput' | 'throughput_to_interactivity',
       costProvider: CostProvider,
       visibleHwKeys?: Set<string>,
+      hideSkuAboveConfigLimit = false,
     ): InterpolatedResult[] => {
       const results: InterpolatedResult[] = [];
 
@@ -363,7 +364,7 @@ export function useThroughputData(
         if (visibleHwKeys && !visibleHwKeys.has(hwKey)) continue;
 
         const result = interpolateForGPU(points, targetValue, mode, costProvider);
-        if (result && result.value > 0) {
+        if (result && result.value > 0 && !(hideSkuAboveConfigLimit && result.clampedAbove)) {
           results.push({
             ...result,
             hwKey, // always the base hwKey for color/config lookup
@@ -396,6 +397,7 @@ export function useThroughputData(
       costProvider: CostProvider,
       visibleHwKeys?: Set<string>,
       runInfoByIndex?: Record<number, { branch: string; url: string }>,
+      hideSkuAboveConfigLimit = false,
     ): InterpolatedResult[] => {
       const results: InterpolatedResult[] = [];
 
@@ -405,7 +407,7 @@ export function useThroughputData(
         if (visibleHwKeys && !visibleHwKeys.has(meta.hwKey)) continue;
 
         const result = interpolateForGPU(points, targetValue, mode, costProvider);
-        if (result && result.value > 0) {
+        if (result && result.value > 0 && !(hideSkuAboveConfigLimit && result.clampedAbove)) {
           results.push({
             ...result,
             hwKey: meta.hwKey,


### PR DESCRIPTION
## Summary
- Add a new calculator toggle to hide SKUs when target interactivity exceeds a SKU's measured config maximum.
- Make the toggle default to ON so this filtering is applied immediately.
- Propagate the behavior through both official results and unofficial-run overlay results by using directional clamp metadata from interpolation.
- Track interaction events for the new toggle.
- Keep bilingual UI strings in English/Chinese.

Checks run (on commit hooks):
- `oxfmt --write`
- `oxlint --fix`
- `tsc --noEmit`

## 中文说明
- 为 TCO 计算器新增“目标交互性超过配置上限时隐藏 SKU”开关。
- 将该开关默认设为开启，使筛选在默认状态即生效。
- 通过插值结果中的方向性 clamp 信息，将该规则同时应用到官方路径与 unofficial-run overlay 路径。
- 补充对应的交互埋点。
- 补齐英文/中文界面文案。

已运行校验（提交钩子）:
- `oxfmt --write`
- `oxlint --fix`
- `tsc --noEmit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized calculator display and filtering logic; default-on changes which bars appear but does not touch auth, APIs, or persisted data.
> 
> **Overview**
> Adds a **TCO calculator** switch (default **on**) to drop SKUs when the target interactivity is above that configuration’s measured frontier maximum, instead of showing values **projected from the max edge**.
> 
> Interpolation now exposes **`clampedAbove`** / **`clampedBelow`** on `InterpolatedResult`; `getResults` and `getOverlayResults` skip `clampedAbove` rows when the toggle is enabled. The control sits under the target slider with EN/ZH copy and **`calculator_hide_over_limit_toggled`** analytics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c05dc38ad2f2374f1166a56b9674ab1843eb433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->