### PR TITLE
Remove the AgentX results launch modal from the landing page

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -59,7 +59,6 @@ describe('Landing page performance', () => {
 
     cy.visit('/', {
       onBeforeLoad(win) {
-        win.localStorage.removeItem('inferencex-agentic-results-modal-dismissed');
         win.localStorage.removeItem('inferencex-openai-rubin-banner-dismissed');
         observeLayoutShifts(win);
       },

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -1,8 +1,6 @@
 // Merged from tabs.cy.ts and first-load-navigation.cy.ts
 // to reduce per-file Cypress startup overhead (~500ms per file)
 
-import { keepLaunchModal } from '../support/e2e';
-
 describe('Chart Section Tabs — E2E', () => {
   before(() => {
     cy.window().then((win) => {
@@ -44,31 +42,22 @@ describe('Chart Section Tabs — E2E', () => {
 });
 
 describe('First-load navigation', () => {
-  // These specs need the launch modal to actually show on first load.
-  before(keepLaunchModal);
-
   beforeEach(() => {
     cy.visit('/', {
       onBeforeLoad(win) {
         win.localStorage.removeItem('inferencex-starred');
-        // Snoozed, not cleared: dismissing the launch modal below makes the
-        // star modal the next eligible landing nudge, and its corner card
-        // would sit over the footer links these specs click.
+        // Snoozed, not cleared: the star modal is the eligible landing nudge
+        // on first load, and its corner card would sit over the footer links
+        // these specs click.
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
-        win.localStorage.removeItem('inferencex-agentic-results-modal-dismissed');
         win.localStorage.removeItem('inferencex-openai-rubin-banner-dismissed');
       },
     });
 
-    // The launch modal is centered behind a backdrop, so it owns the first
-    // interaction — dismiss it before exercising the page underneath.
-    cy.get('[data-testid="launch-modal"]').should('be.visible');
-    cy.get('[data-testid="launch-modal-dismiss"]').click();
-    cy.get('[data-testid="launch-modal"]').should('not.exist');
     cy.get('body').should('not.have.attr', 'data-scroll-locked');
   });
 
-  it('navigates to articles from the footer after the launch modal is dismissed', () => {
+  it('navigates to articles from the footer', () => {
     cy.get('[data-testid="footer-link-articles"]').scrollIntoView().click();
     cy.location('pathname').should('eq', '/blog');
   });

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -6,12 +6,6 @@
  * permanent-suppress ("starred") cross-nudge mechanism.
  */
 
-import { keepLaunchModal } from '../support/e2e';
-
-// This spec owns launch-modal state, so it opts out of the global suppression
-// in cypress/support/e2e.ts rather than fighting it per visit.
-keepLaunchModal();
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -20,7 +14,6 @@ function clearAllNudgeStorage(win: Cypress.AUTWindow) {
   const keys = [
     'inferencex-starred',
     'inferencex-star-modal-dismissed',
-    'inferencex-agentic-results-modal-dismissed',
     'inferencex-openai-rubin-banner-dismissed',
     'inferencex-reproducibility-nudge-shown',
     'inferencex-star-nudge-shown',
@@ -33,17 +26,6 @@ function clearAllNudgeStorage(win: Cypress.AUTWindow) {
     win.localStorage.removeItem(key);
     win.sessionStorage.removeItem(key);
   }
-}
-
-/**
- * Banner-only state: everything cleared except the launch modal, which stays
- * dismissed. The modal is centered behind a full-screen backdrop, and that
- * backdrop covers the banner — including its dismiss button — whenever both
- * are eligible. These tests are about the banner, so keep the modal out.
- */
-function clearBannerNudgeStorage(win: Cypress.AUTWindow) {
-  clearAllNudgeStorage(win);
-  win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
 }
 
 // `cypress.config.ts` runs with `testIsolation: false` — the browser context
@@ -60,11 +42,10 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('Landing nudges — modals', () => {
-  it('shows launch modal and banner simultaneously on fresh first load', () => {
+  it('shows the launch banner on fresh first load', () => {
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
     });
-    // Banner (inline) and modal (overlay) occupy independent slots
     cy.get('[data-testid="launch-banner"]')
       .should('be.visible')
       .and('contain.text', "OpenAI's Latest In House Chip verus Rubin NVL72")
@@ -73,15 +54,8 @@ describe('Landing nudges — modals', () => {
         'Compare Jalapeño (Teacup) with Vera Rubin (July) NVL72 on DeepSeek R1 at 8K / 1K.',
       )
       .and('contain.text', 'View results');
-    cy.get('[data-testid="launch-modal"]')
-      .should('be.visible')
-      .and('contain.text', 'Real-world agentic inference benchmark results are live')
-      .and('contain.text', 'Kimi K3, DeepSeek-V4-Pro-0813, MiniMax-M3, Qwen3.5 397B, and GLM-5.3')
-      .and('contain.text', 'View results')
-      // Centered launch modal: a real backdrop-backed dialog, not a corner card.
-      .and('match', 'div[role="dialog"][aria-modal="true"]');
     cy.get('[data-new-badge]')
-      .should('have.length', 3)
+      .should('have.length', 2)
       .then(($badges) => {
         const sizes = [...$badges].map((badge) => {
           const rect = badge.getBoundingClientRect();
@@ -120,8 +94,6 @@ describe('Landing nudges — modals', () => {
           expect(inkOffset, 'label ink is centred').to.be.closeTo(0, 0.5);
         }
       });
-    // Only one overlay at a time — star modal should not appear
-    cy.get('[data-testid="github-star-modal"]').should('not.exist');
   });
 
   it('localizes the Rubin comparison banner title in Chinese', () => {
@@ -136,79 +108,18 @@ describe('Landing nudges — modals', () => {
         '对比 Jalapeño (Teacup) 与 Vera Rubin (July) NVL72 在 DeepSeek R1 8K / 1K 工作负载下的表现。',
       )
       .and('contain.text', '查看结果');
-    cy.get('[data-testid="launch-modal"]')
-      .should('be.visible')
-      .and('contain.text', '真实场景智能体推理基准测试结果已上线')
-      .and('contain.text', 'Kimi K3、DeepSeek-V4-Pro-0813、MiniMax-M3、Qwen3.5 397B 与 GLM-5.3')
-      .and('contain.text', '查看结果');
   });
 
-  it('renders the launch modal centered in the viewport, over a backdrop', () => {
+  it('shows the star modal on the landing page', () => {
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
     });
-    cy.get('[data-testid="launch-modal"]').should('be.visible');
-    cy.window().then((win) => {
-      const rect = win.document
-        .querySelector('[data-testid="launch-modal"]')!
-        .getBoundingClientRect();
-      // clientWidth, not innerWidth: a fixed overlay is laid out against the
-      // viewport minus the scrollbar, so innerWidth is half a scrollbar off.
-      const { clientWidth, clientHeight } = win.document.documentElement;
-      expect(Math.abs((rect.left + rect.right) / 2 - clientWidth / 2)).to.be.lessThan(2);
-      expect(Math.abs((rect.top + rect.bottom) / 2 - clientHeight / 2)).to.be.lessThan(2);
-    });
-  });
-
-  it('dismissing launch modal persists — not shown on reload', () => {
-    cy.visit('/', {
-      onBeforeLoad: clearAllNudgeStorage,
-    });
-    cy.get('[data-testid="launch-modal"]').should('be.visible');
-    cy.get('[data-testid="launch-modal-dismiss"]').click();
-    cy.get('[data-testid="launch-modal"]').should('not.exist');
-    // Assert the write itself, not just the absence after reload — the latter
-    // is only meaningful because this spec opted out of the global seeding.
-    cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-agentic-results-modal-dismissed')).to.eq('1');
-    });
-
-    cy.reload();
-    cy.get('[data-testid="launch-modal"]').should('not.exist');
-  });
-
-  it('launch modal View results action opens Agentic Traces and persists dismissal', () => {
-    cy.visit('/', {
-      onBeforeLoad: clearAllNudgeStorage,
-    });
-    cy.get('[data-testid="launch-modal"]').should('be.visible');
-
-    // The action records engagement and opens the Agentic Traces results.
-    cy.get('[data-testid="launch-modal-action"]').click();
-    cy.location('pathname').should('eq', '/inference');
-    cy.location('search').should('include', 'i_seq=agentic-traces');
-    cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-agentic-results-modal-dismissed')).to.eq('1');
-    });
-  });
-
-  it('shows star modal when launch modal was previously dismissed', () => {
-    cy.visit('/', {
-      onBeforeLoad(win) {
-        clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
-      },
-    });
-    cy.get('[data-testid="launch-modal"]').should('not.exist');
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
   });
 
   it('star modal dismiss uses timed strategy — re-shows after expiry', () => {
     cy.visit('/', {
-      onBeforeLoad(win) {
-        clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
-      },
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
     cy.get('[data-testid="github-star-modal-dismiss"]').click();
@@ -223,10 +134,7 @@ describe('Landing nudges — modals', () => {
 
   it('starring permanently suppresses both star modal and star nudge', () => {
     cy.visit('/', {
-      onBeforeLoad(win) {
-        clearAllNudgeStorage(win);
-        win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
-      },
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="github-star-modal"]').should('be.visible');
     cy.get('[data-testid="github-star-modal-action"]').click();
@@ -245,22 +153,14 @@ describe('Landing nudges — modals', () => {
 describe('Landing nudges — banner', () => {
   it('shows launch banner on landing page', () => {
     cy.visit('/', {
-      onBeforeLoad(win) {
-        clearBannerNudgeStorage(win);
-        // Dismiss modals so the banner (highest priority at 60) is the active nudge.
-        // Actually the banner has priority 60 > launch modal 50, so it should show first.
-        // But the engine only shows one nudge at a time; the banner wins because of priority.
-      },
+      onBeforeLoad: clearAllNudgeStorage,
     });
-    // The banner has the highest priority (60), so it should appear.
-    // However, NudgeEngine only shows one nudge at a time.
-    // With immediate triggers and priority 60 > 50 > 40, the banner wins.
     cy.get('[data-testid="launch-banner"]').should('be.visible');
   });
 
   it('banner renders within container constraints (not full-width)', () => {
     cy.visit('/', {
-      onBeforeLoad: clearBannerNudgeStorage,
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     // The banner's parent section has the container class for width constraints
@@ -269,7 +169,7 @@ describe('Landing nudges — banner', () => {
 
   it('dismissing the banner persists across reloads', () => {
     cy.visit('/', {
-      onBeforeLoad: clearBannerNudgeStorage,
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.get('[data-testid="launch-banner-dismiss"]').click();
@@ -281,7 +181,7 @@ describe('Landing nudges — banner', () => {
 
   it('rendering the banner does not write its dismissal storage key', () => {
     cy.visit('/', {
-      onBeforeLoad: clearBannerNudgeStorage,
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.window().then((win) => {
@@ -292,7 +192,7 @@ describe('Landing nudges — banner', () => {
 
   it('clicking the banner body navigates without persisting dismissal', () => {
     cy.visit('/', {
-      onBeforeLoad: clearBannerNudgeStorage,
+      onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.get('[data-testid="launch-banner"]').click();
@@ -475,7 +375,6 @@ describe('Nudge scope isolation', () => {
     cy.visit('/inference', {
       onBeforeLoad: clearAllNudgeStorage,
     });
-    cy.get('[data-testid="launch-modal"]').should('not.exist');
     cy.get('[data-testid="github-star-modal"]').should('not.exist');
     cy.get('[data-testid="launch-banner"]').should('not.exist');
   });
@@ -485,7 +384,6 @@ describe('Nudge scope isolation', () => {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
         // Dismiss all landing nudges so nothing blocks visibility checks
-        win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
         win.localStorage.setItem('inferencex-openai-rubin-banner-dismissed', '1');
         win.localStorage.setItem('inferencex-starred', '1');
       },

--- a/packages/app/cypress/support/e2e.ts
+++ b/packages/app/cypress/support/e2e.ts
@@ -2,36 +2,24 @@
  * Global e2e setup. Loaded before every `cy.visit` via `supportFile` in
  * `cypress.config.ts`.
  *
- * Suppresses the two centered modals (feedback-modal on the dashboard, the
- * agentic-results launch modal on the landing page) so their backdrops don't
- * sit on top of the UI under test. Specs that want to exercise the
+ * Suppresses the centered feedback-modal on the dashboard so its backdrop
+ * doesn't sit on top of the UI under test. Specs that want to exercise the
  * feedback-modal flow can clear `inferencex-feedback-modal-snoozed` in their
- * own `onBeforeLoad`, which runs after this hook; specs that exercise the
- * launch modal call `keepLaunchModal()` instead — see below.
+ * own `onBeforeLoad`, which runs after this hook.
  */
 import 'cypress-axe';
 
-let suppressLaunchModal = true;
 let suppressTelemetryTutorial = true;
 let suppressAgenticCoachMark = true;
 
 /**
- * Opt the whole spec out of the launch-modal suppression.
+ * Opt the whole spec out of the telemetry-tutorial suppression.
  *
  * Clearing the key in a visit's `onBeforeLoad` is not enough: this hook also
  * fires on `cy.reload()`, which takes no `onBeforeLoad`, so the key would be
  * re-seeded behind the test and a "still dismissed after reload" assertion
  * would pass even if dismissal never persisted anything. Call this at the top
- * of any spec that owns launch-modal state.
- */
-export function keepLaunchModal(): void {
-  suppressLaunchModal = false;
-}
-
-/**
- * Opt the whole spec out of the telemetry-tutorial suppression, for the same
- * reason as `keepLaunchModal` — the card is seeded on `cy.reload()` too, so a
- * per-visit `onBeforeLoad` clear cannot own its state.
+ * of any spec that owns telemetry-tutorial state.
  *
  * The card is a bottom-right modal on /inference/agentic/[id]. It has no
  * backdrop, but it sits over the last chart in the grid, so agentic specs
@@ -43,8 +31,8 @@ export function keepTelemetryTutorial(): void {
 
 /**
  * Opt the whole spec out of the agentic point coach-mark suppression, for the
- * same reason as `keepLaunchModal` — the key is re-seeded on `cy.reload()`, so
- * a per-visit `onBeforeLoad` clear cannot own its state.
+ * same reason as `keepTelemetryTutorial` — the key is re-seeded on
+ * `cy.reload()`, so a per-visit `onBeforeLoad` clear cannot own its state.
  *
  * The callout is anchored to a point inside `[data-testid="scatter-graph"]`,
  * so on the agentic view it sits over the plot area that other specs click.
@@ -56,9 +44,6 @@ export function keepAgenticCoachMark(): void {
 Cypress.on('window:before:load', (win) => {
   try {
     win.localStorage.setItem('inferencex-feedback-modal-snoozed', String(Date.now()));
-    if (suppressLaunchModal) {
-      win.localStorage.setItem('inferencex-agentic-results-modal-dismissed', '1');
-    }
     if (suppressTelemetryTutorial) {
       win.localStorage.setItem('inferencex-agentx-telemetry-tutorial-dismissed', '1');
     }

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -71,7 +71,6 @@ describe('NUDGE_REGISTRY integrity', () => {
     const ids = NUDGE_REGISTRY.map((n) => n.id).toSorted();
     expect(ids).toEqual([
       'agentic-point-detail',
-      'agentic-results-launch-modal',
       'agentx-telemetry-tutorial',
       'eval-samples',
       'export',
@@ -83,14 +82,6 @@ describe('NUDGE_REGISTRY integrity', () => {
       'reproducibility',
       'star-nudge',
     ]);
-  });
-
-  it('renders the agentic launch modal centered, with the dismissed key e2e suppresses', () => {
-    const launch = NUDGE_REGISTRY.find((n) => n.id === 'agentic-results-launch-modal');
-    expect(launch?.content.centered).toBe(true);
-    // cypress/support/e2e.ts seeds this key so the backdrop can't cover the
-    // UI under test; a rename here has to be mirrored there.
-    expect(launch?.storageKey).toBe('inferencex-agentic-results-modal-dismissed');
   });
 
   it('renders the telemetry tutorial as an uncentered card on the agentic detail scope', () => {
@@ -112,11 +103,6 @@ describe('NUDGE_REGISTRY integrity', () => {
     if (reproducibility?.type !== 'toast') throw new Error('Missing reproducibility toast');
     reproducibility.content.action?.onClick();
     expect(location.href).toBe('/zh/about#reproducibility');
-
-    const launch = NUDGE_REGISTRY.find((nudge) => nudge.id === 'agentic-results-launch-modal');
-    if (launch?.type !== 'modal') throw new Error('Missing launch modal');
-    launch.content.primaryAction?.onClick();
-    expect(location.href).toBe('/zh/inference?i_seq=agentic-traces');
 
     const banner = NUDGE_REGISTRY.find((nudge) => nudge.id === 'openai-rubin-comparison-banner');
     if (banner?.type !== 'banner') throw new Error('Missing launch banner');

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -356,50 +356,6 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
   // Landing modals
   // -------------------------------------------------------------------------
   {
-    id: 'agentic-results-launch-modal',
-    type: 'modal',
-    trigger: { type: 'immediate' },
-    dismissal: { type: 'permanent' },
-    storageKey: 'inferencex-agentic-results-modal-dismissed',
-    priority: 50,
-    scope: 'landing',
-    content: {
-      icon: Sparkles,
-      iconClassName: 'text-brand',
-      title: 'Real-world agentic inference benchmark results are live',
-      titleZh: '真实场景智能体推理基准测试结果已上线',
-      description:
-        'Compare AgentX results for Kimi K3, DeepSeek-V4-Pro-0813, MiniMax-M3, Qwen3.5 397B, and GLM-5.3 across supported chips and serving stacks.',
-      descriptionZh:
-        '查看 Kimi K3、DeepSeek-V4-Pro-0813、MiniMax-M3、Qwen3.5 397B 与 GLM-5.3 在支持芯片和推理服务栈上的 AgentX 结果。',
-      // Both buckets carry two releases on one architecture (GLM-5.2/5.3, the
-      // V4-Pro April preview and the 0813 GA); name the newer one, as the
-      // model selector does for GLM.
-      testId: 'launch-modal',
-      containerClassName: 'border-brand/40',
-      // Launch announcement — centered with a backdrop so it reads as the
-      // page's headline moment instead of a bottom-right corner card.
-      centered: true,
-      badge: 'New',
-      badgeZh: '最新',
-      dismissLabel: 'Maybe Later',
-      dismissLabelZh: '稍后再看',
-      primaryAction: {
-        label: 'View results',
-        labelZh: '查看结果',
-        icon: <ArrowRight className="size-4" />,
-        onClick: () => {
-          window.location.href = localizedNudgeHref('/inference?i_seq=agentic-traces');
-        },
-      },
-    },
-    analytics: {
-      shown: 'agentic_results_modal_shown',
-      dismissed: 'agentic_results_modal_dismissed',
-      action: 'agentic_results_modal_viewed',
-    },
-  },
-  {
     id: 'github-star-modal',
     type: 'modal',
     trigger: { type: 'immediate' },


### PR DESCRIPTION
## Why

The landing page already gives AgentX maximal prominence — the hero deep-links into AgentX results, the nav carries the AgentX **NEW** badge, and the launch banner sits above the fold. The centered "Real-world agentic inference benchmark results are live" modal is now redundant: it just adds a backdrop + dismissal step before visitors can touch the page.

## What changed

- **`lib/nudges/registry.tsx`** — removed the `agentic-results-launch-modal` entry (EN + ZH strings, analytics events, storage key).
- **`lib/nudges/registry.test.ts`** — dropped it from the migrated-ID list, removed its centered/storage-key test, and trimmed the zh-route action assertions.
- **`cypress/support/e2e.ts`** — removed the `suppressLaunchModal` flag, `keepLaunchModal()` export, and the global seeding of `inferencex-agentic-results-modal-dismissed`.
- **`cypress/e2e/nudge-system.cy.ts`** — landing specs now assert the banner + star modal directly; `clearBannerNudgeStorage` (which existed only to keep the modal's backdrop off the banner) is gone; NEW-badge count drops 3 → 2 (banner + AgentX nav).
- **`cypress/e2e/navigation.cy.ts`** — first-load specs no longer dismiss the modal before clicking through the page.
- **`cypress/e2e/landing-performance.cy.ts`** — removed the stale storage-key clear.

No user-facing surface other than the modal is affected; the nudge engine's generic modal rendering is untouched (the GitHub star modal still uses it).

## Checks

- `vitest` nudge suites: 77/77 pass
- `oxlint`, `oxfmt`, `tsc --noEmit`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes one marketing nudge and test harness only; no auth, data, or shared nudge-engine rendering changes beyond deleting a registry entry.
> 
> **Overview**
> Removes the centered **agentic-results-launch-modal** from the nudge registry so first-time visitors no longer get a full-screen backdrop before using the landing page. The Rubin comparison **launch banner**, AgentX hero, and GitHub star modal behavior are unchanged aside from priority: the star modal is now the main landing overlay when storage is fresh.
> 
> **Tests:** Registry/unit expectations drop the modal id, storage key, and zh-route action checks. Cypress no longer seeds `inferencex-agentic-results-modal-dismissed` or exports `keepLaunchModal()`; nudge and navigation specs assert the banner and star modal directly and skip modal dismiss steps. Landing NEW-badge count in E2E is **2** (banner + nav), not **3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69dd1769bf937825630a3f4a7a07f6a80f8dd849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->