### PR TITLE
Add first-visit coach mark pointing at agentic chart data points

### DIFF
--- a/packages/app/cypress/e2e/agentic-point-coach-mark.cy.ts
+++ b/packages/app/cypress/e2e/agentic-point-coach-mark.cy.ts
@@ -12,6 +12,7 @@ import {
   keepAgenticCoachMark,
   unlockAgenticGate,
 } from '../support/e2e';
+import { plotBounds } from '@/lib/d3-chart/plot-bounds';
 import { OVERLAY_RUN_ID, interceptOverlayRun } from '../support/overlay-fixtures';
 
 // This spec owns coach-mark state, so it opts out of the global suppression in
@@ -118,6 +119,33 @@ describe('Agentic point coach mark', () => {
 
     cy.get('[data-testid="scatter-graph"]').scrollIntoView();
     cy.get(COACH_MARK).should('be.visible');
+  });
+
+  it('targets the clipped plot area, not the axis gutters', () => {
+    // `plotBounds` reconstructs the clip region from the live chart DOM. If the
+    // skeleton it reads ever changes shape it returns null and the resolver
+    // silently falls back to the SVG box — which includes the 60px axis
+    // gutters, where a zoomed point is invisible. Assert against the real DOM
+    // so that fallback cannot go unnoticed.
+    visitAgenticChart();
+    cy.get(COACH_MARK).should('be.visible');
+
+    cy.get('[data-testid="scatter-graph"] [data-testid="d3-chart-svg"]').then(($svg) => {
+      const svg = $svg[0];
+      const bounds = plotBounds(svg);
+      expect(bounds, 'clip region resolves against the real chart').to.not.eq(null);
+
+      const box = svg.getBoundingClientRect();
+      expect(bounds!.left, 'left gutter excluded').to.be.greaterThan(box.left);
+      expect(bounds!.bottom, 'bottom gutter excluded').to.be.lessThan(box.bottom);
+
+      cy.get('[data-testid="agentic-point-coach-mark-target"]').then(($ring) => {
+        const cx = Number($ring.attr('cx'));
+        const cy = Number($ring.attr('cy'));
+        expect(cx).to.be.within(bounds!.left, bounds!.right);
+        expect(cy).to.be.within(bounds!.top, bounds!.bottom);
+      });
+    });
   });
 
   it('keeps the card fully on screen', () => {

--- a/packages/app/cypress/e2e/agentic-point-coach-mark.cy.ts
+++ b/packages/app/cypress/e2e/agentic-point-coach-mark.cy.ts
@@ -1,0 +1,256 @@
+/**
+ * First-visit coach mark on the agentic inference chart.
+ *
+ * The affordance it teaches is invisible: clicking an agentic scatter point
+ * pins its tooltip, and the pinned tooltip carries a "View charts" link to the
+ * per-point server metrics and logs. The callout draws a pointer to a real,
+ * currently-visible point and goes away for good once the user either
+ * dismisses it or clicks a point.
+ */
+import {
+  interceptDerivedAgenticMetrics,
+  keepAgenticCoachMark,
+  unlockAgenticGate,
+} from '../support/e2e';
+import { OVERLAY_RUN_ID, interceptOverlayRun } from '../support/overlay-fixtures';
+
+// This spec owns coach-mark state, so it opts out of the global suppression in
+// cypress/support/e2e.ts rather than fighting it on every visit (that hook also
+// runs on cy.reload(), where onBeforeLoad cannot reach).
+keepAgenticCoachMark();
+
+const STORAGE_KEY = 'inferencex-agentic-point-coach-mark-dismissed';
+const COACH_MARK = '[data-testid="agentic-point-coach-mark"]';
+const AGENTIC_POINTS =
+  '[data-testid="scatter-graph"] .dot-group[data-benchmark-type="agentic_traces"]';
+// The pointer targets the marker inside the group, not the group's
+// label-inflated bounding box.
+const AGENTIC_MARKERS = `${AGENTIC_POINTS} .visible-shape`;
+
+/**
+ * Competing dashboard toasts land bottom-right, in the *overlay* slot rather
+ * than the coach mark's own slot — suppressed anyway so nothing else is
+ * animating while positions are measured.
+ */
+function freshCoachMarkState(win: Cypress.AUTWindow) {
+  unlockAgenticGate(win);
+  win.localStorage.removeItem(STORAGE_KEY);
+  win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+  win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
+  win.sessionStorage.setItem('inferencex-star-nudge-shown', '1');
+  win.localStorage.setItem('inferencex-filter-hint-nudge-dismissed', '1');
+}
+
+/**
+ * The callout only appears once there is a point on screen to point at, and at
+ * this viewport the chart starts below the fold — so bring it into view, the
+ * same thing a real first-time visitor does before they can see any of this.
+ */
+function visitAgenticChart(url = '/inference?i_seq=agentic-traces') {
+  interceptOverlayRun();
+  interceptDerivedAgenticMetrics();
+  cy.visit(url, { onBeforeLoad: freshCoachMarkState });
+  cy.get(AGENTIC_POINTS).should('have.length.greaterThan', 0);
+  cy.get('[data-testid="scatter-graph"]').scrollIntoView();
+}
+
+function centreOf(element: Element) {
+  const rect = element.getBoundingClientRect();
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+beforeEach(() => {
+  cy.clearAllLocalStorage();
+  cy.clearAllSessionStorage();
+});
+
+describe('Agentic point coach mark', () => {
+  it('points at a real, visible agentic point on the first visit', () => {
+    visitAgenticChart();
+
+    cy.get(COACH_MARK)
+      .should('be.visible')
+      .and('contain.text', 'Every point has a story')
+      .and('contain.text', 'Click any point to view server metrics and logs');
+
+    // Non-modal by construction: a focus trap or a scrim would block the very
+    // click the tip is asking for.
+    cy.get(COACH_MARK).should('have.attr', 'role', 'dialog');
+    cy.get(COACH_MARK).should('have.attr', 'aria-modal', 'false');
+    cy.get('[data-testid="agentic-point-coach-mark-layer"]').should(
+      'have.css',
+      'pointer-events',
+      'none',
+    );
+
+    // The callout must target an actual point, not empty plot area. The
+    // highlight ring sits exactly on the anchor (the pointer line deliberately
+    // stops short so its arrowhead doesn't cover the dot).
+    cy.get('[data-testid="agentic-point-coach-mark-pointer"]').should('exist');
+    cy.get('[data-testid="agentic-point-coach-mark-target"]').then(($ring) => {
+      const tipX = Number($ring.attr('cx'));
+      const tipY = Number($ring.attr('cy'));
+
+      cy.get(AGENTIC_MARKERS).then(($points) => {
+        const hit = [...$points].some((point) => {
+          const { x, y } = centreOf(point);
+          return Math.abs(x - tipX) < 1 && Math.abs(y - tipY) < 1;
+        });
+        expect(hit, 'pointer ends on an agentic point').to.eq(true);
+      });
+    });
+  });
+
+  it('waits for the chart to be on screen before pointing at anything', () => {
+    interceptOverlayRun();
+    interceptDerivedAgenticMetrics();
+    cy.visit('/inference?i_seq=agentic-traces', { onBeforeLoad: freshCoachMarkState });
+    cy.get(AGENTIC_POINTS).should('have.length.greaterThan', 0);
+
+    // Chart below the fold: no anchor, so no stranded arrow — and no dismissal
+    // burned either, since the tip has not been shown.
+    cy.window().its('scrollY').should('eq', 0);
+    cy.wait(2500);
+    cy.get(COACH_MARK).should('not.exist');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem(STORAGE_KEY)).to.eq(null);
+    });
+
+    cy.get('[data-testid="scatter-graph"]').scrollIntoView();
+    cy.get(COACH_MARK).should('be.visible');
+  });
+
+  it('keeps the card fully on screen', () => {
+    visitAgenticChart();
+    cy.get(COACH_MARK).should('be.visible');
+
+    cy.window().then((win) => {
+      const rect = win.document.querySelector(COACH_MARK)!.getBoundingClientRect();
+      const { clientWidth, clientHeight } = win.document.documentElement;
+      expect(rect.left, 'left edge').to.be.at.least(0);
+      expect(rect.top, 'top edge').to.be.at.least(0);
+      expect(rect.right, 'right edge').to.be.at.most(clientWidth);
+      expect(rect.bottom, 'bottom edge').to.be.at.most(clientHeight);
+    });
+  });
+
+  it('follows its point when the chart is zoomed', () => {
+    visitAgenticChart();
+    cy.get('[data-testid="agentic-point-coach-mark-target"]').should('exist');
+
+    // Shift+wheel is the chart's zoom gesture (see the chart instructions).
+    cy.get('[data-testid="d3-chart-svg"]')
+      .first()
+      .trigger('wheel', { deltaY: -400, shiftKey: true, bubbles: true });
+
+    cy.get('[data-testid="agentic-point-coach-mark-target"]').should(($ring) => {
+      const tipX = Number($ring.attr('cx'));
+      const tipY = Number($ring.attr('cy'));
+      // Wherever the point ended up, the callout is still on top of one —
+      // no stranded arrow pointing at empty plot area.
+      const points = Cypress.$(AGENTIC_MARKERS)
+        .filter((_i, el) => getComputedStyle(el.parentElement!).opacity !== '0')
+        .toArray();
+      const hit = points.some((point) => {
+        const { x, y } = centreOf(point);
+        return Math.abs(x - tipX) < 1.5 && Math.abs(y - tipY) < 1.5;
+      });
+      expect(hit, 'callout still targets an agentic point after zoom').to.eq(true);
+    });
+  });
+
+  it('dismisses from the close button and stays gone after reload', () => {
+    visitAgenticChart();
+    cy.get(COACH_MARK).should('be.visible');
+
+    cy.get('[data-testid="agentic-point-coach-mark-dismiss"]').click();
+    cy.get(COACH_MARK).should('not.exist');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem(STORAGE_KEY)).to.eq('1');
+    });
+
+    interceptOverlayRun();
+    interceptDerivedAgenticMetrics();
+    cy.reload();
+    cy.get(AGENTIC_POINTS).should('have.length.greaterThan', 0);
+    cy.wait(1500);
+    cy.get(COACH_MARK).should('not.exist');
+  });
+
+  it('dismisses when the user actually clicks a point', () => {
+    visitAgenticChart();
+    cy.get(COACH_MARK).should('be.visible');
+
+    cy.get(AGENTIC_POINTS).first().find('.visible-shape').click({ force: true });
+
+    cy.get(COACH_MARK).should('not.exist');
+    // Clicking a point is engagement, so it persists the dismissal too.
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem(STORAGE_KEY)).to.eq('1');
+    });
+    // …and the interaction it was teaching still happened.
+    cy.get('[data-chart-tooltip]:visible').should('have.length', 1);
+  });
+
+  it('is dismissable from the keyboard', () => {
+    visitAgenticChart();
+    cy.get(COACH_MARK).should('be.visible');
+
+    cy.get('body').type('{esc}');
+    cy.get(COACH_MARK).should('not.exist');
+    cy.window().then((win) => {
+      expect(win.localStorage.getItem(STORAGE_KEY)).to.eq('1');
+    });
+  });
+
+  it('never anchors to an unofficial-run overlay marker', () => {
+    // Overlay runs have no stored trace, so their tooltip offers no
+    // "View charts" link — anchoring there would teach a dead end.
+    visitAgenticChart(`/inference?unofficialrun=${OVERLAY_RUN_ID}&i_seq=agentic-traces`);
+    cy.wait('@unofficialRun');
+    cy.get('[data-testid="scatter-graph"] .unofficial-overlay-pt').should(
+      'have.length.greaterThan',
+      0,
+    );
+
+    cy.get(COACH_MARK).should('be.visible');
+    cy.get('[data-testid="agentic-point-coach-mark-target"]').then(($ring) => {
+      const tipX = Number($ring.attr('cx'));
+      const tipY = Number($ring.attr('cy'));
+      const onPoint = (element: Element) => {
+        const { x, y } = centreOf(element);
+        return Math.abs(x - tipX) < 1 && Math.abs(y - tipY) < 1;
+      };
+
+      cy.get('[data-testid="scatter-graph"] .unofficial-overlay-pt').then(($overlay) => {
+        expect([...$overlay].some(onPoint), 'pointer avoids overlay markers').to.eq(false);
+      });
+      cy.get(AGENTIC_MARKERS).then(($official) => {
+        expect([...$official].some(onPoint), 'pointer lands on an official point').to.eq(true);
+      });
+    });
+  });
+
+  it('does not appear on the agentic detail page it links to', () => {
+    cy.visit('/inference/agentic/206885', {
+      onBeforeLoad: freshCoachMarkState,
+      failOnStatusCode: false,
+    });
+    cy.wait(2000);
+    cy.get(COACH_MARK).should('not.exist');
+  });
+
+  it('renders Simplified Chinese copy on /zh', () => {
+    visitAgenticChart('/zh/inference?i_seq=agentic-traces');
+
+    cy.get(COACH_MARK)
+      .should('be.visible')
+      .and('contain.text', '每个数据点背后都有细节')
+      .and('contain.text', '点击任意数据点即可查看服务端指标与日志');
+    cy.get('[data-testid="agentic-point-coach-mark-dismiss"]').should(
+      'have.attr',
+      'aria-label',
+      '关闭提示',
+    );
+  });
+});

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -11,6 +11,7 @@
  */
 let suppressLaunchModal = true;
 let suppressTelemetryTutorial = true;
