### PR TITLE
fix(db): safely backfill stale AgentX payloads

### DIFF
--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -206,7 +206,7 @@ jobs:
         if: inputs.neon-branch != ''
         env:
           PREVIEW_URL: ${{ inputs.preview-url }}
-          INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
+          INVALIDATE_SECRET: ${{ secrets.VERCEL_STAGING_INVALIDATE_SECRET }}
           PROTECTION_BYPASS_SECRET: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
         run: |
           node -e '

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -22,10 +22,6 @@ on:
         description: Optional existing Neon child branch; omit for production on master
         required: false
         type: string
-      preview-url:
-        description: Optional deployment with an isolated cache namespace for the child database
-        required: false
-        type: string
       atom-kv-capacity-only:
         description: Backfill only ATOM KV capacity from stored logs and metrics
         required: false
@@ -180,9 +176,9 @@ jobs:
           RUN_ID: ${{ inputs.run-id }}
         run: bun run --cwd packages/db db:backfill-atom-kv-capacity --run-id "$RUN_ID" --yes
   invalidate:
-    name: Invalidate repaired database cache
+    name: Invalidate production cache
     needs: recompute
-    if: inputs.neon-branch == '' || inputs.preview-url != ''
+    if: inputs.neon-branch == ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -198,27 +194,6 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: '0'
       - name: Invalidate production cache after all shards pass
-        if: inputs.neon-branch == ''
         env:
           INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
         run: bun run admin:cache:invalidate https://inferencex.semianalysis.com
-      - name: Invalidate isolated preview cache after all shards pass
-        if: inputs.neon-branch != ''
-        env:
-          PREVIEW_URL: ${{ inputs.preview-url }}
-          INVALIDATE_SECRET: ${{ secrets.VERCEL_STAGING_INVALIDATE_SECRET }}
-          PROTECTION_BYPASS_SECRET: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
-        run: |
-          node -e '
-            const url = new URL(process.env.PREVIEW_URL);
-            if (url.protocol !== "https:" || url.username || url.password ||
-                !url.hostname.startsWith("inferencemax-app-") ||
-                !url.hostname.endsWith("-semianalysisai.vercel.app") ||
-                url.hostname.includes("-git-master-") || url.hostname.includes("-git-main-")) {
-              throw new Error("Expected an InferenceX preview deployment URL");
-            }
-          '
-          curl --fail-with-body --silent --show-error --max-time 180 --request POST \
-            "${PREVIEW_URL%/}/api/v1/invalidate" \
-            -H "Authorization: Bearer $INVALIDATE_SECRET" \
-            -H "x-vercel-protection-bypass: $PROTECTION_BYPASS_SECRET"

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -41,6 +41,7 @@ concurrency:
 
 jobs:
   scope:
+    name: Select repair shards
     runs-on: ubuntu-latest
     outputs:
       shards: ${{ steps.scope.outputs.shards }}
@@ -161,6 +162,7 @@ jobs:
           RUN_ID: ${{ inputs.run-id }}
         run: bun run --cwd packages/db db:backfill-atom-kv-capacity --run-id "$RUN_ID" --yes
   invalidate:
+    name: Invalidate production cache
     needs: recompute
     if: inputs.neon-branch == ''
     runs-on: ubuntu-latest

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -1,11 +1,21 @@
 name: Recompute Agentic Metrics
-run-name: Recompute metrics for run ${{ inputs.run-id }} (${{ inputs.neon-branch || 'production' }})
+run-name: Recompute metrics for ${{ inputs.run-id || 'all' }} (${{ inputs.neon-branch || 'production' }})
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/recompute-agentic-metrics.yml'
+      - 'packages/db/src/backfill-chart-series.ts'
+      - 'packages/db/src/backfill-aggregate-stats.ts'
+      - 'packages/db/src/backfill-request-timeline.ts'
+      - 'packages/db/src/etl/compute-chart-series.ts'
+      - 'packages/db/src/etl/compute-request-timeline.ts'
+      - 'packages/db/src/queries/agentic-shared.ts'
   workflow_dispatch:
     inputs:
       run-id:
-        description: Already-ingested GitHub benchmark run to recompute
+        description: Already-ingested GitHub benchmark run, or all for stale-only bulk repair
         required: true
         type: string
       neon-branch:
@@ -17,19 +27,54 @@ on:
         required: false
         type: boolean
         default: false
+      stale-only:
+        description: Skip already-current derived payloads
+        required: false
+        type: boolean
+        default: true
 
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.neon-branch || 'production' }}-${{ inputs.run-id }}
+  group: ${{ github.workflow }}-${{ inputs.neon-branch || 'production' }}
   cancel-in-progress: false
 
 jobs:
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.scope.outputs.shards }}
+      count: ${{ steps.scope.outputs.count }}
+    steps:
+      - id: scope
+        env:
+          RUN_ID: ${{ inputs.run-id || 'all' }}
+          ATOM_ONLY: ${{ inputs.atom-kv-capacity-only }}
+        run: |
+          if [[ "$RUN_ID" == all ]]; then
+            if [[ "$ATOM_ONLY" == true ]]; then
+              echo '::error::ATOM capacity backfill requires a specific run'
+              exit 1
+            fi
+            echo 'shards=[0,1,2,3,4,5,6,7]' >> "$GITHUB_OUTPUT"
+            echo 'count=8' >> "$GITHUB_OUTPUT"
+          elif [[ "$RUN_ID" =~ ^[1-9][0-9]*$ ]]; then
+            echo 'shards=[0]' >> "$GITHUB_OUTPUT"
+            echo 'count=1' >> "$GITHUB_OUTPUT"
+          else
+            echo '::error::Expected a GitHub run ID or all'
+            exit 1
+          fi
   recompute:
