### PR TITLE
feat(chart): show only selected chips in TCO $/chip/hr caption badges

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -522,6 +522,13 @@ export default function ChartDisplay() {
     () => new Set([...activeOverlayHwTypes].filter((key) => overlayScope.has(key))),
     [activeOverlayHwTypes, overlayScope],
   );
+  // Caption spec badges (TCO $/chip/hr, Power/Chip) should only quote chips
+  // that can actually appear on the plot: the active official legend selection
+  // plus any active unofficial-overlay selection.
+  const captionHwKeys = useMemo(
+    () => new Set([...selectedOfficialHwTypes, ...scopedActiveOverlayHwTypes]),
+    [selectedOfficialHwTypes, scopedActiveOverlayHwTypes],
+  );
   const overlayScopeRegistration = useMemo(
     () =>
       isUnofficialRun
@@ -918,7 +925,10 @@ export default function ChartDisplay() {
                               {formatTokenLength(residentSequenceLengths.osl.p99)}
                             </p>
                           )}
-                          <MetricAssumptionNotes selectedYAxisMetric={selectedYAxisMetric} />
+                          <MetricAssumptionNotes
+                            selectedYAxisMetric={selectedYAxisMetric}
+                            activeHwKeys={captionHwKeys}
+                          />
                           {isUnofficialRun &&
                             selectedXAxisMode === 'e2e-normalized-interactivity' && (
                               <p className="mb-2 text-xs text-muted-foreground">

--- a/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
+++ b/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
@@ -330,6 +330,7 @@ export default function HistoricalTrendsDisplay() {
                     </p>
                     <MetricAssumptionNotes
                       selectedYAxisMetric={selectedYAxisMetric}
+                      activeHwKeys={activeHwTypes}
                       includeAllPowerThroughputMetrics={false}
                       includePowerThroughputCaveat={false}
                     />

--- a/packages/app/src/components/ui/chart-display-helpers.test.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.test.tsx
@@ -150,6 +150,49 @@ describe('MetricAssumptionNotes', () => {
     );
   });
 
+  it('narrows the TCO badges to the base GPUs of the active legend selection', () => {
+    renderUi(
+      <MetricAssumptionNotes
+        selectedYAxisMetric="y_tokensPerDollarH"
+        activeHwKeys={['h200_dynamo-sglang', 'gb300_dynamo-sglang']}
+      />,
+    );
+
+    expect(getVisibleText()).toContain('TCO $/chip/hr:');
+    expect(getVisibleText()).toContain('H200:');
+    expect(getVisibleText()).toContain('GB300:');
+    expect(getVisibleText()).not.toContain('H100:');
+    expect(getVisibleText()).not.toContain('MI300X:');
+  });
+
+  it('narrows the power badges to the active legend selection', () => {
+    renderUi(
+      <MetricAssumptionNotes selectedYAxisMetric="y_tpPerMw" activeHwKeys={new Set(['mi300x'])} />,
+    );
+
+    expect(getVisibleText()).toContain('All in Power/Chip:');
+    expect(getVisibleText()).toContain('MI300X:');
+    expect(getVisibleText()).not.toContain('H100:');
+    expect(getVisibleText()).not.toContain('H200:');
+  });
+
+  it('falls back to every registry GPU when the selection is empty or unrecognized', () => {
+    renderUi(<MetricAssumptionNotes selectedYAxisMetric="y_tokensPerDollarH" activeHwKeys={[]} />);
+
+    expect(getVisibleText()).toContain('H100:');
+    expect(getVisibleText()).toContain('MI300X:');
+
+    renderUi(
+      <MetricAssumptionNotes
+        selectedYAxisMetric="y_tokensPerDollarH"
+        activeHwKeys={['not-a-gpu_dynamo-sglang']}
+      />,
+    );
+
+    expect(getVisibleText()).toContain('H100:');
+    expect(getVisibleText()).toContain('MI300X:');
+  });
+
   it('renders metric-specific throughput caveats and preserves Joules wording semantics', () => {
     renderUi(<MetricAssumptionNotes selectedYAxisMetric="y_inputTputPerGpu" />);
 

--- a/packages/app/src/components/ui/chart-display-helpers.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 
 import {
   HW_REGISTRY,
@@ -188,16 +188,43 @@ export function ChartShareActions() {
 
 export function MetricAssumptionNotes({
   selectedYAxisMetric,
+  activeHwKeys,
   includeAllPowerThroughputMetrics = true,
   includePowerThroughputCaveat = true,
 }: {
   selectedYAxisMetric: string;
+  /**
+   * Active legend hardware keys (e.g. `gb300_dynamo-sglang`). When provided,
+   * the TCO $/chip/hr and Power/Chip badges are narrowed to the base GPUs the
+   * selection covers, so the caption only quotes chips that can appear on the
+   * plot. Omitted (or when the selection maps to no registry GPU) every
+   * registry GPU is shown, preserving the historical behavior.
+   */
+  activeHwKeys?: ReadonlySet<string> | readonly string[];
   // Historical trends only annotates y_tpPerMw and intentionally omits per-MW caveats to preserve
   // the tab's existing caption contract while sharing the same helper as inference.
   includeAllPowerThroughputMetrics?: boolean;
   includePowerThroughputCaveat?: boolean;
 }) {
   const locale = useLocale();
+  // Legend keys are `{base}` or `{base}_{framework/variant}`; badge maps are
+  // keyed by registry base, so reduce the selection to its base GPUs.
+  const activeBases = useMemo(() => {
+    const bases = new Set<string>();
+    for (const key of activeHwKeys ?? []) {
+      const base = key.split('_')[0];
+      if (base in HW_REGISTRY) bases.add(base);
+    }
+    return bases;
+  }, [activeHwKeys]);
+  const filterToActive = (values: Record<string, string | number>) => {
+    if (activeBases.size === 0) return values;
+    const filtered = Object.fromEntries(
+      Object.entries(values).filter(([base]) => activeBases.has(base)),
+    );
+    // Defensive: never render a badge row with an empty value list.
+    return Object.keys(filtered).length > 0 ? filtered : values;
+  };
   const showPowerSource = includeAllPowerThroughputMetrics
     ? POWER_SOURCE_METRICS.has(selectedYAxisMetric)
     : selectedYAxisMetric === 'y_tpPerMw';
@@ -231,7 +258,7 @@ export function MetricAssumptionNotes({
     <>
       {showPowerSource && (
         <>
-          <MetricBadges label={powerLabel} values={POWER_VALUES} />
+          <MetricBadges label={powerLabel} values={filterToActive(POWER_VALUES)} />
           <SourceLink
             href="https://semianalysis.com/datacenter-industry-model/"
             sourceLabel={sourceLabel}
@@ -242,7 +269,7 @@ export function MetricAssumptionNotes({
       )}
       {costValues && (
         <>
-          <MetricBadges label={costLabel} values={costValues} />
+          <MetricBadges label={costLabel} values={filterToActive(costValues)} />
           <SourceLink href={TCO_SOURCE_URL} sourceLabel={sourceLabel}>
             {TCO_SOURCE_TITLE}
           </SourceLink>
@@ -279,7 +306,7 @@ export function MetricAssumptionNotes({
       )}
       {showJouleSource && (
         <>
-          <MetricBadges label={powerLabel} values={POWER_VALUES} />
+          <MetricBadges label={powerLabel} values={filterToActive(POWER_VALUES)} />
           <SourceLink
             href="https://semianalysis.com/datacenter-industry-model/"
             sourceLabel={sourceLabel}


### PR DESCRIPTION
## Summary

The chart caption's `TCO $/chip/hr:` (and `All in Power/Chip:`) badge rows always rendered every GPU in `HW_REGISTRY`, even when the legend selection was narrowed to a couple of chips. If you select just H200 and GB300, the caption still quoted H100, B200, B300, GB200, MI300X, MI325X, MI355X, and RTX6000PRO pricing for chips that can't appear on the plot.

`MetricAssumptionNotes` now accepts an optional `activeHwKeys` prop (the legend's active hardware keys, e.g. `gb300_dynamo-sglang`), reduces it to registry base GPUs, and narrows the badge rows to that set.

## Changes

- **`chart-display-helpers.tsx`** — new optional `activeHwKeys` prop on `MetricAssumptionNotes`; badge maps (`TCO $/chip/hr`, both `All in Power/Chip` rows) are filtered to the selection's base GPUs. Falls back to the full registry when the prop is omitted, the selection is empty, or no key maps to a known base — so nothing renders an empty badge row and existing call sites are unaffected.
- **`ChartDisplay.tsx`** — passes the union of the active official legend selection and the active unofficial-overlay selection, so overlay chips stay covered while overlays are on.
- **`HistoricalTrendsDisplay.tsx`** — passes `activeHwTypes` for the same behavior on the trends tab.

## Behavior

| Legend selection | Caption badges |
|---|---|
| H200 (Dynamo SGLang) + GB300 NVL72 (Dynamo SGLang) | `H200: 1.22 · GB300: 2.31` only |
| All chips (default) | unchanged — full registry |
| Empty / unrecognized selection | unchanged — full registry (defensive fallback) |

## Testing

- `bun run typecheck` ✅
- `bun run lint` / `bun run fmt` ✅
- `vitest run` on `src/components/ui`, `src/components/trends`, `src/components/inference` — 776 tests pass, including 3 new tests covering narrowing (TCO + power rows) and the full-registry fallback ✅

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only caption filtering with defensive fallback to prior behavior when selection is empty; no changes to metrics, auth, or data handling.
> 
> **Overview**
> Chart captions no longer list **TCO $/chip/hr** and **All in Power/Chip** assumptions for every GPU in the registry when the legend is narrowed—badge rows now follow the chips that can actually appear on the plot.
> 
> `MetricAssumptionNotes` gains an optional `activeHwKeys` prop. Legend keys are reduced to registry base GPUs (e.g. `h200_dynamo-sglang` → `h200`), and power/TCO badge maps are filtered to that set. Empty or unrecognized selections still show the full registry so captions never go blank.
> 
> **Inference** passes the union of the active official legend and active unofficial overlay (`captionHwKeys`). **Historical trends** passes `activeHwTypes`. Three unit tests cover TCO narrowing, power narrowing, and the full-registry fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ece029026b026ebe39476b943149730d86b09e72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->