### PR TITLE
Fix AgentX offload backfill metrics recovery

### DIFF
--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -20,6 +20,7 @@ import { isDeepStrictEqual } from 'node:util';
 
 import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
 import { type Sql, createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
+import { jsonbParam } from './lib/backfill-runner.js';
 import {
   type BenchmarkPointBackfill,
   type ChangelogBackfill,
@@ -183,6 +184,53 @@ async function applyChangelogBackfill(target: ChangelogBackfillTarget): Promise<
 interface BenchmarkPointBackfillTarget {
   backfill: BenchmarkPointBackfill;
   resultId: number;
+  metrics: Record<string, unknown>;
+}
+
+function asMetricsRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function benchmarkPointMetricsPatch(backfill: BenchmarkPointBackfill): Record<string, unknown> {
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  return {
+    ...backfill.set.metricsMerge,
+    ...(backfill.set.offloadMode === undefined ? {} : { offload_mode: desiredOffloadMode }),
+  };
+}
+
+/**
+ * Recognize the exact malformed value written by the first benchmark-point
+ * backfill implementation. It concatenated a metrics object with a JSONB
+ * string, producing `[originalMetrics, "{...patch}"]`.
+ */
+function recoverMalformedBenchmarkPointMetrics(
+  value: unknown,
+  backfill: BenchmarkPointBackfill,
+): Record<string, unknown> | null {
+  if (!Array.isArray(value) || value.length !== 2) return null;
+  const originalMetrics = asMetricsRecord(value[0]);
+  if (!originalMetrics || typeof value[1] !== 'string') return null;
+
+  try {
+    const appendedPatch = JSON.parse(value[1]) as unknown;
+    if (!isDeepStrictEqual(appendedPatch, benchmarkPointMetricsPatch(backfill))) return null;
+  } catch {
+    return null;
+  }
+  return originalMetrics;
+}
+
+function patchedBenchmarkPointMetrics(
+  sourceMetrics: Record<string, unknown>,
+  backfill: BenchmarkPointBackfill,
+): Record<string, unknown> {
+  const metrics = { ...sourceMetrics };
+  for (const key of backfill.set.metricsRemove ?? []) delete metrics[key];
+  Object.assign(metrics, benchmarkPointMetricsPatch(backfill));
+  return metrics;
 }
 
 function benchmarkPointBackfillIsApplied(
@@ -191,7 +239,8 @@ function benchmarkPointBackfillIsApplied(
 ): boolean {
   const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
   if (row.offload_mode !== desiredOffloadMode) return false;
-  const metrics = row.metrics as Record<string, unknown>;
+  const metrics = asMetricsRecord(row.metrics);
+  if (!metrics) return false;
   if (backfill.set.offloadMode !== undefined && metrics.offload_mode !== desiredOffloadMode) {
     return false;
   }
@@ -246,29 +295,41 @@ async function previewBenchmarkPointBackfill(
     console.log('      already applied.');
     return null;
   }
-  if (row.offload_mode === desiredOffloadMode && desiredOffloadMode !== backfill.offloadMode) {
+
+  const malformedMetrics = recoverMalformedBenchmarkPointMetrics(row.metrics, backfill);
+  if (
+    row.offload_mode === desiredOffloadMode &&
+    desiredOffloadMode !== backfill.offloadMode &&
+    malformedMetrics === null
+  ) {
     throw new Error(
       `${backfill.id}: source identity is missing and the desired identity has unexpected data`,
     );
   }
+  const sourceMetrics = asMetricsRecord(row.metrics) ?? malformedMetrics;
+  if (!sourceMetrics) {
+    throw new Error(`${backfill.id}: benchmark metrics have an unexpected JSON shape`);
+  }
+  if (malformedMetrics) {
+    console.log('      repair malformed metrics written by the previous backfill attempt');
+  }
   console.log(`      set ${JSON.stringify(backfill.set)}`);
-  return { backfill, resultId: row.id as number };
+  return {
+    backfill,
+    resultId: row.id as number,
+    metrics: patchedBenchmarkPointMetrics(sourceMetrics, backfill),
+  };
 }
 
 async function applyBenchmarkPointBackfillToDatabase(
   target: BenchmarkPointBackfillTarget,
 ): Promise<void> {
-  const { backfill, resultId } = target;
+  const { backfill, resultId, metrics } = target;
   const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
-  const metricsMerge: Record<string, unknown> = { ...backfill.set.metricsMerge };
-  if (backfill.set.offloadMode !== undefined) {
-    metricsMerge.offload_mode = desiredOffloadMode;
-  }
   const [updated] = await sql`
     UPDATE benchmark_results
     SET offload_mode = ${desiredOffloadMode},
-        metrics = (metrics - ${backfill.set.metricsRemove ?? []}::text[])
-          || ${JSON.stringify(metricsMerge)}::jsonb
+        metrics = ${jsonbParam(sql, metrics)}
     WHERE id = ${resultId}
     RETURNING id
   `;


### PR DESCRIPTION
## Summary

- write benchmark-point backfill metrics as a structured JSONB object
- detect and repair the exact `[original metrics object, appended patch string]` shape produced by the failed production run
- retain fail-closed behavior for every other unexpected desired-identity state

## Root cause

The original database update passed `JSON.stringify(metricsMerge)` through postgres.js and concatenated it with the existing JSONB metrics object. The right-hand value became a JSONB string, so PostgreSQL produced an array instead of merging two objects. The top-level `offload_mode` update succeeded, but post-write verification rejected the malformed metrics value.

## Impact

After merge, the override workflow can safely repair the 13 affected AgentX points, verify the corrected metadata, and proceed with cache invalidation and warming.

## Validation

- pre-commit lint, formatting, and TypeScript checks passed
- read-only production preview recognized all 13 rows as the exact recoverable malformed shape
- preview found no unrelated override writes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Direct production benchmark_results writes for AgentX offload backfills; logic is targeted with strict shape checks and fail-closed errors, but incorrect recovery could corrupt metrics metadata for affected rows.
> 
> **Overview**
> Fixes **benchmark point backfill** in `apply-overrides` so `benchmark_results.metrics` is updated as a single merged JSON object instead of the broken PostgreSQL expression that concatenated existing metrics with a stringified patch (yielding `[originalMetrics, "{...patch}"]`).
> 
> **Write path:** Preview now builds the final metrics in JavaScript (`patchedBenchmarkPointMetrics`) and persists them via `jsonbParam`, matching the ingest/backfill-runner JSONB serialization path.
> 
> **Recovery:** When offload mode already matches the desired identity but metrics are malformed, the tool recognizes the exact two-element array from the failed production run, recovers the original metrics object, logs a repair, and re-applies the patch. Other unexpected desired-identity states still **fail closed**.
> 
> Verification treats non-object metrics as not applied and rejects shapes that cannot be recovered.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216274cbd31bfe59706436f3c5f8f49681623843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->