### PR TITLE
[13/N] fix(zh): fill approved UI translation gaps / 补齐已确认的中文界面翻译

### DIFF
--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -6,6 +6,8 @@ import { unlockAgenticGate } from '../support/e2e';
 
 type CsvCaptureWindow = Cypress.AUTWindow & {
   __capturedLifecycleCsvBlob?: Blob;
+  __capturedLifecyclePngUrl?: string;
+  __capturedLifecyclePngAxis?: string[];
 };
 
 function captureLifecycleCsvDownloads(win: Cypress.AUTWindow): void {
@@ -108,6 +110,24 @@ const firstRowCell = (header: string) => {
 /** The time-axis tick labels, as one string — changes when the x domain moves. */
 const xAxisTicks = () =>
   cy.get('[data-testid="calculator-lifecycle-chart-svg"] .x-axis .tick text').invoke('text');
+
+/** Includes tick positions: a sparse mobile axis can keep the same month while zooming. */
+const xAxisLayout = () =>
+  cy.get('[data-testid="calculator-lifecycle-chart-svg"] .x-axis').invoke('html');
+
+const assertReadableChineseAxis = () =>
+  cy.get('[data-testid="calculator-lifecycle-chart-svg"] .x-axis .tick text').should(($ticks) => {
+    const bounds = $ticks.toArray().map((tick) => {
+      expect(tick.textContent).to.match(/^\d{4}年\d{1,2}月$/u);
+      return tick.getBoundingClientRect();
+    });
+    for (let i = 1; i < bounds.length; i += 1) {
+      expect(
+        bounds[i]!.left - bounds[i - 1]!.right,
+        'gap between Chinese date labels',
+      ).to.be.at.least(4);
+    }
+  });
 
 /** The rect that owns hover for the whole plot area. */
 const plotOverlay = () =>
@@ -1003,6 +1023,7 @@ describe('Fleet — Fleet Lifecycle in Chinese', () => {
     cy.visit('/zh/fleet', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
       },
     });
     // Readiness: the lifecycle section only mounts once run data has loaded.
@@ -1035,4 +1056,145 @@ describe('Fleet — Fleet Lifecycle in Chinese', () => {
       .and('not.contain.text', 'Cumulative Margin')
       .and('not.contain.text', 'First Run');
   });
+
+  it('keeps token-type headers and exported assumptions in Chinese as selections change', () => {
+    showTable();
+    cy.window().then(captureLifecycleCsvDownloads);
+    for (const [testId, value] of [
+      ['calc-lifecycle-price-input', '1.25'],
+      ['calc-lifecycle-output-price-input', '3.5'],
+      ['calc-lifecycle-ramp-input', '2'],
+      ['calc-lifecycle-mtbi-input', '12'],
+      ['calc-lifecycle-recovery-input', '6'],
+      ['calc-lifecycle-horizon-input', '18'],
+      ['calc-fleet-mw-input', '4'],
+    ]) {
+      cy.get(`[data-testid="${testId}"]`).clear().type(value);
+    }
+
+    for (const [option, header] of [
+      ['输入 Token', '当前输入 tok/s/MW'],
+      ['输出 Token', '当前输出 tok/s/MW'],
+      ['总 Token', '当前 tok/s/MW'],
+    ]) {
+      cy.get('[data-testid="fleet-cost-type-selector"]').click();
+      cy.contains('[role="option"]', option).click();
+      cy.get('[data-testid="calculator-lifecycle-table"] thead').should('contain.text', header);
+      exportMenu().click();
+      cy.get('[data-testid="export-csv-button"]').click();
+      readCapturedLifecycleCsv().then((csv) => {
+        expect(csv.split('\n').find((line) => line.startsWith('芯片,'))).to.contain(header);
+        expect(csv.split('\n').find((line) => line.startsWith('# 假设：'))).to.equal(
+          '# 假设：输入价格 $1.25/M tok，输出价格 $3.5/M tok，爬坡期 2 个月，平均中断间隔（MTBI）12 天，恢复时间 6 小时，测算期 18 个月，设施功率 4 MW',
+        );
+        expect(csv).not.to.contain('# Assumptions:');
+      });
+    }
+  });
+
+  it('uses the selected cost tier’s Chinese label in the assumptions footer', () => {
+    for (const [option, label] of [
+      ['Neocloud', '自有设备 · Neocloud'],
+      ['3 年租赁', '租赁设备 · 3 年期'],
+      ['超大规模云服务商', '自有设备 · Hyperscaler'],
+    ]) {
+      cy.get('[data-testid="fleet-cost-selector"]').click();
+      cy.contains('[role="option"]', option).click();
+      cy.contains('[data-testid="calculator-lifecycle-section"] p', '成本 = 芯片数')
+        .should('contain.text', label)
+        .and('not.contain.text', 'Owning -')
+        .and('not.contain.text', 'Renting -');
+    }
+  });
+
+  for (const [width, height] of [
+    [1280, 900],
+    [390, 844],
+  ]) {
+    it(`keeps Chinese axis and pinned dates when zooming at ${width}px`, () => {
+      cy.viewport(width, height);
+      showChart();
+      assertReadableChineseAxis();
+      hoverPlot(0.4);
+      readout()
+        .should('have.css', 'display', 'block')
+        .find('.font-semibold')
+        .invoke('text')
+        .should('match', /^\d{4}年\d{1,2}月\d{1,2}日$/u)
+        .then((date) => {
+          clickPlot(0.4);
+          hoverPlot(0.7);
+          readout().should('have.css', 'pointer-events', 'auto').and('contain.text', date);
+          clickPlot(0.7);
+          readout().should('have.css', 'display', 'none');
+        });
+      xAxisLayout().then((before) => {
+        plotOverlay().then(($overlay) => {
+          const bounds = $overlay[0]!.getBoundingClientRect();
+          plotOverlay().trigger('wheel', {
+            deltaY: -400,
+            shiftKey: true,
+            clientX: bounds.left + bounds.width / 2,
+            clientY: bounds.top + 40,
+            bubbles: true,
+          });
+        });
+        xAxisLayout().should('not.equal', before);
+        assertReadableChineseAxis();
+        cy.get(
+          '[data-testid="calculator-lifecycle-figure"] [data-testid="zoom-reset-button"]',
+        ).click();
+        xAxisLayout().should('equal', before);
+        // Wait for the existing D3 reset transition before the next viewport update.
+        cy.wait(900);
+      });
+
+      if (width === 1280) {
+        cy.window().then((win) => {
+          const capture = win as CsvCaptureWindow;
+          capture.__capturedLifecyclePngUrl = undefined;
+          capture.__capturedLifecyclePngAxis = undefined;
+          win.HTMLAnchorElement.prototype.click = function () {
+            if (this.download.endsWith('.png')) {
+              capture.__capturedLifecyclePngUrl = this.href;
+              capture.__capturedLifecyclePngAxis = Array.from(
+                win.document.querySelectorAll('#fleet-lifecycle-export .x-axis .tick text'),
+                (tick) => tick.textContent ?? '',
+              );
+            }
+          };
+        });
+        exportMenu().click();
+        cy.get('[data-testid="export-png-button"]').click();
+        cy.window()
+          .should((win) => {
+            expect((win as CsvCaptureWindow).__capturedLifecyclePngUrl).to.match(
+              /^data:image\/png;base64,/u,
+            );
+          })
+          .then((win) => {
+            const image = (win as CsvCaptureWindow).__capturedLifecyclePngUrl!;
+            const labels = (win as CsvCaptureWindow).__capturedLifecyclePngAxis!;
+            expect(labels.length, 'date labels in the exported clone').to.be.greaterThan(0);
+            labels.forEach((label) => expect(label).to.match(/^\d{4}年\d{1,2}月$/u));
+            cy.writeFile('cypress/downloads/fleet-lifecycle-zh.png', image.split(',')[1], 'base64');
+            cy.then(
+              () =>
+                new Cypress.Promise<void>((resolve, reject) => {
+                  const png = new win.Image();
+                  png.addEventListener('load', () => {
+                    expect(png.naturalWidth).to.be.greaterThan(600);
+                    expect(png.naturalHeight).to.be.greaterThan(400);
+                    resolve();
+                  });
+                  png.addEventListener('error', () =>
+                    reject(new Error('Exported PNG did not decode')),
+                  );
+                  png.src = image;
+                }),
+            );
+          });
+      }
+    });
+  }
 });

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -1,3 +1,5 @@
+import { SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
+
 describe('Chinese (/zh) pages', () => {
   describe('zh landing page', () => {
     before(() => {
@@ -155,6 +157,26 @@ describe('Chinese (/zh) pages', () => {
   });
 
   describe('Run and Rankings model links', () => {
+    it('adds index supporter attribution only to the search description, matching English scope', () => {
+      for (const path of ['/zh/run', '/zh/rankings']) {
+        cy.request(path).then(({ body }) => {
+          const document = new DOMParser().parseFromString(body, 'text/html');
+          const content = (selector: string) =>
+            document.querySelector(selector)?.getAttribute('content');
+          const baseDescription = content('meta[property="og:description"]');
+          expect(baseDescription).to.be.a('string').and.not.include(SUPPORTERS_LINE_ZH);
+          expect(content('meta[name="description"]')).to.eq(
+            `${baseDescription}${SUPPORTERS_LINE_ZH}`,
+          );
+          expect(content('meta[name="twitter:description"]')).to.eq(baseDescription);
+          const collection = [...document.querySelectorAll('script[type="application/ld+json"]')]
+            .map((script) => JSON.parse(script.textContent ?? '{}'))
+            .find((data) => data['@type'] === 'CollectionPage');
+          expect(collection?.description).to.eq(baseDescription);
+        });
+      }
+    });
+
     for (const [path, section] of [
       ['/zh/run/deepseek-r1-on-b300', 'run-explore'],
       ['/zh/rankings/fastest-gpu-for-deepseek-r1', 'ranking-explore'],
@@ -167,6 +189,13 @@ describe('Chinese (/zh) pages', () => {
           },
         });
 
+        cy.get('meta[name="description"]')
+          .invoke('attr', 'content')
+          .should('match', new RegExp(`${SUPPORTERS_LINE_ZH}$`, 'u'))
+          .then((description) => {
+            cy.get('meta[property="og:description"]').should('have.attr', 'content', description);
+            cy.get('meta[name="twitter:description"]').should('have.attr', 'content', description);
+          });
         cy.get(`[aria-labelledby="${section}"] a[href="/zh/model/deepseek-r1"]`)
           .should('contain.text', 'DeepSeek R1')
           .click();

--- a/packages/app/src/app/zh/rankings/[slug]/page.tsx
+++ b/packages/app/src/app/zh/rankings/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE_ZH,
+} from '@semianalysisai/inferencex-constants';
 
 import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
 import {
@@ -43,7 +48,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!entry) return {};
   const data = await getRankingPageData(entry.slug);
   const title = rankingPageTitleZh(entry);
-  const description = data ? statLedDescriptionZh(entry, data) : rankingPageDescriptionZh(entry);
+  const description = `${data ? statLedDescriptionZh(entry, data) : rankingPageDescriptionZh(entry)}${SUPPORTERS_LINE_ZH}`;
   const url = `${SITE_URL}/zh/rankings/${entry.slug}`;
   return {
     title: { absolute: `${title} | ${SITE_NAME}` },

--- a/packages/app/src/app/zh/rankings/page.tsx
+++ b/packages/app/src/app/zh/rankings/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
@@ -16,7 +16,7 @@ const description =
 
 export const metadata: Metadata = {
   title,
-  description,
+  description: `${description}${SUPPORTERS_LINE_ZH}`,
   keywords: [
     'LLM 推理最快 GPU',
     'LLM 推理最便宜 GPU',

--- a/packages/app/src/app/zh/run/[slug]/page.tsx
+++ b/packages/app/src/app/zh/run/[slug]/page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
-import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import {
+  AUTHOR_NAME,
+  SITE_NAME,
+  SITE_URL,
+  SUPPORTERS_LINE_ZH,
+} from '@semianalysisai/inferencex-constants';
 
 import { fmtCostPerMtok, fmtThroughput } from '@/components/live-seo/format';
 import {
@@ -49,7 +54,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!entry) return {};
   const data = await getRunPageData(entry.slug);
   const title = runPageTitleZh(entry);
-  const description = data ? statLedDescriptionZh(entry, data) : runPageDescriptionZh(entry);
+  const description = `${data ? statLedDescriptionZh(entry, data) : runPageDescriptionZh(entry)}${SUPPORTERS_LINE_ZH}`;
   const url = `${SITE_URL}/zh/run/${entry.slug}`;
   return {
     title: { absolute: `${title} | ${SITE_NAME}` },

--- a/packages/app/src/app/zh/run/page.tsx
+++ b/packages/app/src/app/zh/run/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 
-import { SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
+import { SITE_NAME, SITE_URL, SUPPORTERS_LINE_ZH } from '@semianalysisai/inferencex-constants';
 
 import { JsonLd } from '@/components/json-ld';
 import { Card } from '@/components/ui/card';
@@ -20,7 +20,7 @@ const description =
 export function generateMetadata(): Metadata {
   return {
     title: { absolute: `${title} | ${SITE_NAME}` },
-    description,
+    description: `${description}${SUPPORTERS_LINE_ZH}`,
     keywords: [
       'LLM GPU 基准测试',
       '大模型 GPU 吞吐量',

--- a/packages/app/src/components/calculator/FleetLifecycle.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycle.tsx
@@ -94,6 +94,16 @@ interface FleetLifecycleProps {
 
 type LifecycleView = 'chart' | 'table';
 
+interface CsvAssumptions {
+  priceInput: string;
+  outputPriceInput: string;
+  rampInput: string;
+  mtbiInput: string;
+  recoveryInput: string;
+  horizonInput: string;
+  mw: number | null;
+}
+
 const LIFECYCLE_VIEW_OPTIONS: SegmentedToggleOption<LifecycleView>[] = [
   {
     value: 'chart',
@@ -165,7 +175,19 @@ const STRINGS = {
     colLatest: 'Latest Best',
     colSteps: 'Improvements',
     colGain: 'Gain',
+    inputTokenPrefix: 'input ',
+    outputTokenPrefix: 'output ',
     colTpPerMw: (tokenType: string) => `${tokenType}tok/s/MW now`,
+    csvAssumptions: ({
+      priceInput,
+      outputPriceInput,
+      rampInput,
+      mtbiInput,
+      recoveryInput,
+      horizonInput,
+      mw,
+    }: CsvAssumptions) =>
+      `Assumptions: input $${priceInput}/M tok, output $${outputPriceInput}/M tok, ramp ${rampInput} mo, MTBI ${mtbiInput} d, recovery ${recoveryInput} h, horizon ${horizonInput} mo, power ${mw ?? ''} MW`,
     colRevenue: 'Revenue $/day',
     colCost: 'Cost $/day',
     colMargin: 'Margin $/day',
@@ -279,7 +301,19 @@ const STRINGS = {
     colLatest: '最新最佳',
     colSteps: '提升次数',
     colGain: '提升倍数',
+    inputTokenPrefix: '输入',
+    outputTokenPrefix: '输出',
     colTpPerMw: (tokenType: string) => `当前${tokenType} tok/s/MW`,
+    csvAssumptions: ({
+      priceInput,
+      outputPriceInput,
+      rampInput,
+      mtbiInput,
+      recoveryInput,
+      horizonInput,
+      mw,
+    }: CsvAssumptions) =>
+      `假设：输入价格 $${priceInput}/M tok，输出价格 $${outputPriceInput}/M tok，爬坡期 ${rampInput} 个月，平均中断间隔（MTBI）${mtbiInput} 天，恢复时间 ${recoveryInput} 小时，测算期 ${horizonInput} 个月，设施功率 ${mw ?? ''} MW`,
     colRevenue: '收入 $/天',
     colCost: '成本 $/天',
     colMargin: '利润 $/天',
@@ -891,7 +925,8 @@ export default function FleetLifecycle({
     [rows, colorResolver, anchorMs],
   );
 
-  const tokenTypeLabel = costType === 'input' ? 'input ' : costType === 'output' ? 'output ' : '';
+  const tokenTypeLabel =
+    costType === 'input' ? t.inputTokenPrefix : costType === 'output' ? t.outputTokenPrefix : '';
 
   const handleAssumption = useCallback(
     (
@@ -1000,7 +1035,15 @@ export default function FleetLifecycle({
     exportToCsv(`InferenceX_fleet_lifecycle_${selectedModel}`, headers, body, [
       // The assumptions are not in the rows, and a CSV read six months later
       // cannot be reconstructed without them.
-      `Assumptions: input $${priceInput}/M tok, output $${outputPriceInput}/M tok, ramp ${rampInput} mo, MTBI ${mtbiInput} d, recovery ${recoveryInput} h, horizon ${horizonInput} mo, power ${mw ?? ''} MW`,
+      t.csvAssumptions({
+        priceInput,
+        outputPriceInput,
+        rampInput,
+        mtbiInput,
+        recoveryInput,
+        horizonInput,
+        mw,
+      }),
     ]);
   }, [
     rows,
@@ -1489,7 +1532,11 @@ export default function FleetLifecycle({
 
         <div>
           <p className="text-xs text-muted-foreground mt-1">
-            {t.assumptions(getCostProviderLabel(costProvider), `${mw} MW`, anchorDate ?? '—')}
+            {t.assumptions(
+              getCostProviderLabel(costProvider, locale),
+              `${mw} MW`,
+              anchorDate ?? '—',
+            )}
           </p>
           <p className="text-muted-foreground mt-1">
             <small>

--- a/packages/app/src/components/calculator/FleetLifecycleChart.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleChart.tsx
@@ -5,14 +5,17 @@ import React, { useCallback, useMemo, useRef } from 'react';
 
 import { formatLargeNumber } from '@/lib/chart-rendering';
 import { getChartWatermark } from '@/lib/data-mappings';
+import type { AnyScale } from '@/lib/d3-chart/chart-update';
 import {
   D3Chart,
+  type AxisConfig,
   type D3ChartHandle,
   type LayerConfig,
   type RenderContext,
   type ScaleConfig,
 } from '@/lib/d3-chart/D3Chart';
 import { escapeHtml } from '@/lib/utils';
+import { useLocale } from '@/lib/use-locale';
 
 import {
   isBreakEvenAnchored,
@@ -36,6 +39,11 @@ const LABEL_MIN_GAP = 13;
  * half its glyphs above the SVG edge without this inset.
  */
 const LABEL_HALF_HEIGHT = 6;
+
+const DATE_FORMATS = {
+  en: { axis: '%b %Y', tooltip: '%d %b %Y' },
+  zh: { axis: '%Y年%-m月', tooltip: '%Y年%-m月%-d日' },
+} as const;
 
 /** One plotted series: an hwKey's margin staircase since the model shipped. */
 export interface LifecycleChartSeries {
@@ -151,6 +159,8 @@ const FleetLifecycleChart = React.memo(
     legendElement,
     caption,
   }: FleetLifecycleChartProps) => {
+    const locale = useLocale();
+    const dateFormats = DATE_FORMATS[locale];
     const chartRef = useRef<D3ChartHandle | null>(null);
     const toMs = useCallback((month: number) => anchorMs + month * MS_PER_MONTH, [anchorMs]);
     const valueOf = useCallback((point: LifecyclePoint) => metricValue(point, metric), [metric]);
@@ -503,7 +513,7 @@ const FleetLifecycleChart = React.memo(
       [valueOf],
     );
 
-    const sliceDate = useMemo(() => d3.timeFormat('%d %b %Y'), []);
+    const sliceDate = useMemo(() => d3.timeFormat(dateFormats.tooltip), [dateFormats]);
 
     /**
      * Was the readout frozen when the current click started?
@@ -634,12 +644,30 @@ const FleetLifecycleChart = React.memo(
       [anchorMs, bySafeKey, data, labels, metric, readingAt, sliceDate, sliceSpacing, stepsOnAxis],
     );
 
-    const xAxisConfig = useMemo(
+    const xAxisConfig = useMemo<AxisConfig>(
       () => ({
-        tickFormat: d3.timeFormat('%b %Y') as any,
+        tickFormat: d3.timeFormat(dateFormats.axis) as any,
         tickCount: 8,
+        ...(locale === 'zh'
+          ? {
+              tickValues: (scale: AnyScale) => {
+                const timeScale = scale as d3.ScaleTime<number, number>;
+                // Chinese year/month labels need more room on narrow plots.
+                // Keep the same calendar candidates as English, then thin them
+                // by their positions on the current (possibly zoomed) scale.
+                const ticks = timeScale.ticks(8);
+                let previousX = -Infinity;
+                return ticks.filter((tick) => {
+                  const x = timeScale(tick);
+                  if (x - previousX < 96) return false;
+                  previousX = x;
+                  return true;
+                });
+              },
+            }
+          : {}),
       }),
-      [],
+      [dateFormats, locale],
     );
 
     const yAxisConfig = useMemo(

--- a/packages/app/src/components/chips/chip-page-sections.tsx
+++ b/packages/app/src/components/chips/chip-page-sections.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/chip-pages-zh';
 import { getGlossaryEntry } from '@/lib/glossary';
 import { getZhGlossaryEntry } from '@/lib/glossary-zh';
+import { formatScaleUpTopology } from '@/lib/gpu-specs';
 import { type Locale, localePath, ZH_LANG_TAG } from '@/lib/i18n';
 import {
   ACCELERATOR_MODEL_TITLE,
@@ -317,7 +318,7 @@ export const SpecTable = ({ entry, locale }: { entry: ChipPageEntry; locale: Loc
     [t.specLabels.scaleUp, spec.scaleUpTech],
     [t.specLabels.scaleUpBandwidth, spec.scaleUpBandwidth],
     [t.specLabels.worldSize, String(spec.scaleUpWorldSize)],
-    [t.specLabels.scaleUpTopology, spec.scaleUpTopology],
+    [t.specLabels.scaleUpTopology, formatScaleUpTopology(spec.scaleUpTopology, locale)],
     [t.specLabels.scaleOut, spec.scaleOutTech ?? t.none],
     [t.specLabels.nic, spec.nic ?? t.none],
     [t.specLabels.tdp, `${hw.tdp.toLocaleString('en-US')} W`],

--- a/packages/app/src/components/chips/chip-spec-table.test.tsx
+++ b/packages/app/src/components/chips/chip-spec-table.test.tsx
@@ -4,7 +4,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { getAllChipPages } from '@/lib/chip-pages';
+import { getAllChipPages, getChipPage, getChipSpec } from '@/lib/chip-pages';
 
 import { SpecTable } from './chip-page-sections';
 
@@ -40,11 +40,26 @@ describe('chip specification table', () => {
     expect(container.textContent).toContain('Swipe horizontally');
   });
 
-  it('uses the Chinese mobile hint on the Chinese detail template', () => {
+  it.each([
+    ['b300', '2-rail 优化交换拓扑'],
+    ['mi355x', '全互连'],
+  ])('localizes %s topology and keeps the English registry value unchanged', (slug, topologyZh) => {
+    const entry = getChipPage(slug)!;
+    const topologyEn = getChipSpec(entry).scaleUpTopology;
+
     act(() => {
-      root.render(<SpecTable entry={getAllChipPages()[0]} locale="zh" />);
+      root.render(<SpecTable entry={entry} locale="zh" />);
     });
 
     expect(container.textContent).toContain('左右滑动可查看全部规格参数');
+    expect(container.textContent).toContain(topologyZh);
+    expect(container.textContent).not.toContain(topologyEn);
+
+    act(() => {
+      root.render(<SpecTable entry={entry} locale="en" />);
+    });
+
+    expect(container.textContent).toContain(topologyEn);
+    expect(container.textContent).not.toContain(topologyZh);
   });
 });

--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -1,5 +1,14 @@
 // @vitest-environment jsdom
-import { describe, expect, it } from 'vitest';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const exportMocks = vi.hoisted(() => ({ pathname: '/inference', toPng: vi.fn() }));
+vi.mock('next/navigation', () => ({ usePathname: () => exportMocks.pathname }));
+vi.mock('@jpinsonneau/html-to-image', () => ({
+  toPng: exportMocks.toPng,
+  getFontEmbedCSS: undefined,
+}));
 
 import {
   getExportCaptureDimensions,
@@ -8,7 +17,78 @@ import {
   getLogoWatermarkOpacity,
   getLogoWatermarkSrc,
   normalizeChartSvgWidthsForExport,
+  useChartExport,
 } from './useChartExport';
+
+describe('useChartExport failure messages', () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let chart: HTMLDivElement;
+  let exportContainer: HTMLDivElement;
+  let current: ReturnType<typeof useChartExport>;
+  let originalFonts: PropertyDescriptor | undefined;
+
+  function HookProbe() {
+    current = useChartExport({ chartId: 'inference-chart' });
+    return null;
+  }
+
+  beforeEach(() => {
+    exportMocks.pathname = '/inference';
+    exportMocks.toPng.mockReset();
+    originalFonts = Object.getOwnPropertyDescriptor(document, 'fonts');
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { ready: Promise.resolve() },
+    });
+    container = document.createElement('div');
+    chart = document.createElement('div');
+    chart.id = 'inference-chart';
+    chart.textContent = 'DeepSeek R1';
+    exportContainer = document.createElement('div');
+    exportContainer.id = 'inference-chart-export';
+    document.body.append(container, chart, exportContainer);
+    root = createRoot(container);
+    act(() => root.render(createElement(HookProbe)));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    chart.remove();
+    exportContainer.remove();
+    if (originalFonts) Object.defineProperty(document, 'fonts', originalFonts);
+    else Reflect.deleteProperty(document, 'fonts');
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['/inference', 'Failed to export image. Please try again.'],
+    ['/zh/inference', '图片导出失败，请重试。'],
+  ])('reports a PNG capture failure in the current locale on %s', async (pathname, message) => {
+    // Keep the hook mounted across locale navigation to catch a stale callback.
+    exportMocks.pathname = pathname;
+    act(() => root.render(createElement(HookProbe)));
+    const error = new Error('PNG capture failed');
+    exportMocks.toPng.mockRejectedValueOnce(error);
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await act(async () => {
+      await current.exportToImage();
+    });
+
+    expect(exportMocks.toPng).toHaveBeenCalledExactlyOnceWith(
+      exportContainer,
+      expect.objectContaining({ quality: 1, pixelRatio: 2 }),
+    );
+    expect(alertSpy).toHaveBeenCalledExactlyOnceWith(message);
+    expect(errorSpy).toHaveBeenCalledExactlyOnceWith('Error exporting image:', error);
+    expect(current.isExporting).toBe(false);
+    expect(exportContainer.childElementCount).toBe(0);
+    expect(chart.textContent).toBe('DeepSeek R1');
+  });
+});
 
 describe('getExportFontFamily', () => {
   it('uses Minecraft font stack when minecraft theme is active', () => {

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -1,6 +1,12 @@
 import { useCallback, useState } from 'react';
 
 import { CHART_FONT_MINECRAFT, CHART_FONT_SANS } from '@/lib/d3-chart/typography';
+import { useLocale } from '@/lib/use-locale';
+
+const STRINGS = {
+  en: { exportFailed: 'Failed to export image. Please try again.' },
+  zh: { exportFailed: '图片导出失败，请重试。' },
+};
 
 interface UseChartExportOptions {
   chartId: string;
@@ -315,6 +321,8 @@ export function useChartExport({
   setIsLegendExpanded,
   exportFileName,
 }: UseChartExportOptions) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
   const [isExporting, setIsExporting] = useState(false);
 
   const exportToImage = useCallback(async () => {
@@ -555,14 +563,14 @@ export function useChartExport({
       window.dispatchEvent(new CustomEvent('inferencex:action'));
     } catch (error) {
       console.error('Error exporting image:', error);
-      alert('Failed to export image. Please try again.');
+      alert(t.exportFailed);
       if (wasClosed && setIsLegendExpanded) setIsLegendExpanded(false);
     } finally {
       setIsExporting(false);
       const exportElement = document.querySelector<HTMLElement>(`#${chartId}-export`);
       if (exportElement) exportElement.innerHTML = '';
     }
-  }, [chartId, setIsLegendExpanded]);
+  }, [chartId, setIsLegendExpanded, t]);
 
   return { isExporting, exportToImage };
 }

--- a/packages/app/src/lib/chip-pages-zh.ts
+++ b/packages/app/src/lib/chip-pages-zh.ts
@@ -74,7 +74,7 @@ const translations: Readonly<Record<string, ChipPageTranslation>> = {
       'NVIDIA B200 规格、云端价格与实时 LLM 推理基准测试：180 GB HBM3e、8 TB/s 带宽、9,000 稠密 FP4 TFLOP/s 与 NVLink 5.0，每日在 vLLM、SGLang 与 TensorRT-LLM 上持续测量。',
     overview: [
       'NVIDIA B200 是 Blackwell 一代的主力数据中心芯片：180 GB 可用 HBM3e（带宽 8 TB/s）、单芯片 900 GB/s 的 NVLink 5.0，Tensor Core 每时钟吞吐量翻倍于 Hopper 并新增 FP4。稠密算力 9,000 FP4 / 4,500 FP8 TFLOP/s，在主导 LLM decode 的内存带宽受限场景中，单颗 B200 的表现超过两颗 H100。',
-      'NVFP4 推理正是在 B200 上成为主流：前沿开源模型发布 FP4 checkpoint，精度与 FP8 相差无几，单芯片吞吐量却接近翻倍。它 1,000 W 的 TDP 和约 1.7 kW 的整机功耗使小时租价远高于 Hopper，因此升级决策取决于每美元性能而非峰值算力。',
+      'NVFP4 推理正是在 B200 上成为主流：前沿开源模型发布 FP4 checkpoint，精度与 FP8 相差无几，单芯片吞吐量却接近翻倍。它的单芯片 TDP 为 1,000 W，综合功耗约为 1.7 kW，因此小时租价远高于 Hopper；是否值得升级，取决于每美元性能而非峰值算力。',
     ],
     benchmarkContext:
       'B200 是 InferenceX 上测试最密集的芯片之一：每日在 vLLM、SGLang、TensorRT-LLM 和 Dynamo 分离式推理上运行固定序列扫描与 AgentX agentic 编码 trace，每美元性能与精度对比页面持续追踪每个模型上 NVFP4 与 FP8 的差距。',


### PR DESCRIPTION
## Summary

Implements exactly eight maintainer-approved groups from the next #823 [13/N] batch, on a new branch after #997 merged:

1. Translate Fleet input/output table and CSV header prefixes; preserve the total-token header.
2. Reuse the existing localized cost-provider labels in the Fleet footer.
3. Localize Fleet axis and tooltip dates. Space Chinese date ticks according to plot width so they remain readable on mobile and after zoom; preserve English rendering and all date calculations.
4. Translate the downloaded Fleet CSV assumptions note without changing values, field order, data rows, or filename.
5. Reuse the existing Chinese topology formatter on Chips pages.
6. Restore the existing Chinese supporter attribution in Run/Rankings metadata, with the exact English-equivalent index/detail scope and fallback behavior.
7. Localize the shared chart PNG-export failure alert, including when locale changes while the hook stays mounted.
8. Apply the approved B200 second-paragraph correction from whole-system power to per-chip all-in power. Leave the separate first-paragraph claim unchanged.

English strings, benchmark values, calculation logic, registry values, and URLs are unchanged. Existing English literals were extracted into standard locale dictionaries, so the strict `chinese-copy-only` structural-byte label is deliberately not applied; it flags the dictionary extraction even though English output is identical. The guard itself is unchanged.

## Validation

- All 5,634 unit tests passed. One unchanged gzip-stream test timed out during the initial build/test overlap; complete reruns passed without a code or timeout change.
- All 156 local browser smoke tests passed (43 component, 113 integration), plus all 42 Fleet integration tests against the final production fixture build. Chinese date spacing, hover/pin/zoom/reset, CSV assumptions/headers, and an actual 2396×1128 PNG export passed.
- Production build (1,299 pages), typecheck, lint, formatting, typography, and diff checks passed. Checked the affected Fleet and Chips surfaces at 1280×900 and 390×844; manually inspected the generated PNG. CI results will be reported separately.
- Chinese-copy skill review covers all eight groups, fidelity and naturalness separately; no actionable findings. The maintainer approved all wording before implementation.
- Regression coverage extends existing tests: selected token headers and CSV values, cost tiers, responsive date/hover/pin/zoom behavior, actual PNG export, topology locale switching, metadata attribution scope, and export failure cleanup. No sentence-snapshot suite or new test file.
- Shared PNG failure copy applies to official and unofficial exports through the same hook; data/overlay handling is unchanged. Fleet history remains official-only, as documented by the existing page.

## Roadmap scope

This does **not** complete or close #823. The older prose draft (except attribution), eleven model-architecture badge translations, newly added profit-estimator prose, and two English-source correctness questions remain separate approval items. Long-form articles remain deliberately deferred. No merge requested automatically.

## 中文说明

本 PR 在 #997 合并后新建分支，仅实现 #823 [13/N] 下一批已逐项确认的八组修改：

1. 补齐 Fleet 表格和 CSV 中输入、输出 token 的表头翻译，保留总 token 表头。
2. 在 Fleet 页脚复用已有的中文成本供应商名称。
3. 将 Fleet 坐标轴和提示框日期改为中文格式，并按绘图区宽度调整中文日期刻度密度，避免移动端及缩放后重叠；英文显示和日期计算不变。
4. 翻译 CSV 中的假设说明，保留所有数值、字段顺序、数据行和文件名。
5. 芯片页面复用已有的中文拓扑格式化函数。
6. 补齐 Run/Rankings metadata 中已有的中文支持方署名，与英文索引页、详情页的使用范围和回退逻辑一致。
7. 翻译共用的图表 PNG 导出失败提示，并确保页面切换语言后提示同步更新。
8. 按已确认的完整段落修正 B200 综合功耗的统计范围，保留另有歧义的第一段原文。

英文文案、基准测试数值、计算逻辑、注册表数据和 URL 均不变。此次将原先硬编码的英文抽取到标准双语字典，虽然英文输出完全相同，但严格的 `chinese-copy-only` 字节检查会将字典结构变化标记为差异，因此不添加该标签，也不修改检查规则。

验证结果：全部 5,634 项单元测试、156 项浏览器冒烟测试（43 项组件、113 项集成），以及最终正式构建上的 42 项 Fleet 集成测试通过。首次并行构建和测试时，一项未改动的 gzip 流式处理测试超时；完整重跑均通过，没有修改实现或超时设置。正式构建生成 1,299 个页面，类型、lint、格式、排版与 diff 检查通过。已在 1280×900 和 390×844 下检查 Fleet 与芯片页面，并检查实际导出的 2396×1128 PNG；日期间距、悬停、冻结读数、缩放与重置，以及 CSV 表头和假设说明均通过测试。CI 结果另行报告。

中文文案已按 skill 分别检查语义准确性和自然度，未发现需要处理的问题；全部措辞均在实现前获得维护者确认。测试复用已有文件，覆盖实际行为，不新增整句文案快照。共用导出提示适用于官方和非官方运行图表，数据处理路径保持不变；Fleet 历史数据仍仅包含官方运行。

本批次不代表 #823 完成：此前其余文案草稿、十一项模型架构标签、新增利润估算页面文案，以及两处英文原文准确性问题仍需另行确认。长文翻译继续后置，不自动合并或关闭路线图。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly copy, metadata, and D3 tick formatting; economics and English paths are unchanged, with broad regression tests on Fleet and SEO behavior.
> 
> **Overview**
> Closes several **approved Chinese UI gaps** without changing English output, benchmark math, or registry data.
> 
> **Fleet lifecycle** now localizes input/output token labels in the table and CSV, the assumptions footer line (including cost-tier names via `getCostProviderLabel(..., locale)`), and CSV `# 假设：` notes. The lifecycle chart uses locale-specific axis/tooltip dates (`%Y年%-m月`), with **extra tick spacing on `/zh`** so labels stay readable on mobile and after zoom; Cypress covers CSV headers, cost tiers, hover/pin/zoom/reset, and PNG export axis text.
> 
> **Run/Rankings `/zh` SEO** appends `SUPPORTERS_LINE_ZH` to metadata descriptions with the same scope as English: index pages add it only to `meta[name="description"]` (not OG/Twitter/JSON-LD), while detail pages use it on all description tags.
> 
> **Smaller fixes:** chip spec tables call `formatScaleUpTopology` for Chinese topology strings; chart PNG export failures alert in the active locale (including after navigation); B200 Chinese copy clarifies per-chip vs system power. Tests extend existing Cypress/Vitest files rather than new suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 807e428d1446e87adee9af30092b139a8886888e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->