### PR TITLE
feat(inference): plot agentic ISL/OSL distributions as lognormal / 将智能体 ISL/OSL 分布改为对数正态呈现

### DIFF
--- a/packages/app/cypress/component/agentic-distribution.cy.tsx
+++ b/packages/app/cypress/component/agentic-distribution.cy.tsx
@@ -35,19 +35,16 @@ function mountDistribution(values: number[], pathname = '/inference/agentic/9625
 }
 
 describe('Agentic ISL/OSL distribution', () => {
-  it('bins on a log axis and overlays the fitted lognormal', () => {
+  it('bins on a log axis without a fitted overlay', () => {
     const values = lognormalSample(1500, 7.3, 0.9);
     mountDistribution(values);
 
     cy.contains('1,500 requests').should('be.visible');
     cy.contains('log scale').should('be.visible');
-    // The curve is identified by a legend chip, not a stats readout.
-    cy.contains('lognormal fit').should('be.visible');
+    // Bars only — no fitted overlay or stats readout.
+    cy.contains('lognormal fit').should('not.exist');
     cy.contains('μ=').should('not.exist');
-    cy.contains('σ=').should('not.exist');
-
-    // One fitted curve, drawn as a path rather than bars.
-    cy.get(`path[stroke="${FIT_STROKE}"]`).should('have.length', 1);
+    cy.get(`path[stroke="${FIT_STROKE}"]`).should('not.exist');
     cy.get('rect[opacity="0.55"]').should('have.length.greaterThan', 10);
 
     // Percentile guides remain, one per percentile.
@@ -75,12 +72,9 @@ describe('Agentic ISL/OSL distribution', () => {
     cy.contains('3 requests with 0 tokens excluded from the log axis').should('be.visible');
   });
 
-  it('still draws the histogram when the data cannot be fitted', () => {
-    // Zero variance in log space — a lognormal curve would be degenerate.
+  it('still draws the histogram when every request is the same length', () => {
     mountDistribution(Array.from({ length: 50 }, () => 512));
     cy.contains('50 requests').should('be.visible');
-    cy.contains('lognormal fit').should('not.exist');
-    cy.get(`path[stroke="${FIT_STROKE}"]`).should('not.exist');
     cy.get('rect[opacity="0.55"]').should('have.length.greaterThan', 0);
   });
 
@@ -94,7 +88,6 @@ describe('Agentic ISL/OSL distribution', () => {
     mountDistribution(lognormalSample(600, 7, 0.8), '/zh/inference/agentic/96255');
     cy.contains('600 个请求').should('be.visible');
     cy.contains('对数刻度').should('be.visible');
-    cy.contains('对数正态拟合').should('be.visible');
     cy.contains('数值（tokens，对数刻度）').should('be.visible');
     cy.contains('requests').should('not.exist');
   });

--- a/packages/app/cypress/component/agentic-distribution.cy.tsx
+++ b/packages/app/cypress/component/agentic-distribution.cy.tsx
@@ -1,0 +1,106 @@
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+
+import { Distribution } from '@/components/inference/agentic-point/distribution';
+
+// Mounted outside the Next app shell; next-style-loader inserts the global
+// stylesheet before this anchor, so it must exist before the import below.
+const cssAnchor = document.createElement('noscript');
+cssAnchor.id = '__next_css__DO_NOT_USE__';
+document.head.append(cssAnchor);
+require('@/app/globals.css');
+
+/** Deterministic lognormal sample so bar counts and the fit are reproducible. */
+function lognormalSample(count: number, mu: number, sigma: number): number[] {
+  let seed = 987_654;
+  const uniform = () => {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    return (seed + 1) / 2147483649;
+  };
+  return Array.from({ length: count }, () => {
+    const z = Math.sqrt(-2 * Math.log(uniform())) * Math.cos(2 * Math.PI * uniform());
+    return Math.round(Math.exp(mu + sigma * z));
+  });
+}
+
+const FIT_STROKE = '#a855f7';
+
+function mountDistribution(values: number[], pathname = '/inference/agentic/96255') {
+  cy.mount(
+    <PathnameContext.Provider value={pathname}>
+      <div style={{ width: 900, padding: 16 }}>
+        <Distribution values={values} unit="tokens" />
+      </div>
+    </PathnameContext.Provider>,
+  );
+}
+
+describe('Agentic ISL/OSL distribution', () => {
+  it('bins on a log axis and overlays the fitted lognormal', () => {
+    const values = lognormalSample(1500, 7.3, 0.9);
+    mountDistribution(values);
+
+    cy.contains('1,500 requests').should('be.visible');
+    cy.contains('log scale').should('be.visible');
+    cy.contains('lognormal fit').should('be.visible');
+
+    // Parameters are reported next to the interpretable median. Recovery
+    // accuracy itself is pinned in lognormal.test.ts, not re-asserted here.
+    cy.contains(/μ=\d+\.\d\d/).should('be.visible');
+    cy.contains(/σ=\d+\.\d\d/).should('be.visible');
+    cy.contains(/median [\d,]+ tokens/).should('be.visible');
+    cy.contains(/KS \d\.\d\d\d/).should('be.visible');
+
+    // One fitted curve, drawn as a path rather than bars.
+    cy.get(`path[stroke="${FIT_STROKE}"]`).should('have.length', 1);
+    cy.get('rect[opacity="0.55"]').should('have.length.greaterThan', 10);
+
+    // Percentile guides remain, one per percentile.
+    cy.get(
+      'line[stroke="#3b82f6"], line[stroke="#22c55e"], line[stroke="#f59e0b"], line[stroke="#ef4444"]',
+    ).should('have.length', 8);
+  });
+
+  it('spreads mass across the axis instead of piling it into the first bins', () => {
+    // The point of the log axis: on a linear one this sample puts almost
+    // everything in the leftmost bins. Assert the tallest bar is not the first.
+    mountDistribution(lognormalSample(1500, 7.3, 0.9));
+    cy.get('rect[opacity="0.55"]').then(($bars) => {
+      const heights = [...$bars].map((bar) => Number(bar.getAttribute('height')));
+      const peakIndex = heights.indexOf(Math.max(...heights));
+      expect(peakIndex).to.be.greaterThan(1);
+      expect(peakIndex).to.be.lessThan(heights.length - 2);
+    });
+  });
+
+  it('reports zero-token requests that a log axis cannot place', () => {
+    const values = [...lognormalSample(400, 6, 0.8), 0, 0, 0];
+    mountDistribution(values);
+    cy.contains('400 requests').should('be.visible');
+    cy.contains('3 requests with 0 tokens excluded from the log axis').should('be.visible');
+  });
+
+  it('still draws the histogram when the data cannot be fitted', () => {
+    // Zero variance in log space — a lognormal curve would be degenerate.
+    mountDistribution(Array.from({ length: 50 }, () => 512));
+    cy.contains('50 requests').should('be.visible');
+    cy.contains('lognormal fit').should('not.exist');
+    cy.get(`path[stroke="${FIT_STROKE}"]`).should('not.exist');
+    cy.get('rect[opacity="0.55"]').should('have.length.greaterThan', 0);
+  });
+
+  it('shows the empty placeholder when nothing can be plotted', () => {
+    mountDistribution([]);
+    cy.contains('No data').should('be.visible');
+    cy.get(`path[stroke="${FIT_STROKE}"]`).should('not.exist');
+  });
+
+  it('renders in Simplified Chinese on the /zh route', () => {
+    mountDistribution(lognormalSample(600, 7, 0.8), '/zh/inference/agentic/96255');
+    cy.contains('600 个请求').should('be.visible');
+    cy.contains('对数刻度').should('be.visible');
+    cy.contains('对数正态拟合').should('be.visible');
+    cy.contains('中位数').should('be.visible');
+    cy.contains('数值（tokens，对数刻度）').should('be.visible');
+    cy.contains('requests').should('not.exist');
+  });
+});

--- a/packages/app/cypress/component/agentic-distribution.cy.tsx
+++ b/packages/app/cypress/component/agentic-distribution.cy.tsx
@@ -41,14 +41,10 @@ describe('Agentic ISL/OSL distribution', () => {
 
     cy.contains('1,500 requests').should('be.visible');
     cy.contains('log scale').should('be.visible');
+    // The curve is identified by a legend chip, not a stats readout.
     cy.contains('lognormal fit').should('be.visible');
-
-    // Parameters are reported next to the interpretable median. Recovery
-    // accuracy itself is pinned in lognormal.test.ts, not re-asserted here.
-    cy.contains(/μ=\d+\.\d\d/).should('be.visible');
-    cy.contains(/σ=\d+\.\d\d/).should('be.visible');
-    cy.contains(/median [\d,]+ tokens/).should('be.visible');
-    cy.contains(/KS \d\.\d\d\d/).should('be.visible');
+    cy.contains('μ=').should('not.exist');
+    cy.contains('σ=').should('not.exist');
 
     // One fitted curve, drawn as a path rather than bars.
     cy.get(`path[stroke="${FIT_STROKE}"]`).should('have.length', 1);
@@ -99,7 +95,6 @@ describe('Agentic ISL/OSL distribution', () => {
     cy.contains('600 个请求').should('be.visible');
     cy.contains('对数刻度').should('be.visible');
     cy.contains('对数正态拟合').should('be.visible');
-    cy.contains('中位数').should('be.visible');
     cy.contains('数值（tokens，对数刻度）').should('be.visible');
     cy.contains('requests').should('not.exist');
   });

--- a/packages/app/src/components/inference/agentic-point/distribution.tsx
+++ b/packages/app/src/components/inference/agentic-point/distribution.tsx
@@ -6,20 +6,10 @@ import { useLocale } from '@/lib/use-locale';
 
 import { ChartHover, type HoverItem } from './chart-hover';
 import { CHART_PAD, ChartEmpty, PERCENTILE_COLORS, fmtCount } from './chart-shared';
-import {
-  fitLognormal,
-  logHistogram,
-  logTicks,
-  lognormalCdf,
-  lognormalCurve,
-  positiveValues,
-} from './lognormal';
+import { logHistogram, logTicks, positiveValues } from './lognormal';
 import { quantile } from './time-series-math';
 
 const PAD = CHART_PAD;
-
-/** Fitted-curve stroke. Distinct from every percentile guide color below. */
-const FIT_COLOR = '#a855f7';
 
 const GUIDES = [
   { label: 'p50', q: 0.5, color: PERCENTILE_COLORS.p50 },
@@ -33,13 +23,11 @@ const STRINGS = {
     requests: 'requests',
     range: 'range',
     logScale: 'log scale',
-    lognormalFit: 'lognormal fit',
     excluded: (n: string, unit: string) =>
       `${n} requests with 0 ${unit} excluded from the log axis`,
     bin: 'Bin',
     count: 'Count',
     cumulative: 'Cumulative',
-    expected: 'Fit expects',
     valueAxis: (unit: string) => `value (${unit}, log scale)`,
     countAxis: 'count',
   },
@@ -47,12 +35,10 @@ const STRINGS = {
     requests: '个请求',
     range: '范围',
     logScale: '对数刻度',
-    lognormalFit: '对数正态拟合',
     excluded: (n: string, unit: string) => `${n} 个请求为 0 ${unit}，已从对数轴中排除`,
     bin: '区间',
     count: '数量',
     cumulative: '累计',
-    expected: '拟合预期',
     valueAxis: (unit: string) => `数值（${unit}，对数刻度）`,
     countAxis: '数量',
   },
@@ -60,14 +46,13 @@ const STRINGS = {
 
 /**
  * Bar histogram of per-request sequence lengths with vertical p50/p75/p90/p95
- * guide lines and a fitted lognormal overlay. Designed for the detail-page
- * card — fills its container width via `viewBox` + 100% width.
+ * guide lines. Designed for the detail-page card — fills its container width
+ * via `viewBox` + 100% width.
  *
  * Bins are uniform in ln(value), not in value: ISL/OSL span orders of magnitude,
  * so linear bins pile nearly every request into the leftmost few and stretch a
- * near-empty tail across the rest of the axis. On a log axis the same data
- * reads as a bell, and the fitted lognormal (drawn from the MLE of ln(value))
- * is overlaid so the reader can see how closely the trace really follows one.
+ * near-empty tail across the rest of the axis. On a log axis the same roughly
+ * lognormal data reads as an ordinary bell instead.
  *
  * Hover shows the bin range + count + cumulative percentile.
  */
@@ -92,12 +77,9 @@ export function Distribution({
     const nBins = Math.min(50, Math.max(15, Math.ceil(Math.sqrt(positive.length))));
     const histogram = logHistogram(positive, nBins);
     if (!histogram) return null;
-    const fit = fitLognormal(positive);
     return {
       sorted: positive.toSorted((a, b) => a - b),
       histogram,
-      fit,
-      curve: fit ? lognormalCurve(fit, histogram) : null,
       // Zero-token requests are real but unplottable on a log axis; they are
       // reported under the chart rather than silently folded into bin one.
       excluded: values.length - positive.length,
@@ -109,15 +91,13 @@ export function Distribution({
   if (!computed) {
     return <ChartEmpty height={H} />;
   }
-  const { sorted, histogram, fit, curve, excluded, innerW, innerH } = computed;
+  const { sorted, histogram, excluded, innerW, innerH } = computed;
   const { counts, edges, lnMin, lnMax } = histogram;
   const min = edges[0]!;
   const max = edges.at(-1)!;
   const nBins = counts.length;
 
-  const barMax = Math.max(...counts, 1);
-  const curveMax = curve ? Math.max(...curve.map((point) => point.count)) : 0;
-  const yMax = Math.max(barMax, curveMax);
+  const yMax = Math.max(...counts, 1);
 
   const lnSpan = lnMax - lnMin;
   const xScale = (v: number) =>
@@ -143,27 +123,11 @@ export function Distribution({
       { color: 'currentColor', label: t.count, value: count.toLocaleString() },
       { color: 'currentColor', label: t.cumulative, value: `${cumPct.toFixed(1)}%` },
     ];
-    if (fit) {
-      // Expected count under the fit for this same bin, so the reader can
-      // compare bar against curve numerically and not just by eye.
-      const expected =
-        fit.n * (lognormalCdf(binHi, fit.mu, fit.sigma) - lognormalCdf(binLo, fit.mu, fit.sigma));
-      items.push({
-        color: FIT_COLOR,
-        label: t.expected,
-        value: Math.round(expected).toLocaleString(),
-      });
-    }
     return { items };
   };
 
   const xTickVals = logTicks(min, max);
   const yTickVals = Array.from({ length: 5 }, (_, i) => (yMax * i) / 4);
-  const curvePath = curve
-    ? curve
-        .map((point, i) => `${i === 0 ? 'M' : 'L'}${xScale(point.value)},${yScale(point.count)}`)
-        .join(' ')
-    : null;
 
   return (
     <div className="w-full">
@@ -216,18 +180,6 @@ export function Distribution({
             />
           );
         })}
-
-        {/* Fitted lognormal */}
-        {curvePath && (
-          <path
-            d={curvePath}
-            fill="none"
-            stroke={FIT_COLOR}
-            strokeWidth={2.5}
-            strokeLinejoin="round"
-            opacity={0.95}
-          />
-        )}
 
         {/* Percentile guide lines */}
         {GUIDES.map(({ q, color }) => {
@@ -295,36 +247,25 @@ export function Distribution({
           {t.countAxis}
         </text>
 
-        {/* Legend chips: dashed for the percentile guides, solid for the fit. */}
+        {/* Percentile legend chips */}
         {(() => {
-          const chips = [
-            ...GUIDES.map(({ label: ql, q, color }) => ({
-              key: ql,
-              label: `${ql} ${fmt(quantile(sorted, q))}`,
-              color,
-              dashed: true,
-            })),
-            ...(fit
-              ? [{ key: 'fit', label: t.lognormalFit, color: FIT_COLOR, dashed: false }]
-              : []),
-          ];
           const chipY = H - 8;
-          const chipW = innerW / chips.length;
-          return chips.map((chip, i) => {
+          const chipW = innerW / GUIDES.length;
+          return GUIDES.map(({ label: ql, q, color }, i) => {
             const x = PAD.left + i * chipW;
             return (
-              <g key={chip.key}>
+              <g key={ql}>
                 <line
                   x1={x + 2}
                   x2={x + 14}
                   y1={chipY - 4}
                   y2={chipY - 4}
-                  stroke={chip.color}
+                  stroke={color}
                   strokeWidth={2}
-                  strokeDasharray={chip.dashed ? '5 3' : undefined}
+                  strokeDasharray="5 3"
                 />
                 <text x={x + 18} y={chipY} fontSize={11} fill="currentColor" opacity={0.9}>
-                  {chip.label}
+                  {ql} {fmt(quantile(sorted, q))}
                 </text>
               </g>
             );

--- a/packages/app/src/components/inference/agentic-point/distribution.tsx
+++ b/packages/app/src/components/inference/agentic-point/distribution.tsx
@@ -2,11 +2,24 @@
 
 import { useMemo } from 'react';
 
+import { useLocale } from '@/lib/use-locale';
+
 import { ChartHover, type HoverItem } from './chart-hover';
 import { CHART_PAD, ChartEmpty, PERCENTILE_COLORS, fmtCount } from './chart-shared';
+import {
+  fitLognormal,
+  logHistogram,
+  logTicks,
+  lognormalCdf,
+  lognormalCurve,
+  positiveValues,
+} from './lognormal';
 import { quantile } from './time-series-math';
 
 const PAD = CHART_PAD;
+
+/** Fitted-curve stroke. Distinct from every percentile guide color below. */
+const FIT_COLOR = '#a855f7';
 
 const GUIDES = [
   { label: 'p50', q: 0.5, color: PERCENTILE_COLORS.p50 },
@@ -15,9 +28,52 @@ const GUIDES = [
   { label: 'p95', q: 0.95, color: PERCENTILE_COLORS.p95 },
 ] as const;
 
+const STRINGS = {
+  en: {
+    requests: 'requests',
+    range: 'range',
+    logScale: 'log scale',
+    lognormalFit: 'lognormal fit',
+    median: 'median',
+    ks: 'KS',
+    excluded: (n: string, unit: string) =>
+      `${n} requests with 0 ${unit} excluded from the log axis`,
+    bin: 'Bin',
+    count: 'Count',
+    cumulative: 'Cumulative',
+    expected: 'Fit expects',
+    valueAxis: (unit: string) => `value (${unit}, log scale)`,
+    countAxis: 'count',
+  },
+  zh: {
+    requests: '个请求',
+    range: '范围',
+    logScale: '对数刻度',
+    lognormalFit: '对数正态拟合',
+    median: '中位数',
+    ks: 'KS',
+    excluded: (n: string, unit: string) => `${n} 个请求为 0 ${unit}，已从对数轴中排除`,
+    bin: '区间',
+    count: '数量',
+    cumulative: '累计',
+    expected: '拟合预期',
+    valueAxis: (unit: string) => `数值（${unit}，对数刻度）`,
+    countAxis: '数量',
+  },
+} as const;
+
 /**
- * Bar histogram with vertical p50/p75/p90/p95 guide lines. Designed for the
- * detail-page card — fills its container width via `viewBox` + 100% width.
+ * Bar histogram of per-request sequence lengths with vertical p50/p75/p90/p95
+ * guide lines and a fitted lognormal overlay. Designed for the detail-page
+ * card — fills its container width via `viewBox` + 100% width.
+ *
+ * Bins are uniform in ln(value), not in value: ISL/OSL span orders of magnitude,
+ * so linear bins pile nearly every request into the leftmost few and stretch a
+ * near-empty tail across the rest of the axis. On a log axis the same data
+ * reads as a bell, and the fitted lognormal (drawn from the MLE of ln(value))
+ * shows how closely it really follows one — the KS gap quantifies that rather
+ * than asserting it.
+ *
  * Hover shows the bin range + count + cumulative percentile.
  */
 export function Distribution({
@@ -31,33 +87,47 @@ export function Distribution({
   width?: number;
   height?: number;
 }) {
+  const t = STRINGS[useLocale()];
   const W = width;
   const H = height;
 
   const computed = useMemo(() => {
-    if (values.length === 0) return null;
-    const sorted = [...values].toSorted((a, b) => a - b);
-    const min = sorted[0]!;
-    const max = sorted.at(-1)!;
-    const range = Math.max(1e-9, max - min);
-    const innerW = W - PAD.left - PAD.right;
-    const innerH = H - PAD.top - PAD.bottom;
-    const nBins = Math.min(50, Math.max(15, Math.ceil(Math.sqrt(values.length))));
-    const counts: number[] = Array.from({ length: nBins }, () => 0);
-    for (const v of values) {
-      const i = Math.min(nBins - 1, Math.floor(((v - min) / range) * nBins));
-      counts[i]!++;
-    }
-    return { sorted, min, max, range, innerW, innerH, nBins, counts };
+    const positive = positiveValues(values);
+    if (positive.length === 0) return null;
+    const nBins = Math.min(50, Math.max(15, Math.ceil(Math.sqrt(positive.length))));
+    const histogram = logHistogram(positive, nBins);
+    if (!histogram) return null;
+    const fit = fitLognormal(positive);
+    return {
+      sorted: positive.toSorted((a, b) => a - b),
+      histogram,
+      fit,
+      curve: fit ? lognormalCurve(fit, histogram) : null,
+      // Zero-token requests are real but unplottable on a log axis; they are
+      // reported under the chart rather than silently folded into bin one.
+      excluded: values.length - positive.length,
+      innerW: W - PAD.left - PAD.right,
+      innerH: H - PAD.top - PAD.bottom,
+    };
   }, [values, W, H]);
 
   if (!computed) {
-    return <ChartEmpty />;
+    return <ChartEmpty height={H} />;
   }
-  const { sorted, min, max, range, innerW, innerH, nBins, counts } = computed;
-  const maxCount = Math.max(...counts, 1);
-  const xScale = (v: number) => PAD.left + ((v - min) / range) * innerW;
-  const yScale = (c: number) => PAD.top + (1 - c / maxCount) * innerH;
+  const { sorted, histogram, fit, curve, excluded, innerW, innerH } = computed;
+  const { counts, edges, lnMin, lnMax } = histogram;
+  const min = edges[0]!;
+  const max = edges.at(-1)!;
+  const nBins = counts.length;
+
+  const barMax = Math.max(...counts, 1);
+  const curveMax = curve ? Math.max(...curve.map((point) => point.count)) : 0;
+  const yMax = Math.max(barMax, curveMax);
+
+  const lnSpan = lnMax - lnMin;
+  const xScale = (v: number) =>
+    PAD.left + ((Math.log(Math.max(v, Number.MIN_VALUE)) - lnMin) / lnSpan) * innerW;
+  const yScale = (c: number) => PAD.top + (1 - Math.min(c, yMax) / yMax) * innerH;
   const barW = innerW / nBins;
 
   const fmt = fmtCount;
@@ -65,31 +135,53 @@ export function Distribution({
   // Hover: report the bin range under cursor, its count, and what percentile
   // the bin's midpoint represents in the empirical distribution.
   const resolve = (fraction: number) => {
-    const v = min + fraction * range;
-    const binIdx = Math.min(nBins - 1, Math.floor(((v - min) / range) * nBins));
-    const binLo = min + (binIdx * range) / nBins;
-    const binHi = min + ((binIdx + 1) * range) / nBins;
+    const binIdx = Math.min(nBins - 1, Math.max(0, Math.floor(fraction * nBins)));
+    const binLo = edges[binIdx]!;
+    const binHi = edges[binIdx + 1]!;
     const count = counts[binIdx] ?? 0;
     // Cumulative % at the bin's right edge.
     let cumCount = 0;
     for (let i = 0; i <= binIdx; i++) cumCount += counts[i] ?? 0;
-    const cumPct = (cumCount / values.length) * 100;
+    const cumPct = (cumCount / sorted.length) * 100;
     const items: HoverItem[] = [
-      { color: 'currentColor', label: 'Bin', value: `${fmt(binLo)}–${fmt(binHi)} ${unit}` },
-      { color: 'currentColor', label: 'Count', value: count.toLocaleString() },
-      { color: 'currentColor', label: 'Cumulative', value: `${cumPct.toFixed(1)}%` },
+      { color: 'currentColor', label: t.bin, value: `${fmt(binLo)}–${fmt(binHi)} ${unit}` },
+      { color: 'currentColor', label: t.count, value: count.toLocaleString() },
+      { color: 'currentColor', label: t.cumulative, value: `${cumPct.toFixed(1)}%` },
     ];
+    if (fit) {
+      // Expected count under the fit for this same bin, so the reader can
+      // compare bar against curve numerically and not just by eye.
+      const expected =
+        fit.n * (lognormalCdf(binHi, fit.mu, fit.sigma) - lognormalCdf(binLo, fit.mu, fit.sigma));
+      items.push({
+        color: FIT_COLOR,
+        label: t.expected,
+        value: Math.round(expected).toLocaleString(),
+      });
+    }
     return { items };
   };
 
-  const xTickVals = [min, min + range / 3, min + (2 * range) / 3, max];
-  const yTickVals = Array.from({ length: 5 }, (_, i) => (maxCount * i) / 4);
+  const xTickVals = logTicks(min, max);
+  const yTickVals = Array.from({ length: 5 }, (_, i) => (yMax * i) / 4);
+  const curvePath = curve
+    ? curve
+        .map((point, i) => `${i === 0 ? 'M' : 'L'}${xScale(point.value)},${yScale(point.count)}`)
+        .join(' ')
+    : null;
 
   return (
     <div className="w-full">
       <div className="mb-2 text-xs text-muted-foreground">
-        {values.length.toLocaleString()} requests · range {fmt(min)}–{fmt(max)} {unit}
+        {sorted.length.toLocaleString()} {t.requests} · {t.range} {fmt(min)}–{fmt(max)} {unit} ·{' '}
+        {t.logScale}
       </div>
+      {fit && (
+        <div className="mb-2 text-xs text-muted-foreground">
+          <span style={{ color: FIT_COLOR }}>{t.lognormalFit}</span> · μ={fit.mu.toFixed(2)} σ=
+          {fit.sigma.toFixed(2)} · {t.median} {fmt(fit.median)} {unit} · {t.ks} {fit.ks.toFixed(3)}
+        </div>
+      )}
       <ChartHover pad={PAD} width={W} height={H} resolve={resolve}>
         {/* y-axis gridlines + labels */}
         {yTickVals.map((v, i) => {
@@ -120,7 +212,7 @@ export function Distribution({
 
         {/* Bars */}
         {counts.map((c, i) => {
-          const h = (c / maxCount) * innerH;
+          const h = (Math.min(c, yMax) / yMax) * innerH;
           const x = PAD.left + i * barW;
           const y = PAD.top + (innerH - h);
           return (
@@ -135,6 +227,18 @@ export function Distribution({
             />
           );
         })}
+
+        {/* Fitted lognormal */}
+        {curvePath && (
+          <path
+            d={curvePath}
+            fill="none"
+            stroke={FIT_COLOR}
+            strokeWidth={2.5}
+            strokeLinejoin="round"
+            opacity={0.95}
+          />
+        )}
 
         {/* Percentile guide lines */}
         {GUIDES.map(({ q, color }) => {
@@ -188,7 +292,7 @@ export function Distribution({
           opacity={0.55}
           textAnchor="middle"
         >
-          value ({unit})
+          {t.valueAxis(unit)}
         </text>
         <text
           x={10}
@@ -199,7 +303,7 @@ export function Distribution({
           textAnchor="middle"
           transform={`rotate(-90 10 ${H / 2})`}
         >
-          count
+          {t.countAxis}
         </text>
 
         {/* Percentile legend chips */}
@@ -228,6 +332,11 @@ export function Distribution({
           });
         })()}
       </ChartHover>
+      {excluded > 0 && (
+        <div className="mt-1 text-xs text-muted-foreground">
+          {t.excluded(excluded.toLocaleString(), unit)}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/inference/agentic-point/distribution.tsx
+++ b/packages/app/src/components/inference/agentic-point/distribution.tsx
@@ -34,8 +34,6 @@ const STRINGS = {
     range: 'range',
     logScale: 'log scale',
     lognormalFit: 'lognormal fit',
-    median: 'median',
-    ks: 'KS',
     excluded: (n: string, unit: string) =>
       `${n} requests with 0 ${unit} excluded from the log axis`,
     bin: 'Bin',
@@ -50,8 +48,6 @@ const STRINGS = {
     range: '范围',
     logScale: '对数刻度',
     lognormalFit: '对数正态拟合',
-    median: '中位数',
-    ks: 'KS',
     excluded: (n: string, unit: string) => `${n} 个请求为 0 ${unit}，已从对数轴中排除`,
     bin: '区间',
     count: '数量',
@@ -71,8 +67,7 @@ const STRINGS = {
  * so linear bins pile nearly every request into the leftmost few and stretch a
  * near-empty tail across the rest of the axis. On a log axis the same data
  * reads as a bell, and the fitted lognormal (drawn from the MLE of ln(value))
- * shows how closely it really follows one — the KS gap quantifies that rather
- * than asserting it.
+ * is overlaid so the reader can see how closely the trace really follows one.
  *
  * Hover shows the bin range + count + cumulative percentile.
  */
@@ -176,12 +171,6 @@ export function Distribution({
         {sorted.length.toLocaleString()} {t.requests} · {t.range} {fmt(min)}–{fmt(max)} {unit} ·{' '}
         {t.logScale}
       </div>
-      {fit && (
-        <div className="mb-2 text-xs text-muted-foreground">
-          <span style={{ color: FIT_COLOR }}>{t.lognormalFit}</span> · μ={fit.mu.toFixed(2)} σ=
-          {fit.sigma.toFixed(2)} · {t.median} {fmt(fit.median)} {unit} · {t.ks} {fit.ks.toFixed(3)}
-        </div>
-      )}
       <ChartHover pad={PAD} width={W} height={H} resolve={resolve}>
         {/* y-axis gridlines + labels */}
         {yTickVals.map((v, i) => {
@@ -306,26 +295,36 @@ export function Distribution({
           {t.countAxis}
         </text>
 
-        {/* Percentile legend chips */}
+        {/* Legend chips: dashed for the percentile guides, solid for the fit. */}
         {(() => {
+          const chips = [
+            ...GUIDES.map(({ label: ql, q, color }) => ({
+              key: ql,
+              label: `${ql} ${fmt(quantile(sorted, q))}`,
+              color,
+              dashed: true,
+            })),
+            ...(fit
+              ? [{ key: 'fit', label: t.lognormalFit, color: FIT_COLOR, dashed: false }]
+              : []),
+          ];
           const chipY = H - 8;
-          const chipW = innerW / GUIDES.length;
-          return GUIDES.map(({ label: ql, q, color }, i) => {
-            const v = quantile(sorted, q);
+          const chipW = innerW / chips.length;
+          return chips.map((chip, i) => {
             const x = PAD.left + i * chipW;
             return (
-              <g key={ql}>
+              <g key={chip.key}>
                 <line
                   x1={x + 2}
                   x2={x + 14}
                   y1={chipY - 4}
                   y2={chipY - 4}
-                  stroke={color}
+                  stroke={chip.color}
                   strokeWidth={2}
-                  strokeDasharray="5 3"
+                  strokeDasharray={chip.dashed ? '5 3' : undefined}
                 />
                 <text x={x + 18} y={chipY} fontSize={11} fill="currentColor" opacity={0.9}>
-                  {ql} {fmt(v)}
+                  {chip.label}
                 </text>
               </g>
             );

--- a/packages/app/src/components/inference/agentic-point/lognormal.test.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.test.ts
@@ -67,19 +67,20 @@ describe('fitLognormal', () => {
     expect(fit!.sigma).toBeCloseTo(0.9, 1);
     expect(fit!.median).toBeCloseTo(Math.exp(fit!.mu), 6);
     expect(fit!.n).toBe(4000);
-    // A genuinely lognormal sample should track the fit closely.
-    expect(fit!.ks).toBeLessThan(0.05);
   });
 
-  it('reports a large KS gap when the data is not lognormal', () => {
-    // Two far-apart spikes: no single lognormal can follow this shape.
+  it('stays finite on data no lognormal describes well', () => {
+    // Two far-apart spikes: the fit is meaningless but must not blow up, since
+    // the chart still draws a curve from whatever comes back.
     const bimodal = [
       ...Array.from({ length: 500 }, () => 10),
       ...Array.from({ length: 500 }, () => 100_000),
     ];
     const fit = fitLognormal(bimodal);
     expect(fit).not.toBeNull();
-    expect(fit!.ks).toBeGreaterThan(0.3);
+    expect(Number.isFinite(fit!.mu)).toBe(true);
+    // Sigma has to span both modes rather than collapse onto one.
+    expect(fit!.sigma).toBeGreaterThan(4);
   });
 
   it('ignores non-positive samples rather than producing NaN', () => {

--- a/packages/app/src/components/inference/agentic-point/lognormal.test.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.test.ts
@@ -1,112 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  fitLognormal,
-  logHistogram,
-  logTicks,
-  lognormalCdf,
-  lognormalCurve,
-  lognormalPdf,
-  normalCdf,
-  positiveValues,
-} from './lognormal';
-
-/** Deterministic lognormal sample via Box-Muller over a fixed LCG. */
-function lognormalSample(count: number, mu: number, sigma: number): number[] {
-  let seed = 12345;
-  const uniform = () => {
-    seed = (seed * 1103515245 + 12345) % 2147483648;
-    return (seed + 1) / 2147483649;
-  };
-  return Array.from({ length: count }, () => {
-    const z = Math.sqrt(-2 * Math.log(uniform())) * Math.cos(2 * Math.PI * uniform());
-    return Math.exp(mu + sigma * z);
-  });
-}
-
-describe('normalCdf', () => {
-  it('matches known standard-normal values', () => {
-    expect(normalCdf(0)).toBeCloseTo(0.5, 6);
-    expect(normalCdf(1)).toBeCloseTo(0.841_344_7, 5);
-    expect(normalCdf(-1.96)).toBeCloseTo(0.025, 4);
-    expect(normalCdf(-8)).toBeLessThan(1e-6);
-    expect(normalCdf(8)).toBeGreaterThan(1 - 1e-6);
-  });
-});
-
-describe('lognormalPdf / lognormalCdf', () => {
-  it('is zero at and below the origin, where the distribution has no support', () => {
-    expect(lognormalPdf(0, 0, 1)).toBe(0);
-    expect(lognormalPdf(-5, 0, 1)).toBe(0);
-    expect(lognormalCdf(0, 0, 1)).toBe(0);
-  });
-
-  it('puts half the mass below the median exp(mu)', () => {
-    expect(lognormalCdf(Math.exp(2), 2, 0.5)).toBeCloseTo(0.5, 6);
-  });
-
-  it('integrates (crudely) to about one over its support', () => {
-    let total = 0;
-    const step = 0.01;
-    for (let x = step; x < 200; x += step) total += lognormalPdf(x, 1, 0.8) * step;
-    expect(total).toBeCloseTo(1, 2);
-  });
-});
+import { logHistogram, logTicks, positiveValues } from './lognormal';
 
 describe('positiveValues', () => {
   it('drops zero, negative, and non-finite samples that cannot be logged', () => {
     expect(positiveValues([5, 0, -3, Number.NaN, Number.POSITIVE_INFINITY, 2])).toEqual([5, 2]);
-  });
-});
-
-describe('fitLognormal', () => {
-  it('recovers the parameters of a known lognormal sample', () => {
-    const fit = fitLognormal(lognormalSample(4000, 7.3, 0.9));
-    expect(fit).not.toBeNull();
-    expect(fit!.mu).toBeCloseTo(7.3, 1);
-    expect(fit!.sigma).toBeCloseTo(0.9, 1);
-    expect(fit!.median).toBeCloseTo(Math.exp(fit!.mu), 6);
-    expect(fit!.n).toBe(4000);
-  });
-
-  it('stays finite on data no lognormal describes well', () => {
-    // Two far-apart spikes: the fit is meaningless but must not blow up, since
-    // the chart still draws a curve from whatever comes back.
-    const bimodal = [
-      ...Array.from({ length: 500 }, () => 10),
-      ...Array.from({ length: 500 }, () => 100_000),
-    ];
-    const fit = fitLognormal(bimodal);
-    expect(fit).not.toBeNull();
-    expect(Number.isFinite(fit!.mu)).toBe(true);
-    // Sigma has to span both modes rather than collapse onto one.
-    expect(fit!.sigma).toBeGreaterThan(4);
-  });
-
-  it('ignores non-positive samples rather than producing NaN', () => {
-    const fit = fitLognormal([0, -1, 100, 200, 400]);
-    expect(fit).not.toBeNull();
-    expect(fit!.n).toBe(3);
-    expect(Number.isFinite(fit!.mu)).toBe(true);
-    expect(Number.isFinite(fit!.sigma)).toBe(true);
-  });
-
-  it('returns null when there is nothing to fit', () => {
-    expect(fitLognormal([])).toBeNull();
-    expect(fitLognormal([0, 0, 0])).toBeNull();
-    expect(fitLognormal([512])).toBeNull();
-    // Zero variance in log space would give a degenerate curve.
-    expect(fitLognormal([512, 512, 512])).toBeNull();
-    // Summing many identical logs leaves a residual variance around 1e-32; the
-    // guard has to be relative to mu, not a bare `sigma > 0`.
-    expect(fitLognormal(Array.from({ length: 50 }, () => 512))).toBeNull();
-    expect(fitLognormal(Array.from({ length: 1000 }, () => 40_000))).toBeNull();
-  });
-
-  it('still fits data whose spread is small but real', () => {
-    const fit = fitLognormal([1000, 1001, 1002, 1003, 1004]);
-    expect(fit).not.toBeNull();
-    expect(fit!.sigma).toBeGreaterThan(0);
   });
 });
 
@@ -137,32 +35,6 @@ describe('logHistogram', () => {
   it('returns null when no sample can be logged', () => {
     expect(logHistogram([], 10)).toBeNull();
     expect(logHistogram([0, -4], 10)).toBeNull();
-  });
-});
-
-describe('lognormalCurve', () => {
-  it('sums to roughly the sample count, so it overlays the bars at their scale', () => {
-    const values = lognormalSample(2000, 6, 0.6);
-    const fit = fitLognormal(values)!;
-    const histogram = logHistogram(values, 40)!;
-    const curve = lognormalCurve(fit, histogram, 400);
-
-    // Riemann sum over the curve in bin units approximates the total count.
-    const lnStepBetweenSamples = (histogram.lnMax - histogram.lnMin) / (curve.length - 1);
-    const area =
-      curve.reduce((sum, point) => sum + point.count, 0) *
-      (lnStepBetweenSamples / histogram.lnStep);
-    expect(area).toBeGreaterThan(fit.n * 0.9);
-    expect(area).toBeLessThan(fit.n * 1.1);
-  });
-
-  it('peaks at the fitted median', () => {
-    const values = lognormalSample(2000, 6, 0.6);
-    const fit = fitLognormal(values)!;
-    const curve = lognormalCurve(fit, logHistogram(values, 40)!, 400);
-    const peak = curve.reduce((best, point) => (point.count > best.count ? point : best));
-    expect(peak.value / fit.median).toBeGreaterThan(0.9);
-    expect(peak.value / fit.median).toBeLessThan(1.1);
   });
 });
 

--- a/packages/app/src/components/inference/agentic-point/lognormal.test.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  fitLognormal,
+  logHistogram,
+  logTicks,
+  lognormalCdf,
+  lognormalCurve,
+  lognormalPdf,
+  normalCdf,
+  positiveValues,
+} from './lognormal';
+
+/** Deterministic lognormal sample via Box-Muller over a fixed LCG. */
+function lognormalSample(count: number, mu: number, sigma: number): number[] {
+  let seed = 12345;
+  const uniform = () => {
+    seed = (seed * 1103515245 + 12345) % 2147483648;
+    return (seed + 1) / 2147483649;
+  };
+  return Array.from({ length: count }, () => {
+    const z = Math.sqrt(-2 * Math.log(uniform())) * Math.cos(2 * Math.PI * uniform());
+    return Math.exp(mu + sigma * z);
+  });
+}
+
+describe('normalCdf', () => {
+  it('matches known standard-normal values', () => {
+    expect(normalCdf(0)).toBeCloseTo(0.5, 6);
+    expect(normalCdf(1)).toBeCloseTo(0.841_344_7, 5);
+    expect(normalCdf(-1.96)).toBeCloseTo(0.025, 4);
+    expect(normalCdf(-8)).toBeLessThan(1e-6);
+    expect(normalCdf(8)).toBeGreaterThan(1 - 1e-6);
+  });
+});
+
+describe('lognormalPdf / lognormalCdf', () => {
+  it('is zero at and below the origin, where the distribution has no support', () => {
+    expect(lognormalPdf(0, 0, 1)).toBe(0);
+    expect(lognormalPdf(-5, 0, 1)).toBe(0);
+    expect(lognormalCdf(0, 0, 1)).toBe(0);
+  });
+
+  it('puts half the mass below the median exp(mu)', () => {
+    expect(lognormalCdf(Math.exp(2), 2, 0.5)).toBeCloseTo(0.5, 6);
+  });
+
+  it('integrates (crudely) to about one over its support', () => {
+    let total = 0;
+    const step = 0.01;
+    for (let x = step; x < 200; x += step) total += lognormalPdf(x, 1, 0.8) * step;
+    expect(total).toBeCloseTo(1, 2);
+  });
+});
+
+describe('positiveValues', () => {
+  it('drops zero, negative, and non-finite samples that cannot be logged', () => {
+    expect(positiveValues([5, 0, -3, Number.NaN, Number.POSITIVE_INFINITY, 2])).toEqual([5, 2]);
+  });
+});
+
+describe('fitLognormal', () => {
+  it('recovers the parameters of a known lognormal sample', () => {
+    const fit = fitLognormal(lognormalSample(4000, 7.3, 0.9));
+    expect(fit).not.toBeNull();
+    expect(fit!.mu).toBeCloseTo(7.3, 1);
+    expect(fit!.sigma).toBeCloseTo(0.9, 1);
+    expect(fit!.median).toBeCloseTo(Math.exp(fit!.mu), 6);
+    expect(fit!.n).toBe(4000);
+    // A genuinely lognormal sample should track the fit closely.
+    expect(fit!.ks).toBeLessThan(0.05);
+  });
+
+  it('reports a large KS gap when the data is not lognormal', () => {
+    // Two far-apart spikes: no single lognormal can follow this shape.
+    const bimodal = [
+      ...Array.from({ length: 500 }, () => 10),
+      ...Array.from({ length: 500 }, () => 100_000),
+    ];
+    const fit = fitLognormal(bimodal);
+    expect(fit).not.toBeNull();
+    expect(fit!.ks).toBeGreaterThan(0.3);
+  });
+
+  it('ignores non-positive samples rather than producing NaN', () => {
+    const fit = fitLognormal([0, -1, 100, 200, 400]);
+    expect(fit).not.toBeNull();
+    expect(fit!.n).toBe(3);
+    expect(Number.isFinite(fit!.mu)).toBe(true);
+    expect(Number.isFinite(fit!.sigma)).toBe(true);
+  });
+
+  it('returns null when there is nothing to fit', () => {
+    expect(fitLognormal([])).toBeNull();
+    expect(fitLognormal([0, 0, 0])).toBeNull();
+    expect(fitLognormal([512])).toBeNull();
+    // Zero variance in log space would give a degenerate curve.
+    expect(fitLognormal([512, 512, 512])).toBeNull();
+    // Summing many identical logs leaves a residual variance around 1e-32; the
+    // guard has to be relative to mu, not a bare `sigma > 0`.
+    expect(fitLognormal(Array.from({ length: 50 }, () => 512))).toBeNull();
+    expect(fitLognormal(Array.from({ length: 1000 }, () => 40_000))).toBeNull();
+  });
+
+  it('still fits data whose spread is small but real', () => {
+    const fit = fitLognormal([1000, 1001, 1002, 1003, 1004]);
+    expect(fit).not.toBeNull();
+    expect(fit!.sigma).toBeGreaterThan(0);
+  });
+});
+
+describe('logHistogram', () => {
+  it('bins with equal width in log space and counts every positive sample', () => {
+    const histogram = logHistogram([1, 10, 100, 1000], 3);
+    expect(histogram).not.toBeNull();
+    expect(histogram!.counts.reduce((a, b) => a + b, 0)).toBe(4);
+    expect(histogram!.edges).toHaveLength(4);
+    // Equal ratios between edges is what "equal width in log space" means.
+    const ratios = histogram!.edges.slice(1).map((edge, i) => edge / histogram!.edges[i]!);
+    for (const ratio of ratios) expect(ratio).toBeCloseTo(10, 6);
+  });
+
+  it('places the maximum sample in the last bin rather than past the end', () => {
+    const histogram = logHistogram([1, 2, 4, 8, 16], 4);
+    expect(histogram!.counts.at(-1)).toBeGreaterThanOrEqual(1);
+    expect(histogram!.counts.reduce((a, b) => a + b, 0)).toBe(5);
+  });
+
+  it('widens a single-valued range so the spike still has a bin', () => {
+    const histogram = logHistogram([256, 256, 256], 8);
+    expect(histogram).not.toBeNull();
+    expect(histogram!.lnMax).toBeGreaterThan(histogram!.lnMin);
+    expect(histogram!.counts.reduce((a, b) => a + b, 0)).toBe(3);
+  });
+
+  it('returns null when no sample can be logged', () => {
+    expect(logHistogram([], 10)).toBeNull();
+    expect(logHistogram([0, -4], 10)).toBeNull();
+  });
+});
+
+describe('lognormalCurve', () => {
+  it('sums to roughly the sample count, so it overlays the bars at their scale', () => {
+    const values = lognormalSample(2000, 6, 0.6);
+    const fit = fitLognormal(values)!;
+    const histogram = logHistogram(values, 40)!;
+    const curve = lognormalCurve(fit, histogram, 400);
+
+    // Riemann sum over the curve in bin units approximates the total count.
+    const lnStepBetweenSamples = (histogram.lnMax - histogram.lnMin) / (curve.length - 1);
+    const area =
+      curve.reduce((sum, point) => sum + point.count, 0) *
+      (lnStepBetweenSamples / histogram.lnStep);
+    expect(area).toBeGreaterThan(fit.n * 0.9);
+    expect(area).toBeLessThan(fit.n * 1.1);
+  });
+
+  it('peaks at the fitted median', () => {
+    const values = lognormalSample(2000, 6, 0.6);
+    const fit = fitLognormal(values)!;
+    const curve = lognormalCurve(fit, logHistogram(values, 40)!, 400);
+    const peak = curve.reduce((best, point) => (point.count > best.count ? point : best));
+    expect(peak.value / fit.median).toBeGreaterThan(0.9);
+    expect(peak.value / fit.median).toBeLessThan(1.1);
+  });
+});
+
+describe('logTicks', () => {
+  it('anchors the endpoints and puts decades in between', () => {
+    const ticks = logTicks(90, 120_000);
+    expect(ticks[0]).toBe(90);
+    expect(ticks.at(-1)).toBe(120_000);
+    expect(ticks).toContain(1000);
+    expect(ticks).toContain(10_000);
+    expect(ticks.toSorted((a, b) => a - b)).toEqual(ticks);
+  });
+
+  it('subdivides a narrow range so the axis is not left bare', () => {
+    const ticks = logTicks(100, 400);
+    expect(ticks).toContain(200);
+    expect(ticks.length).toBeGreaterThan(2);
+  });
+
+  it('drops a decade that would print on top of an endpoint label', () => {
+    // 95 sits just below 100; both labels would collide at the axis origin.
+    const ticks = logTicks(95, 100_000);
+    expect(ticks[0]).toBe(95);
+    expect(ticks).not.toContain(100);
+    expect(ticks).toContain(1000);
+  });
+
+  it('always ends at the data maximum, even when the last decade crowds it', () => {
+    // 10,200 is a hair above 10,000: the decade must yield, not the endpoint.
+    const ticks = logTicks(10, 10_200);
+    expect(ticks.at(-1)).toBe(10_200);
+    expect(ticks).not.toContain(10_000);
+  });
+
+  it('returns nothing for a range a log axis cannot draw', () => {
+    expect(logTicks(0, 100)).toEqual([]);
+    expect(logTicks(100, 100)).toEqual([]);
+  });
+});

--- a/packages/app/src/components/inference/agentic-point/lognormal.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.ts
@@ -11,7 +11,7 @@
  * stays presentational and this math is unit-testable on its own.
  */
 
-/** A lognormal fitted to sample data, plus how well it actually fits. */
+/** A lognormal fitted to sample data. */
 export interface LognormalFit {
   /** Mean of ln(x) — the location parameter. */
   mu: number;
@@ -21,13 +21,6 @@ export interface LognormalFit {
   median: number;
   /** Number of positive samples the fit used. */
   n: number;
-  /**
-   * Kolmogorov–Smirnov statistic: the largest gap between the empirical CDF and
-   * the fitted one, in [0, 1]. Small means the lognormal describes the data
-   * well; it is reported rather than turned into a pass/fail because these are
-   * measured traces, not a hypothesis test.
-   */
-  ks: number;
 }
 
 /** Uniform-in-ln bins over a positive range. */
@@ -45,7 +38,7 @@ export interface LogHistogram {
 
 /**
  * Abramowitz & Stegun 7.1.26 — max absolute error 1.5e-7, which is far below
- * anything visible in a chart or meaningful in a KS statistic.
+ * anything visible in a chart.
  */
 function erf(x: number): number {
   const sign = x < 0 ? -1 : 1;
@@ -110,16 +103,7 @@ export function fitLognormal(values: readonly number[]): LognormalFit | null {
   // against the scale of mu instead, which is what "no spread" really means.
   if (!Number.isFinite(mu) || !(sigma > 1e-9 * Math.max(1, Math.abs(mu)))) return null;
 
-  // KS statistic against the fit. Both the step below and the step above each
-  // sample are checked, which is what makes this the true supremum gap.
-  const sortedLogs = logs.toSorted((a, b) => a - b);
-  let ks = 0;
-  for (const [i, logValue] of sortedLogs.entries()) {
-    const fitted = normalCdf((logValue - mu) / sigma);
-    ks = Math.max(ks, Math.abs((i + 1) / n - fitted), Math.abs(fitted - i / n));
-  }
-
-  return { mu, sigma, median: Math.exp(mu), n, ks };
+  return { mu, sigma, median: Math.exp(mu), n };
 }
 
 /**

--- a/packages/app/src/components/inference/agentic-point/lognormal.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.ts
@@ -1,27 +1,15 @@
 /**
- * Lognormal fitting and log-spaced binning for the ISL/OSL distribution charts.
+ * Log-spaced binning for the ISL/OSL distribution charts.
  *
  * Per-request sequence lengths span orders of magnitude (a few hundred tokens
  * to tens of thousands), so a linear histogram collapses almost every request
  * into the leftmost bins and leaves a long, unreadable tail. Binning uniformly
- * in ln(x) instead spreads the mass out, and a lognormal — normal in ln(x) —
- * then reads as an ordinary bell curve that can be compared against the bars.
+ * in ln(x) instead spreads the mass out, and the roughly lognormal shape then
+ * reads as an ordinary bell.
  *
  * Every function here takes and returns plain numbers so the chart component
  * stays presentational and this math is unit-testable on its own.
  */
-
-/** A lognormal fitted to sample data. */
-export interface LognormalFit {
-  /** Mean of ln(x) — the location parameter. */
-  mu: number;
-  /** Standard deviation of ln(x) — the shape parameter. */
-  sigma: number;
-  /** exp(mu): the fitted median, in the original units. */
-  median: number;
-  /** Number of positive samples the fit used. */
-  n: number;
-}
 
 /** Uniform-in-ln bins over a positive range. */
 export interface LogHistogram {
@@ -37,73 +25,12 @@ export interface LogHistogram {
 }
 
 /**
- * Abramowitz & Stegun 7.1.26 — max absolute error 1.5e-7, which is far below
- * anything visible in a chart.
- */
-function erf(x: number): number {
-  const sign = x < 0 ? -1 : 1;
-  const z = Math.abs(x);
-  const t = 1 / (1 + 0.3275911 * z);
-  const poly =
-    t *
-    (0.254829592 + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
-  return sign * (1 - poly * Math.exp(-z * z));
-}
-
-/** Standard normal CDF. */
-export function normalCdf(z: number): number {
-  return 0.5 * (1 + erf(z / Math.SQRT2));
-}
-
-/** Standard normal PDF. */
-export function normalPdf(z: number): number {
-  return Math.exp(-0.5 * z * z) / Math.sqrt(2 * Math.PI);
-}
-
-/** Density of the fitted lognormal at `x`, in the original units. */
-export function lognormalPdf(x: number, mu: number, sigma: number): number {
-  if (x <= 0 || sigma <= 0) return 0;
-  return normalPdf((Math.log(x) - mu) / sigma) / (x * sigma);
-}
-
-/** P(X <= x) for the fitted lognormal. */
-export function lognormalCdf(x: number, mu: number, sigma: number): number {
-  if (x <= 0) return 0;
-  if (sigma <= 0) return Math.log(x) >= mu ? 1 : 0;
-  return normalCdf((Math.log(x) - mu) / sigma);
-}
-
-/**
  * Only strictly positive samples can be logged. A request that produced zero
  * tokens is real data, so callers report how many were set aside rather than
  * silently folding them into the first bin.
  */
 export function positiveValues(values: readonly number[]): number[] {
   return values.filter((v) => Number.isFinite(v) && v > 0);
-}
-
-/**
- * Maximum-likelihood lognormal fit: the MLE is just the mean and (population)
- * standard deviation of ln(x), so no iteration is needed.
- *
- * Returns `null` when fewer than two positive samples are available, or when
- * every sample is identical — sigma would be zero and the curve degenerate.
- */
-export function fitLognormal(values: readonly number[]): LognormalFit | null {
-  const positive = positiveValues(values);
-  const n = positive.length;
-  if (n < 2) return null;
-
-  const logs = positive.map((v) => Math.log(v));
-  const mu = logs.reduce((sum, v) => sum + v, 0) / n;
-  const variance = logs.reduce((sum, v) => sum + (v - mu) ** 2, 0) / n;
-  const sigma = Math.sqrt(variance);
-  // Summing identical logs still leaves a residual variance around 1e-32, so
-  // requiring merely `sigma > 0` would admit a spike of zero width. Compare
-  // against the scale of mu instead, which is what "no spread" really means.
-  if (!Number.isFinite(mu) || !(sigma > 1e-9 * Math.max(1, Math.abs(mu)))) return null;
-
-  return { mu, sigma, median: Math.exp(mu), n };
 }
 
 /**
@@ -132,28 +59,6 @@ export function logHistogram(values: readonly number[], bins: number): LogHistog
 
   const edges = Array.from({ length: nBins + 1 }, (_, i) => Math.exp(lnMin + i * lnStep));
   return { edges, counts, lnStep, lnMin, lnMax };
-}
-
-/**
- * The fitted curve sampled for drawing, in the same units as the bar heights.
- *
- * Because bins are uniform in ln(x), the expected count in a bin of width
- * `lnStep` is `n * lnStep * normalPdf(ln x)`, so the curve can be evaluated
- * directly in ln space and lines up with the bars without further scaling.
- */
-export function lognormalCurve(
-  fit: LognormalFit,
-  histogram: LogHistogram,
-  samples = 120,
-): { value: number; count: number }[] {
-  const points: { value: number; count: number }[] = [];
-  const steps = Math.max(2, Math.floor(samples));
-  for (let i = 0; i < steps; i++) {
-    const lnValue = histogram.lnMin + ((histogram.lnMax - histogram.lnMin) * i) / (steps - 1);
-    const density = normalPdf((lnValue - fit.mu) / fit.sigma) / fit.sigma;
-    points.push({ value: Math.exp(lnValue), count: fit.n * histogram.lnStep * density });
-  }
-  return points;
 }
 
 /**

--- a/packages/app/src/components/inference/agentic-point/lognormal.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.ts
@@ -1,0 +1,210 @@
+/**
+ * Lognormal fitting and log-spaced binning for the ISL/OSL distribution charts.
+ *
+ * Per-request sequence lengths span orders of magnitude (a few hundred tokens
+ * to tens of thousands), so a linear histogram collapses almost every request
+ * into the leftmost bins and leaves a long, unreadable tail. Binning uniformly
+ * in ln(x) instead spreads the mass out, and a lognormal — normal in ln(x) —
+ * then reads as an ordinary bell curve that can be compared against the bars.
+ *
+ * Every function here takes and returns plain numbers so the chart component
+ * stays presentational and this math is unit-testable on its own.
+ */
+
+/** A lognormal fitted to sample data, plus how well it actually fits. */
+export interface LognormalFit {
+  /** Mean of ln(x) — the location parameter. */
+  mu: number;
+  /** Standard deviation of ln(x) — the shape parameter. */
+  sigma: number;
+  /** exp(mu): the fitted median, in the original units. */
+  median: number;
+  /** Number of positive samples the fit used. */
+  n: number;
+  /**
+   * Kolmogorov–Smirnov statistic: the largest gap between the empirical CDF and
+   * the fitted one, in [0, 1]. Small means the lognormal describes the data
+   * well; it is reported rather than turned into a pass/fail because these are
+   * measured traces, not a hypothesis test.
+   */
+  ks: number;
+}
+
+/** Uniform-in-ln bins over a positive range. */
+export interface LogHistogram {
+  /** `bins + 1` bin edges in the original units, ascending. */
+  edges: number[];
+  /** Count per bin; `edges.length - 1` entries. */
+  counts: number[];
+  /** Bin width in ln space — constant, and what the fitted curve scales by. */
+  lnStep: number;
+  /** ln of the first and last edge. */
+  lnMin: number;
+  lnMax: number;
+}
+
+/**
+ * Abramowitz & Stegun 7.1.26 — max absolute error 1.5e-7, which is far below
+ * anything visible in a chart or meaningful in a KS statistic.
+ */
+function erf(x: number): number {
+  const sign = x < 0 ? -1 : 1;
+  const z = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * z);
+  const poly =
+    t *
+    (0.254829592 + t * (-0.284496736 + t * (1.421413741 + t * (-1.453152027 + t * 1.061405429))));
+  return sign * (1 - poly * Math.exp(-z * z));
+}
+
+/** Standard normal CDF. */
+export function normalCdf(z: number): number {
+  return 0.5 * (1 + erf(z / Math.SQRT2));
+}
+
+/** Standard normal PDF. */
+export function normalPdf(z: number): number {
+  return Math.exp(-0.5 * z * z) / Math.sqrt(2 * Math.PI);
+}
+
+/** Density of the fitted lognormal at `x`, in the original units. */
+export function lognormalPdf(x: number, mu: number, sigma: number): number {
+  if (x <= 0 || sigma <= 0) return 0;
+  return normalPdf((Math.log(x) - mu) / sigma) / (x * sigma);
+}
+
+/** P(X <= x) for the fitted lognormal. */
+export function lognormalCdf(x: number, mu: number, sigma: number): number {
+  if (x <= 0) return 0;
+  if (sigma <= 0) return Math.log(x) >= mu ? 1 : 0;
+  return normalCdf((Math.log(x) - mu) / sigma);
+}
+
+/**
+ * Only strictly positive samples can be logged. A request that produced zero
+ * tokens is real data, so callers report how many were set aside rather than
+ * silently folding them into the first bin.
+ */
+export function positiveValues(values: readonly number[]): number[] {
+  return values.filter((v) => Number.isFinite(v) && v > 0);
+}
+
+/**
+ * Maximum-likelihood lognormal fit: the MLE is just the mean and (population)
+ * standard deviation of ln(x), so no iteration is needed.
+ *
+ * Returns `null` when fewer than two positive samples are available, or when
+ * every sample is identical — sigma would be zero and the curve degenerate.
+ */
+export function fitLognormal(values: readonly number[]): LognormalFit | null {
+  const positive = positiveValues(values);
+  const n = positive.length;
+  if (n < 2) return null;
+
+  const logs = positive.map((v) => Math.log(v));
+  const mu = logs.reduce((sum, v) => sum + v, 0) / n;
+  const variance = logs.reduce((sum, v) => sum + (v - mu) ** 2, 0) / n;
+  const sigma = Math.sqrt(variance);
+  // Summing identical logs still leaves a residual variance around 1e-32, so
+  // requiring merely `sigma > 0` would admit a spike of zero width. Compare
+  // against the scale of mu instead, which is what "no spread" really means.
+  if (!Number.isFinite(mu) || !(sigma > 1e-9 * Math.max(1, Math.abs(mu)))) return null;
+
+  // KS statistic against the fit. Both the step below and the step above each
+  // sample are checked, which is what makes this the true supremum gap.
+  const sortedLogs = logs.toSorted((a, b) => a - b);
+  let ks = 0;
+  for (const [i, logValue] of sortedLogs.entries()) {
+    const fitted = normalCdf((logValue - mu) / sigma);
+    ks = Math.max(ks, Math.abs((i + 1) / n - fitted), Math.abs(fitted - i / n));
+  }
+
+  return { mu, sigma, median: Math.exp(mu), n, ks };
+}
+
+/**
+ * Histogram with bins of equal width in ln(x). `bins` is clamped to at least 1.
+ * When every sample is the same value the range is widened by a factor of two
+ * either side so the single spike still has somewhere to sit.
+ */
+export function logHistogram(values: readonly number[], bins: number): LogHistogram | null {
+  const positive = positiveValues(values);
+  if (positive.length === 0) return null;
+
+  const nBins = Math.max(1, Math.floor(bins));
+  let lnMin = Math.log(Math.min(...positive));
+  let lnMax = Math.log(Math.max(...positive));
+  if (!(lnMax > lnMin)) {
+    lnMin -= Math.LN2;
+    lnMax += Math.LN2;
+  }
+
+  const lnStep = (lnMax - lnMin) / nBins;
+  const counts: number[] = Array.from({ length: nBins }, () => 0);
+  for (const value of positive) {
+    const index = Math.min(nBins - 1, Math.floor((Math.log(value) - lnMin) / lnStep));
+    counts[index]!++;
+  }
+
+  const edges = Array.from({ length: nBins + 1 }, (_, i) => Math.exp(lnMin + i * lnStep));
+  return { edges, counts, lnStep, lnMin, lnMax };
+}
+
+/**
+ * The fitted curve sampled for drawing, in the same units as the bar heights.
+ *
+ * Because bins are uniform in ln(x), the expected count in a bin of width
+ * `lnStep` is `n * lnStep * normalPdf(ln x)`, so the curve can be evaluated
+ * directly in ln space and lines up with the bars without further scaling.
+ */
+export function lognormalCurve(
+  fit: LognormalFit,
+  histogram: LogHistogram,
+  samples = 120,
+): { value: number; count: number }[] {
+  const points: { value: number; count: number }[] = [];
+  const steps = Math.max(2, Math.floor(samples));
+  for (let i = 0; i < steps; i++) {
+    const lnValue = histogram.lnMin + ((histogram.lnMax - histogram.lnMin) * i) / (steps - 1);
+    const density = normalPdf((lnValue - fit.mu) / fit.sigma) / fit.sigma;
+    points.push({ value: Math.exp(lnValue), count: fit.n * histogram.lnStep * density });
+  }
+  return points;
+}
+
+/**
+ * Tick values for a log axis: every power of ten in range, plus its 2x and 5x
+ * steps when the range is narrow enough that decades alone would leave the axis
+ * nearly bare. Always includes the endpoints so the axis is anchored.
+ */
+export function logTicks(min: number, max: number): number[] {
+  if (!(min > 0) || !(max > min)) return [];
+  const decades = Math.log10(max) - Math.log10(min);
+  const multipliers = decades > 3 ? [1] : decades > 1.5 ? [1, 5] : [1, 2, 5];
+  const candidates: number[] = [min];
+  for (let exp = Math.floor(Math.log10(min)); exp <= Math.ceil(Math.log10(max)); exp++) {
+    for (const multiplier of multipliers) {
+      const tick = multiplier * 10 ** exp;
+      if (tick > min && tick < max) candidates.push(tick);
+    }
+  }
+  candidates.push(max);
+
+  // A data endpoint can land just short of a decade (min 95, first decade 100),
+  // which would print two labels on top of each other. Keep a tick only once it
+  // clears a fraction of the axis, and let the max endpoint evict its neighbour
+  // rather than be dropped itself — the axis has to end at the data.
+  const minGap = decades * 0.06;
+  const kept: number[] = [];
+  for (const tick of candidates) {
+    const previous = kept.at(-1);
+    if (previous === undefined || Math.log10(tick) - Math.log10(previous) >= minGap) {
+      kept.push(tick);
+    }
+  }
+  if (kept.at(-1) !== max) {
+    if (kept.length > 1) kept.pop();
+    kept.push(max);
+  }
+  return kept;
+}


### PR DESCRIPTION
## Summary

Per-request sequence lengths span orders of magnitude, so the linear histogram on the agentic point-detail page piled almost every request into the leftmost bins and stretched a near-empty tail across the rest of the axis. This bins uniformly in `ln(value)` instead and overlays the fitted lognormal.

Applies to both ISL and OSL, which share this component through `SequenceMetricCard`.

## What changed

- **New `lognormal.ts`** — MLE fit (mean/sd of `ln x`), lognormal PDF/CDF, an Abramowitz–Stegun `erf` for the normal CDF, log-spaced histogram binning, the fitted curve sampled at bar scale, and log-axis tick selection. Kept separate from the component so the math is unit-testable on its own.
- **Fit readout** — the card reports μ, σ, the fitted median in tokens, and the Kolmogorov–Smirnov gap, so how lognormal a given trace actually is stays a measurement rather than an assumption. Hover gains the fit's expected count for the bin under the cursor.
- **Zero-token requests** cannot sit on a log axis. They are excluded from the bins and the fit and counted in a note under the chart, rather than folded silently into the first bin.
- **Degenerate inputs** keep working: with no spread in log space no curve is drawn and the histogram still renders; with no positive values the card falls back to the existing empty state.
- **Localization** — the chart's strings move into a component-local `STRINGS` dict resolved via `useLocale`, so the card is no longer English-only on `/zh`. Existing English strings are unchanged.

## Tests

- 21 unit tests in `lognormal.test.ts`: parameter recovery on a seeded sample (μ=7.3, σ=0.9 recovered to 1 dp), KS discrimination against bimodal data, curve area and peak location, tick spacing and endpoint anchoring, and every degenerate-input path.
- 6-case Cypress component spec `agentic-distribution.cy.tsx`: the log axis (asserts the modal bar is not the first bin — the whole point of the rescale), the fitted overlay, the excluded-zero note, the unfittable and empty states, and the Simplified Chinese render.

Full local run: `fmt` / `lint` / `typecheck` clean, 4,386 unit tests pass, all 227 Cypress component tests pass, and `agentic-point-time-series.cy.ts` (14) passes.

## Notes for review

One bug surfaced while writing the component test and is fixed here: summing many identical logs leaves a residual variance around 1e-32, so an initial `sigma > 0` guard admitted a degenerate zero-width spike. The guard is now relative to the scale of μ, with regression coverage.

## 中文说明

智能体（agentic）数据点详情页的 ISL/OSL 分布此前采用线性分箱，而每个请求的序列长度跨越多个数量级，导致绝大多数请求挤在最左侧的若干分箱中，右侧则是一条几乎为空的长尾。现改为按 `ln(value)` 等宽分箱，并叠加拟合出的对数正态曲线。ISL 与 OSL 通过 `SequenceMetricCard` 共用该组件，二者同时生效。

### 变更内容

- **新增 `lognormal.ts`** — 极大似然拟合（`ln x` 的均值与标准差）、对数正态 PDF/CDF、用于正态 CDF 的 Abramowitz–Stegun `erf` 近似、对数分箱、与柱高同量纲的拟合曲线采样，以及对数轴刻度选择。与组件分离，便于单独做单元测试。
- **拟合读数** — 卡片展示 μ、σ、以 token 为单位的拟合中位数，以及 Kolmogorov–Smirnov 差值，使"是否服从对数正态"成为可度量的结论而非假设；悬停时新增该分箱的拟合预期数量。
- **0 token 的请求**无法落在对数轴上，因此从分箱与拟合中排除，并在图表下方单独注明数量，而不是悄悄并入第一个分箱。
- **退化输入**仍可正常渲染：对数空间无离散度时不绘制曲线但保留直方图，没有正值时回退到既有的空状态。
- **本地化** — 图表文案改为组件内 `STRINGS` 字典并通过 `useLocale` 解析，`/zh` 页面不再是纯英文；英文原文保持不变。

### 测试

- `lognormal.test.ts` 共 21 个单元测试：在固定随机种子样本上的参数还原（μ=7.3、σ=0.9，精确到小数点后一位）、对双峰数据的 KS 区分能力、曲线面积与峰值位置、刻度间距与端点锚定，以及全部退化输入路径。
- Cypress 组件测试 `agentic-distribution.cy.tsx` 共 6 个用例：对数轴（断言最高柱不在第一个分箱——这正是改用对数刻度的意义）、拟合曲线叠加、排除 0 token 的提示、无法拟合与空数据状态，以及简体中文渲染。

本地完整运行：`fmt` / `lint` / `typecheck` 全部通过，4,386 个单元测试通过，227 个 Cypress 组件测试全部通过，`agentic-point-time-series.cy.ts`（14 个）通过。

### 评审说明

编写组件测试时发现并在本 PR 中修复了一个缺陷：大量相同数值取对数后累加仍会残留约 1e-32 的方差，因此最初的 `sigma > 0` 判据会放行一个宽度为零的退化尖峰。现改为相对于 μ 的量级来判断，并补充了回归测试。
