### PR TITLE
feat(collectivex): KV concurrency frontier view / 新增 KV 并发帕累托前沿视图

### DIFF
--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -43,6 +43,11 @@ const kvDataset = buildDataset({
   ],
   meta: { run_id: '162', generated_at: '2026-08-07T12:20:00Z', source_sha: 'e'.repeat(40) },
 });
+const kvComparisonDataset = buildDataset({
+  shards: [makeRawShard()],
+  kv: [{}],
+  meta: { run_id: '164', generated_at: '2026-08-09T12:20:00Z', source_sha: 'a'.repeat(40) },
+});
 const kvOnlyDataset = buildDataset({
   shards: [],
   kv: [{}],
@@ -650,6 +655,44 @@ describe('CollectiveX kv-transfer card', () => {
         expect($kv[0].compareDocumentPosition($chart[0]) & 4).to.equal(4);
       });
     });
+  });
+
+  it('plots the fixed frontier axes and keeps multi-run lines aligned with the legend', () => {
+    installRuns([kvComparisonDataset, kvDataset]);
+    installRun(kvComparisonDataset);
+    installRun(kvDataset, 'comparisonKvRun');
+    openCollectiveX();
+
+    cy.get(`[data-testid="collectivex-run-visible-${kvDataset.run.run_id}"]`).check();
+    cy.wait('@comparisonKvRun');
+    cy.get('[data-testid="collectivex-kv-xaxis-toggle"]').contains('button', 'Frontier').click();
+
+    cy.get('[data-testid="collectivex-kv-metric-toggle"]').should('not.exist');
+    cy.get('[data-testid="collectivex-kv-frontier-chart"]')
+      .should('contain.text', 'Aggregate pull bandwidth at p50 (GB/s, log)')
+      .and('contain.text', 'Burst p95 latency per in-flight request (ms, log)');
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] .line-path')
+      .should('have.length', 2)
+      .then(($lines) => {
+        expect([...$lines].map((line) => line.getAttribute('stroke-dasharray'))).to.have.members([
+          'none',
+          '9 4',
+        ]);
+      });
+  });
+
+  it('localizes the frontier control and chart copy on the Chinese page', () => {
+    installRuns([kvDataset]);
+    installRun(kvDataset);
+    cy.visit('/zh/collectivex');
+    cy.wait('@runs');
+    cy.wait('@run');
+
+    cy.get('[data-testid="collectivex-kv-xaxis-toggle"]').contains('button', '帕累托前沿').click();
+    cy.get('[data-testid="collectivex-kv-frontier-chart"]')
+      .should('contain.text', 'p50 聚合 pull 带宽（GB/s，对数）')
+      .and('contain.text', '每个在途请求的突发 p95 延迟（ms，对数）')
+      .and('contain.text', '越靠右下越优');
   });
 
   it('renders no kv card and no KV suite badge for an EP-only run', () => {

--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -107,11 +107,14 @@ describe('Landing page performance', () => {
       );
       expect(resourceNames.some((name) => name.includes('/minecraft-click.mp3'))).to.eq(false);
       expect(resourceNames.some((name) => name.includes('/Monocraft-'))).to.eq(false);
-      // The carousel only renders the active quote's logo, and it always starts on
-      // the first (MiniMax) quote, so a mobile load fetches at most that one logo —
-      // never the full supporter set.
-      const carouselLogos = new Set(resourceNames.filter((name) => name.includes('/logos/')));
-      expect(carouselLogos.size).to.be.lessThan(3);
+      // The landing AgentX ledger has five lazy model marks. A mobile viewport may
+      // fetch any visible subset, but the text-only supporter strip must not pull
+      // in its former logo set.
+      const landingLogos = new Set(resourceNames.filter((name) => name.includes('/logos/')));
+      expect(landingLogos.size).to.be.lessThan(6);
+      expect(
+        [...landingLogos].filter((name) => !new URL(name).pathname.endsWith('-color.svg')),
+      ).to.deep.eq([]);
       expect(
         resourceNames.some(
           (name) => name.includes('/brand/logo-color.webp') && name.includes('w=128'),

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -4,6 +4,7 @@ import * as d3 from 'd3';
 import { useMemo } from 'react';
 
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import type { RenderContext, ZoomContext } from '@/lib/d3-chart/D3Chart/types';
 
 import {
   type CollectiveXKvFrontierPoint,
@@ -48,6 +49,28 @@ function escapeHtml(value: string): string {
 
 function faded(color: string): string {
   return `color-mix(in srgb, ${color} 35%, transparent)`;
+}
+
+function renderFrontierRings(
+  group: d3.Selection<SVGGElement, unknown, null, undefined>,
+  points: CollectiveXKvFrontierPoint[],
+  xScale: RenderContext['xScale'],
+  yScale: RenderContext['yScale'],
+): void {
+  const x = xScale as d3.ScaleLogarithmic<number, number>;
+  const y = yScale as d3.ScaleLogarithmic<number, number>;
+  group
+    .selectAll<SVGCircleElement, CollectiveXKvFrontierPoint>('.frontier-ring')
+    .data(points, (point) => `${point.seriesId}-${point.row.batch}`)
+    .join('circle')
+    .attr('class', 'frontier-ring')
+    .attr('cx', (point) => x(point.x))
+    .attr('cy', (point) => y(point.y))
+    .attr('r', 8)
+    .attr('fill', 'none')
+    .attr('stroke', 'var(--foreground)')
+    .attr('stroke-width', 1.25)
+    .attr('pointer-events', 'none');
 }
 
 export function CollectiveXKvFrontierChart({
@@ -151,22 +174,16 @@ export function CollectiveXKvFrontierChart({
             maxPoints: Infinity,
           },
         },
+        // A custom layer rather than a second point layer: renderPoints joins
+        // on the shared `.point` class inside the one zoom group, so two point
+        // layers would rebind each other's circles.
         {
-          type: 'point',
+          type: 'custom',
           key: 'collectivex-kv-frontier-rings',
-          data: skuFrontierPoints,
-          config: {
-            getCx: () => 0,
-            getCy: () => 0,
-            getX: (point) => point.x,
-            getY: (point) => point.y,
-            getColor: () => 'none',
-            getRadius: () => 8,
-            stroke: 'var(--foreground)',
-            strokeWidth: 1.25,
-            keyFn: (point) => `${point.seriesId}-${point.row.batch}-ring`,
-            maxPoints: Infinity,
-          },
+          render: (group, ctx: RenderContext) =>
+            renderFrontierRings(group, skuFrontierPoints, ctx.xScale, ctx.yScale),
+          onZoom: (group, ctx: ZoomContext) =>
+            renderFrontierRings(group, skuFrontierPoints, ctx.newXScale, ctx.newYScale),
         },
       ]}
       zoom={{

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -4,12 +4,14 @@ import * as d3 from 'd3';
 import { useMemo } from 'react';
 
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import { useLocale } from '@/lib/use-locale';
 
 import {
   type CollectiveXKvFrontierPoint,
   type CollectiveXKvFrontierSelection,
   type CollectiveXKvRunCase,
   collectiveXKvFrontierPoints,
+  collectiveXRunDasharray,
 } from './data';
 
 interface CollectiveXKvFrontierChartProps {
@@ -21,6 +23,45 @@ interface CollectiveXKvFrontierChartProps {
   legendElement?: React.ReactNode;
   testId?: string;
 }
+
+const STRINGS = {
+  en: {
+    noData: 'No measured KV rows match the selected page size and direction.',
+    instructions:
+      'Shift+Scroll to zoom · Drag to pan · Double-click to reset · Click a point to pin tooltip',
+    xAxis: (op: CollectiveXKvFrontierSelection['op']) =>
+      `Aggregate ${op} bandwidth at p50 (GB/s, log)`,
+    yAxis: 'Burst p95 latency per in-flight request (ms, log)',
+    dismiss: 'Click elsewhere to dismiss',
+    skuFrontier: 'SKU-wide frontier',
+    backendFrontier: 'backend frontier',
+    dominated: 'dominated',
+    pointContext: (row: CollectiveXKvFrontierPoint['row'], tier: string) =>
+      `${row.op} · page ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong>`,
+    pointMetrics: (point: CollectiveXKvFrontierPoint) =>
+      `Aggregate ${point.x.toFixed(point.x >= 100 ? 0 : 2)} GB/s · p95 ÷ in-flight ${point.y.toFixed(point.y >= 100 ? 0 : 1)} ms`,
+    latency: (point: CollectiveXKvFrontierPoint) =>
+      `Burst latency p50 / p95: ${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} descriptors/request`,
+    verify: (passed: boolean) => `verify: ${passed ? 'passed' : 'FAILED'}`,
+  },
+  zh: {
+    noData: '没有与所选页大小和传输方向匹配的 KV 实测数据。',
+    instructions: 'Shift+滚轮缩放 · 拖动平移 · 双击重置 · 点击数据点固定提示框',
+    xAxis: (op: CollectiveXKvFrontierSelection['op']) => `p50 聚合 ${op} 带宽（GB/s，对数）`,
+    yAxis: '每个在途请求的突发 p95 延迟（ms，对数）',
+    dismiss: '点击其他位置关闭',
+    skuFrontier: 'SKU 级帕累托前沿',
+    backendFrontier: '后端帕累托前沿',
+    dominated: '被支配',
+    pointContext: (row: CollectiveXKvFrontierPoint['row'], tier: string) =>
+      `${row.op} · 页大小 ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong>`,
+    pointMetrics: (point: CollectiveXKvFrontierPoint) =>
+      `聚合带宽 ${point.x.toFixed(point.x >= 100 ? 0 : 2)} GB/s · p95 ÷ 在途请求数 ${point.y.toFixed(point.y >= 100 ? 0 : 1)} ms`,
+    latency: (point: CollectiveXKvFrontierPoint) =>
+      `突发延迟 p50 / p95：${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} 个描述符/请求`,
+    verify: (passed: boolean) => `校验：${passed ? '通过' : '失败'}`,
+  },
+} as const;
 
 function paddedDomain(values: number[]): [number, number] {
   if (values.length === 0) return [1, 10];
@@ -54,7 +95,13 @@ export function CollectiveXKvFrontierChart({
   legendElement,
   testId,
 }: CollectiveXKvFrontierChartProps) {
+  const locale = useLocale();
+  const strings = STRINGS[locale === 'zh' ? 'zh' : 'en'];
   const points = useMemo(() => collectiveXKvFrontierPoints(cases, selection), [cases, selection]);
+  const runIndexBySeries = useMemo(
+    () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
+    [cases],
+  );
   // Roofline per series in the /inference style, drawn through the full batch
   // ladder: because raising the batch improves both axes until the backend
   // saturates, the strict Pareto set is usually a single point, so the ladder
@@ -83,9 +130,7 @@ export function CollectiveXKvFrontierChart({
   const noDataOverlay =
     points.length === 0 ? (
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-        <p className="text-sm text-muted-foreground">
-          No measured kv rows match the selected page size and direction.
-        </p>
+        <p className="text-sm text-muted-foreground">{strings.noData}</p>
       </div>
     ) : undefined;
 
@@ -98,16 +143,16 @@ export function CollectiveXKvFrontierChart({
       watermark="logo"
       testId={testId}
       grabCursor
-      instructions="Shift+Scroll to zoom · Drag to pan · Double-click to reset · Click a point to pin tooltip"
+      instructions={strings.instructions}
       xScale={{ type: 'log', domain: xDomain, nice: false }}
       yScale={{ type: 'log', domain: yDomain, nice: false }}
       xAxis={{
-        label: `Aggregate ${selection.op} bandwidth at p50 (GB/s, log)`,
+        label: strings.xAxis(selection.op),
         tickCount: 6,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
       yAxis={{
-        label: 'Burst p95 latency per in-flight request (ms, log)',
+        label: strings.yAxis,
         tickCount: 5,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
@@ -118,6 +163,7 @@ export function CollectiveXKvFrontierChart({
           lines,
           config: {
             getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
+            getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
             strokeWidth: 2.5,
             curve: d3.curveMonotoneX,
           },
@@ -151,17 +197,17 @@ export function CollectiveXKvFrontierChart({
           const color = colors[point.colorKey] ?? '#888';
           const { row } = point;
           const tier = point.onSkuFrontier
-            ? 'SKU-wide frontier'
+            ? strings.skuFrontier
             : point.onSeriesFrontier
-              ? 'backend frontier'
-              : 'dominated';
+              ? strings.backendFrontier
+              : strings.dominated;
           return `<div class="rounded-md border bg-background/95 px-3 py-2 text-xs shadow-md backdrop-blur-sm" style="min-width: 230px; max-width: 380px; user-select: ${isPinned ? 'text' : 'none'}">
-            ${isPinned ? '<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">Click elsewhere to dismiss</div>' : ''}
+            ${isPinned ? `<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">${strings.dismiss}</div>` : ''}
             <div class="font-semibold mb-1" style="color: ${color}">${escapeHtml(point.seriesLabel)}</div>
-            <div>${row.op} · page ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong></div>
-            <div>Aggregate ${point.x.toFixed(point.x >= 100 ? 0 : 2)} GB/s · p95 ÷ in-flight ${point.y.toFixed(point.y >= 100 ? 0 : 1)} ms</div>
-            <div class="text-muted-foreground">Burst latency p50 / p95: ${row.latency_ms.p50.toFixed(1)} / ${row.latency_ms.p95.toFixed(1)} ms · ${row.descs.toLocaleString('en-US')} descriptors/request</div>
-            <div class="text-muted-foreground">verify: ${row.verify_passed ? 'passed' : 'FAILED'}</div>
+            <div>${strings.pointContext(row, tier)}</div>
+            <div>${strings.pointMetrics(point)}</div>
+            <div class="text-muted-foreground">${strings.latency(point)}</div>
+            <div class="text-muted-foreground">${strings.verify(row.verify_passed)}</div>
           </div>`;
         },
         getRulerX: (point, scale) =>

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import * as d3 from 'd3';
+import { useMemo } from 'react';
+
+import { D3Chart } from '@/lib/d3-chart/D3Chart';
+
+import {
+  type CollectiveXKvFrontierPoint,
+  type CollectiveXKvFrontierSelection,
+  type CollectiveXKvRunCase,
+  collectiveXKvFrontierPoints,
+  collectiveXRunDasharray,
+} from './data';
+
+interface CollectiveXKvFrontierChartProps {
+  chartId: string;
+  cases: CollectiveXKvRunCase[];
+  colors: Record<string, string>;
+  selection: CollectiveXKvFrontierSelection;
+  caption?: React.ReactNode;
+  legendElement?: React.ReactNode;
+  testId?: string;
+}
+
+function paddedDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [1, 10];
+  const min = d3.min(values) ?? 1;
+  const max = d3.max(values) ?? 1;
+  return min === max ? [min / 2, max * 2] : [min / 1.15, max * 1.15];
+}
+
+function formatCompact(value: number): string {
+  if (value >= 1e3) return `${(value / 1e3).toFixed(value < 1e4 ? 1 : 0)}k`;
+  if (value >= 10) return value.toFixed(0);
+  if (value >= 1) return value.toFixed(1);
+  return value.toFixed(2);
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function faded(color: string): string {
+  return `color-mix(in srgb, ${color} 35%, transparent)`;
+}
+
+export function CollectiveXKvFrontierChart({
+  chartId,
+  cases,
+  colors,
+  selection,
+  caption,
+  legendElement,
+  testId,
+}: CollectiveXKvFrontierChartProps) {
+  const points = useMemo(() => collectiveXKvFrontierPoints(cases, selection), [cases, selection]);
+  const skuFrontierPoints = useMemo(() => points.filter((point) => point.onSkuFrontier), [points]);
+  const runIndexBySeries = useMemo(
+    () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
+    [cases],
+  );
+  // Batch-ladder walk per series: sorted by requests in flight, so a
+  // serializing backend draws a stub and an overlapping one a curve.
+  const lines = useMemo(() => {
+    const bySeries: Record<string, CollectiveXKvFrontierPoint[]> = {};
+    for (const point of points) {
+      (bySeries[point.seriesId] ??= []).push(point);
+    }
+    const result: Record<string, { x: number; y: number }[]> = {};
+    for (const [seriesId, seriesPoints] of Object.entries(bySeries)) {
+      result[seriesId] = seriesPoints
+        .toSorted((a, b) => a.row.batch - b.row.batch)
+        .map((point) => ({ x: point.x, y: point.y }));
+    }
+    return result;
+  }, [points]);
+  const colorBySeries = useMemo(
+    () => new Map(points.map((point) => [point.seriesId, point.colorKey])),
+    [points],
+  );
+
+  const xDomain = useMemo(() => paddedDomain(points.map((point) => point.x)), [points]);
+  const yDomain = useMemo(() => paddedDomain(points.map((point) => point.y)), [points]);
+
+  const noDataOverlay =
+    points.length === 0 ? (
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <p className="text-sm text-muted-foreground">
+          No measured kv rows match the selected page size and direction.
+        </p>
+      </div>
+    ) : undefined;
+
+  return (
+    <D3Chart<CollectiveXKvFrontierPoint>
+      chartId={chartId}
+      data={points}
+      height={420}
+      margin={{ top: 24, right: 20, bottom: 62, left: 78 }}
+      watermark="logo"
+      testId={testId}
+      grabCursor
+      instructions="Shift+Scroll to zoom · Drag to pan · Double-click to reset · Click a point to pin tooltip"
+      xScale={{ type: 'log', domain: xDomain, nice: false }}
+      yScale={{ type: 'log', domain: yDomain, nice: false }}
+      xAxis={{
+        label: `Aggregate ${selection.op} bandwidth at p50 (GB/s, log)`,
+        tickCount: 6,
+        tickFormat: (value) => formatCompact(Number(value)),
+      }}
+      yAxis={{
+        label: 'Burst p95 latency per in-flight request (ms, log)',
+        tickCount: 5,
+        tickFormat: (value) => formatCompact(Number(value)),
+      }}
+      layers={[
+        {
+          type: 'line',
+          key: 'collectivex-kv-frontier-lines',
+          lines,
+          config: {
+            getColor: (key) => faded(colors[colorBySeries.get(key) ?? ''] ?? '#888'),
+            getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
+            strokeWidth: 1.75,
+            curve: d3.curveLinear,
+          },
+        },
+        {
+          type: 'point',
+          key: 'collectivex-kv-frontier-points',
+          data: points,
+          config: {
+            getCx: () => 0,
+            getCy: () => 0,
+            getX: (point) => point.x,
+            getY: (point) => point.y,
+            getColor: (point) => {
+              const color = colors[point.colorKey] ?? '#888';
+              return point.onSeriesFrontier ? color : faded(color);
+            },
+            getRadius: (point) => (point.onSeriesFrontier ? 4.5 : 3),
+            stroke: 'var(--background)',
+            strokeWidth: 1,
+            keyFn: (point) => `${point.seriesId}-${point.row.batch}`,
+            maxPoints: Infinity,
+          },
+        },
+        {
+          type: 'point',
+          key: 'collectivex-kv-frontier-rings',
+          data: skuFrontierPoints,
+          config: {
+            getCx: () => 0,
+            getCy: () => 0,
+            getX: (point) => point.x,
+            getY: (point) => point.y,
+            getColor: () => 'none',
+            getRadius: () => 8,
+            stroke: 'var(--foreground)',
+            strokeWidth: 1.25,
+            keyFn: (point) => `${point.seriesId}-${point.row.batch}-ring`,
+            maxPoints: Infinity,
+          },
+        },
+      ]}
+      zoom={{
+        enabled: true,
+        axes: 'both',
+        scaleExtent: [1, 20],
+        resetEventName: `collectivex_zoom_reset_${chartId}`,
+      }}
+      tooltip={{
+        rulerType: 'crosshair',
+        attachToLayer: 1,
+        content: (point, isPinned) => {
+          const color = colors[point.colorKey] ?? '#888';
+          const { row } = point;
+          const tier = point.onSkuFrontier
+            ? 'SKU-wide frontier'
+            : point.onSeriesFrontier
+              ? 'backend frontier'
+              : 'dominated';
+          return `<div class="rounded-md border bg-background/95 px-3 py-2 text-xs shadow-md backdrop-blur-sm" style="min-width: 230px; max-width: 380px; user-select: ${isPinned ? 'text' : 'none'}">
+            ${isPinned ? '<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">Click elsewhere to dismiss</div>' : ''}
+            <div class="font-semibold mb-1" style="color: ${color}">${escapeHtml(point.seriesLabel)}</div>
+            <div>${row.op} · page ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong></div>
+            <div>Aggregate ${point.x.toFixed(point.x >= 100 ? 0 : 2)} GB/s · p95 ÷ in-flight ${point.y.toFixed(point.y >= 100 ? 0 : 1)} ms</div>
+            <div class="text-muted-foreground">Burst latency p50 / p95: ${row.latency_ms.p50.toFixed(1)} / ${row.latency_ms.p95.toFixed(1)} ms · ${row.descs.toLocaleString('en-US')} descriptors/request</div>
+            <div class="text-muted-foreground">verify: ${row.verify_passed ? 'passed' : 'FAILED'}</div>
+          </div>`;
+        },
+        getRulerX: (point, scale) =>
+          (scale as d3.ScaleLinear<number, number> | d3.ScaleLogarithmic<number, number>)(point.x),
+        getRulerY: (point, scale) => scale(point.y),
+        onHoverStart: (selectionEl) => {
+          selectionEl.attr('r', 6);
+        },
+        onHoverEnd: (selectionEl, point) => {
+          selectionEl.attr('r', point.onSeriesFrontier ? 4.5 : 3);
+        },
+      }}
+      transitionDuration={200}
+      legendElement={legendElement}
+      noDataOverlay={noDataOverlay}
+      caption={caption}
+    />
+  );
+}

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -88,19 +88,19 @@ export function CollectiveXKvFrontierChart({
     () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
     [cases],
   );
-  // Pareto roofline per series, matching the /inference scatter: the line
-  // connects only frontier points, so a serializing backend draws a stub and
-  // an overlapping one a descending envelope.
+  // Roofline per series in the /inference style, drawn through the full batch
+  // ladder: because raising the batch improves both axes until the backend
+  // saturates, the strict Pareto set is usually a single point, so the ladder
+  // itself is the achievable curve and its endpoint the frontier.
   const lines = useMemo(() => {
     const bySeries: Record<string, CollectiveXKvFrontierPoint[]> = {};
     for (const point of points) {
-      if (!point.onSeriesFrontier) continue;
       (bySeries[point.seriesId] ??= []).push(point);
     }
     const result: Record<string, { x: number; y: number }[]> = {};
     for (const [seriesId, seriesPoints] of Object.entries(bySeries)) {
       result[seriesId] = seriesPoints
-        .toSorted((a, b) => a.x - b.x)
+        .toSorted((a, b) => a.row.batch - b.row.batch)
         .map((point) => ({ x: point.x, y: point.y }));
     }
     return result;

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -88,17 +88,19 @@ export function CollectiveXKvFrontierChart({
     () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
     [cases],
   );
-  // Batch-ladder walk per series: sorted by requests in flight, so a
-  // serializing backend draws a stub and an overlapping one a curve.
+  // Pareto roofline per series, matching the /inference scatter: the line
+  // connects only frontier points, so a serializing backend draws a stub and
+  // an overlapping one a descending envelope.
   const lines = useMemo(() => {
     const bySeries: Record<string, CollectiveXKvFrontierPoint[]> = {};
     for (const point of points) {
+      if (!point.onSeriesFrontier) continue;
       (bySeries[point.seriesId] ??= []).push(point);
     }
     const result: Record<string, { x: number; y: number }[]> = {};
     for (const [seriesId, seriesPoints] of Object.entries(bySeries)) {
       result[seriesId] = seriesPoints
-        .toSorted((a, b) => a.row.batch - b.row.batch)
+        .toSorted((a, b) => a.x - b.x)
         .map((point) => ({ x: point.x, y: point.y }));
     }
     return result;
@@ -148,10 +150,10 @@ export function CollectiveXKvFrontierChart({
           key: 'collectivex-kv-frontier-lines',
           lines,
           config: {
-            getColor: (key) => faded(colors[colorBySeries.get(key) ?? ''] ?? '#888'),
+            getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
             getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
-            strokeWidth: 1.75,
-            curve: d3.curveLinear,
+            strokeWidth: 2.5,
+            curve: d3.curveMonotoneX,
           },
         },
         {
@@ -167,9 +169,7 @@ export function CollectiveXKvFrontierChart({
               const color = colors[point.colorKey] ?? '#888';
               return point.onSeriesFrontier ? color : faded(color);
             },
-            getRadius: (point) => (point.onSeriesFrontier ? 4.5 : 3),
-            stroke: 'var(--background)',
-            strokeWidth: 1,
+            getRadius: () => 3.5,
             keyFn: (point) => `${point.seriesId}-${point.row.batch}`,
             maxPoints: Infinity,
           },
@@ -218,8 +218,8 @@ export function CollectiveXKvFrontierChart({
         onHoverStart: (selectionEl) => {
           selectionEl.attr('r', 6);
         },
-        onHoverEnd: (selectionEl, point) => {
-          selectionEl.attr('r', point.onSeriesFrontier ? 4.5 : 3);
+        onHoverEnd: (selectionEl) => {
+          selectionEl.attr('r', 3.5);
         },
       }}
       transitionDuration={200}

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -4,14 +4,12 @@ import * as d3 from 'd3';
 import { useMemo } from 'react';
 
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
-import type { RenderContext, ZoomContext } from '@/lib/d3-chart/D3Chart/types';
 
 import {
   type CollectiveXKvFrontierPoint,
   type CollectiveXKvFrontierSelection,
   type CollectiveXKvRunCase,
   collectiveXKvFrontierPoints,
-  collectiveXRunDasharray,
 } from './data';
 
 interface CollectiveXKvFrontierChartProps {
@@ -47,32 +45,6 @@ function escapeHtml(value: string): string {
     .replaceAll("'", '&#039;');
 }
 
-function faded(color: string): string {
-  return `color-mix(in srgb, ${color} 35%, transparent)`;
-}
-
-function renderFrontierRings(
-  group: d3.Selection<SVGGElement, unknown, null, undefined>,
-  points: CollectiveXKvFrontierPoint[],
-  xScale: RenderContext['xScale'],
-  yScale: RenderContext['yScale'],
-): void {
-  const x = xScale as d3.ScaleLogarithmic<number, number>;
-  const y = yScale as d3.ScaleLogarithmic<number, number>;
-  group
-    .selectAll<SVGCircleElement, CollectiveXKvFrontierPoint>('.frontier-ring')
-    .data(points, (point) => `${point.seriesId}-${point.row.batch}`)
-    .join('circle')
-    .attr('class', 'frontier-ring')
-    .attr('cx', (point) => x(point.x))
-    .attr('cy', (point) => y(point.y))
-    .attr('r', 8)
-    .attr('fill', 'none')
-    .attr('stroke', 'var(--foreground)')
-    .attr('stroke-width', 1.25)
-    .attr('pointer-events', 'none');
-}
-
 export function CollectiveXKvFrontierChart({
   chartId,
   cases,
@@ -83,11 +55,6 @@ export function CollectiveXKvFrontierChart({
   testId,
 }: CollectiveXKvFrontierChartProps) {
   const points = useMemo(() => collectiveXKvFrontierPoints(cases, selection), [cases, selection]);
-  const skuFrontierPoints = useMemo(() => points.filter((point) => point.onSkuFrontier), [points]);
-  const runIndexBySeries = useMemo(
-    () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
-    [cases],
-  );
   // Roofline per series in the /inference style, drawn through the full batch
   // ladder: because raising the batch improves both axes until the backend
   // saturates, the strict Pareto set is usually a single point, so the ladder
@@ -151,7 +118,6 @@ export function CollectiveXKvFrontierChart({
           lines,
           config: {
             getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
-            getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
             strokeWidth: 2.5,
             curve: d3.curveMonotoneX,
           },
@@ -165,25 +131,11 @@ export function CollectiveXKvFrontierChart({
             getCy: () => 0,
             getX: (point) => point.x,
             getY: (point) => point.y,
-            getColor: (point) => {
-              const color = colors[point.colorKey] ?? '#888';
-              return point.onSeriesFrontier ? color : faded(color);
-            },
+            getColor: (point) => colors[point.colorKey] ?? '#888',
             getRadius: () => 3.5,
             keyFn: (point) => `${point.seriesId}-${point.row.batch}`,
             maxPoints: Infinity,
           },
-        },
-        // A custom layer rather than a second point layer: renderPoints joins
-        // on the shared `.point` class inside the one zoom group, so two point
-        // layers would rebind each other's circles.
-        {
-          type: 'custom',
-          key: 'collectivex-kv-frontier-rings',
-          render: (group, ctx: RenderContext) =>
-            renderFrontierRings(group, skuFrontierPoints, ctx.xScale, ctx.yScale),
-          onZoom: (group, ctx: ZoomContext) =>
-            renderFrontierRings(group, skuFrontierPoints, ctx.newXScale, ctx.newYScale),
         },
       ]}
       zoom={{

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -39,10 +39,15 @@ const STRINGS = {
       'each line walks the batch ladder at the largest measured ISL; down-right is better. ' +
       'A backend that serializes requests collapses to a single point; hover a point for its ' +
       'Pareto status.',
+    frontierOption: 'Frontier',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
     opControl: 'Direction',
+    metricAriaLabel: 'CollectiveX KV metric',
+    xAriaLabel: 'CollectiveX KV X axis',
+    pageAriaLabel: 'CollectiveX KV page size',
+    opAriaLabel: 'CollectiveX KV direction',
   },
   zh: {
     heading: 'KV 缓存传输',
@@ -53,12 +58,17 @@ const STRINGS = {
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
     frontierCaption:
-      '每条线沿最大实测 ISL 的批大小阶梯移动，右下方更优。' +
+      '每条线连接最大实测 ISL 下的批大小阶梯，越靠右下越优。' +
       '串行处理请求的后端会收缩为一个点；悬停可查看各点的帕累托状态。',
+    frontierOption: '帕累托前沿',
     yControl: '指标',
     xControl: 'X 轴',
     pageControl: '页大小',
     opControl: '方向',
+    metricAriaLabel: 'CollectiveX KV 指标',
+    xAriaLabel: 'CollectiveX KV X 轴',
+    pageAriaLabel: 'CollectiveX KV 页大小',
+    opAriaLabel: 'CollectiveX KV 传输方向',
   },
 } as const;
 
@@ -277,7 +287,7 @@ export function CollectiveXKvSection({
                     setYAxis(value);
                     track('collectivex_kv_metric_changed', { metric: value });
                   }}
-                  ariaLabel="CollectiveX kv metric"
+                  ariaLabel={strings.metricAriaLabel}
                   testId="collectivex-kv-metric-toggle"
                   options={[
                     { value: 'bandwidth', label: 'GB/s' },
@@ -294,12 +304,12 @@ export function CollectiveXKvSection({
                   setXAxis(value);
                   track('collectivex_kv_xaxis_changed', { axis: value });
                 }}
-                ariaLabel="CollectiveX kv x axis"
+                ariaLabel={strings.xAriaLabel}
                 testId="collectivex-kv-xaxis-toggle"
                 options={[
                   { value: 'batch', label: 'Batch' },
                   { value: 'isl', label: 'ISL' },
-                  { value: 'frontier', label: 'Frontier' },
+                  { value: 'frontier', label: strings.frontierOption },
                 ]}
               />
             </div>
@@ -308,7 +318,7 @@ export function CollectiveXKvSection({
               <SegmentedToggle
                 value={pageTokens}
                 onValueChange={setPageTokens}
-                ariaLabel="CollectiveX kv page size"
+                ariaLabel={strings.pageAriaLabel}
                 testId="collectivex-kv-page-toggle"
                 options={[
                   { value: '64', label: '64' },
@@ -321,7 +331,7 @@ export function CollectiveXKvSection({
               <SegmentedToggle
                 value={op}
                 onValueChange={setOp}
-                ariaLabel="CollectiveX kv direction"
+                ariaLabel={strings.opAriaLabel}
                 testId="collectivex-kv-op-toggle"
                 options={[
                   { value: 'pull', label: 'pull' },

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -36,9 +36,10 @@ const STRINGS = {
     batchCaption: 'at the largest measured ISL',
     islCaption: 'at batch 1',
     frontierCaption:
-      'each line walks the batch ladder at the largest measured ISL; down-right is better. ' +
-      'Solid points are Pareto-optimal within their backend, ringed points across the whole SKU; ' +
-      'a backend that serializes requests collapses to a single point.',
+      'each line traces a backend Pareto frontier over its batch ladder at the largest measured ISL; ' +
+      'down-right is better. Full-color points are frontier-optimal within their backend, faded points ' +
+      'are dominated, ringed points are optimal across the whole SKU; a backend that serializes ' +
+      'requests collapses to a single point.',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
@@ -53,8 +54,8 @@ const STRINGS = {
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
     frontierCaption:
-      '每条线沿最大实测 ISL 的批大小阶梯移动，右下方更优。' +
-      '实心点为各后端内部的帕累托最优，带圆环的点为整个 SKU 范围内的最优；' +
+      '每条线为该后端在最大实测 ISL 下沿批大小阶梯的帕累托前沿，右下方更优。' +
+      '全色点为各后端内部的前沿最优，淡色点为被支配点，带圆环的点为整个 SKU 范围内的最优；' +
       '串行处理请求的后端会收缩为一个点。',
     yControl: '指标',
     xControl: 'X 轴',

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -13,6 +13,7 @@ import { track } from '@/lib/analytics';
 import { useLocale } from '@/lib/use-locale';
 
 import { CollectiveXKvChart } from './CollectiveXKvChart';
+import { CollectiveXKvFrontierChart } from './CollectiveXKvFrontierChart';
 import {
   type CollectiveXKvChartSelection,
   type CollectiveXKvRunCase,
@@ -34,6 +35,10 @@ const STRINGS = {
       'b1/bmax are requests posted per burst.',
     batchCaption: 'at the largest measured ISL',
     islCaption: 'at batch 1',
+    frontierCaption:
+      'each line walks the batch ladder at the largest measured ISL; down-right is better. ' +
+      'Solid points are Pareto-optimal within their backend, ringed points across the whole SKU; ' +
+      'a backend that serializes requests collapses to a single point.',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
@@ -47,6 +52,10 @@ const STRINGS = {
       'GB/s 为最大 ISL 处按突发聚合的 pull 带宽；b1/bmax 表示每次突发提交的请求数。',
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
+    frontierCaption:
+      '每条线沿最大实测 ISL 的批大小阶梯移动，右下方更优。' +
+      '实心点为各后端内部的帕累托最优，带圆环的点为整个 SKU 范围内的最优；' +
+      '串行处理请求的后端会收缩为一个点。',
     yControl: '指标',
     xControl: 'X 轴',
     pageControl: '页大小',
@@ -88,7 +97,7 @@ export function CollectiveXKvSection({
   const locale = useLocale();
   const strings = STRINGS[locale === 'zh' ? 'zh' : 'en'];
   const [yAxis, setYAxis] = useState<CollectiveXKvChartSelection['y']>('bandwidth');
-  const [xAxis, setXAxis] = useState<CollectiveXKvChartSelection['x']>('batch');
+  const [xAxis, setXAxis] = useState<CollectiveXKvChartSelection['x'] | 'frontier'>('batch');
   const [pageTokens, setPageTokens] = useState<'64' | '16'>('64');
   const [op, setOp] = useState<CollectiveXKvChartSelection['op']>('pull');
   // Legend toggles are keyed to the current series set: when checked runs
@@ -246,7 +255,7 @@ export function CollectiveXKvSection({
   if (rows.length === 0) return null;
   const measured = rows.filter((row) => row.outcome === 'success').length;
   const selection: CollectiveXKvChartSelection = {
-    x: xAxis,
+    x: xAxis === 'frontier' ? 'batch' : xAxis,
     y: yAxis,
     op,
     pageTokens: Number(pageTokens),
@@ -260,22 +269,24 @@ export function CollectiveXKvSection({
       {measuredCases.length > 0 && (
         <>
           <div className="mt-3 flex flex-wrap items-end gap-x-5 gap-y-3">
-            <div className="grid gap-1.5">
-              <Label className="text-xs text-muted-foreground">{strings.yControl}</Label>
-              <SegmentedToggle
-                value={yAxis}
-                onValueChange={(value) => {
-                  setYAxis(value);
-                  track('collectivex_kv_metric_changed', { metric: value });
-                }}
-                ariaLabel="CollectiveX kv metric"
-                testId="collectivex-kv-metric-toggle"
-                options={[
-                  { value: 'bandwidth', label: 'GB/s' },
-                  { value: 'latency', label: 'ms' },
-                ]}
-              />
-            </div>
+            {xAxis !== 'frontier' && (
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-muted-foreground">{strings.yControl}</Label>
+                <SegmentedToggle
+                  value={yAxis}
+                  onValueChange={(value) => {
+                    setYAxis(value);
+                    track('collectivex_kv_metric_changed', { metric: value });
+                  }}
+                  ariaLabel="CollectiveX kv metric"
+                  testId="collectivex-kv-metric-toggle"
+                  options={[
+                    { value: 'bandwidth', label: 'GB/s' },
+                    { value: 'latency', label: 'ms' },
+                  ]}
+                />
+              </div>
+            )}
             <div className="grid gap-1.5">
               <Label className="text-xs text-muted-foreground">{strings.xControl}</Label>
               <SegmentedToggle
@@ -289,6 +300,7 @@ export function CollectiveXKvSection({
                 options={[
                   { value: 'batch', label: 'Batch' },
                   { value: 'isl', label: 'ISL' },
+                  { value: 'frontier', label: 'Frontier' },
                 ]}
               />
             </div>
@@ -320,28 +332,52 @@ export function CollectiveXKvSection({
             </div>
           </div>
           <div className="relative mt-3">
-            <CollectiveXKvChart
-              chartId="collectivex-kv"
-              testId="collectivex-kv-chart"
-              cases={activeCases}
-              colors={colors}
-              selection={selection}
-              caption={
-                <p className="text-sm text-muted-foreground">
-                  {op} · page {pageTokens} ·{' '}
-                  {xAxis === 'batch' ? strings.batchCaption : strings.islCaption}
-                </p>
-              }
-              legendElement={
-                <ChartLegend
-                  variant="sidebar"
-                  legendItems={legendItems}
-                  disableActiveSort
-                  isLegendExpanded={legendExpanded}
-                  onExpandedChange={setLegendExpanded}
-                />
-              }
-            />
+            {xAxis === 'frontier' ? (
+              <CollectiveXKvFrontierChart
+                chartId="collectivex-kv-frontier"
+                testId="collectivex-kv-frontier-chart"
+                cases={activeCases}
+                colors={colors}
+                selection={{ op, pageTokens: Number(pageTokens) }}
+                caption={
+                  <p className="text-sm text-muted-foreground">
+                    {op} · page {pageTokens} · {strings.frontierCaption}
+                  </p>
+                }
+                legendElement={
+                  <ChartLegend
+                    variant="sidebar"
+                    legendItems={legendItems}
+                    disableActiveSort
+                    isLegendExpanded={legendExpanded}
+                    onExpandedChange={setLegendExpanded}
+                  />
+                }
+              />
+            ) : (
+              <CollectiveXKvChart
+                chartId="collectivex-kv"
+                testId="collectivex-kv-chart"
+                cases={activeCases}
+                colors={colors}
+                selection={selection}
+                caption={
+                  <p className="text-sm text-muted-foreground">
+                    {op} · page {pageTokens} ·{' '}
+                    {xAxis === 'batch' ? strings.batchCaption : strings.islCaption}
+                  </p>
+                }
+                legendElement={
+                  <ChartLegend
+                    variant="sidebar"
+                    legendItems={legendItems}
+                    disableActiveSort
+                    isLegendExpanded={legendExpanded}
+                    onExpandedChange={setLegendExpanded}
+                  />
+                }
+              />
+            )}
           </div>
         </>
       )}

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -36,10 +36,10 @@ const STRINGS = {
     batchCaption: 'at the largest measured ISL',
     islCaption: 'at batch 1',
     frontierCaption:
-      'each line traces a backend Pareto frontier over its batch ladder at the largest measured ISL; ' +
-      'down-right is better. Full-color points are frontier-optimal within their backend, faded points ' +
-      'are dominated, ringed points are optimal across the whole SKU; a backend that serializes ' +
-      'requests collapses to a single point.',
+      'each line walks the batch ladder at the largest measured ISL; down-right is better. ' +
+      'Full-color points are frontier-optimal within their backend, faded points are dominated, ' +
+      'ringed points are optimal across the whole SKU; a backend that serializes requests ' +
+      'collapses to a single point.',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
@@ -54,7 +54,7 @@ const STRINGS = {
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
     frontierCaption:
-      '每条线为该后端在最大实测 ISL 下沿批大小阶梯的帕累托前沿，右下方更优。' +
+      '每条线沿最大实测 ISL 的批大小阶梯移动，右下方更优。' +
       '全色点为各后端内部的前沿最优，淡色点为被支配点，带圆环的点为整个 SKU 范围内的最优；' +
       '串行处理请求的后端会收缩为一个点。',
     yControl: '指标',

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -37,9 +37,8 @@ const STRINGS = {
     islCaption: 'at batch 1',
     frontierCaption:
       'each line walks the batch ladder at the largest measured ISL; down-right is better. ' +
-      'Full-color points are frontier-optimal within their backend, faded points are dominated, ' +
-      'ringed points are optimal across the whole SKU; a backend that serializes requests ' +
-      'collapses to a single point.',
+      'A backend that serializes requests collapses to a single point; hover a point for its ' +
+      'Pareto status.',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
@@ -55,8 +54,7 @@ const STRINGS = {
     islCaption: '取批大小 1',
     frontierCaption:
       '每条线沿最大实测 ISL 的批大小阶梯移动，右下方更优。' +
-      '全色点为各后端内部的前沿最优，淡色点为被支配点，带圆环的点为整个 SKU 范围内的最优；' +
-      '串行处理请求的后端会收缩为一个点。',
+      '串行处理请求的后端会收缩为一个点；悬停可查看各点的帕累托状态。',
     yControl: '指标',
     xControl: 'X 轴',
     pageControl: '页大小',

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -16,6 +16,7 @@ import {
   seriesMatchesSelection,
   type CollectiveXSeriesSelection,
   collectiveXKvChartPoints,
+  collectiveXKvFrontierPoints,
   type CollectiveXKvRunCase,
   collectiveXKvCell,
 } from './data';
@@ -307,6 +308,8 @@ describe('chartPoints', () => {
   });
 });
 
+const p95 = (value: number) => ({ p50: value, p95: value, min: value, max: value, n: 24 });
+
 const kvRow = ({
   latency_p50,
   ...overrides
@@ -437,5 +440,72 @@ describe('collectiveXKvChartPoints', () => {
       pageTokens: 64,
     });
     expect(points).toEqual([]);
+  });
+
+  describe('collectiveXKvFrontierPoints', () => {
+    const selection = { op: 'pull', pageTokens: 64 } as const;
+
+    it('plots aggregate GB/s against p95 per in-flight request at the largest ISL', () => {
+      const points = collectiveXKvFrontierPoints(
+        [
+          kase([
+            { isl: 4096, batch: 1, gbps_p50: 5, latency_ms: p95(2) },
+            { isl: 32768, batch: 1, gbps_p50: 7.5, latency_ms: p95(24) },
+            { isl: 32768, batch: 16, gbps_p50: 30, latency_ms: p95(96) },
+            { isl: 32768, batch: 16, op: 'push', gbps_p50: 99, latency_ms: p95(1) },
+          ]),
+        ],
+        selection,
+      );
+      expect(points.map((point) => [point.x, point.y])).toEqual([
+        [7.5, 24],
+        [30, 6],
+      ]);
+      expect(points[0].sku).toBe('gb200');
+    });
+
+    it('fades within-series dominated points and keeps the ladder frontier', () => {
+      const points = collectiveXKvFrontierPoints(
+        [
+          kase([
+            // batch 4 beats batch 1 on both axes; batch 16 trades latency for rate.
+            { batch: 1, gbps_p50: 7.5, latency_ms: p95(26) },
+            { batch: 4, gbps_p50: 20, latency_ms: p95(40) },
+            { batch: 16, gbps_p50: 30, latency_ms: p95(320) },
+          ]),
+        ],
+        selection,
+      );
+      expect(points.map((point) => point.onSeriesFrontier)).toEqual([false, true, true]);
+    });
+
+    it('rings only the SKU-wide frontier across backends of the same SKU', () => {
+      const points = collectiveXKvFrontierPoints(
+        [
+          kase([{ batch: 1, gbps_p50: 20, latency_ms: p95(10) }]),
+          kase([{ batch: 1, gbps_p50: 8, latency_ms: p95(30) }], {
+            case_id: 'gb200-mooncake-kv-dsv4-rdma-xfer-ep2-paged-fp8',
+            backend: 'mooncake',
+          }),
+        ],
+        selection,
+      );
+      expect(points.map((point) => point.onSeriesFrontier)).toEqual([true, true]);
+      expect(points.map((point) => point.onSkuFrontier)).toEqual([true, false]);
+    });
+
+    it('never lets one SKU dominate another', () => {
+      const points = collectiveXKvFrontierPoints(
+        [
+          kase([{ batch: 1, gbps_p50: 20, latency_ms: p95(10) }]),
+          kase([{ batch: 1, gbps_p50: 8, latency_ms: p95(30) }], {
+            case_id: 'h200-nixl-kv-dsv4-rdma-xfer-ep2-paged-fp8',
+            sku: 'h200',
+          }),
+        ],
+        selection,
+      );
+      expect(points.map((point) => point.onSkuFrontier)).toEqual([true, true]);
+    });
   });
 });

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -278,6 +278,86 @@ export function collectiveXKvLegendLabel(kase: CollectiveXKvCase): string {
  * story); ISL on the x axis reads at batch 1 (a single request's handoff).
  * Paged rows only: the single-descriptor bulk ceiling stays a table column.
  */
+export interface CollectiveXKvFrontierSelection {
+  op: 'pull' | 'push';
+  pageTokens: number;
+}
+
+export interface CollectiveXKvFrontierPoint {
+  seriesId: string;
+  seriesLabel: string;
+  colorKey: string;
+  sku: string;
+  /** Aggregate burst bandwidth at p50 (GB/s). */
+  x: number;
+  /** Burst p95 latency divided by requests in flight (ms per request). */
+  y: number;
+  onSeriesFrontier: boolean;
+  onSkuFrontier: boolean;
+  row: CollectiveXKvRow;
+}
+
+/** More throughput at no worse per-request cost, strictly better in one. */
+function frontierDominates(
+  a: Pick<CollectiveXKvFrontierPoint, 'x' | 'y'>,
+  b: Pick<CollectiveXKvFrontierPoint, 'x' | 'y'>,
+): boolean {
+  return a.x >= b.x && a.y <= b.y && (a.x > b.x || a.y < b.y);
+}
+
+/**
+ * Concurrency-frontier points: each case's batch ladder at the largest
+ * measured ISL (the same slice the batch view plots), re-expressed as
+ * aggregate GB/s against p95 latency per in-flight request. A backend that
+ * overlaps requests traces a curve toward the lower right; a serializing
+ * backend collapses to a point (constant aggregate rate, constant
+ * per-request cost). Two dominance tiers: within a series (its own best
+ * operating points) and across every series of the same SKU (which backend
+ * to deploy on that machine).
+ */
+export function collectiveXKvFrontierPoints(
+  cases: readonly CollectiveXKvRunCase[],
+  selection: CollectiveXKvFrontierSelection,
+): CollectiveXKvFrontierPoint[] {
+  const points = cases.flatMap((kase) => {
+    const matching = kase.rows.filter(
+      (row) =>
+        row.kind === 'paged' && row.op === selection.op && row.page_tokens === selection.pageTokens,
+    );
+    if (matching.length === 0) return [];
+    const isl = Math.max(...matching.map((row) => row.isl));
+    return matching
+      .filter((row) => row.isl === isl)
+      .flatMap((row) => {
+        const x = row.gbps_p50;
+        const y = row.latency_ms.p95 / row.batch;
+        if (!Number.isFinite(x) || x <= 0 || !Number.isFinite(y) || y <= 0) return [];
+        return [
+          {
+            seriesId: `${kase.run_id}:${kase.case_id}`,
+            seriesLabel: `#${kase.run_id} · ${collectiveXKvLegendLabel(kase)}`,
+            colorKey: collectiveXKvColorKey(kase),
+            sku: normalizeCollectiveXSku(kase.sku),
+            x,
+            y,
+            onSeriesFrontier: false,
+            onSkuFrontier: false,
+            row,
+          },
+        ];
+      });
+  });
+  for (const point of points) {
+    point.onSeriesFrontier = !points.some(
+      (other) => other.seriesId === point.seriesId && frontierDominates(other, point),
+    );
+    point.onSkuFrontier = !points.some(
+      (other) => other.sku === point.sku && frontierDominates(other, point),
+    );
+  }
+  return points;
+}
+
 export function collectiveXKvChartPoints(
   cases: readonly CollectiveXKvRunCase[],
   selection: CollectiveXKvChartSelection,


### PR DESCRIPTION
## What

Adds a third **Frontier** option to the KV transfer chart's X-axis toggle. It plots each backend's batch ladder at the largest measured ISL—the same slice as the Batch view—as aggregate pull/push bandwidth (GB/s, p50) against p95 burst latency divided by requests in flight, on log-log axes.

`collectiveXKvFrontierPoints` computes Pareto status at two scopes:

- **Within backend**: whether the operating point is dominated by another point in the same backend series.
- **Across the SKU**: whether any backend series on the same SKU dominates the point.

Each backend's full batch ladder is drawn in the same 2.5 px roofline style as `/inference`. Points use a uniform style, while the tooltip reports whether each point is on the backend frontier, on the SKU-wide frontier, or dominated. Multi-run lines retain the dash pattern advertised by the shared run table and legend.

The reading: a backend that overlaps in-flight requests traces a curve toward the lower right as batch grows; a backend that serializes them (constant aggregate rate, constant per-request cost) collapses to a single point.

The Metric (GB/s vs ms) toggle hides in Frontier mode because both axes are fixed; page size, direction, and legend toggles keep working. The new control, chart axes, instructions, empty state, and tooltip are localized for both English and Simplified Chinese.

This follow-up also updates the mobile landing performance assertion for the five intentional lazy AgentX model marks, fixing the repeated Firefox shard failure against current `master` behavior while continuing to reject the former supporter-logo set.

## Tests

- Four Vitest cases for `collectiveXKvFrontierPoints`: axis math at the largest ISL, within-series dominance, SKU-wide dominance across backends, and no cross-SKU domination.
- Cypress coverage for Frontier mode, fixed axes, hidden Metric control, multi-run dash patterns, and Simplified Chinese copy.
- Targeted `collectivex.cy.ts` and `landing-performance.cy.ts` runs in Chrome and Firefox: 36/36 passing in each browser.
- `bun run test:unit`: 304 files and 5,122 tests passing across all workspaces.
- `bun run test:e2e`: 108 smoke tests passing.
- `bun run build`, `bun run lint`, `bun run fmt`, and `bun run typecheck` passing.

## 中文说明

为 KV 传输图表的 X 轴切换新增第三个 **帕累托前沿** 选项。该视图取每个后端在最大实测 ISL 下的 batch 阶梯（与 Batch 视图使用同一数据切片），在双对数坐标中以聚合 pull/push 带宽（GB/s，p50）为横轴，以突发 p95 延迟除以在途请求数为纵轴。

`collectiveXKvFrontierPoints` 会在两个范围内计算帕累托状态：

- **后端内部**：判断某个工作点是否被同一后端序列中的其他点支配。
- **SKU 范围**：判断同一 SKU 上是否存在其他后端序列支配该点。

每个后端的完整 batch 阶梯均采用与 `/inference` 一致的 2.5 px roofline 样式。所有数据点使用统一样式，提示框会说明该点属于后端帕累托前沿、SKU 级帕累托前沿，还是被支配点。多运行对比时，曲线会保留运行表格和共享图例所标示的虚线样式。

解读方式：能并行处理在途请求的后端会随 batch 增大向右下方延伸出曲线；串行处理请求的后端（聚合速率恒定、单请求成本恒定）则会收缩为一个点。

Frontier 模式下隐藏 Metric（GB/s 与 ms）切换，因为两个坐标轴均已固定；页大小、传输方向和图例开关照常工作。新增的控件、坐标轴、操作提示、空状态和提示框均提供英文与简体中文文案。

本次修复还更新了移动端首页性能断言，使其兼容当前 `master` 中有意懒加载的五个 AgentX 模型标志，修复 Firefox 分片反复失败的问题，同时继续防止旧版支持者 logo 集合被加载。

### 测试

- 为 `collectiveXKvFrontierPoints` 添加四个 Vitest 用例，覆盖最大 ISL 下的坐标计算、序列内部支配关系、同一 SKU 跨后端支配关系，以及不同 SKU 之间互不支配。
- 添加 Cypress 覆盖，验证 Frontier 模式、固定坐标轴、隐藏 Metric 控件、多运行虚线样式和简体中文文案。
- 在 Chrome 和 Firefox 中定向运行 `collectivex.cy.ts` 与 `landing-performance.cy.ts`，两个浏览器均为 36/36 通过。
- `bun run test:unit`：全部 workspace 共 304 个测试文件、5,122 个测试通过。
- `bun run test:e2e`：108 个 smoke 测试通过。
- `bun run build`、`bun run lint`、`bun run fmt` 和 `bun run typecheck` 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and analytics visualization on CollectiveX KV data plus a landing perf test tweak; no auth, API, or persistence changes.
> 
> **Overview**
> Adds a **Frontier** X-axis mode on the CollectiveX KV transfer section: a log–log chart of aggregate p50 bandwidth vs p95 latency per in-flight request, with each backend drawn as its batch ladder at the largest measured ISL (same slice as Batch view).
> 
> **`collectiveXKvFrontierPoints`** builds the points and marks **within-series** and **SKU-wide** Pareto dominance; the new **`CollectiveXKvFrontierChart`** renders batch-ladder lines (shared run dash patterns with the EP explorer), points, zoom, and tooltips that label each point’s frontier tier. **`CollectiveXKvSection`** switches between the existing KV chart and the frontier chart, hides the GB/s vs ms metric toggle in frontier mode, and adds EN/ZH copy and aria labels.
> 
> Coverage: Vitest for frontier math and dominance rules; Cypress for multi-run frontier axes, metric toggle absence, and Chinese UI. **`landing-performance.cy.ts`** is updated so mobile logo assertions match the AgentX ledger (lazy `-color.svg` marks, cap &lt; 6) instead of the old quote carousel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0fa2151b45863ef1f3753cbf03e5f9957393bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->