### PR TITLE
Hide total unique input tokens chart

### DIFF
--- a/packages/app/src/components/inference/agentic-point/agentic-point-detail.tsx
+++ b/packages/app/src/components/inference/agentic-point/agentic-point-detail.tsx
@@ -36,7 +36,6 @@ import { PointSummary } from './point-summary';
 import { RequestMetricOverTime, SequenceMetricCard } from './request-metric-cards';
 import { ServerLogViewer } from './server-log-viewer';
 import {
-  CumulativeUniqueInputTokensCard,
   InflightUniqueTokensCard,
   KvCacheUtilizationCard,
   PrefixCacheHitRateCard,
@@ -467,8 +466,6 @@ export function AgenticPointDetail({ id }: Props) {
             />
 
             <PromptTokenSourceCard sliced={sliced} />
-
-            <CumulativeUniqueInputTokensCard sliced={sliced} />
 
             {!requestChartQuery.isError && (
               <InflightUniqueTokensCard


### PR DESCRIPTION
Remove the total unique input tokens over time chart from the per-point AgentX view. No database, ingestion, or metric changes; all other charts remain unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change on the AgentX point detail page with no API, ingestion, or metric pipeline impact.
> 
> **Overview**
> Removes the **total unique input tokens over time** chart from the per-point AgentX detail layout.
> 
> The `CumulativeUniqueInputTokensCard` import and its grid slot are dropped; throughput, prompt token source, inflight unique tokens, and the other server/request charts are unchanged. The card implementation remains in `server-metric-cards` but is no longer shown on this page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9cd1dc6df4c2fc5fc862e69990a04a44be98fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->