### PR TITLE
Fix Qwen TRT-LLM refresh offload metadata and changelog labels

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -25,6 +25,84 @@ const defaultChartDef = createMockChartDefinition();
 const hwConfig = createMockHardwareConfig();
 
 describe('ScatterGraph', () => {
+  for (const mixedRuns of [false, true]) {
+    it(`${mixedRuns ? 'hides' : 'shows'} the refresh changelog for a ${mixedRuns ? 'mixed' : 'matching'} run series`, () => {
+      const refreshUrl =
+        'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33219708211/attempts/1';
+      const point = createMockInferenceData({
+        hwKey: 'gb300_dynamo-trt',
+        model: Model.Qwen3_5,
+        run_url: refreshUrl,
+        benchmark_type: 'agentic_traces',
+      });
+      const description = 'Refresh to collect TensorRT-LLM server metrics.';
+      mountWithProviders(
+        <div style={{ width: 1000, height: 600 }}>
+          <ScatterGraph
+            chartId="changelog-provenance"
+            modelLabel="Qwen3.5 397B"
+            data={
+              mixedRuns
+                ? [
+                    point,
+                    {
+                      ...point,
+                      x: 50,
+                      run_url:
+                        'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/31927376673/attempts/1',
+                    },
+                  ]
+                : [point]
+            }
+            xLabel="Interactivity"
+            yLabel="Throughput"
+            chartDefinition={defaultChartDef}
+          />
+        </div>,
+        {
+          inference: {
+            selectedModel: Model.Qwen3_5,
+            selectedSequence: Sequence.AgenticTraces,
+            selectedRunId: '33219708211',
+            selectedPrecisions: [Precision.FP4],
+            activeHwTypes: new Set(['gb300_dynamo-trt']),
+            hwTypesWithData: new Set(['gb300_dynamo-trt']),
+            hardwareConfig: {
+              'gb300_dynamo-trt': {
+                name: 'gb300-dynamo-trt',
+                label: 'GB300',
+                suffix: '(Dynamo TRTLLM)',
+                gpu: 'GB300',
+              },
+            },
+            availableRuns: {
+              '33219708211': {
+                runId: '33219708211',
+                runUrl: refreshUrl,
+                runDate: '2026-09-01',
+                conclusion: 'success',
+                changelog: {
+                  entries: [
+                    {
+                      config_keys: ['qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg'],
+                      description,
+                      pr_link: null,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          unofficial: {},
+        },
+      );
+      cy.get('label[for="checkbox-gb300_dynamo-trt"]')
+        .parent()
+        .trigger('pointermove', { pointerType: 'mouse' });
+      cy.contains('[role="tooltip"]', description).should(mixedRuns ? 'not.exist' : 'exist');
+    });
+  }
+
   it('offers the complete table when matching official points are all clipped', () => {
     const point = createMockInferenceData({ hwKey: 'b200_trt', precision: Precision.FP4 });
     mountWithProviders(

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -144,7 +144,7 @@ import {
 } from '@/components/inference/utils/knownIssueAnnotations';
 import { matchesQuickFilters } from '@/components/inference/utils/quickFilters';
 import { bestSeriesPerSku } from '@/components/inference/utils/best-series-per-sku';
-import { changelogConfigToHwKey } from '@/components/inference/utils/changelogFormatters';
+import { legendChangelogsByHardware } from '@/components/inference/utils/legend-changelog';
 import {
   buildFrontierContinuations,
   fitContinuationLabelBaseline,
@@ -708,27 +708,15 @@ const ScatterGraph = React.memo(
     });
 
     // --- Changelog ---
-    const changelog = availableRuns ? availableRuns[selectedRunId]?.changelog || null : null;
-    const highlightedHwKeys = useMemo(() => {
-      if (availableRuns) {
-        const cl = availableRuns[selectedRunId]?.changelog;
-        if (cl) {
-          const hwKeys = cl.entries.flatMap((entry: any) =>
-            (entry.config_keys ?? entry['config-keys'] ?? [])
-              .filter((key: string) => selectedPrecisions.includes(key.split('-')[1]))
-              .map((key: string) =>
-                changelogConfigToHwKey(
-                  key,
-                  selectedSequence === Sequence.AgenticTraces ? 'agentic_traces' : undefined,
-                ),
-              )
-              .filter((key: string | null): key is string => key !== null),
-          );
-          return new Set(hwKeys);
-        }
-      }
-      return new Set<string>();
-    }, [availableRuns, selectedRunId, selectedPrecisions, selectedSequence]);
+    const legendChangelogs = useMemo(
+      () =>
+        legendChangelogsByHardware(
+          data,
+          availableRuns,
+          selectedSequence === Sequence.AgenticTraces ? 'agentic_traces' : 'single_turn',
+        ),
+      [data, availableRuns, selectedSequence],
+    );
 
     // --- Data Processing ---
     const groupedData = useMemo(
@@ -3546,7 +3534,7 @@ const ScatterGraph = React.memo(
                     label: getDisplayLabel(hwConfig),
                     color: resolveColor(key),
                     title: hwConfig.gpu,
-                    isHighlighted: highlightedHwKeys.has(key),
+                    isHighlighted: legendChangelogs.get(key)?.runId === selectedRunId,
                     hw: key,
                     isActive: showAllHardwareTypes ? true : effectiveOfficialHwTypes.has(key),
                     onClick: showAllHardwareTypes
@@ -3562,8 +3550,10 @@ const ScatterGraph = React.memo(
                         framework: hwConfig.framework ?? '',
                       });
                     },
-                    tooltip: changelog
-                      ? formatChangelogDescription(changelog.entries[0].description)
+                    tooltip: legendChangelogs.has(key)
+                      ? formatChangelogDescription(
+                          legendChangelogs.get(key)!.entries.map((entry) => entry.description),
+                        )
                       : null,
                   })),
               ]}

--- a/packages/app/src/components/inference/utils/legend-changelog.test.ts
+++ b/packages/app/src/components/inference/utils/legend-changelog.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { MODEL_PREFIX_MAPPING } from '@/lib/data-mappings';
+import type { RunInfo } from '../types';
+import { legendChangelogsByHardware } from './legend-changelog';
+
+const oldRunId = '31927376673';
+const refreshRunId = '33219708211';
+const runUrl = (id: string) =>
+  `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}/attempts/1`;
+const point = {
+  hwKey: 'gb300_dynamo-trt',
+  model: MODEL_PREFIX_MAPPING['qwen3.5'],
+  precision: 'fp4',
+  run_url: runUrl(refreshRunId),
+};
+const unrelatedEntry = {
+  config_keys: ['qwen3.5-fp4-b200-sglang-agentic'],
+  description: 'Unrelated B200 update.',
+  pr_link: null,
+};
+const refreshEntry = {
+  config_keys: ['qwen3.5-fp4-gb300-dynamo-trt-agentic-disagg'],
+  description: 'Refresh to collect TensorRT-LLM server metrics.',
+  pr_link: 'https://github.com/SemiAnalysisAI/InferenceX/pull/2770',
+};
+const runs: Record<string, RunInfo> = {
+  [refreshRunId]: {
+    runId: refreshRunId,
+    runUrl: runUrl(refreshRunId),
+    runDate: '2026-09-01',
+    conclusion: 'success',
+    changelog: { entries: [unrelatedEntry, refreshEntry] },
+  },
+};
+
+describe('legendChangelogsByHardware', () => {
+  it('uses the matching config entry, not the selected run first entry', () => {
+    expect(legendChangelogsByHardware([point], runs, 'agentic_traces').get(point.hwKey)).toEqual({
+      runId: refreshRunId,
+      entries: [refreshEntry],
+    });
+  });
+
+  it('does not label the August 16 point with the September 1 refresh', () => {
+    const original = { ...point, run_url: runUrl(oldRunId) };
+    expect(legendChangelogsByHardware([original], runs, 'agentic_traces').size).toBe(0);
+    expect(legendChangelogsByHardware([original, point], runs, 'agentic_traces').size).toBe(0);
+  });
+
+  it('uses the actual producing run when it is available', () => {
+    const oldEntry = { ...refreshEntry, description: 'Original submission.' };
+    const withHistory = {
+      ...runs,
+      [oldRunId]: { ...runs[refreshRunId]!, runId: oldRunId, changelog: { entries: [oldEntry] } },
+    };
+    expect(
+      legendChangelogsByHardware(
+        [{ ...point, run_url: runUrl(oldRunId) }],
+        withHistory,
+        'agentic_traces',
+      ).get(point.hwKey),
+    ).toEqual({ runId: oldRunId, entries: [oldEntry] });
+  });
+
+  it('does not attach official changelogs to an unrelated unofficial overlay run', () => {
+    expect(
+      legendChangelogsByHardware(
+        [{ ...point, run_url: runUrl('99999999999') }],
+        runs,
+        'agentic_traces',
+      ).size,
+    ).toBe(0);
+  });
+
+  it('requires point provenance, matching model, precision, hardware and scenario', () => {
+    for (const changed of [
+      { run_url: undefined },
+      { model: MODEL_PREFIX_MAPPING.dsv4 },
+      { precision: 'fp8' },
+      { hwKey: 'b300_dynamo-trt' },
+    ]) {
+      expect(
+        legendChangelogsByHardware([{ ...point, ...changed }], runs, 'agentic_traces').size,
+      ).toBe(0);
+    }
+    const fixedOnly = {
+      [refreshRunId]: {
+        ...runs[refreshRunId]!,
+        changelog: {
+          entries: [{ ...refreshEntry, config_keys: ['qwen3.5-fp4-gb300-dynamo-trt'] }],
+        },
+      },
+    };
+    expect(legendChangelogsByHardware([point], fixedOnly, 'agentic_traces').size).toBe(0);
+    expect(legendChangelogsByHardware([point], fixedOnly, 'single_turn').size).toBe(1);
+    expect(legendChangelogsByHardware([point], undefined, 'agentic_traces').size).toBe(0);
+    expect(legendChangelogsByHardware([], runs, 'agentic_traces').size).toBe(0);
+  });
+});

--- a/packages/app/src/components/inference/utils/legend-changelog.ts
+++ b/packages/app/src/components/inference/utils/legend-changelog.ts
@@ -1,0 +1,41 @@
+import type { ChangelogMetadata, InferenceData, RunInfo } from '../types';
+import { MODEL_PREFIX_MAPPING } from '@/lib/data-mappings';
+import { runIdFromRunUrl } from '@/lib/known-issues';
+import { configKeyMatchesHwKey } from './changelogFormatters';
+
+type LegendPoint = Pick<InferenceData, 'hwKey' | 'model' | 'precision' | 'run_url'>;
+
+/** A hardware legend must not attribute a mixed-run curve to one run's changelog. */
+export function legendChangelogsByHardware(
+  points: readonly LegendPoint[],
+  availableRuns: Record<string, RunInfo> | null | undefined,
+  benchmarkType: 'single_turn' | 'agentic_traces',
+): Map<string, { runId: string; entries: ChangelogMetadata['entries'] }> {
+  const grouped = new Map<string, LegendPoint[]>();
+  for (const point of points) {
+    const group = grouped.get(point.hwKey) ?? [];
+    group.push(point);
+    grouped.set(point.hwKey, group);
+  }
+
+  const changelogs = new Map<string, { runId: string; entries: ChangelogMetadata['entries'] }>();
+  for (const [hwKey, group] of grouped) {
+    const runIds = new Set(group.map((point) => runIdFromRunUrl(point.run_url)));
+    const runId = runIds.values().next().value;
+    if (runIds.size !== 1 || !runId) continue;
+    const entries = availableRuns?.[runId]?.changelog?.entries.filter((entry) =>
+      entry.config_keys.some((key) => {
+        const [model, precision] = key.split('-');
+        return (
+          configKeyMatchesHwKey(key, hwKey, benchmarkType) &&
+          group.some(
+            (point) =>
+              point.precision === precision && point.model === MODEL_PREFIX_MAPPING[model!],
+          )
+        );
+      }),
+    );
+    if (entries?.length) changelogs.set(hwKey, { runId, entries });
+  }
+  return changelogs;
+}

--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -67,6 +67,62 @@ describe('audited run backfills', () => {
     expect(() => validateRunBackfills()).not.toThrow();
   });
 
+  it('corrects only the six Qwen metrics-refresh recipes without changing measurements', () => {
+    const backfills = BENCHMARK_POINT_BACKFILLS.filter((b) => b.githubRunId === 33219708211);
+    expect(backfills.map((b) => [b.productionConfigId, b.conc, b.recipeFingerprint])).toEqual([
+      [2360, 7, '18f2c2292689243d0b87de83c376830284db0d86fb04a729376a8e310e01856d'],
+      [2361, 96, '097590578e9c8f65a51537c359a0bc0d0b4fcc5dbb557ee77a0939dbe0baeb3f'],
+      [2362, 704, 'c798a4b016d861f821f34fbc9cffdfdcd74e1b608304f01f4fa944388ddd5ed0'],
+      [2363, 52, '8b163e70d15e09358a90ea0e109a7d60bb822b71155285479822854747fa51bc'],
+      [2364, 565, '3f73af0d7e9b46406415309565b5c912a78e3a7f0661e497a028af7323845fc4'],
+      [2365, 44, '22c7807daf12e816829cdb3d8c8fe08f28d5a8e20b3eb7d33f0090e92dafe866'],
+    ]);
+    for (const backfill of backfills) {
+      const point = {
+        configId: backfill.productionConfigId,
+        config: backfill.config,
+        benchmarkType: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc: backfill.conc,
+        offloadMode: 'off',
+        recipeFingerprint: backfill.recipeFingerprint,
+        metrics: {
+          median_itl: 0.1,
+          output_tput_per_gpu: 123,
+          server_gpu_cache_hit_rate: 0.5284,
+          kv_p2p_transfer: 'nixl',
+          allocated_cpu_dram_gb: 0,
+          kv_offloading: 'none',
+        },
+      };
+      const applied = applyBenchmarkPointBackfill(33219708211, 1, point);
+      expect(applied.point).toEqual({
+        ...point,
+        offloadMode: 'on',
+        metrics: {
+          median_itl: 0.1,
+          output_tput_per_gpu: 123,
+          server_gpu_cache_hit_rate: 0.5284,
+          kv_p2p_transfer: 'nixl',
+          offload_mode: 'on',
+          kv_offloading: 'dram',
+          kv_offload_backend: 'native',
+          kv_offload_backend_version: '1.3.0rc24',
+        },
+      });
+      expect(applyBenchmarkPointBackfill(33219708211, 2, point).backfillId).toBeNull();
+      expect(applyBenchmarkPointBackfill(31927376673, 1, point).backfillId).toBeNull();
+      expect(
+        applyBenchmarkPointBackfill(33219708211, 1, { ...point, recipeFingerprint: null })
+          .backfillId,
+      ).toBeNull();
+      expect(applyBenchmarkPointBackfill(33219708211, 1, applied.point).point).toEqual(
+        applied.point,
+      );
+    }
+  });
+
   it('limits borrowed prefix-cache hit rates to GB300 dynamo-vllm DeepSeek-V4 AgentX points', () => {
     const cacheHitKeys = [
       'server_gpu_cache_hit_rate',

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -757,6 +757,96 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
     },
   })),
 
+  // The Qwen metrics refresh retained the same 128 GiB host KV cache on
+  // prefill and decode, but its artifacts again reported offloading as disabled.
+  ...(
+    [
+      [
+        2360,
+        7,
+        '18f2c2292689243d0b87de83c376830284db0d86fb04a729376a8e310e01856d',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 1 },
+          { tp: 8, ep: 8, dpAttn: false, numWorkers: 7 },
+        ),
+      ],
+      [
+        2361,
+        96,
+        '097590578e9c8f65a51537c359a0bc0d0b4fcc5dbb557ee77a0939dbe0baeb3f',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 2, ep: 2, dpAttn: false, numWorkers: 2 },
+          { tp: 8, ep: 8, dpAttn: false, numWorkers: 3 },
+        ),
+      ],
+      [
+        2362,
+        704,
+        'c798a4b016d861f821f34fbc9cffdfdcd74e1b608304f01f4fa944388ddd5ed0',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 3 },
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 2 },
+        ),
+      ],
+      [
+        2363,
+        52,
+        '8b163e70d15e09358a90ea0e109a7d60bb822b71155285479822854747fa51bc',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 1, ep: 1, dpAttn: true, numWorkers: 2 },
+          { tp: 2, ep: 2, dpAttn: false, numWorkers: 2 },
+        ),
+      ],
+      [
+        2364,
+        565,
+        '3f73af0d7e9b46406415309565b5c912a78e3a7f0661e497a028af7323845fc4',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 4, ep: 4, dpAttn: true, numWorkers: 3 },
+          { tp: 16, ep: 16, dpAttn: true, numWorkers: 1 },
+        ),
+      ],
+      [
+        2365,
+        44,
+        '22c7807daf12e816829cdb3d8c8fe08f28d5a8e20b3eb7d33f0090e92dafe866',
+        disaggregatedConfig(
+          QWEN35_GB300_DYNAMO_TRT,
+          { tp: 1, ep: 1, dpAttn: true, numWorkers: 1 },
+          { tp: 2, ep: 2, dpAttn: false, numWorkers: 1 },
+        ),
+      ],
+    ] as const
+  ).map(([productionConfigId, conc, recipeFingerprint, config]) => ({
+    id: `run-33219708211-config-${productionConfigId}-conc-${conc}-native-offload`,
+    reason:
+      'The Qwen TRT-LLM metrics refresh retained native host KV caching, but its offload metadata incorrectly placed it on a separate frontier from the original run.',
+    githubRunId: 33219708211,
+    runAttempt: 1,
+    productionConfigId,
+    config,
+    benchmarkType: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc,
+    offloadMode: 'off',
+    recipeFingerprint,
+    set: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'native',
+        kv_offload_backend_version: '1.3.0rc24',
+      },
+    },
+  })),
+
   // The six disaggregated DeepSeek-V4-Pro recipes in run 32403083041
   // configure a 180 GiB native host KV cache on each prefill worker. The
   // master matrix omitted the offload annotation, so the artifacts reported


