### PR TITLE
fix(chart): keep point labels inside the plot bounding box / 图表点标签严格限制在绘图区域内

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -94,6 +94,7 @@ import {
   MeasuredPowerSummary,
 } from '@/components/inference/ui/MeasuredPowerSummary';
 import {
+  keepPointLabelsInPlot,
   parallelismLabelBoxes,
   placeLineLabels,
   renderLineLabels,
@@ -1268,6 +1269,8 @@ const GPUGraph = React.memo(
                 d3.axisLeft(newYScale).ticks(10).tickFormat(logTickFormat(newYScale)) as any,
               );
             }
+            // Zoom moves points toward the plot edges; keep their labels inside.
+            if (showPointLabels) keepPointLabelsInPlot(ctx.layout.zoomGroup);
           },
         }}
         tooltip={{
@@ -1372,6 +1375,12 @@ const GPUGraph = React.memo(
           },
           attachToLayer: 1,
         }}
+        onDisplayUpdate={(ctx: RenderContext) => {
+          // Point labels are laid out only while visible (a hidden label has
+          // no measurable box), so re-run the plot-bounds constraint once the
+          // display phase has turned them back on.
+          if (showPointLabels) keepPointLabelsInPlot(ctx.layout.zoomGroup);
+        }}
         onRender={(ctx: RenderContext) => {
           // Remembered so the perf-ruler effect can redraw against the same
           // layout and scales the chart was last drawn with.
@@ -1388,6 +1397,9 @@ const GPUGraph = React.memo(
           }
           // Set foreground color on scatter point labels
           ctx.layout.zoomGroup.selectAll('.point-label').style('fill', 'var(--foreground)');
+          // Strict plot bounding box: a label that would be sliced by the clip
+          // path flips to the other side of its point or slides inward.
+          if (showPointLabels) keepPointLabelsInPlot(ctx.layout.zoomGroup);
 
           // CSS transitions for smooth opacity animation on legend hover —
           // the hover handlers write opacity once and let these animate.

--- a/packages/app/src/components/inference/ui/line-label-layer.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   firstNonCollidingRect,
+  fitsVertically,
+  horizontalShiftIntoBounds,
   placeLineLabels,
   rectsOverlap,
   type LineLabelSeries,
@@ -44,6 +46,38 @@ describe('line-label collision primitives', () => {
     ];
 
     expect(firstNonCollidingRect(candidates, placed)).toBeNull();
+  });
+});
+
+describe('point-label plot bounding box primitives', () => {
+  const plot = { left: 0, right: 100, top: 0, bottom: 50 };
+
+  it('needs no shift when the rect already sits inside the plot', () => {
+    expect(horizontalShiftIntoBounds({ left: 10, right: 40, top: 5, bottom: 15 }, plot)).toBe(0);
+  });
+
+  it('slides a rect that spills past the left edge back inside', () => {
+    expect(horizontalShiftIntoBounds({ left: -8, right: 22, top: 5, bottom: 15 }, plot)).toBe(8);
+  });
+
+  it('slides a rect that spills past the right edge back inside', () => {
+    expect(horizontalShiftIntoBounds({ left: 90, right: 115, top: 5, bottom: 15 }, plot)).toBe(-15);
+  });
+
+  it('gives up on a rect wider than the plot', () => {
+    expect(horizontalShiftIntoBounds({ left: -10, right: 120, top: 5, bottom: 15 }, plot)).toBe(
+      null,
+    );
+  });
+
+  it('accepts a rect touching the plot edges as fitting', () => {
+    expect(horizontalShiftIntoBounds({ left: 0, right: 100, top: 0, bottom: 50 }, plot)).toBe(0);
+    expect(fitsVertically({ left: 0, right: 100, top: 0, bottom: 50 }, plot)).toBe(true);
+  });
+
+  it('rejects any vertical overflow, however small', () => {
+    expect(fitsVertically({ left: 10, right: 20, top: -0.5, bottom: 10 }, plot)).toBe(false);
+    expect(fitsVertically({ left: 10, right: 20, top: 40, bottom: 50.5 }, plot)).toBe(false);
   });
 });
 

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -397,6 +397,13 @@ export function updateRenderedLineLabels(
   });
 }
 