-    name: Recompute stored server metrics
+    name: Recompute stored metrics (shard ${{ matrix.shard }})
+    needs: scope
     if: github.ref == 'refs/heads/master' || inputs.neon-branch != ''
     runs-on: blacksmith-16vcpu-ubuntu-2404
-    timeout-minutes: 90
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ fromJSON(needs.scope.outputs.shards) }}
     permissions:
       contents: read
     steps:
@@ -85,19 +130,54 @@ jobs:
           fi
           echo "::add-mask::$database_url"
           echo "DATABASE_WRITE_URL=$database_url" >> "$GITHUB_ENV"
-      - name: Recompute chart series and aggregate statistics
+      - name: Snapshot, recompute, and verify derived data
         if: inputs.atom-kv-capacity-only != true
         env:
-          RUN_ID: ${{ inputs.run-id }}
+          RUN_ID: ${{ inputs.run-id || 'all' }}
+          STALE_ONLY: ${{ inputs.stale-only }}
+          SHARD_COUNT: ${{ needs.scope.outputs.count }}
+          SHARD_INDEX: ${{ matrix.shard }}
         run: |
-          bun run --cwd packages/db db:backfill-chart-series --run-id "$RUN_ID" --force --yes
-          bun run --cwd packages/db db:backfill-aggregate-stats --run-id "$RUN_ID" --force --yes
+          args=(--yes --shard-count "$SHARD_COUNT" --shard-index "$SHARD_INDEX")
+          if [[ "$RUN_ID" != all ]]; then args+=(--run-id "$RUN_ID"); fi
+          manifest="$RUNNER_TEMP/agentx-integrity.json"
+          bun packages/db/src/verify-agentic-backfill.ts "${args[@]}" --snapshot "$manifest"
+          rebuild=("${args[@]}")
+          if [[ "$RUN_ID" != all && "$STALE_ONLY" == false ]]; then rebuild+=(--force); fi
+          bun run --cwd packages/db db:backfill-chart-series "${rebuild[@]}"
+          bun run --cwd packages/db db:backfill-aggregate-stats "${rebuild[@]}"
+          bun run --cwd packages/db db:backfill-request-timeline "${args[@]}"
+          bun packages/db/src/verify-agentic-backfill.ts "${args[@]}" --verify "$manifest"
+      - name: Retain integrity evidence
+        if: ${{ always() && inputs.atom-kv-capacity-only != true }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: agentx-integrity-${{ matrix.shard }}
+          path: ${{ runner.temp }}/agentx-integrity.json
+          retention-days: 14
       - name: Backfill ATOM KV capacity
+        if: inputs.atom-kv-capacity-only == true
         env:
           RUN_ID: ${{ inputs.run-id }}
         run: bun run --cwd packages/db db:backfill-atom-kv-capacity --run-id "$RUN_ID" --yes
-      - name: Invalidate production cache
-        if: inputs.neon-branch == ''
+  invalidate:
+    needs: recompute
+    if: inputs.neon-branch == ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: package.json
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        env:
+          CYPRESS_INSTALL_BINARY: '0'
+      - name: Invalidate production cache after all shards pass
         env:
           INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
         run: bun run admin:cache:invalidate https://inferencex.semianalysis.com

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -22,6 +22,10 @@ on:
         description: Optional existing Neon child branch; omit for production on master
         required: false
         type: string
+      preview-url:
+        description: Optional deployment with an isolated cache namespace for the child database
+        required: false
+        type: string
       atom-kv-capacity-only:
         description: Backfill only ATOM KV capacity from stored logs and metrics
         required: false
@@ -174,9 +178,9 @@ jobs:
           RUN_ID: ${{ inputs.run-id }}
         run: bun run --cwd packages/db db:backfill-atom-kv-capacity --run-id "$RUN_ID" --yes
   invalidate:
-    name: Invalidate production cache
+    name: Invalidate repaired database cache
     needs: recompute
-    if: inputs.neon-branch == ''
+    if: inputs.neon-branch == '' || inputs.preview-url != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -192,6 +196,27 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: '0'
       - name: Invalidate production cache after all shards pass
+        if: inputs.neon-branch == ''
         env:
           INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
         run: bun run admin:cache:invalidate https://inferencex.semianalysis.com
+      - name: Invalidate isolated preview cache after all shards pass
+        if: inputs.neon-branch != ''
+        env:
+          PREVIEW_URL: ${{ inputs.preview-url }}
+          INVALIDATE_SECRET: ${{ secrets.VERCEL_INVALIDATE_SECRET }}
+          PROTECTION_BYPASS_SECRET: ${{ secrets.VERCEL_STAGING_BYPASS_SECRET }}
+        run: |
+          node -e '
+            const url = new URL(process.env.PREVIEW_URL);
+            if (url.protocol !== "https:" || url.username || url.password ||
+                !url.hostname.startsWith("inferencemax-app-") ||
+                !url.hostname.endsWith("-semianalysisai.vercel.app") ||
+                url.hostname.includes("-git-master-") || url.hostname.includes("-git-main-")) {
+              throw new Error("Expected an InferenceX preview deployment URL");
+            }
+          '
+          curl --fail-with-body --silent --show-error --max-time 180 --request POST \
+            "${PREVIEW_URL%/}/api/v1/invalidate" \
+            -H "Authorization: Bearer $INVALIDATE_SECRET" \
+            -H "x-vercel-protection-bypass: $PROTECTION_BYPASS_SECRET"

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: true
+      restore-missing-trace:
+        description: Restore the registered missing trace artifact for the selected run
+        required: false
+        type: boolean
+        default: false
 
 permissions: {}
 
@@ -51,10 +56,11 @@ jobs:
         env:
           RUN_ID: ${{ inputs.run-id || 'all' }}
           ATOM_ONLY: ${{ inputs.atom-kv-capacity-only }}
+          RESTORE_TRACE: ${{ inputs.restore-missing-trace }}
         run: |
           if [[ "$RUN_ID" == all ]]; then
-            if [[ "$ATOM_ONLY" == true ]]; then
-              echo '::error::ATOM capacity backfill requires a specific run'
+            if [[ "$ATOM_ONLY" == true || "$RESTORE_TRACE" == true ]]; then
+              echo '::error::Artifact recovery and ATOM capacity require a specific run'
               exit 1
             fi
             echo 'shards=[0,1,2,3,4,5,6,7]' >> "$GITHUB_OUTPUT"
@@ -131,6 +137,12 @@ jobs:
           fi
           echo "::add-mask::$database_url"
           echo "DATABASE_WRITE_URL=$database_url" >> "$GITHUB_ENV"
+      - name: Restore a missing trace from its registered original artifact
+        if: inputs.restore-missing-trace == true
+        env:
+          GITHUB_TOKEN: ${{ secrets.INFX_MAIN_PAT }}
+          RUN_ID: ${{ inputs.run-id }}
+        run: bun packages/db/src/backfill-missing-agentic-trace.ts --run-id "$RUN_ID" --yes
       - name: Snapshot, recompute, and verify derived data
         if: inputs.atom-kv-capacity-only != true
         env:

--- a/.github/workflows/recompute-agentic-metrics.yml
+++ b/.github/workflows/recompute-agentic-metrics.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           CYPRESS_INSTALL_BINARY: '0'
       - name: Select database
+        timeout-minutes: 8
         env:
           PRODUCTION_DATABASE_URL: ${{ secrets.DATABASE_WRITE_URL }}
           NEON_API_KEY: ${{ secrets.NEON_API_KEY }}
@@ -114,7 +115,8 @@ jobs:
               exit 1
             fi
             api="https://console.neon.tech/api/v2/projects/$NEON_PROJECT_ID"
-            branches=$(curl -fsS -H "Authorization: Bearer $NEON_API_KEY" "$api/branches?limit=100")
+            curl_args=(--fail --silent --show-error --connect-timeout 10 --max-time 30 --retry 3 --retry-all-errors -H "Authorization: Bearer $NEON_API_KEY")
+            branches=$(curl "${curl_args[@]}" "$api/branches?limit=100")
             branch=$(jq -c --arg name "$NEON_BRANCH_NAME" '.branches[] | select(.name == $name)' <<<"$branches")
             if [ -z "$branch" ]; then
               echo "::error::Neon child branch not found: $NEON_BRANCH_NAME"
@@ -122,11 +124,11 @@ jobs:
             fi
             jq -e '.parent_id != null and .default != true and .protected != true' <<<"$branch" >/dev/null
             branch_id=$(jq -r '.id' <<<"$branch")
-            database_url=$(npx --yes neonctl connection-string "$branch_id" \
-              --api-key "$NEON_API_KEY" --project-id "$NEON_PROJECT_ID" \
-              --database-name neondb --role-name neondb_owner)
+            echo "Resolving connection for child branch $branch_id"
+            database_url=$(curl "${curl_args[@]}" \
+              "$api/connection_uri?branch_id=$branch_id&database_name=neondb&role_name=neondb_owner&pooled=false" | jq -er '.uri')
             echo "::add-mask::$database_url"
-            endpoints=$(curl -fsS -H "Authorization: Bearer $NEON_API_KEY" "$api/endpoints")
+            endpoints=$(curl "${curl_args[@]}" "$api/endpoints")
             database_host=$(CHECK_DATABASE_URL="$database_url" node -e 'console.log(new URL(process.env.CHECK_DATABASE_URL).hostname.replace("-pooler.", "."))')
             jq -e --arg branch "$branch_id" --arg host "$database_host" \
               '.endpoints[] | select(.branch_id == $branch and .host == $host)' <<<"$endpoints" >/dev/null

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -229,6 +229,8 @@ The Recompute Agentic Metrics workflow accepts an optional `neon-branch` to
 rebuild a stored run in an existing child database. It verifies the child and
 connection endpoint before writing; production recomputation still requires
 `master`. Preview environments use branch-scoped database and cache settings.
+After a child-database repair, refresh its isolated `CACHE_NAMESPACE` and
+`BLOB_CACHE_PREFIX` and redeploy that preview to retire cached payloads.
 
 Use `run-id: all` for a stale-only repair across historical and current AgentX
 points. Eight independent shards recompute charts, aggregates, and request

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -230,6 +230,22 @@ rebuild a stored run in an existing child database. It verifies the child and
 connection endpoint before writing; production recomputation still requires
 `master`. Preview environments use branch-scoped database and cache settings.
 
+Use `run-id: all` for a stale-only repair across historical and current AgentX
+points. Eight independent shards recompute charts, aggregates, and request
+timelines using the checked-out code's versions. Each shard records database-side
+fingerprints before writing and verifies that benchmark rows, raw artifacts, and
+already-current timelines are unchanged afterward. Previously populated metrics
+cannot be replaced with empty output; parsing failures fail the job and preserve
+the old payload. Integrity manifests are retained as workflow artifacts.
+
+Relevant backfill/parser changes merged to `master` run this stale-only repair
+against production and invalidate the cache only after every shard passes.
+Test on a snapshot branch first, then staging using the preview's parser version.
+Production must use its own deployed parser version, not an unmerged preview's.
+Runs without original metrics or trace artifacts are reported separately: a
+version upgrade cannot reconstruct data that was never captured. To deliberately
+rebuild an already-current run, set `stale-only: false` with its numeric run ID.
+
 ### Summed Series and the Canonical Grid
 
 The same "components aren't scraped in lockstep" problem hits the **summed** series — prefill/decode/prefix-hit rates, queue depth, host KV usage, and the prompt-token source breakdown — but it cannot be solved the same way. A mean is scale-free, so `averageAcrossEngines` can evaluate on the union of scrape instants; a sum is not. `cumulativeUniqueInputTokens` turns these rates into token totals with `sum += value` and `rollingAverage` is a sample-count mean, so both only stay correct at **one point per scrape bucket**.

--- a/packages/db/src/backfill-aggregate-stats.ts
+++ b/packages/db/src/backfill-aggregate-stats.ts
@@ -35,6 +35,7 @@ import {
   jsonbParam,
   parseLimitForceFlags,
   parseRunIdFlag,
+  retainPopulatedFields,
   runBackfillMain,
   runCandidateIdBackfill,
 } from './lib/backfill-runner.js';
@@ -81,7 +82,7 @@ async function main(): Promise<void> {
             and exists (
               select 1
               from benchmark_results br
-              join latest_workflow_runs wr on wr.id = br.workflow_run_id
+              join workflow_runs wr on wr.id = br.workflow_run_id
               where br.trace_replay_id = agentic_trace_replay.id
                 and wr.github_run_id = ${githubRunId}
             )
@@ -94,7 +95,7 @@ async function main(): Promise<void> {
         ? await sql<{ id: number }[]>`
             select id
             from agentic_trace_replay
-            where true ${runFilter}
+            where mod(id, ${flags.shardCount}) = ${flags.shardIndex} ${runFilter}
             order by id
             ${flags.limit ? sql`limit ${flags.limit}` : sql``}
           `
@@ -102,7 +103,8 @@ async function main(): Promise<void> {
             select id
             from agentic_trace_replay
             where (aggregate_stats is null
-               or coalesce((aggregate_stats->>'version')::int, -1) <> ${STATS_VERSION})
+               or coalesce((aggregate_stats->>'version')::int, -1) < ${STATS_VERSION})
+              and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
               ${runFilter}
             order by id
             ${flags.limit ? sql`limit ${flags.limit}` : sql``}
@@ -168,10 +170,18 @@ async function main(): Promise<void> {
         stats = mergeProfileStatsUpgrade(serverStats, profileStats);
       }
 
+      retainPopulatedFields(row.aggregate_stats, stats, [
+        'isl',
+        'osl',
+        'kvCacheUtil',
+        'prefixCacheHitRate',
+        'e2elPerOsl',
+      ]);
       await sql`
         update agentic_trace_replay
         set aggregate_stats = ${jsonbParam(sql, stats)}
         where id = ${id}
+          and coalesce((aggregate_stats->>'version')::int, -1) <= ${STATS_VERSION}
       `;
       return 'ok';
     },

--- a/packages/db/src/backfill-chart-series.ts
+++ b/packages/db/src/backfill-chart-series.ts
@@ -26,12 +26,18 @@
  */
 
 import { hasNoSslFlag } from './cli-utils.js';
-import { CHART_SERIES_VERSION, computeChartSeries } from './etl/compute-chart-series.js';
+import {
+  CHART_SERIES_VERSION,
+  computeChartSeries,
+  type ChartSeries,
+} from './etl/compute-chart-series.js';
 import { createAdminSql } from './etl/db-utils.js';
 import {
   jsonbParam,
   parseLimitForceFlags,
   parseRunIdFlag,
+  requireBackfillPayload,
+  retainPopulatedFields,
   runBackfillMain,
   runCandidateIdBackfill,
 } from './lib/backfill-runner.js';
@@ -65,7 +71,7 @@ async function main(): Promise<void> {
             and exists (
               select 1
               from benchmark_results br
-              join latest_workflow_runs wr on wr.id = br.workflow_run_id
+              join workflow_runs wr on wr.id = br.workflow_run_id
               where br.trace_replay_id = agentic_trace_replay.id
                 and wr.github_run_id = ${githubRunId}
             )
@@ -90,7 +96,7 @@ async function main(): Promise<void> {
               and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
               and (
                 chart_series is null
-                or coalesce((chart_series->>'version')::int, -1) <> ${CHART_SERIES_VERSION}
+                or coalesce((chart_series->>'version')::int, -1) < ${CHART_SERIES_VERSION}
               )
               ${runFilter}
             -- Restore the newest, most actively viewed runs first. The backfill is
@@ -106,9 +112,10 @@ async function main(): Promise<void> {
           server_metrics_json_gz: Buffer | null;
           framework: string | null;
           disagg: boolean | null;
+          chart_series: ChartSeries | null;
         }[]
       >`
-        select atr.server_metrics_json_gz, source.framework, source.disagg
+        select atr.server_metrics_json_gz, atr.chart_series, source.framework, source.disagg
         from agentic_trace_replay atr
         left join lateral (
           select c.framework, c.disagg
@@ -125,15 +132,28 @@ async function main(): Promise<void> {
         return 'skipped';
       }
 
-      const series = await computeChartSeries(row.server_metrics_json_gz, {
-        framework: row.framework,
-        disagg: row.disagg ?? false,
-      });
+      const series = requireBackfillPayload(
+        await computeChartSeries(row.server_metrics_json_gz, {
+          framework: row.framework,
+          disagg: row.disagg ?? false,
+        }),
+        'chart_series',
+      );
+      retainPopulatedFields(row.chart_series, series, [
+        'kvCacheUsage',
+        'queueDepth',
+        'prefixCacheHitRate',
+        'prefillTps',
+        'decodeTps',
+        'prefixCacheHitsTps',
+        'hostKvCacheUsage',
+      ]);
 
       await sql`
         update agentic_trace_replay
-        set chart_series = ${series === null ? null : jsonbParam(sql, series)}
+        set chart_series = ${jsonbParam(sql, series)}
         where id = ${id}
+          and coalesce((chart_series->>'version')::int, -1) <= ${CHART_SERIES_VERSION}
       `;
       return 'ok';
     },

--- a/packages/db/src/backfill-missing-agentic-trace.ts
+++ b/packages/db/src/backfill-missing-agentic-trace.ts
@@ -1,0 +1,103 @@
+import { createHash } from 'node:crypto';
+import AdmZip from 'adm-zip';
+import { createAdminSql } from './etl/db-utils.js';
+import { prepareTraceReplay, persistPreparedTraceReplay } from './etl/trace-replay-ingest.js';
+import { confirmProceed, parseRunIdFlag, runBackfillMain } from './lib/backfill-runner.js';
+
+// The later evaluation artifact reused this name but omitted the trace files.
+// Recover the original benchmark artifact, not the smaller evaluation upload.
+const recovery = {
+  runId: 31581562219,
+  artifactId: 9140323247,
+  artifactName:
+    'agentic_qwen3.5_tp4_conc40_kvnone_spec-mtp_fp4_sglang_tp4-pp1-dcp1-pcp1-ep1-dpafalse_disagg-false_spec-mtp_conc40_mi355x-amds_00',
+};
+const sql = createAdminSql({ max: 1, onnotice: () => {} });
+const hash = (data: Buffer) => createHash('md5').update(data).digest('hex');
+
+async function main(): Promise<void> {
+  if (parseRunIdFlag() !== recovery.runId)
+    throw new Error('No registered trace recovery for this run');
+  const rows = await sql<{ id: number; trace_replay_id: number | null; fingerprint: string }[]>`
+    select br.id, br.trace_replay_id,
+      md5((to_jsonb(br)-'trace_replay_id')::text) as fingerprint
+    from benchmark_results br
+    join workflow_runs w on w.id=br.workflow_run_id
+    join configs c on c.id=br.config_id
+    where w.github_run_id=${recovery.runId} and w.run_attempt=1
+      and c.hardware='mi355x' and c.framework='sglang' and c.model='qwen3.5'
+      and c.precision='fp4' and c.spec_method='mtp' and not c.disagg
+      and c.prefill_tp=4 and c.decode_tp=4 and c.prefill_ep=1 and c.decode_ep=1
+      and not c.prefill_dp_attention and not c.decode_dp_attention
+      and br.benchmark_type='agentic_traces' and br.conc=40
+      and br.isl is null and br.osl is null and br.offload_mode='off'
+      and br.recipe_fingerprint is null
+  `;
+  if (rows.length !== 1) throw new Error(`Expected one recovery target, found ${rows.length}`);
+  const row = rows[0]!;
+  if (row.trace_replay_id !== null) {
+    console.log(`Point ${row.id} already has a trace; no changes`);
+    return;
+  }
+  if (
+    !(await confirmProceed(
+      `Restore missing trace for point ${row.id} from artifact ${recovery.artifactId}`,
+    ))
+  )
+    return;
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN is required');
+  const api = `https://api.github.com/repos/SemiAnalysisAI/InferenceX/actions/artifacts/${recovery.artifactId}`;
+  const headers = { Authorization: `Bearer ${token}`, Accept: 'application/vnd.github+json' };
+  const response = await fetch(api, { headers });
+  if (!response.ok) throw new Error(`Artifact lookup failed: ${response.status}`);
+  const artifact = (await response.json()) as {
+    name: string;
+    expired: boolean;
+    workflow_run: { id: number };
+  };
+  if (
+    artifact.name !== recovery.artifactName ||
+    artifact.expired ||
+    artifact.workflow_run.id !== recovery.runId
+  ) {
+    throw new Error('Artifact does not match the registered benchmark source');
+  }
+  const download = await fetch(`${api}/zip`, { headers });
+  if (!download.ok) throw new Error(`Artifact download failed: ${download.status}`);
+  const zip = new AdmZip(Buffer.from(await download.arrayBuffer()));
+  const profile = zip.readFile('aiperf_artifacts/profile_export.jsonl');
+  const metrics = zip.readFile('aiperf_artifacts/server_metrics_export.json');
+  const csv = zip.readFile('aiperf_artifacts/server_metrics_export.csv');
+  if (!profile || !metrics || !csv) throw new Error('Original trace files are missing');
+  const prepared = await prepareTraceReplay(profile, csv, metrics, {
+    framework: 'sglang',
+    disagg: false,
+  });
+  if (!prepared.timelineRequests || !prepared.chartWindows)
+    throw new Error('Recovered trace is empty');
+  // Attach only the missing sidecar; published benchmark measurements remain immutable.
+  prepared.cacheHitRates = null;
+  prepared.fullResponseMetrics = {};
+  prepared.atomKvCacheBlocks = null;
+  await persistPreparedTraceReplay(sql, [row.id], prepared);
+  const [after] = await sql<{ fingerprint: string; profile_hash: string; server_hash: string }[]>`
+    select md5((to_jsonb(br)-'trace_replay_id')::text) as fingerprint,
+      md5(a.profile_export_jsonl_gz) as profile_hash, md5(a.server_metrics_json_gz) as server_hash
+    from benchmark_results br join agentic_trace_replay a on a.id=br.trace_replay_id
+    where br.id=${row.id}
+  `;
+  if (
+    !after ||
+    after.fingerprint !== row.fingerprint ||
+    after.profile_hash !== hash(prepared.profileGz!) ||
+    after.server_hash !== hash(prepared.serverMetricsJsonGz!)
+  ) {
+    throw new Error('Recovered trace failed source/benchmark integrity verification');
+  }
+  console.log(
+    `PASS: restored point ${row.id} from artifact ${recovery.artifactId}; benchmark fields unchanged`,
+  );
+}
+
+runBackfillMain('backfill-missing-agentic-trace', sql, main);

--- a/packages/db/src/backfill-request-timeline.ts
+++ b/packages/db/src/backfill-request-timeline.ts
@@ -26,11 +26,14 @@ import {
 } from './etl/trace-replay-ingest.js';
 import {
   parseLimitForceFlags,
+  parseRunIdFlag,
+  requireBackfillPayload,
   runBackfillMain,
   runCandidateIdBackfill,
 } from './lib/backfill-runner.js';
 
 const flags = parseLimitForceFlags();
+const githubRunId = parseRunIdFlag();
 
 const PROFILE_DOWNLOAD_CHUNK_BYTES = TRACE_REPLAY_UPLOAD_CHUNK_BYTES;
 
@@ -69,10 +72,7 @@ async function readProfileBlob(id: number): Promise<Buffer | null> {
 
 /** Upload the JSONB through the same bounded protocol used by trace ingest. */
 async function writeRequestTimeline(id: number, timeline: RequestTimeline | null): Promise<void> {
-  if (timeline === null) {
-    await sql`update agentic_trace_replay set request_timeline = null where id = ${id}`;
-    return;
-  }
+  requireBackfillPayload(timeline, 'request_timeline');
 
   const payload = Buffer.from(JSON.stringify(timeline));
   await sql.begin(async (tx) => {
@@ -93,6 +93,7 @@ async function writeRequestTimeline(id: number, timeline: RequestTimeline | null
         where field = 'request_timeline'
       )
       where id = ${id}
+        and coalesce((request_timeline->>'version')::int, -1) <= ${REQUEST_TIMELINE_VERSION}
     `;
   });
 }
@@ -105,6 +106,14 @@ async function main(): Promise<void> {
 
   await runCandidateIdBackfill(
     async () => {
+      const runFilter = githubRunId
+        ? sql`and exists (
+            select 1 from benchmark_results br
+            join workflow_runs wr on wr.id = br.workflow_run_id
+            where br.trace_replay_id = agentic_trace_replay.id
+              and wr.github_run_id = ${githubRunId}
+          )`
+        : sql``;
       // Only rows with a profile_export blob can produce a timeline. Rows
       // without the blob keep `request_timeline` null and the API serves them
       // as "no timeline data".
@@ -113,6 +122,8 @@ async function main(): Promise<void> {
             select id
             from agentic_trace_replay
             where profile_export_jsonl_gz is not null
+              and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
+              ${runFilter}
             order by id
             ${flags.limit ? sql`limit ${flags.limit}` : sql``}
           `
@@ -120,9 +131,11 @@ async function main(): Promise<void> {
             select id
             from agentic_trace_replay
             where profile_export_jsonl_gz is not null
+              and mod(id, ${flags.shardCount}) = ${flags.shardIndex}
+              ${runFilter}
               and (
                 request_timeline is null
-                or coalesce((request_timeline->>'version')::int, -1) <> ${REQUEST_TIMELINE_VERSION}
+                or coalesce((request_timeline->>'version')::int, -1) < ${REQUEST_TIMELINE_VERSION}
               )
             order by id
             ${flags.limit ? sql`limit ${flags.limit}` : sql``}

--- a/packages/db/src/lib/agentic-backfill-integrity.test.ts
+++ b/packages/db/src/lib/agentic-backfill-integrity.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { verifyBackfillState, type BackfillState } from './agentic-backfill-integrity.js';
+
+const before: BackfillState = {
+  id: '439892',
+  trace_id: '1162',
+  benchmark_hash: 'benchmark',
+  profile_hash: 'requests',
+  server_hash: 'metrics',
+  timeline_hash: 'timeline',
+  chart_version: 15,
+  stats_version: 8,
+  timeline_version: 6,
+  chart_counts: { kvCacheUsage: 200 },
+  stats_present: { isl: true },
+};
+const versions = { chart: 20, stats: 10, timeline: 6 };
+const after = { ...before, chart_version: 20, stats_version: 10 };
+
+describe('verifyBackfillState', () => {
+  it('accepts a derived-data upgrade without changing source data', () => {
+    expect(() => verifyBackfillState(before, after, versions)).not.toThrow();
+  });
+  it.each(['benchmark_hash', 'profile_hash', 'server_hash', 'trace_id', 'timeline_hash'] as const)(
+    'rejects a change to %s',
+    (key) => {
+      expect(() => verifyBackfillState(before, { ...after, [key]: 'changed' }, versions)).toThrow();
+    },
+  );
+  it('rejects a nominally current but empty replacement chart', () => {
+    expect(() => verifyBackfillState(before, { ...after, chart_counts: {} }, versions)).toThrow(
+      'became empty',
+    );
+  });
+  it('rejects lost aggregate data and incompatible versions', () => {
+    expect(() => verifyBackfillState(before, { ...after, stats_present: {} }, versions)).toThrow(
+      'became null',
+    );
+    expect(() => verifyBackfillState(before, { ...after, chart_version: 21 }, versions)).toThrow(
+      'chart version',
+    );
+  });
+  it('does not invent chart requirements for runs without captured server metrics', () => {
+    const missing = { ...before, server_hash: null, chart_version: null, chart_counts: {} };
+    expect(() =>
+      verifyBackfillState(missing, { ...missing, stats_version: 10 }, versions),
+    ).not.toThrow();
+  });
+});

--- a/packages/db/src/lib/agentic-backfill-integrity.ts
+++ b/packages/db/src/lib/agentic-backfill-integrity.ts
@@ -1,0 +1,49 @@
+export interface BackfillState {
+  id: string;
+  trace_id: string | null;
+  benchmark_hash: string;
+  profile_hash: string | null;
+  server_hash: string | null;
+  timeline_hash: string | null;
+  chart_version: number | null;
+  stats_version: number | null;
+  timeline_version: number | null;
+  chart_counts: Record<string, number>;
+  stats_present: Record<string, boolean>;
+}
+
+export function verifyBackfillState(
+  before: BackfillState,
+  after: BackfillState,
+  versions: { chart: number; stats: number; timeline: number },
+): void {
+  for (const key of ['id', 'trace_id', 'benchmark_hash', 'profile_hash', 'server_hash'] as const) {
+    if (before[key] !== after[key]) throw new Error(`point ${before.id}: ${key} changed`);
+  }
+  if (!after.trace_id) return;
+  if (after.server_hash && after.chart_version !== versions.chart) {
+    throw new Error(`point ${before.id}: chart version ${after.chart_version}`);
+  }
+  if (after.stats_version !== versions.stats) {
+    throw new Error(`point ${before.id}: statistics version ${after.stats_version}`);
+  }
+  if (after.profile_hash && after.timeline_version !== versions.timeline) {
+    throw new Error(`point ${before.id}: timeline version ${after.timeline_version}`);
+  }
+  if (
+    before.timeline_version === versions.timeline &&
+    before.timeline_hash !== after.timeline_hash
+  ) {
+    throw new Error(`point ${before.id}: already-current request timeline changed`);
+  }
+  for (const [key, count] of Object.entries(before.chart_counts)) {
+    if (count > 0 && !(after.chart_counts[key]! > 0)) {
+      throw new Error(`point ${before.id}: populated chart ${key} became empty`);
+    }
+  }
+  for (const [key, present] of Object.entries(before.stats_present)) {
+    if (present && !after.stats_present[key]) {
+      throw new Error(`point ${before.id}: populated statistic ${key} became null`);
+    }
+  }
+}

--- a/packages/db/src/lib/backfill-runner.test.ts
+++ b/packages/db/src/lib/backfill-runner.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { computeChartSeries } from '../etl/compute-chart-series.js';
 
 import {
   parseLimitForceFlags,
   parseRunIdFlag,
   runCandidateIdBackfill,
   runPerIdBackfill,
+  requireBackfillPayload,
+  retainPopulatedFields,
 } from './backfill-runner.js';
 
 describe('parseRunIdFlag', () => {
@@ -26,6 +30,54 @@ describe('parseRunIdFlag', () => {
       expect(() => parseRunIdFlag(argv)).toThrow('--run-id requires a positive integer');
     },
   );
+});
+
+describe('failed chart backfills', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+  });
+
+  it.each([Buffer.from('not gzip'), gzipSync('not json')])(
+    'retains existing data and fails the job when the real parser rejects a blob',
+    async (blob) => {
+      vi.spyOn(console, 'log').mockImplementation(() => {});
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const write = vi.fn();
+      await runPerIdBackfill([1162], async () => {
+        const series = requireBackfillPayload(await computeChartSeries(blob), 'chart_series');
+        write(series);
+        return 'ok';
+      });
+      expect(write).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
+      expect(vi.mocked(console.error).mock.calls[0]?.[0]).toContain(
+        'existing data was not changed',
+      );
+    },
+  );
+});
+
+describe('retaining previously populated metrics', () => {
+  it('rejects a partial parse before replacing populated data', () => {
+    expect(() =>
+      retainPopulatedFields({ kv: [0.1], stats: { p50: 10 } }, { kv: [], stats: null }, [
+        'kv',
+        'stats',
+      ]),
+    ).toThrow('kv became empty');
+    expect(() => retainPopulatedFields({ stats: { p50: 10 } }, { stats: null }, ['stats'])).toThrow(
+      'stats became empty',
+    );
+  });
+  it('allows new metrics and changed samples without inventing missing metrics', () => {
+    expect(() =>
+      retainPopulatedFields({ kv: [0.1], stats: null }, { kv: [0.2, 0.4], stats: null }, [
+        'kv',
+        'stats',
+      ]),
+    ).not.toThrow();
+  });
 });
 
 describe('parseLimitForceFlags', () => {

--- a/packages/db/src/lib/backfill-runner.ts
+++ b/packages/db/src/lib/backfill-runner.ts
@@ -16,6 +16,31 @@ export interface LimitForceFlags {
   shardIndex: number;
 }
 
+export function requireBackfillPayload<T>(payload: T | null, field: string): T {
+  if (payload === null) {
+    throw new Error(`Could not compute ${field}; existing data was not changed`);
+  }
+  return payload;
+}
+
+function populated(value: unknown): boolean {
+  return Array.isArray(value) ? value.length > 0 : value !== null && value !== undefined;
+}
+
+export function retainPopulatedFields<T extends object>(
+  previous: T | null,
+  next: T,
+  fields: readonly (keyof T)[],
+): void {
+  for (const field of fields) {
+    const before = previous?.[field];
+    const after = next[field];
+    if (populated(before) && !populated(after)) {
+      throw new Error(`${String(field)} became empty; existing data was not changed`);
+    }
+  }
+}
+
 /** Restrict a backfill to one GitHub run; malformed selectors must never scan all rows. */
 export function parseRunIdFlag(argv: readonly string[] = process.argv): number | undefined {
   const index = argv.indexOf('--run-id');

--- a/packages/db/src/verify-agentic-backfill.ts
+++ b/packages/db/src/verify-agentic-backfill.ts
@@ -1,0 +1,109 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { createAdminSql } from './etl/db-utils.js';
+import { CHART_SERIES_VERSION } from './etl/compute-chart-series.js';
+import { STATS_VERSION } from './etl/compute-aggregate-stats.js';
+import { REQUEST_TIMELINE_VERSION } from './etl/compute-request-timeline.js';
+import { parseLimitForceFlags, parseRunIdFlag, runBackfillMain } from './lib/backfill-runner.js';
+import { verifyBackfillState, type BackfillState } from './lib/agentic-backfill-integrity.js';
+
+const flags = parseLimitForceFlags();
+const runId = parseRunIdFlag();
+const snapshotIndex = process.argv.indexOf('--snapshot');
+const verifyIndex = process.argv.indexOf('--verify');
+const snapshotMode = process.argv.includes('--snapshot');
+const verifyMode = process.argv.includes('--verify');
+if (snapshotMode === verifyMode) throw new Error('Specify --snapshot FILE or --verify FILE');
+const file = process.argv[(snapshotIndex === -1 ? verifyIndex : snapshotIndex) + 1];
+if (!file || file.startsWith('--')) throw new Error('Missing manifest filename');
+const sql = createAdminSql({ max: 1, onnotice: () => {} });
+
+async function states(ids: string[]): Promise<BackfillState[]> {
+  const rows: BackfillState[] = [];
+  // Hash blobs inside Postgres: raw artifacts never leave the database during verification.
+  for (const id of ids) {
+    const result = await sql<BackfillState[]>`
+      select br.id::text, a.id::text as trace_id,
+        md5(row_to_json(br)::text) as benchmark_hash,
+        md5(a.profile_export_jsonl_gz) as profile_hash,
+        md5(a.server_metrics_json_gz) as server_hash,
+        md5(a.request_timeline::text) as timeline_hash,
+        (a.chart_series->>'version')::int as chart_version,
+        (a.aggregate_stats->>'version')::int as stats_version,
+        (a.request_timeline->>'version')::int as timeline_version,
+        jsonb_build_object(
+          'kvCacheUsage', coalesce(jsonb_array_length(a.chart_series->'kvCacheUsage'),0),
+          'queueDepth', coalesce(jsonb_array_length(a.chart_series->'queueDepth'),0),
+          'prefixCacheHitRate', coalesce(jsonb_array_length(a.chart_series->'prefixCacheHitRate'),0),
+          'prefillTps', coalesce(jsonb_array_length(a.chart_series->'prefillTps'),0),
+          'decodeTps', coalesce(jsonb_array_length(a.chart_series->'decodeTps'),0)
+        ) as chart_counts,
+        jsonb_build_object(
+          'isl', coalesce(a.aggregate_stats->'isl' <> 'null'::jsonb,false),
+          'osl', coalesce(a.aggregate_stats->'osl' <> 'null'::jsonb,false),
+          'kvCacheUtil', coalesce(a.aggregate_stats->'kvCacheUtil' <> 'null'::jsonb,false),
+          'prefixCacheHitRate', coalesce(a.aggregate_stats->'prefixCacheHitRate' <> 'null'::jsonb,false)
+        ) as stats_present
+      from benchmark_results br left join agentic_trace_replay a on a.id=br.trace_replay_id
+      where br.id=${id}
+    `;
+    if (!result[0]) throw new Error(`point ${id} disappeared`);
+    rows.push(result[0]);
+    if (rows.length % 10 === 0)
+      console.log(`Verified source fingerprints for ${rows.length}/${ids.length} points`);
+  }
+  return rows;
+}
+
+async function main(): Promise<void> {
+  const database = new URL(process.env.DATABASE_WRITE_URL!).hostname;
+  if (snapshotIndex !== -1) {
+    const runFilter = runId ? sql`and w.github_run_id=${runId}` : sql``;
+    const ids = await sql<{ id: string }[]>`
+      select br.id::text from benchmark_results br
+      join workflow_runs w on w.id=br.workflow_run_id
+      where br.benchmark_type='agentic_traces'
+        and mod(coalesce(br.trace_replay_id,br.id),${flags.shardCount})=${flags.shardIndex}
+        ${runFilter}
+      order by br.id
+    `;
+    if (ids.length === 0) throw new Error('No AgentX points matched the audit scope');
+    const rows = await states(ids.map((row) => row.id));
+    await writeFile(file!, JSON.stringify({ database, rows }));
+    console.log(`Saved immutable-data fingerprints for ${rows.length} points`);
+    return;
+  }
+  const manifest = JSON.parse(await readFile(file!, 'utf8')) as {
+    database: string;
+    rows: BackfillState[];
+  };
+  if (database !== manifest.database) throw new Error('Manifest belongs to a different database');
+  const after = await states(manifest.rows.map((row) => row.id));
+  const versions = {
+    chart: CHART_SERIES_VERSION,
+    stats: STATS_VERSION,
+    timeline: REQUEST_TIMELINE_VERSION,
+  };
+  const failures: string[] = [];
+  for (const [index, row] of after.entries()) {
+    try {
+      verifyBackfillState(manifest.rows[index]!, row, versions);
+    } catch (error) {
+      failures.push(String(error));
+    }
+  }
+  console.log(
+    JSON.stringify({
+      points: after.length,
+      versions,
+      missingTrace: after.filter((r) => !r.trace_id).map((r) => r.id),
+      noRawMetrics: after.filter((r) => r.trace_id && !r.server_hash).map((r) => r.id),
+      failures,
+    }),
+  );
+  if (failures.length > 0) throw new Error(`${failures.length} integrity or version checks failed`);
+  console.log(
+    'PASS: benchmark records, raw artifacts and current timelines unchanged; derived versions and metric coverage verified',
+  );
+}
+
+runBackfillMain('verify-agentic-backfill', sql, main);


### PR DESCRIPTION
Repair outdated AgentX charts, aggregates, and timelines without changing benchmark results or raw artifacts. Failed or empty replacements are rejected, and newer payload versions cannot be downgraded.

Validation:
- [Full staging repair](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/33826699268): 1,122 charts and 1,167 aggregates rebuilt; all 1,188 points passed integrity checks.
- [Recovery and repeat verification](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/33830865280): restored the missing Qwen trace from its original artifact; repeated runs leave current data unchanged.
- Staging audit: no missing traces, stale versions, lost rows, or changed benchmark values. The isolated preview cache was refreshed and the reported pages verified.
- Unit tests, typecheck, and browser tests cover the safety guards.

Merge triggers a stale-only production repair and cache invalidation. Production keeps its deployed parser versions; this does not merge the separate llm-d preview parser changes.