### PR TITLE
Refine Fleet Lifecycle defaults / 优化集群生命周期默认值

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -375,8 +375,9 @@ Four conventions the numbers depend on:
   energised, not from the moment they are loaded. So the opening rollout is paid for
   in full while it earns its way up from zero, which is what puts the first months
   below the rule and gives payback its meaning.
-- **The ramp is an assumption; the steps are not.** It defaults to a nominal
-  quarter (`c_ramp`), and 0 means every config takes effect instantly.
+- **The ramp is an assumption; the steps are not.** It defaults to half a month
+  (`c_ramp`) and moves in quarter-month increments; 0 means every config takes
+  effect instantly.
 - **Markers sit at the release instant** — the foot of each rollout, not its top —
   so every dot on the chart is a sweep the user can open.
 - **Interrupts are an availability haircut, not drawn events.** A 24-day MTBI
@@ -980,6 +981,6 @@ against that allowlist so a stale or hand-edited link falls back to `margin` rat
 than seeding an unknown metric).
 The first two default to
 `''` in `PARAM_DEFAULTS` because their real defaults are derived, not constant — see
-the comment there. The MW budget is
-`c_mw`, owned by `ThroughputCalculatorDisplay` and passed to both the fleet
-planner and this section so one input drives both.
+the comment there. The MW budget is `c_mw`, defaults to 10 MW, and is shared by
+the calculator and Fleet Lifecycle page so a budget set on either seeds the
+other.

