### PR TITLE
feat(inference): restore restricted agentic quick filters / 恢复受限的 agentic 快捷筛选

### DIFF
--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -1,5 +1,4 @@
 import InferenceChartControls from '@/components/inference/ui/ChartControls';
-import { Sequence } from '@/lib/data-mappings';
 import { mountWithProviders } from '../support/test-utils';
 
 describe('Inference ChartControls', () => {
@@ -23,16 +22,6 @@ describe('Inference ChartControls', () => {
     // Default mock: selectedPrecisions = [Precision.FP4] -> label "FP4"
     cy.get('[data-testid="precision-multiselect"]').should('be.visible');
     cy.get('[data-testid="precision-multiselect"]').should('contain.text', 'FP4');
-  });
-
-  it('keeps Quick Filters collapsed until the reader expands them', () => {
-    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'false');
-    cy.get('[data-testid="quick-filter-spec-mtp"]').should('not.exist');
-
-    cy.get('[data-testid="quick-filters-trigger"]').click();
-
-    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'true');
-    cy.get('[data-testid="quick-filter-spec-mtp"]').should('exist');
   });
 
   it('renders the Y-axis metric selector', () => {
@@ -168,38 +157,5 @@ describe('Inference ChartControls with hideGpuComparison', () => {
 
     cy.contains('Chip Config').should('not.exist');
     cy.get('[data-testid="gpu-multiselect"]').should('not.exist');
-    cy.get('[data-testid="quick-filters"]').should('not.exist');
-  });
-});
-
-describe('Inference ChartControls in the agentic scenario', () => {
-  beforeEach(() => {
-    mountWithProviders(<InferenceChartControls />, {
-      inference: {
-        selectedSequence: Sequence.AgenticTraces,
-        availableQuickFilters: {
-          vendors: ['NVIDIA', 'AMD'],
-          frameworks: ['vllm', 'sglang'],
-          deployment: ['single-node', 'multi-node', 'disagg'],
-          spec: ['mtp', 'stp'],
-        },
-      },
-      globalFilters: {
-        selectedSequence: Sequence.AgenticTraces,
-        effectiveSequence: Sequence.AgenticTraces,
-      },
-    });
-  });
-
-  it('offers vendor, framework, and deployment filters but not spec decoding', () => {
-    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'false');
-    cy.get('[data-testid="quick-filters-trigger"]').click();
-
-    cy.get('[data-testid="quick-filter-vendor-NVIDIA"]').click();
-    cy.get('@setQuickFilterVendors').should('have.been.calledWith', ['NVIDIA']);
-    cy.get('[data-testid="quick-filter-framework-vllm"]').should('exist');
-    cy.get('[data-testid="quick-filter-deployment-disagg"]').should('exist');
-    cy.get('[data-testid^="quick-filter-spec-"]').should('not.exist');
-    cy.contains('Spec Decoding').should('not.exist');
   });
 });

--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -25,8 +25,14 @@ describe('Inference ChartControls', () => {
     cy.get('[data-testid="precision-multiselect"]').should('contain.text', 'FP4');
   });
 
-  it('renders Quick Filters for a fixed-sequence scenario', () => {
-    cy.get('[data-testid="quick-filters"]').should('exist');
+  it('keeps Quick Filters collapsed until the reader expands them', () => {
+    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'false');
+    cy.get('[data-testid="quick-filter-spec-mtp"]').should('not.exist');
+
+    cy.get('[data-testid="quick-filters-trigger"]').click();
+
+    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid="quick-filter-spec-mtp"]').should('exist');
   });
 
   it('renders the Y-axis metric selector', () => {
@@ -162,25 +168,38 @@ describe('Inference ChartControls with hideGpuComparison', () => {
 
     cy.contains('Chip Config').should('not.exist');
     cy.get('[data-testid="gpu-multiselect"]').should('not.exist');
+    cy.get('[data-testid="quick-filters"]').should('not.exist');
+  });
+});
+
+describe('Inference ChartControls in the agentic scenario', () => {
+  beforeEach(() => {
+    mountWithProviders(<InferenceChartControls />, {
+      inference: {
+        selectedSequence: Sequence.AgenticTraces,
+        availableQuickFilters: {
+          vendors: ['NVIDIA', 'AMD'],
+          frameworks: ['vllm', 'sglang'],
+          deployment: ['single-node', 'multi-node', 'disagg'],
+          spec: ['mtp', 'stp'],
+        },
+      },
+      globalFilters: {
+        selectedSequence: Sequence.AgenticTraces,
+        effectiveSequence: Sequence.AgenticTraces,
+      },
+    });
   });
 
-  describe('agentic scenario', () => {
-    beforeEach(() => {
-      mountWithProviders(<InferenceChartControls />, {
-        inference: { selectedSequence: Sequence.AgenticTraces },
-        globalFilters: {
-          selectedSequence: Sequence.AgenticTraces,
-          effectiveSequence: Sequence.AgenticTraces,
-        },
-      });
-    });
+  it('offers vendor, framework, and deployment filters but not spec decoding', () => {
+    cy.get('[data-testid="quick-filters-trigger"]').should('have.attr', 'aria-expanded', 'false');
+    cy.get('[data-testid="quick-filters-trigger"]').click();
 
-    it('drops Quick Filters, which have nothing to slice on one combined curve', () => {
-      // AgentX collapses vendor, framework, deployment, and spec decoding into
-      // a single best-available curve per model, SKU, and engine, so the pills
-      // would filter dimensions the chart no longer separates.
-      cy.get('#scenario-select').should('exist');
-      cy.get('[data-testid="quick-filters"]').should('not.exist');
-    });
+    cy.get('[data-testid="quick-filter-vendor-NVIDIA"]').click();
+    cy.get('@setQuickFilterVendors').should('have.been.calledWith', ['NVIDIA']);
+    cy.get('[data-testid="quick-filter-framework-vllm"]').should('exist');
+    cy.get('[data-testid="quick-filter-deployment-disagg"]').should('exist');
+    cy.get('[data-testid^="quick-filter-spec-"]').should('not.exist');
+    cy.contains('Spec Decoding').should('not.exist');
   });
 });

--- a/packages/app/cypress/component/quick-filters-dialog.cy.tsx
+++ b/packages/app/cypress/component/quick-filters-dialog.cy.tsx
@@ -1,0 +1,61 @@
+import { QuickFiltersDialog } from '@/components/inference/ui/QuickFiltersDialog';
+import type { QuickFilters } from '@/components/inference/types';
+import { Sequence } from '@/lib/data-mappings';
+import { mountWithProviders } from '../support/test-utils';
+
+const availableQuickFilters: QuickFilters = {
+  vendors: ['NVIDIA', 'AMD'],
+  frameworks: ['vllm', 'sglang'],
+  deployment: ['single-node', 'multi-node', 'disagg'],
+  spec: ['mtp', 'stp'],
+};
+
+describe('QuickFiltersDialog', () => {
+  it('shows every filter group for fixed-sequence charts', () => {
+    mountWithProviders(<QuickFiltersDialog open onOpenChange={cy.stub()} />, {
+      inference: { availableQuickFilters },
+    });
+
+    cy.get('[data-testid="quick-filters-dialog"]').should('be.visible');
+    cy.get('[data-testid="quick-filter-vendor-NVIDIA"]').should('exist');
+    cy.get('[data-testid="quick-filter-framework-vllm"]').should('exist');
+    cy.get('[data-testid="quick-filter-deployment-disagg"]').should('exist');
+    cy.get('[data-testid="quick-filter-spec-mtp"]').should('exist');
+  });
+
+  it('removes speculative decoding from agentic charts and toggles supported filters', () => {
+    mountWithProviders(<QuickFiltersDialog open onOpenChange={cy.stub()} />, {
+      inference: {
+        selectedSequence: Sequence.AgenticTraces,
+        availableQuickFilters,
+      },
+    });
+
+    cy.get('[data-testid="quick-filter-vendor-NVIDIA"]').click();
+    cy.get('@setQuickFilterVendors').should('have.been.calledWith', ['NVIDIA']);
+    cy.get('[data-testid="quick-filter-framework-vllm"]').should('exist');
+    cy.get('[data-testid="quick-filter-deployment-disagg"]').should('exist');
+    cy.get('[data-testid^="quick-filter-spec-"]').should('not.exist');
+    cy.contains('Spec Decoding').should('not.exist');
+  });
+
+  it('clears every filter category from one action', () => {
+    mountWithProviders(<QuickFiltersDialog open onOpenChange={cy.stub()} />, {
+      inference: {
+        quickFilters: {
+          vendors: ['AMD'],
+          frameworks: ['sglang'],
+          deployment: ['disagg'],
+          spec: ['mtp'],
+        },
+        availableQuickFilters,
+      },
+    });
+
+    cy.contains('button', 'Clear filters').click();
+    cy.get('@setQuickFilterVendors').should('have.been.calledWith', []);
+    cy.get('@setQuickFilterFrameworks').should('have.been.calledWith', []);
+    cy.get('@setQuickFilterDeployment').should('have.been.calledWith', []);
+    cy.get('@setQuickFilterSpec').should('have.been.calledWith', []);
+  });
+});

--- a/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
+++ b/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
@@ -122,5 +122,32 @@ describe('Agentic Quick Filters', () => {
     cy.get('.dot-group[data-hw-key^="b200"]').should('not.exist');
     cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
     cy.get('[data-testid="quick-filters-selected-count"]').should('contain.text', '1 selected');
+
+    // An incompatible cross-group selection produces zero points. The dialog
+    // must stay mounted so the reader can recover without reloading the page.
+    cy.get('[data-testid="quick-filter-framework-vllm"]').click();
+    cy.get('[data-testid="scatter-empty-quick-filters"]').should('exist');
+    cy.get('[data-testid="quick-filters-dialog"]').should('be.visible');
+
+    cy.contains('button', 'Clear filters').click();
+    cy.get('.dot-group[data-hw-key^="b200"]').should('exist');
+    cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
+    cy.get('[data-testid="quick-filters-selected-count"]').should('not.exist');
+  });
+
+  it('clears Quick Filters from the legend reset action', () => {
+    visitAgenticQuickFilters();
+
+    cy.get('[data-testid="scatter-quick-filters"]').click();
+    cy.get('[data-testid="quick-filter-vendor-AMD"]').click();
+    cy.contains('button', 'Done').click();
+
+    cy.get('.dot-group[data-hw-key^="b200"]').should('not.exist');
+    cy.get('[data-testid="scatter-reset-filter"]').click();
+    cy.get('.dot-group[data-hw-key^="b200"]').should('exist');
+    cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
+
+    cy.get('[data-testid="scatter-quick-filters"]').click();
+    cy.get('[data-testid="quick-filter-vendor-AMD"]').should('have.attr', 'aria-pressed', 'false');
   });
 });

