### PR TITLE
Reduce chart transition rendering work / 降低图表过渡渲染开销

### DIFF
--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -116,6 +116,11 @@ D3 bar charts measure actual Y-axis label widths using a temporary SVG `<text>` 
 
 Opacity animates via inline CSS `transition: opacity 150ms ease` (set on dots, rooflines, and labels in the render path); d3 `.transition()` is reserved for attributes CSS can't animate — the `data-update` entrance transitions on dot `transform` and roofline `d`. Never point both systems at the same property: a d3 transition re-writes the style every animation frame, and each write restarts the CSS transition, emitting `transitionrun`/`transitioncancel` per node per frame (a legend hover across a full chart used to produce tens of thousands of events per session, all of it also observed by PostHog's session-replay MutationObserver). Handlers like legend hover therefore write opacity **once** and let CSS do the animation.
 
+Coordinate transitions use one 300ms D3 tween for visible official and unofficial points and
+rooflines. Hidden marks snap directly to their final geometry and are excluded from the transition
+snapshot, avoiding frame-by-frame writes for data the user cannot see. Replay passes a zero duration
+and remains frame-driven.
+
 ## Batched Label Measurement
 
 Label loops that size a background rect to its text (`.ll-bg`/`.pl-bg`, point-label collision avoidance) must not interleave `getBBox()` with DOM writes — each read after a write forces a synchronous layout, turning N labels into N reflows. The pattern is two passes over the selection: write every label's text first, then measure every bbox (one forced layout for the whole batch), then write the rects. Same rule for `measureLegendRightInset`: it reads `getBoundingClientRect`, so it's skipped entirely when there are no known-issue annotations to place — it would otherwise run on every zoom frame.

--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -116,10 +116,10 @@ D3 bar charts measure actual Y-axis label widths using a temporary SVG `<text>` 
 
 Opacity animates via inline CSS `transition: opacity 150ms ease` (set on dots, rooflines, and labels in the render path); d3 `.transition()` is reserved for attributes CSS can't animate — the `data-update` entrance transitions on dot `transform` and roofline `d`. Never point both systems at the same property: a d3 transition re-writes the style every animation frame, and each write restarts the CSS transition, emitting `transitionrun`/`transitioncancel` per node per frame (a legend hover across a full chart used to produce tens of thousands of events per session, all of it also observed by PostHog's session-replay MutationObserver). Handlers like legend hover therefore write opacity **once** and let CSS do the animation.
 
