### PR TITLE
Reduce coach mark anchor scan overhead / 降低引导标记锚点扫描开销

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -813,7 +813,7 @@ export default function ChartDisplay() {
                       );
                     }}
                   />
-                  <Card>
+                  <Card data-coach-mark-root="">
                     {(() => {
                       const chartCaption = (
                         <>

--- a/packages/app/src/components/ui/coach-mark.test.tsx
+++ b/packages/app/src/components/ui/coach-mark.test.tsx
@@ -28,10 +28,10 @@ function stubRect(element: Element, left: number, top: number, size = 12): void 
 }
 
 /** A point the resolver can find, mid-viewport so it passes the on-screen check. */
-function addPoint(): HTMLElement {
+function addPoint(parent: ParentNode = document.body): HTMLElement {
   const point = document.createElement('div');
   point.className = 'dot-group';
-  document.body.append(point);
+  parent.append(point);
   stubRect(point, 500, 300);
   return point;
 }
@@ -170,5 +170,70 @@ describe('CoachMark input handling', () => {
 
     pressEscape();
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CoachMark anchor reuse', () => {
+  it('reuses one resolved anchor across scoped transform mutations', async () => {
+    const chart = document.createElement('div');
+    document.body.append(chart);
+    const point = addPoint(chart);
+    const resolve = vi.fn(() => point);
+    const getRect = vi.fn((element: Element) => element.getBoundingClientRect());
+
+    renderCoachMark({
+      resolve,
+      getRect,
+      getMutationRoot: () => chart,
+      actionSelector: ACTION_SELECTOR,
+    });
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(getRect).toHaveBeenCalledTimes(1);
+
+    const outside = document.createElement('div');
+    document.body.append(outside);
+    outside.setAttribute('transform', 'translate(1,1)');
+    await flushReposition();
+    expect(getRect, 'outside mutation ignored').toHaveBeenCalledTimes(1);
+
+    for (let index = 0; index < 20; index++) {
+      point.setAttribute('transform', `translate(${index},${index})`);
+    }
+    await flushReposition();
+
+    expect(resolve, 'full resolver stays cached').toHaveBeenCalledTimes(1);
+    expect(getRect, 'one cached measurement for the frame').toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves a replacement when the cached anchor becomes unusable', async () => {
+    const chart = document.createElement('div');
+    document.body.append(chart);
+    const first = addPoint(chart);
+    const second = addPoint(chart);
+    stubRect(second, 700, 400);
+    let current = first;
+    let firstUsable = true;
+    const resolve = vi.fn(() => current);
+    const getRect = vi.fn((element: Element) =>
+      element === first && !firstUsable ? null : element.getBoundingClientRect(),
+    );
+
+    renderCoachMark({
+      resolve,
+      getRect,
+      getMutationRoot: () => chart,
+      actionSelector: ACTION_SELECTOR,
+    });
+    expect(resolve).toHaveBeenCalledTimes(1);
+
+    current = second;
+    firstUsable = false;
+    first.setAttribute('transform', 'translate(1,1)');
+    await flushReposition();
+
+    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('[data-testid="coach-mark-target"]')?.getAttribute('cx')).toBe(
+      '706',
+    );
   });
 });

--- a/packages/app/src/components/ui/coach-mark.test.tsx
+++ b/packages/app/src/components/ui/coach-mark.test.tsx
@@ -236,4 +236,16 @@ describe('CoachMark anchor reuse', () => {
       '706',
     );
   });
+
+  it('stays hidden when a resolved anchor fails validation', () => {
+    const point = addPoint();
+
+    renderCoachMark({
+      resolve: () => point,
+      getRect: () => null,
+      actionSelector: ACTION_SELECTOR,
+    });
+
+    expect(isVisible()).toBe(false);
+  });
 });

