### PR TITLE
feat(power): ingest and expose power audit provenance / 功率：摄取并公开功耗审计溯源字段（power_invalid_reasons、power_audit）

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -378,3 +378,14 @@ All normalizer logic lives in `packages/db/src/etl/normalizers.ts`. The function
 - **v2 (2025-12-19+)**: Separate `prefill_tp` / `decode_tp` / `prefill_ep` / `decode_ep` / `prefill_dp_attention` / `decode_dp_attention` / `prefill_num_workers` / `decode_num_workers` / `num_prefill_gpu` / `num_decode_gpu` fields are present. These map directly; `num_prefill_gpu` / `num_decode_gpu` fall back to `tp * ep` if absent.
 
 Detection is a single `'prefill_tp' in row` check — no version field is required in the artifact.
+
+### Power Audit Provenance (`power_invalid_reasons`, `power_audit`)
+
+Producers (`aggregate_power.py`) annotate every aggregate result row with two optional provenance fields alongside the `power_valid` verdict:
+
+- **`power_invalid_reasons`** — array of snake_case reason-code strings explaining a withheld verdict (emitted when `power_valid == 0`), e.g. `sampling_gap_exceeded`, `expected_gpu_count_mismatch`.
+- **`power_audit`** — compact measurement-window audit object with a fixed 8-key shape: `window_start_unix`, `window_end_unix`, `expected_gpu_count`, `observed_gpu_count`, `sample_count`, `max_sample_gap_s`, `producer_sha`, `exporter_image_sha256`. Present on valid and invalid rows alike.
+
+`mapBenchmarkRow()` narrows them defensively (`extractPowerInvalidReasons` / `extractPowerAudit`): reason codes must match `/^[a-z][a-z0-9_]*$/` (≤ 64 chars, deduplicated, capped at 32), audit numerics must be finite (counts: non-negative safe integers), shas collapse to `null` unless a non-empty string ≤ 128 chars, and unknown audit keys are dropped. An empty result maps to `undefined`, so the dedicated `benchmark_results.power_invalid_reasons` / `power_audit` JSONB columns (migration 014, mirroring the `workers` precedent from migration 006) store SQL NULL — never `[]` or `{}`. Legacy artifacts without the fields flow through every layer as NULL/undefined.
+
+Reads are **permanently tolerant**: `queries/benchmarks.ts` selects the columns as `to_jsonb(br) -> 'power_invalid_reasons'` (and `lb` on the matview branch) rather than bare column references. A bare reference fails at query _plan_ time until the next ingest workflow applies the migration (migrations run in the ingest workflows, not at Vercel deploy — PR #405 shipped bare reads ahead of migration 006 and served 500s until #407 identified this jsonb-lookup primitive). The key lookup degrades to NULL while the column is missing and is byte-identical once it exists, making deploy order irrelevant.

--- a/packages/app/src/app/api/unofficial-run/route.test.ts
+++ b/packages/app/src/app/api/unofficial-run/route.test.ts
@@ -193,6 +193,41 @@ describe('normalizeArtifactRows', () => {
     },
   );
 
+  it('carries power audit provenance on overlay rows', () => {
+    const audit = {
+      window_start_unix: 1756174800,
+      window_end_unix: 1756175400,
+      expected_gpu_count: 8,
+      observed_gpu_count: 8,
+      sample_count: 4800,
+      max_sample_gap_s: 1.013,
+      producer_sha: null,
+      exporter_image_sha256: null,
+    };
+    const [row] = normalizeArtifactRows(
+      [
+        rawRow({
+          power_valid: 0,
+          power_invalid_reasons: ['sampling_gap_exceeded'],
+          power_audit: audit,
+        }),
+      ],
+      '2026-03-01',
+    );
+
+    expect(row.power_invalid_reasons).toEqual(['sampling_gap_exceeded']);
+    expect(row.power_audit).toEqual(audit);
+    // The provenance explains the withheld verdict; it never lands in metrics.
+    expect(row.metrics).not.toHaveProperty('power_invalid_reasons');
+    expect(row.metrics).not.toHaveProperty('power_audit');
+  });
+
+  it('leaves provenance keys undefined for rows without the contract fields', () => {
+    const [row] = normalizeArtifactRows([rawRow()], '2026-03-01');
+    expect(row.power_invalid_reasons).toBeUndefined();
+    expect(row.power_audit).toBeUndefined();
+  });
+
   it('preserves recipe identity for unofficial overlays', () => {
     const rows = normalizeArtifactRows(
       [

--- a/packages/app/src/app/api/unofficial-run/route.ts
+++ b/packages/app/src/app/api/unofficial-run/route.ts
@@ -73,6 +73,10 @@ export function normalizeArtifactRows(
       // Surface the same per-worker payload the DB path emits so unofficial
       // overlays carry the multinode measured-power breakdown too.
       workers: params.workers,
+      // Same parity for the power audit provenance: overlay rows explain a
+      // withheld verdict exactly like persisted rows do.
+      power_invalid_reasons: params.powerInvalidReasons,
+      power_audit: params.powerAudit,
       date,
       run_url: runUrl,
     });

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -114,6 +114,11 @@ export interface AggDataEntry {
   // Measured GPU telemetry (emitted by runner's aggregate_power.py).
   // Optional because historical runs predate the fields.
   power_valid?: number;
+  /**
+   * Producer reason codes explaining a withheld power verdict
+   * (PLAN-06 contract; present only when power_valid == 0 upstream).
+   */
+  power_invalid_reasons?: string[];
   power_metric_schema_version?: number;
   avg_power_w?: number;
   joules_per_successful_query?: number;

--- a/packages/app/src/components/inference/utils/tooltip-utils.test.ts
+++ b/packages/app/src/components/inference/utils/tooltip-utils.test.ts
@@ -726,3 +726,74 @@ describe('generateGPUGraphTooltipContent', () => {
     ).not.toContain('data-action="view-charts"');
   });
 });
+
+// ===========================================================================
+// withheld measured-power line (power_invalid_reasons)
+// ===========================================================================
+describe('measured-power withheld tooltip line', () => {
+  const reasons = ['sampling_gap_exceeded', 'expected_gpu_count_mismatch'];
+
+  it('renders the withheld line with humanized codes (en)', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ power_valid: 0, power_invalid_reasons: reasons }) }),
+    );
+    expect(html).toContain('Measured power withheld');
+    expect(html).toContain('sampling gap exceeded');
+    expect(html).toContain('expected gpu count mismatch');
+  });
+
+  it('renders the withheld line in Chinese on /zh surfaces', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({ power_valid: 0, power_invalid_reasons: reasons }),
+        locale: 'zh',
+      }),
+    );
+    expect(html).toContain('实测功耗未采信');
+    expect(html).toContain('sampling gap exceeded');
+  });
+
+  it('filters malformed codes before HTML interpolation (defense in depth)', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({
+        data: pt({
+          power_valid: 0,
+          power_invalid_reasons: ['<img src=x>', 'sampling_gap_exceeded', 'UPPER'],
+        }),
+      }),
+    );
+    expect(html).not.toContain('<img src=x>');
+    expect(html).not.toContain('UPPER');
+    expect(html).toContain('sampling gap exceeded');
+  });
+
+  it('omits the line entirely when every code is malformed', () => {
+    const html = generateTooltipContent(
+      tooltipConfig({ data: pt({ power_valid: 0, power_invalid_reasons: ['<img src=x>'] }) }),
+    );
+    expect(html).not.toContain('Measured power withheld');
+  });
+
+  it.each([
+    ['absent reasons', pt({ power_valid: 0 })],
+    ['empty reasons', pt({ power_valid: 0, power_invalid_reasons: [] })],
+    ['valid row', pt({ power_valid: 1 })],
+  ])('omits the line for %s', (_name, data) => {
+    const html = generateTooltipContent(tooltipConfig({ data }));
+    expect(html).not.toContain('Measured power withheld');
+  });
+
+  it('gives unofficial overlay tooltips the same line', () => {
+    const html = generateOverlayTooltipContent({
+      ...tooltipConfig({ data: pt({ power_valid: 0, power_invalid_reasons: reasons }) }),
+      overlayData: {
+        label: 'feature-branch',
+        hardwareConfig: mockHardwareConfig,
+        data: [],
+        runUrl: 'https://example.com',
+      } as any,
+    } as OverlayTooltipConfig);
+    expect(html).toContain('Measured power withheld');
+    expect(html).toContain('sampling gap exceeded');
+  });
+});

--- a/packages/app/src/components/inference/utils/tooltipUtils.ts
+++ b/packages/app/src/components/inference/utils/tooltipUtils.ts
@@ -135,6 +135,7 @@ const TOOLTIP_STRINGS = {
     precision: 'Precision',
     inputTputPerChip: 'Input Token Throughput per Chip',
     outputTputPerChip: 'Output Token Throughput per Chip',
+    powerWithheld: 'Measured power withheld',
   },
   zh: {
     dismiss: '点击其他区域关闭',
@@ -149,6 +150,7 @@ const TOOLTIP_STRINGS = {
     precision: '精度',
     inputTputPerChip: '每芯片输入 token 吞吐量',
     outputTputPerChip: '每芯片输出 token 吞吐量',
+    powerWithheld: '实测功耗未采信',
   },
 } as const;
 
