### PR TITLE
fix(inference): price GB300 cached input from the theoretical hit rate when unmeasured / GB300 缺少实测命中率时按理论命中率为缓存输入定价

### DIFF
--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -8,7 +8,7 @@ import type { AggDataEntry, HardwareConfig } from '@/components/inference/types'
 import { useBenchmarks } from '@/hooks/api/use-benchmarks';
 import type { BenchmarkRow } from '@/lib/api';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
-import { measuredCacheHitRate } from '@/lib/cache-pricing';
+import { pricingCacheHitRate } from '@/lib/cache-pricing';
 import { getHardwareKey } from '@/lib/chart-utils';
 import { getModelSortIndex, getHardwareConfig, getGpuSpecs } from '@/lib/constants';
 import { Percentile, Sequence, type Model } from '@/lib/data-mappings';
@@ -196,7 +196,7 @@ export function buildGpuGroups<M extends GroupMeta>(
     const tput = m.tput_per_gpu ?? 0;
     const outputTput = m.output_tput_per_gpu ?? tput;
     const inputTput = m.input_tput_per_gpu ?? 0;
-    const cacheHitRate = measuredCacheHitRate(m);
+    const cacheHitRate = pricingCacheHitRate({ ...m, hw: row.hardware });
     const tokenShare = inputTokenShare(row, inputTput, outputTput);
     const specs = getGpuSpecs(hwKey);
     const power = specs.power;

--- a/packages/app/src/components/inference/hooks/useInterpolatedTrendData.ts
+++ b/packages/app/src/components/inference/hooks/useInterpolatedTrendData.ts
@@ -32,7 +32,7 @@ import { isKnownGpu } from '@/lib/constants';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import type { BenchmarkRow } from '@/lib/api';
 import { benchmarkCurveDate, dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
-import { measuredCacheHitRate } from '@/lib/cache-pricing';
+import { pricingCacheHitRate } from '@/lib/cache-pricing';
 import { Sequence, type Model } from '@/lib/data-mappings';
 import { supportsTokenMetric } from '@/lib/supplemental-benchmarks';
 
@@ -65,6 +65,7 @@ export function rowToLightweightPoint(
   const point = {
     x: row.metrics.median_intvty ?? 0,
     y: row.metrics.tput_per_gpu ?? 0,
+    hw: row.hardware,
     hwKey,
     precision: row.precision,
     tp: row.decode_tp,
@@ -80,6 +81,7 @@ export function rowToLightweightPoint(
     server_gpu_cache_hit_rate: entry.server_gpu_cache_hit_rate,
     server_external_cache_hit_rate: entry.server_external_cache_hit_rate,
     server_cpu_cache_hit_rate: entry.server_cpu_cache_hit_rate,
+    theoretical_cache_hit_rate: entry.theoretical_cache_hit_rate,
     ...buildDerivedChartFields(derivedEntry, hwKey, requestedMetrics),
   } as InferenceData;
 
@@ -248,7 +250,7 @@ export function interpolateMetricAtInteractivity(
     };
     const throughputYs = sorted.map((p) => extractMetric(p, 'tpPerGpu')!);
     const inputShares = sorted.map(inputTokenShareForRevenue);
-    const cacheHitRates = sorted.map(measuredCacheHitRate);
+    const cacheHitRates = sorted.map(pricingCacheHitRate);
     const inputShare = inputShares.every((share): share is number => share !== null)
       ? interpolateBounded(inputShares)
       : null;

--- a/packages/app/src/components/inference/token-revenue.test.ts
+++ b/packages/app/src/components/inference/token-revenue.test.ts
@@ -206,3 +206,40 @@ describe('token revenue', () => {
     expect(tokenRevenuePerGpuHour(unknownMix, openRouterPricing)).toBeNull();
   });
 });
+
+describe('GB300 cache hit-rate fallback', () => {
+  // A GB300 AgentX point shaped like production run 32146276534: ~97% of the
+  // 130k tok/s/GPU is cached input, but the server hit rate never got scraped.
+  const unmeasuredGb300 = point({
+    hw: 'gb300',
+    hwKey: 'gb300_dynamo-vllm',
+    tput_per_gpu: 130_000,
+    input_tput_per_gpu: 129_000,
+    output_tput_per_gpu: 1_000,
+    theoretical_cache_hit_rate: 0.97,
+  });
+
+  it('prices GB300 cached input from the theoretical ceiling when no server rate exists', () => {
+    const revenue = tokenRevenuePerGpuHour(unmeasuredGb300, NORMALIZED_TOKEN_REVENUE_PRICING)!;
+    const inputShare = 129_000 / 130_000;
+    const blended = inputShare * (0.03 * 1 + 0.97 * 0.1) + (1 - inputShare) * 1;
+    expect(revenue).toBeCloseTo((130_000 * 3_600 * blended) / 1_000_000, 6);
+    expect(revenue).toBeLessThan(80);
+  });
+
+  it('still bills other hardware at the uncached price when no server rate exists', () => {
+    const gb200 = point({ ...unmeasuredGb300, hw: 'gb200', hwKey: 'gb200_dynamo-vllm' });
+    expect(tokenRevenuePerGpuHour(gb200, NORMALIZED_TOKEN_REVENUE_PRICING)).toBeCloseTo(
+      (130_000 * 3_600) / 1_000_000,
+      6,
+    );
+  });
+
+  it('lets a measured GB300 rate win over the theoretical ceiling', () => {
+    const measured = point({ ...unmeasuredGb300, server_gpu_cache_hit_rate: 0.5 });
+    const fallback = tokenRevenuePerGpuHour(unmeasuredGb300, NORMALIZED_TOKEN_REVENUE_PRICING)!;
+    expect(tokenRevenuePerGpuHour(measured, NORMALIZED_TOKEN_REVENUE_PRICING)).toBeGreaterThan(
+      fallback,
+    );
+  });
+});

--- a/packages/app/src/components/inference/token-revenue.ts
+++ b/packages/app/src/components/inference/token-revenue.ts
@@ -1,5 +1,5 @@
 import type { InferenceData, TokenRevenuePricing } from './types';
-import { DEFAULT_CACHED_INPUT_PRICE_RATIO, measuredCacheHitRate } from '@/lib/cache-pricing';
+import { DEFAULT_CACHED_INPUT_PRICE_RATIO, pricingCacheHitRate } from '@/lib/cache-pricing';
 
 const SECONDS_PER_HOUR = 3_600;
 const TOKENS_PER_MILLION = 1_000_000;
@@ -94,7 +94,7 @@ export function tokenRevenuePerGpuHour(
   pricing: TokenRevenuePricing,
 ): number | null {
   const total = point.tput_per_gpu ?? 0;
-  const cacheHitRate = measuredCacheHitRate(point);
+  const cacheHitRate = pricingCacheHitRate(point);
   const inputShare = inputTokenShareForRevenue(point);
   return tokenRevenueFromRatesPerGpuHour(total, inputShare, cacheHitRate, pricing);
 }

--- a/packages/app/src/lib/benchmark-api-view.test.ts
+++ b/packages/app/src/lib/benchmark-api-view.test.ts
@@ -49,6 +49,8 @@ describe('toCalculatorBenchmarkRows', () => {
   it('keeps all three cache tiers — the trim cannot know which one a row will use', () => {
     // `measuredCacheHitRate` picks between external and CPU per row, so the allowlist
     // has to pass all three through or the choice is made for it by the trim.
+    // `pricingCacheHitRate` additionally falls back to the theoretical ceiling on
+    // GB300 rows with no server measurement, so that survives too.
     // This runs on every calculator response, agentic included.
     const cached = toCalculatorBenchmarkRows(
       [
@@ -72,6 +74,7 @@ describe('toCalculatorBenchmarkRows', () => {
       server_gpu_cache_hit_rate: 0.77,
       server_external_cache_hit_rate: 0.06,
       server_cpu_cache_hit_rate: 0.055,
+      theoretical_cache_hit_rate: 0.95,
     });
   });
 

--- a/packages/app/src/lib/benchmark-api-view.ts
+++ b/packages/app/src/lib/benchmark-api-view.ts
@@ -15,6 +15,9 @@ const CALCULATOR_METRIC_KEYS = new Set([
   // per row — so it has to survive the allowlist either way. See
   // `measuredCacheHitRate` for why the two are not simply summed.
   'server_cpu_cache_hit_rate',
+  // GB300 AgentX rows without a server measurement price cached input from the
+  // trace's theoretical ceiling instead. See `pricingCacheHitRate`.
+  'theoretical_cache_hit_rate',
   ...['median', 'p75', 'p90'].flatMap((percentile) =>
     ['intvty', 'itl', 'full_response_itl', 'e2el', 'ttlt'].map(
       (metric) => `${percentile}_${metric}`,

--- a/packages/app/src/lib/cache-pricing.test.ts
+++ b/packages/app/src/lib/cache-pricing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { measuredCacheHitRate } from './cache-pricing';
+import {
+  CACHE_HIT_RATE_FALLBACK_HARDWARE,
+  measuredCacheHitRate,
+  pricingCacheHitRate,
+} from './cache-pricing';
 
 describe('measuredCacheHitRate', () => {
   it('combines GPU and external tiers without double-counting CPU offload', () => {
@@ -36,5 +40,38 @@ describe('measuredCacheHitRate', () => {
     expect(measuredCacheHitRate({})).toBeNull();
     expect(measuredCacheHitRate({ server_gpu_cache_hit_rate: 1.2 })).toBe(1);
     expect(measuredCacheHitRate({ server_gpu_cache_hit_rate: -0.2 })).toBe(0);
+  });
+});
+
+describe('pricingCacheHitRate', () => {
+  it('prefers the measured server rate on every hardware', () => {
+    expect(
+      pricingCacheHitRate({
+        hw: 'gb300',
+        server_gpu_cache_hit_rate: 0.8,
+        server_external_cache_hit_rate: 0.06,
+        theoretical_cache_hit_rate: 0.97,
+      }),
+    ).toBeCloseTo(0.86, 10);
+  });
+
+  it('falls back to the theoretical ceiling only for GB300 points without a measurement', () => {
+    expect(pricingCacheHitRate({ hw: 'gb300', theoretical_cache_hit_rate: 0.969 })).toBeCloseTo(
+      0.969,
+      10,
+    );
+    expect(pricingCacheHitRate({ hw: 'gb300', theoretical_cache_hit_rate: 1.2 })).toBe(1);
+    expect(pricingCacheHitRate({ hw: 'gb300' })).toBeNull();
+    expect(pricingCacheHitRate({ hw: 'gb300', theoretical_cache_hit_rate: Number.NaN })).toBeNull();
+  });
+
+  it('never invents a hit rate for other hardware or unknown hardware', () => {
+    for (const hw of ['gb200', 'b300', 'b200', 'mi355x', 'h200', undefined]) {
+      expect(pricingCacheHitRate({ hw, theoretical_cache_hit_rate: 0.97 })).toBeNull();
+    }
+  });
+
+  it('keeps the fallback allowlist to GB300', () => {
+    expect([...CACHE_HIT_RATE_FALLBACK_HARDWARE]).toEqual(['gb300']);
   });
 });

--- a/packages/app/src/lib/cache-pricing.ts
+++ b/packages/app/src/lib/cache-pricing.ts
@@ -25,3 +25,38 @@ export function measuredCacheHitRate(metrics: CacheHitMetrics): number | null {
   const sum = (typeof gpu === 'number' ? gpu : 0) + (secondary ?? 0);
   return Math.max(0, Math.min(1, sum));
 }
+
+/**
+ * Hardware whose AgentX sweeps may lack a server-side prefix-cache measurement.
+ *
+ * The GB300 launcher pins srt-slurm builds that do not hand AIPerf the backend
+ * worker `/metrics` URLs, so only the Dynamo frontend gets scraped and every
+ * `server_*_cache_hit_rate` lands as null. Every other hardware measures its
+ * own rate, so the fallback below is deliberately not extended to them: a
+ * missing rate there is a data bug to fix at ingest, not something to paper
+ * over.
+ */
+export const CACHE_HIT_RATE_FALLBACK_HARDWARE: ReadonlySet<string> = new Set(['gb300']);
+
+export interface PricingCacheHitPoint extends CacheHitMetrics {
+  /** Base hardware key, for example `gb300`. */
+  hw?: string;
+  /** Infinite-cache theoretical hit rate (0..1) computed from the trace. */
+  theoretical_cache_hit_rate?: number;
+}
+
+/**
+ * Cache hit rate used to price cached input tokens.
+ *
+ * Prefers the measured server rate. When a GB300 point carries none, falls
+ * back to the trace's theoretical hit rate so cache-aware revenue does not bill
+ * ~97% cache hits at the uncached price. Other hardware never falls back.
+ */
+export function pricingCacheHitRate(point: PricingCacheHitPoint): number | null {
+  const measured = measuredCacheHitRate(point);
+  if (measured !== null) return measured;
+  if (point.hw === undefined || !CACHE_HIT_RATE_FALLBACK_HARDWARE.has(point.hw)) return null;
+  const theoretical = point.theoretical_cache_hit_rate;
+  if (typeof theoretical !== 'number' || !Number.isFinite(theoretical)) return null;
+  return Math.max(0, Math.min(1, theoretical));
+}


### PR DESCRIPTION
## Summary

Follow-up to #975. That PR patched the 14 GB300 dynamo-vllm DeepSeek-V4 AgentX points with GB200 hit rates, but the inflated revenue persisted on other models. The production DB shows the same gap across GB300:

| GB300 group | rows without any `server_*_cache_hit_rate` |
| --- | --- |
| dynamo-vllm Kimi K3 | 7 of 7 |
| dynamo-vllm MiniMax M3 | 6 of 6 |
| dynamo-trt DSv4 / GLM-5.2 / Qwen3.5 | 6 of 12 / 7 of 14 / 6 of 12 |

The cause is the same as #975: the GB300 launcher pins srt-slurm builds that do not hand AIPerf the backend worker `/metrics` URLs, so only the Dynamo frontend gets scraped and no `vllm:prefix_cache_*` counters are captured. Cache-aware pricing treats the missing rate as 0 hits and bills ~97% cached input at the uncached price. On Kimi K3 that put GB300 at ~$42/GPU/hr against ~$7 for GB200.

**Fix.** Add `pricingCacheHitRate` in `src/lib/cache-pricing.ts`:

- Prefer the measured server rate (unchanged `measuredCacheHitRate` semantics, so the #975 backfill still wins for those 14 points).
- When a **GB300** point carries no measurement, fall back to the trace's `theoretical_cache_hit_rate`, clamped to [0, 1]. The allowlist is a single exported set containing only `gb300`, and a test pins it.
- Every other hardware keeps returning null, so a missing measurement elsewhere stays visible as a data bug rather than being papered over.

Wired into the three pricing paths: `tokenRevenuePerGpuHour` (inference chart), `useInterpolatedTrendData` (historical trends, which now also carries `hw` and `theoretical_cache_hit_rate` on its lightweight points), and `useThroughputData` (calculator). `theoretical_cache_hit_rate` is added to the calculator response allowlist so the fallback survives the trim; the API catalog guard passes.

Verified against live API rows for Kimi K3 (2026-08-31) at normalized pricing, best point per hardware:

| Hardware | Before | After |
| --- | --- | --- |
| GB300 dynamo-vllm | ~$42/GPU/hr | $6.0/GPU/hr |
| GB200 dynamo-vllm | $6.9 | $6.9 |
| B300 vLLM | $8.2 | $8.2 |

Overlay support: `applyTokenRevenuePricing` runs on both official rows and `?unofficialrun=` overlay points, so the fallback applies to both paths. Tooltips are unchanged and continue to show the measured rate only when one exists, plus the theoretical rate.

**Still missing, out of scope here:** GB200 dynamo-vllm Kimi K3 (13 of 44 rows), B200/B300 TRT MiniMax M3 (22 of 33 each), and one B200 GLM-5.1 tilert row also lack a server hit rate. Those stay at the uncached price by design of the GB300-only allowlist. The durable fix is upstream: give GB300 AgentX recipes a launcher branch on srt-slurm v1.0.45+ so the sweeps measure their own rate.

## Test plan

- [x] New tests in `cache-pricing.test.ts` (measured wins, GB300 fallback, clamp, other hardware null, allowlist pinned to gb300) and `token-revenue.test.ts` (GB300 revenue with fallback, other hardware unchanged, measured beats fallback)
- [x] Updated `benchmark-api-view.test.ts` for the new allowlisted key
- [x] `bunx vitest run` in `packages/app`: 292 files, 4789 tests pass
- [x] `bun run typecheck`, oxlint, oxfmt clean; `api-route-catalog.test.ts` passes
- [x] Recomputed revenue over live Kimi K3 rows with the patched function (table above)

## 中文说明

#975 的后续修复。该 PR 用 GB200 的命中率修补了 14 个 GB300 dynamo-vllm DeepSeek-V4 AgentX 数据点，但其他模型上的收入仍然虚高。生产库显示 GB300 普遍存在同样缺口：

| GB300 分组 | 缺少任何 `server_*_cache_hit_rate` 的行数 |
| --- | --- |
| dynamo-vllm Kimi K3 | 7 / 7 |
| dynamo-vllm MiniMax M3 | 6 / 6 |
| dynamo-trt DSv4 / GLM-5.2 / Qwen3.5 | 6 / 12、7 / 14、6 / 12 |

原因与 #975 相同：GB300 启动脚本固定使用的 srt-slurm 版本不会把后端 worker 的 `/metrics` 地址交给 AIPerf，只抓取了 Dynamo 前端，没有采集 `vllm:prefix_cache_*` 计数器。缓存感知定价将缺失的命中率视为 0，把约 97% 的缓存输入按未缓存价格计费。Kimi K3 上 GB300 因此约为 $42/GPU/hr，而 GB200 约 $7。

**修复方式。** 在 `src/lib/cache-pricing.ts` 新增 `pricingCacheHitRate`：

- 优先使用实测服务端命中率（`measuredCacheHitRate` 语义不变，#975 回填的 14 个点仍以回填值为准）。
- 仅当 **GB300** 数据点没有实测值时，回退到 trace 的 `theoretical_cache_hit_rate`，并裁剪到 [0, 1]。白名单是仅含 `gb300` 的单个导出集合，并有测试固定。
- 其他硬件继续返回 null，缺失测量值时仍以数据问题的形式暴露，而不是被掩盖。

已接入三条定价路径：`tokenRevenuePerGpuHour`（推理图表）、`useInterpolatedTrendData`（历史趋势，其轻量数据点现在也携带 `hw` 与 `theoretical_cache_hit_rate`）和 `useThroughputData`（计算器）。`theoretical_cache_hit_rate` 加入计算器响应字段白名单，避免被裁剪；API catalog 守卫通过。

用线上 Kimi K3（2026-08-31）数据按标准化定价验证，各硬件最佳点：GB300 dynamo-vllm 从约 $42/GPU/hr 降到 $6.0，GB200 保持 $6.9，B300 vLLM 保持 $8.2。

Overlay 支持：`applyTokenRevenuePricing` 同时作用于官方数据行和 `?unofficialrun=` overlay 数据点，回退逻辑对两条路径均生效。Tooltip 不变，仅在存在实测值时显示实测命中率，另显示理论命中率。

**仍然缺失、不在本 PR 范围：** GB200 dynamo-vllm Kimi K3（44 行中 13 行）、B200/B300 TRT MiniMax M3（各 33 行中 22 行）以及 1 行 B200 GLM-5.1 tilert 也没有服务端命中率。按照仅限 GB300 的白名单设计，这些仍按未缓存价格计费。根本修复应在上游为 GB300 AgentX 配方增加使用 srt-slurm v1.0.45+ 的启动分支，让 sweep 自行测量命中率。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cache-aware revenue math on a hardware-specific fallback; scope is narrow (GB300 allowlist) but affects dollar metrics users compare across SKUs.
> 
> **Overview**
> Fixes **inflated token revenue on GB300** when AgentX sweeps lack scraped `server_*_cache_hit_rate` telemetry (missing backend `/metrics`), which had been pricing ~97% cached input at the uncached rate.
> 
> Introduces **`pricingCacheHitRate`**: still uses **`measuredCacheHitRate`** when present; for **GB300 only**, falls back to **`theoretical_cache_hit_rate`** (clamped). Other hardware keep returning null so missing measurements stay visible.
> 
> Wires that helper into **token revenue** (`tokenRevenuePerGpuHour`), the **calculator** (`useThroughputData`, passing `hw`), and **historical trends** (`useInterpolatedTrendData`, with `hw` + theoretical rate on lightweight points). **`theoretical_cache_hit_rate`** is added to the calculator response metric allowlist so it survives trimming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7955a40402ce5dccff1f4f58f0d3a8be196d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->