### PR TITLE
feat(agentic): put the latency percentile selector behind the feature gate / 将延迟百分位选择器移至功能开关之后

### DIFF
--- a/packages/app/cypress/e2e/calculator-overlay.cy.ts
+++ b/packages/app/cypress/e2e/calculator-overlay.cy.ts
@@ -71,7 +71,9 @@ describe('TCO calculator — unofficial run overlay', () => {
       );
       cy.wait('@unofficialRun');
 
-      cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+      // Gate locked here, so the percentile control is absent; the chart still
+      // computes on the P90 default, asserted on the heading below.
+      cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get(BARS).should('have.length', 2);
       cy.get(Y_TICKS).should('contain.text', OVERLAY_RUN_BRANCH);
       cy.get('[data-testid="calculator-chart-section"] h2')

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -2,6 +2,7 @@ import {
   availability as agenticAvailability,
   b300Rows as agenticB300Rows,
 } from '../support/overlay-fixtures';
+import { unlockAgenticGate } from '../support/e2e';
 
 describe('TCO Calculator', () => {
   // ---------------------------------------------------------------------------
@@ -614,6 +615,9 @@ describe('TCO Calculator', () => {
       cy.visit('/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
         onBeforeLoad(win) {
           win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+          // The percentile control sits behind the ↑↑↓↓ gate; unlock it so the
+          // specs below can still exercise switching to P75.
+          unlockAgenticGate(win);
         },
       });
       cy.wait('@agenticBenchmarks');
@@ -663,6 +667,29 @@ describe('TCO Calculator', () => {
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()
         .should('contain.text', 'P75 Interactivity');
+    });
+
+    // AgentX publishes on P90, so the percentile control is insider-only. With
+    // the gate locked it must not render at all, and the calculator must still
+    // compute on P90.
+    it('hides the percentile selector behind the feature gate and defaults to P90', () => {
+      cy.visit('/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
+        onBeforeLoad(win) {
+          win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+          win.localStorage.removeItem('inferencex-feature-gate');
+        },
+      });
+      cy.wait('@agenticBenchmarks');
+
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Traces');
+      cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
+      cy.get('[data-testid="calculator-chart-section"] h2')
+        .first()
+        .should('contain.text', 'P90 Interactivity');
+      cy.get('[data-testid="calculator-controls"]').should(
+        'contain.text',
+        'Target P90 Interactivity',
+      );
     });
   });
 

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -348,6 +348,23 @@ describe('X-axis mode URL param', () => {
       'false',
     );
   });
