### PR TITLE
feat: show resident ISL and OSL percentiles

### DIFF
--- a/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
+++ b/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
@@ -1,0 +1,63 @@
+import { buildTokenLengthSketch } from '@semianalysisai/inferencex-constants';
+
+import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
+import { interceptOverlayRun, OVERLAY_RUN_ID } from '../support/overlay-fixtures';
+
+function visitAgenticChart(extraQuery = '') {
+  cy.visit(`/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4${extraQuery}`, {
+    onBeforeLoad(win) {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      unlockAgenticGate(win);
+    },
+  });
+}
+
+describe('resident sequence-length subtitle', () => {
+  it('summarizes every resident official point without following legend selection', () => {
+    interceptOverlayRun();
+    interceptDerivedAgenticMetrics();
+    cy.intercept('GET', '/api/v1/resident-sequence-lengths*', (request) => {
+      const ids = new URL(request.url).searchParams.get('ids')?.split(',').filter(Boolean) ?? [];
+      expect(ids.length).to.be.greaterThan(1);
+      request.reply({
+        body: {
+          isl: buildTokenLengthSketch(Array.from({ length: ids.length * 2 }, () => 8_192)),
+          osl: buildTokenLengthSketch(Array.from({ length: ids.length * 2 }, () => 1_024)),
+          coveredPoints: ids.length,
+          requestedPoints: ids.length,
+        },
+      });
+    }).as('residentSequenceLengths');
+
+    visitAgenticChart();
+    cy.wait('@residentSequenceLengths');
+    cy.get('[data-testid="resident-sequence-lengths"]')
+      .should('be.visible')
+      .and('contain.text', 'Completed requests across all resident points')
+      .and('contain.text', 'ISL p50 8.2k')
+      .and('contain.text', 'p95 8.2k')
+      .and('contain.text', 'OSL p50 1k');
+
+    // Legend visibility is downstream of the resident set. Hiding a series
+    // must not remove the subtitle or issue a narrower stats request.
+    cy.get('.sidebar-legend button').first().click({ force: true });
+    cy.get('[data-testid="resident-sequence-lengths"]').should('be.visible');
+    cy.get('@residentSequenceLengths.all').should('have.length', 1);
+  });
+
+  it('does not label official-only stats as covering an unofficial overlay', () => {
+    let requestCount = 0;
+    interceptOverlayRun();
+    interceptDerivedAgenticMetrics();
+    cy.intercept('GET', '/api/v1/resident-sequence-lengths*', (request) => {
+      requestCount += 1;
+      request.reply({ body: {} });
+    });
+
+    visitAgenticChart(`&unofficialrun=${OVERLAY_RUN_ID}`);
+    cy.wait('@unofficialRun');
+    cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
+    cy.get('[data-testid="resident-sequence-lengths"]').should('not.exist');
+    cy.then(() => expect(requestCount).to.equal(0));
+  });
+});

