### PR TITLE
Narrow scatter display invalidation / 缩小散点图显示失效更新范围

### DIFF
--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -15,6 +15,8 @@ One effect for every D3 operation takes roughly 500ms (React reconciliation ~200
 
 Custom layers that own scale-neutral decorations declare a `displayIdentity` and an `onDisplayUpdate` callback. The renderer snapshots each identity after the data and metric phases, then reruns only the custom layers whose identities changed. This removes stale labels and decorative overlays without rebuilding joins, scales, or unrelated paths. Callbacks receive the current zoomed scales so toggles do not jump decorations back to the unzoomed frame.
 
+`ScatterGraph` further partitions Effect 4 because its controls have disjoint mutation scopes. Mark visibility, palette/shape, trace metadata, point-label visibility/collision, line-label placement, and known-issue annotations each have a dedicated layout effect. It deliberately omits the generic scatter `displayIdentity`: point-label toggles update only `.point-label` nodes, while the unofficial overlay layer's own display callback updates only `.overlay-label` nodes. Recombining these passes causes label toggles to restamp thousands of unchanged shape, visibility, and trace attributes.
+
 ## In-Place Y-Value Mutation
 
 Effect 3 mutates `datum.y` directly on D3-bound data:

--- a/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
@@ -180,6 +180,33 @@ describe('ScatterGraph toggle decoration', () => {
     unmount();
   });
 
+  it('keeps point-label visibility synchronized while the chart is empty', () => {
+    const chartProps = { data: [] as InferenceData[] };
+    inferenceState.current = {
+      ...baseInferenceState(),
+      showPointLabels: false,
+    };
+    const { container, rerender, unmount } = mountChart(chartProps);
+
+    inferenceState.current = {
+      ...inferenceState.current,
+      showPointLabels: true,
+    };
+    rerender();
+    chartProps.data = POINTS;
+    rerender();
+    const label = container.querySelector<SVGTextElement>('.point-label');
+    expect(label?.style.display).toBe('');
+
+    inferenceState.current = {
+      ...inferenceState.current,
+      showPointLabels: false,
+    };
+    rerender();
+    expect(label?.style.display).toBe('none');
+    unmount();
+  });
+
   it('hides a toggled-off hw via opacity without rebuilding the chart', () => {
     const { container, rerender, unmount } = mountChart();
     const buildsAfterMount = rebuildCount();

--- a/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
@@ -207,6 +207,33 @@ describe('ScatterGraph toggle decoration', () => {
     unmount();
   });
 
+  it('rechecks point-label collisions when line-label obstacles change', () => {
+    inferenceState.current = {
+      ...baseInferenceState(),
+      showPointLabels: true,
+      showLineLabels: false,
+    };
+    const getBBox = vi.spyOn(
+      SVGElement.prototype as unknown as { getBBox: () => DOMRect },
+      'getBBox',
+    );
+    const { rerender, unmount } = mountChart();
+    getBBox.mockClear();
+
+    inferenceState.current = {
+      ...inferenceState.current,
+      showLineLabels: true,
+    };
+    rerender();
+
+    expect(
+      getBBox.mock.contexts.some(
+        (element) => element instanceof SVGElement && element.classList.contains('point-label'),
+      ),
+    ).toBe(true);
+    unmount();
+  });
+
   it('hides a toggled-off hw via opacity without rebuilding the chart', () => {
     const { container, rerender, unmount } = mountChart();
     const buildsAfterMount = rebuildCount();

--- a/packages/app/src/components/inference/ui/ScatterGraph.overlay.test.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.overlay.test.tsx
@@ -89,6 +89,9 @@ describe('ScatterGraph unofficial overlays', () => {
     expect(overlayLabel).not.toBeNull();
     expect(officialLabel!.style.display).toBe('none');
     expect(overlayLabel!.style.display).toBe('none');
+    const mutationRecords: MutationRecord[] = [];
+    const observer = new MutationObserver((records) => mutationRecords.push(...records));
+    observer.observe(container.querySelector('svg')!, { attributes: true, subtree: true });
 
     inferenceState.current = {
       ...inferenceState.current,
@@ -98,6 +101,15 @@ describe('ScatterGraph unofficial overlays', () => {
 
     expect(officialLabel!.style.display).toBe('');
     expect(overlayLabel!.style.display).toBe('');
+    mutationRecords.push(...observer.takeRecords());
+    observer.disconnect();
+    expect(mutationRecords.length).toBeGreaterThan(0);
+    expect(
+      mutationRecords.every(
+        ({ target }) =>
+          target instanceof Element && target.closest('.point-label, .overlay-label') !== null,
+      ),
+    ).toBe(true);
     expect(rebuildCount()).toBe(buildsAfterMount);
     unmount();
   });

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -295,6 +295,16 @@ const hasNamedTransition = (node: Element, name: string): boolean => {
   return Object.values(schedules).some((schedule) => schedule?.name === name);
 };
 
+const currentZoomRenderContext = (svg: SVGSVGElement, ctx: RenderContext): RenderContext => {
+  const transform = d3.zoomTransform(svg);
+  if (transform.k === 1 && transform.x === 0 && transform.y === 0) return ctx;
+  return {
+    ...ctx,
+    xScale: transform.rescaleX(ctx.xScale as ContinuousScale),
+    yScale: transform.rescaleY(ctx.yScale as ContinuousScale),
+  };
+};
+
 // Derive a readable label from a hwKey using the HARDWARE_CONFIG source of truth.
 // `model` (display name) enables per-model suffix overrides (e.g. M3 MTP → EAGLE).
 const parseHwKeyToLabel = (hwKey: string, model?: string): { name: string; label: string } => {
@@ -1253,6 +1263,18 @@ const ScatterGraph = React.memo(
     // Render context from the last D3 render — lets the decoration effect
     // restyle with the same layout/scales the chart was drawn with.
     const lastRenderCtxRef = useRef<RenderContext | null>(null);
+    const labelDisplayRef = useRef({ showPointLabels, showGradientLabels, showLineLabels });
+    labelDisplayRef.current = { showPointLabels, showGradientLabels, showLineLabels };
+    const pointLabelsVisible = showPointLabels && !showGradientLabels;
+    const lastPointLabelsVisibleRef = useRef(pointLabelsVisible);
+
+    const getDisplaySelection = useCallback(() => {
+      const svg = chartRef.current?.getSvgElement?.();
+      const ctx = lastRenderCtxRef.current;
+      if (!svg || !ctx) return null;
+      const zoomGroup = d3.select(svg).select<SVGGElement>('.zoom-group');
+      return zoomGroup.empty() ? null : { svg, ctx, zoomGroup };
+    }, []);
 
     // Hover dimming animates via the inline `transition: opacity 150ms ease`
     // the render path puts on dots, rooflines, and labels — a single style
@@ -2611,64 +2633,40 @@ const ScatterGraph = React.memo(
 
     // --- Side effects ---
 
-    // Toggle decoration: restyle the existing DOM when visibility or colors
-    // change (legend hw toggles, precision toggles, optimal-only, high
-    // contrast, theme). This is the cheap "Effect 4" display-toggle path from
-    // docs/d3-charts.md — the full chart rebuild only runs when data or scale
-    // domains actually change.
+    // ScatterGraph has more independent display controls than the generic
+    // D3 scatter layer. Keep their mutation scopes separate so a label-only
+    // toggle never restamps every point shape, visibility flag, or trace
+    // attribute.
     //
-    // This effect can run in the same commit as (right after) the full render
-    // effect, while the renderer's old→new "data-update" entrance transitions
-    // are scheduled but not yet started. It therefore NEVER writes the
-    // attributes those transitions animate — dot-group `transform` and
-    // roofline `d` — or a freshly rebuilt roofline would start its transition
-    // already at the destination and teleport while the dots animate.
+    // Mark styling: visibility, palette, and precision shape. This effect can
+    // run immediately after a full render while the renderer's old-to-new
+    // entrance transitions are only scheduled, so it never writes the
+    // animated dot-group `transform` or roofline `d` attributes.
     useLayoutEffect(() => {
-      const svg = chartRef.current?.getSvgElement?.();
-      const ctx = lastRenderCtxRef.current;
-      if (!svg || !ctx) return;
+      const display = getDisplaySelection();
+      if (!display) return;
+      const { zoomGroup } = display;
       const ir = interactionRef.current;
-      const zoomGroup = d3.select(svg).select<SVGGElement>('.zoom-group');
-      if (zoomGroup.empty()) return;
 
-      // Dots: visibility, vendor recolor, and precision shape.
-      // Hand-rolled rather than a full renderScatterPoints pass so we skip
-      // re-writing label text on every point (the expensive part of the join)
-      // — and, critically, never touch the animated `transform`.
       zoomGroup.selectAll<SVGGElement, InferenceData>('.dot-group').each(function (d) {
-        const sel = d3.select(this);
+        const point = d3.select(this);
         const visible = ir.isPointVisible(d);
-        sel.style('opacity', visible ? 1 : 0).style('pointer-events', visible ? 'auto' : 'none');
+        point.style('opacity', visible ? 1 : 0).style('pointer-events', visible ? 'auto' : 'none');
         const color =
           (showGradientLabels && gradientColorByPoint.get(d)) ||
           ir.getCssColor(ir.resolveColor(d.hwKey as string));
         syncPointShape(
-          sel as unknown as d3.Selection<SVGGElement, unknown, null, undefined>,
+          point as unknown as d3.Selection<SVGGElement, unknown, null, undefined>,
           getShapeKeyForPrecision(d.precision, ir.selectedPrecisions),
           color,
         );
         // A precision toggle may replace and append the visible SVG shape.
         // Keep the offload halo above that shape after the swap.
-        sel.selectAll('.offload-halo').raise();
-        // Whether this point's pinned tooltip will offer "View charts". Written
-        // here rather than in the layer's dataAttrs because availability
-        // resolves after the chart renders, and a rebuild would drop the zoom.
-        const pointId = isPersistedBenchmarkId(d.id) ? d.id : null;
-        const persistedAgenticPoint = d.benchmark_type === 'agentic_traces' && pointId !== null;
-        sel
-          .attr(
-            'data-has-trace',
-            pointId !== null && traceAvailability?.[pointId] === true ? 'true' : null,
-          )
-          .attr(
-            'data-trace-availability',
-            persistedAgenticPoint ? (isTraceAvailabilityPending ? 'pending' : 'resolved') : null,
-          );
+        point.selectAll('.offload-halo').raise();
       });
 
-      // Overlay X markers: Optimal Only visibility (mirrors the official dot
-      // loop above — the overlay layer render applies the same predicate, but
-      // a toggle flip must restyle existing DOM without a chart rebuild).
+      // Overlay points keep their X marker and run-derived color. Only their
+      // visibility follows Optimal Only and overlay hardware selection.
       zoomGroup.selectAll<SVGGElement, InferenceData>('.unofficial-overlay-pt').each(function (d) {
         const visible = ir.isOverlayPointVisible(d);
         d3.select(this)
@@ -2676,21 +2674,19 @@ const ScatterGraph = React.memo(
           .style('pointer-events', visible ? 'auto' : 'none');
       });
 
-      // Rooflines: visibility + solid-stroke recolor as direct writes (never
-      // `d`). Gradient strokes keep their url(#…) reference — gradient stop
-      // colors come from the fixed parallelism palette and don't change with
-      // the active set.
+      // Rooflines: visibility and solid-stroke recolor as direct writes. Keep
+      // gradient url references intact and never touch animated path geometry.
       zoomGroup.selectAll<SVGPathElement, unknown>('.roofline-path').each(function () {
         const hw = this.dataset.hwKey;
         const precision = this.dataset.precision;
         if (!hw || !precision) return;
-        const el = d3.select(this);
+        const roofline = d3.select(this);
         const visible =
           ir.effectiveActiveHwTypes.has(hw) && ir.selectedPrecisions.includes(precision);
-        el.style('opacity', visible ? 1 : 0);
-        const stroke = el.attr('stroke');
+        roofline.style('opacity', visible ? 1 : 0);
+        const stroke = roofline.attr('stroke');
         if (stroke && !stroke.startsWith('url(')) {
-          el.attr('stroke', ir.getCssColor(ir.resolveColor(hw)));
+          roofline.attr('stroke', ir.getCssColor(ir.resolveColor(hw)));
         }
       });
 
@@ -2713,8 +2709,6 @@ const ScatterGraph = React.memo(
         .selectAll<SVGTextElement, unknown>('.overflow-continuation-label')
         .attr('stroke', ir.getCssColor('--background'));
 
-      // Parallelism / line labels: visibility via data attributes (mirrors
-      // handleLegendHoverEnd). Placement-level updates happen below.
       zoomGroup
         .selectAll<SVGGElement, unknown>('.parallelism-label, .line-label')
         .style('opacity', function () {
@@ -2724,45 +2718,8 @@ const ScatterGraph = React.memo(
             ir.selectedPrecisions,
           );
         });
-
-      // Label placement (greedy collision layout) depends on the visible set,
-      // so when labels are shown, re-run the rooflines layer render — UNLESS
-      // an entrance transition is still pending/running, because that render
-      // also rewrites roofline `d` and would defeat the animation. In that
-      // case the in-flight render was produced with current interaction state
-      // anyway; the direct writes above keep visibility correct.
-      const entranceInFlight = zoomGroup
-        .selectAll<SVGPathElement, unknown>('.roofline-path')
-        .nodes()
-        .some((node) => hasNamedTransition(node, 'data-update'));
-
-      // Current (possibly zoomed) scales for layer re-renders — same scales
-      // the zoom handler would use.
-      const t = d3.zoomTransform(svg);
-      const zoomed = t.k !== 1 || t.x !== 0 || t.y !== 0;
-      const xScale = zoomed ? t.rescaleX(ctx.xScale as ContinuousScale) : ctx.xScale;
-      const yScale = zoomed ? t.rescaleY(ctx.yScale as ContinuousScale) : ctx.yScale;
-      const decorationCtx: RenderContext = { ...ctx, xScale, yScale };
-
-      const layerByKey = (key: string) => layersRef.current.find((l) => l.key === key);
-      if ((showGradientLabels || showLineLabels) && !entranceInFlight) {
-        const rooflineLayer = layerByKey('rooflines');
-        if (rooflineLayer?.type === 'custom' && rooflineLayer.render) {
-          rooflineLayer.render(zoomGroup, decorationCtx);
-        }
-      }
-
-      if (showPointLabels && !showGradientLabels) {
-        avoidPointLabelCollisions(zoomGroup);
-      }
-
-      // Known-issue annotations follow the visible series; their layer writes
-      // no animated attributes, so re-rendering is always safe.
-      const knownIssueLayer = layerByKey('known-issues');
-      if (knownIssueLayer?.type === 'custom' && knownIssueLayer.render) {
-        knownIssueLayer.render(zoomGroup, decorationCtx);
-      }
     }, [
+      getDisplaySelection,
       isPointVisible,
       isOverlayPointVisible,
       effectiveActiveHwTypes,
@@ -2770,16 +2727,91 @@ const ScatterGraph = React.memo(
       activeOverlayHwTypes,
       getCssColor,
       resolveColor,
-      knownIssueAnnotations,
-      showPointLabels,
-      useAdvancedLabels,
       showGradientLabels,
-      showLineLabels,
       gradientColorByPoint,
-      // Re-stamps `data-has-trace` once the presence lookup resolves.
-      traceAvailability,
-      isTraceAvailabilityPending,
     ]);
+
+    // Trace presence resolves asynchronously after the points render. Stamp
+    // only the tooltip metadata it owns, without restyling any chart marks.
+    useLayoutEffect(() => {
+      const display = getDisplaySelection();
+      if (!display) return;
+      display.zoomGroup.selectAll<SVGGElement, InferenceData>('.dot-group').each(function (d) {
+        const pointId = isPersistedBenchmarkId(d.id) ? d.id : null;
+        const persistedAgenticPoint = d.benchmark_type === 'agentic_traces' && pointId !== null;
+        d3.select(this)
+          .attr(
+            'data-has-trace',
+            pointId !== null && traceAvailability?.[pointId] === true ? 'true' : null,
+          )
+          .attr(
+            'data-trace-availability',
+            persistedAgenticPoint ? (isTraceAvailabilityPending ? 'pending' : 'resolved') : null,
+          );
+      });
+    }, [getDisplaySelection, dataIdentity, traceAvailability, isTraceAvailabilityPending]);
+
+    // Point-label controls own only label visibility and collision placement.
+    // Overlay label visibility remains owned by the overlay custom layer's
+    // matching selective display callback.
+    useLayoutEffect(() => {
+      if (lastPointLabelsVisibleRef.current === pointLabelsVisible) return;
+      lastPointLabelsVisibleRef.current = pointLabelsVisible;
+      const display = getDisplaySelection();
+      if (!display) return;
+      display.zoomGroup
+        .selectAll<SVGTextElement, unknown>('.dot-group .point-label')
+        .style('display', pointLabelsVisible ? '' : 'none')
+        .style('opacity', pointLabelsVisible ? 1 : 0);
+      if (pointLabelsVisible) avoidPointLabelCollisions(display.zoomGroup);
+    }, [getDisplaySelection, pointLabelsVisible]);
+
+    // Visibility and palette changes can alter label collision placement and
+    // line-label colors. Label mode changes are handled by each custom layer's
+    // display identity, so they do not also enter this pass.
+    useLayoutEffect(() => {
+      const display = getDisplaySelection();
+      if (!display) return;
+      const labelDisplay = labelDisplayRef.current;
+      const { svg, ctx, zoomGroup } = display;
+      const entranceInFlight = zoomGroup
+        .selectAll<SVGPathElement, unknown>('.roofline-path')
+        .nodes()
+        .some((node) => hasNamedTransition(node, 'data-update'));
+
+      if ((labelDisplay.showGradientLabels || labelDisplay.showLineLabels) && !entranceInFlight) {
+        const rooflineLayer = layersRef.current.find((layer) => layer.key === 'rooflines');
+        if (rooflineLayer?.type === 'custom' && rooflineLayer.render) {
+          rooflineLayer.render(zoomGroup, currentZoomRenderContext(svg, ctx));
+        }
+      }
+      if (labelDisplay.showPointLabels && !labelDisplay.showGradientLabels) {
+        avoidPointLabelCollisions(zoomGroup);
+      }
+    }, [
+      getDisplaySelection,
+      isPointVisible,
+      isOverlayPointVisible,
+      effectiveActiveHwTypes,
+      selectedPrecisions,
+      activeOverlayHwTypes,
+      getCssColor,
+      resolveColor,
+    ]);
+
+    // Known-issue annotations have their own data and theme inputs. Re-render
+    // only that layer when either changes.
+    useLayoutEffect(() => {
+      const display = getDisplaySelection();
+      if (!display) return;
+      const knownIssueLayer = layersRef.current.find((layer) => layer.key === 'known-issues');
+      if (knownIssueLayer?.type === 'custom' && knownIssueLayer.render) {
+        knownIssueLayer.render(
+          display.zoomGroup,
+          currentZoomRenderContext(display.svg, display.ctx),
+        );
+      }
+    }, [getDisplaySelection, knownIssueAnnotations, getCssColor, resolveColor]);
 
     // D3 custom layers are keyed additions, so removing the overlay layer from
     // the config does not delete DOM that the previous render created. Clear
@@ -2868,7 +2900,6 @@ const ScatterGraph = React.memo(
           data={pointsData}
           dataIdentity={dataIdentity}
           metricIdentity={metricIdentity}
-          displayIdentity={`${showPointLabels}:${showGradientLabels}:${selectedPrecisions.join(',')}`}
           margin={CHART_MARGIN}
           watermark={getChartWatermark(isUnofficialRun)}
           testId="scatter-graph"

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1267,6 +1267,8 @@ const ScatterGraph = React.memo(
     labelDisplayRef.current = { showPointLabels, showGradientLabels, showLineLabels };
     const pointLabelsVisible = showPointLabels && !showGradientLabels;
     const lastPointLabelsVisibleRef = useRef(pointLabelsVisible);
+    const lastShowLineLabelsRef = useRef(showLineLabels);
+    const lastShowGradientLabelsRef = useRef(showGradientLabels);
 
     const getDisplaySelection = useCallback(() => {
       const svg = chartRef.current?.getSvgElement?.();
@@ -2751,20 +2753,41 @@ const ScatterGraph = React.memo(
       });
     }, [getDisplaySelection, dataIdentity, traceAvailability, isTraceAvailabilityPending]);
 
-    // Point-label controls own only label visibility and collision placement.
-    // Overlay label visibility remains owned by the overlay custom layer's
-    // matching selective display callback.
+    // Label-mode controls own point-label visibility and collision placement.
+    // Line and gradient labels are collision obstacles whose custom layer
+    // renders once through D3's display phase. Replaying that layer before the
+    // point-label collision pass preserves its stable placement behavior
+    // without restyling unrelated point marks. Overlay label visibility remains
+    // owned by the overlay custom layer's matching selective display callback.
     useLayoutEffect(() => {
-      if (lastPointLabelsVisibleRef.current === pointLabelsVisible) return;
+      const visibilityChanged = lastPointLabelsVisibleRef.current !== pointLabelsVisible;
+      const lineLabelsChanged = lastShowLineLabelsRef.current !== showLineLabels;
+      const gradientLabelsChanged = lastShowGradientLabelsRef.current !== showGradientLabels;
+      if (!visibilityChanged && !lineLabelsChanged && !gradientLabelsChanged) return;
       lastPointLabelsVisibleRef.current = pointLabelsVisible;
+      lastShowLineLabelsRef.current = showLineLabels;
+      lastShowGradientLabelsRef.current = showGradientLabels;
       const display = getDisplaySelection();
       if (!display) return;
-      display.zoomGroup
-        .selectAll<SVGTextElement, unknown>('.dot-group .point-label')
-        .style('display', pointLabelsVisible ? '' : 'none')
-        .style('opacity', pointLabelsVisible ? 1 : 0);
-      if (pointLabelsVisible) avoidPointLabelCollisions(display.zoomGroup);
-    }, [getDisplaySelection, pointLabelsVisible]);
+      const { svg, ctx, zoomGroup } = display;
+      if (visibilityChanged) {
+        zoomGroup
+          .selectAll<SVGTextElement, unknown>('.dot-group .point-label')
+          .style('display', pointLabelsVisible ? '' : 'none')
+          .style('opacity', pointLabelsVisible ? 1 : 0);
+      }
+      if ((lineLabelsChanged || gradientLabelsChanged) && (showLineLabels || showGradientLabels)) {
+        const entranceInFlight = zoomGroup
+          .selectAll<SVGPathElement, unknown>('.roofline-path')
+          .nodes()
+          .some((node) => hasNamedTransition(node, 'data-update'));
+        const rooflineLayer = layersRef.current.find((layer) => layer.key === 'rooflines');
+        if (!entranceInFlight && rooflineLayer?.type === 'custom' && rooflineLayer.render) {
+          rooflineLayer.render(zoomGroup, currentZoomRenderContext(svg, ctx));
+        }
+      }
+      if (pointLabelsVisible) avoidPointLabelCollisions(zoomGroup);
+    }, [getDisplaySelection, pointLabelsVisible, showGradientLabels, showLineLabels]);
 
     // Visibility and palette changes can alter label collision placement and
     // line-label colors. Label mode changes are handled by each custom layer's


### PR DESCRIPTION
## Summary

- Split `ScatterGraph` display updates into independently owned passes for mark styling, trace metadata, point labels, line-label placement, and known-issue annotations.
- Remove the chart-level scatter `displayIdentity` from this complex chart so point-label toggles no longer restamp unrelated point shapes, visibility state, rooflines, or trace attributes.
- Keep unofficial overlay labels on their existing custom-layer display callback.
- Add regressions proving label toggles mutate only official or overlay label descendants, including the empty-chart to loaded-chart transition.

## Benchmark

Measured before changing the implementation, then repeated against the optimized production build with the same `/inference` view, 166 official points, viewport, Chrome instrumentation, 250ms observation window, and two complete Labels off/on cycles.

| Per-toggle mean | Before | After | Change |
| --- | ---: | ---: | ---: |
| SVG attribute writes | 2,252.5 | 45.5 | -98.0% |
| CSS style writes | 1,074 | 332 | -69.1% |
| Layout count | 3.5 | 1.5 | -57.1% |
| Script duration | 7.28ms | 6.23ms | -14.4% |
| Main-thread task duration | 14.88ms | 14.43ms | -3.0% |

Turning labels off now performs zero chart SVG attribute writes and zero `getBBox()` calls. Turning them on measures only the 50 visible official point labels. The previous path also measured 13 unrelated line labels and rewrote point shape, palette, visibility, and trace attributes.

## Behavior verification

- Production DOM comparison confirmed all 166 official points and 13 official rooflines retain identical non-label state across a label toggle.
- With `?unofficialrun=32315429801&i_seq=agentic-traces`, all 4 overlay points and the overlay roofline also retained identical non-label state. Observed SVG mutation targets were only `.point-label` and `.overlay-label`.
- Unofficial-run dismissal still removed all overlay points and paths while retaining all official points.
- High Contrast still changed point fill and roofline stroke while preserving point coordinates and roofline geometry.
- Line Labels still removed and restored the same 13 label nodes, with 6 visible under the tested selection.

Works for both official runs and `?unofficialrun=` overlays. Verified in a local production build and at the [preview deployment](https://inferencemax-app-git-refactor-narrow-scat-c2b39f-semianalysisai.vercel.app) (Vercel authentication required).

## Verification

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,610 tests across workspaces)
- `bun run build`
- `bun run test:e2e` (27 component and 75 integration tests)
- Focused regression was first confirmed failing on the original implementation, then passing after the fix.
- Independent review found and verified the empty-chart synchronization regression before delivery, with no remaining correctness concerns.

## 中文说明

- 将 `ScatterGraph` 的显示更新拆分为独立阶段，分别负责图形样式、trace 元数据、数据点标签、曲线标签布局和已知问题标注。
- 这个复杂图表不再使用图表级 scatter `displayIdentity`，因此切换数据点标签时不会重复写入无关的数据点形状、可见性、roofline 或 trace 属性。
- unofficial overlay 标签继续由现有自定义图层的显示回调处理。
- 新增回归测试，确保标签切换只修改官方或 overlay 标签节点，并覆盖图表从空数据恢复到有数据后的标签状态同步。

### 基准测试

在修改实现前先测量基线，再使用相同的 `/inference` 页面、166 个官方数据点、Chrome 插桩、视口和 250ms 观测窗口，对优化后的 production build 重复两轮完整的 Labels 关闭与开启操作。

| 单次切换平均值 | 优化前 | 优化后 | 变化 |
| --- | ---: | ---: | ---: |
| SVG 属性写入 | 2,252.5 | 45.5 | -98.0% |
| CSS 样式写入 | 1,074 | 332 | -69.1% |
| 布局次数 | 3.5 | 1.5 | -57.1% |
| 脚本执行时间 | 7.28ms | 6.23ms | -14.4% |
| 主线程任务时间 | 14.88ms | 14.43ms | -3.0% |

关闭标签后，图表不会再写入 SVG 属性，也不会调用 `getBBox()`。开启标签时只测量 50 个可见的官方数据点标签。旧路径还会额外测量 13 个无关的曲线标签，并重复写入数据点形状、配色、可见性和 trace 属性。

### 行为验证

- production DOM 对比确认，切换标签时 166 个官方数据点和 13 条官方 roofline 的非标签状态完全一致。
- 加载 `?unofficialrun=32315429801&i_seq=agentic-traces` 后，4 个 overlay 数据点和 1 条 overlay roofline 的非标签状态也保持一致，观测到的 SVG 变更目标只有 `.point-label` 和 `.overlay-label`。
- 按 run 关闭 unofficial overlay 后，所有 overlay 数据点和路径均被移除，官方数据点保持不变。
- High Contrast 仍会更新数据点填充色和 roofline 线条颜色，同时保持数据点坐标及 roofline 几何形状不变。
- Line Labels 仍会删除并恢复相同的 13 个标签节点，测试选择下有 6 个可见标签。

官方 run 与 `?unofficialrun=` overlay 均受支持。已使用本地 production build 和 [preview deployment](https://inferencemax-app-git-refactor-narrow-scat-c2b39f-semianalysisai.vercel.app) 完成验证（需要 Vercel 身份验证）。

### 验证

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（所有 workspace 共 4,610 项测试）
- `bun run build`
- `bun run test:e2e`（27 项 component 测试和 75 项 integration 测试）
- 修改前已确认新增的定向回归测试会失败，修复后通过。
- 独立代码审查在交付前发现并验证了空图表状态同步问题，修复后未发现其他正确性风险。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the inference scatter chart’s D3 layout-effect orchestration; incorrect effect ordering could desync labels, collisions, or zoomed decorations, but behavior is covered by new regressions.
> 
> **Overview**
> Splits `ScatterGraph` Effect-4 display updates so a label toggle no longer restamps every point’s shape, visibility, roofline, and trace attributes.
> 
> The chart-level scatter `displayIdentity` is removed. Dedicated layout effects now own mark styling, async trace metadata, point-label visibility/collision, line-label placement, and known-issue annotations. Overlay labels stay on the overlay layer’s existing display callback. Zoomed scales are applied via `currentZoomRenderContext` when a custom layer is replayed.
> 
> Tests cover empty-chart label sync, collision rechecks when line labels appear, and that label toggles mutate only `.point-label` / `.overlay-label` nodes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5302edb418439a8cd7097175cd5c3c41ef513216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Wall time: 0.48 seconds