### PR TITLE
feat(fleet): move Fleet Lifecycle economics to its own /fleet page / 将集群生命周期经济性移至独立的 /fleet 页面

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -191,6 +191,16 @@ output tokens and then apply it to total throughput; the existing
 
 ## Fleet Lifecycle (`FleetLifecycle.tsx`)
 
+> **Now on its own page.** The section no longer renders on `/calculator`; it is
+> the body of the `/fleet` route (and `/zh/fleet`), hosted by
+> `FleetLifecycleDisplay.tsx`, which owns the same model/scenario/precision/
+> cost-tier/target controls the calculator page does and renders the chip
+> legend in its controls card, where it stays reachable from the table view and
+> when nothing is plottable. The calculator keeps a pointer card linking to `/fleet`, and
+> its cost-target panel now renders the MW budget input (`c_mw` is shared
+> between the two pages, so a budget set on one seeds the other). Everything
+> below about the section's internals still applies unchanged.
+
 Everything above answers "which chip is cheapest at this interactivity, right
 now?". This section answers "what has a fleet of it earned and cost since the
 model shipped?" — and the answer is measured, not assumed.

--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -25,7 +25,7 @@ function readCapturedLifecycleCsv(): Cypress.Chainable<string> {
   });
 }
 
-// Fleet Lifecycle section on /calculator. The distinguishing behaviours, all
+// Fleet Lifecycle section on its own /fleet page. The distinguishing behaviours, all
 // worth locking down:
 //  - it reads the FULL run history, so a row's operating point can come from an
 //    earlier date than the caption's run date — and must say which;
@@ -145,7 +145,7 @@ const lineVertices = () =>
     .invoke('attr', 'd')
     .then((d) => (d ?? '').split('L').length);
 
