### PR TITLE
Ship the Qwen3.8-Flash-Next model page, default and AgentX-only / 新增 Qwen3.8-Flash-Next 模型页面，并改为 default 与仅 AgentX 场景

### DIFF
--- a/packages/app/content/models/qwen-3-8-flash-next.mdx
+++ b/packages/app/content/models/qwen-3-8-flash-next.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Qwen3.8-Flash-Next'
+developer: 'Alibaba (Qwen)'
+releaseDate: 'August 2026'
+description: "Alibaba's open-weights preview of the Qwen4 architecture: 176B total across a 125B main model and a 51B n-gram embedding table, 6B active, with Qwen Sparse Attention, gated residuals and a Gated DeltaNet hybrid stack."
+---
+
+## Overview
+
+Qwen3.8-Flash-Next is an open-weights preview of the architecture underlying **Qwen4**, published by Alibaba's Qwen team in August 2026 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next); [Qwen blog](https://qwen.ai/blog?id=qwen3.8-flash-next)). Qwen frames the release as deliberately architectural rather than a scaling exercise: the card describes the design as emphasising "architectural innovation for sustainable AGI progress, departing from the scaling-focused approach of simply increasing parameters and context windows" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)). The stated purpose of shipping it early is to give the developer community time to prepare for the full Qwen4 family ([TechNode](https://technode.com/2026/08/26/alibabas-qwen-to-open-source-qwen3-8-flash-next-previewing-qwen4-architecture/)).
+
+The parameter count needs care. The card leads with "125B with 6B activated", but that figure covers the main model only. A **51B n-gram embedding table** brings the total to **176B**, and a separate **4B MTP head** sits outside both numbers ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8)). Reading the headline alone understates the checkpoint by roughly a third, which matters for capacity planning even though the n-gram table is a lookup rather than a compute-bearing parameter block.
+
+Weights ship under the `qwen-community-1.0` license, in BF16 and in an FP8 checkpoint that uses fine-grained quantization with a block size of 128; Qwen states the FP8 build's "performance metrics are nearly identical to those of the original model" ([Qwen3.8-Flash-Next-FP8 card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8)). Thinking mode is enabled by default, emitting `<think>...</think>` blocks, and is configurable through `enable_thinking`, `preserve_thinking` and `reasoning_effort`; preserved thinking retains reasoning blocks across conversation history by default ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+
+On InferenceX the model is benchmarked on the [AgentX](/glossary/agentx) agentic-traces scenario rather than fixed sequence lengths, served by SGLang with native NEXTN [multi-token prediction](/glossary/multi-token-prediction). Hopper cannot run the NVFP4 checkpoint — there are no SM100 tensor cores on sm_90 — so H200 serves the FP8 weights while Blackwell parts serve `RadixArk/Qwen3.8-Flash-Next-NVFP4`.
+
+## Architecture
+
+- **Total / active parameters:** 176B total — a 125B main model plus a 51B n-gram embedding table — with 6B activated per forward pass, and a further 4B in the MTP head ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Layers:** 48 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Hidden layout:** `12 × (3 × (Gated DeltaNet → MoE) → 1 × (Qwen Sparse Attention → MoE))` — a 3:1 linear-to-sparse-attention hybrid ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Hidden dimension:** 2560 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Gated DeltaNet (linear attention):** 48 value heads, 16 QK heads, head dimension 128 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Qwen Sparse Attention (full attention):** 24 Q heads, 2 KV heads, head dimension 256, rotary position embedding dimension 64 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **QSA indexer:** MQA with 4 query heads and 1 shared key head, indexer head dimension 128, budget of "512 blocks or 2048 tokens" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **MoE experts:** 512 experts, 10 routed + 1 shared activated per token, expert intermediate dimension 640 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **N-gram embedding:** 20,000,000 bigram/trigram embeddings applied at layer 2 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Gated residual:** 4 branches, bottleneck rank 320 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **MTP:** 1 layer, trained with multi-steps ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Vocabulary:** 248,320 (padded) ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Context window:** 262,144 tokens native, extensible up to 1,000,000 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **Precision:** BF16 weights, plus an FP8 checkpoint using fine-grained quantization at block size 128 ([Qwen3.8-Flash-Next-FP8 card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8))
+- **License:** `qwen-community-1.0` ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next))
+
+## The Qwen4 architecture innovations
+
+Four changes distinguish this checkpoint from Qwen3.5 and the Qwen3-Next line it descends from. Each one attacks a different cost in the serving loop, which is why the model is interesting on a benchmark that measures whole systems rather than kernels.
+
+### N-gram embedding: parameter scaling that is not MoE
+
+The headline idea is a second axis for adding parameters. Qwen describes the n-gram table as "a unique axis for parameter scaling that requires less computation" than mixture-of-experts, achieving "highly efficient parameter scaling for memory-constrained accelerators" by "indexing with short n-grams" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+
+The mechanics matter for anyone sizing a deployment. Twenty million bigram and trigram embeddings are applied at layer 2, contributing 51B parameters — more than 40% of the checkpoint's non-MTP weight — while adding a table lookup rather than a matrix multiply. MoE buys capacity by activating more experts, which costs both memory bandwidth and all-to-all traffic when experts are sharded; an n-gram table buys capacity by growing a structure that is read, not computed. On an accelerator where HBM capacity binds before FLOPS do, those are very different trades.
+
+It also changes what "active parameters" means as a proxy for cost. Six billion active parameters implies a very cheap forward pass, and for the MoE and attention stack it is; the n-gram table is capacity you pay for in memory footprint rather than in arithmetic per token.
+
+### Qwen Sparse Attention: sparsity at the micro-block level
+
+QSA replaces the Gated Attention layers of Qwen3.5's hybrid with a sparse mechanism that "operates at the micro-block level" rather than per token, which the card says "cuts long-context latency significantly" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+
+The selection machinery is small and explicit: an MQA indexer with 4 query heads and a single shared key head, head dimension 128, choosing under a fixed budget of 512 blocks or 2048 tokens. A bounded budget is the operationally important part. Attention cost stops growing with context length once the budget binds, so the per-token cost of a 200k-token session converges toward the cost of a much shorter one, and long-context [interactivity](/glossary/interactivity) stops degrading the way a dense-attention model's does.
+
+Sparsity of this kind is a systems claim as much as a modelling one. As InferenceX has repeatedly found with [sparse attention](/glossary/sparse-attention) stacks, theoretical sparsity says little about realised speed: index construction, irregular memory access, kernel fusion and precision support decide what actually arrives, which is why the benchmark pins engine and image versions alongside the model.
+
+### Gated residual: finer control across a widened residual stream
+
+The gated residual "modulates information flowing through widened residual streams via an element-wise, data-dependent read gate and per-branch scalar write gate", which Qwen says provides "finer-grained expressiveness across layers while preserving training stability and keeping inference overhead low" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)). The configuration is 4 branches at bottleneck rank 320.
+
+The read gate is element-wise and data-dependent; the write gate is a single scalar per branch. That asymmetry is the design: expressive where it is cheap to be expressive, and deliberately coarse where per-element parameters would add inference cost for little return.
+
+### The hybrid ratio and MTP, carried forward
+
+Two elements are inherited rather than new, and both matter for how the model serves. The 3:1 interleave of Gated DeltaNet to full-attention layers is the same ratio Qwen3.5 uses, keeping most layers on [linear attention](/glossary/linear-attention) whose state does not grow with sequence length. And the model ships a 1-layer MTP head trained with multiple steps, exposed by SGLang as native NEXTN [speculative decoding](/glossary/speculative-decoding).
+
+MTP is the piece with the largest effect on measured throughput, and also the one most sensitive to how it is benchmarked. AgentX replays anonymized traces filled with synthetic tokens, so a speculator would accept an unrepresentative number of draft tokens if left to the content; runs therefore apply a fixed [acceptance length](/glossary/acceptance-length) measured separately, which for this model at MTP=3 was 3.24 with thinking off.
+
+### Training recipe
+
+Qwen also reports optimizer-level changes: Muon and AdamW applied to specific weight categories, and the elimination of traditional batch-size warmups in favour of starting directly at the target batch size, which "substantially reduces total optimizer steps" ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)). This has no bearing on inference performance, but it is part of what Qwen means by previewing Qwen4 rather than shipping a larger Qwen3.
+
+## Official vendor eval scores
+
+All values below are Qwen-reported for Qwen3.8-Flash-Next as published on the Hugging Face model card. The card's own comparison columns name Qwen3.8-27B, Qwen3.7-Plus and DeepSeek-V4-Flash; those are omitted here in favour of the cross-page Nemotron 3 Ultra reference.
+
+| Benchmark                    | Score     | Nemotron3 Ultra     | % better | Source                                                          |
+| ---------------------------- | --------- | ------------------- | -------- | --------------------------------------------------------------- |
+| GPQA Diamond                 | 91.7      | 87.0 (no tools)     | +5.4%    | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| LiveCodeBench v6             | 91.9      | 89.0 (v6)           | +3.3%    | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| SWE-bench Multilingual       | 81.0      | 67.7                | +19.6%   | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| SWE-bench Pro                | 62.5      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| IFBench                      | 81.3      | 81.7 (prompt loose) | -0.5%    | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| DeepSWE 1.1                  | 58.7      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| Toolathlon Verified          | 73.5      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| CoWorkBench                  | 73.9      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| JobBench                     | 55.7      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| Agents' Last Exam (Pass@1)   | 25.2      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| ClawEval-MM (Pass@3)         | 64.4      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| AndroidWorld                 | 84.5      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| OSWorld 2.0 (Binary/Partial) | 19.4/52.3 | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| Vision2Web                   | 64.0      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| ERQA                         | 72.3      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| LVBench                      | 76.6      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| RealWorldQA                  | 88.5      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| RecreationBench              | 49.9      | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| MathVision (Without/With CI) | 90.6/95.7 | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+| CharXiv RQ (Without/With CI) | 84.6/90.6 | n.a.                | —        | [HF model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next) |
+
+Nemotron 3 Ultra figures are the vendor-reported numbers from the [NVIDIA Nemotron 3 Ultra model card](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16), shown as a common reference point across model pages. `n.a.` means NVIDIA does not report that benchmark, or reports a different variant of it that would not be a like-for-like comparison. **% better** is `(score − Nemotron) / Nemotron`, computed only where both sides are a plain number on the same metric; a rating scale, a range, or a prose cell shows `—` instead. Neither column is a head-to-head evaluation: each score is self-reported by its own vendor under its own harness.
+
+## Benchmark explanations
+
+- **GPQA Diamond** — graduate-level, Google-proof multiple-choice questions in biology, chemistry and physics written by domain PhDs ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **LiveCodeBench v6** — contamination-controlled competitive-programming problems collected over time; measures code generation correctness ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **SWE-bench Multilingual** — real GitHub issue resolution extended beyond Python to repositories in multiple programming languages ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **SWE-bench Pro** — a harder issue-resolution set than SWE-bench Verified, with longer and more involved patches ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **DeepSWE 1.1** — agentic software-engineering tasks scored on whether the agent's changes resolve the task end to end ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **Toolathlon Verified** — verified subset of multi-tool agentic tasks, scoring correct tool selection and sequencing ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **CoWorkBench / JobBench** — workplace-style agentic task suites measuring completion of realistic multi-step office and job workflows ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **Agents' Last Exam** — very hard agentic tasks designed to remain unsolved by current systems; reported Pass@1 ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **IFBench** — instruction-following accuracy under explicit constraints ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **AndroidWorld / OSWorld 2.0** — GUI-agent benchmarks driving a real Android environment and a real desktop OS respectively; OSWorld reports binary and partial credit ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **Vision2Web / ClawEval-MM / RecreationBench** — multimodal agentic and understanding suites over web pages and visual scenes ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **LVBench / RealWorldQA / ERQA** — long-video understanding, real-world visual question answering, and embodied reasoning question answering ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+- **MathVision / CharXiv RQ** — visual mathematics and chart-reasoning benchmarks, each reported with and without a code interpreter ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)).
+
+## Caveats
+
+- **The 125B figure is the main model, not the checkpoint.** Total parameters are 176B once the 51B n-gram embedding table is counted, with a further 4B in the MTP head ([Hugging Face model card](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8)).
+- **All eval scores are vendor-reported**, produced by Qwen under its own harness. The card's comparison columns are also Qwen's own selection of rivals.
+- **Precision differs by chip generation.** Hopper has no NVFP4 path, so H200 results use the FP8 checkpoint while Blackwell results use NVFP4. Compare across chips with that in mind.
+- **The acceptance length used for MTP is measured separately**, not derived from the replayed traces, because AgentX content is synthetic. The interim value at the first sweep was 3.24 at MTP=3, collected with thinking off.
+- **This is an architecture preview.** Qwen positions the checkpoint as an early look at Qwen4 rather than a finished flagship, and engine support was days old at first benchmark, so results should be expected to move as kernels mature.

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -21,8 +21,9 @@ const PLATFORM_HEADERS = [
 ];
 
 const SINGLE_TURN = 'single_turn_8k1k';
