### PR TITLE
feat(agentic): nest the latency x-axis modes under an Advanced menu / 智能体场景下将延迟类 X 轴指标收纳进高级菜单

### DIFF
--- a/packages/app/cypress/e2e/csv-export-overlay.cy.ts
+++ b/packages/app/cypress/e2e/csv-export-overlay.cy.ts
@@ -47,12 +47,12 @@ describe('Inference CSV export with an unofficial-run overlay', () => {
       },
     });
     cy.wait('@unofficialRun');
+    // Interactivity is nested under the Advanced menu on agentic charts.
+    cy.get('[data-testid="x-axis-mode-advanced"]').click();
     cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    cy.get('[data-testid="x-axis-mode-advanced"]')
+      .should('have.attr', 'data-state', 'active')
+      .and('contain.text', 'Interactivity');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should('exist');
   });
 

--- a/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
+++ b/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
@@ -33,6 +33,8 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
       },
     });
     cy.wait('@unofficialRun');
+    // Interactivity is nested under the Advanced menu on agentic charts.
+    cy.get('[data-testid="x-axis-mode-advanced"]').click();
     cy.get('[data-testid="x-axis-mode-interactivity"]').click();
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(

--- a/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
+++ b/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
@@ -25,13 +25,13 @@ describe('Overlay points follow canonical Optimal Only policy (agentic interacti
       },
     });
     cy.wait('@unofficialRun');
+    // Interactivity is nested under the Advanced menu on agentic charts.
+    cy.get('[data-testid="x-axis-mode-advanced"]').click();
     cy.get('[data-testid="x-axis-mode-interactivity"]').click();
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    cy.get('[data-testid="x-axis-mode-advanced"]')
+      .should('have.attr', 'data-state', 'active')
+      .and('contain.text', 'Interactivity');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(
       'have.length',
       REAL_CONFIGS.length,

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -298,6 +298,34 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     );
   });
 
