### PR TITLE
chore(db): purge outdated DSV4 GB300 AgentX attempt

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -88,6 +88,7 @@ export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new
   [28911223583, new Set([3])], // 2026-07-09 | DeepSeek-V4 FP4 MI355X vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [28955639528, new Set([3])], // 2026-07-09 | DeepSeek-V4 FP4 B200/B300 SGLang agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29376853679, new Set([1])], // 2026-07-20 | DeepSeek-V4 FP4 MI355X Mori-SGLang disaggregated agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29385297092, new Set([4])], // 2026-07-16 | DeepSeek-V4 FP4 GB300 Dynamo-SGLang MTP agentic | Reason: Outdated AgentX harness
   [29413860950, new Set([3])], // 2026-07-16 | DeepSeek-V4 FP4 MI355X SGLang HiCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29445892486, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B200 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29486959583, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B300 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness


### PR DESCRIPTION
## Summary

- Add run `29385297092`, attempt `4`, to `PURGED_RUN_ATTEMPTS`.
- Record the audit reason as `Outdated AgentX harness`.
- Target only the requested attempt and prevent it from being re-ingested.

Source: [InferenceX Actions run 29385297092, attempt 4](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/29385297092/attempts/4).

## Verification

- GitHub Actions logs confirm the attempt contains DeepSeek-V4 FP4 GB300 Dynamo-SGLang MTP AgentX results.
- A read-only production query found exactly one ingested workflow attempt with 9 benchmark rows and no ingested sibling attempts.
- `bun test packages/db/src/etl/run-overrides.test.ts` — 12 passed.
- `bun run lint` passed.
- `bun run fmt` passed.
- `bun run typecheck` passed.

## Impact

After merge, the existing `Apply Run Overrides` workflow will delete only attempt 4, verify the production database, invalidate API caches, and warm the updated benchmark endpoints. The override will also block future re-ingestion of this attempt.

The previous cleanup rationale included a non-MTP clause. This target is explicitly MTP, so the audit entry uses only the applicable reason: the outdated AgentX harness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped ETL override using an established purge map; production impact is limited to deleting/blocking one workflow attempt’s benchmark data.
> 
> **Overview**
> Adds **run `29385297092`, attempt `4`** to `PURGED_RUN_ATTEMPTS` in `run-overrides.ts`, with audit reason **outdated AgentX harness** (DeepSeek-V4 FP4 GB300 Dynamo-SGLang MTP agentic).
> 
> Only that attempt is affected—other attempts on the same workflow stay eligible. After merge, the existing **Apply Run Overrides** flow should remove any ingested rows for attempt 4, verify prod, refresh caches, and **block future re-ingestion** of the same attempt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff3c4a9365761ce6aa26730b724d30f364a3eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->