### PR TITLE
feat(ui): add NEW badges to AgentX models on landing ledger and /inference selector / 在首页模型列表与 /inference 选择器为 AgentX 模型添加 NEW 徽章

### DIFF
--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -49,6 +49,21 @@ describe('Dropdown one-click switching', () => {
     cy.get('[data-slot="select-content"]').should('not.exist');
   });
 
+  it('marks the featured AgentX models with a NEW pill in the dropdown', () => {
+    cy.get('[data-testid="model-selector"]').click();
+
+    // A featured AgentX model carries the pill… (MiniMax M3 rather than the
+    // Kimi K3 default because the availability fixtures don't ship kimik3 rows)
+    cy.contains('[role="option"]', 'MiniMax M3 428B')
+      .find('[data-new-badge="model-option"]')
+      .should('be.visible')
+      .and('have.text', 'NEW');
+    // …while non-featured models render without one.
+    cy.contains('[role="option"]', 'DeepSeek R1 0528 671B')
+      .find('[data-new-badge="model-option"]')
+      .should('not.exist');
+  });
+
   it('separates maintenance-mode models from deprecated models', () => {
     cy.get('[data-testid="model-selector"]').click();
 

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -114,6 +114,10 @@ describe('First-load navigation', () => {
           'qwen-3-8-flash-next',
         ]);
       });
