### PR TITLE
fix(ui): support multi-select kernel modes / fix(ui)：支持内核模式多选

### DIFF
--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -176,7 +176,7 @@ describe('CollectiveX neutral run view', () => {
 
   it('allows both measured kernel modes to be selected together', () => {
     const withLowLatency = buildDataset({
-      shards: [makeRawShard(), makeRawShard({ mode: 'low-latency' })],
+      shards: [makeRawShard(), makeRawShard({ mode: 'low-latency' }), makeRawShard({ ep: 16 })],
     });
     installRuns([withLowLatency]);
     installRun(withLowLatency);
@@ -199,6 +199,18 @@ describe('CollectiveX neutral run view', () => {
     cy.get('[data-testid="chart-legend"]')
       .should('contain.text', 'normal')
       .and('contain.text', 'low-latency');
+    cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 2);
+
+    cy.get('[data-testid="collectivex-ep-select"]').click();
+    cy.contains('[role="option"]', 'EP16').click();
+    cy.get('[data-testid="collectivex-mode-toggle"]').should('not.exist');
+
+    cy.get('[data-testid="collectivex-ep-select"]').click();
+    cy.contains('[role="option"]', 'EP8').click();
+    cy.get('[data-testid="collectivex-mode-toggle"] button[aria-pressed="true"]').should(
+      'have.length',
+      2,
+    );
     cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 2);
   });
 

--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -174,7 +174,7 @@ describe('CollectiveX neutral run view', () => {
       .and('not.contain.text', 'Payload rate is derived');
   });
 
-  it('exposes the kernel-mode toggle when a run measured both modes and pins the LL series', () => {
+  it('allows both measured kernel modes to be selected together', () => {
     const withLowLatency = buildDataset({
       shards: [makeRawShard(), makeRawShard({ mode: 'low-latency' })],
     });
@@ -185,12 +185,21 @@ describe('CollectiveX neutral run view', () => {
     cy.wait('@run');
 
     cy.get('[data-testid="collectivex-mode-toggle"]').should('be.visible');
+    cy.get('[data-testid="collectivex-mode-toggle"] button')
+      .contains('Normal')
+      .should('have.attr', 'aria-pressed', 'true');
     cy.get('[data-testid="collectivex-main-chart"]').should('contain.text', 'deepep-v2');
     cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 1);
 
     cy.get('[data-testid="collectivex-mode-toggle"]').contains('Low-latency').click();
-    cy.get('[data-testid="chart-legend"]').should('contain.text', 'low-latency');
-    cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 1);
+    cy.get('[data-testid="collectivex-mode-toggle"] button[aria-pressed="true"]').should(
+      'have.length',
+      2,
+    );
+    cy.get('[data-testid="chart-legend"]')
+      .should('contain.text', 'normal')
+      .and('contain.text', 'low-latency');
+    cy.get('[data-testid="collectivex-explorer-chart"] .line-path').should('have.length', 2);
   });
 
   it('selects the available phase when a partial run only measured prefill', () => {

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -150,6 +150,14 @@ describe('TCO Calculator', () => {
       });
     });
 
+    it('places the config-range toggle beside its label', () => {
+      cy.get('[data-testid="calculator-hide-over-limit-control"]').then(($control) => {
+        const label = $control.children().first()[0].getBoundingClientRect();
+        const toggle = $control.find('button[role="switch"]')[0].getBoundingClientRect();
+        expect(toggle.left - label.right).to.be.lessThan(12);
+      });
+    });
+
     it('does not show badges when throughput metric is selected', () => {
       cy.get('[data-testid="calculator-cost-badges"]').should('not.exist');
     });

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -150,11 +150,16 @@ describe('TCO Calculator', () => {
       });
     });
 
-    it('places the config-range toggle beside its label', () => {
+    it('places the config-range toggle beside its label above the slider', () => {
       cy.get('[data-testid="calculator-hide-over-limit-control"]').then(($control) => {
         const label = $control.children().first()[0].getBoundingClientRect();
         const toggle = $control.find('button[role="switch"]')[0].getBoundingClientRect();
+        const slider = $control
+          .closest('[data-testid="calculator-controls"]')
+          .find('input[type="range"]')[0]
+          .getBoundingClientRect();
         expect(toggle.left - label.right).to.be.lessThan(12);
+        expect(toggle.bottom).to.be.lessThan(slider.top);
       });
     });
 

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -980,15 +980,35 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
               {/* Target value slider + input */}
               {!loading && hasAnyData && (
                 <div className="space-y-2">
-                  <LabelWithTooltip
-                    htmlFor="calc-target"
-                    label={
-                      isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
-                    }
-                    tooltip={
-                      isAgenticSequence ? t.targetAgenticTooltip(percentileLabel) : t.targetTooltip
-                    }
-                  />
+                  <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+                    <LabelWithTooltip
+                      htmlFor="calc-target"
+                      label={
+                        isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
+                      }
+                      tooltip={
+                        isAgenticSequence
+                          ? t.targetAgenticTooltip(percentileLabel)
+                          : t.targetTooltip
+                      }
+                    />
+                    <div
+                      className="flex items-center gap-2"
+                      data-testid="calculator-hide-over-limit-control"
+                    >
+                      <LabelWithTooltip
+                        htmlFor="calc-hide-over-limit"
+                        label={t.hideSkuAboveConfigLimitLabel}
+                        tooltip={t.hideSkuAboveConfigLimitHelp}
+                      />
+                      <Switch
+                        id="calc-hide-over-limit"
+                        checked={hideSkuAboveConfigLimit}
+                        onCheckedChange={handleHideSkuAboveLimitChange}
+                        className="shrink-0"
+                      />
+                    </div>
+                  </div>
                   <div className="flex items-center gap-4">
                     <div className="flex-1">
                       <input
@@ -1033,22 +1053,6 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                       onBlur={handleInputBlur}
                       className="w-24 h-9"
                       min={0}
-                    />
-                  </div>
-                  <div
-                    className="flex items-center gap-2 pt-1"
-                    data-testid="calculator-hide-over-limit-control"
-                  >
-                    <LabelWithTooltip
-                      htmlFor="calc-hide-over-limit"
-                      label={t.hideSkuAboveConfigLimitLabel}
-                      tooltip={t.hideSkuAboveConfigLimitHelp}
-                    />
-                    <Switch
-                      id="calc-hide-over-limit"
-                      checked={hideSkuAboveConfigLimit}
-                      onCheckedChange={handleHideSkuAboveLimitChange}
-                      className="shrink-0"
                     />
                   </div>
                 </div>

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -1035,7 +1035,10 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                       min={0}
                     />
                   </div>
-                  <div className="flex items-center justify-between gap-3 pt-1">
+                  <div
+                    className="flex items-center gap-2 pt-1"
+                    data-testid="calculator-hide-over-limit-control"
+                  >
                     <LabelWithTooltip
                       htmlFor="calc-hide-over-limit"
                       label={t.hideSkuAboveConfigLimitLabel}

--- a/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
@@ -476,11 +476,13 @@ export default function CollectiveXDisplay() {
     if (availablePhases.length > 0 && !availablePhases.includes(phase)) {
       setPhase(availablePhases[0]);
     }
-    const validModes = modes.filter((mode) => availableModes.includes(mode));
-    if (availableModes.length > 0 && validModes.length === 0) {
+    // Keep the user's full multi-mode preference while availability cascades
+    // through EP/phase changes. In particular, an intermediate empty slice
+    // must not erase both selections; modes that become available again should
+    // still be selected. Fall back only when a settled, non-empty slice has no
+    // overlap with the preference at all.
+    if (availableModes.length > 0 && !modes.some((mode) => availableModes.includes(mode))) {
       setModes([availableModes[0]]);
-    } else if (validModes.length !== modes.length) {
-      setModes(validModes);
     }
     if (availablePrecisions.length > 0 && !availablePrecisions.includes(precision)) {
       setPrecision(availablePrecisions[0]);

--- a/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXDisplay.tsx
@@ -368,7 +368,7 @@ export default function CollectiveXDisplay() {
   const [phase, setPhase] = useState<CollectiveXPhase>('decode');
   // Normal (throughput) kernels are the baseline; the availability effect
   // below falls back when a slice only measured low-latency kernels.
-  const [mode, setMode] = useState<CollectiveXMode>('normal');
+  const [modes, setModes] = useState<CollectiveXMode[]>(['normal']);
   // Prefer FP8 when the run measured it; the availability effect below falls
   // back to bf16 for runs (or EP/phase slices) without FP8 series.
   const [precision, setPrecision] = useState<CollectiveXPrecision>('fp8');
@@ -459,12 +459,12 @@ export default function CollectiveXDisplay() {
           combinedSeries
             .filter(
               (item) =>
-                item.system.ep_size === epSize && item.phase === phase && item.mode === mode,
+                item.system.ep_size === epSize && item.phase === phase && modes.includes(item.mode),
             )
             .map((item) => item.precision),
         ),
       ].toSorted(),
-    [combinedSeries, epSize, mode, phase],
+    [combinedSeries, epSize, modes, phase],
   );
   const precisionOptions: SegmentedToggleOption<CollectiveXPrecision>[] = availablePrecisions.map(
     (value) => ({ value, label: t.precision[value] }),
@@ -476,8 +476,11 @@ export default function CollectiveXDisplay() {
     if (availablePhases.length > 0 && !availablePhases.includes(phase)) {
       setPhase(availablePhases[0]);
     }
-    if (availableModes.length > 0 && !availableModes.includes(mode)) {
-      setMode(availableModes[0]);
+    const validModes = modes.filter((mode) => availableModes.includes(mode));
+    if (availableModes.length > 0 && validModes.length === 0) {
+      setModes([availableModes[0]]);
+    } else if (validModes.length !== modes.length) {
+      setModes(validModes);
     }
     if (availablePrecisions.length > 0 && !availablePrecisions.includes(precision)) {
       setPrecision(availablePrecisions[0]);
@@ -488,13 +491,13 @@ export default function CollectiveXDisplay() {
     availablePhases,
     availablePrecisions,
     epSize,
-    mode,
+    modes,
     phase,
     precision,
   ]);
   const seriesSelection = useMemo<CollectiveXSeriesSelection>(
-    () => ({ epSize, phase, mode, precision }),
-    [epSize, mode, phase, precision],
+    () => ({ epSize, phase, modes, precision }),
+    [epSize, modes, phase, precision],
   );
   // SKU and EP determine topology; V1 fixes routing. EP, phase, kernel mode,
   // and precision are needed before the library/SKU comparison filters.
@@ -971,16 +974,38 @@ export default function CollectiveXDisplay() {
               </ControlGroup>
               {availableModes.length > 1 && (
                 <ControlGroup label={t.modeControl}>
-                  <SegmentedToggle
-                    value={mode}
-                    options={modeOptions}
-                    onValueChange={(next) => {
-                      setMode(next);
-                      track('collectivex_mode_changed', { mode: next });
-                    }}
-                    ariaLabel={t.modeAria}
-                    testId="collectivex-mode-toggle"
-                  />
+                  <div
+                    className="inline-flex items-center gap-0.5 rounded-lg border border-border p-0.5"
+                    role="group"
+                    aria-label={t.modeAria}
+                    data-testid="collectivex-mode-toggle"
+                  >
+                    {modeOptions.map((option) => {
+                      const selected = modes.includes(option.value);
+                      return (
+                        <button
+                          key={option.value}
+                          type="button"
+                          aria-pressed={selected}
+                          className={`inline-flex items-center rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                            selected
+                              ? 'bg-muted text-foreground'
+                              : 'text-muted-foreground hover:text-foreground'
+                          }`}
+                          onClick={() => {
+                            const next = selected
+                              ? modes.filter((mode) => mode !== option.value)
+                              : [...modes, option.value];
+                            if (next.length === 0) return;
+                            setModes(next);
+                            track('collectivex_mode_changed', { modes: next });
+                          }}
+                        >
+                          {option.label}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </ControlGroup>
               )}
               <ControlGroup label={t.precisionControl}>

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -149,7 +149,7 @@ describe('seriesMatchesSelection', () => {
   const base: CollectiveXSeriesSelection = {
     epSize: 8,
     phase: 'decode',
-    mode: 'normal',
+    modes: ['normal'],
     precision: 'bf16',
   };
 
@@ -160,8 +160,16 @@ describe('seriesMatchesSelection', () => {
   it('rejects a series whose EP, phase, mode, or precision differs from the selection', () => {
     expect(seriesMatchesSelection(scaleUp, { ...base, epSize: 16 })).toBe(false);
     expect(seriesMatchesSelection(scaleUp, { ...base, phase: 'prefill' })).toBe(false);
-    expect(seriesMatchesSelection(scaleUp, { ...base, mode: 'low-latency' })).toBe(false);
+    expect(seriesMatchesSelection(scaleUp, { ...base, modes: ['low-latency'] })).toBe(false);
     expect(seriesMatchesSelection(scaleUp, { ...base, precision: 'fp8' })).toBe(false);
+  });
+
+  it('matches every selected kernel mode', () => {
+    const lowLatency = makeCollectiveXSeries({ mode: 'low-latency' });
+    const bothModes = { ...base, modes: ['normal', 'low-latency'] as const };
+
+    expect(seriesMatchesSelection(scaleUp, bothModes)).toBe(true);
+    expect(seriesMatchesSelection(lowLatency, bothModes)).toBe(true);
   });
 });
 

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -17,7 +17,7 @@ import type {
 export interface CollectiveXSeriesSelection {
   epSize: number;
   phase: CollectiveXPhase;
-  mode: CollectiveXMode;
+  modes: readonly CollectiveXMode[];
   precision: CollectiveXPrecision;
 }
 
@@ -90,7 +90,7 @@ export function seriesMatchesSelection(
   return (
     series.system.ep_size === selection.epSize &&
     series.phase === selection.phase &&
-    series.mode === selection.mode &&
+    selection.modes.includes(series.mode) &&
     series.precision === selection.precision
   );
 }


### PR DESCRIPTION
## Summary

- Allow the CollectiveX kernel mode control to keep Normal and Low-latency selected together, so both series can be compared in one chart.
- Preserve at least one selected kernel mode and keep availability filtering consistent as EP and phase change.
- Place the calculator’s “Hide if target exceeds config range” switch directly beside its label.
- Add unit and E2E regression coverage for multi-mode filtering and control spacing.

## Validation

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- CollectiveX unit tests: 36 passed
- CollectiveX Cypress E2E: 26 passed
- The calculator E2E suite could not load benchmark bars locally because `DATABASE_READONLY_URL` is unavailable; the failure occurred in suite setup before the layout assertion.

## 中文说明

- CollectiveX 的内核模式控件现可同时选中“常规”和“低延迟”，便于在同一张图表中对比两类曲线。
- 始终保留至少一种内核模式，并在切换 EP 和阶段时同步更新可用模式筛选。
- 将计算器中的“隐藏超出配置上限的型号”开关移至标签旁边。
- 为多模式筛选和控件间距新增单元测试与 E2E 回归测试。

## 验证

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- CollectiveX 单元测试：36 项通过
- CollectiveX Cypress E2E：26 项通过
- 由于本地环境缺少 `DATABASE_READONLY_URL`，计算器 E2E 测试无法加载基准测试柱形图；测试在套件初始化阶段终止，尚未执行布局断言。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only chart filtering and layout changes with no auth, API, or data-layer impact.
> 
> **Overview**
> **CollectiveX** replaces single-select kernel mode with **multi-select**: `modes` is an array, `seriesMatchesSelection` accepts any selected mode, and the mode control is toggle buttons (`aria-pressed`) that can show Normal and Low-latency together on one chart while blocking deselecting the last mode. Availability logic keeps the user’s mode set across EP/phase changes and only resets when the current slice has no overlap.
> 
> **Throughput calculator** moves the “hide SKU above config limit” switch from below the target slider to a row beside the target label (`calculator-hide-over-limit-control`), with a Cypress layout assertion.
> 
> Tests cover multi-mode filtering (unit) and dual-mode chart lines plus EP round-trip (E2E).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1c84613d920408998e68277f61becb775c84f69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->