### PR TITLE
feat(inference): replace the model-architecture banner with an icon beside the model selector / 将模型架构横幅改为模型选择器旁的图标

### DIFF
--- a/packages/app/cypress/e2e/model-architecture.cy.ts
+++ b/packages/app/cypress/e2e/model-architecture.cy.ts
@@ -504,7 +504,7 @@ describe('Model Architecture Diagram', () => {
     });
   });
 
-  describe('Dashboard architecture link (replaces the drawer)', () => {
+  describe('Dashboard architecture icon link (replaces the banner row)', () => {
     before(() => {
       cy.viewport(1280, 800);
       cy.visit('/inference?g_model=DeepSeek-R1-0528', {
@@ -515,19 +515,29 @@ describe('Model Architecture Diagram', () => {
       cy.get('[data-testid="inference-chart-display"]').should('be.visible');
     });
 
-    it('renders a link row with architecture badges instead of the drawer', () => {
+    it('renders an icon link beside the model selector instead of a banner row', () => {
       cy.get('[data-testid="model-architecture-toggle"]').should('not.exist');
       cy.get('[data-testid="model-architecture-link"]').should('be.visible');
       cy.get('[data-testid="model-architecture-link"]').should(
-        'contain.text',
+        'have.attr',
+        'aria-label',
         'Learn more about the DeepSeek R1 0528 671B architecture',
       );
-      cy.get('[data-testid="model-architecture-link"]').should('contain.text', 'MoE');
-      cy.get('[data-testid="model-architecture-link"]').should('contain.text', 'MLA');
-      cy.get('[data-testid="model-architecture-link"]').should('contain.text', '671B');
       cy.get('[data-testid="model-architecture-link"]')
         .should('have.attr', 'href')
         .and('equal', '/model/deepseek-r1');
+      // The former banner copy and badges now live in the tooltip; Radix
+      // tooltips open on keyboard focus, which is more reliable in Cypress
+      // than synthetic hover.
+      cy.get('[data-testid="model-architecture-link"]').focus();
+      cy.get('[data-testid="model-architecture-tooltip"]')
+        .should('be.visible')
+        .and('contain.text', 'Learn more about the DeepSeek R1 0528 671B architecture')
+        .and('contain.text', 'MoE')
+        .and('contain.text', 'MLA')
+        .and('contain.text', '671B');
+      // Dismiss the tooltip so it doesn't cover the link for the next test.
+      cy.get('body').type('{esc}');
     });
 
     it('navigates to the model deep-dive page', () => {

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -34,6 +34,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { METRIC_CONTROL_GROUPS, METRIC_REGISTRY } from '@/components/inference/metric-registry';
 import { formatTokenPrice } from '@/components/inference/token-revenue';
 import { useOpenDropdown } from '@/hooks/useOpenDropdown';
+import { ModelArchitectureInfoLink } from './ModelArchitectureInfoLink';
 import { Sequence, type Model, type Percentile } from '@/lib/data-mappings';
 import { useLocale } from '@/lib/use-locale';
 
@@ -303,6 +304,7 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
             onOpenChange={handleDropdownOpenChange('model')}
             availableModels={availableModels}
             data-testid="model-selector"
+            trailing={<ModelArchitectureInfoLink model={selectedModel} locale={locale} />}
           />
           <ScenarioSelector
             value={selectedSequence}

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -91,71 +91,10 @@ import CustomPowers from './CustomPowers';
 import GPUGraph from './GPUGraph';
 import ReplayLauncher, { type ReplayLauncherHandle } from '../replay/ReplayLauncher';
 
-import Link from 'next/link';
-
-import { Badge } from '@/components/ui/badge';
-import { getModelSlugEntryForDisplayName } from '@/lib/compare-slug';
-import { formatParamCount, getModelArchitecture } from '@/lib/model-architectures';
 import WorkflowInfoDisplay from './WorkflowInfoDisplay';
 import { NormalizedInteractivityHelpLink } from './NormalizedInteractivityHelpLink';
 
 type InferenceViewMode = 'chart' | 'table';
-
-/**
- * Replaces the old in-card Model Architecture drawer: a row that links to the
- * model's `/model/[slug]` page, which hosts the full architecture diagram,
- * vendor eval scores, and a model-focused view of this dashboard. Renders
- * nothing for models without a public slug (hidden models).
- */
-function ModelArchitectureLink({ model, locale }: { model: Model; locale: 'en' | 'zh' }) {
-  const entry = getModelSlugEntryForDisplayName(model);
-  if (!entry) return null;
-  const arch = getModelArchitecture(model);
-  const label = getModelLabel(model);
-  return (
-    <Link
-      href={`/model/${entry.slug}`}
-      data-testid="model-architecture-link"
-      className="group rounded-lg border border-border/50 bg-muted/30 px-4 py-2 flex items-center justify-between gap-3 hover:bg-muted/50 transition-colors"
-      onClick={() => track('model_architecture_link_clicked', { model, slug: entry.slug })}
-    >
-      <div className="flex items-center gap-2 min-w-0">
-        <svg
-          className="size-4 shrink-0 text-muted-foreground"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <rect x="3" y="3" width="18" height="18" rx="2" />
-          <line x1="3" y1="9" x2="21" y2="9" />
-          <line x1="9" y1="9" x2="9" y2="21" />
-        </svg>
-        <span className="text-sm font-medium truncate">
-          {locale === 'zh'
-            ? `了解 ${label} 模型架构`
-            : `Learn more about the ${label} architecture`}
-        </span>
-        {arch && (
-          <span className="hidden sm:flex items-center gap-1.5">
-            <Badge variant="outline" className="text-xs py-0">
-              {arch.architectureType === 'moe' ? 'MoE' : 'Dense'}
-            </Badge>
-            <Badge variant="outline" className="text-xs py-0">
-              {arch.attentionType === 'AlternatingSinkGQA' ? 'Sink/Full GQA' : arch.attentionType}
-            </Badge>
-            <Badge variant="outline" className="text-xs py-0">
-              {formatParamCount(arch.totalParams)}
-            </Badge>
-          </span>
-        )}
-      </div>
-      <span className="text-sm shrink-0 text-muted-foreground group-hover:text-foreground transition-colors">
-        →
-      </span>
-    </Link>
-  );
-}
 
 const STRINGS = {
   en: {
@@ -1210,7 +1149,6 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                   <ChartShareActions />
                 </div>
                 <ChartControls />
-                <ModelArchitectureLink model={selectedModel} locale={locale} />
               </>
             )}
             {selectedGPUs.length === 0 && <WorkflowInfoDisplay />}

--- a/packages/app/src/components/inference/ui/ModelArchitectureInfoLink.tsx
+++ b/packages/app/src/components/inference/ui/ModelArchitectureInfoLink.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+
+import { track } from '@/lib/analytics';
+import { Badge } from '@/components/ui/badge';
+import { TooltipContent, TooltipRoot, TooltipTrigger } from '@/components/ui/tooltip';
+import { getModelSlugEntryForDisplayName } from '@/lib/compare-slug';
+import { formatParamCount, getModelArchitecture } from '@/lib/model-architectures';
+import { type Model, getModelLabel } from '@/lib/data-mappings';
+
+/**
+ * Compact replacement for the old full-width "Learn more about the … architecture"
+ * banner row: an icon link that sits beside the closed model-selector trigger and
+ * deep-links to the model's `/model/[slug]` page. The former banner copy and the
+ * architecture badges (MoE/Dense, attention type, param count) move into the
+ * tooltip so the dashboard no longer spends a whole row of vertical space on them.
+ * Renders nothing for models without a public slug (hidden models).
+ */
+export function ModelArchitectureInfoLink({
+  model,
+  locale,
+}: {
+  model: Model;
+  locale: 'en' | 'zh';
+}) {
+  const entry = getModelSlugEntryForDisplayName(model);
+  if (!entry) return null;
+  const arch = getModelArchitecture(model);
+  const label = getModelLabel(model);
+  const text =
+    locale === 'zh' ? `了解 ${label} 模型架构` : `Learn more about the ${label} architecture`;
+  return (
+    <TooltipRoot>
+      <TooltipTrigger asChild>
+        <Link
+          href={`/model/${entry.slug}`}
+          aria-label={text}
+          data-testid="model-architecture-link"
+          className="border-input flex size-9 shrink-0 items-center justify-center rounded-md border bg-transparent text-muted-foreground shadow-xs transition-colors hover:bg-muted/50 hover:text-foreground"
+          onClick={() => track('model_architecture_link_clicked', { model, slug: entry.slug })}
+        >
+          <svg
+            className="size-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <rect x="3" y="3" width="18" height="18" rx="2" />
+            <line x1="3" y1="9" x2="21" y2="9" />
+            <line x1="9" y1="9" x2="9" y2="21" />
+          </svg>
+        </Link>
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        collisionPadding={10}
+        className="z-[130]"
+        data-testid="model-architecture-tooltip"
+      >
+        <span className="flex flex-wrap items-center gap-1.5">
+          {text}
+          {arch && (
+            <span className="flex items-center gap-1.5">
+              <Badge variant="outline" className="text-xs py-0">
+                {arch.architectureType === 'moe' ? 'MoE' : 'Dense'}
+              </Badge>
+              <Badge variant="outline" className="text-xs py-0">
+                {arch.attentionType === 'AlternatingSinkGQA' ? 'Sink/Full GQA' : arch.attentionType}
+              </Badge>
+              <Badge variant="outline" className="text-xs py-0">
+                {formatParamCount(arch.totalParams)}
+              </Badge>
+            </span>
+          )}
+        </span>
+      </TooltipContent>
+    </TooltipRoot>
+  );
+}

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Info } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { track } from '@/lib/analytics';
@@ -171,6 +172,12 @@ interface ModelSelectorProps {
   onOpenChange?: (open: boolean) => void;
   availableModels: string[];
   'data-testid'?: string;
+  /**
+   * Optional affordance rendered beside the closed trigger (outside the
+   * dropdown, mirroring the scenario selector's info icon) — e.g. the
+   * model-architecture deep-dive link on the inference dashboard.
+   */
+  trailing?: ReactNode;
 }
 
 export function ModelSelector({
@@ -181,6 +188,7 @@ export function ModelSelector({
   onOpenChange,
   availableModels,
   'data-testid': testId,
+  trailing,
 }: ModelSelectorProps) {
   const t = STRINGS[useLocale()];
   const groups = groupByCategory(availableModels, (m) => getModelCategory(m as Model));
@@ -233,28 +241,31 @@ export function ModelSelector({
   return (
     <div className="flex flex-col space-y-1.5 lg:col-span-2">
       <LabelWithTooltip htmlFor={id} label={t.model} tooltip={t.modelTooltip} />
-      <div>
-        <MultiSelect
-          sections={sections}
-          value={[value]}
-          onChange={(values) => {
-            const next = values[0];
-            if (!next) return;
-            track('selector_model_changed', { model: next });
-            onChange(next as Model);
-          }}
-          open={open}
-          onOpenChange={onOpenChange}
-          triggerId={id}
-          triggerTestId={testId}
-          placeholder={t.model}
-          minSelections={1}
-          maxSelections={1}
-          showClearAll={false}
-          searchable={false}
-          plainSelectedText
-          showSelectionSummary={false}
-        />
+      <div className="flex items-center gap-1.5">
+        <div className="min-w-0 flex-1">
+          <MultiSelect
+            sections={sections}
+            value={[value]}
+            onChange={(values) => {
+              const next = values[0];
+              if (!next) return;
+              track('selector_model_changed', { model: next });
+              onChange(next as Model);
+            }}
+            open={open}
+            onOpenChange={onOpenChange}
+            triggerId={id}
+            triggerTestId={testId}
+            placeholder={t.model}
+            minSelections={1}
+            maxSelections={1}
+            showClearAll={false}
+            searchable={false}
+            plainSelectedText
+            showSelectionSummary={false}
+          />
+        </div>
+        {trailing}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The inference dashboard spent a full-width banner row on "Learn more about the {model} architecture" (screenshot context: it sat between the chart controls and the changelog, costing vertical space on every view). This PR removes that row and replaces it with a compact icon link that sits beside the closed model-selector trigger, mirroring the existing scenario-selector info affordance.

- **New `ModelArchitectureInfoLink`** — a `size-9` icon link (same architecture-grid glyph as before) rendered beside the model selector, deep-linking to `/model/[slug]` with the same `model_architecture_link_clicked` analytics event. The former banner copy and the MoE/Dense, attention-type, and param-count badges move into its tooltip. Models without a public slug render no icon, as before.
- **`ModelSelector` gains an optional `trailing` prop** so the affordance stays out of the calculator/evaluation surfaces that share the selector.
- **Removed the `ModelArchitectureLink` banner row** from `ChartDisplay` (also applied to the `/zh` locale, which shares these components — tooltip copy stays 了解 {model} 模型架构).
- **Cypress**: updated `model-architecture.cy.ts` to assert the icon's `aria-label`, `href`, tooltip badges (via keyboard focus), and unchanged click-through navigation.

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅ / `bun run fmt:fix` ✅
- `bun run test:unit` — pre-existing environment failures on clean master (undici `webidl.util.markAsUncloneable`, local Node mismatch); no failures related to this change. CI is authoritative.

## 中文说明

推理仪表板此前用一整行横幅展示"了解 {model} 模型架构"，在每个视图中都占用一行垂直空间。本 PR 移除该横幅，改为模型选择器关闭状态触发器旁的紧凑图标链接，与现有场景选择器的信息图标保持一致。

- **新增 `ModelArchitectureInfoLink`** —— 模型选择器旁的 `size-9` 图标链接（沿用原有的架构网格图标），仍深链至 `/model/[slug]` 并保留 `model_architecture_link_clicked` 分析事件。原横幅文案及 MoE/Dense、注意力类型、参数量徽章移入 tooltip。无公开 slug 的模型不显示图标，与此前行为一致。
- **`ModelSelector` 新增可选 `trailing` 属性**，避免影响共用该选择器的 calculator/evaluation 页面。
- **从 `ChartDisplay` 移除横幅行**（`/zh` 中文页面共用这些组件，tooltip 文案仍为"了解 {model} 模型架构"）。
- **Cypress**：更新 `model-architecture.cy.ts`，改为断言图标的 `aria-label`、`href`、tooltip 徽章（通过键盘聚焦触发）及原有的点击跳转行为。

### 测试

- `bun run typecheck` ✅
- `bun run lint` ✅ / `bun run fmt:fix` ✅
- `bun run test:unit` —— clean master 上已存在的环境性失败（undici `webidl.util.markAsUncloneable`，本地 Node 版本不匹配），与本改动无关；以 CI 为准。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only relocation of an existing deep link and analytics event; no API, auth, or data-path changes.
> 
> **Overview**
> Removes the full-width **"Learn more about the … architecture"** banner from the inference chart header and replaces it with a compact **icon link** next to the model selector (same pattern as the scenario selector’s info affordance).
> 
> **`ModelArchitectureInfoLink`** is a new component: a `size-9` grid icon that still links to `/model/[slug]` and fires `model_architecture_link_clicked`. Banner text and architecture badges (MoE/Dense, attention type, param count) move into a **tooltip**; models without a public slug still render nothing.
> 
> **`ModelSelector`** accepts an optional **`trailing`** slot so only the inference dashboard (`ChartControls`) shows the link—calculator and other consumers stay unchanged. Cypress now checks `aria-label`, `href`, tooltip content via keyboard focus, and navigation to the model page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37035b94bd5e3d882d0c8525e07362df7a5e1453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->