--- a/packages/app/src/components/ui/coach-mark.tsx
+++ b/packages/app/src/components/ui/coach-mark.tsx
@@ -92,7 +92,7 @@ export function CoachMark({
       let rect = element && getRect ? getRect(element) : null;
       if (!element || !rect) {
         element = resolve();
-        rect = element ? (getRect?.(element) ?? element.getBoundingClientRect()) : null;
+        rect = element ? (getRect ? getRect(element) : element.getBoundingClientRect()) : null;
       }
       anchorRef.current = element && rect ? element : null;
 

--- a/packages/app/src/components/ui/coach-mark.tsx
+++ b/packages/app/src/components/ui/coach-mark.tsx
@@ -70,9 +70,12 @@ export function CoachMark({
   const locale = useLocale();
   const strings = STRINGS[locale];
   const cardRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<Element | null>(null);
   const [placement, setPlacement] = useState<CoachMarkPlacement | null>(null);
 
   const resolve = anchor.resolve;
+  const getRect = anchor.getRect;
+  const getMutationRoot = anchor.getMutationRoot;
   const repositionEvents = anchor.repositionEvents;
   const actionSelector = anchor.actionSelector;
 
@@ -83,13 +86,21 @@ export function CoachMark({
     const measure = () => {
       frame = 0;
       const card = cardRef.current;
-      const element = resolve();
-      if (!card || !element) {
+      if (!card) return;
+
+      let element = getRect && anchorRef.current?.isConnected ? anchorRef.current : null;
+      let rect = element && getRect ? getRect(element) : null;
+      if (!element || !rect) {
+        element = resolve();
+        rect = element ? (getRect?.(element) ?? element.getBoundingClientRect()) : null;
+      }
+      anchorRef.current = element && rect ? element : null;
+
+      if (!element || !rect) {
         setPlacement((prev) => (prev === null ? prev : null));
         return;
       }
       const viewport = viewportSize();
-      const rect = element.getBoundingClientRect();
       if (!isAnchorOnScreen(rect, viewport)) {
         setPlacement((prev) => (prev === null ? prev : null));
         return;
@@ -115,13 +126,29 @@ export function CoachMark({
     window.addEventListener('scroll', schedule, { capture: true, passive: true });
     for (const event of repositionEvents ?? []) window.addEventListener(event, schedule);
 
-    // d3 zoom/pan rewrites `transform` on the zoom group and on every point;
-    // re-renders replace the point nodes outright. Watching both, throttled to
-    // one recompute per frame, keeps the pointer glued to its point.
-    const observer = new MutationObserver(schedule);
-    observer.observe(document.body, {
+    // D3 coordinate transitions rewrite `transform` on every point each
+    // frame. Keep the selected anchor for those mutations and validate just
+    // that point. Structural, visibility, and trace-availability changes can
+    // change which point is eligible, so they invalidate the cached choice.
+    const observer = new MutationObserver((records) => {
+      if (
+        records.some(
+          (record) => record.type === 'childList' || record.attributeName !== 'transform',
+        )
+      ) {
+        anchorRef.current = null;
+      }
+      schedule();
+    });
+    observer.observe(getMutationRoot?.(anchorRef.current) ?? document.body, {
       attributes: true,
-      attributeFilter: ['transform', 'style', 'data-has-trace', 'data-benchmark-type'],
+      attributeFilter: [
+        'transform',
+        'style',
+        'data-has-trace',
+        'data-trace-availability',
+        'data-benchmark-type',
+      ],
       childList: true,
       subtree: true,
     });
@@ -133,7 +160,7 @@ export function CoachMark({
       window.removeEventListener('scroll', schedule, { capture: true });
       for (const event of repositionEvents ?? []) window.removeEventListener(event, schedule);
     };
-  }, [resolve, repositionEvents]);
+  }, [resolve, getRect, getMutationRoot, repositionEvents]);
 
   /**
    * Whether the callout is actually on screen. The card stays mounted while

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.test.ts
@@ -4,6 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   AGENTIC_POINT_ACTION_SELECTOR,
   AGENTIC_POINT_SELECTOR,
+  getAgenticPointAnchorMutationRoot,
+  getAgenticPointAnchorRect,
   resolveAgenticPointAnchor,
 } from './agentic-point-coach-mark';
 
@@ -102,7 +104,8 @@ function appendChartSvg(chart: Element, spec: ChartSvgSpec): void {
  * resolver can work out the clip region.
  */
 function renderChart(points: PointSpec[], svgSpec?: ChartSvgSpec): Element[] {
-  document.body.innerHTML = '<div data-testid="scatter-graph"></div>';
+  document.body.innerHTML =
+    '<div data-coach-mark-root><div data-testid="scatter-graph"></div></div>';
   const chart = document.querySelector('[data-testid="scatter-graph"]')!;
   stubBox(chart, 0, 0, 1000, 600);
   if (svgSpec) appendChartSvg(chart, svgSpec);
@@ -331,5 +334,38 @@ describe('resolveAgenticPointAnchor', () => {
       { left: 400, top: 4000 },
     ]);
     expect(resolveAgenticPointAnchor()).toBeNull();
+  });
+
+  it('validates a cached marker without measuring sibling points', () => {
+    const [first, selected, last] = renderChart([
+      { left: 100, top: 100, withShape: true },
+      { left: 480, top: 280, withShape: true },
+      { left: 900, top: 500, withShape: true },
+    ]);
+    const anchor = resolveAgenticPointAnchor();
+    expect(anchor).toBe(selected.querySelector('.visible-shape'));
+    const firstMeasure = vi.spyOn(first, 'getBoundingClientRect');
+    const lastMeasure = vi.spyOn(last, 'getBoundingClientRect');
+
+    expect(getAgenticPointAnchorRect(anchor!)).not.toBeNull();
+    expect(firstMeasure, 'first sibling skipped').not.toHaveBeenCalled();
+    expect(lastMeasure, 'last sibling skipped').not.toHaveBeenCalled();
+  });
+
+  it('rejects a cached marker after its point becomes hidden', () => {
+    const [group] = renderChart([{ left: 480, top: 280, withShape: true }]);
+    const anchor = resolveAgenticPointAnchor();
+    expect(anchor).not.toBeNull();
+
+    group.setAttribute('style', 'opacity: 0');
+    expect(getAgenticPointAnchorRect(anchor!)).toBeNull();
+  });
+
+  it('scopes mutation observation to the stable chart surface', () => {
+    const [group] = renderChart([{ left: 480, top: 280, withShape: true }], CHART_SVG);
+    const chartRoot = document.querySelector('[data-coach-mark-root]')!;
+    const anchor = group.querySelector('.visible-shape');
+
+    expect(getAgenticPointAnchorMutationRoot(anchor)).toBe(chartRoot);
   });
 });

--- a/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
+++ b/packages/app/src/lib/nudges/agentic-point-coach-mark.ts
@@ -35,8 +35,11 @@ export const SCATTER_RENDERED_EVENT = 'inferencex:scatter-chart-rendered';
  *    tooltip has no "View charts" link (overlay runs have no stored trace), so
  *    pointing at one would teach a dead end.
  */
-export const AGENTIC_POINT_SELECTOR =
-  '[data-testid="scatter-graph"] .dot-group[data-benchmark-type="agentic_traces"]';
+const SCATTER_GRAPH_SELECTOR = '[data-testid="scatter-graph"]';
+const COACH_MARK_ROOT_SELECTOR = '[data-coach-mark-root]';
+const AGENTIC_POINT_GROUP_SELECTOR = '.dot-group[data-benchmark-type="agentic_traces"]';
+
+export const AGENTIC_POINT_SELECTOR = `${SCATTER_GRAPH_SELECTOR} ${AGENTIC_POINT_GROUP_SELECTOR}`;
 
 /**
  * Clicking any scatter point — official or overlay — means the user found the
@@ -51,6 +54,55 @@ function isRendered(element: Element): boolean {
   // not anchor candidates either.
   const style = getComputedStyle(element);
   return style.opacity !== '0' && style.pointerEvents !== 'none' && style.visibility !== 'hidden';
+}
+
+function agenticPointGroup(element: Element): SVGGElement | null {
+  const group = element.matches(AGENTIC_POINT_GROUP_SELECTOR)
+    ? element
+    : element.closest(AGENTIC_POINT_GROUP_SELECTOR);
+  return group as SVGGElement | null;
+}
+
+function canOpenTrace(group: SVGGElement): boolean {
+  return group.dataset.hasTrace === 'true' || group.dataset.traceAvailability !== 'resolved';
+}
+
+/**
+ * Validate one previously selected point without rescanning every series.
+ *
+ * D3 coordinate transitions mutate every point's `transform` each frame. The
+ * coach mark can keep following its chosen point while this stays non-null;
+ * filtering, clipping, or resolved-empty trace availability invalidates it and
+ * sends the caller back through `resolveAgenticPointAnchor`.
+ */
+export function getAgenticPointAnchorRect(element: Element): DOMRect | null {
+  if (typeof document === 'undefined') return null;
+  const group = agenticPointGroup(element);
+  const chart = group?.closest<HTMLElement>(SCATTER_GRAPH_SELECTOR);
+  if (!group || !chart || !isRendered(group) || !canOpenTrace(group)) return null;
+
+  const viewport = viewportSize();
+  const rect = element.getBoundingClientRect();
+  if (!isAnchorOnScreen(rect, viewport)) return null;
+
+  const svg = chart.querySelector('[data-testid="d3-chart-svg"]');
+  const plot =
+    (svg && plotBounds(svg)) ?? svg?.getBoundingClientRect() ?? chart.getBoundingClientRect();
+  return isAnchorWithin(rect, plot) ? rect : null;
+}
+
+/**
+ * Observe the stable chart owner so point mutations are local, while replacing
+ * the chart itself still invalidates the cached anchor.
+ */
+export function getAgenticPointAnchorMutationRoot(element: Element | null): Node | null {
+  if (typeof document === 'undefined') return null;
+  return (
+    element?.closest(COACH_MARK_ROOT_SELECTOR) ??
+    element?.closest(SCATTER_GRAPH_SELECTOR) ??
+    document.querySelector(COACH_MARK_ROOT_SELECTOR) ??
+    document.querySelector(SCATTER_GRAPH_SELECTOR)
+  );
 }
 
 /**
@@ -93,9 +145,7 @@ export function resolveAgenticPointAnchor(): Element | null {
     const svg = chart.querySelector('[data-testid="d3-chart-svg"]');
     const plot = (svg && plotBounds(svg)) ?? svg?.getBoundingClientRect() ?? chartRect;
 
-    for (const element of chart.querySelectorAll<SVGGElement>(
-      '.dot-group[data-benchmark-type="agentic_traces"]',
-    )) {
+    for (const element of chart.querySelectorAll<SVGGElement>(AGENTIC_POINT_GROUP_SELECTOR)) {
       if (!isRendered(element)) continue;
       const rect = element.getBoundingClientRect();
       if (!isAnchorOnScreen(rect, viewport)) continue;

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -134,6 +134,8 @@ describe('NUDGE_REGISTRY integrity', () => {
     expect(coachMark?.storageKey).toBe(AGENTIC_COACH_MARK_STORAGE_KEY);
     expect(dismissesOnAction(coachMark!)).toBe(true);
     expect(coachMark?.content.anchor?.actionSelector).toBe(AGENTIC_POINT_ACTION_SELECTOR);
+    expect(typeof coachMark?.content.anchor?.getRect).toBe('function');
+    expect(typeof coachMark?.content.anchor?.getMutationRoot).toBe('function');
     expect(AGENTIC_COACH_MARK_STORAGE_KEY).toBe('inferencex-agentic-point-coach-mark-dismissed');
   });
 

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -20,6 +20,8 @@ import {
   AGENTIC_COACH_MARK_STORAGE_KEY,
   AGENTIC_POINT_ACTION_SELECTOR,
   SCATTER_RENDERED_EVENT,
+  getAgenticPointAnchorMutationRoot,
+  getAgenticPointAnchorRect,
   resolveAgenticPointAnchor,
 } from '@/lib/nudges/agentic-point-coach-mark';
 import { LANDING_BANNER_STORAGE_KEY } from '@/lib/nudges/landing-banner';
@@ -304,6 +306,8 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       testId: 'agentic-point-coach-mark',
       anchor: {
         resolve: resolveAgenticPointAnchor,
+        getRect: getAgenticPointAnchorRect,
+        getMutationRoot: getAgenticPointAnchorMutationRoot,
         actionSelector: AGENTIC_POINT_ACTION_SELECTOR,
       },
     },

--- a/packages/app/src/lib/nudges/types.ts
+++ b/packages/app/src/lib/nudges/types.ts
@@ -68,6 +68,17 @@ export interface NudgeAnchor {
    */
   resolve: () => Element | null;
   /**
+   * Measure and validate a previously resolved anchor. Returning `null` tells
+   * the coach mark to discard it and run the full resolver again. Supplying
+   * this enables anchor reuse during high-frequency geometry updates.
+   */
+  getRect?: (element: Element) => DOMRect | null;
+  /**
+   * Narrow mutation observation to the live surface that owns the anchor.
+   * Defaults to `document.body` for anchors without a stable local root.
+   */
+  getMutationRoot?: (element: Element | null) => Node | null;
+  /**
    * Clicking an element matching this selector counts as taking the nudge's
    * action: the user found the affordance, so record engagement and stop
    * showing it.


### PR DESCRIPTION
## Summary

- Cache the resolved agentic coach-mark anchor across high-frequency D3 `transform` mutations.
- Validate only the selected point on animation frames, then rerun the full resolver when filtering, clipping, trace availability, or DOM replacement makes it unusable.
- Preserve a validator's `null` rejection instead of falling back to unchecked geometry.
- Scope mutation observation to the stable chart card instead of all of `document.body`.
- Preserve official-run behavior with `?unofficialrun=` overlays. The coach mark still avoids overlay markers because they have no persisted trace detail.
- Add deterministic resolver call-count, cache invalidation, rejected-validation, mutation-scope, and registry wiring tests.

## Performance

With 166 agentic points and the first-visit coach mark visible during a log-scale transition:

- `.dot-group` rectangle reads fell from `3,900` to `50`.
- Total `getBoundingClientRect()` calls fell from `4,136` to `144`.
- The pointer remained attached while its target moved from y=`408.74` to y=`338.87`.

## Verification

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,607 tests)
- Focused coach-mark unit tests (52 tests)
- `bun run test:e2e` against the production build with `E2E_FIXTURES=1`
- `bunx cypress run --spec cypress/e2e/agentic-point-coach-mark.cy.ts --browser chrome` (11 tests, including zoom, clipping, dismissal, Chinese copy, and unofficial-run overlay behavior)
- Production-browser profiling on the real agentic chart
- Preview deployment: https://inferencemax-app-git-fix-coach-mark-ancho-49ae32-semianalysisai.vercel.app (Vercel authentication required). The same `?unofficialrun=` path was verified locally against the production build.

## 中文说明

- 在高频 D3 `transform` 变更期间复用已解析的 agentic 引导标记锚点。
- 动画帧只校验当前选中的数据点。当筛选、裁剪、trace 可用性变化或 DOM 替换使锚点失效时，再重新执行完整解析。
- 保留校验器返回 `null` 的拒绝结果，不再回退到未经校验的几何范围。
- 将 MutationObserver 的范围从整个 `document.body` 缩小到稳定的图表 Card。
- 保持官方运行与 `?unofficialrun=` overlay 共存时的行为。由于 overlay 数据点没有持久化 trace 详情，引导标记仍只会指向官方数据点。
- 新增确定性的解析调用次数、缓存失效、拒绝校验、观察范围及 registry 接线测试。

## 性能结果

在首访引导标记可见、图表包含 166 个 agentic 数据点并切换 log scale 的场景下：

- `.dot-group` 矩形读取次数从 `3,900` 降至 `50`。
- `getBoundingClientRect()` 总调用次数从 `4,136` 降至 `144`。
- 目标点从 y=`408.74` 移动到 y=`338.87` 时，指针仍保持正确跟随。

## 验证

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（共 4,607 项测试）
- Coach mark 聚焦单元测试（52 项测试）
- 使用 `E2E_FIXTURES=1` 启动 production build 后运行 `bun run test:e2e`
- `bunx cypress run --spec cypress/e2e/agentic-point-coach-mark.cy.ts --browser chrome`（11 项测试，覆盖 zoom、裁剪、关闭、中文文案及 unofficial-run overlay 行为）
- 使用真实 agentic 图表进行 production browser 性能分析
- Preview deployment：https://inferencemax-app-git-fix-coach-mark-ancho-49ae32-semianalysisai.vercel.app（需要 Vercel 身份验证）。相同的 `?unofficialrun=` 路径已使用本地 production build 完成验证。