### PR TITLE
chore(db): clean up AgentX results

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -92,11 +92,13 @@ export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new
   [29413860950, new Set([3])], // 2026-07-16 | DeepSeek-V4 FP4 MI355X SGLang HiCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29445892486, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B200 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29486959583, new Set([2])], // 2026-07-16 | DeepSeek-V4 FP4 B300 vLLM agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29506569772, new Set([2])], // 2026-07-16 | Kimi K2.5 FP4 B300 vLLM MTP agentic | Reason: AgentX is no longer supported for this model
   [29651235293, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang single-node agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29657732517, new Set([1])], // 2026-07-18 | GLM-5.2 FP8 MI325X SGLang 1M agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29682242847, new Set([1])], // 2026-08-07 | GLM-5.2 NVFP4 B300 SGLang agentic HiCache | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29706766201, new Set([5])], // 2026-07-21 | DeepSeek-V4 FP4 B300 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29706772949, new Set([3])], // 2026-07-21 | DeepSeek-V4 FP4 B200 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
+  [29765418393, new Set([5])], // 2026-07-20 | MiniMax M2.7 FP4 B200 SGLang MTP agentic | Reason: AgentX is no longer supported for this model
   [30133534310, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 1P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133535261, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133570824, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P4D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -99,10 +99,14 @@ export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new
   [29706766201, new Set([5])], // 2026-07-21 | DeepSeek-V4 FP4 B300 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29706772949, new Set([3])], // 2026-07-21 | DeepSeek-V4 FP4 B200 vLLM LMCache agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [29765418393, new Set([5])], // 2026-07-20 | MiniMax M2.7 FP4 B200 SGLang MTP agentic | Reason: AgentX is no longer supported for this model
+  [29778042138, new Set([1])], // 2026-07-21 | DeepSeek-V4 FP4 B300 vLLM MTP agentic | Reason: Outdated AgentX harness; corrected by v1+ runs 31192604550 and 31415828111
+  [29778042858, new Set([2])], // 2026-07-22 | DeepSeek-V4 FP4 B200 vLLM MTP agentic | Reason: Outdated AgentX harness; corrected by v1+ run 31192602558
   [30133534310, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 1P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133535261, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P2D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30133570824, new Set([1])], // 2026-07-24 | GLM-5.2 FP8 H200 Dynamo-SGLang 2P4D agentic | Reason: Non MTP which we aren't focusing on for AgentX as well as outdated AgentX harness
   [30231719317, new Set([1])], // 2026-07-27 | DeepSeek-V4 FP4 GB300 Dynamo-vLLM MTP agentic | Reason: Outdated AgentX harness
+  [30391410523, new Set([1])], // 2026-07-30 | Qwen3.5 FP4 GB300 Dynamo-SGLang MTP agentic | Reason: Outdated AgentX harness; corrected by v1+ run 31042542308
+  [30425131777, new Set([3])], // 2026-07-30 | Kimi K3 FP4 B300 vLLM MTP agentic | Reason: Outdated AgentX harness
 ]);
 
 export interface BenchmarkPointKey {


### PR DESCRIPTION
## Summary

Purge these exact production attempts:

- Kimi K2.5 FP4 B300 vLLM MTP: run 29506569772, attempt 2 — AgentX is no longer supported for this model.
- MiniMax M2.7 FP4 B200 SGLang MTP: run 29765418393, attempt 5 — AgentX is no longer supported for this model.
- DeepSeek V4 FP4 B300 vLLM MTP: run 29778042138, attempt 1 — outdated AgentX harness; corrected by v1+ runs 31192604550 and 31415828111.
- DeepSeek V4 FP4 B200 vLLM MTP: run 29778042858, attempt 2 — outdated AgentX harness; corrected by v1+ run 31192602558.
- Qwen3.5 FP4 GB300 Dynamo-SGLang MTP: run 30391410523, attempt 1 — outdated AgentX harness; corrected by v1+ run 31042542308.
- Kimi K3 FP4 B300 vLLM MTP: run 30425131777, attempt 3 — outdated AgentX harness.

Only the listed old attempts are purged. The corrected v1+ runs are explicitly preserved. The overrides prevent future re-ingestion and are applied automatically to production after merge.

## Upstream cleanup

- SemiAnalysisAI/InferenceX#2561

The four newly added outdated-harness purges do not remove their upstream configurations.

## Validation

Checks were not rerun for the follow-up additions, per request. The original change passed the purge override tests, lint, formatting, and typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes specific production benchmark attempts via the override pipeline. Risk is limited to wrong run/attempt IDs being purged, with CI verification after merge.
> 
> **Overview**
> Adds **6 purge overrides** to `PURGED_RUN_ATTEMPTS` so specific AgentX benchmark attempts are deleted from production and blocked from re-ingest.
> 
> Two attempts are purged because **AgentX is no longer supported** for those models (Kimi K2.5, MiniMax M2.7). Four more are purged for an **outdated AgentX harness**, with several noting corrected replacement runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d823952664b8a8afcdd95b3821ffb1a1059020b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->