### PR TITLE
fix(legend): closable in-flow legend panel, no chart overlay / 图例改为可关闭的内嵌面板，不再遮挡图表

### DIFF
--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -120,21 +120,8 @@ describe('ChartLegend (sidebar variant)', () => {
     cy.get('.sidebar-legend label').first().find('span').first().should('exist');
   });
 
-  it('search input filters legend items by hiding non-matches', () => {
-    cy.get('.sidebar-legend input[placeholder="Search..."]').should('exist');
-    cy.get('.sidebar-legend input[placeholder="Search..."]').clear().type('MI300');
-    // Non-matching items are hidden via overflow-hidden class, not removed from DOM
-    cy.get('.sidebar-legend li.overflow-hidden').should('have.length', 3);
-    cy.get('.sidebar-legend li:not(.overflow-hidden)').should('have.length', 1);
-    cy.get('.sidebar-legend li:not(.overflow-hidden)').should('contain.text', 'AMD MI300X');
-  });
-
-  it('search clear button resets search', () => {
-    cy.get('.sidebar-legend input[placeholder="Search..."]').type('test');
-    cy.get('button[aria-label="Clear search"]').should('be.visible');
-    cy.get('button[aria-label="Clear search"]').click();
-    cy.get('.sidebar-legend input[placeholder="Search..."]').should('have.value', '');
-    cy.get('button[aria-label="Clear search"]').should('not.exist');
+  it('renders no search input (removed from the sidebar panel)', () => {
+    cy.get('.sidebar-legend input[type="text"]').should('not.exist');
   });
 
   it('clicking a legend item toggles its active state', () => {

--- a/packages/app/cypress/component/chart-legend.cy.tsx
+++ b/packages/app/cypress/component/chart-legend.cy.tsx
@@ -150,13 +150,14 @@ describe('ChartLegend (sidebar variant)', () => {
     cy.contains('Reset filter').should('not.exist');
   });
 
-  it('expand/collapse button toggles legend state', () => {
-    cy.get('.sidebar-legend').should('have.class', 'bg-accent');
-    cy.get('.sidebar-legend button')
-      .filter(':contains("Collapse"), :contains("Expand")')
-      .first()
-      .click();
-    cy.get('.sidebar-legend').should('not.have.class', 'bg-accent');
+  it('close button hides the panel and the reopen button restores it', () => {
+    cy.get('.sidebar-legend').should('exist');
+    cy.get('[data-testid="legend-close-button"]').click();
+    cy.get('.sidebar-legend').should('not.exist');
+    cy.get('[data-testid="legend-open-button"]').should('be.visible');
+    cy.get('[data-testid="legend-open-button"]').click();
+    cy.get('.sidebar-legend').should('exist');
+    cy.get('[data-testid="legend-open-button"]').should('not.exist');
   });
 
   it('renders no points-table icon when items have no onShowPoints handler', () => {

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -39,10 +39,30 @@ describe('URL Parameter Persistence', () => {
   });
 
   describe('Inference legend', () => {
-    it('i_legend=0 collapses the sidebar legend on load', () => {
+    it('i_legend=0 hides the sidebar legend on load and the reopen button restores it', () => {
       visitWithDismissedModal('/inference?i_legend=0');
+      cy.get('[data-testid="legend-open-button"]').first().should('be.visible');
+      cy.get('.sidebar-legend').should('not.exist');
+
+      cy.get('[data-testid="legend-open-button"]').first().click();
       cy.get('.sidebar-legend').first().should('be.visible');
-      cy.get('.sidebar-legend').first().should('not.have.class', 'bg-accent');
+      cy.get('[data-testid="legend-open-button"]').should('not.exist');
+    });
+
+    // The address bar is deliberately left clean after load (see url-state.ts)
+    // — filter changes like closing the legend only reach the in-memory share
+    // state, so this asserts the UI transition rather than location.search.
+    it('legend close button hides the panel and the reopen button restores it', () => {
+      visitWithDismissedModal('/inference');
+      cy.get('.sidebar-legend').first().should('be.visible');
+
+      cy.get('[data-testid="legend-close-button"]').first().click();
+      cy.get('.sidebar-legend').should('not.exist');
+      cy.get('[data-testid="legend-open-button"]').first().should('be.visible');
+
+      cy.get('[data-testid="legend-open-button"]').first().click();
+      cy.get('.sidebar-legend').first().should('be.visible');
+      cy.get('[data-testid="legend-open-button"]').should('not.exist');
     });
 
     it('preserves a legend subset when chart metrics change', () => {

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -116,7 +116,9 @@ export function CollectiveXKvSection({
     ids: Set<string>;
     signature: string;
   } | null>(null);
-  const [legendExpanded, setLegendExpanded] = useState(false);
+  // Default open: with the closable sidebar panel, `false` now means fully
+  // hidden (reopen button only), so the legend must start expanded.
+  const [legendExpanded, setLegendExpanded] = useState(true);
 
   const rows = useMemo<CollectiveXKvRunCase[]>(
     () =>

--- a/packages/app/src/components/ui/chart-legend-item.tsx
+++ b/packages/app/src/components/ui/chart-legend-item.tsx
@@ -97,7 +97,7 @@ const ChartLegendItem: React.FC<CommonLegendItemProps> = ({
         htmlFor={id}
         className={cn(
           'group/item flex items-center cursor-pointer hover:underline peer-focus-visible:ring-1 peer-focus-visible:ring-offset-1 peer-focus-visible:outline-none rounded-sm',
-          isLegendExpanded ? 'w-fit whitespace-nowrap' : '',
+          isLegendExpanded ? 'w-fit whitespace-nowrap' : 'max-w-full',
         )}
         title={!isLegendExpanded && isLongText ? label : title}
         onMouseEnter={onHover && isActive ? () => onHover(hw || name) : undefined}
@@ -170,7 +170,7 @@ const ChartLegendItem: React.FC<CommonLegendItemProps> = ({
           className={cn(
             'pr-2',
             isLongText && !isLegendExpanded
-              ? 'truncate'
+              ? 'truncate min-w-0'
               : isLegendExpanded
                 ? 'whitespace-nowrap'
                 : 'whitespace-normal',

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -2,13 +2,12 @@
 
 import { track } from '@/lib/analytics';
 import {
-  ArrowLeftToLine,
-  ArrowRightToLine,
   ChevronDown,
   ChevronRight,
   Circle,
   Diamond,
   Info,
+  PanelRight,
   Square,
   Triangle,
   X,
@@ -39,27 +38,23 @@ export type { CommonLegendItemProps } from './chart-legend-item';
 const STRINGS = {
   en: {
     advanced: 'Advanced',
-    collapse: 'Collapse',
-    expand: 'Expand',
     searchPlaceholder: 'Search...',
     searchAria: 'Search legend',
     clearSearch: 'Clear search',
     moreInfo: (label: string) => `More info about ${label}`,
-    collapseLegend: 'Collapse legend',
-    expandLegend: 'Expand legend',
+    hideLegend: 'Hide legend',
+    showLegend: 'Show legend',
     hide: (label: string) => `Hide ${label}`,
     showPoints: (label: string) => `Show all ${label} data points`,
   },
   zh: {
     advanced: '高级',
-    collapse: '收起',
-    expand: '展开',
     searchPlaceholder: '搜索…',
     searchAria: '搜索图例',
     clearSearch: '清除搜索',
     moreInfo: (label: string) => `查看${label}的更多信息`,
-    collapseLegend: '收起图例',
-    expandLegend: '展开图例',
+    hideLegend: '隐藏图例',
+    showLegend: '显示图例',
     hide: (label: string) => `隐藏${label}`,
     showPoints: (label: string) => `显示${label}的全部数据点`,
   },
@@ -138,14 +133,16 @@ export default function ChartLegend({
   const locale = useLocale();
   const t = STRINGS[locale];
   const isSidebar = variant === 'sidebar';
-  const hasLongText = legendItems.some((item) => item.label && item.label.length > 8);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
   const advancedControlsId = useId();
 
-  const effectiveExpanded = isLegendExpanded;
+  // Sidebar items always render in the compact (truncate + title tooltip)
+  // layout: the panel is a fixed-width in-flow column and must never grow
+  // over the plot area.
+  const itemsExpanded = isSidebar ? false : isLegendExpanded;
   // Counts only removable series: the guard below exists to stop the user
   // emptying the chart, and label-only entries (unofficial runs) are not
   // something removing leaves you without.
@@ -208,17 +205,15 @@ export default function ChartLegend({
     return result.filter((row) => row.length > 0);
   }, [grouped, legendItems, sortedItems, isSidebar]);
 
-  const handleLegendExpand = () => {
+  const toggleLegendOpen = () => {
     onExpandedChange(!isLegendExpanded);
   };
 
+  // Sidebar: a fixed in-flow panel that takes layout space next to the plot
+  // (Epoch-style). It never overlays the chart; closing it (X) removes it
+  // entirely and the chart reclaims the width.
   const outerClasses = isSidebar
-    ? cn(
-        'p-2 rounded-sm text-sm flex flex-col h-full legend-container sidebar-legend transition-all',
-        isLegendExpanded
-          ? 'absolute right-0 top-0 z-10 w-auto min-w-fit border bg-accent'
-          : 'w-full',
-      )
+    ? 'p-2 rounded-sm border bg-accent text-sm flex flex-col h-full legend-container sidebar-legend w-full'
     : grouped
       ? cn(
           'py-1 px-2 md:py-1 rounded-sm border text-sm top-0 right-0 bg-accent transition-all md:flex md:flex-col legend-container',
@@ -258,8 +253,7 @@ export default function ChartLegend({
     (shapeIndicators !== null ||
       keyIndicators ||
       (switches && switches.length > 0) ||
-      (actions && actions.length > 0) ||
-      hasLongText);
+      (actions && actions.length > 0));
   const scrollClasses = isSidebar
     ? cn(
         'overflow-y-auto flex-1 min-h-0 space-y-0.5',
@@ -275,35 +269,63 @@ export default function ChartLegend({
     }
   }, [searchQuery]);
 
-  const searchInput =
-    isSidebar && isLegendExpanded ? (
-      <div className="pb-1.5 no-export">
-        <div className="relative">
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onBlur={trackSearchOnBlur}
-            placeholder={t.searchPlaceholder}
-            aria-label={t.searchAria}
-            className="w-full px-2 py-1 pr-6 rounded-md border border-border bg-background text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-sky-500/50 focus:border-sky-500/50"
-          />
-          {searchQuery && (
-            <button
-              type="button"
-              onClick={() => {
-                track('inference_legend_search_cleared');
-                setSearchQuery('');
-              }}
-              className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded-sm text-muted-foreground hover:text-foreground transition-colors"
-              aria-label={t.clearSearch}
-            >
-              <X size={12} />
-            </button>
-          )}
-        </div>
+  // Fully-closed sidebar: render only a reopen affordance at the top-right of
+  // the chart area (all hooks above have already run unconditionally).
+  if (isSidebar && !isLegendExpanded) {
+    return (
+      <div className="flex justify-end no-export">
+        <button
+          type="button"
+          data-testid="legend-open-button"
+          onClick={toggleLegendOpen}
+          aria-label={t.showLegend}
+          title={t.showLegend}
+          className="p-1.5 rounded-md border border-border bg-background text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+        >
+          <PanelRight size={16} />
+        </button>
       </div>
-    ) : null;
+    );
+  }
+
+  const searchInput = isSidebar ? (
+    <div className="pb-1.5 no-export flex items-center gap-1">
+      <div className="relative flex-1">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onBlur={trackSearchOnBlur}
+          placeholder={t.searchPlaceholder}
+          aria-label={t.searchAria}
+          className="w-full px-2 py-1 pr-6 rounded-md border border-border bg-background text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-sky-500/50 focus:border-sky-500/50"
+        />
+        {searchQuery && (
+          <button
+            type="button"
+            onClick={() => {
+              track('inference_legend_search_cleared');
+              setSearchQuery('');
+            }}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={t.clearSearch}
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+      <button
+        type="button"
+        data-testid="legend-close-button"
+        onClick={toggleLegendOpen}
+        aria-label={t.hideLegend}
+        title={t.hideLegend}
+        className="p-1 rounded-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  ) : null;
 
   const standardSwitches = switches?.filter((sw) => !sw.advanced) ?? [];
   const advancedSwitches = switches?.filter((sw) => sw.advanced) ?? [];
@@ -409,7 +431,7 @@ export default function ChartLegend({
     <div
       className={cn(
         'w-full md:w-auto mt-2 px-1 pr-2 gap-x-4 gap-y-1',
-        effectiveExpanded ? 'flex flex-wrap' : 'grid grid-cols-2',
+        itemsExpanded ? 'flex flex-wrap' : 'grid grid-cols-2',
       )}
     >
       {shapeIndicators.map(({ precision, shapeKey }) => {
@@ -426,20 +448,6 @@ export default function ChartLegend({
     </div>
   ) : null;
 
-  const expandButton = hasLongText ? (
-    <div className="hidden lg:block mt-2 no-export">
-      <button
-        type="button"
-        onClick={handleLegendExpand}
-        className="text-xs text-accent-foreground hover:text-foreground flex items-center gap-1"
-        aria-label={isLegendExpanded ? t.collapseLegend : t.expandLegend}
-      >
-        {isLegendExpanded ? <ArrowRightToLine size={16} /> : <ArrowLeftToLine size={16} />}
-        {isLegendExpanded ? t.collapse : t.expand}
-      </button>
-    </div>
-  ) : null;
-
   // Compute li className for a legend item (shared by tooltip and non-tooltip paths)
   const itemClassName = (item: CommonLegendItemProps, isHidden: boolean) =>
     cn(
@@ -451,7 +459,7 @@ export default function ChartLegend({
         : item.isActive
           ? 'opacity-100'
           : 'opacity-50 no-export',
-      effectiveExpanded && 'md:w-full md:block',
+      itemsExpanded && 'md:w-full md:block',
       isHidden && 'h-0 m-0! p-0! overflow-hidden',
     );
 
@@ -475,7 +483,7 @@ export default function ChartLegend({
         hideAriaLabel={t.hide(item.label)}
         showPointsAriaLabel={t.showPoints(item.label)}
         asFragment
-        isLegendExpanded={effectiveExpanded}
+        isLegendExpanded={itemsExpanded}
         sidebarMode={isSidebar}
       />
     );
@@ -487,7 +495,7 @@ export default function ChartLegend({
             <TooltipTrigger asChild>
               {/* Full width when the row carries a points-table icon so the
                   ml-auto icon pins to a consistent right-edge column. */}
-              <div className={item.onShowPoints ? 'w-full' : 'w-fit'}>{legendItem}</div>
+              <div className={item.onShowPoints ? 'w-full' : 'w-fit max-w-full'}>{legendItem}</div>
             </TooltipTrigger>
             {item.isHighlighted && item.tooltip && (
               <TooltipContent side="bottom" collisionPadding={10}>
@@ -502,21 +510,15 @@ export default function ChartLegend({
     );
   };
 
-  // Bottom controls (switches, FP indicators, expand button, actions)
+  // Bottom controls (switches, FP indicators, actions)
   const hasBottomControls =
-    switchElements ||
-    actionElements ||
-    fpIndicators ||
-    keyIndicators ||
-    expandButton ||
-    hasAtomFootnote;
+    switchElements || actionElements || fpIndicators || keyIndicators || hasAtomFootnote;
   const bottomControls = hasBottomControls ? (
     <div className="shrink-0 grow-0">
       {actionElements}
       {switchElements}
       {fpIndicators}
       {keyIndicators}
-      {expandButton}
       {hasAtomFootnote && <AtomEngineFootnote className="mt-2 no-export" />}
     </div>
   ) : null;
@@ -547,7 +549,7 @@ export default function ChartLegend({
               <ul
                 className={cn(
                   'flex flex-wrap gap-x-2 gap-y-1',
-                  effectiveExpanded && 'md:block md:space-y-1',
+                  itemsExpanded && 'md:block md:space-y-1',
                 )}
               >
                 {row.map((item: CommonLegendItemProps) => {
@@ -569,6 +571,7 @@ export default function ChartLegend({
                         onShowPoints={item.onShowPoints}
                         hideAriaLabel={t.hide(item.label)}
                         showPointsAriaLabel={t.showPoints(item.label)}
+                        isLegendExpanded={itemsExpanded}
                         sidebarMode={isSidebar}
                         asFragment
                       />

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { track } from '@/lib/analytics';
 import {
   ChevronDown,
   ChevronRight,
@@ -12,7 +11,7 @@ import {
   Triangle,
   X,
 } from 'lucide-react';
-import React, { useCallback, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { SHAPE_ORDER, type ShapeKey, getShapeKeyForPrecision } from '@/lib/chart-rendering';
 import { type Precision, getPrecisionLabel } from '@/lib/data-mappings';
@@ -38,9 +37,6 @@ export type { CommonLegendItemProps } from './chart-legend-item';
 const STRINGS = {
   en: {
     advanced: 'Advanced',
-    searchPlaceholder: 'Search...',
-    searchAria: 'Search legend',
-    clearSearch: 'Clear search',
     moreInfo: (label: string) => `More info about ${label}`,
     hideLegend: 'Hide legend',
     showLegend: 'Show legend',
@@ -49,9 +45,6 @@ const STRINGS = {
   },
   zh: {
     advanced: '高级',
-    searchPlaceholder: '搜索…',
-    searchAria: '搜索图例',
-    clearSearch: '清除搜索',
     moreInfo: (label: string) => `查看${label}的更多信息`,
     hideLegend: '隐藏图例',
     showLegend: '显示图例',
@@ -135,7 +128,6 @@ export default function ChartLegend({
   const isSidebar = variant === 'sidebar';
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
   const advancedControlsId = useId();
 
@@ -170,22 +162,6 @@ export default function ChartLegend({
     return filterAndSortLegendItems(legendItems, '', !disableActiveSort);
   }, [legendItems, isSidebar, disableActiveSort]);
 
-  // Compute which items match the search query (used to hide non-matching via CSS)
-  const hiddenNames = useMemo(() => {
-    if (!isSidebar) return new Set<string>();
-    const query = searchQuery.trim().toLowerCase();
-    if (!query) return new Set<string>();
-    return new Set(
-      legendItems
-        .filter(
-          (item) =>
-            !item.label.toLowerCase().includes(query) &&
-            !(item.title && item.title.toLowerCase().includes(query)),
-        )
-        .map((item) => item.name),
-    );
-  }, [legendItems, searchQuery, isSidebar]);
-
   const rows = useMemo(() => {
     if (!grouped) return null;
     const items = isSidebar ? sortedItems : legendItems;
@@ -213,7 +189,7 @@ export default function ChartLegend({
   // (Epoch-style). It never overlays the chart; closing it (X) removes it
   // entirely and the chart reclaims the width.
   const outerClasses = isSidebar
-    ? 'p-2 rounded-sm border bg-accent text-sm flex flex-col h-full legend-container sidebar-legend w-full'
+    ? 'p-3 rounded-md border border-border/60 bg-background text-sm flex flex-col h-full legend-container sidebar-legend w-full'
     : grouped
       ? cn(
           'py-1 px-2 md:py-1 rounded-sm border text-sm top-0 right-0 bg-accent transition-all md:flex md:flex-col legend-container',
@@ -263,12 +239,6 @@ export default function ChartLegend({
       ? 'flex gap-x-4 flex-wrap flex-row md:block md:overflow-y-auto md:flex-1 md:min-h-0'
       : 'flex flex-row flex-wrap gap-x-4 gap-y-2 md:block md:overflow-y-auto md:flex-1 md:min-h-0';
 
-  const trackSearchOnBlur = useCallback(() => {
-    if (searchQuery.trim()) {
-      track('inference_legend_searched', { query: searchQuery.trim() });
-    }
-  }, [searchQuery]);
-
   // Fully-closed sidebar: render only a reopen affordance at the top-right of
   // the chart area (all hooks above have already run unconditionally).
   if (isSidebar && !isLegendExpanded) {
@@ -288,32 +258,9 @@ export default function ChartLegend({
     );
   }
 
-  const searchInput = isSidebar ? (
-    <div className="pb-1.5 no-export flex items-center gap-1">
-      <div className="relative flex-1">
-        <input
-          type="text"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-          onBlur={trackSearchOnBlur}
-          placeholder={t.searchPlaceholder}
-          aria-label={t.searchAria}
-          className="w-full px-2 py-1 pr-6 rounded-md border border-border bg-background text-foreground text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-sky-500/50 focus:border-sky-500/50"
-        />
-        {searchQuery && (
-          <button
-            type="button"
-            onClick={() => {
-              track('inference_legend_search_cleared');
-              setSearchQuery('');
-            }}
-            className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded-sm text-muted-foreground hover:text-foreground transition-colors"
-            aria-label={t.clearSearch}
-          >
-            <X size={12} />
-          </button>
-        )}
-      </div>
+  // Slim header: just the close (X) affordance, right-aligned (Epoch-style).
+  const panelHeader = isSidebar ? (
+    <div className="pb-1 no-export flex justify-end">
       <button
         type="button"
         data-testid="legend-close-button"
@@ -449,7 +396,7 @@ export default function ChartLegend({
   ) : null;
 
   // Compute li className for a legend item (shared by tooltip and non-tooltip paths)
-  const itemClassName = (item: CommonLegendItemProps, isHidden: boolean) =>
+  const itemClassName = (item: CommonLegendItemProps) =>
     cn(
       'transition-opacity duration-300',
       isSidebar
@@ -460,11 +407,10 @@ export default function ChartLegend({
           ? 'opacity-100'
           : 'opacity-50 no-export',
       itemsExpanded && 'md:w-full md:block',
-      isHidden && 'h-0 m-0! p-0! overflow-hidden',
     );
 
   // Render a single legend item, optionally wrapped with a tooltip
-  const renderItem = (item: CommonLegendItemProps, isHidden: boolean) => {
+  const renderItem = (item: CommonLegendItemProps) => {
     const legendItem = (
       <ChartLegendItem
         name={item.name}
@@ -489,7 +435,7 @@ export default function ChartLegend({
     );
 
     return (
-      <li key={item.name} className={itemClassName(item, isHidden)}>
+      <li key={item.name} className={itemClassName(item)}>
         {enableTooltips ? (
           <TooltipRoot>
             <TooltipTrigger asChild>
@@ -531,57 +477,43 @@ export default function ChartLegend({
         style={isSidebar || isOverflowing ? { scrollbarGutter: 'stable' } : undefined}
         className={cn(scrollClasses, 'custom-scrollbar')}
       >
-        {rows.map((row, i) => {
-          const allHidden =
-            isSidebar && row.every((item: CommonLegendItemProps) => hiddenNames.has(item.name));
-          return (
-            <div
-              key={i}
+        {rows.map((row, i) => (
+          <div key={i} className={cn('p-1 rounded-sm shrink-0', i > 0 && 'mt-2')}>
+            <div className="text-sm font-medium text-muted-foreground gpu-legend-title whitespace-nowrap overflow-ellipsis overflow-hidden">
+              {row[0].title}
+            </div>
+            <ul
               className={cn(
-                'p-1 rounded-sm shrink-0',
-                i > 0 && 'mt-2',
-                allHidden && 'h-0 m-0! p-0! overflow-hidden',
+                'flex flex-wrap gap-x-2 gap-y-1',
+                itemsExpanded && 'md:block md:space-y-1',
               )}
             >
-              <div className="text-sm font-medium text-muted-foreground gpu-legend-title whitespace-nowrap overflow-ellipsis overflow-hidden">
-                {row[0].title}
-              </div>
-              <ul
-                className={cn(
-                  'flex flex-wrap gap-x-2 gap-y-1',
-                  itemsExpanded && 'md:block md:space-y-1',
-                )}
-              >
-                {row.map((item: CommonLegendItemProps) => {
-                  const isHidden = isSidebar && hiddenNames.has(item.name);
-                  return (
-                    <li key={item.name} className={cn(isHidden && 'h-0 m-0! p-0! overflow-hidden')}>
-                      <ChartLegendItem
-                        name={item.name}
-                        hw={item.hw}
-                        label={item.label}
-                        color={item.color}
-                        lineDasharray={item.lineDasharray}
-                        title={item.title}
-                        isActive={item.isActive}
-                        onClick={item.onClick}
-                        onHover={onItemHover}
-                        onHoverEnd={onItemHoverEnd}
-                        onRemove={removeFor(item)}
-                        onShowPoints={item.onShowPoints}
-                        hideAriaLabel={t.hide(item.label)}
-                        showPointsAriaLabel={t.showPoints(item.label)}
-                        isLegendExpanded={itemsExpanded}
-                        sidebarMode={isSidebar}
-                        asFragment
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          );
-        })}
+              {row.map((item: CommonLegendItemProps) => (
+                <li key={item.name}>
+                  <ChartLegendItem
+                    name={item.name}
+                    hw={item.hw}
+                    label={item.label}
+                    color={item.color}
+                    lineDasharray={item.lineDasharray}
+                    title={item.title}
+                    isActive={item.isActive}
+                    onClick={item.onClick}
+                    onHover={onItemHover}
+                    onHoverEnd={onItemHoverEnd}
+                    onRemove={removeFor(item)}
+                    onShowPoints={item.onShowPoints}
+                    hideAriaLabel={t.hide(item.label)}
+                    showPointsAriaLabel={t.showPoints(item.label)}
+                    isLegendExpanded={itemsExpanded}
+                    sidebarMode={isSidebar}
+                    asFragment
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
       </div>
     ) : (
       <ul
@@ -589,16 +521,14 @@ export default function ChartLegend({
         style={isSidebar || isOverflowing ? { scrollbarGutter: 'stable' } : undefined}
         className={cn(scrollClasses, 'custom-scrollbar')}
       >
-        {(isSidebar ? sortedItems : legendItems).map((item) =>
-          renderItem(item, isSidebar && hiddenNames.has(item.name)),
-        )}
+        {(isSidebar ? sortedItems : legendItems).map((item) => renderItem(item))}
       </ul>
     );
 
   const content = (
     <div className={isSidebar ? 'h-full' : 'relative'}>
       <div data-testid="chart-legend" className={outerClasses} style={outerStyle}>
-        {searchInput}
+        {panelHeader}
         {scrollContent}
         {bottomControls}
       </div>

--- a/packages/app/src/components/ui/d3-chart-wrapper.tsx
+++ b/packages/app/src/components/ui/d3-chart-wrapper.tsx
@@ -132,11 +132,12 @@ export function D3ChartWrapper({
         </div>
         {legendElement && (
           /* Sizes to the legend content: when the sidebar legend panel is open
-             (.sidebar-legend present) the column takes its fixed width so the
-             panel sits next to the plot without overlapping it; when closed
-             the legend renders only a small reopen button and the chart
-             reclaims the width. */
-          <div className="w-full lg:w-auto lg:shrink-0 relative mt-3 lg:mt-0 has-[.sidebar-legend]:h-96 lg:has-[.sidebar-legend]:h-[575px] lg:has-[.sidebar-legend]:w-48">
+             (.sidebar-legend present) the column grows to fit the widest
+             legend label (capped) so full names display without truncation,
+             while still sitting next to the plot without overlapping it; when
+             closed the legend renders only a small reopen button and the
+             chart reclaims the width. */
+          <div className="w-full lg:w-auto lg:shrink-0 relative mt-3 lg:mt-0 has-[.sidebar-legend]:h-96 lg:has-[.sidebar-legend]:h-[575px] lg:has-[.sidebar-legend]:w-fit lg:has-[.sidebar-legend]:min-w-48 lg:has-[.sidebar-legend]:max-w-96">
             {legendElement}
           </div>
         )}

--- a/packages/app/src/components/ui/d3-chart-wrapper.tsx
+++ b/packages/app/src/components/ui/d3-chart-wrapper.tsx
@@ -131,7 +131,12 @@ export function D3ChartWrapper({
           </div>
         </div>
         {legendElement && (
-          <div className="w-full h-96 lg:h-[575px] lg:w-48 lg:shrink-0 relative mt-3 lg:mt-0">
+          /* Sizes to the legend content: when the sidebar legend panel is open
+             (.sidebar-legend present) the column takes its fixed width so the
+             panel sits next to the plot without overlapping it; when closed
+             the legend renders only a small reopen button and the chart
+             reclaims the width. */
+          <div className="w-full lg:w-auto lg:shrink-0 relative mt-3 lg:mt-0 has-[.sidebar-legend]:h-96 lg:has-[.sidebar-legend]:h-[575px] lg:has-[.sidebar-legend]:w-48">
             {legendElement}
           </div>
         )}

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -257,13 +257,14 @@ export function useChartExport({
   const exportToImage = useCallback(async () => {
     setIsExporting(true);
 
-    // Temporarily expand the legend so the clone captures expanded state
-    let wasCollapsed = false;
+    // A fully-closed sidebar legend renders only its reopen button (no
+    // .legend-container), so temporarily open it for the clone and restore
+    // the closed state right after.
+    let wasClosed = false;
     if (setIsLegendExpanded) {
       const el = document.querySelector(`#${chartId}`);
-      const legend = el?.getElementsByClassName('legend-container')[0];
-      wasCollapsed = Boolean(legend) && !legend!.classList.contains('bg-accent');
-      if (wasCollapsed) {
+      wasClosed = Boolean(el?.querySelector('[data-testid="legend-open-button"]'));
+      if (wasClosed) {
         setIsLegendExpanded(true);
         await waitForRender();
       }
@@ -305,8 +306,8 @@ export function useChartExport({
 
       exportElement.append(clone);
 
-      // Restore collapsed state immediately after cloning
-      if (wasCollapsed && setIsLegendExpanded) {
+      // Restore closed state immediately after cloning
+      if (wasClosed && setIsLegendExpanded) {
         setIsLegendExpanded(false);
       }
 
@@ -491,7 +492,7 @@ export function useChartExport({
     } catch (error) {
       console.error('Error exporting image:', error);
       alert('Failed to export image. Please try again.');
-      if (wasCollapsed && setIsLegendExpanded) setIsLegendExpanded(false);
+      if (wasClosed && setIsLegendExpanded) setIsLegendExpanded(false);
     } finally {
       setIsExporting(false);
       const exportElement = document.querySelector<HTMLElement>(`#${chartId}-export`);


### PR DESCRIPTION
## Summary

The sidebar chart legend previously "expanded" into an absolutely-positioned overlay (`absolute right-0 top-0 z-10 w-auto min-w-fit`) that covered the plot, toggled by a Collapse/Expand button. This reworks the legend to the pattern Epoch AI uses:

- **Open legend is a normal in-flow panel** beside the chart — it can never overlap the plot, and the chart reclaims the full row width when the legend is closed (via a Tailwind `:has(.sidebar-legend)` rule on the legend column, so no wrapper API changes)
- **X button** in the panel header fully closes the legend (the search input has been removed entirely)
- **Panel button at the chart's top-right** (`PanelRight` icon) reopens it
- The Collapse/Expand button and the overlay positioning are removed entirely
- Long legend labels now ellipsize inside the panel (`w-fit max-w-full` on the tooltip trigger wrapper + `truncate min-w-0` on the label span) instead of overflowing across the chart
- PNG export temporarily opens a closed legend for the export clone and restores it afterward (detection via the new `legend-open-button` test id instead of the old `bg-accent` class check)

### Behavior change

`i_legend=0` now means the legend is fully hidden (previously: narrow "collapsed" strip). The default remains open. Since chart params only live in the in-memory share state, no shared links change meaning beyond that.

### Testing

- `bun run fmt`, `bun run lint`, `bun run typecheck` clean
- Unit tests: 4454 passing
- Cypress component suite passing (updated `chart-legend.cy.tsx` toggle test to the close/reopen flow)
- Cypress smoke suite + full `url-params.cy.ts` (40) + `evaluation-chart.cy.ts` (16) passing
- Visually verified open/closed/reopened states at 1600px and 1280px on `/inference` and `/evaluation`

## 中文说明

侧边图例此前"展开"时会变成绝对定位的悬浮层遮挡图表，且由 Collapse/Expand 按钮切换。本 PR 改为 Epoch AI 风格：

- 打开的图例是图表右侧的常规内嵌面板，不会遮挡图表；关闭后图表自动占满整行宽度
- 面板顶部的 **X 按钮**可完全关闭图例（搜索框已整体移除）
- 图表右上角的面板按钮（`PanelRight` 图标）可重新打开图例
- 彻底移除 Collapse/Expand 按钮和悬浮定位
- 超长标签在面板内以省略号截断，不再溢出到图表上
- PNG 导出时会临时展开已关闭的图例并在导出后恢复

行为变化：`i_legend=0` 现表示图例完全隐藏（此前为窄的"折叠"条）。默认仍为打开。

测试：fmt / lint / typecheck 全部通过；4454 个单元测试通过；Cypress 组件套件与冒烟套件通过（更新了 `chart-legend.cy.tsx` 与 `url-params.cy.ts`、`evaluation-chart.cy.ts` 相关用例）；已在 `/inference` 与 `/evaluation` 页面进行视觉验证。


## Update (follow-ups)

- Legend column now sizes to its content (min 12rem, max 24rem) so full series names display without truncation
- Removed the legend search input and its filtering/analytics plumbing
- Subtler panel styling (plain background, softer border) to match the Epoch-style reference

## 更新（后续修改）

- 图例列宽按内容自适应（最小 12rem，最大 24rem），完整显示系列名称
- 移除图例搜索框及其过滤与埋点逻辑
- 面板样式弱化（普通背景、更淡边框），与 Epoch 参考风格一致

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared chart legend UX and the meaning of `i_legend=0` in deep links, but scope is UI/layout and export cloning rather than auth or data handling.
> 
> **Overview**
> Reworks the **sidebar chart legend** from an absolutely positioned expand/collapse overlay into an **in-flow panel** beside the plot: closing with **X** removes the panel so the chart regains width; a **`PanelRight` reopen button** restores it. **Legend search** (filtering, clear control, and analytics) is removed.
> 
> **`d3-chart-wrapper`** sizes the legend column with `:has(.sidebar-legend)` (min/max width when open, minimal footprint when closed). **`ChartLegend`** uses subtler panel styling; sidebar rows stay compact with **truncate / `min-w-0`** on long labels. **`i_legend=0`** now means fully hidden (not a narrow collapsed strip). **PNG export** temporarily opens a closed legend via **`legend-open-button`** detection instead of **`bg-accent`**. **CollectiveX KV** defaults the legend open. Cypress component and **`url-params`** tests cover close/reopen and the new **`i_legend=0`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460ac5153d550b5041112b97027c460c53301a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->