### PR TITLE
Prevent dataset loading layout shift / 防止数据集加载时发生布局偏移

### DIFF
--- a/packages/app/cypress/e2e/datasets-distributions.cy.ts
+++ b/packages/app/cypress/e2e/datasets-distributions.cy.ts
@@ -19,6 +19,20 @@ const distribution = (values: {
   },
 });
 
+const LAYOUT_DATASET = {
+  id: 'layout-dataset',
+  slug: 'layout-dataset',
+  label: 'Layout dataset',
+  variant: 'full',
+  description: null,
+  hf_url: null,
+  license: 'apache-2.0',
+  conversation_count: 0,
+  summary: {},
+  chart_data: {},
+  ingested_at: '2026-06-23T00:00:00Z',
+};
+
 describe('Dataset distribution percentiles', () => {
   before(() => {
     cy.intercept('GET', '/api/v1/datasets/test-dataset', {
@@ -132,4 +146,29 @@ describe('Dataset distribution percentiles', () => {
       });
     }
   });
+});
+
+describe('Dataset detail loading stability', () => {
+  for (const path of ['/agentx/layout-dataset', '/zh/agentx/layout-dataset']) {
+    it(`keeps the footer below the viewport while ${path} loads`, () => {
+      cy.intercept('GET', '/api/v1/datasets/layout-dataset', {
+        delay: 1500,
+        body: LAYOUT_DATASET,
+      }).as('dataset');
+      cy.intercept('GET', '/api/v1/datasets/layout-dataset/conversations*', {
+        body: { total: 0, items: [] },
+      });
+
+      cy.visit(path, { onBeforeLoad: unlockAgenticGate });
+      cy.get('[data-testid="dataset-detail-loading"]').should('be.visible');
+      cy.get('[data-testid="footer"]').then(($footer) => {
+        cy.window().then((win) => {
+          expect($footer[0].getBoundingClientRect().top).to.be.at.least(win.innerHeight);
+        });
+      });
+
+      cy.wait('@dataset');
+      cy.contains('h1', 'Layout dataset').should('be.visible');
+    });
+  }
 });

--- a/packages/app/src/components/datasets/dataset-detail.tsx
+++ b/packages/app/src/components/datasets/dataset-detail.tsx
@@ -155,11 +155,18 @@ export function DatasetDetail({ slug }: { slug: string }) {
   const paginationPending = searchInput !== search || isFetching || isPlaceholderData;
 
   if (isLoading) {
-    return <div className="py-12 text-center text-sm text-muted-foreground">{t.loading}</div>;
+    return (
+      <div
+        className="min-h-svh py-12 text-center text-sm text-muted-foreground"
+        data-testid="dataset-detail-loading"
+      >
+        {t.loading}
+      </div>
+    );
   }
   if (isError || !dataset) {
     return (
-      <div className="py-12 text-center text-sm text-destructive">
+      <div className="min-h-svh py-12 text-center text-sm text-destructive">
         {t.notFound}{' '}
         <Link href={`${prefix}/agentx`} className="text-primary underline">
           {t.backToDatasets}
@@ -174,7 +181,7 @@ export function DatasetDetail({ slug }: { slug: string }) {
   const pageCount = Math.ceil(total / PAGE);
 
   return (
-    <div className="flex flex-col gap-6">
+    <div className="min-h-svh flex flex-col gap-6">
       {/* header */}
       <div>
         <div className="mb-1 flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Reserve a stable `100svh` minimum height for dataset detail loading, error, and loaded states so delayed API data cannot pull the footer through the viewport.
- Keep the fix shared by the English and `/zh` dataset detail routes.
- Add delayed-response Cypress coverage that verifies the footer remains below the viewport on both routes.

## Verification

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,602 tests)
- `bun run test:e2e` against the production build with `E2E_FIXTURES=1`
- `bunx cypress run --spec cypress/e2e/datasets-distributions.cy.ts --browser chrome` (6 tests)
- Browser verification with a 1.5 second dataset API delay: CLS improved from `0.7298` to `0` on both `/agentx/...` and `/zh/agentx/...`; the loading footer starts at 923 px with an 818 px viewport.

## 中文说明

- 为数据集详情页的加载、错误和正常内容状态统一保留 `100svh` 最小高度，避免 API 响应较慢时 footer 从视口内被推到页面下方，从而产生明显布局偏移。
- 修复由共享组件实现，同时覆盖英文路由与 `/zh` 中文路由。
- 新增延迟响应的 Cypress 回归测试，验证两个路由在加载期间都能让 footer 保持在视口之外。

## 验证

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（共 4,602 项测试）
- 使用 `E2E_FIXTURES=1` 启动 production build 后运行 `bun run test:e2e`
- `bunx cypress run --spec cypress/e2e/datasets-distributions.cy.ts --browser chrome`（6 项测试）
- 将数据集 API 人为延迟 1.5 秒后进行浏览器验证：`/agentx/...` 与 `/zh/agentx/...` 的 CLS 均从 `0.7298` 降至 `0`；视口高度为 818 px 时，加载状态下的 footer 起始位置为 923 px。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS min-height and e2e coverage only; no data, auth, or API behavior changes.
> 
> **Overview**
> Stops the dataset detail footer from jumping into view while the API is still loading, which was causing a large CLS spike on both English and `/zh` routes.
> 
> `DatasetDetail` now uses `min-h-svh` for loading, not-found, and loaded states so the page always occupies at least a full viewport. Cypress covers delayed responses on `/agentx/...` and `/zh/agentx/...` and asserts the footer stays below the viewport until content appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b936aa7ba9d620b18ec2b6c35cb5746a0fc6d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->