### PR TITLE
fix(filters): apply URL filter params on client-side navigation

### DIFF
--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+
 import {
   type ReactNode,
   createContext,
@@ -24,6 +26,7 @@ function isEnumValue<T extends Record<string, string>>(e: T, v: string): v is T[
 import { useAvailability } from '@/hooks/api/use-availability';
 import { useWorkflowInfo } from '@/hooks/api/use-workflow-info';
 import { useUrlState } from '@/hooks/useUrlState';
+import { refreshUrlParams } from '@/lib/url-state';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import {
   Model,
@@ -227,7 +230,23 @@ export function GlobalFilterProvider({
   // so users with shareable URLs (?i_seq=…&g_model=…) see their values without
   // flicker, and SSR/client hydration agree because initial state came from
   // props/defaults on both sides.
+  // Soft navigations do not remount this provider, and `useUrlState` caches the
+  // URL in a ref at first render — so without this, landing on
+  // `/inference?g_model=Qwen-3.5-397B-A17B` via a <Link> kept whatever model
+  // the previous page had (the default, DeepSeek). Every AgentX card on the
+  // landing page pointed at the right URL and still opened the wrong model.
+  // `usePathname` rather than `useSearchParams`: the latter forces every
+  // statically-prerendered page that mounts this provider behind a Suspense
+  // boundary, which fails the build on /ai-chart. Pathname changes on the
+  // navigations that matter here — the AgentX cards and every share link live
+  // on a different route from /inference.
+  const pathname = usePathname();
+
   useIsomorphicLayoutEffect(() => {
+    // Pull the live URL into the shared snapshot first: `getUrlParam` below and
+    // the auto-switch guard further down both read from it, and on a soft
+    // navigation it still holds the previous page's params.
+    refreshUrlParams();
     const applyIfEnum = <T extends Record<string, string>>(
       key: 'g_model' | 'i_seq',
       enumType: T,
@@ -259,8 +278,14 @@ export function GlobalFilterProvider({
     }
     applyIfMatches('g_rundate', RUNDATE_RE, setSelectedRunDateBase);
     applyIfMatches('g_runid', RUNID_RE, setSelectedRunId);
+    // Re-runs on client-side navigation as well as on mount. Keyed on the
+    // pathname, which the Next router owns: the provider's own share-link
+    // writes go through `history.replaceState` and never change it, so this
+    // cannot fight a user changing filters in place. A param-only navigation
+    // within /inference is therefore not picked up — no in-app link does that
+    // today, and covering it would mean the Suspense bailout above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [pathname]);
 
   // ── Availability data ─────────────────────────────────────────────────────
   const { data: availabilityRows } = useAvailability();

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -128,6 +128,65 @@ describe('readUrlParams', () => {
   });
 });
 
+describe('refreshUrlParams', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // A client-side navigation does not reload the module, so the load-time
+  // snapshot still describes the page the user came FROM. Every AgentX card on
+  // the landing page linked to `/inference?g_model=<model>` and opened the
+  // default model instead, because the snapshot from `/` had no g_model.
+  it('picks up params that arrived via a client-side navigation', async () => {
+    const { location } = setupWindow('', '/');
+    const { readUrlParams, refreshUrlParams } = await import('@/lib/url-state');
+    expect(readUrlParams().g_model).toBeUndefined();
+
+    location.search = '?g_model=Qwen-3.5-397B-A17B&i_seq=agentic-traces';
+    location.pathname = '/inference';
+    const refreshed = refreshUrlParams();
+
+    expect(refreshed.g_model).toBe('Qwen-3.5-397B-A17B');
+    expect(refreshed.i_seq).toBe('agentic-traces');
+    // Same object the load-time readers already hold, so they see it too.
+    expect(readUrlParams().g_model).toBe('Qwen-3.5-397B-A17B');
+  });
+
+  it('keeps existing params when the new URL omits them', async () => {
+    const { location } = setupWindow('?g_model=Kimi-K3&i_seq=agentic-traces', '/inference');
+    const { refreshUrlParams } = await import('@/lib/url-state');
+
+    location.search = '?i_seq=8k/1k';
+    const refreshed = refreshUrlParams();
+
+    expect(refreshed.i_seq).toBe('8k/1k');
+    // Not cleared: the provider writes params back as the user filters, and a
+    // partial URL must not wipe state the user did not touch.
+    expect(refreshed.g_model).toBe('Kimi-K3');
+  });
+
+  it('ignores unknown params', async () => {
+    const { location } = setupWindow('', '/');
+    const { refreshUrlParams } = await import('@/lib/url-state');
+    location.search = '?g_model=GLM-5.2&not_a_real_key=x';
+    const refreshed = refreshUrlParams();
+    expect(refreshed.g_model).toBe('GLM-5.2');
+    expect(refreshed).not.toHaveProperty('not_a_real_key');
+  });
+
+  it('is a no-op without a window (SSR)', async () => {
+    vi.stubGlobal('window', undefined);
+    const { refreshUrlParams } = await import('@/lib/url-state');
+    expect(() => refreshUrlParams()).not.toThrow();
+  });
+});
+
 describe('hasAnyUrlParams', () => {
   beforeEach(() => {
     vi.useFakeTimers();

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -192,6 +192,33 @@ export function readUrlParams(): UrlStateParams {
   return _initialParams;
 }
 
+/**
+ * Re-read share-link params from the live URL, replacing the load-time
+ * snapshot.
+ *
+ * The snapshot above is captured once per page load, which is correct for a
+ * hard navigation but wrong for a client-side one: a soft transition to
+ * `/inference?g_model=…` does not remount the provider, so every reader kept
+ * seeing the params of the page the user came FROM (usually none). Callers
+ * must only invoke this on a real router navigation — self-writes go through
+ * `history.replaceState`, which deliberately does not, so re-reading after one
+ * of those would fight the user's own filter changes.
+ *
+ * Also mirrors into `currentState` so the next share-link write starts from
+ * what the URL actually asked for.
+ */
+export function refreshUrlParams(): UrlStateParams {
+  if (typeof window === 'undefined') return _initialParams;
+  const searchParams = new URLSearchParams(window.location.search);
+  for (const key of URL_STATE_KEYS) {
+    const value = searchParams.get(key);
+    if (value === null) continue;
+    _initialParams[key] = value;
+    currentState[key] = value;
+  }
+  return _initialParams;
+}
+
 /** Check whether the current URL has any share-link params. */
 export function hasAnyUrlParams(): boolean {
   if (typeof window === 'undefined') return false;


### PR DESCRIPTION
## Summary

Clicking an AgentX model card on the landing page opened the **wrong model** — "Qwen" landed on DeepSeek.

The links were never at fault. Every card renders the correct href and pasting that URL works:

| | URL | model shown |
|---|---|---|
| paste / hard load | `/inference?g_model=Qwen-3.5-397B-A17B&i_seq=agentic-traces&i_optimal=1` | **Qwen3.5 397B** |
| **click the card** | *identical URL* | **DeepSeek V4 Pro** |

Only the click path broke, which is why it looked like a mislinked card.

## Root cause

Two things compound on a soft navigation, neither of which happens on a hard load:

- **`useUrlState` reads the URL once into a ref** on first render, so `getUrlParam` keeps returning the params of the page the user came *from*.
- **The effect that applies them is mount-only** — `useIsomorphicLayoutEffect(..., [])`.

`GlobalFilterContext` lives in the shared layout and isn't remounted by a `<Link>` transition, so `g_model` was simply never read. Every card fell through to the default model — and DeepSeek's card only *appeared* to work because DeepSeek **is** the default.

This isn't limited to those cards: `i_seq`, `i_prec`, `g_rundate` and `g_runid` were equally ignored, so **any share link followed in-app** lost its filters.

## Why not just re-run the effect

The provider *writes* these params back to the URL as the user changes filters, so naively re-applying on every URL change would fight in-flight edits. It writes through `history.replaceState`, which the Next router doesn't observe — so keying the effect on a router-owned value separates real navigations from self-writes.

That value is **`usePathname`, not `useSearchParams`**. The latter forces every statically-prerendered page that mounts this provider behind a Suspense boundary, which fails the build on `/ai-chart` (I hit exactly that on the first push). Pathname covers the navigations that matter — the AgentX cards and every share link originate on a different route from `/inference`. A param-only navigation *within* `/inference` isn't picked up; no in-app link does that today.

`refreshUrlParams()` re-reads the live URL into the shared snapshot before the params are applied, so the auto-switch guard (which also reads `g_model` via `getUrlParam`) sees the new value too. It **merges rather than replaces** — a partial URL must not wipe filters the user didn't touch.

## Verified

Clicked all five cards against a local build:

| clicked | landed on |
|---|---|
| kimi-k3 | Kimi K3 2.8T |
| deepseek-v4 | DeepSeek V4 Pro 1.6T |
| glm-5-2 | GLM5.2/GLM5.3 |
| minimax-m3 | MiniMax M3 428B |
| qwen-3-5 | **Qwen3.5 397B** |

Before the change, all five landed on DeepSeek V4 Pro.

`bun run build` passes locally, including the `/ai-chart` prerender that caught the first attempt.

Four new unit tests cover `refreshUrlParams`: params arriving via client-side navigation, merge-don't-clobber on a partial URL, unknown keys ignored, and SSR safety. Suite green (516 + 25).

No schema or `CHART_SERIES_VERSION` change, so no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global filter hydration and URL snapshot merging on every pathname change. Wrong merge or effect timing could clobber in-place filter edits or still miss share-link params.
> 
> **Overview**
> Fixes in-app share links (e.g. AgentX cards) opening the **default model** instead of the URL’s `g_model`. Hard loads already worked; `<Link>` did not remount `GlobalFilterProvider`, so the load-time URL snapshot and a mount-only effect never saw the destination query.
> 
> Adds `refreshUrlParams()` to merge live query params into the shared snapshot (does not drop omitted keys). The apply effect now runs on `usePathname()` so real route changes pick up filters, while in-place `history.replaceState` writes from the provider do not retrigger it. Param-only navigations within `/inference` are still ignored by design.
> 
> Unit tests cover client-side param pickup, merge-don’t-clobber, unknown keys, and SSR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b3e7b4070c4e278fabf9ac9d91a44137ec5ecae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->