-Coordinate transitions use one 300ms D3 tween for visible official and unofficial points and
-rooflines. Hidden marks snap directly to their final geometry and are excluded from the transition
-snapshot, avoiding frame-by-frame writes for data the user cannot see. Replay passes a zero duration
-and remains frame-driven.
+Official coordinate transitions use one 300ms D3 tween for visible points and rooflines. Hidden
+official marks snap directly to their final geometry and are excluded from the transition snapshot,
+avoiding frame-by-frame writes for data the user cannot see. Unofficial overlays retain their
+existing snap behavior. Replay passes a zero duration and remains frame-driven.
 
 ## Batched Label Measurement
 

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -447,8 +447,8 @@ export interface ScatterGraphProps {
   overlayData?: OverlayData;
   /**
    * D3 transition duration in ms used when data or scales change. Defaults to
-   * the regular interactive value (750). The replay panel passes 0 so frames
-   * snap to interpolated positions instead of fighting a 750ms tween.
+   * the regular 300ms interactive value. The replay panel passes 0 so frames
+   * snap to interpolated positions instead of fighting an in-flight tween.
    */
   transitionDuration?: number;
   /**

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -368,7 +368,7 @@ const ScatterGraph = React.memo(
     showAllHardwareTypes = false,
     hardwareConfigOverride,
     overlayData,
-    transitionDuration = 750,
+    transitionDuration = 300,
     niceAxes = true,
     pinLineLabels = false,
     xExtentOverride,

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.test.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.test.ts
@@ -1,7 +1,29 @@
-import { describe, expect, it, vi } from 'vitest';
+// @vitest-environment jsdom
+import * as d3 from 'd3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { createZoomFrameBatcher, metricRenderCallbackContext } from './useD3ChartRenderer';
+import {
+  animateTransitionGeometry,
+  captureTransitionGeometry,
+  createZoomFrameBatcher,
+  metricRenderCallbackContext,
+} from './useD3ChartRenderer';
 import type { RenderContext } from './types';
+
+function transitionDuration(element: SVGElement): number | undefined {
+  return Object.values(
+    (
+      element as SVGElement & {
+        __transition?: Record<string, { duration: number }>;
+      }
+    ).__transition ?? {},
+  )[0]?.duration;
+}
+
+afterEach(() => {
+  d3.select(document.body).selectAll('*').interrupt('data-update');
+  document.body.innerHTML = '';
+});
 
 describe('createZoomFrameBatcher', () => {
   it('coalesces a burst and executes only its final transform work', () => {
@@ -94,5 +116,74 @@ describe('metricRenderCallbackContext', () => {
     expect(context.yScale).toBe(baseYScale);
     expect(context.renderedXScale).toBe(renderedXScale);
     expect(context.renderedYScale).toBe(renderedYScale);
+  });
+});
+
+describe('coordinate transitions', () => {
+  it('animates visible official and overlay geometry for 300ms while hidden marks snap', () => {
+    const svg = d3.select(document.body).append('svg');
+    const group = svg.append('g') as unknown as d3.Selection<SVGGElement, unknown, any, any>;
+    const point = (className: string, opacity?: number) => {
+      const selection = group
+        .append('g')
+        .attr('class', className)
+        .attr('transform', 'translate(0,0)');
+      if (opacity !== undefined) selection.style('opacity', opacity);
+      return selection.node()!;
+    };
+    const roofline = (className: string, opacity?: number) => {
+      const selection = group.append('path').attr('class', className).attr('d', 'M0,0L1,1');
+      if (opacity !== undefined) selection.style('opacity', opacity);
+      return selection.node()!;
+    };
+    const visibleOfficialPoint = point('dot-group');
+    const hiddenOfficialPoint = point('dot-group', 0);
+    const visibleOverlayPoint = point('unofficial-overlay-pt');
+    const hiddenOverlayPoint = point('unofficial-overlay-pt', 0);
+    const visibleOfficialRoofline = roofline('roofline-path');
+    const hiddenOfficialRoofline = roofline('roofline-path', 0);
+    const visibleOverlayRoofline = roofline('overlay-roofline-path');
+    const hiddenOverlayRoofline = roofline('overlay-roofline-path', 0);
+    const previous = captureTransitionGeometry(group);
+
+    expect(previous.transforms.size).toBe(2);
+    expect(previous.paths.size).toBe(2);
+
+    for (const element of [
+      visibleOfficialPoint,
+      hiddenOfficialPoint,
+      visibleOverlayPoint,
+      hiddenOverlayPoint,
+    ]) {
+      element.setAttribute('transform', 'translate(100,100)');
+    }
+    for (const element of [
+      visibleOfficialRoofline,
+      hiddenOfficialRoofline,
+      visibleOverlayRoofline,
+      hiddenOverlayRoofline,
+    ]) {
+      element.setAttribute('d', 'M100,100L200,200');
+    }
+
+    animateTransitionGeometry(group, previous, 300);
+
+    expect(visibleOfficialPoint.getAttribute('transform')).toBe('translate(0,0)');
+    expect(visibleOverlayPoint.getAttribute('transform')).toBe('translate(0,0)');
+    expect(hiddenOfficialPoint.getAttribute('transform')).toBe('translate(100,100)');
+    expect(hiddenOverlayPoint.getAttribute('transform')).toBe('translate(100,100)');
+    expect(visibleOfficialRoofline.getAttribute('d')).toBe('M0,0L1,1');
+    expect(visibleOverlayRoofline.getAttribute('d')).toBe('M0,0L1,1');
+    expect(hiddenOfficialRoofline.getAttribute('d')).toBe('M100,100L200,200');
+    expect(hiddenOverlayRoofline.getAttribute('d')).toBe('M100,100L200,200');
+
+    expect(transitionDuration(visibleOfficialPoint)).toBe(300);
+    expect(transitionDuration(visibleOverlayPoint)).toBe(300);
+    expect(transitionDuration(visibleOfficialRoofline)).toBe(300);
+    expect(transitionDuration(visibleOverlayRoofline)).toBe(300);
+    expect(transitionDuration(hiddenOfficialPoint)).toBeUndefined();
+    expect(transitionDuration(hiddenOverlayPoint)).toBeUndefined();
+    expect(transitionDuration(hiddenOfficialRoofline)).toBeUndefined();
+    expect(transitionDuration(hiddenOverlayRoofline)).toBeUndefined();
   });
 });

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.test.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.test.ts
@@ -120,7 +120,7 @@ describe('metricRenderCallbackContext', () => {
 });
 
 describe('coordinate transitions', () => {
-  it('animates visible official and overlay geometry for 300ms while hidden marks snap', () => {
+  it('animates visible official geometry for 300ms while hidden and overlay marks snap', () => {
     const svg = d3.select(document.body).append('svg');
     const group = svg.append('g') as unknown as d3.Selection<SVGGElement, unknown, any, any>;
     const point = (className: string, opacity?: number) => {
@@ -146,8 +146,8 @@ describe('coordinate transitions', () => {
     const hiddenOverlayRoofline = roofline('overlay-roofline-path', 0);
     const previous = captureTransitionGeometry(group);
 
-    expect(previous.transforms.size).toBe(2);
-    expect(previous.paths.size).toBe(2);
+    expect(previous.transforms.size).toBe(1);
+    expect(previous.paths.size).toBe(1);
 
     for (const element of [
       visibleOfficialPoint,
@@ -169,18 +169,18 @@ describe('coordinate transitions', () => {
     animateTransitionGeometry(group, previous, 300);
 
     expect(visibleOfficialPoint.getAttribute('transform')).toBe('translate(0,0)');
-    expect(visibleOverlayPoint.getAttribute('transform')).toBe('translate(0,0)');
+    expect(visibleOverlayPoint.getAttribute('transform')).toBe('translate(100,100)');
     expect(hiddenOfficialPoint.getAttribute('transform')).toBe('translate(100,100)');
     expect(hiddenOverlayPoint.getAttribute('transform')).toBe('translate(100,100)');
     expect(visibleOfficialRoofline.getAttribute('d')).toBe('M0,0L1,1');
-    expect(visibleOverlayRoofline.getAttribute('d')).toBe('M0,0L1,1');
+    expect(visibleOverlayRoofline.getAttribute('d')).toBe('M100,100L200,200');
     expect(hiddenOfficialRoofline.getAttribute('d')).toBe('M100,100L200,200');
     expect(hiddenOverlayRoofline.getAttribute('d')).toBe('M100,100L200,200');
 
     expect(transitionDuration(visibleOfficialPoint)).toBe(300);
-    expect(transitionDuration(visibleOverlayPoint)).toBe(300);
+    expect(transitionDuration(visibleOverlayPoint)).toBeUndefined();
     expect(transitionDuration(visibleOfficialRoofline)).toBe(300);
-    expect(transitionDuration(visibleOverlayRoofline)).toBe(300);
+    expect(transitionDuration(visibleOverlayRoofline)).toBeUndefined();
     expect(transitionDuration(hiddenOfficialPoint)).toBeUndefined();
     expect(transitionDuration(hiddenOverlayPoint)).toBeUndefined();
     expect(transitionDuration(hiddenOfficialRoofline)).toBeUndefined();

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
@@ -118,8 +118,8 @@ export interface TransitionGeometry {
   paths: Map<SVGPathElement, string>;
 }
 
-const TRANSITION_POINT_SELECTOR = '.dot-group, .unofficial-overlay-pt';
-const TRANSITION_ROOFLINE_SELECTOR = '.roofline-path, .overlay-roofline-path';
+const TRANSITION_POINT_SELECTOR = '.dot-group';
+const TRANSITION_ROOFLINE_SELECTOR = '.roofline-path';
 type GeometryVisibility = (element: SVGElement) => boolean;
 
 function isGeometryVisible(element: SVGElement): boolean {

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
@@ -113,32 +113,56 @@ export function createZoomFrameBatcher(
   };
 }
 
-interface TransitionGeometry {
+export interface TransitionGeometry {
   transforms: Map<SVGGElement, string>;
   paths: Map<SVGPathElement, string>;
 }
 
-function captureTransitionGeometry(
+const TRANSITION_POINT_SELECTOR = '.dot-group, .unofficial-overlay-pt';
+const TRANSITION_ROOFLINE_SELECTOR = '.roofline-path, .overlay-roofline-path';
+type GeometryVisibility = (element: SVGElement) => boolean;
+
+function isGeometryVisible(element: SVGElement): boolean {
+  return element.style.opacity !== '0' && element.style.display !== 'none';
+}
+
+function metricGeometryVisibility<T>(layers: LayerConfig<T>[]): GeometryVisibility {
+  const scatterLayer = layers.find((layer) => layer.type === 'scatter');
+  const getOpacity = scatterLayer?.type === 'scatter' ? scatterLayer.config.getOpacity : undefined;
+  if (!getOpacity) return isGeometryVisible;
+
+  return (element) =>
+    element.matches('.dot-group')
+      ? getOpacity(d3.select(element).datum() as Parameters<typeof getOpacity>[0]) > 0
+      : isGeometryVisible(element);
+}
+
+export function captureTransitionGeometry(
   group: d3.Selection<SVGGElement, unknown, any, any>,
 ): TransitionGeometry {
   const transforms = new Map<SVGGElement, string>();
   const paths = new Map<SVGPathElement, string>();
-  group.selectAll<SVGGElement, unknown>('.dot-group').each(function () {
-    transforms.set(this, this.getAttribute('transform') || '');
+  group.selectAll<SVGGElement, unknown>(TRANSITION_POINT_SELECTOR).each(function () {
+    if (isGeometryVisible(this)) transforms.set(this, this.getAttribute('transform') || '');
   });
-  group.selectAll<SVGPathElement, unknown>('.roofline-path').each(function () {
-    paths.set(this, this.getAttribute('d') || '');
+  group.selectAll<SVGPathElement, unknown>(TRANSITION_ROOFLINE_SELECTOR).each(function () {
+    if (isGeometryVisible(this)) paths.set(this, this.getAttribute('d') || '');
   });
   return { transforms, paths };
 }
 
-function animateTransitionGeometry(
+export function animateTransitionGeometry(
   group: d3.Selection<SVGGElement, unknown, any, any>,
   previous: TransitionGeometry | null,
   durationMs: number | undefined = 0,
+  isVisible: GeometryVisibility = isGeometryVisible,
 ): void {
   if (!previous || durationMs <= 0) return;
-  group.selectAll<SVGGElement, unknown>('.dot-group').each(function () {
+  group.selectAll<SVGGElement, unknown>(TRANSITION_POINT_SELECTOR).each(function () {
+    if (!isVisible(this)) {
+      d3.select(this).interrupt('data-update');
+      return;
+    }
     const oldPosition = previous.transforms.get(this);
     const newPosition = this.getAttribute('transform');
     if (oldPosition !== undefined && newPosition && oldPosition !== newPosition) {
@@ -146,7 +170,11 @@ function animateTransitionGeometry(
       d3.select(this).transition('data-update').duration(durationMs).attr('transform', newPosition);
     }
   });
-  group.selectAll<SVGPathElement, unknown>('.roofline-path').each(function () {
+  group.selectAll<SVGPathElement, unknown>(TRANSITION_ROOFLINE_SELECTOR).each(function () {
+    if (!isVisible(this)) {
+      d3.select(this).interrupt('data-update');
+      return;
+    }
     const oldPath = previous.paths.get(this);
     const newPath = this.getAttribute('d');
     if (oldPath !== undefined && newPath && oldPath !== newPath) {
@@ -851,7 +879,12 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
     const metricLayerSelections = layers.map((layer) =>
       updateLayerForMetric(layer, renderGroup, currentXScale, currentYScale, layout, metricCtx),
     );
-    animateTransitionGeometry(renderGroup, previousGeometry, transitionDuration);
+    animateTransitionGeometry(
+      renderGroup,
+      previousGeometry,
+      transitionDuration,
+      metricGeometryVisibility(layers),
+    );
     customLayerDisplayIdentitiesRef.current = customLayerDisplayIdentities(layers);
     lastDisplayIdentityRef.current = displayIdentity;
     renderGroup.selectAll('.dot-group').raise();


### PR DESCRIPTION
## Summary

- Keep inference coordinate transitions at exactly `300ms`.
- Animate only visible official points and rooflines.
- Exclude hidden official geometry from transition snapshots, interrupt stale hidden transitions, and snap hidden marks directly to final coordinates.
- Resolve official point visibility from the current scatter-layer predicate so a filter and metric change in the same commit cannot animate newly hidden points.
- Preserve unofficial overlay behavior exactly: overlay markers and rooflines continue to snap directly to their final geometry.
- Preserve replay behavior, which continues to pass a zero duration for frame-driven rendering.

## Performance

Production-browser log-scale profile with the coach mark dismissed:

| Metric | Before | After |
| --- | ---: | ---: |
| Total SVG attribute writes | 20,675 | 5,880 |
| Official point transform writes | 15,604 | 2,066 |
| Main-thread task time | 225.7ms | 69.6ms |
| Style recalculation time | 73.9ms | 14.2ms |
| Layout events | 95 | 39 |

The browser scheduled 50 visible official points and 6 official rooflines at exactly `300ms`. With `?unofficialrun=32315429801`, overlay points and rooflines retained their existing snap behavior, reached the same final coordinates, and per-run dismissal still removed every overlay point and path.

At 4x CPU throttling on a mobile viewport, the observed long task improved from 76ms to 62ms. The remaining synchronous metric-update work is separate from the frame-by-frame transition writes and is intentionally left for the next display-invalidation PR.

## Behavior compatibility

- Final official and overlay coordinates are unchanged.
- Zoom, filters, labels, tooltips, point selection, replay, and per-run overlay dismissal are unchanged.
- The only user-visible difference is that official coordinate movement completes in 300ms instead of 750ms.

## Verification

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,609 tests)
- Focused D3 transition, ScatterGraph overlay, and decoration tests
- `bun run test:e2e` against the production build with `E2E_FIXTURES=1`
- Production-browser profiling for official data, `?unofficialrun=` overlays, overlay dismissal, and 4x CPU throttling
- Preview deployment: https://inferencemax-app-git-refactor-reduce-char-83e913-semianalysisai.vercel.app (Vercel authentication required). The same official and `?unofficialrun=` scenarios were verified locally against the production build.

## 中文说明

- 将 inference 坐标过渡时间固定为 `300ms`。
- 只为当前可见的官方数据点与官方 roofline 执行动画。
- 隐藏的官方图形不再进入过渡快照，同时会中断旧过渡并直接跳到最终坐标。
- 官方数据点的可见性由当前 scatter layer 的判定函数决定，因此同一次提交中的筛选与 metric 变更不会继续为刚被隐藏的数据点执行动画。
- 完整保留 unofficial overlay 原有行为：overlay marker 与 roofline 继续直接跳到最终几何位置。
- Replay 仍传入 0ms，由帧驱动渲染，行为保持不变。

## 性能结果

在关闭引导标记后，使用 production browser 测量 log scale 切换：

| 指标 | 修改前 | 修改后 |
| --- | ---: | ---: |
| SVG attribute 总写入次数 | 20,675 | 5,880 |
| 官方数据点 transform 写入次数 | 15,604 | 2,066 |
| 主线程 task 时间 | 225.7ms | 69.6ms |
| 样式重计算时间 | 73.9ms | 14.2ms |
| Layout 事件数 | 95 | 39 |

浏览器以 `300ms` 为 50 个可见官方数据点和 6 条官方 roofline 安排过渡。加载 `?unofficialrun=32315429801` 后，overlay 数据点与 roofline 保持原有的坐标直达行为，最终坐标完全一致，关闭该 run 后所有 overlay 数据点和路径仍会被移除。

在移动端视口并启用 4 倍 CPU 限速后，观测到的 long task 从 76ms 降至 62ms。剩余的同步 metric 更新工作与逐帧过渡写入无关，按计划留给下一项 display invalidation PR 处理。

## 行为兼容性

- 官方与 overlay 图形的最终坐标保持不变。
- Zoom、筛选、标签、tooltip、数据点选择、replay 及按 run 关闭 overlay 的行为保持不变。
- 唯一可见变化是官方图形的坐标移动从 750ms 缩短至 300ms。

## 验证

- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（共 4,609 项测试）
- D3 transition、ScatterGraph overlay 与 decoration 聚焦测试
- 使用 `E2E_FIXTURES=1` 启动 production build 后运行 `bun run test:e2e`
- 使用 production browser 验证官方数据、`?unofficialrun=` overlay、overlay 关闭及 4 倍 CPU 限速场景
- Preview deployment：https://inferencemax-app-git-refactor-reduce-char-83e913-semianalysisai.vercel.app（需要 Vercel 身份验证）。相同的官方与 `?unofficialrun=` 场景已使用本地 production build 完成验证。