### PR TITLE
docs(glossary): define agentic inference and AgentX terms

### DIFF
--- a/packages/app/src/app/glossary/page.tsx
+++ b/packages/app/src/app/glossary/page.tsx
@@ -11,13 +11,15 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 
 const title = 'AI Inference Glossary';
 const description =
-  'Clear, technically grounded definitions for LLM inference benchmarks, serving metrics, distributed parallelism, numerical precision, chip hardware, and inference software.';
+  'Clear, technically grounded definitions for agentic inference, LLM benchmarks, serving metrics, distributed parallelism, numerical precision, chip hardware, and inference software.';
 
 export const metadata: Metadata = {
   title,
   description,
   keywords: [
     'AI inference glossary',
+    'agentic inference glossary',
+    'AgentX benchmark terms',
     'LLM inference terms',
     'GPU benchmark terminology',
     'inference serving glossary',
@@ -100,9 +102,9 @@ export default function GlossaryPage() {
                   The language behind the inference curve.
                 </h1>
                 <p className="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
-                  Definitions for the metrics, serving techniques, numerical formats, and
-                  distributed systems concepts used across InferenceX. Based on measured behavior,
-                  not vendor peak specifications.
+                  Definitions for agentic inference, benchmark metrics, serving techniques,
+                  numerical formats, and distributed systems concepts used across InferenceX.
+                  Entries describe measured behavior and published benchmark recipes.
                 </p>
               </div>
 
@@ -173,6 +175,9 @@ export default function GlossaryPage() {
               speedups on unchanged chips.
             </p>
             <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/agentx/methodology" className="text-brand hover:underline">
+                AgentX methodology →
+              </Link>
               <Link href="/blog" className="text-brand hover:underline">
                 Browse technical articles →
               </Link>

--- a/packages/app/src/app/zh/glossary/page.tsx
+++ b/packages/app/src/app/zh/glossary/page.tsx
@@ -20,7 +20,7 @@ import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-con
 
 const title = 'AI 推理术语表';
 const description =
-  '清晰、技术严谨的 LLM 推理基准、服务指标、分布式并行、数值精度、Chip 硬件与推理软件术语定义。';
+  '清晰、技术严谨的智能体推理、LLM 基准测试、服务指标、分布式并行、数值精度、Chip 硬件与推理软件术语定义。';
 const browserLabels: GlossaryBrowserLabels = {
   searchLabel: '搜索 AI 推理术语表',
   searchPlaceholder: '搜索 MTP、延迟、FP4…',
@@ -40,7 +40,15 @@ const browserLabels: GlossaryBrowserLabels = {
 export const metadata: Metadata = {
   title,
   description,
-  keywords: ['AI 推理术语表', 'LLM 推理术语', 'GPU 基准术语', '分布式推理', 'LLM 性能指标'],
+  keywords: [
+    'AI 推理术语表',
+    '智能体推理术语',
+    'AgentX 基准测试术语',
+    'LLM 推理术语',
+    'Chip 基准术语',
+    '分布式推理',
+    'LLM 性能指标',
+  ],
   alternates: zhAlternates('/glossary'),
   openGraph: {
     title: `${title} | ${SITE_NAME}`,
@@ -120,8 +128,8 @@ export default function ZhGlossaryPage() {
                   读懂推理曲线背后的语言。
                 </h1>
                 <p className="mt-6 max-w-3xl text-base leading-7 text-muted-foreground md:text-lg md:leading-8">
-                  解释 InferenceX
-                  使用的性能指标、服务技术、数值格式和分布式系统概念。所有定义都来自实测行为，而非厂商峰值规格。
+                  解释 InferenceX 使用的智能体推理、基准指标、服务技术、数值格式与分布式系统概念。
+                  各条目以实测行为和已发布的基准测试方案为依据。
                 </p>
               </div>
 
@@ -193,6 +201,9 @@ export default function ZhGlossaryPage() {
               Wide EP 扩展，以及硬件不变时的软件性能提升。
             </p>
             <div className="mt-5 flex flex-wrap gap-3 text-sm font-medium">
+              <Link href="/zh/agentx/methodology" className="text-brand hover:underline">
+                AgentX 方法说明 →
+              </Link>
               <Link href="/zh/blog" className="text-brand hover:underline">
                 浏览技术文章 →
               </Link>

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -8,6 +8,7 @@ import {
 export const GLOSSARY_CATEGORY_LABELS_ZH: Readonly<Record<GlossaryCategory, string>> = {
   'Benchmark metrics': '基准指标',
   Serving: '推理服务',
+  'Agentic inference': '智能体推理',
   Parallelism: '并行策略',
   Hardware: '硬件',
   'Numerical precision': '数值精度',
@@ -40,6 +41,88 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '推理既是模型问题，也是系统问题。用户体验取决于延迟和交互性，运营成本则取决于吞吐量、利用率、功耗与硬件成本；只优化其中一个维度，往往会牺牲另一个维度。',
     benchmarkContext:
       'InferenceX 测试完整的推理方案，因为芯片峰值规格无法代表实际服务性能。每条曲线都对应明确的模型、引擎、精度、并行策略、Chip 系统、序列长度和并发扫描。',
+  },
+  'agentic-inference': {
+    term: '智能体推理',
+    aliases: ['agentic inference', 'AI 智能体推理', 'agent 推理'],
+    plainEnglish:
+      '智能体会通过多次模型请求完成一项任务，期间可能调用工具、保留会话状态，也可能把部分工作交给 subagent。',
+    definition:
+      '智能体推理是为 AI agent 提供模型服务的过程。此类 agent 会在多个轮次间保留状态、调用工具、复用不断增长的上下文，并可能并行运行 subagent。',
+    explanation:
+      '一次智能体会话会在模型请求、工具执行和等待之间交替。后续请求通常携带大部分历史对话，因此 prefix cache 和 KV cache 容量会直接影响速度与成本。并行 subagent 还会产生各自具有时间关系和上下文增长过程的请求分支。',
+    significance:
+      '固定 input 和 output 长度无法覆盖智能体带来的全部服务压力。长共享前缀会改变 cache 行为，工具等待会让流量呈现突发性，并行分支则会争用推理容量。同一组软硬件在这种请求模式下可能出现不同的性能排序。',
+    benchmarkContext:
+      'InferenceX 使用 AgentX 测量智能体推理。AgentX 与固定序列场景回答不同的容量问题，应分别比较。AgentX 采用闭环会话回放，同一会话中的后续请求会受前一轮完成时间影响。',
+  },
+  agentx: {
+    term: 'AgentX',
+    aliases: ['AgentX 基准测试', 'AgentX 场景'],
+    plainEnglish: 'AgentX 是 InferenceX 用来测试完整长上下文、多轮编码智能体会话的工作负载。',
+    definition:
+      'AgentX 是 InferenceX 的智能体推理基准测试场景，其工作负载形状来自自愿提供的编码智能体轨迹，并在移除原始内容后构建。',
+    explanation:
+      'AgentX 使用确定性合成 token 重建会话结构。回放会保留请求长度、轮次间隔、共享前缀增长、工具等待以及主 agent 与 subagent 的依赖关系；原始提示词、生成代码和工具 payload 不会进入测试数据。推理栈只接收请求模式。',
+    significance:
+      '长上下文考验 KV cache 容量，重复前缀考验 cache 复用，分支时序则考验请求调度。这些影响在短小独立请求中较少出现。最终曲线反映推理系统在智能体流量下的整体表现。',
+    benchmarkContext:
+      '具备对应数据的模型默认显示 Agentic 场景。比较 AgentX 结果时，应使用兼容设置下的其他 AgentX 运行，并同时查看吞吐量、延迟与交互性。固定序列场景适合分析传统请求流。',
+  },
+  'agentic-coding-workload': {
+    term: '智能体编码工作负载',
+    aliases: ['agentic coding workload', '编码智能体工作负载', '软件工程智能体工作负载'],
+    plainEnglish:
+      '编码智能体读取代码仓库、修改代码并运行工具，随后继续请求模型，直到完成任务；这一连串请求就是智能体编码工作负载。',
+    definition:
+      '智能体编码工作负载由软件 agent 产生，包含多轮模型生成、代码仓库检查、工具调用、代码修改以及委派给 subagent 的子任务。',
+    explanation:
+      '随着 agent 累积指令、文件、工具结果和历史回答，请求长度会持续增长。许多轮次会复用较大的共享前缀。工具执行造成不均匀的停顿，subagent 则可能生成时间重叠的请求分支，因此其流量形状与固定长度提示词不同。',
+    significance:
+      '编码智能体可能通过一串相互依赖的调用让推理系统持续工作数分钟甚至数小时。Cache 策略、调度公平性、内存容量和尾延迟都会影响任务进度，仅看峰值 decode 吞吐量无法描述这种体验。',
+    benchmarkContext:
+      'AgentX 使用从轨迹提取的请求形状与确定性合成内容表示该工作负载。它测量推理系统性能。模型能否完成编码任务需要单独做质量评估，因此质量分数与 AgentX 服务结果应分别解读。',
+  },
+  'trace-replay': {
+    term: '轨迹回放',
+    aliases: ['trace replay', '工作负载回放', '会话回放'],
+    plainEnglish:
+      '轨迹回放重现已记录会话的请求大小、先后关系与时间间隔，让基准测试按照原始工作负载的节奏发送请求。',
+    definition:
+      '轨迹回放是一种基准测试方法，它把记录下来的请求关系、长度和时间信息转化为可重复运行的系统工作负载。',
+    explanation:
+      '回放可以保留由主 agent 轮次、并行 subagent 分支和辅助请求组成的有向图。确定性合成 token 会替换私有内容，同时保留 token 数量与前缀关系。轮次间记录的停顿则重现 agent 使用工具或等待依赖项的时间。',
+    significance:
+      '这种方法能够表达独立提示词列表缺少的流量特征，也能使用相同会话形状重复比较不同软硬件。AgentX 会在公开回放数据前移除源会话内容。',
+    benchmarkContext:
+      'AgentX 通过 AIPerf 回放由轨迹衍生的会话。固定 seed 决定会话采样、起点和合成内容。对外结果只统计 cache warmup 后的 profiling 窗口，使多次运行聚焦于稳态服务表现。',
+  },
+  'closed-loop-benchmark': {
+    term: '闭环基准测试',
+    aliases: ['closed-loop benchmark', '闭环负载测试', '闭环工作负载'],
+    plainEnglish:
+      '在闭环基准测试中，每个模拟用户会等待当前步骤完成，再按照该会话的依赖关系发送下一步请求。',
+    definition:
+      '闭环基准测试中的客户端会在前一个依赖请求完成后生成新工作，同时遵循工作负载记录的等待时间和分支结构。',
+    explanation:
+      'Concurrency 表示活跃客户端或会话数量，同时存在的请求数会随时间变化。更快的系统更早完成轮次，因此会在同一个 profiling 窗口内发出更多请求。每条采样会话的推进速度取决于请求完成时间，实际请求组合可能有小幅变化。',
+    significance:
+      '这种负载模型符合交互式 agent 的运行方式，因为下一步动作依赖上一步结果。响应更快时，会话也会更快地产生后续工作，所以吞吐量与延迟相互关联。低并发运行的采样波动通常会比大型请求池更明显。',
+    benchmarkContext:
+      'AgentX 使用闭环 concurrency。该数值表示同时运行的 agent 客户端数量；request batch 会随着会话推进而变化。解读结果时需要结合吞吐量、首 token 延迟与交互性。',
+  },
+  subagent: {
+    term: '子智能体',
+    aliases: ['subagent', 'child agent', '委派智能体'],
+    plainEnglish: '子智能体由主 agent 启动，负责同一任务中的较小部分，并可能与其他工作同时运行。',
+    definition:
+      '子智能体是一次受委派的 agent 执行，拥有独立会话状态和模型请求，并通过任务关系与依赖关系连接到父会话。',
+    explanation:
+      '主 agent 可以启动一个或多个 subagent，稍后再使用它们的结果。Subagent 的请求可能与父会话或其他分支重叠，从而形成会话图中的分支。每个分支可以增长独立上下文，同时复用部分初始指令或代码仓库状态。',
+    significance:
+      'Subagent 会让智能体流量不再完全串行。一个用户任务可能在短时间内产生多条长上下文请求，调度策略会影响各分支的完成速度。系统总吞吐量上升时，单个分支仍可能等待更久。',
+    benchmarkContext:
+      'AgentX 会保留轨迹衍生工作负载中的 subagent 分支及其依赖关系。委派质量不在测试范围内。基准测试测量推理系统如何处理由此产生的并行请求、共享前缀和完成时序。',
   },
   'inference-engine': {
     term: '推理引擎',

--- a/packages/app/src/lib/glossary.test.ts
+++ b/packages/app/src/lib/glossary.test.ts
@@ -55,6 +55,16 @@ describe('glossary content', () => {
     }
   });
 
+  it('defines the AgentX workload and its agentic inference concepts', () => {
+    expect(GLOSSARY_CATEGORIES).toContain('Agentic inference');
+    expect(getGlossaryEntry('agentic-inference')?.category).toBe('Agentic inference');
+    expect(getGlossaryEntry('agentx')?.definition).toContain('agentic inference benchmark');
+    expect(getGlossaryEntry('agentic-coding-workload')?.relatedTerms).toContain('agentx');
+    expect(getGlossaryEntry('trace-replay')?.benchmarkContext).toContain('AIPerf');
+    expect(getGlossaryEntry('closed-loop-benchmark')?.benchmarkContext).toContain('agent clients');
+    expect(getGlossaryEntry('subagent')?.relatedTerms).toContain('trace-replay');
+  });
+
   it('links every glossary source to a real article and covers the complete article library', () => {
     const entries = getAllGlossaryEntries();
     const referencedArticles = new Set(entries.flatMap((entry) => entry.articleSlugs));
@@ -107,6 +117,12 @@ describe('Chinese glossary content', () => {
   });
 
   it('resolves canonical slugs and walks the Chinese term order without gaps', () => {
+    expect(GLOSSARY_CATEGORY_LABELS_ZH['Agentic inference']).toBe('智能体推理');
+    expect(getZhGlossaryEntry('agentic-inference')?.term).toBe('智能体推理');
+    expect(getZhGlossaryEntry('agentx')?.term).toBe('AgentX');
+    expect(getZhGlossaryEntry('trace-replay')?.term).toBe('轨迹回放');
+    expect(getZhGlossaryEntry('closed-loop-benchmark')?.term).toBe('闭环基准测试');
+    expect(getZhGlossaryEntry('subagent')?.term).toBe('子智能体');
     expect(getZhGlossaryEntry('multi-token-prediction')?.term).toBe('多 token 预测');
     expect(getZhGlossaryEntry('not-a-real-term')).toBeUndefined();
 

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -1,6 +1,7 @@
 export const GLOSSARY_CATEGORIES = [
   'Benchmark metrics',
   'Serving',
+  'Agentic inference',
   'Parallelism',
   'Hardware',
   'Numerical precision',
@@ -65,6 +66,126 @@ const entries = [
       'InferenceX benchmarks complete serving recipes because peak chip specifications alone cannot describe serving performance. Each curve captures a model, engine, numerical precision, parallelism strategy, chip system, sequence length, and concurrency sweep.',
     relatedTerms: ['inference-engine', 'prefill', 'decode', 'throughput', 'interactivity'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
+  },
+  {
+    slug: 'agentic-inference',
+    term: 'Agentic inference',
+    aliases: ['AI agent inference', 'agent inference'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'Agentic inference serves an AI system that works through a task over many model requests, often using tools and delegating work along the way.',
+    definition:
+      'Agentic inference is model serving for agents that maintain state across multiple turns, call tools, reuse growing context, and may run subagents in parallel.',
+    explanation:
+      'A single agent session can alternate between model requests, tool execution, and waiting periods. Later requests often include much of the earlier conversation, so prefix caching and KV-cache capacity affect both speed and cost. Parallel subagents add branches with their own request timing and context growth.',
+    significance:
+      'Fixed input and output lengths miss several pressures created by agents. Long shared prefixes change cache behavior, tool delays make traffic bursty, and concurrent branches compete for serving capacity. Hardware and software can rank differently under this request pattern.',
+    benchmarkContext:
+      'InferenceX uses AgentX to measure agentic inference. Read AgentX results alongside fixed-sequence scenarios because they answer different capacity questions. AgentX reports the behavior of a closed-loop session replay instead of treating every request as an independent batch item.',
+    relatedTerms: ['agentx', 'agentic-coding-workload', 'subagent', 'prefix-caching', 'kv-cache'],
+    articleSlugs: [TILERT, VR_RUBIN, INFERENCEX_V2],
+  },
+  {
+    slug: 'agentx',
+    term: 'AgentX',
+    aliases: ['AgentX benchmark', 'AgentX scenario'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'AgentX is the InferenceX workload for testing how inference systems serve complete long-context, multi-turn coding-agent sessions.',
+    definition:
+      'AgentX is InferenceX’s agentic inference benchmark scenario, built from workload shapes derived from opt-in coding-agent traces after original content is removed.',
+    explanation:
+      'AgentX reconstructs session structure with deterministic synthetic tokens. Its replay keeps request lengths, turn timing, shared-prefix growth, tool pauses, and main-agent or subagent dependencies while excluding original prompts, generated code, and tool payloads. The serving stack receives the traffic pattern without receiving the source conversation.',
+    significance:
+      'Long contexts pressure KV-cache capacity, repeated prefixes reward effective cache reuse, and branch timing tests request scheduling. These effects are small or absent in short, independent requests. The resulting curve describes the complete serving system under agent traffic.',
+    benchmarkContext:
+      'The Agentic scenario appears by default for models with matching AgentX data. Compare its throughput, latency, and interactivity only with other AgentX runs at compatible settings. Use fixed-sequence scenarios when the target workload is a conventional request stream.',
+    relatedTerms: [
+      'agentic-inference',
+      'agentic-coding-workload',
+      'trace-replay',
+      'closed-loop-benchmark',
+      'subagent',
+    ],
+    articleSlugs: [TILERT, VR_RUBIN],
+  },
+  {
+    slug: 'agentic-coding-workload',
+    term: 'Agentic coding workload',
+    aliases: ['coding-agent workload', 'software-engineering agent workload'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'This is the request pattern created when a coding agent reads a repository, edits code, runs tools, and revisits the model until the task is done.',
+    definition:
+      'An agentic coding workload is a multi-turn inference workload produced by a software agent that combines model generation with repository inspection, tool calls, code changes, and delegated subtasks.',
+    explanation:
+      'Request sizes grow as the agent accumulates instructions, files, tool results, and earlier responses. Many turns reuse a large common prefix. Tool execution inserts uneven delays, while subagents can create overlapping request branches. These properties produce a different traffic shape from fixed-length prompt benchmarks.',
+    significance:
+      'Coding agents can keep a serving system busy for minutes or hours through a chain of dependent calls. Cache policy, scheduler fairness, memory capacity, and tail latency all affect task progress. Peak decode throughput alone cannot describe that behavior.',
+    benchmarkContext:
+      'AgentX represents this workload with trace-derived request shapes and deterministic synthetic content. It measures inference-system performance. Model coding quality requires a separate evaluation, so quality scores and AgentX serving results answer separate questions.',
+    relatedTerms: ['agentic-inference', 'agentx', 'subagent', 'prefix-caching', 'trace-replay'],
+    articleSlugs: [TILERT, VR_RUBIN, INFERENCEX_V2],
+  },
+  {
+    slug: 'trace-replay',
+    term: 'Trace replay',
+    aliases: ['workload replay', 'session replay'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'Trace replay recreates the timing and shape of recorded sessions so a benchmark sends requests like the original workload.',
+    definition:
+      'Trace replay is a benchmarking method that converts recorded request relationships, lengths, and timing into a repeatable workload for a system under test.',
+    explanation:
+      'A replay can preserve a directed graph of main-agent turns, parallel subagent branches, and auxiliary requests. Deterministic synthetic tokens replace private content while retaining token counts and prefix relationships. Recorded gaps between turns reproduce the periods when an agent was using tools or waiting on dependencies.',
+    significance:
+      'The method captures traffic features that a list of independent prompts cannot express. It also makes repeated hardware and software comparisons possible from the same session shapes. AgentX removes source-conversation content before publishing replay data.',
+    benchmarkContext:
+      'AgentX replays trace-derived sessions through AIPerf. A fixed seed selects sessions, starting points, and synthetic content. Reported results cover the profiling window after cache warmup, which keeps run-to-run comparisons focused on steady-state serving behavior.',
+    relatedTerms: ['agentx', 'closed-loop-benchmark', 'subagent', 'concurrency', 'kv-cache'],
+    articleSlugs: [TILERT, VR_RUBIN],
+  },
+  {
+    slug: 'closed-loop-benchmark',
+    term: 'Closed-loop benchmark',
+    aliases: ['closed-loop load test', 'closed-loop workload'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'In a closed-loop benchmark, each simulated user waits for one step to finish before sending the next step in that session.',
+    definition:
+      'A closed-loop benchmark generates new work from each client in response to completion of its previous dependent request, subject to the workload’s recorded delays and branch structure.',
+    explanation:
+      'Concurrency is the number of active clients or sessions; the simultaneous request count changes over time. Faster systems complete turns sooner and therefore issue more requests during the same profiling period. The exact request mix can vary slightly because progress through each sampled session depends on completion time.',
+    significance:
+      'This load model resembles interactive agents, where the next action depends on the previous result. Throughput and latency remain coupled: a faster response advances the session and creates later work sooner. Low-concurrency runs can show more sampling variation than large pooled runs.',
+    benchmarkContext:
+      'AgentX uses closed-loop concurrency. Its concurrency value is the number of agent clients; request batch size changes as the sessions advance. Read throughput, time to first token, and interactivity together.',
+    relatedTerms: ['agentx', 'trace-replay', 'concurrency', 'throughput', 'latency'],
+    articleSlugs: [TILERT, INFERENCEX_V2],
+  },
+  {
+    slug: 'subagent',
+    term: 'Subagent',
+    aliases: ['child agent', 'delegated agent'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'A subagent is an additional agent started by a main agent to handle a smaller piece of the same task, sometimes at the same time as other work.',
+    definition:
+      'A subagent is a delegated agent execution with its own conversation state and model requests, connected to a parent session through task and dependency relationships.',
+    explanation:
+      'The main agent can launch one or more subagents and later consume their results. Their requests may overlap with the parent or with each other, creating branches in the session graph. Each branch can grow a separate context while sharing some initial instructions or repository state.',
+    significance:
+      'Subagents make agent traffic less sequential. A serving stack may receive bursts of long-context requests from one user task, and scheduler decisions affect how quickly branches finish. Aggregate throughput can rise while an individual branch waits longer for service.',
+    benchmarkContext:
+      'AgentX preserves subagent branches from the trace-derived workload and replays their dependencies. Delegation quality is outside its scope. The benchmark measures how the inference system serves the resulting parallel requests, shared prefixes, and completion timing.',
+    relatedTerms: [
+      'agentic-inference',
+      'agentic-coding-workload',
+      'agentx',
+      'trace-replay',
+      'concurrency',
+    ],
+    articleSlugs: [TILERT, VR_RUBIN],
   },
   {
     slug: 'inference-engine',


### PR DESCRIPTION
## Summary

- Add a first-class `Agentic inference` glossary category.
- Define Agentic inference, AgentX, agentic coding workload, trace replay, closed-loop benchmark, and subagent in concrete serving terms.
- Add complete Simplified Chinese glossary entries and category labels for the existing `/zh` site.
- Update glossary discovery copy and metadata, and link readers to the detailed AgentX methodology.
- Add content-contract coverage for the new terms, translations, relationships, and category.

The new copy was audited against the requested AI-writing field guide. It avoids promotional filler, canned conclusions, vague significance claims, and decorative contrast patterns; definitions stay tied to observable workload and serving behavior.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run security`
- `bun run test:unit` (3,953 tests)
- `E2E_FIXTURES=1 bun run build` (950 static pages, including both glossary languages and the stacked AgentX methodology routes)

## Merge order

This PR is stacked on #755 because the glossary links to `/agentx/methodology`. Merge #755 first, then this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content and documentation only: glossary data, marketing copy, and unit tests. No runtime serving, auth, or data-handling logic changes.
> 
> **Overview**
> Adds a new **`Agentic inference`** glossary category and six English entries—**agentic inference**, **AgentX**, **agentic coding workload**, **trace replay**, **closed-loop benchmark**, and **subagent**—with definitions tied to serving behavior, trace replay, and AgentX methodology.
> 
> **Simplified Chinese** translations and category labels mirror the new terms in `glossary-zh.ts`. English and `/zh` glossary index pages update SEO metadata, hero copy, and add links to **AgentX methodology**.
> 
> **Tests** assert category presence, term relationships, AIPerf/closed-loop benchmark context strings, and Chinese term resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e73dc1819240d7bad02262d7b5afa99826cee01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->