### PR TITLE
fix(models): show GLM 5.2/5.3 parameter size / 显示 GLM 5.2/5.3 参数规模

### DIFF
--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -277,7 +277,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');
     expect(getModelLabel(Model.GLM_5)).toBe('GLM5/5.1 744B');
-    expect(getModelLabel(Model.GLM_5_2)).toBe('GLM5.2/GLM5.3');
+    expect(getModelLabel(Model.GLM_5_2)).toBe('GLM5.2/GLM5.3 744B');
     expect(getModelLabel(Model.MiniMax_M2_5)).toBe('MiniMax M2.5/2.7 230B');
   });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -165,7 +165,7 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   [Model.GLM_5]: { label: 'GLM5/5.1 744B', prefix: 'glm5', category: 'deprecated' },
   // GLM-5.2 and GLM-5.3 share the same architecture and inference profile, so
   // the selector presents both releases over the existing GLM-5.2 data bucket.
-  [Model.GLM_5_2]: { label: 'GLM5.2/GLM5.3', prefix: 'glm5.2', category: 'default' },
+  [Model.GLM_5_2]: { label: 'GLM5.2/GLM5.3 744B', prefix: 'glm5.2', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {


### PR DESCRIPTION
## Summary

- Append the 744B parameter count to the shared GLM5.2/GLM5.3 model dropdown label.
- Update the model-label regression test to cover the complete display text.
- This is a shared selector-label change only; official and `?unofficialrun=` overlay data paths are unchanged.

## Testing

- `bun run test:unit` (4,452 tests passed)
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:e2e`: component smoke tests passed (27/27); data-backed integration tests could not complete locally because `DATABASE_READONLY_URL` is not set.

## 中文说明

- 在共享的 GLM5.2/GLM5.3 模型下拉菜单标签中补充 744B 参数规模。
- 更新模型标签回归测试，覆盖完整的展示文案。
- 本次仅调整共享选择器标签；官方数据与 `?unofficialrun=` 非官方运行叠加层的数据路径均未改动。

## 测试

- `bun run test:unit`（4,452 项测试通过）
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:e2e`：组件冒烟测试通过（27/27）；由于本地未配置 `DATABASE_READONLY_URL`，依赖数据库的集成测试无法完成。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic label string change only; no routing, data, or security impact.
> 
> **Overview**
> Appends **744B** to the shared GLM5.2/GLM5.3 dropdown label so it matches other models that show parameter count.
> 
> Display-only: `getModelLabel` / `MODEL_CONFIG` text and the unit test; prefixes, categories, and data paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c78d89c2ab5539ab0244d6acc0db0211b653db25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->