### PR TITLE
feat(powerx): annotate measurement window and reconcile trace vs published power | PowerX：标注测量窗口并对账原始轨迹与已发布功耗

### DIFF
--- a/packages/app/cypress/e2e/gpu-power.cy.ts
+++ b/packages/app/cypress/e2e/gpu-power.cy.ts
@@ -90,5 +90,41 @@ describe('PowerX', () => {
         .should('contain.text', 'gpu_metrics')
         .and('contain.text', 'GitHub Actions run ID');
     });
+
+    it('shades the measurement window and reconciles trace vs published power', () => {
+      cy.intercept('GET', '/api/gpu-metrics*', { fixture: 'api/gpu-metrics-run.json' }).as(
+        'gpuMetricsRun',
+      );
+      openPowerX();
+      cy.get('[data-testid="gpu-metrics-load-button"]').click();
+      cy.wait('@gpuMetricsRun');
+
+      cy.get('[data-testid="gpu-metrics-chart-svg"] .measurement-window rect').should('exist');
+      cy.get('[data-testid="gpu-metrics-reconciliation"]').should('be.visible');
+      cy.get('[data-testid="gpu-metrics-power-verdict"]').should('contain.text', 'Power valid');
+      // Published 402 W vs viewer-recomputed 400 W (constant trace) → Δ −0.5%
+      cy.get('[data-testid="gpu-metrics-reconciliation"]').should('contain.text', '402');
+      cy.get('[data-testid="gpu-metrics-reconciliation"]').should('contain.text', '400');
+      cy.get('[data-testid="gpu-metrics-reconciliation-delta"]').should('contain.text', '0.5');
+    });
+
+    it('renders the legacy view unchanged when the response has no power block', () => {
+      cy.fixture('api/gpu-metrics-run.json').then(
+        (fixture: { artifacts: Record<string, unknown>[] }) => {
+          const legacy = {
+            ...fixture,
+            artifacts: fixture.artifacts.map(({ power: _power, ...rest }) => rest),
+          };
+          cy.intercept('GET', '/api/gpu-metrics*', { body: legacy }).as('gpuMetricsLegacy');
+        },
+      );
+      openPowerX();
+      cy.get('[data-testid="gpu-metrics-load-button"]').click();
+      cy.wait('@gpuMetricsLegacy');
+
+      cy.get('[data-testid="gpu-metrics-chart-svg"]').should('exist');
+      cy.get('[data-testid="gpu-metrics-reconciliation"]').should('not.exist');
+      cy.get('[data-testid="gpu-metrics-chart-svg"] .measurement-window').should('not.exist');
+    });
   });
 });

--- a/packages/app/cypress/fixtures/api/_manifest.json
+++ b/packages/app/cypress/fixtures/api/_manifest.json
@@ -58,6 +58,13 @@
       "source": null,
       "topLevel": "array"
     },
