### PR TITLE
fix(inference): stop agentic point pages crashing on runs above the JS argument limit / 修复请求数超过 JS 参数上限时 agentic 数据点页面崩溃

### DIFF
--- a/packages/app/src/components/inference/agentic-point/lognormal.test.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.test.ts
@@ -36,6 +36,18 @@ describe('logHistogram', () => {
     expect(logHistogram([], 10)).toBeNull();
     expect(logHistogram([0, -4], 10)).toBeNull();
   });
+
+  it('bins a sample set larger than the JS argument limit', () => {
+    // A c=1536 agentic point carries ~151k requests. Passing that many
+    // arguments to Math.min/Math.max throws RangeError, so the min/max scan
+    // has to stay a loop.
+    const values = Array.from({ length: 200_000 }, (_, i) => 1 + (i % 4096));
+    const histogram = logHistogram(values, 40);
+    expect(histogram).not.toBeNull();
+    expect(histogram!.counts.reduce((a, b) => a + b, 0)).toBe(200_000);
+    expect(Math.exp(histogram!.lnMin)).toBeCloseTo(1, 6);
+    expect(Math.exp(histogram!.lnMax)).toBeCloseTo(4096, 6);
+  });
 });
 
 describe('logTicks', () => {

--- a/packages/app/src/components/inference/agentic-point/lognormal.ts
+++ b/packages/app/src/components/inference/agentic-point/lognormal.ts
@@ -34,6 +34,24 @@ export function positiveValues(values: readonly number[]): number[] {
 }
 
 /**
+ * Smallest and largest of a non-empty sample set.
+ *
+ * Deliberately a loop rather than `Math.min(...values)`: a high-concurrency
+ * agentic point carries well over 100k requests, and spreading an array that
+ * long into a variadic call exceeds the JS argument limit and throws
+ * `RangeError: Maximum call stack size exceeded`.
+ */
+function extent(values: readonly number[]): [min: number, max: number] {
+  let min = values[0]!;
+  let max = values[0]!;
+  for (const value of values) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  return [min, max];
+}
+
+/**
  * Histogram with bins of equal width in ln(x). `bins` is clamped to at least 1.
  * When every sample is the same value the range is widened by a factor of two
  * either side so the single spike still has somewhere to sit.
@@ -43,8 +61,9 @@ export function logHistogram(values: readonly number[], bins: number): LogHistog
   if (positive.length === 0) return null;
 
   const nBins = Math.max(1, Math.floor(bins));
-  let lnMin = Math.log(Math.min(...positive));
-  let lnMax = Math.log(Math.max(...positive));
+  const [min, max] = extent(positive);
+  let lnMin = Math.log(min);
+  let lnMax = Math.log(max);
   if (!(lnMax > lnMin)) {
     lnMin -= Math.LN2;
     lnMax += Math.LN2;


### PR DESCRIPTION
## Summary

Every AgentX point-detail page whose run carries more requests than the JS argument limit crashes to the root error boundary with `RangeError: Maximum call stack size exceeded`. Live repro before this change: [`/inference/agentic/439331`](https://inferencex.semianalysis.com/inference/agentic/439331) — GB300 · DeepSeek V4 Pro · FP4 · Dynamo SGLANG, c=1536.

`logHistogram` derived its log-space range by spreading the sample array:

```ts
let lnMin = Math.log(Math.min(...positive));
let lnMax = Math.log(Math.max(...positive));
```

`positive` holds one entry per request. That point's `request-chart-data` payload has **151,053 requests → 151,049 positive ISL/OSL values**, well past the ~125k V8 accepts as call arguments. The throw happens inside the `Distribution` `useMemo` during render, so the boundary swallows the entire page — charts, navigator, logs tab and all — not just the one card.

Low-concurrency points stay under the limit, which is why the distribution rebin looked fine when it landed.

## What changed

- **`lognormal.ts`** — a local `extent()` helper scans min and max in one loop; `logHistogram` uses it instead of the two spreads. Kept local and dependency-free so the module keeps its plain-numbers contract.
- **`lognormal.test.ts`** — a 200k-sample case asserting every sample is binned and the edges land on the true extremes. Verified it fails with the exact `RangeError` when reverted against the previous implementation, so it is a real guard rather than a passing decoration.

The two other `Math.min`/`Math.max` spreads in `agentic-point/` are bounded by construction — `aggregate-chart.tsx` spreads at most five percentile values, `distribution.tsx` at most fifty bin counts — and are left alone.

## Tests

`fmt` / `lint` / `typecheck` clean. Full unit suite: **3,774 tests across 198 files pass**.

## Notes for review

`time-series-math.ts:28` in this same directory already documents this exact hazard and exports `maxTimeSeriesValue()` as the loop-based guard for it. Worth considering whether these should converge on one shared helper — I kept the fix local rather than widening the diff.

## 中文说明

只要某个 AgentX 数据点的请求数超过 JS 参数上限，其详情页就会整页崩到根错误边界，显示 `RangeError: Maximum call stack size exceeded`。修复前的线上复现：[`/inference/agentic/439331`](https://inferencex.semianalysis.com/inference/agentic/439331)（GB300 · DeepSeek V4 Pro · FP4 · Dynamo SGLANG, c=1536）。

`logHistogram` 之前通过展开样本数组来求对数空间的取值范围。`positive` 每个请求一项，而该数据点的 `request-chart-data` 有 **151,053 个请求 → 151,049 个正的 ISL/OSL 值**，远超 V8 约 12.5 万的调用参数上限。异常发生在渲染期间 `Distribution` 的 `useMemo` 内，因此错误边界吞掉的是整个页面——图表、导航器、日志页签全部消失，而不只是那一张卡片。

低并发数据点不会触及该上限，这也是分布改版合入时看起来正常的原因。

### 变更内容

- **`lognormal.ts`** — 新增局部 `extent()` 辅助函数，单次循环求最小值与最大值，`logHistogram` 改用它替代两处展开。保持局部且无依赖，以维持该模块「只处理普通数字」的约定。
- **`lognormal.test.ts`** — 新增 20 万样本用例，断言所有样本均被分箱、且边界落在真实极值上。已验证：将实现回退为旧版后该测试会以完全相同的 `RangeError` 失败，因此它是真正的回归防线而非摆设。

`agentic-point/` 目录下另外两处 `Math.min`/`Math.max` 展开在结构上就是有界的——`aggregate-chart.tsx` 最多展开 5 个百分位值，`distribution.tsx` 最多 50 个分箱计数——因此未作改动。

### 测试

`fmt` / `lint` / `typecheck` 均通过。完整单元测试套件：**198 个文件、3,774 个测试全部通过**。

### 评审备注

同目录下的 `time-series-math.ts:28` 早已记录了同一类风险，并导出了基于循环的 `maxTimeSeriesValue()`。是否将两者收敛为一个共享辅助函数值得讨论——本次我选择将修复保持在局部，以免扩大改动范围。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow math-helper change with a regression test; no auth, data, or API surface changes. Remaining Math.min/max spreads in this folder stay bounded by construction.
> 
> **Overview**
> Stops agentic point-detail pages from crashing when a run has more requests than the JS argument limit (~125k). `logHistogram` no longer spreads the full sample array into `Math.min`/`Math.max`.
> 
> It now scans min/max in a local `extent()` loop, then logs those two values. A 200k-sample unit test checks every value is binned and the edges match the true range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c5e2ec916ad66050ce693fd6c8e7ddaaabf6a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->