@@ -411,6 +413,26 @@ const generateParallelismHTML = (d: InferenceData, locale: Locale = 'en'): strin
     ${tooltipLine(t.dpAttention, d.dp_attention ? 'True' : 'False')}`;
 };
 
+/** Producer reason codes are snake_case; anything else never reaches the DOM. */
+const POWER_REASON_CODE_RE = /^[a-z][a-z0-9_]*$/u;
+
+/**
+ * One muted line explaining a withheld measured-power verdict. Empty unless
+ * the point carries producer reason codes. Codes are re-validated against the
+ * snake_case shape before interpolation (defense in depth — tooltip content
+ * is raw HTML) and humanized by replacing underscores with spaces.
+ */
+const powerWithheldHTML = (d: InferenceData, locale: Locale): string => {
+  if (!Array.isArray(d.power_invalid_reasons) || d.power_invalid_reasons.length === 0) return '';
+  const codes = d.power_invalid_reasons
+    .filter(
+      (code) => typeof code === 'string' && code.length <= 64 && POWER_REASON_CODE_RE.test(code),
+    )
+    .map((code) => code.replaceAll('_', ' '));
+  if (codes.length === 0) return '';
+  return tooltipLine(TOOLTIP_STRINGS[locale].powerWithheld, codes.join(', '));
+};
+
 /**
  * Generates HTML content for official data point tooltips.
  *
@@ -463,6 +485,7 @@ export const generateTooltipContent = (config: TooltipConfig): string => {
       ${tooltipLine(t.concurrency, `${d.conc}`)}
       ${tooltipLine(t.precision, `${d.precision.toUpperCase()}`)}
       ${generateCacheMetadataHTML(d, locale)}
+      ${powerWithheldHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
       ${runLinkHTML(runUrl)}
       ${viewActionsHTML(isPinned, Boolean(hasTrace), Boolean(config.hasLog), d.id, d.benchmark_type, locale)}
@@ -503,6 +526,7 @@ export const generateOverlayTooltipContent = (config: OverlayTooltipConfig): str
       ${tooltipLine(t.concurrency, `${d.conc}`)}
       ${tooltipLine(t.precision, `${d.precision.toUpperCase()}`)}
       ${generateCacheMetadataHTML(d, locale)}
+      ${powerWithheldHTML(d, locale)}
       ${generateAgenticHTML(d, locale)}
     </div>
   `;

--- a/packages/app/src/lib/api-documentation.power.test.ts
+++ b/packages/app/src/lib/api-documentation.power.test.ts
@@ -24,12 +24,15 @@ describe('measured-power API documentation', () => {
     }
   });
 
