### PR TITLE
feat(marketing): surface AgentX across site copy

### DIFF
--- a/packages/app/content/blog/ultra-high-interactivity-on-nvidia.mdx
+++ b/packages/app/content/blog/ultra-high-interactivity-on-nvidia.mdx
@@ -3,6 +3,7 @@ title: 'Ultra-High Interactivity on NVIDIA GPUs? TileRT on InferenceX'
 subtitle: 'Can TileRT software on NVIDIA GPUs compete with Cerebras, Groq LPU, and SambaNova? Batch size 1, disaggregated engine, high-throughput prefill engine, high-interactivity decode engine'
 date: '2026-08-10'
 publishDate: '2026-08-10'
+modifiedDate: '2026-08-18'
 tags:
   - benchmark
   - gpu
@@ -13,6 +14,8 @@ tags:
   - tilert
   - vllm
   - glm5
+  - agentx
+  - agentic
 ---
 
 _Originally published on the [SemiAnalysis newsletter](https://newsletter.semianalysis.com/p/ultra-high-interactivity-on-nvidia) on August 10, 2026._
@@ -235,9 +238,9 @@ Work is being done to simplify this, especially as software development can be a
 
 AI coding agents accelerate tuning within known templates, but novel transformations still require expert judgment. A monolithic persistent kernel also reduces the usefulness of conventional per-kernel profiler timelines, making automated feedback loops more difficult.
 
-## Next steps with TileRT and InferenceX
+## Next steps with TileRT
 
-We are actively working on moving TileRT benchmarking from InferenceX's single-turn 8k/1k to our new agentic coding benchmark, which we call AgentX. This scenario replays real Claude Code and Codex traces with long-context, multi-turn requests, realistic subagent activity, and dynamic tool-use delays. Its median input length is 140k tokens, while the theoretical median cache-hit rate roofline reaches 99.2%.
+AgentX, InferenceX's agentic coding benchmark, is now live for supported models and serving stacks. It replays privacy-preserving workload shapes derived from real Claude Code and Codex sessions, with long-context, multi-turn requests, realistic subagent activity, and dynamic tool-use delays. Its median input length is 140k tokens, while the theoretical median cache-hit rate roofline reaches 99.2%. Extending TileRT benchmarking from its current single-turn 8k/1k workload to AgentX remains the next step for this serving stack.
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/agentx-benchmark-characteristics.png"
@@ -245,7 +248,7 @@ We are actively working on moving TileRT benchmarking from InferenceX's single-t
   caption="Source: SemiAnalysis"
 />
 
-This workload will test the entire TileRT and vLLM system, not just decode speed, including incremental KV transfer, prefix-cache reuse, cache retention and offloading, routing, and scheduling. The critical question is whether TileRT can transfer only the newly introduced context between turns while preserving its ultra-high interactivity advantage.
+For TileRT, this workload will test the entire TileRT and vLLM system, not just decode speed, including incremental KV transfer, prefix-cache reuse, cache retention and offloading, routing, and scheduling. The critical question is whether TileRT can transfer only the newly introduced context between turns while preserving its ultra-high interactivity advantage.
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/multi-turn-thinking.png"

--- a/packages/app/content/blog/ultra-high-interactivity-on-nvidia.mdx
+++ b/packages/app/content/blog/ultra-high-interactivity-on-nvidia.mdx
@@ -240,7 +240,7 @@ AI coding agents accelerate tuning within known templates, but novel transformat
 
 ## Next steps with TileRT
 
-AgentX, InferenceX's agentic coding benchmark, is now live for supported models and serving stacks. It replays privacy-preserving workload shapes derived from real Claude Code and Codex sessions, with long-context, multi-turn requests, realistic subagent activity, and dynamic tool-use delays. Its median input length is 140k tokens, while the theoretical median cache-hit rate roofline reaches 99.2%. Extending TileRT benchmarking from its current single-turn 8k/1k workload to AgentX remains the next step for this serving stack.
+AgentX, InferenceX's long-context, multi-turn coding scenario, is now live for supported models and serving stacks. It replays privacy-preserving workload shapes derived from real Claude Code and Codex sessions, with long-context, multi-turn requests, realistic subagent activity, and dynamic tool-use delays. Its median input length is 140k tokens, while the theoretical median cache-hit rate roofline reaches 99.2%. Extending TileRT benchmarking from its current single-turn 8k/1k workload to AgentX remains the next step for this serving stack.
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/agentx-benchmark-characteristics.png"
@@ -248,7 +248,7 @@ AgentX, InferenceX's agentic coding benchmark, is now live for supported models 
   caption="Source: SemiAnalysis"
 />
 
-For TileRT, this workload will test the entire TileRT and vLLM system, not just decode speed, including incremental KV transfer, prefix-cache reuse, cache retention and offloading, routing, and scheduling. The critical question is whether TileRT can transfer only the newly introduced context between turns while preserving its ultra-high interactivity advantage.
+This workload will test the entire TileRT and vLLM system, not just decode speed, including incremental KV transfer, prefix-cache reuse, cache retention and offloading, routing, and scheduling. The critical question is whether TileRT can transfer only the newly introduced context between turns while preserving its ultra-high interactivity advantage.
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/multi-turn-thinking.png"

--- a/packages/app/content/blog/zh/ultra-high-interactivity-on-nvidia.mdx
+++ b/packages/app/content/blog/zh/ultra-high-interactivity-on-nvidia.mdx
@@ -3,6 +3,7 @@ title: '在 NVIDIA GPU 上实现超高交互性？TileRT 登陆 InferenceX'
 subtitle: '运行在 NVIDIA GPU 上的 TileRT 软件能否与 Cerebras、Groq LPU、SambaNova 竞争？批大小为 1、分离式引擎、高吞吐量预填充引擎、高交互性解码引擎'
 date: '2026-08-10'
 publishDate: '2026-08-10'
+modifiedDate: '2026-08-18'
 tags:
   - benchmark
   - gpu
@@ -13,6 +14,8 @@ tags:
   - tilert
   - vllm
   - glm5
+  - agentx
+  - agentic
 ---
 
 _本文最初于 2026 年 8 月 10 日发布在 [SemiAnalysis 通讯](https://newsletter.semianalysis.com/p/ultra-high-interactivity-on-nvidia)。_
@@ -235,9 +238,9 @@ TileRT 继承了 ASIC 厂商最大的弱点。静态提前编译意味着模型�
 
 AI 编码智能体能在已知模板内加速调优，但新颖的变换仍需专家判断。此外，单体式持久化 kernel 也削弱了传统逐 kernel 性能剖析时间线的作用，使自动化反馈闭环更加困难。
 
-## TileRT 与 InferenceX 的下一步
+## TileRT 的下一步
 
-我们正在积极推进，将 TileRT 的基准测试从 InferenceX 的单轮 8k/1k 场景扩展到我们新的智能体编码基准——AgentX。该场景回放真实的 Claude Code 与 Codex 轨迹，包含长上下文、多轮请求、真实的子智能体活动与动态工具调用延迟。其输入长度中位数为 140k tokens，理论缓存命中率中位数屋顶线可达 99.2%。
+InferenceX 的智能体编码基准 AgentX 现已在具备对应数据的模型与服务栈上正式上线。它回放从真实 Claude Code 与 Codex 会话衍生出的隐私保护工作负载形态，包含长上下文、多轮请求、真实的 subagent 活动与动态工具调用延迟。其输入长度中位数为 140k tokens，理论缓存命中率中位数屋顶线可达 99.2%。对 TileRT 而言，下一步仍是将目前的单轮 8k/1k 基准测试扩展到 AgentX。
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/agentx-benchmark-characteristics.png"
@@ -245,7 +248,7 @@ AI 编码智能体能在已知模板内加速调优，但新颖的变换仍需�
   caption="来源：SemiAnalysis"
 />
 
-该工作负载将检验 TileRT 与 vLLM 的整套系统，而不仅是解码速度，涵盖增量 KV 传输、前缀缓存复用、缓存保留与卸载、路由与调度。关键问题在于：TileRT 能否在轮次之间只传输新增上下文，同时保持其超高交互性优势。
+对 TileRT 而言，该工作负载将检验 TileRT 与 vLLM 的整套系统，而不仅是解码速度，涵盖增量 KV 传输、prefix cache 复用、cache 保留与卸载、路由与调度。关键问题在于：TileRT 能否在轮次之间只传输新增上下文，同时保持其超高交互性优势。
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/multi-turn-thinking.png"

--- a/packages/app/content/blog/zh/ultra-high-interactivity-on-nvidia.mdx
+++ b/packages/app/content/blog/zh/ultra-high-interactivity-on-nvidia.mdx
@@ -240,7 +240,7 @@ AI 编码智能体能在已知模板内加速调优，但新颖的变换仍需�
 
 ## TileRT 的下一步
 
-InferenceX 的智能体编码基准 AgentX 现已在具备对应数据的模型与服务栈上正式上线。它回放从真实 Claude Code 与 Codex 会话衍生出的隐私保护工作负载形态，包含长上下文、多轮请求、真实的 subagent 活动与动态工具调用延迟。其输入长度中位数为 140k tokens，理论缓存命中率中位数屋顶线可达 99.2%。对 TileRT 而言，下一步仍是将目前的单轮 8k/1k 基准测试扩展到 AgentX。
+InferenceX 的长上下文多轮编码场景 AgentX 现已在具备对应数据的模型与服务栈上正式上线。它回放从真实 Claude Code 与 Codex 会话衍生出的隐私保护工作负载形态，包含长上下文、多轮请求、真实的 subagent 活动与动态工具调用延迟。其输入长度中位数为 140k tokens，理论缓存命中率中位数屋顶线可达 99.2%。对 TileRT 而言，下一步仍是将目前的单轮 8k/1k 基准测试扩展到 AgentX。
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/agentx-benchmark-characteristics.png"
@@ -248,7 +248,7 @@ InferenceX 的智能体编码基准 AgentX 现已在具备对应数据的模型�
   caption="来源：SemiAnalysis"
 />
 
-对 TileRT 而言，该工作负载将检验 TileRT 与 vLLM 的整套系统，而不仅是解码速度，涵盖增量 KV 传输、prefix cache 复用、cache 保留与卸载、路由与调度。关键问题在于：TileRT 能否在轮次之间只传输新增上下文，同时保持其超高交互性优势。
+该工作负载将检验 TileRT 与 vLLM 的整套系统，而不仅是解码速度，涵盖增量 KV 传输、前缀缓存复用、缓存保留与卸载、路由与调度。关键问题在于：TileRT 能否在轮次之间只传输新增上下文，同时保持其超高交互性优势。
 
 <Figure
   src="/images/ultra-high-interactivity-on-nvidia/multi-turn-thinking.png"

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -27,8 +27,8 @@ const AGENTX_LABEL_ZH = '长上下文多轮真实智能体场景（AgentX）';
 /** Shared by both locales: the scenario is named after its acronym. */
 const AGENTX_SHORT = 'AgentX';
 
-const PAGE_TITLE = 'Inference Cost per Million Tokens';
-const PAGE_TITLE_ZH = '推理每百万 token 成本';
+const PAGE_TITLE = 'Agentic Inference Costs';
+const PAGE_TITLE_ZH = '智能体推理成本';
 const SOURCE_NOTE = 'Source: InferenceX & SemiAnalysis Market July 2026 AI Cloud TCO Model';
 const SOURCE_LINK_TEXT = 'SemiAnalysis Market July 2026 AI Cloud TCO Model';
 const SOURCE_NOTE_ZH = '来源：InferenceX 与 SemiAnalysis Market July 2026 AI Cloud TCO Model';

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -5,6 +5,7 @@ describe('Chinese (/zh) pages', () => {
     });
 
     it('renders the Chinese landing content', () => {
+      cy.get('[data-testid="intro-section"]').should('contain.text', 'AgentX 智能体');
       cy.contains('h2', '探索 InferenceX').should('exist');
       cy.contains('快速对比').should('exist');
     });
@@ -34,7 +35,10 @@ describe('Chinese (/zh) pages', () => {
     });
 
     it('footer renders in Chinese with zh-internal links', () => {
-      cy.get('[data-testid="footer-brand-description"]').should('contain.text', '开源推理基准测试');
+      cy.get('[data-testid="footer-brand-description"]').should(
+        'contain.text',
+        'AgentX 智能体编码',
+      );
       cy.get('[data-testid="footer-link-supporters"]')
         .should('contain.text', '支持者')
         .and('have.attr', 'href', '/zh/quotes');
@@ -62,7 +66,8 @@ describe('Chinese (/zh) pages', () => {
 
     it('renders the Chinese SEO intro above the chart', () => {
       cy.get('[data-testid="zh-tab-intro"]').within(() => {
-        cy.contains('h1', 'AI 推理基准测试').should('exist');
+        cy.contains('h1', 'AgentX 智能体与 AI 推理基准测试').should('exist');
+        cy.contains('长上下文、多轮').should('exist');
       });
     });
 

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -5,7 +5,7 @@ describe('Chinese (/zh) pages', () => {
     });
 
     it('renders the Chinese landing content', () => {
-      cy.get('[data-testid="intro-section"]').should('contain.text', 'AgentX 智能体');
+      cy.get('[data-testid="intro-section"]').should('contain.text', '智能体推理基准测试');
       cy.contains('h2', '探索 InferenceX').should('exist');
       cy.contains('快速对比').should('exist');
     });
@@ -35,10 +35,7 @@ describe('Chinese (/zh) pages', () => {
     });
 
     it('footer renders in Chinese with zh-internal links', () => {
-      cy.get('[data-testid="footer-brand-description"]').should(
-        'contain.text',
-        'AgentX 智能体编码',
-      );
+      cy.get('[data-testid="footer-brand-description"]').should('contain.text', '智能体推理');
       cy.get('[data-testid="footer-link-supporters"]')
         .should('contain.text', '支持者')
         .and('have.attr', 'href', '/zh/quotes');
@@ -66,7 +63,7 @@ describe('Chinese (/zh) pages', () => {
 
     it('renders the Chinese SEO intro above the chart', () => {
       cy.get('[data-testid="zh-tab-intro"]').within(() => {
-        cy.contains('h1', 'AgentX 智能体与 AI 推理基准测试').should('exist');
+        cy.contains('h1', '智能体推理基准测试').should('exist');
         cy.contains('长上下文、多轮').should('exist');
       });
     });

--- a/packages/app/src/app/about/page.tsx
+++ b/packages/app/src/app/about/page.tsx
@@ -22,7 +22,7 @@ const faqJsonLd = {
 };
 
 const ABOUT_DESCRIPTION =
-  'InferenceX is an independent, vendor-neutral, reproducible benchmark for AgentX long-context, multi-turn agentic coding and fixed-sequence AI inference across accelerators and serving stacks.';
+  'InferenceX benchmarks agentic and fixed-sequence AI inference across accelerators and serving stacks. AgentX is its long-context, multi-turn coding scenario.';
 
 export const metadata: Metadata = {
   title: 'About',
@@ -47,7 +47,7 @@ export default function AboutPage() {
         <section>
           <Card>
             <h2 className="text-lg font-semibold mb-2">
-              Open-Source Continuous AgentX & AI Inference Benchmark Trusted by Operators of
+              Open-Source Continuous Agentic Inference Benchmark Trusted by Operators of
               Trillion-Dollar, GigaWatt-Scale Token Factories
             </h2>
             <p className="text-muted-foreground mb-2">

--- a/packages/app/src/app/about/page.tsx
+++ b/packages/app/src/app/about/page.tsx
@@ -21,21 +21,21 @@ const faqJsonLd = {
   })),
 };
 
+const ABOUT_DESCRIPTION =
+  'InferenceX is an independent, vendor-neutral, reproducible benchmark for AgentX long-context, multi-turn agentic coding and fixed-sequence AI inference across accelerators and serving stacks.';
+
 export const metadata: Metadata = {
   title: 'About',
-  description:
-    'InferenceX is an independent, vendor neutral, reproducible benchmark which continuously benchmarks inference software across a wide range of AI accelerators.',
+  description: ABOUT_DESCRIPTION,
   alternates: enAlternates('/about'),
   openGraph: {
     title: 'About | InferenceX',
-    description:
-      'InferenceX is an independent, vendor neutral, reproducible benchmark which continuously benchmarks inference software across a wide range of AI accelerators.',
+    description: ABOUT_DESCRIPTION,
     url: `${SITE_URL}/about`,
   },
   twitter: {
     title: 'About | InferenceX',
-    description:
-      'InferenceX is an independent, vendor neutral, reproducible benchmark which continuously benchmarks inference software across a wide range of AI accelerators.',
+    description: ABOUT_DESCRIPTION,
   },
 };
 
@@ -47,8 +47,8 @@ export default function AboutPage() {
         <section>
           <Card>
             <h2 className="text-lg font-semibold mb-2">
-              Open Source Continuous Inference Benchmark trusted by Operators of Trillion Dollar
-              GigaWatt Scale Token Factories
+              Open-Source Continuous AgentX & AI Inference Benchmark Trusted by Operators of
+              Trillion-Dollar, GigaWatt-Scale Token Factories
             </h2>
             <p className="text-muted-foreground mb-2">
               As the world progresses exponentially towards AGI, software development and model
@@ -58,9 +58,9 @@ export default function AboutPage() {
             </p>
             <p className="text-muted-foreground mb-2">
               <strong>InferenceX&trade;</strong> (formerly InferenceMAX) is our independent, vendor
-              neutral, reproducible benchmark which addresses these issues by continuously
-              benchmarking inference software across a wide range of AI accelerators that are
-              actually available to the ML community.
+              neutral, reproducible benchmark. It measures both fixed-sequence serving and AgentX,
+              our long-context, multi-turn agentic coding workload, across AI accelerators and
+              serving stacks available to the ML community.
             </p>
             <p className="text-muted-foreground">
               Our open data & insights are widely adopted by the ML community, capacity planning

--- a/packages/app/src/app/blog/page.tsx
+++ b/packages/app/src/app/blog/page.tsx
@@ -11,11 +11,11 @@ import { SITE_URL, SITE_NAME, AUTHOR_NAME } from '@semianalysisai/inferencex-con
 
 export const metadata: Metadata = {
   title: 'Articles',
-  description: `Technical articles from ${SITE_NAME} by ${AUTHOR_NAME} — AgentX and AI inference benchmarking, chip performance analysis, and ML infrastructure insights.`,
+  description: `Technical articles from ${SITE_NAME} by ${AUTHOR_NAME} on agentic inference benchmarks, AgentX results, chip performance, and ML infrastructure.`,
   alternates: enAlternates('/blog'),
   openGraph: {
     title: `Articles | ${SITE_NAME} by ${AUTHOR_NAME}`,
-    description: 'AgentX and AI inference benchmarking insights with chip performance analysis.',
+    description: 'Articles on agentic inference benchmarks, AgentX results, and chip performance.',
     url: `${SITE_URL}/blog`,
   },
 };
@@ -49,7 +49,7 @@ export default async function BlogPage({
           <Card>
             <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">Articles</h2>
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
-              Insights on AgentX and AI inference benchmarking, chip performance, and ML
+              Articles on agentic inference, AgentX results, chip performance, and ML
               infrastructure.
             </p>
             <p className="text-sm text-muted-foreground">

--- a/packages/app/src/app/blog/page.tsx
+++ b/packages/app/src/app/blog/page.tsx
@@ -11,11 +11,11 @@ import { SITE_URL, SITE_NAME, AUTHOR_NAME } from '@semianalysisai/inferencex-con
 
 export const metadata: Metadata = {
   title: 'Articles',
-  description: `Technical articles from ${SITE_NAME} by ${AUTHOR_NAME} — AI inference benchmarking, chip performance analysis, and ML infrastructure insights.`,
+  description: `Technical articles from ${SITE_NAME} by ${AUTHOR_NAME} — AgentX and AI inference benchmarking, chip performance analysis, and ML infrastructure insights.`,
   alternates: enAlternates('/blog'),
   openGraph: {
     title: `Articles | ${SITE_NAME} by ${AUTHOR_NAME}`,
-    description: 'AI inference benchmarking insights and chip performance analysis.',
+    description: 'AgentX and AI inference benchmarking insights with chip performance analysis.',
     url: `${SITE_URL}/blog`,
   },
 };
@@ -49,7 +49,8 @@ export default async function BlogPage({
           <Card>
             <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">Articles</h2>
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
-              Insights on AI inference benchmarking, chip performance, and ML infrastructure.
+              Insights on AgentX and AI inference benchmarking, chip performance, and ML
+              infrastructure.
             </p>
             <p className="text-sm text-muted-foreground">
               New to the terminology?{' '}

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -19,7 +19,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX is the independent, open-source chip inference benchmark from SemiAnalysis, with verified, reproducible nightly results. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
+const DESCRIPTION = `InferenceX is the independent, open-source chip inference benchmark from SemiAnalysis, with verified, reproducible results updated as configurations change. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
 
 export const metadata: Metadata = {
   title: 'Chip Comparisons',

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -54,8 +54,8 @@ export const metadata: Metadata = {
   },
   description: DESCRIPTION,
   keywords: [
-    'AgentX benchmark',
-    'agentic AI benchmark',
+    'AgentX scenario',
+    'agentic inference benchmark',
     'agentic coding benchmark',
     'long context inference benchmark',
     'multi-turn inference benchmark',
@@ -165,7 +165,7 @@ const jsonLd = {
       '@id': `${SITE_URL}/#application`,
       name: SITE_NAME,
       description:
-        'Open-source AI inference benchmark dashboard for AgentX long-context, multi-turn agentic coding and fixed-sequence serving workloads. Compare reproducible chip performance across NVIDIA, AMD, and other accelerators.',
+        'InferenceX is an open-source agentic inference benchmark dashboard. It compares the AgentX long-context, multi-turn coding scenario with fixed-sequence serving across NVIDIA, AMD, and other accelerators.',
       url: SITE_URL,
       applicationCategory: 'DeveloperApplication',
       operatingSystem: 'Web',

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -54,6 +54,11 @@ export const metadata: Metadata = {
   },
   description: DESCRIPTION,
   keywords: [
+    'AgentX benchmark',
+    'agentic AI benchmark',
+    'agentic coding benchmark',
+    'long context inference benchmark',
+    'multi-turn inference benchmark',
     'AI inference benchmark',
     'GPU benchmark',
     'LLM benchmark',
@@ -160,7 +165,7 @@ const jsonLd = {
       '@id': `${SITE_URL}/#application`,
       name: SITE_NAME,
       description:
-        'Open-source AI inference benchmark dashboard. Compare chip performance for LLM inference across NVIDIA GB200, H100, AMD MI355X, and more.',
+        'Open-source AI inference benchmark dashboard for AgentX long-context, multi-turn agentic coding and fixed-sequence serving workloads. Compare reproducible chip performance across NVIDIA, AMD, and other accelerators.',
       url: SITE_URL,
       applicationCategory: 'DeveloperApplication',
       operatingSystem: 'Web',

--- a/packages/app/src/app/llms-full.txt/route.ts
+++ b/packages/app/src/app/llms-full.txt/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
     `# ${SITE_NAME} Articles — Full Content`,
     `> By ${AUTHOR_NAME}`,
     '',
-    `This file contains the full text of all articles from ${SITE_NAME} (${SITE_URL}/blog).`,
+    `This file contains the full text of all articles from ${SITE_NAME} (${SITE_URL}/blog), covering AgentX agentic coding and fixed-sequence AI inference benchmarks, chip performance, and ML infrastructure.`,
     `It is intended for consumption by large language models and AI assistants.`,
     '',
     '---',

--- a/packages/app/src/app/llms-full.txt/route.ts
+++ b/packages/app/src/app/llms-full.txt/route.ts
@@ -28,7 +28,7 @@ export async function GET() {
     `# ${SITE_NAME} Articles — Full Content`,
     `> By ${AUTHOR_NAME}`,
     '',
-    `This file contains the full text of all articles from ${SITE_NAME} (${SITE_URL}/blog), covering AgentX agentic coding and fixed-sequence AI inference benchmarks, chip performance, and ML infrastructure.`,
+    `This file contains the full text of all articles from ${SITE_NAME} (${SITE_URL}/blog), covering agentic inference benchmarks including AgentX results, fixed-sequence AI inference, chip performance, and ML infrastructure.`,
     `It is intended for consumption by large language models and AI assistants.`,
     '',
     '---',

--- a/packages/app/src/app/llms.txt/route.ts
+++ b/packages/app/src/app/llms.txt/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   const lines = [
     `# ${SITE_NAME} by ${AUTHOR_NAME}`,
     '',
-    `> ${SITE_NAME} is the open-source AI inference benchmark dashboard. We compare chip performance for LLM inference across NVIDIA GB200, H100, AMD MI355X, and more.`,
+    `> ${SITE_NAME} is an open-source agentic inference benchmark dashboard. It compares the AgentX long-context, multi-turn coding scenario with fixed-sequence serving across NVIDIA, AMD, and other accelerators using public runs.`,
     '',
     `## Links`,
     '',

--- a/packages/app/src/app/manifest.ts
+++ b/packages/app/src/app/manifest.ts
@@ -7,7 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: `${SITE_NAME} by ${AUTHOR_NAME}`,
     short_name: SITE_NAME,
     description:
-      'Open-source AgentX and AI inference benchmark. Compare agentic and fixed-sequence serving performance across NVIDIA, AMD, and more.',
+      'Open-source agentic inference benchmark. Compare the AgentX scenario and fixed-sequence serving performance across NVIDIA, AMD, and more.',
     start_url: '/',
     display: 'standalone',
     background_color: '#09090b',

--- a/packages/app/src/app/manifest.ts
+++ b/packages/app/src/app/manifest.ts
@@ -7,7 +7,7 @@ export default function manifest(): MetadataRoute.Manifest {
     name: `${SITE_NAME} by ${AUTHOR_NAME}`,
     short_name: SITE_NAME,
     description:
-      'Open-source AI inference benchmark. Compare chip performance across NVIDIA, AMD, and more.',
+      'Open-source AgentX and AI inference benchmark. Compare agentic and fixed-sequence serving performance across NVIDIA, AMD, and more.',
     start_url: '/',
     display: 'standalone',
     background_color: '#09090b',

--- a/packages/app/src/app/overview/page.tsx
+++ b/packages/app/src/app/overview/page.tsx
@@ -18,21 +18,21 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200, and GB300 for both AgentX agentic coding and fixed-sequence scenarios where data is available.';
+  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200, and GB300 for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.';
 
 export const metadata: Metadata = {
-  title: 'AgentX & AI Inference Cost Overview',
+  title: 'Agentic Inference Cost Overview',
   description: DESCRIPTION,
   alternates: enAlternates('/overview'),
   openGraph: {
-    title: `AgentX & AI Inference Cost Overview | ${SITE_NAME}`,
+    title: `Agentic Inference Cost Overview | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/overview`,
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: `AgentX & AI Inference Cost Overview | ${SITE_NAME}`,
+    title: `Agentic Inference Cost Overview | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/app/overview/page.tsx
+++ b/packages/app/src/app/overview/page.tsx
@@ -18,21 +18,21 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200 and GB300 using the scenario shown for each active model.';
+  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200, and GB300 for both AgentX agentic coding and fixed-sequence scenarios where data is available.';
 
 export const metadata: Metadata = {
-  title: 'Inference Cost Overview',
+  title: 'AgentX & AI Inference Cost Overview',
   description: DESCRIPTION,
   alternates: enAlternates('/overview'),
   openGraph: {
-    title: `Inference Cost Overview | ${SITE_NAME}`,
+    title: `AgentX & AI Inference Cost Overview | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/overview`,
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: `Inference Cost Overview | ${SITE_NAME}`,
+    title: `AgentX & AI Inference Cost Overview | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/app/overview/page.tsx
+++ b/packages/app/src/app/overview/page.tsx
@@ -21,18 +21,18 @@ const DESCRIPTION =
   'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200, and GB300 for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.';
 
 export const metadata: Metadata = {
-  title: 'Agentic Inference Cost Overview',
+  title: 'Agentic Inference Costs',
   description: DESCRIPTION,
   alternates: enAlternates('/overview'),
   openGraph: {
-    title: `Agentic Inference Cost Overview | ${SITE_NAME}`,
+    title: `Agentic Inference Costs | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/overview`,
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: `Agentic Inference Cost Overview | ${SITE_NAME}`,
+    title: `Agentic Inference Costs | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/app/zh/about/page.tsx
+++ b/packages/app/src/app/zh/about/page.tsx
@@ -23,7 +23,7 @@ const faqJsonLd = {
 };
 
 const ABOUT_DESCRIPTION =
-  'InferenceX 是一个独立、厂商中立、可复现的基准测试平台，覆盖 AgentX 长上下文多轮智能体编码与固定序列 AI 推理，并对比各类加速器和服务栈。';
+  'InferenceX 对比各类加速器与服务栈的智能体推理和固定序列 AI 推理性能。AgentX 是其长上下文多轮编码场景。';
 
 export const metadata: Metadata = {
   title: '关于',
@@ -49,7 +49,7 @@ export default function AboutPageZh() {
         <section>
           <Card>
             <h2 className="text-lg font-semibold mb-2">
-              开源持续 AgentX 智能体与 AI 推理基准测试——受万亿美元级吉瓦规模 Token 工厂运营者的信赖
+              开源持续智能体推理基准测试——受万亿美元级吉瓦规模 Token 工厂运营者的信赖
             </h2>
             <p className="text-muted-foreground mb-2">
               随着世界以指数级速度迈向
@@ -57,9 +57,8 @@ export default function AboutPageZh() {
             </p>
             <p className="text-muted-foreground mb-2">
               <strong>InferenceX&trade;</strong>（原名
-              InferenceMAX）是我们独立、厂商中立、可复现的基准测试平台。它既测试固定序列推理服务，也测试
-              AgentX——我们的长上下文多轮智能体编码工作负载，并覆盖 ML 社区实际可用的各类 AI
-              加速器与服务栈。
+              InferenceMAX）是我们独立、厂商中立、可复现的基准测试平台。它测试固定序列推理服务和
+              AgentX 长上下文多轮智能体编码工作负载，覆盖 ML 社区实际可用的各类 AI 加速器与服务栈。
             </p>
             <p className="text-muted-foreground">
               我们的开放数据与洞察已被 ML 社区广泛采用，包括万亿美元级 Token 工厂和 AI

--- a/packages/app/src/app/zh/about/page.tsx
+++ b/packages/app/src/app/zh/about/page.tsx
@@ -22,22 +22,22 @@ const faqJsonLd = {
   })),
 };
 
+const ABOUT_DESCRIPTION =
+  'InferenceX 是一个独立、厂商中立、可复现的基准测试平台，覆盖 AgentX 长上下文多轮智能体编码与固定序列 AI 推理，并对比各类加速器和服务栈。';
+
 export const metadata: Metadata = {
   title: '关于',
-  description:
-    'InferenceX 是一个独立、厂商中立、可复现的基准测试平台，持续测试各类 AI 加速器上的推理软件性能。',
+  description: ABOUT_DESCRIPTION,
   alternates: zhAlternates('/about'),
   openGraph: {
     title: '关于 | InferenceX',
-    description:
-      'InferenceX 是一个独立、厂商中立、可复现的基准测试平台，持续测试各类 AI 加速器上的推理软件性能。',
+    description: ABOUT_DESCRIPTION,
     url: `${SITE_URL}/zh/about`,
     locale: ZH_OG_LOCALE,
   },
   twitter: {
     title: '关于 | InferenceX',
-    description:
-      'InferenceX 是一个独立、厂商中立、可复现的基准测试平台，持续测试各类 AI 加速器上的推理软件性能。',
+    description: ABOUT_DESCRIPTION,
   },
 };
 
@@ -49,7 +49,7 @@ export default function AboutPageZh() {
         <section>
           <Card>
             <h2 className="text-lg font-semibold mb-2">
-              开源持续推理基准测试——受万亿美元级吉瓦规模 Token 工厂运营者的信赖
+              开源持续 AgentX 智能体与 AI 推理基准测试——受万亿美元级吉瓦规模 Token 工厂运营者的信赖
             </h2>
             <p className="text-muted-foreground mb-2">
               随着世界以指数级速度迈向
@@ -57,8 +57,9 @@ export default function AboutPageZh() {
             </p>
             <p className="text-muted-foreground mb-2">
               <strong>InferenceX&trade;</strong>（原名
-              InferenceMAX）是我们独立、厂商中立、可复现的基准测试平台，通过持续测试实际可用于 ML
-              社区的各类 AI 加速器上的推理软件来解决这些问题。
+              InferenceMAX）是我们独立、厂商中立、可复现的基准测试平台。它既测试固定序列推理服务，也测试
+              AgentX——我们的长上下文多轮智能体编码工作负载，并覆盖 ML 社区实际可用的各类 AI
+              加速器与服务栈。
             </p>
             <p className="text-muted-foreground">
               我们的开放数据与洞察已被 ML 社区广泛采用，包括万亿美元级 Token 工厂和 AI

--- a/packages/app/src/app/zh/blog/page.tsx
+++ b/packages/app/src/app/zh/blog/page.tsx
@@ -11,11 +11,11 @@ import { SITE_URL, SITE_NAME, AUTHOR_NAME } from '@semianalysisai/inferencex-con
 
 export const metadata: Metadata = {
   title: '文章',
-  description: `${SITE_NAME} by ${AUTHOR_NAME} 的技术文章——AgentX 与 AI 推理基准测试、Chip 性能分析及 ML 基础设施洞见。`,
+  description: `${SITE_NAME} by ${AUTHOR_NAME} 发布关于智能体推理基准测试、AgentX 结果、Chip 性能与 ML 基础设施的技术文章。`,
   alternates: zhAlternates('/blog'),
   openGraph: {
     title: `文章 | ${SITE_NAME} by ${AUTHOR_NAME}`,
-    description: 'AgentX 与 AI 推理基准测试洞见及 Chip 性能分析。',
+    description: '关于智能体推理基准测试、AgentX 结果与 Chip 性能的文章。',
     url: `${SITE_URL}/zh/blog`,
     locale: ZH_OG_LOCALE,
   },
@@ -51,7 +51,7 @@ export default async function ZhBlogPage({
           <Card>
             <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">文章</h2>
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
-              关于 AgentX 与 AI 推理基准测试、Chip 性能及 ML 基础设施的深度洞见。
+              关于智能体推理、AgentX 结果、Chip 性能与 ML 基础设施的文章。
             </p>
             <p className="text-sm text-muted-foreground">
               不熟悉相关概念？{' '}

--- a/packages/app/src/app/zh/blog/page.tsx
+++ b/packages/app/src/app/zh/blog/page.tsx
@@ -11,11 +11,11 @@ import { SITE_URL, SITE_NAME, AUTHOR_NAME } from '@semianalysisai/inferencex-con
 
 export const metadata: Metadata = {
   title: '文章',
-  description: `${SITE_NAME} by ${AUTHOR_NAME} 的技术文章——AI 推理基准测试、Chip 性能分析与 ML 基础设施洞见。`,
+  description: `${SITE_NAME} by ${AUTHOR_NAME} 的技术文章——AgentX 与 AI 推理基准测试、Chip 性能分析及 ML 基础设施洞见。`,
   alternates: zhAlternates('/blog'),
   openGraph: {
     title: `文章 | ${SITE_NAME} by ${AUTHOR_NAME}`,
-    description: 'AI 推理基准测试洞见与 Chip 性能分析。',
+    description: 'AgentX 与 AI 推理基准测试洞见及 Chip 性能分析。',
     url: `${SITE_URL}/zh/blog`,
     locale: ZH_OG_LOCALE,
   },
@@ -51,7 +51,7 @@ export default async function ZhBlogPage({
           <Card>
             <h2 className="text-2xl lg:text-4xl font-bold tracking-tight">文章</h2>
             <p className="mt-3 text-base lg:text-lg text-muted-foreground">
-              关于 AI 推理基准测试、Chip 性能与 ML 基础设施的深度洞见。
+              关于 AgentX 与 AI 推理基准测试、Chip 性能及 ML 基础设施的深度洞见。
             </p>
             <p className="text-sm text-muted-foreground">
               不熟悉相关概念？{' '}

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -18,7 +18,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX 是 SemiAnalysis 推出的独立开源 Chip 推理基准测试平台，提供经过验证的、可复现的每夜测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5、Qwen 3.5 等模型的延迟、吞吐量与成本。`;
+const DESCRIPTION = `InferenceX 是 SemiAnalysis 推出的独立开源 Chip 推理基准测试平台，提供经过验证、可复现并随配置变化更新的测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5、Qwen 3.5 等模型的延迟、吞吐量与成本。`;
 
 export const metadata: Metadata = {
   title: 'Chip 对比',

--- a/packages/app/src/app/zh/overview/page.tsx
+++ b/packages/app/src/app/zh/overview/page.tsx
@@ -18,14 +18,14 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  '按各活跃模型标注的场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
+  '在具备对应数据的模型上，分别按 AgentX 智能体编码与固定序列场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
 
 export const metadata: Metadata = {
-  title: '推理成本总览',
+  title: 'AgentX 与 AI 推理成本总览',
   description: DESCRIPTION,
   alternates: zhAlternates('/overview'),
   openGraph: {
-    title: `推理成本总览 | ${SITE_NAME}`,
+    title: `AgentX 与 AI 推理成本总览 | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/zh/overview`,
     type: 'website',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: `推理成本总览 | ${SITE_NAME}`,
+    title: `AgentX 与 AI 推理成本总览 | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/app/zh/overview/page.tsx
+++ b/packages/app/src/app/zh/overview/page.tsx
@@ -21,11 +21,11 @@ const DESCRIPTION =
   '在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
 
 export const metadata: Metadata = {
-  title: '智能体推理成本总览',
+  title: '智能体推理成本',
   description: DESCRIPTION,
   alternates: zhAlternates('/overview'),
   openGraph: {
-    title: `智能体推理成本总览 | ${SITE_NAME}`,
+    title: `智能体推理成本 | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/zh/overview`,
     type: 'website',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: `智能体推理成本总览 | ${SITE_NAME}`,
+    title: `智能体推理成本 | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/app/zh/overview/page.tsx
+++ b/packages/app/src/app/zh/overview/page.tsx
@@ -18,14 +18,14 @@ import { getOverviewPageData } from '@/lib/overview-data.server';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  '在具备对应数据的模型上，分别按 AgentX 智能体编码与固定序列场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
+  '在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
 
 export const metadata: Metadata = {
-  title: 'AgentX 与 AI 推理成本总览',
+  title: '智能体推理成本总览',
   description: DESCRIPTION,
   alternates: zhAlternates('/overview'),
   openGraph: {
-    title: `AgentX 与 AI 推理成本总览 | ${SITE_NAME}`,
+    title: `智能体推理成本总览 | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/zh/overview`,
     type: 'website',
@@ -33,7 +33,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: `AgentX 与 AI 推理成本总览 | ${SITE_NAME}`,
+    title: `智能体推理成本总览 | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };

--- a/packages/app/src/components/about/faq-data-zh.ts
+++ b/packages/app/src/components/about/faq-data-zh.ts
@@ -39,7 +39,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
   {
     question: '什么是 InferenceX？',
     answer:
-      'InferenceX（原名 InferenceMAX）是一个开源、厂商中立的基准测试（benchmark）平台，持续衡量各类 Chip 和软件栈的 AI 推理性能。每当配置发生变化时，基准测试会重新运行，确保结果始终跟随模型和框架的演进保持最新。',
+      'InferenceX（原名 InferenceMAX）是一个开源、厂商中立的基准测试平台，持续衡量各类 Chip 和软件栈在固定序列与 AgentX 智能体编码工作负载下的 AI 推理性能。每当配置发生变化时，基准测试会重新运行，确保结果始终跟随模型和框架的演进保持最新。',
   },
   {
     question: 'InferenceX 由谁开发？',
@@ -52,7 +52,8 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
   },
   {
     question: '测试了哪些 AI 模型？',
-    answer: '每个模型均在多种序列长度配置（1k/1k、1k/8k、8k/1k tokens）和并发级别下进行测试。',
+    answer:
+      '各模型会在其已有数据所覆盖的固定序列配置（1k/1k、1k/8k、8k/1k tokens）与多个并发级别下进行测试。具备对应数据的模型还包含 AgentX 长上下文多轮智能体编码运行。',
     list: modelNames,
   },
   {
@@ -76,6 +77,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
       '每 Chip 输入和输出吞吐量',
       '每兆瓦 token 吞吐量（tok/s/MW）',
       'P99 首 token 延迟（TTFT）',
+      'AgentX 端到端延迟、token 间延迟（ITL）、输出吞吐量、prefix cache 行为以及会话与 subagent 执行情况',
       '每百万 token 成本（总计、输入、输出）——涵盖超大规模云、NeoCoud 和裸机租赁定价',
       '每 token 能耗（焦耳，总计、输入、输出）',
       '用户自定义成本和功耗计算',
@@ -97,7 +99,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
   {
     question: 'InferenceX 与其他 AI 基准测试有何不同？',
     answer:
-      '大多数 AI 基准测试是静态的、单时间点测量，参与者提交的是专为基准测试定制的镜像，无法反映真实的线上推理性能。InferenceX 在真实硬件上持续运行，采用完全可复现的配置。所有测试脚本均提交至代码仓库，基准测试日志在 GitHub Actions 上公开可见，结果端到端可审计。',
+      '大多数 AI 基准测试是静态的、单时间点测量，参与者提交的是专为基准测试定制的镜像，无法反映真实的线上推理性能。InferenceX 在真实硬件上运行可复现的固定序列与 AgentX 智能体编码工作负载。所有测试脚本均提交至代码仓库，基准测试日志在 GitHub Actions 上公开可见，结果端到端可审计。',
   },
   {
     question: '结果如何实现可复现？',

--- a/packages/app/src/components/about/faq-data-zh.ts
+++ b/packages/app/src/components/about/faq-data-zh.ts
@@ -39,7 +39,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
   {
     question: '什么是 InferenceX？',
     answer:
-      'InferenceX（原名 InferenceMAX）是一个开源、厂商中立的基准测试平台，持续衡量各类 Chip 和软件栈在固定序列与 AgentX 智能体编码工作负载下的 AI 推理性能。每当配置发生变化时，基准测试会重新运行，确保结果始终跟随模型和框架的演进保持最新。',
+      'InferenceX（原名 InferenceMAX）持续衡量各类 Chip 和软件栈的智能体推理与固定序列推理性能。AgentX 是其长上下文多轮编码场景。配置发生变化时，基准测试会重新运行。',
   },
   {
     question: 'InferenceX 由谁开发？',
@@ -77,7 +77,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
       '每 Chip 输入和输出吞吐量',
       '每兆瓦 token 吞吐量（tok/s/MW）',
       'P99 首 token 延迟（TTFT）',
-      'AgentX 端到端延迟、token 间延迟（ITL）、输出吞吐量、prefix cache 行为以及会话与 subagent 执行情况',
+      'AgentX 场景的端到端延迟、token 间延迟（ITL）、输出吞吐量、prefix cache 行为以及会话与 subagent 执行情况',
       '每百万 token 成本（总计、输入、输出）——涵盖超大规模云、NeoCoud 和裸机租赁定价',
       '每 token 能耗（焦耳，总计、输入、输出）',
       '用户自定义成本和功耗计算',
@@ -99,7 +99,7 @@ export const FAQ_ITEMS_ZH: FaqItem[] = [
   {
     question: 'InferenceX 与其他 AI 基准测试有何不同？',
     answer:
-      '大多数 AI 基准测试是静态的、单时间点测量，参与者提交的是专为基准测试定制的镜像，无法反映真实的线上推理性能。InferenceX 在真实硬件上运行可复现的固定序列与 AgentX 智能体编码工作负载。所有测试脚本均提交至代码仓库，基准测试日志在 GitHub Actions 上公开可见，结果端到端可审计。',
+      'InferenceX 在真实硬件上运行固定序列工作负载与 AgentX 长上下文多轮编码场景。测试配方保存在代码仓库中，每项结果均链接至对应的 GitHub Actions 运行。',
   },
   {
     question: '结果如何实现可复现？',

--- a/packages/app/src/components/about/faq-data.ts
+++ b/packages/app/src/components/about/faq-data.ts
@@ -54,7 +54,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'What is InferenceX?',
     answer:
-      'InferenceX (formerly InferenceMAX) is an open-source, vendor-neutral benchmark that continuously measures AI inference performance across chips and software stacks. Benchmarks re-run whenever a configuration changes, so results stay current as models and frameworks evolve.',
+      'InferenceX (formerly InferenceMAX) is an open-source, vendor-neutral benchmark that continuously measures fixed-sequence and AgentX agentic coding inference performance across chips and software stacks. Benchmarks re-run whenever a configuration changes, so results stay current as models and frameworks evolve.',
   },
   {
     question: 'Who is behind InferenceX?',
@@ -68,7 +68,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Which AI models are tested?',
     answer:
-      'Each model is tested across multiple sequence length configurations (1k/1k, 1k/8k, 8k/1k tokens) and concurrency levels.',
+      'Models are tested across the fixed-sequence configurations available for them (1k/1k, 1k/8k, and 8k/1k tokens) and multiple concurrency levels. Supported models with corresponding data also include AgentX long-context, multi-turn agentic coding runs.',
     list: modelNames,
   },
   {
@@ -92,6 +92,7 @@ export const FAQ_ITEMS: FaqItem[] = [
       'Input and output throughput per chip',
       'Token throughput per MW (tok/s/MW)',
       'P99 time to first token (TTFT)',
+      'AgentX end-to-end latency, ITL, output throughput, prefix-cache behavior, and session/subagent execution',
       'Cost per million tokens (total, input, output) across hyperscaler, neocloud, and rental pricing',
       'Joules per token (total, input, output)',
       'Custom user-defined cost and power calculations',
@@ -113,7 +114,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'How is InferenceX different from other AI benchmarks?',
     answer:
-      'Most AI benchmarks are static, point-in-time measurements where participants submit purpose-built images that do not reflect real-world serving performance. InferenceX runs continuously on real hardware with fully reproducible configurations. Every recipe is in the repo, benchmark logs are visible on GitHub Actions, and all results are auditable end-to-end.',
+      'Most AI benchmarks are static, point-in-time measurements where participants submit purpose-built images that do not reflect real-world serving performance. InferenceX runs reproducible fixed-sequence and AgentX agentic coding workloads on real hardware. Every recipe is in the repo, benchmark logs are visible on GitHub Actions, and all results are auditable end-to-end.',
   },
   {
     question: 'How are results reproducible?',

--- a/packages/app/src/components/about/faq-data.ts
+++ b/packages/app/src/components/about/faq-data.ts
@@ -54,7 +54,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'What is InferenceX?',
     answer:
-      'InferenceX (formerly InferenceMAX) is an open-source, vendor-neutral benchmark that continuously measures fixed-sequence and AgentX agentic coding inference performance across chips and software stacks. Benchmarks re-run whenever a configuration changes, so results stay current as models and frameworks evolve.',
+      'InferenceX (formerly InferenceMAX) continuously measures agentic and fixed-sequence inference performance across chips and software stacks. AgentX is its long-context, multi-turn coding scenario. Runs repeat whenever a configuration changes.',
   },
   {
     question: 'Who is behind InferenceX?',
@@ -92,7 +92,7 @@ export const FAQ_ITEMS: FaqItem[] = [
       'Input and output throughput per chip',
       'Token throughput per MW (tok/s/MW)',
       'P99 time to first token (TTFT)',
-      'AgentX end-to-end latency, ITL, output throughput, prefix-cache behavior, and session/subagent execution',
+      'For AgentX: end-to-end latency, ITL, output throughput, prefix-cache behavior, and session/subagent execution',
       'Cost per million tokens (total, input, output) across hyperscaler, neocloud, and rental pricing',
       'Joules per token (total, input, output)',
       'Custom user-defined cost and power calculations',
@@ -114,7 +114,7 @@ export const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'How is InferenceX different from other AI benchmarks?',
     answer:
-      'Most AI benchmarks are static, point-in-time measurements where participants submit purpose-built images that do not reflect real-world serving performance. InferenceX runs reproducible fixed-sequence and AgentX agentic coding workloads on real hardware. Every recipe is in the repo, benchmark logs are visible on GitHub Actions, and all results are auditable end-to-end.',
+      'InferenceX runs fixed-sequence workloads and the AgentX long-context, multi-turn coding scenario on real hardware. Test recipes are in the repository, and each result links to its GitHub Actions run.',
   },
   {
     question: 'How are results reproducible?',

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -12,7 +12,7 @@ import { StarButton } from './footer-star-cta';
 const STRINGS = {
   en: {
     description:
-      'Continuous open-source benchmarking for AgentX agentic coding and fixed-sequence AI inference. Reproducible, auditable performance data trusted by leading AI infrastructure operators.',
+      'InferenceX continuously benchmarks agentic and fixed-sequence AI inference, including AgentX results. Each result links to its public run.',
     semianalysis: 'SemiAnalysis',
     mainSite: 'Main Site',
     newsletter: 'Newsletter',
@@ -40,7 +40,7 @@ const STRINGS = {
   },
   zh: {
     description:
-      '持续开源测试 AgentX 智能体编码与固定序列 AI 推理。性能数据可复现、可审计，获得领先 AI 基础设施运营方的信赖。',
+      'InferenceX 持续开展智能体推理与固定序列 AI 推理基准测试，并提供 AgentX 结果。每项结果均链接至对应的公开运行。',
     semianalysis: 'SemiAnalysis',
     mainSite: '官方网站',
     newsletter: '订阅通讯',

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -12,7 +12,7 @@ import { StarButton } from './footer-star-cta';
 const STRINGS = {
   en: {
     description:
-      'Continuous open-source inference benchmarking. Real-world, reproducible, auditable performance data trusted by trillion dollar AI infrastructure operators like OpenAI, Meta, Oracle, Microsoft, etc.',
+      'Continuous open-source benchmarking for AgentX agentic coding and fixed-sequence AI inference. Reproducible, auditable performance data trusted by leading AI infrastructure operators.',
     semianalysis: 'SemiAnalysis',
     mainSite: 'Main Site',
     newsletter: 'Newsletter',
@@ -40,7 +40,7 @@ const STRINGS = {
   },
   zh: {
     description:
-      '持续的开源推理基准测试。真实、可复现、可审计的性能数据，获得 OpenAI、Meta、Oracle、Microsoft 等万亿美元级 AI 基础设施运营方的信赖。',
+      '持续开源测试 AgentX 智能体编码与固定序列 AI 推理。性能数据可复现、可审计，获得领先 AI 基础设施运营方的信赖。',
     semianalysis: 'SemiAnalysis',
     mainSite: '官方网站',
     newsletter: '订阅通讯',

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -82,7 +82,7 @@ const STRINGS = {
   en: {
     inferencePerformance: 'Inference Performance',
     inferencePerformanceDesc:
-      'Inference performance metrics across different models, hardware configurations, and serving parameters.',
+      'AgentX agentic coding and fixed-sequence inference metrics across models, hardware configurations, and serving parameters.',
     chart: 'Chart',
     table: 'Table',
     sourceUnofficial: 'Source: UNOFFICIAL',
@@ -98,7 +98,8 @@ const STRINGS = {
   },
   zh: {
     inferencePerformance: '推理性能',
-    inferencePerformanceDesc: '不同模型、硬件配置和服务参数下的推理性能指标。',
+    inferencePerformanceDesc:
+      '不同模型、硬件配置和服务参数下的 AgentX 智能体编码与固定序列推理性能指标。',
     chart: '图表',
     table: '表格',
     sourceUnofficial: '来源：非官方',

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -82,7 +82,7 @@ const STRINGS = {
   en: {
     inferencePerformance: 'Inference Performance',
     inferencePerformanceDesc:
-      'AgentX agentic coding and fixed-sequence inference metrics across models, hardware configurations, and serving parameters.',
+      'Agentic inference metrics from the AgentX scenario and fixed-sequence inference metrics across models, hardware configurations, and serving parameters.',
     chart: 'Chart',
     table: 'Table',
     sourceUnofficial: 'Source: UNOFFICIAL',
@@ -99,7 +99,7 @@ const STRINGS = {
   zh: {
     inferencePerformance: '推理性能',
     inferencePerformanceDesc:
-      '不同模型、硬件配置和服务参数下的 AgentX 智能体编码与固定序列推理性能指标。',
+      '不同模型、硬件配置和服务参数下，来自 AgentX 场景的智能体推理指标与固定序列推理指标。',
     chart: '图表',
     table: '表格',
     sourceUnofficial: '来源：非官方',

--- a/packages/app/src/components/intro-section.tsx
+++ b/packages/app/src/components/intro-section.tsx
@@ -14,8 +14,8 @@ const CAROUSEL_OVERRIDES = {
 };
 
 const HEADING = {
-  en: 'Open Source Continuous Inference Benchmark Trusted by GigaWatt Token Factories',
-  zh: '受吉瓦级 token 工厂信赖的开源持续推理基准测试',
+  en: 'Open-Source Continuous AgentX & AI Inference Benchmark Trusted by GigaWatt Token Factories',
+  zh: '受吉瓦级 token 工厂信赖的开源持续 AgentX 智能体与 AI 推理基准测试',
 } as const;
 
 export function IntroSection({ locale = 'en' }: { locale?: Locale } = {}) {

--- a/packages/app/src/components/intro-section.tsx
+++ b/packages/app/src/components/intro-section.tsx
@@ -14,8 +14,8 @@ const CAROUSEL_OVERRIDES = {
 };
 
 const HEADING = {
-  en: 'Open-Source Continuous AgentX & AI Inference Benchmark Trusted by GigaWatt Token Factories',
-  zh: '受吉瓦级 token 工厂信赖的开源持续 AgentX 智能体与 AI 推理基准测试',
+  en: 'Open-Source Continuous Agentic Inference Benchmark Trusted by GigaWatt Token Factories',
+  zh: '受吉瓦级 token 工厂信赖的开源持续智能体推理基准测试',
 } as const;
 
 export function IntroSection({ locale = 'en' }: { locale?: Locale } = {}) {

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -13,10 +13,10 @@ const STRINGS = {
   en: {
     exploreInferenceX: 'Explore InferenceX',
     exploreInferenceXLead:
-      'Start with a concise cost overview across active models and key platforms, or open the full dashboard for every model, chip, framework, and metric.',
+      'Start with a concise cost overview spanning AgentX and fixed-sequence workloads, or open the full dashboard for every available model, chip, framework, and metric.',
     fullDashboard: 'Full Dashboard',
     platformCoverage:
-      'Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X, MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7 Ironwood, etc across DeepSeekv4 Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.',
+      'AgentX replays long-context, multi-turn agentic coding workloads with shared prefixes, pauses, and subagent activity. Results are available wherever supported data exists, alongside the fixed-sequence benchmarks across NVIDIA and AMD platforms.',
     overview: 'Overview',
     reproTitle: 'Every Result Is Transparently done through Public GitHub Actions Automation',
     reproP1:
@@ -42,10 +42,10 @@ const STRINGS = {
   zh: {
     exploreInferenceX: '探索 InferenceX',
     exploreInferenceXLead:
-      '先查看活跃模型与关键平台的精简成本总览，或打开完整仪表板，探索所有模型、Chip、框架与指标。',
+      '先查看覆盖 AgentX 与固定序列工作负载的精简成本总览，或打开完整仪表板，探索所有已有数据的模型、Chip、框架与指标。',
     fullDashboard: '完整仪表板',
     platformCoverage:
-      '跨 DeepSeekv4 Pro、Qwen、Kimi、GLM、MiniMax、gpt-oss、Llama 等模型，对比 NVIDIA GB300 NVL72、GB200 NVL72、B300、B200、H200、H100、AMD MI355X、MI325X、MI300X，以及即将上线的 VR200 NVL72、AMD MI455X UALoE72、TPUv7 Ironwood 等硬件。',
+      'AgentX 回放具有共享前缀、轮次间停顿与 subagent 活动的长上下文多轮智能体编码工作负载。在具备对应数据的模型与平台上提供 AgentX 结果，并保留覆盖 NVIDIA 与 AMD 平台的固定序列基准测试。',
     overview: '总览',
     reproTitle: '每一条结果都通过公开的 GitHub Actions 自动化流程透明产生',
     reproP1:

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -16,7 +16,7 @@ const STRINGS = {
       'Start with a concise cost overview spanning AgentX and fixed-sequence workloads, or open the full dashboard for every available model, chip, framework, and metric.',
     fullDashboard: 'Full Dashboard',
     platformCoverage:
-      'AgentX replays long-context, multi-turn agentic coding workloads with shared prefixes, pauses, and subagent activity. Results are available wherever supported data exists, alongside the fixed-sequence benchmarks across NVIDIA and AMD platforms.',
+      'AgentX is our long-context, multi-turn coding scenario. It replays workloads with shared prefixes, pauses, and subagent activity wherever supported data exists. Fixed-sequence benchmarks remain available across NVIDIA and AMD platforms.',
     overview: 'Overview',
     reproTitle: 'Every Result Is Transparently done through Public GitHub Actions Automation',
     reproP1:
@@ -45,7 +45,7 @@ const STRINGS = {
       '先查看覆盖 AgentX 与固定序列工作负载的精简成本总览，或打开完整仪表板，探索所有已有数据的模型、Chip、框架与指标。',
     fullDashboard: '完整仪表板',
     platformCoverage:
-      'AgentX 回放具有共享前缀、轮次间停顿与 subagent 活动的长上下文多轮智能体编码工作负载。在具备对应数据的模型与平台上提供 AgentX 结果，并保留覆盖 NVIDIA 与 AMD 平台的固定序列基准测试。',
+      'AgentX 是我们的长上下文多轮编码场景，回放具有共享前缀、轮次间停顿与 subagent 活动的工作负载。在具备对应数据的模型与平台上提供 AgentX 结果，并保留覆盖 NVIDIA 与 AMD 平台的固定序列基准测试。',
     overview: '总览',
     reproTitle: '每一条结果都通过公开的 GitHub Actions 自动化流程透明产生',
     reproP1:

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -42,7 +42,7 @@ export type OverviewLocale = 'en' | 'zh';
 
 export const OVERVIEW_STRINGS = {
   en: {
-    title: 'Inference Cost per Million Tokens',
+    title: 'Agentic Inference Costs',
     // The active tier is not repeated here — the SLO selector below already
     // states it.
     scopeMetric: 'Hyperscaler cost',
@@ -156,7 +156,7 @@ export const OVERVIEW_STRINGS = {
     loadingStatus: 'Loading the selected comparison…',
   },
   zh: {
-    title: '推理每百万 token 成本',
+    title: '智能体推理成本',
     scopeMetric: '超大规模云（hyperscaler）成本',
     scopeDirection: '↓ 越低越好',
     scopeAria: '超大规模云（hyperscaler）每百万总 token 成本，越低越好。',

--- a/packages/app/src/components/share-buttons.tsx
+++ b/packages/app/src/components/share-buttons.tsx
@@ -9,13 +9,13 @@ const SITE_URL = 'https://inferencex.semianalysis.com';
 const STRINGS = {
   en: {
     shareText:
-      'Explore InferenceX — open-source AgentX agentic coding and fixed-sequence AI inference benchmarks with reproducible, continuously updated chip performance data.',
+      'Explore InferenceX: open-source agentic and fixed-sequence AI inference benchmarks, including AgentX results from public chip runs.',
     twitter: 'Share on X (Twitter)',
     linkedin: 'Share on LinkedIn',
   },
   zh: {
     shareText:
-      '探索 InferenceX——开源测试 AgentX 智能体编码与固定序列 AI 推理，提供可复现、持续更新的 Chip 性能数据。',
+      '探索 InferenceX：开源测试智能体推理与固定序列 AI 推理，并提供来自公开 Chip 运行的 AgentX 结果。',
     twitter: '分享到 X（推特）',
     linkedin: '分享到 LinkedIn',
   },

--- a/packages/app/src/components/share-buttons.tsx
+++ b/packages/app/src/components/share-buttons.tsx
@@ -9,13 +9,13 @@ const SITE_URL = 'https://inferencex.semianalysis.com';
 const STRINGS = {
   en: {
     shareText:
-      'Check out InferenceX — open-source ML inference benchmarks comparing chips across real-world workloads. Transparent, up-to-date data for the ML community.',
+      'Explore InferenceX — open-source AgentX agentic coding and fixed-sequence AI inference benchmarks with reproducible, continuously updated chip performance data.',
     twitter: 'Share on X (Twitter)',
     linkedin: 'Share on LinkedIn',
   },
   zh: {
     shareText:
-      '来看 InferenceX——开源 ML 推理基准测试，跨真实工作负载对比 Chip 性能。为 ML 社区提供透明、最新的数据。',
+      '探索 InferenceX——开源测试 AgentX 智能体编码与固定序列 AI 推理，提供可复现、持续更新的 Chip 性能数据。',
     twitter: '分享到 X（推特）',
     linkedin: '分享到 LinkedIn',
   },

--- a/packages/app/src/lib/tab-meta-zh.test.ts
+++ b/packages/app/src/lib/tab-meta-zh.test.ts
@@ -5,6 +5,7 @@ import { SITE_URL } from '@semianalysisai/inferencex-constants';
 import { isValidTab, TAB_META } from './tab-meta';
 import {
   isZhTab,
+  LANDING_META_ZH,
   TAB_INTRO_ZH,
   TAB_LABELS_ZH,
   TAB_META_ZH,
@@ -13,6 +14,16 @@ import {
 } from './tab-meta-zh';
 
 const HAN_REGEX = /\p{Script=Han}/u;
+
+describe('AgentX Chinese positioning', () => {
+  it('mirrors the English AgentX and fixed-sequence scope', () => {
+    expect(LANDING_META_ZH.title).toMatch(/AgentX.*智能体/u);
+    expect(LANDING_META_ZH.description).toMatch(/AgentX.*长上下文多轮智能体编码/u);
+    expect(LANDING_META_ZH.description).toContain('固定序列');
+    expect(TAB_META_ZH.inference.title).toMatch(/AgentX.*智能体/u);
+    expect(TAB_INTRO_ZH.inference).toContain('固定序列');
+  });
+});
 
 describe('ZH_TAB_KEYS', () => {
   it.each(ZH_TAB_KEYS)('mirrors a valid English tab "%s"', (tab) => {

--- a/packages/app/src/lib/tab-meta-zh.test.ts
+++ b/packages/app/src/lib/tab-meta-zh.test.ts
@@ -15,12 +15,15 @@ import {
 
 const HAN_REGEX = /\p{Script=Han}/u;
 
-describe('AgentX Chinese positioning', () => {
-  it('mirrors the English AgentX and fixed-sequence scope', () => {
-    expect(LANDING_META_ZH.title).toMatch(/AgentX.*智能体/u);
-    expect(LANDING_META_ZH.description).toMatch(/AgentX.*长上下文多轮智能体编码/u);
+describe('Chinese agentic inference positioning', () => {
+  it('uses the category name for titles and AgentX for the scenario', () => {
+    expect(LANDING_META_ZH.title).toContain('智能体推理基准测试');
+    expect(LANDING_META_ZH.title).not.toContain('AgentX');
+    expect(LANDING_META_ZH.description).toMatch(/AgentX.*场景/u);
     expect(LANDING_META_ZH.description).toContain('固定序列');
-    expect(TAB_META_ZH.inference.title).toMatch(/AgentX.*智能体/u);
+    expect(TAB_META_ZH.inference.title).toContain('智能体推理基准测试');
+    expect(TAB_META_ZH.inference.title).not.toContain('AgentX');
+    expect(TAB_META_ZH.inference.description).toMatch(/AgentX.*工作负载/u);
     expect(TAB_INTRO_ZH.inference).toContain('固定序列');
   });
 });

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -4,9 +4,9 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 import { ZH_OG_LOCALE, zhAlternates, zhPath } from '@/lib/i18n';
 
 export const LANDING_META_ZH = {
-  title: '开源 AgentX 智能体与 AI 推理基准测试',
+  title: '开源智能体推理基准测试',
   description:
-    '跨 Chip 与推理框架对比 AgentX 长上下文多轮智能体编码和固定序列 AI 推理性能。基于 NVIDIA 与 AMD 硬件的可复现运行，持续更新。',
+    '跨 Chip 与推理框架，对比 AgentX 长上下文多轮编码场景与固定序列 AI 推理。NVIDIA 与 AMD 的公开运行会在配置变更时更新。',
 };
 
 export const ZH_TAB_KEYS = [
@@ -32,9 +32,9 @@ export function isZhTab(tab: string): tab is ZhTabKey {
 
 export const TAB_META_ZH: Record<ZhTabKey, { title: string; description: string }> = {
   inference: {
-    title: 'AgentX 智能体与 AI 推理基准测试',
+    title: '智能体推理基准测试',
     description:
-      '跨 Chip 与推理框架对比 AgentX 智能体编码和固定序列 AI 推理的延迟、吞吐量、成本与首 token 延迟（TTFT）。',
+      '跨 Chip 与推理框架，对比智能体推理和固定序列 AI 推理的延迟、吞吐量、成本与首 token 延迟（TTFT）。AgentX 提供长上下文多轮编码工作负载。',
   },
   evaluation: {
     title: 'LLM 评估结果',
@@ -95,7 +95,7 @@ export const TAB_META_ZH: Record<ZhTabKey, { title: string; description: string 
  */
 export const TAB_INTRO_ZH: Record<ZhTabKey, string> = {
   inference:
-    '本页面展示 InferenceX 的 AgentX 智能体编码与固定序列 AI 推理基准测试结果：跨 Chip、推理框架与模型对比吞吐量（token/s/Chip）、交互性（token/s/用户）、首 token 延迟（TTFT）等指标。AgentX 对公开智能体编码轨迹衍生出的长上下文、多轮、含 subagent 工作负载进行回放；每个数据点都来自公开的 GitHub Actions 工作流，可复现、可审计。',
+    '本页面展示 InferenceX 的智能体推理与固定序列 AI 推理基准测试结果：跨 Chip、推理框架与模型对比吞吐量（token/s/Chip）、交互性（token/s/用户）、首 token 延迟（TTFT）等指标。智能体推理数据来自 AgentX；该场景对公开智能体编码轨迹衍生出的长上下文、多轮、含 subagent 工作负载进行回放。每个数据点都来自公开的 GitHub Actions 工作流，可复现、可审计。',
   evaluation:
     '本页面展示 LLM 评估（evaluation）结果：使用标准化评估集对比各模型与部署配置的准确率，验证推理优化不会损害模型质量。',
   historical:

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -4,9 +4,9 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 import { ZH_OG_LOCALE, zhAlternates, zhPath } from '@/lib/i18n';
 
 export const LANDING_META_ZH = {
-  title: '开源 AI 推理基准测试',
+  title: '开源 AgentX 智能体与 AI 推理基准测试',
   description:
-    '跨 Chip 与推理框架对比 AI 推理性能。基于 NVIDIA GB200、B200、AMD MI355X 等硬件的真实基准测试。免费、开源、持续更新。',
+    '跨 Chip 与推理框架对比 AgentX 长上下文多轮智能体编码和固定序列 AI 推理性能。基于 NVIDIA 与 AMD 硬件的可复现运行，持续更新。',
 };
 
 export const ZH_TAB_KEYS = [
@@ -32,9 +32,9 @@ export function isZhTab(tab: string): tab is ZhTabKey {
 
 export const TAB_META_ZH: Record<ZhTabKey, { title: string; description: string }> = {
   inference: {
-    title: 'AI 推理基准测试',
+    title: 'AgentX 智能体与 AI 推理基准测试',
     description:
-      '跨 Chip 与云服务商对比 AI 推理延迟、吞吐量与首 token 延迟（TTFT）。基于 NVIDIA GB200、H100、AMD MI355X 等硬件的真实基准测试。',
+      '跨 Chip 与推理框架对比 AgentX 智能体编码和固定序列 AI 推理的延迟、吞吐量、成本与首 token 延迟（TTFT）。',
   },
   evaluation: {
     title: 'LLM 评估结果',
@@ -95,7 +95,7 @@ export const TAB_META_ZH: Record<ZhTabKey, { title: string; description: string 
  */
 export const TAB_INTRO_ZH: Record<ZhTabKey, string> = {
   inference:
-    '本页面展示 InferenceX 的 AI 推理基准测试结果：跨 Chip、推理框架与模型对比吞吐量（token/s/Chip）、交互性（token/s/用户）、首 token 延迟（TTFT）等指标。每个数据点都来自公开的 GitHub Actions 工作流，可复现、可审计。',
+    '本页面展示 InferenceX 的 AgentX 智能体编码与固定序列 AI 推理基准测试结果：跨 Chip、推理框架与模型对比吞吐量（token/s/Chip）、交互性（token/s/用户）、首 token 延迟（TTFT）等指标。AgentX 对公开智能体编码轨迹衍生出的长上下文、多轮、含 subagent 工作负载进行回放；每个数据点都来自公开的 GitHub Actions 工作流，可复现、可审计。',
   evaluation:
     '本页面展示 LLM 评估（evaluation）结果：使用标准化评估集对比各模型与部署配置的准确率，验证推理优化不会损害模型质量。',
   historical:

--- a/packages/app/src/lib/tab-meta.test.ts
+++ b/packages/app/src/lib/tab-meta.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
-import { getTabTitle, isValidTab, TAB_META, VALID_TABS } from './tab-meta';
+import { getTabTitle, isValidTab, LANDING_META, TAB_META, VALID_TABS } from './tab-meta';
+
+describe('AgentX positioning', () => {
+  it('describes AgentX without hiding the fixed-sequence benchmark', () => {
+    expect(LANDING_META.title).toContain('AgentX');
+    expect(LANDING_META.description).toMatch(/AgentX.*agentic coding/u);
+    expect(LANDING_META.description).toContain('fixed-sequence');
+    expect(TAB_META.inference.title).toContain('AgentX');
+    expect(TAB_META.inference.description).toContain('fixed-sequence');
+  });
+});
 
 describe('isValidTab', () => {
   it.each(VALID_TABS)('returns true for valid tab "%s"', (tab) => {

--- a/packages/app/src/lib/tab-meta.test.ts
+++ b/packages/app/src/lib/tab-meta.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { getTabTitle, isValidTab, LANDING_META, TAB_META, VALID_TABS } from './tab-meta';
 
-describe('AgentX positioning', () => {
-  it('describes AgentX without hiding the fixed-sequence benchmark', () => {
-    expect(LANDING_META.title).toContain('AgentX');
-    expect(LANDING_META.description).toMatch(/AgentX.*agentic coding/u);
+describe('agentic inference positioning', () => {
+  it('uses agentic inference for the category and AgentX for the scenario', () => {
+    expect(LANDING_META.title).toContain('Agentic Inference Benchmark');
+    expect(LANDING_META.title).not.toContain('AgentX');
+    expect(LANDING_META.description).toMatch(/AgentX.*scenario/u);
     expect(LANDING_META.description).toContain('fixed-sequence');
-    expect(TAB_META.inference.title).toContain('AgentX');
+    expect(TAB_META.inference.title).toContain('Agentic Inference');
+    expect(TAB_META.inference.title).not.toContain('AgentX');
+    expect(TAB_META.inference.description).toMatch(/AgentX.*workload/u);
     expect(TAB_META.inference.description).toContain('fixed-sequence');
   });
 });

--- a/packages/app/src/lib/tab-meta.ts
+++ b/packages/app/src/lib/tab-meta.ts
@@ -4,9 +4,9 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 import { hasZhSibling, languageAlternates } from '@/lib/i18n';
 
 export const LANDING_META = {
-  title: 'Open-Source AgentX & AI Inference Benchmark',
+  title: 'Open-Source Agentic Inference Benchmark',
   description:
-    'Compare AgentX long-context, multi-turn agentic coding and fixed-sequence AI inference across chips and frameworks. Reproducible NVIDIA and AMD benchmark runs, continuously updated.',
+    "Compare AgentX, InferenceX's long-context, multi-turn coding scenario, with fixed-sequence AI inference across chips and frameworks. Public NVIDIA and AMD runs update when configurations change.",
 };
 
 export const VALID_TABS = [
@@ -28,9 +28,9 @@ export type TabKey = (typeof VALID_TABS)[number];
 
 export const TAB_META: Record<TabKey, { title: string; description: string }> = {
   inference: {
-    title: 'AgentX & AI Inference Benchmarks',
+    title: 'Agentic Inference Benchmarks',
     description:
-      'Compare AgentX agentic coding and fixed-sequence AI inference latency, throughput, cost, and time-to-first-token across chips and serving frameworks.',
+      'Compare latency, throughput, cost, and time-to-first-token for agentic and fixed-sequence AI inference across chips and serving frameworks. AgentX supplies the long-context, multi-turn coding workload.',
   },
   evaluation: {
     title: 'LLM Evaluation Results',

--- a/packages/app/src/lib/tab-meta.ts
+++ b/packages/app/src/lib/tab-meta.ts
@@ -4,9 +4,9 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 import { hasZhSibling, languageAlternates } from '@/lib/i18n';
 
 export const LANDING_META = {
-  title: 'Open Source AI Inference Benchmark',
+  title: 'Open-Source AgentX & AI Inference Benchmark',
   description:
-    'Compare AI inference performance across chips and frameworks. Real benchmarks on NVIDIA GB200, B200, AMD MI355X, and more. Free, open-source, continuously updated.',
+    'Compare AgentX long-context, multi-turn agentic coding and fixed-sequence AI inference across chips and frameworks. Reproducible NVIDIA and AMD benchmark runs, continuously updated.',
 };
 
 export const VALID_TABS = [
@@ -28,9 +28,9 @@ export type TabKey = (typeof VALID_TABS)[number];
 
 export const TAB_META: Record<TabKey, { title: string; description: string }> = {
   inference: {
-    title: 'AI Inference Benchmarks',
+    title: 'AgentX & AI Inference Benchmarks',
     description:
-      'Compare AI inference latency, throughput, and time-to-first-token across chips and providers. Real benchmarks on NVIDIA GB200, H100, AMD MI355X, and more.',
+      'Compare AgentX agentic coding and fixed-sequence AI inference latency, throughput, cost, and time-to-first-token across chips and serving frameworks.',
   },
   evaluation: {
     title: 'LLM Evaluation Results',

--- a/packages/constants/src/seo.test.ts
+++ b/packages/constants/src/seo.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { DESCRIPTION, DESCRIPTION_ZH, SITE_TITLE, SITE_TITLE_ZH } from './seo';
+
+describe('site positioning', () => {
+  it('identifies AgentX in English search and social copy', () => {
+    expect(SITE_TITLE).toContain('AgentX');
+    expect(DESCRIPTION).toMatch(/AgentX.*long-context.*multi-turn.*agentic coding/u);
+    expect(DESCRIPTION).toContain('fixed-sequence');
+  });
+
+  it('ships equivalent AgentX positioning in Simplified Chinese', () => {
+    expect(SITE_TITLE_ZH).toMatch(/AgentX.*智能体/u);
+    expect(DESCRIPTION_ZH).toMatch(/AgentX.*长上下文多轮智能体编码/u);
+    expect(DESCRIPTION_ZH).toContain('固定序列');
+  });
+});

--- a/packages/constants/src/seo.test.ts
+++ b/packages/constants/src/seo.test.ts
@@ -3,15 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { DESCRIPTION, DESCRIPTION_ZH, SITE_TITLE, SITE_TITLE_ZH } from './seo';
 
 describe('site positioning', () => {
-  it('identifies AgentX in English search and social copy', () => {
-    expect(SITE_TITLE).toContain('AgentX');
-    expect(DESCRIPTION).toMatch(/AgentX.*long-context.*multi-turn.*agentic coding/u);
+  it('uses agentic inference for the category and AgentX for the scenario in English', () => {
+    expect(SITE_TITLE).toContain('Agentic Inference Benchmark');
+    expect(SITE_TITLE).not.toContain('AgentX');
+    expect(DESCRIPTION).toMatch(/agentic inference benchmark.*AgentX.*scenario/u);
     expect(DESCRIPTION).toContain('fixed-sequence');
   });
 
-  it('ships equivalent AgentX positioning in Simplified Chinese', () => {
-    expect(SITE_TITLE_ZH).toMatch(/AgentX.*智能体/u);
-    expect(DESCRIPTION_ZH).toMatch(/AgentX.*长上下文多轮智能体编码/u);
+  it('mirrors the category and scenario distinction in Simplified Chinese', () => {
+    expect(SITE_TITLE_ZH).toContain('智能体推理基准测试');
+    expect(SITE_TITLE_ZH).not.toContain('AgentX');
+    expect(DESCRIPTION_ZH).toMatch(/智能体推理基准测试.*AgentX.*场景/u);
     expect(DESCRIPTION_ZH).toContain('固定序列');
   });
 });

--- a/packages/constants/src/seo.ts
+++ b/packages/constants/src/seo.ts
@@ -3,9 +3,9 @@ export const SITE_URL = 'https://inferencex.semianalysis.com';
 export const AUTHOR_NAME = 'SemiAnalysis';
 export const AUTHOR_URL = 'https://semianalysis.com';
 export const AUTHOR_HANDLE = '@SemiAnalysis_';
-export const SITE_TITLE = `${SITE_NAME} by ${AUTHOR_NAME} — AgentX & AI Inference Benchmark`;
+export const SITE_TITLE = `${SITE_NAME} by ${AUTHOR_NAME} — Agentic Inference Benchmark`;
 export const DESCRIPTION =
-  'InferenceX is the open-source, vendor-neutral AI inference benchmark for AgentX long-context, multi-turn agentic coding and fixed-sequence serving workloads. Compare reproducible latency, throughput, cost, and efficiency results across NVIDIA, AMD, and other accelerators.';
+  'InferenceX is an open-source agentic inference benchmark. It compares the AgentX long-context, multi-turn coding scenario with fixed-sequence serving on NVIDIA, AMD, and other accelerators.';
 /**
  * Social-proof line woven into page meta descriptions to lift search CTR. The
  * named supporters mirror the published /quotes supporters page so the copy
@@ -21,7 +21,7 @@ export const OG_IMAGE = `${SITE_URL}/og-image.png`;
  * names (InferenceX, SemiAnalysis, GPU SKUs) stay in English per the
  * translation quality bar in AGENTS.md.
  */
-export const SITE_TITLE_ZH = `${SITE_NAME} by ${AUTHOR_NAME} — AgentX 智能体与 AI 推理基准测试`;
+export const SITE_TITLE_ZH = `${SITE_NAME} by ${AUTHOR_NAME} — 智能体推理基准测试`;
 export const DESCRIPTION_ZH =
-  'InferenceX 是开源、厂商中立的 AI 推理基准测试，覆盖 AgentX 长上下文多轮智能体编码与固定序列服务工作负载。基于可复现的公开运行，跨 NVIDIA、AMD 等加速器对比延迟、吞吐量、成本与能效。';
+  'InferenceX 是开源智能体推理基准测试平台，对比 AgentX 长上下文多轮编码场景与固定序列服务在 NVIDIA、AMD 等加速器上的性能。';
 export const SUPPORTERS_LINE_ZH = '获得 OpenAI、Microsoft 与 PyTorch 基金会的支持。';

--- a/packages/constants/src/seo.ts
+++ b/packages/constants/src/seo.ts
@@ -3,9 +3,9 @@ export const SITE_URL = 'https://inferencex.semianalysis.com';
 export const AUTHOR_NAME = 'SemiAnalysis';
 export const AUTHOR_URL = 'https://semianalysis.com';
 export const AUTHOR_HANDLE = '@SemiAnalysis_';
-export const SITE_TITLE = `${SITE_NAME} by ${AUTHOR_NAME} — AI Inference Benchmark`;
+export const SITE_TITLE = `${SITE_NAME} by ${AUTHOR_NAME} — AgentX & AI Inference Benchmark`;
 export const DESCRIPTION =
-  'InferenceX is the open-source AI inference benchmark that matches the rapid pace of modern AI development. Powered by one of the largest open-source chip CI/CD fleets with NVIDIA GB200, AMD MI355X & many more.';
+  'InferenceX is the open-source, vendor-neutral AI inference benchmark for AgentX long-context, multi-turn agentic coding and fixed-sequence serving workloads. Compare reproducible latency, throughput, cost, and efficiency results across NVIDIA, AMD, and other accelerators.';
 /**
  * Social-proof line woven into page meta descriptions to lift search CTR. The
  * named supporters mirror the published /quotes supporters page so the copy
@@ -21,7 +21,7 @@ export const OG_IMAGE = `${SITE_URL}/og-image.png`;
  * names (InferenceX, SemiAnalysis, GPU SKUs) stay in English per the
  * translation quality bar in AGENTS.md.
  */
-export const SITE_TITLE_ZH = `${SITE_NAME} by ${AUTHOR_NAME} — AI 推理基准测试`;
+export const SITE_TITLE_ZH = `${SITE_NAME} by ${AUTHOR_NAME} — AgentX 智能体与 AI 推理基准测试`;
 export const DESCRIPTION_ZH =
-  'InferenceX 是紧跟现代 AI 发展节奏的开源 AI 推理基准测试，由规模领先的开源 Chip CI/CD 集群持续驱动，涵盖 NVIDIA GB200、AMD MI355X 等众多硬件。';
+  'InferenceX 是开源、厂商中立的 AI 推理基准测试，覆盖 AgentX 长上下文多轮智能体编码与固定序列服务工作负载。基于可复现的公开运行，跨 NVIDIA、AMD 等加速器对比延迟、吞吐量、成本与能效。';
 export const SUPPORTERS_LINE_ZH = '获得 OpenAI、Microsoft 与 PyTorch 基金会的支持。';


### PR DESCRIPTION
## Summary

- describe InferenceX as an agentic inference benchmark across headlines, SEO metadata, structured data, the web manifest, sharing text, and LLM discovery feeds
- reserve AgentX for the named long-context, multi-turn coding scenario, its workload, results, metrics, and methodology
- update the landing page, inference dashboard, overview, About/FAQ, article index, and footer with claims limited to supported models and serving stacks
- mirror every affected user-facing and indexable surface in Simplified Chinese
- correct stale copy that described AgentX itself as forthcoming in the TileRT article while keeping TileRT on AgentX as future work
- replace outdated nightly-cadence metadata on /compare with the configuration-triggered update model

## Terminology and copy audit

Generic category copy now uses "agentic inference benchmark" or "agentic inference." AgentX appears only when naming the specific scenario, workload, results, metrics, or methodology.

Changed copy was audited against the indicators in [Wikipedia: Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing). The follow-up removes vague promotional claims, filler such as "insights," broad unsupported comparisons, repeated summary language, and unnecessary em-dash or parenthetical constructions. Concrete workload mechanics, hardware coverage, metrics, and data-availability qualifiers remain.

## Stack

This PR is stacked directly on #755 and targets `agent/agentx-methodology`. The parent branch supplies the canonical `/agentx`, `/zh/agentx`, and methodology routes plus permanent redirects from the former dataset URLs. This PR only updates semantic copy and machine discovery to use those canonical routes. Merge #755 before #756.

## Claim boundaries

This is a semantic copy and SEO change only. It does not add a popup, redesign the interface, change benchmark behavior, or expand the detailed AgentX methodology. AgentX availability remains qualified by supported or available data.

## Validation

Latest stacked verification:

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- metadata contract tests: 63 passing
- overview Cypress spec in Chrome: 35/35 passing
- overview Cypress spec in Firefox: 35/35 passing
- `/agentx`, `/zh/agentx`, `/agentx/methodology`, and `/zh/agentx/methodology`: HTTP 200
- `/datasets` and `/zh/datasets`: permanent redirects to the canonical AgentX pages
- `llms.txt`: canonical AgentX and methodology links verified

Earlier full PR validation:

- `bun run test:unit`: 3,952 passing
- Cypress quick component suite: 25/25 passing
- Cypress quick integration suite: 63/63 passing, including /zh and unofficial-run overlay coverage
- `bun run build`
- `bun run security`