### PR TITLE
chore(ui): tighten the AgentX hero and recolor the wordmark / 收紧 AgentX hero 并调整 wordmark 配色

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -40,20 +40,20 @@
   content: none;
 }
 
-/* Pride theme for the InferenceX wordmark — celebrating July Disability Pride Month.
-   Paints the brand text with the Disability Pride flag's 5 stripe colors via a
-   clipped diagonal gradient (Ann Magill's 2021 revised, low-sensitivity palette):
-   red = physical, gold = neurodivergent, gray = invisible/undiagnosed,
-   blue = psychiatric, green = sensory. The flag's white stripe is darkened to a
-   readable slate here so the clipped wordmark stays legible on the light header. */
+/* Pride theme for the InferenceX wordmark — the transgender flag's stripe colors
+   painted onto the brand text via a clipped gradient: light blue, pink, white,
+   pink, light blue. The white stripe is darkened to a readable slate here, the
+   same treatment the earlier flag themes used, so the clipped wordmark stays
+   legible on the light header. Fixed flag colors, independent of the theme
+   tokens, so it renders the same in light, dark, and minecraft modes. */
 .pride-wordmark {
   background-image: linear-gradient(
-    135deg,
-    #cf7280 0%,
-    #d9ad2e 28%,
+    90deg,
+    #5bcefa 0%,
+    #f5a9b8 25%,
     #8a8f99 50%,
-    #4aa6cf 72%,
-    #3aa660 100%
+    #f5a9b8 75%,
+    #5bcefa 100%
   );
   background-clip: text;
   -webkit-background-clip: text;

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -52,17 +52,17 @@ export function AgentXCompareHero({
     <section data-testid="compare-agentx-primary">
       <Card className="overflow-hidden p-0 md:p-0">
         <div className="grid lg:grid-cols-[minmax(0,1.15fr)_minmax(19rem,0.85fr)]">
-          <div className="flex flex-col justify-center p-6 md:p-8 lg:p-10">
+          <div className="flex flex-col justify-center px-6 py-5 md:px-8 md:py-6 lg:px-10 lg:py-7">
             <p className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase">
               {t.eyebrow}
             </p>
-            <Heading className="mt-3 max-w-2xl text-3xl font-semibold tracking-tight text-foreground lg:text-5xl">
+            <Heading className="mt-3 max-w-2xl text-[1.5rem]/[1.8rem] font-semibold tracking-tight text-foreground lg:text-[2.4rem]/[2.4rem]">
               {t.title}
             </Heading>
-            <p className="mt-4 max-w-3xl text-base leading-7 text-muted-foreground lg:text-lg">
+            <p className="mt-3 max-w-3xl text-base leading-7 text-muted-foreground lg:text-lg">
               {t.description}
             </p>
-            <div className="mt-7 flex flex-wrap gap-3">
+            <div className="mt-5 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
                 data-testid="compare-agentx-overview-link"
                 href={`${prefix}/overview`}
@@ -87,7 +87,7 @@ export function AgentXCompareHero({
                 <ArrowRight aria-hidden="true" className="size-4" />
               </CompareIndexTrackedLink>
             </div>
-            <div className="mt-3 flex flex-wrap gap-3">
+            <div className="mt-2 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
                 data-testid="compare-agentx-methodology-link"
                 href={`${prefix}/agentx`}
@@ -113,7 +113,7 @@ export function AgentXCompareHero({
                   analyticsTarget={model.slug}
                   analyticsSurface={surface}
                   appNavigation
-                  className="group flex min-h-16 items-center justify-between gap-4 px-5 py-3 transition-colors hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                  className="group flex min-h-14 items-center justify-between gap-4 px-5 py-2.5 transition-colors hover:bg-brand/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                 >
                   <span className="min-w-0">
                     <span className="block text-sm font-semibold leading-tight text-foreground group-hover:text-brand">


### PR DESCRIPTION
## Summary

Two visual chores, both in shared surfaces.

### 1. AgentX hero — less vertical padding, smaller title

The hero is shared by `/` and `/compare`, so both pick this up.

| What | Before | After |
| --- | --- | --- |
| Left column padding | `p-6 md:p-8 lg:p-10` | `px-6 py-5 md:px-8 md:py-6 lg:px-10 lg:py-7` |
| Title → copy gap | `mt-4` | `mt-3` |
| Copy → CTA row 1 | `mt-7` | `mt-5` |
| CTA row 1 → row 2 | `mt-3` | `mt-2` |
| Model rows | `min-h-16` / `py-3` | `min-h-14` / `py-2.5` |

The dead space under the CTAs was mostly the right column driving the card height, so the model rows shrink along with the left column's padding. 56px still clears the tap-target minimum comfortably.

**Title font size drops exactly 20%**, expressed as arbitrary values so the ratio is exact rather than rounded to the nearest step:

- base: `text-3xl` (1.875rem / 2.25rem) → `text-[1.5rem]/[1.8rem]` (1.5rem / 1.8rem)
- lg: `text-5xl` (3rem / 1) → `text-[2.4rem]/[2.4rem]` (2.4rem / 2.4rem)

Verified both utilities are emitted by Tailwind in the served stylesheet, with the exact `font-size` / `line-height` pairs above.

### 2. Header wordmark → transgender flag colors

`.pride-wordmark` moves from the July Disability Pride palette to the transgender flag's stripes: light blue `#5bcefa`, pink `#f5a9b8`, white, pink, light blue. The white stripe keeps the darkened-slate substitution (`#8a8f99`) the previous theme already used, since a true white stripe disappears against the light header when the gradient is clipped to text. Colors stay fixed rather than theme-token-derived, so the wordmark renders identically in light, dark, and minecraft modes.

## Verification

`bun run lint`, `bun run fmt`, `bun run typecheck` pass (pre-commit re-ran them). `bun run test:unit` — 3,506 tests pass. Checked against a local dev server: the hero renders the new padding and font-size classes on `/` and `/compare`, the compiled CSS contains the two arbitrary font-size rules and the three trans-flag hex values, and no `#cf7280` (the old palette) remains.

No test asserted the padding classes, the old font-size classes, or the gradient, so no spec changes were needed.

## 中文说明

两项视觉调整，均位于共享组件。

**1. AgentX hero 收紧纵向留白、标题缩小 20%。** 该 hero 由 `/` 与 `/compare` 共用，两个页面同步生效。左栏 padding 由 `p-6/8/10` 改为 `py-5/6/7`（横向间距不变）；标题、正文与两行 CTA 之间的间距各收一档；模型列表行由 `min-h-16`/`py-3` 改为 `min-h-14`/`py-2.5`。CTA 下方的空白主要由右栏高度撑出，因此列表行需一并收紧；56px 仍充分满足点击区域下限。标题字号精确缩小 20%：基础尺寸 1.875rem/2.25rem → 1.5rem/1.8rem，lg 断点 3rem/1 → 2.4rem/2.4rem，使用 arbitrary value 以保证比例精确而非就近取档。

**2. 页头 wordmark 改为跨性别旗配色。** `.pride-wordmark` 渐变由七月残障骄傲配色改为跨性别旗条纹：浅蓝 `#5bcefa`、粉 `#f5a9b8`、白、粉、浅蓝。其中白色条纹沿用此前主题的深灰替代方案（`#8a8f99`）——渐变被裁剪到文字上时，纯白在浅色页头上会不可见。配色为固定值而非取自主题 token，因此在 light、dark 与 minecraft 模式下表现一致。

本地 `lint`、`fmt`、`typecheck` 与 3,506 项单元测试全部通过；已在开发服务器上确认样式生效、编译后的 CSS 包含两条 arbitrary font-size 规则与三个跨性别旗色值，且旧配色 `#cf7280` 已完全移除。相关 class 与渐变均无测试断言，故无需修改测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d7fe29a1d1deb409a02b06dc5d2d562581c2f72a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->