--- a/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
+++ b/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
@@ -21,8 +21,8 @@ describe('resident sequence-length subtitle', () => {
       expect(ids.length).to.be.greaterThan(1);
       request.reply({
         body: {
-          isl: buildTokenLengthSketch(Array.from({ length: ids.length * 2 }, () => 8_192)),
-          osl: buildTokenLengthSketch(Array.from({ length: ids.length * 2 }, () => 1_024)),
+          isl: buildTokenLengthSketch(Array.from({ length: 12_345 }, () => 8_192)),
+          osl: buildTokenLengthSketch(Array.from({ length: 12_345 }, () => 1_024)),
           coveredPoints: ids.length,
           requestedPoints: ids.length,
         },
@@ -33,7 +33,7 @@ describe('resident sequence-length subtitle', () => {
     cy.wait('@residentSequenceLengths');
     cy.get('[data-testid="resident-sequence-lengths"]')
       .should('be.visible')
-      .and('contain.text', 'Completed requests across all resident points')
+      .and('contain.text', 'Completed requests across all resident points (n=12,345)')
       .and('contain.text', 'ISL p50 8.2k')
       .and('contain.text', 'p95 8.2k')
       .and('contain.text', 'OSL p50 1k');

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "bun run test:e2e:quick",
     "test:e2e:quick": "bun run test:e2e:quick:component && bun run test:e2e:quick:integration",
     "test:e2e:quick:component": "cypress run --component --spec cypress/component/chart-buttons.cy.tsx,cypress/component/scatter-graph.cy.tsx",
-    "test:e2e:quick:integration": "cypress run --spec cypress/e2e/sanity.cy.ts,cypress/e2e/inference-chart.cy.ts,cypress/e2e/evaluation-chart.cy.ts,cypress/e2e/reliability-chart.cy.ts,cypress/e2e/zh-pages.cy.ts,cypress/e2e/csv-export-overlay.cy.ts,cypress/e2e/overlay-optimal-only.cy.ts,cypress/e2e/overview-a11y.cy.ts",
+    "test:e2e:quick:integration": "cypress run --spec cypress/e2e/sanity.cy.ts,cypress/e2e/inference-chart.cy.ts,cypress/e2e/evaluation-chart.cy.ts,cypress/e2e/reliability-chart.cy.ts,cypress/e2e/zh-pages.cy.ts,cypress/e2e/csv-export-overlay.cy.ts,cypress/e2e/overlay-optimal-only.cy.ts,cypress/e2e/resident-sequence-lengths.cy.ts,cypress/e2e/overview-a11y.cy.ts",
     "test:e2e:full": "cypress run --component && cypress run",
     "test:e2e:component": "cypress run --component",
     "test:e2e:integration": "cypress run",

--- a/packages/app/src/app/api/v1/agentic-aggregates/route.ts
+++ b/packages/app/src/app/api/v1/agentic-aggregates/route.ts
@@ -32,7 +32,7 @@ const getCachedAgenticAggregates = cachedQuery(
 /**
  * GET /api/v1/agentic-aggregates?ids=1,2,3
  *
- * Returns per-id mean/p50/p75/p90/p99 for ISL, OSL, KV cache utilization,
+ * Returns per-id mean/p50/p75/p90/p95/p99 for ISL, OSL, KV cache utilization,
  * and prefix cache hit rate — computed live from the stored aiperf
  * profile_export.jsonl + server_metrics_json blobs. Ids without a
  * trace_replay blob (or with no usable samples) get nulls.

--- a/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
+++ b/packages/app/src/app/api/v1/agentic-cache-keys.test.ts
@@ -32,6 +32,7 @@ import { CACHE_KEY_PREFIX as agenticAggregatesKey } from './agentic-aggregates/r
 import { CACHE_KEY_PREFIX as requestTimelineKey } from './request-timeline/route';
 import { CACHE_KEY_PREFIX as traceServerMetricsKey } from './trace-server-metrics/route';
 import { CACHE_KEY_PREFIX as traceHistogramsKey } from './trace-histograms/route';
+import { CACHE_KEY_PREFIX as residentSequenceLengthsKey } from './resident-sequence-lengths/route';
 
 describe('agentic blob-cache keys are version-derived', () => {
   it('agentic-aggregates key embeds STATS_VERSION', () => {
@@ -50,12 +51,17 @@ describe('agentic blob-cache keys are version-derived', () => {
     expect(traceHistogramsKey).toBe(`trace-histograms-v${REQUEST_TIMELINE_VERSION}`);
   });
 
+  it('resident-sequence-lengths key embeds STATS_VERSION', () => {
+    expect(residentSequenceLengthsKey).toBe(`resident-sequence-lengths-v${STATS_VERSION}`);
+  });
+
   it('every key actually contains a version segment (no unversioned literals)', () => {
     for (const key of [
       agenticAggregatesKey,
       requestTimelineKey,
       traceServerMetricsKey,
       traceHistogramsKey,
+      residentSequenceLengthsKey,
     ]) {
       expect(key).toMatch(/-v\d+$/u);
     }

--- a/packages/app/src/app/api/v1/resident-sequence-lengths/route.ts
+++ b/packages/app/src/app/api/v1/resident-sequence-lengths/route.ts
@@ -1,0 +1,32 @@
+import { getDb } from '@semianalysisai/inferencex-db/connection';
+import { STATS_VERSION } from '@semianalysisai/inferencex-db/queries/agentic-shared';
+import {
+  getResidentSequenceLengthSketches,
+  type ResidentSequenceLengthSketches,
+} from '@semianalysisai/inferencex-db/queries/resident-sequence-lengths';
+
+import { cachedQuery } from '@/lib/api-cache';
+
+import { idsQueryRoute } from '../id-routes';
+
+export const dynamic = 'force-dynamic';
+
+export const CACHE_KEY_PREFIX = `resident-sequence-lengths-v${STATS_VERSION}`;
+
+const getCachedResidentSequenceLengths = cachedQuery(
+  (ids: number[]): Promise<ResidentSequenceLengthSketches> =>
+    getResidentSequenceLengthSketches(getDb(), ids),
+  CACHE_KEY_PREFIX,
+);
+
+/**
+ * GET /api/v1/resident-sequence-lengths?ids=1,2,3
+ *
+ * Returns one mergeable ISL/OSL sketch for the requested resident chart
+ * points. The client chunks large charts and merges these bounded payloads.
+ */
+export const GET = idsQueryRoute({
+  maxIds: 200,
+  logLabel: 'resident sequence lengths',
+  fetch: getCachedResidentSequenceLengths,
+});

--- a/packages/app/src/components/inference/agentic-point/aggregate-chart.tsx
+++ b/packages/app/src/components/inference/agentic-point/aggregate-chart.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { ChartHover, type HoverItem } from './chart-hover';
 import { ChartEmpty, PERCENTILE_COLORS } from './chart-shared';
 
-export type PercentileKey = 'mean' | 'p50' | 'p75' | 'p90' | 'p99';
+export type PercentileKey = 'mean' | 'p50' | 'p75' | 'p90' | 'p95' | 'p99';
 
 interface PercentileLine {
   key: PercentileKey;
@@ -19,6 +19,7 @@ const PERCENTILE_LINES: PercentileLine[] = [
   { key: 'p50', label: 'P50', color: PERCENTILE_COLORS.p50 },
   { key: 'p75', label: 'P75', color: PERCENTILE_COLORS.p75 },
   { key: 'p90', label: 'P90', color: PERCENTILE_COLORS.p90 },
+  { key: 'p95', label: 'P95', color: PERCENTILE_COLORS.p95 },
   { key: 'p99', label: 'P99', color: PERCENTILE_COLORS.p99 },
 ];
 
@@ -37,7 +38,7 @@ export interface AggregatePoint {
 
 /**
  * Multi-line chart: one x-position per sibling config, one line per
- * percentile (mean/p50/p75/p90/p99). Designed for the "Aggregates across
+ * percentile (mean/p50/p75/p90/p95/p99). Designed for the "Aggregates across
  * configs" view on the agentic detail page.
  */
 export function AggregateChart({

--- a/packages/app/src/components/inference/agentic-point/aggregates-grid.tsx
+++ b/packages/app/src/components/inference/agentic-point/aggregates-grid.tsx
@@ -19,6 +19,7 @@ function toAggPoint(
     values.p50 = pct.p50;
     values.p75 = pct.p75;
     values.p90 = pct.p90;
+    values.p95 = pct.p95;
     values.p99 = pct.p99;
   }
   return { id: sibling.id, label: sibling.label, values };

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -91,7 +91,8 @@ const STRINGS = {
     updated: 'Updated:',
     e2eNormIntvtyDisclaimer:
       'E2E Normalized Interactivity requires persisted per-request traces, so unofficial-run overlays are unavailable for this experimental view.',
-    completedSequenceLengths: 'Completed requests across all resident points',
+    completedSequenceLengths: (count: string) =>
+      `Completed requests across all resident points (n=${count})`,
     viewMode: 'View mode',
     vsTtft: (word: string) => `vs. ${word} Time To First Token`,
     vsE2eLatency: (pctl?: string) =>
@@ -108,7 +109,7 @@ const STRINGS = {
     updated: '更新时间：',
     e2eNormIntvtyDisclaimer:
       '端到端归一化交互性需要持久化的逐请求 trace 数据，因此该实验性视图不支持非官方运行覆盖。',
-    completedSequenceLengths: '当前所有数据点的已完成请求',
+    completedSequenceLengths: (count: string) => `当前所有数据点的已完成请求（n=${count}）`,
     viewMode: '视图模式',
     vsTtft: (word: string) => `vs. ${word === 'Median' ? '中位' : word} 首 token 延迟（TTFT）`,
     vsE2eLatency: (pctl?: string) => (pctl ? `vs. ${pctl} 端到端延迟` : 'vs. 端到端延迟'),
@@ -906,8 +907,12 @@ export default function ChartDisplay() {
                               className="mb-2 text-xs text-muted-foreground"
                               data-testid="resident-sequence-lengths"
                             >
-                              {t.completedSequenceLengths} · ISL p50{' '}
-                              {formatTokenLength(residentSequenceLengths.isl.p50)} · p75{' '}
+                              {t.completedSequenceLengths(
+                                residentSequenceLengths.isl.n.toLocaleString(
+                                  locale === 'zh' ? 'zh-CN' : 'en-US',
+                                ),
+                              )}{' '}
+                              · ISL p50 {formatTokenLength(residentSequenceLengths.isl.p50)} · p75{' '}
                               {formatTokenLength(residentSequenceLengths.isl.p75)} · p90{' '}
                               {formatTokenLength(residentSequenceLengths.isl.p90)} · p95{' '}
                               {formatTokenLength(residentSequenceLengths.isl.p95)} · p99{' '}

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -59,6 +59,7 @@ import {
   useDerivedAgenticMetrics,
   type DerivedAgenticMetric,
 } from '@/hooks/api/use-derived-agentic-metrics';
+import { useResidentSequenceLengths } from '@/hooks/api/use-resident-sequence-lengths';
 import { getHardwareConfig, hardwareKeyMatchesAnyBase } from '@/lib/constants';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useLocale } from '@/lib/use-locale';
@@ -90,6 +91,7 @@ const STRINGS = {
     updated: 'Updated:',
     e2eNormIntvtyDisclaimer:
       'E2E Normalized Interactivity requires persisted per-request traces, so unofficial-run overlays are unavailable for this experimental view.',
+    completedSequenceLengths: 'Completed requests across all resident points',
     viewMode: 'View mode',
     vsTtft: (word: string) => `vs. ${word} Time To First Token`,
     vsE2eLatency: (pctl?: string) =>
@@ -106,6 +108,7 @@ const STRINGS = {
     updated: '更新时间：',
     e2eNormIntvtyDisclaimer:
       '端到端归一化交互性需要持久化的逐请求 trace 数据，因此该实验性视图不支持非官方运行覆盖。',
+    completedSequenceLengths: '当前所有数据点的已完成请求',
     viewMode: '视图模式',
     vsTtft: (word: string) => `vs. ${word === 'Median' ? '中位' : word} 首 token 延迟（TTFT）`,
     vsE2eLatency: (pctl?: string) => (pctl ? `vs. ${pctl} 端到端延迟` : 'vs. 端到端延迟'),
@@ -180,6 +183,14 @@ const VIEW_MODE_OPTIONS: SegmentedToggleOption<InferenceViewMode>[] = [
     testId: 'inference-table-view-btn',
   },
 ];
+
+export function formatTokenLength(value: number): string {
+  const rounded = Math.round(value);
+  if (rounded < 1_000) return String(rounded);
+  if (rounded < 10_000) return `${(rounded / 1_000).toFixed(1).replace(/\.0$/u, '')}k`;
+  if (rounded < 1_000_000) return `${Math.round(rounded / 1_000)}k`;
+  return `${(rounded / 1_000_000).toFixed(2).replace(/\.0+$/u, '')}m`;
+}
 
 /**
  * Renders the inference chart cards, captions, and overlay controls for the current filtered
@@ -609,6 +620,35 @@ export default function ChartDisplay() {
   }, [effectiveGraphs, selectedXAxisMode]);
 
   const isAgenticSequence = sequenceKind(selectedSequence) === 'agentic';
+  const residentPointIds = useMemo(() => {
+    if (!isAgenticSequence) return [] as number[];
+    const ids = new Set<number>();
+    for (const graph of visibleGraphs) {
+      const points = [...graph.data, ...(graph.clippedData ?? []).map((entry) => entry.point)];
+      for (const point of points) {
+        if (
+          selectedPrecisions.includes(point.precision) &&
+          point.benchmark_type === 'agentic_traces' &&
+          isPersistedBenchmarkId(point.id)
+        ) {
+          ids.add(point.id);
+        }
+      }
+    }
+    return [...ids];
+  }, [isAgenticSequence, selectedPrecisions, visibleGraphs]);
+  // Unofficial-run artifacts are transformed in memory and do not have
+  // persisted aggregate_stats sketches. Suppress the subtitle in overlay mode
+  // rather than presenting official-only values as if they covered the overlay.
+  const residentSequenceLengthsQuery = useResidentSequenceLengths(
+    residentPointIds,
+    isAgenticSequence && !isUnofficialRun,
+  );
+  const residentSequenceLengths =
+    residentSequenceLengthsQuery.data?.coveredPoints ===
+    residentSequenceLengthsQuery.data?.requestedPoints
+      ? residentSequenceLengthsQuery.data
+      : null;
   const useDerivedXAxis = isAgenticSequence && isAgenticOnlyXAxisMode(selectedXAxisMode);
   const derivedTargetIds = useMemo(() => {
     if (!useDerivedXAxis) return [] as number[];
@@ -861,6 +901,24 @@ export default function ChartDisplay() {
                               </>
                             )}
                           </p>
+                          {residentSequenceLengths && (
+                            <p
+                              className="mb-2 text-xs text-muted-foreground"
+                              data-testid="resident-sequence-lengths"
+                            >
+                              {t.completedSequenceLengths} · ISL p50{' '}
+                              {formatTokenLength(residentSequenceLengths.isl.p50)} · p75{' '}
+                              {formatTokenLength(residentSequenceLengths.isl.p75)} · p90{' '}
+                              {formatTokenLength(residentSequenceLengths.isl.p90)} · p95{' '}
+                              {formatTokenLength(residentSequenceLengths.isl.p95)} · p99{' '}
+                              {formatTokenLength(residentSequenceLengths.isl.p99)} | OSL p50{' '}
+                              {formatTokenLength(residentSequenceLengths.osl.p50)} · p75{' '}
+                              {formatTokenLength(residentSequenceLengths.osl.p75)} · p90{' '}
+                              {formatTokenLength(residentSequenceLengths.osl.p90)} · p95{' '}
+                              {formatTokenLength(residentSequenceLengths.osl.p95)} · p99{' '}
+                              {formatTokenLength(residentSequenceLengths.osl.p99)}
+                            </p>
+                          )}
                           <MetricAssumptionNotes selectedYAxisMetric={selectedYAxisMetric} />
                           {isUnofficialRun &&
                             selectedXAxisMode === 'e2e-normalized-interactivity' && (

--- a/packages/app/src/hooks/api/use-agentic-aggregates.ts
+++ b/packages/app/src/hooks/api/use-agentic-aggregates.ts
@@ -5,6 +5,7 @@ export interface MetricPercentiles {
   p50: number;
   p75: number;
   p90: number;
+  p95: number;
   p99: number;
   n: number;
 }
@@ -22,7 +23,7 @@ export type AgenticAggregateMap = Record<number, AgenticAggregate>;
 const fetchAgenticAggregates = bulkIdsFetcher<AgenticAggregate>('agentic-aggregates');
 
 /**
- * Fetch per-id aggregate stats (mean/p50/p75/p90/p99) for ISL, OSL, KV
+ * Fetch per-id aggregate stats (mean/p50/p75/p90/p95/p99) for ISL, OSL, KV
  * cache utilization, and prefix cache hit rate. Used by the "Aggregates
  * across configs" view on the agentic detail page.
  */

--- a/packages/app/src/hooks/api/use-resident-sequence-lengths.test.ts
+++ b/packages/app/src/hooks/api/use-resident-sequence-lengths.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { chunkResidentPointIds } from './use-resident-sequence-lengths';
+
+describe('chunkResidentPointIds', () => {
+  it('keeps resident-point requests within the API limit', () => {
+    const chunks = chunkResidentPointIds(Array.from({ length: 451 }, (_, index) => index + 1));
+    expect(chunks.map((chunk) => chunk.length)).toEqual([200, 200, 51]);
+  });
+});

--- a/packages/app/src/hooks/api/use-resident-sequence-lengths.ts
+++ b/packages/app/src/hooks/api/use-resident-sequence-lengths.ts
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  mergeTokenLengthSketches,
+  tokenLengthPercentiles,
+  type TokenLengthSketch,
+  type TokenLengthPercentiles,
+} from '@semianalysisai/inferencex-constants';
+
+interface ResidentSequenceLengthSketches {
+  isl: TokenLengthSketch | null;
+  osl: TokenLengthSketch | null;
+  coveredPoints: number;
+  requestedPoints: number;
+}
+
+export interface ResidentSequenceLengthPercentiles {
+  isl: TokenLengthPercentiles;
+  osl: TokenLengthPercentiles;
+  coveredPoints: number;
+  requestedPoints: number;
+}
+
+const MAX_IDS_PER_REQUEST = 200;
+const STALE_TIME_MS = 5 * 60 * 1000;
+
+export function chunkResidentPointIds(ids: readonly number[]): number[][] {
+  const chunks: number[][] = [];
+  for (let index = 0; index < ids.length; index += MAX_IDS_PER_REQUEST) {
+    chunks.push(ids.slice(index, index + MAX_IDS_PER_REQUEST));
+  }
+  return chunks;
+}
+
+async function fetchResidentSequenceLengths(
+  ids: number[],
+  signal?: AbortSignal,
+): Promise<ResidentSequenceLengthPercentiles | null> {
+  const chunks = await Promise.all(
+    chunkResidentPointIds(ids).map(async (chunk) => {
+      const response = await fetch(`/api/v1/resident-sequence-lengths?ids=${chunk.join(',')}`, {
+        signal,
+      });
+      if (!response.ok) throw new Error(`resident-sequence-lengths ${response.status}`);
+      return (await response.json()) as ResidentSequenceLengthSketches;
+    }),
+  );
+
+  const isl = tokenLengthPercentiles(mergeTokenLengthSketches(chunks.map((chunk) => chunk.isl)));
+  const osl = tokenLengthPercentiles(mergeTokenLengthSketches(chunks.map((chunk) => chunk.osl)));
+  if (!isl || !osl) return null;
+  return {
+    isl,
+    osl,
+    coveredPoints: chunks.reduce((sum, chunk) => sum + chunk.coveredPoints, 0),
+    requestedPoints: chunks.reduce((sum, chunk) => sum + chunk.requestedPoints, 0),
+  };
+}
+
+export function useResidentSequenceLengths(ids: number[], enabled = true) {
+  const sortedIds = [...new Set(ids)].toSorted((a, b) => a - b);
+  return useQuery({
+    queryKey: ['resident-sequence-lengths', sortedIds.join(',')] as const,
+    queryFn: ({ signal }) => fetchResidentSequenceLengths(sortedIds, signal),
+    enabled: enabled && sortedIds.length > 0,
+    staleTime: STALE_TIME_MS,
+  });
+}

--- a/packages/app/src/lib/api-documentation.ts
+++ b/packages/app/src/lib/api-documentation.ts
@@ -473,7 +473,9 @@ const percentileSchema = objectSchema({
   p50: numberSchema,
   p75: numberSchema,
   p90: numberSchema,
+  p95: numberSchema,
   p99: numberSchema,
+  n: integerSchema,
 });
 const nullablePercentileSchema: ApiSchema = { oneOf: [percentileSchema, { type: 'null' }] };
 const idListSchema: ApiSchema = { type: 'string', pattern: '^\\d+(,\\d+)*$' };
@@ -1670,7 +1672,15 @@ export const apiOperations: readonly ApiOperation[] = [
         {
           '421': {
             id: 421,
-            isl: { mean: 18320, p50: 16440, p75: 20110, p90: 24880, p99: 31900 },
+            isl: {
+              mean: 18320,
+              p50: 16440,
+              p75: 20110,
+              p90: 24880,
+              p95: 27940,
+              p99: 31900,
+              n: 512,
+            },
             osl: null,
             kvCacheUtil: null,
             prefixCacheHitRate: null,

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -84,7 +84,7 @@ export const apiRouteCatalog = [
     method: 'GET',
     classification: 'published-read',
     operationId: 'get-agentic-aggregates',
-    sourceSha256: '6a99fc156b02b86c5c26ca5ba6b05a280e064dd6123aaba528f124ff0f13c577',
+    sourceSha256: '7dab9929039926b2697d5db71c143eb39f94e795a0d83bb0348db8869f279a5f',
   },
   {
     source: 'src/app/api/v1/availability/route.ts',
@@ -308,6 +308,17 @@ export const apiRouteCatalog = [
     sourceSha256: '30659cb757b9fd23411757051b650cfb564016aa15c8b9fec48676b9591f01e9',
   },
   {
+    source: 'src/app/api/v1/resident-sequence-lengths/route.ts',
+    path: '/api/v1/resident-sequence-lengths',
+    method: 'GET',
+    classification: 'ui-artifact-read',
+    exclusionReason: {
+      en: 'UI-only mergeable sequence-length sketches for the resident inference-chart point set.',
+      zh: '仅供界面合并当前推理图表数据点的序列长度 sketch。',
+    },
+    sourceSha256: '7a66a7116be3bf63a8c7fc1a54cc7eaf97405858e633daa0802cc2ae7cdbb37e',
+  },
+  {
     source: 'src/app/api/v1/server-log-files/route.ts',
     path: '/api/v1/server-log-files',
     method: 'GET',
@@ -455,7 +466,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/agentic-aggregates.ts',
-    sourceSha256: 'b0f4be6c39fe440df99db687b4b6deeed58897bf20325770631680f6e41aa304',
+    sourceSha256: 'fae8d19971730132cb30cd781f677562bfc6328b1f4e35a8268a8391ad187c18',
     reviewArea: {
       en: 'Agentic aggregate percentile keys, nullability, and ID-keyed response shape.',
       zh: '智能体汇总百分位字段、可空性和按 ID 索引的响应结构。',

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -8,3 +8,4 @@ export * from './seo';
 export * from './tables';
 export * from './currency';
 export * from './tco';
+export * from './token-length-sketch';

--- a/packages/constants/src/token-length-sketch.test.ts
+++ b/packages/constants/src/token-length-sketch.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTokenLengthSketch,
+  mergeTokenLengthSketches,
+  tokenLengthPercentiles,
+} from './token-length-sketch';
+
+describe('token length sketch', () => {
+  it('keeps percentile error below one percent', () => {
+    const samples = Array.from({ length: 100_000 }, (_, index) => index + 1);
+    const percentiles = tokenLengthPercentiles(buildTokenLengthSketch(samples));
+
+    expect(percentiles?.n).toBe(100_000);
+    for (const [actual, expected] of [
+      [percentiles?.p50, 50_000.5],
+      [percentiles?.p75, 75_000.25],
+      [percentiles?.p90, 90_000.1],
+      [percentiles?.p95, 95_000.05],
+      [percentiles?.p99, 99_000.01],
+    ] as const) {
+      expect(Math.abs((actual ?? 0) - expected) / expected).toBeLessThan(0.004);
+    }
+  });
+
+  it('merges point sketches with request weighting', () => {
+    const smallPoint = buildTokenLengthSketch([10, 20]);
+    const largePoint = buildTokenLengthSketch(Array.from({ length: 8 }, () => 1_000));
+    const percentiles = tokenLengthPercentiles(mergeTokenLengthSketches([smallPoint, largePoint]));
+
+    expect(percentiles?.n).toBe(10);
+    expect(Math.abs((percentiles?.p50 ?? 0) - 1_000)).toBeLessThanOrEqual(1);
+    expect(Math.abs((percentiles?.p90 ?? 0) - 1_000)).toBeLessThanOrEqual(1);
+  });
+
+  it('ignores invalid samples and preserves zero', () => {
+    const percentiles = tokenLengthPercentiles(buildTokenLengthSketch([Number.NaN, -1, 0, 10]));
+    expect(percentiles?.n).toBe(2);
+    expect(percentiles?.p50).toBe(5);
+  });
+});

--- a/packages/constants/src/token-length-sketch.ts
+++ b/packages/constants/src/token-length-sketch.ts
@@ -1,0 +1,171 @@
+/**
+ * Mergeable, bounded-size histogram for positive integer token lengths.
+ *
+ * Each power-of-two interval is split into 256 linear buckets. This keeps the
+ * relative bucket width below 0.4% while bounding a full 1..2^31 distribution
+ * to fewer than 8,000 counters. Sketches can be merged by adding aligned
+ * counters, which lets the dashboard pool request distributions across an
+ * arbitrary set of benchmark points without reading their request timelines.
+ */
+
+export const TOKEN_LENGTH_SKETCH_VERSION = 1;
+export const TOKEN_LENGTH_BINS_PER_OCTAVE = 256;
+
+export interface TokenLengthSketch {
+  version: number;
+  binsPerOctave: number;
+  /** Number of finite, non-negative samples represented by this sketch. */
+  n: number;
+  /** Zero-length samples are kept outside the logarithmic bins. */
+  zeroCount: number;
+  /** Global index represented by counts[0]. */
+  minBin: number;
+  /** Dense counts from minBin through minBin + counts.length - 1. */
+  counts: number[];
+}
+
+export interface TokenLengthPercentiles {
+  p50: number;
+  p75: number;
+  p90: number;
+  p95: number;
+  p99: number;
+  n: number;
+}
+
+function binIndex(value: number, binsPerOctave: number): number {
+  const exponent = Math.floor(Math.log2(value));
+  const base = 2 ** exponent;
+  const subBin = Math.min(binsPerOctave - 1, Math.floor(((value - base) / base) * binsPerOctave));
+  return exponent * binsPerOctave + subBin;
+}
+
+function binValue(index: number, binsPerOctave: number): number {
+  const exponent = Math.floor(index / binsPerOctave);
+  const subBin = index - exponent * binsPerOctave;
+  const base = 2 ** exponent;
+  const lower = base * (1 + subBin / binsPerOctave);
+  const upper = base * (1 + (subBin + 1) / binsPerOctave);
+
+  // Token lengths are integers. When a bucket spans integers, use the middle
+  // integer rather than a fractional geometric representative.
+  const firstInteger = Math.ceil(lower);
+  const lastInteger = Math.ceil(upper) - 1;
+  if (firstInteger <= lastInteger) return (firstInteger + lastInteger) / 2;
+  return (lower + upper) / 2;
+}
+
+export function buildTokenLengthSketch(samples: readonly number[]): TokenLengthSketch | null {
+  const countsByBin = new Map<number, number>();
+  let zeroCount = 0;
+  let n = 0;
+  for (const raw of samples) {
+    if (!Number.isFinite(raw) || raw < 0) continue;
+    const value = Math.round(raw);
+    n += 1;
+    if (value === 0) {
+      zeroCount += 1;
+      continue;
+    }
+    const index = binIndex(value, TOKEN_LENGTH_BINS_PER_OCTAVE);
+    countsByBin.set(index, (countsByBin.get(index) ?? 0) + 1);
+  }
+  if (n === 0) return null;
+
+  const indices = [...countsByBin.keys()];
+  const minBin = indices.length > 0 ? Math.min(...indices) : 0;
+  const maxBin = indices.length > 0 ? Math.max(...indices) : minBin - 1;
+  const counts = Array.from({ length: Math.max(0, maxBin - minBin + 1) }, () => 0);
+  for (const [index, count] of countsByBin) counts[index - minBin] = count;
+
+  return {
+    version: TOKEN_LENGTH_SKETCH_VERSION,
+    binsPerOctave: TOKEN_LENGTH_BINS_PER_OCTAVE,
+    n,
+    zeroCount,
+    minBin,
+    counts,
+  };
+}
+
+function isCompatibleSketch(
+  sketch: TokenLengthSketch | null | undefined,
+): sketch is TokenLengthSketch {
+  return Boolean(
+    sketch &&
+    sketch.version === TOKEN_LENGTH_SKETCH_VERSION &&
+    sketch.binsPerOctave === TOKEN_LENGTH_BINS_PER_OCTAVE &&
+    Number.isFinite(sketch.n) &&
+    sketch.n >= 0 &&
+    Array.isArray(sketch.counts),
+  );
+}
+
+export function mergeTokenLengthSketches(
+  sketches: readonly (TokenLengthSketch | null | undefined)[],
+): TokenLengthSketch | null {
+  const valid = sketches.filter(isCompatibleSketch);
+  if (valid.length === 0) return null;
+
+  const withBins = valid.filter((sketch) => sketch.counts.length > 0);
+  const minBin = withBins.length > 0 ? Math.min(...withBins.map((sketch) => sketch.minBin)) : 0;
+  const maxBin =
+    withBins.length > 0
+      ? Math.max(...withBins.map((sketch) => sketch.minBin + sketch.counts.length - 1))
+      : minBin - 1;
+  const counts = Array.from({ length: Math.max(0, maxBin - minBin + 1) }, () => 0);
+
+  let n = 0;
+  let zeroCount = 0;
+  for (const sketch of valid) {
+    n += sketch.n;
+    zeroCount += sketch.zeroCount;
+    for (let i = 0; i < sketch.counts.length; i += 1) {
+      counts[sketch.minBin + i - minBin] += sketch.counts[i] ?? 0;
+    }
+  }
+  if (n === 0) return null;
+
+  return {
+    version: TOKEN_LENGTH_SKETCH_VERSION,
+    binsPerOctave: TOKEN_LENGTH_BINS_PER_OCTAVE,
+    n,
+    zeroCount,
+    minBin,
+    counts,
+  };
+}
+
+function valueAtRank(sketch: TokenLengthSketch, rank: number): number {
+  if (rank < sketch.zeroCount) return 0;
+  let cumulative = sketch.zeroCount;
+  for (let i = 0; i < sketch.counts.length; i += 1) {
+    cumulative += sketch.counts[i] ?? 0;
+    if (rank < cumulative) return binValue(sketch.minBin + i, sketch.binsPerOctave);
+  }
+  return binValue(sketch.minBin + sketch.counts.length - 1, sketch.binsPerOctave);
+}
+
+function quantile(sketch: TokenLengthSketch, q: number): number {
+  if (sketch.n === 1) return valueAtRank(sketch, 0);
+  const position = (sketch.n - 1) * q;
+  const lowerRank = Math.floor(position);
+  const upperRank = Math.ceil(position);
+  const lower = valueAtRank(sketch, lowerRank);
+  const upper = valueAtRank(sketch, upperRank);
+  return lower + (upper - lower) * (position - lowerRank);
+}
+
+export function tokenLengthPercentiles(
+  sketch: TokenLengthSketch | null | undefined,
+): TokenLengthPercentiles | null {
+  if (!isCompatibleSketch(sketch) || sketch.n <= 0) return null;
+  return {
+    p50: quantile(sketch, 0.5),
+    p75: quantile(sketch, 0.75),
+    p90: quantile(sketch, 0.9),
+    p95: quantile(sketch, 0.95),
+    p99: quantile(sketch, 0.99),
+    n: sketch.n,
+  };
+}

--- a/packages/db/src/backfill-aggregate-stats.ts
+++ b/packages/db/src/backfill-aggregate-stats.ts
@@ -24,6 +24,7 @@
 import { hasNoSslFlag } from './cli-utils.js';
 import {
   computeAggregateStats,
+  computeProfileAggregateStatsFromCompressedChunks,
   mergeProfileStatsUpgrade,
   STATS_VERSION,
   type AggregateStats,
@@ -39,11 +40,30 @@ import {
 
 const flags = parseLimitForceFlags();
 
+// Neon's HTTP response and JS drivers should not receive a 100+ MB bytea as
+// one value. Slice oversized TOAST values into independent bounded reads and
+// feed the compressed bytes directly into the streaming gzip parser.
+const MAX_INLINE_PROFILE_BYTES = 64 * 1024 * 1024;
+const PROFILE_CHUNK_BYTES = 8 * 1024 * 1024;
+
 const sql = createAdminSql({
   noSsl: hasNoSslFlag(),
   max: 1,
   onnotice: () => {},
 });
+
+async function* readProfileChunks(id: number, totalBytes: number): AsyncGenerator<Buffer> {
+  for (let offset = 0; offset < totalBytes; offset += PROFILE_CHUNK_BYTES) {
+    const length = Math.min(PROFILE_CHUNK_BYTES, totalBytes - offset);
+    const [row] = await sql<{ chunk: Buffer }[]>`
+      select substring(profile_export_jsonl_gz from ${offset + 1} for ${length}) as chunk
+      from agentic_trace_replay
+      where id = ${id}
+    `;
+    if (!row?.chunk) throw new Error(`profile blob chunk missing at byte ${offset}`);
+    yield row.chunk;
+  }
+}
 
 async function main(): Promise<void> {
   console.log('=== backfill-aggregate-stats ===');
@@ -82,9 +102,20 @@ async function main(): Promise<void> {
     async (id) => {
       // Fetch one row at a time — the json_gz blob is the heavy field.
       const [row] = await sql<
-        { profile_export_jsonl_gz: Buffer | null; aggregate_stats: AggregateStats | null }[]
+        {
+          profile_export_jsonl_gz: Buffer | null;
+          profile_blob_bytes: number;
+          aggregate_stats: AggregateStats | null;
+        }[]
       >`
-        select profile_export_jsonl_gz, aggregate_stats
+        select
+          case
+            when pg_column_size(profile_export_jsonl_gz) <= ${MAX_INLINE_PROFILE_BYTES}
+              then profile_export_jsonl_gz
+            else null
+          end as profile_export_jsonl_gz,
+          coalesce(pg_column_size(profile_export_jsonl_gz), 0)::bigint as profile_blob_bytes,
+          aggregate_stats
         from agentic_trace_replay
         where id = ${id}
       `;
@@ -93,16 +124,22 @@ async function main(): Promise<void> {
         return 'skipped';
       }
 
+      const profileStats =
+        Number(row.profile_blob_bytes) > MAX_INLINE_PROFILE_BYTES
+          ? await computeProfileAggregateStatsFromCompressedChunks(
+              readProfileChunks(id, Number(row.profile_blob_bytes)),
+            )
+          : await computeAggregateStats({
+              profileBlob: row.profile_export_jsonl_gz,
+              serverBlob: null,
+            });
+
       let stats: AggregateStats;
       // v3 onwards → current is a profile-only change (the server-derived
       // fields haven't changed since v3), so skip re-reading the huge server
       // blob and carry its KV/prefix distributions forward.
       const storedVersion = row.aggregate_stats?.version;
       if (storedVersion !== undefined && storedVersion >= 3 && storedVersion < STATS_VERSION) {
-        const profileStats = await computeAggregateStats({
-          profileBlob: row.profile_export_jsonl_gz,
-          serverBlob: null,
-        });
         stats = mergeProfileStatsUpgrade(row.aggregate_stats!, profileStats);
       } else {
         const [serverRow] = await sql<{ server_metrics_json_gz: Buffer | null }[]>`
@@ -110,10 +147,11 @@ async function main(): Promise<void> {
           from agentic_trace_replay
           where id = ${id}
         `;
-        stats = await computeAggregateStats({
-          profileBlob: row.profile_export_jsonl_gz,
+        const serverStats = await computeAggregateStats({
+          profileBlob: null,
           serverBlob: serverRow?.server_metrics_json_gz ?? null,
         });
+        stats = mergeProfileStatsUpgrade(serverStats, profileStats);
       }
 
       await sql`

--- a/packages/db/src/etl/compute-aggregate-stats.test.ts
+++ b/packages/db/src/etl/compute-aggregate-stats.test.ts
@@ -81,6 +81,8 @@ describe('computeAggregateStats', () => {
     expect(stats.isl?.mean).toBeCloseTo(200, 6);
     expect(stats.osl?.n).toBe(3);
     expect(stats.osl?.mean).toBeCloseTo(75, 6);
+    expect(stats.sequenceLengths.isl?.n).toBe(3);
+    expect(stats.sequenceLengths.osl?.n).toBe(3);
 
     // Server-side metrics still null when there's no server blob.
     expect(stats.kvCacheUtil).toBeNull();
@@ -148,7 +150,15 @@ describe('mergeProfileStatsUpgrade', () => {
       version: STATS_VERSION - 1,
       isl: null,
       osl: null,
-      kvCacheUtil: { mean: 0.4, p50: 0.4, p75: 0.5, p90: 0.6, p99: 0.7, n: 3 },
+      kvCacheUtil: {
+        mean: 0.4,
+        p50: 0.4,
+        p75: 0.5,
+        p90: 0.6,
+        p95: 0.65,
+        p99: 0.7,
+        n: 3,
+      },
       prefixCacheHitRate: null,
       normalizedSessionTimeS: 999,
       p90PrefillTpsPerUser: 999,

--- a/packages/db/src/etl/compute-aggregate-stats.test.ts
+++ b/packages/db/src/etl/compute-aggregate-stats.test.ts
@@ -5,17 +5,21 @@ import { describe, expect, it } from 'vitest';
 import {
   STATS_VERSION,
   computeAggregateStats,
+  computeProfileAggregateStatsFromCompressedChunks,
   mergeProfileStatsUpgrade,
 } from './compute-aggregate-stats.js';
 
 /** Build a minimal `profile_export.jsonl` from a few synthetic requests. */
-function makeProfileBlob(requests: { isl: number; osl: number; rl?: number; ttft?: number }[]) {
+function makeProfileBlob(
+  requests: { isl: number; osl: number; rl?: number; ttft?: number; cancelled?: boolean }[],
+) {
   const lines = requests.map((r, i) =>
     JSON.stringify({
       metadata: {
         benchmark_phase: 'profiling',
         conversation_id: `conv-${i}`,
         turn_index: 0,
+        was_cancelled: r.cancelled,
       },
       metrics: {
         input_sequence_length: { value: r.isl, unit: 'tokens' },
@@ -93,6 +97,38 @@ describe('computeAggregateStats', () => {
     expect(stats.e2elPerOsl?.p50).toBeCloseTo(2 / 75, 6);
     // p90 of 3 values (linear interpolation): pos=1.8 → 0.02667 + 0.8×(0.03-0.02667)
     expect(stats.e2elPerOsl?.p90).toBeCloseTo(2 / 75 + 0.8 * (0.03 - 2 / 75), 6);
+  });
+
+  it('excludes cancelled requests from every streamed profile distribution', async () => {
+    const stats = await computeAggregateStats({
+      profileBlob: makeProfileBlob([
+        { isl: 100, osl: 50, rl: 1000 },
+        { isl: 1_000_000, osl: 1_000_000, rl: 1_000_000, cancelled: true },
+      ]),
+      serverBlob: null,
+    });
+
+    expect(stats.isl?.n).toBe(1);
+    expect(stats.isl?.p50).toBe(100);
+    expect(stats.osl?.n).toBe(1);
+    expect(stats.e2elPerOsl?.n).toBe(1);
+    expect(stats.sequenceLengths.isl?.n).toBe(1);
+    expect(stats.sequenceLengths.osl?.n).toBe(1);
+  });
+
+  it('accepts a gzip profile split across arbitrarily small compressed chunks', async () => {
+    const blob = makeProfileBlob([
+      { isl: 100, osl: 50, rl: 1000 },
+      { isl: 200, osl: 100, rl: 2000 },
+    ]);
+    const chunks = Array.from({ length: Math.ceil(blob.length / 7) }, (_, index) =>
+      blob.subarray(index * 7, Math.min(blob.length, (index + 1) * 7)),
+    );
+
+    const stats = await computeProfileAggregateStatsFromCompressedChunks(chunks);
+    expect(stats.isl?.n).toBe(2);
+    expect(stats.osl?.n).toBe(2);
+    expect(stats.e2elPerOsl?.n).toBe(2);
   });
 
   it('computes KV util + prefix hit rate from the server blob alone', async () => {

--- a/packages/db/src/etl/compute-aggregate-stats.ts
+++ b/packages/db/src/etl/compute-aggregate-stats.ts
@@ -18,7 +18,9 @@ import {
   extractIslOsl,
   extractServerMetricSamples,
   percentilesOf,
+  sequenceLengthSketches,
   type MetricPercentiles,
+  type SequenceLengthSketches,
 } from '../queries/agentic-aggregates';
 
 export { STATS_VERSION };
@@ -35,6 +37,8 @@ export interface AggregateStats {
    * (tok/s/user): pXX E2E Normalized Interactivity = 1 / pXX(E2EL/OSL).
    */
   e2elPerOsl: MetricPercentiles | null;
+  /** Bounded mergeable distributions used by the chart-level subtitle. */
+  sequenceLengths: SequenceLengthSketches;
 }
 
 /**
@@ -128,6 +132,7 @@ export async function computeAggregateStats(args: {
   let islPct: MetricPercentiles | null = null;
   let oslPct: MetricPercentiles | null = null;
   let e2elPerOsl: MetricPercentiles | null = null;
+  let sequenceLengths: SequenceLengthSketches = { isl: null, osl: null };
 
   if (args.profileBlob) {
     try {
@@ -135,6 +140,7 @@ export async function computeAggregateStats(args: {
       const { isl, osl } = extractIslOsl(jsonl);
       islPct = percentilesOf(isl);
       oslPct = percentilesOf(osl);
+      sequenceLengths = sequenceLengthSketches(isl, osl);
       e2elPerOsl = computeDerivedFromBlob(jsonl).e2el_per_osl;
     } catch {
       // ignore malformed blob — leave nulls
@@ -167,5 +173,6 @@ export async function computeAggregateStats(args: {
     kvCacheUtil: kvPct,
     prefixCacheHitRate: prefixPct,
     e2elPerOsl,
+    sequenceLengths,
   };
 }

--- a/packages/db/src/etl/compute-aggregate-stats.ts
+++ b/packages/db/src/etl/compute-aggregate-stats.ts
@@ -9,13 +9,13 @@
  * computation changes so the backfill script knows which rows to recompute.
  */
 
-import { gunzipSync } from 'node:zlib';
+import { createInterface } from 'node:readline';
+import { Readable } from 'node:stream';
+import { createGunzip } from 'node:zlib';
 
 import { gunzipJsonWithinLimit, streamCollectKeys } from './gzip-json-stream';
-import { computeDerivedFromBlob } from '../queries/derived-agentic-metrics';
 import {
   STATS_VERSION,
-  extractIslOsl,
   extractServerMetricSamples,
   percentilesOf,
   sequenceLengthSketches,
@@ -39,6 +39,119 @@ export interface AggregateStats {
   e2elPerOsl: MetricPercentiles | null;
   /** Bounded mergeable distributions used by the chart-level subtitle. */
   sequenceLengths: SequenceLengthSketches;
+}
+
+interface ProfileMetricEnvelope {
+  value?: number;
+}
+
+interface ProfileRecord {
+  metadata?: {
+    benchmark_phase?: string;
+    was_cancelled?: boolean;
+  };
+  metrics?: {
+    input_sequence_length?: ProfileMetricEnvelope | number;
+    output_sequence_length?: ProfileMetricEnvelope | number;
+    request_latency?: ProfileMetricEnvelope | number;
+    time_to_first_token?: ProfileMetricEnvelope | number;
+  };
+}
+
+function profileMetricValue(value: ProfileMetricEnvelope | number | undefined): number | undefined {
+  const number = typeof value === 'number' ? value : value?.value;
+  return typeof number === 'number' && Number.isFinite(number) ? number : undefined;
+}
+
+/**
+ * Stream a profile export line by line so exceptionally large traces never
+ * materialize their multi-gigabyte decompressed JSONL as one string. The
+ * numeric sample arrays are tiny relative to the source and are needed for
+ * exact percentile calculation.
+ */
+async function extractProfileSamples(
+  compressedChunks: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+): Promise<{
+  isl: number[];
+  osl: number[];
+  e2elPerOsl: number[];
+}> {
+  const input = Readable.from(compressedChunks).pipe(createGunzip());
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  const isl: number[] = [];
+  const osl: number[] = [];
+  const e2elPerOsl: number[] = [];
+
+  for await (const line of lines) {
+    if (!line) continue;
+    let record: ProfileRecord;
+    try {
+      record = JSON.parse(line) as ProfileRecord;
+    } catch {
+      continue;
+    }
+    if (record.metadata?.benchmark_phase && record.metadata.benchmark_phase !== 'profiling') {
+      continue;
+    }
+    if (record.metadata?.was_cancelled === true) continue;
+
+    const metrics = record.metrics ?? {};
+    const inputLength = profileMetricValue(metrics.input_sequence_length);
+    const outputLength = profileMetricValue(metrics.output_sequence_length);
+    if (inputLength !== undefined) isl.push(inputLength);
+    if (outputLength !== undefined) osl.push(outputLength);
+
+    const requestLatencyMs = profileMetricValue(metrics.request_latency);
+    const ttftMs = profileMetricValue(metrics.time_to_first_token);
+    if (
+      requestLatencyMs !== undefined &&
+      ttftMs !== undefined &&
+      inputLength !== undefined &&
+      outputLength !== undefined &&
+      requestLatencyMs > 0 &&
+      ttftMs > 0 &&
+      inputLength > 0 &&
+      outputLength > 0
+    ) {
+      e2elPerOsl.push(requestLatencyMs / 1000 / outputLength);
+    }
+  }
+
+  return { isl, osl, e2elPerOsl };
+}
+
+/**
+ * Compute the profile-derived half of the aggregate bundle from compressed
+ * chunks. Backfills use this for oversized TOAST values so neither Postgres
+ * nor the JS driver has to materialize one enormous bytea response.
+ */
+export async function computeProfileAggregateStatsFromCompressedChunks(
+  compressedChunks: Iterable<Uint8Array> | AsyncIterable<Uint8Array>,
+): Promise<AggregateStats> {
+  let islPct: MetricPercentiles | null = null;
+  let oslPct: MetricPercentiles | null = null;
+  let e2elPerOsl: MetricPercentiles | null = null;
+  let sequenceLengths: SequenceLengthSketches = { isl: null, osl: null };
+
+  try {
+    const { isl, osl, e2elPerOsl: ratios } = await extractProfileSamples(compressedChunks);
+    islPct = percentilesOf(isl);
+    oslPct = percentilesOf(osl);
+    sequenceLengths = sequenceLengthSketches(isl, osl);
+    e2elPerOsl = percentilesOf(ratios);
+  } catch {
+    // Ignore malformed blobs and leave the profile-derived fields null.
+  }
+
+  return {
+    version: STATS_VERSION,
+    isl: islPct,
+    osl: oslPct,
+    kvCacheUtil: null,
+    prefixCacheHitRate: null,
+    e2elPerOsl,
+    sequenceLengths,
+  };
 }
 
 /**
@@ -129,23 +242,9 @@ export async function computeAggregateStats(args: {
   profileBlob: Buffer | null;
   serverBlob: Buffer | null;
 }): Promise<AggregateStats> {
-  let islPct: MetricPercentiles | null = null;
-  let oslPct: MetricPercentiles | null = null;
-  let e2elPerOsl: MetricPercentiles | null = null;
-  let sequenceLengths: SequenceLengthSketches = { isl: null, osl: null };
-
-  if (args.profileBlob) {
-    try {
-      const jsonl = gunzipSync(args.profileBlob).toString('utf8');
-      const { isl, osl } = extractIslOsl(jsonl);
-      islPct = percentilesOf(isl);
-      oslPct = percentilesOf(osl);
-      sequenceLengths = sequenceLengthSketches(isl, osl);
-      e2elPerOsl = computeDerivedFromBlob(jsonl).e2el_per_osl;
-    } catch {
-      // ignore malformed blob — leave nulls
-    }
-  }
+  const profile = args.profileBlob
+    ? await computeProfileAggregateStatsFromCompressedChunks([args.profileBlob])
+    : await computeProfileAggregateStatsFromCompressedChunks([]);
 
   let kvPct: MetricPercentiles | null = null;
   let prefixPct: MetricPercentiles | null = null;
@@ -167,12 +266,8 @@ export async function computeAggregateStats(args: {
   }
 
   return {
-    version: STATS_VERSION,
-    isl: islPct,
-    osl: oslPct,
+    ...profile,
     kvCacheUtil: kvPct,
     prefixCacheHitRate: prefixPct,
-    e2elPerOsl,
-    sequenceLengths,
   };
 }

--- a/packages/db/src/queries/agentic-aggregates.test.ts
+++ b/packages/db/src/queries/agentic-aggregates.test.ts
@@ -29,6 +29,7 @@ describe('percentilesOf', () => {
     // For 100 sorted values, p75 = sorted[0.75 * 99] = sorted[74.25] interp.
     expect(p!.p75).toBeCloseTo(75.25, 6);
     expect(p!.p90).toBeCloseTo(90.1, 6);
+    expect(p!.p95).toBeCloseTo(95.05, 6);
     expect(p!.p99).toBeCloseTo(99.01, 6);
   });
 
@@ -47,6 +48,14 @@ describe('extractIslOsl', () => {
         metrics: {
           input_sequence_length: { value: 100, unit: 'tokens' },
           output_sequence_length: { value: 50, unit: 'tokens' },
+        },
+      }),
+      // cancelled profiling record — it did not complete and must be ignored
+      JSON.stringify({
+        metadata: { benchmark_phase: 'profiling', was_cancelled: true },
+        metrics: {
+          input_sequence_length: { value: 7777, unit: 'tokens' },
+          output_sequence_length: { value: 7777, unit: 'tokens' },
         },
       }),
       JSON.stringify({

--- a/packages/db/src/queries/agentic-aggregates.ts
+++ b/packages/db/src/queries/agentic-aggregates.ts
@@ -29,9 +29,11 @@ import {
   extractIslOsl,
   fetchAggregateStatsRows,
   percentilesOf,
+  sequenceLengthSketches,
   STATS_VERSION,
   writeBackTraceReplayJsonb,
   type MetricPercentiles,
+  type SequenceLengthSketches,
 } from './agentic-shared';
 
 // STATS_VERSION, the profile extractor `extractIslOsl`, and the percentile
@@ -41,8 +43,10 @@ import {
 export {
   extractIslOsl,
   percentilesOf,
+  sequenceLengthSketches,
   STATS_VERSION,
   type MetricPercentiles,
+  type SequenceLengthSketches,
 } from './agentic-shared';
 
 export interface AgenticAggregate {
@@ -329,6 +333,7 @@ export async function getAgenticAggregates(
               kvCacheUtil: null,
               prefixCacheHitRate: null,
               e2elPerOsl: derived.e2el_per_osl,
+              sequenceLengths: sequenceLengthSketches(isl, osl),
             },
           });
         } catch {
@@ -414,6 +419,7 @@ interface FullAggregateStats {
   kvCacheUtil: MetricPercentiles | null;
   prefixCacheHitRate: MetricPercentiles | null;
   e2elPerOsl: MetricPercentiles | null;
+  sequenceLengths: SequenceLengthSketches;
 }
 
 function blankAggregate(id: number): AgenticAggregate {

--- a/packages/db/src/queries/agentic-shared.ts
+++ b/packages/db/src/queries/agentic-shared.ts
@@ -15,6 +15,11 @@
 
 import type { DbClient } from '../connection.js';
 
+import {
+  buildTokenLengthSketch,
+  type TokenLengthSketch,
+} from '@semianalysisai/inferencex-constants';
+
 /**
  * Bump when the aggregate-stats computation algorithm changes — the backfill
  * script recomputes any row whose stored `aggregate_stats.version` is older,
@@ -39,11 +44,15 @@ import type { DbClient } from '../connection.js';
  * v7: add `e2elPerOsl` — percentiles of per-request E2E latency divided by
  * OSL (seconds per output token), the inverse of the "E2E Normalized Interactivity" x-axis
  * metric.
+ *
+ * v8: add p95 and bounded mergeable ISL/OSL sketches. The dashboard merges
+ * the sketches for all resident chart points instead of loading request-level
+ * timelines or attempting to combine per-point percentiles.
  */
-export const STATS_VERSION = 7;
+export const STATS_VERSION = 8;
 
 interface ProfileRecord {
-  metadata?: { benchmark_phase?: string };
+  metadata?: { benchmark_phase?: string; was_cancelled?: boolean };
   metrics?: {
     input_sequence_length?: { value?: number } | number;
     output_sequence_length?: { value?: number } | number;
@@ -63,6 +72,7 @@ export function extractIslOsl(jsonl: string): { isl: number[]; osl: number[] } {
       continue;
     }
     if (rec.metadata?.benchmark_phase && rec.metadata.benchmark_phase !== 'profiling') continue;
+    if (rec.metadata?.was_cancelled === true) continue;
     const m = rec.metrics ?? {};
     const i = readNum(m.input_sequence_length);
     const o = readNum(m.output_sequence_length);
@@ -77,6 +87,7 @@ export interface MetricPercentiles {
   p50: number;
   p75: number;
   p90: number;
+  p95: number;
   p99: number;
   /** Sample count used to compute the percentiles. */
   n: number;
@@ -110,8 +121,24 @@ export function percentilesOf(samples: number[]): MetricPercentiles | null {
     p50: quantile(sorted, 0.5),
     p75: quantile(sorted, 0.75),
     p90: quantile(sorted, 0.9),
+    p95: quantile(sorted, 0.95),
     p99: quantile(sorted, 0.99),
     n: sorted.length,
+  };
+}
+
+export interface SequenceLengthSketches {
+  isl: TokenLengthSketch | null;
+  osl: TokenLengthSketch | null;
+}
+
+export function sequenceLengthSketches(
+  isl: readonly number[],
+  osl: readonly number[],
+): SequenceLengthSketches {
+  return {
+    isl: buildTokenLengthSketch(isl),
+    osl: buildTokenLengthSketch(osl),
   };
 }
 

--- a/packages/db/src/queries/derived-agentic-metrics.ts
+++ b/packages/db/src/queries/derived-agentic-metrics.ts
@@ -29,9 +29,11 @@ import {
   fetchAggregateStatsRows,
   percentilesOf,
   readNum,
+  sequenceLengthSketches,
   STATS_VERSION,
   writeBackTraceReplayJsonb,
   type MetricPercentiles,
+  type SequenceLengthSketches,
 } from './agentic-shared';
 
 export interface DerivedAgenticMetric {
@@ -62,6 +64,7 @@ interface StoredAggregateStats {
   kvCacheUtil: MetricPercentiles | null;
   prefixCacheHitRate: MetricPercentiles | null;
   e2elPerOsl: MetricPercentiles | null;
+  sequenceLengths: SequenceLengthSketches;
 }
 
 /**
@@ -233,6 +236,7 @@ export async function getDerivedAgenticMetrics(
           kvCacheUtil: prior?.kvCacheUtil ?? null,
           prefixCacheHitRate: prior?.prefixCacheHitRate ?? null,
           e2elPerOsl: e2el_per_osl,
+          sequenceLengths: sequenceLengthSketches(isl, osl),
         };
         writeBackTraceReplayJsonb(sql, 'aggregate_stats', Number(row.trace_replay_id), merged);
       }

--- a/packages/db/src/queries/resident-sequence-lengths.test.ts
+++ b/packages/db/src/queries/resident-sequence-lengths.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildTokenLengthSketch } from '@semianalysisai/inferencex-constants';
+
+import type { DbClient } from '../connection.js';
+import { STATS_VERSION } from './agentic-shared';
+import { getResidentSequenceLengthSketches } from './resident-sequence-lengths.js';
+
+function mockSql(rows: unknown[]): DbClient {
+  return (() => Promise.resolve(rows)) as unknown as DbClient;
+}
+
+describe('getResidentSequenceLengthSketches', () => {
+  it('merges current sketches and omits stale rows without a blob fallback', async () => {
+    const result = await getResidentSequenceLengthSketches(
+      mockSql([
+        {
+          benchmark_result_id: 1,
+          stats: {
+            version: STATS_VERSION,
+            sequenceLengths: {
+              isl: buildTokenLengthSketch([10, 20]),
+              osl: buildTokenLengthSketch([1, 2]),
+            },
+          },
+        },
+        {
+          benchmark_result_id: 2,
+          stats: {
+            version: STATS_VERSION,
+            sequenceLengths: {
+              isl: buildTokenLengthSketch([1_000]),
+              osl: buildTokenLengthSketch([100]),
+            },
+          },
+        },
+        { benchmark_result_id: 3, stats: { version: STATS_VERSION - 1 } },
+      ]),
+      [1, 2, 3],
+    );
+
+    expect(result.coveredPoints).toBe(2);
+    expect(result.requestedPoints).toBe(3);
+    expect(result.isl?.n).toBe(3);
+    expect(result.osl?.n).toBe(3);
+  });
+});

--- a/packages/db/src/queries/resident-sequence-lengths.ts
+++ b/packages/db/src/queries/resident-sequence-lengths.ts
@@ -1,0 +1,52 @@
+import {
+  mergeTokenLengthSketches,
+  type TokenLengthSketch,
+} from '@semianalysisai/inferencex-constants';
+
+import type { DbClient } from '../connection.js';
+import { fetchAggregateStatsRows, STATS_VERSION } from './agentic-shared';
+
+interface StoredStats {
+  version: number;
+  sequenceLengths?: {
+    isl: TokenLengthSketch | null;
+    osl: TokenLengthSketch | null;
+  };
+}
+
+export interface ResidentSequenceLengthSketches {
+  isl: TokenLengthSketch | null;
+  osl: TokenLengthSketch | null;
+  /** Resident benchmark points represented by current-version sketches. */
+  coveredPoints: number;
+  requestedPoints: number;
+}
+
+/**
+ * Merge the precomputed request-length sketches for a bounded set of chart
+ * points. There is deliberately no raw-blob fallback here: a stale row is
+ * omitted until the versioned backfill reaches it rather than making a chart
+ * load decompress multi-megabyte request profiles.
+ */
+export async function getResidentSequenceLengthSketches(
+  sql: DbClient,
+  benchmarkResultIds: number[],
+): Promise<ResidentSequenceLengthSketches> {
+  if (benchmarkResultIds.length === 0) {
+    return { isl: null, osl: null, coveredPoints: 0, requestedPoints: 0 };
+  }
+
+  const rows = await fetchAggregateStatsRows<StoredStats>(sql, benchmarkResultIds);
+  const current = rows.filter(
+    (row) =>
+      row.stats?.version === STATS_VERSION &&
+      Boolean(row.stats.sequenceLengths?.isl || row.stats.sequenceLengths?.osl),
+  );
+
+  return {
+    isl: mergeTokenLengthSketches(current.map((row) => row.stats?.sequenceLengths?.isl)),
+    osl: mergeTokenLengthSketches(current.map((row) => row.stats?.sequenceLengths?.osl)),
+    coveredPoints: current.length,
+    requestedPoints: benchmarkResultIds.length,
+  };
+}


### PR DESCRIPTION
## Summary

- precompute bounded, mergeable ISL and OSL distributions for completed profiling requests
- pool request-weighted p50, p75, p90, p95, and p99 values across every point resident in the current agentic chart
- show the pooled values and locale-formatted completed-request count beneath each graph without changing them when legend series are hidden
- exclude cancelled requests and add p95 to the existing per-point aggregate response
- stream oversized compressed profiles during backfills so very large artifacts do not exceed the database driver or Node memory limits

## Data path

This reuses the versioned `agentic_trace_replay.aggregate_stats` JSONB column, so no SQL schema migration is required. `STATS_VERSION` advances to 8 and the existing aggregate-stats backfill populates sequence-length sketches from profile artifacts. The chart endpoint only reads and merges those bounded sketches. It never decompresses request profiles during page load.

The subtitle is withheld until every resident point has current-version stats, so a partial backfill cannot be mislabeled as the complete resident distribution. Unofficial-run profiles are not persisted in the database, so the subtitle is intentionally suppressed while an `?unofficialrun=` overlay is active.

Oversized profile blobs are fetched from PostgreSQL in 8 MiB slices and fed directly into a streaming gzip/JSONL reader. Normal-sized profiles retain the single-read path.

## Preview data

- temporary Neon branch: `pr-811-resident-sequence-lengths` (`br-red-rain-aiszml5n`), expires 2026-08-24
- schema migration checked successfully; no new SQL migration was required
- aggregate-stats v8 backfill completed for 918/918 profile rows
- preview-only Vercel database variables point this Git branch at the temporary Neon branch; production variables are unchanged
- [Vercel preview](https://inferencemax-app-git-feat-chart-sequence-d4becd-semianalysisai.vercel.app)

## Verification

- `bun run test:unit` — 4,373 tests passed
- `bun run typecheck`
- `bun run lint`
- `bun run fmt`
- `bun run build`
- dedicated Cypress coverage passed for resident-point pooling, legend independence, and unofficial overlays
- deployed API verified for point 439331 with 1/1 coverage and 134,049 completed requests
- deployed API verified for the four oversized points with 4/4 coverage and 323,423 pooled requests
- the broader smoke suite reaches the new flow; unrelated baseline failures remain in the existing quick-filter assertion and GB300 dark-theme contrast checks

## Production rollout

- created restore branch `backup-pr-811-pre-backfill-2026-08-21` (`br-icy-bird-aicde3o6`), expiring after seven days
- verified the production migration ledger; all SQL migrations were already applied
- completed the aggregate-stats v8 backfill for 918/918 rows with 0 failures
- verified 0 stale rows and sequence sketches on all 918 profile rows

