### PR TITLE
fix(export): prevent PNG legend clipping / 修复 PNG 导出时图例被裁切

### DIFF
--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 
-import { getExportFontFamily } from './useChartExport';
+import { getExportCaptureDimensions, getExportFontFamily } from './useChartExport';
 
 describe('getExportFontFamily', () => {
   it('uses Minecraft font stack when minecraft theme is active', () => {
@@ -19,5 +19,33 @@ describe('getExportFontFamily', () => {
 
     expect(getExportFontFamily()).toContain('var(--font-dm-sans)');
     expect(getExportFontFamily()).toContain('"Segoe UI"');
+  });
+});
+
+describe('getExportCaptureDimensions', () => {
+  it('includes content that overflows the export host to the right', () => {
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      clientWidth: { value: 980 },
+      clientHeight: { value: 604 },
+      scrollWidth: { value: 1168 },
+      scrollHeight: { value: 604 },
+    });
+    element.getBoundingClientRect = () => ({ width: 980, height: 604 }) as DOMRect;
+
+    expect(getExportCaptureDimensions(element)).toEqual({ width: 1168, height: 604 });
+  });
+
+  it('rounds fractional layout bounds up so the edge pixel is not cropped', () => {
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      clientWidth: { value: 1168 },
+      clientHeight: { value: 604 },
+      scrollWidth: { value: 1168 },
+      scrollHeight: { value: 604 },
+    });
+    element.getBoundingClientRect = () => ({ width: 1168.25, height: 604.5 }) as DOMRect;
+
+    expect(getExportCaptureDimensions(element)).toEqual({ width: 1169, height: 605 });
   });
 });

--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { describe, expect, it } from 'vitest';
 
-import { getExportCaptureDimensions, getExportFontFamily } from './useChartExport';
+import {
+  getExportCaptureDimensions,
+  getExportFontFamily,
+  normalizeChartSvgWidthsForExport,
+} from './useChartExport';
 
 describe('getExportFontFamily', () => {
   it('uses Minecraft font stack when minecraft theme is active', () => {
@@ -47,5 +51,28 @@ describe('getExportCaptureDimensions', () => {
     element.getBoundingClientRect = () => ({ width: 1168.25, height: 604.5 }) as DOMRect;
 
     expect(getExportCaptureDimensions(element)).toEqual({ width: 1169, height: 605 });
+  });
+});
+
+describe('normalizeChartSvgWidthsForExport', () => {
+  it('resizes only the chart SVG and leaves UI icons unchanged', () => {
+    const root = document.createElement('div');
+    root.innerHTML = `
+      <svg data-testid="d3-chart-svg" style="width: 800px"></svg>
+      <a href="#"><svg data-testid="external-link-icon" style="width: 12px"></svg></a>
+      <button><svg data-testid="legend-info-icon" style="width: 14px"></svg></button>
+    `;
+
+    normalizeChartSvgWidthsForExport(root);
+
+    expect(root.querySelector<SVGElement>('svg[data-testid="d3-chart-svg"]')?.style.width).toBe(
+      '100%',
+    );
+    expect(
+      root.querySelector<SVGElement>('svg[data-testid="external-link-icon"]')?.style.width,
+    ).toBe('12px');
+    expect(root.querySelector<SVGElement>('svg[data-testid="legend-info-icon"]')?.style.width).toBe(
+      '14px',
+    );
   });
 });

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -169,6 +169,22 @@ function waitForRender(): Promise<void> {
   });
 }
 