-describe('Calculator — Fleet Lifecycle', () => {
+describe('Fleet — Fleet Lifecycle', () => {
   before(() => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
@@ -155,8 +155,9 @@ describe('Calculator — Fleet Lifecycle', () => {
       // something this section can fix, so suppress the nudge rather than race it.
       win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
     });
-    cy.visit('/calculator');
-    cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length.greaterThan', 0);
+    cy.visit('/fleet');
+    // Readiness: the lifecycle section only mounts once run data has loaded.
+    cy.get('[data-testid="calculator-lifecycle-section"]').should('exist');
   });
 
   beforeEach(resetToChart);
@@ -709,20 +710,25 @@ describe('Calculator — Fleet Lifecycle', () => {
   });
 
   it('follows legend visibility', () => {
+    // The legend lives in the controls card, outside the figure, so it stays
+    // reachable from the table view and even when nothing is plottable.
     showTable();
     // Legend entries are configs and clicking one isolates it. Configs sit one
     // level below the lines now, so isolating a single config leaves at most one
     // chip — and none at all when that config was never measured at the target,
-    // which is a legitimate state rather than a broken chart.
+    // which is a legitimate state rather than a broken chart. The section-level
+    // assertion covers both: the table shows at most one row, or is absent
+    // entirely in favour of the explanatory message.
     cy.get('[data-testid="calculator-lifecycle-table"] tbody tr').then(($rows) => {
       const fullCount = $rows.length;
       expect(fullCount).to.be.greaterThan(1);
-      cy.get('.sidebar-legend label').first().click();
-      cy.get('[data-testid="calculator-lifecycle-table"] tbody tr').should(
-        'have.length.at.most',
-        1,
-      );
-      cy.get('.sidebar-legend label').first().click();
+      cy.get('[data-testid="fleet-legend"] ul label').first().click();
+      cy.get('[data-testid="calculator-lifecycle-section"]').should(($section) => {
+        expect(
+          $section.find('[data-testid="calculator-lifecycle-table"] tbody tr').length,
+        ).to.be.at.most(1);
+      });
+      cy.get('[data-testid="fleet-legend"] ul label').first().click();
       cy.get('[data-testid="calculator-lifecycle-table"] tbody tr').should(
         'have.length',
         fullCount,
@@ -733,11 +739,11 @@ describe('Calculator — Fleet Lifecycle', () => {
   it('explains chips that were never measured at an extreme target instead of dropping them', () => {
     // Pushing the target to the top of the range leaves chips outside their
     // measured interactivity; the honest answer is to say so, with the range.
-    cy.get('[data-testid="calculator-controls"] input[type="range"]')
+    cy.get('[data-testid="fleet-controls"] input[type="range"]')
       .invoke('attr', 'max')
       .then((max) => {
-        cy.get('[data-testid="calculator-controls"] input[type="number"]').clear();
-        cy.get('[data-testid="calculator-controls"] input[type="number"]').type(`${max}{enter}`);
+        cy.get('[data-testid="fleet-controls"] input[type="number"]').clear();
+        cy.get('[data-testid="fleet-controls"] input[type="number"]').type(`${max}{enter}`);
       });
     cy.get('[data-testid="calculator-lifecycle-section"]').should(
       'contain.text',
@@ -755,8 +761,8 @@ describe('Calculator — Fleet Lifecycle', () => {
     // is measured — which is the *other* cause, and would make `noneMeasured`
     // the correct answer. So put the target back in a measured range first, or
     // this asserts nothing about the budget at all.
-    cy.get('[data-testid="calculator-controls"] input[type="number"]').clear();
-    cy.get('[data-testid="calculator-controls"] input[type="number"]').type('35{enter}');
+    cy.get('[data-testid="fleet-controls"] input[type="number"]').clear();
+    cy.get('[data-testid="fleet-controls"] input[type="number"]').type('35{enter}');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
 
     cy.get('[data-testid="calc-fleet-mw-input"]').clear();
@@ -775,22 +781,19 @@ describe('Calculator — Fleet Lifecycle', () => {
   });
 });
 
-describe('Calculator — self-contained lifecycle regressions', () => {
+describe('Fleet — self-contained lifecycle regressions', () => {
   before(() => {
     const rows = agenticB300Rows(null);
     cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability });
     cy.intercept('GET', '/api/v1/benchmarks/history*', { body: rows }).as('legacyPriceHistory');
     cy.intercept('GET', '/api/v1/benchmarks*', { body: rows }).as('legacyPriceBenchmarks');
-    cy.visit(
-      '/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4&c_mw=10&c_price=7',
-      {
-        onBeforeLoad(win) {
-          win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
-          win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
-          unlockAgenticGate(win);
-        },
+    cy.visit('/fleet?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4&c_mw=10&c_price=7', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
+        unlockAgenticGate(win);
       },
-    );
+    });
     cy.wait('@legacyPriceBenchmarks');
     cy.wait('@legacyPriceHistory');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
@@ -841,7 +844,7 @@ describe('Calculator — self-contained lifecycle regressions', () => {
   });
 });
 
-describe('Calculator — Fleet Lifecycle with agentic traces', () => {
+describe('Fleet — Fleet Lifecycle with agentic traces', () => {
   // Two run dates so the staircase has a step in it, and a measured cache hit
   // rate on every row so the cached-input discount has something to apply to.
   // The shared history fixture carries ZERO agentic rows, so this spec serves
@@ -886,7 +889,7 @@ describe('Calculator — Fleet Lifecycle with agentic traces', () => {
     cy.intercept('GET', '/api/v1/benchmarks*', { body: [...b300Rows, ...b200Rows] }).as(
       'agenticBenchmarks',
     );
-    cy.visit('/calculator?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
+    cy.visit('/fleet?g_model=DeepSeek-V4-Pro&i_seq=agentic-traces&i_prec=fp4', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
         unlockAgenticGate(win);
@@ -960,14 +963,15 @@ describe('Calculator — Fleet Lifecycle with agentic traces', () => {
   });
 });
 
-describe('Calculator — Fleet Lifecycle in Chinese', () => {
+describe('Fleet — Fleet Lifecycle in Chinese', () => {
   before(() => {
-    cy.visit('/zh/calculator', {
+    cy.visit('/zh/fleet', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
       },
     });
-    cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length.greaterThan', 0);
+    // Readiness: the lifecycle section only mounts once run data has loaded.
+    cy.get('[data-testid="calculator-lifecycle-section"]').should('exist');
   });
 
   it('translates the section, including the table headers and notes', () => {

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -735,10 +735,9 @@ describe('TCO Calculator', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Cost target: the inverse of the interactivity slider. The MW-budget
-  // projection this used to sit beside now lives in the lifecycle section, which
-  // owns the budget input and reports chips and users as columns — see
-  // calculator-lifecycle.cy.ts.
+  // Cost target: the inverse of the interactivity slider. The MW-budget input
+  // lives here now that the Fleet Lifecycle section moved to its own /fleet
+  // page — see fleet-lifecycle.cy.ts. Both pages share the `c_mw` URL param.
   // ---------------------------------------------------------------------------
 
   describe('cost target', () => {
@@ -772,11 +771,15 @@ describe('TCO Calculator', () => {
       });
     });
 
-    it('no longer carries a MW budget input — the lifecycle section owns it', () => {
+    it('owns the MW budget input now that the lifecycle section moved to /fleet', () => {
       cy.get('[data-testid="calculator-costcap-section"]')
-        .find('[data-testid="calc-fleet-mw-input"]')
-        .should('not.exist');
-      cy.get('[data-testid="calculator-fleet-section"]').should('not.exist');
+        .find('[data-testid="calc-costcap-mw-input"]')
+        .should('exist');
+      cy.get('[data-testid="calculator-lifecycle-section"]').should('not.exist');
+      // A pointer to the new page replaces the section.
+      cy.get('[data-testid="calculator-fleet-pointer-link"]')
+        .should('have.attr', 'href')
+        .and('match', /\/fleet$/);
     });
 
     it('entering a generous cost target renders reachable interactivity per GPU', () => {

--- a/packages/app/src/app/(dashboard)/fleet/page.tsx
+++ b/packages/app/src/app/(dashboard)/fleet/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+
+import FleetLifecycleDisplay from '@/components/calculator/FleetLifecycleDisplay';
+import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
+import { tabMetadata } from '@/lib/tab-meta';
+
+export const metadata: Metadata = tabMetadata('fleet');
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function FleetPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const seed = resolveCalculatorUrlSeed(sp);
+  return <FleetLifecycleDisplay urlSeed={seed} />;
+}

--- a/packages/app/src/app/zh/(dashboard)/fleet/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/fleet/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+import FleetLifecycleDisplay from '@/components/calculator/FleetLifecycleDisplay';
+import { resolveCalculatorUrlSeed } from '@/components/calculator/url-seed';
+import { ZhTabIntro } from '@/components/zh/zh-tab-intro';
+import { tabMetadataZh } from '@/lib/tab-meta-zh';
+
+export const metadata: Metadata = tabMetadataZh('fleet');
+
+interface Props {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function ZhFleetPage({ searchParams }: Props) {
+  const sp = await searchParams;
+  const seed = resolveCalculatorUrlSeed(sp);
+  return (
+    <>
+      <ZhTabIntro tab="fleet" />
+      <FleetLifecycleDisplay urlSeed={seed} />
+    </>
+  );
+}

--- a/packages/app/src/components/calculator/CostTargetPanel.tsx
+++ b/packages/app/src/components/calculator/CostTargetPanel.tsx
@@ -46,6 +46,9 @@ interface CostTargetPanelProps {
    * concurrent users; the interactivity result itself does not need it.
    */
   mw: number | null;
+  /** Raw MW input value (page-owned so the `c_mw` URL param has one writer). */
+  mwInput: string;
+  onMwInputChange: (raw: string) => void;
 }
 
 const STRINGS = {
@@ -58,6 +61,10 @@ const STRINGS = {
     costCapTooltip:
       'Maximum acceptable cost per million tokens (at the selected pricing tier and token type). The answer is the highest interactivity whose interpolated cost stays at or below this ceiling.',
     costCapPlaceholder: 'e.g. 0.50',
+    mwLabel: 'Facility Power (MW)',
+    mwTooltip:
+      'Optional facility power budget in megawatts. When set, the answer is also expressed as concurrent users on a fleet sized to this budget, using all-in power per chip (host, networking, cooling) from the SemiAnalysis Datacenter Industry Model, not bare TDP.',
+    mwPlaceholder: 'e.g. 10',
     colGpu: 'Chip',
     colMaxInteractivity: 'Max Interactivity (tok/s/user)',
     colTputAtIv: 'Throughput (tok/s/chip)',
@@ -81,6 +88,10 @@ const STRINGS = {
     costCapTooltip:
       '每百万 token 的最高可接受成本（按所选定价层级和 token 类型）。结果为插值成本不超过该上限的最高交互性。',
     costCapPlaceholder: '如 0.50',
+    mwLabel: '设施功率 (MW)',
+    mwTooltip:
+      '可选的设施功率预算（兆瓦）。设置后，结果会同时换算为按该预算确定规模的集群可服务的并发用户数；芯片数量按每芯片全含功率（主机、网络、散热）计算，数据来自 SemiAnalysis Datacenter Industry Model，而非裸 TDP。',
+    mwPlaceholder: '如 10',
     colGpu: '芯片',
     colMaxInteractivity: '最高交互性 (tok/s/user)',
     colTputAtIv: '吞吐量 (tok/s/chip)',
@@ -128,6 +139,8 @@ export default function CostTargetPanel({
   costType,
   visibleHwKeys,
   mw,
+  mwInput,
+  onMwInputChange,
 }: CostTargetPanelProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
@@ -270,24 +283,45 @@ export default function CostTargetPanel({
           >
             <div className="flex flex-col gap-4">
               <p className="text-muted-foreground text-sm">{t.costCapDescription}</p>
-              <div className="flex flex-col space-y-1.5 max-w-48">
-                <LabelWithTooltip
-                  htmlFor="calc-costcap"
-                  label={t.costCapLabel}
-                  tooltip={t.costCapTooltip}
-                />
-                <Input
-                  id="calc-costcap"
-                  data-testid="calc-costcap-input"
-                  type="number"
-                  min={0}
-                  step="any"
-                  placeholder={t.costCapPlaceholder}
-                  value={costCapInput}
-                  onChange={handleCostCapChange}
-                  onBlur={handleCostCapBlur}
-                  className="w-32 h-9"
-                />
+              <div className="flex flex-wrap gap-4">
+                <div className="flex flex-col space-y-1.5 max-w-48">
+                  <LabelWithTooltip
+                    htmlFor="calc-costcap"
+                    label={t.costCapLabel}
+                    tooltip={t.costCapTooltip}
+                  />
+                  <Input
+                    id="calc-costcap"
+                    data-testid="calc-costcap-input"
+                    type="number"
+                    min={0}
+                    step="any"
+                    placeholder={t.costCapPlaceholder}
+                    value={costCapInput}
+                    onChange={handleCostCapChange}
+                    onBlur={handleCostCapBlur}
+                    className="w-32 h-9"
+                  />
+                </div>
+                <div className="flex flex-col space-y-1.5 max-w-48">
+                  <LabelWithTooltip
+                    htmlFor="calc-costcap-mw"
+                    label={t.mwLabel}
+                    tooltip={t.mwTooltip}
+                  />
+                  <Input
+                    id="calc-costcap-mw"
+                    data-testid="calc-costcap-mw-input"
+                    type="number"
+                    min={0}
+                    step="any"
+                    placeholder={t.mwPlaceholder}
+                    value={mwInput}
+                    onChange={(e) => onMwInputChange(e.target.value)}
+                    onBlur={() => track('calculator_costcap_mw_set', { mw: mwInput })}
+                    className="w-32 h-9"
+                  />
+                </div>
               </div>
               {costCap && costCapRows.length > 0 ? (
                 <>

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -1,0 +1,604 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+
+import FleetLifecycle from '@/components/calculator/FleetLifecycle';
+import {
+  resolveCalculatorTarget,
+  resolveCalculatorTargetInputValue,
+  resolveCalculatorVisibility,
+  type CalculatorVisibilityIntent,
+} from '@/components/calculator/ThroughputCalculatorDisplay';
+import type { CalculatorUrlSeed } from '@/components/calculator/url-seed';
+import {
+  GlobalFilterProvider,
+  useGlobalFilterActions,
+  useGlobalFilterAvailability,
+  useGlobalFilterRun,
+  useGlobalFilterSelection,
+} from '@/components/GlobalFilterContext';
+import { Card } from '@/components/ui/card';
+import ChartLegendItem from '@/components/ui/chart-legend-item';
+import { ChartShareActions } from '@/components/ui/chart-display-helpers';
+import {
+  ModelSelector,
+  PercentileSelector,
+  PrecisionSelector,
+  ScenarioSelector,
+} from '@/components/ui/chart-selectors';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useThemeColors } from '@/hooks/useThemeColors';
+import { useOpenDropdown } from '@/hooks/useOpenDropdown';
+import { useUrlState } from '@/hooks/useUrlState';
+import { track } from '@/lib/analytics';
+import { getModelSortIndex } from '@/lib/constants';
+import { Percentile, Sequence, type Model } from '@/lib/data-mappings';
+import { readUrlParams, writeUrlParams } from '@/lib/url-state';
+import { useFeatureGate } from '@/lib/use-feature-gate';
+import { useLocale } from '@/lib/use-locale';
+import { getDisplayLabel } from '@/lib/utils';
+
+import type { CostProvider, CostType } from './types';
+import { useThroughputData } from './useThroughputData';
+
+const COST_PROVIDER_OPTIONS: {
+  value: CostProvider;
+  label: string;
+  labelZh: string;
+}[] = [
+  { value: 'costh', label: 'Hyperscaler', labelZh: '超大规模云服务商' },
+  { value: 'costn', label: 'Neocloud', labelZh: 'Neocloud' },
+  { value: 'costr', label: '3yr Rental', labelZh: '3 年租赁' },
+];
+
+const COST_TYPE_OPTIONS: { value: CostType; label: string }[] = [
+  { value: 'total', label: 'Total Tokens' },
+  { value: 'input', label: 'Input Tokens' },
+  { value: 'output', label: 'Output Tokens' },
+];
+
+const STRINGS = {
+  en: {
+    title: 'Fleet Lifecycle',
+    description:
+      'Pick the model, workload, and target interactivity. The projection below sizes a fixed fleet of each chip against a facility power budget and reads the full run history at this operating point — see the section itself for what the lines mean.',
+    costProviderLabel: 'Cost Provider',
+    costProviderTooltip:
+      'The pricing tier used for the fleet cost line. Hyperscaler (e.g. AWS/GCP), Neocloud (e.g. CoreWeave), or 3-year rental.',
+    costProviderPlaceholder: 'Cost provider',
+    tokenTypeLabel: 'Token Type',
+    tokenTypeTooltip:
+      'Whether the per-chip figures quoted in the table use total tokens, input tokens only, or output tokens only. Revenue always counts both streams.',
+    tokenTypePlaceholder: 'Token type',
+    targetLabel: 'Target Interactivity (tok/s/user)',
+    targetTooltip:
+      'The interactivity operating point used for interpolation. Each chip\u2019s fleet serves this speed; every run date is read at it.',
+    targetAgenticLabel: (percentile: string) => `Target ${percentile} Interactivity (tok/s/user)`,
+    targetAgenticTooltip: (percentile: string) =>
+      `The ${percentile} interactivity operating point used for agentic workload interpolation. Each chip\u2019s fleet serves this speed; every run date is read at it.`,
+    errorLoading: 'Error loading data. Please try a different selection.',
+    highContrast: 'High Contrast',
+    resetFilter: 'Reset filter',
+  },
+  zh: {
+    title: '集群生命周期',
+    description:
+      '选择模型、工作负载与目标交互性。下方的测算会按设施功率预算确定各芯片固定集群的规模，并在该操作点上读取完整运行历史——各条曲线的含义见板块内说明。',
+    costProviderLabel: '成本供应商',
+    costProviderTooltip:
+      '集群成本线采用的定价层级。Hyperscaler（如 AWS/GCP）、Neocloud（如 CoreWeave）或 3 年租赁。',
+    costProviderPlaceholder: '成本供应商',
+    tokenTypeLabel: 'Token 类型',
+    tokenTypeTooltip:
+      '表格中每芯片指标按总 token、仅输入 token 还是仅输出 token 计。收入始终同时计入两类 token。',
+    tokenTypePlaceholder: 'Token 类型',
+    targetLabel: '目标交互性 (tok/s/user)',
+    targetTooltip:
+      '用于插值的交互性操作点。每款芯片的集群按此速度提供服务；每个运行日期都在该点读取。',
+    targetAgenticLabel: (percentile: string) => `目标 ${percentile} 交互性 (tok/s/user)`,
+    targetAgenticTooltip: (percentile: string) =>
+      `用于智能体工作负载插值的 ${percentile} 交互性操作点。每款芯片的集群按此速度提供服务；每个运行日期都在该点读取。`,
+    errorLoading: '加载数据出错，请尝试其他选择。',
+    highContrast: '高对比度',
+    resetFilter: '重置筛选',
+  },
+} as const;
+
+const COST_TYPE_LABELS_ZH: Record<CostType, string> = {
+  total: '总 Token',
+  input: '输入 Token',
+  output: '输出 Token',
+};
+
+export default function FleetLifecycleDisplay({ urlSeed }: { urlSeed?: CalculatorUrlSeed }) {
+  return (
+    <GlobalFilterProvider
+      initialModel={urlSeed?.model}
+      initialSequence={urlSeed?.sequence}
+      initialPrecisions={urlSeed?.precisions}
+      initialRunDate={urlSeed?.runDate}
+      initialRunId={urlSeed?.runId}
+    >
+      <FleetLifecycleInner initialPercentile={urlSeed?.percentile ?? Percentile.P90} />
+    </GlobalFilterProvider>
+  );
+}
+
+function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percentile }) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
+  const { setUrlParam } = useUrlState();
+  const { openDropdown, handleDropdownOpenChange } = useOpenDropdown();
+
+  const {
+    selectedModel,
+    effectiveSequence: selectedSequence,
+    effectivePrecisions: selectedPrecisions,
+  } = useGlobalFilterSelection();
+  const { setSelectedModel, setSelectedSequence, setSelectedPrecisions } = useGlobalFilterActions();
+  const { selectedRunDate } = useGlobalFilterRun();
+  const { availablePrecisions, availableSequences, availableModels } =
+    useGlobalFilterAvailability();
+  const mode = 'interactivity_to_throughput' as const;
+  const [costProvider, setCostProvider] = useState<CostProvider>('costh');
+  const [costType, setCostType] = useState<CostType>('total');
+  const [requestedTargetValue, setRequestedTargetValue] = useState<number>(35);
+  const [inputValue, setInputValue] = useState<string>('35');
+  const [isTargetInputFocused, setIsTargetInputFocused] = useState(false);
+  const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
+  // Owned here so the `c_mw` URL seed is read once, at the page level — the
+  // lifecycle section renders the input and is its only consumer.
+  const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? '');
+  const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
+  const [highContrast, setHighContrast] = useState(false);
+
+  const { hardwareConfig, ranges, loading, error, hasData, availableHwKeys } = useThroughputData(
+    selectedModel,
+    selectedSequence,
+    selectedPrecisions,
+    selectedRunDate,
+    undefined,
+    selectedPercentile,
+  );
+
+  const isAgenticSequence = selectedSequence === Sequence.AgenticTraces;
+  // AgentX publishes on P90, so the percentile control stays behind the
+  // ↑↑↓↓ feature gate, matching the calculator.
+  const featureGateUnlocked = useFeatureGate();
+  const percentileLabel = selectedPercentile.toUpperCase();
+
+  const handleMwInputChange = useCallback((raw: string) => {
+    setMwInput(raw);
+    const parsed = parseFloat(raw);
+    writeUrlParams({ c_mw: Number.isFinite(parsed) && parsed > 0 ? raw : '' });
+  }, []);
+
+  // The selection key represents user-driven scope, mirroring the calculator's
+  // rule: a data or filter transition reseeds visibility to everything.
+  const selectionKey = `${selectedModel}|${selectedSequence}|${[...selectedPrecisions]
+    .toSorted()
+    .join(',')}|${selectedRunDate}|${[...availableHwKeys].toSorted().join(',')}`;
+
+  const visibleHwKeys = useMemo(
+    () => resolveCalculatorVisibility(visibilityIntent, selectionKey, availableHwKeys),
+    [visibilityIntent, selectionKey, availableHwKeys],
+  );
+  const visibleKeysArray = useMemo(() => [...visibleHwKeys], [visibleHwKeys]);
+  const { resolveColor } = useThemeColors({
+    highContrast,
+    activeKeys: visibleKeysArray,
+  });
+
+  const targetValue = useMemo(
+    () => resolveCalculatorTarget(requestedTargetValue, hasData, ranges.interactivity),
+    [hasData, ranges.interactivity, requestedTargetValue],
+  );
+  const currentRange = ranges.interactivity;
+
+  const handleSliderChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = Number(event.target.value);
+    setRequestedTargetValue(value);
+    setInputValue(String(value));
+  }, []);
+
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    const parsed = parseFloat(e.target.value);
+    if (!isNaN(parsed) && parsed >= 0) {
+      setRequestedTargetValue(parsed);
+    }
+  }, []);
+
+  const handleInputFocus = useCallback(() => {
+    setInputValue(String(targetValue));
+    setIsTargetInputFocused(true);
+  }, [targetValue]);
+
+  const handleInputBlur = useCallback(() => {
+    const parsed = parseFloat(inputValue);
+    if (isNaN(parsed) || parsed < 0) {
+      setInputValue(String(targetValue));
+    } else {
+      const { min, max } = ranges.interactivity;
+      const clamped = Math.max(min, Math.min(max, parsed));
+      setRequestedTargetValue(clamped);
+      setInputValue(String(clamped));
+    }
+    setIsTargetInputFocused(false);
+    track('fleet_target_set', { mode, value: targetValue });
+  }, [inputValue, targetValue, mode, ranges.interactivity]);
+
+  const handleModelChange = useCallback(
+    (value: string) => {
+      setVisibilityIntent(null);
+      setSelectedModel(value as Model);
+      track('fleet_model_selected', { model: value });
+    },
+    [setSelectedModel],
+  );
+
+  const handleSequenceChange = useCallback(
+    (value: string) => {
+      setVisibilityIntent(null);
+      setSelectedSequence(value as Sequence);
+      track('fleet_sequence_selected', { sequence: value });
+    },
+    [setSelectedSequence],
+  );
+
+  const handlePrecisionChange = useCallback(
+    (value: string[]) => {
+      setVisibilityIntent(null);
+      setSelectedPrecisions(value);
+      track('fleet_precision_selected', { precision: value.join(',') });
+    },
+    [setSelectedPrecisions],
+  );
+
+  const handlePercentileChange = useCallback(
+    (value: Percentile) => {
+      setSelectedPercentile(value);
+      setUrlParam('i_pctl', value);
+      track('fleet_percentile_selected', { percentile: value });
+    },
+    [setUrlParam],
+  );
+
+  const toggleGpuVisibility = useCallback(
+    (hwKey: string) => {
+      const visibleLegendKeys = availableHwKeys.filter((key) => visibleHwKeys.has(key));
+      const allVisible = visibleLegendKeys.length === availableHwKeys.length;
+      const isVisible = visibleHwKeys.has(hwKey);
+      let next: Set<string>;
+      if (isVisible && allVisible) {
+        next = new Set([hwKey]);
+      } else if (isVisible && visibleLegendKeys.length === 1) {
+        next = new Set(availableHwKeys);
+      } else {
+        next = new Set(visibleHwKeys);
+        if (isVisible) next.delete(hwKey);
+        else next.add(hwKey);
+      }
+      setVisibilityIntent({
+        scopeKey: selectionKey,
+        visible: next,
+        known: new Set(availableHwKeys),
+      });
+      track('fleet_gpu_toggled', { gpu: hwKey });
+    },
+    [availableHwKeys, visibleHwKeys, selectionKey],
+  );
+
+  const handleResetGpus = useCallback(() => {
+    setVisibilityIntent({
+      scopeKey: selectionKey,
+      visible: new Set(availableHwKeys),
+      known: new Set(availableHwKeys),
+    });
+    track('fleet_gpu_reset', { gpuCount: availableHwKeys.length });
+  }, [availableHwKeys, selectionKey]);
+
+  // The legend filters which chips are candidates for the lifecycle lines,
+  // exactly as the calculator's chart legend did when the section lived there.
+  // It renders in the controls card rather than inside the chart so it stays
+  // reachable from the table view and — critically — after isolating a config
+  // that is unplottable at the current target, when the chart itself unmounts.
+  const legendItems = useMemo(
+    () =>
+      Object.entries(hardwareConfig)
+        .filter(([key]) => availableHwKeys.includes(key))
+        .toSorted(([a], [b]) => getModelSortIndex(a) - getModelSortIndex(b) || a.localeCompare(b))
+        .map(([key, config]) => ({
+          name: config.name,
+          label: getDisplayLabel(config),
+          color: resolveColor(key),
+          title: config.gpu,
+          hw: key,
+          isActive: visibleHwKeys.has(key),
+          onClick: () => toggleGpuVisibility(key),
+        })),
+    [hardwareConfig, availableHwKeys, visibleHwKeys, resolveColor, toggleGpuVisibility],
+  );
+
+  const costTypeLabels: Record<CostType, string> = useMemo(
+    () =>
+      locale === 'zh'
+        ? COST_TYPE_LABELS_ZH
+        : { total: 'Total Tokens', input: 'Input Tokens', output: 'Output Tokens' },
+    [locale],
+  );
+
+  if (!loading && error) {
+    console.error(error);
+    return (
+      <Card>
+        <div className="flex items-center justify-center h-64 text-muted-foreground">
+          {t.errorLoading}
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <section data-testid="fleet-controls">
+        <Card className="relative z-30">
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between">
+              <div>
+                <h2 className="text-lg font-semibold mb-2">{t.title}</h2>
+                <p className="text-muted-foreground text-sm mb-4">{t.description}</p>
+              </div>
+              <ChartShareActions />
+            </div>
+
+            <TooltipProvider delayDuration={0}>
+              <div
+                className={`grid grid-cols-1 md:grid-cols-2 gap-4 ${
+                  isAgenticSequence ? 'lg:grid-cols-6' : 'lg:grid-cols-5'
+                }`}
+              >
+                <ModelSelector
+                  id="fleet-model"
+                  data-testid="fleet-model-selector"
+                  value={selectedModel}
+                  onChange={handleModelChange}
+                  open={openDropdown === 'model'}
+                  onOpenChange={handleDropdownOpenChange('model')}
+                  availableModels={availableModels}
+                />
+                <ScenarioSelector
+                  id="fleet-sequence"
+                  data-testid="fleet-sequence-selector"
+                  value={selectedSequence}
+                  onChange={handleSequenceChange}
+                  open={openDropdown === 'sequence'}
+                  onOpenChange={handleDropdownOpenChange('sequence')}
+                  availableSequences={availableSequences}
+                />
+                {isAgenticSequence && featureGateUnlocked && (
+                  <PercentileSelector
+                    id="fleet-percentile"
+                    data-testid="fleet-percentile-selector"
+                    value={selectedPercentile}
+                    onChange={handlePercentileChange}
+                  />
+                )}
+                <PrecisionSelector
+                  id="fleet-precision"
+                  data-testid="fleet-precision-selector"
+                  value={selectedPrecisions}
+                  onChange={handlePrecisionChange}
+                  open={openDropdown === 'precision'}
+                  onOpenChange={handleDropdownOpenChange('precision')}
+                  availablePrecisions={availablePrecisions}
+                />
+
+                <div className="flex flex-col space-y-1.5 lg:col-span-1">
+                  <LabelWithTooltip
+                    htmlFor="fleet-cost"
+                    label={t.costProviderLabel}
+                    tooltip={t.costProviderTooltip}
+                  />
+                  <div id="fleet-cost" data-testid="fleet-cost-selector">
+                    <MultiSelect
+                      options={COST_PROVIDER_OPTIONS.map((provider) => ({
+                        value: provider.value,
+                        label: locale === 'zh' ? provider.labelZh : provider.label,
+                      }))}
+                      value={[costProvider]}
+                      onChange={(values) => {
+                        const next = values[0];
+                        if (!next) return;
+                        setCostProvider(next as CostProvider);
+                        track('fleet_cost_provider_changed', { provider: next });
+                      }}
+                      open={openDropdown === 'costProvider'}
+                      onOpenChange={handleDropdownOpenChange('costProvider')}
+                      placeholder={t.costProviderPlaceholder}
+                      minSelections={1}
+                      maxSelections={1}
+                      showClearAll={false}
+                      searchable={false}
+                      plainSelectedText
+                      showSelectionSummary={false}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex flex-col space-y-1.5 lg:col-span-1">
+                  <LabelWithTooltip
+                    htmlFor="fleet-cost-type"
+                    label={t.tokenTypeLabel}
+                    tooltip={t.tokenTypeTooltip}
+                  />
+                  <div id="fleet-cost-type" data-testid="fleet-cost-type-selector">
+                    <MultiSelect
+                      options={COST_TYPE_OPTIONS.map((ct) => ({
+                        value: ct.value,
+                        label: costTypeLabels[ct.value],
+                      }))}
+                      value={[costType]}
+                      onChange={(values) => {
+                        const next = values[0];
+                        if (!next) return;
+                        setCostType(next as CostType);
+                        track('fleet_cost_type_changed', { costType: next });
+                      }}
+                      open={openDropdown === 'costType'}
+                      onOpenChange={handleDropdownOpenChange('costType')}
+                      placeholder={t.tokenTypePlaceholder}
+                      minSelections={1}
+                      maxSelections={1}
+                      showClearAll={false}
+                      searchable={false}
+                      plainSelectedText
+                      showSelectionSummary={false}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* Target value slider + input */}
+              {!loading && hasData && (
+                <div className="space-y-2">
+                  <LabelWithTooltip
+                    htmlFor="fleet-target"
+                    label={
+                      isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
+                    }
+                    tooltip={
+                      isAgenticSequence ? t.targetAgenticTooltip(percentileLabel) : t.targetTooltip
+                    }
+                  />
+                  <div className="flex items-center gap-4">
+                    <div className="flex-1">
+                      <input
+                        id="fleet-target"
+                        type="range"
+                        min={currentRange.min}
+                        max={currentRange.max}
+                        step={1}
+                        value={targetValue}
+                        onChange={handleSliderChange}
+                        onPointerUp={() =>
+                          track('fleet_target_slider_set', { mode, value: targetValue })
+                        }
+                        className="w-full h-2 appearance-none rounded-full bg-secondary cursor-pointer
+                        [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4
+                        [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full
+                        [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:cursor-pointer
+                        [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4
+                        [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary
+                        [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:border-0"
+                      />
+                      <div
+                        className="relative h-4 text-xs text-muted-foreground"
+                        style={{ marginLeft: 8, marginRight: 8 }}
+                      >
+                        {Array.from({ length: 6 }, (_, i) => (
+                          <span
+                            key={i}
+                            className="absolute -translate-x-1/2"
+                            style={{ left: `${(i / 5) * 100}%` }}
+                          >
+                            {Math.round(
+                              currentRange.min + (currentRange.max - currentRange.min) * (i / 5),
+                            )}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                    <Input
+                      type="number"
+                      value={resolveCalculatorTargetInputValue(
+                        inputValue,
+                        targetValue,
+                        isTargetInputFocused,
+                      )}
+                      onFocus={handleInputFocus}
+                      onChange={handleInputChange}
+                      onBlur={handleInputBlur}
+                      className="w-24 h-9"
+                      min={0}
+                    />
+                  </div>
+                </div>
+              )}
+            </TooltipProvider>
+
+            {!loading && legendItems.length > 0 && (
+              <div
+                data-testid="fleet-legend"
+                className="flex flex-wrap items-center gap-x-6 gap-y-2 border-t border-border pt-3"
+              >
+                <ul className="flex flex-wrap items-center gap-x-4 gap-y-1">
+                  {legendItems.map((item) => (
+                    <ChartLegendItem key={item.hw} {...item} sidebarMode />
+                  ))}
+                </ul>
+                {visibleHwKeys.size < availableHwKeys.length && (
+                  <button
+                    type="button"
+                    data-testid="fleet-reset-filter"
+                    onClick={handleResetGpus}
+                    className="text-xs text-muted-foreground hover:text-foreground underline cursor-pointer"
+                  >
+                    {t.resetFilter}
+                  </button>
+                )}
+                <div className="flex items-center gap-2">
+                  <Switch
+                    id="fleet-high-contrast"
+                    data-testid="fleet-high-contrast"
+                    checked={highContrast}
+                    onCheckedChange={(checked: boolean) => {
+                      setHighContrast(checked);
+                      track('fleet_high_contrast_toggled', { enabled: checked });
+                    }}
+                  />
+                  <Label
+                    htmlFor="fleet-high-contrast"
+                    className="text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+                  >
+                    {t.highContrast}
+                  </Label>
+                </div>
+              </div>
+            )}
+          </div>
+        </Card>
+      </section>
+
+      {loading && (
+        <Card>
+          <Skeleton className="h-64 w-full" />
+        </Card>
+      )}
+
+      {!loading && hasData && (
+        <FleetLifecycle
+          hardwareConfig={hardwareConfig}
+          costProvider={costProvider}
+          costType={costType}
+          targetValue={targetValue}
+          mode={mode}
+          visibleHwKeys={visibleHwKeys}
+          selectedModel={selectedModel}
+          selectedSequence={selectedSequence}
+          selectedPrecisions={selectedPrecisions}
+          selectedPercentile={selectedPercentile}
+          mwInput={mwInput}
+          onMwInputChange={handleMwInputChange}
+          colorResolver={resolveColor}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -14,7 +14,6 @@ import {
 } from '@semianalysisai/inferencex-constants';
 
 import CalculatorTable from '@/components/calculator/CalculatorTable';
-import FleetLifecycle from '@/components/calculator/FleetLifecycle';
 import CostTargetPanel from '@/components/calculator/CostTargetPanel';
 import type { CalculatorUrlSeed } from '@/components/calculator/url-seed';
 import {
@@ -43,6 +42,7 @@ import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { UnofficialDomainNotice } from '@/components/ui/unofficial-domain-notice';
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import { overlayRunColor } from '@/lib/overlay-run-style';
+import { localePath } from '@/lib/i18n';
 import { readUrlParams, writeUrlParams } from '@/lib/url-state';
 import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -212,9 +212,12 @@ const STRINGS = {
     updated: ' • Updated: ',
     note: 'Note:',
     disaggCost:
-      ' Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) report input and output throughput per prefill chip and per decode chip rather than per chip overall, and $/M tok is derived from those rates — so on the Input and Output token types a disaggregated config reads cheaper than it is, by a median 2× and up to 18× across run history. Total-token cost is unaffected: it comes from throughput per chip overall, which both kinds report on the same basis. The Fleet Lifecycle section below deliberately differs — it derives its per-token-type figures from that total, so everything there is on one denominator.',
+      ' Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) report input and output throughput per prefill chip and per decode chip rather than per chip overall, and $/M tok is derived from those rates — so on the Input and Output token types a disaggregated config reads cheaper than it is, by a median 2× and up to 18× across run history. Total-token cost is unaffected: it comes from throughput per chip overall, which both kinds report on the same basis. The Fleet Lifecycle page deliberately differs — it derives its per-token-type figures from that total, so everything there is on one denominator.',
     disaggThroughput:
-      ' Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) report input and output throughput per prefill chip and per decode chip rather than per chip overall — divided by fewer chips, so on the Input and Output token types a disaggregated config reads faster per chip than it is, by a median 2× and up to 18× on input and 7× on output. Total throughput is unaffected: both kinds report it per chip overall. The Fleet Lifecycle section below deliberately differs — it derives its per-token-type figures from that total, so everything there is on one denominator.',
+      ' Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) report input and output throughput per prefill chip and per decode chip rather than per chip overall — divided by fewer chips, so on the Input and Output token types a disaggregated config reads faster per chip than it is, by a median 2× and up to 18× on input and 7× on output. Total throughput is unaffected: both kinds report it per chip overall. The Fleet Lifecycle page deliberately differs — it derives its per-token-type figures from that total, so everything there is on one denominator.',
+    fleetMoved:
+      'Fleet Lifecycle has its own page: a fixed fleet sized against a power budget, projected across its life with every measured config improvement.',
+    fleetMovedLink: 'Open Fleet Lifecycle',
     compMetricThroughput: 'throughput',
     compMetricCost: 'cost efficiency',
     compMetricPower: 'tok/s/MW',
@@ -265,9 +268,12 @@ const STRINGS = {
     updated: ' • 更新于：',
     note: '注意：',
     disaggCost:
-      '解耦推理配置（如 MoRI SGLang、Dynamo TRTLLM）的输入与输出吞吐量分别按预填充芯片与解码芯片报告，而非按芯片总数，而 $/M tok 由这些速率推导。因此在「输入」与「输出」token 类型下，解耦配置显示的成本低于实际，中位数偏低 2 倍，在运行历史中最高达 18 倍。总计口径的成本不受影响：它来自按芯片总数计的吞吐量，两种部署方式在该口径上一致。下方的「集群生命周期」模块与此有意不同：它由该总量推导各 token 类型的数值，因此那里的所有数字都在同一分母上。',
+      '解耦推理配置（如 MoRI SGLang、Dynamo TRTLLM）的输入与输出吞吐量分别按预填充芯片与解码芯片报告，而非按芯片总数，而 $/M tok 由这些速率推导。因此在「输入」与「输出」token 类型下，解耦配置显示的成本低于实际，中位数偏低 2 倍，在运行历史中最高达 18 倍。总计口径的成本不受影响：它来自按芯片总数计的吞吐量，两种部署方式在该口径上一致。「集群生命周期」页面与此有意不同：它由该总量推导各 token 类型的数值，因此那里的所有数字都在同一分母上。',
     disaggThroughput:
-      '解耦推理配置（如 MoRI SGLang、Dynamo TRTLLM）的输入与输出吞吐量分别按预填充芯片与解码芯片报告，而非按芯片总数。由于除以的芯片数更少，在「输入」与「输出」token 类型下，解耦配置显示的每芯片吞吐量高于实际，中位数偏高 2 倍，输入最高达 18 倍、输出最高达 7 倍。总计口径的吞吐量不受影响：两种部署方式均按芯片总数报告。下方的「集群生命周期」模块与此有意不同：它由该总量推导各 token 类型的数值，因此那里的所有数字都在同一分母上。',
+      '解耦推理配置（如 MoRI SGLang、Dynamo TRTLLM）的输入与输出吞吐量分别按预填充芯片与解码芯片报告，而非按芯片总数。由于除以的芯片数更少，在「输入」与「输出」token 类型下，解耦配置显示的每芯片吞吐量高于实际，中位数偏高 2 倍，输入最高达 18 倍、输出最高达 7 倍。总计口径的吞吐量不受影响：两种部署方式均按芯片总数报告。「集群生命周期」页面与此有意不同：它由该总量推导各 token 类型的数值，因此那里的所有数字都在同一分母上。',
+    fleetMoved:
+      '「集群生命周期」已移至独立页面：按功率预算确定固定集群的规模，结合每次实测配置改进，测算其整个生命周期的经济性。',
+    fleetMovedLink: '打开集群生命周期',
     compMetricThroughput: '吞吐量',
     compMetricCost: '成本效率',
     compMetricPower: 'tok/s/MW',
@@ -350,8 +356,8 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   const [isTargetInputFocused, setIsTargetInputFocused] = useState(false);
   const [barMetric, setBarMetric] = useState<BarMetric>('throughput');
   const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
-  // Owned here rather than inside the lifecycle section so the `c_mw` URL seed is
-  // read once, at the level that also hands the budget to the cost-target panel.
+  // The `c_mw` URL seed is read once here; the cost-target panel renders the
+  // input and consumes the budget. The Fleet Lifecycle page shares the param.
   const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? '');
   const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
   const [barSelectionIntent, setBarSelectionIntent] = useState<{
@@ -1136,6 +1142,8 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
           costType={costType}
           visibleHwKeys={visibleHwKeys}
           mw={mw}
+          mwInput={mwInput}
+          onMwInputChange={handleMwInputChange}
         />
       )}
 
@@ -1411,24 +1419,23 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
         </section>
       )}
 
-      {/* Fleet lifecycle: all-time-best config projected over a fleet's life.
-          Official results only — see the overlay note in the section. */}
+      {/* Fleet lifecycle now lives on its own page (/fleet); leave a pointer
+          so calculator users can find where the section moved. */}
       {!loading && hasData && (
-        <FleetLifecycle
-          hardwareConfig={hardwareConfig}
-          costProvider={costProvider}
-          costType={costType}
-          targetValue={targetValue}
-          mode={mode}
-          visibleHwKeys={visibleHwKeys}
-          selectedModel={selectedModel}
-          selectedSequence={selectedSequence}
-          selectedPrecisions={selectedPrecisions}
-          selectedPercentile={selectedPercentile}
-          mwInput={mwInput}
-          onMwInputChange={handleMwInputChange}
-          colorResolver={resolveColor}
-        />
+        <section data-testid="calculator-fleet-pointer">
+          <Card>
+            <p className="text-sm text-muted-foreground">
+              {t.fleetMoved}{' '}
+              <Link
+                href={localePath('/fleet', locale)}
+                className="underline hover:text-foreground"
+                data-testid="calculator-fleet-pointer-link"
+              >
+                {t.fleetMovedLink}
+              </Link>
+            </p>
+          </Card>
+        </section>
       )}
     </div>
   );

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -38,6 +38,7 @@ const TAB_LABELS_EN: Record<DashboardRouteKey, string> = {
   evaluation: 'Accuracy Evals',
   historical: 'Historical Trends',
   calculator: 'TCO Calculator',
+  fleet: 'Fleet Lifecycle',
   reliability: 'Reliability',
   'gpu-specs': 'Chip Specs',
   submissions: 'Submissions',

--- a/packages/app/src/lib/dashboard-routes.ts
+++ b/packages/app/src/lib/dashboard-routes.ts
@@ -113,6 +113,16 @@ export const DASHBOARD_ROUTES = [
     shareParamScopes: ['g_', 'i_', 'c_'],
   },
   {
+    key: 'fleet',
+    path: '/fleet',
+    canonicalPath: '/fleet',
+    navGroup: 'primary',
+    indexable: true,
+    localeMirrored: true,
+    providers: UNOFFICIAL_ONLY_DASHBOARD_PROVIDERS,
+    shareParamScopes: ['g_', 'i_', 'c_'],
+  },
+  {
     key: 'reliability',
     path: '/reliability',
     canonicalPath: '/reliability',

--- a/packages/app/src/lib/tab-meta-zh.ts
+++ b/packages/app/src/lib/tab-meta-zh.ts
@@ -37,6 +37,11 @@ export const TAB_META_ZH: Record<DashboardRouteKey, { title: string; description
     description:
       '计算 AI 推理吞吐量与总拥有成本（TCO）。跨硬件配置对比 LLM 推理服务的芯片成本效益。',
   },
+  fleet: {
+    title: '集群生命周期经济性',
+    description:
+      '测算固定 AI 推理集群在整个生命周期内的经济性：按设施功率预算确定集群规模，并跟踪实测软件配置随时间改进带来的收入、成本与利润率变化。',
+  },
   reliability: {
     title: '服务商可靠性指标',
     description: 'AI 推理服务商可靠性与可用性跟踪。对比各芯片云服务商的错误率与可用性。',
@@ -89,6 +94,8 @@ export const TAB_INTRO_ZH: Record<DashboardRouteKey, string> = {
     '本页面展示历史趋势图表：跟踪各芯片、框架与模型的推理性能随时间的演进，量化软件栈优化带来的收益。',
   calculator:
     '本页面提供吞吐量与总拥有成本（TCO）计算器：基于真实基准测试数据，估算不同芯片配置下 LLM 推理服务的每百万 token 成本与性价比。',
+  fleet:
+    '本页面提供集群生命周期经济性分析：按设施功率预算确定固定集群的规模，从模型发布之日起，基于历史基准测试中实测的软件配置改进，测算收入、成本、利润率与回本时间。',
   reliability:
     '本页面展示基准测试基础设施的可靠性指标：各芯片集群与服务商的运行成功率、错误率与可用性。',
   'gpu-specs':
@@ -113,6 +120,7 @@ export const TAB_LABELS_ZH: Record<DashboardRouteKey, string> = {
   evaluation: '准确率评估',
   historical: '历史趋势',
   calculator: 'TCO 计算器',
+  fleet: '集群生命周期',
   reliability: '可靠性',
   'gpu-specs': '芯片规格',
   'gpu-metrics': '芯片功耗',

--- a/packages/app/src/lib/tab-meta.ts
+++ b/packages/app/src/lib/tab-meta.ts
@@ -41,6 +41,11 @@ export const TAB_META: Record<DashboardRouteKey, { title: string; description: s
     description:
       'Calculate AI inference throughput and total cost of ownership. Compare chip cost-efficiency for LLM serving across hardware configurations.',
   },
+  fleet: {
+    title: 'Fleet Lifecycle Economics',
+    description:
+      'Project a fixed AI inference fleet across its life: size it against a facility power budget, then track revenue, cost, and margin as measured software configs improve over time.',
+  },
   reliability: {
     title: 'Provider Reliability Metrics',
     description:

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -41,7 +41,7 @@
       "duration": 1537
     },
     {
-      "spec": "cypress/e2e/calculator-lifecycle.cy.ts",
+      "spec": "cypress/e2e/fleet-lifecycle.cy.ts",
       "duration": 18000
     },
     {


### PR DESCRIPTION
Moves the Fleet Lifecycle economics section (added in 077b8e1) out of `/calculator` onto its own dedicated `/fleet` page, per request.

## What changed

- **New `/fleet` route** (and `/zh/fleet` sibling) registered in `dashboard-routes.ts` as a primary, indexable, locale-mirrored page — nav tabs, metadata, and sitemap entries all follow from the registry.
- **New `FleetLifecycleDisplay`** page component owns the same model / scenario / precision / cost-tier / target-interactivity controls the calculator page has, feeds them into the existing `FleetLifecycle` section unchanged, and seeds from the same URL params (`g_model`, `g_seq`, `i_pctl`, `c_mw`, …) so shared links keep working.
- **Persistent chip legend**: the legend renders in the page's controls card rather than inside the chart, so it stays reachable from the table view and after isolating a config that is unplottable at the current target (where the chart itself unmounts — previously a dead end).
- **Calculator page** drops the section and gets a pointer card linking to `/fleet`; the MW facility-power budget input moves into the cost-target panel. `c_mw` is shared between both pages, so a budget set on one seeds the other.
- **E2E**: `calculator-lifecycle.cy.ts` → `fleet-lifecycle.cy.ts`, ported to `/fleet` (37/37 passing against the fixture server); `throughput-calculator.cy.ts` updated for the pointer card and relocated MW input (68/68 passing). `timings.json` renamed accordingly.
- **Docs**: `docs/tco-calculator.md` notes the section's new home.

## Verification

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean
- Unit tests: all suites touching routes/metadata/calculator pass (431 tests). Note: `overview-data.server.test.ts` and a few jsdom-import suites fail identically on clean `master` in this environment (Node/jsdom issue), unrelated to this change.
- E2E with `E2E_FIXTURES=1`: fleet spec 37/37, calculator spec 68/68, smoke suite green
- Manual: `/fleet` and `/zh/fleet` render with correct titles and data

## 中文说明

按需求将集群生命周期经济性板块（077b8e1 引入）从 `/calculator` 移至独立的 `/fleet` 页面。

- **新增 `/fleet` 路由**（含 `/zh/fleet` 中文页面），在路由注册表中登记为主导航、可索引、双语镜像页面，导航标签、元数据与 sitemap 自动生成。
- **新增 `FleetLifecycleDisplay`** 页面组件，拥有与计算器相同的模型/场景/精度/成本档位/目标交互速度控件，原样复用现有 `FleetLifecycle` 板块，并沿用相同的 URL 参数（`g_model`、`g_seq`、`i_pctl`、`c_mw` 等），已分享的链接继续有效。
- **常驻芯片图例**：图例渲染在控件卡片中而非图表内部，切换到表格视图或隔离出无法绘制的配置（此时图表本身会卸载，之前会陷入死角）时依然可用。
- **计算器页面**移除该板块并保留指向 `/fleet` 的提示卡片；功率预算（MW）输入移入成本目标面板，`c_mw` 参数在两个页面间共享。
- **端到端测试**：`calculator-lifecycle.cy.ts` 重命名为 `fleet-lifecycle.cy.ts` 并移植到 `/fleet`（37/37 通过）；`throughput-calculator.cy.ts` 更新（68/68 通过）。
- **文档**：`docs/tco-calculator.md` 已注明板块的新位置。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing route split and shared `c_mw` ownership across two pages could confuse bookmarks or deep links, but lifecycle math and APIs are largely unchanged.
> 
> **Overview**
> **Fleet Lifecycle** is no longer embedded on `/calculator`; it lives on new **`/fleet`** and **`/zh/fleet`** routes, wired through **`FleetLifecycleDisplay`** with the same calculator URL seeds (`g_*`, `i_*`, `c_*`) and primary nav/metadata entries.
> 
> The calculator page **drops** the lifecycle block and shows a **link card** to `/fleet`. The **facility MW input** moves into **Interactivity Within a Cost Target** (`calc-costcap-mw-input`); **`c_mw`** stays shared so a budget set on either page seeds the other. On `/fleet`, the **chip legend** sits in the controls card (not inside the chart) so it remains usable in table view and when nothing is plottable.
> 
> E2E coverage moves from `calculator-lifecycle.cy.ts` to **`fleet-lifecycle.cy.ts`** targeting `/fleet`; calculator specs assert the pointer and relocated MW field. **`docs/tco-calculator.md`** documents the new home.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac6a8557d729dde7598bf0f880483fb533039ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->