### PR TITLE
Increase database backup timeout / 延长数据库备份超时时间

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -48,7 +48,7 @@ jobs:
   dump:
     name: Dump and compress
     needs: preflight
-    timeout-minutes: 180
+    timeout-minutes: 360
     runs-on: ubuntu-latest
     steps:
       - name: Dump, compress, and split database


### PR DESCRIPTION
## Summary

- Increase the database dump job timeout from 180 minutes to GitHub's 360-minute maximum.
- Keep the dump on `ubuntu-latest` because prior Blacksmith runs were OOM-killed by `blacksmithd`.
- Allow the growing database dump to complete after four consecutive runs reached the previous timeout.

## Verification

- `actionlint .github/workflows/db-backup.yml`
- `git diff --check`
- Pre-commit `lint`, `format`, and `typecheck`

## 中文说明

- 将数据库导出任务的超时时间从 180 分钟提高到 GitHub 允许的最高值 360 分钟。
- 继续使用 `ubuntu-latest`，因为此前 Blacksmith 运行中的 `blacksmithd` 曾耗尽内存并导致任务被终止。
- 数据库持续增长后，最近连续四次备份均触及原超时限制，本次调整为完整备份预留足够时间。

## 验证

- `actionlint .github/workflows/db-backup.yml`
- `git diff --check`
- 提交前 `lint`、`format` 和 `typecheck` 检查

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI timeout-only change; dump logic, secrets usage, and release publishing are unchanged.
> 
> **Overview**
> Raises the weekly database dump job timeout from **180** to **360** minutes so growing `pg_dump` + zstd runs can finish instead of hitting GitHub Actions’ previous limit.
> 
> Dump still runs on `ubuntu-latest`; no dump, split, or release steps change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ce089d3f5ab2463cb2b8acb7a195f13427fa5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->