-/** Five models, three of them with both a single-turn and an AgentX row. */
-const MATRIX_ROWS = 8;
+/** Six models: three with both a single-turn and an AgentX row, and three
+ *  curated AgentX-only (Kimi K3, GLM 5.2, Qwen3.8-Flash-Next). */
+const MATRIX_ROWS = 9;
 const AGENTX = 'agentx';
 const AGENTX_LABEL = 'Long Context Multi-Turn Realistic Agentic Scenario (AgentX)';
 const AGENTX_LABEL_ZH = '长上下文、多轮交互的真实智能体场景（AgentX）';

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -668,7 +668,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    sourceSha256: 'd31d0d0601b077836562dc032cc81b47ca66f1497a2c2ee98e2f90f73dcb1e25',
+    sourceSha256: '02ea8d9b72210c7dec8380ec3a4ff30a41254901e4d63a230cba893fc0473811',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -170,15 +170,14 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
   [Model.Qwen3_5]: { label: 'Qwen3.5 397B', prefix: 'qwen3.5', category: 'default' },
   // 176B total: a 125B main model plus a 51B n-gram embedding table, 6B active
   // per forward pass, and a separate 4B MTP head the parameter count excludes.
-  // Experimental rather than default while the only data is the day-zero H200
-  // FP8 agentic arm: `default` would seat it in the /overview matrix, which is
-  // built from DEFAULT_MODELS and would render an empty fixed-sequence row for
-  // it. It stays fully selectable everywhere else, since MODEL_OPTIONS excludes
-  // only `hidden`. Promote to `default` once the sweep covers more chips.
+  // Default alongside the other current models, so it appears in the /overview
+  // matrix from day zero. The matrix is built from DEFAULT_MODELS, so its
+  // fixed-sequence row stays empty until the sweep covers 8k1k as well as the
+  // agentic scenario.
   [Model.Qwen3_8_Flash_Next]: {
     label: 'Qwen3.8 Flash Next 176B',
     prefix: 'qwen3.8next',
-    category: 'experimental',
+    category: 'default',
   },
   [Model.GptOss]: { label: 'gpt-oss 120B', prefix: 'gptoss', category: 'deprecated' },
   [Model.MiniMax_M2_5]: {

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -1336,9 +1336,12 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       overviewRowsFixture as unknown as Record<string, BenchmarkRow[]>,
     );
 
