### PR TITLE
fix(inference): spread line labels along curves on the e2e latency chart / 修复 e2e 延迟图表标签堆积在右侧端点的问题

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -70,7 +70,6 @@ import { renderOffloadHalo } from '@/components/inference/utils/offload-halo';
 import {
   parallelismLabelBoxes,
   placeLineLabels,
-  placeEndpointLineLabels,
   renderLineLabels,
   updateRenderedLineLabels,
   type LineLabelSeries,
@@ -582,12 +581,13 @@ const GPUGraph = React.memo(
       ) => {
         if (!showLineLabels) return [];
         const series = buildSeries();
-        return chartDefinition.chartType === 'interactivity'
-          ? placeLineLabels(series, xScale, yScale, {
-              collisionWidth: 160,
-              obstacles: parallelismLabelBoxes(zoomGroup.node()),
-            })
-          : placeEndpointLineLabels(series, xScale, yScale);
+        // Both chart types spread labels along their lines with collision
+        // avoidance — endpoint-only placement stacked every label at the
+        // right edge of the e2e latency chart.
+        return placeLineLabels(series, xScale, yScale, {
+          collisionWidth: 160,
+          obstacles: parallelismLabelBoxes(zoomGroup.node()),
+        });
       };
 
       return {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -23,7 +23,6 @@ import {
   avoidPointLabelCollisions,
   parallelismLabelBoxes,
   placeLineLabels,
-  placeEndpointLineLabels,
   updateRenderedLineLabels,
   renderLineLabels,
   type LineLabelPlacement,
@@ -2245,17 +2244,15 @@ const ScatterGraph = React.memo(
             });
             const labelSeries = [...officialSeries, ...overlaySeries];
 
-            lineLabels =
-              chartDefinition.chartType === 'interactivity'
-                ? placeLineLabels(labelSeries, xScale, yScale, {
-                    collisionWidth: 120,
-                    anchors: lineLabelAnchorRef.current,
-                    pinAnchors: pinLineLabels,
-                    obstacles: parallelismLabelBoxes(ctx.layout.zoomGroup.node()),
-                  })
-                : placeEndpointLineLabels(labelSeries, xScale, yScale, {
-                    nudge: !pinLineLabels,
-                  });
+            // Both chart types spread labels along their lines with collision
+            // avoidance — endpoint-only placement stacked every label at the
+            // right edge of the e2e latency chart.
+            lineLabels = placeLineLabels(labelSeries, xScale, yScale, {
+              collisionWidth: 120,
+              anchors: lineLabelAnchorRef.current,
+              pinAnchors: pinLineLabels,
+              obstacles: parallelismLabelBoxes(ctx.layout.zoomGroup.node()),
+            });
 
             // Keep hidden data-join entries for precision/date curves that lost
             // deduplication, preserving the chart's one-label-per-series identity.
@@ -2485,17 +2482,12 @@ const ScatterGraph = React.memo(
                 : [],
             );
             const labelSeries = [...officialSeries, ...overlaySeries];
-            const zoomLabels =
-              chartDefinition.chartType === 'interactivity'
-                ? placeLineLabels(labelSeries, newXScale, newYScale, {
-                    collisionWidth: 120,
-                    anchors: lineLabelAnchorRef.current,
-                    pinAnchors: pinLineLabels,
-                    obstacles: parallelismLabelBoxes(zoomGroup.node()),
-                  })
-                : placeEndpointLineLabels(labelSeries, newXScale, newYScale, {
-                    nudge: !pinLineLabels,
-                  });
+            const zoomLabels = placeLineLabels(labelSeries, newXScale, newYScale, {
+              collisionWidth: 120,
+              anchors: lineLabelAnchorRef.current,
+              pinAnchors: pinLineLabels,
+              obstacles: parallelismLabelBoxes(zoomGroup.node()),
+            });
             updateRenderedLineLabels(zoomGroup, zoomLabels);
           }
         },

