### PR TITLE
feat(app): add DeepSeek V4 Pro to the profit estimators with DeepSeek list-price defaults / 利润估算器新增 DeepSeek V4 Pro 并默认采用 DeepSeek 官方定价

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1134,12 +1134,12 @@ and the two can be collapsed into one once both are on master.
   pay-as-you-go page); the OpenRouter aggregate also sits below it. At 83
   tok/s/user the B200, B300, GB200, and MI355X agentic curves are priced, and the
   H100, H200, MI300X, and MI325X curves top out below it and list as not priced.
-  MiniMax M3 also opens on a 20% model license fee; every other model opens on
-  the 30% `DEFAULT_LAB_CUT_PCT`. DeepSeek V4 Pro opens on 24 tok/s/user, the
-  speed DeepSeek's own API serves at, and DeepSeek's peak-hour list price for
+  GLM 5.2/5.3 opens on a 10% model license fee and MiniMax M3 on 20%; Kimi K3
+  opens on the 30% `DEFAULT_LAB_CUT_PCT`. DeepSeek V4 Pro opens on 24 tok/s/user,
+  the speed DeepSeek's own API serves at, DeepSeek's peak-hour list price for
   `deepseek-v4-pro-0813` ($1.32 input / $0.044 cached / $3.96 output per M tok;
-  the off-peak rate is half that, and the OpenRouter aggregate sits below both).
-  At 24 tok/s/user the B200, B300, and MI355X agentic curves are priced; the
+  the off-peak rate is half that, and the OpenRouter aggregate sits below both),
+  and a 5% model license fee. At 24 tok/s/user the B200, B300, and MI355X agentic curves are priced; the
   GB200, GB300, and H200 curves bottom out above it (their lowest measured
   points sit at roughly 40, 30, and 27 tok/s/user) and list as not priced until
   a lower-interactivity run lands. A

--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1107,15 +1107,17 @@ and the two can be collapsed into one once both are on master.
   no scenario selector and no precision selector (precision stays in auto mode, the
   densest measured run set). The interactivity target is a typed number in the same
   row as utilization and the license fee.
-- **Kimi K3, GLM 5.2/5.3, and MiniMax M3.** The model selector offers the tab's route allow-list
+- **Kimi K3, GLM 5.2/5.3, MiniMax M3, and DeepSeek V4 Pro.** The model selector offers the tab's route allow-list
   (`MODEL_ROUTE_TAB_MODELS['profit-estimator']` and
   `['profit-estimator-per-gigawatt']` in `model-routes.ts`) intersected with the
   models that have an agentic run. Each bare path opens on Kimi K3
   (`defaultRouteModel(tab)`); `/profit-estimator/kimi-k3` and
   `/profit-estimator-per-gigawatt/kimi-k3` are the same pages, `/glm-5-3` is the
   GLM 5.2/5.3 page (one data bucket, one slug, as on the rest of the site),
-  `/minimax-m3` is the MiniMax M3 page, aliases 308 to the canonical slug, and any
-  model outside the allow-list 404s. Widening
+  `/minimax-m3` is the MiniMax M3 page, `/deepseek-v4` is the DeepSeek V4 Pro
+  page (the app-wide default elsewhere, but a slugged page here since the bare
+  path is Kimi K3), aliases 308 to the canonical slug, and any model outside the
+  allow-list 404s. Widening
   the pages to more models is one list edit, a `profitModelDefaults` entry, and
   fixture rows.
 - **Per-model defaults.** `profitModelDefaults(model)` in `profit-estimator.ts`
@@ -1133,7 +1135,14 @@ and the two can be collapsed into one once both are on master.
   tok/s/user the B200, B300, GB200, and MI355X agentic curves are priced, and the
   H100, H200, MI300X, and MI325X curves top out below it and list as not priced.
   MiniMax M3 also opens on a 20% model license fee; every other model opens on
