### PR TITLE
Report staging workflow link at startup

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -114,6 +114,32 @@ jobs:
             echo "reset-staging-database=$RESET_STAGING_DATABASE"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Report staging start
+        env:
+          RUN_ID: ${{ steps.request.outputs.run-id }}
+          RUN_DATE: ${{ steps.request.outputs.run-date }}
+          PR_NUMBER: ${{ steps.request.outputs.pr-number }}
+          REQUESTED_BY: ${{ steps.request.outputs.requested-by }}
+          COMMENT_ID: ${{ steps.request.outputs.comment-id }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'SemiAnalysisAI',
+              repo: 'InferenceX',
+              event_type: 'stage-results-started',
+              client_payload: {
+                'source-repository': `${context.repo.owner}/${context.repo.repo}`,
+                'pr-number': process.env.PR_NUMBER,
+                'run-id': process.env.RUN_ID,
+                'run-date': process.env.RUN_DATE,
+                'requested-by': process.env.REQUESTED_BY,
+                'comment-id': process.env.COMMENT_ID,
+                'app-run-id': String(context.runId),
+              },
+            });
+
   sync-staging-branch:
     name: Fast-forward Git staging branch
     needs: validate


### PR DESCRIPTION
## Summary

- dispatch a `stage-results-started` callback to InferenceX immediately after the staging request payload is validated
- include the InferenceX-app Actions run ID so the original PR acknowledgment comment can link to the live staging workflow before ingest begins
- keep the existing completion callback unchanged

## Coordination

This is paired with the InferenceX PR that accepts `stage-results-started` and edits the original staging acknowledgment. Merge the InferenceX receiver PR first, then this sender PR.

## Validation

- pre-commit formatting, lint, and TypeScript checks
- `actionlint .github/workflows/stage-results.yml`
- `uvx --exclude-newer P1D zizmor@latest --strict-collection --pedantic --no-ignores .github/workflows/stage-results.yml`
- `git diff --check`
- no full E2E suite was run because the change is limited to a GitHub Actions callback

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive GitHub Actions callback that mirrors the existing completion dispatch; no changes to staging, ingest, or database logic.
> 
> **Overview**
> Dispatches a **`stage-results-started`** callback to InferenceX right after the staging request is validated, so the original PR acknowledgment can link to the live staging workflow before ingest begins.
> 
> The new step in `validate` sends the same request metadata as the existing completion callback, plus `app-run-id`. The **`stage-results-completed`** path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc836d74505802f52f4f5aa5fe08e6d8d2e92e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->