### PR TITLE
fix(legend): remove the FP4/FP8 precision shape key from the chart legend / 移除图例中的 FP4/FP8 精度形状说明

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -1561,7 +1561,6 @@ const GPUGraph = React.memo(
                 },
               },
             ]}
-            precisionIndicators={selectedPrecisions}
             hideAtomFootnote
             keyIndicators={
               <>

--- a/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
+++ b/packages/app/src/components/trends/HistoricalTrendsDisplay.tsx
@@ -500,7 +500,6 @@ export default function HistoricalTrendsDisplay() {
                         : []
                     }
                     enableTooltips={true}
-                    precisionIndicators={selectedPrecisions}
                   />
                 }
               />

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -1,29 +1,11 @@
 'use client';
 
-import {
-  ChevronDown,
-  ChevronRight,
-  Circle,
-  Diamond,
-  PanelRightClose,
-  PanelRightOpen,
-  Square,
-  Triangle,
-} from 'lucide-react';
+import { ChevronDown, ChevronRight, PanelRightClose, PanelRightOpen } from 'lucide-react';
 import React, { useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-import { SHAPE_ORDER, type ShapeKey, getShapeKeyForPrecision } from '@/lib/chart-rendering';
-import { type Precision, getPrecisionLabel } from '@/lib/data-mappings';
 import { filterAndSortLegendItems } from '@/lib/legend-utils';
 import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
-
-const SHAPE_ICON: Record<ShapeKey, React.ComponentType<{ size?: number; className?: string }>> = {
-  circle: Circle,
-  square: Square,
-  triangle: Triangle,
-  diamond: Diamond,
-};
 
 import { ATOM_FOOTNOTE_MARKER, AtomEngineFootnote } from './atom-engine-footnote';
 import ChartLegendItem, { type CommonLegendItemProps } from './chart-legend-item';
@@ -76,14 +58,7 @@ export interface ChartLegendProps {
   switches?: LegendSwitchConfig[];
   actions?: LegendActionConfig[];
   grouped?: boolean;
-  /**
-   * Selected precisions, in selection order. When 2+ are provided, the legend
-   * renders a shape key: first precision → circle, second → square, third →
-   * triangle, fourth → diamond. Only the selected precisions are listed.
-   * A single precision (or none) hides the shape key entirely.
-   */
-  precisionIndicators?: readonly string[];
-  /** Optional extra key/legend explanation rendered alongside the FP indicators. */
+  /** Optional extra key/legend explanation rendered below the display switches. */
   keyIndicators?: React.ReactNode;
   enableTooltips?: boolean;
   maxHeight?: number;
@@ -110,7 +85,6 @@ export default function ChartLegend({
   switches,
   actions,
   grouped = false,
-  precisionIndicators,
   keyIndicators,
   enableTooltips = false,
   maxHeight,
@@ -220,20 +194,8 @@ export default function ChartLegend({
     [legendItems, hideAtomFootnote],
   );
 
-  const shapeIndicators = useMemo(() => {
-    if (!precisionIndicators || precisionIndicators.length < 2) return null;
-    return precisionIndicators.slice(0, SHAPE_ORDER.length).map((precision) => ({
-      precision,
-      shapeKey: getShapeKeyForPrecision(precision, precisionIndicators),
-    }));
-  }, [precisionIndicators]);
-
   const hasSidebarControls =
-    isSidebar &&
-    (shapeIndicators !== null ||
-      keyIndicators ||
-      (switches && switches.length > 0) ||
-      hasAtomFootnote);
+    isSidebar && (keyIndicators || (switches && switches.length > 0) || hasAtomFootnote);
   const scrollClasses = isSidebar
     ? cn(
         'overflow-y-auto flex-initial min-h-0 space-y-0.5',
@@ -368,27 +330,6 @@ export default function ChartLegend({
       </div>
     ) : null;
 
-  const fpIndicators = shapeIndicators ? (
-    <div
-      className={cn(
-        'w-full md:w-auto mt-2 px-1 pr-2 gap-x-4 gap-y-1',
-        itemsExpanded ? 'flex flex-wrap' : 'grid grid-cols-2',
-      )}
-    >
-      {shapeIndicators.map(({ precision, shapeKey }) => {
-        const Icon = SHAPE_ICON[shapeKey];
-        return (
-          <div key={precision} className="flex items-center gap-2">
-            <Icon size={12} className="inline-block fill-gray-500" />
-            <span className="text-xs text-muted-foreground">
-              {getPrecisionLabel(precision as Precision)}
-            </span>
-          </div>
-        );
-      })}
-    </div>
-  ) : null;
-
   // Compute li className for a legend item (shared by tooltip and non-tooltip paths)
   const itemClassName = (item: CommonLegendItemProps) =>
     cn(
@@ -453,11 +394,7 @@ export default function ChartLegend({
   // Display controls stay immediately below the series instead of being
   // pushed to the bottom of a chart-height panel. Overlay actions stay here.
   const hasBottomControls =
-    switchElements ||
-    (!isSidebar && actionElements) ||
-    fpIndicators ||
-    keyIndicators ||
-    hasAtomFootnote;
+    switchElements || (!isSidebar && actionElements) || keyIndicators || hasAtomFootnote;
   const bottomControls = hasBottomControls ? (
     <div
       data-testid="legend-display-controls"
@@ -466,7 +403,6 @@ export default function ChartLegend({
     >
       {!isSidebar && actionElements}
       {switchElements}
-      {fpIndicators}
       {keyIndicators}
       {hasAtomFootnote && <AtomEngineFootnote className="mt-2 no-export" />}
     </div>


### PR DESCRIPTION
## Summary

Removes the precision shape key (circle FP4, square FP8, …) that rendered in the chart legend under the Advanced toggle whenever two or more precisions were selected.

- Drop `fpIndicators` / `shapeIndicators` and the `SHAPE_ICON` map from `chart-legend.tsx`, plus the now-unused lucide and `chart-rendering` / `data-mappings` imports.
- Remove the `precisionIndicators` prop from `ChartLegendProps` and its two call sites (`GPUGraph.tsx`, `HistoricalTrendsDisplay.tsx`).
- Scatter-point shape encoding per precision is untouched; only the legend key row is gone.

## Checks

- `bun run typecheck`, `bun run lint`, `oxfmt --check` all pass locally.
- No unit or Cypress tests referenced the legend shape key.

## 中文说明

移除图表图例中的精度形状说明行（圆形 FP4、方形 FP8 等）。此前当选择两种及以上精度时，该行会显示在 Advanced 开关下方。

- 从 `chart-legend.tsx` 中删除 `fpIndicators` / `shapeIndicators` 与 `SHAPE_ICON`，以及不再使用的 lucide、`chart-rendering`、`data-mappings` 导入。
- 从 `ChartLegendProps` 中移除 `precisionIndicators` 属性，并同步删除 `GPUGraph.tsx` 与 `HistoricalTrendsDisplay.tsx` 中的两处调用。
- 散点图本身按精度区分的形状编码保持不变，仅移除图例中的说明行。

本地 `bun run typecheck`、`bun run lint`、`oxfmt --check` 均通过；没有单元测试或 Cypress 测试引用该图例形状说明。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Legend-only UI removal with no changes to chart rendering, filters, or data paths.
> 
> **Overview**
> Removes the **precision shape key** from shared `ChartLegend` (circle/square/triangle/diamond labels for FP4, FP8, etc.) that appeared under display switches when two or more precisions were selected.
> 
> **`chart-legend.tsx`** drops the `precisionIndicators` prop, `shapeIndicators` / `fpIndicators` rendering, and related lucide icons plus `chart-rendering` / `data-mappings` imports. Sidebar bottom controls no longer treat that block as part of the panel.
> 
> **`GPUGraph.tsx`** and **`HistoricalTrendsDisplay.tsx`** stop passing `selectedPrecisions` into the legend. Charts still encode precision on scatter points and tooltips via `getShapeKeyForPrecision`; only the redundant legend explanation row is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad5208fc07fef4cec641098cb8d282dd8472e7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->