### PR TITLE
Sync staging database from production every three days

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -40,6 +40,12 @@ on:
 
 permissions: {}
 
+concurrency:
+  # Do not ingest staged benchmark runs while the scheduled production restore
+  # is replacing the shared staging database (or vice versa).
+  group: staging-database-maintenance
+  cancel-in-progress: false
+
 jobs:
   validate:
     name: Validate staging request

--- a/.github/workflows/sync-staging-database.yml
+++ b/.github/workflows/sync-staging-database.yml
@@ -1,0 +1,130 @@
+name: Sync staging database
+
+on:
+  # GitHub cron has no true "every N days" interval: */3 in day-of-month
+  # restarts at each month boundary. Run daily at 04:00 Central and use the
+  # preflight job's epoch-day guard to keep an exact three-calendar-day cadence.
+  schedule:
+    - cron: '0 4 * * *'
+      timezone: America/Chicago
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: staging-database-maintenance
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Check three-day cadence
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      should-sync: ${{ steps.cadence.outputs.should-sync }}
+    steps:
+      - name: Check schedule
+        id: cadence
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "should-sync=true" >> "$GITHUB_OUTPUT"
+            echo "Manual run requested; bypassing the cadence guard."
+            exit 0
+          fi
+
+          epoch_day=$(( $(date -u +%s) / 86400 ))
+          if (( epoch_day % 3 == 0 )); then
+            echo "should-sync=true" >> "$GITHUB_OUTPUT"
+            echo "This is a scheduled sync day."
+          else
+            echo "should-sync=false" >> "$GITHUB_OUTPUT"
+            echo "Not a scheduled sync day; the next daily trigger will check again."
+          fi
+
+  sync:
+    name: Restore staging from production
+    needs: preflight
+    if: needs.preflight.outputs.should-sync == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions: {}
+    steps:
+      - name: Restore staging from production head
+        env:
+          NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
+          NEON_PROJECT_ID: ${{ secrets.NEON_PROJECT_ID }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$NEON_API_KEY" ] || [ -z "$NEON_PROJECT_ID" ]; then
+            echo "::error::NEON_API_KEY and NEON_PROJECT_ID are required"
+            exit 1
+          fi
+
+          api="https://console.neon.tech/api/v2/projects/$NEON_PROJECT_ID"
+          branches=$(curl --retry 3 --retry-all-errors -sSf \
+            -H "Authorization: Bearer $NEON_API_KEY" \
+            "$api/branches?limit=100")
+          production_branch_id=$(jq -r '.branches[] | select(.default == true) | .id' <<<"$branches" | head -n 1)
+          staging_branch_id=$(jq -r '.branches[] | select(.name == "staging") | .id' <<<"$branches" | head -n 1)
+
+          if [ -z "$production_branch_id" ] || [ "$production_branch_id" = "null" ]; then
+            echo "::error::Neon default production branch was not found"
+            exit 1
+          fi
+          if [ -z "$staging_branch_id" ] || [ "$staging_branch_id" = "null" ]; then
+            echo "::error::Neon branch named staging was not found"
+            exit 1
+          fi
+          if [ "$production_branch_id" = "$staging_branch_id" ]; then
+            echo "::error::Refusing to restore the production branch"
+            exit 1
+          fi
+
+          payload=$(jq -cn \
+            --arg source_branch_id "$production_branch_id" \
+            '{source_branch_id: $source_branch_id}')
+          # Do not automatically retry this non-idempotent restore request. If
+          # the response is lost, another POST could start a second restore.
+          curl -sSf -X POST \
+            -H "Authorization: Bearer $NEON_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "$api/branches/$staging_branch_id/restore" >/dev/null
+
+          for attempt in $(seq 1 60); do
+            branch=$(curl --retry 3 --retry-all-errors -sSf \
+              -H "Authorization: Bearer $NEON_API_KEY" \
+              "$api/branches/$staging_branch_id")
+            state=$(jq -r '.branch.current_state' <<<"$branch")
+            pending=$(jq -r '.branch.pending_state // empty' <<<"$branch")
+            if [ "$state" = "ready" ] && [ -z "$pending" ]; then
+              echo "Neon staging branch is synced and ready."
+              exit 0
+            fi
+            echo "Waiting for Neon staging branch (state=$state, pending=${pending:-none}, attempt=$attempt/60)"
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for the Neon staging branch restore"
+          exit 1
+
+      - name: Invalidate staging cache
+        env:
+          STAGING_SITE_URL: ${{ vars.STAGING_SITE_URL }}
+          VERCEL_STAGING_BYPASS_SECRET: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$STAGING_SITE_URL" ] || [ -z "$VERCEL_STAGING_BYPASS_SECRET" ]; then
+            echo "::error::STAGING_SITE_URL and VERCEL_STAGING_BYPASS_SECRET are required"
+            exit 1
+          fi
+
+          curl --retry 3 --retry-all-errors -sSf -X POST \
+            "${STAGING_SITE_URL%/}/api/v1/invalidate" \
+            -H "x-vercel-protection-bypass: $VERCEL_STAGING_BYPASS_SECRET"


### PR DESCRIPTION
## Summary

- add a scheduled GitHub Actions workflow that restores the Neon `staging` branch from the default production branch every three calendar days at 4:00 AM America/Chicago time
- wait for Neon to report the restored branch ready, then invalidate the protected staging deployment cache
- add a shared concurrency lock so scheduled restores cannot race the existing staged-results ingest workflow
- support manual workflow runs for on-demand synchronization

## Why

The staging database accumulates staged benchmark runs and can drift from production. Periodically replacing it from the production head gives staging a predictable, complete baseline while preserving the existing production branch and connection endpoints.

GitHub cron does not provide a true every-N-days interval: `*/3` in the day-of-month field resets at month boundaries. The workflow therefore triggers daily at 4:00 AM Central and uses an epoch-day modulo guard to perform the restore on an exact three-calendar-day cadence. `timezone: America/Chicago` keeps the wall-clock time at 4:00 AM across daylight-saving changes.

## Validation

- `actionlint .github/workflows/stage-results.yml .github/workflows/sync-staging-database.yml`
- `uvx --exclude-newer P1D zizmor@latest --strict-collection --pedantic --no-ignores .github/workflows/stage-results.yml .github/workflows/sync-staging-database.yml`
- pre-commit formatting, lint, and TypeScript checks
- no live database restore was performed
- full E2E tests were not run because the change is limited to GitHub Actions workflows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Periodically wipes and replaces the shared staging database via Neon restore APIs; production is guarded, but a bad restore or race would disrupt staging data and ingest.
> 
> **Overview**
> Adds a scheduled workflow that **restores the Neon `staging` branch from production** every three calendar days (daily 4:00 AM Central trigger with an epoch-day guard), then invalidates the staging site cache. Manual `workflow_dispatch` runs bypass the cadence check.
> 
> Locks `stage-results` and the new sync workflow behind a shared `staging-database-maintenance` concurrency group so restores and staged-run ingest cannot overlap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea47d2de182ef0a4acd5349c8f59851372ec2c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->