### PR TITLE
feat(overview): group AgentX rows above 8K/1K rows in the matrix

### DIFF
--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -1,7 +1,8 @@
 import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
 
 // Order mirrors DEFAULT_MODELS (MODEL_CONFIG insertion order), which fixes the
-// matrix row order.
+// row order within each scenario group — AgentX rows lead the matrix, 8K/1K
+// rows follow.
 const MODEL_LABELS = [
   'DeepSeek V4 Pro 0813 1.6T',
   'Kimi K3 2.8T',
@@ -1283,9 +1284,10 @@ describe('Overview page', () => {
       'have.length',
       2,
     );
-    // Single-turn first, AgentX directly below it, both under the same label.
+    // The AgentX row sits in the leading AgentX group; the single-turn row
+    // follows in the 8K/1K group below it, both under the same label.
     cy.get('[data-testid="overview-desktop-model"][data-model="DeepSeek-V4-Pro"]').then(($rows) => {
-      expect([...$rows].map((row) => row.dataset.scenario)).to.deep.equal([SINGLE_TURN, AGENTX]);
+      expect([...$rows].map((row) => row.dataset.scenario)).to.deep.equal([AGENTX, SINGLE_TURN]);
     });
 
     desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -668,7 +668,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    sourceSha256: '02ea8d9b72210c7dec8380ec3a4ff30a41254901e4d63a230cba893fc0473811',
+    sourceSha256: '8ca280fec5bbe633493cf021fee294927aead799742ac07ac7dbe8c5092e38f2',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/overview-data.server.test.ts
+++ b/packages/app/src/lib/overview-data.server.test.ts
@@ -57,7 +57,9 @@ const rows = [
 ];
 
 function selectedFrameworks(page: OverviewPageData) {
-  const summary = page.models.find((model) => model.model === Model.Qwen3_5);
+  const summary = page.models.find(
+    (model) => model.model === Model.Qwen3_5 && model.scenario === 'single_turn_8k1k',
+  );
   return {
     candidate: summary?.platforms.find(({ hardware }) => hardware === 'mi355x')?.read.config
       ?.framework,
@@ -202,7 +204,9 @@ describe('getOverviewPageData engine scope forwarding', () => {
 
     const { getOverviewPageData } = await import('./overview-data.server');
     const page = await getOverviewPageData(50, 'community', '30d');
-    const qwen = page.models.find((model) => model.model === Model.Qwen3_5);
+    const qwen = page.models.find(
+      (model) => model.model === Model.Qwen3_5 && model.scenario === 'single_turn_8k1k',
+    );
     const mi355x = qwen?.platforms.find(({ hardware }) => hardware === 'mi355x');
     const b300 = qwen?.platforms.find(({ hardware }) => hardware === 'b300');
 

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -1259,7 +1259,7 @@ describe('tier-parameterized overview', () => {
     );
 
     const pair = headlinePairOf(
-      page.models.find((m) => m.model === Model.Qwen3_5)!,
+      page.models.find((m) => m.model === Model.Qwen3_5 && m.scenario === 'single_turn_8k1k')!,
       'mi355x-vs-b200',
     );
     expect(pair?.candidate.read).toMatchObject({ tier: 100, value: 3600 });
@@ -1282,7 +1282,7 @@ describe('tier-parameterized overview', () => {
 
     const at50 = headlinePairOf(
       assembleOverviewPageData({ [Model.Qwen3_5]: rows }).models.find(
-        (m) => m.model === Model.Qwen3_5,
+        (m) => m.model === Model.Qwen3_5 && m.scenario === 'single_turn_8k1k',
       )!,
       'mi355x-vs-b200',
     );
@@ -1290,7 +1290,7 @@ describe('tier-parameterized overview', () => {
 
     const at30 = headlinePairOf(
       assembleOverviewPageData({ [Model.Qwen3_5]: rows }, 30).models.find(
-        (m) => m.model === Model.Qwen3_5,
+        (m) => m.model === Model.Qwen3_5 && m.scenario === 'single_turn_8k1k',
       )!,
       'mi355x-vs-b200',
     );
@@ -1312,7 +1312,7 @@ describe('tier-parameterized overview', () => {
           ],
         },
         tier,
-      ).models.find((m) => m.model === Model.Qwen3_5)!;
+      ).models.find((m) => m.model === Model.Qwen3_5 && m.scenario === 'single_turn_8k1k')!;
 
     const at50 = headlinePairOf(page(), 'mi355x-vs-b200');
     expect(at50?.candidate.precision).toBe(Precision.FP4);
@@ -1341,17 +1341,18 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     // not default models, and the matrix is built from DEFAULT_MODELS.
     // Qwen3.8-Flash-Next is curated AgentX-only, like Kimi K3 and GLM: the
     // model is benchmarked on agentic traces, so it must not claim a
-    // fixed-sequence row it will never fill.
+    // fixed-sequence row it will never fill. AgentX rows group above the 8K/1K
+    // rows, each group in MODEL_CONFIG declaration order.
     expect(page.models.map((m) => `${m.model}/${m.scenario}`)).toEqual([
-      `${Model.DeepSeek_V4_Pro}/single_turn_8k1k`,
       `${Model.DeepSeek_V4_Pro}/agentx`,
       `${Model.Kimi_K3}/agentx`,
-      `${Model.MiniMax_M3}/single_turn_8k1k`,
       `${Model.MiniMax_M3}/agentx`,
       `${Model.GLM_5_2}/agentx`,
-      `${Model.Qwen3_5}/single_turn_8k1k`,
       `${Model.Qwen3_5}/agentx`,
       `${Model.Qwen3_8_Flash_Next}/agentx`,
+      `${Model.DeepSeek_V4_Pro}/single_turn_8k1k`,
+      `${Model.MiniMax_M3}/single_turn_8k1k`,
+      `${Model.Qwen3_5}/single_turn_8k1k`,
     ]);
     expect(page.models.length).toBeGreaterThan(DEFAULT_MODELS.size);
     expect(page).not.toHaveProperty('datasetThroughDate');
@@ -1361,7 +1362,9 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     // therefore have no exact @50 read; GB200's independent FP8 remains visible.
     // GB300's points are single-node and multi-node aggregate deployments, so
     // they must not be interpolated into one synthetic serving curve.
-    const deepseek = page.models.find((m) => m.model === Model.DeepSeek_V4_Pro)!;
+    const deepseek = page.models.find(
+      (m) => m.model === Model.DeepSeek_V4_Pro && m.scenario === 'single_turn_8k1k',
+    )!;
     const dsB300 = headlinePairOf(deepseek, 'b300-vs-b200')!;
     expect(dsB300.baseline.read.value).toBeCloseTo(8101.968);
     expect(dsB300.baseline.costPerMtok).toBeCloseTo(
@@ -1418,7 +1421,9 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
 
     // MiniMax: the platform result remains visible when B200 has no 8K/1K data
     // — priced, but with no percentage baseline (the UI's ∞ badge state).
-    const minimax = page.models.find((m) => m.model === Model.MiniMax_M3)!;
+    const minimax = page.models.find(
+      (m) => m.model === Model.MiniMax_M3 && m.scenario === 'single_turn_8k1k',
+    )!;
     const mmGb300 = headlinePairOf(minimax, 'gb300-vs-b200')!;
     expect(mmGb300.baseline.missingReason).toBe('no_scenario_data');
     expect(mmGb300.candidate.read.value).toBe(6510);
@@ -1429,7 +1434,9 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     expect(mmGb300.candidate.costVsReferencePct).toBeNull();
 
     // Qwen: MI355X independently falls back to FP8 while B200 and B300 use FP4.
-    const qwen = page.models.find((m) => m.model === Model.Qwen3_5)!;
+    const qwen = page.models.find(
+      (m) => m.model === Model.Qwen3_5 && m.scenario === 'single_turn_8k1k',
+    )!;
     const qwenMi = headlinePairOf(qwen, 'mi355x-vs-b200')!;
     expect(qwenMi.candidate.precision).toBe(Precision.FP8);
     expect(qwenMi.candidate.read.value).toBe(6688);

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -65,8 +65,15 @@ export const OVERVIEW_DEFAULT_ROW_SCOPE: OverviewRowScope = 'all';
 export type OverviewHardwareRowScope = 'priced' | 'all';
 export const OVERVIEW_DEFAULT_HARDWARE_ROW_SCOPE: OverviewHardwareRowScope = 'all';
 export type OverviewScenario = 'single_turn_8k1k' | 'agentx';
-/** Row order within a model: the single-turn workload first, AgentX below it. */
+/** Canonical scenario list. Its order decides headline selection on stat-led
+ *  surfaces (single-turn first), NOT matrix row order — the matrix groups
+ *  AgentX rows first via OVERVIEW_SCENARIO_ROW_ORDER below. */
 export const OVERVIEW_SCENARIOS = ['single_turn_8k1k', 'agentx'] as const;
+/** Matrix display order: the AgentX rows lead and the fixed-sequence 8K/1K
+ *  rows follow, so the workload the overview headlines is not buried under
+ *  legacy single-turn rows. Deliberately separate from OVERVIEW_SCENARIOS so
+ *  /run and /rankings keep quoting single-turn where it exists. */
+export const OVERVIEW_SCENARIO_ROW_ORDER = ['agentx', 'single_turn_8k1k'] as const;
 
 export function resolveOverviewEngineScope(
   raw: string | string[] | undefined,
@@ -118,7 +125,9 @@ export function resolveOverviewHardwareRowScope(
 
 // Note (wenyao): row order is a contract — defaults, then maintenance, then
 // deprecated, each in MODEL_CONFIG declaration order; the overview e2e asserts
-// inactive rows always sit below the default rows.
+// inactive rows always sit below the default rows. Within each category band
+// the matrix additionally groups AgentX rows above 8K/1K rows (see
+// sortOverviewSummaries), which never reorders across bands.
 export function overviewModelsForScope(scope: OverviewModelScope): Model[] {
   return scope === 'all'
     ? [...DEFAULT_MODELS, ...MAINTENANCE_MODELS, ...DEPRECATED_MODELS]
@@ -840,11 +849,29 @@ export function overviewHardwareTierReader(
   };
 }
 
-/** DEFAULT_MODELS fixes the row order, and a model benchmarked on both
- *  scenarios contributes one row per scenario; a rowless model still renders
- *  all platforms with missing reasons. Live and fixture paths both feed this.
- *  Scenario presence reads the unscoped rows so switching the engine scope
- *  changes cell contents, never the shape of the matrix. */
+const overviewCategoryRank = (category: CategoryTag): number =>
+  category === 'default' ? 0 : category === 'maintenance' ? 1 : 2;
+const overviewScenarioRank = (scenario: OverviewScenario): number =>
+  OVERVIEW_SCENARIO_ROW_ORDER.indexOf(scenario);
+
+/** Category bands stay in place (defaults, then maintenance, then deprecated)
+ *  while AgentX rows lead within each band — 8K/1K rows follow — and each
+ *  (band, scenario) group keeps MODEL_CONFIG declaration order. The sort is
+ *  stable, so ties never shuffle. */
+function sortOverviewSummaries(summaries: OverviewModelSummary[]): OverviewModelSummary[] {
+  return summaries.toSorted(
+    (a, b) =>
+      overviewCategoryRank(a.category) - overviewCategoryRank(b.category) ||
+      overviewScenarioRank(a.scenario) - overviewScenarioRank(b.scenario),
+  );
+}
+
+/** DEFAULT_MODELS fixes the row order within each (category, scenario) group,
+ *  AgentX rows sit above 8K/1K rows (see sortOverviewSummaries), and a model
+ *  benchmarked on both scenarios contributes one row per scenario; a rowless
+ *  model still renders all platforms with missing reasons. Live and fixture
+ *  paths both feed this. Scenario presence reads the unscoped rows so switching
+ *  the engine scope changes cell contents, never the shape of the matrix. */
 export function assembleOverviewPageData(
   rowsByModel: Record<string, BenchmarkRow[]>,
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,
@@ -857,9 +884,11 @@ export function assembleOverviewPageData(
     rows: rowsByModel[model] ?? [],
   }));
   return {
-    models: perModel.flatMap(({ model, rows }) =>
-      overviewScenariosForModel(model, rows).map((scenario) =>
-        buildOverviewModelSummary(model, rows, tier, engineScope, scenario, referenceHardware),
+    models: sortOverviewSummaries(
+      perModel.flatMap(({ model, rows }) =>
+        overviewScenariosForModel(model, rows).map((scenario) =>
+          buildOverviewModelSummary(model, rows, tier, engineScope, scenario, referenceHardware),
+        ),
       ),
     ),
     tier,


### PR DESCRIPTION
## Why

The /overview matrix listed rows model-major with each model's single-turn row first, so the DeepSeek V4 Pro and MiniMax M3 8K/1K rows sat above most of the AgentX rows the page headlines. AgentX is the workload the overview leads with, so its rows should not be buried under legacy fixed-sequence rows.

## What

- Rows now group by scenario within each category band: **AgentX rows lead, 8K/1K rows follow**, each group keeping MODEL_CONFIG declaration order (`sortOverviewSummaries` in `overview-data.ts`).
- Category bands are untouched: defaults still sit above maintenance and deprecated rows, so the model-scope contract and its e2e assertions hold.
- `OVERVIEW_SCENARIOS` keeps its single-turn-first order, so headline scenario selection on /run and /rankings is unchanged — this is purely a matrix display-order change. New `OVERVIEW_SCENARIO_ROW_ORDER` carries the display order.
- History mode inherits the order for free since it composes `assembleOverviewPageData`.

## New default-scope row order

DeepSeek V4 Pro · AgentX → Kimi K3 · AgentX → MiniMax M3 · AgentX → GLM 5.2 · AgentX → Qwen3.5 · AgentX → Qwen3.8 Flash Next · AgentX → DeepSeek V4 Pro · 8K/1K → MiniMax M3 · 8K/1K → Qwen3.5 · 8K/1K

## Tests

- Updated the fixture-order drift guard in `overview-data.test.ts` and scenario-qualified the lookups that previously relied on the single-turn row being found first (`overview-data.test.ts`, `overview-data.server.test.ts`).
- Updated the e2e expectation for DeepSeek's per-model scenario order (`overview.cy.ts`).
- Bumped the `overview-data.ts` digest in `api-route-catalog.ts` after review: the overview BFF is a page-owned excluded route and the `OverviewPageData` shape is unchanged — only row order moved.
- Full unit suite green locally (250 files / 4454 tests), lint + fmt + typecheck clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order change in overview BFF assembly only; OverviewPageData shape and headline scenario logic elsewhere are unchanged.
> 
> **Overview**
> The overview cost matrix now **lists AgentX scenario rows before 8K/1K rows** within each model category band (defaults, then maintenance, then deprecated). Model order inside each band is unchanged.
> 
> `assembleOverviewPageData` applies a new **`sortOverviewSummaries`** step driven by **`OVERVIEW_SCENARIO_ROW_ORDER`**. **`OVERVIEW_SCENARIOS`** still prefers single-turn first for headline selection on `/run` and `/rankings`, so this is matrix display order only—not pricing or API shape.
> 
> Tests and Cypress expectations were updated for the new row sequence and for lookups that must target a specific `(model, scenario)` pair. The **`overview-data.ts`** digest in **`api-route-catalog.ts`** was bumped after review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34dc0ca92f0d44890776641d35c83832808a3144. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->