### PR TITLE
fix(inference): Keep optional comparison dates neutral / 修复可选对比日期范围误报

### DIFF
--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -96,7 +96,7 @@ describe('Inference ChartControls with GPUs selected', () => {
     cy.contains('Comparison Date Range').should('be.visible');
   });
 
-  it('flags the date range when nothing has been picked to compare against', () => {
+  it('leaves the optional date range unflagged for a selected current config', () => {
     mountWithProviders(<InferenceChartControls />, {
       inference: {
         selectedGPUs: ['h100'],
@@ -105,7 +105,9 @@ describe('Inference ChartControls with GPUs selected', () => {
       },
     });
 
-    cy.contains('button', 'Select date range').should('have.class', 'animate-pulse');
+    cy.contains('button', 'Select date range')
+      .should('not.have.class', 'animate-pulse')
+      .and('not.have.class', 'border-red-500');
   });
 
   it('leaves the date range unflagged when exact comparison entries are pinned', () => {

--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -160,6 +160,10 @@ describe('GPU comparison agentic point detail', () => {
 
     cy.get('[data-testid="gpu-multiselect"] [role="combobox"]').click({ force: true });
     cy.get('[role="option"]').first().click();
+    cy.contains('Comparison Date Range').should('be.visible');
+    cy.contains('button', 'Select date range')
+      .should('not.have.class', 'animate-pulse')
+      .and('not.have.class', 'border-red-500');
     cy.contains('button', 'Select date range').click();
     cy.get('body').then(($body) => {
       if ($body.text().includes('View anyway')) {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -625,7 +625,7 @@ describe('Overview page', () => {
       });
   });
 
-  it('does not flag the optional date range after opening a benchmark result', () => {
+  it('keeps a benchmark result usable without comparison dates', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
@@ -642,6 +642,11 @@ describe('Overview page', () => {
         cy.contains('button', 'Select date range')
           .should('not.have.class', 'animate-pulse')
           .and('not.have.class', 'border-red-500');
+        cy.get('[data-testid="scatter-graph"]')
+          .should('be.visible')
+          .find('svg .dot-group')
+          .should('have.length.greaterThan', 0);
+        cy.contains('Select a date range or add a run to view chip comparison').should('not.exist');
       });
   });
 

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -625,6 +625,42 @@ describe('Overview page', () => {
       });
   });
 
+  it('does not flag the optional date range after opening a benchmark result', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+
+    desktopModel('Qwen-3.5-397B-A17B', SINGLE_TURN)
+      .find(
+        '[data-testid="overview-pair-value"][data-hardware="mi355x"] [data-testid="overview-cost-evidence-link"]',
+      )
+      .then(($link) => {
+        const href = String($link.attr('href'));
+        expect(href).not.to.contain('i_dates=');
+        cy.visit(href);
+
+        cy.contains('Comparison Date Range').should('be.visible');
+        cy.contains('button', 'Select date range')
+          .should('not.have.class', 'animate-pulse')
+          .and('not.have.class', 'border-red-500');
+      });
+  });
+
+  it('does not require comparison dates when opening AgentX details', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+
+    desktopModel('Qwen-3.5-397B-A17B', AGENTX)
+      .contains('a', 'View details')
+      .then(($link) => {
+        const href = String($link.attr('href'));
+        expect(href).to.contain('i_seq=agentic-traces');
+        expect(href).not.to.contain('i_dates=');
+        cy.visit(href);
+
+        cy.contains('Comparison Date Range').should('not.exist');
+      });
+  });
+
   it('keeps the historical comparison complete and non-scrolling across desktop, tablet and phone', () => {
     for (const width of [320, 390, 768, 1024, 1279, 1280, 1440]) {
       cy.viewport(width, 900);

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -28,7 +28,6 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
 import chartDefinitions from '@/components/inference/inference-chart-config.json';
 import type { ChartDefinition, DeploymentMode, SpecMode } from '@/components/inference/types';
-import { resolveComparisonEntries } from '@/components/inference/utils/comparisonEntry';
 import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
 import { Sequence, type Model, type Percentile } from '@/lib/data-mappings';
 import { useLocale } from '@/lib/use-locale';
@@ -244,7 +243,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
     selectedGPUs,
     setSelectedGPUs,
     availableGPUs,
-    selectedDates,
     selectedDateRange,
     setSelectedDateRange,
     dateRangeAvailableDates,
@@ -619,14 +617,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
                 placeholder={t.dateRangePlaceholder}
                 availableDates={dateRangeAvailableDates}
                 isCheckingAvailableDates={isCheckingAvailableDates}
-                className={
-                  // Note (wenyao): a pinned run (`date~rID`) can only reach the chart through
-                  // selectedDates, never through a range, so demanding a range here raises a
-                  // false alarm on comparisons that are already complete.
-                  resolveComparisonEntries(selectedDates, selectedDateRange).length === 0
-                    ? 'border-red-500 ring-4 ring-red-500/40 animate-pulse'
-                    : ''
-                }
               />
             </div>
           )}

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -90,7 +90,6 @@ const STRINGS = {
     updated: 'Updated:',
     e2eNormIntvtyDisclaimer:
       'E2E Normalized Interactivity requires persisted per-request traces, so unofficial-run overlays are unavailable for this experimental view.',
-    selectDateRange: 'Select a date range or add a run to view chip comparison',
     viewMode: 'View mode',
     vsTtft: (word: string) => `vs. ${word} Time To First Token`,
     vsE2eLatency: (pctl?: string) =>
@@ -107,7 +106,6 @@ const STRINGS = {
     updated: '更新时间：',
     e2eNormIntvtyDisclaimer:
       '端到端归一化交互性需要持久化的逐请求 trace 数据，因此该实验性视图不支持非官方运行覆盖。',
-    selectDateRange: '请选择日期范围或添加运行以查看 Chip 对比',
     viewMode: '视图模式',
     vsTtft: (word: string) => `vs. ${word === 'Median' ? '中位' : word} 首 token 延迟（TTFT）`,
     vsE2eLatency: (pctl?: string) => (pctl ? `vs. ${pctl} 端到端延迟` : 'vs. 端到端延迟'),
@@ -945,15 +943,6 @@ export default function ChartDisplay() {
                               ) ?? undefined
                             }
                           />
-                          {selectedGPUs.length > 0 &&
-                            (!selectedDateRange.startDate || !selectedDateRange.endDate) &&
-                            selectedDates.length === 0 && (
-                              <div className="absolute inset-0 flex items-center justify-center bg-background/60 backdrop-blur-[2px] rounded-lg z-10">
-                                <p className="text-sm font-medium text-muted-foreground bg-background/90 border border-border rounded-md px-4 py-2 shadow-sm">
-                                  {t.selectDateRange}
-                                </p>
-                              </div>
-                            )}
                         </div>
                       );
                     })()}


### PR DESCRIPTION
## Summary

- Stop showing an error pulse when Comparison Date Range is empty; selecting historical comparison dates is optional.
- Cover fixed-sequence Overview evidence links and AgentX detail/config-selection flows.

## Why

The shared chart controls treated every selected Chip Config without comparison dates as invalid, so normal Overview and AgentX navigation displayed a false error state.

## Validation

- `bun run test:unit` — 4,085 passing
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `E2E_FIXTURES=1 bun run build`
- ChartControls component Cypress (Chrome) — 13 passing
- Overview + AgentX detail E2E (Chrome and Firefox) — 39 passing per browser

## 中文说明

- 空的“对比日期范围”不再显示错误脉冲；历史对比日期为可选项。
- 覆盖从 Overview 进入的定长序列证据链接，以及 AgentX 详情页和配置选择流程。

## 背景

共享图表控件此前会将“已选择 Chip Config 但未选择对比日期”的所有状态判定为无效，导致正常的 Overview 和 AgentX 导航出现误报。

## 验证

- `bun run test:unit` — 4,085 项通过
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `E2E_FIXTURES=1 bun run build`
- ChartControls 组件 Cypress（Chrome）— 13 项通过
- Overview + AgentX 详情 E2E（Chrome 和 Firefox）— 每个浏览器 39 项通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change removing false validation states; chart data paths for explicit comparison dates are unchanged.
> 
> **Overview**
> **Comparison dates are optional again** for chip-config views. The shared inference chart controls no longer pulse or red-border **Comparison Date Range** when GPUs are selected but no range or pinned runs are set, and the scatter chart no longer shows a blocking overlay asking users to pick dates before viewing data.
> 
> Cypress coverage is updated and extended for Overview evidence links (charts render without `i_dates`), AgentX detail entry (no comparison date control), and GPU compare flows where the date picker stays neutral.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41035f8d744fa3bcc0a3bf7a4ba12935b69668d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->