### PR TITLE
fix(inference): always solo on legend click

### DIFF
--- a/packages/app/src/hooks/toggle-logic.test.ts
+++ b/packages/app/src/hooks/toggle-logic.test.ts
@@ -42,17 +42,29 @@ describe('computeToggle', () => {
     });
   });
 
+  // Clicking an active entry always isolates it, even from a partial
+  // selection. Solo used to require EVERY item to be active, which made it
+  // unreachable wherever something starts deselected — on the agentic chart
+  // the engine guard switches SGLang off on load, so the first legend click
+  // removed the entry instead of isolating it. Removing one entry has its own
+  // control (the X on a legend row).
   describe('when some (but not all/one) items are active', () => {
-    it('removes an active item', () => {
+    it('solos the clicked active item', () => {
       const prev = new Set(['a', 'b']);
       const result = computeToggle(prev, 'a', ALL);
+      expect(result).toEqual(new Set(['a']));
+    });
+
+    it('solos the other active item', () => {
+      const prev = new Set(['a', 'b']);
+      const result = computeToggle(prev, 'b', ALL);
       expect(result).toEqual(new Set(['b']));
     });
 
-    it('removes the other active item', () => {
+    it('does not mutate the input set', () => {
       const prev = new Set(['a', 'b']);
-      const result = computeToggle(prev, 'b', ALL);
-      expect(result).toEqual(new Set(['a']));
+      computeToggle(prev, 'a', ALL);
+      expect(prev).toEqual(new Set(['a', 'b']));
     });
   });
 
@@ -113,14 +125,14 @@ describe('computeToggle', () => {
       expect(step2).toEqual(ALL);
     });
 
-    it('full cycle: all → solo → add → remove → single → restore', () => {
+    it('full cycle: all → solo → add → re-solo → restore', () => {
       const s1 = computeToggle(new Set(['a', 'b', 'c']), 'a', ALL); // solo a
       expect(s1).toEqual(new Set(['a']));
       const s2 = computeToggle(s1, 'b', ALL); // add b
       expect(s2).toEqual(new Set(['a', 'b']));
-      const s3 = computeToggle(s2, 'a', ALL); // remove a
-      expect(s3).toEqual(new Set(['b']));
-      const s4 = computeToggle(s3, 'b', ALL); // restore all (only b active)
+      const s3 = computeToggle(s2, 'a', ALL); // clicking a active entry re-solos
+      expect(s3).toEqual(new Set(['a']));
+      const s4 = computeToggle(s3, 'a', ALL); // restore all (only a active)
       expect(s4).toEqual(ALL);
     });
   });

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -63,13 +63,17 @@ interface ModelConfig {
  * Scoped to `hardware` for the same reason the STP rule below is: the guard
  * exists to stop two engines being read off one SKU's curve, not to stop a
  * chart holding two SKUs. B200 vLLM MTP next to B300 SGLang MTP compares
- * hardware, which is the point of the chart.
+ * hardware, which is the point of the chart. Where only one engine has a run
+ * for a SKU there is nothing to confuse, so that SKU is free to show it.
+ *
+ * ATOM is its own family and is deliberately NOT grouped with SGLang, so it
+ * stays comparable with everything — including both vLLM and SGLang on the
+ * SKUs where it runs.
  */
 const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
   {
     suffix: '_mtp',
     stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
-    groupAliases: { atom: 'sglang' },
     scope: 'hardware',
   },
 ];
@@ -78,12 +82,16 @@ const MTP_ENGINE_EXCLUSION: ExclusionSpec[] = [
  * STP exclusion: unsuffixed standard-token configs for the same hardware SKU
  * can't mix engine families, because each engine tunes its serving path
  * differently. Different hardware may use different engines on one graph.
+ * `dynamo-`/`mori-`/`llmd-`/`mooncake-` are routers, not engines, so
+ * `dynamo-sglang` is SGLang and is guarded as such.
+ *
+ * ATOM is its own family and is not aliased to SGLang — it stays comparable
+ * with everything.
  */
 const STP_ENGINE_EXCLUSION: ExclusionSpec[] = [
   {
     suffix: null,
     stripPrefixes: ['dynamo-', 'mori-', 'llmd-', 'mooncake-'],
-    groupAliases: { atom: 'sglang' },
     scope: 'hardware',
   },
 ];

--- a/packages/app/src/lib/toggle-set.ts
+++ b/packages/app/src/lib/toggle-set.ts
@@ -1,32 +1,27 @@
 /**
  * Pure toggle state transition.
  *
- * - If all items are active and one is toggled, only that item remains active (solo).
- * - If only one item is active and it's toggled, all items become active (restore all).
- * - Otherwise, the item is simply added or removed from the active set.
+ * - Clicking an active item while others are active solos it.
+ * - Clicking the only active item restores all.
+ * - Clicking an inactive item adds it.
+ *
+ * Solo used to require EVERY item to be active, which quietly made it
+ * unreachable wherever something starts deselected. On the agentic view the
+ * engine guard switches SGLang off on load, so a fresh chart never had all
+ * items active and the first click on a legend entry removed it instead of
+ * isolating it. Individual removal has its own control — the X that appears on
+ * a legend row on hover — so the label click is free to always mean "show only
+ * this".
  *
  * Kept free of React so server-only modules (`exclusion.ts`, and through it the
  * overview data layer) can reuse it without pulling client hooks into a Server
  * Component graph.
  */
 export function computeToggle(prev: Set<string>, item: string, allItems: Set<string>): Set<string> {
-  const allAreActive = prev.size === allItems.size;
-  const isActive = prev.has(item);
-
-  if (isActive) {
-    if (allAreActive) {
-      // Solo: only keep the clicked item
-      return new Set([item]);
-    } else if (prev.size === 1) {
-      // Restore all: re-enable everything
-      return allItems;
-    }
-    // Remove the clicked item
-    const next = new Set(prev);
-    next.delete(item);
-    return next;
+  if (prev.has(item)) {
+    // Sole survivor -> restore everything, so a second click undoes the solo.
+    if (prev.size <= 1) return allItems;
+    return new Set([item]);
   }
-  // Add the clicked item
-  const next = new Set([...prev, item]);
-  return next;
+  return new Set([...prev, item]);
 }


### PR DESCRIPTION
On a fresh load of the agentic chart, clicking a legend entry **deselected** it instead of isolating it.

## Cause

`computeToggle` only soloed when *every* item was active:

```ts
const allAreActive = prev.size === allItems.size;
```

The engine guard legitimately leaves entries off on load — a SKU that has both vLLM and SGLang shows only one — so on the agentic chart that condition was never true (6 of 12 entries active) and the click fell through to the plain remove branch.

Clicking an active entry now always isolates it; clicking the last remaining entry restores all. Removing a single series keeps its own control — the X that appears on a legend row on hover — so a label click unambiguously means "show only this".

## Also: dropped a dead `groupAliases` entry

Both engine exclusion specs carried `groupAliases: { atom: 'sglang' }`. That was dead config — the scenarios using these specs set `exclusionFamilies: ['vllm','sglang']`, and that allowlist is intersected into `participatingFamilies` **before** `groupAliases` is consulted, so ATOM never reached the alias. Removing it makes the intent explicit: ATOM is its own engine and stays comparable with everything.

No behaviour change. The existing ATOM cases (`allows 8K/1K ATOM next to vLLM on the same SKU`, etc.) already asserted `fallthrough` and still pass untouched.

## Not changed: `scope: 'hardware'`

Both specs keep their SKU scope, which is the intended rule: **SGLang and vLLM may share a chart, just not a SKU.** Where only one engine has a run for a given SKU there is nothing to confuse, so that SKU is free to show it — `H200 (Dynamo SGLang)` alongside B200/B300 vLLM is correct, since no H200 vLLM run exists.

An earlier revision of this branch made the guard chart-wide; that was wrong and has been reverted, so the exclusion tests are untouched by this PR.

## Verification

Playwright against a local dev server on `/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1`:

| Check | Result |
|---|---|
| Legend click solos | 6 active → clicking `B300 (vLLM)` → exactly 1 active |
| Second click restores | back to the full guard-permitted set |
| Same-SKU guard still blocks | `MI355X (SGLang)` refused against `MI355X (vLLM)`, conflict message shown |
| Cross-SKU still allowed | `H200 (Dynamo SGLang)` shows with B200/B300 vLLM |
| ATOM unaffected | `MI355X (ATOM¹)` sits alongside `MI355X (vLLM)` |

No console errors. `lint`, `fmt`, `typecheck`, `test:unit` (3548 passing) and `build` all pass locally.

## Tests

`toggle-logic.test.ts` — the two "removes an active item" cases now assert solo, the full-cycle case follows the new path, plus an input-immutability case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chart selection and engine-comparability grouping, so mixed-engine views and legend click behavior can shift. Logic is small and covered by unit tests.
> 
> **Overview**
> Legend clicks now always **solo** an already-active series (and restore all on a second click of the last remaining one). Partial selections no longer drop the clicked item, which used to happen on agentic charts where the engine guard leaves some series off at load. Individual removal stays on the hover X.
> 
> MTP/STP engine exclusion no longer aliases **ATOM** onto SGLang (`groupAliases` removed). ATOM is its own family and can sit next to vLLM or SGLang. Router prefixes (`dynamo-` etc.) are still stripped so `dynamo-sglang` is treated as SGLang.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac51a1f90ec3955b152ae9ffede63c6ddb9d334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->