### PR TITLE
fix(etl): strip measured power metrics at ingest when power_valid=0 | ETL：power_valid=0 时在摄取阶段剥离实测功耗指标

### DIFF
--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -1,3 +1,4 @@
+import { MEASURED_POWER_METRIC_KEYS } from '@semianalysisai/inferencex-constants';
 import { describe, it, expect, vi } from 'vitest';
 
 import { getPointLabel } from '@/components/inference/utils/tooltipUtils';
@@ -422,6 +423,28 @@ describe('rowToAggDataEntry', () => {
     expect(point.measuredJPerSuccessfulQuery).toBeUndefined();
     expect(point.measuredWhPerSuccessfulQuery).toBeUndefined();
     expect(point.measuredPowerPercentTdp).toBeUndefined();
+  });
+
+  it('withholds every MEASURED_POWER_METRIC_KEYS field when power_valid=0 (ETL parity)', () => {
+    // Parity with the ingest scrub (benchmark-mapper.ts
+    // scrubWithheldPowerMetrics): the shared constant is the single source of
+    // truth for the withheld set, so a key added there without a matching
+    // display-layer withholding fails here. The reverse direction — the
+    // display layer withholding a key missing from the constant — stays
+    // hand-audited.
+    const metrics: BenchmarkRow['metrics'] = { power_valid: 0 };
+    for (const key of MEASURED_POWER_METRIC_KEYS) metrics[key] = 123.45;
+    const entry = rowToAggDataEntry(
+      makeRow({
+        metrics,
+        workers: [{ role: 'agg', worker_idx: 0, num_gpus: 8, avg_power_w: 123.45 }],
+      }),
+    );
+
+    for (const key of MEASURED_POWER_METRIC_KEYS) {
+      expect((entry as unknown as Record<string, unknown>)[key]).toBeUndefined();
+    }
+    expect(entry.workers).toBeUndefined();
   });
 
   it('keeps measured telemetry compatible when a legacy row omits power_valid', () => {

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -426,12 +426,6 @@ describe('rowToAggDataEntry', () => {
   });
 
   it('withholds every MEASURED_POWER_METRIC_KEYS field when power_valid=0 (ETL parity)', () => {
-    // Parity with the ingest scrub (benchmark-mapper.ts
-    // scrubWithheldPowerMetrics): the shared constant is the single source of
-    // truth for the withheld set, so a key added there without a matching
-    // display-layer withholding fails here. The reverse direction — the
-    // display layer withholding a key missing from the constant — stays
-    // hand-audited.
     const metrics: BenchmarkRow['metrics'] = { power_valid: 0 };
     for (const key of MEASURED_POWER_METRIC_KEYS) metrics[key] = 123.45;
     const entry = rowToAggDataEntry(

--- a/packages/constants/src/metric-keys.test.ts
+++ b/packages/constants/src/metric-keys.test.ts
@@ -14,9 +14,6 @@ describe('MEASURED_POWER_METRIC_KEYS', () => {
   });
 
   it('contains exactly the 13 measured power / energy / telemetry keys', () => {
-    // Guards accidental additions/removals: the ingest scrub and the display
-    // withholding both key off this set, so membership changes are policy
-    // changes and must be deliberate.
     expect(new Set(MEASURED_POWER_METRIC_KEY_LIST)).toEqual(
       new Set([
         'avg_power_w',
@@ -38,11 +35,7 @@ describe('MEASURED_POWER_METRIC_KEYS', () => {
   });
 
   it('never contains the contract discriminators or invalid-verdict companion fields', () => {
-    // power_valid / power_metric_schema_version are the verdict itself and
-    // must survive a scrub; power_invalid_reasons / power_audit are the
-    // producer's explanation of an invalid verdict (persisted app-side by
-    // PLAN-07) and are only meaningful on scrubbed rows. None of them may
-    // ever be added to the withheld set.
+    // These fields describe or explain withholding; they are not measurements.
     for (const key of [
       'power_valid',
       'power_metric_schema_version',

--- a/packages/constants/src/metric-keys.test.ts
+++ b/packages/constants/src/metric-keys.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MEASURED_POWER_METRIC_KEY_LIST,
+  MEASURED_POWER_METRIC_KEYS,
+  METRIC_KEYS,
+} from './metric-keys';
+
+describe('MEASURED_POWER_METRIC_KEYS', () => {
+  it('is a subset of METRIC_KEYS', () => {
+    for (const key of MEASURED_POWER_METRIC_KEYS) {
+      expect(METRIC_KEYS.has(key)).toBe(true);
+    }
+  });
+
+  it('contains exactly the 13 measured power / energy / telemetry keys', () => {
+    // Guards accidental additions/removals: the ingest scrub and the display
+    // withholding both key off this set, so membership changes are policy
+    // changes and must be deliberate.
+    expect(new Set(MEASURED_POWER_METRIC_KEY_LIST)).toEqual(
+      new Set([
+        'avg_power_w',
+        'joules_per_successful_query',
+        'joules_per_output_token',
+        'joules_per_total_token',
+        'prefill_avg_power_w',
+        'decode_avg_power_w',
+        'joules_per_input_token',
+        'prefill_joules_per_input_token',
+        'decode_joules_per_output_token',
+        'avg_temp_c',
+        'peak_temp_c',
+        'avg_util_pct',
+        'avg_mem_used_mb',
+      ]),
+    );
+    expect(MEASURED_POWER_METRIC_KEYS.size).toBe(13);
+  });
+
+  it('never contains the contract discriminators or invalid-verdict companion fields', () => {
+    // power_valid / power_metric_schema_version are the verdict itself and
+    // must survive a scrub; power_invalid_reasons / power_audit are the
+    // producer's explanation of an invalid verdict (persisted app-side by
+    // PLAN-07) and are only meaningful on scrubbed rows. None of them may
+    // ever be added to the withheld set.
+    for (const key of [
+      'power_valid',
+      'power_metric_schema_version',
+      'power_invalid_reasons',
+      'power_audit',
+    ]) {
+      expect(MEASURED_POWER_METRIC_KEYS.has(key)).toBe(false);
+    }
+  });
+});

--- a/packages/constants/src/metric-keys.ts
+++ b/packages/constants/src/metric-keys.ts
@@ -1,4 +1,55 @@
 /**
+ * Measured power / energy / GPU-telemetry metrics that MUST be withheld
+ * whenever a row carries an invalid power verdict (power_valid = 0).
+ * Excludes the contract discriminators (power_valid,
+ * power_metric_schema_version) and the invalid-verdict companion fields
+ * (power_invalid_reasons, power_audit), which are always kept. Add any new
+ * measured power/telemetry key here — it feeds METRIC_KEYS automatically.
+ * Mirrored by the display-layer withholding in
+ * packages/app/src/lib/benchmark-transform.ts (rowToAggDataEntry).
+ */
+export const MEASURED_POWER_METRIC_KEY_LIST = [
+  // measured power / energy (emitted by runner's aggregate_power.py)
+  // avg_power_w:             mean per-GPU draw (W) during the load window
+  // joules_per_successful_query: whole-deployment energy / successful requests
+  // joules_per_output_token: energy / total_output_tokens. CLUSTER-WIDE on
+  //                          schema-version-2 rows, including disaggregated runs.
+  // joules_per_total_token:  total_system_energy / (total_input + total_output)
+  //                          — cluster-wide; workload-shape-fair view that
+  //                          doesn't treat prompt as free.
+  'avg_power_w',
+  'joules_per_successful_query',
+  'joules_per_output_token',
+  'joules_per_total_token',
+  // multinode / disagg role splits (emitted only when the deployment has
+  // distinct prefill / decode workers)
+  // prefill_avg_power_w / decode_avg_power_w:  mean per-GPU draw within each role
+  // Explicit role-local energy remains separate from the version-2 unprefixed
+  // whole-deployment fields.
+  'prefill_avg_power_w',
+  'decode_avg_power_w',
+  'joules_per_input_token',
+  'prefill_joules_per_input_token',
+  'decode_joules_per_output_token',
+  // cluster-wide GPU telemetry beyond power (emitted by aggregate_power.py when
+  // the perfmon CSVs include temperature, utilization, or memory samples).
+  // avg_temp_c:        mean per-GPU temperature (Celsius) during load window
+  // peak_temp_c:       max instantaneous per-GPU temperature in window
+  // avg_util_pct:      mean per-GPU GPU-utilization percent (0-100)
+  // avg_mem_used_mb:   mean per-GPU memory used (MiB / MB)
+  // Single-node and multinode runs both surface these as flat scalars; the
+  // per-worker breakdown carries the same fields on each entry in workers[].
+  'avg_temp_c',
+  'peak_temp_c',
+  'avg_util_pct',
+  'avg_mem_used_mb',
+] as const;
+
+export const MEASURED_POWER_METRIC_KEYS: ReadonlySet<string> = new Set(
+  MEASURED_POWER_METRIC_KEY_LIST,
+);
+
+/**
  * Canonical set of metric keys stored in the benchmark_results.metrics JSONB column.
  *
  * Latency values (ttft/tpot/itl/e2el/intvty) are in seconds. Throughput values are
@@ -130,45 +181,14 @@ export const METRIC_KEYS = new Set([
   // profiling window (agentic aiperf; flat in v2 artifacts, mapped from
   // server_metrics.kv_cache.gpu_usage_pct in v3)
   'gpu_kv_cache_usage_pct',
-  // measured power / energy (emitted by runner's aggregate_power.py)
+  // measured power / energy publication contract (aggregate_power.py)
   // power_valid: numeric 1/0 publication verdict; explicit 0 withholds power
   // power_metric_schema_version: version 2 defines every unprefixed
   //                              joules_per_* field as whole-deployment energy
-  // avg_power_w:             mean per-GPU draw (W) during the load window
-  // joules_per_successful_query: whole-deployment energy / successful requests
-  // joules_per_output_token: energy / total_output_tokens. CLUSTER-WIDE on
-  //                          schema-version-2 rows, including disaggregated runs.
-  // joules_per_total_token:  total_system_energy / (total_input + total_output)
-  //                          — cluster-wide; workload-shape-fair view that
-  //                          doesn't treat prompt as free.
   'power_valid',
   'power_metric_schema_version',
-  'avg_power_w',
-  'joules_per_successful_query',
-  'joules_per_output_token',
-  'joules_per_total_token',
-  // multinode / disagg role splits (emitted only when the deployment has
-  // distinct prefill / decode workers)
-  // prefill_avg_power_w / decode_avg_power_w:  mean per-GPU draw within each role
-  // Explicit role-local energy remains separate from the version-2 unprefixed
-  // whole-deployment fields.
-  'prefill_avg_power_w',
-  'decode_avg_power_w',
-  'joules_per_input_token',
-  'prefill_joules_per_input_token',
-  'decode_joules_per_output_token',
-  // cluster-wide GPU telemetry beyond power (emitted by aggregate_power.py when
-  // the perfmon CSVs include temperature, utilization, or memory samples).
-  // avg_temp_c:        mean per-GPU temperature (Celsius) during load window
-  // peak_temp_c:       max instantaneous per-GPU temperature in window
-  // avg_util_pct:      mean per-GPU GPU-utilization percent (0-100)
-  // avg_mem_used_mb:   mean per-GPU memory used (MiB / MB)
-  // Single-node and multinode runs both surface these as flat scalars; the
-  // per-worker breakdown carries the same fields on each entry in workers[].
-  'avg_temp_c',
-  'peak_temp_c',
-  'avg_util_pct',
-  'avg_mem_used_mb',
+  // measured power / energy / telemetry values, withheld when power_valid = 0
+  ...MEASURED_POWER_METRIC_KEY_LIST,
   // extended parallelism dimensions (2026-07+ artifacts): pipeline parallelism
   // and decode/prefill context parallelism per role. These are config
   // dimensions, not measurements, but the configs table has no columns for

--- a/packages/constants/src/metric-keys.ts
+++ b/packages/constants/src/metric-keys.ts
@@ -1,12 +1,8 @@
 /**
- * Measured power / energy / GPU-telemetry metrics that MUST be withheld
- * whenever a row carries an invalid power verdict (power_valid = 0).
- * Excludes the contract discriminators (power_valid,
- * power_metric_schema_version) and the invalid-verdict companion fields
- * (power_invalid_reasons, power_audit), which are always kept. Add any new
- * measured power/telemetry key here — it feeds METRIC_KEYS automatically.
- * Mirrored by the display-layer withholding in
- * packages/app/src/lib/benchmark-transform.ts (rowToAggDataEntry).
+ * Power, energy, and GPU telemetry withheld at ingest and display when the
+ * normalized `power_valid` verdict is 0. Contract and diagnostic fields are
+ * excluded so the invalid verdict remains auditable. Add new measured fields
+ * here; `METRIC_KEYS` derives from this list.
  */
 export const MEASURED_POWER_METRIC_KEY_LIST = [
   // measured power / energy (emitted by runner's aggregate_power.py)
@@ -187,7 +183,6 @@ export const METRIC_KEYS = new Set([
   //                              joules_per_* field as whole-deployment energy
   'power_valid',
   'power_metric_schema_version',
-  // measured power / energy / telemetry values, withheld when power_valid = 0
   ...MEASURED_POWER_METRIC_KEY_LIST,
   // extended parallelism dimensions (2026-07+ artifacts): pipeline parallelism
   // and decode/prefill context parallelism per role. These are config

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -67,11 +67,6 @@ function makeV2Row(overrides: Record<string, any> = {}): Record<string, any> {
   };
 }
 
-/**
- * All 13 measured power/energy/telemetry keys with distinct sentinel values,
- * plus a valid 2-entry per-worker payload — the shape a producer regression
- * would ship if it stopped stripping measurements on power_valid=0 rows.
- */
 function dirtyPowerPayload(): Record<string, any> {
   return {
     avg_power_w: 685.5,
@@ -334,8 +329,6 @@ describe('mapBenchmarkRow', () => {
         expect(result!.metrics).not.toHaveProperty(key);
       }
       expect(result!.workers).toBeUndefined();
-      // Non-power metrics survive untouched — a power_valid=0 row is still a
-      // perfectly valid performance result.
       expect(result!.metrics.tput_per_gpu).toBe(567.8);
       expect(result!.metrics.median_ttft).toBe(50.2);
     });
@@ -385,9 +378,8 @@ describe('mapBenchmarkRow', () => {
     );
 
     it('converges a dirty pv=0 artifact to exactly what a clean producer would ship', () => {
-      // Re-ingest replaces metrics and workers wholesale (ON CONFLICT DO
-      // UPDATE in benchmark-ingest.ts), so a scrubbed dirty row must be a
-      // fixed point identical to the producer-clean mapping.
+      // Upserts replace metrics and workers wholesale, so re-ingest must
+      // converge to the same row as a producer-clean artifact.
       const tracker = createSkipTracker();
       const dirtyResult = mapBenchmarkRow(
         makeV2Row({ power_valid: 0, power_metric_schema_version: 2, ...dirtyPowerPayload() }),
@@ -415,7 +407,6 @@ describe('mapBenchmarkRow', () => {
       );
 
       expect(result!.metrics.power_valid).toBe(0);
-      // The reassignment ran: full-response ITL became canonical.
       expect(result!.metrics.mean_itl).toBe(0.02);
       for (const key of MEASURED_POWER_METRIC_KEYS) {
         expect(result!.metrics).not.toHaveProperty(key);
@@ -423,12 +414,7 @@ describe('mapBenchmarkRow', () => {
       expect(result!.workers).toBeUndefined();
     });
 
-    it('tolerates the invalid-verdict companion fields without scrubbing them', () => {
-      // PLAN-06 producers ship power_invalid_reasons / power_audit alongside
-      // power_valid=0. The scrub must never touch them; persisting them
-      // app-side is PLAN-07 — today's pinned behavior is that non-numeric
-      // fields simply never land in the numeric metrics record (parseNum
-      // drops arrays/objects).
+    it('keeps structured invalid-verdict companions outside the numeric metrics record', () => {
       const tracker = createSkipTracker();
       const result = mapBenchmarkRow(
         makeV2Row({
@@ -867,9 +853,6 @@ describe('mapBenchmarkRow', () => {
 });
 
 describe('scrubWithheldPowerMetrics (direct — supplemental ingest path)', () => {
-  // ingest-supplemental.ts persists metrics without mapBenchmarkRow, calling
-  // normalizePowerContractMetrics + scrubWithheldPowerMetrics on the raw
-  // record directly. Pin that usage pattern here.
   function supplementalMetrics(overrides: Record<string, any> = {}): Record<string, number> {
     const { workers: _workers, ...measured } = dirtyPowerPayload();
     return { tput_per_gpu: 567.8, ...measured, ...overrides };
@@ -897,8 +880,6 @@ describe('scrubWithheldPowerMetrics (direct — supplemental ingest path)', () =
 
   it('fails closed on a malformed verdict when composed with normalization', () => {
     const metrics = supplementalMetrics({ power_valid: 2 });
-    // The exact ingest-supplemental.ts call sequence: same object as row
-    // and metrics.
     normalizePowerContractMetrics(metrics, metrics);
     expect(scrubWithheldPowerMetrics(metrics)).toBe(true);
 

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { MEASURED_POWER_METRIC_KEYS } from '@semianalysisai/inferencex-constants';
-import { extractWorkers, mapBenchmarkRow } from './benchmark-mapper';
+import {
+  extractWorkers,
+  mapBenchmarkRow,
+  normalizePowerContractMetrics,
+  scrubWithheldPowerMetrics,
+} from './benchmark-mapper';
 import { createSkipTracker } from './skip-tracker';
 
 /** Minimal valid v1 benchmark row. */
@@ -858,6 +863,49 @@ describe('mapBenchmarkRow', () => {
       expect(result!.metrics).not.toHaveProperty('avg_mem_used_mb');
       expect(result!.workers).toBeUndefined();
     });
+  });
+});
+
+describe('scrubWithheldPowerMetrics (direct — supplemental ingest path)', () => {
+  // ingest-supplemental.ts persists metrics without mapBenchmarkRow, calling
+  // normalizePowerContractMetrics + scrubWithheldPowerMetrics on the raw
+  // record directly. Pin that usage pattern here.
+  function supplementalMetrics(overrides: Record<string, any> = {}): Record<string, number> {
+    const { workers: _workers, ...measured } = dirtyPowerPayload();
+    return { tput_per_gpu: 567.8, ...measured, ...overrides };
+  }
+
+  it('strips every measured key on power_valid=0 and reports withheld', () => {
+    const metrics = supplementalMetrics({ power_valid: 0, power_metric_schema_version: 2 });
+
+    expect(scrubWithheldPowerMetrics(metrics)).toBe(true);
+    for (const key of MEASURED_POWER_METRIC_KEYS) {
+      expect(metrics).not.toHaveProperty(key);
+    }
+    expect(metrics.power_valid).toBe(0);
+    expect(metrics.power_metric_schema_version).toBe(2);
+    expect(metrics.tput_per_gpu).toBe(567.8);
+  });
+
+  it('leaves power_valid=1 and legacy no-verdict records untouched', () => {
+    for (const metrics of [supplementalMetrics({ power_valid: 1 }), supplementalMetrics()]) {
+      const before = { ...metrics };
+      expect(scrubWithheldPowerMetrics(metrics)).toBe(false);
+      expect(metrics).toEqual(before);
+    }
+  });
+
+  it('fails closed on a malformed verdict when composed with normalization', () => {
+    const metrics = supplementalMetrics({ power_valid: 2 });
+    // The exact ingest-supplemental.ts call sequence: same object as row
+    // and metrics.
+    normalizePowerContractMetrics(metrics, metrics);
+    expect(scrubWithheldPowerMetrics(metrics)).toBe(true);
+
+    expect(metrics.power_valid).toBe(0);
+    for (const key of MEASURED_POWER_METRIC_KEYS) {
+      expect(metrics).not.toHaveProperty(key);
+    }
   });
 });
 

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { MEASURED_POWER_METRIC_KEYS } from '@semianalysisai/inferencex-constants';
 import { extractWorkers, mapBenchmarkRow } from './benchmark-mapper';
 import { createSkipTracker } from './skip-tracker';
 
@@ -58,6 +59,33 @@ function makeV2Row(overrides: Record<string, any> = {}): Record<string, any> {
     num_decode_gpu: 8,
     tput_per_gpu: 567.8,
     ...overrides,
+  };
+}
+
+/**
+ * All 13 measured power/energy/telemetry keys with distinct sentinel values,
+ * plus a valid 2-entry per-worker payload — the shape a producer regression
+ * would ship if it stopped stripping measurements on power_valid=0 rows.
+ */
+function dirtyPowerPayload(): Record<string, any> {
+  return {
+    avg_power_w: 685.5,
+    joules_per_successful_query: 1542.75,
+    joules_per_output_token: 8.4,
+    joules_per_total_token: 0.8,
+    prefill_avg_power_w: 612.3,
+    decode_avg_power_w: 701.5,
+    joules_per_input_token: 1.2,
+    prefill_joules_per_input_token: 0.4,
+    decode_joules_per_output_token: 5.1,
+    avg_temp_c: 68.4,
+    peak_temp_c: 79.2,
+    avg_util_pct: 88.5,
+    avg_mem_used_mb: 71234.5,
+    workers: [
+      { role: 'prefill', worker_idx: 0, hosts: ['pn0'], num_gpus: 4, avg_power_w: 612.3 },
+      { role: 'decode', worker_idx: 0, hosts: ['dn0'], num_gpus: 8, avg_power_w: 701.5 },
+    ],
   };
 }
 
@@ -278,6 +306,144 @@ describe('mapBenchmarkRow', () => {
 
       expect(result!.config.numPrefillGpu).toBe(8); // 4 * 2
       expect(result!.config.numDecodeGpu).toBe(8); // 2 * 4
+    });
+  });
+
+  describe('power_valid=0 measured-power scrub (defense-in-depth)', () => {
+    it('strips every measured key and the workers payload on an explicit invalid verdict', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV2Row({
+          power_valid: 0,
+          power_metric_schema_version: 2,
+          median_ttft: 50.2,
+          ...dirtyPowerPayload(),
+        }),
+        tracker,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.metrics.power_valid).toBe(0);
+      expect(result!.metrics.power_metric_schema_version).toBe(2);
+      for (const key of MEASURED_POWER_METRIC_KEYS) {
+        expect(result!.metrics).not.toHaveProperty(key);
+      }
+      expect(result!.workers).toBeUndefined();
+      // Non-power metrics survive untouched — a power_valid=0 row is still a
+      // perfectly valid performance result.
+      expect(result!.metrics.tput_per_gpu).toBe(567.8);
+      expect(result!.metrics.median_ttft).toBe(50.2);
+    });
+
+    it('keeps every measured key and the workers payload on a valid verdict', () => {
+      const tracker = createSkipTracker();
+      const dirty = dirtyPowerPayload();
+      const result = mapBenchmarkRow(
+        makeV2Row({ power_valid: 1, power_metric_schema_version: 2, ...dirty }),
+        tracker,
+      );
+
+      expect(result!.metrics.power_valid).toBe(1);
+      for (const key of MEASURED_POWER_METRIC_KEYS) {
+        expect(result!.metrics[key]).toBe(dirty[key]);
+      }
+      expect(result!.workers).toHaveLength(2);
+    });
+
+    it('leaves legacy rows without a verdict untouched (historical measurements kept)', () => {
+      const tracker = createSkipTracker();
+      const dirty = dirtyPowerPayload();
+      const result = mapBenchmarkRow(makeV2Row(dirty), tracker);
+
+      expect(result!.metrics).not.toHaveProperty('power_valid');
+      for (const key of MEASURED_POWER_METRIC_KEYS) {
+        expect(result!.metrics[key]).toBe(dirty[key]);
+      }
+      expect(result!.workers).toHaveLength(2);
+    });
+
+    it.each([true, 'garbage', 2, Number.NaN])(
+      'scrubs after failing closed on malformed verdict %j',
+      (powerValid) => {
+        const tracker = createSkipTracker();
+        const result = mapBenchmarkRow(
+          makeV2Row({ power_valid: powerValid, ...dirtyPowerPayload() }),
+          tracker,
+        );
+
+        expect(result!.metrics.power_valid).toBe(0);
+        for (const key of MEASURED_POWER_METRIC_KEYS) {
+          expect(result!.metrics).not.toHaveProperty(key);
+        }
+        expect(result!.workers).toBeUndefined();
+      },
+    );
+
+    it('converges a dirty pv=0 artifact to exactly what a clean producer would ship', () => {
+      // Re-ingest replaces metrics and workers wholesale (ON CONFLICT DO
+      // UPDATE in benchmark-ingest.ts), so a scrubbed dirty row must be a
+      // fixed point identical to the producer-clean mapping.
+      const tracker = createSkipTracker();
+      const dirtyResult = mapBenchmarkRow(
+        makeV2Row({ power_valid: 0, power_metric_schema_version: 2, ...dirtyPowerPayload() }),
+        tracker,
+      );
+      const cleanResult = mapBenchmarkRow(
+        makeV2Row({ power_valid: 0, power_metric_schema_version: 2 }),
+        tracker,
+      );
+
+      expect(dirtyResult!.metrics).toEqual(cleanResult!.metrics);
+      expect(dirtyResult!.workers).toBeUndefined();
+      expect(cleanResult!.workers).toBeUndefined();
+    });
+
+    it('scrubs agentic rows after the preferFullResponseMetrics reassignment', () => {
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeAgenticRow({
+          power_valid: 0,
+          ...dirtyPowerPayload(),
+          mean_full_response_itl: 0.02,
+        }),
+        tracker,
+      );
+
+      expect(result!.metrics.power_valid).toBe(0);
+      // The reassignment ran: full-response ITL became canonical.
+      expect(result!.metrics.mean_itl).toBe(0.02);
+      for (const key of MEASURED_POWER_METRIC_KEYS) {
+        expect(result!.metrics).not.toHaveProperty(key);
+      }
+      expect(result!.workers).toBeUndefined();
+    });
+
+    it('tolerates the invalid-verdict companion fields without scrubbing them', () => {
+      // PLAN-06 producers ship power_invalid_reasons / power_audit alongside
+      // power_valid=0. The scrub must never touch them; persisting them
+      // app-side is PLAN-07 — today's pinned behavior is that non-numeric
+      // fields simply never land in the numeric metrics record (parseNum
+      // drops arrays/objects).
+      const tracker = createSkipTracker();
+      const result = mapBenchmarkRow(
+        makeV2Row({
+          power_valid: 0,
+          power_metric_schema_version: 2,
+          ...dirtyPowerPayload(),
+          power_invalid_reasons: ['window_too_short'],
+          power_audit: { window_start_unix: 1, window_end_unix: 2 },
+        }),
+        tracker,
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.metrics.power_valid).toBe(0);
+      expect(result!.metrics.power_metric_schema_version).toBe(2);
+      for (const key of MEASURED_POWER_METRIC_KEYS) {
+        expect(result!.metrics).not.toHaveProperty(key);
+      }
+      expect(result!.metrics).not.toHaveProperty('power_invalid_reasons');
+      expect(result!.metrics).not.toHaveProperty('power_audit');
     });
   });
 

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -467,7 +467,7 @@ function captureNumericMetrics(row: Record<string, any>): Record<string, number>
  * two fields are semantic discriminators, so loose numeric coercion must never
  * turn malformed producer output into an affirmative verdict or schema.
  */
-function normalizePowerContractMetrics(
+export function normalizePowerContractMetrics(
   row: Record<string, any>,
   metrics: Record<string, number>,
 ): void {
@@ -507,12 +507,15 @@ function normalizePowerContractMetrics(
  * future companion fields such as power_invalid_reasons / power_audit).
  * Legacy rows without a verdict are untouched. Returns true when the
  * row's power is withheld so the caller also drops the workers payload.
- * This is the single enforcement point — the query layer intentionally
- * serves metrics unfiltered (see queries/benchmarks.ts rawMetrics), and
- * the frontend independently withholds at display
+ * This is the single enforcement policy at ingest: every mapBenchmarkRow
+ * path runs it here, and ingest-supplemental.ts — the one persistence
+ * path that bypasses mapBenchmarkRow — applies the same normalize+scrub
+ * pair to its verbatim metrics. The query layer intentionally serves
+ * metrics unfiltered (see queries/benchmarks.ts rawMetrics), and the
+ * frontend independently withholds at display
  * (benchmark-transform.ts rowToAggDataEntry).
  */
-function scrubWithheldPowerMetrics(metrics: Record<string, number>): boolean {
+export function scrubWithheldPowerMetrics(metrics: Record<string, number>): boolean {
   if (metrics.power_valid !== 0) return false;
   for (const key of MEASURED_POWER_METRIC_KEYS) delete metrics[key];
   return true;

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -347,9 +347,8 @@ export function mapBenchmarkRow(
       ? rawRecipeFingerprint.trim()
       : null;
 
-  // Scrub AFTER the last mutation of `metrics` (the agentic
-  // preferFullResponseMetrics reassignment and the extractRuntimeMetadata
-  // merge above) so no later step can resurrect a withheld key.
+  // Keep this after agentic reassignment and runtime metadata merging so no
+  // later mutation can reintroduce a withheld key.
   const powerWithheld = scrubWithheldPowerMetrics(metrics);
   // Per-worker measured-power breakdown. The runner emits this as an array
   // of objects sibling to the scalar metrics; we surface it on a dedicated
@@ -499,21 +498,12 @@ export function normalizePowerContractMetrics(
 }
 
 /**
- * Defense-in-depth for the power publication contract: when the
- * normalized verdict is an explicit invalid (power_valid === 0), delete
- * every measured power/energy/telemetry metric so withheld measurements
- * can never be persisted or served, even if a producer regression ships
- * them. Keeps power_valid and power_metric_schema_version (and any
- * future companion fields such as power_invalid_reasons / power_audit).
- * Legacy rows without a verdict are untouched. Returns true when the
- * row's power is withheld so the caller also drops the workers payload.
- * This is the single enforcement policy at ingest: every mapBenchmarkRow
- * path runs it here, and ingest-supplemental.ts — the one persistence
- * path that bypasses mapBenchmarkRow — applies the same normalize+scrub
- * pair to its verbatim metrics. The query layer intentionally serves
- * metrics unfiltered (see queries/benchmarks.ts rawMetrics), and the
- * frontend independently withholds at display
- * (benchmark-transform.ts rowToAggDataEntry).
+ * Enforces fail-closed power publication at ingest. An explicit normalized
+ * invalid verdict removes every measured field while preserving the contract
+ * and diagnostic fields; legacy rows without a verdict remain unchanged.
+ * Returns true so callers also drop worker telemetry. Paths that bypass
+ * `mapBenchmarkRow` must normalize the verdict before calling this function.
+ * Queries intentionally remain raw; the frontend withholds independently.
  */
 export function scrubWithheldPowerMetrics(metrics: Record<string, number>): boolean {
   if (metrics.power_valid !== 0) return false;

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -6,7 +6,11 @@
 
 import type { ConfigParams } from './config-cache';
 import type { SkipTracker } from './skip-tracker';
-import { METRIC_KEYS, PRECISION_KEYS } from '@semianalysisai/inferencex-constants';
+import {
+  MEASURED_POWER_METRIC_KEYS,
+  METRIC_KEYS,
+  PRECISION_KEYS,
+} from '@semianalysisai/inferencex-constants';
 import { flattenAgenticAggRow } from './agentic-v3-flatten';
 import { preferFullResponseMetrics } from './full-response-interactivity';
 import {
@@ -343,12 +347,17 @@ export function mapBenchmarkRow(
       ? rawRecipeFingerprint.trim()
       : null;
 
+  // Scrub AFTER the last mutation of `metrics` (the agentic
+  // preferFullResponseMetrics reassignment and the extractRuntimeMetadata
+  // merge above) so no later step can resurrect a withheld key.
+  const powerWithheld = scrubWithheldPowerMetrics(metrics);
   // Per-worker measured-power breakdown. The runner emits this as an array
   // of objects sibling to the scalar metrics; we surface it on a dedicated
   // BenchmarkParams.workers field so downstream consumers can treat it as
   // structured data without polluting the flat metrics record. Defensive
-  // narrowing — anything other than a non-empty array of objects is dropped.
-  const workers = extractWorkers(row.workers);
+  // narrowing — anything other than a non-empty array of objects is dropped,
+  // and a withheld power verdict drops the payload entirely.
+  const workers = powerWithheld ? undefined : extractWorkers(row.workers);
 
   return {
     config: {
@@ -487,6 +496,26 @@ function normalizePowerContractMetrics(
   } else {
     delete metrics.power_metric_schema_version;
   }
+}
+
+/**
+ * Defense-in-depth for the power publication contract: when the
+ * normalized verdict is an explicit invalid (power_valid === 0), delete
+ * every measured power/energy/telemetry metric so withheld measurements
+ * can never be persisted or served, even if a producer regression ships
+ * them. Keeps power_valid and power_metric_schema_version (and any
+ * future companion fields such as power_invalid_reasons / power_audit).
+ * Legacy rows without a verdict are untouched. Returns true when the
+ * row's power is withheld so the caller also drops the workers payload.
+ * This is the single enforcement point — the query layer intentionally
+ * serves metrics unfiltered (see queries/benchmarks.ts rawMetrics), and
+ * the frontend independently withholds at display
+ * (benchmark-transform.ts rowToAggDataEntry).
+ */
+function scrubWithheldPowerMetrics(metrics: Record<string, number>): boolean {
+  if (metrics.power_valid !== 0) return false;
+  for (const key of MEASURED_POWER_METRIC_KEYS) delete metrics[key];
+  return true;
 }
 
 /**

--- a/packages/db/src/ingest-supplemental.ts
+++ b/packages/db/src/ingest-supplemental.ts
@@ -27,6 +27,7 @@ import {
   bulkUpsertAvailability,
   type BenchmarkPersistenceInput,
 } from './etl/benchmark-ingest';
+import { normalizePowerContractMetrics, scrubWithheldPowerMetrics } from './etl/benchmark-mapper';
 import { ingestEvalRow } from './etl/eval-ingest';
 
 const sql = createAdminSql({
@@ -264,6 +265,12 @@ async function ingestSupplementalBmk(
         numPrefillGpu: entry.tp * entry.ep,
         numDecodeGpu: entry.tp * entry.ep,
       });
+
+      // Supplemental metrics bypass mapBenchmarkRow, so apply the power
+      // publication contract here too: fail-closed verdict normalization,
+      // then strip withheld measurements when power_valid=0.
+      normalizePowerContractMetrics(entry.metrics, entry.metrics);
+      scrubWithheldPowerMetrics(entry.metrics);
 
       rows.push({
         configId,


### PR DESCRIPTION
## Problem

There is no defense-in-depth for the power publication contract at the ingest layer.

The database stores whatever measured-power values the producer ships, even when the row carries an explicit invalid verdict (`power_valid: 0`). The only two defenses are upstream and downstream:

- the InferenceX producer (`aggregate_power.py`) strips measured values before publishing — the ~27 existing `power_valid=0` production rows are clean **only** because of this;
- the frontend withholds at display (`rowToAggDataEntry` in `benchmark-transform.ts`).

Nothing in between: `mapBenchmarkRow` captures every numeric power field regardless of verdict, keeps the per-worker `workers` payload, and `/api/v1/benchmarks` serves the metrics JSONB unfiltered. A producer regression (or hand-built artifact) shipping `power_valid: 0` together with populated measurements would be persisted and served in violation of the contract.

## Solution

- **`packages/constants/src/metric-keys.ts`** — the 13 measured power / energy / GPU-telemetry keys move out of the `METRIC_KEYS` literal into an exported `MEASURED_POWER_METRIC_KEY_LIST` / `MEASURED_POWER_METRIC_KEYS` (spread back in, so `METRIC_KEYS` membership is byte-for-byte unchanged). The contract discriminators (`power_valid`, `power_metric_schema_version`) and the invalid-verdict companion fields (`power_invalid_reasons`, `power_audit` — from the row-level power provenance change, `feat/power-row-provenance` in InferenceX (PR queued), and InferenceX-app PR #939) are codified by test as never part of the withheld set.
- **`packages/db/src/etl/benchmark-mapper.ts`** — new `scrubWithheldPowerMetrics` helper: when the normalized verdict is an explicit invalid (`power_valid === 0`, including all malformed verdicts that fail closed), delete exactly the `MEASURED_POWER_METRIC_KEYS` entries and drop the `workers` payload. The scrub runs after the last mutation of `metrics` (agentic `preferFullResponseMetrics` reassignment and the `extractRuntimeMetadata` merge), so no later step can resurrect a scrubbed key. `mapBenchmarkRow` is the shared funnel for the CI ingest, the GCS backup ingest, and both re-mapping backfills.
- **`packages/db/src/ingest-supplemental.ts`** (review fix) — the one persistence path that bypasses `mapBenchmarkRow` now applies the same exported `normalizePowerContractMetrics` + `scrubWithheldPowerMetrics` pair to its verbatim metrics, so every ingest path enforces the contract.
- **Frontend parity** — a test drives `rowToAggDataEntry` off the shared constant so a key added to the set that the display layer forgets to withhold fails CI.

### Deliberate non-changes

- **No query/API-layer scrub.** Subtracting keys in SQL across the query plans would duplicate the policy in a second language, must be kept in sync with the constants set, and protects nothing that bypasses those plans anyway. A single well-tested enforcement policy at ETL plus the existing frontend withholding is the right layering.
- **No retroactive DB rewrite.** Existing `power_valid=0` rows are producer-clean (audit-verified), so **zero expected diff for existing rows**; backfills re-mapping through the scrubbing mapper are no-ops with respect to power fields. Rollback is a plain revert: rows ingested while this was live are exactly what a correct producer would have shipped.

## Tests

- `packages/constants` vitest: 5 files / 50 tests passed (new `metric-keys.test.ts`: subset-of-`METRIC_KEYS`, exact 13-key set, discriminators/companion fields never in set)
- `packages/db` vitest: 49 files / 609 tests passed (new scrub describe: pv=0 strip, pv=1 keep, legacy keep, 4x malformed-verdict fail-closed, replay idempotence, agentic path, companion-field tolerance; plus 3 direct-call tests pinning the supplemental ingest usage; all pre-existing power-contract and workers tests unchanged)
- `packages/app` vitest: 250 files / 4455 tests passed (parity test looping `MEASURED_POWER_METRIC_KEYS` over `rowToAggDataEntry`)
- `bun run typecheck`, `bun run lint`, `bun run fmt` clean at repo root

## Review notes

- `ingest-supplemental.ts` persists `entry.metrics` verbatim via `bulkIngestBenchmarkRows` without `mapBenchmarkRow`, so the original "single enforcement point" docstring was overstated: a supplemental entry carrying `power_valid: 0` plus measured values would have bypassed the scrub (theoretical today: manual-only script, and the checked-in `supplemental-bmk.json` contains no power keys). Fixed in commit `576b54a8`: the supplemental path now runs the same fail-closed normalize+scrub pair, the docstring names the path, and direct unit tests pin the usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark ingest and persisted metrics JSONB for invalid power verdicts; behavior is well-specified and tested but touches the data path between producer and API.
> 
> **Overview**
> Adds **defense-in-depth** for the power publication contract at ingest so rows with an explicit invalid verdict (`power_valid === 0`) no longer persist measured power, energy, or GPU telemetry when a dirty artifact slips past the producer.
> 
> **Shared contract:** The 13 withholdable measurement keys are centralized as `MEASURED_POWER_METRIC_KEY_LIST` / `MEASURED_POWER_METRIC_KEYS` in `@semianalysisai/inferencex-constants` (still spread into `METRIC_KEYS` unchanged). Contract fields like `power_valid` and `power_metric_schema_version` stay out of that set.
> 
> **ETL:** New exported `scrubWithheldPowerMetrics` deletes every key in that set when the normalized verdict is `0`; `mapBenchmarkRow` runs it after all metric mutations and **drops `workers`** when power is withheld. Malformed verdicts still fail closed via existing `normalizePowerContractMetrics`. The **supplemental ingest** path that bypasses `mapBenchmarkRow` now runs the same normalize + scrub pair.
> 
> **Tests:** Broad mapper coverage (valid/legacy/malformed/agentic/re-ingest convergence), direct scrub tests for supplemental, constants unit tests, and a frontend parity test that loops `MEASURED_POWER_METRIC_KEYS` over `rowToAggDataEntry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701fbbacc823f7101c2abb147a7f1c788bd611a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

