### PR TITLE
feat(landing): lead with the AgentX hero and rework its CTAs / 落地页引入 AgentX hero 并调整 CTA

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -128,8 +128,8 @@ describe('Header', () => {
       .should('have.text', '新');
   });
 
-  it('orders the nav with AgentX first', () => {
-    const expected = ['AgentX', 'Home', 'Overview', 'Dashboard', 'Comparisons', 'About'];
+  it('orders the nav with Home first and AgentX second', () => {
+    const expected = ['Home', 'AgentX', 'Overview', 'Dashboard', 'Comparisons', 'About'];
     cy.get('[data-testid^="nav-link-"]').then(($links) => {
       // Strip the NEW badge so the comparison is against the label alone.
       const labels = [...$links].map((link) => (link.textContent ?? '').replace('NEW', '').trim());

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -8,7 +8,7 @@ describe('Compare precision index page', () => {
   it('leads the /compare index with AgentX results and keeps fixed-sequence tools', () => {
     cy.visit('/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
-      cy.get('h1').should('have.text', 'Compare real world, agentic inference results');
+      cy.get('h1').should('have.text', 'Compare Realistic Agentic Inference Perf');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
       cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
         'have.attr',
@@ -49,7 +49,7 @@ describe('Compare precision index page', () => {
   it('ships the same AgentX-first hierarchy on the Simplified Chinese page', () => {
     cy.visit('/zh/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
-      cy.get('h1').should('have.text', '对比真实场景下的智能体推理结果');
+      cy.get('h1').should('have.text', '对比真实场景下的智能体推理性能');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
       cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
         'have.attr',

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -22,8 +22,8 @@ describe('Compare precision index page', () => {
         .should('contain.text', 'Full dashboard')
         .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', 'Read the full methodology')
-        .and('have.attr', 'href', '/agentx/methodology');
+        .should('contain.text', 'Methodology Deep Dive')
+        .and('have.attr', 'href', '/agentx');
     });
     cy.get('[data-testid="compare-model-catalog"]')
       .should('contain.text', 'AgentX and 8K→1K results')
@@ -63,8 +63,8 @@ describe('Compare precision index page', () => {
         .should('contain.text', '完整仪表板')
         .and('have.attr', 'href', '/zh/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', '阅读完整方法论')
-        .and('have.attr', 'href', '/zh/agentx/methodology');
+        .should('contain.text', '方法论深度解析')
+        .and('have.attr', 'href', '/zh/agentx');
     });
     cy.get('[data-testid="compare-model-catalog"]').should('contain.text', 'AgentX 与 8K→1K 结果');
     cy.get('#deepseek-v4 a[data-scenario="AgentX"]')

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -15,11 +15,15 @@ describe('Compare precision index page', () => {
         'href',
         '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1',
       );
-      cy.get('[data-testid="compare-agentx-methodology-link"]').should(
-        'have.attr',
-        'href',
-        '/agentx/methodology',
-      );
+      cy.get('[data-testid="compare-agentx-overview-link"]')
+        .should('contain.text', 'Overview')
+        .and('have.attr', 'href', '/overview');
+      cy.get('[data-testid="compare-agentx-dashboard-link"]')
+        .should('contain.text', 'Full dashboard')
+        .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+      cy.get('[data-testid="compare-agentx-methodology-link"]')
+        .should('contain.text', 'Read the full methodology')
+        .and('have.attr', 'href', '/agentx/methodology');
     });
     cy.get('[data-testid="compare-model-catalog"]')
       .should('contain.text', 'AgentX and 8K→1K results')
@@ -52,11 +56,15 @@ describe('Compare precision index page', () => {
         'href',
         '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
       );
-      cy.get('[data-testid="compare-agentx-methodology-link"]').should(
-        'have.attr',
-        'href',
-        '/zh/agentx/methodology',
-      );
+      cy.get('[data-testid="compare-agentx-overview-link"]')
+        .should('contain.text', '总览')
+        .and('have.attr', 'href', '/zh/overview');
+      cy.get('[data-testid="compare-agentx-dashboard-link"]')
+        .should('contain.text', '完整仪表板')
+        .and('have.attr', 'href', '/zh/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+      cy.get('[data-testid="compare-agentx-methodology-link"]')
+        .should('contain.text', '阅读完整方法论')
+        .and('have.attr', 'href', '/zh/agentx/methodology');
     });
     cy.get('[data-testid="compare-model-catalog"]').should('contain.text', 'AgentX 与 8K→1K 结果');
     cy.get('#deepseek-v4 a[data-scenario="AgentX"]')

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -111,6 +111,26 @@ describe('First-load navigation', () => {
     cy.location('pathname').should('eq', '/inference');
   });
 
+  it('leads the landing page with the AgentX hero and its three CTAs', () => {
+    cy.get('[data-testid="compare-agentx-primary"]').within(() => {
+      // The hero owns /compare's h1; on the landing page it is a section heading.
+      cy.get('h2').should('have.text', 'Compare real world, agentic inference results');
+      cy.get('h1').should('not.exist');
+      cy.get('[data-testid="compare-agentx-overview-link"]')
+        .should('contain.text', 'Overview')
+        .and('have.attr', 'href', '/overview');
+      cy.get('[data-testid="compare-agentx-dashboard-link"]')
+        .should('contain.text', 'Full dashboard')
+        .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+      cy.get('[data-testid="compare-agentx-methodology-link"]')
+        .should('contain.text', 'Read the full methodology')
+        .and('have.attr', 'href', '/agentx/methodology');
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+    });
+    cy.get('[data-testid="compare-agentx-overview-link"]').click();
+    cy.location('pathname').should('eq', '/overview');
+  });
+
   it('navigates to submissions from the landing CTA', () => {
     cy.get('[data-testid="landing-submissions-link"]').click();
     cy.location('pathname').should('eq', '/submissions');

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -123,8 +123,8 @@ describe('First-load navigation', () => {
         .should('contain.text', 'Full dashboard')
         .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', 'Read the full methodology')
-        .and('have.attr', 'href', '/agentx/methodology');
+        .should('contain.text', 'Methodology Deep Dive')
+        .and('have.attr', 'href', '/agentx');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
     });
     cy.get('[data-testid="compare-agentx-overview-link"]').click();

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -114,7 +114,7 @@ describe('First-load navigation', () => {
   it('leads the landing page with the AgentX hero and its three CTAs', () => {
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       // The hero owns /compare's h1; on the landing page it is a section heading.
-      cy.get('h2').should('have.text', 'Compare real world, agentic inference results');
+      cy.get('h2').should('have.text', 'Compare Realistic Agentic Inference Perf');
       cy.get('h1').should('not.exist');
       cy.get('[data-testid="compare-agentx-overview-link"]')
         .should('contain.text', 'Overview')

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -46,8 +46,8 @@ describe('Chinese (/zh) pages', () => {
           .should('contain.text', '总览')
           .and('have.attr', 'href', '/zh/overview');
         cy.get('[data-testid="compare-agentx-methodology-link"]')
-          .should('contain.text', '阅读完整方法论')
-          .and('have.attr', 'href', '/zh/agentx/methodology');
+          .should('contain.text', '方法论深度解析')
+          .and('have.attr', 'href', '/zh/agentx');
       });
     });
 

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -39,6 +39,18 @@ describe('Chinese (/zh) pages', () => {
         .and('have.attr', 'href', '/zh/agentx');
     });
 
+    it('renders the AgentX hero on the Chinese landing page', () => {
+      cy.get('[data-testid="compare-agentx-primary"]').within(() => {
+        cy.get('h2').should('have.text', '对比真实场景下的智能体推理结果');
+        cy.get('[data-testid="compare-agentx-overview-link"]')
+          .should('contain.text', '总览')
+          .and('have.attr', 'href', '/zh/overview');
+        cy.get('[data-testid="compare-agentx-methodology-link"]')
+          .should('contain.text', '阅读完整方法论')
+          .and('have.attr', 'href', '/zh/agentx/methodology');
+      });
+    });
+
     it('footer renders in Chinese with zh-internal links', () => {
       cy.get('[data-testid="footer-brand-description"]').should(
         'contain.text',

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -41,7 +41,7 @@ describe('Chinese (/zh) pages', () => {
 
     it('renders the AgentX hero on the Chinese landing page', () => {
       cy.get('[data-testid="compare-agentx-primary"]').within(() => {
-        cy.get('h2').should('have.text', '对比真实场景下的智能体推理结果');
+        cy.get('h2').should('have.text', '对比真实场景下的智能体推理性能');
         cy.get('[data-testid="compare-agentx-overview-link"]')
           .should('contain.text', '总览')
           .and('have.attr', 'href', '/zh/overview');

--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -17,7 +17,7 @@ import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  'Compare AgentX agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2, plus fixed-sequence chip comparisons.';
+  'Compare AgentX agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.3, plus fixed-sequence chip comparisons.';
 
 export const metadata: Metadata = {
   title: 'AgentX Inference Comparisons',

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -16,7 +16,7 @@ import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 export const dynamic = 'force-dynamic';
 
 const DESCRIPTION =
-  '对比 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的 AgentX 智能体推理结果，并浏览定长序列芯片对比。';
+  '对比 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.3 的 AgentX 智能体推理结果，并浏览定长序列芯片对比。';
 
 export const metadata: Metadata = {
   title: 'AgentX 智能体推理对比',

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -8,9 +8,9 @@ import { CompareIndexTrackedLink } from './compare-index-tracked-link';
 const STRINGS = {
   en: {
     eyebrow: 'AgentX / live results',
-    title: 'Compare real world, agentic inference results',
+    title: 'Compare Realistic Agentic Inference Perf',
     description:
-      'Real-world agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2. Compare throughput, interactivity, time to first token, and cost across serving stacks and accelerator platforms.',
+      'Long Context Multi Turn Inference Performance for Kimi K3 2.8T, DeepSeek v4 Pro-813, GLM 5.3 744B, MiniMax M3 430B, Qwen 3.5. Compare Across MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
     overview: 'Overview',
     dashboard: 'Full dashboard',
     methodology: 'Read the full methodology',
@@ -19,9 +19,9 @@ const STRINGS = {
   },
   zh: {
     eyebrow: 'AgentX / 实时结果',
-    title: '对比真实场景下的智能体推理结果',
+    title: '对比真实场景下的智能体推理性能',
     description:
-      '查看 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的真实智能体推理结果，对比不同 serving stack 与加速平台的吞吐量、交互速度、首 token 延迟和成本。',
+      'Kimi K3 2.8T、DeepSeek v4 Pro-813、GLM 5.3 744B、MiniMax M3 430B、Qwen 3.5 的长上下文多轮推理性能，跨 MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100、RTX Pro 等平台进行对比。',
     overview: '总览',
     dashboard: '完整仪表板',
     methodology: '阅读完整方法论',
@@ -68,6 +68,7 @@ export function AgentXCompareHero({
                 href={`${prefix}/overview`}
                 analyticsEvent="compare_agentx_overview_clicked"
                 analyticsSurface={surface}
+                appNavigation
                 className="inline-flex min-h-11 items-center gap-2 rounded-md bg-brand px-5 py-2.5 font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
               >
                 {t.overview}
@@ -79,6 +80,7 @@ export function AgentXCompareHero({
                 analyticsEvent="compare_agentx_dashboard_clicked"
                 analyticsTarget="kimi-k3"
                 analyticsSurface={surface}
+                appNavigation
                 className="inline-flex min-h-11 items-center gap-2 rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"
               >
                 {t.dashboard}
@@ -111,6 +113,7 @@ export function AgentXCompareHero({
                   analyticsEvent="compare_agentx_model_clicked"
                   analyticsTarget={model.slug}
                   analyticsSurface={surface}
+                  appNavigation
                   className="group flex min-h-16 items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 >
                   <span className="min-w-0">

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -13,7 +13,7 @@ const STRINGS = {
       'Long Context Multi Turn Inference Performance for Kimi K3 2.8T, DeepSeek v4 Pro-813, GLM 5.3 744B, MiniMax M3 430B, Qwen 3.5. Compare Across MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
     overview: 'Overview',
     dashboard: 'Full dashboard',
-    methodology: 'Read the full methodology',
+    methodology: 'Methodology Deep Dive',
     ledgerTitle: 'Models with AgentX results',
     modelAction: 'View results',
   },
@@ -24,7 +24,7 @@ const STRINGS = {
       'Kimi K3 2.8T、DeepSeek v4 Pro-813、GLM 5.3 744B、MiniMax M3 430B、Qwen 3.5 的长上下文多轮推理性能，跨 MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100、RTX Pro 等平台进行对比。',
     overview: '总览',
     dashboard: '完整仪表板',
-    methodology: '阅读完整方法论',
+    methodology: '方法论深度解析',
     ledgerTitle: '已有 AgentX 结果的模型',
     modelAction: '查看结果',
   },
@@ -90,7 +90,7 @@ export function AgentXCompareHero({
             <div className="mt-3 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
                 data-testid="compare-agentx-methodology-link"
-                href={`${prefix}/agentx/methodology`}
+                href={`${prefix}/agentx`}
                 analyticsEvent="compare_agentx_methodology_clicked"
                 analyticsSurface={surface}
                 className="inline-flex min-h-11 items-center rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -101,9 +101,8 @@ export function AgentXCompareHero({
           </div>
 
           <div className="border-t border-border/70 bg-muted/15 lg:border-t-0 lg:border-l">
-            <div className="border-b border-border/70 px-5 py-3 font-mono text-[11px] font-semibold tracking-[0.14em] text-muted-foreground uppercase">
-              {t.ledgerTitle}
-            </div>
+            {/* The visible ledger header is dropped; `ledgerTitle` stays as the
+                nav's accessible name so screen readers still get the label. */}
             <nav aria-label={t.ledgerTitle} className="divide-y divide-border/70">
               {FEATURED_AGENTX_MODELS.map((model) => (
                 <CompareIndexTrackedLink

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -10,7 +10,7 @@ const STRINGS = {
     eyebrow: 'AgentX / live results',
     title: 'Compare Realistic Agentic Inference Perf',
     description:
-      'Long Context Multi Turn Inference Performance for Kimi K3 2.8T, DeepSeek v4 Pro-813, GLM 5.3 744B, MiniMax M3 430B, Qwen 3.5. Compare Across MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
+      'Long Context Multi Turn Inference Performance. Compare Across MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
     overview: 'Overview',
     dashboard: 'Full dashboard',
     methodology: 'Methodology Deep Dive',
@@ -21,7 +21,7 @@ const STRINGS = {
     eyebrow: 'AgentX / 实时结果',
     title: '对比真实场景下的智能体推理性能',
     description:
-      'Kimi K3 2.8T、DeepSeek v4 Pro-813、GLM 5.3 744B、MiniMax M3 430B、Qwen 3.5 的长上下文多轮推理性能，跨 MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100、RTX Pro 等平台进行对比。',
+      '长上下文多轮推理性能，跨 MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100、RTX Pro 等平台进行对比。',
     overview: '总览',
     dashboard: '完整仪表板',
     methodology: '方法论深度解析',

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -11,8 +11,9 @@ const STRINGS = {
     title: 'Compare real world, agentic inference results',
     description:
       'Real-world agentic inference results for Kimi K3, DeepSeek V4 Pro, MiniMax M3, Qwen 3.5, and GLM 5.2. Compare throughput, interactivity, time to first token, and cost across serving stacks and accelerator platforms.',
-    dashboard: 'Open the AgentX dashboard',
-    methodology: 'Read the methodology',
+    overview: 'Overview',
+    dashboard: 'Full dashboard',
+    methodology: 'Read the full methodology',
     ledgerTitle: 'Models with AgentX results',
     modelAction: 'View results',
   },
@@ -21,16 +22,31 @@ const STRINGS = {
     title: '对比真实场景下的智能体推理结果',
     description:
       '查看 Kimi K3、DeepSeek V4 Pro、MiniMax M3、Qwen 3.5 与 GLM 5.2 的真实智能体推理结果，对比不同 serving stack 与加速平台的吞吐量、交互速度、首 token 延迟和成本。',
-    dashboard: '打开 AgentX 仪表板',
-    methodology: '阅读方法论',
+    overview: '总览',
+    dashboard: '完整仪表板',
+    methodology: '阅读完整方法论',
     ledgerTitle: '已有 AgentX 结果的模型',
     modelAction: '查看结果',
   },
 } as const;
 
-export function AgentXCompareHero({ locale }: { locale: 'en' | 'zh' }) {
+/**
+ * The hero leads `/compare` and the landing page. `/compare` owns the page
+ * `h1`; the landing page renders the hero under its own section flow, so the
+ * caller picks the heading level rather than shipping a second `h1`.
+ */
+export function AgentXCompareHero({
+  locale,
+  headingLevel = 'h1',
+  surface = 'compare',
+}: {
+  locale: 'en' | 'zh';
+  headingLevel?: 'h1' | 'h2';
+  surface?: 'compare' | 'landing';
+}) {
   const t = STRINGS[locale];
   const prefix = locale === 'zh' ? '/zh' : '';
+  const Heading = headingLevel;
 
   return (
     <section data-testid="compare-agentx-primary">
@@ -40,27 +56,41 @@ export function AgentXCompareHero({ locale }: { locale: 'en' | 'zh' }) {
             <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
               {t.eyebrow}
             </p>
-            <h1 className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight text-foreground lg:text-5xl">
+            <Heading className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight text-foreground lg:text-5xl">
               {t.title}
-            </h1>
+            </Heading>
             <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground lg:text-lg">
               {t.description}
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
+                data-testid="compare-agentx-overview-link"
+                href={`${prefix}/overview`}
+                analyticsEvent="compare_agentx_overview_clicked"
+                analyticsSurface={surface}
+                className="inline-flex min-h-11 items-center gap-2 rounded-md bg-brand px-5 py-2.5 font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
+              >
+                {t.overview}
+                <ArrowRight aria-hidden="true" className="size-4" />
+              </CompareIndexTrackedLink>
+              <CompareIndexTrackedLink
                 data-testid="compare-agentx-dashboard-link"
                 href={agentxDashboardHref(locale, FEATURED_AGENTX_MODELS[0])}
                 analyticsEvent="compare_agentx_dashboard_clicked"
                 analyticsTarget="kimi-k3"
-                className="inline-flex min-h-11 items-center gap-2 rounded-md bg-brand px-5 py-2.5 font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
+                analyticsSurface={surface}
+                className="inline-flex min-h-11 items-center gap-2 rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"
               >
                 {t.dashboard}
                 <ArrowRight aria-hidden="true" className="size-4" />
               </CompareIndexTrackedLink>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
                 data-testid="compare-agentx-methodology-link"
                 href={`${prefix}/agentx/methodology`}
                 analyticsEvent="compare_agentx_methodology_clicked"
+                analyticsSurface={surface}
                 className="inline-flex min-h-11 items-center rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"
               >
                 {t.methodology}
@@ -80,6 +110,7 @@ export function AgentXCompareHero({ locale }: { locale: 'en' | 'zh' }) {
                   href={agentxDashboardHref(locale, model)}
                   analyticsEvent="compare_agentx_model_clicked"
                   analyticsTarget={model.slug}
+                  analyticsSurface={surface}
                   className="group flex min-h-16 items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 >
                   <span className="min-w-0">

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { track } from '@/lib/analytics';
+import { navigateInApp } from '@/lib/client-navigation';
 
 interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link> {
   analyticsEvent:
@@ -13,15 +15,23 @@ interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link>
   analyticsTarget?: string;
   /** Which page rendered the hero, so `/compare` and `/` clicks stay separable. */
   analyticsSurface?: string;
+  /** Route the click through `navigateInApp`, the way the header nav and the
+   *  landing card already do for `/overview` and `/inference`. The first
+   *  dashboard transition can request the route without committing the URL, so
+   *  those destinations need the retry; content routes do not. */
+  appNavigation?: boolean;
 }
 
 export function CompareIndexTrackedLink({
   analyticsEvent,
   analyticsTarget,
   analyticsSurface,
+  appNavigation = false,
   onClick,
   ...props
 }: CompareIndexTrackedLinkProps) {
+  const router = useRouter();
+
   return (
     <Link
       {...props}
@@ -33,6 +43,9 @@ export function CompareIndexTrackedLink({
           ...(analyticsSurface ? { surface: analyticsSurface } : {}),
         };
         track(analyticsEvent, Object.keys(payload).length > 0 ? payload : undefined);
+        if (appNavigation && typeof props.href === 'string') {
+          navigateInApp(event, router, props.href);
+        }
       }}
     />
   );

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -6,15 +6,19 @@ import { track } from '@/lib/analytics';
 
 interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link> {
   analyticsEvent:
+    | 'compare_agentx_overview_clicked'
     | 'compare_agentx_dashboard_clicked'
     | 'compare_agentx_methodology_clicked'
     | 'compare_agentx_model_clicked';
   analyticsTarget?: string;
+  /** Which page rendered the hero, so `/compare` and `/` clicks stay separable. */
+  analyticsSurface?: string;
 }
 
 export function CompareIndexTrackedLink({
   analyticsEvent,
   analyticsTarget,
+  analyticsSurface,
   onClick,
   ...props
 }: CompareIndexTrackedLinkProps) {
@@ -24,7 +28,11 @@ export function CompareIndexTrackedLink({
       onClick={(event) => {
         onClick?.(event);
         if (event.defaultPrevented) return;
-        track(analyticsEvent, analyticsTarget ? { target: analyticsTarget } : undefined);
+        const payload = {
+          ...(analyticsTarget ? { target: analyticsTarget } : {}),
+          ...(analyticsSurface ? { surface: analyticsSurface } : {}),
+        };
+        track(analyticsEvent, Object.keys(payload).length > 0 ? payload : undefined);
       }}
     />
   );

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -42,8 +42,9 @@ interface NavLink {
 }
 
 const NAV_LINKS: readonly NavLink[] = [
-  // AgentX leads the nav: it is the flagship benchmark, and the surface every
-  // other entry ultimately explains.
+  { href: '/', label: 'Home', testId: 'nav-link-home', event: 'header_home_clicked' },
+  // AgentX sits directly after Home: it is the flagship benchmark, and the
+  // surface every entry below it ultimately explains.
   {
     href: '/agentx',
     label: 'AgentX',
@@ -51,7 +52,6 @@ const NAV_LINKS: readonly NavLink[] = [
     event: 'header_agentx_clicked',
     badge: { en: 'NEW', zh: '新' },
   },
-  { href: '/', label: 'Home', testId: 'nav-link-home', event: 'header_home_clicked' },
   {
     href: '/overview',
     label: 'Overview',

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -84,12 +84,13 @@ export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
       <LandingPageAnalytics />
       <NudgeEngine scope="landing" />
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-4">
-        <IntroSection locale={locale} />
-
-        {/* Same AgentX hero that leads /compare. The landing page owns no h1 of
-            its own, but keep this an h2 so the hero stays a section within the
-            page rather than retitling the whole site. */}
+        {/* Same AgentX hero that leads /compare, above the quote carousel. The
+            landing page owns no h1 of its own, but keep this an h2 so the hero
+            stays a section within the page rather than retitling the whole
+            site. */}
         <AgentXCompareHero locale={locale} headingLevel="h2" surface="landing" />
+
+        <IntroSection locale={locale} />
 
         {/* Split: exploration entry points vs presets */}
         <section className="flex flex-col gap-4 pb-8">

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight, BarChart3, ShieldCheck, Sparkles } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
+import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { IntroSection } from '@/components/intro-section';
 import { LandingPageAnalytics, LandingTrackedLink } from '@/components/landing/landing-analytics';
 import { CuratedViewCard } from '@/components/landing/curated-view-card';
@@ -84,6 +85,11 @@ export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
       <NudgeEngine scope="landing" />
       <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-6 lg:gap-4">
         <IntroSection locale={locale} />
+
+        {/* Same AgentX hero that leads /compare. The landing page owns no h1 of
+            its own, but keep this an h2 so the hero stays a section within the
+            page rather than retitling the whole site. */}
+        <AgentXCompareHero locale={locale} headingLevel="h2" surface="landing" />
 
         {/* Split: exploration entry points vs presets */}
         <section className="flex flex-col gap-4 pb-8">

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -256,7 +256,7 @@ describe('compareModelDisplayLabel', () => {
       'Kimi K2.5/K2.6/K2.7-Code 1T — GB200 NVL72 vs MI355X',
     );
     expect(compareModelDisplayLabel(GLM_51, 'h100', 'h200')).toBe('GLM 5/5.1 — H100 vs H200');
-    expect(compareModelDisplayLabel(GLM_52, 'h100', 'h200')).toBe('GLM 5.2 — H100 vs H200');
+    expect(compareModelDisplayLabel(GLM_52, 'h100', 'h200')).toBe('GLM 5.3 744B — H100 vs H200');
   });
 });
 

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -97,7 +97,10 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     slug: 'glm-5-2',
     displayName: 'GLM-5.2',
     dbKeys: ['glm5.2'],
-    label: 'GLM 5.2',
+    // GLM-5.2 and GLM-5.3 share one data bucket (see MODEL_CONFIG); the card
+    // shows the current release. `slug`, `displayName`, and `dbKeys` stay on
+    // 5.2 so URLs and the `g_model` param keep resolving.
+    label: 'GLM 5.3 744B',
     seoName: 'GLM-5.2',
   },
   {

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -50,7 +50,7 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     slug: 'deepseek-v4',
     displayName: 'DeepSeek-V4-Pro',
     dbKeys: ['dsv4'],
-    label: 'DeepSeek V4 Pro 1.6T',
+    label: 'DeepSeekv4 Pro 0813 1.6T',
     seoName: 'DeepSeek V4 Pro',
   },
   {


### PR DESCRIPTION
## Summary

Three related IA changes.

**1. The AgentX hero now leads the landing page.** The same `AgentXCompareHero` that tops `/compare` renders on `/` and `/zh`, between the quote carousel (`IntroSection`) and the Explore InferenceX card.

**2. The hero's CTAs go from two to three.** Replacing "Open the AgentX dashboard" + "Read the methodology":

| Position | Label | Href |
| --- | --- | --- |
| Row 1, primary | Overview / 总览 | `/overview` |
| Row 1, secondary | Full dashboard / 完整仪表板 | `/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1` |
| Row 2 | Read the full methodology / 阅读完整方法论 | `/agentx/methodology` |

The hero is a shared component, so `/compare` picks up the same three CTAs — confirmed as intended before implementing.

**3. Header nav reorder.** `Home · AgentX (NEW) · Overview · Dashboard · Comparisons · About` — Home and AgentX swap; everything else is unchanged.

### Two small props on the shared hero

- `headingLevel` (`'h1' | 'h2'`, default `'h1'`) — `/compare` owns its page `h1`; the landing page renders the hero as a section, so it passes `h2`. The landing page had no `h1` before this change and still has none.
- `analyticsSurface` on `CompareIndexTrackedLink` — adds `surface: 'compare' | 'landing'` to the tracked payload so hero clicks from the two pages stay separable in PostHog. Existing `target` values are untouched. New event `compare_agentx_overview_clicked` added to the event union.

### Chinese coverage

No new `/zh` route is needed — the hero already carries a full `zh` string dict, and all three CTA labels plus their hrefs are localized. Verified on `/zh`.

### Tests

- `cypress/component/header.cy.tsx` — nav-order expectation updated to the new order.
- `cypress/e2e/compare-precision.cy.ts` — asserts all three CTA labels and hrefs on `/compare` and `/zh/compare`.
- `cypress/e2e/navigation.cy.ts` — new spec: the hero renders on `/` as an `h2` (and no `h1`), all three CTAs resolve, five model rows are present, and the Overview CTA navigates.
- `cypress/e2e/zh-pages.cy.ts` — new spec: the hero renders on `/zh` with Chinese heading and localized CTA hrefs.

### Verification

`bun run lint`, `bun run fmt`, `bun run typecheck` pass (pre-commit re-ran them). Checked against a local dev server: hero renders on `/` between the intro section and Explore InferenceX with heading order `Open-Source Continuous… → Compare real world… → Explore InferenceX → Every Result Is Transparently…`; `/compare` keeps its `h1`; nav order renders `home, agentx, overview, dashboard, compare, about`; `/zh` renders the Chinese heading and `/zh/overview` + `/zh/agentx/methodology` hrefs. Full Cypress matrix runs in CI.

### One judgment call worth a look

"Full dashboard" keeps the AgentX-filtered href rather than bare `/inference`, so the hero's dashboard link stays in AgentX context. On the landing page that means two buttons labeled some form of "Full Dashboard" pointing at different URLs (the hero's AgentX-filtered one, and the Explore card's plain `/inference`). Easy to change either way — say which you prefer.

## 中文说明

三项相关的信息架构调整。

**1. 落地页顶部引入 AgentX hero。** `/compare` 顶部的 `AgentXCompareHero` 组件现在同时渲染在 `/` 与 `/zh`，位置在引用轮播（`IntroSection`）与"探索 InferenceX"卡片之间。

**2. hero 的 CTA 由两个改为三个**（替换原来的"打开 AgentX 仪表板"与"阅读方法论"）：第一行主按钮"总览"指向 `/overview`，次按钮"完整仪表板"指向已按 AgentX 过滤的仪表板；第二行"阅读完整方法论"指向 `/agentx/methodology`。该组件为共享组件，`/compare` 同步获得相同 CTA（实现前已确认为预期行为）。

**3. 顶部导航顺序调整**为 `Home · AgentX（NEW）· Overview · Dashboard · Comparisons · About`，即 Home 与 AgentX 互换，其余不变。

新增两个属性：`headingLevel`（`/compare` 保留 `h1`，落地页使用 `h2`；落地页此前与现在均无 `h1`）与 `analyticsSurface`（在埋点中区分 `compare` 与 `landing` 两个来源，原有 `target` 取值不变）。

hero 组件本身已包含完整中文字典，三个 CTA 的文案与链接均已本地化，无需新增 `/zh` 页面。

测试覆盖：更新 header 组件的导航顺序断言；`/compare` 与 `/zh/compare` 断言三个 CTA 的文案与 href；新增 `/` 与 `/zh` 落地页 hero 的 E2E 用例。本地 `lint`、`fmt`、`typecheck` 全部通过，并已在开发服务器上验证渲染结果。

关于"完整仪表板"按钮：目前仍指向按 AgentX 过滤的仪表板链接，以保持 hero 的 AgentX 语境；这会导致落地页出现两个名称相近但目标不同的按钮，如需改为 `/inference` 可随时调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/IA, link targets, and analytics only; no auth, data, or API behavior changes.
> 
> **Overview**
> **Information architecture:** Primary nav order is now **Home → AgentX (NEW) → …** instead of AgentX first. The shared **`AgentXCompareHero`** is placed at the top of **`/`** and **`/zh`** (above the intro section), using **`h2`** on the landing page while **`/compare`** keeps the page **`h1`**.
> 
> **Hero content and CTAs:** Headlines and body copy are updated (EN/ZH). CTAs expand to three: **Overview** → `/overview` (primary), **Full dashboard** → AgentX-filtered inference URL (secondary), **Methodology Deep Dive** → **`/agentx`** (replacing **`/agentx/methodology`**). **`CompareIndexTrackedLink`** adds **`analyticsSurface`**, **`appNavigation`** via **`navigateInApp`**, and **`compare_agentx_overview_clicked`**.
> 
> **Copy/metadata:** Compare index SEO descriptions and the **`glm-5-2`** display label now say **GLM 5.3** (URLs and **`dbKeys`** unchanged). Cypress specs cover nav order, **`/compare`**, landing, and **`/zh`** hero behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e79aee8680e69689bbbb1095f885d56b33403a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->