### PR TITLE
Use TPOT P50 interactivity in results table / 推理结果表改用 TPOT P50 交互性

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -165,6 +165,14 @@ percentile. Current aggregate artifacts provide the namespaced
 `*_full_response_itl` fields directly. During ingest those fields replace the
 legacy visible-content ITL values in the canonical `*_itl` and `*_intvty` keys.
 
+The inference results table deliberately keeps **P50 Interactivity** on the
+ordinary decode-cadence definition, `1 / median_tpot`. This is the P50 `intvty`
+reported by AIPerf and is distinct from the full-response interactivity used by
+the AgentX chart and its slow-tail percentile selector. CSV exports use the same
+table definition. Ingest preserves AIPerf's unrounded value as
+`median_tpot_intvty`; older rows fall back to `1 / median_tpot`, then to their
+stored `median_intvty` value when TPOT is unavailable.
+
 For artifacts produced before the aggregate field existed, trace-replay ingest
 reconstructs each request's decode interval from the retained lifecycle duration
 minus TTFT, then divides by `output_sequence_length - 1`. The same helper powers

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -952,7 +952,9 @@ describe('ChartDisplay engine comparison guard', () => {
       hwKey: 'b200_sglang',
       precision: Precision.FP4,
       tp: 4,
-      median_intvty: 134.7,
+      median_tpot: 0.00245,
+      median_tpot_intvty: 407.50337,
+      median_intvty: 1315.8,
       costhOutput: { y: 4, roof: true },
     });
     const officialClipped = createMockInferenceData({
@@ -967,7 +969,9 @@ describe('ChartDisplay engine comparison guard', () => {
       hwKey: 'h100_vllm',
       precision: Precision.FP4,
       tp: 4,
-      median_intvty: 130,
+      median_tpot: 0.00245,
+      median_tpot_intvty: 407.50337,
+      median_intvty: 1312.6527,
       costhOutput: { y: 4.5, roof: true },
       run_url: runUrl,
     });
@@ -1027,15 +1031,33 @@ describe('ChartDisplay engine comparison guard', () => {
     });
 
     cy.get('[data-testid="inference-table-view-btn"]').click();
+    cy.get('[data-testid="inference-results-table"] thead').should(
+      'contain.text',
+      'P50 Interactivity (tok/s/user)',
+    );
     cy.get('[data-testid="inference-results-table"] tbody tr').should('have.length', 4);
     cy.get('[data-testid="inference-results-table"] tbody')
-      .contains('tr', '7.0')
+      .contains('td', /^4\.0$/u)
+      .parent('tr')
+      .find('td')
+      .last()
+      .should('have.text', '407.5');
+    cy.get('[data-testid="inference-results-table"] tbody')
+      .contains('td', /^4\.5$/u)
+      .parent('tr')
+      .find('td')
+      .last()
+      .should('have.text', '407.5');
+    cy.get('[data-testid="inference-results-table"] tbody')
+      .contains('td', /^7\.0$/u)
+      .parent('tr')
       .should('contain.text', 'SGLang')
       .find('td')
       .eq(2)
       .should('have.text', '8');
     cy.get('[data-testid="inference-results-table"] tbody')
-      .contains('tr', '7.5')
+      .contains('td', /^7\.5$/u)
+      .parent('tr')
       .should('contain.text', 'vLLM')
       .find('td')
       .eq(2)

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -108,6 +108,8 @@ export interface AggDataEntry {
   mean_tpot: number;
   mean_intvty: number;
   median_tpot: number;
+  /** Original AIPerf P50 decode interactivity before AgentX full-response canonicalization. */
+  median_tpot_intvty?: number;
   median_intvty: number;
   std_tpot: number;
   std_intvty: number;

--- a/packages/app/src/components/inference/ui/InferenceTable.tsx
+++ b/packages/app/src/components/inference/ui/InferenceTable.tsx
@@ -5,15 +5,44 @@ import { useMemo } from 'react';
 import type { ChartDefinition, InferenceData } from '@/components/inference/types';
 import { type DataTableColumn, DataTable } from '@/components/ui/data-table';
 import { getHardwareConfig } from '@/lib/constants';
-import { getNestedYValue } from '@/lib/chart-utils';
+import { getNestedYValue, metricLabel } from '@/lib/chart-utils';
 import { sortRowsByYMetric } from '@/components/inference/ui/inference-table-sort';
 import { type Precision, getPrecisionLabel } from '@/lib/data-mappings';
+import { p50Interactivity } from '@/lib/interactivity-metrics';
+import { useLocale } from '@/lib/use-locale';
 import { getDisplayLabel } from '@/lib/utils';
 
 interface InferenceTableProps {
   data: InferenceData[];
   chartDefinition: ChartDefinition;
   selectedYAxisMetric: string;
+}
+
+const STRINGS = {
+  en: {
+    chip: 'Chip',
+    precision: 'Precision',
+    concurrency: 'Conc',
+    throughputPerChip: 'Throughput/Chip (tok/s)',
+    medianTtft: 'Median TTFT (ms)',
+    p50Interactivity: 'P50 Interactivity (tok/s/user)',
+  },
+  zh: {
+    chip: 'Chip',
+    precision: '精度',
+    concurrency: '并发数',
+    throughputPerChip: '吞吐量/Chip (tok/s)',
+    medianTtft: '中位 TTFT (ms)',
+    p50Interactivity: 'P50 交互性 (tok/s/user)',
+  },
+} as const;
+
+function xAxisLabel(label: string, locale: 'en' | 'zh'): string {
+  if (locale === 'en') return label;
+  return label
+    .replace('Time To First Token', '首 token 延迟（TTFT）')
+    .replace('End-to-end Latency', '端到端延迟')
+    .replace('Interactivity', '交互性');
 }
 
 /** Format a number for table display — picks sensible precision based on magnitude. */
@@ -30,9 +59,11 @@ export default function InferenceTable({
   chartDefinition,
   selectedYAxisMetric,
 }: InferenceTableProps) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
   const yPath = chartDefinition[selectedYAxisMetric as keyof ChartDefinition] as string | undefined;
-  const yLabel = chartDefinition[`${selectedYAxisMetric}_label` as keyof ChartDefinition] as string;
-  const xLabel = chartDefinition.x_label;
+  const yLabel = metricLabel(chartDefinition, selectedYAxisMetric, locale);
+  const xLabel = xAxisLabel(chartDefinition.x_label, locale);
 
   const sorted = useMemo(
     () => sortRowsByYMetric(data, chartDefinition, selectedYAxisMetric),
@@ -42,13 +73,13 @@ export default function InferenceTable({
   const columns = useMemo<DataTableColumn<InferenceData>[]>(
     () => [
       {
-        header: 'Chip',
+        header: t.chip,
         cell: (row) => getDisplayLabel(getHardwareConfig(row.hwKey, row.model)),
         sortValue: (row) => getDisplayLabel(getHardwareConfig(row.hwKey, row.model)),
         className: 'font-medium whitespace-nowrap',
       },
       {
-        header: 'Precision',
+        header: t.precision,
         cell: (row) => (row.precision ? getPrecisionLabel(row.precision as Precision) : ''),
         sortValue: (row) => row.precision ?? '',
         className: 'whitespace-nowrap',
@@ -61,7 +92,7 @@ export default function InferenceTable({
         className: 'tabular-nums',
       },
       {
-        header: 'Conc',
+        header: t.concurrency,
         align: 'right',
         cell: (row) => row.conc,
         sortValue: (row) => row.conc,
@@ -82,28 +113,28 @@ export default function InferenceTable({
         className: 'tabular-nums',
       },
       {
-        header: 'Throughput/Chip (tok/s)',
+        header: t.throughputPerChip,
         align: 'right',
         cell: (row) => fmt(row.tput_per_gpu ?? 0, 1),
         sortValue: (row) => row.tput_per_gpu ?? 0,
         className: 'tabular-nums',
       },
       {
-        header: 'Median TTFT (ms)',
+        header: t.medianTtft,
         align: 'right',
         cell: (row) => fmt((row.median_ttft ?? 0) * 1000, 0),
         sortValue: (row) => row.median_ttft ?? 0,
         className: 'tabular-nums',
       },
       {
-        header: 'Median Interactivity (tok/s)',
+        header: t.p50Interactivity,
         align: 'right',
-        cell: (row) => fmt(row.median_intvty ?? 0, 1),
-        sortValue: (row) => row.median_intvty ?? 0,
+        cell: (row) => fmt(p50Interactivity(row), 1),
+        sortValue: p50Interactivity,
         className: 'tabular-nums',
       },
     ],
-    [yPath, yLabel, xLabel],
+    [t, yPath, yLabel, xLabel],
   );
 
   return (

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -134,6 +134,7 @@ describe('rowToAggDataEntry', () => {
         metrics: {
           median_itl: 0.000003,
           median_intvty: 333_333,
+          median_tpot: 0.00245,
           median_full_response_itl: 0.005,
           median_full_response_intvty: 200,
           std_full_response_itl: 0.001,
@@ -143,7 +144,10 @@ describe('rowToAggDataEntry', () => {
     );
 
     expect(entry.median_itl).toBe(0.005);
-    expect(entry.median_tpot).toBe(0.005);
+    // The ordinary decode TPOT remains available to table consumers even
+    // though chart interactivity is canonicalized from full-response ITL.
+    expect(entry.median_tpot).toBe(0.00245);
+    expect(entry.median_tpot_intvty).toBe(333_333);
     expect(entry.median_intvty).toBe(200);
     expect(entry.std_itl).toBe(0.001);
     expect(entry.std_intvty).toBe(20);

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { getPointLabel } from '@/components/inference/utils/tooltipUtils';
 import type { BenchmarkRow } from '@/lib/api';
 import { dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
+import { p50Interactivity } from '@/lib/interactivity-metrics';
 
 import {
   mergeRunScopedRows,
@@ -130,6 +131,7 @@ describe('rowToAggDataEntry', () => {
   it('prefers full-response AgentX ITL and interactivity for artifact overlays', () => {
     const entry = rowToAggDataEntry(
       makeRow({
+        id: undefined,
         benchmark_type: 'agentic_traces',
         metrics: {
           median_itl: 0.000003,
@@ -151,6 +153,31 @@ describe('rowToAggDataEntry', () => {
     expect(entry.median_intvty).toBe(200);
     expect(entry.std_itl).toBe(0.001);
     expect(entry.std_intvty).toBe(20);
+  });
+
+  it('does not mistake rounded full-response interactivity for persisted artifact P50', () => {
+    const entry = rowToAggDataEntry(
+      makeRow({
+        id: 440_025,
+        hardware: 'b200',
+        framework: 'trt',
+        model: 'minimaxm3',
+        benchmark_type: 'agentic_traces',
+        conc: 15,
+        prefill_tp: 4,
+        decode_tp: 4,
+        metrics: {
+          median_tpot: 0.00247,
+          median_intvty: 1 / 0.00077,
+          median_full_response_itl: 0.00077,
+          median_full_response_intvty: 1296.21319,
+        },
+      }),
+    );
+
+    expect(entry.median_tpot_intvty).toBeUndefined();
+    expect(entry.median_intvty).toBeCloseTo(1 / 0.00077, 10);
+    expect(p50Interactivity(entry)).toBeCloseTo(1 / 0.00247, 10);
   });
 
   it('defaults missing metrics to 0', () => {

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -76,6 +76,16 @@ function applyAgenticMetricAliases(raw: Record<string, number>): Record<string, 
 /** Convert a DB benchmark row to an AggDataEntry. */
 export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
   const isAgentic = row.benchmark_type === 'agentic_traces';
+  const originalMedianInteractivity = row.metrics.median_intvty;
+  const fullResponseMedianInteractivity = row.metrics.median_full_response_intvty;
+  const medianTpotInteractivity =
+    row.metrics.median_tpot_intvty ??
+    (isAgentic &&
+    typeof originalMedianInteractivity === 'number' &&
+    originalMedianInteractivity > 0 &&
+    originalMedianInteractivity !== fullResponseMedianInteractivity
+      ? originalMedianInteractivity
+      : undefined);
   const m = isAgentic ? applyAgenticMetricAliases(row.metrics) : row.metrics;
   // Non-disaggregated multinode artifacts historically stored their one
   // aggregate engine topology in the prefill-shaped fields and left the
@@ -154,6 +164,7 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     'p99.9_ttft': m['p99.9_ttft'] ?? 0,
     mean_tpot: m.mean_tpot ?? 0,
     median_tpot: m.median_tpot ?? 0,
+    median_tpot_intvty: medianTpotInteractivity,
     std_tpot: m.std_tpot ?? 0,
     p75_tpot: m.p75_tpot ?? 0,
     p90_tpot: m.p90_tpot ?? 0,

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -76,11 +76,17 @@ function applyAgenticMetricAliases(raw: Record<string, number>): Record<string, 
 /** Convert a DB benchmark row to an AggDataEntry. */
 export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
   const isAgentic = row.benchmark_type === 'agentic_traces';
+  // Postgres bigint comes through the SQL client as a string; coerce it. Raw
+  // unofficial-run artifact rows have no persisted id, which also lets us
+  // distinguish their pre-alias metrics from already-normalized DB rows.
+  const numericId = typeof row.id === 'number' ? row.id : Number(row.id);
+  const isPersisted = isPersistedBenchmarkId(numericId);
   const originalMedianInteractivity = row.metrics.median_intvty;
   const fullResponseMedianInteractivity = row.metrics.median_full_response_intvty;
   const medianTpotInteractivity =
     row.metrics.median_tpot_intvty ??
-    (isAgentic &&
+    (!isPersisted &&
+    isAgentic &&
     typeof originalMedianInteractivity === 'number' &&
     originalMedianInteractivity > 0 &&
     originalMedianInteractivity !== fullResponseMedianInteractivity
@@ -134,15 +140,9 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     const value = rawMetrics[key];
     return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
   };
-  // Postgres bigint comes through the SQL client as a string; coerce it. Overlay
-  // rows (transformed live from raw artifacts) carry no id, so `Number(undefined)`
-  // is NaN — collapse any non-persisted value to undefined so downstream link /
-  // fetch sites (guarded by isPersistedBenchmarkId) skip it cleanly rather than
-  // emitting `?ids=NaN` or an `/inference/agentic/NaN` link.
-  const numericId = typeof row.id === 'number' ? row.id : Number(row.id);
   return {
     rawMetricKeys: Object.keys(m),
-    id: isPersistedBenchmarkId(numericId) ? numericId : undefined,
+    id: isPersisted ? numericId : undefined,
     recipe_fingerprint: row.recipe_fingerprint ?? undefined,
     hw: row.hardware,
     framework: row.framework,

--- a/packages/app/src/lib/csv-export-helpers.test.ts
+++ b/packages/app/src/lib/csv-export-helpers.test.ts
@@ -64,6 +64,7 @@ describe('inferenceChartToCsv', () => {
     expect(headers).toContain('Mean TTFT (s)');
     expect(headers).toContain('P99 TTFT (s)');
     expect(headers).toContain('Mean Interactivity (tok/s/user)');
+    expect(headers).toContain('P50 Interactivity (tok/s/user)');
     expect(headers).toContain('Mean E2E Latency (s)');
     expect(headers).toContain('Disaggregated');
     expect(headers).toContain('EP');
@@ -71,6 +72,27 @@ describe('inferenceChartToCsv', () => {
     expect(headers).toContain('Run URL');
     expect(rows).toHaveLength(1);
     expect(rows[0]).toHaveLength(headers.length);
+  });
+
+  it('exports P50 interactivity from median TPOT for official and overlay AgentX rows', () => {
+    const official = makePoint({
+      benchmark_type: 'agentic_traces',
+      median_tpot: 0.00245,
+      median_tpot_intvty: 407.50337,
+      median_intvty: 1315.8,
+    });
+    const overlay = makePoint({
+      id: undefined,
+      benchmark_type: 'agentic_traces',
+      median_tpot: 0.00245,
+      median_tpot_intvty: 407.50337,
+      median_intvty: 1312.6527,
+    });
+    const { headers, rows } = inferenceChartToCsv([official], 'MiniMax-M3', 'agentic', [overlay]);
+    const p50Index = headers.indexOf('P50 Interactivity (tok/s/user)');
+
+    expect(rows[0][p50Index]).toBeCloseTo(407.50337, 5);
+    expect(rows[1][p50Index]).toBeCloseTo(407.50337, 5);
   });
 
   it('includes Model, ISL, and OSL columns from model and sequence', () => {

--- a/packages/app/src/lib/csv-export-helpers.ts
+++ b/packages/app/src/lib/csv-export-helpers.ts
@@ -8,6 +8,7 @@
  */
 
 import type { InferenceData, TrendDataPoint } from '@/components/inference/types';
+import { p50Interactivity } from '@/lib/interactivity-metrics';
 import type { SubmissionVolumeRow } from '@/lib/submissions-types';
 
 import { sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
@@ -38,6 +39,18 @@ function benchmarkMetric(point: InferenceData, key: string): number | '' {
   if (point.rawMetricKeys && !point.rawMetricKeys.includes(key)) return '';
   const value = point[key as keyof InferenceData];
   return typeof value === 'number' ? value : '';
+}
+
+function p50InteractivityMetric(point: InferenceData): number | '' {
+  if (
+    point.rawMetricKeys &&
+    !point.rawMetricKeys.includes('median_tpot_intvty') &&
+    !point.rawMetricKeys.includes('median_tpot') &&
+    !point.rawMetricKeys.includes('median_intvty')
+  ) {
+    return '';
+  }
+  return p50Interactivity(point);
 }
 
 /**
@@ -80,7 +93,7 @@ export function inferenceChartToCsv(
     'Std TPOT (s)',
     // Interactivity
     'Mean Interactivity (tok/s/user)',
-    'Median Interactivity (tok/s/user)',
+    'P50 Interactivity (tok/s/user)',
     'P99 Interactivity (tok/s/user)',
     'Std Interactivity (tok/s/user)',
     // ITL
@@ -147,7 +160,7 @@ export function inferenceChartToCsv(
         benchmarkMetric(d, 'p99_tpot'),
         benchmarkMetric(d, 'std_tpot'),
         benchmarkMetric(d, 'mean_intvty'),
-        benchmarkMetric(d, 'median_intvty'),
+        p50InteractivityMetric(d),
         benchmarkMetric(d, 'p99_intvty'),
         benchmarkMetric(d, 'std_intvty'),
         benchmarkMetric(d, 'mean_itl'),

--- a/packages/app/src/lib/interactivity-metrics.test.ts
+++ b/packages/app/src/lib/interactivity-metrics.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { p50Interactivity } from './interactivity-metrics';
+
+describe('p50Interactivity', () => {
+  it('uses median TPOT instead of canonical full-response interactivity for AgentX rows', () => {
+    expect(
+      p50Interactivity({
+        median_tpot: 0.00245,
+        median_tpot_intvty: 407.50337,
+        median_intvty: 1315.8,
+      }),
+    ).toBeCloseTo(407.50337, 5);
+  });
+
+  it('uses the same P50 metric for unofficial-run overlay data', () => {
+    expect(
+      p50Interactivity({
+        median_tpot: 0.00245,
+        median_tpot_intvty: 407.50337,
+        median_intvty: 1312.6527,
+      }),
+    ).toBeCloseTo(407.50337, 5);
+  });
+
+  it('falls back to stored median interactivity when median TPOT is unavailable', () => {
+    expect(p50Interactivity({ median_tpot: 0, median_intvty: 52.4 })).toBe(52.4);
+  });
+
+  it('returns zero for invalid TPOT and interactivity values', () => {
+    expect(p50Interactivity({ median_tpot: Number.NaN, median_intvty: -1 })).toBe(0);
+  });
+});

--- a/packages/app/src/lib/interactivity-metrics.ts
+++ b/packages/app/src/lib/interactivity-metrics.ts
@@ -1,0 +1,24 @@
+export interface P50InteractivityMetrics {
+  median_tpot?: number;
+  median_tpot_intvty?: number;
+  median_intvty?: number;
+}
+
+/**
+ * Ordinary decode P50 interactivity, expressed as the reciprocal of median
+ * time per output token. AgentX's canonical chart interactivity may use
+ * full-response ITL instead, so consumers that promise P50 TPOT semantics
+ * must not read `median_intvty` first.
+ */
+export function p50Interactivity(metrics: P50InteractivityMetrics): number {
+  const directP50 = metrics.median_tpot_intvty;
+  if (typeof directP50 === 'number' && Number.isFinite(directP50) && directP50 > 0) {
+    return directP50;
+  }
+  const medianTpot = metrics.median_tpot;
+  if (typeof medianTpot === 'number' && Number.isFinite(medianTpot) && medianTpot > 0) {
+    return 1 / medianTpot;
+  }
+  const fallback = metrics.median_intvty;
+  return typeof fallback === 'number' && Number.isFinite(fallback) && fallback > 0 ? fallback : 0;
+}

--- a/packages/constants/src/metric-keys.ts
+++ b/packages/constants/src/metric-keys.ts
@@ -62,6 +62,9 @@ export const METRIC_KEYS = new Set([
   'p99_intvty',
   'p99.9_intvty',
   'std_intvty',
+  // AIPerf's ordinary decode-cadence P50 (1 / median TPOT). AgentX ingest
+  // preserves it before full-response interactivity replaces median_intvty.
+  'median_tpot_intvty',
   // Full-response AgentX timing. These namespaced fields preserve provenance;
   // ingest mirrors them onto the canonical *_itl / *_intvty chart fields.
   'median_full_response_itl',

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -1055,6 +1055,7 @@ describe('mapBenchmarkRow — v3 agentic nested agg schema', () => {
     expect(metrics.median_full_response_itl).toBe(0.004);
     expect(metrics.p75_full_response_itl).toBe(0.006);
     expect(metrics.median_itl).toBe(0.004);
+    expect(metrics.median_tpot_intvty).toBeCloseTo(27.19411, 2);
     expect(metrics.p75_intvty).toBeCloseTo(1 / 0.006, 6);
     expect(metrics.std_itl).toBe(0.001);
     expect(metrics.std_intvty).toBe(20);

--- a/packages/db/src/etl/full-response-interactivity.test.ts
+++ b/packages/db/src/etl/full-response-interactivity.test.ts
@@ -104,6 +104,7 @@ describe('preferFullResponseMetrics', () => {
 
     expect(metrics.median_itl).toBe(0.005);
     expect(metrics.median_intvty).toBe(200);
+    expect(metrics.median_tpot_intvty).toBe(333_333);
     expect(metrics).not.toHaveProperty('p99_itl');
     expect(metrics).not.toHaveProperty('p99_intvty');
   });

--- a/packages/db/src/etl/full-response-interactivity.ts
+++ b/packages/db/src/etl/full-response-interactivity.ts
@@ -165,6 +165,16 @@ export function preferFullResponseMetrics(metrics: Record<string, number>): Reco
   );
   if (!hasFullResponse) return out;
 
+  const medianTpotInteractivity = out.median_intvty;
+  if (
+    typeof medianTpotInteractivity === 'number' &&
+    Number.isFinite(medianTpotInteractivity) &&
+    medianTpotInteractivity > 0 &&
+    out.median_tpot_intvty === undefined
+  ) {
+    out.median_tpot_intvty = medianTpotInteractivity;
+  }
+
   for (const stat of FULL_RESPONSE_STAT_KEYS) {
     delete out[`${stat}_itl`];
     delete out[`${stat}_intvty`];


### PR DESCRIPTION
## Summary

- Preserve AIPerf's original, unrounded P50 decode interactivity as `median_tpot_intvty` before AgentX full-response interactivity replaces the canonical chart field.
- Show **P50 Interactivity (tok/s/user)** in the inference results table and export the same value in CSV.
- Prefer the preserved artifact value, fall back to `1 / median_tpot` for historical persisted rows, and use `median_intvty` only as the final compatibility fallback.
- Distinguish persisted benchmark rows from id-less raw `?unofficialrun=` overlay rows so rounded full-response values cannot be mistaken for ordinary P50.
- Localize the table headers and metric labels for the `/zh` dashboard.

## Root cause

AgentX ingest intentionally canonicalizes `median_intvty` from full-response ITL for chart and slow-tail percentile behavior. The table reused that canonical field, so run 32186088945 displayed about 1,315.8 tok/s/user instead of AIPerf's ordinary P50 interactivity of 407.50337 tok/s/user.

The first PR version tried to recognize older raw artifact rows by comparing `median_intvty` with `median_full_response_intvty`. That comparison is valid for id-less unofficial-run artifacts, but not for already persisted rows: historical ingest derived the canonical value from rounded `median_full_response_itl`. For B200 TRTLLM, TP=4, concurrency=15 (row 440025, run 32186776214), that produced 1,298.701 from `1 / 0.00077`, while the namespaced full-response value is 1,296.21319. Their small rounding difference caused the preview to misclassify 1,298.701 as the ordinary P50.

The fix gates that inference to id-less raw overlay rows. Persisted rows without `median_tpot_intvty` now use `1 / median_tpot`; this B200 point therefore displays approximately 404.858 until it is re-ingested, rather than 1,298.7. Newly ingested data uses the exact artifact value.

## Existing point repair

After this PR is merged, run `bun run admin:db:ingest:run 32186776214` from the latest `master` to re-ingest GitHub Actions run 32186776214 (attempt 1). Ingestion is idempotent and will restore the artifact's exact ordinary P50 value, 404.4968 tok/s/user, into `median_tpot_intvty`, then refresh the materialized view. Run `bun run admin:cache:invalidate` afterward so the API serves the repaired row. Until that repair, the UI's TPOT fallback is `1 / 0.00247 ≈ 404.858`.

An audited `BENCHMARK_POINT_BACKFILLS` entry is an alternative if re-ingestion is unsuitable; an ad hoc production SQL update should not be used. This PR performs no production database writes.

## Unofficial-run overlays

Works for both official runs and `?unofficialrun=` overlays. Raw id-less overlays retain their exact AIPerf P50 when present, while persisted official rows follow the preserved-value/TPOT fallback path.

## Validation

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `bun run test:unit` — 223 files, 4,066 tests passed across workspaces
- `bun --cwd packages/app vitest run src/lib/benchmark-transform.test.ts src/lib/interactivity-metrics.test.ts` — 102 tests passed
- `bun --env-file=../../.env vitest run src/lib/api-route-catalog.test.ts` — 7 tests passed
- `bun --cwd packages/app cypress run --component --spec cypress/component/scatter-graph.cy.tsx` — 19 tests passed
- `bun run test:e2e` — the 25-test component smoke portion passed; integration verification could not start because no database-backed local server was available at `localhost:3000`.
- Manual in-app-browser verification was unavailable because no browser instance was connected.

## 中文说明

- 在 AgentX 全响应交互性覆盖图表规范字段之前，将 AIPerf 原始、未舍入的 P50 解码交互性保存在 `median_tpot_intvty`。
- 推理结果表改为显示 **P50 交互性（tok/s/user）**，CSV 导出使用同一数值。
- 优先使用产物中保留的精确值；历史已入库数据回退到 `1 / median_tpot`，仅在两者均不可用时才使用 `median_intvty` 兼容旧数据。
- 区分已入库基准测试记录和没有 ID 的原始 `?unofficialrun=` 覆盖数据，避免把舍入后的全响应数值误判为普通 P50。
- 为 `/zh` 仪表板补充表头与指标名称的中文显示。

## 根因

AgentX 数据摄取会按设计使用全响应 ITL 规范化 `median_intvty`，供图表和慢尾百分位选择器使用。结果表此前直接复用了该字段，导致工作流 32186088945 显示约 1,315.8 tok/s/user，而不是 AIPerf 报告的普通 P50 交互性 407.50337 tok/s/user。

PR 的首个版本通过比较 `median_intvty` 与 `median_full_response_intvty` 来识别旧格式原始产物。这个判断适用于没有 ID 的非官方运行原始数据，却不适用于已入库记录：历史摄取流程会根据已舍入的 `median_full_response_itl` 计算规范值。B200 TRTLLM、TP=4、并发数=15（记录 440025，工作流 32186776214）因此由 `1 / 0.00077` 得到 1,298.701，而命名空间中的精确全响应值为 1,296.21319。两者仅因舍入产生的微小差异，导致预览环境把 1,298.701 错判为普通 P50。

本次修复将该推断限制在没有 ID 的原始覆盖数据。已入库且缺少 `median_tpot_intvty` 的记录现在回退到 `1 / median_tpot`；因此该 B200 数据点在重新摄取前会显示约 404.858，而不再是 1,298.7。新摄取的数据会直接使用产物中的精确值。

## 现有数据点修复

本 PR 合并后，从最新 `master` 执行 `bun run admin:db:ingest:run 32186776214`，重新摄取 GitHub Actions 工作流 32186776214（attempt 1）。摄取流程是幂等的，会把产物中的精确普通 P50 值 404.4968 tok/s/user 写入 `median_tpot_intvty` 并刷新物化视图。随后执行 `bun run admin:cache:invalidate`，让 API 返回修复后的记录。在修复该记录之前，UI 会使用 TPOT 回退值 `1 / 0.00247 ≈ 404.858`。

如果不适合重新摄取，也可以添加经过审计的 `BENCHMARK_POINT_BACKFILLS` 条目；不应直接执行临时生产 SQL。本 PR 不会写入生产数据库。

## 非官方运行覆盖

正式运行与 `?unofficialrun=` 非官方运行覆盖均受支持。没有 ID 的原始覆盖数据会保留其精确 AIPerf P50；已入库正式数据则按“保留值优先、TPOT 回退”的路径处理。

## 验证

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `bun run test:unit` — 各 workspace 共 223 个测试文件、4,066 个测试通过
- `bun --cwd packages/app vitest run src/lib/benchmark-transform.test.ts src/lib/interactivity-metrics.test.ts` — 102 个测试通过
- `bun --env-file=../../.env vitest run src/lib/api-route-catalog.test.ts` — 7 个测试通过
- `bun --cwd packages/app cypress run --component --spec cypress/component/scatter-graph.cy.tsx` — 19 个测试通过
- `bun run test:e2e` — 组件冒烟测试部分的 25 个测试通过；由于 `localhost:3000` 没有可用的数据库后端本地服务器，集成测试无法启动。
- 当前没有连接可用的内置浏览器实例，因此未能进行手动页面验证。
