### PR TITLE
fix: resume previously applied offload backfills

### DIFF
--- a/.github/workflows/ingest-agentic-results.yml
+++ b/.github/workflows/ingest-agentic-results.yml
@@ -292,7 +292,9 @@ jobs:
         run: bun run admin:db:ingest:ci
 
       - name: Apply run overrides
-        run: bun run admin:db:apply-overrides --yes
+        env:
+          OVERRIDE_RUN_ID: ${{ steps.artifacts.outputs.merge-run-id }}
+        run: bun run admin:db:apply-overrides --run-id "$OVERRIDE_RUN_ID" --allow-unregistered-run --yes
 
       - name: Verify database
         run: bun run admin:db:verify

--- a/.github/workflows/ingest-results.yml
+++ b/.github/workflows/ingest-results.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Apply run overrides
         env:
           DATABASE_WRITE_URL: ${{ secrets.DATABASE_WRITE_URL }}
-        run: bun run admin:db:apply-overrides --yes
+          OVERRIDE_RUN_ID: ${{ steps.artifacts.outputs.merge-run-id }}
+        run: bun run admin:db:apply-overrides --run-id "$OVERRIDE_RUN_ID" --allow-unregistered-run --yes
 
       - name: Verify database
         env:

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -118,6 +118,11 @@ When extending an already-applied identity-changing correction, record its old
 `set` as `previousSet`. The recovery command accepts that declared prior patch
 before applying the new fields; unrecognized destination states still fail closed.
 
+Post-ingest workflows scope recovery to the ingested run with `--run-id` and
+`--allow-unregistered-run` (a no-op for runs without corrections). They do not
+reapply unrelated historical corrections that may be absent from a staging branch.
+The standalone recovery command remains strict by default.
+
 Run `bun run admin:db:apply-overrides` to preview the exact rows, reasons, and patches;
 the command requires confirmation unless passed `--yes`. It fails before writing when a
 target is missing, when a point's desired identity already exists, or when registry

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -114,6 +114,10 @@ updates both the first-class column and `metrics.offload_mode`; for example, a m
 KV offload annotation can set `offloadMode: 'on'` and merge `kv_offloading` plus backend
 metadata in one correction. Unrelated metrics remain unchanged.
 
+When extending an already-applied identity-changing correction, record its old
+`set` as `previousSet`. The recovery command accepts that declared prior patch
+before applying the new fields; unrecognized destination states still fail closed.
+
 Run `bun run admin:db:apply-overrides` to preview the exact rows, reasons, and patches;
 the command requires confirmation unless passed `--yes`. It fails before writing when a
 target is missing, when a point's desired identity already exists, or when registry

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -23,6 +23,7 @@ import { confirm, hasNoSslFlag, hasYesFlag } from './cli-utils.js';
 import { configCacheKey } from './etl/config-cache.js';
 import { type Sql, createAdminSql, refreshLatestBenchmarks } from './etl/db-utils.js';
 import { jsonbParam } from './lib/backfill-runner.js';
