### PR TITLE
feat(inference): indexable /inference/<model> subroutes with landing links / 新增可索引的 /inference/<model> 模型子路由并在首页添加入口

### DIFF
--- a/packages/app/cypress/e2e/agentic-detail-back-nav.cy.ts
+++ b/packages/app/cypress/e2e/agentic-detail-back-nav.cy.ts
@@ -254,7 +254,9 @@ describe('Agentic point detail — returning to the chart', () => {
     cy.location('pathname').should('match', /^\/inference\/agentic\/\d+$/u);
     backControl('en').click();
 
-    cy.location('pathname').should('eq', '/inference');
+    // Picking Kimi K3 moved the chart's history entry onto its indexable
+    // subroute, so Back returns there — the path itself now pins the model.
+    cy.location('pathname').should('eq', '/inference/kimi-k3');
     assertRestoredChart();
   });
 

--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -13,14 +13,14 @@ describe('Compare precision index page', () => {
       cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
         'have.attr',
         'href',
-        '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1',
+        '/inference/kimi-k3?i_seq=agentic-traces&i_optimal=1',
       );
       cy.get('[data-testid="compare-agentx-overview-link"]')
         .should('contain.text', 'Overview')
         .and('have.attr', 'href', '/overview');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', 'Full dashboard')
-        .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+        .and('have.attr', 'href', '/inference/kimi-k3?i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
         .should('contain.text', 'Methodology Deep Dive')
         .and('have.attr', 'href', '/agentx');
@@ -54,14 +54,14 @@ describe('Compare precision index page', () => {
       cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
         'have.attr',
         'href',
-        '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
+        '/zh/inference/deepseek-v4?i_seq=agentic-traces&i_optimal=1',
       );
       cy.get('[data-testid="compare-agentx-overview-link"]')
         .should('contain.text', '总览')
         .and('have.attr', 'href', '/zh/overview');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', '查看完整仪表板')
-        .and('have.attr', 'href', '/zh/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+        .and('have.attr', 'href', '/zh/inference/kimi-k3?i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
         .should('contain.text', '测试方法')
         .and('have.attr', 'href', '/zh/agentx');

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -121,7 +121,7 @@ describe('First-load navigation', () => {
         .and('have.attr', 'href', '/overview');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', 'Full dashboard')
-        .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
+        .and('have.attr', 'href', '/inference/kimi-k3?i_seq=agentic-traces&i_optimal=1');
       cy.get('[data-testid="compare-agentx-methodology-link"]')
         .should('contain.text', 'Methodology Deep Dive')
         .and('have.attr', 'href', '/agentx');

--- a/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { InferenceProvider } from '@/components/inference/InferenceContext';
+import InferenceChartDisplay from '@/components/inference/ui/ChartDisplay';
+import { enAlternates } from '@/lib/i18n';
+import { inferenceModelMeta } from '@/lib/inference-model-meta';
+import {
+  getInferenceModelBySlug,
+  INFERENCE_MODEL_SLUGS,
+  inferenceModelPath,
+} from '@/lib/inference-model-slug';
+
+/**
+ * `/inference/<model>` — an indexable path form of `/inference?g_model=<model>`.
+ *
+ * The query form stays supported for share links, but this page gives every
+ * model its own crawlable URL with model-specific metadata, a self-canonical,
+ * and a `/zh` hreflang sibling. The chart body is identical to `/inference`;
+ * the model is pinned from the pathname by the dashboard shell
+ * (`GlobalFilterProvider` seeding via `inferenceModelForPathname`), and an
+ * explicit `?g_model=` param still wins over the path pin.
+ */
+
+interface Props {
+  params: Promise<{ model: string }>;
+}
+
+export function generateStaticParams(): { model: string }[] {
+  return INFERENCE_MODEL_SLUGS.map((entry) => ({ model: entry.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const entry = getInferenceModelBySlug(model);
+  if (!entry) return {};
+  const { title, description } = inferenceModelMeta(entry);
+  const enPath = inferenceModelPath(entry.slug);
+  const url = `${SITE_URL}${enPath}`;
+  return {
+    title: { absolute: `${title} | ${SITE_NAME} by ${AUTHOR_NAME}` },
+    description,
+    alternates: enAlternates(enPath),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  };
+}
+
+export default async function InferenceModelPage({ params }: Props) {
+  const { model } = await params;
+  const entry = getInferenceModelBySlug(model);
+  if (!entry) notFound();
+  // Aliases (family names, superseded versions, raw `g_model` display names,
+  // uppercase variants) collapse onto the one canonical URL per model.
+  if (model !== entry.slug) permanentRedirect(inferenceModelPath(entry.slug));
+  return (
+    <InferenceProvider activeTab="inference">
+      <InferenceChartDisplay />
+    </InferenceProvider>
+  );
+}

--- a/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
@@ -26,6 +26,7 @@ import {
 
 interface Props {
   params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams(): { model: string }[] {
@@ -57,13 +58,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function InferenceModelPage({ params }: Props) {
+export default async function InferenceModelPage({ params, searchParams }: Props) {
   const { model } = await params;
   const entry = getInferenceModelBySlug(model);
   if (!entry) notFound();
   // Aliases (family names, superseded versions, raw `g_model` display names,
   // uppercase variants) collapse onto the one canonical URL per model.
-  if (model !== entry.slug) permanentRedirect(inferenceModelPath(entry.slug));
+  // Preserves the query string so share-link params like `?i_seq=` and
+  // `?i_prec=` survive the redirect — same treatment as the compare pages.
+  if (model !== entry.slug) {
+    const sp = await searchParams;
+    const qs = Object.entries(sp)
+      .flatMap(([k, v]) => {
+        if (Array.isArray(v)) return v.map((vv) => [k, vv] as const);
+        if (v === undefined) return [];
+        return [[k, v] as const];
+      })
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    permanentRedirect(`${inferenceModelPath(entry.slug)}${qs ? `?${qs}` : ''}`);
+  }
   return (
     <InferenceProvider activeTab="inference">
       <InferenceChartDisplay />

--- a/packages/app/src/app/llms.txt/route.ts
+++ b/packages/app/src/app/llms.txt/route.ts
@@ -1,4 +1,6 @@
 import { getAllPosts } from '@/lib/blog';
+import { inferenceModelMeta } from '@/lib/inference-model-meta';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 // oxlint-disable-next-line require-await
@@ -21,6 +23,13 @@ export async function GET() {
     `- [RSS Feed](${SITE_URL}/feed.xml)`,
     `- [Full content for LLMs](${SITE_URL}/llms-full.txt)`,
     `- [GitHub](https://github.com/SemiAnalysisAI/InferenceX)`,
+    '',
+    `## Model Benchmark Pages`,
+    '',
+    ...INFERENCE_MODEL_SLUGS.map(
+      (entry) =>
+        `- [${inferenceModelMeta(entry).title}](${SITE_URL}/inference/${entry.slug}): ${entry.label}`,
+    ),
     '',
     `## Articles`,
     '',

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SITE_URL } from '@semianalysisai/inferencex-constants';
 import { DASHBOARD_ROUTES } from '@/lib/dashboard-routes';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { zhPath } from '@/lib/i18n';
 const mocks = vi.hoisted(() => ({
   fixturesMode: false,
@@ -48,6 +49,16 @@ describe('sitemap locale parity', () => {
 
       expect(urls.has(englishUrl)).toBe(route.indexable);
       expect(urls.has(chineseUrl)).toBe(route.indexable && route.localeMirrored);
+    }
+  });
+
+  it('emits both locales for every /inference/<model> page', async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+    expect(INFERENCE_MODEL_SLUGS.length).toBeGreaterThan(0);
+    for (const entry of INFERENCE_MODEL_SLUGS) {
+      expect(urls.has(`${SITE_URL}/inference/${entry.slug}`)).toBe(true);
+      expect(urls.has(`${SITE_URL}${zhPath(`/inference/${entry.slug}`)}`)).toBe(true);
     }
   });
 

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -16,6 +16,7 @@ import {
   canonicalSpecDecodeCompareSlug,
 } from '@/lib/compare-variant-slug';
 import { getAllGlossaryEntries } from '@/lib/glossary';
+import { ACTIVE_INFERENCE_MODEL_SLUGS, INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { languageAlternates, zhPath } from '@/lib/i18n';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -72,6 +73,16 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'yearly',
       priority: 0.4,
     }),
+    // Per-model inference pages — the indexable path form of
+    // `/inference?g_model=…`. Deprecated models keep their pages (historical
+    // data stays reachable) at a lower priority than actively benchmarked ones.
+    ...INFERENCE_MODEL_SLUGS.flatMap((entry) =>
+      localizedPair(`/inference/${entry.slug}`, {
+        lastModified: now,
+        changeFrequency: 'daily' as const,
+        priority: ACTIVE_INFERENCE_MODEL_SLUGS.includes(entry) ? 0.8 : 0.5,
+      }),
+    ),
     // The catalog index is indexable; the per-point detail pages it links to
     // stay noindex, so only this page enters the sitemap.
     ...localizedPair('/inference/agentic', {

--- a/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
@@ -21,6 +21,7 @@ import {
 
 interface Props {
   params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams(): { model: string }[] {
@@ -53,11 +54,24 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function ZhInferenceModelPage({ params }: Props) {
+export default async function ZhInferenceModelPage({ params, searchParams }: Props) {
   const { model } = await params;
   const entry = getInferenceModelBySlug(model);
   if (!entry) notFound();
-  if (model !== entry.slug) permanentRedirect(zhPath(inferenceModelPath(entry.slug)));
+  // Preserves the query string so share-link params like `?i_seq=` and
+  // `?i_prec=` survive the redirect — same treatment as the compare pages.
+  if (model !== entry.slug) {
+    const sp = await searchParams;
+    const qs = Object.entries(sp)
+      .flatMap(([k, v]) => {
+        if (Array.isArray(v)) return v.map((vv) => [k, vv] as const);
+        if (v === undefined) return [];
+        return [[k, v] as const];
+      })
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('&');
+    permanentRedirect(`${zhPath(inferenceModelPath(entry.slug))}${qs ? `?${qs}` : ''}`);
+  }
   return (
     <>
       <ZhTabIntro tab="inference" />

--- a/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { InferenceProvider } from '@/components/inference/InferenceContext';
+import InferenceChartDisplay from '@/components/inference/ui/ChartDisplay';
+import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
+import { ZH_OG_LOCALE, zhAlternates, zhPath } from '@/lib/i18n';
+import { inferenceModelMetaZh } from '@/lib/inference-model-meta';
+import {
+  getInferenceModelBySlug,
+  INFERENCE_MODEL_SLUGS,
+  inferenceModelPath,
+} from '@/lib/inference-model-slug';
+
+/**
+ * `/zh/inference/<model>` — Chinese sibling of `/inference/<model>`. Same
+ * pinned-model chart body; metadata and intro copy are Simplified Chinese.
+ */
+
+interface Props {
+  params: Promise<{ model: string }>;
+}
+
+export function generateStaticParams(): { model: string }[] {
+  return INFERENCE_MODEL_SLUGS.map((entry) => ({ model: entry.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const entry = getInferenceModelBySlug(model);
+  if (!entry) return {};
+  const { title, description } = inferenceModelMetaZh(entry);
+  const enPath = inferenceModelPath(entry.slug);
+  const url = `${SITE_URL}${zhPath(enPath)}`;
+  return {
+    title: { absolute: `${title} | ${SITE_NAME} by ${AUTHOR_NAME}` },
+    description,
+    alternates: zhAlternates(enPath),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      type: 'website',
+      locale: ZH_OG_LOCALE,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  };
+}
+
+export default async function ZhInferenceModelPage({ params }: Props) {
+  const { model } = await params;
+  const entry = getInferenceModelBySlug(model);
+  if (!entry) notFound();
+  if (model !== entry.slug) permanentRedirect(zhPath(inferenceModelPath(entry.slug)));
+  return (
+    <>
+      <ZhTabIntro tab="inference" />
+      <InferenceProvider activeTab="inference">
+        <InferenceChartDisplay />
+      </InferenceProvider>
+    </>
+  );
+}

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -37,7 +37,10 @@ import {
   Sequence,
   SEQUENCE_OPTIONS,
 } from '@/lib/data-mappings';
-import { inferenceModelForPathname } from '@/lib/inference-model-slug';
+import {
+  inferenceModelForPathname,
+  inferenceModelRouteForSelection,
+} from '@/lib/inference-model-slug';
 import { computeAutoSwitchDecision } from '@/lib/unofficial-run-auto-switch';
 import { countCurvesByPrecision, resolveEffectivePrecisions } from '@/lib/default-precisions';
 import { resolveEffectiveSequence } from '@/lib/default-sequence';
@@ -313,11 +316,17 @@ export function GlobalFilterProvider({
     // `/inference/<model>` pins the model from the path. On first mount the
     // shell already seeded `initialModel` from the same pathname, so this is a
     // no-op; it matters on soft navigations between model pages (and to/from
-    // `/inference`), which do not remount this provider. Applied before the
-    // param reads so an explicit `?g_model=` share link still wins.
+    // `/inference`), which do not remount this provider. An explicit
+    // `?g_model=` in the CURRENT URL still wins over the path pin, but on a
+    // model page the snapshot's `g_model` is otherwise ignored: the snapshot
+    // retains params from the previous navigation (`refreshUrlParams` only
+    // overwrites keys present in the live URL), and letting that stale value
+    // through would override the model the path just asked for.
     const pathModel = inferenceModelForPathname(pathname);
     if (pathModel !== null) setSelectedModel(pathModel);
-    applyIfEnum('g_model', Model, setSelectedModel);
+    if (pathModel === null || hasExplicitUrlParam('g_model')) {
+      applyIfEnum('g_model', Model, setSelectedModel);
+    }
     applyIfEnum('i_seq', Sequence, setSelectedSequence);
     const urlPrec = getUrlParam('i_prec');
     if (urlPrec) {
@@ -342,6 +351,30 @@ export function GlobalFilterProvider({
     // today, and covering it would mean the Suspense bailout above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
+
+  // Selecting a model on the inference tab moves the URL onto the model's
+  // indexable subroute without a reload: Next intercepts
+  // `history.replaceState`, so `usePathname` stays in sync while the chart
+  // simply re-renders in place — no RSC refetch, no scroll reset. The ref
+  // skips the mount run so hard-loading `/inference` (or a `?g_model=` share
+  // link) keeps its URL; only an actual model switch rewrites the path.
+  // `window.location` is read directly — it is always current, unlike the
+  // `pathname` hook value, which lags a rewrite this very effect made.
+  const modelRouteSyncReadyRef = useRef(false);
+  useEffect(() => {
+    if (!modelRouteSyncReadyRef.current) {
+      modelRouteSyncReadyRef.current = true;
+      return;
+    }
+    const target = inferenceModelRouteForSelection(window.location.pathname, selectedModel);
+    if (target === null || window.location.pathname === target) return;
+    const search = new URLSearchParams(window.location.search);
+    // The path now carries the model — a lingering share-link param would
+    // override it on the next snapshot read.
+    search.delete('g_model');
+    const qs = search.toString();
+    window.history.replaceState(null, '', `${target}${qs ? `?${qs}` : ''}${window.location.hash}`);
+  }, [selectedModel]);
 
   // ── Availability data ─────────────────────────────────────────────────────
   const {

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -37,6 +37,7 @@ import {
   Sequence,
   SEQUENCE_OPTIONS,
 } from '@/lib/data-mappings';
+import { inferenceModelForPathname } from '@/lib/inference-model-slug';
 import { computeAutoSwitchDecision } from '@/lib/unofficial-run-auto-switch';
 import { countCurvesByPrecision, resolveEffectivePrecisions } from '@/lib/default-precisions';
 import { resolveEffectiveSequence } from '@/lib/default-sequence';
@@ -309,6 +310,13 @@ export function GlobalFilterProvider({
       if (value !== undefined && pattern.test(value)) apply(value);
     };
 
+    // `/inference/<model>` pins the model from the path. On first mount the
+    // shell already seeded `initialModel` from the same pathname, so this is a
+    // no-op; it matters on soft navigations between model pages (and to/from
+    // `/inference`), which do not remount this provider. Applied before the
+    // param reads so an explicit `?g_model=` share link still wins.
+    const pathModel = inferenceModelForPathname(pathname);
+    if (pathModel !== null) setSelectedModel(pathModel);
     applyIfEnum('g_model', Model, setSelectedModel);
     applyIfEnum('i_seq', Sequence, setSelectedSequence);
     const urlPrec = getUrlParam('i_prec');

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -37,10 +37,7 @@ import {
   Sequence,
   SEQUENCE_OPTIONS,
 } from '@/lib/data-mappings';
-import {
-  inferenceModelForPathname,
-  inferenceModelRouteForSelection,
-} from '@/lib/inference-model-slug';
+import { inferenceModelForPathname } from '@/lib/inference-model-slug';
 import { computeAutoSwitchDecision } from '@/lib/unofficial-run-auto-switch';
 import { countCurvesByPrecision, resolveEffectivePrecisions } from '@/lib/default-precisions';
 import { resolveEffectiveSequence } from '@/lib/default-sequence';
@@ -351,30 +348,6 @@ export function GlobalFilterProvider({
     // today, and covering it would mean the Suspense bailout above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
-
-  // Selecting a model on the inference tab moves the URL onto the model's
-  // indexable subroute without a reload: Next intercepts
-  // `history.replaceState`, so `usePathname` stays in sync while the chart
-  // simply re-renders in place — no RSC refetch, no scroll reset. The ref
-  // skips the mount run so hard-loading `/inference` (or a `?g_model=` share
-  // link) keeps its URL; only an actual model switch rewrites the path.
-  // `window.location` is read directly — it is always current, unlike the
-  // `pathname` hook value, which lags a rewrite this very effect made.
-  const modelRouteSyncReadyRef = useRef(false);
-  useEffect(() => {
-    if (!modelRouteSyncReadyRef.current) {
-      modelRouteSyncReadyRef.current = true;
-      return;
-    }
-    const target = inferenceModelRouteForSelection(window.location.pathname, selectedModel);
-    if (target === null || window.location.pathname === target) return;
-    const search = new URLSearchParams(window.location.search);
-    // The path now carries the model — a lingering share-link param would
-    // override it on the next snapshot read.
-    search.delete('g_model');
-    const qs = search.toString();
-    window.history.replaceState(null, '', `${target}${qs ? `?${qs}` : ''}${window.location.hash}`);
-  }, [selectedModel]);
 
   // ── Availability data ─────────────────────────────────────────────────────
   const {

--- a/packages/app/src/components/dashboard-shell.tsx
+++ b/packages/app/src/components/dashboard-shell.tsx
@@ -5,6 +5,7 @@ import { NudgeEngine } from '@/components/nudge-engine';
 import { TabNav } from '@/components/tab-nav';
 import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
 import { dashboardShellCapabilitiesForPathname } from '@/lib/dashboard-routes';
+import { inferenceModelForPathname } from '@/lib/inference-model-slug';
 import { usePathname } from 'next/navigation';
 
 export function DashboardShell({ children }: { children: React.ReactNode }) {
@@ -14,7 +15,17 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
 
   let content = children;
   if (providerCapabilities.globalFilters) {
-    content = <GlobalFilterProvider>{content}</GlobalFilterProvider>;
+    // `/inference/<model>` pages pin the model from the path. Seeding the
+    // provider (rather than only applying it in an effect) keeps the server
+    // render and first client paint on the right model — `usePathname` is
+    // available during SSR, so hydration agrees. Soft navigations between
+    // model pages don't remount this provider; those are handled by the
+    // pathname-keyed effect inside GlobalFilterProvider.
+    content = (
+      <GlobalFilterProvider initialModel={inferenceModelForPathname(pathname) ?? undefined}>
+        {content}
+      </GlobalFilterProvider>
+    );
   }
   if (providerCapabilities.unofficialRuns) {
     content = <UnofficialRunProvider>{content}</UnofficialRunProvider>;

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import { track } from '@/lib/analytics';
+import { replaceClientPathname } from '@/lib/client-navigation';
+import { inferenceModelRouteForSelection } from '@/lib/inference-model-slug';
 import { useFeatureGate } from '@/lib/use-feature-gate';
 
 import {
@@ -179,6 +181,15 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
 
   const handleModelChange = (value: Model) => {
     setSelectedModel(value);
+    // A deliberate pick moves the URL onto the model's indexable subroute in
+    // place — no reload, RSC refetch, or scroll reset. Kept out of the model
+    // state effects on purpose: programmatic changes (back-nav restore,
+    // config load, auto-switch) must not rewrite the URL, and event handlers
+    // are immune to Strict Mode's double-invoked effects. `g_model` is
+    // dropped because the path now carries the model — a lingering share
+    // param would override it on the next snapshot read.
+    const target = inferenceModelRouteForSelection(window.location.pathname, value);
+    if (target !== null) replaceClientPathname(target, ['g_model']);
     track('inference_model_selected', {
       model: value,
     });

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -8,6 +8,7 @@ import { CuratedViewCard } from '@/components/landing/curated-view-card';
 import { NudgeEngine } from '@/components/nudge-engine';
 import { FAVORITE_PRESETS } from '@/components/favorites/favorite-presets';
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
+import { ACTIVE_INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import type { Locale } from '@/lib/i18n';
 
 const STRINGS = {
@@ -19,6 +20,7 @@ const STRINGS = {
     platformCoverage:
       'Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X, MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7 Ironwood, etc across DeepSeekv4 Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.',
     overview: 'Overview',
+    browseByModel: 'Or jump straight to the benchmarks for one model:',
     reproTitle: 'Every Result Is Transparently done through Public GitHub Actions Automation',
     reproP1:
       'Every data point on the dashboard is produced by a public GitHub Actions workflow run. The recipe lives in the repo, the run executes on the actual target hardware, and the full logs and artifacts are publicly viewable. Click any point on a chart to jump straight to the run that produced it. All reproducible, auditable, and open source.',
@@ -48,6 +50,7 @@ const STRINGS = {
     platformCoverage:
       '目前覆盖 DeepSeekv4 Pro、Qwen、Kimi、GLM、MiniMax、gpt-oss、Llama 等模型，以及 NVIDIA GB300 NVL72、GB200 NVL72、B300、B200、H200、H100 和 AMD MI355X、MI325X、MI300X 等硬件。后续还将加入 VR200 NVL72、AMD MI455X UALoE72 和 TPUv7 Ironwood。',
     overview: '总览',
+    browseByModel: '也可以直接查看单个模型的基准测试：',
     reproTitle: '所有结果均通过公开的 GitHub Actions 流程生成',
     reproP1:
       '仪表板上的每个数据点都来自一次公开的 GitHub Actions 运行。测试配置保存在仓库中，并在对应的真实硬件上执行；完整日志和产物均可公开查看。点击图表中的任意数据点，即可打开生成该结果的运行记录。整个过程可复现、可审计，并完全开源。',
@@ -123,6 +126,26 @@ export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
                 {t.fullDashboard}
                 <ArrowRight aria-hidden="true" className="size-4" />
               </LandingTrackedLink>
+            </div>
+            {/* Per-model entry points — crawlable links to the indexable
+                /inference/<model> pages. Only actively benchmarked models are
+                promoted here; deprecated model pages stay reachable via the
+                sitemap and dashboard selector. */}
+            <p className="text-sm text-muted-foreground mt-6 mb-2">{t.browseByModel}</p>
+            <div className="flex flex-wrap gap-2" data-testid="landing-model-links">
+              {ACTIVE_INFERENCE_MODEL_SLUGS.map((entry) => (
+                <LandingTrackedLink
+                  key={entry.slug}
+                  href={`${prefix}/inference/${entry.slug}`}
+                  data-testid={`landing-model-link-${entry.slug}`}
+                  analyticsEvent="landing_model_page_clicked"
+                  appNavigation
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
+                >
+                  {entry.seoName}
+                  <ArrowRight aria-hidden="true" className="size-3.5" />
+                </LandingTrackedLink>
+              ))}
             </div>
           </Card>
 

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -28,6 +28,26 @@ export function replaceClientSearch(searchParams: URLSearchParams): void {
 }
 
 /**
+ * Shallow-replace the current pathname, preserving the query string (minus
+ * `dropParams`) and hash. Unlike `replaceClientSearch`, this goes through the
+ * Next-patched `window.history.replaceState` on purpose: the pathname is
+ * changing, so the App Router must adopt the new URL (`usePathname` updates)
+ * — but as a same-document rewrite, without an RSC fetch or scroll reset.
+ * Router state is carried over so Back/Forward keep working.
+ */
+export function replaceClientPathname(target: string, dropParams: readonly string[] = []): void {
+  if (window.location.pathname === target) return;
+  const search = new URLSearchParams(window.location.search);
+  for (const param of dropParams) search.delete(param);
+  const qs = search.toString();
+  window.history.replaceState(
+    window.history.state,
+    '',
+    `${target}${qs ? `?${qs}` : ''}${window.location.hash}`,
+  );
+}
+
+/**
  * The first dashboard transition can request the route without committing the
  * URL change. Repeating the same app-router push after the route payload has
  * been requested preserves same-document navigation and avoids a music restart.

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -19,13 +19,21 @@ describe('AgentX comparison links', () => {
     ]);
   });
 
-  it('opens the selected model directly in the Agentic Traces scenario', () => {
+  it('opens the selected model subroute directly in the Agentic Traces scenario', () => {
     expect(agentxDashboardHref('en', FEATURED_AGENTX_MODELS[0])).toBe(
-      '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1',
+      '/inference/kimi-k3?i_seq=agentic-traces&i_optimal=1',
     );
     expect(agentxDashboardHref('zh', FEATURED_AGENTX_MODELS[1])).toBe(
-      '/zh/inference?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_optimal=1',
+      '/zh/inference/deepseek-v4?i_seq=agentic-traces&i_optimal=1',
     );
+  });
+
+  it('routes every featured model to a registered inference page', () => {
+    for (const model of FEATURED_AGENTX_MODELS) {
+      expect(agentxDashboardHref('en', model)).toBe(
+        `/inference/${model.slug}?i_seq=agentic-traces&i_optimal=1`,
+      );
+    }
   });
 
   it('uses AgentX for supported models and 8K→1K for the rest', () => {

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -1,5 +1,6 @@
 import { scenarioSegmentForSequence } from '@/lib/compare-scenario-route';
 import { COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
+import { getInferenceModelBySlug, inferenceModelPath } from '@/lib/inference-model-slug';
 
 const FEATURED_AGENTX_MODEL_SLUGS = [
   'kimi-k3',
@@ -25,13 +26,18 @@ export const FEATURED_AGENTX_MODELS: readonly CompareModelSlug[] = FEATURED_AGEN
 );
 
 export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug): string {
-  const path = locale === 'zh' ? '/zh/inference' : '/inference';
-  const query = new URLSearchParams({
-    g_model: model.displayName,
-    i_seq: 'agentic-traces',
-    i_optimal: '1',
-  });
-  return `${path}?${query}`;
+  // The model rides in the path — the indexable `/inference/<model>` subroute
+  // — so these hero links point crawlers at the canonical model page instead
+  // of a `?g_model=` variant of the base dashboard. Models without a
+  // registered inference page (none of the featured set today) fall back to
+  // the query form.
+  const entry = getInferenceModelBySlug(model.slug);
+  const query = new URLSearchParams();
+  if (!entry) query.set('g_model', model.displayName);
+  query.set('i_seq', 'agentic-traces');
+  query.set('i_optimal', '1');
+  const path = entry ? inferenceModelPath(entry.slug) : '/inference';
+  return `${locale === 'zh' ? `/zh${path}` : path}?${query}`;
 }
 
 export function comparisonScenarioForModel(model: CompareModelSlug): ComparisonScenario {

--- a/packages/app/src/lib/inference-model-meta.ts
+++ b/packages/app/src/lib/inference-model-meta.ts
@@ -1,0 +1,44 @@
+/**
+ * @file inference-model-meta.ts
+ * @description SEO copy for the `/inference/<model>` and `/zh/inference/<model>`
+ * pages, shared by both page files so the English and Chinese descriptions
+ * cannot drift structurally. Prose style mirrors `TAB_META.inference` /
+ * `TAB_META_ZH.inference` with the model name substituted in.
+ */
+import type { InferenceModelSlug } from '@/lib/inference-model-slug';
+
+export interface InferenceModelMeta {
+  title: string;
+  description: string;
+}
+
+/** `label` adds detail beyond `seoName` (e.g. parameter count) for most
+ * models, but for some they are identical — skip the parenthetical then so
+ * the description doesn't read "DeepSeek R1 (DeepSeek R1)". */
+function nameWithDetail(entry: InferenceModelSlug): string {
+  return entry.label === entry.seoName ? entry.seoName : `${entry.seoName} (${entry.label})`;
+}
+
+export function inferenceModelMeta(entry: InferenceModelSlug): InferenceModelMeta {
+  return {
+    // Lead with the model name — that's the phrase people search
+    // ("kimi k3 inference benchmark") and it must survive Google's ~60-char
+    // SERP truncation.
+    title: `${entry.seoName} Inference Benchmarks`,
+    description:
+      `Compare ${nameWithDetail(entry)} latency, throughput, cost, and ` +
+      'time-to-first-token across chips and serving frameworks. Every datapoint is ' +
+      'produced by a public, reproducible GitHub Actions run.',
+  };
+}
+
+export function inferenceModelMetaZh(entry: InferenceModelSlug): InferenceModelMeta {
+  // Model names, SKUs, and product names stay in English per the translation
+  // quality bar; the surrounding prose follows TAB_META_ZH.inference.
+  return {
+    title: `${entry.seoName} 推理基准测试`,
+    description:
+      `跨芯片与推理框架，对比 ${nameWithDetail(entry)} 推理的延迟、吞吐量、` +
+      '成本与首 token 延迟（TTFT）。每个数据点都来自公开的 GitHub Actions 运行，可复现、可审计。',
+  };
+}

--- a/packages/app/src/lib/inference-model-slug.test.ts
+++ b/packages/app/src/lib/inference-model-slug.test.ts
@@ -9,6 +9,7 @@ import {
   INFERENCE_MODEL_SLUGS,
   inferenceModelForPathname,
   inferenceModelPath,
+  inferenceModelRouteForSelection,
   inferenceModelSlugForModel,
 } from './inference-model-slug';
 
@@ -127,5 +128,41 @@ describe('inferenceModelForPathname', () => {
     expect(inferenceModelForPathname(null)).toBeNull();
     expect(inferenceModelForPathname(undefined)).toBeNull();
     expect(inferenceModelForPathname('')).toBeNull();
+  });
+});
+
+describe('inferenceModelRouteForSelection', () => {
+  it('rewrites model subroutes to the newly selected model', () => {
+    expect(inferenceModelRouteForSelection('/inference/kimi-k3', Model.DeepSeek_V4_Pro)).toBe(
+      '/inference/deepseek-v4',
+    );
+    expect(inferenceModelRouteForSelection('/zh/inference/kimi-k3', Model.DeepSeek_V4_Pro)).toBe(
+      '/zh/inference/deepseek-v4',
+    );
+  });
+
+  it('moves the base /inference page onto the model subroute', () => {
+    expect(inferenceModelRouteForSelection('/inference', Model.Kimi_K3)).toBe('/inference/kimi-k3');
+    expect(inferenceModelRouteForSelection('/zh/inference', Model.Kimi_K3)).toBe(
+      '/zh/inference/kimi-k3',
+    );
+  });
+
+  it('leaves every other surface alone', () => {
+    expect(inferenceModelRouteForSelection('/', Model.Kimi_K3)).toBeNull();
+    expect(inferenceModelRouteForSelection('/overview', Model.Kimi_K3)).toBeNull();
+    expect(inferenceModelRouteForSelection('/inference/agentic', Model.Kimi_K3)).toBeNull();
+    expect(inferenceModelRouteForSelection('/inference/agentic/point-1', Model.Kimi_K3)).toBeNull();
+    expect(
+      inferenceModelRouteForSelection('/compare/kimi-k3-h100-vs-h200', Model.Kimi_K3),
+    ).toBeNull();
+    expect(inferenceModelRouteForSelection('/zh', Model.Kimi_K3)).toBeNull();
+    expect(inferenceModelRouteForSelection(null, Model.Kimi_K3)).toBeNull();
+  });
+
+  it('keeps the same path when the selection already matches', () => {
+    expect(inferenceModelRouteForSelection('/inference/kimi-k3', Model.Kimi_K3)).toBe(
+      '/inference/kimi-k3',
+    );
   });
 });

--- a/packages/app/src/lib/inference-model-slug.test.ts
+++ b/packages/app/src/lib/inference-model-slug.test.ts
@@ -122,4 +122,10 @@ describe('inferenceModelForPathname', () => {
     expect(inferenceModelForPathname('/zh')).toBeNull();
     expect(inferenceModelForPathname('/inference/%E4%B8%8D%E5%AD%98%E5%9C%A8')).toBeNull();
   });
+
+  it('returns null when usePathname yields no pathname (bare test renders)', () => {
+    expect(inferenceModelForPathname(null)).toBeNull();
+    expect(inferenceModelForPathname(undefined)).toBeNull();
+    expect(inferenceModelForPathname('')).toBeNull();
+  });
 });

--- a/packages/app/src/lib/inference-model-slug.test.ts
+++ b/packages/app/src/lib/inference-model-slug.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { COMPARE_MODEL_SLUGS } from './compare-slug';
+import { getModelCategory, Model, MODEL_OPTIONS } from './data-mappings';
+import {
+  ACTIVE_INFERENCE_MODEL_SLUGS,
+  getInferenceModelBySlug,
+  INFERENCE_MODEL_ALIASES,
+  INFERENCE_MODEL_SLUGS,
+  inferenceModelForPathname,
+  inferenceModelPath,
+  inferenceModelSlugForModel,
+} from './inference-model-slug';
+
+describe('INFERENCE_MODEL_SLUGS registry', () => {
+  it('covers every non-hidden dashboard model exactly once', () => {
+    const models = INFERENCE_MODEL_SLUGS.map((entry) => entry.model);
+    expect(new Set(models).size).toBe(models.length);
+    expect(new Set(models)).toEqual(new Set(MODEL_OPTIONS));
+  });
+
+  it('excludes hidden models', () => {
+    for (const entry of INFERENCE_MODEL_SLUGS) {
+      expect(getModelCategory(entry.model)).not.toBe('hidden');
+    }
+  });
+
+  it('has unique lowercase slugs shared with the compare vocabulary', () => {
+    const compareSlugs = new Set(COMPARE_MODEL_SLUGS.map((entry) => entry.slug));
+    const slugs = INFERENCE_MODEL_SLUGS.map((entry) => entry.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+    for (const slug of slugs) {
+      expect(slug).toBe(slug.toLowerCase());
+      expect(compareSlugs.has(slug)).toBe(true);
+    }
+  });
+
+  it('keeps active (landing-promoted) entries a subset of the registry', () => {
+    for (const entry of ACTIVE_INFERENCE_MODEL_SLUGS) {
+      expect(getModelCategory(entry.model)).not.toBe('deprecated');
+      expect(INFERENCE_MODEL_SLUGS).toContain(entry);
+    }
+  });
+});
+
+describe('getInferenceModelBySlug', () => {
+  it('resolves canonical slugs', () => {
+    expect(getInferenceModelBySlug('kimi-k3')?.model).toBe(Model.Kimi_K3);
+    expect(getInferenceModelBySlug('deepseek-v4')?.model).toBe(Model.DeepSeek_V4_Pro);
+  });
+
+  it('is case-insensitive', () => {
+    expect(getInferenceModelBySlug('Kimi-K3')?.model).toBe(Model.Kimi_K3);
+  });
+
+  it('resolves g_model display names as aliases', () => {
+    for (const entry of INFERENCE_MODEL_SLUGS) {
+      expect(getInferenceModelBySlug(entry.model)?.slug).toBe(entry.slug);
+    }
+  });
+
+  it('resolves compare family aliases', () => {
+    expect(getInferenceModelBySlug('kimi')?.slug).toBe('kimi-k26');
+    expect(getInferenceModelBySlug('glm-5')?.slug).toBe('glm-5-1');
+  });
+
+  it('returns null for unknown and reserved segments', () => {
+    expect(getInferenceModelBySlug('agentic')).toBeNull();
+    expect(getInferenceModelBySlug('logs')).toBeNull();
+    expect(getInferenceModelBySlug('not-a-model')).toBeNull();
+  });
+
+  it('alias targets all resolve to canonical entries', () => {
+    for (const [alias, target] of Object.entries(INFERENCE_MODEL_ALIASES)) {
+      expect(getInferenceModelBySlug(alias)?.slug).toBe(target);
+    }
+  });
+});
+
+describe('inferenceModelSlugForModel / inferenceModelPath', () => {
+  it('round-trips every registry entry', () => {
+    for (const entry of INFERENCE_MODEL_SLUGS) {
+      expect(inferenceModelSlugForModel(entry.model)).toBe(entry.slug);
+      expect(inferenceModelPath(entry.slug)).toBe(`/inference/${entry.slug}`);
+    }
+  });
+
+  it('returns null for hidden models', () => {
+    expect(inferenceModelSlugForModel(Model.Llama3_1_70B)).toBeNull();
+  });
+});
+
+describe('inferenceModelForPathname', () => {
+  it('pins the model on English model pages', () => {
+    expect(inferenceModelForPathname('/inference/kimi-k3')).toBe(Model.Kimi_K3);
+    expect(inferenceModelForPathname('/inference/minimax-m3/')).toBe(Model.MiniMax_M3);
+  });
+
+  it('pins the model on /zh model pages', () => {
+    expect(inferenceModelForPathname('/zh/inference/kimi-k3')).toBe(Model.Kimi_K3);
+  });
+
+  it('resolves alias segments (pre-redirect client render)', () => {
+    expect(inferenceModelForPathname('/inference/Kimi-K3')).toBe(Model.Kimi_K3);
+    expect(inferenceModelForPathname('/inference/deepseek-v4-pro')).toBe(Model.DeepSeek_V4_Pro);
+    expect(inferenceModelForPathname('/inference/Kimi-K2.5')).toBe(Model.Kimi_K2_5);
+  });
+
+  it('ignores query strings and hashes', () => {
+    expect(inferenceModelForPathname('/inference/kimi-k3?i_seq=8k%2F1k#chart')).toBe(Model.Kimi_K3);
+  });
+
+  it('returns null off the model pages', () => {
+    expect(inferenceModelForPathname('/inference')).toBeNull();
+    expect(inferenceModelForPathname('/zh/inference')).toBeNull();
+    expect(inferenceModelForPathname('/inference/agentic')).toBeNull();
+    expect(inferenceModelForPathname('/inference/agentic/some-point')).toBeNull();
+    expect(inferenceModelForPathname('/inference/logs')).toBeNull();
+    expect(inferenceModelForPathname('/inference/kimi-k3/extra')).toBeNull();
+    expect(inferenceModelForPathname('/compare/kimi-k3-gb200-vs-mi355x')).toBeNull();
+    expect(inferenceModelForPathname('/')).toBeNull();
+    expect(inferenceModelForPathname('/zh')).toBeNull();
+    expect(inferenceModelForPathname('/inference/%E4%B8%8D%E5%AD%98%E5%9C%A8')).toBeNull();
+  });
+});

--- a/packages/app/src/lib/inference-model-slug.ts
+++ b/packages/app/src/lib/inference-model-slug.ts
@@ -113,8 +113,12 @@ export const ACTIVE_INFERENCE_MODEL_SLUGS: readonly InferenceModelSlug[] =
  * resolves). Used by the dashboard shell to seed `GlobalFilterProvider` and by
  * the provider's pathname effect on soft navigations; an explicit `?g_model=`
  * param always wins over the path pin.
+ *
+ * Accepts null/undefined because `usePathname()` is typed to return null
+ * outside an app router (e.g. in unit tests that render the provider bare).
  */
-export function inferenceModelForPathname(pathname: string): Model | null {
+export function inferenceModelForPathname(pathname: string | null | undefined): Model | null {
+  if (!pathname) return null;
   const barePath = pathname.split(/[?#]/u, 1)[0] || '/';
   const enPath = barePath === '/zh' ? '/' : barePath.replace(/^\/zh(?=\/)/u, '');
   const match = /^\/inference\/(?<slug>[^/]+)\/?$/u.exec(enPath);

--- a/packages/app/src/lib/inference-model-slug.ts
+++ b/packages/app/src/lib/inference-model-slug.ts
@@ -1,0 +1,129 @@
+/**
+ * @file inference-model-slug.ts
+ * @description Model-slug registry for the indexable `/inference/<model>`
+ * subroutes.
+ *
+ * `/inference?g_model=Kimi-K3` keeps working as a share-link form, but query
+ * params are a weak indexing surface: crawlers treat them as views of one page
+ * and the canonical collapses them all to `/`. The `/inference/<model>` path
+ * form gives every model a stable, individually indexable URL with its own
+ * title, description, canonical, and hreflang pair — same playbook as the
+ * `/compare/<slug>` pages.
+ *
+ * The slug vocabulary is deliberately NOT a second naming scheme: entries are
+ * derived from `COMPARE_MODEL_SLUGS`, so `/inference/kimi-k3` and
+ * `/compare/kimi-k3-gb200-vs-mi355x` agree on what "kimi-k3" means. Aliases
+ * accept the compare aliases plus the lowercased `?g_model=` display names
+ * (e.g. `/inference/deepseek-v4-pro`), all 308-redirecting to the canonical
+ * slug so exactly one URL per model is ever indexed.
+ */
+import { COMPARE_MODEL_ALIASES, COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { getModelCategory, Model } from '@/lib/data-mappings';
+
+export interface InferenceModelSlug {
+  /** Canonical URL slug, e.g. 'kimi-k3'. Lowercase, matches the compare slug. */
+  slug: string;
+  /** Model enum value — the same string `?g_model=` accepts. */
+  model: Model;
+  /** Human label for the page header and OG copy, e.g. 'Kimi K3 2.8T'. */
+  label: string;
+  /** Short, search-shaped model name for `<title>` tags, e.g. 'Kimi K3'. */
+  seoName: string;
+}
+
+const MODEL_VALUES = new Set<string>(Object.values(Model));
+
+/**
+ * Ordered like `COMPARE_MODEL_SLUGS` (flagship models first, per product
+ * spec). One entry per dashboard model option: compare slugs are finer-grained
+ * than the display-grouped dropdown (`kimi-k26` vs the retired `kimi-k25`
+ * alias), but each display name appears exactly once in the compare registry,
+ * so the mapping is 1:1. Hidden models get no page.
+ */
+export const INFERENCE_MODEL_SLUGS: readonly InferenceModelSlug[] = COMPARE_MODEL_SLUGS.filter(
+  (entry) => MODEL_VALUES.has(entry.displayName),
+)
+  .map((entry) => ({
+    slug: entry.slug,
+    model: entry.displayName as Model,
+    label: entry.label,
+    seoName: entry.seoName,
+  }))
+  .filter((entry) => getModelCategory(entry.model) !== 'hidden');
+
+const SLUG_TO_ENTRY: ReadonlyMap<string, InferenceModelSlug> = new Map(
+  INFERENCE_MODEL_SLUGS.map((entry) => [entry.slug, entry]),
+);
+
+const MODEL_TO_SLUG: ReadonlyMap<Model, string> = new Map(
+  INFERENCE_MODEL_SLUGS.map((entry) => [entry.model, entry.slug]),
+);
+
+/**
+ * Alias slugs that 308 to the canonical page. Two sources:
+ * - the compare aliases (family names and superseded versions), filtered to
+ *   targets that actually have an inference page;
+ * - the lowercased `Model` enum values, so a `?g_model=` value can be dropped
+ *   into the path verbatim (`/inference/Kimi-K2.5` → `/inference/kimi-k26`).
+ */
+export const INFERENCE_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  ...Object.fromEntries(
+    Object.entries(COMPARE_MODEL_ALIASES).filter(([, target]) => SLUG_TO_ENTRY.has(target)),
+  ),
+  ...Object.fromEntries(
+    INFERENCE_MODEL_SLUGS.filter((entry) => entry.model.toLowerCase() !== entry.slug).map(
+      (entry) => [entry.model.toLowerCase(), entry.slug],
+    ),
+  ),
+};
+
+/**
+ * Resolve a raw path segment (any case, aliases allowed) to its registry
+ * entry. Returns null for unknown slugs — including the reserved static
+ * `/inference/*` segments (`agentic`, `logs`), which are not in the registry.
+ */
+export function getInferenceModelBySlug(rawSlug: string): InferenceModelSlug | null {
+  const lower = rawSlug.toLowerCase();
+  const canonical = INFERENCE_MODEL_ALIASES[lower] ?? lower;
+  return SLUG_TO_ENTRY.get(canonical) ?? null;
+}
+
+/** Canonical slug for a dashboard model, or null for hidden models. */
+export function inferenceModelSlugForModel(model: Model): string | null {
+  return MODEL_TO_SLUG.get(model) ?? null;
+}
+
+/** English path of a model page, e.g. '/inference/kimi-k3'. */
+export function inferenceModelPath(slug: string): string {
+  return `/inference/${slug}`;
+}
+
+/**
+ * Registry entries whose model is still actively benchmarked. Deprecated
+ * models keep their pages (historical data stays reachable and indexed) but
+ * are not promoted on the landing page.
+ */
+export const ACTIVE_INFERENCE_MODEL_SLUGS: readonly InferenceModelSlug[] =
+  INFERENCE_MODEL_SLUGS.filter((entry) => getModelCategory(entry.model) !== 'deprecated');
+
+/**
+ * Model pinned by the current pathname, or null when the path carries no
+ * model. Accepts the English and `/zh` trees and alias slugs (aliases redirect
+ * server-side, but the client provider may briefly render before the redirect
+ * resolves). Used by the dashboard shell to seed `GlobalFilterProvider` and by
+ * the provider's pathname effect on soft navigations; an explicit `?g_model=`
+ * param always wins over the path pin.
+ */
+export function inferenceModelForPathname(pathname: string): Model | null {
+  const barePath = pathname.split(/[?#]/u, 1)[0] || '/';
+  const enPath = barePath === '/zh' ? '/' : barePath.replace(/^\/zh(?=\/)/u, '');
+  const match = /^\/inference\/(?<slug>[^/]+)\/?$/u.exec(enPath);
+  if (!match?.groups?.slug) return null;
+  let segment: string;
+  try {
+    segment = decodeURIComponent(match.groups.slug);
+  } catch {
+    return null;
+  }
+  return getInferenceModelBySlug(segment)?.model ?? null;
+}

--- a/packages/app/src/lib/inference-model-slug.ts
+++ b/packages/app/src/lib/inference-model-slug.ts
@@ -131,3 +131,32 @@ export function inferenceModelForPathname(pathname: string | null | undefined): 
   }
   return getInferenceModelBySlug(segment)?.model ?? null;
 }
+
+/**
+ * Pathname the inference dashboard should shallow-rewrite to when the user
+ * picks `model` from the selector, or null when the current path must be left
+ * alone. Only the inference tab itself qualifies — the base `/inference`
+ * page and the `/inference/<model>` subroutes (in both locale trees). Every
+ * other surface sharing the global model filter (overview, compare, the
+ * agentic catalog, …) keeps its own URL.
+ *
+ * Models without a registry page (hidden entries) fall back to the base
+ * `/inference` path rather than minting a URL that would 404 on reload.
+ */
+export function inferenceModelRouteForSelection(
+  pathname: string | null | undefined,
+  model: Model,
+): string | null {
+  if (!pathname) return null;
+  const barePath = pathname.split(/[?#]/u, 1)[0] || '/';
+  const isZh = barePath === '/zh' || barePath.startsWith('/zh/');
+  const enPath = isZh ? barePath.replace(/^\/zh(?=\/|$)/u, '') || '/' : barePath;
+  const onInferenceTab =
+    enPath === '/inference' ||
+    enPath === '/inference/' ||
+    inferenceModelForPathname(pathname) !== null;
+  if (!onInferenceTab) return null;
+  const slug = inferenceModelSlugForModel(model);
+  const target = slug ? inferenceModelPath(slug) : '/inference';
+  return isZh ? `/zh${target}` : target;
+}


### PR DESCRIPTION
## Summary

Adds indexable per-model subroutes — `/inference/<model>` and `/zh/inference/<model>` — in addition to the existing `/inference?g_model=…` query form, which keeps working unchanged. Extends the SSR/SEO playbook from the compare pages to the main inference dashboard.

### Routes & registry

- **`lib/inference-model-slug.ts`** — model slug registry derived from `COMPARE_MODEL_SLUGS` (same slug vocabulary as `/compare`, 1:1 by display name), plus alias map, pathname parser, and helpers. 11 models get pages; the hidden Llama 3.1 70B entry does not.
- **`app/(dashboard)/inference/[model]/page.tsx`** + **`app/zh/(dashboard)/inference/[model]/page.tsx`** — SSG pages (`generateStaticParams`) rendering the full inference dashboard with the model pinned. Unknown slugs 404; aliases and non-canonical casing 308-redirect to the canonical slug (e.g. `/inference/Kimi-K3` → `/inference/kimi-k3`).

### SEO

- Self-canonical URLs with bidirectional `hreflang` (en / zh-CN / x-default) via the existing i18n helpers; per-model titles/descriptions in `lib/inference-model-meta.ts` styled after `TAB_META` / `TAB_META_ZH`.
- Sitemap entries for both locales (active models priority 0.8, deprecated 0.5) + a locale-parity test.
- `llms.txt` gains a "Model Benchmark Pages" section.

### Model pinning

- `dashboard-shell.tsx` seeds `GlobalFilterProvider`'s `initialModel` from the pathname (SSR-consistent), and `GlobalFilterContext` re-pins on soft navigation. Applied before the `g_model` param read, so an explicit `?g_model=` share link still wins.

### Client-side model switching

- Picking a model in the `/inference` selector shallow-rewrites the URL onto the model's subroute (`history.replaceState` with router state carried over) — the chart re-renders in place with no reload, RSC refetch, or scroll reset. Only deliberate selector picks rewrite the URL; programmatic changes (agentic back-nav restore, config load, auto-switch) leave it alone. `g_model` is dropped from the preserved query since the path now carries the model.

### Landing page

- New chip row in the "Explore InferenceX" card linking to the 6 active model pages, in both locales (`landing_model_page_clicked` analytics event).

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean.
- New unit tests: slug registry parity with `MODEL_OPTIONS`, alias resolution, pathname parsing (incl. `/zh`, query/hash, reserved segments like `agentic`/`logs`), sitemap locale parity for the model pages. All pass.
- `E2E_FIXTURES=1 bun run build` succeeds; verified on `next start`: metadata/canonical/hreflang, 308 alias redirects, 404 for unknown slugs, sitemap.xml, llms.txt, and landing links in both locales.

## 中文说明

在保留现有 `/inference?g_model=…` 查询参数形式的同时，新增可被搜索引擎索引的按模型子路由 `/inference/<model>` 与 `/zh/inference/<model>`，将 compare 页面的 SSR/SEO 打法延伸到主推理仪表板。

- **路由与注册表**：复用 compare 的 slug 词表建立模型注册表（`lib/inference-model-slug.ts`），11 个模型生成静态页面；未知 slug 返回 404，别名与大小写差异通过 308 重定向到规范 slug。
- **SEO**：每个页面有自身 canonical 与双向 hreflang（en / zh-CN / x-default），标题与描述沿用 `TAB_META` / `TAB_META_ZH` 的风格；sitemap 同时收录两种语言版本（活跃模型优先级 0.8，已停更模型 0.5）；`llms.txt` 新增模型页面列表。
- **模型锁定**：路径中的模型在服务端与客户端一致地注入 `GlobalFilterProvider`；显式的 `?g_model=` 参数仍优先于路径。
- **客户端模型切换**：在 `/inference` 的模型选择器中选择模型时，地址栏会原地改写为对应子路由（`history.replaceState`，并保留 Next 路由状态）——图表就地重新渲染，无整页刷新、无 RSC 重新请求、不重置滚动位置。仅用户主动选择才会改写 URL，程序化的模型变更（返回恢复、配置加载、自动切换）不受影响。
- **首页**：在 "Explore InferenceX" 卡片中新增指向 6 个活跃模型页面的链接（中英文均有）。
- **测试**：typecheck、lint、fmt 全部通过；新增 slug 注册表、别名解析、路径解析与 sitemap 双语覆盖的单元测试；fixtures 模式下构建成功，并在本地实际验证了元数据、重定向、404、sitemap.xml、llms.txt 与首页链接。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core inference URL semantics, global filter initialization, and client history rewrites; mistakes could mis-pin models or break back-navigation and share links, but scope is routing/SEO rather than auth or data integrity.
> 
> **Overview**
> Introduces **crawlable per-model inference URLs** (`/inference/<model>` and `/zh/inference/<model>`) alongside the existing `?g_model=` share links. A new slug registry (`inference-model-slug.ts`, aligned with compare slugs) backs SSG pages with per-model metadata, 308 alias redirects, sitemap entries (both locales), and **`llms.txt`** model links.
> 
> **Model pinning** now comes from the path: the dashboard shell seeds `GlobalFilterProvider`, soft navigations re-apply via pathname, and stale `g_model` from the URL snapshot no longer overrides an `/inference/<model>` path unless `g_model` is explicitly in the current URL. **Manual model picks** on the inference tab shallow-rewrite the address bar to the model subroute (`replaceRouterPathname`, dropping `g_model`) without a full navigation.
> 
> Compare/landing CTAs and AgentX hero links point at the path form instead of `?g_model=`. The landing page adds chip links for active models. E2E expectations update accordingly (e.g. browser **Back** after choosing a model returns to `/inference/kimi-k3`, not bare `/inference`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19644d7b63472621db2c59f2070bcc34a4fc5635. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

