### PR TITLE
feat(export): watermark SemiAnalysis logo behind PNG chart exports / PNG 图表导出背景添加 SemiAnalysis logo 水印

### DIFF
--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it } from 'vitest';
 import {
   getExportCaptureDimensions,
   getExportFontFamily,
+  getLogoWatermarkLayout,
+  getLogoWatermarkOpacity,
+  getLogoWatermarkSrc,
   normalizeChartSvgWidthsForExport,
 } from './useChartExport';
 
@@ -74,5 +77,38 @@ describe('normalizeChartSvgWidthsForExport', () => {
     expect(root.querySelector<SVGElement>('svg[data-testid="legend-info-icon"]')?.style.width).toBe(
       '14px',
     );
+  });
+});
+
+describe('logo watermark', () => {
+  it('uses the white logo on dark themes and the color logo on light themes', () => {
+    expect(getLogoWatermarkSrc(true)).toBe('/brand/logo-white.png');
+    expect(getLogoWatermarkSrc(false)).toBe('/brand/logo-color.png');
+  });
+
+  it('keeps the logo faint so plotted data stays legible', () => {
+    expect(getLogoWatermarkOpacity(false)).toBeLessThan(0.15);
+    expect(getLogoWatermarkOpacity(true)).toBeLessThan(0.15);
+  });
+
+  it('centers the logo and caps its width for wide captures', () => {
+    const layout = getLogoWatermarkLayout(
+      { width: 2000, height: 1200 },
+      { width: 1920, height: 825 },
+    );
+    // Width-bound: 60% of 2000 = 1200 wide, aspect preserved
+    expect(layout.width).toBe(1200);
+    expect(layout.height).toBe(Math.round(825 * (1200 / 1920)));
+    expect(layout.x).toBe((2000 - layout.width) / 2);
+    expect(layout.y).toBe(Math.round((1200 - layout.height) / 2));
+  });
+
+  it('caps the logo height for tall, narrow captures', () => {
+    const layout = getLogoWatermarkLayout(
+      { width: 800, height: 600 },
+      { width: 1000, height: 1000 },
+    );
+    // Height-bound: 60% of 600 = 360 tall square logo
+    expect(layout).toEqual({ x: 220, y: 120, width: 360, height: 360 });
   });
 });

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -198,52 +198,113 @@ function watermarkFont(size: number): string {
   return `bold ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
 }
 
-/** Add a subtle watermark bar at the bottom of the exported image */
-function addWatermark(dataUrl: string, bgColor: string): Promise<string> {
+/** Fraction of the chart capture the background logo may span (width and height). */
+const LOGO_WATERMARK_MAX_FRACTION = 0.6;
+
+/** Public path of the SemiAnalysis logo to tile behind the chart, per theme. */
+export function getLogoWatermarkSrc(isDark: boolean): string {
+  return isDark ? '/brand/logo-white.png' : '/brand/logo-color.png';
+}
+
+/** Opacity of the background logo, per theme (kept faint so data stays legible). */
+export function getLogoWatermarkOpacity(isDark: boolean): number {
+  return isDark ? 0.09 : 0.08;
+}
+
+/**
+ * Fit the logo inside the chart capture, centered, preserving aspect ratio and
+ * capped to a fraction of the capture so it reads as a background mark rather
+ * than a foreground element.
+ */
+export function getLogoWatermarkLayout(
+  capture: { width: number; height: number },
+  logo: { width: number; height: number },
+): { x: number; y: number; width: number; height: number } {
+  const maxWidth = capture.width * LOGO_WATERMARK_MAX_FRACTION;
+  const maxHeight = capture.height * LOGO_WATERMARK_MAX_FRACTION;
+  const scale = Math.min(maxWidth / logo.width, maxHeight / logo.height);
+  const width = Math.round(logo.width * scale);
+  const height = Math.round(logo.height * scale);
+  return {
+    x: Math.round((capture.width - width) / 2),
+    y: Math.round((capture.height - height) / 2),
+    width,
+    height,
+  };
+}
+
+function loadImage(src: string): Promise<HTMLImageElement | null> {
   return new Promise((resolve) => {
     const img = new Image();
-    img.addEventListener('load', () => {
-      const WATERMARK_HEIGHT = 240;
-      const canvas = document.createElement('canvas');
-      canvas.width = img.width;
-      canvas.height = img.height + WATERMARK_HEIGHT;
-      const ctx = canvas.getContext('2d');
-      if (!ctx) {
-        resolve(dataUrl);
-        return;
-      }
-
-      // Draw original image
-      ctx.drawImage(img, 0, 0);
-
-      // Draw watermark bar
-      const isDark =
-        document.documentElement.classList.contains('dark') ||
-        document.documentElement.classList.contains('minecraft') ||
-        bgColor.includes('0 0%');
-      ctx.fillStyle = isDark ? '#1a1a2e' : '#f5f5f5';
-      ctx.fillRect(0, img.height, canvas.width, WATERMARK_HEIGHT);
-
-      // Draw watermark text (shrink to fit on narrow exports)
-      const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
-      let fontSize = 80;
-      ctx.font = watermarkFont(fontSize);
-      const maxTextWidth = canvas.width - 48;
-      const textWidth = ctx.measureText(WATERMARK_TEXT).width;
-      if (textWidth > maxTextWidth) {
-        fontSize = Math.max(16, Math.floor((fontSize * maxTextWidth) / textWidth));
-        ctx.font = watermarkFont(fontSize);
-      }
-      ctx.fillStyle = isDark ? '#aaa' : '#555';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(WATERMARK_TEXT, canvas.width / 2, img.height + WATERMARK_HEIGHT / 2);
-
-      resolve(canvas.toDataURL('image/png'));
-    });
-    img.addEventListener('error', () => resolve(dataUrl));
-    img.src = dataUrl;
+    img.addEventListener('load', () => resolve(img));
+    img.addEventListener('error', () => resolve(null));
+    img.src = src;
   });
+}
+
+/**
+ * Compose the final export: theme background, a faint SemiAnalysis logo
+ * behind the chart, the (transparent) chart capture on top, and the branded
+ * footer bar. The chart is captured without a background so the logo really
+ * sits behind the plot instead of tinting the data on top.
+ */
+async function addWatermark(chartDataUrl: string, bgColor: string): Promise<string> {
+  const img = await loadImage(chartDataUrl);
+  if (!img) return chartDataUrl;
+
+  const isDark =
+    document.documentElement.classList.contains('dark') ||
+    document.documentElement.classList.contains('minecraft') ||
+    bgColor.includes('0 0%');
+
+  const WATERMARK_HEIGHT = 240;
+  const canvas = document.createElement('canvas');
+  canvas.width = img.width;
+  canvas.height = img.height + WATERMARK_HEIGHT;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return chartDataUrl;
+
+  // Solid theme background (the chart capture itself is transparent)
+  ctx.fillStyle = bgColor || (isDark ? '#131416' : '#eaebec');
+  ctx.fillRect(0, 0, canvas.width, img.height);
+
+  // Faint SemiAnalysis logo centered behind the chart. Skip silently if the
+  // asset fails to load so export never blocks on branding.
+  const logo = await loadImage(getLogoWatermarkSrc(isDark));
+  if (logo && logo.naturalWidth > 0 && logo.naturalHeight > 0) {
+    const layout = getLogoWatermarkLayout(
+      { width: img.width, height: img.height },
+      { width: logo.naturalWidth, height: logo.naturalHeight },
+    );
+    ctx.save();
+    ctx.globalAlpha = getLogoWatermarkOpacity(isDark);
+    ctx.drawImage(logo, layout.x, layout.y, layout.width, layout.height);
+    ctx.restore();
+  }
+
+  // Draw chart capture over the background + logo
+  ctx.drawImage(img, 0, 0);
+
+  // Draw watermark bar
+  ctx.fillStyle = isDark ? '#1a1a2e' : '#f5f5f5';
+  ctx.fillRect(0, img.height, canvas.width, WATERMARK_HEIGHT);
+
+  // Draw watermark text (shrink to fit on narrow exports)
+  const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
+  let fontSize = 80;
+  ctx.font = watermarkFont(fontSize);
+  const maxTextWidth = canvas.width - 48;
+  const textWidth = ctx.measureText(WATERMARK_TEXT).width;
+  if (textWidth > maxTextWidth) {
+    fontSize = Math.max(16, Math.floor((fontSize * maxTextWidth) / textWidth));
+    ctx.font = watermarkFont(fontSize);
+  }
+  ctx.fillStyle = isDark ? '#aaa' : '#555';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(WATERMARK_TEXT, canvas.width / 2, img.height + WATERMARK_HEIGHT / 2);
+
+  return canvas.toDataURL('image/png');
 }
 
 /**
@@ -465,11 +526,12 @@ export function useChartExport({
         }
       }
       const captureDimensions = getExportCaptureDimensions(exportElement);
+      // Capture without a background: addWatermark paints the theme background
+      // and the SemiAnalysis logo underneath, then layers this capture on top.
       const chartDataUrl = await toPng(exportElement, {
         ...captureDimensions,
         quality: 1,
         pixelRatio: 2,
-        backgroundColor: bgColor,
         cacheBust: true,
         skipFonts: false,
         fontEmbedCSS,
@@ -481,7 +543,7 @@ export function useChartExport({
         },
       });
 
-      // Add watermark with InferenceX branding
+      // Compose background + SemiAnalysis logo watermark + chart + footer bar
       const dataUrl = await addWatermark(chartDataUrl, bgColor);
 
       const link = document.createElement('a');


### PR DESCRIPTION
## Summary

When a chart is exported as PNG, the SemiAnalysis logo is now watermarked faintly in the background of the chart area (the existing `InferenceX — github.com/SemiAnalysisAI/InferenceX` footer bar is unchanged).

- `toPng` now captures the chart **without** a background color so the capture is transparent.
- `addWatermark` composes the final image on canvas in order: theme background → centered SemiAnalysis logo at low opacity (≤60% of the capture's width/height, aspect preserved) → chart capture → footer bar. Because the logo is drawn *under* the chart, it does not tint data points, lines or text.
- Light theme uses `/brand/logo-color.png` at 8% opacity; dark/Minecraft themes use `/brand/logo-white.png` at 9%.
- If the logo asset fails to load, the export continues without it (never blocks the download).
- New exported helpers `getLogoWatermarkSrc`, `getLogoWatermarkOpacity`, `getLogoWatermarkLayout` with unit tests in `useChartExport.test.ts`.

## Test plan

- [x] `bun run lint`, `bun run fmt`, `tsc --noEmit` clean
- [x] `vitest run src/hooks/useChartExport.test.ts` — 9 passed
- [x] Visually verified the compose step (light + dark) against a synthetic transparent chart capture: logo sits behind grid/data, footer bar unchanged
- [ ] Manual: export a PNG from the inference dashboard in light and dark mode and confirm the logo appears behind the plot

## 中文说明

导出图表为 PNG 时，现在会在图表区域的背景中淡淡地叠加 SemiAnalysis logo 水印（原有的 `InferenceX — github.com/SemiAnalysisAI/InferenceX` 底部信息栏保持不变）。

- `toPng` 现在以透明背景截取图表。
- `addWatermark` 在 canvas 上按以下顺序合成最终图片：主题背景 → 居中、低透明度的 SemiAnalysis logo（最大不超过截图宽高的 60%，保持比例）→ 图表截图 → 底部信息栏。由于 logo 绘制在图表**下方**，不会影响数据点、曲线和文字的颜色。
- 浅色主题使用 `/brand/logo-color.png`（8% 透明度）；深色 / Minecraft 主题使用 `/brand/logo-white.png`（9%）。
- 若 logo 资源加载失败，导出会跳过 logo 正常继续，不会阻塞下载。
- 新增导出的辅助函数 `getLogoWatermarkSrc`、`getLogoWatermarkOpacity`、`getLogoWatermarkLayout`，并在 `useChartExport.test.ts` 中补充单元测试。

测试：lint / fmt / typecheck 通过，单元测试 9 个全部通过；已用合成的透明图表截图在浅色和深色主题下目视验证合成效果。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to client-side PNG export composition in `useChartExport`; no auth, API, or data-path impact, with graceful fallback if logo assets fail to load.
> 
> **Overview**
> PNG chart exports now show a **faint, centered SemiAnalysis logo** in the plot area while keeping the existing **InferenceX** footer bar.
> 
> The export pipeline changes so **`toPng` captures the chart with a transparent background** (no `backgroundColor`). **`addWatermark`** is refactored to an async canvas compose step: solid theme background → low-opacity logo (theme-specific asset and ~8–9% opacity, sized up to **60%** of the capture, aspect preserved) → chart layer → footer. Logo loading failures are ignored so downloads still complete.
> 
> New testable helpers—**`getLogoWatermarkSrc`**, **`getLogoWatermarkOpacity`**, **`getLogoWatermarkLayout`**—back the layout logic; **`useChartExport.test.ts`** adds unit coverage for theme assets, opacity, and wide vs tall captures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d3b629c2d1da5cc8cb2eef4966ce99310ff38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->