+
+  // AgentX publishes on P90, so the percentile control is insider-only. With
+  // the gate locked it must not render, and the chart must still plot P90.
+  it('hides the percentile selector behind the feature gate and defaults to P90', () => {
+    interceptAgenticData();
+    interceptDerivedAgenticMetrics();
+    cy.visit('/inference?i_seq=agentic-traces', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        win.localStorage.removeItem('inferencex-feature-gate');
+      },
+    });
+
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('[data-testid="percentile-selector"]').should('not.exist');
+    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'P90');
+  });
 });
 
 describe('Default scenario', () => {

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -3,6 +3,7 @@
 import { track } from '@/lib/analytics';
 import Link from 'next/link';
 import { BarChart3, Table2 } from 'lucide-react';
+import { useFeatureGate } from '@/lib/use-feature-gate';
 import { useLocale } from '@/lib/use-locale';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -354,6 +355,10 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   );
 
   const isAgenticSequence = selectedSequence === Sequence.AgenticTraces;
+  // AgentX publishes on P90, so the percentile control is an insider affordance
+  // rather than a normal filter: it stays behind the ↑↑↓↓ feature gate, matching
+  // the inference chart, and the calculator defaults to P90 without it.
+  const featureGateUnlocked = useFeatureGate();
   const percentileLabel = selectedPercentile.toUpperCase();
 
   /**
@@ -866,7 +871,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                   onOpenChange={handleDropdownOpenChange('sequence')}
                   availableSequences={availableSequences}
                 />
-                {isAgenticSequence && (
+                {isAgenticSequence && featureGateUnlocked && (
                   <PercentileSelector
                     id="calc-percentile"
                     data-testid="calc-percentile-selector"

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -484,7 +484,10 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
             availableSequences={availableSequences}
             data-testid="scenario-selector"
           />
-          {mounted && selectedSequence === Sequence.AgenticTraces && (
+          {/* AgentX publishes on P90, so the percentile control is an insider
+              affordance rather than a normal chart filter: it stays behind the
+              ↑↑↓↓ feature gate and the chart defaults to P90 without it. */}
+          {mounted && selectedSequence === Sequence.AgenticTraces && featureGateUnlocked && (
             <PercentileSelector
               value={selectedPercentile}
               onChange={(p: Percentile) => setSelectedPercentile(p)}


### PR DESCRIPTION
## Summary

Hides the **Latency Percentile** selector on the agentic-coding scenario unless the ↑↑↓↓ konami feature gate is unlocked. Locked users get P90 with no control; unlocking restores the selector and the p75 option exactly as before.

AgentX publishes on P90, so this control is an insider affordance rather than a normal chart filter — the same treatment the gated **Measured Energy** metric group already gets in the same component.

## Scope: both surfaces render it

The screenshot is the inference chart, but `PercentileSelector` has two call sites and both render it for `Sequence.AgenticTraces`:

- `components/inference/ui/ChartControls.tsx` — the one in the screenshot
- `components/calculator/ThroughputCalculatorDisplay.tsx` — the TCO calculator's agentic view

Gating only the first would leave the identical control visible one tab over, so both are gated. `ChartControls` already had `featureGateUnlocked` in scope (for Measured Energy), so it reuses that; the calculator gains the `useFeatureGate` import.

## No default changes were needed

I checked all three places the value could come from, and every one already defaults to p90:

| Source | Default |
|---|---|
| `InferenceContext.tsx` — `useState(() => getUrlParam('i_pctl') \|\| 'p90')` | `p90` |
| `ThroughputCalculatorDisplay.tsx` — seeded from `url-seed.ts` | `p90` |
| `url-state.ts` — `i_pctl` param default | `p90` |

So this is purely a visibility change; no state or URL plumbing moved.

**One edge case worth knowing about, deliberately left as-is:** `?i_pctl=p75` in a URL still applies while the gate is locked, so a shared p75 link reproduces for the recipient and the chart renders P75 with no visible control. Coercing to P90 when locked would silently break shared links between unlocked users, which seemed worse. The same applies if someone unlocks, picks p75, then re-locks via the PowerX/Feedback re-lock button — recoverable with ↑↑↓↓ or by dropping the URL param. Say the word if you'd rather force P90 whenever the gate is locked.

## Tests

Existing percentile coverage is preserved by unlocking the gate where the specs need to drive the control, and new tests cover the gated behavior itself:

- **`ttft-x-axis-toggle.cy.ts`** — already unlocked the gate on its agentic visits, so its p75-switching tests were unaffected. **New test**: with the gate explicitly cleared, `percentile-selector` must not exist and the chart heading must still read P90.
- **`throughput-calculator.cy.ts`** — the agentic `beforeEach` now unlocks the gate so the two p75 tests keep working. **New test**: with the gate cleared, `calc-percentile-selector` must not exist, and both the chart heading and the target-slider label must read P90.
- **`calculator-overlay.cy.ts`** — this spec does not unlock the gate, so its `contain.text 'p90'` assertion became `should('not.exist')`; the pre-existing `P90 Interactivity` heading assertion two lines down still proves the default is applied.

**Ran locally: 105/105 pass** across the three specs (`ttft-x-axis-toggle` 20, `throughput-calculator` 68, `calculator-overlay` 17). Full unit suite **3,763 passed**; `typecheck`, `lint`, `fmt` clean.

Overlay note: verified on the `?unofficialrun=` path too — `calculator-overlay.cy.ts` exercises the agentic overlay with the gate locked and confirms the overlay bars still render and price on P90 without the control.

## 中文说明

在智能体编码（agentic coding）场景下隐藏**延迟百分位**（Latency Percentile）选择器，仅在通过 ↑↑↓↓ konami 功能开关解锁后显示。未解锁的用户直接使用 P90 且看不到该控件；解锁后选择器与 p75 选项的行为与此前完全一致。

AgentX 以 P90 发布结果，因此该控件属于内部人员使用的功能，而非常规图表筛选项——这与同一组件中已受开关控制的 **Measured Energy** 指标分组的处理方式一致。

**覆盖两处界面：** 截图为推理图表，但 `PercentileSelector` 有两个调用点，且都在 `Sequence.AgenticTraces` 下渲染——`ChartControls.tsx`（截图所示）与 `ThroughputCalculatorDisplay.tsx`（TCO 计算器的智能体视图）。若只处理前者，相同控件在相邻标签页仍然可见，因此两处一并隐藏。`ChartControls` 中已有 `featureGateUnlocked`（用于 Measured Energy），此处直接复用；计算器新增 `useFeatureGate` 引入。

**无需改动默认值：** 该值可能来源的三处位置本就均为 p90——`InferenceContext.tsx` 的 `useState(() => getUrlParam('i_pctl') || 'p90')`、计算器经 `url-seed.ts` 的初始值，以及 `url-state.ts` 中 `i_pctl` 参数的默认值。因此本次改动纯粹是可见性调整，未改动任何状态或 URL 逻辑。

**一处刻意保留的边界情况：** 在开关锁定状态下，URL 中的 `?i_pctl=p75` 仍会生效，因此分享的 p75 链接对接收方仍可复现，图表会显示 P75 但没有可见控件。若在锁定时强制回退到 P90，会导致已解锁用户之间分享的链接被静默破坏，权衡后认为后者更糟。同理，若用户解锁后选择 p75 再通过 PowerX／Feedback 的重新锁定按钮上锁，也会出现该状态——可通过 ↑↑↓↓ 重新解锁或去掉 URL 参数恢复。如果你更希望锁定时一律强制 P90，请告知。

**测试：** 通过在需要操作该控件的用例中解锁开关，保留了原有的百分位覆盖；同时新增用例覆盖隐藏行为本身。`ttft-x-axis-toggle.cy.ts` 原本就在智能体访问中解锁，其 p75 切换用例不受影响，并新增"显式清除开关后选择器不存在且图表标题仍为 P90"的用例；`throughput-calculator.cy.ts` 的智能体 `beforeEach` 现会解锁开关以保证两个 p75 用例正常，并新增"清除开关后 `calc-percentile-selector` 不存在，且图表标题与目标滑块标签均为 P90"的用例；`calculator-overlay.cy.ts` 未解锁开关，故其 `contain.text 'p90'` 断言改为 `should('not.exist')`，其下方原有的 `P90 Interactivity` 标题断言仍可证明默认值生效。

本地运行三个 spec 共 **105/105 通过**；完整单元测试 **3,763 项通过**；`typecheck`、`lint`、`fmt` 均通过。覆盖层说明：`?unofficialrun=` 路径同样已验证——`calculator-overlay.cy.ts` 在开关锁定状态下测试智能体覆盖层，确认覆盖层柱状图仍能在 P90 下正常渲染与计价。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility only for an insider control; defaults and URL percentile behavior are intentionally preserved, with broad Cypress coverage.
> 
> **Overview**
> For **Agentic Traces**, the **Latency Percentile** control is now shown only when the ↑↑↓↓ konami **feature gate** is unlocked, on both the inference chart (`ChartControls`) and the TCO calculator (`ThroughputCalculatorDisplay`). Locked users still run on the existing **P90** default (headings, slider labels, and calculations unchanged); unlocking restores **p75** and the selector as before.
> 
> This mirrors how **Measured Energy** is already gated in the same inference controls. URL state (`i_pctl`) is unchanged—shared **p75** links can still apply while the control is hidden.
> 
> **Tests:** Cypress unlocks the gate where specs drive percentile switching; new cases clear `inferencex-feature-gate` and assert the selector is absent while **P90** copy remains. Overlay calculator coverage expects no percentile control with the gate locked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cf9b0e0f422be413e2f1e57caa46d0586683ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->