### PR TITLE
Fix landing → dashboard navigation committing twice / 修复着陆页到仪表盘导航的重复提交

### DIFF
--- a/packages/app/cypress/component/header.cy.tsx
+++ b/packages/app/cypress/component/header.cy.tsx
@@ -81,15 +81,19 @@ describe('Header', () => {
       .and('have.attr', 'href', '/overview');
   });
 
-  it('uses resilient app navigation for the desktop Overview link', () => {
+  it('pushes the desktop Overview link exactly once — no timer-based re-push', () => {
+    // The old 250ms retry re-read the address bar, which a stale
+    // mid-transition restore could revert; the retry then stacked a duplicate
+    // history entry and visibly restarted the transition (landing "Full
+    // dashboard" regression). A single push is the contract now.
     cy.clock();
     cy.get('[data-testid="nav-link-overview"]').click();
     cy.wrap(mockRouter.push).should('have.been.calledOnceWith', '/overview');
-    cy.tick(250);
-    cy.wrap(mockRouter.push).should('have.been.calledTwice');
+    cy.tick(5000);
+    cy.wrap(mockRouter.push).should('have.been.calledOnce');
   });
 
-  it('retains resilient locale navigation outside Overview', () => {
+  it('pushes locale navigation exactly once outside Overview', () => {
     cy.clock();
     mountHeader('/inference');
     cy.get('[data-testid="language-toggle"]')
@@ -98,8 +102,8 @@ describe('Header', () => {
         expect(href).to.include('/zh/inference');
         cy.get('[data-testid="language-toggle"]').click();
         cy.wrap(mockRouter.push).should('have.been.calledOnceWith', href);
-        cy.tick(250);
-        cy.wrap(mockRouter.push).should('have.been.calledTwice');
+        cy.tick(5000);
+        cy.wrap(mockRouter.push).should('have.been.calledOnce');
       });
   });
 
@@ -207,14 +211,14 @@ describe('Header', () => {
     });
   });
 
-  it('uses resilient app navigation for the mobile Overview link', () => {
+  it('pushes the mobile Overview link exactly once — no timer-based re-push', () => {
     cy.clock();
     cy.viewport(375, 812);
     cy.get('[data-testid="mobile-menu-toggle"]').click();
     cy.get('[data-testid="mobile-menu"]').contains('a', 'Overview').click();
     cy.wrap(mockRouter.push).should('have.been.calledOnceWith', '/overview');
-    cy.tick(250);
-    cy.wrap(mockRouter.push).should('have.been.calledTwice');
+    cy.tick(5000);
+    cy.wrap(mockRouter.push).should('have.been.calledOnce');
   });
 
   it('uses the hamburger without horizontal overflow from 1009 through 1024 CSS pixels', () => {

--- a/packages/app/cypress/e2e/landing-dashboard-navigation.cy.ts
+++ b/packages/app/cypress/e2e/landing-dashboard-navigation.cy.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression: the landing "Full dashboard" CTA must navigate in exactly one
+ * transition — one router commit, one new history entry, no URL revert.
+ *
+ * One click used to: commit /inference/kimi-k3, get reverted to `/` by a
+ * stale router restore (url-state.ts initializing mid-transition and calling
+ * the Next-patched history.replaceState), then be pushed again by
+ * navigateInApp's 250ms retry — replaying the landing reveal, pausing, and
+ * stacking a duplicate history entry (a single Back no longer returned to
+ * the landing page).
+ *
+ * The cold-load simulation below (failed prefetches + a slow click-time RSC
+ * response) makes that race deterministic. Motion is re-enabled via CDP on
+ * chromium — the launch flags force reduced motion there, which hides the
+ * visible half of this regression — while Firefox runs motion-enabled
+ * natively.
+ */
+
+const TARGET = '/inference/kimi-k3';
+
+interface HistoryWrite {
+  kind: 'push' | 'replace';
+  pathname: string;
+}
+
+describe('landing → full dashboard navigation', () => {
+  const isChromium = Cypress.browser.family === 'chromium';
+
+  const setReducedMotion = (value: string) =>
+    isChromium
+      ? Cypress.automation('remote:debugger:protocol', {
+          command: 'Emulation.setEmulatedMedia',
+          params: { features: [{ name: 'prefers-reduced-motion', value }] },
+        })
+      : Promise.resolve();
+
+  before(() => {
+    cy.wrap(null).then(() => setReducedMotion('no-preference'));
+  });
+
+  after(() => {
+    // Other specs in this run expect the config's forced reduced motion.
+    cy.wrap(null).then(() => setReducedMotion(''));
+  });
+
+  it('commits exactly one navigation and one history entry on a cold dashboard load', () => {
+    const writes: HistoryWrite[] = [];
+
+    cy.intercept({ url: /\/inference\/kimi-k3/ }, (req) => {
+      if (req.headers['next-router-prefetch']) {
+        // A cold visit has no warmed router cache for the target.
+        req.reply({ statusCode: 404, body: '' });
+        return;
+      }
+      // The click-time payload takes longer than any timer-based re-push.
+      req.on('response', (res) => {
+        res.setDelay(800);
+      });
+    });
+
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        // Wrap the native methods before Next patches them, so the router's
+        // own commits are observed too.
+        const origPush = win.history.pushState.bind(win.history);
+        const origReplace = win.history.replaceState.bind(win.history);
+        const pathnameOf = (url: unknown) =>
+          new URL(String(url ?? win.location.href), win.location.origin).pathname;
+        win.history.pushState = function (data, unused, url) {
+          writes.push({ kind: 'push', pathname: pathnameOf(url) });
+          return origPush(data, unused, url as string);
+        };
+        win.history.replaceState = function (data, unused, url) {
+          writes.push({ kind: 'replace', pathname: pathnameOf(url) });
+          return origReplace(data, unused, url as string);
+        };
+      },
+    });
+
+    // The real motion path must be active (reduced motion hides the visible
+    // half of this regression).
+    cy.window().then((win) => {
+      expect(
+        win.matchMedia('(prefers-reduced-motion: reduce)').matches,
+        'prefers-reduced-motion: reduce',
+      ).to.eq(false);
+    });
+
+    // Let hydration and the landing reveal settle, as in the manual repro.
+    cy.get('[data-testid="compare-agentx-dashboard-link"]').should('be.visible');
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1500);
+
+    cy.window().then((win) => {
+      cy.wrap(win.history.length).as('historyLenBefore');
+    });
+
+    cy.get('[data-testid="compare-agentx-dashboard-link"]').click();
+    cy.location('pathname', { timeout: 15000 }).should('eq', TARGET);
+
+    // Give any stray timer-based re-push time to fire before asserting.
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(1000);
+
+    cy.location('pathname').should('eq', TARGET);
+    cy.then(() => {
+      const commits = writes.filter((w) => w.kind === 'push' && w.pathname === TARGET);
+      expect(commits.length, 'router commits to the dashboard').to.eq(1);
+
+      const firstCommit = writes.findIndex((w) => w.kind === 'push' && w.pathname === TARGET);
+      const revertsAfterCommit = writes.slice(firstCommit + 1).filter((w) => w.pathname === '/');
+      expect(
+        revertsAfterCommit,
+        'URL rewrites back to the landing page after the commit',
+      ).to.deep.eq([]);
+    });
+    cy.window().then(function (win) {
+      expect(win.history.length, 'exactly one new history entry').to.eq(
+        Number(this.historyLenBefore) + 1,
+      );
+    });
+
+    // A single Back must return to the landing page, and Forward must come
+    // straight back to the dashboard.
+    cy.go('back');
+    cy.location('pathname').should('eq', '/');
+    cy.get('[data-testid="compare-agentx-dashboard-link"]').should('be.visible');
+    cy.go('forward');
+    cy.location('pathname').should('eq', TARGET);
+  });
+});

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -15,9 +15,8 @@ interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link>
   /** Which page rendered the hero, so `/compare` and `/` clicks stay separable. */
   analyticsSurface?: string;
   /** Route the click through `navigateInApp`, the way the header nav and the
-   *  landing card already do for `/overview` and `/inference`. The first
-   *  dashboard transition can request the route without committing the URL, so
-   *  those destinations need the retry; content routes do not. */
+   *  landing card already do for `/overview` and `/inference`, keeping the
+   *  transition same-document so the Minecraft music persists. */
   appNavigation?: boolean;
 }
 

--- a/packages/app/src/components/model/ModelIndexLink.tsx
+++ b/packages/app/src/components/model/ModelIndexLink.tsx
@@ -15,9 +15,9 @@ interface ModelIndexLinkProps extends Omit<ComponentProps<typeof Link>, 'href'> 
 }
 
 /**
- * Model detail routes are generated from MDX. On a cold App Router transition,
- * the first push can fetch the route without committing the URL, so use the
- * shared retry-aware navigation path already used by dashboard entry links.
+ * Model detail routes are generated from MDX. Use the shared same-document
+ * navigation path already used by dashboard entry links, so background audio
+ * and layout state survive the transition.
  */
 export function ModelIndexLink({ href, slug, locale, onClick, ...props }: ModelIndexLinkProps) {
   const router = useRouter();

--- a/packages/app/src/lib/client-navigation.test.ts
+++ b/packages/app/src/lib/client-navigation.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { navigateInApp } from '@/lib/client-navigation';
+
+import type { MouseEvent } from 'react';
+
+function makeEvent(overrides: Partial<MouseEvent<HTMLAnchorElement>> = {}) {
+  const preventDefault = vi.fn();
+  return {
+    event: {
+      defaultPrevented: false,
+      button: 0,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+      currentTarget: { target: '' } as HTMLAnchorElement,
+      preventDefault,
+      ...overrides,
+    } as unknown as MouseEvent<HTMLAnchorElement>,
+    preventDefault,
+  };
+}
+
+describe('navigateInApp', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('window', {
+      location: { pathname: '/', origin: 'https://example.com' },
+      setTimeout: setTimeout.bind(globalThis),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('pushes the route exactly once — no timer-based re-push', () => {
+    // The old 250ms retry re-read `window.location.pathname`, which a stale
+    // mid-transition restore could revert to the origin page; the retry then
+    // pushed again, stacking a duplicate history entry and visibly restarting
+    // the transition (landing "Full dashboard" regression).
+    const router = { push: vi.fn() };
+    const { event, preventDefault } = makeEvent();
+
+    navigateInApp(event, router, '/inference/kimi-k3');
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledTimes(1);
+    expect(router.push).toHaveBeenCalledWith('/inference/kimi-k3');
+
+    // Even if the address bar still shows the origin (slow commit or a stale
+    // revert), no second push may fire later.
+    vi.advanceTimersByTime(5000);
+    expect(router.push).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['defaultPrevented', { defaultPrevented: true }],
+    ['non-primary button', { button: 1 }],
+    ['metaKey', { metaKey: true }],
+    ['ctrlKey', { ctrlKey: true }],
+    ['shiftKey', { shiftKey: true }],
+    ['altKey', { altKey: true }],
+    ['anchor target', { currentTarget: { target: '_blank' } as HTMLAnchorElement }],
+  ])('leaves %s clicks to the browser', (_label, overrides) => {
+    const router = { push: vi.fn() };
+    const { event, preventDefault } = makeEvent(
+      overrides as Partial<MouseEvent<HTMLAnchorElement>>,
+    );
+
+    navigateInApp(event, router, '/inference/kimi-k3');
+    vi.advanceTimersByTime(5000);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/lib/client-navigation.ts
+++ b/packages/app/src/lib/client-navigation.ts
@@ -76,9 +76,19 @@ export function replaceRouterPathname(target: string, dropParams: readonly strin
 }
 
 /**
- * The first dashboard transition can request the route without committing the
- * URL change. Repeating the same app-router push after the route payload has
- * been requested preserves same-document navigation and avoids a music restart.
+ * Same-document navigation for in-app links: preventDefault + `router.push`
+ * keeps the transition soft (the Minecraft music keeps playing) while
+ * preserving modified-click, middle-click and `target` behaviors.
+ *
+ * History note: this used to re-push after 250ms because the first
+ * landing → dashboard click could "request the route without committing the
+ * URL change". The real culprit was `url-state.ts` initializing
+ * mid-transition and dispatching a stale router restore through the
+ * Next-patched `history.replaceState`, which reverted the just-committed
+ * URL; the timed retry then read the reverted address bar, pushed again,
+ * stacked a duplicate history entry (breaking a single Back) and visibly
+ * restarted the transition. That module no longer talks to the router, so a
+ * single push is both sufficient and required.
  */
 export function navigateInApp(
   event: MouseEvent<HTMLAnchorElement>,
@@ -98,14 +108,5 @@ export function navigateInApp(
   }
 
   event.preventDefault();
-  const from = window.location.pathname;
-  const target = new URL(href, window.location.origin).pathname;
   router.push(href);
-  // Retry only while nothing has moved. Once the pathname has changed — to this
-  // target, or to a later navigation the user started — a second push only
-  // re-renders the destination, cancels its in-flight work and stacks a
-  // duplicate history entry.
-  window.setTimeout(() => {
-    if (window.location.pathname === from && from !== target) router.push(href);
-  }, 250);
 }

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -151,10 +151,40 @@ describe('readUrlParams', () => {
     await vi.runAllTimersAsync();
 
     expect(history.replaceState).toHaveBeenCalledWith(
-      null,
+      history.state,
       '',
       '/zh/evaluation?eval=42#sample-detail',
     );
+  });
+
+  it('skips the deferred cleanup entirely when the URL has no share-link params', async () => {
+    // The module initializes when dashboard chunks are evaluated, which on a
+    // landing → dashboard client navigation happens mid-transition. A
+    // replaceState here — even a same-URL one — routed through the Next-patched
+    // method would dispatch a stale router restore and revert the committed
+    // navigation (the "first dashboard click replays the landing" regression).
+    const { history } = setupWindow('?unrelated=1', '/');
+    await import('@/lib/url-state');
+    await vi.runAllTimersAsync();
+
+    expect(history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('cleans share-link params via the pristine History prototype, not the patched method', async () => {
+    // Next patches `window.history.replaceState` to sync the App Router; the
+    // cleanup must bypass it (same trick as `replaceClientSearch`) so the
+    // router never sees a mid-transition restore.
+    const { history } = setupWindow('?g_model=test&eval=42', '/inference');
+    const pristine = vi.fn();
+    vi.stubGlobal('History', { prototype: { replaceState: pristine } });
+    await import('@/lib/url-state');
+    await vi.runAllTimersAsync();
+
+    expect(history.replaceState).not.toHaveBeenCalled();
+    expect(pristine).toHaveBeenCalledTimes(1);
+    expect(pristine.mock.calls[0]).toEqual([history.state, '', '/inference?eval=42']);
+    // `this` must be the history object for the prototype call to work.
+    expect(pristine.mock.contexts[0]).toBe(history);
   });
 });
 

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -206,19 +206,41 @@ if (typeof window !== 'undefined') {
       currentState[key] = value;
     }
   }
-  // Defer cleanup so the Next.js router doesn't overwrite it during hydration
-  setTimeout(() => {
-    const sp = new URLSearchParams(window.location.search);
-    for (const key of URL_STATE_KEYS) {
-      sp.delete(key);
-    }
-    const s = sp.toString();
-    window.history.replaceState(
-      null,
-      '',
-      `${window.location.pathname}${s ? `?${s}` : ''}${window.location.hash}`,
-    );
-  }, 0);
+  // Strip share-link params from the address bar. Deferred so the Next.js
+  // router doesn't overwrite it during hydration, and skipped entirely when
+  // the URL carries none: this module is pulled in by dashboard chunks, so on
+  // a landing → dashboard client navigation it initializes *mid-transition*.
+  // Going through the Next-patched `window.history.replaceState` here would
+  // dispatch a router restore built from the pre-commit URL, reverting the
+  // just-committed navigation (the "first dashboard click replays the landing
+  // page" regression). The pristine prototype method rewrites the address bar
+  // without involving the App Router — same trick as `replaceClientSearch` in
+  // client-navigation.ts. Router state is carried over so Back/Forward keep
+  // working.
+  if (Object.keys(_initialParams).length > 0) {
+    setTimeout(() => {
+      const sp = new URLSearchParams(window.location.search);
+      let dirty = false;
+      for (const key of URL_STATE_KEYS) {
+        if (sp.has(key)) {
+          sp.delete(key);
+          dirty = true;
+        }
+      }
+      if (!dirty) return;
+      const s = sp.toString();
+      const replace =
+        typeof History === 'undefined'
+          ? window.history.replaceState
+          : History.prototype.replaceState;
+      replace.call(
+        window.history,
+        window.history.state,
+        '',
+        `${window.location.pathname}${s ? `?${s}` : ''}${window.location.hash}`,
+      );
+    }, 0);
+  }
 }
 
 /** Returns the current share-link state, flushing pending writes for provider remounts. */

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -161,6 +161,10 @@
       "duration": 6076
     },
     {
+      "spec": "cypress/e2e/landing-dashboard-navigation.cy.ts",
+      "duration": 5500
+    },
+    {
       "spec": "cypress/e2e/landing-performance.cy.ts",
       "duration": 7454
     },


### PR DESCRIPTION
## Problem

Clicking **Full dashboard** on the landing page appeared to refresh the landing page: the reveal motion replayed, the page paused, and only then `/inference/kimi-k3` opened — leaving a duplicate history entry, so a single Back no longer returned to the landing page.

## Root cause (instrumented before any code change)

Wrapping `history.pushState`/`replaceState` in a Cypress run produced a deterministic timeline (3/3 runs) for one click:

```
click
+13ms   replaceState → /                    url-state.ts deferred cleanup (module init mid-transition)
+50ms   pushState    → /inference/kimi-k3   router commit #1
+77ms   replaceState → /                    stale router restore reverts the committed URL
+250ms  (navigateInApp retry reads the reverted address bar)
+830ms  pushState    → /inference/kimi-k3   router commit #2 — duplicate history entry
history.length: +2
```

`url-state.ts` is pulled in by dashboard chunks, so on a landing → dashboard client navigation it initializes **mid-transition**. Its deferred share-param cleanup called the Next-patched `window.history.replaceState`, dispatching a router restore built from the pre-commit URL (`/`), which reverted the just-committed navigation. `navigateInApp`'s 250ms retry then saw the reverted address bar and pushed again: a second commit, a duplicate history entry, and a visible restart of the transition — the 550ms landing `Reveal` made the restart obvious. No RSC request is needed at navigation time for this to happen; it reproduces on prefetch-cached routes too.

## Fix

- **`url-state.ts`** — skip the deferred cleanup entirely when the URL carries no share-link params (the landing → dashboard case), and when params must be stripped, rewrite the address bar via the pristine `History.prototype.replaceState` (the same trick `replaceClientSearch` already documents) so the App Router never sees a mid-transition restore. Router history state is carried over so Back/Forward keep working.
- **`client-navigation.ts`** — remove the 250ms blind re-push. It existed to paper over the revert above; with the saboteur gone, a single `router.push` is both sufficient and required (a second push cancels in-flight work, replays entry animations, and stacks a duplicate entry). All guards for modified clicks, non-primary buttons, and `target` attributes are unchanged.

Not touched, per the intended behaviors: Next.js prefetching, locale-prefixed routes, Minecraft music persistence (navigation stays same-document), the compare-card cross-document view transitions (`@view-transition` in motion.css), reduced-motion behavior, and the `RouteTransition` feature flag (still off).

## Tests

- **New Cypress regression spec `landing-dashboard-navigation.cy.ts`** — clicks `compare-agentx-dashboard-link` from `/` under a cold-load simulation (prefetches rejected, click-time RSC delayed 800ms > the old 250ms retry window), with real motion re-enabled via CDP on chromium (the launch flags force reduced motion there, which hides the visible half of this bug; Firefox runs motion-enabled natively). Asserts exactly one router commit, exactly one new history entry, no URL rewrite back to `/` after the commit, and that one Back returns to the landing page. **Fails on the previous code with 2 commits; passes with the fix — verified in Chrome for Testing 152 and Firefox.**
- **New unit tests** for `navigateInApp` (single push, no timer-based re-push, modified-click guards) and the url-state cleanup (skip without share params; pristine-prototype path with them).
- `lint`, `typecheck`, unit suite (4230 passed; the one failure, `benchmark-transform.test.ts`, is a pre-existing `Object.groupBy` Node-20 environment failure that also fails on untouched `master`), and the `navigation`, `landing-performance`, `compare-table`, `compare-scenario-routes`, `url-params`, and `compare-redirect` E2E specs all pass locally.
- `timings.json` gained an entry for the new spec (required by `cypress-timings.test.ts`).

## 中文说明

### 问题

在着陆页点击「完整仪表盘」时，页面看似刷新：入场动画重放、短暂停顿后才打开 `/inference/kimi-k3`，并留下重复的历史记录条目，导致单次「后退」无法回到着陆页。

### 根因（修改代码前已用插桩确认）

`url-state.ts` 由仪表盘代码块引入，因此在着陆页 → 仪表盘的客户端导航过程中才初始化。它延迟执行的分享参数清理调用了被 Next 补丁过的 `window.history.replaceState`，用提交前的 URL（`/`）触发了路由恢复，回退了刚提交的导航；`navigateInApp` 的 250ms 重试随后读取到被回退的地址栏并再次推送，造成第二次提交、重复的历史记录条目以及可见的过渡重启。

### 修复

- `url-state.ts`：URL 中没有分享参数时完全跳过清理；需要清理时改用原生 `History.prototype.replaceState`（与 `replaceClientSearch` 相同的技巧）绕过 App Router，并保留路由器的 history state。
- `client-navigation.ts`：移除 250ms 的盲目重试；根因修复后单次 `router.push` 即足够且必要。修饰键点击、非主键点击和 `target` 属性的处理保持不变。

预取、多语言路由、背景音乐持续播放、对比卡片的跨文档过渡、减少动态效果行为均未改动；`RouteTransition` 功能开关保持关闭。

### 测试

- 新增 Cypress 回归测试（冷加载模拟 + 通过 CDP 启用真实动画路径）：断言恰好一次路由提交、恰好一条新历史记录、提交后 URL 不回退、单次「后退」回到着陆页。修复前该测试因出现 2 次提交而失败，修复后在 Chrome 与 Firefox 均通过。
- 新增 `navigateInApp` 与 url-state 清理路径的单元测试；lint、typecheck、单元测试与相关 E2E 均在本地通过（唯一失败的 `benchmark-transform.test.ts` 为 Node 20 环境缺少 `Object.groupBy` 的既有问题，在未改动的 `master` 上同样失败）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client navigation and history integration with the Next App Router during mid-transition chunk load; well-covered by new e2e and unit tests but regressions could affect Back/Forward or share-link URL cleanup.
> 
> **Overview**
> Fixes the landing **Full dashboard** flow where one click could replay the reveal, stack **two** history entries, and break a single Back to `/`.
> 
> **`url-state.ts`** no longer triggers a mid-transition App Router restore when dashboard chunks load during client navigation. Deferred share-param cleanup is **skipped** when the URL has no share-link params (typical landing → dashboard path). When cleanup is needed, it uses **`History.prototype.replaceState`** (like `replaceClientSearch`) so the address bar updates without Next’s patched handler reverting the committed route; router history state is preserved for Back/Forward.
> 
> **`navigateInApp`** drops the **250ms blind re-push** that amplified the revert (second `router.push`, duplicate entry, visible transition restart). In-app links now call **`router.push` once**; modified-click and `target` guards are unchanged.
> 
> **Tests:** new Cypress e2e `landing-dashboard-navigation.cy.ts` (cold prefetch + delayed RSC, motion on Chromium via CDP); Vitest for `navigateInApp` and url-state cleanup; header Cypress specs assert **one push** after 5s instead of two after 250ms. Comment-only tweaks on compare/model link components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19c0c93ffb1c790284b7e9e63fe9c8a9ced068e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->