### PR TITLE
CollectiveX KV: derive the page ladder from measured rows / CollectiveX KV：页大小从实测数据推导

### DIFF
--- a/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
+++ b/packages/app/src/components/collectivex/CollectiveXKvSection.tsx
@@ -22,6 +22,7 @@ import {
   collectiveXKvColorKey,
   collectiveXKvIslValues,
   collectiveXKvLegendLabel,
+  collectiveXKvPageValues,
   collectiveXRunDasharray,
   collectiveXSkuLabel,
 } from './data';
@@ -128,11 +129,14 @@ function formatIsl(value: number): string {
   return value >= 1024 && value % 1024 === 0 ? `${value / 1024}k` : String(value);
 }
 
-function cellsOf(row: CollectiveXKvRunCase) {
+function cellsOf(row: CollectiveXKvRunCase, primaryPage: number, secondaryPage?: number) {
   return {
-    p64b1: collectiveXKvCell(row.rows, 'paged', 64, 'min'),
-    p64bmax: collectiveXKvCell(row.rows, 'paged', 64, 'max'),
-    p16b1: collectiveXKvCell(row.rows, 'paged', 16, 'min'),
+    pb1: collectiveXKvCell(row.rows, 'paged', primaryPage, 'min'),
+    pbmax: collectiveXKvCell(row.rows, 'paged', primaryPage, 'max'),
+    sb1:
+      secondaryPage === undefined
+        ? null
+        : collectiveXKvCell(row.rows, 'paged', secondaryPage, 'min'),
     bulk: collectiveXKvCell(row.rows, 'bulk', null, 'min'),
   };
 }
@@ -152,7 +156,10 @@ export function CollectiveXKvSection({
   const [xAxis, setXAxis] = useState<CollectiveXKvChartSelection['x'] | 'frontier' | 'overlap'>(
     'batch',
   );
-  const [pageTokens, setPageTokens] = useState<'64' | '16'>('64');
+  // The page ladder lives in the data (the sweep moved from 64/16 to the
+  // production block 256); a stored choice the current rows no longer carry
+  // falls back to the largest measured page rather than an empty chart.
+  const [pageChoice, setPageChoice] = useState<string | null>(null);
   const [op, setOp] = useState<CollectiveXKvChartSelection['op']>('pull');
   // Overlap view only: 'max' normalizes each series at its own largest
   // measured ISL; a numeric string pins every series to that ISL.
@@ -183,6 +190,15 @@ export function CollectiveXKvSection({
     [datasets, runIndexById],
   );
   const measuredCases = useMemo(() => rows.filter((row) => row.rows.length > 0), [rows]);
+  const pageValues = useMemo(() => collectiveXKvPageValues(measuredCases), [measuredCases]);
+  const pageTokens =
+    pageChoice !== null && pageValues.includes(Number(pageChoice))
+      ? Number(pageChoice)
+      : (pageValues[0] ?? 64);
+  // Table cells always read the ladder's top page (and the runner-up when one
+  // exists) so the columns stay stable while the chart toggle moves.
+  const primaryPage = pageValues[0] ?? 64;
+  const secondaryPage = pageValues[1];
   const seriesSignature = useMemo(
     () =>
       measuredCases
@@ -207,7 +223,7 @@ export function CollectiveXKvSection({
   // no longer exists for the current direction and page size falls back to
   // 'max' rather than an empty chart.
   const overlapIslValues = useMemo(
-    () => collectiveXKvIslValues(measuredCases, { op, pageTokens: Number(pageTokens) }),
+    () => collectiveXKvIslValues(measuredCases, { op, pageTokens }),
     [measuredCases, op, pageTokens],
   );
   const effectiveOverlapIsl =
@@ -287,43 +303,47 @@ export function CollectiveXKvSection({
       },
       {
         header: 'Bulk GB/s',
-        cell: (row) => formatGbps(cellsOf(row).bulk?.gbps_p50),
-        sortValue: (row) => cellsOf(row).bulk?.gbps_p50 ?? -1,
+        cell: (row) => formatGbps(cellsOf(row, primaryPage).bulk?.gbps_p50),
+        sortValue: (row) => cellsOf(row, primaryPage).bulk?.gbps_p50 ?? -1,
         className: 'text-right tabular-nums',
       },
       {
-        header: 'p64 GB/s b1',
-        cell: (row) => formatGbps(cellsOf(row).p64b1?.gbps_p50),
-        sortValue: (row) => cellsOf(row).p64b1?.gbps_p50 ?? -1,
+        header: `p${primaryPage} GB/s b1`,
+        cell: (row) => formatGbps(cellsOf(row, primaryPage).pb1?.gbps_p50),
+        sortValue: (row) => cellsOf(row, primaryPage).pb1?.gbps_p50 ?? -1,
         className: 'text-right tabular-nums',
       },
       {
-        header: 'p64 GB/s bmax',
+        header: `p${primaryPage} GB/s bmax`,
         cell: (row) => {
-          const cell = cellsOf(row).p64bmax;
+          const cell = cellsOf(row, primaryPage).pbmax;
           if (!cell) return '-';
           return `${formatGbps(cell.gbps_p50)} (b${cell.batch})`;
         },
-        sortValue: (row) => cellsOf(row).p64bmax?.gbps_p50 ?? -1,
+        sortValue: (row) => cellsOf(row, primaryPage).pbmax?.gbps_p50 ?? -1,
         className: 'text-right tabular-nums whitespace-nowrap',
       },
-      {
-        header: 'p16 GB/s b1',
-        cell: (row) => formatGbps(cellsOf(row).p16b1?.gbps_p50),
-        sortValue: (row) => cellsOf(row).p16b1?.gbps_p50 ?? -1,
-        className: 'text-right tabular-nums',
-      },
+      ...(secondaryPage === undefined
+        ? []
+        : [
+            {
+              header: `p${secondaryPage} GB/s b1`,
+              cell: (row) => formatGbps(cellsOf(row, primaryPage, secondaryPage).sb1?.gbps_p50),
+              sortValue: (row) => cellsOf(row, primaryPage, secondaryPage).sb1?.gbps_p50 ?? -1,
+              className: 'text-right tabular-nums',
+            } satisfies DataTableColumn<CollectiveXKvRunCase>,
+          ]),
       {
         header: 'Handoff ms',
         cell: (row) => {
-          const cell = cellsOf(row).p64b1;
+          const cell = cellsOf(row, primaryPage).pb1;
           return cell ? cell.latency_ms.p50.toFixed(1) : '-';
         },
-        sortValue: (row) => cellsOf(row).p64b1?.latency_ms.p50 ?? -1,
+        sortValue: (row) => cellsOf(row, primaryPage).pb1?.latency_ms.p50 ?? -1,
         className: 'text-right tabular-nums',
       },
     ],
-    [],
+    [primaryPage, secondaryPage],
   );
 
   if (rows.length === 0) return null;
@@ -332,7 +352,7 @@ export function CollectiveXKvSection({
     x: xAxis === 'batch' || xAxis === 'isl' ? xAxis : 'batch',
     y: yAxis,
     op,
-    pageTokens: Number(pageTokens),
+    pageTokens,
   };
   const legendSwitches = [
     {
@@ -414,19 +434,21 @@ export function CollectiveXKvSection({
                 ]}
               />
             </div>
-            <div className="grid gap-1.5">
-              <Label className="text-xs text-muted-foreground">{strings.pageControl}</Label>
-              <SegmentedToggle
-                value={pageTokens}
-                onValueChange={setPageTokens}
-                ariaLabel={strings.pageAriaLabel}
-                testId="collectivex-kv-page-toggle"
-                options={[
-                  { value: '64', label: '64' },
-                  { value: '16', label: '16' },
-                ]}
-              />
-            </div>
+            {pageValues.length > 1 && (
+              <div className="grid gap-1.5">
+                <Label className="text-xs text-muted-foreground">{strings.pageControl}</Label>
+                <SegmentedToggle
+                  value={String(pageTokens)}
+                  onValueChange={setPageChoice}
+                  ariaLabel={strings.pageAriaLabel}
+                  testId="collectivex-kv-page-toggle"
+                  options={pageValues.map((value) => ({
+                    value: String(value),
+                    label: String(value),
+                  }))}
+                />
+              </div>
+            )}
             <div className="grid gap-1.5">
               <Label className="text-xs text-muted-foreground">{strings.opControl}</Label>
               <SegmentedToggle
@@ -469,7 +491,7 @@ export function CollectiveXKvSection({
                 testId="collectivex-kv-frontier-chart"
                 cases={activeCases}
                 colors={colors}
-                selection={{ op, pageTokens: Number(pageTokens) }}
+                selection={{ op, pageTokens }}
                 xLogScale={xLogScale}
                 yLogScale={yLogScale}
                 showWireCeilings={showWireCeilings}
@@ -498,7 +520,7 @@ export function CollectiveXKvSection({
                 testId="collectivex-kv-overlap-chart"
                 cases={activeCases}
                 colors={colors}
-                selection={{ op, pageTokens: Number(pageTokens), isl: effectiveOverlapIsl }}
+                selection={{ op, pageTokens, isl: effectiveOverlapIsl }}
                 caption={
                   <p className="text-sm text-muted-foreground">
                     {op} · page {pageTokens} · ISL{' '}

--- a/packages/app/src/components/collectivex/data.test.ts
+++ b/packages/app/src/components/collectivex/data.test.ts
@@ -22,6 +22,7 @@ import {
   collectiveXKvWireCeilings,
   type CollectiveXKvRunCase,
   collectiveXKvCell,
+  collectiveXKvPageValues,
 } from './data';
 import type { CollectiveXKvRow, CollectiveXPercentiles, CollectiveXSeries } from './types';
 import { makeCollectiveXDataset, makeCollectiveXSeries } from './test-fixture';
@@ -365,6 +366,24 @@ describe('collectiveXKvCell', () => {
   it('selects bulk rows by their null page size', () => {
     const rows = [kvRow({}), kvRow({ kind: 'bulk', page_tokens: null, gbps_p50: 89.41 })];
     expect(collectiveXKvCell(rows, 'bulk', null, 'min')?.gbps_p50).toBe(89.41);
+  });
+});
+
+describe('collectiveXKvPageValues', () => {
+  const kaseWithRows = (rows: (Partial<CollectiveXKvRow> & { latency_p50?: number })[]) =>
+    ({ rows: rows.map(kvRow) }) as CollectiveXKvRunCase;
+
+  it('collects the distinct measured page sizes descending, ignoring bulk rows', () => {
+    const cases = [
+      kaseWithRows([{}, { page_tokens: 16 }, bulk({ gbps_p50: 89.41 })]),
+      kaseWithRows([{ page_tokens: 256 }, { page_tokens: 64 }]),
+    ];
+    expect(collectiveXKvPageValues(cases)).toEqual([256, 64, 16]);
+  });
+
+  it('is empty when no paged rows exist', () => {
+    expect(collectiveXKvPageValues([])).toEqual([]);
+    expect(collectiveXKvPageValues([kaseWithRows([bulk({})])])).toEqual([]);
   });
 });
 

--- a/packages/app/src/components/collectivex/data.ts
+++ b/packages/app/src/components/collectivex/data.ts
@@ -422,6 +422,22 @@ export function collectiveXKvIslValues(
   return [...values].toSorted((a, b) => a - b);
 }
 
+/**
+ * Distinct page sizes across the measured paged rows, descending. Drives the
+ * page toggle and the table's paged columns: the sweep's page ladder has
+ * already changed once (64/16 to the production block 256), and hardcoding it
+ * left every view empty against the new rows.
+ */
+export function collectiveXKvPageValues(cases: readonly CollectiveXKvRunCase[]): number[] {
+  const values = new Set<number>();
+  for (const kase of cases) {
+    for (const row of kase.rows) {
+      if (row.kind === 'paged' && row.page_tokens !== null) values.add(row.page_tokens);
+    }
+  }
+  return [...values].toSorted((a, b) => b - a);
+}
+
 export interface CollectiveXKvWireCeilingPoint {
   x: number;
   y: number;


### PR DESCRIPTION
## Problem

Every CollectiveX KV view on runs from the new sweep renders only the empty state: "No measured kv rows match the selected page size and direction."

The kv sweep rebuilt its transfer geometry on vLLM's packed block-major layout and moved the page ladder to the production block size, so new rows carry `page_tokens: 256` only. The frontend hardcoded the ladder as `'64' | '16'`: the chart selection filtered on a page the rows never carry, and the table cells asked `collectiveXKvCell` for pages 64 and 16 directly.

## Fix

Derive the ladder from the measured rows via a new `collectiveXKvPageValues` helper (distinct paged `page_tokens`, descending):

- The page toggle lists the measured page sizes and is hidden when only one exists. A stored choice the current rows no longer carry falls back to the largest measured page instead of an empty chart.
- The table's paged columns pin to the top one or two pages of the ladder (independent of the chart toggle), so headers read `p256 GB/s b1` / `p256 GB/s bmax` on new runs while mixed old runs still show a secondary `p64`/`p16` column.
- Frontier and overlap selections pass the derived page through unchanged.

## Validation

- Unit: `data.test.ts` 52 passed, including new `collectiveXKvPageValues` cases (descending distinct pages, bulk rows ignored, empty input).
- E2E: `cypress/e2e/collectivex.cy.ts` 34 passed against the dev server, including the two-page fixture path (page toggle click on '16', table cells 89.41 / 7.39 / 15.12 (b16) / 2.72).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-layer fix for CollectiveX KV visualization; no auth, persistence, or API contract changes beyond matching existing row shapes.
> 
> **Overview**
> Fixes CollectiveX KV charts and tables that showed empty states after the sweep moved to **production block size 256** instead of hardcoded **64/16**.
> 
> Adds **`collectiveXKvPageValues`** to collect distinct paged `page_tokens` from measured cases (descending, bulk ignored). The **page-size toggle** is built from that list and hidden when only one size exists; invalid stored choices fall back to the **largest measured page** rather than filtering on a missing size.
> 
> The **results table** pins paged columns to the ladder’s top one or two pages (`p256`, optional secondary) so headers stay stable while the chart toggle switches page size. **`cellsOf`** and chart/frontier/overlap selections use the derived **`pageTokens`** instead of fixed 64/16.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29d5db8af85ac12df41eff3cef43e8a9ce2ac91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->