### PR TITLE
Remove Explore InferenceX section from landing page

### DIFF
--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -98,19 +98,6 @@ describe('First-load navigation', () => {
     cy.location('pathname').should('eq', '/agentx');
   });
 
-  it('navigates to overview and the full dashboard from the landing CTAs', () => {
-    cy.get('[data-testid="landing-overview-link"]')
-      .should('have.attr', 'href', '/overview')
-      .click();
-    cy.location('pathname').should('eq', '/overview');
-
-    cy.visit('/');
-    cy.get('[data-testid="landing-full-dashboard-link"]')
-      .should('have.attr', 'href', '/inference')
-      .click();
-    cy.location('pathname').should('eq', '/inference');
-  });
-
   it('leads the landing page with the AgentX hero and its two CTAs', () => {
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       // The hero owns /compare's h1; on the landing page it is a section heading.

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -7,21 +7,11 @@ describe('Chinese (/zh) pages', () => {
     it('renders the Chinese landing content', () => {
       cy.get('[data-testid="intro-section"]').should('contain.text', '智能体推理基准测试');
       cy.get('[data-testid="splash-text"]').should('have.text', 'AgentX 来了！！');
-      cy.contains('h2', '探索 InferenceX').should('exist');
       // Quick Comparisons is hidden behind SHOW_QUICK_COMPARISONS in
       // landing-page.tsx; the card and its Chinese strings still exist in the
       // source, so assert it is not rendered rather than dropping the check.
       cy.get('[data-testid="landing-quick-comparisons"]').should('not.exist');
       cy.contains('快速对比').should('not.exist');
-    });
-
-    it('links to the Chinese overview and full dashboard', () => {
-      cy.get('[data-testid="landing-overview-link"]')
-        .should('have.attr', 'href', '/zh/overview')
-        .and('have.text', '总览');
-      cy.get('[data-testid="landing-full-dashboard-link"]')
-        .should('have.attr', 'href', '/zh/inference')
-        .and('have.text', '查看完整仪表板');
     });
 
     it('sets hreflang alternates to the English homepage', () => {

--- a/packages/app/src/components/landing/landing-page.tsx
+++ b/packages/app/src/components/landing/landing-page.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, BarChart3, ShieldCheck, Sparkles } from 'lucide-react';
+import { ArrowRight, ShieldCheck, Sparkles } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
@@ -8,19 +8,10 @@ import { CuratedViewCard } from '@/components/landing/curated-view-card';
 import { NudgeEngine } from '@/components/nudge-engine';
 import { FAVORITE_PRESETS } from '@/components/favorites/favorite-presets';
 import { GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
-import { ACTIVE_INFERENCE_MODEL_SLUGS } from '@/lib/inference-model-slug';
 import type { Locale } from '@/lib/i18n';
 
 const STRINGS = {
   en: {
-    exploreInferenceX: 'Explore InferenceX',
-    exploreInferenceXLead:
-      'Start with a concise cost overview across active models and key platforms, or open the full dashboard for every model, chip, framework, and metric. AgentX is our long-context, multi-turn coding scenario.',
-    fullDashboard: 'Full Dashboard',
-    platformCoverage:
-      'Compare NVIDIA GB300 NVL72, GB200 NVL72, B300, B200, H200, H100, AMD MI355X, MI325X, MI300X and soon VR200 NVL72, AMD MI455X UALoE72, TPUv7 Ironwood, etc across DeepSeekv4 Pro, Qwen, Kimi, GLM, MiniMax, gpt-oss, Llama and other models.',
-    overview: 'Overview',
-    browseByModel: 'Or jump straight to the benchmarks for one model:',
     reproTitle: 'Every Result Is Transparently done through Public GitHub Actions Automation',
     reproP1:
       'Every data point on the dashboard is produced by a public GitHub Actions workflow run. The recipe lives in the repo, the run executes on the actual target hardware, and the full logs and artifacts are publicly viewable. Click any point on a chart to jump straight to the run that produced it. All reproducible, auditable, and open source.',
@@ -43,14 +34,6 @@ const STRINGS = {
       'Jump straight into the most popular chip inference benchmark comparisons, curated and ready to explore.',
   },
   zh: {
-    exploreInferenceX: '探索 InferenceX',
-    exploreInferenceXLead:
-      '先从成本总览了解当前活跃的模型和主要硬件平台，也可以进入仪表板，按模型、芯片、框架和指标深入比较。AgentX 用于评测长上下文、多轮编码的工作负载。',
-    fullDashboard: '查看完整仪表板',
-    platformCoverage:
-      '目前覆盖 DeepSeekv4 Pro、Qwen、Kimi、GLM、MiniMax、gpt-oss、Llama 等模型，以及 NVIDIA GB300 NVL72、GB200 NVL72、B300、B200、H200、H100 和 AMD MI355X、MI325X、MI300X 等硬件。后续还将加入 VR200 NVL72、AMD MI455X UALoE72 和 TPUv7 Ironwood。',
-    overview: '总览',
-    browseByModel: '也可以直接查看单个模型的基准测试：',
     reproTitle: '所有结果均通过公开的 GitHub Actions 流程生成',
     reproP1:
       '仪表板上的每个数据点都来自一次公开的 GitHub Actions 运行。测试配置保存在仓库中，并在对应的真实硬件上执行；完整日志和产物均可公开查看。点击图表中的任意数据点，即可打开生成该结果的运行记录。整个过程可复现、可审计，并完全开源。',
@@ -97,58 +80,6 @@ export function LandingPage({ locale = 'en' }: { locale?: Locale } = {}) {
 
         {/* Split: exploration entry points vs presets */}
         <section className="flex flex-col gap-4 pb-8">
-          {/* Primary product entry points */}
-          <Card>
-            <div className="flex items-center gap-2 mb-3">
-              <BarChart3 className="size-5 shrink-0 text-brand" />
-              <h2 className="text-lg font-semibold">{t.exploreInferenceX}</h2>
-            </div>
-            <p className="text-sm text-muted-foreground mb-2">{t.exploreInferenceXLead}</p>
-            <p className="text-sm text-muted-foreground mb-6">{t.platformCoverage}</p>
-            <div className="mt-auto flex flex-col gap-2 sm:flex-row">
-              <LandingTrackedLink
-                href={`${prefix}/overview`}
-                data-testid="landing-overview-link"
-                analyticsEvent="landing_overview_clicked"
-                appNavigation
-                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md bg-brand px-8 text-sm font-medium text-primary-foreground transition-colors hover:bg-brand/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 motion-reduce:transition-none sm:w-auto sm:text-base"
-              >
-                {t.overview}
-                <ArrowRight aria-hidden="true" className="size-4" />
-              </LandingTrackedLink>
-              <LandingTrackedLink
-                href={`${prefix}/inference`}
-                data-testid="landing-full-dashboard-link"
-                analyticsEvent="landing_full_dashboard_clicked"
-                appNavigation
-                className="inline-flex h-12 w-full items-center justify-center gap-2 rounded-md border border-border px-8 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 motion-reduce:transition-none sm:w-auto sm:text-base"
-              >
-                {t.fullDashboard}
-                <ArrowRight aria-hidden="true" className="size-4" />
-              </LandingTrackedLink>
-            </div>
-            {/* Per-model entry points — crawlable links to the indexable
-                /inference/<model> pages. Only actively benchmarked models are
-                promoted here; deprecated model pages stay reachable via the
-                sitemap and dashboard selector. */}
-            <p className="text-sm text-muted-foreground mt-6 mb-2">{t.browseByModel}</p>
-            <div className="flex flex-wrap gap-2" data-testid="landing-model-links">
-              {ACTIVE_INFERENCE_MODEL_SLUGS.map((entry) => (
-                <LandingTrackedLink
-                  key={entry.slug}
-                  href={`${prefix}/inference/${entry.slug}`}
-                  data-testid={`landing-model-link-${entry.slug}`}
-                  analyticsEvent="landing_model_page_clicked"
-                  appNavigation
-                  className="inline-flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-sm hover:bg-accent transition-colors"
-                >
-                  {entry.seoName}
-                  <ArrowRight aria-hidden="true" className="size-3.5" />
-                </LandingTrackedLink>
-              ))}
-            </div>
-          </Card>
-
           {/* Reproducibility callout */}
           <Card>
             <div className="flex items-center gap-2 mb-3">


### PR DESCRIPTION
Removes the **Explore InferenceX** card from the landing page (both English and `/zh`):

- Section heading, lead copy, and platform-coverage paragraph
- Overview / Full Dashboard CTAs
- Per-model quick links (`landing-model-links`)

Also removes the now-unused `exploreInferenceX*`, `fullDashboard`, `platformCoverage`, `overview`, and `browseByModel` strings, the `BarChart3` and `ACTIVE_INFERENCE_MODEL_SLUGS` imports, and the Cypress assertions in `navigation.cy.ts` and `zh-pages.cy.ts` that covered the removed card.

`typecheck`, `lint`, and `fmt` pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page layout and marketing copy only; routes and header navigation are unchanged.
> 
> **Overview**
> Removes the **Explore InferenceX** card from the English and `/zh` landing pages so the homepage no longer duplicates overview, full-dashboard, and per-model entry points below the hero.
> 
> That section’s copy, **Overview** / **Full Dashboard** buttons (`landing-overview-link`, `landing-full-dashboard-link`), and crawlable per-model links are deleted along with related i18n strings and unused imports (`BarChart3`, `ACTIVE_INFERENCE_MODEL_SLUGS`). Primary navigation to overview and the dashboard now relies on the existing **AgentX** hero CTAs and header links, which Cypress still covers.
> 
> E2E tests that asserted the removed card and zh-specific overview/dashboard links are dropped; zh landing checks no longer expect the “探索 InferenceX” heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d94dd2a898813f889083ab14d74e4de25e039083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->