### PR TITLE
fix(inference): default to the day's last run by start time, not max run id / 默认选中当天按开始时间最新的运行，而非最大 run id

### DIFF
--- a/packages/app/src/components/GlobalFilterContext.stale-url.test.tsx
+++ b/packages/app/src/components/GlobalFilterContext.stale-url.test.tsx
@@ -56,7 +56,11 @@ vi.mock('@/components/unofficial-run-provider', () => ({
   useUnofficialRun: () => ({ availableModelsAndSequences: [] }),
 }));
 
-import { GlobalFilterProvider, useGlobalFilterSelection } from './GlobalFilterContext';
+import {
+  GlobalFilterProvider,
+  useGlobalFilterRun,
+  useGlobalFilterSelection,
+} from './GlobalFilterContext';
 
 /** Kimi-K3 availability: both the Agentic and the 8K/1K scenario exist. */
 const KIMI_K3_ROWS = [
@@ -64,15 +68,25 @@ const KIMI_K3_ROWS = [
   { model: 'kimik3', isl: 8192, osl: 1024, benchmark_type: 'single_turn' },
 ];
 
+/** Two Agentic run dates; a retained `g_rundate` snapshot points at the older one. */
+const STALE_RUN_DATE = '2026-08-20';
+const LATEST_RUN_DATE = '2026-09-01';
+const KIMI_K3_DATED_ROWS = [
+  { ...KIMI_K3_ROWS[0], precision: 'fp8', date: STALE_RUN_DATE },
+  { ...KIMI_K3_ROWS[0], precision: 'fp8', date: LATEST_RUN_DATE },
+];
+
 let root: Root | undefined;
 let container: HTMLDivElement | undefined;
 let observedSequence: Sequence | undefined;
 let observedResolved: boolean | undefined;
+let observedRunDate: string | undefined;
 
 const SequenceProbe = memo(() => {
   const selection = useGlobalFilterSelection();
   observedSequence = selection.effectiveSequence;
   observedResolved = selection.sequenceResolved;
+  observedRunDate = useGlobalFilterRun().effectiveRunDate;
   return null;
 });
 
@@ -95,6 +109,7 @@ beforeEach(() => {
   mocks.hasExplicitUrlParam.mockClear();
   observedSequence = undefined;
   observedResolved = undefined;
+  observedRunDate = undefined;
 });
 
 afterEach(() => {
@@ -117,5 +132,38 @@ describe('GlobalFilterProvider stale i_seq snapshot', () => {
     mountProvider();
     expect(observedResolved).toBe(true);
     expect(observedSequence).toBe(Sequence.EightK_OneK);
+  });
+});
+
+/**
+ * The same snapshot-vs-live-URL split applies to the run pins. Every manual
+ * date pick (and every blog "live chart" link) writes `g_rundate` into the
+ * snapshot; `refreshUrlParams` never evicts it. If the provider honored that
+ * retained value on a navigation whose URL carries no `g_rundate`, it would flip
+ * the explicit-date flag and open a fresh dashboard on the OLD date instead of
+ * the latest run — the "run date is not at the latest on a fresh load" bug.
+ */
+describe('GlobalFilterProvider stale g_rundate snapshot', () => {
+  beforeEach(() => {
+    mocks.availability.data = KIMI_K3_DATED_ROWS;
+    mocks.getUrlParam.mockImplementation((key: string) =>
+      key === 'g_rundate' ? STALE_RUN_DATE : undefined,
+    );
+  });
+
+  afterEach(() => {
+    mocks.getUrlParam.mockImplementation((key: string) => (key === 'i_seq' ? '8k/1k' : undefined));
+  });
+
+  it('ignores a retained g_rundate the current URL does not carry — latest date wins', () => {
+    mocks.hasExplicitUrlParam.mockReturnValue(false);
+    mountProvider();
+    expect(observedRunDate).toBe(LATEST_RUN_DATE);
+  });
+
+  it('still pins a g_rundate explicitly present in the current URL', () => {
+    mocks.hasExplicitUrlParam.mockImplementation((key: string) => key === 'g_rundate');
+    mountProvider();
+    expect(observedRunDate).toBe(STALE_RUN_DATE);
   });
 });

--- a/packages/app/src/components/GlobalFilterContext.test.ts
+++ b/packages/app/src/components/GlobalFilterContext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildRunInfo,
   getRequestedRunUrlParams,
+  latestRunId,
   resolveEffectiveRunDate,
   resolveEffectiveRunId,
 } from '@/components/GlobalFilterContext';
@@ -10,10 +11,10 @@ import workflowFixture from '../../cypress/fixtures/api/workflow-info.json';
 import type { WorkflowInfoResponse } from '@/lib/api';
 import type { RunInfo } from '@/components/inference/types';
 
