### PR TITLE
feat(inference): split gradient labels by KV offload state / 渐变标签按 KV 卸载状态区分渐变与标签

### DIFF
--- a/packages/app/src/components/inference/utils/pareto-labels.test.ts
+++ b/packages/app/src/components/inference/utils/pareto-labels.test.ts
@@ -74,6 +74,37 @@ describe('getParetoLabel', () => {
     expect(getParetoLabel(point)).toBe('TP1');
   });
 
+  it('appends "+KV" when kv_offloading tier is set', () => {
+    const point = makePoint({ tp: 4, kv_offloading: 'dram' });
+    expect(getParetoLabel(point)).toBe('TP4+KV');
+  });
+
+  it('does not append "+KV" when kv_offloading is "none"', () => {
+    const point = makePoint({ tp: 4, kv_offloading: 'none' });
+    expect(getParetoLabel(point)).toBe('TP4');
+  });
+
+  it('appends "+KV" for legacy offload_mode="on" rows', () => {
+    const point = makePoint({ tp: 8, offload_mode: 'on' });
+    expect(getParetoLabel(point)).toBe('TP8+KV');
+  });
+
+  it('does not append "+KV" for legacy offload_mode="off" rows', () => {
+    const point = makePoint({ tp: 8, offload_mode: 'off' });
+    expect(getParetoLabel(point)).toBe('TP8');
+  });
+
+  it('appends "+KV" to full parallelism labels too', () => {
+    const point = makePoint({ tp: 8, ep: 8, dp_attention: true, kv_offloading: 'dram' });
+    expect(getParetoLabel(point)).toBe('DEP8+KV');
+  });
+
+  it('kv_offloading="none" wins over legacy offload_mode="on"', () => {
+    // Current metadata must not be overridden by the legacy fallback
+    const point = makePoint({ tp: 4, kv_offloading: 'none', offload_mode: 'on' });
+    expect(getParetoLabel(point)).toBe('TP4');
+  });
+
   it('handles multinode disagg format with "TP" prefix stripped', () => {
     const point = makePoint({
       tp: 8,
@@ -118,6 +149,11 @@ describe('parseLabelComponents', () => {
   it('parses mixed multi-node labels', () => {
     expect(parseLabelComponents('2xEP4+1xDPAEP32')).toEqual(['EP4', 'DPAEP32']);
   });
+
+  it('parses the KV offload marker as its own component', () => {
+    expect(parseLabelComponents('TP8+KV')).toEqual(['TP8', 'KV']);
+    expect(parseLabelComponents('2xEP4+1xDPAEP32+KV')).toEqual(['EP4', 'DPAEP32', 'KV']);
+  });
 });
 
 describe('labelSimilarity', () => {
@@ -136,6 +172,11 @@ describe('labelSimilarity', () => {
     // Shared: DPAEP4 (1), All unique: DPAEP4, DPAEP32, DPAEP16 (3)
     const sim = labelSimilarity('1xDPAEP4+1xDPAEP32', '1xDPAEP4+1xDPAEP16');
     expect(sim).toBeCloseTo(1 / 3);
+  });
+
+  it('returns partial similarity between offload-on and offload-off of the same parallelism', () => {
+    // "TP8" → ["TP8"], "TP8+KV" → ["TP8", "KV"]; shared TP8 → 1/2
+    expect(labelSimilarity('TP8', 'TP8+KV')).toBeCloseTo(0.5);
   });
 
   it('returns higher similarity for more shared components', () => {

--- a/packages/app/src/components/inference/utils/pareto-labels.test.ts
+++ b/packages/app/src/components/inference/utils/pareto-labels.test.ts
@@ -74,29 +74,29 @@ describe('getParetoLabel', () => {
     expect(getParetoLabel(point)).toBe('TP1');
   });
 
-  it('appends "+KV" when kv_offloading tier is set', () => {
+  it('appends "+ CPU KV Offloading" when kv_offloading tier is set', () => {
     const point = makePoint({ tp: 4, kv_offloading: 'dram' });
-    expect(getParetoLabel(point)).toBe('TP4+KV');
+    expect(getParetoLabel(point)).toBe('TP4 + CPU KV Offloading');
   });
 
-  it('does not append "+KV" when kv_offloading is "none"', () => {
+  it('does not append "+ CPU KV Offloading" when kv_offloading is "none"', () => {
     const point = makePoint({ tp: 4, kv_offloading: 'none' });
     expect(getParetoLabel(point)).toBe('TP4');
   });
 
-  it('appends "+KV" for legacy offload_mode="on" rows', () => {
+  it('appends "+ CPU KV Offloading" for legacy offload_mode="on" rows', () => {
     const point = makePoint({ tp: 8, offload_mode: 'on' });
-    expect(getParetoLabel(point)).toBe('TP8+KV');
+    expect(getParetoLabel(point)).toBe('TP8 + CPU KV Offloading');
   });
 
-  it('does not append "+KV" for legacy offload_mode="off" rows', () => {
+  it('does not append "+ CPU KV Offloading" for legacy offload_mode="off" rows', () => {
     const point = makePoint({ tp: 8, offload_mode: 'off' });
     expect(getParetoLabel(point)).toBe('TP8');
   });
 
-  it('appends "+KV" to full parallelism labels too', () => {
+  it('appends "+ CPU KV Offloading" to full parallelism labels too', () => {
     const point = makePoint({ tp: 8, ep: 8, dp_attention: true, kv_offloading: 'dram' });
-    expect(getParetoLabel(point)).toBe('DEP8+KV');
+    expect(getParetoLabel(point)).toBe('DEP8 + CPU KV Offloading');
   });
 
   it('kv_offloading="none" wins over legacy offload_mode="on"', () => {
@@ -151,8 +151,12 @@ describe('parseLabelComponents', () => {
   });
 
   it('parses the KV offload marker as its own component', () => {
-    expect(parseLabelComponents('TP8+KV')).toEqual(['TP8', 'KV']);
-    expect(parseLabelComponents('2xEP4+1xDPAEP32+KV')).toEqual(['EP4', 'DPAEP32', 'KV']);
+    expect(parseLabelComponents('TP8 + CPU KV Offloading')).toEqual(['TP8', 'CPU KV Offloading']);
+    expect(parseLabelComponents('2xEP4+1xDPAEP32 + CPU KV Offloading')).toEqual([
+      'EP4',
+      'DPAEP32',
+      'CPU KV Offloading',
+    ]);
   });
 });
 
@@ -175,8 +179,9 @@ describe('labelSimilarity', () => {
   });
 
   it('returns partial similarity between offload-on and offload-off of the same parallelism', () => {
-    // "TP8" → ["TP8"], "TP8+KV" → ["TP8", "KV"]; shared TP8 → 1/2
-    expect(labelSimilarity('TP8', 'TP8+KV')).toBeCloseTo(0.5);
+    // "TP8" → ["TP8"], "TP8 + CPU KV Offloading" → ["TP8", "CPU KV Offloading"];
+    // shared TP8 → 1/2
+    expect(labelSimilarity('TP8', 'TP8 + CPU KV Offloading')).toBeCloseTo(0.5);
   });
 
   it('returns higher similarity for more shared components', () => {

--- a/packages/app/src/components/inference/utils/paretoLabels.ts
+++ b/packages/app/src/components/inference/utils/paretoLabels.ts
@@ -29,15 +29,15 @@ export interface ParetoPointLabel {
  * offload-on/off transitions of the same parallelism a partial
  * {@link labelSimilarity} (smooth-ish gradient blend) instead of 0.
  */
-export const KV_OFFLOAD_LABEL_SUFFIX = '+KV';
+export const KV_OFFLOAD_LABEL_SUFFIX = ' + CPU KV Offloading';
 
 /**
  * Returns a Pareto frontier label for a data point.
  * Always prefixes with "TP" for simple numeric labels (legacy data without ep).
  * For data with ep/dp_attention, uses the full parallelism label.
- * Points that ran with KV offload enabled get a "+KV" suffix so gradient
- * segments and pill labels distinguish offload-on from offload-off, matching
- * the dashed-halo point decoration.
+ * Points that ran with KV offload enabled get a " + CPU KV Offloading"
+ * suffix so gradient segments and pill labels distinguish offload-on from
+ * offload-off, matching the dashed-halo point decoration.
  */
 export const getParetoLabel = (d: InferenceData): string => {
   const label = getPointLabel(d);
@@ -51,12 +51,14 @@ export const getParetoLabel = (d: InferenceData): string => {
  * E.g. "1xDPAEP4+1xDPAEP32" → ["DPAEP4", "DPAEP32"]
  * E.g. "TP8" → ["TP8"], "TEP8" → ["TEP8"], "DEP8" → ["DEP8"]
  * E.g. "2xEP4+1xDPAEP32" → ["EP4", "DPAEP32"]
- * E.g. "TP8+KV" → ["TP8", "KV"] (KV offload marker counts as a component,
- * so "TP8" vs "TP8+KV" share TP8 and blend at the boundary)
+ * E.g. "TP8 + CPU KV Offloading" → ["TP8", "CPU KV Offloading"] (the KV
+ * offload marker counts as a component, so "TP8" vs "TP8 + CPU KV Offloading"
+ * share TP8 and blend at the boundary)
  */
 export const parseLabelComponents = (label: string): string[] => {
-  // Split multinode labels on "+"
-  const parts = label.split('+');
+  // Split multinode labels on "+" (trim so the spaced KV-offload suffix
+  // yields clean components that match their unspaced counterparts)
+  const parts = label.split('+').map((p) => p.trim());
   return parts.map((p) => {
     // Strip the leading "NxNNN" multiplier (e.g., "1x" or "3x")
     const match = p.match(/^\d+x(?<strategy>.+)$/u);

--- a/packages/app/src/components/inference/utils/paretoLabels.ts
+++ b/packages/app/src/components/inference/utils/paretoLabels.ts
@@ -1,5 +1,6 @@
 import type { InferenceData } from '@/components/inference/types';
 import { getPointLabel } from '@/components/inference/utils/tooltipUtils';
+import { isKvOffloadEnabled } from '@/lib/kv-offload';
 
 // Color palette for Pareto frontier section labels
 export const PARETO_LABEL_COLORS = [
@@ -22,17 +23,27 @@ export interface ParetoPointLabel {
 }
 
 /**
+ * Suffix appended to the Pareto label when a point ran with KV cache
+ * offloading enabled. Uses the "+" separator so it parses as its own
+ * sub-strategy component in {@link parseLabelComponents}, which gives
+ * offload-on/off transitions of the same parallelism a partial
+ * {@link labelSimilarity} (smooth-ish gradient blend) instead of 0.
+ */
+export const KV_OFFLOAD_LABEL_SUFFIX = '+KV';
+
+/**
  * Returns a Pareto frontier label for a data point.
  * Always prefixes with "TP" for simple numeric labels (legacy data without ep).
  * For data with ep/dp_attention, uses the full parallelism label.
+ * Points that ran with KV offload enabled get a "+KV" suffix so gradient
+ * segments and pill labels distinguish offload-on from offload-off, matching
+ * the dashed-halo point decoration.
  */
 export const getParetoLabel = (d: InferenceData): string => {
   const label = getPointLabel(d);
   // If the label is just a number (no parallelism info), prefix with "TP"
-  if (/^\d+$/u.test(label)) {
-    return `TP${label}`;
-  }
-  return label;
+  const base = /^\d+$/u.test(label) ? `TP${label}` : label;
+  return isKvOffloadEnabled(d) ? `${base}${KV_OFFLOAD_LABEL_SUFFIX}` : base;
 };
 
 /**
@@ -40,6 +51,8 @@ export const getParetoLabel = (d: InferenceData): string => {
  * E.g. "1xDPAEP4+1xDPAEP32" → ["DPAEP4", "DPAEP32"]
  * E.g. "TP8" → ["TP8"], "TEP8" → ["TEP8"], "DEP8" → ["DEP8"]
  * E.g. "2xEP4+1xDPAEP32" → ["EP4", "DPAEP32"]
+ * E.g. "TP8+KV" → ["TP8", "KV"] (KV offload marker counts as a component,
+ * so "TP8" vs "TP8+KV" share TP8 and blend at the boundary)
  */
 export const parseLabelComponents = (label: string): string[] => {
   // Split multinode labels on "+"


### PR DESCRIPTION
## Summary

AgentX UX feedback in Slack: gradient labels should produce **different gradients and different labels when KV offload is on versus off**. Today the whole gradient-label pipeline keys off the parallelism-only Pareto label, so offload-on and offload-off points with the same config (e.g. `TP4`) collapse into one color territory and one pill — the only offload cue is the dashed halo.

## Changes

- `getParetoLabel` now appends a ` + CPU KV Offloading` suffix when the point ran with KV cache offloading enabled, resolved through the canonical `isKvOffloadEnabled` helper (`kv_offloading` tier first, legacy `offload_mode` fallback).
- Because gradient stop computation, segment pill labels, and gradient point coloring all key off this label, offload-on runs automatically get:
  - a **distinct gradient color territory** on the roofline,
  - a **distinct pill label** (`TP4 + CPU KV Offloading` vs `TP4`),
  - **distinct point colors** when gradient labels are enabled.
- The offload marker parses as its own sub-strategy component in `parseLabelComponents`, so `TP4` → `TP4 + CPU KV Offloading` transitions get 0.5 `labelSimilarity` and a smooth blend zone at the boundary instead of a hard cut.
- Unit tests: new coverage for the offload suffix (tier, legacy fallback, `none` precedence), component parsing, and boundary similarity.

## Testing

- `bun run typecheck` ✅
- `bun run lint` / `bun run fmt` ✅
- `vitest` inference component suite: 587 tests pass (41 in `pareto-labels.test.ts`, including 9 new) ✅

## 中文说明

Slack 中对 AgentX UX 的反馈：渐变标签（Gradient Labels）应当在 KV 卸载开启与关闭时显示**不同的渐变和不同的标签**。目前整个渐变标签管线仅以并行策略生成 Pareto 标签，因此同一配置（例如 `TP4`）下卸载开启与关闭的数据点会合并为同一个颜色区段和同一个标签胶囊，唯一的卸载提示只有虚线光环。

主要改动：

- `getParetoLabel` 在数据点启用 KV cache 卸载时追加 ` + CPU KV Offloading` 后缀，通过规范的 `isKvOffloadEnabled` 辅助函数判定（优先 `kv_offloading` 层级，兼容旧的 `offload_mode` 字段）。
- 由于渐变色标计算、区段标签胶囊和渐变点着色均以该标签为键，启用卸载的运行会自动获得独立的渐变颜色区段、独立的标签胶囊（`TP4 + CPU KV Offloading` 对比 `TP4`）以及独立的点颜色。
- 卸载标记在 `parseLabelComponents` 中被解析为独立的子策略组件，因此 `TP4` → `TP4 + CPU KV Offloading` 的边界会以 0.5 相似度平滑过渡，而不是生硬切换。
- 单元测试：新增对卸载后缀（层级、旧字段回退、`none` 优先级）、组件解析和边界相似度的覆盖。

测试：typecheck、lint、格式检查均通过；inference 组件 vitest 套件 587 个测试全部通过（其中 `pareto-labels.test.ts` 41 个，含 9 个新增）。