+  // Documents the intended pairing of the Advanced menu with manual tab
+  // activation: focus may move to the lone remaining tab without the x-axis
+  // snapping back to it. The load-bearing guard for manual activation is the
+  // 8K/1K test below, where focus-activation is directly observable; this one
+  // states the agentic-side expectation.
+  it('keeps the Advanced selection when the remaining tab is focused', () => {
+    selectAdvancedXAxisMode('ttft', 'TTFT');
+
+    // Let the popover finish closing first: Radix restores focus to its own
+    // trigger on close, which would otherwise win the race against the focus
+    // below and mask the revert this test is guarding against.
+    cy.get('[data-testid="x-axis-mode-advanced-menu"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-advanced"]').should('have.focus');
+
+    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').focus();
+    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').should('have.focus');
+
+    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').should(
+      'have.attr',
+      'aria-selected',
+      'false',
+    );
+    cy.get('[data-testid="x-axis-mode-advanced"]')
+      .should('have.attr', 'data-state', 'active')
+      .and('contain.text', 'TTFT');
+    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
+  });
+
   it('switches back to Interactivity', () => {
     selectAdvancedXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
@@ -396,6 +424,34 @@ describe('Label defaults for fixed-sequence scenarios', () => {
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+  });
+
+  // Radix Tabs activates on focus by default, which would switch the x-axis
+  // (and redraw the chart) just from tabbing through the strip. The Tabs root
+  // sets activationMode="manual" to prevent that. Pins the intended behavior;
+  // note that focus-activation proved timing-dependent to reproduce, so treat
+  // this as a behavioral assertion rather than a proven pre-fix reproduction.
+  it('does not switch the x-axis merely by focusing another tab', () => {
+    interceptFixedSequenceData();
+    cy.visit('/inference?i_seq=8k%2F1k', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+
+    cy.get('[data-testid="x-axis-mode-ttft"]').click();
+    cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
+
+    cy.get('[data-testid="x-axis-mode-interactivity"]').focus();
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should('have.focus');
+
+    // Focus moved, selection did not.
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
+      'have.attr',
+      'aria-selected',
+      'false',
+    );
+    cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
   });
 
   // Only agentic nests the latency modes: E2E Normalized Interactivity is

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -123,6 +123,21 @@ const interceptFixedSequenceData = () => {
   cy.intercept('GET', '/api/v1/benchmarks*', { body: fixedSequenceBenchmarks }).as('benchmarks');
 };
 
+/**
+ * On agentic charts, Interactivity / E2E Latency / TTFT live inside the
+ * "Advanced" menu rather than as top-level tabs, so they must be revealed
+ * before they can be clicked. The menu closes on select, so the post-select
+ * assertion targets the trigger, which carries the active state and the
+ * selected metric's label.
+ */
+function selectAdvancedXAxisMode(mode: 'interactivity' | 'e2e' | 'ttft', label: string) {
+  cy.get('[data-testid="x-axis-mode-advanced"]').click();
+  cy.get(`[data-testid="x-axis-mode-${mode}"]`).click();
+  cy.get('[data-testid="x-axis-mode-advanced"]')
+    .should('have.attr', 'data-state', 'active')
+    .and('contain.text', label);
+}
+
 describe('X-Axis Mode Toggle (inference chart)', () => {
   before(() => {
     interceptAgenticData();
@@ -141,9 +156,13 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
 
   it('shows E2E Normalized Interactivity by default for the agentic view, as the leftmost option', () => {
     cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
-    cy.get('[data-testid="x-axis-mode-ttft"]').should('be.visible');
-    cy.get('[data-testid="x-axis-mode-e2e"]').should('be.visible');
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should('be.visible');
+    // The three per-request latency modes are nested under Advanced on agentic.
+    cy.get('[data-testid="x-axis-mode-ttft"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-e2e"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-advanced"]')
+      .should('be.visible')
+      .and('have.attr', 'data-state', 'inactive');
     cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]')
       .should('be.visible')
       .and('have.attr', 'aria-selected', 'true');
@@ -162,12 +181,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('switches to Interactivity and updates the heading', () => {
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    selectAdvancedXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
   });
 
@@ -206,12 +220,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
 
   it('shows the selected percentile in the Interactivity axis label', () => {
     // Explicitly select the mode — do not rely on the agentic default mode.
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    selectAdvancedXAxisMode('interactivity', 'Interactivity');
     // Agentic plots percentile fields (p90_intvty), so the axis label carries it.
     cy.get('[data-testid="chart-figure"] svg').should(
       'contain.text',
@@ -243,14 +252,12 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('switches the x-axis to TTFT and updates the heading', () => {
-    cy.get('[data-testid="x-axis-mode-ttft"]').click();
-    cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
+    selectAdvancedXAxisMode('ttft', 'TTFT');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
   });
 
   it('switches the x-axis to E2E Latency and updates the heading', () => {
-    cy.get('[data-testid="x-axis-mode-e2e"]').click();
-    cy.get('[data-testid="x-axis-mode-e2e"]').should('have.attr', 'aria-selected', 'true');
+    selectAdvancedXAxisMode('e2e', 'E2E Latency');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'End-to-end Latency');
     cy.get('[data-testid="chart-figure"] svg').should('contain.text', 'P90 End-to-end Latency (s)');
   });
@@ -292,12 +299,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('switches back to Interactivity', () => {
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    selectAdvancedXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
     cy.get('[data-testid="chart-figure"] svg').should(
       'contain.text',
@@ -308,7 +310,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   it('follows the percentile selector in the Interactivity axis label', () => {
     // Select p75 here rather than inheriting it from another test — the axis
     // label must track the selector on its own.
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    selectAdvancedXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="percentile-selector"]').click();
     cy.contains('[role="option"]', 'p75').click();
     cy.get('[data-testid="chart-figure"] svg').should(
@@ -333,11 +335,9 @@ describe('X-axis mode URL param', () => {
       },
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    cy.get('[data-testid="x-axis-mode-advanced"]')
+      .should('have.attr', 'data-state', 'active')
+      .and('contain.text', 'Interactivity');
     // Assert on the rendered chart too: the clobber happened one tick after
     // the buttons first painted, so a button-only check could pass too early.
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
@@ -396,6 +396,25 @@ describe('Label defaults for fixed-sequence scenarios', () => {
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
+  });
+
+  // Only agentic nests the latency modes: E2E Normalized Interactivity is
+  // agentic-only, so collapsing them here would leave an empty tab strip.
+  it('keeps the flat x-axis strip with no Advanced menu', () => {
+    interceptFixedSequenceData();
+    cy.visit('/inference?i_seq=8k%2F1k', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+
+    cy.get('[data-testid="x-axis-mode-buttons"]').should('be.visible');
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should('be.visible');
+    cy.get('[data-testid="x-axis-mode-e2e"]').should('be.visible');
+    cy.get('[data-testid="x-axis-mode-ttft"]').should('be.visible');
+    cy.get('[data-testid="x-axis-mode-advanced"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').should('not.exist');
+    cy.get('[data-testid="x-axis-mode-buttons"] [role="tab"]').should('have.length', 3);
   });
 
   it('honors explicit label URL overrides', () => {
@@ -495,12 +514,7 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
 
   it('shows overlay (unofficial-run) watermark SVG when an overlay is loaded', () => {
     // Explicitly select Interactivity — do not rely on the agentic default mode.
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
-      'have.attr',
-      'aria-selected',
-      'true',
-    );
+    selectAdvancedXAxisMode('interactivity', 'Interactivity');
     // The unofficial-run pattern watermark appears when isUnofficialRun is true.
     cy.get('[data-testid="inference-chart-display"] svg pattern[id^="unofficial-pattern-"]').should(
       'exist',
@@ -516,8 +530,7 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
   });
 
   it('switches to ttft x-axis mode and renders SVG with overlay points', () => {
-    cy.get('[data-testid="x-axis-mode-ttft"]').click();
-    cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
+    selectAdvancedXAxisMode('ttft', 'TTFT');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
     // Overlay points render as triangles or circles inside the chart SVG.
     cy.get('[data-testid="inference-chart-display"] svg').should('exist');

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -194,7 +194,9 @@ function AdvancedXAxisMenu({
       <PopoverTrigger
         data-testid="x-axis-mode-advanced"
         data-state={active ? 'active' : 'inactive'}
-        aria-label={labels.advanced}
+        // No aria-label: the accessible name comes from the visible text, so
+        // screen readers announce "Advanced: TTFT" rather than a bare
+        // "Advanced" that hides which metric the x-axis is plotting.
         className={cn(
           'relative inline-flex items-center justify-center gap-1.5',
           'border-b-2 border-transparent px-4 py-2',
@@ -1149,7 +1151,16 @@ export default function ChartDisplay() {
           <CustomPowers loading={loading} />
         </section>
       )}
+      {/*
+        Manual activation: with Radix's default automatic mode, merely focusing
+        a trigger fires onValueChange. On agentic the strip renders a single tab
+        while the selected mode may live in the Advanced menu, so tabbing to
+        that lone trigger would silently snap the x-axis back to E2E Normalized
+        Interactivity. Manual activation also suits a control whose every change
+        redraws the chart — arrow keys move focus, Enter/Space commits.
+      */}
       <Tabs
+        activationMode="manual"
         value={selectedXAxisMode}
         onValueChange={(value) => {
           setSelectedXAxisMode(value as XAxisMode);

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -3,7 +3,7 @@ import { DISPLAY_MODEL_TO_DB } from '@semianalysisai/inferencex-constants';
 import { track } from '@/lib/analytics';
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { BarChart3, Table2 } from 'lucide-react';
+import { BarChart3, Check, ChevronDown, Table2 } from 'lucide-react';
 
 import chartDefinitions from '@/components/inference/inference-chart-config.json';
 import { useInference } from '@/components/inference/InferenceContext';
@@ -30,6 +30,7 @@ import ScatterGraph from '@/components/inference/ui/ScatterGraph';
 import { Card } from '@/components/ui/card';
 import { ChartButtons } from '@/components/ui/chart-buttons';
 import { type SegmentedToggleOption, SegmentedToggle } from '@/components/ui/segmented-toggle';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ChartShareActions, MetricAssumptionNotes } from '@/components/ui/chart-display-helpers';
 import { UnofficialDomainNotice } from '@/components/ui/unofficial-domain-notice';
@@ -37,7 +38,7 @@ import { metricLabel, metricTitle } from '@/lib/chart-utils';
 import { exportToCsv } from '@/lib/csv-export';
 import { inferenceChartToCsv } from '@/lib/csv-export-helpers';
 import { knownIssueCsvNote, matchKnownConfigIssues } from '@/lib/known-issues';
-import { getDisplayLabel } from '@/lib/utils';
+import { cn, getDisplayLabel } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import {
@@ -62,6 +63,7 @@ import {
 } from '@/hooks/api/use-derived-agentic-metrics';
 import { getHardwareConfig, hardwareKeyMatchesAnyBase } from '@/lib/constants';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
+import type { Locale } from '@/lib/i18n';
 import { useLocale } from '@/lib/use-locale';
 
 import ChartControls from './ChartControls';
@@ -96,6 +98,8 @@ const STRINGS = {
     vsTtft: (word: string) => `vs. ${word} Time To First Token`,
     vsE2eLatency: (pctl?: string) =>
       pctl ? `vs. ${pctl} End-to-end Latency` : 'vs. End-to-end Latency',
+    advancedXAxis: 'Advanced',
+    advancedXAxisWith: (label: string) => `Advanced: ${label}`,
   },
   zh: {
     inferencePerformance: '推理性能',
@@ -111,6 +115,8 @@ const STRINGS = {
     viewMode: '视图模式',
     vsTtft: (word: string) => `vs. ${word === 'Median' ? '中位' : word} 首 token 延迟（TTFT）`,
     vsE2eLatency: (pctl?: string) => (pctl ? `vs. ${pctl} 端到端延迟` : 'vs. 端到端延迟'),
+    advancedXAxis: '高级',
+    advancedXAxisWith: (label: string) => `高级：${label}`,
   },
 } as const;
 
@@ -145,6 +151,101 @@ const X_AXIS_MODE_BUTTONS: { value: XAxisMode; label: string; labelZh: string }[
   { value: 'e2e', label: 'E2E Latency', labelZh: '端到端延迟' },
   { value: 'ttft', label: 'TTFT', labelZh: 'TTFT' },
 ];
+
+/**
+ * X-axis modes tucked behind the "Advanced" menu on agentic charts.
+ *
+ * AgentX headlines E2E Normalized Interactivity, so the three per-request
+ * latency views are secondary there and would otherwise crowd the strip. They
+ * stay flat top-level tabs on every other scenario: E2E Normalized
+ * Interactivity is agentic-only, so collapsing them elsewhere would leave the
+ * strip with nothing in it.
+ */
+const ADVANCED_X_AXIS_MODES: readonly XAxisMode[] = ['interactivity', 'e2e', 'ttft'];
+
+const isAdvancedXAxisMode = (mode: XAxisMode): boolean => ADVANCED_X_AXIS_MODES.includes(mode);
+
+/**
+ * "Advanced" x-axis picker for agentic charts. Styled to sit in the tab strip
+ * beside the real tabs, but it is a menu button rather than a `TabsTrigger`:
+ * Radix would otherwise treat it as a fifth tab stop and steal arrow-key
+ * navigation from the modes inside it. The active mode's label is shown on the
+ * trigger so the strip still says which metric the x-axis is plotting.
+ */
+function AdvancedXAxisMenu({
+  selected,
+  onSelect,
+  locale,
+  labels,
+}: {
+  selected: XAxisMode;
+  onSelect: (mode: XAxisMode) => void;
+  locale: Locale;
+  labels: { advanced: string; advancedWith: (label: string) => string };
+}) {
+  const [open, setOpen] = useState(false);
+  const active = isAdvancedXAxisMode(selected);
+  const options = X_AXIS_MODE_BUTTONS.filter(({ value }) => isAdvancedXAxisMode(value));
+  const activeLabel = options.find(({ value }) => value === selected);
+  const activeText = activeLabel && (locale === 'zh' ? activeLabel.labelZh : activeLabel.label);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        data-testid="x-axis-mode-advanced"
+        data-state={active ? 'active' : 'inactive'}
+        aria-label={labels.advanced}
+        className={cn(
+          'relative inline-flex items-center justify-center gap-1.5',
+          'border-b-2 border-transparent px-4 py-2',
+          'text-sm font-semibold whitespace-nowrap',
+          'text-muted-foreground hover:border-muted-foreground/30',
+          'data-[state=active]:text-secondary dark:data-[state=active]:text-primary',
+          'data-[state=active]:border-secondary dark:data-[state=active]:border-primary',
+          'transition-colors duration-200',
+          'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring',
+          'min-w-[130px] sm:min-w-[140px] flex-1 sm:flex-initial cursor-pointer',
+        )}
+      >
+        {active && activeText ? labels.advancedWith(activeText) : labels.advanced}
+        <ChevronDown
+          className={cn('size-4 transition-transform', open && 'rotate-180')}
+          aria-hidden
+        />
+      </PopoverTrigger>
+      <PopoverContent align="center" className="w-52 p-1" data-testid="x-axis-mode-advanced-menu">
+        <ul className="flex flex-col">
+          {options.map(({ value, label, labelZh }) => {
+            const isActive = value === selected;
+            return (
+              <li key={value}>
+                <button
+                  type="button"
+                  data-testid={`x-axis-mode-${value}`}
+                  aria-current={isActive}
+                  onClick={() => {
+                    setOpen(false);
+                    onSelect(value);
+                  }}
+                  className={cn(
+                    'flex w-full items-center justify-between rounded-sm px-2 py-1.5 text-sm',
+                    'cursor-pointer transition-colors',
+                    isActive
+                      ? 'bg-accent text-secondary dark:text-primary font-medium'
+                      : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                  )}
+                >
+                  {locale === 'zh' ? labelZh : label}
+                  {isActive && <Check className="size-4" aria-hidden />}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 /** Presentation and data plumbing for trace-derived agentic x-axis modes. */
 interface DerivedXModeSpec {
@@ -1061,10 +1162,11 @@ export default function ChartDisplay() {
           className="flex-wrap justify-center gap-x-1 gap-y-1.5 sm:gap-x-1.5"
         >
           {X_AXIS_MODE_BUTTONS.filter(({ value }) => {
-            if (!isAgenticOnlyXAxisMode(value)) return true;
-            // Before mount, render all buttons so SSR and first client render match.
+            // Before mount, render the flat strip so SSR and first client render match.
             if (!mounted) return true;
-            return isAgenticSequence;
+            if (isAgenticOnlyXAxisMode(value)) return isAgenticSequence;
+            // On agentic these three move into the Advanced menu below.
+            return !(isAgenticSequence && isAdvancedXAxisMode(value));
           }).map(({ value, label, labelZh }) => (
             <TabsTrigger
               key={value}
@@ -1075,6 +1177,17 @@ export default function ChartDisplay() {
               {locale === 'zh' ? labelZh : label}
             </TabsTrigger>
           ))}
+          {mounted && isAgenticSequence && (
+            <AdvancedXAxisMenu
+              selected={selectedXAxisMode}
+              onSelect={(mode) => {
+                setSelectedXAxisMode(mode);
+                track('latency_x_axis_mode_selected', { mode });
+              }}
+              locale={locale}
+              labels={{ advanced: t.advancedXAxis, advancedWith: t.advancedXAxisWith }}
+            />
+          )}
         </TabsList>
       </Tabs>
       <div className="flex flex-col gap-4">{displayGraphs}</div>


### PR DESCRIPTION
## Summary

On the agentic-traces chart, the x-axis strip carried four peers. **Interactivity, E2E Latency, and TTFT** now live behind an **Advanced** menu next to E2E Normalized Interactivity, which is the metric AgentX headlines.

```
Before (agentic):
  E2E Normalized Interactivity | Interactivity | E2E Latency | TTFT

After (agentic):
  E2E Normalized Interactivity | Advanced ▾
  ———————————————————           ┌───────────────┐
                                │ Interactivity │
                                │ E2E Latency   │
                                │ TTFT        ✓ │
                                └───────────────┘
```

When one of the three is selected the trigger reads **"Advanced: TTFT"** and takes the same active underline a tab would, so the strip still tells you what the x-axis is plotting rather than going blank.

## Two decisions worth reviewing

**Scoped to agentic on purpose.** `E2E Normalized Interactivity` is agentic-only (`isAgenticOnlyXAxisMode`), so collapsing the other three on fixed-sequence scenarios would leave the strip with **nothing in it**. 8K/1K and the other scenarios keep today's flat three-tab row, and there's a new regression test pinning that.

**The Advanced trigger is a popover button, not a fifth `TabsTrigger`.** Radix Tabs would otherwise treat it as a tab stop and steal arrow-key navigation from the three modes nested inside it. It's styled to match `TabsTrigger` exactly (same border/active/hover recipe) and exposes `data-state="active" | "inactive"` so it reads and tests like the tabs beside it. Menu items use `aria-current` and show a check on the selected one.

Both locales covered: `Advanced` / `高级`, and `Advanced: {metric}` / `高级：{metric}`.

## Test impact

The three modes moved inside a popover, so every agentic test that clicked them needed to open the menu first, and post-click assertions moved from the (now-unmounted) menu item to the trigger. Four specs were affected:

- **`ttft-x-axis-toggle.cy.ts`** — added a `selectAdvancedXAxisMode(mode, label)` helper that opens the menu, clicks the mode, and asserts the trigger went active with the right label. The default-view test now asserts the three are **absent** from the strip and Advanced renders inactive. The URL-restore test (`?i_xmode=interactivity`) asserts the trigger restores to active with "Interactivity".
- **`csv-export-overlay.cy.ts`**, **`overlay-legend-remove.cy.ts`**, **`overlay-optimal-only.cy.ts`** — each opens the Advanced menu before selecting Interactivity in setup.

**New test:** `keeps the flat x-axis strip with no Advanced menu` on 8K/1K — asserts all three modes are visible as real tabs, `x-axis-mode-advanced` does not exist, and the strip has exactly 3 `[role="tab"]` elements. That's the guard against someone later applying the nesting globally and emptying the non-agentic strip.

**Ran locally: 28/28 across the four specs** (ttft-x-axis-toggle 21, csv-export-overlay 1, overlay-legend-remove 3, overlay-optimal-only 3). Full unit suite **3,871 passed**; `typecheck`, `lint`, `fmt` clean.

Overlay note: verified on the `?unofficialrun=` path — the three overlay specs drive the chart through the Advanced menu and still assert overlay points, legend removal, and optimal-only filtering, so the nesting doesn't disturb overlay rendering.

## 中文说明

在智能体轨迹（agentic-traces）图表中，X 轴切换条原本并列四项。现将 **交互性、端到端延迟、TTFT** 三项收纳进 **高级** 菜单，置于 AgentX 主推指标"端到端归一化交互性"旁边。选中其中一项后，触发器显示为 **"高级：TTFT"**，并呈现与标签页一致的选中下划线，因此切换条仍能表明 X 轴当前绘制的指标，而不会变成一片空白。

**两处需要重点评审的决策。** 其一，**有意仅限智能体场景**：`E2E Normalized Interactivity` 为智能体专有（见 `isAgenticOnlyXAxisMode`），若在固定序列场景下同样收纳其余三项，切换条将**空无一物**；因此 8K/1K 等场景保持现有的三标签平铺布局，并新增回归测试加以固定。其二，**"高级"触发器是弹出菜单按钮而非第五个 `TabsTrigger`**：否则 Radix 会将其视为一个标签停靠点，抢走其内部三个模式的方向键导航。该按钮的样式与 `TabsTrigger` 完全一致（相同的边框／选中／悬停配方），并暴露 `data-state="active" | "inactive"`，因此在外观与测试上都与相邻标签一致；菜单项使用 `aria-current`，并在选中项上显示对勾。中英文文案均已覆盖：`Advanced` / `高级`，以及 `Advanced: {metric}` / `高级：{metric}`。

**测试影响：** 三个模式移入弹出菜单后，所有点击它们的智能体用例都需先展开菜单，且点击后的断言从（已卸载的）菜单项转移到触发器上，共影响四个 spec。`ttft-x-axis-toggle.cy.ts` 新增 `selectAdvancedXAxisMode(mode, label)` 辅助函数，负责展开菜单、点击模式并断言触发器进入选中态且标签正确；默认视图用例改为断言三项**不存在**于切换条且"高级"呈未选中态；URL 恢复用例（`?i_xmode=interactivity`）断言触发器恢复为选中态并显示"Interactivity"。`csv-export-overlay.cy.ts`、`overlay-legend-remove.cy.ts`、`overlay-optimal-only.cy.ts` 三个 spec 在初始化时先展开"高级"菜单再选择 Interactivity。

**新增用例** `keeps the flat x-axis strip with no Advanced menu`（8K/1K）：断言三项均作为真实标签可见、`x-axis-mode-advanced` 不存在、切换条恰好包含 3 个 `[role="tab"]` 元素——用以防止后续有人将该嵌套逻辑全局化，从而清空非智能体场景的切换条。

本地运行四个 spec 共 **28/28 通过**；完整单元测试 **3,871 项通过**；`typecheck`、`lint`、`fmt` 均通过。覆盖层说明：`?unofficialrun=` 路径已验证——三个覆盖层 spec 均通过"高级"菜单切换图表，并仍断言覆盖层数据点、图例移除与仅最优点筛选功能正常，说明该嵌套不影响覆盖层渲染。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only inference chart x-axis navigation scoped to agentic scenario, with broad Cypress coverage and no API or data-path changes.
> 
> **Overview**
> On **agentic-traces** charts, **Interactivity**, **E2E Latency**, and **TTFT** are no longer top-level x-axis tabs. They sit behind an **Advanced** popover beside **E2E Normalized Interactivity**; when one is selected, the trigger shows **Advanced: {metric}** with the same active styling as tabs.
> 
> **8K/1K and other fixed-sequence scenarios** still use the flat three-tab row—no Advanced menu—because collapsing those modes there would leave an empty strip.
> 
> The x-axis **Tabs** root now uses **`activationMode="manual"`** so keyboard focus on the lone agentic tab does not snap the chart back to E2E Normalized Interactivity. The Advanced control is a **popover button** (not a fifth `TabsTrigger`) to avoid Radix stealing arrow-key navigation.
> 
> Cypress specs that drive agentic overlay and x-axis flows open Advanced first and assert on the trigger’s `data-state` and label; new tests pin the non-agentic flat strip and manual tab activation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 037ec8ffbc21a4785c237c719941bbab84c15d71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->