### PR TITLE
feat(quotes): add Mooncake supporter quote / 添加 Mooncake 支持者评价

### DIFF
--- a/packages/app/cypress/component/quotes-content.cy.tsx
+++ b/packages/app/cypress/component/quotes-content.cy.tsx
@@ -32,6 +32,26 @@ describe('QuotesContent', () => {
     cy.get('button[aria-label^="Jump to"]').should('have.length', uniqueOrgsWithLogo.length);
   });
 
+  it('renders the Mooncake team quote with the KVCache.AI identity', () => {
+    cy.get('#quote-mooncake').within(() => {
+      cy.contains('Mooncake makes KV cache a first-class system resource').should('be.visible');
+      cy.contains('a', 'Mooncake Team')
+        .should('have.attr', 'href', 'https://kvcache.ai/')
+        .and('have.attr', 'target', '_blank');
+      cy.get('img[alt="Mooncake"]')
+        .should('have.attr', 'src', '/logos/kvcache-ai.svg')
+        .and(($logo) => {
+          expect(($logo[0] as HTMLImageElement).naturalWidth).to.be.greaterThan(0);
+        });
+    });
+
+    cy.mount(<QuotesContent locale="zh" />);
+    cy.get('#quote-mooncake').should(
+      'contain.text',
+      'Mooncake 将 KV cache 作为分离式 LLM 推理中的一等系统资源',
+    );
+  });
+
   it('scrolls to the matching quote when a logo is clicked', () => {
     const targetOrg = uniqueOrgsWithLogo[0];
 

--- a/packages/app/public/logos/kvcache-ai.svg
+++ b/packages/app/public/logos/kvcache-ai.svg
@@ -1,0 +1,5 @@
+<!-- Vectorized from the official KVCache.AI mark at https://kvcache.ai/media/icon_1.png. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240" role="img" aria-label="KVCache.AI">
+  <path d="M0 0h68v44L0 108V0Zm0 132 68 64v44H0V132Z" />
+  <path fill="#9d0eb3" d="M157 0h83L115 120l125 120h-83L31 120 157 0Z" />
+</svg>

--- a/packages/app/src/components/quotes/quotes-data.test.ts
+++ b/packages/app/src/components/quotes/quotes-data.test.ts
@@ -22,6 +22,10 @@ describe('quote carousel membership', () => {
     expect(new Set(CAROUSEL_ORGS).size).toBe(CAROUSEL_ORGS.length);
   });
 
+  it('features Mooncake in the landing carousel', () => {
+    expect(CAROUSEL_ORGS).toContain('Mooncake');
+  });
+
   it.each(OFF_CAROUSEL_ONLY)('excludes %s from the carousel', (org) => {
     expect((CAROUSEL_ORGS as readonly string[]).includes(org)).toBe(false);
   });

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -541,6 +541,7 @@ export const CAROUSEL_ORGS = [
   'Red Hat',
   'SambaNova',
   'TileRT',
+  'Mooncake',
 ] as const;
 
 /**

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -502,6 +502,16 @@ export const QUOTES: Quote[] = [
     logo: 'lmcache.webp',
     link: 'https://www.linkedin.com/in/yihuacheng-215133327/',
   },
+  {
+    text: 'Mooncake makes KV cache a first-class system resource for disaggregated LLM serving. Real-world performance depends on the full configuration model, hardware, prefill/decode topology, parallelism strategy, and workload. InferenceX™ tests Mooncake across a broad and growing range of configurations, openly and reproducibly, giving the community a clear view of the tradeoffs and helping us improve the system faster.',
+    textZh:
+      'Mooncake 将 KV cache 作为分离式 LLM 推理中的一等系统资源。真实性能取决于完整的配置组合——模型、硬件、预填充/解码拓扑、并行策略和工作负载。InferenceX™ 以开放、可复现的方式，在持续扩展的丰富配置上测试 Mooncake，让社区清晰了解其中的权衡，也帮助我们更快地改进系统。',
+    name: 'Mooncake Team',
+    title: '',
+    org: 'Mooncake',
+    logo: 'kvcache-ai.svg',
+    link: 'https://kvcache.ai/',
+  },
 ];
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Content and asset updates on marketing quotes UI with accompanying tests; no auth, data, or core inference logic changes.
> 
> **Overview**
> Adds a **Mooncake** supporter quote to the quotes page and landing carousel, with English and Simplified Chinese copy attributed to the Mooncake Team and linking to **kvcache.ai**.
> 
> Introduces **`kvcache-ai.svg`** for the carousel/logo treatment and extends **unit** and **Cypress** coverage so Mooncake appears in `CAROUSEL_ORGS` and the `#quote-mooncake` block renders the expected text, link, logo, and zh translation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416c8f8670f7f44e29d5203bca76910ae8b11021. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->