### PR TITLE
Add normalized interactivity FAQ help link / 为归一化交互性添加 FAQ 帮助链接

### DIFF
--- a/packages/app/cypress/component/normalized-interactivity-help-link.cy.tsx
+++ b/packages/app/cypress/component/normalized-interactivity-help-link.cy.tsx
@@ -1,0 +1,35 @@
+import { NormalizedInteractivityHelpLink } from '@/components/inference/ui/NormalizedInteractivityHelpLink';
+
+describe('NormalizedInteractivityHelpLink', () => {
+  it('renders a subtle icon-only link to the English FAQ', () => {
+    cy.mount(
+      <div className="relative h-10 w-80">
+        <NormalizedInteractivityHelpLink locale="en" />
+      </div>,
+    );
+
+    cy.get('[data-testid="normalized-interactivity-faq-link"]')
+      .should('be.visible')
+      .and('have.text', '')
+      .and('have.attr', 'href', '/about#faq-normalized-interactivity')
+      .and('have.attr', 'title', 'What does E2E Normalized Interactivity mean?')
+      .and('have.attr', 'aria-label', 'What does E2E Normalized Interactivity mean?')
+      .and('have.class', 'no-export')
+      .find('svg[aria-hidden="true"]')
+      .should('be.visible')
+      .and('have.attr', 'width', '24');
+  });
+
+  it('links the Chinese control to the Chinese FAQ', () => {
+    cy.mount(
+      <div className="relative h-10 w-80">
+        <NormalizedInteractivityHelpLink locale="zh" />
+      </div>,
+    );
+
+    cy.get('[data-testid="normalized-interactivity-faq-link"]')
+      .should('have.attr', 'href', '/zh/about#faq-normalized-interactivity')
+      .and('have.attr', 'title', '什么是端到端归一化交互性？')
+      .and('have.attr', 'aria-label', '什么是端到端归一化交互性？');
+  });
+});

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -172,6 +172,20 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     );
   });
 
+  it('offers unobtrusive FAQ help beside E2E Normalized Interactivity', () => {
+    cy.get('[data-testid="normalized-interactivity-faq-link"]')
+      .should('be.visible')
+      .and('have.attr', 'href', '/about#faq-normalized-interactivity')
+      .and('have.attr', 'title', 'What does E2E Normalized Interactivity mean?')
+      .and('have.class', 'no-export')
+      .find('svg[aria-hidden="true"]')
+      .should('be.visible');
+
+    // The metric tabs sit outside the chart capture root, and no-export is a
+    // second guard if this control moves into that tree in the future.
+    cy.get('#chart-0 [data-testid="normalized-interactivity-faq-link"]').should('not.exist');
+  });
+
   it('switches to E2E Normalized Interactivity and updates the heading', () => {
     // The first entry into this mode fetches the trace-derived metrics, which the
     // suite's intercept stubs; the default no longer fetches them on load.

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -84,6 +84,7 @@ const ModelArchitectureDiagram = dynamic(() => import('./ModelArchitectureDiagra
   loading: () => <Skeleton className="h-40 w-full" />,
 });
 import WorkflowInfoDisplay from './WorkflowInfoDisplay';
+import { NormalizedInteractivityHelpLink } from './NormalizedInteractivityHelpLink';
 
 type InferenceViewMode = 'chart' | 'table';
 
@@ -1090,16 +1091,38 @@ export default function ChartDisplay() {
             // Before mount, render all buttons so SSR and first client render match.
             if (!mounted) return true;
             return !isAgenticOnlyXAxisMode(value) || isAgenticSequence;
-          }).map(({ value, label, labelZh }) => (
-            <TabsTrigger
-              key={value}
-              value={value}
-              data-testid={`x-axis-mode-${value}`}
-              className="min-w-[130px] sm:min-w-[140px] flex-1 sm:flex-initial justify-center"
-            >
-              {locale === 'zh' ? labelZh : label}
-            </TabsTrigger>
-          ))}
+          }).map(({ value, label, labelZh }) => {
+            const modeLabel = locale === 'zh' ? labelZh : label;
+            if (value !== 'e2e-normalized-interactivity') {
+              return (
+                <TabsTrigger
+                  key={value}
+                  value={value}
+                  data-testid={`x-axis-mode-${value}`}
+                  className="min-w-[130px] sm:min-w-[140px] flex-1 sm:flex-initial justify-center"
+                >
+                  {modeLabel}
+                </TabsTrigger>
+              );
+            }
+
+            return (
+              <span
+                key={value}
+                role="presentation"
+                className="relative flex flex-1 sm:flex-initial"
+              >
+                <TabsTrigger
+                  value={value}
+                  data-testid={`x-axis-mode-${value}`}
+                  className="min-w-[130px] flex-1 justify-center pr-9 sm:min-w-[140px] sm:flex-initial"
+                >
+                  {modeLabel}
+                </TabsTrigger>
+                <NormalizedInteractivityHelpLink locale={locale} />
+              </span>
+            );
+          })}
         </TabsList>
       </Tabs>
       <div className="flex flex-col gap-4">{displayGraphs}</div>

