### PR TITLE
refactor(tco): centralize provenance metadata / 集中管理 TCO 来源元数据

### DIFF
--- a/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
+++ b/packages/app/cypress/e2e/compare-per-dollar-table.cy.ts
@@ -1,3 +1,5 @@
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 describe('Compare-per-dollar slug page — slimmed table + cross-link', () => {
   before(() => {
     cy.window().then((win) => {
@@ -57,6 +59,12 @@ describe('Compare-per-dollar slug page — slimmed table + cross-link', () => {
 
   it('uses "Performance per Dollar" framing in the page header', () => {
     cy.contains('Performance per Dollar').should('be.visible');
+  });
+
+  it('attributes pricing to the shared TCO source', () => {
+    cy.get('[data-testid="compare-per-dollar-pricing"]')
+      .contains('a', TCO_SOURCE_TITLE)
+      .should('have.attr', 'href', TCO_SOURCE_URL);
   });
 
   it('renders an indexable comparison PNG with descriptive alt text', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -1,3 +1,5 @@
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 // Order mirrors DEFAULT_MODELS (MODEL_CONFIG insertion order), which fixes the
 // matrix row order.
 const MODEL_LABELS = [
@@ -29,10 +31,8 @@ const AGENTX_SHORT = 'AgentX';
 
 const PAGE_TITLE = 'Agentic Inference Costs';
 const PAGE_TITLE_ZH = '智能体推理成本';
-const SOURCE_NOTE = 'Source: InferenceX & SemiAnalysis Market July 2026 AI Cloud TCO Model';
-const SOURCE_LINK_TEXT = 'SemiAnalysis Market July 2026 AI Cloud TCO Model';
-const SOURCE_NOTE_ZH = '来源：InferenceX 与 SemiAnalysis Market July 2026 AI Cloud TCO Model';
-const SOURCE_HREF = 'https://semianalysis.com/ai-cloud-tco-model/';
+const SOURCE_NOTE = `Source: InferenceX & ${TCO_SOURCE_TITLE}`;
+const SOURCE_NOTE_ZH = `来源：InferenceX 与 ${TCO_SOURCE_TITLE}`;
 const SCOPE_METRIC = 'Hyperscaler cost';
 const SCOPE_DIRECTION = '↓ Lower is better';
 const SCOPE_LINE = `${SCOPE_METRIC} · ${SCOPE_DIRECTION} · ${SOURCE_NOTE}`;
@@ -947,8 +947,8 @@ describe('Overview page', () => {
       .and('not.contain.text', '8K→1K');
     // The TCO model behind every $/GPU/hr is cited under the metric.
     cy.get('[data-testid="overview-source-link"]')
-      .should('have.text', SOURCE_LINK_TEXT)
-      .and('have.attr', 'href', SOURCE_HREF)
+      .should('have.text', TCO_SOURCE_TITLE)
+      .and('have.attr', 'href', TCO_SOURCE_URL)
       .and('have.attr', 'target', '_blank')
       .and('have.attr', 'rel', 'noopener noreferrer');
     // Opening off-site is signalled by the shared external-link glyph.
@@ -1489,8 +1489,8 @@ describe('Overview page', () => {
     );
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
     cy.get('[data-testid="overview-source-link"]')
-      .should('have.text', SOURCE_LINK_TEXT)
-      .and('have.attr', 'href', SOURCE_HREF);
+      .should('have.text', TCO_SOURCE_TITLE)
+      .and('have.attr', 'href', TCO_SOURCE_URL);
     cy.get('body').should('not.contain.text', '一眼对比');
     cy.contains('— = 无结果。∞ = 缺少 B200 基线。').should('exist');
     cy.get('[data-testid="overview-methodology"]').children('p').should('have.length', 2);

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -1,3 +1,5 @@
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 import {
   availability as agenticAvailability,
   b300Rows as agenticB300Rows,
@@ -217,6 +219,9 @@ describe('TCO Calculator', () => {
     it('shows TCO badges when cost metric is selected', () => {
       cy.get('[data-testid="calculator-cost-badges"]').should('contain.text', 'TCO $/chip/hr');
       cy.get('[data-testid="calculator-cost-badges"]').should('contain.text', '$');
+      cy.get('[data-testid="calculator-chart-section"]')
+        .contains('a', TCO_SOURCE_TITLE)
+        .should('have.attr', 'href', TCO_SOURCE_URL);
     });
 
     it('displays chart title that updates when metric changes', () => {
@@ -742,6 +747,9 @@ describe('TCO Calculator', () => {
         'contain.text',
         'SemiAnalysis Datacenter Industry Model',
       );
+      cy.get('[data-testid="calculator-fleet-section"]')
+        .contains('a', TCO_SOURCE_TITLE)
+        .should('have.attr', 'href', TCO_SOURCE_URL);
     });
 
     it('entering a generous cost target renders reachable interactivity per GPU', () => {

--- a/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/page-client.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { useEffect, useMemo } from 'react';
 
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 import type { GPUDataPoint, InterpolatedResult } from '@/components/calculator/types';
 import { useThroughputData } from '@/components/calculator/useThroughputData';
 import { CompareInterpolatedTable } from '@/components/compare/compare-interpolated-table';
@@ -228,13 +230,13 @@ export default function ComparePerDollarPageClient({
                   {bCostPerGpuHr > 0 ? `$${bCostPerGpuHr.toFixed(2)}/chip/hr` : '—'}.{' '}
                   {t.pricingSource}{' '}
                   <a
-                    href="https://semianalysis.com/ai-cloud-tco-model/"
+                    href={TCO_SOURCE_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-primary"
                     onClick={() => track('compare_per_dollar_tco_source_clicked', { slug })}
                   >
-                    SemiAnalysis Market July 2026 Pricing Surveys &amp; AI Cloud TCO Model
+                    {TCO_SOURCE_TITLE}
                   </a>
                   .
                 </p>

--- a/packages/app/src/components/calculator/FleetPlanner.tsx
+++ b/packages/app/src/components/calculator/FleetPlanner.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
 
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 import { track } from '@/lib/analytics';
 import type { HardwareConfig } from '@/components/inference/types';
 import { Card } from '@/components/ui/card';
@@ -394,12 +396,8 @@ export default function FleetPlanner({
             <ExternalLinkIcon />
           </Link>
           {' & '}
-          <Link
-            target="_blank"
-            className="underline hover:text-foreground"
-            href="https://semianalysis.com/ai-cloud-tco-model/"
-          >
-            SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model
+          <Link target="_blank" className="underline hover:text-foreground" href={TCO_SOURCE_URL}>
+            {TCO_SOURCE_TITLE}
             <ExternalLinkIcon />
           </Link>
         </small>

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -7,6 +7,12 @@ import { useFeatureGate } from '@/lib/use-feature-gate';
 import { useLocale } from '@/lib/use-locale';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import {
+  HW_REGISTRY,
+  TCO_SOURCE_TITLE,
+  TCO_SOURCE_URL,
+} from '@semianalysisai/inferencex-constants';
+
 import CalculatorTable from '@/components/calculator/CalculatorTable';
 import FleetPlanner from '@/components/calculator/FleetPlanner';
 import type { CalculatorUrlSeed } from '@/components/calculator/url-seed';
@@ -42,7 +48,6 @@ import {
   getPrecisionLabel,
   getSequenceLabel,
 } from '@/lib/data-mappings';
-import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useUrlState } from '@/hooks/useUrlState';
@@ -1192,9 +1197,9 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                               <Link
                                 target="_blank"
                                 className="underline hover:text-foreground"
-                                href="https://semianalysis.com/ai-cloud-tco-model/"
+                                href={TCO_SOURCE_URL}
                               >
-                                SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model
+                                {TCO_SOURCE_TITLE}
                                 <ExternalLinkIcon />
                               </Link>
                             </small>

--- a/packages/app/src/components/overview/overview-page.tsx
+++ b/packages/app/src/components/overview/overview-page.tsx
@@ -2,6 +2,8 @@
 
 import type { ReactNode } from 'react';
 
+import { TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 import { Card } from '@/components/ui/card';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { OVERVIEW_HISTORY_WINDOW_DAYS, type OverviewPageData } from '@/lib/overview-data';
@@ -34,9 +36,6 @@ import {
   useOverviewPresentation,
 } from './overview-presentation';
 import { useWideViewport } from './use-wide-viewport';
-
-/** The SemiAnalysis AI Cloud TCO model behind `HW_REGISTRY.costh`. */
-const OVERVIEW_SOURCE_HREF = 'https://semianalysis.com/ai-cloud-tco-model/';
 
 interface OverviewPageProps {
   data: OverviewPageData;
@@ -149,7 +148,7 @@ function OverviewPageBody({ locale }: { locale: OverviewLocale }) {
                   {strings.sourcePrefix}
                   <a
                     data-testid="overview-source-link"
-                    href={OVERVIEW_SOURCE_HREF}
+                    href={TCO_SOURCE_URL}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="group rounded-sm underline decoration-dotted underline-offset-4 hover:decoration-solid focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -2,6 +2,8 @@
 
 import { type ComponentPropsWithoutRef, useEffect, useRef } from 'react';
 
+import { TCO_SOURCE_TITLE } from '@semianalysisai/inferencex-constants';
+
 import {
   OVERVIEW_DEFAULT_HISTORY_WINDOW,
   OVERVIEW_DEFAULT_REFERENCE_HARDWARE,
@@ -50,7 +52,7 @@ export const OVERVIEW_STRINGS = {
     // The unit is dropped from the visible line but kept for screen readers.
     scopeAria: 'Hyperscaler cost per one million total tokens. Lower is better.',
     sourcePrefix: 'Source: InferenceX & ',
-    sourceLinkText: 'SemiAnalysis Market July 2026 AI Cloud TCO Model',
+    sourceLinkText: TCO_SOURCE_TITLE,
     tierNavLabel: 'SLO',
     tierUnit: 'tok/s/user',
     engineScopeNavLabel: 'Engine scope',
@@ -161,7 +163,7 @@ export const OVERVIEW_STRINGS = {
     scopeDirection: '↓ 越低越好',
     scopeAria: '超大规模云（hyperscaler）每百万总 token 成本，越低越好。',
     sourcePrefix: '来源：InferenceX 与 ',
-    sourceLinkText: 'SemiAnalysis Market July 2026 AI Cloud TCO Model',
+    sourceLinkText: TCO_SOURCE_TITLE,
     tierNavLabel: 'SLO',
     tierUnit: 'tok/s/用户',
     engineScopeNavLabel: '引擎范围',

--- a/packages/app/src/components/ui/chart-display-helpers.test.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.test.tsx
@@ -3,6 +3,8 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+
 import { ChartShareActions, MetricAssumptionNotes } from '@/components/ui/chart-display-helpers';
 
 let container: HTMLDivElement;
@@ -84,9 +86,8 @@ describe('MetricAssumptionNotes', () => {
     renderUi(<MetricAssumptionNotes selectedYAxisMetric="y_outputTokensPerDollarH" />);
 
     expect(getVisibleText()).toContain('TCO $/chip/hr:');
-    expect(getVisibleText()).toContain(
-      'SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model',
-    );
+    expect(getVisibleText()).toContain(TCO_SOURCE_TITLE);
+    expect(container.querySelector(`a[href="${TCO_SOURCE_URL}"]`)).not.toBeNull();
     expect(getVisibleCaveatText()).toContain(
       'calculate tokens per $1 USD per decode chip or per prefill chip',
     );
@@ -142,9 +143,8 @@ describe('MetricAssumptionNotes', () => {
 
     // The TCO badges and source attribution still explain the hourly-price input.
     expect(getVisibleText()).toContain('TCO $/chip/hr:');
-    expect(getVisibleText()).toContain(
-      'SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model',
-    );
+    expect(getVisibleText()).toContain(TCO_SOURCE_TITLE);
+    expect(container.querySelector(`a[href="${TCO_SOURCE_URL}"]`)).not.toBeNull();
     expect(getVisibleCaveatText()).not.toContain(
       'calculate tokens per $1 USD per decode chip or per prefill chip',
     );

--- a/packages/app/src/components/ui/chart-display-helpers.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.tsx
@@ -3,10 +3,15 @@
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 
+import {
+  HW_REGISTRY,
+  TCO_SOURCE_TITLE,
+  TCO_SOURCE_URL,
+} from '@semianalysisai/inferencex-constants';
+
 import { Badge } from '@/components/ui/badge';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { ShareButton } from '@/components/ui/share-button';
-import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 import { useLocale } from '@/lib/use-locale';
 import type { Locale } from '@/lib/i18n';
 
@@ -238,8 +243,8 @@ export function MetricAssumptionNotes({
       {costValues && (
         <>
           <MetricBadges label={costLabel} values={costValues} />
-          <SourceLink href="https://semianalysis.com/ai-cloud-tco-model/" sourceLabel={sourceLabel}>
-            SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model
+          <SourceLink href={TCO_SOURCE_URL} sourceLabel={sourceLabel}>
+            {TCO_SOURCE_TITLE}
           </SourceLink>
         </>
       )}

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -7,3 +7,4 @@ export * from './models';
 export * from './seo';
 export * from './tables';
 export * from './currency';
+export * from './tco';

--- a/packages/constants/src/tco.ts
+++ b/packages/constants/src/tco.ts
@@ -1,0 +1,5 @@
+/** Canonical public source for the TCO inputs used across InferenceX. */
+export const TCO_SOURCE_TITLE =
+  'SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model';
+
+export const TCO_SOURCE_URL = 'https://semianalysis.com/ai-cloud-tco-model/';


### PR DESCRIPTION
## What changed

- Define one canonical TCO source title and URL in the shared constants package.
- Reuse that provenance across Overview, inference metric notes, the calculator, Fleet Planner, and compare-per-dollar.
- Add consumer-level assertions for the rendered source label and link.

## Why

The same TCO attribution was duplicated across five surfaces, so wording or links could drift independently. This centralizes provenance only; pricing values and calculations are unchanged.

## Validation

- Focused unit tests: 24/24 passed
- Overview, calculator, and compare-per-dollar E2E: Chrome 112/112, Firefox 112/112
- Fixture production build, typecheck, lint, format, and diff check passed

## 中文说明

- 在共享 constants package 中定义唯一的 TCO 来源标题与链接。
- 在 Overview、inference metric 说明、Calculator、Fleet Planner 和 compare-per-dollar 中复用这份来源信息。
- 增加消费端断言，固定最终渲染的来源标题与链接。

此前同一份 TCO 来源信息分散在五个界面中，文案或链接可能各自发生漂移。本 PR 只集中管理来源元数据，不改变价格数值或计算逻辑。

验证结果：相关单元测试 24/24 通过；Overview、Calculator 与 compare-per-dollar E2E 在 Chrome 和 Firefox 中各 112/112 通过；fixture production build、typecheck、lint、format 与 diff check 均通过。
