### PR TITLE
fix(submissions): keep prev run selected on agentic compare vs prev links

### DIFF
--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -58,7 +58,7 @@ import { useUrlState } from '@/hooks/useUrlState';
 import { useOpenRouterPricing } from '@/hooks/api/use-openrouter-pricing';
 import { DEFAULT_Y_AXIS_METRIC } from '@/lib/url-state';
 import { computeToggle } from '@/hooks/useTogglableSet';
-import { buildAvailabilityHwKey } from '@/lib/chart-utils';
+import { buildAvailabilityHwKey, reconcileGpuSelection } from '@/lib/chart-utils';
 import { getHardwareConfig, getModelSortIndex, isKnownGpu } from '@/lib/constants';
 import {
   getOpenRouterModelId,
@@ -1342,13 +1342,20 @@ export function InferenceProvider({
     resolveHwSelection,
   ]);
 
-  // Remove selected GPUs only after successful availability has settled. An
+  // Reconcile selected GPUs only after successful availability has settled. An
   // empty successful scope is different from the transient empty loading state.
+  // Spec-suffixed keys (`b200_vllm_mtp`) that only exist spec-less under the
+  // agentic scope (`b200_vllm`) are remapped rather than dropped, so links built
+  // without scenario knowledge (e.g. /submissions "compare vs prev") keep their
+  // chip config and comparison date range.
   useEffect(() => {
     if (!availabilitySettled || !sequenceResolved || selectedGPUs.length === 0) return;
     const validKeys = new Set(availableGPUs.map((gpu) => gpu.value));
-    const valid = selectedGPUs.filter((gpu) => validKeys.has(gpu));
-    if (valid.length !== selectedGPUs.length) setSelectedGpuState(valid);
+    const reconciled = reconcileGpuSelection(selectedGPUs, validKeys);
+    const unchanged =
+      reconciled.length === selectedGPUs.length &&
+      reconciled.every((gpu, index) => gpu === selectedGPUs[index]);
+    if (!unchanged) setSelectedGpuState(reconciled);
   }, [availabilitySettled, sequenceResolved, availableGPUs, selectedGPUs]);
 
   useEffect(() => {

--- a/packages/app/src/components/submissions/submissions-utils.ts
+++ b/packages/app/src/components/submissions/submissions-utils.ts
@@ -85,6 +85,10 @@ export function buildInferenceCompareUrl(
   // and misses those rows.
   const displayModel = DB_MODEL_TO_DISPLAY[currentRow.model];
   if (!displayModel) return null;
+  // Summary rows carry no benchmark_type, so this key keeps the spec-method
+  // suffix (e.g. `b200_vllm_mtp`). Agentic scopes key hardware without it;
+  // InferenceContext reconciles the selection (reconcileGpuSelection) so the
+  // chip config is remapped instead of dropped when the chart lands on AgentX.
   const hwKey = buildAvailabilityHwKey(
     currentRow.hardware,
     currentRow.framework,

--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -7,6 +7,8 @@ import type { AggDataEntry, ChartDefinition, InferenceData } from '@/components/
 import { chartDefinitions } from '@/components/inference/metric-registry';
 import {
   buildAvailabilityHwKey,
+  reconcileGpuSelection,
+  stripSpecMethodFromHwKey,
   generateHighContrastColors,
   getNestedYValue,
   getHardwareKey,
@@ -217,6 +219,55 @@ describe('buildAvailabilityHwKey', () => {
     expect(buildAvailabilityHwKey('mi355x', 'sglang-disagg', 'mtp', true)).toBe(
       'mi355x_mori-sglang_mtp',
     );
+  });
+});
+
+describe('stripSpecMethodFromHwKey', () => {
+  it('drops the trailing spec-method segment', () => {
+    expect(stripSpecMethodFromHwKey('b200_vllm_mtp')).toBe('b200_vllm');
+    expect(stripSpecMethodFromHwKey('h200_trt_eagle')).toBe('h200_trt');
+    expect(stripSpecMethodFromHwKey('mi355x_mori-sglang_mtp')).toBe('mi355x_mori-sglang');
+  });
+
+  it('never strips the framework segment', () => {
+    expect(stripSpecMethodFromHwKey('b200_vllm')).toBeNull();
+    expect(stripSpecMethodFromHwKey('b200')).toBeNull();
+  });
+});
+
+describe('reconcileGpuSelection', () => {
+  it('keeps keys that match the scope exactly', () => {
+    const valid = new Set(['b200_vllm_mtp', 'b200_vllm', 'h200_sglang']);
+    expect(reconcileGpuSelection(['b200_vllm_mtp', 'h200_sglang'], valid)).toEqual([
+      'b200_vllm_mtp',
+      'h200_sglang',
+    ]);
+  });
+
+  it('remaps a spec-suffixed key to its spec-less agentic key', () => {
+    // /submissions "compare vs prev" builds `b200_vllm_mtp` from a summary row
+    // (no benchmark_type); the agentic scope only offers `b200_vllm`.
+    const agenticScope = new Set(['b200_vllm', 'b300_vllm', 'gb300_dynamo-trt']);
+    expect(reconcileGpuSelection(['b200_vllm_mtp'], agenticScope)).toEqual(['b200_vllm']);
+  });
+
+  it('prefers the exact key when both spec and spec-less variants exist', () => {
+    const fixedScope = new Set(['b200_vllm', 'b200_vllm_mtp']);
+    expect(reconcileGpuSelection(['b200_vllm_mtp'], fixedScope)).toEqual(['b200_vllm_mtp']);
+    expect(reconcileGpuSelection(['b200_vllm'], fixedScope)).toEqual(['b200_vllm']);
+  });
+
+  it('drops keys with neither an exact nor a stripped match', () => {
+    const scope = new Set(['b200_vllm']);
+    expect(reconcileGpuSelection(['mi355x_sglang_mtp', 'b200_vllm_mtp'], scope)).toEqual([
+      'b200_vllm',
+    ]);
+    expect(reconcileGpuSelection(['mi355x_sglang'], scope)).toEqual([]);
+  });
+
+  it('dedupes when two selections collapse onto one scope key', () => {
+    const scope = new Set(['b200_vllm']);
+    expect(reconcileGpuSelection(['b200_vllm_mtp', 'b200_vllm'], scope)).toEqual(['b200_vllm']);
   });
 });
 

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -283,6 +283,48 @@ export function buildAvailabilityHwKey(
   return hwKey;
 }
 
+/**
+ * Drop the trailing spec-method segment from a `{gpu}_{framework}_{spec}` key.
+ * Returns null when the key has no spec segment to strip — the framework
+ * segment is never removed, so `b200_vllm` stays untouched.
+ */
+export function stripSpecMethodFromHwKey(hwKey: string): string | null {
+  const segments = hwKey.split('_');
+  if (segments.length < 3) return null;
+  return segments.slice(0, -1).join('_');
+}
+
+/**
+ * Reconcile a GPU selection (URL-restored or stale) with the keys the current
+ * scope actually offers.
+ *
+ * Fixed-sequence keys carry the spec method (`b200_vllm_mtp`); agentic keys
+ * drop it (`b200_vllm`) because one production curve may mix speculative and
+ * standard decoding. Links built without knowing which scenario the chart will
+ * land on — e.g. the /submissions "compare vs prev" link — can therefore carry
+ * a spec-suffixed key with no exact match under the agentic scope. Rather than
+ * dropping such a key (which also wipes the dependent comparison date range),
+ * fall back to its spec-stripped form when that is what the scope offers.
+ * Keys with neither an exact nor a stripped match are removed as before.
+ */
+export function reconcileGpuSelection(
+  selected: readonly string[],
+  validKeys: ReadonlySet<string>,
+): string[] {
+  const result: string[] = [];
+  for (const key of selected) {
+    let resolved: string | null = null;
+    if (validKeys.has(key)) {
+      resolved = key;
+    } else {
+      const stripped = stripSpecMethodFromHwKey(key);
+      if (stripped !== null && validKeys.has(stripped)) resolved = stripped;
+    }
+    if (resolved !== null && !result.includes(resolved)) result.push(resolved);
+  }
+  return result;
+}
+
 export type DerivedMetricKey = BenchmarkMetricKey;
 export type DerivedChartFields = Pick<InferenceData, DerivedMetricKey>;
 


### PR DESCRIPTION
## Problem

On `/submissions`, clicking **vs prev** on an agentic (AgentX) config lands on `/inference` with the Chip Config empty, no Comparison Date Range, and only the current run's curve drawn.

Repro on prod, DeepSeek V4 Pro B200 vLLM MTP, 2026-08-22 vs 2026-08-17:

- Generated link (`i_gpus=b200_vllm_mtp`): Chip Config shows "Select a Chip Config for comparison", one curve.
- Same link with `i_gpus=b200_vllm`: Chip Config = B200 (vLLM), Comparison Date Range = Aug 17 – Aug 22, two curves.

## Root cause

`buildInferenceCompareUrl` builds `i_gpus` from a `SubmissionSummaryRow`, which has no `benchmark_type`, so `buildAvailabilityHwKey` appends the spec suffix (`b200_vllm_mtp`). The agentic scope keys hardware without the spec suffix (`b200_vllm`) because one production curve can mix speculative and standard decoding. The "remove GPUs not in availability" effect in `InferenceContext` then drops the key, `selectedGPUs` goes empty, and the follow-on effect clears `i_dstart`/`i_dend`.

## Fix

- `chart-utils.ts`: add `stripSpecMethodFromHwKey` and `reconcileGpuSelection`. A selected key that has no exact match in the scope falls back to its spec-stripped form when that key exists; exact matches still win, unmatched keys are still removed, results are deduped. The framework segment is never stripped.
- `InferenceContext.tsx`: the availability-settled effect now reconciles instead of filtering, so the chip config and date range survive.
- `submissions-utils.ts`: comment explaining why the link keeps the spec suffix and where it gets reconciled.
- Unit tests for both helpers.

Fixing this on the chart side rather than in the link builder means stale share links with `_mtp` keys also recover under agentic scopes, and the `/api/v1/submissions` shape is unchanged.

## Checks

- `bun run fmt:fix`, `bun run lint`, `bun run typecheck`, `bun run check:typography`: clean
- `vitest run src/lib/chart-utils.test.ts src/components/submissions/submissions-utils.test.ts`: 214 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to inference GPU URL reconciliation and chart-utils helpers; behavior change only affects mismatched spec-suffixed keys, with tests and no API changes.
> 
> **Overview**
> Fixes **/submissions “compare vs prev”** links that open **/inference** with an empty Chip Config and no comparison date range when the run is agentic (AgentX).
> 
> Those links still put spec-suffixed hardware in `i_gpus` (e.g. `b200_vllm_mtp`) because summary rows have no `benchmark_type`, while agentic availability only exposes keys without the spec suffix (`b200_vllm`). The post-availability effect used to **drop** invalid keys, which cleared `selectedGPUs` and then wiped `i_dstart`/`i_dend`.
> 
> The chart now **reconciles** URL GPU keys via `stripSpecMethodFromHwKey` and `reconcileGpuSelection`: exact matches win, otherwise fall back to the spec-stripped key when the scope offers it, still remove keys with no match, and dedupe. `InferenceContext` calls this instead of a strict filter. A comment in `submissions-utils` documents why links keep the suffix. Unit tests cover the helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54b9e428fc70d04825087db368a26ced287c9a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->