### PR TITLE
chore: drop the Median TTFT column, tighten the AgentX banner copy, hide Quick Comparisons / 移除 Median TTFT 列、优化 AgentX 横幅文案并隐藏快速对比区块

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -1114,7 +1114,7 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('@setLocalOfficialOverride').should('not.have.been.called');
   });
 
-  it('renders the table columns without a Median Interactivity column', () => {
+  it('renders the table columns without the median interactivity or TTFT columns', () => {
     // Mirror the real interactivity chart: x IS interactivity, which is what
     // made the separate median column a duplicate.
     const chartDefinition = createMockChartDefinition({
@@ -1162,6 +1162,10 @@ describe('ChartDisplay engine comparison guard', () => {
       // quietly reintroduce the duplicate.
       expect(headers).to.not.include('Median Interactivity (tok/s)');
       expect(headers.filter((h) => h.toLowerCase().includes('interactivity'))).to.have.length(1);
+      // Median TTFT was dropped too; unlike interactivity it is not duplicated
+      // by the x-axis column, so nothing else in the table should carry it.
+      expect(headers).to.not.include('Median TTFT (ms)');
+      expect(headers.filter((h) => h.toLowerCase().includes('ttft'))).to.have.length(0);
     });
   });
 

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -8,7 +8,11 @@ describe('Chinese (/zh) pages', () => {
       cy.get('[data-testid="intro-section"]').should('contain.text', '智能体推理基准测试');
       cy.get('[data-testid="splash-text"]').should('have.text', 'AgentX 来了！！');
       cy.contains('h2', '探索 InferenceX').should('exist');
-      cy.contains('快速对比').should('exist');
+      // Quick Comparisons is hidden behind SHOW_QUICK_COMPARISONS in
+      // landing-page.tsx; the card and its Chinese strings still exist in the
+      // source, so assert it is not rendered rather than dropping the check.
+      cy.get('[data-testid="landing-quick-comparisons"]').should('not.exist');
+      cy.contains('快速对比').should('not.exist');
     });
 
     it('links to the Chinese overview and full dashboard', () => {

--- a/packages/app/src/components/inference/ui/InferenceTable.tsx
+++ b/packages/app/src/components/inference/ui/InferenceTable.tsx
@@ -88,13 +88,6 @@ export default function InferenceTable({
         sortValue: (row) => row.tput_per_gpu ?? 0,
         className: 'tabular-nums',
       },
-      {
-        header: 'Median TTFT (ms)',
-        align: 'right',
-        cell: (row) => fmt((row.median_ttft ?? 0) * 1000, 0),
-        sortValue: (row) => row.median_ttft ?? 0,
-        className: 'tabular-nums',
-      },
     ],
     [yPath, yLabel, xLabel],
   );

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -67,6 +67,13 @@ const STRINGS = {
   },
 } as const;
 
+/**
+ * Quick Comparisons is hidden for now. The card, its `quickComparisons*`
+ * strings, `CuratedViewCard`, and `FAVORITE_PRESETS` are all left in place —
+ * flip this to `true` to bring the section back.
+ */
+const SHOW_QUICK_COMPARISONS = false;
+
 export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
   const t = STRINGS[locale];
   // Internal links stay within the current language tree.
@@ -167,19 +174,21 @@ export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
             </div>
           </Card>
 
-          {/* Right - Curated Presets */}
-          <Card>
-            <div className="flex items-center gap-2 mb-3">
-              <Sparkles className="size-5 shrink-0 text-brand" />
-              <h2 className="text-lg font-semibold">{t.quickComparisons}</h2>
-            </div>
-            <p className="text-sm text-muted-foreground mb-4">{t.quickComparisonsDesc}</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {FAVORITE_PRESETS.filter((preset) => !preset.hidden).map((preset) => (
-                <CuratedViewCard key={preset.id} preset={preset} />
-              ))}
-            </div>
-          </Card>
+          {/* Right - Curated Presets (temporarily hidden, see SHOW_QUICK_COMPARISONS) */}
+          {SHOW_QUICK_COMPARISONS && (
+            <Card data-testid="landing-quick-comparisons">
+              <div className="flex items-center gap-2 mb-3">
+                <Sparkles className="size-5 shrink-0 text-brand" />
+                <h2 className="text-lg font-semibold">{t.quickComparisons}</h2>
+              </div>
+              <p className="text-sm text-muted-foreground mb-4">{t.quickComparisonsDesc}</p>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {FAVORITE_PRESETS.filter((preset) => !preset.hidden).map((preset) => (
+                  <CuratedViewCard key={preset.id} preset={preset} />
+                ))}
+              </div>
+            </Card>
+          )}
         </section>
       </div>
     </main>

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -399,9 +399,8 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       title: 'Agentic benchmark results are live',
       titleZh: '智能体基准测试结果已上线',
       description:
-        "AgentX is the World's First Fully Realistic Open Sourced 1 Mil+ Long Context Length, Multi-Turn Agentic Benchmark",
-      descriptionZh:
-        'AgentX 是全球首个完全贴近真实场景、开源的百万级 (1M+) 长上下文多轮智能体基准测试',
+        "AgentX is the World's First Fully Open Source Realistic 1Mil+ Long Context, Multi Turn Benchmark",
+      descriptionZh: 'AgentX 是全球首个完全开源、贴近真实场景的百万级 (1M+) 长上下文多轮基准测试',
       testId: 'launch-banner',
       badge: 'New',
       badgeZh: '最新',


### PR DESCRIPTION
## Summary

Three changes.

### 1. Drop the Median TTFT column from the `/inference` table view

Follows #776, which removed Median Interactivity. The table is now seven columns:

`Chip · Precision · TP · Conc · <chart y metric> · <chart x metric> · Throughput/Chip (tok/s)`

**One difference from #776 worth knowing.** Median Interactivity was a genuine duplicate — on the interactivity chart the x-axis column *is* interactivity, so the same number appeared twice in one row. **Median TTFT is not duplicated by anything.** No chart config uses `median_ttft` as its x-axis — `inference-chart-config.json` uses `median_intvty` or `median_e2el`, and the `ttft` x-axis *mode* maps to `p90_ttft` for one metric, not `median_ttft`. So this removes a value from table view rather than de-duplicating one. Flagging it because the two changes read as the same cleanup but aren't.

The data is still available: `median_ttft` remains in the **CSV export** (`lib/csv-export-helpers.ts` builds its own column list and does not read the table's), and the field is untouched everywhere else.

### 2. Tighten the AgentX launch banner subtitle

| | Copy |
| --- | --- |
| Before | AgentX is the World's First Fully **Realistic Open Sourced 1 Mil+ Long Context Length, Multi-Turn Agentic** Benchmark |
| After | AgentX is the World's First Fully **Open Source Realistic 1Mil+ Long Context, Multi Turn** Benchmark |

Leads with "Fully Open Source", trims "Long Context Length" to "Long Context", and drops "Agentic" before "Benchmark". Chinese copy follows: 完全贴近真实场景、开源的… → 完全开源、贴近真实场景的…，并去掉"智能体".

Title, `NEW` badge, link target, and analytics events are unchanged.

### 3. Hide the Quick Comparisons section on the landing page

The card is gated behind a `SHOW_QUICK_COMPARISONS` constant in `landing-page.tsx`, currently `false`. **Nothing is deleted** — the card's JSX, its `quickComparisons` / `quickComparisonsDesc` strings in both locales, `CuratedViewCard`, and `FAVORITE_PRESETS` all stay in place. Flipping the constant to `true` restores the section exactly as it was.

`cypress/e2e/zh-pages.cy.ts` asserted the section was present; it now asserts the opposite rather than dropping the check, since the strings still exist in the source and a silent re-render would otherwise go unnoticed.

## Changes

- `src/components/inference/ui/InferenceTable.tsx` — remove the Median TTFT column definition.
- `cypress/component/scatter-graph.cy.tsx` — extend the column test from #776 to assert no header is `Median TTFT (ms)` and that no header mentions TTFT at all, so a rename can't reintroduce it.
- `src/lib/nudges/registry.tsx` — `description` / `descriptionZh` on the `agentic-results-launch-banner` nudge.
- `src/components/landing/landing-page.tsx` — `SHOW_QUICK_COMPARISONS` flag gating the Quick Comparisons card.
- `cypress/e2e/zh-pages.cy.ts` — assert the section is not rendered.

## Verification

```
bun run lint / fmt / typecheck                          # pass
vitest src/components/inference/                        # 38 files, 631 tests passed
vitest src/lib/nudges/                                  # 50 tests passed
cypress run --component --spec scatter-graph.cy.tsx     # 20/20 passed
cypress run --spec zh-pages.cy.ts,sanity.cy.ts          # 20/20 passed
```

Confirmed the column test guards the change: re-adding the column definition fails with `expected [ Array(8) ] to not include 'Median TTFT (ms)'`. With it removed, 20/20 pass.

Rendered locally: `/` and `/zh` return zero matches for "Quick Comparisons" / "快速对比", with `intro-section`, `landing-overview-link`, `landing-full-dashboard-link`, and `launch-banner` all still present.

The banner change needs no test update — `cypress/e2e/nudge-system.cy.ts` asserts the banner *title* and link label, not the subtitle.

## Notes

- **Overlay path unaffected** — official and `?unofficialrun=` overlay rows render through the same column list, so the column disappears for both; existing overlay table specs still pass.
- **Localization** — the banner ships both locales in the same commit. `InferenceTable.tsx` still has hardcoded English headers, a pre-existing gap this PR neither introduces nor worsens.

## 中文说明

本 PR 包含三项改动。

**1. 移除 `/inference` 表格视图中的 Median TTFT 列。** 延续 #776（移除 Median Interactivity 列），表格现为七列：`Chip · Precision · TP · Conc · 图表 y 指标 · 图表 x 指标 · Throughput/Chip (tok/s)`。

需要说明的是，本次与 #776 有一处区别：Median Interactivity 确实是重复列——在 interactivity 图表下，x 轴列本身就是 interactivity，同一个数字在一行里出现了两次。而 **Median TTFT 并不与任何列重复**：没有任何图表配置以 `median_ttft` 作为 x 轴（配置使用 `median_intvty` 或 `median_e2el`；`ttft` 这一 x 轴模式对应的是某个指标的 `p90_ttft`）。因此本次改动是从表格视图中移除一项数据，而非去重。数据本身仍可获取：`median_ttft` 依然保留在 **CSV 导出**中（导出在 `lib/csv-export-helpers.ts` 中独立构建列），该字段在其他位置也未改动。

**2. 优化落地页横幅副标题。** 由"AgentX is the World's First Fully Realistic Open Sourced 1 Mil+ Long Context Length, Multi-Turn Agentic Benchmark"改为"AgentX is the World's First Fully Open Source Realistic 1Mil+ Long Context, Multi Turn Benchmark"：突出"完全开源"，精简 Long Context Length 为 Long Context，并去掉 Benchmark 前的 Agentic。中文文案同步调整为"AgentX 是全球首个完全开源、贴近真实场景的百万级 (1M+) 长上下文多轮基准测试"。横幅标题、`NEW` 徽标、跳转链接与埋点事件均保持不变。

**3. 隐藏落地页的"快速对比"区块。** 该卡片现由 `landing-page.tsx` 中的 `SHOW_QUICK_COMPARISONS` 常量控制，当前为 `false`。**未删除任何代码**——卡片的 JSX、中英两种语言的 `quickComparisons` / `quickComparisonsDesc` 文案、`CuratedViewCard` 与 `FAVORITE_PRESETS` 均保留原样，将该常量改为 `true` 即可完整恢复。`cypress/e2e/zh-pages.cy.ts` 原先断言该区块存在，现改为断言其不渲染，而非直接删除断言——相关文案仍在源码中，否则若被意外重新渲染将无人察觉。

**验证**：`lint`、`fmt`、`typecheck` 均通过；inference 单元测试 631 项、nudges 单元测试 50 项、组件测试 20/20 全部通过。已确认列测试有效：把列加回后测试失败。横幅改动无需调整测试——`nudge-system.cy.ts` 断言的是横幅标题与链接文字，不涉及副标题。

表格对官方数据与 `?unofficialrun=` 叠加数据使用同一套列定义，两条路径下该列都会移除，既有叠加层测试仍全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only UI and marketing copy changes; benchmark data and exports are largely untouched aside from one optional table column.
> 
> **Overview**
> Removes the **Median TTFT (ms)** column from the `/inference` table view in `InferenceTable.tsx`, continuing the slimmer table layout after #776. Unlike median interactivity, TTFT is not duplicated by the chart x-axis—this simply drops that metric from table mode; **`median_ttft` remains in CSV export** and elsewhere in the app.
> 
> Component tests in `scatter-graph.cy.tsx` now assert no **Median TTFT** header and no header text containing “ttft”, so the column cannot sneak back via a rename.
> 
> The landing page **Quick Comparisons** card is gated behind `SHOW_QUICK_COMPARISONS = false` (preset UI and strings stay in the repo). Chinese e2e in `zh-pages.cy.ts` expects the quick-comparisons card and “快速对比” **not** to render.
> 
> The AgentX launch banner subtitle in `nudges/registry.tsx` is tightened in English and Chinese (emphasis on fully open source, shorter phrasing); title, badge, and link behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6586aaff073580c01636cc48c3d56d66d60cc606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->