### PR TITLE
chore(inference): drop the Median Interactivity column from table view / 移除 /inference 表格视图中的 Median Interactivity 列

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -1114,6 +1114,57 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('@setLocalOfficialOverride').should('not.have.been.called');
   });
 
+  it('renders the table columns without a Median Interactivity column', () => {
+    // Mirror the real interactivity chart: x IS interactivity, which is what
+    // made the separate median column a duplicate.
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      x: 'median_intvty',
+      x_label: 'Interactivity (tok/s/user)',
+    });
+    const row = createMockInferenceData({
+      hwKey: 'b200_sglang',
+      hw: 'Official SGLang',
+      model: Model.DeepSeek_V4_Pro,
+      precision: Precision.FP4,
+    });
+
+    mountWithProviders(<ChartDisplay />, {
+      inference: {
+        graphs: [
+          {
+            model: Model.DeepSeek_V4_Pro,
+            sequence: Sequence.AgenticTraces,
+            chartDefinition,
+            data: [row],
+          },
+        ],
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        selectedXAxisMode: 'interactivity',
+        activeHwTypes: new Set(['b200_sglang']),
+        hwTypesWithData: new Set(['b200_sglang']),
+      },
+      globalFilters: {
+        selectedModel: Model.DeepSeek_V4_Pro,
+        selectedSequence: Sequence.AgenticTraces,
+        effectiveSequence: Sequence.AgenticTraces,
+      },
+      unofficial: {},
+    });
+
+    cy.get('[data-testid="inference-table-view-btn"]').click();
+    cy.get('[data-testid="inference-results-table"] thead th').then(($headers) => {
+      const headers = [...$headers].map((th) => (th.textContent ?? '').trim());
+      // Interactivity is already the x-axis column on the interactivity chart,
+      // so the median column duplicated it. Assert both that the column is gone
+      // and that exactly one interactivity column remains, so a rename cannot
+      // quietly reintroduce the duplicate.
+      expect(headers).to.not.include('Median Interactivity (tok/s)');
+      expect(headers.filter((h) => h.toLowerCase().includes('interactivity'))).to.have.length(1);
+    });
+  });
+
   it('keeps same-hardware cross-engine AgentX STP rows out of table mode', () => {
     const chartDefinition = createMockChartDefinition({ chartType: 'interactivity' });
     const sglangRow = createMockInferenceData({

--- a/packages/app/src/components/inference/ui/InferenceTable.tsx
+++ b/packages/app/src/components/inference/ui/InferenceTable.tsx
@@ -95,13 +95,6 @@ export default function InferenceTable({
         sortValue: (row) => row.median_ttft ?? 0,
         className: 'tabular-nums',
       },
-      {
-        header: 'Median Interactivity (tok/s)',
-        align: 'right',
-        cell: (row) => fmt(row.median_intvty ?? 0, 1),
-        sortValue: (row) => row.median_intvty ?? 0,
-        className: 'tabular-nums',
-      },
     ],
     [yPath, yLabel, xLabel],
   );


### PR DESCRIPTION
## Summary

Removes the trailing **Median Interactivity (tok/s)** column from the `/inference` table view.

On the interactivity chart the x-axis column *is* interactivity, so the median column repeated the same number one cell over. Table goes from nine columns to eight:

`Chip · Precision · TP · Conc · <y metric> · <x metric> · Throughput/Chip (tok/s) · Median TTFT (ms)`

## Scope — what is *not* changed

The `median_intvty` **field is untouched**. It still:

- drives the interactivity chart's x-axis (`chartDefinition.x`),
- feeds the throughput calculator (`useThroughputData.ts`),
- appears in the **CSV export** — `lib/csv-export-helpers.ts` builds its own column list and does not read the table's, so exports keep the value even though the column is gone from the UI.

Only the one `DataTableColumn` entry in `InferenceTable.tsx` is deleted.

## Changes

- `src/components/inference/ui/InferenceTable.tsx` — remove the column definition (7 lines).
- `cypress/component/scatter-graph.cy.tsx` — new test pinning the behavior: asserts the header set excludes `Median Interactivity (tok/s)` **and** that exactly one interactivity column remains, so a rename can't quietly reintroduce the duplicate. It mounts with `x: 'median_intvty'` / `x_label: 'Interactivity (tok/s/user)'` so it exercises the exact configuration where the duplication occurred.

## Verification

```
bun run lint / fmt / typecheck                                  # pass
vitest src/components/inference/                                # 38 files, 631 tests passed
cypress run --component --spec scatter-graph.cy.tsx             # 20/20 passed
```

Checked the new test actually guards the change: re-adding the column definition makes it fail with `expected [ Array(9) ] to not include 'Median Interactivity (tok/s)'`. With the column removed, 20/20 pass.

## Notes

- **Not localized either way.** `InferenceTable.tsx` has hardcoded English headers today — a pre-existing gap against the `/zh` UI-string rule, not something this PR introduces or worsens. Removing a column touches no translation dictionary. Happy to file a follow-up to localize the whole table's headers if you want that closed.
- **Overlay path unaffected** — the table renders official and `?unofficialrun=` overlay rows through the same column list, so the column disappears for both. The existing overlay table specs in `scatter-graph.cy.tsx` still pass.

## 中文说明

移除 `/inference` 表格视图末尾的 **Median Interactivity (tok/s)** 列。

在 interactivity 图表下，表格的 x 轴列本身就是 interactivity，因此该中位数列只是把同一个数字在相邻单元格里重复了一遍。表格由九列减为八列：`Chip · Precision · TP · Conc · <y 指标> · <x 指标> · Throughput/Chip (tok/s) · Median TTFT (ms)`。

**改动范围**：`median_intvty` 字段本身未做任何改动，它仍然驱动 interactivity 图表的 x 轴、吞吐量计算器，并且仍会出现在 **CSV 导出**中——`lib/csv-export-helpers.ts` 独立构建导出列，不读取表格的列定义，因此导出数据不受影响。本次仅删除 `InferenceTable.tsx` 中的一个列定义。

**测试**：在 `scatter-graph.cy.tsx` 中新增测试，断言表头不包含 `Median Interactivity (tok/s)`，且仅保留一列 interactivity，防止日后通过重命名重新引入重复列。该测试以 `x: 'median_intvty'` 挂载，正好覆盖出现重复的那种配置。已验证该测试确实有效：把列加回后测试失败。

**验证**：`lint`、`fmt`、`typecheck` 均通过；inference 单元测试 38 个文件 631 项通过；组件测试 20/20 通过。

**补充说明**：`InferenceTable.tsx` 目前的表头为硬编码英文，这是既有的中文化缺口，本次改动既未引入也未加剧该问题；如需补齐整张表格的中文表头，可另开 PR 处理。表格对官方数据与 `?unofficialrun=` 叠加数据使用同一套列定义，因此两条路径下该列都会移除，既有的叠加层表格测试仍全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only column removal in inference table display with regression test coverage; no changes to data fields or export logic.
> 
> **Overview**
> Removes the **Median Interactivity (tok/s)** column from the `/inference` table view in `InferenceTable.tsx`, so the table drops from nine columns to eight.
> 
> On interactivity charts the x-axis column already uses `median_intvty` (labeled e.g. **Interactivity (tok/s/user)**), so the extra median column repeated the same value in an adjacent cell. **`median_intvty` is unchanged** elsewhere—charts, throughput helpers, and **CSV export** (`csv-export-helpers.ts` builds its own columns) still include it.
> 
> Adds a Cypress component test in `scatter-graph.cy.tsx` that mounts table mode with the interactivity chart config and asserts the header set excludes **Median Interactivity (tok/s)** and contains exactly one interactivity-related column, so a rename cannot quietly restore the duplicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73fbab2d4214175149b59d78803f9790940fdbba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->