### PR TITLE
feat(landing): AgentX splash text in light/dark + centered launch modal / 落地页浅色深色模式新增 AgentX 标语文字并将发布弹窗居中

### DIFF
--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -46,18 +46,24 @@ describe('First-load navigation', () => {
     cy.visit('/', {
       onBeforeLoad(win) {
         win.localStorage.removeItem('inferencex-starred');
-        win.localStorage.removeItem('inferencex-star-modal-dismissed');
+        // Snoozed, not cleared: dismissing the launch modal below makes the
+        // star modal the next eligible landing nudge, and its corner card
+        // would sit over the footer links these specs click.
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         win.localStorage.removeItem('inferencex-agentic-results-modal-dismissed');
         win.localStorage.removeItem('inferencex-agentic-results-banner-dismissed');
       },
     });
 
-    // Banner (inline) and overlay modal coexist in independent slots.
+    // The launch modal is centered behind a backdrop, so it owns the first
+    // interaction — dismiss it before exercising the page underneath.
     cy.get('[data-testid="launch-modal"]').should('be.visible');
+    cy.get('[data-testid="launch-modal-dismiss"]').click();
+    cy.get('[data-testid="launch-modal"]').should('not.exist');
     cy.get('body').should('not.have.attr', 'data-scroll-locked');
   });
 
