### PR TITLE
Label singleton unofficial overlay series / 为单点 unofficial overlay series 显示标签

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -442,6 +442,78 @@ describe('ScatterGraph', () => {
       .should('contain.text', 'feature-branch');
   });
 
+  it('renders a line label for a singleton unofficial overlay series', () => {
+    const runUrl = 'https://github.com/x/y/actions/runs/31266452885';
+    const interactivityChartDef = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const overlayData = {
+      data: [
+        createMockInferenceData({
+          hwKey: 'b200_trt',
+          x: 24,
+          y: 310,
+          precision: Precision.FP4,
+          run_url: runUrl,
+        }),
+      ],
+      hardwareConfig: hwConfig,
+      label: 'tileRT',
+      runUrl,
+    };
+
+    mountWithProviders(
+      <div style={{ width: 800, height: 600 }}>
+        <ScatterGraph
+          chartId="test-scatter-singleton-overlay-label"
+          modelLabel="DeepSeek R1"
+          data={[]}
+          xLabel="Concurrency"
+          yLabel="Throughput / Chip (tok/s)"
+          chartDefinition={interactivityChartDef}
+          overlayData={overlayData}
+        />
+      </div>,
+      {
+        inference: {
+          hardwareConfig: hwConfig,
+          activeHwTypes: new Set(),
+          hwTypesWithData: new Set(),
+          selectedPrecisions: [Precision.FP4],
+          showLineLabels: true,
+        },
+        unofficial: {
+          activeOverlayHwTypes: new Set(['b200_trt']),
+          allOverlayHwTypes: new Set(['b200_trt']),
+          runIndexByUrl: { [runUrl]: 0, '31266452885': 0 },
+          unofficialRunInfos: [
+            {
+              id: 31266452885,
+              name: 'CI run',
+              branch: 'tileRT',
+              sha: 'abc123',
+              createdAt: '2026-08-09T00:00:00Z',
+              url: runUrl,
+              conclusion: 'success',
+              status: 'completed',
+              isNonMainBranch: true,
+            },
+          ],
+        },
+      },
+    );
+
+    cy.get('#test-scatter-singleton-overlay-label svg .unofficial-overlay-pt').should(
+      'have.length',
+      1,
+    );
+    cy.get('#test-scatter-singleton-overlay-label svg .line-label[data-line-key^="overlay-"]')
+      .should('have.length', 1)
+      .find('text')
+      .should('contain.text', 'tileRT');
+  });
+
   it('renders M3 mtp rooflines with the EAGLE label (official + overlay)', () => {
     const interactivityChartDef = createMockChartDefinition({
       chartType: 'interactivity',

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -512,6 +512,25 @@ describe('ScatterGraph', () => {
       .should('have.length', 1)
       .find('text')
       .should('contain.text', 'tileRT');
+
+    cy.get('#test-scatter-singleton-overlay-label svg').then(($svg) => {
+      const svg = $svg[0];
+      const bounds = svg.getBoundingClientRect();
+      svg.dispatchEvent(
+        new WheelEvent('wheel', {
+          deltaY: -240,
+          clientX: bounds.x + bounds.width / 2,
+          clientY: bounds.y + bounds.height / 2,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    cy.get(
+      '#test-scatter-singleton-overlay-label svg .line-label[data-line-key^="overlay-"]',
+    ).should('have.css', 'opacity', '1');
   });
 
   it('renders M3 mtp rooflines with the EAGLE label (official + overlay)', () => {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1863,10 +1863,7 @@ const ScatterGraph = React.memo(
                   : base;
               };
               const sortedOverlay = Object.entries(overlayRooflines)
-                .filter(
-                  ([, group]) =>
-                    ir.activeOverlayHwTypes.has(group.hwKey) && group.points.length >= 2,
-                )
+                .filter(([, group]) => ir.activeOverlayHwTypes.has(group.hwKey))
                 .toSorted(([, a], [, b]) => yScale(a.points[0].y) - yScale(b.points[0].y));
 
               for (const [ovKey, group] of sortedOverlay) {
@@ -1911,7 +1908,7 @@ const ScatterGraph = React.memo(
               // Endpoint labels for overlay rooflines too (one per (hw, runIndex)),
               // labeled with the run's branch name to mirror the overlay legend.
               for (const [ovKey, group] of Object.entries(overlayRooflines)) {
-                if (group.points.length < 2 || !ir.activeOverlayHwTypes.has(group.hwKey)) continue;
+                if (!ir.activeOverlayHwTypes.has(group.hwKey)) continue;
                 const info = unofficialRunInfos[group.runIndex];
                 const branchOrHw = info
                   ? `✕ ${info.branch || `run ${info.id}`}`
@@ -2209,7 +2206,7 @@ const ScatterGraph = React.memo(
               });
               // Overlay rooflines: per-(hw, runIndex) endpoint labels.
               for (const [ovKey, group] of Object.entries(overlayRooflines)) {
-                if (group.points.length < 2 || !ir.activeOverlayHwTypes.has(group.hwKey)) continue;
+                if (!ir.activeOverlayHwTypes.has(group.hwKey)) continue;
                 const pt = group.points.at(-1)!;
                 zoomLabels.push({
                   key: `overlay-${ovKey}`,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2116,10 +2116,7 @@ const ScatterGraph = React.memo(
                 ([, a], [, b]) => newYScale(a[0].y) - newYScale(b[0].y),
               );
               const overlayVisible = Object.entries(overlayRooflines)
-                .filter(
-                  ([, group]) =>
-                    ir.activeOverlayHwTypes.has(group.hwKey) && group.points.length >= 2,
-                )
+                .filter(([, group]) => ir.activeOverlayHwTypes.has(group.hwKey))
                 .toSorted(([, a], [, b]) => newYScale(a.points[0].y) - newYScale(b.points[0].y));
 
               const zoomResults = new Map<string, { x: number; y: number; vis: boolean }>();


### PR DESCRIPTION
## Summary

- Allow unofficial overlay line labels when a hardware series contains only one point.
- Keep singleton overlay labels positioned correctly during zoom and across endpoint-label chart modes.
- Add regression coverage for a singleton B200 tileRT overlay.
- Works for `?unofficialrun=` overlays and respects overlay hardware visibility.

## Root cause

Overlay labels required `group.points.length >= 2`, even though only the roofline path itself requires two points. A singleton B200 tileRT result therefore rendered its X marker without any line label.

## Validation

- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx` (17 passing)
- `bun run typecheck`
- Pre-commit lint and formatting checks

## 中文说明

- unofficial overlay 的硬件 series 仅包含一个数据点时，也会显示曲线标签。
- 在缩放及不同端点标签图表模式下，单点 overlay 标签均可保持正确定位。
- 新增 B200 tileRT 单点 overlay 的回归测试。
- 支持 `?unofficialrun=` overlay，并继续遵循 overlay 硬件可见性筛选。

## 根因

此前 overlay 标签要求 `group.points.length >= 2`，但实际上只有 roofline path 才需要至少两个点。因此，单点 B200 tileRT 结果虽然会显示 X 标记，却不会显示曲线标签。

## 验证

- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx`（17 项通过）
- `bun run typecheck`
- pre-commit lint 与格式检查

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart labeling-only change for unofficial overlays; behavior is covered by a new Cypress component test with no auth or data-pipeline impact.
> 
> **Overview**
> **Unofficial overlay curves with only one benchmark point** now get **line labels** (branch name, e.g. `tileRT`) on scatter charts, matching what multi-point overlay series already showed.
> 
> Previously, label placement required `group.points.length >= 2`, which fits drawn roofline paths but wrongly hid labels when only an **X marker** existed for a one-point unofficial run. **`ScatterGraph`** now gates overlay labels on **active overlay hardware visibility** only, in both **interactivity** (greedy placement) and **TTFT/E2EL** (endpoint labels), including **zoom** repositioning.
> 
> A **component test** mounts a singleton B200 tileRT overlay, asserts the overlay line label text, and checks the label stays visible after wheel zoom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76671eac706dc534c68274ba9a4c49378bdd9c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->