### PR TITLE
chore(quotes)optimize save on  landing quote carousel but still keep in /supporters route

### DIFF
--- a/packages/app/src/components/quotes/quotes-data.test.ts
+++ b/packages/app/src/components/quotes/quotes-data.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { CAROUSEL_LABELS, CAROUSEL_ORGS, QUOTES } from './quotes-data';
+
+/**
+ * The landing carousel renders `QUOTES` filtered by `CAROUSEL_ORGS`, while the
+ * /quotes page renders every entry in `QUOTES`. That split is what lets a
+ * supporter come off the carousel without being dropped from the site, so it is
+ * asserted here rather than left implicit.
+ */
+const OFF_CAROUSEL_ONLY = ['Together AI', 'Nebius', 'White House', 'UC San Diego'] as const;
+
+describe('quote carousel membership', () => {
+  it('keeps every carousel org backed by a real quote', () => {
+    const quotedOrgs = new Set(QUOTES.map((quote) => quote.org));
+    for (const org of CAROUSEL_ORGS) {
+      expect(quotedOrgs.has(org), `${org} is in CAROUSEL_ORGS but has no quote`).toBe(true);
+    }
+  });
+
+  it('lists each carousel org once', () => {
+    expect(new Set(CAROUSEL_ORGS).size).toBe(CAROUSEL_ORGS.length);
+  });
+
+  it.each(OFF_CAROUSEL_ONLY)('excludes %s from the carousel', (org) => {
+    expect((CAROUSEL_ORGS as readonly string[]).includes(org)).toBe(false);
+  });
+
+  it.each(OFF_CAROUSEL_ONLY)('still shows %s on the quotes page', (org) => {
+    expect(QUOTES.some((quote) => quote.org === org)).toBe(true);
+  });
+
+  it('resolves carousel display labels for the orgs that use them', () => {
+    // Overrides may outlive carousel membership (see the note in quotes-data),
+    // so only assert that active carousel orgs resolve to a non-empty label.
+    for (const org of CAROUSEL_ORGS) {
+      expect(CAROUSEL_LABELS[org] ?? org).not.toBe('');
+    }
+  });
+});

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -518,26 +518,28 @@ export const CAROUSEL_ORGS = [
   'Microsoft',
   'Meta Superintelligence Labs',
   'Oracle',
-  'Together AI',
   'vLLM',
   'GPU Mode',
   'PyTorch Foundation',
   'CoreWeave',
-  'Nebius',
   'TensorWave',
   'SGLang',
   'WEKA',
   'Stanford',
   'Hugging Face',
   'Lambda',
-  'UC San Diego',
   'Red Hat',
-  'White House',
   'SambaNova',
   'TileRT',
 ] as const;
 
