### PR TITLE
chore(compare): reorder the AgentX model ledger / 调整 AgentX 模型列表顺序

### DIFF
--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -126,6 +126,19 @@ describe('First-load navigation', () => {
         .should('contain.text', 'Methodology Deep Dive')
         .and('have.attr', 'href', '/agentx');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      // Editorial order, not alphabetical — see FEATURED_AGENTX_MODEL_SLUGS.
+      cy.get('[data-testid^="compare-agentx-model-"]').then(($rows) => {
+        const slugs = [...$rows].map((row) =>
+          (row.dataset.testid ?? '').replace('compare-agentx-model-', ''),
+        );
+        expect(slugs).to.deep.equal([
+          'kimi-k3',
+          'deepseek-v4',
+          'glm-5-2',
+          'minimax-m3',
+          'qwen-3-5',
+        ]);
+      });
     });
     cy.get('[data-testid="compare-agentx-overview-link"]').click();
     cy.location('pathname').should('eq', '/overview');

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -13,9 +13,9 @@ describe('AgentX comparison links', () => {
     expect(FEATURED_AGENTX_MODELS.map((model) => model.slug)).toEqual([
       'kimi-k3',
       'deepseek-v4',
+      'glm-5-2',
       'minimax-m3',
       'qwen-3-5',
-      'glm-5-2',
     ]);
   });
 

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -3,9 +3,9 @@ import { COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 const FEATURED_AGENTX_MODEL_SLUGS = [
   'kimi-k3',
   'deepseek-v4',
+  'glm-5-2',
   'minimax-m3',
   'qwen-3-5',
-  'glm-5-2',
 ] as const;
 
 const FEATURED_AGENTX_MODEL_SET = new Set<string>(FEATURED_AGENTX_MODEL_SLUGS);


### PR DESCRIPTION
## Summary

The AgentX model list in the hero (right column) is reordered to Kimi → DeepSeek → GLM → MiniMax → Qwen.

| Position | Before | After |
| --- | --- | --- |
| 1 | Kimi K3 2.8T | Kimi K3 2.8T |
| 2 | DeepSeekv4 Pro 0813 1.6T | DeepSeekv4 Pro 0813 1.6T |
| 3 | MiniMax M3 428B | **GLM 5.3 744B** |
| 4 | Qwen 3.5 397B-A17B | **MiniMax M3 428B** |
| 5 | GLM 5.3 744B | **Qwen 3.5 397B-A17B** |

One-line change to `FEATURED_AGENTX_MODEL_SLUGS` in `packages/app/src/lib/compare-agentx.ts`, which is the single source for the ledger. The hero is shared, so `/compare` and `/zh/compare` get the same order as `/` and `/zh`.

Kimi stays at index 0, so the hero's "Full dashboard" CTA — which reads `FEATURED_AGENTX_MODELS[0]` — still opens Kimi K3 in the AgentX scenario. Nothing else keys off position.

## Tests

- `compare-agentx.test.ts` pins the editorial order; expectation updated to match.
- `navigation.cy.ts` previously only checked that five rows render on the landing page. It now also asserts the rendered `data-testid` sequence, so a future accidental reorder fails a test instead of shipping.

## Verification

`bun run lint`, `bun run fmt`, `bun run typecheck` pass (pre-commit re-ran them). `bun run test:unit` — 3,506 tests pass. No other spec asserts row order; the existing `/compare` specs address rows by individual `data-testid`, so they are position-independent and unchanged.

## 中文说明

将 hero 右侧的 AgentX 模型列表顺序调整为 Kimi → DeepSeek → GLM → MiniMax → Qwen：GLM 由第 5 位上移至第 3 位，MiniMax 与 Qwen 各下移一位。

改动集中在 `packages/app/src/lib/compare-agentx.ts` 中的 `FEATURED_AGENTX_MODEL_SLUGS`——该常量是列表的唯一数据来源。由于 hero 为共享组件，`/compare` 与 `/zh/compare` 同步采用相同顺序。

Kimi 仍位于索引 0，因此 hero 中读取 `FEATURED_AGENTX_MODELS[0]` 的"完整仪表板"CTA 依旧打开 Kimi K3 的 AgentX 场景；其余逻辑均不依赖位置。

测试方面：更新 `compare-agentx.test.ts` 中固定顺序的断言；`navigation.cy.ts` 此前仅校验渲染五行，现补充对实际渲染顺序的断言，以便日后误改顺序时能被测试拦截。本地 `lint`、`fmt`、`typecheck` 与 3,506 项单元测试全部通过；其余 E2E 用例均通过独立 `data-testid` 定位行，与位置无关，无需修改。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 01f09afb9576da5e80443ed49a75a67949f6c39f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->