### PR TITLE
One high-contrast color per config, dates as a gradient / 高对比度下每个配置一种颜色，日期用渐变区分

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -9,7 +9,7 @@ import { useInference } from '@/components/inference/InferenceContext';
 import ChartLegend from '@/components/ui/chart-legend';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import { getChartWatermark, Sequence } from '@/lib/data-mappings';
-import { generateGpuDateColors } from '@/lib/dynamic-colors';
+import { generateGpuDateColors, generateHighContrastGpuDateColors } from '@/lib/dynamic-colors';
 import { useLocale } from '@/lib/use-locale';
 import { formatNumber, getDisplayLabel, updateRepoUrl } from '@/lib/utils';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -193,9 +193,13 @@ const GPUGraph = React.memo(
       return ids;
     }, [gpuDatePairs]);
 
+    // High contrast keys off the GPU (not `date_gpu`) so each hardware config
+    // gets exactly one hue; the dates within a config are separated by the
+    // lightness ramp built below rather than by unrelated hues.
     const { resolveColor, getCssColor } = useThemeColors({
       highContrast,
       identifiers: graphIdentifiers,
+      hcKeys: gpuDatePairs.sortedGPUs,
     });
 
     // Dynamic GPU×date color map
@@ -206,25 +210,38 @@ const GPUGraph = React.memo(
       return generateGpuDateColors(sortedGPUs, dates.length, theme);
     }, [gpuDatePairs, resolvedTheme]);
 
+    // High-contrast GPU×date color map: one iwanthue hue per GPU, ramped across
+    // the compared dates so a config's runs stay recognisably the same color
+    // while still reading oldest → newest.
+    const hcGpuDateColorMap = useMemo(() => {
+      const { dates, sortedGPUs } = gpuDatePairs;
+      if (!highContrast || sortedGPUs.length === 0 || dates.length === 0) return {};
+      const theme = resolvedTheme === 'dark' || resolvedTheme === 'minecraft' ? 'dark' : 'light';
+      const baseColors: Record<string, string> = {};
+      for (const gpu of sortedGPUs) baseColors[gpu] = getCssColor(resolveColor(gpu));
+      return generateHighContrastGpuDateColors(baseColors, dates.length, theme);
+    }, [gpuDatePairs, highContrast, resolvedTheme, resolveColor, getCssColor]);
+
     const allGraphs = useMemo(() => {
       const { dates, sortedGPUs } = gpuDatePairs;
       const result: { date: string; color: string; hwKey: string; id: string }[] = [];
       sortedGPUs.forEach((gpu) => {
         dates.forEach((date, dateIndex) => {
           const id = `${date}_${gpu}`;
-          const dynamicColor = gpuDateColorMap[`${dateIndex}_${gpu}`];
+          const compositeKey = `${dateIndex}_${gpu}`;
+          const dynamicColor = gpuDateColorMap[compositeKey];
           result.push({
             date,
             hwKey: gpu,
             id,
             color: highContrast
-              ? getCssColor(resolveColor(id))
+              ? hcGpuDateColorMap[compositeKey] || getCssColor(resolveColor(gpu))
               : dynamicColor || 'var(--foreground)',
           });
         });
       });
       return result;
-    }, [gpuDatePairs, gpuDateColorMap, highContrast, resolveColor, getCssColor]);
+    }, [gpuDatePairs, gpuDateColorMap, hcGpuDateColorMap, highContrast, resolveColor, getCssColor]);
 
     const groupedData = useMemo(
       () =>

--- a/packages/app/src/lib/dynamic-colors.test.ts
+++ b/packages/app/src/lib/dynamic-colors.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import { VENDOR_OKLCH_ZONES } from '@semianalysisai/inferencex-constants';
 
-import { generateVendorColors, getVendor } from './dynamic-colors';
+import {
+  generateHighContrastGpuDateColors,
+  generateVendorColors,
+  getVendor,
+} from './dynamic-colors';
 
 function hueOf(color: string): number {
   const match = /^oklch\([\d.]+ [\d.]+ (?<hue>[\d.]+)\)$/.exec(color);
@@ -44,5 +48,62 @@ describe('generateVendorColors', () => {
     const unknown = VENDOR_OKLCH_ZONES.unknown;
     expect(hueOf(colors['mystery_series'])).toBeGreaterThanOrEqual(unknown.start);
     expect(hueOf(colors['mystery_series'])).toBeLessThanOrEqual(unknown.end);
+  });
+});
+
+function lightnessOf(color: string): number {
+  const match = /^oklch\((?<l>[\d.]+) [\d.]+ [\d.]+\)$/u.exec(color);
+  expect(match, `expected oklch color, got ${color}`).not.toBeNull();
+  return Number(match!.groups!.l);
+}
+
+describe('generateHighContrastGpuDateColors', () => {
+  const bases = { h200_sglang: '#1f77b4', mi355x_vllm: '#d62728' };
+
+  it('gives every date of one GPU the same hue and chroma', () => {
+    const colors = generateHighContrastGpuDateColors(bases, 4, 'light');
+    const hues = [0, 1, 2, 3].map((di) => hueOf(colors[`${di}_h200_sglang`]));
+    expect(new Set(hues).size).toBe(1);
+  });
+
+  it('keeps different GPUs on different hues', () => {
+    const colors = generateHighContrastGpuDateColors(bases, 3, 'light');
+    expect(hueOf(colors['0_h200_sglang'])).not.toBeCloseTo(hueOf(colors['0_mi355x_vllm']), 0);
+  });
+
+  it('ramps lightness oldest → newest, matching the non-HC ramp direction', () => {
+    const colors = generateHighContrastGpuDateColors(bases, 3, 'light');
+    const ls = [0, 1, 2].map((di) => lightnessOf(colors[`${di}_h200_sglang`]));
+    expect(ls[0]).toBeGreaterThan(ls[1]);
+    expect(ls[1]).toBeGreaterThan(ls[2]);
+  });
+
+  it('separates consecutive dates enough to be noticeable', () => {
+    for (const theme of ['light', 'dark'] as const) {
+      const colors = generateHighContrastGpuDateColors(bases, 4, theme);
+      const ls = [0, 1, 2, 3].map((di) => lightnessOf(colors[`${di}_mi355x_vllm`]));
+      for (let i = 1; i < ls.length; i++) {
+        expect(ls[i - 1] - ls[i], `${theme} step ${i}`).toBeGreaterThan(0.08);
+      }
+    }
+  });
+
+  it('keeps the full span inside theme bounds even for a very dark base', () => {
+    const colors = generateHighContrastGpuDateColors({ gpu: '#0a0a1e' }, 2, 'dark');
+    const ls = [0, 1].map((di) => lightnessOf(colors[`${di}_gpu`]));
+    expect(Math.min(...ls)).toBeGreaterThanOrEqual(0.44);
+    expect(Math.max(...ls)).toBeLessThanOrEqual(0.95);
+    expect(ls[0] - ls[1]).toBeCloseTo(0.36, 2);
+  });
+
+  it('holds a single date at the base lightness', () => {
+    const colors = generateHighContrastGpuDateColors(bases, 1, 'light');
+    expect(Object.keys(colors)).toEqual(['0_h200_sglang', '0_mi355x_vllm']);
+  });
+
+  it('falls back to the base color when it cannot be parsed', () => {
+    const colors = generateHighContrastGpuDateColors({ gpu: 'var(--foreground)' }, 2, 'light');
+    expect(colors['0_gpu']).toBe('var(--foreground)');
+    expect(colors['1_gpu']).toBe('var(--foreground)');
   });
 });

