### PR TITLE
Preserve unofficial overlays when soloing official hardware / 单独显示官方硬件时保留非官方 overlay

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -910,6 +910,75 @@ describe('ScatterGraph', () => {
     });
   });
 
+  it('keeps the unofficial overlay active when soloing an official hardware series', () => {
+    const chartDefinition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_tpPerGpu_roofline: 'upper_left',
+    });
+    const officialData = ['b200_sglang', 'h100_vllm'].flatMap((hwKey, hwIndex) =>
+      [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey,
+          x,
+          y: 320 - hwIndex * 20 - index * 40,
+          precision: Precision.FP4,
+        }),
+      ),
+    );
+    const runUrl = 'https://github.com/x/y/actions/runs/official-solo';
+    const overlayData = {
+      data: [8, 16, 32].map((x, index) =>
+        createMockInferenceData({
+          hwKey: 'h100_vllm',
+          x,
+          y: 260 - index * 40,
+          precision: Precision.FP4,
+          run_url: runUrl,
+        }),
+      ),
+      hardwareConfig: hwConfig,
+      label: 'official-solo',
+      runUrl,
+    };
+
+    mountWithProviders(
+      <div style={{ width: 800, height: 600 }}>
+        <ScatterGraph
+          chartId="test-scatter-official-solo"
+          modelLabel="DeepSeek V4 Pro"
+          data={officialData}
+          xLabel="Concurrency"
+          yLabel="Throughput / Chip (tok/s)"
+          chartDefinition={chartDefinition}
+          overlayData={overlayData}
+        />
+      </div>,
+      {
+        inference: {
+          hardwareConfig: hwConfig,
+          activeHwTypes: new Set(['b200_sglang', 'h100_vllm']),
+          hwTypesWithData: new Set(['b200_sglang', 'h100_vllm']),
+          selectedModel: Model.DeepSeek_V4_Pro,
+          selectedSequence: Sequence.AgenticTraces,
+          selectedPrecisions: [Precision.FP4],
+        },
+        unofficial: {
+          activeOverlayHwTypes: new Set(['h100_vllm']),
+          allOverlayHwTypes: new Set(['h100_vllm']),
+        },
+      },
+    );
+
+    cy.get('#test-scatter-official-solo svg .overlay-roofline-path').should('exist');
+    cy.get('label[for="checkbox-h100_vllm"]').click();
+    cy.get('@setUnifiedOverlaySelection').should((setSelection) => {
+      const official = setSelection.lastCall.args[0] as Set<string>;
+      const overlay = setSelection.lastCall.args[1] as Set<string>;
+      expect([...official]).to.deep.equal(['h100_vllm']);
+      expect([...overlay]).to.deep.equal(['h100_vllm']);
+    });
+  });
+
   it('renders both official and overlay AgentX STP series from the same engine family', () => {
     const chartDefinition = createMockChartDefinition({
       chartType: 'interactivity',

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -525,14 +525,21 @@ const ScatterGraph = React.memo(
       },
       [providerActiveOverlayHwTypes, scopedOverlayHwTypes, setUnifiedOverlaySelection],
     );
-    const unifiedToggle = useCallback(
-      (key: string, isOverlay: boolean) => {
-        const prefixedKey = isOverlay ? `overlay:${key}` : key;
-        commitUnifiedSelection(
-          computeToggle(resolvedUnifiedSelection, prefixedKey, allUnifiedHwTypes),
+    const toggleOfficialHwType = useCallback(
+      (key: string) => {
+        // The unofficial run is a pinned comparison, not an official legend item.
+        // Soloing an official series must therefore leave every overlay selection unchanged.
+        setUnifiedOverlaySelection(
+          computeToggle(effectiveOfficialHwTypes, key, hwTypesWithData),
+          providerActiveOverlayHwTypes,
         );
       },
-      [resolvedUnifiedSelection, allUnifiedHwTypes, commitUnifiedSelection],
+      [
+        effectiveOfficialHwTypes,
+        hwTypesWithData,
+        providerActiveOverlayHwTypes,
+        setUnifiedOverlaySelection,
+      ],
     );
     const resetUnifiedSelection = useCallback(() => {
       selectAllHwTypes();
@@ -557,9 +564,9 @@ const ScatterGraph = React.memo(
           return;
         }
         setBestPerSku(false, { applySelection: false });
-        unifiedToggle(key, false);
+        toggleOfficialHwType(key);
       },
-      [overlayData, setBestPerSku, unifiedToggle, toggleHwType],
+      [overlayData, setBestPerSku, toggleOfficialHwType, toggleHwType],
     );
 
     // Legend "X" (remove) — same overlay split as handleToggleHwType. With an


### PR DESCRIPTION
## Summary

- Keep loaded unofficial-run overlays visible when a user solos an official hardware series.
- Scope legend solo and restore behavior to official hardware while leaving overlay selection unchanged.
- Add a Cypress regression reproducing the official and overlay hardware collision.

## Verification

- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx` (22 passing)
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- Loaded `https://inferencex.semianalysis.com/inference?unofficialRun=32724927772`, soloed `MI355X (SGLang)`, and confirmed the official series plus all 8 overlay points and the overlay roofline remained visible on the corrected local build.

## Overlay support

Works for both official runs and `?unofficialrun=` overlays. Verified locally with the reported run `32724927772`.

## 中文说明

## 摘要

- 用户单独显示某个官方硬件系列时，保持已加载的非官方运行 overlay 可见。
- 将图例的单独显示和恢复逻辑限定在官方硬件范围内，不再改动 overlay 选择状态。
- 新增 Cypress 回归测试，覆盖官方系列与 overlay 硬件键相同的场景。

## 验证

- `bunx cypress run --component --spec cypress/component/scatter-graph.cy.tsx`（22 项通过）
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- 加载 `https://inferencex.semianalysis.com/inference?unofficialRun=32724927772`，单独显示 `MI355X (SGLang)`，并在修复后的本地构建中确认官方系列、全部 8 个 overlay 数据点及 overlay 屋顶线仍保持可见。

## 非官方运行支持

同时适用于官方运行和 `?unofficialrun=` overlay。已使用报告中的运行 `32724927772` 完成本地验证。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized legend toggle behavior in ScatterGraph with overlay data; regression test added. No auth, data, or API changes.
> 
> **Overview**
> Fixes a regression where **soloing an official hardware series** in the scatter legend could hide or clear the pinned unofficial-run overlay, including when official and overlay share the same hardware key (e.g. `h100_vllm`).
> 
> **ScatterGraph** no longer routes official legend clicks through the combined unified selection toggle. It updates only official hardware via `toggleOfficialHwType`, passing overlay selection through unchanged to `setUnifiedOverlaySelection`.
> 
> A **Cypress component test** covers the collision case: after soloing an official series, official and overlay selections both remain on the expected key and the overlay roofline stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e94689ad2b9c50d5822cbd53e0cec1b2b8e1cb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->