### PR TITLE
fix(landing): remove duplicate GitHub star card overlaying the footer / 移除悬浮在页脚上的重复 GitHub 加星卡片

### DIFF
--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -110,39 +110,16 @@ describe('Landing nudges — modals', () => {
       .and('contain.text', '查看结果');
   });
 
-  it('shows the star modal on the landing page', () => {
+  it('does not float a duplicate GitHub star card over the footer', () => {
+    // The persistent star CTA lives in the footer grid (footer-star-cta) and
+    // the header; the old immediate star modal duplicated it and covered the
+    // footer, so it must stay gone.
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
     });
-    cy.get('[data-testid="github-star-modal"]').should('be.visible');
-  });
-
-  it('star modal dismiss uses timed strategy — re-shows after expiry', () => {
-    cy.visit('/', {
-      onBeforeLoad: clearAllNudgeStorage,
-    });
-    cy.get('[data-testid="github-star-modal"]').should('be.visible');
-    cy.get('[data-testid="github-star-modal-dismiss"]').click();
+    cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.get('[data-testid="github-star-modal"]').should('not.exist');
-
-    cy.window().then((win) => {
-      const value = win.localStorage.getItem('inferencex-star-modal-dismissed');
-      expect(value).to.not.equal(null);
-      expect(Number(value)).to.be.greaterThan(0);
-    });
-  });
-
-  it('starring permanently suppresses both star modal and star nudge', () => {
-    cy.visit('/', {
-      onBeforeLoad: clearAllNudgeStorage,
-    });
-    cy.get('[data-testid="github-star-modal"]').should('be.visible');
-    cy.get('[data-testid="github-star-modal-action"]').click();
-    cy.get('[data-testid="github-star-modal"]').should('not.exist');
-
-    cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-starred')).to.eq('1');
-    });
+    cy.get('[data-testid="footer-star-cta"]').should('exist');
   });
 });
 

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -61,9 +61,7 @@ describe('Chinese (/zh) pages', () => {
         'href',
         '/zh/land-acknowledgement',
       );
-      cy.get('[data-testid="footer-link-zh"]')
-        .should('contain.text', 'English')
-        .and('have.attr', 'href', '/');
+      cy.get('[data-testid="footer-link-zh"]').should('not.exist');
     });
   });
 

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -118,7 +118,10 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
           </div>
 
           {/* Center — Links */}
-          <div data-testid="footer-links" className="grid grid-cols-3 gap-x-6 gap-y-8">
+          <div
+            data-testid="footer-links"
+            className="grid grid-cols-3 gap-x-6 gap-y-8 break-words min-w-0"
+          >
             <div data-testid="footer-links-semianalysis" className="flex flex-col gap-2.5">
               <span className="text-sm font-medium text-foreground">{t.semianalysis}</span>
               <a

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -38,9 +38,6 @@ const STRINGS = {
     chipSpecs: 'Chip Specs & Pricing',
     rankings: 'GPU Rankings',
     runPages: 'Model on GPU Results',
-    languageLink: '中文版',
-    languageHref: '/zh',
-    languageHrefLang: 'zh-CN',
     cta: 'If this data helps your work, consider starring us on GitHub or sharing with your network.',
     rights: 'All rights reserved.',
   },
@@ -72,9 +69,6 @@ const STRINGS = {
     chipSpecs: '芯片规格与价格',
     rankings: 'GPU 排行榜',
     runPages: '模型在 GPU 上的实测结果',
-    languageLink: 'English',
-    languageHref: '/',
-    languageHrefLang: 'en',
     cta: '如果这些数据对您的工作有帮助，欢迎在 GitHub 上点个 Star，或分享给同事。',
     rights: '版权所有。',
   },
@@ -308,14 +302,6 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                   className="text-sm text-muted-foreground hover:text-foreground transition-colors"
                 >
                   {t.runPages}
-                </Link>
-                <Link
-                  data-testid="footer-link-zh"
-                  href={t.languageHref}
-                  hrefLang={t.languageHrefLang}
-                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  {t.languageLink}
                 </Link>
               </div>
             </div>

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -120,7 +120,7 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
           {/* Center — Links */}
           <div
             data-testid="footer-links"
