### PR TITLE
fix(db): restore append-only metadata for run 32242794988

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -257,7 +257,20 @@ export interface ChangelogBackfill extends AuditedBackfill {
  * Audited corrections to changelog rows already produced by workflow artifacts.
  * Selectors use the table's complete durable identity. `set` is a partial patch.
  */
-export const CHANGELOG_BACKFILLS: readonly ChangelogBackfill[] = [];
+export const CHANGELOG_BACKFILLS: readonly ChangelogBackfill[] = [
+  {
+    id: 'run-32242794988-restore-append-only',
+    reason:
+      'PR #2676 produced an append-only delta sweep, but conflict resolution removed the marker before its artifacts were reused for merge ingestion.',
+    githubRunId: 32242794988,
+    runAttempt: 3,
+    baseRef: '43996b8dc1b3fa53989abb0c86491a7d3e3b4472',
+    headRef: 'de871da96f061b097fef318489462a958240917a',
+    set: {
+      appendOnly: true,
+    },
+  },
+];
 
 export type JsonValue =
   | boolean


### PR DESCRIPTION
## Summary

- register an audited changelog backfill for run 32242794988 attempt 3
- restore append-only metadata on both the workflow run and changelog row
- preserve the correction for future re-ingestion

This repairs the metadata lost during conflict resolution in InferenceX PR #2676. It does not add reuse-prevention changes.

## Verification

- `bunx vitest run packages/db/src/etl/run-overrides.test.ts` (22 tests)
- `bunx oxfmt --check packages/db/src/etl/run-overrides.ts`
- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production changelog metadata via the audited override pipeline, but the patch is a single targeted append-only flag restore with no ingest-logic changes.
> 
> **Overview**
> Adds a `CHANGELOG_BACKFILLS` entry for GitHub run `32242794988` attempt 3 so ingest and `db:apply-overrides` set `appendOnly: true` on that exact base/head changelog row.
> 
> This repairs metadata lost during conflict resolution on PR #2676 and keeps the correction in the ledger for future re-ingestion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424c504058affabf1672f1396d57a756ddaad31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->