### PR TITLE
feat(glossary): target offloading and long-context search terms / 词汇表新增 offloading 与长上下文词条以覆盖相应搜索词

### DIFF
--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -71,7 +71,12 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   },
   'agentic-coding-workload': {
     term: '智能体编码工作负载',
-    aliases: ['agentic coding workload', '编码智能体工作负载', '软件工程智能体工作负载'],
+    aliases: [
+      'agentic coding',
+      'agentic coding workload',
+      '编码智能体工作负载',
+      '软件工程智能体工作负载',
+    ],
     plainEnglish:
       '编码智能体读取代码仓库、修改代码并运行工具，随后继续请求模型，直到完成任务；这一连串请求就是智能体编码工作负载。',
     definition:
@@ -345,7 +350,7 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   },
   'kv-cache': {
     term: 'KV 缓存',
-    aliases: ['KV cache', '键值缓存', '注意力缓存'],
+    aliases: ['KV cache', 'KVCache', 'KV caching', '键值缓存', '注意力缓存'],
     plainEnglish: 'KV 缓存是模型对当前对话的工作记忆，让它生成新 token 时不必每次从头重读。',
     definition:
       'KV 缓存保存已经处理过的 token 的注意力 key/value 状态，避免每个解码步重新计算它们。',
@@ -783,18 +788,46 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       'InferenceX 在数据点 tooltip 和并行标签中与 TP、EP、DP 一起展示 DCP 与 PCP 的并行度。各厂商支持程度并不均衡：在 AgentX 1.0 结果发布时，vLLM 支持矩阵中 AMD 的注意力后端仍标为不支持，因此该技术仍构成 CUDA 实际优势的一部分。',
   },
   'kv-cache-offload': {
-    term: 'KV cache offload',
-    aliases: ['KV cache offload', 'CPU offload', 'KV 卸载'],
+    term: 'KV cache offloading',
+    aliases: ['KV cache offload', 'KV offloading', 'KV 卸载', 'KV cache 分层'],
     plainEnglish:
       '把芯片放不下的注意力状态暂存到主机内存，长会话下一轮就能直接恢复，而不必整段重算。',
     definition:
-      'KV cache offload 把 KV block 从加速器显存移到更慢的存储层（通常是主机 DRAM），并在后续请求复用该前缀时再读回来。',
+      'KV cache offloading 把 KV block 从加速器显存移到更慢的存储层，先是主机 DRAM，其下还有 NVMe，并在后续请求复用该前缀时再读回来。',
     explanation:
       'offload 通常实现为写穿缓存：写入 HBM 缓存的前缀会同时写入较慢的一层，因此当 offload 池容量大致是 HBM 的 1.5 到 3 倍时效果最好。在 agentic 的上下文长度下，重新载入长前缀远比重算划算；但对短提示词结论相反，传输开销会超过它省下的 prefill。',
     significance:
       '长 agentic 会话超出 HBM 中 KV 容量的时间，远早于超出合理的 DRAM 预算，因此 offload 决定了有多少并发对话仍可恢复。它也会转移瓶颈：前缀能够留存之后，store 与 load 路径、传输批量化和索引记账才是值得优化的开销。',
     benchmarkContext:
       'InferenceX 会给每个使用了 offload 的数据点加上虚线光环，无论它是否位于 Pareto 前沿；点详情视图还会给出 offload 类型、引擎，以及芯片与 CPU 两侧的缓存命中率。offload 属于允许但可选的优化，因此同一条曲线上可以同时存在启用和未启用的数据点。',
+  },
+  'cpu-offloading': {
+    term: 'CPU offloading',
+    aliases: ['CPU offload', 'DRAM offloading', '主机内存卸载'],
+    plainEnglish:
+      'CPU offloading 把加速器装不下的 KV cache 溢出到主机 DRAM，让长对话可以从内存中恢复，而不必从头重算。',
+    definition:
+      'CPU offloading 把可复用的 KV cache block 保存在主机 CPU DRAM 而非加速器 HBM 中，当后续请求复用该前缀时再经主机链路读回。',
+    explanation:
+      '在推理服务语境下，这个词几乎总是指把 KV cache offload 到 DRAM，与训练侧把权重或优化器状态放到 CPU 的做法不同。引擎通过 connector 访问 DRAM，例如 vLLM 的 CPU offloading connector、LMCache、SGLang HiCache、Mooncake Store 和 Dynamo KVBM。该池通常是写穿实现，因此当用于 offload 的主机 DRAM 约为 HBM KV 容量的 1.5 到 3 倍时收益最大；其余取决于传输效率：在 hipMemcpyBatchAsync 于 ROCm 7.14 落地之前，AMD vLLM 无法批量执行 GPU 到 CPU 的拷贝，其 CPU offload 路径远不如 NVIDIA 上的同类功能好用。',
+    significance:
+      '当并发会话的 KV 工作集总量超过 HBM 时，DRAM offloading 决定了有多少智能体会话仍可恢复。它并非免费容量：在高并发下过度依赖 DRAM 层会增加重载流量，可能把交互性拖到可接受水平之下，所以真正值得回答的问题是这一层什么时候有用，而不是它是否存在。',
+    benchmarkContext:
+      'AgentX 把 CPU KV offloading 视为允许但可选的优化。用于 offload 的 DRAM 必须随所用 GPU 的比例同步扩缩，非标准化 DRAM 配置的系统另有 3 TB 上限。使用了 offload 的数据点会被虚线光环标记，点详情视图会给出 offload 后端以及 HBM 与 CPU 两侧的缓存命中率。',
+  },
+  'nvme-offloading': {
+    term: 'NVMe offloading',
+    aliases: ['NVMe offload', 'SSD offloading', '闪存 KV cache 卸载'],
+    plainEnglish:
+      'NVMe offloading 把 KV cache 再向下延伸一层到本地 SSD，让 GPU 和 CPU 内存都装不下的前缀日后仍能重新载入。',
+    definition:
+      'NVMe offloading 把可复用的 KV cache block 保存在 HBM 与主机 DRAM 之下的 NVMe SSD 层，用更慢的重载速度换取大得多的可取回 KV 工作集。',
+    explanation:
+      '存储层级每往下一层，容量成倍增长而带宽成倍下降，因此只有当重新载入长前缀仍然比重算划算时，SSD 层才有收益。LMCache、Mooncake Store 等 KV cache 管理器已经在 DRAM 和远端存储之外支持本地 NVMe 后端。这一层在两种情况下帮助最大：复用工作集超出任何合理的 DRAM 预算，或会话空闲太久、DRAM 淘汰已经把它丢弃之后才回来。',
+    significance:
+      'NVMe offloading 实际上延长了长生命周期智能体会话的缓存存活时间，当 agent 需要等待工具、人类或 CI 数分钟时这一点尤为重要。它高度依赖工作负载：如果高并发部署下 DRAM offloading 已经在拖累延迟，更慢的一层也救不回来，因为瓶颈在重载带宽而不是容量。',
+    benchmarkContext:
+      'AgentX v1 测量 HBM 和 DRAM 两层，暂缓 NVMe offloading；SSD/NVMe KV offloading 已列为快速跟进项，用来把工作集扩展到 DRAM 之外。届时回放流当前 5 分钟的空闲上限也可能随之提高，使更长的缓存存活时间变得可测量。',
   },
   'kv-cache-manager': {
     term: 'KV cache 管理器',
@@ -1281,9 +1314,23 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     benchmarkContext:
       'InferenceX 吞吐量对交互性曲线的最右端，即批次最大、单用户速度最低处，近似离线运行。在一条曲线的两端各读一次，就能看到该配置从在线到离线的完整成本区间。',
   },
