### PR TITLE
feat(blog): retitle Qwen3.5 SGLang post to MI355X versus GB300 NVL72

### DIFF
--- a/packages/app/content/blog/qwen3-5-397b-agentx-nvidia-vs-amd-sglang.mdx
+++ b/packages/app/content/blog/qwen3-5-397b-agentx-nvidia-vs-amd-sglang.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Qwen3.5 397B on AgentX: A 20x SGLang Gap at 90 tok/s/user'
+title: 'MI355X versus GB300 NVL72 Inference Performance: 20x Gap on Qwen3.5 SGLang'
 subtitle: 'GatedDeltaNet, a 262k native context, and no AMD competition at all on the same engine'
 seoDescription: 'Qwen3.5 397B AgentX results. On SGLang against SGLang, NVIDIA is over 20x better at 90 tok/s/user with zero competition from AMD, and NVIDIA SGLang submissions hold much lower p90 TTFT than TRT-LLM.'
 date: '2026-08-25'

--- a/packages/app/content/blog/zh/qwen3-5-397b-agentx-nvidia-vs-amd-sglang.mdx
+++ b/packages/app/content/blog/zh/qwen3-5-397b-agentx-nvidia-vs-amd-sglang.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Qwen3.5 397B 的 AgentX 结果：90 tok/s/user 下 20 倍的 SGLang 差距'
+title: 'MI355X 对比 GB300 NVL72 推理性能：Qwen3.5 SGLang 上 20 倍差距'
 subtitle: 'GatedDeltaNet、262k 原生上下文，以及同一引擎上 AMD 完全缺席的竞争'
 seoDescription: 'Qwen3.5 397B 的 AgentX 结果。在 SGLang 对 SGLang 的比较中，NVIDIA 在 90 tok/s/user 下领先 20 倍以上，AMD 完全没有竞争力；NVIDIA 的 SGLang 提交在 p90 TTFT 上也远低于 TRT-LLM。'
 date: '2026-08-25'


### PR DESCRIPTION
Retitles /blog/qwen3-5-397b-agentx-nvidia-vs-amd-sglang.

- EN title: `MI355X versus GB300 NVL72 Inference Performance: 20x Gap on Qwen3.5 SGLang`
- ZH title updated to match: `MI355X 对比 GB300 NVL72 推理性能：Qwen3.5 SGLang 上 20 倍差距`

Slug, subtitle, SEO description, and body unchanged. Requested by Oren via Slack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only title edits with no routing, logic, or data changes.
> 
> **Overview**
> Updates only the **frontmatter `title`** on the English and Chinese versions of `qwen3-5-397b-agentx-nvidia-vs-amd-sglang`, reframing the headline around **MI355X vs GB300 NVL72** inference performance instead of a generic “Qwen3.5 397B on AgentX” framing while keeping the **20× SGLang gap** message.
> 
> **Slug, subtitle, `seoDescription`, tags, body, figures, and JSON-LD** are unchanged, so URLs and SEO snippets stay the same aside from whatever the site derives from `title`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0af923b2c5bbdeec3fa9b45788dcd8041327e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->