### PR TITLE
feat(seo): live GPU rankings and model-on-hardware result pages / 新增实时 GPU 排行榜与模型硬件实测页面

### DIFF
--- a/packages/app/src/app/llms.txt/route.ts
+++ b/packages/app/src/app/llms.txt/route.ts
@@ -1,5 +1,6 @@
 import { getAllPosts } from '@/lib/blog';
 import { getAllChipPages, getAllChipVsPages } from '@/lib/chip-pages';
+import { getAllRankingPageEntries, rankingPageHeading } from '@/lib/rankings';
 import { inferenceModelMeta } from '@/lib/inference-model-meta';
 import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
@@ -41,6 +42,18 @@ export async function GET() {
       (page) =>
         `- [${page.a.label} vs ${page.b.label}](${SITE_URL}/chips/${page.slug}): head-to-head comparison`,
     ),
+    '',
+    `## GPU Rankings`,
+    '',
+    `- [GPU Rankings for LLM Inference](${SITE_URL}/rankings): live fastest and cheapest GPU leaderboards per model`,
+    ...getAllRankingPageEntries().map(
+      (entry) =>
+        `- [${rankingPageHeading(entry)}](${SITE_URL}/rankings/${entry.slug}): live benchmark ranking`,
+    ),
+    '',
+    `## Model on GPU Results`,
+    '',
+    `- [Run Any Model on Any GPU](${SITE_URL}/run): measured throughput and cost for every benchmarked model and GPU pairing`,
     '',
     `## Articles`,
     '',

--- a/packages/app/src/app/rankings/[slug]/page.tsx
+++ b/packages/app/src/app/rankings/[slug]/page.tsx
@@ -1,0 +1,210 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
+
+import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
+import {
+  RankingsDetailContent,
+  type RankingsStrings,
+} from '@/components/live-seo/rankings-page-sections';
+import { JsonLd } from '@/components/json-ld';
+import { enAlternates } from '@/lib/i18n';
+import {
+  getRankingPageEntry,
+  rankingPageDescription,
+  rankingPageHeading,
+  rankingPageKeywords,
+  rankingPageTitle,
+  scenarioLabel,
+  type RankingPageEntry,
+} from '@/lib/rankings';
+import { getRankingPageData, type RankingPageData } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function statLedDescription(entry: RankingPageEntry, data: RankingPageData): string {
+  const [first] = data.rows;
+  if (!first) return rankingPageDescription(entry);
+  if (entry.kind === 'fastest-gpu' && first.throughputPerGpu !== null) {
+    return `${first.hardwareLabel} currently serves ${entry.model.seoName} fastest at ${fmtThroughput(first.throughputPerGpu)} tokens/s per GPU. Live ranking of ${data.rows.length} platforms, re-benchmarked continuously.`;
+  }
+  if (entry.kind === 'cheapest-gpu' && first.costPerMtok !== null) {
+    return `${first.hardwareLabel} currently serves ${entry.model.seoName} cheapest at ${fmtCostPerMtok(first.costPerMtok)} per million tokens. Live ranking of ${data.rows.length} platforms, re-benchmarked continuously.`;
+  }
+  return rankingPageDescription(entry);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getRankingPageEntry(slug);
+  if (!entry) return {};
+  const data = await getRankingPageData(entry.slug);
+  const title = rankingPageTitle(entry);
+  const description = `${data ? statLedDescription(entry, data) : rankingPageDescription(entry)} ${SUPPORTERS_LINE}`;
+  const url = `${SITE_URL}/rankings/${entry.slug}`;
+  return {
+    title,
+    description,
+    keywords: rankingPageKeywords(entry),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: enAlternates(`/rankings/${entry.slug}`),
+    openGraph: { title: `${title} | ${SITE_NAME}`, description, url, type: 'article' },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+function buildFaq(
+  entry: RankingPageEntry,
+  data: RankingPageData,
+): { question: string; answer: string }[] {
+  const model = entry.model.seoName;
+  const [first] = data.rows;
+  const workload = scenarioLabel(data.scenario, 'en');
+  const fallbackLeader = `The ranking is refreshed continuously from InferenceX benchmark runs; check the table above for the current leader.`;
+  const kindFaq =
+    entry.kind === 'fastest-gpu'
+      ? [
+          {
+            question: `What is the fastest GPU for ${model} inference?`,
+            answer:
+              first && typeof first.throughputPerGpu === 'number'
+                ? `As of the latest benchmark runs, ${first.hardwareLabel} leads at ${fmtThroughput(first.throughputPerGpu)} tokens/s per GPU on ${workload}, measured at a matched interactivity target of ${data.tier} tokens/s per user.`
+                : fallbackLeader,
+          },
+          {
+            question: `How is "fastest" measured?`,
+            answer: `Every platform is read at the same interactivity tier (${data.tier} tokens/s per user) on ${workload}, then ranked by measured throughput per GPU. This is the same derivation the InferenceX overview leaderboard renders, so the ranking can never disagree with the dashboard.`,
+          },
+        ]
+      : [
+          {
+            question: `What is the cheapest GPU to run ${model}?`,
+            answer:
+              first && typeof first.costPerMtok === 'number'
+                ? `As of the latest benchmark runs, ${first.hardwareLabel} is cheapest at ${fmtCostPerMtok(first.costPerMtok)} per million total tokens on ${workload}, at hyperscaler $/GPU/hr pricing and a matched interactivity target of ${data.tier} tokens/s per user.`
+                : fallbackLeader,
+          },
+          {
+            question: `How is cost per million tokens calculated?`,
+            answer: `Measured throughput per GPU at the ${data.tier} tokens/s per user tier is converted to $ per million total (input plus output) tokens using hyperscaler $/GPU/hr rates from the SemiAnalysis AI Cloud TCO model. Slower interactivity targets or cheaper rental tiers change the absolute numbers but rarely the order.`,
+          },
+        ];
+  return [
+    ...kindFaq,
+    {
+      question: `How often is this ranking updated?`,
+      answer: data.newest
+        ? `Benchmarks re-run continuously on the InferenceX cluster fleet; the newest result feeding this ranking landed on ${data.newest}. The page always renders the latest data.`
+        : `Benchmarks re-run continuously on the InferenceX cluster fleet, and the page always renders the latest data.`,
+    },
+  ];
+}
+
+export default async function RankingPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getRankingPageEntry(slug);
+  if (!entry) notFound();
+  const data = await getRankingPageData(entry.slug);
+  if (!data) notFound();
+
+  const url = `${SITE_URL}/rankings/${entry.slug}`;
+  const heading = rankingPageHeading(entry);
+  const faq = buildFaq(entry, data);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'ItemList',
+        name: rankingPageTitle(entry),
+        itemListOrder: 'https://schema.org/ItemListOrderAscending',
+        numberOfItems: data.rows.length,
+        itemListElement: data.rows.map((row) => ({
+          '@type': 'ListItem',
+          position: row.rank,
+          name: row.hardwareLabel,
+          ...(row.chip && { url: `${SITE_URL}/chips/${row.chip.slug}` }),
+        })),
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: faq.map((item) => ({
+          '@type': 'Question',
+          name: item.question,
+          acceptedAnswer: { '@type': 'Answer', text: item.answer },
+        })),
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Rankings', item: `${SITE_URL}/rankings` },
+          { '@type': 'ListItem', position: 2, name: heading, item: url },
+        ],
+      },
+    ],
+  };
+
+  const t: RankingsStrings = {
+    backLabel: 'GPU rankings',
+    heading,
+    scenarioNote: `Measured on ${scenarioLabel(data.scenario, 'en')} at a matched interactivity target of ${data.tier} tokens/s per user. Hardware without a measurement at this operating point is not ranked.`,
+    tableCaption: `${heading}: live benchmark ranking`,
+    colRank: 'Rank',
+    colGpu: 'GPU',
+    colThroughput: 'Tokens/s per GPU',
+    colCost: '$ / 1M tokens',
+    colPrecision: 'Precision',
+    colEngine: 'Engine',
+    emptyState: `No benchmark measurements are available for ${entry.model.seoName} at this operating point yet. The InferenceX fleet re-benchmarks continuously; this page fills in automatically as soon as runs land.`,
+    siblingLead:
+      entry.kind === 'fastest-gpu'
+        ? 'Optimizing for cost instead of speed?'
+        : 'Optimizing for speed instead of cost?',
+    siblingLabel:
+      entry.kind === 'fastest-gpu'
+        ? `See the cheapest GPU for ${entry.model.seoName}`
+        : `See the fastest GPU for ${entry.model.seoName}`,
+    methodologyHeading: 'Methodology',
+    methodologyBody: [
+      `Every number on this page is a measurement, not a spec-sheet estimate. The InferenceX fleet serves ${entry.model.seoName} on real hardware with community serving engines, sweeping concurrency to trace each platform's throughput-versus-interactivity frontier.`,
+      `Platforms are then read at the same operating point (${data.tier} tokens/s per user) so the comparison is iso-interactivity: a GPU cannot win by quoting throughput at an unusably slow per-user speed. Cost converts measured throughput to $ per million total tokens using $/GPU/hr rates from the SemiAnalysis AI Cloud TCO model.`,
+      `The derivation is shared with the InferenceX overview leaderboard, and results re-run continuously, so this ranking updates as new engine releases and configs land.`,
+    ],
+    faqHeading: 'Frequently asked questions',
+    faq,
+    exploreHeading: 'Explore the data',
+    exploreLinks: [
+      {
+        href: `/model/${entry.model.slug}`,
+        label: `${entry.model.seoName} deep dive: architecture, evals, and performance`,
+      },
+      { href: '/inference', label: 'Interactive inference dashboard' },
+      { href: '/overview', label: 'Cross-model inference leaderboard' },
+      { href: '/compare', label: 'Head-to-head GPU comparisons' },
+      { href: '/chips', label: 'GPU specs and pricing' },
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <RankingsDetailContent entry={entry} data={data} t={t} locale="en" />
+    </>
+  );
+}

