### PR TITLE
Move resident ISL/OSL summary from chart subtitle to info footer

### DIFF
--- a/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
+++ b/packages/app/cypress/e2e/resident-sequence-lengths.cy.ts
@@ -12,7 +12,7 @@ function visitAgenticChart(extraQuery = '') {
   });
 }
 
-describe('resident sequence-length subtitle', () => {
+describe('resident sequence-length footer summary', () => {
   it('summarizes every resident official point without following legend selection', () => {
     interceptOverlayRun();
     interceptDerivedAgenticMetrics();
@@ -39,7 +39,7 @@ describe('resident sequence-length subtitle', () => {
       .and('contain.text', 'OSL p50 1k');
 
     // Legend visibility is downstream of the resident set. Hiding a series
-    // must not remove the subtitle or issue a narrower stats request.
+    // must not remove the footer summary or issue a narrower stats request.
     cy.get('.sidebar-legend button').first().click({ force: true });
     cy.get('[data-testid="resident-sequence-lengths"]').should('be.visible');
     cy.get('@residentSequenceLengths.all').should('have.length', 1);

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -689,7 +689,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
     return [...ids];
   }, [isAgenticSequence, selectedPrecisions, visibleGraphs]);
   // Unofficial-run artifacts are transformed in memory and do not have
-  // persisted aggregate_stats sketches. Suppress the subtitle in overlay mode
+  // persisted aggregate_stats sketches. Suppress the footer summary in overlay mode
   // rather than presenting official-only values as if they covered the overlay.
   const residentSequenceLengthsQuery = useResidentSequenceLengths(
     residentPointIds,
@@ -861,6 +861,9 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                 point.framework !== undefined &&
                 getFrameworkLabel(point.framework).includes(ATOM_FOOTNOTE_MARKER),
             );
+            // The resident ISL/OSL percentile summary (agentic only) renders
+            // here as the footer's last block rather than in the chart subtitle,
+            // so the header stays a one-line source/date caption.
             const footerNotices =
               hasOffloadHalo || hasLegacyPowerPoints || isAgenticSequence || hasAtomSeries ? (
                 <>
@@ -868,6 +871,28 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                   {hasLegacyPowerPoints && <LegacyPowerLegendKey />}
                   {isAgenticSequence && <AgenticOptimizationNote />}
                   {hasAtomSeries && <AtomEngineFootnote />}
+                  {residentSequenceLengths && (
+                    <p
+                      className="text-3xs leading-tight text-muted-foreground/70"
+                      data-testid="resident-sequence-lengths"
+                    >
+                      {t.completedSequenceLengths(
+                        residentSequenceLengths.isl.n.toLocaleString(
+                          locale === 'zh' ? 'zh-CN' : 'en-US',
+                        ),
+                      )}{' '}
+                      · ISL p50 {formatTokenLength(residentSequenceLengths.isl.p50)} · p75{' '}
+                      {formatTokenLength(residentSequenceLengths.isl.p75)} · p90{' '}
+                      {formatTokenLength(residentSequenceLengths.isl.p90)} · p95{' '}
+                      {formatTokenLength(residentSequenceLengths.isl.p95)} · p99{' '}
+                      {formatTokenLength(residentSequenceLengths.isl.p99)} | OSL p50{' '}
+                      {formatTokenLength(residentSequenceLengths.osl.p50)} · p75{' '}
+                      {formatTokenLength(residentSequenceLengths.osl.p75)} · p90{' '}
+                      {formatTokenLength(residentSequenceLengths.osl.p90)} · p95{' '}
+                      {formatTokenLength(residentSequenceLengths.osl.p95)} · p99{' '}
+                      {formatTokenLength(residentSequenceLengths.osl.p99)}
+                    </p>
+                  )}
                 </>
               ) : undefined;
             return (
@@ -1051,28 +1076,6 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                               </>
                             )}
                           </p>
-                          {residentSequenceLengths && (
-                            <p
-                              className="mb-2 text-xs text-muted-foreground"
-                              data-testid="resident-sequence-lengths"
-                            >
-                              {t.completedSequenceLengths(
-                                residentSequenceLengths.isl.n.toLocaleString(
-                                  locale === 'zh' ? 'zh-CN' : 'en-US',
-                                ),
-                              )}{' '}
-                              · ISL p50 {formatTokenLength(residentSequenceLengths.isl.p50)} · p75{' '}
-                              {formatTokenLength(residentSequenceLengths.isl.p75)} · p90{' '}
-                              {formatTokenLength(residentSequenceLengths.isl.p90)} · p95{' '}
-                              {formatTokenLength(residentSequenceLengths.isl.p95)} · p99{' '}
-                              {formatTokenLength(residentSequenceLengths.isl.p99)} | OSL p50{' '}
-                              {formatTokenLength(residentSequenceLengths.osl.p50)} · p75{' '}
-                              {formatTokenLength(residentSequenceLengths.osl.p75)} · p90{' '}
-                              {formatTokenLength(residentSequenceLengths.osl.p90)} · p95{' '}
-                              {formatTokenLength(residentSequenceLengths.osl.p95)} · p99{' '}
-                              {formatTokenLength(residentSequenceLengths.osl.p99)}
-                            </p>
-                          )}
                           <MetricAssumptionNotes
                             selectedYAxisMetric={selectedYAxisMetric}
                             activeHwKeys={captionHwKeys}


### PR DESCRIPTION
## What

The `Completed requests across all resident points (n=…) · ISL p50 … | OSL p50 …` line was rendered directly under the chart title, between the source/date caption and the TCO pills. It crowded the header on every agentic chart.

This moves it to the bottom of the card: it now renders as the last block of the axis-metric info footer, after the KV offload key, agentic optimization note, and ATOM footnote. Styled to match the ATOM footnote (`text-3xs text-muted-foreground/70`).

## Behavior unchanged

- Same data source (`useResidentSequenceLengths`) and same gates: agentic only, hidden in `?unofficialrun=` overlay mode, hidden if coverage is partial.
- Same `data-testid="resident-sequence-lengths"`, so the existing Cypress spec still applies (only its describe/comment wording updated from "subtitle" to "footer summary").
- Header is back to a single source/date caption line.

## Note

The footer is `no-export`, so PNG exports no longer include the ISL/OSL percentile line. That seems consistent with decluttering, but flag it if the export should keep it.

Verified locally: `bun run fmt`, `bun run lint`, `bun run typecheck` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only relocation with unchanged fetch logic and existing E2E coverage; only notable product change is omission from PNG exports.
> 
> **Overview**
> **Moves the agentic resident ISL/OSL percentile line** (`Completed requests across all resident points…`) **out of the chart header** and into the **axis-metric info footer** as the last block (after KV offload, agentic note, and ATOM footnote), using smaller muted styling (`text-3xs`) so the caption stays a single source/date line.
> 
> **Behavior is otherwise unchanged:** same `useResidentSequenceLengths` data, same gates (agentic only, hidden for unofficial overlay and partial coverage), same `data-testid="resident-sequence-lengths"`. Cypress copy is updated from “subtitle” to “footer summary.”
> 
> Because the footer is **`no-export`**, **PNG/chart image exports no longer include** this summary (it previously lived in the exportable caption area).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2321a3b96b9d9271faf13c97cde98514f6adf95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->