### PR TITLE
Retire the MiniMax M3 single-turn 8k1k scenario / 停用 MiniMax M3 单轮 8k1k 场景

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -211,6 +211,46 @@ describe('Chart Selectors', () => {
       cy.get('[data-testid="scenario-agentic-info"]').should('not.exist');
     });
 
+    it('groups a per-model retired scenario under Deprecated (MiniMax M3 8K/1K)', () => {
+      // MiniMax M3's single-turn 8k1k sweep was retired on 2026-08-04
+      // (InferenceX#2493): with the model passed in, 8K / 1K moves out of the
+      // default fixed-seq group into the Deprecated group.
+      cy.mount(
+        <TooltipProvider delayDuration={0}>
+          <ScenarioSelector
+            value={Sequence.AgenticTraces}
+            onChange={() => {}}
+            availableSequences={[Sequence.EightK_OneK, Sequence.AgenticTraces]}
+            model={Model.MiniMax_M3}
+            data-testid="scenario-selector"
+          />
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="scenario-selector"]').click();
+      cy.contains('[data-slot="select-label"]', 'Deprecated').should('be.visible');
+      cy.contains('[data-slot="select-label"]', 'Deprecated')
+        .nextAll('[role="option"]')
+        .first()
+        .should('contain.text', '8K / 1K');
+    });
+
+    it('keeps 8K/1K in the default group for models still sweeping it', () => {
+      cy.mount(
+        <TooltipProvider delayDuration={0}>
+          <ScenarioSelector
+            value={Sequence.AgenticTraces}
+            onChange={() => {}}
+            availableSequences={[Sequence.EightK_OneK, Sequence.AgenticTraces]}
+            model={Model.DeepSeek_V4_Pro}
+            data-testid="scenario-selector"
+          />
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="scenario-selector"]').click();
+      cy.contains('[role="option"]', '8K / 1K').should('be.visible');
+      cy.get('[data-slot="select-content"]').should('not.contain.text', 'Deprecated');
+    });
+
     it('hides the agentic explainer on fixed-sequence scenarios', () => {
       cy.mount(<ScenarioSelectorHarness initial={Sequence.EightK_OneK} />);
       cy.get('[data-testid="scenario-selector"]').should('contain.text', '8K / 1K');

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -22,9 +22,11 @@ const PLATFORM_HEADERS = [
 ];
 
 const SINGLE_TURN = 'single_turn_8k1k';
-/** Six models: three with both a single-turn and an AgentX row, and three
- *  curated AgentX-only (Kimi K3, GLM 5.2, Qwen3.8-Flash-Next). */
-const MATRIX_ROWS = 9;
+/** Six models: two with both a single-turn and an AgentX row (DeepSeek,
+ *  Qwen3.5), and four curated AgentX-only (Kimi K3, GLM 5.2,
+ *  Qwen3.8-Flash-Next, and MiniMax M3, whose 8k1k sweep was retired on
+ *  2026-08-04 in InferenceX#2493). */
+const MATRIX_ROWS = 8;
 const AGENTX = 'agentx';
 const AGENTX_LABEL = 'Long Context Multi-Turn Realistic Agentic Scenario (AgentX)';
 const AGENTX_LABEL_ZH = '长上下文、多轮交互的真实智能体场景（AgentX）';
@@ -1110,7 +1112,7 @@ describe('Overview page', () => {
         );
       });
     });
