### PR TITLE
refactor(overview): share route and metadata assembly / 复用 Overview 路由与元数据组装

### DIFF
--- a/packages/app/src/app/overview/page.tsx
+++ b/packages/app/src/app/overview/page.tsx
@@ -1,56 +1,13 @@
-import type { Metadata } from 'next';
-
-import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
-
-import { OverviewPageContent } from '@/components/overview/overview-page';
-import { enAlternates } from '@/lib/i18n';
 import {
-  resolveOverviewComparisonMode,
-  resolveOverviewEngineScope,
-  resolveOverviewHardwareRowScope,
-  resolveOverviewModelScope,
-  resolveOverviewReferenceHardware,
-  resolveOverviewRowScope,
-  resolveOverviewTier,
-} from '@/lib/overview-data';
-import { getOverviewPageData } from '@/lib/overview-data.server';
+  buildOverviewMetadata,
+  type OverviewRoutePageProps,
+  renderOverviewPage,
+} from '@/lib/overview-route.server';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION =
-  'Compare hyperscaler cost per million total tokens across MI355X, B200, B300, GB200, and GB300 for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.';
+export const metadata = buildOverviewMetadata('en');
 
-export const metadata: Metadata = {
-  title: 'Agentic Inference Costs',
-  description: DESCRIPTION,
-  alternates: enAlternates('/overview'),
-  openGraph: {
-    title: `Agentic Inference Costs | ${SITE_NAME}`,
-    description: DESCRIPTION,
-    url: `${SITE_URL}/overview`,
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: `Agentic Inference Costs | ${SITE_NAME}`,
-    description: DESCRIPTION,
-  },
-};
-
-interface Props {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
-export default async function OverviewPage({ searchParams }: Props) {
-  const sp = await searchParams;
-  const data = await getOverviewPageData(
-    resolveOverviewTier(sp.tier),
-    resolveOverviewEngineScope(sp.engine),
-    resolveOverviewComparisonMode(sp.compare),
-    resolveOverviewReferenceHardware(sp.ref),
-    resolveOverviewModelScope(sp.models),
-    resolveOverviewRowScope(sp.rows),
-    resolveOverviewHardwareRowScope(sp.hwrows),
-  );
-  return <OverviewPageContent data={data} locale="en" />;
+export default function OverviewPage({ searchParams }: OverviewRoutePageProps) {
+  return renderOverviewPage({ locale: 'en', searchParams });
 }

--- a/packages/app/src/app/zh/overview/page.tsx
+++ b/packages/app/src/app/zh/overview/page.tsx
@@ -1,57 +1,13 @@
-import type { Metadata } from 'next';
-
-import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
-
-import { OverviewPageContent } from '@/components/overview/overview-page';
-import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import {
-  resolveOverviewComparisonMode,
-  resolveOverviewEngineScope,
-  resolveOverviewHardwareRowScope,
-  resolveOverviewModelScope,
-  resolveOverviewReferenceHardware,
-  resolveOverviewRowScope,
-  resolveOverviewTier,
-} from '@/lib/overview-data';
-import { getOverviewPageData } from '@/lib/overview-data.server';
+  buildOverviewMetadata,
+  type OverviewRoutePageProps,
+  renderOverviewPage,
+} from '@/lib/overview-route.server';
 
 export const dynamic = 'force-dynamic';
 
-const DESCRIPTION =
-  '在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 MI355X、B200、B300、GB200 与 GB300 的每百万总 token 超大规模云成本。';
+export const metadata = buildOverviewMetadata('zh');
 
-export const metadata: Metadata = {
-  title: '智能体推理成本',
-  description: DESCRIPTION,
-  alternates: zhAlternates('/overview'),
-  openGraph: {
-    title: `智能体推理成本 | ${SITE_NAME}`,
-    description: DESCRIPTION,
-    url: `${SITE_URL}/zh/overview`,
-    type: 'website',
-    locale: ZH_OG_LOCALE,
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: `智能体推理成本 | ${SITE_NAME}`,
-    description: DESCRIPTION,
-  },
-};
-
-interface Props {
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
-export default async function ZhOverviewPage({ searchParams }: Props) {
-  const sp = await searchParams;
-  const data = await getOverviewPageData(
-    resolveOverviewTier(sp.tier),
-    resolveOverviewEngineScope(sp.engine),
-    resolveOverviewComparisonMode(sp.compare),
-    resolveOverviewReferenceHardware(sp.ref),
-    resolveOverviewModelScope(sp.models),
-    resolveOverviewRowScope(sp.rows),
-    resolveOverviewHardwareRowScope(sp.hwrows),
-  );
-  return <OverviewPageContent data={data} locale="zh" />;
+export default function ZhOverviewPage({ searchParams }: OverviewRoutePageProps) {
+  return renderOverviewPage({ locale: 'zh', searchParams });
 }

--- a/packages/app/src/lib/overview-metadata.test.ts
+++ b/packages/app/src/lib/overview-metadata.test.ts
@@ -2,22 +2,18 @@ import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 import { describe, expect, it } from 'vitest';
 
 import { ZH_OG_LOCALE } from './i18n';
-import { OVERVIEW_HARDWARE, overviewHardwareLabel } from './overview-data';
 import { buildOverviewMetadata } from './overview-route.server';
 
-const CURATED_LABELS = OVERVIEW_HARDWARE.map((hardware) => overviewHardwareLabel(hardware));
-const NON_OVERVIEW_LABELS = ['h100', 'h200', 'mi300x', 'mi325x', 'rtx6000pro'].map((hardware) =>
-  overviewHardwareLabel(hardware),
-);
+const EXPECTED_DESCRIPTIONS = {
+  en: 'Compare hyperscaler cost per million total tokens across B200, MI355X, B300, GB200 NVL72, and GB300 NVL72 for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.',
+  zh: '在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 B200、MI355X、B300、GB200 NVL72 与 GB300 NVL72 的每百万总 token 超大规模云成本。',
+} as const;
 
 describe('buildOverviewMetadata', () => {
-  it.each(['en', 'zh'] as const)('names only the curated Overview platforms in %s', (locale) => {
+  it.each(['en', 'zh'] as const)('locks the curated Overview platform wording in %s', (locale) => {
     const metadata = buildOverviewMetadata(locale);
-    const description = metadata.description;
 
-    expect(typeof description).toBe('string');
-    for (const label of CURATED_LABELS) expect(description).toContain(label);
-    for (const label of NON_OVERVIEW_LABELS) expect(description).not.toContain(label);
+    expect(metadata.description).toBe(EXPECTED_DESCRIPTIONS[locale]);
   });
 
   it('preserves the English title, canonical URL, and OpenGraph identity', () => {

--- a/packages/app/src/lib/overview-metadata.test.ts
+++ b/packages/app/src/lib/overview-metadata.test.ts
@@ -1,0 +1,48 @@
+import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import { describe, expect, it } from 'vitest';
+
+import { ZH_OG_LOCALE } from './i18n';
+import { OVERVIEW_HARDWARE, overviewHardwareLabel } from './overview-data';
+import { buildOverviewMetadata } from './overview-route.server';
+
+const CURATED_LABELS = OVERVIEW_HARDWARE.map((hardware) => overviewHardwareLabel(hardware));
+const NON_OVERVIEW_LABELS = ['h100', 'h200', 'mi300x', 'mi325x', 'rtx6000pro'].map((hardware) =>
+  overviewHardwareLabel(hardware),
+);
+
+describe('buildOverviewMetadata', () => {
+  it.each(['en', 'zh'] as const)('names only the curated Overview platforms in %s', (locale) => {
+    const metadata = buildOverviewMetadata(locale);
+    const description = metadata.description;
+
+    expect(typeof description).toBe('string');
+    for (const label of CURATED_LABELS) expect(description).toContain(label);
+    for (const label of NON_OVERVIEW_LABELS) expect(description).not.toContain(label);
+  });
+
+  it('preserves the English title, canonical URL, and OpenGraph identity', () => {
+    const metadata = buildOverviewMetadata('en');
+
+    expect(metadata.title).toBe('Agentic Inference Costs');
+    expect(metadata.alternates).toMatchObject({ canonical: `${SITE_URL}/overview` });
+    expect(metadata.openGraph).toMatchObject({
+      title: `Agentic Inference Costs | ${SITE_NAME}`,
+      url: `${SITE_URL}/overview`,
+      type: 'website',
+    });
+    expect(metadata.openGraph).not.toHaveProperty('locale');
+  });
+
+  it('preserves the Chinese title, canonical URL, and OpenGraph locale', () => {
+    const metadata = buildOverviewMetadata('zh');
+
+    expect(metadata.title).toBe('智能体推理成本');
+    expect(metadata.alternates).toMatchObject({ canonical: `${SITE_URL}/zh/overview` });
+    expect(metadata.openGraph).toMatchObject({
+      title: `智能体推理成本 | ${SITE_NAME}`,
+      url: `${SITE_URL}/zh/overview`,
+      type: 'website',
+      locale: ZH_OG_LOCALE,
+    });
+  });
+});

--- a/packages/app/src/lib/overview-route.server.test.tsx
+++ b/packages/app/src/lib/overview-route.server.test.tsx
@@ -1,0 +1,80 @@
+import { isValidElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OverviewPageData } from './overview-data';
+
+const { mockGetOverviewPageData } = vi.hoisted(() => ({
+  mockGetOverviewPageData: vi.fn(),
+}));
+
+vi.mock('@/lib/overview-data.server', () => ({
+  getOverviewPageData: mockGetOverviewPageData,
+}));
+
+import { renderOverviewPage } from './overview-route.server';
+
+const PAGE_DATA = { models: [] } as unknown as OverviewPageData;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetOverviewPageData.mockResolvedValue(PAGE_DATA);
+});
+
+describe('renderOverviewPage', () => {
+  it.each(['en', 'zh'] as const)(
+    'resolves every query control once and propagates the %s locale',
+    async (locale) => {
+      const element = await renderOverviewPage({
+        locale,
+        searchParams: Promise.resolve({
+          tier: ['100', '75'],
+          engine: ['all', 'community'],
+          compare: ['60d', 'hardware'],
+          ref: ['gb300', 'b200'],
+          models: ['all', 'default'],
+          rows: ['changed', 'all'],
+          hwrows: ['priced', 'all'],
+        }),
+      });
+
+      expect(mockGetOverviewPageData).toHaveBeenCalledOnce();
+      expect(mockGetOverviewPageData).toHaveBeenCalledWith(
+        100,
+        'all',
+        '60d',
+        'gb300',
+        'all',
+        'changed',
+        'priced',
+      );
+      expect(isValidElement(element)).toBe(true);
+      expect(element.props).toMatchObject({ data: PAGE_DATA, locale });
+    },
+  );
+
+  it('normalizes invalid and array values with the canonical overview defaults', async () => {
+    await renderOverviewPage({
+      locale: 'en',
+      searchParams: Promise.resolve({
+        tier: ['999', '75'],
+        engine: ['vendor', 'all'],
+        compare: ['weekly', '30d'],
+        ref: ['h100', 'b300'],
+        models: ['inactive', 'all'],
+        rows: ['some', 'changed'],
+        hwrows: ['blank', 'priced'],
+      }),
+    });
+
+    expect(mockGetOverviewPageData).toHaveBeenCalledOnce();
+    expect(mockGetOverviewPageData).toHaveBeenCalledWith(
+      50,
+      'community',
+      'hardware',
+      'b200',
+      'default',
+      'all',
+      'all',
+    );
+  });
+});

--- a/packages/app/src/lib/overview-route.server.tsx
+++ b/packages/app/src/lib/overview-route.server.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next';
+
+import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { OverviewPageContent } from '@/components/overview/overview-page';
+import { enAlternates, type Locale, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import {
+  OVERVIEW_HARDWARE,
+  overviewHardwareLabel,
+  resolveOverviewComparisonMode,
+  resolveOverviewEngineScope,
+  resolveOverviewHardwareRowScope,
+  resolveOverviewModelScope,
+  resolveOverviewReferenceHardware,
+  resolveOverviewRowScope,
+  resolveOverviewTier,
+} from '@/lib/overview-data';
+import { getOverviewPageData } from '@/lib/overview-data.server';
+
+export type OverviewSearchParams = Record<string, string | string[] | undefined>;
+
+export interface OverviewRoutePageProps {
+  searchParams: Promise<OverviewSearchParams>;
+}
+
+interface OverviewRouteProps extends OverviewRoutePageProps {
+  locale: Locale;
+}
+
+function overviewPlatformList(locale: Locale): string {
+  const labels = OVERVIEW_HARDWARE.map((hardware) => overviewHardwareLabel(hardware));
+  if (locale === 'zh') return labels.join('、');
+  return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
+}
+
+export function buildOverviewMetadata(locale: Locale): Metadata {
+  const platforms = overviewPlatformList(locale);
+  const title = locale === 'zh' ? '智能体推理成本' : 'Agentic Inference Costs';
+  const description =
+    locale === 'zh'
+      ? `在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 ${platforms} 的每百万总 token 超大规模云成本。`
+      : `Compare hyperscaler cost per million total tokens across ${platforms} for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.`;
+  const path = locale === 'zh' ? '/zh/overview' : '/overview';
+
+  return {
+    title,
+    description,
+    alternates: locale === 'zh' ? zhAlternates('/overview') : enAlternates('/overview'),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url: `${SITE_URL}${path}`,
+      type: 'website',
+      ...(locale === 'zh' ? { locale: ZH_OG_LOCALE } : {}),
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  };
+}
+
+export async function renderOverviewPage({ locale, searchParams }: OverviewRouteProps) {
+  const params = await searchParams;
+  const data = await getOverviewPageData(
+    resolveOverviewTier(params.tier),
+    resolveOverviewEngineScope(params.engine),
+    resolveOverviewComparisonMode(params.compare),
+    resolveOverviewReferenceHardware(params.ref),
+    resolveOverviewModelScope(params.models),
+    resolveOverviewRowScope(params.rows),
+    resolveOverviewHardwareRowScope(params.hwrows),
+  );
+
+  return <OverviewPageContent data={data} locale={locale} />;
+}

--- a/packages/app/src/lib/overview-route.server.tsx
+++ b/packages/app/src/lib/overview-route.server.tsx
@@ -29,7 +29,7 @@ interface OverviewRouteProps extends OverviewRoutePageProps {
 
 function overviewPlatformList(locale: Locale): string {
   const labels = OVERVIEW_HARDWARE.map((hardware) => overviewHardwareLabel(hardware));
-  if (locale === 'zh') return labels.join('、');
+  if (locale === 'zh') return `${labels.slice(0, -1).join('、')} 与 ${labels.at(-1)}`;
   return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
 }
 


### PR DESCRIPTION
## What changed

- Share one server-side query resolver and locale-aware renderer between `/overview` and `/zh/overview`.
- Build platform metadata from the curated Overview hardware contract instead of duplicated labels.
- Cover all seven query controls, locale propagation, canonical URLs, and OpenGraph identity with focused tests.

## Why

The English and Chinese routes independently repeated the same query and metadata assembly, creating two places for defaults, hardware labels, or SEO fields to drift. This refactor preserves existing behavior while giving both routes one source of truth.

## Validation

- Focused route and metadata unit tests: 7/7 passed
- Overview E2E: Chrome 37/37, Firefox 37/37
- Fixture production build, typecheck, lint, format, and diff check passed

## 中文说明

- 在 `/overview` 与 `/zh/overview` 之间复用同一套服务端查询参数解析和本地化渲染逻辑。
- 基于 Overview 明确维护的硬件 contract 生成平台 metadata，不再重复维护硬件名称。
- 通过聚焦测试覆盖全部七个查询参数、locale 传递、canonical URL 与 OpenGraph 标识。

此前英文与中文路由分别重复实现查询参数和 metadata 组装，默认值、硬件名称或 SEO 字段可能发生漂移。本次重构保持现有行为不变，同时为两个路由建立唯一的数据源。

验证结果：路由与 metadata 单元测试 7/7 通过；Overview E2E 在 Chrome 和 Firefox 中各 37/37 通过；fixture production build、typecheck、lint、format 与 diff check 均通过。
