### PR TITLE
fix: correct DeepSeek V4 GB300 Mooncake offload metadata

### DIFF
--- a/packages/db/src/etl/run-overrides.test.ts
+++ b/packages/db/src/etl/run-overrides.test.ts
@@ -123,6 +123,63 @@ describe('audited run backfills', () => {
     }
   });
 
+  it.each([
+    [128, 4, 'd84f06bb4a4016f9f2fe917feb4f10b960f87ac5f48bfae1b0bca1d66d7c887b'],
+    [256, 4, '1472857d464c0780b5eeb41184ff70290c5f6b9ad6a8c07b2524697e21dd0e07'],
+    [512, 8, '6ab19ba8680ab38b81c0d6a251d252576caafaf660118007c508b1f62df08c39'],
+  ] as const)(
+    'corrects the GB300 Mooncake c%i recipe without changing performance',
+    (conc, prefillSize, recipeFingerprint) => {
+      const point = {
+        configId: prefillSize === 4 ? 2449 : 2448,
+        config: {
+          ...EXAMPLE_CONFIG,
+          prefillTp: prefillSize,
+          prefillEp: prefillSize,
+          numPrefillGpu: prefillSize,
+          decodeTp: 16,
+          decodeEp: 16,
+          numDecodeGpu: 16,
+        },
+        benchmarkType: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc,
+        offloadMode: 'off',
+        recipeFingerprint,
+        metrics: {
+          kv_offloading: 'none',
+          allocated_cpu_dram_gb: 0,
+          median_itl: 0.1,
+          output_tput_per_gpu: 123,
+        },
+      };
+      const applied = applyBenchmarkPointBackfill(32809502132, 1, point);
+      expect(applied.point.offloadMode).toBe('on');
+      expect(applied.point.metrics).toMatchObject({
+        offload_mode: 'on',
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+        median_itl: 0.1,
+        output_tput_per_gpu: 123,
+      });
+      expect(applied.point.metrics).not.toHaveProperty('allocated_cpu_dram_gb');
+      expect(applyBenchmarkPointBackfill(32809502132, 2, point).backfillId).toBeNull();
+      expect(
+        applyBenchmarkPointBackfill(32809502132, 1, { ...point, recipeFingerprint: null })
+          .backfillId,
+      ).toBeNull();
+      expect(applyBenchmarkPointBackfill(32809502132, 1, applied.point).point).toEqual(
+        applied.point,
+      );
+      expect(
+        BENCHMARK_POINT_BACKFILLS.find((b) => b.githubRunId === 32809502132 && b.conc === 4)?.set
+          .offloadMode,
+      ).toBeUndefined();
+    },
+  );
+
   it('limits borrowed prefix-cache hit rates to GB300 dynamo-vllm DeepSeek-V4 AgentX points', () => {
     const cacheHitKeys = [
       'server_gpu_cache_hit_rate',

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -639,31 +639,42 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
       ],
     ] as const
   ).map(
-    ([
-      githubRunId,
-      runAttempt,
-      productionConfigId,
-      conc,
-      donorConc,
-      recipeFingerprint,
-      config,
-    ]) => ({
-      id: `run-${githubRunId}-config-${productionConfigId}-conc-${conc}-gb200-cache-hit-rate`,
-      reason: GB300_CACHE_HIT_RATE_REASON,
-      githubRunId,
-      runAttempt,
-      productionConfigId,
-      config,
-      benchmarkType: 'agentic_traces',
-      isl: null,
-      osl: null,
-      conc,
-      offloadMode: 'off',
-      recipeFingerprint,
-      set: {
-        metricsMerge: gb200CacheHitRateMerge(donorConc),
-      },
-    }),
+    ([githubRunId, runAttempt, productionConfigId, conc, donorConc, recipeFingerprint, config]) => {
+      const usesMooncake = githubRunId === 32809502132 && conc !== 4;
+      return {
+        id: `run-${githubRunId}-config-${productionConfigId}-conc-${conc}-gb200-cache-hit-rate`,
+        reason:
+          GB300_CACHE_HIT_RATE_REASON +
+          (usesMooncake
+            ? ' The runtime also enabled Mooncake DRAM caching, which the artifact mislabeled as non-offloaded.'
+            : ''),
+        githubRunId,
+        runAttempt,
+        productionConfigId,
+        config,
+        benchmarkType: 'agentic_traces',
+        isl: null,
+        osl: null,
+        conc,
+        offloadMode: 'off',
+        recipeFingerprint,
+        set: {
+          ...(usesMooncake
+            ? { offloadMode: 'on' as const, metricsRemove: ['allocated_cpu_dram_gb'] }
+            : {}),
+          metricsMerge: {
+            ...gb200CacheHitRateMerge(donorConc),
+            ...(usesMooncake
+              ? {
+                  kv_offloading: 'dram',
+                  kv_offload_backend: 'mooncake',
+                  kv_offload_backend_version: '0.3.11.post1',
+                }
+              : {}),
+          },
+        },
+      };
+    },
   ),
 
   // Every TensorRT-LLM recipe in run 31927376673 configures a 128 GiB native


### PR DESCRIPTION
Correct the c128, c256 and c512 points from [run 32809502132](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/32809502132), submitted in SemiAnalysisAI/InferenceX#2665. Their worker logs show Mooncake DRAM caching, but the artifacts label them non-offloaded. Keep c4 non-offloaded.

Extend their existing audited backfills so re-ingestion preserves the correction. Retain the previously registered cache-hit-rate corrections; do not change throughput, latency, runtime settings or point IDs. GB200 already has its database correction.

Related master-YAML PR: SemiAnalysisAI/InferenceX#2817. Validation: focused override tests and typecheck pass; verify the targeted correction on an expiring production child branch before applying it through GitHub Actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ETL-only audited backfill metadata for three benchmark points; performance metrics and point IDs are explicitly preserved, with tests guarding behavior.
> 
> **Overview**
> Fixes mislabeled **offload identity** for DeepSeek-V4 GB300 dynamo-vllm AgentX points from run **32809502132** at concurrency **128, 256, and 512**. Worker logs show Mooncake DRAM caching, but artifacts stored them as non-offloaded.
> 
> The change **extends the existing GB200 cache-hit-rate backfill entries** for those three points (same IDs and performance fields): on ingest/re-apply it sets `offloadMode` to **on**, strips `allocated_cpu_dram_gb`, and merges Mooncake KV metadata (`kv_offloading: dram`, backend `mooncake`, version `0.3.11.post1`) while **keeping borrowed prefix-cache hit rates and throughput/latency unchanged**. **c4** in the same run stays non-offloaded—no `set.offloadMode` patch.
> 
> Adds parameterized tests that assert the correction, idempotency, attempt/fingerprint matching, and that the c4 registry entry still has no offload override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde49aec215807c3f821562dd88148aa40abd71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
