### PR TITLE
Move KV-offload key, optimization note, and ATOM footnote to the info footer

### DIFF
--- a/packages/app/cypress/component/gpu-graph.cy.tsx
+++ b/packages/app/cypress/component/gpu-graph.cy.tsx
@@ -185,12 +185,12 @@ describe('GPUGraph', () => {
     cy.get('#test-gpu-agentic-decorations [data-testid="spec-decode-marker-key"]').should(
       'not.exist',
     );
-    cy.get('#test-gpu-agentic-decorations [data-testid="offload-halo-key"]').should('exist');
-    cy.get('#test-gpu-agentic-decorations [data-testid="agentic-optimization-note"]')
-      .should('contain.text', 'Inference optimizations enabled')
-      .find('button')
-      .focus();
-    cy.contains('Each configuration may use inference optimizations').should('be.visible');
+    // The KV-offload key and optimization note moved to the axis-metric info
+    // footer rendered by ChartDisplay, so the chart itself carries neither.
+    cy.get('#test-gpu-agentic-decorations [data-testid="offload-halo-key"]').should('not.exist');
+    cy.get('#test-gpu-agentic-decorations [data-testid="agentic-optimization-note"]').should(
+      'not.exist',
+    );
     cy.get('#test-gpu-agentic-decorations svg .dot-group').first().trigger('mouseenter');
     cy.get('[data-chart-tooltip]').should('contain.text', 'Speculative Decoding');
     cy.get('[data-chart-tooltip]').should('contain.text', 'MTP');

--- a/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
+++ b/packages/app/cypress/e2e/ttft-x-axis-toggle.cy.ts
@@ -199,8 +199,8 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     cy.get('[data-testid="chart-figure"] h2').should('contain.text', 'Interactivity');
   });
 
