### PR TITLE
test: realign the AgentX frontier tests with #736 / 将 AgentX 前沿相关测试对齐 #736

### DIFF
--- a/packages/app/cypress/e2e/csv-export-overlay.cy.ts
+++ b/packages/app/cypress/e2e/csv-export-overlay.cy.ts
@@ -35,9 +35,10 @@ function readCapturedCsv(): Cypress.Chainable<string> {
 describe('Inference CSV export with an unofficial-run overlay', () => {
   before(() => {
     interceptOverlayRun();
-    // The agentic default mode is E2E Normalized Interactivity (which suppresses overlays and
-    // fetches derived metrics) — stub the fetch, then switch to the
-    // Interactivity mode this suite's overlay assertions rely on.
+    // Agentic charts default to Interactivity, where the overlay renders. The
+    // derived-metrics fetch now happens only under E2E Normalized Interactivity,
+    // so the stub below is a guard against a stray request rather than a
+    // dependency of this suite.
     interceptDerivedAgenticMetrics();
     cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces&i_pctl=p90`, {
       onBeforeLoad(win) {
@@ -47,12 +48,11 @@ describe('Inference CSV export with an unofficial-run overlay', () => {
       },
     });
     cy.wait('@unofficialRun');
-    // Interactivity is nested under the Advanced menu on agentic charts.
-    cy.get('[data-testid="x-axis-mode-advanced"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
-    cy.get('[data-testid="x-axis-mode-advanced"]')
-      .should('have.attr', 'data-state', 'active')
-      .and('contain.text', 'Interactivity');
+    // Every x-axis metric is a top-level tab on agentic charts, and Interactivity
+    // is the default — clicked anyway so the suite does not depend on that.
+    cy.get('[data-testid="x-axis-mode-interactivity"]')
+      .click()
+      .should('have.attr', 'data-state', 'active');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should('exist');
   });
 

--- a/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
+++ b/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
@@ -22,9 +22,10 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
     // Use distinct hardware so the engine-comparison exclusion policy does
     // not resolve the official and unofficial rows as one competing family.
     interceptOverlayRun({ overlayHardware: 'h100' });
-    // The agentic default mode is E2E Normalized Interactivity (which suppresses overlays and
-    // fetches derived metrics) — stub the fetch, then switch to Interactivity
-    // where the overlay renders.
+    // Agentic charts default to Interactivity, where the overlay renders. The
+    // derived-metrics fetch now happens only under E2E Normalized Interactivity,
+    // so the stub below is a guard against a stray request rather than a
+    // dependency of this suite.
     interceptDerivedAgenticMetrics();
     cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces&i_pctl=p90`, {
       onBeforeLoad(win) {
@@ -33,14 +34,26 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
       },
     });
     cy.wait('@unofficialRun');
-    // Interactivity is nested under the Advanced menu on agentic charts.
-    cy.get('[data-testid="x-axis-mode-advanced"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    // Every x-axis metric is a top-level tab on agentic charts, and Interactivity
+    // is the default — clicked anyway so the suite does not depend on that.
+    cy.get('[data-testid="x-axis-mode-interactivity"]')
+      .click()
+      .should('have.attr', 'data-state', 'active');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(
       'have.length',
       REAL_CONFIGS.length,
     );
+  });
+
+  // Cypress clears intercepts between tests, so the derived-metrics stub is
+  // re-registered per test rather than once in `before`. Until #736 the
+  // agentic default was E2E Normalized Interactivity, so the fetch happened
+  // during `before` while the stub was still alive and React Query held the
+  // result for the rest of the spec. The default no longer fetches, so any
+  // later switch into that mode issues a fresh request.
+  beforeEach(() => {
+    interceptDerivedAgenticMetrics();
   });
 
   it('shows official points and an official legend entry initially', () => {
@@ -69,10 +82,12 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
     cy.get('[data-testid="inference-chart-display"] svg .dot-group').should(($dots) => {
       expect(countVisible($dots), 'visible official points after remove').to.eq(0);
     });
-    // The overlay series is untouched. Optimal Only still hides its trace-less
-    // points because unofficial rows cannot join the canonical frontier.
+    // The overlay series is untouched — hiding an official SKU must not disturb
+    // it. All five overlay points stay visible under Optimal Only: they are
+    // non-dominated on the interactivity axes, and since #736 lacking persisted
+    // traces no longer excludes them from the frontier.
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(($pts) => {
-      expect(countVisible($pts), 'visible overlay X markers').to.eq(0);
+      expect(countVisible($pts), 'visible overlay X markers').to.eq(REAL_CONFIGS.length);
     });
     // Inactive row: the hover affordance flips to the "+" restore indicator
     // (explicit "clicking the name brings it back"), and the Hide X is gone.

--- a/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
+++ b/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
@@ -1,22 +1,31 @@
 /**
- * Unofficial runs do not have persisted request traces, so they cannot join
- * the canonical E2E Normalized Interactivity frontier. Optimal Only must hide
- * them on every AgentX axis; Show All remains the explicit way to inspect them.
+ * Optimal Only must filter overlay (unofficial-run) points by the same rule it
+ * applies to official ones: the Pareto frontier of the *selected* axes.
+ *
+ * Until #736 the rule was different — unofficial runs have no persisted request
+ * traces, so they could never join the canonical E2E Normalized Interactivity
+ * frontier and Optimal Only hid every one of them. That gating is gone, so an
+ * overlay point now survives exactly when it is non-dominated on the axes on
+ * screen, and Show All remains the way to inspect the rest.
  */
 import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
 import {
   countVisible,
+  DOMINATED_CONFIG,
   interceptOverlayRun,
   OVERLAY_RUN_ID,
   REAL_CONFIGS,
 } from '../support/overlay-fixtures';
 
-describe('Overlay points follow canonical Optimal Only policy (agentic interactivity)', () => {
+// The five real configs are all non-dominated on the interactivity axes, so a
+// sixth, deliberately dominated point is what gives Optimal Only something to
+// remove. Without it this suite would assert the same count either way and pass
+// no matter what the filter did.
+const OVERLAY_CONFIGS = [...REAL_CONFIGS, DOMINATED_CONFIG];
+
+describe('Overlay points follow Optimal Only on the selected axes', () => {
   before(() => {
-    interceptOverlayRun();
-    // The agentic default mode is E2E Normalized Interactivity (which suppresses overlays and
-    // fetches derived metrics) — stub the fetch, then switch to the
-    // Interactivity mode this suite is about.
+    interceptOverlayRun({ overlayConfigs: OVERLAY_CONFIGS });
     interceptDerivedAgenticMetrics();
     cy.visit(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces&i_pctl=p90`, {
       onBeforeLoad(win) {
@@ -25,30 +34,37 @@ describe('Overlay points follow canonical Optimal Only policy (agentic interacti
       },
     });
     cy.wait('@unofficialRun');
-    // Interactivity is nested under the Advanced menu on agentic charts.
-    cy.get('[data-testid="x-axis-mode-advanced"]').click();
-    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    // Every x-axis metric is a top-level tab on agentic charts, and Interactivity
+    // is the default — clicked anyway so the suite does not depend on that.
+    cy.get('[data-testid="x-axis-mode-interactivity"]')
+      .click()
+      .should('have.attr', 'data-state', 'active');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
-    cy.get('[data-testid="x-axis-mode-advanced"]')
-      .should('have.attr', 'data-state', 'active')
-      .and('contain.text', 'Interactivity');
+    // All six are rendered; visibility is what Optimal Only changes.
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(
       'have.length',
-      REAL_CONFIGS.length,
+      OVERLAY_CONFIGS.length,
     );
   });
 
-  it('hides trace-less overlay points in the default Optimal Only view', () => {
+  // Cypress clears intercepts between tests, so the derived-metrics stub is
+  // re-registered per test rather than once in `before`. Until #736 the agentic
+  // default was E2E Normalized Interactivity, so the fetch happened during
+  // `before` while the stub was still alive and React Query held the result for
+  // the rest of the spec. The default no longer fetches.
+  beforeEach(() => {
+    interceptDerivedAgenticMetrics();
+  });
+
+  it('drops only the dominated overlay point in the default Optimal Only view', () => {
     cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'checked');
-    // The deterministic derived-metric stub puts all five official rows on the
-    // canonical frontier.
     cy.get('[data-testid="inference-chart-display"] svg .dot-group').should(($dots) => {
       expect(countVisible($dots), 'visible official points').to.eq(REAL_CONFIGS.length);
     });
-    // Overlay rows have no persisted trace ids and therefore no canonical
-    // frontier membership.
+    // Five of six survive: every real config is non-dominated on these axes, and
+    // the overlay's trace-less rows are no longer excluded for lacking traces.
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(($pts) => {
-      expect(countVisible($pts), 'visible overlay X markers').to.eq(0);
+      expect(countVisible($pts), 'visible overlay X markers').to.eq(REAL_CONFIGS.length);
     });
   });
 
@@ -56,15 +72,15 @@ describe('Overlay points follow canonical Optimal Only policy (agentic interacti
     cy.get('#scatter-hide-non-optimal').click();
     cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'unchecked');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(($pts) => {
-      expect(countVisible($pts), 'visible overlay X markers').to.eq(REAL_CONFIGS.length);
+      expect(countVisible($pts), 'visible overlay X markers').to.eq(OVERLAY_CONFIGS.length);
     });
   });
 
-  it('re-hides trace-less overlay points when Optimal Only is re-enabled', () => {
+  it('re-drops the dominated overlay point when Optimal Only is re-enabled', () => {
     cy.get('#scatter-hide-non-optimal').click();
     cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'checked');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(($pts) => {
-      expect(countVisible($pts), 'visible overlay X markers').to.eq(0);
+      expect(countVisible($pts), 'visible overlay X markers').to.eq(REAL_CONFIGS.length);
     });
   });
 });

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -124,25 +124,23 @@ const interceptFixedSequenceData = () => {
 };
 
 /**
- * On agentic charts, Interactivity / E2E Latency / TTFT live inside the
- * "Advanced" menu rather than as top-level tabs, so they must be revealed
- * before they can be clicked. The menu closes on select, so the post-select
- * assertion targets the trigger, which carries the active state and the
- * selected metric's label.
+ * Every x-axis metric is a top-level tab, on agentic charts as well as fixed
+ * sequences — #736 removed the "Advanced" popover that used to hide
+ * Interactivity / E2E Latency / TTFT behind a trigger. The tab itself now
+ * carries both the selected state and the metric's label.
  */
-function selectAdvancedXAxisMode(mode: 'interactivity' | 'e2e' | 'ttft', label: string) {
-  cy.get('[data-testid="x-axis-mode-advanced"]').click();
+function selectXAxisMode(mode: 'interactivity' | 'e2e' | 'ttft', label: string) {
   cy.get(`[data-testid="x-axis-mode-${mode}"]`).click();
-  cy.get('[data-testid="x-axis-mode-advanced"]')
-    .should('have.attr', 'data-state', 'active')
+  cy.get(`[data-testid="x-axis-mode-${mode}"]`)
+    .should('have.attr', 'aria-selected', 'true')
     .and('contain.text', label);
 }
 
 describe('X-Axis Mode Toggle (inference chart)', () => {
   before(() => {
     interceptAgenticData();
-    // The agentic default mode is E2E Normalized Interactivity, which fetches derived metrics
-    // on first render — stub them before the visit.
+    // Agentic defaults to Interactivity, which needs no derived metrics. The stub
+    // covers the first switch into E2E Normalized Interactivity further down.
     interceptDerivedAgenticMetrics();
     cy.visit('/inference?i_seq=agentic-traces', {
       onBeforeLoad(win) {
@@ -154,34 +152,50 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
   });
 
-  it('shows E2E Normalized Interactivity by default for the agentic view, as the leftmost option', () => {
+  // Cypress clears intercepts between tests, so the derived-metrics stub is
+  // re-registered per test rather than once in `before`. Until #736 the
+  // agentic default was E2E Normalized Interactivity, so the fetch happened
+  // during `before` while the stub was still alive and React Query held the
+  // result for the rest of the spec. The default no longer fetches, so any
+  // later switch into that mode issues a fresh request.
+  beforeEach(() => {
+    interceptDerivedAgenticMetrics();
+  });
+
+  it('defaults the agentic view to Interactivity, with all four modes as flat tabs', () => {
     cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
-    // The three per-request latency modes are nested under Advanced on agentic.
-    cy.get('[data-testid="x-axis-mode-ttft"]').should('not.exist');
-    cy.get('[data-testid="x-axis-mode-e2e"]').should('not.exist');
-    cy.get('[data-testid="x-axis-mode-interactivity"]').should('not.exist');
-    cy.get('[data-testid="x-axis-mode-advanced"]')
-      .should('be.visible')
-      .and('have.attr', 'data-state', 'inactive');
-    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]')
-      .should('be.visible')
-      .and('have.attr', 'aria-selected', 'true');
-    // E2E Normalized Interactivity leads the mode list for agentic.
+    // #736 made every latency mode a top-level tab and moved the default off E2E
+    // Normalized Interactivity, which still leads the strip without being selected.
+    cy.get('[data-testid="x-axis-mode-advanced"]').should('not.exist');
+    for (const mode of ['e2e-normalized-interactivity', 'interactivity', 'e2e', 'ttft']) {
+      cy.get(`[data-testid="x-axis-mode-${mode}"]`).should('be.visible');
+    }
+    cy.get('[data-testid="x-axis-mode-buttons"] [role="tab"]').should('have.length', 4);
     cy.get('[data-testid="x-axis-mode-buttons"] [role="tab"]')
       .first()
-      .should('have.attr', 'data-testid', 'x-axis-mode-e2e-normalized-interactivity');
+      .should('have.attr', 'data-testid', 'x-axis-mode-e2e-normalized-interactivity')
+      .and('have.attr', 'aria-selected', 'false');
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
+      'have.attr',
+      'aria-selected',
+      'true',
+    );
+    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
+    cy.get('[data-testid="chart-figure"] svg').should(
+      'contain.text',
+      'P90 Interactivity (tok/s/user)',
+    );
+  });
+
+  it('switches to E2E Normalized Interactivity and updates the heading', () => {
+    // The first entry into this mode fetches the trace-derived metrics, which the
+    // suite's intercept stubs; the default no longer fetches them on load.
+    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').click();
     cy.get('[data-testid="chart-figure"] h2').should(
       'contain.text',
       'P90 E2E Normalized Interactivity',
     );
-    cy.get('[data-testid="chart-figure"] svg').should(
-      'contain.text',
-      'P90 E2E Normalized Interactivity (tok/s/user)',
-    );
-  });
-
-  it('switches to Interactivity and updates the heading', () => {
-    selectAdvancedXAxisMode('interactivity', 'Interactivity');
+    selectXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
   });
 
@@ -220,7 +234,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
 
   it('shows the selected percentile in the Interactivity axis label', () => {
     // Explicitly select the mode — do not rely on the agentic default mode.
-    selectAdvancedXAxisMode('interactivity', 'Interactivity');
+    selectXAxisMode('interactivity', 'Interactivity');
     // Agentic plots percentile fields (p90_intvty), so the axis label carries it.
     cy.get('[data-testid="chart-figure"] svg').should(
       'contain.text',
@@ -252,12 +266,12 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('switches the x-axis to TTFT and updates the heading', () => {
-    selectAdvancedXAxisMode('ttft', 'TTFT');
+    selectXAxisMode('ttft', 'TTFT');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
   });
 
   it('switches the x-axis to E2E Latency and updates the heading', () => {
-    selectAdvancedXAxisMode('e2e', 'E2E Latency');
+    selectXAxisMode('e2e', 'E2E Latency');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'End-to-end Latency');
     cy.get('[data-testid="chart-figure"] svg').should('contain.text', 'P90 End-to-end Latency (s)');
   });
@@ -298,19 +312,12 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     );
   });
 
-  // Documents the intended pairing of the Advanced menu with manual tab
-  // activation: focus may move to the lone remaining tab without the x-axis
-  // snapping back to it. The load-bearing guard for manual activation is the
-  // 8K/1K test below, where focus-activation is directly observable; this one
-  // states the agentic-side expectation.
-  it('keeps the Advanced selection when the remaining tab is focused', () => {
-    selectAdvancedXAxisMode('ttft', 'TTFT');
-
-    // Let the popover finish closing first: Radix restores focus to its own
-    // trigger on close, which would otherwise win the race against the focus
-    // below and mask the revert this test is guarding against.
-    cy.get('[data-testid="x-axis-mode-advanced-menu"]').should('not.exist');
-    cy.get('[data-testid="x-axis-mode-advanced"]').should('have.focus');
+  // Tabs are manually activated: moving focus along the strip must not change
+  // the x-axis. The load-bearing guard is the 8K/1K test below, where the same
+  // behaviour is asserted on the fixed-sequence strip; this one states the
+  // agentic-side expectation, across the agentic-only mode.
+  it('keeps the selected mode when another tab is focused', () => {
+    selectXAxisMode('ttft', 'TTFT');
 
     cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').focus();
     cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').should('have.focus');
@@ -320,14 +327,12 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       'aria-selected',
       'false',
     );
-    cy.get('[data-testid="x-axis-mode-advanced"]')
-      .should('have.attr', 'data-state', 'active')
-      .and('contain.text', 'TTFT');
+    cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
   });
 
   it('switches back to Interactivity', () => {
-    selectAdvancedXAxisMode('interactivity', 'Interactivity');
+    selectXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
     cy.get('[data-testid="chart-figure"] svg').should(
       'contain.text',
@@ -338,7 +343,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   it('follows the percentile selector in the Interactivity axis label', () => {
     // Select p75 here rather than inheriting it from another test — the axis
     // label must track the selector on its own.
-    selectAdvancedXAxisMode('interactivity', 'Interactivity');
+    selectXAxisMode('interactivity', 'Interactivity');
     cy.get('[data-testid="percentile-selector"]').click();
     cy.contains('[role="option"]', 'p75').click();
     cy.get('[data-testid="chart-figure"] svg').should(
@@ -352,24 +357,28 @@ describe('X-axis mode URL param', () => {
   // Regression: the reconcile effect used to run before availability resolved
   // the sequence. It recorded the fixed-seq placeholder kind, then treated the
   // switch to agentic as a user-driven kind change and clobbered the
-  // URL-restored mode with the agentic default (E2E Normalized Interactivity).
+  // URL-restored mode with the agentic default.
+  //
+  // The restored mode must differ from that default or the test cannot fail:
+  // #736 moved the default to Interactivity, so restoring Interactivity now
+  // proves nothing. TTFT is a mode the snap would visibly overwrite.
   it('keeps a URL-restored mode through the agentic sequence resolving', () => {
     interceptAgenticData();
     interceptDerivedAgenticMetrics();
-    cy.visit('/inference?i_seq=agentic-traces&i_xmode=interactivity', {
+    cy.visit('/inference?i_seq=agentic-traces&i_xmode=ttft', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         unlockAgenticGate(win);
       },
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
-    cy.get('[data-testid="x-axis-mode-advanced"]')
-      .should('have.attr', 'data-state', 'active')
-      .and('contain.text', 'Interactivity');
+    cy.get('[data-testid="x-axis-mode-ttft"]')
+      .should('have.attr', 'aria-selected', 'true')
+      .and('contain.text', 'TTFT');
     // Assert on the rendered chart too: the clobber happened one tick after
     // the buttons first painted, so a button-only check could pass too early.
-    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
-    cy.get('[data-testid="x-axis-mode-e2e-normalized-interactivity"]').should(
+    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
+    cy.get('[data-testid="x-axis-mode-interactivity"]').should(
       'have.attr',
       'aria-selected',
       'false',
@@ -454,8 +463,9 @@ describe('Label defaults for fixed-sequence scenarios', () => {
     cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
   });
 
-  // Only agentic nests the latency modes: E2E Normalized Interactivity is
-  // agentic-only, so collapsing them here would leave an empty tab strip.
+  // The strip is flat everywhere since #736; what is still specific to a fixed
+  // sequence is that E2E Normalized Interactivity is agentic-only, so this strip
+  // carries three tabs rather than four.
   it('keeps the flat x-axis strip with no Advanced menu', () => {
     interceptFixedSequenceData();
     cy.visit('/inference?i_seq=8k%2F1k', {
@@ -568,9 +578,19 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
   });
 
+  // Cypress clears intercepts between tests, so the derived-metrics stub is
+  // re-registered per test rather than once in `before`. Until #736 the
+  // agentic default was E2E Normalized Interactivity, so the fetch happened
+  // during `before` while the stub was still alive and React Query held the
+  // result for the rest of the spec. The default no longer fetches, so any
+  // later switch into that mode issues a fresh request.
+  beforeEach(() => {
+    interceptDerivedAgenticMetrics();
+  });
+
   it('shows overlay (unofficial-run) watermark SVG when an overlay is loaded', () => {
     // Explicitly select Interactivity — do not rely on the agentic default mode.
-    selectAdvancedXAxisMode('interactivity', 'Interactivity');
+    selectXAxisMode('interactivity', 'Interactivity');
     // The unofficial-run pattern watermark appears when isUnofficialRun is true.
     cy.get('[data-testid="inference-chart-display"] svg pattern[id^="unofficial-pattern-"]').should(
       'exist',
@@ -586,7 +606,7 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
   });
 
   it('switches to ttft x-axis mode and renders SVG with overlay points', () => {
-    selectAdvancedXAxisMode('ttft', 'TTFT');
+    selectXAxisMode('ttft', 'TTFT');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Time To First Token');
     // Overlay points render as triangles or circles inside the chart SVG.
     cy.get('[data-testid="inference-chart-display"] svg').should('exist');

--- a/packages/app/cypress/support/overlay-fixtures.ts
+++ b/packages/app/cypress/support/overlay-fixtures.ts
@@ -4,8 +4,11 @@
  * The benchmark values are the real numbers from GitHub run 29682242847
  * (GLM5.2 B300 agentic hicache, offload=on rows):
  *   conc, p90_intvty (tok/s/user), tput_per_gpu, p90_e2el (s)
- * C=4 is dominated on e2e by C=8 (12874 tok/s @ 33.1s vs 9415 @ 48.0s), which
- * makes the set a ready-made probe for the e2e-restricted frontier behaviors.
+ * C=4 is dominated on e2e by C=8 (12874 tok/s @ 33.1s vs 9415 @ 48.0s). That
+ * used to make the set a probe for the e2e-restricted frontier; #736 removed
+ * that gating, so on the interactivity axes all five are Pareto-optimal —
+ * throughput falls monotonically as interactivity rises. Use
+ * `DOMINATED_CONFIG` when a test needs a point Optimal Only will actually drop.
  */
 export const DEFAULT_MODEL_DB_KEY = 'dsv4';
 export const AGENTIC_DATE = '2026-07-19';
@@ -39,9 +42,21 @@ export const metricsFor = (intvty: number, tput: number, e2el: number): Record<s
   input_tput_per_gpu: tput * 0.7,
 });
 
+/**
+ * A sixth config that is dominated on the *interactivity* axes: C=8 beats it on
+ * both interactivity (68.5 > 60) and throughput (12874 > 5000). Since #736 the
+ * Pareto frontier is computed from the selected axes alone, so this is the point
+ * Optimal Only must drop — the e2e-dominated C=4 above no longer is one.
+ */
+export const DOMINATED_CONFIG: [number, number, number, number] = [6, 60, 5000, 40];
+
 let idCursor = 900000;
-export const b300Rows = (runUrl: string | null, hardware = 'b300') =>
-  REAL_CONFIGS.map(([conc, intvty, tput, e2el]) => ({
+export const b300Rows = (
+  runUrl: string | null,
+  hardware = 'b300',
+  configs: [number, number, number, number][] = REAL_CONFIGS,
+) =>
+  configs.map(([conc, intvty, tput, e2el]) => ({
     id: runUrl ? 0 : idCursor++,
     hardware,
     framework: 'sglang',
@@ -81,8 +96,18 @@ export const availability = [
   },
 ];
 
-/** Intercept availability + benchmarks + unofficial-run with the B300 fixture. */
-export const interceptOverlayRun = ({ overlayHardware = 'b300' } = {}) => {
+/**
+ * Intercept availability + benchmarks + unofficial-run with the B300 fixture.
+ * `overlayConfigs` overrides only the overlay run's rows, leaving the official
+ * rows as the standard five.
+ */
+export const interceptOverlayRun = ({
+  overlayHardware = 'b300',
+  overlayConfigs = REAL_CONFIGS,
+}: {
+  overlayHardware?: string;
+  overlayConfigs?: [number, number, number, number][];
+} = {}) => {
   cy.intercept('GET', '/api/v1/availability', { body: availability }).as('availability');
   cy.intercept('GET', '/api/v1/benchmarks*', { body: b300Rows(null) }).as('benchmarks');
   cy.intercept('GET', '/api/unofficial-run*', {
@@ -100,7 +125,7 @@ export const interceptOverlayRun = ({ overlayHardware = 'b300' } = {}) => {
           isNonMainBranch: true,
         },
       ],
-      benchmarks: b300Rows(OVERLAY_RUN_URL, overlayHardware),
+      benchmarks: b300Rows(OVERLAY_RUN_URL, overlayHardware, overlayConfigs),
       evaluations: [],
     },
   }).as('unofficialRun');

--- a/packages/app/src/components/calculator/useThroughputData.test.ts
+++ b/packages/app/src/components/calculator/useThroughputData.test.ts
@@ -1216,7 +1216,13 @@ describe('buildGpuGroups', () => {
     });
   });
 
-  it('restricts agentic interpolation to the same date-scoped e2e Pareto winners as the chart', () => {
+  it('keeps an e2e-dominated agentic point, because grouping no longer gates on the e2e frontier', () => {
+    // Until #736 this dropped every point that lost on E2E normalized
+    // interactivity, so grouping matched the chart's canonical frontier. That
+    // gating was removed deliberately: a frontier is now computed from the axes
+    // the reader actually selected, so grouping keeps every measured point and
+    // eligibility is decided downstream. Concurrency 2 is dominated on e2e by
+    // concurrency 1 and must survive anyway.
     const agenticRow = (
       conc: number,
       interactivity: number,
@@ -1245,7 +1251,6 @@ describe('buildGpuGroups', () => {
         agenticRow(1, 100, 20, 900),
         agenticRow(2, 80, 30, 800), // e2e-dominated by concurrency 1
         agenticRow(4, 60, 40, 1200),
-        // A different date gets its own e2e frontier and must survive.
         agenticRow(8, 40, 50, 700, '2026-07-20'),
       ],
       {
@@ -1257,7 +1262,7 @@ describe('buildGpuGroups', () => {
     );
 
     const points = Object.values(grouped)[0];
-    expect(points.map((point) => point.concurrency).toSorted()).toEqual([1, 4, 8]);
+    expect(points.map((point) => point.concurrency).toSorted()).toEqual([1, 2, 4, 8]);
   });
 
   it('keeps agentic overlay frontiers isolated per unofficial run', () => {

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -1167,17 +1167,20 @@ describe('overview platform selection', () => {
     });
   });
 
-  it('restricts AgentX points to the E2E frontier on total throughput', () => {
-    // The slower-E2E point wins on output tokens but loses on total tokens, so
-    // the total-token frontier drops it and the tier read becomes unreachable.
+  it('reads AgentX tiers from every measured point, not just the E2E frontier', () => {
+    // The second point is dominated on total tokens (8100 < 9000) and slower on
+    // E2E (25 > 20). Until #736 the E2E frontier dropped it, leaving only the
+    // interactivity-40 point, which cannot reach the tier-50 read — so the tier
+    // came back null. That gating was removed deliberately, so the point now
+    // stands and the read lands on it exactly.
     const summary = buildOverviewModelSummary(Model.GLM_5_2, [
       agenticRow(40, 20, 9000, 500, { hardware: 'b200', conc: 8 }),
       agenticRow(50, 25, 8100, 900, { hardware: 'b200', conc: 12 }),
     ]);
 
     const b200 = summary.platforms.find(({ hardware }) => hardware === 'b200')!;
-    expect(b200.read.value).toBeNull();
-    expect(b200.missingReason).toBe('cannot_reach_at_tier');
+    expect(b200.read.value).toBe(8100);
+    expect(b200.missingReason).toBeNull();
   });
 
   it('reports scenario-level missing coverage when AgentX rows lack usable P90 metrics', () => {


### PR DESCRIPTION
> Rebased onto `b367003` (post-#743). #743's own body cites this PR as *"the exact test-only realignment"* for the drift it hit.

## Summary

`master` went red at #736. That PR removed E2E normalized-interactivity frontier gating **on purpose** — its own summary says *"compute each Pareto frontier from its selected axes without E2E normalized-interactivity gating"* — and merged with *"full checks intentionally skipped for this focused change"*. The tests asserting the old gating were never updated.

Bisected: `08e1f7d` green, `7fded35` (#736) red. **This PR changes no `src` behaviour** — it moves the tests to the behaviour that was chosen. Two later PRs (#737, #743) hit the same failures and merged past them.

## Unit

| Test | Now asserts |
|---|---|
| `overview-data` | A point dominated on total tokens and slower on E2E is no longer dropped, so the tier-50 read lands on it (`8100`) instead of `null` |
| `useThroughputData` | `buildGpuGroups` keeps an e2e-dominated point; eligibility is decided downstream from the selected axes |

The `overview-data.ts` API-doc digest was part of this PR until the rebase. #743 changed that file again and re-reviewed the entry itself, so `api-route-catalog.ts` is **no longer touched here**.

## E2E

- **The "Advanced" popover is gone** and all four x-axis modes are flat tabs, so the four specs that opened it click the tab instead. Agentic also defaults to Interactivity now, not E2E Normalized Interactivity.
- **The derived-metrics stub moves to `beforeEach`.** Cypress clears intercepts between tests; these specs relied on the *old* default fetching during `before` while the stub was alive, after which React Query held the result for the whole spec. Nothing fetches on load anymore, so a later switch into that mode issued a live request and rendered no chart at all.
- **The URL-restored-mode regression test now restores TTFT.** It restored Interactivity — the new default — so it could no longer detect the clobber it exists to catch.
- **`overlay-optimal-only` needed a new fixture point.** It asserted overlay points are hidden because trace-less rows cannot join the canonical frontier. They now stand or fall on the selected axes like any other point, and all five fixture configs are non-dominated there — throughput falls monotonically as interactivity rises — so the suite would have asserted five visible whatever the filter did. It gets a sixth, deliberately dominated overlay config (`DOMINATED_CONFIG`), giving Optimal Only something to drop.

`interceptOverlayRun`'s new `overlayConfigs` option defaults to `REAL_CONFIGS`, so the other four consumers are untouched.

## Verification (re-run on `b367003`)

- **Unit: 3372 passed, 173 files.**
- **E2E: 600/602 locally**; the four repaired specs 30/30 at `retries=0`, re-run after rebuilding against #743 — which touched overlay and chart consumers, so this was re-verified rather than assumed.
- Mutation-checked the one new assertion: making `DOMINATED_CONFIG` non-dominated fails `drops only the dominated overlay point…` (1 visible vs 5 expected).
- `lint` / `fmt` / `typecheck` clean.
- The pre-rebase revision was green in CI on all 8 browser shards.

**The two local e2e failures are not from this change**: `inference-replay` asserts a scrubber advances after a wall-clock `cy.wait(800)` — it imports nothing touched here and passed CI. (`zh-pages` failed once under parallel load and passes on re-run.)

## Note for @cquil11

#736 left `restrictAgenticPointsToE2eFrontier` in the tree with **zero callers**, and its own tests still pass, so it now reads as live policy. Separately, `MODELS.md` in the InferenceX repo still documents the North-star Pareto policy as binding ("a point cannot appear on any AgentX Pareto frontier unless it is both a North Star winner and non-dominated on the selected chart"), which the app no longer enforces. Neither is touched here — deleting dead code and reconciling that doc are your calls, not a test fix's.

## 中文说明

已 rebase 到 `b367003`（#743 之后）。#743 的说明中亦将本 PR 称为"针对该漂移的纯测试对齐修复"。

`master` 自 #736 起转红。该 PR **有意**移除了端到端归一化交互性的前沿门控（其摘要即为"各 Pareto 前沿仅依据所选坐标轴计算，不再受端到端归一化交互性门控约束"），且合并时"刻意跳过完整检查"，但断言旧门控的测试未随之更新。已二分定位：`08e1f7d` 通过，`7fded35`（#736）失败。**本 PR 不改动任何 `src` 行为**，只是把测试对齐到既定行为；此后 #737 与 #743 均遇到同一组失败并带红合并。

单测：概览档位读数不再因总 token 被支配且 E2E 较慢而丢弃该点，tier-50 读数落在 `8100` 而非 `null`；`buildGpuGroups` 保留被 e2e 支配的点。`overview-data.ts` 的 API 文档摘要原本也在本 PR 范围内，但 #743 已再次修改该文件并重新复核了该条目，故 `api-route-catalog.ts` **在此不再改动**。

E2E：Advanced 弹出菜单已移除，四个模式改为平铺标签页，四个原先打开该菜单的套件改为直接点击标签页；派生指标 stub 移至 `beforeEach`（Cypress 会在测试间清除拦截，这些套件此前依赖旧默认值在 `before` 期间完成抓取并由 React Query 缓存，现在加载时不再抓取，后续切换会发出真实请求并导致图表无法渲染）；URL 恢复模式的回归测试改用 TTFT；`overlay-optimal-only` 新增一个刻意被支配的配置 `DOMINATED_CONFIG`，否则五个真实配置在交互性坐标轴上均非被支配，该断言无论过滤器如何都会通过。`interceptOverlayRun` 新增的 `overlayConfigs` 默认为 `REAL_CONFIGS`，其余四处调用不受影响。

验证（已在 `b367003` 上重跑）：单测 3372 项全部通过；本地 e2e 600/602，四个修复套件在 `retries=0` 下 30/30——因 #743 改动了叠加层与图表消费方，此处为重新构建后实测而非沿用旧结论；新断言已通过变异测试验证；lint/fmt/typecheck 均通过；rebase 前的版本在 CI 全部 8 个浏览器分片上均为绿色。两项本地失败与本 PR 无关：`inference-replay` 依赖真实时钟的动画断言且未引用本 PR 改动的任何内容，在 CI 中通过（`zh-pages` 仅在并行负载下偶发超时，重跑通过）。

另请 @cquil11 注意：#736 之后 `restrictAgenticPointsToE2eFrontier` 仍留在代码中但**已无任何调用方**，其自身测试仍通过，容易被误读为仍在生效的策略；此外 InferenceX 仓库的 `MODELS.md` 仍将 North-star Pareto 政策记为强制约束，而应用已不再执行。这两点本 PR 均未触碰——删除死代码与同步该文档应由你决定。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test and Cypress fixture changes; production code is untouched.
> 
> **Overview**
> **Test-only alignment** after #736 removed E2E normalized-interactivity frontier gating and reshaped the agentic chart UI. No `src` behavior changes in this PR.
> 
> **Unit tests** now expect Pareto and tier logic on the **selected axes** only: `buildGpuGroups` keeps e2e-dominated agentic points, and overview AgentX tier reads can land on points that are dominated on total tokens / slower on E2E (`8100` instead of `null`).
> 
> **Cypress** drops the **Advanced** popover flow—four x-axis modes are **flat tabs**; agentic **defaults to Interactivity** (not E2E Normalized Interactivity). Derived-metrics intercepts move to **`beforeEach`** because the default no longer fetches on load and Cypress clears intercepts between tests. Overlay specs assert **Optimal Only** hides only dominated overlay points (not all trace-less overlays); **`DOMINATED_CONFIG`** and **`overlayConfigs`** on `interceptOverlayRun` make that test meaningful. URL-restore regression uses **TTFT** so it can still detect clobbering against the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609487389391a9aecb41ffc1a437931ca1493c9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->