+  'long-context': {
+    term: '长上下文',
+    aliases: ['long context', '长上下文推理', '长上下文服务'],
+    plainEnglish:
+      '长上下文指模型一次要处理非常大量的对话、代码或文档，此时压力主要落在内存上，而不是原始算力上。',
+    definition:
+      '长上下文指提示词和累积的对话历史达到数万甚至数十万 token 的推理场景，此时 KV cache 容量、内存带宽和缓存复用主导服务行为。',
+    explanation:
+      'KV cache 随上下文中的每个 token 增长，prefill 开销增长得更快，因此长上下文流量会在算力耗尽之前先耗尽 HBM。编码智能体是最典型的来源：每一轮都把文件、工具输出和历史回答追加到可能持续数小时的会话中。模型架构用滑动窗口、潜在注意力、线性注意力和稀疏注意力应对，服务栈则用前缀缓存、向 DRAM 和 NVMe 的 KV cache offloading 以及上下文并行应对。',
+    significance:
+      '在短固定序列上测出的硬件与引擎排名无法直接迁移到长上下文流量，因为约束条件从算术吞吐量转移到了 KV 容量和数据搬运。并发上限表现为容量悬崖，而应对这些悬崖的系统能力，决定了智能体、检索流水线和文档分析是否具备可服务的经济性。',
+    benchmarkContext:
+      'InferenceX 从两个方向覆盖长上下文：固定序列场景钉住输入输出长度，例如 8K 输入 1K 输出；AgentX 则回放上下文逐轮增长、逼近真实 agent 工作集的多轮编码会话，并让并发扫描跨越 HBM 容量悬崖。',
+  },
   'context-window': {
     term: '上下文窗口',
-    aliases: ['context window', '上下文长度', '长上下文'],
+    aliases: ['context window', '上下文长度', '最大序列长度'],
     plainEnglish: '上下文窗口是模型一次能处理的最大 token 数，涵盖输入和到目前为止生成的全部内容。',
     definition:
       '上下文窗口是模型支持的最大序列长度，约束提示词、对话历史、检索材料与生成输出的 token 总数。',

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -126,7 +126,7 @@ const entries = [
   {
     slug: 'agentic-coding-workload',
     term: 'Agentic coding workload',
-    aliases: ['coding-agent workload', 'software-engineering agent workload'],
+    aliases: ['agentic coding', 'coding-agent workload', 'software-engineering agent workload'],
     category: 'Agentic inference',
     plainEnglish:
       'This is the request pattern created when a coding agent reads a repository, edits code, runs tools, and revisits the model until the task is done.',
@@ -559,7 +559,7 @@ const entries = [
   {
     slug: 'kv-cache',
     term: 'KV cache',
-    aliases: ['key-value cache', 'attention cache'],
+    aliases: ['KVCache', 'KV caching', 'key-value cache', 'attention cache'],
     category: 'Serving',
     plainEnglish:
       'The KV cache is the model’s working memory for the current conversation. It keeps useful notes and avoids rereading everything for every new token.',
@@ -1235,21 +1235,101 @@ const entries = [
   },
   {
     slug: 'kv-cache-offload',
-    term: 'KV cache offload',
-    aliases: ['CPU offload', 'KV offloading'],
+    term: 'KV cache offloading',
+    aliases: ['KV cache offload', 'KV offloading', 'KV cache tiering'],
     category: 'Serving',
     plainEnglish:
-      'KV cache offload parks attention state the chips cannot hold in host memory, so a long session can be resumed instead of recomputed.',
+      'KV cache offloading parks attention state the chips cannot hold in host memory, so a long session can be resumed instead of recomputed.',
     definition:
-      'KV cache offload moves KV blocks out of accelerator memory into a slower tier, usually host DRAM, and loads them back when a later request reuses that prefix.',
+      'KV cache offloading moves KV blocks out of accelerator memory into a slower tier, host DRAM first and NVMe below it, and loads them back when a later request reuses that prefix.',
     explanation:
       'Offload is usually a write-through cache: a prefix written to the HBM cache is also written to the slower tier, so it helps most when the offload pool is roughly one and a half to three times HBM capacity. Reloading a long prefix beats recomputing it by a wide margin at agentic context lengths, but the arithmetic reverses for short prompts, where the transfer costs more than the prefill it avoids.',
     significance:
       'Long agentic sessions exceed HBM KV capacity well before they exceed a plausible DRAM budget, so offload decides how many concurrent conversations stay resumable. It also shifts the bottleneck: once prefixes survive, store and load paths, transfer batching, and index bookkeeping become the costs worth optimizing.',
     benchmarkContext:
       'InferenceX rings every point that used KV offload with a dashed halo, whether or not it is Pareto optimal, and the point detail view names the offload type and engine alongside the chip and CPU cache hit rates. Offload is an allowed but optional optimization, so a single curve can mix points with and without it.',
-    relatedTerms: ['kv-cache', 'prefix-caching', 'kv-cache-manager', 'high-bandwidth-memory'],
+    relatedTerms: [
+      'kv-cache',
+      'prefix-caching',
+      'cpu-offloading',
+      'nvme-offloading',
+      'kv-cache-manager',
+      'high-bandwidth-memory',
+    ],
     articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS, KIMI_K3, AGENTX_DSV4_B200_B300],
+  },
+  {
+    slug: 'cpu-offloading',
+    term: 'CPU offloading',
+    aliases: ['CPU offload', 'DRAM offloading', 'host memory offloading'],
+    category: 'Serving',
+    plainEnglish:
+      'CPU offloading spills KV cache the accelerators cannot hold into the host machine DRAM, so long conversations resume from memory instead of being recomputed from scratch.',
+    definition:
+      'CPU offloading stores reusable KV cache blocks in host CPU DRAM instead of accelerator HBM and loads them back over the host link when a later request reuses that prefix.',
+    explanation:
+      'In inference serving the term almost always means KV cache offloading to DRAM, distinct from the training-side practice of parking weights or optimizer state on the CPU. Engines reach DRAM through connectors such as the vLLM CPU offloading connectors, LMCache, SGLang HiCache, Mooncake Store, and Dynamo KVBM. The pool is usually write-through, so it pays off when host DRAM for offload is roughly 1.5 to 3 times HBM KV capacity, and transfer efficiency decides the rest: AMD vLLM could not batch GPU-to-CPU copies before hipMemcpyBatchAsync landed in ROCm 7.14, which made its CPU offload path far less useful than the same feature on NVIDIA.',
+    significance:
+      'DRAM offloading decides how many concurrent agent sessions stay resumable once their combined KV working set exceeds HBM. It is not free capacity: at high concurrency, heavy reliance on the DRAM tier adds reload traffic that can push interactivity below acceptable levels, so the useful question is when the tier helps rather than whether it exists.',
+    benchmarkContext:
+      'AgentX treats CPU KV offloading as an allowed, optional optimization. Offload DRAM must scale with the fraction of GPUs used, with a 3 TB cap for systems without standardized DRAM configurations. Points that used offload are ringed with a dashed halo, and the point detail view reports the offload backend plus HBM and CPU cache hit rates.',
+    relatedTerms: [
+      'kv-cache-offload',
+      'nvme-offloading',
+      'kv-cache-manager',
+      'kv-cache',
+      'high-bandwidth-memory',
+    ],
+    articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS, AGENTX_DSV4_B200_B300],
+  },
+  {
+    slug: 'nvme-offloading',
+    term: 'NVMe offloading',
+    aliases: ['NVMe offload', 'SSD offloading', 'flash KV cache offload'],
+    category: 'Serving',
+    plainEnglish:
+      'NVMe offloading extends the KV cache one tier further, onto local SSDs, so prefixes that no longer fit in GPU or CPU memory can still be reloaded later.',
+    definition:
+      'NVMe offloading stores reusable KV cache blocks on NVMe SSDs beneath the HBM and host DRAM tiers, trading slower reloads for a much larger retrievable KV working set.',
+    explanation:
+      'Each step down the memory hierarchy multiplies capacity and divides bandwidth, so the SSD tier only pays off when reloading a long prefix still beats recomputing it. KV cache managers such as LMCache and Mooncake Store already support local NVMe backends alongside DRAM and remote storage. The tier helps most when the reuse working set exceeds any plausible DRAM budget or when sessions return after idle gaps long enough that DRAM eviction has already discarded them.',
+    significance:
+      'NVMe offloading effectively lengthens cache lifetime for long-lived agent sessions, which matters as agents wait on tools, humans, or CI for minutes at a time. It is workload dependent: a high-concurrency deployment where DRAM offloading already degrades latency will not be rescued by an even slower tier, because the bottleneck is reload bandwidth rather than capacity.',
+    benchmarkContext:
+      'AgentX v1 measures HBM and DRAM tiers and defers NVMe offloading, with SSD/NVMe KV offloading planned as a fast follow to grow the working set beyond DRAM. The current 5 minute idle cap on replayed streams may rise alongside it so that longer cache lifetimes become measurable.',
+    relatedTerms: [
+      'kv-cache-offload',
+      'cpu-offloading',
+      'kv-cache-manager',
+      'kv-cache',
+      'prefix-cache-hit-rate',
+    ],
+    articleSlugs: [AGENTX_V3, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'long-context',
+    term: 'Long context',
+    aliases: ['long-context inference', 'long-context serving', 'long context length'],
+    category: 'Serving',
+    plainEnglish:
+      'Long context means the model is working over a very large amount of conversation, code, or documents at once, which stresses memory far more than raw compute.',
+    definition:
+      'Long context describes inference where prompts and accumulated conversation history reach tens or hundreds of thousands of tokens, so KV cache capacity, memory bandwidth, and cache reuse dominate serving behavior.',
+    explanation:
+      'KV cache size grows with every token in context, and prefill cost grows even faster, so long-context traffic drains HBM well before compute runs out. Coding agents are the canonical source: each turn appends files, tool output, and earlier responses to a session that can span hours. Model architectures respond with sliding window, latent, linear, and sparse attention, while serving stacks respond with prefix caching, KV cache offloading to DRAM and NVMe, and context parallelism.',
+    significance:
+      'Hardware and engine rankings measured on short fixed sequences do not transfer to long-context traffic, because the binding constraint shifts from arithmetic throughput to KV capacity and movement. Concurrency limits appear as capacity cliffs, and the systems that handle them define whether agents, retrieval pipelines, and document analysis are economical to serve.',
+    benchmarkContext:
+      'InferenceX covers long context from both directions: fixed sequence scenarios pin lengths such as 8K in and 1K out, while AgentX replays multi-turn coding sessions whose contexts grow turn by turn toward realistic agent working sets, sweeping concurrency across the HBM capacity cliff.',
+    relatedTerms: [
+      'context-window',
+      'kv-cache',
+      'kv-cache-offload',
+      'agentic-coding-workload',
+      'sparse-attention',
+      'context-parallelism',
+    ],
+    articleSlugs: [AGENTIC_WORKLOADS, AGENTX_V3, KIMI_K3],
   },
   {
     slug: 'kv-cache-manager',
@@ -1972,7 +2052,7 @@ const entries = [
   {
     slug: 'context-window',
     term: 'Context window',
-    aliases: ['context length', 'max sequence length', 'long context'],
+    aliases: ['context length', 'max sequence length'],
     category: 'Model architecture',
     plainEnglish:
       'The context window is the maximum number of tokens a model can consider at once, covering both the input and everything generated so far.',
@@ -1985,6 +2065,7 @@ const entries = [
     benchmarkContext:
       'InferenceX covers the window from both directions: fixed sequence scenarios pin input and output lengths such as 8K in and 1K out, while AgentX replays sessions whose contexts grow turn by turn toward realistic agent working sets.',
     relatedTerms: [
+      'long-context',
       'kv-cache',
       'input-output-sequence-length',
       'sliding-window-attention',


### PR DESCRIPTION
## Summary

Google Search Console shows zero impressions for the query terms **KV Cache Offloading**, **CPU Offloading**, **DRAM Offloading**, **NVMe Offloading**, **Long Context**, and **Agentic Coding** (only **KVCache** registers, at 86 impressions). None of these phrases currently appear as an indexable H1/title anywhere on the site. This PR closes that gap through the glossary, which already ships per-term metadata, `DefinedTerm` JSON-LD, hreflang alternates, and sitemap entries.

### New glossary entries (EN + ZH siblings)

- **`/glossary/cpu-offloading` — CPU offloading** (aliases: CPU offload, DRAM offloading, host memory offloading). Covers the DRAM tier, write-through 1.5-3x HBM sizing, connector landscape (vLLM CPU connectors, LMCache, HiCache, Mooncake Store, Dynamo KVBM), and the AMD `hipMemcpyBatchAsync` transfer-efficiency story. One page deliberately covers both the "CPU Offloading" and "DRAM Offloading" queries to avoid near-duplicate doorway pages.
- **`/glossary/nvme-offloading` — NVMe offloading** (aliases: NVMe offload, SSD offloading, flash KV cache offload). Grounded in the public AgentX v1 position: NVMe deferred, SSD/NVMe offload planned as a fast follow, 5-minute idle cap may rise with it.
- **`/glossary/long-context` — Long context** (aliases: long-context inference, long-context serving). Serving-side sibling of the existing Context window (model-architecture) entry; the `long context` alias moves here from `context-window`.

### Retargeted existing entries

- **`kv-cache-offload`**: term retitled **KV cache offload → KV cache offloading** (gerund matches the query; slug/URL unchanged), old form kept as alias, related-terms now link the two new tier pages.
- **`kv-cache`**: added **KVCache** and **KV caching** aliases (exact spelling of the one term already getting impressions).
- **`agentic-coding-workload`**: added **agentic coding** alias.

Aliases render as visible "Also known as" copy and feed `keywords` metadata plus the command-palette/glossary search index, so each phrase now exists as crawlable on-page text. All copy is grounded in published blog posts (AgentX v3, agentic workloads overview); no unpublished roadmap details.

### Checks

- `bun run typecheck`, `bun run lint`, `bun run fmt` clean
- `glossary.test.ts` passes (entry parity, ZH sibling coverage, word-count and dash rules, article-slug validity)
- Full unit suite: 4230/4231 pass; the one failure (`benchmark-transform.test.ts`) is a pre-existing local-environment issue (`Object.groupBy` requires Node 21+, local Node 20) and is untouched by this PR

## 中文说明

Google Search Console 显示 KV Cache Offloading、CPU Offloading、DRAM Offloading、NVMe Offloading、Long Context 与 Agentic Coding 等搜索词曝光为零（仅 KVCache 有 86 次曝光），这些短语目前都没有对应的可索引 H1 或标题。本 PR 通过词汇表补齐这一缺口，词汇表页面已自带 per-term metadata、DefinedTerm JSON-LD、hreflang 与 sitemap。

新增词条（中英文同步）：

- `/glossary/cpu-offloading` — CPU offloading（别名：CPU offload、DRAM offloading、主机内存卸载）。一个页面同时覆盖 CPU Offloading 与 DRAM Offloading 两个查询，避免内容近似的重复页面。
- `/glossary/nvme-offloading` — NVMe offloading（别名：NVMe offload、SSD offloading）。内容以已发布的 AgentX v1 口径为准：NVMe 暂缓，SSD/NVMe offload 为快速跟进项。
- `/glossary/long-context` — 长上下文（别名：long context、长上下文推理）。作为现有"上下文窗口"（模型架构）词条在推理服务侧的姊妹页，long context 别名从 context-window 移至此处。

现有词条调整：kv-cache-offload 词条标题由 KV cache offload 改为 KV cache offloading（slug 与 URL 不变，旧写法保留为别名）；KV cache 增加 KVCache 与 KV caching 别名；智能体编码工作负载增加 agentic coding 别名。

别名会以"Also known as"形式渲染为页面可见文本，并进入 keywords metadata 与站内搜索索引。全部内容均以已发布的博客文章为依据。

检查：typecheck、lint、fmt 全部通过；glossary 测试通过；完整单元测试 4230/4231 通过，唯一失败项为本地 Node 20 缺少 `Object.groupBy` 的既有环境问题，与本 PR 无关。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only glossary and translation changes; no runtime logic, auth, or data paths.
> 
> **Overview**
> **Expands the EN/ZH glossary** so high-intent search phrases (KV cache offloading, CPU/DRAM/NVMe offloading, long context, agentic coding) appear as indexable term titles, visible “Also known as” copy, and search metadata—without new URLs for retitled entries.
> 
> **Adds three paired entries:** `cpu-offloading` (DRAM tier + connectors/AgentX rules in one page), `nvme-offloading` (SSD tier, AgentX v1 deferral), and `long-context` (serving-focused sibling to context window).
> 
> **Updates existing terms:** `kv-cache-offload` is retitled to **KV cache offloading** (slug unchanged) and links to the new tier pages; **KV cache** gains `KVCache` / `KV caching` aliases; **agentic-coding-workload** gains **agentic coding**; **context window** drops the **long context** alias (moved to the new entry) and links to `long-context`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea99deff4807de93c6b51e7f031fb6e803f27df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->