### PR TITLE
Landing: supporter org names link to their quotes / 首页支持者名称可点击跳转到对应评价

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -48,6 +48,7 @@ describe('Landing page performance', () => {
     cy.request('/')
       .its('body')
       .should('contain', 'See full quotes')
+      .and('contain', 'href="/quotes#quote-minimax"')
       .and('contain', 'data-testid="launch-banner"');
 
     cy.intercept('GET', '**/_next/static/**/*.js', (request) => {

--- a/packages/app/src/components/intro-section.tsx
+++ b/packages/app/src/components/intro-section.tsx
@@ -2,15 +2,26 @@ import { Quote } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { SupportersStrip } from '@/components/supporters-strip';
-import { QUOTES, CAROUSEL_ORGS, CAROUSEL_LABELS } from '@/components/quotes/quotes-data';
+import {
+  QUOTES,
+  CAROUSEL_ORGS,
+  CAROUSEL_LABELS,
+  orgAnchorId,
+} from '@/components/quotes/quotes-data';
 import type { Locale } from '@/lib/i18n';
 
 // Strip order follows QUOTES order — supporter orgs are listed first there.
-const supporterOrgs = [
+const stripOrgs = [
   ...new Set(
     QUOTES.filter((q) => (CAROUSEL_ORGS as readonly string[]).includes(q.org)).map((q) => q.org),
   ),
-].map((org) => CAROUSEL_LABELS[org] ?? org);
+];
+
+const supporterOrgs = (quotesPath: string) =>
+  stripOrgs.map((org) => ({
+    label: CAROUSEL_LABELS[org] ?? org,
+    href: `${quotesPath}#${orgAnchorId(org)}`,
+  }));
 
 const HEADING = {
   en: 'Open-Source Continuous Agentic Inference Benchmark Trusted by GigaWatt Token Factories',
@@ -32,7 +43,7 @@ export function IntroSection({ locale = 'en' }: { locale?: Locale } = {}) {
         {/* Quote text lives on /quotes now — the band keeps just the org
             strip and a link out, saving vertical space above the fold. */}
         <SupportersStrip
-          orgs={supporterOrgs}
+          orgs={supporterOrgs(isZh ? '/zh/quotes' : '/quotes')}
           moreHref={isZh ? '/zh/quotes' : '/quotes'}
           moreLabel={isZh ? '查看完整评价与更多支持者 →' : undefined}
         />

--- a/packages/app/src/components/quotes/quotes-content.tsx
+++ b/packages/app/src/components/quotes/quotes-content.tsx
@@ -10,7 +10,7 @@ import { track } from '@/lib/analytics';
 import type { Locale } from '@/lib/i18n';
 
 import { CompanyLogo, highlightBrand } from './quote-utils';
-import { QUOTES } from './quotes-data';
+import { QUOTES, orgAnchorId } from './quotes-data';
 
 const STRINGS = {
   en: {
@@ -26,15 +26,6 @@ const STRINGS = {
     jumpTo: (org: string) => `查看 ${org} 的评价`,
   },
 } as const;
-
-/** Stable anchor id for an org's quote (first occurrence wins). */
-function orgAnchorId(org: string): string {
-  const slug = org
-    .toLowerCase()
-    .replaceAll(/[^a-z0-9]+/gu, '-')
-    .replaceAll(/^-|-$/gu, '');
-  return `quote-${slug}`;
-}
 
 /** Deduplicated logos from all quote orgs. */
 const orgLogos: { org: string; logo: string }[] = [];

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -1,3 +1,12 @@
+/** Stable anchor id for an org's quote on the quotes page (first occurrence wins). */
+export function orgAnchorId(org: string): string {
+  const slug = org
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/gu, '-')
+    .replaceAll(/^-|-$/gu, '');
+  return `quote-${slug}`;
+}
+
 export interface Quote {
   text: string;
   /** Simplified Chinese translation of `text`, shown on /zh pages. */

--- a/packages/app/src/components/supporters-strip.tsx
+++ b/packages/app/src/components/supporters-strip.tsx
@@ -4,9 +4,16 @@ import Link from 'next/link';
 
 import { track } from '@/lib/analytics';
 
+export interface SupporterOrg {
+  /** Display name shown in the org strip */
+  label: string;
+  /** Link to the org's quote on the supporters page */
+  href: string;
+}
+
 export interface SupportersStripProps {
-  /** Display names shown in the org strip, in display order */
-  orgs: string[];
+  /** Supporter orgs shown in the strip, in display order */
+  orgs: SupporterOrg[];
   /** Link to the page with all quotes and supporters */
   moreHref: string;
   /** Label for the moreHref link (default "See full quotes & more supporters →") */
@@ -16,7 +23,8 @@ export interface SupportersStripProps {
 /**
  * Compact replacement for the landing quote carousel: renders the supporter
  * org strip plus a single link out to the full quotes page instead of a
- * rotating quote block, saving vertical space above the fold.
+ * rotating quote block, saving vertical space above the fold. Each org links
+ * to its quote anchor on the supporters page.
  */
 export function SupportersStrip({ orgs, moreHref, moreLabel }: SupportersStripProps) {
   return (
@@ -24,9 +32,15 @@ export function SupportersStrip({ orgs, moreHref, moreLabel }: SupportersStripPr
       {/* Org name strip */}
       <div className="flex flex-wrap justify-center gap-x-6 md:gap-x-8 gap-y-2 mx-4">
         {orgs.map((org) => (
-          <span key={org} className="text-xs font-semibold tracking-wide uppercase text-[#808488]">
-            {org}
-          </span>
+          <Link
+            key={org.label}
+            href={org.href}
+            prefetch={false}
+            className="text-xs font-semibold tracking-wide uppercase text-[#808488] transition-colors duration-200 hover:text-foreground hover:underline"
+            onClick={() => track('supporters_strip_org_clicked', { org: org.label })}
+          >
+            {org.label}
+          </Link>
         ))}
       </div>
 


### PR DESCRIPTION
## What

Each company name in the landing supporters strip is now a link to that company's quote on the supporters page — `/quotes#quote-<org>` (zh: `/zh/quotes#quote-<org>`). The quotes page already renders a stable anchor id on the first quote card per org, so clicking e.g. **SGLANG** lands directly on the SGLang quote.

## Changes

- `quotes-data.ts`: `orgAnchorId` moved here (from `quotes-content.tsx`) so the server-rendered strip and the quotes page share the same anchor slugs
- `supporters-strip.tsx`: org entries are now `{ label, href }` links with hover styling and a new `supporters_strip_org_clicked` analytics event
- `intro-section.tsx`: builds per-org hrefs from `QUOTES` / `CAROUSEL_ORGS` / `CAROUSEL_LABELS` + `orgAnchorId`
- Cypress: landing hydration test also asserts the SSR body contains `href="/quotes#quote-minimax"`

## QA

- Verified locally: en and zh strips render anchor links for every org; clicking SGLANG navigates to `/quotes#quote-sglang` with the quote scrolled into view (`scroll-mt-24` already on the anchor)
- `typecheck` and `lint` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and presentation changes on the landing page only; no auth, data, or API changes.
> 
> **Overview**
> Landing **supporter org names** in the intro band are now **clickable links** to that org’s quote on the supporters page (`/quotes#quote-<slug>`, or `/zh/quotes#…` for Chinese), instead of plain text.
> 
> **`orgAnchorId`** is **exported from `quotes-data.ts`** (moved out of `quotes-content.tsx`) so the SSR landing strip and the quotes page use the **same anchor IDs** on the first quote card per org.
> 
> **`SupportersStrip`** now takes `{ label, href }` entries rendered as Next `Link`s with hover styling and a **`supporters_strip_org_clicked`** analytics event; **`intro-section`** builds those hrefs from carousel org data and `orgAnchorId`.
> 
> The **landing hydration Cypress test** also asserts the SSR HTML includes an example anchor (`href="/quotes#quote-minimax"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e58a2de42847a2f84aeb971234c55b2a5c47f42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->