### PR TITLE
fix(db): backfill AgentX KV offload metadata

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -209,7 +209,111 @@ export interface BenchmarkPointBackfill extends BenchmarkPointKey, AuditedBackfi
  *   },
  * }
  */
-export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [];
+export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
+  // The source recipes in run 31633154542 attach MooncakeStoreConnector to
+  // every disaggregated worker and allocate a 180 GB Mooncake segment per
+  // node. The master matrix omitted the corresponding offload annotation.
+  ...(
+    [
+      [2106, 256, null],
+      [2334, 1152, null],
+      [2336, 1024, null],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31633154542-config-${configId}-conc-${conc}-mooncake-offload`,
+    reason:
+      'The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31633154542,
+    runAttempt: 2,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+      },
+    },
+  })),
+
+  // Every TensorRT-LLM recipe in run 31927376673 configures a 128 GiB native
+  // host KV cache on both prefill and decode workers. The master matrix only
+  // declared NIXL transfer, so all six artifacts lost the offload identity.
+  ...(
+    [
+      [2360, 7, '5c282408e21b662cf5afbef0d26a63ad2fb19bb66ca3b431763a1c40628f3036'],
+      [2361, 96, 'da36b834945785abfa06c44f742684db7a96af49542d9012019063d552dc7393'],
+      [2362, 704, '60e4361ec00fd8a94a700b7ae9dbb4d8b6cf4095b1553f098af45551669fcf1f'],
+      [2363, 52, 'd7fccb3572037431f39757640d090ab1204bb27ac57ff0f9f9a635e9cefb5867'],
+      [2364, 565, 'a6017a5c8a675fb4f1f74e49bb0091f172e6ea357a1bb1b2d6577eb661c9f1c5'],
+      [2365, 44, 'ac8406a4d46f3711732aa352c801bbd1eb7c3545b2982c5d2c56520fa8288342'],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31927376673-config-${configId}-conc-${conc}-native-offload`,
+    reason:
+      'The TensorRT-LLM runtime recipe configured a native host KV cache, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31927376673,
+    runAttempt: 1,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'native',
+        kv_offload_backend_version: '1.3.0rc24',
+      },
+    },
+  })),
+
+  // The four disaggregated recipes in run 31965016666 attach
+  // MooncakeStoreConnector to NIXL through MultiConnector and allocate a
+  // 140 GB Mooncake segment per node. The three aggregate points in the same
+  // run do not attach the connector and are intentionally excluded.
+  ...(
+    [
+      [1012, 128, 'b01cb33e392b60b01e2f498ea7300118c6046e074556199a3fe9a7208cf7929e'],
+      [1012, 256, '856babb1e00e524c7eddca689e1345d1a97a41f6743c5d5c109347444581aeef'],
+      [2374, 576, 'd7afa7f01be968e02911263a9792bb1200ca27de702b5e79d7907e6d46adfc44'],
+      [2375, 512, '47a4969f521268bccc1a3efd97a5ceaf231ff33ab13fa6fe3f9cadf48573f2b1'],
+    ] as const
+  ).map(([configId, conc, recipeFingerprint]) => ({
+    id: `run-31965016666-config-${configId}-conc-${conc}-mooncake-offload`,
+    reason:
+      'The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 31965016666,
+    runAttempt: 2,
+    configId,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+      },
+    },
+  })),
+];
 
 function pointIdentity(
   point: BenchmarkPointKey & { githubRunId: number; runAttempt: number },


### PR DESCRIPTION
## Summary

- register audited backfills for 13 AgentX points whose runtime recipes used host-DRAM KV offload but whose artifacts reported `offload_mode=off` and `kv_offloading=none`
- correct 7 Mooncake Store points across runs `31633154542` and `31965016666`
- correct 6 TensorRT-LLM native host-cache points from run `31927376673`
- remove the false `allocated_cpu_dram_gb=0` value instead of inventing a capacity that the artifacts did not record
- preserve existing NIXL peer-to-peer transfer metadata

## Why

The source master-matrix entries declared NIXL where applicable but omitted the separate KV-offload annotation. The runtime recipes still enabled `MooncakeStoreConnector` or TensorRT-LLM `host_cache_size`, so ingestion classified these points as non-offloaded. That collapses materially different memory configurations in AgentX charts and comparisons.

This PR is stacked on #753, which introduces the reviewed and re-ingest-safe benchmark backfill registry.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun --cwd packages/db run test:unit src/etl/run-overrides.test.ts` (19 tests passed)
- read-only `admin:db:apply-overrides` preview against production matched all 13 exact natural-key selectors; the command was aborted before writes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only ETL backfill registry entries with audited selectors and no runtime logic changes; wrong keys would mislabel charts but validation and preview tooling reduce that risk.
> 
> **Overview**
> Registers **13 audited `BENCHMARK_POINT_BACKFILLS`** entries so AgentX points that actually used host-DRAM KV offload are no longer stored as `offload_mode=off` with `kv_offloading=none`.
> 
> **Mooncake Store (7 points):** three disaggregated points from run `31633154542` and four from `31965016666` get `offloadMode: on`, `kv_offload_backend: mooncake`, and version `0.3.11.post1`. Aggregate points in the latter run stay unchanged.
> 
> **TensorRT-LLM native host cache (6 points):** run `31927376673` points get native DRAM offload (`kv_offload_backend: native`, `1.3.0rc24`) matching recipes that set a 128 GiB host KV cache on prefill and decode workers.
> 
> Each backfill targets rows by exact natural key (`githubRunId`, attempt, `configId`, `conc`, `recipeFingerprint`, etc.), flips offload identity, merges KV metrics, and **removes** `allocated_cpu_dram_gb` instead of fabricating capacity. Existing NIXL transfer metadata is left intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 211c96604a5664dc56e29a18589d757ec151b7a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->