### PR TITLE
chore(nudges): restate the AgentX launch banner subtitle / 重写落地页 AgentX 横幅副标题

### DIFF
--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -384,8 +384,10 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       iconClassName: 'text-brand',
       title: 'Agentic benchmark results are live',
       titleZh: '智能体基准测试结果已上线',
-      description: 'Compare AgentX across supported models, chips, and serving stacks.',
-      descriptionZh: '对比 AgentX 在支持模型、Chip 与推理服务栈上的表现。',
+      description:
+        "AgentX is the World's First Fully Realistic Open Sourced 1 Mil+ Long Context Length, Multi-Turn Agentic Benchmark",
+      descriptionZh:
+        'AgentX 是全球首个完全贴近真实场景、开源的百万级 (1M+) 长上下文多轮智能体基准测试',
       testId: 'launch-banner',
       badge: 'New',
       badgeZh: '最新',


### PR DESCRIPTION
## Summary

The landing banner's subtitle described what the reader could *do* with AgentX rather than what AgentX *is*. Replaced with the positioning claim.

| | Before | After |
| --- | --- | --- |
| EN | Compare AgentX across supported models, chips, and serving stacks. | AgentX is the World's First Fully Realistic Open Sourced 1 Mil+ Long Context Length, Multi-Turn Agentic Benchmark |
| ZH | 对比 AgentX 在支持模型、Chip 与推理服务栈上的表现。 | AgentX 是全球首个完全贴近真实场景、开源的百万级 (1M+) 长上下文多轮智能体基准测试 |

The banner title (`Agentic benchmark results are live`), badge, link target, and analytics events are unchanged.

## Changes

- `packages/app/src/lib/nudges/registry.tsx` — `description` / `descriptionZh` of the `agentic-results-launch-banner` nudge.

## Notes

- **Copy-only, both locales updated in the same commit** — no `/zh` page or component work is needed; the banner resolves `descriptionZh` through the existing locale-aware nudge renderer.
- **No test changes required.** `cypress/e2e/nudge-system.cy.ts` asserts on the banner *title* and link label, not the subtitle, so the existing assertions still hold. `src/lib/nudges/registry.test.ts` checks ids and the modal's storage key.
- **Not an overlay/chart feature**, so the unofficial-run overlay requirement in AGENTS.md does not apply.
- The new subtitle is noticeably longer than the old one; worth an eyeball on the preview deploy at mobile widths to confirm the banner wraps acceptably.

## Verification

```
bun run lint        # pass
bun run fmt         # pass
bun run typecheck   # pass
bun vitest run src/lib/nudges/   # 3 files, 49 tests passed
```

## 中文说明

落地页横幅的副标题原本描述的是读者能用 AgentX **做什么**，而不是 AgentX **是什么**。现改为定位性表述（见上方对照表），英文与简体中文文案在同一提交中同步更新。

横幅标题、`NEW` 徽标、跳转链接与埋点事件均保持不变。

**改动文件**：`packages/app/src/lib/nudges/registry.tsx` 中 `agentic-results-launch-banner` 的 `description` / `descriptionZh`。

**说明**：

- 纯文案改动，两种语言同步更新；横幅通过现有的多语言 nudge 渲染逻辑读取 `descriptionZh`，无需新增 `/zh` 页面或组件改动。
- 无需改动测试。`nudge-system.cy.ts` 断言的是横幅**标题**和链接文字，不涉及副标题；`registry.test.ts` 校验的是 nudge id 与弹窗的 storage key。
- 该改动不属于图表功能，因此 AGENTS.md 中关于非官方运行 (unofficial run) 叠加层的要求不适用。
- 新副标题明显更长，建议在预览部署上确认移动端宽度下的换行效果。

**验证**：`lint`、`fmt`、`typecheck` 均通过；nudges 单元测试 3 个文件 49 项全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in the nudge registry with no logic, routing, or test assertion updates.
> 
> **Overview**
> Updates only the **subtitle** (`description` / `descriptionZh`) on the landing **`agentic-results-launch-banner`** nudge in `registry.tsx`.
> 
> The copy shifts from inviting users to compare AgentX across models, chips, and stacks to a **positioning claim**: AgentX as the first fully realistic, open-source 1M+ long-context, multi-turn agentic benchmark (English and Chinese updated together).
> 
> Title, badge, link to `/inference?i_seq=agentic-traces`, dismissal, and analytics are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdcc907419485f9e4ae8638ed92b0c17a0417912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->