### PR TITLE
Remove stage results concurrency lock

### DIFF
--- a/.github/workflows/stage-results.yml
+++ b/.github/workflows/stage-results.yml
@@ -40,12 +40,6 @@ on:
 
 permissions: {}
 
-concurrency:
-  # Do not ingest staged benchmark runs while the scheduled production restore
-  # is replacing the shared staging database (or vice versa).
-  group: staging-database-maintenance
-  cancel-in-progress: false
-
 jobs:
   validate:
     name: Validate staging request


### PR DESCRIPTION
## Summary

Remove the workflow-level concurrency group from the stage-results workflow so independent staging requests can run in parallel.

## Validation

- YAML parse
- Repository pre-commit format, lint, and TypeScript checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Staging Neon ingest can now overlap with other **`stage-results`** runs and with the scheduled production restore workflow, which may race on the shared staging database despite idempotent run-keyed ingest.
> 
> **Overview**
> Removes the workflow-level **`concurrency`** block (`group: staging-database-maintenance`, `cancel-in-progress: false`) from **`stage-results.yml`**.
> 
> That group previously serialized **`stage-results`** with other workflows using the same name—notably the scheduled **`sync-staging-database`** production restore—so ingest and full DB restore would not overlap. **`sync-staging-database.yml`** still uses **`staging-database-maintenance`**; only **`stage-results`** leaves the queue.
> 
> **Effect:** independent InferenceX staging requests can start and run **`stage-results`** concurrently instead of waiting on the shared maintenance lock (and on each other when they shared the group).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c46e2c1502bc9085de22894757eca95fd3471ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->