### PR TITLE
feat(embed): /embed/model/[slug] chart route with vLLM framework lock / 新增可嵌入模型图表路由并支持框架锁定

### DIFF
--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -291,6 +291,7 @@ export function createMockInferenceContextValues(
     setActivePresetId: namedStub('setActivePresetId'),
     presetGuardRef: { current: false } as React.RefObject<boolean>,
     compareGpuPair: null,
+    lockedFrameworks: null,
     ...overrides,
   };
 }

--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -292,6 +292,7 @@ export function createMockInferenceContextValues(
     presetGuardRef: { current: false } as React.RefObject<boolean>,
     compareGpuPair: null,
     lockedFrameworks: null,
+    minimalChrome: false,
     ...overrides,
   };
 }

--- a/packages/app/src/app/embed/layout.tsx
+++ b/packages/app/src/app/embed/layout.tsx
@@ -1,18 +1,18 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
-import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+import EmbedShell from '@/components/embed/EmbedShell';
 
 /**
  * Embed shell. Embeds are fragments meant to live inside another site's
  * iframe, so they are kept out of search indexes; the host page is the
- * canonical surface. `UnofficialRunProvider` is required by the dashboard's
- * filter contexts (same dependency `/model` satisfies in its layout).
+ * canonical surface. `EmbedShell` loads the skin fonts and the providers the
+ * dashboard needs.
  */
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
 export default function EmbedLayout({ children }: { children: ReactNode }) {
-  return <UnofficialRunProvider>{children}</UnofficialRunProvider>;
+  return <EmbedShell>{children}</EmbedShell>;
 }

--- a/packages/app/src/app/embed/layout.tsx
+++ b/packages/app/src/app/embed/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
+import EmbedBoot from '@/components/embed/EmbedBoot';
 import EmbedShell from '@/components/embed/EmbedShell';
 
 /**
@@ -14,5 +15,10 @@ export const metadata: Metadata = {
 };
 
 export default function EmbedLayout({ children }: { children: ReactNode }) {
-  return <EmbedShell>{children}</EmbedShell>;
+  return (
+    <>
+      <EmbedBoot />
+      <EmbedShell>{children}</EmbedShell>
+    </>
+  );
 }

--- a/packages/app/src/app/embed/layout.tsx
+++ b/packages/app/src/app/embed/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+
+/**
+ * Embed shell. Embeds are fragments meant to live inside another site's
+ * iframe, so they are kept out of search indexes; the host page is the
+ * canonical surface. `UnofficialRunProvider` is required by the dashboard's
+ * filter contexts (same dependency `/model` satisfies in its layout).
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function EmbedLayout({ children }: { children: ReactNode }) {
+  return <UnofficialRunProvider>{children}</UnofficialRunProvider>;
+}

--- a/packages/app/src/app/embed/model/[slug]/page.tsx
+++ b/packages/app/src/app/embed/model/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from 'next';
+
+import EmbedModelPage, { type EmbedSearchParams } from '@/components/embed/EmbedModelPage';
+import { getCompareModelBySlug } from '@/lib/compare-slug';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<EmbedSearchParams>;
+}
+
+/**
+ * Embeddable single-model chart: `/embed/model/<slug>?framework=vllm`.
+ *
+ * Query options are documented on `parseEmbedOptions` in `@/lib/embed`. The
+ * route is rendered per request because the framework lock, theme, and
+ * scenario come from the query string.
+ */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getCompareModelBySlug(slug);
+  return {
+    title: entry ? `${entry.label} — InferenceX embed` : 'InferenceX embed',
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function EmbedModelRoute({ params, searchParams }: Props) {
+  const [{ slug }, query] = await Promise.all([params, searchParams]);
+  return <EmbedModelPage slug={slug} searchParams={query} locale="en" />;
+}

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -381,6 +381,14 @@
   display: none;
 }
 
+/* Embed routes (/embed/model/[slug]) render one chart inside a third-party
+ * iframe. The decorative backgrounds would show through as noise behind the
+ * host page's own layout, so they are dropped; the attribute is set by
+ * EmbedFrame on mount. */
+html[data-inferencex-embed] .circuit-bg {
+  display: none;
+}
+
 /* Ender-dragon fly-across — one-shot animation on minecraft theme activation,
  * triggered from minecraft-decorations.tsx. Plays once (iteration-count: 1)
  * and lands the dragon off-screen left so the GIF stops being rendered. The

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -389,6 +389,75 @@ html[data-inferencex-embed] .circuit-bg {
   display: none;
 }
 
+/* ── Embed skin: vLLM recipes ──
+ * `/embed/model/[slug]?theme=vllm-light|vllm-dark`. Re-tokens the embed with
+ * the vLLM recipes site's palette (shadcn slate scale, oklch values copied from
+ * recipes/src/app/globals.css) plus its Inter / JetBrains Mono fonts, so the
+ * iframe reads as part of the host page. Tokens InferenceX uses differently
+ * from shadcn (`--muted` is a text color here, cards are translucent) get
+ * embed-specific values instead of a straight copy. The skin attribute is set
+ * by EmbedFrame; the theme class still comes from next-themes, so every
+ * `.dark`-keyed rule and `resolvedTheme` check keeps working. */
+html[data-inferencex-skin='vllm'] {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.129 0.042 264.695);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.129 0.042 264.695);
+  --popover: oklch(0.97 0.005 265);
+  --popover-foreground: oklch(0.25 0.04 265);
+  --primary: #fdb517; /* vLLM yellow */
+  --primary-foreground: oklch(0.129 0.042 264.695);
+  --secondary: #30a2ff; /* vLLM blue */
+  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --brand: var(--secondary);
+  --muted: oklch(0.72 0.03 257); /* readable as text on white */
+  --muted-foreground: oklch(0.554 0.046 257.417);
+  --accent: oklch(0.968 0.007 247.896);
+  --accent-foreground: oklch(0.208 0.042 265.755);
+  --border: oklch(0.929 0.013 255.508);
+  --border-alt: oklch(0.96 0.008 255);
+  --input: oklch(0.929 0.013 255.508);
+  --ring: oklch(0.704 0.04 256.788);
+}
+
+html[data-inferencex-skin='vllm'].dark {
+  --background: oklch(0.129 0.042 264.695);
+  --foreground: oklch(0.984 0.003 247.858);
+  --card: oklch(0.208 0.042 265.755);
+  --card-foreground: oklch(0.984 0.003 247.858);
+  --popover: oklch(0.245 0.016 258);
+  --popover-foreground: oklch(0.92 0.008 245);
+  --primary: #fdb517;
+  --primary-foreground: oklch(0.129 0.042 264.695);
+  --secondary: #30a2ff;
+  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --brand: var(--primary);
+  --muted: oklch(0.55 0.035 258); /* readable as text on slate */
+  --muted-foreground: oklch(0.704 0.04 256.788);
+  --accent: oklch(0.279 0.041 260.031);
+  --accent-foreground: oklch(0.984 0.003 247.858);
+  --border: oklch(1 0 0 / 10%);
+  --border-alt: oklch(1 0 0 / 6%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.551 0.027 264.364);
+}
+
+/* Fonts: EmbedFrame copies --font-embed-* from the layout wrapper onto <html>. */
+html[data-inferencex-skin='vllm'] body {
+  --font-dm-sans: var(--font-embed-sans, Inter, system-ui, sans-serif);
+  --font-mono: var(--font-embed-mono, 'JetBrains Mono', ui-monospace, monospace);
+}
+
+/* Solid cards with a full-strength border, like the host's shadcn cards;
+ * InferenceX's translucent blurred card reads as a foreign object on a flat
+ * white or slate page. */
+html[data-inferencex-skin='vllm'] [data-slot='card'] {
+  background-color: var(--card);
+  border-color: var(--border);
+  backdrop-filter: none;
+}
+
 /* Ender-dragon fly-across — one-shot animation on minecraft theme activation,
  * triggered from minecraft-decorations.tsx. Plays once (iteration-count: 1)
  * and lands the dragon off-screen left so the GIF stops being rendered. The

--- a/packages/app/src/app/zh/embed/layout.tsx
+++ b/packages/app/src/app/zh/embed/layout.tsx
@@ -1,18 +1,18 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
-import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+import EmbedShell from '@/components/embed/EmbedShell';
 
 /**
  * Embed shell. Embeds are fragments meant to live inside another site's
  * iframe, so they are kept out of search indexes; the host page is the
- * canonical surface. `UnofficialRunProvider` is required by the dashboard's
- * filter contexts (same dependency `/model` satisfies in its layout).
+ * canonical surface. `EmbedShell` loads the skin fonts and the providers the
+ * dashboard needs.
  */
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
 export default function ZhEmbedLayout({ children }: { children: ReactNode }) {
-  return <UnofficialRunProvider>{children}</UnofficialRunProvider>;
+  return <EmbedShell>{children}</EmbedShell>;
 }

--- a/packages/app/src/app/zh/embed/layout.tsx
+++ b/packages/app/src/app/zh/embed/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+
+/**
+ * Embed shell. Embeds are fragments meant to live inside another site's
+ * iframe, so they are kept out of search indexes; the host page is the
+ * canonical surface. `UnofficialRunProvider` is required by the dashboard's
+ * filter contexts (same dependency `/model` satisfies in its layout).
+ */
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default function ZhEmbedLayout({ children }: { children: ReactNode }) {
+  return <UnofficialRunProvider>{children}</UnofficialRunProvider>;
+}

--- a/packages/app/src/app/zh/embed/layout.tsx
+++ b/packages/app/src/app/zh/embed/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 
+import EmbedBoot from '@/components/embed/EmbedBoot';
 import EmbedShell from '@/components/embed/EmbedShell';
 
 /**
@@ -14,5 +15,10 @@ export const metadata: Metadata = {
 };
 
 export default function ZhEmbedLayout({ children }: { children: ReactNode }) {
-  return <EmbedShell>{children}</EmbedShell>;
+  return (
+    <>
+      <EmbedBoot />
+      <EmbedShell>{children}</EmbedShell>
+    </>
+  );
 }

--- a/packages/app/src/app/zh/embed/model/[slug]/page.tsx
+++ b/packages/app/src/app/zh/embed/model/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+
+import EmbedModelPage, { type EmbedSearchParams } from '@/components/embed/EmbedModelPage';
+import { getCompareModelBySlug } from '@/lib/compare-slug';
+
+interface Props {
+  params: Promise<{ slug: string }>;
+  searchParams: Promise<EmbedSearchParams>;
+}
+
+/** Chinese sibling of `/embed/model/[slug]`; see that route for the contract. */
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const entry = getCompareModelBySlug(slug);
+  return {
+    title: entry ? `${entry.label} — InferenceX 嵌入图表` : 'InferenceX 嵌入图表',
+    robots: { index: false, follow: false },
+  };
+}
+
+export default async function ZhEmbedModelRoute({ params, searchParams }: Props) {
+  const [{ slug }, query] = await Promise.all([params, searchParams]);
+  return <EmbedModelPage slug={slug} searchParams={query} locale="zh" />;
+}

--- a/packages/app/src/components/embed/EmbedBoot.tsx
+++ b/packages/app/src/components/embed/EmbedBoot.tsx
@@ -1,0 +1,16 @@
+import { headers } from 'next/headers';
+
+import { embedBootScript, embedThemeFromHeaders } from '@/lib/embed';
+
+/**
+ * Server component rendered by the embed layouts. It reads the theme/skin the
+ * proxy forwarded as request headers and emits the pre-paint boot script in
+ * the layout's HTML flush, ahead of `next-themes` and the streamed page, so a
+ * host asking for `theme=vllm-light` never sees a frame of InferenceX dark.
+ * `EmbedFrame` repeats the same script from the page for client navigations.
+ */
+export default async function EmbedBoot() {
+  const h = await headers();
+  const { theme, skin } = embedThemeFromHeaders((name) => h.get(name));
+  return <script dangerouslySetInnerHTML={{ __html: embedBootScript(theme, skin) }} />;
+}

