### PR TITLE
[app] Add full-color hardware-vendor logos to chart line labels / 图表曲线标签新增全彩硬件厂商 Logo

### DIFF
--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/lib/data-mappings';
 import { matchKnownConfigIssues, pointMatchesIssue } from '@/lib/known-issues';
 import { useLocale } from '@/lib/use-locale';
+import { getLineLabelVendorIcon } from '@/lib/vendor-logos';
 import { formatNumber, getDisplayLabel, updateRepoUrl } from '@/lib/utils';
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
 import type {
@@ -2261,6 +2262,7 @@ const ScatterGraph = React.memo(
 
           renderLineLabels(zoomGroup, lineLabels, {
             seriesAttribute: 'data-hw-key',
+            iconFor: (label) => getLineLabelVendorIcon(label.seriesId),
             configureGroup: (labelGroup, label) => {
               labelGroup
                 .attr('data-visible', label.visible ? '1' : '0')

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -266,6 +266,25 @@ function yScaleRange(scale: (value: number) => number): [number, number] | null 
     : null;
 }
 
+/** Full-color icon rendered on a white chip at the left edge of a pill. */
+export interface LineLabelIconSpec {
+  href: string;
+  width: number;
+  height: number;
+}
+
+/** Padding between a label icon's chip edge and the mark inside it. */
+const ICON_CHIP_PAD = 2;
+/** Gap between the icon chip and the label text. */
+const ICON_TEXT_GAP = 4;
+/** Icon chip height — matches the pill's inner height at the 10px font. */
+const ICON_CHIP_HEIGHT = 14;
+
+/** Horizontal space an icon occupies to the left of the label text. */
+function iconSpace(icon: LineLabelIconSpec | undefined): number {
+  return icon ? icon.width + ICON_CHIP_PAD * 2 + ICON_TEXT_GAP : 0;
+}
+
 export function renderLineLabels(
   group: d3.Selection<SVGGElement, unknown, null, undefined>,
   labels: readonly LineLabelPlacement[],
@@ -274,6 +293,8 @@ export function renderLineLabels(
     opacity?: number;
     offsetX?: number;
     offsetY?: number;
+    /** Optional full-color icon (e.g. vendor mark) per label. */
+    iconFor?: (label: LineLabelPlacement) => LineLabelIconSpec | undefined;
     configureText?: (
       text: d3.Selection<SVGTextElement, LineLabelPlacement, null, undefined>,
       label: LineLabelPlacement,
@@ -320,6 +341,11 @@ export function renderLineLabels(
     const labelGroup = d3.select<SVGGElement, LineLabelPlacement>(this);
     options.configureGroup?.(labelGroup, label);
     const text = labelGroup.select<SVGTextElement>('.ll-text');
+    // Shift the text right to leave room for the icon chip; the background
+    // sizing pass below expands the pill back over that space.
+    const space = iconSpace(options.iconFor?.(label));
+    if (space > 0) text.attr('x', space);
+    else text.attr('x', null);
     if (options.configureText) options.configureText(text, label);
     else text.text(label.label);
   });
@@ -330,13 +356,46 @@ export function renderLineLabels(
     if (text) measured.push({ node: this, label, bbox: text.getBBox() });
   });
   for (const { node, label, bbox } of measured) {
-    d3.select(node)
+    const labelGroup = d3.select(node);
+    const icon = options.iconFor?.(label);
+    const space = iconSpace(icon);
+    labelGroup
       .select('.ll-bg')
-      .attr('x', bbox.x - 5)
+      .attr('x', bbox.x - space - 5)
       .attr('y', bbox.y - 3)
-      .attr('width', bbox.width + 10)
+      .attr('width', bbox.width + space + 10)
       .attr('height', bbox.height + 6)
       .attr('fill', label.color);
+
+    // White chip + full-color mark. The chip keeps official brand colors
+    // (NVIDIA green, AMD black) legible on any pill fill in both themes.
+    const chipData = icon ? [icon] : [];
+    const chipHeight = Math.max(ICON_CHIP_HEIGHT, Math.min(bbox.height + 2, 16));
+    const chipY = bbox.y + bbox.height / 2 - chipHeight / 2;
+    const chipX = bbox.x - space;
+    labelGroup
+      .selectAll<SVGRectElement, LineLabelIconSpec>('.ll-logo-chip')
+      .data(chipData)
+      .join('rect')
+      .attr('class', 'll-logo-chip')
+      .attr('rx', 3)
+      .attr('ry', 3)
+      .attr('fill', 'white')
+      .attr('x', chipX)
+      .attr('y', chipY)
+      .attr('width', (d) => d.width + ICON_CHIP_PAD * 2)
+      .attr('height', chipHeight);
+    labelGroup
+      .selectAll<SVGImageElement, LineLabelIconSpec>('.ll-logo')
+      .data(chipData)
+      .join('image')
+      .attr('class', 'll-logo')
+      .attr('href', (d) => d.href)
+      .attr('preserveAspectRatio', 'xMidYMid meet')
+      .attr('x', chipX + ICON_CHIP_PAD)
+      .attr('y', (d) => chipY + (chipHeight - d.height) / 2)
+      .attr('width', (d) => d.width)
+      .attr('height', (d) => d.height);
   }
 }
 

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -273,16 +273,12 @@ export interface LineLabelIconSpec {
   height: number;
 }
 
-/** Padding between a label icon's chip edge and the mark inside it. */
-const ICON_CHIP_PAD = 2;
-/** Gap between the icon chip and the label text. */
+/** Gap between the icon and the label text. */
 const ICON_TEXT_GAP = 4;
-/** Icon chip height — matches the pill's inner height at the 10px font. */
-const ICON_CHIP_HEIGHT = 14;
 
 /** Horizontal space an icon occupies to the left of the label text. */
 function iconSpace(icon: LineLabelIconSpec | undefined): number {
-  return icon ? icon.width + ICON_CHIP_PAD * 2 + ICON_TEXT_GAP : 0;
+  return icon ? icon.width + ICON_TEXT_GAP : 0;
 }
 
 export function renderLineLabels(
@@ -367,33 +363,17 @@ export function renderLineLabels(
       .attr('height', bbox.height + 6)
       .attr('fill', label.color);
 
-    // White chip + full-color mark. The chip keeps official brand colors
-    // (NVIDIA green, AMD black) legible on any pill fill in both themes.
-    const chipData = icon ? [icon] : [];
-    const chipHeight = Math.max(ICON_CHIP_HEIGHT, Math.min(bbox.height + 2, 16));
-    const chipY = bbox.y + bbox.height / 2 - chipHeight / 2;
-    const chipX = bbox.x - space;
-    labelGroup
-      .selectAll<SVGRectElement, LineLabelIconSpec>('.ll-logo-chip')
-      .data(chipData)
-      .join('rect')
-      .attr('class', 'll-logo-chip')
-      .attr('rx', 3)
-      .attr('ry', 3)
-      .attr('fill', 'white')
-      .attr('x', chipX)
-      .attr('y', chipY)
-      .attr('width', (d) => d.width + ICON_CHIP_PAD * 2)
-      .attr('height', chipHeight);
+    // Full-color mark drawn directly on the pill — transparent background, so
+    // the icon shares the label's own fill shade (including gradient fills).
     labelGroup
       .selectAll<SVGImageElement, LineLabelIconSpec>('.ll-logo')
-      .data(chipData)
+      .data(icon ? [icon] : [])
       .join('image')
       .attr('class', 'll-logo')
       .attr('href', (d) => d.href)
       .attr('preserveAspectRatio', 'xMidYMid meet')
-      .attr('x', chipX + ICON_CHIP_PAD)
-      .attr('y', (d) => chipY + (chipHeight - d.height) / 2)
+      .attr('x', bbox.x - space)
+      .attr('y', (d) => bbox.y + bbox.height / 2 - d.height / 2)
       .attr('width', (d) => d.width)
       .attr('height', (d) => d.height);
   }

--- a/packages/app/src/lib/vendor-logos.test.ts
+++ b/packages/app/src/lib/vendor-logos.test.ts
@@ -20,14 +20,17 @@ describe('vendor logo icons', () => {
     expect(getLineLabelVendorIcon('gb200_dynamo')).toBe(VENDOR_LOGO_ICONS.NVIDIA);
   });
 
-  it('returns no icon for unknown hardware or vendors without a public logo', () => {
+  it('maps Jalapeño (Teacup/OpenAI) to the OpenAI mark', () => {
+    expect(getLineLabelVendorIcon('jalapeno')).toBe(VENDOR_LOGO_ICONS.Teacup);
+  });
+
+  it('returns no icon for unknown hardware', () => {
     expect(getLineLabelVendorIcon('unknown-hw')).toBeUndefined();
-    // Anonymized preview silicon (Teacup Jalapeño) has no official mark.
-    expect(getLineLabelVendorIcon('jalapeno')).toBeUndefined();
   });
 
   it('inlines brand colors in the data URIs', () => {
     expect(decodeURIComponent(VENDOR_LOGO_ICONS.NVIDIA.href)).toContain('#76B900');
     expect(decodeURIComponent(VENDOR_LOGO_ICONS.AMD.href)).toContain('#000000');
+    expect(decodeURIComponent(VENDOR_LOGO_ICONS.Teacup.href)).toContain('#ffffff');
   });
 });

--- a/packages/app/src/lib/vendor-logos.test.ts
+++ b/packages/app/src/lib/vendor-logos.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { VENDOR_LOGO_ICONS, getLineLabelVendorIcon } from './vendor-logos';
+
+describe('vendor logo icons', () => {
+  it('maps NVIDIA hardware keys to the full-color NVIDIA mark', () => {
+    for (const key of ['gb300', 'gb200', 'b300', 'b200', 'h100', 'vr200']) {
+      expect(getLineLabelVendorIcon(key)).toBe(VENDOR_LOGO_ICONS.NVIDIA);
+    }
+  });
+
+  it('maps AMD hardware keys to the full-color AMD mark', () => {
+    for (const key of ['mi300x', 'mi325x', 'mi355x']) {
+      expect(getLineLabelVendorIcon(key)).toBe(VENDOR_LOGO_ICONS.AMD);
+    }
+  });
+
+  it('resolves suffixed hardware keys through the base key', () => {
+    expect(getLineLabelVendorIcon('mi355x_dsv4')).toBe(VENDOR_LOGO_ICONS.AMD);
+    expect(getLineLabelVendorIcon('gb200_dynamo')).toBe(VENDOR_LOGO_ICONS.NVIDIA);
+  });
+
+  it('returns no icon for unknown hardware or vendors without a public logo', () => {
+    expect(getLineLabelVendorIcon('unknown-hw')).toBeUndefined();
+    // Anonymized preview silicon (Teacup Jalapeño) has no official mark.
+    expect(getLineLabelVendorIcon('jalapeno')).toBeUndefined();
+  });
+
+  it('inlines brand colors in the data URIs', () => {
+    expect(decodeURIComponent(VENDOR_LOGO_ICONS.NVIDIA.href)).toContain('#76B900');
+    expect(decodeURIComponent(VENDOR_LOGO_ICONS.AMD.href)).toContain('#000000');
+  });
+});

--- a/packages/app/src/lib/vendor-logos.ts
+++ b/packages/app/src/lib/vendor-logos.ts
@@ -1,3 +1,5 @@
+import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
+
 /**
  * Maps `HW_REGISTRY` vendor names to logo files under `public/logos/`.
  *
@@ -19,7 +21,6 @@ export const HW_VENDOR_LOGOS: Record<string, string> = {
 export function getHwVendorLogo(vendor: string | undefined): string | undefined {
   return vendor ? HW_VENDOR_LOGOS[vendor] : undefined;
 }
-import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
 
 /**
  * Full-color hardware-vendor marks for chart line labels.
@@ -32,7 +33,11 @@ import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
  * Color notes (this is deliberate — do not swap in the monochrome
  * `public/logos/{nvidia,amd}.svg` simple-icons assets here):
  * - NVIDIA: official brand green `#76B900` eye mark.
- * - AMD: the official full-color (positive) AMD lockup in brand black.
+ * - AMD: the arrow symbol from the official AMD logo, in brand black —
+ *   symbol only, no "AMD" wordmark, so it reads as a square mark like the
+ *   other vendor icons at the 10px label size.
+ * - OpenAI (Jalapeño): the OpenAI mark is monochrome by design; the white
+ *   reversed variant is the official usage on colored backgrounds.
  * The marks are drawn with a transparent background directly on the pill,
  * so the area behind each logo stays the exact shade of the line-label fill.
  */
@@ -51,18 +56,23 @@ const svgDataUri = (svg: string): string => `data:image/svg+xml,${encodeURICompo
 const NVIDIA_LOGO_SVG =
   '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#76B900"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></svg>';
 
-/** AMD arrow-and-wordmark lockup (simple-icons geometry) in AMD brand black. */
+/** AMD arrow symbol (extracted from the official logo geometry) in brand black. */
 const AMD_LOGO_SVG =
-  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3.5 7.83 31.0 8.34" fill="#000000"><path d="M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137zM2 9.52l-2 4.96h1.309l.37-.982H3.9l.408.982h1.338L3.432 9.52zm4.209 0v4.955h1.238v-3.092l1.338 1.562h.188l1.338-1.556v3.091h1.238V9.52H10.47l-1.592 1.845L7.287 9.52zm6.283 0v4.96h2.057c1.979 0 2.88-1.046 2.88-2.472 0-1.36-.937-2.488-2.747-2.488zm1.237.91h.792c1.17 0 1.63.711 1.63 1.57 0 .728-.372 1.572-1.616 1.572h-.806zm-10.985.273l.791 1.932H2.008zm17.137.307l-1.604 1.603v2.25h2.246l1.604-1.607h-2.246z"/></svg>';
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="18.277 9.137 5.723 5.726" fill="#000000"><path d="M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137z"/><path d="M19.881 11.01L18.277 12.613L18.277 14.863L20.523 14.863L22.127 13.256L19.881 13.256z"/></svg>';
+
+/** OpenAI mark (repo `public/logos/openai.svg` geometry) in reversed white. */
+const OPENAI_LOGO_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 260" fill="#ffffff"><path d="M239.184 106.203a64.716 64.716 0 0 0-5.576-53.103C219.452 28.459 191 15.784 163.213 21.74A65.586 65.586 0 0 0 52.096 45.22a64.716 64.716 0 0 0-43.23 31.36c-14.31 24.602-11.061 55.634 8.033 76.74a64.665 64.665 0 0 0 5.525 53.102c14.174 24.65 42.644 37.324 70.446 31.36a64.72 64.72 0 0 0 48.754 21.744c28.481.025 53.714-18.361 62.414-45.481a64.767 64.767 0 0 0 43.229-31.36c14.137-24.558 10.875-55.423-8.083-76.483Zm-97.56 136.338a48.397 48.397 0 0 1-31.105-11.255l1.535-.87 51.67-29.825a8.595 8.595 0 0 0 4.247-7.367v-72.85l21.845 12.636c.218.111.37.32.409.563v60.367c-.056 26.818-21.783 48.545-48.601 48.601Zm-104.466-44.61a48.345 48.345 0 0 1-5.781-32.589l1.534.921 51.722 29.826a8.339 8.339 0 0 0 8.441 0l63.181-36.425v25.221a.87.87 0 0 1-.358.665l-52.335 30.184c-23.257 13.398-52.97 5.431-66.404-17.803ZM23.549 85.38a48.499 48.499 0 0 1 25.58-21.333v61.39a8.288 8.288 0 0 0 4.195 7.316l62.874 36.272-21.845 12.636a.819.819 0 0 1-.767 0L41.353 151.53c-23.211-13.454-31.171-43.144-17.804-66.405v.256Zm179.466 41.695-63.08-36.63L161.73 77.86a.819.819 0 0 1 .768 0l52.233 30.184a48.6 48.6 0 0 1-7.316 87.635v-61.391a8.544 8.544 0 0 0-4.4-7.213Zm21.742-32.69-1.535-.922-51.619-30.081a8.39 8.39 0 0 0-8.492 0L99.98 99.808V74.587a.716.716 0 0 1 .307-.665l52.233-30.133a48.652 48.652 0 0 1 72.236 50.391v.205ZM88.061 139.097l-21.845-12.585a.87.87 0 0 1-.41-.614V65.685a48.652 48.652 0 0 1 79.757-37.346l-1.535.87-51.67 29.825a8.595 8.595 0 0 0-4.246 7.367l-.051 72.697Zm11.868-25.58 28.138-16.217 28.188 16.218v32.434l-28.086 16.218-28.188-16.218-.052-32.434Z"/></svg>';
 
 /**
- * Vendor display name → full-color mark. Vendors without an official public
- * logo (e.g. anonymized preview silicon) are intentionally absent; labels for
- * those series render exactly as before, with no icon.
+ * Vendor display name → mark. Vendors without a known mark are absent;
+ * labels for those series render exactly as before, with no icon.
  */
 export const VENDOR_LOGO_ICONS: Record<string, VendorLogoIcon> = {
   NVIDIA: { href: svgDataUri(NVIDIA_LOGO_SVG), width: 10, height: 10 },
-  AMD: { href: svgDataUri(AMD_LOGO_SVG), width: 18, height: 4.85 },
+  AMD: { href: svgDataUri(AMD_LOGO_SVG), width: 10, height: 10 },
+  // Jalapeño (Teacup) is OpenAI silicon — it carries the OpenAI mark.
+  Teacup: { href: svgDataUri(OPENAI_LOGO_SVG), width: 10, height: 10 },
 };
 
 /**

--- a/packages/app/src/lib/vendor-logos.ts
+++ b/packages/app/src/lib/vendor-logos.ts
@@ -19,3 +19,59 @@ export const HW_VENDOR_LOGOS: Record<string, string> = {
 export function getHwVendorLogo(vendor: string | undefined): string | undefined {
   return vendor ? HW_VENDOR_LOGOS[vendor] : undefined;
 }
+import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
+
+/**
+ * Full-color hardware-vendor marks for chart line labels.
+ *
+ * The SVGs are inlined as `data:` URIs (rather than referencing
+ * `public/logos/*`) so the marks render synchronously inside the D3 SVG —
+ * no network fetch, no flicker on zoom re-renders — and survive the
+ * html-to-image chart export path without any resource embedding.
+ *
+ * Color notes (this is deliberate — do not swap in the monochrome
+ * `public/logos/{nvidia,amd}.svg` simple-icons assets here):
+ * - NVIDIA: official brand green `#76B900` eye mark.
+ * - AMD: the official full-color (positive) AMD lockup is black-on-white.
+ * Line-label pills are filled with the series color, so each mark sits on a
+ * small white chip to preserve the official full-color rendering on any
+ * pill background in both light and dark mode.
+ */
+export interface VendorLogoIcon {
+  /** `data:image/svg+xml` URI for an SVG `<image href>`. */
+  href: string;
+  /** Rendered mark width in px (chart/user units). */
+  width: number;
+  /** Rendered mark height in px (chart/user units). */
+  height: number;
+}
+
+const svgDataUri = (svg: string): string => `data:image/svg+xml,${encodeURIComponent(svg)}`;
+
+/** NVIDIA eye mark (simple-icons geometry) in NVIDIA brand green. */
+const NVIDIA_LOGO_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#76B900"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></svg>';
+
+/** AMD arrow-and-wordmark lockup (simple-icons geometry) in AMD brand black. */
+const AMD_LOGO_SVG =
+  '<svg xmlns="http://www.w3.org/2000/svg" viewBox="-3.5 7.83 31.0 8.34" fill="#000000"><path d="M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137zM2 9.52l-2 4.96h1.309l.37-.982H3.9l.408.982h1.338L3.432 9.52zm4.209 0v4.955h1.238v-3.092l1.338 1.562h.188l1.338-1.556v3.091h1.238V9.52H10.47l-1.592 1.845L7.287 9.52zm6.283 0v4.96h2.057c1.979 0 2.88-1.046 2.88-2.472 0-1.36-.937-2.488-2.747-2.488zm1.237.91h.792c1.17 0 1.63.711 1.63 1.57 0 .728-.372 1.572-1.616 1.572h-.806zm-10.985.273l.791 1.932H2.008zm17.137.307l-1.604 1.603v2.25h2.246l1.604-1.607h-2.246z"/></svg>';
+
+/**
+ * Vendor display name → full-color mark. Vendors without an official public
+ * logo (e.g. anonymized preview silicon) are intentionally absent; labels for
+ * those series render exactly as before, with no icon.
+ */
+export const VENDOR_LOGO_ICONS: Record<string, VendorLogoIcon> = {
+  NVIDIA: { href: svgDataUri(NVIDIA_LOGO_SVG), width: 10, height: 10 },
+  AMD: { href: svgDataUri(AMD_LOGO_SVG), width: 18, height: 4.85 },
+};
+
+/**
+ * Full-color vendor mark for a hardware key (`gb200`, `mi355x_dsv4`, ...).
+ * Uses the same base-key convention as `quickFilters`: everything before the
+ * first `_` is the registry key.
+ */
+export function getLineLabelVendorIcon(hwKey: string): VendorLogoIcon | undefined {
+  const vendor = GPU_VENDORS[hwKey.split('_')[0]];
+  return vendor ? VENDOR_LOGO_ICONS[vendor] : undefined;
+}

--- a/packages/app/src/lib/vendor-logos.ts
+++ b/packages/app/src/lib/vendor-logos.ts
@@ -32,10 +32,9 @@ import { GPU_VENDORS } from '@semianalysisai/inferencex-constants';
  * Color notes (this is deliberate — do not swap in the monochrome
  * `public/logos/{nvidia,amd}.svg` simple-icons assets here):
  * - NVIDIA: official brand green `#76B900` eye mark.
- * - AMD: the official full-color (positive) AMD lockup is black-on-white.
- * Line-label pills are filled with the series color, so each mark sits on a
- * small white chip to preserve the official full-color rendering on any
- * pill background in both light and dark mode.
+ * - AMD: the official full-color (positive) AMD lockup in brand black.
+ * The marks are drawn with a transparent background directly on the pill,
+ * so the area behind each logo stays the exact shade of the line-label fill.
  */
 export interface VendorLogoIcon {
   /** `data:image/svg+xml` URI for an SVG `<image href>`. */


### PR DESCRIPTION
## Summary

Adds each hardware vendor's official mark, in full color, to the roofline line-label pills on the inference Pareto charts (`ScatterGraph`):

- **NVIDIA** — eye mark in official brand green `#76B900`
- **AMD** — the arrow symbol from the official AMD logo, in brand black (symbol only, no wordmark, so it reads as a square mark at label size)
- **Jalapeño (Teacup)** — OpenAI silicon, so it carries the OpenAI mark; the OpenAI logo is monochrome by design and uses the official reversed-white variant on colored backgrounds

The marks are drawn with a **transparent background directly on the pill**, so the area behind each logo keeps the exact line-label fill shade (including gradient fills) in both light and dark mode. Rendering was visually verified at 5x zoom against the current pill palette.

### Implementation

- `lib/vendor-logos.ts` (new): logo SVGs inlined as `data:` URIs — synchronous rendering inside the D3 SVG (no fetch, no flicker on zoom re-renders) and compatible with the `html-to-image` chart-export path. The existing `public/logos/{nvidia,amd}.svg` simple-icons assets are monochrome full lockups, which is why purpose-built variants are inlined here instead. Hardware key → vendor resolution reuses the `GPU_VENDORS` base-key convention from `quickFilters`.
- `line-label-layer.ts`: `renderLineLabels` gains an optional `iconFor` — the text shifts right, the pill background expands over the icon space, and the mark is drawn as an `<image>` per label. Callers without `iconFor` (`GPUGraph`) are unchanged.
- `ScatterGraph.tsx`: passes `iconFor` resolving `label.seriesId` (hw key) to the vendor mark; overlay-run labels get the icon too since they carry the same hw key.
- Unit tests for the hw-key → logo mapping and mark colors.

`typecheck`, `lint`, `fmt`, and the touched unit tests pass locally.

## 中文说明

在推理 Pareto 图表（`ScatterGraph`）的曲线标签（roofline pill）左侧新增硬件厂商官方全彩标识：

- **NVIDIA** — 官方品牌绿 `#76B900` 眼形标识
- **AMD** — 官方 Logo 中的箭头符号（仅符号、不含 AMD 字标），品牌黑色，在标签尺寸下呈方形，与其他厂商图标一致
- **Jalapeño（Teacup）** — 为 OpenAI 芯片，使用 OpenAI 标识；OpenAI Logo 本身为单色设计，在彩色底上采用官方反白（白色）变体

标识以**透明背景直接绘制在标签上**，其背后保持与曲线标签完全相同的填充色（含渐变填充），明暗主题下均如此；已在 5 倍放大下对照现有配色目视验证。

实现要点：新增 `lib/vendor-logos.ts`，将标识 SVG 以 `data:` URI 内联（同步渲染、无网络请求，且兼容 `html-to-image` 图表导出）；现有 `public/logos/{nvidia,amd}.svg` 为单色完整组合标识，故此处内联定制变体。`renderLineLabels` 新增可选 `iconFor` 参数，文本右移、背景扩展并以 `<image>` 绘制标识；未传入该参数的调用方（`GPUGraph`）行为不变。已补充硬件 key → 标识映射及颜色的单元测试。`typecheck`、`lint`、`fmt` 与相关单元测试本地全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart presentation-only changes with optional D3 label rendering; no auth, data, or API impact.
> 
> **Overview**
> Inference Pareto charts (`ScatterGraph`) now show **full-color vendor marks** on the left of roofline line-label pills (NVIDIA, AMD, and Jalapeño/Teacup via OpenAI), resolved from each series’ hardware key.
> 
> A new **`vendor-logos`** module inlines brand SVGs as `data:` URIs and maps keys through `GPU_VENDORS` (including suffixed keys like `mi355x_dsv4`). **`renderLineLabels`** gains an optional `iconFor` callback: label text shifts right, the pill background widens, and a `.ll-logo` `<image>` is drawn on the pill fill. Only `ScatterGraph` passes `iconFor`; other callers (e.g. `GPUGraph`) stay unchanged.
> 
> Unit tests cover hardware-key → icon mapping and embedded brand colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d3193738e8e3d2646b6e1b75fcb5c96077bef5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->