### PR TITLE
chore: remove unnecessary `as any` casts in D3 chart code / 移除 D3 图表代码中不必要的 `as any` 类型断言

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -40,6 +40,7 @@ import {
   formatLargeNumber,
   getShapeKeyForPrecision,
   logTickFormat,
+  type ShapeSelection,
 } from '@/lib/chart-rendering';
 import {
   isFrontierEligible,
@@ -1265,7 +1266,7 @@ const GPUGraph = React.memo(
             if (logScale) {
               const newYScale = ctx.newYScale as d3.ScaleLogarithmic<number, number>;
               ctx.layout.yAxisGroup.call(
-                d3.axisLeft(newYScale).ticks(10).tickFormat(logTickFormat(newYScale)) as any,
+                d3.axisLeft(newYScale).ticks(10).tickFormat(logTickFormat(newYScale)),
               );
             }
           },
@@ -1293,12 +1294,12 @@ const GPUGraph = React.memo(
           getRulerY: (d, yScale) => (yScale as d3.ScaleLinear<number, number>)(d.y),
           onHoverStart: (sel, d) =>
             applyHoverState(
-              sel.select('.visible-shape') as any,
+              sel.select('.visible-shape') as ShapeSelection,
               getShapeKeyForPrecision(d.precision, selectedPrecisions),
             ),
           onHoverEnd: (sel, d) =>
             applyNormalState(
-              sel.select('.visible-shape') as any,
+              sel.select('.visible-shape') as ShapeSelection,
               getShapeKeyForPrecision(d.precision, selectedPrecisions),
             ),
           onPointClick: (d: InferenceData) => {
@@ -1383,7 +1384,7 @@ const GPUGraph = React.memo(
               number
             >;
             ctx.layout.yAxisGroup.call(
-              d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)) as any,
+              d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)),
             );
           }
           // Set foreground color on scatter point labels

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -95,6 +95,7 @@ import {
   applyHoverState,
   applyNormalState,
   getShapeKeyForPrecision,
+  type ShapeSelection,
 } from '@/lib/chart-rendering';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import {
@@ -1865,13 +1866,13 @@ const ScatterGraph = React.memo(
           if (xScaleConfig._isLog) {
             const newXS = ctx.newXScale as d3.ScaleLogarithmic<number, number>;
             ctx.layout.xAxisGroup.call(
-              d3.axisBottom(newXS).ticks(10).tickFormat(logTickFormat(newXS)) as any,
+              d3.axisBottom(newXS).ticks(10).tickFormat(logTickFormat(newXS)),
             );
           }
           if (yScaleConfig.type === 'log') {
             const newYS = ctx.newYScale as d3.ScaleLogarithmic<number, number>;
             ctx.layout.yAxisGroup.call(
-              d3.axisLeft(newYS).ticks(10).tickFormat(logTickFormat(newYS)) as any,
+              d3.axisLeft(newYS).ticks(10).tickFormat(logTickFormat(newYS)),
             );
           }
           if (showPointLabels && !showGradientLabels) {
@@ -1915,12 +1916,12 @@ const ScatterGraph = React.memo(
         getRulerY: (d: InferenceData, yScale: any) => (yScale as ContinuousScale)(d.y),
         onHoverStart: (sel: d3.Selection<any, InferenceData, any, any>, d: InferenceData) =>
           applyHoverState(
-            sel.select('.visible-shape') as any,
+            sel.select('.visible-shape') as ShapeSelection,
             getShapeKeyForPrecision(d.precision, interactionRef.current.selectedPrecisions),
           ),
         onHoverEnd: (sel: d3.Selection<any, InferenceData, any, any>, d: InferenceData) =>
           applyNormalState(
-            sel.select('.visible-shape') as any,
+            sel.select('.visible-shape') as ShapeSelection,
             getShapeKeyForPrecision(d.precision, interactionRef.current.selectedPrecisions),
           ),
         onPointClick: (d: InferenceData) => {
@@ -3074,13 +3075,13 @@ const ScatterGraph = React.memo(
         if (xScaleConfig._isLog) {
           const xScale = (ctx.renderedXScale ?? ctx.xScale) as d3.ScaleLogarithmic<number, number>;
           ctx.layout.xAxisGroup.call(
-            d3.axisBottom(xScale).ticks(10).tickFormat(logTickFormat(xScale)) as any,
+            d3.axisBottom(xScale).ticks(10).tickFormat(logTickFormat(xScale)),
           );
         }
         if (yScaleConfig.type === 'log') {
           const yScale = (ctx.renderedYScale ?? ctx.yScale) as d3.ScaleLogarithmic<number, number>;
           ctx.layout.yAxisGroup.call(
-            d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)) as any,
+            d3.axisLeft(yScale).ticks(10).tickFormat(logTickFormat(yScale)),
           );
         }
       },

--- a/packages/app/src/components/inference/ui/TrendChart.tsx
+++ b/packages/app/src/components/inference/ui/TrendChart.tsx
@@ -16,6 +16,7 @@ import {
   formatLargeNumber,
   getShapeKeyForPrecision,
   logTickFormat,
+  type ShapeSelection,
 } from '@/lib/chart-rendering';
 import { getChartWatermark } from '@/lib/data-mappings';
 import { useLocale } from '@/lib/use-locale';
@@ -275,12 +276,12 @@ const TrendChart = React.memo(
         getRulerY: (d: PreparedPoint, yScale: any) => yScale(d.y),
         onHoverStart: (sel: d3.Selection<any, PreparedPoint, any, any>, d: PreparedPoint) =>
           applyHoverState(
-            sel.select('.visible-shape') as any,
+            sel.select('.visible-shape') as ShapeSelection,
             getShapeKeyForPrecision(d.precision, selectedPrecisions ?? []),
           ),
         onHoverEnd: (sel: d3.Selection<any, PreparedPoint, any, any>, d: PreparedPoint) =>
           applyNormalState(
-            sel.select('.visible-shape') as any,
+            sel.select('.visible-shape') as ShapeSelection,
             getShapeKeyForPrecision(d.precision, selectedPrecisions ?? []),
           ),
         onPointClick: (d: PreparedPoint) => {
@@ -295,10 +296,10 @@ const TrendChart = React.memo(
 
     const xAxisConfig = useMemo(
       () => ({
-        tickFormat: ((value: d3.AxisDomain) =>
+        tickFormat: (value: d3.AxisDomain) =>
           locale === 'zh'
             ? axisDateFormatter.format(new Date(Number(value)))
-            : d3.timeFormat('%b %d')(new Date(Number(value)))) as any,
+            : d3.timeFormat('%b %d')(new Date(Number(value))),
         tickCount: 10,
         customize: (g: d3.Selection<SVGGElement, unknown, null, undefined>) => {
           g.selectAll('.tick text').attr('transform', 'rotate(-30)').attr('text-anchor', 'end');

--- a/packages/app/src/hooks/useChartTooltipHandlers.ts
+++ b/packages/app/src/hooks/useChartTooltipHandlers.ts
@@ -231,14 +231,14 @@ export function useChartTooltipHandlers<TData>(): ChartTooltipHandlers<TData> {
         if (svgRef?.current) {
           const transform = d3.zoomTransform(svgRef.current);
           if ((effectiveZoomAxes === 'x' || effectiveZoomAxes === 'both') && 'invert' in xScale) {
-            curX = transform.rescaleX(xScale as any);
+            curX = transform.rescaleX(xScale);
           }
           if (
             (effectiveZoomAxes === 'y' || effectiveZoomAxes === 'both') &&
             yScale &&
             'invert' in yScale
           ) {
-            curY = transform.rescaleY(yScale as any);
+            curY = transform.rescaleY(yScale);
           }
         }
         return { curX, curY };

--- a/packages/app/src/hooks/useStickyTooltip.ts
+++ b/packages/app/src/hooks/useStickyTooltip.ts
@@ -96,10 +96,12 @@ export const useStickyTooltip = <T = any>() => {
         // know the caller's selectedPrecisions.
         svg.selectAll('.dot-group').each(function () {
           const group = d3.select(this);
-          const shape = group.select<SVGElement>('.visible-shape');
+          const shape = group.select<SVGCircleElement | SVGRectElement | SVGPathElement>(
+            '.visible-shape',
+          );
           const node = shape.node();
           if (node) {
-            applyNormalState(shape as any, readShapeKey(node));
+            applyNormalState(shape, readShapeKey(node));
           }
         });
       }

--- a/packages/app/src/lib/chart-rendering.ts
+++ b/packages/app/src/lib/chart-rendering.ts
@@ -24,6 +24,14 @@ const getDiamondPath = (size: number) => `M 0 ${-size} L ${size} 0 L 0 ${size} L
 
 export type ShapeKey = 'circle' | 'square' | 'triangle' | 'diamond';
 
+/** A d3 selection of one of the SVG shape elements that point shapes render as. */
+export type ShapeSelection = d3.Selection<
+  SVGCircleElement | SVGRectElement | SVGPathElement,
+  unknown,
+  null,
+  undefined
+>;
+
 // Shape assignment order: first selected precision gets circle, second square, etc.
 export const SHAPE_ORDER: readonly ShapeKey[] = ['circle', 'square', 'triangle', 'diamond'];
 
@@ -98,10 +106,7 @@ export const getShapeKeyForPrecision = (
 export const getShapeConfig = (shapeKey: ShapeKey) => SHAPE_CONFIG[shapeKey];
 
 // Helper function to apply normal state attributes to a shape
-export const applyNormalState = (
-  shape: d3.Selection<SVGCircleElement | SVGRectElement | SVGPathElement, unknown, null, undefined>,
-  shapeKey: ShapeKey,
-) => {
+export const applyNormalState = (shape: ShapeSelection, shapeKey: ShapeKey) => {
   const config = getShapeConfig(shapeKey);
   if (config.type === 'path') {
     (shape as d3.Selection<SVGPathElement, unknown, null, undefined>)
@@ -122,10 +127,7 @@ export const applyNormalState = (
 };
 
 // Helper function to apply hover state attributes to a shape
-export const applyHoverState = (
-  shape: d3.Selection<SVGCircleElement | SVGRectElement | SVGPathElement, unknown, null, undefined>,
-  shapeKey: ShapeKey,
-) => {
+export const applyHoverState = (shape: ShapeSelection, shapeKey: ShapeKey) => {
   const config = getShapeConfig(shapeKey);
   if (config.type === 'path') {
     (shape as d3.Selection<SVGPathElement, unknown, null, undefined>)

--- a/packages/app/src/lib/d3-chart/layers/scatter-points.ts
+++ b/packages/app/src/lib/d3-chart/layers/scatter-points.ts
@@ -3,6 +3,7 @@ import * as d3 from 'd3';
 import {
   HIT_AREA_RADIUS,
   type ShapeKey,
+  type ShapeSelection,
   getShapeConfig,
   getShapeKeyForPrecision,
   applyNormalState,
@@ -56,26 +57,21 @@ export function syncPointShape(
   const targetType = getShapeConfig(shapeKey).type;
   const existing = g.select<SVGElement>('.visible-shape').node();
   const currentType = existing?.tagName.toLowerCase();
+  let shape: ShapeSelection;
   if (!existing || currentType !== targetType) {
     g.select('.visible-shape').remove();
-    const shape = g
+    shape = g
       .append(targetType)
       .attr('class', 'visible-shape')
       .attr('data-shape-key', shapeKey)
       .attr('fill', fill)
       .attr('stroke', 'none')
-      .attr('cursor', 'pointer') as d3.Selection<
-      SVGCircleElement | SVGRectElement | SVGPathElement,
-      unknown,
-      null,
-      undefined
-    >;
-    applyNormalState(shape, shapeKey);
+      .attr('cursor', 'pointer') as ShapeSelection;
   } else {
-    const shape = g.select<SVGElement>('.visible-shape');
+    shape = g.select<SVGCircleElement | SVGRectElement | SVGPathElement>('.visible-shape');
     shape.attr('fill', fill).attr('data-shape-key', shapeKey);
-    applyNormalState(shape as any, shapeKey);
   }
+  applyNormalState(shape, shapeKey);
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR improves type safety across the D3 chart rendering code by removing unnecessary `as any` type assertions and replacing them with precise types. All automated gates (oxlint, oxfmt, `tsc --noEmit`, typography check, unit tests) pass.

### Changes

- **New `ShapeSelection` type alias** in `chart-rendering.ts` — a shared `d3.Selection<SVGCircleElement | SVGRectElement | SVGPathElement, unknown, null, undefined>` type for SVG shape selections. `applyNormalState` / `applyHoverState` now use this alias instead of the inline union, and it is exported for reuse by callers.
- **Replaced `as any` with `as ShapeSelection`** for `sel.select('.visible-shape')` casts across `TrendChart.tsx`, `GPUGraph.tsx`, `ScatterGraph.tsx`, and `useStickyTooltip.ts` — preserving type safety while keeping the same runtime behavior.
- **Removed redundant `as any` on `logTickFormat()` calls** in `GPUGraph.tsx` and `ScatterGraph.tsx` — `logTickFormat` returns `(d: d3.AxisDomain) => string`, which already matches `AxisConfig.tickFormat`. Casts existed unnecessarily.
- **Removed redundant `as any` on `transform.rescaleX()` / `transform.rescaleY()`** in `useChartTooltipHandlers.ts` — the scale parameters are already typed as the correct union, so `rescaleX`/`rescaleY` accept them directly.
- **Removed redundant `as any` on `tickFormat` in `TrendChart.tsx`** — the inline `(value: d3.AxisDomain) => string` already matches the `AxisConfig.tickFormat` signature.
- **Refactored `syncPointShape` in `scatter-points.ts`** — hoisted the shared `applyNormalState(shape, shapeKey)` call out of the if/else branches, eliminating the duplicated call (the oxlint `branches-sharing-code` rule now passes) and replacing `as any` with a precise `ShapeSelection` select.

### Validation

- `bun run lint` — 0 warnings, 0 errors
- `bun run fmt` — all files formatted correctly
- `bun run typecheck` (tsc --noEmit, strict) — passes
- `bun run check:typography` — OK
- `bun run test:unit` — 228/229 test files pass (the 1 failure is a pre-existing jsdom/undici environment incompatibility with Node 20, unrelated to these changes; the repo targets Node 24). The two test files covering changed code (`chart-rendering.test.ts`, `scatter-points.test.ts`) pass with 53/53 tests.

### Scope

No behavioral changes. Every removal was validated empirically by running `tsc --noEmit` after each edit — casts that the compiler could not resolve without `as any` (e.g. `d3.timeFormat` return-type contravariance, union-of-scale-functions) were left untouched.

## 中文说明

本 PR 通过移除不必要的 `as any` 类型断言并替换为精确类型，提升了 D3 图表渲染代码的类型安全性。所有自动化检查（oxlint、oxfmt、tsc --noEmit、排版检查、单元测试）均通过。

### 改动内容

- **新增 `ShapeSelection` 类型别名**（`chart-rendering.ts`）——统一描述 SVG 形状元素的 `d3.Selection` 类型，`applyNormalState` / `applyHoverState` 改用该别名。
- **将 `sel.select('.visible-shape') as any` 替换为 `as ShapeSelection`**（`TrendChart.tsx`、`GPUGraph.tsx`、`ScatterGraph.tsx`、`useStickyTooltip.ts`）——在保持运行时行为不变的前提下提升类型安全。
- **移除 `logTickFormat()` 调用处的冗余 `as any`**（`GPUGraph.tsx`、`ScatterGraph.tsx`）——返回类型已匹配 `AxisConfig.tickFormat`。
- **移除 `transform.rescaleX()` / `transform.rescaleY()` 处的冗余 `as any`**（`useChartTooltipHandlers.ts`）——参数类型已正确匹配。
- **移除 `TrendChart.tsx` 中 `tickFormat` 的冗余 `as any`**——函数签名已匹配。
- **重构 `syncPointShape`**（`scatter-points.ts`）——提取公共 `applyNormalState` 调用，消除分支重复代码，并用精确类型替代 `as any`。

### 验证

- `bun run lint`——0 警告、0 错误
- `bun run fmt`——格式全部正确
- `bun run typecheck`（tsc --noEmit，strict）——通过
- `bun run check:typography`——通过
- `bun run test:unit`——228/229 测试文件通过（唯一失败为 jsdom/undici 与 Node 20 的环境兼容问题，与本改动无关；涉及改动文件的两个测试 `chart-rendering.test.ts`、`scatter-points.test.ts` 全部 53/53 通过）。

### 范围

无行为变更。每处移除均通过 `tsc --noEmit` 实证验证——编译器无法在缺少 `as any` 时解析的断言（如 `d3.timeFormat` 返回类型逆变、scale 联合类型函数调用）保持不变。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only cleanup in chart rendering and tooltip hooks; no auth, data, or behavioral changes.
> 
> **Overview**
> This PR tightens TypeScript around D3 chart rendering **without changing runtime behavior**. It introduces a shared **`ShapeSelection`** alias for circle/rect/path shape selections and uses it in **`applyHoverState` / `applyNormalState`**, tooltip hover handlers, and **`syncPointShape`**.
> 
> **Scatter / GPU / trend charts** now cast `.visible-shape` selections to **`ShapeSelection`** instead of **`as any`**. **`logTickFormat`** and axis **`tickFormat`** callbacks no longer need **`as any`** where signatures already match. **`useChartTooltipHandlers`** passes scales directly into **`rescaleX` / `rescaleY`**. In **`scatter-points.ts`**, **`applyNormalState`** is called once after the create/update branch, fixing duplicated branch logic while keeping precise typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46388cdfbce33e386f2eaafb6808d072c441d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->