### PR TITLE
Purge seven hung AgentX benchmark points

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -137,7 +137,99 @@ export interface PurgedBenchmarkPoint extends BenchmarkPointKey {
  * `{ githubRunId, runAttempt, configId, benchmarkType, isl, osl, conc, offloadMode,
  * recipeFingerprint }`. Omitted fingerprints target only legacy NULL rows.
  */
-export const PURGED_BENCHMARK_POINTS: readonly PurgedBenchmarkPoint[] = [];
+export const PURGED_BENCHMARK_POINTS: readonly PurgedBenchmarkPoint[] = [
+  // 2026-08-03 | Point 438205 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 32.
+  // Reason: the one-hour AgentX profile stopped after 3,102s, then emitted no requests for 538s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 32,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438197 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 34.
+  // Reason: the one-hour AgentX profile stopped after 373s, then emitted no requests for 3,267s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 34,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438193 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 38.
+  // Reason: the one-hour AgentX profile stopped after 2,994s, then emitted no requests for 646s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 38,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438195 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 40.
+  // Reason: the one-hour AgentX profile stopped after 692s, then emitted no requests for 2,948s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 40,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438207 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 48.
+  // Reason: the one-hour AgentX profile stopped after 1,033s, then emitted no requests for 2,607s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 48,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438211 | Qwen3.5 FP4 B300 SGLang MTP, TP2/EP2, conc 56.
+  // Reason: the one-hour AgentX profile stopped after 2,073s, then emitted no requests for 1,568s.
+  {
+    githubRunId: 30730541420,
+    runAttempt: 1,
+    configId: 744,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 56,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+  // 2026-08-03 | Point 438242 | Qwen3.5 FP4 B200 SGLang MTP, TP4/EP1, conc 76.
+  // Reason: the one-hour AgentX profile stopped after 20s, then emitted no requests for 3,620s.
+  {
+    githubRunId: 30758866378,
+    runAttempt: 1,
+    configId: 754,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 76,
+    offloadMode: 'on',
+    recipeFingerprint: null,
+  },
+];
 
 interface AuditedBackfill {
   /** Stable, descriptive identifier used in logs and review history. */


### PR DESCRIPTION
## Summary

- purge seven hung Qwen3.5 AgentX benchmark points using the existing exact-point override registry
- retain the two containing GitHub workflow runs and their 60 healthy benchmark points
- document each point's run, durable identity, observed profiling duration, and request-free telemetry tail

## Database audit

I queried all 745 current `agentic_traces` rows that have both a precomputed request timeline and server-metrics chart series. The hung-point signature was:

- the nominal one-hour profiling phase recorded less than 3,240 seconds (90% of the expected window), and
- server telemetry continued for at least 300 seconds after the final request ended

This returned exactly seven rows, all Qwen3.5 FP4 SGLang MTP:

| Point | Workflow run | Hardware | Config | Concurrency | Profile duration | Telemetry after final request |
| --- | --- | --- | --- | ---: | ---: | ---: |
| [438205](https://inferencex.semianalysis.com/inference/agentic/438205) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 32 | 3,102s | 538s |
| [438197](https://inferencex.semianalysis.com/inference/agentic/438197) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 34 | 373s | 3,267s |
| [438193](https://inferencex.semianalysis.com/inference/agentic/438193) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 38 | 2,994s | 646s |
| [438195](https://inferencex.semianalysis.com/inference/agentic/438195) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 40 | 692s | 2,948s |
| [438207](https://inferencex.semianalysis.com/inference/agentic/438207) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 48 | 1,033s | 2,607s |
| [438211](https://inferencex.semianalysis.com/inference/agentic/438211) | [30730541420](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30730541420/attempts/1) | B300 | TP2/EP2, offload on | 56 | 2,073s | 1,568s |
| [438242](https://inferencex.semianalysis.com/inference/agentic/438242) | [30758866378](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/30758866378/attempts/1) | B200 | TP4/EP1, offload on | 76 | 20s | 3,620s |

Healthy sibling medians were 3,606–3,628 seconds, which confirms these rows ended early rather than representing shorter configured runs.

## How the purge works

Each entry in `PURGED_BENCHMARK_POINTS` selects one row by GitHub run ID, attempt, config ID, benchmark type, ISL/OSL, concurrency, offload mode, and recipe fingerprint. Ingest skips a matching artifact row, and the post-merge override workflow removes an existing matching database row plus orphaned server-log/trace sidecars and stale availability records. The rest of each workflow run remains available.

## Verification

- `bun run --cwd packages/db test:unit -- src/etl/run-overrides.test.ts`
- `bun run test:unit` (218 files, 3,958 tests)
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run security`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only change on an established purge path; no ingest or schema logic changes, only targeted benchmark row removal after merge.
> 
> **Overview**
> Registers **seven** hung Qwen3.5 FP4 SGLang MTP `agentic_traces` rows in `PURGED_BENCHMARK_POINTS` so ingest skips them and the post-merge override workflow deletes matching DB rows (and related sidecars).
> 
> Six points share workflow run `30730541420` (B300, config 744, conc 32–56); one is on `30758866378` (B200, config 754, conc 76). Each entry is keyed by the existing natural identity (run, attempt, config, benchmark type, conc, offload, null recipe fingerprint) with dated comments citing short AgentX profiling vs long request-free telemetry tails.
> 
> The parent workflow runs and their healthy sibling points are **not** purged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6e3ada11475761b09003a8a6517f1c65baf3c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->