### PR TITLE
feat(compare): show Qwen3.8-Flash-Next in the AgentX hero / AgentX 主打模型列表新增 Qwen3.8-Flash-Next

### DIFF
--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -9,7 +9,7 @@ describe('Compare precision index page', () => {
     cy.visit('/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       cy.get('h1').should('have.text', 'Compare Realistic Agentic Inference Perf');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
       cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
         'have.attr',
         'href',
@@ -52,7 +52,7 @@ describe('Compare precision index page', () => {
     cy.visit('/zh/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       cy.get('h1').should('have.text', '真实智能体工作负载下的推理性能对比');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
       cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
         'have.attr',
         'href',

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -123,7 +123,7 @@ describe('First-load navigation', () => {
         .should('contain.text', 'Full dashboard')
         .and('have.attr', 'href', '/inference/kimi-k3');
       cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 5);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
       // Editorial order, not alphabetical — see FEATURED_AGENTX_MODEL_SLUGS.
       cy.get('[data-testid^="compare-agentx-model-"]').then(($rows) => {
         const slugs = [...$rows].map((row) =>
@@ -135,6 +135,7 @@ describe('First-load navigation', () => {
           'glm-5-2',
           'minimax-m3',
           'qwen-3-5',
+          'qwen-3-8-flash-next',
         ]);
       });
     });

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -19,6 +19,7 @@ const MODEL_LOGOS: Record<string, string> = {
   // mark rather than the Zhipu corporate dot cluster.
   'glm-5-2': '/logos/zai-color.svg',
   'minimax-m3': '/logos/minimax-color.svg',
+  'qwen-3-8-flash-next': '/logos/qwen-color.svg',
   'qwen-3-5': '/logos/qwen-color.svg',
 };
 

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -16,6 +16,7 @@ describe('AgentX comparison links', () => {
       'glm-5-2',
       'minimax-m3',
       'qwen-3-5',
+      'qwen-3-8-flash-next',
     ]);
   });
 

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -7,7 +7,9 @@ const FEATURED_AGENTX_MODEL_SLUGS = [
   'deepseek-v4',
   'glm-5-2',
   'minimax-m3',
+  // Editorial call: Flash Next sits below Qwen 3.5, the family's flagship row.
   'qwen-3-5',
+  'qwen-3-8-flash-next',
 ] as const;
 
 const FEATURED_AGENTX_MODEL_SET = new Set<string>(FEATURED_AGENTX_MODEL_SLUGS);


### PR DESCRIPTION
## What

Adds Qwen3.8-Flash-Next to the featured AgentX model ledger in the hero that leads both the landing page and `/compare`.

- `FEATURED_AGENTX_MODEL_SLUGS` gains `qwen-3-8-flash-next`, placed directly below `qwen-3-5` per editorial call.
- Hero `MODEL_LOGOS` maps the new slug to the shared `/logos/qwen-color.svg` mark.
- The row links to the canonical `/inference/qwen-3-8-flash-next` page (bare subroute — Agentic + Optimal Only are already the defaults), and compare pair cards for the model now use the AgentX scenario.

## Why

Qwen3.8-Flash-Next has day-zero AgentX results across H100/H200/B200/B300 (InferenceX #2751–#2753, #2758), so it belongs in the "Models with AgentX results" hero ledger alongside the other actively benchmarked models.

## Tests

- `compare-agentx.test.ts` editorial-order expectation updated (vitest green).
- Cypress `navigation.cy.ts` and `compare-precision.cy.ts` hero row counts 5 → 6; slug order updated.
- `tsc --noEmit`, oxlint, and oxfmt all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Limited to compare/landing hero content and test fixtures; no auth, API, or data-pipeline changes.
> 
> **Overview**
> Adds **Qwen3.8-Flash-Next** (`qwen-3-8-flash-next`) to the featured AgentX model ledger on the landing page and `/compare`, directly under Qwen 3.5 in editorial order.
> 
> `FEATURED_AGENTX_MODEL_SLUGS` drives the sixth hero row (inference dashboard link via existing `agentxDashboardHref` behavior) and treats the slug as **AgentX** for compare catalog pair links through `FEATURED_AGENTX_MODEL_SET`. The hero maps the new row to `/logos/qwen-color.svg`.
> 
> Vitest and Cypress expectations move from five to six model rows and assert the updated slug order on English and Chinese surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cd24e386c3fad667e99447477744942f729e8b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->