### PR TITLE
feat(app): add MiniMax M3 to the profit estimators with MiniMax list-price defaults / 利润估算器新增 MiniMax M3 并默认采用 MiniMax 官方定价

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1089,14 +1089,15 @@ and the two can be collapsed into one once both are on master.
   no scenario selector and no precision selector (precision stays in auto mode, the
   densest measured run set). The interactivity target is a typed number in the same
   row as utilization and the license fee.
-- **Kimi K3 and GLM 5.2/5.3.** The model selector offers the tab's route allow-list
+- **Kimi K3, GLM 5.2/5.3, and MiniMax M3.** The model selector offers the tab's route allow-list
   (`MODEL_ROUTE_TAB_MODELS['profit-estimator']` and
   `['profit-estimator-per-gigawatt']` in `model-routes.ts`) intersected with the
   models that have an agentic run. Each bare path opens on Kimi K3
   (`defaultRouteModel(tab)`); `/profit-estimator/kimi-k3` and
   `/profit-estimator-per-gigawatt/kimi-k3` are the same pages, `/glm-5-3` is the
-  GLM 5.2/5.3 page (one data bucket, one slug, as on the rest of the site), aliases
-  308 to the canonical slug, and any model outside the allow-list 404s. Widening
+  GLM 5.2/5.3 page (one data bucket, one slug, as on the rest of the site),
+  `/minimax-m3` is the MiniMax M3 page, aliases 308 to the canonical slug, and any
+  model outside the allow-list 404s. Widening
   the pages to more models is one list edit, a `profitModelDefaults` entry, and
   fixture rows.
 - **Per-model defaults.** `profitModelDefaults(model)` in `profit-estimator.ts`
@@ -1107,7 +1108,13 @@ and the two can be collapsed into one once both are on master.
   third-party hosts undercut Z.ai on OpenRouter, so the catalog aggregate would
   understate what the lab charges, and Z.ai's own 48 tok/s/user is below the
   measured range of the priced SKUs, so 100 is the nearest round point every curve
