### PR TITLE
feat(overview): persist presentation intent in URL / 在 URL 中保存 Overview 演示状态

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -63,6 +63,37 @@ function expectNoHorizontalScroller(testId: string) {
   });
 }
 
+function stubFullscreenApi(win: Window) {
+  let fullscreenElement: Element | null = null;
+  const document = win.document;
+  const EventConstructor = document.defaultView?.Event ?? Event;
+  const ElementConstructor = document.defaultView?.Element ?? Element;
+  Object.defineProperty(document, 'fullscreenEnabled', {
+    configurable: true,
+    value: true,
+  });
+  Object.defineProperty(document, 'fullscreenElement', {
+    configurable: true,
+    get: () => fullscreenElement,
+  });
+  Object.defineProperty(document, 'exitFullscreen', {
+    configurable: true,
+    value: () => {
+      fullscreenElement = null;
+      document.dispatchEvent(new EventConstructor('fullscreenchange'));
+      return Promise.resolve();
+    },
+  });
+  Object.defineProperty(ElementConstructor.prototype, 'requestFullscreen', {
+    configurable: true,
+    value() {
+      fullscreenElement = document.querySelector('[data-testid="overview-presentation-surface"]');
+      document.dispatchEvent(new EventConstructor('fullscreenchange'));
+      return Promise.resolve();
+    },
+  });
+}
+
 /**
  * The row header shows the acronym so the 22%-wide model column stays one line,
  * and keeps the full scenario name for assistive tech and the hover title. Both
@@ -369,6 +400,10 @@ describe('Overview page', () => {
 
     cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
     cy.location('search').should('eq', '?tier=100');
+    cy.get('[data-testid="overview-tier-switcher"] [aria-current="page"]').should(
+      'have.text',
+      '100',
+    );
     cy.then(() => {
       expect(jsonRequests, 'the click reuses the warmed response').to.equal(1);
     });
@@ -557,6 +592,98 @@ describe('Overview page', () => {
       });
     cy.contains('当前成本及其相对 30–60 天前最近一次有效平台结果的变化。').should('exist');
     cy.contains('缺少有效 30 天对比的平台仅显示当前成本。').should('exist');
+  });
+
+  it('keeps client-only presentation intent across selectors without forcing fullscreen on load', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview?tier=75&present=1&utm_source=deck#matrix', {
+      onBeforeLoad: stubFullscreenApi,
+    });
+
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'false',
+    );
+    cy.get('[data-testid="language-toggle"]').should(
+      'have.attr',
+      'href',
+      '/zh/overview?tier=75&present=1&utm_source=deck',
+    );
+
+    cy.get('[data-testid="overview-present-toggle"]').click();
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'true',
+    );
+    cy.location('search').should('eq', '?tier=75&present=1&utm_source=deck');
+    cy.location('hash').should('eq', '#matrix');
+
+    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
+    cy.location('search').should('eq', '?tier=100&present=1&utm_source=deck');
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'true',
+    );
+
+    cy.get('[data-overview-comparison="30d"]').click();
+    cy.location('search').should('eq', '?tier=100&compare=30d&present=1&utm_source=deck');
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'true',
+    );
+
+    cy.get('[data-testid="overview-present-toggle"]').click();
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'false',
+    );
+    cy.location('search').should('eq', '?tier=100&compare=30d&utm_source=deck');
+    cy.location('hash').should('eq', '#matrix');
+    cy.get('[data-testid="language-toggle"]').should(
+      'have.attr',
+      'href',
+      '/zh/overview?tier=100&compare=30d&utm_source=deck',
+    );
+  });
+
+  it('reasserts presentation intent when browser history changes during fullscreen', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview?tier=75', { onBeforeLoad: stubFullscreenApi });
+
+    // A selector push creates a real same-document history entry.
+    cy.get('[data-testid="overview-tier-switcher"]').contains('a', '100').click();
+    cy.location('search').should('eq', '?tier=100');
+    cy.get('[data-testid="overview-present-toggle"]').click();
+    cy.location('search').should('eq', '?tier=100&present=1');
+
+    cy.window().then((win) => win.history.back());
+    cy.location('search').should('eq', '?tier=75&present=1');
+    cy.get('[data-testid="overview-presentation-surface"]').should(
+      'have.attr',
+      'data-presenting',
+      'true',
+    );
+  });
+
+  it('leaves comparison paging to a focused presentation select option', () => {
+    cy.viewport(1280, 900);
+    cy.visit('/overview?compare=30d', { onBeforeLoad: stubFullscreenApi });
+    cy.get('[data-testid="overview-present-toggle"]').click();
+
+    cy.get('[data-testid="overview-history-window-select"]').click();
+    cy.get('[role="option"]').first().focus().trigger('keydown', {
+      key: 'ArrowRight',
+      code: 'ArrowRight',
+      bubbles: true,
+    });
+
+    cy.location('search').should('eq', '?compare=30d&present=1');
+    cy.get('[data-overview-comparison="30d"]').should('have.attr', 'aria-current', 'true');
   });
 
   it('switches the history window through the embedded selector', () => {

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -266,8 +266,23 @@ export function OverviewNavigationProvider({
 
   const replaceClientState = useCallback(
     (targetHref: string, keys: readonly OverviewClientOnlySearchKey[]) => {
-      const pending = mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys);
-      const committed = mergeOverviewControlHref(committedHrefRef.current, targetHref, keys);
+      // A child effect can request client-only cleanup before this provider's
+      // mount effect adopts the loaded URL. Rebase both snapshots on the live
+      // address first so campaign params and the fragment survive that race,
+      // while server-owned keys still come from their pending/committed state.
+      const actualHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const pendingBase = mergeOverviewControlHref(
+        actualHref,
+        pendingHrefRef.current,
+        OVERVIEW_SERVER_SEARCH_KEYS,
+      );
+      const committedBase = mergeOverviewControlHref(
+        actualHref,
+        committedHrefRef.current,
+        OVERVIEW_SERVER_SEARCH_KEYS,
+      );
+      const pending = mergeOverviewControlHref(pendingBase, targetHref, keys);
+      const committed = mergeOverviewControlHref(committedBase, targetHref, keys);
       pendingHrefRef.current = pending;
       committedHrefRef.current = committed;
       setPendingHref(pending);

--- a/packages/app/src/components/overview/overview-navigation.tsx
+++ b/packages/app/src/components/overview/overview-navigation.tsx
@@ -31,13 +31,19 @@ import {
   mergeOverviewControlHref,
   OVERVIEW_CLIENT_ONLY_KEYS,
   OVERVIEW_SEARCH_ORDER,
+  type OverviewClientOnlySearchKey,
   overviewHref,
   type OverviewSearchKey,
 } from '@/lib/overview-links';
 
+const OVERVIEW_SERVER_SEARCH_KEYS = OVERVIEW_SEARCH_ORDER.filter(
+  (key): key is Exclude<OverviewSearchKey, OverviewClientOnlySearchKey> =>
+    !OVERVIEW_CLIENT_ONLY_KEYS.includes(key as OverviewClientOnlySearchKey),
+);
+
 /**
  * Cache and request identity. The payload depends only on the server-resolved
- * params, minus `ref`, which the client derives. Equivalent URLs — explicit
+ * params, minus `ref` and `present`, which the client derives. Equivalent URLs — explicit
  * defaults, reordered params, campaign tags, a fragment — collapse to one key,
  * so a `ref` change is a guaranteed hit and the CDN sees one entry per data
  * state instead of one per link anyone has ever shared.
@@ -69,6 +75,7 @@ interface OverviewNavigationValue {
    *  that replaces it can take the focus its predecessor lost on unmount. */
   focusIntent: MutableRefObject<OverviewNavControl | null>;
   prefetch: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
