### PR TITLE
Add CollectiveX KV axis scale toggles / 新增 CollectiveX KV 坐标轴缩放开关

### DIFF
--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -683,6 +683,30 @@ describe('CollectiveX kv-transfer card', () => {
     cy.get('[data-testid="collectivex-kv-chart"] circle').should('have.length', 2);
     cy.get('[data-testid="collectivex-kv-chart"]').should(
       'contain.text',
+      'Aggregate pull bandwidth at p50 (GB/s, log)',
+    );
+    cy.get('[data-testid="collectivex-kv-chart"] .line-path').should(
+      'have.attr',
+      'stroke-width',
+      '1.75',
+    );
+    // Axis-scale switches live in the same Advanced legend drawer as the
+    // /inference chart controls and start enabled for the existing log-log view.
+    cy.get('[data-testid="collectivex-kv-chart"] [data-testid="legend-advanced-toggle"]').click();
+    cy.get('[data-testid="collectivex-kv-x-log-scale"]')
+      .should('have.attr', 'aria-checked', 'true')
+      .click()
+      .should('have.attr', 'aria-checked', 'false');
+    cy.get('[data-testid="collectivex-kv-chart"] .x-axis-label').should(
+      'have.text',
+      'Requests per burst',
+    );
+    cy.get('[data-testid="collectivex-kv-y-log-scale"]')
+      .should('have.attr', 'aria-checked', 'true')
+      .click()
+      .should('have.attr', 'aria-checked', 'false');
+    cy.get('[data-testid="collectivex-kv-chart"] .y-axis-label').should(
+      'have.text',
       'Aggregate pull bandwidth at p50 (GB/s)',
     );
     // Metric toggle swaps the y axis to burst latency.
@@ -719,9 +743,26 @@ describe('CollectiveX kv-transfer card', () => {
     cy.get('[data-testid="collectivex-kv-frontier-chart"]')
       .should('contain.text', 'Sequence length (ISL tokens, log)')
       .and('contain.text', 'Aggregate pull bandwidth at p50 (GB/s, log)');
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] [data-testid="legend-advanced-toggle"]',
+    ).click();
+    cy.get('[data-testid="collectivex-kv-x-log-scale"]').click();
+    cy.get('[data-testid="collectivex-kv-y-log-scale"]').click();
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] .x-axis-label').should(
+      'have.text',
+      'Sequence length (ISL tokens)',
+    );
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] .y-axis-label').should(
+      'have.text',
+      'Aggregate pull bandwidth at p50 (GB/s)',
+    );
     cy.get('[data-testid="collectivex-kv-frontier-chart"] .line-path')
       .should('have.length', 2)
       .then(($lines) => {
+        expect([...$lines].map((line) => line.getAttribute('stroke-width'))).to.deep.equal([
+          '2',
+          '2',
+        ]);
         expect([...$lines].map((line) => line.getAttribute('stroke-dasharray'))).to.have.members([
           'none',
           '9 4',
@@ -759,6 +800,12 @@ describe('CollectiveX kv-transfer card', () => {
       .should('contain.text', '序列长度（ISL token，对数）')
       .and('contain.text', 'p50 聚合 pull 带宽（GB/s，对数）')
       .and('contain.text', '越高越优');
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] [data-testid="legend-advanced-toggle"]',
+    ).click();
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] [data-testid="chart-legend"]')
+      .should('contain.text', 'X 轴对数缩放')
+      .and('contain.text', 'Y 轴对数缩放');
   });
 
   it('renders no kv card and no KV suite badge for an EP-only run', () => {

--- a/packages/app/src/components/collectivex/CollectiveXKvChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvChart.tsx
@@ -4,6 +4,7 @@ import * as d3 from 'd3';
 import { useMemo } from 'react';
 
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import { useLocale } from '@/lib/use-locale';
 
 import {
   type CollectiveXKvChartPoint,
@@ -18,21 +19,31 @@ interface CollectiveXKvChartProps {
   cases: CollectiveXKvRunCase[];
   colors: Record<string, string>;
   selection: CollectiveXKvChartSelection;
+  xLogScale: boolean;
+  yLogScale: boolean;
   caption?: React.ReactNode;
   legendElement?: React.ReactNode;
   testId?: string;
 }
 
-const X_LABELS: Record<CollectiveXKvChartSelection['x'], string> = {
-  batch: 'Requests per burst (log)',
-  isl: 'Input sequence length, tokens (log)',
-};
-
-function yLabel(selection: CollectiveXKvChartSelection): string {
-  return selection.y === 'bandwidth'
-    ? `Aggregate ${selection.op} bandwidth at p50 (GB/s)`
-    : 'Burst completion latency p50 (ms)';
-}
+const STRINGS = {
+  en: {
+    xAxis: (axis: CollectiveXKvChartSelection['x'], logScale: boolean) =>
+      `${axis === 'batch' ? 'Requests per burst' : 'Input sequence length, tokens'}${logScale ? ' (log)' : ''}`,
+    yAxis: (selection: CollectiveXKvChartSelection, logScale: boolean) =>
+      selection.y === 'bandwidth'
+        ? `Aggregate ${selection.op} bandwidth at p50 (GB/s${logScale ? ', log' : ''})`
+        : `Burst completion latency p50 (ms${logScale ? ', log' : ''})`,
+  },
+  zh: {
+    xAxis: (axis: CollectiveXKvChartSelection['x'], logScale: boolean) =>
+      `${axis === 'batch' ? '每次突发的请求数' : '输入序列长度（token）'}${logScale ? '（对数）' : ''}`,
+    yAxis: (selection: CollectiveXKvChartSelection, logScale: boolean) =>
+      selection.y === 'bandwidth'
+        ? `p50 聚合 ${selection.op} 带宽（GB/s${logScale ? '，对数' : ''}）`
+        : `突发完成延迟 p50（ms${logScale ? '，对数' : ''}）`,
+  },
+} as const;
 
 function paddedDomain(values: number[]): [number, number] {
   if (values.length === 0) return [1, 10];
@@ -62,10 +73,14 @@ export function CollectiveXKvChart({
   cases,
   colors,
   selection,
+  xLogScale,
+  yLogScale,
   caption,
   legendElement,
   testId,
 }: CollectiveXKvChartProps) {
+  const locale = useLocale();
+  const strings = STRINGS[locale === 'zh' ? 'zh' : 'en'];
   const points = useMemo(() => collectiveXKvChartPoints(cases, selection), [cases, selection]);
   const runIndexBySeries = useMemo(
     () => new Map(cases.map((kase) => [`${kase.run_id}:${kase.case_id}`, kase.run_index])),
@@ -112,16 +127,16 @@ export function CollectiveXKvChart({
       testId={testId}
       grabCursor
       instructions="Shift+Scroll to zoom · Drag to pan · Double-click to reset · Click a point to pin tooltip"
-      xScale={{ type: 'log', domain: xDomain, nice: false }}
-      yScale={{ type: 'log', domain: yDomain, nice: false }}
+      xScale={{ type: xLogScale ? 'log' : 'linear', domain: xDomain, nice: false }}
+      yScale={{ type: yLogScale ? 'log' : 'linear', domain: yDomain, nice: false }}
       xAxis={{
-        label: X_LABELS[selection.x],
+        label: strings.xAxis(selection.x, xLogScale),
         tickCount: 6,
         tickValues: xTickValues,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
       yAxis={{
-        label: yLabel(selection),
+        label: strings.yAxis(selection, yLogScale),
         tickCount: 5,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
@@ -133,7 +148,7 @@ export function CollectiveXKvChart({
           config: {
             getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
             getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
-            strokeWidth: 2.25,
+            strokeWidth: 1.75,
             curve: d3.curveLinear,
           },
         },

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -19,6 +19,8 @@ interface CollectiveXKvFrontierChartProps {
   cases: CollectiveXKvRunCase[];
   colors: Record<string, string>;
   selection: CollectiveXKvFrontierSelection;
+  xLogScale: boolean;
+  yLogScale: boolean;
   caption?: React.ReactNode;
   legendElement?: React.ReactNode;
   testId?: string;
@@ -29,9 +31,9 @@ const STRINGS = {
     noData: 'No measured KV rows match the selected page size and direction.',
     instructions:
       'Shift+Scroll to zoom · Drag to pan · Double-click to reset · Click a point to pin tooltip',
-    xAxis: 'Sequence length (ISL tokens, log)',
-    yAxis: (op: CollectiveXKvFrontierSelection['op']) =>
-      `Aggregate ${op} bandwidth at p50 (GB/s, log)`,
+    xAxis: (logScale: boolean) => `Sequence length (ISL tokens${logScale ? ', log' : ''})`,
+    yAxis: (op: CollectiveXKvFrontierSelection['op'], logScale: boolean) =>
+      `Aggregate ${op} bandwidth at p50 (GB/s${logScale ? ', log' : ''})`,
     dismiss: 'Click elsewhere to dismiss',
     skuFrontier: 'SKU-wide best at this ISL',
     backendFrontier: 'backend best at this ISL',
@@ -49,8 +51,9 @@ const STRINGS = {
   zh: {
     noData: '没有与所选页大小和传输方向匹配的 KV 实测数据。',
     instructions: 'Shift+滚轮缩放 · 拖动平移 · 双击重置 · 点击数据点固定提示框',
-    xAxis: '序列长度（ISL token，对数）',
-    yAxis: (op: CollectiveXKvFrontierSelection['op']) => `p50 聚合 ${op} 带宽（GB/s，对数）`,
+    xAxis: (logScale: boolean) => `序列长度（ISL token${logScale ? '，对数' : ''}）`,
+    yAxis: (op: CollectiveXKvFrontierSelection['op'], logScale: boolean) =>
+      `p50 聚合 ${op} 带宽（GB/s${logScale ? '，对数' : ''}）`,
     dismiss: '点击其他位置关闭',
     skuFrontier: '该 ISL 下 SKU 级最优',
     backendFrontier: '该 ISL 下后端最优',
@@ -95,6 +98,8 @@ export function CollectiveXKvFrontierChart({
   cases,
   colors,
   selection,
+  xLogScale,
+  yLogScale,
   caption,
   legendElement,
   testId,
@@ -151,15 +156,15 @@ export function CollectiveXKvFrontierChart({
       testId={testId}
       grabCursor
       instructions={strings.instructions}
-      xScale={{ type: 'log', domain: xDomain, nice: false }}
-      yScale={{ type: 'log', domain: yDomain, nice: false }}
+      xScale={{ type: xLogScale ? 'log' : 'linear', domain: xDomain, nice: false }}
+      yScale={{ type: yLogScale ? 'log' : 'linear', domain: yDomain, nice: false }}
       xAxis={{
-        label: strings.xAxis,
+        label: strings.xAxis(xLogScale),
         tickCount: 6,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
       yAxis={{
-        label: strings.yAxis(selection.op),
+        label: strings.yAxis(selection.op, yLogScale),
         tickCount: 5,
         tickFormat: (value) => formatCompact(Number(value)),
       }}
@@ -171,7 +176,7 @@ export function CollectiveXKvFrontierChart({
           config: {
             getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
             getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
-            strokeWidth: 2.5,
+            strokeWidth: 2,
             curve: d3.curveMonotoneX,
           },
         },

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -54,6 +54,8 @@ const STRINGS = {
     xAriaLabel: 'CollectiveX KV X axis',
     pageAriaLabel: 'CollectiveX KV page size',
     opAriaLabel: 'CollectiveX KV direction',
+    xLogScale: 'X-axis Log Scale',
+    yLogScale: 'Y-axis Log Scale',
   },
   zh: {
     heading: 'KV 缓存传输',
@@ -79,6 +81,8 @@ const STRINGS = {
     xAriaLabel: 'CollectiveX KV X 轴',
     pageAriaLabel: 'CollectiveX KV 页大小',
     opAriaLabel: 'CollectiveX KV 传输方向',
+    xLogScale: 'X 轴对数缩放',
+    yLogScale: 'Y 轴对数缩放',
   },
 } as const;
 
@@ -121,6 +125,8 @@ export function CollectiveXKvSection({
   );
   const [pageTokens, setPageTokens] = useState<'64' | '16'>('64');
   const [op, setOp] = useState<CollectiveXKvChartSelection['op']>('pull');
+  const [xLogScale, setXLogScale] = useState(true);
+  const [yLogScale, setYLogScale] = useState(true);
   // Legend toggles are keyed to the current series set: when checked runs
   // change, the stored selection is stale and every series starts active
   // again (the EP explorer resets the same way).
@@ -283,6 +289,28 @@ export function CollectiveXKvSection({
     op,
     pageTokens: Number(pageTokens),
   };
+  const legendSwitches = [
+    {
+      id: 'collectivex-kv-x-log-scale',
+      label: strings.xLogScale,
+      advanced: true,
+      checked: xLogScale,
+      onCheckedChange: (checked: boolean) => {
+        setXLogScale(checked);
+        track('collectivex_kv_x_log_scale_toggled', { enabled: checked });
+      },
+    },
+    {
+      id: 'collectivex-kv-y-log-scale',
+      label: strings.yLogScale,
+      advanced: true,
+      checked: yLogScale,
+      onCheckedChange: (checked: boolean) => {
+        setYLogScale(checked);
+        track('collectivex_kv_y_log_scale_toggled', { enabled: checked });
+      },
+    },
+  ];
   return (
     <Card data-testid="collectivex-kv-table" className="min-w-0 w-full max-w-full overflow-hidden">
       <h2 className="text-lg font-semibold">{strings.heading}</h2>
@@ -363,6 +391,8 @@ export function CollectiveXKvSection({
                 cases={activeCases}
                 colors={colors}
                 selection={{ op, pageTokens: Number(pageTokens) }}
+                xLogScale={xLogScale}
+                yLogScale={yLogScale}
                 caption={
                   <p className="text-sm text-muted-foreground">
                     {op} · page {pageTokens} · {strings.frontierCaption}
@@ -372,6 +402,7 @@ export function CollectiveXKvSection({
                   <ChartLegend
                     variant="sidebar"
                     legendItems={legendItems}
+                    switches={legendSwitches}
                     disableActiveSort
                     isLegendExpanded={legendExpanded}
                     onExpandedChange={setLegendExpanded}
@@ -407,6 +438,8 @@ export function CollectiveXKvSection({
                 cases={activeCases}
                 colors={colors}
                 selection={selection}
+                xLogScale={xLogScale}
+                yLogScale={yLogScale}
                 caption={
                   <p className="text-sm text-muted-foreground">
                     {op} · page {pageTokens} ·{' '}
@@ -417,6 +450,7 @@ export function CollectiveXKvSection({
                   <ChartLegend
                     variant="sidebar"
                     legendItems={legendItems}
+                    switches={legendSwitches}
                     disableActiveSort
                     isLegendExpanded={legendExpanded}
                     onExpandedChange={setLegendExpanded}


### PR DESCRIPTION
## Summary

- Add independent X-axis and Y-axis Log Scale switches to the CollectiveX KV legend, following the `/inference` Advanced-control pattern.
- Preserve the existing log-log defaults and carry the selected scales between the standard and Envelope KV views.
- Reduce standard KV line width from 2.25px to 1.75px and Envelope line width from 2.5px to 2px.
- Localize the new controls and dynamic axis labels for `/zh/collectivex`.

## Testing

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (5,297 tests)
- `bunx cypress run --spec cypress/e2e/collectivex.cy.ts` (33 tests)
- `bun run test:e2e` (117 tests)

Chinese copy was checked manually against `docs/chinese-copy.md` because the referenced `review-zh-copy` skill was not available in this session.

## 中文说明

### 概要

- 参照 `/inference` 图表的高级设置，在 CollectiveX KV 图例中新增 X 轴和 Y 轴两个独立的对数缩放开关。
- 保留现有的双对数默认设置，并在标准 KV 图表与带宽包络图之间沿用用户选择的坐标轴设置。
- 标准 KV 图表的曲线线宽由 2.25px 调整为 1.75px，带宽包络图的曲线线宽由 2.5px 调整为 2px。
- 为 `/zh/collectivex` 补充新控件和动态坐标轴标签的中文文案。

### 测试

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（5,297 项测试）
- `bunx cypress run --spec cypress/e2e/collectivex.cy.ts`（33 项测试）
- `bun run test:e2e`（117 项测试）

由于本次会话未提供文档中提到的 `review-zh-copy` skill，中文文案已参照 `docs/chinese-copy.md` 完成人工检查。