-            className="grid grid-cols-3 gap-x-6 gap-y-8 break-words min-w-0"
+            className="grid grid-cols-2 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)_minmax(0,1fr)_minmax(0,2fr)] gap-x-6 gap-y-8 break-words hyphens-auto min-w-0"
           >
             <div data-testid="footer-links-semianalysis" className="flex flex-col gap-2.5">
               <span className="text-sm font-medium text-foreground">{t.semianalysis}</span>
@@ -210,106 +210,114 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                 {t.visualization}
               </a>
             </div>
-            <div data-testid="footer-links-more" className="flex flex-col gap-2.5">
+            {/* "More" holds many links, so it gets a double-width column with
+                the links flowing in two sub-columns. This keeps every group on
+                one balanced row instead of wrapping below the others. */}
+            <div
+              data-testid="footer-links-more"
+              className="col-span-2 xl:col-span-1 flex flex-col gap-2.5"
+            >
               <span className="text-sm font-medium text-foreground">{t.more}</span>
-              <Link
-                data-testid="footer-link-supporters"
-                href={`${prefix}/quotes`}
-                onClick={() => track('footer_supporters_clicked')}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.supporters}
-              </Link>
-              <Link
-                data-testid="footer-link-agentx"
-                href={`${prefix}/agentx`}
-                onClick={() => track('footer_agentx_clicked')}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.agentx}
-              </Link>
-              <Link
-                data-testid="footer-link-telemetry"
-                href={`${prefix}/inference/agentic`}
-                onClick={() => track('footer_telemetry_clicked')}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.telemetry}
-              </Link>
-              <Link
-                data-testid="footer-link-articles"
-                href={`${prefix}/blog`}
-                onClick={() => track('footer_articles_clicked')}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.articles}
-              </Link>
-              <Link
-                data-testid="footer-link-api"
-                href={`${prefix}/api`}
-                onClick={() => track('footer_api_clicked')}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.apiReference}
-              </Link>
-              <Link
-                data-testid="footer-link-reliability"
-                href={`${prefix}/reliability`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.gpuReliability}
-              </Link>
-              <Link
-                data-testid="footer-link-compare-per-dollar"
-                href={`${prefix}/compare-per-dollar`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.perfPerDollar}
-              </Link>
-              <Link
-                data-testid="footer-link-model-architectures"
-                // English-only route (not zh-mirrored), so no locale prefix.
-                href="/model"
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.modelArchitectures}
-              </Link>
-              <Link
-                data-testid="footer-link-glossary"
-                href={`${prefix}/glossary`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.glossary}
-              </Link>
-              <Link
-                data-testid="footer-link-chips"
-                href={`${prefix}/chips`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.chipSpecs}
-              </Link>
-              <Link
-                data-testid="footer-link-rankings"
-                href={`${prefix}/rankings`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.rankings}
-              </Link>
-              <Link
-                data-testid="footer-link-run"
-                href={`${prefix}/run`}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.runPages}
-              </Link>
-              <Link
-                data-testid="footer-link-zh"
-                href={t.languageHref}
-                hrefLang={t.languageHrefLang}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                {t.languageLink}
-              </Link>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-2.5">
+                <Link
+                  data-testid="footer-link-supporters"
+                  href={`${prefix}/quotes`}
+                  onClick={() => track('footer_supporters_clicked')}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.supporters}
+                </Link>
+                <Link
+                  data-testid="footer-link-agentx"
+                  href={`${prefix}/agentx`}
+                  onClick={() => track('footer_agentx_clicked')}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.agentx}
+                </Link>
+                <Link
+                  data-testid="footer-link-telemetry"
+                  href={`${prefix}/inference/agentic`}
+                  onClick={() => track('footer_telemetry_clicked')}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.telemetry}
+                </Link>
+                <Link
+                  data-testid="footer-link-articles"
+                  href={`${prefix}/blog`}
+                  onClick={() => track('footer_articles_clicked')}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.articles}
+                </Link>
+                <Link
+                  data-testid="footer-link-api"
+                  href={`${prefix}/api`}
+                  onClick={() => track('footer_api_clicked')}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.apiReference}
+                </Link>
+                <Link
+                  data-testid="footer-link-reliability"
+                  href={`${prefix}/reliability`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.gpuReliability}
+                </Link>
+                <Link
+                  data-testid="footer-link-compare-per-dollar"
+                  href={`${prefix}/compare-per-dollar`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.perfPerDollar}
+                </Link>
+                <Link
+                  data-testid="footer-link-model-architectures"
+                  // English-only route (not zh-mirrored), so no locale prefix.
+                  href="/model"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.modelArchitectures}
+                </Link>
+                <Link
+                  data-testid="footer-link-glossary"
+                  href={`${prefix}/glossary`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.glossary}
+                </Link>
+                <Link
+                  data-testid="footer-link-chips"
+                  href={`${prefix}/chips`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.chipSpecs}
+                </Link>
+                <Link
+                  data-testid="footer-link-rankings"
+                  href={`${prefix}/rankings`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.rankings}
+                </Link>
+                <Link
+                  data-testid="footer-link-run"
+                  href={`${prefix}/run`}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.runPages}
+                </Link>
+                <Link
+                  data-testid="footer-link-zh"
+                  href={t.languageHref}
+                  hrefLang={t.languageHrefLang}
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t.languageLink}
+                </Link>
+              </div>
             </div>
           </div>
 

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -76,7 +76,6 @@ describe('NUDGE_REGISTRY integrity', () => {
       'export',
       'feedback-modal',
       'filter-hint',
-      'github-star-modal',
       'gradient-label',
       'openai-rubin-comparison-banner',
       'reproducibility',

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -32,7 +32,7 @@ const FeedbackForm = dynamic(
   { ssr: false },
 );
 import { GitHubIcon } from '@/components/ui/github-icon';
-import { STARRED_EVENT, STARRED_KEY, saveStarred } from '@/lib/star-storage';
+import { STARRED_EVENT, STARRED_KEY } from '@/lib/star-storage';
 import type { NudgeDefinition } from './types';
 
 const GITHUB_REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
@@ -353,50 +353,13 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
   },
 
   // -------------------------------------------------------------------------
-  // Landing modals
-  // -------------------------------------------------------------------------
-  {
-    id: 'github-star-modal',
-    type: 'modal',
-    trigger: { type: 'immediate' },
-    dismissal: { type: 'timed', durationMs: 7 * 24 * 60 * 60 * 1000 },
-    storageKey: 'inferencex-star-modal-dismissed',
-    permanentSuppressKey: STARRED_KEY,
-    permanentSuppressEvent: STARRED_EVENT,
-    priority: 40,
-    scope: 'landing',
-    content: {
-      icon: Star,
-      iconClassName: 'text-yellow-500 fill-yellow-500',
-      title: 'Star InferenceX on GitHub',
-      titleZh: '在 GitHub 上为 InferenceX 加星',
-      description:
-        'Star InferenceX on GitHub to get notified when we publish new benchmark data. We update chip performance comparisons regularly — starring is the easiest way to stay in the loop and help the project grow.',
-      descriptionZh:
-        '在 GitHub 上为 InferenceX 加星，以便在我们发布新基准测试数据时收到通知。我们定期更新芯片性能对比——加星是保持关注并帮助项目成长的最简单方式。',
-      testId: 'github-star-modal',
-      dismissLabel: 'Maybe Later',
-      dismissLabelZh: '稍后再看',
-      primaryAction: {
-        label: 'Star on GitHub',
-        labelZh: '在 GitHub 上加星',
-        icon: <GitHubIcon className="size-4" />,
-        onClick: () => {
-          window.open(GITHUB_REPO_URL, '_blank', 'noopener,noreferrer');
-          saveStarred();
-        },
-      },
-      actionClassName: 'star-button-glow',
-    },
-    analytics: {
-      shown: 'star_modal_shown',
-      dismissed: 'star_modal_dismissed',
-      action: 'star_modal_starred',
-    },
-  },
-
-  // -------------------------------------------------------------------------
   // Landing banner
+  //
+  // Note: the landing scope deliberately has no GitHub star nudge. The footer
+  // grid already carries the persistent star CTA (footer-star-cta) and the
+  // header carries another, so a fixed bottom card here duplicated the control
+  // and covered the footer. The engagement-triggered star-nudge toast on the
+  // dashboard scope is the only overlay star prompt.
   // -------------------------------------------------------------------------
   {
     id: 'openai-rubin-comparison-banner',

--- a/packages/app/src/lib/nudges/types.ts
+++ b/packages/app/src/lib/nudges/types.ts
@@ -189,7 +189,7 @@ export interface NudgeDefinition {
 
   /**
    * A secondary localStorage key that permanently suppresses the nudge.
-   * Example: `inferencex-starred` suppresses both star-nudge and github-star-modal.
+   * Example: `inferencex-starred` suppresses the star-nudge toast.
    */
   permanentSuppressKey?: string;
   /**


### PR DESCRIPTION
## Root cause
The `github-star-modal` nudge (immediate trigger, `landing` scope) rendered as a **fixed bottom-right card** (`fixed bottom-4 right-4 z-50`) on every homepage visit, re-arming 7 days after each dismissal. At the bottom of the page it sat on top of the footer — covering the copyright bar and footer links — while duplicating the GitHub Star control already present in **both** the header (`header-star-button`) and the footer grid (`footer-star-cta`), which carries the identical "consider starring us on GitHub" message. Separately, long footer link labels (e.g. *Land Acknowledgement*) overflowed their grid column and overlapped the *Contribute* column at intermediate widths.

## Decision
Per the existing design system the persistent GitHub CTA **belongs in the footer**, where it is already integrated into the footer grid. The floating card is the accidental duplicate and is removed. The engagement-triggered `star-nudge` toast on the dashboard scope, the header star button, and the footer CTA are all unchanged.

## Changes
- `src/lib/nudges/registry.tsx` — remove the `github-star-modal` entry (+ explanatory note); drop the now-unused `saveStarred` import
- `src/lib/nudges/registry.test.ts` — update expected registry ids
- `src/lib/nudges/types.ts` — update stale doc comment
- `cypress/e2e/nudge-system.cy.ts` — replace the three star-modal specs with a regression guard asserting no floating star card renders on landing while `footer-star-cta` exists
- `src/components/footer/footer.tsx` — `break-words min-w-0` on the footer links grid so long labels wrap inside their column instead of overlapping the next one

## Verification
- Vitest nudge suites: 77/77 pass; `tsc --noEmit` and oxlint clean
- Rendered locally and inspected the homepage bottom at **375 / 768 / 1024 / 1200 / 1440 / 1920 px**: no fixed bottom overlay, no horizontal overflow, no clipped text or column overlap, footer copyright fully visible, exactly two star controls (header + footer)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and nudge-registry changes only; no auth, API, or data-path changes. Residual risk is layout/regression on footer breakpoints and lost footer language link (mitigated by header toggle).
> 
> **Overview**
> Removes the landing-scope **`github-star-modal`** nudge so the homepage no longer shows a fixed bottom-right star card that duplicated the header and **`footer-star-cta`** and obscured the footer. Dashboard **`star-nudge`**, header star, and footer CTA are unchanged; registry tests and nudge type docs are updated accordingly.
> 
> Cypress now asserts no **`github-star-modal`** on `/` while the launch banner and footer star CTA remain, and drops the old modal dismiss/star flows. Chinese footer tests expect **`footer-link-zh`** to be gone (locale switching stays in the header).
> 
> **Footer** drops the in-grid language switcher strings/link, reflows link columns (responsive grid, two-column “More” block, **`break-words` / `min-w-0`**) so long labels wrap instead of overlapping adjacent columns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 786d9fb5063ce8d5045c45d772e3c1722dabbc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->