### PR TITLE
Rename DeepSeek V4 Pro label to DeepSeek V4 Pro 0813

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -3,7 +3,7 @@ import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-con
 // Order mirrors DEFAULT_MODELS (MODEL_CONFIG insertion order), which fixes the
 // matrix row order.
 const MODEL_LABELS = [
-  'DeepSeek V4 Pro 1.6T',
+  'DeepSeek V4 Pro 0813 1.6T',
   'Kimi K3 2.8T',
   'MiniMax M3 428B',
   'GLM5.2/GLM5.3',
@@ -858,8 +858,11 @@ describe('Overview page', () => {
 
         cy.get('[data-testid="inference-chart-display"]').should('exist');
         cy.get('[data-testid="model-selector"]').click();
-        cy.contains('[role="option"]', 'DeepSeek V4 Pro 1.6T').click();
-        cy.get('[data-testid="model-selector"]').should('contain.text', 'DeepSeek V4 Pro 1.6T');
+        cy.contains('[role="option"]', 'DeepSeek V4 Pro 0813 1.6T').click();
+        cy.get('[data-testid="model-selector"]').should(
+          'contain.text',
+          'DeepSeek V4 Pro 0813 1.6T',
+        );
         cy.get('[data-testid="inference-chart-display"]').should(
           'not.contain.text',
           'No data available',
@@ -1085,12 +1088,12 @@ describe('Overview page', () => {
           .should(
             'have.attr',
             'title',
-            'Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP',
+            'Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 0813 1.6T · B200 · SGLang · FP4 · MTP',
           )
           .and(
             'have.attr',
             'aria-label',
-            'Approximately $0.059. Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP',
+            'Approximately $0.059. Estimated from validated benchmark runs. Open raw source dashboard for Jul 18: DeepSeek V4 Pro 0813 1.6T · B200 · SGLang · FP4 · MTP',
           );
         cy.get('[data-testid="overview-pair-missing"]').should('not.exist');
       });
@@ -1286,7 +1289,7 @@ describe('Overview page', () => {
 
     desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       expectAgentxScenario(AGENTX_LABEL);
-      cy.contains('DeepSeek V4 Pro 1.6T').should('exist');
+      cy.contains('DeepSeek V4 Pro 0813 1.6T').should('exist');
       // Priced from the AgentX rows alone — the single-turn sweep never leaks in.
       cy.get(
         '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
@@ -1304,14 +1307,14 @@ describe('Overview page', () => {
       cy.contains('a', 'View details').should(
         'have.attr',
         'aria-label',
-        `View details: DeepSeek V4 Pro 1.6T · ${AGENTX_LABEL}`,
+        `View details: DeepSeek V4 Pro 0813 1.6T · ${AGENTX_LABEL}`,
       );
     });
     desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
       cy.contains('a', 'View details').should(
         'have.attr',
         'aria-label',
-        'View details: DeepSeek V4 Pro 1.6T · 8K/1K',
+        'View details: DeepSeek V4 Pro 0813 1.6T · 8K/1K',
       );
     });
   });
@@ -1784,7 +1787,7 @@ describe('Overview page', () => {
       .as('estimatedB200')
       .invoke('attr', 'title')
       .should('include', '根据已验证的基准测试结果估算。')
-      .and('include', '原始数据仪表板：DeepSeek V4 Pro 1.6T · B200 · SGLang · FP4 · MTP');
+      .and('include', '原始数据仪表板：DeepSeek V4 Pro 0813 1.6T · B200 · SGLang · FP4 · MTP');
     cy.get('@estimatedB200')
       .invoke('attr', 'aria-label')
       .should('include', '约 $0.059。根据已验证的基准测试结果估算。');

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -595,7 +595,7 @@ describe('TCO Calculator', () => {
     // open straight to the right model without a flash of the default. See #430.
     it('?g_model= seeds the model selector before client hydration', () => {
       cy.request('/calculator?g_model=DeepSeek-V4-Pro').then((response) => {
-        expect(response.body).to.contain('DeepSeek V4 Pro 1.6T');
+        expect(response.body).to.contain('DeepSeek V4 Pro 0813 1.6T');
         expect(response.body).not.to.contain('DeepSeek R1 0528 671B');
       });
     });
@@ -605,7 +605,10 @@ describe('TCO Calculator', () => {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       });
       cy.visit('/calculator?g_model=DeepSeek-V4-Pro');
-      cy.get('[data-testid="calc-model-selector"]').should('contain.text', 'DeepSeek V4 Pro 1.6T');
+      cy.get('[data-testid="calc-model-selector"]').should(
+        'contain.text',
+        'DeepSeek V4 Pro 0813 1.6T',
+      );
     });
   });
 

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -272,7 +272,7 @@ describe('getModelLabel', () => {
     expect(getModelLabel(Model.Llama3_3_70B)).toBe('Llama 3.3 70B Instruct');
     expect(getModelLabel(Model.Llama3_1_70B)).toBe('Llama 3.1 70B Instruct');
     expect(getModelLabel(Model.DeepSeek_R1)).toBe('DeepSeek R1 0528 671B');
-    expect(getModelLabel(Model.DeepSeek_V4_Pro)).toBe('DeepSeek V4 Pro 1.6T');
+    expect(getModelLabel(Model.DeepSeek_V4_Pro)).toBe('DeepSeek V4 Pro 0813 1.6T');
     expect(getModelLabel(Model.GptOss)).toBe('gpt-oss 120B');
     expect(getModelLabel(Model.Qwen3_5)).toBe('Qwen3.5 397B');
     expect(getModelLabel(Model.Kimi_K2_5)).toBe('Kimi K2.5/2.6/2.7-Code 1T');

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -125,7 +125,7 @@ const GUARDED_ENGINE_FAMILIES = ['vllm', 'sglang'] as const;
 // duplication needed.
 const MODEL_CONFIG: Record<Model, ModelConfig> = {
   [Model.DeepSeek_V4_Pro]: {
-    label: 'DeepSeek V4 Pro 1.6T',
+    label: 'DeepSeek V4 Pro 0813 1.6T',
     prefix: 'dsv4',
     category: 'default',
     exclusion: MTP_ENGINE_EXCLUSION,


### PR DESCRIPTION
## Summary
- Update the model label from `DeepSeek V4 Pro 1.6T` to `DeepSeek V4 Pro 0813 1.6T` in `data-mappings.ts`, matching the `DeepSeek R1 0528 671B` version-date convention
- Update the unit test and Cypress specs (`overview.cy.ts`, `throughput-calculator.cy.ts`) that assert on the literal label
- Published article MDX alt-text left untouched (historical content)

## Testing
- `vitest run src/lib/data-mappings.test.ts` — 47 passed
- lefthook typecheck/lint/format passed

Requested by Oren in Slack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only label change with no routing, data, or exclusion logic touched; risk is limited to missed string assertions elsewhere.
> 
> **Overview**
> Updates the **display label** for `DeepSeek-V4-Pro` from `DeepSeek V4 Pro 1.6T` to **`DeepSeek V4 Pro 0813 1.6T`** in `MODEL_CONFIG` (`data-mappings.ts`), aligning with the version-date style used for models like `DeepSeek R1 0528 671B`. The internal enum and URL keys (`g_model=DeepSeek-V4-Pro`) are unchanged.
> 
> **Tests** that assert on the human-readable string were updated in `data-mappings.test.ts`, `overview.cy.ts`, and `throughput-calculator.cy.ts` (including SSR HTML checks for calculator share links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387e9025116ec5a3759b6f4b50ecf8efe7dd69b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->