### PR TITLE
feat(models): label GLM-5.2 data as GLM-5.2/GLM-5.3 / 将 GLM-5.2 数据标注为 GLM-5.2/GLM-5.3

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -4,7 +4,7 @@ const MODEL_LABELS = [
   'DeepSeek V4 Pro 1.6T',
   'Kimi K3 2.8T',
   'MiniMax M3 428B',
-  'GLM5.2',
+  'GLM5.2/GLM5.3',
   'Qwen3.5 397B',
 ];
 

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -277,7 +277,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
     expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
-    expect(getModelLabel(Model.GLM_5_2)).toBe('GLM5.2');
+    expect(getModelLabel(Model.GLM_5_2)).toBe('GLM5.2/GLM5.3');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -155,7 +155,9 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     category: 'maintenance',
   },
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'deprecated' },
-  [Model.GLM_5_2]: { label: 'GLM5.2', prefix: 'glm5.2', category: 'default' },
+  // GLM-5.2 and GLM-5.3 share the same architecture and inference profile, so
+  // the selector presents both releases over the existing GLM-5.2 data bucket.
+  [Model.GLM_5_2]: { label: 'GLM5.2/GLM5.3', prefix: 'glm5.2', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only label and test string updates; benchmark routing and data keys (`GLM-5.2`, `glm5.2` prefix) are unchanged.
> 
> **Overview**
> Updates the **display label** for `Model.GLM_5_2` from `GLM5.2` to **`GLM5.2/GLM5.3`** in `MODEL_CONFIG`, with a short comment that GLM-5.2 and GLM-5.3 share the same architecture and inference profile so both releases are shown against the existing GLM-5.2 data bucket (no new model key or prefix).
> 
> **Tests** align with the new label in `getModelLabel` and the overview Cypress `MODEL_LABELS` fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0c60c18690844ef8fad8c789e9fc638314d7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->