### PR TITLE
revert(compare): drop the Methodology Deep Dive hero CTA

### DIFF
--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -21,9 +21,7 @@ describe('Compare precision index page', () => {
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', 'Full dashboard')
         .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
-      cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', 'Methodology Deep Dive')
-        .and('have.attr', 'href', '/agentx');
+      cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
     });
     cy.get('[data-testid="compare-model-catalog"]')
       .should('contain.text', 'AgentX and 8K→1K results')
@@ -62,9 +60,7 @@ describe('Compare precision index page', () => {
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', '查看完整仪表板')
         .and('have.attr', 'href', '/zh/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
-      cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', '测试方法')
-        .and('have.attr', 'href', '/zh/agentx');
+      cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
     });
     cy.get('[data-testid="compare-model-catalog"]').should('contain.text', 'AgentX 与 8K→1K 结果');
     cy.get('#deepseek-v4 a[data-scenario="AgentX"]')

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -111,7 +111,7 @@ describe('First-load navigation', () => {
     cy.location('pathname').should('eq', '/inference');
   });
 
-  it('leads the landing page with the AgentX hero and its three CTAs', () => {
+  it('leads the landing page with the AgentX hero and its two CTAs', () => {
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       // The hero owns /compare's h1; on the landing page it is a section heading.
       cy.get('h2').should('have.text', 'Compare Realistic Agentic Inference Perf');
@@ -122,9 +122,7 @@ describe('First-load navigation', () => {
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
         .should('contain.text', 'Full dashboard')
         .and('have.attr', 'href', '/inference?g_model=Kimi-K3&i_seq=agentic-traces&i_optimal=1');
-      cy.get('[data-testid="compare-agentx-methodology-link"]')
-        .should('contain.text', 'Methodology Deep Dive')
-        .and('have.attr', 'href', '/agentx');
+      cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
       // Editorial order, not alphabetical — see FEATURED_AGENTX_MODEL_SLUGS.
       cy.get('[data-testid^="compare-agentx-model-"]').then(($rows) => {

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -45,9 +45,7 @@ describe('Chinese (/zh) pages', () => {
         cy.get('[data-testid="compare-agentx-overview-link"]')
           .should('contain.text', '总览')
           .and('have.attr', 'href', '/zh/overview');
-        cy.get('[data-testid="compare-agentx-methodology-link"]')
-          .should('contain.text', '测试方法')
-          .and('have.attr', 'href', '/zh/agentx');
+        cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
       });
     });
 

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -14,7 +14,6 @@ const STRINGS = {
       'Long Context Multi Turn Inference Performance. Compare Across MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
     overview: 'Overview',
     dashboard: 'Full dashboard',
-    methodology: 'Methodology Deep Dive',
     ledgerTitle: 'Models with AgentX results',
     modelAction: 'View results',
   },
@@ -25,7 +24,6 @@ const STRINGS = {
       '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro 等平台。',
     overview: '总览',
     dashboard: '查看完整仪表板',
-    methodology: '测试方法',
     ledgerTitle: '已发布 AgentX 结果的模型',
     modelAction: '查看结果',
   },
@@ -92,17 +90,6 @@ export function AgentXCompareHero({
               >
                 {t.dashboard}
                 <ArrowRight aria-hidden="true" className="size-4" />
-              </CompareIndexTrackedLink>
-            </div>
-            <div className="mt-2 flex flex-wrap gap-3">
-              <CompareIndexTrackedLink
-                data-testid="compare-agentx-methodology-link"
-                href={`${prefix}/agentx`}
-                analyticsEvent="compare_agentx_methodology_clicked"
-                analyticsSurface={surface}
-                className="inline-flex min-h-11 items-center rounded-md border border-border px-5 py-2.5 font-semibold text-foreground transition-colors hover:bg-muted"
-              >
-                {t.methodology}
               </CompareIndexTrackedLink>
             </div>
           </div>

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -10,7 +10,6 @@ interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link>
   analyticsEvent:
     | 'compare_agentx_overview_clicked'
     | 'compare_agentx_dashboard_clicked'
-    | 'compare_agentx_methodology_clicked'
     | 'compare_agentx_model_clicked';
   analyticsTarget?: string;
   /** Which page rendered the hero, so `/compare` and `/` clicks stay separable. */


### PR DESCRIPTION
Removes the third CTA ("Methodology Deep Dive" → /agentx) from the AgentX compare hero, returning it to the two original CTAs: Overview and Full dashboard.

- `agentx-compare-hero.tsx`: drop the second CTA row and the en/zh methodology strings
- `compare-index-tracked-link.tsx`: remove the now-unused `compare_agentx_methodology_clicked` analytics event type
- Cypress (`navigation`, `compare-precision`, `zh-pages`): replace the methodology-link assertions with `should('not.exist')` guards

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and test-only changes with no auth, data, or routing logic beyond removing one marketing link and its analytics type.
> 
> **Overview**
> Reverts the AgentX compare hero to **two CTAs**—Overview and Full dashboard—by removing the third **Methodology Deep Dive** link to `/agentx` (and `/zh/agentx`).
> 
> In `agentx-compare-hero.tsx`, the extra CTA row and en/zh methodology copy are deleted. `compare-index-tracked-link.tsx` no longer accepts the `compare_agentx_methodology_clicked` analytics event. Cypress specs on `/compare`, `/`, and `/zh` now assert `compare-agentx-methodology-link` **does not exist** instead of checking its label and href; the landing navigation test title is updated to “two CTAs.”
> 
> AgentX remains reachable via header and footer links; only the hero shortcut is gone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60968d3b1a0fb669c030eb1dc418adc4f473a9ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->