### PR TITLE
feat(compare): add model brand logos to /compare catalog sections / 在 /compare 目录区块标题中加入模型品牌标识

### DIFF
--- a/packages/app/src/app/compare/page.tsx
+++ b/packages/app/src/app/compare/page.tsx
@@ -9,10 +9,12 @@ import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { ModelLogo } from '@/components/ui/model-logo';
 import { comparisonPairHref, comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
 import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { type Model } from '@/lib/data-mappings';
 
 export const dynamic = 'force-dynamic';
 
@@ -154,7 +156,15 @@ export default async function CompareIndexPage() {
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
               <div>
-                <h2 className="text-xl lg:text-2xl font-bold tracking-tight">{model.label}</h2>
+                {/* `displayName` is the Model enum value by contract (see
+                    CompareModelSlug in compare-slug.ts), so the shared
+                    ModelLogo resolves each section's brand mark (DeepSeek,
+                    MiniMax, Kimi, ...) from MODEL_CONFIG and renders nothing
+                    for models without one. */}
+                <h2 className="flex items-center gap-2.5 text-xl lg:text-2xl font-bold tracking-tight">
+                  <ModelLogo model={model.displayName as Model} className="size-6 lg:size-7" />
+                  {model.label}
+                </h2>
                 <p className="text-sm text-muted-foreground mt-1">
                   {pairs.length} chip pair{pairs.length === 1 ? '' : 's'} with benchmark data on{' '}
                   {model.label}.

--- a/packages/app/src/app/zh/compare/page.tsx
+++ b/packages/app/src/app/zh/compare/page.tsx
@@ -7,10 +7,12 @@ import { AgentXCompareHero } from '@/components/compare/agentx-compare-hero';
 import { ComparePairCardLink } from '@/components/compare/compare-pair-card-link';
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
+import { ModelLogo } from '@/components/ui/model-logo';
 import { comparisonPairHref, comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { getComparablePairsByModelSlug } from '@/lib/compare-availability';
 import { type ComparePair, COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 import { bucketComparePairsByVendor, formatModelList } from '@/lib/compare-ssr';
+import { type Model } from '@/lib/data-mappings';
 import { ZH_OG_LOCALE, zhAlternates } from '@/lib/i18n';
 
 export const dynamic = 'force-dynamic';
@@ -150,7 +152,14 @@ export default async function CompareIndexPageZh() {
           <section key={model.slug} id={model.slug}>
             <Card className="flex flex-col gap-4">
               <div>
-                <h2 className="text-xl lg:text-2xl font-bold tracking-tight">{model.label}</h2>
+                {/* `displayName` 按约定即 Model 枚举值（见 compare-slug.ts 中的
+                    CompareModelSlug），因此共享的 ModelLogo 可从 MODEL_CONFIG
+                    解析各区块的品牌标识（DeepSeek、MiniMax、Kimi 等）；没有
+                    配置 logo 的模型则不渲染任何内容。 */}
+                <h2 className="flex items-center gap-2.5 text-xl lg:text-2xl font-bold tracking-tight">
+                  <ModelLogo model={model.displayName as Model} className="size-6 lg:size-7" />
+                  {model.label}
+                </h2>
                 <p className="text-sm text-muted-foreground mt-1">
                   {pairs.length} 组芯片对比具有 {model.label} 的基准测试数据。
                 </p>


### PR DESCRIPTION
## Summary

The `/compare` hero ledger already renders full-color brand marks, but the per-model catalog section headings below it were plain text. This PR renders the shared `ModelLogo` component beside each model section `h2` on `/compare` and `/zh/compare`, so the DeepSeek, MiniMax, Kimi, GLM, Qwen, gpt-oss, and Llama sections carry their brand marks.

- `CompareModelSlug.displayName` is the `Model` enum value by contract (see `compare-slug.ts`), so the existing `getModelLogo` mapping in `MODEL_CONFIG` resolves each section's mark with no new logo registry.
- `ModelLogo` renders nothing when a model has no configured logo or the asset fails to load, so sections degrade to the current text-only heading.
- Monochrome marks (e.g. `openai.svg` for gpt-oss) keep their dark-mode invert via the shared component.

## Testing

- `bun run typecheck` — clean
- `bun run lint` / `bun run fmt` — clean
- `bun run test:unit` — same pre-existing failures as `master` (local env lacks DB config); no new failures from this change

## 中文说明

`/compare` 页面顶部的 hero 模型列表已经展示全彩品牌标识，但下方各模型对比目录区块的标题仍是纯文本。本 PR 在 `/compare` 与 `/zh/compare` 的每个模型区块标题旁渲染共享的 `ModelLogo` 组件，使 DeepSeek、MiniMax、Kimi、GLM、Qwen、gpt-oss、Llama 等区块都带有品牌标识。

- `CompareModelSlug.displayName` 按约定即 `Model` 枚举值（见 `compare-slug.ts`），因此直接复用 `MODEL_CONFIG` 中现有的 `getModelLogo` 映射，无需新增 logo 注册表。
- 模型未配置 logo 或资源加载失败时，`ModelLogo` 不渲染任何内容，区块自动回退为现有的纯文本标题。
- 单色标识（如 gpt-oss 的 `openai.svg`）通过共享组件保留暗色模式下的反色处理。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational-only change to compare index pages with no auth, data, or routing impact.
> 
> **Overview**
> Per-model catalog sections on **`/compare`** and **`/zh/compare`** now show the shared **`ModelLogo`** next to each section title, matching the hero’s brand marks instead of text-only **`h2`** headings.
> 
> Logos resolve from **`model.displayName`** (typed as **`Model`**) via existing **`MODEL_CONFIG`** / **`getModelLogo`**; models without a logo still render as text-only when **`ModelLogo`** returns null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc149949a03464802ddda5121f1804c4ba69bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->