### PR DESCRIPTION
## Summary

- Correct the six Qwen3.5 GB300 TRT-LLM AgentX points from [run 33219708211, attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33219708211/attempts/1) to native DRAM offloading. They retained a 128 GiB host KV cache but were ingested as offload-disabled, leaving the older offload-enabled results on the latest frontier.
- Match legend changelogs to the actual producing run and configuration; suppress a single-run label on mixed-run series.
- Preserve benchmark IDs, measurements, traces and run links. The existing post-merge override workflow applies the correction and refreshes production caches; no sweep rerun or trace backfill is needed.

Evidence: the [executed c704 recipe](https://github.com/SemiAnalysisAI/InferenceX/blob/0ad41b7c38078d2275c150f409626a297c853906/benchmarks/multi_node/srt-slurm-recipes/trtllm/qwen3.5/gb300-fp4/disagg/agentx/disagg-gb300-3p2d-dep4-dep4-c704-b32-mtp-kvoffload.yaml#L88) and startup logs both configure 128 GiB. This corrects refresh [InferenceX #2770](https://github.com/SemiAnalysisAI/InferenceX/pull/2770).

## Verification

Unit tests, typecheck, lint, and browser smoke tests pass (43 component / 110 integration tests), including matching/mixed-run tooltip regressions and unofficial-overlay coverage. Production data has not been modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production ETL backfills for benchmark metadata and user-visible legend/changelog attribution; measurements are preserved but offload grouping and labels change on the inference charts.
> 
> **Overview**
> Adds **ETL backfills** for six Qwen3.5 GB300 Dynamo TRT-LLM AgentX points from run `33219708211` so they report **native DRAM KV offload** (`offloadMode: on` and related metrics) without altering throughput or other measurements—fixing a frontier split where the metrics refresh was ingested as offload-off despite unchanged host KV cache.
> 
> **Scatter graph legend changelogs** no longer key off the globally selected run’s first changelog entry. A new `legendChangelogsByHardware` helper ties tooltips and highlight state to the **producing run** and **matching changelog config keys** (model, precision, hardware, agentic vs single-turn). Series that mix multiple GitHub runs on one hardware curve **omit** the changelog tooltip so a refresh label is not wrongly attributed.
> 
> Coverage includes Vitest for the helper, a focused backfill regression test, and Cypress cases for matching vs mixed-run tooltip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4bbdb2bde17caf05e5bfa093bf03f8cefe72fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->