### PR TITLE
fix(ai-chart): respect metric direction and missing values / 修复 AI 图表指标方向与缺失值

### DIFF
--- a/packages/app/cypress/e2e/ai-chart.cy.ts
+++ b/packages/app/cypress/e2e/ai-chart.cy.ts
@@ -81,10 +81,10 @@ describe('AI chart metric semantics', () => {
     cy.visit('/ai-chart');
   });
 
-  it('uses the minimum cost when selecting the top configuration', () => {
+  it('excludes unavailable zero cost when selecting the top configuration', () => {
     cy.fixture<FixtureRow[]>('api/benchmarks.json').then((fixtureRows) => {
       const rows = [
-        fixtureRow(fixtureRows, 'b200', 40, 100),
+        fixtureRow(fixtureRows, 'b200', 40, 0),
         fixtureRow(fixtureRows, 'mi355x', 40, 10_000),
       ];
       interceptGeneration(

--- a/packages/app/cypress/e2e/ai-chart.cy.ts
+++ b/packages/app/cypress/e2e/ai-chart.cy.ts
@@ -1,0 +1,171 @@
+type FixtureRow = Record<string, any> & { metrics: Record<string, number> };
+
+function fixtureRow(
+  rows: FixtureRow[],
+  hardware: 'b200' | 'mi355x',
+  x: number,
+  throughput: number,
+  measuredPower?: number,
+): FixtureRow {
+  const template = rows.find(
+    (row) =>
+      row.hardware === hardware &&
+      row.framework === 'sglang' &&
+      row.spec_method === 'mtp' &&
+      row.disagg === false &&
+      row.isl === 8192 &&
+      row.osl === 1024,
+  );
+  if (!template) throw new Error(`Missing ${hardware} SGLang fixture row`);
+
+  const metrics: Record<string, number> = {
+    ...template.metrics,
+    median_intvty: x,
+    tput_per_gpu: throughput,
+    output_tput_per_gpu: throughput / 2,
+    input_tput_per_gpu: throughput / 2,
+  };
+  if (measuredPower === undefined) delete metrics.avg_power_w;
+  else metrics.avg_power_w = measuredPower;
+
+  return {
+    ...template,
+    conc: x,
+    metrics,
+  };
+}
+
+function interceptGeneration(spec: Record<string, unknown>, rows: FixtureRow[]): void {
+  cy.intercept('GET', '**/api/v1/benchmarks?*', rows).as('benchmarks');
+  cy.intercept('POST', 'https://api.openai.com/v1/chat/completions', (request) => {
+    const systemPrompt = request.body.messages?.[0]?.content ?? '';
+    const content = systemPrompt.includes('chart generation assistant')
+      ? JSON.stringify(spec)
+      : 'Deterministic test summary.';
+    request.reply({ choices: [{ message: { content } }] });
+  }).as('openAi');
+}
+
+function generateChart(): void {
+  cy.get('input[placeholder="OpenAI API Key"]').type('test-api-key', { log: false });
+  cy.get('textarea').type('Generate the requested chart');
+  cy.contains('button', 'Generate Chart').click();
+  cy.wait('@benchmarks');
+}
+
+function benchmarkSpec(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    chartType: 'bar',
+    dataSource: 'benchmarks',
+    model: 'DeepSeek-R1-0528',
+    sequence: '8k/1k',
+    hardwareKeys: ['b200', 'mi355x'],
+    precisions: [],
+    frameworks: ['sglang'],
+    disagg: false,
+    yAxisMetric: 'y_tpPerGpu',
+    yAxisLabel: 'Throughput/Chip',
+    targetInteractivity: 40,
+    sortOrder: 'desc',
+    radarMetrics: null,
+    topN: null,
+    topNDistinctGpus: true,
+    title: 'AI chart regression',
+    description: 'Deterministic fixture data.',
+    ...overrides,
+  };
+}
+
+describe('AI chart metric semantics', () => {
+  beforeEach(() => {
+    cy.visit('/ai-chart');
+  });
+
+  it('uses the minimum cost when selecting the top configuration', () => {
+    cy.fixture<FixtureRow[]>('api/benchmarks.json').then((fixtureRows) => {
+      const rows = [
+        fixtureRow(fixtureRows, 'b200', 40, 100),
+        fixtureRow(fixtureRows, 'mi355x', 40, 10_000),
+      ];
+      interceptGeneration(
+        benchmarkSpec({
+          yAxisMetric: 'y_costh',
+          yAxisLabel: 'Cost per Million Total Tokens',
+          sortOrder: 'asc',
+          topN: 1,
+          topNDistinctGpus: false,
+        }),
+        rows,
+      );
+
+      generateChart();
+
+      cy.get('#ai-chart-bar-export')
+        .should('contain.text', 'MI355X')
+        .and('not.contain.text', 'B200');
+      cy.get('#ai-chart-bar-export .bar').should('have.length', 1);
+    });
+  });
+
+  it('renders lower measured power farther from the radar center', () => {
+    cy.fixture<FixtureRow[]>('api/benchmarks.json').then((fixtureRows) => {
+      const rows = [
+        fixtureRow(fixtureRows, 'b200', 40, 100, 600),
+        fixtureRow(fixtureRows, 'mi355x', 40, 100, 300),
+      ];
+      interceptGeneration(
+        benchmarkSpec({
+          chartType: 'radar',
+          yAxisMetric: 'y_measuredAvgPower',
+          yAxisLabel: 'Measured Average Power per Chip',
+          radarMetrics: ['y_measuredAvgPower'],
+        }),
+        rows,
+      );
+
+      generateChart();
+
+      cy.get('#ai-chart-radar-export .radar-dot')
+        .should('have.length', 2)
+        .then(($dots) => {
+          const b200Radius = Math.hypot(
+            Number($dots.eq(0).attr('cx')),
+            Number($dots.eq(0).attr('cy')),
+          );
+          const mi355xRadius = Math.hypot(
+            Number($dots.eq(1).attr('cx')),
+            Number($dots.eq(1).attr('cy')),
+          );
+          expect(mi355xRadius).to.be.greaterThan(b200Radius);
+        });
+    });
+  });
+
+  it('keeps a missing middle metric as a line gap instead of a zero-valued dot', () => {
+    cy.fixture<FixtureRow[]>('api/benchmarks.json').then((fixtureRows) => {
+      const rows = [
+        fixtureRow(fixtureRows, 'b200', 10, 100, 500),
+        fixtureRow(fixtureRows, 'b200', 20, 200),
+        fixtureRow(fixtureRows, 'b200', 30, 300, 400),
+      ];
+      interceptGeneration(
+        benchmarkSpec({
+          chartType: 'line',
+          hardwareKeys: ['b200'],
+          yAxisMetric: 'y_measuredAvgPower',
+          yAxisLabel: 'Measured Average Power per Chip',
+        }),
+        rows,
+      );
+
+      generateChart();
+
+      cy.get('#ai-chart-line-export .dot-group').should('have.length', 2);
+      cy.get('#ai-chart-line-export .line-path')
+        .invoke('attr', 'd')
+        .should((path) => {
+          expect(path?.match(/M/gu)).to.have.length(2);
+        });
+    });
+  });
+});

--- a/packages/app/src/components/ai-chart/AiChartDisplay.tsx
+++ b/packages/app/src/components/ai-chart/AiChartDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { AlertCircle, Eye, EyeOff, Sparkles } from 'lucide-react';
 
 import { track } from '@/lib/analytics';
@@ -66,9 +66,14 @@ export default function AiChartDisplay() {
   });
   const [prompt, setPrompt] = useState('');
   const [showKey, setShowKey] = useState(false);
+  const [isMac, setIsMac] = useState(false);
   const { result, isLoading, error, generate, reset } = useAiChart();
   const locale = useLocale();
   const t = STRINGS[locale];
+
+  useEffect(() => {
+    setIsMac(navigator.userAgent.includes('Mac'));
+  }, []);
 
   const apiKey = apiKeys[provider];
 
@@ -157,7 +162,7 @@ export default function AiChartDisplay() {
             />
             <div className="flex items-center justify-between">
               <span className="text-muted-foreground text-xs">
-                {navigator.userAgent.includes('Mac') ? '⌘' : 'Ctrl'}
+                {isMac ? '⌘' : 'Ctrl'}
                 {t.enterToGenerate}
               </span>
               <Button

--- a/packages/app/src/components/ai-chart/AiChartResult.tsx
+++ b/packages/app/src/components/ai-chart/AiChartResult.tsx
@@ -233,7 +233,9 @@ function LineChart({
   const flatPoints = useMemo<LinePoint[]>(
     () =>
       Object.entries(lineData).flatMap(([hwKey, pts]) =>
-        pts.map((p) => ({ hwKey, precision: 'fp8', x: p.x, y: p.y })),
+        pts
+          .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.y))
+          .map((p) => ({ hwKey, precision: 'fp8', x: p.x, y: p.y })),
       ),
     [lineData],
   );
@@ -267,6 +269,7 @@ function LineChart({
       config: {
         getColor: (key) => colorMap[key] ?? '#888',
         strokeWidth: 2.5,
+        isDefined: ({ x, y }) => Number.isFinite(x) && Number.isFinite(y),
       },
     };
     const scatterLayer: ScatterLayerConfig<LinePoint> = {

--- a/packages/app/src/components/ai-chart/prompt-templates.ts
+++ b/packages/app/src/components/ai-chart/prompt-templates.ts
@@ -71,7 +71,7 @@ Pick the chart type that best matches the user's intent. Be flexible — interpr
 - **bar** — Horizontal bar chart. Compares one metric across GPU configs at a fixed interactivity point. Best for rankings, comparisons, "which is best". DEFAULT.
 - **scatter** — XY scatter plot (x=interactivity, y=metric). Shows all data points. Good for trade-off analysis, pareto frontiers.
 - **line** — Connected lines (x=interactivity, y=metric), one line per GPU config. Good for seeing how performance changes with load, comparing curves.
-- **radar** — Spider/radar chart. Compares GPUs across MULTIPLE metrics simultaneously on normalized axes. Set radarMetrics to choose which metrics are axes (pick 3-6 that are relevant). Cost/energy metrics are auto-inverted (lower=better=further out).
+- **radar** — Spider/radar chart. Compares GPUs across MULTIPLE metrics simultaneously on normalized axes. Set radarMetrics to choose which metrics are axes (pick 3-6 that are relevant). Metric direction comes from the dashboard definition, so lower-is-better metrics render better values farther out.
 
 ## Filtering
 
@@ -82,12 +82,12 @@ Pick the chart type that best matches the user's intent. Be flexible — interpr
 
 ## Sorting & Sampling
 
-- **sortOrder** ("registry"): Sort order for bar charts. "desc" = highest value first, "asc" = lowest first, "registry" = default GPU registry order. Use "desc" when user asks for "best" or "rank by".
+- **sortOrder** ("registry"): Sort order for bar charts. "desc" = highest value first, "asc" = lowest first, "registry" = default GPU registry order. When the user asks for "best" or "rank by", use "asc" for lower-is-better metrics such as cost/energy/power and "desc" for higher-is-better metrics such as throughput.
 - **targetInteractivity** (40): The interactivity level (tok/s/user) to sample at for bar charts. Adjust if user specifies a concurrency level.
 
 ## Top-N
 
-- **topN** (null): "top 3 GPUs" → topN: 3. Ranks ALL configs by peak metric value after data loads. Don't guess — let data decide.
+- **topN** (null): "top 3 GPUs" → topN: 3. Ranks ALL configs by their best observed value in the metric's dashboard-defined direction after data loads (minimum for lower-is-better; maximum for higher-is-better). Don't guess — let data decide.
 - **topNDistinctGpus** (true): When true, topN picks the best config from each unique GPU family (so "top 2 GPUs" = 2 different GPU types). Set false when user says "top N configs" or "top N combos" (may return same GPU with different frameworks).
 
 ## Multi-Chart

--- a/packages/app/src/hooks/api/ai-chart-data.test.ts
+++ b/packages/app/src/hooks/api/ai-chart-data.test.ts
@@ -13,10 +13,27 @@ import {
 const chartDefinition = chartDefinitions[0] as Record<string, unknown>;
 
 describe('readAiMetric', () => {
-  it('distinguishes an absent nested metric from a measured zero', () => {
-    expect(readAiMetric({ measuredAvgPower: { y: 0 } }, 'measuredAvgPower.y')).toBe(0);
-    expect(readAiMetric({}, 'measuredAvgPower.y')).toBeNull();
-    expect(readAiMetric({ measuredAvgPower: { y: Number.NaN } }, 'measuredAvgPower.y')).toBeNull();
+  it('preserves an explicitly measured zero while rejecting a missing telemetry property', () => {
+    expect(
+      readAiMetric({ measuredAvgPower: { y: 0 } }, 'measuredAvgPower.y', 'y_measuredAvgPower'),
+    ).toBe(0);
+    expect(readAiMetric({}, 'measuredAvgPower.y', 'y_measuredAvgPower')).toBeNull();
+    expect(
+      readAiMetric(
+        { measuredAvgPower: { y: Number.NaN } },
+        'measuredAvgPower.y',
+        'y_measuredAvgPower',
+      ),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['costh.y', 'y_costh'],
+    ['tpPerGpu.y', 'y_tpPerGpu'],
+    ['jTotal.y', 'y_jTotal'],
+  ])('rejects a synthetic zero sentinel for %s', (path, metric) => {
+    const [field] = path.split('.');
+    expect(readAiMetric({ [field]: { y: 0 } }, path, metric)).toBeNull();
   });
 });
 
@@ -46,7 +63,7 @@ describe('buildAiLineData', () => {
       { hwKey: 'b200_vllm', x: 30, metric: { y: 0 } },
     ];
 
-    const lines = buildAiLineData(points, 'metric.y', new Set(['b200_vllm']));
+    const lines = buildAiLineData(points, 'y_measuredAvgPower', 'metric.y', new Set(['b200_vllm']));
 
     expect(lines.b200_vllm).toHaveLength(3);
     expect(lines.b200_vllm?.map((point) => point.x)).toEqual([10, 20, 30]);
@@ -61,6 +78,7 @@ describe('buildAiLineData', () => {
         { hwKey: 'b200_vllm', x: 10 },
         { hwKey: 'b200_vllm', x: 20 },
       ],
+      'y_measuredAvgPower',
       'metric.y',
       new Set(['b200_vllm']),
     );
@@ -88,7 +106,7 @@ describe('normalizeAiRadarRows', () => {
     const normalized = normalizeAiRadarRows(
       new Map([
         ['missing', [null]],
-        ['zero', [0]],
+        ['low', [5]],
         ['positive', [10]],
       ]),
       ['y_tpPerGpu'],
@@ -96,8 +114,60 @@ describe('normalizeAiRadarRows', () => {
     );
 
     expect(normalized.get('missing')?.[0]).toBeNull();
-    expect(normalized.get('zero')?.[0]).toBe(0);
+    expect(normalized.get('low')?.[0]).toBe(0);
     expect(normalized.get('positive')?.[0]).toBe(1);
+  });
+
+  it('rejects synthetic zero sentinels while preserving measured zero telemetry', () => {
+    const unavailableCost = normalizeAiRadarRows(
+      new Map([
+        ['unavailable', [0]],
+        ['valid-low', [1]],
+        ['valid-high', [2]],
+      ]),
+      ['y_costh'],
+      chartDefinition,
+    );
+    const measuredPower = normalizeAiRadarRows(
+      new Map([
+        ['zero', [0]],
+        ['positive', [100]],
+      ]),
+      ['y_measuredAvgPower'],
+      chartDefinition,
+    );
+
+    expect(unavailableCost.get('unavailable')?.[0]).toBeNull();
+    expect(measuredPower.get('zero')?.[0]).toBe(1);
+  });
+});
+
+describe('synthetic metric availability', () => {
+  it('turns an unavailable cost into no bar value, a radar gap, and a line gap', () => {
+    const unavailable = { hwKey: 'b200_vllm', x: 20, costh: { y: 0 } };
+    const lines = buildAiLineData(
+      [
+        { hwKey: 'b200_vllm', x: 10, costh: { y: 2 } },
+        unavailable,
+        { hwKey: 'b200_vllm', x: 30, costh: { y: 1 } },
+      ],
+      'y_costh',
+      'costh.y',
+      new Set(['b200_vllm']),
+    );
+    const radar = normalizeAiRadarRows(
+      new Map([
+        ['unavailable', [0]],
+        ['valid-low', [1]],
+        ['valid-high', [2]],
+      ]),
+      ['y_costh'],
+      chartDefinition,
+    );
+
+    expect(readAiMetric(unavailable, 'costh.y', 'y_costh')).toBeNull();
+    expect(lines.b200_vllm?.[1]?.y).toBeNaN();
+    expect(radar.get('unavailable')?.[0]).toBeNull();
   });
 });
 
@@ -159,7 +229,7 @@ describe('rankAiHardwareKeys', () => {
     ).toEqual(['b200_sglang', 'mi355x_vllm']);
   });
 
-  it('excludes missing values while preserving a measured zero', () => {
+  it('excludes missing and synthetic zero values from lower-is-better ranking', () => {
     const points = [
       { hwKey: 'missing', x: 10 },
       { hwKey: 'zero', x: 10, costh: { y: 0 } },
@@ -171,6 +241,21 @@ describe('rankAiHardwareKeys', () => {
         ...baseOptions,
         metric: 'y_costh',
         metricPath: 'costh.y',
+      }),
+    ).toEqual(['positive']);
+  });
+
+  it('preserves measured zero telemetry in lower-is-better ranking', () => {
+    const points = [
+      { hwKey: 'zero', x: 10, measuredAvgPower: { y: 0 } },
+      { hwKey: 'positive', x: 10, measuredAvgPower: { y: 1 } },
+    ];
+
+    expect(
+      rankAiHardwareKeys(points, {
+        ...baseOptions,
+        metric: 'y_measuredAvgPower',
+        metricPath: 'measuredAvgPower.y',
       }),
     ).toEqual(['zero']);
   });

--- a/packages/app/src/hooks/api/ai-chart-data.test.ts
+++ b/packages/app/src/hooks/api/ai-chart-data.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+
+import chartDefinitions from '@/components/inference/inference-chart-config.json';
+
+import {
+  buildAiLineData,
+  getAiMetricDirection,
+  normalizeAiRadarRows,
+  rankAiHardwareKeys,
+  readAiMetric,
+} from './ai-chart-data';
+
+const chartDefinition = chartDefinitions[0] as Record<string, unknown>;
+
+describe('readAiMetric', () => {
+  it('distinguishes an absent nested metric from a measured zero', () => {
+    expect(readAiMetric({ measuredAvgPower: { y: 0 } }, 'measuredAvgPower.y')).toBe(0);
+    expect(readAiMetric({}, 'measuredAvgPower.y')).toBeNull();
+    expect(readAiMetric({ measuredAvgPower: { y: Number.NaN } }, 'measuredAvgPower.y')).toBeNull();
+  });
+});
+
+describe('getAiMetricDirection', () => {
+  const lowerIsBetterMetrics = Object.entries(chartDefinition)
+    .filter(([key, value]) => key.endsWith('_roofline') && String(value).startsWith('lower_'))
+    .map(([key]) => key.slice(0, -'_roofline'.length));
+
+  it.each(lowerIsBetterMetrics)('derives lower-is-better for %s from its roofline', (metric) => {
+    expect(getAiMetricDirection(metric, chartDefinition)).toBe('lower');
+  });
+
+  it('derives higher-is-better from an upper roofline', () => {
+    expect(getAiMetricDirection('y_tpPerGpu', chartDefinition)).toBe('higher');
+  });
+
+  it('defaults a directionless metric to higher-is-better', () => {
+    expect(getAiMetricDirection('y_measuredPowerPercentTdp', chartDefinition)).toBe('higher');
+  });
+});
+
+describe('buildAiLineData', () => {
+  it('keeps missing X positions as line gaps while preserving a real zero', () => {
+    const points = [
+      { hwKey: 'b200_vllm', x: 10, metric: { y: 5 } },
+      { hwKey: 'b200_vllm', x: 20 },
+      { hwKey: 'b200_vllm', x: 30, metric: { y: 0 } },
+    ];
+
+    const lines = buildAiLineData(points, 'metric.y', new Set(['b200_vllm']));
+
+    expect(lines.b200_vllm).toHaveLength(3);
+    expect(lines.b200_vllm?.map((point) => point.x)).toEqual([10, 20, 30]);
+    expect(lines.b200_vllm?.[0]?.y).toBe(5);
+    expect(lines.b200_vllm?.[1]?.y).toBeNaN();
+    expect(lines.b200_vllm?.[2]?.y).toBe(0);
+  });
+
+  it('excludes a line whose selected metric is missing at every point', () => {
+    const lines = buildAiLineData(
+      [
+        { hwKey: 'b200_vllm', x: 10 },
+        { hwKey: 'b200_vllm', x: 20 },
+      ],
+      'metric.y',
+      new Set(['b200_vllm']),
+    );
+
+    expect(lines).toEqual({});
+  });
+});
+
+describe('normalizeAiRadarRows', () => {
+  it('places lower measured power farther out on the radar', () => {
+    const normalized = normalizeAiRadarRows(
+      new Map([
+        ['low-power', [300]],
+        ['high-power', [600]],
+      ]),
+      ['y_measuredAvgPower'],
+      chartDefinition,
+    );
+
+    expect(normalized.get('low-power')?.[0]).toBe(1);
+    expect(normalized.get('high-power')?.[0]).toBe(0);
+  });
+
+  it('preserves missing radar metrics without treating them as zero', () => {
+    const normalized = normalizeAiRadarRows(
+      new Map([
+        ['missing', [null]],
+        ['zero', [0]],
+        ['positive', [10]],
+      ]),
+      ['y_tpPerGpu'],
+      chartDefinition,
+    );
+
+    expect(normalized.get('missing')?.[0]).toBeNull();
+    expect(normalized.get('zero')?.[0]).toBe(0);
+    expect(normalized.get('positive')?.[0]).toBe(1);
+  });
+});
+
+describe('rankAiHardwareKeys', () => {
+  const baseOptions = {
+    chartDefinition,
+    topN: 1,
+    distinctGpus: false,
+  };
+
+  it('selects minima for lower-is-better cost metrics', () => {
+    const points = [
+      { hwKey: 'b200_vllm', x: 10, costh: { y: 2 } },
+      { hwKey: 'b200_vllm', x: 20, costh: { y: 1.8 } },
+      { hwKey: 'mi355x_sglang', x: 10, costh: { y: 1.2 } },
+    ];
+
+    expect(
+      rankAiHardwareKeys(points, {
+        ...baseOptions,
+        metric: 'y_costh',
+        metricPath: 'costh.y',
+      }),
+    ).toEqual(['mi355x_sglang']);
+  });
+
+  it('selects maxima for higher-is-better throughput metrics', () => {
+    const points = [
+      { hwKey: 'b200_vllm', x: 10, tpPerGpu: { y: 80 } },
+      { hwKey: 'b200_vllm', x: 20, tpPerGpu: { y: 100 } },
+      { hwKey: 'mi355x_sglang', x: 10, tpPerGpu: { y: 90 } },
+    ];
+
+    expect(
+      rankAiHardwareKeys(points, {
+        ...baseOptions,
+        metric: 'y_tpPerGpu',
+        metricPath: 'tpPerGpu.y',
+      }),
+    ).toEqual(['b200_vllm']);
+  });
+
+  it('picks one best config per GPU before ranking distinct GPU families', () => {
+    const points = [
+      { hwKey: 'b200_vllm', x: 10, costh: { y: 2 } },
+      { hwKey: 'b200_sglang', x: 10, costh: { y: 1 } },
+      { hwKey: 'mi355x_vllm', x: 10, costh: { y: 1.5 } },
+      { hwKey: 'h200_vllm', x: 10, costh: { y: 3 } },
+    ];
+
+    expect(
+      rankAiHardwareKeys(points, {
+        chartDefinition,
+        metric: 'y_costh',
+        metricPath: 'costh.y',
+        topN: 2,
+        distinctGpus: true,
+      }),
+    ).toEqual(['b200_sglang', 'mi355x_vllm']);
+  });
+
+  it('excludes missing values while preserving a measured zero', () => {
+    const points = [
+      { hwKey: 'missing', x: 10 },
+      { hwKey: 'zero', x: 10, costh: { y: 0 } },
+      { hwKey: 'positive', x: 10, costh: { y: 1 } },
+    ];
+
+    expect(
+      rankAiHardwareKeys(points, {
+        ...baseOptions,
+        metric: 'y_costh',
+        metricPath: 'costh.y',
+      }),
+    ).toEqual(['zero']);
+  });
+});

--- a/packages/app/src/hooks/api/ai-chart-data.ts
+++ b/packages/app/src/hooks/api/ai-chart-data.ts
@@ -1,0 +1,144 @@
+export type AiMetricDirection = 'higher' | 'lower';
+
+export interface AiMetricPoint {
+  hwKey?: string | null;
+  x: number;
+}
+
+export interface RankAiHardwareOptions {
+  metric: string;
+  metricPath: string;
+  chartDefinition: Record<string, unknown>;
+  topN: number;
+  distinctGpus: boolean;
+}
+
+export function readAiMetric(point: unknown, path: string): number | null {
+  let value: unknown = point;
+
+  for (const key of path.split('.')) {
+    if (typeof value !== 'object' || value === null || !(key in value)) return null;
+    value = (value as Record<string, unknown>)[key];
+  }
+
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function getAiMetricDirection(
+  metric: string,
+  chartDefinition: Record<string, unknown>,
+): AiMetricDirection {
+  const roofline = chartDefinition[`${metric}_roofline`];
+  return typeof roofline === 'string' && roofline.startsWith('lower_') ? 'lower' : 'higher';
+}
+
+export function buildAiLineData<T extends AiMetricPoint>(
+  points: readonly T[],
+  metricPath: string,
+  visibleHardwareKeys: ReadonlySet<string>,
+): Record<string, { x: number; y: number }[]> {
+  const lines: Record<string, { x: number; y: number }[]> = {};
+
+  for (const point of points) {
+    const hwKey = point.hwKey ?? '';
+    if (!hwKey || !visibleHardwareKeys.has(hwKey)) continue;
+
+    lines[hwKey] ??= [];
+    lines[hwKey].push({ x: point.x, y: readAiMetric(point, metricPath) ?? Number.NaN });
+  }
+
+  for (const [hwKey, line] of Object.entries(lines)) {
+    line.sort((a, b) => a.x - b.x);
+    if (!line.some(({ y }) => Number.isFinite(y))) delete lines[hwKey];
+  }
+  return lines;
+}
+
+export function normalizeAiRadarRows(
+  rawRows: ReadonlyMap<string, readonly (number | null)[]>,
+  metrics: readonly string[],
+  chartDefinition: Record<string, unknown>,
+): Map<string, (number | null)[]> {
+  const mins = metrics.map(() => Infinity);
+  const maxs = metrics.map(() => -Infinity);
+
+  for (const values of rawRows.values()) {
+    for (let index = 0; index < metrics.length; index++) {
+      const value = values[index];
+      if (value === null || value === undefined || !Number.isFinite(value)) continue;
+      mins[index] = Math.min(mins[index], value);
+      maxs[index] = Math.max(maxs[index], value);
+    }
+  }
+
+  const normalizedRows = new Map<string, (number | null)[]>();
+  for (const [hwKey, values] of rawRows) {
+    normalizedRows.set(
+      hwKey,
+      metrics.map((metric, index) => {
+        const value = values[index];
+        if (
+          value === null ||
+          value === undefined ||
+          !Number.isFinite(value) ||
+          !Number.isFinite(mins[index]) ||
+          maxs[index] === mins[index]
+        ) {
+          return null;
+        }
+
+        const normalized = (value - mins[index]) / (maxs[index] - mins[index]);
+        return getAiMetricDirection(metric, chartDefinition) === 'lower'
+          ? 1 - normalized
+          : normalized;
+      }),
+    );
+  }
+
+  return normalizedRows;
+}
+
+export function rankAiHardwareKeys<T extends AiMetricPoint>(
+  points: readonly T[],
+  options: RankAiHardwareOptions,
+): string[] {
+  const direction = getAiMetricDirection(options.metric, options.chartDefinition);
+  const bestByHardware = new Map<string, number>();
+
+  for (const point of points) {
+    const hwKey = point.hwKey ?? '';
+    if (!hwKey) continue;
+
+    const value = readAiMetric(point, options.metricPath);
+    if (value === null) continue;
+
+    const existing = bestByHardware.get(hwKey);
+    if (existing === undefined || (direction === 'lower' ? value < existing : value > existing)) {
+      bestByHardware.set(hwKey, value);
+    }
+  }
+
+  const compare = (left: number, right: number) =>
+    direction === 'lower' ? left - right : right - left;
+
+  if (!options.distinctGpus) {
+    return [...bestByHardware.entries()]
+      .toSorted(([, left], [, right]) => compare(left, right))
+      .slice(0, options.topN)
+      .map(([hwKey]) => hwKey);
+  }
+
+  const bestPerGpu = new Map<string, { hwKey: string; value: number }>();
+  for (const [hwKey, value] of bestByHardware) {
+    const baseGpu = hwKey.split('_')[0];
+    const existing = bestPerGpu.get(baseGpu);
+    if (!existing || compare(value, existing.value) < 0) {
+      bestPerGpu.set(baseGpu, { hwKey, value });
+    }
+  }
+
+  return [...bestPerGpu.values()]
+    .toSorted((left, right) => compare(left.value, right.value))
+    .slice(0, options.topN)
+    .map(({ hwKey }) => hwKey);
+}

--- a/packages/app/src/hooks/api/ai-chart-data.ts
+++ b/packages/app/src/hooks/api/ai-chart-data.ts
@@ -13,7 +13,19 @@ export interface RankAiHardwareOptions {
   distinctGpus: boolean;
 }
 
-export function readAiMetric(point: unknown, path: string): number | null {
+function isMeasuredTelemetryMetric(metric: string): boolean {
+  return metric.startsWith('y_measured');
+}
+
+export function isAiMetricValueValid(metric: string, value: unknown): value is number {
+  return (
+    typeof value === 'number' &&
+    Number.isFinite(value) &&
+    (value > 0 || (value === 0 && isMeasuredTelemetryMetric(metric)))
+  );
+}
+
+export function readAiMetric(point: unknown, path: string, metric: string): number | null {
   let value: unknown = point;
 
   for (const key of path.split('.')) {
@@ -21,7 +33,7 @@ export function readAiMetric(point: unknown, path: string): number | null {
     value = (value as Record<string, unknown>)[key];
   }
 
-  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+  return isAiMetricValueValid(metric, value) ? value : null;
 }
 
 export function getAiMetricDirection(
@@ -34,6 +46,7 @@ export function getAiMetricDirection(
 
 export function buildAiLineData<T extends AiMetricPoint>(
   points: readonly T[],
+  metric: string,
   metricPath: string,
   visibleHardwareKeys: ReadonlySet<string>,
 ): Record<string, { x: number; y: number }[]> {
@@ -44,7 +57,10 @@ export function buildAiLineData<T extends AiMetricPoint>(
     if (!hwKey || !visibleHardwareKeys.has(hwKey)) continue;
 
     lines[hwKey] ??= [];
-    lines[hwKey].push({ x: point.x, y: readAiMetric(point, metricPath) ?? Number.NaN });
+    lines[hwKey].push({
+      x: point.x,
+      y: readAiMetric(point, metricPath, metric) ?? Number.NaN,
+    });
   }
 
   for (const [hwKey, line] of Object.entries(lines)) {
@@ -65,7 +81,7 @@ export function normalizeAiRadarRows(
   for (const values of rawRows.values()) {
     for (let index = 0; index < metrics.length; index++) {
       const value = values[index];
-      if (value === null || value === undefined || !Number.isFinite(value)) continue;
+      if (!isAiMetricValueValid(metrics[index], value)) continue;
       mins[index] = Math.min(mins[index], value);
       maxs[index] = Math.max(maxs[index], value);
     }
@@ -78,9 +94,7 @@ export function normalizeAiRadarRows(
       metrics.map((metric, index) => {
         const value = values[index];
         if (
-          value === null ||
-          value === undefined ||
-          !Number.isFinite(value) ||
+          !isAiMetricValueValid(metric, value) ||
           !Number.isFinite(mins[index]) ||
           maxs[index] === mins[index]
         ) {
@@ -109,7 +123,7 @@ export function rankAiHardwareKeys<T extends AiMetricPoint>(
     const hwKey = point.hwKey ?? '';
     if (!hwKey) continue;
 
-    const value = readAiMetric(point, options.metricPath);
+    const value = readAiMetric(point, options.metricPath, options.metric);
     if (value === null) continue;
 
     const existing = bestByHardware.get(hwKey);

--- a/packages/app/src/hooks/api/use-ai-chart.ts
+++ b/packages/app/src/hooks/api/use-ai-chart.ts
@@ -26,12 +26,15 @@ import {
   dedupeAgenticHistoryRuns,
   dedupeRowsToLatestPerConfig,
 } from '@/lib/benchmark-run-selection';
-import {
-  getNestedYValue,
-  normalizeEvalHardwareKey,
-  generateHighContrastColors,
-} from '@/lib/chart-utils';
+import { normalizeEvalHardwareKey, generateHighContrastColors } from '@/lib/chart-utils';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
+
+import {
+  buildAiLineData,
+  normalizeAiRadarRows,
+  rankAiHardwareKeys,
+  readAiMetric,
+} from './ai-chart-data';
 
 import chartDefinitions from '@/components/inference/inference-chart-config.json';
 
@@ -123,8 +126,8 @@ function buildBenchmarkBarData(
       }
     }
 
-    const value = getNestedYValue(closest, yFieldPath);
-    if (value <= 0) continue;
+    const value = readAiMetric(closest, yFieldPath);
+    if (value === null) continue;
 
     const config = getHardwareConfig(hwKey, closest.model);
     bars.push({
@@ -271,19 +274,7 @@ function buildLineData(
 ): Record<string, { x: number; y: number }[]> {
   const chartDef = (chartDefinitions as any[])[0];
   const yFieldPath: string = chartDef[spec.yAxisMetric] ?? 'tpPerGpu.y';
-
-  const lines: Record<string, { x: number; y: number }[]> = {};
-  for (const p of points) {
-    const hwKey = p.hwKey ?? '';
-    if (!hwKey || !colorMap[hwKey]) continue;
-    if (!lines[hwKey]) lines[hwKey] = [];
-    lines[hwKey].push({ x: p.x, y: getNestedYValue(p, yFieldPath) });
-  }
-  // Sort each line by x
-  for (const pts of Object.values(lines)) {
-    pts.sort((a, b) => a.x - b.x);
-  }
-  return lines;
+  return buildAiLineData(points, yFieldPath, new Set(Object.keys(colorMap)));
 }
 
 function buildRadarData(
@@ -307,51 +298,25 @@ function buildRadarData(
   }
 
   // Extract raw values per metric per GPU
-  const rawMatrix = new Map<string, number[]>();
+  const rawMatrix = new Map<string, (number | null)[]>();
   for (const [hwKey, point] of groups) {
     const vals = metrics.map((m) => {
       const path: string = chartDef[m] ?? m;
-      return getNestedYValue(point, path);
+      return readAiMetric(point, path);
     });
     rawMatrix.set(hwKey, vals);
   }
-
-  // Find min/max per metric for normalization
-  const mins = metrics.map(() => Infinity);
-  const maxs = metrics.map(() => -Infinity);
-  for (const vals of rawMatrix.values()) {
-    for (let i = 0; i < vals.length; i++) {
-      if (vals[i] > 0) {
-        mins[i] = Math.min(mins[i], vals[i]);
-        maxs[i] = Math.max(maxs[i], vals[i]);
-      }
-    }
-  }
-
-  // For cost/energy metrics, invert normalization (lower is better)
-  const invertMetric = new Set([
-    'y_costh',
-    'y_costn',
-    'y_costr',
-    'y_jTotal',
-    'y_jOutput',
-    'y_jInput',
-  ]);
+  const normalizedMatrix = normalizeAiRadarRows(rawMatrix, metrics, chartDef);
 
   const items: AiRadarItem[] = [];
   for (const [hwKey, rawVals] of rawMatrix) {
     const config = getHardwareConfig(hwKey, groups.get(hwKey)?.model);
-    const normalized = rawVals.map((v, i) => {
-      if (v <= 0 || !isFinite(mins[i]) || maxs[i] === mins[i]) return null;
-      const norm = (v - mins[i]) / (maxs[i] - mins[i]);
-      return invertMetric.has(metrics[i]) ? 1 - norm : norm;
-    });
     items.push({
       hwKey,
       label: config ? `${config.label}${config.suffix ? ` ${config.suffix}` : ''}` : hwKey,
       color: colorMap[hwKey] ?? '#888',
-      values: normalized,
-      rawValues: rawVals.map((v) => (v > 0 ? v : null)),
+      values: normalizedMatrix.get(hwKey) ?? metrics.map(() => null),
+      rawValues: rawVals,
     });
   }
 
@@ -459,43 +424,19 @@ async function resolveSpec(spec: AiChartSpec): Promise<AiSingleChartResult> {
     });
   }
 
-  // topN: rank configs by peak metric value and keep only the best N
+  // topN: rank configs by their best value in the metric's canonical direction.
   if (spec.topN) {
     const chartDef = (chartDefinitions as any[])[0];
     const yFieldPath: string = chartDef[spec.yAxisMetric] ?? 'tpPerGpu.y';
-    const peakByHw = new Map<string, number>();
-    for (const p of points) {
-      const hw = p.hwKey ?? '';
-      if (!hw) continue;
-      const val = getNestedYValue(p, yFieldPath);
-      peakByHw.set(hw, Math.max(peakByHw.get(hw) ?? 0, val));
-    }
-
-    let topHwKeys: Set<string>;
-    if (spec.topNDistinctGpus === false) {
-      // Rank individual configs regardless of GPU family
-      topHwKeys = new Set(
-        [...peakByHw.entries()]
-          .toSorted(([, a], [, b]) => b - a)
-          .slice(0, spec.topN)
-          .map(([k]) => k),
-      );
-    } else {
-      // Group by base GPU, pick the best config per GPU, then take top N GPUs
-      const bestPerGpu = new Map<string, { hwKey: string; peak: number }>();
-      for (const [hwKey, peak] of peakByHw) {
-        const base = hwKey.split('_')[0];
-        const existing = bestPerGpu.get(base);
-        if (!existing || peak > existing.peak) {
-          bestPerGpu.set(base, { hwKey, peak });
-        }
-      }
-      const topBases = [...bestPerGpu.entries()]
-        .toSorted(([, a], [, b]) => b.peak - a.peak)
-        .slice(0, spec.topN);
-      // Include only the single best config per winning GPU
-      topHwKeys = new Set(topBases.map(([, v]) => v.hwKey));
-    }
+    const topHwKeys = new Set(
+      rankAiHardwareKeys(points, {
+        metric: spec.yAxisMetric,
+        metricPath: yFieldPath,
+        chartDefinition: chartDef,
+        topN: spec.topN,
+        distinctGpus: spec.topNDistinctGpus !== false,
+      }),
+    );
     points = points.filter((p) => topHwKeys.has(p.hwKey ?? ''));
   }
 

--- a/packages/app/src/hooks/api/use-ai-chart.ts
+++ b/packages/app/src/hooks/api/use-ai-chart.ts
@@ -126,7 +126,7 @@ function buildBenchmarkBarData(
       }
     }
 
-    const value = readAiMetric(closest, yFieldPath);
+    const value = readAiMetric(closest, yFieldPath, spec.yAxisMetric);
     if (value === null) continue;
 
     const config = getHardwareConfig(hwKey, closest.model);
@@ -274,7 +274,7 @@ function buildLineData(
 ): Record<string, { x: number; y: number }[]> {
   const chartDef = (chartDefinitions as any[])[0];
   const yFieldPath: string = chartDef[spec.yAxisMetric] ?? 'tpPerGpu.y';
-  return buildAiLineData(points, yFieldPath, new Set(Object.keys(colorMap)));
+  return buildAiLineData(points, spec.yAxisMetric, yFieldPath, new Set(Object.keys(colorMap)));
 }
 
 function buildRadarData(
@@ -302,7 +302,7 @@ function buildRadarData(
   for (const [hwKey, point] of groups) {
     const vals = metrics.map((m) => {
       const path: string = chartDef[m] ?? m;
-      return readAiMetric(point, path);
+      return readAiMetric(point, path, m);
     });
     rawMatrix.set(hwKey, vals);
   }


### PR DESCRIPTION
Fixes #797

## What changed

- Preserve missing AI-chart metrics as gaps while keeping genuine measured zero values.
- Use the canonical metric direction for radar normalization and Top-N selection.
- Exclude unavailable synthetic zero sentinels from charts and rankings.

## Why

Missing or lower-is-better metrics could be rendered and ranked incorrectly, allowing an unavailable, expensive, or high-power configuration to appear preferable.

## Validation

- Focused unit tests: 38 passed
- AI-chart E2E: Chrome 3/3, Firefox 3/3
- Fixture production build, typecheck, lint, format, and diff check passed

## 中文说明

- AI 图表中的缺失指标现在保持为断点，同时保留真实测得的零值。
- 雷达图归一化与 Top-N 选择统一使用指标配置中的权威方向。
- 不可用的派生指标零哨兵不再进入图表和排名。

此前缺失值或“越低越好”的指标可能被错误展示和排序，导致无数据、成本更高或功耗更高的配置看起来更优。

验证结果：38 项聚焦单元测试通过；Chrome 与 Firefox 的 AI-chart E2E 各 3/3 通过；fixture production build、typecheck、lint、format 与 diff check 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how benchmark configs are ranked and visualized (Top-N, radar, lines), which can change which GPU looks “best.” Logic is isolated to AI charts and covered by unit plus E2E tests.
> 
> **Overview**
> AI charts no longer treat missing or synthetic-zero metrics as real zeros, and they rank/normalize using the dashboard’s canonical higher-vs-lower direction.
> 
> **Top-N, radar, and bars** now pick minima for lower-is-better metrics (cost/energy/power) and maxima for throughput, instead of always ranking by peak. Unavailable cost/energy zeros are dropped from ranking and rendering; genuine measured zeros (e.g. power telemetry) are kept.
> 
> **Line charts** keep missing points as gaps (`NaN` + `isDefined`) rather than plotting a zero-valued dot. Radar inversion is driven by each metric’s `_roofline` instead of a hardcoded cost/energy set.
> 
> Prompt instructions were updated so “best” / Top-N follow the same direction. Unit tests plus Cypress coverage lock in ranking, radar polarity, and line gaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e29bf92b68fcc1a5f868dee8962344647f972f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->