+  replaceClientState: (targetHref: string, keys: readonly OverviewClientOnlySearchKey[]) => void;
   resolve: (targetHref: string, keys: readonly OverviewSearchKey[]) => string;
   push: (targetHref: string, keys: readonly OverviewSearchKey[]) => void;
 }
@@ -159,10 +166,25 @@ export function OverviewNavigationProvider({
       void load(href)
         .then((nextData) => {
           if (navigationId !== navigationIdRef.current) return;
-          committedHrefRef.current = href;
-          setCommittedHref(href);
+          // A client-only control can change while this data request is in
+          // flight. Commit the loaded server state without rolling that newer
+          // local state back out of the address bar or navigation context.
+          const settledHref = mergeOverviewControlHref(
+            href,
+            pendingHrefRef.current,
+            OVERVIEW_CLIENT_ONLY_KEYS,
+          );
+          committedHrefRef.current = settledHref;
+          pendingHrefRef.current = settledHref;
+          setCommittedHref(settledHref);
+          setPendingHref(settledHref);
           if (updateHistory) {
-            History.prototype.replaceState.call(window.history, window.history.state, '', href);
+            History.prototype.replaceState.call(
+              window.history,
+              window.history.state,
+              '',
+              settledHref,
+            );
           }
           setData(nextData);
           setNavigationError(false);
@@ -170,7 +192,9 @@ export function OverviewNavigationProvider({
           // pageview tracker never fires here. Emit once per committed state —
           // in the success branch so Back/Forward is covered too, and so the
           // recoverable failure path never records a pageview.
-          track('$pageview', { $current_url: new URL(href, window.location.origin).href });
+          track('$pageview', {
+            $current_url: new URL(settledHref, window.location.origin).href,
+          });
         })
         .catch(() => {
           if (navigationId !== navigationIdRef.current) return;
@@ -179,9 +203,10 @@ export function OverviewNavigationProvider({
           // request was in flight needs no payload of its own, and the address
           // bar keeps it either way, so dropping it here would repaint against
           // a column the URL still claims.
+          const clientState = pendingHrefRef.current;
           const rolledBack = mergeOverviewControlHref(
             committedHrefRef.current,
-            href,
+            clientState,
             OVERVIEW_CLIENT_ONLY_KEYS,
           );
           pendingHrefRef.current = rolledBack;
@@ -198,7 +223,7 @@ export function OverviewNavigationProvider({
     // (utm_*, gclid, a fragment) are adopted from the address bar, so a stale
     // location can never key the cache to the wrong payload.
     const actual = `${window.location.pathname}${window.location.search}${window.location.hash}`;
-    const href = mergeOverviewControlHref(actual, initialHref, OVERVIEW_SEARCH_ORDER);
+    const href = mergeOverviewControlHref(actual, initialHref, OVERVIEW_SERVER_SEARCH_KEYS);
     dataCacheRef.current.set(overviewDataKey(href), initialData);
     committedHrefRef.current = href;
     setCommittedHref(href);
@@ -237,6 +262,24 @@ export function OverviewNavigationProvider({
     (targetHref: string, keys: readonly OverviewSearchKey[]) =>
       mergeOverviewControlHref(pendingHref, targetHref, keys),
     [pendingHref],
+  );
+
+  const replaceClientState = useCallback(
+    (targetHref: string, keys: readonly OverviewClientOnlySearchKey[]) => {
+      const pending = mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys);
+      const committed = mergeOverviewControlHref(committedHrefRef.current, targetHref, keys);
+      pendingHrefRef.current = pending;
+      committedHrefRef.current = committed;
+      setPendingHref(pending);
+      setCommittedHref(committed);
+
+      const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      if (pending !== currentHref) {
+        History.prototype.replaceState.call(window.history, window.history.state, '', pending);
+        notifyClientSearchChange(pending);
+      }
+    },
+    [],
   );
 
   /** The URL already shows the new selection while the matrix still shows the
@@ -280,6 +323,7 @@ export function OverviewNavigationProvider({
       isPending,
       focusIntent: focusIntentRef,
       resolve,
+      replaceClientState,
       prefetch: (targetHref, keys) => {
         const href = mergeOverviewControlHref(pendingHrefRef.current, targetHref, keys);
         void load(href).catch(() => undefined);
@@ -289,7 +333,7 @@ export function OverviewNavigationProvider({
         commit(href, true);
       },
     }),
-    [commit, isPending, load, resolve],
+    [commit, isPending, load, replaceClientState, resolve],
   );
 
   return (

--- a/packages/app/src/components/overview/overview-presentation.test.tsx
+++ b/packages/app/src/components/overview/overview-presentation.test.tsx
@@ -4,13 +4,16 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { CLIENT_SEARCH_CHANGE_EVENT } from '@/lib/client-navigation';
 import type { OverviewPageData } from '@/lib/overview-data';
 
-vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
-}));
+const routerStub = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+const trackStub = vi.hoisted(() => vi.fn());
 
-import { OverviewNavigationProvider } from './overview-navigation';
+vi.mock('next/navigation', () => ({ useRouter: () => routerStub }));
+vi.mock('@/lib/analytics', () => ({ track: trackStub }));
+
+import { OverviewNavigationProvider, useOverviewNavigation } from './overview-navigation';
 import {
   DesktopOverviewMatrix,
   overviewFormatters,
@@ -81,13 +84,17 @@ function stubFullscreenApi(enabled: boolean) {
   });
 }
 
-function render() {
+function render(initialHref = '/overview?compare=30d') {
   act(() => {
     root.render(
-      <OverviewNavigationProvider initialData={HISTORY_DATA} initialHref="/overview?compare=30d">
+      <OverviewNavigationProvider initialData={HISTORY_DATA} initialHref={initialHref}>
         <OverviewPresentationProvider locale="en">
           <OverviewPresentationSurface>
             <OverviewPresentToggle strings={strings} />
+            <NavigationProbe />
+            <div role="option" tabIndex={-1} data-testid="overview-select-option">
+              7 days
+            </div>
           </OverviewPresentationSurface>
         </OverviewPresentationProvider>
       </OverviewNavigationProvider>,
@@ -95,12 +102,37 @@ function render() {
   });
 }
 
+function NavigationProbe() {
+  const navigation = useOverviewNavigation();
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="overview-server-selection"
+        onClick={() => navigation.push('/overview', ['compare'])}
+      >
+        Hardware
+      </button>
+      <output data-testid="overview-next-href">
+        {navigation.resolve('/overview?tier=75', ['tier'])}
+      </output>
+    </>
+  );
+}
+
 const surface = () =>
   container.querySelector<HTMLElement>('[data-testid="overview-presentation-surface"]');
 const toggle = () =>
   container.querySelector<HTMLButtonElement>('[data-testid="overview-present-toggle"]');
+const serverSelection = () =>
+  container.querySelector<HTMLButtonElement>('[data-testid="overview-server-selection"]');
+const selectOption = () =>
+  container.querySelector<HTMLElement>('[data-testid="overview-select-option"]');
 
 beforeEach(() => {
+  routerStub.push.mockClear();
+  routerStub.replace.mockClear();
+  trackStub.mockClear();
   window.history.replaceState({}, '', '/overview?compare=30d');
   container = document.createElement('div');
   document.body.append(container);
@@ -115,21 +147,29 @@ afterEach(() => {
 });
 
 describe('OverviewPresentationSurface', () => {
-  it('hands the surface to the Fullscreen API and mirrors the browser back', () => {
+  it('hands the surface to the Fullscreen API and mirrors presentation intent in the URL', () => {
     render();
     expect(toggle()?.textContent).toBe('Present');
     expect(surface()?.dataset.presenting).toBe('false');
 
     act(() => toggle()?.click());
     expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe('?compare=30d&present=1');
     expect(fullscreenElement).toBe(surface());
     expect(surface()?.dataset.presenting).toBe('true');
     expect(toggle()?.textContent).toBe('Exit');
+    expect(trackStub).toHaveBeenLastCalledWith('overview_presentation_toggled', {
+      action: 'enter',
+    });
 
     act(() => toggle()?.click());
     expect(exitFullscreen).toHaveBeenCalledTimes(1);
+    expect(window.location.search).toBe('?compare=30d');
     expect(surface()?.dataset.presenting).toBe('false');
     expect(toggle()?.textContent).toBe('Present');
+    expect(trackStub).toHaveBeenLastCalledWith('overview_presentation_toggled', {
+      action: 'exit',
+    });
   });
 
   it('follows the browser out of fullscreen when Esc bypasses the button', () => {
@@ -142,6 +182,210 @@ describe('OverviewPresentationSurface', () => {
       document.dispatchEvent(new Event('fullscreenchange'));
     });
     expect(surface()?.dataset.presenting).toBe('false');
+    expect(window.location.search).toBe('?compare=30d');
+  });
+
+  it('reasserts presentation intent when Back or Forward lands on an older URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise(() => {
+            // Keep server navigation pending while checking client URL state.
+          }),
+      ),
+    );
+    window.history.replaceState({}, '', '/overview?tier=100&compare=30d');
+    render('/overview?tier=100&compare=30d');
+    act(() => toggle()?.click());
+
+    await act(async () => {
+      window.history.replaceState({}, '', '/overview?tier=75&compare=30d');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      await Promise.resolve();
+    });
+
+    expect(window.location.search).toBe('?tier=75&compare=30d&present=1');
+    expect(container.querySelector('[data-testid="overview-next-href"]')?.textContent).toBe(
+      '/overview?tier=75&compare=30d&present=1',
+    );
+    expect(surface()?.dataset.presenting).toBe('true');
+    expect(fullscreenElement).toBe(surface());
+    expect(fetch).toHaveBeenCalledWith('/api/v1/overview?tier=75&compare=30d', {
+      headers: { Accept: 'application/json' },
+    });
+  });
+
+  it('does not carry presentation intent onto a route left through browser history', () => {
+    render();
+    act(() => toggle()?.click());
+
+    act(() => {
+      window.history.replaceState({}, '', '/inference');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+
+    expect(window.location.pathname).toBe('/inference');
+    expect(window.location.search).toBe('');
+  });
+
+  it('preserves every other query parameter and the fragment while notifying persistent chrome', () => {
+    vi.stubGlobal('fetch', vi.fn());
+    window.history.replaceState({}, '', '/overview?tier=75&compare=30d&utm_source=deck#matrix');
+    const searchEvents: string[] = [];
+    const onSearchChange = (event: Event) => {
+      if (event instanceof CustomEvent && typeof event.detail === 'string') {
+        searchEvents.push(event.detail);
+      }
+    };
+    window.addEventListener(CLIENT_SEARCH_CHANGE_EVENT, onSearchChange);
+
+    render('/overview?tier=75&compare=30d');
+    act(() => toggle()?.click());
+
+    expect(window.location.pathname).toBe('/overview');
+    expect(window.location.search).toBe('?tier=75&compare=30d&present=1&utm_source=deck');
+    expect(window.location.hash).toBe('#matrix');
+    expect(searchEvents).toEqual(['?tier=75&compare=30d&present=1&utm_source=deck']);
+    expect(fetch).not.toHaveBeenCalled();
+
+    act(() => toggle()?.click());
+    expect(window.location.search).toBe('?tier=75&compare=30d&utm_source=deck');
+    expect(window.location.hash).toBe('#matrix');
+    expect(searchEvents).toEqual([
+      '?tier=75&compare=30d&present=1&utm_source=deck',
+      '?tier=75&compare=30d&utm_source=deck',
+    ]);
+    window.removeEventListener(CLIENT_SEARCH_CHANGE_EVENT, onSearchChange);
+  });
+
+  it('does not attempt native fullscreen from a shared presentation URL without a user gesture', () => {
+    window.history.replaceState({}, '', '/overview?compare=30d&present=1');
+    render('/overview?compare=30d');
+
+    expect(requestFullscreen).not.toHaveBeenCalled();
+    expect(surface()?.dataset.presenting).toBe('false');
+    expect(window.location.search).toBe('?compare=30d&present=1');
+
+    act(() => toggle()?.click());
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(surface()?.dataset.presenting).toBe('true');
+  });
+
+  it('keeps presentation intent and fullscreen active while paging to another view', async () => {
+    const requested: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        requested.push(String(input));
+        return Promise.resolve(Response.json({ ...HISTORY_DATA, comparisonMode: 'hardware' }));
+      }),
+    );
+    render();
+
+    act(() => toggle()?.click());
+    await act(async () => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(requested).toHaveLength(1);
+    expect(requested[0]).not.toContain('present=1');
+    expect(window.location.search).toBe('?present=1');
+    expect(surface()?.dataset.presenting).toBe('true');
+    expect(fullscreenElement).toBe(surface());
+  });
+
+  it('does not page when an arrow key belongs to an interactive control', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    render();
+    act(() => toggle()?.click());
+
+    act(() =>
+      toggle()?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true })),
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(window.location.search).toBe('?compare=30d&present=1');
+  });
+
+  it('does not page when a Radix Select option owns the arrow key', () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => new Promise<Response>(() => {})),
+    );
+    render();
+    act(() => toggle()?.click());
+
+    act(() =>
+      selectOption()?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+      ),
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(window.location.search).toBe('?compare=30d&present=1');
+  });
+
+  it('keeps presentation intent when an older server selection fails', async () => {
+    let rejectRequest: ((error: Error) => void) | undefined;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>((_resolve, reject) => {
+            rejectRequest = reject;
+          }),
+      ),
+    );
+    render();
+
+    act(() => serverSelection()?.click());
+    act(() => toggle()?.click());
+    expect(window.location.search).toBe('?present=1');
+
+    await act(async () => {
+      rejectRequest?.(new Error('network down'));
+      await Promise.resolve();
+    });
+
+    expect(window.location.search).toBe('?present=1');
+    expect(surface()?.dataset.presenting).toBe('true');
+    expect(container.querySelector('[data-testid="overview-next-href"]')?.textContent).toContain(
+      'present=1',
+    );
+  });
+
+  it('removes presentation intent if the browser refuses fullscreen', async () => {
+    requestFullscreen.mockRejectedValueOnce(new Error('denied'));
+    render();
+
+    await act(async () => {
+      toggle()?.click();
+      await Promise.resolve();
+    });
+
+    expect(window.location.search).toBe('?compare=30d');
+    expect(surface()?.dataset.presenting).toBe('false');
+  });
+
+  it('keeps presenting without an unhandled rejection if exiting fullscreen is refused', async () => {
+    render();
+    act(() => toggle()?.click());
+    exitFullscreen.mockRejectedValueOnce(new Error('denied'));
+
+    await act(async () => {
+      toggle()?.click();
+      await Promise.resolve();
+    });
+
+    expect(window.location.search).toBe('?compare=30d&present=1');
+    expect(surface()?.dataset.presenting).toBe('true');
+    expect(fullscreenElement).toBe(surface());
   });
 
   it('pages between the two views with the arrow keys, but only while presenting', () => {
@@ -169,9 +413,11 @@ describe('OverviewPresentationSurface', () => {
 
   it('stays out of the way on browsers that refuse fullscreen', () => {
     stubFullscreenApi(false);
+    window.history.replaceState({}, '', '/overview?compare=30d&present=1');
     render();
     expect(toggle()).toBeNull();
     expect(surface()).not.toBeNull();
+    expect(window.location.search).toBe('?compare=30d');
   });
 });
 

--- a/packages/app/src/components/overview/overview-presentation.test.tsx
+++ b/packages/app/src/components/overview/overview-presentation.test.tsx
@@ -413,11 +413,12 @@ describe('OverviewPresentationSurface', () => {
 
   it('stays out of the way on browsers that refuse fullscreen', () => {
     stubFullscreenApi(false);
-    window.history.replaceState({}, '', '/overview?compare=30d&present=1');
-    render();
+    window.history.replaceState({}, '', '/overview?compare=30d&present=1&utm_source=deck#matrix');
+    render('/overview?compare=30d');
     expect(toggle()).toBeNull();
     expect(surface()).not.toBeNull();
-    expect(window.location.search).toBe('?compare=30d');
+    expect(window.location.search).toBe('?compare=30d&utm_source=deck');
+    expect(window.location.hash).toBe('#matrix');
   });
 });
 

--- a/packages/app/src/components/overview/overview-presentation.tsx
+++ b/packages/app/src/components/overview/overview-presentation.tsx
@@ -11,6 +11,8 @@ import {
   useState,
 } from 'react';
 
+import { track } from '@/lib/analytics';
+import { notifyClientSearchChange } from '@/lib/client-navigation';
 import { OVERVIEW_DEFAULT_HISTORY_WINDOW, type OverviewComparisonMode } from '@/lib/overview-data';
 import { overviewHref } from '@/lib/overview-links';
 
@@ -83,29 +85,85 @@ export function OverviewPresentationProvider({
   // Same reason the matrix reads it here: the reference follows the URL, so a
   // payload still cached from another reference must not rewrite it.
   const referenceHardware = useOverviewReference();
-  const { push } = useOverviewNavigation();
+  const { push, replaceClientState } = useOverviewNavigation();
   const surfaceRef = useRef<HTMLDivElement>(null);
   const scalerRef = useRef<HTMLDivElement>(null);
   const [presenting, setPresenting] = useState(false);
   const [supported, setSupported] = useState(false);
 
-  useEffect(() => setSupported(document.fullscreenEnabled), []);
+  const setPresentationIntent = useCallback(
+    (enabled: boolean) => {
+      const target = new URL(
+        `${window.location.pathname}${window.location.search}${window.location.hash}`,
+        window.location.origin,
+      );
+      if (enabled) target.searchParams.set('present', '1');
+      else target.searchParams.delete('present');
+      replaceClientState(`${target.pathname}${target.search}${target.hash}`, ['present']);
+    },
+    [replaceClientState],
+  );
 
   useEffect(() => {
-    const syncPresenting = () =>
-      setPresenting(
-        surfaceRef.current !== null && document.fullscreenElement === surfaceRef.current,
-      );
+    setSupported(document.fullscreenEnabled);
+    if (!document.fullscreenEnabled) setPresentationIntent(false);
+  }, [setPresentationIntent]);
+
+  useEffect(() => {
+    const syncPresenting = () => {
+      const nextPresenting =
+        surfaceRef.current !== null && document.fullscreenElement === surfaceRef.current;
+      setPresenting(nextPresenting);
+      if (!nextPresenting) setPresentationIntent(false);
+    };
     document.addEventListener('fullscreenchange', syncPresenting);
     return () => document.removeEventListener('fullscreenchange', syncPresenting);
+  }, [setPresentationIntent]);
+
+  useEffect(() => {
+    const preserveIntentWhileFullscreen = () => {
+      const onOverview =
+        window.location.pathname === '/overview' || window.location.pathname === '/zh/overview';
+      if (
+        onOverview &&
+        surfaceRef.current !== null &&
+        document.fullscreenElement === surfaceRef.current
+      ) {
+        const target = new URL(
+          `${window.location.pathname}${window.location.search}${window.location.hash}`,
+          window.location.origin,
+        );
+        target.searchParams.set('present', '1');
+        const href = `${target.pathname}${target.search}${target.hash}`;
+        History.prototype.replaceState.call(window.history, window.history.state, '', href);
+        notifyClientSearchChange(href);
+      }
+    };
+    // Capture runs before the navigation provider reads the new location, so
+    // a Back/Forward entry that predates presentation cannot make its client
+    // state disagree with the still-active browser fullscreen surface.
+    window.addEventListener('popstate', preserveIntentWhileFullscreen, true);
+    return () => window.removeEventListener('popstate', preserveIntentWhileFullscreen, true);
   }, []);
 
   const toggle = useCallback(() => {
     const surface = surfaceRef.current;
     if (surface === null) return;
-    if (document.fullscreenElement === surface) void document.exitFullscreen();
-    else void surface.requestFullscreen().catch(() => setPresenting(false));
-  }, []);
+    if (document.fullscreenElement === surface) {
+      track('overview_presentation_toggled', { action: 'exit' });
+      void document.exitFullscreen().catch(() => {
+        setPresenting(true);
+        setPresentationIntent(true);
+      });
+    } else {
+      track('overview_presentation_toggled', { action: 'enter' });
+      setPresentationIntent(true);
+      void surface.requestFullscreen().catch(() => {
+        setPresenting(false);
+        setPresentationIntent(false);
+      });
+    }
+  }, [setPresentationIntent]);
 
   // Magnify rather than restyle: one `zoom` scales type, padding and rules
   // together, so the projected matrix cannot drift from the page's own layout.
@@ -143,6 +201,15 @@ export function OverviewPresentationProvider({
       // Key repeat would oscillate between the two views and spam fetches;
       // one page per physical press.
       if (event.repeat) return;
+      const eventTarget = event.target;
+      if (
+        eventTarget instanceof Element &&
+        eventTarget.closest(
+          'a, button, input, select, textarea, [contenteditable="true"], [role="button"], [role="combobox"], [role="listbox"], [role="option"], [role="menuitem"]',
+        ) !== null
+      ) {
+        return;
+      }
       // Two views, so either arrow means "the other one" — the audience reads
       // it as paging through slides.
       const target: OverviewComparisonMode =

--- a/packages/app/src/lib/overview-links.test.ts
+++ b/packages/app/src/lib/overview-links.test.ts
@@ -12,6 +12,7 @@ import {
   buildOverviewHistoryDashboardHref,
   detailHref,
   mergeOverviewControlHref,
+  OVERVIEW_CLIENT_ONLY_KEYS,
   overviewEngineScopeHref,
   overviewHref,
   overviewTierHref,
@@ -270,6 +271,24 @@ describe('overviewHref', () => {
 });
 
 describe('overview switch links', () => {
+  it('treats presentation intent as client-only navigation state', () => {
+    expect(OVERVIEW_CLIENT_ONLY_KEYS).toContain('present');
+  });
+
+  it('merges presentation intent canonically without dropping query state or fragments', () => {
+    expect(
+      mergeOverviewControlHref('/overview?tier=75&utm_source=deck#matrix', '/overview?present=1', [
+        'present',
+      ]),
+    ).toBe('/overview?tier=75&present=1&utm_source=deck#matrix');
+
+    expect(
+      mergeOverviewControlHref('/overview?tier=75&present=1&utm_source=deck#matrix', '/overview', [
+        'present',
+      ]),
+    ).toBe('/overview?tier=75&utm_source=deck#matrix');
+  });
+
   it('merges rapid control changes into the latest pending overview URL', () => {
     const tierHref = mergeOverviewControlHref('/overview', '/overview?tier=75', ['tier']);
     const engineHref = mergeOverviewControlHref(tierHref, '/overview?engine=all', ['engine']);

--- a/packages/app/src/lib/overview-links.ts
+++ b/packages/app/src/lib/overview-links.ts
@@ -24,7 +24,8 @@ export type OverviewSearchKey =
   | 'compare'
   | 'models'
   | 'rows'
-  | 'hwrows';
+  | 'hwrows'
+  | 'present';
 
 export const OVERVIEW_SEARCH_ORDER: readonly OverviewSearchKey[] = [
   'tier',
@@ -34,12 +35,15 @@ export const OVERVIEW_SEARCH_ORDER: readonly OverviewSearchKey[] = [
   'models',
   'rows',
   'hwrows',
+  'present',
 ];
 
 /** Params the client resolves without asking the server. `ref` only picks which
- *  column the percentages are measured against, and every cost that needs is
- *  already in the payload — so it must not vary the data cache key. */
-export const OVERVIEW_CLIENT_ONLY_KEYS: readonly OverviewSearchKey[] = ['ref'];
+ *  column the percentages are measured against, and `present` only records the
+ *  requested layout. Neither changes the Overview payload or its cache key. */
+export const OVERVIEW_CLIENT_ONLY_KEYS = ['ref', 'present'] as const;
+
+export type OverviewClientOnlySearchKey = (typeof OVERVIEW_CLIENT_ONLY_KEYS)[number];
 
 /** Apply one control's destination to the latest pending overview URL.
  * This prevents a second, fast selection from rebuilding from stale server


### PR DESCRIPTION
## What changed

- Persist Overview presentation intent as the client-only `present=1` URL state without adding it to BFF/cache identity.
- Preserve presentation intent across selectors, Back/Forward navigation, and recoverable request failures.
- Keep native fullscreen gesture-gated and synchronize URL state on Exit, Escape, unsupported browsers, and rejected fullscreen operations.

## Why

Presentation mode could not be shared or preserved reliably across Overview navigation, while treating URL intent as native fullscreen state would violate browser gesture requirements.

## Validation

- Focused unit tests: 81 passed
- Overview E2E: Chrome 42/42, Firefox 42/42
- Fixture production build, typecheck, lint, format, and diff check passed

Stacked on #800 because both changes update the Overview navigation lifecycle.

## 中文说明

- 使用仅限客户端的 `present=1` URL 状态保存 Overview 演示意图，不将其计入 BFF 或缓存标识。
- 在选择器操作、浏览器前进/后退及可恢复的请求失败期间保持演示意图。
- 原生全屏仍必须由用户手势触发；退出按钮、Escape、不支持全屏的浏览器及全屏调用失败都会与 URL 状态正确同步。

此前演示模式无法通过链接可靠分享，也可能在 Overview 导航过程中丢失；同时，URL 中的演示意图不能绕过浏览器的用户手势要求直接恢复原生全屏。

验证结果：81 项聚焦单元测试通过；Chrome 与 Firefox 的 Overview E2E 各 42/42 通过；fixture production build、typecheck、lint、format 与 diff check 均通过。

本 PR 基于 #800，因为两项改动都会影响 Overview navigation lifecycle。
