### PR TITLE
feat(inference): default AgentX-capable models to the Agentic scenario

### DIFF
--- a/docs/state-ownership.md
+++ b/docs/state-ownership.md
@@ -39,9 +39,9 @@ File: `packages/app/src/components/GlobalFilterContext.tsx`
 
 **Effective (auto-corrected) values** (derived, not settable directly):
 
-- `effectiveSequence` — the model's per-model default scenario while the user has made no explicit
-  choice (`getModelDefaultSequence`, e.g. Agentic Workloads for the AgentX models), otherwise
-  `selectedSequence` if valid for the current model, else 8K/1K, else first available
+- `effectiveSequence` — Agentic Workloads while the user has made no explicit choice and the model
+  has corresponding availability, otherwise `selectedSequence` if valid for the current model,
+  else 8K/1K, else first available
 - `effectivePrecisions` — subset of `selectedPrecisions` that are available; falls back to `[availablePrecisions[0]]`
 - `effectiveRunDate` — latest available date unless user explicitly picked one
 
@@ -192,7 +192,7 @@ GlobalFilterProvider
   → selectedModel     (user pick)
   → modelRows         = availabilityRows filtered to selectedModel (internal memo)
   → availableSequences = unique sequences in modelRows
-  → effectiveSequence  = model default (if unchosen and in availableSequences),
+  → effectiveSequence  = Agentic Workloads (if unchosen and in availableSequences),
                          else selectedSequence if in availableSequences,
                          else 8k/1k if available, else availableSequences[0]
   → availablePrecisions = unique precisions in modelRows where sequence = effectiveSequence

--- a/docs/state-ownership.md
+++ b/docs/state-ownership.md
@@ -39,9 +39,9 @@ File: `packages/app/src/components/GlobalFilterContext.tsx`
 
 **Effective (auto-corrected) values** (derived, not settable directly):
 
-- `effectiveSequence` — Agentic Workloads while the user has made no explicit choice and the model
-  has corresponding availability, otherwise `selectedSequence` if valid for the current model,
-  else 8K/1K, else first available
+- `effectiveSequence` — the Agentic scenario while the user has made no explicit choice and the
+  model has corresponding availability, otherwise `selectedSequence` if valid for the current
+  model, else 8K/1K, else first available
 - `effectivePrecisions` — subset of `selectedPrecisions` that are available; falls back to `[availablePrecisions[0]]`
 - `effectiveRunDate` — latest available date unless user explicitly picked one
 
@@ -192,7 +192,7 @@ GlobalFilterProvider
   → selectedModel     (user pick)
   → modelRows         = availabilityRows filtered to selectedModel (internal memo)
   → availableSequences = unique sequences in modelRows
-  → effectiveSequence  = Agentic Workloads (if unchosen and in availableSequences),
+  → effectiveSequence  = Agentic (if unchosen and in availableSequences),
                          else selectedSequence if in availableSequences,
                          else 8k/1k if available, else availableSequences[0]
   → availablePrecisions = unique precisions in modelRows where sequence = effectiveSequence

--- a/docs/state-ownership.md
+++ b/docs/state-ownership.md
@@ -39,7 +39,9 @@ File: `packages/app/src/components/GlobalFilterContext.tsx`
 
 **Effective (auto-corrected) values** (derived, not settable directly):
 
-- `effectiveSequence` — `selectedSequence` if valid for current model, else first available
+- `effectiveSequence` — the model's per-model default scenario while the user has made no explicit
+  choice (`getModelDefaultSequence`, e.g. Agentic Workloads for the AgentX models), otherwise
+  `selectedSequence` if valid for the current model, else 8K/1K, else first available
 - `effectivePrecisions` — subset of `selectedPrecisions` that are available; falls back to `[availablePrecisions[0]]`
 - `effectiveRunDate` — latest available date unless user explicitly picked one
 
@@ -190,7 +192,9 @@ GlobalFilterProvider
   → selectedModel     (user pick)
   → modelRows         = availabilityRows filtered to selectedModel (internal memo)
   → availableSequences = unique sequences in modelRows
-  → effectiveSequence  = selectedSequence if in availableSequences, else availableSequences[0]
+  → effectiveSequence  = model default (if unchosen and in availableSequences),
+                         else selectedSequence if in availableSequences,
+                         else 8k/1k if available, else availableSequences[0]
   → availablePrecisions = unique precisions in modelRows where sequence = effectiveSequence
   → effectivePrecisions = selectedPrecisions ∩ availablePrecisions; falls back to [availablePrecisions[0]]
   → availableDates     = unique dates in modelRows where sequence = effectiveSequence

--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -102,7 +102,7 @@ The reset's early-out guards on the **merged** list, not the official one. An em
 - **Clamped values.** `interpolateForGPU` clamps the target into each series' measured range and always returns a value, so a bar can be showing its nearest edge point rather than an interpolation. This is pre-existing across GPUs with different ranges, but widening the slider to cover overlay operating points makes it reachable for every official bar at once — which would turn a side-by-side overlay delta into a real-vs-clamped comparison. Results carry a `clamped` flag and the tooltip says so. (Narrowing the slider back is not the fix: it only moves the clamping onto the overlay bars, and an overlay-only model loses its bounds entirely.)
 - **Escaping.** The tooltip is a hand-built HTML string injected with `.html()`, and branch names and run URLs come from the GitHub API for whatever run id the user pasted. Everything untrusted goes through `escapeHtml` (`lib/utils`). The y-axis tick labels render the same branch but go through d3 `.text()`, and the legend entry is React — both already safe.
 
-The calculator supports both fixed-sequence and Agentic Traces scenarios through
+The calculator supports both fixed-sequence and Agentic Workloads scenarios through
 the shared `rowToSequence` classifier. Agentic rows carry null `isl`/`osl`, so
 filtering them by numeric sequence lengths would silently drop every point.
 

--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -102,7 +102,7 @@ The reset's early-out guards on the **merged** list, not the official one. An em
 - **Clamped values.** `interpolateForGPU` clamps the target into each series' measured range and always returns a value, so a bar can be showing its nearest edge point rather than an interpolation. This is pre-existing across GPUs with different ranges, but widening the slider to cover overlay operating points makes it reachable for every official bar at once — which would turn a side-by-side overlay delta into a real-vs-clamped comparison. Results carry a `clamped` flag and the tooltip says so. (Narrowing the slider back is not the fix: it only moves the clamping onto the overlay bars, and an overlay-only model loses its bounds entirely.)
 - **Escaping.** The tooltip is a hand-built HTML string injected with `.html()`, and branch names and run URLs come from the GitHub API for whatever run id the user pasted. Everything untrusted goes through `escapeHtml` (`lib/utils`). The y-axis tick labels render the same branch but go through d3 `.text()`, and the legend entry is React — both already safe.
 
-The calculator supports both fixed-sequence and Agentic Workloads scenarios through
+The calculator supports both fixed-sequence and Agentic scenarios through
 the shared `rowToSequence` classifier. Agentic rows carry null `isl`/`osl`, so
 filtering them by numeric sequence lengths would silently drop every point.
 

--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -232,7 +232,7 @@ function LegendWithPointsTable() {
             if (!open) setOpenSeries(null);
           }}
           title={isOverlay ? '✕ my-branch' : 'B300 (vLLM)'}
-          subtitle="DeepSeek V4 Pro · Agentic Workloads"
+          subtitle="DeepSeek V4 Pro · Agentic"
           accentColor={isOverlay ? '#dc2626' : '#2b83ba'}
           rows={buildLegendPointsRows(isOverlay ? OVERLAY_POINTS : OFFICIAL_POINTS, isOverlay)}
           isOverlay={isOverlay}