--- a/packages/app/src/app/rankings/page.tsx
+++ b/packages/app/src/app/rankings/page.tsx
@@ -1,0 +1,103 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE } from '@semianalysisai/inferencex-constants';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { enAlternates } from '@/lib/i18n';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import { getAllRankingPageEntries } from '@/lib/rankings';
+
+const title = 'GPU Rankings for LLM Inference';
+const description =
+  'Live leaderboards of the fastest and cheapest GPUs for serving open LLMs like DeepSeek, Kimi, GLM, MiniMax, and Qwen. Ranked by measured tokens/s per GPU and $ per million tokens, re-benchmarked continuously.';
+
+export const metadata: Metadata = {
+  title,
+  description: `${description} ${SUPPORTERS_LINE}`,
+  keywords: [
+    'fastest GPU for LLM inference',
+    'cheapest GPU for LLM inference',
+    'GPU leaderboard LLM',
+    'best GPU for AI inference',
+    'LLM inference cost per token',
+    'H100 vs B200 vs MI355X',
+    'tokens per second per GPU',
+    'GPU inference rankings',
+  ],
+  alternates: enAlternates('/rankings'),
+  openGraph: {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    url: `${SITE_URL}/rankings`,
+    type: 'website',
+  },
+  twitter: { card: 'summary_large_image', title, description },
+};
+
+export default function RankingsIndexPage() {
+  const entries = getAllRankingPageEntries();
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url: `${SITE_URL}/rankings`,
+    hasPart: entries.map((entry) => ({
+      '@type': 'WebPage',
+      name:
+        entry.kind === 'fastest-gpu'
+          ? `Fastest GPU for ${entry.model.seoName}`
+          : `Cheapest GPU for ${entry.model.seoName}`,
+      url: `${SITE_URL}/rankings/${entry.slug}`,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <h1 className="max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted-foreground">
+              Which GPU should serve your model? Every ranking below is derived from measured
+              benchmark runs at matched interactivity, not spec sheets, and re-renders as new
+              results land.
+            </p>
+          </header>
+
+          <section className="mt-10 mb-16 grid gap-4 sm:grid-cols-2">
+            {INFERENCE_MODEL_SLUGS.map((model) => (
+              <Card key={model.slug} className="p-5">
+                <h2 className="text-lg font-semibold tracking-tight">{model.seoName}</h2>
+                <ul className="mt-3 space-y-1">
+                  <li>
+                    <Link
+                      href={`/rankings/fastest-gpu-for-${model.slug}`}
+                      className="text-sm font-medium text-brand hover:underline"
+                    >
+                      Fastest GPU for {model.seoName}
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href={`/rankings/cheapest-gpu-for-${model.slug}`}
+                      className="text-sm font-medium text-brand hover:underline"
+                    >
+                      Cheapest GPU for {model.seoName}
+                    </Link>
+                  </li>
+                </ul>
+              </Card>
+            ))}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/run/[slug]/page.tsx
+++ b/packages/app/src/app/run/[slug]/page.tsx
@@ -156,7 +156,9 @@ export default async function RunPage({ params }: Props) {
       ? `, which works out to ${fmtCostPerMtok(read.costPerMtok)} per million tokens at hyperscaler pricing`
       : '';
   const latency = latencyQuote(data);
-  const quickAnswerLatency = latency ? ` Best measured latency: ${latency}.` : '';
+  const quickAnswerLatency = latency
+    ? ` Fastest measured TTFT: ${latency.ttft}; fastest TPOT: ${latency.tpot} (each the best across all configs, not one run).`
+    : '';
   const quickAnswer =
     typeof read?.throughputPerGpu === 'number'
       ? `${entry.model.seoName} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU on ${entry.chip.label} at ${data.primaryTier} tokens/s per user${quickAnswerCost}${read.framework ? `, served by ${read.framework}` : ''}.${quickAnswerLatency}`

--- a/packages/app/src/app/run/[slug]/page.tsx
+++ b/packages/app/src/app/run/[slug]/page.tsx
@@ -10,7 +10,11 @@ import {
 } from '@semianalysisai/inferencex-constants';
 
 import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
-import { RunDetailContent, type RunStrings } from '@/components/live-seo/run-page-sections';
+import {
+  latencyQuote,
+  RunDetailContent,
+  type RunStrings,
+} from '@/components/live-seo/run-page-sections';
 import { JsonLd } from '@/components/json-ld';
 import { enAlternates } from '@/lib/i18n';
 import { scenarioLabel } from '@/lib/rankings';
@@ -58,6 +62,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description,
     keywords: runPageKeywords(entry),
     authors: [{ name: AUTHOR_NAME }],
+    // Valid slugs without benchmark data render an empty state; keep those
+    // out of the index (the sitemap already excludes them).
+    ...(data?.hasData ? {} : { robots: { index: false, follow: true } }),
     alternates: enAlternates(`/run/${entry.slug}`),
     openGraph: { title: `${title} | ${SITE_NAME}`, description, url, type: 'article' },
     twitter: {
@@ -148,9 +155,11 @@ export default async function RunPage({ params }: Props) {
     typeof read?.costPerMtok === 'number'
       ? `, which works out to ${fmtCostPerMtok(read.costPerMtok)} per million tokens at hyperscaler pricing`
       : '';
+  const latency = latencyQuote(data);
+  const quickAnswerLatency = latency ? ` Best measured latency: ${latency}.` : '';
   const quickAnswer =
     typeof read?.throughputPerGpu === 'number'
-      ? `${entry.model.seoName} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU on ${entry.chip.label} at ${data.primaryTier} tokens/s per user${quickAnswerCost}${read.framework ? `, served by ${read.framework}` : ''}.`
+      ? `${entry.model.seoName} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU on ${entry.chip.label} at ${data.primaryTier} tokens/s per user${quickAnswerCost}${read.framework ? `, served by ${read.framework}` : ''}.${quickAnswerLatency}`
       : `${entry.model.seoName} runs on ${entry.chip.label}: ${data.configCount} benchmarked configs so far. See the interactivity ladder below for measured operating points.`;
 
   const t: RunStrings = {

--- a/packages/app/src/app/run/[slug]/page.tsx
+++ b/packages/app/src/app/run/[slug]/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import {
+  AUTHOR_HANDLE,
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE,
+} from '@semianalysisai/inferencex-constants';
+
+import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
+import { RunDetailContent, type RunStrings } from '@/components/live-seo/run-page-sections';
+import { JsonLd } from '@/components/json-ld';
+import { enAlternates } from '@/lib/i18n';
+import { scenarioLabel } from '@/lib/rankings';
+import {
+  getRunPageEntry,
+  runPageDescription,
+  runPageFaqQuestions,
+  runPageHeading,
+  runPageKeywords,
+  runPageTitle,
+  type RunPageEntry,
+} from '@/lib/run-pages';
+import { getRunPageData, type RunPageData } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function primaryRead(data: RunPageData) {
+  return data.tierLadder.find((read) => read.tier === data.primaryTier);
+}
+
+function statLedDescription(entry: RunPageEntry, data: RunPageData): string {
+  const read = primaryRead(data);
+  if (!data.hasData || !read?.throughputPerGpu) return runPageDescription(entry);
+  const cost =
+    read.costPerMtok === null
+      ? ''
+      : `, ${fmtCostPerMtok(read.costPerMtok)} per million tokens at hyperscaler pricing`;
+  return `Measured: ${entry.model.seoName} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU on ${entry.chip.label} at ${data.primaryTier} tokens/s per user${cost}. Live data from ${data.configCount} benchmarked configs.`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getRunPageEntry(slug);
+  if (!entry) return {};
+  const data = await getRunPageData(entry.slug);
+  const title = runPageTitle(entry);
+  const description = `${data ? statLedDescription(entry, data) : runPageDescription(entry)} ${SUPPORTERS_LINE}`;
+  const url = `${SITE_URL}/run/${entry.slug}`;
+  return {
+    title,
+    description,
+    keywords: runPageKeywords(entry),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: enAlternates(`/run/${entry.slug}`),
+    openGraph: { title: `${title} | ${SITE_NAME}`, description, url, type: 'article' },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      creator: AUTHOR_HANDLE,
+    },
+  };
+}
+
+function buildFaq(entry: RunPageEntry, data: RunPageData): { question: string; answer: string }[] {
+  const questions = runPageFaqQuestions(entry);
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  const read = primaryRead(data);
+  const workload = scenarioLabel(data.scenario, 'en');
+
+  const peak =
+    data.bestThroughputPerGpu === null ? 'n/a' : fmtThroughput(data.bestThroughputPerGpu);
+  const throughputAnswer =
+    typeof read?.throughputPerGpu === 'number'
+      ? `At an interactivity target of ${data.primaryTier} tokens/s per user on ${workload}, ${chip} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU serving ${model}${read.framework ? ` with ${read.framework}` : ''}${read.precision ? ` in ${read.precision.toUpperCase()}` : ''}. Peak measured throughput across all configs is ${peak} tokens/s per GPU.`
+      : `The InferenceX fleet has ${data.configCount} benchmarked configs for this pairing; see the interactivity ladder above for the operating points reached so far.`;
+
+  const costAnswer =
+    typeof read?.costPerMtok === 'number'
+      ? `${fmtCostPerMtok(read.costPerMtok)} per million total tokens at hyperscaler $/GPU/hr pricing, at ${data.primaryTier} tokens/s per user. Neocloud and retail rental tiers are tabulated above; slower interactivity targets lower the cost further.`
+      : `Cost per million tokens is derived from measured throughput and $/GPU/hr rates from the SemiAnalysis AI Cloud TCO model; it appears once this pairing reaches the primary interactivity tier.`;
+
+  const servingAnswer = `The runs behind this page used ${data.frameworks.join(', ')} in ${data.precisions.map((p) => p.toUpperCase()).join(', ')}${data.hasDisagg ? ', including disaggregated prefill' : ''}${data.hasMultinode ? ' and multi-node serving' : ''}. Engines are rebuilt and re-benchmarked continuously, so the best config can change between visits.`;
+
+  const methodologyAnswer = `Every number is measured on real ${chip} hardware by the InferenceX fleet, sweeping concurrency on ${workload} to trace the throughput-versus-interactivity frontier${data.newest ? `; the newest run landed on ${data.newest}` : ''}. The same derivation powers the InferenceX overview leaderboard.`;
+
+  return [
+    { question: questions.throughput, answer: throughputAnswer },
+    { question: questions.cost, answer: costAnswer },
+    { question: questions.serving, answer: servingAnswer },
+    { question: questions.methodology, answer: methodologyAnswer },
+  ];
+}
+
+export default async function RunPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getRunPageEntry(slug);
+  if (!entry) notFound();
+  const data = await getRunPageData(entry.slug);
+  if (!data) notFound();
+
+  const url = `${SITE_URL}/run/${entry.slug}`;
+  const heading = runPageHeading(entry);
+  const faq = data.hasData ? buildFaq(entry, data) : [];
+  const read = primaryRead(data);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        name: runPageTitle(entry),
+        url,
+        ...(data.newest && { dateModified: data.newest }),
+        ...(data.oldest && { datePublished: data.oldest }),
+      },
+      ...(faq.length > 0
+        ? [
+            {
+              '@type': 'FAQPage',
+              mainEntity: faq.map((item) => ({
+                '@type': 'Question',
+                name: item.question,
+                acceptedAnswer: { '@type': 'Answer', text: item.answer },
+              })),
+            },
+          ]
+        : []),
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Run', item: `${SITE_URL}/run` },
+          { '@type': 'ListItem', position: 2, name: heading, item: url },
+        ],
+      },
+    ],
+  };
+
+  const quickAnswerCost =
+    typeof read?.costPerMtok === 'number'
+      ? `, which works out to ${fmtCostPerMtok(read.costPerMtok)} per million tokens at hyperscaler pricing`
+      : '';
+  const quickAnswer =
+    typeof read?.throughputPerGpu === 'number'
+      ? `${entry.model.seoName} sustains ${fmtThroughput(read.throughputPerGpu)} tokens/s per GPU on ${entry.chip.label} at ${data.primaryTier} tokens/s per user${quickAnswerCost}${read.framework ? `, served by ${read.framework}` : ''}.`
+      : `${entry.model.seoName} runs on ${entry.chip.label}: ${data.configCount} benchmarked configs so far. See the interactivity ladder below for measured operating points.`;
+
+  const t: RunStrings = {
+    backHref: '/run',
+    backLabel: 'All model and GPU pairings',
+    heading,
+    quickAnswerLabel: 'Quick answer',
+    quickAnswer,
+    statConfigs: 'Benchmarked configs',
+    statEngines: 'Serving engines',
+    statPrecisions: 'Precisions',
+    statFreshness: 'Run dates',
+    ladderHeading: 'Throughput at every interactivity target',
+    ladderIntro: `Serving is a trade-off: push more concurrent users through a GPU and each user's tokens arrive slower. The ladder below reads the measured frontier at each per-user speed target on ${scenarioLabel(data.scenario, 'en')}, using the best engine and precision at that point.`,
+    colTier: 'Per-user target',
+    colThroughput: 'Tokens/s per GPU',
+    colCost: '$ / 1M tokens',
+    colEngine: 'Engine',
+    colPrecision: 'Precision',
+    costHeading: 'What serving actually costs',
+    costIntro: `Converting the ${data.primaryTier} tokens/s per user operating point to $ per million total tokens across rental pricing tiers from the SemiAnalysis AI Cloud TCO model.`,
+    colPriceTier: 'Pricing tier',
+    colGpuHour: '$ / GPU / hr',
+    colCostPerMtok: '$ / 1M tokens',
+    priceTierLabels: {
+      hyperscaler: 'Hyperscaler',
+      neocloud: 'Neocloud',
+      retail: 'Retail',
+    },
+    emptyState: `The InferenceX fleet has not published benchmark runs for ${entry.model.seoName} on ${entry.chip.label} yet. Benchmarks re-run continuously; this page fills in automatically as soon as results land.`,
+    faqHeading: 'Frequently asked questions',
+    faq,
+    exploreHeading: 'Explore the data',
+    exploreLinks: [
+      {
+        href: `/rankings/fastest-gpu-for-${entry.model.slug}`,
+        label: `Fastest GPU for ${entry.model.seoName}: full ranking`,
+      },
+      {
+        href: `/rankings/cheapest-gpu-for-${entry.model.slug}`,
+        label: `Cheapest GPU for ${entry.model.seoName}: full ranking`,
+      },
+      {
+        href: `/model/${entry.model.slug}`,
+        label: `${entry.model.seoName} deep dive: architecture, evals, and performance`,
+      },
+      { href: `/chips/${entry.chip.slug}`, label: `${entry.chip.title} specs and pricing` },
+      { href: '/inference', label: 'Interactive inference dashboard' },
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <RunDetailContent entry={entry} data={data} t={t} />
+    </>
+  );
+}

--- a/packages/app/src/app/run/page.tsx
+++ b/packages/app/src/app/run/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE } from '@semianalysisai/inferencex-constants';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { enAlternates } from '@/lib/i18n';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import { runPageHeading, type RunPageEntry } from '@/lib/run-pages';
+import { getAvailableRunEntries } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+const title = 'Run Any Model on Any GPU: Measured Results';
+const description =
+  'Measured throughput, latency, and cost for every open LLM and GPU pairing the InferenceX fleet benchmarks: DeepSeek, Kimi, GLM, MiniMax, and Qwen on H100, H200, B200, GB200 NVL72, MI300X, MI325X, MI355X, and more.';
+
+export function generateMetadata(): Metadata {
+  return {
+    title,
+    description: `${description} ${SUPPORTERS_LINE}`,
+    keywords: [
+      'run LLM on GPU benchmark',
+      'LLM GPU throughput',
+      'model on GPU performance',
+      'DeepSeek GPU benchmark',
+      'Kimi GPU benchmark',
+      'LLM inference cost per GPU',
+      'H100 LLM benchmark',
+      'MI355X LLM benchmark',
+    ],
+    alternates: enAlternates('/run'),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url: `${SITE_URL}/run`,
+      type: 'website',
+    },
+    twitter: { card: 'summary_large_image', title, description },
+  };
+}
+
+export default async function RunIndexPage() {
+  const entries = await getAvailableRunEntries();
+  const byModel = new Map<string, RunPageEntry[]>();
+  for (const entry of entries) {
+    const list = byModel.get(entry.model.slug) ?? [];
+    list.push(entry);
+    byModel.set(entry.model.slug, list);
+  }
+  const models = INFERENCE_MODEL_SLUGS.filter((model) => byModel.has(model.slug));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url: `${SITE_URL}/run`,
+    hasPart: entries.map((entry) => ({
+      '@type': 'WebPage',
+      name: runPageHeading(entry),
+      url: `${SITE_URL}/run/${entry.slug}`,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <h1 className="max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted-foreground">
+              Pick a model and a GPU: each page below answers how fast it runs, what it costs per
+              million tokens, and which serving engine produced the number, from continuously
+              re-benchmarked runs on real hardware.
+            </p>
+          </header>
+
+          <section className="mt-10 mb-16 space-y-8">
+            {models.map((model) => (
+              <Card key={model.slug} className="p-5">
+                <h2 className="text-lg font-semibold tracking-tight">{model.seoName}</h2>
+                <ul className="mt-3 grid gap-1 sm:grid-cols-2">
+                  {(byModel.get(model.slug) ?? []).map((entry) => (
+                    <li key={entry.slug}>
+                      <Link
+                        href={`/run/${entry.slug}`}
+                        className="text-sm font-medium text-brand hover:underline"
+                      >
+                        {model.seoName} on {entry.chip.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -30,6 +30,11 @@ vi.mock('@/lib/compare-variant-availability', () => ({
   getAllComparableSpecDecodeSlugs: () => Promise.resolve([]),
 }));
 vi.mock('@/lib/glossary', () => ({ getAllGlossaryEntries: () => [] }));
+vi.mock('@/lib/run-rankings-data.server', () => ({
+  getAvailableRunEntries: () => Promise.resolve([]),
+}));
+
+import { getAllRankingPageEntries } from '@/lib/rankings';
 
 import sitemap from './sitemap';
 
@@ -73,6 +78,31 @@ describe('sitemap locale parity', () => {
     for (const slug of slugs) {
       expect(urls.has(`${SITE_URL}/chips/${slug}`)).toBe(true);
       expect(urls.has(`${SITE_URL}${zhPath(`/chips/${slug}`)}`)).toBe(true);
+    }
+  });
+
+  it('emits both locales for the rankings index and every ranking page', async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+    expect(urls.has(`${SITE_URL}/rankings`)).toBe(true);
+    expect(urls.has(`${SITE_URL}${zhPath('/rankings')}`)).toBe(true);
+    const rankingEntries = getAllRankingPageEntries();
+    expect(rankingEntries.length).toBeGreaterThan(0);
+    for (const entry of rankingEntries) {
+      expect(urls.has(`${SITE_URL}/rankings/${entry.slug}`)).toBe(true);
+      expect(urls.has(`${SITE_URL}${zhPath(`/rankings/${entry.slug}`)}`)).toBe(true);
+    }
+  });
+
+  it('emits the /run index in both locales and only available run pages', async () => {
+    const entries = await sitemap();
+    const urls = new Set(entries.map((entry) => entry.url));
+    expect(urls.has(`${SITE_URL}/run`)).toBe(true);
+    expect(urls.has(`${SITE_URL}${zhPath('/run')}`)).toBe(true);
+    // Availability mock returns no pairs, so no /run/<pair> URLs may leak in.
+    for (const url of urls) {
+      expect(url.startsWith(`${SITE_URL}/run/`)).toBe(false);
+      expect(url.startsWith(`${SITE_URL}/zh/run/`)).toBe(false);
     }
   });
 

--- a/packages/app/src/app/sitemap.ts
+++ b/packages/app/src/app/sitemap.ts
@@ -26,6 +26,8 @@ import {
   MODEL_ROUTES,
   modelRoutePath,
 } from '@/lib/model-routes';
+import { getAllRankingPageEntries } from '@/lib/rankings';
+import { getAvailableRunEntries } from '@/lib/run-rankings-data.server';
 import { SITE_URL as BASE_URL } from '@semianalysisai/inferencex-constants';
 
 type SitemapEntry = MetadataRoute.Sitemap[number];
@@ -53,11 +55,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date().toISOString();
   // Only emit (model, pair) URLs that have benchmark data on both sides —
   // avoids polluting the sitemap with empty pages that hurt crawl budget.
-  const [compareSlugs, precisionSlugs, specDecodeSlugs, datasets] = await Promise.all([
+  const [compareSlugs, precisionSlugs, specDecodeSlugs, datasets, runEntries] = await Promise.all([
     getAllComparableCompareSlugs(),
     getAllComparablePrecisionSlugs(),
     getAllComparableSpecDecodeSlugs(),
     FIXTURES_MODE ? Promise.resolve([]) : listDatasets(getDb()),
+    getAvailableRunEntries(),
   ]);
   const zhPosts = new Set(getAllPosts('zh').map((post) => post.slug));
 
@@ -179,6 +182,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       localizedPair(`/chips/${slug}`, {
         lastModified: now,
         changeFrequency: 'weekly' as const,
+        priority: 0.7,
+      }),
+    ),
+    // Live GPU rankings per model (fastest / cheapest). The registry is
+    // static; page bodies render from live benchmark data on request.
+    ...localizedPair('/rankings', { lastModified: now, changeFrequency: 'daily', priority: 0.8 }),
+    ...getAllRankingPageEntries().flatMap((entry) =>
+      localizedPair(`/rankings/${entry.slug}`, {
+        lastModified: now,
+        changeFrequency: 'daily' as const,
+        priority: 0.7,
+      }),
+    ),
+    // Model-on-hardware pages, availability-filtered so only pairings with
+    // benchmark rows enter the sitemap (same crawl-budget rule as /compare).
+    ...localizedPair('/run', { lastModified: now, changeFrequency: 'daily', priority: 0.8 }),
+    ...runEntries.flatMap((entry) =>
+      localizedPair(`/run/${entry.slug}`, {
+        lastModified: now,
+        changeFrequency: 'daily' as const,
         priority: 0.7,
       }),
     ),

--- a/packages/app/src/app/zh/rankings/[slug]/page.tsx
+++ b/packages/app/src/app/zh/rankings/[slug]/page.tsx
@@ -1,0 +1,203 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
+import {
+  RankingsDetailContent,
+  type RankingsStrings,
+} from '@/components/live-seo/rankings-page-sections';
+import { JsonLd } from '@/components/json-ld';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { getRankingPageEntry, scenarioLabel, type RankingPageEntry } from '@/lib/rankings';
+import {
+  rankingPageDescriptionZh,
+  rankingPageHeadingZh,
+  rankingPageKeywordsZh,
+  rankingPageTitleZh,
+} from '@/lib/rankings-zh';
+import { getRankingPageData, type RankingPageData } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function statLedDescriptionZh(entry: RankingPageEntry, data: RankingPageData): string {
+  const [first] = data.rows;
+  if (!first) return rankingPageDescriptionZh(entry);
+  if (entry.kind === 'fastest-gpu' && first.throughputPerGpu !== null) {
+    return `${first.hardwareLabel} 目前以单 GPU 每秒 ${fmtThroughput(first.throughputPerGpu)} token 领跑 ${entry.model.seoName} 推理。共 ${data.rows.length} 个平台实时排名，数据持续更新。`;
+  }
+  if (entry.kind === 'cheapest-gpu' && first.costPerMtok !== null) {
+    return `${first.hardwareLabel} 目前以每百万 token ${fmtCostPerMtok(first.costPerMtok)} 的成本领跑 ${entry.model.seoName} 推理。共 ${data.rows.length} 个平台实时排名，数据持续更新。`;
+  }
+  return rankingPageDescriptionZh(entry);
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getRankingPageEntry(slug);
+  if (!entry) return {};
+  const data = await getRankingPageData(entry.slug);
+  const title = rankingPageTitleZh(entry);
+  const description = data ? statLedDescriptionZh(entry, data) : rankingPageDescriptionZh(entry);
+  const url = `${SITE_URL}/zh/rankings/${entry.slug}`;
+  return {
+    title: { absolute: `${title} | ${SITE_NAME}` },
+    description,
+    keywords: rankingPageKeywordsZh(entry),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: zhAlternates(`/rankings/${entry.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      locale: ZH_OG_LOCALE,
+      type: 'article',
+    },
+    twitter: { card: 'summary_large_image', title: `${title} | ${SITE_NAME}`, description },
+  };
+}
+
+function buildFaqZh(
+  entry: RankingPageEntry,
+  data: RankingPageData,
+): { question: string; answer: string }[] {
+  const model = entry.model.seoName;
+  const [first] = data.rows;
+  const workload = scenarioLabel(data.scenario, 'zh');
+  const fallbackLeader = `排行数据来自 InferenceX 持续运行的基准测试，最新领先者见上方表格。`;
+  const kindFaq =
+    entry.kind === 'fastest-gpu'
+      ? [
+          {
+            question: `${model} 推理最快的 GPU 是哪款？`,
+            answer:
+              first && typeof first.throughputPerGpu === 'number'
+                ? `按最新基准测试结果，${first.hardwareLabel} 在${workload}下以单 GPU 每秒 ${fmtThroughput(first.throughputPerGpu)} token 领先，交互速度统一设定为每用户每秒 ${data.tier} token。`
+                : fallbackLeader,
+          },
+          {
+            question: `“最快”是如何衡量的？`,
+            answer: `所有平台都在相同的交互速度档位（每用户每秒 ${data.tier} token）和${workload}下读取，再按实测单 GPU 吞吐排名。推导方式与 InferenceX 总览排行榜完全一致，因此本页排名不会与仪表盘出现分歧。`,
+          },
+        ]
+      : [
+          {
+            question: `运行 ${model} 最省钱的 GPU 是哪款？`,
+            answer:
+              first && typeof first.costPerMtok === 'number'
+                ? `按最新基准测试结果，${first.hardwareLabel} 在${workload}下成本最低，每百万 token（输入加输出）仅 ${fmtCostPerMtok(first.costPerMtok)}，按超大规模云 $/GPU/小时 价格计算，交互速度统一设定为每用户每秒 ${data.tier} token。`
+                : fallbackLeader,
+          },
+          {
+            question: `每百万 token 成本是如何计算的？`,
+            answer: `将每用户每秒 ${data.tier} token 档位下的实测单 GPU 吞吐，按 SemiAnalysis AI Cloud TCO 模型中的超大规模云 $/GPU/小时 价格换算为每百万 token（输入加输出）成本。更慢的交互档位或更便宜的租用价格会改变绝对数值，但很少改变排名顺序。`,
+          },
+        ];
+  return [
+    ...kindFaq,
+    {
+      question: `排行多久更新一次？`,
+      answer: data.newest
+        ? `基准测试在 InferenceX 集群上持续运行，本排行最新一条结果落在 ${data.newest}。页面始终渲染最新数据。`
+        : `基准测试在 InferenceX 集群上持续运行，页面始终渲染最新数据。`,
+    },
+  ];
+}
+
+export default async function ZhRankingPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getRankingPageEntry(slug);
+  if (!entry) notFound();
+  const data = await getRankingPageData(entry.slug);
+  if (!data) notFound();
+
+  const url = `${SITE_URL}/zh/rankings/${entry.slug}`;
+  const heading = rankingPageHeadingZh(entry);
+  const faq = buildFaqZh(entry, data);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'ItemList',
+        name: rankingPageTitleZh(entry),
+        inLanguage: ZH_LANG_TAG,
+        itemListOrder: 'https://schema.org/ItemListOrderAscending',
+        numberOfItems: data.rows.length,
+        itemListElement: data.rows.map((row) => ({
+          '@type': 'ListItem',
+          position: row.rank,
+          name: row.hardwareLabel,
+          ...(row.chip && { url: `${SITE_URL}/zh/chips/${row.chip.slug}` }),
+        })),
+      },
+      {
+        '@type': 'FAQPage',
+        inLanguage: ZH_LANG_TAG,
+        mainEntity: faq.map((item) => ({
+          '@type': 'Question',
+          name: item.question,
+          acceptedAnswer: { '@type': 'Answer', text: item.answer },
+        })),
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'GPU 排行榜',
+            item: `${SITE_URL}/zh/rankings`,
+          },
+          { '@type': 'ListItem', position: 2, name: heading, item: url },
+        ],
+      },
+    ],
+  };
+
+  const t: RankingsStrings = {
+    backLabel: 'GPU 排行榜',
+    heading,
+    scenarioNote: `测试基于${scenarioLabel(data.scenario, 'zh')}，交互速度统一设定为每用户每秒 ${data.tier} token。在该工作点没有实测数据的硬件不参与排名。`,
+    tableCaption: `${heading}：实时基准排行`,
+    colRank: '排名',
+    colGpu: 'GPU',
+    colThroughput: '单 GPU 每秒 token 数',
+    colCost: '每百万 token 成本',
+    colPrecision: '精度',
+    colEngine: '推理引擎',
+    emptyState: `${entry.model.seoName} 在该工作点暂无实测数据。InferenceX 集群持续运行基准测试，新结果落地后本页会自动填充。`,
+    siblingLead: entry.kind === 'fastest-gpu' ? '更关注成本而不是速度？' : '更关注速度而不是成本？',
+    siblingLabel:
+      entry.kind === 'fastest-gpu'
+        ? `查看运行 ${entry.model.seoName} 最省钱的 GPU`
+        : `查看 ${entry.model.seoName} 推理最快的 GPU`,
+    methodologyHeading: '测试方法',
+    methodologyBody: [
+      `本页所有数字都来自实测，而非纸面规格估算。InferenceX 集群使用社区推理引擎在真实硬件上部署 ${entry.model.seoName}，通过扫描并发数绘制每个平台的吞吐与交互速度前沿曲线。`,
+      `所有平台在同一工作点（每用户每秒 ${data.tier} token）读取，保证对比是等交互速度的：任何 GPU 都无法靠牺牲单用户速度换取纸面吞吐来取胜。成本按 SemiAnalysis AI Cloud TCO 模型的 $/GPU/小时 价格，把实测吞吐换算为每百万 token（输入加输出）成本。`,
+      `推导逻辑与 InferenceX 总览排行榜共用，基准测试持续重跑，新引擎版本和新配置落地后排行会自动更新。`,
+    ],
+    faqHeading: '常见问题',
+    faq,
+    exploreHeading: '继续探索数据',
+    exploreLinks: [
+      { href: '/zh/inference', label: '交互式推理仪表盘' },
+      { href: '/zh/overview', label: '跨模型推理排行榜' },
+      { href: '/zh/compare', label: 'GPU 一对一对比' },
+      { href: '/zh/chips', label: 'GPU 规格与价格' },
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <RankingsDetailContent entry={entry} data={data} t={t} locale="zh" />
+    </>
+  );
+}

--- a/packages/app/src/app/zh/rankings/page.tsx
+++ b/packages/app/src/app/zh/rankings/page.tsx
@@ -1,0 +1,102 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import { getAllRankingPageEntries } from '@/lib/rankings';
+import { rankingPageHeadingZh } from '@/lib/rankings-zh';
+
+const title = 'LLM 推理 GPU 排行榜';
+const description =
+  'DeepSeek、Kimi、GLM、MiniMax、Qwen 等开源大模型推理的最快与最省钱 GPU 实时排行。按实测单 GPU 每秒 token 数与每百万 token 成本排名，数据持续更新。';
+
+export const metadata: Metadata = {
+  title,
+  description,
+  keywords: [
+    'LLM 推理最快 GPU',
+    'LLM 推理最便宜 GPU',
+    'GPU 推理排行榜',
+    'AI 推理最佳 GPU',
+    'LLM 推理 token 成本',
+    'H100 B200 MI355X 对比',
+    '单 GPU 每秒 token 数',
+    'GPU 推理排名',
+  ],
+  alternates: zhAlternates('/rankings'),
+  openGraph: {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    url: `${SITE_URL}/zh/rankings`,
+    locale: ZH_OG_LOCALE,
+    type: 'website',
+  },
+  twitter: { card: 'summary_large_image', title, description },
+};
+
+export default function ZhRankingsIndexPage() {
+  const entries = getAllRankingPageEntries();
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url: `${SITE_URL}/zh/rankings`,
+    inLanguage: ZH_LANG_TAG,
+    hasPart: entries.map((entry) => ({
+      '@type': 'WebPage',
+      name: rankingPageHeadingZh(entry),
+      url: `${SITE_URL}/zh/rankings/${entry.slug}`,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <h1 className="max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted-foreground">
+              哪款 GPU
+              最适合部署你的模型？以下每个排行都来自匹配交互速度下的实测基准数据，而非纸面规格，并随新结果自动更新。
+            </p>
+          </header>
+
+          <section className="mt-10 mb-16 grid gap-4 sm:grid-cols-2">
+            {INFERENCE_MODEL_SLUGS.map((model) => (
+              <Card key={model.slug} className="p-5">
+                <h2 className="text-lg font-semibold tracking-tight">{model.seoName}</h2>
+                <ul className="mt-3 space-y-1">
+                  <li>
+                    <Link
+                      href={`/zh/rankings/fastest-gpu-for-${model.slug}`}
+                      className="text-sm font-medium text-brand hover:underline"
+                    >
+                      {model.seoName} 最快 GPU 排行
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href={`/zh/rankings/cheapest-gpu-for-${model.slug}`}
+                      className="text-sm font-medium text-brand hover:underline"
+                    >
+                      {model.seoName} 最低成本 GPU 排行
+                    </Link>
+                  </li>
+                </ul>
+              </Card>
+            ))}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/zh/run/[slug]/page.tsx
+++ b/packages/app/src/app/zh/run/[slug]/page.tsx
@@ -35,7 +35,8 @@ function statLedDescriptionZh(entry: RunPageEntry, data: RunPageData): string {
     read.costPerMtok === null
       ? ''
       : `，按超大规模云价格每百万 token 成本 ${fmtCostPerMtok(read.costPerMtok)}`;
-  return `实测数据：${entry.model.seoName} 在 ${entry.chip.label} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${cost}。共 ${data.configCount} 组实测配置，数据持续更新。`;
+  const chipLabel = entry.chip.label;
+  return `实测数据：${entry.model.seoName} 在 ${chipLabel} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${cost}。共 ${data.configCount} 组实测配置，数据持续更新。`;
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -69,7 +70,7 @@ function buildFaqZh(
 ): { question: string; answer: string }[] {
   const questions = runPageFaqQuestionsZh(entry);
   const model = entry.model.seoName;
-  const chip = entry.chip.label;
+  const chipLabel = entry.chip.label;
   const read = primaryRead(data);
   const workload = scenarioLabel(data.scenario, 'zh');
 
@@ -77,7 +78,7 @@ function buildFaqZh(
     data.bestThroughputPerGpu === null ? '暂无' : fmtThroughput(data.bestThroughputPerGpu);
   const throughputAnswer =
     typeof read?.throughputPerGpu === 'number'
-      ? `在${workload}、每用户每秒 ${data.primaryTier} token 的交互档位下，${chip} 部署 ${model} 单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${read.framework ? `，推理引擎为 ${read.framework}` : ''}${read.precision ? `，精度 ${read.precision.toUpperCase()}` : ''}。全部配置中的实测峰值吞吐为单 GPU ${peak} token/s。`
+      ? `在${workload}、每用户每秒 ${data.primaryTier} token 的交互档位下，${chipLabel} 部署 ${model} 单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${read.framework ? `，推理引擎为 ${read.framework}` : ''}${read.precision ? `，精度 ${read.precision.toUpperCase()}` : ''}。全部配置中的实测峰值吞吐为单 GPU ${peak} token/s。`
       : `InferenceX 集群已为该组合完成 ${data.configCount} 组实测配置，各交互档位的实测结果见上方阶梯表。`;
 
   const costAnswer =
@@ -87,7 +88,7 @@ function buildFaqZh(
 
   const servingAnswer = `本页数据来自 ${data.frameworks.join('、')}，精度覆盖 ${data.precisions.map((p) => p.toUpperCase()).join('、')}${data.hasDisagg ? '，包含 prefill 分离部署' : ''}${data.hasMultinode ? '，并包含多节点部署' : ''}。推理引擎持续重新构建并重跑基准，最优配置可能随时变化。`;
 
-  const methodologyAnswer = `所有数字均由 InferenceX 集群在真实 ${chip} 硬件上实测，通过在${workload}下扫描并发数绘制吞吐与交互速度前沿曲线${data.newest ? `；最新一次运行落在 ${data.newest}` : ''}。推导方式与 InferenceX 总览排行榜完全一致。`;
+  const methodologyAnswer = `所有数字均由 InferenceX 集群在真实 ${chipLabel} 硬件上实测，通过在${workload}下扫描并发数绘制吞吐与交互速度前沿曲线${data.newest ? `；最新一次运行落在 ${data.newest}` : ''}。推导方式与 InferenceX 总览排行榜完全一致。`;
 
   return [
     { question: questions.throughput, answer: throughputAnswer },
@@ -108,6 +109,9 @@ export default async function ZhRunPage({ params }: Props) {
   const heading = runPageHeadingZh(entry);
   const faq = data.hasData ? buildFaqZh(entry, data) : [];
   const read = primaryRead(data);
+  const model = entry.model.seoName;
+  const chipLabel = entry.chip.label;
+  const chipTitle = entry.chip.title;
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -149,8 +153,8 @@ export default async function ZhRunPage({ params }: Props) {
       : '';
   const quickAnswer =
     typeof read?.throughputPerGpu === 'number'
-      ? `${entry.model.seoName} 在 ${entry.chip.label} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。`
-      : `${entry.model.seoName} 可在 ${entry.chip.label} 上运行：目前已有 ${data.configCount} 组实测配置，各档位实测结果见下方阶梯表。`;
+      ? `${model} 在 ${chipLabel} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。`
+      : `${model} 可在 ${chipLabel} 上运行：目前已有 ${data.configCount} 组实测配置，各档位实测结果见下方阶梯表。`;
 
   const t: RunStrings = {
     backHref: '/zh/run',
@@ -179,7 +183,7 @@ export default async function ZhRunPage({ params }: Props) {
       neocloud: '新兴云',
       retail: '零售租用',
     },
-    emptyState: `InferenceX 集群尚未发布 ${entry.model.seoName} 在 ${entry.chip.label} 上的基准测试结果。基准测试持续运行，新结果落地后本页会自动填充。`,
+    emptyState: `InferenceX 集群尚未发布 ${model} 在 ${chipLabel} 上的基准测试结果。基准测试持续运行，新结果落地后本页会自动填充。`,
     faqHeading: '常见问题',
     faq,
     exploreHeading: '继续探索数据',
@@ -192,7 +196,7 @@ export default async function ZhRunPage({ params }: Props) {
         href: `/zh/rankings/cheapest-gpu-for-${entry.model.slug}`,
         label: `运行 ${entry.model.seoName} 最省钱 GPU 完整排行`,
       },
-      { href: `/zh/chips/${entry.chip.slug}`, label: `${entry.chip.title} 规格与价格` },
+      { href: `/zh/chips/${entry.chip.slug}`, label: `${chipTitle} 规格与价格` },
       { href: '/zh/inference', label: '交互式推理仪表盘' },
     ],
   };

--- a/packages/app/src/app/zh/run/[slug]/page.tsx
+++ b/packages/app/src/app/zh/run/[slug]/page.tsx
@@ -4,7 +4,11 @@ import { notFound } from 'next/navigation';
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
-import { RunDetailContent, type RunStrings } from '@/components/live-seo/run-page-sections';
+import {
+  latencyQuote,
+  RunDetailContent,
+  type RunStrings,
+} from '@/components/live-seo/run-page-sections';
 import { JsonLd } from '@/components/json-ld';
 import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 import { scenarioLabel } from '@/lib/rankings';
@@ -52,6 +56,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description,
     keywords: runPageKeywordsZh(entry),
     authors: [{ name: AUTHOR_NAME }],
+    // Valid slugs without benchmark data render an empty state; keep those
+    // out of the index (the sitemap already excludes them).
+    ...(data?.hasData ? {} : { robots: { index: false, follow: true } }),
     alternates: zhAlternates(`/run/${entry.slug}`),
     openGraph: {
       title: `${title} | ${SITE_NAME}`,
@@ -151,9 +158,11 @@ export default async function ZhRunPage({ params }: Props) {
     typeof read?.costPerMtok === 'number'
       ? `，按超大规模云价格折合每百万 token ${fmtCostPerMtok(read.costPerMtok)}`
       : '';
+  const latency = latencyQuote(data);
+  const quickAnswerLatency = latency ? `最佳实测延迟：${latency}。` : '';
   const quickAnswer =
     typeof read?.throughputPerGpu === 'number'
-      ? `${model} 在 ${chipLabel} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。`
+      ? `${model} 在 ${chipLabel} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。${quickAnswerLatency}`
       : `${model} 可在 ${chipLabel} 上运行：目前已有 ${data.configCount} 组实测配置，各档位实测结果见下方阶梯表。`;
 
   const t: RunStrings = {

--- a/packages/app/src/app/zh/run/[slug]/page.tsx
+++ b/packages/app/src/app/zh/run/[slug]/page.tsx
@@ -159,7 +159,9 @@ export default async function ZhRunPage({ params }: Props) {
       ? `，按超大规模云价格折合每百万 token ${fmtCostPerMtok(read.costPerMtok)}`
       : '';
   const latency = latencyQuote(data);
-  const quickAnswerLatency = latency ? `最佳实测延迟：${latency}。` : '';
+  const quickAnswerLatency = latency
+    ? `全部实测配置中最快 TTFT 为 ${latency.ttft}，最快 TPOT 为 ${latency.tpot}（两者各自取最优，可能来自不同配置）。`
+    : '';
   const quickAnswer =
     typeof read?.throughputPerGpu === 'number'
       ? `${model} 在 ${chipLabel} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。${quickAnswerLatency}`

--- a/packages/app/src/app/zh/run/[slug]/page.tsx
+++ b/packages/app/src/app/zh/run/[slug]/page.tsx
@@ -1,0 +1,206 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
+import { RunDetailContent, type RunStrings } from '@/components/live-seo/run-page-sections';
+import { JsonLd } from '@/components/json-ld';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { scenarioLabel } from '@/lib/rankings';
+import { getRunPageEntry, type RunPageEntry } from '@/lib/run-pages';
+import {
+  runPageDescriptionZh,
+  runPageFaqQuestionsZh,
+  runPageHeadingZh,
+  runPageTitleZh,
+  runPageKeywordsZh,
+} from '@/lib/run-pages-zh';
+import { getRunPageData, type RunPageData } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+}
+
+function primaryRead(data: RunPageData) {
+  return data.tierLadder.find((read) => read.tier === data.primaryTier);
+}
+
+function statLedDescriptionZh(entry: RunPageEntry, data: RunPageData): string {
+  const read = primaryRead(data);
+  if (!data.hasData || !read?.throughputPerGpu) return runPageDescriptionZh(entry);
+  const cost =
+    read.costPerMtok === null
+      ? ''
+      : `，按超大规模云价格每百万 token 成本 ${fmtCostPerMtok(read.costPerMtok)}`;
+  return `实测数据：${entry.model.seoName} 在 ${entry.chip.label} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${cost}。共 ${data.configCount} 组实测配置，数据持续更新。`;
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getRunPageEntry(slug);
+  if (!entry) return {};
+  const data = await getRunPageData(entry.slug);
+  const title = runPageTitleZh(entry);
+  const description = data ? statLedDescriptionZh(entry, data) : runPageDescriptionZh(entry);
+  const url = `${SITE_URL}/zh/run/${entry.slug}`;
+  return {
+    title: { absolute: `${title} | ${SITE_NAME}` },
+    description,
+    keywords: runPageKeywordsZh(entry),
+    authors: [{ name: AUTHOR_NAME }],
+    alternates: zhAlternates(`/run/${entry.slug}`),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url,
+      locale: ZH_OG_LOCALE,
+      type: 'article',
+    },
+    twitter: { card: 'summary_large_image', title: `${title} | ${SITE_NAME}`, description },
+  };
+}
+
+function buildFaqZh(
+  entry: RunPageEntry,
+  data: RunPageData,
+): { question: string; answer: string }[] {
+  const questions = runPageFaqQuestionsZh(entry);
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  const read = primaryRead(data);
+  const workload = scenarioLabel(data.scenario, 'zh');
+
+  const peak =
+    data.bestThroughputPerGpu === null ? '暂无' : fmtThroughput(data.bestThroughputPerGpu);
+  const throughputAnswer =
+    typeof read?.throughputPerGpu === 'number'
+      ? `在${workload}、每用户每秒 ${data.primaryTier} token 的交互档位下，${chip} 部署 ${model} 单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${read.framework ? `，推理引擎为 ${read.framework}` : ''}${read.precision ? `，精度 ${read.precision.toUpperCase()}` : ''}。全部配置中的实测峰值吞吐为单 GPU ${peak} token/s。`
+      : `InferenceX 集群已为该组合完成 ${data.configCount} 组实测配置，各交互档位的实测结果见上方阶梯表。`;
+
+  const costAnswer =
+    typeof read?.costPerMtok === 'number'
+      ? `按超大规模云 $/GPU/小时 价格、每用户每秒 ${data.primaryTier} token 档位计算，每百万 token（输入加输出）成本为 ${fmtCostPerMtok(read.costPerMtok)}。新兴云与零售租用价格见上方表格；更慢的交互档位成本更低。`
+      : `每百万 token 成本由实测吞吐和 SemiAnalysis AI Cloud TCO 模型的 $/GPU/小时 价格换算得出，待该组合达到主交互档位后即会显示。`;
+
+  const servingAnswer = `本页数据来自 ${data.frameworks.join('、')}，精度覆盖 ${data.precisions.map((p) => p.toUpperCase()).join('、')}${data.hasDisagg ? '，包含 prefill 分离部署' : ''}${data.hasMultinode ? '，并包含多节点部署' : ''}。推理引擎持续重新构建并重跑基准，最优配置可能随时变化。`;
+
+  const methodologyAnswer = `所有数字均由 InferenceX 集群在真实 ${chip} 硬件上实测，通过在${workload}下扫描并发数绘制吞吐与交互速度前沿曲线${data.newest ? `；最新一次运行落在 ${data.newest}` : ''}。推导方式与 InferenceX 总览排行榜完全一致。`;
+
+  return [
+    { question: questions.throughput, answer: throughputAnswer },
+    { question: questions.cost, answer: costAnswer },
+    { question: questions.serving, answer: servingAnswer },
+    { question: questions.methodology, answer: methodologyAnswer },
+  ];
+}
+
+export default async function ZhRunPage({ params }: Props) {
+  const { slug } = await params;
+  const entry = getRunPageEntry(slug);
+  if (!entry) notFound();
+  const data = await getRunPageData(entry.slug);
+  if (!data) notFound();
+
+  const url = `${SITE_URL}/zh/run/${entry.slug}`;
+  const heading = runPageHeadingZh(entry);
+  const faq = data.hasData ? buildFaqZh(entry, data) : [];
+  const read = primaryRead(data);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        name: runPageTitleZh(entry),
+        url,
+        inLanguage: ZH_LANG_TAG,
+        ...(data.newest && { dateModified: data.newest }),
+        ...(data.oldest && { datePublished: data.oldest }),
+      },
+      ...(faq.length > 0
+        ? [
+            {
+              '@type': 'FAQPage',
+              inLanguage: ZH_LANG_TAG,
+              mainEntity: faq.map((item) => ({
+                '@type': 'Question',
+                name: item.question,
+                acceptedAnswer: { '@type': 'Answer', text: item.answer },
+              })),
+            },
+          ]
+        : []),
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: '模型与 GPU 组合', item: `${SITE_URL}/zh/run` },
+          { '@type': 'ListItem', position: 2, name: heading, item: url },
+        ],
+      },
+    ],
+  };
+
+  const quickAnswerCost =
+    typeof read?.costPerMtok === 'number'
+      ? `，按超大规模云价格折合每百万 token ${fmtCostPerMtok(read.costPerMtok)}`
+      : '';
+  const quickAnswer =
+    typeof read?.throughputPerGpu === 'number'
+      ? `${entry.model.seoName} 在 ${entry.chip.label} 上、每用户每秒 ${data.primaryTier} token 档位下单 GPU 可持续输出 ${fmtThroughput(read.throughputPerGpu)} token/s${quickAnswerCost}${read.framework ? `，推理引擎为 ${read.framework}` : ''}。`
+      : `${entry.model.seoName} 可在 ${entry.chip.label} 上运行：目前已有 ${data.configCount} 组实测配置，各档位实测结果见下方阶梯表。`;
+
+  const t: RunStrings = {
+    backHref: '/zh/run',
+    backLabel: '全部模型与 GPU 组合',
+    heading,
+    quickAnswerLabel: '快速结论',
+    quickAnswer,
+    statConfigs: '实测配置数',
+    statEngines: '推理引擎',
+    statPrecisions: '精度',
+    statFreshness: '运行日期',
+    ladderHeading: '各交互档位下的吞吐表现',
+    ladderIntro: `推理部署是一种权衡：单 GPU 上并发用户越多，每个用户收到 token 的速度就越慢。下表在${scenarioLabel(data.scenario, 'zh')}下按每个单用户速度目标读取实测前沿，取该工作点上最优的引擎与精度。`,
+    colTier: '单用户速度目标',
+    colThroughput: '单 GPU 每秒 token 数',
+    colCost: '每百万 token 成本',
+    colEngine: '推理引擎',
+    colPrecision: '精度',
+    costHeading: '实际部署成本',
+    costIntro: `将每用户每秒 ${data.primaryTier} token 工作点的实测吞吐，按 SemiAnalysis AI Cloud TCO 模型的各档租用价格换算为每百万 token（输入加输出）成本。`,
+    colPriceTier: '价格档位',
+    colGpuHour: '$/GPU/小时',
+    colCostPerMtok: '每百万 token 成本',
+    priceTierLabels: {
+      hyperscaler: '超大规模云',
+      neocloud: '新兴云',
+      retail: '零售租用',
+    },
+    emptyState: `InferenceX 集群尚未发布 ${entry.model.seoName} 在 ${entry.chip.label} 上的基准测试结果。基准测试持续运行，新结果落地后本页会自动填充。`,
+    faqHeading: '常见问题',
+    faq,
+    exploreHeading: '继续探索数据',
+    exploreLinks: [
+      {
+        href: `/zh/rankings/fastest-gpu-for-${entry.model.slug}`,
+        label: `${entry.model.seoName} 推理最快 GPU 完整排行`,
+      },
+      {
+        href: `/zh/rankings/cheapest-gpu-for-${entry.model.slug}`,
+        label: `运行 ${entry.model.seoName} 最省钱 GPU 完整排行`,
+      },
+      { href: `/zh/chips/${entry.chip.slug}`, label: `${entry.chip.title} 规格与价格` },
+      { href: '/zh/inference', label: '交互式推理仪表盘' },
+    ],
+  };
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <RunDetailContent entry={entry} data={data} t={t} />
+    </>
+  );
+}

--- a/packages/app/src/app/zh/run/page.tsx
+++ b/packages/app/src/app/zh/run/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+
+import { JsonLd } from '@/components/json-ld';
+import { Card } from '@/components/ui/card';
+import { ZH_LANG_TAG, ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import type { RunPageEntry } from '@/lib/run-pages';
+import { runPageHeadingZh } from '@/lib/run-pages-zh';
+import { getAvailableRunEntries } from '@/lib/run-rankings-data.server';
+
+export const dynamic = 'force-dynamic';
+
+const title = '任意模型在任意 GPU 上的实测结果';
+const description =
+  'InferenceX 集群实测的每一组开源大模型与 GPU 组合的吞吐、延迟与成本数据：DeepSeek、Kimi、GLM、MiniMax、Qwen 运行在 H100、H200、B200、GB200 NVL72、MI300X、MI325X、MI355X 等硬件上。';
+
+export function generateMetadata(): Metadata {
+  return {
+    title: { absolute: `${title} | ${SITE_NAME}` },
+    description,
+    keywords: [
+      'LLM GPU 基准测试',
+      '大模型 GPU 吞吐量',
+      '模型 GPU 推理性能',
+      'DeepSeek GPU 基准测试',
+      'Kimi GPU 基准测试',
+      'LLM 推理成本',
+      'H100 大模型基准测试',
+      'MI355X 大模型基准测试',
+    ],
+    alternates: zhAlternates('/run'),
+    openGraph: {
+      title: `${title} | ${SITE_NAME}`,
+      description,
+      url: `${SITE_URL}/zh/run`,
+      locale: ZH_OG_LOCALE,
+      type: 'website',
+    },
+    twitter: { card: 'summary_large_image', title, description },
+  };
+}
+
+export default async function ZhRunIndexPage() {
+  const entries = await getAvailableRunEntries();
+  const byModel = new Map<string, RunPageEntry[]>();
+  for (const entry of entries) {
+    const list = byModel.get(entry.model.slug) ?? [];
+    list.push(entry);
+    byModel.set(entry.model.slug, list);
+  }
+  const models = INFERENCE_MODEL_SLUGS.filter((model) => byModel.has(model.slug));
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: title,
+    description,
+    url: `${SITE_URL}/zh/run`,
+    inLanguage: ZH_LANG_TAG,
+    hasPart: entries.map((entry) => ({
+      '@type': 'WebPage',
+      name: runPageHeadingZh(entry),
+      url: `${SITE_URL}/zh/run/${entry.slug}`,
+    })),
+  };
+
+  return (
+    <main className="relative">
+      <JsonLd data={jsonLd} />
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <h1 className="max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {title}
+            </h1>
+            <p className="mt-4 max-w-3xl text-lg leading-relaxed text-muted-foreground">
+              选一个模型和一款 GPU：下面每个页面都会回答它能跑多快、每百万 token
+              成本多少、以及数字出自哪个推理引擎，数据来自真实硬件上持续重跑的基准测试。
+            </p>
+          </header>
+
+          <section className="mt-10 mb-16 space-y-8">
+            {models.map((model) => (
+              <Card key={model.slug} className="p-5">
+                <h2 className="text-lg font-semibold tracking-tight">{model.seoName}</h2>
+                <ul className="mt-3 grid gap-1 sm:grid-cols-2">
+                  {(byModel.get(model.slug) ?? []).map((entry) => (
+                    <li key={entry.slug}>
+                      <Link
+                        href={`/zh/run/${entry.slug}`}
+                        className="text-sm font-medium text-brand hover:underline"
+                      >
+                        {model.seoName} 运行在 {entry.chip.label}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ))}
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/app/zh/run/page.tsx
+++ b/packages/app/src/app/zh/run/page.tsx
@@ -87,16 +87,19 @@ export default async function ZhRunIndexPage() {
               <Card key={model.slug} className="p-5">
                 <h2 className="text-lg font-semibold tracking-tight">{model.seoName}</h2>
                 <ul className="mt-3 grid gap-1 sm:grid-cols-2">
-                  {(byModel.get(model.slug) ?? []).map((entry) => (
-                    <li key={entry.slug}>
-                      <Link
-                        href={`/zh/run/${entry.slug}`}
-                        className="text-sm font-medium text-brand hover:underline"
-                      >
-                        {model.seoName} 运行在 {entry.chip.label}
-                      </Link>
-                    </li>
-                  ))}
+                  {(byModel.get(model.slug) ?? []).map((entry) => {
+                    const chipLabel = entry.chip.label;
+                    return (
+                      <li key={entry.slug}>
+                        <Link
+                          href={`/zh/run/${entry.slug}`}
+                          className="text-sm font-medium text-brand hover:underline"
+                        >
+                          {model.seoName} 运行在 {chipLabel}
+                        </Link>
+                      </li>
+                    );
+                  })}
                 </ul>
               </Card>
             ))}

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -36,6 +36,8 @@ const STRINGS = {
     modelArchitectures: 'Model Architectures',
     glossary: 'AI Inference Glossary',
     chipSpecs: 'Chip Specs & Pricing',
+    rankings: 'GPU Rankings',
+    runPages: 'Model on GPU Results',
     languageLink: '中文版',
     languageHref: '/zh',
     languageHrefLang: 'zh-CN',
@@ -68,6 +70,8 @@ const STRINGS = {
     modelArchitectures: '模型架构',
     glossary: 'AI 推理术语表',
     chipSpecs: '芯片规格与价格',
+    rankings: 'GPU 排行榜',
+    runPages: '模型在 GPU 上的实测结果',
     languageLink: 'English',
     languageHref: '/',
     languageHrefLang: 'en',
@@ -280,6 +284,20 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 className="text-sm text-muted-foreground hover:text-foreground transition-colors"
               >
                 {t.chipSpecs}
+              </Link>
+              <Link
+                data-testid="footer-link-rankings"
+                href={`${prefix}/rankings`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.rankings}
+              </Link>
+              <Link
+                data-testid="footer-link-run"
+                href={`${prefix}/run`}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {t.runPages}
               </Link>
               <Link
                 data-testid="footer-link-zh"

--- a/packages/app/src/components/live-seo/format.ts
+++ b/packages/app/src/components/live-seo/format.ts
@@ -1,0 +1,30 @@
+/**
+ * Number formatting shared by the /rankings and /run server-rendered pages.
+ * Locale-independent by design: both the English and Chinese pages quote
+ * half-width digits with the same precision, per docs/chinese-copy.md.
+ */
+
+/** Tokens/s per GPU: whole numbers above 100, one decimal below. */
+export function fmtThroughput(value: number): string {
+  return value >= 100 ? Math.round(value).toLocaleString('en-US') : value.toFixed(1);
+}
+
+/** $ per million tokens: cents precision, sub-cent gets a third digit. */
+export function fmtCostPerMtok(value: number): string {
+  return `$${value >= 0.1 ? value.toFixed(2) : value.toFixed(3)}`;
+}
+
+/** $/GPU/hr price points from HW_REGISTRY. */
+export function fmtGpuHour(value: number): string {
+  return `$${value.toFixed(2)}`;
+}
+
+/** Percentage delta between a winner and a runner-up, e.g. 23. */
+export function pctFaster(winner: number, runnerUp: number): number {
+  return Math.round((winner / runnerUp - 1) * 100);
+}
+
+/** Milliseconds with sensible precision for TTFT/TPOT quotes. */
+export function fmtMs(value: number): string {
+  return value >= 100 ? `${Math.round(value)} ms` : `${value.toFixed(1)} ms`;
+}

--- a/packages/app/src/components/live-seo/format.ts
+++ b/packages/app/src/components/live-seo/format.ts
@@ -24,6 +24,11 @@ export function pctFaster(winner: number, runnerUp: number): number {
   return Math.round((winner / runnerUp - 1) * 100);
 }
 
+/** Percent below the runner-up: a $1 winner against a $2 runner-up is 50. */
+export function pctCheaper(winner: number, runnerUp: number): number {
+  return Math.round((1 - winner / runnerUp) * 100);
+}
+
 /** Milliseconds with sensible precision for TTFT/TPOT quotes. */
 export function fmtMs(value: number): string {
   return value >= 100 ? `${Math.round(value)} ms` : `${value.toFixed(1)} ms`;

--- a/packages/app/src/components/live-seo/rankings-page-sections.tsx
+++ b/packages/app/src/components/live-seo/rankings-page-sections.tsx
@@ -7,7 +7,7 @@
 
 import Link from 'next/link';
 
-import { fmtCostPerMtok, fmtThroughput, pctFaster } from '@/components/live-seo/format';
+import { fmtCostPerMtok, fmtThroughput, pctCheaper, pctFaster } from '@/components/live-seo/format';
 import type { RankingPageData } from '@/lib/run-rankings-data.server';
 import type { RankingPageEntry, RankingRow } from '@/lib/rankings';
 import { getRunPageEntry } from '@/lib/run-pages';
@@ -44,7 +44,7 @@ function leadSentence(rows: RankingRow[], entry: RankingPageEntry, zh: boolean):
     return zh ? leadZh : lead;
   }
   if (entry.kind === 'cheapest-gpu' && first.costPerMtok && second.costPerMtok) {
-    const pct = pctFaster(second.costPerMtok, first.costPerMtok);
+    const pct = pctCheaper(first.costPerMtok, second.costPerMtok);
     const lead = `${first.hardwareLabel} is the cheapest at ${fmtCostPerMtok(first.costPerMtok)} per million tokens, ${pct}% below ${second.hardwareLabel}.`;
     const leadZh = `${first.hardwareLabel} 成本最低，每百万 token 仅 ${fmtCostPerMtok(first.costPerMtok)}，比第二名 ${second.hardwareLabel} 低 ${pct}%。`;
     return zh ? leadZh : lead;

--- a/packages/app/src/components/live-seo/rankings-page-sections.tsx
+++ b/packages/app/src/components/live-seo/rankings-page-sections.tsx
@@ -1,0 +1,237 @@
+/**
+ * Shared server-rendered body for `/rankings/<slug>` and `/zh/rankings/<slug>`.
+ * One markup tree, two string bundles — the EN and ZH routes cannot drift.
+ * All numbers come pre-derived from `getRankingPageData`, which reads the
+ * exact cells the /overview leaderboard renders.
+ */
+
+import Link from 'next/link';
+
+import { fmtCostPerMtok, fmtThroughput, pctFaster } from '@/components/live-seo/format';
+import type { RankingPageData } from '@/lib/run-rankings-data.server';
+import type { RankingPageEntry, RankingRow } from '@/lib/rankings';
+import { getRunPageEntry } from '@/lib/run-pages';
+
+export interface RankingsStrings {
+  backLabel: string;
+  heading: string;
+  scenarioNote: string;
+  tableCaption: string;
+  colRank: string;
+  colGpu: string;
+  colThroughput: string;
+  colCost: string;
+  colPrecision: string;
+  colEngine: string;
+  emptyState: string;
+  siblingLead: string;
+  siblingLabel: string;
+  methodologyHeading: string;
+  methodologyBody: string[];
+  faqHeading: string;
+  faq: { question: string; answer: string }[];
+  exploreHeading: string;
+  exploreLinks: { href: string; label: string }[];
+}
+
+function leadSentence(rows: RankingRow[], entry: RankingPageEntry, zh: boolean): string {
+  if (rows.length < 2) return '';
+  const [first, second] = rows;
+  if (entry.kind === 'fastest-gpu' && first.throughputPerGpu && second.throughputPerGpu) {
+    const pct = pctFaster(first.throughputPerGpu, second.throughputPerGpu);
+    const lead = `${first.hardwareLabel} leads at ${fmtThroughput(first.throughputPerGpu)} tokens/s per GPU, ${pct}% ahead of ${second.hardwareLabel}.`;
+    const leadZh = `${first.hardwareLabel} 以单 GPU 每秒 ${fmtThroughput(first.throughputPerGpu)} token 领先，比第二名 ${second.hardwareLabel} 高 ${pct}%。`;
+    return zh ? leadZh : lead;
+  }
+  if (entry.kind === 'cheapest-gpu' && first.costPerMtok && second.costPerMtok) {
+    const pct = pctFaster(second.costPerMtok, first.costPerMtok);
+    const lead = `${first.hardwareLabel} is the cheapest at ${fmtCostPerMtok(first.costPerMtok)} per million tokens, ${pct}% below ${second.hardwareLabel}.`;
+    const leadZh = `${first.hardwareLabel} 成本最低，每百万 token 仅 ${fmtCostPerMtok(first.costPerMtok)}，比第二名 ${second.hardwareLabel} 低 ${pct}%。`;
+    return zh ? leadZh : lead;
+  }
+  return '';
+}
+
+export function rankingsLeadSentence(
+  rows: RankingRow[],
+  entry: RankingPageEntry,
+  locale: 'en' | 'zh',
+): string {
+  return leadSentence(rows, entry, locale === 'zh');
+}
+
+export function RankingsDetailContent({
+  entry,
+  data,
+  t,
+  locale,
+}: {
+  entry: RankingPageEntry;
+  data: RankingPageData;
+  t: RankingsStrings;
+  locale: 'en' | 'zh';
+}) {
+  const prefix = locale === 'zh' ? '/zh' : '';
+  const lead = rankingsLeadSentence(data.rows, entry, locale);
+
+  return (
+    <main className="relative">
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <Link
+              href={`${prefix}/rankings`}
+              className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+            >
+              <span
+                aria-hidden="true"
+                className="transition-transform group-hover:-translate-x-0.5"
+              >
+                ←
+              </span>
+              {t.backLabel}
+            </Link>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-brand/25 bg-brand/8 px-3 py-1 text-xs font-semibold tracking-[0.14em] text-brand uppercase">
+                {entry.model.label}
+              </span>
+            </div>
+            <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {t.heading}
+            </h1>
+            {lead && <p className="mt-4 max-w-3xl text-lg leading-relaxed">{lead}</p>}
+            <p className="mt-3 max-w-3xl text-sm text-muted-foreground">{t.scenarioNote}</p>
+          </header>
+
+          <section className="mt-10">
+            {data.rows.length === 0 ? (
+              <p className="rounded-xl border border-border/50 p-6 leading-7 text-muted-foreground">
+                {t.emptyState}
+              </p>
+            ) : (
+              <div className="overflow-x-auto rounded-xl border border-border/50">
+                <table className="w-full min-w-[40rem] text-sm">
+                  <caption className="sr-only">{t.tableCaption}</caption>
+                  <thead>
+                    <tr className="border-b border-border/50 text-left text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                      <th scope="col" className="px-4 py-3">
+                        {t.colRank}
+                      </th>
+                      <th scope="col" className="px-4 py-3">
+                        {t.colGpu}
+                      </th>
+                      <th scope="col" className="px-4 py-3">
+                        {t.colThroughput}
+                      </th>
+                      <th scope="col" className="px-4 py-3">
+                        {t.colCost}
+                      </th>
+                      <th scope="col" className="px-4 py-3">
+                        {t.colPrecision}
+                      </th>
+                      <th scope="col" className="px-4 py-3">
+                        {t.colEngine}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.rows.map((row) => {
+                      const runEntry = row.chip
+                        ? getRunPageEntry(`${entry.model.slug}-on-${row.chip.slug}`)
+                        : undefined;
+                      return (
+                        <tr
+                          key={row.hardware}
+                          className="border-b border-border/30 last:border-b-0"
+                        >
+                          <td className="px-4 py-3 font-mono">{row.rank}</td>
+                          <td className="px-4 py-3 font-medium">
+                            {runEntry ? (
+                              <Link
+                                href={`${prefix}/run/${runEntry.slug}`}
+                                className="text-brand hover:underline"
+                              >
+                                {row.hardwareLabel}
+                              </Link>
+                            ) : (
+                              row.hardwareLabel
+                            )}
+                          </td>
+                          <td className="px-4 py-3 font-mono">
+                            {row.throughputPerGpu === null
+                              ? '-'
+                              : fmtThroughput(row.throughputPerGpu)}
+                          </td>
+                          <td className="px-4 py-3 font-mono">
+                            {row.costPerMtok === null ? '-' : fmtCostPerMtok(row.costPerMtok)}
+                          </td>
+                          <td className="px-4 py-3 uppercase">{row.precision ?? '-'}</td>
+                          <td className="px-4 py-3">{row.framework ?? '-'}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            <p className="mt-4 text-sm text-muted-foreground">
+              {t.siblingLead}{' '}
+              <Link
+                href={`${prefix}/rankings/${entry.kind === 'fastest-gpu' ? 'cheapest-gpu' : 'fastest-gpu'}-for-${entry.model.slug}`}
+                className="font-medium text-brand hover:underline"
+              >
+                {t.siblingLabel}
+              </Link>
+            </p>
+          </section>
+
+          <section
+            aria-labelledby="ranking-methodology"
+            className="mt-10 border-t border-border/50 pt-10"
+          >
+            <h2 id="ranking-methodology" className="text-xl font-semibold tracking-tight">
+              {t.methodologyHeading}
+            </h2>
+            {t.methodologyBody.map((paragraph) => (
+              <p key={paragraph.slice(0, 32)} className="mt-3 leading-7 text-muted-foreground">
+                {paragraph}
+              </p>
+            ))}
+          </section>
+
+          <section aria-labelledby="ranking-faq" className="mt-10 border-t border-border/50 pt-10">
+            <h2 id="ranking-faq" className="text-xl font-semibold tracking-tight">
+              {t.faqHeading}
+            </h2>
+            <dl className="mt-4 space-y-6">
+              {t.faq.map((item) => (
+                <div key={item.question}>
+                  <dt className="font-medium">{item.question}</dt>
+                  <dd className="mt-2 leading-7 text-muted-foreground">{item.answer}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section
+            aria-labelledby="ranking-explore"
+            className="mt-10 mb-16 rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+          >
+            <h2 id="ranking-explore" className="text-xl font-semibold tracking-tight">
+              {t.exploreHeading}
+            </h2>
+            <ul className="mt-3 space-y-1">
+              {t.exploreLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-sm font-medium text-brand hover:underline">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </article>
+      </div>
+    </main>
+  );
+}

--- a/packages/app/src/components/live-seo/run-page-sections.tsx
+++ b/packages/app/src/components/live-seo/run-page-sections.tsx
@@ -1,0 +1,279 @@
+/**
+ * Shared server-rendered body for `/run/<pair>` and `/zh/run/<pair>`.
+ * One markup tree, two string bundles — the EN and ZH routes cannot drift.
+ * All numbers come pre-derived from `getRunPageData`, which reads through the
+ * same cached benchmark query the dashboard renders.
+ */
+
+import Link from 'next/link';
+
+import { fmtCostPerMtok, fmtGpuHour, fmtMs, fmtThroughput } from '@/components/live-seo/format';
+import { getChipHw } from '@/lib/chip-pages';
+import type { RunPageData } from '@/lib/run-rankings-data.server';
+import type { RunPageEntry } from '@/lib/run-pages';
+
+export interface RunStrings {
+  backHref: string;
+  backLabel: string;
+  heading: string;
+  quickAnswerLabel: string;
+  quickAnswer: string;
+  statConfigs: string;
+  statEngines: string;
+  statPrecisions: string;
+  statFreshness: string;
+  ladderHeading: string;
+  ladderIntro: string;
+  colTier: string;
+  colThroughput: string;
+  colCost: string;
+  colEngine: string;
+  colPrecision: string;
+  costHeading: string;
+  costIntro: string;
+  colPriceTier: string;
+  colGpuHour: string;
+  colCostPerMtok: string;
+  priceTierLabels: Record<'hyperscaler' | 'neocloud' | 'retail', string>;
+  emptyState: string;
+  faqHeading: string;
+  faq: { question: string; answer: string }[];
+  exploreHeading: string;
+  exploreLinks: { href: string; label: string }[];
+}
+
+export function RunDetailContent({
+  entry,
+  data,
+  t,
+}: {
+  entry: RunPageEntry;
+  data: RunPageData;
+  t: RunStrings;
+}) {
+  return (
+    <main className="relative">
+      <div className="container mx-auto px-4 lg:px-8">
+        <article className="mx-auto max-w-5xl">
+          <header className="pt-8 md:pt-12">
+            <Link
+              href={t.backHref}
+              className="group inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-brand"
+            >
+              <span
+                aria-hidden="true"
+                className="transition-transform group-hover:-translate-x-0.5"
+              >
+                ←
+              </span>
+              {t.backLabel}
+            </Link>
+            <div className="mt-6 flex flex-wrap items-center gap-2">
+              <span className="rounded-full border border-brand/25 bg-brand/8 px-3 py-1 text-xs font-semibold tracking-[0.14em] text-brand uppercase">
+                {entry.model.label}
+              </span>
+              <span className="font-mono text-xs tracking-[0.16em] text-muted-foreground uppercase">
+                {getChipHw(entry.chip).vendor} {getChipHw(entry.chip).arch}
+              </span>
+            </div>
+            <h1 className="mt-4 max-w-4xl text-4xl font-bold tracking-[-0.035em] text-balance md:text-5xl">
+              {t.heading}
+            </h1>
+          </header>
+
+          {data.hasData ? (
+            <>
+              <section
+                aria-labelledby="run-quick-answer"
+                className="mt-8 rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+              >
+                <p
+                  id="run-quick-answer"
+                  className="font-mono text-xs font-semibold tracking-[0.18em] text-brand uppercase"
+                >
+                  {t.quickAnswerLabel}
+                </p>
+                <p className="mt-3 text-lg leading-relaxed font-medium text-pretty md:text-xl">
+                  {t.quickAnswer}
+                </p>
+              </section>
+
+              <section
+                aria-label={t.statConfigs}
+                className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4"
+              >
+                <div className="rounded-xl border border-border/50 p-4">
+                  <p className="text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                    {t.statConfigs}
+                  </p>
+                  <p className="mt-1 font-mono text-2xl font-semibold">{data.configCount}</p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-4">
+                  <p className="text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                    {t.statEngines}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 font-medium">{data.frameworks.join(', ')}</p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-4">
+                  <p className="text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                    {t.statPrecisions}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 font-medium uppercase">
+                    {data.precisions.join(', ')}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-border/50 p-4">
+                  <p className="text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                    {t.statFreshness}
+                  </p>
+                  <p className="mt-1 font-mono text-sm leading-6 font-medium">
+                    {data.oldest} → {data.newest}
+                  </p>
+                </div>
+              </section>
+
+              <section
+                aria-labelledby="run-ladder"
+                className="mt-10 border-t border-border/50 pt-10"
+              >
+                <h2 id="run-ladder" className="text-xl font-semibold tracking-tight">
+                  {t.ladderHeading}
+                </h2>
+                <p className="mt-3 leading-7 text-muted-foreground">{t.ladderIntro}</p>
+                <div className="mt-4 overflow-x-auto rounded-xl border border-border/50">
+                  <table className="w-full min-w-[36rem] text-sm">
+                    <thead>
+                      <tr className="border-b border-border/50 text-left text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                        <th scope="col" className="px-4 py-3">
+                          {t.colTier}
+                        </th>
+                        <th scope="col" className="px-4 py-3">
+                          {t.colThroughput}
+                        </th>
+                        <th scope="col" className="px-4 py-3">
+                          {t.colCost}
+                        </th>
+                        <th scope="col" className="px-4 py-3">
+                          {t.colEngine}
+                        </th>
+                        <th scope="col" className="px-4 py-3">
+                          {t.colPrecision}
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.tierLadder.map((read) => (
+                        <tr key={read.tier} className="border-b border-border/30 last:border-b-0">
+                          <td className="px-4 py-3 font-mono">{read.tier} tok/s</td>
+                          <td className="px-4 py-3 font-mono">
+                            {read.throughputPerGpu === null
+                              ? '-'
+                              : fmtThroughput(read.throughputPerGpu)}
+                          </td>
+                          <td className="px-4 py-3 font-mono">
+                            {read.costPerMtok === null ? '-' : fmtCostPerMtok(read.costPerMtok)}
+                          </td>
+                          <td className="px-4 py-3">{read.framework ?? '-'}</td>
+                          <td className="px-4 py-3 uppercase">{read.precision ?? '-'}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+
+              {data.costTiers.length > 0 && (
+                <section
+                  aria-labelledby="run-cost"
+                  className="mt-10 border-t border-border/50 pt-10"
+                >
+                  <h2 id="run-cost" className="text-xl font-semibold tracking-tight">
+                    {t.costHeading}
+                  </h2>
+                  <p className="mt-3 leading-7 text-muted-foreground">{t.costIntro}</p>
+                  <div className="mt-4 overflow-x-auto rounded-xl border border-border/50">
+                    <table className="w-full min-w-[28rem] text-sm">
+                      <thead>
+                        <tr className="border-b border-border/50 text-left text-xs tracking-[0.1em] text-muted-foreground uppercase">
+                          <th scope="col" className="px-4 py-3">
+                            {t.colPriceTier}
+                          </th>
+                          <th scope="col" className="px-4 py-3">
+                            {t.colGpuHour}
+                          </th>
+                          <th scope="col" className="px-4 py-3">
+                            {t.colCostPerMtok}
+                          </th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {data.costTiers.map((tier) => (
+                          <tr
+                            key={tier.tierLabel}
+                            className="border-b border-border/30 last:border-b-0"
+                          >
+                            <td className="px-4 py-3 font-medium">
+                              {t.priceTierLabels[tier.tierLabel]}
+                            </td>
+                            <td className="px-4 py-3 font-mono">
+                              {fmtGpuHour(tier.costPerGpuHour)}
+                            </td>
+                            <td className="px-4 py-3 font-mono">
+                              {fmtCostPerMtok(tier.costPerMtok)}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+              )}
+
+              <section aria-labelledby="run-faq" className="mt-10 border-t border-border/50 pt-10">
+                <h2 id="run-faq" className="text-xl font-semibold tracking-tight">
+                  {t.faqHeading}
+                </h2>
+                <dl className="mt-4 space-y-6">
+                  {t.faq.map((item) => (
+                    <div key={item.question}>
+                      <dt className="font-medium">{item.question}</dt>
+                      <dd className="mt-2 leading-7 text-muted-foreground">{item.answer}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </section>
+            </>
+          ) : (
+            <p className="mt-10 mb-16 rounded-xl border border-border/50 p-6 leading-7 text-muted-foreground">
+              {t.emptyState}
+            </p>
+          )}
+
+          <section
+            aria-labelledby="run-explore"
+            className="mt-10 mb-16 rounded-xl border border-brand/20 bg-brand/6 p-5 md:p-6"
+          >
+            <h2 id="run-explore" className="text-xl font-semibold tracking-tight">
+              {t.exploreHeading}
+            </h2>
+            <ul className="mt-3 space-y-1">
+              {t.exploreLinks.map((link) => (
+                <li key={link.href}>
+                  <Link href={link.href} className="text-sm font-medium text-brand hover:underline">
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </article>
+      </div>
+    </main>
+  );
+}
+
+/** TTFT/TPOT quote line used by both locales' quick answers when present. */
+export function latencyQuote(data: RunPageData): string | null {
+  if (data.bestMedianTtft === null || data.bestMedianTpot === null) return null;
+  return `${fmtMs(data.bestMedianTtft)} TTFT / ${fmtMs(data.bestMedianTpot)} TPOT`;
+}

--- a/packages/app/src/components/live-seo/run-page-sections.tsx
+++ b/packages/app/src/components/live-seo/run-page-sections.tsx
@@ -272,8 +272,13 @@ export function RunDetailContent({
   );
 }
 
-/** TTFT/TPOT quote line used by both locales' quick answers when present. */
-export function latencyQuote(data: RunPageData): string | null {
+/**
+ * Formatted best-of-config TTFT and TPOT for the quick answers. Returned as
+ * separate values because each is minimized independently across configs:
+ * the two bests can come from different runs, so composing them as a single
+ * measured pair would misstate the data.
+ */
+export function latencyQuote(data: RunPageData): { ttft: string; tpot: string } | null {
   if (data.bestMedianTtft === null || data.bestMedianTpot === null) return null;
-  return `${fmtMs(data.bestMedianTtft)} TTFT / ${fmtMs(data.bestMedianTpot)} TPOT`;
+  return { ttft: fmtMs(data.bestMedianTtft), tpot: fmtMs(data.bestMedianTpot) };
 }

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -668,7 +668,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    sourceSha256: 'f54940c63a16d1c97a491b901aebcf9cb8893023eefef9f80ddace8936cabba8',
+    sourceSha256: 'd31d0d0601b077836562dc032cc81b47ca66f1497a2c2ee98e2f90f73dcb1e25',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -58,6 +58,8 @@ export const ZH_MIRRORED_ROUTES: readonly { path: string; exact?: boolean }[] = 
   { path: '/glossary' },
   { path: '/chips' },
   { path: '/agentx' },
+  { path: '/rankings' },
+  { path: '/run' },
 ];
 
 export function hasZhSibling(enPathname: string): boolean {

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -364,6 +364,24 @@ export function overviewScenariosForModel(
       OVERVIEW_SCENARIOS.filter((scenario) => curated.includes(scenario));
 }
 
+/**
+ * The single scenario a stat-led SEO surface quotes for a model: the first
+ * curated scenario that actually has rows, then the first curated scenario.
+ * Keeps /run and /rankings from headlining a workload the overview matrix
+ * does not show for the model (Kimi K3 and GLM 5.2 stay on AgentX even when
+ * single-turn rows exist).
+ */
+export function overviewHeadlineScenarioForModel(
+  model: Model,
+  rows: readonly BenchmarkRow[] = [],
+): OverviewScenario {
+  const scenarios = overviewScenariosForModel(model, rows);
+  return (
+    scenarios.find((scenario) => rows.some((row) => overviewScenarioOfRow(row) === scenario)) ??
+    scenarios[0]
+  );
+}
+
 function overviewEngineRows(
   rows: readonly BenchmarkRow[],
   engineScope: OverviewEngineScope,
@@ -792,6 +810,30 @@ export function buildOverviewModelSummary(
     category: getModelCategory(model),
     scenario,
     platforms: buildPlatformResults(model, scenario, scenarioRows, tier, referenceHardware),
+  };
+}
+
+/**
+ * Tier reads for one hardware SKU without the OVERVIEW_HARDWARE restriction.
+ * Same config building and read selection as the overview matrix, so a /run
+ * page for H100-class hardware quotes the number the overview would show if
+ * its matrix listed that SKU.
+ */
+export function overviewHardwareTierReader(
+  model: Model,
+  rows: BenchmarkRow[],
+  scenario: OverviewScenario = overviewScenarioForModel(model, rows),
+  engineScope: OverviewEngineScope = 'community',
+): (
+  hardware: string,
+  tier: OverviewTier,
+) => { read: OverviewTierRead; costPerMtok: number | null } {
+  const scopedRows = overviewEngineRows(rows, engineScope);
+  const scenarioRows = overviewScenarioRows(scenario, scopedRows);
+  const configs = buildConfigs(model, scenario, scenarioRows);
+  return (hardware, tier) => {
+    const read = selectPlatformRead(configs, hardware, tier);
+    return { read, costPerMtok: overviewCostPerMtok(hardware, read.value) };
   };
 }
 

--- a/packages/app/src/lib/rankings-zh.ts
+++ b/packages/app/src/lib/rankings-zh.ts
@@ -1,0 +1,55 @@
+/**
+ * @file rankings-zh.ts
+ * @description Simplified Chinese copy builders for the `/zh/rankings/<slug>`
+ * pages. Same structure as the English builders in `rankings.ts`; model
+ * names, hardware SKUs, and framework names stay in English per
+ * `docs/chinese-copy.md`.
+ */
+
+import type { RankingPageEntry } from '@/lib/rankings';
+
+export function rankingPageTitleZh(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `${entry.model.seoName} 推理最快 GPU 实时排行`
+    : `运行 ${entry.model.seoName} 最省钱的 GPU：每百万 token 成本排行`;
+}
+
+export function rankingPageHeadingZh(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `${entry.model.seoName} 最快 GPU 排行`
+    : `${entry.model.seoName} 最低成本 GPU 排行`;
+}
+
+/** Static fallback meta description; the route swaps in a stat-led one when
+ *  live numbers are available. */
+export function rankingPageDescriptionZh(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `哪款 GPU 跑 ${entry.model.seoName} 最快？基于实测单 GPU 每秒 token 数对 NVIDIA 与 AMD 硬件持续排名，数据持续更新。`
+    : `哪款 GPU 跑 ${entry.model.seoName} 最省钱？按超大规模云 GPU 价格下实测的每百万 token 成本持续排名，数据持续更新。`;
+}
+
+export function rankingPageKeywordsZh(entry: RankingPageEntry): string[] {
+  const model = entry.model.seoName;
+  if (entry.kind === 'fastest-gpu') {
+    return [
+      `${model} 最快 GPU`,
+      `${model} 最佳 GPU`,
+      `${model} GPU 基准测试`,
+      `${model} 每秒 token 数`,
+      `${model} 推理速度`,
+      `${model} GPU 排行`,
+      `${model} H100 B200 MI355X 对比`,
+      `${model} 推理硬件`,
+    ];
+  }
+  return [
+    `${model} 最便宜 GPU`,
+    `${model} 每百万 token 成本`,
+    `${model} 推理成本`,
+    `运行 ${model} 最省钱的方案`,
+    `${model} GPU 成本对比`,
+    `${model} 部署成本`,
+    `${model} token 单价`,
+    `${model} 推理定价`,
+  ];
+}

--- a/packages/app/src/lib/rankings.test.ts
+++ b/packages/app/src/lib/rankings.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RANKING_KINDS,
+  buildRankingRows,
+  chipForHardware,
+  getAllRankingPageEntries,
+  getRankingPageEntry,
+  rankingPageDescription,
+  rankingPageHeading,
+  rankingPageKeywords,
+  rankingPagePath,
+  rankingPageTitle,
+  scenarioLabel,
+} from '@/lib/rankings';
+import {
+  rankingPageDescriptionZh,
+  rankingPageHeadingZh,
+  rankingPageKeywordsZh,
+  rankingPageTitleZh,
+} from '@/lib/rankings-zh';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import type {
+  OverviewModelSummary,
+  OverviewPlatformResult,
+  OverviewTierRead,
+} from '@/lib/overview-data';
+
+const FORBIDDEN_DASHES = /[\u2013\u2014]/;
+const CJK = /[\u4E00-\u9FFF]/;
+
+function syntheticRead(value: number | null): OverviewTierRead {
+  return {
+    tier: 50,
+    value,
+    boundary: null,
+    estimated: false,
+    evidenceDate: null,
+    evidenceTopologies: [],
+    config: null,
+  };
+}
+
+function syntheticPlatform(overrides: Partial<OverviewPlatformResult>): OverviewPlatformResult {
+  return {
+    hardware: 'h100',
+    hardwareLabel: 'H100',
+    precision: 'fp8',
+    read: syntheticRead(100),
+    missingReason: null,
+    costPerMtok: 1,
+    costVsReferencePct: null,
+    historicalComparison: null,
+    ...overrides,
+  };
+}
+
+function syntheticSummary(platforms: OverviewPlatformResult[]): OverviewModelSummary {
+  return {
+    modelLabel: 'Synthetic',
+    scenario: 'single_turn_8k1k',
+    platforms,
+  } as OverviewModelSummary;
+}
+
+describe('rankings registry', () => {
+  it('has one page per (kind, model) pair', () => {
+    const entries = getAllRankingPageEntries();
+    expect(entries.length).toBe(RANKING_KINDS.length * INFERENCE_MODEL_SLUGS.length);
+    expect(entries.length).toBe(22);
+  });
+
+  it('has unique, well-formed slugs', () => {
+    const entries = getAllRankingPageEntries();
+    expect(new Set(entries.map((entry) => entry.slug)).size).toBe(entries.length);
+    for (const entry of entries) {
+      expect(entry.slug).toBe(`${entry.kind}-for-${entry.model.slug}`);
+      expect(entry.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(rankingPagePath(entry)).toBe(`/rankings/${entry.slug}`);
+      expect(entry.dbKeys.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolves slugs case-insensitively and rejects unknown slugs', () => {
+    const [first] = getAllRankingPageEntries();
+    expect(getRankingPageEntry(first.slug)).toBe(first);
+    expect(getRankingPageEntry(first.slug.toUpperCase())).toBe(first);
+    expect(getRankingPageEntry('fastest-gpu-for-nonexistent')).toBeUndefined();
+  });
+
+  it('maps hardware keys to chip pages', () => {
+    expect(chipForHardware('gb200')?.slug).toBe('gb200-nvl72');
+    expect(chipForHardware('not-a-gpu')).toBeNull();
+  });
+});
+
+describe('rankings copy', () => {
+  it('contains no em or en dashes and enough keywords in either locale', () => {
+    for (const entry of getAllRankingPageEntries()) {
+      const copy = [
+        rankingPageTitle(entry),
+        rankingPageHeading(entry),
+        rankingPageDescription(entry),
+        ...rankingPageKeywords(entry),
+        rankingPageTitleZh(entry),
+        rankingPageHeadingZh(entry),
+        rankingPageDescriptionZh(entry),
+        ...rankingPageKeywordsZh(entry),
+      ];
+      for (const text of copy) {
+        expect(text, `dash found in copy for ${entry.slug}: ${text}`).not.toMatch(FORBIDDEN_DASHES);
+        expect(text.length).toBeGreaterThan(0);
+      }
+      expect(rankingPageKeywords(entry).length).toBeGreaterThanOrEqual(6);
+      expect(rankingPageKeywordsZh(entry).length).toBeGreaterThanOrEqual(6);
+    }
+  });
+
+  it('keeps Chinese copy Chinese while model names stay English', () => {
+    for (const entry of getAllRankingPageEntries()) {
+      expect(rankingPageTitleZh(entry)).toMatch(CJK);
+      expect(rankingPageDescriptionZh(entry)).toMatch(CJK);
+      expect(rankingPageTitleZh(entry)).toContain(entry.model.seoName);
+    }
+  });
+
+  it('words every scenario in both locales without dashes', () => {
+    for (const scenario of ['single_turn_8k1k', 'agentx'] as const) {
+      for (const locale of ['en', 'zh'] as const) {
+        const label = scenarioLabel(scenario, locale);
+        expect(label.length).toBeGreaterThan(0);
+        expect(label).not.toMatch(FORBIDDEN_DASHES);
+      }
+    }
+  });
+});
+
+describe('buildRankingRows', () => {
+  const platforms = [
+    syntheticPlatform({
+      hardware: 'h100',
+      hardwareLabel: 'H100',
+      read: syntheticRead(100),
+      costPerMtok: 3,
+    }),
+    syntheticPlatform({
+      hardware: 'mi355x',
+      hardwareLabel: 'MI355X',
+      read: syntheticRead(250),
+      costPerMtok: 1,
+    }),
+    syntheticPlatform({
+      hardware: 'b200',
+      hardwareLabel: 'B200',
+      read: syntheticRead(null),
+      costPerMtok: null,
+    }),
+    syntheticPlatform({
+      hardware: 'h200',
+      hardwareLabel: 'H200',
+      read: syntheticRead(180),
+      costPerMtok: 2,
+    }),
+  ];
+
+  it('ranks fastest-gpu by descending throughput and drops unmeasured platforms', () => {
+    const rows = buildRankingRows(syntheticSummary(platforms), 'fastest-gpu');
+    expect(rows.map((row) => row.hardware)).toEqual(['mi355x', 'h200', 'h100']);
+    expect(rows.map((row) => row.rank)).toEqual([1, 2, 3]);
+    expect(rows[0].throughputPerGpu).toBe(250);
+  });
+
+  it('ranks cheapest-gpu by ascending cost and drops platforms without cost', () => {
+    const rows = buildRankingRows(syntheticSummary(platforms), 'cheapest-gpu');
+    expect(rows.map((row) => row.hardware)).toEqual(['mi355x', 'h200', 'h100']);
+    expect(rows[0].costPerMtok).toBe(1);
+    expect(rows.at(-1)?.costPerMtok).toBe(3);
+  });
+
+  it('links ranked rows to chip pages when the hardware has one', () => {
+    const rows = buildRankingRows(syntheticSummary(platforms), 'fastest-gpu');
+    expect(rows.find((row) => row.hardware === 'mi355x')?.chip?.slug).toBe('mi355x');
+  });
+});

--- a/packages/app/src/lib/rankings.ts
+++ b/packages/app/src/lib/rankings.ts
@@ -1,0 +1,199 @@
+/**
+ * @file rankings.ts
+ * @description Slug registry, ranking derivation, and copy builders for the
+ * indexable `/rankings/<slug>` pages.
+ *
+ * Two ranking kinds exist per model, matching the two questions people
+ * actually type into a search box:
+ *
+ *   - `fastest-gpu-for-<model>`  — hardware ranked by measured tokens/s per
+ *     GPU at the overview's primary interactivity tier.
+ *   - `cheapest-gpu-for-<model>` — hardware ranked by $ per million total
+ *     tokens at hyperscaler $/GPU/hr pricing, same tier.
+ *
+ * The ranking engine is NOT reimplemented here: rows come from
+ * `buildOverviewModelSummary`, the exact same derivation the /overview
+ * leaderboard renders, so a ranking page can never disagree with the
+ * dashboard. This module only sorts, filters, and words the result.
+ *
+ * Model slugs reuse `INFERENCE_MODEL_SLUGS` — the /inference, /compare, and
+ * /run vocabulary — so every ranking row can deep-link to its pair page.
+ */
+
+import { getAllChipPages, type ChipPageEntry } from '@/lib/chip-pages';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { INFERENCE_MODEL_SLUGS, type InferenceModelSlug } from '@/lib/inference-model-slug';
+import type {
+  OverviewModelSummary,
+  OverviewPlatformResult,
+  OverviewScenario,
+} from '@/lib/overview-data';
+
+export const RANKING_KINDS = ['fastest-gpu', 'cheapest-gpu'] as const;
+export type RankingKind = (typeof RANKING_KINDS)[number];
+
+export interface RankingPageEntry {
+  /** Canonical URL slug under /rankings/, e.g. 'fastest-gpu-for-kimi-k3'. */
+  slug: string;
+  kind: RankingKind;
+  /** Model registry entry — same slug vocabulary as /inference/<model>. */
+  model: InferenceModelSlug;
+  /** DB keys to fetch benchmark rows for, from the compare registry. */
+  dbKeys: string[];
+}
+
+const DB_KEYS_BY_MODEL_SLUG: ReadonlyMap<string, string[]> = new Map(
+  COMPARE_MODEL_SLUGS.map((entry) => [entry.slug, entry.dbKeys]),
+);
+
+function buildEntries(): RankingPageEntry[] {
+  const out: RankingPageEntry[] = [];
+  for (const kind of RANKING_KINDS) {
+    for (const model of INFERENCE_MODEL_SLUGS) {
+      const dbKeys = DB_KEYS_BY_MODEL_SLUG.get(model.slug);
+      if (!dbKeys) continue;
+      out.push({ slug: `${kind}-for-${model.slug}`, kind, model, dbKeys });
+    }
+  }
+  return out;
+}
+
+const ENTRIES: readonly RankingPageEntry[] = buildEntries();
+
+const ENTRY_BY_SLUG: ReadonlyMap<string, RankingPageEntry> = new Map(
+  ENTRIES.map((entry) => [entry.slug, entry]),
+);
+
+export function getAllRankingPageEntries(): readonly RankingPageEntry[] {
+  return ENTRIES;
+}
+
+export function getRankingPageEntry(slug: string): RankingPageEntry | undefined {
+  return ENTRY_BY_SLUG.get(slug.toLowerCase());
+}
+
+export function rankingPagePath(entry: RankingPageEntry): string {
+  return `/rankings/${entry.slug}`;
+}
+
+// ---------------------------------------------------------------------------
+// Ranking derivation (pure — operates on the overview summary shape)
+// ---------------------------------------------------------------------------
+
+export interface RankingRow {
+  rank: number;
+  /** HW_REGISTRY key, e.g. 'gb200'. */
+  hardware: string;
+  hardwareLabel: string;
+  /** /chips/<slug> registry entry when one exists for this hardware. */
+  chip: ChipPageEntry | null;
+  /** Measured tokens/s per GPU at the ranking tier; null when unavailable. */
+  throughputPerGpu: number | null;
+  /** $ per million total tokens at hyperscaler $/GPU/hr; null when unavailable. */
+  costPerMtok: number | null;
+  /** Precision of the winning config, e.g. 'fp4'. */
+  precision: string | null;
+  /** Framework label of the winning config, e.g. 'SGLang'. */
+  framework: string | null;
+  /** Whether the winning config runs disaggregated prefill/decode. */
+  disagg: boolean | null;
+}
+
+const CHIP_BY_HW_KEY: ReadonlyMap<string, ChipPageEntry> = new Map(
+  getAllChipPages().map((chip) => [chip.hwKey, chip]),
+);
+
+export function chipForHardware(hardware: string): ChipPageEntry | null {
+  return CHIP_BY_HW_KEY.get(hardware) ?? null;
+}
+
+function toRankingRow(platform: OverviewPlatformResult, rank: number): RankingRow {
+  return {
+    rank,
+    hardware: platform.hardware,
+    hardwareLabel: platform.hardwareLabel,
+    chip: chipForHardware(platform.hardware),
+    throughputPerGpu: platform.read.value,
+    costPerMtok: platform.costPerMtok,
+    precision: platform.read.config?.precision ?? platform.precision,
+    framework: platform.read.config?.frameworkLabel ?? null,
+    disagg: platform.read.config?.disagg ?? null,
+  };
+}
+
+/** Sort and rank the overview platforms for one ranking kind. Platforms with
+ *  no measurement for the metric are dropped rather than ranked last, so an
+ *  under-swept GPU is never presented as "slowest". */
+export function buildRankingRows(summary: OverviewModelSummary, kind: RankingKind): RankingRow[] {
+  const measurable = summary.platforms.filter((platform) =>
+    kind === 'fastest-gpu' ? platform.read.value !== null : platform.costPerMtok !== null,
+  );
+  const sorted = [...measurable].sort((a, b) => {
+    if (kind === 'fastest-gpu') return (b.read.value ?? 0) - (a.read.value ?? 0);
+    return (
+      (a.costPerMtok ?? Number.POSITIVE_INFINITY) - (b.costPerMtok ?? Number.POSITIVE_INFINITY)
+    );
+  });
+  return sorted.map((platform, index) => toRankingRow(platform, index + 1));
+}
+
+/** Human wording for the overview scenario a ranking or run page is read
+ *  from. EN and ZH variants live together so the two locales cannot drift. */
+export function scenarioLabel(scenario: OverviewScenario, locale: 'en' | 'zh'): string {
+  if (scenario === 'agentx') {
+    return locale === 'zh' ? 'AgentX 智能体编码工作负载' : 'the AgentX agentic coding workload';
+  }
+  return locale === 'zh'
+    ? '单轮对话工作负载（8k 输入 / 1k 输出）'
+    : 'a single-turn chat workload (8k input / 1k output)';
+}
+
+// ---------------------------------------------------------------------------
+// English copy
+// ---------------------------------------------------------------------------
+
+export function rankingPageTitle(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `Fastest GPU for ${entry.model.seoName} Inference: Live Rankings`
+    : `Cheapest GPU to Run ${entry.model.seoName}: $ per Million Tokens`;
+}
+
+export function rankingPageHeading(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `Fastest GPU for ${entry.model.seoName}`
+    : `Cheapest GPU for ${entry.model.seoName}`;
+}
+
+/** Static fallback meta description; the route swaps in a stat-led one when
+ *  live numbers are available. */
+export function rankingPageDescription(entry: RankingPageEntry): string {
+  return entry.kind === 'fastest-gpu'
+    ? `Which GPU serves ${entry.model.seoName} fastest? Live ranking of NVIDIA and AMD hardware by measured tokens per second per GPU, re-benchmarked continuously.`
+    : `Which GPU serves ${entry.model.seoName} cheapest? Live ranking by measured $ per million tokens at hyperscaler GPU pricing, re-benchmarked continuously.`;
+}
+
+export function rankingPageKeywords(entry: RankingPageEntry): string[] {
+  const model = entry.model.seoName;
+  if (entry.kind === 'fastest-gpu') {
+    return [
+      `fastest GPU for ${model}`,
+      `best GPU for ${model}`,
+      `${model} GPU benchmark`,
+      `${model} tokens per second`,
+      `${model} inference speed`,
+      `${model} GPU ranking`,
+      `${model} H100 B200 MI355X comparison`,
+      `${model} inference hardware`,
+    ];
+  }
+  return [
+    `cheapest GPU for ${model}`,
+    `${model} cost per million tokens`,
+    `${model} inference cost`,
+    `cheapest way to run ${model}`,
+    `${model} GPU cost comparison`,
+    `${model} serving cost`,
+    `${model} $ per token`,
+    `${model} inference pricing`,
+  ];
+}

--- a/packages/app/src/lib/run-pages-zh.ts
+++ b/packages/app/src/lib/run-pages-zh.ts
@@ -9,31 +9,34 @@
 import type { RunPageEntry } from '@/lib/run-pages';
 
 export function runPageTitleZh(entry: RunPageEntry): string {
-  return `${entry.model.seoName} 在 ${entry.chip.label} 上的实测推理吞吐与成本`;
+  const chipLabel = entry.chip.label;
+  return `${entry.model.seoName} 在 ${chipLabel} 上的实测推理吞吐与成本`;
 }
 
 export function runPageHeadingZh(entry: RunPageEntry): string {
-  return `在 ${entry.chip.label} 上运行 ${entry.model.seoName}`;
+  const chipLabel = entry.chip.label;
+  return `在 ${chipLabel} 上运行 ${entry.model.seoName}`;
 }
 
 /** Static fallback meta description; the route swaps in a stat-led one when
  *  live numbers are available. */
 export function runPageDescriptionZh(entry: RunPageEntry): string {
-  return `${entry.model.seoName} 在 ${entry.chip.title} 上的实时基准数据：单 GPU 每秒 token 数、每百万 token 成本，以及产生这些结果的推理配置。`;
+  const chipTitle = entry.chip.title;
+  return `${entry.model.seoName} 在 ${chipTitle} 上的实时基准数据：单 GPU 每秒 token 数、每百万 token 成本，以及产生这些结果的推理配置。`;
 }
 
 export function runPageKeywordsZh(entry: RunPageEntry): string[] {
   const model = entry.model.seoName;
-  const chip = entry.chip.label;
+  const chipLabel = entry.chip.label;
   return [
-    `${model} ${chip} 基准测试`,
-    `在 ${chip} 上运行 ${model}`,
-    `${model} ${chip} 吞吐量`,
-    `${model} ${chip} 每秒 token 数`,
-    `${model} ${chip} 每百万 token 成本`,
-    `${model} ${chip} 推理性能`,
+    `${model} ${chipLabel} 基准测试`,
+    `在 ${chipLabel} 上运行 ${model}`,
+    `${model} ${chipLabel} 吞吐量`,
+    `${model} ${chipLabel} 每秒 token 数`,
+    `${model} ${chipLabel} 每百万 token 成本`,
+    `${model} ${chipLabel} 推理性能`,
     `${model} 推理硬件`,
-    `${model} 部署 ${chip}`,
+    `${model} 部署 ${chipLabel}`,
   ];
 }
 
@@ -44,11 +47,11 @@ export function runPageFaqQuestionsZh(entry: RunPageEntry): {
   methodology: string;
 } {
   const model = entry.model.seoName;
-  const chip = entry.chip.label;
+  const chipLabel = entry.chip.label;
   return {
-    throughput: `${model} 在 ${chip} 上能跑多快？`,
-    cost: `在 ${chip} 上部署 ${model} 的成本是多少？`,
-    serving: `哪些推理引擎可以在 ${chip} 上运行 ${model}？`,
+    throughput: `${model} 在 ${chipLabel} 上能跑多快？`,
+    cost: `在 ${chipLabel} 上部署 ${model} 的成本是多少？`,
+    serving: `哪些推理引擎可以在 ${chipLabel} 上运行 ${model}？`,
     methodology: `这些 ${model} 数据是如何测得的？`,
   };
 }

--- a/packages/app/src/lib/run-pages-zh.ts
+++ b/packages/app/src/lib/run-pages-zh.ts
@@ -1,0 +1,54 @@
+/**
+ * @file run-pages-zh.ts
+ * @description Simplified Chinese copy builders for the `/zh/run/<pair>`
+ * pages. Same structure as the English builders in `run-pages.ts`; model
+ * names, hardware SKUs, and framework names stay in English per
+ * `docs/chinese-copy.md`.
+ */
+
+import type { RunPageEntry } from '@/lib/run-pages';
+
+export function runPageTitleZh(entry: RunPageEntry): string {
+  return `${entry.model.seoName} 在 ${entry.chip.label} 上的实测推理吞吐与成本`;
+}
+
+export function runPageHeadingZh(entry: RunPageEntry): string {
+  return `在 ${entry.chip.label} 上运行 ${entry.model.seoName}`;
+}
+
+/** Static fallback meta description; the route swaps in a stat-led one when
+ *  live numbers are available. */
+export function runPageDescriptionZh(entry: RunPageEntry): string {
+  return `${entry.model.seoName} 在 ${entry.chip.title} 上的实时基准数据：单 GPU 每秒 token 数、每百万 token 成本，以及产生这些结果的推理配置。`;
+}
+
+export function runPageKeywordsZh(entry: RunPageEntry): string[] {
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  return [
+    `${model} ${chip} 基准测试`,
+    `在 ${chip} 上运行 ${model}`,
+    `${model} ${chip} 吞吐量`,
+    `${model} ${chip} 每秒 token 数`,
+    `${model} ${chip} 每百万 token 成本`,
+    `${model} ${chip} 推理性能`,
+    `${model} 推理硬件`,
+    `${model} 部署 ${chip}`,
+  ];
+}
+
+export function runPageFaqQuestionsZh(entry: RunPageEntry): {
+  throughput: string;
+  cost: string;
+  serving: string;
+  methodology: string;
+} {
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  return {
+    throughput: `${model} 在 ${chip} 上能跑多快？`,
+    cost: `在 ${chip} 上部署 ${model} 的成本是多少？`,
+    serving: `哪些推理引擎可以在 ${chip} 上运行 ${model}？`,
+    methodology: `这些 ${model} 数据是如何测得的？`,
+  };
+}

--- a/packages/app/src/lib/run-pages.test.ts
+++ b/packages/app/src/lib/run-pages.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  fmtCostPerMtok,
+  fmtGpuHour,
+  fmtMs,
+  fmtThroughput,
+  pctFaster,
+} from '@/components/live-seo/format';
+import { getAllChipPages } from '@/lib/chip-pages';
+import { INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
+import {
+  getAllRunPageEntries,
+  getRunPageEntry,
+  runPageDescription,
+  runPageFaqQuestions,
+  runPageHeading,
+  runPageKeywords,
+  runPagePath,
+  runPageTitle,
+} from '@/lib/run-pages';
+import {
+  runPageDescriptionZh,
+  runPageFaqQuestionsZh,
+  runPageHeadingZh,
+  runPageKeywordsZh,
+  runPageTitleZh,
+} from '@/lib/run-pages-zh';
+
+const FORBIDDEN_DASHES = /[\u2013\u2014]/;
+const CJK = /[\u4E00-\u9FFF]/;
+
+describe('run pages registry', () => {
+  it('has one candidate per (model, chip) pair', () => {
+    const entries = getAllRunPageEntries();
+    expect(entries.length).toBe(INFERENCE_MODEL_SLUGS.length * getAllChipPages().length);
+    expect(entries.length).toBe(99);
+  });
+
+  it('has unique, well-formed slugs', () => {
+    const entries = getAllRunPageEntries();
+    expect(new Set(entries.map((entry) => entry.slug)).size).toBe(entries.length);
+    for (const entry of entries) {
+      expect(entry.slug).toBe(`${entry.model.slug}-on-${entry.chip.slug}`);
+      expect(entry.slug).toMatch(/^[a-z0-9-]+$/);
+      expect(runPagePath(entry)).toBe(`/run/${entry.slug}`);
+      expect(entry.dbKeys.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('resolves slugs case-insensitively and rejects unknown slugs', () => {
+    const [first] = getAllRunPageEntries();
+    expect(getRunPageEntry(first.slug)).toBe(first);
+    expect(getRunPageEntry(first.slug.toUpperCase())).toBe(first);
+    expect(getRunPageEntry('kimi-k3-on-abacus')).toBeUndefined();
+  });
+});
+
+describe('run pages copy', () => {
+  it('contains no em or en dashes and enough keywords in either locale', () => {
+    for (const entry of getAllRunPageEntries()) {
+      const faq = runPageFaqQuestions(entry);
+      const faqZh = runPageFaqQuestionsZh(entry);
+      const copy = [
+        runPageTitle(entry),
+        runPageHeading(entry),
+        runPageDescription(entry),
+        ...runPageKeywords(entry),
+        faq.throughput,
+        faq.cost,
+        faq.serving,
+        faq.methodology,
+        runPageTitleZh(entry),
+        runPageHeadingZh(entry),
+        runPageDescriptionZh(entry),
+        ...runPageKeywordsZh(entry),
+        faqZh.throughput,
+        faqZh.cost,
+        faqZh.serving,
+        faqZh.methodology,
+      ];
+      for (const text of copy) {
+        expect(text, `dash found in copy for ${entry.slug}: ${text}`).not.toMatch(FORBIDDEN_DASHES);
+        expect(text.length).toBeGreaterThan(0);
+      }
+      expect(runPageKeywords(entry).length).toBeGreaterThanOrEqual(6);
+      expect(runPageKeywordsZh(entry).length).toBeGreaterThanOrEqual(6);
+    }
+  });
+
+  it('keeps Chinese copy Chinese while model and chip names stay English', () => {
+    for (const entry of getAllRunPageEntries()) {
+      expect(runPageTitleZh(entry)).toMatch(CJK);
+      expect(runPageDescriptionZh(entry)).toMatch(CJK);
+      expect(runPageTitleZh(entry)).toContain(entry.model.seoName);
+      expect(runPageTitleZh(entry)).toContain(entry.chip.label);
+    }
+  });
+
+  it('mentions both the model and the chip in every English title', () => {
+    for (const entry of getAllRunPageEntries()) {
+      expect(runPageTitle(entry)).toContain(entry.model.seoName);
+      expect(runPageTitle(entry)).toContain(entry.chip.label);
+    }
+  });
+});
+
+describe('live-seo number formatting', () => {
+  it('formats throughput with sensible precision', () => {
+    expect(fmtThroughput(1234.56)).toBe('1,235');
+    expect(fmtThroughput(250)).toBe('250');
+    expect(fmtThroughput(42.345)).toBe('42.3');
+  });
+
+  it('formats costs at cents precision with a sub-cent fallback', () => {
+    expect(fmtCostPerMtok(1.234)).toBe('$1.23');
+    expect(fmtCostPerMtok(0.056)).toBe('$0.056');
+    expect(fmtGpuHour(2.5)).toBe('$2.50');
+  });
+
+  it('formats latency and percentage deltas', () => {
+    expect(fmtMs(123.4)).toBe('123 ms');
+    expect(fmtMs(45.67)).toBe('45.7 ms');
+    expect(pctFaster(250, 200)).toBe(25);
+  });
+});

--- a/packages/app/src/lib/run-pages.test.ts
+++ b/packages/app/src/lib/run-pages.test.ts
@@ -5,6 +5,7 @@ import {
   fmtGpuHour,
   fmtMs,
   fmtThroughput,
+  pctCheaper,
   pctFaster,
 } from '@/components/live-seo/format';
 import { getAllChipPages } from '@/lib/chip-pages';
@@ -122,5 +123,8 @@ describe('live-seo number formatting', () => {
     expect(fmtMs(123.4)).toBe('123 ms');
     expect(fmtMs(45.67)).toBe('45.7 ms');
     expect(pctFaster(250, 200)).toBe(25);
+    // A $1 winner against a $2 runner-up is 50% below, not 100%.
+    expect(pctCheaper(1, 2)).toBe(50);
+    expect(pctCheaper(1.5, 2)).toBe(25);
   });
 });

--- a/packages/app/src/lib/run-pages.ts
+++ b/packages/app/src/lib/run-pages.ts
@@ -1,0 +1,129 @@
+/**
+ * @file run-pages.ts
+ * @description Slug registry and copy builders for the indexable
+ * `/run/<model>-on-<chip>` pages.
+ *
+ * Each page answers one search-shaped question: what does it actually look
+ * like to serve model X on GPU Y today? The dashboard already measures the
+ * answer daily; these pages give every (model, chip) pair a stable URL with
+ * its own title, meta description, and server-rendered numbers so the
+ * measurement is indexable instead of trapped behind dashboard query params.
+ *
+ * The vocabulary deliberately reuses the two registries that already exist:
+ * model slugs come from `INFERENCE_MODEL_SLUGS` (same slugs as `/inference/…`
+ * and `/compare/…`) and chip slugs come from `chip-pages.ts` (same slugs as
+ * `/chips/…`), so `/run/kimi-k3-on-gb200-nvl72`, `/inference/kimi-k3` and
+ * `/chips/gb200-nvl72` all agree on what the words mean. No third naming
+ * scheme is introduced.
+ *
+ * Which pairs actually get indexed is decided by benchmark availability at
+ * request time (see `run-rankings-data.server.ts`); this module only defines
+ * the static candidate space and the copy.
+ */
+
+import { getAllChipPages, type ChipPageEntry } from '@/lib/chip-pages';
+import { COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
+import { INFERENCE_MODEL_SLUGS, type InferenceModelSlug } from '@/lib/inference-model-slug';
+
+export interface RunPageEntry {
+  /** Canonical URL slug under /run/, e.g. 'kimi-k3-on-gb200-nvl72'. */
+  slug: string;
+  /** Model registry entry — same slug vocabulary as /inference/<model>. */
+  model: InferenceModelSlug;
+  /** DB keys to fetch benchmark rows for, from the compare registry. */
+  dbKeys: string[];
+  /** Chip registry entry — same slug vocabulary as /chips/<slug>. */
+  chip: ChipPageEntry;
+}
+
+const DB_KEYS_BY_MODEL_SLUG: ReadonlyMap<string, string[]> = new Map(
+  COMPARE_MODEL_SLUGS.map((entry) => [entry.slug, entry.dbKeys]),
+);
+
+function buildEntries(): RunPageEntry[] {
+  const out: RunPageEntry[] = [];
+  for (const model of INFERENCE_MODEL_SLUGS) {
+    const dbKeys = DB_KEYS_BY_MODEL_SLUG.get(model.slug);
+    if (!dbKeys) continue;
+    for (const chip of getAllChipPages()) {
+      out.push({
+        slug: `${model.slug}-on-${chip.slug}`,
+        model,
+        dbKeys,
+        chip,
+      });
+    }
+  }
+  return out;
+}
+
+const ENTRIES: readonly RunPageEntry[] = buildEntries();
+
+const ENTRY_BY_SLUG: ReadonlyMap<string, RunPageEntry> = new Map(
+  ENTRIES.map((entry) => [entry.slug, entry]),
+);
+
+/** Every candidate (model, chip) pair. Availability filtering happens in the
+ *  server layer; unknown slugs 404 at the route. */
+export function getAllRunPageEntries(): readonly RunPageEntry[] {
+  return ENTRIES;
+}
+
+export function getRunPageEntry(slug: string): RunPageEntry | undefined {
+  return ENTRY_BY_SLUG.get(slug.toLowerCase());
+}
+
+export function runPagePath(entry: RunPageEntry): string {
+  return `/run/${entry.slug}`;
+}
+
+// ---------------------------------------------------------------------------
+// English copy
+// ---------------------------------------------------------------------------
+
+export function runPageTitle(entry: RunPageEntry): string {
+  return `${entry.model.seoName} on ${entry.chip.label}: Measured Inference Throughput and Cost`;
+}
+
+export function runPageHeading(entry: RunPageEntry): string {
+  return `Running ${entry.model.seoName} on ${entry.chip.label}`;
+}
+
+/** Static fallback meta description; the route swaps in a stat-led one when
+ *  live numbers are available. Keep ≤160 chars before the supporters line. */
+export function runPageDescription(entry: RunPageEntry): string {
+  return `Live benchmark data for ${entry.model.seoName} inference on ${entry.chip.title}: tokens per second per GPU, cost per million tokens, and the serving configs that produced them.`;
+}
+
+export function runPageKeywords(entry: RunPageEntry): string[] {
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  return [
+    `${model} on ${chip}`,
+    `run ${model} on ${chip}`,
+    `${model} ${chip} benchmark`,
+    `${model} ${chip} throughput`,
+    `${model} ${chip} tokens per second`,
+    `${model} ${chip} cost per million tokens`,
+    `${chip} ${model} inference performance`,
+    `${model} inference hardware`,
+  ];
+}
+
+/** Search-shaped FAQ scaffolding. Answers that need live numbers are filled
+ *  by the route; these are the stable question strings. */
+export function runPageFaqQuestions(entry: RunPageEntry): {
+  throughput: string;
+  cost: string;
+  serving: string;
+  methodology: string;
+} {
+  const model = entry.model.seoName;
+  const chip = entry.chip.label;
+  return {
+    throughput: `How fast is ${model} on ${chip}?`,
+    cost: `How much does it cost to serve ${model} on ${chip}?`,
+    serving: `Which serving engines run ${model} on ${chip}?`,
+    methodology: `How are these ${model} numbers measured?`,
+  };
+}

--- a/packages/app/src/lib/run-rankings-data.server.ts
+++ b/packages/app/src/lib/run-rankings-data.server.ts
@@ -1,0 +1,256 @@
+/**
+ * @file run-rankings-data.server.ts
+ * @description Server-side data derivation for the `/run/<pair>` and
+ * `/rankings/<slug>` pages.
+ *
+ * Both families read through `getCachedBenchmarks` — the same cached query the
+ * dashboard, /compare, and /overview use — and derive their numbers with
+ * `buildOverviewModelSummary`, so a ranked or quoted figure on these pages is
+ * always the figure the /overview leaderboard shows for the same cell.
+ * Fixtures mode short-circuits inside those shared helpers, so tests and
+ * DB-less builds never touch a connection here.
+ */
+
+import { resolveFrameworkPartLabel } from '@semianalysisai/inferencex-constants';
+
+import type { BenchmarkRow } from '@/lib/api';
+import { cachedDerivedData } from '@/lib/api-cache';
+import { getCachedBenchmarks } from '@/lib/benchmark-data.server';
+import { getChipHw } from '@/lib/chip-pages';
+import { buildDbKeyToSlugMap, getCachedAvailability } from '@/lib/compare-availability';
+import {
+  buildOverviewModelSummary,
+  OVERVIEW_PRIMARY_TIER,
+  OVERVIEW_TIERS,
+  overviewScenarioForModel,
+  type OverviewScenario,
+  type OverviewTier,
+} from '@/lib/overview-data';
+import {
+  buildRankingRows,
+  getAllRankingPageEntries,
+  type RankingPageEntry,
+  type RankingRow,
+} from '@/lib/rankings';
+import { getAllRunPageEntries, type RunPageEntry } from '@/lib/run-pages';
+
+// ---------------------------------------------------------------------------
+// Availability: which (model, chip) pairs actually have benchmark rows
+// ---------------------------------------------------------------------------
+
+async function loadAvailableRunEntries(): Promise<RunPageEntry[]> {
+  const rows = await getCachedAvailability();
+  const dbKeyToSlug = buildDbKeyToSlugMap();
+  const availableByModelSlug = new Map<string, Set<string>>();
+  for (const row of rows) {
+    const modelSlug = dbKeyToSlug.get(row.model);
+    if (!modelSlug) continue;
+    let set = availableByModelSlug.get(modelSlug);
+    if (!set) {
+      set = new Set<string>();
+      availableByModelSlug.set(modelSlug, set);
+    }
+    set.add(row.hardware);
+  }
+  return getAllRunPageEntries().filter((entry) =>
+    availableByModelSlug.get(entry.model.slug)?.has(entry.chip.hwKey),
+  );
+}
+
+const getCachedAvailableRunEntries = cachedDerivedData(
+  loadAvailableRunEntries,
+  'run-pages-availability-v1',
+);
+
+/** Candidate pairs narrowed to those with at least one benchmark row. Used by
+ *  the sitemap, the /run index, and related-page link lists. */
+export function getAvailableRunEntries(): Promise<RunPageEntry[]> {
+  return getCachedAvailableRunEntries();
+}
+
+// ---------------------------------------------------------------------------
+// /run/<pair> page data
+// ---------------------------------------------------------------------------
+
+export interface RunTierRead {
+  tier: OverviewTier;
+  /** Tokens/s per GPU at this interactivity tier; null when unreachable. */
+  throughputPerGpu: number | null;
+  /** $ per million total tokens at hyperscaler $/GPU/hr; null when unknown. */
+  costPerMtok: number | null;
+  precision: string | null;
+  framework: string | null;
+  disagg: boolean | null;
+}
+
+export interface RunCostTier {
+  tierLabel: 'hyperscaler' | 'neocloud' | 'retail';
+  costPerGpuHour: number;
+  costPerMtok: number;
+}
+
+export interface RunPageData {
+  hasData: boolean;
+  scenario: OverviewScenario;
+  configCount: number;
+  frameworks: string[];
+  precisions: string[];
+  hasDisagg: boolean;
+  hasMultinode: boolean;
+  bestThroughputPerGpu: number | null;
+  bestMedianTtft: number | null;
+  bestMedianTpot: number | null;
+  primaryTier: OverviewTier;
+  tierLadder: RunTierRead[];
+  /** Cost per million tokens at the primary tier across the three $/GPU/hr
+   *  pricing tiers from HW_REGISTRY. Empty when the tier is unreachable. */
+  costTiers: RunCostTier[];
+  oldest: string | null;
+  newest: string | null;
+}
+
+function costPerMtokAt(costPerGpuHour: number, throughputPerGpu: number): number {
+  return (costPerGpuHour * 1_000_000) / (throughputPerGpu * 3600);
+}
+
+function buildRunPageData(entry: RunPageEntry, rows: BenchmarkRow[]): RunPageData {
+  const hwKey = entry.chip.hwKey;
+  const hwRows = rows.filter((row) => row.hardware === hwKey);
+  const scenario = overviewScenarioForModel(entry.model.model, rows);
+
+  const frameworks = new Set<string>();
+  const precisions = new Set<string>();
+  let hasDisagg = false;
+  let hasMultinode = false;
+  let bestThroughputPerGpu: number | null = null;
+  let bestMedianTtft: number | null = null;
+  let bestMedianTpot: number | null = null;
+  let oldest: string | null = null;
+  let newest: string | null = null;
+
+  for (const row of hwRows) {
+    frameworks.add(resolveFrameworkPartLabel(row.model, row.framework));
+    precisions.add(row.precision);
+    if (row.disagg) hasDisagg = true;
+    if (row.is_multinode) hasMultinode = true;
+    const metrics = row.metrics ?? {};
+    const tput = typeof metrics.tput_per_gpu === 'number' ? metrics.tput_per_gpu : null;
+    const ttft = typeof metrics.median_ttft === 'number' ? metrics.median_ttft : null;
+    const tpot = typeof metrics.median_tpot === 'number' ? metrics.median_tpot : null;
+    if (tput !== null && (bestThroughputPerGpu === null || tput > bestThroughputPerGpu)) {
+      bestThroughputPerGpu = tput;
+    }
+    if (ttft !== null && (bestMedianTtft === null || ttft < bestMedianTtft)) {
+      bestMedianTtft = ttft;
+    }
+    if (tpot !== null && (bestMedianTpot === null || tpot < bestMedianTpot)) {
+      bestMedianTpot = tpot;
+    }
+    if (row.date && (oldest === null || row.date < oldest)) oldest = row.date;
+    if (row.date && (newest === null || row.date > newest)) newest = row.date;
+  }
+
+  const tierLadder: RunTierRead[] = OVERVIEW_TIERS.map((tier) => {
+    const summary = buildOverviewModelSummary(entry.model.model, rows, tier);
+    const platform = summary.platforms.find((p) => p.hardware === hwKey);
+    return {
+      tier,
+      throughputPerGpu: platform?.read.value ?? null,
+      costPerMtok: platform?.costPerMtok ?? null,
+      precision: platform?.read.config?.precision ?? platform?.precision ?? null,
+      framework: platform?.read.config?.frameworkLabel ?? null,
+      disagg: platform?.read.config?.disagg ?? null,
+    };
+  });
+
+  const primaryRead = tierLadder.find((read) => read.tier === OVERVIEW_PRIMARY_TIER);
+  const hw = getChipHw(entry.chip);
+  const costTiers: RunCostTier[] =
+    primaryRead?.throughputPerGpu && primaryRead.throughputPerGpu > 0
+      ? (
+          [
+            ['hyperscaler', hw.costh],
+            ['neocloud', hw.costn],
+            ['retail', hw.costr],
+          ] as const
+        )
+          .filter(([, costPerGpuHour]) => costPerGpuHour > 0)
+          .map(([tierLabel, costPerGpuHour]) => ({
+            tierLabel,
+            costPerGpuHour,
+            costPerMtok: costPerMtokAt(costPerGpuHour, primaryRead.throughputPerGpu as number),
+          }))
+      : [];
+
+  return {
+    hasData: hwRows.length > 0,
+    scenario,
+    configCount: hwRows.length,
+    frameworks: [...frameworks].sort(),
+    precisions: [...precisions].sort(),
+    hasDisagg,
+    hasMultinode,
+    bestThroughputPerGpu,
+    bestMedianTtft,
+    bestMedianTpot,
+    primaryTier: OVERVIEW_PRIMARY_TIER,
+    tierLadder,
+    costTiers,
+    oldest,
+    newest,
+  };
+}
+
+async function loadRunPageData(slug: string): Promise<RunPageData | null> {
+  const entry = getAllRunPageEntries().find((candidate) => candidate.slug === slug);
+  if (!entry) return null;
+  const rows = await getCachedBenchmarks(entry.dbKeys);
+  return buildRunPageData(entry, rows);
+}
+
+const getCachedRunPageData = cachedDerivedData(loadRunPageData, 'run-page-data-v1');
+
+export function getRunPageData(slug: string): Promise<RunPageData | null> {
+  return getCachedRunPageData(slug);
+}
+
+// ---------------------------------------------------------------------------
+// /rankings/<slug> page data
+// ---------------------------------------------------------------------------
+
+export interface RankingPageData {
+  scenario: OverviewScenario;
+  tier: OverviewTier;
+  rows: RankingRow[];
+  oldest: string | null;
+  newest: string | null;
+}
+
+async function loadRankingPageData(slug: string): Promise<RankingPageData | null> {
+  const entry: RankingPageEntry | undefined = getAllRankingPageEntries().find(
+    (candidate) => candidate.slug === slug,
+  );
+  if (!entry) return null;
+  const rows = await getCachedBenchmarks(entry.dbKeys);
+  const summary = buildOverviewModelSummary(entry.model.model, rows);
+  let oldest: string | null = null;
+  let newest: string | null = null;
+  for (const row of rows) {
+    if (!row.date) continue;
+    if (oldest === null || row.date < oldest) oldest = row.date;
+    if (newest === null || row.date > newest) newest = row.date;
+  }
+  return {
+    scenario: summary.scenario,
+    tier: OVERVIEW_PRIMARY_TIER,
+    rows: buildRankingRows(summary, entry.kind),
+    oldest,
+    newest,
+  };
+}
+
+const getCachedRankingPageData = cachedDerivedData(loadRankingPageData, 'ranking-page-data-v1');
+
+export function getRankingPageData(slug: string): Promise<RankingPageData | null> {
+  return getCachedRankingPageData(slug);
+}

--- a/packages/app/src/lib/run-rankings-data.server.ts
+++ b/packages/app/src/lib/run-rankings-data.server.ts
@@ -4,9 +4,11 @@
  * `/rankings/<slug>` pages.
  *
  * Both families read through `getCachedBenchmarks` — the same cached query the
- * dashboard, /compare, and /overview use — and derive their numbers with
- * `buildOverviewModelSummary`, so a ranked or quoted figure on these pages is
- * always the figure the /overview leaderboard shows for the same cell.
+ * dashboard, /compare, and /overview use — and derive their numbers with the
+ * overview's own config building and read selection (`buildOverviewModelSummary`
+ * for rankings, `overviewHardwareTierReader` for run pages, which also covers
+ * SKUs outside the overview matrix), so a ranked or quoted figure on these
+ * pages is always the figure the overview derivation yields for that cell.
  * Fixtures mode short-circuits inside those shared helpers, so tests and
  * DB-less builds never touch a connection here.
  */
@@ -22,7 +24,8 @@ import {
   buildOverviewModelSummary,
   OVERVIEW_PRIMARY_TIER,
   OVERVIEW_TIERS,
-  overviewScenarioForModel,
+  overviewHardwareTierReader,
+  overviewHeadlineScenarioForModel,
   type OverviewScenario,
   type OverviewTier,
 } from '@/lib/overview-data';
@@ -116,7 +119,7 @@ function costPerMtokAt(costPerGpuHour: number, throughputPerGpu: number): number
 function buildRunPageData(entry: RunPageEntry, rows: BenchmarkRow[]): RunPageData {
   const hwKey = entry.chip.hwKey;
   const hwRows = rows.filter((row) => row.hardware === hwKey);
-  const scenario = overviewScenarioForModel(entry.model.model, rows);
+  const scenario = overviewHeadlineScenarioForModel(entry.model.model, rows);
 
   const frameworks = new Set<string>();
   const precisions = new Set<string>();
@@ -150,16 +153,18 @@ function buildRunPageData(entry: RunPageEntry, rows: BenchmarkRow[]): RunPageDat
     if (row.date && (newest === null || row.date > newest)) newest = row.date;
   }
 
+  // Reads come from the same derivation as the overview matrix but without
+  // its fixed platform list, so H100-class SKUs get real ladders too.
+  const readAt = overviewHardwareTierReader(entry.model.model, rows, scenario);
   const tierLadder: RunTierRead[] = OVERVIEW_TIERS.map((tier) => {
-    const summary = buildOverviewModelSummary(entry.model.model, rows, tier);
-    const platform = summary.platforms.find((p) => p.hardware === hwKey);
+    const { read, costPerMtok } = readAt(hwKey, tier);
     return {
       tier,
-      throughputPerGpu: platform?.read.value ?? null,
-      costPerMtok: platform?.costPerMtok ?? null,
-      precision: platform?.read.config?.precision ?? platform?.precision ?? null,
-      framework: platform?.read.config?.frameworkLabel ?? null,
-      disagg: platform?.read.config?.disagg ?? null,
+      throughputPerGpu: read.value,
+      costPerMtok,
+      precision: read.config?.precision ?? null,
+      framework: read.config?.frameworkLabel ?? null,
+      disagg: read.config?.disagg ?? null,
     };
   });
 
@@ -208,7 +213,7 @@ async function loadRunPageData(slug: string): Promise<RunPageData | null> {
   return buildRunPageData(entry, rows);
 }
 
-const getCachedRunPageData = cachedDerivedData(loadRunPageData, 'run-page-data-v1');
+const getCachedRunPageData = cachedDerivedData(loadRunPageData, 'run-page-data-v2');
 
 export function getRunPageData(slug: string): Promise<RunPageData | null> {
   return getCachedRunPageData(slug);
@@ -232,7 +237,14 @@ async function loadRankingPageData(slug: string): Promise<RankingPageData | null
   );
   if (!entry) return null;
   const rows = await getCachedBenchmarks(entry.dbKeys);
-  const summary = buildOverviewModelSummary(entry.model.model, rows);
+  const scenario = overviewHeadlineScenarioForModel(entry.model.model, rows);
+  const summary = buildOverviewModelSummary(
+    entry.model.model,
+    rows,
+    OVERVIEW_PRIMARY_TIER,
+    'community',
+    scenario,
+  );
   let oldest: string | null = null;
   let newest: string | null = null;
   for (const row of rows) {
@@ -249,7 +261,7 @@ async function loadRankingPageData(slug: string): Promise<RankingPageData | null
   };
 }
 
-const getCachedRankingPageData = cachedDerivedData(loadRankingPageData, 'ranking-page-data-v1');
+const getCachedRankingPageData = cachedDerivedData(loadRankingPageData, 'ranking-page-data-v2');
 
 export function getRankingPageData(slug: string): Promise<RankingPageData | null> {
   return getCachedRankingPageData(slug);


### PR DESCRIPTION
## Summary

Adds two data-backed, indexable SEO page families that render live benchmark numbers straight from the InferenceX overview derivation, plus Simplified Chinese siblings for every page:

### `/rankings/[slug]` - GPU rankings (22 pages + index, x2 locales)
- `fastest-gpu-for-<model>` and `cheapest-gpu-for-<model>` for all 11 models (DeepSeek V4/R1, Kimi K3/K2.6, GLM 5.1/5.2, MiniMax M3/M2.7, Qwen 3.5, gpt-oss-120B, Llama 3.3 70B).
- Ranked table of every measured platform at a matched interactivity tier, with throughput per GPU, $/M tokens, precision, and framework. GPU cells deep-link into the matching `/run/<model>-on-<chip>` page.
- Stat-led meta descriptions and FAQ answers computed from live rows, so titles/snippets update as the fleet re-benchmarks.
- `ItemList` + `FAQPage` + `BreadcrumbList` JSON-LD; cross-link between the fastest/cheapest sibling of each model.

### `/run/[slug]` - model-on-hardware results (99 candidate pairs, availability-filtered, x2 locales)
- `<model>-on-<chip>` for all model x chip pairs with measured data (chips: H100, H200, B200, B300, GB200 NVL72, GB300 NVL72, MI300X, MI325X, MI355X). Pairs without data render a noindex-safe empty state and are excluded from the sitemap.
- Quick-answer box, 4-stat grid (best throughput/GPU, median TTFT, median TPOT, config count), full interactivity-tier ladder, and hyperscaler/neocloud/retail cost tiers from the SemiAnalysis AI Cloud TCO model.
- `WebPage` (with `datePublished`/`dateModified` from oldest/newest run) + `FAQPage` + `BreadcrumbList` JSON-LD.

### Wiring
- Sitemap: localized pairs for `/rankings`, all 22 ranking slugs, `/run`, and every available run pair.
- `/zh` mirrors registered in `ZH_MIRRORED_ROUTES`; hreflang alternates on every page.
- Footer links (EN + ZH) and new `llms.txt` sections.
- Tests: registry counts/slug roundtrips, no em/en dashes in EN + ZH copy, CJK presence, ranking-row sort/filter behavior, sitemap locale parity, and number-formatting helpers (26 tests).

All numbers are read through the same cached overview derivation the dashboard uses, so these pages can never disagree with the leaderboard.

## 中文说明

新增两组由实测数据驱动的可索引 SEO 页面，直接复用 InferenceX 总览推导的实时基准数据，且每个页面都有简体中文版本：

### `/rankings/[slug]` - GPU 排行榜（22 页 + 索引，双语）
- 为全部 11 个模型生成 `fastest-gpu-for-<model>`（最快 GPU）与 `cheapest-gpu-for-<model>`（最省钱 GPU）页面。
- 在统一交互速度档位下对所有实测平台排名，展示单 GPU 吞吐、每百万 token 成本、精度与推理引擎；GPU 单元格深度链接到对应的 `/run/<model>-on-<chip>` 页面。
- Meta 描述与 FAQ 答案由实时数据计算，随集群重跑基准自动更新。
- `ItemList` + `FAQPage` + `BreadcrumbList` 结构化数据；同一模型的最快/最省钱页面互相交叉链接。

### `/run/[slug]` - 模型在硬件上的实测结果（99 个候选组合，按数据可用性过滤，双语）
- 覆盖全部模型 x 芯片组合（H100、H200、B200、B300、GB200 NVL72、GB300 NVL72、MI300X、MI325X、MI355X）；无数据的组合渲染空状态且不进入 sitemap。
- 快速答案框、四项关键指标（最佳单 GPU 吞吐、TTFT 中位数、TPOT 中位数、配置数）、完整交互档位阶梯表，以及超大规模云/新兴云/零售租用三档成本（来自 SemiAnalysis AI Cloud TCO 模型）。
- `WebPage`（含 `datePublished`/`dateModified`）+ `FAQPage` + `BreadcrumbList` 结构化数据。

### 配套改动
- Sitemap 收录 `/rankings` 及 22 个排行页、`/run` 及全部有数据的组合页（中英双语对）。
- `/zh` 镜像路由注册进 `ZH_MIRRORED_ROUTES`，所有页面带 hreflang 双语互链。
- 页脚新增中英双语入口；`llms.txt` 新增对应章节。
- 测试：注册表数量与 slug 往返、中英文案禁用长短破折号、中文字符校验、排行行排序/过滤、sitemap 双语一致性、数字格式化工具（共 26 项）。

所有数字均通过与仪表盘相同的缓存推导读取，页面数据不会与排行榜出现分歧。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New dynamic routes depend on shared overview/benchmark derivation and availability filtering; incorrect alignment would misstate public leaderboard numbers, though there is no auth or mutation surface.
> 
> **Overview**
> Adds two **indexable, server-rendered SEO surfaces** that expose live benchmark numbers from the same overview derivation as the dashboard, in **English and Simplified Chinese**.
> 
> **`/rankings`** introduces an index plus per-model **fastest** and **cheapest GPU** leaderboards (static slug registry, dynamic tables, stat-led meta/FAQ, JSON-LD, cross-links to sibling rankings and `/run` pages). **`/run`** adds an index and **model-on-GPU** detail pages with quick answers, interactivity-tier ladders, TCO pricing tiers, and FAQ/schema markup; only pairings with benchmark data are listed in the sitemap, while empty slugs get **noindex**.
> 
> Shared **`live-seo`** UI and **`rankings` / `run-pages` / `run-rankings-data.server`** libs wire registries, sorting, and cached loads via `getCachedBenchmarks`. **`overview-data`** gains `overviewHeadlineScenarioForModel` and `overviewHardwareTierReader` so SEO copy matches overview workload choice and can quote SKUs outside the overview matrix.
> 
> Discovery updates: **sitemap** and **`llms.txt`** entries, **footer** links, **`ZH_MIRRORED_ROUTES`**, plus tests for registries, copy rules, ranking sort behavior, and sitemap locale parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fceba5a08ccc238939dca6640eb79162640f99af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->