### PR TITLE
feat(db): add audited run metadata backfills

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -78,6 +78,44 @@ conservative fallback prevents a failed GitHub lookup from restoring a suppresse
 point. It can only suppress an identical point from another attempt while that
 attempt remains unknown.
 
+### Audited Run Backfills
+
+Exceptional metadata corrections use the same reviewed, automatically enforced ledger
+as purges. Add a `CHANGELOG_BACKFILLS` or `BENCHMARK_POINT_BACKFILLS` entry in
+`packages/db/src/etl/run-overrides.ts`; never add a one-off production SQL statement.
+Every entry has a stable kebab-case `id`, a human-readable `reason`, an exact run attempt,
+and the target table's complete natural-key selector. The source-control history records
+who approved the correction and why, while the stable ID appears in ingest and apply logs.
+
+Changelog backfills select `(githubRunId, runAttempt, baseRef, headRef)` and can patch
+`configKeys`, `description`, `prLink`, or `appendOnly`. An `appendOnly` correction updates
+both `changelog_entries.append_only` and `workflow_runs.append_only` atomically because
+the materialized benchmark view reads the run-level value.
+
+Benchmark point backfills use the same complete point selector as audited point purges:
+`githubRunId`, `runAttempt`, `configId`, `benchmarkType`, `isl`, `osl`, `conc`,
+`offloadMode`, and nullable `recipeFingerprint`. Their `set` block supports a shallow
+`metricsMerge`, top-level `metricsRemove`, and `offloadMode`. Setting `offloadMode`
+updates both the first-class column and `metrics.offload_mode`; for example, a missed CPU
+KV offload annotation can set `offloadMode: 'on'` and merge `kv_offloading` plus backend
+metadata in one correction. Unrelated metrics remain unchanged.
+
+Run `bun run admin:db:apply-overrides` to preview the exact rows, reasons, and patches;
+the command requires confirmation unless passed `--yes`. It fails before writing when a
+target is missing, when a point's desired identity already exists, or when registry
+validation finds an overlap or duplicate. Writes are verified against the declared state
+and `latest_benchmarks` is refreshed afterward. Merges to `master` run the same command in
+CI, followed by database verification, cache invalidation, and cache warmup.
+
+Point corrections are additionally applied before each CI or GCS benchmark insert. This
+prevents a later idempotent re-ingest from restoring the artifact's original value. The
+ingest tracks source and desired identities across the run and fails on a collision instead
+of silently collapsing two distinct artifact points. When GCS cannot recover an attempt
+number, it follows the purge path's conservative fallback and matches the exact run and
+point across attempts; the log records the applied backfill ID. Changelog corrections are
+likewise applied to artifact metadata before `appendOnly`/`evalsOnly` run semantics are
+resolved and before the changelog is upserted.
+
 ### Why Two Connection Types
 
 | Connection                      | Library     | Use Case                             | Why                                                                                                  |

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -1,9 +1,11 @@
 /**
  * Enforce all run-overrides.ts entries against the DB:
  *   1. Patch conclusions for CONCLUSION_OVERRIDES
- *   2. Purge runs listed in PURGED_RUNS
- *   3. Purge specific attempts listed in PURGED_RUN_ATTEMPTS
- *   4. Purge individual benchmark points listed in PURGED_BENCHMARK_POINTS
+ *   2. Patch changelogs listed in CHANGELOG_BACKFILLS
+ *   3. Patch benchmark points listed in BENCHMARK_POINT_BACKFILLS
+ *   4. Purge runs listed in PURGED_RUNS
+ *   5. Purge specific attempts listed in PURGED_RUN_ATTEMPTS
+ *   6. Purge individual benchmark points listed in PURGED_BENCHMARK_POINTS
  * Previews changes (read-only), then confirms before writing.
  *
  * Usage:
@@ -14,14 +16,21 @@
  * Use this command directly only for local preview or manual recovery.
  */
 
