### PR TITLE
feat(app): role-local measured energy axes + per-worker power drilldown | 前端：新增角色级实测能耗坐标轴与每 worker 功耗下钻

### DIFF
--- a/packages/app/cypress/e2e/agentic-measured-power.cy.ts
+++ b/packages/app/cypress/e2e/agentic-measured-power.cy.ts
@@ -1,0 +1,157 @@
+// AgentX measured power (PLAN-10 / gap G15): the role-local energy axes
+// (Measured Prefill/Decode J per token) render for agentic runs, and pinned
+// tooltips carry the per-worker power drilldown when the row ships workers[].
+//
+// The shared cypress/fixtures/api/*.json files contain ZERO agentic rows (by
+// design), so this spec injects agentic availability + benchmark rows via
+// spec-scoped intercepts, following ttft-x-axis-toggle.cy.ts. Production
+// AgentX rows currently ship workers: null (producer emission lands with
+// PLAN-09), so the synthetic workers here verify the UI ahead of real data —
+// and the workers-less series proves the graceful-absence path.
+import { interceptDerivedAgenticMetrics, unlockAgenticGate } from '../support/e2e';
+import {
+  agenticMetrics,
+  measuredPowerMetrics,
+  syntheticWorkers,
+} from '../support/agentic-fixtures';
+
+const MODEL_DB_KEY = 'dsv4'; // DeepSeek-V4-Pro
+const AGENTIC_DATE = '2026-06-12';
+
+// One disaggregated series carrying role energy + workers, one aggregate
+// series with whole-run measured metrics only and no workers.
+const POWER_GPUS = [
+  { hardware: 'b200', framework: 'vllm', disagg: true },
+  { hardware: 'b300', framework: 'vllm', disagg: false },
+];
+
+const agenticAvailability = POWER_GPUS.flatMap((g) => [
+  {
+    model: MODEL_DB_KEY,
+    isl: null,
+    osl: null,
+    precision: 'fp4',
+    hardware: g.hardware,
+    framework: g.framework,
+    spec_method: 'none',
+    disagg: g.disagg,
+    benchmark_type: 'agentic_traces',
+    date: AGENTIC_DATE,
+  },
+  {
+    model: MODEL_DB_KEY,
+    isl: 8192,
+    osl: 1024,
+    precision: 'fp4',
+    hardware: g.hardware,
+    framework: g.framework,
+    spec_method: 'none',
+    disagg: g.disagg,
+    benchmark_type: 'single_turn',
+    date: AGENTIC_DATE,
+  },
+]);
+
+let benchIdCursor = 930000;
+const agenticBenchmarks = POWER_GPUS.flatMap((g) =>
+  [16, 64, 128].map((conc) => ({
+    id: benchIdCursor++,
+    hardware: g.hardware,
+    framework: g.framework,
+    model: MODEL_DB_KEY,
+    precision: 'fp4',
+    spec_method: 'none',
+    disagg: g.disagg,
+    is_multinode: g.disagg,
+    prefill_tp: 8,
+    prefill_ep: 1,
+    prefill_dp_attention: false,
+    prefill_num_workers: g.disagg ? 1 : 0,
+    decode_tp: 8,
+    decode_ep: 1,
+    decode_dp_attention: false,
+    decode_num_workers: g.disagg ? 1 : 0,
+    num_prefill_gpu: 8,
+    num_decode_gpu: 8,
+    isl: null,
+    osl: null,
+    conc,
+    offload_mode: 'off',
+    benchmark_type: 'agentic_traces',
+    image: 'vllm/vllm-openai:v0.9.0',
+    metrics: { ...agenticMetrics(conc), ...measuredPowerMetrics(conc, { disagg: g.disagg }) },
+    workers: g.disagg ? syntheticWorkers(true) : null,
+    date: AGENTIC_DATE,
+    run_url: null,
+  })),
+);
+
+const DISAGG_DOTS = '.dot-group[data-hw-key^="b200"]';
+const AGGREGATE_DOTS = '.dot-group[data-hw-key^="b300"]';
+
+describe('AgentX measured power (role energy axes + worker drilldown)', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/v1/availability', { body: agenticAvailability }).as('availability');
+    cy.intercept('GET', '/api/v1/benchmarks*', { body: agenticBenchmarks }).as('benchmarks');
+    interceptDerivedAgenticMetrics();
+    // No stored traces or logs for the synthetic ids: keeps the pinned
+    // tooltip free of the "View charts/logs" actions this spec doesn't test.
+    cy.intercept('GET', '/api/v1/trace-availability*', (request) => {
+      const ids = new URL(request.url).searchParams.get('ids')?.split(',').filter(Boolean) ?? [];
+      request.reply({ body: Object.fromEntries(ids.map((id) => [id, false])) });
+    });
+    cy.intercept('GET', '/api/v1/log-availability*', (request) => {
+      const ids = new URL(request.url).searchParams.get('ids')?.split(',').filter(Boolean) ?? [];
+      request.reply({ body: Object.fromEntries(ids.map((id) => [id, false])) });
+    });
+    cy.visit('/inference?i_seq=agentic-traces', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        unlockAgenticGate(win);
+      },
+    });
+    cy.get('[data-testid="scatter-graph"] .dot-group').should('have.length.greaterThan', 0);
+  });
+
+  it('offers the role-energy axes and coverage-filters series without role energy', () => {
+    cy.get('[data-testid="yaxis-metric-selector"]').click();
+    cy.contains('[data-slot="select-content"]', 'Measured Energy')
+      .scrollIntoView()
+      .should('be.visible');
+    cy.contains('[role="option"]', 'Measured Prefill Joules per Input Token')
+      .scrollIntoView()
+      .should('be.visible');
+    cy.contains('[role="option"]', 'Measured Decode Joules per Output Token')
+      .scrollIntoView()
+      .should('be.visible');
+
+    cy.contains('[role="option"]', 'Measured Prefill Joules per Input Token').click();
+    cy.get('[data-slot="select-content"]').should('not.exist');
+
+    // Only the disagg series carries prefill_joules_per_input_token; the
+    // aggregate series drops off the chart while the legend universe stays
+    // intact (selectionPoints reconciliation).
+    cy.get(DISAGG_DOTS).should('have.length', 3);
+    cy.get(AGGREGATE_DOTS).should('not.exist');
+    cy.get('[data-testid="chart-legend"]').should('contain.text', 'B200');
+    cy.get('[data-testid="chart-legend"]').should('contain.text', 'B300');
+  });
+
+  it('renders the per-worker power table on a pinned agentic tooltip', () => {
+    cy.get(`${DISAGG_DOTS} .visible-shape`).first().click({ force: true });
+
+    cy.get('[data-chart-tooltip]:visible').should('have.length', 1);
+    cy.get('[data-chart-tooltip]:visible [data-testid="tooltip-worker-power"]')
+      .should('exist')
+      .and('contain.text', 'prefill[0]')
+      .and('contain.text', '612.3 W')
+      .and('contain.text', 'decode[0]');
+  });
+
+  it('stays graceful when the pinned point has no workers payload', () => {
+    cy.get(`${AGGREGATE_DOTS} .visible-shape`).first().click({ force: true });
+
+    cy.get('[data-chart-tooltip]:visible').should('have.length', 1);
+    cy.get('[data-testid="tooltip-worker-power"]').should('not.exist');
+  });
+});

