### PR TITLE
Lead Comparisons with AgentX results

### DIFF
--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -8,7 +8,7 @@ describe('Compare precision index page', () => {
   it('leads the /compare index with AgentX results and keeps fixed-sequence tools', () => {
     cy.visit('/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
-      cy.get('h1').should('have.text', 'Compare AgentX inference results');
+      cy.get('h1').should('have.text', 'Compare real world, agentic inference results');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
       cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
         'have.attr',
@@ -35,7 +35,7 @@ describe('Compare precision index page', () => {
   it('ships the same AgentX-first hierarchy on the Simplified Chinese page', () => {
     cy.visit('/zh/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
-      cy.get('h1').should('have.text', '对比 AgentX 推理结果');
+      cy.get('h1').should('have.text', '对比真实场景下的智能体推理结果');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
       cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
         'have.attr',

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -21,15 +21,25 @@ describe('Compare precision index page', () => {
         '/agentx/methodology',
       );
     });
-    cy.get('[data-testid="compare-fixed-sequence-catalog"]')
-      .should('contain.text', 'Controlled workload comparisons')
-      .and('contain.text', 'fixed input and output lengths');
+    cy.get('[data-testid="compare-model-catalog"]')
+      .should('contain.text', 'AgentX and 8K→1K results')
+      .and('contain.text', 'Each card identifies its scenario');
     cy.get('[data-testid="compare-index-precision-link"]')
       .should('have.attr', 'href', '/compare-precision')
       .and('contain.text', 'Compare precisions');
     cy.get('[data-testid="compare-index-spec-decode-link"]')
       .should('have.attr', 'href', '/compare-spec-decode')
       .and('contain.text', 'Compare speculative decoding');
+    cy.get('#deepseek-v4 a[data-scenario="AgentX"]')
+      .first()
+      .should('contain.text', 'AgentX')
+      .and('have.attr', 'href')
+      .and('match', /\?i_seq=agentic-traces$/u);
+    cy.get('#deepseek-r1 a[data-scenario="8K→1K"]')
+      .first()
+      .should('contain.text', '8K→1K')
+      .and('have.attr', 'href')
+      .and('match', /\?i_seq=8k%2F1k$/u);
   });
 
   it('ships the same AgentX-first hierarchy on the Simplified Chinese page', () => {
@@ -48,10 +58,11 @@ describe('Compare precision index page', () => {
         '/zh/agentx/methodology',
       );
     });
-    cy.get('[data-testid="compare-fixed-sequence-catalog"]').should(
-      'contain.text',
-      '受控工作负载对比',
-    );
+    cy.get('[data-testid="compare-model-catalog"]').should('contain.text', 'AgentX 与 8K→1K 结果');
+    cy.get('#deepseek-v4 a[data-scenario="AgentX"]')
+      .first()
+      .should('have.attr', 'href')
+      .and('match', /^\/zh\/compare\/.+\?i_seq=agentic-traces$/u);
   });
 
   it('renders the /compare-per-dollar index with precision and spec-decode CTA links', () => {

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -5,14 +5,53 @@ describe('Compare precision index page', () => {
     });
   });
 
-  it('renders the /compare index with precision and spec-decode CTA links', () => {
+  it('leads the /compare index with AgentX results and keeps fixed-sequence tools', () => {
     cy.visit('/compare');
+    cy.get('[data-testid="compare-agentx-primary"]').within(() => {
+      cy.get('h1').should('have.text', 'Compare AgentX inference results');
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
+        'have.attr',
+        'href',
+        '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1',
+      );
+      cy.get('[data-testid="compare-agentx-methodology-link"]').should(
+        'have.attr',
+        'href',
+        '/agentx/methodology',
+      );
+    });
+    cy.get('[data-testid="compare-fixed-sequence-catalog"]')
+      .should('contain.text', 'Controlled workload comparisons')
+      .and('contain.text', 'fixed input and output lengths');
     cy.get('[data-testid="compare-index-precision-link"]')
       .should('have.attr', 'href', '/compare-precision')
       .and('contain.text', 'Compare precisions');
     cy.get('[data-testid="compare-index-spec-decode-link"]')
       .should('have.attr', 'href', '/compare-spec-decode')
       .and('contain.text', 'Compare speculative decoding');
+  });
+
+  it('ships the same AgentX-first hierarchy on the Simplified Chinese page', () => {
+    cy.visit('/zh/compare');
+    cy.get('[data-testid="compare-agentx-primary"]').within(() => {
+      cy.get('h1').should('have.text', '对比 AgentX 推理结果');
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
+        'have.attr',
+        'href',
+        '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
+      );
+      cy.get('[data-testid="compare-agentx-methodology-link"]').should(
+        'have.attr',
+        'href',
+        '/zh/agentx/methodology',
+      );
+    });
+    cy.get('[data-testid="compare-fixed-sequence-catalog"]').should(
+      'contain.text',
+      '受控工作负载对比',
+    );
   });
 
   it('renders the /compare-per-dollar index with precision and spec-decode CTA links', () => {

--- a/packages/app/src/app/compare/[slug]/page.tsx
+++ b/packages/app/src/app/compare/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
+import { comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { languageAlternates } from '@/lib/i18n';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
 import {
@@ -58,7 +59,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // at the slug's default operating point (falls back to boilerplate for
   // sparse-data pairs). Fetch is blob-cached and shared with the page render.
   const rows = await getCachedBenchmarks(parsed.model.dbKeys);
-  const { sequence, precision } = pickPairDefaults(rows, parsed.a, parsed.b);
+  const { sequence, precision } = pickPairDefaults(
+    rows,
+    parsed.a,
+    parsed.b,
+    comparisonScenarioForModel(parsed.model).sequence,
+  );
   const { ssrRows } = computeCompareTableData(rows, parsed.a, parsed.b, sequence, precision);
   const description = compareMetaDescription(parsed.model, parsed.a, parsed.b, ssrRows);
 
@@ -128,6 +134,7 @@ export default async function ComparePage({ params, searchParams }: Props) {
     rows,
     parsed.a,
     parsed.b,
+    comparisonScenarioForModel(parsed.model).sequence,
   );
 
   // URL params win over slug-derived defaults; this baking-into-SSR avoids the

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -1,15 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE,
-} from '@semianalysisai/inferencex-constants';
+import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 import { enAlternates } from '@/lib/i18n';
 
+import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
@@ -19,21 +15,22 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX is the independent, open-source chip inference benchmark from SemiAnalysis, with verified, reproducible results updated as configurations change. ${SUPPORTERS_LINE} Compare latency, throughput & cost head-to-head across DeepSeek V4 Pro, DeepSeek R1, Kimi K2, MiniMax M3, GLM 5, Qwen 3.5 & more.`;
+const DESCRIPTION =
+  'Compare AgentX agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2, plus fixed-sequence chip comparisons.';
 
 export const metadata: Metadata = {
-  title: 'Chip Comparisons',
+  title: 'AgentX Inference Comparisons',
   description: DESCRIPTION,
   alternates: enAlternates('/compare'),
   openGraph: {
-    title: `Chip Comparisons | ${SITE_NAME}`,
+    title: `AgentX Inference Comparisons | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/compare`,
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
-    title: `Chip Comparisons | ${SITE_NAME}`,
+    title: `AgentX Inference Comparisons | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };
@@ -77,7 +74,7 @@ function groupPairsByVendorForModel(
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
-  name: `Chip Comparisons | ${SITE_NAME}`,
+  name: `AgentX Inference Comparisons | ${SITE_NAME}`,
   description: DESCRIPTION,
   url: `${SITE_URL}/compare`,
 };
@@ -97,19 +94,27 @@ export default async function CompareIndexPage() {
   return (
     <>
       <JsonLd data={jsonLd} />
-      <section>
+      <AgentXCompareHero locale="en" />
+
+      <section id="fixed-sequence-comparisons" data-testid="compare-fixed-sequence-catalog">
         <Card>
-          <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">Chip Comparisons</h1>
+          <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+            Fixed-sequence catalog
+          </p>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight lg:text-3xl">
+            Controlled workload comparisons
+          </h2>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons across{' '}
             {formatModelList(modelsWithPairs)}. Each page includes interactive charts for latency,
-            throughput, and cost metrics, plus an interpolated comparison table.
+            throughput, and cost metrics on fixed input and output lengths, plus an interpolated
+            comparison table.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
               data-testid="compare-index-per-dollar-link"
               href="/compare-per-dollar"
-              className="inline-flex items-center gap-2 rounded-md bg-brand px-5 py-3 text-base lg:text-lg font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
+              className="inline-flex items-center gap-2 rounded-md border border-border px-5 py-3 text-base lg:text-lg font-semibold text-foreground shadow-sm transition-colors hover:bg-muted"
             >
               Compare Chip performance per dollar
               <span aria-hidden="true" className="text-lg lg:text-xl">

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -9,6 +9,7 @@ import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { comparisonPairHref, comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
 import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
@@ -96,19 +97,19 @@ export default async function CompareIndexPage() {
       <JsonLd data={jsonLd} />
       <AgentXCompareHero locale="en" />
 
-      <section id="fixed-sequence-comparisons" data-testid="compare-fixed-sequence-catalog">
+      <section id="model-comparisons" data-testid="compare-model-catalog">
         <Card>
           <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
-            Fixed-sequence catalog
+            Comparison catalog
           </p>
           <h2 className="mt-2 text-2xl font-bold tracking-tight lg:text-3xl">
-            Controlled workload comparisons
+            AgentX and 8K→1K results
           </h2>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} head-to-head inference benchmark comparisons across{' '}
-            {formatModelList(modelsWithPairs)}. Each page includes interactive charts for latency,
-            throughput, and cost metrics on fixed input and output lengths, plus an interpolated
-            comparison table.
+            {formatModelList(modelsWithPairs)}. Models with AgentX data open long-context,
+            multi-turn trace replay results. Models not yet covered by AgentX open the controlled
+            8K→1K workload. Each card identifies its scenario.
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
@@ -148,6 +149,7 @@ export default async function CompareIndexPage() {
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
         const groups = groupPairsByVendorForModel(model, pairs);
+        const scenario = comparisonScenarioForModel(model);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -172,10 +174,11 @@ export default async function CompareIndexPage() {
                       return (
                         <ComparePairCardLink
                           key={slug}
-                          href={`/compare/${slug}`}
+                          href={comparisonPairHref('en', slug, model)}
                           slug={slug}
                           label={label}
                           archLine={archLine}
+                          scenarioLabel={scenario.label}
                         />
                       );
                     })}

--- a/packages/app/src/app/zh/compare/[slug]/page.tsx
+++ b/packages/app/src/app/zh/compare/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
+import { comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { pickPairDefaults } from '@/lib/compare-pair-defaults';
 import {
   canonicalCompareSlug,
@@ -56,7 +57,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // Stat-led Chinese meta description from the interpolated head-to-head numbers
   // at the slug's default operating point (falls back to boilerplate when thin).
   const rows = await getCachedBenchmarks(parsed.model.dbKeys);
-  const { sequence, precision } = pickPairDefaults(rows, parsed.a, parsed.b);
+  const { sequence, precision } = pickPairDefaults(
+    rows,
+    parsed.a,
+    parsed.b,
+    comparisonScenarioForModel(parsed.model).sequence,
+  );
   const { ssrRows } = computeCompareTableData(rows, parsed.a, parsed.b, sequence, precision);
   const description = compareMetaDescriptionZh(parsed.model, parsed.a, parsed.b, ssrRows);
 
@@ -106,6 +112,7 @@ export default async function ComparePageZh({ params, searchParams }: Props) {
     rows,
     parsed.a,
     parsed.b,
+    comparisonScenarioForModel(parsed.model).sequence,
   );
 
   const urlSeq = pickString(sp.i_seq);

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -1,13 +1,9 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
-import {
-  HW_REGISTRY,
-  SITE_NAME,
-  SITE_URL,
-  SUPPORTERS_LINE_ZH,
-} from '@semianalysisai/inferencex-constants';
+import { HW_REGISTRY, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
+import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
@@ -18,14 +14,15 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION = `InferenceX 是 SemiAnalysis 推出的独立开源 Chip 推理基准测试平台，提供经过验证、可复现并随配置变化更新的测试结果。${SUPPORTERS_LINE_ZH}横向对比 DeepSeek V4 Pro、DeepSeek R1、Kimi K2、MiniMax M3、GLM 5、Qwen 3.5 等模型的延迟、吞吐量与成本。`;
+const DESCRIPTION =
+  '对比 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的 AgentX 智能体推理结果，并浏览定长序列芯片对比。';
 
 export const metadata: Metadata = {
-  title: 'Chip 对比',
+  title: 'AgentX 智能体推理对比',
   description: DESCRIPTION,
   alternates: zhAlternates('/compare'),
   openGraph: {
-    title: `Chip 对比 | ${SITE_NAME}`,
+    title: `AgentX 智能体推理对比 | ${SITE_NAME}`,
     description: DESCRIPTION,
     url: `${SITE_URL}/zh/compare`,
     type: 'website',
@@ -33,7 +30,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: `Chip 对比 | ${SITE_NAME}`,
+    title: `AgentX 智能体推理对比 | ${SITE_NAME}`,
     description: DESCRIPTION,
   },
 };
@@ -77,7 +74,7 @@ function groupPairsByVendorForModel(
 const jsonLd = {
   '@context': 'https://schema.org',
   '@type': 'CollectionPage',
-  name: `Chip 对比 | ${SITE_NAME}`,
+  name: `AgentX 智能体推理对比 | ${SITE_NAME}`,
   description: DESCRIPTION,
   url: `${SITE_URL}/zh/compare`,
   inLanguage: 'zh-CN',
@@ -93,19 +90,24 @@ export default async function CompareIndexPageZh() {
   return (
     <>
       <JsonLd data={jsonLd} />
-      <section>
+      <AgentXCompareHero locale="zh" />
+
+      <section id="fixed-sequence-comparisons" data-testid="compare-fixed-sequence-catalog">
         <Card>
-          <h1 className="text-2xl lg:text-4xl font-bold tracking-tight">Chip 对比</h1>
+          <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
+            定长序列对比资料库
+          </p>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight lg:text-3xl">受控工作负载对比</h2>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} 组推理基准测试的正面对比，涵盖{' '}
             {formatModelList(modelsWithPairs)}
-            。每个页面均包含延迟、吞吐量和成本指标的交互式图表，以及插值对比表格。
+            。每个页面均针对固定输入与输出长度，提供延迟、吞吐量和成本指标的交互式图表，以及插值对比表格。
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
               data-testid="compare-index-per-dollar-link-zh"
               href="/zh/compare-per-dollar"
-              className="inline-flex items-center gap-2 rounded-md bg-brand px-5 py-3 text-base lg:text-lg font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
+              className="inline-flex items-center gap-2 rounded-md border border-border px-5 py-3 text-base lg:text-lg font-semibold text-foreground shadow-sm transition-colors hover:bg-muted"
             >
               Chip 每美元性能对比
               <span aria-hidden="true" className="text-lg lg:text-xl">

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -7,6 +7,7 @@ import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { comparisonPairHref, comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
 import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
@@ -92,16 +93,19 @@ export default async function CompareIndexPageZh() {
       <JsonLd data={jsonLd} />
       <AgentXCompareHero locale="zh" />
 
-      <section id="fixed-sequence-comparisons" data-testid="compare-fixed-sequence-catalog">
+      <section id="model-comparisons" data-testid="compare-model-catalog">
         <Card>
           <p className="font-mono text-xs font-semibold tracking-[0.16em] text-muted-foreground uppercase">
-            定长序列对比资料库
+            对比结果目录
           </p>
-          <h2 className="mt-2 text-2xl font-bold tracking-tight lg:text-3xl">受控工作负载对比</h2>
+          <h2 className="mt-2 text-2xl font-bold tracking-tight lg:text-3xl">
+            AgentX 与 8K→1K 结果
+          </h2>
           <p className="mt-3 text-base lg:text-lg text-muted-foreground max-w-3xl">
             {totalUrls.toLocaleString()} 组推理基准测试的正面对比，涵盖{' '}
             {formatModelList(modelsWithPairs)}
-            。每个页面均针对固定输入与输出长度，提供延迟、吞吐量和成本指标的交互式图表，以及插值对比表格。
+            。已有 AgentX 数据的模型默认打开长上下文、多轮 trace replay 结果；尚未纳入 AgentX
+            的模型默认打开受控的 8K→1K 工作负载。每张卡片均标明对应场景。
           </p>
           <div className="mt-6 flex flex-wrap gap-3">
             <Link
@@ -141,6 +145,7 @@ export default async function CompareIndexPageZh() {
       {modelsWithPairs.map((model) => {
         const pairs = comparablePairsByModel.get(model.slug) ?? [];
         const groups = groupPairsByVendorForModel(model, pairs);
+        const scenario = comparisonScenarioForModel(model);
         return (
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
@@ -164,10 +169,11 @@ export default async function CompareIndexPageZh() {
                       return (
                         <ComparePairCardLink
                           key={slug}
-                          href={`/zh/compare/${slug}`}
+                          href={comparisonPairHref('zh', slug, model)}
                           slug={slug}
                           label={label}
                           archLine={archLine}
+                          scenarioLabel={scenario.label}
                         />
                       );
                     })}

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -1,0 +1,105 @@
+import { ArrowRight } from 'lucide-react';
+
+import { Card } from '@/components/ui/card';
+import { agentxDashboardHref, FEATURED_AGENTX_MODELS } from '@/lib/compare-agentx';
+
+import { CompareIndexTrackedLink } from './compare-index-tracked-link';
+
+const STRINGS = {
+  en: {
+    eyebrow: 'AgentX / live results',
+    title: 'Compare AgentX inference results',
+    description:
+      'Real-world agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2. Compare throughput, interactivity, time to first token, and cost across serving stacks and accelerator platforms.',
+    dashboard: 'Open the AgentX dashboard',
+    methodology: 'Read the methodology',
+    ledgerTitle: 'Models with AgentX results',
+    modelAction: 'View results',
+  },
+  zh: {
+    eyebrow: 'AgentX / 实时结果',
+    title: '对比 AgentX 推理结果',
+    description:
+      '查看 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的真实智能体推理结果，对比不同 serving stack 与加速平台的吞吐量、交互速度、首 token 延迟和成本。',
+    dashboard: '打开 AgentX 仪表板',
+    methodology: '阅读方法论',
+    ledgerTitle: '已有 AgentX 结果的模型',
+    modelAction: '查看结果',
+  },
+} as const;
+
+export function AgentXCompareHero({ locale }: { locale: 'en' | 'zh' }) {
+  const t = STRINGS[locale];
+  const prefix = locale === 'zh' ? '/zh' : '';
+
+  return (
+    <section data-testid="compare-agentx-primary">
+      <Card className="overflow-hidden p-0 md:p-0">
+        <div className="grid lg:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
+          <div className="flex flex-col justify-center p-6 md:p-8 lg:p-10">
+            <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
+              {t.eyebrow}
+            </p>
+            <h1 className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight text-foreground lg:text-5xl">
+              {t.title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground lg:text-lg">
+              {t.description}
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3">
+              <CompareIndexTrackedLink
+                data-testid="compare-agentx-dashboard-link"
+                href={agentxDashboardHref(locale, FEATURED_AGENTX_MODELS[0])}
+                analyticsEvent="compare_agentx_dashboard_clicked"
+                analyticsTarget="kimi-k3"
+                className="inline-flex min-h-11 items-center gap-2 rounded-md bg-brand px-5 py-2.5 font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
+              >
+                {t.dashboard}
+                <ArrowRight aria-hidden="true" className="size-4" />
+              </CompareIndexTrackedLink>
+              <CompareIndexTrackedLink
+                data-testid="compare-agentx-methodology-link"
+                href={`${prefix}/agentx/methodology`}
+                analyticsEvent="compare_agentx_methodology_clicked"
+                className="inline-flex min-h-11 items-center rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"
+              >
+                {t.methodology}
+              </CompareIndexTrackedLink>
+            </div>
+          </div>
+
+          <div className="border-t border-border/70 bg-muted/15 lg:border-t-0 lg:border-l">
+            <div className="border-b border-border/70 px-5 py-3 font-mono text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+              {t.ledgerTitle}
+            </div>
+            <nav aria-label={t.ledgerTitle} className="divide-y divide-border/70">
+              {FEATURED_AGENTX_MODELS.map((model) => (
+                <CompareIndexTrackedLink
+                  key={model.slug}
+                  data-testid={`compare-agentx-model-${model.slug}`}
+                  href={agentxDashboardHref(locale, model)}
+                  analyticsEvent="compare_agentx_model_clicked"
+                  analyticsTarget={model.slug}
+                  className="group flex min-h-16 items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                >
+                  <span className="min-w-0">
+                    <span className="block text-sm font-semibold leading-tight text-foreground group-hover:text-brand">
+                      {model.label}
+                    </span>
+                    <span className="mt-1 block font-mono text-[10px] tracking-[0.14em] text-brand uppercase">
+                      AgentX
+                    </span>
+                  </span>
+                  <span className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground group-hover:text-foreground">
+                    {t.modelAction}
+                    <ArrowRight aria-hidden="true" className="size-3.5" />
+                  </span>
+                </CompareIndexTrackedLink>
+              ))}
+            </nav>
+          </div>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -8,7 +8,7 @@ import { CompareIndexTrackedLink } from './compare-index-tracked-link';
 const STRINGS = {
   en: {
     eyebrow: 'AgentX / live results',
-    title: 'Compare AgentX inference results',
+    title: 'Compare real world, agentic inference results',
     description:
       'Real-world agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2. Compare throughput, interactivity, time to first token, and cost across serving stacks and accelerator platforms.',
     dashboard: 'Open the AgentX dashboard',
@@ -18,7 +18,7 @@ const STRINGS = {
   },
   zh: {
     eyebrow: 'AgentX / 实时结果',
-    title: '对比 AgentX 推理结果',
+    title: '对比真实场景下的智能体推理结果',
     description:
       '查看 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的真实智能体推理结果，对比不同 serving stack 与加速平台的吞吐量、交互速度、首 token 延迟和成本。',
     dashboard: '打开 AgentX 仪表板',

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import Link from 'next/link';
+
+import { track } from '@/lib/analytics';
+
+interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link> {
+  analyticsEvent:
+    | 'compare_agentx_dashboard_clicked'
+    | 'compare_agentx_methodology_clicked'
+    | 'compare_agentx_model_clicked';
+  analyticsTarget?: string;
+}
+
+export function CompareIndexTrackedLink({
+  analyticsEvent,
+  analyticsTarget,
+  onClick,
+  ...props
+}: CompareIndexTrackedLinkProps) {
+  return (
+    <Link
+      {...props}
+      onClick={(event) => {
+        onClick?.(event);
+        if (event.defaultPrevented) return;
+        track(analyticsEvent, analyticsTarget ? { target: analyticsTarget } : undefined);
+      }}
+    />
+  );
+}

--- a/packages/app/src/components/compare/compare-pair-card-link.tsx
+++ b/packages/app/src/components/compare/compare-pair-card-link.tsx
@@ -9,26 +9,45 @@ interface ComparePairCardLinkProps {
   slug: string;
   label: string;
   archLine: string;
+  scenarioLabel?: 'AgentX' | '8K→1K';
 }
 
-export function ComparePairCardLink({ href, slug, label, archLine }: ComparePairCardLinkProps) {
+export function ComparePairCardLink({
+  href,
+  slug,
+  label,
+  archLine,
+  scenarioLabel,
+}: ComparePairCardLinkProps) {
   return (
     <a
       href={href}
+      data-scenario={scenarioLabel}
       className="group relative flex flex-col rounded-xl border border-border bg-background/20 backdrop-blur-[2px] p-5 transition-all duration-200 hover:border-brand/50 hover:shadow-lg hover:shadow-brand/5 hover:scale-[1.01]"
       onClick={(e) => {
         if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
         e.preventDefault();
-        track('compare_index_pair_clicked', { slug, label });
+        track('compare_index_pair_clicked', {
+          slug,
+          label,
+          ...(scenarioLabel ? { scenario: scenarioLabel } : {}),
+        });
         window.location.href = href;
       }}
     >
       <div className="absolute inset-y-3 left-0 w-0.5 rounded-full bg-brand/60 transition-all duration-200 group-hover:bg-brand group-hover:inset-y-2" />
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <h3 className="font-semibold text-sm leading-tight group-hover:text-brand transition-colors duration-200">
-            {label}
-          </h3>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="font-semibold text-sm leading-tight group-hover:text-brand transition-colors duration-200">
+              {label}
+            </h3>
+            {scenarioLabel && (
+              <span className="inline-flex min-h-5 items-center rounded-full border border-brand/30 bg-brand/10 px-2 font-mono text-[10px] font-semibold leading-none text-brand">
+                {scenarioLabel}
+              </span>
+            )}
+          </div>
           <p className="text-xs text-muted-foreground leading-relaxed mt-1.5">{archLine}</p>
         </div>
         <ArrowRight className="size-4 shrink-0 text-muted-foreground transition-all duration-200 group-hover:translate-x-0.5 group-hover:text-brand" />

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { agentxDashboardHref, FEATURED_AGENTX_MODELS } from './compare-agentx';
+import {
+  agentxDashboardHref,
+  comparisonPairHref,
+  comparisonScenarioForModel,
+  FEATURED_AGENTX_MODELS,
+} from './compare-agentx';
+import { COMPARE_MODEL_SLUGS } from './compare-slug';
 
 describe('AgentX comparison links', () => {
   it('keeps the live AgentX models in the editorial order', () => {
@@ -19,6 +25,26 @@ describe('AgentX comparison links', () => {
     );
     expect(agentxDashboardHref('zh', FEATURED_AGENTX_MODELS[1])).toBe(
       '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
+    );
+  });
+
+  it('uses AgentX for supported models and 8K→1K for the rest', () => {
+    const deepSeekV4 = COMPARE_MODEL_SLUGS.find((model) => model.slug === 'deepseek-v4')!;
+    const deepSeekR1 = COMPARE_MODEL_SLUGS.find((model) => model.slug === 'deepseek-r1')!;
+
+    expect(comparisonScenarioForModel(deepSeekV4)).toEqual({
+      label: 'AgentX',
+      sequence: 'agentic-traces',
+    });
+    expect(comparisonPairHref('en', 'deepseek-v4-h100-vs-h200', deepSeekV4)).toBe(
+      '/compare/deepseek-v4-h100-vs-h200?i_seq=agentic-traces',
+    );
+    expect(comparisonScenarioForModel(deepSeekR1)).toEqual({
+      label: '8K→1K',
+      sequence: '8k/1k',
+    });
+    expect(comparisonPairHref('zh', 'deepseek-r1-h100-vs-h200', deepSeekR1)).toBe(
+      '/zh/compare/deepseek-r1-h100-vs-h200?i_seq=8k%2F1k',
     );
   });
 });

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { agentxDashboardHref, FEATURED_AGENTX_MODELS } from './compare-agentx';
+
+describe('AgentX comparison links', () => {
+  it('keeps the live AgentX models in the editorial order', () => {
+    expect(FEATURED_AGENTX_MODELS.map((model) => model.slug)).toEqual([
+      'kimi-k3',
+      'deepseek-v4',
+      'minimax-m3',
+      'qwen-3-5',
+      'glm-5-2',
+    ]);
+  });
+
+  it('opens the selected model directly in the Agentic Traces scenario', () => {
+    expect(agentxDashboardHref('en', FEATURED_AGENTX_MODELS[0])).toBe(
+      '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1',
+    );
+    expect(agentxDashboardHref('zh', FEATURED_AGENTX_MODELS[1])).toBe(
+      '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
+    );
+  });
+});

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -8,6 +8,13 @@ const FEATURED_AGENTX_MODEL_SLUGS = [
   'glm-5-2',
 ] as const;
 
+const FEATURED_AGENTX_MODEL_SET = new Set<string>(FEATURED_AGENTX_MODEL_SLUGS);
+
+export interface ComparisonScenario {
+  label: 'AgentX' | '8K→1K';
+  sequence: 'agentic-traces' | '8k/1k';
+}
+
 export const FEATURED_AGENTX_MODELS: readonly CompareModelSlug[] = FEATURED_AGENTX_MODEL_SLUGS.map(
   (slug) => {
     const model = COMPARE_MODEL_SLUGS.find((candidate) => candidate.slug === slug);
@@ -23,5 +30,21 @@ export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug
     i_seq: 'agentic-traces',
     i_optimal: '1',
   });
+  return `${path}?${query}`;
+}
+
+export function comparisonScenarioForModel(model: CompareModelSlug): ComparisonScenario {
+  return FEATURED_AGENTX_MODEL_SET.has(model.slug)
+    ? { label: 'AgentX', sequence: 'agentic-traces' }
+    : { label: '8K→1K', sequence: '8k/1k' };
+}
+
+export function comparisonPairHref(
+  locale: 'en' | 'zh',
+  slug: string,
+  model: CompareModelSlug,
+): string {
+  const path = locale === 'zh' ? `/zh/compare/${slug}` : `/compare/${slug}`;
+  const query = new URLSearchParams({ i_seq: comparisonScenarioForModel(model).sequence });
   return `${path}?${query}`;
 }

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -1,0 +1,27 @@
+import { COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
+
+const FEATURED_AGENTX_MODEL_SLUGS = [
+  'kimi-k3',
+  'deepseek-v4',
+  'minimax-m3',
+  'qwen-3-5',
+  'glm-5-2',
+] as const;
+
+export const FEATURED_AGENTX_MODELS: readonly CompareModelSlug[] = FEATURED_AGENTX_MODEL_SLUGS.map(
+  (slug) => {
+    const model = COMPARE_MODEL_SLUGS.find((candidate) => candidate.slug === slug);
+    if (!model) throw new Error(`Missing AgentX comparison model: ${slug}`);
+    return model;
+  },
+);
+
+export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug): string {
+  const path = locale === 'zh' ? '/zh/inference' : '/inference';
+  const query = new URLSearchParams({
+    g_model: model.displayName,
+    i_seq: 'agentic-traces',
+    i_optimal: '1',
+  });
+  return `${path}?${query}`;
+}

--- a/packages/app/src/lib/compare-pair-defaults.test.ts
+++ b/packages/app/src/lib/compare-pair-defaults.test.ts
@@ -112,4 +112,72 @@ describe('pickPairDefaults', () => {
       precision: 'fp8',
     });
   });
+
+  it('recognizes AgentX rows without fixed input or output lengths', () => {
+    const rows: BenchmarkRow[] = [
+      makeRow({
+        hardware: 'h100',
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        precision: 'fp8',
+      }),
+      makeRow({
+        hardware: 'gb200',
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        precision: 'fp8',
+      }),
+    ];
+
+    expect(pickPairDefaults(rows, 'h100', 'gb200')).toEqual({
+      sequence: 'agentic-traces',
+      precision: 'fp8',
+    });
+  });
+
+  it('honors an available preferred scenario before overlap ranking', () => {
+    const rows: BenchmarkRow[] = [
+      makeRow({ hardware: 'h100', conc: 32 }),
+      makeRow({ hardware: 'h100', conc: 64 }),
+      makeRow({ hardware: 'gb200', conc: 32 }),
+      makeRow({ hardware: 'gb200', conc: 64 }),
+      makeRow({
+        hardware: 'h100',
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc: 8,
+      }),
+      makeRow({
+        hardware: 'gb200',
+        benchmark_type: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc: 8,
+      }),
+    ];
+
+    expect(pickPairDefaults(rows, 'h100', 'gb200', 'agentic-traces')).toEqual({
+      sequence: 'agentic-traces',
+      precision: 'fp8',
+    });
+    expect(pickPairDefaults(rows, 'h100', 'gb200', '8k/1k')).toEqual({
+      sequence: '8k/1k',
+      precision: 'fp8',
+    });
+  });
+
+  it('falls back to the best available scenario when the preference has no rows', () => {
+    const rows: BenchmarkRow[] = [
+      makeRow({ hardware: 'h100', conc: 64 }),
+      makeRow({ hardware: 'gb200', conc: 64 }),
+    ];
+
+    expect(pickPairDefaults(rows, 'h100', 'gb200', 'agentic-traces')).toEqual({
+      sequence: '8k/1k',
+      precision: 'fp8',
+    });
+  });
 });

--- a/packages/app/src/lib/compare-pair-defaults.ts
+++ b/packages/app/src/lib/compare-pair-defaults.ts
@@ -1,4 +1,4 @@
-import { islOslToSequence } from '@semianalysisai/inferencex-constants';
+import { rowToSequence } from '@semianalysisai/inferencex-constants';
 import type { BenchmarkRow } from '@semianalysisai/inferencex-db/queries/benchmarks';
 
 // Picks the (sequence, precision) that maximises overlap of distinct
@@ -8,14 +8,14 @@ export function pickPairDefaults(
   rows: BenchmarkRow[],
   a: string,
   b: string,
+  preferredSequence?: string,
 ): { sequence: string | null; precision: string | null } {
   const tally = new Map<string, { both: number; either: number }>();
   const seenA = new Map<string, Set<string>>();
   const seenB = new Map<string, Set<string>>();
   for (const row of rows) {
     if (row.hardware !== a && row.hardware !== b) continue;
-    if (row.isl === null || row.osl === null) continue;
-    const seq = islOslToSequence(row.isl, row.osl);
+    const seq = rowToSequence(row);
     if (!seq) continue;
     const key = `${seq}|${row.precision}`;
     const variantId = `${row.framework}|${row.spec_method}|${row.conc}`;
@@ -36,6 +36,11 @@ export function pickPairDefaults(
   }
   if (tally.size === 0) return { sequence: null, precision: null };
   const best = [...tally.entries()].toSorted((left, right) => {
+    if (preferredSequence) {
+      const leftPreferred = left[0].startsWith(`${preferredSequence}|`);
+      const rightPreferred = right[0].startsWith(`${preferredSequence}|`);
+      if (leftPreferred !== rightPreferred) return leftPreferred ? -1 : 1;
+    }
     if (left[1].both !== right[1].both) return right[1].both - left[1].both;
     return right[1].either - left[1].either;
   })[0];

--- a/packages/app/src/lib/compare-ssr.test.ts
+++ b/packages/app/src/lib/compare-ssr.test.ts
@@ -7,7 +7,9 @@ import { COMPARE_MODEL_SLUGS } from './compare-slug';
 import {
   compareMetaDescription,
   computeCompareImageRows,
+  computeCompareTableData,
   KNOWN_MODELS,
+  KNOWN_SEQUENCES,
   META_DESCRIPTION_MAX,
   type SsrInterpolatedRow,
 } from './compare-ssr';
@@ -20,6 +22,10 @@ let nextStubId = 1;
 describe('compare URL validators', () => {
   it('accepts GLM-5.2 as a model override', () => {
     expect(KNOWN_MODELS.has('GLM-5.2')).toBe(true);
+  });
+
+  it('accepts AgentX as a comparison scenario override', () => {
+    expect(KNOWN_SEQUENCES.has('agentic-traces')).toBe(true);
   });
 });
 
@@ -68,6 +74,60 @@ function pairRows(): BenchmarkRow[] {
     stubRow({ hardware: 'b200', conc: 128, metrics: { tput_per_gpu: 250, median_intvty: 40 } }),
   ];
 }
+
+function agenticPairRows(): BenchmarkRow[] {
+  return [
+    stubRow({
+      hardware: 'h200',
+      benchmark_type: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc: 16,
+      metrics: { tput_per_gpu: 800, p90_itl: 0.1 },
+    }),
+    stubRow({
+      hardware: 'h200',
+      benchmark_type: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc: 32,
+      metrics: { tput_per_gpu: 600, p90_itl: 0.05 },
+    }),
+    stubRow({
+      hardware: 'b200',
+      benchmark_type: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc: 16,
+      metrics: { tput_per_gpu: 900, p90_itl: 0.1 },
+    }),
+    stubRow({
+      hardware: 'b200',
+      benchmark_type: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc: 32,
+      metrics: { tput_per_gpu: 700, p90_itl: 0.05 },
+    }),
+  ];
+}
+
+describe('computeCompareTableData', () => {
+  it('builds AgentX comparison rows from p90 full-response interactivity', () => {
+    const result = computeCompareTableData(
+      agenticPairRows(),
+      'h200',
+      'b200',
+      'agentic-traces',
+      'fp8',
+    );
+
+    expect(result.interactivityRange).toEqual({ min: 10, max: 20 });
+    expect(result.defaultTargets).toEqual([13, 15, 18]);
+    expect(result.ssrRows).toHaveLength(3);
+    expect(result.ssrRows.every((row) => row.a !== null && row.b !== null)).toBe(true);
+  });
+});
 
 describe('computeCompareImageRows', () => {
   const range = { min: 10, max: 40 };

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -14,6 +14,7 @@ import {
   AUTHOR_NAME,
   AUTHOR_URL,
   HW_REGISTRY,
+  rowToSequence,
   SITE_NAME,
   SITE_URL,
   sequenceToIslOsl,
@@ -55,7 +56,7 @@ export const KNOWN_MODELS = new Set([
   'GLM-5.2',
   'DeepSeek-V4-Pro',
 ]);
-export const KNOWN_SEQUENCES = new Set(['1k/1k', '1k/8k', '8k/1k']);
+export const KNOWN_SEQUENCES = new Set(['1k/1k', '1k/8k', '8k/1k', 'agentic-traces']);
 export const KNOWN_PRECISIONS = new Set(['fp4', 'fp4fp8', 'fp8', 'bf16', 'int4', 'nvfp4', 'mxfp4']);
 
 export function pickString(value: string | string[] | undefined): string | undefined {
@@ -168,6 +169,74 @@ export function buildGpuDataPoints(
   return points;
 }
 
+function buildAgenticGpuDataPoints(
+  rows: BenchmarkRow[],
+  hw: string,
+  precision: string,
+  specMethod?: string,
+): GPUDataPoint[] {
+  const points: GPUDataPoint[] = [];
+  for (const row of rows) {
+    if (row.hardware !== hw) continue;
+    if (rowToSequence(row) !== 'agentic-traces') continue;
+    if (row.precision !== precision) continue;
+    if (specMethod !== undefined && row.spec_method !== specMethod) continue;
+
+    const entry = rowToAggDataEntry(row);
+    const hwKey = getHardwareKey(entry);
+    if (!getHardwareConfig(hwKey)) continue;
+
+    const interactivity = entry.p90_intvty;
+    if (!Number.isFinite(interactivity) || interactivity <= 0) continue;
+
+    const tput = entry.tput_per_gpu;
+    const outputTput = entry.output_tput_per_gpu || tput;
+    const inputTput = entry.input_tput_per_gpu;
+    const specs = getGpuSpecs(hwKey);
+    const power = specs.power;
+
+    points.push({
+      hwKey,
+      interactivity,
+      throughput: tput,
+      outputThroughput: outputTput,
+      inputThroughput: inputTput,
+      concurrency: row.conc,
+      tp: row.decode_tp,
+      precision: row.precision,
+      ep: row.decode_ep,
+      dp_attention: row.decode_dp_attention,
+      disagg: row.disagg,
+      costh: computeGpuCost(specs.costh, tput),
+      costn: computeGpuCost(specs.costn, tput),
+      costr: computeGpuCost(specs.costr, tput),
+      costhi: computeGpuCost(specs.costh, inputTput),
+      costni: computeGpuCost(specs.costn, inputTput),
+      costri: computeGpuCost(specs.costr, inputTput),
+      costhOutput: computeGpuCost(specs.costh, outputTput),
+      costnOutput: computeGpuCost(specs.costn, outputTput),
+      costrOutput: computeGpuCost(specs.costr, outputTput),
+      tpPerMw: power && power > 0 ? (tput * 1000) / power : 0,
+      inputTpPerMw: power && power > 0 ? (inputTput * 1000) / power : 0,
+      outputTpPerMw: power && power > 0 ? (outputTput * 1000) / power : 0,
+    });
+  }
+  return points;
+}
+
+function buildGpuDataPointsForSequence(
+  rows: BenchmarkRow[],
+  hw: string,
+  sequence: string,
+  precision: string,
+): GPUDataPoint[] {
+  if (sequence === 'agentic-traces') {
+    return buildAgenticGpuDataPoints(rows, hw, precision);
+  }
+  const islOsl = sequenceToIslOsl(sequence);
+  return islOsl ? buildGpuDataPoints(rows, hw, islOsl.isl, islOsl.osl, precision) : [];
+}
+
 function interactivityRangeOf(pts: GPUDataPoint[]): { min: number; max: number } | null {
   if (pts.length === 0) return null;
   let min = Infinity;
@@ -195,11 +264,8 @@ export function computeCompareTableData(
   const empty = { defaultTargets: [], ssrRows: [], interactivityRange: { min: 0, max: 100 } };
   if (!sequence || !precision) return empty;
 
-  const islOsl = sequenceToIslOsl(sequence);
-  if (!islOsl) return empty;
-
-  const pointsA = buildGpuDataPoints(rows, a, islOsl.isl, islOsl.osl, precision);
-  const pointsB = buildGpuDataPoints(rows, b, islOsl.isl, islOsl.osl, precision);
+  const pointsA = buildGpuDataPointsForSequence(rows, a, sequence, precision);
+  const pointsB = buildGpuDataPointsForSequence(rows, b, sequence, precision);
 
   if (pointsA.length === 0 && pointsB.length === 0) return empty;
 
@@ -269,11 +335,8 @@ export function computeCompareImageRows(
 ): SsrInterpolatedRow[] {
   if (!sequence || !precision || interactivityRange.max <= interactivityRange.min) return [];
 
-  const islOsl = sequenceToIslOsl(sequence);
-  if (!islOsl) return [];
-
-  const pointsA = buildGpuDataPoints(rows, a, islOsl.isl, islOsl.osl, precision);
-  const pointsB = buildGpuDataPoints(rows, b, islOsl.isl, islOsl.osl, precision);
+  const pointsA = buildGpuDataPointsForSequence(rows, a, sequence, precision);
+  const pointsB = buildGpuDataPointsForSequence(rows, b, sequence, precision);
   if (pointsA.length === 0 && pointsB.length === 0) return [];
 
   const sampleCount = 17;


### PR DESCRIPTION
## Summary

- Make AgentX results the primary experience on the Comparisons page.
- Use the headline “Compare real world, agentic inference results.”
- Add direct Agentic Traces dashboard links for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2.
- Label every model comparison card with its scenario: AgentX where results are available, otherwise 8K→1K.
- Open every comparison card in the matching scenario and use that same scenario for server-rendered defaults, metadata, the interpolated table, and the hydrated chart.
- Preserve performance-per-dollar, precision, and speculative-decoding tools below the model comparison catalog.
- Ship the same hierarchy, behavior, and natural copy on the Simplified Chinese page.
- Track AgentX dashboard, model, methodology, and scenario-aware comparison clicks.

## Why

The Comparisons page previously opened with the fixed-sequence chip-pair library even though InferenceX now publishes real-world AgentX benchmarks. This change puts those agentic results first and makes the workload behind every comparison explicit. Models not yet covered by AgentX retain the controlled 8K→1K comparison path.

## Verification

- bun run lint
- bun run fmt
- bun run typecheck
- Focused Vitest: 31/31
- Earlier branch-wide unit suite: 3,965/3,965
- Earlier fixture production build: 950 routes
- Earlier Chrome Cypress compare-precision.cy.ts: 7/7
- Earlier desktop English and mobile Simplified Chinese rendered checks: no overflow, error overlay, or console errors

Latest push intentionally did not wait for remote checks, per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default comparison scenario and SEO copy for many compare URLs and extends the SSR interpolation path for agentic data; URL overrides remain, but wrong scenario mapping could mislead users and meta snippets.
> 
> **Overview**
> **Repositions the Comparisons index** (English and Simplified Chinese) around AgentX: a new hero with dashboard and methodology links for five featured models, updated titles and descriptions, and the chip-pair catalog moved under an “AgentX and 8K→1K” section with demoted secondary tool links.
> 
> **Makes workload explicit end-to-end.** A shared `compare-agentx` helper picks **AgentX (`agentic-traces`)** for featured models and **8K→1K** for the rest. Index cards show scenario badges, link with `?i_seq=…`, and pair-click analytics include scenario. Slug pages pass the model’s preferred sequence into `pickPairDefaults` so SSR defaults, meta descriptions, and the interpolated table align with those links (URL `i_seq` still wins).
> 
> **Extends compare SSR for agentic benchmarks.** `pickPairDefaults` uses `rowToSequence` (including rows without fixed ISL/OSL) and can prefer a scenario when data exists. `computeCompareTableData` builds GPU points from AgentX rows via **p90 interactivity**, with `agentic-traces` added to known sequences. New unit and Cypress coverage exercises hero hierarchy, hrefs, and AgentX table interpolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8247f56ec33f7f78382c484c3629283ed50ebf7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->