### PR TITLE
feat(inference): guard only vLLM vs SGLang, per hardware SKU / 引擎互斥限定为 vLLM 与 SGLang，并按硬件 SKU 划分

### DIFF
--- a/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
+++ b/packages/app/src/components/inference/utils/comparison-exclusion.test.ts
@@ -179,25 +179,48 @@ describe('comparisonExclusion', () => {
     expect(exclusion.scopesOf(key)).toEqual([]);
   });
 
-  it('keeps ATOM and TRTLLM guarded on the Agentic chart', () => {
-    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false)!;
+  // ATOM and TRTLLM sit outside the guarded families on both scenarios, so they
+  // do not participate at all and stay comparable with every other engine.
+  it.each([Sequence.AgenticTraces, Sequence.EightK_OneK])(
+    'leaves ATOM and TRTLLM unguarded on %s',
+    (sequence) => {
+      const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, sequence, false)!;
 
-    expect(exclusion.groupOf('mi355x_atom')).toBe('sglang');
-    expect(exclusion.groupOf('mi355x_atom_mtp')).toBe('sglang');
-    expect(exclusion.groupOf('b200_trt')).toBe('trt');
-    expect(exclusion.groupOf('b200_trt_mtp')).toBe('trt');
-  });
+      expect(exclusion.groupOf('mi355x_atom')).toBeNull();
+      expect(exclusion.groupOf('mi355x_atom_mtp')).toBeNull();
+      expect(exclusion.groupOf('b200_trt')).toBeNull();
+      expect(exclusion.groupOf('b200_trt_mtp')).toBeNull();
+    },
+  );
 
-  it('guards only the literal vLLM and SGLang families on the 8K/1K chart', () => {
-    const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK, false)!;
+  it.each([Sequence.AgenticTraces, Sequence.EightK_OneK])(
+    'guards only the literal vLLM and SGLang families on %s',
+    (sequence) => {
+      const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, sequence, false)!;
 
-    expect(exclusion.groupOf('b200_vllm')).toBe('vllm');
-    expect(exclusion.groupOf('gb300_dynamo-vllm')).toBe('vllm');
-    expect(exclusion.groupOf('gb200_llmd-vllm')).toBe('vllm');
-    expect(exclusion.groupOf('b200_sglang')).toBe('sglang');
-    expect(exclusion.groupOf('gb300_dynamo-sglang')).toBe('sglang');
-    expect(exclusion.groupOf('mi355x_mori-sglang')).toBe('sglang');
-  });
+      expect(exclusion.groupOf('b200_vllm')).toBe('vllm');
+      expect(exclusion.groupOf('gb300_dynamo-vllm')).toBe('vllm');
+      expect(exclusion.groupOf('gb200_llmd-vllm')).toBe('vllm');
+      expect(exclusion.groupOf('b200_sglang')).toBe('sglang');
+      expect(exclusion.groupOf('gb300_dynamo-sglang')).toBe('sglang');
+      expect(exclusion.groupOf('mi355x_mori-sglang')).toBe('sglang');
+    },
+  );
+
+  // The guard exists to stop two engines being read off one SKU's curve, so
+  // every participating key is scoped to its own hardware and never globally.
+  it.each([Sequence.AgenticTraces, Sequence.EightK_OneK, Sequence.OneK_OneK])(
+    'scopes both standard-token and MTP guards to a single SKU on %s',
+    (sequence) => {
+      const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, sequence, false)!;
+
+      for (const key of ['b200_vllm', 'b200_vllm_mtp', 'b200_sglang', 'b200_sglang_mtp']) {
+        const scopes = exclusion.scopesOf(key);
+        if (scopes.length === 0) continue; // key not guarded on this scenario
+        expect(scopes).toEqual(['b200']);
+      }
+    },
+  );
 
   it('keeps the engine-family guard for official Agentic Traces charts', () => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces, false);
