### PR TITLE
fix(ui): drop the static Scenario readout when agentic is the only scenario / 当 Agentic 为唯一场景时移除多余的静态 Scenario 显示

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -189,9 +189,9 @@ describe('Chart Selectors', () => {
       cy.contains('Scenario').should('not.exist');
     });
 
-    it('keeps a static agentic readout when agentic is the only scenario', () => {
-      // No dropdown — but the explainer (tooltip + /agentx link) must survive,
-      // since agentic-only models are exactly the ones that need it.
+    it('renders nothing when agentic is the only scenario', () => {
+      // A static "Scenario: Agentic" readout is as redundant as a one-option
+      // dropdown — the whole control disappears for single-scenario models.
       cy.mount(
         <TooltipProvider delayDuration={0}>
           <div data-testid="selector-host">
@@ -204,10 +204,11 @@ describe('Chart Selectors', () => {
           </div>
         </TooltipProvider>,
       );
+      cy.get('[data-testid="selector-host"]').should('exist');
       cy.get('[data-testid="scenario-selector"]').should('not.exist');
-      cy.contains('Scenario').should('exist');
-      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
-      cy.get('[data-testid="scenario-agentic-info"]').should('exist');
+      cy.contains('Scenario').should('not.exist');
+      cy.get('[data-testid="scenario-static-value"]').should('not.exist');
+      cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
     });
 
     it('hides the agentic explainer on fixed-sequence scenarios', () => {

--- a/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/calculator-lifecycle.cy.ts
@@ -893,9 +893,9 @@ describe('Calculator — Fleet Lifecycle with agentic traces', () => {
       },
     });
     cy.wait('@agenticBenchmarks');
-    // The agentic fixture exposes a single scenario, so the dropdown is
-    // replaced by a static readout that keeps the agentic explainer.
-    cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
+    // The agentic fixture exposes a single scenario, so the scenario
+    // control disappears entirely — no dropdown, no static readout.
+    cy.get('[data-testid="scenario-static-value"]').should('not.exist');
     cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
     cy.wait('@agenticHistory');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -656,9 +656,9 @@ describe('TCO Calculator', () => {
     });
 
     it('renders throughput and cost calculations from null-ISL/OSL agentic rows', () => {
-      // The agentic fixture exposes a single scenario, so the dropdown is
-      // replaced by a static readout that keeps the agentic explainer.
-      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
+      // The agentic fixture exposes a single scenario, so the scenario
+      // control disappears entirely — no dropdown, no static readout.
+      cy.get('[data-testid="scenario-static-value"]').should('not.exist');
       cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
       cy.get('[data-testid="calc-percentile-selector"]').should('contain.text', 'p90');
       cy.get('[data-testid="calculator-no-data"]').should('not.exist');
@@ -716,9 +716,9 @@ describe('TCO Calculator', () => {
       });
       cy.wait('@agenticBenchmarks');
 
-      // Single-scenario fixture → the dropdown gives way to a static agentic
-      // readout; the gate is locked, so no percentile selector either.
-      cy.get('[data-testid="scenario-static-value"]').should('contain.text', 'Agentic');
+      // Single-scenario fixture → the scenario control disappears entirely;
+      // the gate is locked, so no percentile selector either.
+      cy.get('[data-testid="scenario-static-value"]').should('not.exist');
       cy.get('[data-testid="calc-sequence-selector"]').should('not.exist');
       cy.get('[data-testid="calc-percentile-selector"]').should('not.exist');
       cy.get('[data-testid="calculator-chart-section"] h2')

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -357,12 +357,10 @@ interface ScenarioSelectorProps {
  * agentic-trace rows rendered flat below. Label is "Scenario" (the ISL/OSL
  * framing only applies to the fixed-seq subset).
  *
- * Renders no dropdown when fewer than two scenarios are available: a dropdown
- * with a single choice is dead UI (e.g. agentic-only models like Kimi K3), so
- * the control disappears instead of offering a no-op menu. When that lone
- * scenario is agentic, a static readout with the explainer stays behind — the
- * workload isn't self-describing, and the tooltip's /agentx link is the only
- * in-controls path to that guidance.
+ * Renders nothing when fewer than two scenarios are available: a dropdown
+ * with a single choice is dead UI (e.g. agentic-only models like Kimi K3),
+ * and a static "Scenario: Agentic" readout is just as redundant when there is
+ * nothing to choose — so the whole control disappears.
  */
 export function ScenarioSelector({
   id = 'scenario-select',
@@ -380,23 +378,7 @@ export function ScenarioSelector({
   const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
   const isAgenticSelected = sequenceKind(value as Sequence) === 'agentic';
 
-  if (availableSequences.length < 2) {
-    if (!isAgenticSelected) return null;
-    return (
-      <div className="flex flex-col space-y-1.5 lg:col-span-1">
-        {/* No htmlFor: the static readout is not a labelable control. */}
-        <LabelWithTooltip label={t.scenario} tooltip={t.scenarioTooltip} />
-        <div className="flex h-9 items-center gap-1.5 text-sm" data-testid="scenario-static-value">
-          <span>{getSequenceLabel(value as Sequence, locale)}</span>
-          <AgenticScenarioInfo
-            tooltip={t.agenticScenarioTooltip}
-            learnMore={t.agenticScenarioLearnMore}
-            href={locale === 'zh' ? '/zh/agentx' : '/agentx'}
-          />
-        </div>
-      </div>
-    );
-  }
+  if (availableSequences.length < 2) return null;
 
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-1">


### PR DESCRIPTION
## Summary

#859 removed one-option dropdowns, but left a static `Scenario: Agentic` readout behind for agentic-only models. That readout is just as redundant — there is nothing to choose — so the whole Scenario control now disappears when fewer than two scenarios are available.

## Changes
- `chart-selectors.tsx`: `ScenarioSelector` now returns `null` for single-scenario models instead of rendering the static agentic readout (`scenario-static-value`) with the `AgenticScenarioInfo` explainer.
- Component spec: the agentic-only test now asserts the control renders nothing at all.
- E2E specs (`throughput-calculator`, `calculator-lifecycle`): static-readout assertions flipped to `not.exist`.

Note: the /agentx explainer tooltip is no longer reachable from the controls on agentic-only models; it still shows next to the dropdown whenever multiple scenarios exist.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only selector visibility change with test updates; no API or calculation logic changes.
> 
> **Overview**
> **Removes the static “Scenario: Agentic” readout** for models with a single scenario (e.g. agentic-only), so `ScenarioSelector` now returns nothing whenever fewer than two scenarios exist—same rule as fixed-sequence-only models, not a special case for agentic.
> 
> The dropdown and **`AgenticScenarioInfo`** (/agentx tooltip) still appear when the user can actually switch scenarios; on agentic-only calculator views those controls are no longer shown.
> 
> Component and calculator E2E specs were updated to expect no scenario UI (`scenario-static-value`, `scenario-agentic-info`) instead of a static Agentic label.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 608842fe7c719263b8b90bb313e5f433c5bf8d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->