+import { isDeepStrictEqual } from 'node:util';
+
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
 import { type Sql, createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
 import {
+  type BenchmarkPointBackfill,
+  type ChangelogBackfill,
   type PurgedBenchmarkPoint,
+  BENCHMARK_POINT_BACKFILLS,
+  CHANGELOG_BACKFILLS,
   CONCLUSION_OVERRIDES,
   PURGED_BENCHMARK_POINTS,
   PURGED_RUN_ATTEMPTS,
   PURGED_RUNS,
+  validateRunBackfills,
 } from './etl/run-overrides.js';
 
 const sql = createAdminSql({
@@ -71,6 +80,200 @@ async function applyConclusions(stale: StaleRow[]): Promise<void> {
     `;
     console.log(`    ${githubRunId} → ${expected}`);
   }
+}
+
+// ── Audited backfills ────────────────────────────────────────────────────────
+
+interface ChangelogBackfillTarget {
+  backfill: ChangelogBackfill;
+  changelogId: number;
+  workflowRunId: number;
+}
+
+function changelogBackfillIsApplied(
+  row: Record<string, unknown>,
+  backfill: ChangelogBackfill,
+): boolean {
+  const { set } = backfill;
+  return (
+    (set.configKeys === undefined || isDeepStrictEqual(row.config_keys, [...set.configKeys])) &&
+    (set.description === undefined || row.description === set.description) &&
+    (set.prLink === undefined || row.pr_link === set.prLink) &&
+    (set.appendOnly === undefined ||
+      (row.changelog_append_only === set.appendOnly && row.run_append_only === set.appendOnly))
+  );
+}
+
+/** Resolve one exact changelog row and return it only when its patch is stale. */
+async function previewChangelogBackfill(
+  backfill: ChangelogBackfill,
+): Promise<ChangelogBackfillTarget | null> {
+  const rows = await sql`
+    SELECT cl.id, cl.workflow_run_id, cl.config_keys, cl.description, cl.pr_link,
+           cl.append_only AS changelog_append_only, wr.append_only AS run_append_only
+    FROM changelog_entries cl
+    JOIN workflow_runs wr ON wr.id = cl.workflow_run_id
+    WHERE wr.github_run_id = ${backfill.githubRunId}
+      AND wr.run_attempt = ${backfill.runAttempt}
+      AND cl.base_ref = ${backfill.baseRef}
+      AND cl.head_ref = ${backfill.headRef}
+  `;
+  if (rows.length !== 1) {
+    throw new Error(
+      `${backfill.id}: expected exactly one changelog row, found ${rows.length} ` +
+        `(run ${backfill.githubRunId} attempt ${backfill.runAttempt}, ` +
+        `${backfill.baseRef}..${backfill.headRef})`,
+    );
+  }
+  const [row] = rows;
+  console.log(
+    `    ${backfill.id}: run ${backfill.githubRunId} attempt ${backfill.runAttempt}, ` +
+      `${backfill.baseRef}..${backfill.headRef}`,
+  );
+  console.log(`      reason: ${backfill.reason}`);
+  if (changelogBackfillIsApplied(row, backfill)) {
+    console.log('      already applied.');
+    return null;
+  }
+  console.log(`      set ${JSON.stringify(backfill.set)}`);
+  return {
+    backfill,
+    changelogId: row.id as number,
+    workflowRunId: row.workflow_run_id as number,
+  };
+}
+
+async function applyChangelogBackfill(target: ChangelogBackfillTarget): Promise<void> {
+  const { backfill, changelogId, workflowRunId } = target;
+  await sql.begin(async (_tx) => {
+    const tx = _tx as unknown as Sql;
+    if (backfill.set.configKeys !== undefined) {
+      await tx`
+        UPDATE changelog_entries
+        SET config_keys = ${[...backfill.set.configKeys]}
+        WHERE id = ${changelogId}
+      `;
+    }
+    if (backfill.set.description !== undefined) {
+      await tx`
+        UPDATE changelog_entries SET description = ${backfill.set.description}
+        WHERE id = ${changelogId}
+      `;
+    }
+    if (backfill.set.prLink !== undefined) {
+      await tx`
+        UPDATE changelog_entries SET pr_link = ${backfill.set.prLink}
+        WHERE id = ${changelogId}
+      `;
+    }
+    if (backfill.set.appendOnly !== undefined) {
+      await tx`
+        UPDATE changelog_entries SET append_only = ${backfill.set.appendOnly}
+        WHERE id = ${changelogId}
+      `;
+      await tx`
+        UPDATE workflow_runs SET append_only = ${backfill.set.appendOnly}
+        WHERE id = ${workflowRunId}
+      `;
+    }
+  });
+  console.log(`    ${backfill.id} patched.`);
+}
+
+interface BenchmarkPointBackfillTarget {
+  backfill: BenchmarkPointBackfill;
+  resultId: number;
+}
+
+function benchmarkPointBackfillIsApplied(
+  row: Record<string, unknown>,
+  backfill: BenchmarkPointBackfill,
+): boolean {
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  if (row.offload_mode !== desiredOffloadMode) return false;
+  const metrics = row.metrics as Record<string, unknown>;
+  if (backfill.set.offloadMode !== undefined && metrics.offload_mode !== desiredOffloadMode) {
+    return false;
+  }
+  for (const [key, value] of Object.entries(backfill.set.metricsMerge ?? {})) {
+    if (!isDeepStrictEqual(metrics[key], value)) return false;
+  }
+  for (const key of backfill.set.metricsRemove ?? []) {
+    if (Object.hasOwn(metrics, key)) return false;
+  }
+  return true;
+}
+
+function benchmarkPointDescription(backfill: BenchmarkPointBackfill): string {
+  return (
+    `run ${backfill.githubRunId} attempt ${backfill.runAttempt}, config ${backfill.configId}, ` +
+    `${backfill.benchmarkType}, isl ${backfill.isl}, osl ${backfill.osl}, ` +
+    `conc ${backfill.conc}, offload ${backfill.offloadMode}, ` +
+    `recipe ${backfill.recipeFingerprint ?? 'legacy'}`
+  );
+}
+
+/** Resolve one source/desired point identity and fail closed on ambiguity. */
+async function previewBenchmarkPointBackfill(
+  backfill: BenchmarkPointBackfill,
+): Promise<BenchmarkPointBackfillTarget | null> {
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  const offloadModes = [...new Set([backfill.offloadMode, desiredOffloadMode])];
+  const rows = await sql`
+    SELECT br.id, br.offload_mode, br.metrics
+    FROM benchmark_results br
+    JOIN workflow_runs wr ON wr.id = br.workflow_run_id
+    WHERE wr.github_run_id = ${backfill.githubRunId}
+      AND wr.run_attempt = ${backfill.runAttempt}
+      AND br.config_id = ${backfill.configId}
+      AND br.benchmark_type = ${backfill.benchmarkType}
+      AND br.isl IS NOT DISTINCT FROM ${backfill.isl}
+      AND br.osl IS NOT DISTINCT FROM ${backfill.osl}
+      AND br.conc = ${backfill.conc}
+      AND br.offload_mode = ANY(${offloadModes})
+      AND br.recipe_fingerprint IS NOT DISTINCT FROM ${backfill.recipeFingerprint ?? null}
+  `;
+  if (rows.length !== 1) {
+    throw new Error(
+      `${backfill.id}: expected exactly one source or desired benchmark row, ` +
+        `found ${rows.length} (${benchmarkPointDescription(backfill)})`,
+    );
+  }
+  const [row] = rows;
+  console.log(`    ${backfill.id}: ${benchmarkPointDescription(backfill)}`);
+  console.log(`      reason: ${backfill.reason}`);
+  if (benchmarkPointBackfillIsApplied(row, backfill)) {
+    console.log('      already applied.');
+    return null;
+  }
+  if (row.offload_mode === desiredOffloadMode && desiredOffloadMode !== backfill.offloadMode) {
+    throw new Error(
+      `${backfill.id}: source identity is missing and the desired identity has unexpected data`,
+    );
+  }
+  console.log(`      set ${JSON.stringify(backfill.set)}`);
+  return { backfill, resultId: row.id as number };
+}
+
+async function applyBenchmarkPointBackfillToDatabase(
+  target: BenchmarkPointBackfillTarget,
+): Promise<void> {
+  const { backfill, resultId } = target;
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  const metricsMerge: Record<string, unknown> = { ...backfill.set.metricsMerge };
+  if (backfill.set.offloadMode !== undefined) {
+    metricsMerge.offload_mode = desiredOffloadMode;
+  }
+  const [updated] = await sql`
+    UPDATE benchmark_results
+    SET offload_mode = ${desiredOffloadMode},
+        metrics = (metrics - ${backfill.set.metricsRemove ?? []}::text[])
+          || ${JSON.stringify(metricsMerge)}::jsonb
+    WHERE id = ${resultId}
+    RETURNING id
+  `;
+  if (!updated) throw new Error(`${backfill.id}: benchmark row disappeared before update`);
+  console.log(`    ${backfill.id} patched.`);
 }
 
 // ── Purge ─────────────────────────────────────────────────────────────────────
@@ -314,6 +517,7 @@ async function purgeBenchmarkPoints(resultIds: number[]): Promise<void> {
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  validateRunBackfills();
   console.log('=== apply-overrides ===');
 
   // Phase 1: preview (read-only)
@@ -329,6 +533,30 @@ async function main(): Promise<void> {
   } else {
     console.log('\n  Conclusions: all up to date.');
   }
+
+  const changelogBackfillTargets: ChangelogBackfillTarget[] = [];
+  if (CHANGELOG_BACKFILLS.length > 0) {
+    console.log(`\n  Changelog backfills (${CHANGELOG_BACKFILLS.length}):`);
+    for (const backfill of CHANGELOG_BACKFILLS) {
+      const target = await previewChangelogBackfill(backfill);
+      if (target) changelogBackfillTargets.push(target);
+    }
+  } else {
+    console.log('\n  Changelog backfills: none registered.');
+  }
+  if (changelogBackfillTargets.length > 0) hasWork = true;
+
+  const benchmarkPointBackfillTargets: BenchmarkPointBackfillTarget[] = [];
+  if (BENCHMARK_POINT_BACKFILLS.length > 0) {
+    console.log(`\n  Benchmark point backfills (${BENCHMARK_POINT_BACKFILLS.length}):`);
+    for (const backfill of BENCHMARK_POINT_BACKFILLS) {
+      const target = await previewBenchmarkPointBackfill(backfill);
+      if (target) benchmarkPointBackfillTargets.push(target);
+    }
+  } else {
+    console.log('\n  Benchmark point backfills: none registered.');
+  }
+  if (benchmarkPointBackfillTargets.length > 0) hasWork = true;
 
   const purgeTargets = [...PURGED_RUNS];
   const found: PurgeTarget[] = [];
@@ -395,6 +623,20 @@ async function main(): Promise<void> {
     await applyConclusions(stale);
   }
 
+  if (changelogBackfillTargets.length > 0) {
+    console.log('\n  Patching changelogs...');
+    for (const target of changelogBackfillTargets) {
+      await applyChangelogBackfill(target);
+    }
+  }
+
+  if (benchmarkPointBackfillTargets.length > 0) {
+    console.log('\n  Patching benchmark points...');
+    for (const target of benchmarkPointBackfillTargets) {
+      await applyBenchmarkPointBackfillToDatabase(target);
+    }
+  }
+
   if (found.length > 0) {
     console.log('\n  Purging runs...');
     for (const { wrIds } of found) {
@@ -409,7 +651,17 @@ async function main(): Promise<void> {
     }
   }
 
-  // Phase 4: refresh mat view
+  // Phase 4: verify every requested backfill reached its declared state.
+  for (const backfill of CHANGELOG_BACKFILLS) {
+    const staleTarget = await previewChangelogBackfill(backfill);
+    if (staleTarget) throw new Error(`${backfill.id}: changelog verification failed`);
+  }
+  for (const backfill of BENCHMARK_POINT_BACKFILLS) {
+    const staleTarget = await previewBenchmarkPointBackfill(backfill);
+    if (staleTarget) throw new Error(`${backfill.id}: benchmark point verification failed`);
+  }
+
+  // Phase 5: refresh mat view
   await refreshLatestBenchmarks(sql);
 
   console.log('\n=== apply-overrides complete ===');

--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -1,13 +1,174 @@
 import { describe, it, expect } from 'vitest';
 import {
+  type BenchmarkPointBackfill,
+  type ChangelogBackfill,
   type PurgedBenchmarkPoint,
+  applyBenchmarkPointBackfill,
+  applyChangelogBackfills,
+  BENCHMARK_POINT_BACKFILLS,
+  CHANGELOG_BACKFILLS,
   CONCLUSION_OVERRIDES,
   PURGED_BENCHMARK_POINTS,
   PURGED_RUN_ATTEMPTS,
   PURGED_RUNS,
   isBenchmarkPointPurged,
   isRunAttemptPurged,
+  recordBackfilledPointIdentity,
+  validateRunBackfills,
 } from './run-overrides';
+
+function examplePointBackfill(
+  overrides: Partial<BenchmarkPointBackfill> = {},
+): BenchmarkPointBackfill {
+  return {
+    id: 'run-123-point-offload',
+    reason: 'Artifact omitted the offload metadata.',
+    githubRunId: 123,
+    runAttempt: 1,
+    configId: 456,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 64,
+    offloadMode: 'off',
+    recipeFingerprint: null,
+    set: {
+      offloadMode: 'on',
+      metricsMerge: { kv_offloading: 'dram', kv_offload_backend: 'lmcache' },
+      metricsRemove: ['stale_offload_field'],
+    },
+    ...overrides,
+  };
+}
+
+describe('audited run backfills', () => {
+  it('validates the checked-in registries', () => {
+    expect(() => validateRunBackfills()).not.toThrow();
+  });
+
+  it('requires a stable ID, reason, exact selector, and non-empty patch', () => {
+    expect(() => validateRunBackfills([], [examplePointBackfill({ id: 'Not Valid' })])).toThrow(
+      /kebab-case/u,
+    );
+    expect(() => validateRunBackfills([], [examplePointBackfill({ reason: ' ' })])).toThrow(
+      /reason/u,
+    );
+    expect(() => validateRunBackfills([], [examplePointBackfill({ set: {} })])).toThrow(
+      /at least one field/u,
+    );
+  });
+
+  it('rejects source-to-destination point identity collisions', () => {
+    const first = examplePointBackfill();
+    const second = examplePointBackfill({
+      id: 'run-123-existing-offload-point',
+      offloadMode: 'on',
+      set: { metricsMerge: { note: 'already on' } },
+    });
+    expect(() => validateRunBackfills([], [first, second])).toThrow(/collides/u);
+  });
+
+  it('applies point corrections during ingest and synchronizes offload metadata', () => {
+    const backfill = examplePointBackfill();
+    const registry = BENCHMARK_POINT_BACKFILLS as BenchmarkPointBackfill[];
+    registry.push(backfill);
+    const point = {
+      configId: 456,
+      benchmarkType: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc: 64,
+      offloadMode: 'off',
+      recipeFingerprint: null,
+      metrics: { median_itl: 0.1, stale_offload_field: true },
+    };
+
+    try {
+      const applied = applyBenchmarkPointBackfill(123, 1, point);
+      expect(applied.backfillId).toBe(backfill.id);
+      expect(applied.point.offloadMode).toBe('on');
+      expect(applied.point.metrics).toEqual({
+        median_itl: 0.1,
+        offload_mode: 'on',
+        kv_offloading: 'dram',
+        kv_offload_backend: 'lmcache',
+      });
+      expect(applied.desiredIdentity).not.toBe(applied.sourceIdentity);
+
+      const otherAttempt = applyBenchmarkPointBackfill(123, 2, point);
+      expect(otherAttempt.backfillId).toBeNull();
+      // GCS fallback has no attempt metadata and intentionally matches by run + point.
+      expect(applyBenchmarkPointBackfill(123, undefined, point).backfillId).toBe(backfill.id);
+    } finally {
+      registry.splice(registry.indexOf(backfill), 1);
+    }
+  });
+
+  it('applies changelog corrections to the row that ingest persists', () => {
+    const backfill: ChangelogBackfill = {
+      id: 'run-123-changelog-configs',
+      reason: 'The artifact listed the wrong config key.',
+      githubRunId: 123,
+      runAttempt: 1,
+      baseRef: 'master',
+      headRef: 'feature-sha',
+      set: {
+        configKeys: ['dsv4-fp4-b300-vllm-mtp'],
+        description: 'Corrected description',
+        prLink: null,
+        appendOnly: true,
+      },
+    };
+    const registry = CHANGELOG_BACKFILLS as ChangelogBackfill[];
+    registry.push(backfill);
+
+    try {
+      const applied = applyChangelogBackfills(123, 1, [
+        {
+          baseRef: 'master',
+          headRef: 'feature-sha',
+          entries: [
+            {
+              configKeys: ['old-first'],
+              description: 'First entry is overwritten by ingest',
+              prLink: 'https://example.com/first',
+              evalsOnly: false,
+              appendOnly: false,
+            },
+            {
+              configKeys: ['old-final'],
+              description: 'Final stored entry',
+              prLink: 'https://example.com/final',
+              evalsOnly: false,
+              appendOnly: false,
+            },
+          ],
+        },
+      ]);
+
+      expect(applied.backfillIds).toEqual([backfill.id]);
+      expect(applied.changelogs[0].entries[0].configKeys).toEqual(['old-first']);
+      expect(applied.changelogs[0].entries[0].appendOnly).toBe(true);
+      expect(applied.changelogs[0].entries[1]).toMatchObject({
+        configKeys: ['dsv4-fp4-b300-vllm-mtp'],
+        description: 'Corrected description',
+        prLink: null,
+        appendOnly: true,
+        evalsOnly: false,
+      });
+    } finally {
+      registry.splice(registry.indexOf(backfill), 1);
+    }
+  });
+
+  it('detects two artifact rows collapsing onto one corrected identity', () => {
+    const seen = new Map<string, string>();
+    recordBackfilledPointIdentity(seen, 'source-off', 'desired-on');
+    expect(() => recordBackfilledPointIdentity(seen, 'source-on', 'desired-on')).toThrow(
+      /collision/u,
+    );
+  });
+});
 
 describe('CONCLUSION_OVERRIDES', () => {
   it('all run IDs are positive integers', () => {

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -209,7 +209,111 @@ export interface BenchmarkPointBackfill extends BenchmarkPointKey, AuditedBackfi
  *   },
  * }
  */
-export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [];
+export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
+  // The source recipes in run 31633154542 attach MooncakeStoreConnector to
+  // every disaggregated worker and allocate a 180 GB Mooncake segment per
+  // node. The master matrix omitted the corresponding offload annotation.
+  ...(
+    [
+      [2106, 256, null],
+      [2334, 1152, null],
+      [2336, 1024, null],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31633154542-config-${configId}-conc-${conc}-mooncake-offload`,
+    reason:
+      'The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31633154542,
+    runAttempt: 2,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+      },
+    },
+  })),
+
+  // Every TensorRT-LLM recipe in run 31927376673 configures a 128 GiB native
+  // host KV cache on both prefill and decode workers. The master matrix only
+  // declared NIXL transfer, so all six artifacts lost the offload identity.
+  ...(
+    [
+      [2360, 7, '5c282408e21b662cf5afbef0d26a63ad2fb19bb66ca3b431763a1c40628f3036'],
+      [2361, 96, 'da36b834945785abfa06c44f742684db7a96af49542d9012019063d552dc7393'],
+      [2362, 704, '60e4361ec00fd8a94a700b7ae9dbb4d8b6cf4095b1553f098af45551669fcf1f'],
+      [2363, 52, 'd7fccb3572037431f39757640d090ab1204bb27ac57ff0f9f9a635e9cefb5867'],
+      [2364, 565, 'a6017a5c8a675fb4f1f74e49bb0091f172e6ea357a1bb1b2d6577eb661c9f1c5'],
+      [2365, 44, 'ac8406a4d46f3711732aa352c801bbd1eb7c3545b2982c5d2c56520fa8288342'],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31927376673-config-${configId}-conc-${conc}-native-offload`,
+    reason:
+      'The TensorRT-LLM runtime recipe configured a native host KV cache, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31927376673,
+    runAttempt: 1,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'native',
+        kv_offload_backend_version: '1.3.0rc24',
+      },
+    },
+  })),
+
+  // The four disaggregated recipes in run 31965016666 attach
+  // MooncakeStoreConnector to NIXL through MultiConnector and allocate a
+  // 140 GB Mooncake segment per node. The three aggregate points in the same
+  // run do not attach the connector and are intentionally excluded.
+  ...(
+    [
+      [1012, 128, 'b01cb33e392b60b01e2f498ea7300118c6046e074556199a3fe9a7208cf7929e'],
+      [1012, 256, '856babb1e00e524c7eddca689e1345d1a97a41f6743c5d5c109347444581aeef'],
+      [2374, 576, 'd7afa7f01be968e02911263a9792bb1200ca27de702b5e79d7907e6d46adfc44'],
+      [2375, 512, '47a4969f521268bccc1a3efd97a5ceaf231ff33ab13fa6fe3f9cadf48573f2b1'],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31965016666-config-${configId}-conc-${conc}-mooncake-offload`,
+    reason:
+      'The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31965016666,
+    runAttempt: 2,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+      },
+    },
+  })),
+];
 
 function pointIdentity(
   point: BenchmarkPointKey & { githubRunId: number; runAttempt: number },

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -19,6 +19,12 @@
  * run attempt and skip them on every future ingest. Each entry uses the row's durable
  * database natural key, which can be queried from the linked dashboard point.
  *
+ * CHANGELOG_BACKFILLS — correct stored changelog metadata for one exact run attempt
+ * and base/head ref pair.
+ *
+ * BENCHMARK_POINT_BACKFILLS — correct metrics and/or offload identity for one exact
+ * benchmark point. These are applied both during ingest and against existing DB rows.
+ *
  * Note: GitHub deletes old workflow runs over time so these overrides may not be applicable forever,
  *       but we should keep them around for historical reference. You can find these on github (if available) by filling
  *       in the run id into the following link: https://github.com/SemiAnalysisAI/InferenceX/actions/runs/{run_id_here}
@@ -132,6 +138,380 @@ export interface PurgedBenchmarkPoint extends BenchmarkPointKey {
  * recipeFingerprint }`. Omitted fingerprints target only legacy NULL rows.
  */
 export const PURGED_BENCHMARK_POINTS: readonly PurgedBenchmarkPoint[] = [];
+
+interface AuditedBackfill {
+  /** Stable, descriptive identifier used in logs and review history. */
+  id: string;
+  /** Why artifact data is being corrected instead of re-running the benchmark. */
+  reason: string;
+}
+
+export interface ChangelogBackfill extends AuditedBackfill {
+  githubRunId: number;
+  runAttempt: number;
+  baseRef: string;
+  headRef: string;
+  set: {
+    configKeys?: readonly string[];
+    description?: string;
+    prLink?: string | null;
+    appendOnly?: boolean;
+  };
+}
+
+/**
+ * Audited corrections to changelog rows already produced by workflow artifacts.
+ * Selectors use the table's complete durable identity. `set` is a partial patch.
+ */
+export const CHANGELOG_BACKFILLS: readonly ChangelogBackfill[] = [];
+
+export type JsonValue =
+  | boolean
+  | number
+  | string
+  | null
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue };
+
+export interface BenchmarkPointBackfill extends BenchmarkPointKey, AuditedBackfill {
+  githubRunId: number;
+  runAttempt: number;
+  set: {
+    /** Updates both the first-class column and metrics.offload_mode. */
+    offloadMode?: 'on' | 'off';
+    /** Shallow JSONB merge; existing unrelated metrics are preserved. */
+    metricsMerge?: Readonly<Record<string, JsonValue>>;
+    /** Top-level metric keys to remove before metricsMerge is applied. */
+    metricsRemove?: readonly string[];
+  };
+}
+
+/**
+ * Audited corrections to individual benchmark points. The selector is the row's
+ * complete pre-backfill natural identity; `set` contains only the desired changes.
+ *
+ * Example:
+ * {
+ *   id: 'run-123-attempt-1-conc-64-enable-offload',
+ *   reason: 'The artifact omitted offload metadata for this point.',
+ *   githubRunId: 123,
+ *   runAttempt: 1,
+ *   configId: 456,
+ *   benchmarkType: 'agentic_traces',
+ *   isl: null,
+ *   osl: null,
+ *   conc: 64,
+ *   offloadMode: 'off',
+ *   recipeFingerprint: null,
+ *   set: {
+ *     offloadMode: 'on',
+ *     metricsMerge: { kv_offloading: 'dram', kv_offload_backend: 'lmcache' },
+ *   },
+ * }
+ */
+export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [];
+
+function pointIdentity(
+  point: BenchmarkPointKey & { githubRunId: number; runAttempt: number },
+): string {
+  return JSON.stringify([
+    point.githubRunId,
+    point.runAttempt,
+    point.configId,
+    point.benchmarkType,
+    point.isl,
+    point.osl,
+    point.conc,
+    point.offloadMode,
+    point.recipeFingerprint ?? null,
+  ]);
+}
+
+function validatePositiveInteger(value: number, label: string, id: string): void {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${id}: ${label} must be a positive integer`);
+  }
+}
+
+/** Validate the backfill ledger before an ingest or database write starts. */
+export function validateRunBackfills(
+  changelogs: readonly ChangelogBackfill[] = CHANGELOG_BACKFILLS,
+  points: readonly BenchmarkPointBackfill[] = BENCHMARK_POINT_BACKFILLS,
+): void {
+  const ids = new Set<string>();
+  const changelogIdentities = new Set<string>();
+  const pointSourceIdentities = new Map<string, string>();
+  const pointDesiredIdentities = new Map<string, string>();
+
+  for (const backfill of [...changelogs, ...points]) {
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(backfill.id)) {
+      throw new Error(`${backfill.id || '<empty>'}: id must be lowercase kebab-case`);
+    }
+    if (ids.has(backfill.id)) throw new Error(`duplicate backfill id: ${backfill.id}`);
+    ids.add(backfill.id);
+    if (backfill.reason.trim().length === 0) {
+      throw new Error(`${backfill.id}: reason must not be empty`);
+    }
+    validatePositiveInteger(backfill.githubRunId, 'githubRunId', backfill.id);
+    validatePositiveInteger(backfill.runAttempt, 'runAttempt', backfill.id);
+    if (PURGED_RUNS.has(backfill.githubRunId)) {
+      throw new Error(`${backfill.id}: run is already in PURGED_RUNS`);
+    }
+    if (PURGED_RUN_ATTEMPTS.get(backfill.githubRunId)?.has(backfill.runAttempt)) {
+      throw new Error(`${backfill.id}: run attempt is already in PURGED_RUN_ATTEMPTS`);
+    }
+  }
+
+  for (const backfill of changelogs) {
+    if (backfill.baseRef.length === 0 || backfill.headRef.length === 0) {
+      throw new Error(`${backfill.id}: baseRef and headRef must not be empty`);
+    }
+    if (
+      backfill.set.configKeys === undefined &&
+      backfill.set.description === undefined &&
+      backfill.set.prLink === undefined &&
+      backfill.set.appendOnly === undefined
+    ) {
+      throw new Error(`${backfill.id}: set must change at least one field`);
+    }
+    if (backfill.set.configKeys?.some((key) => key.length === 0)) {
+      throw new Error(`${backfill.id}: configKeys must not contain empty values`);
+    }
+    const identity = JSON.stringify([
+      backfill.githubRunId,
+      backfill.runAttempt,
+      backfill.baseRef,
+      backfill.headRef,
+    ]);
+    if (changelogIdentities.has(identity)) {
+      throw new Error(`${backfill.id}: duplicate changelog selector ${identity}`);
+    }
+    changelogIdentities.add(identity);
+  }
+
+  for (const backfill of points) {
+    validatePositiveInteger(backfill.configId, 'configId', backfill.id);
+    validatePositiveInteger(backfill.conc, 'conc', backfill.id);
+    if (backfill.benchmarkType.length === 0 || backfill.offloadMode.length === 0) {
+      throw new Error(`${backfill.id}: benchmarkType and offloadMode must not be empty`);
+    }
+    if (backfill.isl !== null) validatePositiveInteger(backfill.isl, 'isl', backfill.id);
+    if (backfill.osl !== null) validatePositiveInteger(backfill.osl, 'osl', backfill.id);
+    if (backfill.recipeFingerprint === '') {
+      throw new Error(`${backfill.id}: recipeFingerprint must be null or non-empty`);
+    }
+    const mergeKeys = Object.keys(backfill.set.metricsMerge ?? {});
+    const removeKeys = backfill.set.metricsRemove ?? [];
+    if (
+      backfill.set.offloadMode === undefined &&
+      mergeKeys.length === 0 &&
+      removeKeys.length === 0
+    ) {
+      throw new Error(`${backfill.id}: set must change at least one field`);
+    }
+    if (mergeKeys.includes('offload_mode') || removeKeys.includes('offload_mode')) {
+      throw new Error(`${backfill.id}: use set.offloadMode to change metrics.offload_mode`);
+    }
+    if (new Set(removeKeys).size !== removeKeys.length || removeKeys.some((key) => key === '')) {
+      throw new Error(`${backfill.id}: metricsRemove keys must be unique and non-empty`);
+    }
+    const overlap = mergeKeys.find((key) => removeKeys.includes(key));
+    if (overlap) throw new Error(`${backfill.id}: metric ${overlap} is both merged and removed`);
+
+    const sourceIdentity = pointIdentity(backfill);
+    if (pointSourceIdentities.has(sourceIdentity)) {
+      throw new Error(`${backfill.id}: duplicate benchmark point selector ${sourceIdentity}`);
+    }
+    pointSourceIdentities.set(sourceIdentity, backfill.id);
+
+    const desiredIdentity = pointIdentity({
+      ...backfill,
+      offloadMode: backfill.set.offloadMode ?? backfill.offloadMode,
+    });
+    if (pointDesiredIdentities.has(desiredIdentity)) {
+      throw new Error(`${backfill.id}: desired point identity collides with another backfill`);
+    }
+    pointDesiredIdentities.set(desiredIdentity, backfill.id);
+
+    if (
+      PURGED_BENCHMARK_POINTS.some((purged) => {
+        const purgedIdentity = pointIdentity(purged);
+        return purgedIdentity === sourceIdentity || purgedIdentity === desiredIdentity;
+      })
+    ) {
+      throw new Error(`${backfill.id}: source or desired point is already being purged`);
+    }
+  }
+
+  for (const [identity, desiredBy] of pointDesiredIdentities) {
+    const selectedBy = pointSourceIdentities.get(identity);
+    if (selectedBy !== undefined && selectedBy !== desiredBy) {
+      throw new Error(
+        `${desiredBy}: desired point identity collides with selector from ${selectedBy}`,
+      );
+    }
+  }
+}
+
+interface BackfillablePoint extends BenchmarkPointKey {
+  metrics: Record<string, unknown>;
+}
+
+export interface AppliedBenchmarkPointBackfill<T extends BackfillablePoint> {
+  point: T;
+  backfillId: string | null;
+  sourceIdentity: string;
+  desiredIdentity: string;
+}
+
+interface BackfillableChangelogEntry {
+  configKeys: string[];
+  description: string;
+  prLink: string | null;
+  appendOnly: boolean;
+}
+
+interface BackfillableChangelog<T extends BackfillableChangelogEntry> {
+  baseRef: string;
+  headRef: string;
+  entries: T[];
+}
+
+/** Apply changelog corrections before artifact metadata is written to PostgreSQL. */
+export function applyChangelogBackfills<T extends BackfillableChangelogEntry>(
+  githubRunId: number,
+  runAttempt: number | null | undefined,
+  changelogs: readonly BackfillableChangelog<T>[],
+): { changelogs: BackfillableChangelog<T>[]; backfillIds: string[] } {
+  const relevant = CHANGELOG_BACKFILLS.filter(
+    (backfill) =>
+      backfill.githubRunId === githubRunId &&
+      (runAttempt === null || runAttempt === undefined || backfill.runAttempt === runAttempt),
+  );
+  const corrected = changelogs.map((changelog) => ({
+    ...changelog,
+    entries: [...changelog.entries],
+  }));
+  const backfillIds: string[] = [];
+
+  for (const changelog of corrected) {
+    const matches = relevant.filter(
+      (backfill) =>
+        backfill.baseRef === changelog.baseRef && backfill.headRef === changelog.headRef,
+    );
+    if (matches.length > 1) {
+      throw new Error(
+        `changelog matches multiple backfills: ${matches.map((backfill) => backfill.id).join(', ')}`,
+      );
+    }
+    const [backfill] = matches;
+    if (!backfill || changelog.entries.length === 0) continue;
+
+    const { appendOnly } = backfill.set;
+    if (appendOnly !== undefined) {
+      changelog.entries = changelog.entries.map((entry) => ({
+        ...entry,
+        appendOnly,
+      }));
+    }
+    // ingestChangelogEntries upserts every entry onto the same (run, base, head)
+    // identity, so the final artifact entry is the row that persists.
+    const entryIndex = changelog.entries.length - 1;
+    const entry = changelog.entries[entryIndex];
+    changelog.entries[entryIndex] = {
+      ...entry,
+      ...(backfill.set.configKeys === undefined
+        ? {}
+        : { configKeys: [...backfill.set.configKeys] }),
+      ...(backfill.set.description === undefined ? {} : { description: backfill.set.description }),
+      ...(backfill.set.prLink === undefined ? {} : { prLink: backfill.set.prLink }),
+    };
+    backfillIds.push(backfill.id);
+  }
+
+  return { changelogs: corrected, backfillIds };
+}
+
+function matchesBenchmarkPoint(point: BenchmarkPointKey, selector: BenchmarkPointKey): boolean {
+  return (
+    point.configId === selector.configId &&
+    point.benchmarkType === selector.benchmarkType &&
+    point.isl === selector.isl &&
+    point.osl === selector.osl &&
+    point.conc === selector.conc &&
+    point.offloadMode === selector.offloadMode &&
+    (point.recipeFingerprint ?? null) === (selector.recipeFingerprint ?? null)
+  );
+}
+
+/** Apply one point patch to an ingest row before it reaches PostgreSQL. */
+export function applyBenchmarkPointBackfill<T extends BackfillablePoint>(
+  githubRunId: number,
+  runAttempt: number | null | undefined,
+  point: T,
+): AppliedBenchmarkPointBackfill<T> {
+  const sourceIdentity = JSON.stringify([
+    point.configId,
+    point.benchmarkType,
+    point.isl,
+    point.osl,
+    point.conc,
+    point.offloadMode,
+    point.recipeFingerprint ?? null,
+  ]);
+  const matches = BENCHMARK_POINT_BACKFILLS.filter(
+    (backfill) =>
+      backfill.githubRunId === githubRunId &&
+      (runAttempt === null || runAttempt === undefined || backfill.runAttempt === runAttempt) &&
+      matchesBenchmarkPoint(point, backfill),
+  );
+  if (matches.length > 1) {
+    throw new Error(
+      `benchmark point matches multiple backfills: ${matches.map((b) => b.id).join(', ')}`,
+    );
+  }
+  const [backfill] = matches;
+  if (!backfill) {
+    return { point, backfillId: null, sourceIdentity, desiredIdentity: sourceIdentity };
+  }
+
+  const metrics = { ...point.metrics };
+  for (const key of backfill.set.metricsRemove ?? []) delete metrics[key];
+  Object.assign(metrics, backfill.set.metricsMerge);
+  const offloadMode = backfill.set.offloadMode ?? point.offloadMode;
+  if (backfill.set.offloadMode !== undefined) metrics.offload_mode = offloadMode;
+  const patched = { ...point, offloadMode, metrics };
+  const desiredIdentity = JSON.stringify([
+    patched.configId,
+    patched.benchmarkType,
+    patched.isl,
+    patched.osl,
+    patched.conc,
+    patched.offloadMode,
+    patched.recipeFingerprint ?? null,
+  ]);
+  return {
+    point: patched,
+    backfillId: backfill.id,
+    sourceIdentity,
+    desiredIdentity,
+  };
+}
+
+/** Fail if two distinct artifact points collapse onto one identity after correction. */
+export function recordBackfilledPointIdentity(
+  seen: Map<string, string>,
+  sourceIdentity: string,
+  desiredIdentity: string,
+): void {
+  const existingSource = seen.get(desiredIdentity);
+  if (existingSource !== undefined && existingSource !== sourceIdentity) {
+    throw new Error(
+      `benchmark point backfill collision: ${existingSource} and ${sourceIdentity} both become ${desiredIdentity}`,
+    );
+  }
+  seen.set(desiredIdentity, sourceIdentity);
+}
 
 /**
  * True when this exact benchmark result is suppressed. When an ingest source

--- a/packages/db/src/ingest-ci-run.ts
+++ b/packages/db/src/ingest-ci-run.ts
@@ -36,7 +36,14 @@ import {
   listRunArtifacts,
 } from './lib/github-artifacts';
 import { createAdminSql, refreshLatestBenchmarks } from './etl/db-utils';
-import { isBenchmarkPointPurged, isRunAttemptPurged } from './etl/run-overrides';
+import {
+  applyBenchmarkPointBackfill,
+  applyChangelogBackfills,
+  isBenchmarkPointPurged,
+  isRunAttemptPurged,
+  recordBackfilledPointIdentity,
+  validateRunBackfills,
+} from './etl/run-overrides';
 import { createSkipTracker } from './etl/skip-tracker';
 import { createConfigCache } from './etl/config-cache';
 import { createWorkflowRunServices } from './etl/workflow-run';
@@ -233,6 +240,7 @@ function findJsonFiles(dir: string): string[] {
 // ── Main ────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  validateRunBackfills();
   const tracker = createSkipTracker();
   const configCache = createConfigCache(sql);
   const { getOrCreateConfig, preloadConfigs } = configCache;
@@ -334,8 +342,16 @@ async function main(): Promise<void> {
       `  No changelog metadata artifact found; using fallback changelog: ${fallbackDescription}`,
     );
   }
-  const appendOnly = hasAppendOnlyFlag(parsedChangelogs);
-  const evalsOnly = hasEvalsOnlyFlag(parsedChangelogs);
+  const { changelogs, backfillIds: changelogBackfillIds } = applyChangelogBackfills(
+    runIdNum,
+    runAttemptNum,
+    parsedChangelogs,
+  );
+  for (const backfillId of changelogBackfillIds) {
+    console.log(`  Applied changelog backfill ${backfillId}`);
+  }
+  const appendOnly = hasAppendOnlyFlag(changelogs);
+  const evalsOnly = hasEvalsOnlyFlag(changelogs);
 
   const workflowRunId = await getOrCreateWorkflowRun({
     githubRunId: runId,
@@ -448,6 +464,7 @@ async function main(): Promise<void> {
     }
 
     const allBmkFiles = [...bmkFiles, ...allBmkDirs.flatMap((d) => findJsonFiles(d))];
+    const seenPointIdentities = new Map<string, string>();
     console.log(`  Found ${allBmkFiles.length} benchmark JSON file(s)`);
 
     for (const [fileIndex, file] of allBmkFiles.entries()) {
@@ -486,30 +503,47 @@ async function main(): Promise<void> {
 
       const toInsert = [];
       for (const row of rows) {
+        let configId: number;
         try {
-          const configId = await getOrCreateConfig(row.config);
-          if (
-            isBenchmarkPointPurged(runIdNum, runAttemptNum, {
-              configId,
-              benchmarkType: row.benchmarkType,
-              isl: row.isl,
-              osl: row.osl,
-              conc: row.conc,
-              offloadMode: row.offloadMode,
-              recipeFingerprint: row.recipeFingerprint,
-            })
-          ) {
-            console.log(
-              `    skipped purged benchmark point: config ${configId}, ${row.benchmarkType}, ` +
-                `isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, offload ${row.offloadMode}, ` +
-                `recipe ${row.recipeFingerprint ?? 'legacy'}`,
-            );
-            continue;
-          }
-          toInsert.push({ ...row, configId });
+          configId = await getOrCreateConfig(row.config);
         } catch (error: any) {
           tracker.recordDbError(`config for ${path.basename(file)}`, error);
+          continue;
         }
+        if (
+          isBenchmarkPointPurged(runIdNum, runAttemptNum, {
+            configId,
+            benchmarkType: row.benchmarkType,
+            isl: row.isl,
+            osl: row.osl,
+            conc: row.conc,
+            offloadMode: row.offloadMode,
+            recipeFingerprint: row.recipeFingerprint,
+          })
+        ) {
+          console.log(
+            `    skipped purged benchmark point: config ${configId}, ${row.benchmarkType}, ` +
+              `isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, offload ${row.offloadMode}, ` +
+              `recipe ${row.recipeFingerprint ?? 'legacy'}`,
+          );
+          continue;
+        }
+        const applied = applyBenchmarkPointBackfill(runIdNum, runAttemptNum, {
+          ...row,
+          configId,
+        });
+        recordBackfilledPointIdentity(
+          seenPointIdentities,
+          applied.sourceIdentity,
+          applied.desiredIdentity,
+        );
+        if (applied.backfillId) {
+          console.log(
+            `    applied benchmark point backfill ${applied.backfillId}: ` +
+              `config ${configId}, conc ${row.conc}`,
+          );
+        }
+        toInsert.push(applied.point);
       }
       console.log(`    rows with resolved configs: ${toInsert.length}`);
 
@@ -865,7 +899,7 @@ async function main(): Promise<void> {
   // ── Ingest changelog (already parsed above for evals-only check) ─────
 
   console.log('\n--- Changelog ---');
-  for (const { baseRef, headRef, entries } of parsedChangelogs) {
+  for (const { baseRef, headRef, entries } of changelogs) {
     try {
       const written = await ingestChangelogEntries(
         sql,

--- a/packages/db/src/ingest-gcs-backup.ts
+++ b/packages/db/src/ingest-gcs-backup.ts
@@ -32,7 +32,14 @@ import path from 'path';
 
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils';
 import { createAdminSql, refreshLatestBenchmarks } from './etl/db-utils';
-import { isBenchmarkPointPurged, PURGED_RUNS } from './etl/run-overrides';
+import {
+  applyBenchmarkPointBackfill,
+  applyChangelogBackfills,
+  isBenchmarkPointPurged,
+  PURGED_RUNS,
+  recordBackfilledPointIdentity,
+  validateRunBackfills,
+} from './etl/run-overrides';
 import { createSkipTracker, type Skips } from './etl/skip-tracker';
 import { GPU_KEYS, parseIslOsl } from './etl/normalizers';
 import { createConfigCache } from './etl/config-cache';
@@ -458,7 +465,11 @@ async function mapWorkflowDir(
     if (entries.length > 0) changelogs.push({ baseRef, headRef, entries });
   }
 
-  const evalsOnly = hasEvalsOnlyFlag(changelogs);
+  const correctedChangelogs = applyChangelogBackfills(githubRunId, ghInfo?.runAttempt, changelogs);
+  for (const backfillId of correctedChangelogs.backfillIds) {
+    warnings.push(`  [${dateDir}] applied changelog backfill ${backfillId}`);
+  }
+  const evalsOnly = hasEvalsOnlyFlag(correctedChangelogs.changelogs);
   if (evalsOnly) {
     console.log(
       `  [${dateDir}] evals-only run ${githubRunId} — skipping ${bmkZips.length} benchmark ZIP(s) and ${statsRows.length} stats row(s)`,
@@ -477,7 +488,7 @@ async function mapWorkflowDir(
     bmkZips: evalsOnly ? [] : bmkZips,
     statsRows: evalsOnly ? [] : statsRows,
     evalRows,
-    changelogs,
+    changelogs: correctedChangelogs.changelogs,
     evalsOnly,
     localSkips: {
       badZip: local.skips.badZip,
@@ -497,6 +508,7 @@ async function mapWorkflowDir(
 // ── Main ──────────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
+  validateRunBackfills();
   console.log('=== db:ingest:gcs ===');
   console.log(
     'This will ingest all GCS backup ZIP artifacts into the database.\n' +
@@ -610,33 +622,51 @@ async function main(): Promise<void> {
     if (workflowRunId === null) return wr;
 
     const allInserted: (BenchmarkParams & { configId: number })[] = [];
+    const seenPointIdentities = new Map<string, string>();
     for (const { zipFile, rows, serverLogPath } of result.bmkZips) {
       const toInsert: (BenchmarkParams & { configId: number })[] = [];
       for (const row of rows) {
+        let configId: number;
         try {
-          const configId = await getOrCreateConfig(row.config);
-          if (
-            isBenchmarkPointPurged(result.githubRunId, result.ghInfo?.runAttempt, {
-              configId,
-              benchmarkType: row.benchmarkType,
-              isl: row.isl,
-              osl: row.osl,
-              conc: row.conc,
-              offloadMode: row.offloadMode,
-              recipeFingerprint: row.recipeFingerprint,
-            })
-          ) {
-            console.log(
-              `  [${result.dateDir}] skipped purged benchmark point: config ${configId}, ` +
-                `${row.benchmarkType}, isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, ` +
-                `offload ${row.offloadMode}, recipe ${row.recipeFingerprint ?? 'legacy'}`,
-            );
-            continue;
-          }
-          toInsert.push({ ...row, configId });
+          configId = await getOrCreateConfig(row.config);
         } catch (error: any) {
           tracker.recordDbError(`config for ${zipFile}`, error);
+          continue;
         }
+        if (
+          isBenchmarkPointPurged(result.githubRunId, result.ghInfo?.runAttempt, {
+            configId,
+            benchmarkType: row.benchmarkType,
+            isl: row.isl,
+            osl: row.osl,
+            conc: row.conc,
+            offloadMode: row.offloadMode,
+            recipeFingerprint: row.recipeFingerprint,
+          })
+        ) {
+          console.log(
+            `  [${result.dateDir}] skipped purged benchmark point: config ${configId}, ` +
+              `${row.benchmarkType}, isl ${row.isl}, osl ${row.osl}, conc ${row.conc}, ` +
+              `offload ${row.offloadMode}, recipe ${row.recipeFingerprint ?? 'legacy'}`,
+          );
+          continue;
+        }
+        const applied = applyBenchmarkPointBackfill(result.githubRunId, result.ghInfo?.runAttempt, {
+          ...row,
+          configId,
+        });
+        recordBackfilledPointIdentity(
+          seenPointIdentities,
+          applied.sourceIdentity,
+          applied.desiredIdentity,
+        );
+        if (applied.backfillId) {
+          console.log(
+            `  [${result.dateDir}] applied benchmark point backfill ` +
+              `${applied.backfillId}: config ${configId}, conc ${row.conc}`,
+          );
+        }
+        toInsert.push(applied.point);
       }
       if (toInsert.length > 0) {
         try {


### PR DESCRIPTION
## Summary

- add declarative, source-controlled changelog and benchmark-point backfill registries beside the existing run purge registries
- require stable IDs, explicit reasons, exact natural-key selectors, and validated partial patches
- preview, confirm, apply, and verify corrections through `admin:db:apply-overrides`, with fail-closed handling for missing rows and identity collisions
- enforce corrections during CI and GCS ingestion so re-ingesting an artifact cannot restore the original metadata
- document the operator workflow and add coverage for validation, offload/metric correction, changelog correction, and collision detection

## Why

Exceptional metadata fixes previously required ad hoc SQL or a new ingest. That made intent harder to review and allowed later idempotent ingests to overwrite the correction. This gives metadata changes the same durable, reviewable path as run and point purges.

## Operational behavior

`CHANGELOG_BACKFILLS` targets one `(githubRunId, runAttempt, baseRef, headRef)` row and can patch config keys, description, PR link, or append-only status. Append-only changes update both the changelog and workflow-run values.

`BENCHMARK_POINT_BACKFILLS` targets the complete benchmark natural key and can shallow-merge/remove metrics or change offload mode. Offload changes keep the first-class column and `metrics.offload_mode` synchronized. Ingest tracks pre- and post-correction identities across the whole run and aborts instead of collapsing two distinct points.

The production override workflow continues to invalidate and warm caches after applying a merged registry entry.

## Validation

- `bun run test:unit` — 3,954 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run security` — no vulnerabilities found

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stored benchmark offload identity and metrics in production via the same override path as purges; mistakes could mislabel curves, but validation, verification, and collision checks are fail-closed.
> 
> **Overview**
> Adds **reviewed, source-controlled metadata corrections** alongside existing purge registries in `run-overrides.ts`, so exceptional fixes no longer rely on ad hoc SQL or get undone by idempotent re-ingest.
> 
> **`CHANGELOG_BACKFILLS`** and **`BENCHMARK_POINT_BACKFILLS`** entries require stable IDs, reasons, exact natural-key selectors, and validated partial patches. Benchmark backfills can shallow-merge/remove metrics and flip **`offloadMode`**, keeping the column and **`metrics.offload_mode`** in sync. **`admin:db:apply-overrides`** now previews, applies, verifies backfills, and refreshes **`latest_benchmarks`**.
> 
> CI and GCS ingest call the same logic **before** benchmark/changelog writes, track pre/post identities per run, and **fail** if two artifact rows would collapse onto one corrected point. This PR registers **13 AgentX point backfills** across three runs to mark Mooncake/native host KV offload that recipes enabled but artifacts reported as non-offloaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836ead783818909f797b68a1cc5e35c421d9a5d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->