### PR TITLE
Rename subtitle label to "Model License Fee Assumption" on profit estimator pages

### DIFF
--- a/packages/app/src/components/ui/result-context.test.tsx
+++ b/packages/app/src/components/ui/result-context.test.tsx
@@ -77,14 +77,14 @@ describe('ResultContext', () => {
       createRoot(en).render(<ResultContext locale="en" utilization="60%" licenseFee="30%" />);
     });
     expect(en.textContent).toContain('Utilization: 60%');
-    expect(en.textContent).toContain('Model License Fee: 30%');
+    expect(en.textContent).toContain('Model License Fee Assumption: 30%');
     expect(en.querySelector('[data-testid="result-context-license-fee"]')?.textContent).toBe('30%');
     const zh = document.createElement('div');
     act(() => {
       createRoot(zh).render(<ResultContext locale="zh" utilization="60%" licenseFee="30%" />);
     });
     expect(zh.textContent).toContain('利用率: 60%');
-    expect(zh.textContent).toContain('模型许可费: 30%');
+    expect(zh.textContent).toContain('模型许可费假设: 30%');
   });
 
   it('localizes the Cost Tier label', () => {

--- a/packages/app/src/components/ui/result-context.tsx
+++ b/packages/app/src/components/ui/result-context.tsx
@@ -54,7 +54,7 @@ export function ResultContext({
           cost: '成本口径',
           costTier: '成本层级',
           utilization: '利用率',
-          licenseFee: '模型许可费',
+          licenseFee: '模型许可费假设',
         }
       : {
           model: 'Model',
@@ -68,7 +68,7 @@ export function ResultContext({
           cost: 'Cost basis',
           costTier: 'Cost Tier',
           utilization: 'Utilization',
-          licenseFee: 'Model License Fee',
+          licenseFee: 'Model License Fee Assumption',
         };
   const hasRange = Boolean(dateRange?.start && dateRange.end);
   const selectedDates = dates && dates.length > 1 ? dates.join(', ') : date;


### PR DESCRIPTION
## Summary
The result-context subtitle on `/profit-estimator` and `/profit-estimator-per-gigawatt` read `Model License Fee: 20%`. It now reads `Model License Fee Assumption: 20%` to make clear the value is a user-set assumption rather than a measured figure.

- `ResultContext` en label: `Model License Fee` → `Model License Fee Assumption`
- zh label updated for parity: `模型许可费` → `模型许可费假设`
- Unit test expectations updated to match

The `data-testid="result-context-license-fee"` selector is unchanged, so Cypress specs are unaffected. The chart legend and the input label (`Model License Fee (%)`) are intentionally left as-is.

## Verification
- `vitest run src/components/ui/result-context.test.tsx` — 6 passed
- `oxfmt --check` on both files — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only localization in a shared UI component; no logic, APIs, or test selectors changed.
> 
> **Overview**
> Updates the **`ResultContext`** subtitle copy so the license-fee line reads as an **assumption**, not a fixed fact—e.g. `Model License Fee Assumption: 20%` on profit estimator result charts.
> 
> English label **`Model License Fee`** → **`Model License Fee Assumption`**; Chinese **`模型许可费`** → **`模型许可费假设`**. Only the displayed label strings change; the `licenseFee` prop and `data-testid="result-context-license-fee"` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02190dda10fdaf15878c419bbbe470b19ee69102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->