### PR TITLE
fix(profit): tighten space under x labels, drop formula note outline

### DIFF
--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -41,12 +41,14 @@ export interface ProfitSegment {
 }
 
 /**
- * Bottom and left margins leave room for x labels rotated 50° (the longest
- * SKU label is ≈32 chars, ≈190px at the sub-label size): 190·sin50° ≈ 146px
- * of height below the axis and 190·cos50° ≈ 122px of reach left of the first
- * tick.
+ * Base margins for slanted x labels. The bottom is only a floor for the
+ * shortest labels (tick, one line of text and a little air); `slantedMargins`
+ * grows both the bottom and the left from the actual label set, so a short
+ * label set does not leave a band of dead space between the axis and the
+ * formula note under the chart. The longest SKU label (≈32 chars, ≈190px at
+ * the sub-label size) rotated 50° needs ≈146px of drop and ≈122px of reach.
  */
-const CHART_MARGIN = { top: 12, right: 24, bottom: 172, left: 116 };
+const CHART_MARGIN = { top: 12, right: 24, bottom: 40, left: 116 };
 /** Bottom margin when the x labels stand upright on two lines (name / framework). */
 const X_LABEL_STACKED_BOTTOM = 64;
 /** Tallest the chart gets, on a viewport with room to spare. */
@@ -62,7 +64,7 @@ export const CHART_HEIGHT_MIN = 440;
 export const CHART_VIEWPORT_RESERVE = 260;
 /** Below this container width the chart uses the compact margins and height. */
 export const COMPACT_CHART_MAX_WIDTH = 640;
-const CHART_MARGIN_COMPACT = { top: 12, right: 8, bottom: 140, left: 64 };
+const CHART_MARGIN_COMPACT = { top: 12, right: 8, bottom: 40, left: 64 };
 export const CHART_HEIGHT_COMPACT = 560;
 
 /** Chart height for a viewport: as tall as `maxHeight`, but never taller than the space under the card header. */

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -309,7 +309,7 @@ const STRINGS = {
   },
 } as const;
 
-/** A bordered note under the chart that folds behind its title, like the metric notes on /inference. */
+/** A plain note under the chart that folds behind its title, like the metric notes on /inference. */
 function InfoFold({
   title,
   toggleLabel,
@@ -324,7 +324,7 @@ function InfoFold({
   // Collapsed by default; the formula is reference material, not the result.
   const [open, setOpen] = useState(false);
   return (
-    <div className="rounded-md border border-border px-3 py-2 text-xs" data-testid={testId}>
+    <div className="py-1 text-xs" data-testid={testId}>
       <button
         type="button"
         aria-expanded={open}
@@ -1160,7 +1160,7 @@ function ProfitEstimatorInner({
                 assumptions={assumptions}
                 caption={caption}
               />
-              <div className="mt-3">
+              <div className="mt-1">
                 <InfoFold
                   title={t.formulaTitle[basis]}
                   toggleLabel={t.formulaToggle}


### PR DESCRIPTION
## Summary
- The profit estimator chart no longer floors its bottom margin at the worst-case slanted-label drop (172px / 140px compact). The floor is now 40px and `slantedMargins` grows it from the actual label set, so short SKU labels stop leaving a band of dead space between the x axis and the formula note.
- The Revenue per Chip-Hour / per GigaWatt formula note loses its rounded outline and horizontal padding and sits flush under the chart; the gap above it goes from `mt-3` to `mt-1`.

## Checks
- `bun run fmt`, `bun run lint`, `bun run typecheck` clean (also via the lefthook pre-commit)
- `ProfitEstimatorChart.test.ts` (35 tests) passing; `slantedMargins` semantics unchanged, only the base floor moved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual spacing and presentation-only UI tweaks on the profit estimator; chart margin logic still grows for long slanted labels via `slantedMargins`.
> 
> **Overview**
> **Profit estimator chart layout** no longer uses a worst-case bottom margin (172px / 140px compact) as the default floor for slanted x-axis labels. The floor is **40px** in both layouts; **`slantedMargins`** still expands bottom and left from the real label set, so short SKU labels avoid a large empty band between the axis and the formula note below.
> 
> **Formula note styling** under the chart: **`InfoFold`** loses its rounded border and horizontal padding (plain text block with `py-1`), and the spacing above it shrinks from **`mt-3`** to **`mt-1`** so it sits closer to the chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2923123ed67b97ca60817e76d4db003c1e6d87cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->