### PR TITLE
Professionalize the zh rendering of Kaichao's testimonial / 专业化 Kaichao 推荐语的中文翻译

### DIFF
--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -132,7 +132,7 @@ export const QUOTES: Quote[] = [
   },
   {
     text: 'InferenceMAX™ benchmark is pogchamp & W in chat',
-    textZh: 'InferenceMAX™ 基准测试绝绝子，大写的赢',
+    textZh: 'InferenceMAX™ 为推理基准测试树立了新标杆，是社区的一大胜利',
     name: 'Kaichao You',
     title: 'vLLM Project Co-Lead & PhD Student @ Tsinghua University',
     titleZh: 'vLLM 项目联合负责人、清华大学博士生',


### PR DESCRIPTION
## What

Replace the Chinese rendering of Kaichao You's testimonial on the quotes wall:

- Before: `InferenceMAX™ 基准测试绝绝子，大写的赢`
- After: `InferenceMAX™ 为推理基准测试树立了新标杆，是社区的一大胜利`

## Why

The current zh line mirrors the meme register of the English original ("pogchamp & W in chat") with internet slang, which reads as unprofessional to zh-locale visitors and drew client feedback. The English quote is the author's own wording and is left unchanged; only the translation is lifted to a neutral professional register.

`bun run typecheck` and `bun run lint` pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static string change in marketing copy with no logic, API, or security impact.
> 
> **Overview**
> Updates **only** the Simplified Chinese (`textZh`) line for Kaichao You’s quote in `quotes-data.ts`. The English testimonial is unchanged.
> 
> The zh copy moves from meme-style slang (mirroring “pogchamp & W in chat”) to neutral, professional wording: *InferenceMAX™ 为推理基准测试树立了新标杆，是社区的一大胜利*. That string is what `/zh` visitors see on the quotes wall and intro carousel via existing `textZh ?? text` rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 673d0b373e562d9cfc37e881b003039889c97e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->