+/**
+ * Marks a `.point-label` that {@link placePointLabels} hid because no slot fit
+ * (as opposed to one hidden by the label toggle or a legend hover), so the
+ * next pass knows it may un-hide it.
+ */
+export const PLACEMENT_HIDDEN_ATTR = 'data-placement-hidden';
+
 export interface PointLabelPlacementOptions {
   /**
    * Strict bounding box, in zoom-group coordinates, that every label must lie
@@ -446,8 +453,16 @@ export function placePointLabels(
 
   zoomGroup.selectAll<SVGGElement, unknown>('.dot-group').each(function () {
     const label = this.querySelector<SVGTextElement>('.point-label');
+    if (!label) return;
+    // A label this pass hid on an earlier frame (no slot fit, or its point had
+    // left the plot) is only provisionally hidden: give it back its opacity so
+    // it is reconsidered now that the layout may have changed. Labels hidden
+    // for any other reason (toggle off, legend hover, faded series) stay put.
+    if (label.hasAttribute(PLACEMENT_HIDDEN_ATTR)) {
+      label.removeAttribute(PLACEMENT_HIDDEN_ATTR);
+      label.style.opacity = '1';
+    }
     if (
-      !label ||
       label.style.display === 'none' ||
       label.style.visibility === 'hidden' ||
       label.style.opacity === '0' ||
@@ -529,6 +544,7 @@ export function placePointLabels(
         : null;
     if (index === null) {
       label.element.style.opacity = '0';
+      label.element.setAttribute(PLACEMENT_HIDDEN_ATTR, '');
       continue;
     }
     const chosen = candidates[index];

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -1,6 +1,7 @@
 import * as d3 from 'd3';
 
 import { pointNearestX } from '@/components/inference/ui/line-label-anchor';
+import { plotClipSize } from '@/lib/d3-chart/plot-bounds';
 
 export interface CartesianPoint {
   x: number;
@@ -45,6 +46,37 @@ export function firstNonCollidingRect(
     if (!placed.some((other) => rectsOverlap(candidates[i], other))) return i;
   }
   return null;
+}
+
+/**
+ * Horizontal shift that slides `rect` fully inside `bounds`, or `null` when it
+ * is wider than the bounds and cannot fit at any offset. Zero when it already
+ * fits; positive moves right, negative moves left.
+ */
+export function horizontalShiftIntoBounds(rect: RectBounds, bounds: RectBounds): number | null {
+  if (rect.right - rect.left > bounds.right - bounds.left) return null;
+  if (rect.left < bounds.left) return bounds.left - rect.left;
+  if (rect.right > bounds.right) return bounds.right - rect.right;
+  return 0;
+}
+
+/** Whether `rect` lies fully inside `bounds` on the vertical axis. */
+export function fitsVertically(rect: RectBounds, bounds: RectBounds): boolean {
+  return rect.top >= bounds.top && rect.bottom <= bounds.bottom;
+}
+
+/**
+ * The plot area in zoom-group coordinates — the strict bounding box every
+ * point label must stay inside. Read from the clip rect `setupChart` puts on
+ * the zoom group; `null` for charts that do not clip (`clipContent: false`),
+ * where nothing is painted away and no constraint applies.
+ */
+export function plotAreaBounds(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+): RectBounds | null {
+  const node = zoomGroup.node();
+  const size = node ? plotClipSize(node) : null;
+  return size ? { left: 0, top: 0, right: size.width, bottom: size.height } : null;
 }
 
 /** A drawn pill box, as centre point + half-width, for overlap tests. */
@@ -365,12 +397,41 @@ export function updateRenderedLineLabels(
   });
 }
 
