### PR TITLE
Show clipped benchmark rows in inference tables / 在推理表格中显示裁剪数据行

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -938,6 +938,110 @@ describe('ScatterGraph', () => {
 });
 
 describe('ChartDisplay engine comparison guard', () => {
+  it('includes cost-clipped official and unofficial points in table mode', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      x: 'median_intvty',
+      x_label: 'Interactivity (tok/s/user)',
+      y_costhOutput: 'costhOutput.y',
+      y_costhOutput_label: 'Cost per Million Output Tokens ($)',
+      y_costhOutput_roofline: 'lower_right',
+      y_cost_limit: 5,
+    });
+    const officialVisible = createMockInferenceData({
+      hwKey: 'b200_sglang',
+      precision: Precision.FP4,
+      tp: 4,
+      median_intvty: 134.7,
+      costhOutput: { y: 4, roof: true },
+    });
+    const officialClipped = createMockInferenceData({
+      hwKey: 'b200_sglang',
+      precision: Precision.FP4,
+      tp: 8,
+      median_intvty: 142.1,
+      costhOutput: { y: 7.016, roof: true },
+    });
+    const runUrl = 'https://github.com/x/y/actions/runs/707';
+    const overlayVisible = createMockInferenceData({
+      hwKey: 'h100_vllm',
+      precision: Precision.FP4,
+      tp: 4,
+      median_intvty: 130,
+      costhOutput: { y: 4.5, roof: true },
+      run_url: runUrl,
+    });
+    const overlayClipped = createMockInferenceData({
+      hwKey: 'h100_vllm',
+      precision: Precision.FP4,
+      tp: 8,
+      median_intvty: 145,
+      costhOutput: { y: 7.5, roof: true },
+      run_url: runUrl,
+    });
+    const runInfo = {
+      id: 707,
+      name: 'clipped-table-overlay',
+      branch: 'clipped-table-overlay',
+      sha: 'abc707',
+      createdAt: '2026-08-09T00:00:00Z',
+      url: runUrl,
+      conclusion: 'success',
+      status: 'completed',
+      isNonMainBranch: true,
+    };
+
+    mountWithProviders(<ChartDisplay />, {
+      inference: {
+        graphs: [
+          {
+            model: Model.DeepSeek_R1,
+            sequence: Sequence.EightK_OneK,
+            chartDefinition,
+            data: [officialVisible],
+            clippedData: [{ point: officialClipped, reasons: ['cost'] }],
+          },
+        ],
+        selectedYAxisMetric: 'y_costhOutput',
+        selectedXAxisMode: 'interactivity',
+        activeHwTypes: new Set(['b200_sglang']),
+        hwTypesWithData: new Set(['b200_sglang']),
+      },
+      globalFilters: {
+        selectedModel: Model.DeepSeek_R1,
+        selectedSequence: Sequence.EightK_OneK,
+        effectiveSequence: Sequence.EightK_OneK,
+      },
+      unofficial: {
+        isUnofficialRun: true,
+        unofficialRunInfo: runInfo,
+        unofficialRunInfos: [runInfo],
+        runIndexByUrl: { [runUrl]: 0, '707': 0 },
+        getOverlayData: () => ({
+          data: [overlayVisible, overlayClipped],
+          hardwareConfig: hwConfig,
+        }),
+        activeOverlayHwTypes: new Set(['h100_vllm']),
+        allOverlayHwTypes: new Set(['h100_vllm']),
+      },
+    });
+
+    cy.get('[data-testid="inference-table-view-btn"]').click();
+    cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);
+    cy.get('[data-testid="inference-results-table"] tbody')
+      .contains('tr', '7.0')
+      .should('contain.text', 'SGLang')
+      .find('td')
+      .eq(2)
+      .should('have.text', '8');
+    cy.get('[data-testid="inference-results-table"] tbody')
+      .contains('tr', '7.5')
+      .should('contain.text', 'vLLM')
+      .find('td')
+      .eq(2)
+      .should('have.text', '8');
+  });
+
   it('keeps official table rows synchronized with legend state after a scope change', () => {
     const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
     const baseInference = createMockInferenceContext();

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -415,7 +415,11 @@ export default function ChartDisplay() {
   const overlayScope = useMemo(() => {
     const eligibleKeys = new Set<string>();
     for (const overlay of [overlayDataByChartType.e2e, overlayDataByChartType.interactivity]) {
-      for (const point of overlay?.data ?? []) {
+      const points = [
+        ...(overlay?.data ?? []),
+        ...(overlay?.clippedData ?? []).map((entry) => entry.point),
+      ];
+      for (const point of points) {
         const key = String(point.hwKey);
         if (
           selectedPrecisions.includes(point.precision) &&
@@ -430,7 +434,8 @@ export default function ChartDisplay() {
   const officialScope = useMemo(() => {
     const eligibleKeys = new Set<string>();
     for (const graph of graphs) {
-      for (const point of graph.data) {
+      const points = [...graph.data, ...(graph.clippedData ?? []).map((entry) => entry.point)];
+      for (const point of points) {
         if (
           selectedPrecisions.includes(point.precision) &&
           matchesQuickFilters(point, quickFilters)
@@ -538,7 +543,9 @@ export default function ChartDisplay() {
     if (graphs.length > 0) return graphs;
     const hasOverlay =
       (overlayDataByChartType.e2e?.data.length ?? 0) > 0 ||
-      (overlayDataByChartType.interactivity?.data.length ?? 0) > 0;
+      (overlayDataByChartType.e2e?.clippedData?.length ?? 0) > 0 ||
+      (overlayDataByChartType.interactivity?.data.length ?? 0) > 0 ||
+      (overlayDataByChartType.interactivity?.clippedData?.length ?? 0) > 0;
     if (!hasOverlay) return graphs;
     return (chartDefinitions as ChartDefinition[]).map((chartDefinition) => ({
       model: selectedModel,
@@ -835,9 +842,26 @@ export default function ChartDisplay() {
                           graph.chartDefinition.chartType,
                           overlayDataByChartType,
                         );
+                        // Display limits keep outliers off the plotted domain but
+                        // must not silently remove measured rows from the table.
+                        // Restore both official and unofficial clipped points before
+                        // applying the shared precision, quick-filter, and legend gates.
+                        const tableOfficialData = [
+                          ...graph.data,
+                          ...(graph.clippedData ?? []).map((entry) => entry.point),
+                        ];
+                        const tableOverlay = overlay
+                          ? {
+                              ...overlay,
+                              data: [
+                                ...overlay.data,
+                                ...(overlay.clippedData ?? []).map((entry) => entry.point),
+                              ],
+                            }
+                          : overlay;
                         const { officialRows, overlayRows } = visibleComparisonRows(
-                          graph.data,
-                          overlay,
+                          tableOfficialData,
+                          tableOverlay,
                         );
                         return (
                           <>


### PR DESCRIPTION
## Summary

- restore cost- and latency-clipped benchmark points in inference table mode while keeping chart display limits unchanged
- include clipped points in official and `?unofficialrun=` overlay visibility scopes
- add component regression coverage using the B200 TP4 `$4.0/M` and TP8 `$7.016/M` case plus an unofficial overlay

## Root cause

The inference chart correctly retains values above its `$5/M` visual cap in `clippedData` so chart mode can draw boundary continuations. Table mode rendered only `graph.data`, however, silently omitting the B200 TP8 `$7.016/M` row even though the calculator correctly consumed it from the API.

## Impact

Inference tables now list every measured row, including values intentionally excluded from the plotted domain. The TP8 `$7.016/M` row appears alongside TP4 `$4.0/M`; chart axes and boundary-continuation behavior remain unchanged.

Works for both official runs and `?unofficialrun=` overlays.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `TZ=UTC bun run test:unit` (3,731 tests passed)
- `bun run --cwd packages/app test:e2e:quick:component` (25 tests passed)
- local integration smoke attempted; DB-backed inference cases cannot run because `DATABASE_READONLY_URL` is unavailable in this environment

## 中文说明

### 摘要

- 推理表格恢复因成本或延迟超出图表显示上限而被裁剪的基准测试点，同时保持图表显示范围不变
- 官方运行和 `?unofficialrun=` overlay 的可见范围均纳入裁剪点
- 使用 B200 TP4 `$4.0/M`、TP8 `$7.016/M` 以及 unofficial overlay 场景补充组件回归测试

### 根因

推理图表会将超过 `$5/M` 显示上限的数值正确保留在 `clippedData` 中，以便图表模式绘制边界延伸线。但表格模式只渲染 `graph.data`，导致 B200 TP8 `$7.016/M` 行被静默遗漏，而计算器仍会从 API 正确读取该数据。

### 影响

推理表格现在会列出所有实测数据，包括为保持图表易读性而排除在绘图区之外的数值。TP8 `$7.016/M` 会与 TP4 `$4.0/M` 同时显示；图表坐标轴和边界延伸线行为保持不变。

官方运行和 `?unofficialrun=` overlay 均已覆盖。

### 验证

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `TZ=UTC bun run test:unit`（3,731 项测试通过）
- `bun run --cwd packages/app test:e2e:quick:component`（25 项测试通过）
- 已尝试本地 integration smoke；当前环境未提供 `DATABASE_READONLY_URL`，因此无法运行依赖数据库的推理用例

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only inference display logic with targeted component regression coverage; chart rendering paths are unchanged.
> 
> **Overview**
> **Inference table mode** now merges `clippedData` into the row set for official graphs and unofficial overlays before legend and filter gates, so cost- or latency-capped points (e.g. B200 TP8 above a `$5/M` chart cap) appear in the table while **chart** plotting and display limits stay the same.
> 
> **Scope and stub charts** also count clipped overlay and official points when building `officialScope` / `overlayScope` and when deciding whether overlay-only data should synthesize empty stub graphs.
> 
> A **Cypress** case in `scatter-graph.cy.tsx` asserts four table rows for clipped official and overlay cost points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2fcc9716658be2f6d654358c6784ba89492dc38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->