### PR TITLE
CollectiveX: wire-basis payload bandwidth + nccl-ep LL hold in the support matrix

### DIFF
--- a/packages/app/src/components/collectivex/known-support.ts
+++ b/packages/app/src/components/collectivex/known-support.ts
@@ -115,8 +115,12 @@ export const COLLECTIVEX_KNOWN_FOOTNOTES: Record<string, CollectiveXKnownFootnot
     zh: '跨节点 IBGDA 在 NVSHMEM 建立阶段失败——2026-08-28 在新节点对上复验：ibv_reg_dmabuf_mr 返回空 MR，随后才是 ibv_create_ah 失败，且 nvidia_peermem 已加载；当前疑点是容器镜像中过旧的 libmlx5（需镜像升级而非主机修复）。',
   },
   'mori-ll-scale-up-only': {
-    en: 'MoRI low-latency measures AsyncLL split-phase (the kernel SGLang deploys for low-latency, validated 2026-08-30); the benchmark keeps it scale-up EP8 only.',
-    zh: 'MoRI 低延迟测量 AsyncLL 分阶段路径（即 SGLang 在低延迟模式下实际部署的 Kernel，2026-08-30 验证）；基准仅覆盖节点内 EP8。',
+    en: 'MoRI low-latency measures AsyncLL split-phase (the kernel SGLang deploys); the benchmark keeps it scale-up EP8 only.',
+    zh: 'MoRI 低延迟测量 AsyncLL 分阶段路径（即 SGLang 实际部署的 Kernel）；基准仅覆盖节点内 EP8。',
+  },
+  'mori-asyncll-topk6': {
+    en: "AsyncLL (the deployed low-latency kernel) hits a device-side assert whenever top-k does not divide the 64-lane warp — the DeepSeek-V4-Pro workload's top-k 6 crashes where top-k 8 passes (bisected on-metal, pure mori API). Fixed upstream in ROCm/mori#505 (2026-07-31); red until the mi35x images ship a mori containing it (newest tag is mori-0706).",
+    zh: 'AsyncLL（实际部署的低延迟 Kernel）在 top-k 无法整除 64 lane warp 时触发设备端断言——DeepSeek-V4-Pro 工作负载的 top-k 6 崩溃而 top-k 8 通过（裸金属上用纯 mori API 二分定位）。上游已在 ROCm/mori#505（2026-07-31）修复；在 mi35x 镜像包含该修复前（最新标签为 mori-0706）保持红色。',
   },
   'no-ll-kernels': {
     en: 'The library has no low-latency kernels.',
@@ -256,21 +260,21 @@ const LOW_LATENCY: KnownMatrix = {
   },
   mi300x: {
     'deepep-v2': off('nvidia-only'),
-    mori: cell(works, na('mori-ll-scale-up-only')),
+    mori: cell(broken('mori-asyncll-topk6'), na('mori-ll-scale-up-only')),
     'uccl-ep': cell(broken('uccl-amd-ll-kernel'), broken('uccl-amd-ll-kernel')),
     'nccl-ep': off('nvidia-only'),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   mi325x: {
     'deepep-v2': off('nvidia-only'),
-    mori: cell(works, na('mori-ll-scale-up-only')),
+    mori: cell(broken('mori-asyncll-topk6'), na('mori-ll-scale-up-only')),
     'uccl-ep': cell(broken('uccl-amd-ll-kernel'), broken('uccl-amd-ll-kernel')),
     'nccl-ep': off('nvidia-only'),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   mi355x: {
     'deepep-v2': off('nvidia-only'),
-    mori: cell(works, na('mori-ll-scale-up-only')),
+    mori: cell(broken('mori-asyncll-topk6'), na('mori-ll-scale-up-only')),
     'uccl-ep': cell(broken('uccl-amd-ll-kernel'), broken('uccl-amd-ll-kernel')),
     'nccl-ep': off('nvidia-only'),
     'flashinfer-ep': off('no-ll-kernels'),

--- a/packages/app/src/components/collectivex/known-support.ts
+++ b/packages/app/src/components/collectivex/known-support.ts
@@ -98,9 +98,9 @@ export const COLLECTIVEX_KNOWN_FOOTNOTES: Record<string, CollectiveXKnownFootnot
     en: "NCCL EP's GPU-initiated RDMA (GDAKI) does not work for EP16 scale-out on the x86 pools — re-confirmed on bare metal 2026-08-28: every rank hits an illegal memory access in the EP kernel, so it is not a virtualization artifact. EP16 works only over MNNVL on the GB SKUs.",
     zh: 'NCCL EP 的 GPU 发起 RDMA（GDAKI）在 x86 集群上无法支撑 EP16 横向扩展——2026-08-28 在裸金属上复验：所有 rank 在 EP Kernel 中触发非法内存访问，故并非虚拟化产物。EP16 仅在 GB SKU 的 MNNVL 上可用。',
   },
-  'nccl-ll-clamped': {
-    en: 'Works, BF16 only, with the ladder clamped to ≤128 tokens/rank pending an upstream low-latency fence-race fix (NVIDIA/nccl-extensions#8).',
-    zh: '可用，但仅支持 BF16，且在上游修复低延迟栅栏竞争（NVIDIA/nccl-extensions#8）之前，梯度上限为每 rank 128 token。',
+  'nccl-ll-fence-race': {
+    en: "Held: nccl_ep's low-latency combine is a port of DeepEP's pre-fix pipeline, missing the DeepEP #642 fence, and the shared-memory race is present on every rung — the former T≤128 clamp only reduced exposure (observed 1-in-5 corruption at T=256, bimodal). Rows are withheld until a fenced wheel ships.",
+    zh: '暂缓发布：nccl_ep 的低延迟 combine 移植自 DeepEP 修复前的流水线，缺少 DeepEP #642 的栅栏，共享内存竞争存在于每一级梯度——此前的 T≤128 限制只是降低了暴露度（T=256 观察到约五分之一的双峰型损坏）。在修复后的 wheel 发布前不发布数据。',
   },
   'hseries-ll-gdr': {
     en: 'Functional and numerically correct, but the IBGDA send path runs 2.3–26x slower than bare-metal references in these virtualized pods (gdrcopy present but insufficient); held until the platform GDR question is resolved.',
@@ -115,8 +115,8 @@ export const COLLECTIVEX_KNOWN_FOOTNOTES: Record<string, CollectiveXKnownFootnot
     zh: '跨节点 IBGDA 在 NVSHMEM 建立阶段失败——2026-08-28 在新节点对上复验：ibv_reg_dmabuf_mr 返回空 MR，随后才是 ibv_create_ah 失败，且 nvidia_peermem 已加载；当前疑点是容器镜像中过旧的 libmlx5（需镜像升级而非主机修复）。',
   },
   'mori-ll-scale-up-only': {
-    en: 'MoRI low-latency uses the IntraNodeLL kernel, which is scale-up-only by design; a cross-node low-latency mode does not exist.',
-    zh: 'MoRI 低延迟使用 IntraNodeLL Kernel，按设计仅限节点内扩展；不存在跨节点低延迟模式。',
+    en: 'MoRI low-latency measures AsyncLL split-phase (the kernel SGLang deploys for low-latency, validated 2026-08-30); the benchmark keeps it scale-up EP8 only.',
+    zh: 'MoRI 低延迟测量 AsyncLL 分阶段路径（即 SGLang 在低延迟模式下实际部署的 Kernel，2026-08-30 验证）；基准仅覆盖节点内 EP8。',
   },
   'no-ll-kernels': {
     en: 'The library has no low-latency kernels.',
@@ -216,42 +216,42 @@ const LOW_LATENCY: KnownMatrix = {
     'deepep-v2': cell(works, broken('hseries-ll-gdr')),
     mori: off('amd-only'),
     'uccl-ep': cell(works, na('ll-ep16-not-enabled')),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   h200: {
     'deepep-v2': cell(works, broken('hseries-ll-gdr')),
     mori: off('amd-only'),
     'uccl-ep': cell(works, na('ll-ep16-not-enabled')),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   b200: {
     'deepep-v2': bothWork,
     mori: off('amd-only'),
     'uccl-ep': cell(works, na('ll-ep16-not-enabled')),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   b300: {
     'deepep-v2': cell(worksWith('b300-ll-single-node-pin'), broken('b300-ll-create-ah')),
     mori: off('amd-only'),
     'uccl-ep': off('uccl-not-brought-up'),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   gb200: {
     'deepep-v2': bothWork,
     mori: off('amd-only'),
     'uccl-ep': off('uccl-not-brought-up'),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   gb300: {
     'deepep-v2': bothWork,
     mori: off('amd-only'),
     'uccl-ep': off('uccl-not-brought-up'),
-    'nccl-ep': cell(worksWith('nccl-ll-clamped'), na('ll-ep16-not-enabled')),
+    'nccl-ep': cell(broken('nccl-ll-fence-race'), na('ll-ep16-not-enabled')),
     'flashinfer-ep': off('no-ll-kernels'),
   },
   mi300x: {

--- a/packages/db/src/collectivex/reader.test.ts
+++ b/packages/db/src/collectivex/reader.test.ts
@@ -215,6 +215,19 @@ describe('CollectiveX artifact assembly', () => {
     );
   });
 
+  it('prefers wire_byte_provenance when the artifact carries it', () => {
+    // A token-expert LL row moves one copy per (token, expert); its deduplicated
+    // byte_provenance is a lower bound (~34% low on nccl-ep LL EP8 at T=128), so
+    // rates must divide from the wire basis when present.
+    const dispatch = makeCollectiveXSeries({ rows: [{ wireBytesFactor: 1.5 }] }).points[0]
+      .components.dispatch;
+    expect(dispatch?.payload_data_rate_gbps_at_latency_percentile?.p50).toBeCloseTo(
+      ((400000000 * 1.5) / 8 / 417) * 1e-3,
+      3,
+    );
+    expect(dispatch?.payload_bytes).toBe(400000000 * 1.5);
+  });
+
   it('does not invent rates for zero-byte or unavailable components', () => {
     const zeroStage = makeCollectiveXSeries({ rows: [{ stageZeroBytes: true }] }).points[0]
       .components.stage;

--- a/packages/db/src/collectivex/reader.ts
+++ b/packages/db/src/collectivex/reader.ts
@@ -59,6 +59,17 @@ interface RawRow {
   token_rate_at_latency_percentile: CollectiveXPercentiles;
   components: Record<string, RawComponent | null>;
   byte_provenance: Record<string, { activation_data_bytes: number; total_logical_bytes?: number }>;
+  /**
+   * Bytes the kernels actually move: per-(token, expert) for the low-latency layouts
+   * that do not rank-deduplicate (DeepEP/UCCL/NCCL LL), identical to `byte_provenance`
+   * everywhere else. Absent on artifacts written before the wire basis shipped —
+   * for those, LL rates derived from `byte_provenance` are a lower bound (~34% low
+   * on nccl-ep LL EP8 at T=128), never an overstatement.
+   */
+  wire_byte_provenance?: Record<
+    string,
+    { activation_data_bytes: number; total_logical_bytes?: number }
+  >;
 }
 
 // KV shards report per-burst rows instead of per-ladder-token rows; the two
@@ -200,8 +211,11 @@ function mapComponent(
 }
 
 function mapPoint(row: RawRow, ep: number): CollectiveXPoint {
-  const component = (name: string) =>
-    mapComponent(row.components[name], row.byte_provenance[name], ep);
+  // Divide rates from the wire basis when the artifact carries it: for the LL layouts
+  // that move one copy per (token, expert), `byte_provenance` is rank-deduplicated and
+  // publishing a rate from it presented a lower bound as the wire bandwidth.
+  const provenance = row.wire_byte_provenance ?? row.byte_provenance;
+  const component = (name: string) => mapComponent(row.components[name], provenance[name], ep);
   return {
     tokens_per_rank: row.tokens_per_rank,
     global_tokens: row.global_tokens,

--- a/packages/db/src/collectivex/test-fixture.ts
+++ b/packages/db/src/collectivex/test-fixture.ts
@@ -14,6 +14,8 @@ export interface RowOverrides {
   globalTokens?: number;
   stageUnavailable?: boolean;
   stageZeroBytes?: boolean;
+  /** Adds wire_byte_provenance at this multiple of byte_provenance (a token-expert LL row). */
+  wireBytesFactor?: number;
 }
 
 export interface ShardOverrides {
@@ -78,13 +80,29 @@ function makeRawRow(index: number, row: RowOverrides, worldSize: number): Json {
   if (!row.stageUnavailable) {
     byteProvenance.stage = bytes(row.stageZeroBytes ? 0 : 192381952);
   }
-  return {
+  const raw: Json = {
     tokens_per_rank: tokensPerRank,
     global_tokens: row.globalTokens ?? tokensPerRank * worldSize,
     token_rate_at_latency_percentile: percentiles(8_338_218),
     components,
     byte_provenance: byteProvenance,
   };
+  if (row.wireBytesFactor !== undefined) {
+    const scaled = (entry: Json): Json => ({
+      activation_data_bytes:
+        (entry as { activation_data_bytes: number }).activation_data_bytes * row.wireBytesFactor!,
+      total_logical_bytes:
+        ((entry as { total_logical_bytes?: number }).total_logical_bytes ?? 0) *
+        row.wireBytesFactor!,
+    });
+    raw.wire_byte_provenance = Object.fromEntries(
+      Object.entries(byteProvenance as Record<string, Json>).map(([name, entry]) => [
+        name,
+        scaled(entry),
+      ]),
+    );
+  }
+  return raw;
 }
 
 function makeRawCase(options: ShardOverrides, caseId: string): Json {


### PR DESCRIPTION
Companion to SemiAnalysisAI/InferenceX#2786 (measurement-side).

1. **Payload bandwidth divides from the wire basis.** `packages/db/src/collectivex/reader.ts` mapped rates only from `byte_provenance`, which is rank-deduplicated — for DeepEP/UCCL/NCCL low-latency layouts (one copy per token–expert assignment) that published a lower bound as the wire rate, 34.1% low on nccl-ep LL EP8 at T=128 (77.4 vs 117.4 MB per direction), and made LL GB/s incomparable across backends. The reader now prefers the new `wire_byte_provenance` field; artifacts written before it fall back and only ever understate.
2. **Known-support matrix: nccl-ep LL cells go red.** The "works with ladder clamped to ≤128" note presented the clamp as a safety boundary; the harness source says it is not one (the un-fenced combine race is on every rung). Cells flip to broken/held until a fenced wheel ships; the registry hold is in InferenceX#2786.
3. **MoRI LL note** now reflects AsyncLL split-phase (the kernel SGLang deploys; validated on mi355x, run 33319409233, both precisions green).

Tests: reader/known-support/data suites 72 pass (new test pins the wire-basis preference and payload_bytes); tsc clean on db+app.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CollectiveX metric interpretation and curated support labels only; no auth, persistence, or runtime execution paths.
> 
> **Overview**
> **Payload bandwidth** now derives from **`wire_byte_provenance`** when artifacts include it, instead of rank-deduplicated **`byte_provenance`** alone—so low-latency token–expert layouts no longer show understated wire GB/s; older shards still fall back and only understate. A reader test and fixture hook (`wireBytesFactor`) lock in that preference for `payload_bytes` and payload rates.
> 
> The **known-support matrix** reclassifies **nccl-ep** low-latency from “works with T≤128 clamp” to **held/broken** (`nccl-ll-fence-race`) across NVIDIA SKUs, and marks **MoRI** LL on mi3xx as **broken** for AsyncLL top-k 6 (`mori-asyncll-topk6`) while updating the scale-up-only footnote to describe AsyncLL split-phase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1728eb72ccbd2f1a05a389eb62512b6a05f7f8d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->