### PR TITLE
feat(overview): merge the matrix footer into one bar and dim stale data in flight / 合并矩阵页脚为单栏并在加载中淡化旧数据

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -255,10 +255,12 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/zh/overview?models=all');
 
-    cy.get('[data-testid="overview-model-scope-toggle"]').should(
-      'contain.text',
-      '隐藏已弃用与维护模式模型',
-    );
+    // The chip carries the short label; the full sentence stays on the
+    // accessible name and hover title.
+    cy.get('[data-testid="overview-model-scope-toggle"]')
+      .should('contain.text', '隐藏停用模型')
+      .find('[data-overview-model-scope="default"]')
+      .should('have.attr', 'aria-label', '隐藏已弃用与维护模式模型');
     desktopModel('gpt-oss-120b')
       .find('[data-testid="overview-model-category-badge"]')
       .should('contain.text', '已弃用');

--- a/packages/app/src/components/overview/overview-navigation.test.tsx
+++ b/packages/app/src/components/overview/overview-navigation.test.tsx
@@ -41,7 +41,12 @@ function pageData(tier: OverviewTier): OverviewPageData {
 function Probe() {
   const navigation = useOverviewNavigation();
   selectTier = () => navigation.push('/overview?tier=75', ['tier']);
-  return <output data-testid="tier">{navigation.data.tier}</output>;
+  return (
+    <>
+      <output data-testid="tier">{navigation.data.tier}</output>
+      <output data-testid="pending">{String(navigation.pending)}</output>
+    </>
+  );
 }
 
 function renderProvider(data: OverviewPageData, href: string) {
@@ -97,5 +102,60 @@ describe('OverviewNavigationProvider', () => {
     });
 
     expect(container.querySelector('[data-testid="tier"]')?.textContent).toBe('100');
+  });
+
+  it('reports pending only while a selector response is in flight', async () => {
+    let resolveSelectorRequest: ((response: Response) => void) | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveSelectorRequest = resolve;
+          }),
+      ),
+    );
+
+    renderProvider(pageData(50), '/overview');
+    const pending = () => container.querySelector('[data-testid="pending"]')?.textContent;
+    expect(pending()).toBe('false');
+
+    act(() => selectTier?.());
+    expect(pending()).toBe('true');
+
+    await act(async () => {
+      resolveSelectorRequest?.(Response.json(pageData(75)));
+      await Promise.resolve();
+    });
+
+    expect(pending()).toBe('false');
+    expect(container.querySelector('[data-testid="tier"]')?.textContent).toBe('75');
+  });
+
+  it('clears pending when the selector request fails', async () => {
+    let rejectSelectorRequest: ((reason: Error) => void) | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((_resolve, reject) => {
+            rejectSelectorRequest = reject;
+          }),
+      ),
+    );
+
+    renderProvider(pageData(50), '/overview');
+    act(() => selectTier?.());
+    expect(container.querySelector('[data-testid="pending"]')?.textContent).toBe('true');
+
+    await act(async () => {
+      rejectSelectorRequest?.(new Error('offline'));
+      await Promise.resolve();
+    });
+
+    // The failed selection falls back to a router navigation; the matrix must
+    // not be left permanently dimmed over the data it still shows.
+    expect(container.querySelector('[data-testid="pending"]')?.textContent).toBe('false');
+    expect(container.querySelector('[data-testid="tier"]')?.textContent).toBe('50');
   });
 });

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -18,6 +18,8 @@ import { mergeOverviewControlHref, type OverviewSearchKey } from '@/lib/overview
 
 interface OverviewNavigationValue {
   data: OverviewPageData;
+  /** True while `data` still shows the previous selection during a fetch. */
+  pending: boolean;
   prefetch: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
   resolve: (targetHref: string, keys: readonly OverviewSearchKey[]) => string;
   push: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
@@ -36,6 +38,7 @@ export function OverviewNavigationProvider({
 }) {
   const router = useRouter();
   const [data, setData] = useState(initialData);
+  const [pending, setPending] = useState(false);
   const [pendingHref, setPendingHref] = useState(initialHref);
   const pendingHrefRef = useRef(initialHref);
   const committedHrefRef = useRef(initialHref);
@@ -47,8 +50,8 @@ export function OverviewNavigationProvider({
     const cached = dataCacheRef.current.get(href);
     if (cached !== undefined) return Promise.resolve(cached);
 
-    const pending = requestCacheRef.current.get(href);
-    if (pending !== undefined) return pending;
+    const inFlight = requestCacheRef.current.get(href);
+    if (inFlight !== undefined) return inFlight;
 
     const url = new URL(href, window.location.origin);
     const request = fetch(`/api/v1/overview${url.search}`, {
@@ -71,6 +74,7 @@ export function OverviewNavigationProvider({
       const navigationId = ++navigationIdRef.current;
       pendingHrefRef.current = href;
       setPendingHref(href);
+      setPending(true);
       if (updateHistory) {
         History.prototype.pushState.call(window.history, window.history.state, '', href);
         notifyClientSearchChange(href);
@@ -84,9 +88,11 @@ export function OverviewNavigationProvider({
             History.prototype.replaceState.call(window.history, window.history.state, '', href);
           }
           setData(nextData);
+          setPending(false);
         })
         .catch(() => {
           if (navigationId !== navigationIdRef.current) return;
+          setPending(false);
           if (updateHistory) {
             History.prototype.replaceState.call(
               window.history,
@@ -111,6 +117,7 @@ export function OverviewNavigationProvider({
     pendingHrefRef.current = initialHref;
     setPendingHref(initialHref);
     setData(initialData);
+    setPending(false);
   }, [initialData, initialHref]);
 
   useEffect(() => {
@@ -135,6 +142,7 @@ export function OverviewNavigationProvider({
   const value = useMemo<OverviewNavigationValue>(
     () => ({
       data,
+      pending,
       resolve,
       prefetch: (targetHref, keys) => {
         const href = mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys);
@@ -145,7 +153,7 @@ export function OverviewNavigationProvider({
         commit(href, true);
       },
     }),
-    [commit, data, load, resolve],
+    [commit, data, load, pending, resolve],
   );
 
   return (

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -180,10 +180,18 @@ function OverviewControlRow({ locale }: { locale: OverviewLocale }) {
   );
 
   if (!presenting) {
+    // Same three-column skeleton as the presenting toolbar below: the tabs
+    // keep the matrix centre and Present anchors the right edge as an action,
+    // instead of trailing the tabs and reading as a third view.
     return (
-      <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5">
-        {views}
-        <OverviewPresentToggle strings={strings} />
+      <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 md:grid md:grid-cols-[1fr_auto_1fr]">
+        <div className="hidden md:block" />
+        <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 md:justify-self-center">
+          {views}
+        </div>
+        <div className="md:justify-self-end">
+          <OverviewPresentToggle strings={strings} />
+        </div>
       </div>
     );
   }
@@ -257,7 +265,7 @@ function OverviewControlRow({ locale }: { locale: OverviewLocale }) {
 
 /** The half of the page that goes fullscreen: the view tabs and the matrix. */
 function OverviewMatrixSection({ locale }: { locale: OverviewLocale }) {
-  const { data } = useOverviewNavigation();
+  const { data, pending } = useOverviewNavigation();
   const { presenting } = useOverviewPresentation();
   const strings = OVERVIEW_STRINGS[locale];
   const formatters = overviewFormatters(locale);
@@ -269,7 +277,14 @@ function OverviewMatrixSection({ locale }: { locale: OverviewLocale }) {
       {/* Official-only summary; uploaded runs remain in the linked dashboard. */}
       {/* Clipped on phones for the rounded corners; visible from xl so the
           desktop matrix header can stick to the page as it scrolls. */}
-      <Card className="overflow-hidden p-0 md:p-0 xl:overflow-visible">
+      {/* The 150ms delay keeps cache hits and fast responses from flickering;
+          only a fetch still in flight past it dims the stale matrix. */}
+      <Card
+        data-pending={pending}
+        className={`overflow-hidden p-0 transition-opacity duration-200 md:p-0 xl:overflow-visible ${
+          pending ? 'opacity-60 delay-150' : 'opacity-100'
+        }`}
+      >
         <DesktopOverviewMatrix
           models={data.models}
           locale={locale}
@@ -291,47 +306,52 @@ function OverviewMatrixSection({ locale }: { locale: OverviewLocale }) {
           />
         )}
         {presenting ? null : (
-          <>
+          /* One footer bar instead of three stacked link rows: the notes keep
+             the left edge, the scope chips keep the right, and the card ends
+             on a single rule. */
+          <div className="flex flex-col gap-x-6 gap-y-2 border-t border-border/50 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:px-6">
             <OverviewMethodology
               strings={strings}
               comparisonMode={data.comparisonMode}
               referenceHardware={data.referenceHardware}
             />
-            {data.comparisonMode === 'history' ? (
-              <OverviewRowScopeToggle
+            <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1">
+              {data.comparisonMode === 'history' ? (
+                <OverviewRowScopeToggle
+                  rowScope={data.rowScope}
+                  unchangedRowCount={data.unchangedRowCount}
+                  tier={data.tier}
+                  engineScope={data.engineScope}
+                  referenceHardware={data.referenceHardware}
+                  modelScope={data.modelScope}
+                  locale={locale}
+                  strings={strings}
+                />
+              ) : (
+                <OverviewHardwareRowScopeToggle
+                  hardwareRowScope={data.hardwareRowScope}
+                  emptyRowCount={data.emptyRowCount}
+                  tier={data.tier}
+                  engineScope={data.engineScope}
+                  referenceHardware={data.referenceHardware}
+                  modelScope={data.modelScope}
+                  locale={locale}
+                  strings={strings}
+                />
+              )}
+              <OverviewModelScopeToggle
+                modelScope={data.modelScope}
+                tier={data.tier}
+                engineScope={data.engineScope}
+                comparisonMode={data.comparisonMode}
+                referenceHardware={data.referenceHardware}
                 rowScope={data.rowScope}
-                unchangedRowCount={data.unchangedRowCount}
-                tier={data.tier}
-                engineScope={data.engineScope}
-                referenceHardware={data.referenceHardware}
-                modelScope={data.modelScope}
-                locale={locale}
-                strings={strings}
-              />
-            ) : (
-              <OverviewHardwareRowScopeToggle
                 hardwareRowScope={data.hardwareRowScope}
-                emptyRowCount={data.emptyRowCount}
-                tier={data.tier}
-                engineScope={data.engineScope}
-                referenceHardware={data.referenceHardware}
-                modelScope={data.modelScope}
                 locale={locale}
                 strings={strings}
               />
-            )}
-            <OverviewModelScopeToggle
-              modelScope={data.modelScope}
-              tier={data.tier}
-              engineScope={data.engineScope}
-              comparisonMode={data.comparisonMode}
-              referenceHardware={data.referenceHardware}
-              rowScope={data.rowScope}
-              hardwareRowScope={data.hardwareRowScope}
-              locale={locale}
-              strings={strings}
-            />
-          </>
+            </div>
+          </div>
         )}
       </Card>
     </>

--- a/packages/app/src/components/overview/overview-presentation.tsx
+++ b/packages/app/src/components/overview/overview-presentation.tsx
@@ -210,8 +210,24 @@ export function OverviewPresentToggle({ strings }: { strings: OverviewStrings })
       aria-pressed={presenting}
       aria-label={presenting ? strings.presentExitAria : strings.presentEnterAria}
       title={strings.presentShortcutHint}
-      className="inline-flex min-h-11 items-center rounded-md border border-border/60 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      className="inline-flex min-h-11 items-center gap-x-1.5 rounded-md border border-border/60 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
     >
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="size-3.5"
+      >
+        {presenting ? (
+          <path d="M6 2v4H2M10 2v4h4M6 14v-4H2M10 14v-4h4" />
+        ) : (
+          <path d="M6 2H2v4M10 2h4v4M6 14H2v-4M10 14h4v-4" />
+        )}
+      </svg>
       {presenting ? strings.presentExit : strings.presentEnter}
     </button>
   );

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -1103,14 +1103,11 @@ export function OverviewComparisonSwitcher({
 }
 
 /**
- * Where a scope toggle is drawn. `section` is the underlined sentence beneath
- * the matrix; `toolbar` is the button that replaces it while presenting, where
- * the sentence does not fit.
+ * Where a scope toggle is drawn. `section` is the chip in the footer bar
+ * beneath the matrix; `toolbar` is the same chip riding the deck toolbar while
+ * presenting, where the count badge would be noise at projection size.
  */
 type OverviewScopeToggleVariant = 'section' | 'toolbar';
-
-const SCOPE_SENTENCE_CLASS =
-  'inline-flex min-h-11 items-center text-muted-foreground underline decoration-dotted underline-offset-4 transition-colors hover:text-foreground hover:decoration-solid';
 
 /**
  * Matches Exit, so the right end of the deck toolbar reads as one row of
@@ -1119,6 +1116,19 @@ const SCOPE_SENTENCE_CLASS =
  */
 const SCOPE_CHIP_CLASS =
   'inline-flex min-h-11 items-center whitespace-nowrap rounded-md border border-border/60 px-3 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
+
+/** The count the chip's short label elides; the full sentence stays on the
+ *  accessible name, so the badge is presentation only. */
+function ScopeChipCount({ count }: { count: number }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="ml-1.5 inline-flex min-w-5 items-center justify-center rounded-full bg-muted px-1.5 py-0.5 text-[10px] leading-none tabular-nums"
+    >
+      {count}
+    </span>
+  );
+}
 
 export function OverviewModelScopeToggle({
   modelScope,
@@ -1169,15 +1179,11 @@ export function OverviewModelScopeToggle({
       )}
       analytics={{ control: 'models', value: target }}
       searchKeys={['models', 'rows', 'hwrows']}
-      aria-label={variant === 'toolbar' ? sentence : undefined}
-      title={variant === 'toolbar' ? sentence : undefined}
-      className={variant === 'toolbar' ? SCOPE_CHIP_CLASS : SCOPE_SENTENCE_CLASS}
+      aria-label={sentence}
+      title={sentence}
+      className={SCOPE_CHIP_CLASS}
     >
-      {variant === 'toolbar'
-        ? modelScope === 'all'
-          ? strings.modelScopeChipHide
-          : strings.modelScopeChipShow
-        : sentence}
+      {modelScope === 'all' ? strings.modelScopeChipHide : strings.modelScopeChipShow}
     </OverviewNavLink>
   );
   if (variant === 'toolbar') return link;
@@ -1185,7 +1191,7 @@ export function OverviewModelScopeToggle({
     <nav
       data-testid="overview-model-scope-toggle"
       aria-label={strings.modelScopeNavLabel}
-      className="border-t border-border/50 px-4 text-xs lg:px-6"
+      className="text-xs"
     >
       {link}
     </nav>
@@ -1238,15 +1244,12 @@ export function OverviewRowScopeToggle({
       )}
       analytics={{ control: 'rows', value: target }}
       searchKeys={['rows']}
-      aria-label={variant === 'toolbar' ? sentence : undefined}
-      title={variant === 'toolbar' ? sentence : undefined}
-      className={variant === 'toolbar' ? SCOPE_CHIP_CLASS : SCOPE_SENTENCE_CLASS}
+      aria-label={sentence}
+      title={sentence}
+      className={SCOPE_CHIP_CLASS}
     >
-      {variant === 'toolbar'
-        ? rowScope === 'all'
-          ? strings.rowScopeChipHide
-          : strings.rowScopeChipShow
-        : sentence}
+      {rowScope === 'all' ? strings.rowScopeChipHide : strings.rowScopeChipShow}
+      {variant === 'section' ? <ScopeChipCount count={unchangedRowCount} /> : null}
     </OverviewNavLink>
   );
   if (variant === 'toolbar') return link;
@@ -1254,7 +1257,7 @@ export function OverviewRowScopeToggle({
     <nav
       data-testid="overview-row-scope-toggle"
       aria-label={strings.rowScopeNavLabel}
-      className="border-t border-border/50 px-4 text-xs lg:px-6"
+      className="text-xs"
     >
       {link}
     </nav>
@@ -1306,15 +1309,14 @@ export function OverviewHardwareRowScopeToggle({
       )}
       analytics={{ control: 'hwrows', value: target }}
       searchKeys={['hwrows']}
-      aria-label={variant === 'toolbar' ? sentence : undefined}
-      title={variant === 'toolbar' ? sentence : undefined}
-      className={variant === 'toolbar' ? SCOPE_CHIP_CLASS : SCOPE_SENTENCE_CLASS}
+      aria-label={sentence}
+      title={sentence}
+      className={SCOPE_CHIP_CLASS}
     >
-      {variant === 'toolbar'
-        ? hardwareRowScope === 'all'
-          ? strings.hardwareRowScopeChipHide
-          : strings.hardwareRowScopeChipShow
-        : sentence}
+      {hardwareRowScope === 'all'
+        ? strings.hardwareRowScopeChipHide
+        : strings.hardwareRowScopeChipShow}
+      {variant === 'section' ? <ScopeChipCount count={emptyRowCount} /> : null}
     </OverviewNavLink>
   );
   if (variant === 'toolbar') return link;
@@ -1322,7 +1324,7 @@ export function OverviewHardwareRowScopeToggle({
     <nav
       data-testid="overview-hardware-row-scope-toggle"
       aria-label={strings.hardwareRowScopeNavLabel}
-      className="border-t border-border/50 px-4 text-xs lg:px-6"
+      className="text-xs"
     >
       {link}
     </nav>
@@ -1342,7 +1344,7 @@ export function OverviewMethodology({
   return (
     <div
       data-testid="overview-methodology"
-      className="space-y-1 border-t border-border/50 px-4 py-3 text-xs leading-snug text-muted-foreground lg:px-6"
+      className="space-y-1 text-xs leading-snug text-muted-foreground"
     >
       {comparisonMode === 'history' ? <p>{strings.historyCaption}</p> : null}
       <p>


### PR DESCRIPTION
Stacked on #719 — UI/UX polish only, no behavior change to its features.

## Summary

- **One footer bar instead of three stacked link rows.** The methodology notes keep the card's left edge and the two scope filters ride the right as chips with count badges ("Hide blanks ④" / "Show inactive"). The full counted sentences stay on the accessible name and hover title. The card ends on a single rule, returning ~90px to the matrix on a laptop viewport.
- **Balanced control strip.** The on-page strip now uses the same three-column skeleton as the presenting toolbar: view tabs stay centred on the matrix, and Present — now carrying an expand glyph, Exit a collapse glyph — anchors the right edge as an action instead of trailing the tabs like a third view.
- **Page and presentation states share one chip style.** The footer chips are the same control the deck toolbar already showed, so entering Present no longer restyles the filters (the badge is dropped there, where it would be noise at projection size).
- **In-flight feedback.** `OverviewNavigationProvider` exposes `pending`; a fetch still unresolved after 150ms dims the stale matrix to 60% opacity. Cache hits and fast responses stay under the delay and never flicker. The URL-driven server filtering, hover prefetch and client cache are untouched.

## Test plan

- [x] `bun run test:unit` — 3,796 tests pass
- [x] `bun run typecheck`, `bun run lint`, `bun run fmt` clean
- [x] `overview.cy.ts` against a fixtures dev server: same 5 pre-existing environmental failures as the unmodified #719 head, zero new; the zh model-scope assertion updated for the chip label with the full sentence asserted on `aria-label`
- [x] Manual: both locales, both comparison modes, chip toggles flip `rows=`/`hwrows=` correctly

## 中文说明

基于 #719 的增量 PR——仅打磨 UI/UX，不改变其功能行为。

- **底部三条堆叠链接行合并为单条页脚栏。** 方法学注释保持左侧，两个范围过滤器以带计数徽标的 chip 形式靠右（"隐藏空行 ④"/"显示停用模型"）。带计数的完整句子保留在无障碍名称与悬停提示中。卡片以单条分隔线收尾，在笔记本视口上为矩阵让出约 90px。
- **控制条重新配平。** 页面态控制条改用与演示态工具栏相同的三栏骨架：视图标签相对矩阵居中，Present（新增展开图标，Exit 为收起图标）右对齐为动作按钮，不再像第三个视图标签。
- **页面态与演示态共用同一 chip 样式。** 页脚 chip 即演示工具栏原有控件，进入演示不再改变过滤器外观（演示态省略徽标，投影尺寸下是噪声）。
- **加载中反馈。** `OverviewNavigationProvider` 暴露 `pending`；请求超过 150ms 未返回时旧矩阵淡化至 60% 不透明度，缓存命中与快速响应不闪烁。URL 驱动的服务端过滤、悬停预取与客户端缓存均未改动。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side overview navigation and presentation UI only; no API or data-model changes, with tests for pending state and existing navigation race handling.
> 
> **Overview**
> Overview **UI polish** on top of #719: layout and loading feedback, not new filtering behavior.
> 
> The matrix card **footer** is one bar—methodology notes on the left, row/model scope controls as **chips with count badges** on the right (full counted sentences on `aria-label`/`title`). Scope toggles use the same chip style in the footer and presentation toolbar; presentation drops the badge.
> 
> The **control strip** matches the presenting toolbar’s three-column layout: view tabs centered, **Present** (expand/collapse icons) anchored on the right.
> 
> `OverviewNavigationProvider` exposes **`pending`**; the matrix card dims to 60% opacity after a **150ms** delay while a selector fetch is in flight, and clears on success or failure. Unit tests cover `pending` lifecycle; Cypress zh locale asserts the short chip label plus full `aria-label`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0385d4b866b51d34f259d9b4286fc647f4d49abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->