### PR TITLE
Add prev/next run arrows and enable Latest when an older run is selected / 新增运行前后箭头，并在选中旧运行时启用「最新」按钮

### DIFF
--- a/packages/app/src/components/inference/ui/WorkflowInfoDisplay.test.ts
+++ b/packages/app/src/components/inference/ui/WorkflowInfoDisplay.test.ts
@@ -1,10 +1,34 @@
 import { describe, expect, it } from 'vitest';
 
-import { workflowRunCountLabel } from './WorkflowInfoDisplay';
+import { getAdjacentRunId, getLatestRunId, workflowRunCountLabel } from './WorkflowInfoDisplay';
 
 describe('workflow run count label', () => {
   it('preserves the English label and uses natural Chinese counting syntax', () => {
     expect(workflowRunCountLabel(2, 5, 'en')).toBe('Run 2/5');
     expect(workflowRunCountLabel(2, 5, 'zh')).toBe('第 2 次运行（共 5 次）');
+  });
+});
+
+describe('run navigation helpers', () => {
+  const runIds = ['100', '200', '300'];
+
+  it('steps to the adjacent run in each direction', () => {
+    expect(getAdjacentRunId(runIds, '200', 'previous')).toBe('100');
+    expect(getAdjacentRunId(runIds, '200', 'next')).toBe('300');
+  });
+
+  it('returns undefined at the ends of the run list', () => {
+    expect(getAdjacentRunId(runIds, '100', 'previous')).toBeUndefined();
+    expect(getAdjacentRunId(runIds, '300', 'next')).toBeUndefined();
+  });
+
+  it('returns undefined when the selected run is unknown or the list is empty', () => {
+    expect(getAdjacentRunId(runIds, '999', 'next')).toBeUndefined();
+    expect(getAdjacentRunId([], '100', 'previous')).toBeUndefined();
+  });
+
+  it('treats the last run id as the latest run', () => {
+    expect(getLatestRunId(runIds)).toBe('300');
+    expect(getLatestRunId([])).toBeUndefined();
   });
 });

--- a/packages/app/src/components/inference/ui/WorkflowInfoDisplay.tsx
+++ b/packages/app/src/components/inference/ui/WorkflowInfoDisplay.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from 'lucide-react';
+import { ChevronDownIcon, ChevronLeft, ChevronRight } from 'lucide-react';
 
 import { track } from '@/lib/analytics';
 import { Button } from '@/components/ui/button';
