### PR TITLE
Port the OpenAI Jalapeño article to the blog / 将 OpenAI Jalapeño 文章移植到博客

### DIFF
--- a/packages/app/content/blog/openai-jalapeno-better-than-nvidia.mdx
+++ b/packages/app/content/blog/openai-jalapeno-better-than-nvidia.mdx
@@ -1,0 +1,383 @@
+---
+title: 'OpenAI Jalapeño: Better Than Nvidia Blackwell'
+subtitle: 'OpenAI’s self-designed ASIC compared with Rubin, Jalapeño’s TCO, throughput per MW, and spicy deets'
+seoDescription: 'OpenAI’s first-generation inference ASIC, built with Broadcom and benchmarked on InferenceX. Perf per MW against Blackwell and Vera Rubin, the HBM4 and MXFP4 specs, the Gluon software stack, why OpenAI skipped prefill-decode disaggregation, and the Katsu, Vindaloo, and Chana rack architecture.'
+date: '2026-08-25'
+publishDate: '2026-08-25'
+tags:
+  - inference
+  - benchmark
+  - gpu
+  - nvidia
+  - openai
+  - asic
+  - rubin
+---
+
+OpenAI has spent the past couple years quietly building “Jalapeño,” an inference chip just announced at Hot Chips. Rumors of a successful tapeout had been swirling for a while. But now we have details. OpenAI invited us to look at their chip, go to their labs to check out how real it is, and [benchmark](https://openai.com/index/jalapeno-first-results/) it with our [InferenceX](https://inferencex.semianalysis.com/) suite.
+
+In June, [OpenAI unveiled the chip program](https://openai.com/index/openai-broadcom-jalapeno-inference-chip/) in partnership with Broadcom, built from a blank slate exclusively for LLM inference. [Design work began in the middle of 2024](https://newsletter.semianalysis.com/p/openai-chip-team-is-now-serious), going from initial team hiring to manufacturing tape-out in ~16 months, an extremely fast ASIC development cycle.
+
+In general first generation chips are not competitive, but OpenAI bucks the trend by being industry leading and beating every Nvidia, AMD, and Google chip we have been able to test on multiple top open source models. OpenAI does this with extreme hardware software codesign. Surprisingly, OpenAI is not over specialization on any specific part of model inference, but instead by focusing on being a general chip that delivers high performance in all scenarios.
+
+In this article, we will go into architectural details, software details and performance results for Jalapeño on InferenceX.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c028f756-4748-4583-91b2-5c4a63893cb5_2048x1153.png"
+  caption="Source: [OpenAI](https://openai.com/index/openai-broadcom-jalapeno-inference-chip/)"
+/>
+
+## A generalized inference chip
+
+Everyone says that OpenAI’s chip is specialized for OpenAI models, but that’s wrong, OpenAI made a generalized chip for AI inference.
+
+The timelines are insane. It shows that claims that use of AI is being used to accelerate chip design are real. Regardless of the quick timelines,Open AI spent a bunch of money, made pragmatic design decisions and their team is cracked, so this comes as no surprise.
+
+Just looking at the specs, it is an immediate contender:
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/e346a4e5-76cb-4fd9-be95-00321116b605_1846x510.png"
+  caption="Source: SemiAnalysis"
+/>
+
+And the use of HBM4 makes it stand out as comparable to flagship GPUs from NVIDIA and AMD:
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/327f95f7-ab6b-44ae-9b8f-17c1ff5d296b_1712x1300.png"
+  caption="Source: OpenAI"
+/>
+
+A lot of the media coverage of this chip has followed a few throwaway comments from OpenAI that claim the chip will be optimized for their models in a way that other chips are not. This is wrong. Jalapeño is a generalized inference chip capable of running all sorts of models, and all sorts of workloads, including our benchmark InferenceX, where we ran the benchmark with OpenAI engineers in the lab. As a joke, OpenAI even showed us it running Doom, which was ported to their chip with just Codex prompts.
+
+The following is our headline perf/W result, looking at token throughput per All-in utility MW. **Jalapeño smokes every other chip**. All this is done without Multi Token Prediction (MTP), while the other chips on the chart are the best performing configs of each respective SKU, all with MTP.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/19a7f45a-df8e-436e-ba04-df5d8610f3da_2048x1330.png"
+  caption="Source: SemiAnalysis"
+/>
+
+Jalapeño beats Blackwell on perf/W across almost all scenarios without being tuned for any specific point in the curve. It excels not only in low-latency scenarios but also in high-throughput scenarios. A more apples to apples comparison is against Single Token Prediction results, it knocks every competitor out of the water. At low concurrency scenarios, Jalapeño demonstrates remarkable interactivity, hitting over 700 tokens per sec per user at concurrency 1 on the DeepSeek R1 model.
+
+Incredibly, this is all achieved with single-token prediction (STP), no speculative decoding and no prefill-decode disaggregation. In addition to DeepSeek R1, we also got to see some other models, including Kimi-K2.5 and GPT-OSS which ran at approximately 1,400 tok/sec/user. For all models, we confirmed that Jalapeño’s GSM8k evals attained results on par with Nvidia chips.
+
+Some caveats on this. First, all numbers are provided to us by OpenAI. We verified the InferenceX runs in person in the lab, but we did not run the full suite of [InferenceX](https://inferencex.semianalysis.com/) benchmarks nor have we seen [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) results. AgentX is our preferred suite for comparing chip performance due to the datasets’ long context and multi-turn characteristics that reflect the cache behavior of realistic production workflows. Frameworks that perform well on 8k1k may perform worse on AgentX as real production loads stress components like routers, prefix cache mechanisms, cache management, offload infrastructure, etc. These are not tested by single turn 8k1k. Read more about this in out AgentX article.
+
+[AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) — Since the Claude Code inflection point in November 2025, long-context, multi-turn agentic workloads have grown rapidly. They now dominate traffic for production inferencing. In April 2026, OpenAI’s Enterprise agentic spending overtook ChatGPT spending.
+
+Second, we believe that comparison to Blackwell is somewhat incomplete and unfair. Jalapeño is really competing against chips like Rubin that also use HBM4. Vera Rubin systems are starting to ship to customers right now, while it will still be some time before OpenAI has anything beyond engineering samples of Jalapeño.
+
+Thus, performance should really be compared against Rubin, not Blackwell, and in some sense we expect a custom chip like Jalapeño to outperform Blackwell. Vera Rubin NVL72 delivers 5.4x the perf/MW of GB200 NVL72 [as we described in our article analyzing the NVIDIA performance claims in their launch with CoreWeave last month](https://newsletter.semianalysis.com/p/vera-rubin-nvl72-vs-gb200-nvl72-inference). We will compare Jalapeño to Vera Rubin’s July performance figures later below.
+
+[Vera Rubin NVL72 vs GB200 NVL72? Inference TCO & Architecture Analysis](https://newsletter.semianalysis.com/p/vera-rubin-nvl72-vs-gb200-nvl72-inference) — Vera Rubin NVL72 is the second generation of Nvidia’s rack-scale Oberon architecture, and its gains on inference come from extreme co-design. Early results from engineering samples are encouraging. Vera Rubin NVL72 running DeepSeek R1 delivers 5.4x performance per MW and 5x performance per dollar over GB200 NVL72 today, and the gap is even wider against GB200 NVL72 during its early bringup in 2025. Vera Rubin is still in the early bringup stage now, so we expect the gap to continue widen. Rubin's inference performance will keep improving as software matures, the same pattern we demonstrated for Blackwell in our
+
+Third, the models being tested are not on the open frontier. NVIDIA and AMD have published results on larger models such as DeepSeek V4 Pro and Kimi K3, using AgentX. The larger the model and the more recent the release, the more complicated it is to bring up on a new chip. With that said the models OpenAI has working on Jalapeno aren’t exactly small either.
+
+## Performance Analysis
+
+OpenAI designs for perf/W. The reason is simple: OpenAI is currently limited by datacenter power, not by budget or floorspace, and thus tokens per MW is paramount. At Computex 2026, Jensen said that perf/W, reliability and long lifetime are the core features of future GPUs. To quote: “If you have 1 gigawatt of power, then throughput per watt is revenue”. He also mentioned that choosing the wrong architecture just because the chips are cheaper doesn’t make sense.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/69dc13f6-ffb1-4d56-8df7-b75b57280382_1980x1254.png"
+  caption="Source: Computex 2026 keynote"
+/>
+
+This was emphasized by Nvidia during the Vera talk at Hot Chips 2026 while showing the same revenue graph: “The data center is power limited today.” Power matters and drives revenue.
+
+Operators cannot simply obtain more MW because adding GPUs and adding grid capacity happen on very different timescales. Datacenter power envelopes have constraints such as their utility interconnection, infrastructure, cooling capacity, and UPS/backup-generation design. Grid delays repeatedly outpace hardware and construction timelines, driving the need for BtM (behind-the-meter) power capacity: gas turbines and on-site generators built and located at the data center itself. This capacity sits behind the utility’s meter rather than being drawn from the public grid. It lets an operator power a facility without waiting on grid interconnection and utility upgrades, which is exactly why xAI’s Colossus 2 relies so heavily on BtM while its actual grid connection lags far behind. Find out more in our [Energy model](https://semianalysis.com/energy-model/).
+
+As we wrote in an X post, tok/s/MW reduces to tokens per joule since a watt is a joule per second. This makes tok/s/MW representative of a system’s efficiency and ability to convert energy into tokens.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c1a1da73-425c-4800-b396-01c7d2151be9_1200x1432.png"
+  caption="Source: [SemiAnalysis](https://x.com/SemiAnalysis_/status/2091208991271420076)"
+/>
+
+On this front, even when compared with Rubin, Jalapeño wins. OpenAI’s Jalapeño has STP output token throughput per MW surpassing [Vera Rubin’s MTP results that NVIDIA and CoreWeave published in July. It also far exceeds GB200’s 2025 MTP results.](https://www.coreweave.com/blog/nvidia-vera-rubin-nvl72-on-coreweave-10x-more-tokens-per-megawatt-than-blackwell) As mentioned in our Vera Rubin article, VR was compared to 2025 GB200 results because that was a similar stage of early bring-up, and comparing to GB200 in 2025 holds software maturity constant. Following this logic, we compare Vera Rubin’s latest July 2026 results, GB200 2025 results, and today’s Jalapeño results. This is a very valid comparison as these are the best public Rubin numbers, and OpenAI taped out their chip after Rubin. Both OpenAI and Rubin are still immature thus performance will continue to rise.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/6e8f9fd2-ec7f-45fa-80b9-dc132e32c661_2048x1450.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+On perf/TCO, Vera Rubin and Jalapeño are head-to-head, producing almost the same number of output tokens per $. However, as previously mentioned, **Jalapeño’s results are obtained without speculative decoding** and Vera Rubin’s results use speculative decoding. Speculative decoding leads to a ~3-5x reduction in cost per token. When speculative decoding is implemented on Jalapeño, this will enable Jalapeño to serve tokens even more cost effectively. Of course, part of this TCO advantage comes from trading Nvidia’s high margins for Broadcom’s lower (though still high) margins. But this is not all of it. For example, Meta and Microsoft’s AI ASIC programs not getting off the ground despite being at it for much longer shows that cost is only one part of the equation. For Jalapeño’s full TCO breakdown, see the [SemiAnalysis AI Cloud TCO model](https://semianalysis.com/ai-cloud-tco-model/).
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/a6c58331-c05a-4823-9c4b-aae90705bb53_2048x1485.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+Architecturally, OpenAI chose not to disaggregate prefill and decode (PD) across separate chip pools. The draft model and main model share the same chips and fabric, a design philosophy that trades some theoretical efficiency for practical operations. The motivation is that the workload mix changes over time, for example the ratio of input to cache write to cache read to output tokens has changed significantly as we have moved through the three eras of models ([knowledge, reasoning, and agentic, as discussed in our recent article](https://newsletter.semianalysis.com/p/are-open-models-catching-up)). Therefore, picking a fixed amount of heterogenous prefill silicon and decode silicon up front can lead to inefficiencies over time. OpenAI chooses a homogenous pool in this architecture and tries to make the chip perform well on everything.
+
+And it does. On Kimi K2.5 (which Cursor Composer 2.5 is based on), Jalapeño reaches nearly 700tok/s/user and more than 9x the next best performing chip at 100tok/s/user.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/3088f64c-9bee-46d9-a445-6818248ba573_2048x1366.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+On GPT-OSS, it’s another bloodbath. Jalapeño’s iso-interactivity throughput per MW is nearly double GB200’s highest throughput point and more than 50x GB200’s concurrency 1 point. The higher concurrency Jalapeño points use EP8.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/9f245dd7-c6b7-48a3-9215-3976633bb77f_2048x1366.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+These results are impressive! However, we have to nitpick: they’re just 8k1k, a much easier workload to tune for, and there are no [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) runs yet. As mentioned in our [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) article, multiturn, long context workloads stress much more aspects of the serving stack, such as routers and prefix cache. Many more optimizations are needed to excel in agentic workloads. Read more about this in the [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) article.
+
+[AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) — Since the Claude Code inflection point in November 2025, long-context, multi-turn agentic workloads have grown rapidly. They now dominate traffic for production inferencing. In April 2026, OpenAI’s Enterprise agentic spending overtook ChatGPT spending.
+
+## Digging into the specs and architecture
+
+All these results were gathered on the A0 stepping of Jalapeño, just 9 months into the program. But there is already a B0 stepping that is currently in the fab! B0 has optimizations that deliver roughly a 25% perf-per-watt improvement over the earlier A0 silicon. Specifically, the B0 stepping delivers 13.4 PFLOPs of MXFP4 on a single reticle-sized compute die that is manufactured on TSMC’s N3P. This compares to 17.5 PFLOPs of dense Rubin NVFP4 for a single Rubin compute die that is similar size and on the same node.
+
+This is more respectable considering Jalapeño’s TDP is only 700W compared to Rubin’s at 900-1,150W per compute die. As Jalapeño is geared towards inference rather than training, it is understandable that OpenAI doesn’t need to push TDPs higher to maximize FLOPs, but regardless the above shows that Jalapeño delivers respectable peak theoretical FLOPs.
+
+When compared directly to other accelerators, Jalapeño has the highest HBM bandwidth per watt, and the highest FLOPs per watt, comparable to the 1,800W Rubin Max-Q configuration:
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c5795c45-d23b-403c-8bc4-f13d5ba6fb45_2048x394.png"
+  caption="Source: SemiAnalysis"
+/>
+
+Off-package I/O is provided by an N3E I/O chiplet with 32 lanes of 800G SerDes, for the compute fabric, with 24 lanes (600GB/s) being used for local scale-up within the rack, and 8 lanes (200GB/s) for global scale-up which is the 2,048 XPU multi-rack domain. PCIe Gen 5 is used for system I/O to connect to the x86 host CPU.
+
+Jalapeño will ship with HBM4, making this chip one of the relatively early adopters after Nvidia and AMD, even beating the established TPU and Trainium programs. As one of the key architectural principles behind Jalapeño is getting the most out of HBM bandwidth, settling for anything but the best HBM would run counter to that goal. This results in 15.4TB/s of memory bandwidth per package which bests all the other accelerators shipping that are using HBM3E. The 15.4TB/s bandwidth shows its HBM4 can hit 10Gbps pin speeds, which would give it a slight edge over the 9.6Gbps Nvidia is getting out of its HBM4 in Rubin. The HBM is likely provided by Samsung.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/0d7d181a-2bb9-45d4-bd67-2f7e525ce6d1_1426x376.png"
+  caption="Source: OpenAI"
+/>
+
+OpenAI taped out Jalapeño in November 2025, or more specifically, this was a tape out of the CoWoS design, not just the top die silicon. Within 9 months of that Nov 2025 tapeout, and with only 3 months of bring-up on actual silicon, OpenAI has already delivered very good results with Jalapeño. This is all the more impressive as the team is starting from zero on the software stack.
+
+Meanwhile, Rubin’s CoWoS tape out was completed in October 2025, a month earlier, and yet the only early results we have seen are from CoreWeave’s engineering samples. Nvidia has not let us test and release benchmarks in the same way that OpenAI has, indicating their chip software is still immature. The CUDA moat is potentially dead given how fast OpenAI can bring up new models on their silicon.
+
+They are still far from optimized and we can see that generally Jalapeño has delivered better numbers. We don’t think that Nvidia hardware is inferior, but more so that Jalapeño’s software bring-up has progressed more quickly than Nvidia’s. This speaks to the power of hardware/software co-design, which is the main area where a cracked frontier lab ASIC team can excel over more established merchant silicon players. Counterintuitively, starting from scratch may also have benefited OpenAI as it could make clean-sheet architectural decisions without worrying about backwards compatibility or older software versions.
+
+While OpenAI has engineering samples of Jalapeño, production is currently scheduled to gradually ramp over 2027 with most of the output currently scheduled for the end of next year. [For more details of unit volumes and ASPs, see the SemiAnalysis Accelerator Model](https://semianalysis.com/accelerator-hbm-model/).
+
+Suffice to say, OpenAI Jalapeno is a real high volume ASIC.
+
+When compared against Rubin’s timeline, Jalapeño’s is shockingly quick. As shown earlier, Jalapeño’s results beat Rubin’s despite Rubin’s head start.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/bb59cacc-1f16-4c6a-98a5-0f0db74dada7_2048x411.png"
+  caption="Source: SemiAnalysis"
+/>
+
+## Jalapeno Architecture
+
+Digging into the architecture now, the chip’s matrix engine uses MXFP numerical formats and a weight stationary systolic array, similar to TPU. But when compared directly to TPU, it has support for smaller shapes / dimensions, meaning that it doesn’t have weird performance cliffs that get exposed by awkwardly shaped matmuls on bigger systolics.
+
+It also has 64-bit scalar cores and FP32/INT32 vector cores. OpenAI has also invested in redundancy at the tray level and has yield harvesting built in at the core and channel level. They claim that AI assistance in chip design delivered an 8% reduction in SIMD area and a 10% reduction in matrix-engine area during design. While they did not clarify the exact process/voltage/temperature (PVT) conditions, they also mentioned the AI-assisted blocks improved timing and power over the initial blocks.
+
+The Jalapeño architecture design focuses on eliminating memory movement of KVCache and weights as well as fixed latencies and overheads in order to make it possible to get closer to the raw peak flops/bandwidth even for small batches or shapes as compared to other accelerators.
+
+The cores and the HBM are divided into slices, where each core slice has a low-latency local view on its own slice of HBM. Synchronization between slices occurs on a high-bandwidth dedicated collective network. This minimal memory hierarchy already gives Jalapeño a big potential advantage over GPUs, where memory accesses must traverse a complicated memory system, resulting in large latencies that must be amortized or hidden over larger shapes.
+
+This choice is feasible because with careful placement of weights and KVs, synchronization between cores can be restricted to limited, known high-bandwidth comms such as tensor-parallel communication that can be overlapped with compute.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/871631ee-8f0d-4fb6-869c-a6fb298e800e_2048x832.png"
+  caption="Source: OpenAI"
+/>
+
+There is also an additional general NoC which is used for general comms and to access the scale-up network. In general OpenAI saves huge power and gets big performance gains with a simplified NOC and memory subsystem vs Nvidia and Google.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/1f93df86-2ea2-4904-8fd1-e0e5eff4b410_1638x854.png"
+  caption="Source: OpenAI"
+/>
+
+At the core level, OpenAI describes an out-of-order (OoO) core with an L1 cache. This is a large divergence from the pattern we have seen in other accelerators, all of which instead use software-managed scratchpad commonly paired with some async DMA support. Again, the argument being made here is that this allows Jalapeño to avoid fixed overheads such as barrier latencies, which on other accelerators (such as GPUs) need to be hidden or amortized over with higher work per core, and make it harder to get close to the raw peak bandwidth/flops.
+
+The tradeoff is that Jalapeño therefore relies on good prefetching to ensure timely arrivals of memory requests, which is less predictable and more difficult to reason about. However, with Codex in a good harness with access to detailed tracing, it is likely that finding the optimal kernel with the best prefetching for a given shape requires little human intervention. We think that is exactly what OpenAI has done to bring up DeepSeek R1, Kimi K2.5, and GPT-OSS so quickly.
+
+The cores also have support for “small” matrix dimensions, which (depending on how small) should make it more general across different model and batch dimensions less sensitive to matrix dimension alignment, padding overhead, and tiling inefficiency. For instance, TPUs, Trainium, and Etched chips have very large systolic arrays which can require large batches or exactly-divisible model dimensions to avoid tiling inefficiencies.
+
+With Jalapeño, OpenAI has focused on eliminating fixed latencies in the system to allow for as-close-to-roofline performance as possible across all areas of the pareto curve. In theory, this could give them advantages over the GPU at multiple operating points:
+
+- Much better upper-bound performance on low-latency/small-batch inference, which on GPUs is limited by many fixed overheads such as launch latencies, barrier latencies, memory system latency
+- Some potential to achieve closer to the hardware roofline even for large-batch or long-context
+
+This comes with the caveat that even if the upper-bound performance is available in theory, it may be more difficult to realize that performance for real kernels. So it seems the approach is:
+
+1. Design for the highest upper-bound performance across all workload shapes
+2. Let Codex do the tedious work of finding the kernels that achieve that upper bound
+
+Judging by the extremely fast turnaround for the OpenAI team to bring up InferenceX workloads on Jalapeño, we are optimistic about this approach.
+
+If Jalapeño is a success, it will be a strong signal that the industry’s obsession over programming models and perfect, universal compilers are invalidated by frontier AI models.
+
+## Software
+
+OpenAI writes Jalapeño kernels like assembly. Each kernel gets hand-tuned code, some running to ~3,000 lines, backed by correctness checks and a custom sanitizer. Early kernel work was human-in-the-loop rather than fully automated, but this shifted with a more scaled-up, internal version of Codex, one which OpenAI plans to pitch to enterprise customers. The internal serving engine is called “Teacup”. Interestingly, **OpenAI had no internal implementation of MLA kernels until they benchmarked DeepSeek with InferenceX**. The ability for Codex to write functional and efficient kernels so quickly (without any of OpenAI’s kernel engineering team intervening) shows the software pipeline’s developmental ability.
+
+OpenAI programs Jalapeño with Gluon. Gluon is OpenAI’s kernel programming language. Built on top of Triton, Gluon preserves Triton’s SPMD (Single Program Multiple Data) programming model, but it exposes **low-level programming abstractions**. For example, for NVIDIA GPUs, it offers APIs that map to PTX instructions, including MMA instructions, TMA instructions, mbarrier mechanisms, and many more. The most unique abstraction Gluon provides is **the layout**. Generally speaking, a layout defines a mapping between a hardware resource (e.g. 5th register of warp 9) and a tensor element (e.g. tensor element on row 6 column 7). Gluon’s layout abstraction is based on [Linear Layouts](https://arxiv.org/abs/2505.23819), a type of layout algebra OpenAI invented. Linear Layouts mathematically formalizes what a layout is and provides tools to operate on layouts. This enables many features, such as provably correct layout conversions and optimal memory swizzling.
+
+In terms of Jalapeño’s programming model, each Gluon program maps to a persistent thread. We believe this hints that Jalapeño suits the **persistent kernel programming pattern**, where each program executes on multiple tiles, and the programmer, rather than the hardware scheduler, assigns the work. OpenAI mentioned TensorInfo, an abstraction that explicitly encodes layouts. This is likely the set of layouts designed for Jalapeño, which will be powered by Linear Layouts. Finally, each core offers data prefetching and decoupled out-of-order units. For example, a user might program a wait on a prefetched data, which is locked behind a semaphore.
+
+In a weird twist of fate, OpenAI models like GPT 5.6 Sol, which currently run on NVIDIA GPUs, have been used to design a chip that poses a real threat to the CUDA moat - NVIDIA’s own GPUs are helping usher in their potential successor in real time.
+
+Comparing across time, we can also see Jalapeño’s developmental pace, achieving more than 2x throughput improvements at certain interactivities in less than 2 weeks. Each tarball we get from the Jalapeño team has a world of wonders inside.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/b38d958b-6d53-4ebe-b92f-c2cb58de05c2_2048x1485.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+Not only did kernel performance improve, in the span of 8 days, the Jalapeño team enabled TP32, building on the previous TP8 configs and expanding beyond a single system to get a full rack-scale config running on a large model. This is a really impressive pace of development.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/a18d5611-f7c1-4e34-8919-99b1c683054f_2048x1485.png"
+  caption="Source: OpenAI, SemiAnalysis"
+/>
+
+To validate performance before committing to real hardware runs, OpenAI also has a simulator “chilisim” accurate to within 5% of measured hardware, using a fixed-width trace bus. Tracing on A0 was limited but has improved substantially on B0, likely with inputs from actual runs on A0 silicon. Engineers have demoed the Codex CLI running an internal model, nicknamed “Raiku” or “5.3 Codex Spark”, at 1.2ms TPOT.
+
+The team also showed off Codex-written demos running directly on the chip: Doom at 36 FPS, an FP32 fluid-dynamics simulation, and a “Liquid Light” mouse-drag visualization.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/d410878f-5f19-40bd-ad2c-d92ad45d65a9_1252x1232.png"
+  caption="Source: SemiAnalysis"
+/>
+
+On the model side, OpenAI’s internal megakernel approach, nicknamed “gigakernel”, is built around a single megakernel that loops on-device to reduce CPU overhead and launch time. The team is also leaning further into test-time compute strategies, with internal interest specifically in how to coherently use 1 million rollouts.
+
+## To Disagg or Not to Disagg, ‘tis the Question
+
+We mentioned earlier that OpenAI is not using prefill decode disaggregation on these chips. This came as a surprise to us, as NVIDIA and AMD GPU performance benefits significantly from PDD, even on homogenous hardware. Let’s dig into why the Jalapeño team went this way.
+
+Prefill-decode disaggregation (PDD) looks attractive when the workload is frozen. Prefill and decode stress hardware differently, so assigning each phase to a separately tuned pool can improve efficiency at one chosen input/output ratio. Production traffic, however, does not stay at that ratio. Input and output sequence lengths, concurrency, cache-hit rates, speculative-acceptance rates, and latency targets all move throughout the day.
+
+Once devices are divided into prefill and decode pools, too much prefill demand leaves decode chips idle while requests queue. But too much decode demand does the opposite. The operator must continuously predict the right split, provision spare capacity on both sides, and rebalance a system whose ideal ratio is always moving.
+
+In a unified system, some resources may be underused during a particular phase, but every device remains available to serve the next request. In a disaggregated system, an entire chip can sit idle simply because it belongs to the wrong pool. Local utilization looks better, but global utilization can be bad.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/92d363ab-c391-4b9a-9f67-516dac22f534_1364x938.png"
+  caption="Source: SemiAnalysis"
+/>
+
+Disaggregation also breaks locality. The prefill worker produces a large KV cache that the decode worker immediately needs, so the system must transfer that state across the network before generation can continue. That adds bandwidth consumption, synchronization, queueing, and another failure domain. The cost also rises with input sequence length because KV cache grows. However, avoiding the movement of KVs is largely a power and latency optimization; being willing to move some KVs around can allow for increased hardware utilization at the expense of some power and per-request latency.
+
+<Figure src="https://substack-post-media.s3.amazonaws.com/public/images/5789e0ea-2d0d-4924-b338-f0559c7e7ee9_1928x1292.png" />
+
+A fungible fleet shifts capacity between latency-sensitive requests and throughput-oriented batches, while a fixed split strands hardware whenever the traffic mix changes. Moreover, context length changes the balance between attention and FFN work, making any fixed hardware ratio efficient only near its design point.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/9f3a37f8-0996-4dea-9631-02ade61d7fae_1358x938.png"
+  caption="Source: SemiAnalysis"
+/>
+
+The same constraint applies to speculative decoding. A draft model has to feed candidate tokens to the verifier with extremely low latency. Separating the two across specialized pools turns a tightly coupled decoding loop into a distributed protocol. The extra communication and coordination can consume the latency saved by drafting. Keeping both models on the same devices and low-latency fabric preserves the locality that makes speculation worthwhile in the first place.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/2eb19374-5a08-4d82-84a3-9875b3fc0f5b_1980x1220.png"
+  caption="Source: SemiAnalysis"
+/>
+
+However, disaggregation can still win where demand is sufficiently large, stable, and predictable, particularly when conventional GPUs need large phase-specific batches to reach good throughput. But it is not free lunch.
+
+## From Japanese to Indian (Mild to Spicy): Katsu, Vindaloo, and Chana - How are the curry dishes put together into a rack system?
+
+The Jalapeño System at the rack unit level consists of a CPU host rack and an ASIC rack. The host rack houses 16 host CPU trays named “Katsu,” each corresponding to one of the 16 ASIC trays, named “Vindaloo,” to the right of the Katsu. Each host houses two Turin-class AMD EPYC CPUs with 1.5TB of DRAM, 2x E1.S, and 2x M.2 SSDs per rack. Each tray is also specced with 400G (2x200G) frontend networking. Each Katsu tray connects to each Vindaloo tray via 8 external PCIe DAC cables that run horizontally across the rack at the front. The system level design is done in partnership with Celestica.
+
+The ASIC rack consists of 16 Vindaloo trays and 8 scale up switch trays (6 for local + 2 for global), named “Chana.” Each Vindaloo tray consists of 8 Jalapeño ASICs, making up a total of 128 Jalapeño ASICs per rack. The ASICs are connected to each of the Chana switch trays via a copper cable backplane, just like that of Nvidia’s Oberon. The scale up topology is split into a local domain of 128 ASICs within the rack and a global domain connecting up to 16 racks or 2,048 ASICs. We will explain the bandwidth and the topology in more detail below.
+
+Power provisioning to a sidecar host rack draws roughly 50kW provisioned (31kW in production), and the ASIC rack draws 130kW, making the total two rack system roughly 160kW. That’s basically a double-wide GB300 rack in terms of power draw.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/596ca531-3bde-44fa-8d1b-34d04b8cc6b8_1304x1382.png"
+  caption="Source: SemiAnalysis, OpenAI"
+/>
+
+OpenAI can connect up to 2,048 Jalapeño XPUs within a single scale-up network. The scale-up network consists of two domains, a local domain connecting all 128 XPUs over backplane within the rack, as well as a global domain connecting 2,048 XPUs over 16 racks using a hybrid of copper and optical interconnect. Each rack consists of 8 Chana switch trays. Six Chana switches in the middle are for the local domain, which come with one 102.4T Tomahawk 6 switch ASIC each. Two Chana switches at the top and bottom of the local switches are for the global domain, which we think could consist of 2x 102.4T Tomahawk 6 switches making up to 204.8T per switch tray.
+
+In the local domain, each of the 128 Jalapeño chips has a per XPU uni-directional bandwidth of 4.8Tb/s and is connected on an all-to-all basis to 6x 102.4Tb/s Tomahawk 6 ASICs. This would amount to 48-differential pair (DP) male and female connector pairs per XPU translating to a total of 6,144DPs worth of passive copper cables per rack used for local scale-up.
+
+For the global domain, 16 racks totaling 2,048 XPUs are connected together via a combination of copper backplane, electrical 204.8T TH6 switch, 1.6T transceivers, and optical circuit switch. Each XPU has a uni-directional bandwidth of 1.6Tb/s for the global link, which is 16-differential pair (DP) male and female connector pairs per XPU for the backplane between the XPU and the global switch. Bandwidth exiting each global switch tray of 2 ASICs each is split between the backplane and front panel optics.
+
+Between local domain and global domain, backplane connector count per rack comes up to 64 DPs per XPU and a total of 8,192 DPs worth of passive copper cables per rack.
+
+The global domain adopts a rail-only architecture consisting of 8-rails across the global domain. We think OpenAI routes optical links in the global domain via Optical Circuit Switches (OCS) installed in every rack. For every XPU, 1.6Tb/s of global bandwidth will travel to the global switch tray over the copper backplane. This then exits the switch through the front panel via 1.6T transceivers, which go to the passive optical switch before exiting the rack. This expands the scale-up world size to 2,048 XPUs combining 16 racks of 128 XPUs each.
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/ae9b26b8-471a-43b2-a60c-cd99ce2b9b07_3480x1342.png"
+  caption="Source: SemiAnalysis"
+/>
+
+Because scale-up networking is only about 10% of total system cost, that flexibility buys valuable optionality for future 10–20 trillion parameter models or 2–4 million token context windows. On deployment, OpenAI is partnering with neoclouds and is gathering reliability data with datacenter partners through January while optimizing dock-to-rack rollout time.
+
+## What’s Next
+
+Next, we talk about the future of Jalapeño, whose first production token is coming soon. The next goal is 100MW, and the hurdles will mostly be hardware: How much can they produce, how well can they deploy and operate datacenters, how do they handle monitoring, and resiliency, etc. The software is already proven, and with internal models, every software headstart is easily caught up to. Behind the paywall we will discuss implications for NVIDIA, AMD, Cerebras, and other chip companies who have signed deals with OpenAI in the coming years.
+
+[We also cover production volumes, units, and timelines for the next generation chip in our Accelerator model here](https://semianalysis.com/accelerator-hbm-model/).
+
+## Direct Implications for NVIDIA, AMD and Cerebras
+
+<Blur>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+</Blur>
+
+---
+
+_This article continues on our Substack. [Subscribe to SemiAnalysis](https://newsletter.semianalysis.com/subscribe) to read the complete article._
+
+<JsonLd>{`{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is OpenAI Jalapeño?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jalapeño is OpenAI's first self-designed inference ASIC, built with Broadcom from a blank slate for LLM inference and announced at Hot Chips. Design work began in the middle of 2024 and the CoWoS design taped out in November 2025, roughly a 16 month cycle from team hiring to tape-out. The B0 stepping now in the fab delivers 13.4 PFLOPs of MXFP4 on a single reticle-sized N3P compute die at a 700W TDP, with HBM4 providing 15.4 TB/s of memory bandwidth per package."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Jalapeño compare to NVIDIA Blackwell and Vera Rubin?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "On token throughput per all-in utility megawatt, Jalapeño beats Blackwell across almost all scenarios, and its single-token-prediction results surpass the Vera Rubin MTP figures NVIDIA and CoreWeave published in July 2026. On performance per dollar of TCO, Jalapeño and Vera Rubin are roughly head to head. Blackwell is the weaker comparison because Jalapeño competes against HBM4 parts like Rubin, and Jalapeño achieves these results without speculative decoding while the NVIDIA configurations use it."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why did OpenAI skip prefill-decode disaggregation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Disaggregation is attractive when the workload mix is frozen, but production traffic is not: input and output lengths, concurrency, cache hit rates, speculative acceptance, and latency targets all move through the day. Once chips are split into prefill and decode pools, an entire chip can sit idle because it belongs to the wrong pool, so local utilization improves while global utilization suffers. A unified pool also preserves the locality that speculative decoding depends on, since a draft model separated from its verifier turns a tight decoding loop into a distributed protocol."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is a Jalapeño rack put together?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The system is two racks. A host rack holds 16 CPU trays named Katsu, each with two AMD EPYC Turin-class CPUs and 1.5TB of DRAM, connected by external PCIe DAC cables to the ASIC rack. The ASIC rack holds 16 Vindaloo trays of 8 Jalapeño ASICs each, for 128 ASICs per rack, plus 8 Chana scale-up switch trays built on Tomahawk 6. Scale-up runs as a 128-ASIC local domain over a copper backplane and a global domain reaching 2,048 ASICs across 16 racks. The two-rack system draws roughly 160kW."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What software stack runs on Jalapeño?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "OpenAI programs the chip with Gluon, its own kernel language built on Triton, which keeps Triton's SPMD model while exposing low-level abstractions. Its distinguishing feature is the layout abstraction, based on Linear Layouts, a layout algebra OpenAI invented that enables provably correct layout conversions and optimal memory swizzling. The internal serving engine is called Teacup, a simulator called chilisim tracks measured hardware to within 5 percent, and a scaled-up internal version of Codex writes much of the kernel code."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the caveats on these Jalapeño results?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "All numbers were provided by OpenAI. SemiAnalysis verified the InferenceX runs in person in the lab but did not run the full benchmark suite, and there are no AgentX results yet. The published runs are 8k1k single-turn, which is easier to tune for than long-context multi-turn traffic: agentic workloads stress routers, prefix caching, cache management, and offload infrastructure that a single-turn 8k1k run never exercises. The models tested are also not the newest frontier open-weight releases."
+      }
+    }
+  ]
+}`}</JsonLd>

--- a/packages/app/content/blog/zh/openai-jalapeno-better-than-nvidia.mdx
+++ b/packages/app/content/blog/zh/openai-jalapeno-better-than-nvidia.mdx
@@ -1,0 +1,383 @@
+---
+title: 'OpenAI Jalapeño：比 NVIDIA Blackwell 更强'
+subtitle: 'OpenAI 自研 ASIC 对比 Rubin：Jalapeño 的 TCO、每兆瓦吞吐量，以及那些够辣的细节'
+seoDescription: 'OpenAI 首代自研推理 ASIC，与 Broadcom 合作打造，并在 InferenceX 上完成基准测试。文中对比它与 Blackwell、Vera Rubin 的每兆瓦性能，介绍 HBM4 与 MXFP4 规格、Gluon 软件栈、OpenAI 为何不做 prefill-decode 分离，以及 Katsu、Vindaloo 与 Chana 组成的机架架构。'
+date: '2026-08-25'
+publishDate: '2026-08-25'
+tags:
+  - inference
+  - benchmark
+  - gpu
+  - nvidia
+  - openai
+  - asic
+  - rubin
+---
+
+过去两年，OpenAI 一直在低调打造一款名为「Jalapeño」的推理芯片，如今在 Hot Chips 上正式发布。此前关于它成功流片的传闻已经流传了一段时间，现在细节终于公开。OpenAI 邀请我们实地查看这颗芯片、走进他们的实验室确认它的真实性，并用我们的 [InferenceX](https://inferencex.semianalysis.com/) 套件对它做了[基准测试](https://openai.com/index/jalapeno-first-results/)。
+
+今年 6 月，[OpenAI 公布了这项芯片计划](https://openai.com/index/openai-broadcom-jalapeno-inference-chip/)，与 Broadcom 合作，从零开始、专为 LLM 推理设计。[设计工作始于 2024 年年中](https://newsletter.semianalysis.com/p/openai-chip-team-is-now-serious)，从组建团队到量产流片只用了约 16 个月，这在 ASIC 开发中是极快的节奏。
+
+通常第一代芯片并不具备竞争力，但 OpenAI 打破了这一规律：在多个主流开源模型上，它击败了我们测试过的每一款 NVIDIA、AMD 和 Google 芯片，处于业界领先水平。OpenAI 靠的是极致的软硬件协同设计。令人意外的是，他们并没有针对推理的某个特定环节做过度特化，而是专注于做一颗在所有场景下都有高性能的通用芯片。
+
+本文将深入介绍 Jalapeño 的架构细节、软件细节，以及它在 InferenceX 上的性能结果。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c028f756-4748-4583-91b2-5c4a63893cb5_2048x1153.png"
+  caption="来源：[OpenAI](https://openai.com/index/openai-broadcom-jalapeno-inference-chip/)"
+/>
+
+## 一颗通用的推理芯片
+
+外界普遍认为 OpenAI 的芯片是为自家模型特化的，但这是错的：OpenAI 做的是一颗面向 AI 推理的通用芯片。
+
+这个时间线堪称疯狂，说明「用 AI 加速芯片设计」的说法确有其事。抛开进度不谈，OpenAI 投入了大量资金、做出了务实的设计取舍，团队本身也很能打，因此这个结果并不令人意外。
+
+仅看规格，它就已经是有力的竞争者：
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/e346a4e5-76cb-4fd9-be95-00321116b605_1846x510.png"
+  caption="来源：SemiAnalysis"
+/>
+
+而采用 HBM4，使它足以与 NVIDIA 和 AMD 的旗舰 GPU 相提并论：
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/327f95f7-ab6b-44ae-9b8f-17c1ff5d296b_1712x1300.png"
+  caption="来源：OpenAI"
+/>
+
+关于这颗芯片的媒体报道，大多沿用了 OpenAI 随口提到的几句话，认为它会以其他芯片做不到的方式为自家模型做优化。这种说法是错的。Jalapeño 是一颗通用推理芯片，能够运行各类模型和各类工作负载，也包括我们的 InferenceX 基准测试——我们正是与 OpenAI 工程师一起在实验室里跑的。他们还开玩笑似地展示了在这颗芯片上运行 Doom，而移植工作只用 Codex 提示词就完成了。
+
+下面是我们的核心 perf/W 结果，看的是每兆瓦全量供电所能产出的 token 吞吐量。**Jalapeño 碾压了其他所有芯片**。而且这一切都是在不使用多 token 预测（MTP）的前提下取得的，图中其他芯片则都是各自 SKU 上开启 MTP 的最佳配置。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/19a7f45a-df8e-436e-ba04-df5d8610f3da_2048x1330.png"
+  caption="来源：SemiAnalysis"
+/>
+
+在几乎所有场景下，Jalapeño 的 perf/W 都胜过 Blackwell，而且并没有针对曲线上的某个点做专门调优。它不仅在低延迟场景表现出色，在高吞吐场景同样如此。更对等的比较是与单 token 预测的结果对比，此时它把所有竞争对手都甩在身后。在低并发场景下，Jalapeño 展现出惊人的交互性：在 DeepSeek R1 上，并发为 1 时超过 700 tok/s/user。
+
+更惊人的是，这一切都是在单 token 预测（STP）下完成的，没有投机解码，也没有 prefill 与 decode 分离。除 DeepSeek R1 外，我们还看到了其他一些模型，包括 Kimi-K2.5 和 GPT-OSS，后者约为 1,400 tok/s/user。对所有这些模型，我们确认 Jalapeño 的 GSM8k 评估结果与 NVIDIA 芯片相当。
+
+有几点需要说明。第一，所有数据均由 OpenAI 提供。我们在实验室现场验证了 InferenceX 的运行过程，但没有跑完整套 [InferenceX](https://inferencex.semianalysis.com/) 基准测试，也没有看到 [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) 结果。AgentX 是我们更倾向用于比较芯片性能的套件，因为其数据集具备长上下文和多轮特征，能反映真实生产流程中的缓存行为。在 8k1k 上表现良好的框架，在 AgentX 上可能明显变差，因为真实生产负载会给 router、前缀缓存机制、缓存管理、offload 基础设施等组件施加压力，而单轮 8k1k 根本考察不到这些。相关内容可参见我们的 AgentX 文章。
+
+[AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) — 自 2025 年 11 月的 Claude Code 拐点以来，长上下文、多轮的 agentic 工作负载快速增长，如今已经主导生产推理的流量。2026 年 4 月，OpenAI 的企业级 agentic 支出超过了 ChatGPT 支出。
+
+第二，我们认为拿它和 Blackwell 比并不完整，也不够公平。Jalapeño 真正的对手是同样使用 HBM4 的 Rubin 这类芯片。Vera Rubin 系统现在已经开始向客户发货，而 OpenAI 手上除了工程样片之外还需要一段时间才能有更多东西。
+
+因此，性能比较的对象应该是 Rubin 而不是 Blackwell；从某种意义上说，我们本就预期 Jalapeño 这样的定制芯片会胜过 Blackwell。Vera Rubin NVL72 的 perf/MW 是 GB200 NVL72 的 5.4 倍，[我们在分析 NVIDIA 上月与 CoreWeave 联合发布时所给出性能数据的文章中已有说明](https://newsletter.semianalysis.com/p/vera-rubin-nvl72-vs-gb200-nvl72-inference)。下文我们会把 Jalapeño 与 Vera Rubin 7 月的性能数据做对比。
+
+[Vera Rubin NVL72 vs GB200 NVL72? Inference TCO & Architecture Analysis](https://newsletter.semianalysis.com/p/vera-rubin-nvl72-vs-gb200-nvl72-inference) — Vera Rubin NVL72 是 NVIDIA 机架级 Oberon 架构的第二代产品，其推理性能提升来自极致的协同设计。工程样片的早期结果令人鼓舞：运行 DeepSeek R1 的 Vera Rubin NVL72 相比 GB200 NVL72 目前有 5.4 倍的每兆瓦性能和 5 倍的每美元性能，而与 2025 年 GB200 NVL72 早期 bring-up 阶段相比差距更大。Vera Rubin 目前仍处于早期 bring-up 阶段，我们预计差距还会继续拉大。随着软件成熟，Rubin 的推理性能会持续提升，这与我们此前在 Blackwell 上观察到的规律一致。
+
+第三，被测试的模型并不处于开源前沿。NVIDIA 和 AMD 已经用 AgentX 公布了 DeepSeek V4 Pro、Kimi K3 等更大模型的结果。模型越大、发布越新，在一颗新芯片上完成 bring-up 就越复杂。话虽如此，OpenAI 在 Jalapeño 上跑通的这些模型也算不上小。
+
+## 性能分析
+
+OpenAI 是按 perf/W 来做设计的。原因很简单：OpenAI 当前的瓶颈是数据中心电力，而不是预算或场地，因此每兆瓦 token 数至关重要。在 Computex 2026 上，黄仁勋表示 perf/W、可靠性和长使用寿命是未来 GPU 的核心特性。用他的原话说：「如果你有 1 吉瓦电力，那么每瓦吞吐量就是营收。」他还提到，仅仅因为芯片更便宜就选择错误的架构是说不通的。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/69dc13f6-ffb1-4d56-8df7-b75b57280382_1980x1254.png"
+  caption="来源：Computex 2026 主题演讲"
+/>
+
+NVIDIA 在 Hot Chips 2026 的 Vera 演讲中展示同一张营收图时也强调了这一点：「今天的数据中心是电力受限的。」电力很重要，而且直接驱动营收。
+
+运营方无法简单地获取更多兆瓦，因为增加 GPU 与增加电网容量的时间尺度完全不同。数据中心的电力上限受制于并网接入、基础设施、制冷能力以及 UPS 与备用发电设计。电网审批的延误一再落后于硬件与建设进度，这催生了对 BtM（表后）电力容量的需求：直接建在数据中心现场的燃气轮机和自备发电机。这部分容量位于电网计费表之后，而不是从公共电网取电，因此运营方无需等待并网和电力扩容就能给园区供电——这正是 xAI 的 Colossus 2 高度依赖 BtM、而实际并网进度远远滞后的原因。更多内容参见我们的[能源模型](https://semianalysis.com/energy-model/)。
+
+正如我们在 X 上写过的，由于瓦特就是焦耳每秒，tok/s/MW 可以约化为每焦耳 token 数。这使 tok/s/MW 能够代表一套系统把能量转化为 token 的效率与能力。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c1a1da73-425c-4800-b396-01c7d2151be9_1200x1432.png"
+  caption="来源：[SemiAnalysis](https://x.com/SemiAnalysis_/status/2091208991271420076)"
+/>
+
+在这一点上，即便与 Rubin 相比，Jalapeño 也胜出。OpenAI 的 Jalapeño 在 STP 下的每兆瓦输出 token 吞吐量，超过了 [NVIDIA 与 CoreWeave 在 7 月公布的 Vera Rubin MTP 结果，也远超 GB200 在 2025 年的 MTP 结果](https://www.coreweave.com/blog/nvidia-vera-rubin-nvl72-on-coreweave-10x-more-tokens-per-megawatt-than-blackwell)。正如我们在 Vera Rubin 文章中所说，之所以拿 VR 与 2025 年的 GB200 结果对比，是因为二者处于类似的早期 bring-up 阶段，这样可以保持软件成熟度这一变量不变。沿用同样的逻辑，我们把 Vera Rubin 2026 年 7 月的最新结果、GB200 2025 年的结果与今天的 Jalapeño 结果放在一起比较。这是很合理的对比：这些是目前公开的最佳 Rubin 数据，而 OpenAI 的流片时间还在 Rubin 之后。OpenAI 和 Rubin 都还不成熟，性能都会继续提升。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/6e8f9fd2-ec7f-45fa-80b9-dc132e32c661_2048x1450.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+在 perf/TCO 上，Vera Rubin 与 Jalapeño 势均力敌，每美元产出的输出 token 数几乎相同。但如前所述，**Jalapeño 的结果是在不使用投机解码的前提下取得的**，而 Vera Rubin 的结果用了投机解码。投机解码可以把单 token 成本降低约 3 到 5 倍。等 Jalapeño 用上投机解码之后，它的 token 服务成本还会更低。当然，这部分 TCO 优势来自用 Broadcom 相对更低（尽管依然很高）的毛利替换了 NVIDIA 的高毛利，但这并不是全部原因。举例来说，Meta 和 Microsoft 的 AI ASIC 项目投入时间更久却始终没能真正跑起来，这说明成本只是方程式的一部分。Jalapeño 的完整 TCO 拆解见 [SemiAnalysis AI Cloud TCO 模型](https://semianalysis.com/ai-cloud-tco-model/)。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/a6c58331-c05a-4823-9c4b-aae90705bb53_2048x1485.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+在架构上，OpenAI 选择不把 prefill 与 decode（PD）分离到不同的芯片池。draft 模型与主模型共用同一批芯片和同一张网络，这种设计理念用一部分理论效率换取了运维上的实用性。理由在于工作负载的构成会随时间变化：随着我们走过三个模型时代（[知识、推理和 agentic，见我们近期的文章](https://newsletter.semianalysis.com/p/are-open-models-catching-up)），输入 token、缓存写入、缓存读取与输出 token 之间的比例已经发生了显著变化。因此，事先固定异构的 prefill 硅片与 decode 硅片比例，长期来看会带来低效。OpenAI 在这套架构中选择了同构资源池，并努力让芯片在所有场景下都表现良好。
+
+事实也确实如此。在 Kimi K2.5（Cursor Composer 2.5 基于该模型）上，Jalapeño 达到接近 700 tok/s/user，在 100 tok/s/user 处更是次优芯片的 9 倍以上。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/3088f64c-9bee-46d9-a445-6818248ba573_2048x1366.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+在 GPT-OSS 上又是一边倒。Jalapeño 在等交互性下的每兆瓦吞吐量接近 GB200 最高吞吐点的两倍，是 GB200 并发为 1 时的 50 倍以上。Jalapeño 并发较高的那些点使用了 EP8。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/9f245dd7-c6b7-48a3-9215-3976633bb77f_2048x1366.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+这些结果令人印象深刻！不过我们还是要挑刺：它们只是 8k1k，是一个明显更容易调优的工作负载，而且目前还没有 [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) 运行结果。正如我们在 [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) 文章中所说，多轮长上下文工作负载会给服务栈的更多环节施加压力，例如 router 和前缀缓存。要在 agentic 工作负载上取得优异表现，还需要大量优化。更多内容请见 [AgentX](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) 文章。
+
+[AgentX - InferenceXv3: Does CUDA Moat Hold up in Agentic Inferencing?](https://newsletter.semianalysis.com/p/agentx-inferencexv3-does-cuda-moat) — 自 2025 年 11 月的 Claude Code 拐点以来，长上下文、多轮的 agentic 工作负载快速增长，如今已经主导生产推理的流量。2026 年 4 月，OpenAI 的企业级 agentic 支出超过了 ChatGPT 支出。
+
+## 深入规格与架构
+
+上述所有结果都是在 Jalapeño 的 A0 步进上取得的，距离项目启动仅 9 个月。而 B0 步进已经在 fab 中流片，其优化相比早期的 A0 硅片带来约 25% 的每瓦性能提升。具体来说，B0 步进在采用台积电 N3P 工艺、单颗满掩模尺寸的计算 die 上提供 13.4 PFLOPs 的 MXFP4 算力。作为对比，尺寸相近、同一工艺节点的单颗 Rubin 计算 die 提供 17.5 PFLOPs 的稠密 NVFP4 算力。
+
+考虑到 Jalapeño 的 TDP 只有 700W，而 Rubin 每颗计算 die 为 900 至 1,150W，这个数字就相当可观了。由于 Jalapeño 面向推理而非训练，OpenAI 不需要把 TDP 推高来榨取 FLOPs，这可以理解；但无论如何，上述数据说明 Jalapeño 的峰值理论算力是拿得出手的。
+
+与其他加速器直接对比时，Jalapeño 拥有最高的每瓦 HBM 带宽和最高的每瓦 FLOPs，与 1,800W 的 Rubin Max-Q 配置相当：
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/c5795c45-d23b-403c-8bc4-f13d5ba6fb45_2048x394.png"
+  caption="来源：SemiAnalysis"
+/>
+
+片外 I/O 由一颗 N3E I/O chiplet 提供，具备 32 条 800G SerDes 通道用于计算网络，其中 24 条（600GB/s）用于机架内的本地 scale-up，8 条（200GB/s）用于全局 scale-up，即 2,048 颗 XPU 的多机架域。系统 I/O 使用 PCIe Gen 5 连接 x86 主机 CPU。
+
+Jalapeño 将搭载 HBM4，使它成为继 NVIDIA 和 AMD 之后相对较早的采用者，甚至领先于已经成熟的 TPU 和 Trainium 项目。既然 Jalapeño 的核心架构原则之一是把 HBM 带宽用到极致，那么选择次优的 HBM 就与这一目标背道而驰。最终它实现了每封装 15.4TB/s 的显存带宽，超过所有在售的 HBM3E 加速器。15.4TB/s 说明其 HBM4 达到了 10Gbps 的引脚速率，略高于 NVIDIA 在 Rubin 上跑出的 9.6Gbps。这批 HBM 很可能由三星提供。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/0d7d181a-2bb9-45d4-bd67-2f7e525ce6d1_1426x376.png"
+  caption="来源：OpenAI"
+/>
+
+OpenAI 在 2025 年 11 月完成了 Jalapeño 的流片，更准确地说，这是 CoWoS 设计的流片，而不只是顶层 die 的硅片流片。在那次流片之后的 9 个月内、且只有 3 个月的实际硅片 bring-up 时间里，OpenAI 就用 Jalapeño 拿出了非常好的结果。考虑到团队的软件栈是从零起步，这就更令人印象深刻了。
+
+与之相对，Rubin 的 CoWoS 流片在 2025 年 10 月完成，早了一个月，但我们目前看到的早期结果只有 CoreWeave 的工程样片。NVIDIA 并没有像 OpenAI 这样让我们测试并发布基准结果，这说明他们的芯片软件仍不成熟。考虑到 OpenAI 在自家硅片上 bring-up 新模型的速度，CUDA 护城河有可能已经不复存在。
+
+它们都还远未优化到位，但总体上可以看到 Jalapeño 交出了更好的数据。我们并不认为 NVIDIA 的硬件更差，更多是 Jalapeño 的软件 bring-up 推进得比 NVIDIA 更快。这体现了软硬件协同设计的威力，而这正是一支能打的前沿实验室 ASIC 团队相比更成熟的商用芯片厂商最可能胜出的地方。反直觉的是，从零开始或许也帮了 OpenAI：他们可以做出干净利落的架构决策，而不必顾虑向后兼容或旧版软件。
+
+虽然 OpenAI 目前只有 Jalapeño 的工程样片，但量产计划将在 2027 年逐步爬坡，大部分产出目前排在明年年底。[关于出货量与 ASP 的更多细节，请见 SemiAnalysis 加速器模型](https://semianalysis.com/accelerator-hbm-model/)。
+
+可以说，OpenAI Jalapeno 是一款真正会大批量出货的 ASIC。
+
+与 Rubin 的时间线相比，Jalapeño 的推进速度快得惊人。如前所示，尽管 Rubin 起步更早，Jalapeño 的结果依然胜出。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/bb59cacc-1f16-4c6a-98a5-0f0db74dada7_2048x411.png"
+  caption="来源：SemiAnalysis"
+/>
+
+## Jalapeno 架构
+
+接下来深入架构。这颗芯片的矩阵引擎采用 MXFP 数值格式和权重驻留（weight stationary）的脉动阵列，与 TPU 类似。但与 TPU 直接对比时，它支持更小的形状与维度，这意味着不会像更大的脉动阵列那样，在遇到形状不规整的矩阵乘法时出现奇怪的性能悬崖。
+
+它还配有 64 位标量核心以及 FP32/INT32 向量核心。OpenAI 在托盘级别投入了冗余设计，并在核心与通道级别内置了良率收割机制。他们表示，AI 辅助设计在设计阶段使 SIMD 面积减少 8%、矩阵引擎面积减少 10%。虽然没有说明具体的工艺、电压、温度（PVT）条件，但他们也提到 AI 辅助生成的模块在时序和功耗上都优于最初版本。
+
+Jalapeño 的架构设计重点在于消除 KVCache 与权重的内存搬运，以及固定延迟和各类开销，从而即便在小 batch 或小形状下，也能比其他加速器更接近原始峰值算力与带宽。
+
+核心与 HBM 被划分为多个 slice，每个核心 slice 对自己那一份 HBM 具有低延迟的本地视图。slice 之间的同步走一张专用的高带宽集合通信网络。这种极简的内存层级结构，已经让 Jalapeño 相对 GPU 具备了很大的潜在优势：在 GPU 上，内存访问必须穿过复杂的内存系统，产生的高延迟只能靠更大的形状去摊薄或掩盖。
+
+之所以可行，是因为只要仔细安排权重和 KV 的放置，核心之间的同步就可以被限制在有限且已知的高带宽通信上，例如可以与计算重叠的张量并行通信。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/871631ee-8f0d-4fb6-869c-a6fb298e800e_2048x832.png"
+  caption="来源：OpenAI"
+/>
+
+此外还有一张通用 NoC，用于常规通信以及访问 scale-up 网络。总体而言，相比 NVIDIA 和 Google，OpenAI 依靠简化的 NoC 与内存子系统节省了大量功耗，并获得了可观的性能提升。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/1f93df86-2ea2-4904-8fd1-e0e5eff4b410_1638x854.png"
+  caption="来源：OpenAI"
+/>
+
+在核心层面，OpenAI 描述的是带 L1 缓存的乱序（OoO）核心。这与我们在其他加速器上看到的模式差异很大：后者普遍采用软件管理的 scratchpad，并搭配某种异步 DMA 支持。同样，这里的论点是它能让 Jalapeño 避免诸如 barrier 延迟这类固定开销；而在 GPU 等其他加速器上，这些开销必须靠给每个核心分配更多工作来掩盖或摊薄，也因此更难逼近原始的峰值带宽与算力。
+
+代价是 Jalapeño 因而更依赖良好的预取来保证内存请求及时到达，而这一点可预测性更差、也更难推理。不过，只要 Codex 处在一个好的 harness 中并能拿到详细 trace，为给定形状找到预取最优的 kernel 很可能几乎不需要人工介入。我们认为 OpenAI 正是这样做的，才得以如此迅速地跑通 DeepSeek R1、Kimi K2.5 和 GPT-OSS。
+
+这些核心还支持「小」矩阵维度。视其小到什么程度，这应当能让它在不同模型和 batch 维度上更通用，也更不易受矩阵维度对齐、padding 开销和 tiling 低效的影响。相比之下，TPU、Trainium 和 Etched 的芯片都采用很大的脉动阵列，往往需要较大 batch 或恰好可整除的模型维度，才能避免 tiling 带来的浪费。
+
+在 Jalapeño 上，OpenAI 专注于消除系统中的固定延迟，以便在 Pareto 曲线的各个区间都尽可能逼近 roofline 性能。理论上，这可能在多个运行点上带来相对 GPU 的优势：
+
+- 在低延迟 / 小 batch 推理上有高得多的性能上界，而 GPU 在这里受制于诸多固定开销，例如启动延迟、barrier 延迟和内存系统延迟
+- 在大 batch 或长上下文场景下，也有一定机会更接近硬件 roofline
+
+需要说明的是，即便理论上存在这样的性能上界，对真实 kernel 而言未必容易兑现。因此这套思路大致是：
+
+1. 面向所有工作负载形状，设计出尽可能高的性能上界
+2. 让 Codex 去做那些繁琐的工作，找出能够逼近该上界的 kernel
+
+从 OpenAI 团队在 Jalapeño 上跑通 InferenceX 工作负载的极快速度来看，我们对这条路线持乐观态度。
+
+如果 Jalapeño 成功，那将是一个强烈信号：业界对编程模型和完美通用编译器的执念，正在被前沿 AI 模型所瓦解。
+
+## 软件
+
+OpenAI 写 Jalapeño 的 kernel 就像写汇编。每个 kernel 都是手工调优的代码，有些长达约 3,000 行，并配有正确性检查和自研 sanitizer。早期的 kernel 工作以人在回路为主而非完全自动化，但随着内部一个规模更大的 Codex 版本投入使用，这一点发生了变化——OpenAI 计划把该版本推向企业客户。内部的服务引擎名为「Teacup」。有意思的是，**在用 InferenceX 对 DeepSeek 做基准测试之前，OpenAI 内部并没有 MLA kernel 的实现**。Codex 能在 OpenAI kernel 工程团队完全不介入的情况下这么快写出可用且高效的 kernel，足见其软件流水线的开发能力。
+
+OpenAI 用 Gluon 为 Jalapeño 编程。Gluon 是 OpenAI 的 kernel 编程语言，构建在 Triton 之上，保留了 Triton 的 SPMD（单程序多数据）编程模型，同时暴露出**更底层的编程抽象**。例如在 NVIDIA GPU 上，它提供映射到 PTX 指令的 API，包括 MMA 指令、TMA 指令、mbarrier 机制等等。Gluon 最独特的抽象是 **layout**。一般来说，layout 定义的是硬件资源（例如 warp 9 的第 5 个寄存器）与张量元素（例如第 6 行第 7 列的元素）之间的映射。Gluon 的 layout 抽象基于 [Linear Layouts](https://arxiv.org/abs/2505.23819)，这是 OpenAI 提出的一套 layout 代数，用数学方式形式化了 layout 的定义，并提供了在 layout 上做运算的工具。由此可以实现许多能力，例如可证明正确的 layout 转换和最优的内存 swizzling。
+
+就 Jalapeño 的编程模型而言，每个 Gluon 程序对应一个常驻线程。我们认为这暗示 Jalapeño 适合**常驻 kernel 编程模式**：每个程序处理多个 tile，且由程序员而非硬件调度器来分配工作。OpenAI 提到了 TensorInfo，这是一种显式编码 layout 的抽象，很可能就是为 Jalapeño 设计、并由 Linear Layouts 驱动的那套 layout。最后，每个核心都提供数据预取和解耦的乱序单元，例如用户可以对已预取的数据编写等待逻辑，由信号量控制解锁。
+
+命运的奇妙之处在于：像 GPT 5.6 Sol 这样目前跑在 NVIDIA GPU 上的 OpenAI 模型，被用来设计了一颗真正威胁 CUDA 护城河的芯片——NVIDIA 自己的 GPU 正在实时地帮助催生它潜在的接班者。
+
+把时间轴拉开看，还能看到 Jalapeño 的开发节奏：在不到两周的时间里，某些交互性区间的吞吐量提升超过 2 倍。Jalapeño 团队每次发来的压缩包里都藏着惊喜。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/b38d958b-6d53-4ebe-b92f-c2cb58de05c2_2048x1485.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+不只是 kernel 性能提升。在 8 天之内，Jalapeño 团队在此前 TP8 配置的基础上启用了 TP32，从单机扩展到完整的机架级配置来运行大模型。这样的开发速度确实令人印象深刻。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/a18d5611-f7c1-4e34-8919-99b1c683054f_2048x1485.png"
+  caption="来源：OpenAI、SemiAnalysis"
+/>
+
+为了在投入真实硬件运行之前验证性能，OpenAI 还有一个名为「chilisim」的模拟器，采用定宽 trace 总线，与实测硬件的误差在 5% 以内。A0 上的 tracing 能力有限，但在 B0 上有了大幅改进，很可能吸收了 A0 实际运行的反馈。工程师还演示了 Codex CLI 运行一个内部模型（代号「Raiku」或「5.3 Codex Spark」），TPOT 为 1.2ms。
+
+团队还展示了由 Codex 编写、直接在芯片上运行的演示：36 FPS 的 Doom、一个 FP32 流体力学模拟，以及一个名为「Liquid Light」的鼠标拖拽可视化。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/d410878f-5f19-40bd-ad2c-d92ad45d65a9_1252x1232.png"
+  caption="来源：SemiAnalysis"
+/>
+
+在模型侧，OpenAI 内部的 megakernel 方案（代号「gigakernel」）围绕单个 megakernel 构建，在设备上循环执行，以减少 CPU 开销和启动时间。团队还在进一步押注测试时计算策略，内部尤其关注如何连贯地使用 100 万次 rollout。
+
+## 分离还是不分离，这是个问题
+
+前面提到，OpenAI 在这些芯片上没有使用 prefill decode 分离。这让我们相当意外，因为 NVIDIA 和 AMD 的 GPU 即便在同构硬件上也能从 PDD 中获得显著收益。下面我们来看看 Jalapeño 团队为什么这样选。
+
+当工作负载固定不变时，prefill-decode 分离（PDD）看起来很有吸引力。prefill 与 decode 对硬件的压力方式不同，因此把两个阶段分别放到各自调优过的资源池中，可以在某个选定的输入输出比例下提升效率。但生产流量并不会停在那个比例上：输入与输出序列长度、并发、缓存命中率、投机接受率和延迟目标，都会在一天之内不断变化。
+
+一旦设备被划分为 prefill 池和 decode 池，prefill 需求过多时 decode 芯片就会闲置而请求排队；decode 需求过多时则反过来。运营方必须持续预测正确的比例、在两侧都预留冗余容量，并不断重新平衡一个理想比例始终在移动的系统。
+
+在统一的系统中，某些资源在特定阶段可能利用不足，但每台设备都随时可以服务下一条请求。而在分离式系统中，一颗芯片可能仅仅因为归属于错误的资源池就完全闲置：局部利用率看起来更好，全局利用率却可能很差。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/92d363ab-c391-4b9a-9f67-516dac22f534_1364x938.png"
+  caption="来源：SemiAnalysis"
+/>
+
+分离还会破坏局部性。prefill worker 产生的大量 KV cache 是 decode worker 立刻需要的，因此系统必须先把这份状态通过网络传过去，生成才能继续。这会带来额外的带宽消耗、同步、排队，以及又一个故障域。开销还会随输入序列长度上升，因为 KV cache 会变大。不过，避免搬运 KV 主要是一项功耗与延迟优化；愿意搬运一部分 KV，可以用一些功耗和单请求延迟换来更高的硬件利用率。
+
+<Figure src="https://substack-post-media.s3.amazonaws.com/public/images/5789e0ea-2d0d-4924-b338-f0559c7e7ee9_1928x1292.png" />
+
+可调配的统一集群能够在延迟敏感请求和吞吐导向的批处理之间转移容量，而固定的划分方式则会在流量构成变化时让硬件被闲置。此外，上下文长度会改变注意力与 FFN 之间的工作量平衡，使任何固定的硬件比例都只在其设计点附近才高效。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/9f3a37f8-0996-4dea-9631-02ade61d7fae_1358x938.png"
+  caption="来源：SemiAnalysis"
+/>
+
+同样的约束也适用于投机解码。draft 模型必须以极低延迟把候选 token 送给验证方。把两者拆到各自专用的资源池中，会把一个紧耦合的解码循环变成分布式协议，额外的通信与协调开销可能把起草省下的延迟又吃回去。让两个模型留在同一批设备和同一张低延迟网络上，才能保住让投机解码值得做的那份局部性。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/2eb19374-5a08-4d82-84a3-9875b3fc0f5b_1980x1220.png"
+  caption="来源：SemiAnalysis"
+/>
+
+不过，当需求足够大、足够稳定且可预测时，分离仍然可以胜出，尤其是当常规 GPU 需要较大的分阶段 batch 才能获得良好吞吐时。但它并不是免费的午餐。
+
+## 从日式到印式（由淡到辣）：Katsu、Vindaloo 与 Chana —— 这些咖喱菜如何组成一套机架系统
+
+Jalapeño 系统在机架层面由一个 CPU 主机机架和一个 ASIC 机架组成。主机机架容纳 16 个名为「Katsu」的主机 CPU 托盘，每个对应右侧一个名为「Vindaloo」的 ASIC 托盘。每台主机配备两颗 Turin 级 AMD EPYC CPU 和 1.5TB DRAM，每机架配 2 个 E1.S 和 2 个 M.2 SSD。每个托盘还配有 400G（2x200G）前端网络。每个 Katsu 托盘通过 8 条外部 PCIe DAC 线缆与对应的 Vindaloo 托盘相连，这些线缆在机架前部横向走线。系统级设计由 Celestica 合作完成。
+
+ASIC 机架由 16 个 Vindaloo 托盘和 8 个名为「Chana」的 scale-up 交换托盘（6 个用于本地域、2 个用于全局域）组成。每个 Vindaloo 托盘装有 8 颗 Jalapeño ASIC，每机架合计 128 颗。ASIC 通过铜缆背板连接到各个 Chana 交换托盘，与 NVIDIA 的 Oberon 类似。scale-up 拓扑分为机架内 128 颗 ASIC 的本地域，以及最多连接 16 个机架、2,048 颗 ASIC 的全局域。带宽与拓扑细节见下文。
+
+边车式主机机架的供电约为 50kW 规划容量（生产环境 31kW），ASIC 机架为 130kW，两机架系统合计约 160kW，基本相当于一个双倍宽度的 GB300 机架的功耗。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/596ca531-3bde-44fa-8d1b-34d04b8cc6b8_1304x1382.png"
+  caption="来源：SemiAnalysis、OpenAI"
+/>
+
+OpenAI 可以在单个 scale-up 网络内连接多达 2,048 颗 Jalapeño XPU。该 scale-up 网络由两个域组成：本地域通过背板连接机架内全部 128 颗 XPU；全局域采用铜缆与光互连混合方案，跨 16 个机架连接 2,048 颗 XPU。每个机架有 8 个 Chana 交换托盘，中间 6 个用于本地域，各配一颗 102.4T 的 Tomahawk 6 交换 ASIC；位于本地交换托盘上下方的 2 个用于全局域，我们认为它们可能各由 2 颗 102.4T Tomahawk 6 组成，单托盘可达 204.8T。
+
+在本地域中，128 颗 Jalapeño 芯片每颗具备 4.8Tb/s 的单向带宽，以 all-to-all 方式连接到 6 颗 102.4Tb/s 的 Tomahawk 6 ASIC。这相当于每颗 XPU 需要 48 对差分（DP）公母连接器，每机架用于本地 scale-up 的无源铜缆合计 6,144 DP。
+
+在全局域中，16 个机架共 2,048 颗 XPU 通过铜缆背板、204.8T TH6 电交换、1.6T 光模块和光路交换的组合连接在一起。每颗 XPU 的全局链路具备 1.6Tb/s 单向带宽，对应 XPU 与全局交换之间背板上每颗 XPU 16 对差分连接器。每个全局交换托盘（含 2 颗 ASIC）的出向带宽在背板与前面板光口之间分配。
+
+把本地域与全局域合并计算，每机架每颗 XPU 的背板连接器数量为 64 DP，全机架用于无源铜缆的连接器合计 8,192 DP。
+
+全局域采用 rail-only 架构，跨全局域共 8 条 rail。我们认为 OpenAI 通过安装在每个机架中的光路交换机（OCS）来疏导全局域的光链路。对每颗 XPU 而言，1.6Tb/s 的全局带宽先经铜缆背板到达全局交换托盘，再通过前面板的 1.6T 光模块出口，进入无源光交换后离开机架。由此把 scale-up world size 扩展到 16 个机架、每机架 128 颗、合计 2,048 颗 XPU。
+
+<Figure
+  src="https://substack-post-media.s3.amazonaws.com/public/images/ae9b26b8-471a-43b2-a60c-cd99ce2b9b07_3480x1342.png"
+  caption="来源：SemiAnalysis"
+/>
+
+由于 scale-up 网络只占系统总成本约 10%，这种灵活性为未来 10 到 20 万亿参数的模型、或 200 万到 400 万 token 的上下文窗口买到了宝贵的可选性。在部署方面，OpenAI 正与 neocloud 合作，并在与数据中心伙伴一起采集可靠性数据直到 1 月，同时优化从到货到上架的部署时间。
+
+## 下一步
+
+接下来我们谈谈 Jalapeño 的未来，它的第一个生产 token 即将到来。下一个目标是 100MW，而障碍主要在硬件侧：能造出多少、数据中心能部署和运营得多好、监控与韧性如何处理等等。软件已经得到验证，而有了内部模型，任何软件上的先发优势都很容易被追上。付费部分我们会讨论这对 NVIDIA、AMD、Cerebras，以及未来几年与 OpenAI 签约的其他芯片公司意味着什么。
+
+[我们在加速器模型中还覆盖了下一代芯片的产量、出货单位与时间线](https://semianalysis.com/accelerator-hbm-model/)。
+
+## 对 NVIDIA、AMD 和 Cerebras 的直接影响
+
+<Blur>
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+</Blur>
+
+---
+
+_本文完整版发布在我们的 Substack 上。[订阅 SemiAnalysis](https://newsletter.semianalysis.com/subscribe) 阅读完整文章。_
+
+<JsonLd>{`{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "什么是 OpenAI Jalapeño？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Jalapeño 是 OpenAI 首款自研推理 ASIC，与 Broadcom 合作、从零开始专为 LLM 推理设计，在 Hot Chips 上正式发布。设计工作始于 2024 年年中，CoWoS 设计于 2025 年 11 月流片，从组建团队到流片约 16 个月。目前在 fab 中的 B0 步进采用台积电 N3P 工艺，在单颗满掩模尺寸的计算 die 上提供 13.4 PFLOPs 的 MXFP4 算力，TDP 为 700W，并通过 HBM4 实现每封装 15.4 TB/s 的显存带宽。"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jalapeño 与 NVIDIA Blackwell、Vera Rubin 相比如何？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "在每兆瓦全量供电的 token 吞吐量上，Jalapeño 在几乎所有场景中都胜过 Blackwell；其单 token 预测（STP）结果还超过了 NVIDIA 与 CoreWeave 在 2026 年 7 月公布的 Vera Rubin MTP 数据。在每美元 TCO 性能上，Jalapeño 与 Vera Rubin 大致势均力敌。与 Blackwell 比较的参考价值较弱，因为 Jalapeño 真正的对手是 Rubin 这类 HBM4 产品；而且 Jalapeño 取得这些结果时并未使用投机解码，NVIDIA 的对应配置则使用了。"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "OpenAI 为什么没有采用 prefill-decode 分离？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "当工作负载构成固定时，分离很有吸引力，但生产流量并非如此：输入与输出长度、并发、缓存命中率、投机接受率和延迟目标都会在一天之内变化。一旦把芯片划分为 prefill 池和 decode 池，一颗芯片可能仅因归属错误的资源池而完全闲置，于是局部利用率提升、全局利用率反而下降。统一资源池还能保住投机解码所依赖的局部性：一旦把 draft 模型与验证方分开，紧耦合的解码循环就会变成分布式协议。"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jalapeño 的机架是如何组成的？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "该系统由两个机架组成。主机机架容纳 16 个名为 Katsu 的 CPU 托盘，每个配备两颗 Turin 级 AMD EPYC CPU 和 1.5TB DRAM，通过外部 PCIe DAC 线缆连接到 ASIC 机架。ASIC 机架容纳 16 个 Vindaloo 托盘，每个装有 8 颗 Jalapeño ASIC，每机架合计 128 颗，另有 8 个基于 Tomahawk 6 的 Chana scale-up 交换托盘。scale-up 分为通过铜缆背板连接的 128 颗 ASIC 本地域，以及跨 16 个机架、连接 2,048 颗 ASIC 的全局域。两机架系统功耗约 160kW。"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Jalapeño 上运行的是什么软件栈？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "OpenAI 使用自研 kernel 语言 Gluon 为该芯片编程。Gluon 构建在 Triton 之上，保留 Triton 的 SPMD 模型，同时暴露更底层的抽象。它最具特色的能力是 layout 抽象，基于 OpenAI 提出的 layout 代数 Linear Layouts，可实现可证明正确的 layout 转换和最优的内存 swizzling。内部服务引擎名为 Teacup，模拟器 chilisim 与实测硬件的误差在 5% 以内，而大量 kernel 代码由内部规模更大的 Codex 版本编写。"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "这些 Jalapeño 结果有哪些需要注意的前提？",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "所有数据均由 OpenAI 提供。SemiAnalysis 在实验室现场验证了 InferenceX 的运行过程，但没有跑完整套基准测试，目前也没有 AgentX 结果。公布的运行均为 8k1k 单轮场景，比长上下文多轮流量更容易调优：agentic 工作负载会给 router、前缀缓存、缓存管理和 offload 基础设施施加压力，而单轮 8k1k 完全考察不到这些。此外，所测试的模型也不是最新的前沿开放权重模型。"
+      }
+    }
+  ]
+}`}</JsonLd>

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -60,6 +60,7 @@ const AGENTX_QWEN_SGLANG = 'qwen3-5-397b-agentx-nvidia-vs-amd-sglang';
 const AGENTX_QWEN_B300 = 'qwen3-5-397b-agentx-b300-fp4-vs-h100';
 const AGENTX_GLM_SGLANG = 'glm-5-3-agentx-nvidia-vs-amd-sglang-150-toks';
 const AGENTX_GLM_ATOM = 'glm-5-3-agentx-mi355x-atom-vs-gb300-nvl72';
+const JALAPENO = 'openai-jalapeno-better-than-nvidia';
 
 const entries = [
   {
@@ -486,7 +487,7 @@ const entries = [
       'tokens-per-megawatt',
       'throughput',
     ],
-    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, GB200_R1, VR_RUBIN],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, GB200_R1, VR_RUBIN, JALAPENO],
   },
   {
     slug: 'tokens-per-megawatt',
@@ -511,7 +512,7 @@ const entries = [
       'total-cost-of-ownership',
       'performance-per-dollar',
     ],
-    articleSlugs: [INFERENCEMAX, DEEPSEEK_V4, VR_RUBIN],
+    articleSlugs: [INFERENCEMAX, DEEPSEEK_V4, VR_RUBIN, JALAPENO],
   },
   {
     slug: 'prefill',
@@ -630,6 +631,7 @@ const entries = [
       TILERT,
       AGENTX_V3,
       AGENTX_DSV4_GB200_GB300,
+      JALAPENO,
     ],
   },
   {
@@ -824,7 +826,7 @@ const entries = [
     benchmarkContext:
       'System topology determines the communication domain. A B200 in an eight-chip node and a GB200 NVL72 expose related silicon through different scale-up group sizes.',
     relatedTerms: ['nvlink', 'wide-expert-parallelism', 'all-to-all', 'tensor-parallelism'],
-    articleSlugs: [INFERENCEX_V2, GB200_R1, GB200_KIMI],
+    articleSlugs: [INFERENCEX_V2, GB200_R1, GB200_KIMI, JALAPENO],
   },
   {
     slug: 'high-bandwidth-memory',
@@ -842,7 +844,7 @@ const entries = [
     benchmarkContext:
       'InferenceX hardware comparisons separate HBM capacity from bandwidth. For example, GB300’s larger capacity fits wider prefill/decode layouts than GB200 despite similar bandwidth per chip.',
     relatedTerms: ['memory-bandwidth', 'decode', 'kv-cache', 'quantization'],
-    articleSlugs: [GB300_DSV4, B200_KIMI, MI355X_DSV4],
+    articleSlugs: [GB300_DSV4, B200_KIMI, MI355X_DSV4, JALAPENO],
   },
   {
     slug: 'memory-bandwidth',
@@ -968,7 +970,7 @@ const entries = [
     benchmarkContext:
       'InferenceX records MXFP4 as part of a complete engine and hardware recipe. Comparisons with NVFP4 or FP8 should use the same model, sequence length, quality requirements, and interactivity target.',
     relatedTerms: ['fp4', 'quantization', 'nvfp4', 'rocm', 'memory-bandwidth'],
-    articleSlugs: [MI355X_KIMI, INFERENCEX_V2],
+    articleSlugs: [MI355X_KIMI, INFERENCEX_V2, JALAPENO],
   },
   {
     slug: 'mixture-of-experts',
@@ -1210,7 +1212,7 @@ const entries = [
       'Read the label before comparing: all-in provisioned and measured values differ by the facility overhead between them. InferenceX withholds measured energy where the underlying telemetry is invalid or its scope is ambiguous, so a missing value means the measurement could not be trusted rather than that the run drew no power.',
     measurement: { label: 'Typical unit', value: 'joules per token (J/tok)' },
     relatedTerms: ['tokens-per-megawatt', 'throughput', 'total-cost-of-ownership', 'concurrency'],
-    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, AGENTX_V3],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, AGENTX_V3, JALAPENO],
   },
   {
     slug: 'context-parallelism',
@@ -1452,7 +1454,7 @@ const entries = [
     benchmarkContext:
       'The split explains recurring shapes in the data. Low interactivity points run large batches at high intensity and approach compute limits, while the high interactivity end runs small batches and tracks memory bandwidth, so bandwidth-rich parts often win there despite lower peak throughput.',
     relatedTerms: ['prefill', 'decode', 'memory-bandwidth', 'batching'],
-    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, TILERT],
+    articleSlugs: [INFERENCEMAX, INFERENCEX_V2, TILERT, JALAPENO],
   },
   {
     slug: 'prefix-cache-hit-rate',
@@ -1694,7 +1696,7 @@ const entries = [
       'all-to-all',
       'total-cost-of-ownership',
     ],
-    articleSlugs: [GB200_R1, GB300_DSV4, GB200_KIMI, VR_RUBIN, AGENTX_K3_ATOM],
+    articleSlugs: [GB200_R1, GB300_DSV4, GB200_KIMI, VR_RUBIN, AGENTX_K3_ATOM, JALAPENO],
   },
   {
     slug: 'atom',

--- a/packages/app/src/lib/zh-copy-mechanical-regressions.jsonl
+++ b/packages/app/src/lib/zh-copy-mechanical-regressions.jsonl
@@ -4,6 +4,7 @@
 {"rule": "chip-untranslated", "kind": "exemption", "text": "'吞吐量（token/s/chip）'", "note": "expanded spelling of the same unit also stays English"}
 {"rule": "chip-untranslated", "kind": "exemption", "text": "'$/M = TCO（$/chip-hour）× 1,000,000 /（3600 × tok/s/chip）'", "note": "unit inside a formula"}
 {"rule": "chip-untranslated", "kind": "exemption", "text": "const powerLabel = locale === 'zh' ? '全含功率/芯片：' : 'All in Power/Chip:';", "note": "the English sibling on a bilingual ternary must not be rewritten — this exact line was broken once by a line-level scan, which is why segmentation is per string literal"}
+{"rule": "chip-untranslated", "kind": "exemption", "text": "今年 6 月，[OpenAI 公布了这项芯片计划](https://openai.com/index/openai-broadcom-jalapeno-inference-chip/)，与 Broadcom 合作。", "note": "URL path — the word sits in a link target, and rewriting it would break the link"}
 {"rule": "hardcoded-english-label", "kind": "regression", "before": "`<div><strong>Concurrency:</strong> ${d.concurrency}</div>`", "after": "`<div><strong>${t.concurrency}：</strong> ${d.concurrency}</div>`", "note": "chart tooltip shipped 16 of these; a /zh reader saw them beside 投机解码：关闭"}
 {"rule": "hardcoded-english-label", "kind": "exemption", "text": "`<div><strong>TP:</strong> ${d.tp}</div>`", "note": "acronym — stays English"}
 {"rule": "hardcoded-english-label", "kind": "exemption", "text": "`<div><strong>tok/s/MW:</strong> ${d.perMw}</div>`", "note": "unit — stays English"}

--- a/packages/app/src/lib/zh-copy.test.ts
+++ b/packages/app/src/lib/zh-copy.test.ts
@@ -86,12 +86,20 @@ function segment(raw: string, isProse: boolean): string[] {
 // English form per AGENTS.md rule 6 — that is the one recorded exception.
 const CHIP_UNITS = /(?:tok|tokens?)\/s\/chip|\$\/chip[/-](?:hr|hour)|[A-Za-z]Chip\b|\bChip[A-Z]/giu;
 
+// A URL is an address, not prose. `…/openai-broadcom-jalapeno-inference-chip/`
+// carries the word without stating any translation decision, and rewriting it
+// would break the link, so URLs leave the corpus before any rule reads it.
+const URL_LIKE = /https?:\/\/\S+/giu;
+
+const ignoring = (...patterns: RegExp[]) =>
+  new RegExp(patterns.map((pattern) => pattern.source).join('|'), 'giu');
+
 const RULES: Rule[] = [
   {
     id: 'chip-untranslated',
     corpus: 'chinese',
     fix: '写作「芯片」（单位 tok/s/chip 等除外）',
-    find: matcher(/\b[Cc]hip\b/gu, CHIP_UNITS),
+    find: matcher(/\b[Cc]hip\b/gu, ignoring(URL_LIKE, CHIP_UNITS)),
   },
   {
     id: 'hardcoded-english-label',


### PR DESCRIPTION
## Summary

Ports the SemiAnalysis newsletter article [**OpenAI Jalapeño: Better Than Nvidia Blackwell**](https://newsletter.semianalysis.com/p/openai-jalapeno-better-than-nvidia) (2026-08-25) to the blog, following the same convention as the InferenceX v2 and AgentX v3 ports.

- `packages/app/content/blog/openai-jalapeno-better-than-nvidia.mdx`
- `packages/app/content/blog/zh/openai-jalapeno-better-than-nvidia.mdx` — hand-authored Simplified Chinese sibling

The slug matches the newsletter slug so the two URLs stay recognizably the same piece.

## What was ported

The full publicly available portion: nine sections and 24 figures, covering the perf/W result against Blackwell and Vera Rubin, the HBM4 and MXFP4 specs, the Gluon and Linear Layouts software stack, the argument for skipping prefill-decode disaggregation, and the Katsu / Vindaloo / Chana rack architecture. Image URLs, source links, and captions are preserved; the EN and ZH files carry an identical `<Figure src=…>` list and an identical outbound link set (verified programmatically).

**Paywalled remainder.** The article is paywalled from "Direct Implications for NVIDIA, AMD and Cerebras" onward. As with the v2 and v3 ports, the post ends with a `<Blur>` placeholder and a Substack subscribe note. Nothing behind the paywall was reproduced.

`FAQPage` JSON-LD in both languages, with every figure taken from the article body: the 13.4 PFLOPs MXFP4 B0 stepping at 700W on N3P, 15.4 TB/s of HBM4, the November 2025 CoWoS tape-out, 128 ASICs per rack in a 2,048-ASIC scale-up domain, and the roughly 160kW two-rack system.

## Two supporting changes

**1. `glossary.ts` cites the new post** from the nine entries it is a real source for: tokens per megawatt, energy per token, TCO, disaggregated inference, NVL72, scale-up vs scale-out, HBM, MXFP4, and arithmetic intensity. `glossary.test.ts` requires every post to be cited by at least one entry, so this is mandatory.

**2. `zh-copy.test.ts` now drops URLs before the `chip-untranslated` rule reads the corpus.** This is the part worth a careful look, because it changes a shared guard.

The Chinese post links to `openai-broadcom-jalapeno-inference-chip`, and the rule flagged the word inside that link target. A word sitting in a URL states no translation decision, and rewriting it would break the link, so the false positive is in the guard rather than in the copy. The fix follows the pattern the rule already uses for units:

```ts
const URL_LIKE = /https?:\/\/\S+/giu;
const ignoring = (...patterns) => new RegExp(patterns.map((p) => p.source).join('|'), 'giu');
// chip rule: matcher(/\b[Cc]hip\b/gu, ignoring(URL_LIKE, CHIP_UNITS))
```

An exemption fixture is recorded in `zh-copy-mechanical-regressions.jsonl` alongside the existing unit exemptions, so the behavior is pinned by a test rather than by a comment. The rule still catches every case it was written for; its regression fixtures are unchanged and passing.

## Notes for reviewers

- Rebased onto current `master` (post #863). The only conflicts were additive `articleSlugs` arrays in `glossary.ts`, resolved by union so both the AgentX breakout citations and the Jalapeño citation survive.
- Article-side caveats are reproduced as written rather than softened: all numbers were provided by OpenAI, SemiAnalysis verified the InferenceX runs in the lab but did not run the full suite, there are no AgentX results yet, and the published runs are 8k1k single-turn.
- Content-only otherwise: no API surface, no chart code, no interpolation touched, so the overlay and TS/Python interpolation sync rules do not apply.

## Verification

- `bun run test:unit` — 4,902 tests pass across all workspaces
- `bun run build` — `/blog/openai-jalapeno-better-than-nvidia` and its `/zh` sibling prerender with no MDX errors
- `bun run lint`, `bun run fmt`, `bun run typecheck` clean

## 中文说明

将 SemiAnalysis newsletter 文章[**《OpenAI Jalapeño：比 NVIDIA Blackwell 更强》**](https://newsletter.semianalysis.com/p/openai-jalapeno-better-than-nvidia)（2026-08-25）移植到博客，沿用 InferenceX v2 与 AgentX v3 的移植约定。slug 与 newsletter 保持一致，便于两处 URL 相互对应。

### 移植内容

文章公开部分的全文：九个章节、24 张图表，涵盖与 Blackwell 及 Vera Rubin 对比的每瓦性能结果、HBM4 与 MXFP4 规格、Gluon 与 Linear Layouts 软件栈、不做 prefill-decode 分离的理由，以及 Katsu / Vindaloo / Chana 机架架构。图片 URL、来源链接与图注均保持原样；中英文文件的 `<Figure src=…>` 列表与外链集合完全一致（已用脚本校验）。

**付费部分**：原文自「Direct Implications for NVIDIA, AMD and Cerebras」起为付费内容。与 v2、v3 移植一致，文末使用 `<Blur>` 占位加 Substack 订阅提示，未复制任何付费内容。

中英文均包含 `FAQPage` JSON-LD，其中数据全部取自正文：B0 步进在 N3P 上以 700W TDP 提供 13.4 PFLOPs MXFP4、HBM4 带宽 15.4 TB/s、2025 年 11 月完成 CoWoS 流片、每机架 128 颗 ASIC 且 scale-up 域达 2,048 颗、两机架系统功耗约 160kW。

### 两处配套改动

**1. `glossary.ts` 引用该文**，覆盖它确实作为来源的九个条目：每兆瓦 token 数、每 token 能耗、TCO、分离式推理、NVL72、scale-up 与 scale-out、HBM、MXFP4、算术强度。`glossary.test.ts` 要求每篇文章至少被一个条目引用，因此这是必需项。

**2. `zh-copy.test.ts` 在 `chip-untranslated` 规则读取语料前先剔除 URL。** 这一处改动了共用守卫，值得重点评审。

中文版链接到 `openai-broadcom-jalapeno-inference-chip`，该规则把链接地址中的单词判为违规。URL 中的单词并不构成翻译决策，改写它反而会破坏链接，因此误报出在守卫而非文案。修复方式沿用该规则已有的单位豁免写法，并在 `zh-copy-mechanical-regressions.jsonl` 中记录一条豁免用例，使该行为由测试固定而非仅靠注释说明。规则仍能捕获它原本要捕获的全部情形，既有回归用例未改动且全部通过。

### 评审提示

- 已 rebase 到当前 `master`（#863 之后）。冲突仅出现在 `glossary.ts` 中可叠加的 `articleSlugs` 数组，按并集解决，AgentX 拆分文章与 Jalapeño 的引用均予保留。
- 原文中的限定条件按原样保留、未作弱化：所有数据由 OpenAI 提供；SemiAnalysis 在实验室现场验证了 InferenceX 运行但未跑完整套；目前没有 AgentX 结果；公开运行均为 8k1k 单轮场景。
- 其余部分仅涉及内容，不改动 API、图表代码或插值逻辑，因此 overlay 与 TS/Python 插值同步规则均不适用。

### 验证

- `bun run test:unit` — 全部 workspace 共 4,902 项测试通过
- `bun run build` — `/blog/openai-jalapeno-better-than-nvidia` 及其 `/zh` 版本均成功预渲染，无 MDX 报错
- `bun run lint`、`bun run fmt`、`bun run typecheck` 均通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only MDX plus a localized test exemption; no runtime APIs, auth, or data paths change.
> 
> **Overview**
> Adds **English and Simplified Chinese** blog posts at `openai-jalapeno-better-than-nvidia`, porting the public newsletter piece (nine sections, figures, outbound links) with the same **paywalled tail** pattern: `<Blur>` placeholder plus Substack subscribe CTA instead of vendor-implications content. Both locales include matching **`FAQPage` JSON-LD** derived from the article body.
> 
> **`glossary.ts`** introduces a `JALAPENO` slug constant and attaches it to nine existing entries (tokens/MW, energy/token, TCO, disaggregated inference, NVL72, scale-up vs scale-out, HBM, MXFP4, arithmetic intensity) so the new post satisfies glossary coverage tests.
> 
> **Chinese copy guard:** `zh-copy.test.ts` now strips **`https?://…` URLs** before the `chip-untranslated` rule runs, alongside existing unit exemptions—fixing false positives when prose links to paths like `…/jalapeno-inference-chip/`. A regression fixture in `zh-copy-mechanical-regressions.jsonl` pins that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e4971574026187934fbde7314fdae8e29718c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->