### PR TITLE
CollectiveX KV: add bulk wire-ceiling lines to Envelope / CollectiveX KV：为带宽包络图新增 bulk 线速上限

### DIFF
--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -48,6 +48,20 @@ const kvComparisonDataset = buildDataset({
   kv: [{}],
   meta: { run_id: '164', generated_at: '2026-08-09T12:20:00Z', source_sha: 'a'.repeat(40) },
 });
+const kvWireCeilingDataset = buildDataset({
+  shards: [makeRawShard()],
+  kv: [
+    {
+      rows: [
+        { kind: 'paged', page_tokens: 64, batch: 1, isl: 4096, gbps_p50: 5.1 },
+        { kind: 'paged', page_tokens: 64, batch: 1, isl: 32768, gbps_p50: 7.39 },
+        { kind: 'bulk', page_tokens: null, batch: 1, isl: 4096, gbps_p50: 52.3 },
+        { kind: 'bulk', page_tokens: null, batch: 1, isl: 32768, gbps_p50: 89.41 },
+      ],
+    },
+  ],
+  meta: { run_id: '165', generated_at: '2026-08-10T12:20:00Z', source_sha: 'b'.repeat(40) },
+});
 const kvOnlyDataset = buildDataset({
   shards: [],
   kv: [{}],
@@ -770,6 +784,38 @@ describe('CollectiveX kv-transfer card', () => {
       });
   });
 
