### PR TITLE
feat(inference): expandable x/y-axis metric footer with explanations and y-axis formula / 图表新增可展开的 X/Y 轴指标页脚（含指标说明与 Y 轴计算公式）

### DIFF
--- a/packages/app/src/components/inference/axis-metric-explanations.test.ts
+++ b/packages/app/src/components/inference/axis-metric-explanations.test.ts
@@ -79,8 +79,7 @@ describe('X_AXIS_EXPLANATIONS', () => {
 
 describe('resolveXAxisKind', () => {
   const base = {
-    isInputMetric: false,
-    isTtftOverride: false,
+    xAxisField: 'intvty',
     isDerivedNormalizedInteractivity: false,
   };
 
@@ -88,30 +87,34 @@ describe('resolveXAxisKind', () => {
     expect(resolveXAxisKind('interactivity', base)).toBe('interactivity');
   });
 
-  it('interactivity chart plots TTFT for input metrics', () => {
-    expect(resolveXAxisKind('interactivity', { ...base, isInputMetric: true })).toBe('ttft');
+  it('interactivity chart plots TTFT when the resolved field is a TTFT column', () => {
+    expect(resolveXAxisKind('interactivity', { ...base, xAxisField: 'p90_ttft' })).toBe('ttft');
+    expect(resolveXAxisKind('interactivity', { ...base, xAxisField: 'median_ttft' })).toBe('ttft');
+  });
+
+  it('interactivity chart keeps interactivity for input metrics without a TTFT override', () => {
+    // Input metric with no `*_x` config override: `resolveXAxisField` falls
+    // back to the chart's natural x, so the footer must say interactivity.
+    expect(resolveXAxisKind('interactivity', { ...base, xAxisField: 'p90_intvty' })).toBe(
+      'interactivity',
+    );
   });
 
   it('e2e chart plots end-to-end latency by default', () => {
-    expect(resolveXAxisKind('e2e', base)).toBe('e2eLatency');
+    expect(resolveXAxisKind('e2e', { ...base, xAxisField: 'e2el' })).toBe('e2eLatency');
   });
 
   it('e2e chart plots TTFT under the ttft x-axis mode', () => {
-    expect(resolveXAxisKind('e2e', { ...base, isTtftOverride: true })).toBe('ttft');
+    expect(resolveXAxisKind('e2e', { ...base, xAxisField: 'p99_ttft' })).toBe('ttft');
   });
 
   it('e2e chart plots normalized interactivity under the derived agentic mode', () => {
     expect(
       resolveXAxisKind('e2e', {
-        ...base,
-        isTtftOverride: true,
+        xAxisField: 'p90_ttft',
         isDerivedNormalizedInteractivity: true,
       }),
     ).toBe('e2eNormalizedInteractivity');
-  });
-
-  it('input-metric override only applies to the interactivity chart', () => {
-    expect(resolveXAxisKind('e2e', { ...base, isInputMetric: true })).toBe('e2eLatency');
   });
 });
 

--- a/packages/app/src/components/inference/axis-metric-explanations.test.ts
+++ b/packages/app/src/components/inference/axis-metric-explanations.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  METRIC_EXPLANATIONS,
+  metricRowLabel,
+  resolveXAxisKind,
+  X_AXIS_EXPLANATIONS,
+  X_AXIS_KINDS,
+  xAxisPercentileFromLabel,
+} from './axis-metric-explanations';
+import { METRIC_REGISTRY, type MetricKey } from './metric-registry';
+
+const CJK = /[\u4E00-\u9FFF]/u;
+const metricKeys = Object.keys(METRIC_REGISTRY) as MetricKey[];
+
+describe('METRIC_EXPLANATIONS completeness', () => {
+  it('covers every METRIC_REGISTRY key and nothing else', () => {
+    expect(Object.keys(METRIC_EXPLANATIONS).sort()).toEqual([...metricKeys].sort());
+  });
+
+  it.each(metricKeys)('%s has non-empty bilingual description and formula', (key) => {
+    const entry = METRIC_EXPLANATIONS[key];
+    expect(entry.description.en.length).toBeGreaterThan(20);
+    expect(entry.description.zh.length).toBeGreaterThan(10);
+    expect(entry.formula.en.length).toBeGreaterThan(5);
+    expect(entry.formula.zh.length).toBeGreaterThan(5);
+    // Chinese strings must actually be Chinese, not copied English.
+    expect(entry.description.zh).toMatch(CJK);
+    expect(entry.formula.zh).toMatch(CJK);
+    expect(entry.description.en).not.toMatch(CJK);
+    // Formulas are structural: they must show a computation, not a number soup.
+    expect(entry.formula.en).toMatch(/[÷×=]/u);
+  });
+
+  it('per-MW metrics describe the per-MW normalization', () => {
+    for (const key of ['tpPerMw', 'inputTputPerMw', 'outputTputPerMw', 'powerUser'] as const) {
+      expect(METRIC_EXPLANATIONS[key].formula.en).toContain('all-in utility MW');
+    }
+  });
+
+  it('cost metrics show the $/Mtok formula', () => {
+    for (const key of [
+      'costh',
+      'costn',
+      'costr',
+      'costhOutput',
+      'costnOutput',
+      'costrOutput',
+      'costhi',
+      'costni',
+      'costri',
+      'costUser',
+    ] as const) {
+      expect(METRIC_EXPLANATIONS[key].formula.en).toContain('$/Mtok =');
+    }
+  });
+});
+
+describe('X_AXIS_EXPLANATIONS', () => {
+  it('covers every x-axis kind', () => {
+    expect(Object.keys(X_AXIS_EXPLANATIONS).sort()).toEqual([...X_AXIS_KINDS].sort());
+  });
+
+  it.each(X_AXIS_KINDS)('%s has bilingual name and description', (kind) => {
+    const entry = X_AXIS_EXPLANATIONS[kind];
+    expect(entry.name.en(null).length).toBeGreaterThan(3);
+    expect(entry.name.zh(null)).toMatch(CJK);
+    expect(entry.description.en.length).toBeGreaterThan(20);
+    expect(entry.description.zh).toMatch(CJK);
+  });
+
+  it('renders percentile prefixes in row names', () => {
+    expect(X_AXIS_EXPLANATIONS.ttft.name.en('P90')).toBe('P90 Time To First Token (s)');
+    expect(X_AXIS_EXPLANATIONS.ttft.name.en(null)).toBe('Time To First Token (s)');
+    expect(X_AXIS_EXPLANATIONS.ttft.name.zh('Median')).toContain('中位');
+    expect(X_AXIS_EXPLANATIONS.e2eNormalizedInteractivity.name.zh('P90')).toContain('P90 ');
+  });
+});
+
+describe('resolveXAxisKind', () => {
+  const base = {
+    isInputMetric: false,
+    isTtftOverride: false,
+    isDerivedNormalizedInteractivity: false,
+  };
+
+  it('interactivity chart plots interactivity by default', () => {
+    expect(resolveXAxisKind('interactivity', base)).toBe('interactivity');
+  });
+
+  it('interactivity chart plots TTFT for input metrics', () => {
+    expect(resolveXAxisKind('interactivity', { ...base, isInputMetric: true })).toBe('ttft');
+  });
+
+  it('e2e chart plots end-to-end latency by default', () => {
+    expect(resolveXAxisKind('e2e', base)).toBe('e2eLatency');
+  });
+
+  it('e2e chart plots TTFT under the ttft x-axis mode', () => {
+    expect(resolveXAxisKind('e2e', { ...base, isTtftOverride: true })).toBe('ttft');
+  });
+
+  it('e2e chart plots normalized interactivity under the derived agentic mode', () => {
+    expect(
+      resolveXAxisKind('e2e', {
+        ...base,
+        isTtftOverride: true,
+        isDerivedNormalizedInteractivity: true,
+      }),
+    ).toBe('e2eNormalizedInteractivity');
+  });
+
+  it('input-metric override only applies to the interactivity chart', () => {
+    expect(resolveXAxisKind('e2e', { ...base, isInputMetric: true })).toBe('e2eLatency');
+  });
+});
+
+describe('xAxisPercentileFromLabel', () => {
+  it('extracts percentile words', () => {
+    expect(xAxisPercentileFromLabel('P90 Time To First Token (s)')).toBe('P90');
+    expect(xAxisPercentileFromLabel('Median Time To First Token (s)')).toBe('Median');
+    expect(xAxisPercentileFromLabel('P75 E2E Normalized Interactivity (tok/s/user)')).toBe('P75');
+    expect(xAxisPercentileFromLabel('P99.9 End-to-end Latency (s)')).toBe('P99.9');
+  });
+
+  it('returns null when there is no percentile prefix', () => {
+    expect(xAxisPercentileFromLabel('Interactivity (tok/s/user)')).toBeNull();
+    expect(xAxisPercentileFromLabel('End-to-end Latency (s)')).toBeNull();
+  });
+});
+
+describe('metricRowLabel', () => {
+  it('resolves locale-aware titles from the registry', () => {
+    expect(metricRowLabel('tpPerGpu', 'en')).toBe('Token Throughput per Chip');
+    expect(metricRowLabel('tpPerGpu', 'zh')).toBe('每芯片 token 吞吐量');
+  });
+});

--- a/packages/app/src/components/inference/axis-metric-explanations.ts
+++ b/packages/app/src/components/inference/axis-metric-explanations.ts
@@ -1,0 +1,501 @@
+/**
+ * @file axis-metric-explanations.ts
+ * @description Bilingual plain-English explanations (and, for y-axis metrics,
+ * structural formulas) backing the expandable axis-metric footer rendered
+ * below each inference chart. Y-axis entries are keyed by `METRIC_REGISTRY`
+ * keys; x-axis entries are keyed by the resolved x-axis kind. A unit test
+ * asserts completeness against the registry, so adding a metric without an
+ * explanation fails CI.
+ *
+ * Formulas are structural descriptions of the derived-field math in
+ * `buildDerivedChartFields` (src/lib/chart-utils.ts) and the glossary
+ * (src/lib/glossary.ts) — they describe how a value is computed, they do not
+ * restate assumed constants.
+ */
+import { METRIC_REGISTRY, type MetricKey } from './metric-registry';
+
+export interface LocalizedText {
+  en: string;
+  zh: string;
+}
+
+export interface MetricExplanation {
+  /** 1–3 sentence plain-language explanation of the metric. */
+  description: LocalizedText;
+  /** Structural formula, rendered in monospace in the footer. */
+  formula: LocalizedText;
+}
+
+/** Cost-basis flavor shared by the $/¥/cost metric families. */
+type CostBasis = 'h' | 'n' | 'r';
+type TokenType = 'total' | 'output' | 'input';
+
+const COST_BASIS_EN: Record<CostBasis, string> = {
+  h: 'all-in hourly ownership cost of a hyperscaler operator',
+  n: 'all-in hourly ownership cost of a Neocloud Giant operator',
+  r: 'all-in hourly cost of a 3-year rental contract',
+};
+
+const COST_BASIS_ZH: Record<CostBasis, string> = {
+  h: '超大规模云厂商自有硬件的每小时全包成本',
+  n: 'Neocloud Giant 自有硬件的每小时全包成本',
+  r: '3 年期租赁合同的每小时全包成本',
+};
+
+const TOKEN_TYPE_EN: Record<TokenType, string> = {
+  total: 'total tokens (input + output)',
+  output: 'output tokens',
+  input: 'input tokens',
+};
+
+const TOKEN_TYPE_ZH: Record<TokenType, string> = {
+  total: '总 token（输入 + 输出）',
+  output: '输出 token',
+  input: '输入 token',
+};
+
+const TOKEN_RATE_EN: Record<TokenType, string> = {
+  total: 'total tok/s/chip',
+  output: 'output tok/s/chip',
+  input: 'input tok/s/chip',
+};
+
+const TOKEN_RATE_ZH: Record<TokenType, string> = {
+  total: '总 tok/s/chip',
+  output: '输出 tok/s/chip',
+  input: '输入 tok/s/chip',
+};
+
+function throughputPerChip(tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Rate of ${TOKEN_TYPE_EN[tokenType]} the serving replica handles each second, divided ` +
+        'across every chip serving it. Normalizing per chip keeps different parallelism setups ' +
+        'and replica sizes comparable.',
+      zh:
+        `服务副本每秒处理的${TOKEN_TYPE_ZH[tokenType]}速率，平均到服务该副本的每一块芯片上。` +
+        '按芯片归一化后，不同并行配置和副本规模之间可以直接比较。',
+    },
+    formula: {
+      en: `tok/s/chip = ${TOKEN_TYPE_EN[tokenType]} per second ÷ number of chips serving the replica`,
+      zh: `tok/s/chip = 每秒${TOKEN_TYPE_ZH[tokenType]}数 ÷ 服务该副本的芯片数`,
+    },
+  };
+}
+
+function throughputPerMw(tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Rate of ${TOKEN_TYPE_EN[tokenType]} produced per megawatt of all-in utility power ` +
+        'provisioned for the hardware — the full data-center power budget attributed to the ' +
+        'chips, not just their own draw. It answers how much output a fixed power budget buys.',
+      zh:
+        `按硬件全电源配置（all-in utility）功率归一化的${TOKEN_TYPE_ZH[tokenType]}速率——` +
+        '即分摊到芯片上的整个数据中心电力预算，而不仅是芯片自身功耗。' +
+        '它回答的是固定电力预算能换来多少产出。',
+    },
+    formula: {
+      en: `tok/s/MW = ${TOKEN_RATE_EN[tokenType]} ÷ all-in utility MW provisioned per chip`,
+      zh: `tok/s/MW = ${TOKEN_RATE_ZH[tokenType]} ÷ 每芯片全电源配置功率（MW）`,
+    },
+  };
+}
+
+function costPerMillion(basis: CostBasis, tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Estimated infrastructure cost of producing one million ${TOKEN_TYPE_EN[tokenType]} at ` +
+        `this operating point, priced with the ${COST_BASIS_EN[basis]}. Lower is cheaper.`,
+      zh:
+        `在该运行点生产一百万${TOKEN_TYPE_ZH[tokenType]}的基础设施成本估算，` +
+        `按${COST_BASIS_ZH[basis]}计价。数值越低越便宜。`,
+    },
+    formula: {
+      en: `$/Mtok = all-in cost per chip-hour ($) × 1,000,000 ÷ (3,600 × ${TOKEN_RATE_EN[tokenType]})`,
+      zh: `$/Mtok = 每芯片小时全包成本（$）× 1,000,000 ÷（3,600 × ${TOKEN_RATE_ZH[tokenType]}）`,
+    },
+  };
+}
+
+function tokensPerDollar(basis: CostBasis, tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `How many ${TOKEN_TYPE_EN[tokenType]} one US dollar of infrastructure spend buys, ` +
+        `priced with the ${COST_BASIS_EN[basis]}. It is the reciprocal of cost per token, so ` +
+        'higher means cheaper.',
+      zh:
+        `1 美元基础设施开支能换来多少${TOKEN_TYPE_ZH[tokenType]}，` +
+        `按${COST_BASIS_ZH[basis]}计价。它是单 token 成本的倒数，数值越高越便宜。`,
+    },
+    formula: {
+      en: `tok/$ = (${TOKEN_RATE_EN[tokenType]} × 3,600) ÷ all-in cost per chip-hour ($)`,
+      zh: `tok/$ =（${TOKEN_RATE_ZH[tokenType]} × 3,600）÷ 每芯片小时全包成本（$）`,
+    },
+  };
+}
+
+function tokensPerRmb(basis: CostBasis, tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `How many ${TOKEN_TYPE_EN[tokenType]} one Chinese yuan of infrastructure spend buys, ` +
+        `priced with the ${COST_BASIS_EN[basis]} converted at a fixed USD→CNY exchange rate. ` +
+        'Higher means cheaper.',
+      zh:
+        `1 元人民币基础设施开支能换来多少${TOKEN_TYPE_ZH[tokenType]}，` +
+        `按${COST_BASIS_ZH[basis]}以固定 USD→CNY 汇率折算计价。数值越高越便宜。`,
+    },
+    formula: {
+      en:
+        `tok/¥ = (${TOKEN_RATE_EN[tokenType]} × 3,600) ÷ ` +
+        '(all-in cost per chip-hour ($) × USD→CNY exchange rate)',
+      zh:
+        `tok/¥ =（${TOKEN_RATE_ZH[tokenType]} × 3,600）÷` +
+        '（每芯片小时全包成本（$）× USD→CNY 汇率）',
+    },
+  };
+}
+
+function provisionedJoules(tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Electrical energy attributed to each of the ${TOKEN_TYPE_EN[tokenType]}, assuming the ` +
+        'full all-in utility power provisioned for the hardware is drawn. It is a provisioned ' +
+        'upper bound, not a telemetry measurement.',
+      zh:
+        `平均到每个${TOKEN_TYPE_ZH[tokenType]}上的电能，假设硬件按全电源配置功率满额用电。` +
+        '这是按配置功率计算的上限值，不是遥测实测值。',
+    },
+    formula: {
+      en: `J/tok = all-in utility power per chip (W) ÷ ${TOKEN_RATE_EN[tokenType]}`,
+      zh: `J/tok = 每芯片全电源配置功率（W）÷ ${TOKEN_RATE_ZH[tokenType]}`,
+    },
+  };
+}
+
+type MeasuredPhase = 'run' | 'prefill' | 'decode';
+
+const MEASURED_PHASE_EN: Record<MeasuredPhase, string> = {
+  run: 'the whole benchmark run',
+  prefill: 'the prefill phase (prompt processing)',
+  decode: 'the decode phase (token generation)',
+};
+
+const MEASURED_PHASE_ZH: Record<MeasuredPhase, string> = {
+  run: '整个基准测试运行期间',
+  prefill: 'prefill 阶段（处理提示词）',
+  decode: 'decode 阶段（生成 token）',
+};
+
+function measuredPower(phase: MeasuredPhase): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Average per-chip accelerator power actually drawn during ${MEASURED_PHASE_EN[phase]}, ` +
+        'read from runner telemetry. Unlike the all-in provisioned metrics, this reflects real ' +
+        'measured draw, not the provisioned budget.',
+      zh:
+        `${MEASURED_PHASE_ZH[phase]}每块加速器芯片的实际平均功耗，来自运行器遥测数据。` +
+        '与全电源配置类指标不同，它反映的是真实实测功耗，而不是按配置计算的预算值。',
+    },
+    formula: {
+      en: `W = mean of sampled per-chip accelerator power draw over ${MEASURED_PHASE_EN[phase]}`,
+      zh: `W = ${MEASURED_PHASE_ZH[phase]}每芯片加速器功耗采样值的平均`,
+    },
+  };
+}
+
+function measuredJoulesPerToken(tokenType: TokenType): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Measured accelerator energy consumed per ${
+          tokenType === 'total' ? 'token (including prompt tokens)' : `${tokenType} token`
+        }, from runner power telemetry integrated over the run. Lower means the system converts ` +
+        'electricity into tokens more efficiently.',
+      zh:
+        `每个${TOKEN_TYPE_ZH[tokenType]}消耗的加速器实测能耗，由运行器功耗遥测在整个运行期间积分得到。` +
+        '数值越低，说明系统把电能转化为 token 的效率越高。',
+    },
+    formula: {
+      en: `J/tok = measured accelerator energy over the run ÷ ${TOKEN_TYPE_EN[tokenType]} processed`,
+      zh: `J/tok = 运行期间加速器实测能耗 ÷ 处理的${TOKEN_TYPE_ZH[tokenType]}数`,
+    },
+  };
+}
+
+/**
+ * Every `METRIC_REGISTRY` key gets a bilingual explanation and a structural
+ * formula. Grounded in `buildDerivedChartFields` (src/lib/chart-utils.ts) and
+ * the glossary entries for throughput, cost per million tokens, tokens per
+ * dollar, tokens per megawatt, and energy per token.
+ */
+export const METRIC_EXPLANATIONS: Record<MetricKey, MetricExplanation> = {
+  tpPerGpu: throughputPerChip('total'),
+  inputTputPerGpu: throughputPerChip('input'),
+  outputTputPerGpu: throughputPerChip('output'),
+  tpPerMw: throughputPerMw('total'),
+  inputTputPerMw: throughputPerMw('input'),
+  outputTputPerMw: throughputPerMw('output'),
+  costh: costPerMillion('h', 'total'),
+  costn: costPerMillion('n', 'total'),
+  costr: costPerMillion('r', 'total'),
+  costhOutput: costPerMillion('h', 'output'),
+  costnOutput: costPerMillion('n', 'output'),
+  costrOutput: costPerMillion('r', 'output'),
+  costhi: costPerMillion('h', 'input'),
+  costni: costPerMillion('n', 'input'),
+  costri: costPerMillion('r', 'input'),
+  tokensPerDollarH: tokensPerDollar('h', 'total'),
+  tokensPerDollarN: tokensPerDollar('n', 'total'),
+  tokensPerDollarR: tokensPerDollar('r', 'total'),
+  outputTokensPerDollarH: tokensPerDollar('h', 'output'),
+  outputTokensPerDollarN: tokensPerDollar('n', 'output'),
+  outputTokensPerDollarR: tokensPerDollar('r', 'output'),
+  inputTokensPerDollarH: tokensPerDollar('h', 'input'),
+  inputTokensPerDollarN: tokensPerDollar('n', 'input'),
+  inputTokensPerDollarR: tokensPerDollar('r', 'input'),
+  tokensPerRmbH: tokensPerRmb('h', 'total'),
+  tokensPerRmbN: tokensPerRmb('n', 'total'),
+  tokensPerRmbR: tokensPerRmb('r', 'total'),
+  outputTokensPerRmbH: tokensPerRmb('h', 'output'),
+  outputTokensPerRmbN: tokensPerRmb('n', 'output'),
+  outputTokensPerRmbR: tokensPerRmb('r', 'output'),
+  inputTokensPerRmbH: tokensPerRmb('h', 'input'),
+  inputTokensPerRmbN: tokensPerRmb('n', 'input'),
+  inputTokensPerRmbR: tokensPerRmb('r', 'input'),
+  costUser: {
+    description: {
+      en:
+        'Estimated infrastructure cost of producing one million total tokens, priced with the ' +
+        'hourly cost you entered in the custom-values panel instead of a modeled cost basis.',
+      zh:
+        '生产一百万总 token 的基础设施成本估算，按你在自定义值面板中输入的每小时成本计价，' +
+        '而不是按内置成本模型计价。',
+    },
+    formula: {
+      en: '$/Mtok = user-entered cost per chip-hour ($) × 1,000,000 ÷ (3,600 × total tok/s/chip)',
+      zh: '$/Mtok = 自定义每芯片小时成本（$）× 1,000,000 ÷（3,600 × 总 tok/s/chip）',
+    },
+  },
+  tokensPerDollarUser: {
+    description: {
+      en:
+        'How many total tokens one US dollar buys, priced with the hourly cost you entered in ' +
+        'the custom-values panel. Higher means cheaper under your own cost assumptions.',
+      zh:
+        '1 美元能换来多少总 token，按你在自定义值面板中输入的每小时成本计价。' +
+        '在你自己的成本假设下，数值越高越便宜。',
+    },
+    formula: {
+      en: 'tok/$ = (total tok/s/chip × 3,600) ÷ user-entered cost per chip-hour ($)',
+      zh: 'tok/$ =（总 tok/s/chip × 3,600）÷ 自定义每芯片小时成本（$）',
+    },
+  },
+  powerUser: {
+    description: {
+      en:
+        'Total token throughput normalized by the all-in utility power you entered in the ' +
+        'custom-values panel, instead of the modeled per-chip power budget.',
+      zh: '按你在自定义值面板中输入的全电源配置功率归一化的总 token 吞吐量，而不是按内置的每芯片电力预算。',
+    },
+    formula: {
+      en: 'tok/s/MW = total tok/s/chip ÷ user-entered all-in utility MW per chip',
+      zh: 'tok/s/MW = 总 tok/s/chip ÷ 自定义每芯片全电源配置功率（MW）',
+    },
+  },
+  jTotal: provisionedJoules('total'),
+  jOutput: provisionedJoules('output'),
+  jInput: provisionedJoules('input'),
+  measuredAvgPower: measuredPower('run'),
+  measuredPrefillAvgPower: measuredPower('prefill'),
+  measuredDecodeAvgPower: measuredPower('decode'),
+  measuredJPerOutputToken: measuredJoulesPerToken('output'),
+  measuredJPerInputToken: measuredJoulesPerToken('input'),
+  measuredJPerTotalToken: measuredJoulesPerToken('total'),
+  measuredJPerSuccessfulQuery: {
+    description: {
+      en:
+        'Measured accelerator energy consumed per successfully completed request, from runner ' +
+        'power telemetry. It charges the energy of the whole run only to requests that finished ' +
+        'successfully.',
+      zh:
+        '每个成功完成的请求消耗的加速器实测能耗，来自运行器功耗遥测。' +
+        '整个运行的能耗只计入成功完成的请求。',
+    },
+    formula: {
+      en: 'J/query = measured accelerator energy over the run ÷ successfully completed requests',
+      zh: 'J/query = 运行期间加速器实测能耗 ÷ 成功完成的请求数',
+    },
+  },
+  measuredWhPerSuccessfulQuery: {
+    description: {
+      en:
+        'The same measured energy per successful request expressed in watt-hours, a more ' +
+        'familiar household unit (1 Wh = 3,600 J).',
+      zh: '与每次成功请求实测能耗相同的量，换算成更直观的瓦时单位（1 Wh = 3,600 J）。',
+    },
+    formula: {
+      en: 'Wh/query = measured J per successful query ÷ 3,600',
+      zh: 'Wh/query = 每次成功请求实测能耗（J）÷ 3,600',
+    },
+  },
+  measuredPowerPercentTdp: {
+    description: {
+      en:
+        'Measured average per-chip power as a share of the accelerator’s rated TDP. Values well ' +
+        'below 100% suggest the workload leaves thermal or power headroom on the table.',
+      zh:
+        '每芯片实测平均功耗占加速器额定 TDP 的百分比。' +
+        '明显低于 100% 说明该工作负载没有用满散热或供电余量。',
+    },
+    formula: {
+      en: '% TDP = measured average power per chip (W) ÷ rated TDP (W) × 100',
+      zh: '% TDP = 每芯片实测平均功耗（W）÷ 额定 TDP（W）× 100',
+    },
+  },
+};
+
+/**
+ * The four logical x-axis metrics an inference chart can plot, independent of
+ * the percentile prefix. Mirrors the branch logic in `resolveXAxisField` plus
+ * the derived agentic x-axis mode handled in `ChartDisplay`.
+ */
+export type XAxisKind = 'interactivity' | 'e2eLatency' | 'ttft' | 'e2eNormalizedInteractivity';
+
+export const X_AXIS_KINDS: readonly XAxisKind[] = [
+  'interactivity',
+  'e2eLatency',
+  'ttft',
+  'e2eNormalizedInteractivity',
+];
+
+export interface XAxisExplanation {
+  /** Display name for the footer row; `pctl` is e.g. 'P90' | 'Median' | null. */
+  name: {
+    en: (pctl: string | null) => string;
+    zh: (pctl: string | null) => string;
+  };
+  description: LocalizedText;
+}
+
+const zhPctl = (pctl: string | null): string =>
+  pctl === null ? '' : pctl === 'Median' ? '中位' : `${pctl} `;
+
+const enPctl = (pctl: string | null): string => (pctl === null ? '' : `${pctl} `);
+
+export const X_AXIS_EXPLANATIONS: Record<XAxisKind, XAxisExplanation> = {
+  interactivity: {
+    name: {
+      en: (pctl) => `${enPctl(pctl)}Interactivity (tok/s/user)`,
+      zh: (pctl) => `${zhPctl(pctl)}交互性（tok/s/user）`,
+    },
+    description: {
+      en:
+        'Interactivity is the rate at which a single user receives generated tokens while the ' +
+        'model streams its answer — how quickly new words appear on screen. Higher values feel ' +
+        'snappier; operators trade it against batch throughput.',
+      zh:
+        '交互性（interactivity）指模型流式输出回答时，单个用户接收生成 token 的速率——' +
+        '即新内容出现在屏幕上的快慢。数值越高体验越流畅；运营方需要在交互性与批量吞吐量之间权衡。',
+    },
+  },
+  e2eLatency: {
+    name: {
+      en: (pctl) => `${enPctl(pctl)}End-to-end Latency (s)`,
+      zh: (pctl) => `${zhPctl(pctl)}端到端延迟（s）`,
+    },
+    description: {
+      en:
+        'End-to-end latency is the total wall-clock time from submitting a request until the ' +
+        'complete response finishes — the wait before the first token plus the entire ' +
+        'generation. Lower is better.',
+      zh:
+        '端到端延迟指从提交请求到完整响应结束的总耗时——包括收到首个 token 之前的等待和之后的全部生成过程。' +
+        '数值越低越好。',
+    },
+  },
+  ttft: {
+    name: {
+      en: (pctl) => `${enPctl(pctl)}Time To First Token (s)`,
+      zh: (pctl) => `${zhPctl(pctl)}首 token 延迟（TTFT，s）`,
+    },
+    description: {
+      en:
+        'Time to first token (TTFT) is the delay from submitting a request until the first ' +
+        'generated token arrives — the “thinking…” pause before the answer starts. Percentile ' +
+        'prefixes (Median, P90, P99) report that delay across all requests in the run.',
+      zh:
+        '首 token 延迟（TTFT，Time To First Token）指从提交请求到收到第一个生成 token 的等待时间——' +
+        '也就是回答开始前的“思考”停顿。百分位前缀（Median、P90、P99）表示该延迟在整个运行的所有请求上的分布。',
+    },
+  },
+  e2eNormalizedInteractivity: {
+    name: {
+      en: (pctl) => `${enPctl(pctl)}E2E Normalized Interactivity (tok/s/user)`,
+      zh: (pctl) => `${zhPctl(pctl)}端到端归一化交互性（tok/s/user）`,
+    },
+    description: {
+      en:
+        'E2E normalized interactivity is the effective per-user token rate over a complete ' +
+        'request: output tokens divided by end-to-end latency. Unlike plain interactivity it ' +
+        'also counts the wait before the first token, so slow prefill lowers the score.',
+      zh:
+        '端到端归一化交互性是完整请求内的等效单用户 token 速率：输出 token 数除以端到端延迟。' +
+        '与普通交互性不同，它把首个 token 之前的等待也计算在内，prefill 越慢得分越低。',
+    },
+  },
+};
+
+/**
+ * Resolve which logical x-axis metric a chart is currently plotting. Mirrors
+ * the display branches in `ChartDisplay` (chart heading) and the field
+ * branches in `resolveXAxisField`, for both the official pipeline and
+ * `?unofficialrun=` overlays — the overlay path shares the chart's resolved
+ * x-axis, so one footer row describes both.
+ */
+export function resolveXAxisKind(
+  chartType: 'interactivity' | 'e2e',
+  opts: {
+    /** English metric title contains 'input' → interactivity chart plots TTFT. */
+    isInputMetric: boolean;
+    /** e2e chart with a *_ttft x-axis mode selected. */
+    isTtftOverride: boolean;
+    /** Agentic trace-derived normalized-interactivity x-axis mode. */
+    isDerivedNormalizedInteractivity: boolean;
+  },
+): XAxisKind {
+  if (chartType === 'e2e') {
+    if (opts.isDerivedNormalizedInteractivity) return 'e2eNormalizedInteractivity';
+    if (opts.isTtftOverride) return 'ttft';
+    return 'e2eLatency';
+  }
+  return opts.isInputMetric ? 'ttft' : 'interactivity';
+}
+
+/**
+ * Extract the percentile word from a resolved x-axis label (e.g.
+ * "P90 Time To First Token (s)" → "P90"). The chart pipelines always render
+ * the percentile prefix in this English form, including on /zh pages.
+ */
+export function xAxisPercentileFromLabel(xAxisLabel: string): string | null {
+  const match = /^(?<pctl>Median|Mean|P\d+(?:\.\d+)?)\s/iu.exec(xAxisLabel);
+  if (!match?.groups?.pctl) return null;
+  const pctl = match.groups.pctl;
+  return pctl.toLowerCase() === 'median'
+    ? 'Median'
+    : pctl.toLowerCase() === 'mean'
+      ? 'Mean'
+      : pctl.toUpperCase();
+}
+
+/** Locale-aware y-axis row label straight from the metric registry. */
+export function metricRowLabel(metricKey: MetricKey, locale: 'en' | 'zh'): string {
+  const metric = METRIC_REGISTRY[metricKey];
+  return locale === 'zh' ? metric.titleZh : metric.title;
+}

