### PR TITLE
feat(landing): add AMD Lisa Su & NVIDIA Jensen to supporters strip, remove TensorWave / 首页支持者栏新增 AMD Lisa Su 与 NVIDIA Jensen，移除 TensorWave

### DIFF
--- a/packages/app/src/components/quotes/quotes-data.test.ts
+++ b/packages/app/src/components/quotes/quotes-data.test.ts
@@ -8,7 +8,13 @@ import { CAROUSEL_LABELS, CAROUSEL_ORGS, QUOTES } from './quotes-data';
  * supporter come off the carousel without being dropped from the site, so it is
  * asserted here rather than left implicit.
  */
-const OFF_CAROUSEL_ONLY = ['Together AI', 'Nebius', 'White House', 'UC San Diego'] as const;
+const OFF_CAROUSEL_ONLY = [
+  'Together AI',
+  'Nebius',
+  'White House',
+  'UC San Diego',
+  'TensorWave',
+] as const;
 
 describe('quote carousel membership', () => {
   it('keeps every carousel org backed by a real quote', () => {
@@ -24,6 +30,13 @@ describe('quote carousel membership', () => {
 
   it('features Mooncake in the landing carousel', () => {
     expect(CAROUSEL_ORGS).toContain('Mooncake');
+  });
+
+  it('features AMD and NVIDIA in the landing carousel under CEO labels', () => {
+    expect(CAROUSEL_ORGS).toContain('AMD');
+    expect(CAROUSEL_ORGS).toContain('NVIDIA');
+    expect(CAROUSEL_LABELS['AMD']).toBe('AMD Lisa Su');
+    expect(CAROUSEL_LABELS['NVIDIA']).toBe('NVIDIA Jensen');
   });
 
   it.each(OFF_CAROUSEL_ONLY)('excludes %s from the carousel', (org) => {

--- a/packages/app/src/components/quotes/quotes-data.ts
+++ b/packages/app/src/components/quotes/quotes-data.ts
@@ -582,6 +582,8 @@ export const CAROUSEL_ORGS = [
   'Alibaba Qwen',
   'Zhipu GLM',
   'OpenAI',
+  'AMD',
+  'NVIDIA',
   'Microsoft',
   'Meta Superintelligence Labs',
   'Oracle',
@@ -589,7 +591,6 @@ export const CAROUSEL_ORGS = [
   'GPU Mode',
   'PyTorch Foundation',
   'CoreWeave',
-  'TensorWave',
   'SGLang',
   'WEKA',
   'Stanford',
@@ -613,4 +614,6 @@ export const CAROUSEL_LABELS: Record<string, string> = {
   'PyTorch Foundation': 'PyTorch',
   'Meta Superintelligence Labs': 'Meta',
   'Moonshot AI': 'Moonshot Kimi',
+  AMD: 'AMD Lisa Su',
+  NVIDIA: 'NVIDIA Jensen',
 };


### PR DESCRIPTION
## Summary
- Add **AMD** and **NVIDIA** to the landing page supporters strip (`CAROUSEL_ORGS`), shown with the display labels **"AMD Lisa Su"** and **"NVIDIA Jensen"** via `CAROUSEL_LABELS`. Both orgs already have quotes from Dr. Lisa Su and Jensen Huang in `QUOTES`, so the strip entries link to their existing quote anchors on `/quotes`.
- Remove **TensorWave** from the landing supporters strip. Its quote remains on the `/quotes` page (added to the `OFF_CAROUSEL_ONLY` test list).
- Unit tests updated: new assertions for AMD/NVIDIA membership + labels, and TensorWave off-carousel coverage.

## Checks
- `bun run lint`, `bun run fmt`, `bun run typecheck` clean
- `quotes-data.test.ts`: 16/16 passing

## 中文说明
- 在首页支持者栏（`CAROUSEL_ORGS`）新增 **AMD** 与 **NVIDIA**，通过 `CAROUSEL_LABELS` 分别显示为 **"AMD Lisa Su"** 和 **"NVIDIA Jensen"**。两家公司的 Lisa Su 博士与 Jensen Huang 评价已存在于 `QUOTES` 中，支持者栏条目会链接到 `/quotes` 页面上对应的评价锚点。
- 将 **TensorWave** 从首页支持者栏移除，其评价仍保留在 `/quotes` 页面（已加入测试中的 `OFF_CAROUSEL_ONLY` 列表）。
- 单元测试已更新：新增 AMD/NVIDIA 成员资格与标签断言，以及 TensorWave 不在支持者栏的覆盖。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static carousel membership and display-label changes in quotes data plus tests; no API, auth, or runtime logic changes.
> 
> **Overview**
> Updates the **landing supporters strip** by adding **AMD** and **NVIDIA** to `CAROUSEL_ORGS` and showing them as **"AMD Lisa Su"** and **"NVIDIA Jensen"** via new `CAROUSEL_LABELS` entries. Both orgs already have quotes in `QUOTES`, so strip items still link to existing `/quotes` anchors.
> 
> **TensorWave** is removed from the carousel only; its quote stays on `/quotes`. Tests add AMD/NVIDIA membership and label checks and list TensorWave in `OFF_CAROUSEL_ONLY` so off-carousel-but-on-quotes-page behavior stays enforced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b204b939dd25b04af270f1f6eb6227e2b064859f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->