### PR TITLE
Retain TileRT in best-per-SKU views / 在每个 SKU 最佳配置视图中保留 TileRT

### DIFF
--- a/packages/app/src/components/inference/utils/best-series-per-sku.test.ts
+++ b/packages/app/src/components/inference/utils/best-series-per-sku.test.ts
@@ -8,6 +8,16 @@ function point(hw: string, hwKey: string, x: number, y: number): InferenceData {
   return { hw, hwKey, x, y } as InferenceData;
 }
 
+function frameworkPoint(
+  hw: string,
+  hwKey: string,
+  framework: string,
+  x: number,
+  y: number,
+): InferenceData {
+  return { ...point(hw, hwKey, x, y), framework };
+}
+
 describe('bestSeriesPerSku', () => {
   it('selects the highest normalized frontier AUC within each SKU', () => {
     const selected = bestSeriesPerSku(
@@ -57,6 +67,21 @@ describe('bestSeriesPerSku', () => {
     expect(baseSku(point('GB200-NVL72', 'gb200_dynamo-trt', 1, 1))).toBe('GB200');
   });
 
+  it('keeps every eligible TileRT series alongside the SKU AUC winner', () => {
+    const selected = bestSeriesPerSku(
+      [
+        frameworkPoint('B200-8', 'b200_sglang', 'sglang', 20, 1_800),
+        frameworkPoint('B200-8', 'b200_sglang', 'sglang', 60, 1_000),
+        frameworkPoint('B200-8', 'b200_tilert_mtp', 'tilert', 340, 160),
+        frameworkPoint('B200-8', 'b200_tilert_stp', 'tilert', 300, 140),
+        frameworkPoint('B200-8', 'b200_unrelated_endpoint', 'vllm', 400, 120),
+      ],
+      'upper_left',
+    );
+
+    expect(selected).toEqual(new Set(['b200_sglang', 'b200_tilert_mtp', 'b200_tilert_stp']));
+  });
+
   it('ranks unofficial-run overlay series with the same SKU policy', () => {
     const overlayPoint = (hwKey: string, x: number, y: number) =>
       ({
@@ -74,5 +99,23 @@ describe('bestSeriesPerSku', () => {
     );
 
     expect(selected).toEqual(new Set(['b200_overlay_sglang']));
+  });
+
+  it('keeps TileRT series from an unofficial-run overlay', () => {
+    const overlayPoint = (hwKey: string, framework: string, x: number, y: number) =>
+      ({
+        ...frameworkPoint('B200-8', hwKey, framework, x, y),
+        run_url: 'https://github.com/example/actions/runs/123',
+      }) as InferenceData;
+    const selected = bestSeriesPerSku(
+      [
+        overlayPoint('b200_overlay_sglang', 'sglang', 20, 1_800),
+        overlayPoint('b200_overlay_sglang', 'sglang', 60, 1_000),
+        overlayPoint('b200_overlay_tilert_mtp', 'tilert', 340, 160),
+      ],
+      'upper_left',
+    );
+
+    expect(selected).toEqual(new Set(['b200_overlay_sglang', 'b200_overlay_tilert_mtp']));
   });
 });

--- a/packages/app/src/components/inference/utils/best-series-per-sku.ts
+++ b/packages/app/src/components/inference/utils/best-series-per-sku.ts
@@ -22,19 +22,25 @@ interface ScoredSeries {
 }
 
 /**
- * Select one configuration line per physical SKU using normalized frontier AUC.
+ * Select the best configuration line per physical SKU using normalized frontier AUC.
  *
  * Every candidate is sampled over the common measured x-domain for that SKU,
  * so a curve cannot win merely because it spans a wider range. The chart's
  * existing Pareto direction and monotone interpolation are reused to keep the
  * ranking aligned with the line users see. Ties are deterministic by hwKey.
+ *
+ * TileRT is the deliberate exception to the one-line policy. Its specialized
+ * operating points can be exceptional even when a broader serving curve wins
+ * the AUC comparison, so every eligible TileRT series remains visible.
  */
 export function bestSeriesPerSku(points: InferenceData[], direction: Direction): Set<string> {
   const bySku = new Map<string, Map<string, InferenceData[]>>();
+  const featured = new Set<string>();
   for (const point of points) {
     if (!isFrontierEligible(point) || !Number.isFinite(point.y)) continue;
     const sku = baseSku(point);
     const key = String(point.hwKey);
+    if (point.framework === 'tilert') featured.add(key);
     let series = bySku.get(sku);
     if (!series) {
       series = new Map();
@@ -45,7 +51,7 @@ export function bestSeriesPerSku(points: InferenceData[], direction: Direction):
     series.set(key, rows);
   }
 
-  const selected = new Set<string>();
+  const selected = new Set(featured);
   const higherYIsBetter = direction.startsWith('upper');
 
   for (const series of bySku.values()) {


### PR DESCRIPTION
## Summary

- Keep every eligible TileRT series visible alongside the normalized AUC winner when Best per SKU is enabled.
- Preserve the existing AUC selection policy for every other framework; unrelated endpoint configurations remain filtered.
- Works for both official runs and `?unofficialrun=` overlays through the shared selector, with focused unit coverage for both paths.

## Testing

- `bunx oxfmt --check src/components/inference/utils/best-series-per-sku.ts src/components/inference/utils/best-series-per-sku.test.ts`
- `bunx oxlint src/components/inference/utils/best-series-per-sku.ts src/components/inference/utils/best-series-per-sku.test.ts`
- `bun vitest run src/components/inference/utils/best-series-per-sku.test.ts`
- `bun run typecheck`

## 中文说明

- 启用“每个 SKU 仅显示最佳配置”后，在标准化 AUC 胜出曲线之外，始终保留所有符合条件的 TileRT 系列。
- 其他框架继续沿用现有 AUC 选择策略；无关的端点配置仍会被过滤。
- 官方运行与 `?unofficialrun=` 叠加层均通过共享选择器获得一致支持，并已为两条路径补充针对性单元测试。

## 测试

- `bunx oxfmt --check src/components/inference/utils/best-series-per-sku.ts src/components/inference/utils/best-series-per-sku.test.ts`
- `bunx oxlint src/components/inference/utils/best-series-per-sku.ts src/components/inference/utils/best-series-per-sku.test.ts`
- `bun vitest run src/components/inference/utils/best-series-per-sku.test.ts`
- `bun run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small chart-selection change with unit tests; no auth, data, or API surface is involved.
> 
> **Overview**
> When **Best per SKU** is on, every eligible TileRT series stays on the chart next to the normalized-AUC winner for that hardware. Other frameworks still compete as before, so unrelated endpoints remain filtered.
> 
> The exception is applied in the shared `bestSeriesPerSku` selector, so official runs and unofficial-run overlays behave the same. Tests cover both paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5067f308d150b1d2d20d2f88a96fb948888e075b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->