--- a/packages/app/cypress/e2e/agentic-measured-power.cy.ts
+++ b/packages/app/cypress/e2e/agentic-measured-power.cy.ts
@@ -129,11 +129,20 @@ describe('AgentX measured power (role energy axes + worker drilldown)', () => {
     cy.get('[data-slot="select-content"]').should('not.exist');
 
     // Only the disagg series carries prefill_joules_per_input_token; the
-    // aggregate series drops off the chart while the legend universe stays
-    // intact (selectionPoints reconciliation).
+    // aggregate series is coverage-filtered off the chart AND out of the
+    // rendered legend (hwTypesWithData is metric-aware — InferenceContext).
     cy.get(DISAGG_DOTS).should('have.length', 3);
     cy.get(AGGREGATE_DOTS).should('not.exist');
     cy.get('[data-testid="chart-legend"]').should('contain.text', 'B200');
+    cy.get('[data-testid="chart-legend"]').should('not.contain.text', 'B300');
+
+    // The switch is non-destructive: the selection universe never intersects
+    // metric coverage (selectableHwTypes), so picking a whole-run measured
+    // axis both series carry brings the aggregate series straight back.
+    cy.get('[data-testid="yaxis-metric-selector"]').click();
+    cy.contains('[role="option"]', 'Measured Joules per Output Token').scrollIntoView().click();
+    cy.get('[data-slot="select-content"]').should('not.exist');
+    cy.get(AGGREGATE_DOTS).should('have.length', 3);
     cy.get('[data-testid="chart-legend"]').should('contain.text', 'B300');
   });
 

--- a/packages/app/cypress/support/agentic-fixtures.ts
+++ b/packages/app/cypress/support/agentic-fixtures.ts
@@ -9,6 +9,61 @@ export function percentileLadder(prefix: string, base: number): Record<string, n
   };
 }
 
+/**
+ * Deterministic measured-power telemetry (schema v2, validated) so axis
+ * positions are stable across runs. `disagg` adds the role splits — role
+ * watts plus the role-local energy scalars behind the
+ * Measured Prefill/Decode J-per-token axes.
+ */
+export function measuredPowerMetrics(
+  concurrency: number,
+  opts: { disagg?: boolean } = {},
+): Record<string, number> {
+  const scale = concurrency / 16;
+  return {
+    power_valid: 1,
+    power_metric_schema_version: 2,
+    avg_power_w: 600 + 10 * scale,
+    joules_per_input_token: 0.3 / scale,
+    joules_per_output_token: 8 / scale,
+    joules_per_total_token: 0.9 / scale,
+    joules_per_successful_query: 1500 / scale,
+    avg_temp_c: 65 + scale,
+    avg_util_pct: 80 + scale,
+    ...(opts.disagg
+      ? {
+          prefill_avg_power_w: 612.3,
+          decode_avg_power_w: 701.5,
+          prefill_joules_per_input_token: 0.4 / scale,
+          decode_joules_per_output_token: 5.1 / scale,
+        }
+      : {}),
+  };
+}
+
+/**
+ * WorkerPower-shaped rows for the pinned-tooltip drilldown. Plain object
+ * literals — cypress support files never import types from src.
+ */
+export function syntheticWorkers(disagg: boolean) {
+  if (!disagg) {
+    return [{ role: 'agg', worker_idx: 0, hosts: ['n0'], num_gpus: 8, avg_power_w: 640.2 }];
+  }
+  return [
+    { role: 'frontend', worker_idx: 0, hosts: ['fe0'], num_gpus: 0, avg_power_w: 120 },
+    {
+      role: 'prefill',
+      worker_idx: 0,
+      hosts: ['pn0'],
+      num_gpus: 8,
+      avg_power_w: 612.3,
+      avg_temp_c: 68.4,
+      avg_util_pct: 88.5,
+    },
+    { role: 'decode', worker_idx: 0, hosts: ['dn0'], num_gpus: 8, avg_power_w: 701.5 },
+  ];
+}
+
 export function agenticMetrics(concurrency: number): Record<string, number> {
   const scale = concurrency / 16;
   const itl = 0.011 * scale;

--- a/packages/app/src/components/inference/axis-metric-explanations.ts
+++ b/packages/app/src/components/inference/axis-metric-explanations.ts
@@ -262,6 +262,41 @@ function measuredJoulesPerToken(tokenType: TokenType): MetricExplanation {
   };
 }
 