--- a/packages/app/src/components/inference/ui/line-label-layer.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import * as d3 from 'd3';
 
 import {
   firstNonCollidingRect,
-  placeEndpointLineLabels,
   placeLineLabels,
   rectsOverlap,
   type LineLabelSeries,
@@ -102,16 +100,36 @@ describe('line-label placement', () => {
     expect(zoomed[0]).toMatchObject({ x: 60, y: 120, visible: true });
   });
 
-  it('nudges endpoint labels into the scale range without changing identities', () => {
-    const yScale = d3.scaleLinear().domain([0, 100]).range([100, 0]);
-    const labels = placeEndpointLineLabels(
-      [series('a', [{ x: 1, y: 50 }]), series('b', [{ x: 2, y: 51 }])],
+  it('staggers anchor slots so converging curves spread along the line instead of stacking at the endpoint', () => {
+    // Frontier-shaped curves that all converge on the same right-edge region,
+    // like the e2e latency chart: endpoint placement used to pile every label
+    // on top of the shared endpoint.
+    const converging = (key: string, startY: number): LineLabelSeries<Point> =>
+      series(
+        key,
+        [0, 25, 50, 75, 100].map((x) => ({ x, y: startY + ((50 - startY) * x) / 100 })),
+      );
+    const labels = placeLineLabels(
+      [converging('a', 0), converging('b', 100), converging('c', 200), converging('d', 300)],
       identity,
-      yScale,
+      identity,
+      { collisionWidth: 30 },
     );
 
-    expect(labels.map((label) => label.key).toSorted()).toEqual(['a', 'b']);
-    expect(Math.abs(labels[0].y - labels[1].y)).toBeGreaterThanOrEqual(17.9);
-    expect(labels.every((label) => label.y >= 18 && label.y <= 82)).toBe(true);
+    expect(labels).toHaveLength(4);
+    expect(labels.every((label) => label.visible)).toBe(true);
+    // Labels occupy distinct anchor slots along the x-range rather than all
+    // sitting at the shared endpoint (x = 100).
+    const distinctX = new Set(labels.map((label) => label.x));
+    expect(distinctX.size).toBeGreaterThanOrEqual(3);
+    expect(labels.filter((label) => label.x === 100).length).toBeLessThanOrEqual(1);
+  });
+
+  it('places a single-point series at its only point', () => {
+    const labels = placeLineLabels([series('solo', [{ x: 5, y: 7 }])], identity, identity, {
+      collisionWidth: 30,
+    });
+
+    expect(labels[0]).toMatchObject({ x: 5, y: 7, visible: true });
   });
 });

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -114,13 +114,29 @@ function pillObstacles(
   return boxes;
 }
 
-function lineCandidates<TPoint extends CartesianPoint>(points: readonly TPoint[]): TPoint[] {
-  return [
-    points[Math.min(1, points.length - 1)],
-    points[Math.floor(points.length / 2)],
-    points[Math.max(0, Math.floor((points.length * 2) / 3))],
-    points.at(-1)!,
-  ];
+/**
+ * Preferred anchor fractions along a line, from left to right. Each series
+ * starts at a different slot (rotated by its index) so labels spread across
+ * the plot instead of all racing for the same spot, then falls back to the
+ * remaining slots on collision.
+ */
+const ANCHOR_SLOTS = [0.25, 0.5, 0.75, 1] as const;
+
+function lineCandidates<TPoint extends CartesianPoint>(
+  points: readonly TPoint[],
+  seriesIndex: number,
+): TPoint[] {
+  const last = points.length - 1;
+  if (last <= 0) return [points[0]];
+  // Clamp to index >= 1 so a label never sits on the line's first point,
+  // which typically hugs the axis.
+  const at = (fraction: number) => points[Math.max(1, Math.min(last, Math.round(fraction * last)))];
+  const candidates: TPoint[] = [];
+  for (let slot = 0; slot < ANCHOR_SLOTS.length; slot++) {
+    const point = at(ANCHOR_SLOTS[(slot + seriesIndex) % ANCHOR_SLOTS.length]);
+    if (!candidates.includes(point)) candidates.push(point);
+  }
+  return candidates;
 }
 
 export function placeLineLabels<TPoint extends CartesianPoint>(
@@ -151,9 +167,9 @@ export function placeLineLabels<TPoint extends CartesianPoint>(
         Math.abs(other.x - x) < other.halfW + labelHalfWidth,
     );
 
-  for (const entry of sorted) {
+  for (const [seriesIndex, entry] of sorted.entries()) {
     if (entry.points.length === 0) continue;
-    const candidates = lineCandidates(entry.points);
+    const candidates = lineCandidates(entry.points, seriesIndex);
 
     if (options.pinAnchors && options.anchors) {
       let anchorX = options.anchors.get(entry.key);
@@ -212,58 +228,6 @@ export function placeLineLabels<TPoint extends CartesianPoint>(
   }
 
   return result;
-}
-
-export function placeEndpointLineLabels<TPoint extends CartesianPoint>(
-  series: readonly LineLabelSeries<TPoint>[],
-  xScale: (value: number) => number,
-  yScale: (value: number) => number,
-  options: { collisionHeight?: number; nudge?: boolean } = {},
-): LineLabelPlacement[] {
-  const collisionHeight = options.collisionHeight ?? 18;
-  const labels = series.flatMap((entry) => {
-    const point = entry.points.at(-1);
-    return point
-      ? [
-          {
-            key: entry.key,
-            seriesId: entry.seriesId,
-            label: entry.label,
-            color: entry.color,
-            x: xScale(point.x),
-            y: yScale(point.y),
-            visible: true,
-          },
-        ]
-      : [];
-  });
-
-  if (labels.length < 2 || options.nudge === false) return labels;
-
-  const range = yScaleRange(yScale);
-  if (!range) return labels;
-  const top = Math.min(range[0], range[1]) + collisionHeight;
-  const bottom = Math.max(range[0], range[1]) - collisionHeight;
-  labels.sort((a, b) => a.y - b.y);
-  for (let pass = 0; pass < 5; pass++) {
-    for (let i = 1; i < labels.length; i++) {
-      const overlap = labels[i - 1].y + collisionHeight - labels[i].y;
-      if (overlap <= 0) continue;
-      const half = overlap / 2;
-      labels[i - 1].y -= half;
-      labels[i].y += half;
-    }
-    for (const label of labels) label.y = Math.max(top, Math.min(bottom, label.y));
-  }
-  return labels;
-}
-
-function yScaleRange(scale: (value: number) => number): [number, number] | null {
-  const withRange = scale as ((value: number) => number) & { range?: () => unknown[] };
-  const range = withRange.range?.();
-  return range && range.length >= 2 && typeof range[0] === 'number' && typeof range[1] === 'number'
-    ? [range[0], range[1]]
-    : null;
 }
 
 /** Full-color icon rendered on a white chip at the left edge of a pill. */


### PR DESCRIPTION
## Summary

On the **e2e latency chart** (e.g. [/inference/kimi-k3](https://inferencex.semianalysis.com/inference/kimi-k3)), every run-name line label was placed at its line's **last point**, so all labels piled up on top of each other at the right edge of the plot. The interactivity chart already spread labels along the curves.

### What changed

- **Unified placement**: both chart types (`e2e` and `interactivity`) now use `placeLineLabels`, which anchors each label to a point along its line with collision avoidance against other labels and the parallelism pills. This applies to initial render and zoom updates in both `ScatterGraph` and `GPUGraph`.
- **Better spread algorithm**: `lineCandidates` now staggers preferred anchor slots at 25/50/75/100% of each line, rotated per series index, so each series prefers a *different* spot along the x-range instead of all racing for the same one; on collision it falls back to the remaining slots, then to the existing `keepVisibleOnCollision` fallback. Labels are also clamped off a line's first point so they don't hug the axis.
- **Dead code removed**: `placeEndpointLineLabels` and `yScaleRange` (now unused) are deleted along with their test.

### Tests

- New regression test: converging frontier-shaped curves (the kimi-k3 e2e shape) get visible labels on distinct anchor slots along the x-range, with at most one at the shared endpoint.
- New test: single-point series keep their label at the only point.
- Existing `placeLineLabels` tests (collision fallback, pinned data-space anchors across zoom) pass unchanged.
- Full unit suite green: 4,644 (app) + 596 (db) + 47 + 25 tests, `typecheck`, `lint`, `fmt` all pass on Node 24.

### Overlay support

Works for both official runs and `?unofficialrun=` overlays: the placement operates on the combined `labelSeries = [...officialSeries, ...overlaySeries]` in both the initial-render and zoom paths, so overlay labels participate in the same staggered placement and collision avoidance. No overlay-only code path was changed.

## 中文说明

**e2e 延迟图表**（如 [/inference/kimi-k3](https://inferencex.semianalysis.com/inference/kimi-k3)）此前把每条曲线的标签固定放在线的最后一个点上，导致所有标签在图表右侧边缘互相堆叠；而 interactivity 图表已经沿曲线分布标签。

### 变更内容

- **统一放置逻辑**：`e2e` 与 `interactivity` 两种图表类型现在统一使用 `placeLineLabels`，沿曲线选取锚点，并对其他标签和并行度标签做碰撞规避。初始渲染和缩放更新（`ScatterGraph` 与 `GPUGraph`）均已覆盖。
- **更优的分布算法**：`lineCandidates` 在每条线的 25/50/75/100% 位置设置首选锚点，并按系列索引轮换，使每条曲线优先选择不同的位置，标签沿 x 轴自然分散；冲突时回退到其余位置。同时避免标签落在线的第一个点上（贴近坐标轴）。
- **删除废弃代码**：不再使用的 `placeEndpointLineLabels` 与 `yScaleRange` 及其测试已删除。

### 测试

- 新增回归测试：汇聚型 frontier 曲线（kimi-k3 e2e 形态）的标签分布在 x 轴上的不同锚点位置，共享端点处最多一个标签。
- 新增单点系列测试；现有 `placeLineLabels` 测试全部保持通过。
- 全部单元测试、`typecheck`、`lint`、`fmt` 在 Node 24 上通过。

### Overlay 支持

官方 run 与 `?unofficialrun=` overlay 均适用：放置逻辑作用于合并后的 `labelSeries`（官方 + overlay），overlay 标签参与同样的错位分布与碰撞规避。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart label layout only in inference UI; behavior is covered by unit tests and does not touch auth, APIs, or data handling.
> 
> **Overview**
> Fixes **run-name line labels** on the **e2e latency chart** piling up on the right edge when every series shared the same endpoint.
> 
> **Unified placement:** `ScatterGraph` and `GPUGraph` no longer branch on chart type. **e2e** and **interactivity** both call `placeLineLabels` on initial render and zoom, with collision avoidance and parallelism pill obstacles (anchors/pinning unchanged on scatter).
> 
> **Algorithm:** `lineCandidates` picks anchors at **25/50/75/100%** along each line, with slots **rotated by series index** so converging frontier curves prefer different x positions; labels avoid the first point on the line. **`placeEndpointLineLabels`** and **`yScaleRange`** are removed.
> 
> **Tests:** Regression for converging curves (distinct x slots, ≤1 at x=100) plus single-point series; prior `placeLineLabels` cases kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afc5b0fc32891c20ecb6738763358fa929c61288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->