### PR TITLE
Add per-model SEO subroutes to /calculator and /historical / 为计算器与历史趋势页新增按模型划分的 SEO 子路由

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,19 @@ Chinese route map.
 Chart state survives navigation through the URL-state contract rather than a
 long-lived single-page tab tree. Each route mounts only the providers it consumes.
 
+### Per-Model Tab Routes
+
+`/calculator/<model>` and `/historical/<model>` (plus `/zh` siblings) give every
+dashboard model an indexable URL. `packages/app/src/lib/model-routes.ts` derives
+the slugs from the compare-page model registry (one slug vocabulary site-wide)
+and stays a thin layer on top of `dashboard-routes.ts`, whose prefix matching
+already resolves the child paths — it is not a second route registry.
+`GlobalFilterProvider` seeds the model from the pathname; switching models on
+the page rewrites the pathname with the pristine `History.prototype.replaceState`
+(same trick as `replaceClientSearch`), so the address bar tracks the model
+without an App Router navigation or remount. The bare tab paths remain the
+canonical home of the default model; alias slugs 308-redirect like `/compare`.
+
 ## URL State Persistence
 
 Chart filter state (model, sequence, metric, precisions, date range, GPU selections) is serialized to URL query params. This enables shareable links that reproduce exact chart views.

--- a/packages/app/cypress/e2e/model-route-slugs.cy.ts
+++ b/packages/app/cypress/e2e/model-route-slugs.cy.ts
@@ -1,0 +1,67 @@
+/**
+ * Per-model SEO routes: /historical/<model> and /calculator/<model> (and
+ * their /zh siblings) render the tab seeded to the routed model. Switching
+ * models on the page rewrites the pathname in place via history.replaceState
+ * — no full page reload and no App Router remount.
+ */
+const visitOptions = {
+  onBeforeLoad(win: Cypress.AUTWindow) {
+    win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+  },
+};
+
+type MarkerWindow = Cypress.AUTWindow & { __modelRouteNoReloadMarker?: boolean };
+
+const unlockPointerEvents = () => {
+  cy.document().then((doc) => {
+    delete doc.body.dataset.scrollLocked;
+    doc.body.style.removeProperty('pointer-events');
+  });
+};
+
+describe('Per-model dashboard routes', () => {
+  it('seeds /historical/<slug> to the routed model and rewrites the URL on switch without a reload', () => {
+    cy.visit('/historical/minimax-m3', visitOptions);
+    cy.get('[data-testid="historical-trends-display"]').should('be.visible');
+    cy.get('[data-testid="model-selector"]').should('contain.text', 'MiniMax');
+
+    // A full page load (or App Router remount via hard navigation) would wipe
+    // this marker; the in-place history.replaceState rewrite must keep it.
+    cy.window().then((win) => {
+      (win as MarkerWindow).__modelRouteNoReloadMarker = true;
+    });
+    unlockPointerEvents();
+    cy.get('[data-testid="model-selector"]').click();
+    cy.get('[role="option"]').not('[aria-selected="true"]').first().click();
+
+    cy.location('pathname').should('not.eq', '/historical/minimax-m3');
+    cy.location('pathname').should('match', /^\/historical\/[a-z0-9-]+$/u);
+    cy.window().its('__modelRouteNoReloadMarker').should('eq', true);
+  });
+
+  it('moves from the bare tab path to a slugged path when a non-default model is chosen', () => {
+    cy.visit('/historical', visitOptions);
+    cy.get('[data-testid="historical-trends-display"]').should('be.visible');
+    unlockPointerEvents();
+    cy.get('[data-testid="model-selector"]').click();
+    cy.get('[role="option"]').not('[aria-selected="true"]').first().click();
+    cy.location('pathname').should('match', /^\/historical\/[a-z0-9-]+$/u);
+  });
+
+  it('redirects alias slugs to the canonical model slug', () => {
+    cy.visit('/calculator/kimi', visitOptions);
+    cy.location('pathname').should('eq', '/calculator/kimi-k26');
+  });
+
+  it('returns 404 for unknown model slugs', () => {
+    cy.request({ url: '/historical/not-a-model', failOnStatusCode: false })
+      .its('status')
+      .should('eq', 404);
+  });
+
+  it('renders the /zh sibling with a model-specific Chinese intro', () => {
+    cy.visit('/zh/historical/minimax-m3', visitOptions);
+    cy.get('[data-testid="zh-tab-intro"]').should('be.visible').and('contain.text', 'MiniMax M3');
+    cy.get('[data-testid="historical-trends-display"]').should('be.visible');
+  });
+});

--- a/packages/app/cypress/e2e/model-route-slugs.cy.ts
+++ b/packages/app/cypress/e2e/model-route-slugs.cy.ts
@@ -48,9 +48,24 @@ describe('Per-model dashboard routes', () => {
     cy.location('pathname').should('match', /^\/historical\/[a-z0-9-]+$/u);
   });
 
