### PR TITLE
feat(inference): draggable curve-to-curve iso-x perf ruler for the latency scatter chart / 为延迟散点图新增可拖动的曲线对曲线等横坐标性能标尺

### DIFF
--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1384,17 +1384,45 @@ const ScatterGraph = React.memo(
       | null
     >(null);
 
+    // Completion clamp for nextPerfRulerState: the stored iso-x must lie
+    // inside the curve pair's overlapping x range, or the completed ruler
+    // could render nowhere — no line and no drag handle to recover it.
+    // Data → pixel through the exact scales/paths the chart is currently
+    // drawn with, clamp, and back. Null (missing paths or disjoint spans)
+    // rejects the measurement and keeps the draft anchored.
+    const clampPerfRulerIsoXToOverlap = useCallback(
+      (curveA: string, curveB: string, isoX: number): number | null => {
+        const ctx = perfRulerDrawCtxRef.current;
+        if (!ctx) return null;
+        const [nodeA, nodeB] = [curveA, curveB].map((cls) =>
+          ctx.zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node(),
+        );
+        if (!nodeA || !nodeB || typeof nodeA.getPointAtLength !== 'function') return null;
+        const extentA = pathXExtent(nodeA);
+        const extentB = pathXExtent(nodeB);
+        if (!extentA || !extentB) return null;
+        const clamped = clampIsoX(Number(ctx.xScale(isoX)), extentA, extentB);
+        return clamped === null ? null : Number(ctx.xScale.invert(clamped));
+      },
+      [],
+    );
+
     // Curve click (widened hit strokes): iso-x is the click's x pixel
     // through the CURRENT rendered x scale, stored in data space.
-    const handlePerfRulerCurveClick = useCallback((curve: string, pixelX: number) => {
-      const ctx = perfRulerDrawCtxRef.current;
-      if (!ctx) return;
-      track('latency_perf_ruler_curve_clicked', { curve });
-      const isoX = Number(ctx.xScale.invert(pixelX));
-      setPerfRulerState((prev) => nextPerfRulerState(prev, { curve, isoX }));
-      chartRef.current?.dismissTooltip();
-      chartRef.current?.hideTooltip();
-    }, []);
+    const handlePerfRulerCurveClick = useCallback(
+      (curve: string, pixelX: number) => {
+        const ctx = perfRulerDrawCtxRef.current;
+        if (!ctx) return;
+        track('latency_perf_ruler_curve_clicked', { curve });
+        const isoX = Number(ctx.xScale.invert(pixelX));
+        setPerfRulerState((prev) =>
+          nextPerfRulerState(prev, { curve, isoX }, clampPerfRulerIsoXToOverlap),
+        );
+        chartRef.current?.dismissTooltip();
+        chartRef.current?.hideTooltip();
+      },
+      [clampPerfRulerIsoXToOverlap],
+    );
     const perfRulerCurveClickRef = useRef(handlePerfRulerCurveClick);
     perfRulerCurveClickRef.current = handlePerfRulerCurveClick;
 
@@ -1420,11 +1448,13 @@ const ScatterGraph = React.memo(
         );
         // Single-point series render no roofline path — nothing to measure.
         if (!curve) return;
-        setPerfRulerState((prev) => nextPerfRulerState(prev, { curve, isoX: point.x }));
+        setPerfRulerState((prev) =>
+          nextPerfRulerState(prev, { curve, isoX: point.x }, clampPerfRulerIsoXToOverlap),
+        );
         chartRef.current?.dismissTooltip();
         chartRef.current?.hideTooltip();
       },
-      [runIndexByUrl],
+      [runIndexByUrl, clampPerfRulerIsoXToOverlap],
     );
 
     // Read by long-lived D3 click closures (official tooltip config + overlay

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -56,6 +56,7 @@ import type {
 } from '@/lib/d3-chart/D3Chart/types';
 import type { ContinuousScale } from '@/lib/d3-chart/types';
 import { computeTooltipPosition, syncPointShape } from '@/lib/d3-chart/layers/scatter-points';
+import { computePerfRulerGeometry, renderPerfRuler } from '@/lib/d3-chart/layers/perf-ruler';
 import {
   attachOverlayXMarkerHandlers,
   overlayMarkerPosition,
@@ -340,6 +341,8 @@ const SCATTER_STRINGS = {
     concurrencyLabels: '# Concurrent Sessions',
     gradientLabels: 'Gradient Labels',
     lineLabels: 'Line Labels',
+    perfRuler: 'Perf Ruler',
+    perfRulerInfo: 'Click two points to measure the performance multiple between them.',
     resetFilter: 'Reset filter',
     quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
     overflowMixed: (count: number) => `${pointCountEn(count)} clipped`,
@@ -356,6 +359,8 @@ const SCATTER_STRINGS = {
     concurrencyLabels: '并发会话数',
     gradientLabels: '渐变标签',
     lineLabels: '曲线标签',
+    perfRuler: '性能标尺',
+    perfRulerInfo: '点击两个数据点，测量二者之间的性能倍数。',
     resetFilter: '重置筛选',
     quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
     overflowMixed: (count: number) => `${count} 个点已截断`,
@@ -1305,6 +1310,123 @@ const ScatterGraph = React.memo(
       logAvailability: persistedLogAvailability,
     };
 
+    // --- Perf ruler (opt-in: click two points, measure the y-value multiple) ---
+    // Selection stores stable point keys (not indices) so the measurement
+    // survives metric/display re-renders where the points still exist. Keys
+    // distinguish official points from unofficial overlay points, mirroring
+    // the dataIdentity convention.
+    const [perfRulerMode, setPerfRulerMode] = useState(false);
+    const [perfRulerSelection, setPerfRulerSelection] = useState<string[]>([]);
+
+    const perfRulerKey = useCallback(
+      (point: InferenceData, source: 'official' | 'overlay') =>
+        source === 'official'
+          ? `official:${buildPointId(point)}`
+          : `overlay:${buildPointId(point)}:${point.run_url ?? ''}`,
+      [buildPointId],
+    );
+
+    // Resolve each selected key to its current point object (raw x/y follow
+    // the active metric). A key resolves to null when its point disappeared
+    // or is hidden by filters — the prune effect below then drops it.
+    const perfRulerResolvedPoints = useMemo(() => {
+      if (perfRulerSelection.length === 0) return [] as (InferenceData | null)[];
+      const resolve = (key: string): InferenceData | null => {
+        if (key.startsWith('official:')) {
+          return (
+            pointsData.find((p) => perfRulerKey(p, 'official') === key && isPointVisible(p)) ?? null
+          );
+        }
+        return (
+          processedOverlayData.find(
+            (p) => perfRulerKey(p, 'overlay') === key && isOverlayPointVisible(p),
+          ) ?? null
+        );
+      };
+      return perfRulerSelection.map(resolve);
+    }, [
+      perfRulerSelection,
+      pointsData,
+      processedOverlayData,
+      perfRulerKey,
+      isPointVisible,
+      isOverlayPointVisible,
+    ]);
+
+    const perfRulerMeasuredPair = useMemo(() => {
+      if (perfRulerSelection.length !== 2) return null;
+      const [a, b] = perfRulerResolvedPoints;
+      return a && b ? ([a, b] as const) : null;
+    }, [perfRulerSelection, perfRulerResolvedPoints]);
+    const perfRulerPairRef = useRef(perfRulerMeasuredPair);
+    perfRulerPairRef.current = perfRulerMeasuredPair;
+
+    // Clear the measurement when the toggle turns off; drop any selected
+    // point that disappeared (data/filter change) while keeping the other.
+    useEffect(() => {
+      if (!perfRulerMode) {
+        setPerfRulerSelection((prev) => (prev.length > 0 ? [] : prev));
+        return;
+      }
+      const kept = perfRulerSelection.filter((_, i) => perfRulerResolvedPoints[i] !== null);
+      if (kept.length !== perfRulerSelection.length) setPerfRulerSelection(kept);
+    }, [perfRulerMode, perfRulerSelection, perfRulerResolvedPoints]);
+
+    // Selection toggling: first click selects, second click on another point
+    // completes the measurement, a third click starts a new measurement from
+    // that point, re-clicking a selected point deselects it. Ruler-mode
+    // clicks measure INSTEAD of pinning the tooltip, so drop the pin the
+    // shared click handler applied just before this callback ran.
+    const handlePerfRulerPointClick = useCallback((key: string) => {
+      setPerfRulerSelection((prev) => {
+        if (prev.includes(key)) return prev.filter((k) => k !== key);
+        if (prev.length >= 2) return [key];
+        return [...prev, key];
+      });
+      chartRef.current?.dismissTooltip();
+      chartRef.current?.hideTooltip();
+    }, []);
+
+    // Read by long-lived D3 click closures (official tooltip config + overlay
+    // marker handlers) — same refs-over-closures rule as interactionRef.
+    const perfRulerRef = useRef({
+      mode: perfRulerMode,
+      onPointClick: handlePerfRulerPointClick,
+      keyFor: perfRulerKey,
+    });
+    perfRulerRef.current = {
+      mode: perfRulerMode,
+      onPointClick: handlePerfRulerPointClick,
+      keyFor: perfRulerKey,
+    };
+
+    // Draw (or clear) the ruler from the currently resolved pair. Stable
+    // callback so the custom layer can live outside the perf-ruler state
+    // dependencies — render/zoom passes read the pair through the ref.
+    const drawPerfRuler = useCallback(
+      (
+        zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+        xScale: ContinuousScale,
+        yScale: ContinuousScale,
+        width: number,
+      ) => {
+        const pair = perfRulerPairRef.current;
+        const geometry = pair
+          ? computePerfRulerGeometry(
+              { px: xScale(pair[0].x), py: yScale(pair[0].y), rawY: pair[0].y },
+              { px: xScale(pair[1].x), py: yScale(pair[1].y), rawY: pair[1].y },
+            )
+          : null;
+        renderPerfRuler(zoomGroup, geometry, {
+          color: 'var(--primary)',
+          labelBg: 'var(--primary)',
+          labelText: 'var(--primary-foreground)',
+          chartWidth: width,
+        });
+      },
+      [],
+    );
+
     // Render context from the last D3 render — lets the decoration effect
     // restyle with the same layout/scales the chart was drawn with.
     const lastRenderCtxRef = useRef<RenderContext | null>(null);
@@ -1468,6 +1590,20 @@ const ScatterGraph = React.memo(
             getShapeKeyForPrecision(d.precision, interactionRef.current.selectedPrecisions),
           ),
         onPointClick: (d: InferenceData) => {
+          // Perf ruler mode: the click selects a measurement endpoint INSTEAD
+          // of pinning the tooltip (the handler drops the pin applied by the
+          // shared click path; the hover tooltip stays available).
+          const ruler = perfRulerRef.current;
+          if (ruler.mode) {
+            track('latency_data_point_clicked', {
+              hw: String(d.hwKey),
+              x: d.x,
+              y: d.y,
+              perfRuler: true,
+            });
+            ruler.onPointClick(ruler.keyFor(d, 'official'));
+            return;
+          }
           track('latency_data_point_clicked', { hw: String(d.hwKey), x: d.x, y: d.y });
           const tooltipEl = chartRef.current?.getTooltipElement();
           if (!tooltipEl) return;
@@ -2276,6 +2412,21 @@ const ScatterGraph = React.memo(
                   hide: () => zoomGroup.select('.ruler-group').style('display', 'none'),
                 },
                 onClick: (point) => {
+                  // Overlay points participate in the perf ruler too — a
+                  // ruler-mode click selects the point instead of keeping the
+                  // pinned tooltip (see AGENTS.md "Unofficial Run Support").
+                  const ruler = perfRulerRef.current;
+                  if (ruler.mode) {
+                    track('latency_data_point_clicked', {
+                      hw: String(point.hwKey),
+                      x: point.x,
+                      y: point.y,
+                      overlay: true,
+                      perfRuler: true,
+                    });
+                    ruler.onPointClick(ruler.keyFor(point, 'overlay'));
+                    return;
+                  }
                   track('latency_data_point_clicked', {
                     hw: String(point.hwKey),
                     x: point.x,
@@ -2489,9 +2640,35 @@ const ScatterGraph = React.memo(
         };
       });
 
+      // ── Perf ruler (opt-in measurement between two selected points) ──
+      // Selection state is read through perfRulerPairRef, so this layer needs
+      // no perf-ruler dependencies: full re-renders redraw it after the data
+      // phase (it survives metric/display re-renders where the points still
+      // exist), and onZoom keeps it glued to the points during pan/zoom. It
+      // lives inside the zoomGroup, so it is clipped and PNG-exported like
+      // any other mark.
+      const perfRulerLayer: CustomLayerConfig = {
+        type: 'custom',
+        key: 'perf-ruler',
+        render: (zoomGroup, ctx) =>
+          drawPerfRuler(
+            zoomGroup,
+            (ctx.renderedXScale ?? ctx.xScale) as ContinuousScale,
+            (ctx.renderedYScale ?? ctx.yScale) as ContinuousScale,
+            ctx.width,
+          ),
+        onZoom: (zoomGroup, ctx) =>
+          drawPerfRuler(
+            zoomGroup,
+            ctx.newXScale as ContinuousScale,
+            ctx.newYScale as ContinuousScale,
+            ctx.width,
+          ),
+      };
+
       const result: LayerConfig<InferenceData>[] = [rooflineLayer, scatterLayer];
       if (overlayLayer) result.push(overlayLayer);
-      result.push(overflowContinuationLayer, knownIssueLayer);
+      result.push(overflowContinuationLayer, perfRulerLayer, knownIssueLayer);
       return result;
       // Interaction state (visibility, colors, precision shapes, known-issue
       // annotations) is deliberately NOT a dependency: layer closures read it
@@ -2524,6 +2701,7 @@ const ScatterGraph = React.memo(
       selectedYAxisMetric,
       chartDefinition,
       locale,
+      drawPerfRuler,
     ]);
 
     // Layers handle for the decoration effect — lets it re-run individual
@@ -2779,6 +2957,60 @@ const ScatterGraph = React.memo(
         );
       }
     }, [getDisplaySelection, knownIssueAnnotations, getCssColor, resolveColor]);
+
+    // Perf-ruler decorations: stamp a selection ring on the chosen point(s)
+    // and redraw the ruler line whenever the selection or underlying data
+    // changes. Narrow mutation scope — only ring circles and the ruler group
+    // are touched; the chart itself never rebuilds for a ruler click.
+    useLayoutEffect(() => {
+      const display = getDisplaySelection();
+      if (!display) return;
+      const { svg, ctx, zoomGroup } = display;
+      const selected = new Set(perfRulerSelection);
+
+      const syncRing = (node: SVGGElement, key: string) => {
+        const group = d3.select(node);
+        const isSelected = perfRulerMode && selected.has(key);
+        const ring = group.select<SVGCircleElement>('.perf-ruler-ring');
+        if (isSelected && ring.empty()) {
+          group
+            .append('circle')
+            .attr('class', 'perf-ruler-ring')
+            .attr('r', 9)
+            .attr('fill', 'none')
+            .attr('stroke', 'var(--primary)')
+            .attr('stroke-width', 2)
+            .attr('pointer-events', 'none');
+        } else if (!isSelected && !ring.empty()) {
+          ring.remove();
+        }
+      };
+
+      zoomGroup.selectAll<SVGGElement, InferenceData>('.dot-group').each(function (d) {
+        syncRing(this, perfRulerKey(d, 'official'));
+      });
+      zoomGroup.selectAll<SVGGElement, InferenceData>('.unofficial-overlay-pt').each(function (d) {
+        syncRing(this, perfRulerKey(d, 'overlay'));
+      });
+
+      // Redraw the ruler with the currently applied zoom transform (the
+      // measured pair is read through perfRulerPairRef inside drawPerfRuler).
+      const zoomCtx = currentZoomRenderContext(svg, ctx);
+      drawPerfRuler(
+        zoomGroup,
+        zoomCtx.xScale as ContinuousScale,
+        zoomCtx.yScale as ContinuousScale,
+        ctx.width,
+      );
+    }, [
+      getDisplaySelection,
+      perfRulerMode,
+      perfRulerSelection,
+      perfRulerMeasuredPair,
+      perfRulerKey,
+      drawPerfRuler,
+      dataIdentity,
+    ]);
 
     // D3 custom layers are keyed additions, so removing the overlay layer from
     // the config does not delete DOM that the previous render created. Clear
@@ -3098,6 +3330,16 @@ const ScatterGraph = React.memo(
                   onCheckedChange: (checked: boolean) => {
                     setShowLineLabels(checked);
                     track('latency_line_labels_toggled', { enabled: checked });
+                  },
+                },
+                {
+                  id: 'scatter-perf-ruler',
+                  label: legendT.perfRuler,
+                  checked: perfRulerMode,
+                  infoTooltip: legendT.perfRulerInfo,
+                  onCheckedChange: (checked: boolean) => {
+                    setPerfRulerMode(checked);
+                    track('latency_perf_ruler_toggled', { enabled: checked });
                   },
                 },
                 {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -57,17 +57,24 @@ import type {
 import type { ContinuousScale } from '@/lib/d3-chart/types';
 import { computeTooltipPosition, syncPointShape } from '@/lib/d3-chart/layers/scatter-points';
 import {
-  EMPTY_PERF_RULER_SELECTION,
+  EMPTY_PERF_RULER_STATE,
   clampIsoX,
+  clearPerfRulers,
   computeIsoXRulerGeometry,
+  computePerfRulerLabelLayouts,
+  deletePerfRuler,
   intersectPathAtX,
   isPerfRulerCurveVisible,
-  nextPerfRulerSelection,
+  movePerfRulerIsoX,
+  nextPerfRulerState,
   pathXExtent,
-  renderPerfRuler,
-  type PerfRulerCurveSelection,
+  perfRulerCurveSet,
+  prunePerfRulers,
+  renderPerfRulers,
   type PerfRulerEndInput,
   type PerfRulerGeometry,
+  type PerfRulerRenderEntry,
+  type PerfRulerState,
 } from '@/lib/d3-chart/layers/perf-ruler';
 import {
   attachOverlayXMarkerHandlers,
@@ -355,8 +362,9 @@ const SCATTER_STRINGS = {
     lineLabels: 'Line Labels',
     perfRuler: 'Perf Ruler',
     perfRulerInfo:
-      'Click two curves to place a vertical ruler, then drag it to measure the performance multiple between them at any x value.',
+      'Click two curves to place a vertical ruler, then drag it to measure the performance multiple between them at any x value. Repeat to add more rulers (up to 8); hover a ruler and click × to delete it. Turning the toggle off clears all rulers.',
     resetFilter: 'Reset filter',
+    clearPerfRulers: (count: number) => `Clear rulers (${count})`,
     quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
     overflowMixed: (count: number) => `${pointCountEn(count)} clipped`,
     overflowCost: (count: number, limit: number) => `${pointCountEn(count)} > $${limit}/Mtok`,
@@ -374,8 +382,9 @@ const SCATTER_STRINGS = {
     lineLabels: '曲线标签',
     perfRuler: '性能标尺',
     perfRulerInfo:
-      '先点击两条曲线放置垂直标尺，再拖动标尺，测量任意横坐标下两条曲线之间的性能倍数。',
+      '先点击两条曲线放置垂直标尺，再拖动标尺，测量任意横坐标下两条曲线之间的性能倍数。重复操作可添加多把标尺（最多 8 把）；悬停标尺并点击 × 可删除该标尺。关闭开关将清除所有标尺。',
     resetFilter: '重置筛选',
+    clearPerfRulers: (count: number) => `清除标尺（${count}）`,
     quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
     overflowMixed: (count: number) => `${count} 个点已截断`,
     overflowCost: (count: number, limit: number) => `${count} 个点 > $${limit}/Mtok`,
@@ -1325,31 +1334,32 @@ const ScatterGraph = React.memo(
     };
 
     // --- Perf ruler (opt-in: click two curves, drag the ruler to any iso-x) ---
-    // Curve-to-curve ISO-X semantics: the selection is two CURVES (rendered
-    // roofline path class tokens) plus a freely chosen iso-x stored in DATA
-    // space (xScale.invert of the click), so the measurement survives zoom
-    // and metric changes. BOTH ruler ends are interpolated on the curves'
-    // rendered paths at the iso-x — neither end needs to be a data point.
+    // Curve-to-curve ISO-X semantics: each measurement is two CURVES
+    // (rendered roofline path class tokens) plus a freely chosen iso-x
+    // stored in DATA space (xScale.invert of the click), so measurements
+    // survive zoom and metric changes. BOTH ruler ends are interpolated on
+    // the curves' rendered paths at the iso-x — neither end needs to be a
+    // data point. Multiple rulers accumulate (capped in the pure module);
+    // completing one immediately allows starting the next.
     const [perfRulerMode, setPerfRulerMode] = useState(false);
-    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerCurveSelection>(
-      EMPTY_PERF_RULER_SELECTION,
-    );
-    // Draw passes read mode/selection through refs so toggling off clears
-    // the ruler in the same pre-paint layout pass — the line/chip must never
+    const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
+    // Draw passes read mode/state through refs so toggling off clears the
+    // rulers in the same pre-paint layout pass — lines/labels must never
     // linger a frame after the switch flips (Bugbot report on PR #853).
     const perfRulerModeRef = useRef(perfRulerMode);
     perfRulerModeRef.current = perfRulerMode;
-    const perfRulerSelectionRef = useRef(perfRulerSelection);
-    perfRulerSelectionRef.current = perfRulerSelection;
-    // Live iso-x for draw passes. Dragging the ruler updates it once per
-    // animation frame WITHOUT touching React state (the drag commits on
-    // end), so the ruler follows the pointer with one redraw per frame.
-    // Synced from committed state in an effect (not per render) so an
-    // unrelated re-render mid-drag cannot snap the ruler back.
-    const perfRulerIsoXRef = useRef<number | null>(null);
+    const perfRulerStateRef = useRef(perfRulerState);
+    perfRulerStateRef.current = perfRulerState;
+    // Live per-ruler iso-x overrides for draw passes. Dragging a ruler
+    // updates its entry once per animation frame WITHOUT touching React
+    // state (the drag commits on end), so the ruler follows the pointer
+    // with one redraw per frame. Cleared when committed state changes (an
+    // effect, not per render, so an unrelated re-render mid-drag cannot
+    // snap the dragged ruler back).
+    const perfRulerLiveIsoXRef = useRef(new Map<number, number>());
     useLayoutEffect(() => {
-      perfRulerIsoXRef.current = perfRulerSelection.isoX;
-    }, [perfRulerSelection]);
+      perfRulerLiveIsoXRef.current.clear();
+    }, [perfRulerState]);
 
     // Scales/group from the most recent draw pass — click and drag handlers
     // convert between pixel and data space with the exact scales the chart
@@ -1381,7 +1391,7 @@ const ScatterGraph = React.memo(
       if (!ctx) return;
       track('latency_perf_ruler_curve_clicked', { curve });
       const isoX = Number(ctx.xScale.invert(pixelX));
-      setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, { curve, isoX }));
+      setPerfRulerState((prev) => nextPerfRulerState(prev, { curve, isoX }));
       chartRef.current?.dismissTooltip();
       chartRef.current?.hideTooltip();
     }, []);
@@ -1410,7 +1420,7 @@ const ScatterGraph = React.memo(
         );
         // Single-point series render no roofline path — nothing to measure.
         if (!curve) return;
-        setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, { curve, isoX: point.x }));
+        setPerfRulerState((prev) => nextPerfRulerState(prev, { curve, isoX: point.x }));
         chartRef.current?.dismissTooltip();
         chartRef.current?.hideTooltip();
       },
@@ -1422,14 +1432,13 @@ const ScatterGraph = React.memo(
     const perfRulerRef = useRef({ mode: perfRulerMode, onPointClick: handlePerfRulerPointClick });
     perfRulerRef.current = { mode: perfRulerMode, onPointClick: handlePerfRulerPointClick };
 
-    // Clear the measurement when the toggle turns off (the switch handler
-    // also clears synchronously; this covers programmatic mode changes).
+    // Turning the toggle off clears ALL rulers and any in-progress
+    // selection (documented in the info tooltip — simple and predictable;
+    // the switch handler also clears synchronously, this covers
+    // programmatic mode changes). `clearPerfRulers` bails out with the same
+    // reference when there is nothing to clear.
     useEffect(() => {
-      if (!perfRulerMode) {
-        setPerfRulerSelection((prev) =>
-          prev.curves.length > 0 || prev.isoX !== null ? EMPTY_PERF_RULER_SELECTION : prev,
-        );
-      }
+      if (!perfRulerMode) setPerfRulerState(clearPerfRulers);
     }, [perfRulerMode]);
 
     // Invisible widened hit strokes over every rendered roofline path
@@ -1473,7 +1482,7 @@ const ScatterGraph = React.memo(
             if (!curve || !d || !isPerfRulerCurveVisible(this.style.opacity)) return;
             entries.push({ curve, d });
           });
-        const selected = new Set(perfRulerSelectionRef.current.curves);
+        const selected = perfRulerCurveSet(perfRulerStateRef.current);
         hitLayer
           .selectAll<SVGPathElement, HitEntry>('.perf-ruler-hit')
           .data(entries, (e) => e.curve)
@@ -1498,28 +1507,31 @@ const ScatterGraph = React.memo(
       [],
     );
 