-  the 30% `DEFAULT_LAB_CUT_PCT`. A
+  the 30% `DEFAULT_LAB_CUT_PCT`. DeepSeek V4 Pro opens on 24 tok/s/user, the
+  speed DeepSeek's own API serves at, and DeepSeek's peak-hour list price for
+  `deepseek-v4-pro-0813` ($1.32 input / $0.044 cached / $3.96 output per M tok;
+  the off-peak rate is half that, and the OpenRouter aggregate sits below both).
+  At 24 tok/s/user the B200, B300, and MI355X agentic curves are priced; the
+  GB200, GB300, and H200 curves bottom out above it (their lowest measured
+  points sit at roughly 40, 30, and 27 tok/s/user) and list as not priced until
+  a lower-interactivity run lands. A
   model with a list price gets a third Token Price option, `<vendor> list
 price`, next to OpenRouter and Custom; the caption names the source in force and
   links the lab's pricing page when the list price is used. Switching to Custom

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -6,6 +6,8 @@
 //    re-seeds all three;
 //  - MiniMax M3 opens on 83 tok/s/user, the MiniMax list price, and a 20% license fee
 //    ($0.30 / $0.06 cached / $1.20);
+//  - DeepSeek V4 Pro opens on 24 tok/s/user and the DeepSeek peak list price
+//    ($1.32 / $0.044 cached / $3.96);
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
@@ -13,8 +15,9 @@
 //  - the OpenRouter catalog is the default price source and a custom triple
 //    (input, cached input, output) can replace it;
 //  - the workload is pinned to agentic traces, so there is no scenario or
-//    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3 and
-//    MiniMax M3 only, and the target interactivity is a typed number, not a slider;
+//    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3,
+//    MiniMax M3 and DeepSeek V4 Pro only, and the target interactivity is a
+//    typed number, not a slider;
 //  - the cost provider has a custom $/GPU/hr option with one input per chip;
 //  - the per-GW page opens on Owning at Large Hyperscaler Volume while the
 //    per chip-hour page opens on Rent - 3 Year Commit;
@@ -37,9 +40,9 @@ import {
 } from '../support/profit-fixtures';
 
 // Kimi K3 is the page default; the DeepSeek row proves the page prices the
