### PR TITLE
Fix chart title overlapping toolbar at reduced tab widths / 修复缩小标签页宽度时图表标题与工具栏重叠

### DIFF
--- a/packages/app/cypress/e2e/chart-header-toolbar-overlap.cy.ts
+++ b/packages/app/cypress/e2e/chart-header-toolbar-overlap.cy.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression: the chart action toolbar (view toggle, share, download, reset
+ * zoom) renders as an absolute overlay in the chart figure's top-right corner
+ * from `md` up. The chart heading spanned the full card width, so at reduced
+ * tab widths (browser side panel, split screen) a long title — e.g. the
+ * default "Total Tokens per $1 TCO (Owning - Hyperscaler) vs. P90
+ * Interactivity" — wrapped underneath the toolbar and was covered by it.
+ *
+ * The heading now reserves the overlay's width (`md:mr-80`), so the title and
+ * toolbar bounding boxes must never intersect at any viewport width, in both
+ * Chart and Table views. Below `md` the toolbar is a normal-flow row above
+ * the card (#948), which must stay overlap-free too.
+ */
+
+interface Box {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+const boxOf = ($el: JQuery): Box => {
+  const r = $el[0].getBoundingClientRect();
+  return { left: r.left, right: r.right, top: r.top, bottom: r.bottom };
+};
+
+const intersects = (a: Box, b: Box): boolean =>
+  a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom;
+
+/** md boundary, side-panel width (the reported repro), lg, and full desktop. */
+const OVERLAY_WIDTHS = [768, 880, 1024, 1280] as const;
+/** Below md the toolbar renders as a normal-flow row above the card. */
+const FLOW_WIDTH = 500;
+
+function assertHeaderClearsToolbar(width: number) {
+  cy.viewport(width, 900);
+  cy.get('[data-testid="chart-figure"]')
+    .first()
+    .within(() => {
+      cy.get('.export-buttons').should('be.visible');
+      cy.get('h2').should('be.visible');
+      cy.get('.export-buttons').then(($toolbar) => {
+        const toolbar = boxOf($toolbar);
+        cy.get('h2').then(($title) => {
+          const title = boxOf($title);
+          expect(
+            intersects(title, toolbar),
+            `title ${JSON.stringify(title)} must not intersect toolbar ${JSON.stringify(
+              toolbar,
+            )} at ${width}px`,
+          ).to.eq(false);
+        });
+      });
+    });
+}
+
+function assertToolbarActionsPresent() {
+  cy.get('[data-testid="chart-figure"]')
+    .first()
+    .within(() => {
+      cy.get('[data-testid="inference-chart-view-btn"]').should('be.visible');
+      cy.get('[data-testid="inference-table-view-btn"]').should('be.visible');
+      cy.get('[data-testid="share-button"]').should('be.visible');
+      cy.get('[data-testid="export-button"]').should('be.visible');
+      cy.get('[data-testid="zoom-reset-button"]').should('be.visible');
+    });
+}
+
+describe('chart header toolbar overlap', () => {
+  before(() => {
+    cy.viewport(1280, 900);
+    cy.window().then((win) => {
+      win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+    });
+    cy.visit('/inference');
+    cy.get('[data-testid="x-axis-mode-interactivity"]').click();
+    cy.get('[data-testid="chart-figure"]').first().find('h2').should('not.be.empty');
+  });
+
+  it('keeps every toolbar action available in chart view', () => {
+    cy.viewport(1280, 900);
+    assertToolbarActionsPresent();
+  });
+
+  for (const width of OVERLAY_WIDTHS) {
+    it(`chart view: title and toolbar do not overlap at ${width}px`, () => {
+      assertHeaderClearsToolbar(width);
+    });
+  }
+
+  it(`chart view: title and toolbar do not overlap at ${FLOW_WIDTH}px (normal-flow toolbar)`, () => {
+    assertHeaderClearsToolbar(FLOW_WIDTH);
+  });
+
+  it('table view: title and toolbar do not overlap across widths', () => {
+    cy.viewport(1280, 900);
+    cy.get('[data-testid="chart-figure"]')
+      .first()
+      .find('[data-testid="inference-table-view-btn"]')
+      .click();
+    cy.get('[data-testid="chart-figure"]').first().find('table').should('be.visible');
+    for (const width of [...OVERLAY_WIDTHS, FLOW_WIDTH]) {
+      assertHeaderClearsToolbar(width);
+    }
+    assertToolbarActionsPresent();
+    // Restore chart view for any spec that runs after this one.
+    cy.get('[data-testid="chart-figure"]')
+      .first()
+      .find('[data-testid="inference-chart-view-btn"]')
+      .click();
+  });
+});

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -944,7 +944,10 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                     {(() => {
                       const chartCaption = (
                         <>
-                          <h2 className="text-lg font-semibold">
+                          {/* md:mr-80 keeps the heading clear of the absolute
+                              toolbar overlay (~287px wide at md:right-8), so a
+                              long title wraps instead of running under it. */}
+                          <h2 className="text-lg font-semibold md:mr-80">
                             {metricTitle(graph.chartDefinition, selectedYAxisMetric, locale)}{' '}
                             {(() => {
                               // For Input metrics with dynamic x-axis, use dynamic heading.

--- a/packages/app/timings.json
+++ b/packages/app/timings.json
@@ -49,6 +49,10 @@
       "duration": 9822
     },
     {
+      "spec": "cypress/e2e/chart-header-toolbar-overlap.cy.ts",
+      "duration": 4000
+    },
+    {
       "spec": "cypress/e2e/chart-overflow-continuation.cy.ts",
       "duration": 1955
     },


### PR DESCRIPTION
## Problem

On `/inference`, with *Interactivity* selected, shrinking the browser tab width (window resize or side panel) makes the **Chart / Table / Share / download / reset** controls overlap the chart title.

## Root cause

`ChartButtons` renders the toolbar as an absolute overlay (`md:absolute md:top-8 md:right-8`, ~287px wide) from `md` (768px) up, while the `h2` title in `ChartDisplay.tsx` spans the full card width. With the long default title ("Total Tokens per $1 TCO (Owning – Hyperscaler) vs. P90 Interactivity"), the title/toolbar bounding boxes intersect at every width ≥768px; visible text collision starts around ~1020px. Below 768px, #948's normal-flow row already handles it, which is why only intermediate widths were broken.

## Fix

Reserve the overlay's width on the heading (`md:mr-80`) so long titles wrap instead of running under the toolbar. Nothing is hidden or truncated, the full-width desktop layout and every toolbar action are preserved, and shared `ChartButtons` is untouched.

## Regression test

`chart-header-toolbar-overlap.cy.ts` selects Interactivity and asserts the title and `.export-buttons` bounding boxes never intersect at 768/880/1024/1280px (overlay mode) and 500px (flow mode), in both Chart and Table views, and that all five toolbar actions stay visible. `timings.json` gets the baseline entry required by `cypress-timings.test.ts`.

- Pre-fix proof: run against production (unfixed) → 5/7 fail with intersecting boxes at every overlay width
- Post-fix: Chromium 7/7 pass, Firefox 154 7/7 pass
- lint, format, typography gate, typecheck clean; unit tests pass (one pre-existing `benchmark-transform.test.ts` failure exists on clean master)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind margin on the chart heading plus e2e coverage; no auth, data, or shared toolbar component changes.
> 
> **Overview**
> Fixes a layout bug on `/inference` where long chart titles (e.g. Interactivity mode) were drawn under the absolutely positioned action toolbar when the tab was narrowed.
> 
> The chart card **`h2` in `ChartDisplay.tsx`** now uses **`md:mr-80`** so the title wraps in the space left of the overlay instead of sharing the full card width with **`.export-buttons`**. Toolbar behavior and actions are unchanged.
> 
> Adds Cypress regression **`chart-header-toolbar-overlap.cy.ts`**: bounding-box checks that title and toolbar never intersect at overlay widths (768–1280px), below-`md` flow layout (500px), and in both Chart and Table views, plus visibility of all five toolbar controls. **`timings.json`** includes the new spec baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1509611f96093142aee8f670bc62478e2566d3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->