### PR TITLE
Allow run-scoped metadata repair through Actions

### DIFF
--- a/.github/workflows/apply-run-overrides.yml
+++ b/.github/workflows/apply-run-overrides.yml
@@ -7,6 +7,11 @@ on:
       - 'packages/db/src/etl/run-overrides.ts'
       - '.github/workflows/apply-run-overrides.yml'
   workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Optional GitHub run ID; only apply its registered overrides'
+        required: false
+        type: string
 
 permissions: {}
 
@@ -49,7 +54,13 @@ jobs:
       - name: Apply run overrides
         env:
           DATABASE_WRITE_URL: ${{ secrets.DATABASE_WRITE_URL }}
-        run: bun run admin:db:apply-overrides --yes
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          args=(--yes)
+          if [[ -n "$RUN_ID" ]]; then
+            args+=(--run-id "$RUN_ID")
+          fi
+          bun run admin:db:apply-overrides "${args[@]}"
 
       - name: Verify database
         env:

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -11,6 +11,7 @@
  * Usage:
  *   bun run db:apply-overrides            # preview + confirm
  *   bun run db:apply-overrides --yes      # skip confirmation
+ *   bun run db:apply-overrides --run-id 33219708211 --yes  # one registered run
  *
  * Commits to run-overrides.ts are applied to production automatically after merge.
  * Use this command directly only for local preview or manual recovery.
