### PR TITLE
feat(overview): selectable history comparison window / 总览历史对比支持可选时间窗口（1周/1月/2月/3月）

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -50,6 +50,9 @@ function expectNoHorizontalScroller(testId: string) {
       .filter(
         (el) =>
           !el.classList.contains('sr-only') &&
+          // Radix selects render an aria-hidden native <select> clipped to 1px,
+          // which Firefox reports as scrollable; hidden elements cannot scroll.
+          el.getAttribute('aria-hidden') !== 'true' &&
           getComputedStyle(el).display !== 'inline' &&
           el.scrollWidth > el.clientWidth + 1,
       )

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -158,7 +158,7 @@ describe('Overview page', () => {
     cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
-    cy.get('[data-overview-comparison="history"]').click();
+    cy.get('[data-overview-comparison="30d"]').click();
     cy.wait('@overviewJson');
     cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all&compare=30d');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
@@ -296,13 +296,13 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
-    cy.get('[data-overview-comparison="history"]').click();
-    cy.get('[data-overview-comparison="history"]', { timeout: 15_000 }).should(
+    cy.get('[data-overview-comparison="30d"]').click();
+    cy.get('[data-overview-comparison="30d"]', { timeout: 15_000 }).should(
       'have.attr',
       'aria-current',
       'true',
     );
-    cy.focused().should('have.attr', 'data-overview-comparison', 'history');
+    cy.focused().should('have.attr', 'data-overview-comparison', '30d');
   });
 
   it('reveals deprecated and maintenance models via the bottom toggle', () => {
@@ -382,7 +382,7 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-engine-scope-switcher"]')
       .find('[data-overview-engine-scope="all"]')
       .should('have.attr', 'href', '/overview?engine=all&ref=b300');
-    cy.get('[data-overview-comparison="history"]').should(
+    cy.get('[data-overview-comparison="30d"]').should(
       'have.attr',
       'href',
       '/overview?ref=b300&compare=30d',
@@ -423,15 +423,15 @@ describe('Overview page', () => {
             expect(style.borderBottomWidth).to.equal('2px');
             expect(style.backgroundColor).to.match(/rgba\(0, 0, 0, 0\)|transparent/);
           });
-        cy.get('[data-overview-comparison="history"]')
+        cy.get('[data-overview-comparison="30d"]')
           .should('have.attr', 'href', '/overview?compare=30d')
-          .and('have.text', '30-day change')
+          .and('have.text', 'Change over time')
           .click();
       });
 
     cy.location('search').should('eq', '?compare=30d');
     cy.get('[data-testid="overview-comparison-switcher"]')
-      .find('[data-overview-comparison="history"]')
+      .find('[data-overview-comparison="30d"]')
       .should('have.attr', 'aria-current', 'true')
       .and('match', 'span');
     cy.get('[data-testid="overview-desktop-matrix"] thead').should('contain.text', 'B200');
@@ -452,12 +452,32 @@ describe('Overview page', () => {
       .should('have.attr', 'aria-label', '对比方式')
       .within(() => {
         cy.get('[data-overview-comparison="hardware"]').should('have.text', '对比 B200');
-        cy.get('[data-overview-comparison="history"]')
+        cy.get('[data-overview-comparison="30d"]')
           .should('have.attr', 'aria-current', 'true')
-          .and('have.text', '30 天变化');
+          .and('have.text', '对比 1 个月前');
       });
     cy.contains('当前成本及其相对 30–60 天前最近一次有效平台结果的变化。').should('exist');
     cy.contains('缺少有效 30 天对比的平台仅显示当前成本。').should('exist');
+  });
+
+  it('switches the history window through the embedded selector', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview?compare=30d');
+
+    cy.get('[data-testid="overview-history-window-select"]').click();
+    cy.get('[data-overview-window="7d"]').click();
+    cy.location('search', { timeout: 15_000 }).should('eq', '?compare=7d');
+    cy.get('[data-overview-comparison="7d"]').should('have.attr', 'aria-current', 'true');
+    cy.contains(
+      'Current cost and change versus the latest validated platform result 7–14 days earlier.',
+    ).should('exist');
+
+    cy.get('[data-testid="overview-history-window-select"]').click();
+    cy.get('[data-overview-window="90d"]').click();
+    cy.location('search', { timeout: 15_000 }).should('eq', '?compare=90d');
+    cy.contains(
+      'Current cost and change versus the latest validated platform result 90–180 days earlier.',
+    ).should('exist');
   });
 
   it('compares each platform with its own validated result from 30–60 days earlier', () => {

--- a/packages/app/src/app/api/v1/overview/route.test.ts
+++ b/packages/app/src/app/api/v1/overview/route.test.ts
@@ -29,7 +29,7 @@ describe('GET /api/v1/overview', () => {
     const data = {
       tier: 75,
       engineScope: 'all',
-      comparisonMode: 'history',
+      comparisonMode: '30d',
       referenceHardware: 'b300',
       models: [],
       historicalWindow: null,
@@ -42,7 +42,7 @@ describe('GET /api/v1/overview', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(data);
-    expect(mockGetOverviewPageData).toHaveBeenCalledWith(75, 'all', 'history', 'b300', 'all');
+    expect(mockGetOverviewPageData).toHaveBeenCalledWith(75, 'all', '30d', 'b300', 'all');
     expect(mockCachedJson).toHaveBeenCalledWith(data);
   });
 

--- a/packages/app/src/components/overview/overview-history-window-select.tsx
+++ b/packages/app/src/components/overview/overview-history-window-select.tsx
@@ -10,7 +10,7 @@ import {
 import { track } from '@/lib/analytics';
 import type { OverviewHistoryWindowKey } from '@/lib/overview-data';
 
-import { useOverviewNavigation } from './overview-navigation';
+import { useOverviewComparisonMode, useOverviewNavigation } from './overview-navigation';
 
 interface WindowOption {
   href: string;
@@ -20,7 +20,7 @@ interface WindowOption {
 
 export function OverviewHistoryWindowSelect({
   ariaLabel,
-  value,
+  value: committedValue,
   options,
 }: {
   ariaLabel: string;
@@ -28,6 +28,12 @@ export function OverviewHistoryWindowSelect({
   options: readonly WindowOption[];
 }) {
   const navigation = useOverviewNavigation();
+  // Control the trigger from the pending URL so a window chosen during a slow
+  // load shows immediately and re-selecting the previous window undoes it
+  // instead of being dropped by the `next === value` guard. A pending switch
+  // back to hardware mode carries no window, so keep the committed one.
+  const pendingMode = useOverviewComparisonMode();
+  const value = pendingMode === 'hardware' ? committedValue : pendingMode;
 
   return (
     <Select

--- a/packages/app/src/components/overview/overview-history-window-select.tsx
+++ b/packages/app/src/components/overview/overview-history-window-select.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { track } from '@/lib/analytics';
+import type { OverviewHistoryWindowKey } from '@/lib/overview-data';
+
+import { useOverviewNavigation } from './overview-navigation';
+
+interface WindowOption {
+  href: string;
+  label: string;
+  value: OverviewHistoryWindowKey;
+}
+
+export function OverviewHistoryWindowSelect({
+  ariaLabel,
+  value,
+  options,
+}: {
+  ariaLabel: string;
+  value: OverviewHistoryWindowKey;
+  options: readonly WindowOption[];
+}) {
+  const navigation = useOverviewNavigation();
+
+  return (
+    <Select
+      value={value}
+      onValueChange={(next: OverviewHistoryWindowKey) => {
+        const option = options.find((candidate) => candidate.value === next);
+        if (option === undefined || next === value) return;
+        track('overview_history_window_changed', { from: value, to: next });
+        navigation.push(option.href, ['compare']);
+      }}
+    >
+      <SelectTrigger
+        data-testid="overview-history-window-select"
+        aria-label={ariaLabel}
+        size="sm"
+        className="h-8 border-0 bg-transparent px-1.5 text-sm font-semibold shadow-none hover:bg-muted/60 focus-visible:ring-2"
+      >
+        <SelectValue>{options.find((option) => option.value === value)?.label}</SelectValue>
+      </SelectTrigger>
+      <SelectContent align="center">
+        {options.map((option) => (
+          <SelectItem key={option.value} value={option.value} data-overview-window={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -17,6 +17,7 @@ import { track } from '@/lib/analytics';
 import { notifyClientSearchChange } from '@/lib/client-navigation';
 import {
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
+  type OverviewComparisonMode,
   type OverviewPageData,
   type OverviewReferenceHardware,
   resolveOverviewComparisonMode,
@@ -73,6 +74,7 @@ interface OverviewNavigationValue {
  */
 const OverviewDataContext = createContext<OverviewPageData | null>(null);
 const OverviewReferenceContext = createContext<OverviewReferenceHardware | null>(null);
+const OverviewComparisonContext = createContext<OverviewComparisonMode | null>(null);
 const OverviewNavigationContext = createContext<OverviewNavigationValue | null>(null);
 
 export function OverviewNavigationProvider({
@@ -259,6 +261,17 @@ export function OverviewNavigationProvider({
     [pendingHref],
   );
 
+  // Derived from the pending URL, not the settled payload, so the window
+  // selector reflects a choice whose request is still in flight — including
+  // re-selecting the previous window to undo it.
+  const comparisonMode = useMemo(
+    () =>
+      resolveOverviewComparisonMode(
+        new URL(pendingHref, 'https://inferencex.local').searchParams.get('compare') ?? undefined,
+      ),
+    [pendingHref],
+  );
+
   const value = useMemo<OverviewNavigationValue>(
     () => ({
       isPending,
@@ -279,9 +292,11 @@ export function OverviewNavigationProvider({
   return (
     <OverviewDataContext.Provider value={data}>
       <OverviewReferenceContext.Provider value={referenceHardware}>
-        <OverviewNavigationContext.Provider value={value}>
-          {children}
-        </OverviewNavigationContext.Provider>
+        <OverviewComparisonContext.Provider value={comparisonMode}>
+          <OverviewNavigationContext.Provider value={value}>
+            {children}
+          </OverviewNavigationContext.Provider>
+        </OverviewComparisonContext.Provider>
       </OverviewReferenceContext.Provider>
     </OverviewDataContext.Provider>
   );
@@ -301,6 +316,12 @@ export function useOverviewData(): OverviewPageData {
 
 export function useOverviewReference(): OverviewReferenceHardware {
   const value = useContext(OverviewReferenceContext);
+  if (value === null) throw new Error('Overview controls require OverviewNavigationProvider');
+  return value;
+}
+
+export function useOverviewComparisonMode(): OverviewComparisonMode {
+  const value = useContext(OverviewComparisonContext);
   if (value === null) throw new Error('Overview controls require OverviewNavigationProvider');
   return value;
 }

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -3,8 +3,11 @@
 import { type ComponentPropsWithoutRef, useEffect, useRef } from 'react';
 
 import {
+  OVERVIEW_DEFAULT_HISTORY_WINDOW,
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
   OVERVIEW_HARDWARE,
+  OVERVIEW_HISTORY_WINDOW_DAYS,
+  OVERVIEW_HISTORY_WINDOWS,
   OVERVIEW_TIERS,
   overviewHardwareLabel,
   type OverviewComparisonMode,
@@ -27,6 +30,7 @@ import {
 
 import { OverviewDetailLink } from './overview-detail-link';
 import { OverviewHistoryDetailLink } from './overview-history-detail-link';
+import { OverviewHistoryWindowSelect } from './overview-history-window-select';
 import { OverviewNavLink } from './overview-nav-link';
 import { type OverviewNavControl, useOverviewNavigation } from './overview-navigation';
 import { OverviewReferenceSelect } from './overview-reference-select';
@@ -53,14 +57,21 @@ export const OVERVIEW_STRINGS = {
     },
     comparisonNavLabel: 'Compare',
     comparisonOptions: {
-      history: '30-day change',
+      history: 'Change over time',
     },
+    historyWindowOptions: {
+      '7d': '1 week ago',
+      '30d': '1 month ago',
+      '60d': '2 months ago',
+      '90d': '3 months ago',
+    } as Record<string, string>,
+    historyWindowSelectAria: 'Comparison window',
     hardwareComparisonLabel: (reference: string) => `vs ${reference}`,
     referenceSelectorAria: 'Reference hardware',
     caption:
       'Cost per million total tokens from each platform’s best observed serving envelope for the scenario shown with each model.',
-    historyCaption:
-      'Current cost and change versus the latest validated platform result 30–60 days earlier.',
+    historyCaption: (days: number) =>
+      `Current cost and change versus the latest validated platform result ${days}–${days * 2} days earlier.`,
     modelHeader: 'Model · Scenario',
     scenarioLabels: {
       single_turn_8k1k: '8K/1K',
@@ -97,7 +108,8 @@ export const OVERVIEW_STRINGS = {
       `${pct} ${cheaper ? 'cheaper' : 'more expensive'} than this platform’s ${baselineDate} result`,
     historicalEvenAria: (baselineDate: string) =>
       `About the same cost as this platform’s ${baselineDate} result`,
-    historyCellStateLegend: 'Platforms without a valid 30-day comparison show current cost only.',
+    historyCellStateLegend: (days: number) =>
+      `Platforms without a valid ${days}-day comparison show current cost only.`,
     referenceHeader: 'Reference',
     modelScopeNavLabel: 'Inactive models',
     modelScopeShow: 'Show deprecated & maintenance-mode models',
@@ -125,12 +137,20 @@ export const OVERVIEW_STRINGS = {
     },
     comparisonNavLabel: '对比方式',
     comparisonOptions: {
-      history: '30 天变化',
+      history: '历史变化',
     },
+    historyWindowOptions: {
+      '7d': '1 周前',
+      '30d': '1 个月前',
+      '60d': '2 个月前',
+      '90d': '3 个月前',
+    } as Record<string, string>,
+    historyWindowSelectAria: '对比时间窗口',
     hardwareComparisonLabel: (reference: string) => `对比 ${reference}`,
     referenceSelectorAria: '基准硬件',
     caption: '按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本。',
-    historyCaption: '当前成本及其相对 30–60 天前最近一次有效平台结果的变化。',
+    historyCaption: (days: number) =>
+      `当前成本及其相对 ${days}–${days * 2} 天前最近一次有效平台结果的变化。`,
     modelHeader: '模型 · 场景',
     scenarioLabels: {
       single_turn_8k1k: '8K/1K',
@@ -165,7 +185,7 @@ export const OVERVIEW_STRINGS = {
     historicalDeltaAria: (pct: string, cheaper: boolean, baselineDate: string) =>
       `比该平台 ${baselineDate} 的结果${cheaper ? '便宜' : '昂贵'} ${pct}`,
     historicalEvenAria: (baselineDate: string) => `与该平台 ${baselineDate} 的结果成本基本持平`,
-    historyCellStateLegend: '缺少有效 30 天对比的平台仅显示当前成本。',
+    historyCellStateLegend: (days: number) => `缺少有效 ${days} 天对比的平台仅显示当前成本。`,
     referenceHeader: '基准',
     modelScopeNavLabel: '非活跃模型',
     modelScopeShow: '显示已弃用与维护模式模型',
@@ -306,7 +326,7 @@ function displayedComparison(
   referenceCost: number | null,
 ): DisplayedComparison | null {
   if (platform.costPerMtok === null) return null;
-  if (comparisonMode === 'history') {
+  if (comparisonMode !== 'hardware') {
     const comparison = platform.historicalComparison;
     return comparison?.status === 'comparable' && comparison.costDeltaPct !== null
       ? {
@@ -437,7 +457,7 @@ function CostDeltaBadge({
       data-testid="overview-cost-delta"
       data-hardware={hardware}
       data-cost-polarity={polarity}
-      data-history-status={comparisonMode === 'history' ? status : undefined}
+      data-history-status={comparisonMode === 'hardware' ? undefined : status}
       title={aria}
       // The cell behind it carries the shade, so the badge itself stays
       // untinted — two washes of the same hue would double up.
@@ -525,7 +545,7 @@ function CellValue({
   const costText = formattedValue;
   const comparison = displayedComparison(member, comparisonMode, referenceHardware, referenceCost);
   const historicalConfig =
-    comparisonMode === 'history' && member.historicalComparison?.status === 'comparable'
+    comparisonMode !== 'hardware' && member.historicalComparison?.status === 'comparable'
       ? member.historicalComparison.baselineConfig
       : null;
   return (
@@ -695,7 +715,9 @@ export function DesktopOverviewMatrix({
     <div className="hidden xl:block">
       <table data-testid="overview-desktop-matrix" className="w-full border-collapse text-sm">
         <caption className="sr-only">
-          {comparisonMode === 'history' ? strings.historyCaption : strings.caption}
+          {comparisonMode === 'hardware'
+            ? strings.caption
+            : strings.historyCaption(OVERVIEW_HISTORY_WINDOW_DAYS[comparisonMode])}
         </caption>
         <colgroup>
           <col className="w-[22%]" />
@@ -744,7 +766,7 @@ export function DesktopOverviewMatrix({
                   <ModelName model={model} strings={strings} />
                   {/* The link lives with the model it drills into, so the matrix
                     spends no column on a header that is the same every row. */}
-                  {comparisonMode === 'history' ? null : (
+                  {comparisonMode === 'hardware' && (
                     <OverviewDetailLink
                       href={detailHref(locale, model)}
                       model={model.model}
@@ -850,7 +872,7 @@ export function MobileOverviewList({
                   </div>
                 ))}
               </div>
-              {comparisonMode === 'history' ? null : (
+              {comparisonMode === 'hardware' && (
                 <OverviewDetailLink
                   href={detailHref(locale, model)}
                   model={model.model}
@@ -1048,12 +1070,16 @@ export function OverviewComparisonSwitcher({
   locale: OverviewLocale;
   strings: OverviewStrings;
 }) {
-  const options: OverviewComparisonMode[] = ['hardware', 'history'];
   const referenceLabel = overviewHardwareLabel(referenceHardware);
   const referenceOptions = OVERVIEW_HARDWARE.map((hardware) => ({
     value: hardware,
     label: overviewHardwareLabel(hardware),
     href: overviewHref(locale, tier, engineScope, 'hardware', hardware, modelScope),
+  }));
+  const windowOptions = OVERVIEW_HISTORY_WINDOWS.map((window) => ({
+    value: window,
+    label: strings.historyWindowOptions[window],
+    href: overviewHref(locale, tier, engineScope, window, referenceHardware, modelScope),
   }));
   // The inactive-only classes live on the inactive branch, not here: Tailwind
   // emits `border-transparent` after `border-secondary` at equal specificity,
@@ -1069,44 +1095,66 @@ export function OverviewComparisonSwitcher({
       aria-label={strings.comparisonNavLabel}
       className="flex flex-wrap justify-center gap-x-1 gap-y-1.5 sm:gap-x-1.5"
     >
-      {options.map((option) => {
-        const label =
-          option === 'hardware'
-            ? strings.hardwareComparisonLabel(referenceLabel)
-            : strings.comparisonOptions.history;
-        return option === comparisonMode ? (
-          <ActiveSwitcherOption
-            key={option}
-            control="comparison"
-            data-overview-comparison={option}
-            aria-current="true"
-            className={`${optionClass} border-secondary text-secondary dark:border-primary dark:text-primary`}
-          >
-            {option === 'hardware' ? (
-              <span className="inline-flex items-center gap-0.5">
-                <span>{locale === 'zh' ? '对比 ' : 'vs '}</span>
-                <OverviewReferenceSelect
-                  ariaLabel={strings.referenceSelectorAria}
-                  options={referenceOptions}
-                />
-              </span>
-            ) : (
-              label
-            )}
-          </ActiveSwitcherOption>
-        ) : (
-          <OverviewNavLink
-            key={option}
-            data-overview-comparison={option}
-            href={overviewHref(locale, tier, engineScope, option, referenceHardware, modelScope)}
-            analytics={{ control: 'comparison', value: option }}
-            searchKeys={['compare']}
-            className={`${optionClass} ${inactiveOptionClass}`}
-          >
-            {label}
-          </OverviewNavLink>
-        );
-      })}
+      {comparisonMode === 'hardware' ? (
+        <ActiveSwitcherOption
+          control="comparison"
+          data-overview-comparison="hardware"
+          aria-current="true"
+          className={`${optionClass} border-secondary text-secondary dark:border-primary dark:text-primary`}
+        >
+          <span className="inline-flex items-center gap-0.5">
+            <span>{locale === 'zh' ? '对比 ' : 'vs '}</span>
+            <OverviewReferenceSelect
+              ariaLabel={strings.referenceSelectorAria}
+              options={referenceOptions}
+            />
+          </span>
+        </ActiveSwitcherOption>
+      ) : (
+        <OverviewNavLink
+          data-overview-comparison="hardware"
+          href={overviewHref(locale, tier, engineScope, 'hardware', referenceHardware, modelScope)}
+          analytics={{ control: 'comparison', value: 'hardware' }}
+          searchKeys={['compare']}
+          className={`${optionClass} ${inactiveOptionClass}`}
+        >
+          {strings.hardwareComparisonLabel(referenceLabel)}
+        </OverviewNavLink>
+      )}
+      {comparisonMode === 'hardware' ? (
+        <OverviewNavLink
+          data-overview-comparison={OVERVIEW_DEFAULT_HISTORY_WINDOW}
+          href={overviewHref(
+            locale,
+            tier,
+            engineScope,
+            OVERVIEW_DEFAULT_HISTORY_WINDOW,
+            referenceHardware,
+            modelScope,
+          )}
+          analytics={{ control: 'comparison', value: OVERVIEW_DEFAULT_HISTORY_WINDOW }}
+          searchKeys={['compare']}
+          className={`${optionClass} ${inactiveOptionClass}`}
+        >
+          {strings.comparisonOptions.history}
+        </OverviewNavLink>
+      ) : (
+        <ActiveSwitcherOption
+          control="comparison"
+          data-overview-comparison={comparisonMode}
+          aria-current="true"
+          className={`${optionClass} border-secondary text-secondary dark:border-primary dark:text-primary`}
+        >
+          <span className="inline-flex items-center gap-0.5">
+            <span>{locale === 'zh' ? '对比 ' : 'vs '}</span>
+            <OverviewHistoryWindowSelect
+              ariaLabel={strings.historyWindowSelectAria}
+              value={comparisonMode}
+              options={windowOptions}
+            />
+          </span>
+        </ActiveSwitcherOption>
+      )}
     </nav>
   );
 }
@@ -1163,11 +1211,13 @@ export function OverviewMethodology({
       data-testid="overview-methodology"
       className="space-y-1 border-t border-border/50 px-4 py-3 text-xs leading-snug text-muted-foreground lg:px-6"
     >
-      {comparisonMode === 'history' ? <p>{strings.historyCaption}</p> : null}
+      {comparisonMode === 'hardware' ? null : (
+        <p>{strings.historyCaption(OVERVIEW_HISTORY_WINDOW_DAYS[comparisonMode])}</p>
+      )}
       <p>
-        {comparisonMode === 'history'
-          ? strings.historyCellStateLegend
-          : strings.cellStateLegend(referenceLabel)}
+        {comparisonMode === 'hardware'
+          ? strings.cellStateLegend(referenceLabel)
+          : strings.historyCellStateLegend(OVERVIEW_HISTORY_WINDOW_DAYS[comparisonMode])}
       </p>
       <p>{strings.methodologyNote}</p>
     </div>

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -387,6 +387,14 @@ export const apiContractSourceDigests = [
     },
   },
   {
+    source: 'src/lib/overview-data.ts',
+    sourceSha256: '7757b32c1769bf4e25e8dd156ba049830ab25b8e3cf345d718cfad46adfd8e43',
+    reviewArea: {
+      en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
+      zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',
+    },
+  },
+  {
     source: 'src/lib/tco-feed.ts',
     sourceSha256: '52d95a0c867513e6f6e3aaace4d066e69a28495ac593b89821b7b81d7475861a',
     reviewArea: {

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -144,13 +144,14 @@ describe('getOverviewPageData engine scope forwarding', () => {
     vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
 
     const { getOverviewPageData } = await import('./overview-data.server');
-    const page = await getOverviewPageData(50, 'community', 'history');
+    const page = await getOverviewPageData(50, 'community', '30d');
     const qwen = page.models.find((model) => model.model === Model.Qwen3_5);
     const mi355x = qwen?.platforms.find(({ hardware }) => hardware === 'mi355x');
     const b300 = qwen?.platforms.find(({ hardware }) => hardware === 'b300');
 
-    expect(page.comparisonMode).toBe('history');
+    expect(page.comparisonMode).toBe('30d');
     expect(page.historicalWindow).toEqual({
+      key: '30d',
       snapshotDate: '2026-07-20',
       targetDate: '2026-06-20',
       earliestDate: '2026-05-21',
@@ -180,9 +181,9 @@ describe('getOverviewPageData engine scope forwarding', () => {
     vi.doMock('@/lib/test-fixtures', () => ({ loadFixture }));
 
     const { getOverviewPageData } = await import('./overview-data.server');
-    const page = await getOverviewPageData(50, 'community', 'history');
+    const page = await getOverviewPageData(50, 'community', '30d');
 
-    expect(page.comparisonMode).toBe('history');
+    expect(page.comparisonMode).toBe('30d');
     expect(loadFixture).toHaveBeenCalledWith('overview-rows');
     expect(loadFixture).toHaveBeenCalledWith('overview-history-rows');
     expect(getCachedBenchmarks).not.toHaveBeenCalled();
@@ -235,7 +236,7 @@ describe('getOverviewPageData model scope forwarding', () => {
     vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
 
     const { getOverviewPageData } = await import('./overview-data.server');
-    const page = await getOverviewPageData(50, 'community', 'history', 'b200', 'all');
+    const page = await getOverviewPageData(50, 'community', '30d', 'b200', 'all');
 
     expect(page.historicalWindow?.snapshotDate).toBe('2026-07-20');
   });
@@ -249,9 +250,9 @@ describe('getOverviewPageData model scope forwarding', () => {
     vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
 
     const { getOverviewPageData } = await import('./overview-data.server');
-    const page = await getOverviewPageData(50, 'community', 'history', 'b200', 'all');
+    const page = await getOverviewPageData(50, 'community', '30d', 'b200', 'all');
 
-    expect(page.comparisonMode).toBe('history');
+    expect(page.comparisonMode).toBe('30d');
     expect(page.modelScope).toBe('all');
     expect(page.models.some((m) => m.model === Model.GptOss)).toBe(true);
   });

--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -83,11 +83,11 @@ export async function getOverviewPageData(
         referenceHardware,
         modelScope,
       ),
-      comparisonMode: 'history',
+      comparisonMode,
     };
   }
 
-  const window = overviewHistoricalWindow(snapshotDate);
+  const window = overviewHistoricalWindow(snapshotDate, comparisonMode);
   const unboundedBaselineRows = FIXTURES_MODE
     ? loadFixture<Record<string, BenchmarkRow[]>>('overview-history-rows')
     : await loadRowsByModel(models, (keys) => getCachedBenchmarksAsOf(keys, window.targetDate));

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -156,8 +156,11 @@ describe('overview engine scope and scenario selection', () => {
   it.each([
     [undefined, 'hardware'],
     ['hardware', 'hardware'],
-    ['30d', 'history'],
-    [['30d'], 'history'],
+    ['7d', '7d'],
+    ['30d', '30d'],
+    ['60d', '60d'],
+    ['90d', '90d'],
+    [['30d'], '30d'],
     ['unknown', 'hardware'],
   ] as const)('resolves comparison mode %j to %s', (raw, expected) => {
     expect(resolveOverviewComparisonMode(raw)).toBe(expected);
@@ -693,11 +696,28 @@ describe('overview engine scope and scenario selection', () => {
 describe('overview historical window', () => {
   it('anchors the target and floor to the latest database evidence date', () => {
     expect(overviewHistoricalWindow('2026-08-03')).toEqual({
+      key: '30d',
       snapshotDate: '2026-08-03',
       targetDate: '2026-07-04',
       earliestDate: '2026-06-04',
     });
   });
+
+  it.each([
+    ['7d', '2026-07-27', '2026-07-20'],
+    ['60d', '2026-06-04', '2026-04-05'],
+    ['90d', '2026-05-05', '2026-02-04'],
+  ] as const)(
+    'sizes the %s window to its day count with a window-wide floor',
+    (key, target, earliest) => {
+      expect(overviewHistoricalWindow('2026-08-03', key)).toEqual({
+        key,
+        snapshotDate: '2026-08-03',
+        targetDate: target,
+        earliestDate: earliest,
+      });
+    },
+  );
 
   it('returns the latest date across model buckets', () => {
     expect(
@@ -767,6 +787,7 @@ describe('overview historical window', () => {
 
 describe('assembleOverviewHistoricalPageData', () => {
   const window = {
+    key: '30d',
     snapshotDate: '2026-08-03',
     targetDate: '2026-07-04',
     earliestDate: '2026-06-04',
@@ -820,7 +841,7 @@ describe('assembleOverviewHistoricalPageData', () => {
     );
     const platform = platformFor(page, Model.Qwen3_5, 'single_turn_8k1k', 'mi355x');
 
-    expect(page.comparisonMode).toBe('history');
+    expect(page.comparisonMode).toBe('30d');
     expect(page.historicalWindow).toEqual(window);
     expect(platform?.historicalComparison?.status).toBe('comparable');
     expect(platform?.historicalComparison?.costDeltaPct).toBeCloseTo(-0.2, 9);

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -32,7 +32,18 @@ export const OVERVIEW_HARDWARE = ['b200', 'mi355x', 'b300', 'gb200', 'gb300'] as
 export type OverviewReferenceHardware = (typeof OVERVIEW_HARDWARE)[number];
 export const OVERVIEW_DEFAULT_REFERENCE_HARDWARE: OverviewReferenceHardware = 'b200';
 export type OverviewEngineScope = 'all' | 'community';
-export type OverviewComparisonMode = 'hardware' | 'history';
+export const OVERVIEW_HISTORY_WINDOWS = ['7d', '30d', '60d', '90d'] as const;
+export type OverviewHistoryWindowKey = (typeof OVERVIEW_HISTORY_WINDOWS)[number];
+export const OVERVIEW_DEFAULT_HISTORY_WINDOW: OverviewHistoryWindowKey = '30d';
+export const OVERVIEW_HISTORY_WINDOW_DAYS: Record<OverviewHistoryWindowKey, number> = {
+  '7d': 7,
+  '30d': 30,
+  '60d': 60,
+  '90d': 90,
+};
+/** A history mode IS its window key, so `?compare=<key>` alone determines the
+ *  payload and every href/caching path threads the window with no extra param. */
+export type OverviewComparisonMode = 'hardware' | OverviewHistoryWindowKey;
 export const OVERVIEW_DEFAULT_COMPARISON_MODE: OverviewComparisonMode = 'hardware';
 export type OverviewModelScope = 'default' | 'all';
 export const OVERVIEW_DEFAULT_MODEL_SCOPE: OverviewModelScope = 'default';
@@ -61,7 +72,10 @@ export function resolveOverviewComparisonMode(
   raw: string | readonly string[] | undefined,
 ): OverviewComparisonMode {
   const candidate = Array.isArray(raw) ? raw[0] : raw;
-  return candidate === '30d' ? 'history' : OVERVIEW_DEFAULT_COMPARISON_MODE;
+  return (
+    OVERVIEW_HISTORY_WINDOWS.find((window) => window === candidate) ??
+    OVERVIEW_DEFAULT_COMPARISON_MODE
+  );
 }
 
 export function resolveOverviewModelScope(
@@ -188,6 +202,7 @@ export interface OverviewPageData {
 }
 
 export interface OverviewHistoricalWindow {
+  key: OverviewHistoryWindowKey;
   snapshotDate: string;
   targetDate: string;
   earliestDate: string;
@@ -231,11 +246,19 @@ export function overviewSnapshotDate(
   return dates.length === 0 ? null : (dates.toSorted().at(-1) ?? null);
 }
 
-export function overviewHistoricalWindow(snapshotDate: string): OverviewHistoricalWindow {
+/** Baseline band is one window-width wide ([snapshot−2w, snapshot−w]): wide
+ *  enough that a benchmark cadence sparser than the window still finds a
+ *  baseline, without ever reaching into results newer than the window. */
+export function overviewHistoricalWindow(
+  snapshotDate: string,
+  key: OverviewHistoryWindowKey = OVERVIEW_DEFAULT_HISTORY_WINDOW,
+): OverviewHistoricalWindow {
+  const days = OVERVIEW_HISTORY_WINDOW_DAYS[key];
   return {
+    key,
     snapshotDate,
-    targetDate: subtractUtcDays(snapshotDate, 30),
-    earliestDate: subtractUtcDays(snapshotDate, 60),
+    targetDate: subtractUtcDays(snapshotDate, days),
+    earliestDate: subtractUtcDays(snapshotDate, days * 2),
   };
 }
 
@@ -790,7 +813,7 @@ export function assembleOverviewHistoricalPageData(
 
   return {
     ...current,
-    comparisonMode: 'history',
+    comparisonMode: window.key,
     historicalWindow: window,
     models: current.models.map((model) => ({
       ...model,

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -250,11 +250,9 @@ describe('overviewHref', () => {
 
   it('adds historical comparison last and omits the default comparison mode', () => {
     expect(overviewHref('en', 50, 'community', 'hardware')).toBe('/overview');
-    expect(overviewHref('en', 50, 'community', 'history')).toBe('/overview?compare=30d');
-    expect(overviewHref('en', 100, 'all', 'history')).toBe(
-      '/overview?tier=100&engine=all&compare=30d',
-    );
-    expect(overviewHref('zh', 100, 'all', 'history')).toBe(
+    expect(overviewHref('en', 50, 'community', '30d')).toBe('/overview?compare=30d');
+    expect(overviewHref('en', 100, 'all', '30d')).toBe('/overview?tier=100&engine=all&compare=30d');
+    expect(overviewHref('zh', 100, 'all', '30d')).toBe(
       '/zh/overview?tier=100&engine=all&compare=30d',
     );
   });
@@ -262,10 +260,10 @@ describe('overviewHref', () => {
   it('omits the B200 default reference and preserves a non-default reference in every mode', () => {
     expect(overviewHref('en', 50, 'community', 'hardware', 'b200')).toBe('/overview');
     expect(overviewHref('en', 50, 'community', 'hardware', 'b300')).toBe('/overview?ref=b300');
-    expect(overviewHref('en', 100, 'all', 'history', 'b300')).toBe(
+    expect(overviewHref('en', 100, 'all', '30d', 'b300')).toBe(
       '/overview?tier=100&engine=all&ref=b300&compare=30d',
     );
-    expect(overviewHref('zh', 50, 'community', 'history', 'b300')).toBe(
+    expect(overviewHref('zh', 50, 'community', '30d', 'b300')).toBe(
       '/zh/overview?ref=b300&compare=30d',
     );
   });
@@ -304,7 +302,7 @@ describe('overview switch links', () => {
   );
 
   it('preserves historical comparison when changing tiers', () => {
-    expect(overviewTierHref('en', 75, 'all', 'history')).toBe(
+    expect(overviewTierHref('en', 75, 'all', '30d')).toBe(
       '/overview?tier=75&engine=all&compare=30d',
     );
   });
@@ -329,7 +327,7 @@ describe('overview switch links', () => {
   );
 
   it('preserves historical comparison when changing engine scope', () => {
-    expect(overviewEngineScopeHref('en', 'all', 50, 'history')).toBe(
+    expect(overviewEngineScopeHref('en', 'all', 50, '30d')).toBe(
       '/overview?engine=all&compare=30d',
     );
   });
@@ -347,7 +345,7 @@ describe('overview model scope links', () => {
     expect(overviewHref('en', 50, 'community', 'hardware', 'b200', 'all')).toBe(
       '/overview?models=all',
     );
-    expect(overviewHref('en', 100, 'all', 'history', 'b300', 'all')).toBe(
+    expect(overviewHref('en', 100, 'all', '30d', 'b300', 'all')).toBe(
       '/overview?tier=100&engine=all&ref=b300&compare=30d&models=all',
     );
     expect(overviewHref('zh', 50, 'community', 'hardware', 'b200', 'all')).toBe(

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -205,7 +205,7 @@ export function overviewHref(
   if (referenceHardware !== OVERVIEW_DEFAULT_REFERENCE_HARDWARE) {
     query.set('ref', referenceHardware);
   }
-  if (comparisonMode === 'history') query.set('compare', '30d');
+  if (comparisonMode !== 'hardware') query.set('compare', comparisonMode);
   if (modelScope !== OVERVIEW_DEFAULT_MODEL_SCOPE) query.set('models', modelScope);
   const search = query.toString();
   return search === '' ? base : `${base}?${search}`;


### PR DESCRIPTION
## What changed

- The Overview history comparison, previously fixed at 30 days, now offers 1 week / 1 month / 2 months / 3 months ago, picked from a selector embedded in the active tab — the same pattern as the hardware reference selector.
- `OverviewComparisonMode` is now `'hardware' | '7d' | '30d' | '60d' | '90d'`: the mode itself carries the window, so `?compare=<key>` alone determines the payload and every href, cache key, and resolver threads the window with no extra parameter. `?compare=30d` links keep working unchanged.
- The baseline band generalizes the existing 30/60-day rule: target = snapshot − window, floor = snapshot − 2×window.
- Captions and legends now state the active window's day range (e.g. "7–14 days earlier").

Data context: weekly scheduled snapshot sweeps (SemiAnalysisAI/InferenceX#2586, parent SemiAnalysisAI/InferenceX#2304) will populate the 1-week window; longer windows work from existing history today.

## Validation

- `bun run test:unit` — 3362 passed (resolver/window/assembler cases added)
- Overview Cypress: 34/34 (new spec: switching 7d/90d through the selector updates URL, aria-current and captions)
- `bun run typecheck` / `bun run lint` / `bun run fmt` / `bun run build`

## 中文说明

- Overview 历史对比原先固定 30 天，现在可选 1 周前 / 1 个月前 / 2 个月前 / 3 个月前，选择器内嵌在激活的对比标签中——与基准硬件选择器同一交互模式。
- `OverviewComparisonMode` 改为 `'hardware' | '7d' | '30d' | '60d' | '90d'`：模式本身携带时间窗口，`?compare=<key>` 单参数即可决定数据负载，所有 href、缓存 key、resolver 无需额外参数即穿透窗口。旧 `?compare=30d` 链接行为不变。
- 基线区间泛化现有 30/60 天规则：target = snapshot − 窗口，下限 = snapshot − 2×窗口。
- 说明文字与图例按当前窗口显示天数范围（如「7–14 天前」）。

数据背景：每周定时 snapshot sweep（SemiAnalysisAI/InferenceX#2586，父 issue SemiAnalysisAI/InferenceX#2304）将为 1 周窗口供数；更长窗口基于现有历史即可工作。

https://claude.ai/code/session_01Ltmsy4CWWcA1XetNR7JBev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes overview comparison semantics, URL/BFF parameters, and historical baseline queries across the matrix—not auth—but incorrect window math or caching could show wrong cost deltas.
> 
> **Overview**
> Overview history comparison is no longer locked to 30 days. Users can pick **1 week / 1 month / 2 months / 3 months ago** from a Radix select embedded in the active “change over time” tab, mirroring the hardware reference selector.
> 
> **Model & URL contract:** `OverviewComparisonMode` becomes `'hardware' | '7d' | '30d' | '60d' | '90d'` instead of a generic `'history'` mode. `?compare=<key>` alone drives BFF assembly, cache keys, and link builders; existing `?compare=30d` links keep working.
> 
> **Data:** `overviewHistoricalWindow` generalizes the baseline band to `target = snapshot − window` and `earliest = snapshot − 2×window`. The server passes the resolved window key into historical assembly instead of hard-coding 30/60 days.
> 
> **UI/navigation:** `OverviewComparisonContext` and `useOverviewComparisonMode` derive the active window from the **pending** URL so the selector updates during in-flight navigations. Captions and legends use the active window’s day range (e.g. 7–14 days earlier).
> 
> Tests and Cypress specs follow the new `data-overview-comparison` keys and add coverage for switching 7d/90d via the embedded selector; horizontal-overflow checks ignore Radix’s aria-hidden native `<select>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0ad9a83c74899c919feedd9ba91a559b9040e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->