### PR TITLE
Add Qwen3.8-Flash-Next (FP8 + NVFP4) / 新增 Qwen3.8-Flash-Next 模型（FP8 与 NVFP4）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 | Kimi-K2.6              | 1T    | 32B         | `moonshotai/Kimi-K2.6`              | HF model card                      |
 | Kimi-K2.7-Code         | 1T    | 32B         | `moonshotai/Kimi-K2.7-Code`         | HF model card                      |
 | Qwen3.5-397B-A17B      | 397B  | 17B         | `Qwen/Qwen3.5-397B-A17B`            | HF model card                      |
+| Qwen3.8-Flash-Next     | 176B  | 6B          | `Qwen/Qwen3.8-Flash-Next-FP8`       | HF model card                      |
 | GLM-5                  | 744B  | 40B         | `zai-org/GLM-5`                     | HF model card                      |
 | GLM-5.1                | 744B  | 40B         | `zai-org/GLM-5.1-FP8`               | HF model card (same base as GLM-5) |
 | MiniMax-M2.5           | 230B  | 10B         | `MiniMaxAI/MiniMax-M2.5`            | HF model card                      |
@@ -234,6 +235,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 
 **Common mislabel traps** (have all bitten this repo at least once — do not repeat):
 
+- **Qwen3.8-Flash-Next is 176B, not 125B.** The model card leads with "125B with 6B activated", but that is the main model only; the 51B n-gram embedding table brings the total to 176B. The separate 4B MTP head sits outside both figures. It is a Qwen4-architecture preview (GatedDeltaNet + Qwen Sparse Attention, 512 experts, 10 routed + 1 shared), not a Qwen3.5 point release, so it gets its own DB bucket.
 - **GLM-5 ≠ 355B.** 355B is GLM-4.5. GLM-5 jumped to 744B / 40B active (256-expert MoE with DSA).
 - **MiniMax-M2.5/M2.7 ≠ 456B.** 456B is the older MiniMax-Text-01 / M1 (32 large experts). The M2 series is a different architecture: 230B / 10B active, 256 small experts.
 - **DeepSeek-R1 is 671B, not 685B.** HF metadata shows 685B because the bundled MTP head adds ~14B; the core MoE is 671B / 37B active.

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -687,7 +687,7 @@ export const apiContractSourceDigests = [
     // Reviewed again for the release-date corrections: values inside
     // MODEL_RELEASE_DATES only. No published model name, alias, or parameter enum
     // is touched, and no endpoint exposes a release date, so the docs stand.
-    sourceSha256: 'f8f46a341bf57384c0080c2ed75d867801142675ded08225281cf7c102236628',
+    sourceSha256: '9faf1ed1ed1712ee04741b6aa2291d42b2c202c2dadbb1a2681b5391da555e6c',
     reviewArea: {
       en: 'Published benchmark and TCO model names, aliases, and parameter enums.',
       zh: '已发布基准与 TCO 模型名称、别名和参数枚举。',

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -272,6 +272,7 @@ describe('compareModelSeoName', () => {
     'glm-5-2': 'GLM-5.2',
     'minimax-m3': 'MiniMax M3',
     'minimax-m27': 'MiniMax M2.7',
+    'qwen-3-8-flash-next': 'Qwen3.8-Flash-Next',
     'qwen-3-5': 'Qwen3.5',
     'gptoss-120b': 'gpt-oss-120b',
     'llama-3-3-70b': 'Llama 3.3 70B',

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -123,6 +123,15 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     seoName: 'MiniMax M2.7',
   },
   {
+    slug: 'qwen-3-8-flash-next',
+    displayName: 'Qwen3.8-Flash-Next',
+    dbKeys: ['qwen3.8next'],
+    // 176B total: a 125B main model plus a 51B n-gram embedding table, with 6B
+    // active per forward pass (MoE). The 4B MTP head sits outside that total.
+    label: 'Qwen 3.8 Flash Next 176B-A6B',
+    seoName: 'Qwen3.8-Flash-Next',
+  },
+  {
     slug: 'qwen-3-5',
     displayName: 'Qwen-3.5-397B-A17B',
     dbKeys: ['qwen3.5'],

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -48,6 +48,7 @@ export const KNOWN_MODELS = new Set([
   'DeepSeek-R1-0528',
   'gpt-oss-120b',
   'Qwen-3.5-397B-A17B',
+  'Qwen3.8-Flash-Next',
   'Kimi-K2.5',
   'Kimi-K3',
   'MiniMax-M2.5',

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -6,6 +6,7 @@ export enum Model {
   DeepSeek_R1 = 'DeepSeek-R1-0528',
   GptOss = 'gpt-oss-120b',
   Qwen3_5 = 'Qwen-3.5-397B-A17B',
+  Qwen3_8_Flash_Next = 'Qwen3.8-Flash-Next',
   Kimi_K2_5 = 'Kimi-K2.5',
   Kimi_K3 = 'Kimi-K3',
   MiniMax_M2_5 = 'MiniMax-M2.5',
@@ -167,6 +168,18 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   // the selector presents both releases over the existing GLM-5.2 data bucket.
   [Model.GLM_5_2]: { label: 'GLM5.2/GLM5.3 744B', prefix: 'glm5.2', category: 'default' },
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
+  // 176B total: a 125B main model plus a 51B n-gram embedding table, 6B active
+  // per forward pass, and a separate 4B MTP head the parameter count excludes.
+  // Experimental rather than default while the only data is the day-zero H200
+  // FP8 agentic arm: `default` would seat it in the /overview matrix, which is
+  // built from DEFAULT_MODELS and would render an empty fixed-sequence row for
+  // it. It stays fully selectable everywhere else, since MODEL_OPTIONS excludes
+  // only `hidden`. Promote to `default` once the sweep covers more chips.
+  [Model.Qwen3_8_Flash_Next]: {
+    label: 'Qwen3.8 Flash Next 176B',
+    prefix: 'qwen3.8next',
+    category: 'experimental',
+  },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {
     // M2.5 and M2.7 share an architecture — same GLM5/5.1 pattern as Kimi.

--- a/packages/app/src/lib/rankings.test.ts
+++ b/packages/app/src/lib/rankings.test.ts
@@ -67,7 +67,7 @@ describe('rankings registry', () => {
   it('has one page per (kind, model) pair', () => {
     const entries = getAllRankingPageEntries();
     expect(entries.length).toBe(RANKING_KINDS.length * INFERENCE_MODEL_SLUGS.length);
-    expect(entries.length).toBe(22);
+    expect(entries.length).toBe(24);
   });
 
   it('has unique, well-formed slugs', () => {

--- a/packages/app/src/lib/run-pages.test.ts
+++ b/packages/app/src/lib/run-pages.test.ts
@@ -35,7 +35,7 @@ describe('run pages registry', () => {
   it('has one candidate per (model, chip) pair', () => {
     const entries = getAllRunPageEntries();
     expect(entries.length).toBe(INFERENCE_MODEL_SLUGS.length * getAllChipPages().length);
-    expect(entries.length).toBe(99);
+    expect(entries.length).toBe(108);
   });
 
   it('has unique, well-formed slugs', () => {

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -11,6 +11,9 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   gptoss120b: 'gpt-oss-120b',
   llama70b: 'Llama-3.3-70B-Instruct-FP8',
   'qwen3.5': 'Qwen-3.5-397B-A17B',
+  // Qwen4-architecture preview, not a Qwen3.5 point release (GatedDeltaNet plus
+  // Qwen Sparse Attention, 512 experts), so it gets its own display bucket.
+  'qwen3.8next': 'Qwen3.8-Flash-Next',
   'kimik2.5': 'Kimi-K2.5',
   'kimik2.6': 'Kimi-K2.5',
   'kimik2.7-code': 'Kimi-K2.5',
@@ -140,6 +143,13 @@ export const MODEL_RELEASE_DATES: Record<string, string> = {
   // Qwen/Qwen3.5-397B-A17B on 2026-02-16 — the same day InferenceX first swept
   // it. sweep: 2026-02-16 — day zero.
   'Qwen-3.5-397B-A17B': '2026-02-16',
+  // Qwen announced the open-sourcing of Qwen3.8-Flash-Next and its FP8 sibling
+  // for 23:00 Beijing time on 2026-08-26, which is also the day the SGLang
+  // bring-up image tag was published. Some coverage puts the Hugging Face repo
+  // live on 08-24; the announced date is the one used here, and either way it
+  // precedes the first sweep on 08-27. The model card itself states no date.
+  // sweep: 2026-08-27 — day zero.
+  'Qwen3.8-Flash-Next': '2026-08-26',
   // Bucket covers M2.5 and M2.7, so the date is M2.5's: announced 2026-02-12
   // with weights on Hugging Face, architecturally unchanged from M2 (230B/10B).
   // Was 2025-10-25, which is M2's launch, not M2.5's — `model-architectures.ts`

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -94,6 +94,14 @@ export const MODEL_TO_KEY: Record<string, string> = {
   // Qwen3.5
   'Qwen/Qwen3.5-397B-A17B': 'qwen3.5',
   'Qwen/Qwen3.5-397B-A17B-FP8': 'qwen3.5',
+  // Qwen3.8-Flash-Next (Qwen4 architecture preview — distinct bucket from 3.5).
+  // Hopper has no NVFP4 path, so H200 serves the FP8 checkpoint while Blackwell
+  // serves NVFP4. Both paths are taken from executed sweeps rather than inferred:
+  // FP8 from run 33038487711 (H200, PR #2753), NVFP4 from run 33039186365
+  // (B300, PR #2752). Both report `infmax_model_prefix: qwen3.8next`, so no
+  // PREFIX_ALIASES entry is needed.
+  'Qwen/Qwen3.8-Flash-Next-FP8': 'qwen3.8next',
+  'RadixArk/Qwen3.8-Flash-Next-NVFP4': 'qwen3.8next',
   // Kimi-K2.5 / K2.6 / K2.7-Code (same architecture, distinct DB buckets)
   'moonshotai/Kimi-K2.5': 'kimik2.5',
   'moonshotai/Kimi-K2.6': 'kimik2.6',


### PR DESCRIPTION
## Summary

Registers **Qwen3.8-Flash-Next** — the Qwen4-architecture preview — as its own model, wired end to end: DB bucket, normalizer paths, dashboard selector, compare pages, rankings, and run pages.

| | |
| --- | --- |
| DB key / `infmax_model_prefix` | `qwen3.8next` |
| Display name | `Qwen3.8-Flash-Next` |
| Dashboard label | `Qwen3.8 Flash Next 176B` |
| Compare slug | `qwen-3-8-flash-next` |
| Category | `experimental` (see below) |
| Release date | `2026-08-26` |

## Both serving paths resolve, and both were verified against real sweeps

Hopper has no NVFP4 path, so H200 serves the FP8 checkpoint while Blackwell serves NVFP4. I checked each against an executed run rather than inferring either from a PR description:

| HF path | → key | Verified in |
| --- | --- | --- |
| `Qwen/Qwen3.8-Flash-Next-FP8` | `qwen3.8next` | [run 33038487711](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33038487711) (H200, [#2753](https://github.com/SemiAnalysisAI/InferenceX/pull/2753)) |
| `RadixArk/Qwen3.8-Flash-Next-NVFP4` | `qwen3.8next` | [run 33039186365](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33039186365) (B300, [#2752](https://github.com/SemiAnalysisAI/InferenceX/pull/2752)) |

Resolution exercised directly through `resolveModelKey`, covering the row shapes the ingest actually sees:

```
{ model: 'Qwen/Qwen3.8-Flash-Next-FP8' }         -> qwen3.8next
{ model: 'RadixArk/Qwen3.8-Flash-Next-NVFP4' }   -> qwen3.8next
{ infmax_model_prefix: 'qwen3.8next' }           -> qwen3.8next
{ model: 'Qwen/Qwen3.5-397B-A17B-FP8' }          -> qwen3.5      (unchanged)
```

Both runs report `infmax_model_prefix: qwen3.8next`, so no `PREFIX_ALIASES` entry is needed. The `fp4` precision the B300 job reports is already in `KNOWN_PRECISIONS`.

## The parameter count is 176B, not 125B

The model card leads with *"125B with 6B activated"*, but that covers the main model only. The **51B n-gram embedding table** brings the total to **176B**, and a separate **4B MTP head** sits outside both figures.

This is exactly the class of mistake the AGENTS.md parameter table exists to prevent, so the row and a mislabel-trap entry are added there alongside the GLM-5 and MiniMax entries.

Architecture, for the record: GatedDeltaNet + Qwen Sparse Attention hybrid, 512 experts (10 routed + 1 shared), license `qwen-community-1.0`.

## Why `experimental` rather than `default`

Every other current model is `default`, so this is a deliberate exception worth a second opinion.

The only data today is the day-zero agentic arm. `default` puts a model into `DEFAULT_MODELS`, which is what builds the `/overview` matrix — and I confirmed against the overview fixture that a `default` registration emits a `Qwen3.8-Flash-Next/single_turn_8k1k` row with no data behind it. `MODEL_OPTIONS` excludes only `hidden`, so `experimental` keeps the model fully selectable in the dashboard, compare pages, rankings, and run pages while keeping that empty row out of the curated matrix.

**Promoting it later is a one-word change** in `MODEL_CONFIG`, and the comment there says so.

## On the release date

The model card states no publication date. Qwen announced the open-sourcing for 23:00 Beijing time on **2026-08-26**, which is also the day the `lmsysorg/sglang:qwen38flashnext` bring-up tag was published. Some coverage puts the Hugging Face repo live on 08-24; either way it precedes the first sweep on 08-27, which is the invariant `model-architectures.test.ts` pins. The reasoning is recorded in a comment next to the entry, matching the style of its neighbours.

## Three pinned-count guards moved

These are guards that exist to force a decision when a model is added, not incidental churn:

- `compare-slug.test.ts` — seoName coverage map gains the new slug
- `rankings.test.ts` — 22 → 24 (2 kinds × 12 models)
- `run-pages.test.ts` — 99 → 108 (12 models × 9 chips)

The `api-route-catalog` digest for `constants/src/models.ts` is refreshed. Per the rule in AGENTS.md I checked the documentation first rather than bumping the hash blind: `api-documentation.ts` derives its model enum from `DB_MODEL_TO_DISPLAY`, so the new key appears automatically and no reference copy, example, or OpenAPI schema needed editing.

## Not done here

- **`model-architectures.ts`** — optional per the checklist and skipped deliberately. The entries carry verified `config.json` values, and this model's shape (n-gram embedding table, separate MTP head, QSA) is unusual enough that I would rather add it from the config than approximate it. Omitted models simply render no diagram.
- **The `/compare` SEO blurb** lists a five-model sample and is already 158 characters; adding a sixth name would push the meta description past the useful length. Left alone.

> **Deploy order matters.** Per `docs/adding-entities.md`, the `packages/constants` and `packages/db` changes must be merged and deployed **before** the first ingest containing `qwen3.8next` rows, or those rows are silently skipped by the normalizer and need a full re-ingest to recover.

## Verification

- `bun run test:unit` — 4,419 app tests pass (246 files), all workspaces green
- `bun run typecheck` clean — the `Record<Model, …>` configs are the safety net that catches a half-registered enum member
- `bun run build` — zero errors; the new model appears in `INFERENCE_MODEL_SLUGS` (12 entries) and generates 9 run pages
- `resolveModelKey` exercised directly on both HF paths and the artifact prefix

## 中文说明

新增 **Qwen3.8-Flash-Next**（Qwen4 架构预览）作为独立模型，并完成端到端接入：数据库分桶、normalizer 路径、仪表板选择器、对比页、排名页与运行页。DB key 为 `qwen3.8next`，展示名 `Qwen3.8-Flash-Next`，标签 `Qwen3.8 Flash Next 176B`，对比 slug 为 `qwen-3-8-flash-next`，分类 `experimental`，发布日期 `2026-08-26`。

### 两条服务路径均已通过真实 sweep 验证

Hopper 无 NVFP4 路径，因此 H200 使用 FP8 权重、Blackwell 使用 NVFP4。两者均对照已执行的运行核实，而非依据 PR 描述推断：`Qwen/Qwen3.8-Flash-Next-FP8` 来自 [run 33038487711](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33038487711)（H200，[#2753](https://github.com/SemiAnalysisAI/InferenceX/pull/2753)），`RadixArk/Qwen3.8-Flash-Next-NVFP4` 来自 [run 33039186365](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33039186365)（B300，[#2752](https://github.com/SemiAnalysisAI/InferenceX/pull/2752)）。两次运行的 `infmax_model_prefix` 均为 `qwen3.8next`，因此无需 `PREFIX_ALIASES`；B300 任务上报的 `fp4` 精度已在 `KNOWN_PRECISIONS` 中。已直接调用 `resolveModelKey` 验证各种 row 形态，且 Qwen3.5 的解析结果保持不变。

### 参数量是 176B 而非 125B

model card 首行写的是「125B with 6B activated」，但那只是主模型；加上 **51B n-gram embedding** 后总量为 **176B**，另有 **4B MTP 头**不计入其中。这正是 AGENTS.md 参数表要防范的错误类型，因此已在该表及易错清单中补充相应条目。架构为 GatedDeltaNet + Qwen Sparse Attention 混合结构，512 个专家（10 路由 + 1 共享），许可证 `qwen-community-1.0`。

### 为何使用 `experimental` 而非 `default`

其他现有模型均为 `default`，因此这是一个需要评审确认的有意例外。目前仅有首发 agentic 数据；`default` 会把模型纳入 `DEFAULT_MODELS`，而 `/overview` 矩阵正是由它构建——我已对照 overview fixture 确认，设为 default 会生成一条没有数据支撑的 `Qwen3.8-Flash-Next/single_turn_8k1k` 行。`MODEL_OPTIONS` 仅排除 `hidden`，因此 `experimental` 仍可在仪表板、对比页、排名页和运行页中正常选择。后续提升为 `default` 只需改动一个词。

### 关于发布日期

model card 未标注发布日期。Qwen 宣布于北京时间 2026-08-26 23:00 开源，同日发布了 `lmsysorg/sglang:qwen38flashnext` 适配镜像标签；部分报道称 Hugging Face 仓库在 08-24 上线。无论采用哪个，都早于 08-27 的首次 sweep，满足 `model-architectures.test.ts` 所固定的不变式。相关推理已按邻近条目的风格写入注释。

### 三处计数守卫按预期变化

`compare-slug.test.ts` 的 seoName 覆盖表新增该 slug；`rankings.test.ts` 由 22 增至 24（2 种类型 × 12 个模型）；`run-pages.test.ts` 由 99 增至 108（12 个模型 × 9 款芯片）。`constants/src/models.ts` 的 api-route-catalog 摘要哈希已更新——按 AGENTS.md 规定先核查了文档：`api-documentation.ts` 的模型枚举派生自 `DB_MODEL_TO_DISPLAY`，新 key 会自动出现，无需修改参考文档、示例或 OpenAPI schema。

### 本次未做

`model-architectures.ts` 属可选项，本次有意跳过：该文件条目均使用经核实的 `config.json` 数值，而该模型结构较特殊（n-gram embedding 表、独立 MTP 头、QSA），宁可日后依据 config 补充，也不做近似；缺失条目仅表现为不渲染架构图。`/compare` 的 SEO 简介目前列举五个模型、已达 158 字符，再加一个会超出 meta description 的合理长度，故未改动。

> **部署顺序很重要。** 按 `docs/adding-entities.md`，`packages/constants` 与 `packages/db` 的改动必须在首次包含 `qwen3.8next` 数据的 ingest **之前**合并并部署，否则这些行会被 normalizer 静默跳过，需要完整重新 ingest 才能恢复。

### 验证

- `bun run test:unit` — app 端 4,419 项测试通过（246 个文件），各 workspace 全部通过
- `bun run typecheck` 通过——`Record<Model, …>` 类型是捕获枚举成员未完整注册的安全网
- `bun run build` — 零报错；新模型已出现在 `INFERENCE_MODEL_SLUGS`（共 12 项）并生成 9 个运行页
- 已直接对两条 HF 路径与 artifact prefix 调用 `resolveModelKey` 验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ETL model-resolution path and shared model registries; incorrect deploy order or mapping would drop or mis-attribute `qwen3.8next` ingest rows until re-ingest.
> 
> **Overview**
> Registers **Qwen3.8-Flash-Next** as its own model (`qwen3.8next` / display `Qwen3.8-Flash-Next`) across ingest, shared constants, the dashboard `Model` enum, compare URLs (`qwen-3-8-flash-next`), and SSR allowlists. ETL maps both `Qwen/Qwen3.8-Flash-Next-FP8` and `RadixArk/Qwen3.8-Flash-Next-NVFP4` into the same DB bucket.
> 
> The dashboard lists it as **Qwen3.8 Flash Next 176B** with category **`experimental`** so it stays selectable but is excluded from the `/overview` default matrix until more sweep coverage exists. **AGENTS.md** documents the **176B** total (not 125B) and adds a mislabel trap.
> 
> Registry tests bump expected ranking pages (22→24) and run pages (99→108); `api-route-catalog` refreshes the digest for `constants/src/models.ts` after the new display mapping and release date (`2026-08-26`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91a1dd7c7a1ba495ed3b1bf4390638ddc069f924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->