### PR TITLE
Make PNG export footer 5x larger

### DIFF
--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -197,7 +197,7 @@ function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
   return new Promise((resolve) => {
     const img = new Image();
     img.addEventListener('load', () => {
-      const WATERMARK_HEIGHT = 48;
+      const WATERMARK_HEIGHT = 240;
       const canvas = document.createElement('canvas');
       canvas.width = img.width;
       canvas.height = img.height + WATERMARK_HEIGHT;
@@ -218,16 +218,22 @@ function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
       ctx.fillStyle = isDark ? '#1a1a2e' : '#f5f5f5';
       ctx.fillRect(0, img.height, canvas.width, WATERMARK_HEIGHT);
 
-      // Draw watermark text
+      // Draw watermark text (shrink to fit on narrow exports)
+      const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
+      const fontFor = (size: number) =>
+        `bold ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+      let fontSize = 80;
+      ctx.font = fontFor(fontSize);
+      const maxTextWidth = canvas.width - 48;
+      const textWidth = ctx.measureText(WATERMARK_TEXT).width;
+      if (textWidth > maxTextWidth) {
+        fontSize = Math.max(16, Math.floor((fontSize * maxTextWidth) / textWidth));
+        ctx.font = fontFor(fontSize);
+      }
       ctx.fillStyle = isDark ? '#aaa' : '#555';
-      ctx.font = 'bold 16px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      ctx.fillText(
-        'InferenceX — github.com/SemiAnalysisAI/InferenceX',
-        canvas.width / 2,
-        img.height + WATERMARK_HEIGHT / 2,
-      );
+      ctx.fillText(WATERMARK_TEXT, canvas.width / 2, img.height + WATERMARK_HEIGHT / 2);
 
       resolve(canvas.toDataURL('image/png'));
     });

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -192,6 +192,10 @@ export function normalizeChartSvgWidthsForExport(root: HTMLElement): void {
   }
 }
 
+function watermarkFont(size: number): string {
+  return `bold ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
+}
+
 /** Add a subtle watermark bar at the bottom of the exported image */
 function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
   return new Promise((resolve) => {
@@ -220,15 +224,13 @@ function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
 
       // Draw watermark text (shrink to fit on narrow exports)
       const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
-      const fontFor = (size: number) =>
-        `bold ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
       let fontSize = 80;
-      ctx.font = fontFor(fontSize);
+      ctx.font = watermarkFont(fontSize);
       const maxTextWidth = canvas.width - 48;
       const textWidth = ctx.measureText(WATERMARK_TEXT).width;
       if (textWidth > maxTextWidth) {
         fontSize = Math.max(16, Math.floor((fontSize * maxTextWidth) / textWidth));
-        ctx.font = fontFor(fontSize);
+        ctx.font = watermarkFont(fontSize);
       }
       ctx.fillStyle = isDark ? '#aaa' : '#555';
       ctx.textAlign = 'center';


### PR DESCRIPTION
The exported-PNG watermark footer was hard to read: charts export at `pixelRatio: 2`, so the 48px bar / 16px text rendered at half size relative to the chart.

Changes in `useChartExport.ts` (`addWatermark`):
- Footer bar height: 48px → 240px
- Footer text: bold 16px → bold 80px
- Text now shrinks to fit on narrow exports so it never clips (floor of 16px)

MP4 export watermark (`exportMp4.ts`) is untouched — this only affects exported PNGs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side canvas watermark sizing only; no auth, data, or API behavior changes.
> 
> **Overview**
> **PNG chart exports** get a much larger InferenceX footer so branding stays readable when captures use `pixelRatio: 2`.
> 
> In `addWatermark` (`useChartExport.ts`), the bottom bar grows from **48px → 240px** and default label text from **16px → 80px**, with a `watermarkFont` helper. **Narrow images** scale the text down (minimum **16px**) so the full `InferenceX — github.com/SemiAnalysisAI/InferenceX` string does not clip. **MP4 replay export** (`exportMp4.ts`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 296c7aea7c9a907a5fae9e1548c0ce141b86e9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->