### PR TITLE
Move Telemetry to the footer, add Articles to the header nav / Telemetry 移入页脚，页头新增 Articles

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -137,8 +137,8 @@ describe('Header', () => {
       'AgentX',
       'Overview',
       'Dashboard',
-      'Telemetry',
       'Comparisons',
+      'Articles',
       'About',
     ];
     cy.get('[data-testid^="nav-link-"]').then(($links) => {
@@ -150,7 +150,8 @@ describe('Header', () => {
 
   it('keeps footer destinations out of the primary nav', () => {
     cy.get('[data-testid="nav-link-supporters"]').should('not.exist');
-    cy.get('[data-testid="nav-link-blog"]').should('not.exist');
+    // Telemetry moved to the footer; Articles took its place in the nav.
+    cy.get('[data-testid="nav-link-telemetry"]').should('not.exist');
   });
 
   it('shows the GitHub stars button linking to the correct repo', () => {
@@ -181,8 +182,9 @@ describe('Header', () => {
         .and('have.attr', 'href', '/agentx')
         .find('[data-nav-badge="agentx"]')
         .should('have.text', 'NEW');
+      cy.contains('a', 'Articles').should('be.visible').and('have.attr', 'href', '/blog');
       cy.contains('a', 'Supporters').should('not.exist');
-      cy.contains('a', 'Articles').should('not.exist');
+      cy.contains('a', 'Telemetry').should('not.exist');
     });
   });
 
@@ -285,10 +287,12 @@ describe('Header', () => {
       cy.get('[data-testid="mobile-menu-toggle"]').click();
       cy.get('[data-testid="mobile-menu"]').should('be.visible');
       cy.get('[data-testid="mobile-menu"]').within(() => {
-        ['Home', 'Overview', 'Dashboard', 'Comparisons', 'AgentX', 'About'].forEach((label) => {
-          cy.contains('a', label).should('be.visible');
-        });
-        ['Supporters', 'Articles'].forEach((label) => {
+        ['Home', 'Overview', 'Dashboard', 'Comparisons', 'Articles', 'AgentX', 'About'].forEach(
+          (label) => {
+            cy.contains('a', label).should('be.visible');
+          },
+        );
+        ['Supporters', 'Telemetry'].forEach((label) => {
           cy.contains('a', label).should('not.exist');
         });
       });

--- a/packages/app/cypress/e2e/agentic-catalog.cy.ts
+++ b/packages/app/cypress/e2e/agentic-catalog.cy.ts
@@ -42,13 +42,18 @@ describe('AgentX telemetry catalog', () => {
       .and('match', /^\/inference\/agentic\/\d+$/u);
   });
 
-  it('highlights Telemetry rather than Dashboard in the header nav', () => {
+  it('reaches the catalog from the footer and highlights Dashboard in the header nav', () => {
     cy.visit('/inference/agentic', { onBeforeLoad: unlockAgenticGate });
 
-    cy.get('[data-testid="nav-link-telemetry"]')
-      .should('have.attr', 'href', '/inference/agentic')
-      .and('have.class', 'text-brand');
-    cy.get('[data-testid="nav-link-dashboard"]').should('not.have.class', 'text-brand');
+    // Telemetry is a footer destination now, so the catalog sits under the
+    // Dashboard nav entry rather than owning one of its own.
+    cy.get('[data-testid="nav-link-telemetry"]').should('not.exist');
+    cy.get('[data-testid="nav-link-dashboard"]').should('have.class', 'text-brand');
+    cy.get('[data-testid="footer-link-telemetry"]').should(
+      'have.attr',
+      'href',
+      '/inference/agentic',
+    );
   });
 
   it('ships the Simplified Chinese catalog', () => {

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -54,7 +54,7 @@ describe('Chinese (/zh) pages', () => {
     it('footer renders in Chinese with zh-internal links', () => {
       cy.get('[data-testid="footer-brand-description"]').should(
         'contain.text',
-        'InferenceX 持续开展开源推理基准测试',
+        'InferenceX 持续开展开源的 agentic 推理基准测试',
       );
       cy.get('[data-testid="footer-link-supporters"]')
         .should('contain.text', '业界评价')

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -12,7 +12,7 @@ import { StarButton } from './footer-star-cta';
 const STRINGS = {
   en: {
     description:
-      'Continuous open-source inference benchmarking. Real-world, reproducible, auditable performance data trusted by trillion dollar AI infrastructure operators like OpenAI, Meta, Oracle, Microsoft, etc.',
+      'Continuous open-source agentic inference benchmarking. Real-world, reproducible, auditable performance data trusted by trillion dollar AI infrastructure operators like OpenAI, Meta, Oracle, Microsoft, etc.',
     semianalysis: 'SemiAnalysis',
     mainSite: 'Main Site',
     newsletter: 'Newsletter',
@@ -28,6 +28,7 @@ const STRINGS = {
     more: 'More',
     supporters: 'Supporters',
     agentx: 'AgentX',
+    telemetry: 'Telemetry',
     articles: 'Articles',
     apiReference: 'API Reference',
     gpuReliability: 'Chip Reliability',
@@ -41,7 +42,7 @@ const STRINGS = {
   },
   zh: {
     description:
-      'InferenceX 持续开展开源推理基准测试，发布来自真实环境、可复现、可审计的性能数据，并获得 OpenAI、Meta、Oracle、Microsoft 等万亿美元级 AI 基础设施运营方的信赖。',
+      'InferenceX 持续开展开源的 agentic 推理基准测试，发布来自真实环境、可复现、可审计的性能数据，并获得 OpenAI、Meta、Oracle、Microsoft 等万亿美元级 AI 基础设施运营方的信赖。',
     semianalysis: 'SemiAnalysis',
     mainSite: 'SemiAnalysis 官网',
     newsletter: '订阅通讯',
@@ -57,6 +58,7 @@ const STRINGS = {
     more: '更多',
     supporters: '业界评价',
     agentx: 'AgentX',
+    telemetry: '遥测数据',
     articles: '技术文章',
     gpuReliability: '芯片可靠性',
     apiReference: 'API 文档',
@@ -214,6 +216,14 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 {t.agentx}
+              </Link>
+              <Link
+                data-testid="footer-link-telemetry"
+                href={`${prefix}/inference/agentic`}
+                onClick={() => track('footer_telemetry_clicked')}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.telemetry}
               </Link>
               <Link
                 data-testid="footer-link-articles"

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -18,9 +18,6 @@ import { cn } from '@/lib/utils';
 
 import { GitHubStars } from './GithubStars';
 
-/** The Telemetry nav entry, carved out of the Dashboard tab prefix match. */
-const TELEMETRY_PATH = '/inference/agentic';
-
 const DASHBOARD_TABS = DASHBOARD_ROUTES.map((route) => route.path);
 
 interface NavLink {
@@ -58,16 +55,16 @@ const NAV_LINKS: readonly NavLink[] = [
     event: 'header_dashboard_clicked',
   },
   {
-    href: '/inference/agentic',
-    label: 'Telemetry',
-    testId: 'nav-link-telemetry',
-    event: 'header_telemetry_clicked',
-  },
-  {
     href: '/compare',
     label: 'Comparisons',
     testId: 'nav-link-compare',
     event: 'header_compare_clicked',
+  },
+  {
+    href: '/blog',
+    label: 'Articles',
+    testId: 'nav-link-articles',
+    event: 'header_articles_clicked',
   },
   { href: '/about', label: 'About', testId: 'nav-link-about', event: 'header_about_clicked' },
 ] as const;
@@ -81,13 +78,10 @@ function isActive(pathname: string, href: string): boolean {
       : pathname.slice(ZH_PREFIX.length)
     : pathname;
   if (href === '/') return enPathname === '/';
-  // `/inference/agentic` is its own nav entry, so exclude it here — a bare
-  // `startsWith('/inference')` would light up Dashboard and Telemetry at once.
+  // Dashboard owns every tab path, including the telemetry catalog beneath
+  // `/inference`, which now lives in the footer rather than the primary nav.
   if (href === '/inference') {
-    return (
-      !enPathname.startsWith(TELEMETRY_PATH) &&
-      DASHBOARD_TABS.some((tab) => enPathname.startsWith(tab))
-    );
+    return DASHBOARD_TABS.some((tab) => enPathname.startsWith(tab));
   }
   // Exact match or a child path under `<href>/...`. The bare `startsWith` would
   // light up `/compare` when the user is on `/compare-per-dollar/...` since the

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -127,8 +127,8 @@ export type HeaderNavHref =
   | '/agentx'
   | '/overview'
   | '/inference'
-  | '/inference/agentic'
   | '/compare'
+  | '/blog'
   | '/about';
 
 /** Chinese labels for the site header nav, keyed by its exact English href set. */
@@ -136,8 +136,8 @@ export const NAV_LABELS_ZH: Record<HeaderNavHref, string> = {
   '/': '首页',
   '/overview': '总览',
   '/inference': '仪表板',
-  '/inference/agentic': '遥测数据',
   '/compare': '性能对比',
+  '/blog': '技术文章',
   '/agentx': 'AgentX',
   '/about': '关于',
 };


### PR DESCRIPTION
## Summary

Two navigation and copy changes.

**1. Telemetry leaves the header, Articles takes its place.** The primary nav now reads:

```
Home · AgentX · Overview · Dashboard · Comparisons · Articles · About
```

Telemetry moves into the footer's More column, between AgentX and Articles, pointing at the same `/inference/agentic` catalog.

**2. The footer brand line names the workload.** It now reads:

> Continuous open-source **agentic** inference benchmarking. Real-world, reproducible, auditable performance data trusted by trillion dollar AI infrastructure operators like OpenAI, Meta, Oracle, Microsoft, etc.

The Chinese sibling is updated to match.

## Two consequences worth a look

**The Dashboard carve-out is gone.** `header.tsx` special-cased `/inference/agentic` so a bare `startsWith('/inference')` would not light up Dashboard and Telemetry at the same time. With Telemetry out of the nav, that exclusion would leave the telemetry catalog highlighting nothing, so it is removed and the catalog now lights up Dashboard, which is where it sits in the route tree.

**The Chinese nav dictionary follows the href set.** `HeaderNavHref` swaps `/inference/agentic` for `/blog`, and `NAV_LABELS_ZH` swaps `遥测数据` for `技术文章`. That type is an exact union over the nav hrefs and the label record is keyed by it, so the compiler enforces that the two stay in step; the footer keeps a `遥测数据` label of its own.

## Tests

Updated to follow the new behavior rather than loosened:

- `cypress/component/header.cy.tsx` — nav order now expects Articles where Telemetry was; the "footer destinations stay out of the nav" case now guards Telemetry instead of Articles; both mobile-menu cases assert Articles is present and reaches `/blog`, and that Telemetry is not.
- `cypress/e2e/agentic-catalog.cy.ts` — the nav-highlight case becomes "reaches the catalog from the footer and highlights Dashboard", asserting the footer link href and that no Telemetry nav entry exists.
- `cypress/e2e/zh-pages.cy.ts` — the Chinese footer assertion tracks the new wording.

## Verification

- `bunx cypress run --component --spec cypress/component/header.cy.tsx` — 26/26 pass
- `bunx cypress run --component --spec cypress/component/footer.cy.tsx` — 8/8 pass
- `bunx cypress run --e2e --spec cypress/e2e/agentic-catalog.cy.ts` — 4/4 pass
- `bunx cypress run --e2e --spec cypress/e2e/zh-pages.cy.ts` — 16/16 pass
- `bun run test:unit` — 4,896 pass; `lint`, `fmt`, `typecheck` clean

**Pre-existing failure, not from this change:** `cypress/e2e/overview-a11y.cy.ts` fails 3 of 6 on color-contrast violations in the Overview hardware matrix. I stashed this branch and reran it on unmodified `master` at `296ed598`: identical 3 passing / 3 failing. It needs its own fix; flagging it rather than folding it in here.

## 中文说明

两处导航与文案改动。

**1. Telemetry 移出页头，Articles 顶替其位置。** 主导航现在为：

```
Home · AgentX · Overview · Dashboard · Comparisons · Articles · About
```

Telemetry 移入页脚「更多」栏，位于 AgentX 与 Articles 之间，指向同一个 `/inference/agentic` 目录页。

**2. 页脚品牌简介点明工作负载类型**，改为「Continuous open-source **agentic** inference benchmarking…」，中文版本同步更新。

### 两点值得关注的连带影响

**Dashboard 的特例判断被移除。** `header.tsx` 此前对 `/inference/agentic` 做了特殊处理，避免 `startsWith('/inference')` 同时点亮 Dashboard 和 Telemetry。Telemetry 退出导航后，若保留该排除逻辑，遥测目录页将不会高亮任何导航项，因此移除它，使该页面高亮 Dashboard——这与它在路由树中的位置一致。

**中文导航词典跟随 href 集合调整。** `HeaderNavHref` 以 `/blog` 替换 `/inference/agentic`，`NAV_LABELS_ZH` 相应地以`技术文章`替换`遥测数据`。该类型是导航 href 的精确联合类型，标签记录以它为键，因此编译器会强制两者保持同步；页脚则保留自己的`遥测数据`标签。

### 测试

按新行为更新，而非放宽断言：`header.cy.tsx` 的导航顺序断言改为 Articles，「页脚目标不出现在导航中」的用例改为校验 Telemetry，两个移动端菜单用例断言 Articles 存在且指向 `/blog`、Telemetry 不存在；`agentic-catalog.cy.ts` 的导航高亮用例改为校验页脚链接与 Dashboard 高亮；`zh-pages.cy.ts` 的中文页脚断言跟随新文案。

### 验证

- header 组件测试 26/26 通过，footer 组件测试 8/8 通过
- `agentic-catalog.cy.ts` 4/4 通过，`zh-pages.cy.ts` 16/16 通过
- `bun run test:unit` 4,896 项通过；`lint`、`fmt`、`typecheck` 均通过

**既有失败，与本次改动无关：** `cypress/e2e/overview-a11y.cy.ts` 有 3/6 因 Overview 硬件矩阵的色彩对比度问题失败。我已将本分支改动 stash 后在未修改的 `master`（`296ed598`）上复跑，结果同为 3 通过 / 3 失败。该问题需要单独修复，此处仅作提示，不并入本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI navigation and marketing copy only; routes are unchanged and there is no auth or data-layer impact.
> 
> **Overview**
> **Telemetry** is removed from the primary header and added to the footer “More” column (`footer-link-telemetry` → `/inference/agentic`, with `footer_telemetry_clicked` analytics). **Articles** (`/blog`) takes Telemetry’s slot in the main nav on desktop and mobile.
> 
> The footer brand blurb now says **agentic** inference benchmarking in English and Chinese. Chinese header typing/labels follow the new href set (`HeaderNavHref` drops `/inference/agentic` for `/blog`; `NAV_LABELS_ZH` maps it to 技术文章).
> 
> Because Telemetry is no longer a top-level nav item, **`isActive` for Dashboard** no longer excludes `/inference/agentic`—the agentic catalog page highlights **Dashboard** instead of a dedicated Telemetry tab. Cypress header, agentic-catalog, and zh-pages specs are updated for nav order, mobile menu, footer access, and copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732017e9254df2d666fbb9ea98fb18b41819427a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->