### PR TITLE
feat(nav): surface Datasets in primary navigation

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -105,9 +105,26 @@ describe('Header', () => {
     cy.get('[data-testid="nav-link-compare"]').should('have.attr', 'href', '/compare');
   });
 
+  it('shows Datasets as a top-level nav link and highlights dataset child pages', () => {
+    cy.get('[data-testid="nav-link-datasets"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/datasets');
+
+    mountHeader('/datasets/claude-code-traces');
+    cy.get('[data-testid="nav-link-datasets"]').should('have.class', 'text-brand');
+  });
+
+  it('keeps Datasets in the Chinese navigation tree', () => {
+    mountHeader('/zh/datasets');
+    cy.get('[data-testid="nav-link-datasets"]')
+      .should('be.visible')
+      .and('contain.text', '数据集')
+      .and('have.attr', 'href', '/zh/datasets')
+      .and('have.class', 'text-brand');
+  });
+
   it('keeps footer destinations out of the primary nav', () => {
     cy.get('[data-testid="nav-link-supporters"]').should('not.exist');
-    cy.get('[data-testid="nav-link-datasets"]').should('not.exist');
     cy.get('[data-testid="nav-link-blog"]').should('not.exist');
   });
 
@@ -134,8 +151,8 @@ describe('Header', () => {
       cy.contains('a', 'Overview').should('be.visible').and('have.attr', 'href', '/overview');
       cy.contains('a', 'Dashboard').should('be.visible').and('have.attr', 'href', '/inference');
       cy.contains('a', 'Comparisons').should('be.visible').and('have.attr', 'href', '/compare');
+      cy.contains('a', 'Datasets').should('be.visible').and('have.attr', 'href', '/datasets');
       cy.contains('a', 'Supporters').should('not.exist');
-      cy.contains('a', 'Datasets').should('not.exist');
       cy.contains('a', 'Articles').should('not.exist');
     });
   });
@@ -148,6 +165,21 @@ describe('Header', () => {
     cy.wrap(mockRouter.push).should('have.been.calledOnceWith', '/overview');
     cy.tick(250);
     cy.wrap(mockRouter.push).should('have.been.calledTwice');
+  });
+
+  it('keeps every primary link inside the header at the desktop breakpoint', () => {
+    cy.viewport(1024, 720);
+    cy.get('[data-testid="header"]').then(($header) => {
+      const header = $header[0];
+      const bounds = header.getBoundingClientRect();
+      expect(header.scrollWidth, 'header scrollWidth').to.be.at.most(header.clientWidth);
+
+      cy.get('[data-testid^="nav-link-"]:visible').each(($link) => {
+        const rect = $link[0].getBoundingClientRect();
+        expect(rect.left, `${$link.text()} left edge`).to.be.at.least(bounds.left - EPSILON);
+        expect(rect.right, `${$link.text()} right edge`).to.be.at.most(bounds.right + EPSILON);
+      });
+    });
   });
 
   describe('at 320x700', () => {
@@ -205,10 +237,10 @@ describe('Header', () => {
       cy.get('[data-testid="mobile-menu-toggle"]').click();
       cy.get('[data-testid="mobile-menu"]').should('be.visible');
       cy.get('[data-testid="mobile-menu"]').within(() => {
-        ['Home', 'Overview', 'Dashboard', 'Comparisons', 'About'].forEach((label) => {
+        ['Home', 'Overview', 'Dashboard', 'Comparisons', 'Datasets', 'About'].forEach((label) => {
           cy.contains('a', label).should('be.visible');
         });
-        ['Supporters', 'Datasets', 'Articles'].forEach((label) => {
+        ['Supporters', 'Articles'].forEach((label) => {
           cy.contains('a', label).should('not.exist');
         });
       });

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -77,6 +77,11 @@ describe('First-load navigation', () => {
     cy.location('pathname').should('eq', '/compare');
   });
 
+  it('navigates to datasets from the header with one click', () => {
+    cy.get('[data-testid="nav-link-datasets"]').should('have.attr', 'href', '/datasets').click();
+    cy.location('pathname').should('eq', '/datasets');
+  });
+
   it('navigates to overview and the full dashboard from the landing CTAs', () => {
     cy.get('[data-testid="landing-overview-link"]')
       .should('have.attr', 'href', '/overview')

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -27,6 +27,12 @@ describe('Chinese (/zh) pages', () => {
       cy.get('[data-testid="language-toggle"]').should('have.attr', 'href', '/');
     });
 
+    it('header links to the Chinese datasets page', () => {
+      cy.get('[data-testid="nav-link-datasets"]')
+        .should('contain.text', '数据集')
+        .and('have.attr', 'href', '/zh/datasets');
+    });
+
     it('footer renders in Chinese with zh-internal links', () => {
       cy.get('[data-testid="footer-brand-description"]').should('contain.text', '开源推理基准测试');
       cy.get('[data-testid="footer-link-supporters"]')

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -49,6 +49,12 @@ const NAV_LINKS = [
     testId: 'nav-link-compare',
     event: 'header_compare_clicked',
   },
+  {
+    href: '/datasets',
+    label: 'Datasets',
+    testId: 'nav-link-datasets',
+    event: 'header_datasets_clicked',
+  },
   { href: '/about', label: 'About', testId: 'nav-link-about', event: 'header_about_clicked' },
 ] as const;
 

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -143,6 +143,7 @@ export const NAV_LABELS_ZH: Record<string, string> = {
   '/overview': '总览',
   '/inference': '仪表板',
   '/compare': 'Chip 对比',
+  '/datasets': '数据集',
   '/about': '关于',
 };
 


### PR DESCRIPTION
## Summary

- surface the existing Agentic Datasets page in the primary site header
- keep the destination visible in both desktop and mobile navigation
- localize the Chinese header entry and route it to `/zh/datasets`
- preserve active styling across dataset detail routes
- track clicks with `header_datasets_clicked`

## User impact

Agentic trace datasets and their methodology are now directly discoverable from every page instead of requiring a footer link or direct URL.

## Validation

- `bun run build` with `E2E_FIXTURES=1`
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `vitest run src/lib/tab-meta-zh.test.ts` (28 assertions)
- Cypress component: `header.cy.tsx` (23 tests)
- Cypress integration: `navigation.cy.ts`, `zh-pages.cy.ts` (24 tests)

## Merge order

Independent; no dependency on another PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and localization changes only; no auth, data, or core inference logic touched.
> 
> **Overview**
> **Datasets** moves from footer-only discovery into the **primary header** on desktop and mobile, with clicks tracked via `header_datasets_clicked`.
> 
> On `/zh` routes the nav shows **数据集**, links to `/zh/datasets`, and stays active on dataset detail paths (e.g. `/datasets/claude-code-traces`) through the existing child-path active logic. Cypress coverage was updated so Datasets is expected in primary nav and footer-only assertions were removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e80554d5277d7586e70144102ff3b9b14d9bfb5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->