+let suppressAgenticCoachMark = true;
 
 /**
  * Opt the whole spec out of the launch-modal suppression.
@@ -38,6 +39,18 @@ export function keepTelemetryTutorial(): void {
   suppressTelemetryTutorial = false;
 }
 
+/**
+ * Opt the whole spec out of the agentic point coach-mark suppression, for the
+ * same reason as `keepLaunchModal` — the key is re-seeded on `cy.reload()`, so
+ * a per-visit `onBeforeLoad` clear cannot own its state.
+ *
+ * The callout is anchored to a point inside `[data-testid="scatter-graph"]`,
+ * so on the agentic view it sits over the plot area that other specs click.
+ */
+export function keepAgenticCoachMark(): void {
+  suppressAgenticCoachMark = false;
+}
+
 Cypress.on('window:before:load', (win) => {
   try {
     win.localStorage.setItem('inferencex-feedback-modal-snoozed', String(Date.now()));
@@ -46,6 +59,9 @@ Cypress.on('window:before:load', (win) => {
     }
     if (suppressTelemetryTutorial) {
       win.localStorage.setItem('inferencex-agentx-telemetry-tutorial-dismissed', '1');
+    }
+    if (suppressAgenticCoachMark) {
+      win.localStorage.setItem('inferencex-agentic-point-coach-mark-dismissed', '1');
     }
   } catch {
     // localStorage unavailable — fine, the test will just see the modal.

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -4,6 +4,7 @@ import { track } from '@/lib/analytics';
 import * as d3 from 'd3';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
+import { SCATTER_RENDERED_EVENT } from '@/lib/nudges/agentic-point-coach-mark';
 import { GRADIENT_NUDGE_EVENT } from '@/lib/nudges/registry';
 import { useInference } from '@/components/inference/InferenceContext';
 import { useTraceAvailability } from '@/hooks/api/use-trace-availability';
@@ -2386,6 +2387,9 @@ const ScatterGraph = React.memo(
           dataAttrs: {
             'hw-key': (d) => String(d.hwKey),
             precision: (d) => d.precision,
+            // Lets the agentic coach mark pick an anchor out of the DOM
+            // without knowing anything about React state.
+            'benchmark-type': (d) => d.benchmark_type ?? '',
           },
           getShapeKey: (d) =>
             getShapeKeyForPrecision(d.precision, interactionRef.current.selectedPrecisions),
@@ -2990,6 +2994,11 @@ const ScatterGraph = React.memo(
 
         avoidLabelCollisions(zoomGroup);
 
+        // Tell the nudge engine the chart has painted, so an anchored coach
+        // mark can (re)try resolving a point to point at. Cheap: one event per
+        // full render, not per zoom frame.
+        window.dispatchEvent(new CustomEvent(SCATTER_RENDERED_EVENT));
+
         // Log tick formatting on initial render
         if (xScaleConfig._isLog) {
           const xScale = ctx.xScale as d3.ScaleLogarithmic<number, number>;
@@ -3055,6 +3064,13 @@ const ScatterGraph = React.memo(
         // A precision toggle may replace and append the visible SVG shape.
         // Keep the offload halo above that shape after the swap.
         sel.selectAll('.offload-halo').raise();
+        // Whether this point's pinned tooltip will offer "View charts". Written
+        // here rather than in the layer's dataAttrs because availability
+        // resolves after the chart renders, and a rebuild would drop the zoom.
+        sel.attr(
+          'data-has-trace',
+          typeof d.id === 'number' && traceAvailability?.[d.id] === true ? 'true' : null,
+        );
       });
 
       // Overlay X markers: Optimal Only visibility (mirrors the official dot
@@ -3161,6 +3177,8 @@ const ScatterGraph = React.memo(
       showGradientLabels,
       showLineLabels,
       gradientColorByPoint,
+      // Re-stamps `data-has-trace` once the presence lookup resolves.
+      traceAvailability,
     ]);
 
     // D3 custom layers are keyed additions, so removing the overlay layer from

--- a/packages/app/src/components/nudge-engine.tsx
+++ b/packages/app/src/components/nudge-engine.tsx
@@ -18,6 +18,7 @@ import { NUDGE_REGISTRY } from '@/lib/nudges/registry';
 import type { NudgeDefinition, NudgeScope, NudgeTrigger } from '@/lib/nudges/types';
 import { LANDING_BANNER_DISMISSED_ATTRIBUTE } from '@/lib/nudges/landing-banner';
 import { BottomToast } from '@/components/ui/bottom-toast';
+import { CoachMark } from '@/components/ui/coach-mark';
 import { Button } from '@/components/ui/button';
 import { NewBadge } from '@/components/ui/new-badge';
 
@@ -30,7 +31,17 @@ function trackNudgeEvent(def: NudgeDefinition, event: 'shown' | 'dismissed' | 'a
   track(name, def.analytics?.properties);
 }
 
-function isEligible(def: NudgeDefinition): boolean {
+/**
+ * `requireAnchor` separates the two questions the engine asks.
+ *
+ * Trigger *setup* asks "could this nudge ever fire?" and must not consult the
+ * anchor: a coach mark's anchor only exists once the chart has painted, and
+ * skipping setup at mount would mean its triggers are never wired up at all.
+ * Showing asks "can it fire right now?" — there a missing anchor is
+ * disqualifying, and the show is simply retried on the next trigger.
+ */
+function isEligible(def: NudgeDefinition, { requireAnchor = true } = {}): boolean {
+  if (requireAnchor && def.type === 'coach-mark' && !def.content.anchor?.resolve()) return false;
   if (!isWithinSchedule(def.schedule)) return false;
   if (def.permanentSuppressKey && isPermanentlySuppressed(def.permanentSuppressKey)) return false;
   if (isDismissed(def.storageKey, def.dismissal)) return false;
@@ -47,12 +58,14 @@ interface NudgeEngineProps {
 }
 
 /**
- * Two independent slots:
+ * Three independent slots:
  *  - **banner** — inline content (one at a time)
  *  - **overlay** — toasts and modals (one at a time)
+ *  - **coach mark** — a callout anchored to a live element (one at a time)
  *
- * A banner and an overlay can be visible simultaneously because they
- * occupy different visual layers.
+ * All three can be visible simultaneously because they occupy different
+ * visual layers: a banner sits in the document flow, an overlay in the
+ * bottom-right corner, and a coach mark next to the element it explains.
  */
 export function NudgeEngine({ scope }: NudgeEngineProps) {
   const scopeNudges = useMemo(() => NUDGE_REGISTRY.filter((n) => n.scope === scope), [scope]);
@@ -69,8 +82,10 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
     return initialBanner?.id ?? null;
   });
   const [activeOverlayId, setActiveOverlayId] = useState<string | null>(null);
+  const [activeCoachMarkId, setActiveCoachMarkId] = useState<string | null>(null);
   const bannerShownRef = useRef(false);
   const overlayShownRef = useRef(false);
+  const coachMarkShownRef = useRef(false);
 
   const triggerCountsRef = useRef<Record<string, number>>({});
   const eventDetailRef = useRef<Record<string, unknown> | null>(null);
@@ -78,6 +93,9 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
 
   const activeBanner = activeBannerId ? scopeNudges.find((n) => n.id === activeBannerId) : null;
   const activeOverlay = activeOverlayId ? scopeNudges.find((n) => n.id === activeOverlayId) : null;
+  const activeCoachMark = activeCoachMarkId
+    ? scopeNudges.find((n) => n.id === activeCoachMarkId)
+    : null;
 
   const showNudge = useCallback((def: NudgeDefinition) => {
     if (sessionDismissedRef.current.has(def.id)) return;
@@ -87,6 +105,10 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
       if (bannerShownRef.current) return;
       bannerShownRef.current = true;
       setActiveBannerId(def.id);
+    } else if (def.type === 'coach-mark') {
+      if (coachMarkShownRef.current) return;
+      coachMarkShownRef.current = true;
+      setActiveCoachMarkId(def.id);
     } else {
       if (overlayShownRef.current) return;
       overlayShownRef.current = true;
@@ -116,6 +138,31 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
     setActiveOverlayId(null);
     overlayShownRef.current = false;
   }, [activeOverlay]);
+
+  const dismissCoachMark = useCallback(() => {
+    if (!activeCoachMark) return;
+    trackNudgeEvent(activeCoachMark, 'dismissed');
+    markDismissed(activeCoachMark.storageKey, activeCoachMark.dismissal);
+    sessionDismissedRef.current.add(activeCoachMark.id);
+    setActiveCoachMarkId(null);
+    coachMarkShownRef.current = false;
+  }, [activeCoachMark]);
+
+  /**
+   * The user performed the interaction the coach mark was teaching (clicked a
+   * point). That is engagement, not rejection — record it as an action and,
+   * per `dismissesOnAction`, stop showing the tip.
+   */
+  const handleCoachMarkAction = useCallback(() => {
+    if (!activeCoachMark) return;
+    trackNudgeEvent(activeCoachMark, 'action');
+    activeCoachMark.content.action?.onClick(eventDetailRef.current ?? undefined);
+    if (!dismissesOnAction(activeCoachMark)) return;
+    markDismissed(activeCoachMark.storageKey, activeCoachMark.dismissal);
+    sessionDismissedRef.current.add(activeCoachMark.id);
+    setActiveCoachMarkId(null);
+    coachMarkShownRef.current = false;
+  }, [activeCoachMark]);
 
   const handleBannerAction = useCallback(() => {
     if (!activeBanner) return;
@@ -167,7 +214,11 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
     const sorted = [...scopeNudges].toSorted((a, b) => b.priority - a.priority);
 
     for (const def of sorted) {
-      if (!isEligible(def)) continue;
+      // Already occupying its slot — re-arming would keep re-running the
+      // (potentially expensive) eligibility check for no benefit.
+      if (def.id === activeBannerId || def.id === activeOverlayId) continue;
+      if (def.id === activeCoachMarkId) continue;
+      if (!isEligible(def, { requireAnchor: false })) continue;
       if (sessionDismissedRef.current.has(def.id)) continue;
 
       const triggers = Array.isArray(def.trigger) ? def.trigger : [def.trigger];
@@ -182,7 +233,7 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
       for (const fn of cleanups) fn();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeBannerId, activeOverlayId, scope]);
+  }, [activeBannerId, activeOverlayId, activeCoachMarkId, scope]);
 
   // -------------------------------------------------------------------------
   // Permanent suppress event listener
@@ -198,6 +249,9 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
         if (def.type === 'banner' && activeBannerId === def.id) {
           setActiveBannerId(null);
           bannerShownRef.current = false;
+        } else if (def.type === 'coach-mark' && activeCoachMarkId === def.id) {
+          setActiveCoachMarkId(null);
+          coachMarkShownRef.current = false;
         } else if (activeOverlayId === def.id) {
           setActiveOverlayId(null);
           overlayShownRef.current = false;
@@ -224,7 +278,7 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
         window.removeEventListener(event, handler);
       }
     };
-  }, [activeBannerId, activeOverlayId, scopeNudges]);
+  }, [activeBannerId, activeOverlayId, activeCoachMarkId, scopeNudges]);
 
   // -------------------------------------------------------------------------
   // Render — banner and overlay can coexist
@@ -251,6 +305,13 @@ export function NudgeEngine({ scope }: NudgeEngineProps) {
           def={activeOverlay}
           onDismiss={dismissOverlay}
           onAction={handleOverlayAction}
+        />
+      )}
+      {activeCoachMark?.content.anchor && (
+        <CoachMarkRenderer
+          def={activeCoachMark}
+          onDismiss={dismissCoachMark}
+          onAction={handleCoachMarkAction}
         />
       )}
     </>
