### PR TITLE
perf(build): render compare OG images on demand and skip duplicate CI typecheck

### DIFF
--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -11,6 +11,15 @@ const nextConfig: NextConfig = {
   distDir: process.env.NEXT_DIST_DIR || '.next',
   allowedDevOrigins: allowedDevOriginsFromEnv(),
   transpilePackages: ['@semianalysisai/inferencex-constants'],
+  // The whole-workspace typecheck already runs as its own gating CI job
+  // (`bun run typecheck` in tests-unit.yml), and the E2E matrix builds the
+  // app in eight parallel E2E shard jobs that each repeated the same ~30s TypeScript
+  // pass inside `next build`. Skip the duplicate pass in GitHub Actions only;
+  // Vercel and local builds still typecheck. Gated on GITHUB_ACTIONS (not CI,
+  // which Vercel also sets) to match turbopackFileSystemCacheForBuild below.
+  typescript: {
+    ignoreBuildErrors: process.env.GITHUB_ACTIONS === 'true',
+  },
   serverExternalPackages: ['shiki'],
   redirects() {
     return Promise.resolve([

--- a/packages/app/src/app/compare-per-dollar/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-per-dollar/[slug]/opengraph-image.tsx
@@ -1,16 +1,21 @@
 import { notFound } from 'next/navigation';
 
-import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import { renderCompareOg } from '@/lib/compare-og';
-import { canonicalCompareSlug, compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
+import { compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
 
 export const alt = 'Chip performance-per-dollar inference benchmark comparison';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableCompareSlugs();
-  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/compare-precision/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-precision/[slug]/opengraph-image.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation';
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 import { renderCompareOg } from '@/lib/compare-og';
-import { getAllComparablePrecisionSlugs } from '@/lib/compare-variant-availability';
 import {
   canonicalPrecisionCompareSlug,
   parsePrecisionCompareSlug,
@@ -14,11 +13,15 @@ export const alt = 'Chip precision inference benchmark comparison';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparablePrecisionSlugs();
-  return slugs.map(({ modelSlug, gpu, precA, precB }) => ({
-    slug: canonicalPrecisionCompareSlug(modelSlug, gpu, precA, precB),
-  }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/compare-spec-decode/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare-spec-decode/[slug]/opengraph-image.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation';
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 import { renderCompareOg } from '@/lib/compare-og';
-import { getAllComparableSpecDecodeSlugs } from '@/lib/compare-variant-availability';
 import {
   canonicalSpecDecodeCompareSlug,
   parseSpecDecodeCompareSlug,
@@ -15,11 +14,15 @@ export const alt = 'Chip speculative decoding inference benchmark comparison';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableSpecDecodeSlugs();
-  return slugs.map(({ modelSlug, gpu, precision, method }) => ({
-    slug: canonicalSpecDecodeCompareSlug(modelSlug, gpu, precision, method),
-  }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/compare/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/compare/[slug]/opengraph-image.tsx
@@ -1,16 +1,21 @@
 import { notFound } from 'next/navigation';
 
-import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import { renderCompareOg } from '@/lib/compare-og';
-import { canonicalCompareSlug, compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
+import { compareDisplayLabel, parseCompareSlug } from '@/lib/compare-slug';
 
 export const alt = 'Chip inference benchmark comparison';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableCompareSlugs();
-  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/zh/compare-per-dollar/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/zh/compare-per-dollar/[slug]/opengraph-image.tsx
@@ -2,17 +2,22 @@ import { notFound } from 'next/navigation';
 
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
-import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import { renderCompareOg } from '@/lib/compare-og';
-import { canonicalCompareSlug, parseCompareSlug } from '@/lib/compare-slug';
+import { parseCompareSlug } from '@/lib/compare-slug';
 
 export const alt = '芯片每美元推理性能基准测试对比';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableCompareSlugs();
-  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/zh/compare-precision/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/zh/compare-precision/[slug]/opengraph-image.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation';
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 import { renderCompareOg } from '@/lib/compare-og';
-import { getAllComparablePrecisionSlugs } from '@/lib/compare-variant-availability';
 import {
   canonicalPrecisionCompareSlug,
   parsePrecisionCompareSlug,
@@ -14,11 +13,15 @@ export const alt = '芯片推理精度基准测试对比';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparablePrecisionSlugs();
-  return slugs.map(({ modelSlug, gpu, precA, precB }) => ({
-    slug: canonicalPrecisionCompareSlug(modelSlug, gpu, precA, precB),
-  }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/zh/compare-spec-decode/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/zh/compare-spec-decode/[slug]/opengraph-image.tsx
@@ -3,7 +3,6 @@ import { notFound } from 'next/navigation';
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 import { renderCompareOg } from '@/lib/compare-og';
-import { getAllComparableSpecDecodeSlugs } from '@/lib/compare-variant-availability';
 import {
   canonicalSpecDecodeCompareSlug,
   parseSpecDecodeCompareSlug,
@@ -15,11 +14,15 @@ export const alt = '芯片推理投机解码基准测试对比';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableSpecDecodeSlugs();
-  return slugs.map(({ modelSlug, gpu, precision, method }) => ({
-    slug: canonicalSpecDecodeCompareSlug(modelSlug, gpu, precision, method),
-  }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {

--- a/packages/app/src/app/zh/compare/[slug]/opengraph-image.tsx
+++ b/packages/app/src/app/zh/compare/[slug]/opengraph-image.tsx
@@ -2,17 +2,22 @@ import { notFound } from 'next/navigation';
 
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
-import { getAllComparableCompareSlugs } from '@/lib/compare-availability';
 import { renderCompareOg } from '@/lib/compare-og';
-import { canonicalCompareSlug, parseCompareSlug } from '@/lib/compare-slug';
+import { parseCompareSlug } from '@/lib/compare-slug';
 
 export const alt = '芯片推理基准测试对比';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-export async function generateStaticParams() {
-  const slugs = await getAllComparableCompareSlugs();
-  return slugs.map(({ modelSlug, a, b }) => ({ slug: canonicalCompareSlug(modelSlug, a, b) }));
+// Rendered on demand (then cached) rather than prerendered at build time.
+// Enumerating every comparable slug here queued ~700 satori renders per build
+// across the compare-family OG routes, dominating `next build` static
+// generation time. These images are only fetched by link-preview crawlers, so
+// on-demand rendering with the default ISR cache serves them at the same URLs
+// with no build-time cost. Returning [] (vs deleting generateStaticParams)
+// keeps the route statically cacheable instead of per-request dynamic.
+export function generateStaticParams(): { slug: string }[] {
+  return [];
 }
 
 export default async function OgImage({ params }: { params: Promise<{ slug: string }> }) {


### PR DESCRIPTION
## Why builds were slow

Profiled a cold `next build --turbopack` (E2E fixtures mode, 2 vCPU): **160s total**, split as

| Phase | Time |
|---|---|
| Turbopack compile | 27.5s |
| TypeScript pass inside build | 30.8s |
| **Static page generation (1,289 pages)** | **97s** |

**793 of the 1,289 build-time pages were satori-rendered `opengraph-image` PNGs**, and ~718 of those came from the eight compare-family `[slug]` OG routes (`compare`, `compare-per-dollar`, `compare-precision`, `compare-spec-decode` × en/zh) — even though the pages themselves are `force-dynamic` and never prerendered. Every deploy re-rendered ~700+ social-preview images that only link-preview crawlers ever fetch.

## Changes

1. **Compare-family OG images render on demand.** `generateStaticParams` now returns `[]` in those eight routes (kept, rather than deleted, so the route stays statically cacheable instead of per-request dynamic). First request renders the image, then it's served from the ISR cache at the same URL. Blog/model OG images (small, stable sets) stay prerendered.
2. **Skip the duplicate TypeScript pass in GitHub Actions builds.** `tests-unit.yml` already gates PRs with a whole-workspace `bun run typecheck`; each of the 8 E2E shard builds repeated the same ~30s pass inside `next build`. `typescript.ignoreBuildErrors` is now gated on `GITHUB_ACTIONS` (mirroring `turbopackFileSystemCacheForBuild`). Vercel and local builds still typecheck.

## Results (cold, 2 vCPU, fixtures mode)

| Build | Pages | Static gen | Total |
|---|---|---|---|
| Before | 1,289 | 97s | 160s |
| After (Vercel/local mode) | 571 | 27.5s | **87s (−46%)** |
| After (CI mode, TS skipped) | 571 | 27.5s | **65s (−59%)** |

CI savings multiply ×8 across the E2E shard matrix; Vercel deploys get the static-gen win plus fewer build-time DB slug enumerations.

## Verification

- `bun run lint`, `bun run fmt`, `bun run typecheck`, targeted vitest (sitemap, blog, compare-availability) all pass
- Built + served the app, then fetched OG routes on demand:
  - `/compare/…/opengraph-image` and `/zh/compare/…/opengraph-image` → 200 `image/png`, ZH renders with bundled Noto Sans SC intact (visually inspected)
  - repeat fetch served from cache in ~10ms (`x-nextjs-cache` HIT/STALE revalidate)
  - unknown slug → 404 via existing `notFound()` guard

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and caching behavior only; OG URLs and render paths are unchanged, and CI still relies on the separate workspace typecheck job for type safety.
> 
> **Overview**
> Speeds up **`next build`** by cutting redundant work in CI and at static-generation time.
> 
> **Compare-family Open Graph images** (eight en/zh routes: `compare`, `compare-per-dollar`, `compare-precision`, `compare-spec-decode`) no longer enumerate every comparable slug at build time. **`generateStaticParams` now returns `[]`**, so ~700+ satori PNG renders are skipped during deploy; images are generated on first crawler/request and then served from the default ISR cache at the same URLs. Slug validation and rendering logic are unchanged; blog and other small OG sets stay prerendered.
> 
> **GitHub Actions builds** set **`typescript.ignoreBuildErrors`** when `GITHUB_ACTIONS === 'true'**, avoiding a duplicate ~30s TypeScript pass inside each of eight parallel E2E shard builds while **`bun run typecheck`** still gates PRs. Vercel and local builds continue to typecheck during `next build`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd0f526ff62f967bf072bce1563122e194ada23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->