### PR TITLE
chore(agentx): point the results CTA at /inference / 将 AgentX 结果 CTA 指向 /inference

### DIFF
--- a/packages/app/cypress/e2e/datasets-methodology.cy.ts
+++ b/packages/app/cypress/e2e/datasets-methodology.cy.ts
@@ -30,7 +30,7 @@ describe('AgentX dataset methodology', () => {
         .and('have.attr', 'href', '/agentx/methodology');
       cy.get('[data-testid="agentx-results-cta"]')
         .should('contain.text', 'View AgentX Performance Results')
-        .and('have.attr', 'href', '/overview');
+        .and('have.attr', 'href', '/inference');
     });
   });
 
@@ -48,7 +48,7 @@ describe('AgentX dataset methodology', () => {
         .and('have.attr', 'href', '/zh/agentx/methodology');
       cy.get('[data-testid="agentx-results-cta"]')
         .should('contain.text', '查看 AgentX 性能结果')
-        .and('have.attr', 'href', '/zh/overview');
+        .and('have.attr', 'href', '/zh/inference');
     });
   });
 

--- a/packages/app/src/components/datasets/agentx-methodology.tsx
+++ b/packages/app/src/components/datasets/agentx-methodology.tsx
@@ -185,7 +185,7 @@ export function AgentXMethodology({ locale }: { locale: Locale }) {
         <h1 className="text-xl font-semibold text-foreground">{t.title}</h1>
         <p className="mt-3 max-w-4xl text-sm leading-6 text-muted-foreground">{t.intro}</p>
         <AgentXMethodologyLink
-          href={locale === 'zh' ? '/zh/overview' : '/overview'}
+          href={locale === 'zh' ? '/zh/inference' : '/inference'}
           analyticsEvent="agentx_results_opened"
           analyticsTarget="methodology-header"
           data-testid="agentx-results-cta"


### PR DESCRIPTION
## Summary

The **View AgentX Performance Results** button in the `/agentx` methodology header linked to `/overview`. This points it at the inference dashboard tab instead.

- `packages/app/src/components/datasets/agentx-methodology.tsx` — CTA `href` is now `/inference` (`/zh/inference` on the Chinese page).
- `packages/app/cypress/e2e/datasets-methodology.cy.ts` — the two existing `href` assertions (EN + ZH) updated to match.

Both locales change together, so there is no EN/ZH drift. Copy is unchanged in both languages; only the destination moves. Nothing else in the repo linked this CTA — the remaining `/overview` links (landing page hero) are untouched.

### Checks

`bun run lint`, `bun run fmt`, `bun run typecheck` all pass locally; the pre-commit hook re-ran them. The full Cypress suite runs in CI.

Overlay note: not applicable — this is a static marketing/methodology link, not inference or evaluation chart data.

## 中文说明

`/agentx` 方法论页头部的 **查看 AgentX 性能结果** 按钮此前链接到 `/overview`，现改为指向 inference 仪表板标签页。

- `packages/app/src/components/datasets/agentx-methodology.tsx` — CTA 的 `href` 改为 `/inference`（中文页对应 `/zh/inference`）。
- `packages/app/cypress/e2e/datasets-methodology.cy.ts` — 同步更新英文与中文两处 `href` 断言。

两种语言同时修改，不存在中英内容漂移；文案未变，仅改变跳转目标。仓库中没有其他位置引用该 CTA，落地页 hero 中的 `/overview` 链接保持不变。

本地 `bun run lint`、`bun run fmt`、`bun run typecheck` 均通过，pre-commit hook 已再次执行；完整 Cypress 套件由 CI 运行。此改动为静态链接，不涉及 inference/evaluation 图表数据，因此与 `?unofficialrun=` overlay 路径无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static navigation target change only; no auth, data, or inference chart logic.
> 
> **Overview**
> The **View AgentX Performance Results** CTA on the AgentX methodology header now routes to the inference dashboard (`/inference` and `/zh/inference`) instead of `/overview`.
> 
> **`agentx-methodology.tsx`** updates the `AgentXMethodologyLink` `href` for `agentx-results-cta`; button copy and analytics are unchanged. **Cypress** (`datasets-methodology.cy.ts`) updates EN and ZH `href` assertions to match.
> 
> Other `/overview` links (e.g. landing hero) are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3486bec44e021f6dc1410f97e30d5be0d93f11cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->