### PR TITLE
Theme InferenceX wordmark gold for Childhood Cancer Awareness Month

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -41,20 +41,21 @@
   content: none;
 }
 
-/* Pride theme for the InferenceX wordmark — the transgender flag's stripe colors
-   painted onto the brand text via a clipped gradient: light blue, pink, white,
-   pink, light blue. The white stripe is darkened to a readable slate here, the
-   same treatment the earlier flag themes used, so the clipped wordmark stays
-   legible on the light header. Fixed flag colors, independent of the theme
-   tokens, so it renders the same in light, dark, and minecraft modes. */
+/* September theme for the InferenceX wordmark — Childhood Cancer Awareness Month
+   ("Go Gold"). The gold awareness ribbon's palette painted onto the brand text
+   via a clipped gradient, running from deep goldenrod through bright gold and
+   back. The darker anchors keep the clipped wordmark legible on the light
+   header, the same treatment the earlier flag themes used. Fixed colors,
+   independent of the theme tokens, so it renders the same in light, dark, and
+   minecraft modes. */
 .pride-wordmark {
   background-image: linear-gradient(
     90deg,
-    #5bcefa 0%,
-    #f5a9b8 25%,
-    #8a8f99 50%,
-    #f5a9b8 75%,
-    #5bcefa 100%
+    #9a6a00 0%,
+    #d4a017 30%,
+    #ffd700 50%,
+    #d4a017 70%,
+    #9a6a00 100%
   );
   background-clip: text;
   -webkit-background-clip: text;


### PR DESCRIPTION
## Summary
September is **Childhood Cancer Awareness Month** ("Go Gold"). This updates the `.pride-wordmark` gradient (the clipped text gradient on the **InferenceX** wordmark in the header) from the previous flag palette to the gold awareness ribbon's colors.

## Details
- Swaps the `linear-gradient` in `packages/app/src/app/globals.css` to a gold ribbon palette:
  - Deep goldenrod `#9a6a00` (anchors)
  - Goldenrod `#d4a017`
  - Bright gold `#ffd700` (center)
- Darker gold anchors keep the clipped wordmark legible on the light header — same treatment the earlier flag themes used.
- Comment updated to document September / Childhood Cancer Awareness Month.

## Notes
- CSS-only, no component/markup changes — only the gradient behind the existing `.pride-wordmark` class used in `header.tsx`. Same pattern as #583.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only cosmetic gradient and comment update on the header wordmark, with no logic or data-handling impact.
> 
> **Overview**
> Swaps the header **InferenceX** clipped-text gradient (`.pride-wordmark` in `globals.css`) from the prior flag palette to a **Go Gold** ribbon scheme for Childhood Cancer Awareness Month—deep goldenrod anchors, goldenrod, and bright gold at the center.
> 
> The block comment is updated to describe the September theme; markup and class names are unchanged, so only the visible wordmark colors change across light, dark, and minecraft modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 387fe3dd8e072eaebabdf01039e8316fff07cc71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->