### PR TITLE
fix(overview): bump derived cache key so AgentX-first order serves immediately

### DIFF
--- a/packages/app/src/lib/overview-data.server.ts
+++ b/packages/app/src/lib/overview-data.server.ts
@@ -134,7 +134,10 @@ async function buildOverviewPageData(
   );
 }
 
-const getCachedOverviewPageData = cachedDerivedData(buildOverviewPageData, 'overview-page-v1');
+// v2: AgentX rows group above 8K/1K rows (#918). The assembled models array is
+// stored in the derived cache, so the display-order change needs a new key —
+// v1 entries keep serving the old order until they expire otherwise.
+const getCachedOverviewPageData = cachedDerivedData(buildOverviewPageData, 'overview-page-v2');
 
 export function getOverviewPageData(
   tier: OverviewTier = OVERVIEW_PRIMARY_TIER,


### PR DESCRIPTION
Follow-up to #918. The assembled `OverviewPageData` — including the models array order — is stored in the derived blob cache under `overview-page-v1`, and those entries survive deploys, so production kept serving the old single-turn-first row order after #918 shipped.

Bump the key to `overview-page-v2`, matching the existing `run-page-data-v2` / `ranking-page-data-v2` convention. Orphaned v1 entries get dropped by the next ordinary prefix purge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single cache-key string change with no logic changes; only affects when cached overview payloads are reused versus rebuilt.
> 
> **Overview**
> **Invalidates stale overview derived cache** so production picks up the AgentX-above-8K/1K row order from #918 right after deploy.
> 
> The overview page’s assembled data (including `models` order) is cached under a versioned key; this PR renames that key from `overview-page-v1` to `overview-page-v2`, aligned with `run-page-data-v2` / `ranking-page-data-v2`. Old v1 blobs are left to age out via the normal prefix purge rather than being read anymore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2c847aae28f82491a15944c26e4fa803cd7f1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->