### PR TITLE
fix(inference): preserve chart state when returning from a point detail page

### DIFF
--- a/docs/state-ownership.md
+++ b/docs/state-ownership.md
@@ -258,6 +258,43 @@ Note: `i_seq` and `i_prec` are written by `GlobalFilterProvider` (not InferenceP
 
 `useUrlStateSync` (used by InferenceProvider, EvaluationProvider, ReliabilityProvider) skips the first render via `isMountedRef` to avoid overwriting the just-snapshotted URL params. GlobalFilterProvider uses a manually-written equivalent (lines 288–308 in `GlobalFilterContext.tsx`).
 
+### Carrying state across a full-document navigation
+
+The two effects above combine into a trap: filter changes reach only the
+in-memory `currentState`, and the address bar is stripped clean, so **the URL of
+the `/inference` history entry describes nothing**. Any full-document navigation
+away from the chart therefore destroys the state entirely — the module is torn
+down, and Back returns to a bare `/inference` that rebuilds from defaults.
+
+The agentic point-detail links (`/inference/agentic/<id>`, rendered by
+`tooltipUtils.viewChartsButtonHTML` and `legend-points-table.pointDetailHref`)
+are exactly that: plain `<a href>`, deliberately, so browsers can offer
+open-in-new-tab. Three helpers in `url-state.ts` bridge the gap:
+
+| Helper                      | Used by                                                      | Why                                                                           |
+| --------------------------- | ------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| `rememberChartStateInUrl()` | the point-click handlers (Scatter / GPU graph, legend table) | `history.replaceState`s the chart state onto the entry Back will return to    |
+| `withChartState(href)`      | `agenticDetailHref()`                                        | appends it to the outbound link so the detail page can link back to that view |
+| `currentChartSearch()`      | both of the above                                            | resolves the tab through the `/zh` prefix, flushes pending writes, filters    |
+
+The detail page reads the state back through `withChartState` (its own URL was
+snapshotted into `currentState` at load, then stripped as usual), which is what
+makes its "Inference chart" link land on the chart the reader left rather than
+on defaults.
+
+### Re-hydration on client-side navigation
+
+`useUrlState` calls `refreshUrlParamsOnNavigation(pathname)` **during render**,
+guarded by a module-level last-pathname so it runs at most once per navigation.
+That ordering matters: providers read `getUrlParam` in `useState` initialisers
+and mount effects, both of which run before any parent's layout effect, so
+refreshing from an effect (as `GlobalFilterContext` does on its own account)
+is too late for anything below it. With the hook-level refresh, every provider
+— `InferenceProvider`'s `i_gpus` / `i_metric` / `i_active` included — sees the
+params of the page it actually landed on. The once-per-pathname guard is what
+keeps a late-mounting component from replaying a stale URL over filter changes
+the user has made since.
+
 ### Share URL construction
 
 `buildShareUrl()` flushes pending writes, reads `currentState`, and filters to only the param prefixes relevant to the current tab (defined in `TAB_PARAM_PREFIXES`). Inference share URLs include `g_` + `i_` params; evaluation includes `g_` + `e_`; reliability includes only `r_`.

--- a/packages/app/cypress/e2e/agentic-detail-back-nav.cy.ts
+++ b/packages/app/cypress/e2e/agentic-detail-back-nav.cy.ts
@@ -1,0 +1,320 @@
+import { interceptDerivedAgenticMetrics } from '../support/e2e';
+
+// ---------------------------------------------------------------------------
+// Regression: returning from an agentic point-detail page reset the chart.
+//
+// Chart filters only ever reach an in-memory store — `url-state.ts` strips the
+// share params from the address bar after load — and the point-detail links are
+// plain `<a href>` (they must support open-in-new-tab), so following one is a
+// full-document navigation that destroys that store. Back therefore returned to
+// a bare `/inference` and the chart rebuilt from defaults: DeepSeek V4 Pro with
+// every legend series on, no matter what the reader had been looking at.
+//
+// The shared fixtures carry ZERO agentic_traces rows, so this spec injects its
+// own agentic coverage (same pattern as gpu-compare-agentic-detail.cy.ts).
+// ---------------------------------------------------------------------------
+
+const AGENTIC_DATE = '2026-06-12';
+const DEFAULT_MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro, the dashboard default
+const TARGET_MODEL_DB_KEY = 'kimik3'; // Kimi-K3, the non-default the reader picks
+const TARGET_MODEL_LABEL = 'Kimi K3';
+
+const AGENTIC_HARDWARE = [
+  { hardware: 'b200', framework: 'vllm' },
+  { hardware: 'b300', framework: 'vllm' },
+  { hardware: 'h200', framework: 'vllm' },
+];
+
+/** The series the reader solos — must differ from the "all on" default. */
+const SOLO_HW_KEY = 'b300_vllm';
+const SOLO_HW_LABEL = 'B300 (vLLM)';
+
+const availabilityFor = (model: string) => [
+  ...AGENTIC_HARDWARE.map((g) => ({
+    model,
+    isl: null,
+    osl: null,
+    precision: 'fp4',
+    hardware: g.hardware,
+    framework: g.framework,
+    spec_method: 'none',
+    disagg: false,
+    benchmark_type: 'agentic_traces',
+    date: AGENTIC_DATE,
+  })),
+  // Fixed-seq rows alongside, so the scenario selector sees the "both exist"
+  // signal it needs to settle confidently on agentic.
+  ...AGENTIC_HARDWARE.map((g) => ({
+    model,
+    isl: 8192,
+    osl: 1024,
+    precision: 'fp4',
+    hardware: g.hardware,
+    framework: g.framework,
+    spec_method: 'none',
+    disagg: false,
+    benchmark_type: 'single_turn',
+    date: AGENTIC_DATE,
+  })),
+];
+
+const availability = [
+  ...availabilityFor(DEFAULT_MODEL_DB_KEY),
+  ...availabilityFor(TARGET_MODEL_DB_KEY),
+];
+
+const percentileLadder = (prefix: string, base: number): Record<string, number> => ({
+  [`median_${prefix}`]: base,
+  [`p75_${prefix}`]: base * 1.2,
+  [`p90_${prefix}`]: base * 1.5,
+  [`p95_${prefix}`]: base * 1.7,
+  [`p99_${prefix}`]: base * 2.2,
+  [`std_${prefix}`]: base * 0.3,
+});
+
+const agenticMetrics = (conc: number): Record<string, number> => {
+  const scale = conc / 16;
+  const itl = 0.011 * scale;
+  return {
+    ...percentileLadder('ttft', 0.4 * scale),
+    ...percentileLadder('tpot', 0.012 * scale),
+    ...percentileLadder('itl', itl),
+    ...percentileLadder('e2el', 8 * scale),
+    median_intvty: 1 / itl,
+    p75_intvty: 1 / (itl * 1.2),
+    p90_intvty: 1 / (itl * 1.5),
+    p99_intvty: 1 / (itl * 2.2),
+    std_intvty: (1 / itl) * 0.1,
+    tput_per_gpu: 950 / Math.sqrt(scale),
+    output_tput_per_gpu: 210,
+    input_tput_per_gpu: 740,
+    total_tput_tps: 7600 * conc * 0.05,
+  };
+};
+
+let benchIdCursor = 900100;
+const benchmarksFor = (model: string) =>
+  AGENTIC_HARDWARE.flatMap((g) =>
+    [16, 64, 128].map((conc) => ({
+      id: benchIdCursor++,
+      hardware: g.hardware,
+      framework: g.framework,
+      model,
+      precision: 'fp4',
+      spec_method: 'none',
+      disagg: false,
+      is_multinode: false,
+      prefill_tp: 8,
+      prefill_ep: 1,
+      prefill_dp_attention: false,
+      prefill_num_workers: 0,
+      decode_tp: 8,
+      decode_ep: 1,
+      decode_dp_attention: false,
+      decode_num_workers: 0,
+      num_prefill_gpu: 8,
+      num_decode_gpu: 8,
+      isl: null,
+      osl: null,
+      conc,
+      offload_mode: 'off',
+      benchmark_type: 'agentic_traces',
+      image: 'vllm/vllm-openai:v0.9.0',
+      metrics: agenticMetrics(conc),
+      workers: null,
+      date: AGENTIC_DATE,
+      run_url: null,
+    })),
+  );
+
+const benchmarks = [...benchmarksFor(DEFAULT_MODEL_DB_KEY), ...benchmarksFor(TARGET_MODEL_DB_KEY)];
+const tracedIds = new Set(benchmarks.map((b) => b.id));
+
+/** Minimal detail-page payloads — this spec only cares about its nav controls. */
+function interceptDetailPage(): void {
+  cy.intercept('GET', '/api/v1/trace-server-metrics*', { body: null });
+  cy.intercept('GET', '/api/v1/trace-histograms*', { body: {} });
+  cy.intercept('GET', '/api/v1/request-timeline*', { body: null });
+  cy.intercept('GET', '/api/v1/benchmark-siblings*', { body: null });
+  cy.intercept('GET', '/api/v1/agentic-aggregates*', { body: null });
+}
+
+function interceptChart(): void {
+  cy.intercept('GET', '/api/v1/availability', { body: availability }).as('availability');
+  cy.intercept('GET', '/api/v1/benchmarks*', { body: benchmarks }).as('benchmarks');
+  cy.intercept('GET', '/api/v1/trace-availability*', (request) => {
+    const ids = new URL(request.url).searchParams.get('ids')?.split(',') ?? [];
+    request.reply({
+      body: Object.fromEntries(
+        ids.filter((id) => tracedIds.has(Number(id))).map((id) => [id, true]),
+      ),
+    });
+  });
+  interceptDerivedAgenticMetrics();
+  interceptDetailPage();
+}
+
+function visitChart(path: string): void {
+  interceptChart();
+  cy.visit(path, {
+    onBeforeLoad(win) {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    },
+  });
+  cy.get('[data-testid="inference-chart-display"]').should('exist');
+}
+
+/** Pick the non-default model through the dropdown, exactly as the report does. */
+function selectTargetModel(): void {
+  cy.get('[data-testid="model-selector"]').should('contain.text', 'DeepSeek V4 Pro');
+  cy.get('[data-testid="model-selector"]').click();
+  cy.contains('[role="option"]', TARGET_MODEL_LABEL).click();
+  cy.get('[data-testid="model-selector"]').should('contain.text', TARGET_MODEL_LABEL);
+}
+
+/** Solo one legend series so the restored state is distinguishable from "all on". */
+function soloLegendSeries(): void {
+  cy.get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked').should(
+    'have.length.greaterThan',
+    1,
+  );
+  cy.contains('[data-testid="chart-legend"] label', SOLO_HW_LABEL).click();
+  cy.get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked').should('have.length', 1);
+}
+
+/** Pin the tooltip on a visible point of the soloed series and open its detail page. */
+function openPointDetail(): void {
+  cy.get(`[data-testid="legend-points-${SOLO_HW_KEY}"]`).should('exist');
+  cy.get('[data-testid="inference-chart-display"] svg .dot-group')
+    .should('have.length.greaterThan', 0)
+    .then(($dots) => {
+      const target = [...$dots].find((node) => {
+        const datum = (node as unknown as { __data__?: { hwKey?: string; id?: number } }).__data__;
+        return datum?.hwKey === SOLO_HW_KEY && tracedIds.has(Number(datum?.id));
+      });
+      expect(target, `a traced ${SOLO_HW_KEY} point`).to.not.equal(undefined);
+      cy.wrap(target).find('.visible-shape').click({ force: true });
+    });
+  cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]').should('be.visible').click();
+}
+
+/**
+ * The detail page's two nav controls, addressed by their visible label so this
+ * spec fails on the restoration assertion rather than on a missing hook when
+ * run against a build without the fix.
+ */
+const backControl = (locale: 'en' | 'zh') =>
+  cy.contains('button', locale === 'zh' ? '返回' : 'Back');
+const chartLink = (locale: 'en' | 'zh') =>
+  cy.contains('a', locale === 'zh' ? '推理图表' : 'Inference chart');
+
+/** The state the reader left behind, as it must come back. */
+function assertRestoredChart(): void {
+  cy.get('[data-testid="model-selector"]').should('contain.text', TARGET_MODEL_LABEL);
+  cy.get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked')
+    .should('have.length', 1)
+    .closest('li')
+    .should('contain.text', SOLO_HW_LABEL);
+}
+
+describe('Agentic point detail — returning to the chart', () => {
+  it('carries the chart state into the detail link instead of dropping it', () => {
+    visitChart('/inference');
+    selectTargetModel();
+    soloLegendSeries();
+
+    cy.get('[data-testid="inference-chart-display"] svg .dot-group')
+      .should('have.length.greaterThan', 0)
+      .then(($dots) => {
+        const target = [...$dots].find((node) => {
+          const datum = (node as unknown as { __data__?: { hwKey?: string; id?: number } })
+            .__data__;
+          return datum?.hwKey === SOLO_HW_KEY && tracedIds.has(Number(datum?.id));
+        });
+        cy.wrap(target).find('.visible-shape').click({ force: true });
+      });
+
+    cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]')
+      .should('be.visible')
+      .then(($link) => {
+        const href = $link.attr('href') ?? '';
+        expect(href, 'detail href').to.match(/^\/inference\/agentic\/\d+\?/u);
+        const params = new URLSearchParams(href.slice(href.indexOf('?')));
+        expect(params.get('g_model'), 'g_model carried into the detail link').to.equal('Kimi-K3');
+        expect(params.get('i_active'), 'legend selection carried').to.equal(SOLO_HW_KEY);
+      });
+  });
+
+  it('restores the model and legend when the reader clicks Back', () => {
+    visitChart('/inference');
+    selectTargetModel();
+    soloLegendSeries();
+    openPointDetail();
+
+    cy.location('pathname').should('match', /^\/inference\/agentic\/\d+$/u);
+    backControl('en').click();
+
+    cy.location('pathname').should('eq', '/inference');
+    assertRestoredChart();
+  });
+
+  it('restores the model and legend through the "Inference chart" link', () => {
+    visitChart('/inference');
+    selectTargetModel();
+    soloLegendSeries();
+    openPointDetail();
+
+    chartLink('en')
+      .should('have.attr', 'href')
+      .and('match', /^\/inference\?/u);
+    chartLink('en').click();
+
+    cy.location('pathname').should('eq', '/inference');
+    assertRestoredChart();
+  });
+
+  it('keeps a Chinese reader on /zh for the whole round trip', () => {
+    visitChart('/zh/inference');
+    selectTargetModel();
+    soloLegendSeries();
+    openPointDetail();
+
+    cy.location('pathname').should('match', /^\/zh\/inference\/agentic\/\d+$/u);
+    chartLink('zh')
+      .should('have.attr', 'href')
+      .and('match', /^\/zh\/inference\?/u);
+    chartLink('zh').click();
+
+    cy.location('pathname').should('eq', '/zh/inference');
+    assertRestoredChart();
+  });
+
+  it('does not drop the unofficialruns overlay param on the round trip', () => {
+    visitChart('/inference?unofficialruns=987654321');
+    selectTargetModel();
+    soloLegendSeries();
+
+    cy.get('[data-testid="inference-chart-display"] svg .dot-group')
+      .should('have.length.greaterThan', 0)
+      .then(($dots) => {
+        const target = [...$dots].find((node) => {
+          const datum = (node as unknown as { __data__?: { hwKey?: string; id?: number } })
+            .__data__;
+          return datum?.hwKey === SOLO_HW_KEY && tracedIds.has(Number(datum?.id));
+        });
+        cy.wrap(target).find('.visible-shape').click({ force: true });
+      });
+
+    cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]')
+      .should('be.visible')
+      .then(($link) => {
+        const href = $link.attr('href') ?? '';
+        const params = new URLSearchParams(href.slice(href.indexOf('?')));
+        expect(params.get('unofficialruns'), 'overlay run carried forward').to.equal('987654321');
+      });
+
+    cy.get('[data-chart-tooltip]:visible [data-action="view-charts"]').click();
+    cy.location('search').should('contain', 'unofficialruns=987654321');
+    chartLink('en').should('have.attr', 'href').and('contain', 'unofficialruns=987654321');
+  });
+});