--- a/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
+++ b/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
@@ -1,0 +1,128 @@
+import { unlockAgenticGate } from '../support/e2e';
+
+const MODEL = 'dsv4';
+const DATE = '2026-06-12';
+
+const percentileLadder = (prefix: string, base: number): Record<string, number> => ({
+  [`median_${prefix}`]: base,
+  [`p75_${prefix}`]: base * 1.2,
+  [`p90_${prefix}`]: base * 1.5,
+  [`p95_${prefix}`]: base * 1.7,
+  [`p99_${prefix}`]: base * 2.2,
+  [`std_${prefix}`]: base * 0.3,
+});
+
+const metrics = (conc: number): Record<string, number> => {
+  const scale = conc / 16;
+  const itl = 0.011 * scale;
+  return {
+    ...percentileLadder('ttft', 0.4 * scale),
+    ...percentileLadder('tpot', 0.012 * scale),
+    ...percentileLadder('itl', itl),
+    ...percentileLadder('e2el', 8 * scale),
+    median_intvty: 1 / itl,
+    p75_intvty: 1 / (itl * 1.2),
+    p90_intvty: 1 / (itl * 1.5),
+    p99_intvty: 1 / (itl * 2.2),
+    std_intvty: (1 / itl) * 0.1,
+    tput_per_gpu: 950 / Math.sqrt(scale),
+    output_tput_per_gpu: 210,
+    input_tput_per_gpu: 740,
+    total_tput_tps: 380 * conc,
+  };
+};
+
+const configs = [
+  { hardware: 'b200', framework: 'vllm', disagg: false },
+  { hardware: 'mi300x', framework: 'sglang', disagg: true },
+];
+
+const availability = [
+  ...configs.map((config) => ({
+    model: MODEL,
+    isl: null,
+    osl: null,
+    precision: 'fp4',
+    hardware: config.hardware,
+    framework: config.framework,
+    spec_method: 'mtp',
+    disagg: config.disagg,
+    benchmark_type: 'agentic_traces',
+    date: DATE,
+  })),
+  ...configs.map((config) => ({
+    model: MODEL,
+    isl: 8192,
+    osl: 1024,
+    precision: 'fp4',
+    hardware: config.hardware,
+    framework: config.framework,
+    spec_method: 'none',
+    disagg: config.disagg,
+    benchmark_type: 'single_turn',
+    date: DATE,
+  })),
+];
+
+let benchmarkId = 980000;
+const benchmarks = configs.flatMap((config) =>
+  [16, 64, 128].map((conc) => ({
+    id: benchmarkId++,
+    ...config,
+    model: MODEL,
+    precision: 'fp4',
+    spec_method: 'mtp',
+    is_multinode: false,
+    prefill_tp: 8,
+    decode_tp: 8,
+    num_prefill_gpu: 8,
+    num_decode_gpu: 8,
+    isl: null,
+    osl: null,
+    conc,
+    offload_mode: 'off',
+    benchmark_type: 'agentic_traces',
+    image: `${config.framework}/server:test`,
+    metrics: metrics(conc),
+    workers: null,
+    date: DATE,
+    run_url: null,
+  })),
+);
+
+function visitAgenticQuickFilters() {
+  cy.intercept('GET', '/api/v1/availability', { body: availability }).as('availability');
+  cy.intercept('GET', '/api/v1/benchmarks*', { body: benchmarks }).as('benchmarks');
+  cy.visit('/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4&i_spec=mtp', {
+    onBeforeLoad(win) {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      unlockAgenticGate(win);
+    },
+  });
+  cy.wait(['@availability', '@benchmarks']);
+  cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
+}
+
+describe('Agentic Quick Filters', () => {
+  it('starts collapsed, omits spec decoding, and filters the rendered agentic points', () => {
+    visitAgenticQuickFilters();
+
+    // A stale speculative-decoding URL selection is ignored for agentic data.
+    cy.get('.dot-group[data-hw-key^="b200"]').should('exist');
+    cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
+    cy.get('[data-testid="quick-filters-selected-count"]').should('not.exist');
+
+    cy.get('[data-testid="quick-filters-trigger"]')
+      .should('have.attr', 'aria-expanded', 'false')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
+
+    cy.get('[data-testid^="quick-filter-spec-"]').should('not.exist');
+    cy.contains('Spec Decoding').should('not.exist');
+
+    cy.get('[data-testid="quick-filter-vendor-AMD"]').click();
+    cy.get('.dot-group[data-hw-key^="b200"]').should('not.exist');
+    cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
+    cy.get('[data-testid="quick-filters-selected-count"]').should('contain.text', '1 selected');
+  });
+});