@@ -258,7 +258,7 @@ describe('ChartLegend points-table icon + dialog', () => {
     cy.get('[data-testid="legend-points-dialog"]').should('contain.text', 'B300 (vLLM)');
     cy.get('[data-testid="legend-points-dialog"]').should(
       'contain.text',
-      'DeepSeek V4 Pro · Agentic Workloads',
+      'DeepSeek V4 Pro · Agentic',
     );
     // Two rows, conc ascending, linked to the agentic detail pages
     cy.get('[data-testid="legend-points-row"]').should('have.length', 2);

--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -232,7 +232,7 @@ function LegendWithPointsTable() {
             if (!open) setOpenSeries(null);
           }}
           title={isOverlay ? '✕ my-branch' : 'B300 (vLLM)'}
-          subtitle="DeepSeek V4 Pro · Agentic Traces"
+          subtitle="DeepSeek V4 Pro · Agentic Workloads"
           accentColor={isOverlay ? '#dc2626' : '#2b83ba'}
           rows={buildLegendPointsRows(isOverlay ? OVERLAY_POINTS : OFFICIAL_POINTS, isOverlay)}
           isOverlay={isOverlay}
@@ -258,7 +258,7 @@ describe('ChartLegend points-table icon + dialog', () => {
     cy.get('[data-testid="legend-points-dialog"]').should('contain.text', 'B300 (vLLM)');
     cy.get('[data-testid="legend-points-dialog"]').should(
       'contain.text',
-      'DeepSeek V4 Pro · Agentic Traces',
+      'DeepSeek V4 Pro · Agentic Workloads',
     );
     // Two rows, conc ascending, linked to the agentic detail pages
     cy.get('[data-testid="legend-points-row"]').should('have.length', 2);

--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -128,12 +128,16 @@ describe('Chart Selectors', () => {
   });
 
   describe('ScenarioSelector', () => {
-    it('labels the agentic scenario "Agentic Workloads"', () => {
+    it('labels the agentic scenario "Agentic"', () => {
       cy.mount(<ScenarioSelectorHarness />);
-      cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+      cy.get('[data-testid="scenario-selector"]').should('have.text', 'Agentic');
       cy.get('[data-testid="scenario-selector"]').click();
-      cy.contains('[role="option"]', 'Agentic Workloads').should('be.visible');
+      cy.contains('[role="option"]', 'Agentic').should('be.visible');
       cy.contains('[role="option"]', 'Agentic Traces').should('not.exist');
+      // The lone agentic entry needs no "Agentic" heading above it.
+      cy.get('[data-slot="select-content"]')
+        .find('[data-slot="select-label"]')
+        .should('not.contain.text', 'Agentic');
     });
 
     it('explains the agentic workload in a tooltip that links to /datasets', () => {
@@ -157,7 +161,7 @@ describe('Chart Selectors', () => {
 
       // ...and appears as soon as the user picks the agentic scenario.
       cy.get('[data-testid="scenario-selector"]').click();
-      cy.contains('[role="option"]', 'Agentic Workloads').click();
+      cy.contains('[role="option"]', 'Agentic').click();
       cy.get('[data-testid="scenario-agentic-info"]').should('exist');
     });
   });

--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 
 import {
   ModelSelector,
+  ScenarioSelector,
   SequenceSelector,
   PrecisionSelector,
 } from '@/components/ui/chart-selectors';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { Model } from '@/lib/data-mappings';
+import { Model, Sequence } from '@/lib/data-mappings';
 
 function ModelSelectorHarness() {
   const [value, setValue] = useState('DeepSeek-R1-0528');
@@ -37,6 +38,20 @@ function SequenceSelectorHarness() {
         onChange={setValue}
         availableSequences={['1024_128', '1024_8192', '8192_1024']}
         data-testid="sequence-selector"
+      />
+    </TooltipProvider>
+  );
+}
+
+function ScenarioSelectorHarness({ initial = Sequence.AgenticTraces }: { initial?: Sequence }) {
+  const [value, setValue] = useState<string>(initial);
+  return (
+    <TooltipProvider delayDuration={0}>
+      <ScenarioSelector
+        value={value}
+        onChange={setValue}
+        availableSequences={[Sequence.EightK_OneK, Sequence.AgenticTraces]}
+        data-testid="scenario-selector"
       />
     </TooltipProvider>
   );
@@ -109,6 +124,41 @@ describe('Chart Selectors', () => {
       cy.get('[data-testid="sequence-selector"]').click();
       cy.get('[role="option"]').last().click();
       cy.get('[data-testid="sequence-selector"]').should('not.contain', '1K / 128');
+    });
+  });
+
+  describe('ScenarioSelector', () => {
+    it('labels the agentic scenario "Agentic Workloads"', () => {
+      cy.mount(<ScenarioSelectorHarness />);
+      cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+      cy.get('[data-testid="scenario-selector"]').click();
+      cy.contains('[role="option"]', 'Agentic Workloads').should('be.visible');
+      cy.contains('[role="option"]', 'Agentic Traces').should('not.exist');
+    });
+
+    it('explains the agentic workload in a tooltip that links to /datasets', () => {
+      cy.mount(<ScenarioSelectorHarness />);
+      cy.get('[data-testid="scenario-agentic-info"]').trigger('pointermove', {
+        pointerType: 'mouse',
+      });
+
+      cy.contains('Realistic Long Context Multi Turn Agentic Workload with Sub Agents.').should(
+        'be.visible',
+      );
+      cy.get('[data-testid="scenario-agentic-info-link"]')
+        .should('be.visible')
+        .and('have.attr', 'href', '/datasets');
+    });
+
+    it('hides the agentic explainer on fixed-sequence scenarios', () => {
+      cy.mount(<ScenarioSelectorHarness initial={Sequence.EightK_OneK} />);
+      cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+      cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
+
+      // ...and appears as soon as the user picks the agentic scenario.
+      cy.get('[data-testid="scenario-selector"]').click();
+      cy.contains('[role="option"]', 'Agentic Workloads').click();
+      cy.get('[data-testid="scenario-agentic-info"]').should('exist');
     });
   });
 

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -624,7 +624,7 @@ describe('TCO Calculator', () => {
     });
 
     it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Traces');
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Workloads');
       cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
       cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
@@ -681,7 +681,7 @@ describe('TCO Calculator', () => {
       });
       cy.wait('@agenticBenchmarks');
 
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Traces');
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Workloads');
       cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -624,7 +624,7 @@ describe('TCO Calculator', () => {
     });
 
     it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Workloads');
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic');
       cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
       cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
@@ -681,7 +681,7 @@ describe('TCO Calculator', () => {
       });
       cy.wait('@agenticBenchmarks');
 
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic Workloads');
+      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic');
       cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -8,8 +8,7 @@ import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2
 // SPEC-SCOPED INTERCEPTS (not the shared fixtures) so this spec — and only this
 // spec — sees the agentic view. Most cases still pass ?i_seq=agentic-traces
 // explicitly; the "Default scenario" block below covers the implicit path,
-// where DeepSeek-V4-Pro's per-model default opens the agentic scenario on its
-// own.
+// where availability opens the agentic scenario on its own.
 const DEFAULT_MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro is the default model
 const AGENTIC_DATE = '2026-06-12';
 
@@ -120,14 +119,14 @@ const interceptAgenticData = () => {
   cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticBenchmarks }).as('benchmarks');
 };
 
-// Same rows re-keyed to a model that declares no per-model default scenario, so
-// the "app default wins" branch stays covered.
-const OTHER_MODEL_DB_KEY = 'dsr1'; // DeepSeek-R1-0528 declares no default scenario
+// Same rows re-keyed to another model to prove the default follows availability
+// rather than a hard-coded model registry.
+const OTHER_MODEL_DB_KEY = 'dsr1';
 const otherModelAvailability = agenticAvailability.map((row) => ({
   ...row,
   model: OTHER_MODEL_DB_KEY,
 }));
-const otherModelBenchmarks = fixedSequenceBenchmarks.map((row, index) => ({
+const otherModelBenchmarks = agenticBenchmarks.map((row, index) => ({
   ...row,
   id: 920000 + index,
   model: OTHER_MODEL_DB_KEY,
@@ -419,10 +418,9 @@ describe('X-axis mode URL param', () => {
 });
 
 describe('Default scenario', () => {
-  it('bare /inference opens on Agentic Workloads for a model that declares it', () => {
+  it('bare /inference opens on Agentic Workloads when the model has corresponding data', () => {
     // Availability contains BOTH agentic and fixed-seq rows for DeepSeek-V4-Pro,
-    // which declares Agentic Workloads as its opening scenario — so the
-    // untouched 8K/1K selection must not win.
+    // so the untouched 8K/1K selection must not win.
     interceptAgenticData();
     interceptDerivedAgenticMetrics();
     cy.visit('/inference', {
@@ -438,7 +436,7 @@ describe('Default scenario', () => {
   });
 
   it('keeps 8K / 1K when the link asks for it explicitly', () => {
-    // An explicit selection always beats the per-model default.
+    // An explicit selection always beats the availability-driven default.
     interceptFixedSequenceData();
     cy.visit('/inference?i_seq=8k%2F1k', {
       onBeforeLoad(win) {
@@ -453,9 +451,9 @@ describe('Default scenario', () => {
     cy.get('[data-testid="chart-figure"] svg').should('not.contain.text', 'P90 Interactivity');
   });
 
-  it('leaves a model without a declared default on 8K / 1K', () => {
-    // DeepSeek-R1 has agentic rows here too, but declares no opening scenario,
-    // so it keeps the app-wide 8K/1K default.
+  it('opens Agentic Workloads for another model with corresponding data', () => {
+    // DeepSeek-R1 is intentionally outside the original hard-coded model list;
+    // its agentic availability must still make Agentic Workloads the default.
     cy.intercept('GET', '/api/v1/availability', { body: otherModelAvailability }).as(
       'availability',
     );
@@ -465,8 +463,8 @@ describe('Default scenario', () => {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
-    cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-agentic-info"]').should('exist');
   });
 });
 

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -1,7 +1,7 @@
 import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
 
 // This spec exercises the agentic x-axis modes, which only exist when the
-// selected model resolves to the Agentic Workloads scenario. The default e2e
+// selected model resolves to the Agentic scenario. The default e2e
 // fixtures (cypress/fixtures/api/*.json) have NO agentic rows for any model, so
 // bare /inference always resolves to a fixed-seq scenario there. We therefore
 // inject agentic availability + benchmark rows for the default model VIA
@@ -177,7 +177,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('defaults the agentic view to Interactivity, with all four modes as flat tabs', () => {
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     // #736 made every latency mode a top-level tab and moved the default off E2E
     // Normalized Interactivity, which still leads the strip without being selected.
     cy.get('[data-testid="x-axis-mode-advanced"]').should('not.exist');
@@ -273,7 +273,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
         unlockAgenticGate(win);
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
@@ -385,7 +385,7 @@ describe('X-axis mode URL param', () => {
         unlockAgenticGate(win);
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     cy.get('[data-testid="x-axis-mode-ttft"]')
       .should('have.attr', 'aria-selected', 'true')
       .and('contain.text', 'TTFT');
@@ -411,14 +411,14 @@ describe('X-axis mode URL param', () => {
       },
     });
 
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     cy.get('[data-testid="percentile-selector"]').should('not.exist');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'P90');
   });
 });
 
 describe('Default scenario', () => {
-  it('bare /inference opens on Agentic Workloads when the model has corresponding data', () => {
+  it('bare /inference opens on the Agentic scenario when the model has corresponding data', () => {
     // Availability contains BOTH agentic and fixed-seq rows for DeepSeek-V4-Pro,
     // so the untouched 8K/1K selection must not win.
     interceptAgenticData();
@@ -428,7 +428,7 @@ describe('Default scenario', () => {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     // The explainer sits beside the trigger, linking out to the dataset page.
     cy.get('[data-testid="scenario-agentic-info"]').should('exist');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
@@ -451,9 +451,9 @@ describe('Default scenario', () => {
     cy.get('[data-testid="chart-figure"] svg').should('not.contain.text', 'P90 Interactivity');
   });
 
-  it('opens Agentic Workloads for another model with corresponding data', () => {
+  it('opens the Agentic scenario for another model with corresponding data', () => {
     // DeepSeek-R1 is intentionally outside the original hard-coded model list;
-    // its agentic availability must still make Agentic Workloads the default.
+    // its agentic availability must still make the Agentic scenario the default.
     cy.intercept('GET', '/api/v1/availability', { body: otherModelAvailability }).as(
       'availability',
     );
@@ -463,7 +463,7 @@ describe('Default scenario', () => {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
     cy.get('[data-testid="scenario-agentic-info"]').should('exist');
   });
 });

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -1,13 +1,15 @@
 import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
 
 // This spec exercises the agentic x-axis modes, which only exist when the
-// selected model resolves to the Agentic Traces scenario. The default e2e
-// fixtures (cypress/fixtures/api/*.json) have NO agentic rows for any model, and
-// the app default scenario is 8K/1K, so bare /inference always resolves to a
-// fixed-seq scenario. We therefore inject agentic availability + benchmark rows
-// for the default model VIA SPEC-SCOPED INTERCEPTS (not the shared fixtures) and
-// visit with an explicit ?i_seq=agentic-traces so this test — and only this
-// test — sees the agentic view.
+// selected model resolves to the Agentic Workloads scenario. The default e2e
+// fixtures (cypress/fixtures/api/*.json) have NO agentic rows for any model, so
+// bare /inference always resolves to a fixed-seq scenario there. We therefore
+// inject agentic availability + benchmark rows for the default model VIA
+// SPEC-SCOPED INTERCEPTS (not the shared fixtures) so this spec — and only this
+// spec — sees the agentic view. Most cases still pass ?i_seq=agentic-traces
+// explicitly; the "Default scenario" block below covers the implicit path,
+// where DeepSeek-V4-Pro's per-model default opens the agentic scenario on its
+// own.
 const DEFAULT_MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro is the default model
 const AGENTIC_DATE = '2026-06-12';
 
@@ -46,8 +48,8 @@ const agenticGpus = [
   { hardware: 'b300', framework: 'vllm', disagg: false },
 ];
 
-// Availability: default model has BOTH agentic and fixed-seq. The agentic view
-// is selected explicitly via ?i_seq=agentic-traces (the app default is 8K/1K).
+// Availability: default model has BOTH agentic and fixed-seq, so the scenario
+// the chart lands on is a real choice rather than the only option.
 const agenticAvailability = [
   ...agenticGpus.map((g) => ({
     model: DEFAULT_MODEL_DB_KEY,
@@ -118,6 +120,19 @@ const interceptAgenticData = () => {
   cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticBenchmarks }).as('benchmarks');
 };
 
+// Same rows re-keyed to a model that declares no per-model default scenario, so
+// the "app default wins" branch stays covered.
+const OTHER_MODEL_DB_KEY = 'dsr1'; // DeepSeek-R1-0528 declares no default scenario
+const otherModelAvailability = agenticAvailability.map((row) => ({
+  ...row,
+  model: OTHER_MODEL_DB_KEY,
+}));
+const otherModelBenchmarks = fixedSequenceBenchmarks.map((row, index) => ({
+  ...row,
+  id: 920000 + index,
+  model: OTHER_MODEL_DB_KEY,
+}));
+
 const interceptFixedSequenceData = () => {
   cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as('availability');
   cy.intercept('GET', '/api/v1/benchmarks*', { body: fixedSequenceBenchmarks }).as('benchmarks');
@@ -163,7 +178,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
   });
 
   it('defaults the agentic view to Interactivity, with all four modes as flat tabs', () => {
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
     // #736 made every latency mode a top-level tab and moved the default off E2E
     // Normalized Interactivity, which still leads the strip without being selected.
     cy.get('[data-testid="x-axis-mode-advanced"]').should('not.exist');
@@ -259,7 +274,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
         unlockAgenticGate(win);
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
@@ -371,7 +386,7 @@ describe('X-axis mode URL param', () => {
         unlockAgenticGate(win);
       },
     });
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
     cy.get('[data-testid="x-axis-mode-ttft"]')
       .should('have.attr', 'aria-selected', 'true')
       .and('contain.text', 'TTFT');
@@ -397,27 +412,61 @@ describe('X-axis mode URL param', () => {
       },
     });
 
-    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Traces');
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
     cy.get('[data-testid="percentile-selector"]').should('not.exist');
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'P90');
   });
 });
 
 describe('Default scenario', () => {
-  it('bare /inference defaults to 8K / 1K even when the model has agentic data', () => {
-    // Availability contains BOTH agentic and fixed-seq rows for the default
-    // model; the default selection must still resolve to 8K/1K, not agentic.
-    interceptFixedSequenceData();
+  it('bare /inference opens on Agentic Workloads for a model that declares it', () => {
+    // Availability contains BOTH agentic and fixed-seq rows for DeepSeek-V4-Pro,
+    // which declares Agentic Workloads as its opening scenario — so the
+    // untouched 8K/1K selection must not win.
+    interceptAgenticData();
+    interceptDerivedAgenticMetrics();
     cy.visit('/inference', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
     });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic Workloads');
+    // The explainer sits beside the trigger, linking out to the dataset page.
+    cy.get('[data-testid="scenario-agentic-info"]').should('exist');
+    cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
+    cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'P90');
+  });
+
+  it('keeps 8K / 1K when the link asks for it explicitly', () => {
+    // An explicit selection always beats the per-model default.
+    interceptFixedSequenceData();
+    cy.visit('/inference?i_seq=8k%2F1k', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
     cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
     // Fixed-seq plots the mean field — no percentile prefix on the axis label.
     cy.get('[data-testid="chart-figure"] svg').should('contain.text', 'Interactivity (tok/s/user)');
     cy.get('[data-testid="chart-figure"] svg').should('not.contain.text', 'P90 Interactivity');
+  });
+
+  it('leaves a model without a declared default on 8K / 1K', () => {
+    // DeepSeek-R1 has agentic rows here too, but declares no opening scenario,
+    // so it keeps the app-wide 8K/1K default.
+    cy.intercept('GET', '/api/v1/availability', { body: otherModelAvailability }).as(
+      'availability',
+    );
+    cy.intercept('GET', '/api/v1/benchmarks*', { body: otherModelBenchmarks }).as('benchmarks');
+    cy.visit('/inference?g_model=DeepSeek-R1-0528', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
   });
 });
 

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -19,7 +19,7 @@ Cypress.on('window:before:load', (win) => {
  * Seed the shared feature-gate flag (the same localStorage key the ↑↑↓↓ konami
  * unlock writes — see use-feature-gate.ts).
  *
- * The agentic surfaces (the "Agentic Workloads" scenario, /datasets,
+ * The agentic surfaces (the "Agentic" scenario, /datasets,
  * /inference/agentic/[id], and the Datasets nav link) are now PUBLIC by default
  * — they no longer sit behind this gate — so agentic specs no longer need it.
  * The helper is retained as a harmless no-op for those specs (and still unlocks

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -19,7 +19,7 @@ Cypress.on('window:before:load', (win) => {
  * Seed the shared feature-gate flag (the same localStorage key the ↑↑↓↓ konami
  * unlock writes — see use-feature-gate.ts).
  *
- * The agentic surfaces (the "Agentic Traces" scenario, /datasets,
+ * The agentic surfaces (the "Agentic Workloads" scenario, /datasets,
  * /inference/agentic/[id], and the Datasets nav link) are now PUBLIC by default
  * — they no longer sit behind this gate — so agentic specs no longer need it.
  * The helper is retained as a harmless no-op for those specs (and still unlocks

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -26,7 +26,6 @@ import { useWorkflowInfo } from '@/hooks/api/use-workflow-info';
 import { useUrlState } from '@/hooks/useUrlState';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import {
-  getModelDefaultSequence,
   Model,
   MODEL_OPTIONS,
   Precision,
@@ -43,13 +42,10 @@ const RUNDATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const RUNID_RE = /^[A-Za-z0-9_-]{1,64}$/u;
 
 // Placeholder for the public (non-null) `effectiveSequence` during the window
-// before availability has loaded: the scenario the model is *expected* to open
-// on — its per-model default when the user hasn't chosen, otherwise `8k/1k`,
-// the app default scenario. Guessing the model's own default keeps the selector
-// from flashing "8K / 1K" on an agentic-default model (and, as before, from
-// flashing an agentic label on a fixed-seq-only model) while the chart shows its
-// loading skeleton. It stays a guess: consumers that must not act on an
-// unresolved sequence gate on `sequenceResolved` instead.
+// before availability has loaded. It stays on the fixed-sequence app default
+// until availability confirms whether the selected model has AgentX data, so a
+// fixed-seq-only model never flashes an agentic label. Consumers that must not
+// act on an unresolved sequence gate on `sequenceResolved` instead.
 // (Declared after the import block so it never references `Sequence` above its import.)
 const APP_DEFAULT_SEQUENCE = Sequence.EightK_OneK;
 
@@ -176,14 +172,15 @@ export function GlobalFilterProvider({
     const urlSeq = getUrlParam('i_seq');
     if (urlSeq && Object.values(Sequence).includes(urlSeq as Sequence)) return urlSeq as Sequence;
     // Default to the 8K/1K fixed-seq scenario; the effectiveSequence resolution
-    // below handles per-model defaults (e.g. the AgentX models, which open on
-    // Agentic Workloads) and models that lack 8K/1K entirely.
+    // below prefers Agentic Workloads when availability confirms the model has
+    // corresponding data, and handles models that lack 8K/1K entirely.
     return Sequence.EightK_OneK;
   });
   // Whether the scenario was chosen explicitly (seeded `initialSequence` prop,
-  // URL `i_seq`, or a manual pick). Until then the per-model default applies —
+  // URL `i_seq`, or a manual pick). Until then the availability-driven AgentX
+  // default applies —
   // without this flag the initial `8k/1k` state is indistinguishable from a
-  // deliberate 8K/1K selection, and the model default could never win.
+  // deliberate 8K/1K selection, and Agentic Workloads could never win.
   //
   // Deliberately NOT seeded from `i_seq` here: this flag feeds the scenario
   // label rendered during the pre-availability window, and `getUrlParam` sees
@@ -352,37 +349,21 @@ export function GlobalFilterProvider({
   // — we surface that as `sequenceResolved` so InferenceContext can gate the
   // benchmark fetch until the real sequence is known (no agentic fetch fires for
   // a fixed-seq-only model). For the non-null public `effectiveSequence` value
-  // we substitute the scenario the model is expected to open on during that
-  // window, so the scenario selector doesn't flash a label it will immediately
-  // replace; the chart shows its normal loading skeleton until
+  // we retain the fixed-sequence placeholder until availability confirms the
+  // AgentX scenario exists; the chart shows its normal loading skeleton until
   // `sequenceResolved` flips true.
-  const modelDefaultSequence = useMemo(
-    () => getModelDefaultSequence(selectedModel),
-    [selectedModel],
-  );
   const resolvedSequence = useMemo(
     () =>
       resolveEffectiveSequence({
         selectedSequence,
         availableSequences,
         availabilityLoaded,
-        modelDefaultSequence,
         sequenceExplicit,
       }),
-    [
-      selectedSequence,
-      availableSequences,
-      availabilityLoaded,
-      modelDefaultSequence,
-      sequenceExplicit,
-    ],
+    [selectedSequence, availableSequences, availabilityLoaded, sequenceExplicit],
   );
   const sequenceResolved = resolvedSequence !== null;
-  const preAvailabilitySequence =
-    !sequenceExplicit && modelDefaultSequence !== null
-      ? modelDefaultSequence
-      : APP_DEFAULT_SEQUENCE;
-  const effectiveSequence = resolvedSequence ?? preAvailabilitySequence;
+  const effectiveSequence = resolvedSequence ?? APP_DEFAULT_SEQUENCE;
 
   // Precisions available for the selected model + sequence (DB ∪ unofficial run)
   const availablePrecisions = useMemo(() => {

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -184,11 +184,17 @@ export function GlobalFilterProvider({
   // URL `i_seq`, or a manual pick). Until then the per-model default applies —
   // without this flag the initial `8k/1k` state is indistinguishable from a
   // deliberate 8K/1K selection, and the model default could never win.
-  const [sequenceExplicit, setSequenceExplicit] = useState<boolean>(() => {
-    if (initialSequence) return true;
-    const urlSeq = getUrlParam('i_seq');
-    return Boolean(urlSeq && Object.values(Sequence).includes(urlSeq as Sequence));
-  });
+  //
+  // Deliberately NOT seeded from `i_seq` here: this flag feeds the scenario
+  // label rendered during the pre-availability window, and `getUrlParam` sees
+  // the query string on the client but not on the server. Reading it in the
+  // initializer would render a different label on each side and fail
+  // hydration. The layout effect below applies `i_seq` (flag included) after
+  // the first commit and before paint, which is how every other URL param
+  // lands.
+  const [sequenceExplicit, setSequenceExplicit] = useState<boolean>(
+    () => initialSequence !== undefined,
+  );
   const setSelectedSequence = useCallback((sequence: Sequence) => {
     setSelectedSequenceRaw(sequence);
     setSequenceExplicit(true);

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -172,15 +172,15 @@ export function GlobalFilterProvider({
     const urlSeq = getUrlParam('i_seq');
     if (urlSeq && Object.values(Sequence).includes(urlSeq as Sequence)) return urlSeq as Sequence;
     // Default to the 8K/1K fixed-seq scenario; the effectiveSequence resolution
-    // below prefers Agentic Workloads when availability confirms the model has
-    // corresponding data, and handles models that lack 8K/1K entirely.
+    // below prefers the Agentic scenario when availability confirms the model
+    // has corresponding data, and handles models that lack 8K/1K entirely.
     return Sequence.EightK_OneK;
   });
   // Whether the scenario was chosen explicitly (seeded `initialSequence` prop,
   // URL `i_seq`, or a manual pick). Until then the availability-driven AgentX
   // default applies —
   // without this flag the initial `8k/1k` state is indistinguishable from a
-  // deliberate 8K/1K selection, and Agentic Workloads could never win.
+  // deliberate 8K/1K selection, and the Agentic scenario could never win.
   //
   // Deliberately NOT seeded from `i_seq` here: this flag feeds the scenario
   // label rendered during the pre-availability window, and `getUrlParam` sees

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -26,6 +26,7 @@ import { useWorkflowInfo } from '@/hooks/api/use-workflow-info';
 import { useUrlState } from '@/hooks/useUrlState';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import {
+  getModelDefaultSequence,
   Model,
   MODEL_OPTIONS,
   Precision,
@@ -42,13 +43,15 @@ const RUNDATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const RUNID_RE = /^[A-Za-z0-9_-]{1,64}$/u;
 
 // Placeholder for the public (non-null) `effectiveSequence` during the window
-// before availability has loaded. It must be a fixed-seq scenario — never
-// AgenticTraces — so the scenario selector doesn't flash "Agentic Traces" for a
-// fixed-seq-only model while the chart shows its loading skeleton. `8k/1k` is
-// the app default scenario. Consumers that must not act on an unresolved
-// sequence gate on `sequenceResolved` instead.
+// before availability has loaded: the scenario the model is *expected* to open
+// on — its per-model default when the user hasn't chosen, otherwise `8k/1k`,
+// the app default scenario. Guessing the model's own default keeps the selector
+// from flashing "8K / 1K" on an agentic-default model (and, as before, from
+// flashing an agentic label on a fixed-seq-only model) while the chart shows its
+// loading skeleton. It stays a guess: consumers that must not act on an
+// unresolved sequence gate on `sequenceResolved` instead.
 // (Declared after the import block so it never references `Sequence` above its import.)
-const PRE_AVAILABILITY_SEQUENCE = Sequence.EightK_OneK;
+const APP_DEFAULT_SEQUENCE = Sequence.EightK_OneK;
 
 interface RunInfo {
   runId: string;
@@ -168,14 +171,28 @@ export function GlobalFilterProvider({
     () => initialModel ?? Model.DeepSeek_V4_Pro,
   );
 
-  const [selectedSequence, setSelectedSequence] = useState<Sequence>(() => {
+  const [selectedSequence, setSelectedSequenceRaw] = useState<Sequence>(() => {
     if (initialSequence) return initialSequence;
     const urlSeq = getUrlParam('i_seq');
     if (urlSeq && Object.values(Sequence).includes(urlSeq as Sequence)) return urlSeq as Sequence;
-    // Default to the 8K/1K fixed-seq scenario; the effectiveSequence fallback
-    // below handles models that lack it (e.g. agentic-only models).
+    // Default to the 8K/1K fixed-seq scenario; the effectiveSequence resolution
+    // below handles per-model defaults (e.g. the AgentX models, which open on
+    // Agentic Workloads) and models that lack 8K/1K entirely.
     return Sequence.EightK_OneK;
   });
+  // Whether the scenario was chosen explicitly (seeded `initialSequence` prop,
+  // URL `i_seq`, or a manual pick). Until then the per-model default applies —
+  // without this flag the initial `8k/1k` state is indistinguishable from a
+  // deliberate 8K/1K selection, and the model default could never win.
+  const [sequenceExplicit, setSequenceExplicit] = useState<boolean>(() => {
+    if (initialSequence) return true;
+    const urlSeq = getUrlParam('i_seq');
+    return Boolean(urlSeq && Object.values(Sequence).includes(urlSeq as Sequence));
+  });
+  const setSelectedSequence = useCallback((sequence: Sequence) => {
+    setSelectedSequenceRaw(sequence);
+    setSequenceExplicit(true);
+  }, []);
 
   const initialValidPrecisions = useMemo(
     () =>
@@ -329,20 +346,37 @@ export function GlobalFilterProvider({
   // — we surface that as `sequenceResolved` so InferenceContext can gate the
   // benchmark fetch until the real sequence is known (no agentic fetch fires for
   // a fixed-seq-only model). For the non-null public `effectiveSequence` value
-  // we substitute a fixed-seq scenario (never AgenticTraces) during that window
-  // so the scenario selector never flashes "Agentic Traces"; the chart shows its
-  // normal loading skeleton until `sequenceResolved` flips true.
+  // we substitute the scenario the model is expected to open on during that
+  // window, so the scenario selector doesn't flash a label it will immediately
+  // replace; the chart shows its normal loading skeleton until
+  // `sequenceResolved` flips true.
+  const modelDefaultSequence = useMemo(
+    () => getModelDefaultSequence(selectedModel),
+    [selectedModel],
+  );
   const resolvedSequence = useMemo(
     () =>
       resolveEffectiveSequence({
         selectedSequence,
         availableSequences,
         availabilityLoaded,
+        modelDefaultSequence,
+        sequenceExplicit,
       }),
-    [selectedSequence, availableSequences, availabilityLoaded],
+    [
+      selectedSequence,
+      availableSequences,
+      availabilityLoaded,
+      modelDefaultSequence,
+      sequenceExplicit,
+    ],
   );
   const sequenceResolved = resolvedSequence !== null;
-  const effectiveSequence = resolvedSequence ?? PRE_AVAILABILITY_SEQUENCE;
+  const preAvailabilitySequence =
+    !sequenceExplicit && modelDefaultSequence !== null
+      ? modelDefaultSequence
+      : APP_DEFAULT_SEQUENCE;
+  const effectiveSequence = resolvedSequence ?? preAvailabilitySequence;
 
   // Precisions available for the selected model + sequence (DB ∪ unofficial run)
   const availablePrecisions = useMemo(() => {

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -126,7 +126,7 @@ const STRINGS = {
       'The interactivity operating point used for interpolation. Adjust the slider to compare chip throughput, cost, and power efficiency at different interactivity levels.',
     targetAgenticLabel: (percentile: string) => `Target ${percentile} Interactivity (tok/s/user)`,
     targetAgenticTooltip: (percentile: string) =>
-      `The ${percentile} interactivity operating point used for agentic trace interpolation. Adjust the slider to compare chip throughput, cost, and power efficiency.`,
+      `The ${percentile} interactivity operating point used for agentic workload interpolation. Adjust the slider to compare chip throughput, cost, and power efficiency.`,
     metricThroughput: 'Throughput',
     metricCost: 'Cost',
     viewChart: 'Chart',
@@ -178,7 +178,7 @@ const STRINGS = {
       '用于插值的交互性操作点。调整滑块以比较不同交互性级别下 Chip 的吞吐量、成本和能效。',
     targetAgenticLabel: (percentile: string) => `目标 ${percentile} 交互性 (tok/s/user)`,
     targetAgenticTooltip: (percentile: string) =>
-      `用于智能体轨迹插值的 ${percentile} 交互性操作点。调整滑块以比较 Chip 的吞吐量、成本和能效。`,
+      `用于智能体工作负载插值的 ${percentile} 交互性操作点。调整滑块以比较 Chip 的吞吐量、成本和能效。`,
     metricThroughput: '吞吐量',
     metricCost: '成本',
     viewChart: '图表',

--- a/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
+++ b/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
@@ -24,7 +24,7 @@ export interface LegendPointsDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Series label, e.g. "B300 (vLLM)". */
   title: string;
-  /** Context line, e.g. "DeepSeek V4 Pro · Agentic Traces". */
+  /** Context line, e.g. "DeepSeek V4 Pro · Agentic Workloads". */
   subtitle: string;
   /** Legend swatch color for this series (overlayRunColor for overlay runs). */
   accentColor: string;

--- a/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
+++ b/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
@@ -24,7 +24,7 @@ export interface LegendPointsDialogProps {
   onOpenChange: (open: boolean) => void;
   /** Series label, e.g. "B300 (vLLM)". */
   title: string;
-  /** Context line, e.g. "DeepSeek V4 Pro · Agentic Workloads". */
+  /** Context line, e.g. "DeepSeek V4 Pro · Agentic". */
   subtitle: string;
   /** Legend swatch color for this series (overlayRunColor for overlay runs). */
   accentColor: string;

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -41,7 +41,7 @@ const STRINGS = {
       'Input Sequence Length / Output Sequence Length. Defines the number of input and output tokens for the benchmark (e.g., 1K/8K means 1,024 input tokens and 8,192 output tokens).',
     scenario: 'Scenario',
     scenarioTooltip:
-      'Benchmark scenario. Fixed Sequence Length runs use a defined input/output token count (ISL/OSL). Agentic Workloads replay real agentic workloads with variable inputs/outputs.',
+      'Benchmark scenario. Fixed Sequence Length runs use a defined input/output token count (ISL/OSL). The Agentic scenario replays real agentic workloads with variable inputs/outputs.',
     agenticScenarioTooltip: 'Realistic Long Context Multi Turn Agentic Workload with Sub Agents.',
     agenticScenarioLearnMore: 'Learn More Here',
     latencyPercentile: 'Latency Percentile',
@@ -50,7 +50,6 @@ const STRINGS = {
     precision: 'Precision',
     precisionTooltip:
       "Numerical precision used for model weights. Lower precision like 'FP4' uses less memory and increases throughput but may slightly reduce accuracy compared to higher precisions like 'FP8'.",
-    agenticGroup: 'Agentic',
     fixedSequenceLength: 'Fixed Sequence Length',
     deprecated: 'Deprecated',
     deprecatedSequenceReason:
@@ -64,7 +63,7 @@ const STRINGS = {
       '输入序列长度 / 输出序列长度（Input Sequence Length / Output Sequence Length）。定义基准测试的输入和输出 token 数量（如 1K/8K 表示 1,024 个输入 token 和 8,192 个输出 token）。',
     scenario: '场景',
     scenarioTooltip:
-      '基准测试场景。Fixed Sequence Length 使用预设的输入/输出 token 数（ISL/OSL）。Agentic Workloads 回放具有可变输入/输出的真实智能体工作负载。',
+      '基准测试场景。Fixed Sequence Length 使用预设的输入/输出 token 数（ISL/OSL）。Agentic 场景回放具有可变输入/输出的真实智能体工作负载。',
     agenticScenarioTooltip: '真实的长上下文、多轮、带子智能体（sub-agent）的智能体工作负载。',
     agenticScenarioLearnMore: '点此了解更多',
     latencyPercentile: '延迟分位数',
@@ -72,7 +71,6 @@ const STRINGS = {
     precision: '精度',
     precisionTooltip:
       '模型权重的数值精度。FP4 等低精度占用更少显存并提高吞吐量，但与 FP8 等高精度相比可能略微降低准确度。',
-    agenticGroup: '智能体',
     fixedSequenceLength: '固定序列长度',
     deprecated: '已弃用',
     deprecatedSequenceReason: 'CI 容量已重新分配给智能体编程和多轮对话场景。',
@@ -373,11 +371,14 @@ export function ScenarioSelector({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {/* Agentic group listed first when available (display order only —
-                availability decides which scenario opens by default). */}
+            {/* Agentic entries listed first when available (display order only
+                — availability decides which scenario opens by default). They
+                carry no group header: they are named "Agentic" themselves, so a
+                heading above them would just repeat the word. They stay in their
+                own SelectGroup so the "Fixed Sequence Length" heading below
+                still reads as a separate section. */}
             {agentic.length > 0 && (
               <SelectGroup>
-                <SelectLabel>{t.agenticGroup}</SelectLabel>
                 {agentic.map((seq) => (
                   <SelectItem key={seq} value={seq}>
                     {getSequenceLabel(seq as Sequence, locale)}

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -374,7 +374,7 @@ export function ScenarioSelector({
           </SelectTrigger>
           <SelectContent>
             {/* Agentic group listed first when available (display order only —
-                the per-model default decides which scenario opens). */}
+                availability decides which scenario opens by default). */}
             {agentic.length > 0 && (
               <SelectGroup>
                 <SelectLabel>{t.agenticGroup}</SelectLabel>

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -41,7 +41,9 @@ const STRINGS = {
       'Input Sequence Length / Output Sequence Length. Defines the number of input and output tokens for the benchmark (e.g., 1K/8K means 1,024 input tokens and 8,192 output tokens).',
     scenario: 'Scenario',
     scenarioTooltip:
-      'Benchmark scenario. Fixed Sequence Length runs use a defined input/output token count (ISL/OSL). Agentic Traces replay real agentic workloads with variable inputs/outputs.',
+      'Benchmark scenario. Fixed Sequence Length runs use a defined input/output token count (ISL/OSL). Agentic Workloads replay real agentic workloads with variable inputs/outputs.',
+    agenticScenarioTooltip: 'Realistic Long Context Multi Turn Agentic Workload with Sub Agents.',
+    agenticScenarioLearnMore: 'Learn More Here',
     latencyPercentile: 'Latency Percentile',
     latencyPercentileTooltip:
       'Percentile of the latency distribution used for the chart x-axis on agentic runs.',
@@ -62,7 +64,9 @@ const STRINGS = {
       '输入序列长度 / 输出序列长度（Input Sequence Length / Output Sequence Length）。定义基准测试的输入和输出 token 数量（如 1K/8K 表示 1,024 个输入 token 和 8,192 个输出 token）。',
     scenario: '场景',
     scenarioTooltip:
-      '基准测试场景。Fixed Sequence Length 使用预设的输入/输出 token 数（ISL/OSL）。Agentic Traces 回放具有可变输入/输出的真实智能体工作负载。',
+      '基准测试场景。Fixed Sequence Length 使用预设的输入/输出 token 数（ISL/OSL）。Agentic Workloads 回放具有可变输入/输出的真实智能体工作负载。',
+    agenticScenarioTooltip: '真实的长上下文、多轮、带子智能体（sub-agent）的智能体工作负载。',
+    agenticScenarioLearnMore: '点此了解更多',
     latencyPercentile: '延迟分位数',
     latencyPercentileTooltip: '用于智能体运行图表 X 轴的延迟分布分位数。',
     precision: '精度',
@@ -91,6 +95,47 @@ function CategorySectionTitle({ label, reason }: { label: string; reason: string
         </TooltipContent>
       </TooltipRoot>
     </span>
+  );
+}
+
+/**
+ * Info affordance shown next to the scenario selector while an agentic scenario
+ * is selected. The agentic workload isn't self-describing from its name alone,
+ * and it's now the opening scenario for the AgentX models — so the explainer
+ * sits beside the closed trigger rather than inside the dropdown, where the
+ * "learn more" link would be swallowed by the select's outside-click handling.
+ */
+function AgenticScenarioInfo({
+  tooltip,
+  learnMore,
+  href,
+}: {
+  tooltip: string;
+  learnMore: string;
+  href: string;
+}) {
+  return (
+    <TooltipRoot>
+      <TooltipTrigger asChild>
+        <Info
+          className="size-3.5 shrink-0 text-muted-foreground cursor-help"
+          data-testid="scenario-agentic-info"
+        />
+      </TooltipTrigger>
+      <TooltipContent side="top" collisionPadding={10} className="z-[130]">
+        <span>
+          {tooltip}{' '}
+          <a
+            href={href}
+            className="underline underline-offset-2"
+            data-testid="scenario-agentic-info-link"
+            onClick={() => track('selector_scenario_datasets_link')}
+          >
+            {learnMore}
+          </a>
+        </span>
+      </TooltipContent>
+    </TooltipRoot>
   );
 }
 
@@ -309,62 +354,72 @@ export function ScenarioSelector({
   const fixedSeq = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'fixed-seq');
   const agentic = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'agentic');
   const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
+  const isAgenticSelected = sequenceKind(value as Sequence) === 'agentic';
 
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-1">
       <LabelWithTooltip htmlFor={id} label={t.scenario} tooltip={t.scenarioTooltip} />
-      <Select
-        value={value}
-        onValueChange={(v) => {
-          track('selector_scenario_changed', { scenario: v });
-          onChange(v as Sequence);
-        }}
-        open={open}
-        onOpenChange={onOpenChange}
-      >
-        <SelectTrigger id={id} data-testid={testId} className="w-full">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {/* Agentic group listed first when available (display order only —
-              the app default scenario is 8K/1K). */}
-          {agentic.length > 0 && (
-            <SelectGroup>
-              <SelectLabel>{t.agenticGroup}</SelectLabel>
-              {agentic.map((seq) => (
-                <SelectItem key={seq} value={seq}>
-                  {getSequenceLabel(seq as Sequence, locale)}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          )}
-          {fixedSeq.length > 0 && (
-            <SelectGroup>
-              <SelectLabel>{t.fixedSequenceLength}</SelectLabel>
-              {fixedGroups.default.map((seq) => (
-                <SelectItem key={seq} value={seq}>
-                  {getSequenceLabel(seq as Sequence, locale)}
-                </SelectItem>
-              ))}
-              {fixedGroups.deprecated.length > 0 && (
-                <>
-                  <SelectLabel>
-                    <CategorySectionTitle
-                      label={t.deprecated}
-                      reason={t.deprecatedSequenceReason}
-                    />
-                  </SelectLabel>
-                  {fixedGroups.deprecated.map((seq) => (
-                    <SelectItem key={seq} value={seq}>
-                      {getSequenceLabel(seq as Sequence, locale)}
-                    </SelectItem>
-                  ))}
-                </>
-              )}
-            </SelectGroup>
-          )}
-        </SelectContent>
-      </Select>
+      <div className="flex items-center gap-1.5">
+        <Select
+          value={value}
+          onValueChange={(v) => {
+            track('selector_scenario_changed', { scenario: v });
+            onChange(v as Sequence);
+          }}
+          open={open}
+          onOpenChange={onOpenChange}
+        >
+          <SelectTrigger id={id} data-testid={testId} className="w-full min-w-0">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {/* Agentic group listed first when available (display order only —
+                the per-model default decides which scenario opens). */}
+            {agentic.length > 0 && (
+              <SelectGroup>
+                <SelectLabel>{t.agenticGroup}</SelectLabel>
+                {agentic.map((seq) => (
+                  <SelectItem key={seq} value={seq}>
+                    {getSequenceLabel(seq as Sequence, locale)}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            )}
+            {fixedSeq.length > 0 && (
+              <SelectGroup>
+                <SelectLabel>{t.fixedSequenceLength}</SelectLabel>
+                {fixedGroups.default.map((seq) => (
+                  <SelectItem key={seq} value={seq}>
+                    {getSequenceLabel(seq as Sequence, locale)}
+                  </SelectItem>
+                ))}
+                {fixedGroups.deprecated.length > 0 && (
+                  <>
+                    <SelectLabel>
+                      <CategorySectionTitle
+                        label={t.deprecated}
+                        reason={t.deprecatedSequenceReason}
+                      />
+                    </SelectLabel>
+                    {fixedGroups.deprecated.map((seq) => (
+                      <SelectItem key={seq} value={seq}>
+                        {getSequenceLabel(seq as Sequence, locale)}
+                      </SelectItem>
+                    ))}
+                  </>
+                )}
+              </SelectGroup>
+            )}
+          </SelectContent>
+        </Select>
+        {isAgenticSelected && (
+          <AgenticScenarioInfo
+            tooltip={t.agenticScenarioTooltip}
+            learnMore={t.agenticScenarioLearnMore}
+            href={locale === 'zh' ? '/zh/datasets' : '/datasets'}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest';
 import {
   getModelAndSequence,
   getModelAndSequenceFromArtifact,
-  getModelDefaultSequence,
   getModelLabel,
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
@@ -285,29 +284,6 @@ describe('getModelLabel', () => {
   it('falls back to the model value for unknown model', () => {
     const result = getModelLabel('NewModel-XYZ' as Model);
     expect(result).toBe('NewModel-XYZ');
-  });
-});
-
-// ===========================================================================
-// getModelDefaultSequence
-// ===========================================================================
-describe('getModelDefaultSequence', () => {
-  it('opens the actively benchmarked AgentX models on Agentic Workloads', () => {
-    for (const model of [Model.DeepSeek_V4_Pro, Model.MiniMax_M3, Model.GLM_5_2, Model.Qwen3_5]) {
-      expect(getModelDefaultSequence(model)).toBe(Sequence.AgenticTraces);
-    }
-  });
-
-  it('returns null for models that keep the app-wide 8K/1K default', () => {
-    expect(getModelDefaultSequence(Model.Llama3_3_70B)).toBeNull();
-    expect(getModelDefaultSequence(Model.DeepSeek_R1)).toBeNull();
-    expect(getModelDefaultSequence(Model.Kimi_K3)).toBeNull();
-  });
-
-  it('returns null for unknown or missing models', () => {
-    expect(getModelDefaultSequence('NewModel-XYZ' as Model)).toBeNull();
-    expect(getModelDefaultSequence(null)).toBeNull();
-    expect(getModelDefaultSequence(undefined)).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   getModelAndSequence,
   getModelAndSequenceFromArtifact,
+  getModelDefaultSequence,
   getModelLabel,
   getModelExclusion,
   getSequenceDefaultExclusionGroup,
@@ -288,6 +289,29 @@ describe('getModelLabel', () => {
 });
 
 // ===========================================================================
+// getModelDefaultSequence
+// ===========================================================================
+describe('getModelDefaultSequence', () => {
+  it('opens the actively benchmarked AgentX models on Agentic Workloads', () => {
+    for (const model of [Model.DeepSeek_V4_Pro, Model.MiniMax_M3, Model.GLM_5_2, Model.Qwen3_5]) {
+      expect(getModelDefaultSequence(model)).toBe(Sequence.AgenticTraces);
+    }
+  });
+
+  it('returns null for models that keep the app-wide 8K/1K default', () => {
+    expect(getModelDefaultSequence(Model.Llama3_3_70B)).toBeNull();
+    expect(getModelDefaultSequence(Model.DeepSeek_R1)).toBeNull();
+    expect(getModelDefaultSequence(Model.Kimi_K3)).toBeNull();
+  });
+
+  it('returns null for unknown or missing models', () => {
+    expect(getModelDefaultSequence('NewModel-XYZ' as Model)).toBeNull();
+    expect(getModelDefaultSequence(null)).toBeNull();
+    expect(getModelDefaultSequence(undefined)).toBeNull();
+  });
+});
+
+// ===========================================================================
 // getSequenceLabel
 // ===========================================================================
 describe('getSequenceLabel', () => {
@@ -295,11 +319,11 @@ describe('getSequenceLabel', () => {
     expect(getSequenceLabel(Sequence.OneK_OneK)).toBe('1K / 1K');
     expect(getSequenceLabel(Sequence.OneK_EightK)).toBe('1K / 8K');
     expect(getSequenceLabel(Sequence.EightK_OneK)).toBe('8K / 1K');
-    expect(getSequenceLabel(Sequence.AgenticTraces)).toBe('Agentic Traces');
+    expect(getSequenceLabel(Sequence.AgenticTraces)).toBe('Agentic Workloads');
   });
 
   it('returns the Chinese agentic scenario label for the zh locale', () => {
-    expect(getSequenceLabel(Sequence.AgenticTraces, 'zh')).toBe('智能体轨迹');
+    expect(getSequenceLabel(Sequence.AgenticTraces, 'zh')).toBe('智能体工作负载');
   });
 
   it('falls back to the sequence value for unknown sequence', () => {

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -295,11 +295,11 @@ describe('getSequenceLabel', () => {
     expect(getSequenceLabel(Sequence.OneK_OneK)).toBe('1K / 1K');
     expect(getSequenceLabel(Sequence.OneK_EightK)).toBe('1K / 8K');
     expect(getSequenceLabel(Sequence.EightK_OneK)).toBe('8K / 1K');
-    expect(getSequenceLabel(Sequence.AgenticTraces)).toBe('Agentic Workloads');
+    expect(getSequenceLabel(Sequence.AgenticTraces)).toBe('Agentic');
   });
 
   it('returns the Chinese agentic scenario label for the zh locale', () => {
-    expect(getSequenceLabel(Sequence.AgenticTraces, 'zh')).toBe('智能体工作负载');
+    expect(getSequenceLabel(Sequence.AgenticTraces, 'zh')).toBe('智能体');
   });
 
   it('falls back to the sequence value for unknown sequence', () => {

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -370,36 +370,6 @@ export function getSequenceExclusionFamilies(
 export const SEQUENCE_OPTIONS = Object.keys(SEQUENCE_CONFIG) as Sequence[];
 
 /**
- * Scenario a model opens on when the user hasn't picked one.
- *
- * The app-wide default is 8K/1K (see `resolveEffectiveSequence`), but for the
- * models we actively benchmark on AgentX the agentic workload — long-context,
- * multi-turn, sub-agent traces — is the representative view, so those models
- * open on it instead. Models absent from this map keep the 8K/1K default.
- *
- * This is a *default*, not a pin: an explicit selection (a `?i_seq=` link, a
- * route-seeded `initialSequence`, or a manual pick in the selector) always
- * wins, and the entry is ignored when the model has no agentic rows for the
- * selected run date.
- *
- * Declared here rather than in `MODEL_CONFIG` because `Sequence` is defined
- * below that object — referencing it there would read the enum before it is
- * initialized.
- */
-const MODEL_DEFAULT_SEQUENCE: Partial<Record<Model, Sequence>> = {
-  [Model.DeepSeek_V4_Pro]: Sequence.AgenticTraces,
-  [Model.MiniMax_M3]: Sequence.AgenticTraces,
-  [Model.GLM_5_2]: Sequence.AgenticTraces,
-  [Model.Qwen3_5]: Sequence.AgenticTraces,
-};
-
-/** Preferred opening scenario for a model, or null when it uses the app default. */
-export function getModelDefaultSequence(model: Model | string | null | undefined): Sequence | null {
-  if (!model) return null;
-  return MODEL_DEFAULT_SEQUENCE[model as Model] ?? null;
-}
-
-/**
  * Percentile of the latency distribution used for the chart x-axis when
  * viewing agentic traces. Agentic rows carry median/p75/p90/p95/p99/p99.9
  * variants for ttft, ttlt (=e2el), and itl (and intvty derived from itl);

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -320,8 +320,8 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     exclusionFamilies: GUARDED_ENGINE_FAMILIES,
   },
   [Sequence.AgenticTraces]: {
-    label: 'Agentic Traces',
-    labelZh: '智能体轨迹',
+    label: 'Agentic Workloads',
+    labelZh: '智能体工作负载',
     compact: 'agentic',
     category: 'default',
     kind: 'agentic',
@@ -368,6 +368,36 @@ export function getSequenceExclusionFamilies(
 }
 
 export const SEQUENCE_OPTIONS = Object.keys(SEQUENCE_CONFIG) as Sequence[];
+
+/**
+ * Scenario a model opens on when the user hasn't picked one.
+ *
+ * The app-wide default is 8K/1K (see `resolveEffectiveSequence`), but for the
+ * models we actively benchmark on AgentX the agentic workload — long-context,
+ * multi-turn, sub-agent traces — is the representative view, so those models
+ * open on it instead. Models absent from this map keep the 8K/1K default.
+ *
+ * This is a *default*, not a pin: an explicit selection (a `?i_seq=` link, a
+ * route-seeded `initialSequence`, or a manual pick in the selector) always
+ * wins, and the entry is ignored when the model has no agentic rows for the
+ * selected run date.
+ *
+ * Declared here rather than in `MODEL_CONFIG` because `Sequence` is defined
+ * below that object — referencing it there would read the enum before it is
+ * initialized.
+ */
+const MODEL_DEFAULT_SEQUENCE: Partial<Record<Model, Sequence>> = {
+  [Model.DeepSeek_V4_Pro]: Sequence.AgenticTraces,
+  [Model.MiniMax_M3]: Sequence.AgenticTraces,
+  [Model.GLM_5_2]: Sequence.AgenticTraces,
+  [Model.Qwen3_5]: Sequence.AgenticTraces,
+};
+
+/** Preferred opening scenario for a model, or null when it uses the app default. */
+export function getModelDefaultSequence(model: Model | string | null | undefined): Sequence | null {
+  if (!model) return null;
+  return MODEL_DEFAULT_SEQUENCE[model as Model] ?? null;
+}
 
 /**
  * Percentile of the latency distribution used for the chart x-axis when

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -320,8 +320,8 @@ const SEQUENCE_CONFIG: Record<Sequence, SequenceConfig> = {
     exclusionFamilies: GUARDED_ENGINE_FAMILIES,
   },
   [Sequence.AgenticTraces]: {
-    label: 'Agentic Workloads',
-    labelZh: '智能体工作负载',
+    label: 'Agentic',
+    labelZh: '智能体',
     compact: 'agentic',
     category: 'default',
     kind: 'agentic',

--- a/packages/app/src/lib/default-sequence.test.ts
+++ b/packages/app/src/lib/default-sequence.test.ts
@@ -35,7 +35,7 @@ describe('resolveEffectiveSequence', () => {
   });
 
   describe('availability-driven AgentX default (rule 2)', () => {
-    it('opens Agentic Workloads whenever the model has data and the user has not chosen', () => {
+    it('opens the Agentic scenario whenever the model has data and the user has not chosen', () => {
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,
@@ -58,7 +58,7 @@ describe('resolveEffectiveSequence', () => {
       ).toBe(Sequence.EightK_OneK);
     });
 
-    it('keeps the app default when the model has no Agentic Workloads data', () => {
+    it('keeps the app default when the model has no Agentic data', () => {
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,

--- a/packages/app/src/lib/default-sequence.test.ts
+++ b/packages/app/src/lib/default-sequence.test.ts
@@ -34,71 +34,52 @@ describe('resolveEffectiveSequence', () => {
     });
   });
 
-  describe('per-model default (rule 2)', () => {
-    it('opens on the model default when the user has not chosen a scenario', () => {
-      // DeepSeek-V4-Pro declares Agentic Workloads as its opening scenario, so
-      // the untouched `8k/1k` initial state must not win.
+  describe('availability-driven AgentX default (rule 2)', () => {
+    it('opens Agentic Workloads whenever the model has data and the user has not chosen', () => {
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,
           availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
           availabilityLoaded: true,
-          modelDefaultSequence: Sequence.AgenticTraces,
           sequenceExplicit: false,
         }),
       ).toBe(Sequence.AgenticTraces);
     });
 
     it('yields to an explicit selection', () => {
-      // A shared `?i_seq=8k-1k` link (or a manual pick) on an agentic-default
-      // model must stay on 8K/1K.
+      // A shared `?i_seq=8k-1k` link (or a manual pick) must stay on 8K/1K.
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,
           availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
           availabilityLoaded: true,
-          modelDefaultSequence: Sequence.AgenticTraces,
           sequenceExplicit: true,
         }),
       ).toBe(Sequence.EightK_OneK);
     });
 
-    it('ignores the model default when that scenario has no data for the run', () => {
+    it('keeps the app default when the model has no Agentic Workloads data', () => {
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,
           availableSequences: [Sequence.EightK_OneK],
           availabilityLoaded: true,
-          modelDefaultSequence: Sequence.AgenticTraces,
           sequenceExplicit: false,
         }),
       ).toBe(Sequence.EightK_OneK);
     });
 
     it('does not apply before availability has loaded', () => {
-      // The static fallback list contains every scenario, so applying the model
-      // default here would fetch agentic rows the model may not have.
+      // The static fallback list contains every scenario, so applying the
+      // AgentX preference here would fetch rows the model may not have.
       expect(
         resolveEffectiveSequence({
           selectedSequence: Sequence.EightK_OneK,
           availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
           availabilityLoaded: false,
-          modelDefaultSequence: Sequence.AgenticTraces,
           sequenceExplicit: false,
         }),
       ).toBeNull();
-    });
-
-    it('leaves models without a declared default on the app default', () => {
-      expect(
-        resolveEffectiveSequence({
-          selectedSequence: Sequence.EightK_OneK,
-          availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
-          availabilityLoaded: true,
-          modelDefaultSequence: null,
-          sequenceExplicit: false,
-        }),
-      ).toBe(Sequence.EightK_OneK);
     });
   });
 

--- a/packages/app/src/lib/default-sequence.test.ts
+++ b/packages/app/src/lib/default-sequence.test.ts
@@ -34,7 +34,75 @@ describe('resolveEffectiveSequence', () => {
     });
   });
 
-  describe('honors a valid selection (rule 2a)', () => {
+  describe('per-model default (rule 2)', () => {
+    it('opens on the model default when the user has not chosen a scenario', () => {
+      // DeepSeek-V4-Pro declares Agentic Workloads as its opening scenario, so
+      // the untouched `8k/1k` initial state must not win.
+      expect(
+        resolveEffectiveSequence({
+          selectedSequence: Sequence.EightK_OneK,
+          availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
+          availabilityLoaded: true,
+          modelDefaultSequence: Sequence.AgenticTraces,
+          sequenceExplicit: false,
+        }),
+      ).toBe(Sequence.AgenticTraces);
+    });
+
+    it('yields to an explicit selection', () => {
+      // A shared `?i_seq=8k-1k` link (or a manual pick) on an agentic-default
+      // model must stay on 8K/1K.
+      expect(
+        resolveEffectiveSequence({
+          selectedSequence: Sequence.EightK_OneK,
+          availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
+          availabilityLoaded: true,
+          modelDefaultSequence: Sequence.AgenticTraces,
+          sequenceExplicit: true,
+        }),
+      ).toBe(Sequence.EightK_OneK);
+    });
+
+    it('ignores the model default when that scenario has no data for the run', () => {
+      expect(
+        resolveEffectiveSequence({
+          selectedSequence: Sequence.EightK_OneK,
+          availableSequences: [Sequence.EightK_OneK],
+          availabilityLoaded: true,
+          modelDefaultSequence: Sequence.AgenticTraces,
+          sequenceExplicit: false,
+        }),
+      ).toBe(Sequence.EightK_OneK);
+    });
+
+    it('does not apply before availability has loaded', () => {
+      // The static fallback list contains every scenario, so applying the model
+      // default here would fetch agentic rows the model may not have.
+      expect(
+        resolveEffectiveSequence({
+          selectedSequence: Sequence.EightK_OneK,
+          availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
+          availabilityLoaded: false,
+          modelDefaultSequence: Sequence.AgenticTraces,
+          sequenceExplicit: false,
+        }),
+      ).toBeNull();
+    });
+
+    it('leaves models without a declared default on the app default', () => {
+      expect(
+        resolveEffectiveSequence({
+          selectedSequence: Sequence.EightK_OneK,
+          availableSequences: [Sequence.EightK_OneK, Sequence.AgenticTraces],
+          availabilityLoaded: true,
+          modelDefaultSequence: null,
+          sequenceExplicit: false,
+        }),
+      ).toBe(Sequence.EightK_OneK);
+    });
+  });
+
+  describe('honors a valid selection (rule 3a)', () => {
     it('keeps AgenticTraces when the model actually has agentic data (dsr1 case)', () => {
       // DeepSeek-R1 in the seeded DB has both agentic and 8k/1k — an explicit
       // agentic selection (e.g. a shared ?i_seq= link) must survive.
@@ -58,7 +126,7 @@ describe('resolveEffectiveSequence', () => {
     });
   });
 
-  describe('fallback ordering when the selection is unavailable (rule 2b/2c)', () => {
+  describe('fallback ordering when the selection is unavailable (rule 3b/3c)', () => {
     it('for a fixed-seq-only model, an agentic selection falls back to 8k/1k, not the raw first entry (llama70b case)', () => {
       // Llama-3.3-70B has only 8k/1k in the seeded DB. An agentic selection is
       // unavailable, so it must resolve to a fixed-seq scenario — here the sole

--- a/packages/app/src/lib/default-sequence.ts
+++ b/packages/app/src/lib/default-sequence.ts
@@ -4,12 +4,12 @@ import { Sequence } from './data-mappings';
  * Effective-sequence resolution.
  *
  * `selectedSequence` defaults to {@link Sequence.EightK_OneK}, but the user may
- * have selected a scenario the model doesn't offer (e.g. Agentic Traces via a
+ * have selected a scenario the model doesn't offer (e.g. Agentic Workloads via a
  * shared `?i_seq=` link on a fixed-seq-only model). This helper turns the raw
  * user/default selection into the sequence the chart should actually render,
  * given what the selected model offers.
  *
- * Two rules, in order:
+ * Three rules, in order:
  *
  * 1. **Availability gate.** Until availability rows have loaded we do NOT know
  *    which sequences the model has. Resolving eagerly here would pick the static
@@ -21,33 +21,58 @@ import { Sequence } from './data-mappings';
  *    on a non-null result (a loading skeleton covers this window, which is
  *    short).
  *
- * 2. **Fallback ordering.** Once availability is known: keep the user's
- *    `selectedSequence` if the model has it. Otherwise fall back to a sensible
- *    fixed-seq scenario. `availableSequences[0]` follows DB row order, which can
- *    surface `1k/1k` even when `8k/1k` exists — but `8k/1k` is the app default
- *    scenario, so prefer it when present. Only if neither the selection nor
- *    `8k/1k` is available do we fall to `availableSequences[0]`.
+ * 2. **Per-model default.** `selectedSequence` starts at the app-wide default
+ *    (`8k/1k`) until the user actually picks something, so it can't distinguish
+ *    "the user wants 8K/1K" from "nobody has chosen yet". `sequenceExplicit`
+ *    makes that distinction: while it is false, a model that declares a
+ *    `modelDefaultSequence` (see `getModelDefaultSequence`) opens on that
+ *    scenario if it has data for it — that's how the AgentX models open on
+ *    Agentic Workloads instead of 8K/1K. Any explicit selection turns the flag
+ *    on and this rule stops applying.
+ *
+ * 3. **Fallback ordering.** Otherwise: keep the user's `selectedSequence` if the
+ *    model has it. Otherwise fall back to a sensible fixed-seq scenario.
+ *    `availableSequences[0]` follows DB row order, which can surface `1k/1k`
+ *    even when `8k/1k` exists — but `8k/1k` is the app default scenario, so
+ *    prefer it when present. Only if neither the selection nor `8k/1k` is
+ *    available do we fall to `availableSequences[0]`.
  */
 export function resolveEffectiveSequence({
   selectedSequence,
   availableSequences,
   availabilityLoaded,
+  modelDefaultSequence = null,
+  sequenceExplicit = false,
 }: {
   selectedSequence: Sequence;
   availableSequences: Sequence[];
   availabilityLoaded: boolean;
+  /** The selected model's preferred opening scenario, or null for the app default. */
+  modelDefaultSequence?: Sequence | null;
+  /** Whether `selectedSequence` came from a real user/route choice. */
+  sequenceExplicit?: boolean;
 }): Sequence | null {
   // Rule 1: do not commit to a sequence before we know what the model has.
   if (!availabilityLoaded) return null;
 
-  // Rule 2a: honor the user's / default selection when the model supports it.
+  // Rule 2: nobody has chosen yet — open on the model's preferred scenario when
+  // the model actually has data for it.
+  if (
+    !sequenceExplicit &&
+    modelDefaultSequence !== null &&
+    availableSequences.includes(modelDefaultSequence)
+  ) {
+    return modelDefaultSequence;
+  }
+
+  // Rule 3a: honor the user's / default selection when the model supports it.
   if (availableSequences.includes(selectedSequence)) return selectedSequence;
 
-  // Rule 2b: prefer 8k/1k (the app default scenario) over whatever
+  // Rule 3b: prefer 8k/1k (the app default scenario) over whatever
   // availableSequences[0] happens to be (DB row order can yield 1k/1k).
   if (availableSequences.includes(Sequence.EightK_OneK)) return Sequence.EightK_OneK;
 
-  // Rule 2c: last resort — first available, or the selection itself if the model
+  // Rule 3c: last resort — first available, or the selection itself if the model
   // has no sequences at all (keeps the type non-null; downstream shows empty).
   return availableSequences[0] ?? selectedSequence;
 }

--- a/packages/app/src/lib/default-sequence.ts
+++ b/packages/app/src/lib/default-sequence.ts
@@ -21,14 +21,12 @@ import { Sequence } from './data-mappings';
  *    on a non-null result (a loading skeleton covers this window, which is
  *    short).
  *
- * 2. **Per-model default.** `selectedSequence` starts at the app-wide default
+ * 2. **Availability-driven default.** `selectedSequence` starts at the app-wide default
  *    (`8k/1k`) until the user actually picks something, so it can't distinguish
  *    "the user wants 8K/1K" from "nobody has chosen yet". `sequenceExplicit`
- *    makes that distinction: while it is false, a model that declares a
- *    `modelDefaultSequence` (see `getModelDefaultSequence`) opens on that
- *    scenario if it has data for it — that's how the AgentX models open on
- *    Agentic Workloads instead of 8K/1K. Any explicit selection turns the flag
- *    on and this rule stops applying.
+ *    makes that distinction: while it is false, any model with Agentic Workloads
+ *    data opens on that scenario instead of 8K/1K. Any explicit selection turns
+ *    the flag on and this rule stops applying.
  *
  * 3. **Fallback ordering.** Otherwise: keep the user's `selectedSequence` if the
  *    model has it. Otherwise fall back to a sensible fixed-seq scenario.
@@ -41,28 +39,21 @@ export function resolveEffectiveSequence({
   selectedSequence,
   availableSequences,
   availabilityLoaded,
-  modelDefaultSequence = null,
   sequenceExplicit = false,
 }: {
   selectedSequence: Sequence;
   availableSequences: Sequence[];
   availabilityLoaded: boolean;
-  /** The selected model's preferred opening scenario, or null for the app default. */
-  modelDefaultSequence?: Sequence | null;
   /** Whether `selectedSequence` came from a real user/route choice. */
   sequenceExplicit?: boolean;
 }): Sequence | null {
   // Rule 1: do not commit to a sequence before we know what the model has.
   if (!availabilityLoaded) return null;
 
-  // Rule 2: nobody has chosen yet — open on the model's preferred scenario when
-  // the model actually has data for it.
-  if (
-    !sequenceExplicit &&
-    modelDefaultSequence !== null &&
-    availableSequences.includes(modelDefaultSequence)
-  ) {
-    return modelDefaultSequence;
+  // Rule 2: nobody has chosen yet — prefer the real AgentX workload whenever
+  // availability confirms that the selected model has data for it.
+  if (!sequenceExplicit && availableSequences.includes(Sequence.AgenticTraces)) {
+    return Sequence.AgenticTraces;
   }
 
   // Rule 3a: honor the user's / default selection when the model supports it.

--- a/packages/app/src/lib/default-sequence.ts
+++ b/packages/app/src/lib/default-sequence.ts
@@ -4,7 +4,7 @@ import { Sequence } from './data-mappings';
  * Effective-sequence resolution.
  *
  * `selectedSequence` defaults to {@link Sequence.EightK_OneK}, but the user may
- * have selected a scenario the model doesn't offer (e.g. Agentic Workloads via a
+ * have selected a scenario the model doesn't offer (e.g. the Agentic scenario via a
  * shared `?i_seq=` link on a fixed-seq-only model). This helper turns the raw
  * user/default selection into the sequence the chart should actually render,
  * given what the selected model offers.
@@ -24,9 +24,9 @@ import { Sequence } from './data-mappings';
  * 2. **Availability-driven default.** `selectedSequence` starts at the app-wide default
  *    (`8k/1k`) until the user actually picks something, so it can't distinguish
  *    "the user wants 8K/1K" from "nobody has chosen yet". `sequenceExplicit`
- *    makes that distinction: while it is false, any model with Agentic Workloads
- *    data opens on that scenario instead of 8K/1K. Any explicit selection turns
- *    the flag on and this rule stops applying.
+ *    makes that distinction: while it is false, any model with Agentic data
+ *    opens on that scenario instead of 8K/1K. Any explicit selection turns the
+ *    flag on and this rule stops applying.
  *
  * 3. **Fallback ordering.** Otherwise: keep the user's `selectedSequence` if the
  *    model has it. Otherwise fall back to a sensible fixed-seq scenario.


### PR DESCRIPTION
## Summary

- Rename the user-facing scenario from **Agentic Traces** to **Agentic** while preserving the internal `agentic-traces` API value.
- Make Agentic the default for every model whose official or unofficial-run availability includes corresponding data. The default is data-driven rather than a hard-coded model list, so new models inherit it automatically.
- Preserve explicit scenario choices from `?i_seq=`, route seeds, and manual selection.
- Add a concise scenario explainer beside the selector with a link to `/datasets` and the localized datasets page on Chinese routes.
- Update localized UI labels, calculator copy, supporting docs, and regression coverage.

## Why

AgentX is now a real benchmark scenario in InferenceX, not a future capability. Models with corresponding data should open on the representative long-context, multi-turn workload instead of the generic 8K/1K scenario.

Production availability currently includes AgentX rows for DeepSeek V4 Pro, GLM-5.2/5.3, MiniMax M3, Qwen3.5, and Kimi K3. Future models will receive the same default automatically when their data lands.

## Behavior

1. Wait for official or unofficial-run availability to resolve.
2. If the user has not chosen a scenario and Agentic is available, open it.
3. Otherwise honor the explicit selection, then fall back to 8K/1K or the first available scenario.

The shared availability path means the same behavior applies to `?unofficialrun=` overlays.

## Validation

- Focused unit coverage for availability gating, implicit defaults, explicit overrides, and fallback behavior
- Cypress coverage for two different models with AgentX data plus an explicit 8K/1K shared link
- Full GitHub unit, component, Chrome/Firefox E2E, lint, typecheck, CodeQL, Vercel, and Cursor Bugbot checks pass
- No unresolved review threads
