### PR TITLE
fix(app): halve PNG export footer bar

### DIFF
--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -257,7 +257,7 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
     document.documentElement.classList.contains('minecraft') ||
     bgColor.includes('0 0%');
 
-  const WATERMARK_HEIGHT = 240;
+  const WATERMARK_HEIGHT = 120;
   const canvas = document.createElement('canvas');
   canvas.width = img.width;
   canvas.height = img.height + WATERMARK_HEIGHT;
@@ -291,7 +291,7 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
 
   // Draw watermark text (shrink to fit on narrow exports)
   const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
-  let fontSize = 80;
+  let fontSize = 40;
   ctx.font = watermarkFont(fontSize);
   const maxTextWidth = canvas.width - 48;
   const textWidth = ctx.measureText(WATERMARK_TEXT).width;


### PR DESCRIPTION
## Summary
The branded footer bar on exported chart PNGs was oversized relative to the chart (240px tall, 80px text at 2x pixel ratio). This halves it to 120px / 40px so the footer no longer dominates the image.

Text still shrinks to fit on narrow exports via the existing measure-and-scale logic.

## Test plan
- Export a chart PNG from any dashboard in dark and light themes; footer should be half as tall with the same centered text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only sizing tweak to PNG export branding in one hook; no auth, data, or export pipeline behavior changes beyond footer proportions.
> 
> **Overview**
> Exported chart PNGs were getting a **branded footer** that felt too large next to the plot (especially at **2x** `pixelRatio`). This PR **halves** the footer in `addWatermark` inside `useChartExport`: bar height **240 → 120** and default watermark text size **80 → 40**.
> 
> The footer still uses the same dark/light bar colors and centered **InferenceX** GitHub line; **narrow exports** still scale the text down via the existing `measureText` / `maxTextWidth` logic. Chart capture, background logo, and the rest of the export pipeline are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6ee4d5e12942d38e0bce0fc63f10c58d36b438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->