### PR TITLE
fix(labels): render Kimi K3 speculative decoding as "DSpark" / 将 Kimi K3 的投机解码显示为 "DSpark"

### DIFF
--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -524,6 +524,21 @@ describe('generateOverlayTooltipContent', () => {
     expect(standardZh).toContain('<strong>投机解码:</strong> 关闭');
   });
 
+  it('labels Kimi-K3 speculative decoding "DSpark" rather than the generic MTP', () => {
+    const html = generateOverlayTooltipContent(
+      overlayConfig({
+        data: pt({
+          benchmark_type: 'agentic_traces',
+          model: 'Kimi-K3',
+          spec_decoding: 'mtp',
+        }),
+      }),
+    );
+
+    expect(html).toContain('<strong>Speculative Decoding:</strong> DSpark');
+    expect(html).not.toContain('<strong>Speculative Decoding:</strong> MTP');
+  });
+
   it('hides stale CPU cache hits for unofficial overlays without offload', () => {
     const html = generateOverlayTooltipContent(
       overlayConfig({

--- a/packages/constants/src/framework-aliases.test.ts
+++ b/packages/constants/src/framework-aliases.test.ts
@@ -31,11 +31,19 @@ describe('MODEL_SPEC_METHOD_LABELS', () => {
   it('maps MiniMax-M3 mtp to "M3 EAGLE"', () => {
     expect(MODEL_SPEC_METHOD_LABELS['MiniMax-M3']?.mtp).toBe('M3 EAGLE');
   });
+
+  it('maps Kimi-K3 mtp to "DSpark"', () => {
+    expect(MODEL_SPEC_METHOD_LABELS['Kimi-K3']?.mtp).toBe('DSpark');
+  });
 });
 
 describe('resolveFrameworkPartLabel', () => {
   it('renders M3 mtp as "M3 EAGLE"', () => {
     expect(resolveFrameworkPartLabel('MiniMax-M3', 'mtp')).toBe('M3 EAGLE');
+  });
+
+  it('renders K3 mtp as "DSpark"', () => {
+    expect(resolveFrameworkPartLabel('Kimi-K3', 'mtp')).toBe('DSpark');
   });
 
   it('keeps the generic MTP label for other models', () => {
@@ -44,6 +52,10 @@ describe('resolveFrameworkPartLabel', () => {
 
   it('keeps the generic MTP label when no model is provided', () => {
     expect(resolveFrameworkPartLabel(undefined, 'mtp')).toBe('MTP');
+  });
+
+  it('keeps the generic MTP label for sibling Kimi models', () => {
+    expect(resolveFrameworkPartLabel('Kimi-K2.5', 'mtp')).toBe('MTP');
   });
 
   it('falls back to FRAMEWORK_LABELS for non-overridden parts even for M3', () => {

--- a/packages/constants/src/framework-aliases.ts
+++ b/packages/constants/src/framework-aliases.ts
@@ -55,12 +55,13 @@ export const FRAMEWORK_LABELS: Record<string, string> = {
  * Per-model display overrides for hwKey suffix parts (framework / spec_method
  * tokens), keyed by frontend display model name → token → label.
  *
- * M3's speculative-decoding runs are ingested under the generic `mtp` token but
- * actually use EAGLE, so for MiniMax-M3 the suffix reads "EAGLE" while every
- * other model keeps the generic "MTP" label.
+ * Some models are ingested under the generic `mtp` token but ship a
+ * differently-named method: M3 uses EAGLE, and K3 uses DSpark. Those models get
+ * their own label while every other model keeps the generic "MTP" label.
  */
 export const MODEL_SPEC_METHOD_LABELS: Record<string, Record<string, string>> = {
   'MiniMax-M3': { mtp: 'M3 EAGLE' },
+  'Kimi-K3': { mtp: 'DSpark' },
 };
 
 /**


### PR DESCRIPTION
## Summary

Kimi K3's speculative-decoding runs are ingested under the generic `mtp` token, so every display surface read **MTP** — including the chart tooltip line in the reported screenshot. K3's method is **DSpark**.

This adds a per-model display override in `MODEL_SPEC_METHOD_LABELS` (`packages/constants/src/framework-aliases.ts`), the same mechanism already used for MiniMax-M3 (`mtp` → `M3 EAGLE`):

```ts
export const MODEL_SPEC_METHOD_LABELS: Record<string, Record<string, string>> = {
  'MiniMax-M3': { mtp: 'M3 EAGLE' },
  'Kimi-K3': { mtp: 'DSpark' },
};
```

Every label surface resolves through `resolveFrameworkPartLabel` / `specMethodDisplayLabel`, so the one-line override fixes all of them at once:

- Inference chart tooltip → `Speculative Decoding: DSpark` (both the official and the `?unofficialrun=` overlay path — they share `generateAgenticHTML`)
- Hardware suffixes / legend labels — `B300 (vLLM, DSpark)` instead of `B300 (vLLM, MTP)` (`getHardwareConfig`)
- Submissions table spec-method cell, evaluation column headers, changelog entries, overview matrix source labels
- Spec-decode comparison pages and their OG images (`/compare-spec-decode/*` and `/zh/compare-spec-decode/*`)

Every other model keeps the generic `MTP` label; `none` still renders as `Off` / `关闭`.

No `/zh` page changes are needed — `DSpark` is a method/product name, which per the translation quality bar stays in English on both language sides (the surrounding label `投机解码` was already translated).

### Note on the earlier E2E failure

The first run of this PR failed `E2E (chrome|firefox, shard 3)` on `overview.cy.ts` (`expected 1012 to be at most 1009`). That was pre-existing master breakage, not this change: the same shards failed on #754 before it merged, and the failure reproduced locally with this branch's label change reverted. The cause was the header's desktop nav overflowing a 1024px viewport. #755 has since moved the desktop nav to the `xl` breakpoint, which resolves it at the root, so after rebasing onto master this branch carries only the label change — `overview.cy.ts` passes locally on the rebased tree (35/35).

### Tests

- `packages/constants/src/framework-aliases.test.ts` — `MODEL_SPEC_METHOD_LABELS['Kimi-K3'].mtp === 'DSpark'`, `resolveFrameworkPartLabel('Kimi-K3', 'mtp') === 'DSpark'`, plus a guard that sibling Kimi models (`Kimi-K2.5`) keep `MTP`
- `packages/app/src/components/inference/utils/tooltip-utils.test.ts` — K3 agentic tooltip renders `Speculative Decoding: DSpark` and no longer contains the generic `MTP` (exercises the overlay tooltip path)

Local on the rebased tree: `typecheck`, `lint`, `fmt`, `test:unit` (app 3427, constants 44), plus `overview.cy.ts` and `navigation.cy.ts` in Chrome against a production build with `E2E_FIXTURES=1` — all green.

## 中文说明

Kimi K3 的运行数据在入库时统一使用通用的 `mtp` 标记，因此所有展示位置都显示为 **MTP**（包括截图中的图表工具提示）。K3 实际使用的方法是 **DSpark**。

改动在 `MODEL_SPEC_METHOD_LABELS`（`packages/constants/src/framework-aliases.ts`）中新增按模型的显示覆盖，复用 MiniMax-M3（`mtp` → `M3 EAGLE`）已有的同一机制。由于所有标签都经由 `resolveFrameworkPartLabel` / `specMethodDisplayLabel` 解析，这一行改动可一次性修正全部展示位置：

- 推理图表工具提示 → `Speculative Decoding: DSpark`（官方数据与 `?unofficialrun=` 叠加两条路径共用 `generateAgenticHTML`，均已覆盖）
- 硬件后缀与图例标签 —— `B300 (vLLM, DSpark)`
- 提交记录表格的投机解码方法列、评估表头、变更日志、总览矩阵的数据来源标签
- 投机解码对比页面及其 OG 图片（`/compare-spec-decode/*` 与 `/zh/compare-spec-decode/*`）

其他模型仍保留通用的 `MTP` 标签，`none` 依然显示为 `Off` / `关闭`。无需改动 `/zh` 页面：按翻译规范，`DSpark` 属于方法名称，中英两侧均保留英文。

### 关于此前的 E2E 失败

本 PR 首次运行时 `E2E (chrome|firefox, shard 3)` 在 `overview.cy.ts` 上失败（`expected 1012 to be at most 1009`），这是 master 上已存在的问题，与本次改动无关：#754 合并前同样的分片就已失败，且在本分支回退标签改动后仍可本地复现。根因是页头桌面导航在 1024px 视口下溢出；#755 已将桌面导航移至 `xl` 断点，从根本上解决了该问题。因此在基于 master 变基后，本分支只保留标签改动，`overview.cy.ts` 在变基后的本地环境中 35/35 通过。

### 测试

新增常量层映射与解析用例（含 `Kimi-K2.5` 仍为 `MTP` 的回归保护），以及工具提示渲染 `DSpark` 的单元测试。变基后本地 `typecheck`、`lint`、`fmt`、`test:unit`（app 3427、constants 44）与相关 Cypress 规格全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)