### PR TITLE
Update utilization tooltip copy on profit estimator pages

### DIFF
--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -153,7 +153,7 @@ const STRINGS = {
       `The ${percentile} interactivity operating point used for agentic workload interpolation.`,
     utilizationLabel: 'Utilization (%)',
     utilizationTooltip:
-      'Share of benchmarked throughput that is actually sold. 60% means the fleet bills 60% of the tokens it could produce. Revenue scales with it; compute expense does not, since the chips are paid for whether or not they are busy.',
+      'Utilization % factors in the swings & dips of token traffic throughout day & night in addition to efficiency losses of scaling out large scale deployments.',
     labCutLabel: 'Model License Fee (%)',
     labCutTooltip:
       'Share of revenue paid to the model lab as a license fee on every token sold. It is owed even when compute alone exceeds revenue, so the operator can show a loss.',
@@ -241,7 +241,7 @@ const STRINGS = {
       `用于智能体工作负载插值的 ${percentile} 交互性操作点。`,
     utilizationLabel: '利用率 (%)',
     utilizationTooltip:
-      '实际售出的基准吞吐量比例。60% 表示集群只计费其可产出 token 的 60%。收入随之缩放；算力支出不变，因为芯片无论忙闲都要付费。',
+      '利用率 % 考虑了 token 流量在昼夜间的起伏波动，以及大规模部署横向扩展时的效率损失。',
     labCutLabel: '模型许可费（%）',
     labCutTooltip:
       '每售出一个 token 以许可费形式支付给模型实验室的收入比例。即使算力支出已超过收入也需支付，因此运营方可能亏损。',


### PR DESCRIPTION
Replaces the Utilization (%) tooltip text in `ProfitEstimatorDisplay` (shared by `/profit-estimator` and `/profit-estimator-per-gigawatt`, incl. `/zh` routes) with:

> Utilization % factors in the swings & dips of token traffic throughout day & night in addition to efficiency losses of scaling out large scale deployments.

The zh string is updated to match. Formatter check passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only string changes in UI tooltips with no calculation or behavior changes.
> 
> **Overview**
> Updates the **Utilization (%)** field tooltip in `ProfitEstimatorDisplay` so it no longer describes sold share of benchmarked throughput vs. fixed compute cost.
> 
> The new English copy explains that utilization reflects **day/night traffic swings** and **efficiency losses when scaling large deployments**. The matching **zh** string is updated in parallel. Both `/profit-estimator` and `/profit-estimator-per-gigawatt` (including localized routes) pick up the change via the shared component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4148e766d47849825e387f557c3e83bd53204c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->