-    desktopModel('MiniMax-M3', SINGLE_TURN).within(() => {
+    desktopModel('MiniMax-M3', AGENTX).within(() => {
       platform('gb300')
         .should('contain.text', 'SGLang · FP8')
         .and('not.contain.text', 'M3 EAGLE')
@@ -1169,7 +1171,7 @@ describe('Overview page', () => {
 
     // Priced result with no B200 baseline: neutral gray ∞ and a neutral cell —
     // availability, not a good/bad judgment, so no red/green tint.
-    desktopModel('MiniMax-M3', SINGLE_TURN).within(() => {
+    desktopModel('MiniMax-M3', AGENTX).within(() => {
       platform('gb300')
         .find('[data-testid="overview-cost-delta"]')
         .should('contain.text', '∞')
@@ -1247,8 +1249,8 @@ describe('Overview page', () => {
             expect(getComputedStyle(header).fontSize).to.equal('14px');
           }
         });
-        // One row per curated (model, scenario) pair: six models, three of
-        // which (DeepSeek, MiniMax, Qwen) carry a second AgentX row.
+        // One row per curated (model, scenario) pair: six models, two of
+        // which (DeepSeek, Qwen3.5) carry a second single-turn row.
         cy.get('[data-testid="overview-desktop-model"]').should('have.length', MATRIX_ROWS);
         cy.get('[data-testid="overview-platform"]').should('have.length', MATRIX_ROWS * 5);
         cy.get('[data-testid="overview-model-coverage-note"]').should('not.exist');
@@ -1264,12 +1266,12 @@ describe('Overview page', () => {
     for (const label of MODEL_LABELS) {
       cy.get('[data-testid="overview-desktop-matrix"]').should('contain.text', label);
     }
-    for (const model of ['Kimi-K3', 'GLM-5.2']) {
+    for (const model of ['Kimi-K3', 'GLM-5.2', 'MiniMax-M3']) {
       desktopModel(model).within(() => {
         expectAgentxScenario(AGENTX_LABEL);
       });
     }
-    for (const model of ['DeepSeek-V4-Pro', 'MiniMax-M3', 'Qwen-3.5-397B-A17B']) {
+    for (const model of ['DeepSeek-V4-Pro', 'Qwen-3.5-397B-A17B']) {
       desktopModel(model, SINGLE_TURN)
         .find('[data-testid="overview-model-scenario"]')
         .should('have.text', '8K/1K');
@@ -1424,7 +1426,7 @@ describe('Overview page', () => {
         .and('include', 'Estimated from validated benchmark runs.');
     });
 
-    desktopModel('MiniMax-M3', SINGLE_TURN).within(() => {
+    desktopModel('MiniMax-M3', AGENTX).within(() => {
       platform('b200')
         .find('[data-testid="overview-pair-missing"]')
         .should('contain.text', '—')
@@ -1818,7 +1820,7 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
       platform('b200').should('contain.text', 'SGLang · FP4').and('not.contain.text', 'STP');
     });
-    desktopModel('MiniMax-M3', SINGLE_TURN).within(() => {
+    desktopModel('MiniMax-M3', AGENTX).within(() => {
       platform('gb300')
         .find('[data-testid="overview-cost-delta"]')
         .should('contain.text', '∞')

--- a/packages/app/cypress/fixtures/api/_manifest.json
+++ b/packages/app/cypress/fixtures/api/_manifest.json
@@ -66,9 +66,9 @@
       "topLevel": "object"
     },
     "overview-rows": {
-      "bytes": 22152,
+      "bytes": 22206,
       "capturedAt": null,
-      "sha256": "ccdc4c23fc6b5ab6f664e19db2ec31efe2b34318976baec06e9219987e240922",
+      "sha256": "ca6cb56cae88b928cc9bba01916bbf640b4579ac42c34a8cc8621db62072c72c",
       "source": null,
       "topLevel": "object"
     },

--- a/packages/app/cypress/fixtures/api/overview-rows.json
+++ b/packages/app/cypress/fixtures/api/overview-rows.json
@@ -818,13 +818,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 6510, "output_tput_per_gpu": 700 },
+      "metrics": {
+        "p90_itl": 0.02,
+        "p90_ttlt": 125,
+        "tput_per_gpu": 6510,
+        "output_tput_per_gpu": 700
+      },
       "date": "2026-07-18",
       "run_url": null
     }

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -384,6 +384,7 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                   open={openDropdown === 'sequence'}
                   onOpenChange={handleDropdownOpenChange('sequence')}
                   availableSequences={availableSequences}
+                  model={selectedModel}
                 />
                 {isAgenticSequence && featureGateUnlocked && (
                   <PercentileSelector

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -947,6 +947,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                   open={openDropdown === 'sequence'}
                   onOpenChange={handleDropdownOpenChange('sequence')}
                   availableSequences={availableSequences}
+                  model={selectedModel}
                 />
                 {isAgenticSequence && featureGateUnlocked && (
                   <PercentileSelector

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -322,6 +322,7 @@ export default function ChartControls({ hideGpuComparison = false }: ChartContro
             open={openDropdown === 'sequence'}
             onOpenChange={handleDropdownOpenChange('sequence')}
             availableSequences={availableSequences}
+            model={selectedModel}
             data-testid="scenario-selector"
           />
           {/* AgentX publishes on P90, so the percentile control is an insider

--- a/packages/app/src/components/ui/chart-selectors.tsx
+++ b/packages/app/src/components/ui/chart-selectors.tsx
@@ -28,7 +28,7 @@ import {
   getModelLabel,
   getPercentileLabel,
   getPrecisionLabel,
-  getSequenceCategory,
+  getSequenceCategoryForModel,
   getSequenceLabel,
   groupByCategory,
   sequenceKind,
@@ -296,6 +296,8 @@ interface SequenceSelectorProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   availableSequences: string[];
+  /** Selected model, so per-model scenario retirements group as Deprecated. */
+  model?: Model | null;
   'data-testid'?: string;
 }
 
@@ -306,11 +308,14 @@ export function SequenceSelector({
   open,
   onOpenChange,
   availableSequences,
+  model,
   'data-testid': testId,
 }: SequenceSelectorProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
-  const groups = groupByCategory(availableSequences, (s) => getSequenceCategory(s as Sequence));
+  const groups = groupByCategory(availableSequences, (s) =>
+    getSequenceCategoryForModel(s as Sequence, model),
+  );
   const sections = [
     {
       id: 'default',
@@ -376,6 +381,8 @@ interface ScenarioSelectorProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   availableSequences: string[];
+  /** Selected model, so per-model scenario retirements group as Deprecated. */
+  model?: Model | null;
   'data-testid'?: string;
 }
 
@@ -396,13 +403,16 @@ export function ScenarioSelector({
   open,
   onOpenChange,
   availableSequences,
+  model,
   'data-testid': testId,
 }: ScenarioSelectorProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
   const fixedSeq = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'fixed-seq');
   const agentic = availableSequences.filter((s) => sequenceKind(s as Sequence) === 'agentic');
-  const fixedGroups = groupByCategory(fixedSeq, (s) => getSequenceCategory(s as Sequence));
+  const fixedGroups = groupByCategory(fixedSeq, (s) =>
+    getSequenceCategoryForModel(s as Sequence, model),
+  );
   const isAgenticSelected = sequenceKind(value as Sequence) === 'agentic';
 
   if (availableSequences.length < 2) return null;

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -668,7 +668,11 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    sourceSha256: '8ca280fec5bbe633493cf021fee294927aead799742ac07ac7dbe8c5092e38f2',
+    // Reviewed for the MiniMax M3 8k1k retirement (InferenceX#2493): only the
+    // curated OVERVIEW_MODEL_SCENARIOS list and the no-rows scenario fallback
+    // changed — no parameter or OverviewPageData shape change, so the docs
+    // stand.
+    sourceSha256: 'e80e92dc4c87fd4cbdd7194877b91cedab0e8a3267bfe5ec63731388be82b692',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -17,6 +17,8 @@ import {
   isModelDeprecated,
   isModelMaintenance,
   isSequenceDeprecated,
+  isSequenceDeprecatedForModel,
+  getSequenceCategoryForModel,
   Model,
   Sequence,
   Precision,
@@ -222,6 +224,40 @@ describe('isSequenceDeprecated', () => {
 
   it('returns false for non-deprecated sequence EightK_OneK', () => {
     expect(isSequenceDeprecated(Sequence.EightK_OneK)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// per-model sequence retirement
+// ===========================================================================
+describe('isSequenceDeprecatedForModel / getSequenceCategoryForModel', () => {
+  it('marks 8K/1K deprecated for MiniMax M3 (retired 2026-08-04, InferenceX#2493)', () => {
+    expect(isSequenceDeprecatedForModel(Model.MiniMax_M3, Sequence.EightK_OneK)).toBe(true);
+    expect(getSequenceCategoryForModel(Sequence.EightK_OneK, Model.MiniMax_M3)).toBe('deprecated');
+  });
+
+  it('keeps 8K/1K default for models still sweeping it', () => {
+    expect(isSequenceDeprecatedForModel(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK)).toBe(false);
+    expect(getSequenceCategoryForModel(Sequence.EightK_OneK, Model.DeepSeek_V4_Pro)).toBe(
+      'default',
+    );
+  });
+
+  it('does not un-deprecate globally deprecated sequences', () => {
+    expect(getSequenceCategoryForModel(Sequence.OneK_OneK, Model.MiniMax_M3)).toBe('deprecated');
+    expect(getSequenceCategoryForModel(Sequence.OneK_OneK, Model.DeepSeek_V4_Pro)).toBe(
+      'deprecated',
+    );
+  });
+
+  it('falls back to the global category when no model is given', () => {
+    expect(getSequenceCategoryForModel(Sequence.EightK_OneK)).toBe('default');
+    expect(getSequenceCategoryForModel(Sequence.EightK_OneK, null)).toBe('default');
+  });
+
+  it('leaves MiniMax M3 agentic traces active', () => {
+    expect(isSequenceDeprecatedForModel(Model.MiniMax_M3, Sequence.AgenticTraces)).toBe(false);
+    expect(getSequenceCategoryForModel(Sequence.AgenticTraces, Model.MiniMax_M3)).toBe('default');
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -498,6 +498,38 @@ export function getSequenceCategory(sequence: Sequence): CategoryTag {
   return SEQUENCE_CONFIG[sequence]?.category ?? 'default';
 }
 
+/**
+ * Scenarios retired for a specific model while staying active for others.
+ * `SEQUENCE_CONFIG` categories are global — 8K/1K is `default` because most
+ * fixed-seq models still sweep it — so a per-model retirement needs its own
+ * table. Listing a scenario here moves it under the Deprecated group in the
+ * scenario selector for that model only; historical rows stay queryable, the
+ * scenario just stops presenting as actively benchmarked.
+ *
+ * MiniMax M3: the Single-turn 8k1k sweep was removed on 2026-08-04
+ * (InferenceX#2493, per MODELS.md "Scenario and precision retirements");
+ * Agentic coding is the model's only active scenario.
+ */
+const MODEL_DEPRECATED_SEQUENCES: Partial<Record<Model, ReadonlySet<Sequence>>> = {
+  [Model.MiniMax_M3]: new Set([Sequence.EightK_OneK]),
+};
+
+/** Whether this model retired the scenario even though it is globally active. */
+export function isSequenceDeprecatedForModel(model: Model, sequence: Sequence): boolean {
+  return MODEL_DEPRECATED_SEQUENCES[model]?.has(sequence) ?? false;
+}
+
+/**
+ * Sequence category as seen from one model's point of view: the global
+ * category, overridden to `deprecated` when the model retired the scenario.
+ * Selectors pass the selected model so a per-model retirement (MiniMax M3's
+ * 8K/1K) groups under Deprecated without touching other models.
+ */
+export function getSequenceCategoryForModel(sequence: Sequence, model?: Model | null): CategoryTag {
+  if (model && isSequenceDeprecatedForModel(model, sequence)) return 'deprecated';
+  return getSequenceCategory(sequence);
+}
+
 export function getSequenceLabel(sequence: Sequence, locale: 'en' | 'zh' = 'en'): string {
   const config = SEQUENCE_CONFIG[sequence];
   if (!config) return sequence;

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -179,7 +179,7 @@ describe('overview engine scope and scenario selection', () => {
     expect(overviewScenarioForModel(Model.GLM_5_2)).toBe('agentx');
     expect(overviewScenarioForModel(Model.DeepSeek_V4_Pro)).toBe('single_turn_8k1k');
     expect(overviewScenarioForModel(Model.Kimi_K2_5)).toBe('single_turn_8k1k');
-    expect(overviewScenarioForModel(Model.MiniMax_M3)).toBe('single_turn_8k1k');
+    expect(overviewScenarioForModel(Model.MiniMax_M3)).toBe('agentx');
     expect(overviewScenarioForModel(Model.Qwen3_5)).toBe('single_turn_8k1k');
   });
 
@@ -1336,13 +1336,16 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       overviewRowsFixture as unknown as Record<string, BenchmarkRow[]>,
     );
 
-    // Curated scenarios: DeepSeek, MiniMax and Qwen3.5 each get both rows, Kimi
-    // K3 and GLM are AgentX-only. Kimi K2.5 is absent — deprecated models are
-    // not default models, and the matrix is built from DEFAULT_MODELS.
+    // Curated scenarios: DeepSeek and Qwen3.5 each get both rows, Kimi K3 and
+    // GLM are AgentX-only. Kimi K2.5 is absent — deprecated models are not
+    // default models, and the matrix is built from DEFAULT_MODELS.
     // Qwen3.8-Flash-Next is curated AgentX-only, like Kimi K3 and GLM: the
     // model is benchmarked on agentic traces, so it must not claim a
-    // fixed-sequence row it will never fill. AgentX rows group above the 8K/1K
-    // rows, each group in MODEL_CONFIG declaration order.
+    // fixed-sequence row it will never fill. MiniMax M3 is AgentX-only too,
+    // but by retirement: its single-turn 8k1k sweep stopped on 2026-08-04
+    // (InferenceX#2493), so the matrix must not keep a row that never
+    // refreshes. AgentX rows group above the 8K/1K rows, each group in
+    // MODEL_CONFIG declaration order.
     expect(page.models.map((m) => `${m.model}/${m.scenario}`)).toEqual([
       `${Model.DeepSeek_V4_Pro}/agentx`,
       `${Model.Kimi_K3}/agentx`,
@@ -1351,7 +1354,6 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       `${Model.Qwen3_5}/agentx`,
       `${Model.Qwen3_8_Flash_Next}/agentx`,
       `${Model.DeepSeek_V4_Pro}/single_turn_8k1k`,
-      `${Model.MiniMax_M3}/single_turn_8k1k`,
       `${Model.Qwen3_5}/single_turn_8k1k`,
     ]);
     expect(page.models.length).toBeGreaterThan(DEFAULT_MODELS.size);
@@ -1419,10 +1421,10 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
         .map((p) => p.missingReason),
     ).toEqual(['no_scenario_data', 'no_scenario_data', 'no_scenario_data']);
 
-    // MiniMax: the platform result remains visible when B200 has no 8K/1K data
-    // — priced, but with no percentage baseline (the UI's ∞ badge state).
+    // MiniMax: the platform result remains visible when B200 has no AgentX
+    // data — priced, but with no percentage baseline (the UI's ∞ badge state).
     const minimax = page.models.find(
-      (m) => m.model === Model.MiniMax_M3 && m.scenario === 'single_turn_8k1k',
+      (m) => m.model === Model.MiniMax_M3 && m.scenario === 'agentx',
     )!;
     const mmGb300 = headlinePairOf(minimax, 'gb300-vs-b200')!;
     expect(mmGb300.baseline.missingReason).toBe('no_scenario_data');

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -342,7 +342,12 @@ export function overviewScenarioForModel(
     return 'single_turn_8k1k';
   }
   if (rows.some((row) => row.benchmark_type === 'agentic_traces')) return 'agentx';
-  return model === Model.Kimi_K3 || model === Model.GLM_5_2 || model === Model.Qwen3_8_Flash_Next
+  // AgentX-only models: Kimi K3, GLM 5.2 and Qwen3.8 Flash Next never swept
+  // 8K/1K; MiniMax M3 retired it on 2026-08-04 (InferenceX#2493, MODELS.md).
+  return model === Model.Kimi_K3 ||
+    model === Model.GLM_5_2 ||
+    model === Model.Qwen3_8_Flash_Next ||
+    model === Model.MiniMax_M3
     ? 'agentx'
     : 'single_turn_8k1k';
 }
@@ -355,7 +360,10 @@ export function overviewScenarioForModel(
  */
 const OVERVIEW_MODEL_SCENARIOS: Partial<Record<Model, readonly OverviewScenario[]>> = {
   [Model.DeepSeek_V4_Pro]: ['single_turn_8k1k', 'agentx'],
-  [Model.MiniMax_M3]: ['single_turn_8k1k', 'agentx'],
+  // MiniMax M3's single-turn 8k1k sweep was retired on 2026-08-04
+  // (InferenceX#2493, MODELS.md), so the matrix must not keep a fixed-sequence
+  // row that will never refresh; AgentX is the model's only active scenario.
+  [Model.MiniMax_M3]: ['agentx'],
   [Model.Qwen3_5]: ['single_turn_8k1k', 'agentx'],
   [Model.Kimi_K3]: ['agentx'],
   [Model.GLM_5_2]: ['agentx'],


### PR DESCRIPTION
## Summary

The benchmark sweep retired the single-turn 8k1k scenario for MiniMax M3 on **2026-08-04** ([InferenceX#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493), recorded under [MODELS.md scenario retirements](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md)), but the app still presented it as a live scenario. This PR makes the app match reality:

- **Per-model scenario retirement mechanism**: new `MODEL_DEPRECATED_SEQUENCES` map plus `isSequenceDeprecatedForModel` / `getSequenceCategoryForModel` in `data-mappings.ts`. Unlike the Kimi K2.5 precedent (whole-model deprecation), MiniMax M3 stays active on AgentX — only its 8k1k sequence is retired.
- **Scenario selectors**: `SequenceSelector` / `ScenarioSelector` accept an optional `model` prop; chart controls, throughput calculator, and fleet lifecycle pages pass the selected model, so 8K/1K groups under **Deprecated** (with the existing reallocation tooltip) for MiniMax M3 only.
- **Overview matrix**: `OVERVIEW_MODEL_SCENARIOS` now curates MiniMax M3 as AgentX-only (matrix drops from 9 to 8 rows), and the no-rows scenario fallback points at AgentX.
- **Tests & fixtures**: overview fixture row converted to agentic traces (preserving the ∞/no-baseline coverage), fixture manifest refreshed, overview-data docs-review digest bumped, and unit / e2e / component tests migrated with new coverage for the per-model retirement helpers.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run fmt` — clean
- `bun run test:unit` — 4,287 passing (one pre-existing `Object.groupBy` failure in the sandbox's older Node runtime, unrelated; CI Node is unaffected)
- Cypress e2e/component suites updated; relying on CI to execute them

## 中文说明

基准测试已于 **2026-08-04** 停止对 MiniMax M3 运行单轮 8k1k 场景（[InferenceX#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493)，见 [MODELS.md 场景停用记录](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md)），但仪表板仍将其展示为在用场景。本 PR 使仪表板与实际情况保持一致：

- **按模型的场景停用机制**：在 `data-mappings.ts` 中新增 `MODEL_DEPRECATED_SEQUENCES` 映射及 `isSequenceDeprecatedForModel` / `getSequenceCategoryForModel`。与 Kimi K2.5 的整模型弃用先例不同，MiniMax M3 在 AgentX 上仍然活跃——仅停用其 8k1k 序列。
- **场景选择器**：`SequenceSelector` / `ScenarioSelector` 新增可选 `model` 属性；图表控件、吞吐量计算器和机群生命周期页面传入所选模型，因此仅对 MiniMax M3 将 8K/1K 归入**已弃用**分组（沿用现有的容量重新分配提示）。
- **概览矩阵**：`OVERVIEW_MODEL_SCENARIOS` 现将 MiniMax M3 设为仅 AgentX（矩阵从 9 行减至 8 行），无数据回退指向 AgentX。
- **测试与夹具**：概览夹具行转换为智能体轨迹（保留 ∞/无基线覆盖），刷新夹具清单，更新 overview-data 文档审查摘要，并迁移单元/端到端/组件测试，为按模型停用辅助函数新增覆盖。

## 测试计划

- `bun run typecheck`、`bun run lint`、`bun run fmt` —— 通过
- `bun run test:unit` —— 4,287 项通过（沙箱较旧 Node 运行时中存在一个与本改动无关的 `Object.groupBy` 既有失败；CI 的 Node 不受影响）
- Cypress 端到端/组件测试已更新，由 CI 执行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Curated overview rows and selector grouping for one model/scenario pair; no auth or API contract changes beyond fixture data.
> 
> **Overview**
> Aligns the dashboard with the **2026-08-04** retirement of MiniMax M3’s single-turn 8k1k sweep (InferenceX#2493): the model stays on **AgentX**, but 8K/1K is no longer presented as an active headline scenario.
> 
> Adds **per-model scenario retirement** via `MODEL_DEPRECATED_SEQUENCES` and helpers `isSequenceDeprecatedForModel` / `getSequenceCategoryForModel`. `SequenceSelector` and `ScenarioSelector` take an optional `model` prop (wired from chart controls, TCO calculator, and fleet lifecycle) so **8K/1K moves under Deprecated for MiniMax M3 only** while other models keep it in the default group.
> 
> The **overview matrix** curates MiniMax M3 as AgentX-only (`OVERVIEW_MODEL_SCENARIOS`, scenario fallback), dropping one row (9→8). Cypress fixtures, unit tests, and e2e expectations follow the AgentX row and refreshed overview fixture manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a96279a914c18972f8aaa6def0b6846eea083c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->