### PR TITLE
perf(api): add compact calculator benchmarks / perf(api)：新增计算器精简基准测试响应

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ Some routes serve a purpose that raw DB rows cannot satisfy:
 - CollectiveX assembles stored sweep documents through its shared reader.
 - `tco-feed` performs server-side frontier interpolation for spreadsheet consumers that cannot run the TypeScript transforms.
 - `/api/v1/overview` is a page-owned backend-for-frontend (BFF). It returns the compact `OverviewPageData` shape used by the initial server render, allowing selector changes to update the matrix without downloading every model's raw benchmark history or triggering a React Server Component (RSC) round trip. It is not a reusable public data API.
+- `/api/v1/benchmarks?view=calculator&sequence=...` is a page-owned compact view. It returns only the selected calculator scenario and the metric keys needed for interpolation, while the default endpoint preserves the raw-row contract. This reduces transfer and browser parsing without narrowing the reusable inference response.
 
 ## Hash-Based Tab Routing (Not Next.js Routes)
 

--- a/packages/app/src/app/api/v1/benchmarks/route.test.ts
+++ b/packages/app/src/app/api/v1/benchmarks/route.test.ts
@@ -78,6 +78,48 @@ describe('GET /api/v1/benchmarks', () => {
     );
   });
 
+  it('returns a compact, single-sequence calculator response', async () => {
+    mockGetLatestBenchmarks.mockResolvedValueOnce([
+      {
+        benchmark_type: 'single_turn',
+        isl: 1024,
+        osl: 1024,
+        metrics: { tput_per_gpu: 100, median_intvty: 30, avg_power_w: 700 },
+        workers: [{ rank: 0 }],
+      },
+      {
+        benchmark_type: 'single_turn',
+        isl: 8192,
+        osl: 1024,
+        metrics: { tput_per_gpu: 80, median_intvty: 20 },
+      },
+    ]);
+
+    const res = await GET(
+      req('/api/v1/benchmarks?model=DeepSeek-R1-0528&view=calculator&sequence=1k%2F1k'),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      {
+        benchmark_type: 'single_turn',
+        isl: 1024,
+        osl: 1024,
+        metrics: { tput_per_gpu: 100, median_intvty: 30 },
+      },
+    ]);
+  });
+
+  it('rejects an unknown calculator sequence', async () => {
+    const res = await GET(
+      req('/api/v1/benchmarks?model=DeepSeek-R1-0528&view=calculator&sequence=unknown'),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Unknown calculator sequence' });
+    expect(mockGetLatestBenchmarks).not.toHaveBeenCalled();
+  });
+
   it('passes exact=true when query param set', async () => {
     mockGetLatestBenchmarks.mockResolvedValueOnce([]);
 

--- a/packages/app/src/app/api/v1/benchmarks/route.ts
+++ b/packages/app/src/app/api/v1/benchmarks/route.ts
@@ -6,9 +6,11 @@ import { FIXTURES_MODE, getDb } from '@semianalysisai/inferencex-db/connection';
 import {
   getBenchmarksForRun,
   getLatestBenchmarks,
+  type BenchmarkRow,
 } from '@semianalysisai/inferencex-db/queries/benchmarks';
 
 import { cachedJson, cachedQuery } from '@/lib/api-cache';
+import { toCalculatorBenchmarkRows } from '@/lib/benchmark-api-view';
 import { loadFixture } from '@/lib/test-fixtures';
 
 export const dynamic = 'force-dynamic';
@@ -28,6 +30,13 @@ const getCachedBenchmarksForRun = cachedQuery(
   { blobOnly: true },
 );
 
+const getCachedCalculatorBenchmarks = cachedQuery(
+  async (dbModelKeys: string[], sequence: string, date?: string) =>
+    toCalculatorBenchmarkRows(await getLatestBenchmarks(getDb(), dbModelKeys, date), sequence),
+  'benchmarks-calculator',
+  { blobOnly: true },
+);
+
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const model = params.get('model') ?? '';
@@ -38,17 +47,29 @@ export async function GET(request: NextRequest) {
   const runId = runIdParam && /^\d+$/u.test(runIdParam) ? runIdParam : undefined;
   // exactRun=true → return exactly this run's results (GPU comparison of same-day runs).
   const exactRun = params.get('exactRun') === 'true';
+  const view = params.get('view');
+  const sequence = params.get('sequence') ?? '';
   const dbModelKeys = DISPLAY_MODEL_TO_DB[model];
   if (!dbModelKeys || dbModelKeys.length === 0) {
     return NextResponse.json({ error: 'Unknown model' }, { status: 400 });
   }
-  if (FIXTURES_MODE) return cachedJson(loadFixture('benchmarks'));
+  if (view === 'calculator' && !['1k/1k', '1k/8k', '8k/1k', 'agentic-traces'].includes(sequence)) {
+    return NextResponse.json({ error: 'Unknown calculator sequence' }, { status: 400 });
+  }
+  if (FIXTURES_MODE) {
+    const fixture = loadFixture<BenchmarkRow[]>('benchmarks');
+    return cachedJson(
+      view === 'calculator' ? toCalculatorBenchmarkRows(fixture, sequence) : fixture,
+    );
+  }
 
   try {
     const rows =
-      exactRun && runId
-        ? await getCachedBenchmarksForRun(dbModelKeys, runId)
-        : await getCachedBenchmarks(dbModelKeys, date, exact || undefined, runId);
+      view === 'calculator'
+        ? await getCachedCalculatorBenchmarks(dbModelKeys, sequence, date)
+        : exactRun && runId
+          ? await getCachedBenchmarksForRun(dbModelKeys, runId)
+          : await getCachedBenchmarks(dbModelKeys, date, exact || undefined, runId);
     return cachedJson(rows);
   } catch (error) {
     console.error('Error fetching benchmarks:', error);

--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -190,7 +190,10 @@ export function useThroughputData(
     data: allRows,
     isLoading: queryLoading,
     error: queryError,
-  } = useBenchmarks(selectedModel, selectedRunDate);
+  } = useBenchmarks(selectedModel, selectedRunDate, true, undefined, undefined, {
+    type: 'calculator',
+    sequence: selectedSequence,
+  });
 
   const loading = queryLoading || !allRows;
   const error = queryError ? queryError.message : null;

--- a/packages/app/src/hooks/api/use-benchmarks.test.ts
+++ b/packages/app/src/hooks/api/use-benchmarks.test.ts
@@ -68,6 +68,21 @@ describe('benchmarkQueryOptions', () => {
     expect(a.queryKey).not.toEqual(b.queryKey);
   });
 
+  it('separates compact calculator sequences from the raw benchmark cache', () => {
+    const raw = benchmarkQueryOptions('m', '2026-03-01');
+    const calculator = benchmarkQueryOptions('m', '2026-03-01', true, false, undefined, false, {
+      type: 'calculator',
+      sequence: '1k/1k',
+    });
+    const otherSequence = benchmarkQueryOptions('m', '2026-03-01', true, false, undefined, false, {
+      type: 'calculator',
+      sequence: '8k/1k',
+    });
+
+    expect(calculator.queryKey).not.toEqual(raw.queryKey);
+    expect(calculator.queryKey).not.toEqual(otherSequence.queryKey);
+  });
+
   it('is enabled when model is non-empty', () => {
     const opts = benchmarkQueryOptions('DeepSeek-R1-0528', '2026-03-01');
     expect(opts.enabled).toBe(true);

--- a/packages/app/src/hooks/api/use-benchmarks.ts
+++ b/packages/app/src/hooks/api/use-benchmarks.ts
@@ -12,6 +12,7 @@ export function benchmarkQueryOptions(
   runId?: string,
   /** When true with a runId, fetch exactly that run's results (GPU comparison). */
   exactRun?: boolean,
+  view?: { type: 'calculator'; sequence: string },
 ) {
   return {
     queryKey: [
@@ -21,9 +22,10 @@ export function benchmarkQueryOptions(
       exact ? 'exact' : 'latest',
       runId ?? 'all',
       exactRun ? 'run' : 'asof',
+      ...(view ? ([view.type, view.sequence] as const) : []),
     ] as const,
     queryFn: ({ signal }: { signal: AbortSignal }) =>
-      fetchBenchmarks(model, date, exact, signal, runId, exactRun),
+      fetchBenchmarks(model, date, exact, signal, runId, exactRun, view),
     enabled: enabled && Boolean(model),
   };
 }
@@ -34,8 +36,9 @@ export function useBenchmarks(
   enabled = true,
   runId?: string,
   exactRun?: boolean,
+  view?: { type: 'calculator'; sequence: string },
 ) {
   return useQuery(
-    benchmarkQueryOptions(model, date ?? 'latest', enabled, undefined, runId, exactRun),
+    benchmarkQueryOptions(model, date ?? 'latest', enabled, undefined, runId, exactRun, view),
   );
 }

--- a/packages/app/src/lib/api.test.ts
+++ b/packages/app/src/lib/api.test.ts
@@ -75,6 +75,26 @@ describe('fetchBenchmarks', () => {
     );
   });
 
+  it('requests the compact calculator view for one sequence', async () => {
+    mockOk([]);
+    await fetchBenchmarks(
+      'DeepSeek-R1-0528',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        type: 'calculator',
+        sequence: 'agentic-traces',
+      },
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/v1/benchmarks?model=DeepSeek-R1-0528&view=calculator&sequence=agentic-traces',
+      expect.objectContaining({}),
+    );
+  });
+
   it('returns parsed JSON on success', async () => {
     const data = [{ hardware: 'h200', metrics: {} }];
     mockOk(data);

--- a/packages/app/src/lib/api.ts
+++ b/packages/app/src/lib/api.ts
@@ -160,12 +160,17 @@ export function fetchBenchmarks(
   runId?: string,
   /** When true with a runId, fetch exactly that run's results (GPU comparison). */
   exactRun?: boolean,
+  view?: { type: 'calculator'; sequence: string },
 ) {
   const params = new URLSearchParams({ model });
   if (date) params.set('date', date);
   if (exact) params.set('exact', 'true');
   if (runId) params.set('runId', runId);
   if (exactRun) params.set('exactRun', 'true');
+  if (view) {
+    params.set('view', view.type);
+    params.set('sequence', view.sequence);
+  }
   return fetchJson<BenchmarkRow[]>(`/api/v1/benchmarks?${params}`, signal);
 }
 

--- a/packages/app/src/lib/benchmark-api-view.test.ts
+++ b/packages/app/src/lib/benchmark-api-view.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCalculatorBenchmarkRows } from './benchmark-api-view';
+
+const rows = [
+  {
+    benchmark_type: 'single_turn',
+    isl: 1024,
+    osl: 1024,
+    metrics: {
+      tput_per_gpu: 120,
+      median_intvty: 35,
+      avg_power_w: 700,
+      unused_debug_metric: 99,
+    },
+    workers: [{ rank: 0, avg_power_w: 700 }],
+  },
+  {
+    benchmark_type: 'single_turn',
+    isl: 8192,
+    osl: 1024,
+    metrics: { tput_per_gpu: 80, median_intvty: 20 },
+  },
+  {
+    benchmark_type: 'agentic_traces',
+    isl: null,
+    osl: null,
+    metrics: {
+      output_tput_per_gpu: 42,
+      p90_full_response_itl: 0.04,
+      p90_ttlt: 12,
+      p99_ttlt: 20,
+    },
+  },
+];
+
+describe('toCalculatorBenchmarkRows', () => {
+  it('returns only the selected fixed sequence and calculator metrics', () => {
+    expect(toCalculatorBenchmarkRows(rows, '1k/1k')).toEqual([
+      {
+        benchmark_type: 'single_turn',
+        isl: 1024,
+        osl: 1024,
+        metrics: { tput_per_gpu: 120, median_intvty: 35 },
+      },
+    ]);
+  });
+
+  it('keeps the agentic percentile inputs used for interpolation', () => {
+    expect(toCalculatorBenchmarkRows(rows, 'agentic-traces')).toEqual([
+      {
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        metrics: {
+          output_tput_per_gpu: 42,
+          p90_full_response_itl: 0.04,
+          p90_ttlt: 12,
+        },
+      },
+    ]);
+  });
+});

--- a/packages/app/src/lib/benchmark-api-view.ts
+++ b/packages/app/src/lib/benchmark-api-view.ts
@@ -1,0 +1,44 @@
+import { rowToSequence } from '@semianalysisai/inferencex-constants';
+
+const CALCULATOR_METRIC_KEYS = new Set([
+  'tput_per_gpu',
+  'input_tput_per_gpu',
+  'output_tput_per_gpu',
+  'prefill_pp',
+  'decode_pp',
+  ...['median', 'p75', 'p90'].flatMap((percentile) =>
+    ['intvty', 'itl', 'full_response_itl', 'e2el', 'ttlt'].map(
+      (metric) => `${percentile}_${metric}`,
+    ),
+  ),
+]);
+
+interface BenchmarkViewRow {
+  benchmark_type: string;
+  isl: number | null;
+  osl: number | null;
+  metrics: Record<string, unknown>;
+  workers?: unknown;
+}
+
+/**
+ * Page-owned calculator response: one selected scenario and only the metrics
+ * its interpolation pipeline consumes. The default benchmarks API remains the
+ * raw-row contract used by inference and other consumers.
+ */
+export function toCalculatorBenchmarkRows<T extends BenchmarkViewRow>(
+  rows: readonly T[],
+  sequence: string,
+): T[] {
+  return rows
+    .filter((row) => rowToSequence(row) === sequence)
+    .map((row) => {
+      const { workers: _workers, ...rest } = row;
+      return {
+        ...rest,
+        metrics: Object.fromEntries(
+          Object.entries(row.metrics).filter(([key]) => CALCULATOR_METRIC_KEYS.has(key)),
+        ),
+      } as T;
+    });
+}


### PR DESCRIPTION
## Summary

- Add a cached, page-owned `view=calculator&sequence=...` response to `/api/v1/benchmarks`.
- Return only the selected calculator scenario and metric keys used by interpolation; omit per-worker telemetry from this view.
- Keep the default raw benchmark API response unchanged for inference charts and external consumers.
- Give each compact sequence its own React Query and Blob cache identity.
- Document the new backend-for-frontend exception and add projection, API-route, client URL, cache-key, and calculator regression coverage.

## Impact

Against the repository's representative benchmark fixture, the uncompressed response is smaller by:

- `1k/1k`: 78.0%
- `1k/8k`: 88.2%
- `8k/1k`: 78.0%

This reduces calculator transfer size, browser JSON parsing, and retained React Query memory without changing the reusable raw API contract.

## Validation

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- Focused unit/API/calculator tests: 120 passed
- Calculator Cypress E2E: 66 passed
- Full unit suite: 3,236 passed; one unrelated pre-existing timezone-sensitive failure remains in `visit-tracking.test.ts` (`does NOT increment when a new session happens on the same calendar day`).

## 中文说明

- 为 `/api/v1/benchmarks` 新增带缓存的页面专用响应：`view=calculator&sequence=...`。
- 仅返回计算器当前所选场景和插值所需指标，并在该视图中省略逐 worker 遥测数据。
- 推理图表和外部消费者使用的默认原始基准测试 API 响应保持不变。
- 不同精简场景分别使用独立的 React Query 与 Blob 缓存标识。
- 补充后端为前端服务（BFF）例外说明，以及字段投影、API 路由、客户端 URL、缓存键和计算器回归测试。

## 效果

基于仓库中的代表性基准测试 fixture，未压缩响应体缩小：

- `1k/1k`：78.0%
- `1k/8k`：88.2%
- `8k/1k`：78.0%

该优化可减少计算器的数据传输量、浏览器 JSON 解析开销及 React Query 内存占用，同时不改变可复用的原始 API 契约。

## 验证

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- 聚焦单元测试、API 测试及计算器测试：120 项通过
- 计算器 Cypress E2E：66 项通过
- 完整单元测试：3,236 项通过；`visit-tracking.test.ts` 中仍有一项与本改动无关、受时区影响的既有失败（`does NOT increment when a new session happens on the same calendar day`）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped BFF addition with a separate cache namespace; default benchmarks API and inference chart fetching are untouched, with regression tests on projection, routing, URLs, and cache keys.
> 
> **Overview**
> Introduces a **page-owned compact response** on `/api/v1/benchmarks` via `view=calculator&sequence=...`, documented alongside other deliberate BFF exceptions. Valid sequences are `1k/1k`, `1k/8k`, `8k/1k`, and `agentic-traces`; unknown sequences return **400** before hitting the DB.
> 
> The route applies **`toCalculatorBenchmarkRows`**: filter to the requested scenario, drop **`workers`**, and keep only metric keys the calculator interpolation path uses. Results are cached under a separate **`benchmarks-calculator`** blob cache key; the default benchmarks response and inference chart consumers are unchanged.
> 
> **Client plumbing** extends `fetchBenchmarks`, React Query **`benchmarkQueryOptions` / `useBenchmarks`** (sequence-specific cache keys), and **`useThroughputData`** so the calculator requests the compact view per selected sequence instead of full raw rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff367dbb7aab03dbfc7b10e10c7229eec8cae837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->