### PR TITLE
fix(db): backfill GB300 dynamo-vllm AgentX cache hit rates from GB200 / 用 GB200 实测值回填 GB300 dynamo-vllm AgentX 缓存命中率

### DIFF
--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -67,6 +67,33 @@ describe('audited run backfills', () => {
     expect(() => validateRunBackfills()).not.toThrow();
   });
 
+  it('limits borrowed prefix-cache hit rates to GB300 dynamo-vllm DeepSeek-V4 AgentX points', () => {
+    const cacheHitKeys = [
+      'server_gpu_cache_hit_rate',
+      'server_external_cache_hit_rate',
+      'server_cpu_cache_hit_rate',
+    ];
+    const borrowed = BENCHMARK_POINT_BACKFILLS.filter((backfill) =>
+      cacheHitKeys.some((key) => key in (backfill.set.metricsMerge ?? {})),
+    );
+
+    // Only the GB300 sweeps missed the backend worker metrics scrape; every
+    // other hardware measured its own hit rate and must never inherit one.
+    expect(borrowed.length).toBe(14);
+    for (const backfill of borrowed) {
+      expect(backfill.config.hardware).toBe('gb300');
+      expect(backfill.config.framework).toBe('dynamo-vllm');
+      expect(backfill.config.model).toBe('dsv4');
+      expect(backfill.benchmarkType).toBe('agentic_traces');
+      for (const key of cacheHitKeys) {
+        const value = backfill.set.metricsMerge?.[key];
+        expect(typeof value).toBe('number');
+        expect(value).toBeGreaterThanOrEqual(0);
+        expect(value).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
   it('requires a stable ID, reason, exact selector, and non-empty patch', () => {
     expect(() => validateRunBackfills([], [examplePointBackfill({ id: 'Not Valid' })])).toThrow(
       /kebab-case/u,

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -390,6 +390,74 @@ const DSV4_GB200_DYNAMO_VLLM = {
   specMethod: 'mtp',
 } as const;
 
+const DSV4_GB300_DYNAMO_VLLM = {
+  hardware: 'gb300',
+  framework: 'dynamo-vllm',
+  model: 'dsv4',
+  precision: 'fp4',
+  specMethod: 'mtp',
+} as const;
+
+/** Aggregated multi-node config where prefill and decode share one TP-only worker. */
+function aggregatedMultinodeConfig(
+  base: Pick<ConfigParams, 'hardware' | 'framework' | 'model' | 'precision' | 'specMethod'>,
+  tp: number,
+): ConfigParams {
+  return {
+    ...base,
+    disagg: false,
+    isMultinode: true,
+    prefillTp: tp,
+    prefillEp: 1,
+    prefillDpAttn: false,
+    prefillNumWorkers: 1,
+    decodeTp: tp,
+    decodeEp: 1,
+    decodeDpAttn: false,
+    decodeNumWorkers: 1,
+    numPrefillGpu: tp,
+    numDecodeGpu: tp,
+  };
+}
+
+/**
+ * Measured Dynamo + vLLM prefix-cache hit rates from the GB200 DeepSeek-V4 AgentX
+ * sweep in run 31965016666 (attempt 2), keyed by concurrency.
+ *
+ * The GB300 launcher has no dedicated dsv4 dynamo-vllm AgentX branch, so those
+ * sweeps fall through to the generic srt-slurm v1.0.36 pin, which predates the
+ * logical-worker metrics discovery that GB200 gets from v1.0.45. Without
+ * `AIPERF_SERVER_METRICS_URLS`, AIPerf scraped only the Dynamo frontend, which
+ * exposes no `vllm:prefix_cache_*` counters, so every
+ * `server_metrics.cache.*_cache_hit_rate` landed as null. Cache-aware pricing
+ * treats a missing hit rate as 0 and bills ~97% cache hits at the full input
+ * price. Until the GB300 sweeps are re-run with worker scraping, each point
+ * borrows the nearest-concurrency GB200 measurement.
+ */
+const GB200_DYNAMO_VLLM_CACHE_HIT_RATES = {
+  1: { gpu: 0.9631118724591531, external: 0, cpu: 0 },
+  4: { gpu: 0.9564614718743584, external: 0, cpu: 0 },
+  8: { gpu: 0.9490932531502648, external: 0, cpu: 0 },
+  128: { gpu: 0.21230551115259855, external: 0.75003, cpu: 0.7536240046010246 },
+  256: { gpu: 0.11829426868903234, external: 0.84522, cpu: 0.8500825947463053 },
+  512: { gpu: 0.21678884556039354, external: 0.73111, cpu: 0.7382413630407794 },
+  576: { gpu: 0.17858801070890962, external: 0.77599, cpu: 0.7815028871123451 },
+} as const;
+
+type Gb200CacheHitRateConc = keyof typeof GB200_DYNAMO_VLLM_CACHE_HIT_RATES;
+
+function gb200CacheHitRateMerge(donorConc: Gb200CacheHitRateConc) {
+  const rates = GB200_DYNAMO_VLLM_CACHE_HIT_RATES[donorConc];
+  return {
+    server_gpu_cache_hit_rate: rates.gpu,
+    server_external_cache_hit_rate: rates.external,
+    server_cpu_cache_hit_rate: rates.cpu,
+  };
+}
+
+const GB300_CACHE_HIT_RATE_REASON =
+  'The GB300 dynamo-vllm recipe scraped only the Dynamo frontend, so AIPerf reported no prefix-cache hit rate; borrow the nearest-concurrency GB200 dynamo-vllm measurement so cache-aware pricing does not bill cached input at full price.';
+
 export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
   // The source recipes in run 31633154542 attach MooncakeStoreConnector to
   // every disaggregated worker and allocate a 180 GB Mooncake segment per
@@ -398,6 +466,7 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
     [
       [
         2106,
+        256,
         256,
         null,
         disaggregatedConfig(
@@ -415,6 +484,7 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
       [
         2334,
         1152,
+        576,
         null,
         disaggregatedConfig(
           {
@@ -431,6 +501,7 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
       [
         2336,
         1024,
+        512,
         null,
         disaggregatedConfig(
           {
@@ -445,10 +516,9 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
         ),
       ],
     ] as const
-  ).map(([productionConfigId, conc, recipeFingerprint, config]) => ({
+  ).map(([productionConfigId, conc, donorConc, recipeFingerprint, config]) => ({
     id: `run-31633154542-config-${productionConfigId}-conc-${conc}-mooncake-offload`,
-    reason:
-      'The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded.',
+    reason: `The runtime recipe enabled MooncakeStoreConnector, but the artifact reported this AgentX point as non-offloaded. ${GB300_CACHE_HIT_RATE_REASON}`,
     githubRunId: 31633154542,
     runAttempt: 2,
     productionConfigId,
@@ -466,9 +536,135 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
         kv_offloading: 'dram',
         kv_offload_backend: 'mooncake',
         kv_offload_backend_version: '0.3.11.post1',
+        ...gb200CacheHitRateMerge(donorConc),
       },
     },
   })),
+
+  // The remaining GB300 dynamo-vllm DeepSeek-V4 AgentX points share the
+  // frontend-only scrape described on GB200_DYNAMO_VLLM_CACHE_HIT_RATES. The
+  // three run-31633154542 offload points above carry the same merge.
+  ...(
+    [
+      [31633154542, 2, 2337, 1, 1, null, aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 8)],
+      [31633154542, 2, 2337, 4, 4, null, aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 8)],
+      [31633154542, 2, 2335, 8, 8, null, aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 4)],
+      [
+        32242794988,
+        3,
+        2335,
+        1,
+        1,
+        '8f36ba74ab8eb938802ec15a55f6d316f86e4d3ef2dcd38ff71e566dfa04cb9c',
+        aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 4),
+      ],
+      [
+        32242794988,
+        3,
+        2335,
+        2,
+        1,
+        '8f36ba74ab8eb938802ec15a55f6d316f86e4d3ef2dcd38ff71e566dfa04cb9c',
+        aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 4),
+      ],
+      [
+        32242794988,
+        3,
+        2335,
+        4,
+        4,
+        '8f36ba74ab8eb938802ec15a55f6d316f86e4d3ef2dcd38ff71e566dfa04cb9c',
+        aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 4),
+      ],
+      [
+        32242794988,
+        3,
+        2335,
+        6,
+        4,
+        '8f36ba74ab8eb938802ec15a55f6d316f86e4d3ef2dcd38ff71e566dfa04cb9c',
+        aggregatedMultinodeConfig(DSV4_GB300_DYNAMO_VLLM, 4),
+      ],
+      [
+        32809502132,
+        1,
+        2450,
+        4,
+        4,
+        'ccc45769efa2ef8b519dd47ab99f77ae033bbfba26f499b14d97253a8badce74',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_VLLM,
+          { tp: 1, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 8, ep: 1, dpAttn: false, numWorkers: 4 },
+        ),
+      ],
+      [
+        32809502132,
+        1,
+        2449,
+        128,
+        128,
+        'd84f06bb4a4016f9f2fe917feb4f10b960f87ac5f48bfae1b0bca1d66d7c887b',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_VLLM,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        32809502132,
+        1,
+        2449,
+        256,
+        256,
+        '1472857d464c0780b5eeb41184ff70290c5f6b9ad6a8c07b2524697e21dd0e07',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_VLLM,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        32809502132,
+        1,
+        2448,
+        512,
+        512,
+        '6ab19ba8680ab38b81c0d6a251d252576caafaf660118007c508b1f62df08c39',
+        disaggregatedConfig(
+          DSV4_GB300_DYNAMO_VLLM,
+          { tp: 8, ep: 8, dpAttn: true, numWorkers: 1 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+    ] as const
+  ).map(
+    ([
+      githubRunId,
+      runAttempt,
+      productionConfigId,
+      conc,
+      donorConc,
+      recipeFingerprint,
+      config,
+    ]) => ({
+      id: `run-${githubRunId}-config-${productionConfigId}-conc-${conc}-gb200-cache-hit-rate`,
+      reason: GB300_CACHE_HIT_RATE_REASON,
+      githubRunId,
+      runAttempt,
+      productionConfigId,
+      config,
+      benchmarkType: 'agentic_traces',
+      isl: null,
+      osl: null,
+      conc,
+      offloadMode: 'off',
+      recipeFingerprint,
+      set: {
+        metricsMerge: gb200CacheHitRateMerge(donorConc),
+      },
+    }),
+  ),
 
   // Every TensorRT-LLM recipe in run 31927376673 configures a 128 GiB native
   // host KV cache on both prefill and decode workers. The master matrix only


### PR DESCRIPTION
## Summary

The Token Revenue per GPU Hour Y-axis shows GB300 at roughly **$475/GPU/hr** while B300 sits at about $68. The cause is missing data, not throughput: all 14 GB300 dynamo-vllm DeepSeek-V4 AgentX points (runs 31633154542, 32242794988, 32809502132) have no `server_*_cache_hit_rate` metrics. `measuredCacheHitRate` returns null, pricing treats that as 0 hits, and ~97% cached input tokens get billed at the full input price.

**Why the hit rates are missing.** The GB200 launcher pins srt-slurm v1.0.45 for dsv4 fp4 dynamo-vllm AgentX, which discovers every logical worker's `/metrics` URL and forwards it to AIPerf as `--server-metrics`. The GB300 launcher has no such branch, so dynamo-vllm falls into the generic agentic branch pinned to v1.0.36. Its AIPerf run auto-discovered only the Dynamo frontend at `localhost:8000/metrics`, which exposes no `vllm:prefix_cache_*` counters, so `server_metrics.cache.gpu_cache_hit_rate` landed as null in the artifact.

**Fix.** Borrow the nearest-concurrency GB200 dynamo-vllm measurement (run 31965016666) via `BENCHMARK_POINT_BACKFILLS`:

- Extends the three existing Mooncake offload entries for run 31633154542 (conc 256 → GB200 conc 256, 1024 → 512, 1152 → 576).
- Adds eleven new entries for the remaining aggregated and disaggregated GB300 points (conc 1, 2 → GB200 conc 1; 4, 6 → 4; 8 → 8; 128, 256, 512 → equals).
- Adds a test asserting that any backfill merging a cache hit rate targets only GB300 / dynamo-vllm / dsv4 / `agentic_traces`, so no other hardware can inherit a borrowed rate.

CI applies the ledger to production on merge. Running the real matcher over the 14 rows exported from the production DB confirms each matches exactly one backfill and none is left unmatched. Resulting best GB300 point at $1 in / $0.10 cached / $3 out per million: $76/GPU/hr.

**Not covered here.** The proper upstream fix is a GB300 dsv4 dynamo-vllm launcher branch pinning srt-slurm v1.0.45+ so the sweeps measure their own hit rate; the GB300 artifacts also carry a Dynamo `frontend_cache_hit_rate` (~0.968) that the ETL deliberately does not map. Until then, tooltips display these GB200 values as GB300 measurements; provenance lives in the backfill `reason`.

Overlay support: not applicable. Backfills operate on ingested official rows; `?unofficialrun=` overlays read artifacts directly and are unaffected.

## Test plan

- [x] `bunx vitest run` in `packages/db` — 51 files, 628 tests pass
- [x] `bun run typecheck`, oxlint, oxfmt clean (pre-commit hook)
- [x] Offline simulation of `applyBenchmarkPointBackfill` against the 14 production rows: 14/14 matched, 0 unmatched backfills

## 中文说明

Token Revenue per GPU Hour 的 Y 轴上 GB300 约为 **$475/GPU/hr**，而 B300 约为 $68。原因不是吞吐量，而是数据缺失：GB300 dynamo-vllm DeepSeek-V4 AgentX 的 14 个数据点（运行 31633154542、32242794988、32809502132）都没有 `server_*_cache_hit_rate` 指标。`measuredCacheHitRate` 返回 null，定价逻辑按 0 命中处理，约 97% 的缓存输入 token 被按全价计费。

**命中率缺失的原因。** GB200 启动脚本为 dsv4 fp4 dynamo-vllm AgentX 固定使用 srt-slurm v1.0.45，会发现每个逻辑 worker 的 `/metrics` 地址并通过 `--server-metrics` 传给 AIPerf。GB300 启动脚本没有对应分支，dynamo-vllm 回落到固定 v1.0.36 的通用 agentic 分支，AIPerf 只自动发现了 `localhost:8000/metrics` 的 Dynamo 前端，该端点不暴露 `vllm:prefix_cache_*` 计数器，因此产物中的 `server_metrics.cache.gpu_cache_hit_rate` 为 null。

**修复方式。** 通过 `BENCHMARK_POINT_BACKFILLS` 借用最近并发度的 GB200 dynamo-vllm 实测值（运行 31965016666）：

- 扩展运行 31633154542 已有的三条 Mooncake offload 回填（conc 256 → GB200 conc 256，1024 → 512，1152 → 576）。
- 为其余 11 个聚合及分离式 GB300 数据点新增回填（conc 1、2 → GB200 conc 1；4、6 → 4；8 → 8；128、256、512 → 相同并发度）。
- 新增测试，确保任何合并缓存命中率的回填只针对 GB300 / dynamo-vllm / dsv4 / `agentic_traces`，其他硬件不会继承借用的命中率。

合并后 CI 会将回填账本应用到生产库。用生产库导出的 14 行数据离线运行真实匹配逻辑，每行恰好匹配一条回填，无遗漏。修复后 GB300 最佳点（输入 $1 / 缓存 $0.10 / 输出 $3 每百万 token）约为 $76/GPU/hr。

**本 PR 未覆盖。** 根本修复应在上游为 GB300 dsv4 dynamo-vllm 增加固定 srt-slurm v1.0.45+ 的启动分支，让 sweep 自行测量命中率；GB300 产物中也有 Dynamo 的 `frontend_cache_hit_rate`（约 0.968），ETL 目前有意未映射。在此之前，tooltip 会把这些 GB200 数值显示为 GB300 的测量值，来源记录在回填的 `reason` 字段中。

不涉及 `?unofficialrun=` overlay：回填只作用于已入库的官方数据行，overlay 直接读取产物，不受影响。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production benchmark metrics and cache-aware pricing for 14 GB300 points via ETL backfills; values are borrowed from GB200, not re-measured on GB300.
> 
> **Overview**
> Fixes inflated **Token Revenue per GPU Hour** for GB300 dynamo-vllm DeepSeek-V4 AgentX points where `server_*_cache_hit_rate` was null because AIPerf only scraped the Dynamo frontend (no vLLM prefix-cache counters). Pricing treated missing rates as zero cache hits.
> 
> **`BENCHMARK_POINT_BACKFILLS`** now merges GPU/external/CPU hit rates from measured GB200 dynamo-vllm run 31965016666, keyed by nearest donor concurrency. The three existing run 31633154542 Mooncake offload entries gain a `donorConc` column and the same merge; **11 new** backfills cover the remaining GB300 AgentX rows across runs 31633154542, 32242794988, and 32809502132. Helpers include `DSV4_GB300_DYNAMO_VLLM`, `aggregatedMultinodeConfig`, `GB200_DYNAMO_VLLM_CACHE_HIT_RATES`, and `gb200CacheHitRateMerge`.
> 
> A registry test asserts **exactly 14** backfills borrow cache hit rates and that they target only **gb300 / dynamo-vllm / dsv4 / agentic_traces** with valid \[0, 1\] values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df65ccb4d9c6c6926679756ba6826f7cc448424b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->