### PR TITLE
refactor(agentx): move the optimizations callout into the datasets card / 将优化引导块移入 AgentX 数据集卡片

### DIFF
--- a/packages/app/src/app/agentx/page.tsx
+++ b/packages/app/src/app/agentx/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 
 import { AgentXMethodology } from '@/components/datasets/agentx-methodology';
-import { AgentXOptimizationsCallout } from '@/components/datasets/agentx-optimizations-callout';
 import { DatasetList } from '@/components/datasets/dataset-list';
 import { JsonLd } from '@/components/json-ld';
 import { enAlternates } from '@/lib/i18n';
@@ -37,10 +36,6 @@ export default function AgentXPage() {
       <div className="container mx-auto flex flex-col gap-6 px-4 pb-8 lg:px-8">
         <section>
           <AgentXMethodology locale="en" />
-        </section>
-
-        <section>
-          <AgentXOptimizationsCallout locale="en" />
         </section>
 
         <section className="flex flex-col gap-3">

--- a/packages/app/src/app/zh/agentx/page.tsx
+++ b/packages/app/src/app/zh/agentx/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 
 import { AgentXMethodology } from '@/components/datasets/agentx-methodology';
-import { AgentXOptimizationsCallout } from '@/components/datasets/agentx-optimizations-callout';
 import { DatasetList } from '@/components/datasets/dataset-list';
 import { JsonLd } from '@/components/json-ld';
 import { zhAlternates, ZH_LANG_TAG, ZH_OG_LOCALE } from '@/lib/i18n';
@@ -39,10 +38,6 @@ export default function AgentXPageZh() {
       <div className="container mx-auto flex flex-col gap-6 px-4 pb-8 lg:px-8">
         <section>
           <AgentXMethodology locale="zh" />
-        </section>
-
-        <section>
-          <AgentXOptimizationsCallout locale="zh" />
         </section>
 
         <section className="flex flex-col gap-3">

--- a/packages/app/src/components/datasets/agentx-methodology.tsx
+++ b/packages/app/src/components/datasets/agentx-methodology.tsx
@@ -1,5 +1,7 @@
 import { Card } from '@/components/ui/card';
+
 import { AgentXMethodologyLink } from './agentx-methodology-link';
+import { AgentXOptimizationsCallout } from './agentx-optimizations-callout';
 
 type Locale = 'en' | 'zh';
 
@@ -193,6 +195,8 @@ export function AgentXMethodology({ locale }: { locale: Locale }) {
       </header>
 
       <div className="space-y-8 px-5 py-6 sm:px-6">
+        <AgentXOptimizationsCallout locale={locale} />
+
         <section aria-labelledby="agentx-process-title">
           <h2 id="agentx-process-title" className="mb-3 text-base font-semibold text-foreground">
             {t.processTitle}

--- a/packages/app/src/components/datasets/agentx-optimizations-callout.tsx
+++ b/packages/app/src/components/datasets/agentx-optimizations-callout.tsx
@@ -1,4 +1,3 @@
-import { Card } from '@/components/ui/card';
 import { getLocalizedFrameworks, getOptimizationsOverview } from '@/lib/agentx-optimizations-zh';
 import type { Locale } from '@/lib/i18n';
 
@@ -7,7 +6,8 @@ import { AgentXOptimizationsLink } from './agentx-optimizations-link';
 /**
  * Entry point from /agentx into the optimizations pages: the headline claim,
  * a button to the index, and one link per project so a reader who already
- * knows which engine they care about can go straight there.
+ * knows which engine they care about can go straight there. Rendered inside
+ * the AgentX methodology card, so it is a section rather than its own card.
  */
 export function AgentXOptimizationsCallout({ locale }: { locale: Locale }) {
   const overview = getOptimizationsOverview(locale);
@@ -15,12 +15,18 @@ export function AgentXOptimizationsCallout({ locale }: { locale: Locale }) {
   const prefix = locale === 'zh' ? '/zh' : '';
 
   return (
-    <Card className="overflow-hidden p-0" data-testid="agentx-optimizations-callout">
-      <div className="px-5 py-5 sm:px-6">
+    <section
+      aria-labelledby="agentx-optimizations-title"
+      data-testid="agentx-optimizations-callout"
+      className="rounded-lg border border-primary/30 bg-primary/5"
+    >
+      <div className="px-4 py-4 sm:px-5 sm:py-5">
         <p className="mb-2 font-mono text-[11px] font-medium tracking-[0.18em] text-primary uppercase">
           {overview.eyebrow}
         </p>
-        <h2 className="text-xl font-semibold text-foreground">{overview.title}</h2>
+        <h2 id="agentx-optimizations-title" className="text-lg font-semibold text-foreground">
+          {overview.title}
+        </h2>
         <p className="mt-3 max-w-4xl text-sm leading-6 text-muted-foreground">{overview.lead}</p>
 
         <AgentXOptimizationsLink
@@ -50,6 +56,6 @@ export function AgentXOptimizationsCallout({ locale }: { locale: Locale }) {
           ))}
         </ul>
       </div>
-    </Card>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #766, placing the industry-impact block where it reads best.

The optimizations callout was its own card below the AgentX card, which put it after the entire methodology write-up — steps, dataset profile, replay controls, and interpretation. It now sits **inside** the AgentX Benchmark Datasets card, between the "View AgentX Performance Results" button and "How an AgentX run is built", so a reader meets the upstream work while still at the top of the card.

Being nested, it renders as a highlighted section (`border-primary/30 bg-primary/5`) rather than a card inside a card, and its heading drops to the size the surrounding card sections use. The button, the eight project links, the test ids, and the analytics events are unchanged.

## Tests

`agentx-optimizations.cy.ts` and `datasets-methodology.cy.ts` both still pass against a dev server on the real read-only DB — the callout keeps its `data-testid`, so the existing assertions cover the new position. `lint`, `fmt`, and `typecheck` clean.

## 中文说明

#766 的后续调整，把行业影响板块放到更合适的位置。

优化引导块此前是 AgentX 卡片下方的独立卡片，位置排在整篇方法论说明（步骤、数据集概况、回放控制、结果解读）之后。现在它位于 AgentX 基准测试数据集卡片**内部**，夹在"查看 AgentX 性能结果"按钮与"AgentX 如何构建一次回放"之间，读者在卡片开头就能看到这些上游工作。

由于改为嵌套，它以高亮区块（`border-primary/30 bg-primary/5`）而非卡中卡的形式呈现，标题字号也与卡片内其他小节一致。按钮、八个项目链接、test id 与埋点事件均保持不变。

### 测试

`agentx-optimizations.cy.ts` 与 `datasets-methodology.cy.ts` 在连接真实只读数据库的本地开发服务器上均通过——引导块保留了原有 `data-testid`，现有断言即可覆盖新位置。`lint`、`fmt`、`typecheck` 均无问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure layout and presentation refactor on AgentX marketing pages; no API, auth, or data changes.
> 
> **Overview**
> Moves the **AgentX optimizations callout** from a separate card below the methodology block into the **AgentX Benchmark Datasets** card, directly under the performance-results CTA and before “How an AgentX run is built” (English and Chinese `/agentx` pages).
> 
> The callout is no longer a nested `Card`; it renders as a **highlighted section** (`border-primary/30`, `bg-primary/5`) with a section-sized heading. **CTAs, framework links, `data-testid`s, and analytics events are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ecb904558a08f6ee7623fdff7ae7030f073227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->