--- a/packages/app/src/components/inference/ui/NormalizedInteractivityHelpLink.tsx
+++ b/packages/app/src/components/inference/ui/NormalizedInteractivityHelpLink.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { CircleHelp } from 'lucide-react';
+
+import { track } from '@/lib/analytics';
+import type { Locale } from '@/lib/i18n';
+
+const STRINGS = {
+  en: 'What does E2E Normalized Interactivity mean?',
+  zh: '什么是端到端归一化交互性？',
+} as const;
+
+export function NormalizedInteractivityHelpLink({ locale }: { locale: Locale }) {
+  const label = STRINGS[locale];
+  const href = `${locale === 'zh' ? '/zh' : ''}/about#faq-normalized-interactivity`;
+
+  return (
+    <a
+      href={href}
+      data-testid="normalized-interactivity-faq-link"
+      aria-label={label}
+      title={label}
+      onClick={() => track('interactivity_normalized_faq_opened', { locale })}
+      className="no-export absolute right-1 top-1/2 z-10 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground/55 transition-colors hover:bg-muted hover:text-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1"
+    >
+      <CircleHelp aria-hidden="true" className="size-3.5" strokeWidth={1.75} />
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a subdued circled-question-mark link beside the **E2E Normalized Interactivity** tab on `/inference`.
- Link directly to the explanation added in #847 at `/about#faq-normalized-interactivity`, with `/zh/about#faq-normalized-interactivity` on the Chinese page.
- Keep the visual icon at 14px with a 24px hit target, low default contrast, hover/focus feedback, localized hover and accessibility labels, and interaction analytics.
- Keep the help control outside the chart capture tree and mark it `no-export`, so it is excluded from PNG and MP4 exports. CSV export contains data only.
- Works for both official runs and `?unofficialrun=` overlays; the existing overlay-path E2E coverage passes with the wrapped metric tab.

## Chinese copy review

The new Chinese control text is limited to the hover/accessibility label `什么是端到端归一化交互性？`. It was checked manually for semantic fidelity and concise UI register because the repository-referenced `review-zh-copy` skill was unavailable in this session.

## Testing

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `bun run test:unit` — 4,772 tests passed
- `bunx cypress run --component --spec cypress/component/normalized-interactivity-help-link.cy.tsx` — 2 tests passed
- `bunx cypress run --spec cypress/e2e/ttft-x-axis-toggle.cy.ts` — 26 tests passed, including unofficial overlays and PNG export behavior
- `bun run test:e2e` — 106 tests passed

## 中文说明

## 改动摘要

- 在 `/inference` 的**端到端归一化交互性**标签旁添加低调的圆形问号链接。
- 英文页面直达 #847 新增的 `/about#faq-normalized-interactivity` 说明，中文页面则链接到 `/zh/about#faq-normalized-interactivity`。
- 图标视觉尺寸为 14px，点击区域为 24px；默认采用低对比度，并提供 hover、键盘焦点、本地化悬停提示、无障碍文案和交互埋点。
- 帮助控件位于图表捕获范围之外，并标记为 `no-export`，因此不会出现在 PNG 或 MP4 导出中；CSV 仅导出数据。
- 官方运行和 `?unofficialrun=` 非官方运行覆盖均可正常使用；使用新标签结构后，现有 overlay 路径 E2E 测试仍然通过。

## 中文文案审核

新增中文文案仅包含悬停提示和无障碍标签 `什么是端到端归一化交互性？`。由于本次会话无法使用仓库中提及的 `review-zh-copy` skill，因此按照简短 UI 文案的语域要求，人工检查了语义准确性与表达自然度。

## 测试

- `bun run lint`
- `bun run fmt`
- `bun run typecheck`
- `bun run test:unit` — 4,772 项测试通过
- `bunx cypress run --component --spec cypress/component/normalized-interactivity-help-link.cy.tsx` — 2 项测试通过
- `bunx cypress run --spec cypress/e2e/ttft-x-axis-toggle.cy.ts` — 26 项测试通过，包括非官方运行覆盖和 PNG 导出行为
- `bun run test:e2e` — 106 项测试通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only help affordance on the inference chart tabs with analytics and export exclusions; no auth, API, or metric computation changes.
> 
> **Overview**
> Adds a **low-contrast circled-question help link** next to the **E2E Normalized Interactivity** x-axis tab on `/inference`, pointing to the About FAQ (`/about#faq-normalized-interactivity`, or `/zh/...` for Chinese). The new `NormalizedInteractivityHelpLink` is icon-only with localized `title`/`aria-label`, fires `interactivity_normalized_faq_opened` on click, and uses **`no-export`** so it stays out of chart PNG/MP4 captures; the tab row also gets extra right padding so the control fits beside the trigger.
> 
> `ChartDisplay` only special-cases that one metric tab—the other x-axis tabs are unchanged. Coverage includes a component spec for EN/ZH hrefs and labels, plus an e2e check that the link is visible on the inference page and **not** inside `#chart-0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e3c9457624ea70cecdbbfb62a865637c2bcec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->