### PR TITLE
Update AgentX hero description with upcoming platforms

### DIFF
--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -29,7 +29,7 @@ const STRINGS = {
     eyebrow: 'AgentX / live results',
     title: 'Compare Realistic Agentic Inference Perf',
     description:
-      'Long Context Multi Turn Inference Performance. Compare Across OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, etc.',
+      'Long Context Multi Turn Inference Performance. Compare Across OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv7/v8 & Rubin NVL72 & MI455X UALoE72',
     overview: 'Overview',
     dashboard: 'Full dashboard',
     ledgerTitle: 'Models with AgentX results',
@@ -40,7 +40,7 @@ const STRINGS = {
     eyebrow: 'AgentX｜最新结果',
     title: '真实智能体工作负载下的推理性能对比',
     description:
-      '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 OpenAI Jalapeño、MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro 等平台。',
+      '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 OpenAI Jalapeño、MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro，即将支持 TPUv7/v8、Rubin NVL72 与 MI455X UALoE72。',
     overview: '总览',
     dashboard: '查看完整仪表板',
     ledgerTitle: '已发布 AgentX 结果的模型',


### PR DESCRIPTION
Updates the AgentX compare hero subtitle to read:

> Long Context Multi Turn Inference Performance. Compare Across OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv7/v8 & Rubin NVL72 & MI455X UALoE72

Also mirrors the upcoming-platform mention (TPUv7/v8, Rubin NVL72, MI455X UALoE72) in the Chinese description for parity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to localized marketing strings; no logic, routing, or data handling.
> 
> **Overview**
> Updates the **AgentX compare hero** subtitle on `/compare` and the landing page so it no longer ends with a vague “etc.” and instead calls out **upcoming** coverage: **TPUv7/v8**, **Rubin NVL72**, and **MI455X UALoE72**.
> 
> The same “coming soon” platforms are added to the **Chinese** `description` string in `agentx-compare-hero.tsx` so EN/ZH stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6966cd475caa9e7be7c402f1f67f8c9a7e3a3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->