@@ -22,18 +23,23 @@ import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
 import { configCacheKey } from './etl/config-cache.js';
 import { type Sql, createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
 import { jsonbParam } from './lib/backfill-runner.js';
+import { selectRunOverrides } from './lib/run-override-selection.js';
 import {
   type BenchmarkPointBackfill,
   type ChangelogBackfill,
   type PurgedBenchmarkPoint,
-  BENCHMARK_POINT_BACKFILLS,
-  CHANGELOG_BACKFILLS,
-  CONCLUSION_OVERRIDES,
-  PURGED_BENCHMARK_POINTS,
-  PURGED_RUN_ATTEMPTS,
-  PURGED_RUNS,
   validateRunBackfills,
 } from './etl/run-overrides.js';
+
+const {
+  runId,
+  benchmarks: BENCHMARK_POINT_BACKFILLS,
+  changelogs: CHANGELOG_BACKFILLS,
+  conclusions: CONCLUSION_OVERRIDES,
+  purgedPoints: PURGED_BENCHMARK_POINTS,
+  purgedAttempts: PURGED_RUN_ATTEMPTS,
+  purgedRuns: PURGED_RUNS,
+} = selectRunOverrides(process.argv.slice(2));
 
 const sql = createAdminSql({
   noSsl: hasNoSslFlag(),
@@ -600,6 +606,7 @@ async function purgeBenchmarkPoints(resultIds: number[]): Promise<void> {
 async function main(): Promise<void> {
   validateRunBackfills();
   console.log('=== apply-overrides ===');
+  if (runId !== undefined) console.log(`  Scoped to GitHub run ${runId}`);
 
   // Phase 1: preview (read-only)
   let hasWork = false;

--- a/packages/db/src/lib/run-override-selection.test.ts
+++ b/packages/db/src/lib/run-override-selection.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BENCHMARK_POINT_BACKFILLS,
+  CHANGELOG_BACKFILLS,
+  CONCLUSION_OVERRIDES,
+  PURGED_BENCHMARK_POINTS,
+  PURGED_RUN_ATTEMPTS,
+  PURGED_RUNS,
+} from '../etl/run-overrides';
+import { selectRunOverrides } from './run-override-selection';
+
+describe('run override selection', () => {
+  it('keeps all registered operations when no run is selected', () => {
+    expect(selectRunOverrides(['--yes'])).toEqual({
+      runId: undefined,
+      conclusions: CONCLUSION_OVERRIDES,
+      changelogs: CHANGELOG_BACKFILLS,
+      benchmarks: BENCHMARK_POINT_BACKFILLS,
+      purgedRuns: PURGED_RUNS,
+      purgedAttempts: PURGED_RUN_ATTEMPTS,
+      purgedPoints: PURGED_BENCHMARK_POINTS,
+    });
+  });
+
+  it('isolates the six Qwen refresh patches from unrelated backfills and purges', () => {
+    const selected = selectRunOverrides(['--run-id', '33219708211', '-y', '--no-ssl']);
+    expect(selected.runId).toBe(33219708211);
+    expect(selected.benchmarks.map((entry) => entry.conc).toSorted((a, b) => a - b)).toEqual([
+      7, 44, 52, 96, 565, 704,
+    ]);
+    expect(selected.benchmarks.every((entry) => entry.githubRunId === 33219708211)).toBe(true);
+    expect(selected.conclusions.size).toBe(0);
+    expect(selected.changelogs).toEqual([]);
+    expect(selected.purgedRuns.size).toBe(0);
+    expect(selected.purgedAttempts.size).toBe(0);
+    expect(selected.purgedPoints).toEqual([]);
+  });
+
+  it('scopes every operation type to its selected run', () => {
+    const ids = new Set([
+      ...CONCLUSION_OVERRIDES.keys(),
+      ...CHANGELOG_BACKFILLS.map((entry) => entry.githubRunId),
+      ...BENCHMARK_POINT_BACKFILLS.map((entry) => entry.githubRunId),
+      ...PURGED_RUNS,
+      ...PURGED_RUN_ATTEMPTS.keys(),
+      ...PURGED_BENCHMARK_POINTS.map((entry) => entry.githubRunId),
+    ]);
+    for (const id of ids) {
+      const selected = selectRunOverrides([`--run-id=${id}`]);
+      expect([...selected.conclusions]).toEqual(
+        [...CONCLUSION_OVERRIDES].filter(([run]) => run === id),
+      );
+      expect(selected.changelogs).toEqual(
+        CHANGELOG_BACKFILLS.filter((entry) => entry.githubRunId === id),
+      );
+      expect(selected.benchmarks).toEqual(
+        BENCHMARK_POINT_BACKFILLS.filter((entry) => entry.githubRunId === id),
+      );
+      expect([...selected.purgedRuns]).toEqual([...PURGED_RUNS].filter((run) => run === id));
+      expect([...selected.purgedAttempts]).toEqual(
+        [...PURGED_RUN_ATTEMPTS].filter(([run]) => run === id),
+      );
+      expect(selected.purgedPoints).toEqual(
+        PURGED_BENCHMARK_POINTS.filter((entry) => entry.githubRunId === id),
+      );
+    }
+  });
+
+  it.each(['', '0', '-1', '1.2', '1e3', '123abc', ' 123 ', '9007199254740992'])(
+    'rejects invalid run ID %j before any database access',
+    (value) => {
+      expect(() => selectRunOverrides([`--run-id=${value}`])).toThrow('positive integer');
+    },
+  );
+
+  it('rejects a missing value, unknown flags, and unregistered runs', () => {
+    expect(() => selectRunOverrides(['--run-id'])).toThrow();
+    expect(() => selectRunOverrides(['--runid', '33219708211'])).toThrow();
+    expect(() => selectRunOverrides(['--run-id', '1'])).toThrow('No registered overrides');
+  });
+});

--- a/packages/db/src/lib/run-override-selection.ts
+++ b/packages/db/src/lib/run-override-selection.ts
@@ -1,0 +1,49 @@
+import { parseArgs } from 'node:util';
+
+import {
+  BENCHMARK_POINT_BACKFILLS,
+  CHANGELOG_BACKFILLS,
+  CONCLUSION_OVERRIDES,
+  PURGED_BENCHMARK_POINTS,
+  PURGED_RUN_ATTEMPTS,
+  PURGED_RUNS,
+} from '../etl/run-overrides.js';
+
+export function selectRunOverrides(args: string[]) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      'run-id': { type: 'string' },
+      yes: { type: 'boolean', short: 'y' },
+      'no-ssl': { type: 'boolean' },
+    },
+  });
+  const value = values['run-id'];
+  if (value !== undefined && (!/^[1-9]\d*$/u.test(value) || !Number.isSafeInteger(Number(value)))) {
+    throw new Error('--run-id must be a positive integer GitHub run ID');
+  }
+  const runId = value === undefined ? undefined : Number(value);
+  const matches = (id: number) => runId === undefined || id === runId;
+  const selection = {
+    runId,
+    conclusions: new Map([...CONCLUSION_OVERRIDES].filter(([id]) => matches(id))),
+    changelogs: CHANGELOG_BACKFILLS.filter((entry) => matches(entry.githubRunId)),
+    benchmarks: BENCHMARK_POINT_BACKFILLS.filter((entry) => matches(entry.githubRunId)),
+    purgedRuns: new Set([...PURGED_RUNS].filter(matches)),
+    purgedAttempts: new Map([...PURGED_RUN_ATTEMPTS].filter(([id]) => matches(id))),
+    purgedPoints: PURGED_BENCHMARK_POINTS.filter((entry) => matches(entry.githubRunId)),
+  };
+  if (
+    runId !== undefined &&
+    selection.conclusions.size +
+      selection.changelogs.length +
+      selection.benchmarks.length +
+      selection.purgedRuns.size +
+      selection.purgedAttempts.size +
+      selection.purgedPoints.length ===
+      0
+  ) {
+    throw new Error(`No registered overrides for run ${runId}`);
+  }
+  return selection;
+}


### PR DESCRIPTION
Adds an optional run ID to Apply Run Overrides so a reviewed correction can run independently of unrelated backfills. Existing identity checks and production cache invalidation remain unchanged.

Needed for Qwen refresh run 33219708211: the automatic job for #981 stopped on an older DeepSeek backfill before applying the six Qwen corrections. This does not change that unrelated patch or relax its safety checks.

Validation: 641 DB unit tests, typecheck, lint and formatting passed. No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production override application paths and can run targeted purges/backfills, but scoping is opt-in with strict ID validation and existing verify/cache steps remain.
> 
> **Overview**
> Adds optional **`--run-id`** so `apply-overrides` and the **Apply Run Overrides** GitHub Action can apply only the registered corrections, backfills, and purges for one GitHub workflow run instead of the full `run-overrides.ts` queue.
> 
> A new **`selectRunOverrides`** helper parses CLI args, validates positive safe-integer run IDs, errors on unregistered runs, and filters all six override categories. **`apply-overrides`** loads lists through that helper and logs when scoped. **Manual workflow dispatch** accepts an optional `run_id` input forwarded to the admin script; push-to-main behavior is unchanged when the input is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91af86fecf8b8727199024f6281e39d59fbc46c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->