--- a/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
+++ b/packages/app/cypress/e2e/gpu-compare-agentic-detail.cy.ts
@@ -203,7 +203,15 @@ describe('GPU comparison agentic point detail', () => {
       .then(($link) => {
         expect($link).to.match('a');
         expect($link).not.to.have.attr('target');
-        expect($link.attr('href')).to.match(/^\/inference\/agentic\/\d+$/u);
+        const href = $link.attr('href') ?? '';
+        expect(href).to.match(/^\/inference\/agentic\/\d+\?/u);
+        // The chart state rides along so the detail page can link back to the
+        // view the reader left — see agentic-detail-back-nav.cy.ts. Only
+        // non-default values are carried, so `g_model` (DeepSeek-V4-Pro IS the
+        // default) is absent while the scenario and GPU selection are not.
+        const params = new URLSearchParams(href.slice(href.indexOf('?')));
+        expect(params.get('i_seq')).to.equal('agentic-traces');
+        expect(params.get('i_gpus')).to.be.a('string').and.not.equal('');
       });
     cy.location('pathname').should('eq', '/inference');
   });

--- a/packages/app/src/components/inference/agentic-point/agentic-point-detail.tsx
+++ b/packages/app/src/components/inference/agentic-point/agentic-point-detail.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ArrowLeft } from 'lucide-react';
 
 import { useAgenticAggregates } from '@/hooks/api/use-agentic-aggregates';
