### PR TITLE
fix(inference): stop point labels rendering under run-name pills

### DIFF
--- a/packages/app/cypress/component/scatter-label-overlap.cy.tsx
+++ b/packages/app/cypress/component/scatter-label-overlap.cy.tsx
@@ -1,0 +1,152 @@
+import ScatterGraph from '@/components/inference/ui/ScatterGraph';
+import { Precision } from '@/lib/data-mappings';
+
+import {
+  createMockChartDefinition,
+  createMockHardwareConfig,
+  createMockInferenceData,
+} from '../support/mock-data';
+import { mountWithProviders } from '../support/test-utils';
+
+const hwConfig = createMockHardwareConfig();
+
+const CHART_ID = 'test-scatter-label-overlap';
+
+interface Box {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+/** Overlap depth of two boxes along each axis; negative means no overlap. */
+function overlap(a: Box, b: Box): { x: number; y: number } {
+  return {
+    x: Math.min(a.right, b.right) - Math.max(a.left, b.left),
+    y: Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top),
+  };
+}
+
+/**
+ * Both axes must exceed this for a collision to count. The placement engine
+ * models a text block with fixed ascent/descent constants, so a glyph's real
+ * ink box can stick out by about a pixel without anything looking wrong.
+ */
+const TOLERANCE_PX = 1;
+
+/** A curve dense enough that its run-name pill has point labels to land on. */
+function curve(hwKey: string, ys: number[]) {
+  return ys.map((y, i) =>
+    createMockInferenceData({
+      hwKey,
+      x: 2 ** (i + 3),
+      y,
+      conc: 2 ** (i + 3),
+      precision: Precision.FP4,
+      // Widens the label in advanced mode (a disagg prefill/decode split),
+      // which is the shape that overlapped in practice.
+      disagg: true,
+      dp_attention: true,
+      prefill_tp: 8,
+      prefill_ep: 8,
+      prefill_dp_attention: true,
+      prefill_num_workers: 2,
+      decode_tp: 16,
+      decode_ep: 16,
+      decode_dp_attention: true,
+      decode_num_workers: 1,
+    }),
+  );
+}
+
+function mountChart(useAdvancedLabels: boolean) {
+  mountWithProviders(
+    <div style={{ width: 900, height: 600 }}>
+      <ScatterGraph
+        chartId={CHART_ID}
+        modelLabel="DeepSeek R1"
+        data={[
+          ...curve('h100', [240, 232, 210, 180, 150, 118]),
+          ...curve('b200_trt', [330, 315, 288, 250, 205, 160]),
+        ]}
+        xLabel="Concurrency"
+        yLabel="Throughput / Chip (tok/s)"
+        chartDefinition={createMockChartDefinition({
+          chartType: 'interactivity',
+          y_tpPerGpu_roofline: 'upper_left',
+        })}
+      />
+    </div>,
+    {
+      inference: {
+        hardwareConfig: hwConfig,
+        activeHwTypes: new Set(['h100', 'b200_trt']),
+        hwTypesWithData: new Set(['h100', 'b200_trt']),
+        selectedPrecisions: [Precision.FP4],
+        showLineLabels: true,
+        showPointLabels: true,
+        useAdvancedLabels,
+      },
+      unofficial: {},
+    },
+  );
+}
+
+/** Asserts no visible point label is drawn through a visible pill. */
+function expectNoPillOverlap() {
+  cy.get(`#${CHART_ID} svg .ll-bg`).should('exist');
+
+  cy.get(`#${CHART_ID} svg`).then(($svg) => {
+    const svg = $svg[0];
+
+    const pills = [...svg.querySelectorAll<SVGGElement>('.line-label, .parallelism-label')]
+      .filter((group) => group.style.opacity !== '0')
+      .map((group) => ({
+        label: group.textContent ?? '',
+        box: (group.querySelector('.ll-bg, .pl-bg') as SVGRectElement).getBoundingClientRect(),
+      }));
+
+    const points = [...svg.querySelectorAll<SVGTextElement>('.point-label')]
+      .filter((text) => {
+        const group = text.closest<SVGGElement>('.dot-group');
+        return text.style.opacity !== '0' && group?.style.opacity !== '0';
+      })
+      .map((text) => ({ label: text.textContent ?? '', box: text.getBoundingClientRect() }));
+
+    // Without these the assertion below would pass on an empty chart.
+    expect(pills.length, 'visible run-name pills').to.be.greaterThan(0);
+    expect(points.length, 'visible point labels').to.be.greaterThan(3);
+
+    const collisions: string[] = [];
+    for (const pill of pills) {
+      for (const point of points) {
+        const { x, y } = overlap(pill.box, point.box);
+        if (x > TOLERANCE_PX && y > TOLERANCE_PX) {
+          collisions.push(
+            `"${point.label}" overlaps pill "${pill.label}" by ${x.toFixed(1)}x${y.toFixed(1)}px`,
+          );
+        }
+      }
+    }
+
+    expect(collisions, collisions.join('; ')).to.have.length(0);
+  });
+}
+
+describe('Scatter label overlap', () => {
+  it('draws both label kinds (guards the overlap assertions below)', () => {
+    mountChart(false);
+    cy.get(`#${CHART_ID} svg .line-label`).should('have.length.greaterThan', 0);
+    cy.get(`#${CHART_ID} svg .point-label`).should('have.length.greaterThan', 3);
+  });
+
+  it('keeps point labels clear of the run-name pills', () => {
+    mountChart(false);
+    expectNoPillOverlap();
+  });
+
+  it('keeps the wider parallelism labels clear of the run-name pills', () => {
+    mountChart(true);
+    expectNoPillOverlap();
+  });
+});

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -112,6 +112,42 @@ const FixedSequenceLogDialog = dynamic(() =>
   ),
 );
 
