### PR TITLE
Align calculator endpoints with inference tables / 对齐计算器端点与推理表格

### DIFF
--- a/packages/app/src/components/calculator/interpolation.ts
+++ b/packages/app/src/components/calculator/interpolation.ts
@@ -323,11 +323,19 @@ export function interpolateForGPU(
   const outputTpPerMw = buildMetric((p) => p.outputTpPerMw);
   const concurrency = Math.round(buildMetric((p) => p.concurrency));
 
-  let lowerIdx = 0;
-  for (let i = 0; i < sorted.length - 1; i++) {
-    if (getInputValue(sorted[i]) <= clampedTarget) lowerIdx = i;
+  let nearestPoints: GPUDataPoint[];
+  if (clampedTarget <= minInput) {
+    nearestPoints = [sorted[0]];
+  } else if (clampedTarget >= maxInput) {
+    nearestPoints = [sorted.at(-1)!];
+  } else {
+    let lowerIdx = 0;
+    for (let i = 0; i < sorted.length - 1; i++) {
+      if (getInputValue(sorted[i]) <= clampedTarget) lowerIdx = i;
+    }
+    const upperIdx = lowerIdx + 1;
+    nearestPoints = [sorted[lowerIdx], sorted[upperIdx]];
   }
-  const upperIdx = Math.min(lowerIdx + 1, sorted.length - 1);
 
   return {
     hwKey,
@@ -342,7 +350,7 @@ export function interpolateForGPU(
     inputTpPerMw,
     outputTpPerMw,
     concurrency,
-    nearestPoints: [sorted[lowerIdx], sorted[upperIdx]],
+    nearestPoints,
     clamped,
     clampedAbove,
     clampedBelow,

--- a/packages/app/src/components/calculator/useThroughputData.test.ts
+++ b/packages/app/src/components/calculator/useThroughputData.test.ts
@@ -332,8 +332,8 @@ describe('interpolateForGPU', () => {
 
   it('clamps target to the pareto-front input range instead of returning null', () => {
     const points = [
-      makePoint({ interactivity: 20, throughput: 500 }),
-      makePoint({ interactivity: 40, throughput: 300 }),
+      makePoint({ interactivity: 20, throughput: 500, tp: 4 }),
+      makePoint({ interactivity: 40, throughput: 300, tp: 8 }),
     ];
     const below = interpolateForGPU(points, 10, 'interactivity_to_throughput', 'costh');
     const above = interpolateForGPU(points, 50, 'interactivity_to_throughput', 'costh');
@@ -341,6 +341,19 @@ describe('interpolateForGPU', () => {
     expect(above).not.toBeNull();
     expect(below!.value).toBe(500);
     expect(above!.value).toBe(300);
+    expect(below!.nearestPoints).toEqual([expect.objectContaining({ interactivity: 20, tp: 4 })]);
+    expect(above!.nearestPoints).toEqual([expect.objectContaining({ interactivity: 40, tp: 8 })]);
+  });
+
+  it('uses the exact endpoint as the sole metadata source', () => {
+    const points = [
+      makePoint({ interactivity: 20, throughput: 500, tp: 4 }),
+      makePoint({ interactivity: 40, throughput: 300, tp: 8 }),
+    ];
+
+    const result = interpolateForGPU(points, 40, 'interactivity_to_throughput', 'costh');
+
+    expect(result?.nearestPoints).toEqual([expect.objectContaining({ interactivity: 40, tp: 8 })]);
   });
 
   it('returns the single point value when target matches exactly', () => {


### PR DESCRIPTION
## Summary

- use the selected Pareto endpoint as the sole metadata source when calculator interpolation lands on or clamps to a measured-range boundary
- restore cost- and latency-clipped benchmark points in inference table mode while keeping chart display limits unchanged
- apply table restoration and visibility scoping to both official runs and `?unofficialrun=` overlays
- add regression coverage for endpoint topology and clipped official/overlay table rows

## Root cause

Two independent presentation paths obscured the same B200 configuration:

1. Calculator metrics were evaluated at the clamped TP8 endpoint, but `nearestPoints[0]` remained the preceding TP4 point, so the tooltip mislabeled TP8 values as TP4.
2. The inference chart correctly retained values above its `$5/M` visual cap in `clippedData`, but table mode rendered only `graph.data`. The TP8 `$7.016/M` row therefore disappeared from the table even though the calculator correctly consumed it from the API.

## Impact

Calculator tooltip topology now matches its numeric endpoint. Inference tables list every measured row, including values intentionally excluded from the plotted domain, so the TP8 `$7.016/M` row is visible alongside TP4 `$4.0/M`. Chart axes and boundary-continuation behavior are unchanged.

The shared paths work for both official runs and `?unofficialrun=` overlays.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `TZ=UTC bun run test:unit` (3,731 tests passed)
- `bun run --cwd packages/app test:e2e:quick:component` (25 tests passed)
- local integration smoke attempted; DB-backed inference cases cannot run because `DATABASE_READONLY_URL` is unavailable in this environment

## 中文说明

### 摘要

- 当计算器插值命中或限制到实测范围端点时，仅使用实际选中的 Pareto 端点作为元数据来源
- 推理表格恢复因成本或延迟超出图表显示上限而被裁剪的基准测试点，同时保持图表显示范围不变
- 官方运行和 `?unofficialrun=` overlay 均采用相同的表格恢复与可见范围逻辑
- 补充端点拓扑元数据以及官方/overlay 裁剪行的回归测试

### 根因

两个独立的展示路径共同掩盖了同一个 B200 配置：

1. 计算器按限制后的 TP8 端点计算数值，但 `nearestPoints[0]` 仍指向前一个 TP4 点，导致 tooltip 把 TP8 数值错误标为 TP4。
2. 推理图表会将超过 `$5/M` 显示上限的数值正确保留在 `clippedData` 中，但表格模式只渲染 `graph.data`。因此，尽管计算器从 API 正确读取了 TP8 `$7.016/M` 数据，该行仍从表格中消失。

### 影响

计算器 tooltip 的拓扑元数据现在与数值端点一致。推理表格会列出所有实测数据，包括为保持图表易读性而排除在绘图区之外的数值，因此 TP8 `$7.016/M` 会与 TP4 `$4.0/M` 同时显示。图表坐标轴和边界延伸线行为保持不变。

官方运行和 `?unofficialrun=` overlay 共用的两条路径均已覆盖。

### 验证

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `TZ=UTC bun run test:unit`（3,731 项测试通过）
- `bun run --cwd packages/app test:e2e:quick:component`（25 项测试通过）
- 已尝试本地 integration smoke；当前环境未提供 `DATABASE_READONLY_URL`，因此无法运行依赖数据库的推理用例
