### PR TITLE
Prevent unofficial run legend crash / 防止非官方运行图例崩溃

### DIFF
--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Profiler, useState } from 'react';
 
 import LegendPointsDialog from '@/components/inference/ui/LegendPointsDialog';
 import { OffloadHaloLegendKey } from '@/components/inference/ui/OffloadHaloLegendKey';
@@ -79,6 +79,41 @@ describe('ChartLegend (sidebar variant)', () => {
   it('renders legend with items', () => {
     cy.get('.sidebar-legend').should('be.visible');
     cy.get('.sidebar-legend label').should('have.length', 4);
+  });
+
+  it('derives long unofficial labels without a nested update', () => {
+    const branch = 'qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp-pareto-refresh';
+    const onRender = cy.spy().as('legendRender');
+
+    cy.mount(
+      <Profiler id="long-unofficial-run-legend" onRender={onRender}>
+        <ChartLegend
+          legendItems={[
+            {
+              ...MOCK_ITEMS[0],
+              name: 'unofficial-run-32177976542',
+              label: `✕ ${branch}`,
+            },
+          ]}
+          isLegendExpanded={true}
+          onExpandedChange={() => {}}
+          variant="sidebar"
+        />
+      </Profiler>,
+    );
+
+    cy.get('[data-testid="chart-legend"]').should('contain.text', branch);
+    cy.get('@legendRender').should((renderSpy) => {
+      // Cypress loses the Sinon spy type when resolving an alias.
+      const profilerSpy = renderSpy as unknown as {
+        getCalls: () => { args: unknown[] }[];
+      };
+      const calls = profilerSpy.getCalls();
+      expect(
+        calls.map(({ args }) => args[1]),
+        'React render phases',
+      ).not.to.include('nested-update');
+    });
   });
 
   it('legend items have colored dots', () => {

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -346,6 +346,9 @@ describe('ScatterGraph', () => {
       chartType: 'interactivity',
       y_tpPerGpu_roofline: 'upper_left',
     });
+    const runId = 32177976542;
+    const runBranch = 'qwen3.5-fp4-gb200-dynamo-sglang-agentic-mtp-pareto-refresh';
+    const runUrl = `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId}`;
     const officialData = [
       createMockInferenceData({ hwKey: 'h100', x: 8, y: 240, precision: Precision.FP4 }),
       createMockInferenceData({ hwKey: 'h100', x: 16, y: 200, precision: Precision.FP4 }),
@@ -358,26 +361,26 @@ describe('ScatterGraph', () => {
           x: 8,
           y: 320,
           precision: Precision.FP4,
-          run_url: 'https://github.com/x/y/actions/runs/12345',
+          run_url: runUrl,
         }),
         createMockInferenceData({
           hwKey: 'b200_trt',
           x: 16,
           y: 280,
           precision: Precision.FP4,
-          run_url: 'https://github.com/x/y/actions/runs/12345',
+          run_url: runUrl,
         }),
         createMockInferenceData({
           hwKey: 'b200_trt',
           x: 32,
           y: 220,
           precision: Precision.FP4,
-          run_url: 'https://github.com/x/y/actions/runs/12345',
+          run_url: runUrl,
         }),
       ],
       hardwareConfig: hwConfig,
-      label: 'feature-branch',
-      runUrl: 'https://github.com/x/y/actions/runs/12345',
+      label: runBranch,
+      runUrl,
     };
 
     mountWithProviders(
@@ -403,15 +406,15 @@ describe('ScatterGraph', () => {
         unofficial: {
           activeOverlayHwTypes: new Set(['b200_trt']),
           allOverlayHwTypes: new Set(['b200_trt']),
-          runIndexByUrl: { 'https://github.com/x/y/actions/runs/12345': 0, '12345': 0 },
+          runIndexByUrl: { [runUrl]: 0, [String(runId)]: 0 },
           unofficialRunInfos: [
             {
-              id: 12345,
+              id: runId,
               name: 'CI run',
-              branch: 'feature-branch',
-              sha: 'abc123',
-              createdAt: '2026-05-01T00:00:00Z',
-              url: 'https://github.com/x/y/actions/runs/12345',
+              branch: runBranch,
+              sha: '7a4a06b',
+              createdAt: '2026-08-18T19:40:51Z',
+              url: runUrl,
               conclusion: 'success',
               status: 'completed',
               isNonMainBranch: true,
@@ -435,11 +438,15 @@ describe('ScatterGraph', () => {
     cy.get('#test-scatter-overlay-labels svg .line-label')
       .filter('[data-line-key]:not([data-line-key^="overlay-"])')
       .should('have.length.greaterThan', 0);
-    // Overlay label text is the run's branch name (matching the overlay legend),
-    // not the hw label.
+    // The exact branch that crashed the production page remains visible in the
+    // overlay line label and legend after ScatterGraph's render-time updates.
     cy.get('#test-scatter-overlay-labels svg .line-label[data-line-key^="overlay-"]')
       .find('text')
-      .should('contain.text', 'feature-branch');
+      .should('contain.text', runBranch);
+    cy.get('#test-scatter-overlay-labels [data-testid="chart-legend"]').should(
+      'contain.text',
+      runBranch,
+    );
   });
 
   it('renders a line label for a singleton unofficial overlay series', () => {

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -133,7 +133,7 @@ export default function ChartLegend({
   const locale = useLocale();
   const t = STRINGS[locale];
   const isSidebar = variant === 'sidebar';
-  const [hasLongText, setHasLongText] = useState(false);
+  const hasLongText = legendItems.some((item) => item.label && item.label.length > 8);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -151,10 +151,6 @@ export default function ChartLegend({
   const effectiveRemove = onItemRemove && activeCount > 1 ? onItemRemove : undefined;
   const removeFor = (item: CommonLegendItemProps) =>
     item.isRemovable === false ? undefined : effectiveRemove;
-
-  useLayoutEffect(() => {
-    setHasLongText(legendItems.some((item) => item.label && item.label.length > 8));
-  }, [legendItems]);
 
   useLayoutEffect(() => {
     const el = scrollRef.current;


### PR DESCRIPTION
## Summary
- Derive the legend's long-label state during render instead of scheduling a layout-effect state update.
- Prevent unstable unofficial-run legend arrays from entering React's nested update loop.
- Add regression coverage using run `32177976542` and its exact long branch label.

Works for official charts and `?unofficialRun=` overlays. Verified locally with run `32177976542`: Qwen3.5 selected, the branch legend rendered, and all 16 overlay points appeared without the maximum-update-depth error.

## Testing
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,080 tests)
- `bun run test:e2e` (91 tests)
- `bun x cypress run --component --spec cypress/component/chart-legend.cy.tsx` (14 tests)

## 中文说明
- 将图例长标签状态改为渲染期间直接派生，避免通过布局 effect 触发额外状态更新。
- 防止非官方运行图例数组引用变化时进入 React 嵌套更新循环。
- 使用运行 `32177976542` 及其完整长分支名称补充回归测试。

该修复同时适用于官方图表和 `?unofficialRun=` 叠加层。本地使用运行 `32177976542` 验证：页面自动选择 Qwen3.5，图例正确显示分支名称，16 个叠加数据点全部渲染，且不再出现最大更新深度错误。

## 测试
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（4,080 项测试）
- `bun run test:e2e`（91 项测试）
- `bun x cypress run --component --spec cypress/component/chart-legend.cy.tsx`（14 项测试）

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change in legend layout logic with component tests covering the production failure case; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes a **maximum update depth** crash when unofficial overlay runs show long branch names in the chart legend (e.g. run `32177976542`).
> 
> **`ChartLegend`** no longer stores “long label” layout in state via `useLayoutEffect`. It **derives** `hasLongText` from `legendItems` on each render (`label.length > 8`), so unstable unofficial legend item arrays do not trigger an extra state update after paint and React does not enter a **nested-update** loop.
> 
> **Regression tests:** a Cypress component test mounts the legend with a `Profiler` and asserts render phases never include `nested-update`; **`scatter-graph.cy.tsx`** uses the same production run/branch and checks overlay line labels and legend text still render after `ScatterGraph` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e864733d851e95b251bce7ee7dad9cc2e2558a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->