+const MEASURED_ROLE_EN: Record<'prefill' | 'decode', { tokens: string; isolates: string }> = {
+  prefill: { tokens: 'input (prompt)', isolates: 'prompt-processing' },
+  decode: { tokens: 'output', isolates: 'token-generation' },
+};
+
+const MEASURED_ROLE_ZH: Record<'prefill' | 'decode', { tokens: string; isolates: string }> = {
+  prefill: { tokens: '输入', isolates: '提示词处理' },
+  decode: { tokens: '输出', isolates: 'token 生成' },
+};
+
+function measuredRoleJoulesPerToken(role: 'prefill' | 'decode'): MetricExplanation {
+  return {
+    description: {
+      en:
+        `Measured accelerator energy consumed by the ${role} workers per ` +
+        `${MEASURED_ROLE_EN[role].tokens} token, from runner power telemetry integrated over ` +
+        `the run. Unlike the whole-deployment J/tok metrics, only that role's energy is ` +
+        `charged, so it isolates ${MEASURED_ROLE_EN[role].isolates} efficiency in ` +
+        `disaggregated deployments.${MEASURED_TIER_NOTE_EN}`,
+      zh:
+        `每个${MEASURED_ROLE_ZH[role].tokens} token 由 ${MEASURED_PHASE_ZH[role]}工作进程消耗的` +
+        `加速器实测能耗，由运行器功耗遥测在整个运行期间积分得到。与全部署 J/tok 指标不同，` +
+        `它只计入该角色的能耗，因此可以在分离式部署中单独衡量${
+          MEASURED_ROLE_ZH[role].isolates
+        }效率。${MEASURED_TIER_NOTE_ZH}`,
+    },
+    formula: {
+      en:
+        `J/tok = measured ${role}-worker energy over the run ÷ ` +
+        `${role === 'prefill' ? 'input' : 'output'} tokens processed`,
+      zh: `J/tok = 运行期间 ${role} 工作进程实测能耗 ÷ 处理的${MEASURED_ROLE_ZH[role].tokens} token 数`,
+    },
+  };
+}
+
 /**
  * Every `METRIC_REGISTRY` key gets a bilingual explanation and a structural
  * formula. Grounded in `buildDerivedChartFields` (src/lib/chart-utils.ts) and
@@ -352,6 +387,8 @@ export const METRIC_EXPLANATIONS: Record<MetricKey, MetricExplanation> = {
   measuredJPerOutputToken: measuredJoulesPerToken('output'),
   measuredJPerInputToken: measuredJoulesPerToken('input'),
   measuredJPerTotalToken: measuredJoulesPerToken('total'),
+  measuredPrefillJPerInputToken: measuredRoleJoulesPerToken('prefill'),
+  measuredDecodeJPerOutputToken: measuredRoleJoulesPerToken('decode'),
   measuredJPerSuccessfulQuery: {
     description: {
       en:

--- a/packages/app/src/components/inference/measured-power-direction.test.ts
+++ b/packages/app/src/components/inference/measured-power-direction.test.ts
@@ -35,6 +35,11 @@ const QUERY_ENERGY_METRICS = [
   'y_measuredWhPerSuccessfulQuery',
 ] as const;
 
+const ROLE_ENERGY_METRICS = [
+  'y_measuredPrefillJPerInputToken',
+  'y_measuredDecodeJPerOutputToken',
+] as const;
+
 const defs = chartDefinitions as unknown as ChartDefinition[];
 const interactivityDef = defs.find((d) => d.chartType === 'interactivity')!;
 const e2eDef = defs.find((d) => d.chartType === 'e2e')!;
@@ -140,6 +145,16 @@ describe('measured-power Pareto direction', () => {
   });
 
   it.each(QUERY_ENERGY_METRICS)('%s is bilingual and lower-is-better', (metric) => {
+    expect(declaredDirection(interactivityDef, metric)).toBe('lower_right');
+    expect(declaredDirection(e2eDef, metric)).toBe('lower_left');
+    for (const chartDef of [interactivityDef, e2eDef]) {
+      expect(chartDef[metric]).toMatch(/\.y$/u);
+      expect(chartDef[`${metric}_label`]).toBeTruthy();
+      expect(chartDef[`${metric}_labelZh`]).toBeTruthy();
+    }
+  });
+
+  it.each(ROLE_ENERGY_METRICS)('%s is bilingual and lower-is-better', (metric) => {
     expect(declaredDirection(interactivityDef, metric)).toBe('lower_right');
     expect(declaredDirection(e2eDef, metric)).toBe('lower_left');
     for (const chartDef of [interactivityDef, e2eDef]) {

--- a/packages/app/src/components/inference/metric-registry.test.ts
+++ b/packages/app/src/components/inference/metric-registry.test.ts
@@ -87,6 +87,12 @@ describe('metric compatibility', () => {
     expect(resolveMetricConfigKey('y_measuredJPerSuccessfulQuery')).toBe(
       'y_measuredJPerSuccessfulQuery',
     );
+    expect(resolveMetricConfigKey('y_measuredPrefillJPerInputToken')).toBe(
+      'y_measuredPrefillJPerInputToken',
+    );
+    expect(resolveMetricConfigKey('y_measuredDecodeJPerOutputToken')).toBe(
+      'y_measuredDecodeJPerOutputToken',
+    );
     expect(resolveMetricConfigKey('y_costUser')).toBe('y_costUser');
     expect(isBenchmarkMetricKey('tpPerGpu')).toBe(true);
     expect(isBenchmarkMetricKey('tokenRevenuePerGpuHour')).toBe(true);
@@ -101,5 +107,7 @@ describe('metric compatibility', () => {
     expect(tokenMetricTypeForConfigKey('y_tpPerGpu')).toBe('total');
     expect(tokenMetricTypeForConfigKey('y_tokenRevenuePerGpuHour')).toBe('total');
     expect(tokenMetricTypeForConfigKey('y_measuredAvgPower')).toBe('total');
+    expect(tokenMetricTypeForConfigKey('y_measuredPrefillJPerInputToken')).toBe('input');
+    expect(tokenMetricTypeForConfigKey('y_measuredDecodeJPerOutputToken')).toBe('output');
   });
 });

--- a/packages/app/src/components/inference/metric-registry.ts
+++ b/packages/app/src/components/inference/metric-registry.ts
@@ -375,12 +375,28 @@ export const METRIC_REGISTRY = {
     titleZh: '每输出 token 实测焦耳能耗',
     polarity: 'lower',
   },
+  measuredDecodeJPerOutputToken: {
+    field: 'measuredDecodeJPerOutputToken.y',
+    label: 'Measured Decode J per Output Token (J/tok)',
+    labelZh: '每输出 token 实测 Decode 能耗（J/tok）',
+    title: 'Measured Decode Joules per Output Token',
+    titleZh: '每输出 token 实测 Decode 焦耳能耗',
+    polarity: 'lower',
+  },
   measuredJPerInputToken: {
     field: 'measuredJPerInputToken.y',
     label: 'Measured J per Input Token (J/tok)',
     labelZh: '每输入 token 实测能耗（J/tok）',
     title: 'Measured Joules per Input Token',
     titleZh: '每输入 token 实测焦耳能耗',
+    polarity: 'lower',
+  },
+  measuredPrefillJPerInputToken: {
+    field: 'measuredPrefillJPerInputToken.y',
+    label: 'Measured Prefill J per Input Token (J/tok)',
+    labelZh: '每输入 token 实测 Prefill 能耗（J/tok）',
+    title: 'Measured Prefill Joules per Input Token',
+    titleZh: '每输入 token 实测 Prefill 焦耳能耗',
     polarity: 'lower',
   },
   measuredJPerTotalToken: {
@@ -484,7 +500,7 @@ export interface MetricControlGroup {
 }
 
 /**
- * The nine runner-telemetry y-axes in the "Measured Energy" control group.
+ * The runner-telemetry y-axes in the "Measured Energy" control group.
  * Exported (and referenced by the group below, so the two cannot drift) for
  * consumers that treat measured axes specially — the legacy-power point ring,
  * tooltip tier line, and footer legend key.
@@ -494,7 +510,9 @@ export const MEASURED_ENERGY_METRIC_CONFIG_KEYS = [
   'y_measuredDecodeAvgPower',
   'y_measuredAvgPower',
   'y_measuredJPerInputToken',
+  'y_measuredPrefillJPerInputToken',
   'y_measuredJPerOutputToken',
+  'y_measuredDecodeJPerOutputToken',
   'y_measuredJPerTotalToken',
   'y_measuredJPerSuccessfulQuery',
   'y_measuredWhPerSuccessfulQuery',

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -336,6 +336,9 @@ export interface InferenceData extends Partial<Omit<AggDataEntry, AggDataConflic
   measuredJPerOutputToken?: { y: number; roof: boolean };
   measuredJPerTotalToken?: { y: number; roof: boolean };
   measuredJPerInputToken?: { y: number; roof: boolean };
+  // Role-local energy (prefill/decode workers only) — disagg-only in practice.
+  measuredPrefillJPerInputToken?: { y: number; roof: boolean };
+  measuredDecodeJPerOutputToken?: { y: number; roof: boolean };
   measuredJPerSuccessfulQuery?: { y: number; roof: boolean };
   measuredWhPerSuccessfulQuery?: { y: number; roof: boolean };
   measuredPowerPercentTdp?: { y: number; roof: boolean };

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -728,6 +728,137 @@ describe('generateGPUGraphTooltipContent', () => {
 });
 
 // ===========================================================================
+// per-worker measured power drilldown (all three generators, pinned-only)
+// ===========================================================================
+describe('worker power drilldown', () => {
+  const workers = [
+    { role: 'frontend', worker_idx: 0, hosts: ['fe0'], num_gpus: 0, avg_power_w: 120 },
+    {
+      role: 'prefill',
+      worker_idx: 0,
+      hosts: ['pn0'],
+      num_gpus: 8,
+      avg_power_w: 612.3,
+      avg_temp_c: 68.4,
+      peak_temp_c: 79.2,
+      avg_util_pct: 88.5,
+      avg_mem_used_mb: 71234.5,
+    },
+    { role: 'decode', worker_idx: 0, hosts: ['dn0'], num_gpus: 8, avg_power_w: 701.5 },
+  ];
+
+  const overlayData = {
+    label: 'feature-branch',
+    hardwareConfig: mockHardwareConfig,
+    data: [],
+    runUrl: 'https://example.com',
+  } as any;
+
+  it('renders the worker table on a pinned tooltip in all three generators', () => {
+    const config = tooltipConfig({ data: pt({ workers }), isPinned: true });
+    const outputs = [
+      generateTooltipContent(config),
+      generateOverlayTooltipContent({ ...config, overlayData }),
+      generateGPUGraphTooltipContent(config),
+    ];
+    for (const html of outputs) {
+      expect(html).toContain('data-testid="tooltip-worker-power"');
+      expect(html).toContain('Measured Worker Power');
+      expect(html).toContain('<strong>prefill[0]</strong>');
+      expect(html).toContain('612.3 W');
+      expect(html).toContain('<strong>decode[0]</strong>');
+      expect(html).toContain('701.5 W');
+      expect(html).toContain('<strong>frontend[0]</strong>');
+      expect(html).toContain('0 chips');
+      expect(html).toContain('pn0');
+    }
+  });
+
+  it('includes optional telemetry cells only when the worker carries them', () => {
+    const html = generateTooltipContent(tooltipConfig({ data: pt({ workers }), isPinned: true }));
+    // Prefill worker: avg/peak temp, util %, mem in GiB (71234.5 MB ≈ 69.565 GiB).
+    expect(html).toContain('68.4/79.2°C');
+    expect(html).toContain('88.5%');
+    expect(html).toContain('69.565 GiB');
+    // Decode worker row (no telemetry) keeps only role/chips/watts/hosts.
+    const decodeRow = html.split('<strong>decode[0]</strong>')[1].split('</div>')[0];
+    expect(decodeRow).not.toContain('°C');
+    expect(decodeRow).not.toContain('%');
+    expect(decodeRow).not.toContain('GiB');
+  });
+
+  it('renders nothing when the tooltip is not pinned', () => {
+    const config = tooltipConfig({ data: pt({ workers }), isPinned: false });
+    expect(generateTooltipContent(config)).not.toContain('tooltip-worker-power');
+    expect(generateOverlayTooltipContent({ ...config, overlayData })).not.toContain(
+      'tooltip-worker-power',
+    );
+    expect(generateGPUGraphTooltipContent(config)).not.toContain('tooltip-worker-power');
+  });
+
+  it('renders nothing when workers is absent or empty', () => {
+    expect(generateTooltipContent(tooltipConfig({ isPinned: true }))).not.toContain(
+      'tooltip-worker-power',
+    );
+    expect(
+      generateTooltipContent(tooltipConfig({ data: pt({ workers: [] }), isPinned: true })),
+    ).not.toContain('tooltip-worker-power');
+  });
+
+  it('caps the table at 8 rows with a "+N more workers" line', () => {
+    const many = Array.from({ length: 10 }, (_, i) => ({
+      role: 'decode',
+      worker_idx: i,
+      num_gpus: 8,
+      avg_power_w: 700 + i,
+    }));
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ workers: many }), isPinned: true }),
+    );
+    expect(html).toContain('<strong>decode[7]</strong>');
+    expect(html).not.toContain('<strong>decode[8]</strong>');
+    expect(html).toContain('+2 more workers');
+  });
+
+  it('renders the ZH strings under the zh locale', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ workers }), isPinned: true, locale: 'zh' }),
+    );
+    expect(html).toContain('各 Worker 实测功耗');
+    expect(html).toContain('8 芯片');
+    const many = Array.from({ length: 9 }, (_, i) => ({
+      role: 'decode',
+      worker_idx: i,
+      num_gpus: 8,
+      avg_power_w: 700,
+    }));
+    const capped = generateTooltipContent(
+      tooltipConfig({ data: pt({ workers: many }), isPinned: true, locale: 'zh' }),
+    );
+    expect(capped).toContain('另有 1 个 worker');
+  });
+
+  it('HTML-escapes role and hosts strings from the JSONB boundary', () => {
+    const hostile = [
+      {
+        role: '<img src=x onerror=alert(1)>',
+        worker_idx: 0,
+        hosts: ['<script>evil</script>'],
+        num_gpus: 8,
+        avg_power_w: 700,
+      },
+    ];
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ workers: hostile }), isPinned: true }),
+    );
+    expect(html).not.toContain('<img src=x');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(html).toContain('&lt;script&gt;evil&lt;/script&gt;');
+  });
+});
+
+// ===========================================================================
 // measured-power certification tier line (all three generators)
 // ===========================================================================
 describe('power tier tooltip line', () => {

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -170,6 +170,67 @@ const powerTierHTML = (d: InferenceData, selectedYAxisMetric: string, locale: Lo
   return tooltipLine(t.powerData, d.power_tier === 'certified' ? t.powerCertified : t.powerLegacy);
 };
 
+/** Escape strings that arrive from artifact JSONB (worker role / hosts)
+ *  before interpolating them into tooltip HTML. */
+const escapeHtml = (s: string): string =>
+  s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const WORKER_POWER_STRINGS = {
+  en: {
+    heading: 'Measured Worker Power',
+    chips: 'chips',
+    more: (n: number) => `+${n} more workers`,
+  },
+  zh: {
+    heading: '各 Worker 实测功耗',
+    chips: '芯片',
+    more: (n: number) => `另有 ${n} 个 worker`,
+  },
+} as const;
+
+/** Pinned tooltips list at most this many workers before the "+N more" line. */
+const WORKER_ROWS_LIMIT = 8;
+
+/**
+ * Per-worker measured power drilldown. Rendered only while the tooltip is
+ * pinned (same rule as the point-detail actions) so hover tooltips stay lean;
+ * nothing renders when `workers` is absent or empty — production AgentX rows
+ * currently ship without it.
+ */
+const generateWorkerPowerHTML = (d: InferenceData, isPinned: boolean, locale: Locale): string => {
+  if (!isPinned || !Array.isArray(d.workers) || d.workers.length === 0) return '';
+  const t = WORKER_POWER_STRINGS[locale];
+  const rows = d.workers.slice(0, WORKER_ROWS_LIMIT).map((w) => {
+    const parts = [
+      `<strong>${escapeHtml(w.role)}[${w.worker_idx}]</strong>`,
+      `${w.num_gpus} ${t.chips}`,
+      `${fmt(w.avg_power_w)} W`,
+    ];
+    if (typeof w.avg_temp_c === 'number') {
+      parts.push(
+        typeof w.peak_temp_c === 'number'
+          ? `${fmt(w.avg_temp_c)}/${fmt(w.peak_temp_c)}°C`
+          : `${fmt(w.avg_temp_c)}°C`,
+      );
+    }
+    if (typeof w.avg_util_pct === 'number') parts.push(`${fmt(w.avg_util_pct)}%`);
+    if (typeof w.avg_mem_used_mb === 'number') parts.push(`${fmt(w.avg_mem_used_mb / 1024)} GiB`);
+    if (Array.isArray(w.hosts) && w.hosts.length > 0) parts.push(escapeHtml(w.hosts.join(',')));
+    return `<div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px; overflow-wrap: anywhere;">${parts.join(' · ')}</div>`;
+  });
+  const overflow = d.workers.length - WORKER_ROWS_LIMIT;
+  return `<div data-testid="tooltip-worker-power" style="margin-top: 8px; border-top: 1px solid var(--border); padding-top: 6px;">
+      <div style="color: var(--foreground); font-size: 11px; font-weight: 600; margin-bottom: 4px;">${t.heading}</div>
+      ${rows.join('')}
+      ${overflow > 0 ? `<div style="color: var(--muted-foreground); font-size: 11px;">${t.more(overflow)}</div>` : ''}
+    </div>`;
+};
+
 const CACHE_STRINGS = {
   en: {
     offloadType: 'Offload Type',
@@ -483,6 +544,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
       ${tooltipLine(t.precision, `${d.precision.toUpperCase()}`)}
       ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
+      ${generateWorkerPowerHTML(d, isPinned, locale)}
       ${runLinkHTML(runUrl)}
       ${viewActionsHTML(isPinned, Boolean(hasTrace), Boolean(config.hasLog), d.id, d.benchmark_type, locale)}
     </div>
@@ -524,6 +586,7 @@ export const generateOverlayTooltipContent = (config: OverlayTooltipConfig): str
       ${tooltipLine(t.precision, `${d.precision.toUpperCase()}`)}
       ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
+      ${generateWorkerPowerHTML(d, isPinned, locale)}
     </div>
   `;
 };
@@ -582,6 +645,7 @@ export const generateGPUGraphTooltipContent = (config: TooltipConfig): string =>
       ${tooltipLine(t.precision, `${d.precision.toUpperCase()}`)}
       ${generateCacheMetadataHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
+      ${generateWorkerPowerHTML(d, isPinned, locale)}
       ${runLinkHTML(runUrl)}
       ${viewActionsHTML(isPinned, Boolean(hasTrace), Boolean(hasLog), d.id, d.benchmark_type, locale)}
     </div>

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -219,6 +219,8 @@ const generateWorkerPowerHTML = (d: InferenceData, isPinned: boolean, locale: Lo
       );
     }
     if (typeof w.avg_util_pct === 'number') parts.push(`${fmt(w.avg_util_pct)}%`);
+    // avg_mem_used_mb follows the nvidia-smi/telemetry convention (MiB despite
+    // the _mb suffix), hence /1024 → GiB. Revisit if PLAN-09's producer differs.
     if (typeof w.avg_mem_used_mb === 'number') parts.push(`${fmt(w.avg_mem_used_mb / 1024)} GiB`);
     if (Array.isArray(w.hosts) && w.hosts.length > 0) parts.push(escapeHtml(w.hosts.join(',')));
     return `<div style="color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px; overflow-wrap: anywhere;">${parts.join(' · ')}</div>`;

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -650,6 +650,108 @@ describe('rowToAggDataEntry', () => {
   });
 });
 
+describe('rowToAggDataEntry — agentic measured power', () => {
+  // AgentX (agentic_traces) rows carry the same measured-power contract as
+  // fixed-seq rows; nothing in the transform may key off benchmark_type.
+  const agenticPowerMetrics = {
+    tput_per_gpu: 100,
+    power_valid: 1,
+    power_metric_schema_version: 2,
+    avg_power_w: 685.5,
+    prefill_avg_power_w: 612.3,
+    decode_avg_power_w: 701.5,
+    joules_per_input_token: 1.2,
+    joules_per_output_token: 9.7,
+    joules_per_total_token: 0.8,
+    joules_per_successful_query: 1542.75,
+    prefill_joules_per_input_token: 0.4,
+    decode_joules_per_output_token: 5.1,
+    avg_temp_c: 68.4,
+    peak_temp_c: 79.2,
+    avg_util_pct: 88.5,
+    avg_mem_used_mb: 71234.5,
+  };
+  const agenticWorkers = [
+    {
+      role: 'prefill' as const,
+      worker_idx: 0,
+      hosts: ['pn0'],
+      num_gpus: 8,
+      avg_power_w: 612.3,
+      avg_temp_c: 68.4,
+      avg_util_pct: 88.5,
+    },
+    { role: 'decode' as const, worker_idx: 0, hosts: ['dn0'], num_gpus: 8, avg_power_w: 701.5 },
+  ];
+  const agenticPowerRow = (metricOverrides: Record<string, number> = {}) =>
+    makeRow({
+      benchmark_type: 'agentic_traces',
+      isl: null,
+      osl: null,
+      disagg: true,
+      metrics: { ...agenticPowerMetrics, ...metricOverrides },
+      workers: agenticWorkers,
+    });
+
+  it('passes the full measured-power payload through for a validated agentic disagg row', () => {
+    const entry = rowToAggDataEntry(agenticPowerRow());
+
+    expect(entry.benchmark_type).toBe('agentic_traces');
+    expect(entry.power_valid).toBe(1);
+    expect(entry.power_metric_schema_version).toBe(2);
+    expect(entry.power_tier).toBe('certified');
+    expect(entry.avg_power_w).toBe(685.5);
+    expect(entry.prefill_avg_power_w).toBe(612.3);
+    expect(entry.decode_avg_power_w).toBe(701.5);
+    expect(entry.joules_per_input_token).toBe(1.2);
+    expect(entry.joules_per_output_token).toBe(9.7);
+    expect(entry.joules_per_total_token).toBe(0.8);
+    expect(entry.joules_per_successful_query).toBe(1542.75);
+    expect(entry.prefill_joules_per_input_token).toBe(0.4);
+    expect(entry.decode_joules_per_output_token).toBe(5.1);
+    expect(entry.avg_temp_c).toBe(68.4);
+    expect(entry.peak_temp_c).toBe(79.2);
+    expect(entry.avg_util_pct).toBe(88.5);
+    expect(entry.avg_mem_used_mb).toBe(71234.5);
+    expect(entry.workers).toEqual(agenticWorkers);
+  });
+
+  it('carries agentic role energy onto chart points as the new role-local axes', () => {
+    const { chartData } = transformBenchmarkRows([agenticPowerRow()]);
+    const point = chartData.find((data) => data.length > 0)![0];
+    expect(point.measuredPrefillJPerInputToken?.y).toBe(0.4);
+    expect(point.measuredDecodeJPerOutputToken?.y).toBe(5.1);
+    expect(point.workers).toEqual(agenticWorkers);
+  });
+
+  it('scrubs all measured telemetry (including workers) on an agentic power_valid=0 row', () => {
+    const row = agenticPowerRow({ power_valid: 0 });
+    const entry = rowToAggDataEntry(row);
+
+    expect(entry.avg_power_w).toBeUndefined();
+    expect(entry.prefill_avg_power_w).toBeUndefined();
+    expect(entry.decode_avg_power_w).toBeUndefined();
+    expect(entry.joules_per_input_token).toBeUndefined();
+    expect(entry.joules_per_output_token).toBeUndefined();
+    expect(entry.joules_per_total_token).toBeUndefined();
+    expect(entry.joules_per_successful_query).toBeUndefined();
+    expect(entry.prefill_joules_per_input_token).toBeUndefined();
+    expect(entry.decode_joules_per_output_token).toBeUndefined();
+    expect(entry.avg_temp_c).toBeUndefined();
+    expect(entry.peak_temp_c).toBeUndefined();
+    expect(entry.avg_util_pct).toBeUndefined();
+    expect(entry.avg_mem_used_mb).toBeUndefined();
+    expect(entry.workers).toBeUndefined();
+    expect(entry.power_tier).toBeUndefined();
+
+    const { chartData } = transformBenchmarkRows([row]);
+    const point = chartData.find((data) => data.length > 0)![0];
+    expect(point.measuredPrefillJPerInputToken).toBeUndefined();
+    expect(point.measuredDecodeJPerOutputToken).toBeUndefined();
+    expect(point.workers).toBeUndefined();
+  });
+});
+
 describe('transformBenchmarkRows', () => {
   it('returns empty arrays for empty input', () => {
     const { chartData, hardwareConfig } = transformBenchmarkRows([]);

--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -1154,6 +1154,36 @@ describe('createChartDataPoint per-stage measured power fields', () => {
     expect(point.measuredJPerInputToken!.y).toBe(0.18);
     expect(point.measuredJPerOutputToken!.y).toBe(1.64);
   });
+
+  it('emits role-local energy fields when the role joules scalars are present', () => {
+    const e = entry({ prefill_joules_per_input_token: 0.4, decode_joules_per_output_token: 5.1 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredPrefillJPerInputToken).toBeDefined();
+    expect(point.measuredPrefillJPerInputToken!.y).toBe(0.4);
+    expect(point.measuredPrefillJPerInputToken!.roof).toBe(false);
+    expect(point.measuredDecodeJPerOutputToken).toBeDefined();
+    expect(point.measuredDecodeJPerOutputToken!.y).toBe(5.1);
+    expect(point.measuredDecodeJPerOutputToken!.roof).toBe(false);
+  });
+
+  it('omits role-local energy fields on rows without the role joules scalars', () => {
+    // Single-node aggregated (and legacy) rows never carry role energy — the
+    // fields must be absent (not 0) so the coverage filter drops them from the
+    // role-energy axes rather than plotting fake data.
+    const e = entry({ avg_power_w: 685.5, joules_per_output_token: 8.4 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredPrefillJPerInputToken).toBeUndefined();
+    expect(point.measuredDecodeJPerOutputToken).toBeUndefined();
+  });
+
+  it('preserves a zero role-local energy value (not falsy-coerced away)', () => {
+    const e = entry({ prefill_joules_per_input_token: 0, decode_joules_per_output_token: 0 });
+    const point = createChartDataPoint('2025-01-01', e, 'median_e2el', 'tput_per_gpu', 'h100');
+    expect(point.measuredPrefillJPerInputToken).toBeDefined();
+    expect(point.measuredPrefillJPerInputToken!.y).toBe(0);
+    expect(point.measuredDecodeJPerOutputToken).toBeDefined();
+    expect(point.measuredDecodeJPerOutputToken!.y).toBe(0);
+  });
 });
 
 // ===========================================================================

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -550,6 +550,8 @@ type MeasuredPowerChartFields = Partial<
     | 'measuredJPerOutputToken'
     | 'measuredJPerTotalToken'
     | 'measuredJPerInputToken'
+    | 'measuredPrefillJPerInputToken'
+    | 'measuredDecodeJPerOutputToken'
     | 'measuredJPerSuccessfulQuery'
     | 'measuredWhPerSuccessfulQuery'
     | 'measuredPowerPercentTdp'
@@ -579,6 +581,14 @@ function buildMeasuredPowerChartFields(
       : {}),
     ...(typeof entry.joules_per_input_token === 'number'
       ? { measuredJPerInputToken: chartMetric(entry.joules_per_input_token) }
+      : {}),
+    // Role-local energy is not additionally gated on power_valid here —
+    // rowToAggDataEntry already scrubbed it, same as the role-watts fields.
+    ...(typeof entry.prefill_joules_per_input_token === 'number'
+      ? { measuredPrefillJPerInputToken: chartMetric(entry.prefill_joules_per_input_token) }
+      : {}),
+    ...(typeof entry.decode_joules_per_output_token === 'number'
+      ? { measuredDecodeJPerOutputToken: chartMetric(entry.decode_joules_per_output_token) }
       : {}),
     ...(typeof entry.joules_per_successful_query === 'number'
       ? {

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -9,6 +9,10 @@
       "duration": 2000
     },
     {
+      "spec": "cypress/e2e/agentic-measured-power.cy.ts",
+      "duration": 1500
+    },
+    {
       "spec": "cypress/e2e/agentic-point-coach-mark.cy.ts",
       "duration": 8000
     },


### PR DESCRIPTION
> [!IMPORTANT]
> **STACKED PR — base branch is `klaud/powerx-02-certified-view` (#907).** That PR must merge first; this diff contains only the PLAN-10 deltas on top of it. Do not squash-merge this PR into `master` before #907 lands.

## What (PLAN-10 / gap G15)

Three connected gaps left measured-power data invisible or untested in the app frontend:

1. **`workers[]` was plumbed end-to-end but nothing rendered it.** The type, transform (`benchmark-transform.ts`), and API docs all carry per-worker power, yet no tooltip/dialog/page consumed it.
2. **Role-local energy had no y-axis.** `prefill_joules_per_input_token` / `decode_joules_per_output_token` are populated whenever `power_valid !== 0`, but users could only plot whole-deployment J/tok and role *watts* — not the role *energy efficiency* that separates prefill-bound from decode-bound disagg deployments.
3. **No frontend test covered AgentX + measured power.** All transform power tests used `single_turn`; both power cypress specs were fixed-seq only.

## Changes

### Two new registry axes (Measured Energy group)
- `y_measuredPrefillJPerInputToken` — *Measured Prefill Joules per Input Token* / 每输入 token 实测 Prefill 能耗
- `y_measuredDecodeJPerOutputToken` — *Measured Decode Joules per Output Token* / 每输出 token 实测 Decode 能耗
- Both `polarity: 'lower'` (Pareto `lower_right` on interactivity / `lower_left` on e2e derives automatically), bilingual labels/titles, entries in `METRIC_EXPLANATIONS` with the certification-tier note, and membership in `MEASURED_ENERGY_METRIC_CONFIG_KEYS` — so the PLAN-02 tier ring / tooltip tier line / footer key apply to them too.
- `buildMeasuredPowerChartFields` maps the two role scalars into `{y, roof}` chart fields; `tokenMetricTypeForConfigKey` classifies them `input`/`output` by substring (asserted in tests).
- Coverage filtering is generic: series without role energy (single-node aggregated, legacy rows) drop off the chart **and out of the rendered legend** when the axis is selected — the rendered legend is metric-aware (`hwTypesWithData`). The switch is non-destructive: the selection universe (`selectableHwTypes`) never intersects metric coverage, so switching back to an axis both series carry restores the series with no legend re-selection (asserted in the e2e spec).

### WorkerPower drilldown in the pinned chart tooltip
- New `generateWorkerPowerHTML(d, isPinned, locale)` in `tooltipUtils.ts`, rendered by all three generators (official, overlay, GPU-compare) **only when pinned and `workers` is non-empty**.
- Per row: `role[worker_idx] · N chips · W`, plus temp (`avg/peak°C`), util %, mem GiB, and hosts when present. Capped at 8 rows with a bilingual `+N more workers` line. `role` and `hosts` are HTML-escaped (they arrive from artifact JSONB).
- `avg_mem_used_mb` is read as MiB (nvidia-smi convention) → `/1024` GiB; commented in code, to be confirmed against PLAN-09's producer.

### Tests
- Transform unit tests: `benchmark_type='agentic_traces'` with the full measured-power payload (pass-through incl. `workers`) and the `power_valid: 0` scrub mirror.
- `chart-utils.test.ts`: emission / absence / zero-preservation for the two new chart fields.
- `measured-power-direction.test.ts`: Pareto corners + bilingual labels for both new config keys.
- `metric-registry.test.ts`: token-type classification + share-link round-trip; the pre-existing registry⇄groups parity test enforces group membership.
- `tooltip-utils.test.ts`: worker table across all three generators — pinned/unpinned, empty/absent, 8-row cap, ZH strings, HTML escaping.
- New e2e spec `cypress/e2e/agentic-measured-power.cy.ts` (spec-scoped intercepts, synthetic fixtures via new `measuredPowerMetrics()` / `syntheticWorkers()` helpers in `agentic-fixtures.ts`): both axes visible under Measured Energy, aggregate series coverage-filtered off chart *and* legend with a non-destructive switch back, worker table on a pinned agentic point, graceful absence on a workers-less point. Registered in `timings.json` for cypress-split.

## Data caveat

Production `workers[]` is **currently empty for AgentX runs** — producer-side emission lands with PLAN-09 (InferenceX repo). The UI renders gracefully with `workers` absent/empty (verified by unit tests and the e2e spec's aggregate series); the synthetic cypress fixtures verify the drilldown ahead of real data. Fixed-seq multinode disagg points already carry real `workers` today.

## Backward compatibility

- Legacy rows (no `workers`, no role energy, no `power_valid`) render exactly as before — the untouched pre-existing transform/chart/tooltip tests stay green.
- New share-link metric keys degrade safely on old deploys via `resolveMetricConfigKey` (fall back to the default axis); old links are unaffected.
- No schema, API, or stored-state migration; a single revert restores prior behavior.

## Review findings & resolutions

An independent two-lens review of the initial push found:

1. **Blocker (confirmed, fixed in `703aaae0`):** the e2e spec's first test asserted the legend still contains `B300` after selecting the prefill-energy axis, but the rendered legend is metric-aware (`hwTypesWithData`, `InferenceContext.tsx`) and intentionally drops coverage-filtered series — the assertion failed deterministically. Fixed to assert `not.contain.text('B300')`, and the test now also proves the switch is non-destructive by re-selecting *Measured Joules per Output Token* and asserting the b300 dots and legend entry return.
2. **Minor (confirmed, resolved):** the spec had been pushed unexecuted. It has now been run locally (portable Node 22.14.0 + `E2E_FIXTURES=1` dev server): **3/3 passing**, plus adjacent regression specs `measured-power-overlay` / `yaxis-metrics-render` / `ttft-x-axis-toggle` / `certified-power-filter` — **69/69 passing**.
3. **Nit (resolved):** stray Next.js-generated `packages/app/AGENTS.md` / `CLAUDE.md` (dev-server byproducts, regenerated on every `next dev`) removed from the worktree; never part of this diff.
4. **Nit (documented):** the `avg_mem_used_mb` → GiB `/1024` conversion assumes MiB semantics (nvidia-smi convention); noted in code for re-check when PLAN-09's producer lands.
5. **Minor (no change):** the spec's exact dot-count assertion (`have.length`, 3) is stricter than sibling specs' `at.least`. Kept: the fixture injects exactly 3 disagg rows, hidden points are hidden via opacity (not DOM removal), and the assertion passed locally on the first attempt; relax only if CI proves it flaky.

## Validation

- `bun run typecheck` ✅  `bun run lint` ✅  `bun run fmt` ✅
- `packages/app` full unit suite: **251 files / 4499 tests passed** ✅ (targeted power/registry/tooltip suites: 456 tests ✅)
- `packages/db` (596 tests) and `packages/constants` (47 tests) ✅ (`packages/mcp` `src/server.test.ts` fails identically on the base branch — pre-existing environment issue, untouched here)
- Cypress (local, Node 22.14.0 + `E2E_FIXTURES=1`): new `agentic-measured-power.cy.ts` **3/3** ✅; adjacent `measured-power-overlay` + `yaxis-metrics-render` + `ttft-x-axis-toggle` + `certified-power-filter` **69/69** ✅. CI re-verifies via `tests-e2e.yml` (`specPattern` + cypress-split, `timings.json` entry added).
- Manual smoke screenshots to be attached from the PR preview once CI e2e is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only visualization and test additions; worker tooltip data is escaped before HTML interpolation and invalid power rows continue to scrub telemetry unchanged.
> 
> **Overview**
> Adds **two Measured Energy y-axes** — *Measured Prefill Joules per Input Token* and *Measured Decode Joules per Output Token* — wired through the metric registry, bilingual explanations, chart field mapping from `prefill_joules_per_input_token` / `decode_joules_per_output_token`, and existing coverage filtering so aggregate rows without role energy drop off those axes.
> 
> **Pinned chart tooltips** now show a *Measured Worker Power* section when `workers[]` is present: per-worker watts (and optional temp, util, memory, hosts), capped at eight rows with overflow text, HTML-escaped role/host strings, and EN/ZH copy across official, overlay, and GPU-compare tooltip generators; hover and empty/missing `workers` stay unchanged.
> 
> Test coverage expands with transform/chart/registry/tooltip unit tests, Cypress helpers (`measuredPowerMetrics`, `syntheticWorkers`), and a new **AgentX e2e spec** that intercepts synthetic agentic benchmarks to assert axis visibility, legend filtering, worker drilldown, and graceful absence without workers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703aaae0543e9821c1db550d62fdb3838a9a8513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->