+import { planBenchmarkPointBackfill } from './lib/benchmark-point-backfill.js';
 import { selectRunOverrides } from './lib/run-override-selection.js';
 import {
   type BenchmarkPointBackfill,
@@ -194,72 +195,6 @@ interface BenchmarkPointBackfillTarget {
   metrics: Record<string, unknown>;
 }
 
-function asMetricsRecord(value: unknown): Record<string, unknown> | null {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function benchmarkPointMetricsPatch(backfill: BenchmarkPointBackfill): Record<string, unknown> {
-  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
-  return {
-    ...backfill.set.metricsMerge,
-    ...(backfill.set.offloadMode === undefined ? {} : { offload_mode: desiredOffloadMode }),
-  };
-}
-
-/**
- * Recognize the exact malformed value written by the first benchmark-point
- * backfill implementation. It concatenated a metrics object with a JSONB
- * string, producing `[originalMetrics, "{...patch}"]`.
- */
-function recoverMalformedBenchmarkPointMetrics(
-  value: unknown,
-  backfill: BenchmarkPointBackfill,
-): Record<string, unknown> | null {
-  if (!Array.isArray(value) || value.length !== 2) return null;
-  const originalMetrics = asMetricsRecord(value[0]);
-  if (!originalMetrics || typeof value[1] !== 'string') return null;
-
-  try {
-    const appendedPatch = JSON.parse(value[1]) as unknown;
-    if (!isDeepStrictEqual(appendedPatch, benchmarkPointMetricsPatch(backfill))) return null;
-  } catch {
-    return null;
-  }
-  return originalMetrics;
-}
-
-function patchedBenchmarkPointMetrics(
-  sourceMetrics: Record<string, unknown>,
-  backfill: BenchmarkPointBackfill,
-): Record<string, unknown> {
-  const metrics = { ...sourceMetrics };
-  for (const key of backfill.set.metricsRemove ?? []) delete metrics[key];
-  Object.assign(metrics, benchmarkPointMetricsPatch(backfill));
-  return metrics;
-}
-
-function benchmarkPointBackfillIsApplied(
-  row: Record<string, unknown>,
-  backfill: BenchmarkPointBackfill,
-): boolean {
-  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
-  if (row.offload_mode !== desiredOffloadMode) return false;
-  const metrics = asMetricsRecord(row.metrics);
-  if (!metrics) return false;
-  if (backfill.set.offloadMode !== undefined && metrics.offload_mode !== desiredOffloadMode) {
-    return false;
-  }
-  for (const [key, value] of Object.entries(backfill.set.metricsMerge ?? {})) {
-    if (!isDeepStrictEqual(metrics[key], value)) return false;
-  }
-  for (const key of backfill.set.metricsRemove ?? []) {
-    if (Object.hasOwn(metrics, key)) return false;
-  }
-  return true;
-}
-
 function benchmarkPointDescription(backfill: BenchmarkPointBackfill): string {
   return (
     `run ${backfill.githubRunId} attempt ${backfill.runAttempt}, ` +
@@ -317,33 +252,23 @@ async function previewBenchmarkPointBackfill(
   const [row] = rows;
   console.log(`    ${backfill.id}: ${benchmarkPointDescription(backfill)}`);
   console.log(`      reason: ${backfill.reason}`);
-  if (benchmarkPointBackfillIsApplied(row, backfill)) {
+  const metrics = planBenchmarkPointBackfill(
+    { offload_mode: row.offload_mode, metrics: row.metrics },
+    backfill,
+  );
+  if (metrics === null) {
     console.log('      already applied.');
     return null;
   }
 
-  const malformedMetrics = recoverMalformedBenchmarkPointMetrics(row.metrics, backfill);
-  if (
-    row.offload_mode === desiredOffloadMode &&
-    desiredOffloadMode !== backfill.offloadMode &&
-    malformedMetrics === null
-  ) {
-    throw new Error(
-      `${backfill.id}: source identity is missing and the desired identity has unexpected data`,
-    );
-  }
-  const sourceMetrics = asMetricsRecord(row.metrics) ?? malformedMetrics;
-  if (!sourceMetrics) {
-    throw new Error(`${backfill.id}: benchmark metrics have an unexpected JSON shape`);
-  }
-  if (malformedMetrics) {
+  if (Array.isArray(row.metrics)) {
     console.log('      repair malformed metrics written by the previous backfill attempt');
   }
   console.log(`      set ${JSON.stringify(backfill.set)}`);
   return {
     backfill,
     resultId: row.id as number,
-    metrics: patchedBenchmarkPointMetrics(sourceMetrics, backfill),
+    metrics,
   };
 }
 

--- a/packages/db/src/apply-overrides.ts
+++ b/packages/db/src/apply-overrides.ts
@@ -12,6 +12,7 @@
  *   bun run db:apply-overrides            # preview + confirm
  *   bun run db:apply-overrides --yes      # skip confirmation
  *   bun run db:apply-overrides --run-id 33219708211 --yes  # one registered run
+ *   bun run db:apply-overrides --run-id 33721476500 --allow-unregistered-run --yes  # ingest
  *
  * Commits to run-overrides.ts are applied to production automatically after merge.
  * Use this command directly only for local preview or manual recovery.

--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -296,6 +296,8 @@ export interface BenchmarkPointBackfill extends AuditedBackfill {
   offloadMode: string;
   /** Producer recipe identity. Omit or set null only for legacy rows. */
   recipeFingerprint?: string | null;
+  /** Previously applied patch accepted when extending an identity-changing backfill. */
+  previousSet?: BenchmarkPointBackfill['set'];
   set: {
     /** Updates both the first-class column and metrics.offload_mode. */
     offloadMode?: 'on' | 'off';
@@ -529,6 +531,16 @@ export const BENCHMARK_POINT_BACKFILLS: readonly BenchmarkPointBackfill[] = [
     conc,
     offloadMode: 'off',
     recipeFingerprint,
+    // The offload-only version was applied before PR #975 added cache-hit fields.
+    previousSet: {
+      offloadMode: 'on' as const,
+      metricsRemove: ['allocated_cpu_dram_gb'],
+      metricsMerge: {
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+      },
+    },
     set: {
       offloadMode: 'on' as const,
       metricsRemove: ['allocated_cpu_dram_gb'],
@@ -1264,6 +1276,18 @@ export function validateRunBackfills(
       throw new Error(`${backfill.id}: recipeFingerprint must be null or non-empty`);
     }
     const mergeKeys = Object.keys(backfill.set.metricsMerge ?? {});
+    if (backfill.previousSet) {
+      const previous = backfill.previousSet;
+      if (
+        previous.offloadMode === undefined ||
+        previous.offloadMode !== backfill.set.offloadMode ||
+        previous.offloadMode === backfill.offloadMode ||
+        Object.keys(previous.metricsMerge ?? {}).length === 0
+      ) {
+        throw new Error(`${backfill.id}: previousSet must identify the prior destination patch`);
+      }
+      validateRunBackfills([], [{ ...backfill, previousSet: undefined, set: previous }]);
+    }
     const removeKeys = backfill.set.metricsRemove ?? [];
     if (
       backfill.set.offloadMode === undefined &&

--- a/packages/db/src/lib/benchmark-point-backfill.test.ts
+++ b/packages/db/src/lib/benchmark-point-backfill.test.ts
@@ -84,11 +84,14 @@ describe('benchmark point backfill recovery', () => {
     expect(metrics).not.toHaveProperty('allocated_cpu_dram_gb');
   });
 
-  it.each([null, [], [{}, 'not-json']])('rejects malformed metrics: %j', (metrics) => {
-    expect(() => planBenchmarkPointBackfill({ offload_mode: 'off', metrics }, backfill)).toThrow(
-      'unexpected JSON shape',
-    );
-  });
+  it.each([{ metrics: null }, { metrics: [] }, { metrics: [{}, 'not-json'] }])(
+    'rejects malformed metrics: $metrics',
+    ({ metrics }) => {
+      expect(() => planBenchmarkPointBackfill({ offload_mode: 'off', metrics }, backfill)).toThrow(
+        'unexpected JSON shape',
+      );
+    },
+  );
 
   it('rejects a previous patch targeting a different offload identity', () => {
     expect(() =>

--- a/packages/db/src/lib/benchmark-point-backfill.test.ts
+++ b/packages/db/src/lib/benchmark-point-backfill.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { BENCHMARK_POINT_BACKFILLS, validateRunBackfills } from '../etl/run-overrides';
+import { planBenchmarkPointBackfill } from './benchmark-point-backfill';
+
+const backfills = BENCHMARK_POINT_BACKFILLS.filter(
+  (b) => b.githubRunId === 31633154542 && b.set.offloadMode === 'on',
+);
+
+describe('benchmark point backfill recovery', () => {
+  it.each(backfills)('extends the previously applied c$conc offload patch', (backfill) => {
+    // State written before #975 added the cache-hit fields to this ledger entry.
+    const row = {
+      offload_mode: 'on',
+      metrics: {
+        offload_mode: 'on',
+        kv_offloading: 'dram',
+        kv_offload_backend: 'mooncake',
+        kv_offload_backend_version: '0.3.11.post1',
+        output_tput_per_gpu: 123.45,
+        median_itl: 0.025,
+      },
+    };
+    const original = structuredClone(row);
+    // Reproduces the failure without the explicitly registered previous version.
+    expect(() => planBenchmarkPointBackfill(row, { ...backfill, previousSet: undefined })).toThrow(
+      'desired identity has unexpected data',
+    );
+
+    const metrics = planBenchmarkPointBackfill(row, backfill)!;
+    expect(metrics).toMatchObject({
+      ...row.metrics,
+      ...backfill.set.metricsMerge,
+    });
+    expect(metrics.server_gpu_cache_hit_rate).toBeGreaterThan(0);
+    expect(metrics.server_cpu_cache_hit_rate).toBeGreaterThan(0);
+    expect(planBenchmarkPointBackfill({ ...row, metrics }, backfill)).toBeNull();
+    expect(row).toEqual(original);
+  });
+
+  const backfill = backfills[0]!;
+  const prior = {
+    offload_mode: 'on',
+    kv_offloading: 'dram',
+    kv_offload_backend: 'mooncake',
+    kv_offload_backend_version: '0.3.11.post1',
+  };
+
+  it.each([
+    { kv_offload_backend: 'lmcache' },
+    { kv_offload_backend_version: 'wrong-version' },
+    { offload_mode: 'off' },
+    { allocated_cpu_dram_gb: 0 },
+  ])('still rejects an unexpected destination: %j', (unexpected) => {
+    expect(() =>
+      planBenchmarkPointBackfill(
+        { offload_mode: 'on', metrics: { ...prior, ...unexpected } },
+        backfill,
+      ),
+    ).toThrow('desired identity has unexpected data');
+  });
+
+  it('applies to an untouched source and preserves unrelated measurements', () => {
+    const metrics = planBenchmarkPointBackfill(
+      { offload_mode: 'off', metrics: { allocated_cpu_dram_gb: 0, output_tput_per_gpu: 42 } },
+      backfill,
+    );
+    expect(metrics).toMatchObject({ ...prior, output_tput_per_gpu: 42 });
+    expect(metrics).not.toHaveProperty('allocated_cpu_dram_gb');
+  });
+
+  it('retains recovery of the original malformed JSONB patch', () => {
+    const metrics = planBenchmarkPointBackfill(
+      {
+        offload_mode: 'on',
+        metrics: [
+          { output_tput_per_gpu: 42, allocated_cpu_dram_gb: 0 },
+          JSON.stringify({ ...backfill.set.metricsMerge, offload_mode: 'on' }),
+        ],
+      },
+      backfill,
+    );
+    expect(metrics).toMatchObject({ ...prior, output_tput_per_gpu: 42 });
+    expect(metrics).not.toHaveProperty('allocated_cpu_dram_gb');
+  });
+
+  it.each([null, [], [{}, 'not-json']])('rejects malformed metrics: %j', (metrics) => {
+    expect(() => planBenchmarkPointBackfill({ offload_mode: 'off', metrics }, backfill)).toThrow(
+      'unexpected JSON shape',
+    );
+  });
+
+  it('rejects a previous patch targeting a different offload identity', () => {
+    expect(() =>
+      validateRunBackfills([], [{ ...backfill, previousSet: { offloadMode: 'off' } }]),
+    ).toThrow('previousSet must identify the prior destination patch');
+  });
+});

--- a/packages/db/src/lib/benchmark-point-backfill.ts
+++ b/packages/db/src/lib/benchmark-point-backfill.ts
@@ -1,0 +1,81 @@
+import { isDeepStrictEqual } from 'node:util';
+
+import type { BenchmarkPointBackfill } from '../etl/run-overrides.js';
+
+interface BackfillRow {
+  offload_mode: unknown;
+  metrics: unknown;
+}
+
+function asMetricsRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function metricsPatch(backfill: BenchmarkPointBackfill): Record<string, unknown> {
+  return {
+    ...backfill.set.metricsMerge,
+    ...(backfill.set.offloadMode === undefined ? {} : { offload_mode: backfill.set.offloadMode }),
+  };
+}
+
+function isApplied(row: BackfillRow, backfill: BenchmarkPointBackfill): boolean {
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  if (row.offload_mode !== desiredOffloadMode) return false;
+  const metrics = asMetricsRecord(row.metrics);
+  if (!metrics) return false;
+  return (
+    Object.entries(metricsPatch(backfill)).every(([key, value]) =>
+      isDeepStrictEqual(metrics[key], value),
+    ) && (backfill.set.metricsRemove ?? []).every((key) => !Object.hasOwn(metrics, key))
+  );
+}
+
+/** Recover only the exact JSONB array written by the original broken backfill. */
+function recoverMalformedMetrics(
+  value: unknown,
+  backfill: BenchmarkPointBackfill,
+): Record<string, unknown> | null {
+  if (!Array.isArray(value) || value.length !== 2) return null;
+  const originalMetrics = asMetricsRecord(value[0]);
+  if (!originalMetrics || typeof value[1] !== 'string') return null;
+  try {
+    if (!isDeepStrictEqual(JSON.parse(value[1]), metricsPatch(backfill))) return null;
+  } catch {
+    return null;
+  }
+  return originalMetrics;
+}
+
+/** The caller must first resolve exactly one source-or-destination identity. */
+export function planBenchmarkPointBackfill(
+  row: BackfillRow,
+  backfill: BenchmarkPointBackfill,
+): Record<string, unknown> | null {
+  if (isApplied(row, backfill)) return null;
+
+  const desiredOffloadMode = backfill.set.offloadMode ?? backfill.offloadMode;
+  const malformedMetrics = recoverMalformedMetrics(row.metrics, backfill);
+  const previousApplied =
+    backfill.previousSet !== undefined &&
+    isApplied(row, { ...backfill, set: backfill.previousSet });
+  if (
+    row.offload_mode === desiredOffloadMode &&
+    desiredOffloadMode !== backfill.offloadMode &&
+    malformedMetrics === null &&
+    !previousApplied
+  ) {
+    throw new Error(
+      `${backfill.id}: source identity is missing and the desired identity has unexpected data`,
+    );
+  }
+  const sourceMetrics = asMetricsRecord(row.metrics) ?? malformedMetrics;
+  if (!sourceMetrics) {
+    throw new Error(`${backfill.id}: benchmark metrics have an unexpected JSON shape`);
+  }
+  const metrics = { ...sourceMetrics };
+  for (const key of backfill.set.metricsRemove ?? []) delete metrics[key];
+  Object.assign(metrics, metricsPatch(backfill));
+  return metrics;
+}

--- a/packages/db/src/lib/run-override-selection.test.ts
+++ b/packages/db/src/lib/run-override-selection.test.ts
@@ -11,6 +11,27 @@ import {
 import { selectRunOverrides } from './run-override-selection';
 
 describe('run override selection', () => {
+  it('makes an unregistered ingest a no-op without touching historical rows', () => {
+    expect(
+      selectRunOverrides(['--run-id', '33721476500', '--allow-unregistered-run', '--yes']),
+    ).toEqual({
+      runId: 33721476500,
+      conclusions: new Map(),
+      changelogs: [],
+      benchmarks: [],
+      purgedRuns: new Set(),
+      purgedAttempts: new Map(),
+      purgedPoints: [],
+    });
+  });
+
+  it('still selects registered corrections when allowing an unregistered run', () => {
+    expect(selectRunOverrides(['--run-id', '33219708211', '--allow-unregistered-run'])).toEqual(
+      selectRunOverrides(['--run-id', '33219708211']),
+    );
+    expect(() => selectRunOverrides(['--allow-unregistered-run'])).toThrow('requires --run-id');
+  });
+
   it('keeps all registered operations when no run is selected', () => {
     expect(selectRunOverrides(['--yes'])).toEqual({
       runId: undefined,

--- a/packages/db/src/lib/run-override-selection.ts
+++ b/packages/db/src/lib/run-override-selection.ts
@@ -14,11 +14,15 @@ export function selectRunOverrides(args: string[]) {
     args,
     options: {
       'run-id': { type: 'string' },
+      'allow-unregistered-run': { type: 'boolean' },
       yes: { type: 'boolean', short: 'y' },
       'no-ssl': { type: 'boolean' },
     },
   });
   const value = values['run-id'];
+  if (values['allow-unregistered-run'] && value === undefined) {
+    throw new Error('--allow-unregistered-run requires --run-id');
+  }
   if (value !== undefined && (!/^[1-9]\d*$/u.test(value) || !Number.isSafeInteger(Number(value)))) {
     throw new Error('--run-id must be a positive integer GitHub run ID');
   }
@@ -35,6 +39,7 @@ export function selectRunOverrides(args: string[]) {
   };
   if (
     runId !== undefined &&
+    !values['allow-unregistered-run'] &&
     selection.conclusions.size +
       selection.changelogs.length +
       selection.benchmarks.length +


### PR DESCRIPTION
Fix two failures exposed by staging ingestion:

- Accept the explicitly recorded offload-only version when applying the newer cache-hit backfill. Unexpected destination data and duplicate identities still fail closed.
- Scope post-ingest overrides to the ingested run. Unrelated historical corrections may not exist in staging; runs without registered corrections are an explicit no-op. Standalone recovery remains strict.

Failing ingestion: https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/33789946574/job/100763995835

Validation: regression tests reproduce the prior-patch failure and cover reruns, malformed data, conflict rejection, and run-scoped selection. Workspace unit tests, typecheck, lint, and formatting pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production/staging post-ingest database correction paths and benchmark metrics patching logic; mistakes could skip needed backfills or write wrong metrics, though fail-closed checks and tests limit blast radius.
> 
> **Overview**
> Fixes staging ingest failures by tightening **benchmark point backfill recovery** and **how CI applies overrides after ingest**.
> 
> **Backfill extensions:** Ledger entries can declare `previousSet` when a correction grows after part of it was already applied (e.g. offload-only Mooncake patches later extended with GB200 cache-hit metrics). New `planBenchmarkPointBackfill` centralizes idempotency, malformed JSONB repair, and accepting rows that match the declared prior patch; unexpected destination data still errors. `apply-overrides` delegates to that planner instead of duplicating logic.
> 
> **Run-scoped ingest:** `ingest-results` and `ingest-agentic-results` now run `admin:db:apply-overrides` with the ingested merge run id plus `--allow-unregistered-run`, so runs without ledger entries no-op instead of failing, and staging does not try to apply unrelated historical corrections. Manual `apply-overrides` without that flag stays strict.
> 
> Docs in `data-pipeline.md` describe `previousSet` and the ingest workflow behavior; unit tests cover recovery, rejection paths, and selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d91a69b8f1f418e12ea0e0318c60f9add6073b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->