### PR TITLE
fix(ui): hide Scenario and Precision selectors when only one option exists / 当仅有一个可选项时隐藏 Scenario 和 Precision 选择器

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -171,7 +171,27 @@ describe('Chart Selectors', () => {
         .and('have.attr', 'href', '/agentx');
     });
 
-    it('renders nothing when only one scenario is available', () => {
+    it('renders nothing when the only scenario is fixed-sequence', () => {
+      cy.mount(
+        <TooltipProvider delayDuration={0}>
+          <div data-testid="selector-host">
+            <ScenarioSelector
+              value={Sequence.EightK_OneK}
+              onChange={() => {}}
+              availableSequences={[Sequence.EightK_OneK]}
+              data-testid="scenario-selector"
+            />
+          </div>
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="selector-host"]').should('exist');
+      cy.get('[data-testid="scenario-selector"]').should('not.exist');
+      cy.contains('Scenario').should('not.exist');
+    });
+
+    it('keeps a static agentic readout when agentic is the only scenario', () => {
+      // No dropdown — but the explainer (tooltip + /agentx link) must survive,
+      // since agentic-only models are exactly the ones that need it.
       cy.mount(
         <TooltipProvider delayDuration={0}>
           <div data-testid="selector-host">
@@ -184,9 +204,10 @@ describe('Chart Selectors', () => {
           </div>
         </TooltipProvider>,
       );
-      cy.get('[data-testid="selector-host"]').should('exist');
       cy.get('[data-testid="scenario-selector"]').should('not.exist');
-      cy.contains('Scenario').should('not.exist');
+      cy.contains('Scenario').should('exist');
+      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
+      cy.get('[data-testid="scenario-agentic-info"]').should('exist');
     });
 
     it('hides the agentic explainer on fixed-sequence scenarios', () => {

--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -171,6 +171,24 @@ describe('Chart Selectors', () => {
         .and('have.attr', 'href', '/agentx');
     });
 
+    it('renders nothing when only one scenario is available', () => {
+      cy.mount(
+        <TooltipProvider delayDuration={0}>
+          <div data-testid="selector-host">
+            <ScenarioSelector
+              value={Sequence.AgenticTraces}
+              onChange={() => {}}
+              availableSequences={[Sequence.AgenticTraces]}
+              data-testid="scenario-selector"
+            />
+          </div>
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="selector-host"]').should('exist');
+      cy.get('[data-testid="scenario-selector"]').should('not.exist');
+      cy.contains('Scenario').should('not.exist');
+    });
+
     it('hides the agentic explainer on fixed-sequence scenarios', () => {
       cy.mount(<ScenarioSelectorHarness initial={Sequence.EightK_OneK} />);
       cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');
@@ -190,6 +208,24 @@ describe('Chart Selectors', () => {
 
     it('shows current selection', () => {
       cy.get('[data-testid="precision-multiselect"]').should('contain', 'FP8');
+    });
+
+    it('renders nothing when only one precision is available', () => {
+      cy.mount(
+        <TooltipProvider>
+          <div data-testid="selector-host">
+            <PrecisionSelector
+              value={['FP8']}
+              onChange={() => {}}
+              availablePrecisions={['FP8']}
+              data-testid="precision-multiselect"
+            />
+          </div>
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="selector-host"]').should('exist');
+      cy.get('[data-testid="precision-multiselect"]').should('not.exist');
+      cy.contains('Precision').should('not.exist');
     });
   });
 });

--- a/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
@@ -893,9 +893,9 @@ describe('Calculator — Fleet Lifecycle with agentic traces', () => {
       },
     });
     cy.wait('@agenticBenchmarks');
-    // The agentic fixture exposes a single scenario, so the scenario selector
-    // is hidden; the unlocked percentile control anchors the agentic view.
-    cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+    // The agentic fixture exposes a single scenario, so the dropdown is
+    // replaced by a static readout that keeps the agentic explainer.
+    cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
     cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
     cy.wait('@agenticHistory');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');

--- a/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
@@ -893,7 +893,9 @@ describe('Calculator — Fleet Lifecycle with agentic traces', () => {
       },
     });
     cy.wait('@agenticBenchmarks');
-    cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic');
+    // The agentic fixture exposes a single scenario, so the scenario selector
+    // is hidden; the unlocked percentile control anchors the agentic view.
+    cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
     cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
     cy.wait('@agenticHistory');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');

--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -25,6 +25,11 @@ describe('Dropdown one-click switching', () => {
   });
 
   it('only one MultiSelect content panel is open at a time when switching dropdowns', () => {
+    // The default model is FP4-only in the fixtures, which hides the Precision
+    // control — switch to a multi-precision model so both dropdowns exist.
+    cy.visit('/inference?g_model=DeepSeek-R1-0528');
+    cy.get('[data-testid="inference-chart-display"]').should('exist');
+
     cy.get('[data-testid="model-selector"]').click();
     cy.get('[data-slot="select-content"]').should('have.length', 1);
 

--- a/packages/app/cypress/e2e/historical-trends.cy.ts
+++ b/packages/app/cypress/e2e/historical-trends.cy.ts
@@ -94,7 +94,12 @@ describe('Historical Trends — Content & Interactions', () => {
     cy.get('body').type('{esc}');
   });
 
-  it('precision multi-select is present', () => {
+  it('precision multi-select is present only for multi-precision models', () => {
+    // The default model is FP4-only in the fixtures, so the control is hidden;
+    // a multi-precision model brings it back.
+    cy.get('[data-testid="precision-multiselect"]').should('not.exist');
+    cy.visit('/historical?g_model=DeepSeek-R1-0528');
+    cy.get('[data-testid="historical-trends-display"]').should('be.visible');
     cy.get('[data-testid="precision-multiselect"]').should('be.visible');
   });
 

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -656,10 +656,11 @@ describe('TCO Calculator', () => {
     });
 
     it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
-      // The agentic fixture exposes a single scenario, so the scenario
-      // selector is hidden; the percentile control anchors the agentic view.
-      cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+      // The agentic fixture exposes a single scenario, so the dropdown is
+      // replaced by a static readout that keeps the agentic explainer.
+      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
       cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
+      cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
       cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
       cy.get('[data-testid="calculator-chart-section"] h2')
@@ -715,8 +716,9 @@ describe('TCO Calculator', () => {
       });
       cy.wait('@agenticBenchmarks');
 
-      // Single-scenario fixture → no scenario selector; the gate is locked, so
-      // no percentile selector either. The P90 heading proves the agentic view.
+      // Single-scenario fixture → the dropdown gives way to a static agentic
+      // readout; the gate is locked, so no percentile selector either.
+      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
       cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
       cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-chart-section"] h2')

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -80,9 +80,12 @@ describe('TCO Calculator', () => {
       });
     });
 
-    it('renders Precision multi-selector', () => {
+    it('hides the Precision selector for a single-precision model', () => {
+      // DeepSeek-V4-Pro is FP4-only in the fixtures — with one precision there
+      // is nothing to choose, so the control is hidden entirely.
+      cy.get('[data-testid="calc-cost-selector"]').should('exist');
       cy.get('[data-testid="calculator-controls"]').within(() => {
-        cy.contains('Precision').should('exist');
+        cy.contains('Precision').should('not.exist');
       });
     });
 
@@ -653,8 +656,10 @@ describe('TCO Calculator', () => {
     });
 
     it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic');
+      // The agentic fixture exposes a single scenario, so the scenario
+      // selector is hidden; the percentile control anchors the agentic view.
       cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
+      cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
       cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length', 2);
       cy.get('[data-testid="calculator-chart-section"] h2')
@@ -710,7 +715,9 @@ describe('TCO Calculator', () => {
       });
       cy.wait('@agenticBenchmarks');
 
-      cy.get('[data-testid="calc-sequence-selector"]').should('contain.text', 'Agentic');
+      // Single-scenario fixture → no scenario selector; the gate is locked, so
+      // no percentile selector either. The P90 heading proves the agentic view.
+      cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
       cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-chart-section"] h2')
         .first()

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -381,7 +381,9 @@ describe('URL Parameter Persistence', () => {
     });
 
     it('/inference with invalid ?i_prec=junk falls back to the default', () => {
-      visitWithErrorSpy('/inference?i_prec=junk');
+      // Pair with a multi-precision model — the FP4-only default model hides
+      // the precision selector entirely, leaving nothing to assert against.
+      visitWithErrorSpy('/inference?g_model=DeepSeek-R1-0528&i_prec=junk');
       cy.get('[data-testid="precision-multiselect"]').invoke('text').should('not.contain', 'junk');
       assertNoHydrationMismatch();
     });

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -384,7 +384,8 @@ export function ScenarioSelector({
     if (!isAgenticSelected) return null;
     return (
       <div className="flex flex-col space-y-1.5 lg:col-span-1">
-        <LabelWithTooltip htmlFor={id} label={t.scenario} tooltip={t.scenarioTooltip} />
+        {/* No htmlFor: the static readout is not a labelable control. */}
+        <LabelWithTooltip label={t.scenario} tooltip={t.scenarioTooltip} />
         <div className="flex h-9 items-center gap-1.5 text-sm" data-testid="scenario-static-value">
           <span>{getSequenceLabel(value as Sequence, locale)}</span>
           <AgenticScenarioInfo

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -357,9 +357,12 @@ interface ScenarioSelectorProps {
  * agentic-trace rows rendered flat below. Label is "Scenario" (the ISL/OSL
  * framing only applies to the fixed-seq subset).
  *
- * Renders nothing when fewer than two scenarios are available: a dropdown with
- * a single choice is dead UI (e.g. agentic-only models like Kimi K3), so the
- * control disappears instead of offering a no-op menu.
+ * Renders no dropdown when fewer than two scenarios are available: a dropdown
+ * with a single choice is dead UI (e.g. agentic-only models like Kimi K3), so
+ * the control disappears instead of offering a no-op menu. When that lone
+ * scenario is agentic, a static readout with the explainer stays behind — the
+ * workload isn't self-describing, and the tooltip's /agentx link is the only
+ * in-controls path to that guidance.
  */
 export function ScenarioSelector({
   id = 'scenario-select',
@@ -377,7 +380,22 @@ export function ScenarioSelector({
   const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
   const isAgenticSelected = sequenceKind(value as Sequence) === 'agentic';
 
-  if (availableSequences.length < 2) return null;
+  if (availableSequences.length < 2) {
+    if (!isAgenticSelected) return null;
+    return (
+      <div className="flex flex-col space-y-1.5 lg:col-span-1">
+        <LabelWithTooltip htmlFor={id} label={t.scenario} tooltip={t.scenarioTooltip} />
+        <div className="flex h-9 items-center gap-1.5 text-sm" data-testid="scenario-static-value">
+          <span>{getSequenceLabel(value as Sequence, locale)}</span>
+          <AgenticScenarioInfo
+            tooltip={t.agenticScenarioTooltip}
+            learnMore={t.agenticScenarioLearnMore}
+            href={locale === 'zh' ? '/zh/agentx' : '/agentx'}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-1">

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -356,6 +356,10 @@ interface ScenarioSelectorProps {
  * Scenario selector — fixed-seq-len rows grouped under "Fixed Sequence Length",
  * agentic-trace rows rendered flat below. Label is "Scenario" (the ISL/OSL
  * framing only applies to the fixed-seq subset).
+ *
+ * Renders nothing when fewer than two scenarios are available: a dropdown with
+ * a single choice is dead UI (e.g. agentic-only models like Kimi K3), so the
+ * control disappears instead of offering a no-op menu.
  */
 export function ScenarioSelector({
   id = 'scenario-select',
@@ -372,6 +376,8 @@ export function ScenarioSelector({
   const agentic = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'agentic');
   const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
   const isAgenticSelected = sequenceKind(value as Sequence) === 'agentic';
+
+  if (availableSequences.length < 2) return null;
 
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-1">
@@ -503,6 +509,11 @@ interface PrecisionSelectorProps {
   'data-testid'?: string;
 }
 
+/**
+ * Precision multi-select. Renders nothing when fewer than two precisions are
+ * available — a single-precision model (e.g. Kimi K3) has nothing to toggle,
+ * so the control disappears instead of offering a no-op menu.
+ */
 export function PrecisionSelector({
   id = 'precision-select',
   value,
@@ -513,6 +524,9 @@ export function PrecisionSelector({
   'data-testid': testId,
 }: PrecisionSelectorProps) {
   const t = STRINGS[useLocale()];
+
+  if (availablePrecisions.length < 2) return null;
+
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-1">
       <LabelWithTooltip htmlFor={id} label={t.precision} tooltip={t.precisionTooltip} />


### PR DESCRIPTION
## Summary

For models with only one benchmark scenario (e.g. Kimi K3, which is agentic-only), the Scenario dropdown offered exactly one choice — dead UI. The same applied to the Precision multi-select for single-precision models.

- `ScenarioSelector` now renders nothing when fewer than two scenarios are available.
- `PrecisionSelector` now renders nothing when fewer than two precisions are available.
- Since both live in the shared `chart-selectors.tsx`, the behavior applies consistently across the inference dashboard, historical trends, compare views, the throughput calculator, and the evaluation tab.
- Added component tests covering both hidden states (single scenario, single precision).

Notes:
- Multi-option models are unaffected; the controls appear exactly as before.
- While availability data is still loading, `availablePrecisions` falls back to a single entry, so the Precision control mounts once real availability lands — same moment its contents became meaningful before this change.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean.
- `cypress run --component --spec chart-selectors.cy.tsx,inference-chart-controls.cy.tsx` — 28/28 passing, including the two new hidden-state tests.

## 中文说明

对于只有一个基准测试场景的模型（如仅有 Agentic 场景的 Kimi K3），Scenario 下拉框只有一个选项，属于无效 UI；仅有一种精度的模型的 Precision 多选框同样如此。

- `ScenarioSelector` 在可用场景少于两个时不再渲染。
- `PrecisionSelector` 在可用精度少于两个时不再渲染。
- 两个组件均位于共享的 `chart-selectors.tsx`，因此该行为一致地覆盖推理仪表板、历史趋势、对比页面、吞吐量计算器和评估页。
- 新增组件测试，验证单场景和单精度两种隐藏状态。

说明：
- 有多个选项的模型不受影响，控件展示与之前完全一致。
- 可用性数据加载期间 `availablePrecisions` 会回退为单个条目，因此 Precision 控件会在真实可用性数据到达后再挂载——与此前该控件内容真正可用的时机一致。

测试：`typecheck` / `lint` / `fmt` 全部通过；相关 Cypress 组件测试 28/28 通过（含两个新增用例）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only conditional rendering in shared chart selectors; multi-option models keep prior behavior, with e2e updates aligned to fixture defaults.
> 
> **Overview**
> **Scenario** and **Precision** controls no longer render pointless single-option dropdowns across inference, historical, calculator, and related views.
> 
> `ScenarioSelector` returns nothing when there is only one fixed-sequence scenario; when the sole scenario is **Agentic**, it shows a **static readout** (`scenario-static-value`) with the existing tooltip and `/agentx` link instead of a menu. `PrecisionSelector` returns nothing when `availablePrecisions` has fewer than two entries.
> 
> Cypress coverage adds component cases for both hide paths and updates e2e specs to expect the static agentic readout (and to visit multi-precision models like `DeepSeek-R1-0528` wherever the precision multiselect must exist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079a4dad2740a3d270437b411eb40ecfbc410574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->