@@ -259,10 +282,10 @@ describe('comparisonExclusion', () => {
       expected: 'fallthrough',
     },
     {
-      name: 'blocks Agentic cross-engine MTP globally',
+      name: 'blocks Agentic cross-engine MTP on the same SKU',
       sequence: Sequence.AgenticTraces,
       active: 'b200_sglang_mtp',
-      candidate: 'mi355x_vllm_mtp',
+      candidate: 'b200_vllm_mtp',
       expected: 'block',
     },
     {
@@ -343,10 +366,17 @@ describe('comparisonExclusion', () => {
       expected: 'fallthrough',
     },
     {
-      name: 'still blocks 8K/1K cross-engine MTP globally',
+      name: 'allows 8K/1K cross-engine MTP on different SKUs',
       sequence: Sequence.EightK_OneK,
       active: 'b200_sglang_mtp',
       candidate: 'mi355x_vllm_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'still blocks 8K/1K cross-engine MTP on the same SKU',
+      sequence: Sequence.EightK_OneK,
+      active: 'b200_sglang_mtp',
+      candidate: 'b200_vllm_mtp',
       expected: 'block',
     },
     {
@@ -377,19 +407,63 @@ describe('comparisonExclusion', () => {
       candidate: 'b200_trt',
       expected: 'fallthrough',
     },
+    // Agentic now guards the same two families as 8K/1K, so ATOM and TRTLLM are
+    // comparable with everything there too.
     {
-      name: 'keeps the Agentic ATOM MTP guard untouched',
+      name: 'allows Agentic ATOM MTP next to vLLM MTP on the same SKU',
       sequence: Sequence.AgenticTraces,
       active: 'mi355x_atom_mtp',
       candidate: 'mi355x_vllm_mtp',
-      expected: 'block',
+      expected: 'fallthrough',
     },
     {
-      name: 'keeps the Agentic TRTLLM guard untouched',
+      name: 'allows Agentic TRTLLM next to vLLM on the same SKU',
       sequence: Sequence.AgenticTraces,
       active: 'b200_trt',
       candidate: 'b200_vllm',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows Agentic TRTLLM next to SGLang on the same SKU',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_sglang',
+      candidate: 'b200_trt',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows Agentic TRTLLM MTP next to ATOM MTP on the same SKU',
+      sequence: Sequence.AgenticTraces,
+      active: 'mi355x_atom_mtp',
+      candidate: 'mi355x_trt_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'still blocks Agentic vLLM against SGLang on the same SKU',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_sglang',
+      candidate: 'b200_vllm',
       expected: 'block',
+    },
+    {
+      name: 'still blocks Agentic cross-engine MTP on the same SKU',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_sglang_mtp',
+      candidate: 'b200_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'allows Agentic cross-engine MTP on different SKUs',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_sglang_mtp',
+      candidate: 'mi355x_vllm_mtp',
+      expected: 'fallthrough',
+    },
+    {
+      name: 'allows Agentic vLLM and SGLang on different SKUs',
+      sequence: Sequence.AgenticTraces,
+      active: 'b200_sglang',
+      candidate: 'mi355x_vllm',
+      expected: 'fallthrough',
     },
     {
       name: 'allows 8K/1K STP engines on different SKUs',
@@ -434,11 +508,18 @@ describe('comparisonExclusion', () => {
       expected: 'fallthrough',
     },
     {
-      name: 'blocks fixed-sequence cross-engine MTP globally',
+      name: 'blocks fixed-sequence cross-engine MTP on the same SKU',
+      sequence: Sequence.OneK_OneK,
+      active: 'b200_sglang_mtp',
+      candidate: 'b200_vllm_mtp',
+      expected: 'block',
+    },
+    {
+      name: 'allows fixed-sequence cross-engine MTP on different SKUs',
       sequence: Sequence.OneK_OneK,
       active: 'b200_sglang_mtp',
       candidate: 'mi355x_vllm_mtp',
-      expected: 'block',
+      expected: 'fallthrough',
     },
   ] as const)('$name', ({ sequence, active, candidate, expected }) => {
     const exclusion = comparisonExclusion(Model.DeepSeek_V4_Pro, sequence, false)!;

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -236,10 +236,11 @@ describe('comparison exclusions', () => {
     expect(getSequenceExclusion(Sequence.OneK_EightK)).toEqual([]);
   });
 
-  it('guards only vLLM and SGLang on 8K/1K, every family on Agentic', () => {
+  it('guards only vLLM and SGLang on both 8K/1K and Agentic', () => {
     expect(getSequenceExclusionFamilies(Sequence.EightK_OneK)).toEqual(['vllm', 'sglang']);
-    // Agentic keeps every engine family exclusive while the benchmark is new.
-    expect(getSequenceExclusionFamilies(Sequence.AgenticTraces)).toBeNull();
+    expect(getSequenceExclusionFamilies(Sequence.AgenticTraces)).toEqual(['vllm', 'sglang']);
+    // Deprecated fixed sequences carry no scenario rule of their own; only the
+    // model-level MTP spec applies there.
     expect(getSequenceExclusionFamilies(Sequence.OneK_OneK)).toBeNull();
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -59,12 +59,18 @@ interface ModelConfig {
  * be active together because their acceptance-rate forcing implementations
  * differ. ATOM and SGLang share the upstream ROCm MTP path, so they form one
  * comparability group; vLLM is its own group.
+ *
+ * Scoped to `hardware` for the same reason the STP rule below is: the guard
+ * exists to stop two engines being read off one SKU's curve, not to stop a
+ * chart holding two SKUs. B200 vLLM MTP next to B300 SGLang MTP compares
+ * hardware, which is the point of the chart.
  */
 const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
   {
     suffix: '_mtp',
     stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
     groupAliases: { atom: 'sglang' },
+    scope: 'hardware',
   },
 ];
 
@@ -72,10 +78,6 @@ const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
  * STP exclusion: unsuffixed standard-token configs for the same hardware SKU
  * can't mix engine families, because each engine tunes its serving path
  * differently. Different hardware may use different engines on one graph.
- *
- * Which families this covers is per-scenario: AgentX applies it to every engine
- * family while the agentic benchmark is new, whereas 8K/1K narrows it (and its
- * MTP sibling) to vLLM and SGLang via `exclusionFamilies` below.
  */
 const STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
   {
@@ -87,16 +89,27 @@ const STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
 ];
 
 /**
- * Engine families guarded on the 8K/1K chart. vLLM and SGLang tune their runs
- * against engine-specific serving paths, so their numbers aren't directly
- * comparable on one graph — for standard-token and MTP configs alike.
+ * Engine families guarded on the 8K/1K and Agentic Traces charts. vLLM and
+ * SGLang tune their runs against engine-specific serving paths, so their
+ * numbers aren't directly comparable on one SKU — for standard-token and MTP
+ * configs alike. The resulting matrix, per SKU:
  *
- * Every other engine is comparable with everything here: TRTLLM, ATOM, and
- * Mooncake ATOMesh stay freely selectable next to either engine and next to
- * each other. Because the list is matched before `groupAliases`, ATOM escapes
- * even though the MTP rule folds it into SGLang's comparability group.
+ *   vLLM ↔ SGLang           blocked  (standard-token and MTP)
+ *   TRTLLM ↔ vLLM           allowed
+ *   TRTLLM ↔ SGLang         allowed
+ *   TRTLLM ↔ ATOM           allowed
+ *   ATOM ↔ vLLM or SGLang   allowed
+ *
+ * Every engine outside this list is comparable with everything: TRTLLM, ATOM,
+ * and Mooncake ATOMesh stay freely selectable next to either guarded engine and
+ * next to each other. Because the list is matched before `groupAliases`, ATOM
+ * escapes even though the MTP rule folds it into SGLang's comparability group.
+ *
+ * Both scenarios share the list. AgentX guarded every engine family while the
+ * agentic benchmark was new; that blocked TRTLLM against vLLM, SGLang, and ATOM
+ * on the same SKU, which the pairs above now allow.
  */
-const EIGHTK_ONEK_EXCLUSION_FAMILIES = ['vllm', 'sglang'] as const;
+const GUARDED_ENGINE_FAMILIES = ['vllm', 'sglang'] as const;
 
 // Total parameter counts appended to each label so users can compare model
 // scale at a glance in the dropdown. For Llama and gpt-oss the count is
@@ -302,7 +315,7 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     exclusion: STP_ENGINE_EXCLUSION,
     exclusionPolicy: 'keep-sticky',
     defaultExclusionGroup: 'vllm',
-    exclusionFamilies: EIGHTK_ONEK_EXCLUSION_FAMILIES,
+    exclusionFamilies: GUARDED_ENGINE_FAMILIES,
   },
   [Sequence.AgenticTraces]: {
     label: 'Agentic Traces',
@@ -313,6 +326,7 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     exclusion: STP_ENGINE_EXCLUSION,
     exclusionPolicy: 'keep-sticky',
     defaultExclusionGroup: 'vllm',
+    exclusionFamilies: GUARDED_ENGINE_FAMILIES,
   },
 };
 


### PR DESCRIPTION
## Summary

Applies one engine-comparability matrix to **both Agentic Traces and 8K/1K**, scoped to a **single hardware SKU**.

| Pair (same SKU) | Standard-token | MTP |
|---|---|---|
| vLLM ↔ SGLang | blocked | blocked |
| TRTLLM ↔ vLLM | allowed | **allowed** (was blocked on Agentic) |
| TRTLLM ↔ SGLang | allowed | **allowed** (was blocked on Agentic) |
| TRTLLM ↔ ATOM | allowed | **allowed** (was blocked on Agentic) |
| ATOM ↔ vLLM or SGLang | allowed | allowed |

Per hardware means exactly what it says: **B200 vLLM + B200 SGLang is blocked; B200 vLLM + B300 anything is allowed.**

## The two changes that produce it

**1. Agentic Traces gains the `exclusionFamilies` allowlist that 8K/1K already had** (`data-mappings.ts`). Agentic guarded *every* engine family while the agentic benchmark was new, so TRTLLM and ATOM were blocked against vLLM and SGLang there. It now shares the same `['vllm', 'sglang']` list. Because that list is matched **before** `groupAliases`, ATOM escapes the rule that otherwise folds it into SGLang's comparability group — which is what makes the ATOM row allowed without deleting the alias.

**2. The model-level MTP spec becomes `scope: 'hardware'`**, matching the standard-token spec. It was global, so selecting B200 SGLang MTP blocked MI355X vLLM MTP — a pure hardware comparison, which is the point of the chart. Same-SKU cross-engine MTP is still blocked.

The guard exists to stop two engines being read off one SKU's curve, not to stop a chart holding two SKUs, so hardware scope is now the rule everywhere. `EIGHTK_ONEK_EXCLUSION_FAMILIES` is renamed `GUARDED_ENGINE_FAMILIES` since both scenarios share it, and the matrix above is recorded in the comment above the constant.

No changes to `exclusion.ts` — the engine already supported both `participatingFamilies` and `scope: 'hardware'`. This is a data change to the rule set, which is how that module is designed to be extended.

**Scope note.** The MTP spec is attached to `Model.DeepSeek_V4_Pro`, the only model that declares one, so the MTP column applies there; other models have no MTP guard to begin with. The hardware-scope fix also reaches the deprecated 1K/1K and 1K/8K sequences, since the model rule applies on every scenario — same direction of change, and they carry no scenario rule of their own.

## Tests

`comparison-exclusion.test.ts` — the table-driven toggle cases now assert the full matrix on **both** scenarios, and every previously-global MTP case is split into a same-SKU case (still `block`) and a different-SKU case (now `fallthrough`):

- Agentic: TRTLLM ↔ vLLM, TRTLLM ↔ SGLang, ATOM ↔ vLLM MTP, TRTLLM ↔ ATOM MTP all fall through; vLLM ↔ SGLang still blocks on the same SKU, allowed across SKUs
- 8K/1K and 1K/1K: cross-engine MTP blocks on the same SKU, falls through across SKUs
- The two `groupOf` tests became `it.each` over both scenarios: ATOM/TRTLLM resolve to `null` (unguarded), vLLM/SGLang keep their groups through every `dynamo-`/`mori-`/`llmd-` prefix
- New: asserts `scopesOf` is exactly `['b200']` — never the global scope — for standard-token and MTP keys alike, across all three scenarios

`data-mappings.test.ts` — updated the allowlist assertion to cover both scenarios.

`bun run test:unit` — **3,744 passed**, 0 failed. `typecheck`, `lint`, `fmt` clean.

Overlay note: `comparisonExclusion` returns `null` for unofficial runs, so `?unofficialrun=` previews deliberately impose no engine guard. That behavior is unchanged and still covered by its existing test.

## 中文说明

为**「智能体轨迹」（Agentic Traces）与 8K/1K 两个场景**应用同一套引擎可比性矩阵，并限定在**单一硬件 SKU** 范围内。

| 配对（同一 SKU） | 标准 token | MTP |
|---|---|---|
| vLLM ↔ SGLang | 阻止 | 阻止 |
| TRTLLM ↔ vLLM | 允许 | **允许**（此前在智能体场景下被阻止） |
| TRTLLM ↔ SGLang | 允许 | **允许**（此前在智能体场景下被阻止） |
| TRTLLM ↔ ATOM | 允许 | **允许**（此前在智能体场景下被阻止） |
| ATOM ↔ vLLM 或 SGLang | 允许 | 允许 |

"按硬件划分"即：**B200 vLLM 与 B200 SGLang 不可同时选中；B200 vLLM 与 B300 的任意配置可同时选中。**

**由两处改动实现。** 其一，智能体场景新增 8K/1K 已有的 `exclusionFamilies` 允许列表（`data-mappings.ts`）。此前该场景在智能体基准测试尚新时限制*所有*引擎 family，导致 TRTLLM 与 ATOM 无法与 vLLM、SGLang 同时选中；现改为共用同一份 `['vllm', 'sglang']` 列表。由于该列表在 `groupAliases` **之前**匹配，ATOM 得以不受"折叠进 SGLang 可比性分组"规则的影响——这正是无需删除该别名即可放开 ATOM 一行的原因。其二，模型级 MTP 规则改为 `scope: 'hardware'`，与标准 token 规则一致；此前为全局范围，导致选中 B200 SGLang MTP 后无法再选 MI355X vLLM MTP，而这是纯粹的硬件对比，正是图表意在支持的用法。同一 SKU 内的跨引擎 MTP 仍被阻止。

该限制的目的是避免在同一 SKU 的曲线上混读两种引擎，而非限制图表同时展示两种硬件，因此现统一采用硬件范围。常量 `EIGHTK_ONEK_EXCLUSION_FAMILIES` 因两个场景共用而更名为 `GUARDED_ENGINE_FAMILIES`，上述矩阵已写入该常量上方的注释。`exclusion.ts` 未作改动——引擎本身已支持 `participatingFamilies` 与 `scope: 'hardware'`，本次仅调整规则数据，这正是该模块的预期扩展方式。

**适用范围说明：** MTP 规则挂在 `Model.DeepSeek_V4_Pro` 上（目前唯一声明该规则的模型），因此 MTP 一列适用于该模型；其他模型本就没有 MTP 限制。硬件范围的修正同样作用于已弃用的 1K/1K 与 1K/8K 序列（模型级规则在所有场景生效），变化方向一致，且这两个序列本身没有场景级规则。

**测试：** `comparison-exclusion.test.ts` 的表驱动用例现在在**两个场景**下均断言完整矩阵，且每个原先的全局 MTP 用例都拆分为同 SKU（仍为 `block`）与跨 SKU（现为 `fallthrough`）两种情形；两个 `groupOf` 用例改为对两个场景 `it.each`，验证 ATOM/TRTLLM 解析为 `null`（不受限制），vLLM/SGLang 在各类 `dynamo-`/`mori-`/`llmd-` 前缀下仍归入各自分组；新增用例断言 `scopesOf` 恒为 `['b200']` 而非全局范围，覆盖标准 token 与 MTP 键、三个场景。`data-mappings.test.ts` 的允许列表断言更新为覆盖两个场景。`bun run test:unit` 3,744 项全部通过；`typecheck`、`lint`、`fmt` 均通过。

覆盖层说明：`comparisonExclusion` 对非官方运行返回 `null`，即 `?unofficialrun=` 预览有意不施加引擎限制；该行为未变，且仍由既有用例覆盖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which inference configs can be selected together on official Agentic and DSV4 MTP charts; wrong rules could mislead benchmark comparisons, but behavior is heavily covered by updated unit tests and no exclusion engine code changed.
> 
> **Overview**
> Inference chart **engine comparability rules** for DeepSeek V4 Pro are tightened so users can mix more engines on one graph while still blocking misleading same-SKU vLLM vs SGLang pairs.
> 
> **Agentic Traces** now uses the same `exclusionFamilies` allowlist as **8K/1K** (`vllm`, `sglang` only). TRTLLM, ATOM, and related stacks are no longer mutually exclusive with vLLM/SGLang on Agentic (standard-token and MTP), matching 8K/1K behavior.
> 
> The model-level **MTP** rule gains `scope: 'hardware'`, so cross-engine MTP blocks apply **per SKU** (e.g. B200 SGLang MTP vs B200 vLLM MTP) but **not** across hardware (e.g. B200 vs MI355X). STP rules were already hardware-scoped; MTP now follows the same intent.
> 
> `EIGHTK_ONEK_EXCLUSION_FAMILIES` is renamed **`GUARDED_ENGINE_FAMILIES`** and shared by both scenarios. Tests document the full per-SKU matrix and split former “global MTP” cases into same-SKU block vs cross-SKU allow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42b491c8ad2d7d0a22a3ba3b9c86b2dc4ba5cfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->