### PR TITLE
fix: /model embed no longer auto-populates chip configs and changelog on Back-navigation to /inference / 修复：从 /model 返回 /inference 时不再自动填充 chip config 与 changelog

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -2,6 +2,7 @@
 
 import { track } from '@/lib/analytics';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
+import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
 import * as d3 from 'd3';
 import dynamic from 'next/dynamic';
@@ -172,6 +173,7 @@ const GPUGraph = React.memo(
     } = useInferenceActions();
     const locale = useLocale();
     const legendT = GPU_STRINGS[locale];
+    const ephemeralUrlState = useEphemeralUrlState();
     const { resolvedTheme } = useTheme();
     const chartRef = useRef<D3ChartHandle>(null);
     const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
@@ -838,8 +840,10 @@ const GPUGraph = React.memo(
                 event.stopPropagation();
                 // Full-document navigation: stamp the chart state onto THIS
                 // history entry first, or Back returns to a bare /inference
-                // that rebuilds from defaults.
-                rememberChartStateInUrl();
+                // that rebuilds from defaults. Skipped in ephemeral scopes
+                // (/model embeds): the store holds the primary dashboard's
+                // state there, not this chart's.
+                if (!ephemeralUrlState) rememberChartStateInUrl();
                 track('gpu_timeseries_view_charts_opened', {
                   id: d.id,
                   hwKey: String(d.hwKey),

--- a/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
+++ b/packages/app/src/components/inference/ui/LegendPointsDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
 import { cn } from '@/lib/utils';
 
@@ -65,6 +66,7 @@ export default function LegendPointsDialog({
   onRowClick,
 }: LegendPointsDialogProps) {
   const [sort, setSort] = useState<{ key: LegendPointsSortKey; dir: 'asc' | 'desc' } | null>(null);
+  const ephemeralUrlState = useEphemeralUrlState();
 
   const hasOffload = rows.some((r) => r.offload !== null);
   const columns = useMemo(
@@ -185,8 +187,10 @@ export default function LegendPointsDialog({
                   onClick={() => {
                     // In-app detail links are full-document navigations, so the
                     // chart state has to be written into this history entry
-                    // before we leave or Back lands on a default chart.
-                    if (!row.isExternal) rememberChartStateInUrl();
+                    // before we leave or Back lands on a default chart. Skipped
+                    // in ephemeral scopes (/model embeds): the store holds the
+                    // primary dashboard's state there, not this chart's.
+                    if (!row.isExternal && !ephemeralUrlState) rememberChartStateInUrl();
                     onRowClick?.(row);
                   }}
                   className="col-span-full grid grid-cols-subgrid items-center rounded-sm hover:bg-accent whitespace-nowrap"

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -2,6 +2,7 @@
 
 import { track } from '@/lib/analytics';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
+import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
 import * as d3 from 'd3';
 import dynamic from 'next/dynamic';
@@ -461,6 +462,7 @@ const ScatterGraph = React.memo(
     } = useInferenceActions();
     const locale = useLocale();
     const legendT = SCATTER_STRINGS[locale];
+    const ephemeralUrlState = useEphemeralUrlState();
     const costLimit = chartDefinition.y_cost_limit ?? 0;
     const latencyLimit = chartDefinition.y_latency_limit ?? 0;
 
@@ -1889,8 +1891,10 @@ const ScatterGraph = React.memo(
               btnEvent.stopPropagation();
               // Full-document navigation: stamp the chart state onto THIS
               // history entry first, or Back returns to a bare /inference that
-              // rebuilds from defaults.
-              rememberChartStateInUrl();
+              // rebuilds from defaults. Skipped in ephemeral scopes (/model
+              // embeds): the store holds the primary dashboard's state there,
+              // not this chart's.
+              if (!ephemeralUrlState) rememberChartStateInUrl();
               track('latency_view_charts_opened', {
                 id: d.id,
                 hwKey: String(d.hwKey),

--- a/packages/app/src/components/model/EmbeddedModelDashboard.tsx
+++ b/packages/app/src/components/model/EmbeddedModelDashboard.tsx
@@ -3,6 +3,7 @@
 import { GlobalFilterProvider } from '@/components/GlobalFilterContext';
 import { InferenceProvider } from '@/components/inference/InferenceContext';
 import InferenceChartDisplay from '@/components/inference/ui/ChartDisplay';
+import { EphemeralUrlStateContext } from '@/hooks/useUrlState';
 import { toModel, toSequence } from '@/lib/compare-enum-coerce';
 import { DEFAULT_Y_AXIS_METRIC } from '@/lib/url-state';
 
@@ -13,6 +14,15 @@ import { DEFAULT_Y_AXIS_METRIC } from '@/lib/url-state';
  * (AgentX where available, otherwise 8K→1K), and the default
  * total-tokens-per-$ y-axis metric; every chip config with data is
  * auto-selected so the embed renders populated charts on first paint.
+ *
+ * The whole embed runs inside an ephemeral URL-state scope: its providers are
+ * the same ones the primary dashboards use, and those persist their state in
+ * the module-scoped store in `url-state.ts` that survives client-side
+ * navigations. Without the scope, the embed's auto-populated selection (all
+ * chip configs, seeded model/scenario) would overwrite that store, so
+ * Back-navigating to a bare `/inference` would rebuild WITH the embed's state
+ * — auto-populated chip configs and an unfolded config changelog the user
+ * never selected.
  */
 export default function EmbeddedModelDashboard({
   displayName,
@@ -22,17 +32,19 @@ export default function EmbeddedModelDashboard({
   sequence: string;
 }) {
   return (
-    <GlobalFilterProvider
-      initialModel={toModel(displayName)}
-      initialSequence={toSequence(sequence)}
-    >
-      <InferenceProvider
-        activeTab="inference"
-        initialYAxisMetric={DEFAULT_Y_AXIS_METRIC}
-        autoSelectAllGpus
+    <EphemeralUrlStateContext.Provider value={true}>
+      <GlobalFilterProvider
+        initialModel={toModel(displayName)}
+        initialSequence={toSequence(sequence)}
       >
-        <InferenceChartDisplay embedded />
-      </InferenceProvider>
-    </GlobalFilterProvider>
+        <InferenceProvider
+          activeTab="inference"
+          initialYAxisMetric={DEFAULT_Y_AXIS_METRIC}
+          autoSelectAllGpus
+        >
+          <InferenceChartDisplay embedded />
+        </InferenceProvider>
+      </GlobalFilterProvider>
+    </EphemeralUrlStateContext.Provider>
   );
 }

--- a/packages/app/src/hooks/useUrlState.ephemeral.test.tsx
+++ b/packages/app/src/hooks/useUrlState.ephemeral.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  writeUrlParams: vi.fn(),
+  refreshUrlParamsOnNavigation: vi.fn(() => true),
+  readUrlParams: vi.fn(() => ({}) as Record<string, string>),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/model/test-model',
+}));
+
+vi.mock('@/lib/url-state', () => ({
+  readUrlParams: mocks.readUrlParams,
+  refreshUrlParamsOnNavigation: mocks.refreshUrlParamsOnNavigation,
+  writeUrlParams: mocks.writeUrlParams,
+}));
+
+import { EphemeralUrlStateContext, useEphemeralUrlState, useUrlState } from './useUrlState';
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+let hookValue: ReturnType<typeof useUrlState> | undefined;
+let ephemeralValue: boolean | undefined;
+
+function Probe() {
+  hookValue = useUrlState();
+  ephemeralValue = useEphemeralUrlState();
+  return null;
+}
+
+function mount(ui: React.ReactElement): void {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  act(() => root?.render(ui));
+}
+
+beforeEach(() => {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+  mocks.writeUrlParams.mockClear();
+  mocks.readUrlParams.mockReturnValue({});
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  hookValue = undefined;
+  ephemeralValue = undefined;
+});
+
+describe('useUrlState outside an ephemeral scope', () => {
+  it('writes params to the shared store', () => {
+    mount(<Probe />);
+    expect(ephemeralValue).toBe(false);
+
+    act(() => hookValue?.setUrlParam('i_gpus', 'B200_vllm'));
+    expect(mocks.writeUrlParams).toHaveBeenCalledWith({ i_gpus: 'B200_vllm' });
+
+    act(() => hookValue?.setUrlParams({ g_model: 'Kimi-K3', i_seq: 'agentic-traces' }));
+    expect(mocks.writeUrlParams).toHaveBeenCalledWith({
+      g_model: 'Kimi-K3',
+      i_seq: 'agentic-traces',
+    });
+  });
+});
+
+describe('useUrlState inside an ephemeral scope', () => {
+  // The /model/[slug] embed reuses the dashboard providers, whose URL-sync
+  // effects write every state change (auto-selected chip configs included)
+  // into the module-scoped share-link store. Inside the ephemeral scope those
+  // writes must be dropped, or Back-navigating to a bare /inference rebuilds
+  // with the embed's auto-populated state instead of the user's own.
+  it('drops writes so embed state cannot leak into the dashboard', () => {
+    mount(
+      <EphemeralUrlStateContext.Provider value={true}>
+        <Probe />
+      </EphemeralUrlStateContext.Provider>,
+    );
+    expect(ephemeralValue).toBe(true);
+
+    act(() => hookValue?.setUrlParam('i_gpus', 'B200_vllm,GB200_dynamo'));
+    act(() => hookValue?.setUrlParams({ g_model: 'Kimi-K3' }));
+    expect(mocks.writeUrlParams).not.toHaveBeenCalled();
+  });
+
+  it('still reads params (share links into the embed keep working)', () => {
+    mocks.readUrlParams.mockReturnValue({ i_gpus: 'MI355X_atom' });
+    mount(
+      <EphemeralUrlStateContext.Provider value={true}>
+        <Probe />
+      </EphemeralUrlStateContext.Provider>,
+    );
+
+    expect(hookValue?.getUrlParam('i_gpus')).toBe('MI355X_atom');
+    expect(hookValue?.hasUrlParam('i_gpus')).toBe(true);
+  });
+});

--- a/packages/app/src/hooks/useUrlState.ts
+++ b/packages/app/src/hooks/useUrlState.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useCallback, useRef } from 'react';
+import { createContext, useCallback, useContext, useRef } from 'react';
 
 import {
   type UrlStateKey,
@@ -12,9 +12,37 @@ import {
 } from '@/lib/url-state';
 
 /**
+ * Marks a subtree whose chart providers must treat the shared URL-state store
+ * as READ-ONLY.
+ *
+ * The store in `url-state.ts` is module-scoped and deliberately outlives
+ * client-side navigations, so the dashboard's filters survive a round-trip
+ * through other pages. Embedded chart instances reuse the same providers
+ * (`GlobalFilterProvider` → `InferenceProvider`), so without this scope their
+ * seeded state — e.g. the `/model/[slug]` embed's auto-selected "every chip
+ * config with data" — is written into the store and becomes the state a bare
+ * `/inference` rebuilds from on Back-navigation, silently replacing whatever
+ * the user actually had selected.
+ *
+ * Reads stay live inside the scope: explicit share-link params on the embed's
+ * own URL keep working, and writes made by the primary dashboards are still
+ * visible. Only writes (including `rememberChartStateInUrl` stamping — see the
+ * chart components) are suppressed.
+ */
+export const EphemeralUrlStateContext = createContext(false);
+
+/** Whether the calling component is inside an ephemeral URL-state scope. */
+export function useEphemeralUrlState(): boolean {
+  return useContext(EphemeralUrlStateContext);
+}
+
+/**
  * React hook for URL state synchronization.
  * Reads URL params once on mount (cached in ref), and provides
  * functions to write params back to the URL.
+ *
+ * Inside an `EphemeralUrlStateContext` scope the write functions are no-ops
+ * (see the context doc above); reads are unaffected.
  */
 export function useUrlState() {
   const initialParams = useRef<UrlStateParams | null>(null);
@@ -47,13 +75,23 @@ export function useUrlState() {
     [],
   );
 
-  const setUrlParam = useCallback((key: UrlStateKey, value: string) => {
-    writeUrlParams({ [key]: value });
-  }, []);
+  const ephemeral = useContext(EphemeralUrlStateContext);
 
-  const setUrlParams = useCallback((params: UrlStateParams) => {
-    writeUrlParams(params);
-  }, []);
+  const setUrlParam = useCallback(
+    (key: UrlStateKey, value: string) => {
+      if (ephemeral) return;
+      writeUrlParams({ [key]: value });
+    },
+    [ephemeral],
+  );
+
+  const setUrlParams = useCallback(
+    (params: UrlStateParams) => {
+      if (ephemeral) return;
+      writeUrlParams(params);
+    },
+    [ephemeral],
+  );
 
   return {
     initialParams: initialParams.current,


### PR DESCRIPTION
## Summary

Clicking the "Learn more about the … architecture" icon next to the model selector navigates to `/model/[slug]`, whose embedded dashboard intentionally auto-selects every chip config with data. But because the embed reuses `GlobalFilterProvider` → `InferenceProvider`, their URL-sync effects wrote that auto-populated state (`i_gpus`, seeded `g_model`/`i_seq`, …) into the module-scoped share-link store in `url-state.ts` — which deliberately survives client-side navigations. Clicking **Back** to a bare `/inference` then rebuilt from that contaminated store: the chip configs auto-populated and the config changelog expanded, exactly like `/model/[slug]`, replacing whatever the user actually had selected.

## Fix

- New `EphemeralUrlStateContext` (in `useUrlState.ts`): a scope in which `useUrlState`'s write functions (`setUrlParam` / `setUrlParams`, and therefore `useUrlStateSync`) are no-ops. **Reads stay live**, so explicit share links into `/model` pages keep working and continuity from the primary dashboard is preserved.
- `EmbeddedModelDashboard` wraps its providers in that scope, so the embed's `autoSelectAllGpus` selection and seeded model/scenario never reach the shared store.
- `rememberChartStateInUrl()` stamping in `ScatterGraph`, `GPUGraph`, and `LegendPointsDialog` is skipped inside the scope: there the store holds the primary dashboard's state, not the embed's, so stamping it onto the `/model` history entry would be wrong for the same reason.

## Repro (before)

1. Open `/inference` with the default (or any) chip selection.
2. Click the model-architecture info icon → `/model/<slug>` (auto-populates all chip configs — intended there).
3. Click browser Back → `/inference` now shows every chip config selected and the Config Changelog panel, none of which the user chose.

## Tests

- New `useUrlState.ephemeral.test.tsx`: writes pass through outside the scope, are dropped inside it, and reads still work inside it.
- `bun run typecheck`, `bun run lint`, full unit suite (251 files / 4457 tests) pass.

## 中文说明

点击模型选择器旁的"了解模型架构"图标会跳转到 `/model/[slug]`，该页面的内嵌仪表板会有意自动全选所有有数据的 chip config。但内嵌仪表板复用了 `GlobalFilterProvider` → `InferenceProvider`，其 URL 同步逻辑会把这些自动填充的状态（`i_gpus`、预置的 `g_model`/`i_seq` 等）写入 `url-state.ts` 中跨客户端导航存活的模块级共享存储。点击浏览器返回键回到 `/inference` 后，页面会基于被污染的存储重建：chip config 被自动填满、config changelog 面板自动展开，覆盖了用户原本的选择。

修复方案：

- 新增 `EphemeralUrlStateContext` 作用域，其中 `useUrlState` 的写入函数为空操作；读取不受影响，指向 `/model` 页面的分享链接仍然有效。
- `EmbeddedModelDashboard` 将其 provider 包裹在该作用域内，使内嵌仪表板的自动全选状态不会进入共享存储。
- `ScatterGraph`、`GPUGraph`、`LegendPointsDialog` 中的 `rememberChartStateInUrl()` 状态回写在该作用域内同样跳过。

测试：新增 `useUrlState.ephemeral.test.tsx`（作用域外写入正常、作用域内写入被丢弃、读取仍可用）；`typecheck`、`lint` 与全部单元测试（251 个文件 / 4457 个用例）均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-route navigation and the module-scoped share-link store; scope is limited to the embed subtree and chart navigation hooks, with unit tests covering the new behavior.
> 
> **Overview**
> Fixes **Back** from `/model/[slug]` to `/inference` restoring the user’s chip selection instead of the embed’s auto–select-all state.
> 
> The `/model` **EmbeddedModelDashboard** now wraps its providers in **`EphemeralUrlStateContext`**, where **`useUrlState`** write paths (`setUrlParam` / `setUrlParams`) are no-ops while **reads** still work for share links. **`ScatterGraph`**, **`GPUGraph`**, and **`LegendPointsDialog`** skip **`rememberChartStateInUrl()`** in that scope so history entries are not stamped with the wrong store snapshot.
> 
> Adds **`useUrlState.ephemeral.test.tsx`** for write-through outside the scope, dropped writes inside, and preserved reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375bacd79fb162da540efb257bf5ea7a19ff67c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->