-/** Display label overrides for carousel orgs. */
+/**
+ * Display label overrides for carousel orgs.
+ *
+ * `Together AI` is not currently in CAROUSEL_ORGS, so its override is inert —
+ * it is kept so the card reads "Tri Dao" rather than "Together AI" if the org
+ * is added back to the carousel.
+ */
 export const CAROUSEL_LABELS: Record<string, string> = {
   'Together AI': 'Tri Dao',
   'PyTorch Foundation': 'PyTorch',


### PR DESCRIPTION
## Summary

Removes four orgs from the landing-page quote carousel while keeping their quotes on the quotes page:

- **Together AI** — rendered as **Tri Dao** via `CAROUSEL_LABELS`
- **Nebius**
- **White House**
- **UC San Diego**

⚠️ **Count check:** the request said "3 less" but named four orgs. I removed all four as listed, since the names were unambiguous. Say the word if one of them should stay and I'll restore it — it's a one-line revert.

## How the split works

The landing carousel renders `QUOTES` filtered by the `CAROUSEL_ORGS` allowlist (`intro-section.tsx`), while `/quotes` renders **every** entry in `QUOTES` (`quotes-content.tsx`). So trimming the allowlist takes a supporter off the carousel without dropping them from the site — no quote text was touched, and `QUOTES` is byte-identical.

The `'Together AI' -> 'Tri Dao'` entry in `CAROUSEL_LABELS` is intentionally **left in place** and annotated as inert. Deleting it would silently lose the display name if the org is ever added back to the carousel, and it costs nothing while unused. Easy to drop if you'd rather have zero dead config.

## Verification

Rendered both pages on a local fixtures server and grepped the **rendered text only** (stripping `<script>`, since the label dictionary is serialized into the RSC payload and produces a misleading raw-HTML match for "Tri Dao"):

| Org | Landing (carousel) | `/quotes` | `/zh/quotes` |
| --- | --- | --- | --- |
| Tri Dao / Together AI | **0** | 1 | 1 |
| Nebius | **0** | 2 | 2 |
| White House | **0** | 1 | 1 |
| UC San Diego | **0** | 1 | 1 |
| CoreWeave *(control)* | 3 | — | — |
| SambaNova *(control)* | 2 | — | — |
| PyTorch *(control)* | 6 | — | — |

Retained orgs still render on the landing page, so the carousel itself is intact rather than broken.

## Tests

New `quotes-data.test.ts` (11 cases) locks the contract that was previously implicit:

- every org in `CAROUSEL_ORGS` is backed by a real quote (catches a typo'd allowlist entry silently dropping a card)
- no duplicate carousel orgs
- each of the four removed orgs is **absent** from `CAROUSEL_ORGS`
- each of the four is **still present** in `QUOTES`, so they stay on the quotes page
- active carousel orgs resolve to a non-empty display label

`bun run test:unit` — **3,838 passed**, 0 failed. `typecheck`, `lint`, `fmt` clean.

No `/zh` page work was needed: the Chinese quotes page renders from the same `QUOTES` array and already carries `textZh`.

## 中文说明

从落地页引用轮播中移除四个组织，同时保留其在引用页上的内容：**Together AI**（通过 `CAROUSEL_LABELS` 显示为 **Tri Dao**）、**Nebius**、**White House**、**UC San Diego**。

⚠️ **数量核对：** 需求中写的是"减少 3 个"，但实际列出了四个组织名。由于名称明确无歧义，我按所列的四个全部移除。如果其中某一个应当保留，请告知，恢复只需改一行。

**机制说明：** 落地页轮播渲染的是经 `CAROUSEL_ORGS` 白名单过滤后的 `QUOTES`（见 `intro-section.tsx`），而 `/quotes` 渲染 `QUOTES` 中的**全部**条目（见 `quotes-content.tsx`）。因此仅调整白名单，即可让支持者从轮播中移除而不从站点上消失；引用文本未作任何改动，`QUOTES` 与改动前完全一致。`CAROUSEL_LABELS` 中 `'Together AI' -> 'Tri Dao'` 的映射有意保留并加注说明其当前未生效——若删除，该组织日后重新加入轮播时会静默丢失展示名，而保留它在未使用时没有任何代价。如希望不留任何无用配置，可随时删除。

**验证：** 在本地 fixtures 服务器上渲染两个页面，并仅对**渲染后的文本**进行检索（剔除 `<script>`，因为标签字典会被序列化进 RSC payload，直接检索原始 HTML 会对 "Tri Dao" 产生误报）。结果：四个组织在落地页的渲染次数均为 **0**，在 `/quotes` 与 `/zh/quotes` 上均正常显示；作为对照，CoreWeave、SambaNova、PyTorch 等保留组织在落地页仍正常渲染，说明轮播本身未被破坏。

**测试：** 新增 `quotes-data.test.ts`（11 个用例），将此前隐含的约定固化下来：`CAROUSEL_ORGS` 中的每个组织都必须有对应引用（可捕获白名单拼写错误导致卡片静默消失的情况）；轮播组织不得重复；上述四个组织必须不在 `CAROUSEL_ORGS` 中；四者必须仍存在于 `QUOTES` 中，以保证引用页正常显示；处于轮播中的组织必须能解析出非空展示名。`bun run test:unit` 3,838 项全部通过；`typecheck`、`lint`、`fmt` 均通过。无需额外的 `/zh` 改动：中文引用页读取同一份 `QUOTES` 数组，且已包含 `textZh`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/content configuration only—no auth, APIs, or quote data edits; FAQ supporter text updates automatically with the shorter carousel list.
> 
> **Overview**
> **Shrinks the landing quote carousel** by removing four organizations from the `CAROUSEL_ORGS` allowlist: Together AI, Nebius, White House, and UC San Diego. Quote text in `QUOTES` is unchanged; the landing carousel still filters `QUOTES` by that list (`intro-section.tsx`), while `/quotes` still shows every entry.
> 
> **Documents and preserves config:** a comment on `CAROUSEL_LABELS` explains that the `'Together AI' → 'Tri Dao'` override stays even though Together AI is no longer on the carousel, so re-adding the org would still show Tri Dao on the card.
> 
> **Adds `quotes-data.test.ts`** to lock in behavior: carousel orgs must exist in `QUOTES`, must be unique, the four removed orgs must be off the carousel but still in `QUOTES`, and active carousel orgs must resolve to non-empty display labels.
> 
> **Side effect:** FAQ supporter lists built from `CAROUSEL_ORGS` (`faq-data.ts` / `faq-data-zh.ts`) will no longer mention these four orgs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73a05589eccea52a0e9819c654ad840d62fc7c76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->