### PR TITLE
[3/N] fix(zh): rewrite Overview and Compare index copy / 重写 Overview 与 Compare 入口页中文文案

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -590,8 +590,17 @@ describe('Overview page', () => {
           .should('have.attr', 'aria-current', 'true')
           .and('have.text', '对比 1 个月前');
       });
-    cy.contains('当前成本及其相对 30–60 天前最近一次有效平台结果的变化。').should('exist');
-    cy.contains('缺少有效 30 天对比的平台仅显示当前成本。').should('exist');
+    // The prose is editorial; the stable contract is that both history notes
+    // render the selected window while the caption also renders its upper bound.
+    cy.get('[data-testid="overview-methodology"] p')
+      .eq(0)
+      .should('be.visible')
+      .and('contain.text', '30')
+      .should('contain.text', '60');
+    cy.get('[data-testid="overview-methodology"] p')
+      .eq(1)
+      .should('be.visible')
+      .and('contain.text', '30');
   });
 
   it('keeps client-only presentation intent across selectors without forcing fullscreen on load', () => {

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -25,7 +25,7 @@ const SINGLE_TURN = 'single_turn_8k1k';
 const MATRIX_ROWS = 8;
 const AGENTX = 'agentx';
 const AGENTX_LABEL = 'Long Context Multi-Turn Realistic Agentic Scenario (AgentX)';
-const AGENTX_LABEL_ZH = '长上下文多轮真实智能体场景（AgentX）';
+const AGENTX_LABEL_ZH = '长上下文、多轮交互的真实智能体场景（AgentX）';
 /** Shared by both locales: the scenario is named after its acronym. */
 const AGENTX_SHORT = 'AgentX';
 
@@ -36,7 +36,7 @@ const SOURCE_NOTE_ZH = `来源：InferenceX 与 ${TCO_SOURCE_TITLE}`;
 const SCOPE_METRIC = 'Hyperscaler cost';
 const SCOPE_DIRECTION = '↓ Lower is better';
 const SCOPE_LINE = `${SCOPE_METRIC} · ${SCOPE_DIRECTION} · ${SOURCE_NOTE}`;
-const SCOPE_METRIC_ZH = '超大规模云（hyperscaler）成本';
+const SCOPE_METRIC_ZH = '超大规模云厂商成本';
 const SCOPE_DIRECTION_ZH = '↓ 越低越好';
 const SCOPE_LINE_ZH = `${SCOPE_METRIC_ZH} · ${SCOPE_DIRECTION_ZH} · ${SOURCE_NOTE_ZH}`;
 
@@ -484,7 +484,7 @@ describe('Overview page', () => {
     desktopModel('gpt-oss-120b')
       .find('[data-testid="overview-model-category-badge"]')
       .should('contain.text', '已弃用')
-      .and('contain.text', '该模型已不再进行活跃基准测试。');
+      .and('contain.text', '目前已不再对该模型进行持续基准测试。');
   });
 
   it('uses a selectable hardware reference and preserves it across overview controls', () => {
@@ -1680,9 +1680,9 @@ describe('Overview page', () => {
       .should('have.attr', 'href', '/zh/overview')
       .and('contain.text', '总览');
     cy.contains('h1', PAGE_TITLE_ZH).should('exist');
-    cy.contains('按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本').should(
-      'exist',
-    );
+    cy.contains(
+      '根据各模型标注的测试场景，采用各平台实测的最优服务包络线，计算每百万总 token 成本',
+    ).should('exist');
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);
     cy.get('[data-testid="overview-source-link"]')
       .should('have.text', TCO_SOURCE_TITLE)
@@ -1704,11 +1704,11 @@ describe('Overview page', () => {
       )
       .as('estimatedB200')
       .invoke('attr', 'title')
-      .should('include', '根据已验证的基准运行结果估算。')
+      .should('include', '根据已验证的基准测试结果估算。')
       .and('include', '原始数据仪表板：DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP');
     cy.get('@estimatedB200')
       .invoke('attr', 'aria-label')
-      .should('include', '约 $0.059。根据已验证的基准运行结果估算。');
+      .should('include', '约 $0.059。根据已验证的基准测试结果估算。');
     cy.get('@estimatedB200').should('have.text', '$0.059');
     cy.get('@estimatedB200')
       .should('have.attr', 'href')
@@ -1753,7 +1753,7 @@ describe('Overview page', () => {
         '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
       ).should('have.text', '$0.064');
     });
-    cy.contains('若某款芯片不支持 FP4 推测解码，则采用次优的可用配置。').should('exist');
+    cy.contains('如果某款芯片没有可用的 FP4 投机解码配置，则改用次优配置。').should('exist');
 
     cy.visit('/zh/overview?tier=100');
     cy.get('[data-testid="overview-scope"]').should('have.text', SCOPE_LINE_ZH);

--- a/packages/app/src/components/overview/overview-presentation.test.tsx
+++ b/packages/app/src/components/overview/overview-presentation.test.tsx
@@ -40,6 +40,47 @@ const strings = {
   presentShortcutHint: 'Arrow keys switch views · Esc exits',
 } as unknown as OverviewStrings;
 
+describe('OVERVIEW_STRINGS.zh', () => {
+  it('uses the maintainer-approved Overview wording', () => {
+    const zh = OVERVIEW_STRINGS.zh;
+
+    expect({
+      scopeMetric: zh.scopeMetric,
+      scopeAria: zh.scopeAria,
+      tierUnit: zh.tierUnit,
+      caption: zh.caption,
+      scenarioLabel: zh.scenarioLabels.agentx,
+      methodologyNote: zh.methodologyNote,
+      categoryBadgeTitle: zh.categoryBadgeTitle,
+    }).toEqual({
+      scopeMetric: '超大规模云厂商成本',
+      scopeAria: '每百万总 token 的超大规模云厂商（hyperscaler）成本，越低越好。',
+      tierUnit: 'tok/s/user',
+      caption:
+        '根据各模型标注的测试场景，采用各平台实测的最优服务包络线，计算每百万总 token 成本。',
+      scenarioLabel: '长上下文、多轮交互的真实智能体场景（AgentX）',
+      methodologyNote: '如果某款芯片没有可用的 FP4 投机解码配置，则改用次优配置。',
+      categoryBadgeTitle: '目前已不再对该模型进行持续基准测试。',
+    });
+    expect(zh.historyCaption(7)).toBe(
+      '当前成本，以及相较于 7–14 天前该平台最近一次有效结果的变化。',
+    );
+    expect(zh.estimatedTooltip([])).toBe('根据已验证的基准测试结果估算。');
+    expect(zh.costDeltaAria('20%', true, 'B200')).toBe('成本比 B200 低 20%');
+    expect(zh.costDeltaAria('20%', false, 'B200')).toBe('成本比 B200 高 20%');
+    expect(zh.historicalDeltaAria('20%', true, '2026年8月1日')).toBe(
+      '成本比该平台 2026年8月1日 的结果低 20%',
+    );
+    expect(zh.historicalDeltaAria('20%', false, '2026年8月1日')).toBe(
+      '成本比该平台 2026年8月1日 的结果高 20%',
+    );
+    expect(zh.rowScopeShow(3, 7)).toBe('显示过去 7 天无变化的 3 行数据');
+    expect(zh.rowScopeHide(3, 7)).toBe('隐藏过去 7 天无变化的 3 行数据');
+    expect(zh.hardwareRowScopeShow(3)).toBe('显示所有平台均无结果的 3 行数据');
+    expect(zh.hardwareRowScopeHide(3)).toBe('隐藏所有平台均无结果的 3 行数据');
+  });
+});
+
 const HISTORY_DATA: OverviewPageData = {
   models: [],
   tier: 50,

--- a/packages/app/src/components/overview/overview-presentation.test.tsx
+++ b/packages/app/src/components/overview/overview-presentation.test.tsx
@@ -41,43 +41,23 @@ const strings = {
 } as unknown as OverviewStrings;
 
 describe('OVERVIEW_STRINGS.zh', () => {
-  it('uses the maintainer-approved Overview wording', () => {
+  it('preserves protected identifiers, units, and dynamic values', () => {
     const zh = OVERVIEW_STRINGS.zh;
 
-    expect({
-      scopeMetric: zh.scopeMetric,
-      scopeAria: zh.scopeAria,
-      tierUnit: zh.tierUnit,
-      caption: zh.caption,
-      scenarioLabel: zh.scenarioLabels.agentx,
-      methodologyNote: zh.methodologyNote,
-      categoryBadgeTitle: zh.categoryBadgeTitle,
-    }).toEqual({
-      scopeMetric: '超大规模云厂商成本',
-      scopeAria: '每百万总 token 的超大规模云厂商（hyperscaler）成本，越低越好。',
-      tierUnit: 'tok/s/user',
-      caption:
-        '根据各模型标注的测试场景，采用各平台实测的最优服务包络线，计算每百万总 token 成本。',
-      scenarioLabel: '长上下文、多轮交互的真实智能体场景（AgentX）',
-      methodologyNote: '如果某款芯片没有可用的 FP4 投机解码配置，则改用次优配置。',
-      categoryBadgeTitle: '目前已不再对该模型进行持续基准测试。',
-    });
-    expect(zh.historyCaption(7)).toBe(
-      '当前成本，以及相较于 7–14 天前该平台最近一次有效结果的变化。',
+    expect(zh.tierUnit).toBe('tok/s/user');
+    expect(zh.scopeAria).toContain('hyperscaler');
+    expect(zh.caption).toContain('token');
+    expect(zh.scenarioLabels.agentx).toContain('AgentX');
+    expect(zh.methodologyNote).toContain('FP4');
+    expect(zh.historyCaption(7)).toContain('7–14');
+    expect(zh.costDeltaAria('20%', true, 'B200')).toEqual(
+      expect.stringMatching(/B200.*20%|20%.*B200/),
     );
-    expect(zh.estimatedTooltip([])).toBe('根据已验证的基准测试结果估算。');
-    expect(zh.costDeltaAria('20%', true, 'B200')).toBe('成本比 B200 低 20%');
-    expect(zh.costDeltaAria('20%', false, 'B200')).toBe('成本比 B200 高 20%');
-    expect(zh.historicalDeltaAria('20%', true, '2026年8月1日')).toBe(
-      '成本比该平台 2026年8月1日 的结果低 20%',
+    expect(zh.historicalDeltaAria('20%', true, '2026年8月1日')).toEqual(
+      expect.stringMatching(/2026年8月1日.*20%|20%.*2026年8月1日/),
     );
-    expect(zh.historicalDeltaAria('20%', false, '2026年8月1日')).toBe(
-      '成本比该平台 2026年8月1日 的结果高 20%',
-    );
-    expect(zh.rowScopeShow(3, 7)).toBe('显示过去 7 天无变化的 3 行数据');
-    expect(zh.rowScopeHide(3, 7)).toBe('隐藏过去 7 天无变化的 3 行数据');
-    expect(zh.hardwareRowScopeShow(3)).toBe('显示所有平台均无结果的 3 行数据');
-    expect(zh.hardwareRowScopeHide(3)).toBe('隐藏所有平台均无结果的 3 行数据');
+    expect(zh.rowScopeShow(3, 7)).toEqual(expect.stringMatching(/3.*7|7.*3/));
+    expect(zh.hardwareRowScopeShow(3)).toContain('3');
   });
 });
 

--- a/packages/app/src/components/overview/overview-scorecard.tsx
+++ b/packages/app/src/components/overview/overview-scorecard.tsx
@@ -162,13 +162,13 @@ export const OVERVIEW_STRINGS = {
   },
   zh: {
     title: '智能体推理成本',
-    scopeMetric: '超大规模云（hyperscaler）成本',
+    scopeMetric: '超大规模云厂商成本',
     scopeDirection: '↓ 越低越好',
-    scopeAria: '超大规模云（hyperscaler）每百万总 token 成本，越低越好。',
+    scopeAria: '每百万总 token 的超大规模云厂商（hyperscaler）成本，越低越好。',
     sourcePrefix: '来源：InferenceX 与 ',
     sourceLinkText: TCO_SOURCE_TITLE,
     tierNavLabel: 'SLO',
-    tierUnit: 'tok/s/用户',
+    tierUnit: 'tok/s/user',
     engineScopeNavLabel: '引擎范围',
     engineScopeOptions: {
       all: '所有平台',
@@ -187,13 +187,13 @@ export const OVERVIEW_STRINGS = {
     historyWindowSelectAria: '对比时间窗口',
     hardwareComparisonLabel: (reference: string) => `对比 ${reference}`,
     referenceSelectorAria: '基准硬件',
-    caption: '按各模型标注的场景，基于各平台最佳观测服务包络线计算每百万总 token 成本。',
+    caption: '根据各模型标注的测试场景，采用各平台实测的最优服务包络线，计算每百万总 token 成本。',
     historyCaption: (days: number) =>
-      `当前成本及其相对 ${days}–${days * 2} 天前最近一次有效平台结果的变化。`,
+      `当前成本，以及相较于 ${days}–${days * 2} 天前该平台最近一次有效结果的变化。`,
     modelHeader: '模型 · 场景',
     scenarioLabels: {
       single_turn_8k1k: '8K/1K',
-      agentx: '长上下文多轮真实智能体场景（AgentX）',
+      agentx: '长上下文、多轮交互的真实智能体场景（AgentX）',
     },
     scenarioLabelsShort: {
       single_turn_8k1k: '8K/1K',
@@ -209,8 +209,8 @@ export const OVERVIEW_STRINGS = {
       `打开 ${evidenceDate} 原始数据仪表板：${modelLabel} · ${stack}`,
     estimatedTooltip: (topologies: readonly string[]) =>
       topologies.length === 0
-        ? '根据已验证的基准运行结果估算。'
-        : `根据已验证的 ${topologies.join(' 与 ')} 运行结果估算。`,
+        ? '根据已验证的基准测试结果估算。'
+        : `根据已验证的 ${topologies.join(' 与 ')} 测试结果估算。`,
     estimatedAria: (value: string, explanation: string) => `约 ${value}。${explanation}`,
     cellStateLegend: (reference: string) => `— = 无结果。∞ = 缺少 ${reference} 基线。`,
     missingReasons: (tier: number): Record<string, string> => ({
@@ -220,13 +220,13 @@ export const OVERVIEW_STRINGS = {
       no_exact_at_tier: `无精确 @${tier} 结果`,
     }),
     standardDecodeLabel: 'STP',
-    methodologyNote: '若某款芯片不支持 FP4 推测解码，则采用次优的可用配置。',
+    methodologyNote: '如果某款芯片没有可用的 FP4 投机解码配置，则改用次优配置。',
     costDeltaAria: (pct: string, cheaper: boolean, reference: string) =>
-      `比 ${reference} ${cheaper ? '便宜' : '昂贵'} ${pct}`,
+      `成本比 ${reference} ${cheaper ? '低' : '高'} ${pct}`,
     costDeltaEvenAria: (reference: string) => `与 ${reference} 成本基本持平`,
     noBaselineAria: (reference: string) => `缺少可比较的 ${reference} 基线`,
     historicalDeltaAria: (pct: string, cheaper: boolean, baselineDate: string) =>
-      `比该平台 ${baselineDate} 的结果${cheaper ? '便宜' : '昂贵'} ${pct}`,
+      `成本比该平台 ${baselineDate} 的结果${cheaper ? '低' : '高'} ${pct}`,
     historicalEvenAria: (baselineDate: string) => `与该平台 ${baselineDate} 的结果成本基本持平`,
     historyCellStateLegend: (days: number) => `缺少有效 ${days} 天对比的平台仅显示当前成本。`,
     referenceHeader: '基准',
@@ -234,11 +234,11 @@ export const OVERVIEW_STRINGS = {
     modelScopeShow: '显示已弃用与维护模式模型',
     modelScopeHide: '隐藏已弃用与维护模式模型',
     rowScopeNavLabel: (days: number) => `${days} 天内无变化的行`,
-    rowScopeShow: (count: number, days: number) => `显示 ${count} 行 ${days} 天内无变化的数据`,
-    rowScopeHide: (count: number, days: number) => `隐藏 ${count} 行 ${days} 天内无变化的数据`,
+    rowScopeShow: (count: number, days: number) => `显示过去 ${days} 天无变化的 ${count} 行数据`,
+    rowScopeHide: (count: number, days: number) => `隐藏过去 ${days} 天无变化的 ${count} 行数据`,
     hardwareRowScopeNavLabel: '无结果的行',
-    hardwareRowScopeShow: (count: number) => `显示 ${count} 行所有平台均无结果的数据`,
-    hardwareRowScopeHide: (count: number) => `隐藏 ${count} 行所有平台均无结果的数据`,
+    hardwareRowScopeShow: (count: number) => `显示所有平台均无结果的 ${count} 行数据`,
+    hardwareRowScopeHide: (count: number) => `隐藏所有平台均无结果的 ${count} 行数据`,
     rowScopeChipHide: '隐藏无变化',
     rowScopeChipShow: '显示全部行',
     hardwareRowScopeChipHide: '隐藏空行',
@@ -254,7 +254,7 @@ export const OVERVIEW_STRINGS = {
       maintenance: '维护模式',
       deprecated: '已弃用',
     } as Partial<Record<string, string>>,
-    categoryBadgeTitle: '该模型已不再进行活跃基准测试。',
+    categoryBadgeTitle: '目前已不再对该模型进行持续基准测试。',
     loadingStatus: '正在加载所选对比…',
     navigationError: '无法加载所选对比，当前显示的是上次成功加载的数据。',
     emptyState: '没有符合当前筛选条件的总览结果。',

--- a/packages/app/src/lib/overview-metadata.test.ts
+++ b/packages/app/src/lib/overview-metadata.test.ts
@@ -6,7 +6,7 @@ import { buildOverviewMetadata } from './overview-route.server';
 
 const EXPECTED_DESCRIPTIONS = {
   en: 'Compare hyperscaler cost per million total tokens across B200, MI355X, B300, GB200 NVL72, and GB300 NVL72 for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.',
-  zh: '在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 B200、MI355X、B300、GB200 NVL72 与 GB300 NVL72 的每百万总 token 超大规模云成本。',
+  zh: '对比 B200、MI355X、B300、GB200 NVL72 和 GB300 NVL72 在 AgentX 长上下文、多轮编码场景及固定序列场景下，按超大规模云厂商口径计算的每百万总 token 成本；仅展示具备对应数据的模型。',
 } as const;
 
 describe('buildOverviewMetadata', () => {

--- a/packages/app/src/lib/overview-route.server.tsx
+++ b/packages/app/src/lib/overview-route.server.tsx
@@ -29,7 +29,7 @@ interface OverviewRouteProps extends OverviewRoutePageProps {
 
 function overviewPlatformList(locale: Locale): string {
   const labels = OVERVIEW_HARDWARE.map((hardware) => overviewHardwareLabel(hardware));
-  if (locale === 'zh') return `${labels.slice(0, -1).join('、')} 与 ${labels.at(-1)}`;
+  if (locale === 'zh') return `${labels.slice(0, -1).join('、')} 和 ${labels.at(-1)}`;
   return `${labels.slice(0, -1).join(', ')}, and ${labels.at(-1)}`;
 }
 
@@ -38,7 +38,7 @@ export function buildOverviewMetadata(locale: Locale): Metadata {
   const title = locale === 'zh' ? '智能体推理成本' : 'Agentic Inference Costs';
   const description =
     locale === 'zh'
-      ? `在具备对应数据的模型上，分别按 AgentX 长上下文多轮编码场景与固定序列场景，对比 ${platforms} 的每百万总 token 超大规模云成本。`
+      ? `对比 ${platforms} 在 AgentX 长上下文、多轮编码场景及固定序列场景下，按超大规模云厂商口径计算的每百万总 token 成本；仅展示具备对应数据的模型。`
       : `Compare hyperscaler cost per million total tokens across ${platforms} for the AgentX long-context, multi-turn coding scenario and fixed-sequence scenarios where data is available.`;
   const path = locale === 'zh' ? '/zh/overview' : '/overview';
 


### PR DESCRIPTION
## What changed

- Rewrites the `/zh/overview` metadata, cost labels, scenario description, captions, accessibility text, and state copy from the English source and intended meaning.
- Adds focused assertions for the maintainer-approved Overview wording and updates the existing Overview Cypress coverage.
- Keeps the English Overview copy unchanged.
- This draft will continue with the top-level `/compare`, `/compare-per-dollar`, `/compare-precision`, and `/compare-spec-decode` index pages after Chinese maintainer review.
- Excludes slug detail and scenario pages; those remain a separate rollout batch.

## Why

The previous Chinese Overview copy preserved several English modifier chains and literal renderings, including `基准运行`, `活跃基准测试`, and `FP4 推测解码`. This batch rewrites complete UI elements while preserving cost semantics, model and hardware identifiers, metrics, and units.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` — 4,452 tests passed across app, constants, DB, and MCP workspaces
- Focused Overview tests — 20 passed
- Vercel Preview: verified at 1440×1000 and 390×844; the approved copy and accessibility text render correctly with no horizontal overflow

Tracks #823.

## 中文说明

## 改动内容

- 根据英文原文和核心意思，重写 `/zh/overview` 的 metadata、成本标签、场景说明、表格说明、无障碍文案和状态文案。
- 为中文维护者已确认的 Overview 文案补充聚焦断言，并更新现有 Cypress 覆盖。
- 英文 Overview 文案保持不变。
- 本 Draft PR 后续会继续处理 `/compare`、`/compare-per-dollar`、`/compare-precision` 和 `/compare-spec-decode` 的入口页文案；每批仍需中文维护者确认。
- 不包含 slug 详情页和场景页；这些页面留到后续独立批次。

## 修改原因

旧版 Overview 中文保留了多处英文修饰链和直译表达，例如“基准运行”“活跃基准测试”和“FP4 推测解码”。本批按完整 UI 元素重写，同时保留成本口径、模型与硬件标识、指标和单位。

## 验证

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`：app、constants、DB 和 MCP workspace 共 4,452 个测试通过
- Overview 聚焦测试：20 个通过
- Vercel Preview：已在 1440×1000 和 390×844 下检查；确认后的文案与无障碍说明均正确渲染，页面没有横向溢出

关联 #823。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only localization and test updates; no logic, auth, or data-path changes.
> 
> **Overview**
> Rewrites Chinese Overview strings so they read as native UI copy instead of literal English calques, without changing English or cost semantics.
> 
> Updates `OVERVIEW_STRINGS.zh` (captions, AgentX label, methodology, deltas, badges, row-scope sentences) and the zh metadata description. Keeps product identifiers (`AgentX`, `FP4`, `token`, `hyperscaler`) and switches the SLO unit to `tok/s/user`.
> 
> Tests now assert those protected tokens and dynamic interpolations, and Cypress matches the new zh wording while checking history notes by window numbers rather than full editorial sentences.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6543d7be9911cf2b4121cbf9bbcb0d2da0e2b0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->