-    // Curated scenarios: DeepSeek, MiniMax and Qwen each get both rows, Kimi
+    // Curated scenarios: DeepSeek, MiniMax and Qwen3.5 each get both rows, Kimi
     // K3 and GLM are AgentX-only. Kimi K2.5 is absent — deprecated models are
     // not default models, and the matrix is built from DEFAULT_MODELS.
+    // Qwen3.8-Flash-Next is curated AgentX-only, like Kimi K3 and GLM: the
+    // model is benchmarked on agentic traces, so it must not claim a
+    // fixed-sequence row it will never fill.
     expect(page.models.map((m) => `${m.model}/${m.scenario}`)).toEqual([
       `${Model.DeepSeek_V4_Pro}/single_turn_8k1k`,
       `${Model.DeepSeek_V4_Pro}/agentx`,
@@ -1348,6 +1351,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       `${Model.GLM_5_2}/agentx`,
       `${Model.Qwen3_5}/single_turn_8k1k`,
       `${Model.Qwen3_5}/agentx`,
+      `${Model.Qwen3_8_Flash_Next}/agentx`,
     ]);
     expect(page.models.length).toBeGreaterThan(DEFAULT_MODELS.size);
     expect(page).not.toHaveProperty('datasetThroughDate');

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -333,7 +333,9 @@ export function overviewScenarioForModel(
     return 'single_turn_8k1k';
   }
   if (rows.some((row) => row.benchmark_type === 'agentic_traces')) return 'agentx';
