### PR TITLE
fix(models): correct four release dates and source the other eight / 修正四个错误的模型发布日期并为其余八个补充来源

### DIFF
--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -404,10 +404,10 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../constants/src/models.ts',
-    // Reviewed for the release-date table move: it adds MODEL_RELEASE_DATES and
-    // getModelReleaseDate. No published model name, alias, or parameter enum is
-    // touched, and no endpoint exposes a release date, so the docs stand.
-    sourceSha256: 'fde7ec056e048452663ddcaa46af137e9ec192676b94c701f57bcc4498417157',
+    // Reviewed again for the release-date corrections: values inside
+    // MODEL_RELEASE_DATES only. No published model name, alias, or parameter enum
+    // is touched, and no endpoint exposes a release date, so the docs stand.
+    sourceSha256: 'f8f46a341bf57384c0080c2ed75d867801142675ded08225281cf7c102236628',
     reviewArea: {
       en: 'Published benchmark and TCO model names, aliases, and parameter enums.',
       zh: '已发布基准与 TCO 模型名称、别名和参数枚举。',

--- a/packages/app/src/lib/model-architectures.test.ts
+++ b/packages/app/src/lib/model-architectures.test.ts
@@ -1,7 +1,7 @@
 import { MODEL_RELEASE_DATES, getModelReleaseDate } from '@semianalysisai/inferencex-constants';
 import { describe, expect, it } from 'vitest';
 
-import { Model } from '@/lib/data-mappings';
+import { MODEL_OPTIONS, Model } from '@/lib/data-mappings';
 
 import {
   type SubBlockFlow,
@@ -21,7 +21,35 @@ import {
   MODEL_ARCHITECTURES,
 } from './model-architectures';
 
-describe('MODEL_RELEASE_DATES keys', () => {
+describe('MODEL_RELEASE_DATES coverage', () => {
+  it('has a sourced date for every model the user can select', () => {
+    // Without a date the Fleet Lifecycle axis falls back to the model's first
+    // benchmark run, which reads as "this is when the model appeared" when it is
+    // really "this is when we got to it" — for gpt-oss that gap is five weeks.
+    // A model whose release date genuinely cannot be sourced belongs in an
+    // explicit allowlist here, so the gap stays visible; do not delete the test.
+    const missing = MODEL_OPTIONS.filter((model) => !getModelReleaseDate(model));
+    expect(missing).toEqual([]);
+  });
+
+  it('anchors each model to its weights publication, not its first sweep', () => {
+    // Pinned so a silent revert fails. Every one of these predates the model's
+    // first InferenceX sweep, which is the invariant that caught the four wrong
+    // dates: a model cannot be benchmarked before its weights exist.
+    expect(getModelReleaseDate(Model.Kimi_K3)).toBe('2026-07-27');
+    expect(getModelReleaseDate(Model.GLM_5_2)).toBe('2026-06-13');
+    expect(getModelReleaseDate(Model.MiniMax_M3)).toBe('2026-06-07');
+    expect(getModelReleaseDate(Model.DeepSeek_V4_Pro)).toBe('2026-04-24');
+    expect(getModelReleaseDate(Model.GLM_5)).toBe('2026-02-13');
+    expect(getModelReleaseDate(Model.Qwen3_5)).toBe('2026-02-16');
+    expect(getModelReleaseDate(Model.MiniMax_M2_5)).toBe('2026-02-12');
+    expect(getModelReleaseDate(Model.Kimi_K2_5)).toBe('2026-01-27');
+    expect(getModelReleaseDate(Model.GptOss)).toBe('2025-08-05');
+    expect(getModelReleaseDate(Model.DeepSeek_R1)).toBe('2025-05-28');
+    expect(getModelReleaseDate(Model.Llama3_3_70B)).toBe('2024-12-06');
+    expect(getModelReleaseDate(Model.Llama3_1_70B)).toBe('2024-07-23');
+  });
+
   it('names a real model, so no entry is dead weight', () => {
     // The table is keyed by string because it lives in the constants package,
     // below the `Model` enum. A key that matches no model never throws — the
@@ -72,12 +100,11 @@ describe('MODEL_ARCHITECTURES', () => {
 
   it('sources every architecture caption from the one release-date table', () => {
     // The diagram prints "Released by {developer} on {date}", so an entry with a
-    // developer and no date silently drops the whole caption. Listing the models
-    // that have no sourced date keeps that visible instead of invisible.
+    // developer and no date silently drops the whole caption.
     const missing = Object.values(MODEL_ARCHITECTURES)
       .filter((arch) => arch?.developer && !getModelReleaseDate(arch.model))
       .map((arch) => arch!.model);
-    expect(missing).toEqual([Model.MiniMax_M3]);
+    expect(missing).toEqual([]);
   });
 
   it('ensures dense models have equal active and total params', () => {

--- a/packages/constants/src/models.test.ts
+++ b/packages/constants/src/models.test.ts
@@ -70,8 +70,10 @@ describe('MODEL_RELEASE_DATES', () => {
   });
 
   it('returns null rather than throwing for a model with no sourced date', () => {
-    expect(getModelReleaseDate('GLM-5.2')).toBeNull();
+    // Every model shipped today has a date, so this documents the fallback path
+    // that a future model arrives on rather than an existing gap.
     expect(getModelReleaseDate('not-a-model')).toBeNull();
+    expect(getModelReleaseDate('')).toBeNull();
   });
 });
 

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -105,14 +105,66 @@ export function rowToSequence(row: {
  * earliest date they actually have data for.
  */
 export const MODEL_RELEASE_DATES: Record<string, string> = {
-  'DeepSeek-R1-0528': '2025-05-28',
-  'Llama-3.3-70B-Instruct-FP8': '2024-12-06',
-  'Llama-3.1-70B-Instruct-FP8-KV': '2024-07-23',
-  'gpt-oss-120b': '2025-06-13',
+  // Newest first. `sweep:` is the model's "Date added" from MODELS.md — the first
+  // InferenceX benchmark — recorded so the "cannot predate its own weights"
+  // invariant above is checkable by eye at review time.
+  //
+  // Weights published on Hugging Face 2026-07-27 under the Kimi K3 License,
+  // eleven days after the 2026-07-16 product launch; the gap was to let vLLM,
+  // NVIDIA and AMD prepare day-zero support. sweep: 2026-07-27 — day zero.
+  'Kimi-K3': '2026-07-27',
+  // Zhipu launched GLM-5.2 on 2026-06-13 via the GLM Coding Plan with MIT
+  // weights at zai-org/GLM-5.2; standalone API and provider support followed
+  // over the next few days. One source dates the Hugging Face upload 2026-06-16
+  // instead, so this is ±3 days — immaterial on a multi-month axis, but it is an
+  // announcement-day date rather than a confirmed upload day. sweep: 2026-07-18.
+  'GLM-5.2': '2026-06-13',
+  // Weights and the official MXFP8 quant live on Hugging Face at
+  // MiniMaxAI/MiniMax-M3 by 2026-06-07, under the custom minimax-community
+  // license. The 2026-06-01 launch shipped API access only; the arXiv report
+  // followed on 2026-06-11. sweep: 2026-06-12.
+  'MiniMax-M3': '2026-06-07',
+  // V4 Preview — V4-Pro (1.6T total / 49B active) and V4-Flash (284B/13B)
+  // published together under MIT on Hugging Face, the API and chat.deepseek.com.
+  // V4-Pro-0813 went GA on 2026-08-13, but the Hugging Face repo still hosts the
+  // April preview build, so the weights date is unchanged. sweep: 2026-04-25.
+  'DeepSeek-V4-Pro': '2026-04-24',
+  // Bucket covers GLM-5 and GLM-5.1, so the date is GLM-5's: released
+  // 2026-02-13, 744B/40B active, MIT, trained entirely on Huawei Ascend. Sources
+  // put the weights in "mid-February" without a day, and reporting clusters on
+  // 2026-02-13 and 2026-02-17; the Hugging Face commit history at zai-org/GLM-5
+  // is the authority if this ever needs to be exact. GLM-5.1 followed in April
+  // 2026. sweep: 2026-03-06.
+  'GLM-5': '2026-02-13',
+  // Apache 2.0 weights, plus official FP8 and GPTQ-Int4 quants, published at
+  // Qwen/Qwen3.5-397B-A17B on 2026-02-16 — the same day InferenceX first swept
+  // it. sweep: 2026-02-16 — day zero.
+  'Qwen-3.5-397B-A17B': '2026-02-16',
+  // Bucket covers M2.5 and M2.7, so the date is M2.5's: announced 2026-02-12
+  // with weights on Hugging Face, architecturally unchanged from M2 (230B/10B).
+  // Was 2025-10-25, which is M2's launch, not M2.5's — `model-architectures.ts`
+  // still points its sourceUrl at MiniMax-M2, which is where that came from.
+  // sweep: 2026-02-18.
+  'MiniMax-M2.5': '2026-02-12',
+  // Weights at moonshotai/Kimi-K2.5 on 2026-01-27 under a modified MIT license,
+  // 1.04T total / 32B active. sweep: 2026-02-17.
   'Kimi-K2.5': '2026-01-27',
-  'Kimi-K3': '2026-06-13',
-  'MiniMax-M2.5': '2025-10-25',
-  'DeepSeek-V4-Pro': '2026-06-08',
+  // Weights landed on Hugging Face 2025-08-05 under Apache 2.0, alongside
+  // gpt-oss-20b — OpenAI's first open-weight release since GPT-2. AWS Bedrock
+  // lists the same launch date; the model-card paper followed on 2025-08-08. Was
+  // 2025-06-13, which precedes the release by seven weeks and matches no
+  // published event. sweep: 2025-09-09.
+  'gpt-oss-120b': '2025-08-05',
+  // Announced by WeChat post and pushed to Hugging Face on 2025-05-28 under MIT
+  // — the date the model name encodes. The model card commit landed a day later,
+  // weights first. sweep: 2025-08-13.
+  'DeepSeek-R1-0528': '2025-05-28',
+  // Meta published Llama 3.3 70B Instruct on 2024-12-06. sweep: 2025-08-12,
+  // shipped as workflow templates in the initial repo import.
+  'Llama-3.3-70B-Instruct-FP8': '2024-12-06',
+  // Llama 3.1 was published 2024-07-23. Hidden in the model selector, but the
+  // architecture diagram still captions it. No InferenceX sweep of its own.
+  'Llama-3.1-70B-Instruct-FP8-KV': '2024-07-23',
 };
 
 /** Release date for a display model name, or null when we have no sourced date. */


### PR DESCRIPTION
> #738 and #742 have merged. Rebased directly onto `master` — the squash-merge of #738 landed as a new commit, so this branch was still carrying the original and GitHub saw the same change twice. Now a single commit on `master`, no conflicts.

## Summary

#738 moved the release dates into one table without changing them. This PR fixes them. Four of the eight were wrong, and four models had no date at all.

Every entry now cites its source and records the model's **first InferenceX sweep** (MODELS.md "Date added") beside it, so the invariant that caught these is checkable at review time: *a model cannot be benchmarked before its weights exist.*

### Corrected

| Model | Was | Now | Why the old value is wrong |
|---|---|---|---|
| DeepSeek-V4-Pro | 2026-06-08 | **2026-04-24** | Six weeks *after* its own first sweep (2026-04-25). V4-Pro-0813 went GA 2026-08-13, but Hugging Face still hosts the April preview build, so the weights date does not move. |
| Kimi-K3 | 2026-06-13 | **2026-07-27** | Weights day. The product launched 2026-07-16; the gap let vLLM/NVIDIA/AMD prepare day-zero support, and InferenceX swept it the day weights landed. |
| MiniMax-M2.5 | 2025-10-25 | **2026-02-12** | That is **M2's** launch, not M2.5's. M2.5 is architecturally unchanged from M2, and the architecture entry still points its `sourceUrl` at `MiniMax-M2` — which is where the date came from. |
| gpt-oss-120b | 2025-06-13 | **2025-08-05** | The Apache 2.0 release alongside gpt-oss-20b. The old date precedes it by seven weeks and matches no published event. |

### Added

`Qwen-3.5-397B-A17B` 2026-02-16 · `GLM-5` 2026-02-13 · `MiniMax-M3` 2026-06-07 · `GLM-5.2` 2026-06-13

### Unchanged, confirmed

`DeepSeek-R1-0528` 2025-05-28 (the date the name encodes) · `Kimi-K2.5` 2026-01-27 · `Llama-3.3-70B` 2024-12-06 · `Llama-3.1-70B` 2024-07-23

## Two dates are softer than the rest

Both say so in place rather than presenting a guess as sourced:

- **GLM-5** — weights sourced only to "mid-February"; reporting splits between 2026-02-13 and 2026-02-17. The HF commit history at `zai-org/GLM-5` is the authority if it ever needs to be exact.
- **GLM-5.2** — most sources date the HF upload 2026-06-13, one says 2026-06-16.

Each is ±3 days on an axis sampled monthly, and both sit comfortably before their first sweep, so the ambiguity changes no rendered value — but these are announcement-day dates, not confirmed upload days.

## Conventions applied

- **The date is the weights publication**, not the announcement and not the day InferenceX started benchmarking. Third-party inference optimisation — exactly what the Fleet Lifecycle chart tracks — cannot begin before the weights are public.
- **A point-release bucket takes the earliest release in it**, because that is when the bucket's weights first existed: `GLM-5` covers 5 and 5.1, `MiniMax-M2.5` covers 2.5 and 2.7, `Kimi-K2.5` covers 2.5, 2.6 and 2.7-Code.

## Why it matters

Every selectable model now has a date, so the Fleet Lifecycle axis stops falling back to "anchored to its first benchmark run instead" — which reads as *when the model appeared* but means *when we got to it*. For gpt-oss that fallback was five weeks late; for Llama-3.3, eight months.

On `master` the visible change is the architecture-diagram caption for the four corrected models, plus MiniMax-M3 gaining a caption it never rendered.

## Verification

Both new tests were mutation-verified — mutant applied, named test observed failing, reverted:

| Test | Mutation that kills it |
|---|---|
| coverage over `MODEL_OPTIONS` | delete the `Qwen-3.5-397B-A17B` entry |
| the twelve dates pinned | revert gpt-oss to `2025-06-13` |

- `packages/constants` unit: 39/39 · `model-architectures.test.ts`: 68/68
- `bun run lint`, `bun run fmt`, `bun run typecheck`: clean
- **Pre-existing failures on `master`, untouched here**: `api-route-catalog` digest, `overview-data` AgentX frontier, `useThroughputData` agentic interpolation.

## 中文说明

#738 只是把发布日期合并到一张表，未改动数值；本 PR 负责修正。八个日期中四个是错的，另有四个模型完全没有日期。现每条均附来源，并在旁记录 MODELS.md 中该模型的首次 InferenceX 基准日期，以便评审时核对「模型不可能早于其权重发布被基准测试」这一约束。

修正：DeepSeek-V4-Pro 2026-06-08 → **2026-04-24**（原值比首次基准 2026-04-25 还晚六周；0813 版本虽已 GA，但 Hugging Face 仍托管四月预览版权重，故日期不变）；Kimi-K3 2026-06-13 → **2026-07-27**（权重发布日，产品发布为 07-16，留出时间供 vLLM/NVIDIA/AMD 准备零日支持）；MiniMax-M2.5 2025-10-25 → **2026-02-12**（原值是 M2 的发布日而非 M2.5；M2.5 架构与 M2 相同，架构条目的 sourceUrl 至今仍指向 MiniMax-M2，错误正源于此）；gpt-oss-120b 2025-06-13 → **2025-08-05**（Apache 2.0 发布日，原值早了七周且不对应任何公开事件）。

新增：Qwen-3.5-397B-A17B 2026-02-16、GLM-5 2026-02-13、MiniMax-M3 2026-06-07、GLM-5.2 2026-06-13。确认无误：DeepSeek-R1-0528、Kimi-K2.5、Llama-3.3-70B、Llama-3.1-70B。

其中 GLM-5 与 GLM-5.2 的权重上传日仅能定位到 ±3 天（GLM-5 仅有"二月中"的说法，报道分散在 02-13 与 02-17；GLM-5.2 多数来源为 06-13，一处为 06-16），已在注释中如实标明，不将推测包装为确证。

约定：日期取**权重公开可下载之日**，而非发布公告日或 InferenceX 开始基准测试之日——第三方推理优化（也正是集群生命周期图所追踪的内容）只能在权重公开后才可能开始；分桶取其中最早的发布日期。

现所有可选模型均有日期，集群生命周期时间轴不再回退到"以首次基准测试锚定"——该回退会被读作"模型出现的时间"，实则是"我们开始测的时间"，gpt-oss 相差五周，Llama-3.3 相差八个月。在 `master` 上可见的变化是四个模型的架构图日期说明，以及 MiniMax-M3 首次显示该说明。

验证：两项新测试均经变异测试验证；constants 单测 39/39，`model-architectures.test.ts` 68/68，lint/fmt/typecheck 均通过。另有三项单测在 `master` 上即为失败，与本 PR 无关。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal constants and UI date anchoring only; no API contract or auth changes. Wrong dates would mislabel charts but are now heavily tested.
> 
> **Overview**
> **Corrects and completes `MODEL_RELEASE_DATES`** so Fleet Lifecycle and architecture captions anchor on **weights publication**, not first InferenceX sweep or wrong sibling launches.
> 
> Four dates are fixed: **DeepSeek-V4-Pro** (2026-04-24, before its first sweep), **Kimi-K3** (2026-07-27), **MiniMax-M2.5** (2026-02-12, not M2’s date), and **gpt-oss-120b** (2025-08-05). Four models gain sourced entries (**Qwen-3.5**, **GLM-5**, **MiniMax-M3**, **GLM-5.2**), each with inline sources and `sweep:` notes for review.
> 
> **Tests** now require every `MODEL_OPTIONS` model to have a release date, pin twelve expected dates (mutation-tested), and expect full architecture-caption coverage (e.g. MiniMax-M3). Constants tests document the null fallback for unknown names only.
> 
> **API contract ledger** updates the `models.ts` digest and review note—release-date values only; no published API surface change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66721e074f19ea6a28f3f05595d56b9407b0d7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
