### PR TITLE
fix(overview): preserve data across navigation failures / 导航失败时保留 Overview 数据

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -260,7 +260,76 @@ describe('Overview page', () => {
     cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('not.exist');
   });
 
-  it('rewrites one history entry when the overview request fails', () => {
+  it('keeps the last matrix and history entry when a popstate request fails', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview');
+    // A client-derived reference switch proves hydration and the popstate
+    // listener are established without warming the tier payload under test.
+    cy.get('[data-testid="overview-reference-select"]').click();
+    cy.get('[data-overview-reference="b300"]').click();
+    cy.location('search').should('eq', '?ref=b300');
+    cy.intercept('GET', '**/api/v1/overview?tier=75', { statusCode: 500 }).as(
+      'overviewPopstateFailure',
+    );
+    cy.window().then((win) => {
+      (win as Window & { __overviewNavigationSentinel?: string }).__overviewNavigationSentinel =
+        'preserved';
+      win.History.prototype.pushState.call(
+        win.history,
+        win.history.state,
+        '',
+        '/overview?tier=75&ref=b300',
+      );
+      cy.wrap(win.history.length).as('overviewHistoryLength');
+    });
+
+    cy.go('back');
+    cy.location('search').should('eq', '?ref=b300');
+    cy.go('forward');
+    cy.wait('@overviewPopstateFailure');
+    cy.get('[data-testid="overview-navigation-error"]')
+      .should('have.attr', 'role', 'alert')
+      .and(
+        'have.text',
+        'Could not load the selected comparison. Showing the last successfully loaded data.',
+      );
+    cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]').should(
+      'have.text',
+      '50',
+    );
+    cy.get('[data-testid="overview-page"] [aria-busy="true"]').should('not.exist');
+    cy.location('search').should('eq', '?tier=75&ref=b300');
+    cy.get<number>('@overviewHistoryLength').then((expectedHistoryLength) => {
+      cy.window().then((after) => {
+        expect(after.history.length).to.equal(expectedHistoryLength);
+        expect(
+          (after as Window & { __overviewNavigationSentinel?: string })
+            .__overviewNavigationSentinel,
+        ).to.equal('preserved');
+      });
+    });
+  });
+
+  it('shows a localized empty state after a selector returns no models', () => {
+    cy.viewport(1280, 900);
+    cy.request('/api/v1/overview?tier=75').then(({ body }) => {
+      cy.intercept('GET', '**/api/v1/overview?tier=75', {
+        statusCode: 200,
+        body: { ...body, models: [] },
+      }).as('emptyOverview');
+      cy.visit('/zh/overview');
+
+      cy.get('[data-testid="overview-tier-switcher"]').contains('a', '75').click();
+      cy.wait('@emptyOverview');
+      cy.get('[data-testid="overview-empty-state"]')
+        .should('have.attr', 'role', 'status')
+        .and('have.text', '没有符合当前筛选条件的总览结果。');
+      cy.get('[data-testid="overview-desktop-matrix"]').should('not.exist');
+      cy.get('[data-testid="overview-mobile-list"]').should('not.exist');
+    });
+  });
+
+  it('keeps one history entry when the overview request fails', () => {
     cy.viewport(1280, 900);
     cy.visit('/inference');
     cy.visit('/overview');

--- a/packages/app/src/components/overview/overview-navigation.test.tsx
+++ b/packages/app/src/components/overview/overview-navigation.test.tsx
@@ -18,6 +18,7 @@ vi.mock('next/navigation', () => ({
 import {
   OverviewNavigationProvider,
   useOverviewData,
+  useOverviewNavigationError,
   useOverviewNavigation,
   useOverviewReference,
 } from './overview-navigation';
@@ -55,6 +56,7 @@ function pageData(tier: OverviewTier): OverviewPageData {
 
 function Probe() {
   const navigation = useOverviewNavigation();
+  const navigationError = useOverviewNavigationError();
   const data = useOverviewData();
   const reference = useOverviewReference();
   selectTier = () => navigation.push('/overview?tier=75', ['tier']);
@@ -68,6 +70,7 @@ function Probe() {
       <output data-testid="tier">{data.tier}</output>
       <output data-testid="reference">{reference}</output>
       <output data-testid="pending">{navigation.isPending ? 'pending' : 'settled'}</output>
+      <output data-testid="error">{navigationError ? 'error' : 'ok'}</output>
     </>
   );
 }
@@ -163,7 +166,7 @@ describe('OverviewNavigationProvider', () => {
     // The shared afterEach unmounts again; react-dom tolerates the repeat.
   });
 
-  it('replaces rather than pushes when the overview request fails', async () => {
+  it('keeps a failed selector entry without falling back to router navigation', async () => {
     const { settlers } = deferredFetch();
     const searchEvents: string[] = [];
     const onSearchChange = (event: Event) => {
@@ -183,12 +186,14 @@ describe('OverviewNavigationProvider', () => {
 
     window.removeEventListener(CLIENT_SEARCH_CHANGE_EVENT, onSearchChange);
 
-    expect(routerStub.replace).toHaveBeenCalledTimes(1);
-    expect(routerStub.replace).toHaveBeenCalledWith('/overview?tier=75', { scroll: false });
+    expect(routerStub.replace).not.toHaveBeenCalled();
     expect(routerStub.push).not.toHaveBeenCalled();
     // The failed selection stays in the address bar so a retry click still works.
     expect(window.location.search).toBe('?tier=75');
     expect(searchEvents).toEqual(['?tier=75']);
+    expect(readProbe('tier')).toBe('50');
+    expect(readProbe('pending')).toBe('settled');
+    expect(readProbe('error')).toBe('error');
   });
 
   it('pushes one history entry when the same selection repeats while pending', () => {
@@ -206,7 +211,7 @@ describe('OverviewNavigationProvider', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('reloads on a failed popstate commit', async () => {
+  it('retains the last data and history when a popstate request fails, then clears the error', async () => {
     renderProvider(pageData(50), '/overview');
 
     const { settlers } = deferredFetch();
@@ -222,6 +227,11 @@ describe('OverviewNavigationProvider', () => {
       origin: 'http://localhost',
       reload,
     });
+    const replaceState = vi.spyOn(History.prototype, 'replaceState');
+    const pushState = vi.spyOn(History.prototype, 'pushState');
+    replaceState.mockClear();
+    pushState.mockClear();
+    const historyLength = window.history.length;
 
     await act(async () => {
       window.dispatchEvent(new PopStateEvent('popstate'));
@@ -230,7 +240,29 @@ describe('OverviewNavigationProvider', () => {
       await Promise.resolve();
     });
 
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+    expect(routerStub.push).not.toHaveBeenCalled();
+    expect(routerStub.replace).not.toHaveBeenCalled();
+    expect(pushState).not.toHaveBeenCalled();
+    expect(replaceState).not.toHaveBeenCalled();
+    expect(window.history.length).toBe(historyLength);
+    expect(window.location.search).toBe('?tier=75');
+    expect(readProbe('tier')).toBe('50');
+    expect(readProbe('pending')).toBe('settled');
+    expect(readProbe('error')).toBe('error');
+
+    window.history.replaceState({}, '', '/overview?tier=100');
+    await act(async () => {
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await Promise.resolve();
+      settlers[1]?.resolve(Response.json(pageData(100)));
+      await Promise.resolve();
+    });
+
+    expect(readProbe('tier')).toBe('100');
+    expect(readProbe('error')).toBe('ok');
+    replaceState.mockRestore();
+    pushState.mockRestore();
   });
 
   it('fetches on a cache-miss popstate and ignores non-overview routes', async () => {
@@ -387,9 +419,7 @@ describe('OverviewNavigationProvider', () => {
     });
 
     expect(settlers).toHaveLength(1);
-    expect(routerStub.replace).toHaveBeenCalledWith('/overview?tier=75&ref=b300', {
-      scroll: false,
-    });
+    expect(routerStub.replace).not.toHaveBeenCalled();
     expect(readProbe('tier')).toBe('50');
     expect(readProbe('reference')).toBe('b300');
   });

--- a/packages/app/src/components/overview/overview-navigation.test.tsx
+++ b/packages/app/src/components/overview/overview-navigation.test.tsx
@@ -255,6 +255,12 @@ describe('OverviewNavigationProvider', () => {
     await act(async () => {
       window.dispatchEvent(new PopStateEvent('popstate'));
       await Promise.resolve();
+    });
+
+    expect(readProbe('pending')).toBe('pending');
+    expect(readProbe('error')).toBe('ok');
+
+    await act(async () => {
       settlers[1]?.resolve(Response.json(pageData(100)));
       await Promise.resolve();
     });

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -137,6 +137,7 @@ export function OverviewNavigationProvider({
       const navigationId = ++navigationIdRef.current;
       pendingHrefRef.current = href;
       setPendingHref(href);
+      setNavigationError(false);
       if (updateHistory) {
         // Deliberately the pristine prototype method: `window.history.pushState`
         // is patched by Next to dispatch a router action, and that per-click

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import {
   createContext,
   type MutableRefObject,
@@ -75,14 +74,16 @@ interface OverviewNavigationValue {
 }
 
 /**
- * Three contexts, not one. A selector click moves the pending href immediately
+ * Split contexts, not one. A selector click moves the pending href immediately
  * and the payload only when the request settles, so a single value would push
  * two full matrix renders per uncached selection. Splitting them means the
- * controls can re-render on their own while the matrix waits for real data.
+ * controls and failure notice can re-render on their own while the matrix waits
+ * for real data.
  */
 const OverviewDataContext = createContext<OverviewPageData | null>(null);
 const OverviewReferenceContext = createContext<OverviewReferenceHardware | null>(null);
 const OverviewComparisonContext = createContext<OverviewComparisonMode | null>(null);
+const OverviewNavigationErrorContext = createContext(false);
 const OverviewNavigationContext = createContext<OverviewNavigationValue | null>(null);
 
 export function OverviewNavigationProvider({
@@ -94,8 +95,8 @@ export function OverviewNavigationProvider({
   initialHref: string;
   children: ReactNode;
 }) {
-  const router = useRouter();
   const [data, setData] = useState(initialData);
+  const [navigationError, setNavigationError] = useState(false);
   const [pendingHref, setPendingHref] = useState(initialHref);
   const [committedHref, setCommittedHref] = useState(initialHref);
   const pendingHrefRef = useRef(initialHref);
@@ -163,10 +164,11 @@ export function OverviewNavigationProvider({
             History.prototype.replaceState.call(window.history, window.history.state, '', href);
           }
           setData(nextData);
+          setNavigationError(false);
           // The pushState above is invisible to Next's router, so the app-wide
           // pageview tracker never fires here. Emit once per committed state —
           // in the success branch so Back/Forward is covered too, and so the
-          // failure path's `router.replace` is not double-counted.
+          // recoverable failure path never records a pageview.
           track('$pageview', { $current_url: new URL(href, window.location.origin).href });
         })
         .catch(() => {
@@ -183,19 +185,10 @@ export function OverviewNavigationProvider({
           );
           pendingHrefRef.current = rolledBack;
           setPendingHref(rolledBack);
-          if (updateHistory) {
-            // The entry pushed above already carries `href`, so `replace`
-            // rewrites it in place instead of stacking a duplicate the user
-            // has to press Back through twice. Rewinding to the committed
-            // href first would also strand the header language toggle, which
-            // only ever hears about search changes through the event above.
-            router.replace(href, { scroll: false });
-          } else {
-            window.location.reload();
-          }
+          setNavigationError(true);
         });
     },
-    [load, router],
+    [load],
   );
 
   useEffect(() => {
@@ -211,6 +204,7 @@ export function OverviewNavigationProvider({
     pendingHrefRef.current = href;
     setPendingHref(href);
     setData(initialData);
+    setNavigationError(false);
   }, [initialData, initialHref]);
 
   useEffect(() => {
@@ -301,9 +295,11 @@ export function OverviewNavigationProvider({
     <OverviewDataContext.Provider value={data}>
       <OverviewReferenceContext.Provider value={referenceHardware}>
         <OverviewComparisonContext.Provider value={comparisonMode}>
-          <OverviewNavigationContext.Provider value={value}>
-            {children}
-          </OverviewNavigationContext.Provider>
+          <OverviewNavigationErrorContext.Provider value={navigationError}>
+            <OverviewNavigationContext.Provider value={value}>
+              {children}
+            </OverviewNavigationContext.Provider>
+          </OverviewNavigationErrorContext.Provider>
         </OverviewComparisonContext.Provider>
       </OverviewReferenceContext.Provider>
     </OverviewDataContext.Provider>
@@ -314,6 +310,10 @@ export function useOverviewNavigation(): OverviewNavigationValue {
   const value = useContext(OverviewNavigationContext);
   if (value === null) throw new Error('Overview controls require OverviewNavigationProvider');
   return value;
+}
+
+export function useOverviewNavigationError(): boolean {
+  return useContext(OverviewNavigationErrorContext);
 }
 
 export function useOverviewData(): OverviewPageData {

--- a/packages/app/src/components/overview/overview-page.test.tsx
+++ b/packages/app/src/components/overview/overview-page.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OverviewPageData } from '@/lib/overview-data';
+
+import { OverviewPageContent } from './overview-page';
+import type { OverviewLocale } from './overview-scorecard';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const EMPTY_DATA: OverviewPageData = {
+  models: [],
+  tier: 50,
+  engineScope: 'community',
+  comparisonMode: 'hardware',
+  referenceHardware: 'b200',
+  modelScope: 'default',
+  rowScope: 'all',
+  hardwareRowScope: 'all',
+  unchangedRowCount: 0,
+  emptyRowCount: 0,
+  historicalWindow: null,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderPage(locale: OverviewLocale) {
+  act(() => {
+    root.render(<OverviewPageContent data={EMPTY_DATA} locale={locale} />);
+  });
+}
+
+beforeEach(() => {
+  window.history.replaceState({}, '', '/overview');
+  Object.defineProperty(document, 'fullscreenEnabled', { configurable: true, value: false });
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+describe('OverviewPageContent failure states', () => {
+  it.each([
+    ['en', 'No overview results match this selection.'],
+    ['zh', '没有符合当前筛选条件的总览结果。'],
+  ] as const)('renders the localized empty state for %s', (locale, message) => {
+    renderPage(locale);
+
+    const empty = container.querySelector('[data-testid="overview-empty-state"]');
+    expect(empty?.textContent).toBe(message);
+    expect(container.querySelector('[data-testid="overview-desktop-matrix"]')).toBeNull();
+    expect(container.querySelector('[data-testid="overview-mobile-list"]')).toBeNull();
+  });
+
+  it.each([
+    ['en', 'Could not load the selected comparison. Showing the last successfully loaded data.'],
+    ['zh', '无法加载所选对比，当前显示的是上次成功加载的数据。'],
+  ] as const)(
+    'renders a localized recoverable navigation alert for %s',
+    async (locale, message) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(() => Promise.reject(new Error('network down'))),
+      );
+      window.history.replaceState({}, '', locale === 'zh' ? '/zh/overview' : '/overview');
+      renderPage(locale);
+
+      const tierLink = [...container.querySelectorAll<HTMLAnchorElement>('a')].find(
+        (link) => link.textContent === '75',
+      );
+      expect(tierLink).toBeDefined();
+
+      await act(async () => {
+        tierLink?.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const alert = container.querySelector('[role="alert"]');
+      expect(alert?.textContent).toBe(message);
+      expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+    },
+  );
+});

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -25,6 +25,7 @@ import {
   OverviewNavigationProvider,
   useOverviewData,
   useOverviewNavigation,
+  useOverviewNavigationError,
   useOverviewReference,
 } from './overview-navigation';
 import {
@@ -81,6 +82,20 @@ function OverviewPendingStatus({ label }: { label: string }) {
   );
 }
 
+function OverviewNavigationErrorStatus({ label }: { label: string }) {
+  const hasError = useOverviewNavigationError();
+  if (!hasError) return null;
+  return (
+    <p
+      role="alert"
+      data-testid="overview-navigation-error"
+      className="rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-foreground"
+    >
+      {label}
+    </p>
+  );
+}
+
 function OverviewMatrixCard({ children }: { children: ReactNode }) {
   const { isPending } = useOverviewNavigation();
   return (
@@ -106,6 +121,7 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
   return (
     <section data-testid="overview-page" className="flex flex-col gap-4">
       <OverviewPendingStatus label={strings.loadingStatus} />
+      <OverviewNavigationErrorStatus label={strings.navigationError} />
       {/* Held in a stable child slot: swapping the header out for the surface
           would remount the surface and drop the browser out of fullscreen. The
           browser already stops painting it, so this only keeps the hidden
@@ -330,6 +346,23 @@ function OverviewMatrixSection({ locale }: { locale: OverviewLocale }) {
       presenting={presenting}
     />
   );
+
+  if (data.models.length === 0) {
+    return (
+      <>
+        <OverviewControlRow locale={locale} />
+        <OverviewMatrixCard>
+          <p
+            role="status"
+            data-testid="overview-empty-state"
+            className="px-6 py-12 text-center text-sm text-muted-foreground"
+          >
+            {strings.emptyState}
+          </p>
+        </OverviewMatrixCard>
+      </>
+    );
+  }
 
   return (
     <>

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -154,6 +154,9 @@ export const OVERVIEW_STRINGS = {
     } as Partial<Record<string, string>>,
     categoryBadgeTitle: 'Model is no longer actively benchmarked.',
     loadingStatus: 'Loading the selected comparison…',
+    navigationError:
+      'Could not load the selected comparison. Showing the last successfully loaded data.',
+    emptyState: 'No overview results match this selection.',
   },
   zh: {
     title: '智能体推理成本',
@@ -251,6 +254,8 @@ export const OVERVIEW_STRINGS = {
     } as Partial<Record<string, string>>,
     categoryBadgeTitle: '该模型已不再进行活跃基准测试。',
     loadingStatus: '正在加载所选对比…',
+    navigationError: '无法加载所选对比，当前显示的是上次成功加载的数据。',
+    emptyState: '没有符合当前筛选条件的总览结果。',
   },
 } as const;
 

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -71,7 +71,7 @@ afterEach(() => {
 });
 
 describe('getOverviewPageData engine scope forwarding', () => {
-  it('fails closed when history mode has no current snapshot', async () => {
+  it('returns a renderable empty history payload when no current snapshot exists', async () => {
     const getCachedBenchmarks = vi.fn(() => Promise.resolve([]));
     const getCachedBenchmarksAsOf = vi.fn();
     vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
@@ -81,12 +81,23 @@ describe('getOverviewPageData engine scope forwarding', () => {
     }));
     vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
 
-    const { getOverviewPageData, OverviewHistoryUnavailableError } =
-      await import('./overview-data.server');
+    const { getOverviewPageData } = await import('./overview-data.server');
 
-    await expect(getOverviewPageData(50, 'community', '30d')).rejects.toBeInstanceOf(
-      OverviewHistoryUnavailableError,
-    );
+    await expect(
+      getOverviewPageData(75, 'all', '30d', 'b300', 'all', 'changed', 'priced'),
+    ).resolves.toEqual({
+      models: [],
+      tier: 75,
+      engineScope: 'all',
+      comparisonMode: '30d',
+      referenceHardware: 'b300',
+      modelScope: 'all',
+      rowScope: 'changed',
+      hardwareRowScope: 'priced',
+      unchangedRowCount: 0,
+      emptyRowCount: 0,
+      historicalWindow: null,
+    });
     expect(getCachedBenchmarksAsOf).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -71,6 +71,48 @@ afterEach(() => {
 });
 
 describe('getOverviewPageData engine scope forwarding', () => {
+  it('fails closed when history mode has no current snapshot', async () => {
+    const getCachedBenchmarks = vi.fn(() => Promise.resolve([]));
+    const getCachedBenchmarksAsOf = vi.fn();
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({
+      getCachedBenchmarks,
+      getCachedBenchmarksAsOf,
+    }));
+    vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
+
+    const { getOverviewPageData, OverviewHistoryUnavailableError } =
+      await import('./overview-data.server');
+
+    await expect(getOverviewPageData(50, 'community', '30d')).rejects.toBeInstanceOf(
+      OverviewHistoryUnavailableError,
+    );
+    expect(getCachedBenchmarksAsOf).not.toHaveBeenCalled();
+  });
+
+  it('keeps hardware mode valid when every platform is missing', async () => {
+    const getCachedBenchmarks = vi.fn(() => Promise.resolve([]));
+    const getCachedBenchmarksAsOf = vi.fn();
+    vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: false }));
+    vi.doMock('@/lib/benchmark-data.server', () => ({
+      getCachedBenchmarks,
+      getCachedBenchmarksAsOf,
+    }));
+    vi.doMock('@/lib/test-fixtures', () => ({ loadFixture: vi.fn() }));
+
+    const { getOverviewPageData } = await import('./overview-data.server');
+    const page = await getOverviewPageData(50, 'community', 'hardware');
+
+    expect(page.comparisonMode).toBe('hardware');
+    expect(page.models.length).toBeGreaterThan(0);
+    expect(
+      page.models.every((model) =>
+        model.platforms.every((platform) => platform.costPerMtok === null),
+      ),
+    ).toBe(true);
+    expect(getCachedBenchmarksAsOf).not.toHaveBeenCalled();
+  });
+
   it('forwards the selected hardware reference through fixture mode', async () => {
     vi.doMock('@semianalysisai/inferencex-db/connection', () => ({ FIXTURES_MODE: true }));
     vi.doMock('@/lib/benchmark-data.server', () => ({ getCachedBenchmarks: vi.fn() }));

--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -30,13 +30,6 @@ import {
 } from '@/lib/overview-data';
 import { loadFixture } from '@/lib/test-fixtures';
 
-export class OverviewHistoryUnavailableError extends Error {
-  constructor(comparisonMode: OverviewComparisonMode) {
-    super(`Overview history is unavailable for ${comparisonMode}`);
-    this.name = 'OverviewHistoryUnavailableError';
-  }
-}
-
 async function loadRowsByModel(
   models: readonly Model[],
   loader: (keys: string[]) => Promise<BenchmarkRow[]>,
@@ -97,7 +90,19 @@ export async function getOverviewPageData(
       : currentRowsByModel;
   const snapshotDate = overviewSnapshotDate(snapshotRows, engineScope);
   if (snapshotDate === null) {
-    throw new OverviewHistoryUnavailableError(comparisonMode);
+    return {
+      models: [],
+      tier,
+      engineScope,
+      comparisonMode,
+      referenceHardware,
+      modelScope,
+      rowScope,
+      hardwareRowScope,
+      unchangedRowCount: 0,
+      emptyRowCount: 0,
+      historicalWindow: null,
+    };
   }
 
   const window = overviewHistoricalWindow(snapshotDate, comparisonMode);

--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -30,6 +30,13 @@ import {
 } from '@/lib/overview-data';
 import { loadFixture } from '@/lib/test-fixtures';
 
+export class OverviewHistoryUnavailableError extends Error {
+  constructor(comparisonMode: OverviewComparisonMode) {
+    super(`Overview history is unavailable for ${comparisonMode}`);
+    this.name = 'OverviewHistoryUnavailableError';
+  }
+}
+
 async function loadRowsByModel(
   models: readonly Model[],
   loader: (keys: string[]) => Promise<BenchmarkRow[]>,
@@ -90,16 +97,7 @@ export async function getOverviewPageData(
       : currentRowsByModel;
   const snapshotDate = overviewSnapshotDate(snapshotRows, engineScope);
   if (snapshotDate === null) {
-    return scopeRows({
-      ...assembleOverviewPageData(
-        currentRowsByModel,
-        tier,
-        engineScope,
-        referenceHardware,
-        modelScope,
-      ),
-      comparisonMode,
-    });
+    throw new OverviewHistoryUnavailableError(comparisonMode);
   }
 
   const window = overviewHistoricalWindow(snapshotDate, comparisonMode);


### PR DESCRIPTION
## What changed

- Keep the last successful Overview matrix visible when selector or Back/Forward requests fail.
- Surface localized recoverable errors instead of reloading the page.
- Fail closed when a historical snapshot is unavailable and render explicit English/Chinese empty states.

## Why

A transient navigation failure could discard the current context through a full reload, while missing history or empty data could leave users with a misleading or blank comparison.

## Validation

- Focused unit tests: 31 passed
- Overview E2E: Chrome 39/39, Firefox 39/39
- Fixture production build, typecheck, lint, format, and diff check passed

## 中文说明

- Overview 的选择器或浏览器前进/后退请求失败时，继续保留上一次成功加载的矩阵。
- 使用可恢复的中英文错误提示代替整页刷新。
- 历史快照不可用时安全终止对比，并为无数据结果提供明确的中英文空状态。

此前短暂的导航失败可能通过整页刷新丢失当前上下文；历史数据缺失或查询结果为空时，也可能展示误导性对比或空白页面。

验证结果：31 项聚焦单元测试通过；Chrome 与 Firefox 的 Overview E2E 各 39/39 通过；fixture production build、typecheck、lint、format 与 diff check 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes client history/commit behavior and how missing historical snapshots are treated, which can affect what comparison users see after a failed load. Coverage is strong (unit + E2E), but the failure path is user-visible navigation logic.
> 
> **Overview**
> Failed Overview selector and Back/Forward loads no longer rewrite history or reload the page. The last successful matrix stays on screen, the failed URL remains so retry still works, and a localized alert explains that the previous data is still shown.
> 
> Empty selector results now render an English/Chinese empty state instead of a blank matrix. History mode with no current snapshot **fails closed** via `OverviewHistoryUnavailableError` instead of assembling a misleading comparison; hardware mode still returns unpriced rows when every platform is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 908d4ff8429e15deb3de7fc4569a707d028a37f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->