+      // Every featured ledger row carries the NEW pill.
+      cy.get('[data-testid^="compare-agentx-model-"] [data-new-badge="agentx-ledger"]')
+        .should('have.length', 6)
+        .each(($badge) => expect($badge.text()).to.equal('NEW'));
     });
     cy.get('[data-testid="compare-agentx-overview-link"]').click();
     cy.location('pathname').should('eq', '/overview');

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -54,8 +54,10 @@ describe('Landing nudges — modals', () => {
         'Compare Jalapeño (Teacup) with Vera Rubin (July) NVL72 on DeepSeek R1 at 8K / 1K.',
       )
       .and('contain.text', 'View results');
+    // Banner + header-nav badges, plus the six AgentX hero ledger rows — the
+    // shared pill must render at the same fixed size everywhere it appears.
     cy.get('[data-new-badge]')
-      .should('have.length', 2)
+      .should('have.length', 8)
       .then(($badges) => {
         const sizes = [...$badges].map((badge) => {
           const rect = badge.getBoundingClientRect();

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -36,6 +36,10 @@ describe('Chinese (/zh) pages', () => {
           .should('contain.text', '总览')
           .and('have.attr', 'href', '/zh/overview');
         cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
+        // Ledger NEW pills localize to 新 on the Chinese landing page.
+        cy.get('[data-testid^="compare-agentx-model-"] [data-new-badge="agentx-ledger"]')
+          .should('have.length', 6)
+          .each(($badge) => expect($badge.text()).to.equal('新'));
       });
     });
 

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -2,6 +2,7 @@ import { ArrowRight } from 'lucide-react';
 
 import { Card } from '@/components/ui/card';
 import { MinecraftSplash } from '@/components/minecraft/minecraft-splash';
+import { NewBadge } from '@/components/ui/new-badge';
 import { agentxDashboardHref, FEATURED_AGENTX_MODELS } from '@/lib/compare-agentx';
 
 import { CompareIndexTrackedLink } from './compare-index-tracked-link';
@@ -33,6 +34,7 @@ const STRINGS = {
     dashboard: 'Full dashboard',
     ledgerTitle: 'Models with AgentX results',
     modelAction: 'View results',
+    newModel: 'NEW',
   },
   zh: {
     eyebrow: 'AgentX｜最新结果',
@@ -43,6 +45,7 @@ const STRINGS = {
     dashboard: '查看完整仪表板',
     ledgerTitle: '已发布 AgentX 结果的模型',
     modelAction: '查看结果',
+    newModel: '新',
   },
 } as const;
 
@@ -139,8 +142,9 @@ export function AgentXCompareHero({
                       />
                     )}
                     <span className="min-w-0">
-                      <span className="block text-sm font-semibold leading-tight text-foreground group-hover:text-brand">
-                        {model.label}
+                      <span className="flex items-center gap-1.5 text-sm font-semibold leading-tight text-foreground group-hover:text-brand">
+                        <span className="min-w-0">{model.label}</span>
+                        <NewBadge data-new-badge="agentx-ledger">{t.newModel}</NewBadge>
                       </span>
                       <span className="mt-1 block font-mono text-[10px] tracking-[0.14em] text-brand uppercase">
                         AgentX

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { track } from '@/lib/analytics';
 import { replaceRouterPathname } from '@/lib/client-navigation';
+import { AGENTX_NEW_MODEL_DISPLAY_NAMES } from '@/lib/compare-agentx';
 import { inferenceModelRouteForSelection } from '@/lib/inference-model-slug';
 import { useFeatureGate } from '@/lib/use-feature-gate';
 
@@ -305,6 +306,7 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
             availableModels={availableModels}
             data-testid="model-selector"
             trailing={<ModelArchitectureInfoLink model={selectedModel} locale={locale} />}
+            newModels={AGENTX_NEW_MODEL_DISPLAY_NAMES}
           />
           <ScenarioSelector
             value={selectedSequence}

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -7,6 +7,7 @@ import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { track } from '@/lib/analytics';
 import { ModelLogo } from '@/components/ui/model-logo';
 import { MultiSelect } from '@/components/ui/multi-select';
+import { NewBadge } from '@/components/ui/new-badge';
 import {
   Select,
   SelectContent,
@@ -38,6 +39,7 @@ const STRINGS = {
   en: {
     model: 'Model',
     modelTooltip: 'The language model being benchmarked.',
+    newModel: 'NEW',
     islOsl: 'ISL / OSL',
     islOslTooltip:
       'Input Sequence Length / Output Sequence Length. Defines the number of input and output tokens for the benchmark (e.g., 1K/8K means 1,024 input tokens and 8,192 output tokens).',
@@ -64,6 +66,7 @@ const STRINGS = {
   zh: {
     model: '模型',
     modelTooltip: '正在进行基准测试的语言模型。',
+    newModel: '新',
     islOsl: 'ISL / OSL',
     islOslTooltip:
       '输入序列长度 / 输出序列长度（Input Sequence Length / Output Sequence Length）。定义基准测试的输入和输出 token 数量（如 1K/8K 表示 1,024 个输入 token 和 8,192 个输出 token）。',
@@ -158,10 +161,11 @@ function AgenticScenarioInfo({
 // Full-color creator logo beside each model name, in the dropdown rows and
 // the closed trigger alike. `ModelLogo` renders nothing for models without
 // a configured logo, so rows degrade to plain text instead of breaking.
-const toOption = (model: string) => ({
+const toOption = (model: string, badge?: ReactNode) => ({
   value: model,
   label: getModelLabel(model as Model),
   icon: <ModelLogo model={model as Model} />,
+  badge,
 });
 
 interface ModelSelectorProps {
@@ -178,6 +182,12 @@ interface ModelSelectorProps {
    * model-architecture deep-dive link on the inference dashboard.
    */
   trailing?: ReactNode;
+  /**
+   * Models whose dropdown rows carry a NEW pill (localized). The inference
+   * dashboard passes the featured AgentX set; surfaces that don't highlight
+   * new models simply omit the prop.
+   */
+  newModels?: ReadonlySet<string>;
 }
 
 export function ModelSelector({
@@ -189,20 +199,28 @@ export function ModelSelector({
   availableModels,
   'data-testid': testId,
   trailing,
+  newModels,
 }: ModelSelectorProps) {
   const t = STRINGS[useLocale()];
   const groups = groupByCategory(availableModels, (m) => getModelCategory(m as Model));
+  const optionFor = (model: string) =>
+    toOption(
+      model,
+      newModels?.has(model) ? (
+        <NewBadge data-new-badge="model-option">{t.newModel}</NewBadge>
+      ) : undefined,
+    );
   const sections = [
     {
       id: 'default',
-      options: groups.default.map(toOption),
+      options: groups.default.map(optionFor),
     },
     ...(groups.experimental.length > 0
       ? [
           {
             id: 'experimental',
             header: t.experimentalSupport,
-            options: groups.experimental.map(toOption),
+            options: groups.experimental.map(optionFor),
           },
         ]
       : []),
@@ -217,7 +235,7 @@ export function ModelSelector({
                 reason={t.maintenanceReason}
               />
             ),
-            options: groups.maintenance.map(toOption),
+            options: groups.maintenance.map(optionFor),
           },
         ]
       : []),
@@ -232,7 +250,7 @@ export function ModelSelector({
                 reason={t.deprecatedModelReason}
               />
             ),
-            options: groups.deprecated.map(toOption),
+            options: groups.deprecated.map(optionFor),
           },
         ]
       : []),

--- a/packages/app/src/components/ui/multi-select.tsx
+++ b/packages/app/src/components/ui/multi-select.tsx
@@ -37,6 +37,8 @@ interface MultiSelectOption {
   label: string;
   /** Optional leading visual (e.g. a brand logo) rendered before the label. */
   icon?: React.ReactNode;
+  /** Optional trailing visual (e.g. a NEW pill) rendered after the label. */
+  badge?: React.ReactNode;
 }
 
 export interface MultiSelectSection {
@@ -460,9 +462,10 @@ function MultiSelect({
                             <span className="absolute right-2 flex size-3.5 items-center justify-center">
                               {isSelected && <CheckIcon className="size-4 text-primary" />}
                             </span>
-                            <span className="flex items-center gap-2">
+                            <span className="flex min-w-0 items-center gap-2">
                               {option.icon}
                               {option.label}
+                              {option.badge}
                             </span>
                           </div>
                         );
@@ -492,9 +495,10 @@ function MultiSelect({
                       <span className="absolute right-2 flex size-3.5 items-center justify-center">
                         {isSelected && <CheckIcon className="size-4 text-primary" />}
                       </span>
-                      <span className="flex items-center gap-2">
+                      <span className="flex min-w-0 items-center gap-2">
                         {option.icon}
                         {option.label}
+                        {option.badge}
                       </span>
                     </div>
                   );

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   agentxDashboardHref,
+  AGENTX_NEW_MODEL_DISPLAY_NAMES,
   comparisonPairHref,
   comparisonScenarioForModel,
   FEATURED_AGENTX_MODELS,
@@ -18,6 +19,19 @@ describe('AgentX comparison links', () => {
       'qwen-3-5',
       'qwen-3-8-flash-next',
     ]);
+  });
+
+  it('marks exactly the featured models as NEW for the dashboard selector', () => {
+    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES).toEqual(
+      new Set([
+        'Kimi-K3',
+        'DeepSeek-V4-Pro',
+        'GLM-5.2',
+        'MiniMax-M3',
+        'Qwen-3.5-397B-A17B',
+        'Qwen3.8-Flash-Next',
+      ]),
+    );
   });
 
   it('opens the bare model subroute — Agentic + Optimal Only are already the defaults', () => {

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -27,6 +27,16 @@ export const FEATURED_AGENTX_MODELS: readonly CompareModelSlug[] = FEATURED_AGEN
   },
 );
 
+/**
+ * `Model` enum values (the dashboard's model identifiers) for the featured
+ * AgentX set. The landing/compare hero ledger and the /inference model
+ * selector both mark these models with a NEW badge, so the badge follows the
+ * single featured list instead of maintaining a second one.
+ */
+export const AGENTX_NEW_MODEL_DISPLAY_NAMES: ReadonlySet<string> = new Set(
+  FEATURED_AGENTX_MODELS.map((model) => model.displayName),
+);
+
 export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug): string {
   // The model rides in the path — the indexable `/inference/<model>` subroute
   // — so these hero links point crawlers at the canonical model page instead


### PR DESCRIPTION
Adds the shared `NewBadge` pill beside the featured AgentX models in the two places they're listed:

- **Landing page / `/compare` AgentX hero ledger** — every featured model row (Kimi K3 2.8T, DeepSeekv4 Pro 0813 1.6T, GLM 5.3 744B, MiniMax M3 428B, Qwen 3.5 397B-A17B, Qwen 3.8 Flash Next 176B-A6B) now shows a NEW pill next to its name.
- **`/inference` model selector** — the dropdown rows for the same six AgentX models carry the NEW pill; non-featured (maintenance/deprecated) models render unchanged.

### Implementation

- New export `AGENTX_NEW_MODEL_DISPLAY_NAMES` in `lib/compare-agentx.ts`, derived from `FEATURED_AGENTX_MODELS`, so both surfaces follow the single featured list and cannot drift.
- `MultiSelectOption` gains an optional `badge?: ReactNode` trailing slot, rendered after the label in both sectioned and flat option rows.
- `ModelSelector` accepts an optional `newModels?: ReadonlySet<string>` prop; only the inference dashboard passes it, so the evaluation/calculator selectors are unaffected.
- Badge text is localized: `NEW` on English surfaces, `新` on `/zh` — matching the existing header-nav AgentX badge dictionary (`{ en: 'NEW', zh: '新' }`).

### Tests

- `compare-agentx.test.ts`: asserts the NEW set contains exactly the six featured model display names.
- `navigation.cy.ts`: landing hero ledger shows 6 NEW pills.
- `zh-pages.cy.ts`: Chinese landing ledger pills read `新`.
- `dropdown-switching.cy.ts`: `/inference` dropdown shows the pill on a featured AgentX model and not on a maintenance-mode model.

Overlay support: N/A — this is selector/ledger chrome only; it does not touch chart data paths, so official runs and `?unofficialrun=` overlays are unaffected.

Chinese copy note (advisory, per review-zh-copy): the only added user-visible Chinese string is the badge label `新`, reusing the established header-nav badge wording; no prose was added or changed.

## 中文说明

在两个列出精选 AgentX 模型的位置添加共享的 `NewBadge` 徽章：

- **首页 / `/compare` 的 AgentX 模型列表** — 每个精选模型行（Kimi K3 2.8T、DeepSeekv4 Pro 0813 1.6T、GLM 5.3 744B、MiniMax M3 428B、Qwen 3.5 397B-A17B、Qwen 3.8 Flash Next 176B-A6B）的名称旁现在都会显示 NEW 徽章。
- **`/inference` 模型选择器** — 下拉菜单中这六个 AgentX 模型的选项行同样显示 NEW 徽章；非精选（维护模式/已弃用）模型保持不变。

### 实现方式

- 在 `lib/compare-agentx.ts` 中新增导出 `AGENTX_NEW_MODEL_DISPLAY_NAMES`，由 `FEATURED_AGENTX_MODELS` 派生，两个界面共用同一份精选列表，避免不同步。
- `MultiSelectOption` 新增可选的 `badge?: ReactNode` 尾部插槽，在分组和平铺两种选项渲染路径中都在标签后渲染。
- `ModelSelector` 新增可选的 `newModels?: ReadonlySet<string>` 属性；仅推理仪表板传入该属性，评估/计算器页面的选择器不受影响。
- 徽章文案已本地化：英文界面为 `NEW`，`/zh` 界面为「新」，与页头导航现有的 AgentX 徽章词典（`{ en: 'NEW', zh: '新' }`）保持一致。

### 测试

- `compare-agentx.test.ts`：断言 NEW 集合恰好包含六个精选模型的 display name。
- `navigation.cy.ts`：首页模型列表显示 6 个 NEW 徽章。
- `zh-pages.cy.ts`：中文首页列表徽章显示「新」。
- `dropdown-switching.cy.ts`：`/inference` 下拉菜单中精选 AgentX 模型显示徽章，维护模式模型不显示。

Overlay 支持：不适用 — 本次改动仅涉及选择器/列表的界面元素，不触及图表数据路径，官方运行与 `?unofficialrun=` 叠加数据均不受影响。

中文文案说明（advisory，遵循 review-zh-copy）：新增的用户可见中文字符串仅有徽章文案「新」，沿用页头导航徽章的既有措辞，未新增或修改任何中文段落。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only labeling on model lists and selectors; no auth, data, or chart pipeline changes.
> 
> **Overview**
> Featured AgentX models now show the shared **`NewBadge`** pill in two list surfaces: the landing/`/compare` **AgentX hero ledger** (all six `FEATURED_AGENTX_MODELS` rows) and the **`/inference` model dropdown** (only when `ChartControls` passes the featured set).
> 
> A single source of truth drives both: **`AGENTX_NEW_MODEL_DISPLAY_NAMES`** is derived from `FEATURED_AGENTX_MODELS` display names in `compare-agentx.ts`. **`ModelSelector`** accepts optional `newModels` and attaches localized pills (`NEW` / `新`) via **`MultiSelectOption.badge`**, which **`MultiSelect`** renders after each option label. Evaluation/calculator selectors omit `newModels`, so they stay unchanged.
> 
> Cypress and unit tests were extended to assert pill presence, localization on `/zh`, consistent pill sizing with existing nav/banner badges (8 total on landing), and that non-featured dropdown rows have no badge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d96924dbfd31de872c22de8d09249c4b48d5486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->