+  it('toggles the Envelope bulk wire-ceiling lines from Advanced controls', () => {
+    installRuns([kvWireCeilingDataset]);
+    installRun(kvWireCeilingDataset);
+    openCollectiveX();
+
+    cy.get('[data-testid="collectivex-kv-xaxis-toggle"]').contains('button', 'Envelope').click();
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] .line-path').should('have.length', 2);
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] .line-path[stroke-dasharray="1 4"]',
+    ).should('have.length', 1);
+
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] [data-testid="legend-advanced-toggle"]',
+    ).click();
+    cy.get('[data-testid="collectivex-kv-bulk-wire-ceiling"]')
+      .should('have.attr', 'aria-checked', 'true')
+      .click()
+      .should('have.attr', 'aria-checked', 'false');
+    cy.get('[data-testid="collectivex-kv-frontier-chart"] .line-path').should('have.length', 1);
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] .line-path[stroke-dasharray="1 4"]',
+    ).should('not.exist');
+    cy.get('[data-testid="collectivex-kv-frontier-chart"]')
+      .should('contain.text', 'hover a point for its batch, latency, and status')
+      .and('not.contain.text', 'dotted line above each backend');
+
+    cy.get('[data-testid="collectivex-kv-bulk-wire-ceiling"]').click();
+    cy.get(
+      '[data-testid="collectivex-kv-frontier-chart"] .line-path[stroke-dasharray="1 4"]',
+    ).should('have.length', 1);
+  });
+
   it('plots the overlap-gain view with its dotted ideal line', () => {
     installRuns([kvDataset]);
     installRun(kvDataset);
@@ -805,7 +851,8 @@ describe('CollectiveX kv-transfer card', () => {
     ).click();
     cy.get('[data-testid="collectivex-kv-frontier-chart"] [data-testid="chart-legend"]')
       .should('contain.text', 'X 轴对数缩放')
-      .and('contain.text', 'Y 轴对数缩放');
+      .and('contain.text', 'Y 轴对数缩放')
+      .and('contain.text', 'Bulk 线速上限');
   });
 
   it('renders no kv card and no KV suite badge for an EP-only run', () => {

--- a/packages/app/cypress/e2e/collectivex.cy.ts
+++ b/packages/app/cypress/e2e/collectivex.cy.ts
@@ -852,7 +852,7 @@ describe('CollectiveX kv-transfer card', () => {
     cy.get('[data-testid="collectivex-kv-frontier-chart"] [data-testid="chart-legend"]')
       .should('contain.text', 'X 轴对数缩放')
       .and('contain.text', 'Y 轴对数缩放')
-      .and('contain.text', 'Bulk 线速上限');
+      .and('contain.text', 'Bulk 连续传输基线');
   });
 
   it('renders no kv card and no KV suite badge for an EP-only run', () => {

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -11,8 +11,12 @@ import {
   type CollectiveXKvFrontierSelection,
   type CollectiveXKvRunCase,
   collectiveXKvFrontierPoints,
+  collectiveXKvWireCeilings,
   collectiveXRunDasharray,
 } from './data';
+
+/** Line-key suffix marking a series' bulk wire-ceiling line (not an envelope). */
+const CEILING_SUFFIX = '__collectivex-kv-wire-ceiling';
 
 interface CollectiveXKvFrontierChartProps {
   chartId: string;
@@ -46,6 +50,8 @@ const STRINGS = {
     },
     latency: (point: CollectiveXKvFrontierPoint) =>
       `Burst latency p50 / p95: ${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} descriptors/request`,
+    ceiling: (gbps: number, share: string) =>
+      `Bulk wire ceiling ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s (dotted) · this rung reaches ${share} of it`,
     verify: (passed: boolean) => `verify: ${passed ? 'passed' : 'FAILED'}`,
   },
   zh: {
@@ -66,6 +72,8 @@ const STRINGS = {
     },
     latency: (point: CollectiveXKvFrontierPoint) =>
       `突发延迟 p50 / p95：${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} 个描述符/请求`,
+    ceiling: (gbps: number, share: string) =>
+      `单描述符线速上限 ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s（点状线）· 此组合达到其 ${share}`,
     verify: (passed: boolean) => `校验：${passed ? '通过' : '失败'}`,
   },
 } as const;
@@ -135,9 +143,32 @@ export function CollectiveXKvFrontierChart({
     () => new Map(points.map((point) => [point.seriesId, point.colorKey])),
     [points],
   );
+  // Each series' bulk single-descriptor rows, drawn as a dotted line above the
+  // envelope: what the fabric itself moves at that ISL. The gap from a paged
+  // rung up to this line is per-descriptor software overhead, not the wire.
+  const ceilings = useMemo(
+    () => collectiveXKvWireCeilings(cases, selection.op),
+    [cases, selection.op],
+  );
+  const allLines = useMemo(() => {
+    const merged: Record<string, { x: number; y: number }[]> = { ...lines };
+    for (const [seriesId, ceiling] of ceilings) {
+      // Only series that are actually plotted get a ceiling line.
+      if (!(seriesId in lines) || ceiling.length < 2) continue;
+      merged[`${seriesId}${CEILING_SUFFIX}`] = ceiling.map(({ x, y }) => ({ x, y }));
+    }
+    return merged;
+  }, [lines, ceilings]);
 
   const xDomain = useMemo(() => paddedDomain(points.map((point) => point.x)), [points]);
-  const yDomain = useMemo(() => paddedDomain(points.map((point) => point.y)), [points]);
+  const yDomain = useMemo(() => {
+    const values = points.map((point) => point.y);
+    for (const key of Object.keys(allLines)) {
+      if (!key.endsWith(CEILING_SUFFIX)) continue;
+      for (const { y } of allLines[key]) values.push(y);
+    }
+    return paddedDomain(values);
+  }, [points, allLines]);
 
   const noDataOverlay =
     points.length === 0 ? (
@@ -172,10 +203,20 @@ export function CollectiveXKvFrontierChart({
         {
           type: 'line',
           key: 'collectivex-kv-frontier-lines',
-          lines,
+          lines: allLines,
           config: {
-            getColor: (key) => colors[colorBySeries.get(key) ?? ''] ?? '#888',
-            getStrokeDasharray: (key) => collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
+            getColor: (key) => {
+              const seriesId = key.endsWith(CEILING_SUFFIX)
+                ? key.slice(0, -CEILING_SUFFIX.length)
+                : key;
+              return colors[colorBySeries.get(seriesId) ?? ''] ?? '#888';
+            },
+            // Ceiling lines are dotted ('1 4' is used by no run dasharray) so
+            // they read as reference lines, not another measured envelope.
+            getStrokeDasharray: (key) =>
+              key.endsWith(CEILING_SUFFIX)
+                ? '1 4'
+                : collectiveXRunDasharray(runIndexBySeries.get(key) ?? 0),
             strokeWidth: 2,
             curve: d3.curveMonotoneX,
           },
@@ -213,12 +254,22 @@ export function CollectiveXKvFrontierChart({
             : point.onSeriesFrontier
               ? strings.backendFrontier
               : strings.dominated;
+          const ceilingAtIsl = ceilings
+            .get(point.seriesId)
+            ?.find((ceiling) => ceiling.x === row.isl);
+          let ceilingLine = '';
+          if (ceilingAtIsl && ceilingAtIsl.y > 0) {
+            const fraction = point.y / ceilingAtIsl.y;
+            const share = fraction < 0.001 ? '<0.1%' : `${(fraction * 100).toFixed(1)}%`;
+            ceilingLine = `<div class="text-muted-foreground">${strings.ceiling(ceilingAtIsl.y, share)}</div>`;
+          }
           return `<div class="rounded-md border bg-background/95 px-3 py-2 text-xs shadow-md backdrop-blur-sm" style="min-width: 230px; max-width: 380px; user-select: ${isPinned ? 'text' : 'none'}">
             ${isPinned ? `<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">${strings.dismiss}</div>` : ''}
             <div class="font-semibold mb-1" style="color: ${color}">${escapeHtml(point.seriesLabel)}</div>
             <div>${strings.pointContext(row, tier)}</div>
             <div>${strings.pointMetrics(point)}</div>
             <div class="text-muted-foreground">${strings.latency(point)}</div>
+            ${ceilingLine}
             <div class="text-muted-foreground">${strings.verify(row.verify_passed)}</div>
           </div>`;
         },

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -46,13 +46,18 @@ const STRINGS = {
     pointContext: (row: CollectiveXKvFrontierPoint['row'], tier: string) =>
       `${row.op} · page ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong>`,
     pointMetrics: (point: CollectiveXKvFrontierPoint) => {
-      const perInflight = point.row.latency_ms.p95 / point.row.batch;
-      return `Aggregate ${point.y.toFixed(point.y >= 100 ? 0 : 2)} GB/s · p95 ÷ in-flight ${perInflight.toFixed(perInflight >= 100 ? 0 : 1)} ms`;
+      const aggregate = `Aggregate ${point.y.toFixed(point.y >= 100 ? 0 : 2)} GB/s`;
+      const req = point.row.request_ms;
+      if (req) {
+        return `${aggregate} · per-request p95 ${req.p95.toFixed(req.p95 >= 100 ? 0 : 1)} ms`;
+      }
+      const amortized = point.row.latency_ms.p95 / point.row.batch;
+      return `${aggregate} · burst p95 ÷ batch ${amortized.toFixed(amortized >= 100 ? 0 : 1)} ms (amortized capacity, not per-request latency)`;
     },
     latency: (point: CollectiveXKvFrontierPoint) =>
       `Burst latency p50 / p95: ${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} descriptors/request`,
     ceiling: (gbps: number, share: string) =>
-      `Bulk wire ceiling ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s (dotted) · this rung reaches ${share} of it`,
+      `Contiguous baseline ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s (dotted) · this rung reaches ${share} of it`,
     verify: (passed: boolean) => `verify: ${passed ? 'passed' : 'FAILED'}`,
   },
   zh: {
@@ -68,13 +73,18 @@ const STRINGS = {
     pointContext: (row: CollectiveXKvFrontierPoint['row'], tier: string) =>
       `${row.op} · 页大小 ${row.page_tokens} · batch ${row.batch} · ISL ${row.isl.toLocaleString('en-US')} · <strong>${tier}</strong>`,
     pointMetrics: (point: CollectiveXKvFrontierPoint) => {
-      const perInflight = point.row.latency_ms.p95 / point.row.batch;
-      return `聚合带宽 ${point.y.toFixed(point.y >= 100 ? 0 : 2)} GB/s · p95 ÷ 在途请求数 ${perInflight.toFixed(perInflight >= 100 ? 0 : 1)} ms`;
+      const aggregate = `聚合带宽 ${point.y.toFixed(point.y >= 100 ? 0 : 2)} GB/s`;
+      const req = point.row.request_ms;
+      if (req) {
+        return `${aggregate} · 单请求 p95 ${req.p95.toFixed(req.p95 >= 100 ? 0 : 1)} ms`;
+      }
+      const amortized = point.row.latency_ms.p95 / point.row.batch;
+      return `${aggregate} · 突发 p95 ÷ 批大小 ${amortized.toFixed(amortized >= 100 ? 0 : 1)} ms（摊销容量指标，非单请求延迟）`;
     },
     latency: (point: CollectiveXKvFrontierPoint) =>
       `突发延迟 p50 / p95：${point.row.latency_ms.p50.toFixed(1)} / ${point.row.latency_ms.p95.toFixed(1)} ms · ${point.row.descs.toLocaleString('en-US')} 个描述符/请求`,
     ceiling: (gbps: number, share: string) =>
-      `单描述符线速上限 ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s（点状线）· 此组合达到其 ${share}`,
+      `单描述符连续传输基线 ${gbps.toFixed(gbps >= 100 ? 0 : 1)} GB/s（点状线）· 此组合达到其 ${share}`,
     verify: (passed: boolean) => `校验：${passed ? '通过' : '失败'}`,
   },
 } as const;

--- a/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvFrontierChart.tsx
@@ -25,6 +25,7 @@ interface CollectiveXKvFrontierChartProps {
   selection: CollectiveXKvFrontierSelection;
   xLogScale: boolean;
   yLogScale: boolean;
+  showWireCeilings: boolean;
   caption?: React.ReactNode;
   legendElement?: React.ReactNode;
   testId?: string;
@@ -108,6 +109,7 @@ export function CollectiveXKvFrontierChart({
   selection,
   xLogScale,
   yLogScale,
+  showWireCeilings,
   caption,
   legendElement,
   testId,
@@ -152,13 +154,14 @@ export function CollectiveXKvFrontierChart({
   );
   const allLines = useMemo(() => {
     const merged: Record<string, { x: number; y: number }[]> = { ...lines };
+    if (!showWireCeilings) return merged;
     for (const [seriesId, ceiling] of ceilings) {
       // Only series that are actually plotted get a ceiling line.
       if (!(seriesId in lines) || ceiling.length < 2) continue;
       merged[`${seriesId}${CEILING_SUFFIX}`] = ceiling.map(({ x, y }) => ({ x, y }));
     }
     return merged;
-  }, [lines, ceilings]);
+  }, [lines, ceilings, showWireCeilings]);
 
   const xDomain = useMemo(() => paddedDomain(points.map((point) => point.x)), [points]);
   const yDomain = useMemo(() => {
@@ -254,9 +257,9 @@ export function CollectiveXKvFrontierChart({
             : point.onSeriesFrontier
               ? strings.backendFrontier
               : strings.dominated;
-          const ceilingAtIsl = ceilings
-            .get(point.seriesId)
-            ?.find((ceiling) => ceiling.x === row.isl);
+          const ceilingAtIsl = showWireCeilings
+            ? ceilings.get(point.seriesId)?.find((ceiling) => ceiling.x === row.isl)
+            : undefined;
           let ceilingLine = '';
           if (ceilingAtIsl && ceilingAtIsl.y > 0) {
             const fraction = point.y / ceilingAtIsl.y;

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -32,19 +32,19 @@ const STRINGS = {
     heading: 'KV-cache transfer',
     description:
       'Prefill-to-decode KV handoff (2 nodes x 1 GPU, DeepSeek-V4-Pro cache as vLLM allocates it). ' +
-      'Paged rows move per-request layer-major descriptor lists over randomized block tables; ' +
-      'bulk is the single-descriptor wire ceiling. GB/s is burst-aggregate pull at the largest ISL; ' +
-      'b1/bmax are requests posted per burst.',
+      'Paged rows move packed block-major descriptor lists over randomized block tables: one ' +
+      'contiguous descriptor per physical block per cache group, matching the production NIXL path. ' +
+      'Bulk is the single-descriptor contiguous baseline (host-observed goodput, not proven wire ' +
+      'utilization). GB/s is burst-aggregate pull at the largest ISL; b1/bmax are requests posted per burst.',
     batchCaption: 'at the largest measured ISL',
     islCaption: 'at batch 1',
     frontierCaption:
       'every measured (ISL, batch) rung is a point; each solid or dashed line traces the ' +
       'backend at its best batch for every ISL, so higher is better. The dotted line above ' +
-      'each backend is its bulk wire ceiling: the same bytes moved as one contiguous ' +
-      'descriptor, so it is what the fabric itself achieves. Paged rungs sit far below it ' +
-      'because the DeepSeek-V4-Pro layout fragments each request into thousands of tiny ' +
-      'per-layer page descriptors, making the transfer descriptor-rate bound (per-operation ' +
-      'software cost), not fabric-bandwidth bound. Hover a point for its share of the wire.',
+      'each backend is its contiguous baseline: the same bytes moved as one contiguous ' +
+      'descriptor through the same backend call, a host-observed goodput reference rather ' +
+      'than a proven physical link rate. The gap between a paged rung and its baseline is ' +
+      'the cost of the packed multi-descriptor path. Hover a point for its share of the baseline.',
     frontierCaptionWithoutCeilings:
       'every measured (ISL, batch) rung is a point; each line traces the backend at its best ' +
       'batch for every ISL, so higher is better. A backend that overlaps requests lifts its ' +
@@ -69,21 +69,22 @@ const STRINGS = {
     islAriaLabel: 'CollectiveX KV overlap ISL',
     xLogScale: 'X-axis Log Scale',
     yLogScale: 'Y-axis Log Scale',
-    bulkWireCeiling: 'Bulk Wire Ceiling',
+    bulkBaseline: 'Bulk Contiguous Baseline',
   },
   zh: {
     heading: 'KV 缓存传输',
     description:
       '预填充到解码的 KV 交接（2 节点 x 1 GPU，按 vLLM 为 DeepSeek-V4-Pro 分配的缓存布局）。' +
-      '分页行按随机块表以逐层描述符列表搬运每个请求；bulk 为单描述符线速上限。' +
+      '分页行按随机块表以块主序打包描述符列表搬运每个请求：每个缓存组的每个物理块对应一个连续描述符，' +
+      '与生产 NIXL 路径一致。bulk 为单描述符连续传输基线（主机侧观测的有效吞吐，并非实测物理链路利用率）。' +
       'GB/s 为最大 ISL 处按突发聚合的 pull 带宽；b1/bmax 表示每次突发提交的请求数。',
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
     frontierCaption:
       '每个实测 (ISL, 批大小) 组合都是一个点；实线或虚线取该后端在各 ISL 下的最优批大小，越高越优。' +
-      '每个后端上方的点状线是其 bulk 线速上限：同样的字节量以单个连续描述符搬运，即链路本身的能力。' +
-      '分页组合远低于上限，是因为 DeepSeek-V4-Pro 布局把每个请求碎片化为数千个微小的逐层页描述符，' +
-      '瓶颈在描述符处理速率（每操作软件开销）而非链路带宽。悬停数据点可查看其达到线速的比例。',
+      '每个后端上方的点状线是其连续传输基线：同样的字节量经同一后端调用以单个连续描述符搬运，' +
+      '是主机侧观测的有效吞吐参考，而非实测物理链路速率。' +
+      '分页组合与基线之间的差距即打包多描述符路径的开销。悬停数据点可查看其相对基线的比例。',
     frontierCaptionWithoutCeilings:
       '每个实测 (ISL, 批大小) 组合都是一个点；每条线取该后端在各 ISL 下的最优批大小，越高越优。' +
       '能重叠请求的后端其线会明显高于批大小 1 的点；悬停可查看批大小、延迟与状态。',
@@ -106,7 +107,7 @@ const STRINGS = {
     islAriaLabel: 'CollectiveX KV 重叠增益 ISL',
     xLogScale: 'X 轴对数缩放',
     yLogScale: 'Y 轴对数缩放',
-    bulkWireCeiling: 'Bulk 线速上限',
+    bulkBaseline: 'Bulk 连续传输基线',
   },
 } as const;
 
@@ -359,7 +360,7 @@ export function CollectiveXKvSection({
     ...legendSwitches,
     {
       id: 'collectivex-kv-bulk-wire-ceiling',
-      label: strings.bulkWireCeiling,
+      label: strings.bulkBaseline,
       advanced: true,
       checked: showWireCeilings,
       onCheckedChange: (checked: boolean) => {

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -20,6 +20,7 @@ import {
   type CollectiveXKvRunCase,
   collectiveXKvCell,
   collectiveXKvColorKey,
+  collectiveXKvIslValues,
   collectiveXKvLegendLabel,
   collectiveXRunDasharray,
   collectiveXSkuLabel,
@@ -51,17 +52,21 @@ const STRINGS = {
     frontierOption: 'Envelope',
     overlapOption: 'Overlap gain',
     overlapCaption:
-      'aggregate bandwidth relative to batch 1 at the largest measured ISL; the dotted ideal ' +
-      'is y = batch. A perfect overlapper tracks the ideal until the wire saturates; a ' +
-      'serializing backend stays flat at 1.',
+      'aggregate bandwidth relative to batch 1 at the selected ISL (Max reads each backend at ' +
+      'its largest measured ISL); the dotted ideal is y = batch. A perfect overlapper tracks ' +
+      'the ideal until the wire saturates; a serializing backend stays flat at 1. Backends ' +
+      'without a batch-1 rung at the selected ISL are hidden.',
     yControl: 'Metric',
     xControl: 'X axis',
     pageControl: 'Page size',
     opControl: 'Direction',
+    islControl: 'ISL',
+    islMaxOption: 'Max',
     metricAriaLabel: 'CollectiveX KV metric',
     xAriaLabel: 'CollectiveX KV X axis',
     pageAriaLabel: 'CollectiveX KV page size',
     opAriaLabel: 'CollectiveX KV direction',
+    islAriaLabel: 'CollectiveX KV overlap ISL',
     xLogScale: 'X-axis Log Scale',
     yLogScale: 'Y-axis Log Scale',
     bulkWireCeiling: 'Bulk Wire Ceiling',
@@ -85,16 +90,20 @@ const STRINGS = {
     frontierOption: '带宽包络',
     overlapOption: '重叠增益',
     overlapCaption:
-      '相对批大小 1 的聚合带宽，取最大实测 ISL；虚线为理想值 y = 批大小。' +
-      '完全重叠请求的后端会贴着理想线直到线速饱和；串行处理的后端保持在 1。',
+      '相对批大小 1 的聚合带宽，取所选 ISL（“最大”表示各后端取其最大实测 ISL）；虚线为理想值 y = 批大小。' +
+      '完全重叠请求的后端会贴着理想线直到线速饱和；串行处理的后端保持在 1。' +
+      '在所选 ISL 处没有批大小 1 数据的后端将被隐藏。',
     yControl: '指标',
     xControl: 'X 轴',
     pageControl: '页大小',
     opControl: '方向',
+    islControl: 'ISL',
+    islMaxOption: '最大',
     metricAriaLabel: 'CollectiveX KV 指标',
     xAriaLabel: 'CollectiveX KV X 轴',
     pageAriaLabel: 'CollectiveX KV 页大小',
     opAriaLabel: 'CollectiveX KV 传输方向',
+    islAriaLabel: 'CollectiveX KV 重叠增益 ISL',
     xLogScale: 'X 轴对数缩放',
     yLogScale: 'Y 轴对数缩放',
     bulkWireCeiling: 'Bulk 线速上限',
@@ -112,6 +121,10 @@ const OUTCOME_CLASS: Record<CollectiveXOutcome, string> = {
 
 function formatGbps(value: number | null | undefined): string {
   return value === null || value === undefined ? '-' : value.toFixed(value >= 100 ? 0 : 2);
+}
+
+function formatIsl(value: number): string {
+  return value >= 1024 && value % 1024 === 0 ? `${value / 1024}k` : String(value);
 }
 
 function cellsOf(row: CollectiveXKvRunCase) {
@@ -140,6 +153,9 @@ export function CollectiveXKvSection({
   );
   const [pageTokens, setPageTokens] = useState<'64' | '16'>('64');
   const [op, setOp] = useState<CollectiveXKvChartSelection['op']>('pull');
+  // Overlap view only: 'max' normalizes each series at its own largest
+  // measured ISL; a numeric string pins every series to that ISL.
+  const [overlapIsl, setOverlapIsl] = useState<string>('max');
   const [xLogScale, setXLogScale] = useState(true);
   const [yLogScale, setYLogScale] = useState(true);
   const [showWireCeilings, setShowWireCeilings] = useState(true);
@@ -185,6 +201,18 @@ export function CollectiveXKvSection({
     () => measuredCases.filter((kase) => activeIds.has(`${kase.run_id}:${kase.case_id}`)),
     [activeIds, measuredCases],
   );
+  // ISL options come from all measured cases (not the legend-active subset)
+  // so the selector is stable while series are toggled. A stored value that
+  // no longer exists for the current direction and page size falls back to
+  // 'max' rather than an empty chart.
+  const overlapIslValues = useMemo(
+    () => collectiveXKvIslValues(measuredCases, { op, pageTokens: Number(pageTokens) }),
+    [measuredCases, op, pageTokens],
+  );
+  const effectiveOverlapIsl =
+    overlapIsl !== 'max' && overlapIslValues.includes(Number(overlapIsl))
+      ? Number(overlapIsl)
+      : undefined;
 
   const colorKeys = useMemo(
     () => [...new Set(measuredCases.map(collectiveXKvColorKey))],
@@ -411,6 +439,27 @@ export function CollectiveXKvSection({
                 ]}
               />
             </div>
+            {xAxis === 'overlap' && overlapIslValues.length > 0 && (
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-muted-foreground">{strings.islControl}</Label>
+                <SegmentedToggle
+                  value={effectiveOverlapIsl === undefined ? 'max' : String(effectiveOverlapIsl)}
+                  onValueChange={(value) => {
+                    setOverlapIsl(value);
+                    track('collectivex_kv_overlap_isl_changed', { isl: value });
+                  }}
+                  ariaLabel={strings.islAriaLabel}
+                  testId="collectivex-kv-overlap-isl-toggle"
+                  options={[
+                    { value: 'max', label: strings.islMaxOption },
+                    ...overlapIslValues.map((value) => ({
+                      value: String(value),
+                      label: formatIsl(value),
+                    })),
+                  ]}
+                />
+              </div>
+            )}
           </div>
           <div className="relative mt-3">
             {xAxis === 'frontier' ? (
@@ -448,10 +497,14 @@ export function CollectiveXKvSection({
                 testId="collectivex-kv-overlap-chart"
                 cases={activeCases}
                 colors={colors}
-                selection={{ op, pageTokens: Number(pageTokens) }}
+                selection={{ op, pageTokens: Number(pageTokens), isl: effectiveOverlapIsl }}
                 caption={
                   <p className="text-sm text-muted-foreground">
-                    {op} · page {pageTokens} · {strings.overlapCaption}
+                    {op} · page {pageTokens} · ISL{' '}
+                    {effectiveOverlapIsl === undefined
+                      ? strings.islMaxOption
+                      : formatIsl(effectiveOverlapIsl)}{' '}
+                    · {strings.overlapCaption}
                   </p>
                 }
                 legendElement={

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -37,9 +37,13 @@ const STRINGS = {
     batchCaption: 'at the largest measured ISL',
     islCaption: 'at batch 1',
     frontierCaption:
-      'every measured (ISL, batch) rung is a point; each line traces the backend at its best ' +
-      'batch for every ISL, so higher is better. A backend that overlaps requests lifts its ' +
-      'line well above its batch-1 points; hover a point for its batch, latency, and status.',
+      'every measured (ISL, batch) rung is a point; each solid or dashed line traces the ' +
+      'backend at its best batch for every ISL, so higher is better. The dotted line above ' +
+      'each backend is its bulk wire ceiling: the same bytes moved as one contiguous ' +
+      'descriptor, so it is what the fabric itself achieves. Paged rungs sit far below it ' +
+      'because the DeepSeek-V4-Pro layout fragments each request into thousands of tiny ' +
+      'per-layer page descriptors, making the transfer descriptor-rate bound (per-operation ' +
+      'software cost), not fabric-bandwidth bound. Hover a point for its share of the wire.',
     frontierOption: 'Envelope',
     overlapOption: 'Overlap gain',
     overlapCaption:
@@ -66,8 +70,10 @@ const STRINGS = {
     batchCaption: '取最大实测 ISL',
     islCaption: '取批大小 1',
     frontierCaption:
-      '每个实测 (ISL, 批大小) 组合都是一个点；每条线取该后端在各 ISL 下的最优批大小，越高越优。' +
-      '能重叠请求的后端其线会明显高于批大小 1 的点；悬停可查看批大小、时延与状态。',
+      '每个实测 (ISL, 批大小) 组合都是一个点；实线或虚线取该后端在各 ISL 下的最优批大小，越高越优。' +
+      '每个后端上方的点状线是其 bulk 线速上限：同样的字节量以单个连续描述符搬运，即链路本身的能力。' +
+      '分页组合远低于上限，是因为 DeepSeek-V4-Pro 布局把每个请求碎片化为数千个微小的逐层页描述符，' +
+      '瓶颈在描述符处理速率（每操作软件开销）而非链路带宽。悬停数据点可查看其达到线速的比例。',
     frontierOption: '带宽包络',
     overlapOption: '重叠增益',
     overlapCaption:

--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -44,6 +44,10 @@ const STRINGS = {
       'because the DeepSeek-V4-Pro layout fragments each request into thousands of tiny ' +
       'per-layer page descriptors, making the transfer descriptor-rate bound (per-operation ' +
       'software cost), not fabric-bandwidth bound. Hover a point for its share of the wire.',
+    frontierCaptionWithoutCeilings:
+      'every measured (ISL, batch) rung is a point; each line traces the backend at its best ' +
+      'batch for every ISL, so higher is better. A backend that overlaps requests lifts its ' +
+      'line well above its batch-1 points; hover a point for its batch, latency, and status.',
     frontierOption: 'Envelope',
     overlapOption: 'Overlap gain',
     overlapCaption:
@@ -60,6 +64,7 @@ const STRINGS = {
     opAriaLabel: 'CollectiveX KV direction',
     xLogScale: 'X-axis Log Scale',
     yLogScale: 'Y-axis Log Scale',
+    bulkWireCeiling: 'Bulk Wire Ceiling',
   },
   zh: {
     heading: 'KV 缓存传输',
@@ -74,6 +79,9 @@ const STRINGS = {
       '每个后端上方的点状线是其 bulk 线速上限：同样的字节量以单个连续描述符搬运，即链路本身的能力。' +
       '分页组合远低于上限，是因为 DeepSeek-V4-Pro 布局把每个请求碎片化为数千个微小的逐层页描述符，' +
       '瓶颈在描述符处理速率（每操作软件开销）而非链路带宽。悬停数据点可查看其达到线速的比例。',
+    frontierCaptionWithoutCeilings:
+      '每个实测 (ISL, 批大小) 组合都是一个点；每条线取该后端在各 ISL 下的最优批大小，越高越优。' +
+      '能重叠请求的后端其线会明显高于批大小 1 的点；悬停可查看批大小、延迟与状态。',
     frontierOption: '带宽包络',
     overlapOption: '重叠增益',
     overlapCaption:
@@ -89,6 +97,7 @@ const STRINGS = {
     opAriaLabel: 'CollectiveX KV 传输方向',
     xLogScale: 'X 轴对数缩放',
     yLogScale: 'Y 轴对数缩放',
+    bulkWireCeiling: 'Bulk 线速上限',
   },
 } as const;
 
@@ -133,6 +142,7 @@ export function CollectiveXKvSection({
   const [op, setOp] = useState<CollectiveXKvChartSelection['op']>('pull');
   const [xLogScale, setXLogScale] = useState(true);
   const [yLogScale, setYLogScale] = useState(true);
+  const [showWireCeilings, setShowWireCeilings] = useState(true);
   // Legend toggles are keyed to the current series set: when checked runs
   // change, the stored selection is stale and every series starts active
   // again (the EP explorer resets the same way).
@@ -317,6 +327,19 @@ export function CollectiveXKvSection({
       },
     },
   ];
+  const envelopeLegendSwitches = [
+    ...legendSwitches,
+    {
+      id: 'collectivex-kv-bulk-wire-ceiling',
+      label: strings.bulkWireCeiling,
+      advanced: true,
+      checked: showWireCeilings,
+      onCheckedChange: (checked: boolean) => {
+        setShowWireCeilings(checked);
+        track('collectivex_kv_bulk_wire_ceiling_toggled', { enabled: checked });
+      },
+    },
+  ];
   return (
     <Card data-testid="collectivex-kv-table" className="min-w-0 w-full max-w-full overflow-hidden">
       <h2 className="text-lg font-semibold">{strings.heading}</h2>
@@ -399,16 +422,20 @@ export function CollectiveXKvSection({
                 selection={{ op, pageTokens: Number(pageTokens) }}
                 xLogScale={xLogScale}
                 yLogScale={yLogScale}
+                showWireCeilings={showWireCeilings}
                 caption={
                   <p className="text-sm text-muted-foreground">
-                    {op} · page {pageTokens} · {strings.frontierCaption}
+                    {op} · page {pageTokens} ·{' '}
+                    {showWireCeilings
+                      ? strings.frontierCaption
+                      : strings.frontierCaptionWithoutCeilings}
                   </p>
                 }
                 legendElement={
                   <ChartLegend
                     variant="sidebar"
                     legendItems={legendItems}
-                    switches={legendSwitches}
+                    switches={envelopeLegendSwitches}
                     disableActiveSort
                     isLegendExpanded={legendExpanded}
                     onExpandedChange={setLegendExpanded}

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -17,6 +17,7 @@ import {
   type CollectiveXSeriesSelection,
   collectiveXKvChartPoints,
   collectiveXKvFrontierPoints,
+  collectiveXKvIslValues,
   collectiveXKvOverlapPoints,
   collectiveXKvWireCeilings,
   type CollectiveXKvRunCase,
@@ -559,6 +560,57 @@ describe('collectiveXKvChartPoints', () => {
         selection,
       );
       expect(points).toEqual([]);
+    });
+
+    it('pins the normalization to the requested ISL when one is selected', () => {
+      const points = collectiveXKvOverlapPoints(
+        [
+          kase([
+            { isl: 4096, batch: 1, gbps_p50: 6 },
+            { isl: 4096, batch: 4, gbps_p50: 18 },
+            // The larger-ISL ladder is ignored once 4096 is pinned.
+            { isl: 32768, batch: 1, gbps_p50: 8 },
+            { isl: 32768, batch: 4, gbps_p50: 24 },
+          ]),
+        ],
+        { ...selection, isl: 4096 },
+      );
+      expect(points.map((point) => [point.x, point.y])).toEqual([
+        [1, 1],
+        [4, 3],
+      ]);
+    });
+
+    it('drops a series with no rows at the requested ISL', () => {
+      const points = collectiveXKvOverlapPoints(
+        [
+          kase([
+            { isl: 32768, batch: 1, gbps_p50: 8 },
+            { isl: 32768, batch: 4, gbps_p50: 24 },
+          ]),
+        ],
+        { ...selection, isl: 4096 },
+      );
+      expect(points).toEqual([]);
+    });
+  });
+
+  describe('collectiveXKvIslValues', () => {
+    it('lists distinct paged ISLs of the selected direction and page size, ascending', () => {
+      const values = collectiveXKvIslValues(
+        [
+          kase([
+            { isl: 32768, batch: 1 },
+            { isl: 32768, batch: 4 },
+            { isl: 4096, batch: 1 },
+            { isl: 8192, batch: 1, op: 'push' },
+            { isl: 16384, batch: 1, page_tokens: 16 },
+            bulk({ isl: 65536 }),
+          ]),
+        ],
+        { op: 'pull', pageTokens: 64 },
+      );
+      expect(values).toEqual([4096, 32768]);
     });
   });
 

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -18,6 +18,7 @@ import {
   collectiveXKvChartPoints,
   collectiveXKvFrontierPoints,
   collectiveXKvOverlapPoints,
+  collectiveXKvWireCeilings,
   type CollectiveXKvRunCase,
   collectiveXKvCell,
 } from './data';
@@ -340,6 +341,9 @@ const kvRow = ({
   ...overrides,
 });
 
+const bulk = (overrides: Partial<CollectiveXKvRow>) =>
+  ({ kind: 'bulk', page_tokens: null, ...overrides }) as Partial<CollectiveXKvRow>;
+
 describe('collectiveXKvCell', () => {
   it('picks the largest-ISL pull row at the requested batch extreme', () => {
     const rows = [
@@ -555,6 +559,56 @@ describe('collectiveXKvChartPoints', () => {
         selection,
       );
       expect(points).toEqual([]);
+    });
+  });
+
+  describe('collectiveXKvWireCeilings', () => {
+    it('traces the bulk ladder of the selected direction, sorted by ISL', () => {
+      const ceilings = collectiveXKvWireCeilings(
+        [
+          kase([
+            bulk({ isl: 32768, gbps_p50: 89.41 }),
+            bulk({ isl: 4096, gbps_p50: 52.3 }),
+            bulk({ isl: 32768, op: 'push', gbps_p50: 70 }),
+            // Paged rows never enter the ceiling.
+            { isl: 32768, batch: 1, gbps_p50: 7.39 },
+          ]),
+        ],
+        'pull',
+      );
+      expect(ceilings.get('318:gb200-nixl-kv-dsv4-rdma-xfer-ep2-paged-fp8')).toMatchObject([
+        { x: 4096, y: 52.3 },
+        { x: 32768, y: 89.41 },
+      ]);
+    });
+
+    it('keeps the fastest bulk row when several share an ISL', () => {
+      const ceilings = collectiveXKvWireCeilings(
+        [
+          kase([
+            bulk({ isl: 32768, batch: 1, gbps_p50: 89.41 }),
+            bulk({ isl: 32768, batch: 4, gbps_p50: 96.2 }),
+          ]),
+        ],
+        'pull',
+      );
+      expect(ceilings.get('318:gb200-nixl-kv-dsv4-rdma-xfer-ep2-paged-fp8')).toMatchObject([
+        { x: 32768, y: 96.2 },
+      ]);
+    });
+
+    it('omits series without usable bulk rows', () => {
+      const ceilings = collectiveXKvWireCeilings(
+        [
+          kase([
+            { isl: 32768, batch: 1, gbps_p50: 7.39 },
+            bulk({ isl: 32768, gbps_p50: 0 }),
+            bulk({ isl: 4096, gbps_p50: Number.NaN }),
+          ]),
+        ],
+        'pull',
+      );
+      expect(ceilings.size).toBe(0);
     });
   });
 });

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -281,6 +281,9 @@ export function collectiveXKvLegendLabel(kase: CollectiveXKvCase): string {
 export interface CollectiveXKvFrontierSelection {
   op: 'pull' | 'push';
   pageTokens: number;
+  /** Overlap view only: pin the ladder to this ISL. Absent means each
+   * series reads at its own largest measured ISL. */
+  isl?: number;
 }
 
 export interface CollectiveXKvFrontierPoint {
@@ -356,9 +359,10 @@ export function collectiveXKvFrontierPoints(
 
 /**
  * Overlap-gain points: aggregate bandwidth relative to the batch-1 rung at
- * the largest measured ISL of the selected direction and page size, so y is 1
- * at batch 1 by construction. An ideal overlapper tracks y = batch until the
- * wire saturates; a serializing backend stays flat at 1. A series without a
+ * one ISL of the selected direction and page size, so y is 1 at batch 1 by
+ * construction. The ISL is `selection.isl` when set, else each series' own
+ * largest measured ISL. An ideal overlapper tracks y = batch until the wire
+ * saturates; a serializing backend stays flat at 1. A series without a
  * batch-1 rung at that ISL has no baseline and is dropped.
  */
 export function collectiveXKvOverlapPoints(
@@ -371,7 +375,7 @@ export function collectiveXKvOverlapPoints(
         row.kind === 'paged' && row.op === selection.op && row.page_tokens === selection.pageTokens,
     );
     if (matching.length === 0) return [];
-    const isl = Math.max(...matching.map((row) => row.isl));
+    const isl = selection.isl ?? Math.max(...matching.map((row) => row.isl));
     const atIsl = matching.filter((row) => row.isl === isl);
     const baseline = atIsl.find((row) => row.batch === 1);
     if (!baseline || !(baseline.gbps_p50 > 0)) return [];
@@ -391,6 +395,31 @@ export function collectiveXKvOverlapPoints(
       ];
     });
   });
+}
+
+/**
+ * Distinct measured ISLs of the paged rows matching the selected direction
+ * and page size, ascending. Drives the overlap view's ISL selector; a series
+ * with no rows at a chosen ISL simply drops from the chart via the missing
+ * batch-1 baseline.
+ */
+export function collectiveXKvIslValues(
+  cases: readonly CollectiveXKvRunCase[],
+  selection: Pick<CollectiveXKvFrontierSelection, 'op' | 'pageTokens'>,
+): number[] {
+  const values = new Set<number>();
+  for (const kase of cases) {
+    for (const row of kase.rows) {
+      if (
+        row.kind === 'paged' &&
+        row.op === selection.op &&
+        row.page_tokens === selection.pageTokens
+      ) {
+        values.add(row.isl);
+      }
+    }
+  }
+  return [...values].toSorted((a, b) => a - b);
 }
 
 export interface CollectiveXKvWireCeilingPoint {

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -393,6 +393,47 @@ export function collectiveXKvOverlapPoints(
   });
 }
 
+export interface CollectiveXKvWireCeilingPoint {
+  x: number;
+  y: number;
+  row: CollectiveXKvRow;
+}
+
+/**
+ * Wire-ceiling lines for the envelope view: each series' bulk rows of the
+ * selected direction across the ISL ladder, keyed by series id. A bulk row
+ * moves the same bytes as the paged rungs at that ISL in one contiguous
+ * descriptor, so it is what the fabric itself achieves; the gap from a paged
+ * rung up to this line is per-descriptor software overhead, not the wire.
+ * Bulk rows have no page size, so the page toggle does not apply. When
+ * several bulk rows share an ISL (a batch ladder), the fastest one is the
+ * ceiling.
+ */
+export function collectiveXKvWireCeilings(
+  cases: readonly CollectiveXKvRunCase[],
+  op: 'pull' | 'push',
+): Map<string, CollectiveXKvWireCeilingPoint[]> {
+  const ceilings = new Map<string, CollectiveXKvWireCeilingPoint[]>();
+  for (const kase of cases) {
+    const byIsl = new Map<number, CollectiveXKvRow>();
+    for (const row of kase.rows) {
+      if (row.kind !== 'bulk' || row.op !== op) continue;
+      if (!Number.isFinite(row.isl) || row.isl <= 0) continue;
+      if (!Number.isFinite(row.gbps_p50) || row.gbps_p50 <= 0) continue;
+      const best = byIsl.get(row.isl);
+      if (!best || row.gbps_p50 > best.gbps_p50) byIsl.set(row.isl, row);
+    }
+    if (byIsl.size === 0) continue;
+    ceilings.set(
+      `${kase.run_id}:${kase.case_id}`,
+      [...byIsl.values()]
+        .toSorted((a, b) => a.isl - b.isl)
+        .map((row) => ({ x: row.isl, y: row.gbps_p50, row })),
+    );
+  }
+  return ceilings;
+}
+
 export function collectiveXKvChartPoints(
   cases: readonly CollectiveXKvRunCase[],
   selection: CollectiveXKvChartSelection,

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -695,7 +695,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/collectivex/types.ts',
-    sourceSha256: '40079de1a9b1faef47cc72090331b9d2987f2895da34a77292f3bfcdf1dc5a64',
+    sourceSha256: 'd988f0c348d187667aedaba63848bf5c0afd038c7fee6bcaf830747ee6c0dc61',
     reviewArea: {
       en: 'CollectiveX version negotiation and versioned dataset/run response types.',
       zh: 'CollectiveX 版本协商以及带版本的数据集与运行响应类型。',

--- a/packages/db/src/collectivex/reader.ts
+++ b/packages/db/src/collectivex/reader.ts
@@ -73,7 +73,9 @@ interface RawKvRow {
   req_bytes: number;
   prep_ms?: number;
   latency_ms: CollectiveXKvLatency;
+  request_ms?: CollectiveXKvLatency;
   gbps_p50: number;
+  gbps_p50_incl_prep?: number;
   verify?: { passed: boolean; detail?: string };
 }
 
@@ -319,7 +321,12 @@ function mapKvRow(row: RawKvRow): CollectiveXKvRow {
     req_bytes: row.req_bytes,
     prep_ms: row.prep_ms ?? 0,
     latency_ms: row.latency_ms,
+    // Absent on rows measured before the harness recorded per-request marks.
+    ...(row.request_ms ? { request_ms: row.request_ms } : {}),
     gbps_p50: row.gbps_p50,
+    ...(typeof row.gbps_p50_incl_prep === 'number'
+      ? { gbps_p50_incl_prep: row.gbps_p50_incl_prep }
+      : {}),
     verify_passed: row.verify?.passed ?? true,
   };
 }

--- a/packages/db/src/collectivex/types.ts
+++ b/packages/db/src/collectivex/types.ts
@@ -128,7 +128,15 @@ export interface CollectiveXKvRow {
   req_bytes: number;
   prep_ms: number;
   latency_ms: CollectiveXKvLatency;
+  /**
+   * Each request's host-observed completion offset within its burst — the
+   * per-request latency distribution. Absent on rows measured before the
+   * harness recorded it; `latency_ms` (whole-burst) is a capacity quantity.
+   */
+  request_ms?: CollectiveXKvLatency;
   gbps_p50: number;
+  /** Cold-path rate: descriptor/handle prep paid once per burst. */
+  gbps_p50_incl_prep?: number;
   verify_passed: boolean;
 }
 


### PR DESCRIPTION
## What

Adds each backend's bulk wire ceiling to the KV Envelope view as a dotted line in the series color, with a default-on Advanced legend switch beside the X/Y Log Scale controls. Also adds an ISL selector to the Overlap gain view.

- `collectiveXKvWireCeilings(cases, op)` extracts each series' bulk rows across the ISL ladder, keeping the fastest row when several share an ISL.
- The Envelope chart draws a `1 4` dotted ceiling line for each plotted series, expands the Y domain to include visible ceilings, and reports the ceiling plus each rung's percentage of wire in the tooltip.
- The new `Bulk Wire Ceiling` switch hides or restores the dotted lines, their Y-domain contribution, tooltip detail, and ceiling-specific caption copy.
- The Overlap gain view gains an ISL toggle (`Max` plus every measured ISL for the selected direction and page size, via the new `collectiveXKvIslValues` helper). `Max` keeps the old behavior of normalizing each backend at its own largest measured ISL; picking a value pins every backend's batch ladder to that ISL, and backends without a batch-1 rung there drop from the chart through the existing missing-baseline path.
- English and Simplified Chinese captions and control labels explain why paged rungs can sit far below the single-descriptor wire ceiling and which ISL the overlap normalization uses.

## Why

Paged rows can sit one to two orders of magnitude below fabric capacity because the DeepSeek-V4-Pro layout fragments each request into thousands of small per-layer descriptors. The bulk rows move the same bytes as one contiguous descriptor, showing that the gap is dominated by per-descriptor software cost rather than a broken fabric. The visibility switch lets readers focus on the paged envelopes when the reference lines are not needed. The ISL selector makes overlap scaling comparable across backends at one context length instead of mixing each backend's largest measured ISL.

## Tests

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit` (4,635 tests)
- `bunx cypress run --spec cypress/e2e/collectivex.cy.ts` (34 tests)

Chinese copy was checked manually against `docs/chinese-copy.md` because the referenced `review-zh-copy` skill was not available in this session.

## 中文说明

### 变更内容

在 KV 带宽包络图中，以对应序列颜色的点状线显示各后端的 bulk 线速上限，并在 X/Y 轴对数缩放开关旁新增默认开启的高级图例开关。同时为重叠增益视图新增 ISL 选择器。

- `collectiveXKvWireCeilings(cases, op)` 从各序列中提取覆盖 ISL 阶梯的 bulk 数据；同一 ISL 存在多条数据时保留带宽最高的一条。
- 带宽包络图为每个已绘制序列添加 `1 4` 点状线；显示线速上限时，Y 轴范围会覆盖这些数据，提示框也会显示线速上限及当前组合达到线速的比例。
- 新增的 `Bulk 线速上限` 开关可同步隐藏或恢复点状线、其对 Y 轴范围的影响、提示框详情以及线速上限专用说明。
- 重叠增益视图新增 ISL 选择器（"最大"加上当前方向与页大小下的所有实测 ISL，由新增的 `collectiveXKvIslValues` 提供）。"最大"保持原有行为，即各后端取其最大实测 ISL 归一化；选定具体值后所有后端的批阶梯都固定在该 ISL，在该 ISL 处没有批大小 1 数据的后端沿既有缺失基线路径从图中隐藏。
- 英文和简体中文文案均说明了分页组合为何可能远低于单描述符线速上限，以及重叠归一化所使用的 ISL。

### 原因

DeepSeek-V4-Pro 的缓存布局会把每个请求拆分成数千个微小的逐层描述符，因此分页数据可能比链路容量低一至两个数量级。Bulk 数据以单个连续描述符搬运相同的字节量，说明两者差距主要来自每描述符软件开销，而非链路异常。不需要参考线时，读者可关闭开关，专注查看分页带宽包络。ISL 选择器使各后端的重叠扩展性可以在同一上下文长度下比较，而不是混用各后端自己的最大实测 ISL。

### 测试

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test:unit`（4,635 项测试）
- `bunx cypress run --spec cypress/e2e/collectivex.cy.ts`（34 项测试）

由于本次会话未提供文档中提到的 `review-zh-copy` skill，中文文案已参照 `docs/chinese-copy.md` 完成人工检查。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and optional CollectiveX KV field extensions with backward-compatible reader mapping; no auth or mutation paths change.
> 
> **Overview**
> The KV **Envelope** view now overlays each backend’s **bulk contiguous baseline** as a dotted line (same color as the envelope), with Y-axis scaling and tooltips that show how much of that baseline each paged rung reaches. An Advanced legend switch (**Bulk Contiguous Baseline**, default on) hides the lines, ceiling-aware caption copy, and tooltip ceiling rows without changing the measured envelope points.
> 
> **Overlap gain** adds an **ISL** control (`Max` or a measured ISL for the current direction and page size). `Max` keeps per-backend normalization at each series’ largest ISL; a fixed ISL pins every backend to that context length and drops series missing batch-1 at that ISL. New helpers `collectiveXKvWireCeilings`, `collectiveXKvIslValues`, and optional `selection.isl` on overlap data drive the charts.
> 
> The neutral KV contract and reader now accept optional **`request_ms`** and **`gbps_p50_incl_prep`** on rows; envelope point tooltips prefer per-request p95 when `request_ms` is present. Section copy (EN/zh) is updated for NIXL-style paged descriptors and baseline semantics. Cypress and unit tests cover the ceiling toggle and new data helpers; the API contract digest for `collectivex/types.ts` is bumped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94e7537e917527d5f9c9ea3e61d774153ecf1bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->