-export function avoidPointLabelCollisions(
+export interface PointLabelPlacementOptions {
+  /**
+   * Strict bounding box, in zoom-group coordinates, that every label must lie
+   * fully inside. Defaults to the plot's clip rect ({@link plotAreaBounds});
+   * pass `null` to skip the constraint (charts that clip nothing).
+   */
+  bounds?: RectBounds | null;
+  /**
+   * Whether labels also avoid each other and the run-name / parallelism pills.
+   * The single-run scatter keeps this on; the compare chart only needs the
+   * bounding box.
+   */
+  avoidCollisions?: boolean;
+}
+
+/**
+ * Lay out every visible `.point-label` inside `zoomGroup`.
+ *
+ * Each label tries a fixed ladder of vertical slots around its point (above,
+ * below, further above, further below). A slot is only eligible when the label
+ * fits inside `bounds` — sliding horizontally as far as needed to stay inside,
+ * so labels near the left/right edge hug the edge instead of spilling past
+ * it — and, with `avoidCollisions`, when it overlaps nothing placed so far.
+ * A label with no eligible slot is hidden rather than drawn partly outside
+ * the plot: the clip path would otherwise slice it in half.
+ */
+export function placePointLabels(
   zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  options: PointLabelPlacementOptions = {},
 ): void {
+  const bounds = options.bounds === undefined ? plotAreaBounds(zoomGroup) : options.bounds;
+  const avoidCollisions = options.avoidCollisions ?? true;
   interface LabelInfo {
     element: SVGTextElement;
-    firstTspan: SVGTSpanElement;
+    tspans: SVGTSpanElement[];
     centerX: number;
     centerY: number;
     width: number;
@@ -394,18 +455,21 @@ export function avoidPointLabelCollisions(
     ) {
       return;
     }
-    const tspans = label.querySelectorAll<SVGTSpanElement>('tspan');
+    const tspans = [...label.querySelectorAll<SVGTSpanElement>('tspan')];
     if (tspans.length === 0) return;
     const transform = this.getAttribute('transform') ?? '';
     const match = transform.match(/translate\((?<tx>[^,]+),(?<ty>[^)]+)\)/u);
     if (!match) return;
     const lineCount = tspans.length;
     const defaultFirstY = -(8 + (lineCount - 1) * lineHeight);
+    // Reset to the centred default before measuring so a shift applied on a
+    // previous pass does not leak into this one.
     tspans[0].setAttribute('dy', `${defaultFirstY}px`);
+    for (const tspan of tspans) tspan.setAttribute('x', '0');
     label.style.opacity = '1';
     pending.push({
       element: label,
-      firstTspan: tspans[0],
+      tspans,
       centerX: Number.parseFloat(match[1]),
       centerY: Number.parseFloat(match[2]),
       lineCount,
@@ -422,7 +486,7 @@ export function avoidPointLabelCollisions(
   // sit underneath one is pushed to its next candidate slot (or hidden) rather
   // than being drawn through it. Point-label-vs-point-label behaviour below is
   // unchanged; the pills simply occupy space before the first label is placed.
-  const placed: RectBounds[] = pillObstacles(zoomGroup);
+  const placed: RectBounds[] = avoidCollisions ? pillObstacles(zoomGroup) : [];
 
   for (const label of labels) {
     const blockHeight = (label.lineCount - 1) * lineHeight + ascent + descent;
@@ -432,19 +496,70 @@ export function avoidPointLabelCollisions(
       label.defaultFirstY - blockHeight - 2,
       14 + blockHeight + 2,
     ];
-    const boxes = firstBaselines.map((firstY) => ({
-      left: label.centerX - label.width / 2 - padding,
-      right: label.centerX + label.width / 2 + padding,
-      top: label.centerY + firstY - ascent - padding,
-      bottom: label.centerY + firstY + (label.lineCount - 1) * lineHeight + descent + padding,
-    }));
-    const index = firstNonCollidingRect(boxes, placed);
+    const candidates: { firstY: number; dx: number; box: RectBounds }[] = [];
+    for (const firstY of firstBaselines) {
+      const box: RectBounds = {
+        left: label.centerX - label.width / 2 - padding,
+        right: label.centerX + label.width / 2 + padding,
+        top: label.centerY + firstY - ascent - padding,
+        bottom: label.centerY + firstY + (label.lineCount - 1) * lineHeight + descent + padding,
+      };
+      let dx = 0;
+      if (bounds) {
+        // The bounding box is strict: a slot that would leave any part of the
+        // label outside the plot is not a slot at all.
+        if (!fitsVertically(box, bounds)) continue;
+        const shift = horizontalShiftIntoBounds(box, bounds);
+        if (shift === null) continue;
+        dx = shift;
+      }
+      candidates.push({
+        firstY,
+        dx,
+        box: { left: box.left + dx, right: box.right + dx, top: box.top, bottom: box.bottom },
+      });
+    }
+    const index = avoidCollisions
+      ? firstNonCollidingRect(
+          candidates.map((candidate) => candidate.box),
+          placed,
+        )
+      : candidates.length > 0
+        ? 0
+        : null;
     if (index === null) {
       label.element.style.opacity = '0';
       continue;
     }
-    label.firstTspan.setAttribute('dy', `${firstBaselines[index]}px`);
+    const chosen = candidates[index];
+    label.tspans[0].setAttribute('dy', `${chosen.firstY}px`);
+    if (chosen.dx !== 0) {
+      for (const tspan of label.tspans) tspan.setAttribute('x', String(chosen.dx));
+    }
     label.element.style.opacity = '1';
-    placed.push(boxes[index]);
+    if (avoidCollisions) placed.push(chosen.box);
   }
+}
+
+/**
+ * Point-label layout for the single-run scatter: strict plot bounding box
+ * plus collision avoidance against other labels and the drawn pills.
+ */
+export function avoidPointLabelCollisions(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  bounds?: RectBounds | null,
+): void {
+  placePointLabels(zoomGroup, { bounds, avoidCollisions: true });
+}
+
+/**
+ * Point-label layout for charts without collision avoidance (the GPU compare
+ * chart): only the strict plot bounding box is enforced, so a label at the
+ * top edge flips below its point and one at a side edge slides inward.
+ */
+export function keepPointLabelsInPlot(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  bounds?: RectBounds | null,
+): void {
+  placePointLabels(zoomGroup, { bounds, avoidCollisions: false });
 }

--- a/packages/app/src/components/inference/ui/point-label-placement.test.ts
+++ b/packages/app/src/components/inference/ui/point-label-placement.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import * as d3 from 'd3';
+import { describe, expect, it } from 'vitest';
+
+import {
+  avoidPointLabelCollisions,
+  keepPointLabelsInPlot,
+  placePointLabels,
+  plotAreaBounds,
+} from './line-label-layer';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const PLOT = { width: 400, height: 300 };
+const CLIP_ID = 'clip-test-chart';
+
+/**
+ * A chart skeleton shaped like `setupChartStructure` builds it: a clipPath
+ * in <defs> sized to the plot and a `.zoom-group` that references it.
+ */
+function renderChart(clip = true) {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const defs = document.createElementNS(SVG_NS, 'defs');
+  svg.append(defs);
+  if (clip) {
+    const clipPath = document.createElementNS(SVG_NS, 'clipPath');
+    clipPath.setAttribute('id', CLIP_ID);
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('width', String(PLOT.width));
+    rect.setAttribute('height', String(PLOT.height));
+    clipPath.append(rect);
+    defs.append(clipPath);
+  }
+  const root = document.createElementNS(SVG_NS, 'g');
+  root.setAttribute('class', 'chart-root');
+  svg.append(root);
+  const zoomGroupEl = document.createElementNS(SVG_NS, 'g');
+  zoomGroupEl.setAttribute('class', 'zoom-group');
+  if (clip) zoomGroupEl.setAttribute('clip-path', `url(#${CLIP_ID})`);
+  root.append(zoomGroupEl);
+  return { svg, zoomGroup: d3.select(zoomGroupEl) };
+}
+
+interface PointSpec {
+  x: number;
+  y: number;
+  /** Label lines; each becomes a tspan. */
+  lines?: string[];
+  /** Stubbed text width so the test controls the collision box. */
+  width?: number;
+}
+
+/** Add a `.dot-group` with a `.point-label`, mirroring `renderScatterPoints`. */
+function addPoint(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  { x, y, lines = ['TP8'], width = 30 }: PointSpec,
+) {
+  const group = zoomGroup
+    .append('g')
+    .attr('class', 'dot-group')
+    .attr('transform', `translate(${x},${y})`);
+  const text = group.append('text').attr('class', 'point-label');
+  text
+    .selectAll('tspan')
+    .data(lines)
+    .join('tspan')
+    .attr('x', 0)
+    .attr('dy', (_line, index) => (index === 0 ? '-0.8em' : '1.1em'))
+    .text((line) => line);
+  // jsdom has no layout engine; give the label a deterministic box.
+  Object.defineProperty(text.node()!, 'getBBox', {
+    value: () => new DOMRect(-width / 2, -20, width, 12),
+  });
+  return text;
+}
+
+const firstDy = (text: d3.Selection<SVGTextElement, unknown, null, undefined>) =>
+  Number.parseFloat(text.select('tspan').attr('dy'));
+const tspanXs = (text: d3.Selection<SVGTextElement, unknown, null, undefined>) =>
+  text
+    .selectAll('tspan')
+    .nodes()
+    .map((node) => Number((node as SVGTSpanElement).getAttribute('x')));
+
+describe('plotAreaBounds', () => {
+  it('reads the plot rect the zoom group is clipped to', () => {
+    const { zoomGroup } = renderChart();
+    expect(plotAreaBounds(zoomGroup)).toEqual({ left: 0, top: 0, right: 400, bottom: 300 });
+  });
+
+  it('is null when the chart clips nothing', () => {
+    const { zoomGroup } = renderChart(false);
+    expect(plotAreaBounds(zoomGroup)).toBeNull();
+  });
+});
+
+describe('point labels stay inside the plot bounding box', () => {
+  it('keeps the default above-the-point slot for a label with room', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: 150 });
+
+    placePointLabels(zoomGroup);
+
+    expect(firstDy(label)).toBe(-8);
+    expect(label.style('opacity')).toBe('1');
+  });
+
+  it('flips a label below its point when the default slot would cross the top edge', () => {
+    // The regression: a Pareto-frontier point pinned at the very top of the
+    // y-range put its label above itself, where the clip path sliced the
+    // text in half.
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: 6, lines: ['5xDEP8+1xDEP16'], width: 90 });
+
+    placePointLabels(zoomGroup);
+
+    expect(firstDy(label)).toBe(14);
+    expect(label.style('opacity')).toBe('1');
+  });
+
+  it('flips a label above its point when the below slot would cross the bottom edge', () => {
+    const { zoomGroup } = renderChart();
+    // A neighbour whose own label occupies this label's default (above)
+    // slot, so the ladder has to move on to the next candidate.
+    const blocker = addPoint(zoomGroup, { x: 200, y: 296 });
+    const label = addPoint(zoomGroup, { x: 202, y: 292 });
+
+    avoidPointLabelCollisions(zoomGroup);
+
+    // The first-placed label keeps "above"; the second cannot use "above"
+    // (collision) or "below" (its box would end at y=311, past the 300px
+    // plot), so it takes the "further above" slot instead of spilling out.
+    expect(firstDy(blocker)).toBe(-8);
+    expect(firstDy(label)).toBe(-22);
+    expect(label.style('opacity')).toBe('1');
+  });
+
+  it('slides a label at the right edge inward instead of letting it spill past', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 395, y: 150, lines: ['TP8', 'C=64'], width: 40 });
+
+    placePointLabels(zoomGroup);
+
+    // Box right = 395 + 20 + 2 padding = 417 → shift left by 17 so every
+    // tspan (text-anchor: middle) is re-centred inside the plot.
+    expect(tspanXs(label)).toEqual([-17, -17]);
+    expect(label.style('opacity')).toBe('1');
+  });
+
+  it('slides a label at the left edge inward', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 4, y: 150, width: 40 });
+
+    placePointLabels(zoomGroup);
+
+    expect(tspanXs(label)).toEqual([18]);
+  });
+
+  it('hides a label that cannot fit inside the plot at any slot', () => {
+    const { zoomGroup } = renderChart();
+    // Wider than the whole plot: no horizontal shift can rescue it.
+    const label = addPoint(zoomGroup, { x: 200, y: 150, width: 500 });
+
+    placePointLabels(zoomGroup);
+
+    expect(label.style('opacity')).toBe('0');
+  });
+
+  it('hides the label of a point zoomed outside the plot', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: -40 });
+
+    placePointLabels(zoomGroup);
+
+    expect(label.style('opacity')).toBe('0');
+  });
+
+  it('resets a previous horizontal shift before laying out again', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 395, y: 150, width: 40 });
+    const group = zoomGroup.select<SVGGElement>('.dot-group');
+
+    keepPointLabelsInPlot(zoomGroup);
+    expect(tspanXs(label)).toEqual([-17]);
+
+    // Zoom moves the point back to the middle: the shift must not linger.
+    group.attr('transform', 'translate(200,150)');
+    keepPointLabelsInPlot(zoomGroup);
+    expect(tspanXs(label)).toEqual([0]);
+  });
+
+  it('applies no constraint to charts that clip nothing', () => {
+    const { zoomGroup } = renderChart(false);
+    const label = addPoint(zoomGroup, { x: 200, y: 6 });
+
+    placePointLabels(zoomGroup);
+
+    expect(firstDy(label)).toBe(-8);
+    expect(label.style('opacity')).toBe('1');
+  });
+
+  it('honours explicit bounds over the clip rect', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: 150 });
+
+    placePointLabels(zoomGroup, { bounds: { left: 0, top: 140, right: 400, bottom: 300 } });
+
+    // Above (top = 150 - 8 - 9 - 2 = 131) breaches the tightened top edge.
+    expect(firstDy(label)).toBe(14);
+  });
+
+  it('skips collision avoidance for keepPointLabelsInPlot', () => {
+    const { zoomGroup } = renderChart();
+    const first = addPoint(zoomGroup, { x: 200, y: 150 });
+    const second = addPoint(zoomGroup, { x: 202, y: 150 });
+
+    keepPointLabelsInPlot(zoomGroup);
+
+    expect(firstDy(first)).toBe(-8);
+    expect(firstDy(second)).toBe(-8);
+  });
+});