+/**
+ * html-to-image measures `clientWidth`/`clientHeight`, which exclude content
+ * overflowing the export host. The sidebar legend deliberately grows beyond
+ * that host for long labels, so capture the larger scroll dimensions instead.
+ */
+export function getExportCaptureDimensions(element: HTMLElement): {
+  width: number;
+  height: number;
+} {
+  const bounds = element.getBoundingClientRect();
+  return {
+    width: Math.ceil(Math.max(bounds.width, element.clientWidth, element.scrollWidth)),
+    height: Math.ceil(Math.max(bounds.height, element.clientHeight, element.scrollHeight)),
+  };
+}
+
 /** Add a subtle watermark bar at the bottom of the exported image */
 function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
   return new Promise((resolve) => {
@@ -287,7 +303,7 @@ export function useChartExport({
         | undefined;
 
       // Layout: force side-by-side flex row for export
-      applyStyles(exportElement, { width: 'fit-content', overflow: 'visible', padding: '16px' });
+      applyStyles(exportElement, { width: 'max-content', overflow: 'visible', padding: '16px' });
 
       const flexContainer = clone.querySelector(':scope > .flex') as HTMLElement | null;
       applyStyles(flexContainer, {
@@ -432,7 +448,9 @@ export function useChartExport({
           // Fallback to @font-face extraction from loaded stylesheets.
         }
       }
+      const captureDimensions = getExportCaptureDimensions(exportElement);
       const chartDataUrl = await toPng(exportElement, {
+        ...captureDimensions,
         quality: 1,
         pixelRatio: 2,
         backgroundColor: bgColor,

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -185,6 +185,13 @@ export function getExportCaptureDimensions(element: HTMLElement): {
   };
 }
 
+/** Keep the plot responsive without stretching small UI icons in the clone. */
+export function normalizeChartSvgWidthsForExport(root: HTMLElement): void {
+  for (const svg of root.querySelectorAll<SVGElement>('svg[data-testid="d3-chart-svg"]')) {
+    svg.style.width = '100%';
+  }
+}
+
 /** Add a subtle watermark bar at the bottom of the exported image */
 function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
   return new Promise((resolve) => {
@@ -303,7 +310,7 @@ export function useChartExport({
         | undefined;
 
       // Layout: force side-by-side flex row for export
-      applyStyles(exportElement, { width: 'max-content', overflow: 'visible', padding: '16px' });
+      applyStyles(exportElement, { width: 'fit-content', overflow: 'visible', padding: '16px' });
 
       const flexContainer = clone.querySelector(':scope > .flex') as HTMLElement | null;
       applyStyles(flexContainer, {
@@ -328,7 +335,7 @@ export function useChartExport({
       // Force legend into inline flow
       if (legendContainer) {
         legendContainer.style.cssText +=
-          '; position: relative !important; right: auto !important; top: auto !important; left: auto !important; bottom: auto !important; width: auto !important; min-width: fit-content !important; z-index: auto !important; overflow: visible !important; padding: 8px !important;';
+          '; position: relative !important; right: auto !important; top: auto !important; left: auto !important; bottom: auto !important; width: auto !important; min-width: fit-content !important; height: auto !important; min-height: 0 !important; max-height: none !important; z-index: auto !important; overflow: visible !important; padding: 8px !important;';
 
         const scrollContainer = legendContainer.querySelector(
           'ul, [class*="overflow"]',
@@ -424,9 +431,7 @@ export function useChartExport({
       for (const span of clone.querySelectorAll('span')) {
         span.style.fontSize = '14px';
       }
-      for (const svg of clone.querySelectorAll('svg')) {
-        svg.style.width = '100%';
-      }
+      normalizeChartSvgWidthsForExport(clone);
 
       // Wait for fonts before capture
       try {


### PR DESCRIPTION
## Summary

- Keep the hidden PNG export host constrained so long captions and notices wrap within the chart layout instead of creating a wide empty canvas.
- Measure overflow-inclusive scroll and bounding dimensions, round them up, and pass them explicitly to html-to-image so the complete sidebar legend remains captured.
- Let exported legends grow to their natural height and normalize only the main chart SVG width, preserving intrinsic sizes for link and info icons.
- Add regression tests for a right-overflowing legend, fractional edge pixels, and UI icon sizing.

## Testing

- bun --cwd packages/app vitest run src/hooks/useChartExport.test.ts — passed (5 tests)
- bun run lint — passed
- bun run fmt — passed
- bun run typecheck — passed
- Cypress smoke component phase — passed (27 tests)
- Full CI passed on the first push and is rerunning for the latest update.

## 中文说明

- 约束隐藏的 PNG 导出容器，使较长的标题说明和提示文字在图表布局内换行，避免生成带有大块右侧空白的画布。
- 同时测量包含溢出内容的滚动尺寸与边界尺寸，向上取整后显式传给 html-to-image，确保侧边图例完整导出。
- 导出图例按内容自然增高，并且只归一化主图表 SVG 的宽度，链接和信息图标保留自身尺寸。
- 新增回归测试，覆盖图例向右溢出、小数像素边缘以及 UI 图标尺寸。

## 测试

- bun --cwd packages/app vitest run src/hooks/useChartExport.test.ts — 通过（5 项测试）
- bun run lint — 通过
- bun run fmt — 通过
- bun run typecheck — 通过
- Cypress 冒烟测试的组件测试阶段 — 通过（27 项测试）
- 首次推送的完整 CI 已通过，最新更新正在重新运行。