### PR TITLE
Add 24 glossary terms from a codebase and article sweep / 通过梳理代码库与文章新增 24 条术语

### DIFF
--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -835,6 +835,328 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     benchmarkContext:
       'InferenceX 将 TileRT 作为独立的框架标签，并在每个 SKU 最佳配置视图中特意保留它；否则只按吞吐量取胜的曲线会丢掉 TileRT 真正服务的那些运行点。比较时请在匹配交互性下进行，而不要只看峰值吞吐量。',
   },
+  recipe: {
+    term: '测试配置',
+    aliases: ['recipe', '配置方案', '服务配置'],
+    plainEnglish:
+      '一套测试配置就是产生某条曲线的全部选择：模型、引擎、镜像、精度、并行策略和工作负载。',
+    definition:
+      '测试配置是指产生一条实测曲线所需的完整组合：模型、推理引擎与容器镜像、数值精度、并行策略、芯片系统和工作负载。',
+    explanation:
+      'InferenceX 上的每个数据点都属于某套测试配置，对同一套配置做并发扫描就画出它的曲线。改动其中任何一项都会得到另一套配置，而不是同一套配置的变体，因此升级引擎镜像会作为独立结果上报，而不会并入既有曲线。',
+    significance:
+      '芯片峰值规格无法描述服务性能，同一颗芯片在不同配置下可以相差数倍。把整套组合写清楚，结论才可核查：脱离配置的单个数字既无法复现，也无法与其他厂商公平比较。',
+    benchmarkContext:
+      'InferenceX 的测试配置主要跟随 vLLM 与 SGLang 官方 cookbook，并使用上游镜像，因此结果反映用户实际能部署的性能，而不是为基准测试特调过的镜像。数据点 tooltip 会展示背后的配置，并给出运行溯源链接。',
+  },
+  'tail-latency': {
+    term: '尾部延迟',
+    aliases: ['tail latency', 'p90', 'p99', '分位数延迟'],
+    plainEnglish:
+      '尾部延迟描述的是最慢的那部分请求，而不是典型请求，因为用户真正会注意到的正是这些。',
+    definition: '尾部延迟是请求分布高分位处的延迟，例如 p90 或 p99，而不是均值或中位数。',
+    explanation:
+      '分位数回答的问题与平均值不同。p90 为 5 秒意味着每 10 条请求中至少有 1 条等了这么久，而这条请求可能正是卡住某个 agent 继续执行的那一条。真实服务中的延迟分布高度偏斜，均值可能远低于尾部，从而把问题完全掩盖。',
+    significance:
+      '容量规划通常按分位数而不是平均值来定，因为一个平均很快、尾部很慢的服务，对用户来说依然是不合格的。某些优化还会在改善均值的同时恶化尾部，而单一汇总数字只会把它记成一次明确的胜利。',
+    benchmarkContext:
+      'InferenceX 上报的指标都带分位数限定，并在坐标轴上标明，因此 p90 TTFT 与平均 TTFT 不会混在同一次比较里。agentic 运行的分布尤其偏斜，因为端到端延迟随输出长度增长，最长的生成会主导尾部。',
+  },
+  'service-level-objective': {
+    term: '服务级目标',
+    aliases: ['service level objective', 'SLO', '延迟目标'],
+    plainEnglish: 'SLO 是一套部署必须兑现的性能承诺，例如十条请求中有九条要在一秒内返回首 token。',
+    definition: '服务级目标是对某个服务指标设定的目标值，通常表示为对延迟或交互性的分位数约束。',
+    explanation:
+      '一条有用的 SLO 会同时给出指标、分位数和阈值。此时服务容量就是系统在不违反该约束的前提下能维持的吞吐量，它小于峰值吞吐量，也是运营方唯一可以据以规划容量的数字。',
+    significance:
+      '吞吐量曲线上的每个点都是可达的，但只有一部分满足既定承诺。两套系统的峰值吞吐量可能很接近，而在交互性或首 token 约束下能保留多少吞吐量却相差悬殊。',
+    benchmarkContext:
+      'InferenceX 不强加统一的行业 SLO，因为可接受的目标因产品而异：交互式编程需要较高的 token 速率，批处理则可以容忍数秒的首 token 延迟。请按自己的阈值读取前沿曲线，而不要直接比较峰值。',
+  },
+  'acceptance-length': {
+    term: '接受长度',
+    aliases: ['acceptance length', 'AL', '接受率'],
+    plainEnglish:
+      '接受长度是指每次验证中完整模型实际认可的草稿 token 数，它决定了投机解码是否划算。',
+    definition: '接受长度是目标模型在一次验证中平均接受的投机草稿 token 数量。',
+    explanation:
+      '只有草稿能通过验证，投机解码才会省时间。接受长度接近 1 意味着起草与验证这套机制白跑了一趟；数值较高则能把一次昂贵的目标模型计算摊薄到多个输出 token 上。该数值取决于 speculator、草稿长度、模型本身以及正在生成的内容。',
+    significance:
+      '正因为接受率取决于内容，基准测试有可能在无意中左右结论。合成或匿名化文本对于在真实语料上训练的 speculator 而言属于分布外数据，实测接受率会朝任一方向偏离生产环境的真实值。',
+    benchmarkContext:
+      'AgentX 回放的是填充了合成 token 的匿名化 trace，因此不让接受率由这些内容自行决定。运行时改为套用一组固定接受长度，按模型、speculator、草稿长度和思考模式在外部 agentic 编码数据集上采集，从而保持厂商中立。',
+  },
+  'unofficial-run': {
+    term: '非官方运行',
+    aliases: ['unofficial run', '非官方 overlay', '社区运行'],
+    plainEnglish: '非官方运行是尚未入库到已发布数据集的基准运行，但仍可通过 URL 叠加绘制在图表上。',
+    definition:
+      '非官方运行是指通过运行 ID 以 overlay 形式加载进仪表板的 CI 基准运行，其数据不来自已发布的数据库。',
+    explanation:
+      '在页面 URL 中加上运行 ID，就会拉取该次运行，并用专门的 overlay 配色把它的数据点、roofline 和表格行画在官方数据旁边。overlay 走的是独立的渲染路径，因此可以按硬件类型开关，也可以按运行逐个关闭，而不影响下方的官方数据选择。',
+    significance:
+      '结果发布通常滞后于产出，而正在调优某套配置的贡献者，需要在决定是否入库之前先看到新曲线与当前前沿的对比。overlay 让尚未定稿的运行可被审阅，同时不赋予它已发布测量结果的地位。',
+    benchmarkContext:
+      'overlay 的配色来自按运行序号分配的调色板，而不是硬件配色，因此不会被误认为官方数据。部分视图依赖只在入库运行中持久化的数据，这些视图会明确说明 overlay 不可用，而不是默默略过。',
+  },
+  'chunked-prefill': {
+    term: '分块 prefill',
+    aliases: ['chunked prefill', '分块预填充'],
+    plainEnglish:
+      '分块 prefill 把长提示词分片读取，而不是一次性读完，这样其他用户在此期间仍能持续收到 token。',
+    definition:
+      '分块 prefill 把提示词处理切分为固定大小的 token 分块，由调度器与正在进行的 decode 工作交错执行。',
+    explanation:
+      '不切分的 prefill 会占用加速器直到整条提示词处理完，所有正在流式输出的用户都得排在后面。切分之后调度器可以交替执行，让 decode 在分块之间继续推进。分块大小是一个调优旋钮：分块越大 prefill 效率越高，分块越小对 decode 的打断越少。',
+    significance:
+      '这项技术把某一个用户的首 token 问题，转换成对所有人来说小而平稳的开销，通常是更划算的取舍。提示词越长它越重要：单条不切分的十万 token prefill 足以让整套部署卡住。',
+    benchmarkContext:
+      '分块大小属于测试配置的一部分，同一条曲线上不同点的取值也可能不同，因此吞吐量的跳变有可能来自重新调参而不是新硬件。长的 agentic 提示词让这个参数变得关键，而定长短提示词场景根本暴露不出这一点。',
+  },
+  roofline: {
+    term: 'Roofline 曲线',
+    aliases: ['roofline', '前沿包络', 'roofline 曲线'],
+    plainEnglish:
+      '在 InferenceX 上，roofline 是按硬件配置在其最优点上画出的外包络线，用来展示它达到过的边界。',
+    definition:
+      'InferenceX 上的 roofline 是按硬件配置绘制的 Pareto 包络曲线，穿过该配置在当前所选坐标轴下未被支配的数据点。',
+    explanation:
+      '哪个角算“最好”取决于所选指标：吞吐量对交互性取右上角，而成本类指标数值越低越好，因此包络会锚定在所选指标组合定义的那个角上。x 值退化的点不具备入选资格，但在显示全部数据点的视图中仍会绘制。',
+    significance:
+      '直接看一团原始数据点容易挑选有利结果，因为调优不佳的配置也会贡献一些运营方绝不会选择的点。包络线展示的是每套系统可达的边界，而容量决策正是依据这个形状做出的。',
+    benchmarkContext:
+      '这与 HPC 中经典的 roofline 模型不同：后者把可达 FLOPS 与算术强度放在一起，用于判断计算受限还是访存受限，仪表板只借用了“上界”这一图形表达。roofline 方向按指标配置，因此同一批数据点在不同坐标轴下会得到不同的包络。',
+  },
+  'arithmetic-intensity': {
+    term: '算术强度',
+    aliases: ['arithmetic intensity', '运算强度', '计算访存比'],
+    plainEnglish: '算术强度表示每搬运一个字节能做多少次运算，它决定瓶颈落在计算单元还是显存上。',
+    definition: '算术强度是一次计算所执行的算术运算次数与其在显存和计算单元之间搬运的字节数之比。',
+    explanation:
+      'prefill 会用同一份权重处理大量 token，每个载入的字节都被反复复用，因此通常是计算受限的。decode 每一步每条序列只产出一个 token，却仍要读取权重和 KV cache，搬运了大量数据却只做很少运算，因此通常受显存带宽限制。',
+    significance:
+      '两个阶段受限于芯片的不同部分，这解释了为什么峰值 FLOPS 亮眼的规格书在 decode 上可能令人失望，也解释了 batching 为何有效：把多条序列合并会提高算术强度，因为每次权重读取被更多 token 复用。',
+    benchmarkContext:
+      '这一区别解释了数据中反复出现的形态。低交互性的点跑大 batch、算术强度高，接近计算上限；高交互性一端跑小 batch，跟随显存带宽，因此带宽更充裕的硬件常常在这里胜出，尽管其峰值吞吐量更低。',
+  },
+  'prefix-cache-hit-rate': {
+    term: '前缀缓存命中率',
+    aliases: ['prefix cache hit rate', '缓存命中率', 'KV 复用率'],
+    plainEnglish:
+      '命中率是指提示词中有多少 token 直接来自缓存而无需重算，在长会话中这通常是绝大部分。',
+    definition:
+      '前缀缓存命中率是 prefill 阶段由已缓存 KV 状态满足、而非重新计算的输入 token 占比。',
+    explanation:
+      '命中率必须与产生它的缓存层级一起看才有意义，因为从加速器显存读取的 token 与从主机内存取回的 token，代价完全不同。它也不只取决于容量：淘汰策略可能丢掉仍会被用到的前缀，路由也可能把请求发到从未持有该前缀的 worker。',
+    significance:
+      '在多轮流量下，命中率基本决定了 prefill 的开销，因为每一轮都会把整段对话再加一点新内容重新发过来。一旦复用率很高，剩余的 prefill 工作就主要是真正的新 token，瓶颈也从计算转向缓存管理。',
+    benchmarkContext:
+      'AgentX 点详情视图会按缓存层级分别展示命中率随时间的变化，并给出 prompt token 来源拆分。如果一个数据点在低命中率下报出很高的总吞吐量，说明它做的 prefill 工作远多于缓存良好的部署。',
+  },
+  warmup: {
+    term: 'Warmup',
+    aliases: ['warmup', 'warmup 阶段', '缓存预热'],
+    plainEnglish: '性能采集开始前先做一轮预热，让系统进入稳态，而不是在缓存为空的状态下被打分。',
+    definition:
+      'warmup 是性能采集窗口之前的阶段，基准测试在此期间预热缓存并进入稳态，该阶段的请求不计入上报结果。',
+    explanation:
+      '冷启动系统在两方面都不像生产环境：缓存是空的，而且所有会话都从第 0 轮开始会造成同步的突发流量，这在真实部署中并不存在。因此 AgentX 会让每个对话从其历史中一个按 seed 选定的位置开始，先回放重建该状态所需的请求，再让每条回放通道继续前进若干请求，然后才开始测量。',
+    significance:
+      '测量窗口从哪里开始会改变结果。把预热过程算进去，前缀复用会显得比生产环境更差；完全不做预热，依赖缓存的方案则会在一个它们在生产中根本不会遇到的状态下被打分。',
+    benchmarkContext:
+      'AgentX 点详情视图会把两个阶段分开，便于分别查看遥测数据。warmup 请求的输出被限制为单个 token，因此它们的输出长度约为 1，交互性和 decode 曲线为空：单个 token 没有 token 间延迟。',
+  },
+  aiperf: {
+    term: 'AIPerf',
+    aliases: ['AIPerf', '回放框架', '负载生成器'],
+    plainEnglish:
+      'AIPerf 是发送基准流量的厂商中立客户端，负责重建录制的 agent 会话并记录每条请求的时序。',
+    definition: 'AIPerf 是驱动 AgentX 运行、面向服务端点的开源 HTTP 负载生成与回放框架。',
+    explanation:
+      '它把每个会话重建为有向无环图：节点是请求，边携带依赖请求发出前需要等待的延迟。这一结构可以复现主智能体轮次、并行且稍后汇合的子智能体分支、一次性的辅助请求，以及轮次之间的工具调用停顿，而这些都是扁平的提示词列表无法表达的。',
+    significance:
+      '客户端本身就是测量的一部分。无法表达依赖关系的框架，会把 agentic 工作负载当成互相独立的请求发出，从而抹掉这个场景本要考察的突发性与复用特征。保持厂商中立同样重要，可以避免负载生成器偏向某一套服务栈。',
+    benchmarkContext:
+      'seed 固定了采样哪些对话、每个对话从哪里开始，以及用于填充匿名化 block 的合成内容，因此同一套配置重跑会回放同样的工作负载。同一模型的所有提交都运行相同的框架次版本，以保证结果可比。',
+  },
+  'pipeline-parallelism': {
+    term: '流水线并行',
+    aliases: ['pipeline parallelism', 'PP', '层间并行'],
+    plainEnglish: '流水线并行让每颗芯片负责一部分层，沿链条传递激活值，而不是把每一层都切开。',
+    definition:
+      '流水线并行按层切分模型并分配到多个加速器上，每个阶段执行自己的层，并把激活值传给下一个阶段。',
+    explanation:
+      '通信是阶段边界处激活值的点对点交接，比张量并行所需的逐层集合通信便宜得多。代价是空闲：只有一条请求在途时，除当前阶段外其余阶段都在等待，只有持续的并发流量才能把流水线填满。',
+    significance:
+      '对最大的那批模型来说，这首先是容量手段，其次才是提速手段。有些前沿模型根本装不进单个节点，流水线并行才让它们可服务；当某项竞争性优化拒绝与任何方案组合时，它甚至是唯一选项。',
+    benchmarkContext:
+      'InferenceX 在数据点 tooltip 和并行标签中与 TP、EP、DP 一起展示流水线并行度，且仅在大于 1 时显示。可组合性与并行度同样重要：一种会导致投机解码无法启用的阶段切分，代价可能超过它节省的显存。',
+  },
+  'dp-attention': {
+    term: '数据并行注意力',
+    aliases: ['DP attention', 'DPA', '注意力数据并行'],
+    plainEnglish:
+      'DP attention 让每个 rank 处理各自的一批序列并持有自己的缓存，而不是每个 rank 都存同一份副本。',
+    definition:
+      '数据并行注意力让每个 rank 在互不重叠的序列集合上各自计算注意力，因此每个 rank 拥有 KV cache 的私有份额，而专家层仍然共享。',
+    explanation:
+      '张量并行的注意力按 head 切分，在 head 数较少时会在各 rank 之间复制 KV 状态，浪费容量。DP attention 改为把整条序列分配给某个 rank，从而避免这种重复。各 rank 仍共同参与 MoE 集合通信，因此注意力是本地的，而专家分发仍是全局的。',
+    significance:
+      '由于每个 rank 只拥有缓存池的私有一份，请求落在哪里就成了影响性能的关键：长会话一旦被路由到不持有其前缀的 rank，就要全部重算。此时实测命中率会远低于理论上限，而原因与缓存大小毫无关系。',
+    benchmarkContext:
+      'InferenceX 会在数据点 tooltip 的并行策略部分展示 DP attention。它是否有利取决于模型；当缓存局部性变成路由约束时，不启用它的配置有时反而占据前沿曲线。',
+  },
+  int4: {
+    term: 'INT4',
+    aliases: ['INT4', '4 位整数', 'W4A16'],
+    plainEnglish:
+      'INT4 用 4 位整数存放权重，把模型压小，让缺少原生 4 位浮点支持的硬件每个 token 少搬很多数据。',
+    definition:
+      'INT4 是主要用于权重量化的 4 位整数格式，通常为每一组数值配一个更高精度的缩放因子。',
+    explanation:
+      '整数格式的取值是均匀分布的，不像浮点那样疏密不一，因此 INT4 依赖分组缩放因子来跟踪每一块权重的局部数值范围。激活值通常保持更高精度，矩阵乘法在计算时实时反量化，这使得该技术更多是访存优化而不是算力优化。',
+    significance:
+      '它在缺少 4 位浮点硬件支持的平台上最有价值。在这类硬件上，INT4 是落地 4 位权重的现实路径，但通常比原生格式更依赖细致的校准，其精度必须实测验证而不能想当然。',
+    benchmarkContext:
+      'InferenceX 把 INT4 与 FP4、FP8、BF16 并列为独立的精度键，精度属于测试配置而不是显示选项。把 INT4 与原生 FP4 方案对比时，务必同时查看精度评估结果，因为两种格式并不等价。',
+  },
+  bf16: {
+    term: 'BF16',
+    aliases: ['BF16', 'bfloat16', 'brain float 16'],
+    plainEnglish: 'BF16 是多数模型训练所用的 16 位格式，用它做推理也是量化方案精度对照的基准。',
+    definition:
+      'BF16 是一种 16 位浮点格式，指数范围与 FP32 相同而尾数更短，广泛用于训练，也常作为未量化的推理基线。',
+    explanation:
+      '保留 FP32 的指数范围，使 BF16 能很好地容纳 transformer 激活值的数值分布，格式转换很少需要窄格式所依赖的缩放机制。它牺牲的是精度而不是范围，体积是 FP8 的两倍、4 位格式的四倍。',
+    significance:
+      '在基准测试中它通常扮演参照系。decode 阶段以权重读取为主，因此 BF16 方案每个 token 搬运的数据远多于量化方案，往往位于吞吐量曲线更低的位置，同时定义了其他方案所对照的精度水平。',
+    benchmarkContext:
+      'InferenceX 把 BF16 作为精度键，并在规格页给出每个加速器的 BF16 稠密峰值算力。量化方案会通过精度评估验证，而不是默认无损，这正是 BF16 对照有意义的前提。',
+  },
+  'kv-cache-quantization': {
+    term: 'KV cache 量化',
+    aliases: ['KV cache quantization', 'FP8 KV cache', '量化 KV'],
+    plainEnglish: '把对话缓存用更小的格式存放，让芯片装下更多上下文，并在生成时更快地把它读回来。',
+    definition:
+      'KV cache 量化用降精度格式存放注意力的 key 与 value 状态，与模型权重所用精度相互独立。',
+    explanation:
+      '权重精度与缓存精度是两个独立选择，一套方案可以用 FP8 权重搭配 BF16 缓存，反过来也可以。缓存位宽减半，加速器显存能容纳的 token 数大致翻倍，每个 decode 步骤要读取的字节数也减半，而这正是 decode 大部分时间在做的事。',
+    significance:
+      '在长上下文服务中，这往往比压缩权重更划算，因为高并发下最先耗尽显存的是缓存而不是权重。不同模型对精度的敏感度不同，量化 key 还是 value 也有差别，因此需要实测评估而不能一概而论。',
+    benchmarkContext:
+      '缓存精度属于测试配置的一部分，实践中还存在混合布局：有些模型会保留两份位宽不同的缓存缓冲区，分离式传输路径必须把它们成对搬运。阅读显存容量相关的结论时，请连同其背后的缓存格式一起看。',
+  },
+  'sliding-window-attention': {
+    term: '滑动窗口注意力',
+    aliases: ['sliding window attention', 'SWA', '局部注意力'],
+    plainEnglish:
+      '滑动窗口注意力让某些层只看最近一段 token，因此窗口填满之后它的缓存就不再继续增长。',
+    definition:
+      '滑动窗口注意力把每个 query 限制在固定长度的前文范围内，从而限定该层需要保留的 KV 状态。',
+    explanation:
+      '由于窗口长度固定，这类层的缓存会达到上限而不会随对话增长，较早的条目会随窗口推进被移出。模型通常把这类层与全注意力层交错排列，这样远距离信息在网络中仍有通路，而大多数层保持低成本。',
+    significance:
+      '有界的开销带来了分配器层面的问题。窗口页不断翻转，而持久的前缀页静止不动；当两者取自同一个池子时，短暂分配往往会把有价值的那份挤出去，于是长会话可能因为短命的窗口状态而丢失昂贵的全注意力历史。',
+    benchmarkContext:
+      '这些效应只在多轮流量中出现。单条短提示词既不会让窗口绕过前缀，也不会造成池子争用，因此窗口感知的淘汰、offload 和分叉处理都表现为由 AgentX 推动的引擎工作，而不是定长场景的测试结果。',
+  },
+  'hybrid-attention': {
+    term: '混合注意力',
+    aliases: ['hybrid attention', '混合缓存模型'],
+    plainEnglish:
+      '混合模型在不同层使用不同的注意力类型，因此它的缓存是几种不同状态，而不是一块统一的数据。',
+    definition:
+      '混合注意力模型交错使用不同类型的注意力层，从而产生形状和生命周期各不相同的多个 KV cache group。',
+    explanation:
+      '统一模型每个 token 只有一种缓存布局，用单一 block 几何结构就能描述所有需要保存的内容；混合模型则不然：全注意力层、窗口层，以及循环或压缩状态同时存在，各有各的占用、各有各的丢弃时机，能否重建也不一样。',
+    significance:
+      '在状态需要离开加速器之前，这一区别是看不出来的。假设单一布局的 connector 无法说明某个 block 属于哪一组，因此会话最长的那些模型一度反而完全用不了 offload。循环状态最棘手，因为它累积了此前的全部内容，无法从相邻 token 重算。',
+    benchmarkContext:
+      'InferenceX 测试矩阵中的前沿开放权重模型越来越多采用混合结构，因此引擎对混合 cache group 的支持本身就是测试内容的一部分。offload、分离式传输和前缀复用都必须逐组扩展，而不能从统一结构的情形直接继承。',
+  },
+  'linear-attention': {
+    term: '线性注意力',
+    aliases: ['linear attention', 'GatedDeltaNet', '常数状态注意力'],
+    plainEnglish:
+      '线性注意力保存一份固定大小的运行摘要，而不是全部历史 token，因此内存不会随对话增长。',
+    definition:
+      '线性注意力用一个大小恒定、随 token 到达而更新的循环状态，替代不断增长的 key 与 value 缓存。',
+    explanation:
+      '标准注意力保存的状态与序列长度成正比，且每一步都要重新读取。线性或门控循环层改为携带固定大小的状态，用对每个位置的精确回忆换取有界的内存占用。GatedDeltaNet 这类结构只在部分层这样做，其余层保留全注意力，以维持精确的远距离查找能力。',
+    significance:
+      '在长上下文下，节省的存储相当可观，但这种状态改变了缓存的含义：它无法像窗口尾部那样由周围 token 重建，一旦丢弃就只能重放整个序列，因此复用需要显式的检查点机制，而不是普通的 block 复用。',
+    benchmarkContext:
+      'InferenceX 服务的模型中已有采用这类层的，引擎对循环状态的检查点与传输支持属于测试配置的一部分。一个模型可以在 day 0 就能被服务，却仍不支持这类状态的复用，表现为重复轮次上出乎意料的高 prefill 开销。',
+  },
+  nvl72: {
+    term: 'NVL72',
+    aliases: ['NVL72', 'GB200 NVL72', 'GB300 NVL72', '机架级系统'],
+    plainEnglish:
+      'NVL72 是一个机架，其中 72 个加速器共享同一张高速网络，因而更像一台大机器而不是一个集群。',
+    definition:
+      'NVL72 是 NVIDIA 的机架级系统，把 72 个加速器放进同一个 NVLink scale-up 域，而不是分散在多个八芯片节点中。',
+    explanation:
+      '仪表板的规格数据记录为 NVLink 5.0、每颗芯片 900 GB/s 单向带宽、scale-up world size 为 72，并通过 NVSwitch 交换。常规节点把同样的带宽限定在八颗芯片之间，超出后就要退回更慢的 scale-out 网络，因此差别不在于原始速度，而在于换用另一种网络之前能触及多少颗芯片。',
+    significance:
+      '开销以集合通信为主的技术，在大规模 scale-up 域中经济性会发生变化。宽专家并行把专家分散到许多芯片上，每个 token 都要付出 all-to-all 流量；在 scale-up 带宽下这可以承受，在 scale-out 网络上往往不行。',
+    benchmarkContext:
+      '机架级优势并非自动成立。更高的单芯片成本必须被赚回来，而在 agentic 流量下，编排层可能比网络更早成为瓶颈；因此对于不怎么用到宽并行的模型，NVL72 配置在按 TCO 归一化的吞吐量上有时会落后于八芯片节点。',
+  },
+  atom: {
+    term: 'ATOM',
+    aliases: ['ATOM', 'AMD ATOM', 'ATOMesh'],
+    plainEnglish:
+      'ATOM 是 AMD 自研的推理引擎，是它在厂商专用运行时这条路线上的答案，而非上游开源引擎。',
+    definition:
+      'ATOM 是 AMD 面向 Instinct 加速器的推理引擎，与 ROCm 上的上游 vLLM、SGLang 并列，定位为厂商自有运行时。',
+    explanation:
+      '它对 AMD 的意义，与厂商运行时对 NVIDIA 的意义相同：针对自家硬件调优，且可以跑在上游引擎前面。它的 router 名为 ATOMesh，最初是 SGLang router 的一个分支。该引擎最初面向单轮服务设计，因此支持长上下文多轮场景需要对其缓存管理器和 kernel 做大量改造。',
+    significance:
+      '厂商引擎可以在开源栈跟上之前展示硬件的能力上限，这既是有价值的证据，也是不便直接照搬的建议。多数实验室部署的是上游引擎，因此只在厂商运行时下成立的结果，并不能代表这些用户实际拿到的性能。',
+    benchmarkContext:
+      'InferenceX 把 ATOM 作为独立的框架标签，避免与同一加速器上的 vLLM 或 SGLang 结果混为一谈。想知道硬件能做到什么，就拿它与其他厂商运行时比较；想知道客户今天能部署什么，就拿它与上游引擎比较。',
+  },
+  aiter: {
+    term: 'AITER',
+    aliases: ['AITER', 'AMD AITER', 'ROCm kernel 库'],
+    plainEnglish:
+      'AITER 是 AMD 调优过的 kernel 库，决定注意力和矩阵运算在 Instinct 芯片上究竟能跑多快。',
+    definition:
+      'AITER 是 AMD 面向 Instinct 加速器的优化 kernel 库，供运行在 ROCm 上的推理引擎调用。',
+    explanation:
+      '引擎负责表达策略，kernel 决定它是否够快。AITER 提供调优过的注意力、矩阵和融合算子，引擎会用它替代通用路径。这个分发决策本身也可调优，而且在某种 shape 上取胜的 kernel 在另一种 shape 上可能落败，因此选择可能取决于上下文长度，而不是固定不变。',
+    significance:
+      '并行策略只有在 kernel 能表达时才算数，这正是 AMD 上的上下文并行和长上下文稀疏注意力以 kernel 工作而非引擎工作形式出现的原因。超大缓存还会暴露短请求根本触及不到的问题，例如缓存池跨过某个容量边界后地址运算溢出，从而静默访问错误的行。',
+    benchmarkContext:
+      '该库位于测试配置所固定的容器镜像内部，因此 AITER 的改进可以在引擎版本和硬件都不变的情况下推动曲线上移。在统一 shape 上实测到的 kernel 级收益，未必能在 agentic trace 上留存，缓存与调度带来的波动可能将其淹没。',
+  },
+  flashinfer: {
+    term: 'FlashInfer',
+    aliases: ['FlashInfer', '注意力 kernel 库'],
+    plainEnglish: 'FlashInfer 是一个注意力 kernel 库，服务引擎直接调用它，而不必自己实现注意力。',
+    definition:
+      'FlashInfer 是开源的注意力 kernel 与后端库，供推理引擎在 prefill、decode 和投机验证中使用。',
+    explanation:
+      '推理特有的复杂性大多集中在注意力上：分页缓存、变长序列、分组 query head、稀疏模式，以及对草稿 token 的验证，都会改变 kernel 的形态。共享库让多个引擎复用同一份调优实现，引擎则按 shape 和硬件目标选择后端。',
+    significance:
+      '由于后端是被选择而不是固定的，kernel 的可用性就变成了可移植性问题。只为某一家厂商后端实现的功能，会让另一方退回通用路径；而在长上下文下，这不是小小的妥协，而是选错了 kernel。',
+    benchmarkContext:
+      '所使用的后端属于测试配置的一部分，改动它可以在硬件和引擎版本都不变的情况下推动曲线变化。正是这些 kernel 支持了循环状态的检查点，混合模型才得以参与前缀复用。',
+  },
+  'cuda-graphs': {
+    term: 'CUDA graph',
+    aliases: ['CUDA graphs', 'graph capture', 'full-graph 模式'],
+    plainEnglish: 'CUDA graph 把一整串芯片操作录制一次并整体回放，从而免去逐个启动它们的开销。',
+    definition:
+      'CUDA graph capture 把一串 kernel 启动及其依赖关系录制成可回放的图，从而一次性提交整段序列，而不是逐个算子启动。',
+    explanation:
+      '一个 decode 步骤会发出许多小 kernel，在小 batch 下它们之间的启动与调度开销可以与实际运算相当。把整步录制下来即可消除这部分逐次启动的开销。代价是图是固定的：shape 必须稳定，因此引擎会按分桶分别录制，并把真正动态的部分留在图之外。',
+    significance:
+      '这更多是延迟优化而不是吞吐量优化，恰恰在 batch 很小、交互性很高的场景最有价值。它也会与一切改变 shape 的因素相互作用，因此变长的 agentic 流量可能击垮过度特化的运行时，使其几乎为每个请求重新编译。',
+    benchmarkContext:
+      'graph 的使用方式取决于测试配置所固定的引擎镜像，因此它可以在硬件不变的情况下推动曲线变化。有些方案会录制稳定的算子，同时让依赖请求的注意力保持 eager 执行，这是在录制覆盖率与 shape 灵活性之间的有意折中。',
+  },
 };
 
 const entries = getAllGlossaryEntries().map((entry) => {

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -267,7 +267,7 @@ const entries = [
       'Low latency can require smaller batches or more parallel resources, which may reduce hardware utilization and increase cost. Good serving design chooses a latency service level and then maximizes throughput within it.',
     benchmarkContext:
       'InferenceX exposes workload shape and concurrency alongside interactivity. This keeps a high-throughput batch point from being mistaken for a low-latency serving point.',
-    relatedTerms: ['time-to-first-token', 'time-per-output-token', 'interactivity', 'concurrency'],
+    relatedTerms: ['time-to-first-token', 'time-per-output-token', 'tail-latency', 'interactivity'],
     articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
   },
   {
@@ -518,7 +518,13 @@ const entries = [
       'Prefill has a different resource profile from decode. When both share the same workers, large prompt jobs can interrupt decode batches and make streaming latency less predictable.',
     benchmarkContext:
       'Disaggregated recipes place prefill on a separately sized chip pool. When reading a result, check the prefill tensor parallelism, chip count, input length, and whether KV state must cross a network before decode.',
-    relatedTerms: ['decode', 'kv-cache', 'time-to-first-token', 'disaggregated-inference'],
+    relatedTerms: [
+      'decode',
+      'kv-cache',
+      'chunked-prefill',
+      'time-to-first-token',
+      'arithmetic-intensity',
+    ],
     articleSlugs: [INFERENCEX_V2, GB300_DSV4, GB200_KIMI],
   },
   {
@@ -623,7 +629,7 @@ const entries = [
       'The speedup depends on how many draft tokens are accepted and on the cost of drafting and verification. Dense and MoE models can behave differently because verifying several positions may activate more expert weights.',
     benchmarkContext:
       'Fixed-sequence scenarios keep speculative decoding as part of a curve’s identity, so MTP-enabled and disabled recipes plot separately. Agentic curves instead treat it as point-level metadata and merge the points, with the method named in each tooltip, because AgentX reports the best available curve per model, chip SKU, and engine. Since replayed AgentX content is synthetic, a speculator would accept an unrepresentative number of draft tokens, so runs apply an acceptance length collected per model, speculator, draft length, and thinking mode on an external agentic coding dataset.',
-    relatedTerms: ['multi-token-prediction', 'decode', 'batching', 'agentx', 'mixture-of-experts'],
+    relatedTerms: ['multi-token-prediction', 'acceptance-length', 'decode', 'batching', 'agentx'],
     articleSlugs: [INFERENCEX_V2, DEEPSEEK_V4, B200_GLM5, KIMI_K3, AGENTX_V3],
   },
   {
@@ -871,7 +877,7 @@ const entries = [
       'A nominal format alone says little about speed or quality. Conversion quality, model calibration, outliers, kernel maturity, and hardware support determine the result.',
     benchmarkContext:
       'InferenceX treats precision as a first-class recipe dimension and pairs throughput measurements with accuracy checks. Compare FP8, FP4, NVFP4, MXFP4, and INT4 only when the model, workload, engine, and quality bar are compatible.',
-    relatedTerms: ['fp8', 'fp4', 'nvfp4', 'mxfp4', 'high-bandwidth-memory'],
+    relatedTerms: ['fp8', 'fp4', 'int4', 'bf16', 'kv-cache-quantization'],
     articleSlugs: [INFERENCEX_V2, B200_KIMI, B200_GLM5, MI355X_DSV4],
   },
   {
@@ -1276,6 +1282,466 @@ const entries = [
       'InferenceX reports TileRT as its own framework label and deliberately retains it in best-per-SKU views, because a curve that only survives where it dominates on throughput would drop the operating points TileRT exists to serve. Compare it at matched interactivity rather than on peak throughput alone.',
     relatedTerms: ['inference-engine', 'interactivity', 'decode', 'sglang'],
     articleSlugs: [TILERT, AGENTX_V3],
+  },
+  {
+    slug: 'recipe',
+    term: 'Recipe',
+    aliases: ['configuration', 'serving recipe'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'A recipe is the complete set of choices behind one curve: which model, engine, image, precision, parallelism, and workload were run.',
+    definition:
+      'A recipe is the fully specified combination of model, inference engine and container image, numerical precision, parallelism strategy, chip system, and workload that produces one measured curve.',
+    explanation:
+      'Every point on InferenceX belongs to a recipe, and a concurrency sweep across one recipe traces out its curve. Changing any element produces a different recipe rather than a variation of the same one, which is why an engine image bump is reported as its own result rather than folded into an existing line.',
+    significance:
+      'Peak chip specifications do not describe serving performance, and the same silicon can differ by multiples across recipes. Naming the whole combination is what makes a claim checkable: a number without its recipe cannot be reproduced or fairly compared against another vendor.',
+    benchmarkContext:
+      'InferenceX benchmark configs mainly track the published vLLM and SGLang cookbooks on upstream images, so results reflect what users can actually deploy rather than images tuned for the benchmark. Point tooltips expose the recipe behind each point along with links to the run provenance.',
+    relatedTerms: ['inference-engine', 'pareto-frontier', 'concurrency', 'quantization'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, AGENTX_V3],
+  },
+  {
+    slug: 'tail-latency',
+    term: 'Tail latency',
+    aliases: ['p90', 'p99', 'percentile latency'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Tail latency describes the slowest requests rather than the typical one, because the unlucky few are what users actually notice.',
+    definition:
+      'Tail latency is the latency at a high percentile of the request distribution, such as p90 or p99, rather than the mean or median.',
+    explanation:
+      'A percentile answers a different question from an average. A p90 of five seconds means one request in ten waited at least that long, and that request may be the one blocking an agent from continuing. Distributions in real serving are heavily skewed, so the mean can sit far below the tail and hide it completely.',
+    significance:
+      'Capacity planning is usually written against a percentile, not an average, because a service that is fast on average and slow at the tail still fails its users. Optimizations can also improve the mean while worsening the tail, which a single-number summary would report as an unambiguous win.',
+    benchmarkContext:
+      'InferenceX reports percentile-qualified metrics and labels the percentile on the axis, so p90 TTFT and mean TTFT are never mixed on one comparison. Agentic runs are especially skewed, because end to end latency scales with output length and the longest generations dominate the tail.',
+    relatedTerms: ['latency', 'time-to-first-token', 'interactivity', 'concurrency'],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2, AGENT_BENCHMARK],
+  },
+  {
+    slug: 'service-level-objective',
+    term: 'Service level objective',
+    abbreviation: 'SLO',
+    aliases: ['latency target', 'SLA target'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'An SLO is the performance promise a deployment has to keep, such as a first token within one second for nine requests in ten.',
+    definition:
+      'A service level objective is a stated target for a serving metric, usually expressed as a percentile bound on latency or interactivity.',
+    explanation:
+      'A useful SLO names a metric, a percentile, and a threshold together. Serving capacity is then whatever throughput the system sustains without breaching it, which is a smaller number than peak throughput and the only one an operator can safely provision against.',
+    significance:
+      'Every point on a throughput curve is reachable, but only part of the curve satisfies a given promise. Two systems can look close on peak throughput and differ sharply in how much of that throughput survives an interactivity or first-token bound.',
+    benchmarkContext:
+      'InferenceX does not impose one industry SLO, because acceptable targets differ by product: interactive coding needs a high token rate, while batch processing tolerates seconds of first-token delay. Read the frontier at your own threshold instead of comparing peak values.',
+    relatedTerms: ['latency', 'tail-latency', 'interactivity', 'iso-interactivity'],
+    articleSlugs: [AGENTX_V3, INFERENCEMAX, AGENT_BENCHMARK],
+  },
+  {
+    slug: 'acceptance-length',
+    term: 'Acceptance length',
+    abbreviation: 'AL',
+    aliases: ['acceptance rate', 'draft acceptance'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Acceptance length is how many drafted tokens the full model actually approves per verification step, which is what decides whether speculation pays off.',
+    definition:
+      'Acceptance length is the average number of speculatively drafted tokens accepted by the target model in one verification pass.',
+    explanation:
+      'Speculative decoding only saves time when drafts survive verification. An acceptance length near one means the draft and verify machinery ran for nothing, while a high value amortizes one expensive target-model step across several emitted tokens. The value depends on the speculator, the draft length, the model, and the content being generated.',
+    significance:
+      'Because acceptance depends on content, a benchmark can accidentally decide the result. Synthetic or anonymized text is out of distribution for a speculator trained on real language, so measured acceptance drifts away from what production would see, in either direction.',
+    benchmarkContext:
+      'AgentX replays anonymized traces filled with synthetic tokens, so it does not let acceptance emerge from that content. Runs instead apply a fixed acceptance length collected per model, speculator, draft length, and thinking mode on an external agentic coding dataset, which keeps the comparison vendor neutral.',
+    relatedTerms: ['speculative-decoding', 'multi-token-prediction', 'eagle', 'agentx'],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2, DEEPSEEK_V4],
+  },
+  {
+    slug: 'unofficial-run',
+    term: 'Unofficial run',
+    aliases: ['unofficial overlay', 'community run'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'An unofficial run is a benchmark run that has not been ingested into the published dataset but can still be drawn on top of the charts from its URL.',
+    definition:
+      'An unofficial run is a CI benchmark run loaded into the dashboard as an overlay from its run identifier, rather than from the published database.',
+    explanation:
+      'Adding a run identifier to the page URL fetches that run and draws its points, rooflines, and rows alongside the official data in distinct overlay colors. The overlay is a separate rendering path, so it can be toggled per hardware type or dismissed per run without disturbing the official selection underneath.',
+    significance:
+      'Publishing a result usually lags producing it, and a contributor tuning a recipe needs to see the new curve against the current frontier before anyone decides to ingest it. The overlay makes an in-flight run reviewable without granting it the standing of a published measurement.',
+    benchmarkContext:
+      'Overlay colors come from a run-index palette rather than the hardware palette, so an overlay is never mistaken for official data. Some views require data that is only persisted for ingested runs, and those views state that overlays are unavailable rather than silently omitting them.',
+    relatedTerms: ['recipe', 'pareto-frontier', 'inference-engine', 'agentx'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2],
+  },
+  {
+    slug: 'chunked-prefill',
+    term: 'Chunked prefill',
+    aliases: ['split prefill', 'piecewise prefill'],
+    category: 'Serving',
+    plainEnglish:
+      'Chunked prefill reads a long prompt in slices instead of all at once, so other users keep receiving tokens while it is being read.',
+    definition:
+      'Chunked prefill splits prompt processing into fixed-size token chunks that the scheduler interleaves with ongoing decode work.',
+    explanation:
+      'An unsplit prefill occupies the accelerator for as long as the whole prompt takes, and every user already streaming waits behind it. Splitting the prompt lets the scheduler alternate, so decode continues between chunks. The chunk size is a tuning knob: larger chunks prefill more efficiently, smaller chunks interrupt decode less.',
+    significance:
+      'The technique converts a first-token problem for one user into a small, steady tax on everyone else, which is usually the better trade. It matters far more as prompts grow, since a single unsplit hundred-thousand-token prefill would stall a deployment outright.',
+    benchmarkContext:
+      'Chunk size is part of the recipe and can differ across points on the same curve, so a jump in throughput may reflect a retune rather than new hardware. Long agentic prompts make the setting consequential in a way fixed short-prompt scenarios never expose.',
+    relatedTerms: ['prefill', 'decode', 'batching', 'time-to-first-token'],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2, SGLANG_056],
+  },
+  {
+    slug: 'roofline',
+    term: 'Roofline',
+    aliases: ['frontier envelope', 'roofline curve'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'On InferenceX a roofline is the outer envelope drawn through the best points of one hardware configuration, showing the edge of what it achieved.',
+    definition:
+      'A roofline on InferenceX is the Pareto envelope curve drawn per hardware configuration through its non-dominated points for the selected pair of axes.',
+    explanation:
+      'Which corner counts as best depends on the metrics: throughput against interactivity takes the upper right, while a cost axis is better when lower, so the envelope is anchored at whichever corner the selected metric pair defines. Points with a degenerate x value are excluded from eligibility, though they still render in the show-all view.',
+    significance:
+      'Reading a cloud of raw points invites cherry-picking, since a badly tuned configuration contributes points that no operator would ever choose. The envelope shows the achievable boundary per system, which is the shape a capacity decision is actually made against.',
+    benchmarkContext:
+      'This is not the classic roofline model from HPC, which plots attainable FLOPS against arithmetic intensity to expose a compute or memory bound. The dashboard borrows only the picture of an upper bound. Roofline direction is configured per metric, so the same points can produce a different envelope on a different axis.',
+    relatedTerms: ['pareto-frontier', 'iso-interactivity', 'throughput', 'recipe'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, B200_GLM5],
+  },
+  {
+    slug: 'arithmetic-intensity',
+    term: 'Arithmetic intensity',
+    aliases: ['operational intensity', 'compute to memory ratio'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Arithmetic intensity is how much math a computation does per byte it moves, which decides whether the chip or its memory is the limit.',
+    definition:
+      'Arithmetic intensity is the ratio of arithmetic operations performed to bytes moved between memory and the compute units.',
+    explanation:
+      'Prefill processes many tokens against one set of weights, so it reuses each loaded byte heavily and is usually compute bound. Decode emits one token per step per sequence and must still read the weights and the KV cache, so it moves a great deal of data for very little arithmetic and is usually memory bandwidth bound.',
+    significance:
+      'The two phases are limited by different parts of the chip, which is why a specification sheet with impressive peak FLOPS can disappoint on decode and why batching helps: grouping sequences raises intensity by reusing each weight read across more tokens.',
+    benchmarkContext:
+      'The split explains recurring shapes in the data. Low interactivity points run large batches at high intensity and approach compute limits, while the high interactivity end runs small batches and tracks memory bandwidth, so bandwidth-rich parts often win there despite lower peak throughput.',
+    relatedTerms: ['prefill', 'decode', 'memory-bandwidth', 'batching'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, TILERT],
+  },
+  {
+    slug: 'prefix-cache-hit-rate',
+    term: 'Prefix cache hit rate',
+    aliases: ['cache hit rate', 'KV reuse rate'],
+    category: 'Serving',
+    plainEnglish:
+      'The hit rate is the share of prompt tokens served from cache instead of being recomputed, which on long sessions is most of the prompt.',
+    definition:
+      'Prefix cache hit rate is the fraction of input tokens satisfied from cached KV state rather than recomputed during prefill.',
+    explanation:
+      'A hit rate is only meaningful next to the tier that produced it, since a token served from accelerator memory and one fetched back from host memory cost very differently. It also depends on more than capacity: eviction can discard a prefix that is still wanted, and routing can send a request to a worker that never held it.',
+    significance:
+      'On multi-turn traffic the hit rate largely determines prefill cost, because each turn resends the whole conversation plus a little more. Once reuse is high, the remaining prefill work is dominated by genuinely new tokens, and the bottleneck moves from computation to cache management.',
+    benchmarkContext:
+      'The AgentX point view reports hit rate over time, separated by cache tier, alongside the prompt token source breakdown. A run that reports high aggregate throughput on a low hit rate is doing far more prefill work than a well-cached deployment would.',
+    relatedTerms: ['prefix-caching', 'kv-cache', 'prefill', 'agentx'],
+    articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS, AGENT_BENCHMARK],
+  },
+  {
+    slug: 'warmup',
+    term: 'Warmup',
+    aliases: ['warmup phase', 'cache priming'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Warmup is the priming pass before measurement starts, so the run is scored on a system in steady state rather than one with an empty cache.',
+    definition:
+      'Warmup is the phase before the profiling window in which a benchmark primes caches and reaches steady state, and whose requests are excluded from reported results.',
+    explanation:
+      'A cold system misrepresents production twice over: the cache is empty, and every session starting at turn zero creates a synchronized burst that no real deployment sees. AgentX therefore starts each conversation at a seeded point partway through its history, replays the requests needed to reconstruct that state, then advances each replay lane further before measurement begins.',
+    significance:
+      'Where the measurement window starts changes the result. Include the priming pass and prefix reuse looks worse than production; skip priming entirely and cache-dependent recipes are scored on a state they would never serve from.',
+    benchmarkContext:
+      'The AgentX point view separates the two phases, so telemetry can be inspected for either. Warmup requests are capped at a single output token, which is why their output length is about one and their interactivity and decode series are blank: one token has no inter-token latency.',
+    relatedTerms: ['prefix-caching', 'agentx', 'trace-replay', 'closed-loop-benchmark'],
+    articleSlugs: [AGENTX_V3, AGENT_BENCHMARK, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'aiperf',
+    term: 'AIPerf',
+    aliases: ['replay harness', 'load generator'],
+    category: 'Agentic inference',
+    plainEnglish:
+      'AIPerf is the vendor-neutral client that sends the benchmark traffic, reconstructing recorded agent sessions and timing every request.',
+    definition:
+      'AIPerf is the open-source HTTP load generation and replay harness that drives AgentX runs against a serving endpoint.',
+    explanation:
+      'It reconstructs each session as a directed acyclic graph in which nodes are requests and edges carry the delay before a dependent request may be sent. That structure reproduces main-agent turns, parallel subagent branches that join later, one-off auxiliary requests, and the tool-use pauses between turns, none of which a flat list of prompts can express.',
+    significance:
+      'The client is part of the measurement. A harness that cannot express dependencies would issue an agentic workload as independent requests and erase exactly the burstiness and reuse the scenario exists to test. Keeping it vendor neutral also keeps the load generator from favoring any one serving stack.',
+    benchmarkContext:
+      'A seed fixes which conversations are sampled, where each starts, and the synthetic content used to fill anonymized blocks, so a rerun of the same recipe replays the same workload. All submissions for a model run the same harness minor version so results stay comparable.',
+    relatedTerms: ['trace-replay', 'agentx', 'closed-loop-benchmark', 'subagent'],
+    articleSlugs: [AGENTX_V3, AGENT_BENCHMARK, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'pipeline-parallelism',
+    term: 'Pipeline parallelism',
+    abbreviation: 'PP',
+    aliases: ['layer parallelism', 'PP'],
+    category: 'Parallelism',
+    plainEnglish:
+      'Pipeline parallelism gives each chip a different slice of the layers, passing activations along the chain instead of splitting each layer.',
+    definition:
+      'Pipeline parallelism partitions a model by layer across accelerators, so each stage runs its own layers and forwards activations to the next.',
+    explanation:
+      'Communication is a point to point handoff of activations at stage boundaries, which is far cheaper than the per-layer collectives tensor parallelism requires. The cost is idle time: with one request in flight, every stage but the active one waits, and only a stream of concurrent work keeps the pipeline full.',
+    significance:
+      'For the largest models this is a capacity technique before it is a speed technique. Some frontier models do not fit in one node at all, and pipeline parallelism is what makes them servable, sometimes as the only option when a competing optimization refuses to compose with anything else.',
+    benchmarkContext:
+      'InferenceX reports the pipeline degree in point tooltips and parallelism labels alongside TP, EP, and DP, and only when it exceeds one. Composability matters as much as the degree: a stage split that blocks speculative decoding can cost more than the memory it saved.',
+    relatedTerms: [
+      'tensor-parallelism',
+      'expert-parallelism',
+      'data-parallelism',
+      'high-bandwidth-memory',
+    ],
+    articleSlugs: [AGENTX_V3, KIMI_K3, INFERENCEX_V2],
+  },
+  {
+    slug: 'dp-attention',
+    term: 'Data-parallel attention',
+    abbreviation: 'DPA',
+    aliases: ['DP attention', 'attention data parallelism'],
+    category: 'Parallelism',
+    plainEnglish:
+      'DP attention gives each rank its own slice of the attention work and its own cache, instead of every rank holding a copy of the same thing.',
+    definition:
+      'Data-parallel attention replicates attention computation per rank over disjoint sets of sequences, so each rank owns a private share of the KV cache while experts remain shared.',
+    explanation:
+      'Tensor-parallel attention splits heads and ends up replicating KV state across ranks, which wastes capacity when heads are few. DP attention avoids that duplication by assigning whole sequences to ranks. The ranks still participate together in the MoE collectives, so attention is local while expert dispatch stays global.',
+    significance:
+      'Because each rank owns a private slice of the pool, placement becomes correctness-adjacent for performance: a long session routed to a rank that does not hold its prefix recomputes everything. Measured hit rates can then land far below the theoretical ceiling for reasons that have nothing to do with cache size.',
+    benchmarkContext:
+      'InferenceX shows DP attention in the parallelism section of point tooltips. Whether it helps is model dependent, and configurations without it sometimes dominate the frontier when cache locality turns into a routing constraint.',
+    relatedTerms: [
+      'data-parallelism',
+      'tensor-parallelism',
+      'kv-cache',
+      'mixture-of-experts',
+      'prefix-caching',
+    ],
+    articleSlugs: [AGENTX_V3, INFERENCEX_V2, GB200_KIMI],
+  },
+  {
+    slug: 'int4',
+    term: 'INT4',
+    aliases: ['4-bit integer', 'W4A16'],
+    category: 'Numerical precision',
+    plainEnglish:
+      'INT4 stores weights in four-bit integers, shrinking the model enough to move far less memory per token on hardware without native 4-bit floats.',
+    definition:
+      'INT4 is a four-bit integer format used mainly for weight quantization, typically with a higher-precision scale per group of values.',
+    explanation:
+      'Integer formats spread their values evenly, unlike floating point, so INT4 depends on grouped scaling factors to track the local range of each block of weights. Activations commonly stay at higher precision, and the matrix multiply dequantizes on the fly, which makes the technique a memory movement optimization more than an arithmetic one.',
+    significance:
+      'It matters most where 4-bit floating point has no hardware support. On such parts INT4 is the practical route to 4-bit weights, though it usually needs more calibration care than a native format and its accuracy has to be checked rather than assumed.',
+    benchmarkContext:
+      'InferenceX treats INT4 as its own precision key alongside FP4, FP8, and BF16, and precision is part of the recipe rather than a display option. Compare INT4 against a native FP4 recipe only with the accuracy evaluations in view, since the formats are not interchangeable.',
+    relatedTerms: ['quantization', 'fp4', 'fp8', 'memory-bandwidth'],
+    articleSlugs: [B200_KIMI, INFERENCEX_V2, MI355X_KIMI],
+  },
+  {
+    slug: 'bf16',
+    term: 'BF16',
+    aliases: ['bfloat16', 'brain float 16'],
+    category: 'Numerical precision',
+    plainEnglish:
+      'BF16 is the 16-bit format most models are trained in, and serving in it is the accuracy reference the quantized recipes are measured against.',
+    definition:
+      'BF16 is a 16-bit floating point format with the same exponent range as FP32 and a reduced mantissa, widely used for training and as an unquantized serving baseline.',
+    explanation:
+      'Keeping the FP32 exponent range makes BF16 tolerant of the value distributions that appear in transformer activations, so conversion rarely needs the scaling machinery narrower formats require. The tradeoff is precision rather than range, and the format is twice the size of FP8 and four times that of a 4-bit format.',
+    significance:
+      'Its role in a benchmark is usually as a reference point. Weight reads dominate decode, so a BF16 recipe moves far more memory per token than a quantized one and tends to sit lower on the throughput curve while defining the accuracy the others are compared against.',
+    benchmarkContext:
+      'InferenceX carries BF16 as a precision key and reports peak BF16 dense throughput per accelerator in the specs pages. Quantized recipes are validated with accuracy evaluations rather than assumed lossless, which is what makes a BF16 comparison meaningful.',
+    relatedTerms: ['quantization', 'fp8', 'fp4', 'memory-bandwidth'],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, DEEPSEEK_V4],
+  },
+  {
+    slug: 'kv-cache-quantization',
+    term: 'KV cache quantization',
+    aliases: ['FP8 KV cache', 'quantized KV'],
+    category: 'Numerical precision',
+    plainEnglish:
+      'This stores the conversation cache in a smaller format, so a chip holds more context and reads it back faster during generation.',
+    definition:
+      'KV cache quantization stores attention key and value states in a reduced-precision format, independently of the precision used for model weights.',
+    explanation:
+      'Weight precision and cache precision are separate choices, and a recipe can serve FP8 weights with a BF16 cache or the reverse. Halving cache width roughly doubles the tokens that fit in accelerator memory and halves the bytes read per decode step, which is the operation decode spends most of its time on.',
+    significance:
+      'On long-context serving this often buys more than shrinking the weights, because at high concurrency the cache, not the weights, is what exhausts memory. Accuracy sensitivity differs by model and by which of keys and values is quantized, so it needs evaluation rather than a blanket assumption.',
+    benchmarkContext:
+      'Cache precision is part of the recipe, and mixed layouts exist in practice: some models keep two cache buffers at different widths, which disaggregated transfer paths then have to move as a pair. Read a memory-capacity claim together with the cache format behind it.',
+    relatedTerms: ['kv-cache', 'quantization', 'fp8', 'high-bandwidth-memory'],
+    articleSlugs: [INFERENCEX_V2, AGENTX_V3, GB300_DSV4],
+  },
+  {
+    slug: 'sliding-window-attention',
+    term: 'Sliding window attention',
+    abbreviation: 'SWA',
+    aliases: ['local attention', 'windowed attention'],
+    category: 'Model architecture',
+    plainEnglish:
+      'Sliding window attention lets a layer look only at a recent span of tokens, so its cache stops growing once the window is full.',
+    definition:
+      'Sliding window attention restricts each query to a fixed span of preceding tokens, bounding the KV state a layer must retain.',
+    explanation:
+      'Because the span is fixed, the cache for such a layer reaches a ceiling instead of growing with the conversation, and older entries fall out as the window advances. Models usually interleave these layers with full-attention layers, so long-range information still has a path through the network while most layers stay cheap.',
+    significance:
+      'The bounded cost comes with an allocator problem. Window pages turn over constantly while durable prefix pages sit still, and when both are drawn from one pool the transient allocation tends to evict the valuable one, so a long session can lose its expensive full-attention history to short-lived window state.',
+    benchmarkContext:
+      'These effects appear only on multi-turn traffic. A single short prompt never laps the window or contends for the pool, which is why window-aware eviction, offload, and branch handling show up as AgentX-driven engine work rather than as fixed-sequence results.',
+    relatedTerms: ['sparse-attention', 'kv-cache', 'prefix-caching', 'hybrid-attention'],
+    articleSlugs: [AGENTX_V3, KIMI_K3, B200_GLM5],
+  },
+  {
+    slug: 'hybrid-attention',
+    term: 'Hybrid attention',
+    aliases: ['mixed attention', 'hybrid cache model'],
+    category: 'Model architecture',
+    plainEnglish:
+      'A hybrid model mixes attention types across its layers, so its cache is several different kinds of state rather than one uniform block.',
+    definition:
+      'A hybrid attention model interleaves layers of different attention types, producing multiple KV cache groups with distinct shapes and lifetimes.',
+    explanation:
+      'A uniform model has one cache layout per token, so a single block geometry describes everything worth saving. A hybrid model does not: full-attention layers, windowed layers, and recurrent or compressor state coexist, each with its own footprint and its own rules about when it can be discarded and whether it can be rebuilt.',
+    significance:
+      'The distinction is invisible until state has to leave the accelerator. A connector that assumes one uniform layout cannot say which group a block belongs to, so the models with the longest sessions were for a time the ones that could not use offload at all. Recurrent state is the hardest case, since it accumulates everything before it and cannot be recomputed from neighboring tokens.',
+    benchmarkContext:
+      'Frontier open-weight models in the InferenceX matrix are increasingly hybrid, so engine support for hybrid cache groups is part of what a recipe is measuring. Offload, disaggregated transfer, and prefix reuse each had to be extended per group rather than inherited from the uniform case.',
+    relatedTerms: [
+      'sliding-window-attention',
+      'kv-cache',
+      'linear-attention',
+      'sparse-attention',
+      'prefix-caching',
+    ],
+    articleSlugs: [AGENTX_V3, KIMI_K3, DEEPSEEK_V4],
+  },
+  {
+    slug: 'linear-attention',
+    term: 'Linear attention',
+    aliases: ['GatedDeltaNet', 'recurrent attention', 'constant-state attention'],
+    category: 'Model architecture',
+    plainEnglish:
+      'Linear attention keeps a fixed-size running summary instead of every past token, so its memory does not grow as the conversation does.',
+    definition:
+      'Linear attention replaces the growing key and value cache with a recurrent state of constant size that is updated as tokens arrive.',
+    explanation:
+      'Standard attention stores state proportional to sequence length and rereads it every step. A linear or gated recurrent layer carries a fixed-size state instead, trading exact recall of every position for bounded memory. Architectures such as GatedDeltaNet apply this on a fraction of layers, leaving full attention elsewhere to preserve precise long-range lookup.',
+    significance:
+      'For long context the storage saving is substantial, but the state changes what caching means. It cannot be reconstructed from surrounding tokens the way a window tail can, so if it is dropped the only way back is replaying the sequence, and reuse requires an explicit checkpoint mechanism rather than ordinary block reuse.',
+    benchmarkContext:
+      'InferenceX serves models using these layers, and engine support for checkpointing and transferring recurrent state is part of the recipe. A model can be day-zero servable and still lack reuse of that state, which shows up as unexpectedly high prefill cost on repeated turns.',
+    relatedTerms: ['hybrid-attention', 'kv-cache', 'sparse-attention', 'prefill'],
+    articleSlugs: [AGENTX_V3, MI355X_QWEN, KIMI_K3],
+  },
+  {
+    slug: 'nvl72',
+    term: 'NVL72',
+    aliases: ['GB200 NVL72', 'GB300 NVL72', 'rack-scale system'],
+    category: 'Hardware',
+    plainEnglish:
+      'NVL72 is a rack where 72 accelerators share one high-speed fabric, so they behave more like a single large machine than a cluster.',
+    definition:
+      'NVL72 is a rack-scale NVIDIA system that places 72 accelerators in a single NVLink scale-up domain rather than in separate eight-chip nodes.',
+    explanation:
+      'The dashboard specs record NVLink 5.0 at 900 GB/s per chip unidirectional across a scale-up world size of 72, switched through NVSwitch. A conventional node keeps that bandwidth among eight chips and falls back to slower scale-out networking beyond them, so the difference is not raw speed but how many chips are reachable before the fabric changes character.',
+    significance:
+      'Techniques whose cost is dominated by collectives change economics inside a large domain. Wide expert parallelism spreads experts across many chips and pays all-to-all traffic for every token, which is tolerable at scale-up bandwidth and often is not across a scale-out fabric.',
+    benchmarkContext:
+      'A rack-scale advantage is not automatic. Higher cost per chip has to be earned back, and on agentic traffic the orchestration layer can become the bottleneck before the fabric does, so NVL72 configurations sometimes trail eight-chip nodes on TCO-normalized throughput for models that do not exercise wide parallelism.',
+    relatedTerms: [
+      'nvlink',
+      'scale-up-vs-scale-out',
+      'wide-expert-parallelism',
+      'all-to-all',
+      'total-cost-of-ownership',
+    ],
+    articleSlugs: [GB200_R1, GB300_DSV4, GB200_KIMI, VR_RUBIN],
+  },
+  {
+    slug: 'atom',
+    term: 'ATOM',
+    aliases: ['AMD ATOM', 'ATOMesh'],
+    category: 'Software',
+    plainEnglish:
+      'ATOM is AMD’s own inference engine, its answer to a vendor runtime rather than an upstream open-source one.',
+    definition:
+      'ATOM is AMD’s inference engine for Instinct accelerators, positioned as the vendor runtime alongside upstream vLLM and SGLang on ROCm.',
+    explanation:
+      'It occupies the same role for AMD that a vendor runtime does for NVIDIA: tuned for the vendor’s own hardware and free to move ahead of upstream engines. Its router, ATOMesh, began as a fork of the SGLang router. The engine was built for single-turn serving, so long-context multi-turn support required substantial changes to its cache manager and kernels.',
+    significance:
+      'A vendor engine can show what silicon is capable of before the open stack catches up, which makes it useful evidence and awkward guidance at the same time. Most labs deploy upstream engines, so a result that exists only under a vendor runtime does not describe what those users will get.',
+    benchmarkContext:
+      'InferenceX reports ATOM as its own framework label so it is never conflated with a vLLM or SGLang result on the same accelerator. Compare it to other vendor runtimes when asking what the hardware can do, and to upstream engines when asking what a customer can deploy today.',
+    relatedTerms: ['inference-engine', 'rocm', 'vllm', 'sglang', 'tensorrt-llm'],
+    articleSlugs: [AGENTX_V3, MI355X_DSV4, MI355X_GLM5],
+  },
+  {
+    slug: 'aiter',
+    term: 'AITER',
+    aliases: ['AMD AITER', 'ROCm kernel library'],
+    category: 'Software',
+    plainEnglish:
+      'AITER is AMD’s tuned kernel library, the layer that decides how fast attention and matrix work actually run on Instinct chips.',
+    definition:
+      'AITER is AMD’s library of optimized kernels for Instinct accelerators, used by inference engines running on ROCm.',
+    explanation:
+      'Engines express a strategy; kernels decide whether it is fast. AITER supplies tuned attention, matrix, and fused operations, and an engine dispatches to it in place of a generic path. That dispatch decision is itself tunable, and a kernel that wins on one shape can lose on another, so selection may depend on context length rather than being fixed.',
+    significance:
+      'A parallelism strategy is only real if the kernels can express it, which is why context parallelism and long-context sparse attention on AMD arrived as kernel work rather than engine work. Very large caches also expose failures short requests never reach, such as address arithmetic that overflows once a pool crosses a size boundary and silently addresses the wrong row.',
+    benchmarkContext:
+      'The library sits inside the container image a recipe pins, so an AITER improvement can move a curve with no change to the engine version or the hardware. Kernel-level gains measured on uniform shapes do not always survive agentic traces, where cache and scheduling variance can swamp them.',
+    relatedTerms: ['rocm', 'inference-engine', 'sparse-attention', 'memory-bandwidth', 'vllm'],
+    articleSlugs: [MI355X_KIMI, AGENTX_V3, MI355X_DSV4],
+  },
+  {
+    slug: 'flashinfer',
+    term: 'FlashInfer',
+    aliases: ['attention kernel library'],
+    category: 'Software',
+    plainEnglish:
+      'FlashInfer is a library of attention kernels that serving engines call instead of writing their own attention implementations.',
+    definition:
+      'FlashInfer is an open-source library of attention kernels and backends used by inference engines for prefill, decode, and speculative verification.',
+    explanation:
+      'Attention is where most serving-specific complexity lives: paged caches, variable sequence lengths, grouped query heads, sparsity patterns, and verification of drafted tokens all reshape the kernel. A shared library lets several engines reuse one tuned implementation, and engines select a backend per shape and per hardware target.',
+    significance:
+      'Because backends are selected rather than fixed, kernel availability becomes a portability question. A feature implemented only for one vendor’s backend leaves the alternative running a generic path, which on long context is not a small compromise but the wrong kernel for the shape.',
+    benchmarkContext:
+      'The backend in use is part of the recipe, and a change to it can move a curve without any hardware or engine version change. Support for checkpointing recurrent state in these kernels is what allowed hybrid models to participate in prefix reuse at all.',
+    relatedTerms: ['inference-engine', 'sparse-attention', 'kv-cache', 'vllm', 'sglang'],
+    articleSlugs: [AGENTX_V3, SGLANG_056, INFERENCEX_V2],
+  },
+  {
+    slug: 'cuda-graphs',
+    term: 'CUDA graphs',
+    aliases: ['graph capture', 'full-graph mode'],
+    category: 'Software',
+    plainEnglish:
+      'CUDA graphs record a whole sequence of chip operations once and replay it as a unit, removing the per-step cost of launching each one.',
+    definition:
+      'CUDA graph capture records a sequence of kernel launches and their dependencies into a replayable graph, so the sequence is submitted once rather than launched operation by operation.',
+    explanation:
+      'A decode step issues many small kernels, and at small batch sizes the launch and scheduling overhead between them can rival the arithmetic. Capturing the step removes that per-launch cost. The catch is that a graph is fixed: shapes must be stable, so engines capture per bucket and leave genuinely dynamic work outside the graph.',
+    significance:
+      'This is a latency optimization more than a throughput one, and it matters most exactly where batches are small and interactivity is high. It also interacts with everything that changes shape, which is why variable-length agentic traffic can defeat a runtime that specializes too eagerly and recompiles for nearly every request it sees.',
+    benchmarkContext:
+      'Graph usage is part of the engine image a recipe pins, so it can move a curve with no change in hardware. Recipes may capture stable producers while leaving request-dependent attention eager, which is a deliberate compromise between capture coverage and shape flexibility.',
+    relatedTerms: ['cuda', 'decode', 'interactivity', 'inference-engine', 'batching'],
+    articleSlugs: [AGENTX_V3, TILERT, INFERENCEX_V2],
   },
 ] as const satisfies readonly GlossaryEntry[];
 


### PR DESCRIPTION
## Summary

Branched fresh from `master` (which now includes #850). A sweep of the codebase and the full article corpus turned up 24 more terms that are already load-bearing in the product or the writing but had no glossary entry. **62 entries → 86.**

## How the terms were chosen

Not from a list of things that sound like glossary words. Two passes:

**Codebase.** Chart toggles and legend keys (`ScatterGraph.tsx`), point tooltips (`tooltipUtils.ts`, `parallelism-label.ts`), the AgentX telemetry views (`agentic-point/*`), the metric registry, `FW_REGISTRY`, `PRECISION_KEYS`, and `gpu-specs.ts`. Anything a user can see, hover, or toggle is a candidate.

**Articles.** Frequency scan over all 20 English posts. The highest-frequency technical terms with no entry were: NVL72 (397 mentions), recipe (137), AITER (79), ATOM (77), INT4 (69), FlashInfer (42), SLO (38), AIPerf (25), p90/p99 (29), linear attention (23), BF16 (20), CUDA graph (19), warmup (17).

## New entries (24)

| Category | Terms |
| --- | --- |
| Benchmark metrics | recipe, tail latency, service level objective, acceptance length, unofficial run, roofline, arithmetic intensity, warmup |
| Serving | chunked prefill, prefix cache hit rate |
| Agentic inference | AIPerf |
| Parallelism | pipeline parallelism, data-parallel attention (DPA) |
| Numerical precision | INT4, BF16, KV cache quantization |
| Model architecture | sliding window attention, hybrid attention, linear attention |
| Hardware | NVL72 |
| Software | ATOM, AITER, FlashInfer, CUDA graphs |

## Two accuracy notes worth a reviewer's eye

**`roofline` does not mean the HPC roofline model here.** I went in assuming it did. In this codebase a roofline is the per-hardware Pareto envelope, with the corner direction configured per metric (`${metric}_roofline` → `upper_right` / `upper_left` / `lower_left` / `lower_right` via `paretoFrontForDirection`), and degenerate-x points excluded by `isFrontierEligible`. The entry defines the dashboard meaning and explicitly names the difference from the HPC model, because the collision is exactly the kind of thing a glossary should resolve rather than inherit.

**`NVL72` numbers come from our own data, not from memory.** `src/lib/gpu-specs.ts` records NVLink 5.0, `scaleUpBandwidth: '900 GB/s'`, `scaleUpWorldSize: 72`, switched NVSwitch Gen 4.0. The file header states that scale-up bandwidth is per-GPU **unidirectional**, and the entry says so explicitly, per the house rule about uni-di vs bi-di in AGENTS.md.

## Cross-linking

Adding terms without wiring them in leaves a glossary that looks complete and reads disconnected, so `relatedTerms` were rewired both ways: `quantization` → INT4 / BF16 / KV cache quantization; `prefill` → chunked prefill, arithmetic intensity; `latency` → tail latency; `pareto-frontier` → roofline; `speculative-decoding` → acceptance length. The new entries in turn link into #850's terms where the relationship is real (`dp-attention` → `kv-aware-routing`, `aiter` → `context-parallelism`, `prefix-cache-hit-rate` → `kv-cache-offload`).

## Notes for reviewers

- No new files or routes. `/glossary/*`, `/zh/glossary/*`, and the sitemap all derive from the registry, so all 24 appear in both languages automatically.
- Vendor-specific entries (ATOM, AITER, TileRT-adjacent claims) are written to describe the engineering situation rather than to rank vendors: a vendor runtime shows what silicon can do, upstream engines show what a customer can deploy, and the entries say so in those terms.
- Terms considered and deliberately skipped because an existing entry already covers them: continuous batching (in `batching`), InfiniBand / RoCE (in `scale-up-vs-scale-out`), active parameters (in `mixture-of-experts`).

## Verification

- `bun run test:unit` — 4,776 tests pass, including `glossary.test.ts` (unique kebab-case slugs, 8–40 word plain-English gloss, ≥90 word body, ≥3 resolvable non-self related terms, ≥1 real article slug, no em/en dashes, complete zh translation with Han-character floors and distinct `measurement` values) and `zh-copy.test.ts` (24 mechanical Chinese rules).
- `bun run lint`, `bun run fmt`, `bun run typecheck` clean.

## 中文说明

本 PR 基于最新的 `master`（已包含 #850）新建分支。通过对代码库和全部文章的系统梳理，补充了 24 条在产品或文章中已经承担实际作用、但术语表尚未收录的术语。**条目从 62 条增至 86 条。**

### 术语的挑选方式

不是凭感觉罗列，而是分两步：

**代码库**：图表开关与图例（`ScatterGraph.tsx`）、数据点 tooltip（`tooltipUtils.ts`、`parallelism-label.ts`）、AgentX 遥测视图（`agentic-point/*`）、指标注册表、`FW_REGISTRY`、`PRECISION_KEYS` 和 `gpu-specs.ts`。凡是用户能看到、悬停或切换的内容都是候选。

**文章**：对全部 20 篇英文文章做词频统计。出现频率最高且尚无条目的术语为：NVL72（397 次）、recipe（137 次）、AITER（79 次）、ATOM（77 次）、INT4（69 次）、FlashInfer（42 次）、SLO（38 次）、AIPerf（25 次）、p90/p99（29 次）、linear attention（23 次）、BF16（20 次）、CUDA graph（19 次）、warmup（17 次）。

### 新增条目（24 条）

| 分类 | 术语 |
| --- | --- |
| 基准指标 | 测试配置、尾部延迟、服务级目标、接受长度、非官方运行、roofline 曲线、算术强度、warmup |
| 推理服务 | 分块 prefill、前缀缓存命中率 |
| 智能体推理 | AIPerf |
| 并行策略 | 流水线并行、数据并行注意力（DPA） |
| 数值精度 | INT4、BF16、KV cache 量化 |
| 模型架构 | 滑动窗口注意力、混合注意力、线性注意力 |
| 硬件 | NVL72 |
| 软件栈 | ATOM、AITER、FlashInfer、CUDA graph |

### 两处需要评审重点关注的准确性说明

**本代码库中的 `roofline` 并不是 HPC 的 roofline 模型。** 我最初也是这么假设的。在这里，roofline 指按硬件绘制的 Pareto 包络，其角点方向按指标配置（`${metric}_roofline` → `upper_right` / `upper_left` / `lower_left` / `lower_right`，经由 `paretoFrontForDirection`），并由 `isFrontierEligible` 排除 x 值退化的点。该条目按仪表板含义定义，并明确指出与 HPC 模型的差异——这类同名不同义，正是术语表应当澄清而不是照搬的情况。

**`NVL72` 的数据来自我们自己的数据文件，而非记忆。** `src/lib/gpu-specs.ts` 记录为 NVLink 5.0、`scaleUpBandwidth: '900 GB/s'`、`scaleUpWorldSize: 72`，交换芯片为 NVSwitch Gen 4.0。该文件头部说明 scale-up 带宽为每 GPU **单向**带宽，条目中已按 AGENTS.md 中关于单向与双向的约定明确写出。

### 术语关系

只加条目而不接入关系图，会让术语表看起来完整、读起来割裂，因此对 `relatedTerms` 做了双向调整：`quantization` → INT4 / BF16 / KV cache 量化；`prefill` → 分块 prefill、算术强度；`latency` → 尾部延迟；`pareto-frontier` → roofline；`speculative-decoding` → 接受长度。新条目也在关系确实成立时链接到 #850 的术语（`dp-attention` → `kv-aware-routing`，`aiter` → `context-parallelism`，`prefix-cache-hit-rate` → `kv-cache-offload`）。

### 评审提示

- 不新增文件或路由。`/glossary/*`、`/zh/glossary/*` 和 sitemap 均由注册表派生，24 条术语会自动在中英文两侧出现。
- 涉及厂商的条目（ATOM、AITER 等）着重描述工程现状而非给厂商排名：厂商运行时展示硬件能力上限，上游引擎代表客户实际可部署的水平，条目中按此表述。
- 经评估后有意跳过的术语（已被现有条目覆盖）：continuous batching（见 `batching`）、InfiniBand / RoCE（见 `scale-up-vs-scale-out`）、active parameters（见 `mixture-of-experts`）。

### 验证

- `bun run test:unit` — 4,776 项测试通过，包括 `glossary.test.ts`（slug 唯一且为 kebab-case、通俗解释 8–40 词、正文 ≥90 词、≥3 个可解析且不自指的相关术语、≥1 个真实文章 slug、禁用长破折号、中文翻译完整且汉字数量达标、`measurement` 值与英文不同）和 `zh-copy.test.ts`（24 条机械性中文规则）。
- `bun run lint`、`bun run fmt`、`bun run typecheck` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only changes to glossary data and Chinese copy; no API, routing, or inference runtime behavior.
> 
> **Overview**
> Expands the shared glossary registry from **62 to 86 entries**, with matching additions in `glossary-zh.ts`, so `/glossary/*` and `/zh/glossary/*` pick up the new terms automatically.
> 
> The **24 new slugs** cover benchmark concepts (`recipe`, tail latency, SLO, acceptance length, unofficial run, dashboard **roofline** envelope, arithmetic intensity, warmup), serving/agentic pieces (chunked prefill, prefix cache hit rate, **AIPerf**), parallelism (**PP**, DP attention), precision (**INT4**, **BF16**, KV cache quantization), model architecture (sliding window, hybrid, linear attention), hardware (**NVL72**), and software (**ATOM**, **AITER**, **FlashInfer**, CUDA graphs). Entries tie each term to InferenceX/AgentX UI and methodology—for example roofline as per-hardware Pareto envelopes (not the HPC roofline model) and NVL72 figures aligned with `gpu-specs.ts`.
> 
> **Existing entries** get updated `relatedTerms`: `latency` → tail latency; `prefill` → chunked prefill and arithmetic intensity; `quantization` → INT4, BF16, and KV cache quantization; `speculative-decoding` → acceptance length. New entries link back into prior terms (e.g. `dp-attention` ↔ routing/cache terms from #850).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9845358358cf93405626c818803031dfe5a75d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->