--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -55,7 +55,7 @@ const showChart = () => cy.get('[data-testid="calculator-lifecycle-chart-view-bt
  * state. Without this, a test that reads the table leaves the next one looking
  * for a chart that is not mounted — an ordering coupling that fails in whichever
  * order the file happens to be written in. Tolerant of the tab not existing yet:
- * before a power budget is entered there is no figure at all.
+ * when the power budget is cleared there is no figure at all.
  */
 const resetToChart = () =>
   cy.get('body').then(($body) => {
@@ -162,25 +162,16 @@ describe('Fleet — Fleet Lifecycle', () => {
 
   beforeEach(resetToChart);
 
-  it('renders the section with a prompt for a power budget, and fetches nothing yet', () => {
+  it('defaults the power budget to 10 MW and renders the lifecycle', () => {
     cy.get('[data-testid="calculator-lifecycle-section"]')
       .should('be.visible')
       .and('contain.text', 'Fleet Lifecycle');
-    cy.get('[data-testid="calculator-lifecycle-empty"]')
-      .should('be.visible')
-      .and('contain.text', 'Enter a facility power budget');
-    // The history payload is multi-MB, so it must not be requested until the
-    // section can produce something.
-    cy.get('[data-testid="calculator-lifecycle-table"]').should('not.exist');
+    cy.get('[data-testid="calc-fleet-mw-input"]').should('have.value', '10');
+    cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
+    cy.get('[data-testid="calculator-lifecycle-empty"]').should('not.exist');
   });
 
-  it('entering a MW budget in this section drives the lifecycle table', () => {
-    // The input lives here now: it used to sit in a separate Fleet Projection
-    // section, which is what made the empty state above have to point at another
-    // part of the page.
-    cy.get('[data-testid="calculator-lifecycle-section"]')
-      .find('[data-testid="calc-fleet-mw-input"]')
-      .type('10');
+  it('the default MW budget drives the lifecycle table', () => {
     // The figure opens on the chart; the table is the other tab.
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
     cy.get('[data-testid="calculator-lifecycle-table"]').should('not.exist');
@@ -645,7 +636,9 @@ describe('Fleet — Fleet Lifecycle', () => {
   it('rolls each config out over the ramp instead of stepping instantly', () => {
     // Reads both views, so it switches deliberately: `firstRowCell` moves to the
     // table, and the vertex counts are only meaningful on the chart.
-    cy.get('[data-testid="calc-lifecycle-ramp-input"]').should('have.value', '3');
+    cy.get('[data-testid="calc-lifecycle-ramp-input"]')
+      .should('have.value', '0.5')
+      .and('have.attr', 'step', '0.25');
     lineVertices().then((curved) => {
       // Rollouts are sampled into curves, so the line cannot be a bare staircase.
       expect(curved).to.be.greaterThan(20);
@@ -899,7 +892,7 @@ describe('Fleet — Fleet Lifecycle with agentic traces', () => {
     // The agentic fixture exposes a single scenario, so the scenario
     // control disappears entirely — no dropdown, no static readout.
     cy.get('[data-testid="scenario-static-value"]').should('not.exist');
-    cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
+    cy.get('[data-testid="calc-fleet-mw-input"]').should('have.value', '10');
     cy.wait('@agenticHistory');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
     showTable();
@@ -977,8 +970,8 @@ describe('Fleet — Fleet Lifecycle in Chinese', () => {
   it('translates the section, including the table headers and notes', () => {
     cy.get('[data-testid="calculator-lifecycle-section"]')
       .should('contain.text', '集群生命周期')
-      .and('contain.text', '设施功率预算');
-    cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
+      .and('contain.text', '设施功率 (MW)');
+    cy.get('[data-testid="calc-fleet-mw-input"]').should('have.value', '10');
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('be.visible');
     // The caption's price line is translated too, units and all.
     cy.get('[data-testid="calculator-lifecycle-figure"]').should('contain', '每百万 token');

--- a/packages/app/cypress/e2e/jalapeno-preview-notice.cy.ts
+++ b/packages/app/cypress/e2e/jalapeno-preview-notice.cy.ts
@@ -103,7 +103,7 @@ describe('official preview notices', () => {
     cy.get('[role="option"]').contains('Output Tokens').click();
     cy.get('[data-testid="fleet-legend"]', { timeout: 20000 }).should('contain.text', 'Vera Rubin');
     cy.get('[data-testid="fleet-controls"] input[type="number"]').clear().type('100').blur();
-    cy.get('[data-testid="calc-fleet-mw-input"]').type('10');
+    cy.get('[data-testid="calc-fleet-mw-input"]').should('have.value', '10');
     cy.get(VERA_RUBIN_NOTICE, { timeout: 20000 })
       .should('be.visible')
       .and('contain.text', 'Vera Rubin (July) results are an official preview')

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -774,7 +774,7 @@ describe('TCO Calculator', () => {
     it('owns the MW budget input now that the lifecycle section moved to /fleet', () => {
       cy.get('[data-testid="calculator-costcap-section"]')
         .find('[data-testid="calc-costcap-mw-input"]')
-        .should('exist');
+        .should('have.value', '10');
       cy.get('[data-testid="calculator-lifecycle-section"]').should('not.exist');
       // A pointer to the new page replaces the section.
       cy.get('[data-testid="calculator-fleet-pointer-link"]')

--- a/packages/app/src/components/calculator/FleetLifecycle.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycle.tsx
@@ -35,7 +35,7 @@ import {
   type Model,
   type Percentile,
 } from '@/lib/data-mappings';
-import { readUrlParams, writeUrlParams } from '@/lib/url-state';
+import { DEFAULT_LIFECYCLE_RAMP_MONTHS, readUrlParams, writeUrlParams } from '@/lib/url-state';
 import { useLocale } from '@/lib/use-locale';
 import { getDisplayLabel } from '@/lib/utils';
 
@@ -335,9 +335,9 @@ const STRINGS = {
 const DEFAULTS = {
   mtbiDays: 24,
   recoveryHours: 12,
-  // A nominal quarter to bring a fleet to full load. Purely an assumption, and
-  // labelled as one — no measurement in this repo speaks to it.
-  rampMonths: 3,
+  // A nominal half-month to bring a fleet to full load. Purely an assumption,
+  // and labelled as one — no measurement in this repo speaks to it.
+  rampMonths: Number(DEFAULT_LIFECYCLE_RAMP_MONTHS),
   /**
    * A cached input token sells for a tenth of a fresh one — the ratio DeepSeek
    * and Anthropic both publish, and the order of magnitude the others sit at.
@@ -1343,7 +1343,7 @@ export default function FleetLifecycle({
                 data-testid={`${input.id}-input`}
                 type="number"
                 min={0}
-                step="any"
+                step={input.id === 'calc-lifecycle-ramp' ? 0.25 : 'any'}
                 value={input.value}
                 onChange={input.onChange}
                 className="w-32 h-9"

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -39,7 +39,7 @@ import { useUrlState } from '@/hooks/useUrlState';
 import { track } from '@/lib/analytics';
 import { getModelSortIndex } from '@/lib/constants';
 import { Percentile, Sequence, type Model } from '@/lib/data-mappings';
-import { readUrlParams, writeUrlParams } from '@/lib/url-state';
+import { DEFAULT_FLEET_MW, readUrlParams, writeUrlParams } from '@/lib/url-state';
 import { useFeatureGate } from '@/lib/use-feature-gate';
 import { useLocale } from '@/lib/use-locale';
 import { getDisplayLabel } from '@/lib/utils';
@@ -154,7 +154,7 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
   const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
   // Owned here so the `c_mw` URL seed is read once, at the page level — the
   // lifecycle section renders the input and is its only consumer.
-  const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? '');
+  const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? DEFAULT_FLEET_MW);
   const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
   const [highContrast, setHighContrast] = useState(false);
 

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -49,7 +49,7 @@ import {
 import { useUnofficialRun } from '@/components/unofficial-run-provider';
 import { overlayRunColor } from '@/lib/overlay-run-style';
 import { localePath } from '@/lib/i18n';
-import { readUrlParams, writeUrlParams } from '@/lib/url-state';
+import { DEFAULT_FLEET_MW, readUrlParams, writeUrlParams } from '@/lib/url-state';
 import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MultiSelect } from '@/components/ui/multi-select';
@@ -364,7 +364,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
   // The `c_mw` URL seed is read once here; the cost-target panel renders the
   // input and consumes the budget. The Fleet Lifecycle page shares the param.
-  const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? '');
+  const [mwInput, setMwInput] = useState<string>(() => readUrlParams().c_mw ?? DEFAULT_FLEET_MW);
   const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
   const [barSelectionIntent, setBarSelectionIntent] = useState<{
     resultsKey: string;

--- a/packages/app/src/components/calculator/lifecycle.ts
+++ b/packages/app/src/components/calculator/lifecycle.ts
@@ -35,7 +35,7 @@
  *    is paid for in full while it earns its way up from zero, which is what puts
  *    the opening months below the rule and gives payback its meaning.
  * 2. **The ramp is an assumption; the steps are not.** Ramp length is a user
- *    input, defaulting to a nominal quarter, and it applies to every rollout.
+ *    input, defaulting to half a month, and it applies to every rollout.
  *    Which configs exist, when, and how fast they ran are all measured.
  * 3. **Interrupts are an availability haircut, not drawn events.** A 24-day MTBI
  *    over a multi-year window is thousands of events, each far under a pixel, so

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -82,9 +82,13 @@ describe('PARAM_DEFAULTS', () => {
     expect(PARAM_DEFAULTS.r_active).toBe('');
   });
 
-  it('has empty string defaults for calculator fleet-planner params', async () => {
-    const { PARAM_DEFAULTS } = await import('@/lib/url-state');
-    expect(PARAM_DEFAULTS.c_mw).toBe('');
+  it('keeps the fleet defaults aligned with URL-state stripping', async () => {
+    const { DEFAULT_FLEET_MW, DEFAULT_LIFECYCLE_RAMP_MONTHS, PARAM_DEFAULTS } =
+      await import('@/lib/url-state');
+    expect(DEFAULT_FLEET_MW).toBe('10');
+    expect(DEFAULT_LIFECYCLE_RAMP_MONTHS).toBe('0.5');
+    expect(PARAM_DEFAULTS.c_mw).toBe(DEFAULT_FLEET_MW);
+    expect(PARAM_DEFAULTS.c_ramp).toBe(DEFAULT_LIFECYCLE_RAMP_MONTHS);
     expect(PARAM_DEFAULTS.c_costcap).toBe('');
   });
 });
@@ -453,7 +457,7 @@ describe('buildShareUrl tab filtering', () => {
       g_model: 'x',
       i_seq: 'y',
       i_pctl: 'p75',
-      c_mw: '10',
+      c_mw: '20',
       c_costcap: '0.5',
       r_range: 'last-7-days',
     });
@@ -463,7 +467,7 @@ describe('buildShareUrl tab filtering', () => {
     expect(url).toContain('g_model=x');
     expect(url).toContain('i_seq=y');
     expect(url).toContain('i_pctl=p75');
-    expect(url).toContain('c_mw=10');
+    expect(url).toContain('c_mw=20');
     expect(url).toContain('c_costcap=0.5');
     expect(url).not.toContain('r_range');
   });

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -107,6 +107,10 @@ export type UrlStateParams = Partial<Record<UrlStateKey, string>>;
  */
 export const DEFAULT_Y_AXIS_METRIC = 'y_tokensPerDollarN';
 
+/** Shared defaults for the fleet lifecycle and calculator MW controls. */
+export const DEFAULT_FLEET_MW = '10';
+export const DEFAULT_LIFECYCLE_RAMP_MONTHS = '0.5';
+
 export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   g_model: 'DeepSeek-V4-Pro',
   g_rundate: '',
@@ -162,7 +166,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   r_hc: '',
   r_legend: '',
   r_active: '',
-  c_mw: '',
+  c_mw: DEFAULT_FLEET_MW,
   c_costcap: '',
   // Empty means "use the component's default", which for these two is derived
   // rather than constant: the price from the cheapest visible chip's break-even,
@@ -173,7 +177,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   c_life: '',
   // Empty means the default y metric (margin).
   c_ly: '',
-  c_ramp: '3',
+  c_ramp: DEFAULT_LIFECYCLE_RAMP_MONTHS,
   c_cache: '10',
   c_mtbi: '24',
   c_rec: '12',


### PR DESCRIPTION
## Summary

- Default the facility power budget to 10 MW.
- Default ramp time to 0.5 months with 0.25-month increments.
- Keep URL state, documentation, and regression coverage aligned.

## Testing

- bun run typecheck
- bun run test:unit
- bun run test:e2e
- Focused Fleet Lifecycle and calculator Cypress specs

## 中文说明

- 将设施功率预算默认值设为 10 MW。
- 将爬坡期默认值设为 0.5 个月，步进设为 0.25 个月。
- 同步更新 URL 状态、文档与回归测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default fleet sizing and lifecycle economics on first load (10 MW and a much shorter ramp), which shifts projected margins until users override; URL default stripping behavior for `c_mw`/`c_ramp` also changes.
> 
> **Overview**
> **Facility power (`c_mw`)** now defaults to **10 MW** on the calculator cost-target panel and the `/fleet` lifecycle page, via shared constants in `url-state.ts`. Visiting `/fleet` no longer starts in an empty “enter a power budget” state; clearing the field still restores that empty state. **`c_mw` is still one URL param** so a budget set on either page seeds the other.
> 
> **Lifecycle rollout ramp (`c_ramp`)** defaults to **0.5 months** (was 3), with the ramp input stepped in **0.25-month** increments. `FleetLifecycle` and the TCO docs/comments in `lifecycle.ts` match this.
> 
> **Regression coverage** updates Fleet Lifecycle, calculator cost-target, and preview-notice Cypress specs, plus `url-state` unit tests so `PARAM_DEFAULTS` stays aligned with stripping for share links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b5224255701984f824f4080a2b07d2aebe7fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->