### PR TITLE
fix(agentx): parse llm-d worker metrics without frontend duplicates

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -203,6 +203,27 @@ The cluster average is then a mean across those logical engines on the union of 
 
 Engines are ordered by role, then numeric rank, then worker — never by the composed display string, which would sort `"decode 10"` before `"decode 2"` and scramble DP ranks. The role is only shown when engines actually differ in role, so an aggregated deployment reads `DP 0…DP 3` rather than `decode 0…decode 3`.
 
+### llm-d Server Metrics
+
+The llm-d adapter identifies engines by endpoint plus native engine labels. It does
+not merge different workers because their ranks or utilization happen to match.
+AIPerf's `input_config` distinguishes inference URLs from explicit metrics URLs.
+For llm-d, frontend-proxied `vllm:` series are excluded only when an explicitly
+requested endpoint contains the same metric label set with samples. Explicitly
+requested localhost endpoints and metrics without a direct counterpart are kept;
+Dynamo, TRT-LLM, and generic backends retain their existing behavior.
+
+The same adapter normalization runs before chart and aggregate computation on both
+bounded and streaming JSON paths. Raw artifacts remain unchanged. Worker roles
+come from `llmd_metrics_endpoints.json` during ingest or the discovery records in
+stored server logs during historical recomputation. Ambiguous or missing roles
+stay unknown rather than being inferred from traffic or engine indices.
+
+After deployment, use the Recompute Agentic Metrics workflow with the affected
+run ID and `neon-branch: staging` to rebuild staging's stored chart and aggregate
+payloads. No GPU rerun is required. Preview cache namespaces must be distinct from
+production, and changing derived-data versions invalidates versioned chart caches.
+
 ### ATOM Server Metrics
 
 ATOM exports aggregate `atom:` gauges and counters. KV usage and request queues

