### PR TITLE
fix(overview): avoid duplicate locale navigation / 避免总览页语言切换重复导航

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -70,6 +70,20 @@ describe('Header', () => {
     cy.wrap(mockRouter.push).should('have.been.calledTwice');
   });
 
+  it('retains resilient locale navigation outside Overview', () => {
+    cy.clock();
+    mountHeader('/inference');
+    cy.get('[data-testid="language-toggle"]')
+      .invoke('attr', 'href')
+      .then((href) => {
+        expect(href).to.include('/zh/inference');
+        cy.get('[data-testid="language-toggle"]').click();
+        cy.wrap(mockRouter.push).should('have.been.calledOnceWith', href);
+        cy.tick(250);
+        cy.wrap(mockRouter.push).should('have.been.calledTwice');
+      });
+  });
+
   it('makes a click on the tab already showing a no-op', () => {
     mountHeader('/overview');
     cy.get('[data-testid="nav-link-overview"]').click();

--- a/packages/app/cypress/e2e/blog.cy.ts
+++ b/packages/app/cypress/e2e/blog.cy.ts
@@ -28,6 +28,9 @@ describe('Blog', () => {
 
   describe('Blog post page', () => {
     before(() => {
+      cy.intercept('GET', 'https://substack-post-media.s3.amazonaws.com/**', {
+        statusCode: 204,
+      });
       cy.visit('/blog/inferencemax-open-source-inference-benchmarking');
     });
 

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -526,6 +526,28 @@ describe('Overview page', () => {
     cy.get('[data-overview-comparison="hardware"]').should('contain.text', '对比 B300');
   });
 
+  it('sends one RSC request when a slow language switch preserves overview state', () => {
+    let zhOverviewRscRequests = 0;
+
+    cy.intercept('GET', '/zh/overview*', (request) => {
+      if (request.query._rsc === undefined && request.headers.rsc !== '1') return;
+
+      zhOverviewRscRequests += 1;
+      request.continue((response) => {
+        response.setDelay(600);
+      });
+    });
+
+    cy.visit('/overview?tier=100&ref=b300');
+    cy.get('[data-testid="language-toggle"]')
+      .should('have.attr', 'href', '/zh/overview?tier=100&ref=b300')
+      .click();
+
+    cy.location('pathname').should('eq', '/zh/overview');
+    cy.location('search').should('eq', '?tier=100&ref=b300');
+    cy.then(() => expect(zhOverviewRscRequests).to.equal(1));
+  });
+
   it('uses rack SKU labels when GB200 or GB300 is the comparison reference', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview?ref=gb200');

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -107,21 +107,31 @@ function isCurrentPage(pathname: string, displayHref: string): boolean {
 }
 
 /** EN ↔ 中文 switcher; maps the current page to its sibling in the other language. */
-function LanguageToggle({ pathname }: { pathname: string }) {
+function LanguageToggle({
+  pathname,
+  router,
+}: {
+  pathname: string;
+  router: ReturnType<typeof useRouter>;
+}) {
   const isZh = isZhPathname(pathname);
   const target = switchLocalePath(pathname);
   const search = useClientSearch();
+  const isOverview = isActive(pathname, '/overview');
   return (
     <Link
       href={target + search}
       // Only /overview rewrites this href per interaction, which would
       // re-prefetch its force-dynamic sibling on every selector commit.
       // Everywhere else the href is stable, so let Next prefetch it.
-      prefetch={isActive(pathname, '/overview') ? false : undefined}
+      prefetch={isOverview ? false : undefined}
       data-testid="language-toggle"
       hrefLang={isZh ? 'en' : 'zh-CN'}
       className="inline-flex items-center min-h-11 px-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors whitespace-nowrap"
-      onClick={() => track('header_language_toggled', { to: isZh ? 'en' : 'zh' })}
+      onClick={(event) => {
+        track('header_language_toggled', { to: isZh ? 'en' : 'zh' });
+        if (!isOverview) navigateInApp(event, router, target + search);
+      }}
     >
       {isZh ? 'EN' : '中文'}
     </Link>
@@ -247,7 +257,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
             <span className="hidden sm:flex">
               <GitHubStars owner="SemiAnalysisAI" repo="InferenceX" starCount={starCount} />
             </span>
-            <LanguageToggle pathname={pathname} />
+            <LanguageToggle pathname={pathname} router={router} />
             {/* Below `sm` these move into the mobile menu — they are what push
                 a 320px header past its bounds in minecraft mode. */}
             <span className="hidden items-center gap-2 sm:flex">

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -107,13 +107,7 @@ function isCurrentPage(pathname: string, displayHref: string): boolean {
 }
 
 /** EN ↔ 中文 switcher; maps the current page to its sibling in the other language. */
-function LanguageToggle({
-  pathname,
-  router,
-}: {
-  pathname: string;
-  router: ReturnType<typeof useRouter>;
-}) {
+function LanguageToggle({ pathname }: { pathname: string }) {
   const isZh = isZhPathname(pathname);
   const target = switchLocalePath(pathname);
   const search = useClientSearch();
@@ -127,10 +121,7 @@ function LanguageToggle({
       data-testid="language-toggle"
       hrefLang={isZh ? 'en' : 'zh-CN'}
       className="inline-flex items-center min-h-11 px-2 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors whitespace-nowrap"
-      onClick={(event) => {
-        track('header_language_toggled', { to: isZh ? 'en' : 'zh' });
-        navigateInApp(event, router, target + search);
-      }}
+      onClick={() => track('header_language_toggled', { to: isZh ? 'en' : 'zh' })}
     >
       {isZh ? 'EN' : '中文'}
     </Link>
@@ -256,7 +247,7 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
             <span className="hidden sm:flex">
               <GitHubStars owner="SemiAnalysisAI" repo="InferenceX" starCount={starCount} />
             </span>
-            <LanguageToggle pathname={pathname} router={router} />
+            <LanguageToggle pathname={pathname} />
             {/* Below `sm` these move into the mobile menu — they are what push
                 a 320px header past its bounds in minecraft mode. */}
             <span className="hidden items-center gap-2 sm:flex">


### PR DESCRIPTION
## What changed

- Let the EN/中文 toggle use its canonical Next.js Link navigation instead of the 250 ms retry helper.
- Preserve Overview query state and the existing analytics event.
- Add a delayed RSC regression that asserts one request while switching locale.

## Why

A slow `/overview` response kept the pathname unchanged past the retry window, so one language-toggle click issued two RSC requests and made the transition feel slower.

## Validation

- TDD regression: failed with 2 requests before the fix, passes with 1 after it
- Production fixture build
- Overview E2E: Chrome 43/43, Firefox 43/43
- E2E smoke: component 27/27, integration 75/75
- Unit tests: 4,602/4,602
- Typecheck, lint, format, and diff check

## 中文说明

- 中英文切换按钮改用规范的 Next.js Link 导航，不再触发 250 ms 后的重复重试。
- 保留总览页查询参数与原有埋点事件。
- 新增延迟 RSC 回归测试，确保语言切换只发送一次请求。

旧逻辑在 `/overview` 响应较慢时会在路径更新前触发第二次 RSC 请求，导致切换语言的体感延迟被进一步放大。本 PR 只收窄语言切换路径，不改变其他 header 导航的既有 workaround。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small click-handler change on the language toggle, scoped to Overview and covered by a regression that asserts a single RSC request.
> 
> **Overview**
> Stops the Overview language toggle from using the 250ms `navigateInApp` retry. Slow `/overview` RSC responses used to leave the pathname unchanged past that window, so one click issued two requests.
> 
> The EN/中文 link still tracks analytics and keeps query state. On Overview it now relies on Next.js `Link` only. Other header links keep the retry helper.
> 
> Adds a delayed-RSC e2e that asserts a single `/zh/overview` request, a component test that the retry still runs off Overview, and a Substack media intercept to stabilize the blog post visit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad024254906761e8ac8bb939444f492079d81796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->