+    "gpu-metrics-run": {
+      "bytes": 48347,
+      "capturedAt": null,
+      "sha256": "f4c5ab868fdae610430a4800a0f69a96579b55b5fb73c2fb50532cf9a4f9d2d4",
+      "source": "synthetic://gpu-metrics",
+      "topLevel": "object"
+    },
     "overview-history-rows": {
       "bytes": 5002,
       "capturedAt": null,

--- a/packages/app/cypress/fixtures/api/gpu-metrics-run.json
+++ b/packages/app/cypress/fixtures/api/gpu-metrics-run.json
@@ -1,0 +1,2038 @@
+{
+  "runInfo": {
+    "id": 22806827144,
+    "name": "Benchmark Sweep",
+    "branch": "main",
+    "sha": "fixture000sha",
+    "createdAt": "2026-03-01T00:00:00Z",
+    "url": "https://github.com/example/example/actions/runs/22806827144",
+    "conclusion": "success",
+    "status": "completed"
+  },
+  "artifacts": [
+    {
+      "name": "gpu_metrics_fixture_config",
+      "data": [
+        {
+          "timestamp": "1755000000",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000001",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000002",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000003",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000004",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000005",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000006",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000007",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000008",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000009",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000010",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000011",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000012",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000013",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000014",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000015",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000016",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000017",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000018",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000019",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000020",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000021",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000022",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000023",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000024",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000025",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000026",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000027",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000028",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000029",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000030",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000031",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000032",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000033",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000034",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000035",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000036",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000037",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000038",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000039",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000040",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000041",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000042",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000043",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000044",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000045",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000046",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000047",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000048",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000049",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000050",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000051",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000052",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000053",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000054",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000055",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000056",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000057",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000058",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000059",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000060",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000061",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000062",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000063",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000064",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000065",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000066",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000067",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000068",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000069",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000070",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000071",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000072",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000073",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000074",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000075",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000076",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000077",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000078",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000079",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000080",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000081",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000082",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000083",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000084",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000085",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000086",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000087",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000088",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000089",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000090",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000091",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000092",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000093",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000094",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000095",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000096",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000097",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000098",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000099",
+          "index": 0,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000000",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000001",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000002",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000003",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000004",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000005",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000006",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000007",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000008",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000009",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000010",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000011",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000012",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000013",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000014",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000015",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000016",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000017",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000018",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000019",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000020",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000021",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000022",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000023",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000024",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000025",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000026",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000027",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000028",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000029",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000030",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000031",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000032",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000033",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000034",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000035",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000036",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000037",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000038",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000039",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000040",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000041",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000042",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000043",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000044",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000045",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000046",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000047",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000048",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000049",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000050",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000051",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000052",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000053",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000054",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000055",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000056",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000057",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000058",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000059",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000060",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000061",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000062",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000063",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000064",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000065",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000066",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000067",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000068",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000069",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000070",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000071",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000072",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000073",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000074",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000075",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000076",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000077",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000078",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000079",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000080",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000081",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000082",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000083",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000084",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000085",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000086",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000087",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000088",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000089",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000090",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000091",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000092",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000093",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000094",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000095",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000096",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000097",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000098",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        },
+        {
+          "timestamp": "1755000099",
+          "index": 1,
+          "power": 400,
+          "temperature": 60,
+          "smClock": 1500,
+          "memClock": 2000,
+          "gpuUtil": 90,
+          "memUtil": 70
+        }
+      ],
+      "power": {
+        "power_valid": 1,
+        "reasons": [],
+        "window": {
+          "start_unix": 1755000020,
+          "end_unix": 1755000080
+        },
+        "expected_gpu_count": 2,
+        "observed_gpu_count": 2,
+        "published": {
+          "avg_power_w": 402,
+          "avg_total_gpu_power_w": 804,
+          "power_metric_schema_version": 1,
+          "source": "bmk_artifact"
+        },
+        "producer_sha": "abc123def4567890",
+        "exporter_image_sha256": null,
+        "sources": ["bmk_fixture_config"]
+      }
+    }
+  ]
+}

--- a/packages/app/src/app/api/gpu-metrics/route.test.ts
+++ b/packages/app/src/app/api/gpu-metrics/route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockParseCsvData } = vi.hoisted(() => ({
+const { mockParseCsvData, zipRegistry } = vi.hoisted(() => ({
   mockParseCsvData: vi.fn((csv: string) => {
     if (csv.trim().length === 0) return [];
     return [
@@ -16,6 +16,12 @@ const { mockParseCsvData } = vi.hoisted(() => ({
       },
     ];
   }),
+  /**
+   * Per-download ZIP entry sets, keyed by the downloaded buffer's UTF-8
+   * contents (each mocked download returns its registry key as the body).
+   * Unregistered buffers fall back to the default single-CSV zip.
+   */
+  zipRegistry: new Map<string, { entryName: string; contents: string }[]>(),
 }));
 
 vi.mock('@semianalysisai/inferencex-constants', () => ({
@@ -30,15 +36,22 @@ vi.mock('@/components/gpu-power/types', () => ({
 
 vi.mock('adm-zip', () => {
   const csvContent = 'timestamp,index,power\n2026-03-01T00:00:00Z,0,300';
+  const defaultEntries = [{ entryName: 'gpu_metrics_0.csv', contents: csvContent }];
   class MockAdmZip {
+    private readonly entries: { entryName: string; isDirectory: boolean; getData: () => Buffer }[];
+
+    constructor(buffer?: Buffer) {
+      const key = buffer ? buffer.toString('utf8') : '';
+      const entries = zipRegistry.get(key) ?? defaultEntries;
+      this.entries = entries.map((entry) => ({
+        entryName: entry.entryName,
+        isDirectory: false,
+        getData: () => Buffer.from(entry.contents),
+      }));
+    }
+
     getEntries() {
-      return [
-        {
-          entryName: 'gpu_metrics_0.csv',
-          isDirectory: false,
-          getData: () => Buffer.from(csvContent),
-        },
-      ];
+      return this.entries;
     }
   }
   return { default: MockAdmZip };
@@ -56,6 +69,7 @@ function req(url: string): NextRequest {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  zipRegistry.clear();
   origToken = process.env.GITHUB_TOKEN;
   process.env.GITHUB_TOKEN = 'test-gh-token';
 });
@@ -313,5 +327,230 @@ describe('GET /api/gpu-metrics', () => {
     const body = await res.json();
     expect(body.artifacts).toHaveLength(1);
     expect(body.artifacts[0].name).toBe('gpu_metrics_dsr1_b200');
+  });
+
+  describe('power sidecar enrichment', () => {
+    const RUN_JSON = {
+      id: 12345,
+      name: 'Run',
+      head_branch: 'main',
+      head_sha: 'a',
+      created_at: '2026-03-01T00:00:00Z',
+      html_url: 'https://github.com/TestOwner/TestRepo/actions/runs/12345',
+      conclusion: 'success',
+      status: 'completed',
+    };
+
+    interface MockArtifact {
+      id: number;
+      name: string;
+      /** ZIP registry key returned as the download body; '' = default CSV zip. */
+      zipKey?: string;
+      contentLength?: number;
+    }
+
+    /** URL-routed fetch mock: run info, artifact list, and downloads by id. */
+    function installFetch(artifactList: MockArtifact[]): ReturnType<typeof vi.fn> {
+      const fetchMock = vi.fn((input: unknown) => {
+        const url = String(input);
+        if (url.includes('/actions/runs/12345/artifacts')) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                artifacts: artifactList.map((a) => ({
+                  id: a.id,
+                  name: a.name,
+                  archive_download_url: `https://example.com/dl/${a.id}`,
+                })),
+              }),
+          });
+        }
+        if (url.includes('/actions/runs/12345')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(RUN_JSON) });
+        }
+        const artifact = artifactList.find((a) => url === `https://example.com/dl/${a.id}`);
+        if (artifact) {
+          return Promise.resolve({
+            ok: true,
+            headers: new Headers({ 'Content-Length': String(artifact.contentLength ?? 1024) }),
+            arrayBuffer: () => Promise.resolve(Buffer.from(artifact.zipKey ?? '')),
+          });
+        }
+        return Promise.resolve({ ok: false, status: 404, statusText: 'Not Found' });
+      });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+      return fetchMock;
+    }
+
+    const SIDECAR_JSON = JSON.stringify({
+      schema_version: 1,
+      power_valid: true,
+      reasons: [],
+      benchmark_result: '/workspace/results/dsr1_h200.json',
+      benchmark_window: { start_time_unix: 1755000020, end_time_unix: 1755000080 },
+      expected_gpu_count: 8,
+      observed_gpu_count: 8,
+      metrics: { avg_power_w: 401.5, avg_total_gpu_power_w: 3212 },
+    });
+
+    const AGG_JSON = JSON.stringify({
+      power_valid: 1,
+      power_metric_schema_version: 1,
+      avg_power_w: 402,
+      avg_total_gpu_power_w: 3216,
+    });
+
+    it('populates power from the power_audit sidecar on legacy runs without bmk', async () => {
+      zipRegistry.set('zip:power_audit', [
+        { entryName: 'power_validation_dsr1_h200.json', contents: SIDECAR_JSON },
+        { entryName: 'agg_dsr1_h200.json', contents: AGG_JSON },
+        { entryName: 'dsr1_h200.json', contents: '{}' },
+      ]);
+      installFetch([
+        { id: 1, name: 'gpu_metrics_dsr1_h200' },
+        { id: 2, name: 'power_audit_dsr1_h200', zipKey: 'zip:power_audit' },
+      ]);
+
+      const res = await GET(req('/api/gpu-metrics?runId=12345'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.artifacts).toHaveLength(1);
+      expect(body.artifacts[0].power).toEqual({
+        power_valid: 1,
+        reasons: [],
+        window: { start_unix: 1755000020, end_unix: 1755000080 },
+        expected_gpu_count: 8,
+        observed_gpu_count: 8,
+        published: {
+          avg_power_w: 402,
+          avg_total_gpu_power_w: 3216,
+          power_metric_schema_version: 1,
+          source: 'power_audit_agg',
+        },
+        producer_sha: null,
+        exporter_image_sha256: null,
+        sources: ['power_audit_dsr1_h200'],
+      });
+    });
+
+    it('takes the window from a PLAN-06 bmk agg row without downloading power_audit', async () => {
+      zipRegistry.set('zip:bmk', [
+        {
+          entryName: 'agg_dsr1_h200.json',
+          contents: JSON.stringify({
+            power_valid: 1,
+            power_metric_schema_version: 1,
+            avg_power_w: 402,
+            avg_total_gpu_power_w: 3216,
+            power_audit: {
+              window_start_unix: 1755000020,
+              window_end_unix: 1755000080,
+              expected_gpu_count: 8,
+              observed_gpu_count: 8,
+              producer_sha: 'abc123def456',
+              exporter_image_sha256: 'sha256:feedface',
+            },
+          }),
+        },
+      ]);
+      const fetchMock = installFetch([
+        { id: 1, name: 'gpu_metrics_dsr1_h200' },
+        { id: 2, name: 'bmk_dsr1_h200', zipKey: 'zip:bmk' },
+        { id: 3, name: 'power_audit_dsr1_h200', zipKey: 'zip:unused' },
+      ]);
+
+      const res = await GET(req('/api/gpu-metrics?runId=12345'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.artifacts[0].power).toEqual({
+        power_valid: 1,
+        reasons: [],
+        window: { start_unix: 1755000020, end_unix: 1755000080 },
+        expected_gpu_count: 8,
+        observed_gpu_count: 8,
+        published: {
+          avg_power_w: 402,
+          avg_total_gpu_power_w: 3216,
+          power_metric_schema_version: 1,
+          source: 'bmk_artifact',
+        },
+        producer_sha: 'abc123def456',
+        exporter_image_sha256: 'sha256:feedface',
+        sources: ['bmk_dsr1_h200'],
+      });
+      const fetchedUrls = fetchMock.mock.calls.map((call) => String(call[0]));
+      expect(fetchedUrls).not.toContain('https://example.com/dl/3');
+      // run info + artifact list + gpu_metrics zip + bmk zip only
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('omits power entirely when no sibling artifacts exist (legacy shape)', async () => {
+      installFetch([{ id: 1, name: 'gpu_metrics_dsr1_h200' }]);
+
+      const res = await GET(req('/api/gpu-metrics?runId=12345'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.artifacts).toHaveLength(1);
+      expect(Object.keys(body.artifacts[0]).toSorted()).toEqual(['data', 'name']);
+    });
+
+    it('skips an oversized power_audit bundle and keeps Tier 1 content', async () => {
+      zipRegistry.set('zip:bmk-legacy', [{ entryName: 'agg_dsr1_h200.json', contents: AGG_JSON }]);
+      installFetch([
+        { id: 1, name: 'gpu_metrics_dsr1_h200' },
+        { id: 2, name: 'bmk_dsr1_h200', zipKey: 'zip:bmk-legacy' },
+        {
+          id: 3,
+          name: 'power_audit_dsr1_h200',
+          zipKey: 'zip:power_audit',
+          contentLength: 60 * 1024 * 1024,
+        },
+      ]);
+
+      const res = await GET(req('/api/gpu-metrics?runId=12345'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // Tier 2 was skipped (over cap) so no window; Tier 1 published survives.
+      expect(body.artifacts[0].power).toEqual({
+        power_valid: 1,
+        reasons: [],
+        window: null,
+        expected_gpu_count: null,
+        observed_gpu_count: null,
+        published: {
+          avg_power_w: 402,
+          avg_total_gpu_power_w: 3216,
+          power_metric_schema_version: 1,
+          source: 'bmk_artifact',
+        },
+        producer_sha: null,
+        exporter_image_sha256: null,
+        sources: ['bmk_dsr1_h200'],
+      });
+    });
+
+    it('omits power but keeps the CSV view when the sidecar JSON is malformed', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        zipRegistry.set('zip:bad-audit', [
+          { entryName: 'power_validation_dsr1_h200.json', contents: '{not json' },
+        ]);
+        installFetch([
+          { id: 1, name: 'gpu_metrics_dsr1_h200' },
+          { id: 2, name: 'power_audit_dsr1_h200', zipKey: 'zip:bad-audit' },
+        ]);
+
+        const res = await GET(req('/api/gpu-metrics?runId=12345'));
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.artifacts).toHaveLength(1);
+        expect(body.artifacts[0].data).toHaveLength(1);
+        expect(body.artifacts[0].power).toBeUndefined();
+        expect(warnSpy).toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 });

--- a/packages/app/src/app/api/gpu-metrics/route.test.ts
+++ b/packages/app/src/app/api/gpu-metrics/route.test.ts
@@ -530,6 +530,37 @@ describe('GET /api/gpu-metrics', () => {
       });
     });
 
+    it('keeps a no-op bmk artifact out of sources and falls through to the bundle', async () => {
+      zipRegistry.set('zip:bmk-noop', [
+        // Agg row with no power fields at all (e.g. an eval-style row).
+        { entryName: 'agg_dsr1_h200.json', contents: JSON.stringify({ output_toks_per_sec: 1 }) },
+      ]);
+      zipRegistry.set('zip:audit-sidecar-only', [
+        { entryName: 'power_validation_dsr1_h200.json', contents: SIDECAR_JSON },
+      ]);
+      installFetch([
+        { id: 1, name: 'gpu_metrics_dsr1_h200' },
+        { id: 2, name: 'bmk_dsr1_h200', zipKey: 'zip:bmk-noop' },
+        { id: 3, name: 'power_audit_dsr1_h200', zipKey: 'zip:audit-sidecar-only' },
+      ]);
+
+      const res = await GET(req('/api/gpu-metrics?runId=12345'));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      // The bmk artifact contributed nothing, so only the bundle is credited.
+      expect(body.artifacts[0].power.sources).toEqual(['power_audit_dsr1_h200']);
+      expect(body.artifacts[0].power.published).toEqual({
+        avg_power_w: 401.5,
+        avg_total_gpu_power_w: 3212,
+        power_metric_schema_version: null,
+        source: 'validation_metrics',
+      });
+      expect(body.artifacts[0].power.window).toEqual({
+        start_unix: 1755000020,
+        end_unix: 1755000080,
+      });
+    });
+
     it('omits power but keeps the CSV view when the sidecar JSON is malformed', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {

--- a/packages/app/src/app/api/gpu-metrics/route.ts
+++ b/packages/app/src/app/api/gpu-metrics/route.ts
@@ -4,7 +4,7 @@
  */
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { parseCsvData } from '@/components/gpu-power/types';
+import { parseCsvData, type GpuArtifactPower } from '@/components/gpu-power/types';
 import {
   downloadGithubArtifact,
   extractZipEntries,
@@ -12,10 +12,114 @@ import {
   fetchGithubWorkflowRun,
   getGithubToken,
   normalizeGithubRunInfo,
+  type GithubArtifact,
   type GithubWorkflowRun,
 } from '@/lib/github-artifacts';
+import {
+  mergeArtifactPower,
+  powerFromAggRow,
+  powerFromValidationSidecar,
+  selectValidationEntry,
+  siblingArtifactNames,
+} from '@/lib/power-audit-artifacts';
 
 const MAX_ARTIFACT_BYTES = 50 * 1024 * 1024;
+
+interface ZipJsonEntry {
+  entryName: string;
+  json: Record<string, unknown>;
+}
+
+/** Download an artifact ZIP and parse its .json entries; null on any failure. */
+async function downloadJsonEntries(
+  artifact: GithubArtifact,
+  githubToken: string,
+): Promise<ZipJsonEntry[] | null> {
+  const dlResp = await downloadGithubArtifact(artifact.archive_download_url, githubToken);
+  if (!dlResp.ok) {
+    console.warn(`Failed to download artifact ${artifact.name}: ${dlResp.statusText}`);
+    return null;
+  }
+
+  const contentLength = dlResp.headers.get('Content-Length');
+  if (contentLength && parseInt(contentLength, 10) > MAX_ARTIFACT_BYTES) {
+    console.warn(`Artifact ${artifact.name} exceeds 50 MB, skipping`);
+    return null;
+  }
+
+  return extractZipEntries(
+    Buffer.from(await dlResp.arrayBuffer()),
+    '.json',
+    (entryName, contents) => [{ entryName, json: JSON.parse(contents) as Record<string, unknown> }],
+    (entryName, error) => {
+      console.warn(`Failed to parse JSON ${entryName} from ${artifact.name}:`, error);
+    },
+  );
+}
+
+function findNamedAggEntry(
+  entries: ZipJsonEntry[],
+  suffix: string,
+): Record<string, unknown> | null {
+  const named = entries.find((entry) => {
+    const basename = entry.entryName.split('/').pop() ?? entry.entryName;
+    return basename === `agg_${suffix}.json`;
+  });
+  return named?.json ?? null;
+}
+
+/**
+ * Assemble the normalized power block for one gpu_metrics artifact from its
+ * same-suffix siblings, cheapest first: the tiny `bmk_*` agg row (Tier 1), and
+ * only when that yields no window bounds, the `power_audit_*` bundle (Tier 2).
+ * Every step tolerates absence — legacy runs simply get no `power` block.
+ */
+async function resolveArtifactPower(
+  gpuMetricsArtifactName: string,
+  artifactsByName: Map<string, GithubArtifact>,
+  githubToken: string,
+): Promise<GpuArtifactPower | null> {
+  const siblings = siblingArtifactNames(gpuMetricsArtifactName);
+  if (!siblings) return null;
+  const suffix = gpuMetricsArtifactName.slice('gpu_metrics_'.length);
+  const sources: string[] = [];
+
+  // Tier 1: bmk_<suffix> (fallback bmk_agentic_<suffix>) — one agg_*.json.
+  let fromAgg: ReturnType<typeof powerFromAggRow> | null = null;
+  const bmkArtifact = artifactsByName.get(siblings.bmk) ?? artifactsByName.get(siblings.bmkAgentic);
+  if (bmkArtifact) {
+    const entries = await downloadJsonEntries(bmkArtifact, githubToken);
+    if (entries) {
+      // bmk_* holds exactly one agg_*.json; tolerate an unnamed single entry.
+      const aggRow =
+        findNamedAggEntry(entries, suffix) ?? (entries.length === 1 ? entries[0].json : null);
+      if (aggRow) {
+        fromAgg = powerFromAggRow(aggRow, 'bmk_artifact');
+        sources.push(bmkArtifact.name);
+      }
+    }
+  }
+
+  // Tier 2: power_audit_<suffix> bundle — skipped when Tier 1 gave the window.
+  let fromSidecar: ReturnType<typeof powerFromValidationSidecar> | null = null;
+  const auditArtifact = artifactsByName.get(siblings.powerAudit);
+  if (auditArtifact && !fromAgg?.window) {
+    const entries = await downloadJsonEntries(auditArtifact, githubToken);
+    if (entries) {
+      const sidecar = selectValidationEntry(entries, suffix);
+      if (sidecar) fromSidecar = powerFromValidationSidecar(sidecar);
+      if (!fromAgg) {
+        const aggRow = findNamedAggEntry(entries, suffix);
+        if (aggRow) fromAgg = powerFromAggRow(aggRow, 'power_audit_agg');
+      }
+      if (sidecar || fromAgg?.published?.source === 'power_audit_agg') {
+        sources.push(auditArtifact.name);
+      }
+    }
+  }
+
+  return mergeArtifactPower(fromAgg, fromSidecar, sources);
+}
 
 async function fetchGpuMetrics(runId: string) {
   const githubToken = getGithubToken();
@@ -30,7 +134,19 @@ async function fetchGpuMetrics(runId: string) {
   const gpuArtifacts = artifacts.filter((a) => a.name.startsWith('gpu_metrics'));
   if (gpuArtifacts.length === 0) throw new Error('No gpu_metrics artifacts found for this run');
 
-  const parsedArtifacts: { name: string; data: ReturnType<typeof parseCsvData> }[] = [];
+  // Sibling lookup for power sidecars; same-name re-uploads keep only the
+  // newest (highest id), mirroring unofficial-run's per-config selection.
+  const artifactsByName = new Map<string, (typeof artifacts)[number]>();
+  for (const artifact of artifacts) {
+    const prev = artifactsByName.get(artifact.name);
+    if (!prev || artifact.id > prev.id) artifactsByName.set(artifact.name, artifact);
+  }
+
+  const parsedArtifacts: {
+    name: string;
+    data: ReturnType<typeof parseCsvData>;
+    power?: GpuArtifactPower;
+  }[] = [];
   for (const artifact of gpuArtifacts) {
     const dlResp = await downloadGithubArtifact(artifact.archive_download_url, githubToken);
     if (!dlResp.ok) {
@@ -56,6 +172,16 @@ async function fetchGpuMetrics(runId: string) {
   }
 
   if (parsedArtifacts.length === 0) throw new Error('No Chip metrics data found in artifacts');
+
+  // Additive enrichment: a sidecar failure must never break the CSV view.
+  for (const parsed of parsedArtifacts) {
+    try {
+      const power = await resolveArtifactPower(parsed.name, artifactsByName, githubToken);
+      if (power) parsed.power = power;
+    } catch (error) {
+      console.warn(`Failed to resolve power sidecars for ${parsed.name}:`, error);
+    }
+  }
 
   return {
     runInfo: normalizeGithubRunInfo(run),

--- a/packages/app/src/app/api/gpu-metrics/route.ts
+++ b/packages/app/src/app/api/gpu-metrics/route.ts
@@ -16,6 +16,7 @@ import {
   type GithubWorkflowRun,
 } from '@/lib/github-artifacts';
 import {
+  hasPowerContent,
   mergeArtifactPower,
   powerFromAggRow,
   powerFromValidationSidecar,
@@ -94,8 +95,13 @@ async function resolveArtifactPower(
       const aggRow =
         findNamedAggEntry(entries, suffix) ?? (entries.length === 1 ? entries[0].json : null);
       if (aggRow) {
-        fromAgg = powerFromAggRow(aggRow, 'bmk_artifact');
-        sources.push(bmkArtifact.name);
+        const parsed = powerFromAggRow(aggRow, 'bmk_artifact');
+        // A row with no power fields contributes nothing: keep it out of the
+        // sources footer and let Tier 2's agg fallback take over.
+        if (hasPowerContent(parsed)) {
+          fromAgg = parsed;
+          sources.push(bmkArtifact.name);
+        }
       }
     }
   }
@@ -107,14 +113,20 @@ async function resolveArtifactPower(
     const entries = await downloadJsonEntries(auditArtifact, githubToken);
     if (entries) {
       const sidecar = selectValidationEntry(entries, suffix);
-      if (sidecar) fromSidecar = powerFromValidationSidecar(sidecar);
+      const parsedSidecar = sidecar ? powerFromValidationSidecar(sidecar) : null;
+      if (hasPowerContent(parsedSidecar)) fromSidecar = parsedSidecar;
+      let bundleAggContributed = false;
       if (!fromAgg) {
         const aggRow = findNamedAggEntry(entries, suffix);
-        if (aggRow) fromAgg = powerFromAggRow(aggRow, 'power_audit_agg');
+        if (aggRow) {
+          const parsed = powerFromAggRow(aggRow, 'power_audit_agg');
+          if (hasPowerContent(parsed)) {
+            fromAgg = parsed;
+            bundleAggContributed = true;
+          }
+        }
       }
-      if (sidecar || fromAgg?.published?.source === 'power_audit_agg') {
-        sources.push(auditArtifact.name);
-      }
+      if (fromSidecar || bundleAggContributed) sources.push(auditArtifact.name);
     }
   }
 

--- a/packages/app/src/components/gpu-power/GpuPowerChart.tsx
+++ b/packages/app/src/components/gpu-power/GpuPowerChart.tsx
@@ -4,9 +4,11 @@ import * as d3 from 'd3';
 import React, { useMemo } from 'react';
 
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import { type AlignedWindow, alignWindowToTrace } from './power-window';
 import {
   type GpuMetricKey,
   type GpuMetricRow,
+  type PowerWindow,
   ALL_METRIC_OPTIONS,
   detectTdpFromArtifactName,
 } from './types';
@@ -18,6 +20,12 @@ interface ParsedPoint {
   raw: GpuMetricRow;
 }
 
+export interface MeasurementWindowLabels {
+  window: string;
+  warmup: string;
+  after: string;
+}
+
 interface GpuMetricsChartProps {
   data: GpuMetricRow[];
   visibleGpus: Set<number>;
@@ -27,6 +35,9 @@ interface GpuMetricsChartProps {
   caption?: React.ReactNode;
   /** Max interactive points before LTTB downsampling. Infinity to disable. */
   maxPoints?: number;
+  /** Formal power-measurement window (unix epoch bounds) to shade, when known. */
+  measurementWindow?: PowerWindow | null;
+  windowLabels?: MeasurementWindowLabels;
 }
 
 function parseTimestamp(raw: string): Date | null {
@@ -75,6 +86,102 @@ const GPU_COLORS = d3.schemeTableau10;
 const CHART_ID = 'gpu-metrics-line';
 const MARGIN = { top: 24, right: 20, bottom: 60, left: 60 };
 
+const WINDOW_COLOR = '#10b981';
+const DIM_COLOR = '#6b7280';
+const DEFAULT_WINDOW_LABELS: MeasurementWindowLabels = {
+  window: 'Measurement window',
+  warmup: 'Warmup / ramp',
+  after: 'Post-benchmark',
+};
+/** Minimum region width (px) before its label is worth drawing. */
+const WINDOW_LABEL_MIN_PX = 60;
+
+/**
+ * Draw (or clear) the measurement-window band, dashed bounds, and dimmed
+ * warmup/post overlays. Re-invoked with `ctx.newXScale` on every x-zoom; the
+ * group is kept as the first child so re-draws stay beneath the data layers.
+ */
+function drawMeasurementWindow(
+  group: d3.Selection<SVGGElement, unknown, null, undefined>,
+  xScale: d3.ScaleLinear<number, number>,
+  width: number,
+  height: number,
+  aligned: AlignedWindow | null,
+  labels: MeasurementWindowLabels,
+): void {
+  group.selectAll('g.measurement-window').remove();
+  if (!aligned || width <= 0) return;
+
+  const clampX = (x: number) => Math.max(0, Math.min(width, x));
+  const xStart = clampX(xScale(aligned.startSeconds));
+  const xEnd = clampX(xScale(aligned.endSeconds));
+  if (xEnd <= xStart) return;
+
+  const windowGroup = group
+    .insert('g', ':first-child')
+    .attr('class', 'measurement-window')
+    .attr('pointer-events', 'none');
+
+  const addRegionLabel = (x0: number, x1: number, text: string, color: string) => {
+    if (x1 - x0 < WINDOW_LABEL_MIN_PX) return;
+    windowGroup
+      .append('text')
+      .attr('x', (x0 + x1) / 2)
+      .attr('y', 12)
+      .attr('text-anchor', 'middle')
+      .attr('fill', color)
+      .attr('font-size', '10px')
+      .attr('font-weight', '600')
+      .text(text);
+  };
+
+  // Dimmed warmup/post regions outside the formal window
+  if (xStart > 0) {
+    windowGroup
+      .append('rect')
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('width', xStart)
+      .attr('height', height)
+      .attr('fill', DIM_COLOR)
+      .attr('opacity', 0.05);
+    addRegionLabel(0, xStart, labels.warmup, DIM_COLOR);
+  }
+  if (xEnd < width) {
+    windowGroup
+      .append('rect')
+      .attr('x', xEnd)
+      .attr('y', 0)
+      .attr('width', width - xEnd)
+      .attr('height', height)
+      .attr('fill', DIM_COLOR)
+      .attr('opacity', 0.05);
+    addRegionLabel(xEnd, width, labels.after, DIM_COLOR);
+  }
+
+  // Measurement window band + dashed boundary lines
+  windowGroup
+    .append('rect')
+    .attr('x', xStart)
+    .attr('y', 0)
+    .attr('width', xEnd - xStart)
+    .attr('height', height)
+    .attr('fill', WINDOW_COLOR)
+    .attr('opacity', 0.08);
+  for (const x of [xStart, xEnd]) {
+    windowGroup
+      .append('line')
+      .attr('x1', x)
+      .attr('x2', x)
+      .attr('y1', 0)
+      .attr('y2', height)
+      .attr('stroke', WINDOW_COLOR)
+      .attr('stroke-width', 1)
+      .attr('stroke-dasharray', '4,3');
+  }
+  addRegionLabel(xStart, xEnd, labels.window, WINDOW_COLOR);
+}
+
 const GpuMetricsChart = React.memo(
   ({
     data,
@@ -84,6 +191,8 @@ const GpuMetricsChart = React.memo(
     legendElement,
     caption,
     maxPoints,
+    measurementWindow,
+    windowLabels,
   }: GpuMetricsChartProps) => {
     const metricConfig = ALL_METRIC_OPTIONS.find((m) => m.key === metricKey)!;
 
@@ -91,6 +200,15 @@ const GpuMetricsChart = React.memo(
       () => buildGroupedData(data, visibleGpus, metricKey),
       [data, visibleGpus, metricKey],
     );
+
+    // Align over the same visible-GPU row set buildGroupedData consumes so the
+    // seconds origin matches the rendered axis (UTC vs viewer-TZ parsing only
+    // shifts every sample by the same constant, so relative seconds agree).
+    const alignedWindow = useMemo(() => {
+      if (!measurementWindow) return null;
+      const visibleRows = data.filter((row) => visibleGpus.has(row.index));
+      return alignWindowToTrace(visibleRows, measurementWindow);
+    }, [data, visibleGpus, measurementWindow]);
 
     const allPoints = useMemo(() => {
       const pts: ParsedPoint[] = [];
@@ -149,6 +267,35 @@ const GpuMetricsChart = React.memo(
         xAxis={{ label: 'Seconds', tickCount: 10 }}
         yAxis={{ label: metricConfig.yAxisLabel, tickCount: 8 }}
         layers={[
+          // Measurement-window shading (drawn first so it sits beneath data).
+          // The render function always runs so a stale band is cleared when
+          // the window disappears (artifact switch, alignment loss).
+          {
+            type: 'custom',
+            key: 'measurement-window',
+            render: (group, ctx) => {
+              drawMeasurementWindow(
+                group,
+                ctx.xScale as d3.ScaleLinear<number, number>,
+                ctx.width,
+                ctx.height,
+                alignedWindow,
+                windowLabels ?? DEFAULT_WINDOW_LABELS,
+              );
+            },
+            onZoom: alignedWindow
+              ? (group, ctx) => {
+                  drawMeasurementWindow(
+                    group,
+                    ctx.newXScale as d3.ScaleLinear<number, number>,
+                    ctx.width,
+                    ctx.height,
+                    alignedWindow,
+                    windowLabels ?? DEFAULT_WINDOW_LABELS,
+                  );
+                }
+              : null,
+          },
           // TDP reference line (power metric only)
           {
             type: 'custom',
@@ -235,7 +382,8 @@ const GpuMetricsChart = React.memo(
           onHoverEnd: (sel) => {
             sel.attr('r', 2).attr('stroke', 'none');
           },
-          attachToLayer: 2,
+          // gpu-points layer index (measurement-window layer shifted it by one)
+          attachToLayer: 3,
         }}
         legendElement={legendElement}
         caption={caption}

--- a/packages/app/src/components/gpu-power/GpuPowerChart.tsx
+++ b/packages/app/src/components/gpu-power/GpuPowerChart.tsx
@@ -113,9 +113,10 @@ function drawMeasurementWindow(
   if (!aligned || width <= 0) return;
 
   const clampX = (x: number) => Math.max(0, Math.min(width, x));
-  const xStart = clampX(xScale(aligned.startSeconds));
-  const xEnd = clampX(xScale(aligned.endSeconds));
-  if (xEnd <= xStart) return;
+  const rawStart = xScale(aligned.startSeconds);
+  const rawEnd = xScale(aligned.endSeconds);
+  const xStart = clampX(rawStart);
+  const xEnd = clampX(rawEnd);
 
   const windowGroup = group
     .insert('g', ':first-child')
@@ -135,29 +136,30 @@ function drawMeasurementWindow(
       .text(text);
   };
 
+  const addDimRegion = (x0: number, x1: number, text: string) => {
+    windowGroup
+      .append('rect')
+      .attr('x', x0)
+      .attr('y', 0)
+      .attr('width', x1 - x0)
+      .attr('height', height)
+      .attr('fill', DIM_COLOR)
+      .attr('opacity', 0.05);
+    addRegionLabel(x0, x1, text, DIM_COLOR);
+  };
+
+  if (xEnd <= xStart) {
+    // Visible x-range lies wholly on one side of the window (deep zoom into
+    // warmup or post-benchmark): keep the dim overlay so the region is not
+    // mistaken for measured data.
+    if (rawEnd <= 0) addDimRegion(0, width, labels.after);
+    else if (rawStart >= width) addDimRegion(0, width, labels.warmup);
+    return;
+  }
+
   // Dimmed warmup/post regions outside the formal window
-  if (xStart > 0) {
-    windowGroup
-      .append('rect')
-      .attr('x', 0)
-      .attr('y', 0)
-      .attr('width', xStart)
-      .attr('height', height)
-      .attr('fill', DIM_COLOR)
-      .attr('opacity', 0.05);
-    addRegionLabel(0, xStart, labels.warmup, DIM_COLOR);
-  }
-  if (xEnd < width) {
-    windowGroup
-      .append('rect')
-      .attr('x', xEnd)
-      .attr('y', 0)
-      .attr('width', width - xEnd)
-      .attr('height', height)
-      .attr('fill', DIM_COLOR)
-      .attr('opacity', 0.05);
-    addRegionLabel(xEnd, width, labels.after, DIM_COLOR);
-  }
+  if (xStart > 0) addDimRegion(0, xStart, labels.warmup);
+  if (xEnd < width) addDimRegion(xEnd, width, labels.after);
 
   // Measurement window band + dashed boundary lines
   windowGroup

--- a/packages/app/src/components/gpu-power/GpuPowerDisplay.tsx
+++ b/packages/app/src/components/gpu-power/GpuPowerDisplay.tsx
@@ -31,6 +31,7 @@ import { useClientSearchParams } from '@/hooks/useClientSearch';
 import GpuCorrelationChart from './GpuCorrelationChart';
 import GpuMetricsChart from './GpuPowerChart';
 import GpuStatsTable from './GpuStatsTable';
+import { alignWindowToTrace, classifyDelta, integrateWindowPower } from './power-window';
 import {
   type GpuMetricKey,
   type GpuPowerApiResponse,
@@ -67,6 +68,27 @@ const STRINGS = {
     downsample: 'Downsample',
     perGpuStats: 'Per-Chip Statistics',
     rows: 'rows',
+    reconciliationHeading: 'Measurement window & reconciliation',
+    verdictValid: 'Power valid',
+    verdictInvalid: 'Power invalid',
+    verdictUnknown: 'Verdict unknown',
+    windowLabel: 'Window:',
+    windowDurationLabel: 'Duration:',
+    gpuCountLabel: 'Chips (observed / expected):',
+    publishedLabel: 'Published avg power:',
+    recomputedLabel: 'Viewer recomputed:',
+    recomputedMethodNote: 'trapezoid, all chips',
+    deltaLabel: 'Delta:',
+    alignmentFailed: 'The trace could not be aligned to the measurement window.',
+    publishedUnavailable: 'published value unavailable',
+    recomputeUnavailable: 'not enough samples to recompute',
+    partialCoverageNote: 'window partially covered by the trace',
+    producerLabel: 'Producer:',
+    exporterLabel: 'Exporter image:',
+    sourcesLabel: 'Sources:',
+    chartWindowLabel: 'Measurement window',
+    chartWarmupLabel: 'Warmup / ramp',
+    chartAfterLabel: 'Post-benchmark',
   },
   zh: {
     heading: 'PowerX',
@@ -94,7 +116,40 @@ const STRINGS = {
     downsample: '降采样',
     perGpuStats: '每芯片统计信息',
     rows: '行',
+    reconciliationHeading: '测量窗口与对账',
+    verdictValid: '功耗有效',
+    verdictInvalid: '功耗无效',
+    verdictUnknown: '结论未知',
+    windowLabel: '窗口：',
+    windowDurationLabel: '时长：',
+    gpuCountLabel: '芯片数（实测 / 预期）：',
+    publishedLabel: '已发布平均功耗：',
+    recomputedLabel: '查看器重算：',
+    recomputedMethodNote: '梯形积分，全部芯片',
+    deltaLabel: '偏差：',
+    alignmentFailed: '无法将原始轨迹与测量窗口对齐。',
+    publishedUnavailable: '已发布值不可用',
+    recomputeUnavailable: '样本不足，无法重算',
+    partialCoverageNote: '窗口未被轨迹完全覆盖',
+    producerLabel: '生产者：',
+    exporterLabel: '导出镜像：',
+    sourcesLabel: '数据来源：',
+    chartWindowLabel: '测量窗口',
+    chartWarmupLabel: '预热 / 爬坡',
+    chartAfterLabel: '基准结束后',
   },
+} as const;
+
+const VERDICT_BADGE_CLASSES = {
+  valid: 'border-emerald-600/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300',
+  invalid: 'border-red-600/40 bg-red-500/10 text-red-700 dark:text-red-300',
+  unknown: 'border-border bg-muted text-muted-foreground',
+} as const;
+
+const DELTA_LEVEL_CLASSES = {
+  ok: 'text-emerald-700 dark:text-emerald-300',
+  warn: 'text-amber-700 dark:text-amber-300',
+  alert: 'text-red-700 dark:text-red-300',
 } as const;
 
 type GpuMetricsView = 'chart' | 'correlation';
@@ -172,6 +227,28 @@ export default function GpuMetricsDisplay() {
   const currentData = useMemo(
     () => artifacts.find((artifact) => artifact.name === selectedArtifact)?.data ?? [],
     [artifacts, selectedArtifact],
+  );
+  const currentPower = useMemo(
+    () => artifacts.find((artifact) => artifact.name === selectedArtifact)?.power ?? null,
+    [artifacts, selectedArtifact],
+  );
+  // The recompute mirrors the producer: all chips in the trace, never the
+  // visible-GPU filter, so legend toggles cannot change the panel numbers.
+  const windowAlignment = useMemo(
+    () => (currentPower?.window ? alignWindowToTrace(currentData, currentPower.window) : null),
+    [currentData, currentPower],
+  );
+  const windowRecompute = useMemo(
+    () => (currentPower?.window ? integrateWindowPower(currentData, currentPower.window) : null),
+    [currentData, currentPower],
+  );
+  const publishedAvgPowerW = currentPower?.published?.avg_power_w ?? null;
+  const reconciliationDelta = useMemo(
+    () =>
+      windowRecompute !== null && publishedAvgPowerW !== null
+        ? classifyDelta(windowRecompute.avgPowerPerGpuW, publishedAvgPowerW)
+        : null,
+    [windowRecompute, publishedAvgPowerW],
   );
   const availableMetrics = useMemo(() => getAvailableMetrics(currentData), [currentData]);
   const urlMetric = searchParams.get('gm_metric');
@@ -449,6 +526,136 @@ export default function GpuMetricsDisplay() {
             </div>
           </Card>
 
+          {currentPower &&
+            (() => {
+              const verdict =
+                currentPower.power_valid === 1
+                  ? 'valid'
+                  : currentPower.power_valid === 0
+                    ? 'invalid'
+                    : 'unknown';
+              const verdictText =
+                verdict === 'valid'
+                  ? t.verdictValid
+                  : verdict === 'invalid'
+                    ? t.verdictInvalid
+                    : t.verdictUnknown;
+              const window = currentPower.window;
+              return (
+                <Card className="mb-4" data-testid="gpu-metrics-reconciliation">
+                  <h3 className="text-sm font-semibold mb-3">{t.reconciliationHeading}</h3>
+                  <div className="flex flex-wrap items-center gap-1.5 mb-3">
+                    <span
+                      data-testid="gpu-metrics-power-verdict"
+                      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${VERDICT_BADGE_CLASSES[verdict]}`}
+                    >
+                      {verdictText}
+                    </span>
+                    {currentPower.reasons.map((reason) => (
+                      <code key={reason} className="text-xs bg-muted px-1.5 py-0.5 rounded">
+                        {reason}
+                      </code>
+                    ))}
+                  </div>
+                  {window && (
+                    <>
+                      <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm mb-2">
+                        <span>
+                          <span className="text-muted-foreground">{t.windowLabel}</span>{' '}
+                          {new Date(window.start_unix * 1000).toISOString()} →{' '}
+                          {new Date(window.end_unix * 1000).toISOString()}
+                        </span>
+                        <span>
+                          <span className="text-muted-foreground">{t.windowDurationLabel}</span>{' '}
+                          {(window.end_unix - window.start_unix).toFixed(1)}s
+                        </span>
+                        {(currentPower.observed_gpu_count !== null ||
+                          currentPower.expected_gpu_count !== null) && (
+                          <span>
+                            <span className="text-muted-foreground">{t.gpuCountLabel}</span>{' '}
+                            {currentPower.observed_gpu_count ?? '—'} /{' '}
+                            {currentPower.expected_gpu_count ?? '—'}
+                          </span>
+                        )}
+                      </div>
+                      {!windowAlignment && (
+                        <p className="text-sm text-muted-foreground mb-2">{t.alignmentFailed}</p>
+                      )}
+                      <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
+                        <span>
+                          <span className="text-muted-foreground">{t.publishedLabel}</span>{' '}
+                          {publishedAvgPowerW === null ? (
+                            <span className="text-muted-foreground italic">
+                              {t.publishedUnavailable}
+                            </span>
+                          ) : (
+                            <>
+                              {publishedAvgPowerW.toFixed(1)} W{' '}
+                              {currentPower.published && (
+                                <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                                  {currentPower.published.source}
+                                </code>
+                              )}
+                            </>
+                          )}
+                        </span>
+                        <span>
+                          <span className="text-muted-foreground">{t.recomputedLabel}</span>{' '}
+                          {windowRecompute ? (
+                            <>
+                              {windowRecompute.avgPowerPerGpuW.toFixed(1)} W{' '}
+                              <span className="text-muted-foreground text-xs">
+                                ({t.recomputedMethodNote}
+                                {windowRecompute.partialCoverage
+                                  ? `, ${t.partialCoverageNote}`
+                                  : ''}
+                                )
+                              </span>
+                            </>
+                          ) : (
+                            <span className="text-muted-foreground italic">
+                              {t.recomputeUnavailable}
+                            </span>
+                          )}
+                        </span>
+                        {reconciliationDelta && (
+                          <span
+                            data-testid="gpu-metrics-reconciliation-delta"
+                            className={`font-medium ${DELTA_LEVEL_CLASSES[reconciliationDelta.level]}`}
+                          >
+                            {t.deltaLabel} {reconciliationDelta.deltaPct >= 0 ? '+' : ''}
+                            {reconciliationDelta.deltaPct.toFixed(1)}%
+                          </span>
+                        )}
+                      </div>
+                    </>
+                  )}
+                  {(currentPower.producer_sha ||
+                    currentPower.exporter_image_sha256 ||
+                    currentPower.sources.length > 0) && (
+                    <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground mt-3">
+                      {currentPower.producer_sha && (
+                        <span>
+                          {t.producerLabel} <code>{currentPower.producer_sha.slice(0, 12)}</code>
+                        </span>
+                      )}
+                      {currentPower.exporter_image_sha256 && (
+                        <span>
+                          {t.exporterLabel}{' '}
+                          <code>{currentPower.exporter_image_sha256.slice(0, 12)}</code>
+                        </span>
+                      )}
+                      {currentPower.sources.length > 0 && (
+                        <span>
+                          {t.sourcesLabel} {currentPower.sources.join(', ')}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </Card>
+              );
+            })()}
+
           <Card
             id="gpu-metrics-chart"
             data-testid="gpu-metrics-chart-container"
@@ -537,6 +744,12 @@ export default function GpuMetricsDisplay() {
                 metricKey={selectedMetric}
                 artifactName={selectedArtifact}
                 maxPoints={downsample ? 2000 : Infinity}
+                measurementWindow={currentPower?.window ?? null}
+                windowLabels={{
+                  window: t.chartWindowLabel,
+                  warmup: t.chartWarmupLabel,
+                  after: t.chartAfterLabel,
+                }}
                 caption={
                   <>
                     <h2 className="text-lg font-semibold">

--- a/packages/app/src/components/gpu-power/GpuPowerDisplay.tsx
+++ b/packages/app/src/components/gpu-power/GpuPowerDisplay.tsx
@@ -152,6 +152,12 @@ const DELTA_LEVEL_CLASSES = {
   alert: 'text-red-700 dark:text-red-300',
 } as const;
 
+/** ISO-format a unix-seconds window bound; Date throws outside ±8.64e15 ms. */
+function formatWindowBound(unixSeconds: number): string {
+  const ms = unixSeconds * 1000;
+  return Math.abs(ms) <= 8.64e15 ? new Date(ms).toISOString() : String(unixSeconds);
+}
+
 type GpuMetricsView = 'chart' | 'correlation';
 
 const GPU_METRICS_VIEW_OPTIONS: SegmentedToggleOption<GpuMetricsView>[] = [
@@ -562,8 +568,8 @@ export default function GpuMetricsDisplay() {
                       <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm mb-2">
                         <span>
                           <span className="text-muted-foreground">{t.windowLabel}</span>{' '}
-                          {new Date(window.start_unix * 1000).toISOString()} →{' '}
-                          {new Date(window.end_unix * 1000).toISOString()}
+                          {formatWindowBound(window.start_unix)} →{' '}
+                          {formatWindowBound(window.end_unix)}
                         </span>
                         <span>
                           <span className="text-muted-foreground">{t.windowDurationLabel}</span>{' '}

--- a/packages/app/src/components/gpu-power/power-window.test.ts
+++ b/packages/app/src/components/gpu-power/power-window.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  RECONCILIATION_OK_PCT,
+  RECONCILIATION_WARN_PCT,
+  alignWindowToTrace,
+  classifyDelta,
+  integrateWindowPower,
+  parseTimestampUtcMs,
+} from './power-window';
+import type { GpuMetricRow } from './types';
+
+const BASE_UNIX = 1_755_000_000;
+
+function row(overrides: Partial<GpuMetricRow> & { timestamp: string }): GpuMetricRow {
+  return {
+    index: 0,
+    power: 400,
+    temperature: 60,
+    smClock: 1500,
+    memClock: 2000,
+    gpuUtil: 90,
+    memUtil: 70,
+    ...overrides,
+  };
+}
+
+/** Rows for one GPU at 1 Hz epoch-second timestamps with a power function. */
+function gpuRows(
+  gpuIndex: number,
+  startOffsetS: number,
+  endOffsetS: number,
+  powerAt: (offsetS: number) => number,
+  stepS = 1,
+): GpuMetricRow[] {
+  const rows: GpuMetricRow[] = [];
+  for (let t = startOffsetS; t <= endOffsetS; t += stepS) {
+    rows.push(row({ timestamp: String(BASE_UNIX + t), index: gpuIndex, power: powerAt(t) }));
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// parseTimestampUtcMs
+// ---------------------------------------------------------------------------
+
+describe('parseTimestampUtcMs', () => {
+  it('parses nvidia-smi naive timestamps as UTC regardless of viewer timezone', () => {
+    expect(parseTimestampUtcMs('2025/01/15 12:34:56.789')).toBe(
+      Date.UTC(2025, 0, 15, 12, 34, 56, 789),
+    );
+    expect(parseTimestampUtcMs('2025/01/15 12:34:56')).toBe(Date.UTC(2025, 0, 15, 12, 34, 56));
+    // short fraction pads to milliseconds
+    expect(parseTimestampUtcMs('2025/01/15 12:34:56.5')).toBe(
+      Date.UTC(2025, 0, 15, 12, 34, 56, 500),
+    );
+  });
+
+  it('parses naive ISO timestamps as UTC', () => {
+    expect(parseTimestampUtcMs('2026-03-01T00:00:00')).toBe(Date.UTC(2026, 2, 1));
+    expect(parseTimestampUtcMs('2026-03-01 00:00:00.250')).toBe(Date.UTC(2026, 2, 1, 0, 0, 0, 250));
+  });
+
+  it('parses TZ-suffixed ISO timestamps via Date', () => {
+    expect(parseTimestampUtcMs('2026-03-01T00:00:00Z')).toBe(Date.UTC(2026, 2, 1));
+    expect(parseTimestampUtcMs('2026-03-01T01:00:00+01:00')).toBe(Date.UTC(2026, 2, 1));
+  });
+
+  it('parses numeric epochs in seconds and milliseconds', () => {
+    expect(parseTimestampUtcMs('1755000000')).toBe(1_755_000_000_000);
+    expect(parseTimestampUtcMs('1755000000.5')).toBe(1_755_000_000_500);
+    expect(parseTimestampUtcMs('1755000000123')).toBe(1_755_000_000_123);
+  });
+
+  it('returns null for formats whose UTC placement would be a guess', () => {
+    expect(parseTimestampUtcMs('')).toBeNull();
+    expect(parseTimestampUtcMs('N/A')).toBeNull();
+    expect(parseTimestampUtcMs('Wed Mar 01 2026')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// alignWindowToTrace
+// ---------------------------------------------------------------------------
+
+describe('alignWindowToTrace', () => {
+  const trace = gpuRows(0, 0, 100, () => 400);
+
+  it('places a window fully inside the trace', () => {
+    const aligned = alignWindowToTrace(trace, {
+      start_unix: BASE_UNIX + 20,
+      end_unix: BASE_UNIX + 80,
+    });
+    expect(aligned).toEqual({
+      startSeconds: 20,
+      endSeconds: 80,
+      clampedStart: false,
+      clampedEnd: false,
+    });
+  });
+
+  it('clamps and flags a window extending past the trace', () => {
+    const aligned = alignWindowToTrace(trace, {
+      start_unix: BASE_UNIX - 10,
+      end_unix: BASE_UNIX + 120,
+    });
+    expect(aligned).toEqual({
+      startSeconds: 0,
+      endSeconds: 100,
+      clampedStart: true,
+      clampedEnd: true,
+    });
+  });
+
+  it('returns null for a disjoint window (never a shifted guess)', () => {
+    expect(
+      alignWindowToTrace(trace, { start_unix: BASE_UNIX + 500, end_unix: BASE_UNIX + 600 }),
+    ).toBeNull();
+    expect(
+      alignWindowToTrace(trace, { start_unix: BASE_UNIX - 600, end_unix: BASE_UNIX - 500 }),
+    ).toBeNull();
+  });
+
+  it('returns null for an empty or unparseable trace and degenerate windows', () => {
+    expect(alignWindowToTrace([], { start_unix: 0, end_unix: 1 })).toBeNull();
+    expect(
+      alignWindowToTrace([row({ timestamp: 'garbage' })], { start_unix: 0, end_unix: 1 }),
+    ).toBeNull();
+    expect(
+      alignWindowToTrace(trace, { start_unix: BASE_UNIX + 50, end_unix: BASE_UNIX + 50 }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// integrateWindowPower
+// ---------------------------------------------------------------------------
+
+describe('integrateWindowPower', () => {
+  it('recovers a constant power exactly', () => {
+    const data = gpuRows(0, 0, 100, () => 400);
+    const result = integrateWindowPower(data, {
+      start_unix: BASE_UNIX + 20,
+      end_unix: BASE_UNIX + 80,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.avgPowerPerGpuW).toBeCloseTo(400, 9);
+    expect(result!.totalEnergyJ).toBeCloseTo(400 * 60, 9);
+    expect(result!.gpuCount).toBe(1);
+    expect(result!.partialCoverage).toBe(false);
+  });
+
+  it('matches the hand-computed trapezoid for a linear ramp', () => {
+    // power(t) = 100 + 10t over t ∈ [0, 10]; ∫ from 2 to 8 = 900 J
+    const data = gpuRows(0, 0, 10, (t) => 100 + 10 * t);
+    const result = integrateWindowPower(data, {
+      start_unix: BASE_UNIX + 2,
+      end_unix: BASE_UNIX + 8,
+    });
+    expect(result!.totalEnergyJ).toBeCloseTo(900, 9);
+    expect(result!.avgPowerPerGpuW).toBeCloseTo(150, 9);
+  });
+
+  it('interpolates linearly at both window boundaries', () => {
+    // Only two samples: 100 W at t=0, 200 W at t=10. Window [2.5, 7.5]:
+    // boundary powers 125/175, energy = 5 * 150 = 750 J.
+    const data = [
+      row({ timestamp: String(BASE_UNIX), power: 100 }),
+      row({ timestamp: String(BASE_UNIX + 10), power: 200 }),
+    ];
+    const result = integrateWindowPower(data, {
+      start_unix: BASE_UNIX + 2.5,
+      end_unix: BASE_UNIX + 7.5,
+    });
+    expect(result!.totalEnergyJ).toBeCloseTo(750, 9);
+    expect(result!.avgPowerPerGpuW).toBeCloseTo(150, 9);
+    expect(result!.partialCoverage).toBe(false);
+  });
+
+  it('averages across GPUs with different sample cadences', () => {
+    const data = [...gpuRows(0, 0, 100, () => 300, 1), ...gpuRows(1, 0, 100, () => 500, 2)];
+    const result = integrateWindowPower(data, {
+      start_unix: BASE_UNIX + 10,
+      end_unix: BASE_UNIX + 90,
+    });
+    expect(result!.gpuCount).toBe(2);
+    expect(result!.avgPowerPerGpuW).toBeCloseTo(400, 9);
+  });
+
+  it('clamps and flags a window not fully covered by the trace', () => {
+    const data = gpuRows(0, 0, 50, () => 400);
+    const result = integrateWindowPower(data, {
+      start_unix: BASE_UNIX + 40,
+      end_unix: BASE_UNIX + 60,
+    });
+    expect(result!.partialCoverage).toBe(true);
+    expect(result!.avgPowerPerGpuW).toBeCloseTo(400, 9);
+    expect(result!.totalEnergyJ).toBeCloseTo(400 * 10, 9);
+  });
+
+  it('returns null when no GPU has at least 2 overlapping samples', () => {
+    expect(
+      integrateWindowPower([row({ timestamp: String(BASE_UNIX + 30) })], {
+        start_unix: BASE_UNIX + 20,
+        end_unix: BASE_UNIX + 80,
+      }),
+    ).toBeNull();
+    // Two samples but disjoint from the window
+    expect(
+      integrateWindowPower(
+        gpuRows(0, 0, 10, () => 400),
+        {
+          start_unix: BASE_UNIX + 100,
+          end_unix: BASE_UNIX + 200,
+        },
+      ),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyDelta
+// ---------------------------------------------------------------------------
+
+describe('classifyDelta', () => {
+  it('classifies at the 2% and 5% boundaries (inclusive)', () => {
+    expect(RECONCILIATION_OK_PCT).toBe(2);
+    expect(RECONCILIATION_WARN_PCT).toBe(5);
+    expect(classifyDelta(102, 100)).toEqual({ deltaPct: 2, level: 'ok' });
+    expect(classifyDelta(98, 100)).toEqual({ deltaPct: -2, level: 'ok' });
+    expect(classifyDelta(102.5, 100)).toEqual({ deltaPct: 2.5, level: 'warn' });
+    expect(classifyDelta(105, 100)).toEqual({ deltaPct: 5, level: 'warn' });
+    expect(classifyDelta(105.1, 100).level).toBe('alert');
+    expect(classifyDelta(94, 100).level).toBe('alert');
+  });
+
+  it('handles a zero published value without dividing by zero', () => {
+    expect(classifyDelta(0, 0)).toEqual({ deltaPct: 0, level: 'ok' });
+    expect(classifyDelta(5, 0)).toEqual({ deltaPct: Infinity, level: 'alert' });
+  });
+});

--- a/packages/app/src/components/gpu-power/power-window.ts
+++ b/packages/app/src/components/gpu-power/power-window.ts
@@ -1,0 +1,244 @@
+/**
+ * Client-side measurement-window math for the PowerX viewer: UTC-deterministic
+ * timestamp parsing, window-to-trace alignment, and a viewer-side re-run of
+ * the producer's per-device trapezoid integration
+ * (`per_device_trapezoidal_with_linear_boundary_interpolation`,
+ * InferenceX utils/aggregate_power.py). This is an independent cross-check of
+ * the published `avg_power_w`, not a source of truth.
+ */
+import type { GpuMetricRow, PowerWindow } from './types';
+
+/** |Δ| at or below this % renders as ok (well inside the producer tolerance). */
+export const RECONCILIATION_OK_PCT = 2;
+/** |Δ| at or below this % renders as warn — the producer's accumulator cross-check tolerance (5%). */
+export const RECONCILIATION_WARN_PCT = 5;
+
+// nvidia-smi naive local time, e.g. "2025/01/15 12:34:56.789"
+const NVIDIA_NAIVE_RE =
+  /^(?<year>\d{4})\/(?<month>\d{2})\/(?<day>\d{2})[ T](?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?:\.(?<fraction>\d{1,3}))?$/u;
+// naive ISO without timezone designator, e.g. "2025-01-15T12:34:56.789"
+const NAIVE_ISO_RE =
+  /^(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})[ T](?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?:\.(?<fraction>\d{1,3}))?$/u;
+// ISO with explicit offset — safe to hand to Date regardless of viewer TZ
+const TZ_SUFFIX_RE = /(?:Z|[+-]\d{2}:?\d{2})$/u;
+const NUMERIC_EPOCH_RE = /^\d+(?:\.\d+)?$/u;
+
+function utcMsFromParts(match: RegExpExecArray): number {
+  const { year, month, day, hour, minute, second, fraction } = match.groups!;
+  const ms = fraction ? Number(fraction.padEnd(3, '0')) : 0;
+  return Date.UTC(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+    Number(hour),
+    Number(minute),
+    Number(second),
+    ms,
+  );
+}
+
+/**
+ * Parse a trace timestamp to UTC epoch milliseconds, deterministically in any
+ * viewer timezone. Naive timestamps (nvidia-smi and bare ISO) are interpreted
+ * as UTC — matching the UTC clocks of the benchmark runner containers that
+ * wrote them. Returns null for formats whose UTC placement would be a guess.
+ */
+export function parseTimestampUtcMs(raw: string): number | null {
+  const value = raw.trim();
+  if (value.length === 0) return null;
+
+  if (NUMERIC_EPOCH_RE.test(value)) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return null;
+    return numeric < 1e12 ? numeric * 1000 : numeric;
+  }
+
+  const nvidiaMatch = NVIDIA_NAIVE_RE.exec(value);
+  if (nvidiaMatch) return utcMsFromParts(nvidiaMatch);
+
+  const naiveIsoMatch = NAIVE_ISO_RE.exec(value);
+  if (naiveIsoMatch) return utcMsFromParts(naiveIsoMatch);
+
+  if (TZ_SUFFIX_RE.test(value)) {
+    const ms = new Date(value).getTime();
+    return Number.isNaN(ms) ? null : ms;
+  }
+
+  return null;
+}
+
+export interface AlignedWindow {
+  startSeconds: number;
+  endSeconds: number;
+  clampedStart: boolean;
+  clampedEnd: boolean;
+}
+
+/**
+ * Place a unix-epoch measurement window on the chart's relative-seconds axis.
+ * Every sample in one CSV shifts by the same constant under viewer-TZ vs UTC
+ * parsing, so seconds relative to the trace minimum land on the existing axis.
+ * Returns null when the window does not intersect the trace — never a shifted
+ * guess (e.g. a non-UTC runner clock).
+ */
+export function alignWindowToTrace(
+  data: GpuMetricRow[],
+  window: PowerWindow,
+): AlignedWindow | null {
+  if (window.end_unix <= window.start_unix) return null;
+
+  let minMs = Infinity;
+  let maxMs = -Infinity;
+  for (const row of data) {
+    const ms = parseTimestampUtcMs(row.timestamp);
+    if (ms === null) continue;
+    if (ms < minMs) minMs = ms;
+    if (ms > maxMs) maxMs = ms;
+  }
+  if (!Number.isFinite(minMs) || !Number.isFinite(maxMs)) return null;
+
+  const windowStartMs = window.start_unix * 1000;
+  const windowEndMs = window.end_unix * 1000;
+  if (windowEndMs <= minMs || windowStartMs >= maxMs) return null;
+
+  const clampedStart = windowStartMs < minMs;
+  const clampedEnd = windowEndMs > maxMs;
+  return {
+    startSeconds: (Math.max(windowStartMs, minMs) - minMs) / 1000,
+    endSeconds: (Math.min(windowEndMs, maxMs) - minMs) / 1000,
+    clampedStart,
+    clampedEnd,
+  };
+}
+
+/** Linear interpolation at a timestamp bracketed by sorted samples. */
+function interpolatePower(samples: [number, number][], timeS: number): number {
+  let rightIndex = samples.findIndex(([t]) => t >= timeS);
+  if (rightIndex === -1) rightIndex = samples.length;
+  if (rightIndex < samples.length && Math.abs(samples[rightIndex][0] - timeS) <= 1e-9) {
+    return samples[rightIndex][1];
+  }
+  const leftIndex = rightIndex - 1;
+  const [leftTime, leftPower] = samples[leftIndex];
+  const [rightTime, rightPower] = samples[rightIndex];
+  const fraction = (timeS - leftTime) / (rightTime - leftTime);
+  return leftPower + fraction * (rightPower - leftPower);
+}
+
+/** Trapezoid energy of one device over [startS, endS], boundary-interpolated. */
+function integrateDevice(samples: [number, number][], startS: number, endS: number): number {
+  const clipped: [number, number][] = [[startS, interpolatePower(samples, startS)]];
+  for (const [t, p] of samples) {
+    if (t > startS && t < endS) clipped.push([t, p]);
+  }
+  clipped.push([endS, interpolatePower(samples, endS)]);
+
+  let energyJ = 0;
+  for (let i = 1; i < clipped.length; i++) {
+    const [leftTime, leftPower] = clipped[i - 1];
+    const [rightTime, rightPower] = clipped[i];
+    energyJ += (rightTime - leftTime) * ((leftPower + rightPower) / 2);
+  }
+  return energyJ;
+}
+
+export interface WindowPowerRecompute {
+  avgPowerPerGpuW: number;
+  totalEnergyJ: number;
+  gpuCount: number;
+  sampleCount: number;
+  /** true when the window extends past the trace for any device (clamped). */
+  partialCoverage: boolean;
+}
+
+/**
+ * Re-integrate the trace over the measurement window, mirroring the producer:
+ * per-GPU sort by UTC epoch, same-timestamp samples averaged, linear
+ * interpolation at both boundaries, trapezoid inside, energies summed, then
+ * `/ duration / gpuCount`. Coverage gaps are clamped per device and flagged.
+ * Returns null when no GPU has at least 2 samples overlapping the window.
+ */
+export function integrateWindowPower(
+  data: GpuMetricRow[],
+  window: PowerWindow,
+): WindowPowerRecompute | null {
+  if (window.end_unix <= window.start_unix) return null;
+
+  // Group by GPU; average duplicate timestamps like the producer does.
+  const byGpu = new Map<number, Map<number, number[]>>();
+  for (const row of data) {
+    const ms = parseTimestampUtcMs(row.timestamp);
+    if (ms === null || !Number.isFinite(row.power) || row.power < 0) continue;
+    const timeS = ms / 1000;
+    let series = byGpu.get(row.index);
+    if (!series) {
+      series = new Map();
+      byGpu.set(row.index, series);
+    }
+    const values = series.get(timeS);
+    if (values) values.push(row.power);
+    else series.set(timeS, [row.power]);
+  }
+
+  let totalEnergyJ = 0;
+  let sumOfDeviceMeansW = 0;
+  let gpuCount = 0;
+  let sampleCount = 0;
+  let partialCoverage = false;
+
+  for (const series of byGpu.values()) {
+    const samples: [number, number][] = [...series.entries()]
+      .map(([t, values]): [number, number] => [
+        t,
+        values.reduce((a, b) => a + b, 0) / values.length,
+      ])
+      .sort((a, b) => a[0] - b[0]);
+    if (samples.length < 2) continue;
+
+    // Clamp the window to this device's sample extent; skip non-overlapping devices.
+    const deviceStart = Math.max(window.start_unix, samples[0][0]);
+    const deviceEnd = Math.min(window.end_unix, samples.at(-1)![0]);
+    if (deviceEnd <= deviceStart) continue;
+    if (deviceStart > window.start_unix || deviceEnd < window.end_unix) partialCoverage = true;
+
+    const energyJ = integrateDevice(samples, deviceStart, deviceEnd);
+    totalEnergyJ += energyJ;
+    sumOfDeviceMeansW += energyJ / (deviceEnd - deviceStart);
+    gpuCount += 1;
+    sampleCount += samples.filter(([t]) => t >= deviceStart && t <= deviceEnd).length;
+  }
+
+  if (gpuCount === 0) return null;
+
+  return {
+    // Full coverage reduces to the producer's totalEnergy / duration / count;
+    // clamped devices contribute their covered-portion mean instead of a
+    // silently deflated value.
+    avgPowerPerGpuW: sumOfDeviceMeansW / gpuCount,
+    totalEnergyJ,
+    gpuCount,
+    sampleCount,
+    partialCoverage,
+  };
+}
+
+/** Classify recomputed-vs-published delta with the producer-derived thresholds. */
+export function classifyDelta(
+  recomputedW: number,
+  publishedW: number,
+): { deltaPct: number; level: 'ok' | 'warn' | 'alert' } {
+  const deltaPct =
+    publishedW === 0
+      ? recomputedW === 0
+        ? 0
+        : Infinity
+      : ((recomputedW - publishedW) / publishedW) * 100;
+  const magnitude = Math.abs(deltaPct);
+  const level =
+    magnitude <= RECONCILIATION_OK_PCT
+      ? 'ok'
+      : magnitude <= RECONCILIATION_WARN_PCT
+        ? 'warn'
+        : 'alert';
+  return { deltaPct, level };
+}

--- a/packages/app/src/components/gpu-power/types.ts
+++ b/packages/app/src/components/gpu-power/types.ts
@@ -31,9 +31,41 @@ export interface GpuPowerRunInfo {
   status: string;
 }
 
+export interface PowerWindow {
+  start_unix: number;
+  end_unix: number;
+}
+
+/**
+ * Normalized power-measurement contract assembled server-side from same-suffix
+ * sibling artifacts (`bmk_*` agg rows and `power_audit_*` validation sidecars).
+ * Field names are snake_case to mirror the producer sidecars.
+ */
+export interface GpuArtifactPower {
+  /** null = verdict unknown */
+  power_valid: 0 | 1 | null;
+  /** snake_case producer reason codes; [] when valid/unknown */
+  reasons: string[];
+  window: PowerWindow | null;
+  expected_gpu_count: number | null;
+  observed_gpu_count: number | null;
+  published: {
+    avg_power_w: number | null;
+    avg_total_gpu_power_w: number | null;
+    power_metric_schema_version: number | null;
+    source: 'bmk_artifact' | 'power_audit_agg' | 'validation_metrics';
+  } | null;
+  /** agg power_audit.producer_sha or sidecar producer.producer_git_commit */
+  producer_sha: string | null;
+  exporter_image_sha256: string | null;
+  /** artifact names consulted, for the panel footer */
+  sources: string[];
+}
+
 export interface GpuMetricsArtifact {
   name: string;
   data: GpuMetricRow[];
+  power?: GpuArtifactPower;
 }
 
 export interface GpuPowerApiResponse {

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -56,7 +56,7 @@ export const apiRouteCatalog = [
     },
     // 2026-08: additive optional `power` block assembled from same-suffix
     // bmk_*/power_audit_* sibling artifacts; still a UI-only unstable shape.
-    sourceSha256: '80035a01f4a1af5331095be1b4655361aab868d7ebaefb3d0a01fce9078b863c',
+    sourceSha256: 'e2e860cca7365a49fa56e39657a2e7d272a061544415f3adcf445a5a24f94e3c',
   },
   {
     source: 'src/app/api/openapi.json/route.ts',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -54,7 +54,9 @@ export const apiRouteCatalog = [
       en: 'UI-only live GPU metric artifact lookup; its run artifact shape is not a stable public contract.',
       zh: '仅供界面读取实时 GPU 指标制品；其运行制品结构不是稳定的公开契约。',
     },
-    sourceSha256: '28e6cee4d67396ee8ea2e5a7e18271c6ee86228c33f33a20bf573f3a601ba8ed',
+    // 2026-08: additive optional `power` block assembled from same-suffix
+    // bmk_*/power_audit_* sibling artifacts; still a UI-only unstable shape.
+    sourceSha256: '80035a01f4a1af5331095be1b4655361aab868d7ebaefb3d0a01fce9078b863c',
   },
   {
     source: 'src/app/api/openapi.json/route.ts',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -56,7 +56,7 @@ export const apiRouteCatalog = [
     },
     // 2026-08: additive optional `power` block assembled from same-suffix
     // bmk_*/power_audit_* sibling artifacts; still a UI-only unstable shape.
-    sourceSha256: 'e2e860cca7365a49fa56e39657a2e7d272a061544415f3adcf445a5a24f94e3c',
+    sourceSha256: 'a752682622d9685ab7f76a1bd0d49d94df4dcc659fde36e62d56681f6146df7a',
   },
   {
     source: 'src/app/api/openapi.json/route.ts',

--- a/packages/app/src/lib/power-audit-artifacts.test.ts
+++ b/packages/app/src/lib/power-audit-artifacts.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mergeArtifactPower,
+  powerFromAggRow,
+  powerFromValidationSidecar,
+  selectValidationEntry,
+  siblingArtifactNames,
+} from './power-audit-artifacts';
+
+// ---------------------------------------------------------------------------
+// siblingArtifactNames
+// ---------------------------------------------------------------------------
+
+describe('siblingArtifactNames', () => {
+  it('derives bmk, bmk_agentic, and power_audit siblings from the suffix', () => {
+    expect(siblingArtifactNames('gpu_metrics_dsr1_1k8k_fp8_sglang_tp8_h200-nb_0')).toEqual({
+      bmk: 'bmk_dsr1_1k8k_fp8_sglang_tp8_h200-nb_0',
+      bmkAgentic: 'bmk_agentic_dsr1_1k8k_fp8_sglang_tp8_h200-nb_0',
+      powerAudit: 'power_audit_dsr1_1k8k_fp8_sglang_tp8_h200-nb_0',
+    });
+  });
+
+  it('returns null for names without the gpu_metrics_ prefix', () => {
+    expect(siblingArtifactNames('eval_gpu_metrics_dsr1')).toBeNull();
+    expect(siblingArtifactNames('bmk_dsr1')).toBeNull();
+    expect(siblingArtifactNames('gpu_metricsdsr1')).toBeNull();
+  });
+
+  it('returns null for a bare prefix with empty suffix', () => {
+    expect(siblingArtifactNames('gpu_metrics_')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// powerFromAggRow
+// ---------------------------------------------------------------------------
+
+describe('powerFromAggRow', () => {
+  it('maps a legacy agg row to published values + verdict only', () => {
+    const result = powerFromAggRow({
+      power_valid: 1,
+      power_metric_schema_version: 1,
+      avg_power_w: 412.5,
+      avg_total_gpu_power_w: 3300,
+      other_metric: 42,
+    });
+    expect(result.power_valid).toBe(1);
+    expect(result.published).toEqual({
+      avg_power_w: 412.5,
+      avg_total_gpu_power_w: 3300,
+      power_metric_schema_version: 1,
+      source: 'bmk_artifact',
+    });
+    expect(result.window).toBeUndefined();
+    expect(result.producer_sha).toBeUndefined();
+  });
+
+  it('coerces power_valid variants', () => {
+    expect(powerFromAggRow({ power_valid: '1' }).power_valid).toBe(1);
+    expect(powerFromAggRow({ power_valid: 0 }).power_valid).toBe(0);
+    expect(powerFromAggRow({ power_valid: false }).power_valid).toBe(0);
+    expect(powerFromAggRow({}).power_valid).toBeUndefined();
+    expect(powerFromAggRow({ power_valid: null }).power_valid).toBeUndefined();
+  });
+
+  it('maps power_invalid_reasons when present', () => {
+    expect(
+      powerFromAggRow({ power_valid: 0, power_invalid_reasons: ['sampling_gap_exceeded'] }).reasons,
+    ).toEqual(['sampling_gap_exceeded']);
+    expect(powerFromAggRow({ power_valid: 1 }).reasons).toBeUndefined();
+  });
+
+  it('maps a post-PLAN-06 power_audit object through to window and provenance', () => {
+    const result = powerFromAggRow(
+      {
+        power_valid: 1,
+        avg_power_w: 400,
+        power_audit: {
+          window_start_unix: 1_755_000_020,
+          window_end_unix: 1_755_000_080,
+          expected_gpu_count: 8,
+          observed_gpu_count: 8,
+          sample_count: 480,
+          max_sample_gap_s: 1.2,
+          producer_sha: 'abc123def456',
+          exporter_image_sha256: 'sha256:deadbeef',
+        },
+      },
+      'power_audit_agg',
+    );
+    expect(result.window).toEqual({ start_unix: 1_755_000_020, end_unix: 1_755_000_080 });
+    expect(result.expected_gpu_count).toBe(8);
+    expect(result.observed_gpu_count).toBe(8);
+    expect(result.producer_sha).toBe('abc123def456');
+    expect(result.exporter_image_sha256).toBe('sha256:deadbeef');
+    expect(result.published?.source).toBe('power_audit_agg');
+  });
+
+  it('tolerates a malformed power_audit object', () => {
+    const result = powerFromAggRow({
+      power_valid: 1,
+      power_audit: { window_start_unix: 'not-a-number', window_end_unix: 5 },
+    });
+    expect(result.window).toBeUndefined();
+  });
+
+  it('returns an empty partial for a row with no power fields', () => {
+    expect(powerFromAggRow({ output_toks_per_sec: 1000 })).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// powerFromValidationSidecar
+// ---------------------------------------------------------------------------
+
+describe('powerFromValidationSidecar', () => {
+  const singleNodeSidecar = {
+    schema_version: 1,
+    power_valid: true,
+    reasons: [],
+    benchmark_window: {
+      start_time_unix: 1_755_000_020,
+      end_time_unix: 1_755_000_080,
+      reported_duration_s: 60,
+    },
+    expected_gpu_count: 8,
+    observed_gpu_count: 8,
+    metrics: { avg_power_w: 401.25, avg_total_gpu_power_w: 3210, total_gpu_energy_j: 192_600 },
+  };
+
+  it('maps a single-node sidecar (benchmark_window)', () => {
+    const result = powerFromValidationSidecar(singleNodeSidecar);
+    expect(result.power_valid).toBe(1);
+    expect(result.window).toEqual({ start_unix: 1_755_000_020, end_unix: 1_755_000_080 });
+    expect(result.expected_gpu_count).toBe(8);
+    expect(result.observed_gpu_count).toBe(8);
+    expect(result.published).toEqual({
+      avg_power_w: 401.25,
+      avg_total_gpu_power_w: 3210,
+      power_metric_schema_version: 1,
+      source: 'validation_metrics',
+    });
+  });
+
+  it('maps an invalid verdict with reasons', () => {
+    const result = powerFromValidationSidecar({
+      power_valid: false,
+      reasons: ['benchmark_window_not_bracketed', 'sampling_gap_exceeded'],
+    });
+    expect(result.power_valid).toBe(0);
+    expect(result.reasons).toEqual(['benchmark_window_not_bracketed', 'sampling_gap_exceeded']);
+    expect(result.window).toBeUndefined();
+  });
+
+  it('maps a multinode sidecar (selected_window + producer)', () => {
+    const result = powerFromValidationSidecar({
+      schema_version: 1,
+      power_valid: true,
+      reasons: [],
+      benchmark_window: null,
+      selected_window: {
+        window_file: 'windows/w0.json',
+        start_time_unix: 1_755_000_100,
+        end_time_unix: 1_755_000_400,
+        duration: 300,
+      },
+      producer: {
+        producer_git_commit: 'fedcba987654',
+        exporter_image_sha256: 'sha256:cafebabe',
+      },
+      expected_gpu_count: 16,
+      observed_gpu_count: 16,
+      metrics: { avg_power_w: 512.75 },
+    });
+    expect(result.window).toEqual({ start_unix: 1_755_000_100, end_unix: 1_755_000_400 });
+    expect(result.producer_sha).toBe('fedcba987654');
+    expect(result.exporter_image_sha256).toBe('sha256:cafebabe');
+  });
+
+  it('prefers benchmark_window over selected_window when both are present', () => {
+    const result = powerFromValidationSidecar({
+      power_valid: true,
+      benchmark_window: { start_time_unix: 10, end_time_unix: 20 },
+      selected_window: { start_time_unix: 30, end_time_unix: 40 },
+    });
+    expect(result.window).toEqual({ start_unix: 10, end_unix: 20 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectValidationEntry
+// ---------------------------------------------------------------------------
+
+describe('selectValidationEntry', () => {
+  const suffix = 'dsr1_1k8k_fp8_sglang_tp8_h200-nb_0';
+
+  it('picks the single power_validation entry', () => {
+    const sidecar = { power_valid: true };
+    expect(
+      selectValidationEntry(
+        [
+          { entryName: `power_validation_${suffix}.json`, json: sidecar },
+          { entryName: `agg_${suffix}.json`, json: { avg_power_w: 1 } },
+          { entryName: `${suffix}.json`, json: {} },
+        ],
+        suffix,
+      ),
+    ).toBe(sidecar);
+  });
+
+  it('matches agentic results/power_validation.json by basename', () => {
+    const sidecar = { power_valid: true };
+    expect(
+      selectValidationEntry(
+        [{ entryName: 'results/power_validation.json', json: sidecar }],
+        suffix,
+      ),
+    ).toBe(sidecar);
+  });
+
+  it('resolves multinode ambiguity via the benchmark_result stem', () => {
+    const match = { power_valid: true, benchmark_result: `/workspace/results/${suffix}.json` };
+    const other = { power_valid: true, benchmark_result: '/workspace/results/other_config.json' };
+    expect(
+      selectValidationEntry(
+        [
+          { entryName: `power_validation_${suffix}_node0.json`, json: other },
+          { entryName: `power_validation_${suffix}_node1.json`, json: match },
+        ],
+        suffix,
+      ),
+    ).toBe(match);
+  });
+
+  it('returns null when several entries exist and none matches the suffix', () => {
+    expect(
+      selectValidationEntry(
+        [
+          { entryName: 'power_validation_a.json', json: { benchmark_result: '/r/a.json' } },
+          { entryName: 'power_validation_b.json', json: { benchmark_result: '/r/b.json' } },
+        ],
+        suffix,
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when no power_validation entries exist', () => {
+    expect(
+      selectValidationEntry([{ entryName: `agg_${suffix}.json`, json: {} }], suffix),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeArtifactPower
+// ---------------------------------------------------------------------------
+
+describe('mergeArtifactPower', () => {
+  it('returns null when both inputs are null or empty', () => {
+    expect(mergeArtifactPower(null, null, [])).toBeNull();
+    expect(mergeArtifactPower({}, {}, ['bmk_x'])).toBeNull();
+  });
+
+  it('sidecar wins for window/reasons/counts, agg wins for published', () => {
+    const merged = mergeArtifactPower(
+      {
+        power_valid: 1,
+        published: {
+          avg_power_w: 402,
+          avg_total_gpu_power_w: 3216,
+          power_metric_schema_version: 1,
+          source: 'bmk_artifact',
+        },
+        window: { start_unix: 1, end_unix: 2 },
+      },
+      {
+        power_valid: 0,
+        reasons: ['sampling_gap_exceeded'],
+        window: { start_unix: 10, end_unix: 20 },
+        expected_gpu_count: 8,
+        observed_gpu_count: 7,
+        published: {
+          avg_power_w: 400,
+          avg_total_gpu_power_w: null,
+          power_metric_schema_version: 1,
+          source: 'validation_metrics',
+        },
+        producer_sha: 'sidecar-sha',
+      },
+      ['bmk_x', 'power_audit_x'],
+    );
+    expect(merged).toEqual({
+      power_valid: 0,
+      reasons: ['sampling_gap_exceeded'],
+      window: { start_unix: 10, end_unix: 20 },
+      expected_gpu_count: 8,
+      observed_gpu_count: 7,
+      published: {
+        avg_power_w: 402,
+        avg_total_gpu_power_w: 3216,
+        power_metric_schema_version: 1,
+        source: 'bmk_artifact',
+      },
+      producer_sha: 'sidecar-sha',
+      exporter_image_sha256: null,
+      sources: ['bmk_x', 'power_audit_x'],
+    });
+  });
+
+  it('fills every missing field with null/[] defaults from a lone agg row', () => {
+    const merged = mergeArtifactPower({ power_valid: 1 }, null, ['bmk_x']);
+    expect(merged).toEqual({
+      power_valid: 1,
+      reasons: [],
+      window: null,
+      expected_gpu_count: null,
+      observed_gpu_count: null,
+      published: null,
+      producer_sha: null,
+      exporter_image_sha256: null,
+      sources: ['bmk_x'],
+    });
+  });
+
+  it('falls back to sidecar published when the agg row has none', () => {
+    const merged = mergeArtifactPower(
+      { power_valid: 1 },
+      {
+        published: {
+          avg_power_w: 399,
+          avg_total_gpu_power_w: null,
+          power_metric_schema_version: 1,
+          source: 'validation_metrics',
+        },
+      },
+      ['power_audit_x'],
+    );
+    expect(merged?.published?.source).toBe('validation_metrics');
+    expect(merged?.published?.avg_power_w).toBe(399);
+  });
+});

--- a/packages/app/src/lib/power-audit-artifacts.test.ts
+++ b/packages/app/src/lib/power-audit-artifacts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  hasPowerContent,
   mergeArtifactPower,
   powerFromAggRow,
   powerFromValidationSidecar,
@@ -108,6 +109,25 @@ describe('powerFromAggRow', () => {
   it('returns an empty partial for a row with no power fields', () => {
     expect(powerFromAggRow({ output_toks_per_sec: 1000 })).toEqual({});
   });
+
+  it('rejects implausible window epochs (garbage, ms-scale, non-positive)', () => {
+    // 1e16 s → new Date(1e19 ms) would throw RangeError in the client render.
+    expect(
+      powerFromAggRow({
+        power_audit: { window_start_unix: 1e16, window_end_unix: 1e16 + 60 },
+      }).window,
+    ).toBeUndefined();
+    expect(
+      powerFromAggRow({
+        power_audit: { window_start_unix: 1_755_000_020_000, window_end_unix: 1_755_000_080_000 },
+      }).window,
+    ).toBeUndefined();
+    expect(
+      powerFromAggRow({
+        power_audit: { window_start_unix: -5, window_end_unix: 1_755_000_080 },
+      }).window,
+    ).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -138,9 +158,19 @@ describe('powerFromValidationSidecar', () => {
     expect(result.published).toEqual({
       avg_power_w: 401.25,
       avg_total_gpu_power_w: 3210,
-      power_metric_schema_version: 1,
+      // The sidecar's own schema_version is a different versioning axis than
+      // the agg row's power_metric_schema_version — never mapped through.
+      power_metric_schema_version: null,
       source: 'validation_metrics',
     });
+  });
+
+  it('rejects implausible window epochs in the sidecar', () => {
+    expect(
+      powerFromValidationSidecar({
+        benchmark_window: { start_time_unix: 1_755_000_020_000, end_time_unix: 1_755_000_080_000 },
+      }).window,
+    ).toBeUndefined();
   });
 
   it('maps an invalid verdict with reasons', () => {
@@ -249,6 +279,19 @@ describe('selectValidationEntry', () => {
     expect(
       selectValidationEntry([{ entryName: `agg_${suffix}.json`, json: {} }], suffix),
     ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasPowerContent
+// ---------------------------------------------------------------------------
+
+describe('hasPowerContent', () => {
+  it('distinguishes empty partials from ones carrying a power field', () => {
+    expect(hasPowerContent(null)).toBe(false);
+    expect(hasPowerContent({})).toBe(false);
+    expect(hasPowerContent({ power_valid: 1 })).toBe(true);
+    expect(hasPowerContent(powerFromAggRow({ output_toks_per_sec: 1000 }))).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/power-audit-artifacts.ts
+++ b/packages/app/src/lib/power-audit-artifacts.ts
@@ -46,10 +46,17 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+// Upper bound on plausible unix-second epochs (2100-01-01T00:00:00Z). Rejects
+// ms-scale and garbage values, and keeps bound*1000 inside Date's ±8.64e15 ms
+// representable range so the client can always ISO-format the window.
+const MAX_UNIX_SECONDS = 4_102_444_800;
+
 function windowFromUnixPair(start: unknown, end: unknown): PowerWindow | null {
   const startUnix = asFiniteNumber(start);
   const endUnix = asFiniteNumber(end);
   if (startUnix === null || endUnix === null) return null;
+  if (startUnix <= 0 || endUnix <= 0) return null;
+  if (startUnix > MAX_UNIX_SECONDS || endUnix > MAX_UNIX_SECONDS) return null;
   return { start_unix: startUnix, end_unix: endUnix };
 }
 
@@ -141,7 +148,9 @@ export function powerFromValidationSidecar(
       result.published = {
         avg_power_w: avgPowerW,
         avg_total_gpu_power_w: avgTotalGpuPowerW,
-        power_metric_schema_version: asFiniteNumber(sidecar.schema_version),
+        // The sidecar's schema_version versions the sidecar itself, a
+        // different axis than the agg row's power_metric_schema_version.
+        power_metric_schema_version: null,
         source: 'validation_metrics',
       };
     }
@@ -195,7 +204,8 @@ export function selectValidationEntry(
   return null;
 }
 
-function hasContent(
+/** True when a mapped partial carries at least one power field. */
+export function hasPowerContent(
   partial: Partial<GpuArtifactPower> | null,
 ): partial is Partial<GpuArtifactPower> {
   return partial !== null && Object.keys(partial).length > 0;
@@ -212,7 +222,7 @@ export function mergeArtifactPower(
   fromSidecar: Partial<GpuArtifactPower> | null,
   sources: string[],
 ): GpuArtifactPower | null {
-  if (!hasContent(fromAgg) && !hasContent(fromSidecar)) return null;
+  if (!hasPowerContent(fromAgg) && !hasPowerContent(fromSidecar)) return null;
   const agg = fromAgg ?? {};
   const sidecar = fromSidecar ?? {};
 

--- a/packages/app/src/lib/power-audit-artifacts.ts
+++ b/packages/app/src/lib/power-audit-artifacts.ts
@@ -1,0 +1,230 @@
+/**
+ * Pure mapping helpers for assembling a normalized `GpuArtifactPower` block
+ * from the power sidecar artifacts that share a `gpu_metrics_<X>` suffix:
+ * the tiny `bmk_<X>` agg row and the `power_audit_<X>` validation bundle.
+ * No fetching happens here — the /api/gpu-metrics route wires the downloads.
+ */
+import type { GpuArtifactPower, PowerWindow } from '@/components/gpu-power/types';
+
+const GPU_METRICS_PREFIX = 'gpu_metrics_';
+
+export interface SiblingArtifactNames {
+  bmk: string;
+  bmkAgentic: string;
+  powerAudit: string;
+}
+
+/** Derive same-suffix sibling artifact names for a `gpu_metrics_<X>` artifact. */
+export function siblingArtifactNames(gpuMetricsArtifactName: string): SiblingArtifactNames | null {
+  if (!gpuMetricsArtifactName.startsWith(GPU_METRICS_PREFIX)) return null;
+  const suffix = gpuMetricsArtifactName.slice(GPU_METRICS_PREFIX.length);
+  if (suffix.length === 0) return null;
+  return {
+    bmk: `bmk_${suffix}`,
+    bmkAgentic: `bmk_agentic_${suffix}`,
+    powerAudit: `power_audit_${suffix}`,
+  };
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function windowFromUnixPair(start: unknown, end: unknown): PowerWindow | null {
+  const startUnix = asFiniteNumber(start);
+  const endUnix = asFiniteNumber(end);
+  if (startUnix === null || endUnix === null) return null;
+  return { start_unix: startUnix, end_unix: endUnix };
+}
+
+/**
+ * Map an `agg_<X>.json` row (the exact bytes the ETL ingests) to power fields.
+ * Legacy rows yield published values + verdict only; rows carrying the PLAN-06
+ * `power_audit` object additionally yield window bounds, counts, and provenance.
+ */
+export function powerFromAggRow(
+  agg: Record<string, unknown>,
+  source: 'bmk_artifact' | 'power_audit_agg' = 'bmk_artifact',
+): Partial<GpuArtifactPower> {
+  const result: Partial<GpuArtifactPower> = {};
+
+  if ('power_valid' in agg && agg.power_valid !== null && agg.power_valid !== undefined) {
+    result.power_valid = agg.power_valid === 1 || agg.power_valid === '1' ? 1 : 0;
+  }
+
+  const reasons = asStringArray(agg.power_invalid_reasons);
+  if (reasons.length > 0) result.reasons = reasons;
+
+  const avgPowerW = asFiniteNumber(agg.avg_power_w);
+  const avgTotalGpuPowerW = asFiniteNumber(agg.avg_total_gpu_power_w);
+  const schemaVersion = asFiniteNumber(agg.power_metric_schema_version);
+  if (avgPowerW !== null || avgTotalGpuPowerW !== null || schemaVersion !== null) {
+    result.published = {
+      avg_power_w: avgPowerW,
+      avg_total_gpu_power_w: avgTotalGpuPowerW,
+      power_metric_schema_version: schemaVersion,
+      source,
+    };
+  }
+
+  const audit = asRecord(agg.power_audit);
+  if (audit) {
+    const window = windowFromUnixPair(audit.window_start_unix, audit.window_end_unix);
+    if (window) result.window = window;
+    const expected = asFiniteNumber(audit.expected_gpu_count);
+    if (expected !== null) result.expected_gpu_count = expected;
+    const observed = asFiniteNumber(audit.observed_gpu_count);
+    if (observed !== null) result.observed_gpu_count = observed;
+    const producerSha = asString(audit.producer_sha);
+    if (producerSha) result.producer_sha = producerSha;
+    const exporterSha = asString(audit.exporter_image_sha256);
+    if (exporterSha) result.exporter_image_sha256 = exporterSha;
+  }
+
+  return result;
+}
+
+/**
+ * Map a `power_validation_*.json` sidecar (single-node `benchmark_window` or
+ * multinode `selected_window` + `producer`) to power fields.
+ */
+export function powerFromValidationSidecar(
+  sidecar: Record<string, unknown>,
+): Partial<GpuArtifactPower> {
+  const result: Partial<GpuArtifactPower> = {};
+
+  if (typeof sidecar.power_valid === 'boolean') {
+    result.power_valid = sidecar.power_valid ? 1 : 0;
+  } else if (sidecar.power_valid === 0 || sidecar.power_valid === 1) {
+    result.power_valid = sidecar.power_valid;
+  }
+
+  const reasons = asStringArray(sidecar.reasons);
+  if (reasons.length > 0) result.reasons = reasons;
+
+  const benchmarkWindow = asRecord(sidecar.benchmark_window);
+  const selectedWindow = asRecord(sidecar.selected_window);
+  const window =
+    (benchmarkWindow &&
+      windowFromUnixPair(benchmarkWindow.start_time_unix, benchmarkWindow.end_time_unix)) ??
+    (selectedWindow &&
+      windowFromUnixPair(selectedWindow.start_time_unix, selectedWindow.end_time_unix)) ??
+    null;
+  if (window) result.window = window;
+
+  const expected = asFiniteNumber(sidecar.expected_gpu_count);
+  if (expected !== null) result.expected_gpu_count = expected;
+  const observed = asFiniteNumber(sidecar.observed_gpu_count);
+  if (observed !== null) result.observed_gpu_count = observed;
+
+  const metrics = asRecord(sidecar.metrics);
+  if (metrics) {
+    const avgPowerW = asFiniteNumber(metrics.avg_power_w);
+    const avgTotalGpuPowerW = asFiniteNumber(metrics.avg_total_gpu_power_w);
+    if (avgPowerW !== null || avgTotalGpuPowerW !== null) {
+      result.published = {
+        avg_power_w: avgPowerW,
+        avg_total_gpu_power_w: avgTotalGpuPowerW,
+        power_metric_schema_version: asFiniteNumber(sidecar.schema_version),
+        source: 'validation_metrics',
+      };
+    }
+  }
+
+  const producer = asRecord(sidecar.producer);
+  if (producer) {
+    const producerSha = asString(producer.producer_git_commit);
+    if (producerSha) result.producer_sha = producerSha;
+    const exporterSha = asString(producer.exporter_image_sha256);
+    if (exporterSha) result.exporter_image_sha256 = exporterSha;
+  }
+
+  return result;
+}
+
+/** Basename of a ZIP entry path (agentic bundles nest under `results/`). */
+function entryBasename(entryName: string): string {
+  const idx = entryName.lastIndexOf('/');
+  return idx === -1 ? entryName : entryName.slice(idx + 1);
+}
+
+/** Filename stem: basename without its final extension. */
+function pathStem(path: string): string {
+  const base = entryBasename(path.replaceAll('\\', '/'));
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}
+
+/**
+ * Pick the validation sidecar entry for `suffix` out of a `power_audit_*`
+ * bundle. Multinode bundles can hold several `power_validation_*_*.json`
+ * entries; keep the one whose `benchmark_result` stem equals the suffix,
+ * otherwise keep a lone entry. Ambiguity yields null — never a guess.
+ */
+export function selectValidationEntry(
+  entries: { entryName: string; json: Record<string, unknown> }[],
+  suffix: string,
+): Record<string, unknown> | null {
+  const candidates = entries.filter((entry) =>
+    entryBasename(entry.entryName).startsWith('power_validation'),
+  );
+  if (candidates.length === 0) return null;
+
+  const exact = candidates.filter((entry) => {
+    const benchmarkResult = asString(entry.json.benchmark_result);
+    return benchmarkResult !== null && pathStem(benchmarkResult) === suffix;
+  });
+  if (exact.length === 1) return exact[0].json;
+  if (candidates.length === 1) return candidates[0].json;
+  return null;
+}
+
+function hasContent(
+  partial: Partial<GpuArtifactPower> | null,
+): partial is Partial<GpuArtifactPower> {
+  return partial !== null && Object.keys(partial).length > 0;
+}
+
+/**
+ * Merge the agg-row and sidecar mappings into the final normalized block.
+ * The sidecar wins for window/reasons/counts (it is the audit source of
+ * truth); the agg row wins for the published value (it is the exact row the
+ * ETL ingests). Returns null when neither input carried anything.
+ */
+export function mergeArtifactPower(
+  fromAgg: Partial<GpuArtifactPower> | null,
+  fromSidecar: Partial<GpuArtifactPower> | null,
+  sources: string[],
+): GpuArtifactPower | null {
+  if (!hasContent(fromAgg) && !hasContent(fromSidecar)) return null;
+  const agg = fromAgg ?? {};
+  const sidecar = fromSidecar ?? {};
+
+  return {
+    power_valid: sidecar.power_valid ?? agg.power_valid ?? null,
+    reasons: sidecar.reasons ?? agg.reasons ?? [],
+    window: sidecar.window ?? agg.window ?? null,
+    expected_gpu_count: sidecar.expected_gpu_count ?? agg.expected_gpu_count ?? null,
+    observed_gpu_count: sidecar.observed_gpu_count ?? agg.observed_gpu_count ?? null,
+    published: agg.published ?? sidecar.published ?? null,
+    producer_sha: agg.producer_sha ?? sidecar.producer_sha ?? null,
+    exporter_image_sha256: agg.exporter_image_sha256 ?? sidecar.exporter_image_sha256 ?? null,
+    sources,
+  };
+}


### PR DESCRIPTION
## Summary

Closes gap **G21** (PLAN-13): the hidden PowerX viewer (`/gpu-metrics`) rendered raw GPU telemetry with no indication of which part of the trace was formally measured, whether the measurement was declared valid, or whether the published `avg_power_w` matches the trace.

- **`GET /api/gpu-metrics` (additive):** each `gpu_metrics_<X>` artifact entry can now carry an optional `power` block assembled server-side from same-suffix sibling artifacts, cheapest first — the tiny `bmk_<X>` / `bmk_agentic_<X>` agg row (Tier 1; sufficient once PLAN-06's `power_audit` object lands there), falling back to the `power_audit_<X>` bundle's `power_validation` sidecar (Tier 2, same 50 MB Content-Length cap as the CSV path). Tolerant in both directions: pre- and post-PLAN-06 agg rows, single-node `benchmark_window` and multinode `selected_window` sidecars, and PLAN-09's agentic `results/power_validation.json` entry naming all map through the same pure helpers (`src/lib/power-audit-artifacts.ts`).
- **Chart:** a new custom D3 layer shades the measurement window with dashed bounds and labels, dims warmup/post-benchmark regions, and tracks x-zoom.
- **Reconciliation panel:** validity badge + verbatim reason chips, window bounds/duration, observed vs expected chip counts, published `avg_power_w` (with source), a viewer-side trapezoid recompute over **all** chips (mirroring the producer's boundary-interpolated per-device integration), and a color-coded delta (|Δ| ≤ 2% ok, ≤ 5% warn — the producer's accumulator tolerance — else alert), plus provenance (producer sha / exporter digest) when present.
- **Timestamp alignment:** naive nvidia-smi/ISO trace timestamps are placed via UTC parsing; a window that cannot be intersected with the trace yields an explicit message and no shading — never a silently shifted band.

## Backward compatibility

- Runs with no sidecar artifacts (or oversized/malformed ones) return a response shape-identical to master — no `power` key, CSV view untouched; a sidecar failure can never break the trace view.
- No `power` block → no panel, no shading: the page renders bit-for-bit as before (covered by an intercepted legacy-degradation e2e spec).
- `/api/gpu-metrics` stays classified `ui-artifact-read` (excluded from the stable v1 catalog); the review digest was refreshed.

## Tests

- `src/lib/power-audit-artifacts.test.ts` (new): suffix derivation, legacy/PLAN-06 agg mapping, single-node/multinode sidecar mapping, implausible-epoch rejection, deterministic validation-entry selection, merge precedence.
- `src/components/gpu-power/power-window.test.ts` (new): TZ-independent UTC parsing, window alignment (inside / clamped / disjoint-null), hand-computed trapezoid integration (constant, ramp, boundary interpolation, mixed cadences), delta thresholds.
- `src/app/api/gpu-metrics/route.test.ts`: every pre-existing case unmodified; new cases for sidecar-only runs, Tier-1 short-circuit (asserted via fetch call count), sibling-free legacy shape, oversized bundles, malformed sidecar JSON, and no-op bmk source attribution.
- `cypress/e2e/gpu-power.cy.ts`: two new fixture-driven specs (token-free via `cy.intercept`) — window shading + reconciliation (published 402 W vs recomputed 400 W → Δ −0.5%) and legacy degradation.

Full app unit suite: 4514 passed (254 files). `bunx tsc --noEmit`: clean. `gpu-power.cy.ts`: 11/11 passed against the `E2E_FIXTURES=1` dev server.

## Review

Two independent review passes; findings and resolutions (all fixed in `fe82c574`):

- **Confirmed (minor) — corrupt sidecar epoch could crash the page:** a finite-but-out-of-range `start_time_unix` (e.g. `1e16`) reached `new Date(v * 1000).toISOString()` in the panel and threw `RangeError`. Fixed at both ends: `windowFromUnixPair` now rejects non-positive, ms-scale, and past-2100 epochs (unit-tested), and the panel formats bounds through a helper that falls back to the raw number outside `Date`'s representable range.
- **Confirmed (nit) — `sources` footer overstated provenance:** a `bmk_*` artifact whose agg row carried no power fields was still credited, and a bundle agg row contributing only window/counts wasn't. Artifacts are now credited only when their parsed content contributed (`hasPowerContent` gate); a no-op Tier-1 row also falls through to the Tier-2 agg fallback (new route test).
- **Confirmed (nit) — zooming fully into warmup/post lost the dim overlay:** the degenerate-band early return dropped all shading, making a fully-zoomed warmup region look like measured data. The layer now dims the whole visible region (with the warmup/post label) when the view lies wholly on one side of the window.
- **Confirmed (nit) — sidecar `schema_version` leaked into `published.power_metric_schema_version`:** the sidecar's own schema version (1) is a different versioning axis than the agg row's power-metric schema version (2). The `validation_metrics` fallback now reports `null`.
- **Plausible (minor, rejected as by-design) — a non-UTC runner with clock offset smaller than the trace span would still intersect and shade a shifted window.** The plan explicitly rejected heuristic timezone snapping in favor of the intersection-check-or-refuse design; benchmark containers run UTC in practice. Recorded as a residual risk rather than guessed at.

## Out of scope (per plan)

Multinode traces (no `gpu_metrics_*` artifact exists to attach to), DB-vs-artifact drift checks (PLAN-07), and AgentX artifact publication (PLAN-09 — once it uploads `gpu_metrics_<X>`/`power_audit_<X>` for agentic lanes, this viewer lights up with zero app changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds live GitHub artifact downloads and client-side power reconciliation logic on a UI-only route; legacy runs are preserved when sidecars are missing or fail, but incorrect mapping could mislead auditors about measurement validity.
> 
> **Overview**
> Extends the hidden **PowerX** viewer so GPU telemetry shows which interval was formally measured and whether published `avg_power_w` matches a viewer-side recompute.
> 
> **API:** `GET /api/gpu-metrics` can attach an optional **`power`** block per `gpu_metrics_*` artifact by reading same-suffix siblings (`bmk_*` / `bmk_agentic_*` agg JSON first, then `power_audit_*` when needed). Sidecar failures are additive only—CSV responses without siblings stay unchanged.
> 
> **UI:** The chart adds a **measurement-window** band (dimmed warmup/post regions, dashed bounds, zoom-aware). A **reconciliation** card shows validity, window bounds, chip counts, published vs trapezoid-recomputed power (all GPUs), color-coded delta, and provenance when present.
> 
> **Client math:** New `power-window` helpers parse trace timestamps as UTC, align windows to the trace without guessing disjoint clocks, and mirror producer trapezoid integration for the cross-check.
> 
> Coverage includes unit tests for artifact mapping and window math, API route sidecar cases, a synthetic Cypress fixture, and legacy “no `power` key” e2e.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876ccefe2f8a01bab80559b28c1ee289f515d865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
