### PR TITLE
style(app): format stale-url regression test / 格式化 stale-url 回归测试文件

### DIFF
--- a/packages/app/src/components/GlobalFilterContext.stale-url.test.tsx
+++ b/packages/app/src/components/GlobalFilterContext.stale-url.test.tsx
@@ -33,9 +33,7 @@ const mocks = vi.hoisted(() => ({
     isLoading: false,
     error: null as Error | null,
   },
-  getUrlParam: vi.fn((key: string): string | undefined =>
-    key === 'i_seq' ? '8k/1k' : undefined,
-  ),
+  getUrlParam: vi.fn((key: string): string | undefined => (key === 'i_seq' ? '8k/1k' : undefined)),
   setUrlParams: vi.fn(),
   hasExplicitUrlParam: vi.fn((_key: string) => false),
 }));


### PR DESCRIPTION
Follow-up to #890: the regression test file landed unformatted (oxfmt `--check` failure on master). One-line reformat, no behavior change. `bun run fmt`, `bun run lint`, and `tsc --noEmit` all pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only whitespace/formatting with no runtime or test logic changes.
> 
> **Overview**
> **Formatting-only** fix for `GlobalFilterContext.stale-url.test.tsx` so it passes `oxfmt --check` (follow-up to #890).
> 
> The hoisted mock’s `getUrlParam` `vi.fn` callback is collapsed from a multi-line arrow function to a single-line expression; mock behavior and regression coverage are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67024a68375023a2f000d6c649ceb191211ca21d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->