### PR TITLE
fix(overview): explain the category badge without a mouse and unpad the e2e timeouts / 总览分类徽章脱离鼠标可读并收紧 e2e 超时

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -142,7 +142,7 @@ describe('Overview page', () => {
 
     cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
     cy.wait('@overviewJson');
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75');
+    cy.location('search').should('eq', '?tier=75');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
     cy.get('[data-testid="overview-tier-switcher"]').contains('a', '50').click();
@@ -158,17 +158,17 @@ describe('Overview page', () => {
       .find('[data-overview-engine-scope="all"]')
       .click();
     cy.wait('@overviewJson');
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
+    cy.location('search').should('eq', '?tier=75&engine=all');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
     cy.get('[data-overview-comparison="30d"]').click();
     cy.wait('@overviewJson');
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all&compare=30d');
+    cy.location('search').should('eq', '?tier=75&engine=all&compare=30d');
     cy.window().its('__overviewNavigationSentinel').should('eq', 'preserved');
 
     cy.go('back');
     cy.get('[data-overview-comparison="hardware"]').should('have.attr', 'aria-current', 'true');
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
+    cy.location('search').should('eq', '?tier=75&engine=all');
     cy.then(() => {
       expect(rscRequests, 'selector and popstate RSC requests').to.equal(0);
     });
@@ -216,8 +216,11 @@ describe('Overview page', () => {
       .find('[data-overview-engine-scope="all"]')
       .click();
 
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75&engine=all');
+    cy.location('search').should('eq', '?tier=75&engine=all');
     // The rendered state, not just the URL: the losing response must not win.
+    // Keeps its explicit timeout because it waits on the real API through
+    // `request.continue` plus the delay above — unlike the URL assertions
+    // around it, which the click resolves synchronously.
     cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]', {
       timeout: 15_000,
     }).should('have.text', '75');
@@ -237,9 +240,7 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
     cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('exist');
     cy.wait('@overviewJson');
-    cy.get('[data-testid="overview-page"] [aria-busy="true"]', { timeout: 15_000 }).should(
-      'not.exist',
-    );
+    cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('not.exist');
   });
 
   it('rewrites one history entry when the overview request fails', () => {
@@ -252,7 +253,7 @@ describe('Overview page', () => {
       const before = win.history.length;
       cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
       cy.wait('@overviewJsonFailure');
-      cy.location('search', { timeout: 15_000 }).should('eq', '?tier=75');
+      cy.location('search').should('eq', '?tier=75');
       // A plain `.should` would be satisfied by the transient extra entry.
       cy.window().then((after) => {
         expect(after.history.length - before, 'one entry for one selection').to.equal(1);
@@ -260,9 +261,9 @@ describe('Overview page', () => {
     });
 
     cy.go('back');
-    cy.location('search', { timeout: 15_000 }).should('eq', '');
+    cy.location('search').should('eq', '');
     cy.go('back');
-    cy.location('pathname', { timeout: 15_000 }).should('eq', '/inference');
+    cy.location('pathname').should('eq', '/inference');
   });
 
   it('warms a hovered option and derives the reference without a request', () => {
@@ -288,7 +289,7 @@ describe('Overview page', () => {
 
     cy.get('[data-testid="overview-reference-select"]').click();
     cy.get('[data-overview-reference="b300"]').click();
-    cy.location('search', { timeout: 15_000 }).should('eq', '?tier=100&ref=b300');
+    cy.location('search').should('eq', '?tier=100&ref=b300');
     cy.get('[data-overview-comparison="hardware"]').should('contain.text', 'vs B300');
     cy.then(() => {
       expect(jsonRequests, 'a reference change is derived, not fetched').to.equal(1);
@@ -300,6 +301,8 @@ describe('Overview page', () => {
     cy.visit('/overview');
 
     cy.get('[data-overview-comparison="30d"]').click();
+    // Explicit timeout retained: this waits on a real /api/v1/overview response,
+    // not a client-side URL change.
     cy.get('[data-overview-comparison="30d"]', { timeout: 15_000 }).should(
       'have.attr',
       'aria-current',
@@ -321,7 +324,8 @@ describe('Overview page', () => {
     desktopModel('gpt-oss-120b')
       .find('[data-testid="overview-model-category-badge"]')
       .should('have.attr', 'data-category', 'deprecated')
-      .and('contain.text', 'Deprecated');
+      .and('contain.text', 'Deprecated')
+      .and('contain.text', 'Model is no longer actively benchmarked.');
     desktopModel('DeepSeek-R1-0528')
       .find('[data-testid="overview-model-category-badge"]')
       .should('have.attr', 'data-category', 'maintenance');
@@ -356,7 +360,8 @@ describe('Overview page', () => {
     );
     desktopModel('gpt-oss-120b')
       .find('[data-testid="overview-model-category-badge"]')
-      .should('contain.text', '已弃用');
+      .should('contain.text', '已弃用')
+      .and('contain.text', '该模型已不再进行活跃基准测试。');
   });
 
   it('uses a selectable hardware reference and preserves it across overview controls', () => {
@@ -469,7 +474,7 @@ describe('Overview page', () => {
 
     cy.get('[data-testid="overview-history-window-select"]').click();
     cy.get('[data-overview-window="7d"]').click();
-    cy.location('search', { timeout: 15_000 }).should('eq', '?compare=7d');
+    cy.location('search').should('eq', '?compare=7d');
     cy.get('[data-overview-comparison="7d"]').should('have.attr', 'aria-current', 'true');
     cy.contains(
       'Current cost and change versus the latest validated platform result 7–14 days earlier.',
@@ -477,7 +482,7 @@ describe('Overview page', () => {
 
     cy.get('[data-testid="overview-history-window-select"]').click();
     cy.get('[data-overview-window="90d"]').click();
-    cy.location('search', { timeout: 15_000 }).should('eq', '?compare=90d');
+    cy.location('search').should('eq', '?compare=90d');
     cy.contains(
       'Current cost and change versus the latest validated platform result 90–180 days earlier.',
     ).should('exist');

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -679,10 +679,12 @@ function ModelName({ model, strings }: { model: OverviewModelSummary; strings: O
             className="ml-1.5 inline-block rounded-sm border border-border/60 px-1 py-px align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
           >
             {badge}
-            {/* `title` reaches a hovering mouse and nothing else. The badge is
-                an abbreviation, so without this the reason it exists is
-                unavailable to touch, keyboard and screen-reader users. */}
-            <span className="sr-only">{strings.categoryBadgeTitle}</span>
+            {/* `title` reaches a hovering mouse and nothing else, so a screen
+                reader announced this badge as a bare label with no reason
+                attached. `normal-case` because the badge's `uppercase` inherits
+                and browsers expose the transformed string to the accessibility
+                tree, which turns the sentence into shouted, mis-parsed words. */}
+            <span className="sr-only normal-case">{strings.categoryBadgeTitle}</span>
           </span>
         )}
       </h2>

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -679,6 +679,10 @@ function ModelName({ model, strings }: { model: OverviewModelSummary; strings: O
             className="ml-1.5 inline-block rounded-sm border border-border/60 px-1 py-px align-middle text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
           >
             {badge}
+            {/* `title` reaches a hovering mouse and nothing else. The badge is
+                an abbreviation, so without this the reason it exists is
+                unavailable to touch, keyboard and screen-reader users. */}
+            <span className="sr-only">{strings.categoryBadgeTitle}</span>
           </span>
         )}
       </h2>


### PR DESCRIPTION
Two loose ends from the #704 review, both verified against the code before being written. The other items I had listed as follow-ups on that PR did **not** survive verification and are deliberately absent — see *Checked and dropped*.

## The category badge explains itself only to a mouse

Deprecated and maintenance-mode models carry an abbreviation badge next to the model name. What it means — *"Model is no longer actively benchmarked."* — lived only in `title`, which reaches a hovering pointer and nothing else. The badge is a `<span>`, so it is not focusable; touch, keyboard and screen-reader users saw an unexplained abbreviation with no way to resolve it.

Fixed the same way #704 fixed the missing-result reasons: an `sr-only` companion. `title` stays, so nothing changes for a mouse.

## Inline Cypress timeouts on assertions that resolve synchronously

`cypress.config.ts` sets `defaultCommandTimeout: 6000`, but `overview.cy.ts` carried fourteen `{ timeout: 15_000 }` overrides. Twelve of them sat on assertions the click resolves synchronously — `cy.location(...)` after a `pushState` or a `popstate`, and one `aria-busy` check that runs after `cy.wait()` has already landed the response. Those are now on the default.

The number was arbitrary rather than measured, and the file already said so: line 216 asserted `?tier=75&engine=all` at 15 s while line 222, in the same test, asserted the identical thing at the default.

Two overrides are kept, each with a note saying why, because they genuinely wait on a real `/api/v1/overview` round trip — the intercepts are `request.continue` passthroughs with an added delay, not fixtures.

This is not a speed-up. It matters because a 15 s ceiling on a soft navigation that should complete in milliseconds means a regression to eight seconds still passes green, so the work #704 did had no guard on it. The secondary effect is that a genuinely broken assertion now surfaces in 6 s instead of 15.

## Checked and dropped

Three items I had listed as follow-ups on #704 turned out not to hold:

- **Canonicalizing the cache key on the other `cachedJson` routes.** Twelve routes read `searchParams`; the concern does not apply to any of them. Their server cache is keyed on explicit `cachedQuery` arguments, already canonical, and every caller builds the URL programmatically in fixed insertion order (`lib/api.ts`) — no path feeds the page's address bar into an API URL. `/overview` was the exception precisely because its key came from the address bar, where campaign tags and param order vary.
- **Converting the scorecard's template-literal classNames to `cn()`.** The file does bypass the repo's `twMerge` resolver — nine sites, no `cn` import, against 36 component files that use it. But #704 fixed the underline bug structurally, by moving `border-transparent` onto the inactive branch so the two never share a string, and I checked all nine sites: there is no live conflict today. Rewriting them would change the rendered class strings for defensive value only.
- **"Three sibling hover-only affordances."** Only one was bare. The other three (`overview-scorecard.tsx` cost-delta badge, the estimate span, the evidence link) each already pair `title` with an `sr-only` span or an `aria-label`.

## Validation

`typecheck`, `lint`, `fmt` clean; 3,390 unit tests pass. The badge assertion is added to the two existing e2e tests that already cover it, on both the English and Chinese routes — removing the `sr-only` span fails both. Cypress is not runnable locally (no `DATABASE_READONLY_URL`), so CI is the first execution of the spec changes.

## 中文说明

#704 评审遗留的两件事，都先对照代码验证过才动手。当时列为 follow-up 的其余几条**没有通过验证**，本 PR 有意不做，见"已核查并排除"。

**其一，分类徽章只对鼠标解释自己。** 已弃用与维护模式的模型在名称旁带一个缩写徽章，而它的含义"该模型已不再进行活跃基准测试。"只放在 `title` 里 —— 只有悬停的指针能看到。徽章是 `<span>`，不可聚焦，因此触屏、键盘与屏幕阅读器用户看到的是一个无从解释的缩写。修法与 #704 处理"无结果原因"一致：补一个 `sr-only` 伴随文本，`title` 保留，鼠标端体验不变。

**其二，给同步完成的断言加了内联超时。** `cypress.config.ts` 设的是 `defaultCommandTimeout: 6000`，而 `overview.cy.ts` 里有十四处 `{ timeout: 15_000 }`。其中十二处断言的是点击同步完成的状态 —— `pushState` / `popstate` 之后的 `cy.location(...)`，以及一处在 `cy.wait()` 已拿到响应之后才检查的 `aria-busy`，现已改回默认值。这个数字是随手写的而非量出来的，文件本身就是证据：216 行用 15 秒断言 `?tier=75&engine=all`，同一个测试的 222 行用默认值断言了完全相同的东西。保留两处并各自注明原因，因为它们确实在等真实的 `/api/v1/overview` 往返（intercept 是 `request.continue` 透传加延迟，不是 fixture）。

这不是提速。要紧的是：软导航本该毫秒级完成，15 秒的上限意味着退化到八秒依然全绿 —— #704 做的优化等于没有任何回归防护。附带效果是断言真挂时 6 秒暴露而不是 15 秒。

**已核查并排除三条**：其他 `cachedJson` 路由的缓存键规范化（十二条路由的服务端缓存本就按 `cachedQuery` 显式参数取键，且调用方均在 `lib/api.ts` 中按固定顺序程序化拼 URL，没有任何路径把页面地址栏透传给 API；`/overview` 是例外恰恰因为它的键取自地址栏）；把 scorecard 的模板字符串 className 改成 `cn()`（该文件确实绕过了 twMerge —— 九处、无 `cn` 引入，而全库 36 个组件文件在用；但 #704 是结构性修复，把 `border-transparent` 移到了未选中分支使二者永不共存，九处逐一核查后今天无任何活跃冲突，改写只会改变实际渲染的 class 串而无实际收益）；"三处同类 hover-only 缺陷"（实际只有一处是裸的，其余三处均已配 `sr-only` 或 `aria-label`）。

验证：typecheck、lint、fmt 全部通过，3,390 个单元测试通过。徽章断言加在已覆盖该元素的两个 e2e 测试上，中英文路由各一处，移除 `sr-only` 两处都会失败。本地无 `DATABASE_READONLY_URL`，Cypress 未能实际执行，CI 为首次运行。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI accessibility and test-timeout tuning only; no API, auth, or data-path changes.
> 
> **Overview**
> Deprecated/maintenance **category badges** now expose the same explanation that lived only in `title` via an **`sr-only`** span with **`normal-case`**, so screen readers get the full sentence without uppercase mangling; mouse users still see `title` on hover.
> 
> **Overview Cypress** drops twelve **`{ timeout: 15_000 }`** overrides on **`cy.location`** and post-**`cy.wait`** **`aria-busy`** checks that resolve on client-side URL updates or already-finished requests, aligning with **`defaultCommandTimeout: 6000`** so slow soft navigations fail faster. Two assertions that wait on delayed real API round trips keep 15s with inline comments; e2e badge tests now also assert the hidden explanatory text on English and Chinese routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f5c01e27ebc371060d1946d5e5024ac299b143. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->