### PR TITLE
Add indexable /chips SEO page family with 44 localized URLs / 新增可索引的 /chips SEO 页面系列（44 个双语页面）

### DIFF
--- a/packages/app/src/app/chips/[slug]/page.tsx
+++ b/packages/app/src/app/chips/[slug]/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { ChipDetailContent, ChipVsContent } from '@/components/chips/chip-page-sections';
+import {
+  getAllChipRouteSlugs,
+  getChipPage,
+  getChipVsPage,
+  type ChipVsPage,
+} from '@/lib/chip-pages';
+import { enAlternates } from '@/lib/i18n';
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllChipRouteSlugs().map((slug) => ({ slug }));
+}
+
+function vsDescription(page: ChipVsPage): string {
+  return `${page.a.title} vs ${page.b.title}: memory, bandwidth, FP8/FP4 compute, TDP and cloud pricing side by side, with continuously measured LLM inference benchmarks on identical workloads. ${SUPPORTERS_LINE}`;
+}
+
+function vsKeywords(page: ChipVsPage): string[] {
+  const a = page.a.label;
+  const b = page.b.label;
+  return [
+    `${a} vs ${b}`,
+    `${b} vs ${a}`,
+    `${a} vs ${b} benchmark`,
+    `${a} vs ${b} specs`,
+    `${a} vs ${b} inference performance`,
+    `${a} vs ${b} price`,
+    `${a} GPU comparison`,
+    'AI inference benchmarks',
+  ];
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+
+  const chip = getChipPage(slug);
+  if (chip) {
+    const title = `${chip.title} Specs, Pricing & AI Inference Benchmarks`;
+    const description = `${chip.summary} ${SUPPORTERS_LINE}`;
+    const url = `${SITE_URL}/chips/${chip.slug}`;
+    return {
+      title,
+      description,
+      keywords: [...chip.keywords],
+      authors: [{ name: AUTHOR_NAME }],
+      alternates: enAlternates(`/chips/${chip.slug}`),
+      openGraph: {
+        title: `${title} | ${SITE_NAME}`,
+        description,
+        url,
+        type: 'article',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${title} | ${SITE_NAME}`,
+        description,
+        creator: AUTHOR_HANDLE,
+      },
+    };
+  }
+
+  const vsPage = getChipVsPage(slug);
+  if (!vsPage) return {};
+  const title = `${vsPage.a.label} vs ${vsPage.b.label}: Specs, Power & AI Inference Comparison`;
+  const description = vsDescription(vsPage);
+  const url = `${SITE_URL}/chips/${vsPage.slug}`;
+  return {
+    title,
+    description,
+    keywords: vsKeywords(vsPage),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: enAlternates(`/chips/${vsPage.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+export default async function ChipRoutePage({ params }: Props) {
+  const { slug } = await params;
+
+  const chip = getChipPage(slug);
+  if (chip) return <ChipDetailContent entry={chip} locale="en" />;
+
+  const vsPage = getChipVsPage(slug);
+  if (!vsPage) notFound();
+  return <ChipVsContent page={vsPage} locale="en" />;
+}

--- a/packages/app/src/app/chips/page.tsx
+++ b/packages/app/src/app/chips/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+
+import { ChipsIndexContent } from '@/components/chips/chip-page-sections';
+import { enAlternates } from '@/lib/i18n';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE } from '@semianalysisai/inferencex-constants';
+
+const TITLE = 'AI Chips for LLM Inference: Specs, Pricing & Benchmarks';
+const DESCRIPTION = `Specs, cloud pricing and continuously measured LLM inference benchmarks for NVIDIA Hopper and Blackwell (H100, H200, B200, B300, GB200 NVL72, GB300 NVL72) and AMD Instinct (MI300X, MI325X, MI355X) chips. ${SUPPORTERS_LINE}`;
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  keywords: [
+    'AI chips',
+    'AI GPU comparison',
+    'GPU specs',
+    'GPU price per hour',
+    'LLM inference hardware',
+    'NVIDIA vs AMD GPU',
+    'data center GPU pricing',
+    'AI accelerator comparison',
+  ],
+  alternates: enAlternates('/chips'),
+  openGraph: {
+    title: `${TITLE} | ${SITE_NAME}`,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/chips`,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${TITLE} | ${SITE_NAME}`,
+    description: DESCRIPTION,
+  },
+};
+
+export default function ChipsIndexPage() {
+  return <ChipsIndexContent locale="en" />;
+}

--- a/packages/app/src/app/llms.txt/route.ts
+++ b/packages/app/src/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { getAllPosts } from '@/lib/blog';
+import { getAllChipPages, getAllChipVsPages } from '@/lib/chip-pages';
 import { inferenceModelMeta } from '@/lib/inference-model-meta';
 import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
@@ -29,6 +30,16 @@ export async function GET() {
     ...INFERENCE_MODEL_SLUGS.map(
       (entry) =>
         `- [${inferenceModelMeta(entry).title}](${SITE_URL}/inference/${entry.slug}): ${entry.label}`,
+    ),
+    '',
+    `## Chip Pages`,
+    '',
+    ...getAllChipPages().map(
+      (chip) => `- [${chip.title}](${SITE_URL}/chips/${chip.slug}): specs, pricing and benchmarks`,
+    ),
+    ...getAllChipVsPages().map(
+      (page) =>
+        `- [${page.a.label} vs ${page.b.label}](${SITE_URL}/chips/${page.slug}): head-to-head comparison`,
     ),
     '',
     `## Articles`,

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SITE_URL } from '@semianalysisai/inferencex-constants';
 import { DASHBOARD_ROUTES } from '@/lib/dashboard-routes';
+import { getAllChipRouteSlugs } from '@/lib/chip-pages';
 import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { zhPath } from '@/lib/i18n';
 const mocks = vi.hoisted(() => ({
@@ -59,6 +60,19 @@ describe('sitemap locale parity', () => {
     for (const entry of INFERENCE_MODEL_SLUGS) {
       expect(urls.has(`${SITE_URL}/inference/${entry.slug}`)).toBe(true);
       expect(urls.has(`${SITE_URL}${zhPath(`/inference/${entry.slug}`)}`)).toBe(true);
+    }
+  });
+
+  it('emits both locales for the chips index and every chip page', async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+    expect(urls.has(`${SITE_URL}/chips`)).toBe(true);
+    expect(urls.has(`${SITE_URL}${zhPath('/chips')}`)).toBe(true);
+    const slugs = getAllChipRouteSlugs();
+    expect(slugs.length).toBe(21);
+    for (const slug of slugs) {
+      expect(urls.has(`${SITE_URL}/chips/${slug}`)).toBe(true);
+      expect(urls.has(`${SITE_URL}${zhPath(`/chips/${slug}`)}`)).toBe(true);
     }
   });
 

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -16,6 +16,7 @@ import {
   canonicalPrecisionCompareSlug,
   canonicalSpecDecodeCompareSlug,
 } from '@/lib/compare-variant-slug';
+import { getAllChipRouteSlugs } from '@/lib/chip-pages';
 import { getAllGlossaryEntries } from '@/lib/glossary';
 import { ACTIVE_INFERENCE_MODEL_SLUGS, INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { languageAlternates, zhPath } from '@/lib/i18n';
@@ -167,6 +168,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         lastModified: now,
         changeFrequency: 'monthly' as const,
         priority: 0.6,
+      }),
+    ),
+    ...localizedPair('/chips', {
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    }),
+    ...getAllChipRouteSlugs().flatMap((slug) =>
+      localizedPair(`/chips/${slug}`, {
+        lastModified: now,
+        changeFrequency: 'weekly' as const,
+        priority: 0.7,
       }),
     ),
     ...getAllPosts().flatMap((post) => {

--- a/packages/app/src/app/zh/chips/[slug]/page.tsx
+++ b/packages/app/src/app/zh/chips/[slug]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { ChipDetailContent, ChipVsContent } from '@/components/chips/chip-page-sections';
+import {
+  getAllChipRouteSlugs,
+  getChipPage,
+  getChipVsPage,
+  type ChipVsPage,
+} from '@/lib/chip-pages';
+import { getZhChipTranslation } from '@/lib/chip-pages-zh';
+import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE_ZH,
+} from '@semianalysisai/inferencex-constants';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllChipRouteSlugs().map((slug) => ({ slug }));
+}
+
+function vsDescriptionZh(page: ChipVsPage): string {
+  return `${page.a.title} 对比 ${page.b.title}：显存、内存带宽、FP8/FP4 算力、TDP 与云端价格并列呈现，并附相同工作负载上持续测量的 LLM 推理基准测试。${SUPPORTERS_LINE_ZH}`;
+}
+
+function vsKeywordsZh(page: ChipVsPage): string[] {
+  const a = page.a.label;
+  const b = page.b.label;
+  return [
+    `${a} vs ${b}`,
+    `${b} vs ${a}`,
+    `${a} 对比 ${b}`,
+    `${a} vs ${b} 基准测试`,
+    `${a} vs ${b} 规格`,
+    `${a} vs ${b} 价格`,
+    'AI 芯片对比',
+    'AI 推理基准测试',
+  ];
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+
+  const chip = getChipPage(slug);
+  if (chip) {
+    const translation = getZhChipTranslation(chip.slug);
+    if (!translation) return {};
+    const title = `${chip.title} 规格、价格与 AI 推理基准测试`;
+    const description = `${translation.summary}${SUPPORTERS_LINE_ZH}`;
+    const url = `${SITE_URL}/zh/chips/${chip.slug}`;
+    return {
+      title,
+      description,
+      keywords: [...translation.keywords],
+      authors: [{ name: AUTHOR_NAME }],
+      alternates: zhAlternates(`/chips/${chip.slug}`),
+      openGraph: {
+        title: `${title} | ${SITE_NAME}`,
+        description,
+        url,
+        locale: ZH_OG_LOCALE,
+        type: 'article',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${title} | ${SITE_NAME}`,
+        description,
+        creator: AUTHOR_HANDLE,
+      },
+    };
+  }
+
+  const vsPage = getChipVsPage(slug);
+  if (!vsPage) return {};
+  const title = `${vsPage.a.label} vs ${vsPage.b.label}：规格、功耗与 AI 推理对比`;
+  const description = vsDescriptionZh(vsPage);
+  const url = `${SITE_URL}/zh/chips/${vsPage.slug}`;
+  return {
+    title,
+    description,
+    keywords: vsKeywordsZh(vsPage),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: zhAlternates(`/chips/${vsPage.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      locale: ZH_OG_LOCALE,
+      type: 'article',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+export default async function ZhChipRoutePage({ params }: Props) {
+  const { slug } = await params;
+
+  const chip = getChipPage(slug);
+  if (chip) return <ChipDetailContent entry={chip} locale="zh" />;
+
+  const vsPage = getChipVsPage(slug);
+  if (!vsPage) notFound();
+  return <ChipVsContent page={vsPage} locale="zh" />;
+}

--- a/packages/app/src/app/zh/chips/[slug]/page.tsx
+++ b/packages/app/src/app/zh/chips/[slug]/page.tsx
@@ -50,19 +50,19 @@ function vsKeywordsZh(page: ChipVsPage): string[] {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
 
-  const chip = getChipPage(slug);
-  if (chip) {
-    const translation = getZhChipTranslation(chip.slug);
+  const entry = getChipPage(slug);
+  if (entry) {
+    const translation = getZhChipTranslation(entry.slug);
     if (!translation) return {};
-    const title = `${chip.title} 规格、价格与 AI 推理基准测试`;
+    const title = `${entry.title} 规格、价格与 AI 推理基准测试`;
     const description = `${translation.summary}${SUPPORTERS_LINE_ZH}`;
-    const url = `${SITE_URL}/zh/chips/${chip.slug}`;
+    const url = `${SITE_URL}/zh/chips/${entry.slug}`;
     return {
       title,
       description,
       keywords: [...translation.keywords],
       authors: [{ name: AUTHOR_NAME }],
-      alternates: zhAlternates(`/chips/${chip.slug}`),
+      alternates: zhAlternates(`/chips/${entry.slug}`),
       openGraph: {
         title: `${title} | ${SITE_NAME}`,
         description,
@@ -109,8 +109,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function ZhChipRoutePage({ params }: Props) {
   const { slug } = await params;
 
-  const chip = getChipPage(slug);
-  if (chip) return <ChipDetailContent entry={chip} locale="zh" />;
+  const entry = getChipPage(slug);
+  if (entry) return <ChipDetailContent entry={entry} locale="zh" />;
 
   const vsPage = getChipVsPage(slug);
   if (!vsPage) notFound();

--- a/packages/app/src/app/zh/chips/page.tsx
+++ b/packages/app/src/app/zh/chips/page.tsx
@@ -1,0 +1,40 @@
+import type { Metadata } from 'next';
+
+import { ChipsIndexContent } from '@/components/chips/chip-page-sections';
+import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
+
+const TITLE = '面向 LLM 推理的 AI 芯片：规格、价格与基准测试';
+const DESCRIPTION = `NVIDIA Hopper 与 Blackwell（H100、H200、B200、B300、GB200 NVL72、GB300 NVL72）以及 AMD Instinct（MI300X、MI325X、MI355X）芯片的规格、云端价格与持续测量的 LLM 推理基准测试。${SUPPORTERS_LINE_ZH}`;
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  keywords: [
+    'AI 芯片',
+    'AI 芯片对比',
+    'GPU 规格',
+    'GPU 每小时价格',
+    'LLM 推理硬件',
+    'NVIDIA 对比 AMD',
+    '数据中心芯片价格',
+    'AI 加速器对比',
+  ],
+  alternates: zhAlternates('/chips'),
+  openGraph: {
+    title: `${TITLE} | ${SITE_NAME}`,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/zh/chips`,
+    locale: ZH_OG_LOCALE,
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${TITLE} | ${SITE_NAME}`,
+    description: DESCRIPTION,
+  },
+};
+
+export default function ZhChipsIndexPage() {
+  return <ChipsIndexContent locale="zh" />;
+}

--- a/packages/app/src/components/chips/chip-page-sections.tsx
+++ b/packages/app/src/components/chips/chip-page-sections.tsx
@@ -81,6 +81,7 @@ const STRINGS = {
     notSupported: 'Not supported',
     none: 'N/A (NVLink domain only)',
     vsRatioNote: 'Ratios are spec-sheet values; see the live compare pages for measured deltas.',
+    vsRatioNa: 'n/a',
     vsSpecTableCaption: 'Spec-sheet comparison',
     overviewHeading: 'Overview',
     benchmarkHeading: 'How InferenceX benchmarks it',
@@ -133,6 +134,7 @@ const STRINGS = {
     notSupported: '不支持',
     none: '无（仅 NVLink 域内互联）',
     vsRatioNote: '倍数为纸面规格对比；实测差距请见实时对比页面。',
+    vsRatioNa: '不适用',
     vsSpecTableCaption: '纸面规格对比',
     overviewHeading: '概览',
     benchmarkHeading: 'InferenceX 如何测试这款芯片',
@@ -498,7 +500,7 @@ export const ChipVsContent = ({ page, locale }: { page: ChipVsPage; locale: Loca
                           </th>
                           <td className="py-2 pr-4 font-mono">{localizeValue(row.aValue)}</td>
                           <td className="py-2 pr-4 font-mono">{localizeValue(row.bValue)}</td>
-                          <td className="py-2 font-mono">{row.ratio ?? 'n/a'}</td>
+                          <td className="py-2 font-mono">{row.ratio ?? t.vsRatioNa}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/packages/app/src/components/chips/chip-page-sections.tsx
+++ b/packages/app/src/components/chips/chip-page-sections.tsx
@@ -1,0 +1,585 @@
+/**
+ * Server-rendered sections shared by the /chips and /zh/chips pages.
+ *
+ * Locale is passed as a prop per AGENTS.md rule 5 (server components take an
+ * optional `locale`); all prose comes from `chip-pages.ts` (en) and
+ * `chip-pages-zh.ts` (zh), and every number is derived from GPU_SPECS and
+ * HW_REGISTRY so the pages can never drift from the dashboard.
+ */
+import Link from 'next/link';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { getPostBySlug } from '@/lib/blog';
+import {
+  CHIP_VS_HIGHLIGHT_LABELS_EN,
+  buildChipFaq,
+  buildChipVsFaq,
+  buildChipVsHighlights,
+  type ChipFaqItem,
+  type ChipPageEntry,
+  type ChipVsPage,
+  getAllChipPages,
+  getAllChipVsPages,
+  getChipHw,
+  getChipSpec,
+} from '@/lib/chip-pages';
+import {
+  CHIP_VS_HIGHLIGHT_LABELS_ZH,
+  buildZhChipFaq,
+  buildZhChipVsFaq,
+  getZhChipTranslation,
+  localizeVsHighlightValueZh,
+} from '@/lib/chip-pages-zh';
+import { getGlossaryEntry } from '@/lib/glossary';
+import { getZhGlossaryEntry } from '@/lib/glossary-zh';
+import { type Locale, localePath, ZH_LANG_TAG } from '@/lib/i18n';
+import { SITE_URL } from '@semianalysisai/inferencex-constants';
+
+const STRINGS = {
+  en: {
+    breadcrumbRoot: 'AI Chips',
+    backToIndex: 'All AI inference chips',
+    indexTitle: 'AI Chips for LLM Inference',
+    indexIntro:
+      'Specs, cloud pricing and continuously measured inference benchmarks for every chip InferenceX covers. Each page joins the hardware data used by the live dashboard with the SemiAnalysis AI Cloud TCO rates.',
+    chipPages: 'Chip pages',
+    vsPages: 'Head-to-head comparisons',
+    specsHeading: 'Specifications',
+    pricingHeading: 'Power & cloud pricing',
+    faqHeading: 'Frequently asked questions',
+    relatedArticles: 'Benchmark analyses',
+    relatedTerms: 'Glossary',
+    relatedChips: 'Related chips',
+    liveCta: 'See live benchmark results',
+    liveCtaBody:
+      'Every number above is static hardware data. Delivered tokens per second, cost per million tokens and energy per token are measured continuously on the dashboard:',
+    liveLinkInference: 'Live inference dashboard',
+    liveLinkCompare: 'Chip-vs-chip model comparisons',
+    liveLinkPerDollar: 'Performance per dollar',
+    liveLinkOverview: 'Benchmark methodology & overview',
+    specLabels: {
+      vendor: 'Vendor',
+      arch: 'Architecture',
+      memory: 'Memory (usable)',
+      memoryBandwidth: 'Memory bandwidth',
+      fp4: 'FP4 dense TFLOP/s',
+      fp8: 'FP8 dense TFLOP/s',
+      bf16: 'BF16 dense TFLOP/s',
+      scaleUp: 'Scale-up interconnect',
+      scaleUpBandwidth: 'Scale-up bandwidth per chip',
+      worldSize: 'Scale-up world size',
+      scaleUpTopology: 'Scale-up topology',
+      scaleOut: 'Scale-out network',
+      nic: 'NIC',
+      tdp: 'TDP per chip',
+      allInPower: 'All-in power per chip',
+      costHyperscaler: 'Hyperscaler $/chip/hr',
+      costNeocloud: 'Neocloud $/chip/hr',
+      costRetail: 'Retail $/chip/hr',
+    },
+    notSupported: 'Not supported',
+    none: 'N/A (NVLink domain only)',
+    vsRatioNote: 'Ratios are spec-sheet values; see the live compare pages for measured deltas.',
+    vsSpecTableCaption: 'Spec-sheet comparison',
+    overviewHeading: 'Overview',
+    benchmarkHeading: 'How InferenceX benchmarks it',
+    vsIntroPrefix: 'Spec-sheet and pricing comparison of',
+    vsIntroAnd: 'and',
+    vsIntroSuffix:
+      'with links to continuously measured LLM inference benchmarks on identical workloads.',
+  },
+  zh: {
+    breadcrumbRoot: 'AI 芯片',
+    backToIndex: '全部 AI 推理芯片',
+    indexTitle: '面向 LLM 推理的 AI 芯片',
+    indexIntro:
+      'InferenceX 覆盖的每一款芯片的规格、云端价格与持续测量的推理基准测试。每个页面都将实时仪表板使用的硬件数据与 SemiAnalysis AI Cloud TCO 费率相结合。',
+    chipPages: '芯片页面',
+    vsPages: '芯片对比',
+    specsHeading: '规格参数',
+    pricingHeading: '功耗与云端价格',
+    faqHeading: '常见问题',
+    relatedArticles: '基准测试分析',
+    relatedTerms: '术语表',
+    relatedChips: '相关芯片',
+    liveCta: '查看实时基准测试结果',
+    liveCtaBody:
+      '以上都是静态硬件数据。实际交付的 token 吞吐量、每百万 token 成本和每 token 能耗在仪表板上持续测量：',
+    liveLinkInference: '实时推理仪表板',
+    liveLinkCompare: '芯片对芯片模型对比',
+    liveLinkPerDollar: '每美元性能',
+    liveLinkOverview: '基准测试方法与总览',
+    specLabels: {
+      vendor: '厂商',
+      arch: '架构',
+      memory: '显存（可用）',
+      memoryBandwidth: '内存带宽',
+      fp4: 'FP4 稠密 TFLOP/s',
+      fp8: 'FP8 稠密 TFLOP/s',
+      bf16: 'BF16 稠密 TFLOP/s',
+      scaleUp: 'Scale-up 互联',
+      scaleUpBandwidth: '单芯片 scale-up 带宽',
+      worldSize: 'Scale-up 域规模',
+      scaleUpTopology: 'Scale-up 拓扑',
+      scaleOut: 'Scale-out 网络',
+      nic: '网卡',
+      tdp: '单芯片 TDP',
+      allInPower: '单芯片整机功耗',
+      costHyperscaler: '超大规模云 $/芯片/小时',
+      costNeocloud: 'Neocloud $/芯片/小时',
+      costRetail: '零售档 $/芯片/小时',
+    },
+    notSupported: '不支持',
+    none: '无（仅 NVLink 域内互联）',
+    vsRatioNote: '倍数为纸面规格对比；实测差距请见实时对比页面。',
+    vsSpecTableCaption: '纸面规格对比',
+    overviewHeading: '概览',
+    benchmarkHeading: 'InferenceX 如何测试这款芯片',
+    vsIntroPrefix: '本页对比',
+    vsIntroAnd: '与',
+    vsIntroSuffix: '的纸面规格与价格，并链接到相同工作负载上持续测量的 LLM 推理基准测试。',
+  },
+} as const;
+
+function chipFaq(entry: ChipPageEntry, locale: Locale): readonly ChipFaqItem[] {
+  return locale === 'zh' ? buildZhChipFaq(entry) : buildChipFaq(entry);
+}
+
+function vsFaq(page: ChipVsPage, locale: Locale): readonly ChipFaqItem[] {
+  return locale === 'zh' ? buildZhChipVsFaq(page) : buildChipVsFaq(page);
+}
+
+function faqJsonLd(faq: readonly ChipFaqItem[], url: string, locale: Locale) {
+  return {
+    '@type': 'FAQPage',
+    '@id': `${url}#faq`,
+    ...(locale === 'zh' ? { inLanguage: ZH_LANG_TAG } : {}),
+    mainEntity: faq.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: { '@type': 'Answer', text: item.answer },
+    })),
+  };
+}
+
+function breadcrumbJsonLd(locale: Locale, leafName: string, leafPath: string) {
+  const t = STRINGS[locale];
+  return {
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: t.breadcrumbRoot,
+        item: `${SITE_URL}${localePath('/chips', locale)}`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: leafName,
+        item: `${SITE_URL}${localePath(leafPath, locale)}`,
+      },
+    ],
+  };
+}
+
+const FaqSection = ({ faq, locale }: { faq: readonly ChipFaqItem[]; locale: Locale }) => (
+  <section aria-labelledby="chip-faq" className="mt-10 border-t border-border/50 pt-10">
+    <h2 id="chip-faq" className="text-xl font-semibold tracking-tight">
+      {STRINGS[locale].faqHeading}
+    </h2>
+    <dl className="mt-4 space-y-6">
+      {faq.map((item) => (
+        <div key={item.question}>
+          <dt className="font-medium">{item.question}</dt>
+          <dd className="mt-2 leading-7 text-muted-foreground">{item.answer}</dd>
+        </div>
+      ))}
+    </dl>
+  </section>
+);
+
+const LiveResultsSection = ({ locale }: { locale: Locale }) => {
+  const t = STRINGS[locale];
+  const links = [
+    { href: localePath('/', locale), label: t.liveLinkInference },
+    { href: localePath('/compare', locale), label: t.liveLinkCompare },
+    { href: localePath('/compare-per-dollar', locale), label: t.liveLinkPerDollar },
+    { href: localePath('/overview', locale), label: t.liveLinkOverview },
+  ];
+  return (
+    <section
+      aria-labelledby="chip-live-results"
+      className="mt-10 rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+    >
+      <h2 id="chip-live-results" className="text-xl font-semibold tracking-tight">
+        {t.liveCta}
+      </h2>
+      <p className="mt-2 leading-7 text-muted-foreground">{t.liveCtaBody}</p>
+      <ul className="mt-3 space-y-1">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link href={link.href} className="text-sm font-medium text-brand hover:underline">
+              {link.label} →
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+const SpecTable = ({ entry, locale }: { entry: ChipPageEntry; locale: Locale }) => {
+  const t = STRINGS[locale];
+  const spec = getChipSpec(entry);
+  const hw = getChipHw(entry);
+  const rows: readonly [string, string][] = [
+    [t.specLabels.vendor, hw.vendor],
+    [t.specLabels.arch, hw.arch],
+    [t.specLabels.memory, `${spec.memory} ${spec.memoryType}`],
+    [t.specLabels.memoryBandwidth, spec.memoryBandwidth],
+    [t.specLabels.fp4, spec.fp4 ? spec.fp4.toLocaleString('en-US') : t.notSupported],
+    [t.specLabels.fp8, spec.fp8.toLocaleString('en-US')],
+    [t.specLabels.bf16, spec.bf16.toLocaleString('en-US')],
+    [t.specLabels.scaleUp, spec.scaleUpTech],
+    [t.specLabels.scaleUpBandwidth, spec.scaleUpBandwidth],
+    [t.specLabels.worldSize, String(spec.scaleUpWorldSize)],
+    [t.specLabels.scaleUpTopology, spec.scaleUpTopology],
+    [t.specLabels.scaleOut, spec.scaleOutTech ?? t.none],
+    [t.specLabels.nic, spec.nic ?? t.none],
+    [t.specLabels.tdp, `${hw.tdp.toLocaleString('en-US')} W`],
+    [t.specLabels.allInPower, `${hw.power} kW`],
+    [t.specLabels.costHyperscaler, `$${hw.costh.toFixed(2)}`],
+    [t.specLabels.costNeocloud, `$${hw.costn.toFixed(2)}`],
+    [t.specLabels.costRetail, `$${hw.costr.toFixed(2)}`],
+  ];
+  return (
+    <div className="mt-4 overflow-x-auto">
+      <table className="w-full text-sm">
+        <tbody>
+          {rows.map(([label, value]) => (
+            <tr key={label} className="border-b border-border/40">
+              <th scope="row" className="py-2 pr-4 text-left font-medium text-muted-foreground">
+                {label}
+              </th>
+              <td className="py-2 font-mono">{value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+const RelatedLinks = ({ entry, locale }: { entry: ChipPageEntry; locale: Locale }) => {
+  const t = STRINGS[locale];
+  const posts = entry.relatedBlogSlugs.flatMap((slug) => {
+    const post = getPostBySlug(slug, locale === 'zh' ? 'zh' : undefined) ?? getPostBySlug(slug);
+    return post ? [{ slug, title: post.meta.title }] : [];
+  });
+  const terms = entry.relatedGlossarySlugs.flatMap((slug) => {
+    const term = locale === 'zh' ? getZhGlossaryEntry(slug) : getGlossaryEntry(slug);
+    return term ? [{ slug, term: term.term }] : [];
+  });
+  const chips = entry.relatedChipSlugs.flatMap((slug) => {
+    const chip = getAllChipPages().find((page) => page.slug === slug);
+    return chip ? [chip] : [];
+  });
+  return (
+    <div className="mt-10 grid gap-8 border-t border-border/50 pt-10 md:grid-cols-3">
+      <section aria-label={t.relatedArticles}>
+        <h2 className="text-sm font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+          {t.relatedArticles}
+        </h2>
+        <ul className="mt-3 space-y-2">
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <Link
+                href={localePath(`/blog/${post.slug}`, locale)}
+                className="text-sm text-brand hover:underline"
+              >
+                {post.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section aria-label={t.relatedTerms}>
+        <h2 className="text-sm font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+          {t.relatedTerms}
+        </h2>
+        <ul className="mt-3 space-y-2">
+          {terms.map((term) => (
+            <li key={term.slug}>
+              <Link
+                href={localePath(`/glossary/${term.slug}`, locale)}
+                className="text-sm text-brand hover:underline"
+              >
+                {term.term}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section aria-label={t.relatedChips}>
+        <h2 className="text-sm font-semibold tracking-[0.14em] text-muted-foreground uppercase">
+          {t.relatedChips}
+        </h2>
+        <ul className="mt-3 space-y-2">
+          {chips.map((chip) => (
+            <li key={chip.slug}>
+              <Link
+                href={localePath(`/chips/${chip.slug}`, locale)}
+                className="text-sm text-brand hover:underline"
+              >
+                {chip.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+};
+
+export const ChipDetailContent = ({ entry, locale }: { entry: ChipPageEntry; locale: Locale }) => {
+  const t = STRINGS[locale];
+  const translation = locale === 'zh' ? getZhChipTranslation(entry.slug) : undefined;
+  const overview = translation?.overview ?? entry.overview;
+  const benchmarkContext = translation?.benchmarkContext ?? entry.benchmarkContext;
+  const faq = chipFaq(entry, locale);
+  const url = `${SITE_URL}${localePath(`/chips/${entry.slug}`, locale)}`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      breadcrumbJsonLd(locale, entry.title, `/chips/${entry.slug}`),
+      faqJsonLd(faq, url, locale),
+    ],
+  };
+  const hw = getChipHw(entry);
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <Card className="overflow-hidden p-0">
+            <header className="relative border-b border-border/50 px-5 py-8 md:px-10 md:py-12">
+              <Link
+                href={localePath('/chips', locale)}
+                className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+              >
+                <span aria-hidden="true">←</span>
+                {t.backToIndex}
+              </Link>
+              <div className="mt-8 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-brand/25 bg-brand/8 px-3 py-1 text-xs font-semibold tracking-[0.14em] text-brand uppercase">
+                  {hw.vendor} · {hw.arch}
+                </span>
+              </div>
+              <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-6xl">
+                {entry.title}
+              </h1>
+            </header>
+            <div className="px-5 py-8 md:px-10 md:py-12">
+              <section aria-labelledby="chip-overview">
+                <h2 id="chip-overview" className="text-xl font-semibold tracking-tight">
+                  {t.overviewHeading}
+                </h2>
+                {overview.map((paragraph) => (
+                  <p key={paragraph.slice(0, 32)} className="mt-3 leading-7 text-muted-foreground">
+                    {paragraph}
+                  </p>
+                ))}
+              </section>
+              <section
+                aria-labelledby="chip-specs"
+                className="mt-10 border-t border-border/50 pt-10"
+              >
+                <h2 id="chip-specs" className="text-xl font-semibold tracking-tight">
+                  {t.specsHeading}
+                </h2>
+                <SpecTable entry={entry} locale={locale} />
+              </section>
+              <section
+                aria-labelledby="chip-benchmarks"
+                className="mt-10 border-t border-border/50 pt-10"
+              >
+                <h2 id="chip-benchmarks" className="text-xl font-semibold tracking-tight">
+                  {t.benchmarkHeading}
+                </h2>
+                <p className="mt-3 leading-7 text-muted-foreground">{benchmarkContext}</p>
+              </section>
+              <FaqSection faq={faq} locale={locale} />
+              <LiveResultsSection locale={locale} />
+              <RelatedLinks entry={entry} locale={locale} />
+            </div>
+          </Card>
+        </article>
+      </div>
+    </main>
+  );
+};
+
+export const ChipVsContent = ({ page, locale }: { page: ChipVsPage; locale: Locale }) => {
+  const t = STRINGS[locale];
+  const highlights = buildChipVsHighlights(page);
+  const labels = locale === 'zh' ? CHIP_VS_HIGHLIGHT_LABELS_ZH : CHIP_VS_HIGHLIGHT_LABELS_EN;
+  const faq = vsFaq(page, locale);
+  const title = `${page.a.label} vs ${page.b.label}`;
+  const url = `${SITE_URL}${localePath(`/chips/${page.slug}`, locale)}`;
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [breadcrumbJsonLd(locale, title, `/chips/${page.slug}`), faqJsonLd(faq, url, locale)],
+  };
+  const localizeValue = locale === 'zh' ? localizeVsHighlightValueZh : (value: string) => value;
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <Card className="overflow-hidden p-0">
+            <header className="relative border-b border-border/50 px-5 py-8 md:px-10 md:py-12">
+              <Link
+                href={localePath('/chips', locale)}
+                className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+              >
+                <span aria-hidden="true">←</span>
+                {t.backToIndex}
+              </Link>
+              <h1 className="mt-8 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-6xl">
+                {title}
+              </h1>
+              <p className="mt-4 max-w-3xl leading-7 text-muted-foreground">
+                {t.vsIntroPrefix}{' '}
+                <Link
+                  href={localePath(`/chips/${page.a.slug}`, locale)}
+                  className="text-brand hover:underline"
+                >
+                  {page.a.title}
+                </Link>{' '}
+                {t.vsIntroAnd}{' '}
+                <Link
+                  href={localePath(`/chips/${page.b.slug}`, locale)}
+                  className="text-brand hover:underline"
+                >
+                  {page.b.title}
+                </Link>{' '}
+                {t.vsIntroSuffix}
+              </p>
+            </header>
+            <div className="px-5 py-8 md:px-10 md:py-12">
+              <section aria-labelledby="vs-table">
+                <h2 id="vs-table" className="text-xl font-semibold tracking-tight">
+                  {t.vsSpecTableCaption}
+                </h2>
+                <div className="mt-4 overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border/60 text-left">
+                        <th className="py-2 pr-4 font-medium text-muted-foreground"> </th>
+                        <th className="py-2 pr-4 font-semibold">{page.a.label}</th>
+                        <th className="py-2 pr-4 font-semibold">{page.b.label}</th>
+                        <th className="py-2 font-medium text-muted-foreground">
+                          {page.a.label} / {page.b.label}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {highlights.map((row) => (
+                        <tr key={row.key} className="border-b border-border/40">
+                          <th
+                            scope="row"
+                            className="py-2 pr-4 text-left font-medium text-muted-foreground"
+                          >
+                            {labels[row.key]}
+                          </th>
+                          <td className="py-2 pr-4 font-mono">{localizeValue(row.aValue)}</td>
+                          <td className="py-2 pr-4 font-mono">{localizeValue(row.bValue)}</td>
+                          <td className="py-2 font-mono">{row.ratio ?? 'n/a'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <p className="mt-3 text-sm text-muted-foreground">{t.vsRatioNote}</p>
+              </section>
+              <FaqSection faq={faq} locale={locale} />
+              <LiveResultsSection locale={locale} />
+            </div>
+          </Card>
+        </article>
+      </div>
+    </main>
+  );
+};
+
+export const ChipsIndexContent = ({ locale }: { locale: Locale }) => {
+  const t = STRINGS[locale];
+  const chips = getAllChipPages();
+  const vsPages = getAllChipVsPages();
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: t.indexTitle,
+    itemListElement: chips.map((chip, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: chip.title,
+      url: `${SITE_URL}${localePath(`/chips/${chip.slug}`, locale)}`,
+    })),
+  };
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <header className="py-8 md:py-12">
+            <h1 className="text-4xl font-bold tracking-[-0.035em] md:text-5xl">{t.indexTitle}</h1>
+            <p className="mt-4 max-w-3xl leading-7 text-muted-foreground">{t.indexIntro}</p>
+          </header>
+          <section aria-labelledby="chips-list">
+            <h2 id="chips-list" className="text-xl font-semibold tracking-tight">
+              {t.chipPages}
+            </h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {chips.map((chip) => {
+                const translation = locale === 'zh' ? getZhChipTranslation(chip.slug) : undefined;
+                const summary = translation?.summary ?? chip.summary;
+                return (
+                  <Link key={chip.slug} href={localePath(`/chips/${chip.slug}`, locale)}>
+                    <Card className="h-full p-5 transition-colors hover:border-brand/50">
+                      <h3 className="font-semibold">{chip.title}</h3>
+                      <p className="mt-2 line-clamp-4 text-sm leading-6 text-muted-foreground">
+                        {summary}
+                      </p>
+                    </Card>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+          <section aria-labelledby="vs-list" className="mt-12 pb-12">
+            <h2 id="vs-list" className="text-xl font-semibold tracking-tight">
+              {t.vsPages}
+            </h2>
+            <ul className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+              {vsPages.map((page) => (
+                <li key={page.slug}>
+                  <Link
+                    href={localePath(`/chips/${page.slug}`, locale)}
+                    className="text-sm font-medium text-brand hover:underline"
+                  >
+                    {page.a.label} vs {page.b.label} →
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -35,6 +35,7 @@ const STRINGS = {
     perfPerDollar: 'Performance per Dollar',
     modelArchitectures: 'Model Architectures',
     glossary: 'AI Inference Glossary',
+    chipSpecs: 'Chip Specs & Pricing',
     languageLink: '中文版',
     languageHref: '/zh',
     languageHrefLang: 'zh-CN',
@@ -66,6 +67,7 @@ const STRINGS = {
     perfPerDollar: '每美元性能',
     modelArchitectures: '模型架构',
     glossary: 'AI 推理术语表',
+    chipSpecs: '芯片规格与价格',
     languageLink: 'English',
     languageHref: '/',
     languageHrefLang: 'en',
@@ -271,6 +273,13 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 {t.glossary}
+              </Link>
+              <Link
+                data-testid="footer-link-chips"
+                href={`${prefix}/chips`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.chipSpecs}
               </Link>
               <Link
                 data-testid="footer-link-zh"

--- a/packages/app/src/lib/chip-pages-zh.ts
+++ b/packages/app/src/lib/chip-pages-zh.ts
@@ -231,10 +231,14 @@ export const CHIP_VS_HIGHLIGHT_LABELS_ZH: Readonly<Record<ChipVsHighlight['key']
 };
 
 const NOT_SUPPORTED_ZH = '不支持';
+const CHIP_COUNT_PATTERN = /^(?<count>\d+) chips$/u;
 
-/** Localize the generated "Not supported" cell values for zh rendering. */
+/** Localize the generated English cell values ("Not supported", "72 chips") for zh rendering. */
 export function localizeVsHighlightValueZh(value: string): string {
-  return value === 'Not supported' ? NOT_SUPPORTED_ZH : value;
+  if (value === 'Not supported') return NOT_SUPPORTED_ZH;
+  const chipCount = CHIP_COUNT_PATTERN.exec(value)?.groups?.count;
+  if (chipCount) return `${chipCount} 芯片`;
+  return value;
 }
 
 /** Chinese FAQ, generated from the same registries as the English one. */

--- a/packages/app/src/lib/chip-pages-zh.ts
+++ b/packages/app/src/lib/chip-pages-zh.ts
@@ -1,0 +1,307 @@
+/**
+ * Simplified Chinese content for the /zh/chips page family.
+ *
+ * 1:1 sibling of `chip-pages.ts` (see AGENTS.md "Chinese Website Pages" —
+ * every English change there must be mirrored here in the same PR). Numbers
+ * are generated from the same registries, so only prose is translated.
+ */
+import {
+  buildChipVsHighlights,
+  type ChipFaqItem,
+  type ChipPageEntry,
+  type ChipVsHighlight,
+  type ChipVsPage,
+  getAllChipPages,
+  getChipHw,
+  getChipPage,
+  getChipSpec,
+  leadingNumber,
+} from './chip-pages';
+
+export interface ChipPageTranslation {
+  /** Chinese meta-description base. */
+  summary: string;
+  /** Translated overview paragraphs (same count as English). */
+  overview: readonly string[];
+  benchmarkContext: string;
+  /** Chinese-searcher keywords (SKUs stay in English). */
+  keywords: readonly string[];
+}
+
+const translations: Readonly<Record<string, ChipPageTranslation>> = {
+  h100: {
+    summary:
+      'NVIDIA H100 规格、云端价格与实时 LLM 推理基准测试：80 GB HBM3、3.35 TB/s 内存带宽、FP8 Tensor Core、NVLink 4.0，每日在 vLLM、SGLang 与 TensorRT-LLM 上持续测量。',
+    overview: [
+      'NVIDIA H100 SXM 是 Hopper 一代的数据中心加速器，支撑了第一波大规模 LLM 部署。每颗芯片配备 80 GB HBM3（带宽 3.35 TB/s）和第四代 Tensor Core，稠密 FP8 算力达 1,979 TFLOP/s；8 颗芯片通过 NVLink 4.0 组成节点，单芯片互联带宽 450 GB/s。',
+      'H100 仍是衡量其他加速器的基准线：它拥有所有 AI 芯片中最成熟的软件生态、最广泛的云端供应，以及 NVIDIA 产品线中最低的小时租价。它没有 FP4 Tensor Core，因此在适用 NVFP4 的量化推理场景中会落后于更新的 Blackwell 产品。',
+    ],
+    benchmarkContext:
+      'InferenceX 在 vLLM、SGLang 和 TensorRT-LLM 上对 H100 进行持续测试，覆盖固定序列服务与长上下文 agentic trace，发布吞吐量-交互性 Pareto 前沿、每百万 token 成本和每 token 能耗，并与每一代新芯片并列展示，让升级收益始终有数可查。',
+    keywords: [
+      'NVIDIA H100',
+      'H100 规格',
+      'H100 每小时价格',
+      'H100 推理基准测试',
+      'H100 FP8 算力',
+      'H100 内存带宽',
+      'Hopper 芯片',
+      'H100 对比 B200',
+    ],
+  },
+  h200: {
+    summary:
+      'NVIDIA H200 规格、云端价格与实时 LLM 推理基准测试：141 GB HBM3e、4.8 TB/s 内存带宽、FP8 Tensor Core 与 NVLink 4.0，每日与 Blackwell 及 AMD Instinct 对比测量。',
+    overview: [
+      'NVIDIA H200 SXM 是 Hopper 的大内存版本：稠密 FP8 算力与 H100 相同（1,979 TFLOP/s），但配备 141 GB HBM3e，带宽 4.8 TB/s。大 76% 的显存和高 43% 的带宽对长上下文服务和大 KV cache 最为关键，而这恰恰是 H100 最先遇到瓶颈的场景。',
+      '在内存受限的 decode 工作负载中，H200 以相近的小时租价提供明显高于 H100 的单芯片 token 吞吐量，这也是 Blackwell 上市后它仍是 Hopper 出货主力的原因。与 H100 一样，它不支持 FP4，推理精度以 FP8 和 INT4 仅权重量化为主。',
+    ],
+    benchmarkContext:
+      'InferenceX 每日在 vLLM、SGLang 和 TensorRT-LLM 上对 H200 进行基准测试，对比页面将 H200 FP8 与 B200 NVFP4、AMD MI325X 并列呈现，让 Hopper 到 Blackwell、NVIDIA 到 AMD 的取舍以实测数据为准。',
+    keywords: [
+      'NVIDIA H200',
+      'H200 规格',
+      'H200 每小时价格',
+      'H200 推理基准测试',
+      'H200 内存带宽',
+      'H200 对比 H100',
+      'H200 对比 B200',
+      'HBM3e 芯片',
+    ],
+  },
+  b200: {
+    summary:
+      'NVIDIA B200 规格、云端价格与实时 LLM 推理基准测试：180 GB HBM3e、8 TB/s 带宽、9,000 稠密 FP4 TFLOP/s 与 NVLink 5.0，每日在 vLLM、SGLang 与 TensorRT-LLM 上持续测量。',
+    overview: [
+      'NVIDIA B200 是 Blackwell 一代的主力数据中心芯片：180 GB 可用 HBM3e（带宽 8 TB/s）、单芯片 900 GB/s 的 NVLink 5.0，Tensor Core 每时钟吞吐量翻倍于 Hopper 并新增 FP4。稠密算力 9,000 FP4 / 4,500 FP8 TFLOP/s，在主导 LLM decode 的内存带宽受限场景中，单颗 B200 的表现超过两颗 H100。',
+      'NVFP4 推理正是在 B200 上成为主流：前沿开源模型发布 FP4 checkpoint，精度与 FP8 相差无几，单芯片吞吐量却接近翻倍。它 1,000 W 的 TDP 和约 1.7 kW 的整机功耗使小时租价远高于 Hopper，因此升级决策取决于每美元性能而非峰值算力。',
+    ],
+    benchmarkContext:
+      'B200 是 InferenceX 上测试最密集的芯片之一：每日在 vLLM、SGLang、TensorRT-LLM 和 Dynamo 分离式推理上运行固定序列扫描与 AgentX agentic 编码 trace，每美元性能与精度对比页面持续追踪每个模型上 NVFP4 与 FP8 的差距。',
+    keywords: [
+      'NVIDIA B200',
+      'B200 规格',
+      'B200 每小时价格',
+      'B200 推理基准测试',
+      'B200 NVFP4',
+      'B200 对比 H100',
+      'B200 对比 MI355X',
+      'Blackwell 芯片规格',
+    ],
+  },
+  b300: {
+    summary:
+      'NVIDIA B300（Blackwell Ultra）规格、云端价格与实时 LLM 推理基准测试：268 GB 可用 HBM3e、13,500 稠密 FP4 TFLOP/s、800 Gbit/s scale-out 网络，每日与 B200、GB300 NVL72 和 MI355X 对比测量。',
+    overview: [
+      'NVIDIA B300 是 Blackwell Ultra 的 SXM 形态：268 GB 可用 HBM3e（带宽 8 TB/s），稠密 FP4 算力 13,500 TFLOP/s，比 B200 高 1.5 倍，FP8 与 BF16 则保持 B200 水平。对推理而言更重要的是大 49% 的显存：同样的 8 芯片节点能容纳更大的 KV 工作集和更大的模型。',
+      'B300 还通过 ConnectX-8 将单芯片 scale-out 带宽翻倍至 800 Gbit/s，这对 prefill/decode 分离和 wide expert parallelism 尤为重要。它定位于 B200 与机柜级 GB300 NVL72 之间：NVLink 5.0 域规模同为 8，但拥有 Ultra 级的显存和 FP4 算力。',
+    ],
+    benchmarkContext:
+      'InferenceX 以与 B200 相同的每日节奏在 vLLM、SGLang 和 TensorRT-LLM 上测试 B300，包括 AgentX 长上下文 agentic trace：268 GB HBM3e 能让 KV 工作集常驻显存，而较小的芯片则被迫抢占或 offload。',
+    keywords: [
+      'NVIDIA B300',
+      'B300 规格',
+      'Blackwell Ultra',
+      'B300 每小时价格',
+      'B300 推理基准测试',
+      'B300 FP4 算力',
+      'B300 对比 B200',
+      'B300 显存',
+    ],
+  },
+  'gb200-nvl72': {
+    summary:
+      'NVIDIA GB200 NVL72 规格、整机柜价格与实时 LLM 推理基准测试：72 颗 Blackwell 芯片组成单一 NVLink 域，单芯片 186 GB HBM3e、900 GB/s scale-up 带宽，每日在分离式 vLLM、SGLang 与 Dynamo TRT-LLM 上测量。',
+    overview: [
+      'NVIDIA GB200 NVL72 是机柜级系统：72 颗 Blackwell 芯片与 36 颗 Grace CPU 通过第五代 NVLink 组成单一 72 芯片域，单芯片单向带宽 900 GB/s。机柜内部没有 scale-out 网络，因为机柜本身就是计算单元，汇聚约 13.4 TB HBM3e。',
+      '这种一跳全互联的 fabric 正是 GB200 NVL72 在大型 MoE 模型 wide expert parallelism 推理中占优的原因：专家层可以分布到数十颗芯片上而无需经过 InfiniBand 或以太网。Dynamo、SGLang PD 等 prefill/decode 分离方案能自然映射到这个域上。',
+    ],
+    benchmarkContext:
+      'InferenceX 以多节点分离式配置测试 GB200 NVL72，包括前沿 MoE 模型上的 wide-EP vLLM、SGLang 与 Dynamo TRT-LLM 运行，并将结果归一化为单芯片吞吐量，使机柜级数据可与 8 芯片 HGX 节点直接对比。',
+    keywords: [
+      'NVIDIA GB200 NVL72',
+      'GB200 NVL72 规格',
+      'GB200 价格',
+      'GB200 NVL72 基准测试',
+      'NVL72 机柜',
+      'GB200 对比 B200',
+      '机柜级 AI 系统',
+      'GB200 NVL72 功耗',
+    ],
+  },
+  'gb300-nvl72': {
+    summary:
+      'NVIDIA GB300 NVL72 规格、整机柜价格与实时 LLM 推理基准测试：72 颗 Blackwell Ultra 芯片，单芯片 278 GB HBM3e（整柜约 20 TB）、15,000 稠密 FP4 TFLOP/s，每日在分离式推理方案上测量。',
+    overview: [
+      'NVIDIA GB300 NVL72 是 Blackwell Ultra 机柜：72 颗芯片各配 278 GB 可用 HBM3e，整柜约 20 TB 显存，单芯片稠密 FP4 算力 15,000 TFLOP/s，NVLink 5.0 域与 GB200 NVL72 相同为 72 路。FP8 与 BF16 吞吐量沿用 GB200，Ultra 的提升集中在 FP4 和显存。',
+      '单芯片显存的增加在机柜尺度上被进一步放大：更大的前沿 MoE 模型、更长的上下文和更大的 KV 工作集都能常驻而不外溢；相应地每颗芯片 TDP 提高到 1,400 W 以支撑更大的 HBM 堆栈。在 Vera Rubin 之前，GB300 NVL72 是 NVIDIA 推理产品线的当前顶点。',
+    ],
+    benchmarkContext:
+      'InferenceX 在前沿 MoE 模型上以分离式与 wide-EP 配置测试 GB300 NVL72；AgentX agentic 编码基准将这个机柜作为参考上限，用来衡量 AMD MI355X ATOM 结果与更小的 NVIDIA 节点。',
+    keywords: [
+      'NVIDIA GB300 NVL72',
+      'GB300 NVL72 规格',
+      'GB300 价格',
+      'GB300 NVL72 基准测试',
+      'Blackwell Ultra 机柜',
+      'GB300 对比 GB200',
+      'GB300 FP4 算力',
+      'GB300 NVL72 功耗',
+    ],
+  },
+  mi300x: {
+    summary:
+      'AMD Instinct MI300X 规格、云端价格与实时 LLM 推理基准测试：192 GB HBM3、5.3 TB/s 带宽、2,615 稠密 FP8 TFLOP/s、全互联 Infinity Fabric，每日在 ROCm 版 vLLM 与 SGLang 上测量。',
+    overview: [
+      'AMD Instinct MI300X 是让 AMD 真正跻身 LLM 推理市场的 CDNA 3 加速器：192 GB HBM3（带宽 5.3 TB/s），显存超过 H100 的两倍，稠密 FP8 算力 2,615 TFLOP/s。8 颗芯片通过 Infinity Fabric 全互联组网，无需交换机，单芯片 scale-up 带宽 448 GB/s。',
+      '显存优势让 MI300X 能用更少的芯片部署模型，或在每个副本中容纳更大的 KV cache，小时租价也明显低于同级 NVIDIA 产品。软件是历史上的短板：ROCm 版 vLLM 和 SGLang 已大幅缩小差距，而差距究竟缩小了多少，公开基准测试记录里一目了然。',
+    ],
+    benchmarkContext:
+      'MI300X 是最早加入 InferenceMAX 的芯片之一，至今仍在 ROCm vLLM 与 SGLang 的持续扫描中运行，留下了所有加速器中最长的公开软件进步曲线之一：同一颗芯片，随着 kernel 与调度器的改进被连续测量了数月。',
+    keywords: [
+      'AMD MI300X',
+      'MI300X 规格',
+      'MI300X 每小时价格',
+      'MI300X 推理基准测试',
+      'MI300X 对比 H100',
+      'AMD Instinct 芯片',
+      'CDNA 3',
+      'ROCm 推理',
+    ],
+  },
+  mi325x: {
+    summary:
+      'AMD Instinct MI325X 规格、云端价格与实时 LLM 推理基准测试：256 GB HBM3e、6 TB/s 带宽、2,615 稠密 FP8 TFLOP/s、全互联 Infinity Fabric，每日在 ROCm 版 vLLM 与 SGLang 上测量。',
+    overview: [
+      'AMD Instinct MI325X 是 CDNA 3 的大内存版本：稠密 FP8 算力与 MI300X 相同（2,615 TFLOP/s），但配备 256 GB HBM3e，带宽 6 TB/s，是同代产品中最大的显存。一个 8 芯片全互联节点拥有超过 2 TB HBM，足以在节点内部署超大模型。',
+      'MI325X 以容量经济性对标 H200：更大的单芯片显存和更低的小时租价，换取的是 NVIDIA 软件生态的成熟度。对内存受限的 decode 和长上下文服务而言，它的单位价格带宽在 CDNA 4 之前的产品中名列前茅。',
+    ],
+    benchmarkContext:
+      'InferenceX 在 ROCm vLLM 与 SGLang 上以共享模型集测试 MI325X，对比页面将它与 H200、MI355X 并列，使 NVIDIA 与 AMD 之间、代际之间的差距都处于持续测量之下。',
+    keywords: [
+      'AMD MI325X',
+      'MI325X 规格',
+      'MI325X 每小时价格',
+      'MI325X 推理基准测试',
+      'MI325X 对比 H200',
+      'MI325X 显存',
+      'CDNA 3 芯片',
+      'MI325X 对比 MI300X',
+    ],
+  },
+  mi355x: {
+    summary:
+      'AMD Instinct MI355X 规格、云端价格与实时 LLM 推理基准测试：288 GB HBM3e、8 TB/s 带宽、10,066 稠密 FP4 TFLOP/s，AMD 首款支持 FP4 的芯片，每日在 ROCm 版 vLLM、SGLang 与 ATOM 上测量。',
+    overview: [
+      'AMD Instinct MI355X 是 CDNA 4 旗舰，也是 AMD 首款具备 FP4 Tensor 吞吐能力的加速器：稠密算力 10,066 FP4 / 5,033 FP8 TFLOP/s，配备 288 GB HBM3e（带宽 8 TB/s），单芯片显存为当前业界最大。8 颗芯片通过第五代 Infinity Fabric 全互联组网，单芯片带宽 538 GB/s。',
+      'MI355X 在带宽上对齐 B200 级别、显存反超，而小时租价明显更低，是 AMD 迄今在每美元性能上发起的最有力挑战。1,400 W 的 TDP 和 ROCm 推理软件栈的成熟度则是实时数据持续量化的两项代价。',
+    ],
+    benchmarkContext:
+      'MI355X 是 InferenceX 上追踪最密集的 AMD 芯片：每日运行 vLLM、SGLang 与 ATOM，AgentX agentic 编码 trace 与 GB300 NVL72、B300 直接对垒，并留下了最快的公开软件进步曲线之一，包括模型发布数周内的数量级提升。',
+    keywords: [
+      'AMD MI355X',
+      'MI355X 规格',
+      'MI355X 每小时价格',
+      'MI355X 推理基准测试',
+      'MI355X 对比 B200',
+      'MI355X FP4',
+      'CDNA 4 芯片',
+      'MI355X 内存带宽',
+    ],
+  },
+};
+
+export function getZhChipTranslation(slug: string): ChipPageTranslation | undefined {
+  return translations[slug];
+}
+
+export function getAllZhChipSlugs(): readonly string[] {
+  return Object.keys(translations);
+}
+
+/** Localized labels for the data-derived versus highlight rows. */
+export const CHIP_VS_HIGHLIGHT_LABELS_ZH: Readonly<Record<ChipVsHighlight['key'], string>> = {
+  memory: '单芯片显存',
+  memoryBandwidth: '内存带宽',
+  fp8: '稠密 FP8 算力',
+  fp4: '稠密 FP4 算力',
+  tdp: 'TDP',
+  costNeocloud: '小时租价（neocloud 档）',
+  scaleUpWorldSize: 'Scale-up 域规模',
+};
+
+const NOT_SUPPORTED_ZH = '不支持';
+
+/** Localize the generated "Not supported" cell values for zh rendering. */
+export function localizeVsHighlightValueZh(value: string): string {
+  return value === 'Not supported' ? NOT_SUPPORTED_ZH : value;
+}
+
+/** Chinese FAQ, generated from the same registries as the English one. */
+export function buildZhChipFaq(entry: ChipPageEntry): readonly ChipFaqItem[] {
+  const spec = getChipSpec(entry);
+  const hw = getChipHw(entry);
+  const domainGb = Math.round(leadingNumber(spec.memory) * spec.scaleUpWorldSize).toLocaleString(
+    'en-US',
+  );
+  return [
+    {
+      question: `${entry.label} 云端租用每小时多少钱？`,
+      answer: `按 SemiAnalysis AI Cloud TCO 模型，${entry.label} 在超大规模云约 $${hw.costh.toFixed(2)}/小时，neocloud 档约 $${hw.costn.toFixed(2)}/小时，零售档约 $${hw.costr.toFixed(2)}/小时。InferenceX 的每美元性能页面即使用这些费率将实测吞吐量换算为每百万 token 成本。`,
+    },
+    {
+      question: `${entry.label} 有多少显存？`,
+      answer: `${entry.label} 单芯片提供 ${spec.memory} 可用 ${spec.memoryType}，内存带宽 ${spec.memoryBandwidth}；一个 ${spec.scaleUpWorldSize} 芯片的 ${spec.scaleUpTech} 域合计约 ${domainGb} GB。`,
+    },
+    {
+      question: `${entry.label} 的功耗是多少？`,
+      answer: `${entry.label} 单芯片 TDP 为 ${hw.tdp.toLocaleString('en-US')} W，计入主机 CPU、网卡与散热分摊后整机约 ${hw.power} kW。InferenceX 的每 token 能耗计算采用整机功耗口径。`,
+    },
+    {
+      question: `${entry.label} 支持 FP4 吗？`,
+      answer: spec.fp4
+        ? `支持。${entry.label} 稠密 FP4 算力达 ${spec.fp4.toLocaleString('en-US')} TFLOP/s（FP8 为 ${spec.fp8.toLocaleString('en-US')}），InferenceX 的精度对比页面持续追踪 FP4 与 FP8 的推理精度和吞吐量差异。`
+        : `不支持。${entry.label} 最高支持 FP8，稠密算力 ${spec.fp8.toLocaleString('en-US')} TFLOP/s；FP4 推理需要更新一代的芯片。`,
+    },
+    {
+      question: `${entry.label} 的 LLM 推理速度有多快？`,
+      answer: `这取决于模型、推理引擎、精度和交互性目标，因此 InferenceX 为 ${entry.label} 发布持续更新的吞吐量-交互性 Pareto 前沿，而非单一数字。实时仪表板和对比页面展示每个覆盖模型上的最新结果。`,
+    },
+  ];
+}
+
+/** Chinese FAQ for a versus page. */
+export function buildZhChipVsFaq(page: ChipVsPage): readonly ChipFaqItem[] {
+  const highlights = buildChipVsHighlights(page);
+  const memory = highlights.find((h) => h.key === 'memory');
+  const cost = highlights.find((h) => h.key === 'costNeocloud');
+  const fp8 = highlights.find((h) => h.key === 'fp8');
+  return [
+    {
+      question: `${page.a.label} 和 ${page.b.label} 谁的显存更大？`,
+      answer: `${page.a.label} 单芯片为 ${memory?.aValue}，${page.b.label} 为 ${memory?.bValue}，容量比约 ${memory?.ratio}。`,
+    },
+    {
+      question: `${page.a.label} 和 ${page.b.label} 的价格怎么比？`,
+      answer: `按 SemiAnalysis TCO 模型 neocloud 档费率，${page.a.label} 约 ${cost?.aValue}，${page.b.label} 约 ${cost?.bValue}。单看小时租价容易误导：每美元性能对比页面会用实测吞吐量除以这些费率。`,
+    },
+    {
+      question: `${page.a.label} 的 LLM 推理速度比 ${page.b.label} 快吗？`,
+      answer: `纸面上 ${page.a.label} 的稠密 FP8 算力是 ${page.b.label} 的 ${fp8?.ratio}，但实际交付的 token 吞吐量取决于模型、推理引擎、精度和交互性目标。InferenceX 每日在完全相同的工作负载上测量这两款芯片，最新结果请见实时对比页面。`,
+    },
+  ];
+}
+
+/** Parity guard used by tests: every English chip page must have a zh translation. */
+export function assertZhChipParity(): void {
+  for (const entry of getAllChipPages()) {
+    const translation = translations[entry.slug];
+    if (!translation) throw new Error(`Missing zh translation for chip page ${entry.slug}`);
+    if (translation.overview.length !== entry.overview.length) {
+      throw new Error(`zh overview paragraph count mismatch for ${entry.slug}`);
+    }
+  }
+  for (const slug of Object.keys(translations)) {
+    if (!getChipPage(slug)) throw new Error(`zh translation for unknown chip page ${slug}`);
+  }
+}

--- a/packages/app/src/lib/chip-pages.test.ts
+++ b/packages/app/src/lib/chip-pages.test.ts
@@ -85,6 +85,10 @@ describe('chip page registry integrity', () => {
         expect(CHIP_VS_HIGHLIGHT_LABELS_ZH[row.key]).toBeDefined();
         expect(row.aValue.length).toBeGreaterThan(0);
         expect(row.bValue.length).toBeGreaterThan(0);
+        // Only fp4 may omit the ratio (when one side lacks FP4 support).
+        if (row.key !== 'fp4') {
+          expect(row.ratio, `${page.slug} ${row.key} ratio`).toBeDefined();
+        }
       }
     }
   });
@@ -155,6 +159,7 @@ describe('Chinese chip page parity', () => {
 
   it('localizes generated FAQ answers and highlight values', () => {
     expect(localizeVsHighlightValueZh('Not supported')).toBe('不支持');
+    expect(localizeVsHighlightValueZh('72 chips')).toBe('72 芯片');
     expect(localizeVsHighlightValueZh('8 TB/s')).toBe('8 TB/s');
     for (const entry of getAllChipPages()) {
       for (const item of buildZhChipFaq(entry)) {

--- a/packages/app/src/lib/chip-pages.test.ts
+++ b/packages/app/src/lib/chip-pages.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+
+import { GPU_SPECS } from '@/lib/gpu-specs';
+import { getPostBySlug } from '@/lib/blog';
+import { getGlossaryEntry } from '@/lib/glossary';
+import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
+
+import {
+  buildChipFaq,
+  buildChipVsFaq,
+  buildChipVsHighlights,
+  CHIP_VS_HIGHLIGHT_LABELS_EN,
+  CHIP_VS_PAIRS,
+  chipVsSlug,
+  getAllChipPages,
+  getAllChipRouteSlugs,
+  getAllChipVsPages,
+  getChipPage,
+  getChipVsPage,
+} from './chip-pages';
+import {
+  assertZhChipParity,
+  buildZhChipFaq,
+  buildZhChipVsFaq,
+  CHIP_VS_HIGHLIGHT_LABELS_ZH,
+  getAllZhChipSlugs,
+  getZhChipTranslation,
+  localizeVsHighlightValueZh,
+} from './chip-pages-zh';
+
+const EM_OR_EN_DASH = /[—–]/u;
+
+describe('chip page registry integrity', () => {
+  it('resolves every hwKey in HW_REGISTRY and every specName in GPU_SPECS', () => {
+    for (const entry of getAllChipPages()) {
+      expect(HW_REGISTRY[entry.hwKey], `hwKey ${entry.hwKey}`).toBeDefined();
+      expect(
+        GPU_SPECS.find((spec) => spec.name === entry.specName),
+        `specName ${entry.specName}`,
+      ).toBeDefined();
+    }
+  });
+
+  it('has unique slugs across chip and versus pages', () => {
+    const slugs = getAllChipRouteSlugs();
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('covers 9 chips and 12 versus pages (44 localized URLs with the index)', () => {
+    expect(getAllChipPages()).toHaveLength(9);
+    expect(getAllChipVsPages()).toHaveLength(12);
+    // index + chips + versus, each in en and zh
+    expect(2 * (1 + getAllChipRouteSlugs().length)).toBe(44);
+  });
+
+  it('only pairs known chips and never a chip with itself', () => {
+    for (const { a, b } of CHIP_VS_PAIRS) {
+      expect(a).not.toBe(b);
+      expect(getChipPage(a), `pair member ${a}`).toBeDefined();
+      expect(getChipPage(b), `pair member ${b}`).toBeDefined();
+      expect(getChipVsPage(chipVsSlug(a, b))).toBeDefined();
+    }
+  });
+
+  it('links only to blog posts and glossary terms that exist', () => {
+    for (const entry of getAllChipPages()) {
+      for (const slug of entry.relatedBlogSlugs) {
+        expect(getPostBySlug(slug), `blog ${slug} on ${entry.slug}`).not.toBeNull();
+      }
+      for (const slug of entry.relatedGlossarySlugs) {
+        expect(getGlossaryEntry(slug), `glossary ${slug} on ${entry.slug}`).toBeDefined();
+      }
+      for (const slug of entry.relatedChipSlugs) {
+        expect(getChipPage(slug), `related chip ${slug} on ${entry.slug}`).toBeDefined();
+      }
+    }
+  });
+
+  it('builds a ratio-bearing highlight table for every versus page', () => {
+    for (const page of getAllChipVsPages()) {
+      const highlights = buildChipVsHighlights(page);
+      expect(highlights.length).toBeGreaterThanOrEqual(5);
+      for (const row of highlights) {
+        expect(CHIP_VS_HIGHLIGHT_LABELS_EN[row.key]).toBeDefined();
+        expect(CHIP_VS_HIGHLIGHT_LABELS_ZH[row.key]).toBeDefined();
+        expect(row.aValue.length).toBeGreaterThan(0);
+        expect(row.bValue.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('chip page content quality', () => {
+  it('has non-empty keyword-bearing prose and FAQs on every English page', () => {
+    for (const entry of getAllChipPages()) {
+      expect(entry.summary.length).toBeGreaterThan(80);
+      expect(entry.overview.length).toBeGreaterThanOrEqual(2);
+      expect(entry.keywords.length).toBeGreaterThanOrEqual(5);
+      const faq = buildChipFaq(entry);
+      expect(faq.length).toBeGreaterThanOrEqual(4);
+      for (const item of faq) {
+        expect(item.question.length).toBeGreaterThan(0);
+        expect(item.answer.length).toBeGreaterThan(0);
+      }
+    }
+    for (const page of getAllChipVsPages()) {
+      expect(buildChipVsFaq(page).length).toBeGreaterThanOrEqual(3);
+    }
+  });
+
+  it('contains no em or en dashes in any locale (glossary style rule)', () => {
+    for (const entry of getAllChipPages()) {
+      const zh = getZhChipTranslation(entry.slug);
+      const texts = [
+        entry.summary,
+        ...entry.overview,
+        entry.benchmarkContext,
+        ...buildChipFaq(entry).flatMap((item) => [item.question, item.answer]),
+        ...(zh ? [zh.summary, ...zh.overview, zh.benchmarkContext] : []),
+        ...buildZhChipFaq(entry).flatMap((item) => [item.question, item.answer]),
+      ];
+      for (const text of texts) {
+        expect(text).not.toMatch(EM_OR_EN_DASH);
+      }
+    }
+    for (const page of getAllChipVsPages()) {
+      for (const item of [...buildChipVsFaq(page), ...buildZhChipVsFaq(page)]) {
+        expect(item.question).not.toMatch(EM_OR_EN_DASH);
+        expect(item.answer).not.toMatch(EM_OR_EN_DASH);
+      }
+    }
+  });
+});
+
+describe('Chinese chip page parity', () => {
+  it('ships a zh translation for every English page and nothing extra', () => {
+    expect(() => assertZhChipParity()).not.toThrow();
+    expect(getAllZhChipSlugs().length).toBe(getAllChipPages().length);
+  });
+
+  it('keeps SKUs in English while translating the prose', () => {
+    for (const entry of getAllChipPages()) {
+      const zh = getZhChipTranslation(entry.slug);
+      expect(zh).toBeDefined();
+      if (!zh) continue;
+      expect(zh.summary).toMatch(/[\u4E00-\u9FFF]/u);
+      expect(zh.summary).toContain(entry.label);
+      expect(zh.keywords.length).toBeGreaterThanOrEqual(5);
+      // zh-copy rule: the standalone English noun "Chip" must not appear.
+      for (const text of [zh.summary, ...zh.overview, zh.benchmarkContext]) {
+        expect(text).not.toMatch(/(?<![A-Za-z])[Cc]hips?(?![A-Za-z])/u);
+      }
+    }
+  });
+
+  it('localizes generated FAQ answers and highlight values', () => {
+    expect(localizeVsHighlightValueZh('Not supported')).toBe('不支持');
+    expect(localizeVsHighlightValueZh('8 TB/s')).toBe('8 TB/s');
+    for (const entry of getAllChipPages()) {
+      for (const item of buildZhChipFaq(entry)) {
+        expect(item.question).toMatch(/[\u4E00-\u9FFF]/u);
+        expect(item.answer).toMatch(/[\u4E00-\u9FFF]/u);
+      }
+    }
+    for (const page of getAllChipVsPages()) {
+      for (const item of buildZhChipVsFaq(page)) {
+        expect(item.answer).toMatch(/[\u4E00-\u9FFF]/u);
+      }
+    }
+  });
+});

--- a/packages/app/src/lib/chip-pages.ts
+++ b/packages/app/src/lib/chip-pages.ts
@@ -495,6 +495,7 @@ export function buildChipVsHighlights(page: ChipVsPage): readonly ChipVsHighligh
       key: 'scaleUpWorldSize',
       aValue: `${specA.scaleUpWorldSize} chips`,
       bValue: `${specB.scaleUpWorldSize} chips`,
+      ratio: formatRatio(specA.scaleUpWorldSize, specB.scaleUpWorldSize),
     },
   ];
 }

--- a/packages/app/src/lib/chip-pages.ts
+++ b/packages/app/src/lib/chip-pages.ts
@@ -1,0 +1,577 @@
+/**
+ * Chip pages — static, indexable SEO surfaces at /chips, /chips/[slug] and
+ * /chips/[a]-vs-[b].
+ *
+ * Content strategy: every page is fully static (no DB) and joins two existing
+ * sources of truth so numbers can never drift from the rest of the site:
+ *
+ * - `GPU_SPECS` (src/lib/gpu-specs.ts) — memory, bandwidth, dense TFLOP/s,
+ *   interconnect and topology details shown on the Chip Specs tab.
+ * - `HW_REGISTRY` (@semianalysisai/inferencex-constants) — TDP, all-in power
+ *   and the $/chip/hr tiers used by the TCO calculator and per-dollar pages.
+ *
+ * FAQ answers and versus-page copy are generated from those structures at
+ * render time; only the overview prose is hand-authored. The Simplified
+ * Chinese siblings live in `chip-pages-zh.ts` and MUST be updated in the same
+ * PR as this file (see AGENTS.md "Chinese Website Pages").
+ */
+import { HW_REGISTRY, type HwEntry } from '@semianalysisai/inferencex-constants';
+
+import { GPU_SPECS, type GpuSpec } from '@/lib/gpu-specs';
+
+export interface ChipFaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface ChipPageEntry {
+  /** URL slug under /chips/ */
+  slug: string;
+  /** Key into HW_REGISTRY (TDP, all-in power, $/hr tiers) */
+  hwKey: string;
+  /** `name` of the matching GPU_SPECS row */
+  specName: string;
+  /** Full display title, e.g. "NVIDIA B200" */
+  title: string;
+  /** Short label used in tables and versus copy, e.g. "B200" */
+  label: string;
+  /** Meta-description base; supporters line is appended by the page. */
+  summary: string;
+  /** Hand-authored overview paragraphs (keyword-bearing prose). */
+  overview: readonly string[];
+  /** How InferenceX benchmarks this chip. */
+  benchmarkContext: string;
+  /** Meta keywords; searcher-phrased, includes "GPU" variants. */
+  keywords: readonly string[];
+  /** Blog posts under content/blog that feature this chip. */
+  relatedBlogSlugs: readonly string[];
+  /** Glossary entries that explain the concepts named in the prose. */
+  relatedGlossarySlugs: readonly string[];
+  /** Other chip pages worth crosslinking. */
+  relatedChipSlugs: readonly string[];
+}
+
+const INFERENCEMAX = 'inferencemax-open-source-inference-benchmarking';
+const INFERENCEX_V2 = 'inferencex-v2-nvidia-blackwell-vs-amd-vs-hopper';
+
+const entries = [
+  {
+    slug: 'h100',
+    hwKey: 'h100',
+    specName: 'H100 SXM',
+    title: 'NVIDIA H100 SXM',
+    label: 'H100',
+    summary:
+      'NVIDIA H100 specs, cloud pricing and live LLM inference benchmarks: 80 GB HBM3, 3.35 TB/s bandwidth, FP8 tensor cores, NVLink 4.0, measured daily on vLLM, SGLang and TensorRT-LLM.',
+    overview: [
+      'The NVIDIA H100 SXM is the Hopper-generation datacenter accelerator that powered the first wave of large-scale LLM deployment. Each chip pairs 80 GB of HBM3 at 3.35 TB/s with fourth-generation tensor cores that reach 1,979 dense FP8 TFLOP/s, connected in 8-chip nodes over NVLink 4.0 at 450 GB/s per chip.',
+      'H100 remains the baseline other accelerators are judged against: it has the deepest software support of any AI chip, wide cloud availability, and the lowest hourly rates of the NVIDIA lineup. It lacks FP4 tensor cores, so newer Blackwell parts pull ahead on quantized serving workloads where NVFP4 applies.',
+    ],
+    benchmarkContext:
+      'InferenceX runs H100 continuously on vLLM, SGLang and TensorRT-LLM across fixed-sequence serving and long-context agentic traces, publishing throughput-versus-interactivity Pareto frontiers, cost per million tokens and energy per token alongside every newer chip so the upgrade math stays visible.',
+    keywords: [
+      'NVIDIA H100',
+      'H100 GPU',
+      'H100 specs',
+      'H100 price per hour',
+      'H100 cloud pricing',
+      'H100 inference benchmark',
+      'H100 FP8 TFLOPS',
+      'H100 memory bandwidth',
+      'Hopper GPU',
+      'H100 vs B200',
+    ],
+    relatedBlogSlugs: [
+      INFERENCEMAX,
+      'qwen3-5-397b-agentx-b300-fp4-vs-h100',
+      'b200-minimax-m2-5-vllm-nvfp4-vs-h100-fp8-perf-per-dollar',
+    ],
+    relatedGlossarySlugs: ['fp8', 'high-bandwidth-memory', 'nvlink', 'tensor-parallelism'],
+    relatedChipSlugs: ['h200', 'b200', 'mi300x'],
+  },
+  {
+    slug: 'h200',
+    hwKey: 'h200',
+    specName: 'H200 SXM',
+    title: 'NVIDIA H200 SXM',
+    label: 'H200',
+    summary:
+      'NVIDIA H200 specs, cloud pricing and live LLM inference benchmarks: 141 GB HBM3e, 4.8 TB/s bandwidth, FP8 tensor cores and NVLink 4.0, measured daily against Blackwell and AMD Instinct.',
+    overview: [
+      'The NVIDIA H200 SXM is the memory-upgraded Hopper part: the same 1,979 dense FP8 TFLOP/s as H100, but with 141 GB of HBM3e at 4.8 TB/s. The 76% larger memory pool and 43% higher bandwidth matter most for long-context serving and large KV caches, where H100 runs out of headroom first.',
+      'For memory-bound decode workloads the H200 delivers materially better tokens per second per chip than H100 at a similar hourly rate, which is why it stayed the volume Hopper SKU once Blackwell arrived. Like H100 it has no FP4 support, so FP8 and INT4 weight-only quantization are its serving precisions.',
+    ],
+    benchmarkContext:
+      'InferenceX benchmarks H200 daily on vLLM, SGLang and TensorRT-LLM, and its compare pages line H200 FP8 results up against B200 NVFP4 and AMD MI325X so the Hopper-to-Blackwell and NVIDIA-to-AMD tradeoffs are measured rather than asserted.',
+    keywords: [
+      'NVIDIA H200',
+      'H200 GPU',
+      'H200 specs',
+      'H200 price per hour',
+      'H200 inference benchmark',
+      'H200 memory bandwidth',
+      'H200 vs H100',
+      'H200 vs B200',
+      'HBM3e GPU',
+      'Hopper H200 cloud pricing',
+    ],
+    relatedBlogSlugs: [
+      'b200-glm5-nvfp4-vs-h200-fp8-3-6x-perf-per-dollar',
+      'b200-nvfp4-vs-h200-int4-kimi-k2-vllm-perf-per-dollar',
+      INFERENCEX_V2,
+    ],
+    relatedGlossarySlugs: ['high-bandwidth-memory', 'memory-bandwidth', 'kv-cache', 'fp8'],
+    relatedChipSlugs: ['h100', 'b200', 'mi325x'],
+  },
+  {
+    slug: 'b200',
+    hwKey: 'b200',
+    specName: 'B200 SXM',
+    title: 'NVIDIA B200',
+    label: 'B200',
+    summary:
+      'NVIDIA B200 specs, cloud pricing and live LLM inference benchmarks: 180 GB HBM3e, 8 TB/s bandwidth, 9,000 dense FP4 TFLOP/s and NVLink 5.0, measured daily on vLLM, SGLang and TensorRT-LLM.',
+    overview: [
+      'The NVIDIA B200 is the volume Blackwell datacenter chip: 180 GB of usable HBM3e at 8 TB/s, NVLink 5.0 at 900 GB/s per chip, and tensor cores that double Hopper throughput per clock while adding FP4. At 9,000 dense FP4 TFLOP/s and 4,500 FP8, a single B200 more than doubles H100 compute in half the memory-bandwidth-bound regimes that dominate LLM decode.',
+      'B200 is where NVFP4 serving became mainstream: frontier open models ship FP4 checkpoints that keep accuracy within noise of FP8 while nearly doubling throughput per chip. Its 1,000 W TDP and roughly 1.7 kW all-in power draw price it well above Hopper per hour, so performance per dollar, not peak TFLOP/s, decides the upgrade.',
+    ],
+    benchmarkContext:
+      'B200 is one of the most heavily benchmarked chips on InferenceX: daily fixed-sequence sweeps and AgentX agentic-coding traces on vLLM, SGLang, TensorRT-LLM and Dynamo disaggregated serving, with per-dollar and precision compare pages tracking NVFP4 versus FP8 on every covered model.',
+    keywords: [
+      'NVIDIA B200',
+      'B200 GPU',
+      'B200 specs',
+      'B200 price per hour',
+      'B200 cloud pricing',
+      'B200 inference benchmark',
+      'B200 NVFP4',
+      'B200 vs H100',
+      'B200 vs MI355X',
+      'Blackwell GPU specs',
+    ],
+    relatedBlogSlugs: [
+      'b200-glm5-nvfp4-vs-h200-fp8-3-6x-perf-per-dollar',
+      'sglang-0-5-6-b200-deepseek-r1-fp4-up-to-1-8x',
+      'deepseek-v4-pro-agentx-b200-vs-b300-kv-working-set',
+    ],
+    relatedGlossarySlugs: ['nvfp4', 'fp4', 'nvlink', 'quantization'],
+    relatedChipSlugs: ['b300', 'gb200-nvl72', 'h100', 'mi355x'],
+  },
+  {
+    slug: 'b300',
+    hwKey: 'b300',
+    specName: 'B300 SXM',
+    title: 'NVIDIA B300',
+    label: 'B300',
+    summary:
+      'NVIDIA B300 (Blackwell Ultra) specs, cloud pricing and live LLM inference benchmarks: 268 GB usable HBM3e, 13,500 dense FP4 TFLOP/s, 800 Gbit/s scale-out, measured daily against B200, GB300 NVL72 and MI355X.',
+    overview: [
+      'The NVIDIA B300 is the Blackwell Ultra SXM part: 268 GB of usable HBM3e at 8 TB/s and 13,500 dense FP4 TFLOP/s, a 1.5x FP4 uplift over B200 while FP8 and BF16 stay at B200 levels. The 49% larger memory pool is the bigger serving story, holding larger KV working sets and bigger models per 8-chip node.',
+      'B300 also doubles scale-out networking to 800 Gbit/s per chip via ConnectX-8, which matters for disaggregated prefill/decode and wide expert parallelism. It slots between B200 and the rack-scale GB300 NVL72: same NVLink 5.0 world size of 8, but Ultra-class memory and FP4 compute.',
+    ],
+    benchmarkContext:
+      'InferenceX runs B300 on the same daily cadence as B200 across vLLM, SGLang and TensorRT-LLM, including AgentX long-context agentic traces where its 268 GB of HBM3e keeps KV working sets resident that force smaller chips to preempt or offload.',
+    keywords: [
+      'NVIDIA B300',
+      'B300 GPU',
+      'B300 specs',
+      'Blackwell Ultra',
+      'B300 price per hour',
+      'B300 inference benchmark',
+      'B300 FP4 TFLOPS',
+      'B300 vs B200',
+      'B300 memory',
+      'B300 vs MI355X',
+    ],
+    relatedBlogSlugs: [
+      'deepseek-v4-pro-agentx-b200-vs-b300-kv-working-set',
+      'minimax-m3-agentx-b300-trtllm-tp2-vs-the-field',
+      'qwen3-5-397b-agentx-b300-fp4-vs-h100',
+    ],
+    relatedGlossarySlugs: ['fp4', 'kv-cache', 'disaggregated-inference', 'scale-up-vs-scale-out'],
+    relatedChipSlugs: ['b200', 'gb300-nvl72', 'mi355x'],
+  },
+  {
+    slug: 'gb200-nvl72',
+    hwKey: 'gb200',
+    specName: 'GB200 NVL72',
+    title: 'NVIDIA GB200 NVL72',
+    label: 'GB200 NVL72',
+    summary:
+      'NVIDIA GB200 NVL72 specs, rack pricing and live LLM inference benchmarks: 72 Blackwell chips in one NVLink domain, 186 GB HBM3e per chip, 900 GB/s scale-up, measured daily on disaggregated vLLM, SGLang and Dynamo TRT-LLM.',
+    overview: [
+      'The NVIDIA GB200 NVL72 is a rack-scale system: 72 Blackwell chips and 36 Grace CPUs joined by fifth-generation NVLink into a single 72-chip domain with 900 GB/s of unidirectional bandwidth per chip. There is no scale-out network inside the rack because the rack itself is the compute unit, with roughly 13.4 TB of pooled HBM3e.',
+      'That one-hop, all-to-all fabric is why GB200 NVL72 dominates wide-expert-parallel serving of large MoE models: expert layers can be spread across dozens of chips without crossing InfiniBand or Ethernet. Disaggregated prefill/decode stacks such as Dynamo and SGLang PD map naturally onto the domain.',
+    ],
+    benchmarkContext:
+      'InferenceX benchmarks GB200 NVL72 with multi-node disaggregated configurations, including wide-EP vLLM, SGLang and Dynamo TRT-LLM runs on frontier MoE models, and normalizes results as throughput per chip so rack-scale numbers stay comparable with 8-chip HGX nodes.',
+    keywords: [
+      'NVIDIA GB200 NVL72',
+      'GB200 NVL72 specs',
+      'GB200 price',
+      'GB200 NVL72 benchmark',
+      'NVL72 rack',
+      'GB200 vs B200',
+      'NVLink 72 GPU domain',
+      'GB200 inference performance',
+      'rack-scale AI system',
+      'GB200 NVL72 power consumption',
+    ],
+    relatedBlogSlugs: [
+      'gb200-nvl72-kimi-k2-5-vllm-wide-ep-3x-vs-b200',
+      'gb200-nvl72-vs-b200-disagg-deepseek-r1-fp4-dynamo-trt',
+      'vera-rubin-nvl72-vs-gb200-nvl72-inference',
+    ],
+    relatedGlossarySlugs: [
+      'wide-expert-parallelism',
+      'disaggregated-inference',
+      'nvlink',
+      'scale-up-vs-scale-out',
+    ],
+    relatedChipSlugs: ['gb300-nvl72', 'b200', 'b300'],
+  },
+  {
+    slug: 'gb300-nvl72',
+    hwKey: 'gb300',
+    specName: 'GB300 NVL72',
+    title: 'NVIDIA GB300 NVL72',
+    label: 'GB300 NVL72',
+    summary:
+      'NVIDIA GB300 NVL72 specs, rack pricing and live LLM inference benchmarks: 72 Blackwell Ultra chips, 278 GB HBM3e each (20 TB per rack), 15,000 dense FP4 TFLOP/s per chip, measured daily on disaggregated serving stacks.',
+    overview: [
+      'The NVIDIA GB300 NVL72 is the Blackwell Ultra rack: 72 chips with 278 GB of usable HBM3e each, roughly 20 TB of pooled memory per rack, and 15,000 dense FP4 TFLOP/s per chip on the same 72-way NVLink 5.0 domain as GB200 NVL72. FP8 and BF16 throughput carry over from GB200; the Ultra uplift is FP4 and memory.',
+      'The extra memory per chip compounds at rack scale: bigger frontier MoE models, longer contexts and larger KV working sets fit without spilling, and each chip runs a higher 1,400 W TDP to feed the larger stacks. GB300 NVL72 is the current top of the NVIDIA inference lineup ahead of Vera Rubin.',
+    ],
+    benchmarkContext:
+      'InferenceX runs GB300 NVL72 on frontier MoE models with disaggregated and wide-EP configurations, and its AgentX agentic-coding lane uses the rack as the reference ceiling that AMD MI355X ATOM results and smaller NVIDIA nodes are measured against.',
+    keywords: [
+      'NVIDIA GB300 NVL72',
+      'GB300 NVL72 specs',
+      'GB300 price',
+      'GB300 NVL72 benchmark',
+      'Blackwell Ultra rack',
+      'GB300 vs GB200',
+      'GB300 memory per GPU',
+      'GB300 FP4 TFLOPS',
+      'GB300 inference performance',
+      'GB300 NVL72 power',
+    ],
+    relatedBlogSlugs: [
+      'gb300-nvl72-vs-gb200-nvl72-dsv4-pro-vllm-fp4',
+      'deepseek-v4-pro-agentx-gb200-vs-gb300-disagg',
+      'kimi-k3-agentx-mi355x-atom-vs-gb300-nvl72',
+    ],
+    relatedGlossarySlugs: ['fp4', 'wide-expert-parallelism', 'kv-cache', 'disaggregated-inference'],
+    relatedChipSlugs: ['gb200-nvl72', 'b300', 'mi355x'],
+  },
+  {
+    slug: 'mi300x',
+    hwKey: 'mi300x',
+    specName: 'MI300X',
+    title: 'AMD Instinct MI300X',
+    label: 'MI300X',
+    summary:
+      'AMD Instinct MI300X specs, cloud pricing and live LLM inference benchmarks: 192 GB HBM3, 5.3 TB/s bandwidth, 2,615 dense FP8 TFLOP/s, full-mesh Infinity Fabric, measured daily on vLLM and SGLang with ROCm.',
+    overview: [
+      'The AMD Instinct MI300X is the CDNA 3 accelerator that made AMD a serious LLM inference vendor: 192 GB of HBM3 at 5.3 TB/s, more than double H100 memory, with 2,615 dense FP8 TFLOP/s. Eight chips connect in a full-mesh Infinity Fabric node with no switches, 448 GB/s of scale-up bandwidth per chip.',
+      'The memory advantage lets MI300X serve models in fewer chips or hold larger KV caches per replica, and its hourly pricing sits well below comparable NVIDIA parts. Software is the historical caveat: ROCm builds of vLLM and SGLang have closed much of the gap, and the public benchmark record tracks exactly how far.',
+    ],
+    benchmarkContext:
+      'MI300X was one of the original InferenceMAX chips and still runs in the continuous sweep on ROCm vLLM and SGLang, giving one of the longest public software-progress curves of any accelerator: the same chip, measured for months, as kernels and schedulers improved.',
+    keywords: [
+      'AMD MI300X',
+      'MI300X specs',
+      'MI300X price per hour',
+      'MI300X inference benchmark',
+      'MI300X vs H100',
+      'AMD Instinct GPU',
+      'CDNA 3',
+      'ROCm inference',
+      'MI300X memory',
+      'MI300X vLLM performance',
+    ],
+    relatedBlogSlugs: [INFERENCEMAX, INFERENCEX_V2, 'mi355x-kimi-k2-5-vllm-aiter-7x-speedup'],
+    relatedGlossarySlugs: ['rocm', 'high-bandwidth-memory', 'vllm', 'sglang'],
+    relatedChipSlugs: ['mi325x', 'mi355x', 'h100'],
+  },
+  {
+    slug: 'mi325x',
+    hwKey: 'mi325x',
+    specName: 'MI325X',
+    title: 'AMD Instinct MI325X',
+    label: 'MI325X',
+    summary:
+      'AMD Instinct MI325X specs, cloud pricing and live LLM inference benchmarks: 256 GB HBM3e, 6 TB/s bandwidth, 2,615 dense FP8 TFLOP/s, full-mesh Infinity Fabric, measured daily on ROCm vLLM and SGLang.',
+    overview: [
+      'The AMD Instinct MI325X is the memory-bumped CDNA 3 part: the same 2,615 dense FP8 TFLOP/s as MI300X but with 256 GB of HBM3e at 6 TB/s, the largest memory pool of its generation. An 8-chip full-mesh node carries over 2 TB of HBM, enough to serve very large models without leaving the node.',
+      'MI325X competes on capacity economics against H200: more memory per chip and lower hourly rates, traded against the NVIDIA software ecosystem. For memory-bound decode and long-context serving its bandwidth-per-dollar is among the best of the pre-CDNA 4 field.',
+    ],
+    benchmarkContext:
+      'InferenceX benchmarks MI325X on ROCm vLLM and SGLang across the shared model set, with compare pages pairing it against H200 and MI355X so both the NVIDIA-versus-AMD and generation-over-generation deltas stay continuously measured.',
+    keywords: [
+      'AMD MI325X',
+      'MI325X specs',
+      'MI325X price per hour',
+      'MI325X inference benchmark',
+      'MI325X vs H200',
+      'MI325X memory',
+      'AMD Instinct MI325X',
+      'CDNA 3 GPU',
+      'ROCm benchmark',
+      'MI325X vs MI300X',
+    ],
+    relatedBlogSlugs: [INFERENCEX_V2, INFERENCEMAX, 'mi355x-qwen3-5-sglang-v0-5-12-up-to-17x'],
+    relatedGlossarySlugs: ['memory-bandwidth', 'kv-cache', 'rocm', 'expert-parallelism'],
+    relatedChipSlugs: ['mi300x', 'mi355x', 'h200'],
+  },
+  {
+    slug: 'mi355x',
+    hwKey: 'mi355x',
+    specName: 'MI355X',
+    title: 'AMD Instinct MI355X',
+    label: 'MI355X',
+    summary:
+      'AMD Instinct MI355X specs, cloud pricing and live LLM inference benchmarks: 288 GB HBM3e, 8 TB/s bandwidth, 10,066 dense FP4 TFLOP/s, the first AMD chip with FP4, measured daily on ROCm vLLM, SGLang and ATOM.',
+    overview: [
+      'The AMD Instinct MI355X is the CDNA 4 flagship and the first AMD accelerator with FP4 tensor throughput: 10,066 dense FP4 and 5,033 FP8 TFLOP/s with 288 GB of HBM3e at 8 TB/s, the largest single-chip memory in the field. Eight chips form a full-mesh node over fifth-generation Infinity Fabric at 538 GB/s per chip.',
+      'MI355X matches B200-class bandwidth and exceeds its memory while pricing meaningfully lower per hour, making it the sharpest performance-per-dollar challenge AMD has mounted. Its 1,400 W TDP and the maturity of ROCm serving stacks are the tradeoffs the live data quantifies.',
+    ],
+    benchmarkContext:
+      'MI355X is the most intensively tracked AMD chip on InferenceX: daily vLLM, SGLang and ATOM runs, AgentX agentic-coding traces against GB300 NVL72 and B300, and some of the fastest published software-progress curves, including order-of-magnitude gains within weeks of a model release.',
+    keywords: [
+      'AMD MI355X',
+      'MI355X specs',
+      'MI355X price per hour',
+      'MI355X inference benchmark',
+      'MI355X vs B200',
+      'MI355X FP4',
+      'CDNA 4 GPU',
+      'MI355X memory bandwidth',
+      'MI355X vLLM SGLang',
+      'AMD FP4 GPU',
+    ],
+    relatedBlogSlugs: [
+      'mi355x-deepseek-v4-pro-sglang-110x-in-26-days',
+      'mi355x-glm5-fp8-sglang-40-cheaper-than-b200',
+      'deepseek-v4-pro-agentx-mi355x-vs-b200-august',
+    ],
+    relatedGlossarySlugs: ['fp4', 'rocm', 'memory-bandwidth', 'pareto-frontier'],
+    relatedChipSlugs: ['mi325x', 'b200', 'b300', 'gb300-nvl72'],
+  },
+] as const satisfies readonly ChipPageEntry[];
+
+export type ChipSlug = (typeof entries)[number]['slug'];
+
+/** Curated versus pairs. Order = page narrative order (a is the newer/leading chip). */
+export const CHIP_VS_PAIRS = [
+  { a: 'b200', b: 'h100' },
+  { a: 'b200', b: 'h200' },
+  { a: 'b300', b: 'b200' },
+  { a: 'gb200-nvl72', b: 'b200' },
+  { a: 'gb300-nvl72', b: 'gb200-nvl72' },
+  { a: 'gb300-nvl72', b: 'b300' },
+  { a: 'mi355x', b: 'mi325x' },
+  { a: 'mi325x', b: 'mi300x' },
+  { a: 'mi300x', b: 'h100' },
+  { a: 'mi355x', b: 'b200' },
+  { a: 'mi355x', b: 'b300' },
+  { a: 'mi325x', b: 'h200' },
+] as const satisfies readonly { a: ChipSlug; b: ChipSlug }[];
+
+export function getAllChipPages(): readonly ChipPageEntry[] {
+  return entries;
+}
+
+export function getChipPage(slug: string): ChipPageEntry | undefined {
+  return entries.find((entry) => entry.slug === slug);
+}
+
+export function getChipSpec(entry: ChipPageEntry): GpuSpec {
+  const spec = GPU_SPECS.find((row) => row.name === entry.specName);
+  if (!spec) throw new Error(`No GPU_SPECS row named ${entry.specName}`);
+  return spec;
+}
+
+export function getChipHw(entry: ChipPageEntry): HwEntry {
+  const hw = HW_REGISTRY[entry.hwKey];
+  if (!hw) throw new Error(`No HW_REGISTRY entry for ${entry.hwKey}`);
+  return hw;
+}
+
+export function chipVsSlug(a: ChipSlug, b: ChipSlug): string {
+  return `${a}-vs-${b}`;
+}
+
+export interface ChipVsPage {
+  slug: string;
+  a: ChipPageEntry;
+  b: ChipPageEntry;
+}
+
+export function getAllChipVsPages(): readonly ChipVsPage[] {
+  return CHIP_VS_PAIRS.map(({ a, b }) => {
+    const pageA = getChipPage(a);
+    const pageB = getChipPage(b);
+    if (!pageA || !pageB) throw new Error(`Versus pair references unknown chip: ${a} vs ${b}`);
+    return { slug: chipVsSlug(a, b), a: pageA, b: pageB };
+  });
+}
+
+export function getChipVsPage(slug: string): ChipVsPage | undefined {
+  return getAllChipVsPages().find((page) => page.slug === slug);
+}
+
+/** Every slug served by /chips/[slug] (chip pages first, then versus pages). */
+export function getAllChipRouteSlugs(): readonly string[] {
+  return [...entries.map((entry) => entry.slug), ...getAllChipVsPages().map((page) => page.slug)];
+}
+
+/** Parse "186 GB" / "8 TB/s" / "3.35 TB/s" style values to a number in the given unit. */
+export function leadingNumber(value: string): number {
+  const match = /^(?<num>[\d.]+)/u.exec(value.trim());
+  if (!match?.groups?.num) throw new Error(`Cannot parse numeric prefix from "${value}"`);
+  return Number(match.groups.num);
+}
+
+const formatRatio = (x: number, y: number): string => `${(x / y).toFixed(2).replace(/0$/u, '')}x`;
+
+export interface ChipVsHighlight {
+  /** Stable key so the zh sibling can localize the label. */
+  key: 'memory' | 'memoryBandwidth' | 'fp8' | 'fp4' | 'tdp' | 'costNeocloud' | 'scaleUpWorldSize';
+  aValue: string;
+  bValue: string;
+  /** a over b, e.g. "1.5x" — omitted when either side lacks the number. */
+  ratio?: string;
+}
+
+/** Data-derived comparison rows shared by the EN and ZH versus pages. */
+export function buildChipVsHighlights(page: ChipVsPage): readonly ChipVsHighlight[] {
+  const specA = getChipSpec(page.a);
+  const specB = getChipSpec(page.b);
+  const hwA = getChipHw(page.a);
+  const hwB = getChipHw(page.b);
+
+  return [
+    {
+      key: 'memory',
+      aValue: `${specA.memory} ${specA.memoryType}`,
+      bValue: `${specB.memory} ${specB.memoryType}`,
+      ratio: formatRatio(leadingNumber(specA.memory), leadingNumber(specB.memory)),
+    },
+    {
+      key: 'memoryBandwidth',
+      aValue: specA.memoryBandwidth,
+      bValue: specB.memoryBandwidth,
+      ratio: formatRatio(
+        leadingNumber(specA.memoryBandwidth),
+        leadingNumber(specB.memoryBandwidth),
+      ),
+    },
+    {
+      key: 'fp8',
+      aValue: `${specA.fp8.toLocaleString('en-US')} TFLOP/s`,
+      bValue: `${specB.fp8.toLocaleString('en-US')} TFLOP/s`,
+      ratio: formatRatio(specA.fp8, specB.fp8),
+    },
+    {
+      key: 'fp4',
+      aValue: specA.fp4 ? `${specA.fp4.toLocaleString('en-US')} TFLOP/s` : 'Not supported',
+      bValue: specB.fp4 ? `${specB.fp4.toLocaleString('en-US')} TFLOP/s` : 'Not supported',
+      ...(specA.fp4 && specB.fp4 ? { ratio: formatRatio(specA.fp4, specB.fp4) } : {}),
+    },
+    {
+      key: 'tdp',
+      aValue: `${hwA.tdp.toLocaleString('en-US')} W`,
+      bValue: `${hwB.tdp.toLocaleString('en-US')} W`,
+      ratio: formatRatio(hwA.tdp, hwB.tdp),
+    },
+    {
+      key: 'costNeocloud',
+      aValue: `$${hwA.costn.toFixed(2)}/hr`,
+      bValue: `$${hwB.costn.toFixed(2)}/hr`,
+      ratio: formatRatio(hwA.costn, hwB.costn),
+    },
+    {
+      key: 'scaleUpWorldSize',
+      aValue: `${specA.scaleUpWorldSize} chips`,
+      bValue: `${specB.scaleUpWorldSize} chips`,
+    },
+  ];
+}
+
+/** English FAQ, generated from the spec/pricing registries so it cannot drift. */
+export function buildChipFaq(entry: ChipPageEntry): readonly ChipFaqItem[] {
+  const spec = getChipSpec(entry);
+  const hw = getChipHw(entry);
+  return [
+    {
+      question: `How much does ${entry.label} cost per hour in the cloud?`,
+      answer:
+        `The SemiAnalysis AI Cloud TCO model rates ${entry.label} at about $${hw.costh.toFixed(2)}/hr at hyperscalers, ` +
+        `$${hw.costn.toFixed(2)}/hr at neoclouds and $${hw.costr.toFixed(2)}/hr at the retail tier. ` +
+        `InferenceX performance-per-dollar pages use these rates to turn measured throughput into $/M tokens.`,
+    },
+    {
+      question: `How much memory does ${entry.label} have?`,
+      answer:
+        `${entry.label} has ${spec.memory} of usable ${spec.memoryType} per chip with ${spec.memoryBandwidth} of memory bandwidth. ` +
+        `A ${spec.scaleUpWorldSize}-chip ${spec.scaleUpTech} domain pools ${Math.round(leadingNumber(spec.memory) * spec.scaleUpWorldSize).toLocaleString('en-US')} GB.`,
+    },
+    {
+      question: `What is the power consumption of ${entry.label}?`,
+      answer:
+        `${entry.label} has a ${hw.tdp.toLocaleString('en-US')} W TDP per chip, and about ${hw.power} kW all-in per chip ` +
+        `once the host CPU, NICs and cooling share are included. InferenceX uses the all-in figure for energy-per-token math.`,
+    },
+    {
+      question: `Does ${entry.label} support FP4?`,
+      answer: spec.fp4
+        ? `Yes. ${entry.label} reaches ${spec.fp4.toLocaleString('en-US')} dense FP4 TFLOP/s (${spec.fp8.toLocaleString('en-US')} at FP8), and InferenceX tracks FP4-versus-FP8 serving accuracy and throughput on its precision compare pages.`
+        : `No. ${entry.label} tops out at FP8 with ${spec.fp8.toLocaleString('en-US')} dense TFLOP/s; FP4 serving requires a newer chip generation.`,
+    },
+    {
+      question: `How fast is ${entry.label} for LLM inference?`,
+      answer:
+        `It depends on the model, framework, precision and interactivity target, so InferenceX publishes continuously refreshed ` +
+        `throughput-versus-interactivity Pareto frontiers for ${entry.label} instead of a single number. The live dashboard and ` +
+        `compare pages show current results on every covered model.`,
+    },
+  ];
+}
+
+/** English FAQ for a versus page, generated from the same registries. */
+export function buildChipVsFaq(page: ChipVsPage): readonly ChipFaqItem[] {
+  const highlights = buildChipVsHighlights(page);
+  const memory = highlights.find((h) => h.key === 'memory');
+  const cost = highlights.find((h) => h.key === 'costNeocloud');
+  const fp8 = highlights.find((h) => h.key === 'fp8');
+  return [
+    {
+      question: `Which has more memory, ${page.a.label} or ${page.b.label}?`,
+      answer: `${page.a.label} offers ${memory?.aValue} per chip versus ${memory?.bValue} on ${page.b.label} (${memory?.ratio} the capacity).`,
+    },
+    {
+      question: `How do ${page.a.label} and ${page.b.label} prices compare?`,
+      answer:
+        `At the neocloud tier the SemiAnalysis TCO model rates ${page.a.label} at ${cost?.aValue} versus ${cost?.bValue} for ${page.b.label}. ` +
+        `Hourly price alone is misleading; the per-dollar compare pages divide measured throughput by these rates.`,
+    },
+    {
+      question: `Is ${page.a.label} faster than ${page.b.label} for LLM inference?`,
+      answer:
+        `On paper ${page.a.label} has ${fp8?.ratio} the dense FP8 compute of ${page.b.label}, but delivered tokens per second depend on the model, ` +
+        `framework, precision and interactivity target. InferenceX measures both chips daily on identical workloads; see the live compare pages for current results.`,
+    },
+  ];
+}
+
+/** English labels for the data-derived versus highlight rows. */
+export const CHIP_VS_HIGHLIGHT_LABELS_EN: Readonly<Record<ChipVsHighlight['key'], string>> = {
+  memory: 'Memory per chip',
+  memoryBandwidth: 'Memory bandwidth',
+  fp8: 'Dense FP8 compute',
+  fp4: 'Dense FP4 compute',
+  tdp: 'TDP',
+  costNeocloud: 'Hourly rate (neocloud tier)',
+  scaleUpWorldSize: 'Scale-up world size',
+};

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -56,6 +56,7 @@ export const ZH_MIRRORED_ROUTES: readonly { path: string; exact?: boolean }[] = 
   { path: '/compare-spec-decode' },
   { path: '/blog' },
   { path: '/glossary' },
+  { path: '/chips' },
   { path: '/agentx' },
 ];
 


### PR DESCRIPTION
## Summary

Adds a new statically generated, fully indexable `/chips` page family targeting high-volume hardware search queries ("H100 specs", "B200 price per hour", "MI355X vs B200", "GB200 NVL72 power consumption") that InferenceX has the data to answer authoritatively but had no landing pages for.

**44 new indexable URLs:**
- `/chips` index page (+ `/zh/chips`)
- 9 chip detail pages: H100, H200, B200, B300, GB200 NVL72, GB300 NVL72, MI300X, MI325X, MI355X (+ 9 `/zh` siblings)
- 12 chip-vs-chip comparison pages: B200 vs H100, B200 vs H200, B300 vs B200, GB200 NVL72 vs B200, GB300 NVL72 vs GB200 NVL72, GB300 NVL72 vs B300, MI355X vs MI325X, MI325X vs MI300X, MI300X vs H100, MI355X vs B200, MI355X vs B300, MI325X vs H200 (+ 12 `/zh` siblings)

## Design

- All numbers derive from `GPU_SPECS` and `HW_REGISTRY` at build time, so the pages can never drift from the dashboard. Only prose is hand-authored.
- Every page ships BreadcrumbList + FAQPage JSON-LD (ItemList on the index), searcher-phrased meta keywords, hreflang alternates via `enAlternates`/`zhAlternates`, and `openGraph.locale: ZH_OG_LOCALE` on zh pages.
- Pages are fully static (`dynamicParams = false`, `generateStaticParams`), added to the sitemap via `localizedPair`, linked from the footer (`footer-link-chips`), registered in `ZH_MIRRORED_ROUTES` (language switcher works), and listed in `llms.txt`.
- Detail pages crosslink verified blog posts, glossary terms, related chips, and the live compare/per-dollar dashboards to funnel crawl equity into the SSR compare pages.
- Overlay support: N/A (static content pages, no dashboard overlays).

## Chinese pages

Every English page ships its Simplified Chinese sibling in this PR per AGENTS.md. Chinese copy is hand-written natural technical Chinese (not machine-mirrored), keeps SKUs/framework names in English, uses the preferred glossary terms (基准测试, 吞吐量, 内存带宽, 芯片), and contains no em/en dashes.

## Testing

- `chip-pages.test.ts` (11 tests): every `hwKey` resolves in `HW_REGISTRY` and every `specName` in `GPU_SPECS`; slug uniqueness; vs pairs valid with no self-pairs; related blog/glossary/chip slugs all resolve; ratio table integrity; zh parity (every EN page has a zh translation, nothing extra, paragraph counts match); zh copy rules (no standalone English "Chip", SKUs preserved, localized FAQ); no em/en dashes in any locale.
- `sitemap.test.ts`: new locale-parity assertion for `/chips` and all 21 slug routes.
- `bun run typecheck`, `bun run lint`, `bun run fmt` all clean. Pre-existing unit-test failures on unrelated files (jsdom/undici under local Node 20) reproduce on clean master and are untouched by this PR.

## 中文说明

本 PR 新增 44 个静态生成的可索引页面：`/chips` 索引页、9 个芯片详情页（H100、H200、B200、B300、GB200 NVL72、GB300 NVL72、MI300X、MI325X、MI355X）与 12 个芯片对比页，每个英文页面均按 AGENTS.md 要求在 `/zh` 下提供简体中文版本。

所有规格与价格数字均在构建时来自 `GPU_SPECS` 与 `HW_REGISTRY`，与仪表板数据保持一致；仅文字说明为人工撰写。页面包含 BreadcrumbList 与 FAQPage 结构化数据、hreflang 互链、站点地图条目、页脚链接、语言切换支持及 llms.txt 覆盖，并交叉链接到相关博客文章、术语表与实时对比页面。

中文文案为自然的技术中文，SKU 与框架名称保留英文，使用统一术语（基准测试、吞吐量、内存带宽、芯片），不含破折号。单元测试覆盖注册表一致性、slug 唯一性、关联链接有效性与中英文对等性。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds static marketing/SEO pages with no auth or database; numeric claims are tied to existing registries and covered by new unit tests.
> 
> **Overview**
> Introduces a **static `/chips` SEO surface** (index, 9 chip detail pages, 12 head-to-head comparison slugs) in **English and `/zh`**, targeting hardware search queries with no prior landing pages.
> 
> **Data and content:** New `chip-pages` / `chip-pages-zh` registries hand-author overview copy while **specs, TDP, and cloud $/hr come from `GPU_SPECS` and `HW_REGISTRY` at build time**; FAQs and versus tables are generated from those sources so numbers stay aligned with the dashboard.
> 
> **Routing and UX:** Shared server UI in `chip-page-sections` renders spec tables, registry-backed FAQs, JSON-LD (BreadcrumbList, FAQPage, ItemList on index), links to live compare/per-dollar dashboards, and crosslinks to blog/glossary/related chips. Dynamic routes use `generateStaticParams` and `dynamicParams = false`.
> 
> **Discoverability:** `/chips` is added to the **sitemap** (both locales), **`llms.txt`**, **footer** (“Chip Specs & Pricing”), and **`ZH_MIRRORED_ROUTES`** for hreflang and language switching. **`chip-pages.test.ts`** and an extended **`sitemap.test.ts`** assert registry integrity, zh parity, and locale coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 165025ae2d6ccd5bb9c8e53286cb6715449bfeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->