### PR TITLE
chore(nav): lead with AgentX, and link the harness from the footer / 导航以 AgentX 为首并在页脚新增 harness 链接

### DIFF
--- a/packages/app/cypress/component/footer.cy.tsx
+++ b/packages/app/cypress/component/footer.cy.tsx
@@ -49,8 +49,13 @@ describe('Footer', () => {
     cy.get('[data-testid="footer-link-benchmarks"]')
       .should('have.attr', 'href')
       .and('include', 'github.com/SemiAnalysisAI/InferenceX');
-    cy.get('[data-testid="footer-link-frontend"]')
-      .should('have.attr', 'href')
+    cy.get('[data-testid="footer-link-agentx-harness"]')
+      .should('contain.text', 'AgentX Harness')
+      .and('have.attr', 'href')
+      .and('include', 'github.com/SemiAnalysisAI/agentx-harness');
+    cy.get('[data-testid="footer-link-visualization"]')
+      .should('contain.text', 'Visualization')
+      .and('have.attr', 'href')
       .and('include', 'github.com/SemiAnalysisAI/InferenceX-app');
   });
 

--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -128,6 +128,15 @@ describe('Header', () => {
       .should('have.text', '新');
   });
 
+  it('orders the nav with AgentX first', () => {
+    const expected = ['AgentX', 'Home', 'Overview', 'Dashboard', 'Comparisons', 'About'];
+    cy.get('[data-testid^="nav-link-"]').then(($links) => {
+      // Strip the NEW badge so the comparison is against the label alone.
+      const labels = [...$links].map((link) => (link.textContent ?? '').replace('NEW', '').trim());
+      expect(labels).to.deep.equal(expected);
+    });
+  });
+
   it('keeps footer destinations out of the primary nav', () => {
     cy.get('[data-testid="nav-link-supporters"]').should('not.exist');
     cy.get('[data-testid="nav-link-blog"]').should('not.exist');

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -23,7 +23,8 @@ const STRINGS = {
     cookiePolicy: 'Cookie Policy',
     contribute: 'Contribute',
     benchmarks: 'Benchmarks',
-    frontend: 'Frontend',
+    agentxHarness: 'AgentX Harness',
+    visualization: 'Visualization',
     more: 'More',
     supporters: 'Supporters',
     agentx: 'AgentX',
@@ -51,7 +52,8 @@ const STRINGS = {
     cookiePolicy: 'Cookie 政策',
     contribute: '参与贡献',
     benchmarks: '基准测试仓库',
-    frontend: '前端仓库',
+    agentxHarness: 'AgentX 框架仓库',
+    visualization: '可视化仓库',
     more: '更多',
     supporters: '支持者',
     agentx: 'AgentX',
@@ -177,13 +179,22 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 {t.benchmarks}
               </a>
               <a
-                data-testid="footer-link-frontend"
+                data-testid="footer-link-agentx-harness"
+                href="https://github.com/SemiAnalysisAI/agentx-harness"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.agentxHarness}
+              </a>
+              <a
+                data-testid="footer-link-visualization"
                 href="https://github.com/SemiAnalysisAI/InferenceX-app"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
-                {t.frontend}
+                {t.visualization}
               </a>
             </div>
             <div data-testid="footer-links-more" className="flex flex-col gap-2.5">

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -42,6 +42,15 @@ interface NavLink {
 }
 
 const NAV_LINKS: readonly NavLink[] = [
+  // AgentX leads the nav: it is the flagship benchmark, and the surface every
+  // other entry ultimately explains.
+  {
+    href: '/agentx',
+    label: 'AgentX',
+    testId: 'nav-link-agentx',
+    event: 'header_agentx_clicked',
+    badge: { en: 'NEW', zh: '新' },
+  },
   { href: '/', label: 'Home', testId: 'nav-link-home', event: 'header_home_clicked' },
   {
     href: '/overview',
@@ -60,13 +69,6 @@ const NAV_LINKS: readonly NavLink[] = [
     label: 'Comparisons',
     testId: 'nav-link-compare',
     event: 'header_compare_clicked',
-  },
-  {
-    href: '/agentx',
-    label: 'AgentX',
-    testId: 'nav-link-agentx',
-    event: 'header_agentx_clicked',
-    badge: { en: 'NEW', zh: '新' },
   },
   { href: '/about', label: 'About', testId: 'nav-link-about', event: 'header_about_clicked' },
 ] as const;


### PR DESCRIPTION
## Summary

Two small chrome changes.

**1. Primary nav — AgentX first.**

| | Order |
| --- | --- |
| Before | Home · Overview · Dashboard · Comparisons · AgentX `NEW` · About |
| After | **AgentX `NEW`** · Home · Overview · Dashboard · Comparisons · About |

The entry itself is unchanged — same href, same testid, same `NEW` badge, same analytics event and active-state matching. Only its position in `NAV_LINKS` moves. The mobile menu and the `/zh` tree read from the same array, so both follow.

**2. Footer Contribute column.**

| | Before | After |
| --- | --- | --- |
| | Benchmarks | Benchmarks |
| | — | **AgentX Harness** → `github.com/SemiAnalysisAI/agentx-harness` |
| | Frontend | **Visualization** (same href: `InferenceX-app`) |

The two benchmark repos sit together, then the site. "Frontend" undersold what that repo is — it's the whole visualization layer, so the label now says that. Chinese: 前端仓库 → 可视化仓库, plus AgentX 框架仓库 for the new entry.

## Changes

- `src/components/header/header.tsx` — `NAV_LINKS` reorder.
- `src/components/footer/footer.tsx` — new link, `frontend` → `visualization` string key (both locales), `data-testid="footer-link-frontend"` → `footer-link-visualization`.
- `cypress/component/header.cy.tsx` — new test asserting the full nav order, so a future reorder is caught rather than silently shipped.
- `cypress/component/footer.cy.tsx` — Contribute-section test covers all three links.

## Verification

```
bun run lint / fmt / typecheck                                    # pass
cypress run --component --spec header.cy.tsx,footer.cy.tsx        # 33/33 passed
```

Confirmed against a local dev server: nav renders `agentx, home, overview, dashboard, compare, about` in that order on both `/` and `/zh`, and the footer shows all three Contribute links with the translated Chinese labels on `/zh`.

`SemiAnalysisAI/agentx-harness` is confirmed public (`visibility: public` via the GitHub API), so the new footer link is not a dead end for logged-out visitors.

## Notes

The `footer-link-frontend` testid is renamed rather than kept as an alias — the only reference was the footer component spec, updated here. Nothing else in `src/` or `cypress/` referenced it.

## 中文说明

两处站点框架的小改动。

**1. 主导航以 AgentX 为首。** 顺序由 `Home · Overview · Dashboard · Comparisons · AgentX · About` 改为 `AgentX · Home · Overview · Dashboard · Comparisons · About`。该条目本身未变——href、testid、`NEW` 徽标、埋点事件与高亮匹配逻辑均保持原样，仅调整其在 `NAV_LINKS` 中的位置。移动端菜单与 `/zh` 页面读取同一数组，因此会同步变化。

**2. 页脚"参与贡献"栏。** 新增 AgentX Harness 仓库链接（`github.com/SemiAnalysisAI/agentx-harness`），置于 Benchmarks 之后，使两个基准测试仓库相邻，站点仓库排在最后。同时将 InferenceX-app 条目由 Frontend / 前端仓库改为 Visualization / 可视化仓库——"前端"低估了该仓库的职责，它承载的是整个可视化层。

**改动文件**：`header.tsx`（导航顺序）、`footer.tsx`（新增链接与文案键重命名，中英同步）、`header.cy.tsx`（新增导航顺序断言，避免日后被无声改动）、`footer.cy.tsx`（贡献栏三个链接全覆盖）。

**验证**：`lint`、`fmt`、`typecheck` 均通过；组件测试 33/33 通过；本地开发服务器确认中英两侧导航顺序正确，`/zh` 页脚三个链接及中文文案均正常显示。已通过 GitHub API 确认 `agentx-harness` 仓库为公开状态，新链接对未登录访客同样可访问。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chrome-only navigation order and footer link labels/URLs; no auth, data, or business-logic changes.
> 
> **Overview**
> **Primary navigation** now lists **AgentX** (with the existing `NEW` badge) first, before Home, Overview, Dashboard, Comparisons, and About. Desktop, mobile, and `/zh` all use the same `NAV_LINKS` array—only order changed, not hrefs, analytics, or active-state logic.
> 
> **Footer Contribute column** adds an **AgentX Harness** link to `github.com/SemiAnalysisAI/agentx-harness` after Benchmarks. The InferenceX-app GitHub link is relabeled from **Frontend** to **Visualization** (same URL); English and Chinese string keys and `data-testid` values were updated (`footer-link-visualization`, `footer-link-agentx-harness`).
> 
> **Tests** assert the full nav label order (stripping the NEW badge) and all three Contribute GitHub links in the footer spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb192161fdc165d1aa1fb3a4977631d34db81495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->