### PR TITLE
Add eight AgentX-era glossary terms and refresh nine definitions / 新增八条 AgentX 相关术语并更新九条释义

### DIFF
--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -160,7 +160,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '不同产品需要不同运行点。语音和交互式编程要求较高 token 速率，离线摘要则可以牺牲交互性换取更高总吞吐量；在交互性不一致时比较硬件很容易得出误导性结论。',
     benchmarkContext:
-      'InferenceX 将 tok/s/user 与吞吐量或成本一起绘制，并在等交互性表格中沿各自 Pareto 前沿插值，以固定用户体验。',
+      'InferenceX 将 tok/s/user 与吞吐量或成本一起绘制，并在等交互性表格中沿各自 Pareto 前沿插值，以固定用户体验。由于该坐标轴不计入首 token 之前的等待，agentic 图表还提供端到端归一化交互性，用同一单位把 TTFT 一并纳入。',
     measurement: { label: '常用单位', value: 'token/秒/用户（tok/s/user）' },
   },
   latency: {
@@ -238,7 +238,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '前沿能避免噪声点或调优较差的点扭曲比较，并展示真正的权衡。沿曲线仍不存在普适赢家，最佳点取决于用户最低交互性或最高成本目标。',
     benchmarkContext:
-      'InferenceX 连接并发与配置扫描中的 Pareto 最优点，等交互性比较也沿这些前沿插值，避免用随意选择的原始点直接比较。',
+      'InferenceX 连接并发与配置扫描中的 Pareto 最优点，等交互性比较也沿这些前沿插值，避免用随意选择的原始点直接比较。每个 SKU 最佳配置视图现在会把允许启用的优化合并成一条曲线，按模型、芯片 SKU 和引擎各一条，因此同一条线上相邻的点可能在投机解码、分离式部署或 KV cache offload 上并不相同；每个点仍会展示产生它的具体配置。',
   },
   'iso-interactivity': {
     term: '等交互性',
@@ -250,7 +250,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '固定用户体验可以避免常见基准错误：某系统只有在让每个请求更慢时才达到更高吞吐量，却被错误地称为更快。',
     benchmarkContext:
-      'InferenceX 文章使用等交互性表格比较硬件、精度和软件；超出实测前沿的值会标记为不可达，而不会向观测区间之外外推。',
+      'InferenceX 文章使用等交互性表格比较硬件、精度和软件；超出实测前沿的值会标记为不可达，而不会向观测区间之外外推。前沿始终建立在吞吐量与交互性之上，每百万 token 成本和每 token 焦耳则由插值得到的吞吐量推导，而不是各自单独做样条：它们都是每芯片常数除以吞吐量，单独插值会破坏两个 knot 之间的这一恒等关系。',
   },
   'input-output-sequence-length': {
     term: '输入与输出序列长度',
@@ -264,7 +264,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '不同序列长度的结果不能直接互换。短聊天提示词上的最佳配置，在长上下文摘要或推理中可能排名不同，因为计算、容量与带宽压力都会变化。',
     benchmarkContext:
-      'InferenceX 在图表标签与方案描述中列出 ISL/OSL。只有先匹配工作负载形状，才能把差异归因于硬件或软件。',
+      'InferenceX 在图表标签与方案描述中列出 ISL/OSL。只有先匹配工作负载形状，才能把差异归因于硬件或软件。agentic 运行没有单一的 ISL/OSL 组合可供引用：长度近似服从对数正态分布，因此点详情视图会绘制拟合分布并给出分位数，p90 或 p99 输入长度可能是中位数的数倍。',
   },
   'cost-per-million-tokens': {
     term: '每百万 token 成本',
@@ -292,7 +292,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '芯片峰值 FLOPS 不能单独决定服务经济性；内存、网络、软件成熟度、数值精度和实际利用率都会影响最终比值。',
     benchmarkContext:
-      'InferenceX 在匹配交互性时比较 perf/$，并明确使用的 TCO 输入。该比值不能跨模型、序列长度、精度或延迟区间直接套用。',
+      'InferenceX 在匹配交互性时比较 perf/$，并明确使用的 TCO 输入。该比值不能跨模型、序列长度、精度或延迟区间直接套用。图表用每美元 token 数表达同一套经济性，它数值越大越好，也是默认的 Y 轴。',
   },
   'total-cost-of-ownership': {
     term: '总体拥有成本',
@@ -316,7 +316,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '电力供应往往是新增 AI 部署的硬约束。每兆瓦生成更多 token 的系统，即使单个加速器功耗更高，也能在相同电力配额下服务更多需求。',
     benchmarkContext:
-      '比较 tokens/MW 时必须匹配模型、工作负载、精度与交互性，否则高吞吐低交互点可能看似高效，却无法满足目标用户体验。',
+      '比较 tokens/MW 时必须匹配模型、工作负载、精度与交互性，否则高吞吐低交互点可能看似高效，却无法满足目标用户体验。每 token 能耗表达的是同一份供电预算折算到单位输出上的结果；在遥测可信的前提下，InferenceX 还会给出加速器的实测能耗。',
     measurement: { label: '常用单位', value: '每单位配置市电兆瓦的 token/秒' },
   },
   prefill: {
@@ -354,7 +354,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       'KV 缓存压力限制并发与长上下文服务。缓存量化、分页分配、潜在注意力、前缀复用和分离式传输系统都在降低其容量或移动成本。',
     benchmarkContext:
-      '除非方案另有说明，InferenceX 在随机数据比较中禁用前缀缓存，避免无关请求因偶然命中而获得不真实优势。',
+      '除非方案另有说明，InferenceX 在定长场景的随机数据比较中禁用前缀缓存，避免无关请求因偶然命中而获得不真实优势。AgentX 是有意为之的例外：它回放的会话本身就会复用前缀，因此缓存容量、淘汰策略和 offload 都属于该场景要测量的内容。',
   },
   'prefix-caching': {
     term: '前缀缓存',
@@ -367,7 +367,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '具有重复前缀的生产工作负载可能明显快于随机 token 基准；收益取决于命中率、缓存容量、淘汰策略与请求能否路由到持有所需状态的节点。',
     benchmarkContext:
-      'InferenceX 通常在随机数据集上禁用前缀缓存，避免把缓存策略混入完整提示词处理的测量。除非明确说明，应把结果视为无命中基线。',
+      'InferenceX 在定长场景的随机数据集上禁用前缀缓存，避免把缓存策略混入完整提示词处理的测量，因此那些数字应视为无命中基线。AgentX 则相反：命中率本身就是上报指标，会与该点所在的 offload 层级一并展示，因为复用正是这类工作负载的本质特征。',
   },
   'disaggregated-inference': {
     term: '分离式推理',
@@ -393,7 +393,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     significance:
       '加速取决于草稿 token 的接受数量，以及草稿与验证成本。稠密模型和 MoE 的表现可能不同，因为验证多个位置可能激活更多专家权重。',
     benchmarkContext:
-      '应在真实接受率下比较推测方案并验证模型质量。InferenceX 分开展示开启和关闭 MTP 的曲线，因为收益会随并发与交互性变化。',
+      '应在真实接受率下比较投机解码方案并验证模型质量。定长场景仍把投机解码作为曲线标识的一部分，因此开启和关闭 MTP 的方案会分开绘制；agentic 曲线则把它当作数据点级元数据并合并这些点，在 tooltip 中标明具体方式，因为 AgentX 按模型、芯片 SKU 和引擎给出可获得的最佳曲线。由于 AgentX 回放的内容是合成的，speculator 接受的 draft token 数会失真，因此运行时会套用一套按模型、speculator、draft 长度和思考模式在外部 agentic 编码数据集上采集的接受长度。',
   },
   'multi-token-prediction': {
     term: '多 token 预测',
@@ -722,6 +722,118 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       '机架级性能由单芯片运行时、路由、缓存传输、拓扑感知与池大小共同决定。这些因素决定 Wide EP 和分离式推理能否提升端到端性能。',
     benchmarkContext:
       'Dynamo vLLM、Dynamo TRT-LLM 标签同时标识编排层与执行引擎。InferenceX 文章还会明确预填充/解码拓扑，因为两种 Dynamo 配置可能表现完全不同。',
+  },
+  'e2e-normalized-interactivity': {
+    term: '端到端归一化交互性',
+    aliases: ['E2E Normalized Interactivity', '归一化交互性', 'OSL/E2EL'],
+    plainEnglish:
+      '这个指标衡量一整条回答到达得有多快，既算首 token 之前的等待，也算之后的流式速度。',
+    definition:
+      '端到端归一化交互性是整条请求上的有效每用户 token 速率，即输出 token 数除以端到端延迟。',
+    explanation:
+      '把端到端延迟展开为 TTFT 加上输出长度乘以每输出 token 时间，该指标约等于 1 除以（token 间延迟加上 TTFT 除以输出 token 数），也就是常规交互性再加一项与首 token 等待成正比的惩罚。这里的“归一化”指按输出长度归一，既不是 0 到 1 的评分，也不是与其他系统对比后的相对值。',
+    significance:
+      '只看交互性，会奖励那些让用户先等很久、之后再快速输出的方案；只看 TTFT，则会奖励开头很快、随后拖沓的方案。把两者合成一个数字，可以暴露只在单一维度上好看的运行点。输出越短，TTFT 惩罚越明显，因为可供摊薄等待时间的 token 更少。',
+    benchmarkContext:
+      'InferenceX 把它作为 agentic 运行的实验性 X 轴模式，因此需要持久化的逐请求 trace，非官方运行 overlay 无法使用该视图。它是有意保留缺陷的：对高 TTFT 惩罚很重，也无法体现 prefill 与 decode 分离等优化的全部细节，所以 AgentX 提交仍会分别针对交互性和 TTFT 做优化。',
+    measurement: { label: '常用单位', value: 'token/秒/用户（tok/s/user）' },
+  },
+  'tokens-per-dollar': {
+    term: '每美元 token 数',
+    aliases: ['tokens per dollar', 'tok/$', '每 1 美元 token 数'],
+    plainEnglish: '每美元 token 数表示一美元基础设施支出能买到多少 token，数值越大说明系统越便宜。',
+    definition:
+      '每美元 token 数是某个配置在一单位建模成本下产出的 token 数量，即每 token 成本的倒数。',
+    explanation:
+      '它由每芯片吞吐量和建模的每芯片小时成本直接得出，因此与每百万 token 成本共用同一套假设，只是换成了人们规划容量时更习惯的方向。InferenceX 为总 token、输入 token 和输出 token 分别给出该指标，覆盖每种成本口径，并同时提供人民币与美元两种计价。',
+    significance:
+      '每百万 token 成本与每美元 token 数对系统的排序完全一致，但后者随硬件变好而升高，与吞吐量方向相同，因此同一张图里的坐标轴不会中途反向。该数值完全依赖背后的成本模型，脱离所声明的口径就不成立。',
+    benchmarkContext:
+      'InferenceX 推理图表默认的 Y 轴就是每 1 美元可购买的总 token 数。阅读时请对照图表上方的 TCO 行，并只在同一成本口径内比较：自有（超大规模费率）、自有（neocloud 费率）和 3 年租赁对同一颗芯片会给出不同结果。',
+    measurement: { label: '常用单位', value: '每 1 美元 token 数（tok/$）' },
+  },
+  'energy-per-token': {
+    term: '每 token 能耗',
+    aliases: ['energy per token', 'J/token', '每请求能耗'],
+    plainEnglish:
+      '每 token 能耗表示系统产出一个 token 要花多少电，是每 token 成本在电力侧的对应指标。',
+    definition:
+      '每 token 能耗是产出单位 token 所消耗的电能，可以按全量供电口径统计，也可以取加速器实测遥测值。',
+    explanation:
+      '两种口径回答的是不同问题，不能混用。全量供电口径把包含供电与制冷开销在内的设施功耗预算除以实测 token 速率；实测口径来自运行期间的加速器遥测，只覆盖芯片本身。InferenceX 还会给出每次成功请求的实测能耗，以及平均功耗占 TDP 的百分比。',
+    significance:
+      '新建部署的约束往往是电力而不是资本开支，每焦耳产出更多 token 的系统能在同样的用电额度下服务更多需求。TDP 占比则单独反映一套方案究竟把加速器压到了什么程度，这是仅看按 token 归一的数值看不出来的。',
+    benchmarkContext:
+      '比较前请先看清标签：全量供电口径与实测口径之间相差整个设施开销。当底层遥测无效或统计范围不明确时，InferenceX 会屏蔽实测能耗，因此数值缺失意味着该测量不可信，而不是这次运行不耗电。',
+    measurement: { label: '常用单位', value: '焦耳/token（J/tok）' },
+  },
+  'context-parallelism': {
+    term: '上下文并行',
+    aliases: ['context parallelism', 'PCP', 'DCP', '序列并行'],
+    plainEnglish:
+      '上下文并行把一条长提示词拆到多颗芯片上，让它们分担读取提示词和扫描注意力状态的工作。',
+    definition:
+      '上下文并行把 query token 切分到多个加速器上，用于 prefill 的形式称为 PCP，用于 decode 的形式称为 DCP。',
+    explanation:
+      'PCP 让每个 rank 处理一段 query，keys 和 values 以环形方式传递，从而并行化计算受限的 prefill，也避免某个 rank 独自承担整条长提示词。DCP 则切分 KV cache 本身，每个 rank 扫描各自分片，再以 flash-decode 方式合并部分注意力结果；由于 decode 受显存带宽限制，并行读取 KV 可以提高可达 token 速率。',
+    significance:
+      '张量并行会在每个 rank 上复制完整 KV cache，数据并行注意力则把会话绑定在持有其分片的 rank 上，两者在上下文达到几十万 token 时都难以扩展。上下文并行直接针对这一点，而且收益随输入长度增长，而不是随 batch 大小增长。',
+    benchmarkContext:
+      'InferenceX 在数据点 tooltip 和并行标签中与 TP、EP、DP 一起展示 DCP 与 PCP 的并行度。各厂商支持程度并不均衡：在 AgentX 1.0 结果发布时，vLLM 支持矩阵中 AMD 的注意力后端仍标为不支持，因此该技术仍构成 CUDA 实际优势的一部分。',
+  },
+  'kv-cache-offload': {
+    term: 'KV cache offload',
+    aliases: ['KV cache offload', 'CPU offload', 'KV 卸载'],
+    plainEnglish:
+      '把芯片放不下的注意力状态暂存到主机内存，长会话下一轮就能直接恢复，而不必整段重算。',
+    definition:
+      'KV cache offload 把 KV block 从加速器显存移到更慢的存储层（通常是主机 DRAM），并在后续请求复用该前缀时再读回来。',
+    explanation:
+      'offload 通常实现为写穿缓存：写入 HBM 缓存的前缀会同时写入较慢的一层，因此当 offload 池容量大致是 HBM 的 1.5 到 3 倍时效果最好。在 agentic 的上下文长度下，重新载入长前缀远比重算划算；但对短提示词结论相反，传输开销会超过它省下的 prefill。',
+    significance:
+      '长 agentic 会话超出 HBM 中 KV 容量的时间，远早于超出合理的 DRAM 预算，因此 offload 决定了有多少并发对话仍可恢复。它也会转移瓶颈：前缀能够留存之后，store 与 load 路径、传输批量化和索引记账才是值得优化的开销。',
+    benchmarkContext:
+      'InferenceX 会给每个使用了 offload 的数据点加上虚线光环，无论它是否位于 Pareto 前沿；点详情视图还会给出 offload 类型、引擎，以及芯片与 CPU 两侧的缓存命中率。offload 属于允许但可选的优化，因此同一条曲线上可以同时存在启用和未启用的数据点。',
+  },
+  'kv-cache-manager': {
+    term: 'KV cache 管理器',
+    aliases: ['KV cache manager', 'Mooncake', 'LMCache', 'HiCache'],
+    plainEnglish:
+      'KV cache 管理器负责把注意力状态存放在芯片之外，并决定哪些保留、哪些淘汰、什么时候取回。',
+    definition:
+      'KV cache 管理器是位于推理引擎之下的可插拔层，负责跨存储层级保存可复用的 KV block，并管理其放置、淘汰与传输。',
+    explanation:
+      '引擎对外提供 connector 接口，因此 Mooncake Store、LMCache、SGLang HiCache 等管理器可以服务不同运行时。管理器按前缀哈希为 block 建立索引，把它们放在主机 DRAM、本地 NVMe 或远端后端；实际的字节搬运由 Mooncake Transfer Engine、NIXL 等传输引擎完成。同一个引擎内部可以并存多条路径。',
+    significance:
+      '一旦工作负载大量复用前缀，这一层的正确性和记账就和内核速度同等重要。混合注意力模型更难处理：一个模型同时携带形状和生命周期都不同的多个 cache group，而假设单一 block 几何结构的 connector 无法描述它们。',
+    benchmarkContext:
+      'InferenceX 把 KV offload 引擎记录为运行元数据，并在 AgentX 点详情视图中展示。框架标签给出的是组合而不是单个引擎，因此一套方案会显示为 Mooncake ATOMesh 或 MoRI SGLang，而不只是引擎名。',
+  },
+  'kv-aware-routing': {
+    term: 'KV 感知路由',
+    aliases: ['KV-aware routing', '缓存感知路由', '会话亲和性'],
+    plainEnglish: 'KV 感知路由把请求发给已经持有该会话状态的 worker，而不是发给当前最空闲的那个。',
+    definition: 'KV 感知路由依据已缓存前缀状态所在的位置来选择 worker，而不是只看队列深度或负载。',
+    explanation:
+      '不带可复用历史的请求发给谁都行，此时只需考虑负载均衡；但带着数 MB 已缓存前缀的请求不同，把它发给没有该前缀的空闲 worker，就要为整条提示词再付一次代价。因此 router 会跟踪 cache 事件、按会话哈希到固定 worker，并让数据并行 rank 对其持有状态的会话保持粘性。',
+    significance:
+      '在数据并行注意力下，每个 rank 只拥有缓存池的一部分，长会话一旦落到错误的 rank 上就要全部重算，实测命中率会远低于理论上限。仅有亲和性也不够：不加约束的粘性会把负载集中到单个热点 worker，因此缓存均衡也必须进入路由打分。',
+    benchmarkContext:
+      '路由位于引擎之外，因此 InferenceX 把它视为方案的一部分：Dynamo vLLM、llm-d vLLM、Mooncake ATOMesh 这类标签同时标明编排层和运行时。它的开销正比于在线前缀的数量和长度，而不是生成的 token 数，所以在内核变快之后，它可能成为 agentic 流量下的瓶颈。',
+  },
+  tilert: {
+    term: 'TileRT',
+    aliases: ['TileRT engine', 'TileRT 引擎'],
+    plainEnglish:
+      'TileRT 是面向极低延迟单用户生成的推理运行时，它把模型编译成一个常驻程序，而不是许多次内核启动。',
+    definition:
+      'TileRT 是一款推理引擎，通过取消以单个 kernel 作为执行单元的范式，来实现超低延迟服务。',
+    explanation:
+      '常规运行时每个 decode 步骤都要依次派发一串 kernel，而在极小 batch 下，kernel 之间的启动与调度开销会盖过实际算术运算。常驻的 engine kernel 把工作保留在加速器上，这正是交互性坐标轴最右端得以企及的原因。',
+    significance:
+      '前沿曲线的高交互性一端与高吞吐一端是不同的工程问题，为其中一端调优的引擎很少能同时拿下另一端。对延迟敏感的产品来说，能达到每用户每秒数百 token 的方案很有价值，即便它的单芯片总吞吐量并不突出。',
+    benchmarkContext:
+      'InferenceX 将 TileRT 作为独立的框架标签，并在每个 SKU 最佳配置视图中特意保留它；否则只按吞吐量取胜的曲线会丢掉 TileRT 真正服务的那些运行点。比较时请在匹配交互性下进行，而不要只看峰值吞吐量。',
   },
 };
 

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -241,9 +241,15 @@ const entries = [
     significance:
       'Different products need different operating points. Voice and interactive coding demand high token rates, while offline summarization can trade interactivity for much more aggregate throughput. Comparing hardware at unmatched interactivity can therefore produce a misleading winner.',
     benchmarkContext:
-      'InferenceX plots tokens per second per user against throughput or cost. Iso-interactivity tables interpolate each system’s Pareto frontier at the same token rate so the comparison holds user experience constant.',
+      'InferenceX plots tokens per second per user against throughput or cost. Iso-interactivity tables interpolate each system’s Pareto frontier at the same token rate so the comparison holds user experience constant. Because this axis ignores the wait before the first token, agentic charts also offer E2E Normalized Interactivity, which folds TTFT into the same unit.',
     measurement: { label: 'Typical unit', value: 'tokens/second/user (tok/s/user)' },
-    relatedTerms: ['time-per-output-token', 'throughput', 'iso-interactivity', 'latency'],
+    relatedTerms: [
+      'time-per-output-token',
+      'throughput',
+      'iso-interactivity',
+      'e2e-normalized-interactivity',
+      'latency',
+    ],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2, MI355X_KIMI, TILERT],
   },
   {
@@ -352,8 +358,14 @@ const entries = [
     significance:
       'The frontier prevents noisy or poorly tuned points from distorting comparisons and makes the real tradeoff visible. There is still no universal winner along the curve: the best point depends on the user’s minimum interactivity or maximum cost target.',
     benchmarkContext:
-      'InferenceX connects Pareto-optimal points from a concurrency and configuration sweep. Iso-interactivity comparisons interpolate along those frontiers because direct comparisons of arbitrary raw points can mislead.',
-    relatedTerms: ['throughput', 'interactivity', 'iso-interactivity', 'concurrency'],
+      'InferenceX connects Pareto-optimal points from a concurrency and configuration sweep. Iso-interactivity comparisons interpolate along those frontiers because direct comparisons of arbitrary raw points can mislead. Best-per-SKU views now merge the permitted optimizations into one curve per model, chip SKU, and engine, so adjacent points on a single line may differ in speculative decoding, disaggregation, or KV cache offload. Each point still exposes the exact configuration that produced it.',
+    relatedTerms: [
+      'throughput',
+      'interactivity',
+      'iso-interactivity',
+      'kv-cache-offload',
+      'concurrency',
+    ],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2, MI355X_GLM5],
   },
   {
@@ -369,7 +381,7 @@ const entries = [
     significance:
       'Holding user experience constant avoids a common benchmark error: declaring a high-throughput system faster when it reaches that throughput only by serving every request more slowly.',
     benchmarkContext:
-      'InferenceX articles use iso-interactivity tables for hardware, precision, and software comparisons. Values outside a measured frontier are marked unreachable and are not extrapolated beyond observed data.',
+      'InferenceX articles use iso-interactivity tables for hardware, precision, and software comparisons. Values outside a measured frontier are marked unreachable and are not extrapolated beyond observed data. The frontier is always built on throughput against interactivity; cost per million tokens and joules per token are then derived from the interpolated throughput rather than splined on their own, because each is a per-chip constant divided by that throughput and splining it separately would break the identity between knots.',
     relatedTerms: ['interactivity', 'pareto-frontier', 'throughput', 'performance-per-dollar'],
     articleSlugs: [B200_GLM5, B200_MINIMAX, B200_KIMI, GB300_DSV4],
   },
@@ -388,8 +400,8 @@ const entries = [
     significance:
       'Results from different sequence lengths are not interchangeable. A configuration tuned for short chat prompts can rank differently on long-context summarization or reasoning because compute, memory capacity, and bandwidth pressure shift.',
     benchmarkContext:
-      'InferenceX includes ISL and OSL in chart labels and recipe descriptions. Compare systems on the same workload shape before attributing a difference to hardware or software.',
-    relatedTerms: ['prefill', 'decode', 'kv-cache', 'time-to-first-token'],
+      'InferenceX includes ISL and OSL in chart labels and recipe descriptions. Compare systems on the same workload shape before attributing a difference to hardware or software. Agentic runs have no single pair to quote: lengths follow a roughly lognormal distribution, so the point detail view plots the fitted distribution and reports percentiles, and a p90 or p99 input can be several times the median.',
+    relatedTerms: ['prefill', 'decode', 'kv-cache', 'agentx', 'time-to-first-token'],
     articleSlugs: [INFERENCEMAX, B200_GLM5, GB300_DSV4],
   },
   {
@@ -433,9 +445,10 @@ const entries = [
     significance:
       'Peak chip FLOPS account for only part of serving economics. Memory, networking, software maturity, numerical precision, and achievable utilization all affect the measured output behind the ratio.',
     benchmarkContext:
-      'InferenceX compares perf/$ at matched interactivity and names the TCO inputs used. Ratios should not be carried across different model, sequence-length, precision, or latency regimes.',
+      'InferenceX compares perf/$ at matched interactivity and names the TCO inputs used. Ratios should not be carried across different model, sequence-length, precision, or latency regimes. The charts express the same economics as tokens per dollar, which reads in the higher-is-better direction and is the default y-axis.',
     relatedTerms: [
       'cost-per-million-tokens',
+      'tokens-per-dollar',
       'total-cost-of-ownership',
       'iso-interactivity',
       'throughput',
@@ -479,10 +492,11 @@ const entries = [
     significance:
       'Power availability is often the binding constraint on new AI deployments. A system that produces more tokens per provisioned megawatt can serve more demand from the same utility allocation even if its individual accelerators draw more power.',
     benchmarkContext:
-      'Compare tokens/MW at the same model, workload shape, precision, and interactivity. Otherwise a high-throughput low-interactivity point can appear efficient while failing the target user experience.',
+      'Compare tokens/MW at the same model, workload shape, precision, and interactivity. Otherwise a high-throughput low-interactivity point can appear efficient while failing the target user experience. Energy per token expresses the same provisioned budget per unit of output, and InferenceX additionally reports measured accelerator energy where the telemetry is trustworthy.',
     measurement: { label: 'Typical unit', value: 'tokens/second per provisioned utility MW' },
     relatedTerms: [
       'throughput',
+      'energy-per-token',
       'interactivity',
       'total-cost-of-ownership',
       'performance-per-dollar',
@@ -539,11 +553,12 @@ const entries = [
     significance:
       'KV-cache pressure limits concurrency and long-context serving. Cache quantization, paged allocation, latent attention, prefix reuse, and disaggregated transfer systems all target its capacity or movement cost.',
     benchmarkContext:
-      'InferenceX disables prefix caching for random-data comparisons unless a recipe states otherwise. That keeps unrelated requests from receiving artificial cache hits and makes raw serving stacks easier to compare.',
+      'InferenceX disables prefix caching for fixed-sequence comparisons on random data unless a recipe states otherwise, which keeps unrelated requests from receiving artificial cache hits. AgentX is the deliberate exception: its replayed sessions are built to reuse prefixes, so cache capacity, eviction policy, and offload are part of what the scenario measures.',
     relatedTerms: [
       'prefill',
       'decode',
       'prefix-caching',
+      'kv-cache-offload',
       'multi-head-latent-attention',
       'high-bandwidth-memory',
     ],
@@ -563,8 +578,15 @@ const entries = [
     significance:
       'Production workloads with repeated prefixes may outperform synthetic random-token benchmarks. The benefit depends on hit rate, cache capacity, eviction policy, and whether requests route to workers that hold the needed state.',
     benchmarkContext:
-      'InferenceX generally disables prefix caching on random datasets to isolate full prompt processing from cache policy. Treat benchmark cost as a no-hit baseline unless the recipe says otherwise.',
-    relatedTerms: ['kv-cache', 'prefill', 'time-to-first-token', 'nvidia-dynamo'],
+      'InferenceX disables prefix caching on random fixed-sequence datasets to isolate full prompt processing from cache policy, so treat those numbers as a no-hit baseline. AgentX inverts this: hit rate is a reported quantity there, shown per point alongside the offload tier it was served from, because reuse is the defining property of the workload.',
+    relatedTerms: [
+      'kv-cache',
+      'kv-cache-offload',
+      'kv-aware-routing',
+      'prefill',
+      'time-to-first-token',
+      'nvidia-dynamo',
+    ],
     articleSlugs: [AGENTIC_WORKLOADS, INFERENCEX_V2, GB200_KIMI, KIMI_K3, AGENTX_V3],
   },
   {
@@ -600,8 +622,8 @@ const entries = [
     significance:
       'The speedup depends on how many draft tokens are accepted and on the cost of drafting and verification. Dense and MoE models can behave differently because verifying several positions may activate more expert weights.',
     benchmarkContext:
-      'Compare speculative recipes at realistic acceptance rates and verify model quality. InferenceX distinguishes MTP-enabled and disabled curves because the benefit changes across concurrency and interactivity.',
-    relatedTerms: ['multi-token-prediction', 'decode', 'batching', 'mixture-of-experts'],
+      'Fixed-sequence scenarios keep speculative decoding as part of a curve’s identity, so MTP-enabled and disabled recipes plot separately. Agentic curves instead treat it as point-level metadata and merge the points, with the method named in each tooltip, because AgentX reports the best available curve per model, chip SKU, and engine. Since replayed AgentX content is synthetic, a speculator would accept an unrepresentative number of draft tokens, so runs apply an acceptance length collected per model, speculator, draft length, and thinking mode on an external agentic coding dataset.',
+    relatedTerms: ['multi-token-prediction', 'decode', 'batching', 'agentx', 'mixture-of-experts'],
     articleSlugs: [INFERENCEX_V2, DEEPSEEK_V4, B200_GLM5, KIMI_K3, AGENTX_V3],
   },
   {
@@ -1094,6 +1116,166 @@ const entries = [
       'wide-expert-parallelism',
     ],
     articleSlugs: [GB200_R1, GB300_DSV4, GB200_KIMI, INFERENCEX_V2],
+  },
+  {
+    slug: 'e2e-normalized-interactivity',
+    term: 'E2E Normalized Interactivity',
+    aliases: ['normalized interactivity', 'OSL/E2EL'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'This metric asks how fast a whole answer arrives, counting the wait before the first word as well as the streaming speed after it.',
+    definition:
+      'E2E Normalized Interactivity is the effective per-user token rate across a complete request: output tokens divided by end to end latency.',
+    explanation:
+      'Substituting end to end latency for time to first token plus output length times time per output token gives approximately 1 divided by the sum of inter-token latency and TTFT divided by output tokens. The result is ordinary interactivity plus a penalty proportional to first-token wait. Normalized here means normalized by output length, not scaled to a 0 to 1 score or measured against another system.',
+    significance:
+      'Interactivity alone rewards a recipe that streams quickly after making the user wait, and TTFT alone rewards one that starts fast and then crawls. Folding both into one number exposes operating points that look strong on a single axis. Short responses feel the TTFT penalty most, because there are fewer tokens to amortize the wait across.',
+    benchmarkContext:
+      'InferenceX exposes this as an experimental x-axis mode for agentic runs, which is why it needs persisted per-request traces and is unavailable for unofficial-run overlays. It is deliberately imperfect: it penalizes high TTFT heavily and does not capture every nuance of prefill and decode disaggregation, so AgentX submissions still optimize interactivity and TTFT separately.',
+    measurement: { label: 'Typical unit', value: 'tokens/second/user (tok/s/user)' },
+    relatedTerms: ['interactivity', 'time-to-first-token', 'time-per-output-token', 'latency'],
+    articleSlugs: [AGENTX_V3, AGENT_BENCHMARK],
+  },
+  {
+    slug: 'tokens-per-dollar',
+    term: 'Tokens per dollar',
+    abbreviation: 'tok/$',
+    aliases: ['tokens per $1 USD', 'tokens per RMB'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Tokens per dollar asks how many tokens one dollar of infrastructure spend buys, so a bigger number is a cheaper system.',
+    definition:
+      'Tokens per dollar is the count of tokens a configuration produces for one unit of modeled infrastructure cost, the reciprocal of cost per token.',
+    explanation:
+      'The figure follows directly from throughput per chip and the modeled cost per chip hour, so it carries the same assumptions as cost per million tokens while reading in the direction most people reason about capacity. InferenceX publishes it for total, input, and output tokens, against each cost basis it models, and in Chinese yuan alongside US dollars.',
+    significance:
+      'Cost per million tokens and tokens per dollar rank systems identically, but a metric that rises with better hardware sits the same way up as throughput, so a chart mixing the two no longer inverts halfway down the axis. The absolute value depends entirely on the cost model behind it, so it travels only with its stated basis.',
+    benchmarkContext:
+      'Total tokens per $1 USD is the default y-axis on the InferenceX inference charts. Read it against the TCO row shown above the chart, and compare only within one cost basis: owning at hyperscaler rates, owning at neocloud rates, and three year rental produce different numbers for identical silicon.',
+    measurement: { label: 'Typical unit', value: 'tokens per $1 USD (tok/$)' },
+    relatedTerms: [
+      'cost-per-million-tokens',
+      'performance-per-dollar',
+      'total-cost-of-ownership',
+      'throughput',
+    ],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2, B200_GLM5],
+  },
+  {
+    slug: 'energy-per-token',
+    term: 'Energy per token',
+    abbreviation: 'J/token',
+    aliases: ['joules per token', 'joules per query'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Energy per token is how much electricity the system spends to produce one token, the power-side counterpart of cost per token.',
+    definition:
+      'Energy per token is the electrical energy consumed per token produced, reported either from all-in provisioned power or from measured accelerator telemetry.',
+    explanation:
+      'The two bases answer different questions and are not interchangeable. All-in provisioned figures divide a facility power budget, including power delivery and cooling overhead, by measured token rates. Measured figures come from accelerator telemetry during the run and describe the chips alone. InferenceX also reports measured energy per successful query and average power as a percentage of thermal design power.',
+    significance:
+      'Power, not capital, is often the binding constraint on new deployments, and a system that produces more tokens per joule serves more demand from the same utility allocation. The percentage of TDP figure separately reveals how hard a recipe actually drives its accelerators, which a token-normalized number alone hides.',
+    benchmarkContext:
+      'Read the label before comparing: all-in provisioned and measured values differ by the facility overhead between them. InferenceX withholds measured energy where the underlying telemetry is invalid or its scope is ambiguous, so a missing value means the measurement could not be trusted rather than that the run drew no power.',
+    measurement: { label: 'Typical unit', value: 'joules per token (J/tok)' },
+    relatedTerms: ['tokens-per-megawatt', 'throughput', 'total-cost-of-ownership', 'concurrency'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, AGENTX_V3],
+  },
+  {
+    slug: 'context-parallelism',
+    term: 'Context parallelism',
+    abbreviation: 'CP',
+    aliases: ['PCP', 'DCP', 'sequence parallelism'],
+    category: 'Parallelism',
+    plainEnglish:
+      'Context parallelism splits one long prompt across several chips so they share the work of reading it and of scanning its stored attention state.',
+    definition:
+      'Context parallelism shards query tokens across accelerators, in a prefill form known as PCP and a decode form known as DCP.',
+    explanation:
+      'PCP gives each rank a chunk of the query while keys and values are passed around a ring, which parallelizes the compute-bound prefill and stops one rank absorbing an entire long prompt. DCP shards the KV cache itself, so every rank scans its own slice and the partial attention results merge flash-decode style. Because decode is memory-bandwidth bound, parallel KV reads raise the achievable token rate.',
+    significance:
+      'Tensor parallelism replicates the full KV cache on each rank and data-parallel attention pins a session to whichever rank owns its shard, so neither scales cleanly as contexts reach hundreds of thousands of tokens. Context parallelism attacks that directly, and its gain grows with input length rather than with batch size.',
+    benchmarkContext:
+      'InferenceX surfaces DCP and PCP degrees in point tooltips and parallelism labels alongside TP, EP, and DP. Support is uneven across vendors: the technique remains part of the practical CUDA advantage because the AMD attention backends were still listed as unsupported in the vLLM matrix at the time of the AgentX 1.0 results.',
+    relatedTerms: ['tensor-parallelism', 'data-parallelism', 'kv-cache', 'prefill', 'decode'],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2],
+  },
+  {
+    slug: 'kv-cache-offload',
+    term: 'KV cache offload',
+    aliases: ['CPU offload', 'KV offloading'],
+    category: 'Serving',
+    plainEnglish:
+      'KV cache offload parks attention state the chips cannot hold in host memory, so a long session can be resumed instead of recomputed.',
+    definition:
+      'KV cache offload moves KV blocks out of accelerator memory into a slower tier, usually host DRAM, and loads them back when a later request reuses that prefix.',
+    explanation:
+      'Offload is usually a write-through cache: a prefix written to the HBM cache is also written to the slower tier, so it helps most when the offload pool is roughly one and a half to three times HBM capacity. Reloading a long prefix beats recomputing it by a wide margin at agentic context lengths, but the arithmetic reverses for short prompts, where the transfer costs more than the prefill it avoids.',
+    significance:
+      'Long agentic sessions exceed HBM KV capacity well before they exceed a plausible DRAM budget, so offload decides how many concurrent conversations stay resumable. It also shifts the bottleneck: once prefixes survive, store and load paths, transfer batching, and index bookkeeping become the costs worth optimizing.',
+    benchmarkContext:
+      'InferenceX rings every point that used KV offload with a dashed halo, whether or not it is Pareto optimal, and the point detail view names the offload type and engine alongside the chip and CPU cache hit rates. Offload is an allowed but optional optimization, so a single curve can mix points with and without it.',
+    relatedTerms: ['kv-cache', 'prefix-caching', 'kv-cache-manager', 'high-bandwidth-memory'],
+    articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS, KIMI_K3],
+  },
+  {
+    slug: 'kv-cache-manager',
+    term: 'KV cache manager',
+    aliases: ['Mooncake', 'LMCache', 'HiCache'],
+    category: 'Software',
+    plainEnglish:
+      'A KV cache manager is the component that stores attention state outside the chips and decides what to keep, evict, and fetch back.',
+    definition:
+      'A KV cache manager is a pluggable layer beneath an inference engine that stores reusable KV blocks across memory tiers and manages their placement, eviction, and transfer.',
+    explanation:
+      'Engines expose a connector interface, so managers such as Mooncake Store, LMCache, and SGLang HiCache can serve different runtimes. The manager keys blocks by prefix hash and places them in host DRAM, local NVMe, or a remote backend, while a separate transfer engine such as Mooncake Transfer Engine or NIXL performs the byte movement. Several paths can coexist inside one engine.',
+    significance:
+      'Once a workload reuses prefixes heavily, correctness and accounting in this layer matter as much as kernel speed. Hybrid-attention models make it harder still, because a model carrying several cache groups with different shapes and lifetimes cannot be described by a connector that assumes one uniform block geometry.',
+    benchmarkContext:
+      'InferenceX records the KV offload backend as run metadata and shows it in the AgentX point detail view. Framework labels name the combination rather than the engine alone, so a recipe reads as Mooncake ATOMesh or MoRI SGLang instead of just its engine.',
+    relatedTerms: ['kv-cache-offload', 'kv-cache', 'prefix-caching', 'inference-engine'],
+    articleSlugs: [AGENTX_V3, KIMI_K3, INFERENCEX_V2],
+  },
+  {
+    slug: 'kv-aware-routing',
+    term: 'KV-aware routing',
+    aliases: ['cache-aware routing', 'session affinity'],
+    category: 'Serving',
+    plainEnglish:
+      'KV-aware routing sends a request to the worker that already holds its conversation state, instead of to whichever worker is least busy.',
+    definition:
+      'KV-aware routing selects a worker using where cached prefix state already resides, rather than on queue depth or load alone.',
+    explanation:
+      'A request carrying no reusable history can go anywhere, and load balancing is the only question worth asking. A request carrying megabytes of cached prefix is different: sending it to an idle worker that lacks that prefix pays for the whole prompt again. Routers therefore track cache events, hash sessions to consistent workers, and keep data-parallel ranks sticky to the sessions whose state they own.',
+    significance:
+      'Under data-parallel attention each rank owns a private slice of the cache pool, so a long session landing on the wrong rank recomputes everything and the measured hit rate collapses far below its theoretical ceiling. Affinity alone is not enough either, since unchecked stickiness concentrates load on one hot worker, so cache balance has to enter the routing score.',
+    benchmarkContext:
+      'Routing sits outside the engine, so InferenceX treats it as part of the recipe: labels such as Dynamo vLLM, llm-d vLLM, and Mooncake ATOMesh name the orchestration layer as well as the runtime. Its cost scales with the number and length of live prefixes rather than with tokens generated, which is why it can become the bottleneck on agentic traffic once kernels improve.',
+    relatedTerms: [
+      'prefix-caching',
+      'nvidia-dynamo',
+      'data-parallelism',
+      'disaggregated-inference',
+    ],
+    articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'tilert',
+    term: 'TileRT',
+    aliases: ['TileRT engine'],
+    category: 'Software',
+    plainEnglish:
+      'TileRT is an inference runtime built for very fast single-user generation, compiling a model into one resident program instead of many separate kernel launches.',
+    definition:
+      'TileRT is an inference engine that targets ultra-low-latency serving by abolishing the individual kernel as the unit of execution.',
+    explanation:
+      'A conventional runtime dispatches a sequence of kernels for every decode step, and at very small batch sizes the launch and scheduling overhead between them dominates the arithmetic. A persistent engine kernel keeps the work resident on the accelerator instead, which is what makes the far-right end of the interactivity axis reachable at all.',
+    significance:
+      'The high-interactivity corner of the frontier is a different engineering problem from the high-throughput corner, and an engine tuned for one rarely wins the other. Recipes that reach hundreds of tokens per second per user matter for latency-critical products even when their aggregate throughput per chip is unremarkable.',
+    benchmarkContext:
+      'InferenceX reports TileRT as its own framework label and deliberately retains it in best-per-SKU views, because a curve that only survives where it dominates on throughput would drop the operating points TileRT exists to serve. Compare it at matched interactivity rather than on peak throughput alone.',
+    relatedTerms: ['inference-engine', 'interactivity', 'decode', 'sglang'],
+    articleSlugs: [TILERT, AGENTX_V3],
   },
 ] as const satisfies readonly GlossaryEntry[];
 


### PR DESCRIPTION
## Summary

I read the 104 commits merged since 2026-08-11 and pulled out the concepts that became user-visible in that window but had no glossary entry, plus the entries whose text now describes behavior the dashboard no longer has. Both languages updated in the same change.

Glossary is 54 entries → 62.

## New terms (8)

| Term | Category | Why now |
| --- | --- | --- |
| E2E Normalized Interactivity | Benchmark metrics | Shipped as an experimental agentic x-axis with its own FAQ answer and help link (#847, #848) |
| Tokens per dollar | Benchmark metrics | Now the **default y-axis** on the inference charts, with input/output and RMB variants (#770, #787, #793) |
| Energy per token | Benchmark metrics | Query energy and % TDP axes landed, split across all-in provisioned vs measured telemetry (#734, #735) |
| Context parallelism (PCP / DCP) | Parallelism | DCP and PCP degrees are surfaced in point tooltips and parallelism labels (#745) |
| KV cache offload | Serving | Offload halo on the chart, offload type/engine and hit rates in the point detail view (#729, #818, #760) |
| KV cache manager | Software | `kv_offload_backend` is recorded run metadata; Mooncake / LMCache / HiCache sit under the engines |
| KV-aware routing | Serving | Router layer is part of the recipe label (Dynamo, llm-d, Mooncake ATOMesh) and is the AgentX bottleneck story |
| TileRT | Software | A first-class framework label, deliberately retained in best-per-SKU views (#843) |

Each entry follows the existing shape: plain-English gloss, definition, mechanism, why it matters, and an InferenceX-specific `benchmarkContext` that says how to read it on this dashboard rather than restating the definition.

## Refreshed definitions (9)

Corrections, not cosmetic edits:

- **`speculative-decoding`** said InferenceX "distinguishes MTP-enabled and disabled curves". Since #695 that is only true for fixed-sequence scenarios; agentic curves treat spec decode as point-level metadata and merge the points. Also records the fixed acceptance-length methodology, which exists because replayed AgentX content is synthetic.
- **`kv-cache`** and **`prefix-caching`** both said prefix caching is disabled on random data. Still true for fixed-sequence, but AgentX is the deliberate exception: reuse is the property being measured, and hit rate is a reported per-point quantity.
- **`iso-interactivity`** now records the rule from #726 — the frontier is built on throughput vs interactivity, and $/M tok and J/token are derived from the interpolated throughput rather than splined separately, because splining a per-chip constant over throughput breaks the identity between knots.
- **`pareto-frontier`** now explains that best-per-SKU views merge permitted optimizations into one curve per model/SKU/engine, so adjacent points on a line can differ in spec decode, disaggregation, or offload.
- **`input-output-sequence-length`** now covers agentic runs, where there is no single ISL/OSL pair to quote and the point view plots a fitted lognormal with percentiles (#810, #811).
- **`interactivity`**, **`performance-per-dollar`**, **`tokens-per-megawatt`** cross-link to the new metrics that supersede or complement them on the current axes.

## Notes for reviewers

- No new files or routes. The glossary index, per-slug pages, and sitemap all derive from `getAllGlossaryEntries()` / `getAllZhGlossaryEntries()`, so `/glossary/*` and `/zh/glossary/*` pick up all eight terms automatically in both languages.
- `articleSlugs` on the new entries point only at posts that actually discuss the term; most cite the AgentX v3 port, which is where these concepts are documented at length.
- Not done here, deliberately: the FAQ entry for E2E Normalized Interactivity (#848) and the AgentX telemetry tutorial could both link their new glossary pages. That is a cross-linking change to other surfaces and belongs in its own PR.

## Verification

- `bun run test:unit` — 4,772 tests pass. The relevant guards: `glossary.test.ts` (unique slugs, 8–40 word plain-English gloss, ≥90 word body, ≥3 resolvable related terms, ≥1 real article, no em/en dashes, complete zh translation with a Han-character floor and distinct `measurement` labels) and `zh-copy.test.ts` (mechanical Chinese rules, including the untranslated-`chip` and duplicated-loanword checks).
- `bun run lint`, `bun run fmt`, `bun run typecheck` clean.

## 中文说明

我梳理了 2026-08-11 以来合入的 104 个提交，挑出这段时间内新出现在用户界面、但术语表尚未收录的概念，以及释义已经与仪表板当前行为不符的条目，中英文在同一 PR 中同步更新。术语表条目从 54 条增加到 62 条。

### 新增术语（8 条）

| 术语 | 分类 | 新增理由 |
| --- | --- | --- |
| 端到端归一化交互性 | 基准指标 | 已作为 agentic 场景的实验性 X 轴上线，并配有 FAQ 说明与直达链接（#847、#848） |
| 每美元 token 数 | 基准指标 | 已成为推理图表的**默认 Y 轴**，并提供输入/输出与人民币口径（#770、#787、#793） |
| 每 token 能耗 | 基准指标 | 新增每请求能耗与 TDP 占比坐标轴，并区分全量供电口径与实测遥测（#734、#735） |
| 上下文并行（PCP / DCP） | 并行策略 | DCP 与 PCP 并行度已在数据点 tooltip 和并行标签中展示（#745） |
| KV cache offload | 推理服务 | 图表上的 offload 光环，以及点详情中的 offload 类型、引擎与命中率（#729、#818、#760） |
| KV cache 管理器 | 软件栈 | `kv_offload_backend` 已作为运行元数据记录；Mooncake / LMCache / HiCache 位于引擎之下 |
| KV 感知路由 | 推理服务 | 路由层是方案标签的一部分（Dynamo、llm-d、Mooncake ATOMesh），也是 AgentX 的瓶颈所在 |
| TileRT | 软件栈 | 已是独立的框架标签，并在每个 SKU 最佳配置视图中特意保留（#843） |

每条新增条目都沿用既有结构：通俗解释、定义、机制、意义，以及说明在本仪表板上如何解读的 `benchmarkContext`，而不是重复定义。

### 更新释义（9 条）

这些是纠错而非文字润色：

- **`speculative-decoding`** 原文称 InferenceX「区分开启和关闭 MTP 的曲线」。自 #695 起这只对定长场景成立，agentic 曲线已把投机解码作为数据点级元数据并合并这些点。同时补充了固定接受长度的方法说明——之所以需要它，是因为 AgentX 回放内容是合成的。
- **`kv-cache`** 与 **`prefix-caching`** 原本都称在随机数据上禁用前缀缓存。这对定长场景仍然成立，但 AgentX 是有意为之的例外：复用正是被测量的性质，命中率是逐点上报的指标。
- **`iso-interactivity`** 补充了 #726 的规则：前沿建立在吞吐量与交互性之上，每百万 token 成本和每 token 焦耳由插值吞吐量推导，而不是各自单独做样条，否则会破坏「每芯片常数除以吞吐量」这一恒等关系。
- **`pareto-frontier`** 说明每个 SKU 最佳配置视图会把允许的优化合并成一条曲线，因此同一条线上相邻的点可能在投机解码、分离式部署或 offload 上不同。
- **`input-output-sequence-length`** 补充了 agentic 运行的情况：没有单一 ISL/OSL 取值可引用，点详情视图会绘制拟合的对数正态分布并给出分位数（#810、#811）。
- **`interactivity`**、**`performance-per-dollar`**、**`tokens-per-megawatt`** 增加了与新指标的交叉链接。

### 评审提示

- 不新增文件或路由。术语表索引页、单条目页和 sitemap 均由 `getAllGlossaryEntries()` / `getAllZhGlossaryEntries()` 派生，因此 `/glossary/*` 与 `/zh/glossary/*` 会自动收录全部八条术语。
- 新增条目的 `articleSlugs` 只指向确实讨论该术语的文章，多数引用 AgentX v3 移植文，因为这些概念在那里有充分说明。
- 有意未做：#848 的 FAQ 条目和 AgentX 遥测教程都可以链接到新的术语页，但那属于其他界面的交叉链接改动，应当单独提 PR。

### 验证

- `bun run test:unit` — 4,772 项测试通过。相关守卫：`glossary.test.ts`（slug 唯一性、通俗解释 8–40 词、正文 ≥90 词、≥3 个可解析的相关术语、≥1 篇真实文章、禁用长破折号、中文翻译完整且汉字数量达标、`measurement` 标签需与英文不同）与 `zh-copy.test.ts`（机械性中文规则，包括未翻译的 `chip` 和重复借词检查）。
- `bun run lint`、`bun run fmt`、`bun run typecheck` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to glossary data in two lib files; no runtime logic, auth, or API behavior changes.
> 
> **Overview**
> Expands the InferenceX glossary from **54 to 62 entries** by adding eight AgentX-era concepts in **`glossary.ts`** with matching **`glossary-zh.ts`** translations. New terms cover dashboard-visible metrics and serving features: **E2E Normalized Interactivity**, **tokens per dollar** (default chart Y-axis), **energy per token**, **context parallelism (PCP/DCP)**, **KV cache offload**, **KV cache manager**, **KV-aware routing**, and **TileRT**.
> 
> **Nine existing entries** get corrected **`benchmarkContext`** (not cosmetic copy): fixed-sequence vs **AgentX** behavior for prefix caching and speculative decoding; **iso-interactivity** derivation of cost/energy from interpolated throughput; **Pareto** best-per-SKU merged curves; agentic **ISL/OSL** distributions; and cross-links from **interactivity**, **perf/$**, and **tokens/MW** to the new metrics. **`relatedTerms`** are updated so glossary navigation stays consistent.
> 
> No new routes or files—`/glossary/*` and `/zh/glossary/*` pick up slugs from **`getAllGlossaryEntries()`** / **`getAllZhGlossaryEntries()`** automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d5c6ce0a3cc6518fa3c975907cac9df6860704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->