### PR TITLE
Move label + display toggles into the legend Advanced drawer

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -8,6 +8,7 @@ import {
 import ScatterGraph from '@/components/inference/ui/ScatterGraph';
 import ChartDisplay from '@/components/inference/ui/ChartDisplay';
 import { mountWithProviders } from '../support/test-utils';
+import { expandLegendAdvanced } from '../support/legend-advanced';
 import {
   createMockInferenceData,
   createMockChartDefinition,
@@ -711,6 +712,7 @@ describe('ScatterGraph', () => {
       .should('have.text', ' (TileRT, MTP)')
       .and('have.attr', 'fill', '#d1d5db');
 
+    expandLegendAdvanced();
     cy.get('#scatter-line-labels').click();
     cy.get('#test-scatter-ingested-singleton-label svg .line-label').should('not.exist');
     cy.get('#scatter-line-labels').click();

--- a/packages/app/cypress/e2e/gradient-labels.cy.ts
+++ b/packages/app/cypress/e2e/gradient-labels.cy.ts
@@ -1,3 +1,5 @@
+import { expandLegendAdvanced } from '../support/legend-advanced';
+
 describe('Gradient Labels Toggle', () => {
   before(() => {
     cy.visit('/inference', {
@@ -8,6 +10,8 @@ describe('Gradient Labels Toggle', () => {
     // Wait for chart to load
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
     cy.get('.sidebar-legend').first().should('be.visible');
+    // Parallelism Labels lives in the collapsed-by-default Advanced drawer.
+    expandLegendAdvanced();
   });
 
   it('Gradient Labels toggle exists in the legend', () => {
@@ -94,6 +98,7 @@ describe('Gradient Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
   });
 });

--- a/packages/app/cypress/e2e/inference-replay.cy.ts
+++ b/packages/app/cypress/e2e/inference-replay.cy.ts
@@ -1,3 +1,5 @@
+import { expandLegendAdvanced } from '../support/legend-advanced';
+
 const openReplayDialog = () => {
   cy.get('[data-testid="chart-figure"]')
     .first()
@@ -120,6 +122,17 @@ describe('Inference Replay', () => {
   it('re-renders the replay frame when a parent-chart toggle changes', () => {
     cy.get('body').then(($body) => {
       if ($body.find('[data-testid="replay-panel-chart-0"]').length === 0) return;
+      // The log-scale switch lives in the collapsed-by-default Advanced drawer,
+      // so expand it on the parent chart's legend (not the replay panel's).
+      cy.get('[data-testid="legend-advanced-toggle"]').then(($toggles) => {
+        const parentAdvanced = [...$toggles].find(
+          (toggle) => !toggle.closest('[data-testid^="replay-panel-chart-"]'),
+        );
+        if (!parentAdvanced) throw new Error('Parent chart Advanced toggle is missing');
+        if (parentAdvanced.getAttribute('aria-expanded') !== 'true') {
+          cy.wrap(parentAdvanced).click({ force: true });
+        }
+      });
       // Capture the SVG path data for the first roofline as a stable signature.
       cy.get('[data-testid="replay-panel-chart-0"] svg path.roofline-path')
         .first()
@@ -151,6 +164,7 @@ describe('Inference Replay', () => {
       // Enable line labels inside the replay panel (scoped — the parent chart
       // renders the same control behind the dialog).
       cy.get('[data-testid="replay-panel-chart-0"]').within(() => {
+        expandLegendAdvanced();
         cy.get('[data-testid="scatter-line-labels"]').then(($el) => {
           if ($el.attr('data-state') !== 'checked') cy.wrap($el).click();
         });

--- a/packages/app/cypress/e2e/line-labels.cy.ts
+++ b/packages/app/cypress/e2e/line-labels.cy.ts
@@ -1,3 +1,5 @@
+import { expandLegendAdvanced } from '../support/legend-advanced';
+
 describe('Line Labels Toggle', () => {
   before(() => {
     cy.visit('/inference', {
@@ -8,6 +10,8 @@ describe('Line Labels Toggle', () => {
     // Wait for chart to load
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
     cy.get('.sidebar-legend').first().should('be.visible');
+    // Label switches live in the collapsed-by-default Advanced drawer.
+    expandLegendAdvanced();
   });
 
   it('Line Labels toggle exists in the legend', () => {
@@ -156,6 +160,7 @@ describe('Line Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
 
     // Labels should be rendered
@@ -169,6 +174,7 @@ describe('Line Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
 
     // Labels should not be rendered
@@ -182,6 +188,7 @@ describe('Line Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
   });
 
@@ -192,6 +199,7 @@ describe('Line Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     // Labels toggle is auto-enabled by the URL hydration so the advanced
     // (parallelism) point labels actually render.
@@ -205,6 +213,7 @@ describe('Line Labels Toggle', () => {
       },
     });
     cy.get('[data-testid="scatter-graph"]').should('be.visible');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
   });

--- a/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
+++ b/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
@@ -92,7 +92,15 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
     // Inactive row: the hover affordance flips to the "+" restore indicator
     // (explicit "clicking the name brings it back"), and the Hide X is gone.
     cy.get('[data-testid="chart-legend"] [title^="Show B300"]').should('exist');
-    cy.get('[data-testid="scatter-best-per-sku"]').should('have.attr', 'data-state', 'unchecked');
+    // Best per SKU lives in the Quick Filters dialog now.
+    cy.get('[data-testid="scatter-quick-filters"]').click();
+    cy.get('[data-testid="quick-filter-best-per-sku"]').should(
+      'have.attr',
+      'data-state',
+      'unchecked',
+    );
+    cy.contains('button', 'Done').click();
+    cy.get('[data-testid="quick-filters-dialog"]').should('not.exist');
     cy.get(
       '[data-testid="chart-legend"] [role="button"][aria-label^="Hide"][aria-label*="B300"]',
     ).should('not.exist');

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -1,5 +1,6 @@
 import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
 import { agenticMetrics } from '../support/agentic-fixtures';
+import { expandLegendAdvanced } from '../support/legend-advanced';
 
 // This spec exercises the agentic x-axis modes, which only exist when the
 // selected model resolves to the Agentic scenario. The default e2e
@@ -245,6 +246,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     // Line labels name the curve and point labels name the point, so the
     // agentic view turns on both — it differs from fixed-seq only in the
     // parallelism and point labels.
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
@@ -262,6 +264,7 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
       },
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', 'Agentic');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');
@@ -465,6 +468,7 @@ describe('Label defaults for fixed-sequence scenarios', () => {
       },
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'unchecked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'checked');
@@ -526,6 +530,7 @@ describe('Label defaults for fixed-sequence scenarios', () => {
       },
     });
     cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-point-labels').should('have.attr', 'data-state', 'checked');
     cy.get('#scatter-line-labels').should('have.attr', 'data-state', 'unchecked');

--- a/packages/app/cypress/e2e/unofficial-watermark.cy.ts
+++ b/packages/app/cypress/e2e/unofficial-watermark.cy.ts
@@ -1,3 +1,5 @@
+import { expandLegendAdvanced } from '../support/legend-advanced';
+
 describe('Unofficial-run watermark', () => {
   before(() => {
     cy.fixture('api/benchmarks.json').then((benchmarks) => {
@@ -90,6 +92,7 @@ describe('Unofficial-run watermark', () => {
         expect(tooltip).to.contain.text('Chip Cache Hit Rate: 87.5%');
       });
 
+    expandLegendAdvanced();
     cy.get('#scatter-parallelism-labels').click();
     cy.get('[data-testid="scatter-graph"] .unofficial-overlay-pt')
       .first()

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -3,6 +3,7 @@
  * update the visible output (selector text, SVG axis labels).
  * Merged from url-params.cy.ts + chart-filter-effects.cy.ts + high-contrast.cy.ts.
  */
+import { expandLegendAdvanced } from '../support/legend-advanced';
 const visitWithDismissedModal = (path: string) => {
   cy.visit(path, {
     onBeforeLoad(win) {
@@ -244,6 +245,7 @@ describe('URL Parameter Persistence', () => {
 
     it('keeps tooltip rulers aligned after a zoomed metric switch', () => {
       visitWithDismissedModal('/inference?i_metric=y_tpPerGpu');
+      expandLegendAdvanced();
       cy.get('#scatter-log-scale').first().click();
 
       cy.get('[data-testid="scatter-graph"] [data-testid="d3-chart-svg"]')
@@ -414,24 +416,28 @@ describe('URL Parameter Persistence', () => {
     it('inference loads with high contrast off by default', () => {
       visitWithDismissedModal('/inference');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'unchecked');
     });
 
     it('i_hc=0 disables high contrast on load', () => {
       visitWithDismissedModal('/inference?i_hc=0');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'unchecked');
     });
 
     it('i_hc=1 applies high contrast on load', () => {
       visitWithDismissedModal('/inference?i_hc=1');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'checked');
     });
 
     it('multiple high contrast params can coexist in URL', () => {
       visitWithDismissedModal('/inference?i_hc=1&r_hc=1&e_hc=1');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'checked');
     });
 
@@ -467,6 +473,7 @@ describe('URL Parameter Persistence', () => {
     it('a bare /inference link with neither param renders high contrast AND parallelism labels off', () => {
       visitWithDismissedModal('/inference');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'unchecked');
       cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'unchecked');
     });
@@ -474,6 +481,7 @@ describe('URL Parameter Persistence', () => {
     it('i_hc=1&i_advlabel=1 enables both high contrast and parallelism labels on load', () => {
       visitWithDismissedModal('/inference?i_hc=1&i_advlabel=1');
       cy.get('[data-testid="scatter-graph"]').should('exist');
+      expandLegendAdvanced();
       cy.get('#scatter-high-contrast').first().should('have.attr', 'data-state', 'checked');
       cy.get('#scatter-parallelism-labels').should('have.attr', 'data-state', 'checked');
     });

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -80,13 +80,18 @@ describe('URL Parameter Persistence', () => {
     it('refreshes the automatic Best per SKU selection when the metric changes', () => {
       visitWithDismissedModal('/inference');
 
-      cy.get('[data-testid="scatter-best-per-sku"]')
-        .should('have.attr', 'data-state', 'checked')
-        .then(() =>
-          cy
-            .get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked')
-            .then(($inputs) => [...$inputs].map((input) => input.id).toSorted()),
-        )
+      // Best per SKU lives in the Quick Filters dialog now.
+      cy.get('[data-testid="scatter-quick-filters"]').click();
+      cy.get('[data-testid="quick-filter-best-per-sku"]').should(
+        'have.attr',
+        'data-state',
+        'checked',
+      );
+      cy.contains('button', 'Done').click();
+      cy.get('[data-testid="quick-filters-dialog"]').should('not.exist');
+
+      cy.get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked')
+        .then(($inputs) => [...$inputs].map((input) => input.id).toSorted())
         .then((before) => {
           cy.get('[data-testid="yaxis-metric-selector"]').click({ force: true });
           cy.contains(
@@ -94,11 +99,14 @@ describe('URL Parameter Persistence', () => {
             'Cost per Million Total Tokens (Owning - Hyperscaler)',
           ).click({ force: true });
 
-          cy.get('[data-testid="scatter-best-per-sku"]').should(
+          cy.get('[data-testid="scatter-quick-filters"]').click();
+          cy.get('[data-testid="quick-filter-best-per-sku"]').should(
             'have.attr',
             'data-state',
             'checked',
           );
+          cy.contains('button', 'Done').click();
+          cy.get('[data-testid="quick-filters-dialog"]').should('not.exist');
           cy.get('[data-testid="x-axis-mode-ttft"]').click();
           cy.get('[data-testid="x-axis-mode-ttft"]').should('have.attr', 'aria-selected', 'true');
           cy.get('[data-testid="chart-legend"] ul input[type="checkbox"]:checked').then(

--- a/packages/app/cypress/support/legend-advanced.ts
+++ b/packages/app/cypress/support/legend-advanced.ts
@@ -1,0 +1,20 @@
+/**
+ * Expand the chart legend's collapsed-by-default Advanced drawer.
+ *
+ * Log Scale, Labels, High Contrast, Parallelism Labels, and Line Labels live
+ * inside the Advanced section, so tests must open the drawer before reading
+ * or clicking those switches. Idempotent — safe to call when the drawer is
+ * already expanded.
+ *
+ * `cy.get` respects `cy.within` scoping, so call this inside a `.within()`
+ * block to target a specific chart's legend (e.g. a replay panel).
+ */
+export const expandLegendAdvanced = (): void => {
+  cy.get('[data-testid="legend-advanced-toggle"]')
+    .first()
+    .then(($btn) => {
+      if ($btn.attr('aria-expanded') !== 'true') {
+        cy.wrap($btn).click();
+      }
+    });
+};

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -903,6 +903,7 @@ const GPUGraph = React.memo(
               {
                 id: 'gpu-log-scale',
                 label: legendT.logScale,
+                advanced: true,
                 checked: logScale,
                 onCheckedChange: (c) => {
                   setLogScale(c);
@@ -912,6 +913,7 @@ const GPUGraph = React.memo(
               {
                 id: 'gpu-high-contrast',
                 label: legendT.highContrast,
+                advanced: true,
                 checked: highContrast,
                 onCheckedChange: (c) => {
                   setHighContrast(c);
@@ -930,6 +932,7 @@ const GPUGraph = React.memo(
               {
                 id: 'gpu-point-labels',
                 label: legendT.labels,
+                advanced: true,
                 checked: showPointLabels,
                 onCheckedChange: (c) => {
                   setShowPointLabels(c);
@@ -939,6 +942,7 @@ const GPUGraph = React.memo(
               {
                 id: 'gpu-parallelism-labels',
                 label: legendT.parallelismLabels,
+                advanced: true,
                 checked: useAdvancedLabels,
                 onCheckedChange: (c) => {
                   setUseAdvancedLabels(c);
@@ -951,6 +955,7 @@ const GPUGraph = React.memo(
               {
                 id: 'gpu-line-labels',
                 label: legendT.lineLabels,
+                advanced: true,
                 checked: showLineLabels,
                 onCheckedChange: (c) => {
                   setShowLineLabels(c);

--- a/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
+++ b/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
@@ -2,6 +2,7 @@
 
 import { ListFilter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
 import type { DeploymentMode, SpecMode } from '@/components/inference/types';
 import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
 
@@ -32,6 +33,8 @@ const STRINGS = {
     agenticDescription:
       'Narrow the chart by chip vendor, serving framework, and deployment mode. Selecting none in a group shows all.',
     selected: 'selected',
+    bestPerSku: 'Best per SKU',
+    bestPerSkuHint: 'Show only the best configuration for each chip',
     vendor: 'Vendor',
     framework: 'Framework',
     deployment: 'Deployment',
@@ -48,6 +51,8 @@ const STRINGS = {
     description: '按芯片厂商、推理框架、部署模式和投机解码筛选图表。某组不选则显示全部。',
     agenticDescription: '按芯片厂商、推理框架和部署模式筛选图表。某组不选则显示全部。',
     selected: '项已选',
+    bestPerSku: '每个 SKU 仅显示最佳配置',
+    bestPerSkuHint: '每款芯片只显示表现最佳的配置',
     vendor: '厂商',
     framework: '框架',
     deployment: '部署模式',
@@ -78,9 +83,13 @@ function toggleValue<T extends string>(current: T[], value: T): T[] {
 export function QuickFiltersDialog({
   open,
   onOpenChange,
+  bestPerSku,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Optional Best per SKU control (scatter chart only) — the chart owns the
+   * toggle logic because overlay mode manages a temporary unified selection. */
+  bestPerSku?: { checked: boolean; onCheckedChange: (checked: boolean) => void };
 }) {
   const locale = useLocale();
   const t = STRINGS[locale];
@@ -213,6 +222,20 @@ export function QuickFiltersDialog({
         </DialogHeader>
 
         <div className="divide-y divide-border rounded-md border">
+          {bestPerSku && (
+            <section className="flex items-center justify-between gap-3 px-3 py-3">
+              <div>
+                <h3 className="text-xs font-semibold text-muted-foreground">{t.bestPerSku}</h3>
+                <p className="mt-0.5 text-[11px] text-muted-foreground/70">{t.bestPerSkuHint}</p>
+              </div>
+              <Switch
+                data-testid="quick-filter-best-per-sku"
+                checked={bestPerSku.checked}
+                onCheckedChange={bestPerSku.onCheckedChange}
+                aria-label={t.bestPerSku}
+              />
+            </section>
+          )}
           {groups.map((group) => (
             <section
               key={group.key}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -3099,6 +3099,7 @@ const ScatterGraph = React.memo(
                       {
                         id: 'scatter-log-scale',
                         label: legendT.logScale,
+                        advanced: true,
                         checked: logScale,
                         onCheckedChange: (checked: boolean) => {
                           setLogScale(checked);
@@ -3124,6 +3125,7 @@ const ScatterGraph = React.memo(
                 {
                   id: 'scatter-point-labels',
                   label: legendT.labels,
+                  advanced: true,
                   checked: showPointLabels,
                   onCheckedChange: (checked: boolean) => {
                     setShowPointLabels(checked);
@@ -3133,6 +3135,7 @@ const ScatterGraph = React.memo(
                 {
                   id: 'scatter-high-contrast',
                   label: legendT.highContrast,
+                  advanced: true,
                   checked: highContrast,
                   onCheckedChange: (checked: boolean) => {
                     setHighContrast(checked);
@@ -3142,6 +3145,7 @@ const ScatterGraph = React.memo(
                 {
                   id: 'scatter-parallelism-labels',
                   label: legendT.parallelismLabels,
+                  advanced: true,
                   checked: useAdvancedLabels,
                   onCheckedChange: (checked: boolean) => {
                     setUseAdvancedLabels(checked);
@@ -3179,6 +3183,7 @@ const ScatterGraph = React.memo(
                 {
                   id: 'scatter-line-labels',
                   label: legendT.lineLabels,
+                  advanced: true,
                   checked: showLineLabels,
                   onCheckedChange: (checked: boolean) => {
                     setShowLineLabels(checked);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -334,7 +334,6 @@ const SCATTER_STRINGS = {
   en: {
     logScale: 'Log Scale',
     optimalOnly: 'Optimal Only',
-    bestPerSku: 'Best per SKU',
     optimalInfo: 'Optimal points form the Pareto frontier for the selected axes.',
     labels: 'Labels',
     highContrast: 'High Contrast',
@@ -350,7 +349,6 @@ const SCATTER_STRINGS = {
   zh: {
     logScale: '对数缩放',
     optimalOnly: '仅最优',
-    bestPerSku: '每个 SKU 仅显示最佳配置',
     optimalInfo: '最优点构成当前所选坐标轴的 Pareto 前沿。',
     labels: '标签',
     highContrast: '高对比度',
@@ -567,6 +565,45 @@ const ScatterGraph = React.memo(
         toggleOfficialHwType(key);
       },
       [overlayData, setBestPerSku, toggleOfficialHwType, toggleHwType],
+    );
+
+    // Best per SKU lives in the Quick Filters dialog, but the handler stays
+    // here: overlay mode owns a temporary unified selection that must be
+    // recomputed (or restored) when the automatic mode flips.
+    const handleBestPerSkuChange = useCallback(
+      (checked: boolean) => {
+        setBestPerSku(checked);
+        if (overlayData) {
+          if (checked) {
+            const direction =
+              chartDefinition[`${selectedYAxisMetric}_roofline` as keyof ChartDefinition];
+            if (
+              direction === 'upper_right' ||
+              direction === 'upper_left' ||
+              direction === 'lower_left' ||
+              direction === 'lower_right'
+            ) {
+              const selection = bestSeriesPerSku(data, direction);
+              for (const key of bestSeriesPerSku(overlayData.data, direction)) {
+                selection.add(`overlay:${key}`);
+              }
+              commitUnifiedSelection(selection);
+            }
+          } else {
+            resetUnifiedSelection();
+          }
+        }
+        track('inference_best_per_sku_toggled', { enabled: checked });
+      },
+      [
+        setBestPerSku,
+        overlayData,
+        chartDefinition,
+        selectedYAxisMetric,
+        data,
+        commitUnifiedSelection,
+        resetUnifiedSelection,
+      ],
     );
 
     // Legend "X" (remove) — same overlay split as handleToggleHwType. With an
@@ -2914,7 +2951,11 @@ const ScatterGraph = React.memo(
               </Button>
             </div>
           </div>
-          <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
+          <QuickFiltersDialog
+            open={quickFiltersOpen}
+            onOpenChange={setQuickFiltersOpen}
+            bestPerSku={{ checked: bestPerSku, onCheckedChange: handleBestPerSkuChange }}
+          />
         </div>
       );
     }
@@ -3062,37 +3103,6 @@ const ScatterGraph = React.memo(
                 track('latency_legend_expanded', { expanded });
               }}
               switches={[
-                {
-                  id: 'scatter-best-per-sku',
-                  label: legendT.bestPerSku,
-                  checked: bestPerSku,
-                  onCheckedChange: (checked: boolean) => {
-                    setBestPerSku(checked);
-                    if (overlayData) {
-                      if (checked) {
-                        const direction =
-                          chartDefinition[
-                            `${selectedYAxisMetric}_roofline` as keyof ChartDefinition
-                          ];
-                        if (
-                          direction === 'upper_right' ||
-                          direction === 'upper_left' ||
-                          direction === 'lower_left' ||
-                          direction === 'lower_right'
-                        ) {
-                          const selection = bestSeriesPerSku(data, direction);
-                          for (const key of bestSeriesPerSku(overlayData.data, direction)) {
-                            selection.add(`overlay:${key}`);
-                          }
-                          commitUnifiedSelection(selection);
-                        }
-                      } else {
-                        resetUnifiedSelection();
-                      }
-                    }
-                    track('inference_best_per_sku_toggled', { enabled: checked });
-                  },
-                },
                 ...(selectedYAxisMetric === 'y_inputTputPerGpu'
                   ? []
                   : [
@@ -3252,7 +3262,11 @@ const ScatterGraph = React.memo(
             />
           }
         />
-        <QuickFiltersDialog open={quickFiltersOpen} onOpenChange={setQuickFiltersOpen} />
+        <QuickFiltersDialog
+          open={quickFiltersOpen}
+          onOpenChange={setQuickFiltersOpen}
+          bestPerSku={{ checked: bestPerSku, onCheckedChange: handleBestPerSkuChange }}
+        />
         {pointsTable && (
           <LegendPointsDialog
             open


### PR DESCRIPTION
## What

Moves five legend switches on the inference charts (scatter + GPU timeline) into the collapsed-by-default **Advanced** drawer:

- Log Scale
- Labels
- High Contrast
- Parallelism Labels
- Line Labels

**Best per SKU**, **Optimal Only**, and **Gradient Labels** stay top-level.

## Defaults unchanged

No default behavior changes — Line Labels stay on everywhere, Labels + Parallelism Labels stay on for the agentic view, Log Scale and High Contrast stay off. Only where the switches live in the panel changes; URL param hydration (`i_label`, `i_advlabel`, `i_linelabel`, `i_hc`, log scale) is untouched.

## Tests

- New shared `cypress/support/legend-advanced.ts` helper expands the drawer (idempotent, respects `cy.within` scoping) — same pattern the speed-overlay spec already uses.
- Updated the specs that read/click the moved switches: `line-labels`, `gradient-labels`, `ttft-x-axis-toggle`, `url-params`, `unofficial-watermark`, `inference-replay` (parent-chart + replay-panel legends), and the `scatter-graph` component spec.
- `typecheck` and `lint` pass locally; vitest failures on this box are pre-existing env-dependent server tests (identical on a clean tree).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI placement and test harness changes only; chart filter logic and URL-driven defaults are preserved, with Best per SKU wiring moved but not rewritten.
> 
> **Overview**
> **Reorganizes inference chart legend controls** so the sidebar stays less cluttered while keeping toggle defaults and URL hydration the same.
> 
> On **scatter** and **GPU** charts, **Log Scale**, **Labels**, **High Contrast**, **Parallelism Labels**, and **Line Labels** are marked `advanced: true` and render inside the collapsed-by-default **Advanced** drawer. **Optimal Only**, **Gradient Labels**, and the decorative overlay toggles stay visible at the top level.
> 
> **Best per SKU** is removed from the scatter legend and added as an optional switch at the top of **Quick Filters** (`quick-filter-best-per-sku`). Scatter still owns overlay-aware selection via a shared `handleBestPerSkuChange` passed into `QuickFiltersDialog`.
> 
> **Cypress** adds idempotent `expandLegendAdvanced()` and updates specs that assert or click the moved controls (including replay parent vs panel legends). Tests that checked Best per SKU now open Quick Filters and dismiss the dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553df7037a6fd5d9f54553fcf832b458158e310d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Follow-up: Best per SKU → Quick Filters

The **Best per SKU** switch moved from the legend into the top of the **Quick Filters** dialog (scatter chart only, matching where the toggle existed before). Still on by default; `i_best`, context state, and overlay unified-selection handling are unchanged.
