### PR TITLE
Export displayed metrics in inference CSV downloads / 在推理 CSV 下载中导出当前显示指标

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -726,6 +726,13 @@ export default function ChartDisplay() {
                         graph.model,
                         graph.sequence,
                         visibleOverlayRowsForExport,
+                        {
+                          yHeader: metricLabel(graph.chartDefinition, selectedYAxisMetric, locale),
+                          yPath: (graph.chartDefinition as ChartDefinition)[
+                            selectedYAxisMetric
+                          ] as string,
+                          xHeader: graph.chartDefinition.x_label,
+                        },
                       );
                       // Match warnings against the same series the chart annotates,
                       // including visible unofficial-run overlay series.

--- a/packages/app/src/lib/csv-export-helpers.test.ts
+++ b/packages/app/src/lib/csv-export-helpers.test.ts
@@ -101,6 +101,26 @@ describe('inferenceChartToCsv', () => {
     expect(row[p99IntIdx]).toBe(35);
   });
 
+  it('exports the derived Y metric and X value displayed by the table', () => {
+    const data = [makePoint({ x: 42, costh: { y: 0.512, roof: false } })];
+    const overlay = makePoint({
+      x: 37,
+      hwKey: 'b200-sxm-vllm',
+      costh: { y: 0.431, roof: false },
+    });
+    const { headers, rows } = inferenceChartToCsv(data, 'llama-3.1-405b', '1k/1k', [overlay], {
+      yHeader: 'Cost per Million Total Tokens ($)',
+      yPath: 'costh.y',
+      xHeader: 'Interactivity (tok/s/user)',
+    });
+
+    expect(rows[0][headers.indexOf('Cost per Million Total Tokens ($)')]).toBe(0.512);
+    expect(rows[0][headers.indexOf('Interactivity (tok/s/user)')]).toBe(42);
+    expect(rows[1][headers.indexOf('Cost per Million Total Tokens ($)')]).toBe(0.431);
+    expect(rows[1][headers.indexOf('Interactivity (tok/s/user)')]).toBe(37);
+    expect(rows.every((row) => row.length === headers.length)).toBe(true);
+  });
+
   it('labels raw latency statistics as seconds without changing their values', () => {
     const issueMetrics = {
       mean_ttft: 1.615576321,

--- a/packages/app/src/lib/csv-export-helpers.test.ts
+++ b/packages/app/src/lib/csv-export-helpers.test.ts
@@ -121,6 +121,25 @@ describe('inferenceChartToCsv', () => {
     expect(rows.every((row) => row.length === headers.length)).toBe(true);
   });
 
+  it('does not duplicate an agentic P99 X metric already in the fixed schema', () => {
+    const { headers, rows } = inferenceChartToCsv(
+      [makePoint({ x: 35 })],
+      'agentx-model',
+      'agentic',
+      [],
+      {
+        yHeader: 'Cost per Million Total Tokens ($)',
+        yPath: 'costh.y',
+        xHeader: 'P99 Interactivity (tok/s/user)',
+      },
+    );
+
+    expect(headers.filter((header) => header === 'P99 Interactivity (tok/s/user)')).toHaveLength(1);
+    expect(rows[0][headers.indexOf('P99 Interactivity (tok/s/user)')]).toBe(35);
+    expect(new Set(headers).size).toBe(headers.length);
+    expect(rows[0]).toHaveLength(headers.length);
+  });
+
   it('labels raw latency statistics as seconds without changing their values', () => {
     const issueMetrics = {
       mean_ttft: 1.615576321,

--- a/packages/app/src/lib/csv-export-helpers.ts
+++ b/packages/app/src/lib/csv-export-helpers.ts
@@ -17,6 +17,22 @@ interface CsvData {
   rows: (string | number | boolean | null | undefined)[][];
 }
 
+export interface InferenceCsvDisplayedMetrics {
+  yHeader: string;
+  yPath: string;
+  xHeader: string;
+}
+
+function nestedMetric(point: InferenceData, path: string): number | '' {
+  const [key, nestedKey] = path.split('.');
+  const value = point[key as keyof InferenceData];
+  if (nestedKey && typeof value === 'object' && value !== null && nestedKey in value) {
+    const nestedValue = (value as Record<string, unknown>)[nestedKey];
+    return typeof nestedValue === 'number' ? nestedValue : '';
+  }
+  return typeof value === 'number' ? value : '';
+}
+
 /** Preserve a real zero while leaving source metrics that were not measured blank. */
 function benchmarkMetric(point: InferenceData, key: string): number | '' {
   if (point.rawMetricKeys && !point.rawMetricKeys.includes(key)) return '';
@@ -34,6 +50,7 @@ export function inferenceChartToCsv(
   model: string,
   sequence: string,
   overlayData: InferenceData[] = [],
+  displayedMetrics?: InferenceCsvDisplayedMetrics,
 ): CsvData {
   const islOsl = sequenceToIslOsl(sequence);
   const headers = [
@@ -47,6 +64,7 @@ export function inferenceChartToCsv(
     'TP',
     'Concurrency',
     'Date',
+    ...(displayedMetrics ? [displayedMetrics.yHeader, displayedMetrics.xHeader] : []),
     // Throughput
     'Throughput/Chip (tok/s)',
     'Output Throughput/Chip (tok/s)',
@@ -102,6 +120,7 @@ export function inferenceChartToCsv(
       d.tp,
       d.conc,
       d.date,
+      ...(displayedMetrics ? [nestedMetric(d, displayedMetrics.yPath), d.x] : []),
       benchmarkMetric(d, 'tput_per_gpu'),
       benchmarkMetric(d, 'output_tput_per_gpu'),
       benchmarkMetric(d, 'input_tput_per_gpu'),

--- a/packages/app/src/lib/csv-export-helpers.ts
+++ b/packages/app/src/lib/csv-export-helpers.ts
@@ -64,7 +64,6 @@ export function inferenceChartToCsv(
     'TP',
     'Concurrency',
     'Date',
-    ...(displayedMetrics ? [displayedMetrics.yHeader, displayedMetrics.xHeader] : []),
     // Throughput
     'Throughput/Chip (tok/s)',
     'Output Throughput/Chip (tok/s)',
@@ -107,52 +106,70 @@ export function inferenceChartToCsv(
     'Run URL',
   ];
 
+  const displayedColumns = displayedMetrics
+    ? [
+        {
+          header: displayedMetrics.yHeader,
+          value: (point: InferenceData) => nestedMetric(point, displayedMetrics.yPath),
+        },
+        { header: displayedMetrics.xHeader, value: (point: InferenceData) => point.x },
+      ].filter(
+        (column, index, columns) =>
+          !headers.includes(column.header) &&
+          columns.findIndex((candidate) => candidate.header === column.header) === index,
+      )
+    : [];
+  headers.splice(10, 0, ...displayedColumns.map((column) => column.header));
+
   const rows = [...data, ...overlayData]
     .filter((d) => !d.hidden)
-    .map((d) => [
-      model,
-      islOsl?.isl ?? '',
-      islOsl?.osl ?? '',
-      d.hw ?? '',
-      d.hwKey,
-      d.framework ?? '',
-      d.precision,
-      d.tp,
-      d.conc,
-      d.date,
-      ...(displayedMetrics ? [nestedMetric(d, displayedMetrics.yPath), d.x] : []),
-      benchmarkMetric(d, 'tput_per_gpu'),
-      benchmarkMetric(d, 'output_tput_per_gpu'),
-      benchmarkMetric(d, 'input_tput_per_gpu'),
-      benchmarkMetric(d, 'mean_ttft'),
-      benchmarkMetric(d, 'median_ttft'),
-      benchmarkMetric(d, 'p99_ttft'),
-      benchmarkMetric(d, 'std_ttft'),
-      benchmarkMetric(d, 'mean_tpot'),
-      benchmarkMetric(d, 'median_tpot'),
-      benchmarkMetric(d, 'p99_tpot'),
-      benchmarkMetric(d, 'std_tpot'),
-      benchmarkMetric(d, 'mean_intvty'),
-      benchmarkMetric(d, 'median_intvty'),
-      benchmarkMetric(d, 'p99_intvty'),
-      benchmarkMetric(d, 'std_intvty'),
-      benchmarkMetric(d, 'mean_itl'),
-      benchmarkMetric(d, 'median_itl'),
-      benchmarkMetric(d, 'p99_itl'),
-      benchmarkMetric(d, 'std_itl'),
-      benchmarkMetric(d, 'mean_e2el'),
-      benchmarkMetric(d, 'median_e2el'),
-      benchmarkMetric(d, 'p99_e2el'),
-      benchmarkMetric(d, 'std_e2el'),
-      d.disagg ?? false,
-      d.num_prefill_gpu ?? '',
-      d.num_decode_gpu ?? '',
-      d.spec_decoding ?? '',
-      d.ep ?? '',
-      d.dp_attention ?? '',
-      d.is_multinode ?? '',
-      d.run_url ?? '',
-    ]);
+    .map((d) => {
+      const row = [
+        model,
+        islOsl?.isl ?? '',
+        islOsl?.osl ?? '',
+        d.hw ?? '',
+        d.hwKey,
+        d.framework ?? '',
+        d.precision,
+        d.tp,
+        d.conc,
+        d.date,
+        benchmarkMetric(d, 'tput_per_gpu'),
+        benchmarkMetric(d, 'output_tput_per_gpu'),
+        benchmarkMetric(d, 'input_tput_per_gpu'),
+        benchmarkMetric(d, 'mean_ttft'),
+        benchmarkMetric(d, 'median_ttft'),
+        benchmarkMetric(d, 'p99_ttft'),
+        benchmarkMetric(d, 'std_ttft'),
+        benchmarkMetric(d, 'mean_tpot'),
+        benchmarkMetric(d, 'median_tpot'),
+        benchmarkMetric(d, 'p99_tpot'),
+        benchmarkMetric(d, 'std_tpot'),
+        benchmarkMetric(d, 'mean_intvty'),
+        benchmarkMetric(d, 'median_intvty'),
+        benchmarkMetric(d, 'p99_intvty'),
+        benchmarkMetric(d, 'std_intvty'),
+        benchmarkMetric(d, 'mean_itl'),
+        benchmarkMetric(d, 'median_itl'),
+        benchmarkMetric(d, 'p99_itl'),
+        benchmarkMetric(d, 'std_itl'),
+        benchmarkMetric(d, 'mean_e2el'),
+        benchmarkMetric(d, 'median_e2el'),
+        benchmarkMetric(d, 'p99_e2el'),
+        benchmarkMetric(d, 'std_e2el'),
+        d.disagg ?? false,
+        d.num_prefill_gpu ?? '',
+        d.num_decode_gpu ?? '',
+        d.spec_decoding ?? '',
+        d.ep ?? '',
+        d.dp_attention ?? '',
+        d.is_multinode ?? '',
+        d.run_url ?? '',
+      ];
+      row.splice(10, 0, ...displayedColumns.map((column) => column.value(d)));
+      return row;
+    });
 
   return { headers, rows };
 }


### PR DESCRIPTION
## Summary

- include the selected Y-axis metric and current X-axis value in inference CSV downloads
- resolve nested derived metrics such as `costh.y`, so CSV fields match the table view
- export the same displayed fields for both official rows and visible `?unofficialrun=` overlay rows
- retain the existing benchmark summary columns

## Root cause

The inference table resolved the selected metric dynamically from chart data, while the CSV helper exported only a fixed set of raw benchmark fields. Derived metrics such as cost per million total tokens were therefore visible in the table but absent from downloads.

## Validation

- `bun run typecheck`
- `bun run fmt`
- `cd packages/app && bun --env-file=../../.env vitest run src/lib/csv-export-helpers.test.ts` (32 tests passed)
- `git diff --check`
- works for both official runs and `?unofficialrun=` overlays (covered by the regression test)

## 中文说明

- 在推理 CSV 下载中加入当前选择的 Y 轴指标和 X 轴值
- 支持解析 `costh.y` 等嵌套派生指标，使 CSV 字段与表格视图保持一致
- 官方数据和可见的 `?unofficialrun=` overlay 数据都会导出相同的当前显示字段
- 保留现有的基准测试摘要列

## 根本原因

推理表格会根据图表数据动态解析当前选择的指标，而 CSV helper 仅导出一组固定的原始基准测试字段。因此，每百万总 token 成本等派生指标虽然会显示在表格中，却不会出现在下载文件里。

## 验证

- `bun run typecheck`
- `bun run fmt`
- `cd packages/app && bun --env-file=../../.env vitest run src/lib/csv-export-helpers.test.ts`（32 项测试通过）
- `git diff --check`
- 官方数据与 `?unofficialrun=` overlay 数据均受支持（已通过回归测试覆盖）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only change with optional API parameter; existing callers without displayedMetrics behave as before, covered by new unit tests.
> 
> **Overview**
> Inference chart CSV downloads now include the **same Y and X values the table shows**, not only the fixed benchmark summary columns.
> 
> `ChartDisplay` passes the selected axis labels and the chart definition path (e.g. `costh.y`) into `inferenceChartToCsv`, which inserts those columns after **Date** and resolves nested derived metrics via `nestedMetric`. Official rows and visible unofficial-run overlay rows get the same displayed fields. Columns are skipped when the header already exists in the export schema (e.g. agentic **P99 Interactivity**), so headers stay unique.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cddb15403dfd1611fa9e4a9323a804065287b113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->