### PR TITLE
Plug the SemiAnalysis Accelerator & HBM and AI Cloud TCO models on /chips pages / 在 /chips 页面推介 SemiAnalysis Accelerator & HBM 与 AI Cloud TCO 模型

### DIFF
--- a/packages/app/src/components/chips/chip-page-sections.tsx
+++ b/packages/app/src/components/chips/chip-page-sections.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { getPostBySlug } from '@/lib/blog';
 import {
   CHIP_VS_HIGHLIGHT_LABELS_EN,
@@ -34,7 +35,13 @@ import {
 import { getGlossaryEntry } from '@/lib/glossary';
 import { getZhGlossaryEntry } from '@/lib/glossary-zh';
 import { type Locale, localePath, ZH_LANG_TAG } from '@/lib/i18n';
-import { SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  ACCELERATOR_MODEL_TITLE,
+  ACCELERATOR_MODEL_URL,
+  SITE_URL,
+  TCO_MODEL_TITLE,
+  TCO_SOURCE_URL,
+} from '@semianalysisai/inferencex-constants';
 
 const STRINGS = {
   en: {
@@ -58,6 +65,14 @@ const STRINGS = {
     liveLinkCompare: 'Chip-vs-chip model comparisons',
     liveLinkPerDollar: 'Performance per dollar',
     liveLinkOverview: 'Benchmark methodology & overview',
+    modelsHeading: 'Go deeper with the SemiAnalysis models',
+    modelsBody:
+      'InferenceX measures delivered inference performance. The SemiAnalysis institutional models cover the market behind these chips: who ships them, who buys them, and what they cost to own.',
+    modelsAccDesc:
+      'SKU-level AI accelerator shipments, pricing and specifications, from foundry wafer starts and HBM supply through customer-level installed base, quarterly with multi-year forecasts.',
+    modelsTcoDesc:
+      'The source of the hourly rates on this page: all-in GPU cost of ownership built up from server capex, power, colocation and cost of capital, with rental price scenarios and a full cluster finance suite.',
+    pricingSource: 'Source: $/chip/hr rate tiers from the SemiAnalysis',
     specLabels: {
       vendor: 'Vendor',
       arch: 'Architecture',
@@ -111,6 +126,14 @@ const STRINGS = {
     liveLinkCompare: '芯片对芯片模型对比',
     liveLinkPerDollar: '每美元性能',
     liveLinkOverview: '基准测试方法与总览',
+    modelsHeading: '通过 SemiAnalysis 行业模型深入研究',
+    modelsBody:
+      'InferenceX 测量实际交付的推理性能，而 SemiAnalysis 机构级行业模型覆盖这些芯片背后的市场：谁在出货、谁在采购、拥有成本是多少。',
+    modelsAccDesc:
+      '按 SKU 跟踪 AI 加速器的出货量、价格与规格，覆盖从晶圆代工投片、HBM 供应到客户级装机量的完整链路，按季度更新并包含多年预测。',
+    modelsTcoDesc:
+      '本页每小时费率的数据来源：从服务器资本开支、电力、托管与资金成本自下而上构建 GPU 全含拥有成本，并提供租赁价格情景与完整的集群财务模型。',
+    pricingSource: '来源：$/芯片/小时 费率取自 SemiAnalysis',
     specLabels: {
       vendor: '厂商',
       arch: '架构',
@@ -232,6 +255,50 @@ const LiveResultsSection = ({ locale }: { locale: Locale }) => {
   );
 };
 
+const SEMIANALYSIS_MODELS = [
+  {
+    href: ACCELERATOR_MODEL_URL,
+    title: ACCELERATOR_MODEL_TITLE,
+    descKey: 'modelsAccDesc',
+  },
+  {
+    href: TCO_SOURCE_URL,
+    title: TCO_MODEL_TITLE,
+    descKey: 'modelsTcoDesc',
+  },
+] as const;
+
+const ModelsSection = ({ locale }: { locale: Locale }) => {
+  const t = STRINGS[locale];
+  return (
+    <section aria-labelledby="chip-models" className="mt-10 border-t border-border/50 pt-10">
+      <h2 id="chip-models" className="text-xl font-semibold tracking-tight">
+        {t.modelsHeading}
+      </h2>
+      <p className="mt-2 leading-7 text-muted-foreground">{t.modelsBody}</p>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        {SEMIANALYSIS_MODELS.map((model) => (
+          <a
+            key={model.href}
+            href={model.href}
+            target="_blank"
+            rel="noreferrer"
+            className="group block h-full"
+          >
+            <Card className="h-full p-5 transition-colors hover:border-brand/50">
+              <h3 className="font-semibold text-brand">
+                SemiAnalysis {model.title}
+                <ExternalLinkIcon />
+              </h3>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">{t[model.descKey]}</p>
+            </Card>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};
+
 const SpecTable = ({ entry, locale }: { entry: ChipPageEntry; locale: Locale }) => {
   const t = STRINGS[locale];
   const spec = getChipSpec(entry);
@@ -270,6 +337,18 @@ const SpecTable = ({ entry, locale }: { entry: ChipPageEntry; locale: Locale }) 
           ))}
         </tbody>
       </table>
+      <p className="mt-3 text-sm text-muted-foreground">
+        {t.pricingSource}{' '}
+        <a
+          href={TCO_SOURCE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="group underline hover:text-foreground"
+        >
+          {TCO_MODEL_TITLE}
+          <ExternalLinkIcon />
+        </a>
+      </p>
     </div>
   );
 };
@@ -415,6 +494,7 @@ export const ChipDetailContent = ({ entry, locale }: { entry: ChipPageEntry; loc
               </section>
               <FaqSection faq={faq} locale={locale} />
               <LiveResultsSection locale={locale} />
+              <ModelsSection locale={locale} />
               <RelatedLinks entry={entry} locale={locale} />
             </div>
           </Card>
@@ -510,6 +590,7 @@ export const ChipVsContent = ({ page, locale }: { page: ChipVsPage; locale: Loca
               </section>
               <FaqSection faq={faq} locale={locale} />
               <LiveResultsSection locale={locale} />
+              <ModelsSection locale={locale} />
             </div>
           </Card>
         </article>

--- a/packages/constants/src/tco.ts
+++ b/packages/constants/src/tco.ts
@@ -3,3 +3,11 @@ export const TCO_SOURCE_TITLE =
   'SemiAnalysis Market July 2026 Pricing Surveys & AI Cloud TCO Model';
 
 export const TCO_SOURCE_URL = 'https://semianalysis.com/ai-cloud-tco-model/';
+
+/** Short product name for surfaces that plug the model itself rather than cite it as a data source. */
+export const TCO_MODEL_TITLE = 'AI Cloud TCO Model';
+
+/** SemiAnalysis institutional model tracking accelerator shipments, ASPs, specs and HBM supply. */
+export const ACCELERATOR_MODEL_TITLE = 'Accelerator & HBM Model';
+
+export const ACCELERATOR_MODEL_URL = 'https://semianalysis.com/accelerator-hbm-model/';


### PR DESCRIPTION
## Summary

The /chips/[slug] pages already cite the SemiAnalysis AI Cloud TCO model in their FAQ prose but never link either institutional product. This PR plugs both models on every chip surface:

- **New "Go deeper with the SemiAnalysis models" section** on all 9 chip detail pages and 12 versus pages (en + zh): two link cards for the [Accelerator & HBM Model](https://semianalysis.com/accelerator-hbm-model/) and the [AI Cloud TCO Model](https://semianalysis.com/ai-cloud-tco-model/), placed after the live-results CTA.
- **Spec table source credit**: the chip detail spec table now credits the AI Cloud TCO Model as the source of its $/chip/hr rate tiers, with a direct external link.
- **Shared constants**: `ACCELERATOR_MODEL_TITLE/URL` and `TCO_MODEL_TITLE` added to `packages/constants/src/tco.ts` next to the existing `TCO_SOURCE_URL`, so the product links stay single-sourced.

Copy avoids volatile figures (vendor/SKU counts) so the cards cannot drift as the models expand. No changes to generated FAQ text, registries, or routes; the zh side reuses the existing `STRINGS` dictionary in `chip-page-sections.tsx` with hand-written Chinese following docs/chinese-copy.md.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` all green.
- Targeted vitest: `chip-pages.test.ts`, `zh-copy.test.ts`, `sitemap.test.ts` (41 tests) pass; full-suite failures (overview/compare server tests) reproduce identically on a clean master checkout, so they are pre-existing local-env issues.
- Rendered /chips/h100, /zh/chips/h100 and /chips/mi355x-vs-b200 locally and visually verified both locales.

## 中文说明

/chips/[slug] 页面的 FAQ 文案此前虽引用了 SemiAnalysis AI Cloud TCO 模型，但从未链接任何机构级产品。本 PR 在所有芯片页面推介这两个模型：

- **新增"通过 SemiAnalysis 行业模型深入研究"版块**：9 个芯片详情页与 12 个对比页（中英文）均新增两张链接卡片，分别指向 [Accelerator & HBM Model](https://semianalysis.com/accelerator-hbm-model/) 与 [AI Cloud TCO Model](https://semianalysis.com/ai-cloud-tco-model/)，位于实时结果 CTA 之后。
- **规格表来源说明**：芯片详情页规格表下方新增 $/芯片/小时 费率来源说明，直接外链 AI Cloud TCO Model 产品页。
- **共享常量**：`ACCELERATOR_MODEL_TITLE/URL` 与 `TCO_MODEL_TITLE` 加入 `packages/constants/src/tco.ts`，与现有 `TCO_SOURCE_URL` 并列，产品链接单一来源。

文案刻意避开厂商数、SKU 数等易变数字，防止随模型扩展而失真。未改动自动生成的 FAQ、注册表或路由；中文文案沿用 `chip-page-sections.tsx` 的 `STRINGS` 字典，按 docs/chinese-copy.md 手写。

测试：typecheck / lint / fmt 全部通过；针对性 vitest（chip-pages、zh-copy、sitemap 共 41 项）通过；全量测试中的失败项在干净的 master 上同样复现，属于本地环境的既有问题。已在本地渲染中英文页面并逐一目检。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and outbound-link changes on marketing chip pages; no changes to pricing logic, routes, or generated FAQ/registry data.
> 
> **Overview**
> Adds **institutional model promotion** on chip detail and head-to-head pages (en + zh): a new **“Go deeper with the SemiAnalysis models”** section after the live-results CTA, with two external cards for the **Accelerator & HBM Model** and **AI Cloud TCO Model**, using `ExternalLinkIcon` and locale strings in `STRINGS`.
> 
> Chip **spec tables** now credit **$/chip/hr** tiers to the AI Cloud TCO Model with an inline external link below the table.
> 
> **Shared constants** in `packages/constants/src/tco.ts` add `TCO_MODEL_TITLE`, `ACCELERATOR_MODEL_TITLE`, and `ACCELERATOR_MODEL_URL` so product titles and URLs stay single-sourced next to `TCO_SOURCE_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3060a582f7f493bd380b22a1885ee07cf6374ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->