-    // Horizontal drag on the ruler line — the primary way to fine-tune the
-    // iso-x. rAF-throttled: each frame clamps the pointer x to the two
-    // curves' overlapping x range, updates the live iso-x, and redraws; the
-    // value commits to React state on drag end. d3.drag stops mousedown
-    // propagation itself, so dragging the ruler never pans the chart.
-    const perfRulerDragPixelXRef = useRef(0);
+    // Horizontal drag on a ruler line — the primary way to fine-tune that
+    // ruler's iso-x. The drag handle's datum (set by the render join)
+    // identifies WHICH ruler is dragged. rAF-throttled: each frame clamps
+    // the pointer x to that ruler's curve pair's overlapping x range,
+    // updates its live iso-x, and redraws; the value commits to React state
+    // on drag end. d3.drag stops mousedown propagation itself, so dragging
+    // a ruler never pans the chart.
+    const perfRulerDragTargetRef = useRef<{ id: number; pixelX: number } | null>(null);
     const perfRulerDragFrameRef = useRef<number | null>(null);
     const applyPerfRulerDragFrame = useCallback(() => {
       const ctx = perfRulerDrawCtxRef.current;
-      if (!ctx) return;
-      const sel = perfRulerSelectionRef.current;
-      if (sel.curves.length !== 2) return;
-      const [nodeA, nodeB] = sel.curves.map((cls) =>
+      const target = perfRulerDragTargetRef.current;
+      if (!ctx || !target) return;
+      const ruler = perfRulerStateRef.current.rulers.find((r) => r.id === target.id);
+      if (!ruler) return;
+      const [nodeA, nodeB] = [ruler.curveA, ruler.curveB].map((cls) =>
         ctx.zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node(),
       );
       if (!nodeA || !nodeB || typeof nodeA.getPointAtLength !== 'function') return;
       const extentA = pathXExtent(nodeA);
       const extentB = pathXExtent(nodeB);
       if (!extentA || !extentB) return;
-      const clamped = clampIsoX(perfRulerDragPixelXRef.current, extentA, extentB);
+      const clamped = clampIsoX(target.pixelX, extentA, extentB);
       if (clamped === null) return;
-      perfRulerIsoXRef.current = Number(ctx.xScale.invert(clamped));
+      perfRulerLiveIsoXRef.current.set(target.id, Number(ctx.xScale.invert(clamped)));
       drawPerfRulerRef.current?.(ctx.zoomGroup, ctx.xScale, ctx.yScale, ctx.width, ctx.height);
     }, []);
     const applyPerfRulerDragFrameRef = useRef(applyPerfRulerDragFrame);
@@ -1528,33 +1540,43 @@ const ScatterGraph = React.memo(
     const perfRulerDrag = useMemo(
       () =>
         d3
-          .drag<SVGLineElement, unknown>()
-          .on('drag', (event: d3.D3DragEvent<SVGLineElement, unknown, unknown>) => {
-            perfRulerDragPixelXRef.current = event.x;
-            if (perfRulerDragFrameRef.current === null) {
-              perfRulerDragFrameRef.current = requestAnimationFrame(() => {
-                perfRulerDragFrameRef.current = null;
-                applyPerfRulerDragFrameRef.current();
-              });
-            }
-          })
+          .drag<SVGLineElement, PerfRulerRenderEntry>()
+          .on(
+            'drag',
+            (
+              event: d3.D3DragEvent<SVGLineElement, PerfRulerRenderEntry, unknown>,
+              entry: PerfRulerRenderEntry,
+            ) => {
+              perfRulerDragTargetRef.current = { id: entry.id, pixelX: event.x };
+              if (perfRulerDragFrameRef.current === null) {
+                perfRulerDragFrameRef.current = requestAnimationFrame(() => {
+                  perfRulerDragFrameRef.current = null;
+                  applyPerfRulerDragFrameRef.current();
+                });
+              }
+            },
+          )
           .on('end', () => {
-            // Flush the pending frame, then commit the iso-x to state.
+            // Flush the pending frame, then commit this ruler's iso-x.
             if (perfRulerDragFrameRef.current !== null) {
               cancelAnimationFrame(perfRulerDragFrameRef.current);
               perfRulerDragFrameRef.current = null;
               applyPerfRulerDragFrameRef.current();
             }
-            const isoX = perfRulerIsoXRef.current;
-            setPerfRulerSelection((prev) => (prev.isoX === isoX ? prev : { ...prev, isoX }));
+            const target = perfRulerDragTargetRef.current;
+            perfRulerDragTargetRef.current = null;
+            if (!target) return;
+            const isoX = perfRulerLiveIsoXRef.current.get(target.id);
+            if (isoX === undefined) return;
+            setPerfRulerState((prev) => movePerfRulerIsoX(prev, target.id, isoX));
           }),
       [],
     );
 
-    // Draw (or clear) the hit strokes and the ruler for the current draw
+    // Draw (or clear) the hit strokes and all rulers for the current draw
     // pass. Stable callback so the custom layer can live outside the
-    // perf-ruler state dependencies — render/zoom passes read mode,
-    // selection, and iso-x through refs. Gated on the mode ref so a
+    // perf-ruler state dependencies — render/zoom passes read mode, rulers,
+    // and live iso-x values through refs. Gated on the mode ref so a
     // toggle-off clears everything in the very next pre-paint pass.
     const drawPerfRuler = useCallback(
       (
@@ -1566,42 +1588,58 @@ const ScatterGraph = React.memo(
       ) => {
         perfRulerDrawCtxRef.current = { zoomGroup, xScale, yScale, width, height };
         syncPerfRulerHitPaths(zoomGroup);
-        const sel = perfRulerSelectionRef.current;
-        const isoX = perfRulerIsoXRef.current;
-        let geometry: PerfRulerGeometry | null = null;
-        if (perfRulerModeRef.current && sel.curves.length === 2 && isoX !== null) {
-          const pixelX = xScale(isoX);
-          // Both ends are interpolated on the RENDERED paths — the drawn
-          // curve is the measurement surface, so the ruler matches it
-          // exactly and stays correct under zoom (rooflines redraw before
-          // this layer runs). When either curve does not span the iso-x, has
-          // no rendered path, or is hidden (legend/precision toggles keep the
-          // path in the DOM at opacity 0), draw nothing but KEEP the
-          // selection: zoom/drag/legend re-toggles that restore both visible
-          // intersections bring the ruler back.
-          const ends: PerfRulerEndInput[] = [];
-          for (const cls of sel.curves) {
-            const node = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node();
-            if (!node || typeof node.getPointAtLength !== 'function') break;
-            if (!isPerfRulerCurveVisible(node.style.opacity)) break;
-            const hit = intersectPathAtX(node, pixelX);
-            if (!hit) break;
-            ends.push({ py: hit.y, rawY: yScale.invert(hit.y) });
-          }
-          if (ends.length === 2) {
-            geometry = computeIsoXRulerGeometry(pixelX, ends[0], ends[1]);
+        const state = perfRulerStateRef.current;
+        const entries: PerfRulerRenderEntry[] = [];
+        if (perfRulerModeRef.current && state.rulers.length > 0) {
+          // Both ends of each ruler are interpolated on the RENDERED paths —
+          // the drawn curve is the measurement surface, so the ruler matches
+          // it exactly and stays correct under zoom (rooflines redraw before
+          // this layer runs). When either of a ruler's curves does not span
+          // its iso-x, has no rendered path, or is hidden (legend/precision
+          // toggles keep the path in the DOM at opacity 0), that ruler draws
+          // nothing this frame but KEEPS its state — per ruler, others stay
+          // visible; zoom/drag/legend re-toggles that restore both visible
+          // intersections bring it back.
+          const geometries: (PerfRulerGeometry | null)[] = state.rulers.map((ruler) => {
+            const isoX = perfRulerLiveIsoXRef.current.get(ruler.id) ?? ruler.isoX;
+            const pixelX = xScale(isoX);
+            const ends: PerfRulerEndInput[] = [];
+            for (const cls of [ruler.curveA, ruler.curveB]) {
+              const node = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node();
+              if (!node || typeof node.getPointAtLength !== 'function') break;
+              if (!isPerfRulerCurveVisible(node.style.opacity)) break;
+              const hit = intersectPathAtX(node, pixelX);
+              if (!hit) break;
+              ends.push({ py: hit.y, rawY: yScale.invert(hit.y) });
+            }
+            return ends.length === 2 ? computeIsoXRulerGeometry(pixelX, ends[0], ends[1]) : null;
+          });
+          // Lay out all labels together so overlapping labels nudge apart.
+          const layouts = computePerfRulerLabelLayouts(geometries, {
+            chartWidth: width,
+            chartHeight: height,
+          });
+          for (const [index, ruler] of state.rulers.entries()) {
+            const geometry = geometries[index];
+            const layout = layouts[index];
+            if (geometry && layout) entries.push({ id: ruler.id, geometry, layout });
           }
         }
-        renderPerfRuler(zoomGroup, geometry, {
+        renderPerfRulers(zoomGroup, entries, {
           color: 'var(--primary)',
           halo: 'var(--background)',
-          chartWidth: width,
-          chartHeight: height,
+          onDelete: (id) => {
+            track('latency_perf_ruler_deleted');
+            setPerfRulerState((prev) => deletePerfRuler(prev, id));
+          },
         });
         // (Re)attach the horizontal drag behavior to the (possibly fresh)
-        // drag handle the render pass just joined.
-        const dragHandle = zoomGroup.select<SVGLineElement>('.perf-ruler .pr-drag');
-        if (!dragHandle.empty()) dragHandle.call(perfRulerDrag);
+        // drag handles the render pass just joined — their datum (the
+        // render entry) tells the drag which ruler it moves.
+        const dragHandles = zoomGroup.selectAll<SVGLineElement, PerfRulerRenderEntry>(
+          '.perf-ruler .pr-drag',
+        );
+        if (!dragHandles.empty()) dragHandles.call(perfRulerDrag);
       },
       [syncPerfRulerHitPaths, perfRulerDrag],
     );
@@ -3154,12 +3192,12 @@ const ScatterGraph = React.memo(
         .remove();
     }, [overlayData]);
 
-    // Perf-ruler decorations: refresh the curve hit strokes and redraw the
-    // ruler whenever the mode, selection, visibility filters, or underlying
-    // data change. Narrow mutation scope — only the hit layer and the ruler
-    // group are touched; the chart itself never rebuilds for a ruler
-    // interaction. Redraws use the currently applied zoom transform (mode,
-    // selection, and iso-x are read through refs inside drawPerfRuler).
+    // Perf-ruler decorations: refresh the curve hit strokes and redraw all
+    // rulers whenever the mode, ruler state, visibility filters, or
+    // underlying data change. Narrow mutation scope — only the hit layer
+    // and the ruler groups are touched; the chart itself never rebuilds for
+    // a ruler interaction. Redraws use the currently applied zoom transform
+    // (mode, rulers, and live iso-x are read through refs in drawPerfRuler).
     //
     // Ordering matters twice here — this effect is deliberately declared
     // AFTER both (a) the mark-styling effect that writes curve opacities
@@ -3178,21 +3216,18 @@ const ScatterGraph = React.memo(
         display.ctx.width,
         display.ctx.height,
       );
-      // Hidden-but-present curves KEEP the selection (a legend re-toggle
-      // brings the ruler back); curves whose paths left the DOM entirely are
-      // truly gone from the data, so prune them from the selection.
-      setPerfRulerSelection((prev) => {
-        if (prev.curves.length === 0) return prev;
-        const kept = prev.curves.filter(
-          (cls) => !display.zoomGroup.select(`.${CSS.escape(cls)}`).empty(),
-        );
-        if (kept.length === prev.curves.length) return prev;
-        return { curves: kept, isoX: kept.length > 0 ? prev.isoX : null };
-      });
+      // Hidden-but-present curves KEEP their rulers (a legend re-toggle
+      // brings a hidden ruler back); curves whose paths left the DOM
+      // entirely are truly gone from the data, so prune each ruler (and the
+      // draft) that references one. `prunePerfRulers` bails out with the
+      // same reference when nothing changed.
+      setPerfRulerState((prev) =>
+        prunePerfRulers(prev, (cls) => !display.zoomGroup.select(`.${CSS.escape(cls)}`).empty()),
+      );
     }, [
       getDisplaySelection,
       perfRulerMode,
-      perfRulerSelection,
+      perfRulerState,
       drawPerfRuler,
       dataIdentity,
       effectiveActiveHwTypes,
@@ -3516,10 +3551,11 @@ const ScatterGraph = React.memo(
                   infoTooltip: legendT.perfRulerInfo,
                   onCheckedChange: (checked: boolean) => {
                     setPerfRulerMode(checked);
-                    // Clear in the same state batch — the pre-paint decoration
-                    // effect then removes the ruler and the curve hit strokes
-                    // before the next frame (no lingering line after toggle-off).
-                    if (!checked) setPerfRulerSelection(EMPTY_PERF_RULER_SELECTION);
+                    // Toggle-off clears ALL rulers in the same state batch —
+                    // the pre-paint decoration effect then removes the rulers
+                    // and the curve hit strokes before the next frame (no
+                    // lingering lines after toggle-off).
+                    if (!checked) setPerfRulerState(clearPerfRulers);
                     track('latency_perf_ruler_toggled', { enabled: checked });
                   },
                 },
@@ -3552,6 +3588,20 @@ const ScatterGraph = React.memo(
                           resetUnifiedSelection();
                           clearQuickFilters();
                           track('latency_legend_filter_reset');
+                        },
+                      },
+                    ]
+                  : []),
+                ...(perfRulerState.rulers.length > 0
+                  ? [
+                      {
+                        id: 'scatter-clear-perf-rulers',
+                        label: legendT.clearPerfRulers(perfRulerState.rulers.length),
+                        onClick: () => {
+                          track('latency_perf_ruler_cleared', {
+                            count: perfRulerState.rulers.length,
+                          });
+                          setPerfRulerState(clearPerfRulers);
                         },
                       },
                     ]

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -57,12 +57,16 @@ import type {
 import type { ContinuousScale } from '@/lib/d3-chart/types';
 import { computeTooltipPosition, syncPointShape } from '@/lib/d3-chart/layers/scatter-points';
 import {
+  EMPTY_PERF_RULER_SELECTION,
+  clampIsoX,
   computeIsoXRulerGeometry,
   intersectPathAtX,
   nextPerfRulerSelection,
+  pathXExtent,
   renderPerfRuler,
+  type PerfRulerCurveSelection,
+  type PerfRulerEndInput,
   type PerfRulerGeometry,
-  type PerfRulerSelectionEntry,
 } from '@/lib/d3-chart/layers/perf-ruler';
 import {
   attachOverlayXMarkerHandlers,
@@ -350,7 +354,7 @@ const SCATTER_STRINGS = {
     lineLabels: 'Line Labels',
     perfRuler: 'Perf Ruler',
     perfRulerInfo:
-      'Click a point to anchor the ruler, then click another curve to measure the performance multiple between the two curves at that same x value.',
+      'Click two curves to place a vertical ruler, then drag it to measure the performance multiple between them at any x value.',
     resetFilter: 'Reset filter',
     quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
     overflowMixed: (count: number) => `${pointCountEn(count)} clipped`,
@@ -369,7 +373,7 @@ const SCATTER_STRINGS = {
     lineLabels: '曲线标签',
     perfRuler: '性能标尺',
     perfRulerInfo:
-      '先点击一个数据点固定标尺，再点击另一条曲线，测量两条曲线在同一横坐标处的性能倍数。',
+      '先点击两条曲线放置垂直标尺，再拖动标尺，测量任意横坐标下两条曲线之间的性能倍数。',
     resetFilter: '重置筛选',
     quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
     overflowMixed: (count: number) => `${count} 个点已截断`,
@@ -1319,144 +1323,236 @@ const ScatterGraph = React.memo(
       logAvailability: persistedLogAvailability,
     };
 
-    // --- Perf ruler (opt-in: anchor a point, measure the iso-x multiple to another curve) ---
-    // ISO-X semantics: the FIRST selection entry is the anchor point — it
-    // defines the ruler's x position and one end. The SECOND entry only
-    // selects the target CURVE; the ruler's other end is that curve's
-    // rendered-roofline intersection at the anchor's x, not the clicked
-    // point. Selection stores stable point keys (not indices) so the
-    // measurement survives metric/display re-renders where the points still
-    // exist. Keys distinguish official points from unofficial overlay
-    // points, mirroring the dataIdentity convention.
+    // --- Perf ruler (opt-in: click two curves, drag the ruler to any iso-x) ---
+    // Curve-to-curve ISO-X semantics: the selection is two CURVES (rendered
+    // roofline path class tokens) plus a freely chosen iso-x stored in DATA
+    // space (xScale.invert of the click), so the measurement survives zoom
+    // and metric changes. BOTH ruler ends are interpolated on the curves'
+    // rendered paths at the iso-x — neither end needs to be a data point.
     const [perfRulerMode, setPerfRulerMode] = useState(false);
-    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerSelectionEntry[]>([]);
-    // Draw passes read the mode through a ref so toggling off clears the
-    // ruler in the same pre-paint layout pass — the line/chip must never
+    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerCurveSelection>(
+      EMPTY_PERF_RULER_SELECTION,
+    );
+    // Draw passes read mode/selection through refs so toggling off clears
+    // the ruler in the same pre-paint layout pass — the line/chip must never
     // linger a frame after the switch flips (Bugbot report on PR #853).
     const perfRulerModeRef = useRef(perfRulerMode);
     perfRulerModeRef.current = perfRulerMode;
+    const perfRulerSelectionRef = useRef(perfRulerSelection);
+    perfRulerSelectionRef.current = perfRulerSelection;
+    // Live iso-x for draw passes. Dragging the ruler updates it once per
+    // animation frame WITHOUT touching React state (the drag commits on
+    // end), so the ruler follows the pointer with one redraw per frame.
+    // Synced from committed state in an effect (not per render) so an
+    // unrelated re-render mid-drag cannot snap the ruler back.
+    const perfRulerIsoXRef = useRef<number | null>(null);
+    useLayoutEffect(() => {
+      perfRulerIsoXRef.current = perfRulerSelection.isoX;
+    }, [perfRulerSelection]);
 
-    const perfRulerKey = useCallback(
-      (point: InferenceData, source: 'official' | 'overlay') =>
-        source === 'official'
-          ? `official:${buildPointId(point)}`
-          : `overlay:${buildPointId(point)}:${point.run_url ?? ''}`,
-      [buildPointId],
-    );
+    // Scales/group from the most recent draw pass — click and drag handlers
+    // convert between pixel and data space with the exact scales the chart
+    // is currently drawn with.
+    const perfRulerDrawCtxRef = useRef<{
+      zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>;
+      xScale: ContinuousScale;
+      yScale: ContinuousScale;
+      width: number;
+    } | null>(null);
+    // Forward ref: the drag frame needs to redraw, but drawPerfRuler is
+    // defined below (it also attaches the drag behavior — benign cycle).
+    const drawPerfRulerRef = useRef<
+      | ((
+          zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+          xScale: ContinuousScale,
+          yScale: ContinuousScale,
+          width: number,
+        ) => void)
+      | null
+    >(null);
 
-    // Curve identity for click semantics: a second click on the SAME curve
-    // moves the anchor; a different curve selects the measurement target.
-    // Official curves are (hw, precision, date) — comparison-date sub-curves
-    // are distinct targets (measuring a config against its own earlier date
-    // is a legitimate regression check). Overlay curves are per (hw,
-    // precision, run), matching the overlayRooflines grouping.
-    const perfRulerCurve = useCallback(
-      (point: InferenceData, source: 'official' | 'overlay') =>
-        source === 'official'
-          ? `official-curve:${String(point.hwKey)}_${point.precision}__${point.date}`
-          : `overlay-curve:${String(point.hwKey)}_${point.precision}:${point.run_url ?? ''}`,
-      [],
-    );
-
-    // Resolve each selected key to its current point object (raw x/y follow
-    // the active metric). A key resolves to null when its point disappeared
-    // or is hidden by filters — the prune effect below then drops it.
-    const perfRulerResolvedPoints = useMemo(() => {
-      if (perfRulerSelection.length === 0) return [] as (InferenceData | null)[];
-      const resolve = (key: string): InferenceData | null => {
-        if (key.startsWith('official:')) {
-          return (
-            pointsData.find((p) => perfRulerKey(p, 'official') === key && isPointVisible(p)) ?? null
-          );
-        }
-        return (
-          processedOverlayData.find(
-            (p) => perfRulerKey(p, 'overlay') === key && isOverlayPointVisible(p),
-          ) ?? null
-        );
-      };
-      return perfRulerSelection.map((entry) => resolve(entry.key));
-    }, [
-      perfRulerSelection,
-      pointsData,
-      processedOverlayData,
-      perfRulerKey,
-      isPointVisible,
-      isOverlayPointVisible,
-    ]);
-
-    // Anchor point plus the target curve's roofline path class candidates.
-    // The path node is resolved from the DOM at draw time: the RENDERED path
-    // is the measurement surface, so the intersection matches the drawn
-    // curve exactly and stays correct under zoom (paths are redrawn with the
-    // new scales before this layer runs — rooflines render first).
-    const perfRulerMeasurement = useMemo(() => {
-      if (perfRulerSelection.length !== 2) return null;
-      const [anchor, target] = perfRulerResolvedPoints;
-      if (!anchor || !target) return null;
-      const targetClasses: string[] = [];
-      if (perfRulerSelection[1].key.startsWith('overlay:')) {
-        const runIndex = overlayRunIndex(target.run_url ?? null, runIndexByUrl);
-        targetClasses.push(
-          `overlay-roofline-${String(target.hwKey)}_${target.precision}_run${runIndex}`,
-        );
-      } else {
-        const base = `${String(target.hwKey)}_${target.precision}`;
-        // A single comparison date renders `roofline-<key>`; multiple dates
-        // split into `roofline-<key>__<date>` sub-paths — try both.
-        targetClasses.push(`roofline-${base}`, `roofline-${base}__${target.date}`);
-      }
-      return { anchor, targetClasses };
-    }, [perfRulerSelection, perfRulerResolvedPoints, runIndexByUrl]);
-    const perfRulerMeasurementRef = useRef(perfRulerMeasurement);
-    perfRulerMeasurementRef.current = perfRulerMeasurement;
-
-    // Clear the measurement when the toggle turns off; drop any selected
-    // point that disappeared (data/filter change) while keeping the other.
-    useEffect(() => {
-      if (!perfRulerMode) {
-        setPerfRulerSelection((prev) => (prev.length > 0 ? [] : prev));
-        return;
-      }
-      const kept = perfRulerSelection.filter((_, i) => perfRulerResolvedPoints[i] !== null);
-      if (kept.length !== perfRulerSelection.length) setPerfRulerSelection(kept);
-    }, [perfRulerMode, perfRulerSelection, perfRulerResolvedPoints]);
-
-    // Selection transitions live in the pure module (see the transition
-    // table on nextPerfRulerSelection): first click anchors; a click on the
-    // anchor's curve moves the anchor; a different curve selects the target;
-    // clicks on the already-selected target curve are a no-op (the target
-    // entry identifies a CURVE, so they cannot change the iso-x result); a
-    // third curve starts a new measurement; re-clicking the exact anchor
-    // point clears. Ruler-mode clicks measure INSTEAD of pinning the
-    // tooltip, so drop the pin the shared click handler applied just before
-    // this callback ran.
-    const handlePerfRulerPointClick = useCallback((clicked: PerfRulerSelectionEntry) => {
-      setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, clicked));
+    // Curve click (widened hit strokes): iso-x is the click's x pixel
+    // through the CURRENT rendered x scale, stored in data space.
+    const handlePerfRulerCurveClick = useCallback((curve: string, pixelX: number) => {
+      const ctx = perfRulerDrawCtxRef.current;
+      if (!ctx) return;
+      track('latency_perf_ruler_curve_clicked', { curve });
+      const isoX = Number(ctx.xScale.invert(pixelX));
+      setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, { curve, isoX }));
       chartRef.current?.dismissTooltip();
       chartRef.current?.hideTooltip();
     }, []);
+    const perfRulerCurveClickRef = useRef(handlePerfRulerCurveClick);
+    perfRulerCurveClickRef.current = handlePerfRulerCurveClick;
+
+    // Points sit on curves: a ruler-mode click on a data point behaves like
+    // clicking the point's curve at that point's x. Candidates cover the
+    // single- vs multi-date roofline class variants; the first one present
+    // in the DOM wins. Ruler-mode clicks measure INSTEAD of pinning the
+    // tooltip, so drop the pin the shared click handler applied just before
+    // this callback ran.
+    const handlePerfRulerPointClick = useCallback(
+      (point: InferenceData, source: 'official' | 'overlay') => {
+        const ctx = perfRulerDrawCtxRef.current;
+        if (!ctx) return;
+        const base = `${String(point.hwKey)}_${point.precision}`;
+        const candidates =
+          source === 'overlay'
+            ? [
+                `overlay-roofline-${base}_run${overlayRunIndex(point.run_url ?? null, runIndexByUrl)}`,
+              ]
+            : [`roofline-${base}`, `roofline-${base}__${point.date}`];
+        const curve = candidates.find(
+          (cls) => !ctx.zoomGroup.select(`.${CSS.escape(cls)}`).empty(),
+        );
+        // Single-point series render no roofline path — nothing to measure.
+        if (!curve) return;
+        setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, { curve, isoX: point.x }));
+        chartRef.current?.dismissTooltip();
+        chartRef.current?.hideTooltip();
+      },
+      [runIndexByUrl],
+    );
 
     // Read by long-lived D3 click closures (official tooltip config + overlay
     // marker handlers) — same refs-over-closures rule as interactionRef.
-    const perfRulerRef = useRef({
-      mode: perfRulerMode,
-      onPointClick: handlePerfRulerPointClick,
-      keyFor: perfRulerKey,
-      curveFor: perfRulerCurve,
-    });
-    perfRulerRef.current = {
-      mode: perfRulerMode,
-      onPointClick: handlePerfRulerPointClick,
-      keyFor: perfRulerKey,
-      curveFor: perfRulerCurve,
-    };
+    const perfRulerRef = useRef({ mode: perfRulerMode, onPointClick: handlePerfRulerPointClick });
+    perfRulerRef.current = { mode: perfRulerMode, onPointClick: handlePerfRulerPointClick };
 
-    // Draw (or clear) the ruler from the current measurement. Stable
-    // callback so the custom layer can live outside the perf-ruler state
-    // dependencies — render/zoom passes read mode and the measurement
-    // through refs. Gated on the mode ref so a toggle-off clears the ruler
-    // in the very next draw, before the selection-prune state settles.
+    // Clear the measurement when the toggle turns off (the switch handler
+    // also clears synchronously; this covers programmatic mode changes).
+    useEffect(() => {
+      if (!perfRulerMode) {
+        setPerfRulerSelection((prev) =>
+          prev.curves.length > 0 || prev.isoX !== null ? EMPTY_PERF_RULER_SELECTION : prev,
+        );
+      }
+    }, [perfRulerMode]);
+
+    // Invisible widened hit strokes over every rendered roofline path
+    // (official AND overlay) make the curves themselves clickable in ruler
+    // mode. The hit layer sits directly ABOVE `.rooflines-layer` (so the
+    // visible 2.5px strokes never shadow the hit strokes) but BELOW the
+    // dot-groups and overlay markers, so point hover/click behavior is
+    // untouched. The layer only exists while ruler mode is on — with the
+    // mode off there is nothing to intercept hovers, clicks, or zoom.
+    const syncPerfRulerHitPaths = useCallback(
+      (zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>) => {
+        let hitLayer = zoomGroup.select<SVGGElement>('.perf-ruler-hits');
+        const rooflinesLayerNode = zoomGroup.select<SVGGElement>('.rooflines-layer').node();
+        if (!perfRulerModeRef.current || !rooflinesLayerNode) {
+          hitLayer.remove();
+          return;
+        }
+        if (hitLayer.empty()) {
+          const node = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+          node.setAttribute('class', 'perf-ruler-hits');
+          rooflinesLayerNode.after(node);
+          hitLayer = d3.select(node) as typeof hitLayer;
+        }
+        interface HitEntry {
+          curve: string;
+          d: string;
+        }
+        const entries: HitEntry[] = [];
+        zoomGroup
+          .selectAll<SVGPathElement, unknown>('.roofline-path, .overlay-roofline-path')
+          .each(function () {
+            // The identity token is the curve-specific class, e.g.
+            // `roofline-H100_fp8`, `roofline-H100_fp8__2026-01-01`, or
+            // `overlay-roofline-H100_fp8_run0`.
+            const curve = [...this.classList].find(
+              (cls) => cls !== 'roofline-path' && cls !== 'overlay-roofline-path',
+            );
+            const d = this.getAttribute('d');
+            // Curves hidden by legend/precision filters keep their paths at
+            // opacity 0 — invisible curves must not be clickable.
+            if (!curve || !d || this.style.opacity === '0') return;
+            entries.push({ curve, d });
+          });
+        const selected = new Set(perfRulerSelectionRef.current.curves);
+        hitLayer
+          .selectAll<SVGPathElement, HitEntry>('.perf-ruler-hit')
+          .data(entries, (e) => e.curve)
+          .join('path')
+          .attr('class', 'perf-ruler-hit')
+          .attr('fill', 'none')
+          .attr('d', (e) => e.d)
+          .attr('stroke', 'var(--primary)')
+          // Selected curves get a faint halo as feedback; unselected hit
+          // strokes are fully transparent (`pointer-events: stroke` still
+          // hit-tests the invisible stroke geometry).
+          .attr('stroke-opacity', (e) => (selected.has(e.curve) ? 0.18 : 0))
+          .attr('stroke-width', 13)
+          .style('pointer-events', 'stroke')
+          .style('cursor', 'crosshair')
+          .on('click', (event: MouseEvent, e: HitEntry) => {
+            event.stopPropagation();
+            const [pixelX] = d3.pointer(event, zoomGroup.node());
+            perfRulerCurveClickRef.current(e.curve, pixelX);
+          });
+      },
+      [],
+    );
+
+    // Horizontal drag on the ruler line — the primary way to fine-tune the
+    // iso-x. rAF-throttled: each frame clamps the pointer x to the two
+    // curves' overlapping x range, updates the live iso-x, and redraws; the
+    // value commits to React state on drag end. d3.drag stops mousedown
+    // propagation itself, so dragging the ruler never pans the chart.
+    const perfRulerDragPixelXRef = useRef(0);
+    const perfRulerDragFrameRef = useRef<number | null>(null);
+    const applyPerfRulerDragFrame = useCallback(() => {
+      const ctx = perfRulerDrawCtxRef.current;
+      if (!ctx) return;
+      const sel = perfRulerSelectionRef.current;
+      if (sel.curves.length !== 2) return;
+      const [nodeA, nodeB] = sel.curves.map((cls) =>
+        ctx.zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node(),
+      );
+      if (!nodeA || !nodeB || typeof nodeA.getPointAtLength !== 'function') return;
+      const extentA = pathXExtent(nodeA);
+      const extentB = pathXExtent(nodeB);
+      if (!extentA || !extentB) return;
+      const clamped = clampIsoX(perfRulerDragPixelXRef.current, extentA, extentB);
+      if (clamped === null) return;
+      perfRulerIsoXRef.current = Number(ctx.xScale.invert(clamped));
+      drawPerfRulerRef.current?.(ctx.zoomGroup, ctx.xScale, ctx.yScale, ctx.width);
+    }, []);
+    const applyPerfRulerDragFrameRef = useRef(applyPerfRulerDragFrame);
+    applyPerfRulerDragFrameRef.current = applyPerfRulerDragFrame;
+
+    const perfRulerDrag = useMemo(
+      () =>
+        d3
+          .drag<SVGLineElement, unknown>()
+          .on('drag', (event: d3.D3DragEvent<SVGLineElement, unknown, unknown>) => {
+            perfRulerDragPixelXRef.current = event.x;
+            if (perfRulerDragFrameRef.current === null) {
+              perfRulerDragFrameRef.current = requestAnimationFrame(() => {
+                perfRulerDragFrameRef.current = null;
+                applyPerfRulerDragFrameRef.current();
+              });
+            }
+          })
+          .on('end', () => {
+            // Flush the pending frame, then commit the iso-x to state.
+            if (perfRulerDragFrameRef.current !== null) {
+              cancelAnimationFrame(perfRulerDragFrameRef.current);
+              perfRulerDragFrameRef.current = null;
+              applyPerfRulerDragFrameRef.current();
+            }
+            const isoX = perfRulerIsoXRef.current;
+            setPerfRulerSelection((prev) => (prev.isoX === isoX ? prev : { ...prev, isoX }));
+          }),
+      [],
+    );
+
+    // Draw (or clear) the hit strokes and the ruler for the current draw
+    // pass. Stable callback so the custom layer can live outside the
+    // perf-ruler state dependencies — render/zoom passes read mode,
+    // selection, and iso-x through refs. Gated on the mode ref so a
+    // toggle-off clears everything in the very next pre-paint pass.
     const drawPerfRuler = useCallback(
       (
         zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
@@ -1464,31 +1560,30 @@ const ScatterGraph = React.memo(
         yScale: ContinuousScale,
         width: number,
       ) => {
-        const measurement = perfRulerModeRef.current ? perfRulerMeasurementRef.current : null;
+        perfRulerDrawCtxRef.current = { zoomGroup, xScale, yScale, width };
+        syncPerfRulerHitPaths(zoomGroup);
+        const sel = perfRulerSelectionRef.current;
+        const isoX = perfRulerIsoXRef.current;
         let geometry: PerfRulerGeometry | null = null;
-        if (measurement) {
-          const { anchor, targetClasses } = measurement;
-          let pathNode: SVGPathElement | null = null;
-          for (const cls of targetClasses) {
+        if (perfRulerModeRef.current && sel.curves.length === 2 && isoX !== null) {
+          const pixelX = xScale(isoX);
+          // Both ends are interpolated on the RENDERED paths — the drawn
+          // curve is the measurement surface, so the ruler matches it
+          // exactly and stays correct under zoom (rooflines redraw before
+          // this layer runs). When either curve does not span the iso-x (or
+          // has no rendered path), draw nothing but KEEP the selection:
+          // zoom/drag/metric changes that restore both intersections bring
+          // the ruler back.
+          const ends: PerfRulerEndInput[] = [];
+          for (const cls of sel.curves) {
             const node = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node();
-            if (node) {
-              pathNode = node;
-              break;
-            }
+            if (!node || typeof node.getPointAtLength !== 'function') break;
+            const hit = intersectPathAtX(node, pixelX);
+            if (!hit) break;
+            ends.push({ py: hit.y, rawY: yScale.invert(hit.y) });
           }
-          // When the target curve does not span the anchor's x (or has no
-          // rendered path — e.g. a single-point series), draw nothing but
-          // KEEP the selection: zoom/metric changes that make them
-          // intersect bring the ruler back.
-          if (pathNode && typeof pathNode.getPointAtLength === 'function') {
-            const anchorPx = xScale(anchor.x);
-            const hit = intersectPathAtX(pathNode, anchorPx);
-            if (hit) {
-              geometry = computeIsoXRulerGeometry(
-                { px: anchorPx, py: yScale(anchor.y), rawY: anchor.y },
-                { py: hit.y, rawY: yScale.invert(hit.y) },
-              );
-            }
+          if (ends.length === 2) {
+            geometry = computeIsoXRulerGeometry(pixelX, ends[0], ends[1]);
           }
         }
         renderPerfRuler(zoomGroup, geometry, {
@@ -1497,9 +1592,14 @@ const ScatterGraph = React.memo(
           labelText: 'var(--primary-foreground)',
           chartWidth: width,
         });
+        // (Re)attach the horizontal drag behavior to the (possibly fresh)
+        // drag handle the render pass just joined.
+        const dragHandle = zoomGroup.select<SVGLineElement>('.perf-ruler .pr-drag');
+        if (!dragHandle.empty()) dragHandle.call(perfRulerDrag);
       },
-      [],
+      [syncPerfRulerHitPaths, perfRulerDrag],
     );
+    drawPerfRulerRef.current = drawPerfRuler;
 
     // Render context from the last D3 render — lets the decoration effect
     // restyle with the same layout/scales the chart was drawn with.
@@ -1664,9 +1764,10 @@ const ScatterGraph = React.memo(
             getShapeKeyForPrecision(d.precision, interactionRef.current.selectedPrecisions),
           ),
         onPointClick: (d: InferenceData) => {
-          // Perf ruler mode: the click selects a measurement endpoint INSTEAD
-          // of pinning the tooltip (the handler drops the pin applied by the
-          // shared click path; the hover tooltip stays available).
+          // Perf ruler mode: the click acts as a click on the point's CURVE
+          // at the point's x INSTEAD of pinning the tooltip (the handler
+          // drops the pin applied by the shared click path; the hover
+          // tooltip stays available).
           const ruler = perfRulerRef.current;
           if (ruler.mode) {
             track('latency_data_point_clicked', {
@@ -1675,10 +1776,7 @@ const ScatterGraph = React.memo(
               y: d.y,
               perfRuler: true,
             });
-            ruler.onPointClick({
-              key: ruler.keyFor(d, 'official'),
-              curve: ruler.curveFor(d, 'official'),
-            });
+            ruler.onPointClick(d, 'official');
             return;
           }
           track('latency_data_point_clicked', { hw: String(d.hwKey), x: d.x, y: d.y });
@@ -2490,8 +2588,9 @@ const ScatterGraph = React.memo(
                 },
                 onClick: (point) => {
                   // Overlay points participate in the perf ruler too — a
-                  // ruler-mode click selects the point instead of keeping the
-                  // pinned tooltip (see AGENTS.md "Unofficial Run Support").
+                  // ruler-mode click acts as a click on the overlay curve at
+                  // the point's x instead of keeping the pinned tooltip (see
+                  // AGENTS.md "Unofficial Run Support").
                   const ruler = perfRulerRef.current;
                   if (ruler.mode) {
                     track('latency_data_point_clicked', {
@@ -2501,10 +2600,7 @@ const ScatterGraph = React.memo(
                       overlay: true,
                       perfRuler: true,
                     });
-                    ruler.onPointClick({
-                      key: ruler.keyFor(point, 'overlay'),
-                      curve: ruler.curveFor(point, 'overlay'),
-                    });
+                    ruler.onPointClick(point, 'overlay');
                     return;
                   }
                   track('latency_data_point_clicked', {
@@ -2723,9 +2819,9 @@ const ScatterGraph = React.memo(
       // ── Perf ruler (opt-in iso-x measurement between two curves) ──
       // Mode and measurement are read through refs, so this layer needs
       // no perf-ruler dependencies: full re-renders redraw it after the data
-      // phase (it survives metric/display re-renders where the points still
-      // exist), and onZoom keeps it glued to the points during pan/zoom. It
-      // lives inside the zoomGroup, so it is clipped and PNG-exported like
+      // phase (the iso-x lives in data space, so it survives metric/display
+      // re-renders), and onZoom keeps it glued to the curves during pan/zoom.
+      // It lives inside the zoomGroup, so it is clipped and PNG-exported like
       // any other mark.
       const perfRulerLayer: CustomLayerConfig = {
         type: 'custom',
@@ -3038,59 +3134,23 @@ const ScatterGraph = React.memo(
       }
     }, [getDisplaySelection, knownIssueAnnotations, getCssColor, resolveColor]);
 
-    // Perf-ruler decorations: stamp a selection ring on the chosen point(s)
-    // and redraw the ruler line whenever the selection or underlying data
-    // changes. Narrow mutation scope — only ring circles and the ruler group
-    // are touched; the chart itself never rebuilds for a ruler click.
+    // Perf-ruler decorations: refresh the curve hit strokes and redraw the
+    // ruler whenever the mode, selection, or underlying data changes. Narrow
+    // mutation scope — only the hit layer and the ruler group are touched;
+    // the chart itself never rebuilds for a ruler interaction. Redraws use
+    // the currently applied zoom transform (mode, selection, and iso-x are
+    // read through refs inside drawPerfRuler).
     useLayoutEffect(() => {
       const display = getDisplaySelection();
       if (!display) return;
-      const { svg, ctx, zoomGroup } = display;
-      const selected = new Set(perfRulerSelection.map((entry) => entry.key));
-
-      const syncRing = (node: SVGGElement, key: string) => {
-        const group = d3.select(node);
-        const isSelected = perfRulerMode && selected.has(key);
-        const ring = group.select<SVGCircleElement>('.perf-ruler-ring');
-        if (isSelected && ring.empty()) {
-          group
-            .append('circle')
-            .attr('class', 'perf-ruler-ring')
-            .attr('r', 9)
-            .attr('fill', 'none')
-            .attr('stroke', 'var(--primary)')
-            .attr('stroke-width', 2)
-            .attr('pointer-events', 'none');
-        } else if (!isSelected && !ring.empty()) {
-          ring.remove();
-        }
-      };
-
-      zoomGroup.selectAll<SVGGElement, InferenceData>('.dot-group').each(function (d) {
-        syncRing(this, perfRulerKey(d, 'official'));
-      });
-      zoomGroup.selectAll<SVGGElement, InferenceData>('.unofficial-overlay-pt').each(function (d) {
-        syncRing(this, perfRulerKey(d, 'overlay'));
-      });
-
-      // Redraw the ruler with the currently applied zoom transform (the
-      // measurement and mode are read through refs inside drawPerfRuler).
-      const zoomCtx = currentZoomRenderContext(svg, ctx);
+      const zoomCtx = currentZoomRenderContext(display.svg, display.ctx);
       drawPerfRuler(
-        zoomGroup,
+        display.zoomGroup,
         zoomCtx.xScale as ContinuousScale,
         zoomCtx.yScale as ContinuousScale,
-        ctx.width,
+        display.ctx.width,
       );
-    }, [
-      getDisplaySelection,
-      perfRulerMode,
-      perfRulerSelection,
-      perfRulerMeasurement,
-      perfRulerKey,
-      drawPerfRuler,
-      dataIdentity,
-    ]);
+    }, [getDisplaySelection, perfRulerMode, perfRulerSelection, drawPerfRuler, dataIdentity]);
 
     // D3 custom layers are keyed additions, so removing the overlay layer from
     // the config does not delete DOM that the previous render created. Clear
@@ -3420,9 +3480,9 @@ const ScatterGraph = React.memo(
                   onCheckedChange: (checked: boolean) => {
                     setPerfRulerMode(checked);
                     // Clear in the same state batch — the pre-paint decoration
-                    // effect then removes the ruler and rings before the next
-                    // frame (no lingering line after toggle-off).
-                    if (!checked) setPerfRulerSelection([]);
+                    // effect then removes the ruler and the curve hit strokes
+                    // before the next frame (no lingering line after toggle-off).
+                    if (!checked) setPerfRulerSelection(EMPTY_PERF_RULER_SELECTION);
                     track('latency_perf_ruler_toggled', { enabled: checked });
                   },
                 },

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -59,8 +59,10 @@ import { computeTooltipPosition, syncPointShape } from '@/lib/d3-chart/layers/sc
 import {
   computeIsoXRulerGeometry,
   intersectPathAtX,
+  nextPerfRulerSelection,
   renderPerfRuler,
   type PerfRulerGeometry,
+  type PerfRulerSelectionEntry,
 } from '@/lib/d3-chart/layers/perf-ruler';
 import {
   attachOverlayXMarkerHandlers,
@@ -1326,12 +1328,8 @@ const ScatterGraph = React.memo(
     // measurement survives metric/display re-renders where the points still
     // exist. Keys distinguish official points from unofficial overlay
     // points, mirroring the dataIdentity convention.
-    interface PerfRulerClick {
-      key: string;
-      curve: string;
-    }
     const [perfRulerMode, setPerfRulerMode] = useState(false);
-    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerClick[]>([]);
+    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerSelectionEntry[]>([]);
     // Draw passes read the mode through a ref so toggling off clears the
     // ruler in the same pre-paint layout pass — the line/chip must never
     // linger a frame after the switch flips (Bugbot report on PR #853).
@@ -1424,25 +1422,17 @@ const ScatterGraph = React.memo(
       if (kept.length !== perfRulerSelection.length) setPerfRulerSelection(kept);
     }, [perfRulerMode, perfRulerSelection, perfRulerResolvedPoints]);
 
-    // Selection toggling: the first click anchors the ruler; a click on a
-    // DIFFERENT curve selects the target curve; a click on the anchor's own
-    // curve moves the anchor along it; re-clicking the anchor clears the
-    // measurement, re-clicking the target click marker drops the target
-    // only; with a complete measurement, a click on any third curve starts a
-    // new measurement anchored at that point. Ruler-mode clicks measure
-    // INSTEAD of pinning the tooltip, so drop the pin the shared click
-    // handler applied just before this callback ran.
-    const handlePerfRulerPointClick = useCallback((clicked: PerfRulerClick) => {
-      setPerfRulerSelection((prev) => {
-        const anchor = prev[0];
-        const target = prev[1];
-        if (anchor && anchor.key === clicked.key) return [];
-        if (target && target.key === clicked.key) return [anchor];
-        if (!anchor) return [clicked];
-        if (clicked.curve === anchor.curve) return target ? [clicked, target] : [clicked];
-        if (!target) return [anchor, clicked];
-        return [clicked];
-      });
+    // Selection transitions live in the pure module (see the transition
+    // table on nextPerfRulerSelection): first click anchors; a click on the
+    // anchor's curve moves the anchor; a different curve selects the target;
+    // clicks on the already-selected target curve are a no-op (the target
+    // entry identifies a CURVE, so they cannot change the iso-x result); a
+    // third curve starts a new measurement; re-clicking the exact anchor
+    // point clears. Ruler-mode clicks measure INSTEAD of pinning the
+    // tooltip, so drop the pin the shared click handler applied just before
+    // this callback ran.
+    const handlePerfRulerPointClick = useCallback((clicked: PerfRulerSelectionEntry) => {
+      setPerfRulerSelection((prev) => nextPerfRulerSelection(prev, clicked));
       chartRef.current?.dismissTooltip();
       chartRef.current?.hideTooltip();
     }, []);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -61,6 +61,7 @@ import {
   clampIsoX,
   computeIsoXRulerGeometry,
   intersectPathAtX,
+  isPerfRulerCurveVisible,
   nextPerfRulerSelection,
   pathXExtent,
   renderPerfRuler,
@@ -1358,6 +1359,7 @@ const ScatterGraph = React.memo(
       xScale: ContinuousScale;
       yScale: ContinuousScale;
       width: number;
+      height: number;
     } | null>(null);
     // Forward ref: the drag frame needs to redraw, but drawPerfRuler is
     // defined below (it also attaches the drag behavior — benign cycle).
@@ -1367,6 +1369,7 @@ const ScatterGraph = React.memo(
           xScale: ContinuousScale,
           yScale: ContinuousScale,
           width: number,
+          height: number,
         ) => void)
       | null
     >(null);
@@ -1467,7 +1470,7 @@ const ScatterGraph = React.memo(
             const d = this.getAttribute('d');
             // Curves hidden by legend/precision filters keep their paths at
             // opacity 0 — invisible curves must not be clickable.
-            if (!curve || !d || this.style.opacity === '0') return;
+            if (!curve || !d || !isPerfRulerCurveVisible(this.style.opacity)) return;
             entries.push({ curve, d });
           });
         const selected = new Set(perfRulerSelectionRef.current.curves);
@@ -1517,7 +1520,7 @@ const ScatterGraph = React.memo(
       const clamped = clampIsoX(perfRulerDragPixelXRef.current, extentA, extentB);
       if (clamped === null) return;
       perfRulerIsoXRef.current = Number(ctx.xScale.invert(clamped));
-      drawPerfRulerRef.current?.(ctx.zoomGroup, ctx.xScale, ctx.yScale, ctx.width);
+      drawPerfRulerRef.current?.(ctx.zoomGroup, ctx.xScale, ctx.yScale, ctx.width, ctx.height);
     }, []);
     const applyPerfRulerDragFrameRef = useRef(applyPerfRulerDragFrame);
     applyPerfRulerDragFrameRef.current = applyPerfRulerDragFrame;
@@ -1559,8 +1562,9 @@ const ScatterGraph = React.memo(
         xScale: ContinuousScale,
         yScale: ContinuousScale,
         width: number,
+        height: number,
       ) => {
-        perfRulerDrawCtxRef.current = { zoomGroup, xScale, yScale, width };
+        perfRulerDrawCtxRef.current = { zoomGroup, xScale, yScale, width, height };
         syncPerfRulerHitPaths(zoomGroup);
         const sel = perfRulerSelectionRef.current;
         const isoX = perfRulerIsoXRef.current;
@@ -1570,14 +1574,16 @@ const ScatterGraph = React.memo(
           // Both ends are interpolated on the RENDERED paths — the drawn
           // curve is the measurement surface, so the ruler matches it
           // exactly and stays correct under zoom (rooflines redraw before
-          // this layer runs). When either curve does not span the iso-x (or
-          // has no rendered path), draw nothing but KEEP the selection:
-          // zoom/drag/metric changes that restore both intersections bring
-          // the ruler back.
+          // this layer runs). When either curve does not span the iso-x, has
+          // no rendered path, or is hidden (legend/precision toggles keep the
+          // path in the DOM at opacity 0), draw nothing but KEEP the
+          // selection: zoom/drag/legend re-toggles that restore both visible
+          // intersections bring the ruler back.
           const ends: PerfRulerEndInput[] = [];
           for (const cls of sel.curves) {
             const node = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node();
             if (!node || typeof node.getPointAtLength !== 'function') break;
+            if (!isPerfRulerCurveVisible(node.style.opacity)) break;
             const hit = intersectPathAtX(node, pixelX);
             if (!hit) break;
             ends.push({ py: hit.y, rawY: yScale.invert(hit.y) });
@@ -1588,9 +1594,9 @@ const ScatterGraph = React.memo(
         }
         renderPerfRuler(zoomGroup, geometry, {
           color: 'var(--primary)',
-          labelBg: 'var(--primary)',
-          labelText: 'var(--primary-foreground)',
+          halo: 'var(--background)',
           chartWidth: width,
+          chartHeight: height,
         });
         // (Re)attach the horizontal drag behavior to the (possibly fresh)
         // drag handle the render pass just joined.
@@ -2832,6 +2838,7 @@ const ScatterGraph = React.memo(
             (ctx.renderedXScale ?? ctx.xScale) as ContinuousScale,
             (ctx.renderedYScale ?? ctx.yScale) as ContinuousScale,
             ctx.width,
+            ctx.height,
           ),
         onZoom: (zoomGroup, ctx) =>
           drawPerfRuler(
@@ -2839,6 +2846,7 @@ const ScatterGraph = React.memo(
             ctx.newXScale as ContinuousScale,
             ctx.newYScale as ContinuousScale,
             ctx.width,
+            ctx.height,
           ),
       };
 
@@ -3134,24 +3142,6 @@ const ScatterGraph = React.memo(
       }
     }, [getDisplaySelection, knownIssueAnnotations, getCssColor, resolveColor]);
 
-    // Perf-ruler decorations: refresh the curve hit strokes and redraw the
-    // ruler whenever the mode, selection, or underlying data changes. Narrow
-    // mutation scope — only the hit layer and the ruler group are touched;
-    // the chart itself never rebuilds for a ruler interaction. Redraws use
-    // the currently applied zoom transform (mode, selection, and iso-x are
-    // read through refs inside drawPerfRuler).
-    useLayoutEffect(() => {
-      const display = getDisplaySelection();
-      if (!display) return;
-      const zoomCtx = currentZoomRenderContext(display.svg, display.ctx);
-      drawPerfRuler(
-        display.zoomGroup,
-        zoomCtx.xScale as ContinuousScale,
-        zoomCtx.yScale as ContinuousScale,
-        display.ctx.width,
-      );
-    }, [getDisplaySelection, perfRulerMode, perfRulerSelection, drawPerfRuler, dataIdentity]);
-
     // D3 custom layers are keyed additions, so removing the overlay layer from
     // the config does not delete DOM that the previous render created. Clear
     // those marks explicitly when the last unofficial run is dismissed.
@@ -3163,6 +3153,53 @@ const ScatterGraph = React.memo(
         .selectAll('.unofficial-overlay-pt, .overlay-roofline-path, .overlay-overflow-continuation')
         .remove();
     }, [overlayData]);
+
+    // Perf-ruler decorations: refresh the curve hit strokes and redraw the
+    // ruler whenever the mode, selection, visibility filters, or underlying
+    // data change. Narrow mutation scope — only the hit layer and the ruler
+    // group are touched; the chart itself never rebuilds for a ruler
+    // interaction. Redraws use the currently applied zoom transform (mode,
+    // selection, and iso-x are read through refs inside drawPerfRuler).
+    //
+    // Ordering matters twice here — this effect is deliberately declared
+    // AFTER both (a) the mark-styling effect that writes curve opacities
+    // from the legend/precision filters, so hiding a curve clears the ruler,
+    // label, arrow, and halos in the SAME commit paint (no lingering frame),
+    // and (b) the overlay-cleanup effect above, so a dismissed overlay's
+    // paths are already gone when the ruler re-resolves.
+    useLayoutEffect(() => {
+      const display = getDisplaySelection();
+      if (!display) return;
+      const zoomCtx = currentZoomRenderContext(display.svg, display.ctx);
+      drawPerfRuler(
+        display.zoomGroup,
+        zoomCtx.xScale as ContinuousScale,
+        zoomCtx.yScale as ContinuousScale,
+        display.ctx.width,
+        display.ctx.height,
+      );
+      // Hidden-but-present curves KEEP the selection (a legend re-toggle
+      // brings the ruler back); curves whose paths left the DOM entirely are
+      // truly gone from the data, so prune them from the selection.
+      setPerfRulerSelection((prev) => {
+        if (prev.curves.length === 0) return prev;
+        const kept = prev.curves.filter(
+          (cls) => !display.zoomGroup.select(`.${CSS.escape(cls)}`).empty(),
+        );
+        if (kept.length === prev.curves.length) return prev;
+        return { curves: kept, isoX: kept.length > 0 ? prev.isoX : null };
+      });
+    }, [
+      getDisplaySelection,
+      perfRulerMode,
+      perfRulerSelection,
+      drawPerfRuler,
+      dataIdentity,
+      effectiveActiveHwTypes,
+      selectedPrecisions,
+      hideNonOptimal,
+      overlayData,
+    ]);
 
     // Dismiss tooltip on filter changes
     useEffect(() => {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -3577,6 +3577,7 @@ const ScatterGraph = React.memo(
                 {
                   id: 'scatter-perf-ruler',
                   label: legendT.perfRuler,
+                  advanced: true,
                   checked: perfRulerMode,
                   infoTooltip: legendT.perfRulerInfo,
                   onCheckedChange: (checked: boolean) => {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -56,7 +56,12 @@ import type {
 } from '@/lib/d3-chart/D3Chart/types';
 import type { ContinuousScale } from '@/lib/d3-chart/types';
 import { computeTooltipPosition, syncPointShape } from '@/lib/d3-chart/layers/scatter-points';
-import { computePerfRulerGeometry, renderPerfRuler } from '@/lib/d3-chart/layers/perf-ruler';
+import {
+  computeIsoXRulerGeometry,
+  intersectPathAtX,
+  renderPerfRuler,
+  type PerfRulerGeometry,
+} from '@/lib/d3-chart/layers/perf-ruler';
 import {
   attachOverlayXMarkerHandlers,
   overlayMarkerPosition,
@@ -342,7 +347,8 @@ const SCATTER_STRINGS = {
     gradientLabels: 'Gradient Labels',
     lineLabels: 'Line Labels',
     perfRuler: 'Perf Ruler',
-    perfRulerInfo: 'Click two points to measure the performance multiple between them.',
+    perfRulerInfo:
+      'Click a point to anchor the ruler, then click another curve to measure the performance multiple between the two curves at that same x value.',
     resetFilter: 'Reset filter',
     quickFilters: (count: number) => (count > 0 ? `Quick Filters (${count})` : 'Quick Filters'),
     overflowMixed: (count: number) => `${pointCountEn(count)} clipped`,
@@ -360,7 +366,8 @@ const SCATTER_STRINGS = {
     gradientLabels: '渐变标签',
     lineLabels: '曲线标签',
     perfRuler: '性能标尺',
-    perfRulerInfo: '点击两个数据点，测量二者之间的性能倍数。',
+    perfRulerInfo:
+      '先点击一个数据点固定标尺，再点击另一条曲线，测量两条曲线在同一横坐标处的性能倍数。',
     resetFilter: '重置筛选',
     quickFilters: (count: number) => (count > 0 ? `快捷筛选（${count}）` : '快捷筛选'),
     overflowMixed: (count: number) => `${count} 个点已截断`,
@@ -1310,13 +1317,26 @@ const ScatterGraph = React.memo(
       logAvailability: persistedLogAvailability,
     };
 
-    // --- Perf ruler (opt-in: click two points, measure the y-value multiple) ---
-    // Selection stores stable point keys (not indices) so the measurement
-    // survives metric/display re-renders where the points still exist. Keys
-    // distinguish official points from unofficial overlay points, mirroring
-    // the dataIdentity convention.
+    // --- Perf ruler (opt-in: anchor a point, measure the iso-x multiple to another curve) ---
+    // ISO-X semantics: the FIRST selection entry is the anchor point — it
+    // defines the ruler's x position and one end. The SECOND entry only
+    // selects the target CURVE; the ruler's other end is that curve's
+    // rendered-roofline intersection at the anchor's x, not the clicked
+    // point. Selection stores stable point keys (not indices) so the
+    // measurement survives metric/display re-renders where the points still
+    // exist. Keys distinguish official points from unofficial overlay
+    // points, mirroring the dataIdentity convention.
+    interface PerfRulerClick {
+      key: string;
+      curve: string;
+    }
     const [perfRulerMode, setPerfRulerMode] = useState(false);
-    const [perfRulerSelection, setPerfRulerSelection] = useState<string[]>([]);
+    const [perfRulerSelection, setPerfRulerSelection] = useState<PerfRulerClick[]>([]);
+    // Draw passes read the mode through a ref so toggling off clears the
+    // ruler in the same pre-paint layout pass — the line/chip must never
+    // linger a frame after the switch flips (Bugbot report on PR #853).
+    const perfRulerModeRef = useRef(perfRulerMode);
+    perfRulerModeRef.current = perfRulerMode;
 
     const perfRulerKey = useCallback(
       (point: InferenceData, source: 'official' | 'overlay') =>
@@ -1324,6 +1344,20 @@ const ScatterGraph = React.memo(
           ? `official:${buildPointId(point)}`
           : `overlay:${buildPointId(point)}:${point.run_url ?? ''}`,
       [buildPointId],
+    );
+
+    // Curve identity for click semantics: a second click on the SAME curve
+    // moves the anchor; a different curve selects the measurement target.
+    // Official curves are (hw, precision, date) — comparison-date sub-curves
+    // are distinct targets (measuring a config against its own earlier date
+    // is a legitimate regression check). Overlay curves are per (hw,
+    // precision, run), matching the overlayRooflines grouping.
+    const perfRulerCurve = useCallback(
+      (point: InferenceData, source: 'official' | 'overlay') =>
+        source === 'official'
+          ? `official-curve:${String(point.hwKey)}_${point.precision}__${point.date}`
+          : `overlay-curve:${String(point.hwKey)}_${point.precision}:${point.run_url ?? ''}`,
+      [],
     );
 
     // Resolve each selected key to its current point object (raw x/y follow
@@ -1343,7 +1377,7 @@ const ScatterGraph = React.memo(
           ) ?? null
         );
       };
-      return perfRulerSelection.map(resolve);
+      return perfRulerSelection.map((entry) => resolve(entry.key));
     }, [
       perfRulerSelection,
       pointsData,
@@ -1353,13 +1387,31 @@ const ScatterGraph = React.memo(
       isOverlayPointVisible,
     ]);
 
-    const perfRulerMeasuredPair = useMemo(() => {
+    // Anchor point plus the target curve's roofline path class candidates.
+    // The path node is resolved from the DOM at draw time: the RENDERED path
+    // is the measurement surface, so the intersection matches the drawn
+    // curve exactly and stays correct under zoom (paths are redrawn with the
+    // new scales before this layer runs — rooflines render first).
+    const perfRulerMeasurement = useMemo(() => {
       if (perfRulerSelection.length !== 2) return null;
-      const [a, b] = perfRulerResolvedPoints;
-      return a && b ? ([a, b] as const) : null;
-    }, [perfRulerSelection, perfRulerResolvedPoints]);
-    const perfRulerPairRef = useRef(perfRulerMeasuredPair);
-    perfRulerPairRef.current = perfRulerMeasuredPair;
+      const [anchor, target] = perfRulerResolvedPoints;
+      if (!anchor || !target) return null;
+      const targetClasses: string[] = [];
+      if (perfRulerSelection[1].key.startsWith('overlay:')) {
+        const runIndex = overlayRunIndex(target.run_url ?? null, runIndexByUrl);
+        targetClasses.push(
+          `overlay-roofline-${String(target.hwKey)}_${target.precision}_run${runIndex}`,
+        );
+      } else {
+        const base = `${String(target.hwKey)}_${target.precision}`;
+        // A single comparison date renders `roofline-<key>`; multiple dates
+        // split into `roofline-<key>__<date>` sub-paths — try both.
+        targetClasses.push(`roofline-${base}`, `roofline-${base}__${target.date}`);
+      }
+      return { anchor, targetClasses };
+    }, [perfRulerSelection, perfRulerResolvedPoints, runIndexByUrl]);
+    const perfRulerMeasurementRef = useRef(perfRulerMeasurement);
+    perfRulerMeasurementRef.current = perfRulerMeasurement;
 
     // Clear the measurement when the toggle turns off; drop any selected
     // point that disappeared (data/filter change) while keeping the other.
@@ -1372,16 +1424,24 @@ const ScatterGraph = React.memo(
       if (kept.length !== perfRulerSelection.length) setPerfRulerSelection(kept);
     }, [perfRulerMode, perfRulerSelection, perfRulerResolvedPoints]);
 
-    // Selection toggling: first click selects, second click on another point
-    // completes the measurement, a third click starts a new measurement from
-    // that point, re-clicking a selected point deselects it. Ruler-mode
-    // clicks measure INSTEAD of pinning the tooltip, so drop the pin the
-    // shared click handler applied just before this callback ran.
-    const handlePerfRulerPointClick = useCallback((key: string) => {
+    // Selection toggling: the first click anchors the ruler; a click on a
+    // DIFFERENT curve selects the target curve; a click on the anchor's own
+    // curve moves the anchor along it; re-clicking the anchor clears the
+    // measurement, re-clicking the target click marker drops the target
+    // only; with a complete measurement, a click on any third curve starts a
+    // new measurement anchored at that point. Ruler-mode clicks measure
+    // INSTEAD of pinning the tooltip, so drop the pin the shared click
+    // handler applied just before this callback ran.
+    const handlePerfRulerPointClick = useCallback((clicked: PerfRulerClick) => {
       setPerfRulerSelection((prev) => {
-        if (prev.includes(key)) return prev.filter((k) => k !== key);
-        if (prev.length >= 2) return [key];
-        return [...prev, key];
+        const anchor = prev[0];
+        const target = prev[1];
+        if (anchor && anchor.key === clicked.key) return [];
+        if (target && target.key === clicked.key) return [anchor];
+        if (!anchor) return [clicked];
+        if (clicked.curve === anchor.curve) return target ? [clicked, target] : [clicked];
+        if (!target) return [anchor, clicked];
+        return [clicked];
       });
       chartRef.current?.dismissTooltip();
       chartRef.current?.hideTooltip();
@@ -1393,16 +1453,20 @@ const ScatterGraph = React.memo(
       mode: perfRulerMode,
       onPointClick: handlePerfRulerPointClick,
       keyFor: perfRulerKey,
+      curveFor: perfRulerCurve,
     });
     perfRulerRef.current = {
       mode: perfRulerMode,
       onPointClick: handlePerfRulerPointClick,
       keyFor: perfRulerKey,
+      curveFor: perfRulerCurve,
     };
 
-    // Draw (or clear) the ruler from the currently resolved pair. Stable
+    // Draw (or clear) the ruler from the current measurement. Stable
     // callback so the custom layer can live outside the perf-ruler state
-    // dependencies — render/zoom passes read the pair through the ref.
+    // dependencies — render/zoom passes read mode and the measurement
+    // through refs. Gated on the mode ref so a toggle-off clears the ruler
+    // in the very next draw, before the selection-prune state settles.
     const drawPerfRuler = useCallback(
       (
         zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
@@ -1410,13 +1474,33 @@ const ScatterGraph = React.memo(
         yScale: ContinuousScale,
         width: number,
       ) => {
-        const pair = perfRulerPairRef.current;
-        const geometry = pair
-          ? computePerfRulerGeometry(
-              { px: xScale(pair[0].x), py: yScale(pair[0].y), rawY: pair[0].y },
-              { px: xScale(pair[1].x), py: yScale(pair[1].y), rawY: pair[1].y },
-            )
-          : null;
+        const measurement = perfRulerModeRef.current ? perfRulerMeasurementRef.current : null;
+        let geometry: PerfRulerGeometry | null = null;
+        if (measurement) {
+          const { anchor, targetClasses } = measurement;
+          let pathNode: SVGPathElement | null = null;
+          for (const cls of targetClasses) {
+            const node = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`).node();
+            if (node) {
+              pathNode = node;
+              break;
+            }
+          }
+          // When the target curve does not span the anchor's x (or has no
+          // rendered path — e.g. a single-point series), draw nothing but
+          // KEEP the selection: zoom/metric changes that make them
+          // intersect bring the ruler back.
+          if (pathNode && typeof pathNode.getPointAtLength === 'function') {
+            const anchorPx = xScale(anchor.x);
+            const hit = intersectPathAtX(pathNode, anchorPx);
+            if (hit) {
+              geometry = computeIsoXRulerGeometry(
+                { px: anchorPx, py: yScale(anchor.y), rawY: anchor.y },
+                { py: hit.y, rawY: yScale.invert(hit.y) },
+              );
+            }
+          }
+        }
         renderPerfRuler(zoomGroup, geometry, {
           color: 'var(--primary)',
           labelBg: 'var(--primary)',
@@ -1601,7 +1685,10 @@ const ScatterGraph = React.memo(
               y: d.y,
               perfRuler: true,
             });
-            ruler.onPointClick(ruler.keyFor(d, 'official'));
+            ruler.onPointClick({
+              key: ruler.keyFor(d, 'official'),
+              curve: ruler.curveFor(d, 'official'),
+            });
             return;
           }
           track('latency_data_point_clicked', { hw: String(d.hwKey), x: d.x, y: d.y });
@@ -2424,7 +2511,10 @@ const ScatterGraph = React.memo(
                       overlay: true,
                       perfRuler: true,
                     });
-                    ruler.onPointClick(ruler.keyFor(point, 'overlay'));
+                    ruler.onPointClick({
+                      key: ruler.keyFor(point, 'overlay'),
+                      curve: ruler.curveFor(point, 'overlay'),
+                    });
                     return;
                   }
                   track('latency_data_point_clicked', {
@@ -2640,8 +2730,8 @@ const ScatterGraph = React.memo(
         };
       });
 
-      // ── Perf ruler (opt-in measurement between two selected points) ──
-      // Selection state is read through perfRulerPairRef, so this layer needs
+      // ── Perf ruler (opt-in iso-x measurement between two curves) ──
+      // Mode and measurement are read through refs, so this layer needs
       // no perf-ruler dependencies: full re-renders redraw it after the data
       // phase (it survives metric/display re-renders where the points still
       // exist), and onZoom keeps it glued to the points during pan/zoom. It
@@ -2966,7 +3056,7 @@ const ScatterGraph = React.memo(
       const display = getDisplaySelection();
       if (!display) return;
       const { svg, ctx, zoomGroup } = display;
-      const selected = new Set(perfRulerSelection);
+      const selected = new Set(perfRulerSelection.map((entry) => entry.key));
 
       const syncRing = (node: SVGGElement, key: string) => {
         const group = d3.select(node);
@@ -2994,7 +3084,7 @@ const ScatterGraph = React.memo(
       });
 
       // Redraw the ruler with the currently applied zoom transform (the
-      // measured pair is read through perfRulerPairRef inside drawPerfRuler).
+      // measurement and mode are read through refs inside drawPerfRuler).
       const zoomCtx = currentZoomRenderContext(svg, ctx);
       drawPerfRuler(
         zoomGroup,
@@ -3006,7 +3096,7 @@ const ScatterGraph = React.memo(
       getDisplaySelection,
       perfRulerMode,
       perfRulerSelection,
-      perfRulerMeasuredPair,
+      perfRulerMeasurement,
       perfRulerKey,
       drawPerfRuler,
       dataIdentity,
@@ -3339,6 +3429,10 @@ const ScatterGraph = React.memo(
                   infoTooltip: legendT.perfRulerInfo,
                   onCheckedChange: (checked: boolean) => {
                     setPerfRulerMode(checked);
+                    // Clear in the same state batch — the pre-paint decoration
+                    // effect then removes the ruler and rings before the next
+                    // frame (no lingering line after toggle-off).
+                    if (!checked) setPerfRulerSelection([]);
                     track('latency_perf_ruler_toggled', { enabled: checked });
                   },
                 },

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -3,18 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { createMockGroup } from './test-helpers';
 import {
   DEFAULT_MIN_SPAN_FOR_PERCENT,
-  computePerfRulerGeometry,
+  computeIsoXRulerGeometry,
   formatPerfPercent,
   formatPerfRatio,
+  intersectPathAtX,
   renderPerfRuler,
+  type PerfRulerPathLike,
   type PerfRulerPointInput,
   type PerfRulerRenderOptions,
+  type PerfRulerTargetInput,
 } from './perf-ruler';
 
 // ── Fixtures ─────────────────────────────────────────────────────────
 
-const POINT_A: PerfRulerPointInput = { px: 100, py: 50, rawY: 400 };
-const POINT_B: PerfRulerPointInput = { px: 140, py: 150, rawY: 197 };
+const ANCHOR: PerfRulerPointInput = { px: 100, py: 50, rawY: 400 };
+const TARGET: PerfRulerTargetInput = { py: 150, rawY: 197 };
 
 function makeOpts(overrides?: Partial<PerfRulerRenderOptions>): PerfRulerRenderOptions {
   return {
@@ -22,6 +25,39 @@ function makeOpts(overrides?: Partial<PerfRulerRenderOptions>): PerfRulerRenderO
     labelBg: 'var(--primary)',
     labelText: 'var(--primary-foreground)',
     ...overrides,
+  };
+}
+
+/**
+ * Synthetic polyline implementation of the SVGPathElement length API — jsdom
+ * has no getTotalLength/getPointAtLength, so intersection tests drive the
+ * binary search through this instead of a real path node.
+ */
+function polylinePath(vertices: { x: number; y: number }[]): PerfRulerPathLike {
+  const lengths: number[] = [0];
+  for (let i = 1; i < vertices.length; i++) {
+    lengths.push(
+      lengths[i - 1] +
+        Math.hypot(vertices[i].x - vertices[i - 1].x, vertices[i].y - vertices[i - 1].y),
+    );
+  }
+  const total = vertices.length > 0 ? (lengths.at(-1) ?? 0) : 0;
+  return {
+    getTotalLength: () => total,
+    getPointAtLength(length: number) {
+      const clamped = Math.min(Math.max(length, 0), total);
+      for (let i = 1; i < vertices.length; i++) {
+        if (clamped <= lengths[i]) {
+          const segLen = lengths[i] - lengths[i - 1];
+          const t = segLen === 0 ? 0 : (clamped - lengths[i - 1]) / segLen;
+          return {
+            x: vertices[i - 1].x + (vertices[i].x - vertices[i - 1].x) * t,
+            y: vertices[i - 1].y + (vertices[i].y - vertices[i - 1].y) * t,
+          };
+        }
+      }
+      return vertices.at(-1) ?? { x: Number.NaN, y: Number.NaN };
+    },
   };
 }
 
@@ -64,32 +100,141 @@ describe('formatPerfPercent', () => {
   });
 });
 
-// ── computePerfRulerGeometry ─────────────────────────────────────────
+// ── intersectPathAtX ─────────────────────────────────────────────────
 
-describe('computePerfRulerGeometry', () => {
-  it('places the line at the pixel midpoint spanning both y positions', () => {
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B);
+describe('intersectPathAtX', () => {
+  it('finds the mid-segment intersection on a single-segment path', () => {
+    const path = polylinePath([
+      { x: 0, y: 100 },
+      { x: 100, y: 0 },
+    ]);
+    const hit = intersectPathAtX(path, 50);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBeCloseTo(50, 0);
+    expect(hit!.y).toBeCloseTo(50, 0);
+  });
+
+  it('interpolates within the correct segment of a multi-segment curve', () => {
+    const path = polylinePath([
+      { x: 0, y: 200 },
+      { x: 100, y: 100 },
+      { x: 300, y: 50 },
+    ]);
+    const hit = intersectPathAtX(path, 200);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBeCloseTo(200, 0);
+    expect(hit!.y).toBeCloseTo(75, 1);
+  });
+
+  it('hits interior vertices exactly', () => {
+    const path = polylinePath([
+      { x: 0, y: 200 },
+      { x: 100, y: 100 },
+      { x: 300, y: 50 },
+    ]);
+    const hit = intersectPathAtX(path, 100);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBeCloseTo(100, 0);
+    expect(hit!.y).toBeCloseTo(100, 0);
+  });
+
+  it('supports paths whose x decreases along their length', () => {
+    const path = polylinePath([
+      { x: 300, y: 10 },
+      { x: 100, y: 110 },
+    ]);
+    const hit = intersectPathAtX(path, 200);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBeCloseTo(200, 0);
+    expect(hit!.y).toBeCloseTo(60, 0);
+  });
+
+  it('returns null when x lies outside the path x extent', () => {
+    const path = polylinePath([
+      { x: 100, y: 100 },
+      { x: 300, y: 50 },
+    ]);
+    expect(intersectPathAtX(path, 50)).toBeNull();
+    expect(intersectPathAtX(path, 350)).toBeNull();
+  });
+
+  it('still intersects at the endpoints (within half-pixel slack)', () => {
+    const path = polylinePath([
+      { x: 100, y: 100 },
+      { x: 300, y: 50 },
+    ]);
+    const atStart = intersectPathAtX(path, 100);
+    expect(atStart).not.toBeNull();
+    expect(atStart!.y).toBeCloseTo(100, 0);
+    const nearEnd = intersectPathAtX(path, 300.4);
+    expect(nearEnd).not.toBeNull();
+    expect(nearEnd!.y).toBeCloseTo(50, 0);
+  });
+
+  it('converges tightly on shallow curves approximated by many segments', () => {
+    // y = 10000 / x sampled on [50, 500] — a hyperbola like a latency curve.
+    const vertices = Array.from({ length: 91 }, (_v, i) => {
+      const x = 50 + i * 5;
+      return { x, y: 10000 / x };
+    });
+    const path = polylinePath(vertices);
+    const hit = intersectPathAtX(path, 250);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBeCloseTo(250, 0);
+    expect(hit!.y).toBeCloseTo(40, 0);
+  });
+
+  it('returns a point on a vertical (constant-x) path instead of diverging', () => {
+    const path = polylinePath([
+      { x: 50, y: 0 },
+      { x: 50, y: 100 },
+    ]);
+    const hit = intersectPathAtX(path, 50);
+    expect(hit).not.toBeNull();
+    expect(hit!.x).toBe(50);
+  });
+
+  it('returns null for degenerate paths and non-finite x', () => {
+    expect(intersectPathAtX(polylinePath([{ x: 10, y: 10 }]), 10)).toBeNull();
+    expect(intersectPathAtX(polylinePath([]), 10)).toBeNull();
+    const path = polylinePath([
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+    ]);
+    expect(intersectPathAtX(path, Number.NaN)).toBeNull();
+  });
+});
+
+// ── computeIsoXRulerGeometry ─────────────────────────────────────────
+
+describe('computeIsoXRulerGeometry', () => {
+  it('places the line at the anchor x, spanning anchor y to the intersection y', () => {
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET);
     expect(geometry).not.toBeNull();
-    expect(geometry!.x).toBe(120);
+    expect(geometry!.x).toBe(100);
     expect(geometry!.y1).toBe(50);
     expect(geometry!.y2).toBe(150);
   });
 
   it('computes the ratio from raw y values, higher over lower', () => {
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B);
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET);
     expect(geometry!.ratio).toBeCloseTo(400 / 197, 10);
     expect(geometry!.ratioLabel).toBe('2.03x');
     expect(geometry!.percentLabel).toBe('+103%');
   });
 
-  it('is symmetric in argument order', () => {
-    const forward = computePerfRulerGeometry(POINT_A, POINT_B);
-    const reverse = computePerfRulerGeometry(POINT_B, POINT_A);
-    expect(reverse).toEqual(forward);
+  it('yields the same ratio when the target curve is the faster side', () => {
+    const fromSlowAnchor = computeIsoXRulerGeometry(
+      { px: 100, py: 150, rawY: 197 },
+      { py: 50, rawY: 400 },
+    );
+    expect(fromSlowAnchor!.ratio).toBeCloseTo(400 / 197, 10);
+    expect(fromSlowAnchor!.y1).toBe(50);
+    expect(fromSlowAnchor!.y2).toBe(150);
   });
 
-  it('handles an equal pair (ratio 1, zero-height span)', () => {
-    const geometry = computePerfRulerGeometry(POINT_A, { ...POINT_A });
+  it('handles the curves crossing at the anchor x (ratio 1, zero-height span)', () => {
+    const geometry = computeIsoXRulerGeometry(ANCHOR, { py: ANCHOR.py, rawY: ANCHOR.rawY });
     expect(geometry).not.toBeNull();
     expect(geometry!.ratio).toBe(1);
     expect(geometry!.ratioLabel).toBe('1.00x');
@@ -98,16 +243,16 @@ describe('computePerfRulerGeometry', () => {
   });
 
   it('returns null when either raw y is zero or negative', () => {
-    expect(computePerfRulerGeometry(POINT_A, { ...POINT_B, rawY: 0 })).toBeNull();
-    expect(computePerfRulerGeometry({ ...POINT_A, rawY: -5 }, POINT_B)).toBeNull();
+    expect(computeIsoXRulerGeometry(ANCHOR, { ...TARGET, rawY: 0 })).toBeNull();
+    expect(computeIsoXRulerGeometry({ ...ANCHOR, rawY: -5 }, TARGET)).toBeNull();
   });
 
   it('returns null for non-finite inputs', () => {
-    expect(computePerfRulerGeometry({ ...POINT_A, px: Number.NaN }, POINT_B)).toBeNull();
+    expect(computeIsoXRulerGeometry({ ...ANCHOR, px: Number.NaN }, TARGET)).toBeNull();
     expect(
-      computePerfRulerGeometry(POINT_A, { ...POINT_B, py: Number.POSITIVE_INFINITY }),
+      computeIsoXRulerGeometry(ANCHOR, { ...TARGET, py: Number.POSITIVE_INFINITY }),
     ).toBeNull();
-    expect(computePerfRulerGeometry(POINT_A, { ...POINT_B, rawY: Number.NaN })).toBeNull();
+    expect(computeIsoXRulerGeometry(ANCHOR, { ...TARGET, rawY: Number.NaN })).toBeNull();
   });
 });
 
@@ -116,7 +261,7 @@ describe('computePerfRulerGeometry', () => {
 describe('renderPerfRuler', () => {
   it('draws the ruler line, two end caps, chip, and label texts', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');
@@ -130,24 +275,24 @@ describe('renderPerfRuler', () => {
     expect(children).toContain('pr-text pr-text-percent');
   });
 
-  it('positions the vertical line and caps from geometry', () => {
+  it('positions the vertical line and caps at the anchor x', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts({ capHalfWidth: 6 }));
 
     const ruler = group.selectAll('.perf-ruler');
     const byClass = (cls: string) =>
       ruler.elements[0].children.find((c) => String(c.attrs['class']) === cls)!;
     const line = byClass('pr-line');
-    expect(line.attrs['x1']).toBe(120);
-    expect(line.attrs['x2']).toBe(120);
+    expect(line.attrs['x1']).toBe(100);
+    expect(line.attrs['x2']).toBe(100);
     expect(line.attrs['y1']).toBe(50);
     expect(line.attrs['y2']).toBe(150);
     expect(line.attrs['stroke']).toBe('var(--primary)');
 
     const capTop = byClass('pr-cap pr-cap-top');
-    expect(capTop.attrs['x1']).toBe(114);
-    expect(capTop.attrs['x2']).toBe(126);
+    expect(capTop.attrs['x1']).toBe(94);
+    expect(capTop.attrs['x2']).toBe(106);
     expect(capTop.attrs['y1']).toBe(50);
     expect(capTop.attrs['y2']).toBe(50);
 
@@ -158,7 +303,7 @@ describe('renderPerfRuler', () => {
 
   it('writes the ratio label and shows the percent line for a tall span', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     expect(Math.abs(geometry.y2 - geometry.y1)).toBeGreaterThanOrEqual(
       DEFAULT_MIN_SPAN_FOR_PERCENT,
     );
@@ -175,7 +320,7 @@ describe('renderPerfRuler', () => {
 
   it('hides the percent line when the span is too short to fit it cleanly', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, { ...POINT_B, py: POINT_A.py + 10 })!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, { ...TARGET, py: ANCHOR.py + 10 })!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');
@@ -188,7 +333,7 @@ describe('renderPerfRuler', () => {
 
   it('places the chip to the right of the line by default', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800 }));
 
     const ruler = group.selectAll('.perf-ruler');
@@ -199,7 +344,7 @@ describe('renderPerfRuler', () => {
 
   it('flips the chip to the left near the right chart edge', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 125 }));
 
     const ruler = group.selectAll('.perf-ruler');
@@ -210,7 +355,7 @@ describe('renderPerfRuler', () => {
 
   it('is idempotent: re-rendering keeps a single ruler group', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts());
     renderPerfRuler(group as any, { ...geometry, x: 200 }, makeOpts());
 
@@ -222,7 +367,7 @@ describe('renderPerfRuler', () => {
 
   it('clears the ruler when geometry is null', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts());
     renderPerfRuler(group as any, null, makeOpts());
 
@@ -238,7 +383,7 @@ describe('renderPerfRuler', () => {
 
   it('disables pointer events so the ruler never blocks point clicks', () => {
     const group = createMockGroup();
-    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -1,22 +1,31 @@
 import { describe, expect, it } from 'vitest';
 
-import { createMockGroup } from './test-helpers';
+import { createMockGroup, type MockSelection } from './test-helpers';
 import {
   DEFAULT_LABEL_FONT_SIZE,
-  EMPTY_PERF_RULER_SELECTION,
+  EMPTY_PERF_RULER_STATE,
+  MAX_PERF_RULERS,
   clampIsoX,
+  clearPerfRulers,
   computeIsoXRulerGeometry,
   computePerfRulerLabelLayout,
+  computePerfRulerLabelLayouts,
+  deletePerfRuler,
   formatPerfRatio,
   intersectPathAtX,
   isPerfRulerCurveVisible,
-  nextPerfRulerSelection,
+  movePerfRulerIsoX,
+  nextPerfRulerState,
   pathXExtent,
-  renderPerfRuler,
-  type PerfRulerCurveSelection,
+  perfRulerCurveSet,
+  prunePerfRulers,
+  renderPerfRulers,
   type PerfRulerEndInput,
+  type PerfRulerGeometry,
+  type PerfRulerLabelLayoutOptions,
   type PerfRulerPathLike,
   type PerfRulerRenderOptions,
+  type PerfRulerState,
 } from './perf-ruler';
 
 // ── Fixtures ─────────────────────────────────────────
@@ -329,15 +338,81 @@ describe('computePerfRulerLabelLayout', () => {
     expect(computePerfRulerLabelLayout(tall, { fontSize: 12 }).labelY).toBeLessThan(150);
     expect(small.labelY).toBeGreaterThan(50);
   });
+
+  it('anchors the × delete button just past the label, at the label height', () => {
+    const right = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 800, chartHeight: 400 });
+    expect(right.side).toBe(1);
+    expect(right.deleteX).toBeGreaterThan(right.labelX);
+    expect(right.deleteY).toBe(right.labelY);
+    const left = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 125, chartHeight: 400 });
+    expect(left.side).toBe(-1);
+    expect(left.deleteX).toBeLessThan(left.labelX);
+    expect(left.deleteY).toBe(left.labelY);
+  });
 });
 
-// ── renderPerfRuler ────────────────────────────────────────────────────
+// ── computePerfRulerLabelLayouts ──────────────────────────────────
 
-describe('renderPerfRuler', () => {
-  it('draws the ruler line, end caps, arrow, big ratio label, and drag handle', () => {
+describe('computePerfRulerLabelLayouts', () => {
+  const GEOMETRY = { x: 100, y1: 50, y2: 150, ratioLabel: '2.03x' };
+  const OPTS = { chartWidth: 800, chartHeight: 400 };
+
+  it('matches the single-label layout when there is no collision', () => {
+    const [only] = computePerfRulerLabelLayouts([GEOMETRY], OPTS);
+    expect(only).toEqual(computePerfRulerLabelLayout(GEOMETRY, OPTS));
+  });
+
+  it('passes null geometries through, keeping array positions aligned', () => {
+    const layouts = computePerfRulerLabelLayouts([null, GEOMETRY, null], OPTS);
+    expect(layouts).toHaveLength(3);
+    expect(layouts[0]).toBeNull();
+    expect(layouts[1]).not.toBeNull();
+    expect(layouts[2]).toBeNull();
+  });
+
+  it('nudges the second of two colliding labels vertically apart', () => {
+    const [first, second] = computePerfRulerLabelLayouts([GEOMETRY, { ...GEOMETRY }], OPTS);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(second!.labelY).not.toBe(first!.labelY);
+    expect(Math.abs(second!.labelY - first!.labelY)).toBeGreaterThanOrEqual(
+      DEFAULT_LABEL_FONT_SIZE + 8,
+    );
+    // The nudged label's arrow and × follow it.
+    expect(second!.deleteY).toBe(second!.labelY);
+    expect(second!.arrowPath).not.toBe(first!.arrowPath);
+  });
+
+  it('leaves far-apart labels untouched', () => {
+    const other = { x: 500, y1: 250, y2: 350, ratioLabel: '1.50x' };
+    const [first, second] = computePerfRulerLabelLayouts([GEOMETRY, other], OPTS);
+    expect(first).toEqual(computePerfRulerLabelLayout(GEOMETRY, OPTS));
+    expect(second).toEqual(computePerfRulerLabelLayout(other, OPTS));
+  });
+});
+
+// ── renderPerfRulers ───────────────────────────────────────────────────
+
+/** Render one ruler (id 1) with its layout computed like the caller does. */
+function renderSingle(
+  group: MockSelection,
+  geometry: PerfRulerGeometry | null,
+  opts?: Partial<PerfRulerRenderOptions>,
+  layoutOpts?: PerfRulerLabelLayoutOptions,
+): void {
+  const entries = [];
+  if (geometry) {
+    const [layout] = computePerfRulerLabelLayouts([geometry], layoutOpts);
+    entries.push({ id: 1, geometry, layout: layout! });
+  }
+  renderPerfRulers(group as any, entries, makeOpts(opts));
+}
+
+describe('renderPerfRulers', () => {
+  it('draws the ruler line, end caps, arrow, big ratio label, drag handle, and ×', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts());
+    renderSingle(group, geometry);
 
     const ruler = group.selectAll('.perf-ruler');
     expect(ruler.elements).toHaveLength(1);
@@ -349,6 +424,7 @@ describe('renderPerfRuler', () => {
     expect(children).toContain('pr-arrow-head');
     expect(children).toContain('pr-text pr-text-ratio');
     expect(children).toContain('pr-drag');
+    expect(children).toContain('pr-delete no-export');
     // The chip rect and secondary percent line are gone in the big-label
     // design.
     expect(children).not.toContain('pr-bg');
@@ -358,7 +434,7 @@ describe('renderPerfRuler', () => {
   it('positions the vertical line and caps at the iso-x', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ capHalfWidth: 6 }));
+    renderSingle(group, geometry, { capHalfWidth: 6 });
 
     const ruler = group.selectAll('.perf-ruler');
     const byClass = (cls: string) =>
@@ -384,7 +460,7 @@ describe('renderPerfRuler', () => {
   it('overlays an invisible wide drag handle spanning the ruler line', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts());
+    renderSingle(group, geometry);
 
     const ruler = group.selectAll('.perf-ruler');
     const drag = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-drag')!;
@@ -403,7 +479,7 @@ describe('renderPerfRuler', () => {
   it('writes the big ratio label in the accent color with a readability halo', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800, chartHeight: 400 }));
+    renderSingle(group, geometry, undefined, { chartWidth: 800, chartHeight: 400 });
 
     const ruler = group.selectAll('.perf-ruler');
     const byClass = (cls: string) =>
@@ -422,7 +498,7 @@ describe('renderPerfRuler', () => {
   it('honors a custom halo color and font size', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ halo: 'white', labelFontSize: 40 }));
+    renderSingle(group, geometry, { halo: 'white', labelFontSize: 40 });
 
     const ruler = group.selectAll('.perf-ruler');
     const label = ruler.elements[0].children.find(
@@ -435,7 +511,7 @@ describe('renderPerfRuler', () => {
   it('draws the arrow curve and filled head in the accent color', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800, chartHeight: 400 }));
+    renderSingle(group, geometry, undefined, { chartWidth: 800, chartHeight: 400 });
 
     const ruler = group.selectAll('.perf-ruler');
     const byClass = (cls: string) =>
@@ -453,7 +529,7 @@ describe('renderPerfRuler', () => {
   it('places the label right of the line by default', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800 }));
+    renderSingle(group, geometry, undefined, { chartWidth: 800 });
 
     const ruler = group.selectAll('.perf-ruler');
     const label = ruler.elements[0].children.find(
@@ -466,7 +542,7 @@ describe('renderPerfRuler', () => {
   it('flips the label to the left near the right chart edge', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 125 }));
+    renderSingle(group, geometry, undefined, { chartWidth: 125 });
 
     const ruler = group.selectAll('.perf-ruler');
     const label = ruler.elements[0].children.find(
@@ -479,8 +555,8 @@ describe('renderPerfRuler', () => {
   it('is idempotent: re-rendering keeps a single ruler group', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts());
-    renderPerfRuler(group as any, { ...geometry, x: 200 }, makeOpts());
+    renderSingle(group, geometry);
+    renderSingle(group, { ...geometry, x: 200 });
 
     const ruler = group.selectAll('.perf-ruler');
     expect(ruler.elements).toHaveLength(1);
@@ -488,97 +564,254 @@ describe('renderPerfRuler', () => {
     expect(line.attrs['x1']).toBe(200);
   });
 
-  it('clears the ruler when geometry is null', () => {
+  it('renders one group per ruler and removes exited rulers', () => {
+    const group = createMockGroup();
+    const geometryA = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    const geometryB = computeIsoXRulerGeometry(300, { py: 40, rawY: 900 }, { py: 90, rawY: 300 })!;
+    const layouts = computePerfRulerLabelLayouts([geometryA, geometryB], { chartWidth: 800 });
+    const entries = [
+      { id: 1, geometry: geometryA, layout: layouts[0]! },
+      { id: 2, geometry: geometryB, layout: layouts[1]! },
+    ];
+    renderPerfRulers(group as any, entries, makeOpts());
+    expect(group.selectAll('.perf-ruler').elements).toHaveLength(2);
+
+    renderPerfRulers(group as any, entries.slice(0, 1), makeOpts());
+    expect(group.selectAll('.perf-ruler').elements).toHaveLength(1);
+  });
+
+  it('clears all rulers when the entry list is empty', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts());
-    renderPerfRuler(group as any, null, makeOpts());
+    renderSingle(group, geometry);
+    renderSingle(group, null);
 
     const ruler = group.selectAll('.perf-ruler');
     expect(ruler.elements).toHaveLength(0);
   });
 
-  it('renders nothing when called with null on an empty group', () => {
+  it('renders nothing when called with no entries on an empty group', () => {
     const group = createMockGroup();
-    renderPerfRuler(group as any, null, makeOpts());
+    renderSingle(group, null);
     expect(group.selectAll('.perf-ruler').elements).toHaveLength(0);
   });
 
   it('disables pointer events so the ruler never blocks point clicks', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    renderPerfRuler(group as any, geometry, makeOpts());
+    renderSingle(group, geometry);
 
     const ruler = group.selectAll('.perf-ruler');
     expect(ruler.elements[0].styles['pointer-events']).toBe('none');
+    // …while the big label opts back in so it can reveal the × on hover.
+    const label = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-text pr-text-ratio',
+    )!;
+    expect(label.styles['pointer-events']).toBe('auto');
+  });
+
+  it('hides the × delete button by default and marks it no-export', () => {
+    const group = createMockGroup();
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    renderSingle(group, geometry);
+
+    const ruler = group.selectAll('.perf-ruler');
+    const del = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-delete no-export',
+    )!;
+    // Hidden until hover; excluded from PNG exports via `no-export`.
+    expect(del.styles['display']).toBe('none');
+    expect(del.styles['pointer-events']).toBe('all');
+    expect(del.styles['cursor']).toBe('pointer');
+    const classes = String(del.attrs['class']).split(/\s+/u);
+    expect(classes).toContain('pr-delete');
+    expect(classes).toContain('no-export');
+    // Circular chip + × glyph in contrast colors.
+    const bg = del.children.find((c) => String(c.attrs['class']) === 'pr-delete-bg')!;
+    expect(bg.tag).toBe('circle');
+    expect(Number(bg.attrs['r'])).toBeGreaterThanOrEqual(9);
+    expect(bg.attrs['fill']).toBe('var(--primary)');
+    const x = del.children.find((c) => String(c.attrs['class']) === 'pr-delete-x')!;
+    expect(x.textContent).toBe('×');
+    expect(x.attrs['fill']).toBe('var(--background)');
+  });
+
+  it('invokes onDelete with the ruler id when the × is clicked', () => {
+    const group = createMockGroup();
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    const deleted: number[] = [];
+    let stopped = 0;
+    renderSingle(group, geometry, { onDelete: (id) => deleted.push(id) });
+
+    const ruler = group.selectAll('.perf-ruler');
+    const del = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-delete no-export',
+    )!;
+    const click = del.handlers?.['click'];
+    expect(click).toBeTypeOf('function');
+    click!({ stopPropagation: () => stopped++ }, del.datum);
+    expect(deleted).toEqual([1]);
+    // The click must not fall through to the chart underneath.
+    expect(stopped).toBe(1);
+  });
+
+  it('registers hover handlers that reveal the × per ruler group', () => {
+    const group = createMockGroup();
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    renderSingle(group, geometry);
+
+    const ruler = group.selectAll('.perf-ruler');
+    expect(ruler.elements[0].handlers?.['mouseenter']).toBeTypeOf('function');
+    expect(ruler.elements[0].handlers?.['mouseleave']).toBeTypeOf('function');
   });
 });
 
-// ── nextPerfRulerSelection ───────────────────────────────────
+// ── nextPerfRulerState ───────────────────────────────────────
 
-describe('nextPerfRulerSelection', () => {
-  const EMPTY = EMPTY_PERF_RULER_SELECTION;
+/** Complete one measurement (two clicks) on a state, for test setup. */
+function complete(state: PerfRulerState, a: string, b: string, isoX: number): PerfRulerState {
+  return nextPerfRulerState(nextPerfRulerState(state, { curve: a, isoX }), {
+    curve: b,
+    isoX: isoX + 1,
+  });
+}
 
-  it('selects curve A and sets the iso-x on the first click', () => {
-    expect(nextPerfRulerSelection(EMPTY, { curve: 'curve-a', isoX: 40 })).toEqual({
-      curves: ['curve-a'],
-      isoX: 40,
-    });
+describe('nextPerfRulerState', () => {
+  const EMPTY = EMPTY_PERF_RULER_STATE;
+
+  it('starts an in-progress draft on the first click', () => {
+    const state = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
+    expect(state.rulers).toEqual([]);
+    expect(state.draft).toEqual({ curve: 'curve-a', isoX: 40 });
   });
 
-  it('selects curve B on a different curve, keeping the existing iso-x', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 55 })).toEqual({
-      curves: ['curve-a', 'curve-b'],
-      isoX: 40,
-    });
+  it('moves the draft iso-x when the draft curve is clicked again', () => {
+    let state = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
+    state = nextPerfRulerState(state, { curve: 'curve-a', isoX: 72 });
+    expect(state.draft).toEqual({ curve: 'curve-a', isoX: 72 });
+    expect(state.rulers).toEqual([]);
   });
 
-  it('moves the iso-x when the only selected curve is clicked again', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 72 })).toEqual({
-      curves: ['curve-a'],
-      isoX: 72,
-    });
+  it('completes a measurement at the DRAFT iso-x when a second curve is clicked', () => {
+    let state = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
+    state = nextPerfRulerState(state, { curve: 'curve-b', isoX: 55 });
+    expect(state.rulers).toEqual([{ id: 1, curveA: 'curve-a', curveB: 'curve-b', isoX: 40 }]);
+    expect(state.draft).toBeNull();
+    expect(state.nextId).toBe(2);
   });
 
-  it('moves the iso-x when either curve of a complete measurement is clicked', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 72 })).toEqual({
-      curves: ['curve-a', 'curve-b'],
-      isoX: 72,
-    });
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 13 })).toEqual({
-      curves: ['curve-a', 'curve-b'],
-      isoX: 13,
-    });
+  it('starts a NEW ruler on the next click after a completed measurement', () => {
+    let state = complete(EMPTY, 'curve-a', 'curve-b', 40);
+    // Clicking curve-a again does NOT retarget ruler 1 — it drafts ruler 2.
+    state = nextPerfRulerState(state, { curve: 'curve-a', isoX: 90 });
+    expect(state.rulers).toHaveLength(1);
+    expect(state.rulers[0].isoX).toBe(40);
+    expect(state.draft).toEqual({ curve: 'curve-a', isoX: 90 });
+    // …and completing it appends a second measurement with a fresh id.
+    state = nextPerfRulerState(state, { curve: 'curve-c', isoX: 95 });
+    expect(state.rulers.map((r) => r.id)).toEqual([1, 2]);
+    expect(state.rulers[1]).toEqual({ id: 2, curveA: 'curve-a', curveB: 'curve-c', isoX: 90 });
   });
 
-  it('starts a new measurement when a third curve is clicked', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-c', isoX: 90 })).toEqual({
-      curves: ['curve-c'],
-      isoX: 90,
-    });
+  it('accumulates measurements up to the cap, then drops the OLDEST', () => {
+    let state = EMPTY;
+    for (let i = 0; i < MAX_PERF_RULERS + 2; i++) {
+      state = complete(state, `a${i}`, `b${i}`, i * 10);
+    }
+    expect(state.rulers).toHaveLength(MAX_PERF_RULERS);
+    // The two oldest (a0/b0, a1/b1) were dropped; ids keep counting up.
+    expect(state.rulers[0].curveA).toBe('a2');
+    expect(state.rulers.at(-1)!.curveA).toBe(`a${MAX_PERF_RULERS + 1}`);
+    expect(state.nextId).toBe(MAX_PERF_RULERS + 3);
   });
 
-  it('returns the same reference when a selected-curve click does not move the iso-x', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 40 })).toBe(prev);
+  it('returns the same reference for no-op clicks', () => {
+    expect(nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: Number.NaN })).toBe(EMPTY);
+    const drafted = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
+    expect(nextPerfRulerState(drafted, { curve: 'curve-a', isoX: 40 })).toBe(drafted);
+    expect(nextPerfRulerState(drafted, { curve: 'curve-b', isoX: Number.NaN })).toBe(drafted);
+  });
+});
+
+// ── movePerfRulerIsoX / deletePerfRuler / clearPerfRulers ───────────────
+
+describe('movePerfRulerIsoX', () => {
+  const state = complete(EMPTY_PERF_RULER_STATE, 'curve-a', 'curve-b', 40);
+
+  it('moves only the targeted ruler', () => {
+    const two = complete(state, 'curve-c', 'curve-d', 80);
+    const moved = movePerfRulerIsoX(two, 1, 60);
+    expect(moved.rulers[0].isoX).toBe(60);
+    expect(moved.rulers[1].isoX).toBe(80);
   });
 
-  it('ignores clicks with a non-finite iso-x (same reference back)', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: Number.NaN })).toBe(prev);
-    expect(nextPerfRulerSelection(EMPTY, { curve: 'curve-a', isoX: Number.NaN })).toBe(EMPTY);
+  it('returns the same reference for unknown ids, equal values, and non-finite x', () => {
+    expect(movePerfRulerIsoX(state, 99, 60)).toBe(state);
+    expect(movePerfRulerIsoX(state, 1, 40)).toBe(state);
+    expect(movePerfRulerIsoX(state, 1, Number.NaN)).toBe(state);
+  });
+});
+
+describe('deletePerfRuler', () => {
+  it('deletes just the targeted ruler by id', () => {
+    const two = complete(complete(EMPTY_PERF_RULER_STATE, 'a', 'b', 40), 'c', 'd', 80);
+    const afterDelete = deletePerfRuler(two, 1);
+    expect(afterDelete.rulers.map((r) => r.id)).toEqual([2]);
+    // Ids are never reused after a delete.
+    expect(afterDelete.nextId).toBe(3);
   });
 
-  it('falls back to the click x for curve B when the previous iso-x is missing', () => {
-    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: null };
-    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 55 })).toEqual({
-      curves: ['curve-a', 'curve-b'],
-      isoX: 55,
-    });
+  it('returns the same reference when the id is not found', () => {
+    const one = complete(EMPTY_PERF_RULER_STATE, 'a', 'b', 40);
+    expect(deletePerfRuler(one, 99)).toBe(one);
+  });
+});
+
+describe('clearPerfRulers', () => {
+  it('clears all rulers and the draft, preserving the id counter', () => {
+    let state = complete(EMPTY_PERF_RULER_STATE, 'a', 'b', 40);
+    state = nextPerfRulerState(state, { curve: 'c', isoX: 90 });
+    const cleared = clearPerfRulers(state);
+    expect(cleared.rulers).toEqual([]);
+    expect(cleared.draft).toBeNull();
+    expect(cleared.nextId).toBe(state.nextId);
+  });
+
+  it('returns the same reference when already empty', () => {
+    expect(clearPerfRulers(EMPTY_PERF_RULER_STATE)).toBe(EMPTY_PERF_RULER_STATE);
+  });
+});
+
+// ── prunePerfRulers / perfRulerCurveSet ─────────────────────────────
+
+describe('prunePerfRulers', () => {
+  it('removes only rulers whose curves left the data (per ruler)', () => {
+    const two = complete(complete(EMPTY_PERF_RULER_STATE, 'a', 'gone', 40), 'c', 'd', 80);
+    const pruned = prunePerfRulers(two, (curve) => curve !== 'gone');
+    expect(pruned.rulers.map((r) => r.id)).toEqual([2]);
+  });
+
+  it('drops the draft when its curve is gone', () => {
+    const drafted = nextPerfRulerState(EMPTY_PERF_RULER_STATE, { curve: 'gone', isoX: 40 });
+    const pruned = prunePerfRulers(drafted, () => false);
+    expect(pruned.draft).toBeNull();
+  });
+
+  it('returns the same reference when every curve still exists', () => {
+    const one = complete(EMPTY_PERF_RULER_STATE, 'a', 'b', 40);
+    expect(prunePerfRulers(one, () => true)).toBe(one);
+  });
+});
+
+describe('perfRulerCurveSet', () => {
+  it('collects every curve across rulers and the draft', () => {
+    let state = complete(EMPTY_PERF_RULER_STATE, 'a', 'b', 40);
+    state = nextPerfRulerState(state, { curve: 'c', isoX: 90 });
+    expect([...perfRulerCurveSet(state)].sort()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is empty for the empty state', () => {
+    expect(perfRulerCurveSet(EMPTY_PERF_RULER_STATE).size).toBe(0);
   });
 });
 

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -7,12 +7,22 @@ import {
   formatPerfPercent,
   formatPerfRatio,
   intersectPathAtX,
+  nextPerfRulerSelection,
   renderPerfRuler,
   type PerfRulerPathLike,
   type PerfRulerPointInput,
   type PerfRulerRenderOptions,
+  type PerfRulerSelectionEntry,
   type PerfRulerTargetInput,
 } from './perf-ruler';
+
+// ── Selection fixtures ───────────────────────────────────────────
+
+const A1: PerfRulerSelectionEntry = { key: 'official:a1', curve: 'curve-a' };
+const A2: PerfRulerSelectionEntry = { key: 'official:a2', curve: 'curve-a' };
+const B1: PerfRulerSelectionEntry = { key: 'official:b1', curve: 'curve-b' };
+const B2: PerfRulerSelectionEntry = { key: 'official:b2', curve: 'curve-b' };
+const C1: PerfRulerSelectionEntry = { key: 'overlay:c1:run', curve: 'curve-c' };
 
 // ── Fixtures ─────────────────────────────────────────────────────────
 
@@ -388,5 +398,46 @@ describe('renderPerfRuler', () => {
 
     const ruler = group.selectAll('.perf-ruler');
     expect(ruler.elements[0].styles['pointer-events']).toBe('none');
+  });
+});
+
+// ── nextPerfRulerSelection ───────────────────────────────────────────
+
+describe('nextPerfRulerSelection', () => {
+  it('anchors the first click', () => {
+    expect(nextPerfRulerSelection([], A1)).toEqual([A1]);
+  });
+
+  it('clears everything when the exact anchor point is re-clicked', () => {
+    expect(nextPerfRulerSelection([A1], A1)).toEqual([]);
+    expect(nextPerfRulerSelection([A1, B1], A1)).toEqual([]);
+  });
+
+  it('moves the anchor along its own curve', () => {
+    expect(nextPerfRulerSelection([A1], A2)).toEqual([A2]);
+  });
+
+  it('moves the anchor along its own curve while keeping the target', () => {
+    expect(nextPerfRulerSelection([A1, B1], A2)).toEqual([A2, B1]);
+  });
+
+  it('selects a different curve as the target', () => {
+    expect(nextPerfRulerSelection([A1], B1)).toEqual([A1, B1]);
+  });
+
+  it('keeps a complete measurement when another point on the target curve is clicked', () => {
+    const prev = [A1, B1];
+    // Same reference back: the target entry identifies a CURVE, so this
+    // click cannot change the iso-x result — React can bail out.
+    expect(nextPerfRulerSelection(prev, B2)).toBe(prev);
+  });
+
+  it('keeps a complete measurement when the original target point is re-clicked', () => {
+    const prev = [A1, B1];
+    expect(nextPerfRulerSelection(prev, B1)).toBe(prev);
+  });
+
+  it('starts a new measurement anchored at a click on a third curve', () => {
+    expect(nextPerfRulerSelection([A1, B1], C1)).toEqual([C1]);
   });
 });

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -3,31 +3,26 @@ import { describe, expect, it } from 'vitest';
 import { createMockGroup } from './test-helpers';
 import {
   DEFAULT_MIN_SPAN_FOR_PERCENT,
+  EMPTY_PERF_RULER_SELECTION,
+  clampIsoX,
   computeIsoXRulerGeometry,
   formatPerfPercent,
   formatPerfRatio,
   intersectPathAtX,
   nextPerfRulerSelection,
+  pathXExtent,
   renderPerfRuler,
+  type PerfRulerCurveSelection,
+  type PerfRulerEndInput,
   type PerfRulerPathLike,
-  type PerfRulerPointInput,
   type PerfRulerRenderOptions,
-  type PerfRulerSelectionEntry,
-  type PerfRulerTargetInput,
 } from './perf-ruler';
 
-// ── Selection fixtures ───────────────────────────────────────────
+// ── Fixtures ─────────────────────────────────────────
 
-const A1: PerfRulerSelectionEntry = { key: 'official:a1', curve: 'curve-a' };
-const A2: PerfRulerSelectionEntry = { key: 'official:a2', curve: 'curve-a' };
-const B1: PerfRulerSelectionEntry = { key: 'official:b1', curve: 'curve-b' };
-const B2: PerfRulerSelectionEntry = { key: 'official:b2', curve: 'curve-b' };
-const C1: PerfRulerSelectionEntry = { key: 'overlay:c1:run', curve: 'curve-c' };
-
-// ── Fixtures ─────────────────────────────────────────────────────────
-
-const ANCHOR: PerfRulerPointInput = { px: 100, py: 50, rawY: 400 };
-const TARGET: PerfRulerTargetInput = { py: 150, rawY: 197 };
+const ISO_X = 100;
+const END_A: PerfRulerEndInput = { py: 50, rawY: 400 };
+const END_B: PerfRulerEndInput = { py: 150, rawY: 197 };
 
 function makeOpts(overrides?: Partial<PerfRulerRenderOptions>): PerfRulerRenderOptions {
   return {
@@ -218,8 +213,8 @@ describe('intersectPathAtX', () => {
 // ── computeIsoXRulerGeometry ─────────────────────────────────────────
 
 describe('computeIsoXRulerGeometry', () => {
-  it('places the line at the anchor x, spanning anchor y to the intersection y', () => {
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET);
+  it('places the line at the iso-x, spanning the two intersection ys', () => {
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B);
     expect(geometry).not.toBeNull();
     expect(geometry!.x).toBe(100);
     expect(geometry!.y1).toBe(50);
@@ -227,24 +222,21 @@ describe('computeIsoXRulerGeometry', () => {
   });
 
   it('computes the ratio from raw y values, higher over lower', () => {
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET);
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B);
     expect(geometry!.ratio).toBeCloseTo(400 / 197, 10);
     expect(geometry!.ratioLabel).toBe('2.03x');
     expect(geometry!.percentLabel).toBe('+103%');
   });
 
-  it('yields the same ratio when the target curve is the faster side', () => {
-    const fromSlowAnchor = computeIsoXRulerGeometry(
-      { px: 100, py: 150, rawY: 197 },
-      { py: 50, rawY: 400 },
-    );
-    expect(fromSlowAnchor!.ratio).toBeCloseTo(400 / 197, 10);
-    expect(fromSlowAnchor!.y1).toBe(50);
-    expect(fromSlowAnchor!.y2).toBe(150);
+  it('yields the same ratio regardless of end order (symmetric)', () => {
+    const swapped = computeIsoXRulerGeometry(ISO_X, END_B, END_A);
+    expect(swapped!.ratio).toBeCloseTo(400 / 197, 10);
+    expect(swapped!.y1).toBe(50);
+    expect(swapped!.y2).toBe(150);
   });
 
-  it('handles the curves crossing at the anchor x (ratio 1, zero-height span)', () => {
-    const geometry = computeIsoXRulerGeometry(ANCHOR, { py: ANCHOR.py, rawY: ANCHOR.rawY });
+  it('handles the curves crossing at the iso-x (ratio 1, zero-height span)', () => {
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, { ...END_A });
     expect(geometry).not.toBeNull();
     expect(geometry!.ratio).toBe(1);
     expect(geometry!.ratioLabel).toBe('1.00x');
@@ -253,25 +245,25 @@ describe('computeIsoXRulerGeometry', () => {
   });
 
   it('returns null when either raw y is zero or negative', () => {
-    expect(computeIsoXRulerGeometry(ANCHOR, { ...TARGET, rawY: 0 })).toBeNull();
-    expect(computeIsoXRulerGeometry({ ...ANCHOR, rawY: -5 }, TARGET)).toBeNull();
+    expect(computeIsoXRulerGeometry(ISO_X, END_A, { ...END_B, rawY: 0 })).toBeNull();
+    expect(computeIsoXRulerGeometry(ISO_X, { ...END_A, rawY: -5 }, END_B)).toBeNull();
   });
 
   it('returns null for non-finite inputs', () => {
-    expect(computeIsoXRulerGeometry({ ...ANCHOR, px: Number.NaN }, TARGET)).toBeNull();
+    expect(computeIsoXRulerGeometry(Number.NaN, END_A, END_B)).toBeNull();
     expect(
-      computeIsoXRulerGeometry(ANCHOR, { ...TARGET, py: Number.POSITIVE_INFINITY }),
+      computeIsoXRulerGeometry(ISO_X, END_A, { ...END_B, py: Number.POSITIVE_INFINITY }),
     ).toBeNull();
-    expect(computeIsoXRulerGeometry(ANCHOR, { ...TARGET, rawY: Number.NaN })).toBeNull();
+    expect(computeIsoXRulerGeometry(ISO_X, END_A, { ...END_B, rawY: Number.NaN })).toBeNull();
   });
 });
 
 // ── renderPerfRuler ──────────────────────────────────────────────────
 
 describe('renderPerfRuler', () => {
-  it('draws the ruler line, two end caps, chip, and label texts', () => {
+  it('draws the ruler line, two end caps, chip, label texts, and drag handle', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');
@@ -283,11 +275,12 @@ describe('renderPerfRuler', () => {
     expect(children).toContain('pr-bg');
     expect(children).toContain('pr-text pr-text-ratio');
     expect(children).toContain('pr-text pr-text-percent');
+    expect(children).toContain('pr-drag');
   });
 
-  it('positions the vertical line and caps at the anchor x', () => {
+  it('positions the vertical line and caps at the iso-x', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts({ capHalfWidth: 6 }));
 
     const ruler = group.selectAll('.perf-ruler');
@@ -311,9 +304,28 @@ describe('renderPerfRuler', () => {
     expect(capBottom.attrs['y2']).toBe(150);
   });
 
+  it('overlays an invisible wide drag handle spanning the ruler line', () => {
+    const group = createMockGroup();
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    const drag = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-drag')!;
+    expect(drag.attrs['x1']).toBe(100);
+    expect(drag.attrs['x2']).toBe(100);
+    expect(drag.attrs['y1']).toBe(50);
+    expect(drag.attrs['y2']).toBe(150);
+    expect(drag.attrs['stroke']).toBe('transparent');
+    expect(Number(drag.attrs['stroke-width'])).toBeGreaterThanOrEqual(12);
+    // Its own pointer-events overrides the group-level 'none' so the handle
+    // stays draggable while the visible marks never block clicks.
+    expect(drag.styles['pointer-events']).toBe('stroke');
+    expect(drag.styles['cursor']).toBe('ew-resize');
+  });
+
   it('writes the ratio label and shows the percent line for a tall span', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     expect(Math.abs(geometry.y2 - geometry.y1)).toBeGreaterThanOrEqual(
       DEFAULT_MIN_SPAN_FOR_PERCENT,
     );
@@ -330,7 +342,7 @@ describe('renderPerfRuler', () => {
 
   it('hides the percent line when the span is too short to fit it cleanly', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, { ...TARGET, py: ANCHOR.py + 10 })!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, { ...END_B, py: END_A.py + 10 })!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');
@@ -343,7 +355,7 @@ describe('renderPerfRuler', () => {
 
   it('places the chip to the right of the line by default', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800 }));
 
     const ruler = group.selectAll('.perf-ruler');
@@ -354,7 +366,7 @@ describe('renderPerfRuler', () => {
 
   it('flips the chip to the left near the right chart edge', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 125 }));
 
     const ruler = group.selectAll('.perf-ruler');
@@ -365,7 +377,7 @@ describe('renderPerfRuler', () => {
 
   it('is idempotent: re-rendering keeps a single ruler group', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts());
     renderPerfRuler(group as any, { ...geometry, x: 200 }, makeOpts());
 
@@ -377,7 +389,7 @@ describe('renderPerfRuler', () => {
 
   it('clears the ruler when geometry is null', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts());
     renderPerfRuler(group as any, null, makeOpts());
 
@@ -393,7 +405,7 @@ describe('renderPerfRuler', () => {
 
   it('disables pointer events so the ruler never blocks point clicks', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ANCHOR, TARGET)!;
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts());
 
     const ruler = group.selectAll('.perf-ruler');
@@ -401,43 +413,122 @@ describe('renderPerfRuler', () => {
   });
 });
 
-// ── nextPerfRulerSelection ───────────────────────────────────────────
+// ── nextPerfRulerSelection ───────────────────────────────────
 
 describe('nextPerfRulerSelection', () => {
-  it('anchors the first click', () => {
-    expect(nextPerfRulerSelection([], A1)).toEqual([A1]);
+  const EMPTY = EMPTY_PERF_RULER_SELECTION;
+
+  it('selects curve A and sets the iso-x on the first click', () => {
+    expect(nextPerfRulerSelection(EMPTY, { curve: 'curve-a', isoX: 40 })).toEqual({
+      curves: ['curve-a'],
+      isoX: 40,
+    });
   });
 
-  it('clears everything when the exact anchor point is re-clicked', () => {
-    expect(nextPerfRulerSelection([A1], A1)).toEqual([]);
-    expect(nextPerfRulerSelection([A1, B1], A1)).toEqual([]);
+  it('selects curve B on a different curve, keeping the existing iso-x', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 55 })).toEqual({
+      curves: ['curve-a', 'curve-b'],
+      isoX: 40,
+    });
   });
 
-  it('moves the anchor along its own curve', () => {
-    expect(nextPerfRulerSelection([A1], A2)).toEqual([A2]);
+  it('moves the iso-x when the only selected curve is clicked again', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 72 })).toEqual({
+      curves: ['curve-a'],
+      isoX: 72,
+    });
   });
 
-  it('moves the anchor along its own curve while keeping the target', () => {
-    expect(nextPerfRulerSelection([A1, B1], A2)).toEqual([A2, B1]);
+  it('moves the iso-x when either curve of a complete measurement is clicked', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 72 })).toEqual({
+      curves: ['curve-a', 'curve-b'],
+      isoX: 72,
+    });
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 13 })).toEqual({
+      curves: ['curve-a', 'curve-b'],
+      isoX: 13,
+    });
   });
 
-  it('selects a different curve as the target', () => {
-    expect(nextPerfRulerSelection([A1], B1)).toEqual([A1, B1]);
+  it('starts a new measurement when a third curve is clicked', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-c', isoX: 90 })).toEqual({
+      curves: ['curve-c'],
+      isoX: 90,
+    });
   });
 
-  it('keeps a complete measurement when another point on the target curve is clicked', () => {
-    const prev = [A1, B1];
-    // Same reference back: the target entry identifies a CURVE, so this
-    // click cannot change the iso-x result — React can bail out.
-    expect(nextPerfRulerSelection(prev, B2)).toBe(prev);
+  it('returns the same reference when a selected-curve click does not move the iso-x', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a', 'curve-b'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-a', isoX: 40 })).toBe(prev);
   });
 
-  it('keeps a complete measurement when the original target point is re-clicked', () => {
-    const prev = [A1, B1];
-    expect(nextPerfRulerSelection(prev, B1)).toBe(prev);
+  it('ignores clicks with a non-finite iso-x (same reference back)', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: 40 };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: Number.NaN })).toBe(prev);
+    expect(nextPerfRulerSelection(EMPTY, { curve: 'curve-a', isoX: Number.NaN })).toBe(EMPTY);
   });
 
-  it('starts a new measurement anchored at a click on a third curve', () => {
-    expect(nextPerfRulerSelection([A1, B1], C1)).toEqual([C1]);
+  it('falls back to the click x for curve B when the previous iso-x is missing', () => {
+    const prev: PerfRulerCurveSelection = { curves: ['curve-a'], isoX: null };
+    expect(nextPerfRulerSelection(prev, { curve: 'curve-b', isoX: 55 })).toEqual({
+      curves: ['curve-a', 'curve-b'],
+      isoX: 55,
+    });
+  });
+});
+
+// ── pathXExtent ─────────────────────────────────────────────
+
+describe('pathXExtent', () => {
+  it('returns the min/max x of the path endpoints', () => {
+    const path = polylinePath([
+      { x: 100, y: 100 },
+      { x: 300, y: 50 },
+    ]);
+    expect(pathXExtent(path)).toEqual({ min: 100, max: 300 });
+  });
+
+  it('supports paths whose x decreases along their length', () => {
+    const path = polylinePath([
+      { x: 300, y: 10 },
+      { x: 100, y: 110 },
+    ]);
+    expect(pathXExtent(path)).toEqual({ min: 100, max: 300 });
+  });
+
+  it('returns null for degenerate paths', () => {
+    expect(pathXExtent(polylinePath([]))).toBeNull();
+    expect(pathXExtent(polylinePath([{ x: 10, y: 10 }]))).toBeNull();
+  });
+});
+
+// ── clampIsoX ───────────────────────────────────────────────
+
+describe('clampIsoX', () => {
+  const A = { min: 100, max: 300 };
+  const B = { min: 200, max: 500 };
+
+  it('clamps to the overlapping range of two curves', () => {
+    expect(clampIsoX(150, A, B)).toBe(200);
+    expect(clampIsoX(250, A, B)).toBe(250);
+    expect(clampIsoX(450, A, B)).toBe(300);
+  });
+
+  it('clamps to a single curve when the second is absent', () => {
+    expect(clampIsoX(50, A)).toBe(100);
+    expect(clampIsoX(350, A, null)).toBe(300);
+    expect(clampIsoX(200, A)).toBe(200);
+  });
+
+  it('returns null when the ranges do not overlap', () => {
+    expect(clampIsoX(250, { min: 100, max: 150 }, { min: 200, max: 300 })).toBeNull();
+  });
+
+  it('returns null for a non-finite x', () => {
+    expect(clampIsoX(Number.NaN, A, B)).toBeNull();
   });
 });

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockGroup } from './test-helpers';
+import {
+  DEFAULT_MIN_SPAN_FOR_PERCENT,
+  computePerfRulerGeometry,
+  formatPerfPercent,
+  formatPerfRatio,
+  renderPerfRuler,
+  type PerfRulerPointInput,
+  type PerfRulerRenderOptions,
+} from './perf-ruler';
+
+// ── Fixtures ─────────────────────────────────────────────────────────
+
+const POINT_A: PerfRulerPointInput = { px: 100, py: 50, rawY: 400 };
+const POINT_B: PerfRulerPointInput = { px: 140, py: 150, rawY: 197 };
+
+function makeOpts(overrides?: Partial<PerfRulerRenderOptions>): PerfRulerRenderOptions {
+  return {
+    color: 'var(--primary)',
+    labelBg: 'var(--primary)',
+    labelText: 'var(--primary-foreground)',
+    ...overrides,
+  };
+}
+
+// ── formatPerfRatio ──────────────────────────────────────────────────
+
+describe('formatPerfRatio', () => {
+  it('formats small multiples with two decimals', () => {
+    expect(formatPerfRatio(2.0304)).toBe('2.03x');
+    expect(formatPerfRatio(1)).toBe('1.00x');
+  });
+
+  it('drops to one decimal at 10x and none at 100x', () => {
+    expect(formatPerfRatio(10.46)).toBe('10.5x');
+    expect(formatPerfRatio(123.4)).toBe('123x');
+  });
+
+  it('returns empty string for non-finite or non-positive ratios', () => {
+    expect(formatPerfRatio(Number.NaN)).toBe('');
+    expect(formatPerfRatio(Number.POSITIVE_INFINITY)).toBe('');
+    expect(formatPerfRatio(0)).toBe('');
+    expect(formatPerfRatio(-2)).toBe('');
+  });
+});
+
+// ── formatPerfPercent ────────────────────────────────────────────────
+
+describe('formatPerfPercent', () => {
+  it('formats the relative gain rounded to whole percent', () => {
+    expect(formatPerfPercent(2.0304)).toBe('+103%');
+    expect(formatPerfPercent(1.5)).toBe('+50%');
+  });
+
+  it('formats an equal pair as +0%', () => {
+    expect(formatPerfPercent(1)).toBe('+0%');
+  });
+
+  it('returns empty string for invalid ratios', () => {
+    expect(formatPerfPercent(Number.NaN)).toBe('');
+    expect(formatPerfPercent(0)).toBe('');
+  });
+});
+
+// ── computePerfRulerGeometry ─────────────────────────────────────────
+
+describe('computePerfRulerGeometry', () => {
+  it('places the line at the pixel midpoint spanning both y positions', () => {
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B);
+    expect(geometry).not.toBeNull();
+    expect(geometry!.x).toBe(120);
+    expect(geometry!.y1).toBe(50);
+    expect(geometry!.y2).toBe(150);
+  });
+
+  it('computes the ratio from raw y values, higher over lower', () => {
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B);
+    expect(geometry!.ratio).toBeCloseTo(400 / 197, 10);
+    expect(geometry!.ratioLabel).toBe('2.03x');
+    expect(geometry!.percentLabel).toBe('+103%');
+  });
+
+  it('is symmetric in argument order', () => {
+    const forward = computePerfRulerGeometry(POINT_A, POINT_B);
+    const reverse = computePerfRulerGeometry(POINT_B, POINT_A);
+    expect(reverse).toEqual(forward);
+  });
+
+  it('handles an equal pair (ratio 1, zero-height span)', () => {
+    const geometry = computePerfRulerGeometry(POINT_A, { ...POINT_A });
+    expect(geometry).not.toBeNull();
+    expect(geometry!.ratio).toBe(1);
+    expect(geometry!.ratioLabel).toBe('1.00x');
+    expect(geometry!.percentLabel).toBe('+0%');
+    expect(geometry!.y1).toBe(geometry!.y2);
+  });
+
+  it('returns null when either raw y is zero or negative', () => {
+    expect(computePerfRulerGeometry(POINT_A, { ...POINT_B, rawY: 0 })).toBeNull();
+    expect(computePerfRulerGeometry({ ...POINT_A, rawY: -5 }, POINT_B)).toBeNull();
+  });
+
+  it('returns null for non-finite inputs', () => {
+    expect(computePerfRulerGeometry({ ...POINT_A, px: Number.NaN }, POINT_B)).toBeNull();
+    expect(
+      computePerfRulerGeometry(POINT_A, { ...POINT_B, py: Number.POSITIVE_INFINITY }),
+    ).toBeNull();
+    expect(computePerfRulerGeometry(POINT_A, { ...POINT_B, rawY: Number.NaN })).toBeNull();
+  });
+});
+
+// ── renderPerfRuler ──────────────────────────────────────────────────
+
+describe('renderPerfRuler', () => {
+  it('draws the ruler line, two end caps, chip, and label texts', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    expect(ruler.elements).toHaveLength(1);
+    const children = ruler.elements[0].children.map((c) => String(c.attrs['class']));
+    expect(children).toContain('pr-line');
+    expect(children).toContain('pr-cap pr-cap-top');
+    expect(children).toContain('pr-cap pr-cap-bottom');
+    expect(children).toContain('pr-bg');
+    expect(children).toContain('pr-text pr-text-ratio');
+    expect(children).toContain('pr-text pr-text-percent');
+  });
+
+  it('positions the vertical line and caps from geometry', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts({ capHalfWidth: 6 }));
+
+    const ruler = group.selectAll('.perf-ruler');
+    const byClass = (cls: string) =>
+      ruler.elements[0].children.find((c) => String(c.attrs['class']) === cls)!;
+    const line = byClass('pr-line');
+    expect(line.attrs['x1']).toBe(120);
+    expect(line.attrs['x2']).toBe(120);
+    expect(line.attrs['y1']).toBe(50);
+    expect(line.attrs['y2']).toBe(150);
+    expect(line.attrs['stroke']).toBe('var(--primary)');
+
+    const capTop = byClass('pr-cap pr-cap-top');
+    expect(capTop.attrs['x1']).toBe(114);
+    expect(capTop.attrs['x2']).toBe(126);
+    expect(capTop.attrs['y1']).toBe(50);
+    expect(capTop.attrs['y2']).toBe(50);
+
+    const capBottom = byClass('pr-cap pr-cap-bottom');
+    expect(capBottom.attrs['y1']).toBe(150);
+    expect(capBottom.attrs['y2']).toBe(150);
+  });
+
+  it('writes the ratio label and shows the percent line for a tall span', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    expect(Math.abs(geometry.y2 - geometry.y1)).toBeGreaterThanOrEqual(
+      DEFAULT_MIN_SPAN_FOR_PERCENT,
+    );
+    renderPerfRuler(group as any, geometry, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    const byClass = (cls: string) =>
+      ruler.elements[0].children.find((c) => String(c.attrs['class']) === cls)!;
+    expect(byClass('pr-text pr-text-ratio').textContent).toBe('2.03x');
+    const percent = byClass('pr-text pr-text-percent');
+    expect(percent.textContent).toBe('+103%');
+    expect(percent.styles['display']).toBe('');
+  });
+
+  it('hides the percent line when the span is too short to fit it cleanly', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, { ...POINT_B, py: POINT_A.py + 10 })!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    const percent = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-text pr-text-percent',
+    )!;
+    expect(percent.styles['display']).toBe('none');
+    expect(percent.textContent).toBe('');
+  });
+
+  it('places the chip to the right of the line by default', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800 }));
+
+    const ruler = group.selectAll('.perf-ruler');
+    const bg = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-bg')!;
+    expect(Number(bg.attrs['x'])).toBeGreaterThan(geometry.x);
+    expect(bg.attrs['fill']).toBe('var(--primary)');
+  });
+
+  it('flips the chip to the left near the right chart edge', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 125 }));
+
+    const ruler = group.selectAll('.perf-ruler');
+    const bg = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-bg')!;
+    const bgX = Number(bg.attrs['x']);
+    expect(bgX + Number(bg.attrs['width'])).toBeLessThan(geometry.x);
+  });
+
+  it('is idempotent: re-rendering keeps a single ruler group', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+    renderPerfRuler(group as any, { ...geometry, x: 200 }, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    expect(ruler.elements).toHaveLength(1);
+    const line = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-line')!;
+    expect(line.attrs['x1']).toBe(200);
+  });
+
+  it('clears the ruler when geometry is null', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+    renderPerfRuler(group as any, null, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    expect(ruler.elements).toHaveLength(0);
+  });
+
+  it('renders nothing when called with null on an empty group', () => {
+    const group = createMockGroup();
+    renderPerfRuler(group as any, null, makeOpts());
+    expect(group.selectAll('.perf-ruler').elements).toHaveLength(0);
+  });
+
+  it('disables pointer events so the ruler never blocks point clicks', () => {
+    const group = createMockGroup();
+    const geometry = computePerfRulerGeometry(POINT_A, POINT_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts());
+
+    const ruler = group.selectAll('.perf-ruler');
+    expect(ruler.elements[0].styles['pointer-events']).toBe('none');
+  });
+});

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -2,13 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { createMockGroup } from './test-helpers';
 import {
-  DEFAULT_MIN_SPAN_FOR_PERCENT,
+  DEFAULT_LABEL_FONT_SIZE,
   EMPTY_PERF_RULER_SELECTION,
   clampIsoX,
   computeIsoXRulerGeometry,
-  formatPerfPercent,
+  computePerfRulerLabelLayout,
   formatPerfRatio,
   intersectPathAtX,
+  isPerfRulerCurveVisible,
   nextPerfRulerSelection,
   pathXExtent,
   renderPerfRuler,
@@ -27,8 +28,6 @@ const END_B: PerfRulerEndInput = { py: 150, rawY: 197 };
 function makeOpts(overrides?: Partial<PerfRulerRenderOptions>): PerfRulerRenderOptions {
   return {
     color: 'var(--primary)',
-    labelBg: 'var(--primary)',
-    labelText: 'var(--primary-foreground)',
     ...overrides,
   };
 }
@@ -87,21 +86,25 @@ describe('formatPerfRatio', () => {
   });
 });
 
-// ── formatPerfPercent ────────────────────────────────────────────────
+// ── isPerfRulerCurveVisible ────────────────────────────────────────────────
 
-describe('formatPerfPercent', () => {
-  it('formats the relative gain rounded to whole percent', () => {
-    expect(formatPerfPercent(2.0304)).toBe('+103%');
-    expect(formatPerfPercent(1.5)).toBe('+50%');
+describe('isPerfRulerCurveVisible', () => {
+  it('treats legend-hidden curves (opacity 0) as invisible', () => {
+    expect(isPerfRulerCurveVisible('0')).toBe(false);
+    expect(isPerfRulerCurveVisible('0.0')).toBe(false);
+    expect(isPerfRulerCurveVisible(' 0 ')).toBe(false);
   });
 
-  it('formats an equal pair as +0%', () => {
-    expect(formatPerfPercent(1)).toBe('+0%');
+  it('keeps hover-dimmed and fully opaque curves measurable', () => {
+    expect(isPerfRulerCurveVisible('0.15')).toBe(true);
+    expect(isPerfRulerCurveVisible('1')).toBe(true);
   });
 
-  it('returns empty string for invalid ratios', () => {
-    expect(formatPerfPercent(Number.NaN)).toBe('');
-    expect(formatPerfPercent(0)).toBe('');
+  it('treats missing, empty, or unparseable opacity as visible', () => {
+    expect(isPerfRulerCurveVisible(null)).toBe(true);
+    expect(isPerfRulerCurveVisible(undefined)).toBe(true);
+    expect(isPerfRulerCurveVisible('')).toBe(true);
+    expect(isPerfRulerCurveVisible('inherit')).toBe(true);
   });
 });
 
@@ -225,7 +228,6 @@ describe('computeIsoXRulerGeometry', () => {
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B);
     expect(geometry!.ratio).toBeCloseTo(400 / 197, 10);
     expect(geometry!.ratioLabel).toBe('2.03x');
-    expect(geometry!.percentLabel).toBe('+103%');
   });
 
   it('yields the same ratio regardless of end order (symmetric)', () => {
@@ -240,7 +242,6 @@ describe('computeIsoXRulerGeometry', () => {
     expect(geometry).not.toBeNull();
     expect(geometry!.ratio).toBe(1);
     expect(geometry!.ratioLabel).toBe('1.00x');
-    expect(geometry!.percentLabel).toBe('+0%');
     expect(geometry!.y1).toBe(geometry!.y2);
   });
 
@@ -258,10 +259,82 @@ describe('computeIsoXRulerGeometry', () => {
   });
 });
 
-// ── renderPerfRuler ──────────────────────────────────────────────────
+// ── computePerfRulerLabelLayout ──────────────────────────────────────────────────
+
+describe('computePerfRulerLabelLayout', () => {
+  const GEOMETRY = { x: 100, y1: 50, y2: 150, ratioLabel: '2.03x' };
+
+  it('places the label up-right of the line midpoint by default', () => {
+    const layout = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 800, chartHeight: 400 });
+    expect(layout.side).toBe(1);
+    expect(layout.textAnchor).toBe('start');
+    expect(layout.labelX).toBeGreaterThan(GEOMETRY.x);
+    expect(layout.labelY).toBeLessThan((GEOMETRY.y1 + GEOMETRY.y2) / 2);
+  });
+
+  it('flips to the left side near the right chart edge', () => {
+    const layout = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 125, chartHeight: 400 });
+    expect(layout.side).toBe(-1);
+    expect(layout.textAnchor).toBe('end');
+    expect(layout.labelX).toBeLessThan(GEOMETRY.x);
+  });
+
+  it('drops below the midpoint when the label would clip the top', () => {
+    const top = { x: 100, y1: 10, y2: 30, ratioLabel: '2.03x' };
+    const layout = computePerfRulerLabelLayout(top, { chartWidth: 800, chartHeight: 400 });
+    expect(layout.labelY).toBeGreaterThan((top.y1 + top.y2) / 2);
+  });
+
+  it('clamps the label inside the chart when above and below both clip', () => {
+    const top = { x: 100, y1: 10, y2: 30, ratioLabel: '2.03x' };
+    const layout = computePerfRulerLabelLayout(top, { chartWidth: 800, chartHeight: 70 });
+    const fontSize = DEFAULT_LABEL_FONT_SIZE;
+    expect(layout.labelY - fontSize / 2).toBeGreaterThanOrEqual(4);
+    expect(layout.labelY + fontSize / 2).toBeLessThanOrEqual(70);
+  });
+
+  it('ends the arrow curve horizontally next to the line midpoint', () => {
+    const layout = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 800, chartHeight: 400 });
+    const midY = (GEOMETRY.y1 + GEOMETRY.y2) / 2;
+    // Quadratic curve: M sx sy Q cx cy ex ey — the end point sits a few px
+    // right of the line at the midpoint height, tangent horizontal.
+    const numbers = layout.arrowPath.match(/-?\d+(?:\.\d+)?/g)!.map(Number);
+    const [sx, sy, cx, cy, ex, ey] = numbers;
+    expect(sx).toBeGreaterThan(GEOMETRY.x);
+    expect(sy).toBeLessThan(midY);
+    expect(cy).toBe(midY);
+    expect(cx).toBe(sx);
+    expect(ey).toBe(midY);
+    expect(ex).toBeGreaterThan(GEOMETRY.x);
+    expect(ex).toBeLessThan(sx);
+  });
+
+  it('points the arrowhead tip at the line, just off the stroke', () => {
+    const layout = computePerfRulerLabelLayout(GEOMETRY, { chartWidth: 800, chartHeight: 400 });
+    const midY = (GEOMETRY.y1 + GEOMETRY.y2) / 2;
+    const numbers = layout.arrowHeadPath.match(/-?\d+(?:\.\d+)?/g)!.map(Number);
+    const [tipX, tipY] = numbers;
+    expect(tipY).toBe(midY);
+    expect(Math.abs(tipX - GEOMETRY.x)).toBeLessThanOrEqual(6);
+    expect(layout.arrowHeadPath.endsWith('Z')).toBe(true);
+  });
+
+  it('respects a custom font size when checking the top clip', () => {
+    const nearTop = { x: 100, y1: 40, y2: 60, ratioLabel: '2.03x' };
+    const small = computePerfRulerLabelLayout(nearTop, { fontSize: 12 });
+    // 50 - 46 = 4 above the top — fits a 12px label (4 - 6 < 4 fails)…
+    // both sizes clip here, so both drop below; a taller chart midpoint
+    // stays above for both.
+    const tall = { x: 100, y1: 100, y2: 200, ratioLabel: '2.03x' };
+    expect(computePerfRulerLabelLayout(tall, { fontSize: 12 }).labelY).toBeLessThan(150);
+    expect(small.labelY).toBeGreaterThan(50);
+  });
+});
+
+// ── renderPerfRuler ────────────────────────────────────────────────────
 
 describe('renderPerfRuler', () => {
-  it('draws the ruler line, two end caps, chip, label texts, and drag handle', () => {
+  it('draws the ruler line, end caps, arrow, big ratio label, and drag handle', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts());
@@ -272,10 +345,14 @@ describe('renderPerfRuler', () => {
     expect(children).toContain('pr-line');
     expect(children).toContain('pr-cap pr-cap-top');
     expect(children).toContain('pr-cap pr-cap-bottom');
-    expect(children).toContain('pr-bg');
+    expect(children).toContain('pr-arrow');
+    expect(children).toContain('pr-arrow-head');
     expect(children).toContain('pr-text pr-text-ratio');
-    expect(children).toContain('pr-text pr-text-percent');
     expect(children).toContain('pr-drag');
+    // The chip rect and secondary percent line are gone in the big-label
+    // design.
+    expect(children).not.toContain('pr-bg');
+    expect(children).not.toContain('pr-text pr-text-percent');
   });
 
   it('positions the vertical line and caps at the iso-x', () => {
@@ -323,56 +400,80 @@ describe('renderPerfRuler', () => {
     expect(drag.styles['cursor']).toBe('ew-resize');
   });
 
-  it('writes the ratio label and shows the percent line for a tall span', () => {
+  it('writes the big ratio label in the accent color with a readability halo', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
-    expect(Math.abs(geometry.y2 - geometry.y1)).toBeGreaterThanOrEqual(
-      DEFAULT_MIN_SPAN_FOR_PERCENT,
-    );
-    renderPerfRuler(group as any, geometry, makeOpts());
+    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800, chartHeight: 400 }));
 
     const ruler = group.selectAll('.perf-ruler');
     const byClass = (cls: string) =>
       ruler.elements[0].children.find((c) => String(c.attrs['class']) === cls)!;
-    expect(byClass('pr-text pr-text-ratio').textContent).toBe('2.03x');
-    const percent = byClass('pr-text pr-text-percent');
-    expect(percent.textContent).toBe('+103%');
-    expect(percent.styles['display']).toBe('');
+    const label = byClass('pr-text pr-text-ratio');
+    expect(label.textContent).toBe('2.03x');
+    expect(label.attrs['font-size']).toBe(`${DEFAULT_LABEL_FONT_SIZE}px`);
+    expect(label.attrs['font-weight']).toBe('800');
+    expect(label.attrs['fill']).toBe('var(--primary)');
+    // Halo: background-colored stroke painted UNDER the glyph fill.
+    expect(label.attrs['paint-order']).toBe('stroke');
+    expect(label.attrs['stroke']).toBe('var(--background)');
+    expect(Number(label.attrs['stroke-width'])).toBeGreaterThan(0);
   });
 
-  it('hides the percent line when the span is too short to fit it cleanly', () => {
+  it('honors a custom halo color and font size', () => {
     const group = createMockGroup();
-    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, { ...END_B, py: END_A.py + 10 })!;
-    renderPerfRuler(group as any, geometry, makeOpts());
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts({ halo: 'white', labelFontSize: 40 }));
 
     const ruler = group.selectAll('.perf-ruler');
-    const percent = ruler.elements[0].children.find(
-      (c) => String(c.attrs['class']) === 'pr-text pr-text-percent',
+    const label = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-text pr-text-ratio',
     )!;
-    expect(percent.styles['display']).toBe('none');
-    expect(percent.textContent).toBe('');
+    expect(label.attrs['stroke']).toBe('white');
+    expect(label.attrs['font-size']).toBe('40px');
   });
 
-  it('places the chip to the right of the line by default', () => {
+  it('draws the arrow curve and filled head in the accent color', () => {
+    const group = createMockGroup();
+    const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
+    renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800, chartHeight: 400 }));
+
+    const ruler = group.selectAll('.perf-ruler');
+    const byClass = (cls: string) =>
+      ruler.elements[0].children.find((c) => String(c.attrs['class']) === cls)!;
+    const layout = computePerfRulerLabelLayout(geometry, { chartWidth: 800, chartHeight: 400 });
+    const arrow = byClass('pr-arrow');
+    expect(arrow.attrs['d']).toBe(layout.arrowPath);
+    expect(arrow.attrs['stroke']).toBe('var(--primary)');
+    expect(arrow.attrs['fill']).toBe('none');
+    const head = byClass('pr-arrow-head');
+    expect(head.attrs['d']).toBe(layout.arrowHeadPath);
+    expect(head.attrs['fill']).toBe('var(--primary)');
+  });
+
+  it('places the label right of the line by default', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 800 }));
 
     const ruler = group.selectAll('.perf-ruler');
-    const bg = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-bg')!;
-    expect(Number(bg.attrs['x'])).toBeGreaterThan(geometry.x);
-    expect(bg.attrs['fill']).toBe('var(--primary)');
+    const label = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-text pr-text-ratio',
+    )!;
+    expect(Number(label.attrs['x'])).toBeGreaterThan(geometry.x);
+    expect(label.attrs['text-anchor']).toBe('start');
   });
 
-  it('flips the chip to the left near the right chart edge', () => {
+  it('flips the label to the left near the right chart edge', () => {
     const group = createMockGroup();
     const geometry = computeIsoXRulerGeometry(ISO_X, END_A, END_B)!;
     renderPerfRuler(group as any, geometry, makeOpts({ chartWidth: 125 }));
 
     const ruler = group.selectAll('.perf-ruler');
-    const bg = ruler.elements[0].children.find((c) => String(c.attrs['class']) === 'pr-bg')!;
-    const bgX = Number(bg.attrs['x']);
-    expect(bgX + Number(bg.attrs['width'])).toBeLessThan(geometry.x);
+    const label = ruler.elements[0].children.find(
+      (c) => String(c.attrs['class']) === 'pr-text pr-text-ratio',
+    )!;
+    expect(Number(label.attrs['x'])).toBeLessThan(geometry.x);
+    expect(label.attrs['text-anchor']).toBe('end');
   });
 
   it('is idempotent: re-rendering keeps a single ruler group', () => {

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.test.ts
@@ -389,6 +389,44 @@ describe('computePerfRulerLabelLayouts', () => {
     expect(first).toEqual(computePerfRulerLabelLayout(GEOMETRY, OPTS));
     expect(second).toEqual(computePerfRulerLabelLayout(other, OPTS));
   });
+
+  it('keeps the below-midpoint collision fallback inside a short chart', () => {
+    // midY = 60 in a 100px chart: the above placement clips the top, and the
+    // naive below-midpoint fallback (midY + 46 = 106) would leave the plot.
+    const geometry = { x: 100, y1: 40, y2: 80, ratioLabel: '2.03x' };
+    const fontSize = DEFAULT_LABEL_FONT_SIZE;
+    const layouts = computePerfRulerLabelLayouts([geometry, { ...geometry }], {
+      chartWidth: 800,
+      chartHeight: 100,
+    });
+    for (const layout of layouts) {
+      expect(layout!.labelY + fontSize / 2).toBeLessThanOrEqual(100 - 4);
+      expect(layout!.labelY - fontSize / 2).toBeGreaterThanOrEqual(4);
+      expect(layout!.deleteY).toBe(layout!.labelY);
+    }
+  });
+
+  it('clamps downward nudges at the chart bottom, accepting residual overlap', () => {
+    // Three identical rulers near the top of a short chart: labels stack
+    // DOWNWARD, and the third label's second nudge (118 + 42 = 160) would
+    // escape a 140px chart without the clamp.
+    const geometry = { x: 100, y1: 10, y2: 50, ratioLabel: '2.03x' };
+    const fontSize = DEFAULT_LABEL_FONT_SIZE;
+    const chartHeight = 140;
+    const layouts = computePerfRulerLabelLayouts([geometry, { ...geometry }, { ...geometry }], {
+      chartWidth: 800,
+      chartHeight,
+    });
+    for (const layout of layouts) {
+      expect(layout!.labelY + fontSize / 2).toBeLessThanOrEqual(chartHeight - 4);
+      expect(layout!.labelY - fontSize / 2).toBeGreaterThanOrEqual(4);
+      expect(layout!.deleteY).toBe(layout!.labelY);
+    }
+    // The first two still resolve their collision; the third accepts overlap
+    // at the clamped bottom rather than leaving the plot.
+    expect(layouts[1]!.labelY).toBeGreaterThan(layouts[0]!.labelY);
+    expect(layouts[2]!.labelY).toBe(chartHeight - 4 - fontSize / 2);
+  });
 });
 
 // ── renderPerfRulers ───────────────────────────────────────────────────
@@ -730,6 +768,42 @@ describe('nextPerfRulerState', () => {
     const drafted = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
     expect(nextPerfRulerState(drafted, { curve: 'curve-a', isoX: 40 })).toBe(drafted);
     expect(nextPerfRulerState(drafted, { curve: 'curve-b', isoX: Number.NaN })).toBe(drafted);
+  });
+
+  it('stores the CLAMPED iso-x when completion lands outside the pair overlap', () => {
+    const calls: [string, string, number][] = [];
+    const drafted = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 500 });
+    const state = nextPerfRulerState(drafted, { curve: 'curve-b', isoX: 510 }, (a, b, isoX) => {
+      calls.push([a, b, isoX]);
+      return 120; // curve B's span ends at 120 — clamp pulls the ruler back in.
+    });
+    // The clamp sees the DRAFT's iso-x (measurements complete at the draft).
+    expect(calls).toEqual([['curve-a', 'curve-b', 500]]);
+    expect(state.rulers).toEqual([{ id: 1, curveA: 'curve-a', curveB: 'curve-b', isoX: 120 }]);
+    expect(state.draft).toBeNull();
+  });
+
+  it('rejects completion and keeps the draft anchored when the pair has NO overlap', () => {
+    const drafted = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 });
+    const state = nextPerfRulerState(drafted, { curve: 'curve-b', isoX: 55 }, () => null);
+    // No measurement was appended, no id burned, the draft survives — the
+    // user can pick a different second curve. Same reference: React bails.
+    expect(state).toBe(drafted);
+    expect(state.rulers).toEqual([]);
+    expect(state.draft).toEqual({ curve: 'curve-a', isoX: 40 });
+  });
+
+  it('does not consult the clamp for draft-start or draft-move clicks', () => {
+    let calls = 0;
+    const clamp = () => {
+      calls++;
+      return null;
+    };
+    const drafted = nextPerfRulerState(EMPTY, { curve: 'curve-a', isoX: 40 }, clamp);
+    expect(drafted.draft).toEqual({ curve: 'curve-a', isoX: 40 });
+    const moved = nextPerfRulerState(drafted, { curve: 'curve-a', isoX: 60 }, clamp);
+    expect(moved.draft).toEqual({ curve: 'curve-a', isoX: 60 });
+    expect(calls).toBe(0);
   });
 });
 

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -152,6 +152,45 @@ export function computeIsoXRulerGeometry(
   };
 }
 
+/** One perf-ruler click: a stable point key plus the curve it belongs to. */
+export interface PerfRulerSelectionEntry {
+  key: string;
+  curve: string;
+}
+
+/**
+ * Selection-transition table for perf-ruler clicks. The selection holds up
+ * to two entries: `[anchor, target]`. The anchor is a POINT (it defines the
+ * iso-x and one end of the ruler); the target entry only identifies a CURVE
+ * (the other end is that curve's intersection at the anchor's x).
+ *
+ * | State            | Click on…                       | Result                        |
+ * |------------------|---------------------------------|-------------------------------|
+ * | empty            | any point                       | becomes the anchor            |
+ * | any              | the exact anchor point          | clear everything              |
+ * | any              | another point on anchor's curve | move the anchor (keep target) |
+ * | anchor only      | a different curve               | select that curve as target   |
+ * | anchor + target  | any point on the target curve   | no-op (keep the measurement — |
+ * |                  |                                 | it cannot change the result)  |
+ * | anchor + target  | a third curve                   | new measurement anchored there|
+ *
+ * Returns `prev` (same reference) for no-op transitions so React state
+ * updates can bail out without re-rendering.
+ */
+export function nextPerfRulerSelection(
+  prev: PerfRulerSelectionEntry[],
+  clicked: PerfRulerSelectionEntry,
+): PerfRulerSelectionEntry[] {
+  const anchor = prev[0];
+  const target = prev[1];
+  if (anchor && anchor.key === clicked.key) return [];
+  if (!anchor) return [clicked];
+  if (clicked.curve === anchor.curve) return target ? [clicked, target] : [clicked];
+  if (!target) return [anchor, clicked];
+  if (clicked.curve === target.curve) return prev;
+  return [clicked];
+}
+
 export interface PerfRulerRenderOptions {
   /** Stroke for the ruler line and end caps (e.g. `var(--primary)`). */
   color: string;

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -2,12 +2,13 @@ import type * as d3 from 'd3';
 
 /**
  * Perf ruler layer — an ISO-X (iso-interactivity) measurement ruler between
- * two curves. The user anchors the ruler on a point of curve A; the ruler is
- * a vertical line at the anchor's x pixel position running from the anchor's
- * y down/up to curve B's y at that SAME x (found by intersecting curve B's
- * rendered roofline path). Short horizontal end caps mark both ends and a
- * label chip shows the performance multiple between the two RAW y-values at
- * that x (e.g. "2.03x", optionally "+103%").
+ * two curves. The user clicks two curves; the ruler is a vertical line at a
+ * freely chosen iso-x whose BOTH ends are interpolated on the two curves'
+ * rendered roofline paths at that x (neither end needs to be a data point).
+ * The ruler is draggable horizontally to fine-tune the iso-x. Short
+ * horizontal end caps mark both ends and a label chip shows the performance
+ * multiple between the two RAW y-values at that x (e.g. "2.03x",
+ * optionally "+103%").
  *
  * Pure module: intersection search and geometry math are separated from
  * rendering so all three are unit testable (see perf-ruler.test.ts).
@@ -17,25 +18,16 @@ import type * as d3 from 'd3';
 
 type GroupSelection = d3.Selection<SVGGElement, unknown, null, undefined>;
 
-export interface PerfRulerPointInput {
-  /** Pixel x position of the point (already passed through the x scale). */
-  px: number;
-  /** Pixel y position of the point (already passed through the y scale). */
-  py: number;
-  /** Raw data-space y value — the ratio uses raw values, never pixels. */
-  rawY: number;
-}
-
-/** The target-curve end of the ruler: the intersection at the anchor's x. */
-export interface PerfRulerTargetInput {
-  /** Pixel y of the target curve at the anchor's x. */
+/** One end of the ruler: a curve's interpolated position at the iso-x. */
+export interface PerfRulerEndInput {
+  /** Pixel y of the curve at the iso-x (from the rendered path). */
   py: number;
   /** Raw data-space y at that intersection (yScale.invert of `py`). */
   rawY: number;
 }
 
 export interface PerfRulerGeometry {
-  /** Ruler line x pixel position: the anchor point's x. */
+  /** Ruler line x pixel position: the iso-x through the x scale. */
   x: number;
   /** Top pixel y of the ruler span. */
   y1: number;
@@ -123,72 +115,121 @@ export function intersectPathAtX(
 }
 
 /**
- * Compute iso-x ruler geometry from the anchor point and the target curve's
- * intersection at the anchor's x. Returns null for degenerate inputs:
- * non-finite coordinates or non-positive raw y values (a ratio over a
- * zero/negative value is meaningless, and log scales cannot place them).
- * The ratio is symmetric: higher raw y over lower raw y, regardless of which
- * side is the anchor.
+ * Compute iso-x ruler geometry from the two curves' interpolated positions
+ * at the iso-x pixel `x`. Returns null for degenerate inputs: non-finite
+ * coordinates or non-positive raw y values (a ratio over a zero/negative
+ * value is meaningless, and log scales cannot place them). The ratio is
+ * symmetric: higher raw y over lower raw y, regardless of click order.
  */
 export function computeIsoXRulerGeometry(
-  anchor: PerfRulerPointInput,
-  target: PerfRulerTargetInput,
+  x: number,
+  a: PerfRulerEndInput,
+  b: PerfRulerEndInput,
 ): PerfRulerGeometry | null {
-  const inputs = [anchor.px, anchor.py, anchor.rawY, target.py, target.rawY];
+  const inputs = [x, a.py, a.rawY, b.py, b.rawY];
   if (!inputs.every((value) => Number.isFinite(value))) return null;
-  if (anchor.rawY <= 0 || target.rawY <= 0) return null;
+  if (a.rawY <= 0 || b.rawY <= 0) return null;
 
-  const hi = Math.max(anchor.rawY, target.rawY);
-  const lo = Math.min(anchor.rawY, target.rawY);
+  const hi = Math.max(a.rawY, b.rawY);
+  const lo = Math.min(a.rawY, b.rawY);
   const ratio = hi / lo;
 
   return {
-    x: anchor.px,
-    y1: Math.min(anchor.py, target.py),
-    y2: Math.max(anchor.py, target.py),
+    x,
+    y1: Math.min(a.py, b.py),
+    y2: Math.max(a.py, b.py),
     ratio,
     ratioLabel: formatPerfRatio(ratio),
     percentLabel: formatPerfPercent(ratio),
   };
 }
 
-/** One perf-ruler click: a stable point key plus the curve it belongs to. */
-export interface PerfRulerSelectionEntry {
-  key: string;
-  curve: string;
+/** Inclusive pixel x range, e.g. the horizontal extent of a rendered path. */
+export interface PerfRulerXRange {
+  min: number;
+  max: number;
 }
 
 /**
- * Selection-transition table for perf-ruler clicks. The selection holds up
- * to two entries: `[anchor, target]`. The anchor is a POINT (it defines the
- * iso-x and one end of the ruler); the target entry only identifies a CURVE
- * (the other end is that curve's intersection at the anchor's x).
+ * Horizontal pixel extent of a rendered path. Valid for paths whose x is
+ * monotonic along the length parameter (rooflines: pareto frontiers sorted
+ * by x). Returns null for empty/degenerate paths.
+ */
+export function pathXExtent(path: PerfRulerPathLike): PerfRulerXRange | null {
+  const total = path.getTotalLength();
+  if (!Number.isFinite(total) || total <= 0) return null;
+  const start = path.getPointAtLength(0);
+  const end = path.getPointAtLength(total);
+  if (!Number.isFinite(start.x) || !Number.isFinite(end.x)) return null;
+  return { min: Math.min(start.x, end.x), max: Math.max(start.x, end.x) };
+}
+
+/**
+ * Clamp an iso-x pixel position to the overlapping x range of two curves so
+ * a drag can never leave the span where both intersections exist. Returns
+ * null when the ranges do not overlap (no valid iso-x at all) or the input
+ * is not finite.
+ */
+export function clampIsoX(
+  x: number,
+  a: PerfRulerXRange,
+  b?: PerfRulerXRange | null,
+): number | null {
+  if (!Number.isFinite(x)) return null;
+  const min = b ? Math.max(a.min, b.min) : a.min;
+  const max = b ? Math.min(a.max, b.max) : a.max;
+  if (min > max) return null;
+  return Math.min(Math.max(x, min), max);
+}
+
+/** One perf-ruler click: a curve identity plus the click's data-space x. */
+export interface PerfRulerCurveClick {
+  curve: string;
+  isoX: number;
+}
+
+/**
+ * Perf-ruler selection: up to two curve identities plus the iso-x (in DATA
+ * space, so it survives zoom and metric changes). Neither end is a data
+ * point — both are interpolated on the curves' rendered paths at the iso-x.
+ */
+export interface PerfRulerCurveSelection {
+  curves: string[];
+  isoX: number | null;
+}
+
+export const EMPTY_PERF_RULER_SELECTION: PerfRulerCurveSelection = { curves: [], isoX: null };
+
+/**
+ * Selection-transition table for perf-ruler clicks (curve-to-curve
+ * semantics — clicks land on CURVES, either directly on a widened curve hit
+ * stroke or via a data point standing in for its curve at that point's x):
  *
- * | State            | Click on…                       | Result                        |
- * |------------------|---------------------------------|-------------------------------|
- * | empty            | any point                       | becomes the anchor            |
- * | any              | the exact anchor point          | clear everything              |
- * | any              | another point on anchor's curve | move the anchor (keep target) |
- * | anchor only      | a different curve               | select that curve as target   |
- * | anchor + target  | any point on the target curve   | no-op (keep the measurement — |
- * |                  |                                 | it cannot change the result)  |
- * | anchor + target  | a third curve                   | new measurement anchored there|
+ * | State           | Click on…                | Result                          |
+ * |-----------------|--------------------------|---------------------------------|
+ * | empty           | any curve                | curve A selected, iso-x = click |
+ * | any             | an already-selected curve| MOVE iso-x to the click's x     |
+ * | A only          | a different curve        | curve B selected — measurement  |
+ * |                 |                          | complete at the existing iso-x  |
+ * | A + B           | a third curve            | new measurement: that curve is  |
+ * |                 |                          | the new A, iso-x = click        |
  *
- * Returns `prev` (same reference) for no-op transitions so React state
- * updates can bail out without re-rendering.
+ * Dragging the ruler (not handled here) also moves the iso-x; toggling the
+ * mode off clears the selection. Returns `prev` (same reference) for
+ * invalid clicks so React state updates can bail out without re-rendering.
  */
 export function nextPerfRulerSelection(
-  prev: PerfRulerSelectionEntry[],
-  clicked: PerfRulerSelectionEntry,
-): PerfRulerSelectionEntry[] {
-  const anchor = prev[0];
-  const target = prev[1];
-  if (anchor && anchor.key === clicked.key) return [];
-  if (!anchor) return [clicked];
-  if (clicked.curve === anchor.curve) return target ? [clicked, target] : [clicked];
-  if (!target) return [anchor, clicked];
-  if (clicked.curve === target.curve) return prev;
-  return [clicked];
+  prev: PerfRulerCurveSelection,
+  click: PerfRulerCurveClick,
+): PerfRulerCurveSelection {
+  if (!Number.isFinite(click.isoX)) return prev;
+  const [a, b] = prev.curves;
+  if (!a) return { curves: [click.curve], isoX: click.isoX };
+  if (click.curve === a || click.curve === b) {
+    return prev.isoX === click.isoX ? prev : { curves: prev.curves, isoX: click.isoX };
+  }
+  if (!b) return { curves: [a, click.curve], isoX: prev.isoX ?? click.isoX };
+  return { curves: [click.curve], isoX: click.isoX };
 }
 
 export interface PerfRulerRenderOptions {
@@ -270,6 +311,16 @@ export function renderPerfRuler(
     .attr('dominant-baseline', 'central')
     .attr('font-size', `${PERCENT_FONT_SIZE}px`)
     .attr('font-weight', '600');
+  // Wide invisible drag handle over the line — the caller attaches d3.drag
+  // to it to move the iso-x. Its own pointer-events overrides the group's
+  // `none` (pointer-events inherits), so only this element is interactive.
+  entered
+    .append('line')
+    .attr('class', 'pr-drag')
+    .attr('stroke', 'transparent')
+    .attr('stroke-width', 16)
+    .style('pointer-events', 'stroke')
+    .style('cursor', 'ew-resize');
 
   const merged = entered.merge(selection).style('pointer-events', 'none');
 
@@ -298,6 +349,7 @@ export function renderPerfRuler(
     .attr('y1', y2)
     .attr('y2', y2)
     .attr('stroke', opts.color);
+  merged.select('.pr-drag').attr('x1', x).attr('x2', x).attr('y1', y1).attr('y2', y2);
 
   const showPercent =
     Math.abs(y2 - y1) >= (opts.minSpanForPercent ?? DEFAULT_MIN_SPAN_FOR_PERCENT) &&

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -1,16 +1,18 @@
 import type * as d3 from 'd3';
 
 /**
- * Perf ruler layer — a vertical measurement ruler between two selected data
- * points. Draws a vertical line at the midpoint of the two points' x pixel
- * positions, spanning their y pixel positions, with short horizontal end caps
- * and a label chip showing the performance multiple between the two RAW
- * y-values (e.g. "2.03x", optionally "+103%").
+ * Perf ruler layer — an ISO-X (iso-interactivity) measurement ruler between
+ * two curves. The user anchors the ruler on a point of curve A; the ruler is
+ * a vertical line at the anchor's x pixel position running from the anchor's
+ * y down/up to curve B's y at that SAME x (found by intersecting curve B's
+ * rendered roofline path). Short horizontal end caps mark both ends and a
+ * label chip shows the performance multiple between the two RAW y-values at
+ * that x (e.g. "2.03x", optionally "+103%").
  *
- * Pure module: geometry math is separated from rendering so both are unit
- * testable (see perf-ruler.test.ts). Rendering follows the narrow-mutation
- * rules from docs/d3-charts.md — a single keyed join, texts written before
- * any measurement, rects sized last.
+ * Pure module: intersection search and geometry math are separated from
+ * rendering so all three are unit testable (see perf-ruler.test.ts).
+ * Rendering follows the narrow-mutation rules from docs/d3-charts.md — a
+ * single keyed join, texts written before any measurement, rects sized last.
  */
 
 type GroupSelection = d3.Selection<SVGGElement, unknown, null, undefined>;
@@ -24,8 +26,16 @@ export interface PerfRulerPointInput {
   rawY: number;
 }
 
+/** The target-curve end of the ruler: the intersection at the anchor's x. */
+export interface PerfRulerTargetInput {
+  /** Pixel y of the target curve at the anchor's x. */
+  py: number;
+  /** Raw data-space y at that intersection (yScale.invert of `py`). */
+  rawY: number;
+}
+
 export interface PerfRulerGeometry {
-  /** Ruler line x pixel position: midpoint of the two points' x positions. */
+  /** Ruler line x pixel position: the anchor point's x. */
   x: number;
   /** Top pixel y of the ruler span. */
   y1: number;
@@ -54,27 +64,88 @@ export function formatPerfPercent(ratio: number): string {
 }
 
 /**
- * Compute ruler geometry for two selected points. Returns null for degenerate
- * inputs: non-finite coordinates or non-positive raw y values (a ratio over a
- * zero/negative value is meaningless, and log scales cannot place them).
- * Argument order does not matter.
+ * Minimal path interface needed by {@link intersectPathAtX}. Satisfied by a
+ * real `SVGPathElement`; unit tests supply a synthetic polyline
+ * implementation, since jsdom has no path-length support.
  */
-export function computePerfRulerGeometry(
-  a: PerfRulerPointInput,
-  b: PerfRulerPointInput,
-): PerfRulerGeometry | null {
-  const inputs = [a.px, a.py, a.rawY, b.px, b.py, b.rawY];
-  if (!inputs.every((value) => Number.isFinite(value))) return null;
-  if (a.rawY <= 0 || b.rawY <= 0) return null;
+export interface PerfRulerPathLike {
+  getTotalLength: () => number;
+  getPointAtLength: (length: number) => { x: number; y: number };
+}
 
-  const hi = Math.max(a.rawY, b.rawY);
-  const lo = Math.min(a.rawY, b.rawY);
+/**
+ * Find the point on `path` at horizontal pixel position `x` via binary search
+ * over the path-length parameter. Valid for paths whose x is monotonic along
+ * their length — true for every roofline: they are Pareto frontiers sorted by
+ * x and rendered with `d3.curveMonotoneX`, which preserves x-monotonicity.
+ *
+ * Works in RENDERED pixel space: the roofline `d` attribute is rewritten with
+ * the current scales on every zoom/metric pass before this layer runs, so the
+ * intersection matches the drawn curve exactly at any zoom level. Returns
+ * null when `x` lies outside the path's x extent (curve B does not span the
+ * anchor's x) or the path is degenerate.
+ */
+export function intersectPathAtX(
+  path: PerfRulerPathLike,
+  x: number,
+  opts?: { tolerance?: number; maxIterations?: number },
+): { x: number; y: number } | null {
+  if (!Number.isFinite(x)) return null;
+  const total = path.getTotalLength();
+  if (!Number.isFinite(total) || total <= 0) return null;
+
+  const start = path.getPointAtLength(0);
+  const end = path.getPointAtLength(total);
+  const ascending = end.x >= start.x;
+  const minX = Math.min(start.x, end.x);
+  const maxX = Math.max(start.x, end.x);
+  // Half-pixel slack so an anchor sitting exactly on a curve endpoint (a
+  // shared frontier point) still intersects despite float noise.
+  const slack = 0.5;
+  if (x < minX - slack || x > maxX + slack) return null;
+
+  const tolerance = opts?.tolerance ?? 0.25;
+  const maxIterations = opts?.maxIterations ?? 48;
+  let lo = 0;
+  let hi = total;
+  let best = Math.abs(start.x - x) <= Math.abs(end.x - x) ? start : end;
+  for (let i = 0; i < maxIterations; i++) {
+    const mid = (lo + hi) / 2;
+    const p = path.getPointAtLength(mid);
+    if (Math.abs(p.x - x) < Math.abs(best.x - x)) best = p;
+    if (Math.abs(p.x - x) <= tolerance) return { x: p.x, y: p.y };
+    if (ascending === p.x < x) lo = mid;
+    else hi = mid;
+  }
+  // Interval exhausted without hitting tolerance (extremely steep segment) —
+  // the closest sample seen is still visually on the curve.
+  return { x: best.x, y: best.y };
+}
+
+/**
+ * Compute iso-x ruler geometry from the anchor point and the target curve's
+ * intersection at the anchor's x. Returns null for degenerate inputs:
+ * non-finite coordinates or non-positive raw y values (a ratio over a
+ * zero/negative value is meaningless, and log scales cannot place them).
+ * The ratio is symmetric: higher raw y over lower raw y, regardless of which
+ * side is the anchor.
+ */
+export function computeIsoXRulerGeometry(
+  anchor: PerfRulerPointInput,
+  target: PerfRulerTargetInput,
+): PerfRulerGeometry | null {
+  const inputs = [anchor.px, anchor.py, anchor.rawY, target.py, target.rawY];
+  if (!inputs.every((value) => Number.isFinite(value))) return null;
+  if (anchor.rawY <= 0 || target.rawY <= 0) return null;
+
+  const hi = Math.max(anchor.rawY, target.rawY);
+  const lo = Math.min(anchor.rawY, target.rawY);
   const ratio = hi / lo;
 
   return {
-    x: (a.px + b.px) / 2,
-    y1: Math.min(a.py, b.py),
-    y2: Math.max(a.py, b.py),
+    x: anchor.px,
+    y1: Math.min(anchor.py, target.py),
+    y2: Math.max(anchor.py, target.py),
     ratio,
     ratioLabel: formatPerfRatio(ratio),
     percentLabel: formatPerfPercent(ratio),

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -244,10 +244,20 @@ export const EMPTY_PERF_RULER_STATE: PerfRulerState = { rulers: [], draft: null,
  * the in-progress draft). Dragging a completed ruler moves its own iso-x
  * (see {@link movePerfRulerIsoX}); toggling the mode off clears everything.
  * Returns `prev` (same reference) for no-ops so React state can bail out.
+ *
+ * `clampToOverlap` (optional) constrains a COMPLETING measurement's iso-x
+ * to the overlapping x-range of its curve pair (the caller owns the
+ * pixel-space paths/scales, so it supplies the clamp). Returning null
+ * means the pair shares NO x-range at all — the measurement is rejected
+ * and the draft stays anchored so the user can pick a different second
+ * curve. Without the clamp, an out-of-range iso-x would append a ruler
+ * that never renders and has no drag handle to recover it: stuck in
+ * state, counted against the cap, removable only by clear/toggle-off.
  */
 export function nextPerfRulerState(
   prev: PerfRulerState,
   click: PerfRulerCurveClick,
+  clampToOverlap?: (curveA: string, curveB: string, isoX: number) => number | null,
 ): PerfRulerState {
   if (!Number.isFinite(click.isoX)) return prev;
   if (!prev.draft) return { ...prev, draft: { curve: click.curve, isoX: click.isoX } };
@@ -256,11 +266,17 @@ export function nextPerfRulerState(
       ? prev
       : { ...prev, draft: { curve: prev.draft.curve, isoX: click.isoX } };
   }
+  let isoX = prev.draft.isoX;
+  if (clampToOverlap) {
+    const clamped = clampToOverlap(prev.draft.curve, click.curve, isoX);
+    if (clamped === null || !Number.isFinite(clamped)) return prev;
+    isoX = clamped;
+  }
   const measurement: PerfRulerMeasurement = {
     id: prev.nextId,
     curveA: prev.draft.curve,
     curveB: click.curve,
-    isoX: prev.draft.isoX,
+    isoX,
   };
   const rulers = [...prev.rulers, measurement];
   while (rulers.length > MAX_PERF_RULERS) rulers.shift();
@@ -446,6 +462,18 @@ export function computePerfRulerLabelLayout(
   return buildLabelLayout(geometry, side, labelY, fontSize);
 }
 
+/**
+ * Clamp a label center-y so the glyph box (plus 4px padding) stays inside
+ * [0, chartHeight]. The top clamp always applies; the bottom clamp only
+ * when the chart height is known. Top wins if the chart is shorter than
+ * one label.
+ */
+function clampLabelY(y: number, fontSize: number, chartHeight?: number): number {
+  const min = fontSize / 2 + 4;
+  const max = chartHeight === undefined ? Number.POSITIVE_INFINITY : chartHeight - 4 - fontSize / 2;
+  return Math.max(Math.min(y, max), min);
+}
+
 /** Horizontal pixel span of a laid-out label (estimated, no DOM). */
 function labelSpan(
   layout: PerfRulerLabelLayout,
@@ -493,6 +521,12 @@ export function computePerfRulerLabelLayouts(
       const direction = layout.labelY < midY ? -1 : 1;
       let nudgedY = layout.labelY + direction * (fontSize + 10);
       if (direction === -1 && nudgedY - fontSize / 2 < 4) nudgedY = midY + LABEL_OFFSET_Y;
+      // Every nudge (and the below-midpoint fallback) re-applies the same
+      // vertical clamp as the initial placement — a label and its × chip
+      // must never escape the plot, even at the cost of residual overlap.
+      nudgedY = clampLabelY(nudgedY, fontSize, opts?.chartHeight);
+      // Clamped into a wall: no further progress is possible this direction.
+      if (nudgedY === layout.labelY) break;
       layout = buildLabelLayout(geometry, layout.side, nudgedY, fontSize);
     }
     const span = labelSpan(layout, geometry.ratioLabel, fontSize);

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -1,0 +1,241 @@
+import type * as d3 from 'd3';
+
+/**
+ * Perf ruler layer — a vertical measurement ruler between two selected data
+ * points. Draws a vertical line at the midpoint of the two points' x pixel
+ * positions, spanning their y pixel positions, with short horizontal end caps
+ * and a label chip showing the performance multiple between the two RAW
+ * y-values (e.g. "2.03x", optionally "+103%").
+ *
+ * Pure module: geometry math is separated from rendering so both are unit
+ * testable (see perf-ruler.test.ts). Rendering follows the narrow-mutation
+ * rules from docs/d3-charts.md — a single keyed join, texts written before
+ * any measurement, rects sized last.
+ */
+
+type GroupSelection = d3.Selection<SVGGElement, unknown, null, undefined>;
+
+export interface PerfRulerPointInput {
+  /** Pixel x position of the point (already passed through the x scale). */
+  px: number;
+  /** Pixel y position of the point (already passed through the y scale). */
+  py: number;
+  /** Raw data-space y value — the ratio uses raw values, never pixels. */
+  rawY: number;
+}
+
+export interface PerfRulerGeometry {
+  /** Ruler line x pixel position: midpoint of the two points' x positions. */
+  x: number;
+  /** Top pixel y of the ruler span. */
+  y1: number;
+  /** Bottom pixel y of the ruler span. */
+  y2: number;
+  /** Performance multiple: higher raw y over lower raw y (>= 1). */
+  ratio: number;
+  /** Formatted ratio, e.g. "2.03x". */
+  ratioLabel: string;
+  /** Formatted relative gain, e.g. "+103%". */
+  percentLabel: string;
+}
+
+/** Format a performance multiple like "2.03x" (fewer decimals as it grows). */
+export function formatPerfRatio(ratio: number): string {
+  if (!Number.isFinite(ratio) || ratio <= 0) return '';
+  if (ratio >= 100) return `${Math.round(ratio)}x`;
+  if (ratio >= 10) return `${ratio.toFixed(1)}x`;
+  return `${ratio.toFixed(2)}x`;
+}
+
+/** Format the relative gain of a multiple like "+103%". */
+export function formatPerfPercent(ratio: number): string {
+  if (!Number.isFinite(ratio) || ratio <= 0) return '';
+  return `+${Math.round((ratio - 1) * 100)}%`;
+}
+
+/**
+ * Compute ruler geometry for two selected points. Returns null for degenerate
+ * inputs: non-finite coordinates or non-positive raw y values (a ratio over a
+ * zero/negative value is meaningless, and log scales cannot place them).
+ * Argument order does not matter.
+ */
+export function computePerfRulerGeometry(
+  a: PerfRulerPointInput,
+  b: PerfRulerPointInput,
+): PerfRulerGeometry | null {
+  const inputs = [a.px, a.py, a.rawY, b.px, b.py, b.rawY];
+  if (!inputs.every((value) => Number.isFinite(value))) return null;
+  if (a.rawY <= 0 || b.rawY <= 0) return null;
+
+  const hi = Math.max(a.rawY, b.rawY);
+  const lo = Math.min(a.rawY, b.rawY);
+  const ratio = hi / lo;
+
+  return {
+    x: (a.px + b.px) / 2,
+    y1: Math.min(a.py, b.py),
+    y2: Math.max(a.py, b.py),
+    ratio,
+    ratioLabel: formatPerfRatio(ratio),
+    percentLabel: formatPerfPercent(ratio),
+  };
+}
+
+export interface PerfRulerRenderOptions {
+  /** Stroke for the ruler line and end caps (e.g. `var(--primary)`). */
+  color: string;
+  /** Label chip background (readability over chart marks). */
+  labelBg: string;
+  /** Label text color, paired with `labelBg`. */
+  labelText: string;
+  /** Chart inner width; lets the label flip sides instead of clipping. */
+  chartWidth?: number;
+  /** Half-length of the horizontal end caps in px. Default 6. */
+  capHalfWidth?: number;
+  /**
+   * Minimum vertical pixel span before the secondary "+NN%" line is shown.
+   * Below this the chip only fits the ratio cleanly. Default 34.
+   */
+  minSpanForPercent?: number;
+}
+
+const LABEL_GAP = 10;
+const CHIP_PAD_X = 6;
+const CHIP_PAD_Y = 4;
+const RATIO_FONT_SIZE = 11;
+const PERCENT_FONT_SIZE = 9;
+const LINE_HEIGHT = 13;
+export const DEFAULT_MIN_SPAN_FOR_PERCENT = 34;
+
+/**
+ * Estimate text width via getBBox when a real DOM is available, falling back
+ * to a character-count estimate in non-DOM environments (unit tests).
+ */
+function measureTextWidth(node: unknown, text: string, fontSize: number): number {
+  const maybe = node as { getBBox?: () => { width: number } } | null;
+  if (maybe && typeof maybe.getBBox === 'function') {
+    const width = maybe.getBBox().width;
+    if (width > 0) return width;
+  }
+  return text.length * fontSize * 0.62;
+}
+
+/**
+ * Render (or clear, when `geometry` is null) the perf ruler inside `group`.
+ * Idempotent keyed join — safe to call from render, zoom, and display passes.
+ * The whole layer is pointer-events: none so it never intercepts point clicks.
+ */
+export function renderPerfRuler(
+  group: GroupSelection,
+  geometry: PerfRulerGeometry | null,
+  opts: PerfRulerRenderOptions,
+): void {
+  const selection = group
+    .selectAll<SVGGElement, PerfRulerGeometry>('.perf-ruler')
+    .data(geometry ? [geometry] : []);
+
+  selection.exit().remove();
+  if (!geometry) return;
+
+  const entered = selection.enter().append('g').attr('class', 'perf-ruler');
+  entered
+    .append('line')
+    .attr('class', 'pr-line')
+    .attr('stroke-width', 2)
+    .attr('stroke-dasharray', '5 4');
+  entered.append('line').attr('class', 'pr-cap pr-cap-top').attr('stroke-width', 2);
+  entered.append('line').attr('class', 'pr-cap pr-cap-bottom').attr('stroke-width', 2);
+  entered.append('rect').attr('class', 'pr-bg').attr('rx', 4).attr('ry', 4).attr('opacity', 0.92);
+  entered
+    .append('text')
+    .attr('class', 'pr-text pr-text-ratio')
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'central')
+    .attr('font-size', `${RATIO_FONT_SIZE}px`)
+    .attr('font-weight', '700');
+  entered
+    .append('text')
+    .attr('class', 'pr-text pr-text-percent')
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'central')
+    .attr('font-size', `${PERCENT_FONT_SIZE}px`)
+    .attr('font-weight', '600');
+
+  const merged = entered.merge(selection).style('pointer-events', 'none');
+
+  const { x, y1, y2 } = geometry;
+  const capHalfWidth = opts.capHalfWidth ?? 6;
+  const midY = (y1 + y2) / 2;
+
+  merged
+    .select('.pr-line')
+    .attr('x1', x)
+    .attr('x2', x)
+    .attr('y1', y1)
+    .attr('y2', y2)
+    .attr('stroke', opts.color);
+  merged
+    .select('.pr-cap-top')
+    .attr('x1', x - capHalfWidth)
+    .attr('x2', x + capHalfWidth)
+    .attr('y1', y1)
+    .attr('y2', y1)
+    .attr('stroke', opts.color);
+  merged
+    .select('.pr-cap-bottom')
+    .attr('x1', x - capHalfWidth)
+    .attr('x2', x + capHalfWidth)
+    .attr('y1', y2)
+    .attr('y2', y2)
+    .attr('stroke', opts.color);
+
+  const showPercent =
+    Math.abs(y2 - y1) >= (opts.minSpanForPercent ?? DEFAULT_MIN_SPAN_FOR_PERCENT) &&
+    geometry.percentLabel !== '';
+
+  // Two passes per docs/d3-charts.md "Batched Label Measurement": write both
+  // texts first, then measure, then position the chip and texts.
+  merged.select('.pr-text-ratio').attr('fill', opts.labelText).text(geometry.ratioLabel);
+  merged
+    .select('.pr-text-percent')
+    .attr('fill', opts.labelText)
+    .style('display', showPercent ? '' : 'none')
+    .text(showPercent ? geometry.percentLabel : '');
+
+  const ratioWidth = measureTextWidth(
+    merged.select('.pr-text-ratio').node(),
+    geometry.ratioLabel,
+    RATIO_FONT_SIZE,
+  );
+  const percentWidth = showPercent
+    ? measureTextWidth(
+        merged.select('.pr-text-percent').node(),
+        geometry.percentLabel,
+        PERCENT_FONT_SIZE,
+      )
+    : 0;
+  const chipWidth = Math.max(ratioWidth, percentWidth) + CHIP_PAD_X * 2;
+  const chipHeight = (showPercent ? 2 : 1) * LINE_HEIGHT + CHIP_PAD_Y * 2;
+
+  // Prefer the right side of the line; flip left when the chip would clip.
+  const flipLeft = opts.chartWidth !== undefined && x + LABEL_GAP + chipWidth > opts.chartWidth;
+  const chipX = flipLeft ? x - LABEL_GAP - chipWidth : x + LABEL_GAP;
+  const chipY = midY - chipHeight / 2;
+  const textX = chipX + chipWidth / 2;
+
+  merged
+    .select('.pr-bg')
+    .attr('x', chipX)
+    .attr('y', chipY)
+    .attr('width', chipWidth)
+    .attr('height', chipHeight)
+    .attr('fill', opts.labelBg);
+  merged
+    .select('.pr-text-ratio')
+    .attr('x', textX)
+    .attr('y', chipY + CHIP_PAD_Y + LINE_HEIGHT / 2);
+  merged
+    .select('.pr-text-percent')
+    .attr('x', textX)
+    .attr('y', chipY + CHIP_PAD_Y + LINE_HEIGHT * 1.5);
+}

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -9,6 +9,8 @@ import type * as d3 from 'd3';
  * horizontal end caps mark both ends and a big annotation-style label
  * (e.g. "2.03x") sits in open chart space with a curved arrow pointing at
  * the ruler line; the ratio compares the two RAW y-values at that x.
+ * Multiple rulers can coexist (capped at {@link MAX_PERF_RULERS}); each is
+ * individually draggable and deletable via a hover × button.
  *
  * Pure module: intersection search and geometry math are separated from
  * rendering so all three are unit testable (see perf-ruler.test.ts).
@@ -194,48 +196,126 @@ export interface PerfRulerCurveClick {
   isoX: number;
 }
 
-/**
- * Perf-ruler selection: up to two curve identities plus the iso-x (in DATA
- * space, so it survives zoom and metric changes). Neither end is a data
- * point — both are interpolated on the curves' rendered paths at the iso-x.
- */
-export interface PerfRulerCurveSelection {
-  curves: string[];
-  isoX: number | null;
+/** One completed measurement: a curve pair plus its iso-x in DATA space. */
+export interface PerfRulerMeasurement {
+  /** Stable id — render join key, drag identity, and delete target. */
+  id: number;
+  curveA: string;
+  curveB: string;
+  /** Iso-x in DATA space, so it survives zoom and metric changes. */
+  isoX: number;
 }
 
-export const EMPTY_PERF_RULER_SELECTION: PerfRulerCurveSelection = { curves: [], isoX: null };
+/**
+ * Multi-ruler state: completed measurements accumulate in `rulers` while at
+ * most one in-progress `draft` (curve A + iso-x, awaiting curve B) exists.
+ * `nextId` is a monotonic counter so deleted ids are never reused.
+ */
+export interface PerfRulerState {
+  rulers: PerfRulerMeasurement[];
+  draft: PerfRulerCurveClick | null;
+  nextId: number;
+}
 
 /**
- * Selection-transition table for perf-ruler clicks (curve-to-curve
- * semantics — clicks land on CURVES, either directly on a widened curve hit
- * stroke or via a data point standing in for its curve at that point's x):
- *
- * | State           | Click on…                | Result                          |
- * |-----------------|--------------------------|---------------------------------|
- * | empty           | any curve                | curve A selected, iso-x = click |
- * | any             | an already-selected curve| MOVE iso-x to the click's x     |
- * | A only          | a different curve        | curve B selected — measurement  |
- * |                 |                          | complete at the existing iso-x  |
- * | A + B           | a third curve            | new measurement: that curve is  |
- * |                 |                          | the new A, iso-x = click        |
- *
- * Dragging the ruler (not handled here) also moves the iso-x; toggling the
- * mode off clears the selection. Returns `prev` (same reference) for
- * invalid clicks so React state updates can bail out without re-rendering.
+ * Ruler cap — completing a measurement beyond this silently drops the
+ * OLDEST ruler (keeps the chart readable while never rejecting the newest
+ * measurement the user just placed).
  */
-export function nextPerfRulerSelection(
-  prev: PerfRulerCurveSelection,
+export const MAX_PERF_RULERS = 8;
+
+export const EMPTY_PERF_RULER_STATE: PerfRulerState = { rulers: [], draft: null, nextId: 1 };
+
+/**
+ * Click-transition table for multi-ruler mode (clicks land on CURVES,
+ * either on a widened curve hit stroke or via a data point standing in for
+ * its curve at that point's x):
+ *
+ * | State      | Click on…              | Result                             |
+ * |------------|------------------------|------------------------------------|
+ * | no draft   | any curve              | new draft: curve A, iso-x = click  |
+ * | draft on A | curve A again          | MOVE the draft iso-x to the click  |
+ * | draft on A | a different curve B    | measurement COMPLETE at the draft  |
+ * |            |                        | iso-x — appended to `rulers`, the  |
+ * |            |                        | next click starts a fresh draft    |
+ *
+ * Completed rulers are never retargeted by clicks — clicking any curve
+ * after completion starts a NEW ruler (move/reset semantics apply only to
+ * the in-progress draft). Dragging a completed ruler moves its own iso-x
+ * (see {@link movePerfRulerIsoX}); toggling the mode off clears everything.
+ * Returns `prev` (same reference) for no-ops so React state can bail out.
+ */
+export function nextPerfRulerState(
+  prev: PerfRulerState,
   click: PerfRulerCurveClick,
-): PerfRulerCurveSelection {
+): PerfRulerState {
   if (!Number.isFinite(click.isoX)) return prev;
-  const [a, b] = prev.curves;
-  if (!a) return { curves: [click.curve], isoX: click.isoX };
-  if (click.curve === a || click.curve === b) {
-    return prev.isoX === click.isoX ? prev : { curves: prev.curves, isoX: click.isoX };
+  if (!prev.draft) return { ...prev, draft: { curve: click.curve, isoX: click.isoX } };
+  if (click.curve === prev.draft.curve) {
+    return prev.draft.isoX === click.isoX
+      ? prev
+      : { ...prev, draft: { curve: prev.draft.curve, isoX: click.isoX } };
   }
-  if (!b) return { curves: [a, click.curve], isoX: prev.isoX ?? click.isoX };
-  return { curves: [click.curve], isoX: click.isoX };
+  const measurement: PerfRulerMeasurement = {
+    id: prev.nextId,
+    curveA: prev.draft.curve,
+    curveB: click.curve,
+    isoX: prev.draft.isoX,
+  };
+  const rulers = [...prev.rulers, measurement];
+  while (rulers.length > MAX_PERF_RULERS) rulers.shift();
+  return { rulers, draft: null, nextId: prev.nextId + 1 };
+}
+
+/** Move one completed ruler's iso-x (drag commit). No-ops return `prev`. */
+export function movePerfRulerIsoX(prev: PerfRulerState, id: number, isoX: number): PerfRulerState {
+  if (!Number.isFinite(isoX)) return prev;
+  const index = prev.rulers.findIndex((ruler) => ruler.id === id);
+  if (index === -1 || prev.rulers[index].isoX === isoX) return prev;
+  const rulers = [...prev.rulers];
+  rulers[index] = { ...rulers[index], isoX };
+  return { ...prev, rulers };
+}
+
+/** Delete one ruler by id. Unknown ids return `prev` (same reference). */
+export function deletePerfRuler(prev: PerfRulerState, id: number): PerfRulerState {
+  const rulers = prev.rulers.filter((ruler) => ruler.id !== id);
+  return rulers.length === prev.rulers.length ? prev : { ...prev, rulers };
+}
+
+/** Clear all rulers and the draft. Already-empty state returns `prev`. */
+export function clearPerfRulers(prev: PerfRulerState): PerfRulerState {
+  if (prev.rulers.length === 0 && prev.draft === null) return prev;
+  return { rulers: [], draft: null, nextId: prev.nextId };
+}
+
+/**
+ * Prune rulers whose curves left the underlying data entirely (per-ruler:
+ * a ruler survives while BOTH its curves still exist). Hidden-but-present
+ * curves are the caller's visibility concern, not pruning — pass an
+ * existence predicate, not a visibility one. Returns `prev` on no-ops.
+ */
+export function prunePerfRulers(
+  prev: PerfRulerState,
+  curveExists: (curve: string) => boolean,
+): PerfRulerState {
+  const rulers = prev.rulers.filter(
+    (ruler) => curveExists(ruler.curveA) && curveExists(ruler.curveB),
+  );
+  const draft = prev.draft && curveExists(prev.draft.curve) ? prev.draft : null;
+  if (rulers.length === prev.rulers.length && draft === prev.draft) return prev;
+  return { ...prev, rulers, draft };
+}
+
+/** Every curve referenced by any ruler or the draft (hit-halo styling). */
+export function perfRulerCurveSet(state: PerfRulerState): Set<string> {
+  const curves = new Set<string>();
+  for (const ruler of state.rulers) {
+    curves.add(ruler.curveA);
+    curves.add(ruler.curveB);
+  }
+  if (state.draft) curves.add(state.draft.curve);
+  return curves;
 }
 
 export interface PerfRulerRenderOptions {
@@ -246,14 +326,12 @@ export interface PerfRulerRenderOptions {
    * stays readable over chart content. Default `var(--background)`.
    */
   halo?: string;
-  /** Chart inner width; lets the label flip sides instead of clipping. */
-  chartWidth?: number;
-  /** Chart inner height; lets the label drop below near the top edge. */
-  chartHeight?: number;
   /** Half-length of the horizontal end caps in px. Default 6. */
   capHalfWidth?: number;
   /** Big ratio label font size in px. Default 32. */
   labelFontSize?: number;
+  /** Called with the ruler's id when its hover × button is clicked. */
+  onDelete?: (id: number) => void;
 }
 
 export const DEFAULT_LABEL_FONT_SIZE = 32;
@@ -262,6 +340,8 @@ const LABEL_OFFSET_Y = 46;
 const ARROW_TIP_GAP = 5;
 const ARROW_HEAD_LENGTH = 9;
 const ARROW_HEAD_HALF_WIDTH = 4.5;
+const DELETE_GAP = 18;
+const LABEL_COLLISION_NUDGE_TRIES = 4;
 
 export interface PerfRulerLabelLayoutOptions {
   /** Chart inner width; the label flips to the left side when clipping. */
@@ -285,6 +365,48 @@ export interface PerfRulerLabelLayout {
   arrowPath: string;
   /** Filled arrowhead triangle pointing at the ruler-line midpoint. */
   arrowHeadPath: string;
+  /** Center of the × delete button, just past the label's far end. */
+  deleteX: number;
+  deleteY: number;
+}
+
+/** Estimated label width without a DOM (unit-testable placement math). */
+function estimateLabelWidth(label: string, fontSize: number): number {
+  return label.length * fontSize * 0.6;
+}
+
+/** Build the arrow + delete positions for a chosen label placement. */
+function buildLabelLayout(
+  geometry: Pick<PerfRulerGeometry, 'x' | 'y1' | 'y2' | 'ratioLabel'>,
+  side: 1 | -1,
+  labelY: number,
+  fontSize: number,
+): PerfRulerLabelLayout {
+  const midY = (geometry.y1 + geometry.y2) / 2;
+  const labelX = geometry.x + side * LABEL_OFFSET_X;
+  const above = labelY < midY;
+  // Quarter-curve: leaves the label vertically, ends horizontally at the
+  // back of the arrowhead so the head points straight at the line.
+  const startX = labelX + side * 4;
+  const startY = labelY + (above ? 1 : -1) * (fontSize / 2 + 6);
+  const tipX = geometry.x + side * ARROW_TIP_GAP;
+  const backX = tipX + side * ARROW_HEAD_LENGTH;
+  const arrowPath = `M ${startX} ${startY} Q ${startX} ${midY} ${backX} ${midY}`;
+  const arrowHeadPath =
+    `M ${tipX} ${midY} ` +
+    `L ${backX} ${midY - ARROW_HEAD_HALF_WIDTH} ` +
+    `L ${backX} ${midY + ARROW_HEAD_HALF_WIDTH} Z`;
+  const estimatedWidth = estimateLabelWidth(geometry.ratioLabel, fontSize);
+  return {
+    labelX,
+    labelY,
+    textAnchor: side === 1 ? 'start' : 'end',
+    side,
+    arrowPath,
+    arrowHeadPath,
+    deleteX: labelX + side * (estimatedWidth + DELETE_GAP),
+    deleteY: labelY,
+  };
 }
 
 /**
@@ -303,7 +425,7 @@ export function computePerfRulerLabelLayout(
 ): PerfRulerLabelLayout {
   const fontSize = opts?.fontSize ?? DEFAULT_LABEL_FONT_SIZE;
   const midY = (geometry.y1 + geometry.y2) / 2;
-  const estimatedWidth = geometry.ratioLabel.length * fontSize * 0.6;
+  const estimatedWidth = estimateLabelWidth(geometry.ratioLabel, fontSize);
   const requiredRoom = LABEL_OFFSET_X + estimatedWidth + 8;
 
   let side: 1 | -1 = 1;
@@ -312,57 +434,113 @@ export function computePerfRulerLabelLayout(
     if (roomRight < requiredRoom && geometry.x > roomRight) side = -1;
   }
 
-  let above = true;
   let labelY = midY - LABEL_OFFSET_Y;
   if (labelY - fontSize / 2 < 4) {
-    above = false;
     labelY = midY + LABEL_OFFSET_Y;
     if (opts?.chartHeight !== undefined && labelY + fontSize / 2 > opts.chartHeight - 4) {
       // No room below either — clamp the above-placement inside the chart.
-      above = true;
       labelY = Math.max(fontSize / 2 + 4, midY - LABEL_OFFSET_Y);
     }
   }
 
-  const labelX = geometry.x + side * LABEL_OFFSET_X;
-  // Quarter-curve: leaves the label vertically, ends horizontally at the
-  // back of the arrowhead so the head points straight at the line.
-  const startX = labelX + side * 4;
-  const startY = labelY + (above ? 1 : -1) * (fontSize / 2 + 6);
-  const tipX = geometry.x + side * ARROW_TIP_GAP;
-  const backX = tipX + side * ARROW_HEAD_LENGTH;
-  const arrowPath = `M ${startX} ${startY} Q ${startX} ${midY} ${backX} ${midY}`;
-  const arrowHeadPath =
-    `M ${tipX} ${midY} ` +
-    `L ${backX} ${midY - ARROW_HEAD_HALF_WIDTH} ` +
-    `L ${backX} ${midY + ARROW_HEAD_HALF_WIDTH} Z`;
+  return buildLabelLayout(geometry, side, labelY, fontSize);
+}
 
-  return {
-    labelX,
-    labelY,
-    textAnchor: side === 1 ? 'start' : 'end',
-    side,
-    arrowPath,
-    arrowHeadPath,
-  };
+/** Horizontal pixel span of a laid-out label (estimated, no DOM). */
+function labelSpan(
+  layout: PerfRulerLabelLayout,
+  label: string,
+  fontSize: number,
+): { x0: number; x1: number } {
+  const width = estimateLabelWidth(label, fontSize);
+  return layout.textAnchor === 'start'
+    ? { x0: layout.labelX, x1: layout.labelX + width }
+    : { x0: layout.labelX - width, x1: layout.labelX };
 }
 
 /**
- * Render (or clear, when `geometry` is null) the perf ruler inside `group`.
- * Idempotent keyed join — safe to call from render, zoom, and display passes.
- * The whole layer is pointer-events: none so it never intercepts point clicks.
+ * Lay out labels for MULTIPLE rulers at once with cheap collision handling:
+ * each label after the first is nudged vertically (away from its ruler's
+ * midpoint, up to a few steps) while its estimated box overlaps an already
+ * placed label. Best-effort — after the nudge budget, residual overlap is
+ * accepted. Null geometries pass through as null (hidden rulers keep their
+ * slot so results align with the input array).
  */
-export function renderPerfRuler(
+export function computePerfRulerLabelLayouts(
+  geometries: (Pick<PerfRulerGeometry, 'x' | 'y1' | 'y2' | 'ratioLabel'> | null)[],
+  opts?: PerfRulerLabelLayoutOptions,
+): (PerfRulerLabelLayout | null)[] {
+  const fontSize = opts?.fontSize ?? DEFAULT_LABEL_FONT_SIZE;
+  const placed: { x0: number; x1: number; y: number }[] = [];
+  return geometries.map((geometry) => {
+    if (!geometry) return null;
+    let layout = computePerfRulerLabelLayout(geometry, opts);
+    const midY = (geometry.y1 + geometry.y2) / 2;
+    const overlapsPlaced = (candidate: PerfRulerLabelLayout): boolean => {
+      const span = labelSpan(candidate, geometry.ratioLabel, fontSize);
+      return placed.some(
+        (box) =>
+          span.x0 < box.x1 && box.x0 < span.x1 && Math.abs(candidate.labelY - box.y) < fontSize + 8,
+      );
+    };
+    for (
+      let attempt = 0;
+      attempt < LABEL_COLLISION_NUDGE_TRIES && overlapsPlaced(layout);
+      attempt++
+    ) {
+      // Nudge away from the midpoint in the label's current direction; when
+      // that would clip the top, restart below the midpoint instead.
+      const direction = layout.labelY < midY ? -1 : 1;
+      let nudgedY = layout.labelY + direction * (fontSize + 10);
+      if (direction === -1 && nudgedY - fontSize / 2 < 4) nudgedY = midY + LABEL_OFFSET_Y;
+      layout = buildLabelLayout(geometry, layout.side, nudgedY, fontSize);
+    }
+    const span = labelSpan(layout, geometry.ratioLabel, fontSize);
+    placed.push({ x0: span.x0, x1: span.x1, y: layout.labelY });
+    return layout;
+  });
+}
+
+/** One ruler ready to render: id (join key) + geometry + label layout. */
+export interface PerfRulerRenderEntry {
+  id: number;
+  geometry: PerfRulerGeometry;
+  layout: PerfRulerLabelLayout;
+}
+
+/** Delay before the hover × hides — bridges the label → × pointer gap. */
+const DELETE_HIDE_DELAY_MS = 250;
+const hideTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+
+/** Toggle one ruler group's hover affordances (× button + line emphasis). */
+function setPerfRulerHover(node: Element, hovered: boolean): void {
+  const deleteButton = node.querySelector<SVGGElement>('.pr-delete');
+  if (deleteButton) deleteButton.style.display = hovered ? '' : 'none';
+  const line = node.querySelector<SVGLineElement>('.pr-line');
+  line?.setAttribute('stroke-width', hovered ? '3' : '2');
+}
+
+/**
+ * Render ALL perf rulers inside `group` as one keyed join (join key: ruler
+ * id), so rulers enter/exit independently and drags stay bound to the right
+ * ruler. Idempotent — safe to call from render, zoom, and display passes.
+ *
+ * Each ruler group is pointer-events: none so it never intercepts point
+ * clicks; only its drag handle, its big label, and its × button opt back in.
+ * Hovering the label (or drag handle) reveals a circular × delete button
+ * next to the label — the × carries the `no-export` class, which
+ * useChartExport strips from PNG exports.
+ */
+export function renderPerfRulers(
   group: GroupSelection,
-  geometry: PerfRulerGeometry | null,
+  entries: PerfRulerRenderEntry[],
   opts: PerfRulerRenderOptions,
 ): void {
   const selection = group
-    .selectAll<SVGGElement, PerfRulerGeometry>('.perf-ruler')
-    .data(geometry ? [geometry] : []);
+    .selectAll<SVGGElement, PerfRulerRenderEntry>('.perf-ruler')
+    .data(entries, (entry) => String(entry.id));
 
   selection.exit().remove();
-  if (!geometry) return;
 
   const entered = selection.enter().append('g').attr('class', 'perf-ruler');
   entered
@@ -384,17 +562,20 @@ export function renderPerfRuler(
   entered.append('path').attr('class', 'pr-arrow-head').attr('stroke', 'none');
   // Big annotation-style ratio label with a halo stroke painted UNDER the
   // glyph fill (paint-order) so it reads over dense chart content without a
-  // chip rect.
+  // chip rect. It is hoverable (pointer-events overrides the group's none)
+  // so it can reveal this ruler's × delete button.
   entered
     .append('text')
     .attr('class', 'pr-text pr-text-ratio')
     .attr('dominant-baseline', 'central')
     .attr('font-weight', '800')
     .attr('paint-order', 'stroke')
-    .attr('stroke-linejoin', 'round');
+    .attr('stroke-linejoin', 'round')
+    .style('pointer-events', 'auto')
+    .style('cursor', 'default');
   // Wide invisible drag handle over the line — the caller attaches d3.drag
-  // to it to move the iso-x. Its own pointer-events overrides the group's
-  // `none` (pointer-events inherits), so only this element is interactive.
+  // to it to move this ruler's iso-x. Its own pointer-events overrides the
+  // group's `none` (pointer-events inherits).
   entered
     .append('line')
     .attr('class', 'pr-drag')
@@ -402,52 +583,107 @@ export function renderPerfRuler(
     .attr('stroke-width', 16)
     .style('pointer-events', 'stroke')
     .style('cursor', 'ew-resize');
+  // Circular × delete button, revealed on hover. `no-export` keeps it out
+  // of PNG exports (useChartExport hides/filters that class).
+  const enteredDelete = entered
+    .append('g')
+    .attr('class', 'pr-delete no-export')
+    .style('display', 'none')
+    .style('pointer-events', 'all')
+    .style('cursor', 'pointer');
+  enteredDelete.append('circle').attr('class', 'pr-delete-bg').attr('r', 10);
+  enteredDelete
+    .append('text')
+    .attr('class', 'pr-delete-x')
+    .attr('text-anchor', 'middle')
+    .attr('dominant-baseline', 'central')
+    .attr('font-size', '12px')
+    .attr('font-weight', '700')
+    .text('×');
 
   const merged = entered.merge(selection).style('pointer-events', 'none');
 
-  const { x, y1, y2 } = geometry;
   const capHalfWidth = opts.capHalfWidth ?? 6;
-
-  merged
-    .select('.pr-line')
-    .attr('x1', x)
-    .attr('x2', x)
-    .attr('y1', y1)
-    .attr('y2', y2)
-    .attr('stroke', opts.color);
-  merged
-    .select('.pr-cap-top')
-    .attr('x1', x - capHalfWidth)
-    .attr('x2', x + capHalfWidth)
-    .attr('y1', y1)
-    .attr('y2', y1)
-    .attr('stroke', opts.color);
-  merged
-    .select('.pr-cap-bottom')
-    .attr('x1', x - capHalfWidth)
-    .attr('x2', x + capHalfWidth)
-    .attr('y1', y2)
-    .attr('y2', y2)
-    .attr('stroke', opts.color);
-  merged.select('.pr-drag').attr('x1', x).attr('x2', x).attr('y1', y1).attr('y2', y2);
-
   const fontSize = opts.labelFontSize ?? DEFAULT_LABEL_FONT_SIZE;
-  const layout = computePerfRulerLabelLayout(geometry, {
-    chartWidth: opts.chartWidth,
-    chartHeight: opts.chartHeight,
-    fontSize,
-  });
 
-  merged.select('.pr-arrow').attr('d', layout.arrowPath).attr('stroke', opts.color);
-  merged.select('.pr-arrow-head').attr('d', layout.arrowHeadPath).attr('fill', opts.color);
   merged
-    .select('.pr-text-ratio')
-    .attr('x', layout.labelX)
-    .attr('y', layout.labelY)
-    .attr('text-anchor', layout.textAnchor)
+    .select<SVGLineElement>('.pr-line')
+    .attr('x1', (entry) => entry.geometry.x)
+    .attr('x2', (entry) => entry.geometry.x)
+    .attr('y1', (entry) => entry.geometry.y1)
+    .attr('y2', (entry) => entry.geometry.y2)
+    .attr('stroke', opts.color);
+  merged
+    .select<SVGLineElement>('.pr-cap-top')
+    .attr('x1', (entry) => entry.geometry.x - capHalfWidth)
+    .attr('x2', (entry) => entry.geometry.x + capHalfWidth)
+    .attr('y1', (entry) => entry.geometry.y1)
+    .attr('y2', (entry) => entry.geometry.y1)
+    .attr('stroke', opts.color);
+  merged
+    .select<SVGLineElement>('.pr-cap-bottom')
+    .attr('x1', (entry) => entry.geometry.x - capHalfWidth)
+    .attr('x2', (entry) => entry.geometry.x + capHalfWidth)
+    .attr('y1', (entry) => entry.geometry.y2)
+    .attr('y2', (entry) => entry.geometry.y2)
+    .attr('stroke', opts.color);
+  merged
+    .select<SVGLineElement>('.pr-drag')
+    .attr('x1', (entry) => entry.geometry.x)
+    .attr('x2', (entry) => entry.geometry.x)
+    .attr('y1', (entry) => entry.geometry.y1)
+    .attr('y2', (entry) => entry.geometry.y2);
+
+  merged
+    .select<SVGPathElement>('.pr-arrow')
+    .attr('d', (entry) => entry.layout.arrowPath)
+    .attr('stroke', opts.color);
+  merged
+    .select<SVGPathElement>('.pr-arrow-head')
+    .attr('d', (entry) => entry.layout.arrowHeadPath)
+    .attr('fill', opts.color);
+  merged
+    .select<SVGTextElement>('.pr-text-ratio')
+    .attr('x', (entry) => entry.layout.labelX)
+    .attr('y', (entry) => entry.layout.labelY)
+    .attr('text-anchor', (entry) => entry.layout.textAnchor)
     .attr('font-size', `${fontSize}px`)
     .attr('fill', opts.color)
     .attr('stroke', opts.halo ?? 'var(--background)')
     .attr('stroke-width', 5)
-    .text(geometry.ratioLabel);
+    .text((entry) => entry.geometry.ratioLabel);
+
+  merged
+    .select<SVGGElement>('.pr-delete')
+    .attr('transform', (entry) => `translate(${entry.layout.deleteX}, ${entry.layout.deleteY})`)
+    .on('click', (event: MouseEvent, entry: PerfRulerRenderEntry) => {
+      event.stopPropagation();
+      opts.onDelete?.(entry.id);
+    });
+  merged.select<SVGCircleElement>('.pr-delete-bg').attr('fill', opts.color);
+  merged.select<SVGTextElement>('.pr-delete-x').attr('fill', opts.halo ?? 'var(--background)');
+
+  // Hover reveal: the group itself is not hit-testable, but mouseenter /
+  // mouseleave fire on it when the pointer enters/leaves its interactive
+  // children (label, drag handle, ×). The pointer crosses dead space
+  // between the label and the ×, so hide on a short delay and cancel the
+  // timer when hover resumes.
+  merged
+    .on('mouseenter', (event: MouseEvent) => {
+      const node = event.currentTarget as Element;
+      const timer = hideTimers.get(node);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        hideTimers.delete(node);
+      }
+      setPerfRulerHover(node, true);
+    })
+    .on('mouseleave', (event: MouseEvent) => {
+      const node = event.currentTarget as Element;
+      const timer = setTimeout(() => {
+        hideTimers.delete(node);
+        setPerfRulerHover(node, false);
+      }, DELETE_HIDE_DELAY_MS);
+      hideTimers.set(node, timer);
+    });
 }

--- a/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
+++ b/packages/app/src/lib/d3-chart/layers/perf-ruler.ts
@@ -6,9 +6,9 @@ import type * as d3 from 'd3';
  * freely chosen iso-x whose BOTH ends are interpolated on the two curves'
  * rendered roofline paths at that x (neither end needs to be a data point).
  * The ruler is draggable horizontally to fine-tune the iso-x. Short
- * horizontal end caps mark both ends and a label chip shows the performance
- * multiple between the two RAW y-values at that x (e.g. "2.03x",
- * optionally "+103%").
+ * horizontal end caps mark both ends and a big annotation-style label
+ * (e.g. "2.03x") sits in open chart space with a curved arrow pointing at
+ * the ruler line; the ratio compares the two RAW y-values at that x.
  *
  * Pure module: intersection search and geometry math are separated from
  * rendering so all three are unit testable (see perf-ruler.test.ts).
@@ -37,8 +37,6 @@ export interface PerfRulerGeometry {
   ratio: number;
   /** Formatted ratio, e.g. "2.03x". */
   ratioLabel: string;
-  /** Formatted relative gain, e.g. "+103%". */
-  percentLabel: string;
 }
 
 /** Format a performance multiple like "2.03x" (fewer decimals as it grows). */
@@ -47,12 +45,6 @@ export function formatPerfRatio(ratio: number): string {
   if (ratio >= 100) return `${Math.round(ratio)}x`;
   if (ratio >= 10) return `${ratio.toFixed(1)}x`;
   return `${ratio.toFixed(2)}x`;
-}
-
-/** Format the relative gain of a multiple like "+103%". */
-export function formatPerfPercent(ratio: number): string {
-  if (!Number.isFinite(ratio) || ratio <= 0) return '';
-  return `+${Math.round((ratio - 1) * 100)}%`;
 }
 
 /**
@@ -140,8 +132,22 @@ export function computeIsoXRulerGeometry(
     y2: Math.max(a.py, b.py),
     ratio,
     ratioLabel: formatPerfRatio(ratio),
-    percentLabel: formatPerfPercent(ratio),
   };
+}
+
+/**
+ * Whether a rendered curve is visible given its inline `opacity` style.
+ * Legend and precision toggles hide curves with `opacity: 0` while leaving
+ * the path in the DOM (so it can fade back in) — those curves must be
+ * neither clickable nor measurable. Hover dimming uses small non-zero
+ * values and stays measurable; a missing/empty opacity means fully visible.
+ */
+export function isPerfRulerCurveVisible(opacity: string | null | undefined): boolean {
+  if (opacity === null || opacity === undefined) return true;
+  const trimmed = opacity.trim();
+  if (trimmed === '') return true;
+  const value = Number(trimmed);
+  return Number.isNaN(value) ? true : value > 0;
 }
 
 /** Inclusive pixel x range, e.g. the horizontal extent of a rendered path. */
@@ -233,42 +239,112 @@ export function nextPerfRulerSelection(
 }
 
 export interface PerfRulerRenderOptions {
-  /** Stroke for the ruler line and end caps (e.g. `var(--primary)`). */
+  /** Stroke for the ruler line, caps, arrow, and label (accent color). */
   color: string;
-  /** Label chip background (readability over chart marks). */
-  labelBg: string;
-  /** Label text color, paired with `labelBg`. */
-  labelText: string;
+  /**
+   * Halo stroke painted behind the big label (paint-order: stroke) so it
+   * stays readable over chart content. Default `var(--background)`.
+   */
+  halo?: string;
   /** Chart inner width; lets the label flip sides instead of clipping. */
   chartWidth?: number;
+  /** Chart inner height; lets the label drop below near the top edge. */
+  chartHeight?: number;
   /** Half-length of the horizontal end caps in px. Default 6. */
   capHalfWidth?: number;
-  /**
-   * Minimum vertical pixel span before the secondary "+NN%" line is shown.
-   * Below this the chip only fits the ratio cleanly. Default 34.
-   */
-  minSpanForPercent?: number;
+  /** Big ratio label font size in px. Default 32. */
+  labelFontSize?: number;
 }
 
-const LABEL_GAP = 10;
-const CHIP_PAD_X = 6;
-const CHIP_PAD_Y = 4;
-const RATIO_FONT_SIZE = 11;
-const PERCENT_FONT_SIZE = 9;
-const LINE_HEIGHT = 13;
-export const DEFAULT_MIN_SPAN_FOR_PERCENT = 34;
+export const DEFAULT_LABEL_FONT_SIZE = 32;
+const LABEL_OFFSET_X = 46;
+const LABEL_OFFSET_Y = 46;
+const ARROW_TIP_GAP = 5;
+const ARROW_HEAD_LENGTH = 9;
+const ARROW_HEAD_HALF_WIDTH = 4.5;
+
+export interface PerfRulerLabelLayoutOptions {
+  /** Chart inner width; the label flips to the left side when clipping. */
+  chartWidth?: number;
+  /** Chart inner height; keeps the below-placement inside the chart. */
+  chartHeight?: number;
+  /** Label font size in px. Default {@link DEFAULT_LABEL_FONT_SIZE}. */
+  fontSize?: number;
+}
+
+export interface PerfRulerLabelLayout {
+  /** Text anchor-point x (near edge of the label, facing the line). */
+  labelX: number;
+  /** Text center y (render with dominant-baseline: central). */
+  labelY: number;
+  /** 'start' when the label sits right of the line, 'end' when left. */
+  textAnchor: 'start' | 'end';
+  /** +1 = label right of the ruler line, -1 = left. */
+  side: 1 | -1;
+  /** Curved arrow from under the label to the ruler-line midpoint. */
+  arrowPath: string;
+  /** Filled arrowhead triangle pointing at the ruler-line midpoint. */
+  arrowHeadPath: string;
+}
 
 /**
- * Estimate text width via getBBox when a real DOM is available, falling back
- * to a character-count estimate in non-DOM environments (unit tests).
+ * Lay out the big annotation label and its arrow (mock-up: a large "2x"
+ * next to the ruler with a curved arrow pointing at the vertical line).
+ * The label prefers the upper-right of the line midpoint (open chart
+ * space), flips horizontally when it would clip the right edge with more
+ * room on the left, and drops below the midpoint when it would clip the
+ * top. The arrow is a quarter-curve whose end tangent is horizontal, so
+ * the arrowhead points squarely at the line's midpoint. Pure — unit
+ * testable without a DOM (text width is estimated from the label length).
  */
-function measureTextWidth(node: unknown, text: string, fontSize: number): number {
-  const maybe = node as { getBBox?: () => { width: number } } | null;
-  if (maybe && typeof maybe.getBBox === 'function') {
-    const width = maybe.getBBox().width;
-    if (width > 0) return width;
+export function computePerfRulerLabelLayout(
+  geometry: Pick<PerfRulerGeometry, 'x' | 'y1' | 'y2' | 'ratioLabel'>,
+  opts?: PerfRulerLabelLayoutOptions,
+): PerfRulerLabelLayout {
+  const fontSize = opts?.fontSize ?? DEFAULT_LABEL_FONT_SIZE;
+  const midY = (geometry.y1 + geometry.y2) / 2;
+  const estimatedWidth = geometry.ratioLabel.length * fontSize * 0.6;
+  const requiredRoom = LABEL_OFFSET_X + estimatedWidth + 8;
+
+  let side: 1 | -1 = 1;
+  if (opts?.chartWidth !== undefined) {
+    const roomRight = opts.chartWidth - geometry.x;
+    if (roomRight < requiredRoom && geometry.x > roomRight) side = -1;
   }
-  return text.length * fontSize * 0.62;
+
+  let above = true;
+  let labelY = midY - LABEL_OFFSET_Y;
+  if (labelY - fontSize / 2 < 4) {
+    above = false;
+    labelY = midY + LABEL_OFFSET_Y;
+    if (opts?.chartHeight !== undefined && labelY + fontSize / 2 > opts.chartHeight - 4) {
+      // No room below either — clamp the above-placement inside the chart.
+      above = true;
+      labelY = Math.max(fontSize / 2 + 4, midY - LABEL_OFFSET_Y);
+    }
+  }
+
+  const labelX = geometry.x + side * LABEL_OFFSET_X;
+  // Quarter-curve: leaves the label vertically, ends horizontally at the
+  // back of the arrowhead so the head points straight at the line.
+  const startX = labelX + side * 4;
+  const startY = labelY + (above ? 1 : -1) * (fontSize / 2 + 6);
+  const tipX = geometry.x + side * ARROW_TIP_GAP;
+  const backX = tipX + side * ARROW_HEAD_LENGTH;
+  const arrowPath = `M ${startX} ${startY} Q ${startX} ${midY} ${backX} ${midY}`;
+  const arrowHeadPath =
+    `M ${tipX} ${midY} ` +
+    `L ${backX} ${midY - ARROW_HEAD_HALF_WIDTH} ` +
+    `L ${backX} ${midY + ARROW_HEAD_HALF_WIDTH} Z`;
+
+  return {
+    labelX,
+    labelY,
+    textAnchor: side === 1 ? 'start' : 'end',
+    side,
+    arrowPath,
+    arrowHeadPath,
+  };
 }
 
 /**
@@ -296,21 +372,26 @@ export function renderPerfRuler(
     .attr('stroke-dasharray', '5 4');
   entered.append('line').attr('class', 'pr-cap pr-cap-top').attr('stroke-width', 2);
   entered.append('line').attr('class', 'pr-cap pr-cap-bottom').attr('stroke-width', 2);
-  entered.append('rect').attr('class', 'pr-bg').attr('rx', 4).attr('ry', 4).attr('opacity', 0.92);
+  // Curved annotation arrow + filled head pointing at the line midpoint.
+  // The head is a plain filled triangle (no <marker>), so it needs no defs
+  // ids, inherits nothing chart-specific, and PNG-exports like any path.
+  entered
+    .append('path')
+    .attr('class', 'pr-arrow')
+    .attr('fill', 'none')
+    .attr('stroke-width', 2.5)
+    .attr('stroke-linecap', 'round');
+  entered.append('path').attr('class', 'pr-arrow-head').attr('stroke', 'none');
+  // Big annotation-style ratio label with a halo stroke painted UNDER the
+  // glyph fill (paint-order) so it reads over dense chart content without a
+  // chip rect.
   entered
     .append('text')
     .attr('class', 'pr-text pr-text-ratio')
-    .attr('text-anchor', 'middle')
     .attr('dominant-baseline', 'central')
-    .attr('font-size', `${RATIO_FONT_SIZE}px`)
-    .attr('font-weight', '700');
-  entered
-    .append('text')
-    .attr('class', 'pr-text pr-text-percent')
-    .attr('text-anchor', 'middle')
-    .attr('dominant-baseline', 'central')
-    .attr('font-size', `${PERCENT_FONT_SIZE}px`)
-    .attr('font-weight', '600');
+    .attr('font-weight', '800')
+    .attr('paint-order', 'stroke')
+    .attr('stroke-linejoin', 'round');
   // Wide invisible drag handle over the line — the caller attaches d3.drag
   // to it to move the iso-x. Its own pointer-events overrides the group's
   // `none` (pointer-events inherits), so only this element is interactive.
@@ -326,7 +407,6 @@ export function renderPerfRuler(
 
   const { x, y1, y2 } = geometry;
   const capHalfWidth = opts.capHalfWidth ?? 6;
-  const midY = (y1 + y2) / 2;
 
   merged
     .select('.pr-line')
@@ -351,53 +431,23 @@ export function renderPerfRuler(
     .attr('stroke', opts.color);
   merged.select('.pr-drag').attr('x1', x).attr('x2', x).attr('y1', y1).attr('y2', y2);
 
-  const showPercent =
-    Math.abs(y2 - y1) >= (opts.minSpanForPercent ?? DEFAULT_MIN_SPAN_FOR_PERCENT) &&
-    geometry.percentLabel !== '';
+  const fontSize = opts.labelFontSize ?? DEFAULT_LABEL_FONT_SIZE;
+  const layout = computePerfRulerLabelLayout(geometry, {
+    chartWidth: opts.chartWidth,
+    chartHeight: opts.chartHeight,
+    fontSize,
+  });
 
-  // Two passes per docs/d3-charts.md "Batched Label Measurement": write both
-  // texts first, then measure, then position the chip and texts.
-  merged.select('.pr-text-ratio').attr('fill', opts.labelText).text(geometry.ratioLabel);
-  merged
-    .select('.pr-text-percent')
-    .attr('fill', opts.labelText)
-    .style('display', showPercent ? '' : 'none')
-    .text(showPercent ? geometry.percentLabel : '');
-
-  const ratioWidth = measureTextWidth(
-    merged.select('.pr-text-ratio').node(),
-    geometry.ratioLabel,
-    RATIO_FONT_SIZE,
-  );
-  const percentWidth = showPercent
-    ? measureTextWidth(
-        merged.select('.pr-text-percent').node(),
-        geometry.percentLabel,
-        PERCENT_FONT_SIZE,
-      )
-    : 0;
-  const chipWidth = Math.max(ratioWidth, percentWidth) + CHIP_PAD_X * 2;
-  const chipHeight = (showPercent ? 2 : 1) * LINE_HEIGHT + CHIP_PAD_Y * 2;
-
-  // Prefer the right side of the line; flip left when the chip would clip.
-  const flipLeft = opts.chartWidth !== undefined && x + LABEL_GAP + chipWidth > opts.chartWidth;
-  const chipX = flipLeft ? x - LABEL_GAP - chipWidth : x + LABEL_GAP;
-  const chipY = midY - chipHeight / 2;
-  const textX = chipX + chipWidth / 2;
-
-  merged
-    .select('.pr-bg')
-    .attr('x', chipX)
-    .attr('y', chipY)
-    .attr('width', chipWidth)
-    .attr('height', chipHeight)
-    .attr('fill', opts.labelBg);
+  merged.select('.pr-arrow').attr('d', layout.arrowPath).attr('stroke', opts.color);
+  merged.select('.pr-arrow-head').attr('d', layout.arrowHeadPath).attr('fill', opts.color);
   merged
     .select('.pr-text-ratio')
-    .attr('x', textX)
-    .attr('y', chipY + CHIP_PAD_Y + LINE_HEIGHT / 2);
-  merged
-    .select('.pr-text-percent')
-    .attr('x', textX)
-    .attr('y', chipY + CHIP_PAD_Y + LINE_HEIGHT * 1.5);
+    .attr('x', layout.labelX)
+    .attr('y', layout.labelY)
+    .attr('text-anchor', layout.textAnchor)
+    .attr('font-size', `${fontSize}px`)
+    .attr('fill', opts.color)
+    .attr('stroke', opts.halo ?? 'var(--background)')
+    .attr('stroke-width', 5)
+    .text(geometry.ratioLabel);
 }

--- a/packages/app/src/lib/d3-chart/layers/test-helpers.ts
+++ b/packages/app/src/lib/d3-chart/layers/test-helpers.ts
@@ -5,7 +5,8 @@
  * selection that tracks attribute, style, and text calls. The mock supports
  * the full chaining API used by the layer modules: selectAll, data, join,
  * enter, append, exit, remove, merge, select, attr, style, text, each, datum,
- * empty, nodes, transition, duration.
+ * empty, nodes, transition, duration, on (handlers are recorded on the
+ * element, not dispatched — tests can invoke them directly).
  */
 
 // ─── Mock Element ────────────────────────────────────────────────────
@@ -19,6 +20,8 @@ export interface MockElement {
   children: MockElement[];
   datum: unknown;
   removed: boolean;
+  /** Event handlers recorded by `.on()`, keyed by event type. */
+  handlers?: Record<string, (...args: unknown[]) => void>;
 }
 
 function createMockElement(tag: string, datum?: unknown): MockElement {
@@ -72,6 +75,7 @@ export interface MockSelection<Datum = unknown> {
   size: () => number;
   transition: () => MockSelection<Datum>;
   duration: (ms: number) => MockSelection<Datum>;
+  on: (type: string, listener: (...args: unknown[]) => void) => MockSelection<Datum>;
 }
 
 // ─── Entry point ─────────────────────────────────────────────────────
@@ -183,7 +187,9 @@ function makeSel<D>(
       const store = getChildStore(parentEl);
       const existing = store.get(selectorStr)?.elements.filter((e) => !e.removed) ?? [];
 
-      const bound = makeSel(existing, newData, parentEl, selectorStr);
+      // The UPDATE selection holds only elements with a datum (by index,
+      // like d3) — surplus elements belong to exit(), not update/merge.
+      const bound = makeSel(existing.slice(0, newData.length), newData, parentEl, selectorStr);
 
       // Override enter/exit/join on the data-bound selection.
       bound.enter = () => {
@@ -302,6 +308,17 @@ function makeSel<D>(
       );
     },
 
+    // ── on ──
+    // Records the handler on each element (keyed by event type) without
+    // dispatching — tests can look it up and invoke it directly.
+    on(type: string, listener: (...args: unknown[]) => void): MockSelection<D> {
+      for (const el of elements) {
+        el.handlers ??= {};
+        el.handlers[type] = listener;
+      }
+      return sel;
+    },
+
     // ── Utility ──
     empty: () => elements.length === 0,
     nodes: () => elements,
@@ -364,13 +381,19 @@ function findChildBySelector(el: MockElement, selector: string): MockElement | u
     }
   }
 
-  // Fall back to scanning children by class attribute
+  // Fall back to scanning children by class attribute (breadth-first:
+  // direct children win over nested descendants, like d3's `select`).
   for (const child of el.children) {
     if (child.removed) continue;
     const classes = String(child.attrs['class'] || '').split(/\s+/u);
     if (classes.includes(selectorClass)) {
       return child;
     }
+  }
+  for (const child of el.children) {
+    if (child.removed) continue;
+    const nested = findChildBySelector(child, selector);
+    if (nested) return nested;
   }
   return undefined;
 }


### PR DESCRIPTION
Adds an opt-in **Perf Ruler** to the latency scatter chart for
iso-interactivity comparisons — now fully curve-to-curve: the ruler does
not need to start or end at a data point. Toggle the mode on, click two
curves, and a vertical ruler is drawn at a freely chosen iso-x whose BOTH
endpoints are interpolated on the curves' rendered roofline paths; a big
annotation-style ratio label (e.g. **2.03x**) sits in open chart space with
a curved arrow pointing at the ruler line — it flips near chart edges and
stays readable over marks via a background halo. Drag the ruler
horizontally to fine-tune the x position.

- **Interaction:** in ruler mode the curves themselves are clickable via
  invisible widened hit strokes (no interference with point hover/click or
  zoom when the mode is off — the hit layer only exists while the mode is
  on). First click selects curve A and sets the iso-x from the click;
  a second curve completes the measurement; clicking either selected curve
  moves the iso-x; a third curve starts a new measurement; toggling off
  clears. Data-point clicks act as clicks on the point's curve at that
  point's x.
- **Dragging:** the ruler line carries a wide invisible drag handle;
  `d3.drag` moves the iso-x continuously (rAF-throttled recompute of both
  path intersections and the label), clamped to the overlapping x-range of
  the two curves, without panning the chart.
- The iso-x is stored in DATA space, so the measurement survives zoom,
  pan, and metric/display changes; if either curve does not span the
  iso-x at the current render, the ruler hides but the selection is kept
  and recovers. The ratio uses raw `yScale.invert` values (log-safe).
- **Legend/filter edge case:** hiding a selected curve via the legend (or
  precision filters) clears the ruler/label/arrow/halos immediately in the
  same frame; the selection is kept, so re-showing the curve restores the
  measurement. Curves removed from the data entirely are pruned.
- **Unofficial run support:** overlay curves from `?unofficialrun=` views
  are first-class — either side of the measurement can be an overlay
  roofline.
- Pure, unit-tested module (`perf-ruler.ts`, 73 tests): geometry, path
  intersection binary search, x-extent/clamping helpers, label/arrow
  layout, curve-visibility predicate, selection transition table, and
  renderer.
- **Multiple rulers:** completed measurements accumulate (up to 8; oldest
  dropped beyond the cap). Click a curve after completing a measurement to
  start the next ruler. Hover a ruler to reveal a × chip that deletes just
  that ruler (excluded from PNG exports), or use the "Clear rulers (N)"
  legend action to remove all; turning the toggle off clears every ruler.
  Each ruler drags, hides with its own curves' legend toggles, and prunes
  independently; overlapping big labels nudge apart vertically.
- EN/zh UI strings and analytics (`latency_perf_ruler_toggled`,
  `latency_perf_ruler_deleted`, `latency_perf_ruler_cleared{count}`,
  `latency_perf_ruler_curve_clicked`, `latency_data_point_clicked` with
  `perfRuler: true`).

## 中文说明

为延迟散点图新增可选的**性能标尺**，现已升级为完全的曲线对曲线测量——
标尺不再需要以数据点为起点或终点。开启开关后点击两条曲线，即可在任意
选定的横坐标处绘制垂直标尺，两个端点均在两条曲线的渲染路径上插值；大号
注释式比值标签（如 **2.03x**）置于图表空白处，弯曲箭头指向标尺线，靠近
边缘时自动翻转，并以背景色光晕保证在图元上的可读性（不再显示百分比行）。
横向拖动标尺可精细调整测量位置。

- **交互：**标尺模式下曲线本身可点击（隐形加宽命中描边，模式关闭时不
  存在，完全不影响数据点悬停、点击与缩放）。第一次点击选中曲线 A 并设
  定横坐标；点击第二条曲线完成测量；再次点击已选曲线可移动横坐标；点
  击第三条曲线开始新测量；关闭开关清除。点击数据点等同于在该点横坐标
  处点击其所属曲线。
- **拖动：**标尺线带宽大的隐形拖动手柄，`d3.drag` 按帧节流实时重算两
  个交点与标签，拖动范围限制在两条曲线的重叠横坐标区间内，不会触发平移。
- 横坐标以数据空间存储，缩放、平移、切换指标后测量依然有效；若任一曲
  线在当前视图不覆盖该横坐标，标尺隐藏但保留选择，视图恢复后自动重现。
  倍数基于 `yScale.invert` 的原始 y 值计算，对数坐标下依然正确。
- **图例/筛选边界情况：**通过图例或精度筛选隐藏所选曲线时，标尺、标签、
  箭头与光晕立即（同帧）消失；选择保留，重新显示曲线即恢复测量；仅当曲线
  从数据中彻底移除时才清除选择。
- **非官方运行支持：**`?unofficialrun=` 视图中的 overlay 曲线可作为测
  量的任意一侧。
- **多标尺：**完成的测量会累积（最多 8 把，超出时丢弃最旧的）。完成一次
  测量后点击曲线即可开始下一把标尺。悬停标尺会显示 × 按钮，可单独删除该
  标尺（PNG 导出中不会出现）；也可通过图例操作区的「清除标尺（N）」一键
  清空。关闭开关会清除所有标尺。每把标尺可独立拖动、随其所属曲线的图例
  开关独立隐藏、独立剪枝；两个大标签重叠时会自动垂直错开。
- 纯函数模块（`perf-ruler.ts`，73 个单元测试）：几何计算、路径交点二分
  查找、横向范围与钳制、标签与箭头布局、曲线可见性判定、选择状态转移表
  与渲染器。
- 中英文界面文案与埋点事件同步更新。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new interaction surface on the main inference chart (D3 events, refs, layout effects) with many edge cases around zoom, legend visibility, and overlay runs; core math is isolated and tested but integration complexity is moderate.
> 
> **Overview**
> Adds an optional **Perf Ruler** on the latency scatter chart so users can compare two roofline curves at a shared x: click two curves (or points on them), see a vertical ruler with a **performance multiple** label, drag the ruler along x, and keep up to **8** measurements with per-ruler delete and a legend **Clear rulers** action.
> 
> A new pure **`perf-ruler`** D3 layer handles path intersection, geometry, label layout (with collision nudging), and SVG rendering; **`ScatterGraph`** wires mode state, widened curve hit targets, rAF-throttled drag, a custom chart layer on render/zoom, legend toggle plus EN/zh copy, overlay/official point click routing, filter/data pruning, and analytics events. **`perf-ruler.test.ts`** adds broad unit coverage; D3 **test-helpers** gain `.on` recording and tighter data/join behavior for layer tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69176290d8a794be9a0c30b0f8e59f62433cd4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->