--- a/packages/app/src/components/inference/axis-metric-explanations.ts
+++ b/packages/app/src/components/inference/axis-metric-explanations.ts
@@ -453,29 +453,29 @@ export const X_AXIS_EXPLANATIONS: Record<XAxisKind, XAxisExplanation> = {
 };
 
 /**
- * Resolve which logical x-axis metric a chart is currently plotting. Mirrors
- * the display branches in `ChartDisplay` (chart heading) and the field
- * branches in `resolveXAxisField`, for both the official pipeline and
- * `?unofficialrun=` overlays — the overlay path shares the chart's resolved
- * x-axis, so one footer row describes both.
+ * Resolve which logical x-axis metric a chart is currently plotting.
+ * Classifies off the x-axis data field that `resolveXAxisField` actually
+ * resolved for the chart's current state, so the footer can never disagree
+ * with the drawn axis — `resolveXAxisField` is the single source of truth for
+ * the field, including the input-metric fallback where a metric without a
+ * `*_x` config override keeps plotting the chart's natural x. Trace-derived
+ * agentic x-axis modes bypass that resolver entirely, so they arrive as an
+ * explicit flag. Applies to both the official pipeline and `?unofficialrun=`
+ * overlays — the overlay path shares the chart's resolved x-axis, so one
+ * footer row describes both.
  */
 export function resolveXAxisKind(
   chartType: 'interactivity' | 'e2e',
   opts: {
-    /** English metric title contains 'input' → interactivity chart plots TTFT. */
-    isInputMetric: boolean;
-    /** e2e chart with a *_ttft x-axis mode selected. */
-    isTtftOverride: boolean;
+    /** Resolved x-axis data field from `resolveXAxisField` (e.g. `p90_ttft`). */
+    xAxisField: string;
     /** Agentic trace-derived normalized-interactivity x-axis mode. */
     isDerivedNormalizedInteractivity: boolean;
   },
 ): XAxisKind {
-  if (chartType === 'e2e') {
-    if (opts.isDerivedNormalizedInteractivity) return 'e2eNormalizedInteractivity';
-    if (opts.isTtftOverride) return 'ttft';
-    return 'e2eLatency';
-  }
-  return opts.isInputMetric ? 'ttft' : 'interactivity';
+  if (opts.isDerivedNormalizedInteractivity) return 'e2eNormalizedInteractivity';
+  if (opts.xAxisField.endsWith('ttft')) return 'ttft';
+  return chartType === 'e2e' ? 'e2eLatency' : 'interactivity';
 }
 
 /**

--- a/packages/app/src/components/inference/ui/AxisMetricFooter.test.tsx
+++ b/packages/app/src/components/inference/ui/AxisMetricFooter.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  track: vi.fn(),
+  locale: { value: 'en' as 'en' | 'zh' },
+}));
+
+vi.mock('@/lib/analytics', () => ({ track: mocks.track }));
+vi.mock('@/lib/use-locale', () => ({ useLocale: () => mocks.locale.value }));
+
+import AxisMetricFooter from './AxisMetricFooter';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  mocks.track.mockClear();
+  mocks.locale.value = 'en';
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(props?: Partial<React.ComponentProps<typeof AxisMetricFooter>>) {
+  act(() => {
+    root.render(
+      <AxisMetricFooter
+        chartId="chart-0"
+        metricKey="tokensPerDollarH"
+        xAxisKind="interactivity"
+        xAxisLabel="Interactivity (tok/s/user)"
+        {...props}
+      />,
+    );
+  });
+}
+
+function click(el: Element) {
+  act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+describe('AxisMetricFooter', () => {
+  it('renders one collapsed row per axis', () => {
+    render();
+    const xRow = container.querySelector('[data-testid="axis-metric-row-x-chart-0"]');
+    const yRow = container.querySelector('[data-testid="axis-metric-row-y-chart-0"]');
+    expect(xRow).not.toBeNull();
+    expect(yRow).not.toBeNull();
+    expect(xRow!.getAttribute('aria-expanded')).toBe('false');
+    expect(yRow!.getAttribute('aria-expanded')).toBe('false');
+    expect(xRow!.textContent).toContain('X-axis: Interactivity (tok/s/user)');
+    expect(yRow!.textContent).toContain('Y-axis: Total Tokens per $1 USD (Owning - Hyperscaler)');
+    // Bodies exist for aria-controls but stay hidden until toggled.
+    const xBody = container.querySelector<HTMLElement>(
+      '[data-testid="axis-metric-body-x-chart-0"]',
+    );
+    expect(xBody!.hidden).toBe(true);
+    expect(xRow!.getAttribute('aria-controls')).toBe(xBody!.id);
+  });
+
+  it('expands the x-axis row with an explanation and no formula', () => {
+    render();
+    const xRow = container.querySelector('[data-testid="axis-metric-row-x-chart-0"]')!;
+    click(xRow);
+    expect(xRow.getAttribute('aria-expanded')).toBe('true');
+    const xBody = container.querySelector<HTMLElement>(
+      '[data-testid="axis-metric-body-x-chart-0"]',
+    )!;
+    expect(xBody.hidden).toBe(false);
+    expect(xBody.textContent).toContain('rate at which a single user receives generated tokens');
+    // The x-axis row has no formula; the y-axis formula lives in the (still hidden) y body.
+    expect(xBody.querySelector('code')).toBeNull();
+    const yBody = container.querySelector<HTMLElement>(
+      '[data-testid="axis-metric-body-y-chart-0"]',
+    )!;
+    expect(yBody.hidden).toBe(true);
+  });
+
+  it('expands the y-axis row with explanation plus formula, then collapses', () => {
+    render();
+    const yRow = container.querySelector('[data-testid="axis-metric-row-y-chart-0"]')!;
+    click(yRow);
+    const yBody = container.querySelector<HTMLElement>(
+      '[data-testid="axis-metric-body-y-chart-0"]',
+    )!;
+    expect(yBody.hidden).toBe(false);
+    const formula = container.querySelector('[data-testid="axis-metric-formula-chart-0"]')!;
+    expect(formula.textContent).toBe(
+      'tok/$ = (total tok/s/chip × 3,600) ÷ all-in cost per chip-hour ($)',
+    );
+    click(yRow);
+    expect(yRow.getAttribute('aria-expanded')).toBe('false');
+    expect(yBody.hidden).toBe(true);
+  });
+
+  it('tracks toggle analytics with chart, axis, metric, and expanded state', () => {
+    render();
+    const yRow = container.querySelector('[data-testid="axis-metric-row-y-chart-0"]')!;
+    click(yRow);
+    expect(mocks.track).toHaveBeenCalledWith('axis_metric_footer_toggled', {
+      chart: 'chart-0',
+      axis: 'y',
+      metric: 'tokensPerDollarH',
+      expanded: true,
+    });
+    click(yRow);
+    expect(mocks.track).toHaveBeenLastCalledWith('axis_metric_footer_toggled', {
+      chart: 'chart-0',
+      axis: 'y',
+      metric: 'tokensPerDollarH',
+      expanded: false,
+    });
+  });
+
+  it('shows the percentile prefix for TTFT x-axes', () => {
+    render({ xAxisKind: 'ttft', xAxisLabel: 'P90 Time To First Token (s)' });
+    const xRow = container.querySelector('[data-testid="axis-metric-row-x-chart-0"]')!;
+    expect(xRow.textContent).toContain('X-axis: P90 Time To First Token (s)');
+  });
+
+  it('renders Chinese strings on /zh pages', () => {
+    mocks.locale.value = 'zh';
+    render({ metricKey: 'tpPerMw', xAxisKind: 'e2eLatency', xAxisLabel: 'End-to-end Latency (s)' });
+    const xRow = container.querySelector('[data-testid="axis-metric-row-x-chart-0"]')!;
+    const yRow = container.querySelector('[data-testid="axis-metric-row-y-chart-0"]')!;
+    expect(xRow.textContent).toContain('X 轴：端到端延迟（s）');
+    expect(yRow.textContent).toContain('Y 轴：每全电源配置兆瓦 token 吞吐量');
+    click(yRow);
+    const formula = container.querySelector('[data-testid="axis-metric-formula-chart-0"]')!;
+    expect(formula.textContent).toContain('每芯片全电源配置功率（MW）');
+  });
+});

--- a/packages/app/src/components/inference/ui/AxisMetricFooter.tsx
+++ b/packages/app/src/components/inference/ui/AxisMetricFooter.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { Info, Plus } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  METRIC_EXPLANATIONS,
+  metricRowLabel,
+  X_AXIS_EXPLANATIONS,
+  xAxisPercentileFromLabel,
+  type XAxisKind,
+} from '@/components/inference/axis-metric-explanations';
+import type { MetricKey } from '@/components/inference/metric-registry';
+import { track } from '@/lib/analytics';
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+const STRINGS = {
+  en: {
+    xAxisPrefix: 'X-axis: ',
+    yAxisPrefix: 'Y-axis: ',
+    formula: 'Formula',
+  },
+  zh: {
+    xAxisPrefix: 'X 轴：',
+    yAxisPrefix: 'Y 轴：',
+    formula: '计算公式',
+  },
+} as const;
+
+interface AxisMetricFooterProps {
+  /** Chart instance id (e.g. "chart-0") for testids and analytics context. */
+  chartId: string;
+  /** Selected y-axis metric registry key (without the `y_` prefix). */
+  metricKey: MetricKey;
+  /** Resolved logical x-axis metric for the chart's current state. */
+  xAxisKind: XAxisKind;
+  /**
+   * The chart's resolved English x-axis label (percentile-adjusted), used
+   * only to extract the percentile prefix for the row name.
+   */
+  xAxisLabel: string;
+}
+
+interface FooterRow {
+  axis: 'x' | 'y';
+  /** Registry key for analytics (metric key or x-axis kind). */
+  key: string;
+  label: string;
+  description: string;
+  formula?: string;
+}
+
+/**
+ * Expandable per-axis metric explainer rendered below each inference chart.
+ * One row per axis: the x-axis row explains the plotted latency/interactivity
+ * metric, the y-axis row explains the selected metric and shows its
+ * structural formula. Explanations describe the metric itself, so they apply
+ * equally to official runs and `?unofficialrun=` overlay points, which share
+ * the chart's resolved axes. Marked `no-export` so PNG exports (which capture
+ * the chart element) never include it.
+ */
+export default function AxisMetricFooter({
+  chartId,
+  metricKey,
+  xAxisKind,
+  xAxisLabel,
+}: AxisMetricFooterProps) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
+  const [expanded, setExpanded] = useState<{ x: boolean; y: boolean }>({ x: false, y: false });
+
+  const xExplanation = X_AXIS_EXPLANATIONS[xAxisKind];
+  const pctl = xAxisPercentileFromLabel(xAxisLabel);
+  const yExplanation = METRIC_EXPLANATIONS[metricKey];
+
+  const rows: FooterRow[] = [
+    {
+      axis: 'x',
+      key: xAxisKind,
+      label: `${t.xAxisPrefix}${xExplanation.name[locale](pctl)}`,
+      description: xExplanation.description[locale],
+    },
+    {
+      axis: 'y',
+      key: metricKey,
+      label: `${t.yAxisPrefix}${metricRowLabel(metricKey, locale)}`,
+      description: yExplanation.description[locale],
+      formula: yExplanation.formula[locale],
+    },
+  ];
+
+  const toggleRow = (row: FooterRow) => {
+    setExpanded((prev) => {
+      const next = !prev[row.axis];
+      track('axis_metric_footer_toggled', {
+        chart: chartId,
+        axis: row.axis,
+        metric: row.key,
+        expanded: next,
+      });
+      return { ...prev, [row.axis]: next };
+    });
+  };
+
+  return (
+    <div className="no-export mt-4" data-testid={`axis-metric-footer-${chartId}`}>
+      {rows.map((row) => {
+        const isOpen = expanded[row.axis];
+        const bodyId = `${chartId}-axis-metric-${row.axis}`;
+        return (
+          <div key={row.axis} className="border-t border-border/60">
+            <button
+              type="button"
+              className="flex w-full cursor-pointer items-center gap-2 py-2.5 text-left"
+              aria-expanded={isOpen}
+              aria-controls={bodyId}
+              data-testid={`axis-metric-row-${row.axis}-${chartId}`}
+              onClick={() => toggleRow(row)}
+            >
+              <Info aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="flex-1 text-sm text-muted-foreground">{row.label}</span>
+              <Plus
+                aria-hidden="true"
+                className={cn(
+                  'size-4 shrink-0 text-muted-foreground transition-transform duration-200',
+                  isOpen && 'rotate-45',
+                )}
+              />
+            </button>
+            <div
+              id={bodyId}
+              hidden={!isOpen}
+              className="pb-3 pl-[1.375rem]"
+              data-testid={`axis-metric-body-${row.axis}-${chartId}`}
+            >
+              <p className="text-sm text-muted-foreground">{row.description}</p>
+              {row.formula && (
+                <p className="mt-2">
+                  <span className="sr-only">{t.formula}: </span>
+                  <code
+                    className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
+                    data-testid={`axis-metric-formula-${chartId}`}
+                  >
+                    {row.formula}
+                  </code>
+                </p>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -7,6 +7,7 @@ import { BarChart3, Table2 } from 'lucide-react';
 
 import chartDefinitions, { type MetricKey } from '@/components/inference/metric-registry';
 import { resolveXAxisKind } from '@/components/inference/axis-metric-explanations';
+import { resolveXAxisField } from '@/components/inference/utils/resolveXAxisField';
 import {
   useInferenceActions,
   useInferenceData,
@@ -750,16 +751,22 @@ export default function ChartDisplay() {
               selectedDateRange.startDate && selectedDateRange.endDate && selectedGPUs.length > 0,
             );
             const replayAvailable = getViewMode(graphIndex) === 'chart' && !isTimelineMode;
-            // Which logical metric the x-axis plots right now. Classify off the
-            // ENGLISH title (like the caption heading) so /zh resolves the same
-            // branch, and mirror the caption's derived-mode/TTFT-override rules.
+            // Which logical metric the x-axis plots right now. Classify off
+            // the field `resolveXAxisField` resolves for this chart's current
+            // state — the same resolver both chart pipelines plot with — so
+            // the footer always matches the drawn axis (e.g. an input metric
+            // without a `*_x` override keeps the natural interactivity x).
+            // Trace-derived agentic modes bypass that resolver, hence the flag.
             const footerXAxisKind = resolveXAxisKind(graph.chartDefinition.chartType, {
-              isInputMetric: metricTitle(graph.chartDefinition, selectedYAxisMetric, 'en')
-                .toLowerCase()
-                .includes('input'),
-              isTtftOverride: Boolean(selectedE2eXAxisMetric?.endsWith('_ttft')),
-              isDerivedNormalizedInteractivity:
-                isAgenticSequence && Boolean(DERIVED_X_MODE_SPECS[selectedXAxisMode]),
+              xAxisField: resolveXAxisField(
+                graph.chartDefinition,
+                selectedYAxisMetric,
+                graph.chartDefinition.chartType === 'e2e'
+                  ? selectedE2eXAxisMetric
+                  : selectedXAxisMetric,
+                { isAgentic: isAgenticSequence, percentile: selectedPercentile },
+              ).xAxisField,
+              isDerivedNormalizedInteractivity: Boolean(derivedSpec),
             });
             return (
               <section key={graphIndex} className="pt-8 md:pt-0">

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -5,7 +5,8 @@ import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { BarChart3, Table2 } from 'lucide-react';
 
-import chartDefinitions from '@/components/inference/metric-registry';
+import chartDefinitions, { type MetricKey } from '@/components/inference/metric-registry';
+import { resolveXAxisKind } from '@/components/inference/axis-metric-explanations';
 import {
   useInferenceActions,
   useInferenceData,
@@ -72,6 +73,7 @@ import { getHardwareConfig, hardwareKeyMatchesAnyBase } from '@/lib/constants';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useLocale } from '@/lib/use-locale';
 
+import AxisMetricFooter from './AxisMetricFooter';
 import ChartControls from './ChartControls';
 import ComparisonChangelog from './ComparisonChangelog';
 import CustomCosts from './CustomCosts';
@@ -748,6 +750,17 @@ export default function ChartDisplay() {
               selectedDateRange.startDate && selectedDateRange.endDate && selectedGPUs.length > 0,
             );
             const replayAvailable = getViewMode(graphIndex) === 'chart' && !isTimelineMode;
+            // Which logical metric the x-axis plots right now. Classify off the
+            // ENGLISH title (like the caption heading) so /zh resolves the same
+            // branch, and mirror the caption's derived-mode/TTFT-override rules.
+            const footerXAxisKind = resolveXAxisKind(graph.chartDefinition.chartType, {
+              isInputMetric: metricTitle(graph.chartDefinition, selectedYAxisMetric, 'en')
+                .toLowerCase()
+                .includes('input'),
+              isTtftOverride: Boolean(selectedE2eXAxisMetric?.endsWith('_ttft')),
+              isDerivedNormalizedInteractivity:
+                isAgenticSequence && Boolean(DERIVED_X_MODE_SPECS[selectedXAxisMode]),
+            });
             return (
               <section key={graphIndex} className="pt-8 md:pt-0">
                 <figure data-testid="chart-figure" className="relative rounded-lg">
@@ -1013,6 +1026,12 @@ export default function ChartDisplay() {
                         </div>
                       );
                     })()}
+                    <AxisMetricFooter
+                      chartId={`chart-${graphIndex}`}
+                      metricKey={selectedYAxisMetric.replace(/^y_/u, '') as MetricKey}
+                      xAxisKind={footerXAxisKind}
+                      xAxisLabel={graph.chartDefinition.x_label}
+                    />
                     {replayAvailable && (
                       <ReplayLauncher
                         ref={(handle) => {


### PR DESCRIPTION
## Summary

- Adds an expandable axis-metric footer below every chart on the inference tab: one row for the current x-axis metric and one for the current y-axis metric.
- Each row shows an info icon + metric name with a `+` toggle (rotates 45° when open); expanding reveals a 1–3 sentence plain-language explanation of the metric.
- The y-axis row additionally renders the metric's structural formula in monospace (e.g. `tok/s/chip = total tokens per second ÷ number of chips serving the replica`), grounded in `buildDerivedChartFields` (`chart-utils.ts`), `docs/data-transforms.md`, and the glossary — no assumed constants restated.
- Bilingual: every explanation and formula ships `en` and `zh` strings; `/zh` resolves via the existing `useLocale` pattern. X-axis classification runs off the English title so both locales resolve the same branch.
- Covers all 48 `METRIC_REGISTRY` keys and 4 x-axis kinds (interactivity, E2E latency, TTFT percentiles, agentic E2E normalized interactivity); a unit test asserts completeness so adding a metric without an explanation fails CI.
- Accessible (`aria-expanded`/`aria-controls`, keyboard operable), `axis_metric_footer_toggled` PostHog event, and marked `no-export` so exported PNGs are unchanged.

## Validation

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- New focused unit tests: 72 passed (registry completeness, formula shape, x-axis kind branches, render/toggle/analytics/percentile/zh locale)
- `bun run test:unit`: 4,843 tests passed

## 中文说明

- 在 inference 标签页每张图表下方新增可展开的坐标轴指标页脚：X 轴指标一行、Y 轴指标一行。
- 每行左侧为信息图标和指标名称，右侧为 `+` 展开按钮（展开时旋转 45°）；展开后显示 1–3 句通俗易懂的指标说明。
- Y 轴行额外以等宽字体展示该指标的结构化计算公式（例如 `tok/s/chip = 每秒总 token 数 ÷ 服务该副本的芯片数`），公式依据 `buildDerivedChartFields`（`chart-utils.ts`）、`docs/data-transforms.md` 与术语表，不复述假定常量。
- 双语支持：所有说明与公式均提供 `en` 与 `zh` 字符串，`/zh` 页面通过现有 `useLocale` 模式解析；X 轴分类基于英文标题，确保两种语言解析到同一分支。
- 覆盖全部 48 个 `METRIC_REGISTRY` 指标与 4 种 X 轴类型（交互性、端到端延迟、TTFT 分位数、agentic 端到端归一化交互性）；单元测试断言完整性，新增指标若缺少说明将导致 CI 失败。
- 支持无障碍访问（`aria-expanded`/`aria-controls`、键盘可操作），带 `axis_metric_footer_toggled` PostHog 埋点，并标记 `no-export`，导出 PNG 不受影响。

## 验证

- `bun run fmt`、`bun run lint`、`bun run typecheck` 全部通过
- 新增针对性单元测试 72 个全部通过（注册表完整性、公式形态、X 轴分支、渲染/展开/埋点/分位数/中文语言环境）
- `bun run test:unit`：4,843 个测试全部通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer addition with tested copy and axis resolution; no changes to data fetching, auth, or chart computation paths beyond wiring the footer under existing charts.
> 
> **Overview**
> Inference charts now show an **expandable axis-metric footer** under each figure: one row for the plotted X-axis metric and one for the selected Y-axis metric, with plain-language copy and (for Y) a monospace structural formula.
> 
> **`axis-metric-explanations.ts`** centralizes bilingual (`en`/`zh`) descriptions and formulas for every `METRIC_REGISTRY` key plus four X-axis kinds (interactivity, E2E latency, TTFT, agentic E2E normalized interactivity). **`resolveXAxisKind`** classifies the footer’s X row from the same `resolveXAxisField` output (and agentic derived-mode flag) the chart uses so labels stay aligned with what is drawn.
> 
> **`AxisMetricFooter`** implements the collapsible UI (`aria-expanded`/`aria-controls`), locale via `useLocale`, PostHog `axis_metric_footer_toggled`, and `no-export` so PNG exports are unchanged. **`ChartDisplay`** passes `metricKey`, resolved `xAxisKind`, and `x_axis` label into the footer for each graph.
> 
> Unit tests assert registry/x-axis coverage, formula shape, resolver branches, and footer render/toggle/analytics/zh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d02294a8872be8a1fe412a555639988ea144da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->