+/**
+ * Bounding boxes of the pills drawn over the plot: the run-name labels
+ * (`.line-label`) and the parallelism labels (`.parallelism-label`).
+ *
+ * Both are positioned by the roofline layer, which always runs before the two
+ * places that call {@link avoidLabelCollisions} — layers render before the
+ * `onRender` callback, and the per-layer zoom updates run before
+ * `zoomConfig.onZoom` — so reading the DOM here gives their final placement
+ * for the current frame.
+ *
+ * Coordinates: the group carries a `translate(...)`, and the `.ll-bg` /
+ * `.pl-bg` rect carries an offset sized to its text. Summing the two puts the
+ * box in the same space as a point label's `cx`/`cy`.
+ */
+function pillObstacles(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+): { left: number; right: number; top: number; bottom: number }[] {
+  const boxes: { left: number; right: number; top: number; bottom: number }[] = [];
+  zoomGroup.selectAll<SVGGElement, unknown>('.line-label, .parallelism-label').each(function () {
+    // A hidden pill is still in the DOM but covers nothing.
+    if (this.style.opacity === '0') return;
+    const m = /translate\((?<tx>[^,]+),(?<ty>[^)]+)\)/u.exec(this.getAttribute('transform') ?? '');
+    const bg = this.querySelector<SVGRectElement>('.ll-bg, .pl-bg');
+    if (!m?.groups || !bg) return;
+    const tx = Number(m.groups.tx);
+    const ty = Number(m.groups.ty);
+    const x = Number(bg.getAttribute('x'));
+    const y = Number(bg.getAttribute('y'));
+    const w = Number(bg.getAttribute('width'));
+    const h = Number(bg.getAttribute('height'));
+    if (![tx, ty, x, y, w, h].every((v) => Number.isFinite(v))) return;
+    boxes.push({ left: tx + x, top: ty + y, right: tx + x + w, bottom: ty + y + h });
+  });
+  return boxes;
+}
+
 // Greedy label-collision avoidance.
 // Each candidate is the y-position of the FIRST baseline (relative to point
 // center) which we apply via the first tspan's `dy` — later tspans cascade
@@ -166,7 +202,11 @@ function avoidLabelCollisions(
   const labels: LabelInfo[] = pending.map((lab) => ({ ...lab, w: lab.el.getBBox().width }));
 
   labels.sort((a, b) => a.cx - b.cx);
-  const placed: { left: number; right: number; top: number; bottom: number }[] = [];
+  // Seed with the run-name and parallelism pills so a point label that would
+  // sit underneath one is pushed to its next candidate slot (or hidden) rather
+  // than being drawn through it. Point-label-vs-point-label behaviour below is
+  // unchanged; the pills simply occupy space before the first label is placed.
+  const placed = pillObstacles(zoomGroup);
   const pad = 2;
 
   for (const lab of labels) {


### PR DESCRIPTION
## What was actually wrong

#813 fixed the wrong pair of labels. On the interactivity charts the text being covered is the per-point `DEP8 / C=512` annotation (`.point-label`), and what covers it is the **run-name pill** (`.line-label`, e.g. `B300 FP4 (vLLM)`) — not the `.parallelism-label` segment pills that #813 taught line labels to dodge.

`avoidLabelCollisions` already does proper rect-based placement for point labels — four vertical candidates (above, below, and a block further out each way) with hide-on-failure — but its obstacle list started empty, so it only ever saw *other point labels*:

```ts
const placed: { left: number; right: number; top: number; bottom: number }[] = [];
```

## Fix

Seed that list with the pills currently drawn in the zoom group (`.line-label` and `.parallelism-label`), built from each group's `translate(...)` plus its `.ll-bg` / `.pl-bg` rect. Hidden pills (`opacity: 0`) are skipped.

Ordering needs no changes — both callers already run after the pills are placed: layers render before the `onRender` callback, and the per-layer zoom updates run before `zoomConfig.onZoom`, so the roofline layer has positioned every pill by the time this reads the DOM.

Point-label-vs-point-label behaviour is untouched; the pills simply occupy space before the first label is placed. A label that would land under a pill now takes its next candidate slot (or hides, as it already would against another label).

## Verification

New component test measures real `getBoundingClientRect()` boxes and asserts no visible point label overlaps a visible pill by more than 1px in both axes, with guards so it can't pass vacuously on an empty chart.

Run against the **unfixed** code it reproduces the reported bug in both label modes:

```
AssertionError: "8C=16" overlaps pill "B200 (TRTLLM)" by 10.3x16.8px
AssertionError: "DPATP16C=16" overlaps pill "B200 (TRTLLM)" by 20.2x16.8px
```

With the fix, all three cases pass. Also checked visually via a Cypress screenshot — the `B200 (TRTLLM)` and `H100` pills sit clear, with the displaced point labels moved below their points.

- Full Cypress component suite: **231/231** passing
- `ScatterGraph.decoration.test.tsx`: 16/16
- `bun run lint`, `bun run typecheck`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)