-// routed model, not the first catalog entry. The GLM and MiniMax rows sit below
-// their labs' list prices, as the real aggregates do, so the spec can tell the
-// two sources apart.
+// routed model, not the first catalog entry. The GLM, MiniMax, and DeepSeek
+// rows sit below their labs' list prices, as the real aggregates do, so the
+// spec can tell the two sources apart.
 const OPENROUTER_MODELS = {
   data: [
     {
@@ -153,10 +156,11 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-precision-selector"]').should('not.exist');
     cy.get('[data-testid="profit-model-selector"]').should('contain.text', 'Kimi K3').click();
     cy.get('[role="option"]')
-      .should('have.length', 3)
+      .should('have.length', 4)
       .and('contain.text', 'Kimi K3')
       .and('contain.text', 'GLM5.2/GLM5.3')
-      .and('contain.text', 'MiniMax M3');
+      .and('contain.text', 'MiniMax M3')
+      .and('contain.text', 'DeepSeek V4 Pro');
     cy.get('body').type('{esc}');
     // Kimi K3 has no list price, so the selector offers the catalog and custom only.
     cy.get('button#profit-price-source').click();
@@ -636,7 +640,7 @@ describe('Profit Estimator per GW — per-model route', () => {
   });
 
   it('404s models the estimator does not serve yet', () => {
-    cy.request({ url: '/profit-estimator-per-gigawatt/deepseek-v4-pro', failOnStatusCode: false })
+    cy.request({ url: '/profit-estimator-per-gigawatt/deepseek-r1', failOnStatusCode: false })
       .its('status')
       .should('eq', 404);
     cy.request({ url: '/profit-estimator-per-gigawatt/not-a-model', failOnStatusCode: false })
@@ -839,6 +843,99 @@ describe('Profit Estimator — MiniMax M3', () => {
   });
 });
 
+describe('Profit Estimator — DeepSeek V4 Pro', () => {
+  beforeEach(() => {
+    stubOpenRouter();
+    cy.viewport(1280, 1000);
+  });
+
+  it('opens /profit-estimator/deepseek-v4 on 24 tok/s/user and the DeepSeek list price', () => {
+    cy.visit('/profit-estimator/deepseek-v4', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.location('pathname').should('eq', '/profit-estimator/deepseek-v4');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '30%');
+    cy.get('[data-testid="profit-caption"] h2').should(
+      'contain.text',
+      'DeepSeek V4 Pro 0813 1.6T Agentic Revenue & Profit Estimates per Chip per Hour at P90 24 tok/s/user Interactivity',
+    );
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $1.32')
+      .and('contain.text', 'Cached Input: $0.044')
+      .and('contain.text', 'Output: $3.96')
+      .and('contain.text', '(DeepSeek list price)');
+    cy.get('[data-testid="profit-list-price-source"]')
+      .should('have.attr', 'href', 'https://api-docs.deepseek.com/quick_start/pricing/')
+      .and('contain.text', 'DeepSeek');
+    // 24 tok/s/user sits inside every fixture curve, the short H200 one included,
+    // so all five SKUs are priced.
+    chart().find('image.bar-vendor-mark').should('have.length', 5);
+    chart().should('contain.text', 'H200');
+    cy.get('[data-testid="profit-pricing-notice"]').should('not.exist');
+
+    // The catalog stays one click away and reads the DeepSeek row, not Kimi's.
+    cy.get('button#profit-price-source').click();
+    cy.get('[role="option"]')
+      .should('have.length', 3)
+      .and('contain.text', 'OpenRouter')
+      .and('contain.text', 'DeepSeek list price')
+      .and('contain.text', 'Custom $/M tok');
+    cy.contains('[role="option"]', 'OpenRouter').click();
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.66')
+      .and('contain.text', 'Output: $1.98')
+      .and('contain.text', '(OpenRouter)');
+    cy.get('[data-testid="profit-list-price-source"]').should('not.exist');
+
+    // Custom seeds from the price in force, here the list price.
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'DeepSeek list price').click();
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'Custom $/M tok').click();
+    cy.get('[data-testid="profit-input-price"]').should('have.value', '1.32');
+    cy.get('[data-testid="profit-cached-price"]').should('have.value', '0.044');
+    cy.get('[data-testid="profit-output-price"]').should('have.value', '3.96');
+  });
+
+  it('re-seeds the operating point and price source when switching from Kimi K3', () => {
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'DeepSeek V4 Pro').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/deepseek-v4');
+    cy.get('[data-testid="profit-caption"] h2')
+      .should('contain.text', 'DeepSeek V4 Pro')
+      .and('contain.text', '24 tok/s/user');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $1.32')
+      .and('contain.text', '(DeepSeek list price)');
+
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'Kimi K3').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.6')
+      .and('contain.text', '(OpenRouter)');
+  });
+
+  it('serves the Chinese mirror with the list price named in Chinese', () => {
+    cy.visit('/zh/profit-estimator-per-gigawatt/deepseek-v4', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', '输入：$1.32')
+      .and('contain.text', 'DeepSeek 官方定价');
+    cy.get('button#profit-price-source').should('contain.text', 'DeepSeek 官方定价');
+  });
+});
+
 describe('Profit Estimator per GW — Chinese mirror', () => {
   it('renders /zh/profit-estimator-per-gigawatt with translated controls and caption', () => {
     stubOpenRouter();
@@ -912,7 +1009,7 @@ describe('Profit Estimator (per chip-hour)', () => {
       expect(response.status).to.eq(308);
       expect(response.headers.location).to.match(/\/profit-estimator\/kimi-k3$/u);
     });
-    cy.request({ url: '/profit-estimator/deepseek-v4-pro', failOnStatusCode: false })
+    cy.request({ url: '/profit-estimator/deepseek-r1', failOnStatusCode: false })
       .its('status')
       .should('eq', 404);
     stubOpenRouter();

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -6,8 +6,8 @@
 //    re-seeds all three;
 //  - MiniMax M3 opens on 83 tok/s/user, the MiniMax list price, and a 20% license fee
 //    ($0.30 / $0.06 cached / $1.20);
-//  - DeepSeek V4 Pro opens on 24 tok/s/user and the DeepSeek peak list price
-//    ($1.32 / $0.044 cached / $3.96);
+//  - DeepSeek V4 Pro opens on 24 tok/s/user, the DeepSeek peak list price
+//    ($1.32 / $0.044 cached / $3.96), and a 5% license fee;
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
@@ -854,8 +854,8 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
     chart().should('exist');
     cy.location('pathname').should('eq', '/profit-estimator/deepseek-v4');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
-    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '30%');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '5%');
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'DeepSeek V4 Pro 0813 1.6T Agentic Revenue & Profit Estimates per Chip per Hour at P90 24 tok/s/user Interactivity',
@@ -911,15 +911,18 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
       .should('contain.text', 'DeepSeek V4 Pro')
       .and('contain.text', '24 tok/s/user');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $1.32')
       .and('contain.text', '(DeepSeek list price)');
 
     cy.get('[data-testid="profit-model-selector"]').click();
     cy.contains('[role="option"]', 'Kimi K3').click();
-    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
+    // Leaving a per-model path rewrites to the target model's slug; only a
+    // fresh visit canonicalizes the default model to the bare path.
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/kimi-k3');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $0.6')
       .and('contain.text', '(OpenRouter)');

--- a/packages/app/cypress/support/profit-fixtures.ts
+++ b/packages/app/cypress/support/profit-fixtures.ts
@@ -1,6 +1,7 @@
 /**
  * Synthetic agentic rows for the `/profit-estimator` e2e spec, one identical
- * SKU set per model the estimator serves (Kimi K3, GLM 5.2/5.3, MiniMax M3).
+ * SKU set per model the estimator serves (Kimi K3, GLM 5.2/5.3, MiniMax M3,
+ * DeepSeek V4 Pro).
  *
  * The captured API fixtures carry no `agentic_traces` rows, and the estimator
  * is pinned to that workload, so the spec intercepts availability and
@@ -11,18 +12,22 @@
  * The H200 curve tops out below the 45 tok/s/user default on purpose: the page
  * must list it under "Not priced" rather than extrapolate a bar for it. The
  * wide curve reaches 130 tok/s/user so GLM's 100 and MiniMax M3's 83 tok/s/user
- * defaults are reads, not clamps, on every other SKU.
+ * defaults are reads, not clamps, on every other SKU. Both curves start below
+ * DeepSeek V4 Pro's 24 tok/s/user default, so every SKU, H200 included, is
+ * priced there.
  */
 import { metricsFor } from './overlay-fixtures';
 
 export const PROFIT_MODEL_DB_KEY = 'kimik3';
 export const PROFIT_GLM_DB_KEY = 'glm5.2';
 export const PROFIT_MINIMAX_DB_KEY = 'minimaxm3';
+export const PROFIT_DEEPSEEK_DB_KEY = 'dsv4';
 /** `?model=` display key the benchmarks request carries → DB key of its rows. */
 const PROFIT_DB_KEY_BY_DISPLAY_MODEL: Record<string, string> = {
   'Kimi-K3': PROFIT_MODEL_DB_KEY,
   'GLM-5.2': PROFIT_GLM_DB_KEY,
   'MiniMax-M3': PROFIT_MINIMAX_DB_KEY,
+  'DeepSeek-V4-Pro': PROFIT_DEEPSEEK_DB_KEY,
 };
 const PROFIT_DB_KEYS = Object.values(PROFIT_DB_KEY_BY_DISPLAY_MODEL);
 export const PROFIT_DATE = '2026-08-31';

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -84,8 +84,8 @@ describe('sitemap locale parity', () => {
       for (const route of MODEL_ROUTES) {
         // The default model's page canonicalizes to the bare tab path, which
         // the dashboard-route loop above already covers. Models a tab does not
-        // serve (the profit estimator is Kimi K3, GLM 5.2/5.3 and MiniMax M3
-        // only) 404 and stay out.
+        // serve (the profit estimator is Kimi K3, GLM 5.2/5.3, MiniMax M3 and
+        // DeepSeek V4 Pro only) 404 and stay out.
         const expected = served.has(route.model) && route.model !== defaultRouteModel(tab);
         const enPath = modelRoutePath(tab, route.slug);
         expect(urls.has(`${SITE_URL}${enPath}`)).toBe(expected);

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -530,10 +530,11 @@ function ProfitEstimatorInner({
   const { selectedRunDate } = useGlobalFilterRun();
   const { availableModels, availabilityRows } = useGlobalFilterAvailability();
   // This page is agentic only: the sequence is pinned, and the model list is
-  // the tab's route allow-list (Kimi K3, GLM 5.2/5.3, MiniMax M3) intersected
-  // with the models that have an agentic-traces run, so the selector never offers a model
-  // that would draw an empty chart. If the intersection is still loading or
-  // empty, the allow-list alone is offered so the selector is never blank.
+  // the tab's route allow-list (Kimi K3, GLM 5.2/5.3, MiniMax M3, DeepSeek V4
+  // Pro) intersected with the models that have an agentic-traces run, so the
+  // selector never offers a model that would draw an empty chart. If the
+  // intersection is still loading or empty, the allow-list alone is offered so
+  // the selector is never blank.
   const selectedSequence = Sequence.AgenticTraces;
   const agenticModels = useMemo(() => {
     const allowed = modelRoutesForTab(PROFIT_BASIS_TAB[basis]).map((route) => route.model);
@@ -577,7 +578,8 @@ function ProfitEstimatorInner({
   // Each model has its own operating point, price source, and license fee
   // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
   // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
-  // list price at 20%), so a model switch re-seeds all three. The ref keeps
+  // list price at 20%; DeepSeek V4 Pro: 24 tok/s/user on the DeepSeek list
+  // price at 5%), so a model switch re-seeds all three. The ref keeps
   // this to actual switches: re-renders with the same model leave the
   // reader's edits alone.
   const defaultsAppliedFor = useRef<Model>(selectedModel);

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -381,10 +381,10 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('opens DeepSeek V4 Pro on 24 tok/s/user, the DeepSeek peak list price, and a 30% license fee', () => {
+  it('opens DeepSeek V4 Pro on 24 tok/s/user, the DeepSeek peak list price, and a 5% license fee', () => {
     const defaults = profitModelDefaults(Model.DeepSeek_V4_Pro);
     expect(defaults.interactivity).toBe(24);
-    expect(defaults.labCutPct).toBe(DEFAULT_LAB_CUT_PCT);
+    expect(defaults.labCutPct).toBe(5);
     expect(defaults.listPricing).toEqual({
       vendor: 'DeepSeek',
       inputPerMillion: 1.32,

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -381,8 +381,27 @@ describe('profitModelDefaults', () => {
     });
   });
 
+  it('opens DeepSeek V4 Pro on 24 tok/s/user, the DeepSeek peak list price, and a 30% license fee', () => {
+    const defaults = profitModelDefaults(Model.DeepSeek_V4_Pro);
+    expect(defaults.interactivity).toBe(24);
+    expect(defaults.labCutPct).toBe(DEFAULT_LAB_CUT_PCT);
+    expect(defaults.listPricing).toEqual({
+      vendor: 'DeepSeek',
+      inputPerMillion: 1.32,
+      cachedInputPerMillion: 0.044,
+      outputPerMillion: 3.96,
+      sourceUrl: 'https://api-docs.deepseek.com/quick_start/pricing/',
+    });
+    expect(listPricingToTokenRevenuePricing(defaults.listPricing!)).toEqual({
+      source: 'normalized',
+      inputPerMillion: 1.32,
+      cachedInputPerMillion: 0.044,
+      outputPerMillion: 3.96,
+    });
+  });
+
   it('falls back to 45 tok/s/user, OpenRouter, and a 30% license fee for models without an entry', () => {
-    expect(profitModelDefaults(Model.DeepSeek_V4_Pro)).toEqual({
+    expect(profitModelDefaults(Model.DeepSeek_R1)).toEqual({
       interactivity: DEFAULT_PROFIT_INTERACTIVITY,
       listPricing: null,
       labCutPct: DEFAULT_LAB_CUT_PCT,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -72,9 +72,26 @@ export interface ProfitModelDefaults {
  * API serves at; the B200/B300/GB200/MI355X agentic curves all cover that
  * point, and the Hopper and MI300-series curves top out below it and list as
  * not priced. GLM 5.2/5.3 opens on a 10% model license fee and MiniMax M3 on
- * 20%, instead of the 30% the other models assume.
+ * 20%, instead of the 30% the other models assume. DeepSeek V4 Pro opens on
+ * DeepSeek's peak-hour list price ($1.32 / $0.044 cached / $3.96 per M tok;
+ * off-peak is half that) because third-party hosts undercut it on OpenRouter,
+ * on 24 tok/s/user, the speed DeepSeek's own API serves at, and on a 5% model
+ * license fee. The B200, B300, and MI355X agentic curves reach that point; the
+ * GB200, GB300, and H200 curves bottom out above it and list as not priced
+ * until a lower-interactivity run lands.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
+  [Model.DeepSeek_V4_Pro]: {
+    interactivity: 24,
+    labCutPct: 5,
+    listPricing: {
+      vendor: 'DeepSeek',
+      inputPerMillion: 1.32,
+      cachedInputPerMillion: 0.044,
+      outputPerMillion: 3.96,
+      sourceUrl: 'https://api-docs.deepseek.com/quick_start/pricing/',
+    },
+  },
   [Model.Kimi_K3]: {
     interactivity: DEFAULT_PROFIT_INTERACTIVITY,
     listPricing: null,

--- a/packages/app/src/lib/model-routes.test.ts
+++ b/packages/app/src/lib/model-routes.test.ts
@@ -183,10 +183,11 @@ describe('modelRoutePathnameRewrite', () => {
 });
 
 describe('modelRoutesForTab', () => {
-  it('serves Kimi K3, GLM 5.2/5.3 and MiniMax M3 on the profit estimators and every model elsewhere', () => {
+  it('serves Kimi K3, GLM 5.2/5.3, MiniMax M3 and DeepSeek V4 Pro on the profit estimators and every model elsewhere', () => {
     for (const tab of ['profit-estimator', 'profit-estimator-per-gigawatt'] as const) {
       // `MODEL_ROUTES` order (the dashboard selector's), not allow-list order.
       expect(modelRoutesForTab(tab).map((route) => route.model)).toEqual([
+        Model.DeepSeek_V4_Pro,
         Model.Kimi_K3,
         Model.MiniMax_M3,
         Model.GLM_5_2,
@@ -196,6 +197,10 @@ describe('modelRoutesForTab', () => {
       expect(modelRoutesForTab(tab).find((route) => route.model === Model.MiniMax_M3)?.slug).toBe(
         'minimax-m3',
       );
+      expect(modelRouteAvailableForTab(tab, Model.DeepSeek_V4_Pro)).toBe(true);
+      expect(
+        modelRoutesForTab(tab).find((route) => route.model === Model.DeepSeek_V4_Pro)?.slug,
+      ).toBe('deepseek-v4');
       // GLM 5.2 and 5.3 share one data bucket; the slug follows the current
       // release, as on the rest of the site, and `glm-5-2` 308s to it.
       expect(modelRoutesForTab(tab).find((route) => route.model === Model.GLM_5_2)?.slug).toBe(
@@ -207,7 +212,10 @@ describe('modelRoutesForTab', () => {
           route: expect.objectContaining({ slug: 'glm-5-3' }),
         }),
       );
-      expect(modelRouteAvailableForTab(tab, Model.DeepSeek_V4_Pro)).toBe(false);
+      // DeepSeek V4 Pro is the app-wide default but not the estimators'; its
+      // slugged page stays indexable there instead of folding into the bare path.
+      expect(defaultRouteModel(tab)).toBe(Model.Kimi_K3);
+      expect(modelRouteAvailableForTab(tab, Model.DeepSeek_R1)).toBe(false);
       expect(modelRouteAvailableForTab(tab, Model.GLM_5)).toBe(false);
     }
     for (const tab of ['calculator', 'historical'] as const) {

--- a/packages/app/src/lib/model-routes.ts
+++ b/packages/app/src/lib/model-routes.ts
@@ -71,10 +71,16 @@ export function defaultRouteModel(tab: ModelRouteTab): Model {
 /**
  * Tabs that expose only a subset of `MODEL_ROUTES`. The profit estimators
  * serve the agentic models whose coverage spans every SKU we price: Kimi K3
- * (the default), GLM 5.2/5.3, and MiniMax M3. Other slugs 404 there and stay
- * out of the sitemap. Tabs absent from this map offer every model.
+ * (the default), GLM 5.2/5.3, MiniMax M3, and DeepSeek V4 Pro. Other slugs 404
+ * there and stay out of the sitemap. Tabs absent from this map offer every
+ * model.
  */
-const PROFIT_ESTIMATOR_MODELS: readonly Model[] = [Model.Kimi_K3, Model.GLM_5_2, Model.MiniMax_M3];
+const PROFIT_ESTIMATOR_MODELS: readonly Model[] = [
+  Model.Kimi_K3,
+  Model.GLM_5_2,
+  Model.MiniMax_M3,
+  Model.DeepSeek_V4_Pro,
+];
 const MODEL_ROUTE_TAB_MODELS: Partial<Record<ModelRouteTab, readonly Model[]>> = {
   'profit-estimator': PROFIT_ESTIMATOR_MODELS,
   'profit-estimator-per-gigawatt': PROFIT_ESTIMATOR_MODELS,


### PR DESCRIPTION
## Summary

Adds DeepSeek V4 Pro (`DeepSeek V4 Pro 0813 1.6T`) to `/profit-estimator` and `/profit-estimator-per-gigawatt`, plus the `/zh` mirrors, following the pattern from #1001 (GLM 5.2/5.3) and #1002 (MiniMax M3).

- **Routes:** `/profit-estimator/deepseek-v4` and `/profit-estimator-per-gigawatt/deepseek-v4` (`PROFIT_ESTIMATOR_MODELS` in `model-routes.ts`; the slug is the site-wide `deepseek-v4` from the compare registry). Kimi K3 stays the bare-path default, so DeepSeek V4 Pro gets its own slugged, indexable page here even though it is the app-wide default elsewhere. Models outside the allow-list still 404 and stay out of the sitemap.
- **Per-model defaults** (`profitModelDefaults(Model.DeepSeek_V4_Pro)`):
  - **24 tok/s/user**, the speed DeepSeek's own API serves at.
  - **DeepSeek list price $1.32 input / $0.044 cached / $3.96 output per M tok**, the peak-hour rate for `deepseek-v4-pro-0813` on the [DeepSeek pricing page](https://api-docs.deepseek.com/quick_start/pricing/) (off-peak is 50% of that: $0.66 / $0.022 / $1.98). Pinned as a list price for the same reason as GLM and MiniMax: the OpenRouter aggregate for `deepseek/deepseek-v4-pro-0813` sits below even the off-peak rate (about $0.58 / $0.019 / $1.74 at time of writing), so the catalog would understate what the lab charges. OpenRouter and Custom remain one click away; the caption links the DeepSeek pricing page when the list price is in force.
  - **5% model license fee** (Kimi K3 stays on the 30% `DEFAULT_LAB_CUT_PCT`, GLM on 10%, MiniMax on 20%).
- **Coverage at 24 tok/s/user** (checked against the live agentic rows, P90): B200 (SGLang min 16.8, vLLM min 19.9), B300 (SGLang 22.4, vLLM 8.3), and MI355X (ATOM 10.8, SGLang 12.0, vLLM 4.3, MORI-SGLang disagg 23.5) all have a measured point on both sides of 24, so they are priced. GB200 Dynamo-vLLM (min 40.1), GB300 (Dynamo-SGLang disagg 29.6, Dynamo-TRT disagg 37.2, Dynamo-vLLM disagg 38.8), and H200 Dynamo-SGLang (min 26.5) bottom out above 24 and list under Not priced. This is the existing clamp-skip behaviour, not new logic; a lower-interactivity run on those SKUs will price them without a code change.
- **Model switch** re-seeds the interactivity target, price source, and license fee in every direction (45/OpenRouter/30% for Kimi, 100/list/10% for GLM, 83/list/20% for MiniMax, 24/list/5% for DeepSeek).
- Docs: `docs/tco-calculator.md` profit-estimator section.

## Tests

- Unit (vitest): `profitModelDefaults(Model.DeepSeek_V4_Pro)` and its list to revenue-pricing conversion; the fallback case now uses `Model.DeepSeek_R1` since DeepSeek V4 Pro has an entry. `modelRoutesForTab` expects `[DeepSeek V4 Pro, Kimi K3, MiniMax M3, GLM 5.2]` in `MODEL_ROUTES` (selector) order, the `deepseek-v4` slug, and Kimi K3 as the tab default. `bun run typecheck`, `bun run lint`, `bun run fmt`, the typography check, and the full vitest suite pass locally (the one pre-existing `benchmark-transform.test.ts` failure reproduces on `master` in my sandbox and is unrelated).
- E2E (Cypress): fixtures now emit `dsv4` agentic rows keyed by `?model=DeepSeek-V4-Pro`. Both fixture curves start below 24 tok/s/user, so the new spec asserts all five SKUs (H200 included) are priced there, unlike the 45/83/100 defaults where H200 is skipped. New specs cover the `/deepseek-v4` route defaults, caption, and pricing-source link; the 3-option price selector (OpenRouter reads the DeepSeek row at $0.66 / $1.98, not Kimi's); Custom seeding from the list price; Kimi to DeepSeek to Kimi model-switch re-seeding with the expected pathnames (switching back to Kimi lands on the slugged `/kimi-k3` path, matching the GLM and MiniMax specs, per the Bugbot note); and the `/zh` mirror label (`DeepSeek 官方定价`). The Kimi selector assertion now expects four models, and the "404s models the estimator does not serve" checks use `deepseek-r1` instead of the never-valid `deepseek-v4-pro` slug. I could not run Cypress in my sandbox, so please rely on CI for the e2e run.

## 中文说明

在 `/profit-estimator` 与 `/profit-estimator-per-gigawatt`（含 `/zh` 镜像）新增 DeepSeek V4 Pro（`DeepSeek V4 Pro 0813 1.6T`），路径为 `/deepseek-v4`，沿用 #1001（GLM 5.2/5.3）与 #1002（MiniMax M3）的模式。Kimi K3 仍为默认模型，其他模型继续返回 404。

- **按模型的默认值**：DeepSeek V4 Pro 默认 **24 tok/s/user**（DeepSeek 官方 API 的实际服务速度），并采用 **DeepSeek 官方定价：输入 $1.32 / 缓存输入 $0.044 / 输出 $3.96（每百万 token）**，即[官方定价页](https://api-docs.deepseek.com/quick_start/pricing/)上 `deepseek-v4-pro-0813` 的高峰时段价格（非高峰为 5 折：$0.66 / $0.022 / $1.98）。不直接读取 OpenRouter 的原因与 GLM、MiniMax 相同：其聚合价（约 $0.58 / $0.019 / $1.74）低于官方价（甚至低于非高峰价），会低估实验室的实际收入；OpenRouter 与自定义仍可一键切换，使用官方定价时图表说明会链接 DeepSeek 定价页。模型许可费默认 5%（Kimi K3 仍为 30%，GLM 为 10%，MiniMax 为 20%）。
- **24 tok/s/user 处的覆盖**（对照线上 agentic 数据，P90）：B200、B300、MI355X 均有实测点覆盖，可计价；GB200 Dynamo-vLLM（最低约 40）、GB300（最低约 30）、H200 Dynamo-SGLang（最低约 27）曲线下限高于该点，按现有逻辑列为"未计价"，待更低交互性的运行数据落地后无需改代码即可计价。
- **切换模型**时会重置交互性目标、价格来源与许可费。
- 同步更新 `docs/tco-calculator.md`。

**测试**：新增 vitest 单元测试（默认值、官方定价换算、路由白名单与 slug）；Cypress fixture 新增 `dsv4` agentic 数据并按 `?model=` 参数返回，新增 DeepSeek 路由默认值（含 H200 在 24 tok/s/user 下可计价）、价格来源选择器、自定义价格初始化、Kimi → DeepSeek → Kimi 切换重置与中文镜像的 e2e 用例。本地已通过 typecheck / lint / fmt / typography 与完整单元测试；沙箱中无法运行 Cypress，请以 CI 结果为准。
