### PR TITLE
feat(inference): move Share button next to chart download controls / 将 Share 按钮移至图表下载按钮旁

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -38,9 +38,10 @@ import InferenceTable from '@/components/inference/ui/InferenceTable';
 import ScatterGraph from '@/components/inference/ui/ScatterGraph';
 import { Card } from '@/components/ui/card';
 import { ChartButtons } from '@/components/ui/chart-buttons';
+import { ShareButton } from '@/components/ui/share-button';
 import { type SegmentedToggleOption, SegmentedToggle } from '@/components/ui/segmented-toggle';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ChartShareActions, MetricAssumptionNotes } from '@/components/ui/chart-display-helpers';
+import { MetricAssumptionNotes } from '@/components/ui/chart-display-helpers';
 import { UnofficialDomainNotice } from '@/components/ui/unofficial-domain-notice';
 import { ModelLogo } from '@/components/ui/model-logo';
 import { metricLabel, metricTitle } from '@/lib/chart-utils';
@@ -905,13 +906,16 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                           : 'interactivity'
                     }
                     leadingControls={
-                      <SegmentedToggle
-                        value={getViewMode(graphIndex)}
-                        options={viewModeOptions}
-                        onValueChange={(v) => handleViewModeChange(graphIndex, v)}
-                        ariaLabel={t.viewMode}
-                        testId={`inference-view-toggle-${graphIndex}`}
-                      />
+                      <>
+                        <SegmentedToggle
+                          value={getViewMode(graphIndex)}
+                          options={viewModeOptions}
+                          onValueChange={(v) => handleViewModeChange(graphIndex, v)}
+                          ariaLabel={t.viewMode}
+                          testId={`inference-view-toggle-${graphIndex}`}
+                        />
+                        {!embedded && <ShareButton className="h-7" />}
+                      </>
                     }
                     hideImageExport={getViewMode(graphIndex) === 'table'}
                     setIsLegendExpanded={setIsLegendExpanded}
@@ -1207,7 +1211,12 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                       {t.inferencePerformanceDesc}
                     </p>
                   </div>
-                  <ChartShareActions />
+                  {/* The chart-row ShareButton lives in ChartButtons, which is desktop-only
+                      (`hidden md:flex`); keep a header Share on mobile so small screens
+                      don't lose the share entry point. */}
+                  <div className="md:hidden">
+                    <ShareButton />
+                  </div>
                 </div>
                 <ChartControls />
                 <ModelArchitectureLink model={selectedModel} locale={locale} />

--- a/packages/app/src/components/ui/share-button.tsx
+++ b/packages/app/src/components/ui/share-button.tsx
@@ -6,11 +6,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ShareLinkedInButton, ShareTwitterButton } from '@/components/share-buttons';
 import { track } from '@/lib/analytics';
 import { buildShareUrl } from '@/lib/url-state';
+import { cn } from '@/lib/utils';
 
 import { Button } from './button';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 
-export function ShareButton() {
+export function ShareButton({ className }: { className?: string } = {}) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const [url, setUrl] = useState('');
@@ -55,7 +56,10 @@ export function ShareButton() {
         <Button
           data-testid="share-button"
           size="sm"
-          className="h-8 gap-1.5 bg-brand text-primary-foreground hover:bg-brand/90 text-xs font-medium"
+          className={cn(
+            'h-8 gap-1.5 bg-brand text-primary-foreground hover:bg-brand/90 text-xs font-medium',
+            className,
+          )}
           title="Share this view"
         >
           <Share2 className="size-3.5" />


### PR DESCRIPTION
## Summary

Moves the Share button so it sits next to the chart download button, as requested.

- **Desktop:** the Share button now renders inside each chart's top-right control row (`ChartButtons`), directly beside the download/export button, after the Chart/Table toggle. It uses a compact `h-7` height to match the other chart controls.
- **Mobile:** the chart control row is `hidden md:flex`, so a Share button is kept in the Inference Performance header on `< md` screens only, preserving the mobile share entry point.
- `ShareButton` gains an optional `className` prop (merged via `cn`) so callers can adjust sizing; default styling is unchanged, so the calculator/evaluation/trends surfaces that render it via `ChartShareActions` are unaffected.
- The Share button inherits the row's `no-export` behavior, so it stays out of PNG exports, and it is skipped in embedded chart views (matching the previous behavior where the header — and its Share button — was not rendered when `embedded`).

No copy changes and no new pages, so no `/zh` sibling work is needed.

## Testing

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean
- `vitest run src/components/ui/share-button.test.tsx src/components/ui/chart-display-helpers.test.tsx` — 32 passed
- `vitest run src/components/inference` — 813 passed

## 中文说明

按需求将 Share（分享）按钮移动到图表下载按钮旁边。

- **桌面端：** Share 按钮现在渲染在每个图表右上角的控制栏（`ChartButtons`）中，位于 Chart/Table 切换器之后、下载/导出按钮旁边，并使用紧凑的 `h-7` 高度以匹配其他图表控制按钮。
- **移动端：** 图表控制栏为 `hidden md:flex`，因此在 `< md` 屏幕上于 Inference Performance 标题区保留 Share 按钮，确保移动端仍有分享入口。
- `ShareButton` 新增可选的 `className` 属性（通过 `cn` 合并），默认样式不变，因此通过 `ChartShareActions` 使用它的 calculator/evaluation/trends 等页面不受影响。
- Share 按钮继承控制栏的 `no-export` 行为，不会出现在导出的 PNG 中；嵌入（`embedded`）视图中不渲染，与之前标题区不渲染时的行为一致。

无文案改动、无新页面，因此无需 `/zh` 页面配套工作。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation of an existing share control with a responsive fallback; no auth, data, or API changes.
> 
> **Overview**
> Moves inference **Share** from the page header (`ChartShareActions`) into each chart’s top-right control row so it sits beside download/export, after the Chart/Table toggle.
> 
> On **desktop**, `ShareButton` renders inside `ChartButtons` with `h-7` to match other controls; it inherits the row’s `no-export` and `hidden md:flex` behavior. On **mobile**, a header `ShareButton` remains (`md:hidden`) so sharing is still available when the chart control row is hidden. **Embedded** views skip the chart-row share, consistent with the previous non-embedded header behavior.
> 
> `ShareButton` now accepts an optional **`className`** (merged via `cn`); other surfaces that use `ChartShareActions` keep default sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ad7acc5640422b1ad5a8dc95f37278df3fa395c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->