### PR TITLE
fix(agentic): restore large point detail loading / 恢复大型智能体数据点详情页加载

### DIFF
--- a/packages/app/src/components/inference/agentic-point/lognormal.test.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.test.ts
@@ -36,6 +36,17 @@ describe('logHistogram', () => {
     expect(logHistogram([], 10)).toBeNull();
     expect(logHistogram([0, -4], 10)).toBeNull();
   });
+
+  it('handles request counts above the JavaScript variadic argument limit', () => {
+    const values = Array.from({ length: 200_000 }, (_, index) => (index % 4096) + 1);
+
+    const histogram = logHistogram(values, 32);
+
+    expect(histogram).not.toBeNull();
+    expect(histogram!.counts.reduce((sum, count) => sum + count, 0)).toBe(values.length);
+    expect(histogram!.edges[0]).toBeCloseTo(1, 10);
+    expect(histogram!.edges.at(-1)).toBeCloseTo(4096, 6);
+  });
 });
 
 describe('logTicks', () => {

--- a/packages/app/src/components/inference/agentic-point/lognormal.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.ts
@@ -43,8 +43,18 @@ export function logHistogram(values: readonly number[], bins: number): LogHistog
   if (positive.length === 0) return null;
 
   const nBins = Math.max(1, Math.floor(bins));
-  let lnMin = Math.log(Math.min(...positive));
-  let lnMax = Math.log(Math.max(...positive));
+  // Do not spread this array into Math.min/Math.max. Large agentic runs have
+  // hundreds of thousands of requests, which exceeds JavaScript engines'
+  // variadic argument limit and crashes the entire point page.
+  let min = positive[0]!;
+  let max = min;
+  for (let i = 1; i < positive.length; i++) {
+    const value = positive[i]!;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  let lnMin = Math.log(min);
+  let lnMax = Math.log(max);
   if (!(lnMax > lnMin)) {
     lnMin -= Math.LN2;
     lnMax += Math.LN2;

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -592,7 +592,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/trace-server-metrics.ts',
-    sourceSha256: '7702f580ee488ff691f0e1182b58c1f54e2e3a58678f79b3edbdbb18e505be88',
+    sourceSha256: 'da987d22521dc63da34dcacf3caaad6adb21aa6e5e7a65d1a4fa495a71e9f1f0',
     reviewArea: {
       en: 'Trace server metric metadata, time-series groups, source labels, and units.',
       zh: '跟踪服务器指标元数据、时间序列分组、来源标签和单位。',

--- a/packages/db/src/backfill-chart-series.ts
+++ b/packages/db/src/backfill-chart-series.ts
@@ -57,7 +57,9 @@ async function main(): Promise<void> {
         select id
         from agentic_trace_replay
         where server_metrics_json_gz is not null
-        order by id
+        -- Restore the newest, most actively viewed runs first. The backfill is
+        -- idempotent, so an interrupted pass resumes with only stale rows.
+        order by id desc
         ${flags.limit ? sql`limit ${flags.limit}` : sql``}
       `
     : await sql<{ id: number }[]>`
@@ -68,7 +70,9 @@ async function main(): Promise<void> {
             chart_series is null
             or coalesce((chart_series->>'version')::int, -1) <> ${CHART_SERIES_VERSION}
           )
-        order by id
+        -- Restore the newest, most actively viewed runs first. The backfill is
+        -- idempotent, so an interrupted pass resumes with only stale rows.
+        order by id desc
         ${flags.limit ? sql`limit ${flags.limit}` : sql``}
       `;
 

--- a/packages/db/src/backfill-chart-series.ts
+++ b/packages/db/src/backfill-chart-series.ts
@@ -19,6 +19,8 @@
  *   bun run --cwd packages/db db:backfill-chart-series
  *     [--limit N]   only process the first N candidate rows
  *     [--force]     recompute every row, even if version already matches
+ *     [--shard-count N] split work across N independent processes
+ *     [--shard-index N] zero-based shard handled by this process
  *     [--yes]       skip the confirmation prompt
  */
 
@@ -46,6 +48,7 @@ async function main(): Promise<void> {
   console.log(`  CHART_SERIES_VERSION = ${CHART_SERIES_VERSION}`);
   console.log(`  force = ${flags.force}`);
   console.log(`  limit = ${flags.limit ?? 'none'}`);
+  console.log(`  shard = ${flags.shardIndex + 1}/${flags.shardCount}`);
 
   // Only rows that actually have a server_metrics blob can produce a
   // chart_series. Rows without the blob legitimately keep `chart_series`
@@ -57,6 +60,7 @@ async function main(): Promise<void> {
         select id
         from agentic_trace_replay
         where server_metrics_json_gz is not null
+          and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
         -- Restore the newest, most actively viewed runs first. The backfill is
         -- idempotent, so an interrupted pass resumes with only stale rows.
         order by id desc
@@ -66,6 +70,7 @@ async function main(): Promise<void> {
         select id
         from agentic_trace_replay
         where server_metrics_json_gz is not null
+          and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
           and (
             chart_series is null
             or coalesce((chart_series->>'version')::int, -1) <> ${CHART_SERIES_VERSION}

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -8,7 +8,7 @@
  * `CHART_SERIES_VERSION` whenever the extraction algorithm changes.
  */
 
-import { gunzipJsonWithinLimit, streamCollectKeys } from './gzip-json-stream';
+import { collectMetricPhases } from './gzip-json-stream';
 import {
   selectServerMetricsAdapter,
   type MetricSource,
@@ -266,31 +266,17 @@ function mergePhaseMetrics(profiling: MetricsMap, warmup: MetricsMap): MetricsMa
 }
 
 /**
- * Stream-parse fallback: collect the chart's metric subtrees from both phase
- * blocks and merge (see v11) when the full JSON exceeds the in-memory
- * fast-path ceiling.
- */
-async function streamCollectMetrics(buffer: Buffer): Promise<MetricsMap> {
-  const [profiling, warmup] = await Promise.all([
-    streamCollectKeys<RawMetric>(buffer, 'metrics', CHART_METRIC_KEYS),
-    streamCollectKeys<RawMetric>(buffer, 'warmup_metrics', CHART_METRIC_KEYS),
-  ]);
-  return mergePhaseMetrics(profiling, warmup);
-}
-
-/**
  * Parse the gzipped server_metrics blob into the metric map. Small blobs use
- * the synchronous fast path; oversized blobs use the streaming parser. Merges
- * the warmup block into the profiling one (v11) so the series span both phases.
+ * the synchronous fast path; oversized blobs use one streaming parser pass
+ * that collects both phase blocks. Merges the warmup block into the profiling
+ * one (v11) so the series span both phases.
  */
 async function parseMetrics(buffer: Buffer): Promise<MetricsMap> {
-  const json = gunzipJsonWithinLimit(buffer);
-  if (json === null) return await streamCollectMetrics(buffer);
-  const obj = JSON.parse(json) as {
-    metrics?: MetricsMap;
-    warmup_metrics?: MetricsMap;
-  };
-  return mergePhaseMetrics(obj.metrics ?? {}, obj.warmup_metrics ?? {});
+  const { metrics, warmupMetrics } = await collectMetricPhases<RawMetric>(
+    buffer,
+    CHART_METRIC_KEYS,
+  );
+  return mergePhaseMetrics(metrics, warmupMetrics);
 }
 
 /**

--- a/packages/db/src/lib/backfill-runner.test.ts
+++ b/packages/db/src/lib/backfill-runner.test.ts
@@ -10,12 +10,33 @@ describe('parseLimitForceFlags', () => {
 
   it('defaults to no limit and force off', () => {
     process.argv = ['node', 'script.ts'];
-    expect(parseLimitForceFlags()).toEqual({ limit: null, force: false });
+    expect(parseLimitForceFlags()).toEqual({
+      limit: null,
+      force: false,
+      shardCount: 1,
+      shardIndex: 0,
+    });
   });
 
-  it('parses --limit N and --force', () => {
-    process.argv = ['node', 'script.ts', '--limit', '25', '--force', '--yes'];
-    expect(parseLimitForceFlags()).toEqual({ limit: 25, force: true });
+  it('parses --limit N, --force, and process-shard flags', () => {
+    process.argv = [
+      'node',
+      'script.ts',
+      '--limit',
+      '25',
+      '--force',
+      '--shard-count',
+      '4',
+      '--shard-index',
+      '2',
+      '--yes',
+    ];
+    expect(parseLimitForceFlags()).toEqual({
+      limit: 25,
+      force: true,
+      shardCount: 4,
+      shardIndex: 2,
+    });
   });
 });
 

--- a/packages/db/src/lib/backfill-runner.ts
+++ b/packages/db/src/lib/backfill-runner.ts
@@ -12,12 +12,16 @@ import type { Sql } from '../etl/db-utils.js';
 export interface LimitForceFlags {
   limit: number | null;
   force: boolean;
+  shardCount: number;
+  shardIndex: number;
 }
 
 /** Parse the standard `--limit N` / `--force` backfill flags from argv. */
 export function parseLimitForceFlags(): LimitForceFlags {
   let limit: number | null = null;
   let force = false;
+  let shardCount = 1;
+  let shardIndex = 0;
   for (let i = 2; i < process.argv.length; i++) {
     const arg = process.argv[i]!;
     if (arg === '--force') force = true;
@@ -28,9 +32,29 @@ export function parseLimitForceFlags(): LimitForceFlags {
         process.exit(1);
       }
       limit = Number(next);
+    } else if (arg === '--shard-count') {
+      const next = process.argv[++i];
+      const parsed = Number(next);
+      if (!next || !Number.isInteger(parsed) || parsed < 1) {
+        console.error('--shard-count requires a positive integer');
+        process.exit(1);
+      }
+      shardCount = parsed;
+    } else if (arg === '--shard-index') {
+      const next = process.argv[++i];
+      const parsed = Number(next);
+      if (!next || !Number.isInteger(parsed) || parsed < 0) {
+        console.error('--shard-index requires a non-negative integer');
+        process.exit(1);
+      }
+      shardIndex = parsed;
     }
   }
-  return { limit, force };
+  if (shardIndex >= shardCount) {
+    console.error('--shard-index must be less than --shard-count');
+    process.exit(1);
+  }
+  return { limit, force, shardCount, shardIndex };
 }
 
 /**

--- a/packages/db/src/queries/trace-server-metrics.test.ts
+++ b/packages/db/src/queries/trace-server-metrics.test.ts
@@ -37,6 +37,7 @@ function metaRow(overrides: Record<string, unknown> = {}) {
     trace_replay_id: 7,
     has_blob: true,
     chart_series: currentSeries(),
+    metric_sources: [],
     hardware: 'gb200',
     framework: 'dynamo-vllm',
     model: 'deepseek-r1-0528',
@@ -101,6 +102,8 @@ describe('getTraceServerMetrics', () => {
     });
     expect(calls).toHaveLength(1);
     expect(calls[0]).not.toContain('server_metrics_json_gz as blob');
+    expect(calls[0]).toContain("atr.chart_series - 'metricSources'");
+    expect(calls[0]).toContain("metric_source->'kvCacheUsageByEngine'");
     expect(calls[0]).toContain("br.metrics ->> 'kv_offload_backend'");
   });
 
@@ -228,9 +231,8 @@ describe('getTraceServerMetrics all-endpoints KV overlay', () => {
     const series = {
       ...currentSeries(),
       kvCacheUsageByEngine: fallback,
-      metricSources,
     } as unknown as ChartSeries;
-    const { sql } = mockSql([[metaRow({ chart_series: series })]]);
+    const { sql } = mockSql([[metaRow({ chart_series: series, metric_sources: metricSources })]]);
     return getTraceServerMetrics(sql, 42);
   }
 

--- a/packages/db/src/queries/trace-server-metrics.ts
+++ b/packages/db/src/queries/trace-server-metrics.ts
@@ -116,10 +116,13 @@ type ChartSeriesSummary = Omit<ChartSeries, 'metricSources'> & {
   metricSources: MetricSourceDescriptor[];
 };
 
+type KvMetricSource = Pick<MetricSourceSeries, 'source' | 'kvCacheUsage' | 'kvCacheUsageByEngine'>;
+
 interface RawMetaRow extends PointMeta {
   trace_replay_id: number | null;
   has_blob: boolean;
-  chart_series: ChartSeries | null;
+  chart_series: Omit<ChartSeries, 'metricSources'> | null;
+  metric_sources: KvMetricSource[];
   /** Derived at server-log ingest from "GPU KV cache size: N tokens" lines. */
   kv_cache_pool_tokens: string | null;
 }
@@ -232,7 +235,7 @@ function meanOfEngines(engines: readonly { points: TimeSeriesPoint[] }[]): TimeS
  * skew is the signal.
  */
 function collapseKvByWorker(
-  sources: readonly MetricSourceSeries[],
+  sources: readonly KvMetricSource[],
 ): { engineLabel: string; points: TimeSeriesPoint[] }[] | null {
   if (sources.length < 2) return null;
   const entries = sources
@@ -276,8 +279,10 @@ function collapseKvByWorker(
   });
 }
 
-function summarizeSeries(series: ChartSeries): ChartSeriesSummary {
-  const sources = series.metricSources ?? [];
+function summarizeSeries(
+  series: Omit<ChartSeries, 'metricSources'>,
+  sources: readonly KvMetricSource[],
+): ChartSeriesSummary {
   return {
     ...series,
     kvCacheUsageByEngine: collapseKvByWorker(sources) ?? series.kvCacheUsageByEngine ?? [],
@@ -293,7 +298,23 @@ export async function getTraceServerMetrics(
     select
       br.trace_replay_id,
       (atr.server_metrics_json_gz is not null) as has_blob,
-      atr.chart_series,
+      case
+        when atr.chart_series is null then null
+        else atr.chart_series - 'metricSources'
+      end as chart_series,
+      coalesce((
+        select jsonb_agg(jsonb_build_object(
+          'source', metric_source->'source',
+          'kvCacheUsage', coalesce(metric_source->'kvCacheUsage', '[]'::jsonb),
+          'kvCacheUsageByEngine', coalesce(
+            metric_source->'kvCacheUsageByEngine',
+            '[]'::jsonb
+          )
+        ))
+        from jsonb_array_elements(
+          coalesce(atr.chart_series->'metricSources', '[]'::jsonb)
+        ) as metric_source
+      ), '[]'::jsonb) as metric_sources,
       br.id, c.hardware, c.framework, c.model, c.precision, c.spec_method,
       c.disagg, c.is_multinode,
       br.conc, br.offload_mode, br.isl, br.osl, br.benchmark_type,
@@ -323,7 +344,7 @@ export async function getTraceServerMetrics(
 
   // Fast path: pre-computed chart_series at the current version.
   if (row.chart_series && Number(row.chart_series.version) === CHART_SERIES_VERSION) {
-    const summary = summarizeSeries(row.chart_series);
+    const summary = summarizeSeries(row.chart_series, row.metric_sources);
     return merge(meta, summary, kvCachePoolTokens, summary.metricSources);
   }
 
@@ -353,7 +374,7 @@ export async function getTraceServerMetrics(
   // (no-ops on a read-only replica). trace_replay_id is non-null on this path.
   writeBackTraceReplayJsonb(sql, 'chart_series', row.trace_replay_id, series);
 
-  const summary = summarizeSeries(series);
+  const summary = summarizeSeries(series, series.metricSources);
   return merge(meta, summary, kvCachePoolTokens, summary.metricSources);
 }
 


### PR DESCRIPTION
## Summary

- replace variadic `Math.min(...values)` / `Math.max(...values)` calls in agentic ISL/OSL histogram construction with a stack-safe iterative scan
- keep the `trace-server-metrics` fast path under Neon's 64 MiB response limit by projecting aggregate chart data separately from the small source fields needed for the per-worker KV overlay
- process resumable chart-series backfills newest-first so actively viewed runs recover first after a chart-series version bump
- add disjoint process-shard flags so backfills can use multiple CPU cores while each process remains serial and memory-bounded
- add regression coverage with 200,000 request samples, query-shape assertions, and shard-argument tests

Production repair is running against the production writer on the Neon `main` branch using four independent process shards. Point 440193 has already been upgraded to chart-series v15, and its production server-metrics endpoint returns HTTP 200 in approximately 0.44 seconds.

This detail page is keyed by an already-ingested benchmark ID and has no `?unofficialrun=` overlay path; the change does not affect unofficial-run rendering. No user-visible strings or indexable pages changed.

## Verification

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 4,436 tests passed before the operational follow-up
- `bun run --cwd packages/db test:unit` — 590 tests passed after adding process sharding
- `cypress run --component --spec cypress/component/agentic-distribution.cy.tsx` — 6 passed
- `bun run test:e2e` — 71 passed; 3 unrelated pre-existing dark-theme Overview contrast assertions fail against current production data
- exact local reproduction URL renders both distribution charts and the full point-detail page without browser errors
- production `/api/v1/trace-server-metrics?id=440193` returns HTTP 200 after targeted backfill

## 中文说明

- 将智能体 ISL/OSL 直方图中的 `Math.min(...values)` / `Math.max(...values)` 改为迭代扫描，避免超大请求数组超过 JavaScript 可变参数上限并导致页面崩溃
- 将 `trace-server-metrics` 的聚合图表数据与按 worker 汇总 KV 曲线所需的少量来源字段分开查询，确保快速路径不会超过 Neon 64 MiB 响应上限
- 可恢复的 chart-series 回填改为优先处理最新运行，使版本升级后正在查看的数据点先恢复
- 新增互不重叠的进程分片参数，让回填可使用多个 CPU 核心，同时保持每个进程内部串行并限制内存占用
- 新增 20 万条请求的回归测试、SQL 查询形状断言及分片参数测试

生产修复正在 Neon `main` 分支的生产写入端运行，当前使用四个独立进程分片。数据点 440193 已升级至 chart-series v15，其生产服务器指标接口现以 HTTP 200 返回，耗时约 0.44 秒。

该详情页按已入库的 benchmark ID 访问，不存在 `?unofficialrun=` 覆盖路径；本次修改不影响非官方运行渲染。此次也没有新增用户可见文案或可索引页面。

### 验证

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 运营优化前已有 4,436 项测试通过
- `bun run --cwd packages/db test:unit` — 新增进程分片后 590 项测试通过
- `cypress run --component --spec cypress/component/agentic-distribution.cy.tsx` — 6 项通过
- `bun run test:e2e` — 71 项通过；另有 3 项与本次修改无关的 Overview 深色主题对比度断言因当前生产数据而失败
- 使用原始复现 URL 在本地验证：两个分布图及完整详情页正常渲染，浏览器无错误
- 对数据点 440193 完成优先回填后，生产 `/api/v1/trace-server-metrics?id=440193` 返回 HTTP 200

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production trace-server-metrics SQL shape and chart-series backfill used for large blobs. Wrong projection or shard math could serve incomplete charts or skip rows, but this is not an auth/security change.
> 
> **Overview**
> Fixes agentic point-detail crashes and oversized Neon reads for large runs.
> 
> `logHistogram` no longer spreads hundreds of thousands of request lengths into `Math.min`/`Math.max` (that exceeded the JS variadic-arg limit). The trace-server-metrics fast path now returns aggregate `chart_series` without nested `metricSources`, and separately projects only the small KV fields needed for the per-worker overlay.
> 
> Chart-series backfill processes newest IDs first and can be split with `--shard-count` / `--shard-index`. Blob parsing uses a single `collectMetricPhases` pass instead of two stream collectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfb5afd0af6c14a0311fd9d3a0102e9b236e82c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->