--- a/packages/app/src/lib/api-documentation.ts
+++ b/packages/app/src/lib/api-documentation.ts
@@ -2423,8 +2423,8 @@ export const apiOperations: readonly ApiOperation[] = [
     path: '/api/v1/trace-server-metrics',
     summary: text('Read trace server metrics', '读取跟踪服务器指标'),
     description: text(
-      'Returns point metadata and chart-ready aggregate time series for cache usage, queue depth, prefill and decode throughput, and prompt-token sources. metricSources contains source descriptors; source-specific arrays are loaded by the point-detail UI only when selected.',
-      '返回数据点元数据，以及可直接用于图表的聚合时间序列，涵盖缓存使用率、队列深度、prefill/decode 吞吐量和 prompt token 来源。metricSources 包含各来源的描述信息；仅当用户在数据点详情界面选择某个来源时，才会加载该来源对应的数组。',
+      'Returns point metadata and chart-ready aggregate time series for cache usage, queue depth, prefill and decode throughput, and prompt-token sources. metricSources contains backend-normalized worker descriptors, including llm-d prefill/decode roles when discovery metadata is available. Duplicate frontend-proxied llm-d counters are excluded when explicit worker metrics are present. Source-specific arrays are loaded by the point-detail UI only when selected.',
+      '返回数据点元数据，以及可直接用于图表的聚合时间序列，涵盖缓存使用率、队列深度、prefill/decode 吞吐量和 prompt token 来源。metricSources 包含按后端规则归一化的 worker 描述信息；有服务发现元数据时，也包含 llm-d 的 prefill/decode 角色。当显式配置的 worker 提供对应指标时，会排除 llm-d 前端代理返回的重复计数器。仅当用户在数据点详情界面选择某个来源时，才会加载该来源对应的数组。',
     ),
     audience: 'public',
     stability: 'beta',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -715,7 +715,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/agentic-aggregates.ts',
-    sourceSha256: '8d23f65dfb77565120f23207729ed66e6ce55f53acf6bf0cf51e377c41120d6b',
+    sourceSha256: '23f12772913d8abdb9b8520214b206825529e0ca100b3fc74709f594018c22eb',
     reviewArea: {
       en: 'Agentic aggregate percentile keys, nullability, and ID-keyed response shape.',
       zh: '智能体汇总百分位字段、可空性和按 ID 索引的响应结构。',
@@ -787,7 +787,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/server-logs.ts',
-    sourceSha256: '7a6f6b0b3c60e1713f73f6d543745931886654f060cf55d6dc4be9619a64b479',
+    sourceSha256: 'aef946e3c4b8a246dc64594412c97abf6fe960032c05c110206fd5184664fd07',
     reviewArea: {
       en: 'Log filename discovery, selected-file reads, bounded chunk metadata, complete-file search, availability, and legacy-schema fallback.',
       zh: '日志文件名发现、指定文件读取、有界分块元数据、完整文件搜索、可用性以及旧版 schema 回退行为。',
@@ -819,7 +819,7 @@ export const apiContractSourceDigests = [
   },
   {
     source: '../db/src/queries/trace-server-metrics.ts',
-    sourceSha256: '4f70c310675c36ce062fe78861925f0a9e99b05396a6d2b5d0afc9221a89edd7',
+    sourceSha256: 'a4db1d72bc1ba33111725d34739fa2380d36768182a899d2bf285f921e9f536b',
     reviewArea: {
       en: 'Trace server metric metadata, time-series groups, source labels, and units.',
       zh: '跟踪服务器指标元数据、时间序列分组、来源标签和单位。',

--- a/packages/db/src/backfill-aggregate-stats.ts
+++ b/packages/db/src/backfill-aggregate-stats.ts
@@ -151,19 +151,25 @@ async function main(): Promise<void> {
       if (
         !flags.force &&
         storedVersion !== undefined &&
-        storedVersion >= 9 &&
+        storedVersion >= 10 &&
         storedVersion < STATS_VERSION
       ) {
         stats = mergeProfileStatsUpgrade(row.aggregate_stats!, profileStats);
       } else {
-        const [serverRow] = await sql<{ server_metrics_json_gz: Buffer | null }[]>`
-          select server_metrics_json_gz
-          from agentic_trace_replay
-          where id = ${id}
+        const [serverRow] = await sql<
+          { server_metrics_json_gz: Buffer | null; framework: string; disagg: boolean }[]
+        >`
+          select atr.server_metrics_json_gz, c.framework, c.disagg
+          from agentic_trace_replay atr
+          join benchmark_results br on br.trace_replay_id = atr.id
+          join configs c on c.id = br.config_id
+          where atr.id = ${id}
+          order by br.id limit 1
         `;
         const serverStats = await computeAggregateStats({
           profileBlob: null,
           serverBlob: serverRow?.server_metrics_json_gz ?? null,
+          metricsContext: serverRow,
         });
         stats = mergeProfileStatsUpgrade(serverStats, profileStats);
       }

--- a/packages/db/src/backfill-chart-series.ts
+++ b/packages/db/src/backfill-chart-series.ts
@@ -28,6 +28,7 @@
 import { hasNoSslFlag } from './cli-utils.js';
 import { CHART_SERIES_VERSION, computeChartSeries } from './etl/compute-chart-series.js';
 import { createAdminSql } from './etl/db-utils.js';
+import { getServerMetricsContext } from './queries/server-logs.js';
 import {
   jsonbParam,
   parseLimitForceFlags,
@@ -105,13 +106,14 @@ async function main(): Promise<void> {
         {
           server_metrics_json_gz: Buffer | null;
           framework: string | null;
+          benchmark_result_id: number;
           disagg: boolean | null;
         }[]
       >`
-        select atr.server_metrics_json_gz, source.framework, source.disagg
+        select atr.server_metrics_json_gz, source.framework, source.disagg, source.benchmark_result_id
         from agentic_trace_replay atr
         left join lateral (
-          select c.framework, c.disagg
+          select c.framework, c.disagg, br.id as benchmark_result_id
           from benchmark_results br
           join configs c on c.id = br.config_id
           where br.trace_replay_id = atr.id
@@ -125,10 +127,11 @@ async function main(): Promise<void> {
         return 'skipped';
       }
 
-      const series = await computeChartSeries(row.server_metrics_json_gz, {
+      const context = await getServerMetricsContext(sql, row.benchmark_result_id, {
         framework: row.framework,
         disagg: row.disagg ?? false,
       });
+      const series = await computeChartSeries(row.server_metrics_json_gz, context);
 
       await sql`
         update agentic_trace_replay

--- a/packages/db/src/etl/compute-aggregate-stats.ts
+++ b/packages/db/src/etl/compute-aggregate-stats.ts
@@ -13,10 +13,11 @@ import { createInterface } from 'node:readline';
 import { Readable } from 'node:stream';
 import { createGunzip } from 'node:zlib';
 
-import { gunzipJsonWithinLimit, streamCollectKeys } from './gzip-json-stream';
+import type { ServerMetricsContext } from './server-metrics-adapters';
 import {
   STATS_VERSION,
   extractServerMetricSamples,
+  extractServerMetricSamplesFromBlob,
   percentilesOf,
   sequenceLengthSketches,
   type MetricPercentiles,
@@ -206,22 +207,6 @@ export const AGGREGATE_SERVER_METRIC_KEYS = new Set([
 ]);
 
 /**
- * Stream-parse the gzipped server_metrics_json and collect just the metric
- * subtrees we care about when the full JSON exceeds the in-memory fast-path
- * ceiling.
- */
-async function streamExtractServer(
-  buffer: Buffer,
-): Promise<{ kvCacheUtil: number[]; prefixCacheHitRate: number[] }> {
-  const collected = await streamCollectKeys<unknown>(
-    buffer,
-    'metrics',
-    AGGREGATE_SERVER_METRIC_KEYS,
-  );
-  return extractServerMetricSamples(JSON.stringify({ metrics: collected }));
-}
-
-/**
  * Add server-derived distributions to profile stats using an already parsed
  * profiling metric map. Ingest uses this to share one server JSON parse with
  * chart-series generation; the output shape and ordering match
@@ -251,6 +236,7 @@ export function withServerMetricAggregateStats(
 export async function computeAggregateStats(args: {
   profileBlob: Buffer | null;
   serverBlob: Buffer | null;
+  metricsContext?: ServerMetricsContext;
 }): Promise<AggregateStats> {
   const profile = args.profileBlob
     ? await computeProfileAggregateStatsFromCompressedChunks([args.profileBlob])
@@ -261,11 +247,7 @@ export async function computeAggregateStats(args: {
   if (args.serverBlob) {
     let server: { kvCacheUtil: number[]; prefixCacheHitRate: number[] } | null = null;
     try {
-      const json = gunzipJsonWithinLimit(args.serverBlob);
-      server =
-        json === null
-          ? await streamExtractServer(args.serverBlob)
-          : extractServerMetricSamples(json);
+      server = await extractServerMetricSamplesFromBlob(args.serverBlob, args.metricsContext);
     } catch {
       // malformed blob or failed stream fallback — leave nulls
     }

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -11,6 +11,7 @@
 import { collectMetricPhases } from './gzip-json-stream';
 import {
   selectServerMetricsAdapter,
+  normalizeServerMetrics,
   type MetricSource,
   type ServerMetricsContext,
 } from './server-metrics-adapters';
@@ -131,8 +132,9 @@ import {
  * v18: retain Dynamo's per-DP-rank KV gauges within each TRT-LLM worker.
  *
  * v19: extract ATOM's aggregate KV, queue, token and prefix-cache metrics.
+ * v20: exclude llm-d frontend mirrors and retain endpoint-scoped worker roles.
  */
-export const CHART_SERIES_VERSION = 19;
+export const CHART_SERIES_VERSION = 20;
 
 export interface TimeSeriesPoint {
   /** Seconds from benchmark start. */
@@ -308,12 +310,12 @@ function mergePhaseMetrics(profiling: MetricsMap, warmup: MetricsMap): MetricsMa
  * that collects both phase blocks. Merges the warmup block into the profiling
  * one (v11) so the series span both phases.
  */
-async function parseMetrics(buffer: Buffer): Promise<MetricsMap> {
-  const { metrics, warmupMetrics } = await collectMetricPhases<RawMetric>(
+async function parseMetrics(buffer: Buffer, context: ServerMetricsContext): Promise<MetricsMap> {
+  const { metrics, warmupMetrics, inputConfig } = await collectMetricPhases<RawMetric>(
     buffer,
     CHART_METRIC_KEYS,
   );
-  return mergePhaseMetrics(metrics, warmupMetrics);
+  return normalizeServerMetrics(mergePhaseMetrics(metrics, warmupMetrics), inputConfig, context);
 }
 
 /**
@@ -328,7 +330,7 @@ export async function computeChartSeries(
   if (!blob) return null;
   let metrics: MetricsMap;
   try {
-    metrics = await parseMetrics(blob);
+    metrics = await parseMetrics(blob, context);
   } catch {
     // Malformed blob → no series (caller treats null as "no data").
     return null;
@@ -346,7 +348,10 @@ export function computeChartSeriesFromMetricPhases(
   warmup: MetricsMap,
   context: ServerMetricsContext = {},
 ): ChartSeries {
-  return buildSeriesFromMetrics(mergePhaseMetrics(profiling, warmup), context);
+  return buildSeriesFromMetrics(
+    normalizeServerMetrics(mergePhaseMetrics(profiling, warmup), {}, context),
+    context,
+  );
 }
 
 // Note: v14 removed `aggregateByStart`/`sortedEntries`. Nothing groups on an

--- a/packages/db/src/etl/compute-chart-series.ts
+++ b/packages/db/src/etl/compute-chart-series.ts
@@ -14,6 +14,7 @@ import {
   normalizeServerMetrics,
   type MetricSource,
   type ServerMetricsContext,
+  type ServerMetricsInputConfig,
 } from './server-metrics-adapters';
 
 /**
@@ -347,9 +348,10 @@ export function computeChartSeriesFromMetricPhases(
   profiling: MetricsMap,
   warmup: MetricsMap,
   context: ServerMetricsContext = {},
+  inputConfig: ServerMetricsInputConfig = {},
 ): ChartSeries {
   return buildSeriesFromMetrics(
-    normalizeServerMetrics(mergePhaseMetrics(profiling, warmup), {}, context),
+    normalizeServerMetrics(mergePhaseMetrics(profiling, warmup), inputConfig, context),
     context,
   );
 }

--- a/packages/db/src/etl/compute-trace-derived.test.ts
+++ b/packages/db/src/etl/compute-trace-derived.test.ts
@@ -140,3 +140,115 @@ describe('computeTraceDerivedPayloads', () => {
     expect(optimized.requestTimeline).toEqual(await computeRequestTimeline(profileBlob));
   });
 });
+
+const llmdSeries = (endpoint_url: string, rate: number, avg: number) => ({
+  endpoint_url,
+  labels: { engine: '0', model_name: 'deepseek-ai/DeepSeek-V4-Pro-0813' },
+  timeslices: [0, 1].map((t) => ({ start_ns: t * 1e9, end_ns: (t + 1) * 1e9, rate, avg })),
+});
+
+describe('llm-d metric sources', () => {
+  const frontend = 'http://gateway.test:9000/metrics';
+  const prefill = 'http://prefill.test:8200/metrics';
+  const decode = 'http://decode.test:8200/metrics';
+  const context = {
+    framework: 'llmd-vllm',
+    disagg: true,
+    endpointRoles: { [prefill]: 'prefill', [decode]: 'decode' },
+  } as const;
+  const metrics = {
+    'vllm:kv_cache_usage_perc': {
+      series: [
+        llmdSeries(prefill, 0, 0.2),
+        llmdSeries(decode, 0, 0.2),
+        llmdSeries(frontend, 0, 0.9),
+      ],
+    },
+    'vllm:generation_tokens': {
+      series: [
+        llmdSeries(prefill, 1, 0),
+        llmdSeries(decode, 50, 0),
+        llmdSeries(frontend, 10000, 0),
+      ],
+    },
+  };
+  const input_config = {
+    endpoint: { urls: ['http://gateway.test:9000'] },
+    server_metrics: { urls: [prefill, decode] },
+  };
+
+  it.each([undefined, 1])(
+    'filters the frontend and retains same-rank workers (stream limit %s)',
+    async (maxInMemoryBytes) => {
+      const blob = gzipSync(JSON.stringify({ metrics, warmup_metrics: metrics, input_config }));
+      const result = await computeTraceDerivedPayloads(null, blob, context, { maxInMemoryBytes });
+      expect(result.chartSeries?.decodeTps).toEqual([
+        { t: 0, value: 51 },
+        { t: 1, value: 51 },
+      ]);
+      expect(result.chartSeries?.kvCacheUsageByEngine).toHaveLength(2);
+      expect(
+        result.chartSeries?.metricSources.map(({ source }) => [source.role, source.endpointUrl]),
+      ).toEqual([
+        ['prefill', prefill],
+        ['decode', decode],
+      ]);
+      expect(result.aggregateStats.kvCacheUtil?.mean).toBeCloseTo(0.2);
+      expect(result.chartSeries).toEqual(await computeChartSeries(blob, context));
+      expect(result.aggregateStats).toEqual(
+        await computeAggregateStats({
+          profileBlob: null,
+          serverBlob: blob,
+          metricsContext: context,
+        }),
+      );
+    },
+  );
+
+  it('preserves the frontend when it is explicitly requested or has no direct metric counterpart', async () => {
+    for (const urls of [[prefill, decode, frontend], []]) {
+      const blob = gzipSync(
+        JSON.stringify({ metrics, input_config: { ...input_config, server_metrics: { urls } } }),
+      );
+      const result = await computeChartSeries(blob, context);
+      expect(result?.decodeTps[0]?.value).toBe(10051);
+      expect(result?.kvCacheUsageByEngine).toHaveLength(3);
+    }
+    const blob = gzipSync(
+      JSON.stringify({
+        metrics: { 'vllm:generation_tokens': { series: [llmdSeries(frontend, 10, 0)] } },
+        input_config,
+      }),
+    );
+    const result = await computeChartSeries(blob, context);
+    expect(result?.decodeTps[0]?.value).toBe(10);
+  });
+
+  it.each(['vllm', 'dynamo-vllm', 'trtllm'])(
+    'does not apply llm-d filtering to %s',
+    async (framework) => {
+      const blob = gzipSync(JSON.stringify({ metrics, input_config }));
+      const result = await computeChartSeries(blob, { framework, disagg: true });
+      expect(result?.decodeTps[0]?.value).toBe(10051);
+    },
+  );
+
+  it('keeps an explicitly configured localhost worker', async () => {
+    const localhost = 'http://localhost:8080/metrics';
+    const blob = gzipSync(
+      JSON.stringify({
+        input_config: {
+          endpoint: { urls: ['http://localhost:8080'] },
+          server_metrics: { urls: [localhost, decode] },
+        },
+        metrics: {
+          'vllm:generation_tokens': {
+            series: [llmdSeries(localhost, 20, 0), llmdSeries(decode, 50, 0)],
+          },
+        },
+      }),
+    );
+    const result = await computeChartSeries(blob, context);
+    expect(result?.decodeTps[0]?.value).toBe(70);
+  });
+});

--- a/packages/db/src/etl/compute-trace-derived.test.ts
+++ b/packages/db/src/etl/compute-trace-derived.test.ts
@@ -205,6 +205,34 @@ describe('llm-d metric sources', () => {
     },
   );
 
+  it.each([undefined, 1])(
+    'uses the same frontend selection across phases and entry points (stream limit %s)',
+    async (maxInMemoryBytes) => {
+      const blob = gzipSync(
+        JSON.stringify({
+          metrics,
+          warmup_metrics: {
+            'vllm:generation_tokens': { series: [llmdSeries(frontend, 10000, 0)] },
+          },
+          input_config,
+        }),
+      );
+      const result = await computeTraceDerivedPayloads(null, blob, context, { maxInMemoryBytes });
+      expect(result.chartSeries?.decodeTps).toEqual([
+        { t: 0, value: 51 },
+        { t: 1, value: 51 },
+      ]);
+      expect(result.chartSeries).toEqual(await computeChartSeries(blob, context));
+      expect(result.aggregateStats).toEqual(
+        await computeAggregateStats({
+          profileBlob: null,
+          serverBlob: blob,
+          metricsContext: context,
+        }),
+      );
+    },
+  );
+
   it('preserves the frontend when it is explicitly requested or has no direct metric counterpart', async () => {
     for (const urls of [[prefill, decode, frontend], []]) {
       const blob = gzipSync(

--- a/packages/db/src/etl/compute-trace-derived.ts
+++ b/packages/db/src/etl/compute-trace-derived.ts
@@ -79,16 +79,13 @@ export async function computeTraceDerivedPayloads(
   let chartSeries: ChartSeries | null = null;
 
   if (phases) {
-    phases.metrics = normalizeServerMetrics(phases.metrics, phases.inputConfig, metricsContext);
-    phases.warmupMetrics = normalizeServerMetrics(
-      phases.warmupMetrics,
-      phases.inputConfig,
-      metricsContext,
-    );
     const aggregateMetrics = phases.complete
       ? phases.metrics
       : selectMetrics(phases.metrics, AGGREGATE_SERVER_METRIC_KEYS);
-    aggregateStats = withServerMetricAggregateStats(aggregateStats, aggregateMetrics);
+    aggregateStats = withServerMetricAggregateStats(
+      aggregateStats,
+      normalizeServerMetrics(aggregateMetrics, phases.inputConfig, metricsContext),
+    );
 
     // The historical in-memory path builds chart timing metadata from every
     // metric, while its oversized streaming fallback retains only chart keys.
@@ -101,7 +98,12 @@ export async function computeTraceDerivedPayloads(
       ? phases.warmupMetrics
       : selectMetrics(phases.warmupMetrics, CHART_METRIC_KEYS);
     try {
-      chartSeries = computeChartSeriesFromMetricPhases(profiling, warmup, metricsContext);
+      chartSeries = computeChartSeriesFromMetricPhases(
+        profiling,
+        warmup,
+        metricsContext,
+        phases.inputConfig,
+      );
     } catch {
       chartSeries = null;
     }

--- a/packages/db/src/etl/compute-trace-derived.ts
+++ b/packages/db/src/etl/compute-trace-derived.ts
@@ -21,7 +21,7 @@ import {
 import { computeRequestTimeline, type RequestTimeline } from './compute-request-timeline.js';
 import { collectMetricPhases } from './gzip-json-stream.js';
 import { ATOM_KV_BLOCKS_METRIC, atomKvCacheBlocksFromMetricPhases } from './atom-kv-capacity.js';
-import type { ServerMetricsContext } from './server-metrics-adapters.js';
+import { normalizeServerMetrics, type ServerMetricsContext } from './server-metrics-adapters.js';
 
 export interface TraceDerivedPayloads {
   aggregateStats: AggregateStats;
@@ -79,6 +79,12 @@ export async function computeTraceDerivedPayloads(
   let chartSeries: ChartSeries | null = null;
 
   if (phases) {
+    phases.metrics = normalizeServerMetrics(phases.metrics, phases.inputConfig, metricsContext);
+    phases.warmupMetrics = normalizeServerMetrics(
+      phases.warmupMetrics,
+      phases.inputConfig,
+      metricsContext,
+    );
     const aggregateMetrics = phases.complete
       ? phases.metrics
       : selectMetrics(phases.metrics, AGGREGATE_SERVER_METRIC_KEYS);

--- a/packages/db/src/etl/gzip-json-stream.ts
+++ b/packages/db/src/etl/gzip-json-stream.ts
@@ -17,6 +17,7 @@ import Assembler from 'stream-json/assembler.js';
 import type { Token } from 'stream-json/parser.js';
 import { pick } from 'stream-json/filters/pick.js';
 import { streamObject } from 'stream-json/streamers/stream-object.js';
+import type { ServerMetricsInputConfig } from './server-metrics-adapters.js';
 
 /** Bound peak memory while retaining the fast path for ordinary metric blobs. */
 const MAX_IN_MEMORY_JSON_BYTES = 128 * 1024 * 1024;
@@ -81,6 +82,7 @@ export interface MetricPhaseMaps<T> {
   warmupMetrics: Record<string, T>;
   /** True when the bounded fast path retained every metric in the document. */
   complete: boolean;
+  inputConfig?: ServerMetricsInputConfig;
 }
 
 function isValueStart(token: Token): boolean {
@@ -120,6 +122,7 @@ async function streamCollectMetricPhases<T>(
   let valueAssembler: Assembler<T> | null = null;
   let valueTarget: Record<string, T> | null = null;
   let valueKey: string | null = null;
+  const metadata: Record<string, T> = {};
 
   // Packed-only values avoid emitting start/chunk/end tokens in addition to
   // their complete value token. This materially reduces the token count for
@@ -161,7 +164,12 @@ async function streamCollectMetricPhases<T>(
       }
     } else if (isValueStart(token)) {
       if (depthBefore === 1 && topLevelKey !== null) {
-        if (token.name === 'startObject' && topLevelKey === 'metrics') {
+        if (token.name === 'startObject' && topLevelKey === 'input_config') {
+          valueTarget = metadata;
+          valueKey = topLevelKey;
+          valueAssembler = new Assembler<T>();
+          valueAssembler.consume(token);
+        } else if (token.name === 'startObject' && topLevelKey === 'metrics') {
           metrics = {};
           phase = 'metrics';
         } else if (token.name === 'startObject' && topLevelKey === 'warmup_metrics') {
@@ -193,7 +201,14 @@ async function streamCollectMetricPhases<T>(
     }
   }
 
-  return { metrics, warmupMetrics, complete: false };
+  return {
+    metrics,
+    warmupMetrics,
+    complete: false,
+    ...(metadata.input_config
+      ? { inputConfig: metadata.input_config as ServerMetricsInputConfig }
+      : {}),
+  };
 }
 
 /**
@@ -210,11 +225,13 @@ export async function collectMetricPhases<T>(
     const parsed = JSON.parse(json) as {
       metrics?: Record<string, T>;
       warmup_metrics?: Record<string, T>;
+      input_config?: ServerMetricsInputConfig;
     };
     return {
       metrics: parsed.metrics ?? {},
       warmupMetrics: parsed.warmup_metrics ?? {},
       complete: true,
+      ...(parsed.input_config ? { inputConfig: parsed.input_config } : {}),
     };
   }
 

--- a/packages/db/src/etl/server-log-metrics.test.ts
+++ b/packages/db/src/etl/server-log-metrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { kvCachePoolTokensFromServerLog } from './server-log-metrics';
+import { kvCachePoolTokensFromServerLog, llmdEndpointRolesFromLogs } from './server-log-metrics';
 
 describe('kvCachePoolTokensFromServerLog', () => {
   it('returns null for empty / missing logs', () => {
@@ -40,4 +40,18 @@ describe('kvCachePoolTokensFromServerLog', () => {
     const log = `INFO GPU KV cache size: 1,234,567 tokens`;
     expect(kvCachePoolTokensFromServerLog(log)).toBe(1_234_567);
   });
+});
+
+it('reads llm-d discovery roles and rejects conflicting host assignments', () => {
+  const prefill =
+    '- address: 10.30.1.165\n  labels:\n    llm-d.ai/role: prefill\n  name: prefill-0';
+  const decode = '- address: 10.30.1.129\n  labels:\n    llm-d.ai/role: decode\n  name: decode-0';
+  expect(llmdEndpointRolesFromLogs([prefill, prefill, decode])).toEqual({
+    '10.30.1.165': 'prefill',
+    '10.30.1.129': 'decode',
+  });
+  expect(
+    llmdEndpointRolesFromLogs([prefill, prefill.replace('role: prefill', 'role: decode'), decode]),
+  ).toEqual({ '10.30.1.129': 'decode' });
+  expect(llmdEndpointRolesFromLogs(['engine=0 generation_tokens=100'])).toEqual({});
 });

--- a/packages/db/src/etl/server-log-metrics.ts
+++ b/packages/db/src/etl/server-log-metrics.ts
@@ -8,6 +8,29 @@
  * authoritative number.
  */
 
+/** Read llm-d's emitted discovery records, never infer roles from token counts. */
+export function llmdEndpointRolesFromLogs(
+  logs: readonly string[],
+): Record<string, 'prefill' | 'decode'> {
+  const roles = new Map<string, Set<'prefill' | 'decode'>>();
+  const record =
+    /^- address: (?<address>[^\r\n]+)\r?\n  labels:\r?\n    llm-d\.ai\/role: (?<role>prefill|decode)\r?$/gmu;
+  for (const log of logs) {
+    for (const match of log.matchAll(record)) {
+      const address = match.groups!.address!.trim();
+      const role = match.groups!.role as 'prefill' | 'decode';
+      const values = roles.get(address) ?? new Set<'prefill' | 'decode'>();
+      values.add(role);
+      roles.set(address, values);
+    }
+  }
+  return Object.fromEntries(
+    [...roles]
+      .filter(([, values]) => values.size === 1)
+      .map(([address, values]) => [address, [...values][0]!]),
+  );
+}
+
 /**
  * Total KV-cache pool size in tokens.
  *

--- a/packages/db/src/etl/server-metrics-adapters.ts
+++ b/packages/db/src/etl/server-metrics-adapters.ts
@@ -9,6 +9,7 @@ export type MetricSourceRole = 'router' | 'prefill' | 'decode' | 'combined' | 'u
 export interface RawMetricSourceSeries {
   endpoint_url?: string;
   labels?: Record<string, string>;
+  timeslices?: unknown[];
 }
 
 export interface ServerMetricsContext {
@@ -16,6 +17,16 @@ export interface ServerMetricsContext {
   framework?: string | null;
   /** Per-worker role series are only meaningful for disaggregated configs. */
   disagg?: boolean;
+  endpointRoles?: Record<string, MetricSourceRole>;
+}
+
+export interface ServerMetricsInputConfig {
+  endpoint?: { urls?: string[] };
+  server_metrics?: { urls?: string[] };
+}
+
+interface SourceMetric {
+  series?: RawMetricSourceSeries[];
 }
 
 export interface MetricSource {
@@ -34,6 +45,12 @@ interface ServerMetricsAdapter {
   id: string;
   matches: (context: ServerMetricsContext) => boolean;
   identifySource: (series: RawMetricSourceSeries) => MetricSource;
+  normalizeMetric?: <T extends SourceMetric>(
+    name: string,
+    metric: T,
+    input: ServerMetricsInputConfig,
+    context: ServerMetricsContext,
+  ) => T;
 }
 
 function stableId(adapter: string, parts: (string | null | undefined)[]): string {
@@ -130,8 +147,112 @@ const genericAdapter: ServerMetricsAdapter = {
   },
 };
 
-const ADAPTERS: readonly ServerMetricsAdapter[] = [trtllmAdapter, dynamoAdapter, genericAdapter];
+function parsedUrl(value: string | undefined): URL | null {
+  try {
+    return value ? new URL(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+function metricsUrl(value: string): string {
+  const url = parsedUrl(value);
+  if (!url) return value;
+  url.pathname = `${url.pathname.replace(/\/(?:metrics\/?)?$/u, '')}/metrics`;
+  return url.href;
+}
+
+function labelKey(series: RawMetricSourceSeries): string {
+  return JSON.stringify(
+    Object.entries(series.labels ?? {}).toSorted(([a], [b]) => a.localeCompare(b)),
+  );
+}
+
+const llmdAdapter: ServerMetricsAdapter = {
+  id: 'llmd',
+  matches: ({ framework }) => framework === 'llmd-vllm',
+  identifySource(series) {
+    const endpointUrl = series.endpoint_url ?? null;
+    const nativeRole = series.labels?.['engine_type'] ?? series.labels?.['llm-d.ai/role'] ?? null;
+    const role: MetricSourceRole =
+      nativeRole === 'prefill' || nativeRole === 'decode' || nativeRole === 'combined'
+        ? nativeRole
+        : 'unknown';
+    return {
+      id: stableId('llmd', [endpointUrl]),
+      adapter: 'llmd',
+      role,
+      endpointUrl,
+      nativeRole,
+      workerId: endpointUrl,
+      dpRank: null,
+      engine: null,
+    };
+  },
+  normalizeMetric(name, metric, input, context) {
+    if (!name.startsWith('vllm:')) return metric;
+    const explicit = new Set((input.server_metrics?.urls ?? []).map(metricsUrl));
+    const frontends = new Set((input.endpoint?.urls ?? []).map((url) => parsedUrl(url)?.origin));
+    const directLabels = new Set(
+      (metric.series ?? [])
+        .filter((series) => explicit.has(series.endpoint_url ?? '') && series.timeslices?.length)
+        .map(labelKey),
+    );
+    return {
+      ...metric,
+      series: (metric.series ?? [])
+        .filter((series) => {
+          const url = parsedUrl(series.endpoint_url);
+          return (
+            !url ||
+            explicit.has(url.href) ||
+            !frontends.has(url.origin) ||
+            !directLabels.has(labelKey(series))
+          );
+        })
+        .map((series) => {
+          const url = parsedUrl(series.endpoint_url);
+          const role = context.disagg
+            ? (context.endpointRoles?.[series.endpoint_url ?? ''] ??
+              context.endpointRoles?.[url?.hostname ?? ''] ??
+              series.labels?.['llm-d.ai/role'])
+            : 'combined';
+          // Internal identity labels; the stored AIPerf blob remains unchanged.
+          return {
+            ...series,
+            labels: {
+              ...series.labels,
+              worker_id: series.endpoint_url ?? '',
+              ...(role ? { engine_type: role } : {}),
+            },
+          };
+        }),
+    };
+  },
+};
+
+const ADAPTERS: readonly ServerMetricsAdapter[] = [
+  trtllmAdapter,
+  dynamoAdapter,
+  llmdAdapter,
+  genericAdapter,
+];
 
 export function selectServerMetricsAdapter(context: ServerMetricsContext): ServerMetricsAdapter {
   return ADAPTERS.find((adapter) => adapter.matches(context)) ?? genericAdapter;
+}
+
+export function normalizeServerMetrics<T extends SourceMetric>(
+  metrics: Record<string, T>,
+  input: ServerMetricsInputConfig = {},
+  context: ServerMetricsContext = {},
+): Record<string, T> {
+  const normalize = selectServerMetricsAdapter(context).normalizeMetric;
+  if (!normalize) return metrics;
+  return Object.fromEntries(
+    Object.entries(metrics).map(([name, metric]) => [
+      name,
+      normalize(name, metric, input, context),
+    ]),
+  );
 }

--- a/packages/db/src/etl/trace-artifact-discovery.test.ts
+++ b/packages/db/src/etl/trace-artifact-discovery.test.ts
@@ -117,3 +117,18 @@ describe('discoverTraceReplayArtifacts', () => {
     );
   });
 });
+
+it('loads endpoint roles beside multinode concurrency directories', () => {
+  const root = tempDir();
+  const artifact = path.join(root, 'agentic_llmd_conc64');
+  writeTraceFiles(path.join(artifact, 'conc_64'));
+  fs.writeFileSync(
+    path.join(artifact, 'llmd_metrics_endpoints.json'),
+    JSON.stringify({
+      'http://worker.test:8200/metrics': { name: 'prefill-0', role: 'prefill' },
+    }),
+  );
+  expect(discoverTraceReplayArtifacts(root).get('llmd_conc64|64')?.endpointRoles).toEqual({
+    'http://worker.test:8200/metrics': 'prefill',
+  });
+});

--- a/packages/db/src/etl/trace-artifact-discovery.ts
+++ b/packages/db/src/etl/trace-artifact-discovery.ts
@@ -1,11 +1,13 @@
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import type { MetricSourceRole } from './server-metrics-adapters';
 
 export interface TraceReplayArtifactPaths {
   profileJsonl: string | null;
   serverMetricsCsv: string | null;
   serverMetricsJson: string | null;
+  endpointRoles?: Record<string, MetricSourceRole>;
 }
 
 const TRACE_SUBDIRS = ['aiperf_artifacts', 'trace_replay'];
@@ -33,7 +35,24 @@ function traceFilesIn(dir: string): TraceReplayArtifactPaths | null {
   }
 
   if (!profileJsonl && !serverMetricsCsv && !serverMetricsJson) return null;
-  return { profileJsonl, serverMetricsCsv, serverMetricsJson };
+  const manifestPath = path.join(path.dirname(dir), 'llmd_metrics_endpoints.json');
+  const endpointRoles: Record<string, MetricSourceRole> = {};
+  if (fs.existsSync(manifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as Record<
+      string,
+      { role?: string }
+    >;
+    for (const [url, source] of Object.entries(manifest)) {
+      if (source.role === 'prefill' || source.role === 'decode' || source.role === 'combined')
+        endpointRoles[url] = source.role;
+    }
+  }
+  return {
+    profileJsonl,
+    serverMetricsCsv,
+    serverMetricsJson,
+    ...(Object.keys(endpointRoles).length > 0 ? { endpointRoles } : {}),
+  };
 }
 
 function extractMultinodeArchive(artifactDir: string): string | null {

--- a/packages/db/src/ingest-ci-run.ts
+++ b/packages/db/src/ingest-ci-run.ts
@@ -22,6 +22,7 @@
  *     original source sweep run, so public links point at the real benchmark run.
  */
 
+import { getServerMetricsContext } from './queries/server-logs.js';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -660,8 +661,11 @@ async function main(): Promise<void> {
                         serverMetricsCsv: trace.serverMetricsCsv,
                         serverMetricsJson: trace.serverMetricsJson,
                         metricsContext: {
-                          framework: toInsert[0]?.config.framework,
-                          disagg: toInsert[0]?.config.disagg,
+                          ...(await getServerMetricsContext(sql, insertedIds[0]!, {
+                            framework: toInsert[0]?.config.framework,
+                            disagg: toInsert[0]?.config.disagg,
+                            endpointRoles: trace.endpointRoles,
+                          })),
                         },
                       },
                       // oxlint-disable-next-line no-loop-func -- each callback closes over this iteration's block-scoped trace metadata

--- a/packages/db/src/queries/agentic-aggregates.ts
+++ b/packages/db/src/queries/agentic-aggregates.ts
@@ -13,16 +13,14 @@
  * or has no usable samples — frontend treats those as "no data".
  */
 
-import { Readable } from 'node:stream';
-import { createGunzip, gunzipSync } from 'node:zlib';
+import { gunzipSync } from 'node:zlib';
 
-import { chain } from 'stream-chain';
-
-import { parser } from 'stream-json';
-import { pick } from 'stream-json/filters/pick.js';
-import { streamObject } from 'stream-json/streamers/stream-object.js';
-
-import { gunzipJsonWithinLimit } from '../etl/gzip-json-stream';
+import { collectMetricPhases } from '../etl/gzip-json-stream';
+import {
+  normalizeServerMetrics,
+  type ServerMetricsContext,
+  type ServerMetricsInputConfig,
+} from '../etl/server-metrics-adapters';
 import type { DbClient } from '../connection.js';
 import { computeDerivedFromBlob } from './derived-agentic-metrics';
 import {
@@ -143,12 +141,15 @@ function pickFirstNonEmpty(
   return undefined;
 }
 
-export function extractServerMetricSamples(json: string): {
+export function extractServerMetricSamples(
+  json: string,
+  context: ServerMetricsContext = {},
+): {
   kvCacheUtil: number[];
   prefixCacheHitRate: number[];
 } {
-  const parsed = JSON.parse(json) as MetricsJson;
-  const metrics = parsed.metrics ?? {};
+  const parsed = JSON.parse(json) as MetricsJson & { input_config?: ServerMetricsInputConfig };
+  const metrics = normalizeServerMetrics(parsed.metrics ?? {}, parsed.input_config, context);
 
   // KV cache util — per-engine gauge in [0, 1]. Average across engines so the
   // value stays a percentage; summing would give meaningless 0..N.
@@ -242,33 +243,15 @@ const TARGET_METRIC_KEYS = new Set([
  * Returns the same `{ kvCacheUtil, prefixCacheHitRate }` shape as the
  * synchronous fast path so callers can use either interchangeably.
  */
-async function streamExtractServerMetricSamples(
+export async function extractServerMetricSamplesFromBlob(
   buffer: Buffer,
+  context: ServerMetricsContext = {},
 ): Promise<{ kvCacheUtil: number[]; prefixCacheHitRate: number[] }> {
-  const collected: Record<string, MetricMeta> = {};
-  // stream-json's TypeScript types don't compose cleanly with node:stream's
-  // pipeline() generic, and several `.pipe()`/event APIs are typed loosely —
-  // cast to any for this local pipe chain. It works at runtime.
-  // stream-json composes transforms via stream-chain. `pick`/`streamObject`
-  // each return a Transform when called; `chain([...])` wires them.
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  const pipeline = chain([
-    Readable.from(buffer),
-    createGunzip(),
-    parser(),
-    pick({ filter: 'metrics' }),
-    streamObject(),
-  ]);
-  await new Promise<void>((resolve, reject) => {
-    (pipeline as any).on('data', (chunk: unknown) => {
-      const { key, value } = chunk as { key: string; value: MetricMeta };
-      if (TARGET_METRIC_KEYS.has(key)) collected[key] = value;
-    });
-    (pipeline as any).on('end', resolve);
-    (pipeline as any).on('error', reject);
-  });
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-  return extractServerMetricSamples(JSON.stringify({ metrics: collected }));
+  const phases = await collectMetricPhases<MetricMeta>(buffer, TARGET_METRIC_KEYS);
+  return extractServerMetricSamples(
+    JSON.stringify({ metrics: phases.metrics, input_config: phases.inputConfig }),
+    context,
+  );
 }
 
 export async function getAgenticAggregates(
@@ -379,22 +362,24 @@ export async function getAgenticAggregates(
     const rows = (await sql`
       select
         br.id as benchmark_result_id,
-        atr.server_metrics_json_gz as server_blob
+        atr.server_metrics_json_gz as server_blob, c.framework, c.disagg
       from benchmark_results br
       join agentic_trace_replay atr on atr.id = br.trace_replay_id
+      join configs c on c.id = br.config_id
       where br.id = any(${chunk}::bigint[])
-    `) as { benchmark_result_id: number; server_blob: Buffer | null }[];
+    `) as {
+      benchmark_result_id: number;
+      server_blob: Buffer | null;
+      framework: string;
+      disagg: boolean;
+    }[];
     for (const row of rows) {
       const id = Number(row.benchmark_result_id);
       result[id] ??= blankAggregate(id);
       if (!row.server_blob) continue;
       let parsed: { kvCacheUtil: number[]; prefixCacheHitRate: number[] } | null = null;
       try {
-        const json = gunzipJsonWithinLimit(row.server_blob);
-        parsed =
-          json === null
-            ? await streamExtractServerMetricSamples(row.server_blob)
-            : extractServerMetricSamples(json);
+        parsed = await extractServerMetricSamplesFromBlob(row.server_blob, row);
       } catch {
         // malformed blob or failed stream fallback — leave nulls
       }

--- a/packages/db/src/queries/agentic-shared.ts
+++ b/packages/db/src/queries/agentic-shared.ts
@@ -50,8 +50,9 @@ import {
  * timelines or attempting to combine per-point percentiles.
  *
  * v9: extract ATOM KV utilization and admitted prefix-cache hit rates.
+ * v10: exclude llm-d frontend mirrors from server metric aggregates.
  */
-export const STATS_VERSION = 9;
+export const STATS_VERSION = 10;
 
 interface ProfileRecord {
   metadata?: { benchmark_phase?: string; was_cancelled?: boolean };

--- a/packages/db/src/queries/server-logs.test.ts
+++ b/packages/db/src/queries/server-logs.test.ts
@@ -4,6 +4,7 @@ import type { DbClient } from '../connection.js';
 import {
   escapePostgresRegexLiteral,
   getServerLogAvailability,
+  getServerMetricsContext,
   getServerLogChunk,
   getServerLogFileNames,
   searchServerLogs,
@@ -217,5 +218,32 @@ describe('getServerLogAvailability', () => {
     const { sql, call } = mockSql([]);
     await expect(getServerLogAvailability(sql, [])).resolves.toEqual({});
     expect(call).not.toHaveBeenCalled();
+  });
+});
+
+it('loads llm-d roles from bounded discovery matches without changing other backends', async () => {
+  const call = vi
+    .fn()
+    .mockResolvedValueOnce([{ file_name: 'slurm.out' }])
+    .mockResolvedValueOnce([
+      {
+        file_name: 'slurm.out',
+        match_position: 41,
+        char_count: 100,
+        has_more: false,
+        before_text: '- address: 10.0.0.1\n  labels:\n    ',
+        match_text: 'llm-d.ai/role:',
+        after_text: ' prefill\n  name: prefill-0\n',
+      },
+    ])
+    .mockResolvedValueOnce([{ match_position: 0, char_count: 20, has_more: false }]);
+  const sql = call as unknown as DbClient;
+  const dynamo = { framework: 'dynamo-vllm', disagg: true };
+  expect(await getServerMetricsContext(sql, 42, dynamo)).toEqual(dynamo);
+  expect(call).not.toHaveBeenCalled();
+  expect(await getServerMetricsContext(sql, 42, { framework: 'llmd-vllm', disagg: true })).toEqual({
+    framework: 'llmd-vllm',
+    disagg: true,
+    endpointRoles: { '10.0.0.1': 'prefill' },
   });
 });

--- a/packages/db/src/queries/server-logs.ts
+++ b/packages/db/src/queries/server-logs.ts
@@ -1,4 +1,23 @@
 import type { DbClient } from '../connection.js';
+import type postgres from 'postgres';
+import type { ServerMetricsContext } from '../etl/server-metrics-adapters.js';
+import { llmdEndpointRolesFromLogs } from '../etl/server-log-metrics';
+
+export async function getServerMetricsContext(
+  sql: DbClient | ReturnType<typeof postgres>,
+  benchmarkResultId: number,
+  context: ServerMetricsContext,
+): Promise<ServerMetricsContext> {
+  if (context.framework !== 'llmd-vllm' || !context.disagg || context.endpointRoles) return context;
+  const found = await searchServerLogs(sql as DbClient, benchmarkResultId, 'llm-d.ai/role:', 128);
+  if (found.truncated) return context;
+  return {
+    ...context,
+    endpointRoles: llmdEndpointRolesFromLogs(
+      found.matches.map((match) => match.before + match.match + match.after),
+    ),
+  };
+}
 
 /** Map of `benchmark_results.id` → true for each id with a linked log bundle. */
 export type ServerLogAvailabilityMap = Record<number, true>;

--- a/packages/db/src/queries/trace-server-metrics.ts
+++ b/packages/db/src/queries/trace-server-metrics.ts
@@ -20,6 +20,7 @@ import {
 } from '../etl/compute-chart-series';
 
 import type { DbClient } from '../connection.js';
+import { getServerMetricsContext } from './server-logs';
 import { writeBackTraceReplayJsonb } from './agentic-shared';
 
 export type {
@@ -362,10 +363,11 @@ export async function getTraceServerMetrics(
 
   // `computeChartSeries` streams blobs that exceed its in-memory fast-path
   // ceiling so high-conc TP+EP rows succeed before the backfill drains them.
-  const series = await computeChartSeries(blob, {
+  const context = await getServerMetricsContext(sql, benchmarkResultId, {
     framework: row.framework,
     disagg: row.disagg,
   });
+  const series = await computeChartSeries(blob, context);
   if (!series) return null;
 
   // Self-heal the stored chart_series so the next request takes the fast path
@@ -423,10 +425,11 @@ export async function getTraceServerMetricSource(
   `) as unknown as RawBlobRow[];
   const blob = blobRows[0]?.blob;
   if (!blob) return null;
-  const series = await computeChartSeries(blob, {
+  const context = await getServerMetricsContext(sql, benchmarkResultId, {
     framework: row.framework,
     disagg: row.disagg,
   });
+  const series = await computeChartSeries(blob, context);
   if (!series) return null;
   writeBackTraceReplayJsonb(sql, 'chart_series', row.trace_replay_id, series);
   return series.metricSources.find(({ source }) => source.id === sourceId) ?? null;


### PR DESCRIPTION
## Summary

- Add llm-d normalization to the existing server-metrics adapter interface, shared by ingestion, API fallback, and backfills.
- Drop an automatically scraped inference/frontend series only when the same vLLM metric and labels have samples from an explicitly configured worker endpoint. Keep explicit localhost endpoints and other backends unchanged.
- Preserve endpoint-scoped worker/engine identity and prefill/decode roles from endpoint manifests or captured discovery logs. Bump derived-data versions so old charts are recomputed from the unchanged raw artifacts.

## Verification

- All 5,545 workspace unit tests pass; typecheck, lint, formatting, and typography checks pass.
- Reparsed the original 2.18 GB AIPerf P/D concurrency-64 export from [InferenceX run 33721476500, attempt 1](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33721476500/attempts/1): 16 engines, four worker sources, two prefill and two decode, and no frontend mirror.
- Regression coverage extends existing tests for both bounded/streaming parsing, explicit localhost workers, missing worker counterparts, role discovery, and unaffected backend behavior.
- Local Cypress smoke suite passes: 43 component tests and 110 integration tests.
- Staging preview: https://inferencemax-app-env-llmd-metrics-preview-semianalysisai.vercel.app/inference/agentic/440883 (ready; verified against staging point `440883`).
- Live preview verification: all four worker-source endpoints return four engines each; six chart metric families match the original raw-artifact recomputation exactly.
- [Staging-only recomputation](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/33802335555) passed: 13 charts and 13 aggregate records updated, zero failures. The aggregate API returns HTTP 200 and its KV-cache mean matches the raw-artifact recomputation exactly.
- CI passed for the initial fix and is rerunning for the phase-selection follow-up in cd6b879. Local unit tests and raw-artifact verification pass for the follow-up.

## Rollout

Recompute only the affected run on staging with the existing Recompute Agentic Metrics workflow. No schema migration or benchmark/GPU rerun is required. Production DB has not been modified. Drain the aggregate backfill before production rollout: fetching a large raw artifact on the fallback path can exceed Neon’s 64 MiB response limit.

This corrects server-series selection and worker identity. It does not redefine external KV transfer as CPU offload or change client-measured latency/throughput.

The `llmd-metrics-preview` Vercel environment matches this PR branch and references the existing staging DB secrets, with isolated `pr-989-staging` cache namespaces. Remove this temporary environment after testing/merge to free the project’s custom-environment slot.
