### PR TITLE
chore(db): purge run 32863999669 — incomplete failing run

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -90,6 +90,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   30346826643, // 2026-07-28 | Initial AMD submission for MiniMax M3 used incorrect AgentX harness; MTP/spec decode is AgentX-only. Will update after harness updates.
   30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
   32695861783, // 2026-08-24 | Reason: dev image — the dsv4-fp4-b300-sglang-agentic-hicache-mtp AgentX sweep ran on lmsysorg/sglang-staging:dev-cu13-pr-35880, built from the unmerged SGLang draft PR sgl-project/sglang#35880 (source run of the PR #2701 sweep-reuse ingest)
+  32863999669, // 2026-08-25 | Reason: incomplete failing run — Run Sweep on main for #2687 ([Power] Require GB multinode telemetry) failed 30 of 125 jobs (GB200/GB300 multi-node dyn-sgl arms), leaving partial data
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
Adds run [32863999669](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32863999669) to `PURGED_RUNS` so it is skipped on ingest and deleted from the DB.

**Reason:** incomplete failing run — the 2026-08-25 Run Sweep on `main` for SemiAnalysisAI/InferenceX#2687 ([Power] Require GB multinode telemetry) concluded failure with 30 of 125 jobs failed (GB200/GB300 multi-node dyn-sgl arms), leaving partial data.

Checks run locally: `bun run fmt:fix`, `bun run typecheck`, `bun run lint` — all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-ID ETL override with no logic changes; effect is excluding one known-bad partial sweep from the benchmark database.
> 
> **Overview**
> Adds GitHub Actions run **32863999669** to `PURGED_RUNS` in `run-overrides.ts`, with an audit comment tying it to the 2026-08-25 main sweep for #2687 (GB multinode telemetry).
> 
> That sweep failed **30 of 125** jobs (GB200/GB300 multi-node dyn-sgl arms), so only partial benchmark data would otherwise remain in the matrix. Listing the run here makes ingest skip it and lets the normal override pipeline remove any rows already stored for this run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe5ae2bd709cfb13a140be30c92fcd9dcd09ca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->