### PR TITLE
chore(db): purge run 32695861783 (DSV4 B300 SGLang AgentX dev image) / 清除 run 32695861783（DSV4 B300 SGLang AgentX 开发镜像）

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -89,6 +89,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   29912027293, // 2026-07-22 | Reason: accidental ingest while testing
   30346826643, // 2026-07-28 | Initial AMD submission for MiniMax M3 used incorrect AgentX harness; MTP/spec decode is AgentX-only. Will update after harness updates.
   30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
+  32695861783, // 2026-08-24 | Reason: dev image — the dsv4-fp4-b300-sglang-agentic-hicache-mtp AgentX sweep ran on lmsysorg/sglang-staging:dev-cu13-pr-35880, built from the unmerged SGLang draft PR sgl-project/sglang#35880 (source run of the PR #2701 sweep-reuse ingest)
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
Adds run `32695861783` to `PURGED_RUNS`, so ingest skips it and `db:apply-overrides` deletes its rows.

It is the ingest source run for [InferenceX#2701](https://github.com/SemiAnalysisAI/InferenceX/pull/2701) (`dsv4-fp4-b300-sglang-agentic-hicache-mtp`, 12 agentic points). Every job served on `lmsysorg/sglang-staging:dev-cu13-pr-35880`, built from the unmerged draft [sgl-project/sglang#35880](https://github.com/sgl-project/sglang/pull/35880), so the results match no released SGLang build.

Only this run is purged — the three earlier sweeps on that branch (32514214332, 32497504172, 32454825757) failed and were never ingested.

## 中文说明

将 run `32695861783` 加入 `PURGED_RUNS`，使 ingest 跳过该 run，并由 `db:apply-overrides` 删除其数据库记录。

该 run 是 [InferenceX#2701](https://github.com/SemiAnalysisAI/InferenceX/pull/2701) 的 ingest 源 run（`dsv4-fp4-b300-sglang-agentic-hicache-mtp`，12 个 agentic 数据点）。其中所有作业均使用 `lmsysorg/sglang-staging:dev-cu13-pr-35880` 镜像，构建自尚未合并的草稿 PR [sgl-project/sglang#35880](https://github.com/sgl-project/sglang/pull/35880)，因此结果不对应任何已发布的 SGLang 版本。

仅清除该 run —— 同一分支上更早的三次 sweep（32514214332、32497504172、32454825757）均已失败，从未被 ingest。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-run ETL override that drops non-production benchmark data; no application logic or auth changes, though CI will delete existing DB rows for that run after merge.
> 
> **Overview**
> Adds GitHub Actions run **`32695861783`** to **`PURGED_RUNS`** in `run-overrides.ts`, so the ingest pipeline skips it (`isRunAttemptPurged`) and **`db:apply-overrides`** removes any rows already stored for that run.
> 
> The purge targets the ingest source for the **`dsv4-fp4-b300-sglang-agentic-hicache-mtp`** AgentX sweep (InferenceX PR #2701): jobs ran on a **staging dev image** (`lmsysorg/sglang-staging:dev-cu13-pr-35880`) built from an **unmerged** SGLang draft PR, so the points are not comparable to released-stack benchmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f430e90f0bcd442ba804fd8f3a42f5d117b89f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->