@@ -32,6 +32,8 @@ const WORKFLOW_STRINGS = {
     conclusions: { success: 'Run succeeded', failure: 'Run failed', cancelled: 'Run cancelled' },
     run: 'Run',
     runCount: (index: number, total: number) => workflowRunCountLabel(index, total, 'en'),
+    previousRun: 'Previous run',
+    nextRun: 'Next run',
     changelog: 'Changelog',
     description: 'Description',
     updatedConfigs: 'Updated Configs',
@@ -43,6 +45,8 @@ const WORKFLOW_STRINGS = {
     conclusions: { success: '运行成功', failure: '运行失败', cancelled: '运行已取消' },
     run: '运行',
     runCount: (index: number, total: number) => workflowRunCountLabel(index, total, 'zh'),
+    previousRun: '上一次运行',
+    nextRun: '下一次运行',
     changelog: '变更日志',
     description: '说明',
     updatedConfigs: '已更新配置',
@@ -54,6 +58,27 @@ const WORKFLOW_STRINGS = {
 
 export function workflowRunCountLabel(index: number, total: number, locale: Locale): string {
   return locale === 'zh' ? `第 ${index} 次运行（共 ${total} 次）` : `Run ${index}/${total}`;
+}
+
+/**
+ * Returns the run id adjacent to `selectedRunId` in `runIds` (which is ordered
+ * oldest → newest, matching the "Run i/n" labels), or `undefined` when there is
+ * no run in that direction or the selection is unknown.
+ */
+export function getAdjacentRunId(
+  runIds: readonly string[],
+  selectedRunId: string,
+  direction: 'previous' | 'next',
+): string | undefined {
+  const index = runIds.indexOf(selectedRunId);
+  if (index === -1) return undefined;
+  const target = direction === 'previous' ? index - 1 : index + 1;
+  return target >= 0 && target < runIds.length ? runIds[target] : undefined;
+}
+
+/** The newest run id, i.e. the last entry of the oldest → newest `runIds` list. */
+export function getLatestRunId(runIds: readonly string[]): string | undefined {
+  return runIds.at(-1);
 }
 
 function RunConclusionDot({ conclusion, locale }: { conclusion: string | null; locale: Locale }) {
@@ -86,6 +111,16 @@ export default function WorkflowInfoDisplay() {
   const { effectivePrecisions } = useGlobalFilterSelection();
 
   const runIds = Object.keys(availableRuns);
+  const latestRunId = getLatestRunId(runIds);
+  const isLatestRunSelected = latestRunId === undefined || selectedRunId === latestRunId;
+  const previousRunId = getAdjacentRunId(runIds, selectedRunId, 'previous');
+  const nextRunId = getAdjacentRunId(runIds, selectedRunId, 'next');
+
+  const selectRun = (runId: string | undefined, source: string) => {
+    if (!runId) return;
+    track('inference_run_selected', { run: runId, source });
+    setSelectedRunId(runId);
+  };
 
   if (runIds.length === 0) {
     return (
@@ -123,16 +158,22 @@ export default function WorkflowInfoDisplay() {
         onChange={(date) => setSelectedRunDate(date)}
         availableDates={availableDates}
         isCheckingAvailableDates={isCheckingAvailableDates}
+        isLatestRunSelected={isLatestRunSelected}
+        onGoToLatestRun={() => selectRun(latestRunId, 'latest')}
       />
       {runIds.length > 0 ? (
         <div className="flex items-center gap-0.5">
-          <Select
-            value={selectedRunId}
-            onValueChange={(value) => {
-              track('inference_run_selected', { run: value });
-              setSelectedRunId(value);
-            }}
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => selectRun(previousRunId, 'previous')}
+            disabled={previousRunId === undefined}
+            className="size-11 md:size-8"
+            aria-label={t.previousRun}
           >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <Select value={selectedRunId} onValueChange={(value) => selectRun(value, 'select')}>
             <SelectTrigger
               id="run-select"
               aria-label={t.run}
@@ -185,6 +226,16 @@ export default function WorkflowInfoDisplay() {
               })}
             </SelectContent>
           </Select>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => selectRun(nextRunId, 'next')}
+            disabled={nextRunId === undefined}
+            className="size-11 md:size-8"
+            aria-label={t.nextRun}
+          >
+            <ChevronRight className="size-4" />
+          </Button>
         </div>
       ) : null}
       <div>

--- a/packages/app/src/components/ui/date-picker.tsx
+++ b/packages/app/src/components/ui/date-picker.tsx
@@ -72,6 +72,17 @@ export interface DatePickerProps {
   placeholder?: string;
   availableDates?: string[];
   isCheckingAvailableDates?: boolean;
+  /**
+   * Whether the newest run on the selected date is currently selected. When
+   * false, the external "Latest" button stays enabled even on the latest date
+   * so it can jump to the newest run. Defaults to true.
+   */
+  isLatestRunSelected?: boolean;
+  /**
+   * Called by the external "Latest" button when the latest date is already
+   * selected but an older run is active, so the caller can select the newest run.
+   */
+  onGoToLatestRun?: () => void;
 }
 
 /**
@@ -85,6 +96,8 @@ export function DatePicker({
   placeholder,
   availableDates,
   isCheckingAvailableDates,
+  isLatestRunSelected = true,
+  onGoToLatestRun,
 }: DatePickerProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
@@ -167,12 +180,22 @@ export function DatePicker({
     setTempDate(getLatestDate());
   };
 
-  // Go to latest date directly (for external button)
+  // Go to latest date directly (for external button). When the latest date is
+  // already selected, fall through to the latest run instead.
   const handleGoToLatestExternal = () => {
+    if (isCurrentDateLatest()) {
+      if (!isLatestRunSelected && onGoToLatestRun) {
+        track('date_picker_go_to_latest_run');
+        onGoToLatestRun();
+      }
+      return;
+    }
     const latestDate = getLatestDate();
     track('date_picker_go_to_latest', { date: latestDate });
     onChange(latestDate);
   };
+
+  const isLatestDisabled = isCurrentDateLatest() && isLatestRunSelected;
 
   // Get current date index in available dates
   const getCurrentDateIndex = () => {
@@ -229,7 +252,7 @@ export function DatePicker({
           variant="ghost"
           size="sm"
           onClick={handleGoToLatestExternal}
-          disabled={isCurrentDateLatest() || Boolean(isCheckingAvailableDates)}
+          disabled={isLatestDisabled || Boolean(isCheckingAvailableDates)}
           className="px-2"
         >
           {t.latest}


### PR DESCRIPTION
## Summary

Two small UX fixes to the run picker row (Latest / Run Date / Run N/M):

- **Prev/next arrows for runs** — the run selector now has `‹` / `›` ghost icon buttons on either side, matching the existing arrows on the date picker, to step through runs on the selected date. Arrows disable at the first/last run.
- **"Latest" button stays available when the latest run isn't selected** — previously the button was disabled whenever the latest *date* was selected, even if an older run (e.g. Run 2/3) was active. It now stays enabled in that case and jumps to the newest run. On an older date it still jumps to the latest date (which resolves to the newest run automatically).

### Implementation

- `date-picker.tsx`: new optional props `isLatestRunSelected` (default `true`) and `onGoToLatestRun`. The external Latest button is disabled only when both the date and run are latest.
- `WorkflowInfoDisplay.tsx`: adds the arrow buttons, wires the new props, and extracts pure helpers `getAdjacentRunId` / `getLatestRunId`. Run ordering follows `Object.keys(availableRuns)` (oldest → newest), the same order used for the "Run i/n" labels.
- Analytics: `inference_run_selected` now carries a `source` (`select` / `previous` / `next` / `latest`); a new `date_picker_go_to_latest_run` event fires when Latest jumps to a run.

### Testing

- Unit tests added for `getAdjacentRunId` / `getLatestRunId` in `WorkflowInfoDisplay.test.ts`.
- `bun run lint`, `bun run fmt`, `bun run check:typography`, `bun run typecheck` all pass locally.

## 中文说明

对运行选择行（最新 / 运行日期 / 第 N 次运行）的两个小改进：

- **运行前后箭头**：运行选择器两侧新增 `‹` / `›` 图标按钮，与日期选择器的箭头样式一致，可在当前日期内逐个切换运行；处于第一个/最后一个运行时对应箭头禁用。
- **未选中最新运行时「最新」按钮保持可用**：此前只要选中最新日期，「最新」按钮就会被禁用，即使当前是较旧的运行（如第 2/3 次）。现在该情况下按钮保持可用，点击后跳转到最新运行；若处于较旧日期，仍会跳转到最新日期（并自动解析为最新运行）。

实现：`date-picker.tsx` 新增可选属性 `isLatestRunSelected`（默认 `true`）与 `onGoToLatestRun`；`WorkflowInfoDisplay.tsx` 新增箭头按钮并抽取 `getAdjacentRunId` / `getLatestRunId` 辅助函数，附带单元测试。lint、格式、排版与类型检查均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only inference filter navigation with backward-compatible DatePicker defaults; no auth, API, or data-model changes.
> 
> **Overview**
> Improves the inference **run picker** row with **previous/next chevron buttons** around the run dropdown (same pattern as the date picker). Stepping uses new pure helpers `getAdjacentRunId` and `getLatestRunId` over `Object.keys(availableRuns)` (oldest → newest); arrows disable at the ends. EN/ZH `aria-label` strings were added for the new buttons.
> 
> The date picker’s external **Latest** control no longer disables solely because the latest date is selected: optional props `isLatestRunSelected` and `onGoToLatestRun` let `WorkflowInfoDisplay` keep Latest enabled when an older run on that date is active and jump to the newest run. Run changes go through a shared `selectRun` helper; `inference_run_selected` analytics now include a `source` (`select` / `previous` / `next` / `latest`), plus `date_picker_go_to_latest_run` when Latest selects the newest run.
> 
> Unit tests cover the run navigation helpers in `WorkflowInfoDisplay.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb320d799ff1541353ed33ab5da999d33d2358f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->