### PR TITLE
fix(ui): improve unofficial-run banner and evaluation markers / 优化非官方运行横幅并修复评估标记

### DIFF
--- a/packages/app/cypress/component/eval-bar-chart.cy.tsx
+++ b/packages/app/cypress/component/eval-bar-chart.cy.tsx
@@ -2,6 +2,8 @@ import EvalBarChartD3 from '@/components/evaluation/ui/BarChartD3';
 import { mountWithProviders } from '../support/test-utils';
 import { createMockEvaluationChartData } from '../support/mock-data';
 import { Model, Precision } from '@/lib/data-mappings';
+import { normalizeEvalHardwareKey } from '@/lib/chart-utils';
+import { overlayRunColor } from '@/lib/overlay-run-style';
 
 describe('EvalBarChartD3', () => {
   it('shows skeleton during loading with no data', () => {
@@ -149,4 +151,124 @@ describe('EvalBarChartD3', () => {
     cy.contains('Show Labels').should('exist');
     cy.contains('High Contrast').should('exist');
   });
+
+  for (const includeOfficial of [false, true]) {
+    it(`renders interactive unofficial markers with a portaled tooltip (${includeOfficial ? 'with' : 'without'} official rows)`, () => {
+      // Evaluation-only run that originally displayed its error bar and legend
+      // entry, but no marker because the tooltip is no longer an SVG sibling.
+      const run = {
+        id: 33769499103,
+        name: 'Run Sweep - Validate vLLM P/D cache-source metrics on GB300',
+        branch: 'codex/h100-minimaxm3-disagg-source',
+        sha: 'b41d05864fa0f17674b36b8eb89cfaa21c58468b',
+        createdAt: '2026-09-03T14:53:27Z',
+        url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33769499103',
+        conclusion: '',
+        status: 'in_progress',
+        isNonMainBranch: true,
+      };
+      const score = 0.9658832448824868;
+      const scoreError = 0.005000212600773283;
+      const unofficialRow = createMockEvaluationChartData({
+        hardware: 'gb300',
+        hwKey: normalizeEvalHardwareKey('gb300', 'dynamo-vllm', 'mtp'),
+        configLabel: 'GB300 NVL72 (Dynamo vLLM, MTP)\nC256 P(4/4/T/1) D(16/16/T/1)',
+        model: Model.DeepSeek_V4_Pro,
+        benchmark: 'gsm8k',
+        framework: 'dynamo-vllm',
+        score,
+        scoreError,
+        minScore: score,
+        maxScore: score,
+        errorMin: score - scoreError,
+        errorMax: score + scoreError,
+        date: '2026-09-03',
+        runUrl: run.url,
+        conc: 256,
+      });
+      const officialRows = includeOfficial
+        ? [
+            createMockEvaluationChartData({
+              score: 0.95,
+              scoreError: 0.01,
+              errorMin: 0.94,
+              errorMax: 0.96,
+            }),
+          ]
+        : [];
+      const overlayHardware = new Set([String(unofficialRow.hwKey)]);
+      mountWithProviders(
+        <div style={{ width: 1000 }}>
+          <EvalBarChartD3 />
+        </div>,
+        {
+          evaluation: {
+            selectedModel: Model.DeepSeek_V4_Pro,
+            selectedBenchmark: 'gsm8k',
+            chartData: officialRows,
+            unfilteredChartData: officialRows,
+            unofficialChartData: [unofficialRow],
+          },
+          unofficial: {
+            isUnofficialRun: true,
+            unofficialRunInfo: run,
+            unofficialRunInfos: [run],
+            runIndexByUrl: { [run.url]: 0 },
+            activeOverlayHwTypes: overlayHardware,
+            allOverlayHwTypes: overlayHardware,
+          },
+        },
+      );
+
+      const marker = '#evaluation-chart .unofficial-eval-point';
+      const tooltip = 'body > [data-chart-tooltip="evaluation-chart"]';
+      cy.get(tooltip).should('have.length', 1);
+      cy.get('#evaluation-chart [data-chart-tooltip]').should('not.exist');
+      cy.get(marker).should('have.length', 1).and('be.visible');
+      cy.get(`${marker} .unofficial-eval-x`).should('have.attr', 'stroke', overlayRunColor(0));
+      cy.get(`${marker} .unofficial-score-label`).should('have.text', '0.966');
+      cy.get('#evaluation-chart .unofficial-error-bar').should('have.length', 1);
+      cy.get('#evaluation-chart .point').should('have.length', officialRows.length);
+
+      // The group's bounds include its score label; target the visible marker.
+      cy.get(`${marker} .unofficial-eval-x`).trigger('mouseenter').trigger('mousemove');
+      // Hover tooltips ignore pointer events, so Cypress's fixed-position
+      // hit test sees the chart underneath. Check their rendered state directly.
+      cy.get(tooltip)
+        .should('have.css', 'display', 'block')
+        .and('have.css', 'opacity', '1')
+        .and('contain.text', run.branch);
+      cy.get(`${marker} .unofficial-eval-x`).trigger('mouseleave');
+      cy.get(tooltip).should('not.be.visible');
+
+      cy.get(`${marker} .unofficial-eval-x`).click();
+      cy.get(tooltip)
+        .should('be.visible')
+        .and('have.css', 'pointer-events', 'auto')
+        .and('contain.text', '0.9659')
+        .and('contain.text', 'Click elsewhere to dismiss');
+      cy.get(`${tooltip} a`).should('have.attr', 'href', run.url);
+
+      cy.get(marker)
+        .invoke('attr', 'transform')
+        .then((initialTransform) => {
+          cy.get('#evaluation-chart [data-testid="d3-chart-svg"]').then(($svg) => {
+            const svg = $svg[0];
+            const bounds = svg.getBoundingClientRect();
+            svg.dispatchEvent(
+              new WheelEvent('wheel', {
+                deltaY: -240,
+                clientX: bounds.x + bounds.width / 2,
+                clientY: bounds.y + bounds.height / 2,
+                shiftKey: true,
+                bubbles: true,
+                cancelable: true,
+              }),
+            );
+          });
+          cy.get(marker).invoke('attr', 'transform').should('not.equal', initialTransform);
+        });
+      cy.get(tooltip).should('not.be.visible');
+    });
+  }
 });

--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -2,7 +2,11 @@ import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 
 import { TabNav } from '@/components/tab-nav';
-import { UnofficialRunContext } from '@/components/unofficial-run-provider';
+import {
+  UnofficialRunBanner,
+  UnofficialRunContext,
+  type UnofficialRunContextType,
+} from '@/components/unofficial-run-provider';
 import { createMockUnofficialRunContext } from '../support/mock-data';
 import { createMockRouter } from '../support/mock-router';
 
@@ -11,24 +15,106 @@ import { createMockRouter } from '../support/mock-router';
  * via history.replaceState. The component reads `window.location.search` in a
  * useEffect, so the URL must be set before mount.
  */
-function mountTabNav(opts: { pathname?: string; search?: string }) {
+function mountTabNav(opts: {
+  pathname?: string;
+  search?: string;
+  runs?: UnofficialRunContextType['unofficialRunInfos'];
+}) {
   const { pathname = '/inference', search = '' } = opts;
   cy.window().then((win) => {
     win.history.replaceState(null, '', `${pathname}${search}`);
   });
   const router = createMockRouter();
-  const ctxValue = createMockUnofficialRunContext();
+  const ctxValue = createMockUnofficialRunContext({ unofficialRunInfos: opts.runs ?? [] });
 
   cy.mount(
     <AppRouterContext.Provider value={router}>
       <PathnameContext.Provider value={pathname}>
         <UnofficialRunContext.Provider value={ctxValue}>
-          <TabNav />
+          <div className="container mx-auto px-4 lg:px-8">
+            <TabNav footer={<UnofficialRunBanner attached />} />
+          </div>
         </UnofficialRunContext.Provider>
       </PathnameContext.Provider>
     </AppRouterContext.Provider>,
   );
 }
+
+const bannerRun = {
+  id: 33541529678,
+  name: 'Run Sweep',
+  branch: 'dsv4-fp4-b300-dynamo-trt-recipes',
+  sha: 'abc123',
+  createdAt: '2026-09-01T00:00:00Z',
+  url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33541529678',
+  conclusion: 'cancelled',
+  status: 'completed',
+  isNonMainBranch: true,
+};
+
+describe('TabNav — attached unofficial-run banner', () => {
+  for (const width of [320, 390, 768, 1440]) {
+    it(`keeps long branches and all actions inside the navigation at ${width}px`, () => {
+      cy.viewport(width, 900);
+      const longBranch = `experiment/${'very-long-branch-name-'.repeat(8)}`;
+      mountTabNav({
+        pathname: width === 768 ? '/zh/inference' : '/inference',
+        runs: [bannerRun, { ...bannerRun, id: 2, branch: longBranch }],
+      });
+
+      cy.get('[data-slot="unofficial-banner"]').should('have.length', 1).and('be.visible');
+      cy.get('[data-slot="dashboard-navigation"]').should(($navigation) => {
+        const navigation = $navigation[0];
+        const bounds = navigation.getBoundingClientRect();
+        const banner = navigation.querySelector<HTMLElement>('[data-slot="unofficial-banner"]')!;
+        const bannerBounds = banner.getBoundingClientRect();
+        const controls = navigation.querySelector<HTMLElement>(
+          width < 1024 ? '#chart-select' : '[data-testid="chart-section-tabs"]',
+        )!;
+        expect(bannerBounds.top, 'banner follows the navigation controls').to.be.at.least(
+          controls.getBoundingClientRect().bottom,
+        );
+        expect(bannerBounds.bottom, 'banner joins the bottom edge of the card').to.be.closeTo(
+          bounds.bottom - 1,
+          1,
+        );
+        expect(navigation.scrollWidth, 'navigation does not overflow').to.be.at.most(
+          navigation.clientWidth,
+        );
+        for (const action of banner.querySelectorAll('a, button')) {
+          const actionBounds = action.getBoundingClientRect();
+          expect(actionBounds.left, 'action stays inside banner').to.be.at.least(bannerBounds.left);
+          expect(actionBounds.right, 'action stays inside banner').to.be.at.most(
+            bannerBounds.right,
+          );
+          if (width < 640) expect(actionBounds.height, 'phone touch target').to.be.at.least(44);
+        }
+        const label = [...banner.querySelectorAll('span')].find(
+          (span) => span.textContent?.trim() === 'NON-OFFICIAL',
+        )!;
+        expect(label.getBoundingClientRect().height, 'warning label stays on one line').to.equal(
+          parseFloat(getComputedStyle(label).lineHeight),
+        );
+      });
+      cy.get(`[aria-label="View workflow run for ${bannerRun.branch}"]`).should(
+        'have.attr',
+        'href',
+        bannerRun.url,
+      );
+      cy.get(`[aria-label="Dismiss ${bannerRun.branch}"]`).click();
+      cy.get('@dismissRun').should('have.been.calledOnceWith', String(bannerRun.id));
+      cy.get('@clearUnofficialRun').should('not.have.been.called');
+      cy.get('[aria-label="Dismiss all unofficial runs"]').click();
+      cy.get('@clearUnofficialRun').should('have.been.calledOnce');
+    });
+  }
+
+  it('does not leave an empty status strip when there are no unofficial runs', () => {
+    mountTabNav({});
+    cy.get('[data-slot="unofficial-banner"]').should('not.exist');
+    cy.get('[data-slot="dashboard-navigation"]').should('be.visible');
+  });
+});
 
 describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
   afterEach(() => {

--- a/packages/app/cypress/component/unofficial-banner.cy.tsx
+++ b/packages/app/cypress/component/unofficial-banner.cy.tsx
@@ -1,0 +1,65 @@
+import { UnofficialRunBanner, UnofficialRunContext } from '@/components/unofficial-run-provider';
+import { createMockUnofficialRunContext } from '../support/mock-data';
+
+describe('Standalone unofficial-run banner', () => {
+  for (const width of [390, 1440, 1920]) {
+    it(`aligns with compare and model page content at ${width}px`, () => {
+      cy.viewport(width, 900);
+      const run = {
+        id: 33541529678,
+        name: 'Run Sweep',
+        branch: `experiment/${'long-branch-name-'.repeat(8)}`,
+        sha: 'abc123',
+        createdAt: '2026-09-01T00:00:00Z',
+        url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33541529678',
+        conclusion: 'cancelled',
+        status: 'completed',
+        isNonMainBranch: true,
+      };
+      const context = createMockUnofficialRunContext({ unofficialRunInfos: [run] });
+      cy.mount(
+        <UnofficialRunContext.Provider value={context}>
+          {/* Standalone providers precede the page's centered content container. */}
+          <UnofficialRunBanner />
+          <main>
+            <div className="container mx-auto px-4 lg:px-8">
+              <div data-testid="standalone-page-content">Page content</div>
+            </div>
+          </main>
+        </UnofficialRunContext.Provider>,
+      );
+
+      cy.get('[data-testid="standalone-page-content"]').then(($content) => {
+        const contentBounds = $content[0].getBoundingClientRect();
+        cy.get('[data-slot="unofficial-banner"]').should(($banner) => {
+          const banner = $banner[0];
+          const bounds = banner.getBoundingClientRect();
+          expect(bounds.left, 'left page gutter').to.be.closeTo(contentBounds.left, 1);
+          expect(bounds.right, 'right page gutter').to.be.closeTo(contentBounds.right, 1);
+          expect(bounds.bottom, 'spacing before page content').to.be.lessThan(contentBounds.top);
+          expect(banner.scrollWidth, 'long branch stays inside banner').to.be.at.most(
+            banner.clientWidth,
+          );
+        });
+      });
+      cy.get(`[aria-label="View workflow run for ${run.branch}"]`).should(
+        'have.attr',
+        'href',
+        run.url,
+      );
+      cy.get(`[aria-label="Dismiss ${run.branch}"]`).click();
+      cy.get('@dismissRun').should('have.been.calledOnceWith', String(run.id));
+    });
+  }
+
+  it('adds no banner or spacing when no runs are loaded', () => {
+    cy.mount(
+      <UnofficialRunContext.Provider value={createMockUnofficialRunContext()}>
+        <div data-testid="banner-slot">
+          <UnofficialRunBanner />
+        </div>
+      </UnofficialRunContext.Provider>,
+    );
+    cy.get('[data-testid="banner-slot"]').should('be.empty');
+  });
+});

--- a/packages/app/cypress/e2e/csv-export-overlay.cy.ts
+++ b/packages/app/cypress/e2e/csv-export-overlay.cy.ts
@@ -51,6 +51,10 @@ describe('Inference CSV export with an unofficial-run overlay', () => {
     // Explicitly select Interactivity so this suite does not depend on the default.
     selectXAxisMode('interactivity');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should('exist');
+    cy.get('[data-slot="unofficial-banner"]')
+      .should('have.length', 1)
+      .parents('[data-slot="dashboard-navigation"]')
+      .should('have.length', 1);
   });
 
   it('exports second-based latency headers and only currently visible overlay rows', () => {
@@ -64,6 +68,8 @@ describe('Inference CSV export with an unofficial-run overlay', () => {
     });
 
     cy.get(`[aria-label="Dismiss ${OVERLAY_RUN_BRANCH}"]`).click();
+    cy.get('[data-slot="unofficial-banner"]').should('not.exist');
+    cy.get('[data-slot="dashboard-navigation"]').should('be.visible');
     cy.get('[data-testid="inference-chart-display"] svg .unofficial-overlay-pt').should(
       'not.exist',
     );

--- a/packages/app/src/components/dashboard-shell.tsx
+++ b/packages/app/src/components/dashboard-shell.tsx
@@ -3,7 +3,7 @@
 import { GlobalFilterProvider } from '@/components/GlobalFilterContext';
 import { NudgeEngine } from '@/components/nudge-engine';
 import { TabNav } from '@/components/tab-nav';
-import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+import { UnofficialRunBanner, UnofficialRunProvider } from '@/components/unofficial-run-provider';
 import { dashboardShellCapabilitiesForPathname } from '@/lib/dashboard-routes';
 import { inferenceModelForPathname } from '@/lib/inference-model-slug';
 import { usePathname } from 'next/navigation';
@@ -27,18 +27,23 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
       </GlobalFilterProvider>
     );
   }
+  content = (
+    <>
+      <TabNav
+        footer={providerCapabilities.unofficialRuns ? <UnofficialRunBanner attached /> : undefined}
+      />
+      {content}
+    </>
+  );
   if (providerCapabilities.unofficialRuns) {
-    content = <UnofficialRunProvider>{content}</UnofficialRunProvider>;
+    content = <UnofficialRunProvider showBanner={false}>{content}</UnofficialRunProvider>;
   }
 
   return (
     <>
       {dashboardNudge && <NudgeEngine scope="dashboard" />}
       <main className="relative">
-        <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">
-          <TabNav />
-          {content}
-        </div>
+        <div className="container mx-auto px-4 lg:px-8 flex flex-col gap-4">{content}</div>
       </main>
     </>
   );

--- a/packages/app/src/components/evaluation/ui/BarChartD3.tsx
+++ b/packages/app/src/components/evaluation/ui/BarChartD3.tsx
@@ -1077,15 +1077,15 @@ export default function EvalBarChartD3({ caption }: { caption?: ReactNode }) {
         type: 'custom',
         key: 'unofficial-overlay',
         displayIdentity: `${showLabels}:${unofficialPaletteIdentity}`,
-        render: (group, { xScale: xs, yScale: ys, layout }) => {
+        render: (group, { xScale: xs, yScale: ys, layout, tooltipElement }) => {
           const xScale = xs as d3.ScaleLinear<number, number>;
           const yScale = ys as d3.ScaleBand<string>;
           const svgNode = layout.svg.node();
-          const tooltipNode = svgNode?.nextElementSibling as HTMLDivElement | null;
           const container = svgNode?.parentElement as HTMLDivElement | null;
-          if (!svgNode || !tooltipNode || !container) return;
+          if (!svgNode || !container) return;
 
-          const tooltip = d3.select(tooltipNode);
+          // The shared wrapper portals the tooltip to document.body.
+          const tooltip = d3.select(tooltipElement);
           const overlayPoints = group
             .selectAll<SVGGElement, EvaluationChartData>('.unofficial-eval-point')
             .data(unofficialChartData, (datum) => `${datum.runUrl ?? ''}|${datum.configLabel}`)

--- a/packages/app/src/components/tab-nav.tsx
+++ b/packages/app/src/components/tab-nav.tsx
@@ -3,7 +3,15 @@
 import { ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import { track } from '@/lib/analytics';
 import {
@@ -132,7 +140,7 @@ function useTabIndicator(current: DashboardRouteKey, gateUnlocked: boolean) {
   return { navRef, indicator, animate: hasAnimatedRef.current };
 }
 
-export function TabNav() {
+export function TabNav({ footer }: { footer?: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
   const featureGateUnlocked = useFeatureGate();
@@ -164,61 +172,56 @@ export function TabNav() {
   };
 
   return (
-    <>
-      {/* Mobile: Dropdown */}
-      <div className="lg:hidden mb-4">
-        <div className="w-full pb-6" />
-        <Card>
-          <div className="space-y-2">
-            <Label htmlFor="chart-select">{locale === 'zh' ? '选择图表' : 'Select Chart'}</Label>
-            <Select value={selectedTab} onValueChange={handleMobileChange}>
-              <SelectTrigger id="chart-select" data-testid="mobile-chart-select" className="w-full">
-                <SelectValue placeholder={locale === 'zh' ? '选择图表' : 'Select Chart'} />
-              </SelectTrigger>
-              <SelectContent>
-                {PRIMARY_TABS.map((route) => (
-                  <SelectItem
-                    key={route.key}
-                    value={route.key}
-                    data-ph-capture-attribute-tab={route.key}
-                  >
-                    {tabLabel(route)}
-                  </SelectItem>
-                ))}
-                {lockedCurrentGatedTab && (
-                  <SelectItem
-                    value={lockedCurrentGatedTab.key}
-                    data-ph-capture-attribute-tab={lockedCurrentGatedTab.key}
-                  >
-                    {tabLabel(lockedCurrentGatedTab)}
-                  </SelectItem>
-                )}
-                {featureGateUnlocked && (
-                  <>
-                    <SelectSeparator />
-                    <SelectGroup>
-                      <SelectLabel>{locale === 'zh' ? '隐藏' : 'Hidden'}</SelectLabel>
-                      {GATED_TABS.map((route) => (
-                        <SelectItem
-                          key={route.key}
-                          value={route.key}
-                          data-ph-capture-attribute-tab={route.key}
-                        >
-                          {tabLabel(route)}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </>
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-        </Card>
-      </div>
+    <div className="mb-4 pt-6 lg:pt-0">
+      <Card className="vt-dashboard-tabs p-0 md:p-0" data-slot="dashboard-navigation">
+        {/* Mobile: Dropdown */}
+        <div className="space-y-2 p-4 md:p-6 lg:hidden">
+          <Label htmlFor="chart-select">{locale === 'zh' ? '选择图表' : 'Select Chart'}</Label>
+          <Select value={selectedTab} onValueChange={handleMobileChange}>
+            <SelectTrigger id="chart-select" data-testid="mobile-chart-select" className="w-full">
+              <SelectValue placeholder={locale === 'zh' ? '选择图表' : 'Select Chart'} />
+            </SelectTrigger>
+            <SelectContent>
+              {PRIMARY_TABS.map((route) => (
+                <SelectItem
+                  key={route.key}
+                  value={route.key}
+                  data-ph-capture-attribute-tab={route.key}
+                >
+                  {tabLabel(route)}
+                </SelectItem>
+              ))}
+              {lockedCurrentGatedTab && (
+                <SelectItem
+                  value={lockedCurrentGatedTab.key}
+                  data-ph-capture-attribute-tab={lockedCurrentGatedTab.key}
+                >
+                  {tabLabel(lockedCurrentGatedTab)}
+                </SelectItem>
+              )}
+              {featureGateUnlocked && (
+                <>
+                  <SelectSeparator />
+                  <SelectGroup>
+                    <SelectLabel>{locale === 'zh' ? '隐藏' : 'Hidden'}</SelectLabel>
+                    {GATED_TABS.map((route) => (
+                      <SelectItem
+                        key={route.key}
+                        value={route.key}
+                        data-ph-capture-attribute-tab={route.key}
+                      >
+                        {tabLabel(route)}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </>
+              )}
+            </SelectContent>
+          </Select>
+        </div>
 
-      {/* Desktop: Nav links */}
-      <div className="hidden lg:flex flex-col mb-4">
-        <Card className="vt-dashboard-tabs overflow-x-auto py-6 md:py-6">
+        {/* Desktop: Nav links */}
+        <div className="hidden overflow-x-auto p-6 lg:block">
           <nav
             ref={navRef}
             data-testid="chart-section-tabs"
@@ -264,9 +267,10 @@ export function TabNav() {
               />
             )}
           </nav>
-        </Card>
-      </div>
-    </>
+        </div>
+        {footer}
+      </Card>
+    </div>
   );
 }
 

--- a/packages/app/src/components/ui/unofficial-banner.tsx
+++ b/packages/app/src/components/ui/unofficial-banner.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, ExternalLink, X } from 'lucide-react';
 
 import { track } from '@/lib/analytics';
 import { overlayRunColor } from '@/lib/overlay-run-style';
+import { cn } from '@/lib/utils';
 
 interface RunInfo {
   id: number;
@@ -16,6 +17,8 @@ interface RunInfo {
 
 interface UnofficialBannerProps {
   runs: RunInfo[];
+  /** Join the bottom edge of the dashboard navigation card. */
+  attached?: boolean;
   /** Remove a single run from the URL + state. */
   onDismissRun?: (runId: string) => void;
   /** Clear all runs at once. Surfaced as "Dismiss all" when `runs.length > 1`. */
@@ -32,33 +35,42 @@ interface UnofficialBannerProps {
  * run rendered its OWN full-width banner and the dismiss button cleared every
  * run, which both wasted vertical space and made partial dismissal impossible.
  */
-export function UnofficialBanner({ runs, onDismissRun, onDismissAll }: UnofficialBannerProps) {
+export function UnofficialBanner({
+  runs,
+  attached = false,
+  onDismissRun,
+  onDismissAll,
+}: UnofficialBannerProps) {
   if (runs.length === 0) return null;
   const multiple = runs.length > 1;
 
   return (
-    <div className="bg-red-600 text-white px-4 py-2 relative">
-      <div className="container mx-auto flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-        <div className="flex items-start gap-3 min-w-0">
-          <AlertTriangle className="size-5 flex-shrink-0 mt-0.5" />
-          <div className="flex flex-col gap-1 min-w-0">
-            <div className="flex items-center gap-3">
-              <span className="text-lg font-bold tracking-wide">NON-OFFICIAL</span>
-              <span className="text-xs opacity-90">
-                {multiple ? `Viewing ${runs.length} runs` : 'Viewing data from branch'}
-              </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-1.5">
-              {runs.map((run, idx) => (
-                <RunChip
-                  key={run.id}
-                  run={run}
-                  color={overlayRunColor(idx)}
-                  onDismiss={onDismissRun ? () => onDismissRun(String(run.id)) : undefined}
-                />
-              ))}
-            </div>
-          </div>
+    <div
+      data-slot="unofficial-banner"
+      className={cn(
+        'min-w-0 border-red-500/60 bg-red-600 px-4 py-3 text-white md:px-6',
+        attached ? 'rounded-b-xl border-t' : 'rounded-xl border',
+      )}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-x-4 gap-y-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+          <span className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap text-sm font-semibold">
+            <AlertTriangle aria-hidden className="size-4 shrink-0" />
+            NON-OFFICIAL
+          </span>
+          <span className="text-xs text-white/90">
+            {multiple ? `Viewing ${runs.length} runs` : 'Viewing data from branch'}
+          </span>
+        </div>
+        <div className="flex min-w-0 flex-1 basis-full flex-wrap items-center gap-2 sm:basis-auto">
+          {runs.map((run, idx) => (
+            <RunChip
+              key={run.id}
+              run={run}
+              color={overlayRunColor(idx)}
+              onDismiss={onDismissRun ? () => onDismissRun(String(run.id)) : undefined}
+            />
+          ))}
         </div>
         {multiple && onDismissAll && (
           <button
@@ -67,7 +79,7 @@ export function UnofficialBanner({ runs, onDismissRun, onDismissAll }: Unofficia
               track('unofficial_banner_dismissed_all', { count: runs.length });
               onDismissAll();
             }}
-            className="text-xs px-2 py-1 rounded hover:bg-red-700 transition-colors flex items-center gap-1 self-start"
+            className="flex min-h-11 shrink-0 items-center gap-1.5 rounded-md px-3 text-xs transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current sm:ml-auto sm:min-h-8"
             aria-label="Dismiss all unofficial runs"
           >
             <X className="size-3" />
@@ -89,10 +101,10 @@ function RunChip({
   onDismiss?: () => void;
 }) {
   return (
-    <span className="inline-flex items-center gap-1.5 bg-red-700 rounded px-2 py-0.5 text-xs font-mono">
+    <span className="inline-flex min-w-0 max-w-full items-center gap-2 rounded-md border border-white/20 bg-red-950/25 pl-2 text-xs font-mono">
       <span
         aria-hidden
-        className="inline-block rounded-full size-2 border border-red-900"
+        className="inline-block size-2 shrink-0 rounded-full border border-white/40"
         style={{ backgroundColor: color }}
       />
       <a
@@ -100,11 +112,11 @@ function RunChip({
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => track('unofficial_banner_view_run', { branch: run.branch })}
-        className="inline-flex items-center gap-0.5 underline-offset-2 hover:underline"
+        className="inline-flex min-h-11 min-w-0 items-center gap-1.5 py-1 underline-offset-2 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current sm:min-h-7"
         aria-label={`View workflow run for ${run.branch}`}
       >
-        <span>{run.branch}</span>
-        <ExternalLink className="size-3 opacity-70" />
+        <span className="min-w-0 [overflow-wrap:anywhere]">{run.branch}</span>
+        <ExternalLink aria-hidden className="size-3 shrink-0 opacity-70" />
       </a>
       {onDismiss && (
         <button
@@ -113,7 +125,7 @@ function RunChip({
             track('unofficial_banner_run_dismissed', { branch: run.branch });
             onDismiss();
           }}
-          className="inline-flex items-center rounded-sm hover:bg-red-800 transition-colors ml-0.5"
+          className="inline-flex size-11 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current sm:size-7"
           aria-label={`Dismiss ${run.branch}`}
         >
           <X className="size-3" />

--- a/packages/app/src/components/ui/unofficial-banner.tsx
+++ b/packages/app/src/components/ui/unofficial-banner.tsx
@@ -44,7 +44,7 @@ export function UnofficialBanner({
   if (runs.length === 0) return null;
   const multiple = runs.length > 1;
 
-  return (
+  const banner = (
     <div
       data-slot="unofficial-banner"
       className={cn(
@@ -89,6 +89,10 @@ export function UnofficialBanner({
       </div>
     </div>
   );
+
+  // Compare and model pages render the standalone banner outside their own
+  // content containers, so it needs the same width and page gutters here.
+  return attached ? banner : <div className="container mx-auto mb-4 px-4 lg:px-8">{banner}</div>;
 }
 
 function RunChip({

--- a/packages/app/src/components/unofficial-run-provider.tsx
+++ b/packages/app/src/components/unofficial-run-provider.tsx
@@ -364,7 +364,13 @@ async function fetchUnofficialRuns(
   );
 }
 
-export function UnofficialRunProvider({ children }: { children: ReactNode }) {
+export function UnofficialRunProvider({
+  children,
+  showBanner = true,
+}: {
+  children: ReactNode;
+  showBanner?: boolean;
+}) {
   const queryClient = useQueryClient();
   const search = useClientSearch();
   const runIds = useMemo(() => parseUnofficialRunIds(search), [search]);
@@ -521,14 +527,21 @@ export function UnofficialRunProvider({ children }: { children: ReactNode }) {
 
   return (
     <UnofficialRunContext.Provider value={contextValue}>
-      {unofficialRunInfos.length > 0 && (
-        <UnofficialBanner
-          runs={unofficialRunInfos}
-          onDismissRun={dismissRun}
-          onDismissAll={clearUnofficialRun}
-        />
-      )}
+      {showBanner && <UnofficialRunBanner />}
       {children}
     </UnofficialRunContext.Provider>
+  );
+}
+
+/** Allows dashboard navigation to own banner placement while the provider owns its state. */
+export function UnofficialRunBanner({ attached = false }: { attached?: boolean }) {
+  const { unofficialRunInfos, dismissRun, clearUnofficialRun } = useUnofficialRun();
+  return (
+    <UnofficialBanner
+      runs={unofficialRunInfos}
+      attached={attached}
+      onDismissRun={dismissRun}
+      onDismissAll={clearUnofficialRun}
+    />
   );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily UI placement and chart tooltip wiring with broad test coverage; no auth or data-pipeline changes.
> 
> **Overview**
> **Moves the unofficial-run warning into the dashboard tab card** and refreshes its layout for long branch names and touch targets. `TabNav` accepts an optional `footer`; on dashboard routes the shell renders `UnofficialRunBanner` there with `attached`, while `UnofficialRunProvider` can skip its default banner via `showBanner={false}`. Standalone pages still use a gutter-aligned wrapper. The banner UI is more compact (chips, `data-slot="unofficial-banner"`, rounded attached vs standalone styling).
> 
> **Fixes evaluation bar chart unofficial overlays** so tooltips bind to the shared **body-portaled** tooltip (`tooltipElement`) instead of an SVG sibling—restoring visible markers and hover/click tooltip behavior (including zoom dismiss).
> 
> **Adds Cypress coverage**: eval overlay markers/tooltips (with/without official rows), attached banner layout across breakpoints, standalone alignment, tab dismiss actions, and e2e checks that the banner lives under `dashboard-navigation` and clears on dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07216f197317ee28c310c0929465edcd6cfc2071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->