### PR TITLE
[Buggy AF] Fix Best per SKU in MP4 replay / 修复 MP4 回放中的“每个 SKU 最佳配置”

### DIFF
--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -120,10 +120,12 @@ MP4 export captures a sequence of cloned DOM frames. A wall-clock D3 transition
 can look correct in the live preview yet disappear from the video because the
 export loop advances the replay fraction and captures before that timer has
 meaningfully progressed. Best-per-SKU winner changes therefore encode their
-morph directly in replay frame data: a short fraction window resamples the
+morph directly in replay frame data: a visible fraction window resamples the
 outgoing roofline and interpolates it into the incoming config. The preview and
 the encoder consume the same intermediate geometry, while the shared D3
-transition duration stays at zero for replay.
+transition duration stays at zero for replay. Best-per-SKU MP4 mode keeps this
+explicitly requested animation active even when the ambient reduced-motion
+preference is set; regular replay continues to honor that preference.
 
 ## Batched Label Measurement
 

--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -127,6 +127,12 @@ transition duration stays at zero for replay. Best-per-SKU MP4 mode keeps this
 explicitly requested animation active even when the ambient reduced-motion
 preference is set; regular replay continues to honor that preference.
 
+Best-per-SKU export also applies the selected replay speed to the MP4 duration
+while retaining 30 FPS, so 3×–5× produces proportionally fewer frames instead
+of spending time encoding a canonical 1× video. Regular replay keeps its
+existing duration. Each export frame uses one paint boundary after the
+synchronous React commit before the chart DOM is cloned and rasterized.
+
 ## Batched Label Measurement
 
 Label loops that size a background rect to its text (`.ll-bg`/`.pl-bg`, point-label collision avoidance) must not interleave `getBBox()` with DOM writes — each read after a write forces a synchronous layout, turning N labels into N reflows. The pattern is two passes over the selection: write every label's text first, then measure every bbox (one forced layout for the whole batch), then write the rects. Same rule for `measureLegendRightInset`: it reads `getBoundingClientRect`, so it's skipped entirely when there are no known-issue annotations to place — it would otherwise run on every zoom frame.

--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -114,6 +114,17 @@ D3 bar charts measure actual Y-axis label widths using a temporary SVG `<text>` 
 
 Opacity animates via inline CSS `transition: opacity 150ms ease` (set on dots, rooflines, and labels in the render path); d3 `.transition()` is reserved for attributes CSS can't animate — the `data-update` entrance transitions on dot `transform` and roofline `d`. Never point both systems at the same property: a d3 transition re-writes the style every animation frame, and each write restarts the CSS transition, emitting `transitionrun`/`transitioncancel` per node per frame (a legend hover across a full chart used to produce tens of thousands of events per session, all of it also observed by PostHog's session-replay MutationObserver). Handlers like legend hover therefore write opacity **once** and let CSS do the animation.
 
+## Deterministic Motion in MP4 Replay
+
+MP4 export captures a sequence of cloned DOM frames. A wall-clock D3 transition
+can look correct in the live preview yet disappear from the video because the
+export loop advances the replay fraction and captures before that timer has
+meaningfully progressed. Best-per-SKU winner changes therefore encode their
+morph directly in replay frame data: a short fraction window resamples the
+outgoing roofline and interpolates it into the incoming config. The preview and
+the encoder consume the same intermediate geometry, while the shared D3
+transition duration stays at zero for replay.
+
 ## Batched Label Measurement
 
 Label loops that size a background rect to its text (`.ll-bg`/`.pl-bg`, point-label collision avoidance) must not interleave `getBBox()` with DOM writes — each read after a write forces a synchronous layout, turning N labels into N reflows. The pattern is two passes over the selection: write every label's text first, then measure every bbox (one forced layout for the whole batch), then write the rects. Same rule for `measureLegendRightInset`: it reads `getBoundingClientRect`, so it's skipped entirely when there are no known-issue annotations to place — it would otherwise run on every zoom frame.

--- a/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
@@ -17,8 +17,12 @@ const bestReplayHardwareKeys = (): Cypress.Chainable<InferenceData['hwKey'][]> =
       .toSorted(),
   );
 
+type AnimatedRoofline = SVGPathElement & {
+  __transition?: Record<string, { name?: string }>;
+};
+
 describe('Inference replay — Best per SKU', () => {
-  it('recomputes the visible winning hwKeys as the MP4 playhead advances', () => {
+  it('animates changing winners and offers Best-per-SKU-only speeds through 5×', () => {
     cy.intercept('GET', '/api/v1/availability', { fixture: 'api/availability.json' });
     cy.intercept('GET', '**/api/v1/benchmarks?*', { fixture: 'api/benchmarks.json' });
     cy.intercept('GET', '**/api/v1/benchmarks/history*', {
@@ -29,6 +33,20 @@ describe('Inference replay — Best per SKU', () => {
     cy.visit('/inference?g_model=DeepSeek-R1-0528&i_seq=1k%2F1k&i_prec=fp8&i_best=', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        const nativeMatchMedia = win.matchMedia.bind(win);
+        win.matchMedia = (query: string) => {
+          if (query !== '(prefers-reduced-motion: reduce)') return nativeMatchMedia(query);
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: () => {},
+            removeListener: () => {},
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            dispatchEvent: () => false,
+          };
+        };
       },
     });
     cy.get('[data-testid="chart-figure"]')
@@ -43,19 +61,62 @@ describe('Inference replay — Best per SKU', () => {
     setBestReplayScrubber(0);
     bestReplayHardwareKeys().then((startKeys) => {
       expect(startKeys.length, 'at least one SKU winner at the first date').to.be.greaterThan(0);
-      cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').each(($path) => {
-        expect(
-          $path.attr('stroke'),
-          `${$path.data('hw-key')} reuses its current parent SKU color`,
-        ).not.to.equal('var(--muted-foreground)');
-      });
-      setBestReplayScrubber(1000);
-      bestReplayHardwareKeys().then((endKeys) => {
-        expect(endKeys.length, 'at least one SKU winner at the last date').to.be.greaterThan(0);
-        expect(endKeys, 'historical winners are not frozen to the first frame').not.to.deep.equal(
-          startKeys,
-        );
+      cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').then(($startPaths) => {
+        const startPaths = [...$startPaths].map((node) => ({
+          node: node as unknown as AnimatedRoofline,
+          hwKey: node.dataset.hwKey,
+          seriesKey: node.dataset.seriesKey,
+          d: node.getAttribute('d'),
+        }));
+        for (const path of startPaths) {
+          expect(
+            path.node.getAttribute('stroke'),
+            `${path.hwKey} reuses its current parent SKU color`,
+          ).not.to.equal('var(--muted-foreground)');
+        }
+
+        setBestReplayScrubber(1000);
+        cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').then(($endPaths) => {
+          const endPaths = [...$endPaths] as unknown as AnimatedRoofline[];
+          const moved = startPaths.find((start) => {
+            const reused = endPaths.find((end) => end === start.node);
+            return reused && reused.dataset.hwKey !== start.hwKey;
+          });
+          expect(
+            moved,
+            'one physical SKU reuses its roofline when the winner changes',
+          ).not.to.equal(undefined);
+          const movedNode = moved!.node;
+          expect(movedNode.dataset.seriesKey).to.equal(moved!.seriesKey);
+          expect(
+            Object.values(movedNode.__transition ?? {}).some(
+              (transition) => transition.name === 'data-update',
+            ),
+            'the reused roofline has an active D3 movement transition',
+          ).to.equal(true);
+          cy.wrap(movedNode).should(() => {
+            expect(
+              movedNode.getAttribute('d'),
+              'the roofline animates away from its old geometry',
+            ).not.to.equal(moved!.d);
+          });
+        });
+
+        bestReplayHardwareKeys().then((endKeys) => {
+          expect(endKeys.length, 'at least one SKU winner at the last date').to.be.greaterThan(0);
+          expect(endKeys, 'historical winners are not frozen to the first frame').not.to.deep.equal(
+            startKeys,
+          );
+        });
       });
     });
+
+    cy.get('[data-testid="replay-speed-select"]').click();
+    cy.get('[data-testid="replay-speed-5x"]').should('be.visible').click();
+    cy.get('[data-testid="replay-speed-select"]').should('contain.text', '5×');
+
+    cy.get('[data-testid="replay-panel-chart-0"] [data-testid="scatter-best-per-sku"]').click();
+    cy.get('[data-testid="replay-speed-select"]').should('contain.text', '2×').click();
+    cy.get('[data-testid="replay-speed-5x"]').should('not.exist');
   });
 });

--- a/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
@@ -17,12 +17,8 @@ const bestReplayHardwareKeys = (): Cypress.Chainable<InferenceData['hwKey'][]> =
       .toSorted(),
   );
 
