### PR TITLE
Restore Blacksmith database backup runner / 恢复使用 Blacksmith 数据库备份 runner

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -49,7 +49,7 @@ jobs:
     name: Dump and compress
     needs: preflight
     timeout-minutes: 360
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     steps:
       - name: Dump, compress, and split database
         env:


### PR DESCRIPTION
## Summary

- Move the database dump job from `ubuntu-latest` back to `blacksmith-32vcpu-ubuntu-2404`.
- Avoid the GitHub-hosted runner disk exhaustion seen after 4 hours 46 minutes.
- Retain the 360-minute timeout as headroom for future database growth.

## Verification

- Dispatched the workflow from this branch and monitored it through completion.
- [Workflow run #32420504714](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/32420504714) succeeded in 73 minutes.
- Dump, stream verification, checksums, artifact upload, and release creation all passed.
- Published [database dump `db-dump/2026-08-20`](https://github.com/SemiAnalysisAI/InferenceX-app/releases/tag/db-dump/2026-08-20), containing six parts totaling about 10.25 GiB.
- No `blacksmithd` OOM or runner failure occurred.
- Pre-commit lint, formatting, and type checking passed.

## 中文说明

- 将数据库导出任务从 `ubuntu-latest` 切回 `blacksmith-32vcpu-ubuntu-2404`。
- 避免 GitHub 托管 runner 在运行 4 小时 46 分钟后因磁盘空间耗尽而失败。
- 保留 360 分钟超时上限，为数据库后续增长预留空间。

## 验证

- 已从本分支手动触发工作流，并持续监控至任务完成。
- [工作流运行 #32420504714](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/32420504714) 成功完成，总耗时 73 分钟。
- 数据库导出、压缩流校验、校验和生成、产物上传和 Release 创建均成功。
- 已发布[数据库备份 `db-dump/2026-08-20`](https://github.com/SemiAnalysisAI/InferenceX-app/releases/tag/db-dump/2026-08-20)，包含六个分片，总大小约 10.25 GiB。
- 本次运行未出现 `blacksmithd` 内存耗尽或 runner 故障。
- 提交前 lint、格式化和类型检查均通过。