@@ -486,6 +547,34 @@ function ModalRenderer({
   }
 
   return dialog;
+}
+
+function CoachMarkRenderer({
+  def,
+  onDismiss,
+  onAction,
+}: {
+  def: NudgeDefinition;
+  onDismiss: () => void;
+  onAction: () => void;
+}) {
+  const locale = useLocale();
+  const { content } = def;
+  const Icon = content.icon;
+  // Guarded by the caller — `isEligible` also refuses anchorless coach marks.
+  const anchor = content.anchor!;
+
+  return (
+    <CoachMark
+      anchor={anchor}
+      icon={<Icon className={content.iconClassName} />}
+      title={localized(locale, content.title, content.titleZh)}
+      description={localized(locale, content.description, content.descriptionZh)}
+      onDismiss={onDismiss}
+      onAction={onAction}
+      testId={content.testId}
+    />
+  );
 }
 
 function BannerRenderer({

--- a/packages/app/src/components/ui/coach-mark.test.tsx
+++ b/packages/app/src/components/ui/coach-mark.test.tsx
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/inference',
+}));
+
+import { CoachMark } from '@/components/ui/coach-mark';
+import type { NudgeAnchor } from '@/lib/nudges/types';
+
+const ACTION_SELECTOR = '.dot-group';
+
+function stubRect(element: Element, left: number, top: number, size = 12): void {
+  element.getBoundingClientRect = () =>
+    ({
+      left,
+      top,
+      width: size,
+      height: size,
+      right: left + size,
+      bottom: top + size,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+/** A point the resolver can find, mid-viewport so it passes the on-screen check. */
+function addPoint(): HTMLElement {
+  const point = document.createElement('div');
+  point.className = 'dot-group';
+  document.body.append(point);
+  stubRect(point, 500, 300);
+  return point;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let onDismiss: Mock<() => void>;
+let onAction: Mock<() => void>;
+
+function renderCoachMark(anchor: NudgeAnchor) {
+  act(() =>
+    root.render(
+      <CoachMark
+        anchor={anchor}
+        icon={<span />}
+        title="Every point has a story"
+        description="Click any point to view server metrics and logs."
+        onDismiss={onDismiss}
+        onAction={onAction}
+        testId="coach-mark"
+      />,
+    ),
+  );
+}
+
+function pressEscape() {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+  });
+}
+
+const isVisible = () => container.querySelector('[data-testid="coach-mark-target"]') !== null;
+
+/**
+ * Let the component notice a DOM change on its own: the MutationObserver
+ * callback is a microtask, and the reposition it schedules runs on the next
+ * animation frame.
+ */
+async function flushReposition() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => {
+      requestAnimationFrame(() => resolve(null));
+    });
+  });
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  onDismiss = vi.fn<() => void>();
+  onAction = vi.fn<() => void>();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('CoachMark input handling', () => {
+  describe('when an anchor is on screen', () => {
+    let point: HTMLElement;
+
+    beforeEach(() => {
+      point = addPoint();
+      renderCoachMark({ resolve: () => point, actionSelector: ACTION_SELECTOR });
+    });
+
+    it('renders the callout', () => {
+      expect(isVisible()).toBe(true);
+      expect(container.querySelector('[data-testid="coach-mark"]')?.textContent).toContain(
+        'Every point has a story',
+      );
+    });
+
+    it('dismisses on Escape', () => {
+      pressEscape();
+      expect(onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it('treats a click on the anchored element as taking the action', () => {
+      act(() => {
+        point.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(onAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when no anchor resolves (scrolled away, or every point filtered out)', () => {
+    beforeEach(() => {
+      // The card stays mounted so it can be measured and can re-appear, but
+      // nothing is drawn — the user has never seen this tip.
+      renderCoachMark({ resolve: () => null, actionSelector: ACTION_SELECTOR });
+    });
+
+    it('renders nothing visible', () => {
+      expect(isVisible()).toBe(false);
+      expect(
+        container.querySelector<HTMLElement>('[data-testid="coach-mark"]')?.style.visibility,
+      ).toBe('hidden');
+    });
+
+    it('ignores Escape rather than burning the permanent dismissal', () => {
+      // Escape is a global key: the user is closing some other UI entirely.
+      // Acting on it here would permanently dismiss a tip never shown, and it
+      // would not come back on scroll.
+      pressEscape();
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+
+    it('ignores a click on a point rather than recording phantom engagement', () => {
+      const point = addPoint();
+      act(() => {
+        point.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      expect(onAction).not.toHaveBeenCalled();
+    });
+  });
+
+  it('starts responding to Escape once its point comes into view', async () => {
+    let point: HTMLElement | null = null;
+    renderCoachMark({ resolve: () => point, actionSelector: ACTION_SELECTOR });
+    expect(isVisible()).toBe(false);
+
+    pressEscape();
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // The point appears — as it does when the chart is scrolled into view.
+    // No re-render: the component's own MutationObserver has to notice.
+    point = addPoint();
+    await flushReposition();
+    expect(isVisible()).toBe(true);
+
+    pressEscape();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/components/ui/coach-mark.tsx
+++ b/packages/app/src/components/ui/coach-mark.tsx
@@ -135,22 +135,32 @@ export function CoachMark({
     };
   }, [resolve, repositionEvents]);
 
+  /**
+   * Whether the callout is actually on screen. The card stays mounted while
+   * hidden — it has to be in the DOM to be measured, and it re-appears when
+   * its point comes back — so every input handler below is gated on this.
+   * Dismissal is permanent: reacting to a keypress or a click while nothing
+   * is visible would burn the first-visit tip the user never saw.
+   */
+  const visible = placement !== null;
+
   // ── Escape to dismiss ────────────────────────────────────────────────────
   const onDismissRef = useRef(onDismiss);
   onDismissRef.current = onDismiss;
   useEffect(() => {
+    if (!visible) return;
     const handler = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onDismissRef.current();
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [visible]);
 
   // ── Clicking the thing the tip is about counts as taking the action ──────
   const onActionRef = useRef(onAction);
   onActionRef.current = onAction;
   useEffect(() => {
-    if (!actionSelector) return;
+    if (!actionSelector || !visible) return;
     const handler = (event: MouseEvent) => {
       const target = event.target as Element | null;
       if (target?.closest?.(actionSelector)) onActionRef.current?.();
@@ -158,11 +168,10 @@ export function CoachMark({
     // Capture phase: d3's own point handler calls stopPropagation().
     document.addEventListener('click', handler, true);
     return () => document.removeEventListener('click', handler, true);
-  }, [actionSelector]);
+  }, [actionSelector, visible]);
 
   const handleDismiss = useCallback(() => onDismissRef.current(), []);
 
-  const visible = placement !== null;
   const titleId = testId ? `${testId}-title` : undefined;
   const descriptionId = testId ? `${testId}-description` : undefined;
 

--- a/packages/app/src/components/ui/coach-mark.tsx
+++ b/packages/app/src/components/ui/coach-mark.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { X } from 'lucide-react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import {
+  computeCoachMarkPlacement,
+  isAnchorOnScreen,
+  viewportSize,
+  type CoachMarkPlacement,
+  type Size,
+} from '@/lib/nudges/anchor';
+import type { NudgeAnchor } from '@/lib/nudges/types';
+import { useLocale } from '@/lib/use-locale';
+
+const STRINGS = {
+  en: { close: 'Dismiss tip' },
+  zh: { close: '关闭提示' },
+} as const;
+
+/** Card width in px. Mirrors the `w-72` utility so placement can use it before paint. */
+const CARD_WIDTH = 288;
+/** Stop the pointer short of the anchor so the arrowhead doesn't cover the point. */
+const ARROW_STANDOFF = 13;
+
+interface CoachMarkProps {
+  anchor: NudgeAnchor;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  /** Fired by the X button and by Escape. */
+  onDismiss: () => void;
+  /** Fired when the user clicks something matching `anchor.actionSelector`. */
+  onAction?: () => void;
+  testId?: string;
+}
+
+function samePlacement(a: CoachMarkPlacement | null, b: CoachMarkPlacement | null): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    Math.abs(a.left - b.left) < 0.5 &&
+    Math.abs(a.top - b.top) < 0.5 &&
+    Math.abs(a.arrowX1 - b.arrowX1) < 0.5 &&
+    Math.abs(a.arrowY1 - b.arrowY1) < 0.5 &&
+    Math.abs(a.arrowX2 - b.arrowX2) < 0.5 &&
+    Math.abs(a.arrowY2 - b.arrowY2) < 0.5 &&
+    a.side === b.side
+  );
+}
+
+/**
+ * A non-modal callout pinned to a live element: a small card plus a pointer
+ * drawn to the anchor's centre.
+ *
+ * Deliberately *not* a focus trap and not backed by a scrim — the whole point
+ * is to teach an interaction the user then performs on the element underneath,
+ * so everything except the card itself stays `pointer-events: none`. The card
+ * hides (without dismissing) whenever the anchor is missing or scrolled out of
+ * view, and re-appears when it comes back.
+ */
+export function CoachMark({
+  anchor,
+  icon,
+  title,
+  description,
+  onDismiss,
+  onAction,
+  testId,
+}: CoachMarkProps) {
+  const locale = useLocale();
+  const strings = STRINGS[locale];
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<CoachMarkPlacement | null>(null);
+
+  const resolve = anchor.resolve;
+  const repositionEvents = anchor.repositionEvents;
+  const actionSelector = anchor.actionSelector;
+
+  // ── Placement, kept in sync with the live chart ──────────────────────────
+  useLayoutEffect(() => {
+    let frame = 0;
+
+    const measure = () => {
+      frame = 0;
+      const card = cardRef.current;
+      const element = resolve();
+      if (!card || !element) {
+        setPlacement((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const viewport = viewportSize();
+      const rect = element.getBoundingClientRect();
+      if (!isAnchorOnScreen(rect, viewport)) {
+        setPlacement((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const size: Size = {
+        width: card.offsetWidth || CARD_WIDTH,
+        height: card.offsetHeight,
+      };
+      const next = computeCoachMarkPlacement(rect, size, viewport);
+      setPlacement((prev) => (samePlacement(prev, next) ? prev : next));
+    };
+
+    const schedule = () => {
+      if (frame !== 0) return;
+      frame = requestAnimationFrame(measure);
+    };
+
+    measure();
+
+    window.addEventListener('resize', schedule);
+    // Capture phase so scrolling inside any container (not just the document)
+    // repositions the pointer.
+    window.addEventListener('scroll', schedule, { capture: true, passive: true });
+    for (const event of repositionEvents ?? []) window.addEventListener(event, schedule);
+
+    // d3 zoom/pan rewrites `transform` on the zoom group and on every point;
+    // re-renders replace the point nodes outright. Watching both, throttled to
+    // one recompute per frame, keeps the pointer glued to its point.
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ['transform', 'style', 'data-has-trace', 'data-benchmark-type'],
+      childList: true,
+      subtree: true,
+    });
+
+    return () => {
+      if (frame !== 0) cancelAnimationFrame(frame);
+      observer.disconnect();
+      window.removeEventListener('resize', schedule);
+      window.removeEventListener('scroll', schedule, { capture: true });
+      for (const event of repositionEvents ?? []) window.removeEventListener(event, schedule);
+    };
+  }, [resolve, repositionEvents]);
+
+  // ── Escape to dismiss ────────────────────────────────────────────────────
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onDismissRef.current();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  // ── Clicking the thing the tip is about counts as taking the action ──────
+  const onActionRef = useRef(onAction);
+  onActionRef.current = onAction;
+  useEffect(() => {
+    if (!actionSelector) return;
+    const handler = (event: MouseEvent) => {
+      const target = event.target as Element | null;
+      if (target?.closest?.(actionSelector)) onActionRef.current?.();
+    };
+    // Capture phase: d3's own point handler calls stopPropagation().
+    document.addEventListener('click', handler, true);
+    return () => document.removeEventListener('click', handler, true);
+  }, [actionSelector]);
+
+  const handleDismiss = useCallback(() => onDismissRef.current(), []);
+
+  const visible = placement !== null;
+  const titleId = testId ? `${testId}-title` : undefined;
+  const descriptionId = testId ? `${testId}-description` : undefined;
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-50"
+      // The card is measured before it is ever placed, so it must be in the
+      // DOM from the first paint — `aria-hidden` keeps that measuring pass out
+      // of the accessibility tree.
+      aria-hidden={visible ? undefined : 'true'}
+      data-testid={testId ? `${testId}-layer` : undefined}
+    >
+      {visible && (
+        <svg
+          className="pointer-events-none absolute inset-0 size-full overflow-visible"
+          aria-hidden="true"
+        >
+          <defs>
+            <marker
+              id="coach-mark-arrowhead"
+              markerWidth="7"
+              markerHeight="7"
+              refX="5.5"
+              refY="3"
+              orient="auto"
+            >
+              <path d="M0,0 L6,3 L0,6 Z" fill="var(--brand)" />
+            </marker>
+          </defs>
+          {(() => {
+            const dx = placement.arrowX2 - placement.arrowX1;
+            const dy = placement.arrowY2 - placement.arrowY1;
+            const length = Math.hypot(dx, dy) || 1;
+            const scale = Math.max(0, length - ARROW_STANDOFF) / length;
+            return (
+              <line
+                data-testid={testId ? `${testId}-pointer` : undefined}
+                x1={placement.arrowX1}
+                y1={placement.arrowY1}
+                x2={placement.arrowX1 + dx * scale}
+                y2={placement.arrowY1 + dy * scale}
+                stroke="var(--brand)"
+                strokeWidth={2}
+                strokeLinecap="round"
+                markerEnd="url(#coach-mark-arrowhead)"
+              />
+            );
+          })()}
+          {/* Pulsing ring on the anchor itself. Unlike the pointer line —
+              which stops short so its arrowhead doesn't cover the point — this
+              is centred exactly on what the tip is about. */}
+          <circle
+            data-testid={testId ? `${testId}-target` : undefined}
+            cx={placement.arrowX2}
+            cy={placement.arrowY2}
+            r={11}
+            fill="none"
+            stroke="var(--brand)"
+            strokeWidth={2}
+            className="animate-ping"
+            style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
+          />
+        </svg>
+      )}
+
+      <div
+        ref={cardRef}
+        data-testid={testId}
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className={`pointer-events-auto absolute w-72 rounded-lg border border-brand/50 bg-card p-4 shadow-lg transition-opacity duration-200 ${
+          visible ? 'opacity-100' : 'opacity-0'
+        }`}
+        style={{
+          left: placement?.left ?? 0,
+          top: placement?.top ?? 0,
+          visibility: visible ? undefined : 'hidden',
+        }}
+      >
+        <button
+          type="button"
+          onClick={handleDismiss}
+          className="absolute right-2 top-2 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          aria-label={strings.close}
+          data-testid={testId ? `${testId}-dismiss` : undefined}
+        >
+          <X className="size-3.5" />
+        </button>
+        <div className="flex items-start gap-3 pr-4">
+          <span className="mt-0.5 shrink-0 [&_svg]:size-4">{icon}</span>
+          <div className="flex flex-col gap-1">
+            <p id={titleId} className="text-sm font-semibold text-foreground">
+              {title}
+            </p>
+            <p id={descriptionId} className="text-xs text-muted-foreground">
+              {description}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/lib/d3-chart/chart-setup.ts
+++ b/packages/app/src/lib/d3-chart/chart-setup.ts
@@ -89,6 +89,9 @@ export function setupChartStructure(
 
     let zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>;
     if (clipContent) {
+      // `plot-bounds.ts` reconstructs this rect in viewport coordinates (from
+      // the .chart-root translate plus these dimensions) so callers can tell
+      // whether a point is actually visible. Keep the two in step.
       defs
         .append('clipPath')
         .attr('id', `clip-${config.chartId}`)

--- a/packages/app/src/lib/d3-chart/plot-bounds.test.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { plotBounds } from './plot-bounds';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+function svgEl<K extends string>(tag: K): Element {
+  return document.createElementNS(SVG_NS, tag);
+}
+
+function stubBox(element: Element, left: number, top: number, width: number, height: number) {
+  element.getBoundingClientRect = () =>
+    ({
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+/**
+ * The skeleton `setupChart` builds: a root group translated by the margins,
+ * and a clip rect sized to the plot area inside them.
+ */
+function renderChartSvg({
+  box = { left: 100, top: 200, width: 800, height: 600 },
+  transform = 'translate(60,24)' as string | null,
+  clip = { width: 730, height: 516 } as { width: number; height: number } | null,
+} = {}): Element {
+  const svg = svgEl('svg');
+  stubBox(svg, box.left, box.top, box.width, box.height);
+
+  if (clip) {
+    const defs = svgEl('defs');
+    const clipPath = svgEl('clipPath');
+    const rect = svgEl('rect');
+    rect.setAttribute('width', String(clip.width));
+    rect.setAttribute('height', String(clip.height));
+    clipPath.append(rect);
+    defs.append(clipPath);
+    svg.append(defs);
+  }
+
+  const root = svgEl('g');
+  root.setAttribute('class', 'chart-root');
+  if (transform !== null) root.setAttribute('transform', transform);
+  svg.append(root);
+
+  document.body.append(svg);
+  return svg;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('plotBounds', () => {
+  it('insets the SVG box by the chart margins', () => {
+    // 60px left / 24px top margins are the inference scatter's axis gutters.
+    const svg = renderChartSvg();
+
+    expect(plotBounds(svg)).toEqual({
+      left: 160,
+      top: 224,
+      right: 890,
+      bottom: 740,
+    });
+  });
+
+  it('is strictly smaller than the SVG box it is derived from', () => {
+    const svg = renderChartSvg();
+    const box = svg.getBoundingClientRect();
+    const bounds = plotBounds(svg)!;
+
+    expect(bounds.left).toBeGreaterThan(box.left);
+    expect(bounds.top).toBeGreaterThan(box.top);
+    expect(bounds.right).toBeLessThan(box.right);
+    expect(bounds.bottom).toBeLessThan(box.bottom);
+  });
+
+  it('accepts a space-separated translate', () => {
+    const svg = renderChartSvg({ transform: 'translate(60 24)' });
+    expect(plotBounds(svg)?.left).toBe(160);
+  });
+
+  it('returns null when the chart clips nothing', () => {
+    // clipContent: false — the caller should fall back to the SVG box, since
+    // in that mode nothing is painted away.
+    expect(plotBounds(renderChartSvg({ clip: null }))).toBeNull();
+  });
+
+  it('returns null before the skeleton has rendered', () => {
+    const svg = svgEl('svg');
+    stubBox(svg, 0, 0, 800, 600);
+    expect(plotBounds(svg)).toBeNull();
+  });
+
+  it('returns null for a missing or unreadable transform', () => {
+    expect(plotBounds(renderChartSvg({ transform: null }))).toBeNull();
+    expect(plotBounds(renderChartSvg({ transform: 'scale(2)' }))).toBeNull();
+  });
+
+  it('returns null for a degenerate clip rect', () => {
+    expect(plotBounds(renderChartSvg({ clip: { width: 0, height: 516 } }))).toBeNull();
+  });
+});

--- a/packages/app/src/lib/d3-chart/plot-bounds.test.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.test.ts
@@ -28,28 +28,46 @@ function stubBox(element: Element, left: number, top: number, width: number, hei
  * The skeleton `setupChart` builds: a root group translated by the margins,
  * and a clip rect sized to the plot area inside them.
  */
+const CLIP_ID = 'clip-scatter-graph';
+
 function renderChartSvg({
   box = { left: 100, top: 200, width: 800, height: 600 },
   transform = 'translate(60,24)' as string | null,
   clip = { width: 730, height: 516 } as { width: number; height: number } | null,
+  /** A same-SVG clipPath belonging to something else (overflow continuations). */
+  decoyClip = false,
 } = {}): Element {
   const svg = svgEl('svg');
   stubBox(svg, box.left, box.top, box.width, box.height);
 
+  const defs = svgEl('defs');
+  if (decoyClip) {
+    const other = svgEl('clipPath');
+    other.setAttribute('id', 'some-other-clip');
+    const otherRect = svgEl('rect');
+    otherRect.setAttribute('width', '1');
+    otherRect.setAttribute('height', '1');
+    other.append(otherRect);
+    defs.append(other);
+  }
   if (clip) {
-    const defs = svgEl('defs');
     const clipPath = svgEl('clipPath');
+    clipPath.setAttribute('id', CLIP_ID);
     const rect = svgEl('rect');
     rect.setAttribute('width', String(clip.width));
     rect.setAttribute('height', String(clip.height));
     clipPath.append(rect);
     defs.append(clipPath);
-    svg.append(defs);
   }
+  svg.append(defs);
 
   const root = svgEl('g');
   root.setAttribute('class', 'chart-root');
   if (transform !== null) root.setAttribute('transform', transform);
+  const zoomGroup = svgEl('g');
+  zoomGroup.setAttribute('class', 'zoom-group');
+  if (clip) zoomGroup.setAttribute('clip-path', `url(#${CLIP_ID})`);
+  root.append(zoomGroup);
   svg.append(root);
 
   document.body.append(svg);
@@ -89,10 +107,23 @@ describe('plotBounds', () => {
     expect(plotBounds(svg)?.left).toBe(160);
   });
 
+  it("resolves the chart's own clipPath, not whichever one comes first", () => {
+    // The overflow-continuation layer defines a clipPath per group, so
+    // "the first clipPath in the SVG" is not a safe assumption.
+    const svg = renderChartSvg({ decoyClip: true });
+    expect(plotBounds(svg)).toEqual({ left: 160, top: 224, right: 890, bottom: 740 });
+  });
+
   it('returns null when the chart clips nothing', () => {
-    // clipContent: false — the caller should fall back to the SVG box, since
-    // in that mode nothing is painted away.
+    // clipContent: false — no clip-path on the zoom group, so nothing is
+    // painted away and the caller should fall back to the SVG box.
     expect(plotBounds(renderChartSvg({ clip: null }))).toBeNull();
+  });
+
+  it('returns null when the referenced clipPath is missing', () => {
+    const svg = renderChartSvg();
+    svg.querySelector('clipPath')!.remove();
+    expect(plotBounds(svg)).toBeNull();
   });
 
   it('returns null before the skeleton has rendered', () => {

--- a/packages/app/src/lib/d3-chart/plot-bounds.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.ts
@@ -25,6 +25,8 @@ export interface PlotBounds {
 
 /** `translate(x,y)` as written by `setupChart` — also tolerates space separators. */
 const TRANSLATE = /translate\(\s*(?<x>-?[\d.]+)[\s,]+(?<y>-?[\d.]+)\s*\)/u;
+/** The `clip-path="url(#…)"` reference `setupChart` puts on the zoom group. */
+const CLIP_URL = /url\(\s*#(?<id>[^)\s]+)\s*\)/u;
 
 /**
  * @param svg the chart's `<svg>` element (`[data-testid="d3-chart-svg"]`).
@@ -35,8 +37,19 @@ const TRANSLATE = /translate\(\s*(?<x>-?[\d.]+)[\s,]+(?<y>-?[\d.]+)\s*\)/u;
  */
 export function plotBounds(svg: Element): PlotBounds | null {
   const root = svg.querySelector('.chart-root');
-  const clip = svg.querySelector('defs clipPath rect');
-  if (!root || !clip) return null;
+  const zoomGroup = svg.querySelector('.zoom-group');
+  if (!root || !zoomGroup) return null;
+
+  // Follow the zoom group's own reference rather than assuming the chart's is
+  // the only clipPath in the SVG — the overflow-continuation layer defines one
+  // per group, and future layers may too. No reference means `clipContent:
+  // false`, i.e. nothing is being clipped away.
+  const clipId = CLIP_URL.exec(zoomGroup.getAttribute('clip-path') ?? '')?.groups?.id;
+  if (!clipId) return null;
+  const clip = [...svg.querySelectorAll('clipPath')]
+    .find((candidate) => candidate.id === clipId)
+    ?.querySelector('rect');
+  if (!clip) return null;
 
   const translate = TRANSLATE.exec(root.getAttribute('transform') ?? '')?.groups;
   const width = Number(clip.getAttribute('width'));

--- a/packages/app/src/lib/d3-chart/plot-bounds.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.ts
@@ -1,0 +1,52 @@
+/**
+ * Viewport-space bounds of a chart's clip region.
+ *
+ * `setupChart` clips the zoom group to a rect covering the plot area only:
+ * `(0, 0, width, height)` inside `.chart-root`, which is itself translated by
+ * the chart margins. On the inference scatter those margins are 60px on the
+ * left and bottom — the axis gutters — so the SVG's own box is a sizeable
+ * superset of what the user can actually see.
+ *
+ * A zoom pushes points out of the plot, where the clip path paints them away
+ * while `getBoundingClientRect()` keeps reporting perfectly ordinary geometry.
+ * Anything asking "can the user see this point?" therefore has to compare
+ * against this rect, never against the SVG box.
+ *
+ * Deliberately free of d3 so callers outside the chart bundle (the anchored
+ * nudge) can import it without pulling d3 onto pages that have no chart.
+ */
+
+export interface PlotBounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** `translate(x,y)` as written by `setupChart` — also tolerates space separators. */
+const TRANSLATE = /translate\(\s*(?<x>-?[\d.]+)[\s,]+(?<y>-?[\d.]+)\s*\)/u;
+
+/**
+ * @param svg the chart's `<svg>` element (`[data-testid="d3-chart-svg"]`).
+ * @returns the clip region in viewport coordinates, or `null` when the chart
+ *   does not clip its content (`clipContent: false`) or has not rendered its
+ *   skeleton yet. A `null` result means "nothing is being clipped away", so
+ *   callers should fall back to the SVG box rather than reject everything.
+ */
+export function plotBounds(svg: Element): PlotBounds | null {
+  const root = svg.querySelector('.chart-root');
+  const clip = svg.querySelector('defs clipPath rect');
+  if (!root || !clip) return null;
+
+  const translate = TRANSLATE.exec(root.getAttribute('transform') ?? '')?.groups;
+  const width = Number(clip.getAttribute('width'));
+  const height = Number(clip.getAttribute('height'));
+  if (!translate || !(width > 0) || !(height > 0)) return null;
+
+  // No viewBox on the chart SVG, so one user unit is one CSS pixel and the
+  // margins can be added to the client rect directly.
+  const box = svg.getBoundingClientRect();
+  const left = box.left + Number(translate.x);
+  const top = box.top + Number(translate.y);
+  return { left, top, right: left + width, bottom: top + height };
+}

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
@@ -50,24 +50,55 @@ function stubBox(element: Element, left: number, top: number, width: number, hei
     }) as DOMRect;
 }
 
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+interface ChartSvgSpec {
+  /** The `<svg>` box — includes the axis gutters, so bigger than the plot. */
+  box: { left: number; top: number; width: number; height: number };
+  /** `.chart-root` translate, i.e. the left/top chart margins. */
+  margin: { left: number; top: number };
+  /** The clipPath rect `setupChart` sizes to the plot area. */
+  clip: { width: number; height: number };
+}
+
+/**
+ * The chart SVG skeleton `setupChart` builds: a root group translated by the
+ * margins plus a clip rect covering the plot area only. Built for real (rather
+ * than stubbing a single box) because the gap between the SVG box and the clip
+ * region is exactly what the clipping tests are about.
+ */
+function appendChartSvg(chart: Element, spec: ChartSvgSpec): void {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.dataset.testid = 'd3-chart-svg';
+  stubBox(svg, spec.box.left, spec.box.top, spec.box.width, spec.box.height);
+
+  const defs = document.createElementNS(SVG_NS, 'defs');
+  const clipPath = document.createElementNS(SVG_NS, 'clipPath');
+  const clipRect = document.createElementNS(SVG_NS, 'rect');
+  clipRect.setAttribute('width', String(spec.clip.width));
+  clipRect.setAttribute('height', String(spec.clip.height));
+  clipPath.append(clipRect);
+  defs.append(clipPath);
+  svg.append(defs);
+
+  const root = document.createElementNS(SVG_NS, 'g');
+  root.setAttribute('class', 'chart-root');
+  root.setAttribute('transform', `translate(${spec.margin.left},${spec.margin.top})`);
+  svg.append(root);
+
+  chart.append(svg);
+}
+
 /**
  * Build a 1000x600 chart container with the given points and return them in
- * order. When `plot` is set, an inner `d3-chart-svg` with that box stands in
- * for the clipped plot area.
+ * order. When `svgSpec` is set, a real chart SVG skeleton is added so the
+ * resolver can work out the clip region.
  */
-function renderChart(
-  points: PointSpec[],
-  plot?: { left: number; top: number; width: number; height: number },
-): Element[] {
+function renderChart(points: PointSpec[], svgSpec?: ChartSvgSpec): Element[] {
   document.body.innerHTML = '<div data-testid="scatter-graph"></div>';
   const chart = document.querySelector('[data-testid="scatter-graph"]')!;
   stubBox(chart, 0, 0, 1000, 600);
-  if (plot) {
-    const svg = document.createElement('div');
-    svg.dataset.testid = 'd3-chart-svg';
-    chart.append(svg);
-    stubBox(svg, plot.left, plot.top, plot.width, plot.height);
-  }
+  if (svgSpec) appendChartSvg(chart, svgSpec);
 
   return points.map((spec) => {
     const element = document.createElement('div');
@@ -192,27 +223,60 @@ describe('resolveAgenticPointAnchor', () => {
     expect(resolveAgenticPointAnchor()).toBe(group);
   });
 
+  // The scatter's real geometry: a 900x520 SVG with 60px left / 24px top
+  // margins, clipped to the 830x436 plot inside them. The left 60px and the
+  // bottom 60px of the SVG are axis gutters — inside the SVG box, outside the
+  // clip.
+  const CHART_SVG = {
+    box: { left: 40, top: 40, width: 900, height: 520 },
+    margin: { left: 60, top: 24 },
+    clip: { width: 830, height: 436 },
+  };
+
   it('ignores points that zooming has pushed outside the clipped plot area', () => {
     // Outside the plot the chart's clip path hides a point, but its bounding
-    // box stays perfectly ordinary — only the plot bounds rule it out.
-    renderChart([{ left: 900, top: 60 }], { left: 100, top: 100, width: 600, height: 400 });
+    // box stays perfectly ordinary — only the clip region rules it out.
+    renderChart([{ left: 960, top: 300 }], CHART_SVG);
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it.each([
+    ['left gutter, over the y-axis labels', { left: 70, top: 300 }],
+    ['bottom gutter, under the x-axis labels', { left: 500, top: 505 }],
+  ])('ignores a zoomed point parked in the %s', (_label, spec) => {
+    // Regression: this used to be checked against the SVG's own box, which
+    // includes the 60px axis margins — so a point sitting over the axis labels
+    // was painted away by the clip path yet still accepted, aiming the pointer
+    // at something invisible.
+    renderChart([spec], CHART_SVG);
+    const svgBox = document.querySelector('[data-testid="d3-chart-svg"]')!.getBoundingClientRect();
+    // Guard the guard: the point really is inside the SVG, so this is not
+    // vacuously passing because it fell off the element altogether.
+    expect(spec.left).toBeGreaterThan(svgBox.left);
+    expect(spec.left).toBeLessThan(svgBox.right);
+    expect(spec.top).toBeGreaterThan(svgBox.top);
+    expect(spec.top).toBeLessThan(svgBox.bottom);
+
     expect(resolveAgenticPointAnchor()).toBeNull();
   });
 
   it('still anchors to points that remain inside the plot area', () => {
     const [inside] = renderChart(
       [
-        { left: 380, top: 280 },
-        { left: 950, top: 60 },
+        { left: 400, top: 300 },
+        { left: 960, top: 300 },
       ],
-      {
-        left: 100,
-        top: 100,
-        width: 600,
-        height: 400,
-      },
+      CHART_SVG,
     );
     expect(resolveAgenticPointAnchor()).toBe(inside);
+  });
+
+  it('falls back to the SVG box when the chart clips nothing', () => {
+    // clipContent: false leaves no clipPath, so nothing is painted away and
+    // the SVG box is the honest visibility test — not a reason to reject every
+    // point.
+    const [only] = renderChart([{ left: 70, top: 300 }]);
+    expect(resolveAgenticPointAnchor()).toBe(only);
   });
 
   it('bails out cheaply while the whole chart is below the fold', () => {

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
@@ -72,8 +72,10 @@ function appendChartSvg(chart: Element, spec: ChartSvgSpec): void {
   svg.dataset.testid = 'd3-chart-svg';
   stubBox(svg, spec.box.left, spec.box.top, spec.box.width, spec.box.height);
 
+  const clipId = 'clip-scatter-graph';
   const defs = document.createElementNS(SVG_NS, 'defs');
   const clipPath = document.createElementNS(SVG_NS, 'clipPath');
+  clipPath.setAttribute('id', clipId);
   const clipRect = document.createElementNS(SVG_NS, 'rect');
   clipRect.setAttribute('width', String(spec.clip.width));
   clipRect.setAttribute('height', String(spec.clip.height));
@@ -84,6 +86,10 @@ function appendChartSvg(chart: Element, spec: ChartSvgSpec): void {
   const root = document.createElementNS(SVG_NS, 'g');
   root.setAttribute('class', 'chart-root');
   root.setAttribute('transform', `translate(${spec.margin.left},${spec.margin.top})`);
+  const zoomGroup = document.createElementNS(SVG_NS, 'g');
+  zoomGroup.setAttribute('class', 'zoom-group');
+  zoomGroup.setAttribute('clip-path', `url(#${clipId})`);
+  root.append(zoomGroup);
   svg.append(root);
 
   chart.append(svg);

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  AGENTIC_POINT_ACTION_SELECTOR,
+  AGENTIC_POINT_SELECTOR,
+  resolveAgenticPointAnchor,
+} from './agentic-point-coach-mark';
+
+// jsdom gives every element a zero-size box, so the resolver's on-screen check
+// would reject everything. Stub the geometry each test cares about instead.
+function stubRect(element: Element, left: number, top: number, size = 12): void {
+  element.getBoundingClientRect = () =>
+    ({
+      left,
+      top,
+      width: size,
+      height: size,
+      right: left + size,
+      bottom: top + size,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+interface PointSpec {
+  left: number;
+  top: number;
+  benchmarkType?: string;
+  hasTrace?: boolean;
+  hidden?: boolean;
+  overlay?: boolean;
+  /** Add the marker child the real chart renders inside every `.dot-group`. */
+  withShape?: boolean;
+}
+
+function stubBox(element: Element, left: number, top: number, width: number, height: number) {
+  element.getBoundingClientRect = () =>
+    ({
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
+/**
+ * Build a 1000x600 chart container with the given points and return them in
+ * order. When `plot` is set, an inner `d3-chart-svg` with that box stands in
+ * for the clipped plot area.
+ */
+function renderChart(
+  points: PointSpec[],
+  plot?: { left: number; top: number; width: number; height: number },
+): Element[] {
+  document.body.innerHTML = '<div data-testid="scatter-graph"></div>';
+  const chart = document.querySelector('[data-testid="scatter-graph"]')!;
+  stubBox(chart, 0, 0, 1000, 600);
+  if (plot) {
+    const svg = document.createElement('div');
+    svg.dataset.testid = 'd3-chart-svg';
+    chart.append(svg);
+    stubBox(svg, plot.left, plot.top, plot.width, plot.height);
+  }
+
+  return points.map((spec) => {
+    const element = document.createElement('div');
+    element.className = spec.overlay ? 'unofficial-overlay-pt' : 'dot-group';
+    if (!spec.overlay) {
+      element.dataset.benchmarkType = spec.benchmarkType ?? 'agentic_traces';
+    }
+    if (spec.hasTrace) element.dataset.hasTrace = 'true';
+    if (spec.hidden) element.style.opacity = '0';
+    if (spec.withShape) {
+      const shape = document.createElement('div');
+      shape.className = 'visible-shape';
+      element.append(shape);
+      stubRect(shape, spec.left + 2, spec.top + 2, 8);
+    }
+    chart.append(element);
+    stubRect(element, spec.left, spec.top);
+    return element;
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('AGENTIC_POINT_SELECTOR', () => {
+  it('matches only official agentic points inside the scatter chart', () => {
+    renderChart([
+      { left: 100, top: 100 },
+      { left: 200, top: 100, benchmarkType: 'single_turn' },
+      { left: 300, top: 100, overlay: true },
+    ]);
+    const matched = [...document.querySelectorAll<HTMLElement>(AGENTIC_POINT_SELECTOR)];
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].dataset.benchmarkType).toBe('agentic_traces');
+  });
+
+  it('does not reach into the GPU comparison charts', () => {
+    document.body.innerHTML =
+      '<div data-testid="gpu-graph">' +
+      '<div class="dot-group" data-benchmark-type="agentic_traces"></div>' +
+      '</div>';
+    expect(document.querySelectorAll(AGENTIC_POINT_SELECTOR)).toHaveLength(0);
+  });
+});
+
+describe('AGENTIC_POINT_ACTION_SELECTOR', () => {
+  it('treats a click on an official OR an overlay point as taking the action', () => {
+    const [official, overlay] = renderChart([
+      { left: 100, top: 100 },
+      { left: 200, top: 100, overlay: true },
+    ]);
+
+    expect(official.closest(AGENTIC_POINT_ACTION_SELECTOR)).toBe(official);
+    expect(overlay.closest(AGENTIC_POINT_ACTION_SELECTOR)).toBe(overlay);
+  });
+});
+
+describe('resolveAgenticPointAnchor', () => {
+  it('returns null when the chart has not rendered', () => {
+    document.body.innerHTML = '';
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it('returns null when the chart has rendered but has no agentic points', () => {
+    renderChart([{ left: 100, top: 100, benchmarkType: 'single_turn' }]);
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it('picks the agentic point nearest the chart centre', () => {
+    // Chart centre is (500, 300) — the middle point is closest.
+    const [, middle] = renderChart([
+      { left: 60, top: 60 },
+      { left: 480, top: 280 },
+      { left: 900, top: 540 },
+    ]);
+    expect(resolveAgenticPointAnchor()).toBe(middle);
+  });
+
+  it('prefers a point with stored telemetry over a closer one without', () => {
+    const [, withTrace] = renderChart([
+      { left: 490, top: 290 },
+      { left: 300, top: 200, hasTrace: true },
+    ]);
+    expect(resolveAgenticPointAnchor()).toBe(withTrace);
+  });
+
+  it('falls back to any agentic point while the trace lookup is still pending', () => {
+    const [only] = renderChart([{ left: 480, top: 280 }]);
+    expect(resolveAgenticPointAnchor()).toBe(only);
+  });
+
+  it('skips points hidden by a legend or precision filter', () => {
+    const [, visible] = renderChart([
+      { left: 500, top: 300, hidden: true },
+      { left: 200, top: 150 },
+    ]);
+    expect(resolveAgenticPointAnchor()).toBe(visible);
+  });
+
+  it('never anchors to an unofficial-run overlay marker', () => {
+    // Overlay runs have no stored trace, so their tooltip offers no
+    // "View charts" link — pointing at one would teach a dead end.
+    renderChart([{ left: 500, top: 300, overlay: true }]);
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it('points at the marker inside the group, not the label-inflated group box', () => {
+    // A `.dot-group` box also spans the hit area and the C=/DEP label above the
+    // dot, so its centre can sit well off the dot itself.
+    const [group] = renderChart([{ left: 480, top: 280, withShape: true }]);
+    const shape = group.querySelector('.visible-shape');
+
+    expect(shape).not.toBeNull();
+    expect(resolveAgenticPointAnchor()).toBe(shape);
+  });
+
+  it('falls back to the group when it has no marker child yet', () => {
+    const [group] = renderChart([{ left: 480, top: 280 }]);
+    expect(resolveAgenticPointAnchor()).toBe(group);
+  });
+
+  it('ignores points that zooming has pushed outside the clipped plot area', () => {
+    // Outside the plot the chart's clip path hides a point, but its bounding
+    // box stays perfectly ordinary — only the plot bounds rule it out.
+    renderChart([{ left: 900, top: 60 }], { left: 100, top: 100, width: 600, height: 400 });
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it('still anchors to points that remain inside the plot area', () => {
+    const [inside] = renderChart(
+      [
+        { left: 380, top: 280 },
+        { left: 950, top: 60 },
+      ],
+      {
+        left: 100,
+        top: 100,
+        width: 600,
+        height: 400,
+      },
+    );
+    expect(resolveAgenticPointAnchor()).toBe(inside);
+  });
+
+  it('bails out cheaply while the whole chart is below the fold', () => {
+    // The chart usually starts off-screen, and this runs on every scroll
+    // event — so an off-screen chart must be rejected without measuring points.
+    const [only] = renderChart([{ left: 480, top: 280 }]);
+    const chart = document.querySelector('[data-testid="scatter-graph"]')!;
+    stubBox(chart, 0, 5000, 1000, 600);
+    const measure = vi.spyOn(only, 'getBoundingClientRect');
+
+    expect(resolveAgenticPointAnchor()).toBeNull();
+    expect(measure, 'no per-point layout reads').not.toHaveBeenCalled();
+  });
+
+  it('returns null when every point is scrolled out of the viewport', () => {
+    renderChart([
+      { left: 400, top: -900 },
+      { left: 400, top: 4000 },
+    ]);
+    expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+});

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
@@ -1,0 +1,117 @@
+/**
+ * Anchor resolution for the "click a point for server metrics and logs"
+ * coach mark on the agentic inference chart.
+ *
+ * The affordance it teaches: clicking an agentic scatter point pins its
+ * tooltip, and the pinned tooltip carries a "View charts" link to
+ * `/inference/agentic/[id]`. Nothing on the chart hints at that, so first-time
+ * visitors never find it.
+ */
+
+import { isAnchorOnScreen, isAnchorWithin, viewportSize } from './anchor';
+
+export const AGENTIC_COACH_MARK_STORAGE_KEY = 'inferencex-agentic-point-coach-mark-dismissed';
+
+/**
+ * Dispatched by ScatterGraph after every full D3 render.
+ *
+ * The coach mark needs a painted point to anchor to, and the chart paints
+ * asynchronously (availability → benchmarks → derived metrics). A plain timer
+ * would fire into an empty chart and give up; re-attempting on each render
+ * means the tip appears as soon as there is something to point at. Exported so
+ * the dispatch site imports a stable constant, mirroring `GRADIENT_NUDGE_EVENT`.
+ */
+export const SCATTER_RENDERED_EVENT = 'inferencex:scatter-chart-rendered';
+
+/**
+ * Official agentic points on the main inference scatter chart.
+ *
+ * Deliberately scoped to `[data-testid="scatter-graph"]` and to `.dot-group`:
+ *  - the GPU comparison charts (`[data-testid="gpu-graph"]`) are a different
+ *    surface with their own layout;
+ *  - unofficial-run overlay markers are `.unofficial-overlay-pt`, and their
+ *    tooltip has no "View charts" link (overlay runs have no stored trace), so
+ *    pointing at one would teach a dead end.
+ */
+export const AGENTIC_POINT_SELECTOR =
+  '[data-testid="scatter-graph"] .dot-group[data-benchmark-type="agentic_traces"]';
+
+/**
+ * Clicking any scatter point — official or overlay — means the user found the
+ * interaction, so the coach mark has done its job.
+ */
+export const AGENTIC_POINT_ACTION_SELECTOR =
+  '[data-testid="scatter-graph"] .dot-group, [data-testid="scatter-graph"] .unofficial-overlay-pt';
+
+function isRendered(element: Element): boolean {
+  // Hidden points stay in the DOM at opacity 0 with pointer-events off (see
+  // the ScatterGraph decoration effect) — they are not clickable, so they are
+  // not anchor candidates either.
+  const style = getComputedStyle(element);
+  return style.opacity !== '0' && style.pointerEvents !== 'none' && style.visibility !== 'hidden';
+}
+
+/**
+ * Pick the agentic point to point at: the eligible candidate nearest the
+ * chart's centre, so the callout has room on every side and the choice is
+ * stable between re-renders of the same view.
+ *
+ * Prefers points with stored telemetry (`data-has-trace`) — those are the ones
+ * whose tooltip actually offers "View charts" — and falls back to any visible
+ * agentic point while the availability lookup is still in flight.
+ */
+export function resolveAgenticPointAnchor(): Element | null {
+  if (typeof document === 'undefined') return null;
+
+  const chart = document.querySelector('[data-testid="scatter-graph"]');
+  if (!chart) return null;
+
+  const viewport = viewportSize();
+  const chartRect = chart.getBoundingClientRect();
+  // Cheap bail-out. This runs on every scroll event (the chart usually starts
+  // below the fold), and the full scan is a layout read per point — so reject
+  // an off-screen chart with one rect read instead of a hundred.
+  if (
+    chartRect.bottom <= 0 ||
+    chartRect.top >= viewport.height ||
+    chartRect.right <= 0 ||
+    chartRect.left >= viewport.width
+  ) {
+    return null;
+  }
+
+  const eligible: { element: SVGGElement; hasTrace: boolean; distance: number }[] = [];
+  const chartCx = chartRect.left + chartRect.width / 2;
+  const chartCy = chartRect.top + chartRect.height / 2;
+  // Zooming pushes points outside the plot, where a clip path hides them —
+  // but they keep a perfectly ordinary bounding box, so the viewport check
+  // alone would happily point at one the user cannot see.
+  const plot =
+    chart.querySelector('[data-testid="d3-chart-svg"]')?.getBoundingClientRect() ?? chartRect;
+
+  for (const element of document.querySelectorAll<SVGGElement>(AGENTIC_POINT_SELECTOR)) {
+    if (!isRendered(element)) continue;
+    const rect = element.getBoundingClientRect();
+    if (!isAnchorOnScreen(rect, viewport)) continue;
+    if (!isAnchorWithin(rect, plot)) continue;
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    eligible.push({
+      element,
+      hasTrace: element.dataset.hasTrace === 'true',
+      distance: (cx - chartCx) ** 2 + (cy - chartCy) ** 2,
+    });
+  }
+
+  if (eligible.length === 0) return null;
+
+  const withTrace = eligible.filter((c) => c.hasTrace);
+  const pool = withTrace.length > 0 ? withTrace : eligible;
+  const chosen = pool.reduce((best, c) => (c.distance < best.distance ? c : best)).element;
+
+  // Point at the marker, not at the group: a `.dot-group` also contains the
+  // hit area and (when labels are on) the C=/DEP text above the dot, so its
+  // bounding box centre can sit well off the dot itself. Eligibility is still
+  // decided on the group, which is what carries opacity and pointer-events.
+  return chosen.querySelector('.visible-shape') ?? chosen;
+}

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
@@ -8,6 +8,8 @@
  * visitors never find it.
  */
 
+import { plotBounds } from '@/lib/d3-chart/plot-bounds';
+
 import { isAnchorOnScreen, isAnchorWithin, viewportSize } from './anchor';
 
 export const AGENTIC_COACH_MARK_STORAGE_KEY = 'inferencex-agentic-point-coach-mark-dismissed';
@@ -86,8 +88,13 @@ export function resolveAgenticPointAnchor(): Element | null {
   // Zooming pushes points outside the plot, where a clip path hides them —
   // but they keep a perfectly ordinary bounding box, so the viewport check
   // alone would happily point at one the user cannot see.
-  const plot =
-    chart.querySelector('[data-testid="d3-chart-svg"]')?.getBoundingClientRect() ?? chartRect;
+  //
+  // This has to be the clip region, NOT the SVG's own box: the box includes
+  // the 60px axis gutters, so a zoomed point parked over the y-axis labels is
+  // painted away yet still inside the SVG. `plotBounds` returns null only when
+  // the chart clips nothing, in which case the SVG box is the honest answer.
+  const svg = chart.querySelector('[data-testid="d3-chart-svg"]');
+  const plot = (svg && plotBounds(svg)) ?? svg?.getBoundingClientRect() ?? chartRect;
 
   for (const element of document.querySelectorAll<SVGGElement>(AGENTIC_POINT_SELECTOR)) {
     if (!isRendered(element)) continue;

--- a/packages/app/src/lib/nudges/anchor.test.ts
+++ b/packages/app/src/lib/nudges/anchor.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COACH_MARK_MARGIN,
+  anchorCentre,
+  computeCoachMarkPlacement,
+  isAnchorOnScreen,
+  isAnchorWithin,
+  type AnchorRect,
+  type Size,
+} from './anchor';
+
+const VIEWPORT: Size = { width: 1280, height: 800 };
+const CARD: Size = { width: 288, height: 96 };
+
+const point = (left: number, top: number, size = 12): AnchorRect => ({
+  left,
+  top,
+  width: size,
+  height: size,
+});
+
+function cardRect(placement: { left: number; top: number }, card: Size = CARD) {
+  return {
+    left: placement.left,
+    top: placement.top,
+    right: placement.left + card.width,
+    bottom: placement.top + card.height,
+  };
+}
+
+describe('anchorCentre', () => {
+  it('returns the geometric centre of the rect', () => {
+    expect(anchorCentre({ left: 100, top: 40, width: 20, height: 10 })).toEqual({ x: 110, y: 45 });
+  });
+});
+
+describe('isAnchorOnScreen', () => {
+  it('accepts a point well inside the viewport', () => {
+    expect(isAnchorOnScreen(point(600, 400), VIEWPORT)).toBe(true);
+  });
+
+  it('rejects a zero-size rect (element not rendered yet)', () => {
+    expect(isAnchorOnScreen({ left: 600, top: 400, width: 0, height: 0 }, VIEWPORT)).toBe(false);
+  });
+
+  it('rejects a point scrolled above the viewport', () => {
+    expect(isAnchorOnScreen(point(600, -400), VIEWPORT)).toBe(false);
+  });
+
+  it('rejects a point scrolled below the viewport', () => {
+    expect(isAnchorOnScreen(point(600, 1400), VIEWPORT)).toBe(false);
+  });
+
+  it('rejects a point hugging the viewport edge, where the pointer would run off-canvas', () => {
+    expect(isAnchorOnScreen(point(-2, 400), VIEWPORT)).toBe(false);
+    expect(isAnchorOnScreen(point(VIEWPORT.width - 4, 400), VIEWPORT)).toBe(false);
+  });
+});
+
+describe('isAnchorWithin', () => {
+  const plot = { left: 100, top: 100, right: 900, bottom: 500 };
+
+  it('accepts a point inside the bounds', () => {
+    expect(isAnchorWithin(point(500, 300), plot)).toBe(true);
+  });
+
+  it('rejects a point outside the bounds', () => {
+    // Zooming pushes points beyond the plot, where a clip path hides them —
+    // they keep an ordinary bounding box, so bounds are what rule them out.
+    expect(isAnchorWithin(point(1400, 300), plot)).toBe(false);
+    expect(isAnchorWithin(point(500, 40), plot)).toBe(false);
+  });
+
+  it('applies the inset to every edge', () => {
+    expect(isAnchorWithin(point(104, 300), plot)).toBe(true);
+    expect(isAnchorWithin(point(104, 300), plot, 40)).toBe(false);
+  });
+
+  it('rejects a zero-size rect', () => {
+    expect(isAnchorWithin({ left: 500, top: 300, width: 0, height: 0 }, plot)).toBe(false);
+  });
+});
+
+describe('computeCoachMarkPlacement', () => {
+  it('places the card below the anchor and centres it horizontally', () => {
+    const anchor = point(600, 300);
+    const placement = computeCoachMarkPlacement(anchor, CARD, VIEWPORT);
+    const { x: cx, y: cy } = anchorCentre(anchor);
+
+    expect(placement.side).toBe('below');
+    expect(placement.top).toBeGreaterThan(cy);
+    expect(placement.left + CARD.width / 2).toBeCloseTo(cx, 5);
+  });
+
+  it('flips above the anchor when the card would overflow the bottom', () => {
+    const anchor = point(600, 760);
+    const placement = computeCoachMarkPlacement(anchor, CARD, VIEWPORT);
+
+    expect(placement.side).toBe('above');
+    expect(cardRect(placement).bottom).toBeLessThan(anchorCentre(anchor).y);
+  });
+
+  it('always points at the anchor centre', () => {
+    const anchor = point(240, 180);
+    const placement = computeCoachMarkPlacement(anchor, CARD, VIEWPORT);
+    const centre = anchorCentre(anchor);
+
+    expect(placement.arrowX2).toBe(centre.x);
+    expect(placement.arrowY2).toBe(centre.y);
+  });
+
+  it('starts the pointer on the card edge that faces the anchor', () => {
+    const below = computeCoachMarkPlacement(point(600, 300), CARD, VIEWPORT);
+    expect(below.arrowY1).toBe(below.top);
+
+    const above = computeCoachMarkPlacement(point(600, 760), CARD, VIEWPORT);
+    expect(above.arrowY1).toBe(above.top + CARD.height);
+  });
+
+  it('keeps the pointer origin within the card, not at its corner', () => {
+    // An anchor hard against the left edge pushes the card right; the pointer
+    // must still start inside the card rather than beyond its corner.
+    const placement = computeCoachMarkPlacement(point(30, 300), CARD, VIEWPORT);
+    expect(placement.arrowX1).toBeGreaterThan(placement.left);
+    expect(placement.arrowX1).toBeLessThan(placement.left + CARD.width);
+  });
+
+  it.each([
+    ['top-left', point(30, 30)],
+    ['top-right', point(1240, 30)],
+    ['bottom-left', point(30, 770)],
+    ['bottom-right', point(1240, 770)],
+    ['centre', point(640, 400)],
+  ])('never renders off-canvas for a %s anchor', (_label, anchor) => {
+    const rect = cardRect(computeCoachMarkPlacement(anchor, CARD, VIEWPORT));
+
+    expect(rect.left).toBeGreaterThanOrEqual(COACH_MARK_MARGIN);
+    expect(rect.top).toBeGreaterThanOrEqual(COACH_MARK_MARGIN);
+    expect(rect.right).toBeLessThanOrEqual(VIEWPORT.width - COACH_MARK_MARGIN);
+    expect(rect.bottom).toBeLessThanOrEqual(VIEWPORT.height - COACH_MARK_MARGIN);
+  });
+
+  it('pins to the top-left margin when the card is larger than the viewport', () => {
+    const tiny: Size = { width: 320, height: 240 };
+    const placement = computeCoachMarkPlacement(point(160, 120), { width: 400, height: 400 }, tiny);
+
+    expect(placement.left).toBe(COACH_MARK_MARGIN);
+    expect(placement.top).toBe(COACH_MARK_MARGIN);
+  });
+
+  it('moves the card as the anchor moves (zoom / pan)', () => {
+    const before = computeCoachMarkPlacement(point(400, 300), CARD, VIEWPORT);
+    const after = computeCoachMarkPlacement(point(700, 300), CARD, VIEWPORT);
+
+    expect(after.left - before.left).toBeCloseTo(300, 5);
+    expect(after.arrowX2 - before.arrowX2).toBeCloseTo(300, 5);
+  });
+});

--- a/packages/app/src/lib/nudges/anchor.ts
+++ b/packages/app/src/lib/nudges/anchor.ts
@@ -1,0 +1,151 @@
+/**
+ * Geometry for anchored (coach-mark) nudges.
+ *
+ * Kept free of DOM APIs so the placement rules are unit-testable: callers pass
+ * plain rects measured with `getBoundingClientRect()` and get viewport
+ * coordinates back. The DOM-facing half — which element to point at — lives
+ * next to each nudge (see `agentic-point-coach-mark.ts`).
+ */
+
+export interface AnchorRect {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export type CoachMarkSide = 'above' | 'below';
+
+export interface CoachMarkPlacement {
+  /** Card top-left, in viewport coordinates. */
+  left: number;
+  top: number;
+  /** Pointer start — on the card edge facing the anchor. */
+  arrowX1: number;
+  arrowY1: number;
+  /** Pointer end — the anchor's centre. */
+  arrowX2: number;
+  arrowY2: number;
+  side: CoachMarkSide;
+}
+
+/** Gap between the anchor centre and the nearest card edge. */
+export const COACH_MARK_GAP = 52;
+/** Minimum distance the card keeps from every viewport edge. */
+export const COACH_MARK_MARGIN = 12;
+/** How far the pointer's card-edge end stays from the card's corners. */
+const ARROW_INSET = 20;
+/**
+ * A candidate must sit this far inside the viewport to be anchor-worthy — a
+ * point clipped by the plot edge would get a pointer running off-canvas.
+ */
+const ON_SCREEN_INSET = 24;
+
+/**
+ * Current viewport in CSS pixels. The one DOM touch in this module, kept here
+ * so the resolver and the renderer measure against exactly the same box.
+ * `clientWidth` excludes the scrollbar (what a fixed overlay is laid out
+ * against); the `innerWidth` fallback covers environments — jsdom, an
+ * unattached document — that report 0.
+ */
+export function viewportSize(): Size {
+  const root = document.documentElement;
+  return {
+    width: root.clientWidth || window.innerWidth,
+    height: root.clientHeight || window.innerHeight,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  // When the card is wider/taller than the space available, `min > max`; bias
+  // to `min` so the card stays pinned to the top-left edge rather than
+  // flipping to a negative offset.
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function anchorCentre(rect: AnchorRect): { x: number; y: number } {
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+export interface Bounds {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Does this anchor sit comfortably inside `bounds`? Rejects zero-size rects (a
+ * hidden or not-yet-rendered element) and anything whose centre falls outside,
+ * or within `inset` of, the edge.
+ */
+export function isAnchorWithin(rect: AnchorRect, bounds: Bounds, inset = 0): boolean {
+  if (rect.width <= 0 || rect.height <= 0) return false;
+  const { x, y } = anchorCentre(rect);
+  return (
+    x >= bounds.left + inset &&
+    x <= bounds.right - inset &&
+    y >= bounds.top + inset &&
+    y <= bounds.bottom - inset
+  );
+}
+
+/**
+ * Is this anchor usable right now? Off-screen anchors, and anchors hugging a
+ * viewport edge (where the pointer would run off-canvas), are not.
+ */
+export function isAnchorOnScreen(rect: AnchorRect, viewport: Size): boolean {
+  return isAnchorWithin(
+    rect,
+    { left: 0, top: 0, right: viewport.width, bottom: viewport.height },
+    ON_SCREEN_INSET,
+  );
+}
+
+/**
+ * Place the callout near the anchor without ever leaving the viewport.
+ *
+ * Prefers below the anchor (the chart's x-axis and its caption sit there, so
+ * the card covers less data) and flips above when it would overflow the
+ * bottom. Both axes are clamped, so a card can end up offset from the anchor —
+ * the pointer still connects the two, which is why the arrow is computed from
+ * the *placed* card rather than the desired position.
+ */
+export function computeCoachMarkPlacement(
+  rect: AnchorRect,
+  card: Size,
+  viewport: Size,
+): CoachMarkPlacement {
+  const { x: cx, y: cy } = anchorCentre(rect);
+
+  const belowTop = cy + COACH_MARK_GAP;
+  const fitsBelow = belowTop + card.height <= viewport.height - COACH_MARK_MARGIN;
+  const side: CoachMarkSide = fitsBelow ? 'below' : 'above';
+
+  const desiredTop = fitsBelow ? belowTop : cy - COACH_MARK_GAP - card.height;
+  const top = clamp(
+    desiredTop,
+    COACH_MARK_MARGIN,
+    Math.max(COACH_MARK_MARGIN, viewport.height - card.height - COACH_MARK_MARGIN),
+  );
+  const left = clamp(
+    cx - card.width / 2,
+    COACH_MARK_MARGIN,
+    Math.max(COACH_MARK_MARGIN, viewport.width - card.width - COACH_MARK_MARGIN),
+  );
+
+  const arrowX1 = clamp(
+    cx,
+    left + Math.min(ARROW_INSET, card.width / 2),
+    left + card.width - Math.min(ARROW_INSET, card.width / 2),
+  );
+  const arrowY1 = side === 'below' ? top : top + card.height;
+
+  return { left, top, arrowX1, arrowY1, arrowX2: cx, arrowY2: cy, side };
+}

--- a/packages/app/src/lib/nudges/policy.test.ts
+++ b/packages/app/src/lib/nudges/policy.test.ts
@@ -31,6 +31,12 @@ describe('dismissesOnAction', () => {
     expect(dismissesOnAction(makeNudge('modal'))).toBe(true);
   });
 
+  it('returns true for coach-mark by default', () => {
+    // Performing the interaction the coach mark teaches is the whole point —
+    // it must not keep pointing at the chart afterwards.
+    expect(dismissesOnAction(makeNudge('coach-mark'))).toBe(true);
+  });
+
   it('returns false for banner by default', () => {
     expect(dismissesOnAction(makeNudge('banner'))).toBe(false);
   });
@@ -41,6 +47,10 @@ describe('dismissesOnAction', () => {
 
   it('respects explicit dismissOnAction: false on a modal', () => {
     expect(dismissesOnAction(makeNudge('modal', false))).toBe(false);
+  });
+
+  it('respects explicit dismissOnAction: false on a coach-mark', () => {
+    expect(dismissesOnAction(makeNudge('coach-mark', false))).toBe(false);
   });
 
   it('respects explicit dismissOnAction: true on a banner', () => {

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import {
+  AGENTIC_COACH_MARK_STORAGE_KEY,
+  AGENTIC_POINT_ACTION_SELECTOR,
+} from './agentic-point-coach-mark';
+import { dismissesOnAction } from './policy';
 import { NUDGE_REGISTRY, TELEMETRY_TUTORIAL_STORAGE_KEY } from './registry';
 
 describe('NUDGE_REGISTRY integrity', () => {
@@ -15,7 +20,7 @@ describe('NUDGE_REGISTRY integrity', () => {
 
   it('every entry has a valid type', () => {
     for (const nudge of NUDGE_REGISTRY) {
-      expect(['toast', 'modal', 'banner']).toContain(nudge.type);
+      expect(['toast', 'modal', 'banner', 'coach-mark']).toContain(nudge.type);
     }
   });
 
@@ -62,6 +67,7 @@ describe('NUDGE_REGISTRY integrity', () => {
   it('contains the expected set of migrated nudges', () => {
     const ids = NUDGE_REGISTRY.map((n) => n.id).toSorted();
     expect(ids).toEqual([
+      'agentic-point-detail',
       'agentic-results-launch-banner',
       'agentic-results-launch-modal',
       'agentx-telemetry-tutorial',
@@ -93,6 +99,38 @@ describe('NUDGE_REGISTRY integrity', () => {
     // charts under test; a rename here has to be mirrored there.
     expect(tutorial?.storageKey).toBe(TELEMETRY_TUTORIAL_STORAGE_KEY);
     expect(TELEMETRY_TUTORIAL_STORAGE_KEY).toBe('inferencex-agentx-telemetry-tutorial-dismissed');
+  });
+
+  it('gives every coach mark an anchor to point at', () => {
+    for (const nudge of NUDGE_REGISTRY.filter((n) => n.type === 'coach-mark')) {
+      // Without one the engine has nothing to position against and skips it.
+      expect(typeof nudge.content.anchor?.resolve).toBe('function');
+    }
+  });
+
+  it('anchors the agentic coach mark to the inference chart, dismissed for good on a point click', () => {
+    const coachMark = NUDGE_REGISTRY.find((n) => n.id === 'agentic-point-detail');
+
+    expect(coachMark?.type).toBe('coach-mark');
+    // Lives on the dashboard engine, which `DashboardShell` deliberately does
+    // not mount on /inference/agentic/[id] — the page the tip points at.
+    expect(coachMark?.scope).toBe('dashboard');
+    // First visit only.
+    expect(coachMark?.dismissal.type).toBe('permanent');
+    expect(coachMark?.storageKey).toBe(AGENTIC_COACH_MARK_STORAGE_KEY);
+    // Clicking a point is engagement, so it persists the dismissal too.
+    expect(dismissesOnAction(coachMark!)).toBe(true);
+    expect(coachMark?.content.anchor?.actionSelector).toBe(AGENTIC_POINT_ACTION_SELECTOR);
+    // cypress/support/e2e.ts seeds this key so the callout can't sit over the
+    // chart under test; a rename here has to be mirrored there.
+    expect(AGENTIC_COACH_MARK_STORAGE_KEY).toBe('inferencex-agentic-point-coach-mark-dismissed');
+  });
+
+  it('ships a Chinese translation for every user-visible nudge string', () => {
+    for (const nudge of NUDGE_REGISTRY) {
+      expect(nudge.content.titleZh, `${nudge.id} title`).toBeTruthy();
+      expect(nudge.content.descriptionZh, `${nudge.id} description`).toBeTruthy();
+    }
   });
 
   it('preserves testId for every entry', () => {

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -2,6 +2,7 @@ import {
   ArrowRight,
   BookOpen,
   Download,
+  MousePointerClick,
   MessageSquareText,
   Palette,
   ShieldCheck,
@@ -14,6 +15,12 @@ import dynamic from 'next/dynamic';
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
 
 import { FEEDBACK_SUBMITTED_EVENT } from '@/components/feedback-modal';
+import {
+  AGENTIC_COACH_MARK_STORAGE_KEY,
+  AGENTIC_POINT_ACTION_SELECTOR,
+  SCATTER_RENDERED_EVENT,
+  resolveAgenticPointAnchor,
+} from '@/lib/nudges/agentic-point-coach-mark';
 import { LANDING_BANNER_STORAGE_KEY } from '@/lib/nudges/landing-banner';
 
 // Keep the ~210-line FeedbackForm out of the landing/dashboard initial JS.
@@ -257,6 +264,53 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
     analytics: {
       shown: 'evaluation_samples_nudge_shown',
       dismissed: 'evaluation_samples_nudge_dismissed',
+    },
+  },
+
+  // -------------------------------------------------------------------------
+  // Agentic chart coach mark
+  // -------------------------------------------------------------------------
+  {
+    id: 'agentic-point-detail',
+    type: 'coach-mark',
+    // Three ways in, all retried until an anchor exists (see `isEligible`'s
+    // `requireAnchor`): a short timer for a chart that is already painted,
+    // every subsequent chart render for the usual async-data case, and scroll
+    // — on a laptop viewport the chart starts below the fold, so the first two
+    // fire while there is still nothing on screen to point at. The resolver
+    // rejects an off-screen chart with a single rect read, keeping the scroll
+    // path cheap, and the engine drops these listeners once the tip is up.
+    trigger: [
+      { type: 'timer', delayMs: 1200 },
+      { type: 'event', event: SCATTER_RENDERED_EVENT, delayMs: 700 },
+      { type: 'dom-event', event: 'scroll' },
+    ],
+    dismissal: { type: 'permanent' },
+    storageKey: AGENTIC_COACH_MARK_STORAGE_KEY,
+    // Highest dashboard priority: it is the only nudge tied to a specific
+    // element, so it should claim its slot the moment that element exists.
+    // (It has its own slot, so this only orders it against future coach marks.)
+    priority: 45,
+    scope: 'dashboard',
+    content: {
+      icon: MousePointerClick,
+      iconClassName: 'text-brand',
+      title: 'Every point has a story',
+      titleZh: '每个数据点背后都有细节',
+      description:
+        'Click any point to view server metrics and logs — cache hit rates, queue depth, and the full request timeline for that run.',
+      descriptionZh:
+        '点击任意数据点即可查看服务端指标与日志——cache 命中率、队列深度，以及该次运行的完整请求时间线。',
+      testId: 'agentic-point-coach-mark',
+      anchor: {
+        resolve: resolveAgenticPointAnchor,
+        actionSelector: AGENTIC_POINT_ACTION_SELECTOR,
+      },
+    },
+    analytics: {
+      shown: 'inference_agentic_point_coach_mark_shown',
+      dismissed: 'inference_agentic_point_coach_mark_dismissed',
+      action: 'inference_agentic_point_coach_mark_point_clicked',
     },
   },
 

--- a/packages/app/src/lib/nudges/types.ts
+++ b/packages/app/src/lib/nudges/types.ts
@@ -59,6 +59,24 @@ export interface NudgeRenderContext {
   dismiss: () => void;
 }
 
+export interface NudgeAnchor {
+  /**
+   * Resolve the element the coach mark should point at, in the live DOM.
+   * Return `null` when nothing suitable is on screen (chart still loading,
+   * every candidate filtered out, scrolled out of view) — the engine hides
+   * the callout rather than stranding an arrow.
+   */
+  resolve: () => Element | null;
+  /**
+   * Clicking an element matching this selector counts as taking the nudge's
+   * action: the user found the affordance, so record engagement and stop
+   * showing it.
+   */
+  actionSelector?: string;
+  /** Extra window events that should trigger a reposition (beyond scroll/resize). */
+  repositionEvents?: readonly string[];
+}
+
 export interface NudgeContent {
   icon: ComponentType<{ className?: string }>;
   iconClassName?: string;
@@ -90,6 +108,14 @@ export interface NudgeContent {
   badge?: string;
   badgeZh?: string;
 
+  // -- Coach-mark-specific (ignored by toasts/modals/banners) --
+
+  /**
+   * Which on-screen element the callout points at. Required for `coach-mark`;
+   * without it the engine has nothing to anchor to and skips the nudge.
+   */
+  anchor?: NudgeAnchor;
+
   // -- Banner-specific (ignored by toasts/modals) --
 
   /** href for the banner link (the whole banner is clickable). */
@@ -117,7 +143,7 @@ export interface NudgeAnalyticsOverrides {
 // NudgeDefinition — a single registry entry
 // ---------------------------------------------------------------------------
 
-export type NudgeType = 'toast' | 'modal' | 'banner';
+export type NudgeType = 'toast' | 'modal' | 'banner' | 'coach-mark';
 
 /**
  * Which NudgeEngine instance owns a nudge. One engine mounts per scope, so a


### PR DESCRIPTION
## Summary

Clicking a point on the agentic inference chart pins its tooltip, and the pinned tooltip carries a **View charts** link to that run's server metrics and logs at `/inference/agentic/[id]`. Nothing on the chart hints at this, so first-time visitors never find it.

This adds a first-visit **coach mark**: a small callout that draws a pointer at a real, currently-visible data point and says *"Click any point to view server metrics and logs."*

## Approach — extend the nudge engine rather than bolt on a parallel mechanism

The existing nudge system already owns triggering, persistence, scheduling, locale, and analytics, so the coach mark is a new `NudgeType` inside it rather than a one-off component.

| Piece | Change |
| --- | --- |
| `lib/nudges/types.ts` | `NudgeType` gains `'coach-mark'`. `NudgeContent.anchor` is a new `NudgeAnchor` — a `resolve()` DOM lookup, an optional `actionSelector`, and optional extra reposition events. |
| `components/nudge-engine.tsx` | A **third slot** (banner / overlay / coach mark), matching the existing "independent visual layers" rule — the tip lives on the chart, the toasts live in the corner, so they never contend. Plus a `CoachMarkRenderer` and `handleCoachMarkAction`. |
| `lib/nudges/anchor.ts` | New. DOM-free placement geometry — `isAnchorOnScreen`, `isAnchorWithin`, `computeCoachMarkPlacement`. Kept pure so the placement rules are unit-testable. |
| `lib/nudges/agentic-point-coach-mark.ts` | New. The DOM half: which point to point at. |
| `components/ui/coach-mark.tsx` | New. The presentational callout, alongside `bottom-toast.tsx`. |
| `lib/nudges/registry.tsx` | One new entry, `agentic-point-detail`, `scope: 'dashboard'`. |

Registry / persistence / policy contracts are unchanged: dismissal still goes through `markDismissed`, and `dismissesOnAction` already returns `true` for anything that isn't a banner, so a point click both records engagement and persists the dismissal.

Two small engine changes were needed to make an *anchored* nudge work:

- **`isEligible(def, { requireAnchor })`.** Trigger *setup* asks "could this ever fire?" and must not consult the anchor — a coach mark's anchor only exists once the chart has painted, so checking it at mount would mean the triggers were never wired up at all. *Showing* asks "can it fire right now?", where a missing anchor is disqualifying and the show is simply retried on the next trigger.
- **Triggers are no longer re-armed for a nudge already occupying its slot**, so the eligibility check does not keep running for no benefit.

## The anchored rendering

A `position: fixed`, `pointer-events: none` layer over the page containing an SVG pointer and the card:

- a **pulsing ring** centred exactly on the target point,
- a **line + arrowhead** from the card edge to the point, stopping ~13px short so the arrowhead doesn't cover the dot,
- a **288px card** placed 52px from the point — below by default, flipping above when it would overflow the bottom, both axes clamped so it can never render off-canvas.

Verified on the live chart: the ring's centre matches a real `.visible-shape` marker's centre to within 1px, and the card sits fully inside the viewport.

## Picking the anchor

`resolveAgenticPointAnchor()` scans `[data-testid="scatter-graph"] .dot-group[data-benchmark-type="agentic_traces"]` and takes the eligible candidate nearest the chart centre, preferring points that carry `data-has-trace` (the ones whose tooltip actually offers *View charts*) and falling back to any visible agentic point while that lookup is still in flight. It then returns the `.visible-shape` marker inside the group rather than the group itself — a `.dot-group` box also spans the hit area and the `C=`/`DEP` label above the dot, so its centre can sit well off the dot.

Rejected candidates: hidden by a legend/precision/Optimal-Only toggle, off-screen, outside the clip region, or an unofficial-run overlay marker.

The clip check goes through a new `lib/d3-chart/plot-bounds.ts`, which reconstructs the rect `setupChart` clips the zoom group to — the `.chart-root` translate plus the clipPath rect — in viewport coordinates. It deliberately does **not** use the SVG's own box: that includes the 60px axis gutters, so a zoomed point parked over the axis labels is painted away by the clip path while `getBoundingClientRect()` reports perfectly ordinary geometry. The helper is d3-free so it can be imported without pulling d3 onto pages that have no chart, and `chart-setup.ts` carries a comment pointing at it.

Two supporting attributes on the chart:

- `data-benchmark-type` via the scatter layer's existing `dataAttrs`.
- `data-has-trace` written from the **decoration effect**, not the layer config — trace availability resolves after the chart renders, and adding it to the layer memo would rebuild the chart and drop the user's zoom (docs/pitfalls.md).

## Edge cases

| Situation | Behaviour |
| --- | --- |
| Chart loading / no points | No anchor, nothing rendered, no dismissal burned |
| Non-agentic scenario | Never fires (no agentic points exist) |
| Chart below the fold | Hidden until scrolled into view, then appears |
| Zoom / pan | Re-anchors each frame; if every visible point leaves the plot it hides, and returns on zoom reset |
| Window resize | Repositioned |
| Scrolled away | Hides (no stranded arrow), returns on scroll back |
| `/inference/agentic/[id]` | Never shows — `DashboardShell` already excludes the dashboard engine there, and the selector needs a `scatter-graph` that page doesn't render |

Repositioning is driven by `scroll` (capture) + `resize` + a rAF-throttled `MutationObserver` on `transform`/`style`, which is how d3 zoom and re-renders move points.

**Cost control:** the resolver runs on every scroll event, so it bails out with a single rect read when the whole chart is off-screen instead of measuring ~150 points. Covered by a test that asserts no per-point layout reads happen in that case.

## Unofficial run overlays

The coach mark **still shows** when a `?unofficialrun=` overlay is loaded, but it **never anchors to an overlay marker**. Overlay runs have no stored trace, so `generateOverlayTooltipContent` has no *View charts* link — pointing at one would teach a dead end. It anchors to an official agentic point instead, and if the user hides every official series it hides rather than falling back to an overlay point.

Clicking an overlay marker *does* count as taking the action (`actionSelector` covers both), since the user has clearly found the click affordance. Covered by a dedicated E2E case against `interceptOverlayRun`.

## First-visit persistence

`dismissal: { type: 'permanent' }` against `inferencex-agentic-point-coach-mark-dismissed`. `markShown` is a no-op for permanent dismissals, so merely rendering the tip writes nothing — only an explicit dismissal (X button or Escape) or a point click persists. The key is seeded by default in `cypress/support/e2e.ts` with a `keepAgenticCoachMark()` opt-out, matching the existing launch-modal / telemetry-tutorial pattern, so the callout can't sit over the plot area in other specs.

## Accessibility

`role="dialog"` with `aria-modal="false"` — no focus trap, no scrim, and everything except the card is `pointer-events: none`, so the chart underneath stays fully interactive. Escape dismisses, but only while the callout is actually on screen: the card stays mounted while hidden (it has to be in the DOM to be measured, and it re-appears when its point comes back), and since dismissal is permanent, reacting to a global keypress while nothing is drawn would burn a tip the user never saw. The point-click action is gated the same way. The measuring pass (the card must be in the DOM to measure before it can be placed) is kept out of the accessibility tree with `aria-hidden`.

## Chinese

Both strings ship `titleZh`/`descriptionZh`, and the card's own chrome (the close button's `aria-label`) uses the `useLocale()` + component-local `STRINGS = { en, zh }` pattern. The `/zh` dashboard needed no change — the callout is rendered by the shared `DashboardShell` engine, which already mounts on `/zh/inference`. A new registry test asserts *every* nudge has a Chinese title and description, so this can't regress.

## Analytics

Via the engine's existing `trackNudgeEvent`, with `inference_`-prefixed overrides: `inference_agentic_point_coach_mark_shown` / `_dismissed` / `_point_clicked`.

## Tests

- `anchor.test.ts` — 18 cases on the placement geometry: side flipping, viewport clamping from all four corners, pointer origin staying inside the card, bounds/inset checks, degenerate viewport.
- `agentic-point-coach-mark.test.ts` — 16 cases on anchor selection: selector scoping (no GPU-comparison charts, no overlay markers), nearest-centre choice, telemetry preference, hidden/off-screen/clipped rejection, marker-vs-group targeting, off-screen bail-out doing no per-point measurement.
- `registry.test.ts` — coach-mark type/scope/persistence/action wiring, every coach mark has an anchor, every nudge has zh copy.
- `policy.test.ts` — coach-mark dismisses on action by default, and respects an explicit override.
- `agentic-point-coach-mark.cy.ts` — 10 E2E cases: appears anchored to a real point, waits for the chart to be on screen, stays on screen, follows a zoom, dismisses via X (and stays gone after reload), via a point click, via Escape, never anchors to an overlay marker, absent on the detail page, Chinese copy on `/zh`.

## Verification

- `bun run lint`, `bun run fmt`, `bun run typecheck`, `bun run test:unit` (4176 tests), `bun run build` — all pass.
- Full Cypress integration suite against a fixtures build: **689/689 passing**, including `nudge-system`, `inference-chart`, `overlay-optimal-only`, `csv-export-overlay`, `ttft-x-axis-toggle`, `gpu-compare-agentic-detail`.
- Manual browser pass on a dev server against the real read-only DB, with the storage key cleared each time: appears on first agentic load anchored to a real point (ring centre matched a marker centre to <1px); disappears and persists on a point click, with the pinned tooltip and its *View charts* link intact; does not reappear on reload; absent on `/inference/agentic/439758`; absent on the fixed-sequence scenario; Chinese copy and `aria-label` on `/zh/inference`; follows a zoom, hides at a zoom level that pushes every visible point out of the plot, and returns after a zoom reset. No console errors.

## Left out / worth a human call

- **GPU comparison charts.** `GPUGraph` has the same click → tooltip → *View charts* flow, but the coach mark is scoped to the main scatter chart to keep the blast radius small. Extending it would mean stamping the same two attributes there.
- The chosen point is whichever is nearest the chart centre, so the card can land over other points. It's dismissible and only 288x~120px, but a "prefer a sparse region" heuristic is possible if that reads badly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the D3 scatter chart and the shared nudge engine (new slot, eligibility, body MutationObserver for zoom tracking). Onboarding-only, but a bug could overlay the plot or fire extra layout work on scroll.
> 
> **Overview**
> Teaches first-time visitors that clicking an agentic scatter point opens server metrics and logs. A non-modal callout (pointer + pulsing ring + card) anchors to a live, on-screen official point and is permanently dismissed on close, Escape, or actually clicking a point.
> 
> Extends the existing nudge system with a `coach-mark` type and a third independent slot, rather than a one-off overlay. Eligibility splits trigger setup from show so triggers still wire before the chart paints; the chart stamps `data-benchmark-type` / `data-has-trace` and fires `SCATTER_RENDERED_EVENT` so the resolver can pick a visible, in-plot marker (preferring points with traces, never overlay X markers).
> 
> Placement stays in-viewport (below by default, flips above), hides when the chart is off-screen or zoomed empty, and follows zoom/pan. Cypress is suppressed by default via `keepAgenticCoachMark()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5cee4f3d31fd5b1c943cd334429a1e5f463b828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---

## Review follow-ups (commits `2920936`, `80badca`)

Two Medium-severity Bugbot findings, both correct and both fixed:

1. **Escape dismissed a hidden coach mark.** The keydown listener (and the point-click action listener) ran whenever the component was mounted, including while it was only holding its slot and drawing nothing. Both are now gated on the callout being visible.
2. **The clip check used the full SVG box.** My original description claimed the resolver checked "plot bounds"; it actually checked the `d3-chart-svg` rect, which is a superset by the axis margins (60px left, 60px bottom on this chart). A zoomed point in those gutters is hidden by the clip path but was still accepted, aiming the pointer at an invisible point. Fixed via `plot-bounds.ts`, and the description above is corrected.

Each fix has coverage that fails before and passes after: `coach-mark.test.tsx` (3 cases on the hidden-input gating, plus one that the callout starts responding once its point scrolls in) and two new resolver cases for the left and bottom gutters, guarded with assertions that the point really is inside the SVG box so they cannot pass vacuously. `plot-bounds.test.ts` adds 7 cases on the geometry itself.

A third finding from my own re-read of the fix, in `80badca`: `plot-bounds.ts` originally located the clip rect with `defs clipPath rect`, which assumes the chart's is the only clipPath in the SVG — the overflow-continuation layer already defines one per group. It now follows the zoom group's own `clip-path="url(#…)"` reference, with a test that a decoy clipPath does not win. Because a `null` result falls back to the SVG box (i.e. silently back to the original bug), there is also an E2E case asserting `plotBounds` resolves against the **real** chart DOM and excludes the gutters — a skeleton change would otherwise regress this with every other test still green.

Re-ran the full gate (`lint`, `fmt`, `typecheck`, `test:unit` — now 4195 — and `build`) plus the complete Cypress integration suite against a fixtures build: **690/690 passing**.

> **Note for the reviewer:** Bugbot has not re-reviewed these three commits — it replied "Bugbot is paused — on-demand spend limit reached" to an explicit `bugbot run`. That needs a team admin to lift; the two original findings are fixed and their threads resolved, but this PR has not had a fresh automated pass over the fix itself.