@@ -14,6 +14,7 @@ import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/seg
 import { track } from '@/lib/analytics';
 import { useLocale } from '@/lib/use-locale';
 import { isZhPathname, ZH_PREFIX } from '@/lib/i18n';
+import { withChartState } from '@/lib/url-state';
 
 import { AggregatesGrid } from './aggregates-grid';
 import { MetricSourceToolbar } from './metric-source-toolbar';
@@ -118,7 +119,19 @@ export function AgenticPointDetail({ id }: Props) {
   const locale = useLocale();
   const t = STRINGS[locale];
   const isZh = isZhPathname(pathname);
-  const inferenceHref = isZh ? `${ZH_PREFIX}/inference` : '/inference';
+  const inferenceBaseHref = isZh ? `${ZH_PREFIX}/inference` : '/inference';
+  // Carry the chart state the reader arrived with back to the chart. The link
+  // used to be a bare path, so it could only ever land on the default model
+  // with the default legend, no matter what the reader was looking at.
+  //
+  // Resolved after mount, not during render: `withChartState` reads the
+  // in-memory param store (seeded from this page's own URL at load), which
+  // does not exist on the server — computing it during render would make the
+  // server and client markup disagree.
+  const [inferenceHref, setInferenceHref] = useState(inferenceBaseHref);
+  useEffect(() => {
+    setInferenceHref(withChartState(inferenceBaseHref));
+  }, [inferenceBaseHref]);
   const viewOptions: SegmentedToggleOption<DetailView>[] = useMemo(
     () => [
       { value: 'point', label: t.perPoint, testId: 'detail-view-point' },
@@ -220,13 +233,20 @@ export function AgenticPointDetail({ id }: Props) {
       <div className="flex items-center gap-2">
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={() => {
+            track('inference_agentic_detail_back_clicked', { id });
+            router.back();
+          }}
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="size-4" /> {t.back}
         </button>
         <span className="text-sm text-muted-foreground">·</span>
-        <Link href={inferenceHref} className="text-sm text-muted-foreground hover:text-foreground">
+        <Link
+          href={inferenceHref}
+          onClick={() => track('inference_agentic_detail_chart_link_clicked', { id })}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
           {t.inferenceChart}
         </Link>
       </div>

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { track } from '@/lib/analytics';
+import { rememberChartStateInUrl } from '@/lib/url-state';
 import * as d3 from 'd3';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTheme } from 'next-themes';
@@ -876,6 +877,10 @@ const GPUGraph = React.memo(
             if (!viewBtn || typeof d.id !== 'number') return;
             viewBtn.addEventListener('click', (event) => {
               event.stopPropagation();
+              // Full-document navigation: stamp the chart state onto THIS
+              // history entry first, or Back returns to a bare /inference that
+              // rebuilds from defaults.
+              rememberChartStateInUrl();
               track('gpu_timeseries_view_charts_opened', {
                 id: d.id,
                 hwKey: String(d.hwKey),

--- a/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
+++ b/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { rememberChartStateInUrl } from '@/lib/url-state';
 import { cn } from '@/lib/utils';
 
 import {
@@ -181,7 +182,13 @@ export default function LegendPointsDialog({
                   key={row.key}
                   href={row.href}
                   {...(row.isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-                  onClick={() => onRowClick?.(row)}
+                  onClick={() => {
+                    // In-app detail links are full-document navigations, so the
+                    // chart state has to be written into this history entry
+                    // before we leave or Back lands on a default chart.
+                    if (!row.isExternal) rememberChartStateInUrl();
+                    onRowClick?.(row);
+                  }}
                   className="col-span-full grid grid-cols-subgrid items-center rounded-sm hover:bg-accent whitespace-nowrap"
                 >
                   {renderCells(row)}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { track } from '@/lib/analytics';
+import { rememberChartStateInUrl } from '@/lib/url-state';
 import * as d3 from 'd3';
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
@@ -1149,7 +1150,7 @@ const ScatterGraph = React.memo(
           title: hwConfig ? getDisplayLabel(hwConfig) : hwKey,
           color: resolveColor(hwKey),
           isOverlay: false,
-          rows: buildLegendPointsRows(pts, false),
+          rows: buildLegendPointsRows(pts, false, locale),
         };
       }
       const { runIndex, runId, branch } = pointsTableTarget;
@@ -1166,7 +1167,7 @@ const ScatterGraph = React.memo(
         title: `✕ ${branch}`,
         color: overlayRunColor(runIndex),
         isOverlay: true,
-        rows: buildLegendPointsRows(pts, true),
+        rows: buildLegendPointsRows(pts, true, locale),
       };
     }, [
       pointsTableTarget,
@@ -1180,6 +1181,7 @@ const ScatterGraph = React.memo(
       processedOverlayData,
       runIndexByUrl,
       activeOverlayHwTypes,
+      locale,
     ]);
 
     // Gradient label data
@@ -1505,6 +1507,10 @@ const ScatterGraph = React.memo(
           if (viewBtn && typeof d.id === 'number') {
             viewBtn.addEventListener('click', (btnEvent) => {
               btnEvent.stopPropagation();
+              // Full-document navigation: stamp the chart state onto THIS
+              // history entry first, or Back returns to a bare /inference that
+              // rebuilds from defaults.
+              rememberChartStateInUrl();
               track('latency_view_charts_opened', {
                 id: d.id,
                 hwKey: String(d.hwKey),

--- a/packages/app/src/components/inference/utils/legend-points-table.test.ts
+++ b/packages/app/src/components/inference/utils/legend-points-table.test.ts
@@ -49,6 +49,16 @@ describe('pointDetailHref', () => {
     });
   });
 
+  it('keeps a Chinese reader on /zh', () => {
+    // The bare path used to hand /zh readers to the English detail page, and
+    // every link out of that page kept them in English.
+    const d = pt({ benchmark_type: 'agentic_traces', id: 206863 });
+    expect(pointDetailHref(d, false, 'zh')).toEqual({
+      href: '/zh/inference/agentic/206863',
+      isExternal: false,
+    });
+  });
+
   it('fixed-seq point links to its GitHub Actions run (repo URL rewritten)', () => {
     const d = pt({
       benchmark_type: 'single_turn',
@@ -117,6 +127,15 @@ describe('buildLegendPointsRows', () => {
       href: '/inference/agentic/1',
       isExternal: false,
     });
+  });
+
+  it('threads the locale through to each row href', () => {
+    const rows = buildLegendPointsRows(
+      [pt({ benchmark_type: 'agentic_traces', id: 1 })],
+      false,
+      'zh',
+    );
+    expect(rows[0].href).toBe('/zh/inference/agentic/1');
   });
 
   it('default-sorts by concurrency ascending', () => {

--- a/packages/app/src/components/inference/utils/legend-points-table.ts
+++ b/packages/app/src/components/inference/utils/legend-points-table.ts
@@ -1,5 +1,7 @@
 import { updateRepoUrl } from '@/lib/utils';
+import { agenticDetailHref } from '@/lib/agentic-detail-link';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
+import type { Locale } from '@/lib/i18n';
 
 import type { InferenceData } from '@/components/inference/types';
 import { fmt, getPointLabel } from '@/components/inference/utils/tooltipUtils';
@@ -55,10 +57,11 @@ const num = (v: number | undefined | null): number | null =>
 export function pointDetailHref(
   d: InferenceData,
   isOverlay: boolean,
+  locale: Locale = 'en',
 ): { href: string | null; isExternal: boolean } {
   if (isOverlay) return { href: null, isExternal: false };
   if (d.benchmark_type === 'agentic_traces' && isPersistedBenchmarkId(d.id)) {
-    return { href: `/inference/agentic/${d.id}`, isExternal: false };
+    return { href: agenticDetailHref(d.id, locale), isExternal: false };
   }
   if (d.run_url) return { href: updateRepoUrl(d.run_url), isExternal: true };
   return { href: null, isExternal: false };
@@ -72,10 +75,11 @@ export function pointDetailHref(
 export function buildLegendPointsRows(
   points: InferenceData[],
   isOverlay: boolean,
+  locale: Locale = 'en',
 ): LegendPointsTableRow[] {
   return points
     .map((d, i) => {
-      const { href, isExternal } = pointDetailHref(d, isOverlay);
+      const { href, isExternal } = pointDetailHref(d, isOverlay, locale);
       return {
         key: `${d.hwKey}|${d.precision}|${d.conc}|${getPointLabel(d)}|${d.offload_mode ?? ''}|${i}`,
         conc: d.conc,

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -178,6 +178,13 @@ describe('generateTooltipContent', () => {
     expect(html).not.toContain('data-action="view-charts" target=');
   });
 
+  it('points View charts at the /zh detail page for a Chinese reader', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ id: 1 }), isPinned: true, hasTrace: true, locale: 'zh' }),
+    );
+    expect(html).toContain('href="/zh/inference/agentic/1"');
+  });
+
   it('omits View charts when the point id is non-persisted (0 / NaN), even if pinned + hasTrace', () => {
     // Overlay agentic points arrive with id 0 / NaN — the button would otherwise
     // link to /inference/agentic/0, a doomed lookup.

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -1,5 +1,6 @@
 import { formatNumber, getDisplayLabel } from '@/lib/utils';
 import { specMethodDisplayLabel } from '@/lib/compare-variant-slug';
+import { agenticDetailHref } from '@/lib/agentic-detail-link';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import type { Locale } from '@/lib/i18n';
 import { isKvOffloadEnabled } from '@/lib/kv-offload';
@@ -236,9 +237,10 @@ const viewChartsButtonHTML = (
   isPinned: boolean,
   hasTraceData: boolean,
   pointId: number | undefined,
+  locale: Locale,
 ): string => {
   if (!isPinned || !hasTraceData || !isPersistedBenchmarkId(pointId)) return '';
-  return `<a data-action="view-charts" href="/inference/agentic/${pointId}" style="
+  return `<a data-action="view-charts" href="${agenticDetailHref(pointId, locale)}" style="
     display: block; margin-top: 8px; width: 100%; padding: 4px 8px; font-size: 11px; font-weight: 500;
     border: 1px solid var(--border); border-radius: 6px; cursor: pointer;
     background: var(--accent); color: var(--accent-foreground); text-align: center; text-decoration: none;
@@ -420,7 +422,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
       ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
       ${runLinkHTML(runUrl)}
-      ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id)}
+      ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id, locale)}
     </div>
   `;
 };
@@ -542,7 +544,7 @@ export const generateGPUGraphTooltipContent = (config: TooltipConfig): string =>
       ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
       ${runLinkHTML(runUrl)}
-      ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id)}
+      ${viewChartsButtonHTML(isPinned, Boolean(hasTrace), d.id, locale)}
     </div>
   `;
 };

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,11 +1,13 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
 import { useCallback, useRef } from 'react';
 
 import {
   type UrlStateKey,
   type UrlStateParams,
   readUrlParams,
+  refreshUrlParamsOnNavigation,
   writeUrlParams,
 } from '@/lib/url-state';
 
@@ -16,6 +18,19 @@ import {
  */
 export function useUrlState() {
   const initialParams = useRef<UrlStateParams | null>(null);
+
+  // The load-time snapshot in `url-state.ts` is captured once per document, so
+  // on a client-side navigation every provider below would initialise from the
+  // params of the page the user came FROM. Refresh during render — before the
+  // `useState` initialisers and mount effects of the providers underneath —
+  // and only once per navigation, so a component mounting later on the same
+  // path cannot re-import the URL over filter changes made since.
+  //
+  // `usePathname`, not `useSearchParams`: the latter forces every statically
+  // prerendered page that mounts a filter provider behind a Suspense boundary,
+  // which fails the build on /ai-chart.
+  const pathname = usePathname();
+  refreshUrlParamsOnNavigation(pathname ?? '');
 
   // read URL params only once (synchronous, before first render)
   if (initialParams.current === null) {

--- a/packages/app/src/lib/agentic-detail-link.test.ts
+++ b/packages/app/src/lib/agentic-detail-link.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+function setupWindow(search = '', pathname = '/inference') {
+  vi.stubGlobal('window', {
+    location: { search, pathname, hash: '', origin: 'https://example.com' },
+    history: { replaceState: vi.fn(), state: null },
+  });
+}
+
+describe('agenticDetailHref', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps a Chinese reader on /zh', async () => {
+    setupWindow('', '/zh/inference');
+    const { agenticDetailHref } = await import('@/lib/agentic-detail-link');
+
+    // Without the prefix the /zh chart handed readers to the English detail
+    // page, and every link out of that page kept them in English.
+    expect(agenticDetailHref(440106, 'zh')).toBe('/zh/inference/agentic/440106');
+    expect(agenticDetailHref(440106, 'en')).toBe('/inference/agentic/440106');
+  });
+
+  it('defaults to the English path when no locale is given', async () => {
+    setupWindow('', '/inference');
+    const { agenticDetailHref } = await import('@/lib/agentic-detail-link');
+    expect(agenticDetailHref(440106)).toBe('/inference/agentic/440106');
+  });
+
+  it('carries the chart state so the detail page can link back to it', async () => {
+    setupWindow('', '/inference');
+    const { agenticDetailHref } = await import('@/lib/agentic-detail-link');
+    const { writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3', i_active: 'gb200_dynamo-vllm' });
+    const href = agenticDetailHref(440106, 'en');
+    const params = new URLSearchParams(href.slice(href.indexOf('?')));
+
+    expect(href.startsWith('/inference/agentic/440106?')).toBe(true);
+    expect(params.get('g_model')).toBe('Kimi-K3');
+    expect(params.get('i_active')).toBe('gb200_dynamo-vllm');
+  });
+
+  it('carries an unofficial-run overlay so the round trip keeps the overlay', async () => {
+    setupWindow('?unofficialruns=987654321', '/inference');
+    const { agenticDetailHref } = await import('@/lib/agentic-detail-link');
+    const { writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3' });
+    const href = agenticDetailHref(440106, 'zh');
+    const params = new URLSearchParams(href.slice(href.indexOf('?')));
+
+    expect(href.startsWith('/zh/inference/agentic/440106?')).toBe(true);
+    expect(params.get('unofficialruns')).toBe('987654321');
+  });
+
+  it('stays a bare path when the chart is on defaults', async () => {
+    setupWindow('', '/inference');
+    const { agenticDetailHref } = await import('@/lib/agentic-detail-link');
+    const { writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'DeepSeek-V4-Pro' });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(agenticDetailHref(440106, 'en')).toBe('/inference/agentic/440106');
+  });
+});

--- a/packages/app/src/lib/agentic-detail-link.ts
+++ b/packages/app/src/lib/agentic-detail-link.ts
@@ -1,0 +1,24 @@
+import { ZH_PREFIX, type Locale } from '@/lib/i18n';
+import { withChartState } from '@/lib/url-state';
+
+/**
+ * In-app href for an agentic point's detail page.
+ *
+ * Two things the bare `/inference/agentic/<id>` path got wrong:
+ *
+ *  - It dropped the `/zh` prefix, so a Chinese reader clicking a point landed
+ *    on the English detail page and every link out of it kept them there.
+ *  - It carried no chart state. These links are plain `<a href>` (they must
+ *    support open-in-new-tab), so following one is a full-document navigation
+ *    that destroys the in-memory filter store. Without the params in the URL
+ *    the detail page has no way to send the reader back to the chart they
+ *    left, and it opens on the default model with the default legend.
+ *
+ * The params are stripped from the address bar again on load (see
+ * `url-state.ts`), so the detail page still shows a clean URL — they survive
+ * in the in-memory store, which is what `withChartState` reads back when the
+ * detail page builds its "Inference chart" link.
+ */
+export function agenticDetailHref(pointId: number, locale: Locale = 'en'): string {
+  return withChartState(`${locale === 'zh' ? ZH_PREFIX : ''}/inference/agentic/${pointId}`);
+}

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // helper to set up window mocks before module import
-function setupWindow(search = '', pathname = '/inference') {
+function setupWindow(search = '', pathname = '/inference', hash = '') {
   const location = {
     search,
     pathname,
+    hash,
     origin: 'https://example.com',
   };
-  const history = { replaceState: vi.fn() };
+  const history = { replaceState: vi.fn(), state: { __NA: 1 } };
 
   vi.stubGlobal('window', { location, history });
   return { location, history };
@@ -526,5 +527,263 @@ describe('buildShareUrl unofficialrun handling', () => {
 
     const url = buildShareUrl();
     expect(url).not.toContain('unofficialrun');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Carrying chart state across a full-document navigation.
+//
+// Filter changes only ever reach the in-memory store — the address bar is
+// stripped clean after load — so the history entry behind a detail-page link
+// was a bare `/inference` that rebuilt from defaults on Back.
+// ---------------------------------------------------------------------------
+
+describe('currentChartSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the inference params a share link would carry', async () => {
+    setupWindow('', '/inference');
+    const { currentChartSearch, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3', i_active: 'gb200_dynamo-vllm', i_seq: 'agentic-traces' });
+    // Reads through the debounce rather than around it: the click that
+    // navigates away can land inside the 150ms window.
+    const search = currentChartSearch();
+
+    expect(new URLSearchParams(search).get('g_model')).toBe('Kimi-K3');
+    expect(new URLSearchParams(search).get('i_active')).toBe('gb200_dynamo-vllm');
+    expect(new URLSearchParams(search).get('i_seq')).toBe('agentic-traces');
+  });
+
+  it('resolves the tab through the /zh prefix and any trailing segments', async () => {
+    setupWindow('', '/zh/inference/agentic/440106');
+    const { currentChartSearch, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3', r_range: 'all-time' });
+    const params = new URLSearchParams(currentChartSearch());
+
+    // `inference` prefixes, not the reliability tab's — a detail page carries
+    // the chart it was opened from.
+    expect(params.get('g_model')).toBe('Kimi-K3');
+    expect(params.has('r_range')).toBe(false);
+  });
+
+  it('is empty when every value is at its default', async () => {
+    setupWindow('', '/inference');
+    const { currentChartSearch, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'DeepSeek-V4-Pro', r_range: 'last-3-months' });
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(currentChartSearch()).toBe('');
+  });
+
+  it('is a no-op without a window (SSR)', async () => {
+    vi.stubGlobal('window', undefined);
+    const { currentChartSearch } = await import('@/lib/url-state');
+    expect(currentChartSearch()).toBe('');
+  });
+});
+
+describe('rememberChartStateInUrl', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('writes the chart state into the current history entry', async () => {
+    const { history } = setupWindow('', '/inference');
+    const { rememberChartStateInUrl, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3', i_active: 'gb200_dynamo-vllm' });
+    rememberChartStateInUrl();
+
+    expect(history.replaceState).toHaveBeenCalledTimes(1);
+    const [state] = history.replaceState.mock.calls[0] as [unknown, string, string];
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    // Next patches replaceState and keeps its routing bookkeeping in `state`;
+    // dropping it would strand the router on the entry we just rewrote.
+    expect(state).toEqual({ __NA: 1 });
+    expect(url.startsWith('/inference?')).toBe(true);
+    const params = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(params.get('g_model')).toBe('Kimi-K3');
+    expect(params.get('i_active')).toBe('gb200_dynamo-vllm');
+  });
+
+  it('keeps the pathname and hash intact', async () => {
+    const { history } = setupWindow('', '/zh/inference', '#chart');
+    const { rememberChartStateInUrl, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3' });
+    rememberChartStateInUrl();
+
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    expect(url).toBe('/zh/inference?g_model=Kimi-K3#chart');
+  });
+
+  it('leaves a default-only chart on a bare path rather than an empty query', async () => {
+    const { history } = setupWindow('', '/inference');
+    const { rememberChartStateInUrl } = await import('@/lib/url-state');
+
+    expect(rememberChartStateInUrl()).toBe('');
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    expect(url).toBe('/inference');
+  });
+
+  it('carries an unofficial run overlay across the navigation', async () => {
+    const { history } = setupWindow('?unofficialruns=987654321', '/inference');
+    const { rememberChartStateInUrl, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3' });
+    rememberChartStateInUrl();
+
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    expect(new URLSearchParams(url.slice(url.indexOf('?'))).get('unofficialruns')).toBe(
+      '987654321',
+    );
+  });
+
+  it('is a no-op without a window (SSR)', async () => {
+    vi.stubGlobal('window', undefined);
+    const { rememberChartStateInUrl } = await import('@/lib/url-state');
+    expect(() => rememberChartStateInUrl()).not.toThrow();
+    expect(rememberChartStateInUrl()).toBe('');
+  });
+});
+
+describe('withChartState', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('appends the chart state to an in-app href', async () => {
+    setupWindow('', '/inference');
+    const { withChartState, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3', i_active: 'gb200_dynamo-vllm' });
+    const href = withChartState('/inference/agentic/440106');
+
+    expect(href.startsWith('/inference/agentic/440106?')).toBe(true);
+    expect(new URLSearchParams(href.slice(href.indexOf('?'))).get('g_model')).toBe('Kimi-K3');
+  });
+
+  it('merges into an href that already has a query', async () => {
+    setupWindow('', '/inference');
+    const { withChartState, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3' });
+    const href = withChartState('/inference?view=timeline');
+
+    expect(href).toBe('/inference?view=timeline&g_model=Kimi-K3');
+  });
+
+  it('returns the href untouched when there is no state to carry', async () => {
+    setupWindow('', '/inference');
+    const { withChartState } = await import('@/lib/url-state');
+
+    expect(withChartState('/inference/agentic/440106')).toBe('/inference/agentic/440106');
+  });
+
+  it('returns the href untouched without a window (SSR)', async () => {
+    vi.stubGlobal('window', undefined);
+    const { withChartState } = await import('@/lib/url-state');
+    expect(withChartState('/inference')).toBe('/inference');
+  });
+});
+
+describe('refreshUrlParamsOnNavigation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('pulls the new URL in once per navigation', async () => {
+    const { location } = setupWindow('', '/');
+    const { readUrlParams, refreshUrlParamsOnNavigation } = await import('@/lib/url-state');
+
+    // First call on a fresh document still refreshes — the load-time snapshot
+    // and the live URL agree, so it is a no-op in effect.
+    expect(refreshUrlParamsOnNavigation('/')).toBe(true);
+
+    location.search = '?g_model=Kimi-K3&i_active=gb200_dynamo-vllm';
+    location.pathname = '/inference';
+    expect(refreshUrlParamsOnNavigation('/inference')).toBe(true);
+    expect(readUrlParams().g_model).toBe('Kimi-K3');
+    expect(readUrlParams().i_active).toBe('gb200_dynamo-vllm');
+  });
+
+  it('does not re-import the URL for a component mounting later on the same path', async () => {
+    const { location } = setupWindow('?g_model=Kimi-K3', '/inference');
+    const { readUrlParams, refreshUrlParamsOnNavigation } = await import('@/lib/url-state');
+
+    expect(refreshUrlParamsOnNavigation('/inference')).toBe(true);
+    expect(readUrlParams().g_model).toBe('Kimi-K3');
+
+    // The user picks another model. Writes go to the in-memory store, never the
+    // address bar, so the stale URL must not be replayed over the new choice
+    // when some unrelated component mounts.
+    location.search = '?g_model=Kimi-K3';
+    expect(refreshUrlParamsOnNavigation('/inference')).toBe(false);
+  });
+});
+
+describe('rememberChartStateInUrl — params this module does not own', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps unrelated query params on the entry it rewrites', async () => {
+    const { history } = setupWindow('?utm_source=twitter', '/inference');
+    const { rememberChartStateInUrl, writeUrlParams } = await import('@/lib/url-state');
+
+    writeUrlParams({ g_model: 'Kimi-K3' });
+    rememberChartStateInUrl();
+
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    const params = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(params.get('utm_source')).toBe('twitter');
+    expect(params.get('g_model')).toBe('Kimi-K3');
+  });
+
+  it('collapses the singular unofficialrun spelling onto the canonical plural', async () => {
+    const { history } = setupWindow('?unofficialrun=987654321', '/inference');
+    const { rememberChartStateInUrl } = await import('@/lib/url-state');
+
+    rememberChartStateInUrl();
+
+    const url = (history.replaceState.mock.calls[0] as [unknown, string, string])[2];
+    const params = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(params.get('unofficialruns')).toBe('987654321');
+    expect(params.has('unofficialrun')).toBe(false);
   });
 });

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -219,6 +219,34 @@ export function refreshUrlParams(): UrlStateParams {
   return _initialParams;
 }
 
+/**
+ * Pathname of the last navigation whose params were pulled into the snapshot.
+ * Module-level (not a hook ref) so only the FIRST `useUrlState` consumer to
+ * render after a navigation does the work: a component that mounts later on
+ * the same path must not re-import the URL over filter changes the user has
+ * made since.
+ */
+let lastRefreshedPathname: string | null = null;
+
+/**
+ * Refresh the snapshot once per client-side navigation.
+ *
+ * Providers read their initial state through `getUrlParam` during render, so
+ * the snapshot has to be current BEFORE they initialise. `useUrlState` calls
+ * this while rendering, which puts it ahead of every provider below the
+ * component that called it first (React renders top-down), and ahead of the
+ * mount effects that read `i_gpus` and friends.
+ *
+ * Returns whether a refresh actually happened, which is what the unit tests
+ * assert on.
+ */
+export function refreshUrlParamsOnNavigation(pathname: string): boolean {
+  if (lastRefreshedPathname === pathname) return false;
+  lastRefreshedPathname = pathname;
+  refreshUrlParams();
+  return true;
+}
+
 /** Check whether the current URL has any share-link params. */
 export function hasAnyUrlParams(): boolean {
   if (typeof window === 'undefined') return false;
@@ -278,12 +306,15 @@ function flushPendingParams(): void {
  */
 const UNOFFICIAL_RUN_PARAM_RE = /^unofficialruns?$/iu;
 
-export function buildShareUrl(): string {
+/**
+ * Current in-memory state for `tab`, plus any unofficial-run IDs in the address
+ * bar, as a `URLSearchParams`. Flushes pending writes first so the caller sees
+ * the newest filter change rather than the one before it.
+ */
+function collectTabParams(tab: string): URLSearchParams {
   flushPendingParams();
 
-  const pathTab = window.location.pathname.split('/').filter(Boolean)[0] || 'inference';
-  const prefixes = TAB_PARAM_PREFIXES[pathTab] ?? TAB_PARAM_PREFIXES.inference;
-
+  const prefixes = TAB_PARAM_PREFIXES[tab] ?? TAB_PARAM_PREFIXES.inference;
   const filtered = new URLSearchParams();
   for (const [key, value] of Object.entries(currentState)) {
     if (prefixes.some((p) => key.startsWith(p))) {
@@ -303,6 +334,83 @@ export function buildShareUrl(): string {
     }
   }
 
-  const search = filtered.toString();
+  return filtered;
+}
+
+export function buildShareUrl(): string {
+  const pathTab = window.location.pathname.split('/').filter(Boolean)[0] || 'inference';
+  const search = collectTabParams(pathTab).toString();
   return `${window.location.origin}/${pathTab}${search ? `?${search}` : ''}`;
+}
+
+/**
+ * Which tab's params matter for a pathname, ignoring the `/zh` prefix and any
+ * trailing segments. `/zh/inference/agentic/206863` and `/inference` both
+ * resolve to `inference`, so a detail page carries the chart's params.
+ */
+function tabForPathname(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  const first = segments[0] === 'zh' ? segments[1] : segments[0];
+  return first || 'inference';
+}
+
+/**
+ * The chart state this page would share, as a query string (no leading `?`).
+ * Empty when every value is at its default.
+ */
+export function currentChartSearch(): string {
+  if (typeof window === 'undefined') return '';
+  return collectTabParams(tabForPathname(window.location.pathname)).toString();
+}
+
+/**
+ * Write the chart state into the CURRENT history entry, so Back restores it.
+ *
+ * Filter changes only ever reach the in-memory `currentState` — the address bar
+ * is deliberately stripped clean after load — so the entry the browser returns
+ * to is a bare `/inference` that rebuilds from defaults. Detail-page links are
+ * plain `<a href>` (they must support open-in-new-tab), i.e. full-document
+ * navigations that also destroy this module, so the URL is the only channel
+ * that survives. Call this immediately before navigating away from a chart.
+ *
+ * `history.state` is passed straight through so the Next router's own entry
+ * bookkeeping is not clobbered.
+ */
+export function rememberChartStateInUrl(): string {
+  if (typeof window === 'undefined') return '';
+  const { pathname, hash, search: liveSearch } = window.location;
+  const chartParams = collectTabParams(tabForPathname(pathname));
+
+  // Start from whatever is already in the address bar so params this module
+  // does not own (campaign tags and the like) survive the rewrite, then layer
+  // the chart state on top. Both unofficial-run spellings are cleared first —
+  // `collectTabParams` re-emits the canonical plural form.
+  const merged = new URLSearchParams(liveSearch);
+  for (const key of URL_STATE_KEYS) merged.delete(key);
+  const unofficialKeys: string[] = [];
+  for (const key of merged.keys()) {
+    if (UNOFFICIAL_RUN_PARAM_RE.test(key)) unofficialKeys.push(key);
+  }
+  // Deleting inside the iteration above would skip entries.
+  for (const key of unofficialKeys) merged.delete(key);
+  for (const [key, value] of chartParams) merged.set(key, value);
+
+  const search = merged.toString();
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${pathname}${search ? `?${search}` : ''}${hash}`,
+  );
+  return chartParams.toString();
+}
+
+/**
+ * Append the current chart state to an outbound in-app href, so the page it
+ * opens can link back to the chart the user left. Used for the agentic
+ * point-detail links, which are full-document navigations.
+ */
+export function withChartState(href: string): string {
+  const search = currentChartSearch();
+  if (!search) return href;
+  return `${href}${href.includes('?') ? '&' : '?'}${search}`;
 }


### PR DESCRIPTION
## The bug

1. Load `/inference`.
2. Switch to a non-default model (default is DeepSeek V4 Pro) and/or change the legend selection.
3. Click a point → **View charts** → `/inference/agentic/<id>`.
4. Click **Back** or **Inference chart**.

The chart came back on DeepSeek V4 Pro with every legend series on. Everything the reader had selected was gone.

## Root cause

The chart's filter state **never reaches the address bar**. `url-state.ts` snapshots the share params at load, strips them from the URL on a `setTimeout(0)`, and keeps every later change in a module-level `currentState` that is only read when someone asks for a share link. So the URL of the `/inference` history entry describes nothing.

The point-detail links are plain `<a href>` — deliberately, so browsers can offer open-in-new-tab (`tooltipUtils.viewChartsButtonHTML`, `legend-points-table.pointDetailHref`). Following one is therefore a **full-document navigation** that tears down that module along with the state. I confirmed this in a browser: a `window.__marker` set on `/inference` is gone on the detail page.

Both halves have to be true for the bug to appear, which is why it looks like two problems. It is one: **the state exists only in memory, and the navigation destroys memory.**

Two separate defects follow from it:

**Defect 1 — the "Inference chart" link hardcoded a bare path.**

```ts
const inferenceHref = isZh ? `${ZH_PREFIX}/inference` : '/inference';
```

Even if the state had been recoverable, this link discarded it. It could only ever land on defaults.

**Defect 2 — nothing wrote the state anywhere the navigation could survive.** `router.back()` was innocent: it correctly returned to the previous entry, and that entry's URL was a bare `/inference`.

Not the cause, despite looking like one: `InferenceContext`'s `gpuUrlHydrated` flag. It is a mount-only guard that reads `i_gpus` from the snapshot, and the provider genuinely does remount here — but the snapshot it reads is rebuilt from the URL on a full-document load, so it restores correctly once the URL carries the params.

## The fix

Three helpers in `url-state.ts`, sharing one param-collection path with `buildShareUrl`:

| Helper | Called from | Does |
| --- | --- | --- |
| `rememberChartStateInUrl()` | the three point-click handlers | `history.replaceState`s the chart state onto the entry Back will return to |
| `withChartState(href)` | `agenticDetailHref()` | appends it to the outbound detail link |
| `currentChartSearch()` | both | resolves the tab through the `/zh` prefix and trailing segments, flushes pending writes, filters by tab prefix |

`rememberChartStateInUrl` passes `window.history.state` through unchanged (Next patches `replaceState` and keeps its routing bookkeeping there) and merges onto the live query string, so params this module does not own — campaign tags, `unofficialruns` — survive the rewrite.

Because `currentState` is seeded from the URL at load, the detail page can read the same state back through `withChartState` even after a hard navigation. Its own URL is stripped clean on load as usual, so the detail page still shows a tidy address bar.

Both controls are now covered:

- **Back** → `router.back()` lands on the stamped entry, which reloads with the params and restores everything.
- **Inference chart** → carries the params forward, and keeps the `/zh` prefix.

### Shared re-hydration, not a second mechanism

`useUrlState` now calls `refreshUrlParamsOnNavigation(pathname)` **during render**. PR #795 fixed the same class of bug for `GlobalFilterContext` with a `usePathname`-keyed effect, but effects run *after* the `useState` initialisers and mount effects of everything below them — so `InferenceProvider` was still reading the previous page's snapshot for `i_gpus`, `i_metric` and `i_active`. That is a real pre-existing bug on any soft navigation into `/inference` with a share link. Refreshing inside the hook puts it ahead of every provider that consumes it (React renders top-down), and a module-level last-pathname guard means it runs at most once per navigation, so a component mounting later on the same path cannot replay a stale URL over filter changes the user has made since.

Providers now covered: `GlobalFilterProvider`, `InferenceProvider`, `EvaluationProvider`, `ReliabilityProvider`, and `ThroughputCalculatorDisplay` — every `useUrlState` consumer. `GlobalFilterContext`'s own `refreshUrlParams()` call is left in place; it is now redundant but harmless, and removing it would weaken #795's explicit contract if the hook is ever refactored.

### Chinese pages

Point links resolved to `/inference/agentic/<id>` regardless of locale, so a reader on `/zh/inference` was handed the English detail page and every link out of it kept them in English. `agenticDetailHref(id, locale)` now prefixes `/zh`, and the detail page's own links stay on `/zh`. No new user-visible strings were added — the existing `en`/`zh` dict covers both controls.

### Unofficial-run overlays

`currentChartSearch` reuses `buildShareUrl`'s unofficial-run carry-over, so `unofficialruns` rides along on the detail href and on the stamped entry; both spellings (`unofficialrun` / `unofficialruns`) collapse onto the canonical plural. A round trip from an overlay point keeps the overlay loaded. Covered by an E2E case.

## Verification

- Reproduced the reset in a real browser against the live read-only DB, before any change: Kimi K3 + soloed GB200 → point → Back → `DeepSeek V4 Pro` + all series on.
- Same walkthrough after the fix, on `/inference` **and** `/zh/inference`, through **both** Back and "Inference chart": model and legend restored, `lang="zh-CN"` preserved, 0 console errors. Legend-points-table rows verified to carry the state too.
- New spec `cypress/e2e/agentic-detail-back-nav.cy.ts` (5 cases: detail href carries state, Back restores, "Inference chart" restores, `/zh` round trip, `unofficialruns` survives). Run against a build **without** the fix, all 5 fail with the reported symptom — the Back case reports `-'DeepSeek V4 Pro 1.6T'` / `+'Kimi K3'`.
- Unit coverage for `rememberChartStateInUrl`, `withChartState`, `currentChartSearch`, `refreshUrlParamsOnNavigation` (including the SSR and once-per-navigation paths) and `agenticDetailHref`.
- `bun run lint`, `bun run fmt`, `bun run typecheck`, `bun run test:unit` (4156 tests), `bun run build` — all clean.
- Full Cypress suite: 684 integration + 221 component, all passing. One pre-existing assertion in `gpu-compare-agentic-detail.cy.ts` was updated — it pinned the detail href to a bare path; it now asserts the carried params instead.

## Notes for review

- Only non-default values are carried, so a chart already on defaults still produces a bare link — `g_model` is absent when the model is DeepSeek V4 Pro. That is correct, and the updated `gpu-compare-agentic-detail` assertion documents it.
- After a Back, the restored `/inference` URL keeps the params visible for a moment; Next's router re-applies the entry URL after hydration, racing the existing load-time strip. Cosmetic, and arguably an improvement (the view becomes copy-pasteable). Left alone rather than fighting the router.
- Deliberately left out: **Back** still calls `router.back()` unconditionally. In a tab opened via cmd+click on a detail link there is no in-app history, so it does nothing — a pre-existing dead control. Falling back to the chart link would fix it but adds a branch that Cypress cannot exercise; happy to add it if wanted.
- Coordination: another change is in flight on the agentic chart's coach-mark / point-click affordance. My change to the point-click handlers is one added line in each of `ScatterGraph.tsx` and `GPUGraph.tsx` (a `rememberChartStateInUrl()` call inside the existing `view-charts` listener) plus a `locale` argument threaded to `buildLegendPointsRows`, so the two should reconcile cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared URL-state and history.replaceState used by every filter provider, so a bug could mis-hydrate filters on client navigations. Behavior is well covered by unit and Cypress tests.
> 
> **Overview**
> Returning from an agentic point-detail page no longer rebuilds the inference chart from defaults. Filter state lived only in memory while the address bar was stripped, and the detail links are full-document `<a href>`s, so Back landed on a bare `/inference`.
> 
> **`url-state`** now stamps non-default chart params onto the current history entry (`rememberChartStateInUrl`) and onto outbound detail hrefs (`withChartState` / `agenticDetailHref`). The detail page’s “Inference chart” link is built the same way after mount. `unofficialruns` and unrelated query params survive the rewrite.
> 
> **`useUrlState`** refreshes the param snapshot **during render**, once per pathname, so providers initialize from the page they landed on rather than the previous one. Point links also keep the `/zh` prefix.
> 
> Covered by a new Cypress round-trip spec plus unit tests for the helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a17270701964cd3647293c53c253e0508e4256e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->