### PR TITLE
fix(db): backfill native TensorRT-LLM KV offload metadata

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -364,6 +364,22 @@ const QWEN35_GB300_DYNAMO_TRT = {
   specMethod: 'mtp',
 } as const;
 
+const DSV4_GB300_DYNAMO_TRT = {
+  hardware: 'gb300',
+  framework: 'dynamo-trt',
+  model: 'dsv4',
+  precision: 'fp4',
+  specMethod: 'mtp',
+} as const;
+
+const GLM52_GB300_DYNAMO_TRT = {
+  hardware: 'gb300',
+  framework: 'dynamo-trt',
+  model: 'glm5.2',
+  precision: 'fp4',
+  specMethod: 'mtp',
+} as const;
+
 const DSV4_GB200_DYNAMO_VLLM = {
   hardware: 'gb200',
   framework: 'dynamo-vllm',
@@ -539,6 +555,190 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
         kv_offloading: 'dram',
         kv_offload_backend: 'native',
         kv_offload_backend_version: '1.3.0rc24',
+      },
+    },
+  })),
+
+  // The six disaggregated DeepSeek-V4-Pro recipes in run 32403083041
+  // configure a 180 GiB native host KV cache on each prefill worker. The
+  // master matrix omitted the offload annotation, so the artifacts reported
+  // these points as non-offloaded.
+  ...(
+    [
+      [
+        1523,
+        4,
+        '38be5ef96c0cd06d88da9fc176812f805d5a142f618c6c4a98d0e5dd9db6e9b7',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 8, ep: 8, dpAttn: false, numWorkers: 4 },
+        ),
+      ],
+      [
+        2415,
+        24,
+        'fb3f411ba6d72aa06658b108212333afde9ea2cb499e377fdfc65de5412592cb',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 4, ep: 4, dpAttn: false, numWorkers: 6 },
+        ),
+      ],
+      [
+        2417,
+        388,
+        '5d290a80ed5a6d5acf4b19a425017929cc9fe416161c59a76369d14e14694bac',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 1 },
+          { tp: 32, ep: 32, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2419,
+        736,
+        '3c4563cbcbd0145b101f16672e8c8072b55c0dffc0014876cc52b58556d1997b',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 2 },
+          { tp: 32, ep: 32, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2416,
+        1152,
+        '885edc2b1a2521989da184ecc0520dbbdc962b8813fd5a8a26115c343a54745d',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 3 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2418,
+        2626,
+        '6e47ac1cc8896a21dcff448d39454300783009dcd1216009b3466a6fc1d1b730',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_TRT,
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 5 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+    ] as const
+  ).map(([productionConfigId, conc, recipeFingerprint, config]) => ({
+    id: `run-32403083041-config-${productionConfigId}-conc-${conc}-native-offload`,
+    reason:
+      'The TensorRT-LLM runtime recipe configured a native host KV cache, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 32403083041,
+    runAttempt: 3,
+    productionConfigId,
+    config,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'native',
+        kv_offload_backend_version: '1.3.0rc24',
+      },
+    },
+  })),
+
+  // The six disaggregated GLM-5.2 recipes in run 32346724519 configure a
+  // 128 GiB native host KV cache on each prefill worker. The aggregate point
+  // has no host cache and is intentionally excluded. The master matrix omitted
+  // the offload annotation for the disaggregated points.
+  ...(
+    [
+      [
+        2426,
+        20,
+        '16c12cc3717783b1029c8e65865043f7d518de4af8d8477572eb594099844263',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 8, ep: 8, dpAttn: false, numWorkers: 1 },
+        ),
+      ],
+      [
+        2427,
+        30,
+        'daf6d60e1a5c68f3c00719a50d60d1b77ba603e851eb00f6149ef5989ba42e12',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 4, ep: 4, dpAttn: false, numWorkers: 4 },
+        ),
+      ],
+      [
+        2428,
+        60,
+        '454122157cfc71a5252e5ec33d7709cc4f4061c52a7ca5b28f4aea1fa3cc9011',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 3 },
+          { tp: 4, ep: 4, dpAttn: false, numWorkers: 4 },
+        ),
+      ],
+      [
+        2429,
+        152,
+        '02abb316847471b7e7bc68e41b3013dafdaddfa6c464274bdfb11d5f3b386e61',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 5 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2431,
+        227,
+        'ac551c93599bd44d074294d3de65ca5aaa6b240c12187bb5aacbef788446c65f',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 6 },
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2430,
+        259,
+        '86114ba7b339cc49098f489d2621c81c119b7fd156f4f100cde228ff3c8326d2',
+        disaggregatedConfig(
+          GLM52_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 8 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+    ] as const
+  ).map(([productionConfigId, conc, recipeFingerprint, config]) => ({
+    id: `run-32346724519-config-${productionConfigId}-conc-${conc}-native-offload`,
+    reason:
+      'The TensorRT-LLM runtime recipe configured a native host KV cache, but the artifact reported this AgentX point as non-offloaded.',
+    githubRunId: 32346724519,
+    runAttempt: 4,
+    productionConfigId,
+    config,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'native',
+        kv_offload_backend_version: '1.3.0rc22.post1',
       },
     },
   })),


### PR DESCRIPTION
## Summary

- backfill six DeepSeek-V4-Pro GB300 Dynamo–TensorRT-LLM AgentX points from InferenceX PR #2690 / source run 32403083041 attempt 3
- backfill six GLM-5.2 GB300 Dynamo–TensorRT-LLM AgentX points from InferenceX PR #2657 / source run 32346724519 attempt 4
- mark the affected points as DRAM-offloaded with the native TensorRT-LLM backend and the image-specific backend version
- remove the incorrect zero `allocated_cpu_dram_gb` metadata

The runtime recipes configure native host KV caches on the prefill workers, but the master matrix reported `kv-offloading: none`. The GLM-5.2 aggregate point is intentionally excluded because its recipe does not configure a host cache.

## Evidence

- PR #2690 recipes configure a 180 GiB prefill host cache; all six production rows are currently stored as non-offloaded
- PR #2657 disaggregated recipes configure a 128 GiB prefill host cache; all six production rows are currently stored as non-offloaded
- a read-only production preview resolved every audited selector exactly once and was aborted before applying changes

## Verification

- `bunx vitest run packages/db/src/etl/run-overrides.test.ts packages/db/src/queries/benchmarks.test.ts` (25 tests)
- `bunx oxfmt --check packages/db/src/etl/run-overrides.ts`
- `bun run typecheck`
- pre-commit format, lint, and typecheck hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Merging auto-applies production benchmark-point patches (offload identity and metrics). Scope is 12 audited AgentX rows, not ingest logic.
> 
> **Overview**
> Adds **12 audited `BENCHMARK_POINT_BACKFILLS`** so AgentX points that actually used a native TensorRT-LLM host KV cache are stored as DRAM-offloaded instead of `offloadMode: off`.
> 
> **DeepSeek-V4-Pro** (run `32403083041` attempt 3): six disaggregated GB300 Dynamo–TRT recipes with a 180 GiB prefill host cache. **GLM-5.2** (run `32346724519` attempt 4): six disaggregated recipes with a 128 GiB prefill host cache. The GLM aggregate point is left alone because it has no host cache.
> 
> Each patch sets `offloadMode` on, tags `kv_offloading: dram` / `kv_offload_backend: native` with the image-specific backend version, and drops the bogus `allocated_cpu_dram_gb` metric.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e72ea8b534e4f2074af24863efd304e3d43fac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->