-  covers. A model with a list price gets a third Token Price option, `<vendor> list
+  covers. MiniMax M3 opens on 83 tok/s/user, the speed MiniMax's own API serves
+  at, and MiniMax's standard list price for calls up to 512K input tokens ($0.30
+  input / $0.06 cached / $1.20 output per M tok, the permanent 50%-off rate on its
+  pay-as-you-go page); the OpenRouter aggregate also sits below it. At 83
+  tok/s/user the B200, B300, GB200, and MI355X agentic curves are priced, and the
+  H100, H200, MI300X, and MI325X curves top out below it and list as not priced. A
+  model with a list price gets a third Token Price option, `<vendor> list
 price`, next to OpenRouter and Custom; the caption names the source in force and
   links the lab's pricing page when the list price is used. Switching to Custom
   seeds the three fields from whichever price is in force.

--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1101,8 +1101,8 @@ and the two can be collapsed into one once both are on master.
   the pages to more models is one list edit, a `profitModelDefaults` entry, and
   fixture rows.
 - **Per-model defaults.** `profitModelDefaults(model)` in `profit-estimator.ts`
-  gives each model the operating point and price source it opens on, and a model
-  switch re-seeds both. Kimi K3 opens on 45 tok/s/user and the OpenRouter catalog,
+  gives each model the operating point, price source, and model license fee it
+  opens on, and a model switch re-seeds all three. Kimi K3 opens on 45 tok/s/user and the OpenRouter catalog,
   where Moonshot's price holds across hosts. GLM 5.2/5.3 opens on 100 tok/s/user
   and Z.ai's list price ($1.40 input / $0.26 cached / $4.40 output per M tok):
   third-party hosts undercut Z.ai on OpenRouter, so the catalog aggregate would
@@ -1113,7 +1113,9 @@ and the two can be collapsed into one once both are on master.
   input / $0.06 cached / $1.20 output per M tok, the permanent 50%-off rate on its
   pay-as-you-go page); the OpenRouter aggregate also sits below it. At 83
   tok/s/user the B200, B300, GB200, and MI355X agentic curves are priced, and the
-  H100, H200, MI300X, and MI325X curves top out below it and list as not priced. A
+  H100, H200, MI300X, and MI325X curves top out below it and list as not priced.
+  MiniMax M3 also opens on a 20% model license fee; every other model opens on
+  the 30% `DEFAULT_LAB_CUT_PCT`. A
   model with a list price gets a third Token Price option, `<vendor> list
 price`, next to OpenRouter and Custom; the caption names the source in force and
   links the lab's pricing page when the list price is used. Switching to Custom

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -3,7 +3,7 @@
 //  - defaults are Kimi K3, 45 tok/s/user, 60% utilization, 30% model license fee;
 //  - GLM 5.2/5.3 has its own defaults, 100 tok/s/user and the Z.ai list price
 //    ($1.40 / $0.26 cached / $4.40), and a model switch re-seeds both;
-//  - MiniMax M3 opens on 83 tok/s/user and the MiniMax list price
+//  - MiniMax M3 opens on 83 tok/s/user, the MiniMax list price, and a 20% license fee
 //    ($0.30 / $0.06 cached / $1.20);
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
@@ -505,6 +505,8 @@ describe('Profit Estimator — MiniMax M3', () => {
     chart().should('exist');
     cy.location('pathname').should('eq', '/profit-estimator/minimax-m3');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '83');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '20');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '20%');
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'MiniMax M3 428B Agentic Revenue & Profit Estimates per Chip per Hour at P90 83 tok/s/user Interactivity',
@@ -550,6 +552,7 @@ describe('Profit Estimator — MiniMax M3', () => {
     cy.visit('/profit-estimator-per-gigawatt/glm-5-2', { onBeforeLoad: suppressNudges });
     chart().should('exist');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
 
     cy.get('[data-testid="profit-model-selector"]').click();
     cy.contains('[role="option"]', 'MiniMax M3').click();
@@ -558,6 +561,7 @@ describe('Profit Estimator — MiniMax M3', () => {
       .should('contain.text', 'MiniMax M3')
       .and('contain.text', '83 tok/s/user');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '83');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '20');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $0.3')
       .and('contain.text', '(MiniMax list price)');
@@ -566,6 +570,7 @@ describe('Profit Estimator — MiniMax M3', () => {
     cy.contains('[role="option"]', 'Kimi K3').click();
     cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $0.6')
       .and('contain.text', '(OpenRouter)');

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -549,7 +549,7 @@ describe('Profit Estimator — MiniMax M3', () => {
   });
 
   it('re-seeds the operating point and price source when switching from GLM', () => {
-    cy.visit('/profit-estimator-per-gigawatt/glm-5-2', { onBeforeLoad: suppressNudges });
+    cy.visit('/profit-estimator-per-gigawatt/glm-5-3', { onBeforeLoad: suppressNudges });
     chart().should('exist');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -3,6 +3,8 @@
 //  - defaults are Kimi K3, 45 tok/s/user, 60% utilization, 30% model license fee;
 //  - GLM 5.2/5.3 has its own defaults, 100 tok/s/user and the Z.ai list price
 //    ($1.40 / $0.26 cached / $4.40), and a model switch re-seeds both;
+//  - MiniMax M3 opens on 83 tok/s/user and the MiniMax list price
+//    ($0.30 / $0.06 cached / $1.20);
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
@@ -10,8 +12,8 @@
 //  - the OpenRouter catalog is the default price source and a custom triple
 //    (input, cached input, output) can replace it;
 //  - the workload is pinned to agentic traces, so there is no scenario or
-//    precision selector, the model selector offers Kimi K3 and GLM 5.2/5.3 only,
-//    and the target interactivity is a typed number, not a slider;
+//    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3 and
+//    MiniMax M3 only, and the target interactivity is a typed number, not a slider;
 //  - the cost provider has a custom $/GPU/hr option with one input per chip;
 //  - the heading reads like /inference, the subtitle names the utilization, and
 //    the formula folds away under the chart;
@@ -21,8 +23,9 @@
 import { interceptProfitData } from '../support/profit-fixtures';
 
 // Kimi K3 is the page default; the DeepSeek row proves the page prices the
-// routed model, not the first catalog entry. The GLM row sits below Z.ai's
-// list price, as the real aggregate does, so the spec can tell the two apart.
+// routed model, not the first catalog entry. The GLM and MiniMax rows sit below
+// their labs' list prices, as the real aggregates do, so the spec can tell the
+// two sources apart.
 const OPENROUTER_MODELS = {
   data: [
     {
@@ -32,6 +35,10 @@ const OPENROUTER_MODELS = {
     {
       id: 'z-ai/glm-5.3',
       pricing: { prompt: '0.00000115', completion: '0.0000035', input_cache_read: '0.0000002' },
+    },
+    {
+      id: 'minimax/minimax-m3',
+      pricing: { prompt: '0.00000023', completion: '0.00000096', input_cache_read: '0.00000005' },
     },
     {
       id: 'deepseek/deepseek-v4-pro-0813',
@@ -118,9 +125,10 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-precision-selector"]').should('not.exist');
     cy.get('[data-testid="profit-model-selector"]').should('contain.text', 'Kimi K3').click();
     cy.get('[role="option"]')
-      .should('have.length', 2)
+      .should('have.length', 3)
       .and('contain.text', 'Kimi K3')
-      .and('contain.text', 'GLM5.2/GLM5.3');
+      .and('contain.text', 'GLM5.2/GLM5.3')
+      .and('contain.text', 'MiniMax M3');
     cy.get('body').type('{esc}');
     // Kimi K3 has no list price, so the selector offers the catalog and custom only.
     cy.get('button#profit-price-source').click();
@@ -483,6 +491,94 @@ describe('Profit Estimator — GLM 5.2/5.3', () => {
       .should('contain.text', '输入：$1.4')
       .and('contain.text', 'Z.ai 官方定价');
     cy.get('button#profit-price-source').should('contain.text', 'Z.ai 官方定价');
+  });
+});
+
+describe('Profit Estimator — MiniMax M3', () => {
+  beforeEach(() => {
+    stubOpenRouter();
+    cy.viewport(1280, 1000);
+  });
+
+  it('opens /profit-estimator/minimax-m3 on 83 tok/s/user and the MiniMax list price', () => {
+    cy.visit('/profit-estimator/minimax-m3', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.location('pathname').should('eq', '/profit-estimator/minimax-m3');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '83');
+    cy.get('[data-testid="profit-caption"] h2').should(
+      'contain.text',
+      'MiniMax M3 428B Agentic Revenue & Profit Estimates per Chip per Hour at P90 83 tok/s/user Interactivity',
+    );
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.3')
+      .and('contain.text', 'Cached Input: $0.06')
+      .and('contain.text', 'Output: $1.2')
+      .and('contain.text', '(MiniMax list price)');
+    cy.get('[data-testid="profit-list-price-source"]')
+      .should('have.attr', 'href', 'https://platform.minimax.io/docs/guides/pricing-paygo')
+      .and('contain.text', 'MiniMax');
+    // The wide curve covers 83 tok/s/user; the H200 curve stops short of it.
+    chart().find('image.bar-vendor-mark').should('have.length', 4);
+    chart().should('not.contain.text', 'H200');
+    cy.get('[data-testid="profit-pricing-notice"]').should('not.exist');
+
+    // The catalog stays one click away and reads the MiniMax row, not Kimi's.
+    cy.get('button#profit-price-source').click();
+    cy.get('[role="option"]')
+      .should('have.length', 3)
+      .and('contain.text', 'OpenRouter')
+      .and('contain.text', 'MiniMax list price')
+      .and('contain.text', 'Custom $/M tok');
+    cy.contains('[role="option"]', 'OpenRouter').click();
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.23')
+      .and('contain.text', 'Output: $0.96')
+      .and('contain.text', '(OpenRouter)');
+    cy.get('[data-testid="profit-list-price-source"]').should('not.exist');
+
+    // Custom seeds from the price in force, here the list price.
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'MiniMax list price').click();
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'Custom $/M tok').click();
+    cy.get('[data-testid="profit-input-price"]').should('have.value', '0.3');
+    cy.get('[data-testid="profit-cached-price"]').should('have.value', '0.06');
+    cy.get('[data-testid="profit-output-price"]').should('have.value', '1.2');
+  });
+
+  it('re-seeds the operating point and price source when switching from GLM', () => {
+    cy.visit('/profit-estimator-per-gigawatt/glm-5-2', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
+
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'MiniMax M3').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/minimax-m3');
+    cy.get('[data-testid="profit-caption"] h2')
+      .should('contain.text', 'MiniMax M3')
+      .and('contain.text', '83 tok/s/user');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '83');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.3')
+      .and('contain.text', '(MiniMax list price)');
+
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'Kimi K3').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.6')
+      .and('contain.text', '(OpenRouter)');
+  });
+
+  it('serves the Chinese mirror with the list price named in Chinese', () => {
+    cy.visit('/zh/profit-estimator-per-gigawatt/minimax-m3', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '83');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', '输入：$0.3')
+      .and('contain.text', 'MiniMax 官方定价');
+    cy.get('button#profit-price-source').should('contain.text', 'MiniMax 官方定价');
   });
 });
 

--- a/packages/app/cypress/support/profit-fixtures.ts
+++ b/packages/app/cypress/support/profit-fixtures.ts
@@ -1,6 +1,6 @@
 /**
  * Synthetic agentic rows for the `/profit-estimator` e2e spec, one identical
- * SKU set per model the estimator serves (Kimi K3 and GLM 5.2/5.3).
+ * SKU set per model the estimator serves (Kimi K3, GLM 5.2/5.3, MiniMax M3).
  *
  * The captured API fixtures carry no `agentic_traces` rows, and the estimator
  * is pinned to that workload, so the spec intercepts availability and
@@ -10,17 +10,19 @@
  *
  * The H200 curve tops out below the 45 tok/s/user default on purpose: the page
  * must list it under "Not priced" rather than extrapolate a bar for it. The
- * wide curve reaches 130 tok/s/user so GLM's 100 tok/s/user default is a read,
- * not a clamp, on every other SKU.
+ * wide curve reaches 130 tok/s/user so GLM's 100 and MiniMax M3's 83 tok/s/user
+ * defaults are reads, not clamps, on every other SKU.
  */
 import { metricsFor } from './overlay-fixtures';
 
 export const PROFIT_MODEL_DB_KEY = 'kimik3';
 export const PROFIT_GLM_DB_KEY = 'glm5.2';
+export const PROFIT_MINIMAX_DB_KEY = 'minimaxm3';
 /** `?model=` display key the benchmarks request carries → DB key of its rows. */
 const PROFIT_DB_KEY_BY_DISPLAY_MODEL: Record<string, string> = {
   'Kimi-K3': PROFIT_MODEL_DB_KEY,
   'GLM-5.2': PROFIT_GLM_DB_KEY,
+  'MiniMax-M3': PROFIT_MINIMAX_DB_KEY,
 };
 const PROFIT_DB_KEYS = Object.values(PROFIT_DB_KEY_BY_DISPLAY_MODEL);
 export const PROFIT_DATE = '2026-08-31';

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -84,7 +84,8 @@ describe('sitemap locale parity', () => {
       for (const route of MODEL_ROUTES) {
         // The default model's page canonicalizes to the bare tab path, which
         // the dashboard-route loop above already covers. Models a tab does not
-        // serve (the profit estimator is Kimi K3 and GLM 5.2/5.3 only) 404 and stay out.
+        // serve (the profit estimator is Kimi K3, GLM 5.2/5.3 and MiniMax M3
+        // only) 404 and stay out.
         const expected = served.has(route.model) && route.model !== defaultRouteModel(tab);
         const enPath = modelRoutePath(tab, route.slug);
         expect(urls.has(`${SITE_URL}${enPath}`)).toBe(expected);

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -455,8 +455,8 @@ function ProfitEstimatorInner({
   const { selectedRunDate } = useGlobalFilterRun();
   const { availableModels, availabilityRows } = useGlobalFilterAvailability();
   // This page is agentic only: the sequence is pinned, and the model list is
-  // the tab's route allow-list (Kimi K3 and GLM 5.2/5.3) intersected with the models
-  // that have an agentic-traces run, so the selector never offers a model
+  // the tab's route allow-list (Kimi K3, GLM 5.2/5.3, MiniMax M3) intersected
+  // with the models that have an agentic-traces run, so the selector never offers a model
   // that would draw an empty chart. If the intersection is still loading or
   // empty, the allow-list alone is offered so the selector is never blank.
   const selectedSequence = Sequence.AgenticTraces;
@@ -494,8 +494,9 @@ function ProfitEstimatorInner({
   const [targetRaw, setTargetRaw] = useState<string>(() => String(targetValue));
   // Each model has its own operating point and price source (Kimi K3: 45
   // tok/s/user on OpenRouter; GLM 5.2/5.3: 100 tok/s/user on the Z.ai list
-  // price), so a model switch re-seeds both. The ref keeps this to actual
-  // switches: re-renders with the same model leave the reader's edits alone.
+  // price; MiniMax M3: 83 tok/s/user on the MiniMax list price), so a model
+  // switch re-seeds both. The ref keeps this to actual switches: re-renders
+  // with the same model leave the reader's edits alone.
   const defaultsAppliedFor = useRef<Model>(selectedModel);
   useEffect(() => {
     if (defaultsAppliedFor.current === selectedModel) return;

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -71,7 +71,6 @@ import { getDisplayLabel } from '@/lib/utils';
 
 import {
   clampPercent,
-  DEFAULT_LAB_CUT_PCT,
   DEFAULT_UTILIZATION_PCT,
   estimateProfitRows,
   listPricingToTokenRevenuePricing,
@@ -411,6 +410,10 @@ export default function ProfitEstimatorDisplay({
 function usePercentField(defaultValue: number, eventName: string) {
   const [raw, setRaw] = useState(String(defaultValue));
   const [value, setValue] = useState(defaultValue);
+  const reset = useCallback((next: number) => {
+    setRaw(String(next));
+    setValue(next);
+  }, []);
   const onChange = useCallback(
     (next: string) => {
       setRaw(next);
@@ -426,7 +429,7 @@ function usePercentField(defaultValue: number, eventName: string) {
     setRaw(String(clamped));
     track(eventName, { value: clamped });
   }, [raw, defaultValue, eventName]);
-  return { raw, value, onChange, onBlur };
+  return { raw, value, onChange, onBlur, reset };
 }
 
 function ProfitEstimatorInner({
@@ -492,12 +495,19 @@ function ProfitEstimatorInner({
     () => profitModelDefaults(selectedModel).interactivity,
   );
   const [targetRaw, setTargetRaw] = useState<string>(() => String(targetValue));
-  // Each model has its own operating point and price source (Kimi K3: 45
-  // tok/s/user on OpenRouter; GLM 5.2/5.3: 100 tok/s/user on the Z.ai list
-  // price; MiniMax M3: 83 tok/s/user on the MiniMax list price), so a model
-  // switch re-seeds both. The ref keeps this to actual switches: re-renders
-  // with the same model leave the reader's edits alone.
+  const utilization = usePercentField(DEFAULT_UTILIZATION_PCT, 'profit_utilization_set');
+  const labCut = usePercentField(
+    profitModelDefaults(selectedModel).labCutPct,
+    'profit_lab_cut_set',
+  );
+  // Each model has its own operating point, price source, and license fee
+  // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
+  // on the Z.ai list price at 30%; MiniMax M3: 83 tok/s/user on the MiniMax
+  // list price at 20%), so a model switch re-seeds all three. The ref keeps
+  // this to actual switches: re-renders with the same model leave the
+  // reader's edits alone.
   const defaultsAppliedFor = useRef<Model>(selectedModel);
+  const resetLabCut = labCut.reset;
   useEffect(() => {
     if (defaultsAppliedFor.current === selectedModel) return;
     defaultsAppliedFor.current = selectedModel;
@@ -505,7 +515,8 @@ function ProfitEstimatorInner({
     setTargetValue(defaults.interactivity);
     setTargetRaw(String(defaults.interactivity));
     setPriceSource(defaultPriceSource(selectedModel));
-  }, [selectedModel]);
+    resetLabCut(defaults.labCutPct);
+  }, [selectedModel, resetLabCut]);
   const listPricing = profitModelDefaults(selectedModel).listPricing;
   // A model without a list price cannot stay on 'list' (e.g. the route seeded
   // one model and the allow-list swapped it); fall back to the catalog.
@@ -513,8 +524,6 @@ function ProfitEstimatorInner({
     priceSource === 'list' && !listPricing ? 'openrouter' : priceSource;
   const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
   const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
-  const utilization = usePercentField(DEFAULT_UTILIZATION_PCT, 'profit_utilization_set');
-  const labCut = usePercentField(DEFAULT_LAB_CUT_PCT, 'profit_lab_cut_set');
 
   const { hardwareConfig, getResults, loading, error, hasData, availableHwKeys } =
     useThroughputData(

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -5,6 +5,7 @@ import { Model } from '@/lib/data-mappings';
 
 import {
   clampPercent,
+  DEFAULT_LAB_CUT_PCT,
   DEFAULT_PROFIT_INTERACTIVITY,
   estimateProfitRows,
   estimateSkuProfit,
@@ -330,16 +331,18 @@ describe('parseTokenPriceInput', () => {
 });
 
 describe('profitModelDefaults', () => {
-  it('opens Kimi K3 on 45 tok/s/user and the OpenRouter catalog', () => {
+  it('opens Kimi K3 on 45 tok/s/user, the OpenRouter catalog, and a 30% license fee', () => {
     expect(profitModelDefaults(Model.Kimi_K3)).toEqual({
       interactivity: DEFAULT_PROFIT_INTERACTIVITY,
       listPricing: null,
+      labCutPct: DEFAULT_LAB_CUT_PCT,
     });
   });
 
   it('opens GLM 5.2/5.3 on 100 tok/s/user and the Z.ai list price', () => {
     const defaults = profitModelDefaults(Model.GLM_5_2);
     expect(defaults.interactivity).toBe(100);
+    expect(defaults.labCutPct).toBe(DEFAULT_LAB_CUT_PCT);
     expect(defaults.listPricing).toEqual({
       vendor: 'Z.ai',
       inputPerMillion: 1.4,
@@ -349,9 +352,10 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('opens MiniMax M3 on 83 tok/s/user and the MiniMax list price', () => {
+  it('opens MiniMax M3 on 83 tok/s/user, the MiniMax list price, and a 20% license fee', () => {
     const defaults = profitModelDefaults(Model.MiniMax_M3);
     expect(defaults.interactivity).toBe(83);
+    expect(defaults.labCutPct).toBe(20);
     expect(defaults.listPricing).toEqual({
       vendor: 'MiniMax',
       inputPerMillion: 0.3,
@@ -367,10 +371,11 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('falls back to 45 tok/s/user and OpenRouter for models without an entry', () => {
+  it('falls back to 45 tok/s/user, OpenRouter, and a 30% license fee for models without an entry', () => {
     expect(profitModelDefaults(Model.DeepSeek_V4_Pro)).toEqual({
       interactivity: DEFAULT_PROFIT_INTERACTIVITY,
       listPricing: null,
+      labCutPct: DEFAULT_LAB_CUT_PCT,
     });
   });
 

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -349,6 +349,24 @@ describe('profitModelDefaults', () => {
     });
   });
 
+  it('opens MiniMax M3 on 83 tok/s/user and the MiniMax list price', () => {
+    const defaults = profitModelDefaults(Model.MiniMax_M3);
+    expect(defaults.interactivity).toBe(83);
+    expect(defaults.listPricing).toEqual({
+      vendor: 'MiniMax',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.06,
+      outputPerMillion: 1.2,
+      sourceUrl: 'https://platform.minimax.io/docs/guides/pricing-paygo',
+    });
+    expect(listPricingToTokenRevenuePricing(defaults.listPricing!)).toEqual({
+      source: 'normalized',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.06,
+      outputPerMillion: 1.2,
+    });
+  });
+
   it('falls back to 45 tok/s/user and OpenRouter for models without an entry', () => {
     expect(profitModelDefaults(Model.DeepSeek_V4_Pro)).toEqual({
       interactivity: DEFAULT_PROFIT_INTERACTIVITY,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -31,6 +31,8 @@ export const HOURS_PER_YEAR = 8_760;
 const KW_PER_GW = 1_000_000;
 
 export const DEFAULT_PROFIT_INTERACTIVITY = 45;
+/** Share of revenue paid to the model lab. */
+export const DEFAULT_LAB_CUT_PCT = 30;
 
 /**
  * A lab's published API price, offered as a Token Price source next to the
@@ -53,6 +55,8 @@ export interface ProfitModelDefaults {
   interactivity: number;
   /** Lab list price; when present the page opens on it instead of OpenRouter. */
   listPricing: ProfitListPricing | null;
+  /** Model license fee (% of revenue) the page opens on for this model. */
+  labCutPct: number;
 }
 
 /**
@@ -67,12 +71,18 @@ export interface ProfitModelDefaults {
  * aggregate also sits below it, and on 83 tok/s/user, the speed MiniMax's own
  * API serves at; the B200/B300/GB200/MI355X agentic curves all cover that
  * point, and the Hopper and MI300-series curves top out below it and list as
- * not priced.
+ * not priced. MiniMax M3 also opens on a 20% model license fee instead of the
+ * 30% the other models assume.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
-  [Model.Kimi_K3]: { interactivity: DEFAULT_PROFIT_INTERACTIVITY, listPricing: null },
+  [Model.Kimi_K3]: {
+    interactivity: DEFAULT_PROFIT_INTERACTIVITY,
+    listPricing: null,
+    labCutPct: DEFAULT_LAB_CUT_PCT,
+  },
   [Model.GLM_5_2]: {
     interactivity: 100,
+    labCutPct: DEFAULT_LAB_CUT_PCT,
     listPricing: {
       vendor: 'Z.ai',
       inputPerMillion: 1.4,
@@ -83,6 +93,7 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   },
   [Model.MiniMax_M3]: {
     interactivity: 83,
+    labCutPct: 20,
     listPricing: {
       vendor: 'MiniMax',
       inputPerMillion: 0.3,
@@ -96,9 +107,10 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
 const FALLBACK_MODEL_DEFAULTS: ProfitModelDefaults = {
   interactivity: DEFAULT_PROFIT_INTERACTIVITY,
   listPricing: null,
+  labCutPct: DEFAULT_LAB_CUT_PCT,
 };
 
-/** Defaults for `model`; models without an entry get 45 tok/s/user and OpenRouter. */
+/** Defaults for `model`; models without an entry get 45 tok/s/user, OpenRouter, and a 30% license fee. */
 export function profitModelDefaults(model: Model): ProfitModelDefaults {
   return PROFIT_MODEL_DEFAULTS[model] ?? FALLBACK_MODEL_DEFAULTS;
 }
@@ -115,8 +127,6 @@ export function listPricingToTokenRevenuePricing(list: ProfitListPricing): Token
 
 /** Fraction of benchmarked throughput that is actually sold. */
 export const DEFAULT_UTILIZATION_PCT = 60;
-/** Share of revenue paid to the model lab. */
-export const DEFAULT_LAB_CUT_PCT = 30;
 
 /**
  * Denominator every figure is expressed in. `/profit-estimator` is per chip-hour;

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -61,7 +61,13 @@ export interface ProfitModelDefaults {
  * ($1.40 / $0.26 cached / $4.40 per M tok) because third-party hosts undercut
  * it on OpenRouter, and on 100 tok/s/user: Z.ai serves at 48 tok/s/user, but
  * no priced SKU has a measured point that low yet, so the nearest round
- * operating point every curve covers is used until one does.
+ * operating point every curve covers is used until one does. MiniMax M3 opens
+ * on MiniMax's standard list price for <=512K-token calls ($0.30 / $0.06
+ * cached / $1.20 per M tok, the permanent 50%-off rate) because the OpenRouter
+ * aggregate also sits below it, and on 83 tok/s/user, the speed MiniMax's own
+ * API serves at; the B200/B300/GB200/MI355X agentic curves all cover that
+ * point, and the Hopper and MI300-series curves top out below it and list as
+ * not priced.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   [Model.Kimi_K3]: { interactivity: DEFAULT_PROFIT_INTERACTIVITY, listPricing: null },
@@ -73,6 +79,16 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
       cachedInputPerMillion: 0.26,
       outputPerMillion: 4.4,
       sourceUrl: 'https://docs.z.ai/guides/overview/pricing',
+    },
+  },
+  [Model.MiniMax_M3]: {
+    interactivity: 83,
+    listPricing: {
+      vendor: 'MiniMax',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.06,
+      outputPerMillion: 1.2,
+      sourceUrl: 'https://platform.minimax.io/docs/guides/pricing-paygo',
     },
   },
 };

--- a/packages/app/src/lib/model-routes.test.ts
+++ b/packages/app/src/lib/model-routes.test.ts
@@ -183,13 +183,19 @@ describe('modelRoutePathnameRewrite', () => {
 });
 
 describe('modelRoutesForTab', () => {
-  it('serves Kimi K3 and GLM 5.2/5.3 on the profit estimators and every model elsewhere', () => {
+  it('serves Kimi K3, GLM 5.2/5.3 and MiniMax M3 on the profit estimators and every model elsewhere', () => {
     for (const tab of ['profit-estimator', 'profit-estimator-per-gigawatt'] as const) {
+      // `MODEL_ROUTES` order (the dashboard selector's), not allow-list order.
       expect(modelRoutesForTab(tab).map((route) => route.model)).toEqual([
         Model.Kimi_K3,
+        Model.MiniMax_M3,
         Model.GLM_5_2,
       ]);
       expect(modelRouteAvailableForTab(tab, Model.GLM_5_2)).toBe(true);
+      expect(modelRouteAvailableForTab(tab, Model.MiniMax_M3)).toBe(true);
+      expect(modelRoutesForTab(tab).find((route) => route.model === Model.MiniMax_M3)?.slug).toBe(
+        'minimax-m3',
+      );
       // GLM 5.2 and 5.3 share one data bucket; the slug follows the current
       // release, as on the rest of the site, and `glm-5-2` 308s to it.
       expect(modelRoutesForTab(tab).find((route) => route.model === Model.GLM_5_2)?.slug).toBe(

--- a/packages/app/src/lib/model-routes.ts
+++ b/packages/app/src/lib/model-routes.ts
@@ -71,10 +71,10 @@ export function defaultRouteModel(tab: ModelRouteTab): Model {
 /**
  * Tabs that expose only a subset of `MODEL_ROUTES`. The profit estimators
  * serve the agentic models whose coverage spans every SKU we price: Kimi K3
- * (the default) and GLM 5.2/5.3. Other slugs 404 there and stay out of the
- * sitemap. Tabs absent from this map offer every model.
+ * (the default), GLM 5.2/5.3, and MiniMax M3. Other slugs 404 there and stay
+ * out of the sitemap. Tabs absent from this map offer every model.
  */
-const PROFIT_ESTIMATOR_MODELS: readonly Model[] = [Model.Kimi_K3, Model.GLM_5_2];
+const PROFIT_ESTIMATOR_MODELS: readonly Model[] = [Model.Kimi_K3, Model.GLM_5_2, Model.MiniMax_M3];
 const MODEL_ROUTE_TAB_MODELS: Partial<Record<ModelRouteTab, readonly Model[]>> = {
   'profit-estimator': PROFIT_ESTIMATOR_MODELS,
   'profit-estimator-per-gigawatt': PROFIT_ESTIMATOR_MODELS,


### PR DESCRIPTION
## Summary

Adds MiniMax M3 (`MiniMax M3 428B`) to `/profit-estimator` and `/profit-estimator-per-gigawatt`, plus the `/zh` mirrors. Stacked on #1001 (GLM 5.2/5.3), which introduced `profitModelDefaults()` and the `<vendor> list price` option this PR reuses; the base retargets to `master` once #1001 merges.

- **Routes:** `/profit-estimator/minimax-m3` and `/profit-estimator-per-gigawatt/minimax-m3` (`PROFIT_ESTIMATOR_MODELS` in `model-routes.ts`). Kimi K3 stays the bare-path default; models outside the allow-list still 404 and stay out of the sitemap.
- **Per-model defaults** (`profitModelDefaults(Model.MiniMax_M3)`):
  - **83 tok/s/user**, the speed MiniMax's own API serves at.
  - **MiniMax list price $0.30 input / $0.06 cached / $1.20 output per M tok**, the standard tier for calls up to 512K input tokens on the [MiniMax pay-as-you-go page](https://platform.minimax.io/docs/guides/pricing-paygo) (shown there as the permanent 50%-off rate; the >512K tier and the Priority tier are 2x and 1.5x and not modelled). Pinned as a list price rather than read from OpenRouter for the same reason as GLM: the OpenRouter aggregate for `minimax/minimax-m3` sits below it ($0.23 / $0.05 / $0.96 on the [model page](https://openrouter.ai/minimax/minimax-m3)), so the catalog would understate what the lab charges. OpenRouter and Custom remain one click away; the caption links the MiniMax pricing page when the list price is in force.
- **Coverage at 83 tok/s/user** (checked against the live agentic rows): B200 TRT and vLLM, B300 TRT and vLLM, GB200 Dynamo-vLLM, and MI355X vLLM all have a measured point on both sides of 83, so they are priced. H100 (max 18), H200 (max 54), MI300X (max 30), and MI325X (max 32) top out below it and list under Not priced; the GB300 disagg curve starts at 99 and is skipped the same way. This is the existing clamp-skip behaviour, not new logic.
- **Model switch** re-seeds the interactivity target and price source in every direction (45/OpenRouter for Kimi, 100/list for GLM, 83/list for MiniMax).
- Docs: `docs/tco-calculator.md` profit-estimator section.

## Tests

- Unit (vitest): `profitModelDefaults(Model.MiniMax_M3)` and its list to revenue-pricing conversion; `modelRoutesForTab` now expects `[Kimi K3, MiniMax M3, GLM 5.2]` in `MODEL_ROUTES` (selector) order and the `minimax-m3` slug. `bun run typecheck`, `bun run lint`, `bun run fmt`, the typography check, and the calculator/routing/sitemap unit files pass locally. One pre-existing `benchmark-transform.test.ts` case fails in my sandbox on `Object.groupBy` (old Node) on the base branch too; unrelated.
- E2E (Cypress): fixtures now emit `minimaxm3` agentic rows alongside `kimik3` and `glm5.2`, keyed by the `?model=` the benchmarks intercept is asked for. New specs cover the `/minimax-m3` route defaults, caption, and pricing-source link; the 3-option price selector (OpenRouter reads the MiniMax row, not Kimi's); Custom seeding from the list price; GLM to MiniMax to Kimi model-switch re-seeding with the expected pathnames; and the `/zh` mirror label (`MiniMax 官方定价`). The Kimi selector assertion now expects three models. I could not run Cypress in my sandbox, so please rely on CI for the e2e run.

## 中文说明

在 `/profit-estimator` 与 `/profit-estimator-per-gigawatt`（含 `/zh` 镜像）新增 MiniMax M3（`MiniMax M3 428B`），路径为 `/minimax-m3`。本 PR 叠加在 #1001（GLM 5.2/5.3）之上，复用其 `profitModelDefaults()` 与"厂商官方定价"选项；#1001 合并后基准分支会自动切换到 `master`。Kimi K3 仍为默认模型，其他模型继续返回 404。

- **按模型的默认值**：MiniMax M3 默认 **83 tok/s/user**（MiniMax 官方 API 的实际服务速度），并采用 **MiniMax 官方定价：输入 $0.30 / 缓存输入 $0.06 / 输出 $1.20（每百万 token）**，即[按量付费页面](https://platform.minimax.io/docs/guides/pricing-paygo)上 ≤512K 输入的标准档（长期 5 折价；>512K 与 Priority 档未建模）。与 GLM 相同，不直接读取 OpenRouter 的原因是其聚合价（约 $0.23 / $0.05 / $0.96）低于官方价，会低估实验室的实际收入；OpenRouter 与自定义仍可一键切换，使用官方定价时图表说明会链接 MiniMax 定价页。
- **83 tok/s/user 处的覆盖**（对照线上 agentic 数据）：B200（TRT、vLLM）、B300（TRT、vLLM）、GB200 Dynamo-vLLM、MI355X vLLM 均有实测点覆盖，可计价；H100、H200、MI300X、MI325X 曲线上限低于该点，GB300 分离式曲线起点为 99，均按现有逻辑列为"未计价"。
- **切换模型**时会重置交互性目标与价格来源。
- 同步更新 `docs/tco-calculator.md`。

**测试**：新增 vitest 单元测试（默认值、官方定价换算、路由白名单与 slug）；Cypress fixture 新增 `minimaxm3` agentic 数据并按 `?model=` 参数返回，新增 MiniMax 路由默认值、价格来源选择器、自定义价格初始化、GLM → MiniMax → Kimi 切换重置与中文镜像的 e2e 用例。本地已通过 typecheck / lint / fmt / typography 与相关单元测试；沙箱中无法运行 Cypress，请以 CI 结果为准。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Extends an existing profit-estimator model allow-list and default seeding with tests and docs; no auth, payment, or core calculation logic changes beyond new default constants.
> 
> **Overview**
> Adds **MiniMax M3** to `/profit-estimator` and `/profit-estimator-per-gigawatt` (plus `/minimax-m3` routes and sitemap coverage), alongside Kimi K3 and GLM 5.2/5.3.
> 
> **Per-model defaults** in `profitModelDefaults()` now include **`labCutPct`** as well as interactivity and price source. MiniMax M3 opens on **83 tok/s/user**, **MiniMax list price** ($0.30 / $0.06 cached / $1.20 per M tok) with a caption link to MiniMax pay-as-you-go pricing, and a **20%** model license fee (others stay at **30%**). Switching models in `ProfitEstimatorDisplay` **re-seeds** target interactivity, token price source, and license fee via a new `reset` on the percent-field hook.
> 
> Routing allow-list (`PROFIT_ESTIMATOR_MODELS`), docs (`docs/tco-calculator.md`), Cypress fixtures (`minimaxm3` agentic rows), and vitest/sitemap tests are updated to match; new e2e coverage asserts defaults, price-source options, GLM→MiniMax→Kimi resets, and Chinese mirror labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db295fd04940f603430ef06711ddcccae718037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->