--- a/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
+++ b/packages/app/cypress/e2e/agentic-quick-filters.cy.ts
@@ -104,18 +104,16 @@ function visitAgenticQuickFilters() {
 }
 
 describe('Agentic Quick Filters', () => {
-  it('starts collapsed, omits spec decoding, and filters the rendered agentic points', () => {
+  it('opens from the legend, omits spec decoding, and filters the rendered agentic points', () => {
     visitAgenticQuickFilters();
 
     // A stale speculative-decoding URL selection is ignored for agentic data.
     cy.get('.dot-group[data-hw-key^="b200"]').should('exist');
     cy.get('.dot-group[data-hw-key^="mi300x"]').should('exist');
+    cy.get('[data-testid="quick-filters-dialog"]').should('not.exist');
+    cy.get('[data-testid="scatter-quick-filters"]').should('contain.text', 'Quick Filters').click();
+    cy.get('[data-testid="quick-filters-dialog"]').should('be.visible');
     cy.get('[data-testid="quick-filters-selected-count"]').should('not.exist');
-
-    cy.get('[data-testid="quick-filters-trigger"]')
-      .should('have.attr', 'aria-expanded', 'false')
-      .click()
-      .should('have.attr', 'aria-expanded', 'true');
 
     cy.get('[data-testid^="quick-filter-spec-"]').should('not.exist');
     cy.contains('Spec Decoding').should('not.exist');

--- a/packages/app/cypress/e2e/inference-chart.cy.ts
+++ b/packages/app/cypress/e2e/inference-chart.cy.ts
@@ -59,6 +59,10 @@ describe('Inference Chart', () => {
 
   it('renders quick filters and toggles a vendor pill', () => {
     cy.get('[data-testid="quick-filters"]').should('exist');
+    cy.get('[data-testid="quick-filters-trigger"]')
+      .should('have.attr', 'aria-expanded', 'false')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
     cy.get('[data-testid="quick-filter-deployment-single-node"]').should('contain', 'Single-node');
     cy.get('[data-testid="quick-filter-deployment-multi-node"]').should('contain', 'Multi-node');
     cy.get('[data-testid="quick-filter-deployment-disagg"]').should('contain', 'Disaggregated');

--- a/packages/app/cypress/e2e/inference-chart.cy.ts
+++ b/packages/app/cypress/e2e/inference-chart.cy.ts
@@ -58,11 +58,9 @@ describe('Inference Chart', () => {
   });
 
   it('renders quick filters and toggles a vendor pill', () => {
-    cy.get('[data-testid="quick-filters"]').should('exist');
-    cy.get('[data-testid="quick-filters-trigger"]')
-      .should('have.attr', 'aria-expanded', 'false')
-      .click()
-      .should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid="quick-filters-dialog"]').should('not.exist');
+    cy.get('[data-testid="scatter-quick-filters"]').click();
+    cy.get('[data-testid="quick-filters-dialog"]').should('be.visible');
     cy.get('[data-testid="quick-filter-deployment-single-node"]').should('contain', 'Single-node');
     cy.get('[data-testid="quick-filter-deployment-multi-node"]').should('contain', 'Multi-node');
     cy.get('[data-testid="quick-filter-deployment-disagg"]').should('contain', 'Disaggregated');

--- a/packages/app/cypress/e2e/tokens-per-currency.cy.ts
+++ b/packages/app/cypress/e2e/tokens-per-currency.cy.ts
@@ -1,8 +1,7 @@
 /**
  * The dashboard now opens on tokens purchasable per $1 USD, and the same
- * quantities are also available priced in yuan. Quick Filters drop out of the
- * agentic scenario, where the curve is already collapsed to one series per
- * model, SKU, and engine.
+ * quantities are also available priced in yuan. Fixed-sequence Quick Filters
+ * remain available through their collapsed disclosure.
  */
 describe('Tokens per currency and agentic controls', () => {
   beforeEach(() => {
@@ -44,11 +43,11 @@ describe('Tokens per currency and agentic controls', () => {
   });
 
   it('keeps Quick Filters for a fixed-sequence scenario', () => {
-    // The agentic half of this rule lives in
-    // cypress/component/inference-chart-controls.cy.tsx: `?i_seq=agentic-traces`
-    // only sticks when the model has agentic availability, which the e2e
-    // fixture set does not carry, so the sequence falls back here.
     cy.visit('/inference?i_seq=8k%2F1k');
-    cy.get('[data-testid="quick-filters"]').should('exist');
+    cy.get('[data-testid="quick-filters-trigger"]')
+      .should('have.attr', 'aria-expanded', 'false')
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid="quick-filter-spec-mtp"]').should('exist');
   });
 });

--- a/packages/app/cypress/e2e/tokens-per-currency.cy.ts
+++ b/packages/app/cypress/e2e/tokens-per-currency.cy.ts
@@ -1,7 +1,7 @@
 /**
  * The dashboard now opens on tokens purchasable per $1 USD, and the same
  * quantities are also available priced in yuan. Fixed-sequence Quick Filters
- * remain available through their collapsed disclosure.
+ * remain available from the chart legend.
  */
 describe('Tokens per currency and agentic controls', () => {
   beforeEach(() => {
@@ -44,10 +44,8 @@ describe('Tokens per currency and agentic controls', () => {
 
   it('keeps Quick Filters for a fixed-sequence scenario', () => {
     cy.visit('/inference?i_seq=8k%2F1k');
-    cy.get('[data-testid="quick-filters-trigger"]')
-      .should('have.attr', 'aria-expanded', 'false')
-      .click()
-      .should('have.attr', 'aria-expanded', 'true');
+    cy.get('[data-testid="scatter-quick-filters"]').click();
+    cy.get('[data-testid="quick-filters-dialog"]').should('be.visible');
     cy.get('[data-testid="quick-filter-spec-mtp"]').should('exist');
   });
 });

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -319,16 +319,19 @@ export function InferenceProvider({
     }),
     [quickFilterVendors, quickFilterFrameworks, quickFilterDeployment, quickFilterSpec],
   );
-  // The Historical Trends tab hides the quick-filter pills (hideGpuComparison), so
-  // don't silently narrow its chart with selections carried in via share links or
-  // the inference tab — there would be no pill to clear them.
-  // Quick Filters are hidden on the historical tab and in the agentic scenario.
-  // Hiding the pills is not enough: leftover `i_vendor` / `i_fw` / `i_disagg` /
-  // `i_spec` state would keep slicing the chart with no control left to clear
-  // it, so a share link could drop series the reader cannot get back.
-  const quickFiltersHidden =
-    activeTab === 'historical' || effectiveSequence === Sequence.AgenticTraces;
-  const dataQuickFilters = quickFiltersHidden ? EMPTY_QUICK_FILTERS : quickFilters;
+  // Historical Trends hides Quick Filters, so never apply invisible selections there.
+  // Agentic charts expose vendor, framework, and deployment filters, but speculative
+  // decoding is intentionally not an agentic option. Ignore stale `i_spec` state from
+  // an older shared URL without discarding it when the reader returns to fixed-seq.
+  const dataQuickFilters = useMemo(
+    () =>
+      activeTab === 'historical'
+        ? EMPTY_QUICK_FILTERS
+        : effectiveSequence === Sequence.AgenticTraces
+          ? { ...quickFilters, spec: [] }
+          : quickFilters,
+    [activeTab, effectiveSequence, quickFilters],
+  );
   const { highContrast, setHighContrast, isLegendExpanded, setIsLegendExpanded } = useChartUIState({
     urlPrefix: 'i_',
   });

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -4,7 +4,6 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { track } from '@/lib/analytics';
 import { useFeatureGate } from '@/lib/use-feature-gate';
-import { cn } from '@/lib/utils';
 
 import { useInference } from '@/components/inference/InferenceContext';
 import {
@@ -25,16 +24,8 @@ import {
 } from '@/components/ui/select';
 import { SearchableSelect } from '@/components/ui/searchable-select';
 import { TooltipProvider } from '@/components/ui/tooltip';
-import { Button } from '@/components/ui/button';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
 import chartDefinitions from '@/components/inference/inference-chart-config.json';
-import type { ChartDefinition, DeploymentMode, SpecMode } from '@/components/inference/types';
-import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
+import type { ChartDefinition } from '@/components/inference/types';
 import { Sequence, type Model, type Percentile } from '@/lib/data-mappings';
 import { useLocale } from '@/lib/use-locale';
 
@@ -60,20 +51,6 @@ const STRINGS = {
     comparisonDateRangeTooltip:
       'Select the start and end dates for the historical comparison. The chart will show performance data for the selected chip configs across this time range.',
     dateRangePlaceholder: 'Select date range',
-    quickFilters: 'Quick Filters',
-    quickFiltersTooltip:
-      'Narrow the chart by chip vendor, serving framework, deployment mode (single-node, multi-node aggregate, or disaggregated), and speculative decoding. Selecting none in a group shows all.',
-    quickFiltersAgenticTooltip:
-      'Narrow the chart by chip vendor, serving framework, and deployment mode. Selecting none in a group shows all.',
-    filtersSelected: 'selected',
-    filterVendor: 'Vendor',
-    filterFramework: 'Framework',
-    filterDeployment: 'Deployment',
-    singleNode: 'Single-node',
-    multiNode: 'Multi-node',
-    disaggregated: 'Disaggregated',
-    filterSpecDecoding: 'Spec Decoding',
-    noData: 'No data for the current selection',
   },
   zh: {
     yAxisMetric: 'Y 轴指标',
@@ -95,19 +72,6 @@ const STRINGS = {
     comparisonDateRangeTooltip:
       '选择历史对比的起止日期。图表将展示所选 Chip 配置在此时间范围内的性能数据。',
     dateRangePlaceholder: '选择日期范围',
-    quickFilters: '快捷筛选',
-    quickFiltersTooltip:
-      '按 Chip 厂商、推理框架、部署模式（单节点、多节点聚合或分离式）和投机解码筛选图表。某组不选则显示全部。',
-    quickFiltersAgenticTooltip: '按 Chip 厂商、推理框架和部署模式筛选图表。某组不选则显示全部。',
-    filtersSelected: '项已选',
-    filterVendor: '厂商',
-    filterFramework: '框架',
-    filterDeployment: '部署模式',
-    singleNode: '单节点',
-    multiNode: '多节点聚合',
-    disaggregated: '分离式',
-    filterSpecDecoding: '投机解码',
-    noData: '当前选择无可用数据',
   },
 } as const;
 
@@ -233,22 +197,6 @@ const METRIC_TITLE_ZH_MAP = (() => {
   return map;
 })();
 
-/** Quick-filter pill groups: vendor, deployment mode, spec-decoding method. */
-const QUICK_FILTER_VENDORS: { value: string; label: string }[] = [
-  { value: 'NVIDIA', label: 'NVIDIA' },
-  { value: 'AMD', label: 'AMD' },
-];
-const QUICK_FILTER_DEPLOYMENT: DeploymentMode[] = ['single-node', 'multi-node', 'disagg'];
-const QUICK_FILTER_SPEC: { value: SpecMode; label: string }[] = [
-  { value: 'mtp', label: 'MTP' },
-  { value: 'stp', label: 'STP' },
-];
-
-/** Toggle a value in/out of a quick-filter selection array. */
-function toggleValue<T extends string>(current: T[], value: T): T[] {
-  return current.includes(value) ? current.filter((v) => v !== value) : [...current, value];
-}
-
 interface ChartControlsProps {
   /** Hide GPU Config selector and related date pickers (used by Historical Trends tab) */
   hideGpuComparison?: boolean;
@@ -299,12 +247,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
     setSelectedXAxisMetric,
     scaleType,
     setScaleType,
-    quickFilters,
-    availableQuickFilters,
-    setQuickFilterVendors,
-    setQuickFilterFrameworks,
-    setQuickFilterDeployment,
-    setQuickFilterSpec,
   } = useInference();
 
   // Y-axis metric options — built from static chart config JSON (no API dependency).
@@ -409,28 +351,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
     });
   };
 
-  const handleQuickFilterToggle = (
-    category: 'vendor' | 'framework' | 'deployment' | 'spec',
-    value: string,
-  ) => {
-    const wasActive =
-      category === 'vendor'
-        ? quickFilters.vendors.includes(value)
-        : category === 'framework'
-          ? quickFilters.frameworks.includes(value)
-          : category === 'deployment'
-            ? quickFilters.deployment.includes(value as DeploymentMode)
-            : quickFilters.spec.includes(value as SpecMode);
-    if (category === 'vendor') setQuickFilterVendors(toggleValue(quickFilters.vendors, value));
-    else if (category === 'framework')
-      setQuickFilterFrameworks(toggleValue(quickFilters.frameworks, value));
-    else if (category === 'deployment')
-      setQuickFilterDeployment(toggleValue(quickFilters.deployment, value as DeploymentMode));
-    else setQuickFilterSpec(toggleValue(quickFilters.spec, value as SpecMode));
-    // `active` is the state *after* this toggle.
-    track('inference_quick_filter_toggled', { category, value, active: !wasActive });
-  };
-
   const isInputMetric = (() => {
     const chartDef = graphs[0]?.chartDefinition;
     if (!chartDef) return false;
@@ -446,78 +366,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
       endDate: range.endDate,
     });
   };
-
-  // Quick-filter pill groups. Each option carries an `available` flag (has data
-  // for the current model); the render disables unavailable options unless they
-  // are currently selected, so a selection can always be toggled back off. The
-  // Framework group is data-driven — only families present (or selected) are
-  // offered, so it's omitted entirely when none resolve (e.g. while data loads).
-  const fwSelected = quickFilters.frameworks;
-  const frameworkOptions = FRAMEWORK_FAMILIES.filter(
-    (f) => availableQuickFilters.frameworks.includes(f.key) || fwSelected.includes(f.key),
-  ).map((f) => ({
-    value: f.key,
-    label: f.label,
-    available: availableQuickFilters.frameworks.includes(f.key),
-  }));
-  const quickFilterGroups: {
-    key: 'vendor' | 'framework' | 'deployment' | 'spec';
-    label: string;
-    options: readonly { value: string; label: string; available: boolean }[];
-    selected: readonly string[];
-  }[] = [
-    {
-      key: 'vendor',
-      label: t.filterVendor,
-      options: QUICK_FILTER_VENDORS.map((o) => ({
-        ...o,
-        available: availableQuickFilters.vendors.includes(o.value),
-      })),
-      selected: quickFilters.vendors,
-    },
-    ...(frameworkOptions.length > 0
-      ? [
-          {
-            key: 'framework' as const,
-            label: t.filterFramework,
-            options: frameworkOptions,
-            selected: quickFilters.frameworks,
-          },
-        ]
-      : []),
-    {
-      key: 'deployment',
-      label: t.filterDeployment,
-      options: QUICK_FILTER_DEPLOYMENT.map((value) => ({
-        value,
-        label:
-          value === 'single-node'
-            ? t.singleNode
-            : value === 'multi-node'
-              ? t.multiNode
-              : t.disaggregated,
-        available: availableQuickFilters.deployment.includes(value),
-      })),
-      selected: quickFilters.deployment,
-    },
-    {
-      key: 'spec',
-      label: t.filterSpecDecoding,
-      options: QUICK_FILTER_SPEC.map((o) => ({
-        ...o,
-        available: availableQuickFilters.spec.includes(o.value),
-      })),
-      selected: quickFilters.spec,
-    },
-  ];
-  const isAgentic = selectedSequence === Sequence.AgenticTraces;
-  const visibleQuickFilterGroups = isAgentic
-    ? quickFilterGroups.filter((group) => group.key !== 'spec')
-    : quickFilterGroups;
-  const selectedQuickFilterCount = visibleQuickFilterGroups.reduce(
-    (count, group) => count + group.selected.length,
-    0,
-  );
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -674,77 +522,6 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
             </div>
           )}
         </div>
-
-        {!hideGpuComparison && (
-          <Accordion type="single" collapsible data-testid="quick-filters">
-            <AccordionItem value="quick-filters" className="overflow-hidden">
-              <AccordionTrigger
-                className="items-center px-3 py-2.5 text-sm hover:no-underline"
-                data-testid="quick-filters-trigger"
-                onClick={() => track('inference_quick_filters_disclosure_toggled')}
-              >
-                <span className="flex min-w-0 flex-col gap-0.5">
-                  <span className="flex items-center gap-2">
-                    <span>{t.quickFilters}</span>
-                    {selectedQuickFilterCount > 0 && (
-                      <span
-                        className="rounded-full bg-brand/10 px-2 py-0.5 text-[11px] font-medium text-brand"
-                        data-testid="quick-filters-selected-count"
-                      >
-                        {selectedQuickFilterCount} {t.filtersSelected}
-                      </span>
-                    )}
-                  </span>
-                  <span className="text-xs font-normal text-muted-foreground">
-                    {isAgentic ? t.quickFiltersAgenticTooltip : t.quickFiltersTooltip}
-                  </span>
-                </span>
-              </AccordionTrigger>
-              <AccordionContent className="border-t pt-4">
-                <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
-                  {visibleQuickFilterGroups.map((group) => (
-                    <div key={group.key} className="flex items-center gap-1.5">
-                      <span className="text-xs font-medium text-muted-foreground">
-                        {group.label}:
-                      </span>
-                      <div className="flex flex-wrap gap-1">
-                        {group.options.map((option) => {
-                          const active = (group.selected as readonly string[]).includes(
-                            option.value,
-                          );
-                          // Disable options with no data, but keep a selected one
-                          // clickable so it can always be toggled back off.
-                          const disabled = !option.available && !active;
-                          return (
-                            <Button
-                              key={option.value}
-                              type="button"
-                              size="sm"
-                              variant={active ? 'default' : 'outline'}
-                              aria-pressed={active}
-                              disabled={disabled}
-                              title={disabled ? t.noData : undefined}
-                              // Active pills use the brand color (blue in light, amber in dark)
-                              // rather than the amber primary fill.
-                              className={cn(
-                                'h-7 rounded-full px-3 text-xs',
-                                active && 'bg-brand hover:bg-brand/90',
-                              )}
-                              data-testid={`quick-filter-${group.key}-${option.value}`}
-                              onClick={() => handleQuickFilterToggle(group.key, option.value)}
-                            >
-                              {option.label}
-                            </Button>
-                          );
-                        })}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        )}
       </div>
     </TooltipProvider>
   );

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -26,6 +26,12 @@ import {
 import { SearchableSelect } from '@/components/ui/searchable-select';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Button } from '@/components/ui/button';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import chartDefinitions from '@/components/inference/inference-chart-config.json';
 import type { ChartDefinition, DeploymentMode, SpecMode } from '@/components/inference/types';
 import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
@@ -57,6 +63,9 @@ const STRINGS = {
     quickFilters: 'Quick Filters',
     quickFiltersTooltip:
       'Narrow the chart by chip vendor, serving framework, deployment mode (single-node, multi-node aggregate, or disaggregated), and speculative decoding. Selecting none in a group shows all.',
+    quickFiltersAgenticTooltip:
+      'Narrow the chart by chip vendor, serving framework, and deployment mode. Selecting none in a group shows all.',
+    filtersSelected: 'selected',
     filterVendor: 'Vendor',
     filterFramework: 'Framework',
     filterDeployment: 'Deployment',
@@ -89,6 +98,8 @@ const STRINGS = {
     quickFilters: '快捷筛选',
     quickFiltersTooltip:
       '按 Chip 厂商、推理框架、部署模式（单节点、多节点聚合或分离式）和投机解码筛选图表。某组不选则显示全部。',
+    quickFiltersAgenticTooltip: '按 Chip 厂商、推理框架和部署模式筛选图表。某组不选则显示全部。',
+    filtersSelected: '项已选',
     filterVendor: '厂商',
     filterFramework: '框架',
     filterDeployment: '部署模式',
@@ -499,6 +510,14 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
       selected: quickFilters.spec,
     },
   ];
+  const isAgentic = selectedSequence === Sequence.AgenticTraces;
+  const visibleQuickFilterGroups = isAgentic
+    ? quickFilterGroups.filter((group) => group.key !== 'spec')
+    : quickFilterGroups;
+  const selectedQuickFilterCount = visibleQuickFilterGroups.reduce(
+    (count, group) => count + group.selected.length,
+    0,
+  );
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -656,54 +675,75 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
           )}
         </div>
 
-        {/* Quick Filters slice by vendor, framework, deployment, and spec
-            decoding — dimensions the agentic scenario collapses into one
-            best-available curve per model, SKU, and engine, so the chips have
-            nothing meaningful to filter there. */}
-        {!hideGpuComparison && selectedSequence !== Sequence.AgenticTraces && (
-          <div className="flex flex-col space-y-1.5" data-testid="quick-filters">
-            <LabelWithTooltip
-              htmlFor="quick-filters"
-              label={t.quickFilters}
-              tooltip={t.quickFiltersTooltip}
-            />
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-              {quickFilterGroups.map((group) => (
-                <div key={group.key} className="flex items-center gap-1.5">
-                  <span className="text-xs font-medium text-muted-foreground">{group.label}:</span>
-                  <div className="flex flex-wrap gap-1">
-                    {group.options.map((option) => {
-                      const active = (group.selected as readonly string[]).includes(option.value);
-                      // Disable options with no data, but keep a selected one
-                      // clickable so it can always be toggled back off.
-                      const disabled = !option.available && !active;
-                      return (
-                        <Button
-                          key={option.value}
-                          type="button"
-                          size="sm"
-                          variant={active ? 'default' : 'outline'}
-                          aria-pressed={active}
-                          disabled={disabled}
-                          title={disabled ? t.noData : undefined}
-                          // Active pills use the brand color (blue in light, amber in dark)
-                          // rather than the amber primary fill.
-                          className={cn(
-                            'h-7 rounded-full px-3 text-xs',
-                            active && 'bg-brand hover:bg-brand/90',
-                          )}
-                          data-testid={`quick-filter-${group.key}-${option.value}`}
-                          onClick={() => handleQuickFilterToggle(group.key, option.value)}
-                        >
-                          {option.label}
-                        </Button>
-                      );
-                    })}
-                  </div>
+        {!hideGpuComparison && (
+          <Accordion type="single" collapsible data-testid="quick-filters">
+            <AccordionItem value="quick-filters" className="overflow-hidden">
+              <AccordionTrigger
+                className="items-center px-3 py-2.5 text-sm hover:no-underline"
+                data-testid="quick-filters-trigger"
+                onClick={() => track('inference_quick_filters_disclosure_toggled')}
+              >
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span className="flex items-center gap-2">
+                    <span>{t.quickFilters}</span>
+                    {selectedQuickFilterCount > 0 && (
+                      <span
+                        className="rounded-full bg-brand/10 px-2 py-0.5 text-[11px] font-medium text-brand"
+                        data-testid="quick-filters-selected-count"
+                      >
+                        {selectedQuickFilterCount} {t.filtersSelected}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs font-normal text-muted-foreground">
+                    {isAgentic ? t.quickFiltersAgenticTooltip : t.quickFiltersTooltip}
+                  </span>
+                </span>
+              </AccordionTrigger>
+              <AccordionContent className="border-t pt-4">
+                <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+                  {visibleQuickFilterGroups.map((group) => (
+                    <div key={group.key} className="flex items-center gap-1.5">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        {group.label}:
+                      </span>
+                      <div className="flex flex-wrap gap-1">
+                        {group.options.map((option) => {
+                          const active = (group.selected as readonly string[]).includes(
+                            option.value,
+                          );
+                          // Disable options with no data, but keep a selected one
+                          // clickable so it can always be toggled back off.
+                          const disabled = !option.available && !active;
+                          return (
+                            <Button
+                              key={option.value}
+                              type="button"
+                              size="sm"
+                              variant={active ? 'default' : 'outline'}
+                              aria-pressed={active}
+                              disabled={disabled}
+                              title={disabled ? t.noData : undefined}
+                              // Active pills use the brand color (blue in light, amber in dark)
+                              // rather than the amber primary fill.
+                              className={cn(
+                                'h-7 rounded-full px-3 text-xs',
+                                active && 'bg-brand hover:bg-brand/90',
+                              )}
+                              data-testid={`quick-filter-${group.key}-${option.value}`}
+                              onClick={() => handleQuickFilterToggle(group.key, option.value)}
+                            >
+                              {option.label}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         )}
       </div>
     </TooltipProvider>

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -9,6 +9,7 @@ import { useTheme } from 'next-themes';
 
 import { useInference } from '@/components/inference/InferenceContext';
 import ChartLegend from '@/components/ui/chart-legend';
+import { Button } from '@/components/ui/button';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import { getChartWatermark, Sequence } from '@/lib/data-mappings';
 import { generateGpuDateColors, generateHighContrastGpuDateColors } from '@/lib/dynamic-colors';
@@ -149,6 +150,10 @@ const GPUGraph = React.memo(
       showLineLabels,
       setShowLineLabels,
       quickFilters,
+      setQuickFilterVendors,
+      setQuickFilterFrameworks,
+      setQuickFilterDeployment,
+      setQuickFilterSpec,
     } = useInference();
     const locale = useLocale();
     const legendT = GPU_STRINGS[locale];
@@ -160,6 +165,17 @@ const GPUGraph = React.memo(
       quickFilters.frameworks.length +
       quickFilters.deployment.length +
       (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);
+    const clearQuickFilters = useCallback(() => {
+      setQuickFilterVendors([]);
+      setQuickFilterFrameworks([]);
+      setQuickFilterDeployment([]);
+      setQuickFilterSpec([]);
+    }, [
+      setQuickFilterVendors,
+      setQuickFilterFrameworks,
+      setQuickFilterDeployment,
+      setQuickFilterSpec,
+    ]);
     const hasOffloadHalo = useMemo(() => data.some((point) => point.offload_mode === 'on'), [data]);
 
     // Shared date+GPU pairs. `dates` holds comparison-series entries (plain dates
@@ -805,8 +821,22 @@ const GPUGraph = React.memo(
               <p className="text-xs">
                 Please change the model, sequence, precision, date range or chip selection.
               </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="mt-4"
+                data-testid="gpu-empty-quick-filters"
+                onClick={() => {
+                  setQuickFiltersOpen(true);
+                  track('inference_quick_filters_dialog_opened', { source: 'timeline_empty' });
+                }}
+              >
+                {legendT.quickFilters(quickFilterCount)}
+              </Button>
             </div>
           </div>
+          <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
         </div>
       );
     }
@@ -1095,6 +1125,7 @@ const GPUGraph = React.memo(
                 label: legendT.resetFilter,
                 onClick: () => {
                   selectAllActiveDates();
+                  clearQuickFilters();
                   track('gpu_timeseries_reset_filter');
                 },
               },

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -66,6 +66,7 @@ import {
   OffloadHaloLegendKey,
 } from '@/components/inference/ui/OffloadHaloLegendKey';
 import { AgenticOptimizationNote } from '@/components/inference/ui/AgenticOptimizationNote';
+import { QuickFiltersDialog } from '@/components/inference/ui/QuickFiltersDialog';
 
 const FixedSequenceLogDialog = dynamic(() =>
   import('@/components/inference/log-viewer/fixed-sequence-log-dialog').then(
@@ -95,6 +96,7 @@ const GPU_STRINGS = {
     parallelismLabels: 'Parallelism Labels',
     lineLabels: 'Line Labels',
     resetFilter: 'Reset filter',
+    quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
   },
   zh: {
     logScale: '对数缩放',
@@ -104,6 +106,7 @@ const GPU_STRINGS = {
     parallelismLabels: '并行配置标签',
     lineLabels: '曲线标签',
     resetFilter: '重置筛选',
+    quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
   },
 } as const;
 
@@ -145,11 +148,18 @@ const GPUGraph = React.memo(
       selectAllActiveDates,
       showLineLabels,
       setShowLineLabels,
+      quickFilters,
     } = useInference();
     const locale = useLocale();
     const legendT = GPU_STRINGS[locale];
     const { resolvedTheme } = useTheme();
     const chartRef = useRef<D3ChartHandle>(null);
+    const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
+    const quickFilterCount =
+      quickFilters.vendors.length +
+      quickFilters.frameworks.length +
+      quickFilters.deployment.length +
+      (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);
     const hasOffloadHalo = useMemo(() => data.some((point) => point.offload_mode === 'on'), [data]);
 
     // Shared date+GPU pairs. `dates` holds comparison-series entries (plain dates
@@ -1088,6 +1098,14 @@ const GPUGraph = React.memo(
                   track('gpu_timeseries_reset_filter');
                 },
               },
+              {
+                id: 'gpu-quick-filters',
+                label: legendT.quickFilters(quickFilterCount),
+                onClick: () => {
+                  setQuickFiltersOpen(true);
+                  track('inference_quick_filters_dialog_opened', { source: 'timeline_legend' });
+                },
+              },
             ]}
             precisionIndicators={selectedPrecisions}
             keyIndicators={
@@ -1106,6 +1124,7 @@ const GPUGraph = React.memo(
                     }}
                   />
                 )}
+                <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
               </>
             }
           />

--- a/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
+++ b/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { ListFilter } from 'lucide-react';
+
+import { useInference } from '@/components/inference/InferenceContext';
+import type { DeploymentMode, SpecMode } from '@/components/inference/types';
+import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { track } from '@/lib/analytics';
+import { Sequence } from '@/lib/data-mappings';
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+const STRINGS = {
+  en: {
+    title: 'Quick Filters',
+    description:
+      'Narrow the chart by chip vendor, serving framework, deployment mode, and speculative decoding. Selecting none in a group shows all.',
+    agenticDescription:
+      'Narrow the chart by chip vendor, serving framework, and deployment mode. Selecting none in a group shows all.',
+    selected: 'selected',
+    vendor: 'Vendor',
+    framework: 'Framework',
+    deployment: 'Deployment',
+    singleNode: 'Single-node',
+    multiNode: 'Multi-node',
+    disaggregated: 'Disaggregated',
+    specDecoding: 'Spec Decoding',
+    noData: 'No data for the current selection',
+    clear: 'Clear filters',
+    done: 'Done',
+  },
+  zh: {
+    title: '快捷筛选',
+    description: '按 Chip 厂商、推理框架、部署模式和投机解码筛选图表。某组不选则显示全部。',
+    agenticDescription: '按 Chip 厂商、推理框架和部署模式筛选图表。某组不选则显示全部。',
+    selected: '项已选',
+    vendor: '厂商',
+    framework: '框架',
+    deployment: '部署模式',
+    singleNode: '单节点',
+    multiNode: '多节点聚合',
+    disaggregated: '分离式',
+    specDecoding: '投机解码',
+    noData: '当前选择无可用数据',
+    clear: '清除筛选',
+    done: '完成',
+  },
+} as const;
+
+const VENDORS = [
+  { value: 'NVIDIA', label: 'NVIDIA' },
+  { value: 'AMD', label: 'AMD' },
+] as const;
+const DEPLOYMENT_MODES: DeploymentMode[] = ['single-node', 'multi-node', 'disagg'];
+const SPEC_MODES: { value: SpecMode; label: string }[] = [
+  { value: 'mtp', label: 'MTP' },
+  { value: 'stp', label: 'STP' },
+];
+
+function toggleValue<T extends string>(current: T[], value: T): T[] {
+  return current.includes(value) ? current.filter((item) => item !== value) : [...current, value];
+}
+
+export function QuickFiltersDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
+  const {
+    selectedSequence,
+    quickFilters,
+    availableQuickFilters,
+    setQuickFilterVendors,
+    setQuickFilterFrameworks,
+    setQuickFilterDeployment,
+    setQuickFilterSpec,
+  } = useInference();
+  const isAgentic = selectedSequence === Sequence.AgenticTraces;
+
+  const frameworkOptions = FRAMEWORK_FAMILIES.filter(
+    (framework) =>
+      availableQuickFilters.frameworks.includes(framework.key) ||
+      quickFilters.frameworks.includes(framework.key),
+  ).map((framework) => ({
+    value: framework.key,
+    label: framework.label,
+    available: availableQuickFilters.frameworks.includes(framework.key),
+  }));
+
+  const groups: {
+    key: 'vendor' | 'framework' | 'deployment' | 'spec';
+    label: string;
+    options: readonly { value: string; label: string; available: boolean }[];
+    selected: readonly string[];
+  }[] = [
+    {
+      key: 'vendor',
+      label: t.vendor,
+      options: VENDORS.map((option) => ({
+        ...option,
+        available: availableQuickFilters.vendors.includes(option.value),
+      })),
+      selected: quickFilters.vendors,
+    },
+    ...(frameworkOptions.length > 0
+      ? [
+          {
+            key: 'framework' as const,
+            label: t.framework,
+            options: frameworkOptions,
+            selected: quickFilters.frameworks,
+          },
+        ]
+      : []),
+    {
+      key: 'deployment',
+      label: t.deployment,
+      options: DEPLOYMENT_MODES.map((value) => ({
+        value,
+        label:
+          value === 'single-node'
+            ? t.singleNode
+            : value === 'multi-node'
+              ? t.multiNode
+              : t.disaggregated,
+        available: availableQuickFilters.deployment.includes(value),
+      })),
+      selected: quickFilters.deployment,
+    },
+    ...(isAgentic
+      ? []
+      : [
+          {
+            key: 'spec' as const,
+            label: t.specDecoding,
+            options: SPEC_MODES.map((option) => ({
+              ...option,
+              available: availableQuickFilters.spec.includes(option.value),
+            })),
+            selected: quickFilters.spec,
+          },
+        ]),
+  ];
+
+  const selectedCount = groups.reduce((count, group) => count + group.selected.length, 0);
+
+  const handleToggle = (
+    category: 'vendor' | 'framework' | 'deployment' | 'spec',
+    value: string,
+  ) => {
+    const wasActive =
+      category === 'vendor'
+        ? quickFilters.vendors.includes(value)
+        : category === 'framework'
+          ? quickFilters.frameworks.includes(value)
+          : category === 'deployment'
+            ? quickFilters.deployment.includes(value as DeploymentMode)
+            : quickFilters.spec.includes(value as SpecMode);
+    if (category === 'vendor') setQuickFilterVendors(toggleValue(quickFilters.vendors, value));
+    else if (category === 'framework')
+      setQuickFilterFrameworks(toggleValue(quickFilters.frameworks, value));
+    else if (category === 'deployment')
+      setQuickFilterDeployment(toggleValue(quickFilters.deployment, value as DeploymentMode));
+    else setQuickFilterSpec(toggleValue(quickFilters.spec, value as SpecMode));
+    track('inference_quick_filter_toggled', { category, value, active: !wasActive });
+  };
+
+  const clearFilters = () => {
+    setQuickFilterVendors([]);
+    setQuickFilterFrameworks([]);
+    setQuickFilterDeployment([]);
+    setQuickFilterSpec([]);
+    track('inference_quick_filters_cleared', { source: 'dialog' });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-h-[85vh] overflow-y-auto sm:max-w-xl"
+        data-testid="quick-filters-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ListFilter className="size-4 text-brand" />
+            {t.title}
+            {selectedCount > 0 && (
+              <span
+                className="rounded-full bg-brand/10 px-2 py-0.5 text-[11px] font-medium text-brand"
+                data-testid="quick-filters-selected-count"
+              >
+                {selectedCount} {t.selected}
+              </span>
+            )}
+          </DialogTitle>
+          <DialogDescription>{isAgentic ? t.agenticDescription : t.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="divide-y divide-border rounded-md border">
+          {groups.map((group) => (
+            <section
+              key={group.key}
+              className="grid gap-2 px-3 py-3 sm:grid-cols-[7rem_1fr] sm:items-start"
+            >
+              <h3 className="pt-1 text-xs font-semibold text-muted-foreground">{group.label}</h3>
+              <div className="flex flex-wrap gap-1.5">
+                {group.options.map((option) => {
+                  const active = group.selected.includes(option.value);
+                  const disabled = !option.available && !active;
+                  return (
+                    <Button
+                      key={option.value}
+                      type="button"
+                      size="sm"
+                      variant={active ? 'default' : 'outline'}
+                      aria-pressed={active}
+                      disabled={disabled}
+                      title={disabled ? t.noData : undefined}
+                      className={cn(
+                        'h-7 rounded-full px-3 text-xs',
+                        active && 'bg-brand hover:bg-brand/90',
+                      )}
+                      data-testid={`quick-filter-${group.key}-${option.value}`}
+                      onClick={() => handleToggle(group.key, option.value)}
+                    >
+                      {option.label}
+                    </Button>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <DialogFooter className="flex-row justify-between sm:justify-between">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={selectedCount === 0}
+            onClick={clearFilters}
+          >
+            {t.clear}
+          </Button>
+          <DialogClose asChild>
+            <Button type="button">{t.done}</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -75,6 +75,7 @@ import {
 } from '@/components/inference/utils/tooltipUtils';
 import { scatterPointConfigId } from '@/components/inference/utils/point-identity';
 import LegendPointsDialog from '@/components/inference/ui/LegendPointsDialog';
+import { QuickFiltersDialog } from '@/components/inference/ui/QuickFiltersDialog';
 import {
   OFFLOAD_HALO_DASHARRAY,
   OFFLOAD_HALO_RADIUS,
@@ -437,6 +438,7 @@ const SCATTER_STRINGS = {
     gradientLabels: 'Gradient Labels',
     lineLabels: 'Line Labels',
     resetFilter: 'Reset filter',
+    quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
     overflowMixed: (count: number) => `${pointCountEn(count)} clipped`,
     overflowCost: (count: number, limit: number) => `${pointCountEn(count)} > $${limit}/Mtok`,
     overflowLatency: (count: number, limit: number) => `${pointCountEn(count)} > ${limit}s TTFT`,
@@ -452,6 +454,7 @@ const SCATTER_STRINGS = {
     gradientLabels: '渐变标签',
     lineLabels: '曲线标签',
     resetFilter: '重置筛选',
+    quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
     overflowMixed: (count: number) => `${count} 个点已截断`,
     overflowCost: (count: number, limit: number) => `${count} 个点 > $${limit}/Mtok`,
     overflowLatency: (count: number, limit: number) => `${count} 个点 > ${limit}s TTFT`,
@@ -1150,6 +1153,12 @@ const ScatterGraph = React.memo(
 
     // --- Legend points table (per-series drill-down opened from the legend) ---
     const [pointsTableTarget, setPointsTableTarget] = useState<LegendPointsTarget | null>(null);
+    const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
+    const quickFilterCount =
+      quickFilters.vendors.length +
+      quickFilters.frameworks.length +
+      quickFilters.deployment.length +
+      (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);
 
     const pointsTable = useMemo(() => {
       if (!pointsTableTarget) return null;
@@ -3574,8 +3583,8 @@ const ScatterGraph = React.memo(
               onAdvancedExpandedChange={(expanded) => {
                 track('latency_advanced_controls_toggled', { expanded });
               }}
-              actions={
-                effectiveOfficialHwTypes.size < hwTypesWithData.size ||
+              actions={[
+                ...(effectiveOfficialHwTypes.size < hwTypesWithData.size ||
                 activeOverlayHwTypes.size < scopedOverlayHwTypes.size
                   ? [
                       {
@@ -3587,8 +3596,16 @@ const ScatterGraph = React.memo(
                         },
                       },
                     ]
-                  : []
-              }
+                  : []),
+                {
+                  id: 'scatter-quick-filters',
+                  label: legendT.quickFilters(quickFilterCount),
+                  onClick: () => {
+                    setQuickFiltersOpen(true);
+                    track('inference_quick_filters_dialog_opened', { source: 'scatter_legend' });
+                  },
+                },
+              ]}
               precisionIndicators={selectedPrecisions}
               keyIndicators={
                 hasOffloadHalo || selectedSequence === Sequence.AgenticTraces ? (
@@ -3602,6 +3619,7 @@ const ScatterGraph = React.memo(
             />
           }
         />
+        <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
         {pointsTable && (
           <LegendPointsDialog
             open

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -18,6 +18,7 @@ import {
   labelOpacityForHover,
 } from '@/components/inference/ui/line-label-visibility';
 import ChartLegend from '@/components/ui/chart-legend';
+import { Button } from '@/components/ui/button';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import { getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import {
@@ -518,6 +519,10 @@ const ScatterGraph = React.memo(
       selectedSequence,
       selectedModel,
       quickFilters,
+      setQuickFilterVendors,
+      setQuickFilterFrameworks,
+      setQuickFilterDeployment,
+      setQuickFilterSpec,
       loading,
     } = useInference();
     const locale = useLocale();
@@ -1159,6 +1164,17 @@ const ScatterGraph = React.memo(
       quickFilters.frameworks.length +
       quickFilters.deployment.length +
       (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);
+    const clearQuickFilters = useCallback(() => {
+      setQuickFilterVendors([]);
+      setQuickFilterFrameworks([]);
+      setQuickFilterDeployment([]);
+      setQuickFilterSpec([]);
+    }, [
+      setQuickFilterVendors,
+      setQuickFilterFrameworks,
+      setQuickFilterDeployment,
+      setQuickFilterSpec,
+    ]);
 
     const pointsTable = useMemo(() => {
       if (!pointsTableTarget) return null;
@@ -3289,8 +3305,22 @@ const ScatterGraph = React.memo(
               <p className="text-xs">
                 Please change the model, sequence, precision, date range or chip selection.
               </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="mt-4"
+                data-testid="scatter-empty-quick-filters"
+                onClick={() => {
+                  setQuickFiltersOpen(true);
+                  track('inference_quick_filters_dialog_opened', { source: 'scatter_empty' });
+                }}
+              >
+                {legendT.quickFilters(quickFilterCount)}
+              </Button>
             </div>
           </div>
+          <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
         </div>
       );
     }
@@ -3585,13 +3615,15 @@ const ScatterGraph = React.memo(
               }}
               actions={[
                 ...(effectiveOfficialHwTypes.size < hwTypesWithData.size ||
-                activeOverlayHwTypes.size < scopedOverlayHwTypes.size
+                activeOverlayHwTypes.size < scopedOverlayHwTypes.size ||
+                quickFilterCount > 0
                   ? [
                       {
                         id: 'scatter-reset-filter',
                         label: legendT.resetFilter,
                         onClick: () => {
                           resetUnifiedSelection();
+                          clearQuickFilters();
                           track('latency_legend_filter_reset');
                         },
                       },

--- a/packages/app/src/components/inference/utils/quickFilters.test.ts
+++ b/packages/app/src/components/inference/utils/quickFilters.test.ts
@@ -223,4 +223,26 @@ describe('applyQuickFilters', () => {
       [overlay],
     );
   });
+
+  it('filters agentic unofficial overlays by the options exposed in the UI', () => {
+    const official = point({
+      id: 42,
+      benchmark_type: 'agentic_traces',
+      hwKey: 'b200_vllm_mtp',
+      framework: 'vllm',
+      spec_decoding: 'mtp',
+    });
+    const overlay = point({
+      id: undefined,
+      benchmark_type: 'agentic_traces',
+      run_url: 'https://github.com/example/actions/runs/2',
+      hwKey: 'mi300x_sglang_mtp',
+      framework: 'sglang',
+      spec_decoding: 'mtp',
+    });
+
+    expect(
+      applyQuickFilters([official, overlay], filters({ vendors: ['AMD'], frameworks: ['sglang'] })),
+    ).toEqual([overlay]);
+  });
 });


### PR DESCRIPTION
## Summary

- Restore Vendor, Framework, and Deployment Quick Filters for agentic charts.
- Expose Quick Filters as a compact chart-legend action that opens a dedicated dialog, so the primary chart controls use no extra vertical space.
- Keep the dialog mounted when a filter combination yields zero points and provide a Quick Filters recovery action in the empty state.
- Make Reset filter clear Quick Filters together with hardware and comparison-date selections.
- Keep Spec Decoding unavailable and ignored for agentic, including stale shared-link state.
- Preserve fixed-sequence behavior, including Spec Decoding.
- Show the active-filter count in the legend action.
- Works for official runs and unofficial-run overlays; verified with dedicated overlay unit coverage and the agentic browser flow.

## Testing

- bun run typecheck
- bun run lint
- bun run fmt
- bun run test:unit (4,427 tests passed)
- Focused Cypress component tests (18 passed)
- Focused agentic zero-result recovery and reset E2E tests (2 passed)
- Focused agentic and fixed-sequence Cypress E2E tests (16 passed before the recovery follow-up)
- Next.js production build
- Manual browser verification on desktop and mobile with real agentic data, including a zero-result NVIDIA + ATOM selection and successful recovery

The standard quick E2E suite also exposed three pre-existing dark-theme contrast failures in Overview. They are outside this diff; all changed and focused inference tests pass.

## 中文说明

- 为 agentic 图表恢复厂商、框架和部署模式快捷筛选。
- 将快捷筛选改为图例中的紧凑入口，点击后打开独立弹窗，不再占用主图表控制区的纵向空间。
- 当筛选组合导致结果为零时保持弹窗挂载，并在空状态中提供重新打开快捷筛选的入口。
- 重置筛选时同时清除快捷筛选、硬件选择和对比日期选择。
- agentic 场景不提供投机解码筛选，并忽略旧分享链接中残留的相关状态。
- 保持固定序列长度场景原有行为，包括投机解码筛选。
- 图例入口会显示当前启用的筛选数量。
- 官方运行与非官方运行叠加均受支持；已通过专门的叠加单元测试和 agentic 浏览器流程验证。

## 测试

- bun run typecheck
- bun run lint
- bun run fmt
- bun run test:unit（4,427 项测试通过）
- 定向 Cypress 组件测试（18 项通过）
- 定向 agentic 零结果恢复与重置 E2E 测试（2 项通过）
- 恢复修复前的定向 agentic 与固定序列长度 Cypress E2E 测试（16 项通过）
- Next.js 生产构建
- 使用真实 agentic 数据完成桌面端与移动端浏览器验证，包括 NVIDIA + ATOM 零结果组合及成功恢复

标准快速 E2E 套件还暴露了 Overview 深色主题中 3 个既有的对比度失败，均不在本次 diff 范围内；本次涉及的测试和定向推理测试全部通过。