### PR TITLE
fix: hide disagg power caveat on total tok/s/MW metric

### DIFF
--- a/packages/app/src/components/ui/chart-display-helpers.test.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.test.tsx
@@ -54,6 +54,30 @@ describe('MetricAssumptionNotes', () => {
     expect(getVisibleCaveatText()).toContain('calculate power per decode chip or per prefill chip');
   });
 
+  // Total tok/s/MW divides throughput per chip overall by per-chip power — the
+  // same denominator an aggregated config uses — so, like the total-token cost
+  // metrics, it keeps the power badges but must not carry the disagg caveat.
+  it('hides the disaggregation caveat for the total per-MW metric', () => {
+    renderUi(<MetricAssumptionNotes selectedYAxisMetric="y_tpPerMw" />);
+
+    expect(getVisibleText()).toContain('All in Power/Chip:');
+    expect(getVisibleText()).toContain('SemiAnalysis Datacenter Industry Model');
+    expect(getVisibleCaveatText()).not.toContain(
+      'calculate power per decode chip or per prefill chip',
+    );
+  });
+
+  it.each(['y_inputTputPerMw', 'y_outputTputPerMw'])(
+    'shows the disaggregation caveat for per-token-type per-MW metric %s',
+    (metric) => {
+      renderUi(<MetricAssumptionNotes selectedYAxisMetric={metric} />);
+
+      expect(getVisibleCaveatText()).toContain(
+        'calculate power per decode chip or per prefill chip',
+      );
+    },
+  );
+
   it('preserves historical-trends semantics when both compatibility flags are disabled', () => {
     renderUi(
       <MetricAssumptionNotes

--- a/packages/app/src/components/ui/chart-display-helpers.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.tsx
@@ -18,6 +18,12 @@ import type { Locale } from '@/lib/i18n';
 // Keep these metric-key groups in sync with chart-utils/chart configs when new source-backed
 // metrics are added; this helper owns which caption notes and caveats appear for each family.
 const POWER_SOURCE_METRICS = new Set(['y_tpPerMw', 'y_inputTputPerMw', 'y_outputTputPerMw']);
+// The disaggregation caveat only applies to the per-token-type per-MW metrics: a
+// disaggregated run reports input/output throughput per prefill or per decode chip,
+// so dividing by per-chip power inherits that skew. Total tok/s/MW divides
+// throughput per chip overall by the same per-chip power an aggregated config
+// uses, so it needs no caveat — the same split the cost caveats below make.
+const PER_TOKEN_TYPE_POWER_METRICS = new Set(['y_inputTputPerMw', 'y_outputTputPerMw']);
 const TOTAL_COST_METRICS = new Set([
   'y_costh',
   'y_costn',
@@ -299,7 +305,7 @@ export function MetricAssumptionNotes({
       />
       {includePowerThroughputCaveat && (
         <DisaggCaveat
-          visible={POWER_SOURCE_METRICS.has(selectedYAxisMetric)}
+          visible={PER_TOKEN_TYPE_POWER_METRICS.has(selectedYAxisMetric)}
           calculationNoun="power"
           locale={locale}
         />


### PR DESCRIPTION
## Problem

The disaggregation caveat below the inference charts —

> **Note:** Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) calculate power per decode chip or per prefill chip, rather than per total chip count. This makes direct power comparison with aggregated configs not an apples-to-apples comparison.

— was shown for all three per-MW metrics, including total `y_tpPerMw`.

## Why that's wrong

Total tok/s/MW is `tput_per_gpu × 1000 / hardwarePower`: throughput per chip **overall** divided by per-chip power — the same denominator an aggregated config uses, so the comparison is apples-to-apples and the caveat is misleading there. Only `input_tput_per_gpu` / `output_tput_per_gpu` are reported per prefill / per decode chip on a disaggregated run, so only the input/output per-MW metrics inherit the skew.

This matches the split the cost caveats already make (per-token-type cost metrics carry it; total-token cost metrics don't).

## Change

- `MetricAssumptionNotes`: power `DisaggCaveat` visibility narrowed from `POWER_SOURCE_METRICS` to a new `PER_TOKEN_TYPE_POWER_METRICS` set (`y_inputTputPerMw`, `y_outputTputPerMw`). Power/chip badges and source attribution are unchanged for `y_tpPerMw`.
- Tests: total per-MW metric keeps badges but must not carry the caveat; input/output per-MW metrics still do.

## Verification

- `vitest run chart-display-helpers.test.tsx` — 30/30 pass
- `oxlint`, `oxfmt`, `tsc --noEmit` — clean (pre-commit hook)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Caption-only change in chart assumption notes with no API, auth, or data-path impact; behavior is locked by unit tests.
> 
> **Overview**
> **Stops showing the disaggregated-inference power caveat** on the total per-MW chart metric (`y_tpPerMw`), while keeping it for input/output per-MW metrics.
> 
> `MetricAssumptionNotes` now gates the power `DisaggCaveat` on a new `PER_TOKEN_TYPE_POWER_METRICS` set (`y_inputTputPerMw`, `y_outputTputPerMw`) instead of all `POWER_SOURCE_METRICS`. **Power/chip badges and SemiAnalysis source attribution stay the same** for total tok/s/MW—only the misleading caveat is removed, matching how total-token cost metrics omit disagg notes but per-token-type cost metrics keep them.
> 
> Tests cover total per-MW (badges yes, caveat no) and parameterized input/output per-MW (caveat still shown).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 497abdca43d60584d663e720000f5b5b98480c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->