-type AnimatedRoofline = SVGPathElement & {
-  __transition?: Record<string, { name?: string }>;
-};
-
 describe('Inference replay — Best per SKU', () => {
-  it('animates changing winners and offers Best-per-SKU-only speeds through 5×', () => {
+  it('keeps changing winner geometry continuous and offers Best-per-SKU-only speeds through 5×', () => {
     cy.intercept('GET', '/api/v1/availability', { fixture: 'api/availability.json' });
     cy.intercept('GET', '**/api/v1/benchmarks?*', { fixture: 'api/benchmarks.json' });
     cy.intercept('GET', '**/api/v1/benchmarks/history*', {
@@ -63,7 +59,7 @@ describe('Inference replay — Best per SKU', () => {
       expect(startKeys.length, 'at least one SKU winner at the first date').to.be.greaterThan(0);
       cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').then(($startPaths) => {
         const startPaths = [...$startPaths].map((node) => ({
-          node: node as unknown as AnimatedRoofline,
+          node: node as unknown as SVGPathElement,
           hwKey: node.dataset.hwKey,
           seriesKey: node.dataset.seriesKey,
           d: node.getAttribute('d'),
@@ -77,7 +73,7 @@ describe('Inference replay — Best per SKU', () => {
 
         setBestReplayScrubber(1000);
         cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').then(($endPaths) => {
-          const endPaths = [...$endPaths] as unknown as AnimatedRoofline[];
+          const endPaths = [...$endPaths] as unknown as SVGPathElement[];
           const moved = startPaths.find((start) => {
             const reused = endPaths.find((end) => end === start.node);
             return reused && reused.dataset.hwKey !== start.hwKey;
@@ -88,16 +84,10 @@ describe('Inference replay — Best per SKU', () => {
           ).not.to.equal(undefined);
           const movedNode = moved!.node;
           expect(movedNode.dataset.seriesKey).to.equal(moved!.seriesKey);
-          expect(
-            Object.values(movedNode.__transition ?? {}).some(
-              (transition) => transition.name === 'data-update',
-            ),
-            'the reused roofline has an active D3 movement transition',
-          ).to.equal(true);
           cy.wrap(movedNode).should(() => {
             expect(
               movedNode.getAttribute('d'),
-              'the roofline animates away from its old geometry',
+              'the stable roofline receives the deterministic MP4-frame geometry',
             ).not.to.equal(moved!.d);
           });
         });

--- a/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
@@ -33,7 +33,7 @@ describe('Inference replay — Best per SKU', () => {
         win.matchMedia = (query: string) => {
           if (query !== '(prefers-reduced-motion: reduce)') return nativeMatchMedia(query);
           return {
-            matches: false,
+            matches: true,
             media: query,
             onchange: null,
             addListener: () => {},
@@ -53,6 +53,26 @@ describe('Inference replay — Best per SKU', () => {
       });
     cy.get('[data-testid="export-mp4-button"]').first().click();
     cy.get('[data-testid="replay-scrubber"]', { timeout: 15_000 }).should('exist');
+
+    // Regression: the runtime that exposed the bug reports reduced motion.
+    // Best-per-SKU MP4 mode is an explicit animation request, so it must use
+    // continuous fractions instead of the reduced-motion 1.2s slideshow.
+    cy.window().then((win) => {
+      expect(win.matchMedia('(prefers-reduced-motion: reduce)').matches).to.equal(true);
+    });
+    cy.get('[data-testid="replay-reset"]').click();
+    cy.get('[data-testid="replay-play-pause"]').click();
+    cy.wait(300);
+    cy.get('[data-testid="replay-scrubber"]')
+      .invoke('val')
+      .then((value) => {
+        expect(
+          Number(value),
+          'continuous Best-per-SKU animation advances before 1.2s',
+        ).to.be.greaterThan(0);
+      });
+    cy.get('[data-testid="replay-play-pause"]').click();
+    cy.get('[data-testid="replay-reset"]').click();
 
     setBestReplayScrubber(0);
     bestReplayHardwareKeys().then((startKeys) => {

--- a/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
@@ -1,0 +1,55 @@
+import type { InferenceData } from '@/components/inference/types';
+
+const setBestReplayScrubber = (value: number): Cypress.Chainable<JQuery<HTMLElement>> =>
+  cy.get('[data-testid="replay-scrubber"]').then(($element) => {
+    const element = $element[0] as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')!.set!;
+    setter.call(element, String(value));
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+const bestReplayHardwareKeys = (): Cypress.Chainable<InferenceData['hwKey'][]> =>
+  cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').then(($paths) =>
+    [...$paths]
+      .map((path) => path.dataset.hwKey)
+      .filter((key): key is string => Boolean(key))
+      .toSorted(),
+  );
+
+describe('Inference replay — Best per SKU', () => {
+  it('recomputes the visible winning hwKeys as the MP4 playhead advances', () => {
+    cy.intercept('GET', '/api/v1/availability', { fixture: 'api/availability.json' });
+    cy.intercept('GET', '**/api/v1/benchmarks?*', { fixture: 'api/benchmarks.json' });
+    cy.intercept('GET', '**/api/v1/benchmarks/history*', {
+      fixture: 'api/benchmarks-history.json',
+    });
+    cy.intercept('GET', '/api/v1/workflow-info?*', { fixture: 'api/workflow-info.json' });
+
+    cy.visit('/inference?g_model=DeepSeek-R1-0528&i_seq=1k%2F1k&i_prec=fp8&i_best=', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="chart-figure"]')
+      .first()
+      .within(() => {
+        cy.get('[data-testid="scatter-best-per-sku"]').should('have.attr', 'data-state', 'checked');
+        cy.get('[data-testid="export-button"]').click();
+      });
+    cy.get('[data-testid="export-mp4-button"]').first().click();
+    cy.get('[data-testid="replay-scrubber"]', { timeout: 15_000 }).should('exist');
+
+    setBestReplayScrubber(0);
+    bestReplayHardwareKeys().then((startKeys) => {
+      expect(startKeys.length, 'at least one SKU winner at the first date').to.be.greaterThan(0);
+      setBestReplayScrubber(1000);
+      bestReplayHardwareKeys().then((endKeys) => {
+        expect(endKeys.length, 'at least one SKU winner at the last date').to.be.greaterThan(0);
+        expect(endKeys, 'historical winners are not frozen to the first frame').not.to.deep.equal(
+          startKeys,
+        );
+      });
+    });
+  });
+});

--- a/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay-best-per-sku.cy.ts
@@ -43,6 +43,12 @@ describe('Inference replay — Best per SKU', () => {
     setBestReplayScrubber(0);
     bestReplayHardwareKeys().then((startKeys) => {
       expect(startKeys.length, 'at least one SKU winner at the first date').to.be.greaterThan(0);
+      cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path').each(($path) => {
+        expect(
+          $path.attr('stroke'),
+          `${$path.data('hw-key')} reuses its current parent SKU color`,
+        ).not.to.equal('var(--muted-foreground)');
+      });
       setBestReplayScrubber(1000);
       bestReplayHardwareKeys().then((endKeys) => {
         expect(endKeys.length, 'at least one SKU winner at the last date').to.be.greaterThan(0);

--- a/packages/app/src/components/inference/replay/ReplayLauncher.tsx
+++ b/packages/app/src/components/inference/replay/ReplayLauncher.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { forwardRef, useImperativeHandle, useState } from 'react';
 
-import type { ChartDefinition } from '@/components/inference/types';
+import type { ChartDefinition, OverlayData } from '@/components/inference/types';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 
@@ -21,6 +21,7 @@ interface ReplayLauncherProps {
   chartDefinition: ChartDefinition;
   yLabel: string;
   xLabel: string;
+  overlayData?: OverlayData;
 }
 
 export interface ReplayLauncherHandle {
@@ -33,7 +34,7 @@ export interface ReplayLauncherHandle {
  * keeping mp4-muxer and html-to-image out of the main inference bundle.
  */
 const ReplayLauncher = forwardRef<ReplayLauncherHandle, ReplayLauncherProps>(
-  ({ parentChartId, chartDefinition, yLabel, xLabel }, ref) => {
+  ({ parentChartId, chartDefinition, yLabel, xLabel, overlayData }, ref) => {
     const [open, setOpen] = useState(false);
     useImperativeHandle(ref, () => ({ open: () => setOpen(true) }), []);
     return (
@@ -49,6 +50,7 @@ const ReplayLauncher = forwardRef<ReplayLauncherHandle, ReplayLauncherProps>(
               chartDefinition={chartDefinition}
               yLabel={yLabel}
               xLabel={xLabel}
+              overlayData={overlayData}
             />
           )}
         </DialogContent>

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -63,8 +63,6 @@ interface ReplayPanelProps {
 
 const STANDARD_SPEED_OPTIONS: readonly number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 const BEST_PER_SKU_SPEED_OPTIONS: readonly number[] = [...STANDARD_SPEED_OPTIONS, 3, 4, 5];
-const BEST_PER_SKU_TRANSITION_MS = 240;
-const BEST_PER_SKU_MIN_TRANSITION_MS = 60;
 const REPLAY_BODY_MIN_HEIGHT = 480;
 
 /**
@@ -274,13 +272,6 @@ export default function ReplayPanel({
 
   const prefersReducedMotion = useReducedMotion();
   const speedOptions = dynamicBestPerSku ? BEST_PER_SKU_SPEED_OPTIONS : STANDARD_SPEED_OPTIONS;
-  const replayTransitionDuration =
-    dynamicBestPerSku && !prefersReducedMotion
-      ? Math.max(
-          BEST_PER_SKU_MIN_TRANSITION_MS,
-          Math.round(BEST_PER_SKU_TRANSITION_MS / Math.max(1, speed)),
-        )
-      : 0;
 
   // The extended speeds belong to Best per SKU replay. If that mode is
   // disabled while the panel is open, return to the regular replay ceiling.
@@ -386,9 +377,17 @@ export default function ReplayPanel({
             pointFilter: replayPointMatchesFilters,
             bestPerSku: dynamicBestPerSku,
             direction: rooflineDirection,
+            animateBestPerSku: dynamicBestPerSku && !prefersReducedMotion,
           })
         : [],
-    [timeline, fraction, replayPointMatchesFilters, dynamicBestPerSku, rooflineDirection],
+    [
+      timeline,
+      fraction,
+      replayPointMatchesFilters,
+      dynamicBestPerSku,
+      rooflineDirection,
+      prefersReducedMotion,
+    ],
   );
 
   const currentDate = useMemo(
@@ -646,7 +645,7 @@ export default function ReplayPanel({
           hardwareSeriesKeyMap={replayColorKeyMap}
           syncBestPerSkuSelection={false}
           overlayData={replayOverlayData}
-          transitionDuration={replayTransitionDuration}
+          transitionDuration={0}
           niceAxes={false}
           pinLineLabels
           xExtentOverride={fixedAxes ? fixedExtent?.x : undefined}

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -31,6 +31,7 @@ import { buildReplayTimeline } from './buildReplayTimeline';
 import type { Mp4ExportError, Mp4ExportStage } from './exportMp4';
 import {
   buildFrameData,
+  buildReplayColorKeyMap,
   buildReplayOverlayData,
   computeReplayDomain,
   dateAtFraction,
@@ -132,6 +133,11 @@ export default function ReplayPanel({
       : undefined;
   }, [chartDefinition, selectedYAxisMetric]);
   const dynamicBestPerSku = bestPerSku && rooflineDirection !== undefined;
+  const replayColorKeyMap = useMemo(
+    () =>
+      timeline && dynamicBestPerSku ? buildReplayColorKeyMap(timeline, activeHwTypes) : undefined,
+    [timeline, dynamicBestPerSku, activeHwTypes],
+  );
 
   const replayPointMatchesFilters = useCallback(
     (point: InferenceData) => matchesQuickFilters(point, quickFilters),
@@ -619,6 +625,7 @@ export default function ReplayPanel({
           yLabel={yLabel}
           chartDefinition={chartDefinition}
           showAllHardwareTypes={dynamicBestPerSku}
+          hardwareColorKeyMap={replayColorKeyMap}
           syncBestPerSkuSelection={false}
           overlayData={replayOverlayData}
           transitionDuration={0}

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -315,7 +315,7 @@ export default function ReplayPanel({
     if (!playing || !timeline) return;
     // Reduced motion: advance one observed step per ~1.2s without per-frame
     // interpolation, so users get a slideshow rather than continuous motion.
-    if (prefersReducedMotion) {
+    if (prefersReducedMotion && !dynamicBestPerSku) {
       const stepMs = 1200 / Math.max(0.1, speedRef.current);
       const n = timeline.dates.length;
       const intervalId = window.setInterval(() => {
@@ -362,7 +362,7 @@ export default function ReplayPanel({
       if (rafId !== 0) cancelAnimationFrame(rafId);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [playing, timeline, prefersReducedMotion]);
+  }, [playing, timeline, prefersReducedMotion, dynamicBestPerSku]);
 
   useEffect(() => {
     fractionRef.current = 0;
@@ -377,17 +377,10 @@ export default function ReplayPanel({
             pointFilter: replayPointMatchesFilters,
             bestPerSku: dynamicBestPerSku,
             direction: rooflineDirection,
-            animateBestPerSku: dynamicBestPerSku && !prefersReducedMotion,
+            animateBestPerSku: dynamicBestPerSku,
           })
         : [],
-    [
-      timeline,
-      fraction,
-      replayPointMatchesFilters,
-      dynamicBestPerSku,
-      rooflineDirection,
-      prefersReducedMotion,
-    ],
+    [timeline, fraction, replayPointMatchesFilters, dynamicBestPerSku, rooflineDirection],
   );
 
   const currentDate = useMemo(

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -8,7 +8,9 @@ import { sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
 
 import { useInference } from '@/components/inference/InferenceContext';
 import ScatterGraph from '@/components/inference/ui/ScatterGraph';
-import type { ChartDefinition } from '@/components/inference/types';
+import type { ChartDefinition, InferenceData, OverlayData } from '@/components/inference/types';
+import { matchesQuickFilters } from '@/components/inference/utils/quickFilters';
+import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
@@ -21,12 +23,21 @@ import {
 } from '@/components/ui/select';
 import { useBenchmarkHistory } from '@/hooks/api/use-benchmark-history';
 import { track } from '@/lib/analytics';
+import type { ParetoDirection } from '@/lib/chart-utils';
 import { Sequence } from '@/lib/data-mappings';
 import { cn } from '@/lib/utils';
 
-import { buildReplayTimeline, computeFullRunDomain } from './buildReplayTimeline';
+import { buildReplayTimeline } from './buildReplayTimeline';
 import type { Mp4ExportError, Mp4ExportStage } from './exportMp4';
-import { buildFrameData, dateAtFraction, shouldCommitFraction, spanMs } from './replayFrameData';
+import {
+  buildFrameData,
+  buildReplayOverlayData,
+  computeReplayDomain,
+  dateAtFraction,
+  replayPointsDomain,
+  shouldCommitFraction,
+  spanMs,
+} from './replayFrameData';
 import { useReducedMotion } from './useReducedMotion';
 
 type Mp4ExportGuard = (value: unknown) => value is Mp4ExportError;
@@ -46,6 +57,7 @@ interface ReplayPanelProps {
   chartDefinition: ChartDefinition;
   yLabel: string;
   xLabel: string;
+  overlayData?: OverlayData;
 }
 
 const SPEED_OPTIONS: readonly number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
@@ -64,9 +76,19 @@ export default function ReplayPanel({
   chartDefinition,
   yLabel,
   xLabel,
+  overlayData,
 }: ReplayPanelProps) {
   const inference = useInference();
-  const { selectedModel, selectedSequence, activeHwTypes } = inference;
+  const {
+    selectedModel,
+    selectedSequence,
+    activeHwTypes,
+    bestPerSku,
+    quickFilters,
+    selectedPrecisions,
+    selectedYAxisMetric,
+  } = inference;
+  const { activeOverlayHwTypes } = useUnofficialRun();
 
   const { isl = 0, osl = 0 } = sequenceToIslOsl(selectedSequence) ?? {};
   const history = useBenchmarkHistory(
@@ -98,14 +120,68 @@ export default function ReplayPanel({
     inference.selectedPrecisions,
   ]);
 
-  // Fixed axes for the whole run: take the extent across every step (not just
-  // the current frame) for the active hardware, so the axes stay put and the
-  // frontier visibly expands toward them over time instead of the chart
-  // refitting each frame. Recomputed when the legend's hw filter changes.
-  const fixedExtent = useMemo(
-    () => (timeline ? computeFullRunDomain(timeline, (hw) => activeHwTypes.has(hw)) : null),
-    [timeline, activeHwTypes],
+  const rooflineDirection = useMemo(() => {
+    const value = chartDefinition[`${selectedYAxisMetric}_roofline` as keyof ChartDefinition] as
+      | ParetoDirection
+      | undefined;
+    return value === 'upper_right' ||
+      value === 'upper_left' ||
+      value === 'lower_left' ||
+      value === 'lower_right'
+      ? value
+      : undefined;
+  }, [chartDefinition, selectedYAxisMetric]);
+  const dynamicBestPerSku = bestPerSku && rooflineDirection !== undefined;
+
+  const replayPointMatchesFilters = useCallback(
+    (point: InferenceData) => matchesQuickFilters(point, quickFilters),
+    [quickFilters],
   );
+
+  // Fixed axes span only rows that can appear in this replay. In Best per SKU
+  // mode the winner is recomputed at every observed date, so historical winner
+  // changes are included instead of freezing the latest chart's hwKey set.
+  const fixedExtent = useMemo(() => {
+    if (!timeline) return null;
+    const official = computeReplayDomain(timeline, {
+      pointFilter: (point) =>
+        replayPointMatchesFilters(point) &&
+        (dynamicBestPerSku || activeHwTypes.has(String(point.hwKey))),
+      bestPerSku: dynamicBestPerSku,
+      direction: rooflineDirection,
+    });
+
+    if (!overlayData) return official;
+    const overlayPoints = buildReplayOverlayData(overlayData, {
+      currentDate: '\uFFFF',
+      selectedPrecisions,
+      activeHwTypes: activeOverlayHwTypes,
+      pointFilter: replayPointMatchesFilters,
+      bestPerSku: dynamicBestPerSku,
+      direction: rooflineDirection,
+    }).data;
+    if (overlayPoints.length === 0) return official;
+    const overlay = replayPointsDomain(overlayPoints);
+    return {
+      x: [Math.min(official.x[0], overlay.x[0]), Math.max(official.x[1], overlay.x[1])] as [
+        number,
+        number,
+      ],
+      y: [Math.min(official.y[0], overlay.y[0]), Math.max(official.y[1], overlay.y[1])] as [
+        number,
+        number,
+      ],
+    };
+  }, [
+    timeline,
+    replayPointMatchesFilters,
+    dynamicBestPerSku,
+    activeHwTypes,
+    rooflineDirection,
+    overlayData,
+    selectedPrecisions,
+    activeOverlayHwTypes,
+  ]);
 
   // Track the SVG's position inside our relative wrapper so the date overlay
   // can anchor its bottom-right to the chart plot's top-right (the wrapper
@@ -281,14 +357,41 @@ export default function ReplayPanel({
   }, [timeline]);
 
   const frameData = useMemo(
-    () => (timeline ? buildFrameData(timeline, fraction) : []),
-    [timeline, fraction],
+    () =>
+      timeline
+        ? buildFrameData(timeline, fraction, {
+            pointFilter: replayPointMatchesFilters,
+            bestPerSku: dynamicBestPerSku,
+            direction: rooflineDirection,
+          })
+        : [],
+    [timeline, fraction, replayPointMatchesFilters, dynamicBestPerSku, rooflineDirection],
   );
 
   const currentDate = useMemo(
     () => (timeline ? dateAtFraction(timeline, fraction) : ''),
     [timeline, fraction],
   );
+
+  const replayOverlayData = useMemo(() => {
+    if (!overlayData) return undefined;
+    return buildReplayOverlayData(overlayData, {
+      currentDate,
+      selectedPrecisions,
+      activeHwTypes: activeOverlayHwTypes,
+      pointFilter: replayPointMatchesFilters,
+      bestPerSku: dynamicBestPerSku,
+      direction: rooflineDirection,
+    });
+  }, [
+    overlayData,
+    currentDate,
+    selectedPrecisions,
+    replayPointMatchesFilters,
+    activeOverlayHwTypes,
+    dynamicBestPerSku,
+    rooflineDirection,
+  ]);
 
   const handlePlayPause = useCallback(() => {
     if (playing) {
@@ -515,6 +618,9 @@ export default function ReplayPanel({
           xLabel={xLabel}
           yLabel={yLabel}
           chartDefinition={chartDefinition}
+          showAllHardwareTypes={dynamicBestPerSku}
+          syncBestPerSkuSelection={false}
+          overlayData={replayOverlayData}
           transitionDuration={0}
           niceAxes={false}
           pinLineLabels

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -61,7 +61,10 @@ interface ReplayPanelProps {
   overlayData?: OverlayData;
 }
 
-const SPEED_OPTIONS: readonly number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+const STANDARD_SPEED_OPTIONS: readonly number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+const BEST_PER_SKU_SPEED_OPTIONS: readonly number[] = [...STANDARD_SPEED_OPTIONS, 3, 4, 5];
+const BEST_PER_SKU_TRANSITION_MS = 240;
+const BEST_PER_SKU_MIN_TRANSITION_MS = 60;
 const REPLAY_BODY_MIN_HEIGHT = 480;
 
 /**
@@ -270,6 +273,20 @@ export default function ReplayPanel({
   const abortRef = useRef<AbortController | null>(null);
 
   const prefersReducedMotion = useReducedMotion();
+  const speedOptions = dynamicBestPerSku ? BEST_PER_SKU_SPEED_OPTIONS : STANDARD_SPEED_OPTIONS;
+  const replayTransitionDuration =
+    dynamicBestPerSku && !prefersReducedMotion
+      ? Math.max(
+          BEST_PER_SKU_MIN_TRANSITION_MS,
+          Math.round(BEST_PER_SKU_TRANSITION_MS / Math.max(1, speed)),
+        )
+      : 0;
+
+  // The extended speeds belong to Best per SKU replay. If that mode is
+  // disabled while the panel is open, return to the regular replay ceiling.
+  useEffect(() => {
+    if (!dynamicBestPerSku && speed > 2) setSpeed(2);
+  }, [dynamicBestPerSku, speed]);
 
   // Pre-flight feature detection so the Export button is disabled with a clear
   // reason on browsers that lack WebCodecs (Firefox today, older Safari).
@@ -626,9 +643,10 @@ export default function ReplayPanel({
           chartDefinition={chartDefinition}
           showAllHardwareTypes={dynamicBestPerSku}
           hardwareColorKeyMap={replayColorKeyMap}
+          hardwareSeriesKeyMap={replayColorKeyMap}
           syncBestPerSkuSelection={false}
           overlayData={replayOverlayData}
-          transitionDuration={0}
+          transitionDuration={replayTransitionDuration}
           niceAxes={false}
           pinLineLabels
           xExtentOverride={fixedAxes ? fixedExtent?.x : undefined}
@@ -694,7 +712,7 @@ export default function ReplayPanel({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {SPEED_OPTIONS.map((v) => (
+            {speedOptions.map((v) => (
               <SelectItem key={v} value={String(v)} data-testid={`replay-speed-${v}x`}>
                 {v}×
               </SelectItem>

--- a/packages/app/src/components/inference/replay/ReplayPanel.tsx
+++ b/packages/app/src/components/inference/replay/ReplayPanel.tsx
@@ -35,6 +35,7 @@ import {
   buildReplayOverlayData,
   computeReplayDomain,
   dateAtFraction,
+  replayExportDurationSec,
   replayPointsDomain,
   shouldCommitFraction,
   spanMs,
@@ -63,6 +64,7 @@ interface ReplayPanelProps {
 
 const STANDARD_SPEED_OPTIONS: readonly number[] = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 const BEST_PER_SKU_SPEED_OPTIONS: readonly number[] = [...STANDARD_SPEED_OPTIONS, 3, 4, 5];
+const MP4_EXPORT_FPS = 30;
 const REPLAY_BODY_MIN_HEIGHT = 480;
 
 /**
@@ -502,23 +504,25 @@ export default function ReplayPanel({
       const mod = await import('./exportMp4');
       const { exportReplayMp4 } = mod;
       guard = mod.isMp4ExportError;
-      // Export duration is deterministic from timeline length, NOT playback speed
-      // — the MP4 is an artifact of the dataset, not a recording of the current
-      // UI session. Capped at 60s.
-      const durationSec = Math.max(2, Math.min(60, spanMs(timeline.dates.length) / 1000));
+      // Best per SKU explicitly offers faster playback, so its MP4 uses that
+      // speed too. Regular replay preserves the existing canonical duration.
+      const exportSpeed = dynamicBestPerSku ? speed : 1;
+      const durationSec = replayExportDurationSec(timeline.dates.length, exportSpeed);
       const root = panelRef.current;
       if (!root) throw new Error('Replay panel element is not mounted.');
       await exportReplayMp4({
         captureRoot: root,
         fileName: `InferenceX_${selectedModel}_${chartDefinition.chartType}_replay`,
+        fps: MP4_EXPORT_FPS,
         durationSec,
         signal: ac.signal,
         renderFrame: async (t) => {
-          // flushSync forces React to commit synchronously; two RAFs let the
-          // browser paint before the capture step reads back the DOM.
+          // flushSync commits React synchronously. One animation frame lets
+          // ScatterGraph's D3 effects update the SVG before capture without
+          // imposing two display-refresh waits on every encoded frame.
           flushSync(() => commitFraction(t, { force: true }));
           await new Promise<void>((resolve) => {
-            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            requestAnimationFrame(() => resolve());
           });
         },
         onStage: (s) => {
@@ -526,7 +530,7 @@ export default function ReplayPanel({
         },
         onProgress: (p) => {
           lastProgressAt = performance.now();
-          frameCount = Math.round(p * durationSec * 30);
+          frameCount = Math.round(p * durationSec * MP4_EXPORT_FPS);
           setExportProgress(p);
         },
       });
@@ -580,7 +584,16 @@ export default function ReplayPanel({
       setExportProgress(null);
       abortRef.current = null;
     }
-  }, [chartDefinition.chartType, parentChartId, selectedModel, timeline, hasWebCodecs]);
+  }, [
+    chartDefinition.chartType,
+    parentChartId,
+    selectedModel,
+    timeline,
+    hasWebCodecs,
+    dynamicBestPerSku,
+    speed,
+    commitFraction,
+  ]);
 
   if (history.isLoading || !timeline) {
     return (

--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -6,6 +6,7 @@ import type { ReplayTimeline } from '../buildReplayTimeline';
 import {
   FRACTION_COMMIT_QUANTUM,
   buildFrameData,
+  buildReplayColorKeyMap,
   buildReplayOverlayData,
   computeReplayDomain,
   dateAtFraction,
@@ -329,6 +330,13 @@ describe('buildFrameData', () => {
       x: [10, 20],
       y: [50, 110],
     });
+    expect(buildReplayColorKeyMap(changing, new Set(['b200_engine_b', 'h100_engine_a']))).toEqual(
+      new Map([
+        ['b200_engine_a', 'b200_engine_b'],
+        ['b200_engine_b', 'b200_engine_b'],
+        ['h100_engine_a', 'h100_engine_a'],
+      ]),
+    );
   });
 });
 

--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -11,6 +11,7 @@ import {
   buildReplayOverlayData,
   computeReplayDomain,
   dateAtFraction,
+  replayExportDurationSec,
   shouldCommitFraction,
   spanMs,
   stepFloatAtFraction,
@@ -113,6 +114,21 @@ describe('spanMs', () => {
 
   it('respects a minimum of 4500ms once the floor kicks in', () => {
     expect(spanMs(5)).toBe(4500);
+  });
+});
+
+describe('replayExportDurationSec', () => {
+  it('reduces frame-producing duration at faster playback speeds', () => {
+    expect(replayExportDurationSec(95, 1)).toBe(30);
+    expect(replayExportDurationSec(95, 3)).toBe(10);
+    expect(replayExportDurationSec(95, 5)).toBe(6);
+    expect(replayExportDurationSec(5, 5)).toBe(0.9);
+  });
+
+  it('caps slow exports and ignores invalid playback speeds', () => {
+    expect(replayExportDurationSec(95, 0.25)).toBe(60);
+    expect(replayExportDurationSec(95, 0)).toBe(30);
+    expect(replayExportDurationSec(95, Number.NaN)).toBe(30);
   });
 });
 

--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import type { InferenceData } from '@/components/inference/types';
+import type { InferenceData, OverlayData } from '@/components/inference/types';
 
 import type { ReplayTimeline } from '../buildReplayTimeline';
 import {
   FRACTION_COMMIT_QUANTUM,
   buildFrameData,
+  buildReplayOverlayData,
+  computeReplayDomain,
   dateAtFraction,
   shouldCommitFraction,
   spanMs,
@@ -269,5 +271,110 @@ describe('buildFrameData', () => {
       domain: { x: [0, 1], y: [0, 1] },
     };
     expect(buildFrameData(empty, 0.5)).toEqual([]);
+  });
+
+  it('recomputes Best per SKU for each frame and keeps a winner for every SKU', () => {
+    const series = (
+      configId: string,
+      hw: string,
+      hwKey: string,
+      x: number,
+      startY: number,
+      endY: number,
+    ) => ({
+      configId,
+      hwKey,
+      precision: 'fp8',
+      template: {
+        ...baseTemplate,
+        hw,
+        hwKey,
+        x,
+        y: startY,
+      } as InferenceData,
+      stepValues: [
+        { visible: true as const, x, y: startY },
+        { visible: true as const, x, y: endY },
+      ],
+    });
+    const changing: ReplayTimeline = {
+      dates: ['2025-09-01', '2025-09-02'],
+      configs: [
+        series('b200-a-1', 'B200-8', 'b200_engine_a', 10, 100, 50),
+        series('b200-a-2', 'B200-8', 'b200_engine_a', 20, 80, 40),
+        series('b200-b-1', 'B200-8', 'b200_engine_b', 10, 90, 110),
+        series('b200-b-2', 'B200-8', 'b200_engine_b', 20, 60, 90),
+        series('h100-a-1', 'H100-8', 'h100_engine_a', 10, 60, 65),
+        series('h100-a-2', 'H100-8', 'h100_engine_a', 20, 50, 55),
+      ],
+      domain: { x: [10, 20], y: [40, 110] },
+    };
+
+    const start = buildFrameData(changing, 0, {
+      bestPerSku: true,
+      direction: 'upper_left',
+    });
+    const end = buildFrameData(changing, 1, {
+      bestPerSku: true,
+      direction: 'upper_left',
+    });
+
+    expect(new Set(start.map((point) => point.hwKey))).toEqual(
+      new Set(['b200_engine_a', 'h100_engine_a']),
+    );
+    expect(new Set(end.map((point) => point.hwKey))).toEqual(
+      new Set(['b200_engine_b', 'h100_engine_a']),
+    );
+    expect(computeReplayDomain(changing, { bestPerSku: true, direction: 'upper_left' })).toEqual({
+      x: [10, 20],
+      y: [50, 110],
+    });
+  });
+});
+
+describe('buildReplayOverlayData', () => {
+  const overlayPoint = (hw: string, hwKey: string, x: number, y: number): InferenceData =>
+    ({
+      ...baseTemplate,
+      hw,
+      hwKey,
+      x,
+      y,
+      date: '2025-09-02',
+      run_url: 'https://github.com/example/actions/runs/123',
+    }) as InferenceData;
+  const overlay = {
+    label: 'preview',
+    hardwareConfig: {},
+    data: [
+      overlayPoint('B200-8', 'b200_vllm', 10, 80),
+      overlayPoint('B200-8', 'b200_vllm', 20, 60),
+      overlayPoint('B200-8', 'b200_sglang', 10, 100),
+      overlayPoint('B200-8', 'b200_sglang', 20, 90),
+      overlayPoint('H100-8', 'h100_vllm', 10, 50),
+      overlayPoint('MI355X-8', 'mi355x_hidden', 10, 120),
+    ],
+  } as OverlayData;
+
+  it('date-gates overlays and preserves the best active series for every visible SKU', () => {
+    const beforeRun = buildReplayOverlayData(overlay, {
+      currentDate: '2025-09-01',
+      selectedPrecisions: ['fp8'],
+      activeHwTypes: new Set(['b200_vllm', 'b200_sglang', 'h100_vllm']),
+      bestPerSku: true,
+      direction: 'upper_left',
+    });
+    expect(beforeRun.data).toEqual([]);
+
+    const atRun = buildReplayOverlayData(overlay, {
+      currentDate: '2025-09-02',
+      selectedPrecisions: ['fp8'],
+      activeHwTypes: new Set(['b200_vllm', 'b200_sglang', 'h100_vllm']),
+      bestPerSku: true,
+      direction: 'upper_left',
+    });
+    expect(new Set(atRun.data.map((point) => point.hwKey))).toEqual(
+      new Set(['b200_sglang', 'h100_vllm']),
+    );
   });
 });

--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -5,6 +5,7 @@ import type { InferenceData, OverlayData } from '@/components/inference/types';
 import type { ReplayTimeline } from '../buildReplayTimeline';
 import {
   FRACTION_COMMIT_QUANTUM,
+  bestPerSkuMorphWindowFraction,
   buildFrameData,
   buildReplayColorKeyMap,
   buildReplayOverlayData,
@@ -112,6 +113,14 @@ describe('spanMs', () => {
 
   it('respects a minimum of 4500ms once the floor kicks in', () => {
     expect(spanMs(5)).toBe(4500);
+  });
+});
+
+describe('bestPerSkuMorphWindowFraction', () => {
+  it('allocates about 240ms of the MP4 timeline without overlapping adjacent dates', () => {
+    expect(bestPerSkuMorphWindowFraction(2)).toBeCloseTo(240 / 4500);
+    expect(bestPerSkuMorphWindowFraction(100)).toBeCloseTo(0.45 / 99);
+    expect(bestPerSkuMorphWindowFraction(1)).toBe(0);
   });
 });
 
@@ -336,6 +345,60 @@ describe('buildFrameData', () => {
         ['b200_engine_b', 'b200_engine_b'],
         ['h100_engine_a', 'h100_engine_a'],
       ]),
+    );
+
+    // Regression: MP4 export captures deterministic replay fractions and does
+    // not wait for wall-clock D3 transitions. A frame shortly after the winner
+    // changes must therefore contain intermediate line geometry itself.
+    let switchFraction = 0;
+    for (let step = 1; step <= 1000; step++) {
+      const candidate = step / 1000;
+      const keys = new Set(
+        buildFrameData(changing, candidate, {
+          bestPerSku: true,
+          direction: 'upper_left',
+        }).map((point) => point.hwKey),
+      );
+      if (keys.has('b200_engine_b')) {
+        switchFraction = candidate;
+        break;
+      }
+    }
+    expect(switchFraction).toBeGreaterThan(0);
+
+    const morphFraction = switchFraction + bestPerSkuMorphWindowFraction(2) / 2;
+    const snapped = buildFrameData(changing, morphFraction, {
+      bestPerSku: true,
+      direction: 'upper_left',
+    });
+    const animated = buildFrameData(changing, morphFraction, {
+      bestPerSku: true,
+      direction: 'upper_left',
+      animateBestPerSku: true,
+    });
+    const snappedB200 = snapped
+      .filter((point) => point.hwKey === 'b200_engine_b')
+      .toSorted((a, b) => a.x - b.x);
+    const animatedB200 = animated
+      .filter((point) => point.hwKey === 'b200_engine_b')
+      .toSorted((a, b) => a.x - b.x);
+    expect(animatedB200).toHaveLength(snappedB200.length);
+    expect(animatedB200[0].y).not.toBeCloseTo(snappedB200[0].y);
+    expect(new Set(animated.map((point) => point.hwKey))).toEqual(
+      new Set(['b200_engine_b', 'h100_engine_a']),
+    );
+
+    const settledFraction = switchFraction + bestPerSkuMorphWindowFraction(2) * 1.1;
+    const settled = buildFrameData(changing, settledFraction, {
+      bestPerSku: true,
+      direction: 'upper_left',
+      animateBestPerSku: true,
+    });
+    expect(settled).toEqual(
+      buildFrameData(changing, settledFraction, {
+        bestPerSku: true,
+        direction: 'upper_left',
+      }),
     );
   });
 });

--- a/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/replayFrameData.test.ts
@@ -117,9 +117,9 @@ describe('spanMs', () => {
 });
 
 describe('bestPerSkuMorphWindowFraction', () => {
-  it('allocates about 240ms of the MP4 timeline without overlapping adjacent dates', () => {
-    expect(bestPerSkuMorphWindowFraction(2)).toBeCloseTo(240 / 4500);
-    expect(bestPerSkuMorphWindowFraction(100)).toBeCloseTo(0.45 / 99);
+  it('allocates about 480ms of the MP4 timeline without overlapping adjacent dates', () => {
+    expect(bestPerSkuMorphWindowFraction(2)).toBeCloseTo(480 / 4500);
+    expect(bestPerSkuMorphWindowFraction(100)).toBeCloseTo(0.8 / 99);
     expect(bestPerSkuMorphWindowFraction(1)).toBe(0);
   });
 });

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -101,14 +101,14 @@ const morphSeries = (
   });
 };
 
-const BEST_PER_SKU_MORPH_MS = 240;
+const BEST_PER_SKU_MORPH_MS = 480;
 
 /** Fraction of the exported timeline used to morph one winner into the next. */
 export function bestPerSkuMorphWindowFraction(numDates: number): number {
   if (numDates <= 1) return 0;
-  // Keep the animation close to 240ms in the deterministic MP4 timeline, but
-  // never let it overlap more than 45% of one observed-date segment.
-  return Math.min(BEST_PER_SKU_MORPH_MS / spanMs(numDates), 0.45 / (numDates - 1));
+  // Keep the animation close to 480ms in the deterministic MP4 timeline, but
+  // leave a gap before the next observed date even in long, capped replays.
+  return Math.min(BEST_PER_SKU_MORPH_MS / spanMs(numDates), 0.8 / (numDates - 1));
 }
 
 function findWinnerSwitchFraction(
@@ -122,7 +122,7 @@ function findWinnerSwitchFraction(
 ): number {
   let low = startFraction;
   let high = endFraction;
-  // Eight bisections place a 240ms morph boundary within ~1ms in the longest
+  // Eight bisections place a 480ms morph boundary within ~2ms in the longest
   // 30s export, without precomputing every SKU's complete winner history.
   for (let iteration = 0; iteration < 8; iteration++) {
     const mid = (low + high) / 2;

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -1,9 +1,34 @@
-import type { InferenceData } from '@/components/inference/types';
+import type { InferenceData, OverlayData } from '@/components/inference/types';
+import { bestSeriesPerSku } from '@/components/inference/utils/best-series-per-sku';
+import type { ParetoDirection } from '@/lib/chart-utils';
 
 import type { ReplayTimeline } from './buildReplayTimeline';
 import { interpolateAtStep } from './interpolateAtTime';
 
-export function buildFrameData(timeline: ReplayTimeline, fraction: number): InferenceData[] {
+export interface ReplayFrameOptions {
+  pointFilter?: (point: InferenceData) => boolean;
+  bestPerSku?: boolean;
+  direction?: ParetoDirection;
+}
+
+export interface ReplayOverlayOptions extends ReplayFrameOptions {
+  currentDate: string;
+  selectedPrecisions: readonly string[];
+  activeHwTypes: ReadonlySet<string>;
+}
+
+/**
+ * Build the visible rows for one replay frame.
+ *
+ * Best per SKU is deliberately evaluated after interpolation. A serving
+ * engine that wins today is not necessarily the engine that won on an older
+ * benchmark date, so replay must not reuse the live chart's active hwKey set.
+ */
+export function buildFrameData(
+  timeline: ReplayTimeline,
+  fraction: number,
+  options: ReplayFrameOptions = {},
+): InferenceData[] {
   const idxFloat = stepFloatAtFraction(fraction, timeline.dates.length);
   // A replay frame is a single point in time, so every point gets the
   // playhead's date. Each template keeps its config's first-observation date,
@@ -17,7 +42,76 @@ export function buildFrameData(timeline: ReplayTimeline, fraction: number): Infe
     if (!r.visible) continue;
     out.push({ ...c.template, x: r.x, y: r.y, date: frameDate });
   }
-  return out;
+  const eligible = options.pointFilter ? out.filter(options.pointFilter) : out;
+  if (!options.bestPerSku || !options.direction) return eligible;
+  const winners = bestSeriesPerSku(eligible, options.direction);
+  return winners.size > 0 ? eligible.filter((point) => winners.has(String(point.hwKey))) : eligible;
+}
+
+const safeDomain = (lo: number, hi: number): [number, number] => {
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) return [0, 1];
+  if (lo === hi) {
+    const pad = lo === 0 ? 1 : Math.abs(lo) * 0.1;
+    return [lo - pad, hi + pad];
+  }
+  return lo < hi ? [lo, hi] : [hi, lo];
+};
+
+export function replayPointsDomain(points: readonly InferenceData[]): {
+  x: [number, number];
+  y: [number, number];
+} {
+  let xMin = Infinity;
+  let xMax = -Infinity;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (const point of points) {
+    if (point.x < xMin) xMin = point.x;
+    if (point.x > xMax) xMax = point.x;
+    if (point.y < yMin) yMin = point.y;
+    if (point.y > yMax) yMax = point.y;
+  }
+  return { x: safeDomain(xMin, xMax), y: safeDomain(yMin, yMax) };
+}
+
+/** Fixed-axis extent across the rows that can actually appear in replay. */
+export function computeReplayDomain(
+  timeline: ReplayTimeline,
+  options: ReplayFrameOptions = {},
+): { x: [number, number]; y: [number, number] } {
+  if (timeline.dates.length === 0) return replayPointsDomain([]);
+  const points: InferenceData[] = [];
+  const denominator = Math.max(1, timeline.dates.length - 1);
+  for (let index = 0; index < timeline.dates.length; index++) {
+    points.push(...buildFrameData(timeline, index / denominator, options));
+  }
+  return replayPointsDomain(points);
+}
+
+/**
+ * Apply the replay playhead, visibility, and Best per SKU rules to an
+ * unofficial-run overlay. Unofficial runs have one observed benchmark date,
+ * so they appear when the playhead reaches that date and remain visible.
+ */
+export function buildReplayOverlayData(
+  overlayData: OverlayData,
+  options: ReplayOverlayOptions,
+): OverlayData {
+  const visibleAtPlayhead = (point: InferenceData) =>
+    point.date <= options.currentDate &&
+    options.selectedPrecisions.includes(point.precision) &&
+    options.activeHwTypes.has(String(point.hwKey)) &&
+    (options.pointFilter?.(point) ?? true);
+  let data = overlayData.data.filter(visibleAtPlayhead);
+  let clippedData = (overlayData.clippedData ?? []).filter(({ point }) => visibleAtPlayhead(point));
+  if (options.bestPerSku && options.direction) {
+    const winners = bestSeriesPerSku(data, options.direction);
+    if (winners.size > 0) {
+      data = data.filter((point) => winners.has(String(point.hwKey)));
+      clippedData = clippedData.filter(({ point }) => winners.has(String(point.hwKey)));
+    }
+  }
+  return { ...overlayData, data, clippedData };
 }
 
 // Cubic ease-in-out per segment: playhead settles on observed dates, accelerates between them.

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -1,5 +1,5 @@
 import type { InferenceData, OverlayData } from '@/components/inference/types';
-import { bestSeriesPerSku } from '@/components/inference/utils/best-series-per-sku';
+import { baseSku, bestSeriesPerSku } from '@/components/inference/utils/best-series-per-sku';
 import type { ParetoDirection } from '@/lib/chart-utils';
 
 import type { ReplayTimeline } from './buildReplayTimeline';
@@ -86,6 +86,29 @@ export function computeReplayDomain(
     points.push(...buildFrameData(timeline, index / denominator, options));
   }
   return replayPointsDomain(points);
+}
+
+/**
+ * Alias every historical hwKey to the current parent-chart winner for the same
+ * physical SKU. The replay can change configs without changing the SKU color.
+ */
+export function buildReplayColorKeyMap(
+  timeline: ReplayTimeline,
+  currentHwTypes: ReadonlySet<string>,
+): ReadonlyMap<string, string> {
+  const currentWinnerBySku = new Map<string, string>();
+  for (const config of timeline.configs) {
+    if (currentHwTypes.has(config.hwKey)) {
+      currentWinnerBySku.set(baseSku(config.template), config.hwKey);
+    }
+  }
+
+  const colorKeyByHwType = new Map<string, string>();
+  for (const config of timeline.configs) {
+    const currentWinner = currentWinnerBySku.get(baseSku(config.template));
+    if (currentWinner) colorKeyByHwType.set(config.hwKey, currentWinner);
+  }
+  return colorKeyByHwType;
 }
 
 /**

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -304,6 +304,17 @@ export function spanMs(numDates: number): number {
   return Math.min(30_000, Math.max(4500, numDates * 800));
 }
 
+/**
+ * MP4 duration for a replay speed. Faster Best-per-SKU playback emits fewer
+ * 30 FPS frames, while the 60s ceiling prevents slow playback from creating
+ * an unexpectedly large browser-side export.
+ */
+export function replayExportDurationSec(numDates: number, playbackSpeed = 1): number {
+  const safeSpeed = Number.isFinite(playbackSpeed) && playbackSpeed > 0 ? playbackSpeed : 1;
+  const baseDurationSec = Math.max(2, spanMs(numDates) / 1000);
+  return Math.min(60, baseDurationSec / safeSpeed);
+}
+
 // Scrubber-resolution quantum (1/1000) used to throttle React commits while
 // the rAF loop advances continuously through the underlying ref.
 export const FRACTION_COMMIT_QUANTUM = 1000;

--- a/packages/app/src/components/inference/replay/replayFrameData.ts
+++ b/packages/app/src/components/inference/replay/replayFrameData.ts
@@ -9,6 +9,12 @@ export interface ReplayFrameOptions {
   pointFilter?: (point: InferenceData) => boolean;
   bestPerSku?: boolean;
   direction?: ParetoDirection;
+  /**
+   * Morph a newly winning config from the outgoing config's geometry. This is
+   * driven by replay fraction rather than wall-clock time so MP4 capture sees
+   * the same animation as the live preview.
+   */
+  animateBestPerSku?: boolean;
 }
 
 export interface ReplayOverlayOptions extends ReplayFrameOptions {
@@ -17,17 +23,10 @@ export interface ReplayOverlayOptions extends ReplayFrameOptions {
   activeHwTypes: ReadonlySet<string>;
 }
 
-/**
- * Build the visible rows for one replay frame.
- *
- * Best per SKU is deliberately evaluated after interpolation. A serving
- * engine that wins today is not necessarily the engine that won on an older
- * benchmark date, so replay must not reuse the live chart's active hwKey set.
- */
-export function buildFrameData(
+function buildEligibleFrame(
   timeline: ReplayTimeline,
   fraction: number,
-  options: ReplayFrameOptions = {},
+  pointFilter?: ReplayFrameOptions['pointFilter'],
 ): InferenceData[] {
   const idxFloat = stepFloatAtFraction(fraction, timeline.dates.length);
   // A replay frame is a single point in time, so every point gets the
@@ -42,10 +41,162 @@ export function buildFrameData(
     if (!r.visible) continue;
     out.push({ ...c.template, x: r.x, y: r.y, date: frameDate });
   }
-  const eligible = options.pointFilter ? out.filter(options.pointFilter) : out;
+  return pointFilter ? out.filter(pointFilter) : out;
+}
+
+const winnerBySku = (
+  points: InferenceData[],
+  direction: ParetoDirection,
+): { selected: Set<string>; bySku: Map<string, string> } => {
+  const selected = bestSeriesPerSku(points, direction);
+  const bySku = new Map<string, string>();
+  for (const point of points) {
+    const hwKey = String(point.hwKey);
+    if (selected.has(hwKey)) bySku.set(baseSku(point), hwKey);
+  }
+  return { selected, bySku };
+};
+
+const pointsByHwKey = (points: readonly InferenceData[]): Map<string, InferenceData[]> => {
+  const grouped = new Map<string, InferenceData[]>();
+  for (const point of points) {
+    const key = String(point.hwKey);
+    const rows = grouped.get(key) ?? [];
+    rows.push(point);
+    grouped.set(key, rows);
+  }
+  return grouped;
+};
+
+const sampleSeries = (
+  points: readonly InferenceData[],
+  fraction: number,
+): { x: number; y: number } => {
+  const sorted = points.toSorted((a, b) => a.x - b.x);
+  if (sorted.length === 1) return sorted[0];
+  const position = Math.max(0, Math.min(1, fraction)) * (sorted.length - 1);
+  const low = Math.floor(position);
+  const high = Math.min(sorted.length - 1, low + 1);
+  const mix = position - low;
+  return {
+    x: sorted[low].x + (sorted[high].x - sorted[low].x) * mix,
+    y: sorted[low].y + (sorted[high].y - sorted[low].y) * mix,
+  };
+};
+
+const morphSeries = (
+  outgoing: readonly InferenceData[],
+  incoming: readonly InferenceData[],
+  progress: number,
+): InferenceData[] => {
+  const sortedIncoming = incoming.toSorted((a, b) => a.x - b.x);
+  return sortedIncoming.map((point, index) => {
+    const rank = sortedIncoming.length <= 1 ? 0.5 : index / (sortedIncoming.length - 1);
+    const from = sampleSeries(outgoing, rank);
+    return {
+      ...point,
+      x: from.x + (point.x - from.x) * progress,
+      y: from.y + (point.y - from.y) * progress,
+    };
+  });
+};
+
+const BEST_PER_SKU_MORPH_MS = 240;
+
+/** Fraction of the exported timeline used to morph one winner into the next. */
+export function bestPerSkuMorphWindowFraction(numDates: number): number {
+  if (numDates <= 1) return 0;
+  // Keep the animation close to 240ms in the deterministic MP4 timeline, but
+  // never let it overlap more than 45% of one observed-date segment.
+  return Math.min(BEST_PER_SKU_MORPH_MS / spanMs(numDates), 0.45 / (numDates - 1));
+}
+
+function findWinnerSwitchFraction(
+  timeline: ReplayTimeline,
+  sku: string,
+  incomingHwKey: string,
+  startFraction: number,
+  endFraction: number,
+  direction: ParetoDirection,
+  pointFilter?: ReplayFrameOptions['pointFilter'],
+): number {
+  let low = startFraction;
+  let high = endFraction;
+  // Eight bisections place a 240ms morph boundary within ~1ms in the longest
+  // 30s export, without precomputing every SKU's complete winner history.
+  for (let iteration = 0; iteration < 8; iteration++) {
+    const mid = (low + high) / 2;
+    const eligible = buildEligibleFrame(timeline, mid, pointFilter);
+    const winner = winnerBySku(eligible, direction).bySku.get(sku);
+    if (winner === incomingHwKey) high = mid;
+    else low = mid;
+  }
+  return high;
+}
+
+/**
+ * Build the visible rows for one replay frame.
+ *
+ * Best per SKU is deliberately evaluated after interpolation. A serving
+ * engine that wins today is not necessarily the engine that won on an older
+ * benchmark date, so replay must not reuse the live chart's active hwKey set.
+ * Winner morphs are derived from `fraction`, not a live D3 timer, so every
+ * intermediate position is present in the frames encoded into the MP4.
+ */
+export function buildFrameData(
+  timeline: ReplayTimeline,
+  fraction: number,
+  options: ReplayFrameOptions = {},
+): InferenceData[] {
+  const eligible = buildEligibleFrame(timeline, fraction, options.pointFilter);
   if (!options.bestPerSku || !options.direction) return eligible;
-  const winners = bestSeriesPerSku(eligible, options.direction);
-  return winners.size > 0 ? eligible.filter((point) => winners.has(String(point.hwKey))) : eligible;
+
+  const current = winnerBySku(eligible, options.direction);
+  if (current.selected.size === 0) return eligible;
+  if (!options.animateBestPerSku) {
+    return eligible.filter((point) => current.selected.has(String(point.hwKey)));
+  }
+
+  const windowFraction = bestPerSkuMorphWindowFraction(timeline.dates.length);
+  const previousFraction = Math.max(0, fraction - windowFraction);
+  if (windowFraction === 0 || previousFraction === fraction) {
+    return eligible.filter((point) => current.selected.has(String(point.hwKey)));
+  }
+
+  const previousEligible = buildEligibleFrame(timeline, previousFraction, options.pointFilter);
+  const previous = winnerBySku(previousEligible, options.direction);
+  const currentPoints = pointsByHwKey(eligible);
+  const previousPoints = pointsByHwKey(previousEligible);
+  const output: InferenceData[] = [];
+
+  for (const [sku, incomingHwKey] of current.bySku) {
+    const incoming = currentPoints.get(incomingHwKey) ?? [];
+    const outgoingHwKey = previous.bySku.get(sku);
+    if (!outgoingHwKey || outgoingHwKey === incomingHwKey) {
+      output.push(...incoming);
+      continue;
+    }
+
+    const outgoing = currentPoints.get(outgoingHwKey) ?? previousPoints.get(outgoingHwKey) ?? [];
+    if (outgoing.length === 0 || incoming.length === 0) {
+      output.push(...incoming);
+      continue;
+    }
+
+    const switchFraction = findWinnerSwitchFraction(
+      timeline,
+      sku,
+      incomingHwKey,
+      previousFraction,
+      fraction,
+      options.direction,
+      options.pointFilter,
+    );
+    const progress = Math.max(0, Math.min(1, (fraction - switchFraction) / windowFraction));
+    output.push(...morphSeries(outgoing, incoming, progress));
+  }
+
+  return output;
 }
 
 const safeDomain = (lo: number, hi: number): [number, number] => {

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -662,7 +662,8 @@ export interface ScatterGraphProps {
   /**
    * Optional stable identity alias for official rooflines. Best per SKU replay
    * maps every historical winner for one physical SKU to the same identity so
-   * D3 can morph the existing line when the winning config changes.
+   * deterministic frame geometry updates the existing line when the winning
+   * config changes.
    */
   hardwareSeriesKeyMap?: ReadonlyMap<string, string>;
   /**
@@ -684,8 +685,8 @@ export interface ScatterGraphProps {
   overlayData?: OverlayData;
   /**
    * D3 transition duration in ms used when data or scales change. Defaults to
-   * the regular interactive value (750). Regular replay passes 0; Best per SKU
-   * replay uses a short speed-aware duration to animate winner-line movement.
+   * the regular interactive value (750). Replay passes 0 because its motion is
+   * encoded directly into deterministic frame data for MP4 parity.
    */
   transitionDuration?: number;
   /**

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -654,6 +654,13 @@ export interface ScatterGraphProps {
    */
   showAllHardwareTypes?: boolean;
   /**
+   * Whether this chart should reconcile Best per SKU selections back into the
+   * shared inference context. Replay disables this because its winner set is
+   * intentionally recomputed for every historical frame; committing a past
+   * frame's winners would incorrectly change the live parent chart.
+   */
+  syncBestPerSkuSelection?: boolean;
+  /**
    * Optional hardware configuration override. When provided, this is used instead of the context's
    * hardwareConfig. Used for unofficial run visualization where hardware types may differ.
    */

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -654,6 +654,12 @@ export interface ScatterGraphProps {
    */
   showAllHardwareTypes?: boolean;
   /**
+   * Optional display-color alias for official hardware series. Replay maps a
+   * historical Best per SKU winner to the current parent winner for the same
+   * physical SKU so the SKU keeps one stable color while its config changes.
+   */
+  hardwareColorKeyMap?: ReadonlyMap<string, string>;
+  /**
    * Whether this chart should reconcile Best per SKU selections back into the
    * shared inference context. Replay disables this because its winner set is
    * intentionally recomputed for every historical frame; committing a past

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -660,6 +660,12 @@ export interface ScatterGraphProps {
    */
   hardwareColorKeyMap?: ReadonlyMap<string, string>;
   /**
+   * Optional stable identity alias for official rooflines. Best per SKU replay
+   * maps every historical winner for one physical SKU to the same identity so
+   * D3 can morph the existing line when the winning config changes.
+   */
+  hardwareSeriesKeyMap?: ReadonlyMap<string, string>;
+  /**
    * Whether this chart should reconcile Best per SKU selections back into the
    * shared inference context. Replay disables this because its winner set is
    * intentionally recomputed for every historical frame; committing a past
@@ -678,8 +684,8 @@ export interface ScatterGraphProps {
   overlayData?: OverlayData;
   /**
    * D3 transition duration in ms used when data or scales change. Defaults to
-   * the regular interactive value (750). The replay panel passes 0 so frames
-   * snap to interpolated positions instead of fighting a 750ms tween.
+   * the regular interactive value (750). Regular replay passes 0; Best per SKU
+   * replay uses a short speed-aware duration to animate winner-line movement.
    */
   transitionDuration?: number;
   /**

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -955,6 +955,13 @@ export default function ChartDisplay() {
                         chartDefinition={graph.chartDefinition}
                         yLabel={metricLabel(graph.chartDefinition, selectedYAxisMetric, locale)}
                         xLabel={graph.chartDefinition.x_label}
+                        overlayData={
+                          selectUnofficialOverlayForMode(
+                            selectedXAxisMode,
+                            graph.chartDefinition.chartType,
+                            overlayDataByChartType,
+                          ) ?? undefined
+                        }
                       />
                     )}
                   </Card>

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -460,6 +460,7 @@ const ScatterGraph = React.memo(
     caption,
     showAllHardwareTypes = false,
     hardwareColorKeyMap,
+    hardwareSeriesKeyMap,
     syncBestPerSkuSelection = true,
     hardwareConfigOverride,
     overlayData,
@@ -1576,6 +1577,7 @@ const ScatterGraph = React.memo(
           // Build roofline entries with gradient or solid stroke
           interface Entry {
             key: string;
+            joinKey: string;
             hw: string;
             precision: string;
             points: InferenceData[];
@@ -1632,6 +1634,9 @@ const ScatterGraph = React.memo(
 
               entries.push({
                 key: entryKey,
+                joinKey: singleDate
+                  ? `${hardwareSeriesKeyMap?.get(hw) ?? hw}_${precision}`
+                  : `${hardwareSeriesKeyMap?.get(hw) ?? hw}_${precision}__${date}`,
                 hw,
                 precision,
                 points: datePoints,
@@ -1654,11 +1659,12 @@ const ScatterGraph = React.memo(
             .selectAll<SVGPathElement, Entry>('.roofline-path')
             .data(
               entries.filter((entry) => entry.points.length > 1),
-              (d) => d.key,
+              (d) => d.joinKey,
             )
             .join('path')
             .attr('class', (d) => `roofline-path roofline-${d.key}`)
             .attr('data-hw-key', (d) => d.hw)
+            .attr('data-series-key', (d) => d.joinKey)
             .attr('data-precision', (d) => d.precision)
             .attr('fill', 'none')
             .attr('stroke', (d) => d.stroke)
@@ -2976,6 +2982,7 @@ const ScatterGraph = React.memo(
       selectedYAxisMetric,
       chartDefinition,
       locale,
+      hardwareSeriesKeyMap,
     ]);
 
     // Layers handle for the decoration effect — lets it re-run individual

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -459,6 +459,7 @@ const ScatterGraph = React.memo(
     chartDefinition,
     caption,
     showAllHardwareTypes = false,
+    syncBestPerSkuSelection = true,
     hardwareConfigOverride,
     overlayData,
     transitionDuration = 750,
@@ -685,7 +686,7 @@ const ScatterGraph = React.memo(
       [setLocalOfficialOverride, setActiveOverlayHwTypes, mergeScopedOverlaySelection],
     );
     useEffect(() => {
-      if (!overlayData || !bestPerSku || overlayScopeChanged) return;
+      if (!syncBestPerSkuSelection || !overlayData || !bestPerSku || overlayScopeChanged) return;
       const direction = chartDefinition[`${selectedYAxisMetric}_roofline` as keyof ChartDefinition];
       if (
         direction !== 'upper_right' &&
@@ -704,6 +705,7 @@ const ScatterGraph = React.memo(
       if (!setsEqual(rawUnifiedSelection, selection)) commitUnifiedSelection(selection);
     }, [
       overlayData,
+      syncBestPerSkuSelection,
       bestPerSku,
       overlayScopeChanged,
       chartDefinition,
@@ -3372,7 +3374,7 @@ const ScatterGraph = React.memo(
                   checked: bestPerSku,
                   onCheckedChange: (checked: boolean) => {
                     setBestPerSku(checked);
-                    if (overlayData) {
+                    if (overlayData && syncBestPerSkuSelection) {
                       if (checked) {
                         const direction =
                           chartDefinition[

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -459,6 +459,7 @@ const ScatterGraph = React.memo(
     chartDefinition,
     caption,
     showAllHardwareTypes = false,
+    hardwareColorKeyMap,
     syncBestPerSkuSelection = true,
     hardwareConfigOverride,
     overlayData,
@@ -792,12 +793,20 @@ const ScatterGraph = React.memo(
     // e.g. deselecting B300 would recolor B200 from red to blue). Keying off the
     // stable full set fixes each hw's color so toggling only hides/shows lines.
     const stableHcKeys = useMemo(() => [...hwTypesWithData], [hwTypesWithData]);
-    const { resolveColor, getCssColor } = useThemeColors({
+    const { resolveColor: resolveThemeColor, getCssColor } = useThemeColors({
       highContrast,
       identifiers: activeHwKeys,
       activeKeys: activeOfficialKeys,
       hcKeys: stableHcKeys,
     });
+    const resolveColor = useCallback(
+      (identifier: string, hardwareKey?: string) =>
+        resolveThemeColor(
+          hardwareColorKeyMap?.get(identifier) ?? identifier,
+          hardwareKey ? (hardwareColorKeyMap?.get(hardwareKey) ?? hardwareKey) : undefined,
+        ),
+      [resolveThemeColor, hardwareColorKeyMap],
+    );
 
     // --- Changelog ---
     const changelog = availableRuns ? availableRuns[selectedRunId]?.changelog || null : null;


### PR DESCRIPTION
## Summary

- Recompute the metric-aware Best per SKU winner after interpolation for every replay frame, so the MP4 preview and export can switch hwKeys as benchmark history advances while keeping one winner per physical SKU.
- Reuse the current parent chart winner's color for every historical winner of the same physical SKU, preventing older hwKeys from falling back to gray while their config labels change.
- Give historical winners for one physical SKU a stable roofline identity and encode a deterministic ~480 ms geometry morph directly into replay fractions. The live preview and exported MP4 now consume the same intermediate line positions instead of relying on a wall-clock D3 transition that the encoder could miss.
- Offer 3×, 4×, and 5× playback only while Best per SKU is enabled; disabling the mode clamps playback back to the regular 2× ceiling. Best-per-SKU MP4 mode keeps its explicitly requested animation active even when the ambient reduced-motion preference is enabled; regular replay still uses the stepped, non-animated fallback.
- Apply the selected Best-per-SKU speed to MP4 duration while retaining 30 FPS, cutting a maximum-length export from 900 frames at 1× to 180 at 5×. Wait for one paint boundary instead of two before rasterizing each frame; regular replay export remains unchanged.
- Build fixed replay axes from the configurations that can actually appear, and honor the current precision, quick-filter, and hardware visibility state.
- Carry visible unofficial-run data into replay, date-gate it at the playhead, apply the same Best per SKU policy, and avoid writing historical winners back into the live parent chart.
- Add unit and Cypress regression coverage for changing historical winners, stable SKU colors, encoded intermediate winner geometry, exact settled geometry, speed gating, and unofficial-run overlay filtering.

## Unofficial run overlays

Works for both official runs and `?unofficialrun=` overlays. Overlay rows respect active hardware visibility, per-run dismissal through the assembled overlay input, precision filters, quick filters, and the faster Best-per-SKU playhead. Unofficial runs have one observed benchmark date, so they have no cross-date winning-config geometry to morph; they remain date-gated and use their run colors. The overlay path is covered by the unit regression; the official replay winner transition, historical color reuse, deterministic geometry, and speed gating are verified by unit and Cypress tests. [Vercel preview](https://inferencemax-app-git-fix-inference-replay-f6c686-semianalysisai.vercel.app) is deployed and ready.

## Testing

- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run test:unit` — 4,112 tests passed across workspaces
- `bun vitest run src/components/inference/replay/__tests__/replayFrameData.test.ts` — 31 tests passed; verifies an encoded intermediate MP4 frame differs from the snapped winner and that the line settles exactly on the incoming config
- `bunx cypress run --spec cypress/e2e/inference-replay-best-per-sku.cy.ts` — 1 test passed; forces reduced motion on and verifies continuous progress within 300 ms, stable path reuse, deterministic geometry updates, 5× selection, and removal of 5× outside Best per SKU
- `bun run test:e2e:quick:component` — 27/27 component smoke tests passed
- DB-backed smoke integration remains unavailable locally because `DATABASE_READONLY_URL` is not set

## 中文说明

- 在每个回放帧完成插值后，按当前指标重新计算“每个 SKU 最佳配置”，使 MP4 预览和导出能够随着基准测试历史推进动态切换 hwKey，同时确保每个物理 SKU 始终保留一个胜出配置。
- 同一物理 SKU 的所有历史胜出配置沿用当前父图表胜出配置的颜色，避免旧 hwKey 在配置标签变化时回退为灰色。
- 为同一物理 SKU 的历史胜出配置复用稳定的 roofline 标识，并将约 480 ms 的确定性几何变形直接编码到回放进度中。实时预览和导出的 MP4 现在使用完全相同的中间曲线位置，不再依赖编码器可能错过的实际时间 D3 过渡。
- 仅在启用“每个 SKU 最佳配置”时提供 3×、4× 和 5× 回放速度；关闭该模式后，播放速度自动降至常规上限 2×。即使系统启用了“减少动态效果”，Best-per-SKU MP4 模式仍会保留用户明确请求的动画；常规回放则继续采用分步且无动画的降级方式。
- MP4 导出时长遵循所选的 Best-per-SKU 速度并保持 30 FPS，使最长回放的帧数从 1× 时的 900 帧降至 5× 时的 180 帧。每帧光栅化前只等待一次绘制边界而非两次；常规回放导出保持不变。
- 固定坐标轴只覆盖回放中实际可能出现的配置，并遵循当前 precision、快速筛选和硬件可见性状态。
- 将可见的 unofficial run 数据纳入回放：根据播放时间点控制出现时机，应用相同的“每个 SKU 最佳配置”规则，同时避免把历史帧的胜出配置写回实时父图表。
- 补充单元测试和 Cypress 回归测试，覆盖历史胜出配置动态变化、SKU 颜色稳定性、编码后的中间曲线几何、最终稳定几何、速度范围限制以及 unofficial run overlay 的筛选逻辑。

## Unofficial run overlay 支持

该改动同时支持 official run 和 `?unofficialrun=` overlay。Overlay 数据遵循硬件可见性、组装 overlay 输入中的单次 run 关闭状态、precision 筛选、快速筛选和更快的“每个 SKU 最佳配置”播放进度。Unofficial run 只有一个观测日期，因此不存在可进行跨日期变形的胜出配置曲线；它们仍按播放时间点出现并使用对应 run 的颜色。单元测试覆盖 overlay 路径；单元测试和 Cypress 测试共同验证 official replay 的胜出配置切换、历史 SKU 颜色复用、确定性几何变化和速度范围限制。[Vercel preview](https://inferencemax-app-git-fix-inference-replay-f6c686-semianalysisai.vercel.app) 已部署并就绪。

## 测试

- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run test:unit` — 所有 workspace 共 4,112 个测试通过
- `bun vitest run src/components/inference/replay/__tests__/replayFrameData.test.ts` — 31 个测试通过；验证 MP4 中间帧不同于直接跳变后的胜出配置，并验证曲线最终精确落在新配置上
- `bunx cypress run --spec cypress/e2e/inference-replay-best-per-sku.cy.ts` — 1 个测试通过；强制启用“减少动态效果”，并验证回放在 300 ms 内持续推进、稳定复用 SVG path、更新确定性几何、支持 5× 选择，以及关闭“每个 SKU 最佳配置”后移除 5×
- `bun run test:e2e:quick:component` — component smoke suite 27/27 通过
- 由于本地未配置 `DATABASE_READONLY_URL`，依赖数据库的 smoke integration 无法运行