--- a/packages/app/src/components/embed/EmbedFrame.tsx
+++ b/packages/app/src/components/embed/EmbedFrame.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, type ReactNode } from 'react';
 
 import {
   EMBED_RESIZE_MESSAGE_TYPE,
+  embedBootScript,
   type EmbedResizeMessage,
   type EmbedSkin,
   type EmbedTheme,
@@ -44,17 +45,6 @@ const STRINGS = {
  */
 /** CSS custom properties the skin fonts are published under (see embed layout). */
 const SKIN_FONT_VARS = ['--font-embed-sans', '--font-embed-mono'] as const;
-
-function bootScript(theme: EmbedTheme, skin: EmbedSkin | undefined): string {
-  // Values are validated enums, so string interpolation into JS is safe here.
-  const skinJs = skin ? JSON.stringify(skin) : 'null';
-  return (
-    `(function(){var h=document.documentElement;h.dataset.inferencexEmbed='';` +
-    `var s=${skinJs};if(s){h.dataset.inferencexSkin=s;}` +
-    `h.classList.remove('light','dark','minecraft');h.classList.add(${JSON.stringify(theme)});` +
-    `h.style.colorScheme=${JSON.stringify(theme)};})();`
-  );
-}
 
 export default function EmbedFrame({
   theme,
@@ -132,7 +122,7 @@ export default function EmbedFrame({
 
   return (
     <div ref={rootRef} data-testid="embed-frame" className="flex flex-col gap-2 p-2 sm:p-3">
-      <script dangerouslySetInnerHTML={{ __html: bootScript(theme, skin) }} />
+      <script dangerouslySetInnerHTML={{ __html: embedBootScript(theme, skin) }} />
       {children}
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-1 text-xs text-muted-foreground">
         <span data-testid="embed-scope">

--- a/packages/app/src/components/embed/EmbedFrame.tsx
+++ b/packages/app/src/components/embed/EmbedFrame.tsx
@@ -3,7 +3,12 @@
 import { useTheme } from 'next-themes';
 import { useEffect, useRef, type ReactNode } from 'react';
 
-import { EMBED_RESIZE_MESSAGE_TYPE, type EmbedResizeMessage, type EmbedTheme } from '@/lib/embed';
+import {
+  EMBED_RESIZE_MESSAGE_TYPE,
+  type EmbedResizeMessage,
+  type EmbedSkin,
+  type EmbedTheme,
+} from '@/lib/embed';
 import type { Locale } from '@/lib/i18n';
 
 const STRINGS = {
@@ -25,19 +30,42 @@ const STRINGS = {
  * - Forces the theme the host asked for (`?theme=`) instead of the site's
  *   stored preference. The iframe has its own storage partition, so this does
  *   not leak into the visitor's InferenceX preference.
- * - Marks `<html data-inferencex-embed>` so decorative backgrounds stay out.
+ * - Marks `<html data-inferencex-embed>` so decorative backgrounds stay out,
+ *   and `<html data-inferencex-skin>` when the host asked for a skin
+ *   (`?theme=vllm-light`). Both, plus the theme class, are also written by an
+ *   inline script that runs before first paint so the frame never flashes the
+ *   default look while React hydrates.
+ * - Hoists the skin's font variables (loaded by the embed layout on a wrapper
+ *   element) onto `<html>` so portalled UI (tooltips, dialogs, selects)
+ *   picks them up too.
  * - Posts its rendered height to the parent window whenever it changes so the
  *   host can size the iframe without an inner scrollbar.
  * - Renders a compact attribution row with a link back to the dashboard.
  */
+/** CSS custom properties the skin fonts are published under (see embed layout). */
+const SKIN_FONT_VARS = ['--font-embed-sans', '--font-embed-mono'] as const;
+
+function bootScript(theme: EmbedTheme, skin: EmbedSkin | undefined): string {
+  // Values are validated enums, so string interpolation into JS is safe here.
+  const skinJs = skin ? JSON.stringify(skin) : 'null';
+  return (
+    `(function(){var h=document.documentElement;h.dataset.inferencexEmbed='';` +
+    `var s=${skinJs};if(s){h.dataset.inferencexSkin=s;}` +
+    `h.classList.remove('light','dark','minecraft');h.classList.add(${JSON.stringify(theme)});` +
+    `h.style.colorScheme=${JSON.stringify(theme)};})();`
+  );
+}
+
 export default function EmbedFrame({
   theme,
+  skin,
   locale,
   dashboardHref,
   frameworkLabels,
   children,
 }: {
   theme: EmbedTheme;
+  skin: EmbedSkin | undefined;
   locale: Locale;
   dashboardHref: string;
   /** Human labels for the locked framework families, if any. */
@@ -55,10 +83,32 @@ export default function EmbedFrame({
   useEffect(() => {
     const html = document.documentElement;
     html.dataset.inferencexEmbed = '';
+    if (skin) html.dataset.inferencexSkin = skin;
+    else delete html.dataset.inferencexSkin;
     return () => {
       delete html.dataset.inferencexEmbed;
+      delete html.dataset.inferencexSkin;
     };
-  }, []);
+  }, [skin]);
+
+  // The embed layout loads the skin fonts with next/font on a wrapper element,
+  // which only defines the variables below that wrapper. Copy them to <html>
+  // so `html[data-inferencex-skin] body { --font-dm-sans: var(--font-embed-sans) }`
+  // resolves everywhere, including Radix portals mounted on <body>.
+  useEffect(() => {
+    if (!skin) return;
+    const root = rootRef.current;
+    if (!root) return;
+    const html = document.documentElement;
+    const computed = getComputedStyle(root);
+    for (const name of SKIN_FONT_VARS) {
+      const value = computed.getPropertyValue(name).trim();
+      if (value) html.style.setProperty(name, value);
+    }
+    return () => {
+      for (const name of SKIN_FONT_VARS) html.style.removeProperty(name);
+    };
+  }, [skin]);
 
   useEffect(() => {
     if (window.parent === window) return;
@@ -82,6 +132,7 @@ export default function EmbedFrame({
 
   return (
     <div ref={rootRef} data-testid="embed-frame" className="flex flex-col gap-2 p-2 sm:p-3">
+      <script dangerouslySetInnerHTML={{ __html: bootScript(theme, skin) }} />
       {children}
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-1 text-xs text-muted-foreground">
         <span data-testid="embed-scope">

--- a/packages/app/src/components/embed/EmbedFrame.tsx
+++ b/packages/app/src/components/embed/EmbedFrame.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useRef, type ReactNode } from 'react';
+
+import { EMBED_RESIZE_MESSAGE_TYPE, type EmbedResizeMessage, type EmbedTheme } from '@/lib/embed';
+import type { Locale } from '@/lib/i18n';
+
+const STRINGS = {
+  en: {
+    attribution: 'Data from',
+    openDashboard: 'Open in InferenceX',
+    scope: (frameworks: string) => `Showing ${frameworks} results only`,
+  },
+  zh: {
+    attribution: '数据来源',
+    openDashboard: '在 InferenceX 中打开',
+    scope: (frameworks: string) => `仅显示 ${frameworks} 的结果`,
+  },
+} as const;
+
+/**
+ * Client shell for `/embed/model/[slug]`.
+ *
+ * - Forces the theme the host asked for (`?theme=`) instead of the site's
+ *   stored preference. The iframe has its own storage partition, so this does
+ *   not leak into the visitor's InferenceX preference.
+ * - Marks `<html data-inferencex-embed>` so decorative backgrounds stay out.
+ * - Posts its rendered height to the parent window whenever it changes so the
+ *   host can size the iframe without an inner scrollbar.
+ * - Renders a compact attribution row with a link back to the dashboard.
+ */
+export default function EmbedFrame({
+  theme,
+  locale,
+  dashboardHref,
+  frameworkLabels,
+  children,
+}: {
+  theme: EmbedTheme;
+  locale: Locale;
+  dashboardHref: string;
+  /** Human labels for the locked framework families, if any. */
+  frameworkLabels: readonly string[];
+  children: ReactNode;
+}) {
+  const { setTheme } = useTheme();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const t = STRINGS[locale];
+
+  useEffect(() => {
+    setTheme(theme);
+  }, [setTheme, theme]);
+
+  useEffect(() => {
+    const html = document.documentElement;
+    html.dataset.inferencexEmbed = '';
+    return () => {
+      delete html.dataset.inferencexEmbed;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (window.parent === window) return;
+    const root = rootRef.current;
+    if (!root) return;
+    let last = 0;
+    const post = () => {
+      const height = Math.ceil(root.getBoundingClientRect().height);
+      if (height === last) return;
+      last = height;
+      const message: EmbedResizeMessage = { type: EMBED_RESIZE_MESSAGE_TYPE, height };
+      // The host origin is unknown by design (any page may embed), so the
+      // message carries nothing beyond the height.
+      window.parent.postMessage(message, '*');
+    };
+    post();
+    const observer = new ResizeObserver(post);
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={rootRef} data-testid="embed-frame" className="flex flex-col gap-2 p-2 sm:p-3">
+      {children}
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-1 text-xs text-muted-foreground">
+        <span data-testid="embed-scope">
+          {frameworkLabels.length > 0 ? t.scope(frameworkLabels.join(', ')) : null}
+        </span>
+        <span>
+          {t.attribution}{' '}
+          <a
+            href={dashboardHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+            data-testid="embed-dashboard-link"
+          >
+            InferenceX
+          </a>
+          {' · '}
+          <a
+            href={dashboardHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-primary"
+          >
+            {t.openDashboard}
+          </a>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/embed/EmbedModelPage.tsx
+++ b/packages/app/src/components/embed/EmbedModelPage.tsx
@@ -46,6 +46,7 @@ export default function EmbedModelPage({
   return (
     <EmbedFrame
       theme={options.theme}
+      skin={options.skin}
       locale={locale}
       dashboardHref={dashboardHref}
       frameworkLabels={frameworkLabels}
@@ -55,6 +56,7 @@ export default function EmbedModelPage({
         sequence={sequence}
         yAxisMetric={options.yAxisMetric}
         lockedFrameworks={options.frameworks.length > 0 ? options.frameworks : undefined}
+        minimalChrome
       />
     </EmbedFrame>
   );

--- a/packages/app/src/components/embed/EmbedModelPage.tsx
+++ b/packages/app/src/components/embed/EmbedModelPage.tsx
@@ -1,0 +1,61 @@
+import { notFound } from 'next/navigation';
+
+import EmbedFrame from '@/components/embed/EmbedFrame';
+import EmbeddedModelDashboard from '@/components/model/EmbeddedModelDashboard';
+import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
+import { comparisonScenarioForModel } from '@/lib/compare-agentx';
+import { getCompareModelBySlug } from '@/lib/compare-slug';
+import { parseEmbedOptions } from '@/lib/embed';
+import { localePath, type Locale } from '@/lib/i18n';
+
+export type EmbedSearchParams = Record<string, string | string[] | undefined>;
+
+/**
+ * Shared body of `/embed/model/[slug]` and `/zh/embed/model/[slug]`.
+ *
+ * Resolves the compare-slug (aliases included) to its dashboard model, seeds
+ * the featured scenario unless `?scenario=` overrides it, and hands the
+ * framework lock from `?framework=` to the dashboard. Unknown slugs 404.
+ */
+export default function EmbedModelPage({
+  slug,
+  searchParams,
+  locale,
+}: {
+  slug: string;
+  searchParams: EmbedSearchParams;
+  locale: Locale;
+}) {
+  const entry = getCompareModelBySlug(slug);
+  if (!entry) notFound();
+
+  const options = parseEmbedOptions(searchParams);
+  const sequence = options.sequence ?? comparisonScenarioForModel(entry).sequence;
+  const frameworkLabels = FRAMEWORK_FAMILIES.filter((f) => options.frameworks.includes(f.key)).map(
+    (f) => f.label,
+  );
+
+  const dashboardQuery = new URLSearchParams({
+    g_model: entry.displayName,
+    i_seq: sequence,
+    i_optimal: '1',
+  });
+  if (options.frameworks.length > 0) dashboardQuery.set('i_fw', options.frameworks.join(','));
+  const dashboardHref = `${localePath('/inference', locale)}?${dashboardQuery.toString()}`;
+
+  return (
+    <EmbedFrame
+      theme={options.theme}
+      locale={locale}
+      dashboardHref={dashboardHref}
+      frameworkLabels={frameworkLabels}
+    >
+      <EmbeddedModelDashboard
+        displayName={entry.displayName}
+        sequence={sequence}
+        yAxisMetric={options.yAxisMetric}
+        lockedFrameworks={options.frameworks.length > 0 ? options.frameworks : undefined}
+      />
+    </EmbedFrame>
+  );
+}

--- a/packages/app/src/components/embed/EmbedShell.tsx
+++ b/packages/app/src/components/embed/EmbedShell.tsx
@@ -1,0 +1,35 @@
+import { Inter, JetBrains_Mono } from 'next/font/google';
+import type { ReactNode } from 'react';
+
+import { UnofficialRunProvider } from '@/components/unofficial-run-provider';
+
+/*
+ * Fonts used by embed skins. They are published as `--font-embed-*` on a
+ * wrapper element (next/font only lets us attach a class), and EmbedFrame
+ * hoists the resolved values onto <html> so a skin's
+ * `body { --font-dm-sans: var(--font-embed-sans) }` reaches portalled UI too.
+ * The vLLM recipes site uses Inter + JetBrains Mono.
+ */
+const embedSans = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-embed-sans',
+});
+const embedMono = JetBrains_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-embed-mono',
+});
+
+/**
+ * Shared shell for `/embed` and `/zh/embed`. `UnofficialRunProvider` is
+ * required by the dashboard's filter contexts (same dependency `/model`
+ * satisfies in its layout).
+ */
+export default function EmbedShell({ children }: { children: ReactNode }) {
+  return (
+    <div className={`${embedSans.variable} ${embedMono.variable} contents`}>
+      <UnofficialRunProvider>{children}</UnofficialRunProvider>
+    </div>
+  );
+}

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -2,9 +2,11 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 import { ShareTwitterButton, ShareLinkedInButton } from '@/components/share-buttons';
 import { track } from '@/lib/analytics';
+import { isEmbedPathname } from '@/lib/embed-route';
 import { useLocale } from '@/lib/use-locale';
 
 import { StarButton } from './footer-star-cta';
@@ -82,9 +84,12 @@ const STRINGS = {
 
 export const Footer = ({ starCount }: { starCount?: number | null }) => {
   const locale = useLocale();
+  const pathname = usePathname();
   const t = STRINGS[locale];
   // Internal links stay within the current language tree.
   const prefix = locale === 'zh' ? '/zh' : '';
+  // Embeds render one chart inside a third-party iframe; no site chrome.
+  if (isEmbedPathname(pathname)) return null;
   return (
     <footer
       data-testid="footer"

--- a/packages/app/src/components/header/header.tsx
+++ b/packages/app/src/components/header/header.tsx
@@ -14,6 +14,7 @@ import { navigateInApp } from '@/lib/client-navigation';
 import { DASHBOARD_ROUTES } from '@/lib/dashboard-routes';
 import { useClientPathname } from '@/hooks/useClientPathname';
 import { useClientSearch } from '@/hooks/useClientSearch';
+import { isEmbedPathname } from '@/lib/embed-route';
 import { hasZhSibling, isZhPathname, switchLocalePath, ZH_PREFIX, zhPath } from '@/lib/i18n';
 import { NAV_LABELS_ZH, type HeaderNavHref } from '@/lib/tab-meta-zh';
 import { cn } from '@/lib/utils';
@@ -188,6 +189,9 @@ export const Header = ({ starCount }: { starCount?: number | null }) => {
     setMobileMenuOpen((prev) => !prev);
     track('header_mobile_menu_toggled');
   }, []);
+
+  // Embeds render one chart inside a third-party iframe; no site chrome.
+  if (isEmbedPathname(pathname)) return null;
 
   return (
     <header

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -209,6 +209,7 @@ export function InferenceProvider({
   initialYAxisMetric,
   autoSelectAllGpus = false,
   lockedFrameworks,
+  minimalChrome = false,
 }: {
   children: ReactNode;
   activeTab: string;
@@ -254,6 +255,13 @@ export function InferenceProvider({
    * `undefined` / empty = no lock.
    */
   lockedFrameworks?: readonly string[];
+  /**
+   * Strip the dashboard down to the chart and a plain legend: no x-axis mode
+   * selector, config changelog, chart toolbar, quick-filter chips, or legend
+   * switches/actions. Used by `/embed/model/[slug]`, where the host page owns
+   * the surrounding UI and a bare chart is what gets pasted.
+   */
+  minimalChrome?: boolean;
 }) {
   const locale = useLocale();
   const localeStrings = INFERENCE_CONTEXT_STRINGS[locale];
@@ -1747,6 +1755,7 @@ export function InferenceProvider({
       presetGuardRef,
       compareGpuPair: compareGpuPair ?? null,
       lockedFrameworks: frameworkLock,
+      minimalChrome,
     }),
     [
       activeHwTypes,
@@ -1766,6 +1775,7 @@ export function InferenceProvider({
       activePresetId,
       compareGpuPair,
       frameworkLock,
+      minimalChrome,
     ],
   );
 

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -60,6 +60,7 @@ import { DEFAULT_Y_AXIS_METRIC } from '@/lib/url-state';
 import { computeToggle } from '@/hooks/useTogglableSet';
 import { buildAvailabilityHwKey } from '@/lib/chart-utils';
 import { getHardwareConfig, getModelSortIndex, isKnownGpu } from '@/lib/constants';
+import { frameworkFamily } from '@/lib/framework-family';
 import {
   getOpenRouterModelId,
   MODEL_PREFIX_MAPPING,
@@ -207,6 +208,7 @@ export function InferenceProvider({
   initialBenchmarkRows,
   initialYAxisMetric,
   autoSelectAllGpus = false,
+  lockedFrameworks,
 }: {
   children: ReactNode;
   activeTab: string;
@@ -242,6 +244,16 @@ export function InferenceProvider({
    * auto-selection (or when the URL provided chips), user deselections stick.
    */
   autoSelectAllGpus?: boolean;
+  /**
+   * Serving-framework families (quick-filter keys such as `vllm`) the chart is
+   * pinned to. Used by the `/embed/model/[slug]` routes so a host page can
+   * scope the chart to the engine it documents. The lock replaces the
+   * user-editable framework quick filter (URL `i_fw` and dialog edits are
+   * ignored) and removes other engines' chip configs from the selectable set,
+   * so nothing outside the lock reaches the plot, legend, or changelog.
+   * `undefined` / empty = no lock.
+   */
+  lockedFrameworks?: readonly string[];
 }) {
   const locale = useLocale();
   const localeStrings = INFERENCE_CONTEXT_STRINGS[locale];
@@ -455,7 +467,20 @@ export function InferenceProvider({
   // inactive/disabled even while the chart filters. The URL selections are applied
   // just below, after mount.
   const [quickFilterVendors, setQuickFilterVendors] = useState<string[]>([]);
-  const [quickFilterFrameworks, setQuickFilterFrameworks] = useState<string[]>([]);
+  const [quickFilterFrameworksState, setQuickFilterFrameworksState] = useState<string[]>([]);
+  // A framework lock pins the filter and makes edits no-ops; see the prop doc.
+  const frameworkLock = useMemo<string[] | null>(
+    () => (lockedFrameworks && lockedFrameworks.length > 0 ? [...lockedFrameworks] : null),
+    [lockedFrameworks],
+  );
+  const quickFilterFrameworks = frameworkLock ?? quickFilterFrameworksState;
+  const setQuickFilterFrameworks = useCallback(
+    (next: SetStateAction<string[]>) => {
+      if (frameworkLock) return;
+      setQuickFilterFrameworksState(next);
+    },
+    [frameworkLock],
+  );
   const [quickFilterDeployment, setQuickFilterDeployment] = useState<DeploymentMode[]>([]);
   const [quickFilterSpec, setQuickFilterSpec] = useState<SpecMode[]>([]);
   const [quickFilterPower, setQuickFilterPower] = useState<PowerTier[]>([]);
@@ -476,7 +501,7 @@ export function InferenceProvider({
     if (deployment.length > 0) setQuickFilterDeployment(deployment);
     if (spec.length > 0) setQuickFilterSpec(spec);
     if (power.length > 0) setQuickFilterPower(power);
-  }, [getUrlParam]);
+  }, [getUrlParam, setQuickFilterFrameworks]);
   const quickFilters = useMemo<QuickFilters>(
     () => ({
       vendors: quickFilterVendors,
@@ -743,6 +768,10 @@ export function InferenceProvider({
       if (rowToSequence(r) !== effectiveSequence) continue;
       if (!effectivePrecisions.includes(r.precision)) continue;
       if (!r.hardware) continue;
+      if (frameworkLock) {
+        const family = frameworkFamily(r.framework);
+        if (!family || !frameworkLock.includes(family)) continue;
+      }
       const hwKey = buildAvailabilityHwKey(
         r.hardware,
         r.framework,
@@ -758,7 +787,14 @@ export function InferenceProvider({
         value: hw,
         label: getDisplayLabel(getHardwareConfig(hw, selectedModel)),
       }));
-  }, [availabilityRows, dbModelKeys, effectiveSequence, effectivePrecisions, selectedModel]);
+  }, [
+    availabilityRows,
+    dbModelKeys,
+    effectiveSequence,
+    effectivePrecisions,
+    selectedModel,
+    frameworkLock,
+  ]);
 
   // One-shot auto-selection of every available chip config (see the
   // `autoSelectAllGpus` prop doc). The selection is pre-resolved through the
@@ -1710,6 +1746,7 @@ export function InferenceProvider({
       activePresetId,
       presetGuardRef,
       compareGpuPair: compareGpuPair ?? null,
+      lockedFrameworks: frameworkLock,
     }),
     [
       activeHwTypes,
@@ -1728,6 +1765,7 @@ export function InferenceProvider({
       userPowers,
       activePresetId,
       compareGpuPair,
+      frameworkLock,
     ],
   );
 

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -618,6 +618,11 @@ export interface InferenceFiltersContextType {
   activePresetId: string | null;
   presetGuardRef: React.RefObject<boolean>;
   compareGpuPair: readonly [string, string] | null;
+  /**
+   * Framework families the provider is pinned to (embed routes), or null. When
+   * set, `quickFilters.frameworks` mirrors it and cannot be edited.
+   */
+  lockedFrameworks: readonly string[] | null;
 }
 
 /** Axis choices and visual presentation state. */

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -623,6 +623,8 @@ export interface InferenceFiltersContextType {
    * set, `quickFilters.frameworks` mirrors it and cannot be edited.
    */
   lockedFrameworks: readonly string[] | null;
+  /** Chart-only rendering for embeds; see `InferenceProvider.minimalChrome`. */
+  minimalChrome: boolean;
 }
 
 /** Axis choices and visual presentation state. */

--- a/packages/app/src/components/inference/ui/ActiveQuickFilters.tsx
+++ b/packages/app/src/components/inference/ui/ActiveQuickFilters.tsx
@@ -18,13 +18,14 @@ const STRINGS = {
 export function ActiveQuickFilters() {
   const locale = useLocale();
   const t = STRINGS[locale];
-  const { quickFilters, selectedSequence } = useInferenceFilters();
+  const { quickFilters, selectedSequence, lockedFrameworks } = useInferenceFilters();
   const actions = useInferenceActions();
+  // A framework lock (embed routes) cannot be removed, so it gets no chip.
   const filters = quickFilterSummary(
     quickFilters,
     locale,
     selectedSequence === Sequence.AgenticTraces,
-  );
+  ).filter((filter) => !(lockedFrameworks && filter.category === 'frameworks'));
   if (filters.length === 0) return null;
 
   const setCategory = (category: (typeof filters)[number]['category'], values: string[]) => {

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -1231,13 +1231,14 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
         </section>
       )}
 
-      {(selectedYAxisMetric === 'y_costUser' ||
-        selectedYAxisMetric === 'y_tokensPerDollarUser') && (
-        <section>
-          <CustomCosts loading={loading} />
-        </section>
-      )}
-      {selectedYAxisMetric === 'y_powerUser' && (
+      {!minimalChrome &&
+        (selectedYAxisMetric === 'y_costUser' ||
+          selectedYAxisMetric === 'y_tokensPerDollarUser') && (
+          <section>
+            <CustomCosts loading={loading} />
+          </section>
+        )}
+      {!minimalChrome && selectedYAxisMetric === 'y_powerUser' && (
         <section>
           <CustomPowers loading={loading} />
         </section>

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -252,6 +252,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
     activeDates,
     compareGpuPair,
     quickFilters,
+    minimalChrome,
   } = useInferenceFilters();
   const {
     selectedYAxisMetric,
@@ -877,79 +878,85 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
             return (
               <section key={graphIndex}>
                 <figure data-testid="chart-figure" className="relative min-w-0 rounded-xl">
-                  <ChartButtons
-                    chartId={`chart-${graphIndex}`}
-                    mobileVisible
-                    analyticsPrefix={
-                      isTimelineMode
-                        ? 'gpu_timeseries'
-                        : graph.chartDefinition.chartType === 'e2e'
-                          ? 'latency'
-                          : 'interactivity'
-                    }
-                    leadingControls={
-                      <>
-                        <SegmentedToggle
-                          value={getViewMode(graphIndex)}
-                          options={viewModeOptions}
-                          onValueChange={(v) => handleViewModeChange(graphIndex, v)}
-                          ariaLabel={t.viewMode}
-                          testId={`inference-view-toggle-${graphIndex}`}
-                        />
-                      </>
-                    }
-                    hideImageExport={getViewMode(graphIndex) === 'table'}
-                    setIsLegendExpanded={setIsLegendExpanded}
-                    exportFileName={`InferenceX_${selectedModel}_${graph.chartDefinition.chartType}`}
-                    onExportMp4={
-                      replayAvailable
-                        ? () => replayHandlesRef.current[graphIndex]?.open()
-                        : undefined
-                    }
-                    onExportCsv={() => {
-                      const candidateVisibleData = isTimelineMode
-                        ? graph.data.filter((d) => activeDates.has(`${d.date}_${d.hwKey}`))
-                        : graph.data;
-                      const overlay = selectUnofficialOverlayForMode(
-                        selectedXAxisMode,
-                        graph.chartDefinition.chartType,
-                        overlayDataByChartType,
-                      );
-                      const {
-                        officialRows: visibleData,
-                        overlayRows: visibleOverlayRowsForExport,
-                      } = isTimelineMode
-                        ? { officialRows: candidateVisibleData, overlayRows: [] }
-                        : visibleComparisonRows(candidateVisibleData, overlay);
-                      const { headers, rows } = inferenceChartToCsv(
-                        visibleData,
-                        graph.model,
-                        graph.sequence,
-                        visibleOverlayRowsForExport,
-                        {
-                          yHeader: metricLabel(graph.chartDefinition, selectedYAxisMetric, locale),
-                          yPath: (graph.chartDefinition as ChartDefinition)[
-                            selectedYAxisMetric
-                          ] as string,
-                          xHeader: resolvedXLabel,
-                        },
-                      );
-                      // Match warnings against the same series the chart annotates,
-                      // including visible unofficial-run overlay series.
-                      const issueNotes = matchKnownConfigIssues(graph.model, [
-                        ...visibleData,
-                        ...visibleOverlayRowsForExport,
-                      ]).map((issue) =>
-                        knownIssueCsvNote(issue, getDisplayLabel(getHardwareConfig(issue.hwKey))),
-                      );
-                      exportToCsv(
-                        `InferenceX_${selectedModel}_${graph.chartDefinition.chartType}`,
-                        headers,
-                        rows,
-                        issueNotes,
-                      );
-                    }}
-                  />
+                  {!minimalChrome && (
+                    <ChartButtons
+                      chartId={`chart-${graphIndex}`}
+                      mobileVisible
+                      analyticsPrefix={
+                        isTimelineMode
+                          ? 'gpu_timeseries'
+                          : graph.chartDefinition.chartType === 'e2e'
+                            ? 'latency'
+                            : 'interactivity'
+                      }
+                      leadingControls={
+                        <>
+                          <SegmentedToggle
+                            value={getViewMode(graphIndex)}
+                            options={viewModeOptions}
+                            onValueChange={(v) => handleViewModeChange(graphIndex, v)}
+                            ariaLabel={t.viewMode}
+                            testId={`inference-view-toggle-${graphIndex}`}
+                          />
+                        </>
+                      }
+                      hideImageExport={getViewMode(graphIndex) === 'table'}
+                      setIsLegendExpanded={setIsLegendExpanded}
+                      exportFileName={`InferenceX_${selectedModel}_${graph.chartDefinition.chartType}`}
+                      onExportMp4={
+                        replayAvailable
+                          ? () => replayHandlesRef.current[graphIndex]?.open()
+                          : undefined
+                      }
+                      onExportCsv={() => {
+                        const candidateVisibleData = isTimelineMode
+                          ? graph.data.filter((d) => activeDates.has(`${d.date}_${d.hwKey}`))
+                          : graph.data;
+                        const overlay = selectUnofficialOverlayForMode(
+                          selectedXAxisMode,
+                          graph.chartDefinition.chartType,
+                          overlayDataByChartType,
+                        );
+                        const {
+                          officialRows: visibleData,
+                          overlayRows: visibleOverlayRowsForExport,
+                        } = isTimelineMode
+                          ? { officialRows: candidateVisibleData, overlayRows: [] }
+                          : visibleComparisonRows(candidateVisibleData, overlay);
+                        const { headers, rows } = inferenceChartToCsv(
+                          visibleData,
+                          graph.model,
+                          graph.sequence,
+                          visibleOverlayRowsForExport,
+                          {
+                            yHeader: metricLabel(
+                              graph.chartDefinition,
+                              selectedYAxisMetric,
+                              locale,
+                            ),
+                            yPath: (graph.chartDefinition as ChartDefinition)[
+                              selectedYAxisMetric
+                            ] as string,
+                            xHeader: resolvedXLabel,
+                          },
+                        );
+                        // Match warnings against the same series the chart annotates,
+                        // including visible unofficial-run overlay series.
+                        const issueNotes = matchKnownConfigIssues(graph.model, [
+                          ...visibleData,
+                          ...visibleOverlayRowsForExport,
+                        ]).map((issue) =>
+                          knownIssueCsvNote(issue, getDisplayLabel(getHardwareConfig(issue.hwKey))),
+                        );
+                        exportToCsv(
+                          `InferenceX_${selectedModel}_${graph.chartDefinition.chartType}`,
+                          headers,
+                          rows,
+                          issueNotes,
+                        );
+                      }}
+                    />
+                  )}
                   <Card data-coach-mark-root="">
                     {(() => {
                       const chartCaption = (
@@ -1064,10 +1071,12 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                                 : undefined
                             }
                           />
-                          <MetricAssumptionNotes
-                            selectedYAxisMetric={selectedYAxisMetric}
-                            activeHwKeys={captionHwKeys}
-                          />
+                          {!minimalChrome && (
+                            <MetricAssumptionNotes
+                              selectedYAxisMetric={selectedYAxisMetric}
+                              activeHwKeys={captionHwKeys}
+                            />
+                          )}
                           {isUnofficialRun &&
                             selectedXAxisMode === 'e2e-normalized-interactivity' && (
                               <p className="mb-2 text-xs text-muted-foreground">
@@ -1152,7 +1161,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                       );
                     })()}
                     <ChartNotices chartId={`chart-${graphIndex}`} notices={footerNotices} />
-                    {replayAvailable && (
+                    {replayAvailable && !minimalChrome && (
                       <ReplayLauncher
                         ref={(handle) => {
                           replayHandlesRef.current[graphIndex] = handle;
@@ -1171,54 +1180,56 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
 
   return (
     <div data-testid="inference-chart-display" className="flex flex-col gap-4">
-      <section className="relative z-20">
-        <Card>
-          <div className="flex flex-col gap-4">
-            {!embedded && (
-              <>
-                <DashboardSectionHeader
-                  title={t.inferencePerformance}
-                  description={t.inferencePerformanceDesc}
-                  actions={<ShareButton />}
+      {!minimalChrome && (
+        <section className="relative z-20">
+          <Card>
+            <div className="flex flex-col gap-4">
+              {!embedded && (
+                <>
+                  <DashboardSectionHeader
+                    title={t.inferencePerformance}
+                    description={t.inferencePerformanceDesc}
+                    actions={<ShareButton />}
+                  />
+                  <ChartControls showXAxisMode />
+                </>
+              )}
+              {embedded && (
+                <div className="w-full max-w-sm">
+                  <XAxisModeSelector />
+                </div>
+              )}
+              {selectedGPUs.length === 0 && <WorkflowInfoDisplay />}
+              {selectedGPUs.length > 0 && (
+                <ComparisonChangelog
+                  changelogs={changelogs}
+                  selectedGPUs={selectedGPUs}
+                  selectedPrecisions={selectedPrecisions}
+                  modelDbKeys={modelDbKeys}
+                  selectedSequence={selectedSequence}
+                  defaultExpanded={!embedded}
+                  loading={changelogsLoading}
+                  totalDatesQueried={totalDatesQueried}
+                  selectedDates={selectedDates}
+                  selectedDateRange={selectedDateRange}
+                  onAddDate={(date) => {
+                    // Functional updater: adding several runs in quick succession must
+                    // each build on the latest state, not the value captured at render.
+                    setSelectedDates((prev) => (prev.includes(date) ? prev : [...prev, date]));
+                  }}
+                  onRemoveDate={(date) => {
+                    setSelectedDates((prev) => prev.filter((d) => d !== date));
+                  }}
+                  onAddAllDates={(dates) => {
+                    setSelectedDates((prev) => [...new Set([...prev, ...dates])]);
+                  }}
+                  firstAvailableDate={dateRangeAvailableDates[0]}
                 />
-                <ChartControls showXAxisMode />
-              </>
-            )}
-            {embedded && (
-              <div className="w-full max-w-sm">
-                <XAxisModeSelector />
-              </div>
-            )}
-            {selectedGPUs.length === 0 && <WorkflowInfoDisplay />}
-            {selectedGPUs.length > 0 && (
-              <ComparisonChangelog
-                changelogs={changelogs}
-                selectedGPUs={selectedGPUs}
-                selectedPrecisions={selectedPrecisions}
-                modelDbKeys={modelDbKeys}
-                selectedSequence={selectedSequence}
-                defaultExpanded={!embedded}
-                loading={changelogsLoading}
-                totalDatesQueried={totalDatesQueried}
-                selectedDates={selectedDates}
-                selectedDateRange={selectedDateRange}
-                onAddDate={(date) => {
-                  // Functional updater: adding several runs in quick succession must
-                  // each build on the latest state, not the value captured at render.
-                  setSelectedDates((prev) => (prev.includes(date) ? prev : [...prev, date]));
-                }}
-                onRemoveDate={(date) => {
-                  setSelectedDates((prev) => prev.filter((d) => d !== date));
-                }}
-                onAddAllDates={(dates) => {
-                  setSelectedDates((prev) => [...new Set([...prev, ...dates])]);
-                }}
-                firstAvailableDate={dateRangeAvailableDates[0]}
-              />
-            )}
-          </div>
-        </Card>
-      </section>
+              )}
+            </div>
+          </Card>
+        </section>
+      )}
 
       {(selectedYAxisMetric === 'y_costUser' ||
         selectedYAxisMetric === 'y_tokensPerDollarUser') && (
@@ -1231,7 +1242,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
           <CustomPowers loading={loading} />
         </section>
       )}
-      <ActiveQuickFilters />
+      {!minimalChrome && <ActiveQuickFilters />}
       <div
         className="motion-stale flex flex-col gap-4"
         data-stale={isRefetching || undefined}

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -203,6 +203,7 @@ const GPUGraph = React.memo(
       selectedSequence,
       quickFilters,
       activeDates,
+      lockedFrameworks,
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
@@ -244,9 +245,10 @@ const GPUGraph = React.memo(
     const { resolvedTheme } = useTheme();
     const chartRef = useRef<D3ChartHandle>(null);
     const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
+    // A framework lock (embed routes) is not a user filter, so it is not counted.
     const quickFilterCount =
       quickFilters.vendors.length +
-      quickFilters.frameworks.length +
+      (lockedFrameworks ? 0 : quickFilters.frameworks.length) +
       quickFilters.deployment.length +
       quickFilters.power.length +
       (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -204,6 +204,7 @@ const GPUGraph = React.memo(
       quickFilters,
       activeDates,
       lockedFrameworks,
+      minimalChrome,
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
@@ -1586,6 +1587,7 @@ const GPUGraph = React.memo(
               },
             ]}
             hideAtomFootnote
+            readOnly={minimalChrome}
             keyIndicators={
               <>
                 {fixedLogPointId === null ? null : (

--- a/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
+++ b/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
@@ -146,7 +146,7 @@ export function QuickFiltersDialog({
     setQuickFilterSpec,
     setQuickFilterPower,
   } = useInferenceActions();
-  const { selectedSequence, quickFilters } = useInferenceFilters();
+  const { selectedSequence, quickFilters, lockedFrameworks } = useInferenceFilters();
   const { availableQuickFilters } = useInferenceData();
   const isAgentic = selectedSequence === Sequence.AgenticTraces;
   const help = {
@@ -196,7 +196,9 @@ export function QuickFiltersDialog({
       })),
       selected: quickFilters.vendors,
     },
-    ...(frameworkOptions.length > 0
+    // A framework lock (embed routes) is not user-editable, so its group is
+    // omitted rather than rendered as a row of disabled pills.
+    ...(frameworkOptions.length > 0 && !lockedFrameworks
       ? [
           {
             key: 'framework' as const,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -453,6 +453,7 @@ const ScatterGraph = React.memo(
       selectedRunId,
       selectedSequence,
       quickFilters,
+      lockedFrameworks,
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
@@ -1085,9 +1086,10 @@ const ScatterGraph = React.memo(
     // --- Legend points table (per-series drill-down opened from the legend) ---
     const [pointsTableTarget, setPointsTableTarget] = useState<LegendPointsTarget | null>(null);
     const [quickFiltersOpen, setQuickFiltersOpen] = useState(false);
+    // A framework lock (embed routes) is not a user filter, so it is not counted.
     const quickFilterCount =
       quickFilters.vendors.length +
-      quickFilters.frameworks.length +
+      (lockedFrameworks ? 0 : quickFilters.frameworks.length) +
       quickFilters.deployment.length +
       quickFilters.power.length +
       (selectedSequence === Sequence.AgenticTraces ? 0 : quickFilters.spec.length);

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -454,6 +454,7 @@ const ScatterGraph = React.memo(
       selectedSequence,
       quickFilters,
       lockedFrameworks,
+      minimalChrome,
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
@@ -3748,6 +3749,7 @@ const ScatterGraph = React.memo(
                 },
               ]}
               hideAtomFootnote
+              readOnly={minimalChrome}
               enableTooltips={true}
             />
           }

--- a/packages/app/src/components/model/EmbeddedModelDashboard.tsx
+++ b/packages/app/src/components/model/EmbeddedModelDashboard.tsx
@@ -29,6 +29,7 @@ export default function EmbeddedModelDashboard({
   sequence,
   yAxisMetric = DEFAULT_Y_AXIS_METRIC,
   lockedFrameworks,
+  minimalChrome,
 }: {
   displayName: string;
   sequence: string;
@@ -40,6 +41,8 @@ export default function EmbeddedModelDashboard({
    * serving engine it documents.
    */
   lockedFrameworks?: readonly string[];
+  /** Chart + plain legend only; see `InferenceProvider.minimalChrome`. */
+  minimalChrome?: boolean;
 }) {
   return (
     <EphemeralUrlStateContext.Provider value={true}>
@@ -52,6 +55,7 @@ export default function EmbeddedModelDashboard({
           initialYAxisMetric={yAxisMetric}
           autoSelectAllGpus
           lockedFrameworks={lockedFrameworks}
+          minimalChrome={minimalChrome}
         >
           <InferenceChartDisplay embedded />
         </InferenceProvider>

--- a/packages/app/src/components/model/EmbeddedModelDashboard.tsx
+++ b/packages/app/src/components/model/EmbeddedModelDashboard.tsx
@@ -27,9 +27,19 @@ import { DEFAULT_Y_AXIS_METRIC } from '@/lib/url-state';
 export default function EmbeddedModelDashboard({
   displayName,
   sequence,
+  yAxisMetric = DEFAULT_Y_AXIS_METRIC,
+  lockedFrameworks,
 }: {
   displayName: string;
   sequence: string;
+  /** Initial y-axis metric; the dashboard default when omitted. */
+  yAxisMetric?: string;
+  /**
+   * Pin the chart to these framework families (see `InferenceProvider`). Used
+   * by `/embed/model/[slug]?framework=vllm` so a host page shows only the
+   * serving engine it documents.
+   */
+  lockedFrameworks?: readonly string[];
 }) {
   return (
     <EphemeralUrlStateContext.Provider value={true}>
@@ -39,8 +49,9 @@ export default function EmbeddedModelDashboard({
       >
         <InferenceProvider
           activeTab="inference"
-          initialYAxisMetric={DEFAULT_Y_AXIS_METRIC}
+          initialYAxisMetric={yAxisMetric}
           autoSelectAllGpus
+          lockedFrameworks={lockedFrameworks}
         >
           <InferenceChartDisplay embedded />
         </InferenceProvider>

--- a/packages/app/src/components/ui/chart-legend.tsx
+++ b/packages/app/src/components/ui/chart-legend.tsx
@@ -76,6 +76,13 @@ export interface ChartLegendProps {
    * the axis-metric info footer below the chart instead of in the legend.
    */
   hideAtomFootnote?: boolean;
+  /**
+   * Render the legend as a plain key: no display switches, no action buttons,
+   * no per-series remove / points-table affordances, no changelog tooltips.
+   * Items stay clickable so a reader can still isolate a series. Used by the
+   * `/embed` chart, which hands every other control to the host page.
+   */
+  readOnly?: boolean;
 }
 
 export default function ChartLegend({
@@ -96,10 +103,31 @@ export default function ChartLegend({
   onItemRemove,
   onAdvancedExpandedChange,
   hideAtomFootnote = false,
+  readOnly = false,
 }: ChartLegendProps) {
   const locale = useLocale();
   const t = STRINGS[locale];
   const isSidebar = variant === 'sidebar';
+  if (readOnly) {
+    switches = undefined;
+    actions = undefined;
+    onItemRemove = undefined;
+    enableTooltips = false;
+  }
+  const items = useMemo(
+    () =>
+      readOnly
+        ? legendItems.map((item) => ({
+            ...item,
+            onShowPoints: undefined,
+            tooltip: null,
+            // Highlight marks the run selected in the changelog, which a
+            // read-only legend has no way to change.
+            isHighlighted: false,
+          }))
+        : legendItems,
+    [legendItems, readOnly],
+  );
   const scrollRef = useRef<HTMLDivElement>(null);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
@@ -112,8 +140,8 @@ export default function ChartLegend({
   // emptying the chart, and label-only entries (unofficial runs) are not
   // something removing leaves you without.
   const activeCount = useMemo(
-    () => legendItems.filter((item) => item.isActive && item.isRemovable !== false).length,
-    [legendItems],
+    () => items.filter((item) => item.isActive && item.isRemovable !== false).length,
+    [items],
   );
   const effectiveRemove = onItemRemove && activeCount > 1 ? onItemRemove : undefined;
   const removeFor = (item: CommonLegendItemProps) =>
@@ -131,17 +159,17 @@ export default function ChartLegend({
 
   // Sort items for sidebar mode (active-first); filtering is done via CSS hide
   const sortedItems = useMemo(() => {
-    if (!isSidebar) return legendItems;
-    return filterAndSortLegendItems(legendItems, '', !disableActiveSort);
-  }, [legendItems, isSidebar, disableActiveSort]);
+    if (!isSidebar) return items;
+    return filterAndSortLegendItems(items, '', !disableActiveSort);
+  }, [items, isSidebar, disableActiveSort]);
 
   const rows = useMemo(() => {
     if (!grouped) return null;
-    const items = isSidebar ? sortedItems : legendItems;
-    const hwKeys = items.map((item) => item.name.split(' ')[0]);
+    const source = isSidebar ? sortedItems : items;
+    const hwKeys = source.map((item) => item.name.split(' ')[0]);
     const uniqueNames = [...new Set(hwKeys)];
     const result = uniqueNames.map((name) =>
-      items.filter((item) => item.name.split(' ')[0] === name),
+      source.filter((item) => item.name.split(' ')[0] === name),
     );
     // In sidebar mode, sort groups so those with active items come first
     if (isSidebar && !disableActiveSort) {
@@ -152,7 +180,7 @@ export default function ChartLegend({
       });
     }
     return result.filter((row) => row.length > 0);
-  }, [grouped, legendItems, sortedItems, isSidebar]);
+  }, [grouped, items, sortedItems, isSidebar]);
 
   const toggleLegendOpen = () => {
     onExpandedChange(!isLegendExpanded);
@@ -189,9 +217,8 @@ export default function ChartLegend({
 
   // Show ATOM footnote when any legend item label contains the ¹ marker
   const hasAtomFootnote = useMemo(
-    () =>
-      !hideAtomFootnote && legendItems.some((item) => item.label.includes(ATOM_FOOTNOTE_MARKER)),
-    [legendItems, hideAtomFootnote],
+    () => !hideAtomFootnote && items.some((item) => item.label.includes(ATOM_FOOTNOTE_MARKER)),
+    [items, hideAtomFootnote],
   );
 
   const hasSidebarControls =
@@ -235,37 +262,38 @@ export default function ChartLegend({
   // Keep the same button mounted in the same padded header in both states.
   // Only its arrow and accessible label change; focus and pointer position stay put.
   const LegendToggleIcon = isLegendExpanded ? PanelRightClose : PanelRightOpen;
-  const panelHeader = isSidebar ? (
-    <div
-      data-testid="legend-toolbar"
-      className="-mx-1 -mt-1 pb-1 no-export flex shrink-0 items-start gap-1"
-    >
-      <div className="min-w-0 flex-1">{isLegendExpanded && actionElements}</div>
-      <button
-        type="button"
-        data-testid={isLegendExpanded ? 'legend-close-button' : 'legend-open-button'}
-        onClick={toggleLegendOpen}
-        aria-expanded={isLegendExpanded}
-        aria-label={isLegendExpanded ? t.hideLegend : t.showLegend}
-        title={isLegendExpanded ? t.hideLegend : t.showLegend}
-        className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
+  const panelHeader =
+    isSidebar && !readOnly ? (
+      <div
+        data-testid="legend-toolbar"
+        className="-mx-1 -mt-1 pb-1 no-export flex shrink-0 items-start gap-1"
       >
-        <LegendToggleIcon size={16} aria-hidden="true" />
-      </button>
-    </div>
-  ) : null;
+        <div className="min-w-0 flex-1">{isLegendExpanded && actionElements}</div>
+        <button
+          type="button"
+          data-testid={isLegendExpanded ? 'legend-close-button' : 'legend-open-button'}
+          onClick={toggleLegendOpen}
+          aria-expanded={isLegendExpanded}
+          aria-label={isLegendExpanded ? t.hideLegend : t.showLegend}
+          title={isLegendExpanded ? t.hideLegend : t.showLegend}
+          className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
+        >
+          <LegendToggleIcon size={16} aria-hidden="true" />
+        </button>
+      </div>
+    ) : null;
 
   const standardSwitches = switches?.filter((sw) => !sw.advanced) ?? [];
   const advancedSwitches = switches?.filter((sw) => sw.advanced) ?? [];
 
-  const renderSwitches = (items: LegendSwitchConfig[]) =>
-    items.length > 0 ? (
+  const renderSwitches = (list: LegendSwitchConfig[]) =>
+    list.length > 0 ? (
       <div
         className={cn(
           isSidebar || grouped ? 'w-full space-y-0' : 'w-full md:w-auto flex flex-wrap gap-2',
         )}
       >
-        {items.map((sw) => (
+        {list.map((sw) => (
           <div key={sw.id} className="mt-2 flex items-center gap-2">
             <Switch
               id={sw.id}
@@ -460,7 +488,7 @@ export default function ChartLegend({
         style={!isSidebar && isOverflowing ? { scrollbarGutter: 'stable' } : undefined}
         className={cn(scrollClasses, 'custom-scrollbar')}
       >
-        {(isSidebar ? sortedItems : legendItems).map((item) => renderItem(item))}
+        {(isSidebar ? sortedItems : items).map((item) => renderItem(item))}
       </ul>
     );
 

--- a/packages/app/src/lib/embed-route.ts
+++ b/packages/app/src/lib/embed-route.ts
@@ -1,0 +1,17 @@
+/**
+ * Embeddable chart routes (`/embed/model/[slug]` and `/zh/embed/model/[slug]`).
+ *
+ * These render a single InferenceX chart without the site chrome so a third
+ * party page — the vLLM recipes site is the first consumer — can drop it into
+ * an `<iframe>`. `proxy.ts` relaxes `frame-ancestors` for the same prefix; the
+ * pathname test here is what the header, footer, and decorations use to stay
+ * out of the frame.
+ *
+ * Kept dependency-free because `proxy.ts` imports it into the edge bundle.
+ */
+export const EMBED_PATH_PREFIX = '/embed/';
+
+export function isEmbedPathname(pathname: string | null | undefined): boolean {
+  if (!pathname) return false;
+  return pathname.startsWith(EMBED_PATH_PREFIX) || pathname.startsWith(`/zh${EMBED_PATH_PREFIX}`);
+}

--- a/packages/app/src/lib/embed-route.ts
+++ b/packages/app/src/lib/embed-route.ts
@@ -15,3 +15,8 @@ export function isEmbedPathname(pathname: string | null | undefined): boolean {
   if (!pathname) return false;
   return pathname.startsWith(EMBED_PATH_PREFIX) || pathname.startsWith(`/zh${EMBED_PATH_PREFIX}`);
 }
+
+/** Request header the proxy uses to hand the raw `?theme=` value to the embed layout. */
+export const EMBED_THEME_HEADER = 'x-inferencex-embed-theme';
+/** Request header the proxy uses to hand the raw `?skin=` value to the embed layout. */
+export const EMBED_SKIN_HEADER = 'x-inferencex-embed-skin';

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { Sequence } from './data-mappings';
 import {
   EMBED_DEFAULT_Y_AXIS_METRIC,
+  EMBED_SKIN_HEADER,
+  EMBED_THEME_HEADER,
+  embedBootScript,
+  embedThemeFromHeaders,
   EMBED_RESIZE_MESSAGE_TYPE,
   isEmbedPathname,
   isEmbedResizeMessage,
@@ -99,6 +103,8 @@ describe('parseEmbedOptions', () => {
   });
 });
 
+const hdrs = (map: Record<string, string>) => (name: string) => map[name] ?? null;
+
 describe('isEmbedResizeMessage', () => {
   it('accepts only the resize shape with a finite height', () => {
     expect(isEmbedResizeMessage({ type: EMBED_RESIZE_MESSAGE_TYPE, height: 640 })).toBe(true);
@@ -108,5 +114,26 @@ describe('isEmbedResizeMessage', () => {
     expect(isEmbedResizeMessage({ type: 'other', height: 640 })).toBe(false);
     expect(isEmbedResizeMessage(null)).toBe(false);
     expect(isEmbedResizeMessage('inferencex:embed-resize')).toBe(false);
+  });
+
+  it('resolves theme and skin from the proxy-forwarded headers', () => {
+    expect(embedThemeFromHeaders(hdrs({}))).toEqual({ theme: 'dark', skin: undefined });
+    expect(embedThemeFromHeaders(hdrs({ [EMBED_THEME_HEADER]: 'vllm-light' }))).toEqual({
+      theme: 'light',
+      skin: 'vllm',
+    });
+    expect(
+      embedThemeFromHeaders(hdrs({ [EMBED_THEME_HEADER]: 'light', [EMBED_SKIN_HEADER]: 'vllm' })),
+    ).toEqual({ theme: 'light', skin: 'vllm' });
+    expect(embedThemeFromHeaders(hdrs({ [EMBED_SKIN_HEADER]: 'nope' })).skin).toBeUndefined();
+  });
+
+  it('boot script stamps the embed flag, theme class, and skin on <html>', () => {
+    const script = embedBootScript('light', 'vllm');
+    expect(script).toContain("h.dataset.inferencexEmbed=''");
+    expect(script).toContain('var s="vllm"');
+    expect(script).toContain('h.classList.add("light")');
+    expect(script).toContain('h.style.colorScheme="light"');
+    expect(embedBootScript('dark', undefined)).toContain('var s=null');
   });
 });

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { Sequence } from './data-mappings';
+import {
+  EMBED_RESIZE_MESSAGE_TYPE,
+  isEmbedPathname,
+  isEmbedResizeMessage,
+  parseEmbedOptions,
+} from './embed';
+
+describe('isEmbedPathname', () => {
+  it('matches the English and Chinese embed trees only', () => {
+    expect(isEmbedPathname('/embed/model/deepseek-v4')).toBe(true);
+    expect(isEmbedPathname('/zh/embed/model/deepseek-v4')).toBe(true);
+    expect(isEmbedPathname('/model/deepseek-v4')).toBe(false);
+    expect(isEmbedPathname('/embedded')).toBe(false);
+    expect(isEmbedPathname('/')).toBe(false);
+    expect(isEmbedPathname(null)).toBe(false);
+    expect(isEmbedPathname(undefined)).toBe(false);
+  });
+});
+
+describe('parseEmbedOptions', () => {
+  it('defaults to an unlocked dark chart on the featured scenario', () => {
+    expect(parseEmbedOptions({})).toEqual({
+      frameworks: [],
+      theme: 'dark',
+      sequence: undefined,
+      yAxisMetric: undefined,
+    });
+  });
+
+  it('locks to the requested framework families and drops unknown ones', () => {
+    // The lock is what keeps a vLLM-hosted embed from ever plotting another
+    // engine, so unknown keys must not silently widen it.
+    expect(parseEmbedOptions({ framework: 'vllm' }).frameworks).toEqual(['vllm']);
+    expect(parseEmbedOptions({ framework: 'VLLM, sglang' }).frameworks).toEqual(['vllm', 'sglang']);
+    expect(parseEmbedOptions({ framework: 'vllm,vllm,nope' }).frameworks).toEqual(['vllm']);
+    expect(parseEmbedOptions({ framework: 'nope' }).frameworks).toEqual([]);
+    expect(parseEmbedOptions({ fw: 'trt' }).frameworks).toEqual(['trt']);
+  });
+
+  it('takes the first value of a repeated query key', () => {
+    expect(parseEmbedOptions({ framework: ['vllm', 'sglang'] }).frameworks).toEqual(['vllm']);
+  });
+
+  it('accepts light or dark and falls back to dark', () => {
+    expect(parseEmbedOptions({ theme: 'light' }).theme).toBe('light');
+    expect(parseEmbedOptions({ theme: 'Dark' }).theme).toBe('dark');
+    expect(parseEmbedOptions({ theme: 'minecraft' }).theme).toBe('dark');
+  });
+
+  it('resolves scenario path segments and raw sequence keys', () => {
+    expect(parseEmbedOptions({ scenario: 'agentic' }).sequence).toBe(Sequence.AgenticTraces);
+    expect(parseEmbedOptions({ scenario: '8k-1k' }).sequence).toBe(Sequence.EightK_OneK);
+    expect(parseEmbedOptions({ i_seq: '1k/8k' }).sequence).toBe(Sequence.OneK_EightK);
+    expect(parseEmbedOptions({ scenario: 'bogus' }).sequence).toBeUndefined();
+  });
+
+  it('accepts known y-axis metrics only', () => {
+    expect(parseEmbedOptions({ metric: 'y_tokensPerDollarH' }).yAxisMetric).toBe(
+      'y_tokensPerDollarH',
+    );
+    expect(parseEmbedOptions({ metric: 'y' }).yAxisMetric).toBe('y');
+    expect(parseEmbedOptions({ metric: 'y_madeUp' }).yAxisMetric).toBeUndefined();
+  });
+});
+
+describe('isEmbedResizeMessage', () => {
+  it('accepts only the resize shape with a finite height', () => {
+    expect(isEmbedResizeMessage({ type: EMBED_RESIZE_MESSAGE_TYPE, height: 640 })).toBe(true);
+    expect(isEmbedResizeMessage({ type: EMBED_RESIZE_MESSAGE_TYPE, height: Number.NaN })).toBe(
+      false,
+    );
+    expect(isEmbedResizeMessage({ type: 'other', height: 640 })).toBe(false);
+    expect(isEmbedResizeMessage(null)).toBe(false);
+    expect(isEmbedResizeMessage('inferencex:embed-resize')).toBe(false);
+  });
+});

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -6,6 +6,7 @@ import {
   isEmbedPathname,
   isEmbedResizeMessage,
   parseEmbedOptions,
+  parseEmbedTheme,
 } from './embed';
 
 describe('isEmbedPathname', () => {
@@ -48,6 +49,32 @@ describe('parseEmbedOptions', () => {
     expect(parseEmbedOptions({ theme: 'light' }).theme).toBe('light');
     expect(parseEmbedOptions({ theme: 'Dark' }).theme).toBe('dark');
     expect(parseEmbedOptions({ theme: 'minecraft' }).theme).toBe('dark');
+    expect(parseEmbedOptions({ theme: 'light' }).skin).toBeUndefined();
+  });
+
+  it('splits a skinned theme into base theme + skin', () => {
+    expect(parseEmbedOptions({ theme: 'vllm-light' })).toMatchObject({
+      theme: 'light',
+      skin: 'vllm',
+    });
+    expect(parseEmbedOptions({ theme: 'VLLM-Dark' })).toMatchObject({
+      theme: 'dark',
+      skin: 'vllm',
+    });
+    // Unknown skin prefix: keep the base theme, drop the skin.
+    expect(parseEmbedOptions({ theme: 'sglang-light' })).toMatchObject({
+      theme: 'light',
+      skin: undefined,
+    });
+    // Standalone skin= is also accepted; theme= prefix wins when both are set.
+    expect(parseEmbedOptions({ skin: 'vllm' })).toMatchObject({ theme: 'dark', skin: 'vllm' });
+    expect(parseEmbedOptions({ skin: 'nope', theme: 'light' }).skin).toBeUndefined();
+  });
+
+  it('parseEmbedTheme handles empty and malformed input', () => {
+    expect(parseEmbedTheme(undefined)).toEqual({ theme: 'dark', skin: undefined });
+    expect(parseEmbedTheme('-')).toEqual({ theme: 'dark', skin: undefined });
+    expect(parseEmbedTheme('vllm-')).toEqual({ theme: 'dark', skin: 'vllm' });
   });
 
   it('resolves scenario path segments and raw sequence keys', () => {

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Sequence } from './data-mappings';
 import {
+  EMBED_DEFAULT_Y_AXIS_METRIC,
   EMBED_RESIZE_MESSAGE_TYPE,
   isEmbedPathname,
   isEmbedResizeMessage,
@@ -27,7 +28,7 @@ describe('parseEmbedOptions', () => {
       frameworks: [],
       theme: 'dark',
       sequence: undefined,
-      yAxisMetric: undefined,
+      yAxisMetric: 'y_tpPerGpu',
     });
   });
 
@@ -84,12 +85,17 @@ describe('parseEmbedOptions', () => {
     expect(parseEmbedOptions({ scenario: 'bogus' }).sequence).toBeUndefined();
   });
 
+  it('defaults the y-axis to total throughput per chip', () => {
+    expect(EMBED_DEFAULT_Y_AXIS_METRIC).toBe('y_tpPerGpu');
+    expect(parseEmbedOptions({}).yAxisMetric).toBe('y_tpPerGpu');
+  });
+
   it('accepts known y-axis metrics only', () => {
     expect(parseEmbedOptions({ metric: 'y_tokensPerDollarH' }).yAxisMetric).toBe(
       'y_tokensPerDollarH',
     );
     expect(parseEmbedOptions({ metric: 'y' }).yAxisMetric).toBe('y');
-    expect(parseEmbedOptions({ metric: 'y_madeUp' }).yAxisMetric).toBeUndefined();
+    expect(parseEmbedOptions({ metric: 'y_madeUp' }).yAxisMetric).toBe('y_tpPerGpu');
   });
 });
 

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -8,6 +8,34 @@ export { EMBED_PATH_PREFIX, isEmbedPathname } from '@/lib/embed-route';
 
 export type EmbedTheme = 'light' | 'dark';
 
+/**
+ * Host-site skins. A skin re-tokens the embed (colors, radius, fonts) so the
+ * chart sits inside the host's page instead of looking like a screenshot of
+ * InferenceX. Each skin has a light and a dark variant selected by the theme;
+ * the CSS lives in `globals.css` under `html[data-inferencex-skin='<skin>']`.
+ */
+export const EMBED_SKINS = ['vllm'] as const;
+export type EmbedSkin = (typeof EMBED_SKINS)[number];
+
+const SKIN_KEYS = new Set<string>(EMBED_SKINS);
+
+/**
+ * Split a `theme=` value into base theme + optional skin. Accepts `light`,
+ * `dark`, `<skin>-light`, `<skin>-dark`. Anything else is the dark default.
+ */
+export function parseEmbedTheme(raw: string | undefined): {
+  theme: EmbedTheme;
+  skin: EmbedSkin | undefined;
+} {
+  const value = raw?.trim().toLowerCase() ?? '';
+  const dash = value.lastIndexOf('-');
+  const base = dash === -1 ? value : value.slice(dash + 1);
+  const prefix = dash === -1 ? '' : value.slice(0, dash);
+  const theme: EmbedTheme = base === 'light' ? 'light' : 'dark';
+  const skin = SKIN_KEYS.has(prefix) ? (prefix as EmbedSkin) : undefined;
+  return { theme, skin };
+}
+
 export interface EmbedOptions {
   /**
    * Serving-framework families the chart is locked to (quick-filter keys:
@@ -17,6 +45,8 @@ export interface EmbedOptions {
    */
   frameworks: string[];
   theme: EmbedTheme;
+  /** Host-site skin; `undefined` renders InferenceX's own look. */
+  skin: EmbedSkin | undefined;
   /** Workload override; `undefined` keeps the model's featured scenario. */
   sequence: Sequence | undefined;
   /** Y-axis metric override; `undefined` keeps the dashboard default. */
@@ -37,7 +67,9 @@ function first(value: string | string[] | undefined): string | undefined {
  * should degrade to the unfiltered chart, not a blank frame.
  *
  * - `framework=vllm` or `framework=vllm,sglang` (also accepts `fw=`)
- * - `theme=light|dark` (default dark, matching the site)
+ * - `theme=light|dark|vllm-light|vllm-dark` (default dark, matching the site;
+ *   the `<skin>-` prefix re-tokens the embed to match the host site). `skin=`
+ *   is also accepted on its own.
  * - `scenario=agentic|8k-1k|1k-1k|1k-8k` (also accepts raw `i_seq=` keys)
  * - `metric=<y-axis metric key>` (e.g. `y_tokensPerDollarH`)
  */
@@ -54,8 +86,11 @@ export function parseEmbedOptions(
     ),
   ];
 
-  const rawTheme = first(searchParams.theme)?.toLowerCase();
-  const theme: EmbedTheme = rawTheme === 'light' ? 'light' : 'dark';
+  const parsedTheme = parseEmbedTheme(first(searchParams.theme));
+  const theme = parsedTheme.theme;
+  const rawSkin = first(searchParams.skin)?.trim().toLowerCase();
+  const skin =
+    parsedTheme.skin ?? (rawSkin && SKIN_KEYS.has(rawSkin) ? (rawSkin as EmbedSkin) : undefined);
 
   const rawScenario = first(searchParams.scenario) ?? first(searchParams.i_seq);
   const sequence = rawScenario
@@ -65,7 +100,7 @@ export function parseEmbedOptions(
   const rawMetric = first(searchParams.metric) ?? first(searchParams.i_metric);
   const yAxisMetric = rawMetric && Y_AXIS_METRIC_KEYS.has(rawMetric) ? rawMetric : undefined;
 
-  return { frameworks, theme, sequence, yAxisMetric };
+  return { frameworks, theme, skin, sequence, yAxisMetric };
 }
 
 /**

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -49,9 +49,17 @@ export interface EmbedOptions {
   skin: EmbedSkin | undefined;
   /** Workload override; `undefined` keeps the model's featured scenario. */
   sequence: Sequence | undefined;
-  /** Y-axis metric override; `undefined` keeps the dashboard default. */
-  yAxisMetric: string | undefined;
+  /**
+   * Y-axis metric. Defaults to {@link EMBED_DEFAULT_Y_AXIS_METRIC} (total
+   * token throughput per chip) rather than the dashboard's $/TCO default,
+   * because host sites want the raw hardware number without InferenceX's
+   * cost-tier assumptions.
+   */
+  yAxisMetric: string;
 }
+
+/** `y_tpPerGpu`: total token throughput per chip (tok/s/chip). */
+export const EMBED_DEFAULT_Y_AXIS_METRIC = 'y_tpPerGpu';
 
 const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
 const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);
@@ -98,7 +106,8 @@ export function parseEmbedOptions(
     : undefined;
 
   const rawMetric = first(searchParams.metric) ?? first(searchParams.i_metric);
-  const yAxisMetric = rawMetric && Y_AXIS_METRIC_KEYS.has(rawMetric) ? rawMetric : undefined;
+  const yAxisMetric =
+    rawMetric && Y_AXIS_METRIC_KEYS.has(rawMetric) ? rawMetric : EMBED_DEFAULT_Y_AXIS_METRIC;
 
   return { frameworks, theme, skin, sequence, yAxisMetric };
 }

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -4,7 +4,13 @@ import { toSequence } from '@/lib/compare-enum-coerce';
 import { sequenceForScenarioSegment } from '@/lib/compare-scenario-route';
 import type { Sequence } from '@/lib/data-mappings';
 
-export { EMBED_PATH_PREFIX, isEmbedPathname } from '@/lib/embed-route';
+export {
+  EMBED_PATH_PREFIX,
+  EMBED_SKIN_HEADER,
+  EMBED_THEME_HEADER,
+  isEmbedPathname,
+} from '@/lib/embed-route';
+import { EMBED_SKIN_HEADER, EMBED_THEME_HEADER } from '@/lib/embed-route';
 
 export type EmbedTheme = 'light' | 'dark';
 
@@ -132,4 +138,33 @@ export function isEmbedResizeMessage(data: unknown): data is EmbedResizeMessage 
     typeof (data as { height?: unknown }).height === 'number' &&
     Number.isFinite((data as { height: number }).height)
   );
+}
+
+/**
+ * Inline script that stamps the embed theme/skin on <html> before first
+ * paint. Rendered by the embed layouts (from the `x-inferencex-embed-theme`
+ * header the proxy forwards) so it runs ahead of `next-themes`; EmbedFrame
+ * re-applies the same state from React for client navigations.
+ * Values are validated enums, so interpolating them into JS is safe.
+ */
+export function embedBootScript(theme: EmbedTheme, skin: EmbedSkin | undefined): string {
+  const skinJs = skin ? JSON.stringify(skin) : 'null';
+  return (
+    `(function(){var h=document.documentElement;h.dataset.inferencexEmbed='';` +
+    `var s=${skinJs};if(s){h.dataset.inferencexSkin=s;}` +
+    `h.classList.remove('light','dark','minecraft');h.classList.add(${JSON.stringify(theme)});` +
+    `h.style.colorScheme=${JSON.stringify(theme)};})();`
+  );
+}
+
+/** Resolve theme + skin from the proxy-forwarded headers (same rules as `parseEmbedOptions`). */
+export function embedThemeFromHeaders(get: (name: string) => string | null | undefined): {
+  theme: EmbedTheme;
+  skin: EmbedSkin | undefined;
+} {
+  const parsed = parseEmbedTheme(get(EMBED_THEME_HEADER) ?? undefined);
+  const rawSkin = get(EMBED_SKIN_HEADER)?.trim().toLowerCase();
+  const skin =
+    parsed.skin ?? (rawSkin && SKIN_KEYS.has(rawSkin) ? (rawSkin as EmbedSkin) : undefined);
+  return { theme: parsed.theme, skin };
 }

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -1,0 +1,91 @@
+import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
+import { Y_AXIS_METRICS } from '@/lib/chart-utils';
+import { toSequence } from '@/lib/compare-enum-coerce';
+import { sequenceForScenarioSegment } from '@/lib/compare-scenario-route';
+import type { Sequence } from '@/lib/data-mappings';
+
+export { EMBED_PATH_PREFIX, isEmbedPathname } from '@/lib/embed-route';
+
+export type EmbedTheme = 'light' | 'dark';
+
+export interface EmbedOptions {
+  /**
+   * Serving-framework families the chart is locked to (quick-filter keys:
+   * `vllm`, `sglang`, `trt`, `atom`). Empty = every framework. A locked embed
+   * never shows other engines — not in the plot, the legend, or the filter
+   * dialog — so a host site can scope the chart to the engine it documents.
+   */
+  frameworks: string[];
+  theme: EmbedTheme;
+  /** Workload override; `undefined` keeps the model's featured scenario. */
+  sequence: Sequence | undefined;
+  /** Y-axis metric override; `undefined` keeps the dashboard default. */
+  yAxisMetric: string | undefined;
+}
+
+const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
+const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);
+
+/** Flatten a Next.js `searchParams` value to its first string. */
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Parse the embed query string. Unknown values fall back to defaults rather
+ * than 404ing — an embed is authored once and pasted many times, so a typo
+ * should degrade to the unfiltered chart, not a blank frame.
+ *
+ * - `framework=vllm` or `framework=vllm,sglang` (also accepts `fw=`)
+ * - `theme=light|dark` (default dark, matching the site)
+ * - `scenario=agentic|8k-1k|1k-1k|1k-8k` (also accepts raw `i_seq=` keys)
+ * - `metric=<y-axis metric key>` (e.g. `y_tokensPerDollarH`)
+ */
+export function parseEmbedOptions(
+  searchParams: Record<string, string | string[] | undefined>,
+): EmbedOptions {
+  const rawFrameworks = first(searchParams.framework) ?? first(searchParams.fw) ?? '';
+  const frameworks = [
+    ...new Set(
+      rawFrameworks
+        .split(',')
+        .map((f) => f.trim().toLowerCase())
+        .filter((f) => FRAMEWORK_KEYS.has(f)),
+    ),
+  ];
+
+  const rawTheme = first(searchParams.theme)?.toLowerCase();
+  const theme: EmbedTheme = rawTheme === 'light' ? 'light' : 'dark';
+
+  const rawScenario = first(searchParams.scenario) ?? first(searchParams.i_seq);
+  const sequence = rawScenario
+    ? (sequenceForScenarioSegment(rawScenario) ?? toSequence(rawScenario))
+    : undefined;
+
+  const rawMetric = first(searchParams.metric) ?? first(searchParams.i_metric);
+  const yAxisMetric = rawMetric && Y_AXIS_METRIC_KEYS.has(rawMetric) ? rawMetric : undefined;
+
+  return { frameworks, theme, sequence, yAxisMetric };
+}
+
+/**
+ * `postMessage` contract between the embed and its host page. The embed posts
+ * its rendered height whenever it changes so the host can size the iframe
+ * without a scrollbar; the host is expected to check `event.origin`.
+ */
+export const EMBED_RESIZE_MESSAGE_TYPE = 'inferencex:embed-resize';
+
+export interface EmbedResizeMessage {
+  type: typeof EMBED_RESIZE_MESSAGE_TYPE;
+  height: number;
+}
+
+export function isEmbedResizeMessage(data: unknown): data is EmbedResizeMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: unknown }).type === EMBED_RESIZE_MESSAGE_TYPE &&
+    typeof (data as { height?: unknown }).height === 'number' &&
+    Number.isFinite((data as { height: number }).height)
+  );
+}

--- a/packages/app/src/lib/i18n.test.ts
+++ b/packages/app/src/lib/i18n.test.ts
@@ -108,6 +108,7 @@ describe('hasZhSibling', () => {
     expect(hasZhSibling('/compare-precision/deepseek-r1-h100-fp8-vs-bf16')).toBe(true);
     expect(hasZhSibling('/compare-spec-decode')).toBe(true);
     expect(hasZhSibling('/compare-spec-decode/deepseek-r1-h100-mtp-vs-none')).toBe(true);
+    expect(hasZhSibling('/embed/model/deepseek-v4')).toBe(true);
   });
 
   it('matches the model index and model detail pages', () => {

--- a/packages/app/src/lib/i18n.ts
+++ b/packages/app/src/lib/i18n.ts
@@ -58,6 +58,7 @@ export const ZH_MIRRORED_ROUTES: readonly { path: string; exact?: boolean }[] = 
   { path: '/glossary' },
   { path: '/chips' },
   { path: '/model' },
+  { path: '/embed' },
   { path: '/agentx' },
   { path: '/rankings' },
   { path: '/run' },

--- a/packages/app/src/proxy.ts
+++ b/packages/app/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-import { isEmbedPathname } from '@/lib/embed-route';
+import { EMBED_SKIN_HEADER, EMBED_THEME_HEADER, isEmbedPathname } from '@/lib/embed-route';
 
 // `/embed/*` and `/zh/embed/*` render single charts meant to be framed by
 // third-party pages (the vLLM recipes site), so they opt out of the default
@@ -12,6 +12,12 @@ export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   if (isEmbedRoute) {
     requestHeaders.set('x-inferencex-embed', '1');
+    // Layouts cannot read search params, so hand the theme/skin over as
+    // headers; the embed layout turns them into a pre-paint boot script.
+    const theme = request.nextUrl.searchParams.get('theme');
+    const skin = request.nextUrl.searchParams.get('skin');
+    if (theme) requestHeaders.set(EMBED_THEME_HEADER, theme);
+    if (skin) requestHeaders.set(EMBED_SKIN_HEADER, skin);
   }
 
   const response = NextResponse.next({

--- a/packages/app/src/proxy.ts
+++ b/packages/app/src/proxy.ts
@@ -1,10 +1,14 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-const EMBED_PATH_PREFIX = '/embed/';
+import { isEmbedPathname } from '@/lib/embed-route';
+
+// `/embed/*` and `/zh/embed/*` render single charts meant to be framed by
+// third-party pages (the vLLM recipes site), so they opt out of the default
+// same-origin framing policy.
 const EMBED_CSP = 'frame-ancestors *';
 
 export function proxy(request: NextRequest) {
-  const isEmbedRoute = request.nextUrl.pathname.startsWith(EMBED_PATH_PREFIX);
+  const isEmbedRoute = isEmbedPathname(request.nextUrl.pathname);
   const requestHeaders = new Headers(request.headers);
   if (isEmbedRoute) {
     requestHeaders.set('x-inferencex-embed', '1');


### PR DESCRIPTION
## Summary

Prototype for embedding InferenceX charts in third-party sites. First consumer is the vLLM recipes site (companion PR: SemiAnalysisAI/recipes `feat/inferencex-embed`).

New route: `/embed/model/<slug>` plus the `/zh/embed/model/<slug>` sibling. It renders `EmbeddedModelDashboard` (the same chart `/model/<slug>` uses) without header, footer, or background decorations, and is `noindex`.

Query options (`parseEmbedOptions` in `lib/embed.ts`; unknown values degrade to defaults instead of 404ing):

| param | values | effect |
|---|---|---|
| `framework` | `vllm`, `sglang`, `trt`, `atom` (comma list) | locks the chart to those framework families |
| `theme` | `light`, `dark` (default), `vllm-light`, `vllm-dark` | forces the theme inside the iframe; a `<skin>-` prefix also applies a host skin |
| `skin` | `vllm` | host skin without the `theme=` prefix form |
| `scenario` | `agentic`, `8k-1k`, `1k-1k`, `1k-8k` | overrides the model's featured scenario |
| `metric` | any `Y_AXIS_METRICS` key | y-axis metric; defaults to `y_tpPerGpu` (total token throughput per chip), not the dashboard's $/TCO default |

### Framework lock

`InferenceProvider` gets a `lockedFrameworks` prop. When set:

- `quickFilters.frameworks` mirrors the lock; `setQuickFilterFrameworks` and the `i_fw` URL param are no-ops.
- `availableGPUs` drops rows whose `frameworkFamily()` is outside the lock, so `autoSelectAllGpus` cannot pull in other engines' chip configs (this is what keeps SGLang/ATOM/TRT out of the plot, legend, and config changelog, not just the filter).
- `QuickFiltersDialog` omits the framework group, `ActiveQuickFilters` renders no removable chip for it, and the legend's "Quick Filters (n)" count excludes it.
- `lockedFrameworks` is exposed on `InferenceFiltersContextType`.

### Host integration

- `proxy.ts` already set `frame-ancestors *` for `/embed/`; the check now uses `isEmbedPathname` so `/zh/embed/` is covered too.
- `EmbedFrame` posts `{ type: 'inferencex:embed-resize', height }` to `window.parent` on every size change so the host can grow the iframe without an inner scrollbar. `isEmbedResizeMessage` is exported for hosts that share code.
- A footer row inside the embed shows the lock ("Showing vLLM results only") and links back to `/inference` with matching `g_model`, `i_seq`, `i_fw`.

### Host skin (`theme=vllm-light` / `theme=vllm-dark`)

Stock InferenceX light/dark looked foreign inside the recipes page, so the embed can carry a per-host skin. `parseEmbedTheme` splits `<skin>-<light|dark>`; the base theme still drives the `light`/`dark` class on `<html>` so every `resolvedTheme` check keeps working, and the skin lands in `data-inferencex-skin`. `globals.css` scopes token overrides to `html[data-inferencex-skin='vllm']` (recipes' shadcn slate palette, vLLM `#fdb517` / `#30a2ff` accents, flat `--card` instead of the blurred translucent card). Fonts come from `EmbedShell` (`next/font` Inter + JetBrains Mono under `--font-embed-sans` / `--font-embed-mono`), hoisted from the shell div onto `<html>` so Radix portals pick them up. `--muted` stays mid-slate because the app uses it as a text color.

### Minimal chrome

`InferenceProvider` gets `minimalChrome` (set by the embed route). `ChartDisplay` then drops `ChartButtons`, the top selector card (x-axis mode, compare history, run dates, config changelog, Optimal Only, gradient labels, Advanced), `ActiveQuickFilters`, `ReplayLauncher`, and the metric assumption notes (which name other engines in their examples). `ChartLegend` gets a `readOnly` prop, threaded from `ScatterGraph`/`GPUGraph`, that removes the switches, panel toolbar, Quick Filters button, per-item actions, tooltips, and the changelog highlight. The chart, a plain legend, and the source/updated caption remain.

### Overlay support

The embed reuses `EmbeddedModelDashboard`, so unofficial-run overlays behave as they do on `/model/<slug>` (`UnofficialRunProvider` is mounted in `embed/layout.tsx`). No new overlay-specific UI.

### Tests

- `lib/embed.test.ts`: pathname matching, option parsing (framework dedupe/unknown keys, theme fallback, skinned themes and `skin=`, unknown skin prefixes, scenario segments and raw sequence keys, metric allowlist), resize message guard.
- `lib/i18n.test.ts`: `/embed` added to mirrored routes.
- Full `vitest run`: 298 files, 4963 tests pass. `bun run lint`, `bun run typecheck`, `bun run fmt` clean.
- Verified locally against the read-only DB: `/embed/model/{deepseek-v4,kimi-k3,minimax-m3}?framework=vllm` render only `(vLLM)` / `(Dynamo vLLM)` legend entries; light/dark and zh variants checked. Screenshots are in the Slack thread.

### Not in this PR

- No sitemap entry (routes are `noindex`).
- No Cypress e2e for the embed route yet; the lock logic is covered by the provider change and the unit tests above.

## 中文说明

新增可嵌入的单模型图表路由 `/embed/model/<slug>`（含 `/zh/embed/model/<slug>`），供第三方站点通过 iframe 引用，首个使用方是 vLLM recipes 网站。页面不渲染页头、页脚与背景装饰，并设置 `noindex`。

支持的查询参数：`framework`（锁定推理框架，如 `vllm`）、`theme`（`light`/`dark`，或带宿主皮肤前缀的 `vllm-light`/`vllm-dark`）、`skin`（`vllm`）、`scenario`（`agentic`、`8k-1k` 等）、`metric`（Y 轴指标，默认 `y_tpPerGpu` 即每芯片总 token 吞吐量）。未知值回退到默认，不会 404。

`InferenceProvider` 新增 `lockedFrameworks`：锁定后框架快捷筛选不可编辑，`availableGPUs` 只保留锁定框架的配置，因此其他框架不会出现在图表、图例、配置变更日志或筛选对话框中。嵌入页通过 postMessage（`inferencex:embed-resize`）向宿主页面上报高度。

宿主皮肤：`vllm-*` 主题保留 `light`/`dark` 类，另在 `<html>` 上写入 `data-inferencex-skin`，由 `globals.css` 覆盖配色令牌（recipes 站点的 slate 色板与 vLLM 黄/蓝强调色），字体由 `EmbedShell` 通过 `next/font` 提供 Inter 与 JetBrains Mono。`InferenceProvider` 新增 `minimalChrome`：嵌入页隐藏坐标轴指标选择、历史对比、运行日期、配置变更日志、快捷筛选、Optimal Only、渐变标签与高级选项，图例改为只读（`ChartLegend.readOnly`），只保留图表、图例和数据来源说明。

测试：新增 `lib/embed.test.ts`，`i18n.test.ts` 补充 `/embed` 镜像路由；全部单元测试、lint、typecheck、格式检查通过；已在本地对 deepseek-v4 / kimi-k3 / minimax-m3 验证图例仅包含 vLLM。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inference filtering/GPU availability and new publicly embeddable routes with relaxed framing CSP (`frame-ancestors *`) on embed paths only; core dashboard paths are unchanged aside from optional provider props.
> 
> **Overview**
> Adds **embeddable single-model chart routes** at `/embed/model/[slug]` and `/zh/embed/model/[slug]` (`noindex`, no header/footer) for third-party iframes (vLLM recipes is the first consumer).
> 
> **Query-driven behavior** is centralized in `parseEmbedOptions`: optional **framework lock** (`framework`/`fw`), **theme** and **vLLM skin** (`theme=vllm-light|vllm-dark`, `skin=vllm`), **scenario**, and **y-axis metric** (default `y_tpPerGpu`). Unknown params degrade to defaults instead of 404ing.
> 
> **Host integration:** `proxy.ts` now uses `isEmbedPathname` (includes `/zh/embed/`), sets `frame-ancestors *`, and forwards `theme`/`skin` as headers for a **pre-paint boot script** (`EmbedBoot` + `EmbedFrame`) so the iframe does not flash the wrong theme. `EmbedFrame` posts **`inferencex:embed-resize`** height updates to the parent and shows attribution plus a deep link back to `/inference`.
> 
> **Dashboard changes for embeds:** `InferenceProvider` gains **`lockedFrameworks`** (pins quick filters, trims `availableGPUs`, hides framework UI) and **`minimalChrome`** (strips chart toolbar, controls card, quick filters, replay, etc.). `ChartLegend.readOnly` simplifies the legend. **`globals.css`** hides decorative backgrounds on `data-inferencex-embed` and adds **vLLM skin** design tokens/fonts.
> 
> Unit tests in `lib/embed.test.ts`; i18n mirrors `/embed`; Cypress mocks extended with the new context fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269fccb3139f6d03ebbfcebc221472e95e7f147c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->