### PR TITLE
chore(db): purge DSV4 GB300 Dynamo-vLLM AgentX attempt

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -100,6 +100,7 @@ export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new
   [30133534310, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 1P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133535261, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133570824, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P4D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [30231719317, new Set([1])], // 2026-07-27 | DeepSeek-V4 FP4 GB300 Dynamo-vLLM MTP agentic | Reason: Outdated AgentX harness
 ]);
 
 export interface BenchmarkPointKey {


### PR DESCRIPTION
## Summary

- Add run `30231719317`, attempt `1`, to `PURGED_RUN_ATTEMPTS`.
- Record the audit reason as `Outdated AgentX harness`.
- Target only the currently published GB300 Dynamo-vLLM DeepSeek-V4 AgentX attempt and prevent it from being re-ingested.

Source: [InferenceX Actions run 30231719317, attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30231719317/attempts/1)

## Verification

- The workflow run is DeepSeek-V4 FP4 on GB300 with Dynamo-vLLM, MTP, and AgentX workloads.
- A production read-only query found exactly one matching attempt, containing four benchmark rows and no server-log or evaluation rows.
- `bun test packages/db/src/etl/run-overrides.test.ts` (12 passed)
- `bun run lint`
- `bun run fmt`
- `bun run typecheck`

## Impact

After merge, the purge workflow will delete attempt `1`, verify its removal, invalidate affected caches, and warm the relevant routes. This removes the current GB300 Dynamo-vLLM DeepSeek-V4 AgentX series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes published production benchmark data for a specific AgentX series, though via the established purge-overrides path.
> 
> **Overview**
> Adds run `30231719317` attempt `1` to `PURGED_RUN_ATTEMPTS` so the outdated DeepSeek-V4 FP4 GB300 Dynamo-vLLM MTP AgentX results are deleted from production and skipped on future ingest.
> 
> After merge, the override workflow removes that published AgentX series, verifies the DB, and refreshes caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57661ba7f535f1b5d5650d9d7f2a3333c333dbb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->