-  return model === Model.Kimi_K3 || model === Model.GLM_5_2 ? 'agentx' : 'single_turn_8k1k';
+  return model === Model.Kimi_K3 || model === Model.GLM_5_2 || model === Model.Qwen3_8_Flash_Next
+    ? 'agentx'
+    : 'single_turn_8k1k';
 }
 
 /**
@@ -348,6 +350,7 @@ const OVERVIEW_MODEL_SCENARIOS: Partial<Record<Model, readonly OverviewScenario[
   [Model.Qwen3_5]: ['single_turn_8k1k', 'agentx'],
   [Model.Kimi_K3]: ['agentx'],
   [Model.GLM_5_2]: ['agentx'],
+  [Model.Qwen3_8_Flash_Next]: ['agentx'],
 };
 
 /** The scenarios this model gets a row for. Unlisted models keep the single


### PR DESCRIPTION
## Summary

Three changes that finish the Qwen3.8-Flash-Next addition started in #887.

## 1. `/model/qwen-3-8-flash-next` was a 404 — fixed

`getModelPageSlugs()` filters the compare slugs down to those that have a `content/models/<slug>.mdx`, and the model had none, so the route never generated. Adds the page, following the shape of the existing model deep-dives (Overview → Architecture → eval scores → benchmark explanations → caveats).

Verified: the page prerenders to `.next/server/app/model/qwen-3-8-flash-next.html` with all six sections present.

## 2. A Qwen4 architecture section, as the centrepiece

You asked for depth here, and it is the right emphasis: Qwen positions this checkpoint as *"architectural innovation for sustainable AGI progress, departing from the scaling-focused approach of simply increasing parameters and context windows."* The architecture is the reason to read about the model, so it gets its own section rather than a bullet list:

- **N-gram embedding as a second parameter-scaling axis** — 20,000,000 bigram/trigram embeddings at layer 2, contributing 51B parameters, which Qwen calls *"a unique axis for parameter scaling that requires less computation"* than MoE. The page draws out why that matters operationally: MoE buys capacity by activating more experts, paying memory bandwidth and all-to-all traffic; an n-gram table buys capacity with a lookup. On a part where HBM capacity binds before FLOPS, those are different trades — and it means "6B active" understates the memory footprint badly.
- **Qwen Sparse Attention** — selects at *"the micro-block level"* under a fixed budget of *"512 blocks or 2048 tokens"*, via an MQA indexer with 4 query heads and 1 shared key head. The page explains the consequence: once the budget binds, attention cost stops tracking context length, so long-context interactivity stops degrading the way dense attention does.
- **Gated residual** — *"element-wise, data-dependent read gate and per-branch scalar write gate"* over 4 branches at bottleneck rank 320, with a note on why the read/write asymmetry is the design.
- **The inherited pieces** — the 3:1 Gated DeltaNet to full-attention interleave carried from Qwen3.5, and the 1-layer multi-step MTP head, plus why AgentX applies a separately measured acceptance length to it rather than letting synthetic replay content decide.
- **Training recipe** — Muon and AdamW on specific weight categories, no batch-size warmup.

Every figure is cited to the model card. The vendor eval table carries the **Nemotron 3 Ultra** and **% better** columns per the convention merged in #876 — GPQA Diamond 91.7 (+5.4%), LiveCodeBench v6 91.9 (+3.3%), SWE-bench Multilingual 81.0 (+19.6%), IFBench 81.3 (−0.5%), with `n.a.` on the twelve benchmarks NVIDIA does not report.

## 3. `default` instead of `experimental`, and AgentX-only

Per your call, the model is promoted to `default` so it appears in the `/overview` matrix from day zero.

`default` on its own would have given it a **`single_turn_8k1k` row**, because an uncurated model falls back to the single data-derived scenario — and this model is benchmarked on agentic traces. So it also joins Kimi K3 and GLM 5.2 in `OVERVIEW_MODEL_SCENARIOS` as `['agentx']`, and in the fallback that picks a scenario for a model with no matching rows yet. It now contributes exactly one matrix row, on AgentX, rather than an empty fixed-sequence row.

## Notes for reviewers

- **The 125B trap is called out in the page itself**, not just in code comments. The card leads with "125B with 6B activated", which is the main model only; 176B is the checkpoint. The caveats section says so explicitly.
- **The Qwen blog is a client-rendered app** and returns no extractable content, so every architectural claim is sourced to the Hugging Face model cards instead, plus TechNode for the release timing.
- **Vendor-reported throughout.** Qwen's own card compares against Qwen3.8-27B, Qwen3.7-Plus and DeepSeek-V4-Flash; those columns are dropped in favour of the cross-page Nemotron reference, and the caveats say the scores are self-reported under Qwen's harness.
- The `api-route-catalog` digest for `overview-data.ts` is refreshed. Per AGENTS.md I checked first: the change touches only the curated model-to-scenario map, no BFF parameter or `OverviewPageData` field moved, and the API reference enumerates neither.

## Verification

- `bun run test:unit` — 4,419 app tests pass (246 files), all workspaces green
- `bun run build` — zero errors; `/model/qwen-3-8-flash-next` and its OG image both prerender
- Rendered HTML checked for the new sections and the computed deltas
- `lint`, `fmt`, `typecheck` clean, also via the pre-commit hook

## 中文说明

本 PR 完成 #887 开始的 Qwen3.8-Flash-Next 接入，共三处改动。

### 1. 修复 `/model/qwen-3-8-flash-next` 的 404

`getModelPageSlugs()` 只保留存在 `content/models/<slug>.mdx` 的 slug，而该模型此前没有内容文件，因此路由从未生成。本次新增该页面，沿用既有模型深度页的结构（概览 → 架构 → 厂商评测 → 基准说明 → 注意事项）。已验证页面成功预渲染为 `.next/server/app/model/qwen-3-8-flash-next.html`，六个章节齐全。

### 2. 以 Qwen4 架构一节为核心

这一强调是恰当的：Qwen 将该 checkpoint 定位为「面向可持续 AGI 进展的架构创新，而非单纯增加参数与上下文窗口的规模路线」。架构正是这个模型值得一读的原因，因此单独成节而非罗列要点：

- **n-gram embedding 作为第二条参数扩展轴** —— 第 2 层的 2000 万条 bigram/trigram、贡献 51B 参数，Qwen 称其为「一条计算量更低的参数扩展轴」。页面进一步说明其工程意义：MoE 通过激活更多专家换取容量，代价是显存带宽与 all-to-all 流量；n-gram 表则以查表换容量。在 HBM 容量先于算力成为瓶颈的硬件上，两者是完全不同的取舍，也意味着「6B 激活」会严重低估显存占用。
- **Qwen Sparse Attention** —— 在「512 blocks 或 2048 tokens」的固定预算下按微块选择，索引器为 4 query head、1 共享 key head 的 MQA。页面点明其后果：预算一旦生效，注意力开销不再随上下文长度增长，长上下文交互性也不会像稠密注意力那样劣化。
- **Gated residual** —— 4 分支、瓶颈秩 320，采用元素级数据相关读门与每分支标量写门，并解释这种读写不对称正是设计意图。
- **沿用的部分** —— 承自 Qwen3.5 的 3:1 Gated DeltaNet 混合结构，以及单层多步 MTP 头，并说明 AgentX 为何对其套用单独测量的接受长度。
- **训练配方** —— Muon 与 AdamW 按权重类别分别应用，取消 batch size 预热。

所有数据均引用 model card。厂商评测表按 #876 的约定附带 **Nemotron 3 Ultra** 与 **% better** 两列：GPQA Diamond 91.7（+5.4%）、LiveCodeBench v6 91.9（+3.3%）、SWE-bench Multilingual 81.0（+19.6%）、IFBench 81.3（−0.5%），NVIDIA 未公布的十二项标为 `n.a.`。

### 3. 改为 `default`，且仅 AgentX 场景

按你的决定，模型提升为 `default`，自首发起即出现在 `/overview` 矩阵中。但仅改为 default 会让它落入 **`single_turn_8k1k` 行**，因为未经策展的模型会回退到唯一由数据推导的场景，而该模型是基于 agentic trace 测试的。因此它同时与 Kimi K3、GLM 5.2 一并在 `OVERVIEW_MODEL_SCENARIOS` 中登记为 `['agentx']`，并同步调整了尚无匹配数据时选择场景的回退分支，最终只贡献一行 AgentX 矩阵行。

### 评审提示

- **125B 这个坑已写入页面本身**，而不只是代码注释：card 首行的「125B with 6B activated」仅指主模型，checkpoint 实为 176B，注意事项中已明确说明。
- **Qwen 官方博客是客户端渲染应用**，无法抓取内容，因此所有架构结论均引用 Hugging Face model card，发布时间引用 TechNode。
- **全部为厂商自报数据。** Qwen 自家 card 的对比列为 Qwen3.8-27B、Qwen3.7-Plus 与 DeepSeek-V4-Flash，本页改用跨页面统一的 Nemotron 参照，并在注意事项中说明分数由厂商在自有 harness 下自报。
- `overview-data.ts` 的 api-route-catalog 摘要哈希已更新；按 AGENTS.md 先行核查：本次仅改动模型到场景的策展映射，未涉及任何 BFF 参数或 `OverviewPageData` 字段，API 参考也未枚举这些内容。

### 验证

- `bun run test:unit` — app 端 4,419 项测试通过（246 个文件），各 workspace 全部通过
- `bun run build` — 零报错；`/model/qwen-3-8-flash-next` 及其 OG 图均成功预渲染
- 已检查渲染后的 HTML，确认新增章节与计算出的差距数值
- `lint`、`fmt`、`typecheck` 均通过（pre-commit hook 亦已执行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and curated overview scenario mapping only; no API contract or benchmark pipeline changes beyond showing one additional default-matrix row.
> 
> **Overview**
> Adds **`content/models/qwen-3-8-flash-next.mdx`** so `/model/qwen-3-8-flash-next` can prerender (it was missing from `getModelPageSlugs()`’s MDX filter). The page follows the usual deep-dive shape: overview, Qwen4 architecture (n-gram table, QSA, gated residual, hybrid/MTP), vendor eval table with Nemotron 3 Ultra / % better columns, benchmark notes, and caveats (176B vs 125B headline, chip precision split, MTP acceptance length).
> 
> **Overview integration:** `Qwen3.8-Flash-Next` moves from **`experimental` to `default`** in `data-mappings.ts` so it appears in the default matrix. It is curated as **AgentX-only** in `OVERVIEW_MODEL_SCENARIOS` and the scenario fallback (with Kimi K3 and GLM 5.2), avoiding an empty `single_turn_8k1k` row. Unit tests and Cypress expect **9** matrix rows; `api-route-catalog` digest for `overview-data.ts` is refreshed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25c8bed99e976a419f529af7c1cfc24fc8549d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->