-  it('redirects alias slugs to the canonical model slug', () => {
-    cy.visit('/calculator/kimi', visitOptions);
+  it('redirects alias slugs to the canonical model slug, keeping share-link params', () => {
+    cy.visit('/calculator/kimi?i_seq=8k%2F1k', visitOptions);
     cy.location('pathname').should('eq', '/calculator/kimi-k26');
+    cy.location('search').should('contain', 'i_seq=8k%2F1k');
+  });
+
+  it('language toggle follows the in-place rewritten per-model path', () => {
+    cy.visit('/historical/minimax-m3', visitOptions);
+    cy.get('[data-testid="historical-trends-display"]').should('be.visible');
+    unlockPointerEvents();
+    cy.get('[data-testid="model-selector"]').click();
+    cy.get('[role="option"]').not('[aria-selected="true"]').first().click();
+    cy.location('pathname')
+      .should('match', /^\/historical\/[a-z0-9-]+$/u)
+      .then((rewritten) => {
+        cy.get('[data-testid="language-toggle"]').click();
+        cy.location('pathname').should('eq', `/zh${rewritten}`);
+      });
   });
 
   it('returns 404 for unknown model slugs', () => {

--- a/packages/app/src/app/(dashboard)/calculator/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/calculator/[model]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 
 import ThroughputCalculatorDisplay from '@/components/calculator/ThroughputCalculatorDisplay';
 import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
-import { modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelRoutePath, pathWithSearchParams, resolveModelRouteSlug } from '@/lib/model-routes';
 import { modelTabMetadata } from '@/lib/tab-meta';
 
 /**
@@ -30,9 +30,11 @@ export default async function CalculatorModelPage({ params, searchParams }: Prop
   const [{ model }, sp] = await Promise.all([params, searchParams]);
   const resolved = resolveModelRouteSlug(model);
   if (!resolved) notFound();
-  // Aliases and non-canonical casing 308 to the canonical slug, mirroring
-  // /compare/[slug].
-  if (resolved.isAlias) permanentRedirect(modelRoutePath('calculator', resolved.route.slug));
+  // Aliases and non-canonical casing 308 to the canonical slug, keeping any
+  // share-link params, mirroring /compare/[slug].
+  if (resolved.isAlias) {
+    permanentRedirect(pathWithSearchParams(modelRoutePath('calculator', resolved.route.slug), sp));
+  }
   const seed = resolveCalculatorUrlSeed(sp);
   // A legacy explicit ?g_model= wins over the path — same precedence as
   // GlobalFilterProvider, which then canonicalizes the pathname client-side.

--- a/packages/app/src/app/(dashboard)/calculator/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/calculator/[model]/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import ThroughputCalculatorDisplay from '@/components/calculator/ThroughputCalculatorDisplay';
+import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
+import { modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelTabMetadata } from '@/lib/tab-meta';
+
+/**
+ * `/calculator/<model>` — the Throughput & TCO calculator seeded to a specific
+ * model, giving every model an indexable URL. Switching models in the UI
+ * rewrites the pathname in place via `history.replaceState` (no reload, no
+ * remount). No `generateStaticParams`: like the bare /calculator route this
+ * page reads searchParams, so it renders dynamically anyway.
+ */
+
+interface Props {
+  params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) return {};
+  return modelTabMetadata('calculator', resolved.route);
+}
+
+export default async function CalculatorModelPage({ params, searchParams }: Props) {
+  const [{ model }, sp] = await Promise.all([params, searchParams]);
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) notFound();
+  // Aliases and non-canonical casing 308 to the canonical slug, mirroring
+  // /compare/[slug].
+  if (resolved.isAlias) permanentRedirect(modelRoutePath('calculator', resolved.route.slug));
+  const seed = resolveCalculatorUrlSeed(sp);
+  // A legacy explicit ?g_model= wins over the path — same precedence as
+  // GlobalFilterProvider, which then canonicalizes the pathname client-side.
+  return (
+    <ThroughputCalculatorDisplay urlSeed={{ ...seed, model: seed.model ?? resolved.route.model }} />
+  );
+}

--- a/packages/app/src/app/(dashboard)/historical/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/historical/[model]/page.tsx
@@ -3,7 +3,12 @@ import { notFound, permanentRedirect } from 'next/navigation';
 
 import { InferenceProvider } from '@/components/inference/InferenceContext';
 import HistoricalTrendsDisplay from '@/components/trends/HistoricalTrendsDisplay';
-import { MODEL_ROUTES, modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import {
+  MODEL_ROUTES,
+  modelRoutePath,
+  pathWithSearchParams,
+  resolveModelRouteSlug,
+} from '@/lib/model-routes';
 import { modelTabMetadata } from '@/lib/tab-meta';
 
 /**
@@ -16,6 +21,7 @@ import { modelTabMetadata } from '@/lib/tab-meta';
 
 interface Props {
   params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams() {
@@ -29,13 +35,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return modelTabMetadata('historical', resolved.route);
 }
 
-export default async function HistoricalModelPage({ params }: Props) {
+export default async function HistoricalModelPage({ params, searchParams }: Props) {
   const { model } = await params;
   const resolved = resolveModelRouteSlug(model);
   if (!resolved) notFound();
-  // Aliases and non-canonical casing 308 to the canonical slug, mirroring
-  // /compare/[slug].
-  if (resolved.isAlias) permanentRedirect(modelRoutePath('historical', resolved.route.slug));
+  // Aliases and non-canonical casing 308 to the canonical slug, keeping any
+  // share-link params, mirroring /compare/[slug]. `searchParams` is awaited
+  // only on this branch so the canonical slugs stay statically generated.
+  if (resolved.isAlias) {
+    permanentRedirect(
+      pathWithSearchParams(modelRoutePath('historical', resolved.route.slug), await searchParams),
+    );
+  }
   return (
     <InferenceProvider activeTab="historical">
       <HistoricalTrendsDisplay />

--- a/packages/app/src/app/(dashboard)/historical/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/historical/[model]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import { InferenceProvider } from '@/components/inference/InferenceContext';
+import HistoricalTrendsDisplay from '@/components/trends/HistoricalTrendsDisplay';
+import { MODEL_ROUTES, modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelTabMetadata } from '@/lib/tab-meta';
+
+/**
+ * `/historical/<model>` — the Historical Trends tab seeded to a specific
+ * model, giving every model an indexable URL. `GlobalFilterProvider` (mounted
+ * by the dashboard shell) reads the model straight from the pathname, so the
+ * page body is identical to the bare tab; switching models in the UI rewrites
+ * the pathname in place via `history.replaceState` (no reload, no remount).
+ */
+
+interface Props {
+  params: Promise<{ model: string }>;
+}
+
+export function generateStaticParams() {
+  return MODEL_ROUTES.map((route) => ({ model: route.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) return {};
+  return modelTabMetadata('historical', resolved.route);
+}
+
+export default async function HistoricalModelPage({ params }: Props) {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) notFound();
+  // Aliases and non-canonical casing 308 to the canonical slug, mirroring
+  // /compare/[slug].
+  if (resolved.isAlias) permanentRedirect(modelRoutePath('historical', resolved.route.slug));
+  return (
+    <InferenceProvider activeTab="historical">
+      <HistoricalTrendsDisplay />
+    </InferenceProvider>
+  );
+}

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -17,6 +17,12 @@ import {
 } from '@/lib/compare-variant-slug';
 import { getAllGlossaryEntries } from '@/lib/glossary';
 import { languageAlternates, zhPath } from '@/lib/i18n';
+import {
+  DEFAULT_ROUTE_MODEL,
+  MODEL_ROUTE_TABS,
+  MODEL_ROUTES,
+  modelRoutePath,
+} from '@/lib/model-routes';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
 type SitemapEntry = MetadataRoute.Sitemap[number];
@@ -59,6 +65,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         changeFrequency: 'daily' as const,
         priority: route.canonicalPath === '/' ? 1 : 0.9,
       }),
+    ),
+    // Per-model tab routes (/calculator/<slug>, /historical/<slug>). The
+    // default model's pages canonicalize to the bare tab paths (already
+    // emitted above), so they stay out of the sitemap.
+    ...MODEL_ROUTE_TABS.flatMap((tab) =>
+      MODEL_ROUTES.filter((route) => route.model !== DEFAULT_ROUTE_MODEL).flatMap((route) =>
+        localizedPair(modelRoutePath(tab, route.slug), {
+          lastModified: now,
+          changeFrequency: 'daily' as const,
+          priority: 0.8,
+        }),
+      ),
     ),
     ...localizedPair('/overview', {
       lastModified: now,

--- a/packages/app/src/app/zh/(dashboard)/calculator/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/calculator/[model]/page.tsx
@@ -4,7 +4,7 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import ThroughputCalculatorDisplay from '@/components/calculator/ThroughputCalculatorDisplay';
 import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
 import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
-import { modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelRoutePath, pathWithSearchParams, resolveModelRouteSlug } from '@/lib/model-routes';
 import { modelTabCanonicalPath } from '@/lib/tab-meta';
 import { MODEL_TAB_META_ZH, modelTabMetadataZh } from '@/lib/tab-meta-zh';
 
@@ -31,8 +31,11 @@ export default async function ZhCalculatorModelPage({ params, searchParams }: Pr
   const [{ model }, sp] = await Promise.all([params, searchParams]);
   const resolved = resolveModelRouteSlug(model);
   if (!resolved) notFound();
+  // Keep share-link params through the 308.
   if (resolved.isAlias) {
-    permanentRedirect(`/zh${modelRoutePath('calculator', resolved.route.slug)}`);
+    permanentRedirect(
+      pathWithSearchParams(`/zh${modelRoutePath('calculator', resolved.route.slug)}`, sp),
+    );
   }
   const seed = resolveCalculatorUrlSeed(sp);
   const meta = MODEL_TAB_META_ZH.calculator;

--- a/packages/app/src/app/zh/(dashboard)/calculator/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/calculator/[model]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import ThroughputCalculatorDisplay from '@/components/calculator/ThroughputCalculatorDisplay';
+import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
+import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
+import { modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelTabCanonicalPath } from '@/lib/tab-meta';
+import { MODEL_TAB_META_ZH, modelTabMetadataZh } from '@/lib/tab-meta-zh';
+
+/** Chinese sibling of `/calculator/<model>` (see that page for the routing
+ *  and client-side model-switch behavior). */
+
+interface Props {
+  params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) return {};
+  return modelTabMetadataZh(
+    'calculator',
+    resolved.route,
+    modelTabCanonicalPath('calculator', resolved.route),
+  );
+}
+
+export default async function ZhCalculatorModelPage({ params, searchParams }: Props) {
+  const [{ model }, sp] = await Promise.all([params, searchParams]);
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) notFound();
+  if (resolved.isAlias) {
+    permanentRedirect(`/zh${modelRoutePath('calculator', resolved.route.slug)}`);
+  }
+  const seed = resolveCalculatorUrlSeed(sp);
+  const meta = MODEL_TAB_META_ZH.calculator;
+  return (
+    <>
+      <ZhTabIntro
+        tab="calculator"
+        title={meta.title(resolved.route.seoName)}
+        intro={meta.intro(resolved.route.seoName)}
+      />
+      <ThroughputCalculatorDisplay
+        urlSeed={{ ...seed, model: seed.model ?? resolved.route.model }}
+      />
+    </>
+  );
+}

--- a/packages/app/src/app/zh/(dashboard)/historical/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/historical/[model]/page.tsx
@@ -4,7 +4,12 @@ import { notFound, permanentRedirect } from 'next/navigation';
 import { InferenceProvider } from '@/components/inference/InferenceContext';
 import HistoricalTrendsDisplay from '@/components/trends/HistoricalTrendsDisplay';
 import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
-import { MODEL_ROUTES, modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import {
+  MODEL_ROUTES,
+  modelRoutePath,
+  pathWithSearchParams,
+  resolveModelRouteSlug,
+} from '@/lib/model-routes';
 import { modelTabCanonicalPath } from '@/lib/tab-meta';
 import { MODEL_TAB_META_ZH, modelTabMetadataZh } from '@/lib/tab-meta-zh';
 
@@ -13,6 +18,7 @@ import { MODEL_TAB_META_ZH, modelTabMetadataZh } from '@/lib/tab-meta-zh';
 
 interface Props {
   params: Promise<{ model: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams() {
@@ -30,12 +36,19 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   );
 }
 
-export default async function ZhHistoricalModelPage({ params }: Props) {
+export default async function ZhHistoricalModelPage({ params, searchParams }: Props) {
   const { model } = await params;
   const resolved = resolveModelRouteSlug(model);
   if (!resolved) notFound();
+  // Keep share-link params through the 308; awaited only on this branch so
+  // the canonical slugs stay statically generated.
   if (resolved.isAlias) {
-    permanentRedirect(`/zh${modelRoutePath('historical', resolved.route.slug)}`);
+    permanentRedirect(
+      pathWithSearchParams(
+        `/zh${modelRoutePath('historical', resolved.route.slug)}`,
+        await searchParams,
+      ),
+    );
   }
   const meta = MODEL_TAB_META_ZH.historical;
   return (

--- a/packages/app/src/app/zh/(dashboard)/historical/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/historical/[model]/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+
+import { InferenceProvider } from '@/components/inference/InferenceContext';
+import HistoricalTrendsDisplay from '@/components/trends/HistoricalTrendsDisplay';
+import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
+import { MODEL_ROUTES, modelRoutePath, resolveModelRouteSlug } from '@/lib/model-routes';
+import { modelTabCanonicalPath } from '@/lib/tab-meta';
+import { MODEL_TAB_META_ZH, modelTabMetadataZh } from '@/lib/tab-meta-zh';
+
+/** Chinese sibling of `/historical/<model>` (see that page for the routing
+ *  and client-side model-switch behavior). */
+
+interface Props {
+  params: Promise<{ model: string }>;
+}
+
+export function generateStaticParams() {
+  return MODEL_ROUTES.map((route) => ({ model: route.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) return {};
+  return modelTabMetadataZh(
+    'historical',
+    resolved.route,
+    modelTabCanonicalPath('historical', resolved.route),
+  );
+}
+
+export default async function ZhHistoricalModelPage({ params }: Props) {
+  const { model } = await params;
+  const resolved = resolveModelRouteSlug(model);
+  if (!resolved) notFound();
+  if (resolved.isAlias) {
+    permanentRedirect(`/zh${modelRoutePath('historical', resolved.route.slug)}`);
+  }
+  const meta = MODEL_TAB_META_ZH.historical;
+  return (
+    <>
+      <ZhTabIntro
+        tab="historical"
+        title={meta.title(resolved.route.seoName)}
+        intro={meta.intro(resolved.route.seoName)}
+      />
+      <InferenceProvider activeTab="historical">
+        <HistoricalTrendsDisplay />
+      </InferenceProvider>
+    </>
+  );
+}

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -27,6 +27,8 @@ import { useAvailability } from '@/hooks/api/use-availability';
 import { useWorkflowInfo } from '@/hooks/api/use-workflow-info';
 import { useUrlState } from '@/hooks/useUrlState';
 import { hasExplicitUrlParam, refreshUrlParams, type UrlStateParams } from '@/lib/url-state';
+import { modelRoutePathnameRewrite, routeModelForPathname } from '@/lib/model-routes';
+import { replaceClientPathname } from '@/lib/client-navigation';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import type { RunInfo } from '@/components/inference/types';
 import {
@@ -207,9 +209,17 @@ export function GlobalFilterProvider({
 }) {
   const { getUrlParam, setUrlParams } = useUrlState();
 
+  // Owned by the Next router. Seeds per-model routes below and keys the
+  // URL-param layout effect further down (see that effect for the full
+  // usePathname-vs-useSearchParams rationale).
+  const pathname = usePathname();
+
   // ── Core filter state ─────────────────────────────────────────────────────
+  // Per-model routes (/historical/<slug>) imply a model at first render so the
+  // server response and hydration already show the routed model — no client
+  // effect flicker. An explicit `initialModel` prop (calculator URL seed) wins.
   const [selectedModel, setSelectedModel] = useState<Model>(
-    () => initialModel ?? Model.DeepSeek_V4_Pro,
+    () => initialModel ?? routeModelForPathname(pathname) ?? Model.DeepSeek_V4_Pro,
   );
 
   const [selectedSequence, setSelectedSequenceRaw] = useState<Sequence>(() => {
@@ -284,9 +294,8 @@ export function GlobalFilterProvider({
   // statically-prerendered page that mounts this provider behind a Suspense
   // boundary, which fails the build on /ai-chart. Pathname changes on the
   // navigations that matter here — the AgentX cards and every share link live
-  // on a different route from /inference.
-  const pathname = usePathname();
-
+  // on a different route from /inference. (`pathname` itself is declared with
+  // the core filter state above, where it also seeds per-model routes.)
   useIsomorphicLayoutEffect(() => {
     // Pull the live URL into the shared snapshot first: `getUrlParam` below and
     // the auto-switch guard further down both read from it, and on a soft
@@ -309,6 +318,12 @@ export function GlobalFilterProvider({
       if (value !== undefined && pattern.test(value)) apply(value);
     };
 
+    // Per-model routes imply a model on soft navigation too (the useState
+    // seed above only covers the mount). Applied before `g_model` so explicit
+    // legacy ?g_model= links still win; the URL-sync effect below then
+    // canonicalizes the pathname to whatever model actually got applied.
+    const routeModel = routeModelForPathname(pathname);
+    if (routeModel) setSelectedModel(routeModel);
     applyIfEnum('g_model', Model, setSelectedModel);
     applyIfEnum('i_seq', Sequence, setSelectedSequence);
     const urlPrec = getUrlParam('i_prec');
@@ -555,6 +570,13 @@ export function GlobalFilterProvider({
       // leave it out so the link keeps following the per-model densest default.
       i_prec: precisionExplicit ? effectivePrecisions.join(',') : undefined,
     });
+    // Keep per-model pathnames (/calculator/<slug>, /historical/<slug>) in
+    // sync with the selected model — a plain history.replaceState, so switching
+    // models updates the address bar without an App Router navigation, RSC
+    // fetch, or component remount. Null when no rewrite is needed (bare tab
+    // path on the default model stays bare).
+    const pathnameRewrite = modelRoutePathnameRewrite(window.location.pathname, selectedModel);
+    if (pathnameRewrite) replaceClientPathname(pathnameRewrite);
   }, [
     selectedModel,
     requestedRunDate,

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -11,6 +11,7 @@ import { NewBadge } from '@/components/ui/new-badge';
 import { MinecraftToggles } from '@/components/minecraft/minecraft-toggles';
 import { navigateInApp } from '@/lib/client-navigation';
 import { DASHBOARD_ROUTES } from '@/lib/dashboard-routes';
+import { useClientPathname } from '@/hooks/useClientPathname';
 import { useClientSearch } from '@/hooks/useClientSearch';
 import { hasZhSibling, isZhPathname, switchLocalePath, ZH_PREFIX, zhPath } from '@/lib/i18n';
 import { NAV_LABELS_ZH, type HeaderNavHref } from '@/lib/tab-meta-zh';
@@ -108,12 +109,16 @@ function isCurrentPage(pathname: string, displayHref: string): boolean {
 
 /** EN ↔ 中文 switcher; maps the current page to its sibling in the other language. */
 function LanguageToggle({
-  pathname,
+  pathname: routerPathname,
   router,
 }: {
   pathname: string;
   router: ReturnType<typeof useRouter>;
 }) {
+  // The toggle maps the CURRENT address to its sibling, so it must see the
+  // live pathname — per-model dashboard routes rewrite the URL with
+  // replaceClientPathname on model switches, which usePathname ignores.
+  const pathname = useClientPathname(routerPathname);
   const isZh = isZhPathname(pathname);
   const target = switchLocalePath(pathname);
   const search = useClientSearch();

--- a/packages/app/src/components/zh/zh-tab-intro.tsx
+++ b/packages/app/src/components/zh/zh-tab-intro.tsx
@@ -7,11 +7,25 @@ import { TAB_INTRO_ZH, TAB_META_ZH } from '@/lib/tab-meta-zh';
  * pages. The charts below render in English; this block gives crawlers and
  * readers genuine Chinese content describing what the page shows.
  */
-export function ZhTabIntro({ tab }: { tab: DashboardRouteKey }) {
+export function ZhTabIntro({
+  tab,
+  title,
+  intro,
+}: {
+  tab: DashboardRouteKey;
+  /** Model-specific overrides used by the per-model routes
+   *  (/zh/historical/<slug>); the tab defaults apply when omitted. */
+  title?: string;
+  intro?: string;
+}) {
   return (
     <Card data-testid="zh-tab-intro">
-      <h1 className="text-xl lg:text-2xl font-bold tracking-tight">{TAB_META_ZH[tab].title}</h1>
-      <p className="mt-2 text-sm lg:text-base text-muted-foreground">{TAB_INTRO_ZH[tab]}</p>
+      <h1 className="text-xl lg:text-2xl font-bold tracking-tight">
+        {title ?? TAB_META_ZH[tab].title}
+      </h1>
+      <p className="mt-2 text-sm lg:text-base text-muted-foreground">
+        {intro ?? TAB_INTRO_ZH[tab]}
+      </p>
       <p className="mt-2 text-xs text-muted-foreground">
         图表中的模型、芯片、框架与指标名称均沿用业界通用英文名称。
       </p>

--- a/packages/app/src/hooks/useClientPathname.ts
+++ b/packages/app/src/hooks/useClientPathname.ts
@@ -2,7 +2,7 @@
 
 import { useSyncExternalStore } from 'react';
 
-import { CLIENT_PATHNAME_CHANGE_EVENT } from '@/lib/client-navigation';
+import { CLIENT_PATHNAME_CHANGE_EVENT, getClientPathnameOverride } from '@/lib/client-navigation';
 
 const subscribers = new Set<() => void>();
 let listening = false;
@@ -35,19 +35,22 @@ function subscribeClientPathname(subscriber: () => void): () => void {
 }
 
 /**
- * Live address-bar pathname. `usePathname` deliberately keeps the
- * server-rendered value after `replaceClientPathname` rewrites the URL for
- * per-model dashboard routes; controls that map the CURRENT address to a
- * destination (the header language toggle) read this instead. The router
- * pathname is the server snapshot, so SSR markup and hydration stay
- * consistent; on the client the snapshot re-reads `window.location.pathname`,
- * which App Router navigations, popstate, and `replaceClientPathname` all
- * keep current.
+ * The router pathname, corrected for in-place `replaceClientPathname`
+ * rewrites. `usePathname` deliberately keeps the server-rendered value after
+ * per-model dashboard routes rewrite the URL on a model switch; controls that
+ * map the CURRENT address to a destination (the header language toggle) read
+ * this instead. The override is honored only while the address bar still
+ * matches it, so App Router navigations (which update `routerPathname`) and
+ * popstate transitions retire it naturally — and environments where the
+ * browser URL is not the route (component tests) keep the router value.
  */
 export function useClientPathname(routerPathname: string): string {
   return useSyncExternalStore(
     subscribeClientPathname,
-    () => window.location.pathname,
+    () => {
+      const override = getClientPathnameOverride();
+      return override !== null && window.location.pathname === override ? override : routerPathname;
+    },
     () => routerPathname,
   );
 }

--- a/packages/app/src/hooks/useClientPathname.ts
+++ b/packages/app/src/hooks/useClientPathname.ts
@@ -1,0 +1,53 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+import { CLIENT_PATHNAME_CHANGE_EVENT } from '@/lib/client-navigation';
+
+const subscribers = new Set<() => void>();
+let listening = false;
+
+function emitPathnameChange(): void {
+  for (const subscriber of subscribers) subscriber();
+}
+
+function startListening(): void {
+  if (listening || typeof window === 'undefined') return;
+  window.addEventListener('popstate', emitPathnameChange);
+  window.addEventListener(CLIENT_PATHNAME_CHANGE_EVENT, emitPathnameChange);
+  listening = true;
+}
+
+function stopListening(): void {
+  if (!listening || subscribers.size > 0 || typeof window === 'undefined') return;
+  window.removeEventListener('popstate', emitPathnameChange);
+  window.removeEventListener(CLIENT_PATHNAME_CHANGE_EVENT, emitPathnameChange);
+  listening = false;
+}
+
+function subscribeClientPathname(subscriber: () => void): () => void {
+  subscribers.add(subscriber);
+  startListening();
+  return () => {
+    subscribers.delete(subscriber);
+    stopListening();
+  };
+}
+
+/**
+ * Live address-bar pathname. `usePathname` deliberately keeps the
+ * server-rendered value after `replaceClientPathname` rewrites the URL for
+ * per-model dashboard routes; controls that map the CURRENT address to a
+ * destination (the header language toggle) read this instead. The router
+ * pathname is the server snapshot, so SSR markup and hydration stay
+ * consistent; on the client the snapshot re-reads `window.location.pathname`,
+ * which App Router navigations, popstate, and `replaceClientPathname` all
+ * keep current.
+ */
+export function useClientPathname(routerPathname: string): string {
+  return useSyncExternalStore(
+    subscribeClientPathname,
+    () => window.location.pathname,
+    () => routerPathname,
+  );
+}

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -7,6 +7,7 @@ interface RouterLike {
 }
 
 export const CLIENT_SEARCH_CHANGE_EVENT = 'inferencex:client-search-change';
+export const CLIENT_PATHNAME_CHANGE_EVENT = 'inferencex:client-pathname-change';
 
 /** Keep persistent layout controls in sync when an App Router transition only
  *  changes search params and therefore reuses the root layout. */
@@ -34,11 +35,14 @@ export function replaceClientSearch(searchParams: URLSearchParams): void {
  * models rewrites `/historical/kimi-k3` in the address bar without an RSC
  * navigation or component remount. `usePathname` intentionally keeps the
  * server-rendered value; route resolution is prefix-based, so nav highlight,
- * providers, and share scopes are unaffected.
+ * providers, and share scopes are unaffected. Controls that must reflect the
+ * live address bar (the header language toggle) subscribe via
+ * `useClientPathname`, which listens for CLIENT_PATHNAME_CHANGE_EVENT.
  */
 export function replaceClientPathname(pathname: string): void {
   const href = `${pathname}${window.location.search}${window.location.hash}`;
   History.prototype.replaceState.call(window.history, window.history.state, '', href);
+  window.dispatchEvent(new CustomEvent(CLIENT_PATHNAME_CHANGE_EVENT, { detail: pathname }));
 }
 
 /**

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -42,7 +42,17 @@ export function replaceClientSearch(searchParams: URLSearchParams): void {
 export function replaceClientPathname(pathname: string): void {
   const href = `${pathname}${window.location.search}${window.location.hash}`;
   History.prototype.replaceState.call(window.history, window.history.state, '', href);
+  clientPathnameOverride = pathname;
   window.dispatchEvent(new CustomEvent(CLIENT_PATHNAME_CHANGE_EVENT, { detail: pathname }));
+}
+
+let clientPathnameOverride: string | null = null;
+
+/** The last pathname written by `replaceClientPathname`, or null. Consumers
+ *  (useClientPathname) honor it only while the address bar still matches, so
+ *  a later App Router navigation naturally retires a stale override. */
+export function getClientPathnameOverride(): string | null {
+  return clientPathnameOverride;
 }
 
 /**

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -28,6 +28,20 @@ export function replaceClientSearch(searchParams: URLSearchParams): void {
 }
 
 /**
+ * Replace only the current document's pathname (keeping search and hash)
+ * without involving the App Router — same pristine-prototype trick as
+ * `replaceClientSearch`. Used by per-model dashboard routes so switching
+ * models rewrites `/historical/kimi-k3` in the address bar without an RSC
+ * navigation or component remount. `usePathname` intentionally keeps the
+ * server-rendered value; route resolution is prefix-based, so nav highlight,
+ * providers, and share scopes are unaffected.
+ */
+export function replaceClientPathname(pathname: string): void {
+  const href = `${pathname}${window.location.search}${window.location.hash}`;
+  History.prototype.replaceState.call(window.history, window.history.state, '', href);
+}
+
+/**
  * The first dashboard transition can request the route without committing the
  * URL change. Repeating the same app-router push after the route payload has
  * been requested preserves same-document navigation and avoids a music restart.

--- a/packages/app/src/lib/model-routes.test.ts
+++ b/packages/app/src/lib/model-routes.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import { Model, MODEL_OPTIONS } from './data-mappings';
+import {
+  DEFAULT_ROUTE_MODEL,
+  MODEL_ROUTE_TABS,
+  MODEL_ROUTES,
+  modelRoutePath,
+  modelRoutePathnameRewrite,
+  modelRouteSlug,
+  parseModelRoutePathname,
+  resolveModelRouteSlug,
+  routeModelForPathname,
+} from './model-routes';
+import { PARAM_DEFAULTS } from './url-state';
+
+describe('MODEL_ROUTES registry', () => {
+  it('covers every visible model with a unique canonical slug', () => {
+    expect(MODEL_ROUTES.map((route) => route.model)).toEqual([...MODEL_OPTIONS]);
+    const slugs = MODEL_ROUTES.map((route) => route.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('uses lowercase hyphenated URL-safe slugs', () => {
+    for (const route of MODEL_ROUTES) {
+      expect(route.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/u);
+    }
+  });
+
+  it('keeps the default route model in lockstep with the g_model URL default', () => {
+    // The pathname rewrite treats a bare /calculator or /historical as
+    // DEFAULT_ROUTE_MODEL; if the app-wide default drifted, plain page loads
+    // would rewrite the URL.
+    expect(PARAM_DEFAULTS.g_model).toBe(DEFAULT_ROUTE_MODEL);
+  });
+});
+
+describe('resolveModelRouteSlug', () => {
+  it('resolves canonical slugs without flagging an alias', () => {
+    const resolved = resolveModelRouteSlug('kimi-k3');
+    expect(resolved?.route.model).toBe(Model.Kimi_K3);
+    expect(resolved?.isAlias).toBe(false);
+  });
+
+  it('resolves compare aliases and flags them for redirect', () => {
+    const resolved = resolveModelRouteSlug('kimi');
+    expect(resolved?.route.slug).toBe('kimi-k26');
+    expect(resolved?.isAlias).toBe(true);
+  });
+
+  it('is case-insensitive but flags non-canonical casing', () => {
+    const resolved = resolveModelRouteSlug('Kimi-K3');
+    expect(resolved?.route.slug).toBe('kimi-k3');
+    expect(resolved?.isAlias).toBe(true);
+  });
+
+  it('returns null for unknown slugs', () => {
+    expect(resolveModelRouteSlug('not-a-model')).toBeNull();
+  });
+});
+
+describe('parseModelRoutePathname', () => {
+  it('parses bare and slugged English tab paths', () => {
+    expect(parseModelRoutePathname('/calculator')).toEqual({
+      tab: 'calculator',
+      zh: false,
+      slug: null,
+    });
+    expect(parseModelRoutePathname('/historical/kimi-k3')).toEqual({
+      tab: 'historical',
+      zh: false,
+      slug: 'kimi-k3',
+    });
+  });
+
+  it('parses /zh siblings', () => {
+    expect(parseModelRoutePathname('/zh/calculator/deepseek-r1')).toEqual({
+      tab: 'calculator',
+      zh: true,
+      slug: 'deepseek-r1',
+    });
+    expect(parseModelRoutePathname('/zh/historical')).toEqual({
+      tab: 'historical',
+      zh: true,
+      slug: null,
+    });
+  });
+
+  it('rejects other routes and deeper paths', () => {
+    expect(parseModelRoutePathname('/')).toBeNull();
+    expect(parseModelRoutePathname('/inference')).toBeNull();
+    expect(parseModelRoutePathname('/compare/kimi-k3-b200-vs-mi355x')).toBeNull();
+    expect(parseModelRoutePathname('/historical/kimi-k3/extra')).toBeNull();
+    expect(parseModelRoutePathname('/calculatorx')).toBeNull();
+  });
+});
+
+describe('routeModelForPathname', () => {
+  it('maps slugged paths (including aliases) to models', () => {
+    expect(routeModelForPathname('/historical/kimi-k3')).toBe(Model.Kimi_K3);
+    expect(routeModelForPathname('/zh/calculator/deepseek-r1')).toBe(Model.DeepSeek_R1);
+    expect(routeModelForPathname('/calculator/glm')).toBe(Model.GLM_5);
+  });
+
+  it('returns null for bare tabs, unknown slugs, and non-model routes', () => {
+    expect(routeModelForPathname('/historical')).toBeNull();
+    expect(routeModelForPathname('/historical/not-a-model')).toBeNull();
+    expect(routeModelForPathname('/inference')).toBeNull();
+    expect(routeModelForPathname(null)).toBeNull();
+    expect(routeModelForPathname(undefined)).toBeNull();
+  });
+});
+
+describe('modelRoutePathnameRewrite', () => {
+  it('rewrites slugged paths when the model changes', () => {
+    expect(modelRoutePathnameRewrite('/historical/kimi-k3', Model.DeepSeek_R1)).toBe(
+      '/historical/deepseek-r1',
+    );
+    expect(modelRoutePathnameRewrite('/zh/calculator/kimi-k3', Model.MiniMax_M3)).toBe(
+      '/zh/calculator/minimax-m3',
+    );
+  });
+
+  it('rewrites bare paths only for non-default models', () => {
+    expect(modelRoutePathnameRewrite('/calculator', DEFAULT_ROUTE_MODEL)).toBeNull();
+    expect(modelRoutePathnameRewrite('/calculator', Model.Kimi_K3)).toBe('/calculator/kimi-k3');
+    expect(modelRoutePathnameRewrite('/zh/historical', Model.Kimi_K3)).toBe(
+      '/zh/historical/kimi-k3',
+    );
+  });
+
+  it('keeps the slugged path when switching to the default model', () => {
+    expect(modelRoutePathnameRewrite('/historical/kimi-k3', DEFAULT_ROUTE_MODEL)).toBe(
+      `/historical/${modelRouteSlug(DEFAULT_ROUTE_MODEL)}`,
+    );
+  });
+
+  it('returns null when the path already matches', () => {
+    expect(modelRoutePathnameRewrite('/historical/kimi-k3', Model.Kimi_K3)).toBeNull();
+  });
+
+  it('never rewrites non-model routes or unknown slugs', () => {
+    expect(modelRoutePathnameRewrite('/inference', Model.Kimi_K3)).toBeNull();
+    expect(modelRoutePathnameRewrite('/', Model.Kimi_K3)).toBeNull();
+    expect(modelRoutePathnameRewrite('/historical/not-a-model', Model.Kimi_K3)).toBeNull();
+  });
+});
+
+describe('modelRoutePath', () => {
+  it('builds canonical English paths for both tabs', () => {
+    for (const tab of MODEL_ROUTE_TABS) {
+      expect(modelRoutePath(tab, 'kimi-k3')).toBe(`/${tab}/kimi-k3`);
+    }
+  });
+});

--- a/packages/app/src/lib/model-routes.test.ts
+++ b/packages/app/src/lib/model-routes.test.ts
@@ -7,6 +7,7 @@ import {
   MODEL_ROUTES,
   modelRoutePath,
   modelRoutePathnameRewrite,
+  pathWithSearchParams,
   modelRouteSlug,
   parseModelRoutePathname,
   resolveModelRouteSlug,
@@ -151,5 +152,21 @@ describe('modelRoutePath', () => {
     for (const tab of MODEL_ROUTE_TABS) {
       expect(modelRoutePath(tab, 'kimi-k3')).toBe(`/${tab}/kimi-k3`);
     }
+  });
+});
+
+describe('pathWithSearchParams', () => {
+  it('returns the bare path when there are no params', () => {
+    expect(pathWithSearchParams('/calculator/kimi-k26', {})).toBe('/calculator/kimi-k26');
+  });
+
+  it('keeps share-link params, including repeated keys and reserved characters', () => {
+    expect(
+      pathWithSearchParams('/calculator/kimi-k26', {
+        i_seq: '8k/1k',
+        unofficialruns: ['a', 'b'],
+        missing: undefined,
+      }),
+    ).toBe('/calculator/kimi-k26?i_seq=8k%2F1k&unofficialruns=a&unofficialruns=b');
   });
 });

--- a/packages/app/src/lib/model-routes.ts
+++ b/packages/app/src/lib/model-routes.ts
@@ -1,0 +1,170 @@
+import {
+  COMPARE_MODEL_ALIASES,
+  COMPARE_MODEL_SLUGS,
+  type CompareModelSlug,
+} from '@/lib/compare-slug';
+import { Model, MODEL_OPTIONS } from '@/lib/data-mappings';
+
+// ---------------------------------------------------------------------------
+// Per-model dashboard routes: /calculator/<model> and /historical/<model>
+// ---------------------------------------------------------------------------
+//
+// The bare /calculator and /historical tabs render the DEFAULT model; the
+// `[model]` child routes render the same page seeded to a specific model so
+// every model gets its own indexable URL (title, description, canonical, and
+// hreflang all model-specific). Slugs deliberately REUSE the compare-page
+// model registry (`COMPARE_MODEL_SLUGS`) so `kimi-k3` means the same model in
+// `/compare/kimi-k3-b200-vs-mi355x`, `/calculator/kimi-k3`, and
+// `/historical/kimi-k3` — one slug vocabulary across the whole site.
+//
+// Unlike compare (whose slugs are finer-grained than the display dropdown,
+// e.g. distinct kimi-k25/k26 DB buckets), these routes address the dashboard's
+// display-grouped model selector, so exactly one canonical slug exists per
+// visible `Model` option. Aliases (`kimi`, `glm-5`, …) 308-redirect to the
+// canonical slug, mirroring compare behavior.
+
+/** Dashboard tabs that expose per-model child routes. */
+export const MODEL_ROUTE_TABS = ['calculator', 'historical'] as const;
+export type ModelRouteTab = (typeof MODEL_ROUTE_TABS)[number];
+
+const MODEL_ROUTE_TAB_PATHS: Record<ModelRouteTab, `/${string}`> = {
+  calculator: '/calculator',
+  historical: '/historical',
+};
+
+/**
+ * Model the bare tab route renders when no slug (and no `?g_model=`) is
+ * present. Must stay in lockstep with `PARAM_DEFAULTS.g_model` in
+ * `url-state.ts` and the `GlobalFilterProvider` initializer — the pathname
+ * rewrite below treats a bare path as this model, so drift would rewrite the
+ * URL on plain page loads. `model-routes.test.ts` pins the invariant.
+ */
+export const DEFAULT_ROUTE_MODEL: Model = Model.DeepSeek_V4_Pro;
+
+export interface ModelRoute {
+  /** Canonical URL segment, e.g. 'kimi-k3'. Lowercase, hyphen-separated. */
+  slug: string;
+  /** Display-grouped dashboard model this route seeds. */
+  model: Model;
+  /** Natural model name for SEO titles/descriptions, e.g. 'Kimi K3'. */
+  seoName: string;
+  /** Human label for headers, e.g. 'Kimi K3 2.8T'. */
+  label: string;
+}
+
+function compareEntryForModel(model: Model): CompareModelSlug | undefined {
+  return COMPARE_MODEL_SLUGS.find((entry) => entry.displayName === model);
+}
+
+/**
+ * One route per visible dashboard model. Derived (not hand-copied) from the
+ * compare registry so a new model added there automatically gets calculator
+ * and historical routes; the test suite fails if a `MODEL_OPTIONS` entry has
+ * no compare slug to derive from.
+ */
+export const MODEL_ROUTES: ModelRoute[] = MODEL_OPTIONS.flatMap((model) => {
+  const entry = compareEntryForModel(model);
+  if (!entry) return [];
+  return [{ slug: entry.slug, model, seoName: entry.seoName, label: entry.label }];
+});
+
+const ROUTE_BY_SLUG: ReadonlyMap<string, ModelRoute> = new Map(
+  MODEL_ROUTES.map((route) => [route.slug, route]),
+);
+const ROUTE_BY_MODEL: ReadonlyMap<Model, ModelRoute> = new Map(
+  MODEL_ROUTES.map((route) => [route.model, route]),
+);
+
+export interface ResolvedModelRoute {
+  route: ModelRoute;
+  /** True when the input was an alias or non-canonical casing — caller should
+   *  308 to the canonical slug. */
+  isAlias: boolean;
+}
+
+/** Resolve a URL segment (canonical slug, alias, or mixed case) to a model
+ *  route. Returns null for unknown slugs. */
+export function resolveModelRouteSlug(slug: string): ResolvedModelRoute | null {
+  const lower = slug.toLowerCase();
+  const canonical = COMPARE_MODEL_ALIASES[lower] ?? lower;
+  const route = ROUTE_BY_SLUG.get(canonical);
+  if (!route) return null;
+  return { route, isAlias: canonical !== slug };
+}
+
+/** Canonical slug for a model, or null for models without a route (hidden). */
+export function modelRouteSlug(model: Model): string | null {
+  return ROUTE_BY_MODEL.get(model)?.slug ?? null;
+}
+
+/** Canonical English path for a per-model tab page, e.g. '/historical/kimi-k3'. */
+export function modelRoutePath(tab: ModelRouteTab, slug: string): string {
+  return `${MODEL_ROUTE_TAB_PATHS[tab]}/${slug}`;
+}
+
+export interface ParsedModelRoutePathname {
+  tab: ModelRouteTab;
+  /** True for /zh-prefixed pathnames. */
+  zh: boolean;
+  /** URL segment after the tab path, or null on the bare tab route. */
+  slug: string | null;
+}
+
+/**
+ * Parse an English or /zh pathname into its model-routed tab, if any.
+ * `/calculator` → slug null; `/zh/historical/kimi-k3` → slug 'kimi-k3';
+ * anything else (other tabs, deeper children) → null.
+ */
+export function parseModelRoutePathname(pathname: string): ParsedModelRoutePathname | null {
+  const barePath = pathname.split(/[?#]/u, 1)[0] || '/';
+  const zh = barePath === '/zh' || barePath.startsWith('/zh/');
+  const enPath = zh ? barePath.slice('/zh'.length) || '/' : barePath;
+  for (const tab of MODEL_ROUTE_TABS) {
+    const tabPath = MODEL_ROUTE_TAB_PATHS[tab];
+    if (enPath === tabPath) return { tab, zh, slug: null };
+    if (enPath.startsWith(`${tabPath}/`)) {
+      const rest = enPath.slice(tabPath.length + 1);
+      if (!rest || rest.includes('/')) return null;
+      return { tab, zh, slug: rest };
+    }
+  }
+  return null;
+}
+
+/**
+ * Model implied by a model-routed pathname, or null when the pathname is not
+ * a model-routed page or carries no (known) slug. Used to seed
+ * `GlobalFilterProvider` so `/historical/kimi-k3` server-renders and hydrates
+ * on Kimi K3 without waiting for a client effect.
+ */
+export function routeModelForPathname(pathname: string | null | undefined): Model | null {
+  if (!pathname) return null;
+  const parsed = parseModelRoutePathname(pathname);
+  if (!parsed?.slug) return null;
+  return resolveModelRouteSlug(parsed.slug)?.route.model ?? null;
+}
+
+/**
+ * Pathname the address bar should show for `model` while on a model-routed
+ * page, or null when no rewrite is needed. Pure so the model-switch URL
+ * behavior is unit-testable; the caller performs the actual
+ * `history.replaceState`.
+ *
+ * Rules:
+ * - Non-model-routed pages, unknown slugs, and slug-less models → null.
+ * - Bare tab path showing the default model → stays bare (plain page loads
+ *   must not rewrite the URL).
+ * - Any other mismatch (model switched, alias slug, legacy `?g_model=` link
+ *   resolved by the provider) → the canonical slugged path.
+ */
+export function modelRoutePathnameRewrite(pathname: string, model: Model): string | null {
+  const parsed = parseModelRoutePathname(pathname);
+  if (!parsed) return null;
+  if (parsed.slug && !resolveModelRouteSlug(parsed.slug)) return null;
+  const slug = modelRouteSlug(model);
+  if (!slug) return null;
+  if (parsed.slug === slug) return null;
+  if (!parsed.slug && model === DEFAULT_ROUTE_MODEL) return null;
+  const enPath = modelRoutePath(parsed.tab, slug);
+  return parsed.zh ? `/zh${enPath}` : enPath;
+}

--- a/packages/app/src/lib/model-routes.ts
+++ b/packages/app/src/lib/model-routes.ts
@@ -102,6 +102,24 @@ export function modelRoutePath(tab: ModelRouteTab, slug: string): string {
   return `${MODEL_ROUTE_TAB_PATHS[tab]}/${slug}`;
 }
 
+/**
+ * Reattach incoming search params when 308ing an alias slug to its canonical
+ * path, so share-link state (g_rundate, i_seq, c_price, unofficialruns, …)
+ * survives the redirect.
+ */
+export function pathWithSearchParams(
+  path: string,
+  sp: Record<string, string | string[] | undefined>,
+): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(sp)) {
+    if (typeof value === 'string') params.append(key, value);
+    else if (Array.isArray(value)) for (const item of value) params.append(key, item);
+  }
+  const search = params.toString();
+  return search ? `${path}?${search}` : path;
+}
+
 export interface ParsedModelRoutePathname {
   tab: ModelRouteTab;
   /** True for /zh-prefixed pathnames. */

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 import { ZH_OG_LOCALE, zhAlternates, zhPath } from '@/lib/i18n';
+import type { ModelRoute, ModelRouteTab } from '@/lib/model-routes';
 import {
   getDashboardRoute,
   isDashboardRouteKey,
@@ -143,6 +144,61 @@ export const NAV_LABELS_ZH: Record<HeaderNavHref, string> = {
 };
 
 const TITLE_SUFFIX = `${SITE_NAME} by ${AUTHOR_NAME}`;
+
+/** Chinese copy for the per-model tab routes (/zh/calculator/<slug>,
+ *  /zh/historical/<slug>). Model names stay in English per site convention. */
+export const MODEL_TAB_META_ZH: Record<
+  ModelRouteTab,
+  {
+    title: (seoName: string) => string;
+    description: (seoName: string) => string;
+    intro: (seoName: string) => string;
+  }
+> = {
+  historical: {
+    title: (seoName) => `${seoName} 历史推理性能趋势`,
+    description: (seoName) =>
+      `跟踪 ${seoName} 推理性能随时间的变化。历史基准测试数据展示各芯片与服务商运行 ${seoName} 时在延迟、吞吐量和成本上的改进。`,
+    intro: (seoName) =>
+      `本页面展示 ${seoName} 的历史趋势图表：跟踪各芯片与框架运行 ${seoName} 时推理性能随时间的演进，量化软件栈优化带来的收益。`,
+  },
+  calculator: {
+    title: (seoName) => `${seoName} 吞吐量与 TCO 计算器`,
+    description: (seoName) =>
+      `计算 ${seoName} 推理的吞吐量与总拥有成本（TCO）。跨硬件配置对比 ${seoName} 推理服务的芯片成本效益。`,
+    intro: (seoName) =>
+      `本页面提供 ${seoName} 吞吐量与总拥有成本（TCO）计算器：基于真实基准测试数据，估算不同芯片配置下 ${seoName} 推理服务的每百万 token 成本与性价比。`,
+  },
+};
+
+/** Generate Next.js Metadata for a per-model /zh tab page. Canonical (and
+ *  hreflang) mirror the English rule in `modelTabCanonicalPath`: the default
+ *  model's page points at the bare tab path, others are self-canonical. */
+export function modelTabMetadataZh(
+  tab: ModelRouteTab,
+  route: ModelRoute,
+  canonicalEnPath: string,
+): Metadata {
+  const meta = MODEL_TAB_META_ZH[tab];
+  const title = meta.title(route.seoName);
+  const description = meta.description(route.seoName);
+  const url = `${SITE_URL}${zhPath(canonicalEnPath)}`;
+  return {
+    title,
+    description,
+    alternates: zhAlternates(canonicalEnPath),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      locale: ZH_OG_LOCALE,
+    },
+    twitter: {
+      title: `${title} | ${TITLE_SUFFIX}`,
+      description,
+    },
+  };
+}
 
 /** Generate Next.js Metadata for a /zh tab page (mirrors `tabMetadata`). */
 export function tabMetadataZh(tab: DashboardRouteKey): Metadata {

--- a/packages/app/src/lib/tab-meta.ts
+++ b/packages/app/src/lib/tab-meta.ts
@@ -7,6 +7,12 @@ import {
   type DashboardRouteKey,
 } from '@/lib/dashboard-routes';
 import { languageAlternates } from '@/lib/i18n';
+import {
+  DEFAULT_ROUTE_MODEL,
+  modelRoutePath,
+  type ModelRoute,
+  type ModelRouteTab,
+} from '@/lib/model-routes';
 
 export const LANDING_META = {
   title: 'Open-Source Agentic Inference Benchmark',
@@ -83,6 +89,63 @@ export const isValidTab = isDashboardRouteKey;
 export function getTabTitle(tab: string): string {
   const meta = isDashboardRouteKey(tab) ? TAB_META[tab] : undefined;
   return meta ? `${meta.title} | ${TITLE_SUFFIX}` : TITLE_SUFFIX;
+}
+
+/** Model-specific copy for the per-model tab routes (/calculator/<slug>,
+ *  /historical/<slug>). Same shape as TAB_META but parameterized on the
+ *  model's SEO name. */
+export const MODEL_TAB_META: Record<
+  ModelRouteTab,
+  { title: (seoName: string) => string; description: (seoName: string) => string }
+> = {
+  historical: {
+    title: (seoName) => `${seoName} Historical Inference Trends`,
+    description: (seoName) =>
+      `Track ${seoName} inference performance over time. Historical benchmark data showing chip and provider improvements in latency, throughput, and cost for ${seoName}.`,
+  },
+  calculator: {
+    title: (seoName) => `${seoName} Throughput & TCO Calculator`,
+    description: (seoName) =>
+      `Calculate ${seoName} inference throughput and total cost of ownership. Compare chip cost-efficiency for serving ${seoName} across hardware configurations.`,
+  },
+};
+
+/**
+ * English path a per-model tab page canonicalizes to. The default model's
+ * page shows exactly what the bare tab route shows, so it canonicalizes to
+ * the bare path instead of competing with it; every other model is
+ * self-canonical.
+ */
+export function modelTabCanonicalPath(tab: ModelRouteTab, route: ModelRoute): string {
+  return route.model === DEFAULT_ROUTE_MODEL
+    ? getDashboardRoute(tab).canonicalPath
+    : modelRoutePath(tab, route.slug);
+}
+
+/** Generate Next.js Metadata for a per-model tab page. */
+export function modelTabMetadata(tab: ModelRouteTab, route: ModelRoute): Metadata {
+  const meta = MODEL_TAB_META[tab];
+  const title = meta.title(route.seoName);
+  const description = meta.description(route.seoName);
+  const enPath = modelTabCanonicalPath(tab, route);
+  const url = `${SITE_URL}${enPath}`;
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+      languages: languageAlternates(enPath),
+    },
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+    },
+    twitter: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+    },
+  };
 }
 
 /** Generate Next.js Metadata for a tab page. */

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -13,6 +13,7 @@
  * Only non-default values are written to keep URLs short.
  */
 import { dashboardRouteForPathname, getDashboardRoute } from '@/lib/dashboard-routes';
+import { routeModelForPathname } from '@/lib/model-routes';
 
 // All known share-link parameter keys
 const URL_STATE_KEYS = [
@@ -357,6 +358,14 @@ function collectTabParams(): URLSearchParams {
     if (prefixes.some((p) => key.startsWith(p))) {
       filtered.set(key, value);
     }
+  }
+
+  // On per-model routes (/calculator/<slug>, /historical/<slug>) the pathname
+  // already encodes the model, so a matching g_model would be redundant in the
+  // share link. A mismatch (possible mid-transition) is kept — explicit
+  // g_model wins over the path on load, so the link still opens correctly.
+  if (routeModelForPathname(window.location.pathname) === filtered.get('g_model')) {
+    filtered.delete('g_model');
   }
 
   // Carry over any unofficial-run IDs currently reflected in the address bar.

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -165,6 +165,10 @@
       "duration": 4570
     },
     {
+      "spec": "cypress/e2e/model-route-slugs.cy.ts",
+      "duration": 2000
+    },
+    {
       "spec": "cypress/e2e/navigation.cy.ts",
       "duration": 3442
     },


### PR DESCRIPTION
## Summary

Adds per-model SEO subroutes for the calculator and historical tabs, per request: every dashboard model gets an indexable URL, and switching models on the page updates the route in place without a full page refresh.

**New routes**

- `/calculator/<model>` and `/historical/<model>`, plus mandatory `/zh` siblings (e.g. `/historical/kimi-k3`, `/zh/calculator/minimax-m3`)
- Slugs reuse the compare-page model registry (`COMPARE_MODEL_SLUGS`) via a new thin `lib/model-routes.ts` — one slug vocabulary site-wide, and `dashboard-routes.ts` prefix matching already resolves the child paths, so this is not a second route registry
- Aliases and non-canonical casing 308-redirect to the canonical slug, mirroring `/compare/[slug]`; unknown slugs 404
- `/historical/[model]` pages are SSG via `generateStaticParams`; calculator stays dynamic (it reads `searchParams` like the bare route)

**SEO**

- Model-specific `<title>`, meta description, OpenGraph/Twitter, canonical, and en/zh-CN/x-default hreflang on all four page families
- The default model's pages canonicalize to the bare tab paths (which remain the canonical home of the default view), avoiding duplicate content; all other model pages are self-canonical and emitted in the sitemap as en+zh pairs
- `/zh` pages render a model-specific Chinese H1 + intro via `ZhTabIntro` overrides

**Client-side model switch (no reload)**

- `GlobalFilterProvider` seeds the selected model from the pathname (SSR + hydration consistent), and its URL-sync effect rewrites the pathname via the pristine `History.prototype.replaceState` — the same established pattern as `replaceClientSearch` — so no App Router navigation, RSC fetch, or remount occurs
- Legacy `?g_model=` links still win on load, then the path canonicalizes; share links omit `g_model` when the pathname already encodes it
- Overlay/unofficial-run behavior is unchanged: the rewrite preserves search + hash, and `dashboardShellCapabilitiesForPathname` resolves child paths by prefix, so providers and share scopes are identical to the bare tabs

**Tests**

- `lib/model-routes.test.ts`: registry coverage/uniqueness, slug parsing (zh prefix, aliases, casing), rewrite rules, and a lockstep guard between `DEFAULT_ROUTE_MODEL` and `PARAM_DEFAULTS.g_model`
- New Cypress spec `model-route-slugs.cy.ts`: routed model seeding, URL rewrite on switch with a window marker proving no reload, bare→slugged transition, alias 308, unknown-slug 404, and the zh sibling's model-specific intro
- Verified locally: `typecheck`, `lint`, `fmt`, full `test:unit` (4124 passing), the new spec (5/5), and regression specs `historical-trends` / `zh-pages` / `dropdown-switching` (39/39) against an `E2E_FIXTURES=1` production build; also manually verified canonicals, hreflang pairs, 308/404 behavior, and sitemap output on the running build

## 中文说明

按需求为计算器与历史趋势标签页新增按模型划分的 SEO 子路由：每个模型都有可被索引的 URL，页面内切换模型时就地更新路由，不触发整页刷新。

- 新增 `/calculator/<model>` 与 `/historical/<model>`，以及必备的 `/zh` 镜像页；slug 复用 compare 页面的模型注册表，全站保持同一套 slug 词汇
- 别名与非规范大小写 308 重定向到规范 slug（与 `/compare/[slug]` 一致）；未知 slug 返回 404
- 每个模型页面均有专属标题、描述、canonical、hreflang 与 sitemap 条目；默认模型页面 canonical 指向裸路径以避免重复内容；`/zh` 页面渲染模型专属的中文 H1 与简介
- 模型切换通过原生 `History.prototype.replaceState` 就地改写路径（与 `replaceClientSearch` 相同的既有模式），不触发 App Router 导航或组件重新挂载；旧版 `?g_model=` 链接加载时仍优先生效，随后路径自动规范化
- 新增单元测试 `model-routes.test.ts` 与端到端测试 `model-route-slugs.cy.ts`；本地已通过 typecheck、lint、fmt、全量单元测试与相关回归 e2e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global filter initialization, URL/share-link serialization, and client-side history overrides alongside many new routes, but behavior is heavily tested and mirrors an existing client-navigation pattern rather than changing auth or data APIs.
> 
> **Overview**
> Adds **indexable per-model URLs** for the calculator and historical dashboard tabs: `/calculator/<slug>` and `/historical/<slug>` (plus `/zh` siblings), driven by a new `model-routes` layer that reuses compare-page slugs and aliases with **308 redirects** to canonical slugs and **404** for unknown models.
> 
> **SEO & routing:** Model-specific metadata, canonical rules (default model pages point at bare tab paths), sitemap entries for non-default models, and model-specific Chinese intros on `/zh` pages. Historical `[model]` pages are statically generated; calculator stays dynamic like the bare route.
> 
> **In-place model switching:** `GlobalFilterProvider` seeds the model from the pathname on SSR/hydration and soft navigation; when the selection changes it rewrites the address bar via `replaceClientPathname` (same pristine `History.prototype.replaceState` pattern as query-string updates) so there is no App Router remount. Share URLs drop redundant `g_model` when the path already encodes the model; the header language toggle uses `useClientPathname` so locale switching follows client-rewritten paths.
> 
> Coverage includes `model-routes` unit tests and a new Cypress spec for seeding, no-reload rewrites, alias redirects, 404s, and zh behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ddd0848dcbccbfc57c9749936199fa5fcef18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->