### PR TITLE
test(e2e): make launch-modal suppression opt-out per spec / e2e：发布弹窗抑制改为按 spec 显式退出

### DIFF
--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -1,6 +1,8 @@
 // Merged from tabs.cy.ts and first-load-navigation.cy.ts
 // to reduce per-file Cypress startup overhead (~500ms per file)
 
+import { keepLaunchModal } from '../support/e2e';
+
 describe('Chart Section Tabs — E2E', () => {
   before(() => {
     cy.window().then((win) => {
@@ -42,6 +44,9 @@ describe('Chart Section Tabs — E2E', () => {
 });
 
 describe('First-load navigation', () => {
+  // These specs need the launch modal to actually show on first load.
+  before(keepLaunchModal);
+
   beforeEach(() => {
     cy.visit('/', {
       onBeforeLoad(win) {

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -6,6 +6,12 @@
  * permanent-suppress ("starred") cross-nudge mechanism.
  */
 
+import { keepLaunchModal } from '../support/e2e';
+
+// This spec owns launch-modal state, so it opts out of the global suppression
+// in cypress/support/e2e.ts rather than fighting it per visit.
+keepLaunchModal();
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -142,6 +148,11 @@ describe('Landing nudges — modals', () => {
     cy.get('[data-testid="launch-modal"]').should('be.visible');
     cy.get('[data-testid="launch-modal-dismiss"]').click();
     cy.get('[data-testid="launch-modal"]').should('not.exist');
+    // Assert the write itself, not just the absence after reload — the latter
+    // is only meaningful because this spec opted out of the global seeding.
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem('inferencex-agentic-results-modal-dismissed')).to.eq('1');
+    });
 
     cy.reload();
     cy.get('[data-testid="launch-modal"]').should('not.exist');

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -4,15 +4,32 @@
  *
  * Suppresses the two centered modals (feedback-modal on the dashboard, the
  * agentic-results launch modal on the landing page) so their backdrops don't
- * sit on top of the UI under test. Specs that want to exercise either flow
- * can clear `inferencex-feedback-modal-snoozed` /
- * `inferencex-agentic-results-modal-dismissed` in their own `onBeforeLoad`,
- * which runs after this hook.
+ * sit on top of the UI under test. Specs that want to exercise the
+ * feedback-modal flow can clear `inferencex-feedback-modal-snoozed` in their
+ * own `onBeforeLoad`, which runs after this hook; specs that exercise the
+ * launch modal call `keepLaunchModal()` instead — see below.
  */
+let suppressLaunchModal = true;
+
+/**
+ * Opt the whole spec out of the launch-modal suppression.
+ *
+ * Clearing the key in a visit's `onBeforeLoad` is not enough: this hook also
+ * fires on `cy.reload()`, which takes no `onBeforeLoad`, so the key would be
+ * re-seeded behind the test and a "still dismissed after reload" assertion
+ * would pass even if dismissal never persisted anything. Call this at the top
+ * of any spec that owns launch-modal state.
+ */
+export function keepLaunchModal(): void {
+  suppressLaunchModal = false;
+}
+
 Cypress.on('window:before:load', (win) => {
   try {
     win.localStorage.setItem('inferencex-feedback-modal-snoozed', String(Date.now()));
-    win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
+    if (suppressLaunchModal) {
+      win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
+    }
   } catch {
     // localStorage unavailable — fine, the test will just see the modal.
   }


### PR DESCRIPTION
## Summary

Follow-up to #764, addressing the Cursor Bugbot finding that landed after that PR was merged.

#764 added a global `window:before:load` hook in `cypress/support/e2e.ts` that seeds `inferencex-agentic-results-modal-dismissed`, so the now-centered launch modal's backdrop cannot cover the UI under test. That hook also fires on `cy.reload()`, which takes no `onBeforeLoad` — so a spec clearing the key per visit gets it re-seeded behind its back on reload. Concretely, "dismissing launch modal persists — not shown on reload" would have stayed green even if dismissal never wrote anything.

- Specs that own launch-modal state now call `keepLaunchModal()` to opt out of the seeding for the whole spec (`nudge-system.cy.ts`, and the first-load `describe` in `navigation.cy.ts`), instead of clearing the key per visit.
- The persistence test asserts the storage write directly rather than inferring it from the modal's absence after reload.

## Tests

`nudge-system.cy.ts` (23), `navigation.cy.ts` (10), and `sanity.cy.ts` (6) all pass locally against a dev server on the real read-only DB; `lint`, `fmt`, and `typecheck` clean.

## 中文说明

#764 的后续修复，处理该 PR 合并之后才出现的 Cursor Bugbot 反馈。

#764 在 `cypress/support/e2e.ts` 中新增了全局 `window:before:load` 钩子，用于写入 `inferencex-agentic-results-modal-dismissed`，避免改为居中的发布弹窗遮罩层挡住被测界面。但该钩子在 `cy.reload()` 时同样会触发，而 `cy.reload()` 不接受 `onBeforeLoad`——因此仅在每次 visit 时清除该键的用例，会在 reload 时被悄悄重新写入。具体表现是："dismissing launch modal persists — not shown on reload" 这条用例即使关闭操作完全没有持久化，也依然会通过。

- 需要操作发布弹窗状态的用例（`nudge-system.cy.ts`，以及 `navigation.cy.ts` 中的首屏 `describe`）现在调用 `keepLaunchModal()`，在整个 spec 范围内退出该抑制，而不是逐次 visit 清除键值。
- 持久化用例改为直接断言 localStorage 的写入结果，而不是通过 reload 后弹窗未出现来推断。

### 测试

`nudge-system.cy.ts`（23 项）、`navigation.cy.ts`（10 项）与 `sanity.cy.ts`（6 项）在连接真实只读数据库的本地开发服务器上全部通过；`lint`、`fmt`、`typecheck` 均无问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Cypress support and e2e spec changes; no production app behavior.
> 
> **Overview**
> Fixes a **false-green** in launch-modal persistence tests: the global `window:before:load` hook seeds `inferencex-agentic-results-modal-dismissed` on every load, including **`cy.reload()`** (which has no `onBeforeLoad`), so “modal still gone after reload” could pass even when dismiss never wrote storage.
> 
> **`keepLaunchModal()`** in `cypress/support/e2e.ts` lets a whole spec opt out of that seeding. **`nudge-system.cy.ts`** calls it at load; **`navigation.cy.ts`** uses `before(keepLaunchModal)` for the first-load `describe`.
> 
> The dismissal persistence test now **asserts `localStorage` is `'1'`** after dismiss, not only absence after reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8300e3f6e16212be85c656851ade57a9698bc42a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->