--- a/packages/app/src/lib/dynamic-colors.ts
+++ b/packages/app/src/lib/dynamic-colors.ts
@@ -166,3 +166,111 @@ export function generateGpuDateColors(
 
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// High-contrast GPU × date gradient
+// ---------------------------------------------------------------------------
+
+/**
+ * Total OKLch lightness span swept across the compared dates in high-contrast
+ * mode. Wide on purpose: the whole point of the gradient is that consecutive
+ * dates read apart at a glance, so a subtle ramp would defeat it.
+ */
+const HC_DATE_L_SPAN = 0.36;
+
+/**
+ * Absolute lightness bounds for the ramp so neither end of the gradient washes
+ * out against the page background (dark themes need a higher floor).
+ */
+const HC_DATE_L_BOUNDS = {
+  light: { min: 0.34, max: 0.86 },
+  dark: { min: 0.44, max: 0.95 },
+} as const;
+
+/** sRGB channel (0–1) → linear-light. */
+function srgbToLinear(c: number): number {
+  return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+}
+
+/** Parse `#rgb` / `#rrggbb` into OKLch `[L, C, H]`, or null when unparseable. */
+function hexToOklch(hex: string): [number, number, number] | null {
+  const raw = hex.trim().replace('#', '');
+  const full =
+    raw.length === 3
+      ? raw
+          .split('')
+          .map((ch) => ch + ch)
+          .join('')
+      : raw;
+  if (full.length !== 6 || !/^[0-9a-f]{6}$/iu.test(full)) return null;
+
+  const r = srgbToLinear(Number.parseInt(full.slice(0, 2), 16) / 255);
+  const g = srgbToLinear(Number.parseInt(full.slice(2, 4), 16) / 255);
+  const b = srgbToLinear(Number.parseInt(full.slice(4, 6), 16) / 255);
+
+  // Linear sRGB → OKLab (Björn Ottosson's matrices).
+  const l = Math.cbrt(0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b);
+  const m = Math.cbrt(0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b);
+  const s = Math.cbrt(0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b);
+
+  const okL = 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s;
+  const okA = 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s;
+  const okB = 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s;
+
+  const chroma = Math.hypot(okA, okB);
+  const hue = ((Math.atan2(okB, okA) * 180) / Math.PI + 360) % 360;
+  return [okL, chroma, hue];
+}
+
+/**
+ * Spread one high-contrast base color per GPU across the compared dates.
+ *
+ * High contrast previously handed every `date × GPU` series its own iwanthue
+ * hue, which severed the visual link between a hardware config's own runs. Here
+ * the hue/chroma stay pinned to the GPU (so a config keeps one identity) and
+ * only lightness ramps — oldest lightest → newest darkest, matching the
+ * non-high-contrast ramp in {@link generateGpuDateColors}.
+ *
+ * @param baseColors - hwKey → high-contrast base color (hex from iwanthue).
+ * @param dateCount  - Number of dates being compared.
+ * @param theme      - 'light' or 'dark'.
+ * @returns Map of `${date-index}_${hwKey}` → `oklch(L C H)` string. GPUs whose
+ *          base color can't be parsed keep that base color at every date index.
+ */
+export function generateHighContrastGpuDateColors(
+  baseColors: Record<string, string>,
+  dateCount: number,
+  theme: 'light' | 'dark',
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  if (dateCount <= 0) return result;
+
+  const { min: lMin, max: lMax } = HC_DATE_L_BOUNDS[theme];
+
+  for (const [hwKey, base] of Object.entries(baseColors)) {
+    const oklch = hexToOklch(base);
+    if (!oklch) {
+      for (let di = 0; di < dateCount; di++) result[`${di}_${hwKey}`] = base;
+      continue;
+    }
+    const [baseL, chroma, hue] = oklch;
+
+    // Center the ramp on the base lightness, then slide (not squash) it back
+    // inside the theme bounds so the full span survives near the extremes.
+    const span = Math.min(HC_DATE_L_SPAN, lMax - lMin);
+    let top = Math.min(lMax, baseL + span / 2);
+    let bottom = top - span;
+    if (bottom < lMin) {
+      bottom = lMin;
+      top = bottom + span;
+    }
+
+    for (let di = 0; di < dateCount; di++) {
+      const lightness = dateCount <= 1 ? baseL : top - (di / (dateCount - 1)) * span;
+      result[`${di}_${hwKey}`] =
+        `oklch(${lightness.toFixed(3)} ${chroma.toFixed(3)} ${hue.toFixed(1)})`;
+    }
+  }
+
+  return result;
+}

--- a/packages/app/src/lib/dynamic-colors.ts
+++ b/packages/app/src/lib/dynamic-colors.ts
@@ -195,13 +195,7 @@ function srgbToLinear(c: number): number {
 /** Parse `#rgb` / `#rrggbb` into OKLch `[L, C, H]`, or null when unparseable. */
 function hexToOklch(hex: string): [number, number, number] | null {
   const raw = hex.trim().replace('#', '');
-  const full =
-    raw.length === 3
-      ? raw
-          .split('')
-          .map((ch) => ch + ch)
-          .join('')
-      : raw;
+  const full = raw.length === 3 ? [...raw].map((ch) => ch + ch).join('') : raw;
   if (full.length !== 6 || !/^[0-9a-f]{6}$/iu.test(full)) return null;
 
   const r = srgbToLinear(Number.parseInt(full.slice(0, 2), 16) / 255);


### PR DESCRIPTION
## Summary

In the GPU comparison view, **high contrast** mode gave every `date × GPU` series its own independent iwanthue hue. With multiple configs and multiple dates selected, one hardware config's runs looked like unrelated configs — the per-config identity was lost.

High contrast now keys off the **GPU**, not the `date_gpu` pair:

- **One hue per hardware config.** `useThemeColors` receives `hcKeys: sortedGPUs`, so iwanthue picks a palette sized to the number of configs (fewer keys → more perceptual separation between configs, too).
- **Dates ramp within that color.** New `generateHighContrastGpuDateColors()` converts each config's high-contrast base hex to OKLch, pins hue + chroma, and sweeps lightness across the compared dates — oldest lightest → newest darkest, matching the direction of the existing non-high-contrast ramp in `generateGpuDateColors()`.
- **The gradient is deliberately noticeable.** Total span is 0.36 OKLch L (≈0.18 L per step at three dates), well past a subtle tint. The ramp *slides* rather than squashes when a base color sits near the theme's lightness bounds, so the full span survives at the extremes; bounds differ per theme (light 0.34–0.86, dark 0.44–0.95) so neither end washes out against the background.

Actual output for three configs × three dates (light theme):

| config | date 1 | date 2 | date 3 |
| --- | --- | --- | --- |
| `b200_sglang` | `oklch(0.761 0.148 126.3)` | `oklch(0.581 0.148 126.3)` | `oklch(0.401 0.148 126.3)` |
| `h200_vllm` | `oklch(0.857 0.108 193.3)` | `oklch(0.677 0.108 193.3)` | `oklch(0.497 0.108 193.3)` |
| `mi355x_sglang` | `oklch(0.830 0.232 32.2)` | `oklch(0.650 0.232 32.2)` | `oklch(0.470 0.232 32.2)` |

Hue is constant down each row (config identity), lightness steps 0.18 across each row (date gradient).

Non-high-contrast mode is untouched. `allGraphs` is the single source of color for both the chart series and the legend swatches, so the legend shows the same gradient.

## Test plan

- New unit tests in `dynamic-colors.test.ts` (12 pass locally) cover: constant hue/chroma per config, distinct hues between configs, oldest → newest ramp direction, a **>0.08 L minimum step between consecutive dates in both themes** (the "noticeable" guarantee), full-span preservation for a very dark base under the dark-theme bounds, single-date and unparseable-base fallbacks.
- Verified the concrete color output above against the real `generateHighContrastColors()` palette.
- Note: `bun run typecheck` / `oxlint` were not run to completion locally — this worktree has no `node_modules` of its own, and the errors surfaced through a symlinked install are all pre-existing cross-package resolution noise (`USD_TO_CNY`, `CollectiveXKvRow`, …) unrelated to these files; **no** diagnostics were reported for `GPUGraph.tsx` or `dynamic-colors.ts`. CI is the authority here.
- No new user-visible strings, so no `/zh` page changes are required.

## 中文说明

在 GPU 对比视图中，**高对比度（High Contrast）** 模式此前为每个「日期 × GPU」序列单独分配 iwanthue 色相。当同时选中多个配置和多个日期时，同一硬件配置在不同日期的运行看起来像是彼此无关的配置，配置本身的辨识度被破坏。

现在高对比度按 **GPU** 而非 `date_gpu` 组合来分配颜色：

- **每个硬件配置一个色相。** `useThemeColors` 接收 `hcKeys: sortedGPUs`，iwanthue 按配置数量生成调色板（键更少 → 配置之间的感知差异也更大）。
- **日期在该颜色内做渐变。** 新增的 `generateHighContrastGpuDateColors()` 将每个配置的高对比度基础色（hex）转换为 OKLch，锁定色相与彩度，仅让明度在各对比日期间变化——由浅到深对应由旧到新，与 `generateGpuDateColors()` 中非高对比度模式的渐变方向一致。
- **渐变刻意做得明显。** 总跨度为 0.36 OKLch L（三个日期时每级约 0.18 L），远超轻微着色的程度。当基础颜色接近主题明度边界时，渐变区间整体**平移**而非压缩，因此在极端情况下仍保留完整跨度；两种主题的边界不同（浅色 0.34–0.86，深色 0.44–0.95），确保渐变两端都不会与背景融为一体。

上表为三个配置 × 三个日期（浅色主题）的实际输出：每一行色相保持不变（配置辨识度），明度逐级变化 0.18（日期渐变）。

非高对比度模式未做改动。`allGraphs` 是图表序列与图例色块的唯一颜色来源，因此图例会呈现相同的渐变。

### 测试

- `dynamic-colors.test.ts` 新增单元测试（本地 12 项全部通过），覆盖：同一配置内色相/彩度恒定、不同配置色相互不相同、由旧到新的渐变方向、**两种主题下相邻日期的明度差均大于 0.08 L**（即「明显」这一保证）、深色主题下极暗基础色仍保留完整跨度，以及单日期与无法解析基础色时的回退行为。
- 已对照真实的 `generateHighContrastColors()` 调色板验证上表中的具体颜色输出。
- 说明：本地未完整运行 `bun run typecheck` / `oxlint`——该 worktree 没有独立的 `node_modules`，通过符号链接安装后出现的报错均为既有的跨包解析问题（`USD_TO_CNY`、`CollectiveXKvRow` 等），与本次改动的文件无关；`GPUGraph.tsx` 与 `dynamic-colors.ts` **没有**任何诊断信息。以 CI 结果为准。
- 未引入新的用户可见文案，因此无需改动 `/zh` 页面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)