--- a/packages/app/src/components/inference/ui/point-label-placement.test.ts
+++ b/packages/app/src/components/inference/ui/point-label-placement.test.ts
@@ -174,6 +174,31 @@ describe('point labels stay inside the plot bounding box', () => {
     expect(label.style('opacity')).toBe('0');
   });
 
+  it('shows the label again once its point zooms back into the plot', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: -40 });
+    const group = zoomGroup.select<SVGGElement>('.dot-group');
+
+    placePointLabels(zoomGroup);
+    expect(label.style('opacity')).toBe('0');
+
+    group.attr('transform', 'translate(200,150)');
+    placePointLabels(zoomGroup);
+
+    expect(label.style('opacity')).toBe('1');
+    expect(firstDy(label)).toBe(-8);
+  });
+
+  it('leaves labels hidden for other reasons alone', () => {
+    const { zoomGroup } = renderChart();
+    const label = addPoint(zoomGroup, { x: 200, y: 150 });
+    label.style('opacity', 0);
+
+    placePointLabels(zoomGroup);
+
+    expect(label.style('opacity')).toBe('0');
+  });
+
   it('resets a previous horizontal shift before laying out again', () => {
     const { zoomGroup } = renderChart();
     const label = addPoint(zoomGroup, { x: 395, y: 150, width: 40 });

--- a/packages/app/src/lib/d3-chart/plot-bounds.test.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { plotBounds } from './plot-bounds';
+import { plotBounds, plotClipSize } from './plot-bounds';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -76,6 +76,40 @@ function renderChartSvg({
 
 afterEach(() => {
   document.body.innerHTML = '';
+});
+
+const zoomGroupOf = (svg: Element) => svg.querySelector('.zoom-group')!;
+
+describe('plotClipSize', () => {
+  it('returns the clip rect size in zoom-group units', () => {
+    expect(plotClipSize(zoomGroupOf(renderChartSvg()))).toEqual({ width: 730, height: 516 });
+  });
+
+  it('finds the owning SVG through the zoom group when none is passed', () => {
+    const svg = renderChartSvg({ decoyClip: true });
+    expect(plotClipSize(zoomGroupOf(svg))).toEqual({ width: 730, height: 516 });
+  });
+
+  it('returns null when the group is not clipped', () => {
+    expect(plotClipSize(zoomGroupOf(renderChartSvg({ clip: null })))).toBeNull();
+  });
+
+  it('returns null when the referenced clipPath is missing', () => {
+    const svg = renderChartSvg();
+    svg.querySelector(`#${CLIP_ID}`)!.remove();
+    expect(plotClipSize(zoomGroupOf(svg))).toBeNull();
+  });
+
+  it('returns null for a degenerate clip rect', () => {
+    const svg = renderChartSvg({ clip: { width: 730, height: 0 } });
+    expect(plotClipSize(zoomGroupOf(svg))).toBeNull();
+  });
+
+  it('returns null for a detached group with no owner SVG', () => {
+    const group = svgEl('g');
+    group.setAttribute('clip-path', `url(#${CLIP_ID})`);
+    expect(plotClipSize(group)).toBeNull();
+  });
 });
 
 describe('plotBounds', () => {

--- a/packages/app/src/lib/d3-chart/plot-bounds.ts
+++ b/packages/app/src/lib/d3-chart/plot-bounds.ts
@@ -28,6 +28,50 @@ const TRANSLATE = /translate\(\s*(?<x>-?[\d.]+)[\s,]+(?<y>-?[\d.]+)\s*\)/u;
 /** The `clip-path="url(#…)"` reference `setupChart` puts on the zoom group. */
 const CLIP_URL = /url\(\s*#(?<id>[^)\s]+)\s*\)/u;
 
+/** Width and height of the plot area, in the zoom group's own user units. */
+export interface PlotSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Size of the clip rect a zoom group is painted through.
+ *
+ * The zoom group carries no transform of its own (zoom re-scales point
+ * positions instead), so the clip rect `(0, 0, width, height)` is also the
+ * plot area in the coordinate space every `.dot-group` translate is written
+ * in. Anything laid out inside the zoom group — point labels in particular —
+ * can compare against this rect directly to know whether it will be painted
+ * or clipped away.
+ *
+ * @param zoomGroup the chart's `.zoom-group` element.
+ * @param svg the owning `<svg>`; defaults to the zoom group's own owner.
+ * @returns the clip size, or `null` when the group clips nothing
+ *   (`clipContent: false`), the referenced clipPath is missing, or the rect
+ *   is degenerate.
+ */
+export function plotClipSize(
+  zoomGroup: Element,
+  svg: Element | null = (zoomGroup as SVGElement).ownerSVGElement,
+): PlotSize | null {
+  if (!svg) return null;
+  // Follow the zoom group's own reference rather than assuming the chart's is
+  // the only clipPath in the SVG — the overflow-continuation layer defines one
+  // per group, and future layers may too. No reference means `clipContent:
+  // false`, i.e. nothing is being clipped away.
+  const clipId = CLIP_URL.exec(zoomGroup.getAttribute('clip-path') ?? '')?.groups?.id;
+  if (!clipId) return null;
+  const clip = [...svg.querySelectorAll('clipPath')]
+    .find((candidate) => candidate.id === clipId)
+    ?.querySelector('rect');
+  if (!clip) return null;
+
+  const width = Number(clip.getAttribute('width'));
+  const height = Number(clip.getAttribute('height'));
+  if (!(width > 0) || !(height > 0)) return null;
+  return { width, height };
+}
+
 /**
  * @param svg the chart's `<svg>` element (`[data-testid="d3-chart-svg"]`).
  * @returns the clip region in viewport coordinates, or `null` when the chart
@@ -40,21 +84,12 @@ export function plotBounds(svg: Element): PlotBounds | null {
   const zoomGroup = svg.querySelector('.zoom-group');
   if (!root || !zoomGroup) return null;
 
-  // Follow the zoom group's own reference rather than assuming the chart's is
-  // the only clipPath in the SVG — the overflow-continuation layer defines one
-  // per group, and future layers may too. No reference means `clipContent:
-  // false`, i.e. nothing is being clipped away.
-  const clipId = CLIP_URL.exec(zoomGroup.getAttribute('clip-path') ?? '')?.groups?.id;
-  if (!clipId) return null;
-  const clip = [...svg.querySelectorAll('clipPath')]
-    .find((candidate) => candidate.id === clipId)
-    ?.querySelector('rect');
-  if (!clip) return null;
+  const size = plotClipSize(zoomGroup, svg);
+  if (!size) return null;
+  const { width, height } = size;
 
   const translate = TRANSLATE.exec(root.getAttribute('transform') ?? '')?.groups;
-  const width = Number(clip.getAttribute('width'));
-  const height = Number(clip.getAttribute('height'));
-  if (!translate || !(width > 0) || !(height > 0)) return null;
+  if (!translate) return null;
 
   // No viewBox on the chart SVG, so one user unit is one CSS pixel and the
   // margins can be added to the client rect directly.


### PR DESCRIPTION
## Summary

Point labels could escape the plot area — a point near the top edge kept its default above-the-point slot and the zoom-group clip path sliced the label in half (e.g. `5xDEP8+1xDEP16` on the Throughput per Utility MW chart). The plot clip rect is now a **strict bounding box** for every point label.

## What changed

- `lib/d3-chart/plot-bounds.ts`: new `plotClipSize(zoomGroup)` reads the `<clipPath>` rect the zoom group is clipped to (in zoom-group units); `plotBounds()` now shares it.
- `inference/ui/line-label-layer.ts`: `placePointLabels()` is the shared layout pass. Each label tries a ladder of slots (above → below → further above → further below) and only accepts one that fits entirely inside the plot, sliding horizontally at the left/right edge instead of spilling past it. A label with no eligible slot is hidden rather than drawn half-clipped. `avoidPointLabelCollisions()` (ScatterGraph, with collision avoidance) and `keepPointLabelsInPlot()` (bounding box only) are thin wrappers. Charts that don't clip (`clipContent: false`) get no constraint.
- `inference/ui/GPUGraph.tsx`: the compare chart had no placement pass at all; it now runs `keepPointLabelsInPlot` on render, zoom, and when the label toggle turns labels back on (via `onDisplayUpdate`).

## Unofficial-run overlays

Overlay points (`?unofficialrun=`) render through the same `.dot-group .point-label` DOM in the same clipped zoom group, so the bounding-box pass covers them identically — no separate code path.

## Tests

- New `point-label-placement.test.ts` (jsdom): reads the clip rect, flips below at the top edge, climbs above at the bottom edge, slides inward at the left/right edges, hides when nothing fits or the point is zoomed out of the plot, resets prior shifts, no constraint when unclipped, explicit bounds, and `keepPointLabelsInPlot` skipping collisions.
- `line-label-layer.test.ts`: primitives `horizontalShiftIntoBounds` / `fitsVertically`.
- `plot-bounds.test.ts`: `plotClipSize` incl. missing/degenerate clip and detached group.
- `bun run typecheck`, `lint`, `fmt`, `check:typography`, and the inference + d3-chart vitest suites pass locally.

## 中文说明

点标签有时会超出绘图区域：靠近顶部边缘的点保留默认的上方标签位置，zoom-group 的裁剪路径把标签切掉一半（例如 Throughput per Utility MW 图中的 `5xDEP8+1xDEP16`）。现在将绘图区的裁剪矩形作为所有点标签的**严格包围盒**。

- `plot-bounds.ts` 新增 `plotClipSize()`，读取 zoom group 所引用的 `<clipPath>` 矩形尺寸；`plotBounds()` 复用它。
- `line-label-layer.ts` 新增共享布局函数 `placePointLabels()`：每个标签依次尝试上方 / 下方 / 更上方 / 更下方，只接受完全落在绘图区内的位置，靠近左右边缘时向内平移；没有可用位置时隐藏而不是半截绘制。`avoidPointLabelCollisions()`（ScatterGraph，含碰撞避让）和 `keepPointLabelsInPlot()`（仅包围盒）为其薄封装。不裁剪的图表不受约束。
- `GPUGraph.tsx` 对比图此前没有任何布局处理，现在在渲染、缩放和标签开关时执行 `keepPointLabelsInPlot`。
- 非官方运行叠加点（`?unofficialrun=`）使用同一套 `.dot-group .point-label` DOM，因此同样受此约束。
- 新增 `point-label-placement.test.ts` 等单元测试；typecheck / lint / fmt / typography 与相关 vitest 套件本地全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visualization-only label layout in inference charts; behavior is covered by new jsdom unit tests and does not touch APIs, auth, or data.
> 
> **Overview**
> Fixes scatter/compare chart point labels being **clipped in half** when points sit on the plot edge (e.g. Pareto points at the top of Throughput per Utility MW).
> 
> **Plot bounds:** `plotClipSize()` reads the zoom group’s clip rect in layout coordinates; point-label layout uses that as a **strict** box (flip above/below, slide horizontally at sides, hide when nothing fits).
> 
> **Layout:** Collision logic moves into shared `placePointLabels()` with optional collision avoidance. `avoidPointLabelCollisions()` (single-run scatter) keeps pills/label overlap behavior plus the new bounds; **`GPUGraph`** now runs `keepPointLabelsInPlot()` on render, zoom, and display update so the compare chart gets bounds-only placement.
> 
> Labels hidden only for placement get `data-placement-hidden` so they can reappear after zoom or toggle. Unclipped charts skip the constraint.
> 
> Tests cover edge flips, horizontal shifts, hide/show on zoom, and `plotClipSize` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14de2fcadff0d729acac50a34da9f15ca77b0841. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->