-  it('explains the offload halo in the legend and distinguishes it from plain points', () => {
-    cy.get('#chart-0 [data-testid="offload-halo-key"]')
+  it('explains the offload halo in the info footer and distinguishes it from plain points', () => {
+    cy.get('[data-testid="axis-metric-footer-chart-0"] [data-testid="offload-halo-key"]')
       .should('be.visible')
       .and('contain.text', 'KV offload ON');
     cy.get('#chart-0 .offload-halo').should('have.length.at.least', 1);
@@ -211,25 +211,14 @@ describe('X-Axis Mode Toggle (inference chart)', () => {
     });
   });
 
-  it('keeps the offload halo explanation in the PNG export clone', () => {
-    cy.window().then((win) => {
-      const exportContainer = win.document.querySelector('#chart-0-export');
-      expect(exportContainer).not.to.equal(null);
-      const state = { seen: false };
-      const observer = new win.MutationObserver(() => {
-        if (exportContainer?.querySelector('[data-testid="offload-halo-key"]')) {
-          state.seen = true;
-          observer.disconnect();
-        }
-      });
-      observer.observe(exportContainer!, { childList: true, subtree: true });
-      (win as typeof win & { __offloadHaloExportState: typeof state }).__offloadHaloExportState =
-        state;
-    });
-
-    cy.get('[data-testid="chart-figure"]').first().find('[data-testid="export-button"]').click();
-    cy.get('[data-testid="export-png-button"]').click();
-    cy.window().its('__offloadHaloExportState.seen').should('eq', true);
+  it('keeps the offload halo explanation out of the chart capture tree', () => {
+    // The key lives in the axis-metric info footer (a `no-export` sibling of
+    // the chart), so the PNG export clone — built from #chart-0 — carries the
+    // halo decoration itself but not the textual key.
+    cy.get('[data-testid="axis-metric-footer-chart-0"] [data-testid="offload-halo-key"]').should(
+      'be.visible',
+    );
+    cy.get('#chart-0 [data-testid="offload-halo-key"]').should('not.exist');
   });
 
   it('shows the selected percentile in the Interactivity axis label', () => {
@@ -640,7 +629,7 @@ describe('X-Axis Mode Toggle — overlay path (finding #8 regression guard)', ()
       'contain.text',
       'P90 Interactivity (tok/s/user)',
     );
-    cy.get('#chart-0 [data-testid="offload-halo-key"]')
+    cy.get('[data-testid="axis-metric-footer-chart-0"] [data-testid="offload-halo-key"]')
       .should('be.visible')
       .and('contain.text', 'KV offload ON');
   });

--- a/packages/app/src/components/inference/ui/AgenticOptimizationNote.tsx
+++ b/packages/app/src/components/inference/ui/AgenticOptimizationNote.tsx
@@ -22,14 +22,14 @@ const STRINGS = {
   },
 } as const;
 
-/** Agentic-only legend note; point tooltips carry the exact optimization method. */
+/** Agentic-only info-footer note; point tooltips carry the exact optimization method. */
 export function AgenticOptimizationNote() {
   const t = STRINGS[useLocale()];
 
   return (
     <div
       data-testid="agentic-optimization-note"
-      className="mt-2 flex w-full items-center gap-1 px-1 pr-2 text-xs italic text-blue-600 dark:text-blue-400"
+      className="flex w-full items-center gap-1 px-1 pr-2 text-xs italic text-blue-600 dark:text-blue-400"
     >
       <span>*{t.label}</span>
       <TooltipProvider delayDuration={100}>

--- a/packages/app/src/components/inference/ui/AxisMetricFooter.test.tsx
+++ b/packages/app/src/components/inference/ui/AxisMetricFooter.test.tsx
@@ -57,6 +57,17 @@ function click(el: Element) {
 }
 
 describe('AxisMetricFooter', () => {
+  it('renders notices in a dedicated section only when provided', () => {
+    render();
+    expect(container.querySelector('[data-testid="axis-metric-notices-chart-0"]')).toBeNull();
+    render({ notices: <span data-testid="footer-notice">KV offload ON</span> });
+    const notices = container.querySelector('[data-testid="axis-metric-notices-chart-0"]');
+    expect(notices).not.toBeNull();
+    expect(notices!.querySelector('[data-testid="footer-notice"]')!.textContent).toBe(
+      'KV offload ON',
+    );
+  });
+
   it('renders one collapsed row per axis', () => {
     render();
     const xRow = container.querySelector('[data-testid="axis-metric-row-x-chart-0"]');

--- a/packages/app/src/components/inference/ui/AxisMetricFooter.tsx
+++ b/packages/app/src/components/inference/ui/AxisMetricFooter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Info, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 
 import {
   METRIC_EXPLANATIONS,
@@ -40,6 +40,11 @@ interface AxisMetricFooterProps {
    * only to extract the percentile prefix for the row name.
    */
   xAxisLabel: string;
+  /**
+   * Chart-level notices (KV-offload halo key, agentic optimization note,
+   * ATOM engine footnote) rendered as the info section's final block.
+   */
+  notices?: ReactNode;
 }
 
 interface FooterRow {
@@ -65,6 +70,7 @@ export default function AxisMetricFooter({
   metricKey,
   xAxisKind,
   xAxisLabel,
+  notices,
 }: AxisMetricFooterProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
@@ -150,6 +156,14 @@ export default function AxisMetricFooter({
           </div>
         );
       })}
+      {notices && (
+        <div
+          className="space-y-2 border-t border-border/60 py-2.5"
+          data-testid={`axis-metric-notices-${chartId}`}
+        >
+          {notices}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -42,7 +42,7 @@ import { metricLabel, metricTitle } from '@/lib/chart-utils';
 import { exportToCsv } from '@/lib/csv-export';
 import { inferenceChartToCsv } from '@/lib/csv-export-helpers';
 import { knownIssueCsvNote, matchKnownConfigIssues } from '@/lib/known-issues';
-import { getDisplayLabel } from '@/lib/utils';
+import { getDisplayLabel, getFrameworkLabel } from '@/lib/utils';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   useOverlayScopeReconciliation,
@@ -72,6 +72,10 @@ import { useResidentSequenceLengths } from '@/hooks/api/use-resident-sequence-le
 import { getHardwareConfig, hardwareKeyMatchesAnyBase } from '@/lib/constants';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useLocale } from '@/lib/use-locale';
+
+import { ATOM_FOOTNOTE_MARKER, AtomEngineFootnote } from '@/components/ui/atom-engine-footnote';
+import { AgenticOptimizationNote } from '@/components/inference/ui/AgenticOptimizationNote';
+import { OffloadHaloLegendKey } from '@/components/inference/ui/OffloadHaloLegendKey';
 
 import AxisMetricFooter from './AxisMetricFooter';
 import ChartControls from './ChartControls';
@@ -829,6 +833,36 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
               ).xAxisField,
               isDerivedNormalizedInteractivity: Boolean(derivedSpec),
             });
+            // Notices for the axis-metric info footer: the KV-offload halo
+            // key, the agentic optimization note, and the ATOM engine
+            // footnote. Detected from the same data the chart plots —
+            // official points plus any loaded unofficial-run overlay for
+            // this chart type — so they moved out of the legend without
+            // changing when they appear.
+            const footerOverlay = selectUnofficialOverlayForMode(
+              selectedXAxisMode,
+              graph.chartDefinition.chartType,
+              overlayDataByChartType,
+            );
+            const footerPoints = [
+              ...graph.data,
+              ...(footerOverlay?.data ?? []),
+              ...(footerOverlay?.clippedData ?? []).map((entry) => entry.point),
+            ];
+            const hasOffloadHalo = footerPoints.some((point) => point.offload_mode === 'on');
+            const hasAtomSeries = footerPoints.some(
+              (point) =>
+                point.framework !== undefined &&
+                getFrameworkLabel(point.framework).includes(ATOM_FOOTNOTE_MARKER),
+            );
+            const footerNotices =
+              hasOffloadHalo || isAgenticSequence || hasAtomSeries ? (
+                <>
+                  {hasOffloadHalo && <OffloadHaloLegendKey />}
+                  {isAgenticSequence && <AgenticOptimizationNote />}
+                  {hasAtomSeries && <AtomEngineFootnote />}
+                </>
+              ) : undefined;
             return (
               <section key={graphIndex} className="pt-8 md:pt-0">
                 <figure data-testid="chart-figure" className="relative rounded-lg">
@@ -1099,6 +1133,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                       metricKey={selectedYAxisMetric.replace(/^y_/u, '') as MetricKey}
                       xAxisKind={footerXAxisKind}
                       xAxisLabel={graph.chartDefinition.x_label}
+                      notices={footerNotices}
                     />
                     {replayAvailable && (
                       <ReplayLauncher

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -839,11 +839,20 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
             // official points plus any loaded unofficial-run overlay for
             // this chart type — so they moved out of the legend without
             // changing when they appear.
-            const footerOverlay = selectUnofficialOverlayForMode(
-              selectedXAxisMode,
-              graph.chartDefinition.chartType,
-              overlayDataByChartType,
-            );
+            // GPU/date comparison renders GPUGraph, which plots official
+            // points only — skip the unofficial overlay there so the footer
+            // can't advertise a halo or ATOM series that isn't on the chart.
+            const isGpuComparison =
+              selectedGPUs.length > 0 &&
+              ((selectedDateRange.startDate && selectedDateRange.endDate) ||
+                selectedDates.length > 0);
+            const footerOverlay = isGpuComparison
+              ? undefined
+              : selectUnofficialOverlayForMode(
+                  selectedXAxisMode,
+                  graph.chartDefinition.chartType,
+                  overlayDataByChartType,
+                );
             const footerPoints = [
               ...graph.data,
               ...(footerOverlay?.data ?? []),
@@ -1093,9 +1102,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                         );
                       }
 
-                      return selectedGPUs.length > 0 &&
-                        ((selectedDateRange.startDate && selectedDateRange.endDate) ||
-                          selectedDates.length > 0) ? (
+                      return isGpuComparison ? (
                         <GPUGraph
                           chartId={`chart-${graphIndex}`}
                           modelLabel={graph.model}

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -64,7 +64,6 @@ import {
   createKnownIssueLayer,
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchKnownConfigIssues, pointMatchesIssue } from '@/lib/known-issues';
-import { OffloadHaloLegendKey } from '@/components/inference/ui/OffloadHaloLegendKey';
 import { renderOffloadHalo } from '@/components/inference/utils/offload-halo';
 import {
   parallelismLabelBoxes,
@@ -74,7 +73,6 @@ import {
   updateRenderedLineLabels,
   type LineLabelSeries,
 } from '@/components/inference/ui/line-label-layer';
-import { AgenticOptimizationNote } from '@/components/inference/ui/AgenticOptimizationNote';
 import { QuickFiltersDialog } from '@/components/inference/ui/QuickFiltersDialog';
 
 const FixedSequenceLogDialog = dynamic(() =>
@@ -192,7 +190,6 @@ const GPUGraph = React.memo(
       setQuickFilterDeployment,
       setQuickFilterSpec,
     ]);
-    const hasOffloadHalo = useMemo(() => data.some((point) => point.offload_mode === 'on'), [data]);
 
     // Shared date+GPU pairs. `dates` holds comparison-series entries (plain dates
     // and/or specific-run entries); a same-day range endpoint is dropped when that
@@ -1007,14 +1004,9 @@ const GPUGraph = React.memo(
               },
             ]}
             precisionIndicators={selectedPrecisions}
+            hideAtomFootnote
             keyIndicators={
               <>
-                {hasOffloadHalo || selectedSequence === Sequence.AgenticTraces ? (
-                  <>
-                    {hasOffloadHalo && <OffloadHaloLegendKey />}
-                    {selectedSequence === Sequence.AgenticTraces && <AgenticOptimizationNote />}
-                  </>
-                ) : null}
                 {fixedLogPointId === null ? null : (
                   <FixedSequenceLogDialog
                     pointId={fixedLogPointId}

--- a/packages/app/src/components/inference/ui/OffloadHaloLegendKey.tsx
+++ b/packages/app/src/components/inference/ui/OffloadHaloLegendKey.tsx
@@ -5,15 +5,15 @@ export const OFFLOAD_HALO_STROKE_WIDTH = 1.5;
 export const OFFLOAD_HALO_DASHARRAY = '3 2';
 
 /**
- * Legend key for the dashed ring drawn around agentic points that use KV-cache
- * offload. This stays outside `no-export` content so the chart export clone
- * carries the same explanation into downloaded PNGs.
+ * Key for the dashed ring drawn around agentic points that use KV-cache
+ * offload. Rendered in the axis-metric info footer below the chart (the
+ * footer is `no-export`, so downloaded PNGs carry only the halo itself).
  */
 export function OffloadHaloLegendKey() {
   return (
     <div
       data-testid="offload-halo-key"
-      className="mt-2 flex w-full items-center gap-2 px-1 pr-2 text-xs text-muted-foreground"
+      className="flex w-full items-center gap-2 px-1 pr-2 text-xs text-muted-foreground"
     >
       <svg
         width="16"

--- a/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.decoration.test.tsx
@@ -120,8 +120,10 @@ describe('ScatterGraph toggle decoration', () => {
     expect(groups[1].querySelector('.offload-halo')).toBeNull();
     expect(groups[2].querySelector('.offload-halo')).not.toBeNull();
     expect(container.querySelector('[data-testid="spec-decode-marker-key"]')).toBeNull();
-    expect(container.querySelector('[data-testid="offload-halo-key"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="agentic-optimization-note"]')).not.toBeNull();
+    // The KV-offload key and optimization note moved to the axis-metric info
+    // footer rendered by ChartDisplay, so the chart itself carries neither.
+    expect(container.querySelector('[data-testid="offload-halo-key"]')).toBeNull();
+    expect(container.querySelector('[data-testid="agentic-optimization-note"]')).toBeNull();
     unmount();
   });
 

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -98,9 +98,7 @@ import {
   scatterPointJoinId,
 } from '@/components/inference/utils/point-identity';
 import LegendPointsDialog from '@/components/inference/ui/LegendPointsDialog';
-import { OffloadHaloLegendKey } from '@/components/inference/ui/OffloadHaloLegendKey';
 import { renderOffloadHalo } from '@/components/inference/utils/offload-halo';
-import { AgenticOptimizationNote } from '@/components/inference/ui/AgenticOptimizationNote';
 import { buildLegendPointsRows } from '@/components/inference/utils/legend-points-table';
 import { pointLabelText } from './point-label';
 import {
@@ -979,12 +977,6 @@ const ScatterGraph = React.memo(
 
     // All official points for rendering (unfiltered — visibility via opacity)
     const pointsData = useMemo(() => Object.values(groupedData).flat(), [groupedData]);
-    const hasOffloadHalo = useMemo(
-      () =>
-        pointsData.some((point) => point.offload_mode === 'on') ||
-        processedOverlayData.some((point) => point.offload_mode === 'on'),
-      [pointsData, processedOverlayData],
-    );
     // Bulk presence lookup for agentic points: which ids have a stored
     // trace_replay blob → controls the "View charts" button in the pinned
     // tooltip. We deliberately don't fetch the histograms themselves here;
@@ -3143,14 +3135,7 @@ const ScatterGraph = React.memo(
                 },
               ]}
               precisionIndicators={selectedPrecisions}
-              keyIndicators={
-                hasOffloadHalo || selectedSequence === Sequence.AgenticTraces ? (
-                  <>
-                    {hasOffloadHalo && <OffloadHaloLegendKey />}
-                    {selectedSequence === Sequence.AgenticTraces && <AgenticOptimizationNote />}
-                  </>
-                ) : undefined
-              }
+              hideAtomFootnote
               enableTooltips={true}
             />
           }

--- a/packages/app/src/components/ui/atom-engine-footnote.tsx
+++ b/packages/app/src/components/ui/atom-engine-footnote.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+/**
+ * Superscript marker appended to ATOM-family framework labels (e.g. "ATOM¹",
+ * "Mooncake ATOMesh¹"). Consumers detect it in a display label to decide
+ * whether the footnote below applies to the chart.
+ */
+export const ATOM_FOOTNOTE_MARKER = '¹';
+
+const STRINGS = {
+  en: {
+    atomFootnote:
+      'The ATOM engine is promising, however it has yet to serve production tokens. It is still in its infant stage.',
+  },
+  zh: {
+    atomFootnote: 'ATOM 引擎前景可期，但尚未用于生产环境 token 服务，仍处于早期阶段。',
+  },
+} as const;
+
+/**
+ * Footnote explaining the ¹ marker on ATOM-family series labels. Rendered in
+ * the evaluation chart legend and in the inference chart's axis-metric info
+ * footer, so the copy lives in one place.
+ */
+export function AtomEngineFootnote({ className }: { className?: string }) {
+  const locale = useLocale();
+  return (
+    <p
+      data-testid="atom-engine-footnote"
+      className={cn('text-[10px] text-muted-foreground/70 leading-tight', className)}
+    >
+      <sup>1</sup> {STRINGS[locale].atomFootnote}
+    </p>
+  );
+}

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -28,6 +28,7 @@ const SHAPE_ICON: Record<ShapeKey, React.ComponentType<{ size?: number; classNam
   diamond: Diamond,
 };
 
+import { ATOM_FOOTNOTE_MARKER, AtomEngineFootnote } from './atom-engine-footnote';
 import ChartLegendItem, { type CommonLegendItemProps } from './chart-legend-item';
 import { Label } from './label';
 import { Switch } from './switch';
@@ -48,8 +49,6 @@ const STRINGS = {
     expandLegend: 'Expand legend',
     hide: (label: string) => `Hide ${label}`,
     showPoints: (label: string) => `Show all ${label} data points`,
-    atomFootnote:
-      'The ATOM engine is promising, however it has yet to serve production tokens. It is still in its infant stage.',
   },
   zh: {
     advanced: '高级',
@@ -63,7 +62,6 @@ const STRINGS = {
     expandLegend: '展开图例',
     hide: (label: string) => `隐藏${label}`,
     showPoints: (label: string) => `显示${label}的全部数据点`,
-    atomFootnote: 'ATOM 引擎前景可期，但尚未用于生产环境 token 服务，仍处于早期阶段。',
   },
 } as const;
 
@@ -109,6 +107,12 @@ export interface ChartLegendProps {
   onItemHoverEnd?: () => void;
   onItemRemove?: (name: string) => void;
   onAdvancedExpandedChange?: (expanded: boolean) => void;
+  /**
+   * Suppress the ATOM engine footnote even when a legend label carries the ¹
+   * marker. Inference charts pass this because they render the footnote in
+   * the axis-metric info footer below the chart instead of in the legend.
+   */
+  hideAtomFootnote?: boolean;
 }
 
 export default function ChartLegend({
@@ -129,6 +133,7 @@ export default function ChartLegend({
   onItemHoverEnd,
   onItemRemove,
   onAdvancedExpandedChange,
+  hideAtomFootnote = false,
 }: ChartLegendProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
@@ -235,8 +240,9 @@ export default function ChartLegend({
 
   // Show ATOM footnote when any legend item label contains the ¹ marker
   const hasAtomFootnote = useMemo(
-    () => legendItems.some((item) => item.label.includes('¹')),
-    [legendItems],
+    () =>
+      !hideAtomFootnote && legendItems.some((item) => item.label.includes(ATOM_FOOTNOTE_MARKER)),
+    [legendItems, hideAtomFootnote],
   );
 
   const shapeIndicators = useMemo(() => {
@@ -511,11 +517,7 @@ export default function ChartLegend({
       {fpIndicators}
       {keyIndicators}
       {expandButton}
-      {hasAtomFootnote && (
-        <p className="mt-2 text-[10px] text-muted-foreground/70 leading-tight no-export">
-          <sup>1</sup> {t.atomFootnote}
-        </p>
-      )}
+      {hasAtomFootnote && <AtomEngineFootnote className="mt-2 no-export" />}
     </div>
   ) : null;
 


### PR DESCRIPTION
## Summary
Moves three chart-legend notices into the axis-metric info footer (the collapsible X-axis/Y-axis section under each inference chart), per request:
- the **KV offload ON** halo key
- the **\*Inference optimizations enabled** note
- the **ATOM engine footnote** (¹ …yet to serve production tokens…)

## Changes
- `AxisMetricFooter` gains a `notices` slot rendered after the axis rows in a bordered section (`axis-metric-notices-<chartId>`).
- `ChartDisplay` derives the notices from the plotted data (official points + any unofficial-run overlay): `offload_mode === 'on'` → halo key, agentic sequence → optimization note, framework label containing the ¹ marker → ATOM footnote (new shared `AtomEngineFootnote` component, en/zh).
- `ScatterGraph`/`GPUGraph` no longer render the halo key or optimization note in the legend; inference legends pass `hideAtomFootnote`. Evaluation charts (`BarChartD3`) keep the in-legend ATOM footnote unchanged.
- Notice components dropped their `mt-2` (spacing now owned by the footer section).

## Behavior notes
- The footer is a `no-export` sibling of `#chart-N`, so **PNG exports now carry only the halo decoration itself, not the textual key** — intentional consequence of the move.
- Timeline (GPU comparison) charts can now show the ATOM footnote where the legend previously couldn't (its labels are dates), since detection is data-driven.

## Testing
- `bun run typecheck`, `bun run lint`, `bun run fmt` clean
- `bun run test:unit` — all 4,947 tests pass (Node 24)
- Updated: `ScatterGraph.decoration.test.tsx`, `gpu-graph.cy.tsx`, `ttft-x-axis-toggle.cy.ts` (footer selectors; the PNG-export-clone test now asserts the key stays out of the capture tree); added an `AxisMetricFooter` notices unit test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI relocation of chart annotations and export behavior with broad test coverage; no auth, data, or API changes.
> 
> **Overview**
> Moves the **KV offload ON** halo key, the agentic **\*Inference optimizations enabled** note, and the **ATOM engine** footnote out of scatter/GPU chart legends into the collapsible **axis-metric info footer** under each inference chart.
> 
> `AxisMetricFooter` adds an optional `notices` block (`axis-metric-notices-<chartId>`). `ChartDisplay` builds those notices from the same points the chart plots (official data plus unofficial overlay), with GPU/date comparison charts excluding overlay so the footer cannot describe series that are not drawn. Inference legends pass `hideAtomFootnote` and use a shared `AtomEngineFootnote` component; evaluation charts still show the ATOM footnote in the legend.
> 
> Because the footer is `no-export`, **PNG exports keep halo graphics on the chart but no longer include the textual legend keys**—tests were updated to assert footer selectors and that `#chart-N` does not contain the offload key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55dd2b3c9ad624baf4548b3211b1b825783e71d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->