-  it('navigates to articles from the footer while the launch modal is visible', () => {
+  it('navigates to articles from the footer after the launch modal is dismissed', () => {
     cy.get('[data-testid="footer-link-articles"]').scrollIntoView().click();
     cy.location('pathname').should('eq', '/blog');
   });

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -55,7 +55,7 @@ describe('Landing nudges — modals', () => {
     cy.get('[data-testid="launch-modal"]')
       .should('be.visible')
       .and('contain.text', 'Real-world agentic inference benchmark results are live')
-      .and('contain.text', 'Kimi K3, DeepSeek-V4-Pro, MiniMax-M3, Qwen3.5 397B, and GLM-5.2')
+      .and('contain.text', 'Kimi K3, DeepSeek-V4-Pro-0813, MiniMax-M3, Qwen3.5 397B, and GLM-5.3')
       .and('contain.text', 'View results')
       // Centered launch modal: a real backdrop-backed dialog, not a corner card.
       .and('match', 'div[role="dialog"][aria-modal="true"]');
@@ -114,7 +114,7 @@ describe('Landing nudges — modals', () => {
     cy.get('[data-testid="launch-modal"]')
       .should('be.visible')
       .and('contain.text', '真实场景智能体推理基准测试结果已上线')
-      .and('contain.text', 'Kimi K3、DeepSeek-V4-Pro、MiniMax-M3、Qwen3.5 397B 与 GLM-5.2')
+      .and('contain.text', 'Kimi K3、DeepSeek-V4-Pro-0813、MiniMax-M3、Qwen3.5 397B 与 GLM-5.3')
       .and('contain.text', '查看结果');
   });
 

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -57,7 +57,8 @@ describe('Landing nudges — modals', () => {
       .and('contain.text', 'Real-world agentic inference benchmark results are live')
       .and('contain.text', 'Kimi K3, DeepSeek-V4-Pro, MiniMax-M3, Qwen3.5 397B, and GLM-5.2')
       .and('contain.text', 'View results')
-      .and('match', 'div[role="dialog"][aria-modal="false"]');
+      // Centered launch modal: a real backdrop-backed dialog, not a corner card.
+      .and('match', 'div[role="dialog"][aria-modal="true"]');
     cy.get('[data-new-badge]')
       .should('have.length', 3)
       .then(($badges) => {
@@ -115,6 +116,23 @@ describe('Landing nudges — modals', () => {
       .and('contain.text', '真实场景智能体推理基准测试结果已上线')
       .and('contain.text', 'Kimi K3、DeepSeek-V4-Pro、MiniMax-M3、Qwen3.5 397B 与 GLM-5.2')
       .and('contain.text', '查看结果');
+  });
+
+  it('renders the launch modal centered in the viewport, over a backdrop', () => {
+    cy.visit('/', {
+      onBeforeLoad: clearAllNudgeStorage,
+    });
+    cy.get('[data-testid="launch-modal"]').should('be.visible');
+    cy.window().then((win) => {
+      const rect = win.document
+        .querySelector('[data-testid="launch-modal"]')!
+        .getBoundingClientRect();
+      // clientWidth, not innerWidth: a fixed overlay is laid out against the
+      // viewport minus the scrollbar, so innerWidth is half a scrollbar off.
+      const { clientWidth, clientHeight } = win.document.documentElement;
+      expect(Math.abs((rect.left + rect.right) / 2 - clientWidth / 2)).to.be.lessThan(2);
+      expect(Math.abs((rect.top + rect.bottom) / 2 - clientHeight / 2)).to.be.lessThan(2);
+    });
   });
 
   it('dismissing launch modal persists — not shown on reload', () => {

--- a/packages/app/cypress/e2e/sanity.cy.ts
+++ b/packages/app/cypress/e2e/sanity.cy.ts
@@ -63,6 +63,24 @@ describe('Page Load & Navigation', () => {
 // Toggle visibility, click behavior, and aria-label are covered by
 // cypress/component/mode-toggle.cy.tsx. Only the reload-persistence test
 // requires a full page load (true e2e concern).
+describe('Splash text', () => {
+  it('announces AgentX on the landing page in both light and dark mode', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        win.localStorage.setItem('theme', 'light');
+      },
+    });
+    cy.get('html').should('not.have.class', 'dark');
+    cy.get('[data-testid="splash-text"]').should('be.visible').and('have.text', 'AgentX is here!!');
+
+    // Same splash after switching themes — it is no longer minecraft-only.
+    cy.get('[data-testid="theme-toggle"]').click();
+    cy.get('html').should('have.class', 'dark');
+    cy.get('[data-testid="splash-text"]').should('be.visible').and('have.text', 'AgentX is here!!');
+  });
+});
+
 describe('Theme Toggle', () => {
   it('theme persists across page reload (localStorage)', () => {
     cy.window().then((win) => {

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -6,6 +6,7 @@ describe('Chinese (/zh) pages', () => {
 
     it('renders the Chinese landing content', () => {
       cy.get('[data-testid="intro-section"]').should('contain.text', '智能体推理基准测试');
+      cy.get('[data-testid="splash-text"]').should('have.text', 'AgentX 来了！！');
       cy.contains('h2', '探索 InferenceX').should('exist');
       cy.contains('快速对比').should('exist');
     });

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -2,14 +2,17 @@
  * Global e2e setup. Loaded before every `cy.visit` via `supportFile` in
  * `cypress.config.ts`.
  *
- * Snoozes the feedback-modal nudge so it doesn't render its centered modal
- * + backdrop on top of the UI under test. Specs that want to exercise the
- * feedback-modal flow can clear `inferencex-feedback-modal-snoozed` in their
- * own `onBeforeLoad`.
+ * Suppresses the two centered modals (feedback-modal on the dashboard, the
+ * agentic-results launch modal on the landing page) so their backdrops don't
+ * sit on top of the UI under test. Specs that want to exercise either flow
+ * can clear `inferencex-feedback-modal-snoozed` /
+ * `inferencex-agentic-results-modal-dismissed` in their own `onBeforeLoad`,
+ * which runs after this hook.
  */
 Cypress.on('window:before:load', (win) => {
   try {
     win.localStorage.setItem('inferencex-feedback-modal-snoozed', String(Date.now()));
+    win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
   } catch {
     // localStorage unavailable — fine, the test will just see the modal.
   }

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -410,17 +410,40 @@
 
 .splash-text {
   display: inline-block;
-  color: #ffff00;
+  /* Light mode paints this over a white card, where flat #ffff00 all but
+     disappears — keep the Minecraft yellow but ring it with a dark outline. */
+  color: #ffcc00;
   font-weight: bold;
   font-size: 0.85rem;
   white-space: nowrap;
-  text-shadow: 2px 2px 0px #3f3f00;
+  text-shadow:
+    1px 1px 0 #4a3800,
+    1px -1px 0 #4a3800,
+    -1px 1px 0 #4a3800,
+    -1px -1px 0 #4a3800,
+    2px 2px 0 #4a3800;
+  /* The keyframes re-declare this; keeping it on the element means the splash
+     still sits where it belongs when the animation is off (reduced motion). */
+  transform: translate(2rem, 2.25rem) rotate(10deg);
   animation: splash-bounce 1.5s ease-in-out infinite;
   transform-origin: center;
   /* Always use Minecraft font & style regardless of active theme */
   font-family: var(--font-minecraft, 'Monocraft', monospace) !important;
   -webkit-font-smoothing: none;
   -moz-osx-font-smoothing: unset;
+}
+
+/* Dark backgrounds need no outline — this is the original title-screen look. */
+.dark .splash-text,
+.minecraft .splash-text {
+  color: #ffff00;
+  text-shadow: 2px 2px 0px #3f3f00;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .splash-text {
+    animation: none;
+  }
 }
 
 @media (min-width: 640px) {

--- a/packages/app/src/components/minecraft/minecraft-splash.test.tsx
+++ b/packages/app/src/components/minecraft/minecraft-splash.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const pathnameStub = vi.hoisted(() => ({ value: '/' }));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathnameStub.value,
+}));
+
+import { MinecraftSplash, SPLASHES } from './minecraft-splash';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => root.render(<MinecraftSplash />));
+}
+
+/** MutationObserver callbacks land on the microtask queue. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function splashText(): string | null {
+  return container.querySelector('.splash-text')?.textContent ?? null;
+}
+
+beforeEach(() => {
+  pathnameStub.value = '/';
+  document.documentElement.className = '';
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.documentElement.className = '';
+});
+
+describe('MinecraftSplash', () => {
+  it('announces AgentX outside the minecraft theme (light + dark)', () => {
+    render();
+    expect(splashText()).toBe('AgentX is here!!');
+  });
+
+  it('announces AgentX in Chinese on /zh pages', () => {
+    pathnameStub.value = '/zh';
+    render();
+    expect(splashText()).toBe('AgentX 来了！！');
+  });
+
+  it('swaps to a random splash from the list when the minecraft theme is on', async () => {
+    document.documentElement.classList.add('minecraft');
+    render();
+    await flush();
+    expect(SPLASHES).toContain(splashText());
+  });
+
+  it('falls back to the announcement when the minecraft theme is turned off', async () => {
+    document.documentElement.classList.add('minecraft');
+    render();
+    await flush();
+
+    await act(async () => {
+      document.documentElement.classList.remove('minecraft');
+      await Promise.resolve();
+    });
+    expect(splashText()).toBe('AgentX is here!!');
+  });
+
+  it('renders the same markup on the server as on the first client render', () => {
+    // The random pick is deferred to an effect precisely so SSR and hydration
+    // agree — a splash chosen during render would mismatch on every load.
+    render();
+    const first = splashText();
+    act(() => root.render(<MinecraftSplash />));
+    expect(splashText()).toBe(first);
+  });
+});

--- a/packages/app/src/components/minecraft/minecraft-splash.tsx
+++ b/packages/app/src/components/minecraft/minecraft-splash.tsx
@@ -2,7 +2,10 @@
 
 import { useState, useEffect } from 'react';
 
-const SPLASHES = [
+import { useLocale } from '@/lib/use-locale';
+
+export const SPLASHES = [
+  'AgentX is here!!',
   'Now with more tokens!',
   'Chip go brrr!',
   'Also try SGLang!',
@@ -36,15 +39,30 @@ const SPLASHES = [
 ];
 
 /**
+ * Splash shown outside the minecraft theme. Light and dark mode get a single
+ * fixed announcement rather than the random rotation — the rotation is a
+ * minecraft-theme easter egg, while this is a launch callout that has to say
+ * the same thing on every load.
+ */
+const ANNOUNCEMENT = {
+  en: 'AgentX is here!!',
+  zh: 'AgentX 来了！！',
+} as const;
+
+/**
  * Splash text — yellow, rotated, bouncing text (Minecraft title screen style)
- * that appears on the landing page only when the minecraft theme is active.
+ * on the landing page. Light and dark mode show the fixed AgentX announcement;
+ * the minecraft theme keeps the random per-load rotation.
  */
 export function MinecraftSplash() {
-  const [splash, setSplash] = useState('');
+  const locale = useLocale();
+  const [randomSplash, setRandomSplash] = useState('');
   const [isMinecraft, setIsMinecraft] = useState(false);
 
+  // Picked client-side only: a server-rendered random pick would mismatch on
+  // hydration. Minecraft mode is the only consumer, and it starts `false`.
   useEffect(() => {
-    setSplash(SPLASHES[Math.floor(Math.random() * SPLASHES.length)]);
+    setRandomSplash(SPLASHES[Math.floor(Math.random() * SPLASHES.length)]);
   }, []);
 
   useEffect(() => {
@@ -57,10 +75,11 @@ export function MinecraftSplash() {
     return () => observer.disconnect();
   }, []);
 
-  if (!splash || !isMinecraft) return null;
+  const splash = isMinecraft ? randomSplash : ANNOUNCEMENT[locale];
+  if (!splash) return null;
 
   return (
-    <div className="splash-wrapper">
+    <div className="splash-wrapper" data-testid="splash-text">
       <span className="splash-text">{splash}</span>
     </div>
   );

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -75,6 +75,14 @@ describe('NUDGE_REGISTRY integrity', () => {
     ]);
   });
 
+  it('renders the agentic launch modal centered, with the dismissed key e2e suppresses', () => {
+    const launch = NUDGE_REGISTRY.find((n) => n.id === 'agentic-results-launch-modal');
+    expect(launch?.content.centered).toBe(true);
+    // cypress/support/e2e.ts seeds this key so the backdrop can't cover the
+    // UI under test; a rename here has to be mirrored there.
+    expect(launch?.storageKey).toBe('inferencex-agentic-results-modal-dismissed');
+  });
+
   it('preserves testId for every entry', () => {
     for (const nudge of NUDGE_REGISTRY) {
       expect(nudge.content.testId).toBeTruthy();

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -302,6 +302,9 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
         '查看 Kimi K3、DeepSeek-V4-Pro、MiniMax-M3、Qwen3.5 397B 与 GLM-5.2 在支持 Chip 和推理服务栈上的 AgentX 结果。',
       testId: 'launch-modal',
       containerClassName: 'border-brand/40',
+      // Launch announcement — centered with a backdrop so it reads as the
+      // page's headline moment instead of a bottom-right corner card.
+      centered: true,
       badge: 'New',
       badgeZh: '最新',
       dismissLabel: 'Maybe Later',

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -297,9 +297,12 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       title: 'Real-world agentic inference benchmark results are live',
       titleZh: '真实场景智能体推理基准测试结果已上线',
       description:
-        'Compare AgentX results for Kimi K3, DeepSeek-V4-Pro, MiniMax-M3, Qwen3.5 397B, and GLM-5.2 across supported chips and serving stacks.',
+        'Compare AgentX results for Kimi K3, DeepSeek-V4-Pro-0813, MiniMax-M3, Qwen3.5 397B, and GLM-5.3 across supported chips and serving stacks.',
       descriptionZh:
-        '查看 Kimi K3、DeepSeek-V4-Pro、MiniMax-M3、Qwen3.5 397B 与 GLM-5.2 在支持 Chip 和推理服务栈上的 AgentX 结果。',
+        '查看 Kimi K3、DeepSeek-V4-Pro-0813、MiniMax-M3、Qwen3.5 397B 与 GLM-5.3 在支持 Chip 和推理服务栈上的 AgentX 结果。',
+      // Both buckets carry two releases on one architecture (GLM-5.2/5.3, the
+      // V4-Pro April preview and the 0813 GA); name the newer one, as the
+      // model selector does for GLM.
       testId: 'launch-modal',
       containerClassName: 'border-brand/40',
       // Launch announcement — centered with a backdrop so it reads as the


### PR DESCRIPTION
## Summary

Two landing-page changes.

**1. Splash text now renders in light and dark mode.** The Minecraft title-screen splash was gated behind `document.documentElement.classList.contains('minecraft')`, so only the minecraft theme ever saw it. It now renders in every theme:

- Light / dark: a fixed `AgentX is here!!` (`AgentX 来了！！` on `/zh`) — a launch callout has to say the same thing on every load, so it does not use the random pool.
- Minecraft: unchanged random per-load rotation, with `AgentX is here!!` added to `SPLASHES`.
- The random pick stays in an effect so SSR and hydration agree.

Styling: flat `#ffff00` is unreadable on the white intro card, so light mode keeps the Minecraft yellow but wraps it in a dark outline; `.dark` / `.minecraft` keep the original single-offset shadow. The bounce now honors `prefers-reduced-motion`, and the base transform moved onto the element so the splash stays in place when the animation is off.

**2. The agentic-results launch modal is centered instead of a corner card.** It sets `centered: true`, the flag the feedback modal already uses, so it renders through the engine's centered-dialog + backdrop path (`aria-modal="true"`).

Because it is now a real modal, it blocks the page until dismissed. Two test-side consequences:

- `navigation.cy.ts` "First-load navigation" dismisses the modal before clicking through, and snoozes the star modal so the next-eligible corner card cannot cover the footer links.
- `cypress/support/e2e.ts` suppresses the launch modal by default, the same way it already suppresses the feedback modal. Specs that exercise it clear the key in their own `onBeforeLoad`.

**3. The modal names the newest release of each shared-architecture bucket.** GLM-5.2 and GLM-5.3 sit in one data bucket on one architecture and the model selector already reads `GLM5.2/GLM5.3`; DeepSeek-V4-Pro is the same story with the April preview and the 0813 GA build. The copy listed the older release of each — it now reads `DeepSeek-V4-Pro-0813` and `GLM-5.3`, in both languages, with the e2e assertions updated.

## Screenshots

| Light | Dark |
| --- | --- |
| Splash renders top-right of the intro card, yellow with a dark outline | Splash renders in the original title-screen yellow |

Verified locally at 1280×720 against a dev server on the real read-only DB; the centered modal's geometry is asserted in e2e rather than eyeballed.

## Tests

- `minecraft-splash.test.tsx` (new): announcement in light/dark, Chinese on `/zh`, swap to the random pool when the minecraft class appears, swap back when it is removed, SSR-stable markup.
- `registry.test.ts`: asserts the launch modal is `centered` and pins its storage key, which `cypress/support/e2e.ts` now depends on.
- e2e: splash in light + dark (`sanity.cy.ts`, in the smoke suite), Chinese splash (`zh-pages.cy.ts`), launch-modal centering geometry (`nudge-system.cy.ts`).
- Full local run: `typecheck`, `lint`, `fmt`, `test:unit` (3433 passing), and `sanity` + `navigation` + `nudge-system` + `zh-pages` e2e.

## Overlay support

Not applicable — neither surface touches inference/evaluation chart data or the `?unofficialrun=` overlay path.

## 中文说明

落地页的两处改动。

**1. 标语文字（splash text）现在在浅色和深色模式下都会显示。** Minecraft 标题画面式的标语此前由 `document.documentElement.classList.contains('minecraft')` 控制，只有 minecraft 主题能看到。现在所有主题都会渲染：

- 浅色 / 深色：固定显示 `AgentX is here!!`（`/zh` 页面为 `AgentX 来了！！`）。发布公告每次加载都应显示同一句，因此不走随机池。
- Minecraft：保持每次加载随机取一条的行为，并把 `AgentX is here!!` 加入 `SPLASHES`。
- 随机选取仍放在 effect 中执行，保证 SSR 与 hydration 结果一致。

样式方面：纯 `#ffff00` 在白色引用卡片上几乎不可读，因此浅色模式保留 Minecraft 黄色但加了深色描边；`.dark` / `.minecraft` 沿用原有的单向投影。弹跳动画现在遵循 `prefers-reduced-motion`，并把基础 transform 移到元素本身，动画关闭时标语位置依然正确。

**2. AgentX 结果发布弹窗由右下角卡片改为居中显示。** 它设置了 `centered: true`——反馈弹窗已经在用的同一开关——从而走引擎已有的居中对话框加遮罩层路径（`aria-modal="true"`）。

由于它现在是真正的模态框，关闭前会遮挡页面，测试侧有两处相应调整：

- `navigation.cy.ts` 的 "First-load navigation" 先关闭弹窗再进行点击，并顺带把 star 弹窗设为已延后，避免下一个符合条件的角落卡片挡住页脚链接。
- `cypress/support/e2e.ts` 默认抑制该弹窗，与已有的反馈弹窗处理方式一致；需要测试该弹窗的用例在自己的 `onBeforeLoad` 中清除对应键即可。

**3. 弹窗改为列出共用架构数据桶中较新的版本。** GLM-5.2 与 GLM-5.3 共用同一数据桶和同一架构，模型选择器已显示为 `GLM5.2/GLM5.3`；DeepSeek-V4-Pro 的 4 月预览版与 0813 正式版同理。原文案列出的是较旧的版本，现改为 `DeepSeek-V4-Pro-0813` 与 `GLM-5.3`（中英文一致），并同步更新了 e2e 断言。

### 测试

- 新增 `minecraft-splash.test.tsx`：浅色/深色下的公告文案、`/zh` 中文文案、加上 minecraft class 后切换到随机池、移除后切回公告、SSR 渲染一致性。
- `registry.test.ts`：断言发布弹窗为 `centered`，并固定其 storage key（`cypress/support/e2e.ts` 现在依赖该键）。
- e2e：浅色 + 深色标语（`sanity.cy.ts`，属于冒烟套件）、中文标语（`zh-pages.cy.ts`）、弹窗居中几何（`nudge-system.cy.ts`）。
- 本地完整校验：`typecheck`、`lint`、`fmt`、`test:unit`（3433 项通过），以及 `sanity` + `navigation` + `nudge-system` + `zh-pages` 四个 e2e 用例集。

### 覆盖层支持

不适用——两处改动都不涉及推理/评估图表数据或 `?unofficialrun=` 覆盖层路径。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page UI, nudge copy, and test harness changes only; no auth, data handling, or inference chart logic.
> 
> **Overview**
> **Landing splash text** now appears in light and dark themes, not only when the minecraft theme is active. Outside minecraft, it shows a fixed **AgentX** announcement (`AgentX is here!!` / `AgentX 来了！！` on `/zh`); minecraft keeps random splashes with AgentX added to the pool. Random picks stay client-only for SSR/hydration stability. CSS improves light-mode readability (outline/shadow), preserves dark/minecraft yellow styling, and respects `prefers-reduced-motion`.
> 
> **Agentic launch modal** is configured as a **centered backdrop dialog** (`centered: true`, `aria-modal="true"`) instead of a corner card, with benchmark copy updated (e.g. GLM-5.3, DeepSeek-V4-Pro-0813). Cypress defaults suppress this modal (and documents the storage key in unit tests); navigation specs dismiss it before clicking footer links and snooze the star modal to avoid overlap.
> 
> New/updated tests cover splash behavior, modal centering geometry, and registry `centered` + dismissal key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe57a7575fee1f8c6073acdd007be818cd994419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->