### PR TITLE
feat(nav): move Chip Specs from dashboard tabs to footer

### DIFF
--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -186,8 +186,8 @@ describe('TabNav — Hidden popover for gated tabs', () => {
     cy.window().then((win) => win.localStorage.removeItem('inferencex-feature-gate'));
     mountTabNav({});
     cy.get('[data-testid="tab-trigger-inference"]').should('exist');
-    cy.get('[data-testid="tab-trigger-gpu-specs"]').should('exist');
     cy.get('[data-testid="tab-trigger-submissions"]').should('exist');
+    cy.get('[data-testid="tab-trigger-gpu-specs"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-hidden"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-feedback"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-ai-chart"]').should('not.exist');

--- a/packages/app/cypress/e2e/gpu-specs.cy.ts
+++ b/packages/app/cypress/e2e/gpu-specs.cy.ts
@@ -409,10 +409,12 @@ describe('GPU Specs Navigation', () => {
     cy.get('[data-testid="chart-section-tabs"]').should('be.visible');
   });
 
-  it('tab switcher activates GPU Specs', () => {
-    cy.get('[data-testid="tab-trigger-gpu-specs"]').click();
+  it('footer link opens GPU Specs and the tab strip shows no active tab', () => {
+    cy.get('[data-testid="tab-trigger-gpu-specs"]').should('not.exist');
+    cy.get('[data-testid="footer-link-gpu-specs"]').scrollIntoView().click();
     cy.url().should('include', '/gpu-specs');
     cy.get('h2').should('contain.text', 'Chip Specifications');
+    cy.get('[data-testid="chart-section-tabs"] [data-tab-active="true"]').should('not.exist');
   });
 });
 

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -19,8 +19,8 @@ describe('Chart Section Tabs — E2E', () => {
     cy.get('[data-testid="tab-trigger-calculator"]').click();
     cy.url().should('include', '/calculator');
 
-    cy.get('[data-testid="tab-trigger-gpu-specs"]').click();
-    cy.url().should('include', '/gpu-specs');
+    cy.get('[data-testid="tab-trigger-submissions"]').click();
+    cy.url().should('include', '/submissions');
 
     cy.get('[data-testid="tab-trigger-inference"]').click();
     cy.url().should('include', '/inference');
@@ -32,6 +32,14 @@ describe('Chart Section Tabs — E2E', () => {
     cy.get('[data-testid="footer-link-reliability"]').scrollIntoView().click();
     cy.url().should('include', '/reliability');
     cy.get('[data-testid="reliability-chart-display"]').should('exist');
+  });
+
+  it('opens Chip Specs from the footer link', () => {
+    cy.get('[data-testid="tab-trigger-gpu-specs"]').should('not.exist');
+
+    cy.get('[data-testid="footer-link-gpu-specs"]').scrollIntoView().click();
+    cy.url().should('include', '/gpu-specs');
+    cy.get('[data-testid="gpu-specs-content"]').should('exist');
   });
 
   it('shows mobile chart select dropdown on small viewport', () => {

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -145,8 +145,8 @@ describe('URL Parameter Persistence', () => {
       cy.contains('[role="option"]', 'Qwen3.5 397B').click();
       cy.get('[data-testid="model-selector"]').should('contain.text', 'Qwen3.5 397B');
       // Navigate immediately to cover pending writes inside the debounce window.
-      cy.get('[data-testid="tab-trigger-gpu-specs"]').click();
-      cy.url().should('include', '/gpu-specs');
+      cy.get('[data-testid="tab-trigger-submissions"]').click();
+      cy.url().should('include', '/submissions');
       cy.get('[data-testid="tab-trigger-inference"]').click();
 
       cy.get('[data-testid="model-selector"]').should('contain.text', 'Qwen3.5 397B');

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -32,6 +32,7 @@ const STRINGS = {
     articles: 'Articles',
     apiReference: 'API Reference',
     gpuReliability: 'Chip Reliability',
+    gpuSpecsDashboard: 'Chip Specs Dashboard',
     perfPerDollar: 'Performance per Dollar',
     modelArchitectures: 'Model Architectures',
     glossary: 'AI Inference Glossary',
@@ -62,6 +63,7 @@ const STRINGS = {
     telemetry: '遥测数据',
     articles: '技术文章',
     gpuReliability: '芯片可靠性',
+    gpuSpecsDashboard: '芯片规格仪表板',
     apiReference: 'API 文档',
     perfPerDollar: '每美元性能',
     modelArchitectures: '模型架构',
@@ -259,6 +261,13 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                   className="inline-flex min-h-11 items-center rounded-sm py-1 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4 focus-visible:outline-none md:min-h-8"
                 >
                   {t.gpuReliability}
+                </Link>
+                <Link
+                  data-testid="footer-link-gpu-specs"
+                  href={`${prefix}/gpu-specs`}
+                  className="inline-flex min-h-11 items-center rounded-sm py-1 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4 focus-visible:outline-none md:min-h-8"
+                >
+                  {t.gpuSpecsDashboard}
                 </Link>
                 <Link
                   data-testid="footer-link-compare-per-dollar"

--- a/packages/app/src/lib/dashboard-routes.test.ts
+++ b/packages/app/src/lib/dashboard-routes.test.ts
@@ -27,9 +27,11 @@ describe('dashboard route registry', () => {
     expect(existsSync(chinesePage)).toBe(route.localeMirrored);
   });
 
-  it('keeps reliability footer-only and indexable, and feedback out of the sitemap', () => {
+  it('keeps reliability and gpu-specs footer-only and indexable, and feedback out of the sitemap', () => {
     expect(getDashboardRoute('reliability').navGroup).toBe('footer-only');
     expect(getDashboardRoute('reliability').indexable).toBe(true);
+    expect(getDashboardRoute('gpu-specs').navGroup).toBe('footer-only');
+    expect(getDashboardRoute('gpu-specs').indexable).toBe(true);
     expect(getDashboardRoute('feedback').indexable).toBe(false);
   });
 

--- a/packages/app/src/lib/dashboard-routes.ts
+++ b/packages/app/src/lib/dashboard-routes.ts
@@ -136,7 +136,7 @@ export const DASHBOARD_ROUTES = [
     key: 'gpu-specs',
     path: '/gpu-specs',
     canonicalPath: '/gpu-specs',
-    navGroup: 'primary',
+    navGroup: 'footer-only',
     indexable: true,
     localeMirrored: true,
     providers: STANDALONE_DASHBOARD_PROVIDERS,


### PR DESCRIPTION
## What

Moves `/gpu-specs` out of the dashboard tab bar and into the footer.

- `dashboard-routes.ts`: `gpu-specs` navGroup `primary` → `footer-only` (same treatment as `/reliability`). It drops out of the desktop tab strip and the mobile chart selector; route, canonical, sitemap entry, and `/zh` mirror are unchanged.
- `footer.tsx`: new **Chip Specs Dashboard** / **芯片规格仪表板** link in the More column, `data-testid="footer-link-gpu-specs"`. The existing "Chip Specs & Pricing" link still points at the SEO `/chips` pages.
- Tests: `dashboard-routes.test.ts` asserts the new group; Cypress tab-switch tests that used `gpu-specs` as a standalone-provider tab now use `/submissions`; new e2e case opens Chip Specs from the footer.

## Verification

`bun run fmt`, `bun run lint`, `bun run typecheck`, and the dashboard-routes / i18n unit tests pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and discoverability change only; no auth, data, or API behavior. Users who relied on the tab must use the footer link.
> 
> **Overview**
> **Chip Specs (`/gpu-specs`) is no longer a primary dashboard tab**; it is reached from the footer like GPU Reliability, while the route, SEO, and `/zh` mirror stay the same.
> 
> `gpu-specs` in `dashboard-routes.ts` moves from `navGroup: 'primary'` to `'footer-only'`, so it disappears from the desktop tab strip and mobile chart selector. On that page the tab strip shows **no active tab** (same as reliability). The footer **More** column gains **Chip Specs Dashboard** / **芯片规格仪表板** (`footer-link-gpu-specs`), separate from the existing **Chip Specs & Pricing** link to `/chips`.
> 
> Tests are updated: route config asserts footer-only + indexable; Cypress expects no `tab-trigger-gpu-specs` when locked, opens `/gpu-specs` via the footer, and uses `/submissions` where flows previously tabbed through gpu-specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3b5450a80882c37b272e8ebf181a906e881de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->