### PR TITLE
Label singleton ingested inference series / 为单点已摄取推理 series 显示标签

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -533,6 +533,68 @@ describe('ScatterGraph', () => {
     ).should('have.css', 'opacity', '1');
   });
 
+  it('renders a line label for a singleton ingested hardware series', () => {
+    const interactivityChartDef = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const data = [
+      createMockInferenceData({
+        hwKey: 'b200_tilert_mtp',
+        x: 340,
+        y: 150,
+        precision: Precision.FP8,
+      }),
+      createMockInferenceData({ hwKey: 'h100', x: 300, y: 190, precision: Precision.FP8 }),
+      createMockInferenceData({ hwKey: 'h100', x: 340, y: 150, precision: Precision.FP8 }),
+    ];
+    const baseInference = createMockInferenceContext();
+
+    function IngestedSingletonLabelHarness() {
+      const [showLineLabels, setShowLineLabels] = useState(true);
+      return (
+        <InferenceContext.Provider
+          value={{
+            ...baseInference,
+            hardwareConfig: hwConfig,
+            activeHwTypes: new Set(['b200_tilert_mtp', 'h100']),
+            hwTypesWithData: new Set(['b200_tilert_mtp', 'h100']),
+            selectedPrecisions: [Precision.FP8],
+            showLineLabels,
+            setShowLineLabels,
+          }}
+        >
+          <div style={{ width: 800, height: 600 }}>
+            <ScatterGraph
+              chartId="test-scatter-ingested-singleton-label"
+              modelLabel="GLM5/5.1 744B"
+              data={data}
+              xLabel="Interactivity (tok/s/user)"
+              yLabel="Token Throughput per GPU"
+              chartDefinition={interactivityChartDef}
+            />
+          </div>
+        </InferenceContext.Provider>
+      );
+    }
+
+    mountWithProviders(<IngestedSingletonLabelHarness />, { unofficial: {} });
+
+    cy.get('#test-scatter-ingested-singleton-label svg .unofficial-overlay-pt').should('not.exist');
+    cy.get('#test-scatter-ingested-singleton-label svg .line-label[data-hw-key="b200_tilert_mtp"]')
+      .should('have.css', 'opacity', '1')
+      .find('text')
+      .should('have.text', 'B200 (TileRT, MTP)');
+
+    cy.get('#scatter-line-labels').click();
+    cy.get('#test-scatter-ingested-singleton-label svg .line-label').should('not.exist');
+    cy.get('#scatter-line-labels').click();
+    cy.get('#test-scatter-ingested-singleton-label svg .line-label[data-hw-key="b200_tilert_mtp"]')
+      .should('have.css', 'opacity', '1')
+      .find('text')
+      .should('have.text', 'B200 (TileRT, MTP)');
+  });
+
   it('renders M3 mtp rooflines with the EAGLE label (official + overlay)', () => {
     const interactivityChartDef = createMockChartDefinition({
       chartType: 'interactivity',

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1757,6 +1757,7 @@ const ScatterGraph = React.memo(
                 label: string,
                 color: string,
                 pts: InferenceData[],
+                keepVisibleOnCollision = false,
               ) => {
                 const candidates = [
                   pts[Math.min(1, pts.length - 1)], // near start
@@ -1807,7 +1808,7 @@ const ScatterGraph = React.memo(
                   color,
                   x: xScale(pt.x),
                   y: yScale(pt.y),
-                  visible: false,
+                  visible: keepVisibleOnCollision,
                 });
               };
 
@@ -2143,7 +2144,11 @@ const ScatterGraph = React.memo(
                 const placed: { x: number; y: number }[] = [];
                 const collides = (cx: number, cy: number) =>
                   placed.some((p) => Math.abs(p.y - cy) < LABEL_H && Math.abs(p.x - cx) < LABEL_W);
-                const greedyPlace = (key: string, pts: InferenceData[]) => {
+                const greedyPlace = (
+                  key: string,
+                  pts: InferenceData[],
+                  keepVisibleOnCollision = false,
+                ) => {
                   const candidates = [
                     pts[Math.min(1, pts.length - 1)],
                     pts[Math.floor(pts.length / 2)],
@@ -2162,7 +2167,7 @@ const ScatterGraph = React.memo(
                   zoomResults.set(key, {
                     x: newXScale(pts[0].x),
                     y: newYScale(pts[0].y),
-                    vis: false,
+                    vis: keepVisibleOnCollision,
                   });
                 };
                 for (const [key, pts] of visibleEntries) greedyPlace(key, pts, pts.length === 1);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1513,7 +1513,6 @@ const ScatterGraph = React.memo(
           const activeGradientIds = new Set<string>();
 
           Object.entries(rooflines).forEach(([key, pts]) => {
-            if (pts.length <= 1) return;
             const hw = key.split('_').slice(0, -1).join('_');
             const precision = key.split('_').pop()!;
             const visible =
@@ -1526,7 +1525,6 @@ const ScatterGraph = React.memo(
             const singleDate = byDate.size === 1;
 
             for (const [date, datePoints] of byDate) {
-              if (datePoints.length <= 1) continue;
               const entryKey = singleDate ? key : `${key}__${date}`;
               let stroke = baseStroke;
 
@@ -1581,7 +1579,10 @@ const ScatterGraph = React.memo(
           // Data join for roofline paths
           rooflinesLayer
             .selectAll<SVGPathElement, Entry>('.roofline-path')
-            .data(entries, (d) => d.key)
+            .data(
+              entries.filter((entry) => entry.points.length > 1),
+              (d) => d.key,
+            )
             .join('path')
             .attr('class', (d) => `roofline-path roofline-${d.key}`)
             .attr('data-hw-key', (d) => d.hw)
@@ -1739,7 +1740,7 @@ const ScatterGraph = React.memo(
               // precision) so each precision curve keeps its own label.
               const bestByGroup = new Map<string, (typeof entries)[0]>();
               for (const e of entries) {
-                if (!e.visible || e.points.length < 2) continue;
+                if (!e.visible) continue;
                 const groupKey = multiPrecision ? e.key : e.hw;
                 const prev = bestByGroup.get(groupKey);
                 if (!prev || e.points.length > prev.points.length) bestByGroup.set(groupKey, e);
@@ -1824,6 +1825,7 @@ const ScatterGraph = React.memo(
                   lineLabelText(entry.hw, entry.precision, multiPrecision, modelLabel),
                   ir.getCssColor(ir.resolveColor(entry.hw)),
                   entry.points,
+                  entry.points.length === 1,
                 );
               }
 
@@ -1831,7 +1833,7 @@ const ScatterGraph = React.memo(
               // D3 data-join, keyed by series key, is clean).
               const labeledKeys = new Set(lineLabels.map((l) => l.key));
               for (const entry of entries) {
-                if (entry.points.length >= 2 && !labeledKeys.has(entry.key)) {
+                if (!labeledKeys.has(entry.key)) {
                   lineLabels.push({
                     key: entry.key,
                     hw: entry.hw,
@@ -1890,7 +1892,7 @@ const ScatterGraph = React.memo(
               // (hw, precision) when multiple precisions are shown).
               const seen = new Set<string>();
               for (const entry of entries) {
-                if (entry.points.length < 2 || !entry.visible) continue;
+                if (!entry.visible) continue;
                 const groupKey = multiPrecision ? entry.key : entry.hw;
                 if (seen.has(groupKey)) continue;
                 seen.add(groupKey);
@@ -2103,7 +2105,6 @@ const ScatterGraph = React.memo(
               // when multiple precisions are shown (mirrors the static render).
               const bestByGroup = new Map<string, [string, InferenceData[]]>();
               for (const [key, pts] of Object.entries(rooflines)) {
-                if (pts.length < 2) continue;
                 const hw = key.split('_').slice(0, -1).join('_');
                 const prec = key.split('_').pop()!;
                 if (!ir.effectiveActiveHwTypes.has(hw) || !ir.selectedPrecisions.includes(prec))
@@ -2164,7 +2165,7 @@ const ScatterGraph = React.memo(
                     vis: false,
                   });
                 };
-                for (const [key, pts] of visibleEntries) greedyPlace(key, pts);
+                for (const [key, pts] of visibleEntries) greedyPlace(key, pts, pts.length === 1);
                 for (const [ovKey, group] of overlayVisible)
                   greedyPlace(`overlay-${ovKey}`, group.points);
               }
@@ -2190,7 +2191,6 @@ const ScatterGraph = React.memo(
               const zoomLabels: ZoomLabel[] = [];
               const seen = new Set<string>();
               Object.entries(rooflines).forEach(([key, pts]) => {
-                if (pts.length < 2) return;
                 const hw = key.split('_').slice(0, -1).join('_');
                 const prec = key.split('_').pop()!;
                 if (!ir.effectiveActiveHwTypes.has(hw) || !ir.selectedPrecisions.includes(prec))

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1801,15 +1801,18 @@ const ScatterGraph = React.memo(
                 }
                 // All candidates collide — hide this label.
                 const pt = pts[0];
+                const px = xScale(pt.x);
+                const py = yScale(pt.y);
                 lineLabels.push({
                   key,
                   hw,
                   label,
                   color,
-                  x: xScale(pt.x),
-                  y: yScale(pt.y),
+                  x: px,
+                  y: py,
                   visible: keepVisibleOnCollision,
                 });
+                if (keepVisibleOnCollision) placed.push({ x: px, y: py });
               };
 
               // Sort entries by highest y-value first (top of chart) for priority
@@ -2164,11 +2167,14 @@ const ScatterGraph = React.memo(
                       return;
                     }
                   }
+                  const px = newXScale(pts[0].x);
+                  const py = newYScale(pts[0].y);
                   zoomResults.set(key, {
-                    x: newXScale(pts[0].x),
-                    y: newYScale(pts[0].y),
+                    x: px,
+                    y: py,
                     vis: keepVisibleOnCollision,
                   });
+                  if (keepVisibleOnCollision) placed.push({ x: px, y: py });
                 };
                 for (const [key, pts] of visibleEntries) greedyPlace(key, pts, pts.length === 1);
                 for (const [ovKey, group] of overlayVisible)


### PR DESCRIPTION
## Summary

- Allow official/ingested inference series containing one point to participate in line-label layout.
- Keep roofline drawing restricted to series with at least two points, avoiding degenerate paths.
- Preserve singleton labels through collision handling, endpoint modes, toggles, and zoom.
- Add regression coverage for the exact `B200 (TileRT, MTP)` ingested-series behavior.

## Root cause

Line labels were built from the same collection as drawable roofline paths. Because a roofline requires at least two points, a singleton ingested series rendered its point but was excluded from label layout.

## Validation

- `bun run typecheck`
- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx` (18 passing)
- Pre-commit lint and formatting checks

## 中文说明

- 允许仅包含一个数据点的官方或已摄取推理 series 参与曲线标签布局。
- roofline 仍仅为至少包含两个点的 series 绘制，避免生成退化路径。
- 单点标签在碰撞处理、端点模式、开关切换和缩放后均保持可见。
- 新增回归测试，覆盖 `B200 (TileRT, MTP)` 已摄取 series 的实际行为。

## 根因

此前曲线标签与可绘制 roofline path 共用同一数据集合。由于 roofline 至少需要两个点，单点已摄取 series 虽然会显示数据点，却被排除在标签布局之外。

## 验证

- `bun run typecheck`
- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx`（18 项通过）
- pre-commit lint 与格式检查

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to ScatterGraph label/roofline rendering and collision logic; no auth, data, or API changes.
> 
> **Overview**
> **ScatterGraph** now shows **line labels** for official/ingested series that only have one frontier point, while **roofline paths** are still drawn only when a series has at least two points.
> 
> Label layout no longer drops entries with `points.length < 2`. Roofline SVG paths are filtered at join time (`entry.points.length > 1`). For interactivity charts, singleton series pass `keepVisibleOnCollision` into greedy placement (and the zoom path mirrors this) so a lone point like **B200 (TileRT, MTP)** stays labeled even when it would collide with multi-point curves. TTFT/E2EL endpoint labeling uses the same relaxed visibility rules.
> 
> A Cypress component test asserts the singleton hardware label text, opacity, and line-label toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c2e040a5c6c1a380035d844323ba52c0ad4317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->