-function run(runId: string): RunInfo {
+function run(runId: string, runDate = '2026-08-20T00:00:00Z'): RunInfo {
   return {
     runId,
-    runDate: '2026-08-20',
+    runDate,
     runUrl: `https://example.test/${runId}`,
     conclusion: 'success',
   };
@@ -136,10 +137,42 @@ describe('global filter requested and effective selectors', () => {
   });
 
   it('keeps a valid run ID and otherwise selects the newest available run', () => {
-    const runs = { '100': run('100'), '102': run('102'), '101': run('101') };
+    const runs = {
+      '100': run('100', '2026-08-20T01:00:00Z'),
+      '102': run('102', '2026-08-20T03:00:00Z'),
+      '101': run('101', '2026-08-20T02:00:00Z'),
+    };
     expect(resolveEffectiveRunId('101', runs)).toBe('101');
     expect(resolveEffectiveRunId('missing', runs)).toBe('102');
     expect(resolveEffectiveRunId('', runs)).toBe('102');
+  });
+
+  it('picks the newest run by start time, not by the greatest GitHub run id', () => {
+    // Production 2026-09-01 DSV4: the largest id (…526958) was created at 17:10Z
+    // while a smaller id (…433573) is the day's last sweep at 21:35Z. The old
+    // max-id rule opened a fresh page on the older run ("Run 2/3").
+    const runs = {
+      '33145139961': run('33145139961', '2026-09-01T17:04:07Z'),
+      '33447526958': run('33447526958', '2026-09-01T17:10:19Z'),
+      '33418433573': run('33418433573', '2026-09-01T21:35:56Z'),
+    };
+    expect(latestRunId(runs)).toBe('33418433573');
+    expect(resolveEffectiveRunId('', runs)).toBe('33418433573');
+    expect(resolveEffectiveRunId('33447526958', runs)).toBe('33447526958');
+  });
+
+  it('falls back to API order (created_at ASC) when start times tie or are missing', () => {
+    const tied = {
+      '33447526958': run('33447526958', '2026-09-01T17:10:19Z'),
+      '33418433573': run('33418433573', '2026-09-01T17:10:19Z'),
+    };
+    expect(latestRunId(tied)).toBe('33418433573');
+    const missing = {
+      '33447526958': run('33447526958', ''),
+      '33418433573': run('33418433573', ''),
+    };
+    expect(latestRunId(missing)).toBe('33418433573');
+    expect(latestRunId({})).toBe('');
   });
 
   it('clears the effective run ID for a settled empty run map', () => {

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -170,14 +170,42 @@ export function resolveEffectiveRunDate(
   return availableDates.at(-1)!;
 }
 
+/**
+ * The run that actually happened last on the selected date.
+ *
+ * GitHub run ids are not a chronological key. A re-run keeps its original id,
+ * and same-day sweeps land with ids out of `created_at` order in production
+ * (2026-09-01 DSV4: 33447526958 at 17:10Z vs 33418433573 at 21:35Z) — so the
+ * lexicographically-greatest id is NOT reliably the newest run. Picking by id
+ * opened a fresh page on "Run 2/3" (an older sweep with a larger id) instead of
+ * the day's last sweep, with that older run's changelog.
+ *
+ * `runDate` is `latest_workflow_runs.created_at`, which the API serializes as
+ * a fixed-width ISO-8601 UTC string, so a plain string compare orders it
+ * chronologically. Ties (and missing timestamps) fall back to API order, which
+ * `getWorkflowRunsByDate` sorts by `created_at ASC` — the same order the run
+ * selector numbers its entries, so "latest" and "Run N/N" agree.
+ */
+export function latestRunId(availableRuns: Readonly<Record<string, RunInfo>>): string {
+  let latest = '';
+  let latestDate = '';
+  for (const [runId, info] of Object.entries(availableRuns)) {
+    const runDate = info.runDate ?? '';
+    if (!latest || runDate >= latestDate) {
+      latest = runId;
+      latestDate = runDate;
+    }
+  }
+  return latest;
+}
+
 export function resolveEffectiveRunId(
   requestedRunId: string,
   availableRuns: Readonly<Record<string, RunInfo>>,
 ): string {
-  const runIds = Object.keys(availableRuns);
-  if (runIds.length === 0) return '';
+  if (Object.keys(availableRuns).length === 0) return '';
   if (requestedRunId && Object.hasOwn(availableRuns, requestedRunId)) return requestedRunId;
-  return runIds.reduce((latest, runId) => (runId > latest ? runId : latest), runIds[0]);
+  return latestRunId(availableRuns);
 }
 
 export function getRequestedRunUrlParams(
@@ -363,11 +391,22 @@ export function GlobalFilterProvider({
         setPrecisionExplicit(true);
       }
     }
-    applyIfMatches('g_rundate', RUNDATE_RE, (date) => {
-      requestedRunDateExplicitRef.current = true;
-      setRequestedRunDate(date);
-    });
-    applyIfMatches('g_runid', RUNID_RE, setRequestedRunId);
+    // Same guard again for the run pins. The snapshot retains `g_rundate` /
+    // `g_runid` self-writes from an earlier visit (a manual date pick, or a
+    // blog "live chart" link that pinned a date), and `refreshUrlParams` does
+    // not evict keys the live URL no longer carries. Applying them here would
+    // flip `requestedRunDateExplicitRef` and re-pin a stale date on a page the
+    // user reached without any `g_rundate` — so a fresh dashboard would open
+    // on an old run instead of the latest one. Only the CURRENT URL may pin.
+    if (hasExplicitUrlParam('g_rundate')) {
+      applyIfMatches('g_rundate', RUNDATE_RE, (date) => {
+        requestedRunDateExplicitRef.current = true;
+        setRequestedRunDate(date);
+      });
+    }
+    if (hasExplicitUrlParam('g_runid')) {
+      applyIfMatches('g_runid', RUNID_RE, setRequestedRunId);
+    }
     // Re-runs on client-side navigation as well as on mount. Keyed on the
     // pathname, which the Next router owns: the provider's own share-link
     // writes go through `history.replaceState` and never change it, so this

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/favorites/favorite-presets';
 
 import {
+  latestRunId,
   useGlobalFilterActions,
   useGlobalFilterAvailability,
   useGlobalFilterRun,
@@ -577,18 +578,21 @@ export function InferenceProvider({
     [availableRuns, modelPrefixes, effectivePrecisions],
   );
 
+  // The latest run for this model on the selected date, by start time. Run ids
+  // are assigned at dispatch and a queued or re-run sweep can start after a
+  // later-dispatched one, so the greatest id is not necessarily the newest run
+  // (see `latestRunId`). The DB side already tiebreaks by `run_started_at`;
+  // this keeps the client's notion of "latest" consistent with it.
+  const latestRunIdForModel = useMemo(
+    () => latestRunId(filteredAvailableRuns),
+    [filteredAvailableRuns],
+  );
+
   const effectiveSelectedRunId = useMemo(() => {
     const filteredRunIds = Object.keys(filteredAvailableRuns);
     if (filteredRunIds.length === 0 || filteredRunIds.includes(selectedRunId)) return selectedRunId;
-    return filteredRunIds.reduce((max, id) => (id > max ? id : max), filteredRunIds[0]);
-  }, [filteredAvailableRuns, selectedRunId]);
-
-  // The latest run for this model on the selected date. GitHub run ids increase
-  // monotonically with time, so the lexicographically-greatest id is the newest run.
-  const latestRunIdForModel = useMemo(() => {
-    const ids = Object.keys(filteredAvailableRuns);
-    return ids.length > 0 ? ids.reduce((max, id) => (id > max ? id : max), ids[0]) : '';
-  }, [filteredAvailableRuns]);
+    return latestRunIdForModel;
+  }, [filteredAvailableRuns, selectedRunId, latestRunIdForModel]);
 
   // Only constrain the base query when an earlier-than-latest run is selected.
   const asOfRunId =


### PR DESCRIPTION
## Summary

On a fresh load the dashboard sometimes opens on an **older same-day run** instead of the latest one — e.g. DSV4 · Agentic on 2026-09-01 lands on **"Run 2/3"** with that run's changelog (screenshot in [#gta6-research-inference](https://semianalysis.slack.com/archives/C09PULGMVNG/p1788457873492749)).

### Root cause

The client treated the **lexicographically-greatest GitHub run id** as "the newest run" (`resolveEffectiveRunId`, and `latestRunIdForModel` / `effectiveSelectedRunId` in `InferenceContext`). Run ids are not a chronological key: a re-run keeps its original id, and same-day sweeps land with ids out of `created_at` order in production. For 2026-09-01 the `/api/v1/workflow-info` runs for DSV4 are:

| run id | created_at | sweep |
|---|---|---|
| 33145139961 | 17:04Z | Bump DSV4 B300 SGLang AgentX HiCache MTP … |
| **33447526958** | 17:10Z | Add DSV4 B200 disaggregated Dynamo SGLang STP … ← **max id, picked by default** |
| 33418433573 | **21:35Z** | Refresh DeepSeek V4 GB300 TRT-LLM AgentX metrics ← actual latest |

The DB side already tiebreaks same-day runs by `run_started_at` (#264, #457 — Alec's earlier fix). The client's "latest" now agrees with it.

### Changes

- **`latestRunId()`** (new, `GlobalFilterContext.tsx`): picks the run with the greatest `runDate` (`latest_workflow_runs.created_at`, fixed-width ISO UTC so a string compare is chronological). Ties / missing timestamps fall back to API order, which `getWorkflowRunsByDate` sorts `created_at ASC` — the same order the run selector numbers its entries, so "latest" and "Run N/N" line up.
- `resolveEffectiveRunId` and `InferenceContext`'s `latestRunIdForModel` / `effectiveSelectedRunId` fallback use it, so the `asOfRunId` cutoff also keys off the real latest run.
- **Stale-snapshot guard for the run pins**: the URL-param layout effect now applies `g_rundate` / `g_runid` only when the *current* URL carries them (`hasExplicitUrlParam`), matching the existing `g_model` / `i_seq` guards from #795 / #890. The module snapshot retains self-written pins across soft navigations (a manual date pick, a blog "live chart" link), and re-applying one flipped `requestedRunDateExplicitRef` and re-pinned an old date on a page reached without any `g_rundate`.

### Tests

- `GlobalFilterContext.test.ts`: out-of-order id scenario (the production 09-01 runs), tie / missing-timestamp fallback, empty map.
- `GlobalFilterContext.stale-url.test.tsx`: retained `g_rundate` snapshot is ignored (latest date wins) unless the current URL carries it. Verified the new case fails without the guard.
- `bun run typecheck`, `lint`, `fmt`, `test:unit` (293 files / 4798 tests in app) all pass.

### Not in scope (follow-up)

`comparisonEntrySortValue` / `buildRunNumbering` in `comparisonEntry.ts` still order multi-run comparison entries by run id; on a day like 09-01 the comparison legend's "#2/#3" can disagree with the selector's "Run 2/3". Harmless for the default view; worth aligning to `created_at` separately.

## 中文说明

### 问题
新鲜加载时仪表板有时会打开当天**较早的运行**而不是最新的运行，例如 DSV4 · Agentic 2026-09-01 默认落在 "Run 2/3"，并显示该运行的 changelog。

### 根因
客户端把**字典序最大的 GitHub run id** 当作"最新运行"。但 run id 并不按时间排序：重跑会保留原 id，且生产环境中同一天的 sweep 会出现 id 与 `created_at` 顺序不一致（09-01：33447526958 创建于 17:10Z，而 33418433573 创建于 21:35Z 才是当天最后一次 sweep）。数据库侧早已按 `run_started_at` 决胜（#264、#457），客户端现在与之一致。

### 修改
- 新增 `latestRunId()`：按 `runDate`（`created_at`）选取最新运行，平局或缺失时回退到接口顺序（`created_at ASC`），与运行选择器的编号顺序一致。
- `resolveEffectiveRunId` 与 `InferenceContext` 中的 `latestRunIdForModel` / `effectiveSelectedRunId` 回退均改用该函数，`asOfRunId` 截止点也随之正确。
- URL 参数应用效果仅在**当前 URL** 确实携带 `g_rundate` / `g_runid` 时才生效（`hasExplicitUrlParam`），与既有的 `g_model` / `i_seq` 守卫一致，避免快照中残留的旧日期在无参数页面上被重新固定。

### 测试
新增单元测试覆盖 id 乱序、平局/缺失回退，以及残留 `g_rundate` 快照的回归用例；`typecheck` / `lint` / `fmt` / `test:unit` 全部通过。

### 后续
`comparisonEntry.ts` 中的多运行对比编号仍按 run id 排序，可另行对齐到 `created_at`。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default run/date resolution for inference dashboards and global filter URL hydration; wrong logic would affect which benchmark slice and changelog users see on load, but behavior is covered by new unit tests and aligns with existing server ordering.
> 
> **Overview**
> Fixes fresh loads opening on an **older same-day workflow run** (e.g. "Run 2/3" with the wrong changelog) and sometimes pinning an **outdated run date** after navigation without run URL params.
> 
> **Latest run selection** no longer uses the greatest GitHub run id. New **`latestRunId()`** chooses the run with the latest `runDate` (`created_at`); ties or missing timestamps keep API insertion order. **`resolveEffectiveRunId`** and **`InferenceContext`** fallbacks (`latestRunIdForModel`, invalid `selectedRunId`) use it so defaults and **`asOfRunId`** match the DB’s start-time ordering and the run selector’s "Run N/N".
> 
> **URL hydration** for **`g_rundate`** / **`g_runid`** now mirrors the existing **`i_seq`** guard: values apply only when **`hasExplicitUrlParam`** says the **current** URL carries them, so retained module snapshot pins from a prior visit do not re-mark the date explicit or stick an old run on paramless pages.
> 
> Tests cover production-style id vs. time ordering, tie/missing fallbacks, and stale **`g_rundate`** snapshot behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ca3ad10f6d2f850de11b5a7fe9aa9520d1a9a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->