-  it('reserves optional power_invalid_reasons and power_audit row fields', () => {
+  it('documents optional power_invalid_reasons and power_audit row fields', () => {
     const reasons = benchmarkRowSchema?.properties?.power_invalid_reasons;
     expect(reasons?.type).toBe('array');
     expect(reasons?.items).toEqual({ type: 'string' });
+    // PLAN-07 turned the fields live; the reserved wording must not linger.
+    expect(reasons?.description).not.toMatch(/reserved|forthcoming/iu);
 
     const audit = benchmarkRowSchema?.properties?.power_audit;
+    expect(audit?.description).not.toMatch(/reserved|forthcoming/iu);
     expect(Object.keys(audit?.properties ?? {}).toSorted()).toEqual(
       [
         'window_start_unix',

--- a/packages/app/src/lib/api-documentation.ts
+++ b/packages/app/src/lib/api-documentation.ts
@@ -248,7 +248,7 @@ const powerAuditSchema: ApiSchema = {
   },
   additionalProperties: true,
   description:
-    'Reserved (forthcoming): power measurement-window audit emitted by newer producers. Absent on legacy rows.',
+    'Compact power measurement-window audit emitted alongside the power_valid verdict: window bounds, expected vs. observed GPU counts, sample statistics, and producer identity (producer_sha / exporter_image_sha256 are null for single-node telemetry without an srt-slurm producer). Present on valid and invalid rows from provenance-aware producers; absent on legacy rows.',
 };
 const workerPowerSchema = objectSchemaWithOptional(
   {
@@ -297,7 +297,7 @@ const benchmarkRowSchema = objectSchemaWithOptional(
     power_invalid_reasons: {
       ...arraySchema(stringSchema),
       description:
-        'Reserved (forthcoming): snake_case reason codes, present when metrics.power_valid == 0. Absent on legacy rows.',
+        'Producer snake_case reason codes explaining a withheld measurement, present when metrics.power_valid == 0. Absent on legacy rows and validated rows.',
     },
     power_audit: powerAuditSchema,
     date: { type: 'string', format: 'date' },
@@ -2663,8 +2663,8 @@ const overview = {
       id: 'measured-power',
       title: text('Measured power', '实测功率'),
       description: text(
-        'Benchmark rows may carry measured power, energy, and GPU-telemetry metric keys (avg_power_w, joules_per_*, avg_temp_c, peak_temp_c, avg_util_pct, avg_mem_used_mb). power_valid is tri-state: 1 means the measurement window was validated; 0 means validation failed and measured values are withheld end-to-end (the producer strips them and ingest scrubs them — treat any that remain as unreliable); absent marks a legacy row predating validation. power_metric_schema_version == 2 defines every unprefixed joules_per_* field as whole-deployment energy — unversioned disaggregated joules are ambiguous because those fields previously carried role-local values. workers[] carries the per-worker power/telemetry breakdown on multinode and disaggregated runs. power_invalid_reasons and power_audit are reserved forthcoming fields. Filter rows with the powerValid request parameter; its strict value is named strictV2 (power_valid == 1 and power_metric_schema_version == 2) rather than "certified" because it is stricter than the InferenceX UI, which also displays validated rows that predate schema versioning.',
-        '基准行可能携带实测功率、能耗和 GPU 遥测指标键（avg_power_w、joules_per_*、avg_temp_c、peak_temp_c、avg_util_pct、avg_mem_used_mb）。power_valid 为三态：1 表示测量窗口已通过验证；0 表示验证失败，实测值会被全链路扣留（生产端剥离、摄取端再次清除——若仍残留请视为不可靠）；缺失表示早于验证机制的旧数据行。power_metric_schema_version == 2 将所有无前缀的 joules_per_* 字段定义为全部署能耗——未标注版本的分离式 joules 含义不明确，因为这些字段曾承载角色本地值。多节点和分离式运行的每 worker 功率/遥测明细位于 workers[]。power_invalid_reasons 与 power_audit 为预留的即将推出字段。可使用 powerValid 请求参数筛选行；其严格取值命名为 strictV2（power_valid == 1 且 power_metric_schema_version == 2）而非 "certified"，因为它比 InferenceX 界面更严格——界面还会展示早于版本标注机制的已验证行。',
+        'Benchmark rows may carry measured power, energy, and GPU-telemetry metric keys (avg_power_w, joules_per_*, avg_temp_c, peak_temp_c, avg_util_pct, avg_mem_used_mb). power_valid is tri-state: 1 means the measurement window was validated; 0 means validation failed and measured values are withheld end-to-end (the producer strips them and ingest scrubs them — treat any that remain as unreliable); absent marks a legacy row predating validation. power_metric_schema_version == 2 defines every unprefixed joules_per_* field as whole-deployment energy — unversioned disaggregated joules are ambiguous because those fields previously carried role-local values. workers[] carries the per-worker power/telemetry breakdown on multinode and disaggregated runs. power_invalid_reasons lists the producer reason codes (snake_case) on withheld rows (power_valid == 0), and power_audit carries the compact measurement-window audit (window bounds, GPU counts, sample statistics, producer identity) on valid and invalid rows alike; both are absent on rows ingested before the provenance contract. Filter rows with the powerValid request parameter; its strict value is named strictV2 (power_valid == 1 and power_metric_schema_version == 2) rather than "certified" because it is stricter than the InferenceX UI, which also displays validated rows that predate schema versioning.',
+        '基准行可能携带实测功率、能耗和 GPU 遥测指标键（avg_power_w、joules_per_*、avg_temp_c、peak_temp_c、avg_util_pct、avg_mem_used_mb）。power_valid 为三态：1 表示测量窗口已通过验证；0 表示验证失败，实测值会被全链路扣留（生产端剥离、摄取端再次清除——若仍残留请视为不可靠）；缺失表示早于验证机制的旧数据行。power_metric_schema_version == 2 将所有无前缀的 joules_per_* 字段定义为全部署能耗——未标注版本的分离式 joules 含义不明确，因为这些字段曾承载角色本地值。多节点和分离式运行的每 worker 功率/遥测明细位于 workers[]。power_invalid_reasons 在实测值被扣留的行（power_valid == 0）上列出生产端的 snake_case 原因码；power_audit 在有效与无效行上都携带精简的测量窗口审计信息（窗口边界、GPU 数量、采样统计、生产者标识）；早于溯源契约摄取的行均不含这两个字段。可使用 powerValid 请求参数筛选行；其严格取值命名为 strictV2（power_valid == 1 且 power_metric_schema_version == 2）而非 "certified"，因为它比 InferenceX 界面更严格——界面还会展示早于版本标注机制的已验证行。',
       ),
       shape: 'BenchmarkRows',
       example: {

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'UI-only overlay for unofficial workflow artifacts; upstream artifact availability and shape are not stable.',
       zh: '仅供界面叠加非官方工作流制品；上游制品的可用性和结构并不稳定。',
     },
-    sourceSha256: '4a3f3da8399c741c26f0f502d44b1870a8ccdc05775edfd6ea3dee4e020df25c',
+    sourceSha256: '252c57b34dfbf94335d085e34aee62e5b88467b27edcf98fdbe53166adec8cfe',
   },
   {
     source: 'src/app/api/v1/agentic-aggregates/route.ts',
@@ -727,7 +727,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/benchmarks.ts',
-    sourceSha256: '486e34d55275170c7e0544af24c151199752eb5628191d38606b1ecec289dfdf',
+    sourceSha256: '6f38e94cbeafed5383e4519bcf691e67cab0ea1fbf75e71d2dfb2de5bd3698dd',
     reviewArea: {
       en: 'Benchmark row fields and latest, exact-run, history, and TCO query semantics.',
       zh: '基准行字段以及最新、精确运行、历史和 TCO 查询语义。',

--- a/packages/app/src/lib/benchmark-api-view.test.ts
+++ b/packages/app/src/lib/benchmark-api-view.test.ts
@@ -14,6 +14,8 @@ const rows = [
       unused_debug_metric: 99,
     },
     workers: [{ rank: 0, avg_power_w: 700 }],
+    power_invalid_reasons: ['sampling_gap_exceeded'],
+    power_audit: { sample_count: 4800, producer_sha: null, exporter_image_sha256: null },
   },
   {
     benchmark_type: 'single_turn',
@@ -44,6 +46,13 @@ describe('toCalculatorBenchmarkRows', () => {
         metrics: { tput_per_gpu: 120, median_intvty: 35 },
       },
     ]);
+  });
+
+  it('strips workers and the power audit provenance from the payload-trimmed view', () => {
+    const [row] = toCalculatorBenchmarkRows(rows, '1k/1k');
+    expect(row).not.toHaveProperty('workers');
+    expect(row).not.toHaveProperty('power_invalid_reasons');
+    expect(row).not.toHaveProperty('power_audit');
   });
 
   it('keeps all three cache tiers — the trim cannot know which one a row will use', () => {

--- a/packages/app/src/lib/benchmark-api-view.ts
+++ b/packages/app/src/lib/benchmark-api-view.ts
@@ -28,6 +28,8 @@ interface BenchmarkViewRow {
   osl: number | null;
   metrics: Record<string, unknown>;
   workers?: unknown;
+  power_invalid_reasons?: unknown;
+  power_audit?: unknown;
 }
 
 /**
@@ -42,7 +44,14 @@ export function toCalculatorBenchmarkRows<T extends BenchmarkViewRow>(
   return rows
     .filter((row) => rowToSequence(row) === sequence)
     .map((row) => {
-      const { workers: _workers, ...rest } = row;
+      // The calculator view excludes measured-power data by design, so the
+      // audit provenance that explains it goes too.
+      const {
+        workers: _workers,
+        power_invalid_reasons: _powerInvalidReasons,
+        power_audit: _powerAudit,
+        ...rest
+      } = row;
       return {
         ...rest,
         metrics: Object.fromEntries(

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -280,6 +280,25 @@ describe('rowToAggDataEntry', () => {
     expect(entry.joules_per_output_token).toBe(8.4);
   });
 
+  it('passes through producer power_invalid_reasons on withheld rows', () => {
+    const entry = rowToAggDataEntry(
+      makeRow({
+        metrics: { power_valid: 0 },
+        power_invalid_reasons: ['thermal_throttle', 'sample_gap'],
+      }),
+    );
+    expect(entry.power_invalid_reasons).toEqual(['thermal_throttle', 'sample_gap']);
+  });
+
+  it.each([
+    ['legacy row without the field', {}],
+    ['API null (SQL NULL column)', { power_invalid_reasons: null }],
+    ['empty array', { power_invalid_reasons: [] }],
+  ])('leaves power_invalid_reasons undefined for %s', (_name, overrides) => {
+    const entry = rowToAggDataEntry(makeRow({ metrics: {}, ...overrides }));
+    expect(entry.power_invalid_reasons).toBeUndefined();
+  });
+
   it('passes through versioned whole-deployment joules per successful query', () => {
     const entry = rowToAggDataEntry(
       makeRow({

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -193,6 +193,13 @@ export function rowToAggDataEntry(row: BenchmarkRow): AggDataEntry {
     // rows predating the field so downstream chart code can distinguish
     // "no measurement" from "0 W" via createChartDataPoint's typeof guard.
     power_valid: m.power_valid,
+    // Narrow at the trust boundary: API rows may carry null (SQL NULL) or
+    // omit the field entirely on legacy data; only a non-empty array of
+    // producer reason codes survives.
+    power_invalid_reasons:
+      Array.isArray(row.power_invalid_reasons) && row.power_invalid_reasons.length > 0
+        ? row.power_invalid_reasons
+        : undefined,
     power_metric_schema_version: m.power_metric_schema_version,
     avg_power_w: measuredPowerValid ? m.avg_power_w : undefined,
     joules_per_successful_query:

--- a/packages/db/migrations/014_power_provenance.sql
+++ b/packages/db/migrations/014_power_provenance.sql
@@ -1,0 +1,162 @@
+-- ============================================================
+-- BENCHMARK_RESULTS — power audit provenance columns
+-- ============================================================
+--
+-- Producers (aggregate_power.py) annotate every aggregate result row with two
+-- optional provenance fields alongside the power_valid verdict:
+--
+--   power_invalid_reasons — array of snake_case reason-code strings explaining
+--     a withheld verdict (present when power_valid == 0);
+--   power_audit — compact measurement-window audit object
+--     {window_start_unix, window_end_unix, expected_gpu_count,
+--      observed_gpu_count, sample_count, max_sample_gap_s, producer_sha,
+--      exporter_image_sha256}, present on valid and invalid rows alike.
+--
+-- These live in dedicated JSONB columns rather than in `metrics` (mirror of
+-- the migration-006 `workers` rationale): metrics is a flat
+-- Record<string, number> — every consumer assumes scalar values, so an array
+-- or object under one key would break parseNum and surface as "missing"
+-- everywhere. Dedicated columns also let SELECTs skip the fields when a
+-- query doesn't need them. NULL on legacy rows and rows whose producers
+-- predate the provenance contract.
+
+alter table benchmark_results
+  add column power_invalid_reasons jsonb;
+
+alter table benchmark_results
+  add column power_audit jsonb;
+
+-- Re-create the latest_benchmarks materialized view so the new columns ride
+-- on the view as well (`br.*` in a matview freezes the column list at
+-- creation time). The definition below is copied VERBATIM from migration
+-- 012_benchmark_recipe_fingerprint.sql — the current canonical definition —
+-- solely so `br.*` picks up the new columns. Do not edit the body here;
+-- line-selection changes belong in a migration of their own.
+
+drop materialized view if exists latest_benchmarks;
+
+create materialized view latest_benchmarks as
+with recursive run_lines as (
+  select
+    c.model,
+    c.hardware,
+    c.framework,
+    c.precision,
+    c.disagg,
+    case when br.benchmark_type = 'agentic_traces' then '' else c.spec_method end as line_spec_method,
+    br.benchmark_type,
+    br.isl,
+    br.osl,
+    br.offload_mode,
+    br.workflow_run_id,
+    br.date,
+    wr.run_started_at,
+    wr.append_only,
+    min(br.image) as image,
+    count(distinct br.image) as image_count,
+    bool_and(br.image is not null) as images_complete
+  from benchmark_results br
+  join configs c on c.id = br.config_id
+  join latest_workflow_runs wr on wr.id = br.workflow_run_id
+  where br.error is null
+  group by
+    c.model, c.hardware, c.framework, c.precision, c.disagg,
+    case when br.benchmark_type = 'agentic_traces' then '' else c.spec_method end,
+    br.benchmark_type, br.isl, br.osl, br.offload_mode,
+    br.workflow_run_id, br.date, wr.run_started_at, wr.append_only
+), ranked_runs as (
+  select
+    run_lines.*,
+    row_number() over (
+      partition by
+        model, hardware, framework, precision, disagg, line_spec_method,
+        benchmark_type, isl, osl, offload_mode
+      order by date desc, run_started_at desc nulls last, workflow_run_id desc
+    ) as run_rank
+  from run_lines
+), curve_runs as (
+  select
+    ranked_runs.*,
+    ranked_runs.image as root_image,
+    ranked_runs.date as snapshot_date,
+    ranked_runs.workflow_run_id as snapshot_workflow_run_id
+  from ranked_runs
+  where run_rank = 1
+
+  union all
+
+  select
+    older.*,
+    current.root_image,
+    current.snapshot_date,
+    current.snapshot_workflow_run_id
+  from curve_runs current
+  join ranked_runs older
+    on older.model = current.model
+    and older.hardware = current.hardware
+    and older.framework = current.framework
+    and older.precision = current.precision
+    and older.disagg = current.disagg
+    and older.line_spec_method = current.line_spec_method
+    and older.benchmark_type = current.benchmark_type
+    and older.isl is not distinct from current.isl
+    and older.osl is not distinct from current.osl
+    and older.offload_mode = current.offload_mode
+    and older.run_rank = current.run_rank + 1
+  where current.append_only
+    and current.image_count = 1
+    and current.images_complete
+    and older.image_count = 1
+    and older.images_complete
+    and older.image = current.root_image
+)
+select distinct on (
+  br.config_id,
+  br.benchmark_type,
+  br.isl,
+  br.osl,
+  br.offload_mode,
+  br.recipe_fingerprint,
+  br.conc
+)
+  br.*,
+  cr.snapshot_date,
+  cr.snapshot_workflow_run_id
+from curve_runs cr
+join benchmark_results br
+  on br.workflow_run_id = cr.workflow_run_id
+  and br.benchmark_type = cr.benchmark_type
+  and br.isl is not distinct from cr.isl
+  and br.osl is not distinct from cr.osl
+  and br.offload_mode = cr.offload_mode
+join configs point_c
+  on point_c.id = br.config_id
+  and point_c.model = cr.model
+  and point_c.hardware = cr.hardware
+  and point_c.framework = cr.framework
+  and point_c.precision = cr.precision
+  and point_c.disagg = cr.disagg
+  and case when br.benchmark_type = 'agentic_traces' then '' else point_c.spec_method end = cr.line_spec_method
+where br.error is null
+order by
+  br.config_id,
+  br.benchmark_type,
+  br.isl,
+  br.osl,
+  br.offload_mode,
+  br.recipe_fingerprint,
+  br.conc,
+  cr.run_rank;
+
+create unique index latest_benchmarks_pk
+  on latest_benchmarks (
+    config_id,
+    conc,
+    isl,
+    osl,
+    benchmark_type,
+    offload_mode,
+    recipe_fingerprint
+  )
+  nulls not distinct;
+create index latest_benchmarks_model_idx on latest_benchmarks (config_id);

--- a/packages/db/src/etl/benchmark-ingest.test.ts
+++ b/packages/db/src/etl/benchmark-ingest.test.ts
@@ -7,8 +7,10 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Sql } from './db-utils';
 import {
   benchmarkPointIngestKey,
+  bulkIngestBenchmarkRows,
   insertServerLogFilePaths,
   insertServerLogFiles,
+  type BenchmarkPersistenceInput,
 } from './benchmark-ingest';
 
 const point = (recipeFingerprint: string | null) => ({
@@ -54,6 +56,80 @@ function fakeTransactionSql(linkedId: number | null) {
   tag.begin = (fn: (tx: typeof tag) => Promise<void>) => fn(tag);
   return { sql: tag as Sql, calls };
 }
+
+function captureInsertSql() {
+  const calls: { text: string; values: unknown[] }[] = [];
+  const tag = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push({ text: strings.join('?').replaceAll(/\s+/gu, ' ').trim(), values });
+    return Promise.resolve([]);
+  }) as any;
+  tag.array = (value: unknown) => value;
+  return { sql: tag as Sql, calls };
+}
+
+describe('bulkIngestBenchmarkRows — power audit provenance lanes', () => {
+  const provenancedRow: BenchmarkPersistenceInput = {
+    configId: 7,
+    benchmarkType: 'single_turn',
+    isl: 1024,
+    osl: 1024,
+    conc: 64,
+    offloadMode: 'off',
+    image: 'img',
+    recipeFingerprint: null,
+    metrics: { power_valid: 0 },
+    powerInvalidReasons: ['sampling_gap_exceeded'],
+    powerAudit: {
+      window_start_unix: 1756174800,
+      window_end_unix: 1756175400,
+      expected_gpu_count: 8,
+      observed_gpu_count: 8,
+      sample_count: 4800,
+      max_sample_gap_s: 1.013,
+      producer_sha: null,
+      exporter_image_sha256: null,
+    },
+  };
+  const legacyRow: BenchmarkPersistenceInput = {
+    configId: 8,
+    benchmarkType: 'single_turn',
+    isl: 1024,
+    osl: 1024,
+    conc: 128,
+    offloadMode: 'off',
+    image: 'img',
+    recipeFingerprint: null,
+    metrics: { tput_per_gpu: 100 },
+  };
+
+  it('names both columns, adds two jsonb lanes, and refreshes both on conflict', async () => {
+    const { sql, calls } = captureInsertSql();
+    await bulkIngestBenchmarkRows(sql, [provenancedRow, legacyRow], 42, '2026-08-27');
+
+    const { text } = calls[0];
+    expect(text).toContain('metrics, workers, power_invalid_reasons, power_audit )');
+    // metrics + workers + power_invalid_reasons + power_audit
+    expect(text.match(/::jsonb\[\]/gu)).toHaveLength(4);
+    expect(text).toContain('power_invalid_reasons = excluded.power_invalid_reasons');
+    expect(text).toContain('power_audit = excluded.power_audit');
+  });
+
+  it('serializes present fields and contributes null lanes for absent ones', async () => {
+    const { sql, calls } = captureInsertSql();
+    await bulkIngestBenchmarkRows(sql, [provenancedRow, legacyRow], 42, '2026-08-27');
+
+    // Template value order mirrors the INSERT column list; the provenance
+    // lanes ride directly after metrics and workers.
+    const { values } = calls[0];
+    expect(values[10]).toEqual([
+      JSON.stringify(provenancedRow.metrics),
+      JSON.stringify(legacyRow.metrics),
+    ]);
+    expect(values[11]).toEqual([null, null]);
+    expect(values[12]).toEqual([JSON.stringify(provenancedRow.powerInvalidReasons), null]);
+    expect(values[13]).toEqual([JSON.stringify(provenancedRow.powerAudit), null]);
+  });
+});
 
 describe('insertServerLogFiles', () => {
   const files = [

--- a/packages/db/src/etl/benchmark-ingest.ts
+++ b/packages/db/src/etl/benchmark-ingest.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 
 import type postgres from 'postgres';
 import { cleanLogText, type ServerLogFile, type ServerLogFilePath } from './server-log-artifacts';
-import type { BenchmarkType, WorkerPower } from './benchmark-mapper';
+import type { BenchmarkType, PowerAudit, WorkerPower } from './benchmark-mapper';
 import { kvCachePoolTokensFromServerLog } from './server-log-metrics';
 
 type Sql = ReturnType<typeof postgres>;
@@ -23,6 +23,8 @@ export interface BenchmarkPersistenceInput {
   recipeFingerprint: string | null;
   metrics: Record<string, number>;
   workers?: WorkerPower[];
+  powerInvalidReasons?: string[];
+  powerAudit?: PowerAudit;
 }
 
 type BenchmarkPointIdentity = Pick<
@@ -88,11 +90,21 @@ export async function bulkIngestBenchmarkRows(
   const workersJsons = deduped.map((r) =>
     r.workers === undefined ? null : JSON.stringify(r.workers),
   );
+  // Same encoding for the power audit provenance columns: JSON null lanes
+  // keep the jsonb[] unnest inputs homogeneous and store SQL NULL for rows
+  // whose artifacts predate the provenance contract.
+  const powerInvalidReasonsJsons = deduped.map((r) =>
+    r.powerInvalidReasons === undefined ? null : JSON.stringify(r.powerInvalidReasons),
+  );
+  const powerAuditJsons = deduped.map((r) =>
+    r.powerAudit === undefined ? null : JSON.stringify(r.powerAudit),
+  );
 
   const result = await sql<{ inserted: boolean; id: number }[]>`
     insert into benchmark_results (
       workflow_run_id, config_id, benchmark_type, offload_mode, date,
-      isl, osl, conc, image, recipe_fingerprint, metrics, workers
+      isl, osl, conc, image, recipe_fingerprint, metrics, workers,
+      power_invalid_reasons, power_audit
     )
     select
       ${workflowRunId},
@@ -106,7 +118,9 @@ export async function bulkIngestBenchmarkRows(
       unnest(${sql.array(images)}),
       unnest(${sql.array(recipeFingerprints)}),
       unnest(${sql.array(metricsJsons)}::jsonb[]),
-      unnest(${sql.array(workersJsons)}::jsonb[])
+      unnest(${sql.array(workersJsons)}::jsonb[]),
+      unnest(${sql.array(powerInvalidReasonsJsons)}::jsonb[]),
+      unnest(${sql.array(powerAuditJsons)}::jsonb[])
     on conflict (
       workflow_run_id, config_id, benchmark_type, isl, osl, conc, offload_mode,
       recipe_fingerprint
@@ -120,7 +134,11 @@ export async function bulkIngestBenchmarkRows(
         jsonb_build_object('kv_cache_pool_tokens', benchmark_results.metrics->'kv_cache_pool_tokens')
       ),
       image = excluded.image,
-      workers = excluded.workers
+      workers = excluded.workers,
+      -- Like workers, the fresh artifact is authoritative for provenance: a
+      -- re-ingest from an artifact without the fields deliberately nulls them.
+      power_invalid_reasons = excluded.power_invalid_reasons,
+      power_audit = excluded.power_audit
     returning (xmax = 0) as inserted, id
   `;
 

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -915,6 +915,34 @@ describe('scrubWithheldPowerMetrics (direct — supplemental ingest path)', () =
       expect(metrics).not.toHaveProperty(key);
     }
   });
+
+  it('recovers provenance companions nested under metrics and leaves the record flat', () => {
+    // ingest-supplemental.ts also accepts the provenance companions nested in
+    // `metrics` (where power_valid rides in that format), extracting them via
+    // the shared narrowers and deleting the keys so the persisted metrics
+    // jsonb stays a flat numeric record. Pin that sequence.
+    const metrics = supplementalMetrics({
+      power_valid: 0,
+      power_invalid_reasons: ['sampling_gap_exceeded', 'sampling_gap_exceeded', '<img src=x>'],
+      power_audit: { sample_count: 12, producer_sha: 'abc123', unknown_key: true },
+    });
+    normalizePowerContractMetrics(metrics, metrics);
+    scrubWithheldPowerMetrics(metrics);
+    const reasons = extractPowerInvalidReasons(metrics.power_invalid_reasons);
+    const audit = extractPowerAudit(metrics.power_audit);
+    delete metrics.power_invalid_reasons;
+    delete metrics.power_audit;
+
+    expect(reasons).toEqual(['sampling_gap_exceeded']);
+    expect(audit).toEqual({
+      sample_count: 12,
+      producer_sha: 'abc123',
+      exporter_image_sha256: null,
+    });
+    expect(metrics).not.toHaveProperty('power_invalid_reasons');
+    expect(metrics).not.toHaveProperty('power_audit');
+    expect(metrics.tput_per_gpu).toBe(567.8);
+  });
 });
 
 describe('extractWorkers', () => {

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MEASURED_POWER_METRIC_KEYS } from '@semianalysisai/inferencex-constants';
 import {
+  extractPowerAudit,
+  extractPowerInvalidReasons,
   extractWorkers,
   mapBenchmarkRow,
   normalizePowerContractMetrics,
@@ -425,10 +427,9 @@ describe('mapBenchmarkRow', () => {
 
     it('tolerates the invalid-verdict companion fields without scrubbing them', () => {
       // PLAN-06 producers ship power_invalid_reasons / power_audit alongside
-      // power_valid=0. The scrub must never touch them; persisting them
-      // app-side is PLAN-07 — today's pinned behavior is that non-numeric
-      // fields simply never land in the numeric metrics record (parseNum
-      // drops arrays/objects).
+      // power_valid=0. The scrub must never touch them: they exist to explain
+      // it, riding dedicated BenchmarkParams fields — never the numeric
+      // metrics record.
       const tracker = createSkipTracker();
       const result = mapBenchmarkRow(
         makeV2Row({
@@ -449,6 +450,13 @@ describe('mapBenchmarkRow', () => {
       }
       expect(result!.metrics).not.toHaveProperty('power_invalid_reasons');
       expect(result!.metrics).not.toHaveProperty('power_audit');
+      expect(result!.powerInvalidReasons).toEqual(['window_too_short']);
+      expect(result!.powerAudit).toEqual({
+        window_start_unix: 1,
+        window_end_unix: 2,
+        producer_sha: null,
+        exporter_image_sha256: null,
+      });
     });
   });
 
@@ -990,6 +998,241 @@ describe('extractWorkers', () => {
 
   it('returns undefined when every entry is malformed', () => {
     expect(extractWorkers([null, 'bad', 0, undefined])).toBeUndefined();
+  });
+});
+
+describe('extractPowerInvalidReasons', () => {
+  it('keeps valid snake_case codes in first-seen order', () => {
+    expect(
+      extractPowerInvalidReasons(['sampling_gap_exceeded', 'expected_gpu_count_mismatch']),
+    ).toEqual(['sampling_gap_exceeded', 'expected_gpu_count_mismatch']);
+  });
+
+  it('deduplicates preserving first-seen order', () => {
+    expect(
+      extractPowerInvalidReasons([
+        'telemetry_file_missing',
+        'no_usable_power_samples',
+        'telemetry_file_missing',
+      ]),
+    ).toEqual(['telemetry_file_missing', 'no_usable_power_samples']);
+  });
+
+  it.each([
+    ['non-string entry', [42]],
+    ['empty string', ['']],
+    ['hyphenated code', ['Bad-Reason']],
+    ['uppercase code', ['UPPER']],
+    ['leading digit', ['9lives']],
+    ['65-char code', ['a'.repeat(65)]],
+  ])('silently drops %s', (_name, raw) => {
+    expect(extractPowerInvalidReasons(raw)).toBeUndefined();
+  });
+
+  it('drops malformed entries while keeping valid siblings', () => {
+    expect(extractPowerInvalidReasons([42, 'sampling_gap_exceeded', '<img src=x>', null])).toEqual([
+      'sampling_gap_exceeded',
+    ]);
+  });
+
+  it('keeps a 64-char code (boundary)', () => {
+    const code = 'a'.repeat(64);
+    expect(extractPowerInvalidReasons([code])).toEqual([code]);
+  });
+
+  it('caps the result at 32 codes', () => {
+    const raw = Array.from({ length: 40 }, (_v, i) => `reason_${i}`);
+    const result = extractPowerInvalidReasons(raw);
+    expect(result).toHaveLength(32);
+    expect(result![0]).toBe('reason_0');
+    expect(result![31]).toBe('reason_31');
+  });
+
+  it.each([
+    ['empty array', []],
+    ['non-array object', { reason: 'x' }],
+    ['string', 'sampling_gap_exceeded'],
+    ['null', null],
+    ['undefined', undefined],
+  ])('returns undefined (never []) for %s', (_name, raw) => {
+    expect(extractPowerInvalidReasons(raw)).toBeUndefined();
+  });
+});
+
+describe('extractPowerAudit', () => {
+  /** Full valid audit as aggregate_power.py emits it on a multinode run. */
+  const fullAudit = {
+    window_start_unix: 1756174800.25,
+    window_end_unix: 1756175400.75,
+    expected_gpu_count: 16,
+    observed_gpu_count: 16,
+    sample_count: 9600,
+    max_sample_gap_s: 1.013,
+    producer_sha: '887a6cb7c2ec174e5e2b977468a12ab34cd56ef7',
+    exporter_image_sha256:
+      'sha256:0b7f1a2c3d4e5f60718293a4b5c6d7e8f9012a3b4c5d6e7f8091a2b3c4d5e6f7',
+  };
+
+  it('round-trips a full valid object across all 8 fields', () => {
+    expect(extractPowerAudit(fullAudit)).toEqual(fullAudit);
+  });
+
+  it('omits Infinity / NaN / junk-string numerics (partial audit beats none)', () => {
+    expect(
+      extractPowerAudit({
+        ...fullAudit,
+        window_start_unix: Number.POSITIVE_INFINITY,
+        window_end_unix: Number.NaN,
+        max_sample_gap_s: 'garbage',
+      }),
+    ).toEqual({
+      expected_gpu_count: 16,
+      observed_gpu_count: 16,
+      sample_count: 9600,
+      producer_sha: fullAudit.producer_sha,
+      exporter_image_sha256: fullAudit.exporter_image_sha256,
+    });
+  });
+
+  it('rejects negative and non-safe-integer counts', () => {
+    expect(
+      extractPowerAudit({
+        ...fullAudit,
+        expected_gpu_count: -1,
+        observed_gpu_count: Number.MAX_SAFE_INTEGER + 1,
+        sample_count: Number.POSITIVE_INFINITY,
+      }),
+    ).toEqual({
+      window_start_unix: fullAudit.window_start_unix,
+      window_end_unix: fullAudit.window_end_unix,
+      max_sample_gap_s: fullAudit.max_sample_gap_s,
+      producer_sha: fullAudit.producer_sha,
+      exporter_image_sha256: fullAudit.exporter_image_sha256,
+    });
+  });
+
+  it('keeps shas trimmed and collapses null / number / oversized shas to null', () => {
+    expect(
+      extractPowerAudit({
+        sample_count: 1,
+        producer_sha: '  abc123  ',
+        exporter_image_sha256: null,
+      }),
+    ).toEqual({ sample_count: 1, producer_sha: 'abc123', exporter_image_sha256: null });
+    expect(
+      extractPowerAudit({
+        sample_count: 1,
+        producer_sha: 42,
+        exporter_image_sha256: 'x'.repeat(129),
+      }),
+    ).toEqual({ sample_count: 1, producer_sha: null, exporter_image_sha256: null });
+  });
+
+  it('nulls the explicit-null numeric fields a producer emits without a benchmark window', () => {
+    // aggregate_power.py sets window_* / max_sample_gap_s to null when the
+    // benchmark result was unreadable; those are omitted, not kept as null.
+    expect(
+      extractPowerAudit({
+        window_start_unix: null,
+        window_end_unix: null,
+        expected_gpu_count: 8,
+        observed_gpu_count: 0,
+        sample_count: 0,
+        max_sample_gap_s: null,
+        producer_sha: null,
+        exporter_image_sha256: null,
+      }),
+    ).toEqual({
+      expected_gpu_count: 8,
+      observed_gpu_count: 0,
+      sample_count: 0,
+      producer_sha: null,
+      exporter_image_sha256: null,
+    });
+  });
+
+  it('drops unknown keys (fixed 8-key shape bounds the stored object)', () => {
+    expect(extractPowerAudit({ sample_count: 3, integration_method: 'trapezoid' })).toEqual({
+      sample_count: 3,
+      producer_sha: null,
+      exporter_image_sha256: null,
+    });
+  });
+
+  it.each([
+    ['string', 'audit'],
+    ['array', [1, 2]],
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 7],
+  ])('returns undefined for non-object input: %s', (_name, raw) => {
+    expect(extractPowerAudit(raw)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty husk (no numerics, both shas null)', () => {
+    expect(extractPowerAudit({})).toBeUndefined();
+    expect(extractPowerAudit({ producer_sha: null, exporter_image_sha256: 42 })).toBeUndefined();
+    expect(extractPowerAudit({ window_start_unix: 'junk' })).toBeUndefined();
+  });
+});
+
+describe('mapBenchmarkRow — power audit provenance', () => {
+  const reasons = ['sampling_gap_exceeded', 'expected_gpu_count_mismatch'];
+  const audit = {
+    window_start_unix: 1756174800,
+    window_end_unix: 1756175400,
+    expected_gpu_count: 8,
+    observed_gpu_count: 8,
+    sample_count: 4800,
+    max_sample_gap_s: 1.013,
+    producer_sha: null,
+    exporter_image_sha256: null,
+  };
+
+  it.each([
+    ['v1', makeV1Row],
+    ['v2', makeV2Row],
+    ['agentic', makeAgenticRow],
+  ])('lands the contract fields on BenchmarkParams for %s rows', (_name, makeRow) => {
+    const tracker = createSkipTracker();
+    const result = mapBenchmarkRow(
+      makeRow({ power_valid: 0, power_invalid_reasons: reasons, power_audit: audit }),
+      tracker,
+    );
+    expect(result!.powerInvalidReasons).toEqual(reasons);
+    expect(result!.powerAudit).toEqual(audit);
+  });
+
+  it('stores provenance from valid rows too (tolerance in both directions)', () => {
+    const tracker = createSkipTracker();
+    const result = mapBenchmarkRow(makeV2Row({ power_valid: 1, power_audit: audit }), tracker);
+    expect(result!.metrics.power_valid).toBe(1);
+    expect(result!.powerAudit).toEqual(audit);
+    expect(result!.powerInvalidReasons).toBeUndefined();
+  });
+
+  it('leaves both fields undefined on legacy rows', () => {
+    const tracker = createSkipTracker();
+    const result = mapBenchmarkRow(makeV2Row(), tracker);
+    expect(result!.powerInvalidReasons).toBeUndefined();
+    expect(result!.powerAudit).toBeUndefined();
+  });
+
+  it("never captures a malformed ['5'] reasons array as a numeric metric", () => {
+    // Number(['5']) === 5 — without the NON_METRIC_KEYS guard the generic
+    // capture loop would mint a bogus power_invalid_reasons numeric metric.
+    const tracker = createSkipTracker();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = mapBenchmarkRow(makeV2Row({ power_invalid_reasons: ['5'] }), tracker);
+      expect(result!.metrics).not.toHaveProperty('power_invalid_reasons');
+      expect(result!.powerInvalidReasons).toBeUndefined();
+      expect(warn.mock.calls.map((call) => String(call[0]))).not.toContainEqual(
+        expect.stringContaining('power_invalid_reasons'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -86,6 +86,12 @@ const NON_METRIC_KEYS = new Set([
   // sibling of the metrics JSONB by mapBenchmarkRow so the metrics column
   // stays Record<string, number> for the index signature on BenchmarkRow.
   'workers',
+  // Power audit provenance (array / object, never scalars). Extracted into
+  // dedicated BenchmarkParams fields by mapBenchmarkRow. Listed here because
+  // Number(['5']) === 5: without the guard a malformed single-element reasons
+  // array would be auto-captured as a bogus numeric metric.
+  'power_invalid_reasons',
+  'power_audit',
 ]);
 
 /**
@@ -126,6 +132,25 @@ export interface WorkerPower {
   avg_mem_used_mb?: number;
 }
 
+/**
+ * Compact measurement-window audit emitted by aggregate_power.py alongside
+ * the power_valid verdict (present on valid and invalid rows alike). All
+ * fields optional: {@link extractPowerAudit} omits malformed numerics rather
+ * than dropping the whole object, and single-node telemetry has no srt-slurm
+ * producer so both shas are null there. Stored on benchmark_results in the
+ * dedicated `power_audit` JSONB column (migration 014).
+ */
+export interface PowerAudit {
+  window_start_unix?: number;
+  window_end_unix?: number;
+  expected_gpu_count?: number;
+  observed_gpu_count?: number;
+  sample_count?: number;
+  max_sample_gap_s?: number;
+  producer_sha?: string | null;
+  exporter_image_sha256?: string | null;
+}
+
 export interface BenchmarkParams {
   config: ConfigParams;
   benchmarkType: BenchmarkType;
@@ -148,6 +173,19 @@ export interface BenchmarkParams {
    * predating the multinode patch.
    */
   workers?: WorkerPower[];
+  /**
+   * Producer reason codes explaining a withheld power verdict
+   * (aggregate_power.py emits them when power_valid == 0). Stored in the
+   * dedicated `power_invalid_reasons` JSONB column (migration 014).
+   * Undefined for legacy artifacts and rows with a valid verdict.
+   */
+  powerInvalidReasons?: string[];
+  /**
+   * Compact power measurement-window audit from the same producer contract.
+   * Stored in the dedicated `power_audit` JSONB column (migration 014).
+   * Undefined for legacy artifacts predating the provenance contract.
+   */
+  powerAudit?: PowerAudit;
 }
 
 /**
@@ -358,6 +396,12 @@ export function mapBenchmarkRow(
   // narrowing — anything other than a non-empty array of objects is dropped,
   // and a withheld power verdict drops the payload entirely.
   const workers = powerWithheld ? undefined : extractWorkers(row.workers);
+  // Audit provenance is extracted unconditionally on power_valid: the
+  // contract says reasons appear when power_valid == 0, but the app stores
+  // whatever validly arrives — tolerance in both directions, and no data
+  // loss if a future producer annotates valid rows too.
+  const powerInvalidReasons = extractPowerInvalidReasons(row.power_invalid_reasons);
+  const powerAudit = extractPowerAudit(row.power_audit);
 
   return {
     config: {
@@ -379,6 +423,8 @@ export function mapBenchmarkRow(
     recipeFingerprint,
     metrics,
     workers,
+    powerInvalidReasons,
+    powerAudit,
   };
 }
 
@@ -503,8 +549,9 @@ export function normalizePowerContractMetrics(
  * normalized verdict is an explicit invalid (power_valid === 0), delete
  * every measured power/energy/telemetry metric so withheld measurements
  * can never be persisted or served, even if a producer regression ships
- * them. Keeps power_valid and power_metric_schema_version (and any
- * future companion fields such as power_invalid_reasons / power_audit).
+ * them. Keeps power_valid and power_metric_schema_version (the
+ * companion power_invalid_reasons / power_audit provenance never enters
+ * metrics at all — it rides dedicated BenchmarkParams fields).
  * Legacy rows without a verdict are untouched. Returns true when the
  * row's power is withheld so the caller also drops the workers payload.
  * This is the single enforcement policy at ingest: every mapBenchmarkRow
@@ -563,4 +610,92 @@ export function extractWorkers(raw: unknown): WorkerPower[] | undefined {
     out.push(w);
   }
   return out.length > 0 ? out : undefined;
+}
+
+/** Producer reason codes are lowercase snake_case identifiers. */
+const POWER_REASON_CODE_RE = /^[a-z][a-z0-9_]*$/u;
+const MAX_POWER_REASON_CODES = 32;
+const MAX_POWER_REASON_LENGTH = 64;
+const MAX_POWER_AUDIT_SHA_LENGTH = 128;
+
+/**
+ * Narrow a raw `power_invalid_reasons` value from the artifact JSON to
+ * `string[]` or undefined. Entries must be snake_case strings (length ≤ 64
+ * after trim) to be kept; anything else is dropped silently (same policy as
+ * `extractWorkers`). Deduplicates preserving first-seen order and caps the
+ * result at 32 codes. Returns undefined for any non-array input or an empty
+ * result so the eventual JSONB column stores null rather than `[]`.
+ */
+export function extractPowerInvalidReasons(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of raw) {
+    if (typeof entry !== 'string') continue;
+    const code = entry.trim();
+    if (code.length === 0 || code.length > MAX_POWER_REASON_LENGTH) continue;
+    if (!POWER_REASON_CODE_RE.test(code) || seen.has(code)) continue;
+    seen.add(code);
+    out.push(code);
+    if (out.length >= MAX_POWER_REASON_CODES) break;
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+/** parseNum plus a finiteness guard: parseNum passes Infinity through. */
+function auditFiniteNum(v: unknown): number | undefined {
+  const n = parseNum(v);
+  return n !== undefined && Number.isFinite(n) ? n : undefined;
+}
+
+/** GPU/sample counts must be non-negative safe integers. */
+function auditCount(v: unknown): number | undefined {
+  const n = parseInt2(v);
+  return n !== undefined && Number.isSafeInteger(n) && n >= 0 ? n : undefined;
+}
+
+/** Trimmed non-empty string of bounded length, anything else → null. */
+function auditSha(v: unknown): string | null {
+  if (typeof v !== 'string') return null;
+  const s = v.trim();
+  return s.length > 0 && s.length <= MAX_POWER_AUDIT_SHA_LENGTH ? s : null;
+}
+
+/**
+ * Narrow a raw `power_audit` value from the artifact JSON to a fixed 8-key
+ * {@link PowerAudit} or undefined. Field-by-field: window/gap fields must be
+ * finite numbers, counts must be non-negative safe integers; malformed
+ * numerics are omitted, since a partial audit beats none. The shas keep a
+ * trimmed non-empty string of length ≤ 128 and collapse anything else
+ * (including explicit null) to null, matching the contract's string|null.
+ * Unknown keys are dropped so the stored object stays bounded. Returns
+ * undefined for non-object input and for an empty husk (no numeric field
+ * survived and both shas are null) so the eventual JSONB column stores null
+ * rather than `{}`.
+ */
+export function extractPowerAudit(raw: unknown): PowerAudit | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
+  const e = raw as Record<string, unknown>;
+  const audit: PowerAudit = {};
+
+  const window_start_unix = auditFiniteNum(e.window_start_unix);
+  if (window_start_unix !== undefined) audit.window_start_unix = window_start_unix;
+  const window_end_unix = auditFiniteNum(e.window_end_unix);
+  if (window_end_unix !== undefined) audit.window_end_unix = window_end_unix;
+  const max_sample_gap_s = auditFiniteNum(e.max_sample_gap_s);
+  if (max_sample_gap_s !== undefined) audit.max_sample_gap_s = max_sample_gap_s;
+  const expected_gpu_count = auditCount(e.expected_gpu_count);
+  if (expected_gpu_count !== undefined) audit.expected_gpu_count = expected_gpu_count;
+  const observed_gpu_count = auditCount(e.observed_gpu_count);
+  if (observed_gpu_count !== undefined) audit.observed_gpu_count = observed_gpu_count;
+  const sample_count = auditCount(e.sample_count);
+  if (sample_count !== undefined) audit.sample_count = sample_count;
+  const hasNumericField = Object.keys(audit).length > 0;
+
+  audit.producer_sha = auditSha(e.producer_sha);
+  audit.exporter_image_sha256 = auditSha(e.exporter_image_sha256);
+  if (!hasNumericField && audit.producer_sha === null && audit.exporter_image_sha256 === null) {
+    return undefined;
+  }
+  return audit;
 }

--- a/packages/db/src/ingest-supplemental.ts
+++ b/packages/db/src/ingest-supplemental.ts
@@ -27,7 +27,12 @@ import {
   bulkUpsertAvailability,
   type BenchmarkPersistenceInput,
 } from './etl/benchmark-ingest';
-import { normalizePowerContractMetrics, scrubWithheldPowerMetrics } from './etl/benchmark-mapper';
+import {
+  extractPowerAudit,
+  extractPowerInvalidReasons,
+  normalizePowerContractMetrics,
+  scrubWithheldPowerMetrics,
+} from './etl/benchmark-mapper';
 import { ingestEvalRow } from './etl/eval-ingest';
 
 const sql = createAdminSql({
@@ -180,6 +185,10 @@ interface SupplementalBmk {
   is_multinode?: boolean;
   prefill_num_workers?: number;
   decode_num_workers?: number;
+  /** Producer power-audit provenance (PLAN-06 contract), sibling to `metrics`
+   * like on artifact rows; narrowed by the shared extractors. */
+  power_invalid_reasons?: unknown;
+  power_audit?: unknown;
 }
 
 async function ingestSupplementalBmk(
@@ -271,6 +280,17 @@ async function ingestSupplementalBmk(
       // then strip withheld measurements when power_valid=0.
       normalizePowerContractMetrics(entry.metrics, entry.metrics);
       scrubWithheldPowerMetrics(entry.metrics);
+      // The provenance companions ride the entry itself (sibling to the flat
+      // numeric `metrics` record), but accept a nesting under `metrics` too —
+      // power_valid lives there in this format. Delete the keys from `metrics`
+      // either way so the structured companions never enter the persisted
+      // metrics jsonb (the NON_METRIC_KEYS guarantee on the mapper path).
+      const powerInvalidReasons = extractPowerInvalidReasons(
+        entry.power_invalid_reasons ?? entry.metrics.power_invalid_reasons,
+      );
+      const powerAudit = extractPowerAudit(entry.power_audit ?? entry.metrics.power_audit);
+      delete entry.metrics.power_invalid_reasons;
+      delete entry.metrics.power_audit;
 
       rows.push({
         configId,
@@ -282,6 +302,8 @@ async function ingestSupplementalBmk(
         image: entry.image,
         recipeFingerprint: null,
         metrics: entry.metrics,
+        powerInvalidReasons,
+        powerAudit,
       });
     }
 

--- a/packages/db/src/queries/benchmarks.test.ts
+++ b/packages/db/src/queries/benchmarks.test.ts
@@ -113,3 +113,45 @@ describe('append-only benchmark snapshots', () => {
     expect(values).toEqual([['dsv4']]);
   });
 });
+
+describe('power audit provenance reads (tolerant to a not-yet-applied migration 014)', () => {
+  const TOLERANT_BR = [
+    "to_jsonb(br) -> 'power_invalid_reasons' AS power_invalid_reasons",
+    "to_jsonb(br) -> 'power_audit' AS power_audit",
+  ];
+
+  it('selects both columns via to_jsonb on the exact-run path', async () => {
+    const captured = captureSql();
+    await getBenchmarksForRun(captured.sql, 'dsv4', 123456);
+    const { text } = captured.query();
+    for (const piece of TOLERANT_BR) expect(text).toContain(piece);
+    expect(text).not.toMatch(/\b(?:br|lb)\.power_(?:invalid_reasons|audit)\b/u);
+  });
+
+  it('selects both columns via to_jsonb on the dated latest path', async () => {
+    const captured = captureSql();
+    await getLatestBenchmarks(captured.sql, 'dsv4', '2026-08-01');
+    const { text } = captured.query();
+    for (const piece of TOLERANT_BR) expect(text).toContain(piece);
+    expect(text).not.toMatch(/\b(?:br|lb)\.power_(?:invalid_reasons|audit)\b/u);
+  });
+
+  it('selects both columns via to_jsonb on the history path', async () => {
+    const captured = captureSql();
+    await getAllBenchmarksForHistory(captured.sql, 'dsv4', 8192, 1024);
+    const { text } = captured.query();
+    for (const piece of TOLERANT_BR) expect(text).toContain(piece);
+    expect(text).not.toMatch(/\b(?:br|lb)\.power_(?:invalid_reasons|audit)\b/u);
+  });
+
+  it('selects both columns via to_jsonb on the no-date matview path', async () => {
+    const captured = captureSql();
+    await getLatestBenchmarks(captured.sql, 'dsv4');
+    const { text } = captured.query();
+    expect(text).toContain("to_jsonb(lb) -> 'power_invalid_reasons' AS power_invalid_reasons");
+    expect(text).toContain("to_jsonb(lb) -> 'power_audit' AS power_audit");
+    // The #407 lesson, pinned: a bare column reference would fail to PLAN
+    // until the next ingest run applies migration 014.
+    expect(text).not.toMatch(/\b(?:br|lb)\.power_(?:invalid_reasons|audit)\b/u);
+  });
+});

--- a/packages/db/src/queries/benchmarks.ts
+++ b/packages/db/src/queries/benchmarks.ts
@@ -1,6 +1,6 @@
 import type { DbClient } from '../connection.js';
-import type { WorkerPower } from '../etl/benchmark-mapper.js';
-export type { WorkerPower } from '../etl/benchmark-mapper.js';
+import type { PowerAudit, WorkerPower } from '../etl/benchmark-mapper.js';
+export type { PowerAudit, WorkerPower } from '../etl/benchmark-mapper.js';
 
 /**
  * One entry in `BenchmarkRow.workers` — mirrors the runner's aggregate_power.py
@@ -47,6 +47,18 @@ export interface BenchmarkRow {
    * aggregate_power.py's multinode patch — surfaced as undefined here.
    */
   workers?: BenchmarkWorkerRow[];
+  /**
+   * Producer reason codes explaining a withheld power verdict. Stored in the
+   * dedicated `power_invalid_reasons` JSONB column (migration 014).
+   * Null/undefined on legacy rows and rows from valid runs.
+   */
+  power_invalid_reasons?: string[] | null;
+  /**
+   * Compact power measurement-window audit from the producer contract.
+   * Stored in the dedicated `power_audit` JSONB column (migration 014).
+   * Null/undefined on legacy rows predating the provenance contract.
+   */
+  power_audit?: PowerAudit | null;
   date: string;
   /** Producer identity and timestamp; preserved for per-point provenance. */
   workflow_run_id?: number;
@@ -256,6 +268,12 @@ function executeRecursiveBenchmarkQuery(
       br.recipe_fingerprint,
       ${plan.metricsExpression},
       br.workers,
+      -- Deploy-order tolerance (the #405/#407 lesson): a bare br.power_* column
+      -- reference fails at query PLAN time until the next ingest run applies
+      -- migration 014. The jsonb key lookup degrades to NULL while the column
+      -- is missing and is byte-identical once it exists.
+      to_jsonb(br) -> 'power_invalid_reasons' AS power_invalid_reasons,
+      to_jsonb(br) -> 'power_audit' AS power_audit,
       br.date::text,
       br.workflow_run_id,
       wr.run_started_at::text,
@@ -451,6 +469,10 @@ export async function getLatestBenchmarks(
       lb.recipe_fingerprint,
       lb.metrics,
       lb.workers,
+      -- Same deploy-order tolerance as the recursive branch: NULL until
+      -- migration 014 recreates latest_benchmarks, identical afterwards.
+      to_jsonb(lb) -> 'power_invalid_reasons' AS power_invalid_reasons,
+      to_jsonb(lb) -> 'power_audit' AS power_audit,
       lb.date::text,
       lb.workflow_run_id,
       wr.run_started_at::text,


### PR DESCRIPTION
> [!IMPORTANT]
> **STACKED PR — do not merge out of order.** Base is `klaud/powerx-04-api-contract` (#921), which is itself stacked on #909. Merge order: **#909 → #921 → this PR**. This PR contains only the PLAN-07 deltas relative to #921.

Implements PLAN-07: ingest and expose the power audit provenance fields (`power_invalid_reasons`, `power_audit`) that the producer (InferenceX `aggregate_power.py`, PLAN-06) emits alongside the `power_valid` verdict. PLAN-04 (#921) reserved the two fields in the OpenAPI schema; this PR turns them live end-to-end while remaining fully tolerant of their absence (legacy artifacts, pre-PLAN-06 runs, legacy DB rows).

## What changed

**Storage — migration `014_power_provenance.sql`**
- Two dedicated `jsonb` columns on `benchmark_results` (`power_invalid_reasons`, `power_audit`), mirroring the migration-006 `workers` precedent: `metrics` is a flat `Record<string, number>`, so structured data gets its own columns.
- Recreates `latest_benchmarks` with the migration-012 definition **verbatim** (recursive append-only-curve body plus both indexes) solely so `br.*` picks up the new columns — not the obsolete 006 definition.

**ETL — `benchmark-mapper.ts`**
- Both keys join `NON_METRIC_KEYS`: `Number(['5']) === 5`, so without the guard a malformed single-element reasons array would be auto-captured as a bogus numeric metric.
- `extractPowerInvalidReasons`: keeps snake_case codes (≤ 64 chars), dedupes preserving order, caps at 32; empty result → `undefined` so the column stores SQL NULL, never `[]`.
- `extractPowerAudit`: fixed 8-key shape (`window_start_unix`, `window_end_unix`, `expected_gpu_count`, `observed_gpu_count`, `sample_count`, `max_sample_gap_s`, `producer_sha`, `exporter_image_sha256`); finite-number/safe-integer narrowing, malformed numerics omitted (partial audit beats none), shas collapse to `null` per the contract's `string|null`, unknown keys dropped, empty husk → `undefined`.
- Extraction is unconditional on `power_valid` — tolerance in both directions.
- No changes needed in `ingest-ci-run.ts` or `run-overrides.ts`: the persistence input is built by spreading (`{...row, configId}` / `applyBenchmarkPointBackfill`'s `{...point}`), so the new `BenchmarkParams` fields flow through.

**Ingest — `benchmark-ingest.ts`**
- Two jsonb `unnest` lanes mirroring `workers`; NULL when absent; `excluded.*` refresh on conflict (fresh artifact is authoritative, same as `workers`).

**Reads — `queries/benchmarks.ts` (deploy-order safety, the #405/#407 lesson)**
- All four read paths select the columns as `to_jsonb(br) -> 'power_invalid_reasons'` / `to_jsonb(lb) -> ...` — never bare column references. Migrations run in the ingest workflows, not at Vercel deploy; a bare reference fails at query *plan* time until the next ingest applies migration 014, which is exactly how PR #405 produced a ~63% error rate. The jsonb key lookup degrades to NULL while the column is missing and is byte-identical once it exists, so merge order and deploy timing are irrelevant. A regression test pins the tolerant form with a negative regex.

**API & frontend**
- `/api/v1/benchmarks` and `/history` return the fields verbatim when stored; calculator view strips them (payload-trimmed projection excludes measured-power data by design); unofficial-run overlay rows carry both fields via the shared mapper.
- Chart tooltips (official + unofficial overlay) render a muted bilingual "Measured power withheld / 实测功耗未采信" line only when the point carries reasons; codes are re-validated against the snake_case regex before HTML interpolation (tooltips are raw HTML strings).
- OpenAPI schema wording moves from "Reserved (forthcoming)" to live; `api-route-catalog.ts` digests refreshed for the two changed contract sources.
- `power_audit` is API-only — no UI surface (follow-up).

## Testing

- `bun run --cwd packages/db test:unit` — 650 passed (extractor suites, mapper integration incl. the `['5']` guard, ingest lane recording-mock, query-shape assertions with the bare-reference regex guard, supplemental-path provenance sequence)
- `bun run --cwd packages/app test:unit` — 4491 passed (transform narrowing, tooltip en/zh + injection filtering + overlay parity, unofficial-run overlay parity, calculator strip, OpenAPI docs invariants, catalog guard)
- `bun run typecheck` / `bun run lint` / `bun run fmt` — clean
- Note: `packages/mcp` `server.test.ts` fails identically on the base branch in this environment (`z.enum` undefined — zod resolution, unrelated to this change).

Deploy-order proof: this PR's Vercel preview serves `/api/v1/benchmarks` against the un-migrated production DB with the two keys null — the live demonstration of the tolerant-read design. The next `stage-results`/ingest run applies migration 014 and new ingests populate the columns.

## Review

Two independent review passes ran over the implementation; one approved with no findings, the other approved with two nits, both addressed:

1. **Supplemental ingest lane dropped provenance (CONFIRMED, nit)** — `ingest-supplemental.ts` participates in the power publication contract (PLAN-03's normalize + scrub) but built its persistence input without `powerInvalidReasons`/`powerAudit`, so a supplemental entry carrying the fields would persist NULL columns silently. **Fixed** in the follow-up commit: the lane now extracts both via the shared narrowers (entry-level fields sibling to `metrics`, with a metrics-nested fallback since `power_valid` rides in `metrics` in that format) and deletes the keys from `metrics` so the persisted jsonb stays a flat numeric record; the call sequence is pinned next to the PLAN-03 supplemental tests.
2. **Vercel-preview live proof not independently probed (PLAUSIBLE, nit)** — the preview deployment is auth-protected (302), so the reviewer could not hit `/api/v1/benchmarks` directly. Indirect evidence is strong (green Vercel check, `to_jsonb` reads pinned by a negative-regex test, Postgres jsonb semantics), but a human with Vercel access should hit the preview once and confirm 200 with `power_invalid_reasons`/`power_audit` null before merging the stack.

## 中文说明

> **堆叠 PR——请勿乱序合并。** 基础分支为 `klaud/powerx-04-api-contract`（#921），后者又堆叠在 #909 之上。合并顺序：**#909 → #921 → 本 PR**。

实现 PLAN-07：摄取并公开生产端（InferenceX `aggregate_power.py`，PLAN-06）随 `power_valid` 判定一同产出的功耗审计溯源字段（`power_invalid_reasons`、`power_audit`）。PLAN-04（#921）已在 OpenAPI 中预留这两个字段；本 PR 将其全链路转正，并对字段缺失（旧产物、早于 PLAN-06 的运行、历史数据行）保持完全兼容。

- **存储**：迁移 014 在 `benchmark_results` 上新增两个专用 `jsonb` 列（沿用迁移 006 `workers` 的先例），并按迁移 012 的定义原样重建 `latest_benchmarks`，使 `br.*` 覆盖新列。
- **ETL**：`mapBenchmarkRow` 防御性收窄两个字段（snake_case 原因码去重限长限量；审计对象固定 8 键、剔除非法数值、sha 归一化为 `string|null`、丢弃未知键；空结果映射为 `undefined` 以存储 SQL NULL）；两个键加入 `NON_METRIC_KEYS`，避免 `Number(['5']) === 5` 生成伪数值指标。
- **摄取**：批量插入新增两条 jsonb 通道，缺失即 NULL，冲突时以新产物为准刷新。
- **读取（部署顺序安全，#405/#407 教训）**：四条读取路径一律使用 `to_jsonb(...) -> 'col'` 容错形式，列尚未迁移时读取为 NULL，迁移后逐字节等价，合并与部署顺序均无关；回归测试用反向正则钉死该形式。
- **API 与前端**：公开 API 原样返回字段；计算器视图剥离；非官方叠加行同样携带；图表提示框仅在存在原因码时渲染双语"实测功耗未采信"行，且在 HTML 插值前再次校验原因码；OpenAPI 文案由预留改为正式，契约摘要已刷新。

测试：db 包 650 项、app 包 4491 项全部通过；typecheck / lint / fmt 干净。（`packages/mcp` 的 `server.test.ts` 在本地环境于基础分支上即失败，与本变更无关。）

评审：两轮独立评审均通过，其中一轮提出两条次要意见——补充数据摄取通道（`ingest-supplemental.ts`）此前未持久化溯源字段，已在后续提交中修复并以单测钉住调用序列；Vercel 预览部署受访问保护，评审无法直接探测，请有权限的同事在合并前访问预览的 `/api/v1/benchmarks` 确认返回 200 且两个新键为 null。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark ingest, matview recreation, and all benchmark read SQL; deploy-order tolerance mitigates migration timing, but a bad matview rebuild or ingest regression could affect latest-curve queries and power tooltip HTML.
> 
> **Overview**
> **PLAN-07** turns `power_invalid_reasons` and `power_audit` from reserved API placeholders into live end-to-end provenance for measured-power verdicts from `aggregate_power.py`.
> 
> **Storage & ingest:** Migration **014** adds dedicated JSONB columns on `benchmark_results` (same pattern as `workers`) and rebuilds `latest_benchmarks` so the matview includes them. `mapBenchmarkRow` extracts and narrows both fields (`extractPowerInvalidReasons` / `extractPowerAudit`), keeps them out of flat `metrics` via `NON_METRIC_KEYS`, and bulk ingest writes them with NULL lanes for legacy rows.
> 
> **Reads:** All benchmark query paths select via `to_jsonb(...) -> 'power_*'` so deploys stay safe before migration 014 is applied on ingest (avoids the #405/#407 plan-time failure mode).
> 
> **API & UI:** Public benchmark rows and unofficial-run overlays surface the fields; the calculator trim strips them. Chart tooltips add a bilingual **“Measured power withheld”** line when reason codes exist, with snake_case re-validation before raw HTML. OpenAPI/docs drop “forthcoming” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6a0eeb758773a58f7df8320f87bf835cc0d4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
