### PR TITLE
feat(profit): add compare history to /profit-estimator and /profit-estimator-per-gigawatt / 利润估算器：新增对比历史趋势面板

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -367,6 +367,13 @@ const chipTrigger = () =>
   cy.get('[data-testid="profit-history-gpu-multiselect"] [role="combobox"]');
 const axisLabels = () => chartSvg().find('.x-axis text');
 const changelog = () => cy.get('[data-testid="profit-history-changelog"]');
+// The chip options need the availability rows and the auto-resolved
+// precision, both of which land with the first priced chart, so every panel
+// interaction waits for a bar before opening the MultiSelect.
+const waitForChart = () => {
+  chart().should('exist');
+  bars().should('have.length.greaterThan', 0);
+};
 const pickChip = (label: string) => {
   chipTrigger().click({ force: true });
   cy.get('[role="option"]').contains(label).click();
@@ -386,40 +393,41 @@ describe('Profit Estimator per GW — compare history', () => {
       .then((allBars) => {
         chipTrigger().should('contain.text', 'Select a Chip Config for comparison');
         chipTrigger().click({ force: true });
-        // The four SKUs at the auto-resolved precision (fp4); the H200 fp8 row is
-        // left out just as it is left off the chart, and single-turn rows are
-        // never offered.
-        cy.get('[role="option"]').should('have.length', 4).and('contain.text', 'GB300');
-        cy.get('[role="option"]').should('not.contain.text', 'H200');
+        // Every agentic SKU at the effective precisions. The lone fp8 curve
+        // (H200) keeps both precisions in play (the sparse-precision rule), so
+        // it is offered as a chip even though its curve stops short of the
+        // target on the chart, as on `/inference`. Single-turn rows are never
+        // offered.
+        cy.get('[role="option"]').should('have.length', 5).and('contain.text', 'GB300');
+        cy.get('[role="option"]').should('contain.text', 'H200');
         cy.get('[role="option"]').contains('GB300').click();
         cy.get('body').type('{esc}');
         cy.get('[data-testid="profit-history-date-range"]').should('be.visible');
         // A chip alone changes nothing: the chart waits for a range.
         bars().should('have.length', allBars);
-        cy.location('search').should('contain', 'i_gpus=gb300_sglang');
+        chipTrigger().should('contain.text', 'GB300');
         // Clearing the chips also clears the range control.
         chipTrigger().click({ force: true });
         cy.get('[role="option"]').contains('GB300').click();
         cy.get('body').type('{esc}');
         cy.get('[data-testid="profit-history-date-range"]').should('not.exist');
-        cy.location('search').should('not.contain', 'i_gpus=');
+        chipTrigger().should('contain.text', 'Select a Chip Config for comparison');
       });
   });
 
-  it('prices the chosen chips on the range endpoints next to today and syncs the URL', () => {
+  it('prices the chosen chips on the range endpoints next to today', () => {
     cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
-    chart().should('exist');
-    chipTrigger().click({ force: true });
-    cy.get('[role="option"]').contains('GB300').click();
-    cy.get('[role="option"]').contains('B200').click();
-    cy.get('body').type('{esc}');
+    waitForChart();
+    // The MultiSelect closes after each pick, so the second chip reopens it.
+    pickChip('GB300');
+    pickChip('B200');
     cy.contains('button', 'Select date range').click();
     cy.contains('button', 'Max Range').click();
     cy.contains('button', 'Apply').click();
 
-    cy.location('search')
-      .should('contain', `i_dstart=${PROFIT_HISTORY_DATE}`)
-      .and('contain', `i_dend=${PROFIT_DATE}`);
+    // The picker shows the applied range (the address bar is deliberately
+    // left clean after load, see url-state.ts, so the UI is what is asserted).
+    cy.contains('button', 'Jul 15, 2026').should('be.visible');
     // Two chips × (today + the earlier endpoint) = four stacked bars; the
     // range's end date is today's run, so it is not fetched again.
     chart().find('rect.bar-tco').should('have.length', 4);
@@ -455,12 +463,13 @@ describe('Profit Estimator per GW — compare history', () => {
     cy.get('[data-testid="profit-history-date-range"]').should('not.exist');
     cy.get('[data-testid="profit-history-note"]').should('not.exist');
     chart().find('rect.bar-tco').should('have.length', 4);
-    cy.location('search').should('not.contain', 'i_dstart=').and('not.contain', 'i_gpus=');
+    chipTrigger().should('contain.text', 'Select a Chip Config for comparison');
+    changelog().should('not.exist');
   });
 
   it('lists the Config Changelog for the chosen chips and pins a date onto the chart', () => {
     cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
-    chart().should('exist');
+    waitForChart();
     changelog().should('not.exist');
     pickChip('GB300');
     // One block per fixture date, expanded by default as on /inference, with
@@ -476,16 +485,15 @@ describe('Profit Estimator per GW — compare history', () => {
       .and('contain.text', 'Add all to chart');
     // Nothing is on the chart yet, so every date offers "Add to chart".
     changelog().find('span:contains("On chart")').should('have.length', 0);
-    // Pin the earlier date: the URL gains `i_dates`, the chart shows GB300
-    // today plus GB300 on that date, and the row flips to "Remove from chart".
+    // Pin the earlier date: the chart shows GB300 today plus GB300 on that
+    // date, the range picker stays empty, and the row flips to "Remove from
+    // chart".
     changelog()
       .contains('span', PROFIT_HISTORY_DATE)
       .parent()
       .contains('button', 'Add to chart')
       .click();
-    cy.location('search')
-      .should('contain', `i_dates=${PROFIT_HISTORY_DATE}`)
-      .and('not.contain', 'i_dstart=');
+    cy.contains('button', 'Select date range').should('be.visible');
     chart().find('rect.bar-tco').should('have.length', 2);
     axisLabels().should('contain.text', PROFIT_HISTORY_DATE);
     cy.get('[data-testid="profit-history-note"]').should('contain.text', PROFIT_HISTORY_DATE);
@@ -494,14 +502,14 @@ describe('Profit Estimator per GW — compare history', () => {
       .parent()
       .contains('button', 'Remove from chart')
       .click();
-    cy.location('search').should('not.contain', 'i_dates=');
+    changelog().find('button:contains("Remove from chart")').should('have.length', 0);
     cy.get('[data-testid="profit-history-note"]').should('not.exist');
     chart().find('rect.bar-tco').should('have.length', 4);
   });
 
   it('offers each same-day run as its own numbered bar and adds them all at once', () => {
     cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
-    chart().should('exist');
+    waitForChart();
     pickChip('GB300');
     // The twice-run date renders one block per run, numbered in start order,
     // each with its own notes.
@@ -515,16 +523,18 @@ describe('Profit Estimator per GW — compare history', () => {
       .parent()
       .contains('button', 'Add to chart')
       .click();
-    cy.location('search').should('contain', `i_dates=${PROFIT_RUN_DATE}~r${PROFIT_RUNS[0].runId}`);
+    changelog()
+      .contains('span', `${PROFIT_RUN_DATE} #1`)
+      .parent()
+      .contains('button', 'Remove from chart')
+      .should('exist');
     chart().find('rect.bar-tco').should('have.length', 2);
     axisLabels().should('contain.text', `${PROFIT_RUN_DATE} #1`);
     // "Add all" pins run #2 and the earlier date as well; today's run date is
     // already the main bar, so it adds nothing. Bars run oldest → newest and,
     // at 80% / 85% / 92% / 100% of today's throughput, rise left to right.
     changelog().contains('button', 'Add all to chart').click();
-    cy.location('search')
-      .should('contain', `${PROFIT_RUN_DATE}~r${PROFIT_RUNS[1].runId}`)
-      .and('contain', PROFIT_HISTORY_DATE);
+    changelog().find('button:contains("Add to chart")').should('have.length', 0);
     chart().find('rect.bar-tco').should('have.length', 4);
     axisLabels().should('contain.text', `${PROFIT_RUN_DATE} #2`);
     revenueLabels().then(($labels) => {
@@ -560,7 +570,7 @@ describe('Profit Estimator per GW — compare history', () => {
 
   it('serves the panel on the Chinese mirror with translated labels', () => {
     cy.visit('/zh/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
-    chart().should('exist');
+    waitForChart();
     historyPanel().should('contain.text', '对比历史趋势').and('contain.text', '芯片配置');
     chipTrigger().should('contain.text', '选择芯片配置进行对比');
     pickChip('GB300');
@@ -785,7 +795,9 @@ describe('Profit Estimator — MiniMax M3', () => {
 
     cy.get('[data-testid="profit-model-selector"]').click();
     cy.contains('[role="option"]', 'Kimi K3').click();
-    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
+    // Leaving a per-model path always rewrites to the target model's slug,
+    // as the GLM → Kimi switch above asserts.
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/kimi-k3');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -24,7 +24,14 @@
 //    chart draws only the compared chips, today's bar plus one per range
 //    endpoint priced from that date's run, labelled with the date.
 
-import { interceptProfitData, PROFIT_DATE, PROFIT_HISTORY_DATE } from '../support/profit-fixtures';
+import {
+  interceptProfitData,
+  PROFIT_CHANGELOG_NOTES,
+  PROFIT_DATE,
+  PROFIT_HISTORY_DATE,
+  PROFIT_RUN_DATE,
+  PROFIT_RUNS,
+} from '../support/profit-fixtures';
 
 // Kimi K3 is the page default; the DeepSeek row proves the page prices the
 // routed model, not the first catalog entry. The GLM and MiniMax rows sit below
@@ -359,6 +366,12 @@ const historyPanel = () => cy.get('[data-testid="profit-history-panel"]');
 const chipTrigger = () =>
   cy.get('[data-testid="profit-history-gpu-multiselect"] [role="combobox"]');
 const axisLabels = () => chartSvg().find('.x-axis text');
+const changelog = () => cy.get('[data-testid="profit-history-changelog"]');
+const pickChip = (label: string) => {
+  chipTrigger().click({ force: true });
+  cy.get('[role="option"]').contains(label).click();
+  cy.get('body').type('{esc}');
+};
 
 describe('Profit Estimator per GW — compare history', () => {
   beforeEach(stubOpenRouter);
@@ -445,11 +458,113 @@ describe('Profit Estimator per GW — compare history', () => {
     cy.location('search').should('not.contain', 'i_dstart=').and('not.contain', 'i_gpus=');
   });
 
+  it('lists the Config Changelog for the chosen chips and pins a date onto the chart', () => {
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    changelog().should('not.exist');
+    pickChip('GB300');
+    // One block per fixture date, expanded by default as on /inference, with
+    // the run's notes and its Git Commit / Workflow Run links.
+    changelog()
+      .contains('button', 'Config Changelog (3 dates with changes)')
+      .should('have.attr', 'aria-expanded', 'true');
+    changelog()
+      .should('contain.text', PROFIT_CHANGELOG_NOTES[PROFIT_HISTORY_DATE])
+      .and('contain.text', PROFIT_CHANGELOG_NOTES[PROFIT_DATE])
+      .and('contain.text', 'Git Commit')
+      .and('contain.text', 'Workflow Run')
+      .and('contain.text', 'Add all to chart');
+    // Nothing is on the chart yet, so every date offers "Add to chart".
+    changelog().find('span:contains("On chart")').should('have.length', 0);
+    // Pin the earlier date: the URL gains `i_dates`, the chart shows GB300
+    // today plus GB300 on that date, and the row flips to "Remove from chart".
+    changelog()
+      .contains('span', PROFIT_HISTORY_DATE)
+      .parent()
+      .contains('button', 'Add to chart')
+      .click();
+    cy.location('search')
+      .should('contain', `i_dates=${PROFIT_HISTORY_DATE}`)
+      .and('not.contain', 'i_dstart=');
+    chart().find('rect.bar-tco').should('have.length', 2);
+    axisLabels().should('contain.text', PROFIT_HISTORY_DATE);
+    cy.get('[data-testid="profit-history-note"]').should('contain.text', PROFIT_HISTORY_DATE);
+    changelog()
+      .contains('span', PROFIT_HISTORY_DATE)
+      .parent()
+      .contains('button', 'Remove from chart')
+      .click();
+    cy.location('search').should('not.contain', 'i_dates=');
+    cy.get('[data-testid="profit-history-note"]').should('not.exist');
+    chart().find('rect.bar-tco').should('have.length', 4);
+  });
+
+  it('offers each same-day run as its own numbered bar and adds them all at once', () => {
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    pickChip('GB300');
+    // The twice-run date renders one block per run, numbered in start order,
+    // each with its own notes.
+    changelog()
+      .should('contain.text', `${PROFIT_RUN_DATE} #1`)
+      .and('contain.text', `${PROFIT_RUN_DATE} #2`)
+      .and('contain.text', PROFIT_CHANGELOG_NOTES.run1)
+      .and('contain.text', PROFIT_CHANGELOG_NOTES.run2);
+    changelog()
+      .contains('span', `${PROFIT_RUN_DATE} #1`)
+      .parent()
+      .contains('button', 'Add to chart')
+      .click();
+    cy.location('search').should('contain', `i_dates=${PROFIT_RUN_DATE}~r${PROFIT_RUNS[0].runId}`);
+    chart().find('rect.bar-tco').should('have.length', 2);
+    axisLabels().should('contain.text', `${PROFIT_RUN_DATE} #1`);
+    // "Add all" pins run #2 and the earlier date as well; today's run date is
+    // already the main bar, so it adds nothing. Bars run oldest → newest and,
+    // at 80% / 85% / 92% / 100% of today's throughput, rise left to right.
+    changelog().contains('button', 'Add all to chart').click();
+    cy.location('search')
+      .should('contain', `${PROFIT_RUN_DATE}~r${PROFIT_RUNS[1].runId}`)
+      .and('contain', PROFIT_HISTORY_DATE);
+    chart().find('rect.bar-tco').should('have.length', 4);
+    axisLabels().should('contain.text', `${PROFIT_RUN_DATE} #2`);
+    revenueLabels().then(($labels) => {
+      const revenues = [...$labels].map((el) => parseCompactUsd(el.textContent ?? ''));
+      expect(revenues).to.have.length(4);
+      expect(revenues[0]).to.be.lessThan(revenues[1]!);
+      expect(revenues[1]).to.be.lessThan(revenues[2]!);
+      expect(revenues[2]).to.be.lessThan(revenues[3]!);
+    });
+  });
+
+  it('hydrates pinned runs from the URL and locks the range endpoints as "On chart"', () => {
+    cy.visit(
+      `/profit-estimator-per-gigawatt?i_gpus=gb300_sglang&i_dstart=${PROFIT_HISTORY_DATE}&i_dend=${PROFIT_DATE}&i_dates=${PROFIT_RUN_DATE}~r${PROFIT_RUNS[1].runId}`,
+      { onBeforeLoad: suppressNudges },
+    );
+    chart().should('exist');
+    // Range start + pinned run #2 + today.
+    chart().find('rect.bar-tco').should('have.length', 3);
+    axisLabels()
+      .should('contain.text', PROFIT_HISTORY_DATE)
+      .and('contain.text', `${PROFIT_RUN_DATE} #2`);
+    // Range endpoints cannot be removed individually; the pinned run can.
+    changelog().find('span:contains("On chart")').should('have.length', 2);
+    changelog().find('button:contains("On chart")').should('have.length', 0);
+    changelog().find('button:contains("Remove from chart")').should('have.length', 1);
+    changelog()
+      .contains('span', `${PROFIT_RUN_DATE} #1`)
+      .parent()
+      .contains('button', 'Add to chart')
+      .should('exist');
+  });
+
   it('serves the panel on the Chinese mirror with translated labels', () => {
     cy.visit('/zh/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
     chart().should('exist');
     historyPanel().should('contain.text', '对比历史趋势').and('contain.text', '芯片配置');
     chipTrigger().should('contain.text', '选择芯片配置进行对比');
+    pickChip('GB300');
+    changelog().should('contain.text', '配置变更日志').and('contain.text', '添加到图表');
   });
 });
 

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -18,9 +18,13 @@
 //  - the heading reads like /inference, the subtitle names the utilization, and
 //    the formula folds away under the chart;
 //  - /profit-estimator/<model> is the per-model route; switching models
-//    rewrites the address bar in place.
+//    rewrites the address bar in place;
+//  - the compare-history panel mirrors /inference: up to four chip configs and
+//    a date range, kept in `i_gpus`/`i_dstart`/`i_dend`; with a range set the
+//    chart draws only the compared chips, today's bar plus one per range
+//    endpoint priced from that date's run, labelled with the date.
 
-import { interceptProfitData } from '../support/profit-fixtures';
+import { interceptProfitData, PROFIT_DATE, PROFIT_HISTORY_DATE } from '../support/profit-fixtures';
 
 // Kimi K3 is the page default; the DeepSeek row proves the page prices the
 // routed model, not the first catalog entry. The GLM and MiniMax rows sit below
@@ -348,6 +352,104 @@ describe('Profit Estimator per GW', () => {
       'OpenRouter has no price',
     );
     chart().should('not.exist');
+  });
+});
+
+const historyPanel = () => cy.get('[data-testid="profit-history-panel"]');
+const chipTrigger = () =>
+  cy.get('[data-testid="profit-history-gpu-multiselect"] [role="combobox"]');
+const axisLabels = () => chartSvg().find('.x-axis text');
+
+describe('Profit Estimator per GW — compare history', () => {
+  beforeEach(stubOpenRouter);
+
+  it('offers the agentic chip configs and shows the range picker once one is chosen', () => {
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    historyPanel().should('contain.text', 'Compare history').and('contain.text', 'Chip Config');
+    cy.get('[data-testid="profit-history-date-range"]').should('not.exist');
+    bars()
+      .its('length')
+      .then((allBars) => {
+        chipTrigger().should('contain.text', 'Select a Chip Config for comparison');
+        chipTrigger().click({ force: true });
+        // The four SKUs at the auto-resolved precision (fp4); the H200 fp8 row is
+        // left out just as it is left off the chart, and single-turn rows are
+        // never offered.
+        cy.get('[role="option"]').should('have.length', 4).and('contain.text', 'GB300');
+        cy.get('[role="option"]').should('not.contain.text', 'H200');
+        cy.get('[role="option"]').contains('GB300').click();
+        cy.get('body').type('{esc}');
+        cy.get('[data-testid="profit-history-date-range"]').should('be.visible');
+        // A chip alone changes nothing: the chart waits for a range.
+        bars().should('have.length', allBars);
+        cy.location('search').should('contain', 'i_gpus=gb300_sglang');
+        // Clearing the chips also clears the range control.
+        chipTrigger().click({ force: true });
+        cy.get('[role="option"]').contains('GB300').click();
+        cy.get('body').type('{esc}');
+        cy.get('[data-testid="profit-history-date-range"]').should('not.exist');
+        cy.location('search').should('not.contain', 'i_gpus=');
+      });
+  });
+
+  it('prices the chosen chips on the range endpoints next to today and syncs the URL', () => {
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    chipTrigger().click({ force: true });
+    cy.get('[role="option"]').contains('GB300').click();
+    cy.get('[role="option"]').contains('B200').click();
+    cy.get('body').type('{esc}');
+    cy.contains('button', 'Select date range').click();
+    cy.contains('button', 'Max Range').click();
+    cy.contains('button', 'Apply').click();
+
+    cy.location('search')
+      .should('contain', `i_dstart=${PROFIT_HISTORY_DATE}`)
+      .and('contain', `i_dend=${PROFIT_DATE}`);
+    // Two chips × (today + the earlier endpoint) = four stacked bars; the
+    // range's end date is today's run, so it is not fetched again.
+    chart().find('rect.bar-tco').should('have.length', 4);
+    cy.get('[data-testid="profit-legend"] li').should('have.length', 2);
+    cy.get('[data-testid="profit-history-note"]')
+      .should('contain.text', 'Compare history')
+      .and('contain.text', PROFIT_HISTORY_DATE);
+    axisLabels().should('contain.text', PROFIT_HISTORY_DATE);
+    // The earlier run carries 80% of the throughput, so each chip's history
+    // bar is shorter than its current one and sits immediately to its left.
+    revenueLabels().then(($labels) => {
+      const revenues = [...$labels].map((el) => parseCompactUsd(el.textContent ?? ''));
+      expect(revenues).to.have.length(4);
+      expect(revenues[0]).to.be.lessThan(revenues[1]!);
+      expect(revenues[2]).to.be.lessThan(revenues[3]!);
+    });
+  });
+
+  it('hydrates the comparison from the URL and clears the range with the chips', () => {
+    cy.visit(
+      `/profit-estimator-per-gigawatt?i_gpus=b200_sglang&i_dstart=${PROFIT_HISTORY_DATE}&i_dend=${PROFIT_DATE}`,
+      { onBeforeLoad: suppressNudges },
+    );
+    chart().should('exist');
+    chipTrigger().should('contain.text', 'B200');
+    cy.contains('button', 'Jul 15, 2026').should('be.visible');
+    chart().find('rect.bar-tco').should('have.length', 2);
+    cy.get('[data-testid="profit-legend"] li').should('have.length', 1);
+
+    chipTrigger().click({ force: true });
+    cy.get('[role="option"]').contains('B200').click();
+    cy.get('body').type('{esc}');
+    cy.get('[data-testid="profit-history-date-range"]').should('not.exist');
+    cy.get('[data-testid="profit-history-note"]').should('not.exist');
+    chart().find('rect.bar-tco').should('have.length', 4);
+    cy.location('search').should('not.contain', 'i_dstart=').and('not.contain', 'i_gpus=');
+  });
+
+  it('serves the panel on the Chinese mirror with translated labels', () => {
+    cy.visit('/zh/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    historyPanel().should('contain.text', '对比历史趋势').and('contain.text', '芯片配置');
+    chipTrigger().should('contain.text', '选择芯片配置进行对比');
   });
 });
 

--- a/packages/app/cypress/support/profit-fixtures.ts
+++ b/packages/app/cypress/support/profit-fixtures.ts
@@ -33,6 +33,32 @@ export const PROFIT_DATE = '2026-08-31';
  */
 export const PROFIT_HISTORY_DATE = '2026-07-15';
 const PROFIT_HISTORY_TPUT_SCALE = 0.8;
+/**
+ * A date between the two above on which the sweep ran twice, so the Config
+ * Changelog offers each run as its own comparison entry (`date~r<runId>`) the
+ * way `/inference` does. Run #1 carries 85% and run #2 92% of today's
+ * throughput; `?date=` (the day's latest) resolves to run #2.
+ */
+export const PROFIT_RUN_DATE = '2026-08-10';
+export const PROFIT_RUNS = [
+  { runId: 27_480_000_001, startedAt: `${PROFIT_RUN_DATE}T02:00:00Z`, tputScale: 0.85 },
+  { runId: 27_480_000_002, startedAt: `${PROFIT_RUN_DATE}T09:00:00Z`, tputScale: 0.92 },
+] as const;
+/** Single run behind each of the other two dates, for the changelog's Git/Workflow links. */
+const PROFIT_SINGLE_RUN_ID: Record<string, number> = {
+  [PROFIT_HISTORY_DATE]: 27_470_000_001,
+  [PROFIT_DATE]: 27_490_000_001,
+};
+const PROFIT_DATES = [PROFIT_HISTORY_DATE, PROFIT_RUN_DATE, PROFIT_DATE];
+
+const tputScaleFor = (date: string, runId?: number): number => {
+  if (date === PROFIT_DATE) return 1;
+  if (date === PROFIT_RUN_DATE) {
+    const run = PROFIT_RUNS.find((r) => r.runId === runId) ?? PROFIT_RUNS.at(-1)!;
+    return run.tputScale;
+  }
+  return PROFIT_HISTORY_TPUT_SCALE;
+};
 
 type Curve = [conc: number, intvty: number, tput: number, e2el: number][];
 
@@ -68,7 +94,11 @@ export const PROFIT_SKUS: ProfitSku[] = [
 
 let idCursor = 800_000;
 
-export const profitBenchmarkRows = (dbKey: string = PROFIT_MODEL_DB_KEY, date = PROFIT_DATE) =>
+export const profitBenchmarkRows = (
+  dbKey: string = PROFIT_MODEL_DB_KEY,
+  date = PROFIT_DATE,
+  runId?: number,
+) =>
   PROFIT_SKUS.flatMap((sku) =>
     sku.curve.map(([conc, intvty, tput, e2el]) => ({
       id: idCursor++,
@@ -91,18 +121,20 @@ export const profitBenchmarkRows = (dbKey: string = PROFIT_MODEL_DB_KEY, date = 
       image: `${sku.framework}:test`,
       metrics: metricsFor(
         intvty,
-        Math.round(tput * sku.tputScale * (date === PROFIT_DATE ? 1 : PROFIT_HISTORY_TPUT_SCALE)),
+        Math.round(tput * sku.tputScale * tputScaleFor(date, runId)),
         e2el,
       ),
       workers: null,
       date,
-      run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${idCursor}`,
+      workflow_run_id: runId ?? PROFIT_SINGLE_RUN_ID[date],
+      run_started_at: PROFIT_RUNS.find((r) => r.runId === runId)?.startedAt ?? `${date}T02:00:00Z`,
+      run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId ?? PROFIT_SINGLE_RUN_ID[date] ?? idCursor}`,
     })),
   );
 
 export const profitAvailabilityRows = (dbKeys: readonly string[] = PROFIT_DB_KEYS) =>
   dbKeys.flatMap((dbKey) =>
-    [PROFIT_HISTORY_DATE, PROFIT_DATE].flatMap((date) =>
+    PROFIT_DATES.flatMap((date) =>
       PROFIT_SKUS.map((sku) => ({
         model: dbKey,
         isl: null,
@@ -118,11 +150,98 @@ export const profitAvailabilityRows = (dbKeys: readonly string[] = PROFIT_DB_KEY
     ),
   );
 
+/** Changelog config key for a SKU, in the `<model>-<precision>-<gpu>-<framework>-agentic` form the API emits. */
+const configKeyFor = (dbKey: string, sku: ProfitSku) =>
+  `${dbKey}-${sku.precision}-${sku.hardware}-${sku.framework}-agentic`;
+
+const runConfigsFor = (runId: number, startedAt: string, sha: string) =>
+  PROFIT_DB_KEYS.flatMap((dbKey) =>
+    PROFIT_SKUS.map((sku) => ({
+      github_run_id: runId,
+      run_started_at: startedAt,
+      html_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId}`,
+      head_sha: sha,
+      model: dbKey,
+      precision: sku.precision,
+      hardware: sku.hardware,
+      framework: sku.framework,
+      spec_method: 'none',
+      disagg: false,
+    })),
+  );
+
+const changelogRow = (runId: number, date: string, sha: string, description: string) => ({
+  workflow_run_id: runId,
+  date,
+  base_ref: `base${sha}`,
+  head_ref: sha,
+  config_keys: PROFIT_DB_KEYS.flatMap((dbKey) =>
+    PROFIT_SKUS.map((sku) => configKeyFor(dbKey, sku)),
+  ),
+  description,
+  pr_link: `https://github.com/SemiAnalysisAI/InferenceX/pull/${runId % 10_000}`,
+});
+
+/** Changelog text the spec asserts on for each run. */
+export const PROFIT_CHANGELOG_NOTES = {
+  [PROFIT_HISTORY_DATE]: 'Initial agentic-traces submission for every SKU',
+  run1: 'Run 1: bump serving image and retune concurrency sweep',
+  run2: 'Run 2: enable prefix caching on the agentic trace',
+  [PROFIT_DATE]: 'Upgrade to the latest serving release',
+} as const;
+
 /**
- * Intercept availability (both models, both dates) and benchmarks (the rows of
- * whichever model the request names, so a model switch never sees another
- * model's bars; the earlier date's rows when the compare-history panel asks
- * for `?date=<PROFIT_HISTORY_DATE>`).
+ * `/api/v1/workflow-info?date=` payload per fixture date: one run with a
+ * changelog on the first and last dates, two runs (each with its own
+ * changelog) on `PROFIT_RUN_DATE`, nothing anywhere else.
+ */
+export const profitWorkflowInfo = (date: string) => {
+  const runRow = (runId: number, createdAt: string) => ({
+    github_run_id: runId,
+    name: `Run Sweep - ${date}`,
+    conclusion: 'success',
+    run_attempt: 1,
+    html_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId}`,
+    created_at: createdAt,
+    date,
+  });
+  if (date === PROFIT_RUN_DATE) {
+    const [r1, r2] = PROFIT_RUNS;
+    return {
+      runs: [runRow(r1.runId, r1.startedAt), runRow(r2.runId, r2.startedAt)],
+      changelogs: [
+        changelogRow(r1.runId, date, 'aaa1111', PROFIT_CHANGELOG_NOTES.run1),
+        changelogRow(r2.runId, date, 'bbb2222', PROFIT_CHANGELOG_NOTES.run2),
+      ],
+      configs: [],
+      runConfigs: [
+        ...runConfigsFor(r1.runId, r1.startedAt, 'aaa1111'),
+        ...runConfigsFor(r2.runId, r2.startedAt, 'bbb2222'),
+      ],
+    };
+  }
+  const runId = PROFIT_SINGLE_RUN_ID[date];
+  if (!runId) return { runs: [], changelogs: [], configs: [], runConfigs: [] };
+  const startedAt = `${date}T02:00:00Z`;
+  const sha = date === PROFIT_DATE ? 'ccc3333' : '0000aaa';
+  const note =
+    date === PROFIT_DATE
+      ? PROFIT_CHANGELOG_NOTES[PROFIT_DATE]
+      : PROFIT_CHANGELOG_NOTES[PROFIT_HISTORY_DATE];
+  return {
+    runs: [runRow(runId, startedAt)],
+    changelogs: [changelogRow(runId, date, sha, note)],
+    configs: [],
+    runConfigs: runConfigsFor(runId, startedAt, sha),
+  };
+};
+
+/**
+ * Intercept availability (every model, all three dates), benchmarks (the rows
+ * of whichever model the request names, so a model switch never sees another
+ * model's bars; an earlier date's rows for `?date=`, one specific run's rows
+ * for `?runId=&exactRun=true`), and the workflow-info feed behind the Config
+ * Changelog.
  */
 export const interceptProfitData = (): void => {
   cy.intercept('GET', '/api/v1/availability*', { body: profitAvailabilityRows() }).as(
@@ -130,8 +249,18 @@ export const interceptProfitData = (): void => {
   );
   cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
     const display = String(req.query['model'] ?? '');
-    const date =
-      String(req.query['date'] ?? '') === PROFIT_HISTORY_DATE ? PROFIT_HISTORY_DATE : PROFIT_DATE;
-    req.reply({ body: profitBenchmarkRows(PROFIT_DB_KEY_BY_DISPLAY_MODEL[display], date) });
+    const dbKey = PROFIT_DB_KEY_BY_DISPLAY_MODEL[display];
+    const runId = Number(req.query['runId'] ?? 0);
+    const run = PROFIT_RUNS.find((r) => r.runId === runId);
+    if (run && String(req.query['exactRun']) === 'true') {
+      req.reply({ body: profitBenchmarkRows(dbKey, PROFIT_RUN_DATE, run.runId) });
+      return;
+    }
+    const requested = String(req.query['date'] ?? '');
+    const date = PROFIT_DATES.includes(requested) ? requested : PROFIT_DATE;
+    req.reply({ body: profitBenchmarkRows(dbKey, date) });
   }).as('profit-benchmarks');
+  cy.intercept('GET', '/api/v1/workflow-info*', (req) => {
+    req.reply({ body: profitWorkflowInfo(String(req.query['date'] ?? '')) });
+  }).as('profit-workflow-info');
 };

--- a/packages/app/cypress/support/profit-fixtures.ts
+++ b/packages/app/cypress/support/profit-fixtures.ts
@@ -26,6 +26,13 @@ const PROFIT_DB_KEY_BY_DISPLAY_MODEL: Record<string, string> = {
 };
 const PROFIT_DB_KEYS = Object.values(PROFIT_DB_KEY_BY_DISPLAY_MODEL);
 export const PROFIT_DATE = '2026-08-31';
+/**
+ * Earlier run date served for the compare-history panel. Its rows carry 80% of
+ * the current throughput, so a history bar always lands below today's for the
+ * same chip and the spec can tell the two apart.
+ */
+export const PROFIT_HISTORY_DATE = '2026-07-15';
+const PROFIT_HISTORY_TPUT_SCALE = 0.8;
 
 type Curve = [conc: number, intvty: number, tput: number, e2el: number][];
 
@@ -61,7 +68,7 @@ export const PROFIT_SKUS: ProfitSku[] = [
 
 let idCursor = 800_000;
 
-export const profitBenchmarkRows = (dbKey: string = PROFIT_MODEL_DB_KEY) =>
+export const profitBenchmarkRows = (dbKey: string = PROFIT_MODEL_DB_KEY, date = PROFIT_DATE) =>
   PROFIT_SKUS.flatMap((sku) =>
     sku.curve.map(([conc, intvty, tput, e2el]) => ({
       id: idCursor++,
@@ -82,32 +89,40 @@ export const profitBenchmarkRows = (dbKey: string = PROFIT_MODEL_DB_KEY) =>
       offload_mode: 'on',
       benchmark_type: 'agentic_traces',
       image: `${sku.framework}:test`,
-      metrics: metricsFor(intvty, Math.round(tput * sku.tputScale), e2el),
+      metrics: metricsFor(
+        intvty,
+        Math.round(tput * sku.tputScale * (date === PROFIT_DATE ? 1 : PROFIT_HISTORY_TPUT_SCALE)),
+        e2el,
+      ),
       workers: null,
-      date: PROFIT_DATE,
+      date,
       run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${idCursor}`,
     })),
   );
 
 export const profitAvailabilityRows = (dbKeys: readonly string[] = PROFIT_DB_KEYS) =>
   dbKeys.flatMap((dbKey) =>
-    PROFIT_SKUS.map((sku) => ({
-      model: dbKey,
-      isl: null,
-      osl: null,
-      precision: sku.precision,
-      hardware: sku.hardware,
-      framework: sku.framework,
-      spec_method: 'none',
-      disagg: false,
-      benchmark_type: 'agentic_traces',
-      date: PROFIT_DATE,
-    })),
+    [PROFIT_HISTORY_DATE, PROFIT_DATE].flatMap((date) =>
+      PROFIT_SKUS.map((sku) => ({
+        model: dbKey,
+        isl: null,
+        osl: null,
+        precision: sku.precision,
+        hardware: sku.hardware,
+        framework: sku.framework,
+        spec_method: 'none',
+        disagg: false,
+        benchmark_type: 'agentic_traces',
+        date,
+      })),
+    ),
   );
 
 /**
- * Intercept availability (both models) and benchmarks (the rows of whichever
- * model the request names, so a model switch never sees another model's bars).
+ * Intercept availability (both models, both dates) and benchmarks (the rows of
+ * whichever model the request names, so a model switch never sees another
+ * model's bars; the earlier date's rows when the compare-history panel asks
+ * for `?date=<PROFIT_HISTORY_DATE>`).
  */
 export const interceptProfitData = (): void => {
   cy.intercept('GET', '/api/v1/availability*', { body: profitAvailabilityRows() }).as(
@@ -115,6 +130,8 @@ export const interceptProfitData = (): void => {
   );
   cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
     const display = String(req.query['model'] ?? '');
-    req.reply({ body: profitBenchmarkRows(PROFIT_DB_KEY_BY_DISPLAY_MODEL[display]) });
+    const date =
+      String(req.query['date'] ?? '') === PROFIT_HISTORY_DATE ? PROFIT_HISTORY_DATE : PROFIT_DATE;
+    req.reply({ body: profitBenchmarkRows(PROFIT_DB_KEY_BY_DISPLAY_MODEL[display], date) });
   }).as('profit-benchmarks');
 };

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -10,6 +10,7 @@ import {
   estimateTextWidth,
   slantedMargins,
   splitAxisLabel,
+  splitHistoryLabel,
   xLabelLayout,
   operatorMarginLabel,
   profitYDomain,
@@ -141,6 +142,22 @@ describe('rowLabel', () => {
   it('falls back to the registry entry when the chart config lacks the key', () => {
     expect(rowLabel(row(), {} as HardwareConfig)).toBe('H200');
   });
+
+  it('names the run date of a compare-history bar after the config', () => {
+    expect(rowLabel(row({ precision: 'fp8', date: '2026-06-14' }), hardwareConfig)).toBe(
+      'H200 (FP8) • 2026-06-14',
+    );
+  });
+});
+
+describe('splitHistoryLabel', () => {
+  it('splits a dated label into its config and date', () => {
+    expect(splitHistoryLabel('B200 (FP4) • 2026-06-14')).toEqual(['B200 (FP4)', '2026-06-14']);
+  });
+
+  it('leaves an undated label whole', () => {
+    expect(splitHistoryLabel('B200 (FP4)')).toEqual(['B200 (FP4)', '']);
+  });
 });
 
 describe('generateProfitTooltipHTML', () => {
@@ -153,6 +170,22 @@ describe('generateProfitTooltipHTML', () => {
     expect(html).toContain('30%');
     expect(html).toContain('60%');
     expect(html).toContain('Profit');
+  });
+
+  it('adds a run-date line for a compare-history bar and keeps the date out of the title', () => {
+    const html = generateProfitTooltipHTML(
+      row({ date: '2026-06-14' }),
+      hardwareConfig,
+      assumptions,
+      'en',
+      false,
+    );
+    expect(html).toContain('Run date');
+    expect(html).toContain('2026-06-14');
+    expect(html).not.toContain('H200 • 2026-06-14');
+    expect(
+      generateProfitTooltipHTML(row(), hardwareConfig, assumptions, 'en', false),
+    ).not.toContain('Run date');
   });
 
   it('labels a negative result as a loss and still lists the license fee, which is a share of revenue', () => {
@@ -265,6 +298,10 @@ describe('xLabelLayout', () => {
     expect(xLabelLayout(labels, 80, 10)).toBe('slanted');
     expect(xLabelLayout([], 200, 10)).toBe('slanted');
     expect(xLabelLayout(labels, 0, 10)).toBe('slanted');
+  });
+  it('measures a compare-history date as its own line rather than widening the detail line', () => {
+    const dated = labels.map((label) => `${label} • 2026-06-14`);
+    expect(xLabelLayout(dated, 200, 10)).toBe('stacked');
   });
 });
 

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -408,9 +408,11 @@ export function rowLabel(row: ProfitEstimatorRow, hardwareConfig: HardwareConfig
   const config = hardwareConfig[row.hwKey] || getHardwareConfig(row.hwKey);
   const base = config ? getDisplayLabel(config) : row.hwKey;
   const withPrecision = row.precision ? `${base} (${row.precision.toUpperCase()})` : base;
-  // A compare-history bar names the run date it was priced on, as the
-  // `/inference` legend does for its "config • date" series.
-  return row.date ? `${withPrecision}${HISTORY_LABEL_SEP}${row.date}` : withPrecision;
+  // A compare-history bar names the run date (and run number, when the day had
+  // several) it was priced on, as the `/inference` legend does for its
+  // "config • date" series.
+  const dateLabel = row.dateLabel ?? row.date;
+  return dateLabel ? `${withPrecision}${HISTORY_LABEL_SEP}${dateLabel}` : withPrecision;
 }
 
 function formatPct(value: number): string {
@@ -451,7 +453,7 @@ export function generateProfitTooltipHTML(
     <div style="background: var(--popover); border: 1px solid var(--border); border-radius: 8px; padding: 12px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); min-width: 260px; max-width: 340px; pointer-events: auto; user-select: ${isPinned ? 'text' : 'none'};">
       ${isPinned ? `<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">${t.dismiss}</div>` : ''}
       <div style="color: var(--foreground); font-size: 13px; font-weight: 600; margin-bottom: 8px;">${label}</div>
-      ${row.date ? line(t.runDate, escapeHtml(row.date)) : ''}
+      ${row.date ? line(t.runDate, escapeHtml(row.dateLabel ?? row.date)) : ''}
       ${line(`${t.revenue} (${t.utilization} ${assumptions.utilizationPct}%)`, usd(row.revenue))}
       ${line(t.tco, usd(row.tco), skuColor, TCO_OPACITY)}
       ${line(t.grossMargin, usd(row.grossMargin))}

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -51,6 +51,8 @@ export interface ProfitSegment {
 const CHART_MARGIN = { top: 12, right: 24, bottom: 40, left: 116 };
 /** Bottom margin when the x labels stand upright on two lines (name / framework). */
 const X_LABEL_STACKED_BOTTOM = 64;
+/** Extra bottom margin for the third stacked line a compare-history date adds. */
+const X_LABEL_HISTORY_LINE_PX = 16;
 /** Tallest the chart gets, on a viewport with room to spare. */
 export const CHART_HEIGHT = 720;
 /** Shortest the chart gets; below this the in-bar labels start colliding. */
@@ -114,6 +116,20 @@ export function splitAxisLabel(label: string): [string, string] {
   return [label.slice(0, at), label.slice(at + 1)];
 }
 
+/** Separator between a compare-history label and its run date; matches the `/inference` legend. */
+export const HISTORY_LABEL_SEP = ' • ';
+
+/**
+ * Split a compare-history label "B200 (FP4) • 2026-06-14" into its config and
+ * date so the date can sit on its own axis line. A label without a date has
+ * an empty second half.
+ */
+export function splitHistoryLabel(label: string): [string, string] {
+  const at = label.lastIndexOf(HISTORY_LABEL_SEP);
+  if (at === -1) return [label, ''];
+  return [label.slice(0, at), label.slice(at + HISTORY_LABEL_SEP.length)];
+}
+
 /**
  * Upright two-line labels when every SKU fits in its own slot; otherwise the
  * classic slanted single line. `slotPx` is the horizontal room per tick,
@@ -123,8 +139,13 @@ export function xLabelLayout(labels: string[], slotPx: number, fontPx: number): 
   if (labels.length === 0 || slotPx <= 0) return 'slanted';
   const widest = Math.max(
     ...labels.map((label) => {
-      const [name, detail] = splitAxisLabel(label);
-      return Math.max(estimateTextWidth(name, fontPx), estimateTextWidth(detail, fontPx));
+      const [config, date] = splitHistoryLabel(label);
+      const [name, detail] = splitAxisLabel(config);
+      return Math.max(
+        estimateTextWidth(name, fontPx),
+        estimateTextWidth(detail, fontPx),
+        estimateTextWidth(date, fontPx),
+      );
     }),
   );
   return widest + LABEL_SIDE_PAD_PX * 2 <= slotPx ? 'stacked' : 'slanted';
@@ -230,6 +251,7 @@ const STRINGS = {
     labCutShare: 'License fee share',
     ofRevenue: 'of revenue',
     dismiss: 'Click anywhere to dismiss',
+    runDate: 'Run date',
     noData: 'No SKU can be priced for the current selection.',
   },
   zh: {
@@ -254,6 +276,7 @@ const STRINGS = {
     labCutShare: '许可费比例',
     ofRevenue: '（占收入）',
     dismiss: '点击任意位置关闭',
+    runDate: '运行日期',
     noData: '当前选择下没有可定价的 SKU。',
   },
 } as const;
@@ -384,7 +407,10 @@ export function profitYDomain(
 export function rowLabel(row: ProfitEstimatorRow, hardwareConfig: HardwareConfig): string {
   const config = hardwareConfig[row.hwKey] || getHardwareConfig(row.hwKey);
   const base = config ? getDisplayLabel(config) : row.hwKey;
-  return row.precision ? `${base} (${row.precision.toUpperCase()})` : base;
+  const withPrecision = row.precision ? `${base} (${row.precision.toUpperCase()})` : base;
+  // A compare-history bar names the run date it was priced on, as the
+  // `/inference` legend does for its "config • date" series.
+  return row.date ? `${withPrecision}${HISTORY_LABEL_SEP}${row.date}` : withPrecision;
 }
 
 function formatPct(value: number): string {
@@ -402,7 +428,7 @@ export function generateProfitTooltipHTML(
   const t = STRINGS[locale];
   const usd = (value: number) => formatProfitUsd(value, assumptions.basis);
   const colon = locale === 'zh' ? '：' : ':';
-  const label = escapeHtml(rowLabel(row, hardwareConfig));
+  const label = escapeHtml(splitHistoryLabel(rowLabel(row, hardwareConfig))[0]);
   const line = (name: string, value: string, color?: string, opacity = 1) =>
     `<div style="display:flex; justify-content:space-between; gap:16px; color: var(--muted-foreground); font-size: 11px; margin-bottom: 4px;"><span>${
       color
@@ -425,6 +451,7 @@ export function generateProfitTooltipHTML(
     <div style="background: var(--popover); border: 1px solid var(--border); border-radius: 8px; padding: 12px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); min-width: 260px; max-width: 340px; pointer-events: auto; user-select: ${isPinned ? 'text' : 'none'};">
       ${isPinned ? `<div style="color: var(--muted-foreground); font-size: 10px; margin-bottom: 6px; font-style: italic;">${t.dismiss}</div>` : ''}
       <div style="color: var(--foreground); font-size: 13px; font-weight: 600; margin-bottom: 8px;">${label}</div>
+      ${row.date ? line(t.runDate, escapeHtml(row.date)) : ''}
       ${line(`${t.revenue} (${t.utilization} ${assumptions.utilizationPct}%)`, usd(row.revenue))}
       ${line(t.tco, usd(row.tco), skuColor, TCO_OPACITY)}
       ${line(t.grossMargin, usd(row.grossMargin))}
@@ -445,7 +472,11 @@ export function generateProfitTooltipHTML(
 interface ProfitEstimatorChartProps {
   rows: ProfitEstimatorRow[];
   hardwareConfig: HardwareConfig;
-  colorResolver: (hwKey: string) => string;
+  /**
+   * Colour of a row's bar. Keyed by the whole row, not just the hwKey, so a
+   * compare-history view can shade a chip's older dates lighter than today's.
+   */
+  colorResolver: (row: ProfitEstimatorRow) => string;
   assumptions: ProfitEstimatorAssumptions;
   legendElement?: React.ReactNode;
   caption?: React.ReactNode;
@@ -486,7 +517,7 @@ export default function ProfitEstimatorChart({
   const fillFor = useCallback(
     (segment: ProfitSegment): string => {
       if (segment.kind === 'loss') return `url(#${lossPatternId(segment.row.resultKey)})`;
-      return colorResolver(segment.row.hwKey);
+      return colorResolver(segment.row);
     },
     [colorResolver],
   );
@@ -494,14 +525,14 @@ export default function ProfitEstimatorChart({
   /** Resting stroke: the tinted segments (TCO, license fee) and loss are outlined in the SKU colour. */
   const outlineFor = useCallback(
     (segment: ProfitSegment): string =>
-      segment.kind === 'profit' ? 'none' : colorResolver(segment.row.hwKey),
+      segment.kind === 'profit' ? 'none' : colorResolver(segment.row),
     [colorResolver],
   );
 
   /** In-segment text colour: neutral on the muted and translucent fills, luminance-picked on solid SKU fills. */
   const labelColorFor = useCallback(
     (segment: ProfitSegment): string => {
-      if (segment.kind === 'profit') return contrastingTextColor(colorResolver(segment.row.hwKey));
+      if (segment.kind === 'profit') return contrastingTextColor(colorResolver(segment.row));
       return 'var(--foreground)';
     },
     [colorResolver],
@@ -553,9 +584,9 @@ export default function ProfitEstimatorChart({
           .attr('id', (d) => lossPatternId(d.resultKey));
         patterns
           .select('.hatch-bg')
-          .attr('fill', (d) => colorResolver(d.hwKey))
+          .attr('fill', (d) => colorResolver(d))
           .attr('fill-opacity', 0.18);
-        patterns.select('.hatch-line').attr('stroke', (d) => colorResolver(d.hwKey));
+        patterns.select('.hatch-line').attr('stroke', (d) => colorResolver(d));
 
         // Zero line, drawn before the bars so loss segments sit on top of it.
         group
@@ -736,7 +767,7 @@ export default function ProfitEstimatorChart({
           state.assumptions,
           state.locale,
           isPinned,
-          colorResolver(segment.row.hwKey),
+          colorResolver(segment.row),
         );
       },
       getRulerX: () => hoveredBarXRef.current,
@@ -782,7 +813,13 @@ export default function ProfitEstimatorChart({
     return xLabelLayout([...labelMap.values()], slot, CHART_TYPE.axisLabelSub);
   }, [dimensions.width, baseMargin, rows.length, labelMap]);
   const margin = useMemo(() => {
-    if (labelLayout === 'stacked') return { ...baseMargin, bottom: X_LABEL_STACKED_BOTTOM };
+    if (labelLayout === 'stacked') {
+      const dated = [...labelMap.values()].some((label) => splitHistoryLabel(label)[1] !== '');
+      return {
+        ...baseMargin,
+        bottom: X_LABEL_STACKED_BOTTOM + (dated ? X_LABEL_HISTORY_LINE_PX : 0),
+      };
+    }
     const plotWidth = dimensions.width - baseMargin.left - baseMargin.right;
     const slot = rows.length > 0 ? plotWidth / rows.length : 0;
     return slantedMargins([...labelMap.values()], slot, CHART_TYPE.axisLabelSub, baseMargin);
@@ -823,7 +860,8 @@ export default function ProfitEstimatorChart({
           if (labelLayout === 'stacked') {
             // Two upright lines centred on the tick: SKU name, then the
             // framework and precision in parentheses.
-            const [name, detail] = splitAxisLabel(labelMap.get(String(d)) ?? String(d));
+            const [config, date] = splitHistoryLabel(labelMap.get(String(d)) ?? String(d));
+            const [name, detail] = splitAxisLabel(config);
             text
               .attr('transform', null)
               .attr('text-anchor', 'middle')
@@ -832,6 +870,16 @@ export default function ProfitEstimatorChart({
               .text(null);
             text.append('tspan').attr('x', 0).text(name);
             if (detail) text.append('tspan').attr('x', 0).attr('dy', '1.2em').text(detail);
+            // Compare-history bars carry their run date on a third, muted line.
+            if (date) {
+              text
+                .append('tspan')
+                .attr('x', 0)
+                .attr('dy', '1.2em')
+                .attr('class', 'history-date')
+                .style('fill', 'var(--muted-foreground)')
+                .text(date);
+            }
             return;
           }
           // One line rotated about the tick and anchored at its end, so the

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -99,8 +99,11 @@ import {
   PROFIT_HISTORY_MAX_GPUS,
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
+  profitHistoryCurrentRunId,
   profitHistoryDateRanks,
   profitHistoryEntryLabel,
+  profitHistoryLegendKeys,
+  profitHistoryMissing,
   shadeHistoryColor,
 } from './profit-history';
 import type { CostProvider } from './types';
@@ -503,7 +506,7 @@ function ProfitEstimatorInner({
     effectivePrecisions: selectedPrecisions,
   } = useGlobalFilterSelection();
   const { setSelectedModel, setSelectedSequence } = useGlobalFilterActions();
-  const { selectedRunDate } = useGlobalFilterRun();
+  const { selectedRunDate, selectedRunId } = useGlobalFilterRun();
   const { availableModels, availabilityRows } = useGlobalFilterAvailability();
   // This page is agentic only: the sequence is pinned, and the model list is
   // the tab's route allow-list (Kimi K3, GLM 5.2/5.3, MiniMax M3) intersected
@@ -628,13 +631,21 @@ function ProfitEstimatorInner({
   );
   // A chip the new model (or precision) has no agentic rows for leaves the
   // selection, the way `/inference` prunes its comparison on a model switch.
+  // When that empties the selection the range and pins go with it, exactly as
+  // clearing the chips by hand does, so the next chip starts a fresh comparison
+  // instead of inheriting the previous model's dates.
   useEffect(() => {
     if (!availabilityRows || selectedGPUs.length === 0 || historyChipOptions.length === 0) return;
     const offered = new Set(historyChipOptions.map((o) => o.value));
     const kept = selectedGPUs.filter((hw) => offered.has(hw));
-    if (kept.length !== selectedGPUs.length) {
-      setSelectedGPUs(kept);
-      setUrlParam('i_gpus', kept.join(','));
+    if (kept.length === selectedGPUs.length) return;
+    setSelectedGPUs(kept);
+    setUrlParam('i_gpus', kept.join(','));
+    if (kept.length === 0) {
+      setSelectedDateRange({ startDate: '', endDate: '' });
+      setSelectedDates([]);
+      setUrlParam('i_dstart', '');
+      setUrlParam('i_dend', '');
     }
   }, [availabilityRows, historyChipOptions, selectedGPUs, setUrlParam]);
   const historyAvailableDates = useMemo(
@@ -698,16 +709,6 @@ function ProfitEstimatorInner({
     [setUrlParam],
   );
 
-  const history = useProfitHistory({
-    model: selectedModel,
-    sequence: selectedSequence,
-    selectedGPUs,
-    selectedDates,
-    dateRange: selectedDateRange,
-    currentRunDate: selectedRunDate,
-    enabled: hasData,
-  });
-  const historyActive = history.comparisonDates.length > 0;
   // Config Changelog for the selected chips: one workflow-info query per
   // available date (bounded to the range once one is set), the same feed
   // `/inference` renders under its chart.
@@ -728,6 +729,33 @@ function ProfitEstimatorInner({
     }),
     [dbModelKeys, selectedGPUs, selectedPrecisions],
   );
+  // The run the main bars already show: the latest run of the current date
+  // for this model's chips once the changelog has enumerated them, else the
+  // global run selection. Pinning it from the changelog must not draw a second
+  // bar of the same data, which is why `/inference` hands `buildComparisonDates`
+  // its `selectedRunId`.
+  const historyCurrentRunId = useMemo(
+    () =>
+      profitHistoryCurrentRunId(
+        historyChangelogs.changelogs,
+        selectedRunDate,
+        historyRunScope,
+        selectedRunId,
+      ),
+    [historyChangelogs.changelogs, selectedRunDate, historyRunScope, selectedRunId],
+  );
+
+  const history = useProfitHistory({
+    model: selectedModel,
+    sequence: selectedSequence,
+    selectedGPUs,
+    selectedDates,
+    dateRange: selectedDateRange,
+    currentRunDate: selectedRunDate,
+    currentRunId: historyCurrentRunId,
+    enabled: hasData,
+  });
+  const historyActive = history.comparisonDates.length > 0;
   const historyRunNumbering = useMemo(() => {
     const numbering = new Map<string, number>();
     for (const { date, runConfigs } of historyChangelogs.changelogs) {
@@ -904,10 +932,13 @@ function ProfitEstimatorInner({
     historyEntryLabel,
   ]);
 
-  const legendHwKeys = useMemo(() => {
-    const priced = new Set(fullEstimate.rows.map((row) => row.hwKey));
-    return availableHwKeys.filter((key) => priced.has(key));
-  }, [fullEstimate.rows, availableHwKeys]);
+  // `availableHwKeys` describes today's run; with a comparison active a chip
+  // that only priced on an earlier date still owns bars, so it stays in the
+  // legend (appended in registry order) rather than being dropped with them.
+  const legendHwKeys = useMemo(
+    () => profitHistoryLegendKeys(availableHwKeys, fullEstimate.rows, historyActive),
+    [fullEstimate.rows, availableHwKeys, historyActive],
+  );
 
   const selectionKey = `${selectedModel}|${selectedSequence}|${[...selectedPrecisions]
     .toSorted()
@@ -1071,20 +1102,22 @@ function ProfitEstimatorInner({
       }));
   }, [legendHwKeys, visibleHwKeys, costPerGpuHourFor]);
 
-  // Compared chips with no bar on a comparison date, named in the caption so
-  // a missing bar reads as "no run that day", not as a zero.
+  // Compared chips with no bar on a comparison date (or on the current date,
+  // when the chip only priced earlier), named in the caption so a missing bar
+  // reads as "no run that day", not as a zero.
   const historyMissing = useMemo(() => {
     if (!historyActive) return [];
-    const priced = new Set(fullEstimate.rows.map((row) => `${row.hwKey}~${row.date ?? ''}`));
-    const missing: string[] = [];
-    for (const entry of history.comparisonDates) {
-      for (const hwKey of selectedGPUs) {
-        if (priced.has(`${hwKey}~${entry}`)) continue;
+    return profitHistoryMissing(
+      fullEstimate.rows,
+      history.comparisonDates,
+      selectedGPUs,
+      (hwKey) => {
         const config = hardwareConfig[hwKey];
-        missing.push(`${config ? getDisplayLabel(config) : hwKey} • ${historyEntryLabel(entry)}`);
-      }
-    }
-    return missing;
+        return config ? getDisplayLabel(config) : hwKey;
+      },
+      historyEntryLabel,
+      selectedRunDate,
+    );
   }, [
     historyActive,
     fullEstimate.rows,
@@ -1092,6 +1125,7 @@ function ProfitEstimatorInner({
     selectedGPUs,
     hardwareConfig,
     historyEntryLabel,
+    selectedRunDate,
   ]);
 
   // Rendered as the chart's figcaption so it is part of the PNG export.

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -64,7 +64,7 @@ import { useOpenDropdown } from '@/hooks/useOpenDropdown';
 import { useThemeColors } from '@/hooks/useThemeColors';
 import { useUrlState } from '@/hooks/useUrlState';
 import { track } from '@/lib/analytics';
-import { getGpuSpecs, getModelSortIndex } from '@/lib/constants';
+import { getGpuSpecs, getHardwareConfig, getModelSortIndex } from '@/lib/constants';
 import { exportToCsv } from '@/lib/csv-export';
 import {
   getModelLabel,
@@ -99,7 +99,7 @@ import {
   PROFIT_HISTORY_MAX_GPUS,
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
-  profitHistoryCurrentRunId,
+  profitHistoryCurrentRunIds,
   profitHistoryDateRanks,
   profitHistoryEntryLabel,
   profitHistoryLegendKeys,
@@ -506,7 +506,7 @@ function ProfitEstimatorInner({
     effectivePrecisions: selectedPrecisions,
   } = useGlobalFilterSelection();
   const { setSelectedModel, setSelectedSequence } = useGlobalFilterActions();
-  const { selectedRunDate, selectedRunId } = useGlobalFilterRun();
+  const { selectedRunDate } = useGlobalFilterRun();
   const { availableModels, availabilityRows } = useGlobalFilterAvailability();
   // This page is agentic only: the sequence is pinned, and the model list is
   // the tab's route allow-list (Kimi K3, GLM 5.2/5.3, MiniMax M3) intersected
@@ -729,20 +729,14 @@ function ProfitEstimatorInner({
     }),
     [dbModelKeys, selectedGPUs, selectedPrecisions],
   );
-  // The run the main bars already show: the latest run of the current date
-  // for this model's chips once the changelog has enumerated them, else the
-  // global run selection. Pinning it from the changelog must not draw a second
-  // bar of the same data, which is why `/inference` hands `buildComparisonDates`
-  // its `selectedRunId`.
-  const historyCurrentRunId = useMemo(
+  // Per chip, the run its current bar already shows (the main query is an
+  // as-of-date fetch, so chips can sit on different runs). Pinning that run
+  // from the changelog must not draw a second bar of the same data, the case
+  // `/inference` covers by handing `buildComparisonDates` its `selectedRunId`.
+  const historyCurrentRunIds = useMemo(
     () =>
-      profitHistoryCurrentRunId(
-        historyChangelogs.changelogs,
-        selectedRunDate,
-        historyRunScope,
-        selectedRunId,
-      ),
-    [historyChangelogs.changelogs, selectedRunDate, historyRunScope, selectedRunId],
+      profitHistoryCurrentRunIds(historyChangelogs.changelogs, selectedRunDate, historyRunScope),
+    [historyChangelogs.changelogs, selectedRunDate, historyRunScope],
   );
 
   const history = useProfitHistory({
@@ -752,7 +746,7 @@ function ProfitEstimatorInner({
     selectedDates,
     dateRange: selectedDateRange,
     currentRunDate: selectedRunDate,
-    currentRunId: historyCurrentRunId,
+    currentRunIds: historyCurrentRunIds,
     enabled: hasData,
   });
   const historyActive = history.comparisonDates.length > 0;
@@ -896,6 +890,7 @@ function ProfitEstimatorInner({
             targetValue,
             mode,
             costProvider: interpolationCostProvider,
+            currentRunIds: historyCurrentRunIds,
           }),
         ]
       : current;
@@ -926,6 +921,7 @@ function ProfitEstimatorInner({
     assumptions,
     historyActive,
     history.rowsByDate,
+    historyCurrentRunIds,
     selectedGPUs,
     selectedPrecisions,
     selectedPercentile,
@@ -1112,7 +1108,9 @@ function ProfitEstimatorInner({
       history.comparisonDates,
       selectedGPUs,
       (hwKey) => {
-        const config = hardwareConfig[hwKey];
+        // `hardwareConfig` covers today's rows only; a chip that priced
+        // earlier alone still has a registry entry to label it by.
+        const config = hardwareConfig[hwKey] || getHardwareConfig(hwKey);
         return config ? getDisplayLabel(config) : hwKey;
       },
       historyEntryLabel,

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -9,6 +9,7 @@ import {
   TCO_SOURCE_URL,
 } from '@semianalysisai/inferencex-constants';
 import { Info, Plus, X } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import Link from 'next/link';
 
 import ProfitEstimatorChart from '@/components/calculator/ProfitEstimatorChart';
@@ -38,7 +39,9 @@ import { ChartButtons } from '@/components/ui/chart-buttons';
 import ChartLegendItem from '@/components/ui/chart-legend-item';
 import { ChartShareActions } from '@/components/ui/chart-display-helpers';
 import { ModelSelector, PercentileSelector } from '@/components/ui/chart-selectors';
+import { ControlPanel } from '@/components/ui/control-panel';
 import { DashboardSectionHeader } from '@/components/ui/dashboard-section-header';
+import { DateRangePicker } from '@/components/ui/date-range-picker';
 import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { Heading } from '@/components/ui/heading';
 import { Input } from '@/components/ui/input';
@@ -78,10 +81,22 @@ import {
   parseTokenPriceInput,
   profitModelDefaults,
   type ProfitBasis,
+  type ProfitEstimatorRow,
   type ProfitEstimatorSkipReason,
 } from './profit-estimator';
 import { profitEstimatorChartStrings, rowLabel } from './ProfitEstimatorChart';
+import {
+  buildProfitHistoryResults,
+  historyFadeShare,
+  orderProfitRowsForHistory,
+  PROFIT_HISTORY_MAX_GPUS,
+  profitHistoryAvailableDates,
+  profitHistoryChipOptions,
+  profitHistoryDateRanks,
+  shadeHistoryColor,
+} from './profit-history';
 import type { CostProvider } from './types';
+import { useProfitHistory } from './useProfitHistory';
 import { useThroughputData } from './useThroughputData';
 
 /**
@@ -242,6 +257,18 @@ const STRINGS = {
       'no-cost': 'no TCO for this tier',
       'no-token-mix': 'no input/output token mix recorded',
     } satisfies Record<ProfitEstimatorSkipReason, string>,
+    compareHistory: 'Compare history',
+    gpuConfig: 'Chip Config',
+    gpuConfigTooltip: `Select up to ${PROFIT_HISTORY_MAX_GPUS} chip configurations to compare how their estimated revenue and profit have moved over time. Each config is priced again at the start and end of the date range using the run measured on that date, so software updates show up as a change in the bar.`,
+    gpuConfigPlaceholder: 'Select a Chip Config for comparison',
+    comparisonDateRange: 'Comparison Date Range',
+    comparisonDateRangeTooltip:
+      'Select the start and end dates for the historical comparison. The chart adds a bar for each selected chip config at both dates, next to its bar for the run date shown above.',
+    dateRangePlaceholder: 'Select date range',
+    historyNote: (dates: string) =>
+      `Compare history: lighter bars are the same chip configs priced on ${dates}, using the same target, prices, and TCO tier.`,
+    historyNoData: (entries: string) => `No run at the target on ${entries}.`,
+    csvDateHeader: 'Run date',
   },
   zh: {
     title: {
@@ -330,6 +357,18 @@ const STRINGS = {
       'no-cost': '该层级无 TCO 数据',
       'no-token-mix': '未记录输入/输出 token 比例',
     } satisfies Record<ProfitEstimatorSkipReason, string>,
+    compareHistory: '对比历史趋势',
+    gpuConfig: '芯片配置',
+    gpuConfigTooltip: `最多选择 ${PROFIT_HISTORY_MAX_GPUS} 个芯片配置，对比其收入与利润估算随时间的变化。每个配置都会用该日期实测的运行结果，在日期范围的起止两端重新估价，软件更新带来的差异会直接体现在柱形上。`,
+    gpuConfigPlaceholder: '选择芯片配置进行对比',
+    comparisonDateRange: '对比日期范围',
+    comparisonDateRangeTooltip:
+      '选择历史对比的起止日期。图表会在上方所示运行日期的柱形旁，为所选芯片配置在这两个日期各增加一根柱形。',
+    dateRangePlaceholder: '选择日期范围',
+    historyNote: (dates: string) =>
+      `对比历史趋势：较浅的柱形为同一芯片配置在 ${dates} 的估价，目标、价格与 TCO 层级保持一致。`,
+    historyNoData: (entries: string) => `${entries} 在目标处无运行结果。`,
+    csvDateHeader: '运行日期',
   },
 } as const;
 
@@ -442,8 +481,9 @@ function ProfitEstimatorInner({
   const locale = useLocale();
   const t = STRINGS[locale];
   const chartStrings = profitEstimatorChartStrings(locale);
-  const { setUrlParam } = useUrlState();
+  const { setUrlParam, getUrlParam } = useUrlState();
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown();
+  const { resolvedTheme } = useTheme();
 
   // Precision is not a control here: `effectivePrecisions` stays in auto mode,
   // which resolves to the densest measured precision per model, so the bars
@@ -525,18 +565,102 @@ function ProfitEstimatorInner({
   const [selectedPercentile, setSelectedPercentile] = useState<Percentile>(initialPercentile);
   const [visibilityIntent, setVisibilityIntent] = useState<CalculatorVisibilityIntent | null>(null);
 
-  const { hardwareConfig, getResults, loading, error, hasData, availableHwKeys } =
-    useThroughputData(
-      selectedModel,
-      selectedSequence,
-      selectedPrecisions,
-      selectedRunDate,
-      undefined,
-      selectedPercentile,
-      undefined,
-      true,
-      'total',
-    );
+  const {
+    hardwareConfig,
+    getResults,
+    loading: throughputLoading,
+    error,
+    hasData,
+    availableHwKeys,
+  } = useThroughputData(
+    selectedModel,
+    selectedSequence,
+    selectedPrecisions,
+    selectedRunDate,
+    undefined,
+    selectedPercentile,
+    undefined,
+    true,
+    'total',
+  );
+
+  // ── Compare history ───────────────────────────────────────────────────────
+  // The `/inference` panel, pinned to this page's workload: up to four chip
+  // configs and a date range. The selection lives in the same `i_gpus`,
+  // `i_dstart`, and `i_dend` URL params, so a comparison built on `/inference`
+  // pastes straight into the estimator. Hydrated after mount so the first
+  // client render matches the server one.
+  const [selectedGPUs, setSelectedGPUs] = useState<string[]>([]);
+  const [selectedDateRange, setSelectedDateRange] = useState({ startDate: '', endDate: '' });
+  useEffect(() => {
+    const gpus = getUrlParam('i_gpus');
+    if (gpus) setSelectedGPUs(gpus.split(',').filter(Boolean).slice(0, PROFIT_HISTORY_MAX_GPUS));
+    const startDate = getUrlParam('i_dstart') || '';
+    const endDate = getUrlParam('i_dend') || '';
+    if (startDate && endDate) setSelectedDateRange({ startDate, endDate });
+  }, [getUrlParam]);
+
+  const dbModelKeys = useMemo<string[]>(
+    () => DISPLAY_MODEL_TO_DB[selectedModel] ?? [selectedModel],
+    [selectedModel],
+  );
+  const historyChipOptions = useMemo(
+    () =>
+      profitHistoryChipOptions(availabilityRows, dbModelKeys, selectedPrecisions, selectedModel),
+    [availabilityRows, dbModelKeys, selectedPrecisions, selectedModel],
+  );
+  // A chip the new model (or precision) has no agentic rows for leaves the
+  // selection, the way `/inference` prunes its comparison on a model switch.
+  useEffect(() => {
+    if (!availabilityRows || selectedGPUs.length === 0 || historyChipOptions.length === 0) return;
+    const offered = new Set(historyChipOptions.map((o) => o.value));
+    const kept = selectedGPUs.filter((hw) => offered.has(hw));
+    if (kept.length !== selectedGPUs.length) {
+      setSelectedGPUs(kept);
+      setUrlParam('i_gpus', kept.join(','));
+    }
+  }, [availabilityRows, historyChipOptions, selectedGPUs, setUrlParam]);
+  const historyAvailableDates = useMemo(
+    () =>
+      profitHistoryAvailableDates(availabilityRows, dbModelKeys, selectedPrecisions, selectedGPUs),
+    [availabilityRows, dbModelKeys, selectedPrecisions, selectedGPUs],
+  );
+
+  const handleHistoryGpuChange = useCallback(
+    (next: string[]) => {
+      setSelectedGPUs(next);
+      setUrlParam('i_gpus', next.join(','));
+      if (next.length === 0) {
+        setSelectedDateRange({ startDate: '', endDate: '' });
+        setUrlParam('i_dstart', '');
+        setUrlParam('i_dend', '');
+      }
+      track('profit_history_gpu_selected', { gpus: next, count: next.length });
+    },
+    [setUrlParam],
+  );
+  const handleHistoryDateRangeChange = useCallback(
+    (range: { startDate: string; endDate: string }) => {
+      setSelectedDateRange(range);
+      setUrlParam('i_dstart', range.startDate);
+      setUrlParam('i_dend', range.endDate);
+      track('profit_history_date_range_changed', range);
+    },
+    [setUrlParam],
+  );
+
+  const history = useProfitHistory({
+    model: selectedModel,
+    sequence: selectedSequence,
+    selectedGPUs,
+    dateRange: selectedDateRange,
+    currentRunDate: selectedRunDate,
+    enabled: hasData,
+  });
+  const historyActive = history.comparisonDates.length > 0;
+  // A comparison date still in flight holds the chart, as on `/inference`, so
+  // the bars never show today's chips with the history half missing.
+  const loading = throughputLoading || history.loading;
 
   // Per-base-GPU $/GPU/hr typed by the reader; seeded from the hyperscaler
   // tier the first time each chip appears so the custom view starts identical
@@ -616,10 +740,27 @@ function ProfitEstimatorInner({
   // Price every SKU first, then build the legend from the ones that produced a
   // bar. A config the target falls outside of (or that cannot be priced) is
   // named in the caption instead of being offered as a legend chip.
+  //
+  // With a history comparison active, only the compared chips are drawn, as on
+  // `/inference`: today's bar for each, then one per comparison date priced
+  // from that date's run with the same target, prices, and TCO tier.
   const fullEstimate = useMemo(() => {
     if (!hasData || !pricing) return { rows: [], skipped: [] };
-    const results = getResults(targetValue, mode, interpolationCostProvider);
-    return estimateProfitRows(
+    const current = getResults(targetValue, mode, interpolationCostProvider);
+    const results = historyActive
+      ? [
+          ...current.filter((r) => selectedGPUs.includes(r.hwKey)),
+          ...buildProfitHistoryResults(history.rowsByDate, {
+            selectedGPUs,
+            precisions: selectedPrecisions,
+            percentile: selectedPercentile,
+            targetValue,
+            mode,
+            costProvider: interpolationCostProvider,
+          }),
+        ]
+      : current;
+    const estimated = estimateProfitRows(
       results,
       (hwKey) => ({
         powerKwPerGpu: getGpuSpecs(hwKey).power,
@@ -628,6 +769,9 @@ function ProfitEstimatorInner({
       pricing,
       assumptions,
     );
+    return historyActive
+      ? { ...estimated, rows: orderProfitRowsForHistory(estimated.rows) }
+      : estimated;
   }, [
     hasData,
     pricing,
@@ -637,6 +781,11 @@ function ProfitEstimatorInner({
     interpolationCostProvider,
     costPerGpuHourFor,
     assumptions,
+    historyActive,
+    history.rowsByDate,
+    selectedGPUs,
+    selectedPrecisions,
+    selectedPercentile,
   ]);
 
   const legendHwKeys = useMemo(() => {
@@ -654,6 +803,27 @@ function ProfitEstimatorInner({
   );
   const visibleKeysArray = useMemo(() => [...visibleHwKeys], [visibleHwKeys]);
   const { resolveColor } = useThemeColors({ highContrast: false, activeKeys: visibleKeysArray });
+
+  // Bar colour: the chip's vendor colour, faded toward the page background for
+  // older comparison dates (oldest lightest, today solid), the lightness ramp
+  // the `/inference` comparison uses to tell one config's dates apart.
+  const historyRanks = useMemo(
+    () => profitHistoryDateRanks(fullEstimate.rows),
+    [fullEstimate.rows],
+  );
+  const colorForRow = useCallback(
+    (row: ProfitEstimatorRow) => {
+      const base = resolveColor(row.hwKey);
+      if (!row.date) return base;
+      const theme = resolvedTheme === 'dark' ? 'dark' : 'light';
+      return shadeHistoryColor(
+        base,
+        historyFadeShare(historyRanks.rank(row.date), historyRanks.count),
+        theme,
+      );
+    },
+    [resolveColor, resolvedTheme, historyRanks],
+  );
 
   const estimate = useMemo(
     () => ({
@@ -785,6 +955,22 @@ function ProfitEstimatorInner({
       }));
   }, [legendHwKeys, visibleHwKeys, costPerGpuHourFor]);
 
+  // Compared chips with no bar on a comparison date, named in the caption so
+  // a missing bar reads as "no run that day", not as a zero.
+  const historyMissing = useMemo(() => {
+    if (!historyActive) return [];
+    const priced = new Set(fullEstimate.rows.map((row) => `${row.hwKey}~${row.date ?? ''}`));
+    const missing: string[] = [];
+    for (const date of history.comparisonDates) {
+      for (const hwKey of selectedGPUs) {
+        if (priced.has(`${hwKey}~${date}`)) continue;
+        const config = hardwareConfig[hwKey];
+        missing.push(`${config ? getDisplayLabel(config) : hwKey} • ${date}`);
+      }
+    }
+    return missing;
+  }, [historyActive, fullEstimate.rows, history.comparisonDates, selectedGPUs, hardwareConfig]);
+
   // Rendered as the chart's figcaption so it is part of the PNG export.
   const caption = useMemo(() => {
     if (!pricing) return null;
@@ -809,6 +995,12 @@ function ProfitEstimatorInner({
           date={selectedRunDate}
           source="SemiAnalysis InferenceX™"
         />
+        {historyActive && (
+          <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-history-note">
+            {t.historyNote(history.comparisonDates.join(locale === 'zh' ? '、' : ', '))}
+            {historyMissing.length > 0 && <> {t.historyNoData(historyMissing.join(', '))}</>}
+          </p>
+        )}
         <p
           className="mb-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground"
           data-testid="profit-tco-badges"
@@ -877,6 +1069,9 @@ function ProfitEstimatorInner({
     tcoBadges,
     priceSourceLabel,
     t,
+    historyActive,
+    history.comparisonDates,
+    historyMissing,
   ]);
 
   const exportFileName =
@@ -888,8 +1083,9 @@ function ProfitEstimatorInner({
     // Whole dollars are plenty per GW-year; per chip-hour the cents are the figure.
     const usd = (value: number) => (basis === 'gw-year' ? Math.round(value) : value.toFixed(4));
     const rows = estimate.rows.map((row) => [
-      rowLabel(row, hardwareConfig),
+      rowLabel({ ...row, date: undefined }, hardwareConfig),
       row.precision?.toUpperCase() ?? '',
+      row.date ?? selectedRunDate ?? '',
       usd(row.revenue),
       usd(row.tco),
       usd(row.grossMargin),
@@ -900,10 +1096,11 @@ function ProfitEstimatorInner({
       // GPU-hours is 1 per chip-hour, so that basis has no column for it.
       ...(basis === 'gw-year' ? [Math.round(row.gpuHours)] : []),
     ]);
-    exportToCsv(exportFileName, [...t.csvHeaders[basis]], rows, [
+    const [sku, precision, ...rest] = t.csvHeaders[basis];
+    exportToCsv(exportFileName, [sku, precision, t.csvDateHeader, ...rest], rows, [
       t.captionFormula[basis](assumptions.utilizationPct, assumptions.labCutPct),
     ]);
-  }, [estimate.rows, hardwareConfig, exportFileName, t, assumptions, basis]);
+  }, [estimate.rows, hardwareConfig, exportFileName, t, assumptions, basis, selectedRunDate]);
 
   if (!loading && error) {
     console.error(error);
@@ -1188,6 +1385,53 @@ function ProfitEstimatorInner({
                   })}
                 </div>
               )}
+
+              <ControlPanel legend={t.compareHistory} data-testid="profit-history-panel">
+                <div className="grid min-w-0 gap-3 md:grid-cols-2">
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      htmlFor="profit-history-gpu"
+                      label={t.gpuConfig}
+                      tooltip={t.gpuConfigTooltip}
+                    />
+                    <div data-testid="profit-history-gpu-multiselect" className="min-w-0">
+                      <MultiSelect
+                        triggerId="profit-history-gpu"
+                        options={historyChipOptions}
+                        value={selectedGPUs}
+                        onChange={handleHistoryGpuChange}
+                        open={openDropdown === 'history-gpu'}
+                        onOpenChange={handleDropdownOpenChange('history-gpu')}
+                        placeholder={t.gpuConfigPlaceholder}
+                        maxSelections={PROFIT_HISTORY_MAX_GPUS}
+                        searchPlaceholder={locale === 'zh' ? '搜索…' : undefined}
+                        noResultsLabel={locale === 'zh' ? '无结果' : undefined}
+                        clearSearchLabel={locale === 'zh' ? '清除搜索' : undefined}
+                        selectedSuffix={locale === 'zh' ? ' 已选' : undefined}
+                      />
+                    </div>
+                  </div>
+
+                  {selectedGPUs.length > 0 && (
+                    <div
+                      className="flex min-w-0 flex-col space-y-1.5"
+                      data-testid="profit-history-date-range"
+                    >
+                      <LabelWithTooltip
+                        htmlFor="profit-history-dates"
+                        label={t.comparisonDateRange}
+                        tooltip={t.comparisonDateRangeTooltip}
+                      />
+                      <DateRangePicker
+                        dateRange={selectedDateRange}
+                        onChange={handleHistoryDateRangeChange}
+                        placeholder={t.dateRangePlaceholder}
+                        availableDates={historyAvailableDates}
+                      />
+                    </div>
+                  )}
+                </div>
+              </ControlPanel>
             </TooltipProvider>
 
             {!loading && legendItems.length > 0 && (
@@ -1247,7 +1491,7 @@ function ProfitEstimatorInner({
               <ProfitEstimatorChart
                 rows={estimate.rows}
                 hardwareConfig={hardwareConfig}
-                colorResolver={resolveColor}
+                colorResolver={colorForRow}
                 assumptions={assumptions}
                 caption={caption}
               />

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -32,6 +32,12 @@ import {
   type CostTier,
 } from '@/components/inference/metric-registry';
 import type { TokenRevenuePricing } from '@/components/inference/types';
+import ComparisonChangelog from '@/components/inference/ui/ComparisonChangelog';
+import {
+  isRunComparisonEntry,
+  makeRunComparisonEntry,
+} from '@/components/inference/utils/comparisonEntry';
+import { dataRunsForDate } from '@/components/inference/utils/runEnumeration';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -52,6 +58,7 @@ import { MultiSelect } from '@/components/ui/multi-select';
 import { ResultContext } from '@/components/ui/result-context';
 import { Skeleton } from '@/components/ui/skeleton';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { useComparisonChangelogs } from '@/hooks/api/use-comparison-changelogs';
 import { useOpenRouterPricing } from '@/hooks/api/use-openrouter-pricing';
 import { useOpenDropdown } from '@/hooks/useOpenDropdown';
 import { useThemeColors } from '@/hooks/useThemeColors';
@@ -93,6 +100,7 @@ import {
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
   profitHistoryDateRanks,
+  profitHistoryEntryLabel,
   shadeHistoryColor,
 } from './profit-history';
 import type { CostProvider } from './types';
@@ -259,11 +267,11 @@ const STRINGS = {
     } satisfies Record<ProfitEstimatorSkipReason, string>,
     compareHistory: 'Compare history',
     gpuConfig: 'Chip Config',
-    gpuConfigTooltip: `Select up to ${PROFIT_HISTORY_MAX_GPUS} chip configurations to compare how their estimated revenue and profit have moved over time. Each config is priced again at the start and end of the date range using the run measured on that date, so software updates show up as a change in the bar.`,
+    gpuConfigTooltip: `Select up to ${PROFIT_HISTORY_MAX_GPUS} chip configurations to compare how their estimated revenue and profit have moved over time. Each config is priced again on every compared date (the ends of the date range, plus any date or run added from the Config Changelog below) using the run measured then, so software updates show up as a change in the bar.`,
     gpuConfigPlaceholder: 'Select a Chip Config for comparison',
     comparisonDateRange: 'Comparison Date Range',
     comparisonDateRangeTooltip:
-      'Select the start and end dates for the historical comparison. The chart adds a bar for each selected chip config at both dates, next to its bar for the run date shown above.',
+      'Select the start and end dates for the historical comparison. The chart adds a bar for each selected chip config at both dates, next to its bar for the run date shown above. Dates in between can be added one at a time from the Config Changelog.',
     dateRangePlaceholder: 'Select date range',
     historyNote: (dates: string) =>
       `Compare history: lighter bars are the same chip configs priced on ${dates}, using the same target, prices, and TCO tier.`,
@@ -359,11 +367,11 @@ const STRINGS = {
     } satisfies Record<ProfitEstimatorSkipReason, string>,
     compareHistory: '对比历史趋势',
     gpuConfig: '芯片配置',
-    gpuConfigTooltip: `最多选择 ${PROFIT_HISTORY_MAX_GPUS} 个芯片配置，对比其收入与利润估算随时间的变化。每个配置都会用该日期实测的运行结果，在日期范围的起止两端重新估价，软件更新带来的差异会直接体现在柱形上。`,
+    gpuConfigTooltip: `最多选择 ${PROFIT_HISTORY_MAX_GPUS} 个芯片配置，对比其收入与利润估算随时间的变化。每个配置都会用当日实测的运行结果，在每个对比日期（日期范围的起止两端，以及从下方配置变更日志中添加的日期或运行）重新估价，软件更新带来的差异会直接体现在柱形上。`,
     gpuConfigPlaceholder: '选择芯片配置进行对比',
     comparisonDateRange: '对比日期范围',
     comparisonDateRangeTooltip:
-      '选择历史对比的起止日期。图表会在上方所示运行日期的柱形旁，为所选芯片配置在这两个日期各增加一根柱形。',
+      '选择历史对比的起止日期。图表会在上方所示运行日期的柱形旁，为所选芯片配置在这两个日期各增加一根柱形。范围内的其他日期可在配置变更日志中逐个添加。',
     dateRangePlaceholder: '选择日期范围',
     historyNote: (dates: string) =>
       `对比历史趋势：较浅的柱形为同一芯片配置在 ${dates} 的估价，目标、价格与 TCO 层级保持一致。`,
@@ -586,19 +594,28 @@ function ProfitEstimatorInner({
 
   // ── Compare history ───────────────────────────────────────────────────────
   // The `/inference` panel, pinned to this page's workload: up to four chip
-  // configs and a date range. The selection lives in the same `i_gpus`,
-  // `i_dstart`, and `i_dend` URL params, so a comparison built on `/inference`
-  // pastes straight into the estimator. Hydrated after mount so the first
-  // client render matches the server one.
+  // configs, a date range, and the Config Changelog from which individual
+  // dates or runs are pinned onto the chart. The selection lives in the same
+  // `i_gpus`, `i_dstart`, `i_dend`, and `i_dates` URL params, so a comparison
+  // built on `/inference` pastes straight into the estimator. Hydrated after
+  // mount so the first client render matches the server one.
   const [selectedGPUs, setSelectedGPUs] = useState<string[]>([]);
   const [selectedDateRange, setSelectedDateRange] = useState({ startDate: '', endDate: '' });
+  const [selectedDates, setSelectedDates] = useState<string[]>([]);
+  const [historyHydrated, setHistoryHydrated] = useState(false);
   useEffect(() => {
     const gpus = getUrlParam('i_gpus');
     if (gpus) setSelectedGPUs(gpus.split(',').filter(Boolean).slice(0, PROFIT_HISTORY_MAX_GPUS));
     const startDate = getUrlParam('i_dstart') || '';
     const endDate = getUrlParam('i_dend') || '';
     if (startDate && endDate) setSelectedDateRange({ startDate, endDate });
+    const dates = getUrlParam('i_dates');
+    if (dates) setSelectedDates(dates.split(',').filter(Boolean));
+    setHistoryHydrated(true);
   }, [getUrlParam]);
+  useEffect(() => {
+    if (historyHydrated) setUrlParam('i_dates', selectedDates.join(','));
+  }, [historyHydrated, selectedDates, setUrlParam]);
 
   const dbModelKeys = useMemo<string[]>(
     () => DISPLAY_MODEL_TO_DB[selectedModel] ?? [selectedModel],
@@ -625,6 +642,26 @@ function ProfitEstimatorInner({
       profitHistoryAvailableDates(availabilityRows, dbModelKeys, selectedPrecisions, selectedGPUs),
     [availabilityRows, dbModelKeys, selectedPrecisions, selectedGPUs],
   );
+  // A range whose endpoints the selected chips no longer have data for is
+  // dropped together with the pinned dates, as `InferenceContext` does.
+  useEffect(() => {
+    if (!historyHydrated || !availabilityRows || selectedGPUs.length === 0) return;
+    const { startDate, endDate } = selectedDateRange;
+    if (!startDate || !endDate) return;
+    const available = new Set(historyAvailableDates);
+    if (available.has(startDate) && available.has(endDate)) return;
+    setSelectedDateRange({ startDate: '', endDate: '' });
+    setSelectedDates([]);
+    setUrlParam('i_dstart', '');
+    setUrlParam('i_dend', '');
+  }, [
+    historyHydrated,
+    availabilityRows,
+    selectedGPUs.length,
+    selectedDateRange,
+    historyAvailableDates,
+    setUrlParam,
+  ]);
 
   const handleHistoryGpuChange = useCallback(
     (next: string[]) => {
@@ -632,6 +669,7 @@ function ProfitEstimatorInner({
       setUrlParam('i_gpus', next.join(','));
       if (next.length === 0) {
         setSelectedDateRange({ startDate: '', endDate: '' });
+        setSelectedDates([]);
         setUrlParam('i_dstart', '');
         setUrlParam('i_dend', '');
       }
@@ -639,6 +677,17 @@ function ProfitEstimatorInner({
     },
     [setUrlParam],
   );
+  // Changelog pins. Functional updaters so "Add all" and quick successive
+  // clicks never overwrite each other (the `/inference` fix for the same race).
+  const handleHistoryAddDate = useCallback((entry: string) => {
+    setSelectedDates((prev) => (prev.includes(entry) ? prev : [...prev, entry]));
+  }, []);
+  const handleHistoryRemoveDate = useCallback((entry: string) => {
+    setSelectedDates((prev) => prev.filter((d) => d !== entry));
+  }, []);
+  const handleHistoryAddAllDates = useCallback((entries: string[]) => {
+    setSelectedDates((prev) => [...new Set([...prev, ...entries])]);
+  }, []);
   const handleHistoryDateRangeChange = useCallback(
     (range: { startDate: string; endDate: string }) => {
       setSelectedDateRange(range);
@@ -653,11 +702,73 @@ function ProfitEstimatorInner({
     model: selectedModel,
     sequence: selectedSequence,
     selectedGPUs,
+    selectedDates,
     dateRange: selectedDateRange,
     currentRunDate: selectedRunDate,
     enabled: hasData,
   });
   const historyActive = history.comparisonDates.length > 0;
+  // Config Changelog for the selected chips: one workflow-info query per
+  // available date (bounded to the range once one is set), the same feed
+  // `/inference` renders under its chart.
+  const historyChangelogs = useComparisonChangelogs(
+    selectedGPUs,
+    selectedDateRange,
+    historyAvailableDates,
+    'agentic_traces',
+  );
+  // Same-day runs are numbered from the changelog's run enumeration so a bar
+  // labelled "#2" is the run the changelog calls "#2" (as `ChartDisplay` does).
+  const historyRunScope = useMemo(
+    () => ({
+      modelDbKeys: dbModelKeys,
+      selectedGPUs,
+      selectedPrecisions,
+      benchmarkType: 'agentic_traces' as const,
+    }),
+    [dbModelKeys, selectedGPUs, selectedPrecisions],
+  );
+  const historyRunNumbering = useMemo(() => {
+    const numbering = new Map<string, number>();
+    for (const { date, runConfigs } of historyChangelogs.changelogs) {
+      dataRunsForDate(runConfigs, historyRunScope).forEach((run, i) => {
+        numbering.set(makeRunComparisonEntry(date, run.runId), i + 1);
+      });
+    }
+    return numbering;
+  }, [historyChangelogs.changelogs, historyRunScope]);
+  // A pinned plain date that turns out to have several runs expands into one
+  // entry per run once the changelog knows them, so the bars match the
+  // changelog's per-run blocks instead of a single merged "latest" bar
+  // (`ChartDisplay` does the same). Idempotent once expanded.
+  useEffect(() => {
+    const runConfigsByDate = new Map(
+      historyChangelogs.changelogs.map((c) => [c.date, c.runConfigs] as const),
+    );
+    setSelectedDates((prev) => {
+      let changed = false;
+      const out: string[] = [];
+      for (const entry of prev) {
+        if (isRunComparisonEntry(entry)) {
+          out.push(entry);
+          continue;
+        }
+        const rc = runConfigsByDate.get(entry);
+        const runs = rc ? dataRunsForDate(rc, historyRunScope) : [];
+        if (runs.length > 1) {
+          changed = true;
+          for (const run of runs) out.push(makeRunComparisonEntry(entry, run.runId));
+        } else {
+          out.push(entry);
+        }
+      }
+      return changed ? [...new Set(out)] : prev;
+    });
+  }, [historyChangelogs.changelogs, historyRunScope]);
+  const historyEntryLabel = useCallback(
+    (entry: string) => profitHistoryEntryLabel(entry, historyRunNumbering),
+    [historyRunNumbering],
+  );
   // A comparison date still in flight holds the chart, as on `/inference`, so
   // the bars never show today's chips with the history half missing.
   const loading = throughputLoading || history.loading;
@@ -769,9 +880,13 @@ function ProfitEstimatorInner({
       pricing,
       assumptions,
     );
-    return historyActive
-      ? { ...estimated, rows: orderProfitRowsForHistory(estimated.rows) }
-      : estimated;
+    if (!historyActive) return estimated;
+    return {
+      ...estimated,
+      rows: orderProfitRowsForHistory(estimated.rows).map((row) =>
+        row.date ? { ...row, dateLabel: historyEntryLabel(row.date) } : row,
+      ),
+    };
   }, [
     hasData,
     pricing,
@@ -786,6 +901,7 @@ function ProfitEstimatorInner({
     selectedGPUs,
     selectedPrecisions,
     selectedPercentile,
+    historyEntryLabel,
   ]);
 
   const legendHwKeys = useMemo(() => {
@@ -961,15 +1077,22 @@ function ProfitEstimatorInner({
     if (!historyActive) return [];
     const priced = new Set(fullEstimate.rows.map((row) => `${row.hwKey}~${row.date ?? ''}`));
     const missing: string[] = [];
-    for (const date of history.comparisonDates) {
+    for (const entry of history.comparisonDates) {
       for (const hwKey of selectedGPUs) {
-        if (priced.has(`${hwKey}~${date}`)) continue;
+        if (priced.has(`${hwKey}~${entry}`)) continue;
         const config = hardwareConfig[hwKey];
-        missing.push(`${config ? getDisplayLabel(config) : hwKey} • ${date}`);
+        missing.push(`${config ? getDisplayLabel(config) : hwKey} • ${historyEntryLabel(entry)}`);
       }
     }
     return missing;
-  }, [historyActive, fullEstimate.rows, history.comparisonDates, selectedGPUs, hardwareConfig]);
+  }, [
+    historyActive,
+    fullEstimate.rows,
+    history.comparisonDates,
+    selectedGPUs,
+    hardwareConfig,
+    historyEntryLabel,
+  ]);
 
   // Rendered as the chart's figcaption so it is part of the PNG export.
   const caption = useMemo(() => {
@@ -997,7 +1120,9 @@ function ProfitEstimatorInner({
         />
         {historyActive && (
           <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-history-note">
-            {t.historyNote(history.comparisonDates.join(locale === 'zh' ? '、' : ', '))}
+            {t.historyNote(
+              history.comparisonDates.map(historyEntryLabel).join(locale === 'zh' ? '、' : ', '),
+            )}
             {historyMissing.length > 0 && <> {t.historyNoData(historyMissing.join(', '))}</>}
           </p>
         )}
@@ -1085,7 +1210,7 @@ function ProfitEstimatorInner({
     const rows = estimate.rows.map((row) => [
       rowLabel({ ...row, date: undefined }, hardwareConfig),
       row.precision?.toUpperCase() ?? '',
-      row.date ?? selectedRunDate ?? '',
+      row.dateLabel ?? row.date ?? selectedRunDate ?? '',
       usd(row.revenue),
       usd(row.tco),
       usd(row.grossMargin),
@@ -1433,6 +1558,27 @@ function ProfitEstimatorInner({
                 </div>
               </ControlPanel>
             </TooltipProvider>
+
+            {selectedGPUs.length > 0 && (
+              <div data-testid="profit-history-changelog">
+                <ComparisonChangelog
+                  changelogs={historyChangelogs.changelogs}
+                  selectedGPUs={selectedGPUs}
+                  selectedPrecisions={selectedPrecisions}
+                  modelDbKeys={dbModelKeys}
+                  selectedSequence={selectedSequence}
+                  loading={historyChangelogs.loading}
+                  totalDatesQueried={historyChangelogs.totalDatesQueried}
+                  selectedDates={selectedDates}
+                  selectedDateRange={selectedDateRange}
+                  onAddDate={handleHistoryAddDate}
+                  onRemoveDate={handleHistoryRemoveDate}
+                  onAddAllDates={handleHistoryAddAllDates}
+                  firstAvailableDate={historyAvailableDates[0]}
+                  analyticsSection="profit"
+                />
+              </div>
+            )}
 
             {!loading && legendItems.length > 0 && (
               <div

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -1115,6 +1115,7 @@ function ProfitEstimatorInner({
       },
       historyEntryLabel,
       selectedRunDate,
+      historyCurrentRunIds,
     );
   }, [
     historyActive,
@@ -1124,6 +1125,7 @@ function ProfitEstimatorInner({
     hardwareConfig,
     historyEntryLabel,
     selectedRunDate,
+    historyCurrentRunIds,
   ]);
 
   // Rendered as the chart's figcaption so it is part of the PNG export.

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -147,10 +147,16 @@ export interface ProfitEstimatorRow {
   resultKey: string;
   precision?: string;
   /**
-   * Run date the SKU was priced on, set only for compare-history bars. Today's
-   * bars carry no date: the run date above the chart describes them.
+   * Comparison entry the SKU was priced on (a run date, or `date~r<runId>` for
+   * one specific run), set only for compare-history bars. Today's bars carry
+   * no date: the run date above the chart describes them.
    */
   date?: string;
+  /**
+   * Human label for `date` (e.g. `2026-06-14 #2` for the second run that day),
+   * as the changelog shows it. Falls back to `date` when unset.
+   */
+  dateLabel?: string;
   /** GPU-hours in the denominator: 1 per chip-hour, or what one GW-year buys for this SKU. */
   gpuHours: number;
   /** Gross $/GPU/hr at 100% utilization, before any haircut. */

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -146,6 +146,11 @@ export interface ProfitEstimatorRow {
   hwKey: string;
   resultKey: string;
   precision?: string;
+  /**
+   * Run date the SKU was priced on, set only for compare-history bars. Today's
+   * bars carry no date: the run date above the chart describes them.
+   */
+  date?: string;
   /** GPU-hours in the denominator: 1 per chip-hour, or what one GW-year buys for this SKU. */
   gpuHours: number;
   /** Gross $/GPU/hr at 100% utilization, before any haircut. */
@@ -178,6 +183,7 @@ export interface ProfitEstimatorSkipped {
   hwKey: string;
   resultKey: string;
   precision?: string;
+  date?: string;
   reason: ProfitEstimatorSkipReason;
 }
 
@@ -218,12 +224,17 @@ export function estimateSkuProfit(
   result: Pick<
     InterpolatedResult,
     'hwKey' | 'resultKey' | 'precision' | 'value' | 'inputTokenShare' | 'cacheHitRate' | 'clamped'
-  >,
+  > & { date?: string },
   specs: ProfitEstimatorSpecs,
   pricing: TokenRevenuePricing,
   assumptions: ProfitEstimatorAssumptions,
 ): ProfitEstimatorRow | ProfitEstimatorSkipped {
-  const base = { hwKey: result.hwKey, resultKey: result.resultKey, precision: result.precision };
+  const base = {
+    hwKey: result.hwKey,
+    resultKey: result.resultKey,
+    precision: result.precision,
+    ...(result.date ? { date: result.date } : {}),
+  };
   if (result.clamped) return { ...base, reason: 'outside-measured-range' };
   // Per chip-hour the denominator is one GPU-hour, so power never enters.
   const gpuHours = assumptions.basis === 'chip-hour' ? 1 : gpuHoursPerGwYear(specs.powerKwPerGpu);

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -327,6 +327,25 @@ describe('shadeHistoryColor', () => {
   });
 });
 
+function rc(over: Partial<RunConfigRow>): RunConfigRow {
+  return {
+    github_run_id: 1,
+    run_started_at: '2026-08-10T00:00:00Z',
+    html_url: null,
+    head_sha: null,
+    model: 'kimik3',
+    precision: 'fp4',
+    hardware: 'b200',
+    framework: 'sglang',
+    spec_method: 'none',
+    disagg: false,
+    ...over,
+  };
+}
+
+const missingChipLabel = (hwKey: string) => hwKey.toUpperCase();
+const missingEntryLabel = (e: string) => `on ${e}`;
+
 describe('profitHistoryCurrentRunId', () => {
   const scope = {
     modelDbKeys: ['kimik3'],
@@ -334,21 +353,6 @@ describe('profitHistoryCurrentRunId', () => {
     selectedPrecisions: ['fp4'],
     benchmarkType: 'agentic_traces' as const,
   };
-  function rc(over: Partial<RunConfigRow>): RunConfigRow {
-    return {
-      github_run_id: 1,
-      run_started_at: '2026-08-10T00:00:00Z',
-      html_url: null,
-      head_sha: null,
-      model: 'kimik3',
-      precision: 'fp4',
-      hardware: 'b200',
-      framework: 'sglang',
-      spec_method: 'none',
-      disagg: false,
-      ...over,
-    };
-  }
   const changelogs = [
     {
       date: '2026-08-10',
@@ -399,9 +403,6 @@ describe('profitHistoryLegendKeys', () => {
 });
 
 describe('profitHistoryMissing', () => {
-  const label = (hwKey: string) => hwKey.toUpperCase();
-  const entry = (e: string) => `on ${e}`;
-
   it('names each compared chip with no bar on an entry, the current date included', () => {
     const rows = [
       { hwKey: 'b200_sglang', date: undefined },
@@ -413,8 +414,8 @@ describe('profitHistoryMissing', () => {
         rows,
         ['2026-07-15', '2026-08-10~r5'],
         ['b200_sglang', 'mi355x_vllm'],
-        label,
-        entry,
+        missingChipLabel,
+        missingEntryLabel,
         '2026-08-31',
       ),
     ).toEqual([
@@ -430,7 +431,14 @@ describe('profitHistoryMissing', () => {
       { hwKey: 'b200_sglang', date: '2026-07-15' },
     ];
     expect(
-      profitHistoryMissing(rows, ['2026-07-15'], ['b200_sglang'], label, entry, '2026-08-31'),
+      profitHistoryMissing(
+        rows,
+        ['2026-07-15'],
+        ['b200_sglang'],
+        missingChipLabel,
+        missingEntryLabel,
+        '2026-08-31',
+      ),
     ).toEqual([]);
   });
 });

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -12,8 +12,9 @@ import {
   parseHistoryResultKey,
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
-  profitHistoryComparisonDates,
   profitHistoryDateRanks,
+  profitHistoryEntryDate,
+  profitHistoryEntryLabel,
   shadeHistoryColor,
 } from './profit-history';
 
@@ -90,8 +91,30 @@ describe('historyResultKey', () => {
     });
   });
 
+  it('round-trips a run entry, whose own `~r<runId>` suffix is not the separator', () => {
+    expect(
+      parseHistoryResultKey(historyResultKey('b200_sglang', '2026-06-14~r27489075807')),
+    ).toEqual({ baseKey: 'b200_sglang', date: '2026-06-14~r27489075807' });
+  });
+
   it('leaves an undated key alone', () => {
     expect(parseHistoryResultKey('b200_sglang')).toEqual({ baseKey: 'b200_sglang' });
+  });
+});
+
+describe('profitHistoryEntryLabel', () => {
+  it('prints a plain date as is', () => {
+    expect(profitHistoryEntryLabel('2026-06-14')).toBe('2026-06-14');
+    expect(profitHistoryEntryLabel('2026-06-14', new Map())).toBe('2026-06-14');
+  });
+
+  it('numbers a run entry the way the changelog does', () => {
+    const numbering = new Map([
+      ['2026-06-14~r1', 1],
+      ['2026-06-14~r2', 2],
+    ]);
+    expect(profitHistoryEntryLabel('2026-06-14~r2', numbering)).toBe('2026-06-14 #2');
+    expect(profitHistoryEntryDate('2026-06-14~r2')).toBe('2026-06-14');
   });
 });
 
@@ -138,37 +161,6 @@ describe('profitHistoryAvailableDates', () => {
   });
 });
 
-describe('profitHistoryComparisonDates', () => {
-  const range = { startDate: '2026-06-14', endDate: '2026-08-31' };
-
-  it('needs both a chip and a full range', () => {
-    expect(profitHistoryComparisonDates([], range, '2026-08-31')).toEqual([]);
-    expect(
-      profitHistoryComparisonDates(['b200_sglang'], { startDate: '2026-06-14', endDate: '' }, ''),
-    ).toEqual([]);
-  });
-
-  it('fetches the range endpoints minus the run date already on the chart', () => {
-    expect(profitHistoryComparisonDates(['b200_sglang'], range, '2026-08-31')).toEqual([
-      '2026-06-14',
-    ]);
-    expect(profitHistoryComparisonDates(['b200_sglang'], range, '2026-07-15')).toEqual([
-      '2026-06-14',
-      '2026-08-31',
-    ]);
-  });
-
-  it('collapses a single-day range to one date', () => {
-    expect(
-      profitHistoryComparisonDates(
-        ['b200_sglang'],
-        { startDate: '2026-06-14', endDate: '2026-06-14' },
-        '2026-08-31',
-      ),
-    ).toEqual(['2026-06-14']);
-  });
-});
-
 describe('buildProfitHistoryResults', () => {
   const options = {
     selectedGPUs: ['b200_sglang'],
@@ -193,7 +185,7 @@ describe('buildProfitHistoryResults', () => {
     expect(results).toHaveLength(1);
     expect(results[0]).toMatchObject({
       hwKey: 'b200_sglang',
-      resultKey: 'b200_sglang~2026-06-14',
+      resultKey: 'b200_sglang|2026-06-14',
       date: '2026-06-14',
       clamped: false,
     });
@@ -263,6 +255,19 @@ describe('orderProfitRowsForHistory', () => {
       'b200_sglang@now',
     ]);
   });
+
+  it('orders same-day runs by run id after the earlier date', () => {
+    const rows = [
+      { hwKey: 'b200_sglang', date: '2026-07-20~r9' },
+      { hwKey: 'b200_sglang', date: '2026-07-20~r10' },
+      { hwKey: 'b200_sglang', date: '2026-06-14' },
+    ];
+    expect(orderProfitRowsForHistory(rows).map((r) => r.date)).toEqual([
+      '2026-06-14',
+      '2026-07-20~r9',
+      '2026-07-20~r10',
+    ]);
+  });
 });
 
 describe('profitHistoryDateRanks', () => {
@@ -276,6 +281,17 @@ describe('profitHistoryDateRanks', () => {
     expect(rank('2026-06-14')).toBe(0);
     expect(rank('2026-07-20')).toBe(1);
     expect(rank(undefined)).toBe(2);
+  });
+
+  it('gives each same-day run its own rank in run order', () => {
+    const { rank, count } = profitHistoryDateRanks([
+      { date: '2026-07-20~r10' },
+      { date: '2026-07-20~r9' },
+      { date: undefined },
+    ]);
+    expect(count).toBe(3);
+    expect(rank('2026-07-20~r9')).toBe(0);
+    expect(rank('2026-07-20~r10')).toBe(1);
   });
 });
 

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -483,6 +483,26 @@ describe('profitHistoryMissing', () => {
     ]);
   });
 
+  it('does not report a pinned run for the chip whose current bar is that run', () => {
+    const rows = [
+      { hwKey: 'b200_sglang', date: undefined },
+      { hwKey: 'gb300_sglang', date: undefined },
+      // GB300 sits on run 150 today, so run 200 is a real extra bar for it.
+      { hwKey: 'gb300_sglang', date: '2026-08-31~r200' },
+    ];
+    expect(
+      profitHistoryMissing(
+        rows,
+        ['2026-08-31~r200'],
+        ['b200_sglang', 'gb300_sglang'],
+        missingChipLabel,
+        missingEntryLabel,
+        '2026-08-31',
+        { b200_sglang: '200', gb300_sglang: '150' },
+      ),
+    ).toEqual([]);
+  });
+
   it('is empty when every compared chip priced everywhere', () => {
     const rows = [
       { hwKey: 'b200_sglang', date: undefined },

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { AvailabilityRow, BenchmarkRow } from '@/lib/api';
+import type { AvailabilityRow, BenchmarkRow, RunConfigRow } from '@/lib/api';
 import { Percentile } from '@/lib/data-mappings';
 
 import {
@@ -12,9 +12,12 @@ import {
   parseHistoryResultKey,
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
+  profitHistoryCurrentRunId,
   profitHistoryDateRanks,
   profitHistoryEntryDate,
   profitHistoryEntryLabel,
+  profitHistoryLegendKeys,
+  profitHistoryMissing,
   shadeHistoryColor,
 } from './profit-history';
 
@@ -321,5 +324,113 @@ describe('shadeHistoryColor', () => {
     expect(shadeHistoryColor('var(--muted-foreground)', 0.5, 'dark')).toBe(
       'var(--muted-foreground)',
     );
+  });
+});
+
+describe('profitHistoryCurrentRunId', () => {
+  const scope = {
+    modelDbKeys: ['kimik3'],
+    selectedGPUs: ['b200_sglang'],
+    selectedPrecisions: ['fp4'],
+    benchmarkType: 'agentic_traces' as const,
+  };
+  function rc(over: Partial<RunConfigRow>): RunConfigRow {
+    return {
+      github_run_id: 1,
+      run_started_at: '2026-08-10T00:00:00Z',
+      html_url: null,
+      head_sha: null,
+      model: 'kimik3',
+      precision: 'fp4',
+      hardware: 'b200',
+      framework: 'sglang',
+      spec_method: 'none',
+      disagg: false,
+      ...over,
+    };
+  }
+  const changelogs = [
+    {
+      date: '2026-08-10',
+      runConfigs: [
+        rc({ github_run_id: 27480000002, run_started_at: '2026-08-10T12:00:00Z' }),
+        rc({ github_run_id: 27480000001, run_started_at: '2026-08-10T03:00:00Z' }),
+        // Another chip's later run is not this comparison's main run.
+        rc({
+          github_run_id: 27480000009,
+          run_started_at: '2026-08-10T20:00:00Z',
+          hardware: 'h200',
+        }),
+      ],
+    },
+    { date: '2026-07-15', runConfigs: [rc({ github_run_id: 27470000001 })] },
+  ];
+
+  it('picks the latest enumerated run of the current date for the compared chips', () => {
+    expect(profitHistoryCurrentRunId(changelogs, '2026-08-10', scope, '999')).toBe('27480000002');
+  });
+
+  it('falls back to the global run id until the current date is in the changelog', () => {
+    expect(profitHistoryCurrentRunId(changelogs, '2026-08-31', scope, '999')).toBe('999');
+    expect(profitHistoryCurrentRunId([], '2026-08-10', scope, '')).toBeUndefined();
+  });
+});
+
+describe('profitHistoryLegendKeys', () => {
+  const rows = [
+    { hwKey: 'b200_sglang' },
+    { hwKey: 'gb300_sglang' },
+    // Priced only on a comparison date; today's run has no row for it.
+    { hwKey: 'mi355x_vllm' },
+  ];
+  const today = ['gb300_sglang', 'b200_sglang', 'h200_vllm'];
+
+  it("lists today's priced chips in availability order without a comparison", () => {
+    expect(profitHistoryLegendKeys(today, rows, false)).toEqual(['gb300_sglang', 'b200_sglang']);
+  });
+
+  it('keeps a chip that only priced on an earlier entry while comparing', () => {
+    expect(profitHistoryLegendKeys(today, rows, true)).toEqual([
+      'gb300_sglang',
+      'b200_sglang',
+      'mi355x_vllm',
+    ]);
+  });
+});
+
+describe('profitHistoryMissing', () => {
+  const label = (hwKey: string) => hwKey.toUpperCase();
+  const entry = (e: string) => `on ${e}`;
+
+  it('names each compared chip with no bar on an entry, the current date included', () => {
+    const rows = [
+      { hwKey: 'b200_sglang', date: undefined },
+      { hwKey: 'b200_sglang', date: '2026-07-15' },
+      { hwKey: 'mi355x_vllm', date: '2026-07-15' },
+    ];
+    expect(
+      profitHistoryMissing(
+        rows,
+        ['2026-07-15', '2026-08-10~r5'],
+        ['b200_sglang', 'mi355x_vllm'],
+        label,
+        entry,
+        '2026-08-31',
+      ),
+    ).toEqual([
+      'B200_SGLANG • on 2026-08-10~r5',
+      'MI355X_VLLM • on 2026-08-10~r5',
+      'MI355X_VLLM • 2026-08-31',
+    ]);
+  });
+
+  it('is empty when every compared chip priced everywhere', () => {
+    const rows = [
+      { hwKey: 'b200_sglang', date: undefined },
+      { hwKey: 'b200_sglang', date: '2026-07-15' },
+    ];
+    expect(
+      profitHistoryMissing(rows, ['2026-07-15'], ['b200_sglang'], label, entry, '2026-08-31'),
+    ).toEqual([]);
   });
 });

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -12,7 +12,8 @@ import {
   parseHistoryResultKey,
   profitHistoryAvailableDates,
   profitHistoryChipOptions,
-  profitHistoryCurrentRunId,
+  dropCurrentRunEntries,
+  profitHistoryCurrentRunIds,
   profitHistoryDateRanks,
   profitHistoryEntryDate,
   profitHistoryEntryLabel,
@@ -231,6 +232,29 @@ describe('buildProfitHistoryResults', () => {
     expect(results[0]!.value).toBeLessThan(1600);
   });
 
+  it("skips a pinned run for the chip whose current bar is that run, keeping the other chip's", () => {
+    const rows = [
+      agenticRow('2026-06-14', 'b200', 40, 800),
+      agenticRow('2026-06-14', 'b200', 80, 400),
+      agenticRow('2026-06-14', 'gb300', 40, 900),
+      agenticRow('2026-06-14', 'gb300', 80, 500),
+    ];
+    const results = buildProfitHistoryResults([{ date: '2026-06-14~r200', rows }], {
+      ...options,
+      selectedGPUs: ['b200_sglang', 'gb300_sglang'],
+      currentRunIds: { b200_sglang: '200', gb300_sglang: '150' },
+    });
+    expect(results.map((r) => r.resultKey)).toEqual(['gb300_sglang|2026-06-14~r200']);
+    // A plain date entry is never a duplicate of a run.
+    expect(
+      buildProfitHistoryResults([{ date: '2026-06-14', rows }], {
+        ...options,
+        selectedGPUs: ['b200_sglang', 'gb300_sglang'],
+        currentRunIds: { b200_sglang: '200' },
+      }),
+    ).toHaveLength(2);
+  });
+
   it('returns nothing with no chip selected', () => {
     expect(
       buildProfitHistoryResults(
@@ -346,11 +370,11 @@ function rc(over: Partial<RunConfigRow>): RunConfigRow {
 const missingChipLabel = (hwKey: string) => hwKey.toUpperCase();
 const missingEntryLabel = (e: string) => `on ${e}`;
 
-describe('profitHistoryCurrentRunId', () => {
+describe('profitHistoryCurrentRunIds', () => {
   const scope = {
     modelDbKeys: ['kimik3'],
-    selectedGPUs: ['b200_sglang'],
-    selectedPrecisions: ['fp4'],
+    selectedGPUs: ['b200_sglang', 'h200_vllm', 'gb300_sglang'],
+    selectedPrecisions: ['fp4', 'fp8'],
     benchmarkType: 'agentic_traces' as const,
   };
   const changelogs = [
@@ -359,24 +383,58 @@ describe('profitHistoryCurrentRunId', () => {
       runConfigs: [
         rc({ github_run_id: 27480000002, run_started_at: '2026-08-10T12:00:00Z' }),
         rc({ github_run_id: 27480000001, run_started_at: '2026-08-10T03:00:00Z' }),
-        // Another chip's later run is not this comparison's main run.
+        // A later sparse run that only covered H200: it is H200's current run,
+        // not B200's.
         rc({
           github_run_id: 27480000009,
           run_started_at: '2026-08-10T20:00:00Z',
           hardware: 'h200',
+          framework: 'vllm',
+          precision: 'fp8',
         }),
       ],
     },
     { date: '2026-07-15', runConfigs: [rc({ github_run_id: 27470000001 })] },
   ];
 
-  it('picks the latest enumerated run of the current date for the compared chips', () => {
-    expect(profitHistoryCurrentRunId(changelogs, '2026-08-10', scope, '999')).toBe('27480000002');
+  it('maps each compared chip to the latest run of the current date that covered it', () => {
+    expect(profitHistoryCurrentRunIds(changelogs, '2026-08-10', scope)).toEqual({
+      b200_sglang: '27480000002',
+      h200_vllm: '27480000009',
+    });
   });
 
-  it('falls back to the global run id until the current date is in the changelog', () => {
-    expect(profitHistoryCurrentRunId(changelogs, '2026-08-31', scope, '999')).toBe('999');
-    expect(profitHistoryCurrentRunId([], '2026-08-10', scope, '')).toBeUndefined();
+  it('is empty until the current date is in the changelog', () => {
+    expect(profitHistoryCurrentRunIds(changelogs, '2026-08-31', scope)).toEqual({});
+    expect(profitHistoryCurrentRunIds([], '2026-08-10', scope)).toEqual({});
+  });
+});
+
+describe('dropCurrentRunEntries', () => {
+  const current = { b200_sglang: '2', h200_vllm: '9' };
+  const gpus = ['b200_sglang', 'h200_vllm', 'gb300_sglang'];
+
+  it('keeps plain dates and runs that add a bar for at least one chip', () => {
+    expect(
+      dropCurrentRunEntries(
+        ['2026-07-15', '2026-08-10~r1', '2026-08-10~r2', '2026-08-10~r9'],
+        gpus,
+        current,
+      ),
+    ).toEqual(['2026-07-15', '2026-08-10~r1', '2026-08-10~r2', '2026-08-10~r9']);
+  });
+
+  it('drops a run every compared chip already shows (chips with no run that day aside)', () => {
+    expect(
+      dropCurrentRunEntries(['2026-08-10~r2'], ['b200_sglang', 'gb300_sglang'], current),
+    ).toEqual([]);
+    expect(dropCurrentRunEntries(['2026-08-10~r2'], ['b200_sglang'], { b200_sglang: '2' })).toEqual(
+      [],
+    );
+  });
+
+  it('drops nothing before the current date has been enumerated', () => {
+    expect(dropCurrentRunEntries(['2026-08-10~r2'], gpus, {})).toEqual(['2026-08-10~r2']);
   });
 });
 

--- a/packages/app/src/components/calculator/profit-history.test.ts
+++ b/packages/app/src/components/calculator/profit-history.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AvailabilityRow, BenchmarkRow } from '@/lib/api';
+import { Percentile } from '@/lib/data-mappings';
+
+import {
+  buildProfitHistoryResults,
+  HISTORY_MAX_FADE,
+  historyFadeShare,
+  historyResultKey,
+  orderProfitRowsForHistory,
+  parseHistoryResultKey,
+  profitHistoryAvailableDates,
+  profitHistoryChipOptions,
+  profitHistoryComparisonDates,
+  profitHistoryDateRanks,
+  shadeHistoryColor,
+} from './profit-history';
+
+function availability(overrides: Partial<AvailabilityRow> = {}): AvailabilityRow {
+  return {
+    model: 'kimik3',
+    isl: null,
+    osl: null,
+    precision: 'fp4',
+    hardware: 'b200',
+    framework: 'sglang',
+    spec_method: 'none',
+    disagg: false,
+    benchmark_type: 'agentic_traces',
+    date: '2026-08-31',
+    ...overrides,
+  };
+}
+
+/** An agentic sweep point on a date; `hardware` must be a registry chip. */
+function agenticRow(
+  date: string,
+  hardware: string,
+  interactivity: number,
+  tputPerGpu: number,
+  overrides: Partial<BenchmarkRow> = {},
+): BenchmarkRow {
+  return {
+    id: Math.round(interactivity * 1000 + tputPerGpu),
+    hardware,
+    framework: 'sglang',
+    model: 'kimik3',
+    precision: 'fp4',
+    spec_method: 'none',
+    disagg: false,
+    is_multinode: false,
+    prefill_tp: 8,
+    prefill_ep: 8,
+    prefill_dp_attention: false,
+    prefill_num_workers: 1,
+    decode_tp: 8,
+    decode_ep: 8,
+    decode_dp_attention: false,
+    decode_num_workers: 1,
+    num_prefill_gpu: 8,
+    num_decode_gpu: 8,
+    benchmark_type: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: Math.round(tputPerGpu / interactivity),
+    offload_mode: 'on',
+    image: 'sglang:test',
+    metrics: {
+      p90_itl: 1 / interactivity,
+      p90_e2el: 10,
+      tput_per_gpu: tputPerGpu,
+      output_tput_per_gpu: tputPerGpu * 0.008,
+      input_tput_per_gpu: tputPerGpu * 0.992,
+      server_gpu_cache_hit_rate: 0.9,
+    },
+    date,
+    run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${date}-${hardware}`,
+    ...overrides,
+  };
+}
+
+const KIMI_KEYS = ['kimik3'];
+
+describe('historyResultKey', () => {
+  it('round-trips a base key and date, including a precision-suffixed base', () => {
+    expect(parseHistoryResultKey(historyResultKey('b200_sglang__fp4', '2026-06-14'))).toEqual({
+      baseKey: 'b200_sglang__fp4',
+      date: '2026-06-14',
+    });
+  });
+
+  it('leaves an undated key alone', () => {
+    expect(parseHistoryResultKey('b200_sglang')).toEqual({ baseKey: 'b200_sglang' });
+  });
+});
+
+describe('profitHistoryChipOptions', () => {
+  const rows = [
+    availability({ hardware: 'gb300', framework: 'sglang' }),
+    availability({ hardware: 'b200', framework: 'sglang' }),
+    // Another model's rows never leak in.
+    availability({ hardware: 'mi355x', framework: 'vllm', model: 'glm5.2' }),
+    // Single-turn rows are not what the estimator prices.
+    availability({ hardware: 'h200', framework: 'vllm', benchmark_type: 'single_turn', isl: 1024 }),
+    // A precision outside the selection is not offered either.
+    availability({ hardware: 'b300', framework: 'vllm', precision: 'fp8' }),
+  ];
+
+  it('offers known agentic configs for the model at the selected precisions, in registry order', () => {
+    const options = profitHistoryChipOptions(rows, KIMI_KEYS, ['fp4']);
+    // HW_REGISTRY sorts the newest chip first, as the /inference selector does.
+    expect(options.map((o) => o.value)).toEqual(['gb300_sglang', 'b200_sglang']);
+    expect(options[0]!.label).toContain('GB300');
+  });
+
+  it('returns nothing before availability loads', () => {
+    expect(profitHistoryChipOptions(undefined, KIMI_KEYS, ['fp4'])).toEqual([]);
+  });
+});
+
+describe('profitHistoryAvailableDates', () => {
+  const rows = [
+    availability({ date: '2026-08-31' }),
+    availability({ date: '2026-06-14' }),
+    availability({ date: '2026-07-01', hardware: 'gb300' }),
+  ];
+
+  it('lists the sorted run dates of the selected chips only', () => {
+    expect(profitHistoryAvailableDates(rows, KIMI_KEYS, ['fp4'], ['b200_sglang'])).toEqual([
+      '2026-06-14',
+      '2026-08-31',
+    ]);
+  });
+
+  it('is empty with no chip selected', () => {
+    expect(profitHistoryAvailableDates(rows, KIMI_KEYS, ['fp4'], [])).toEqual([]);
+  });
+});
+
+describe('profitHistoryComparisonDates', () => {
+  const range = { startDate: '2026-06-14', endDate: '2026-08-31' };
+
+  it('needs both a chip and a full range', () => {
+    expect(profitHistoryComparisonDates([], range, '2026-08-31')).toEqual([]);
+    expect(
+      profitHistoryComparisonDates(['b200_sglang'], { startDate: '2026-06-14', endDate: '' }, ''),
+    ).toEqual([]);
+  });
+
+  it('fetches the range endpoints minus the run date already on the chart', () => {
+    expect(profitHistoryComparisonDates(['b200_sglang'], range, '2026-08-31')).toEqual([
+      '2026-06-14',
+    ]);
+    expect(profitHistoryComparisonDates(['b200_sglang'], range, '2026-07-15')).toEqual([
+      '2026-06-14',
+      '2026-08-31',
+    ]);
+  });
+
+  it('collapses a single-day range to one date', () => {
+    expect(
+      profitHistoryComparisonDates(
+        ['b200_sglang'],
+        { startDate: '2026-06-14', endDate: '2026-06-14' },
+        '2026-08-31',
+      ),
+    ).toEqual(['2026-06-14']);
+  });
+});
+
+describe('buildProfitHistoryResults', () => {
+  const options = {
+    selectedGPUs: ['b200_sglang'],
+    precisions: ['fp4'],
+    percentile: Percentile.P90,
+    targetValue: 60,
+    mode: 'interactivity_to_throughput' as const,
+    costProvider: 'costh' as const,
+  };
+
+  it('interpolates the selected chip at the target on each date and stamps the date', () => {
+    const rowsByDate = [
+      {
+        date: '2026-06-14',
+        rows: [
+          agenticRow('2026-06-14', 'b200', 40, 800),
+          agenticRow('2026-06-14', 'b200', 80, 400),
+        ],
+      },
+    ];
+    const results = buildProfitHistoryResults(rowsByDate, options);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      hwKey: 'b200_sglang',
+      resultKey: 'b200_sglang~2026-06-14',
+      date: '2026-06-14',
+      clamped: false,
+    });
+    // Monotone Hermite between the two knots, the same spline the current bars
+    // use, so the value lands between them rather than on the chord.
+    expect(results[0]!.value).toBeGreaterThan(400);
+    expect(results[0]!.value).toBeLessThan(800);
+  });
+
+  it('ignores chips outside the selection and keeps one run per chip per date', () => {
+    const rowsByDate = [
+      {
+        date: '2026-06-14',
+        rows: [
+          agenticRow('2026-06-14', 'b200', 40, 800, {
+            run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/100',
+          }),
+          agenticRow('2026-06-14', 'b200', 80, 400, {
+            run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/100',
+          }),
+          // A later run the same day supersedes the earlier one.
+          agenticRow('2026-06-14', 'b200', 40, 1600, {
+            id: 9001,
+            run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/200',
+          }),
+          agenticRow('2026-06-14', 'b200', 80, 800, {
+            id: 9002,
+            run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/200',
+          }),
+          agenticRow('2026-06-14', 'gb300', 40, 900),
+          agenticRow('2026-06-14', 'gb300', 80, 500),
+        ],
+      },
+    ];
+    const results = buildProfitHistoryResults(rowsByDate, options);
+    expect(results.map((r) => r.hwKey)).toEqual(['b200_sglang']);
+    // Only the later run's curve (1600 → 800) is priced, so the value clears
+    // the earlier run's best point.
+    expect(results[0]!.value).toBeGreaterThan(800);
+    expect(results[0]!.value).toBeLessThan(1600);
+  });
+
+  it('returns nothing with no chip selected', () => {
+    expect(
+      buildProfitHistoryResults(
+        [{ date: '2026-06-14', rows: [agenticRow('2026-06-14', 'b200', 40, 800)] }],
+        { ...options, selectedGPUs: [] },
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('orderProfitRowsForHistory', () => {
+  it('keeps chips in their incoming order and sorts each chip oldest → today', () => {
+    const rows = [
+      { hwKey: 'gb300_sglang', date: undefined },
+      { hwKey: 'b200_sglang', date: '2026-06-14' },
+      { hwKey: 'gb300_sglang', date: '2026-06-14' },
+      { hwKey: 'b200_sglang', date: undefined },
+      { hwKey: 'gb300_sglang', date: '2026-07-20' },
+    ];
+    expect(orderProfitRowsForHistory(rows).map((r) => `${r.hwKey}@${r.date ?? 'now'}`)).toEqual([
+      'gb300_sglang@2026-06-14',
+      'gb300_sglang@2026-07-20',
+      'gb300_sglang@now',
+      'b200_sglang@2026-06-14',
+      'b200_sglang@now',
+    ]);
+  });
+});
+
+describe('profitHistoryDateRanks', () => {
+  it('ranks dates oldest first with today last', () => {
+    const { rank, count } = profitHistoryDateRanks([
+      { date: undefined },
+      { date: '2026-07-20' },
+      { date: '2026-06-14' },
+    ]);
+    expect(count).toBe(3);
+    expect(rank('2026-06-14')).toBe(0);
+    expect(rank('2026-07-20')).toBe(1);
+    expect(rank(undefined)).toBe(2);
+  });
+});
+
+describe('historyFadeShare', () => {
+  it('fades the oldest date most and today not at all', () => {
+    expect(historyFadeShare(0, 3)).toBeCloseTo(HISTORY_MAX_FADE);
+    expect(historyFadeShare(1, 3)).toBeCloseTo(HISTORY_MAX_FADE / 2);
+    expect(historyFadeShare(2, 3)).toBe(0);
+  });
+
+  it('never fades a lone date', () => {
+    expect(historyFadeShare(0, 1)).toBe(0);
+  });
+});
+
+describe('shadeHistoryColor', () => {
+  it('lifts lightness toward the theme ceiling and eases chroma, keeping the hue', () => {
+    expect(shadeHistoryColor('oklch(0.500 0.200 150.0)', 0.5, 'light')).toBe(
+      'oklch(0.680 0.150 150.0)',
+    );
+  });
+
+  it('returns the colour unchanged with no fade or an unparseable value', () => {
+    expect(shadeHistoryColor('oklch(0.500 0.200 150.0)', 0, 'dark')).toBe(
+      'oklch(0.500 0.200 150.0)',
+    );
+    expect(shadeHistoryColor('var(--muted-foreground)', 0.5, 'dark')).toBe(
+      'var(--muted-foreground)',
+    );
+  });
+});

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -19,6 +19,7 @@ import {
   comparisonEntryDate,
   comparisonEntryLabel,
   comparisonEntrySortValue,
+  parseComparisonEntry,
 } from '@/components/inference/utils/comparisonEntry';
 import { dataRunsForDate, type RunScope } from '@/components/inference/utils/runEnumeration';
 import type { AvailabilityRow, BenchmarkRow, RunConfigRow } from '@/lib/api';
@@ -167,13 +168,28 @@ export function buildProfitHistoryResults(
     targetValue: number;
     mode: CalculatorMode;
     costProvider: CostProvider;
+    /**
+     * Per chip, the run its current bar is built from
+     * (`profitHistoryCurrentRunIds`); a pinned run entry for that same run is
+     * skipped for that chip, since the bar is already on the chart.
+     */
+    currentRunIds?: Readonly<Record<string, string>>;
   },
 ): (InterpolatedResult & { date: string })[] {
-  const { selectedGPUs, precisions, percentile, targetValue, mode, costProvider } = options;
+  const {
+    selectedGPUs,
+    precisions,
+    percentile,
+    targetValue,
+    mode,
+    costProvider,
+    currentRunIds = {},
+  } = options;
   if (selectedGPUs.length === 0) return [];
   const multiPrecision = precisions.length > 1;
   const results: (InterpolatedResult & { date: string })[] = [];
   for (const { date, rows } of rowsByDate) {
+    const { runId } = parseComparisonEntry(date);
     const { grouped, groupMeta } = buildGpuGroups<HistoryGroupMeta>(
       dedupeAgenticHistoryRuns([...rows]),
       {
@@ -183,6 +199,7 @@ export function buildProfitHistoryResults(
         tokenType: 'total',
         classify: (hwKey, row) => {
           if (!selectedGPUs.includes(hwKey)) return null;
+          if (runId !== undefined && currentRunIds[hwKey] === runId) return null;
           const baseKey = multiPrecision ? `${hwKey}__${row.precision}` : hwKey;
           return {
             key: historyResultKey(baseKey, date),
@@ -296,22 +313,51 @@ export function shadeHistoryColor(color: string, fade: number, theme: 'light' | 
 }
 
 /**
- * The run behind the estimator's main bars, which a changelog pin must not
- * draw twice: the latest run of the current date for the compared chips once
- * the changelog has enumerated that date, else the global run selection.
- * `/inference` covers this by handing `buildComparisonDates` its
- * `selectedRunId`; the estimator's main query has no run id of its own, so
- * the id is read back from the changelog it renders.
+ * Per compared chip, the run its current bar is built from: the estimator's
+ * main query is an as-of-date fetch with no run id, and `dedupeAgenticHistoryRuns`
+ * keeps each config's latest run of the day, so two chips can sit on different
+ * runs. Read back from the changelog's enumeration of the current date, the
+ * same ordering the dedupe applies. Chips with no run that day are absent.
  */
-export function profitHistoryCurrentRunId(
+export function profitHistoryCurrentRunIds(
   changelogs: readonly { date: string; runConfigs: RunConfigRow[] }[],
   selectedRunDate: string | undefined,
   scope: RunScope,
-  fallbackRunId: string | undefined,
-): string | undefined {
+): Record<string, string> {
   const today = changelogs.find((c) => c.date === selectedRunDate);
-  const runs = today ? dataRunsForDate(today.runConfigs, scope) : [];
-  return runs.at(-1)?.runId ?? (fallbackRunId || undefined);
+  if (!today) return {};
+  const ids: Record<string, string> = {};
+  for (const hwKey of scope.selectedGPUs) {
+    const runs = dataRunsForDate(today.runConfigs, { ...scope, selectedGPUs: [hwKey] });
+    const latest = runs.at(-1);
+    if (latest) ids[hwKey] = latest.runId;
+  }
+  return ids;
+}
+
+/**
+ * Drop pinned run entries that would only redraw current bars: a run is
+ * skipped when every compared chip either shows that run today already or
+ * has no run that day at all. `/inference` covers its single main run by
+ * handing `buildComparisonDates` a `selectedRunId`; the estimator has one per
+ * chip, so the check is per entry here and per chip in
+ * `buildProfitHistoryResults`. Nothing is dropped until the current date's
+ * changelog has loaded.
+ */
+export function dropCurrentRunEntries(
+  entries: readonly string[],
+  selectedGPUs: readonly string[],
+  currentRunIds: Readonly<Record<string, string>>,
+): string[] {
+  if (Object.keys(currentRunIds).length === 0) return [...entries];
+  return entries.filter((entry) => {
+    const { runId } = parseComparisonEntry(entry);
+    if (runId === undefined) return true;
+    return selectedGPUs.some((hwKey) => {
+      const current = currentRunIds[hwKey];
+      return current !== undefined && current !== runId;
+    });
+  });
 }
 
 /**

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -1,0 +1,277 @@
+/**
+ * Compare-history support for the profit estimator — pure, no React.
+ *
+ * Mirrors the `/inference` "Compare history" panel: the reader picks up to four
+ * chip configs and a date range, and the estimator prices those configs at the
+ * range's start and end dates alongside today's bar. `/inference` fetches each
+ * comparison date as its own exact-date benchmarks query and stamps every row
+ * with the date it was requested for (`useChartData`); this module does the
+ * same grouping for the calculator's interpolation path so a historical bar is
+ * built by the exact logic that builds the current one.
+ */
+
+import { rowToSequence } from '@semianalysisai/inferencex-constants';
+
+import type { AvailabilityRow, BenchmarkRow } from '@/lib/api';
+import { dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
+import { buildAvailabilityHwKey } from '@/lib/chart-utils';
+import { getHardwareConfig, getModelSortIndex, isKnownGpu } from '@/lib/constants';
+import { type Percentile, Sequence } from '@/lib/data-mappings';
+import { getDisplayLabel } from '@/lib/utils';
+
+import { interpolateForGPU } from './interpolation';
+import type { ProfitEstimatorRow } from './profit-estimator';
+import type { CalculatorMode, CostProvider, InterpolatedResult } from './types';
+import { buildGpuGroups, type GroupMeta } from './useThroughputData';
+
+/** Most chip configs the panel compares at once; the same cap `/inference` applies. */
+export const PROFIT_HISTORY_MAX_GPUS = 4;
+
+/**
+ * Separator between a result key and the date it was priced on. `~` matches
+ * the `/inference` comparison entries, is URL-safe, and never appears in a
+ * hwKey, a precision, or an ISO date.
+ */
+const HISTORY_KEY_SEP = '~';
+
+/** Result key for a chip priced on a comparison date: `gb300_sglang~2026-06-14`. */
+export function historyResultKey(baseKey: string, date: string): string {
+  return `${baseKey}${HISTORY_KEY_SEP}${date}`;
+}
+
+/** Split a history result key back into its base key and date. */
+export function parseHistoryResultKey(resultKey: string): { baseKey: string; date?: string } {
+  const at = resultKey.lastIndexOf(HISTORY_KEY_SEP);
+  if (at === -1) return { baseKey: resultKey };
+  return { baseKey: resultKey.slice(0, at), date: resultKey.slice(at + 1) };
+}
+
+interface HistoryGroupMeta extends GroupMeta {
+  date: string;
+}
+
+const byModelOrder = (a: string, b: string) =>
+  getModelSortIndex(a) - getModelSortIndex(b) || a.localeCompare(b);
+
+/**
+ * Chip configs the panel offers: every known config with an agentic-traces
+ * availability row for the model at one of the selected precisions. Same
+ * derivation as `availableGPUs` in `InferenceContext`, pinned to the agentic
+ * workload the estimator prices.
+ */
+export function profitHistoryChipOptions(
+  availabilityRows: readonly AvailabilityRow[] | undefined,
+  dbModelKeys: readonly string[],
+  precisions: readonly string[],
+  displayModel?: string,
+): { value: string; label: string }[] {
+  if (!availabilityRows) return [];
+  const hwKeys = new Set<string>();
+  for (const r of availabilityRows) {
+    if (!dbModelKeys.includes(r.model)) continue;
+    if (rowToSequence(r) !== Sequence.AgenticTraces) continue;
+    if (!precisions.includes(r.precision)) continue;
+    if (!r.hardware) continue;
+    const hwKey = buildAvailabilityHwKey(
+      r.hardware,
+      r.framework,
+      r.spec_method,
+      r.disagg,
+      r.benchmark_type,
+    );
+    if (isKnownGpu(hwKey)) hwKeys.add(hwKey);
+  }
+  return [...hwKeys].toSorted(byModelOrder).map((hw) => ({
+    value: hw,
+    label: getDisplayLabel(getHardwareConfig(hw, displayModel)),
+  }));
+}
+
+/**
+ * Dates the range picker can offer: every run date on which one of the
+ * selected configs has an agentic row for the model. Same derivation as
+ * `dateRangeAvailableDates` in `InferenceContext`.
+ */
+export function profitHistoryAvailableDates(
+  availabilityRows: readonly AvailabilityRow[] | undefined,
+  dbModelKeys: readonly string[],
+  precisions: readonly string[],
+  selectedGPUs: readonly string[],
+): string[] {
+  if (!availabilityRows || selectedGPUs.length === 0) return [];
+  const dates = new Set<string>();
+  for (const r of availabilityRows) {
+    if (!dbModelKeys.includes(r.model)) continue;
+    if (rowToSequence(r) !== Sequence.AgenticTraces) continue;
+    if (!precisions.includes(r.precision)) continue;
+    if (!r.hardware) continue;
+    const hwKey = buildAvailabilityHwKey(
+      r.hardware,
+      r.framework,
+      r.spec_method,
+      r.disagg,
+      r.benchmark_type,
+    );
+    if (selectedGPUs.includes(hwKey)) dates.add(r.date);
+  }
+  return [...dates].toSorted();
+}
+
+/**
+ * The dates to fetch for a comparison: the range endpoints, minus the run date
+ * the main query already covers. Nothing to fetch until both a chip and a
+ * complete range are chosen. (`/inference` does the same in
+ * `buildComparisonDates`, plus individually pinned runs the estimator has no
+ * UI for.)
+ */
+export function profitHistoryComparisonDates(
+  selectedGPUs: readonly string[],
+  range: { startDate: string; endDate: string },
+  currentRunDate: string | undefined,
+): string[] {
+  if (selectedGPUs.length === 0 || !range.startDate || !range.endDate) return [];
+  return [...new Set([range.startDate, range.endDate])].filter((d) => d !== currentRunDate);
+}
+
+/** Rows fetched for one comparison date. */
+export interface ProfitHistoryDateRows {
+  date: string;
+  rows: readonly BenchmarkRow[];
+}
+
+/**
+ * Interpolate the selected chips at the target on each comparison date. One
+ * agentic run per config per date is kept (the same rule the `/inference`
+ * comparison applies), rows are grouped by `hwKey[__precision]~date`, and each
+ * group is read at the target by `interpolateForGPU`, so a historical bar is
+ * priced by the exact logic that prices today's.
+ */
+export function buildProfitHistoryResults(
+  rowsByDate: readonly ProfitHistoryDateRows[],
+  options: {
+    selectedGPUs: readonly string[];
+    precisions: string[];
+    percentile: Percentile;
+    targetValue: number;
+    mode: CalculatorMode;
+    costProvider: CostProvider;
+  },
+): (InterpolatedResult & { date: string })[] {
+  const { selectedGPUs, precisions, percentile, targetValue, mode, costProvider } = options;
+  if (selectedGPUs.length === 0) return [];
+  const multiPrecision = precisions.length > 1;
+  const results: (InterpolatedResult & { date: string })[] = [];
+  for (const { date, rows } of rowsByDate) {
+    const { grouped, groupMeta } = buildGpuGroups<HistoryGroupMeta>(
+      dedupeAgenticHistoryRuns([...rows]),
+      {
+        sequence: Sequence.AgenticTraces,
+        precisions,
+        percentile,
+        tokenType: 'total',
+        classify: (hwKey, row) => {
+          if (!selectedGPUs.includes(hwKey)) return null;
+          const baseKey = multiPrecision ? `${hwKey}__${row.precision}` : hwKey;
+          return {
+            key: historyResultKey(baseKey, date),
+            meta: { hwKey, precision: multiPrecision ? row.precision : undefined, date },
+          };
+        },
+      },
+    );
+    for (const [groupKey, points] of Object.entries(grouped)) {
+      const meta = groupMeta[groupKey];
+      if (!meta) continue;
+      const result = interpolateForGPU(points, targetValue, mode, costProvider);
+      if (!result || !(result.value > 0)) continue;
+      results.push({
+        ...result,
+        hwKey: meta.hwKey,
+        resultKey: groupKey,
+        precision: meta.precision,
+        date: meta.date,
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Order bars for the comparison view: chips in the order they already hold
+ * (revenue descending, from `estimateProfitRows`), and within a chip its dates
+ * oldest → newest so the current bar sits at the right of its group. Rows with
+ * no date are today's and sort last within their chip.
+ */
+export function orderProfitRowsForHistory<T extends Pick<ProfitEstimatorRow, 'hwKey' | 'date'>>(
+  rows: readonly T[],
+): T[] {
+  const chipOrder: string[] = [];
+  for (const row of rows) if (!chipOrder.includes(row.hwKey)) chipOrder.push(row.hwKey);
+  return rows.toSorted((a, b) => {
+    const chip = chipOrder.indexOf(a.hwKey) - chipOrder.indexOf(b.hwKey);
+    if (chip !== 0) return chip;
+    if (a.date === b.date) return 0;
+    if (a.date === undefined) return 1;
+    if (b.date === undefined) return -1;
+    return a.date < b.date ? -1 : 1;
+  });
+}
+
+/**
+ * Rank of each date among the dates on the chart, oldest first, with the
+ * current (undated) bar last. Drives the shade ramp: `/inference` separates a
+ * config's dates by lightness (lighter = older) rather than by hue, and the
+ * bars do the same.
+ */
+export function profitHistoryDateRanks(rows: readonly Pick<ProfitEstimatorRow, 'date'>[]): {
+  rank: (date: string | undefined) => number;
+  count: number;
+} {
+  const dated = [...new Set(rows.map((r) => r.date).filter((d): d is string => Boolean(d)))];
+  dated.sort();
+  const hasCurrent = rows.some((r) => r.date === undefined);
+  const count = dated.length + (hasCurrent ? 1 : 0);
+  return {
+    count,
+    rank: (date) => (date === undefined ? count - 1 : dated.indexOf(date)),
+  };
+}
+
+/** Deepest fade an older bar gets toward the page background, as a mix share. */
+export const HISTORY_MAX_FADE = 0.55;
+
+/**
+ * Mix share toward the background for a bar at `rank` of `count` dates: the
+ * newest is the solid chip colour, the oldest fades by `HISTORY_MAX_FADE`, and
+ * anything between sits on a straight ramp. A single date never fades.
+ */
+export function historyFadeShare(rank: number, count: number): number {
+  if (count <= 1 || rank < 0) return 0;
+  return HISTORY_MAX_FADE * (1 - rank / (count - 1));
+}
+
+/**
+ * Lightness ceiling an older bar fades toward. Below the page background in
+ * each theme so the oldest bar still reads against it.
+ */
+const HISTORY_L_CEILING = { light: 0.86, dark: 0.92 } as const;
+
+/**
+ * Shade a vendor colour for an older comparison date. Chip colours arrive as
+ * `oklch(L C H)` strings from `useThemeColors`; the hue is kept (it names the
+ * chip) and lightness moves toward the theme ceiling by `fade`, with chroma
+ * eased off so the older bar reads as a washed version of today's. Anything
+ * that is not an oklch string is returned unchanged.
+ */
+export function shadeHistoryColor(color: string, fade: number, theme: 'light' | 'dark'): string {
+  if (fade <= 0) return color;
+  const match = /^oklch\(\s*(?<l>[\d.]+)\s+(?<c>[\d.]+)\s+(?<h>[\d.]+)\s*\)$/u.exec(color);
+  if (!match?.groups) return color;
+  const l = Number(match.groups.l);
+  const c = Number(match.groups.c);
+  const h = match.groups.h;
+  const ceiling = HISTORY_L_CEILING[theme];
+  const nextL = l + (ceiling - l) * fade;
+  const nextC = c * (1 - fade * 0.5);
+  return `oklch(${nextL.toFixed(3)} ${nextC.toFixed(3)} ${h})`;
+}

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -384,7 +384,8 @@ export function profitHistoryLegendKeys(
 /**
  * Compared chips with no bar on a comparison entry, or on the current date
  * (`''`) when the chip only priced earlier, as `chip • when` captions so a
- * missing bar reads as "no run that day", not as a zero.
+ * missing bar reads as "no run that day", not as a zero. A pinned run that a
+ * chip already shows as its current bar is not missing for that chip.
  */
 export function profitHistoryMissing(
   pricedRows: readonly Pick<ProfitEstimatorRow, 'hwKey' | 'date'>[],
@@ -393,12 +394,17 @@ export function profitHistoryMissing(
   chipLabel: (hwKey: string) => string,
   entryLabel: (entry: string) => string,
   currentDateLabel: string,
+  currentRunIds: Readonly<Record<string, string>> = {},
 ): string[] {
   const priced = new Set(pricedRows.map((row) => `${row.hwKey}~${row.date ?? ''}`));
   const missing: string[] = [];
   for (const entry of [...comparisonDates, '']) {
+    const { runId } = parseComparisonEntry(entry);
     for (const hwKey of selectedGPUs) {
       if (priced.has(`${hwKey}~${entry}`)) continue;
+      // A pinned run that is this chip's current run is on the chart as
+      // today's bar (`buildProfitHistoryResults` skips it), not missing.
+      if (runId !== undefined && currentRunIds[hwKey] === runId) continue;
       missing.push(`${chipLabel(hwKey)} • ${entry ? entryLabel(entry) : currentDateLabel}`);
     }
   }

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -2,16 +2,24 @@
  * Compare-history support for the profit estimator — pure, no React.
  *
  * Mirrors the `/inference` "Compare history" panel: the reader picks up to four
- * chip configs and a date range, and the estimator prices those configs at the
- * range's start and end dates alongside today's bar. `/inference` fetches each
- * comparison date as its own exact-date benchmarks query and stamps every row
- * with the date it was requested for (`useChartData`); this module does the
- * same grouping for the calculator's interpolation path so a historical bar is
- * built by the exact logic that builds the current one.
+ * chip configs, a date range, and any individual dates or runs from the Config
+ * Changelog, and the estimator prices those configs on each comparison entry
+ * alongside today's bar. Comparison entries are the same strings `/inference`
+ * keeps in `i_dates` (a plain date, or `date~r<runId>` for one specific run,
+ * see `comparisonEntry.ts`); `/inference` fetches each as its own benchmarks
+ * query and stamps every row with the entry it was requested for
+ * (`useChartData`). This module does the same grouping for the calculator's
+ * interpolation path so a historical bar is built by the exact logic that
+ * builds the current one.
  */
 
 import { rowToSequence } from '@semianalysisai/inferencex-constants';
 
+import {
+  comparisonEntryDate,
+  comparisonEntryLabel,
+  comparisonEntrySortValue,
+} from '@/components/inference/utils/comparisonEntry';
 import type { AvailabilityRow, BenchmarkRow } from '@/lib/api';
 import { dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
 import { buildAvailabilityHwKey } from '@/lib/chart-utils';
@@ -28,22 +36,40 @@ import { buildGpuGroups, type GroupMeta } from './useThroughputData';
 export const PROFIT_HISTORY_MAX_GPUS = 4;
 
 /**
- * Separator between a result key and the date it was priced on. `~` matches
- * the `/inference` comparison entries, is URL-safe, and never appears in a
- * hwKey, a precision, or an ISO date.
+ * Separator between a result key and the comparison entry it was priced on.
+ * `|` is URL-safe in a result key (never serialised) and appears in neither a
+ * hwKey, a precision, nor a comparison entry (which uses `~` for its own run
+ * suffix).
  */
-const HISTORY_KEY_SEP = '~';
+const HISTORY_KEY_SEP = '|';
 
-/** Result key for a chip priced on a comparison date: `gb300_sglang~2026-06-14`. */
-export function historyResultKey(baseKey: string, date: string): string {
-  return `${baseKey}${HISTORY_KEY_SEP}${date}`;
+/**
+ * Result key for a chip priced on a comparison entry:
+ * `gb300_sglang|2026-06-14` or `gb300_sglang|2026-06-14~r27489075807`.
+ */
+export function historyResultKey(baseKey: string, entry: string): string {
+  return `${baseKey}${HISTORY_KEY_SEP}${entry}`;
 }
 
-/** Split a history result key back into its base key and date. */
+/** Split a history result key back into its base key and comparison entry. */
 export function parseHistoryResultKey(resultKey: string): { baseKey: string; date?: string } {
-  const at = resultKey.lastIndexOf(HISTORY_KEY_SEP);
+  const at = resultKey.indexOf(HISTORY_KEY_SEP);
   if (at === -1) return { baseKey: resultKey };
   return { baseKey: resultKey.slice(0, at), date: resultKey.slice(at + 1) };
+}
+
+/**
+ * Human label for a comparison entry, as the `/inference` legend shows it: the
+ * plain date, or `date #n` for one of several same-day runs. `numbering` comes
+ * from the changelog's run enumeration so both surfaces print the same #n.
+ */
+export function profitHistoryEntryLabel(entry: string, numbering?: Map<string, number>): string {
+  return comparisonEntryLabel(entry, numbering);
+}
+
+/** Calendar date behind a comparison entry (drops any `~r<runId>` suffix). */
+export function profitHistoryEntryDate(entry: string): string {
+  return comparisonEntryDate(entry);
 }
 
 interface HistoryGroupMeta extends GroupMeta {
@@ -117,32 +143,17 @@ export function profitHistoryAvailableDates(
   return [...dates].toSorted();
 }
 
-/**
- * The dates to fetch for a comparison: the range endpoints, minus the run date
- * the main query already covers. Nothing to fetch until both a chip and a
- * complete range are chosen. (`/inference` does the same in
- * `buildComparisonDates`, plus individually pinned runs the estimator has no
- * UI for.)
- */
-export function profitHistoryComparisonDates(
-  selectedGPUs: readonly string[],
-  range: { startDate: string; endDate: string },
-  currentRunDate: string | undefined,
-): string[] {
-  if (selectedGPUs.length === 0 || !range.startDate || !range.endDate) return [];
-  return [...new Set([range.startDate, range.endDate])].filter((d) => d !== currentRunDate);
-}
-
-/** Rows fetched for one comparison date. */
+/** Rows fetched for one comparison entry (a date, or one run on a date). */
 export interface ProfitHistoryDateRows {
+  /** The comparison entry the rows were requested for. */
   date: string;
   rows: readonly BenchmarkRow[];
 }
 
 /**
- * Interpolate the selected chips at the target on each comparison date. One
- * agentic run per config per date is kept (the same rule the `/inference`
- * comparison applies), rows are grouped by `hwKey[__precision]~date`, and each
+ * Interpolate the selected chips at the target on each comparison entry. One
+ * agentic run per config per entry is kept (the same rule the `/inference`
+ * comparison applies), rows are grouped by `hwKey[__precision]|entry`, and each
  * group is read at the target by `interpolateForGPU`, so a historical bar is
  * priced by the exact logic that prices today's.
  */
@@ -196,11 +207,18 @@ export function buildProfitHistoryResults(
   return results;
 }
 
+const entryOrder = (a: string, b: string): number => {
+  const [ad, ar] = comparisonEntrySortValue(a);
+  const [bd, br] = comparisonEntrySortValue(b);
+  return ad - bd || ar - br;
+};
+
 /**
  * Order bars for the comparison view: chips in the order they already hold
- * (revenue descending, from `estimateProfitRows`), and within a chip its dates
- * oldest → newest so the current bar sits at the right of its group. Rows with
- * no date are today's and sort last within their chip.
+ * (revenue descending, from `estimateProfitRows`), and within a chip its
+ * entries oldest → newest (same-day runs in run order, as `/inference` sorts
+ * them) so the current bar sits at the right of its group. Rows with no entry
+ * are today's and sort last within their chip.
  */
 export function orderProfitRowsForHistory<T extends Pick<ProfitEstimatorRow, 'hwKey' | 'date'>>(
   rows: readonly T[],
@@ -213,7 +231,7 @@ export function orderProfitRowsForHistory<T extends Pick<ProfitEstimatorRow, 'hw
     if (a.date === b.date) return 0;
     if (a.date === undefined) return 1;
     if (b.date === undefined) return -1;
-    return a.date < b.date ? -1 : 1;
+    return entryOrder(a.date, b.date);
   });
 }
 
@@ -228,7 +246,7 @@ export function profitHistoryDateRanks(rows: readonly Pick<ProfitEstimatorRow, '
   count: number;
 } {
   const dated = [...new Set(rows.map((r) => r.date).filter((d): d is string => Boolean(d)))];
-  dated.sort();
+  dated.sort(entryOrder);
   const hasCurrent = rows.some((r) => r.date === undefined);
   const count = dated.length + (hasCurrent ? 1 : 0);
   return {

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -20,7 +20,8 @@ import {
   comparisonEntryLabel,
   comparisonEntrySortValue,
 } from '@/components/inference/utils/comparisonEntry';
-import type { AvailabilityRow, BenchmarkRow } from '@/lib/api';
+import { dataRunsForDate, type RunScope } from '@/components/inference/utils/runEnumeration';
+import type { AvailabilityRow, BenchmarkRow, RunConfigRow } from '@/lib/api';
 import { dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
 import { buildAvailabilityHwKey } from '@/lib/chart-utils';
 import { getHardwareConfig, getModelSortIndex, isKnownGpu } from '@/lib/constants';
@@ -292,4 +293,68 @@ export function shadeHistoryColor(color: string, fade: number, theme: 'light' | 
   const nextL = l + (ceiling - l) * fade;
   const nextC = c * (1 - fade * 0.5);
   return `oklch(${nextL.toFixed(3)} ${nextC.toFixed(3)} ${h})`;
+}
+
+/**
+ * The run behind the estimator's main bars, which a changelog pin must not
+ * draw twice: the latest run of the current date for the compared chips once
+ * the changelog has enumerated that date, else the global run selection.
+ * `/inference` covers this by handing `buildComparisonDates` its
+ * `selectedRunId`; the estimator's main query has no run id of its own, so
+ * the id is read back from the changelog it renders.
+ */
+export function profitHistoryCurrentRunId(
+  changelogs: readonly { date: string; runConfigs: RunConfigRow[] }[],
+  selectedRunDate: string | undefined,
+  scope: RunScope,
+  fallbackRunId: string | undefined,
+): string | undefined {
+  const today = changelogs.find((c) => c.date === selectedRunDate);
+  const runs = today ? dataRunsForDate(today.runConfigs, scope) : [];
+  return runs.at(-1)?.runId ?? (fallbackRunId || undefined);
+}
+
+/**
+ * Chips the legend lists: today's chips that priced, plus, while a
+ * comparison is active, any compared chip that only priced on an earlier
+ * entry (it still owns bars, so it is appended in registry order rather than
+ * dropped with them).
+ */
+export function profitHistoryLegendKeys(
+  availableHwKeys: readonly string[],
+  pricedRows: readonly Pick<ProfitEstimatorRow, 'hwKey'>[],
+  historyActive: boolean,
+): string[] {
+  const priced = new Set(pricedRows.map((row) => row.hwKey));
+  const keys = availableHwKeys.filter((key) => priced.has(key));
+  if (!historyActive) return keys;
+  const seen = new Set(keys);
+  const historyOnly = [...priced]
+    .filter((key) => !seen.has(key))
+    .toSorted((a, b) => getModelSortIndex(a) - getModelSortIndex(b) || a.localeCompare(b));
+  return [...keys, ...historyOnly];
+}
+
+/**
+ * Compared chips with no bar on a comparison entry, or on the current date
+ * (`''`) when the chip only priced earlier, as `chip • when` captions so a
+ * missing bar reads as "no run that day", not as a zero.
+ */
+export function profitHistoryMissing(
+  pricedRows: readonly Pick<ProfitEstimatorRow, 'hwKey' | 'date'>[],
+  comparisonDates: readonly string[],
+  selectedGPUs: readonly string[],
+  chipLabel: (hwKey: string) => string,
+  entryLabel: (entry: string) => string,
+  currentDateLabel: string,
+): string[] {
+  const priced = new Set(pricedRows.map((row) => `${row.hwKey}~${row.date ?? ''}`));
+  const missing: string[] = [];
+  for (const entry of [...comparisonDates, '']) {
+    for (const hwKey of selectedGPUs) {
+      if (priced.has(`${hwKey}~${entry}`)) continue;
+      missing.push(`${chipLabel(hwKey)} • ${entry ? entryLabel(entry) : currentDateLabel}`);
+    }
+  }
+  return missing;
 }

--- a/packages/app/src/components/calculator/useProfitHistory.ts
+++ b/packages/app/src/components/calculator/useProfitHistory.ts
@@ -8,7 +8,7 @@ import { parseComparisonEntry } from '@/components/inference/utils/comparisonEnt
 import { benchmarkQueryOptions } from '@/hooks/api/use-benchmarks';
 import type { Model, Sequence } from '@/lib/data-mappings';
 
-import type { ProfitHistoryDateRows } from './profit-history';
+import { dropCurrentRunEntries, type ProfitHistoryDateRows } from './profit-history';
 
 /**
  * Fetch the benchmark rows behind a profit-estimator history comparison, the
@@ -19,6 +19,8 @@ import type { ProfitHistoryDateRows } from './profit-history';
  * The queries share the `['benchmarks', …]` cache with the inference charts, so
  * a date already compared there costs nothing here.
  */
+const EMPTY_RUN_IDS: Readonly<Record<string, string>> = {};
+
 export function useProfitHistory(options: {
   model: Model;
   sequence: Sequence;
@@ -28,8 +30,8 @@ export function useProfitHistory(options: {
   dateRange: { startDate: string; endDate: string };
   /** Run date the main query already covers; never fetched twice. */
   currentRunDate: string | undefined;
-  /** Run id behind the main bars; a changelog pin of it adds no bar. */
-  currentRunId?: string;
+  /** Per chip, the run behind its main bar; a pin that adds no bar is dropped. */
+  currentRunIds?: Readonly<Record<string, string>>;
   enabled?: boolean;
 }): {
   /** Comparison entries in fetch order (dates or `date~r<runId>` runs). */
@@ -45,20 +47,18 @@ export function useProfitHistory(options: {
     selectedDates,
     dateRange,
     currentRunDate,
-    currentRunId,
+    currentRunIds = EMPTY_RUN_IDS,
     enabled = true,
   } = options;
 
   const comparisonDates = useMemo(
     () =>
-      buildComparisonDates(
-        [...selectedGPUs],
-        [...selectedDates],
-        dateRange,
-        currentRunDate,
-        currentRunId,
+      dropCurrentRunEntries(
+        buildComparisonDates([...selectedGPUs], [...selectedDates], dateRange, currentRunDate),
+        selectedGPUs,
+        currentRunIds,
       ),
-    [selectedGPUs, selectedDates, dateRange, currentRunDate, currentRunId],
+    [selectedGPUs, selectedDates, dateRange, currentRunDate, currentRunIds],
   );
 
   const view = useMemo(() => ({ type: 'calculator' as const, sequence }), [sequence]);

--- a/packages/app/src/components/calculator/useProfitHistory.ts
+++ b/packages/app/src/components/calculator/useProfitHistory.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { benchmarkQueryOptions } from '@/hooks/api/use-benchmarks';
+import type { Model, Sequence } from '@/lib/data-mappings';
+
+import { profitHistoryComparisonDates, type ProfitHistoryDateRows } from './profit-history';
+
+/**
+ * Fetch the benchmark rows behind a profit-estimator history comparison: one
+ * exact-date query per comparison date, the way `useChartData` fans out the
+ * `/inference` comparison. The queries share the `['benchmarks', …]` cache with
+ * the inference charts, so a date already compared there costs nothing here.
+ */
+export function useProfitHistory(options: {
+  model: Model;
+  sequence: Sequence;
+  selectedGPUs: readonly string[];
+  dateRange: { startDate: string; endDate: string };
+  /** Run date the main query already covers; never fetched twice. */
+  currentRunDate: string | undefined;
+  enabled?: boolean;
+}): {
+  comparisonDates: string[];
+  rowsByDate: ProfitHistoryDateRows[];
+  loading: boolean;
+  error: string | null;
+} {
+  const { model, sequence, selectedGPUs, dateRange, currentRunDate, enabled = true } = options;
+
+  const comparisonDates = useMemo(
+    () => profitHistoryComparisonDates(selectedGPUs, dateRange, currentRunDate),
+    [selectedGPUs, dateRange, currentRunDate],
+  );
+
+  const queries = useQueries({
+    queries: comparisonDates.map((date) =>
+      benchmarkQueryOptions(model, date, enabled, true, undefined, undefined, {
+        type: 'calculator',
+        sequence,
+      }),
+    ),
+  });
+
+  const loading = queries.some((q) => q.isLoading);
+  const firstError = queries.find((q) => q.error)?.error;
+  // `useQueries` returns a fresh array every render; key the memo on the
+  // update timestamps so a re-render without new data keeps the same rows.
+  const dataKey = queries.map((q) => q.dataUpdatedAt).join(',');
+
+  const rowsByDate = useMemo<ProfitHistoryDateRows[]>(
+    () =>
+      comparisonDates.map((date, i) => ({
+        date,
+        rows: queries[i]?.data ?? [],
+      })),
+    [comparisonDates, dataKey],
+  );
+
+  return {
+    comparisonDates,
+    rowsByDate,
+    loading,
+    error: firstError ? firstError.message : null,
+  };
+}

--- a/packages/app/src/components/calculator/useProfitHistory.ts
+++ b/packages/app/src/components/calculator/useProfitHistory.ts
@@ -3,45 +3,63 @@
 import { useQueries } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import { buildComparisonDates } from '@/components/inference/hooks/useChartData';
+import { parseComparisonEntry } from '@/components/inference/utils/comparisonEntry';
 import { benchmarkQueryOptions } from '@/hooks/api/use-benchmarks';
 import type { Model, Sequence } from '@/lib/data-mappings';
 
-import { profitHistoryComparisonDates, type ProfitHistoryDateRows } from './profit-history';
+import type { ProfitHistoryDateRows } from './profit-history';
 
 /**
- * Fetch the benchmark rows behind a profit-estimator history comparison: one
- * exact-date query per comparison date, the way `useChartData` fans out the
- * `/inference` comparison. The queries share the `['benchmarks', …]` cache with
- * the inference charts, so a date already compared there costs nothing here.
+ * Fetch the benchmark rows behind a profit-estimator history comparison, the
+ * way `useChartData` fans out the `/inference` comparison: the entries to
+ * compare are the range endpoints plus every date or run pinned from the
+ * Config Changelog (`buildComparisonDates`), a plain date becomes one
+ * exact-date query, and a `date~r<runId>` entry becomes one exact-run query.
+ * The queries share the `['benchmarks', …]` cache with the inference charts, so
+ * a date already compared there costs nothing here.
  */
 export function useProfitHistory(options: {
   model: Model;
   sequence: Sequence;
   selectedGPUs: readonly string[];
+  /** Comparison entries pinned from the changelog (`i_dates`). */
+  selectedDates: readonly string[];
   dateRange: { startDate: string; endDate: string };
   /** Run date the main query already covers; never fetched twice. */
   currentRunDate: string | undefined;
   enabled?: boolean;
 }): {
+  /** Comparison entries in fetch order (dates or `date~r<runId>` runs). */
   comparisonDates: string[];
   rowsByDate: ProfitHistoryDateRows[];
   loading: boolean;
   error: string | null;
 } {
-  const { model, sequence, selectedGPUs, dateRange, currentRunDate, enabled = true } = options;
+  const {
+    model,
+    sequence,
+    selectedGPUs,
+    selectedDates,
+    dateRange,
+    currentRunDate,
+    enabled = true,
+  } = options;
 
   const comparisonDates = useMemo(
-    () => profitHistoryComparisonDates(selectedGPUs, dateRange, currentRunDate),
-    [selectedGPUs, dateRange, currentRunDate],
+    () => buildComparisonDates([...selectedGPUs], [...selectedDates], dateRange, currentRunDate),
+    [selectedGPUs, selectedDates, dateRange, currentRunDate],
   );
 
+  const view = useMemo(() => ({ type: 'calculator' as const, sequence }), [sequence]);
+
   const queries = useQueries({
-    queries: comparisonDates.map((date) =>
-      benchmarkQueryOptions(model, date, enabled, true, undefined, undefined, {
-        type: 'calculator',
-        sequence,
-      }),
-    ),
+    queries: comparisonDates.map((entry) => {
+      const { runId } = parseComparisonEntry(entry);
+      return runId
+        ? benchmarkQueryOptions(model, '', enabled, false, runId, true, view)
+        : benchmarkQueryOptions(model, entry, enabled, true, undefined, undefined, view);
+    }),
   });
 
   const loading = queries.some((q) => q.isLoading);
@@ -52,8 +70,8 @@ export function useProfitHistory(options: {
 
   const rowsByDate = useMemo<ProfitHistoryDateRows[]>(
     () =>
-      comparisonDates.map((date, i) => ({
-        date,
+      comparisonDates.map((entry, i) => ({
+        date: entry,
         rows: queries[i]?.data ?? [],
       })),
     [comparisonDates, dataKey],

--- a/packages/app/src/components/calculator/useProfitHistory.ts
+++ b/packages/app/src/components/calculator/useProfitHistory.ts
@@ -28,6 +28,8 @@ export function useProfitHistory(options: {
   dateRange: { startDate: string; endDate: string };
   /** Run date the main query already covers; never fetched twice. */
   currentRunDate: string | undefined;
+  /** Run id behind the main bars; a changelog pin of it adds no bar. */
+  currentRunId?: string;
   enabled?: boolean;
 }): {
   /** Comparison entries in fetch order (dates or `date~r<runId>` runs). */
@@ -43,12 +45,20 @@ export function useProfitHistory(options: {
     selectedDates,
     dateRange,
     currentRunDate,
+    currentRunId,
     enabled = true,
   } = options;
 
   const comparisonDates = useMemo(
-    () => buildComparisonDates([...selectedGPUs], [...selectedDates], dateRange, currentRunDate),
-    [selectedGPUs, selectedDates, dateRange, currentRunDate],
+    () =>
+      buildComparisonDates(
+        [...selectedGPUs],
+        [...selectedDates],
+        dateRange,
+        currentRunDate,
+        currentRunId,
+      ),
+    [selectedGPUs, selectedDates, dateRange, currentRunDate, currentRunId],
   );
 
   const view = useMemo(() => ({ type: 'calculator' as const, sequence }), [sequence]);

--- a/packages/app/src/components/inference/ui/ComparisonChangelog.tsx
+++ b/packages/app/src/components/inference/ui/ComparisonChangelog.tsx
@@ -135,6 +135,12 @@ interface ComparisonChangelogProps {
   defaultExpanded?: boolean;
   /** Earliest date the selected GPU config has benchmark data */
   firstAvailableDate?: string;
+  /**
+   * Analytics section prefix for the panel's `track()` calls
+   * (`[section]_changelog_add_date`, …). Defaults to `inference`; other pages
+   * that embed the changelog pass their own section.
+   */
+  analyticsSection?: string;
 }
 
 export default function ComparisonChangelog({
@@ -152,6 +158,7 @@ export default function ComparisonChangelog({
   onAddAllDates,
   firstAvailableDate,
   defaultExpanded = true,
+  analyticsSection = 'inference',
 }: ComparisonChangelogProps) {
   const locale = useLocale();
   const t = COMPARISON_CHANGELOG_STRINGS[locale];
@@ -277,7 +284,7 @@ export default function ComparisonChangelog({
   const handleToggle = () => {
     const newState = !isExpanded;
     setIsExpanded(newState);
-    track('inference_comparison_changelog_toggled', { expanded: newState });
+    track(`${analyticsSection}_comparison_changelog_toggled`, { expanded: newState });
   };
 
   // All modelDbKeys for a comparison map to one display model, so [0] suffices
@@ -328,7 +335,9 @@ export default function ComparisonChangelog({
             type="button"
             onClick={() => {
               onAddAllDates(addableEntries);
-              track('inference_changelog_add_all_dates', { count: addableEntries.length });
+              track(`${analyticsSection}_changelog_add_all_dates`, {
+                count: addableEntries.length,
+              });
             }}
             className="text-xs font-medium text-brand hover:text-brand/80 transition-colors flex items-center gap-1"
           >
@@ -373,7 +382,7 @@ export default function ComparisonChangelog({
                             type="button"
                             onClick={() => {
                               onRemoveDate(entry);
-                              track('inference_changelog_remove_run', {
+                              track(`${analyticsSection}_changelog_remove_run`, {
                                 date: item.date,
                                 run: run.runId,
                               });
@@ -388,7 +397,7 @@ export default function ComparisonChangelog({
                             type="button"
                             onClick={() => {
                               onAddDate(entry);
-                              track('inference_changelog_add_run', {
+                              track(`${analyticsSection}_changelog_add_run`, {
                                 date: item.date,
                                 run: run.runId,
                               });
@@ -437,7 +446,7 @@ export default function ComparisonChangelog({
                           type="button"
                           onClick={() => {
                             onRemoveDate(item.date);
-                            track('inference_changelog_remove_date', { date: item.date });
+                            track(`${analyticsSection}_changelog_remove_date`, { date: item.date });
                           }}
                           className="text-xs font-medium text-muted-foreground hover:text-destructive transition-colors flex items-center gap-0.5"
                         >
@@ -455,7 +464,7 @@ export default function ComparisonChangelog({
                         type="button"
                         onClick={() => {
                           onAddDate(item.date);
-                          track('inference_changelog_add_date', { date: item.date });
+                          track(`${analyticsSection}_changelog_add_date`, { date: item.date });
                         }}
                         className="text-xs font-medium text-brand hover:text-brand/80 transition-colors flex items-center gap-0.5"
                       >


### PR DESCRIPTION
## Summary

Adds the `/inference` Compare history panel to `/profit-estimator` and `/profit-estimator-per-gigawatt`, so a chip's revenue and profit at the chosen target can be read against the same chip on an earlier run date, or on one specific run of a day that ran twice.

### How `/inference` does it (what this mirrors)

- `ChartControls.tsx`: `ControlPanel legend="Compare history"` with a `MultiSelect` (max 4 chips) and, once a chip is picked, a `DateRangePicker` whose `availableDates` are the dates those chips have runs on.
- `ChartDisplay.tsx` → `ComparisonChangelog.tsx`: rendered under the controls as soon as a chip is selected. Fed by `useComparisonChangelogs` (one `workflow-info?date=` query per available date, bounded to the range once set). Entries are filtered by model DB key, precision, and `configKeyMatchesHwKey`; range endpoints and the first available date always show. Single-run dates get Git Commit / Workflow Run links and either "Add to chart", "Remove from chart", or a locked "On chart" (range endpoints). Multi-run dates render one block per run (`date~r<runId>`, labelled `#1`, `#2`, …) with their own notes and add/remove. "Add all to chart" pins every entry not yet on the chart.
- `InferenceContext.tsx`: pinned entries live in `selectedDates` / `i_dates` (comma list), cleared with the chips or when the range leaves the available dates. `ChartDisplay` expands a pinned plain date that has several runs into one entry per run, and numbers runs from `dataRunsForDate` so legend and changelog agree.
- `useChartData.ts`: `buildComparisonDates` = `resolveComparisonEntries(selectedDates, range)` minus the main run date; a plain date is fetched with `benchmarkQueryOptions(model, date, enabled, exact=true)`, a run entry with `(model, '', enabled, false, runId, exactRun=true)`.
- `GPUGraph.tsx`: one series per (chip, entry), lighter shade for older entries, labels `${chip} • ${comparisonEntryLabel(entry)}`.

### What this PR does

- "Compare history" `ControlPanel` under the custom-cost block: Chip Config `MultiSelect` (`maxSelections=4`, agentic configs for the current model at the auto-resolved precision) and a Comparison Date Range `DateRangePicker` shown once a chip is selected. Same `i_gpus` / `i_dstart` / `i_dend` / `i_dates` params as `/inference`, so a comparison URL works on both surfaces.
- Config Changelog: the `/inference` `ComparisonChangelog` component, unchanged apart from a new optional `analyticsSection` prop, rendered under the panel whenever a chip is selected and fed by `useComparisonChangelogs(selectedGPUs, range, availableDates, 'agentic_traces')`. Same filters, links, lock, add/remove, "Add all", and per-run blocks. Run numbering comes from `dataRunsForDate` on the changelog's `runConfigs`; a pinned plain date with several runs expands to per-run entries, as on `/inference`.
- `useProfitHistory` resolves entries with `/inference`'s `buildComparisonDates` and fetches plain dates as exact-date queries and run entries as `runId` + `exactRun` queries (calculator view). Loading is folded into the page flag so bars never render half-populated.
- `buildProfitHistoryResults` dedupes runs per chip per entry, builds groups only for the selected chips, and interpolates on the same monotone Hermite spline the current bars use. Result keys are `hwKey[__prec]|entry` (`|` because entries carry their own `~r` suffix); rows carry `date` (the entry) and `dateLabel` (`2026-08-10 #2`).
- Chart: today's bars for the compared chips only, plus one bar per entry next to each, ordered chip → entries by `comparisonEntrySortValue` → today. `shadeHistoryColor` lightens the chip colour in OKLCH, oldest lightest. X labels, tooltip "Run date", caption (`profit-history-note`), and the CSV "Run date" column all print the changelog's label for the entry.
- Pricing inputs are unchanged across entries: same target interactivity, utilization, license fee, price source, and TCO tier (or custom $/GPU/hr).
- Chip options are every agentic config for the model at the effective precisions, as on `/inference`. With the default fixtures that includes H200 fp8: the sparse-precision rule keeps fp8 in play when it has a single curve, so H200 is offered even though its curve stops short of the target on the chart.
- Pinning the run behind a main bar adds no duplicate. The main query is an as-of-date fetch, so each chip's current bar can come from a different run; `profitHistoryCurrentRunIds` maps each compared chip to the latest run of the current date that covered it (from the changelog's enumeration), `dropCurrentRunEntries` skips a pinned run only when every compared chip already shows it, and `buildProfitHistoryResults` skips it per chip. This is the per-chip form of the `selectedRunId` `/inference` hands `buildComparisonDates`.
- A compared chip that only priced on an earlier entry stays in the legend (`profitHistoryLegendKeys`), and the caption names it as missing on the current date (`profitHistoryMissing`) rather than dropping its bars.
- When a model switch prunes the whole chip selection, the range and pinned entries are cleared with it, as clearing the chips by hand does.

### Analytics

`profit_history_gpu_selected` (`{ gpus, count }`), `profit_history_date_range_changed` (`{ startDate, endDate }`), and via `analyticsSection="profit"`: `profit_comparison_changelog_toggled`, `profit_changelog_add_all_dates`, `profit_changelog_add_date` / `remove_date`, `profit_changelog_add_run` / `remove_run`. `/inference` keeps its `inference_*` names (the prop defaults to `inference`).

### Unofficial-run overlays

N/A. The estimator passes no overlay to `useThroughputData`, and the history bars come from official runs by date or run id, so there is no overlay branch to serve.

### /zh

All new estimator strings are in the component `STRINGS` table (对比历史趋势, 芯片配置, 选择芯片配置进行对比, 对比日期范围, 选择日期范围, 运行日期); the changelog reuses its own zh table (配置变更日志, 添加到图表, 全部添加到图表, 已在图表中, …). Covered by a Cypress case on `/zh/profit-estimator-per-gigawatt`.

### Tests

- `profit-history.test.ts`: option filtering and registry ordering; result key parse/format incl. run entries; `profitHistoryEntryLabel` / `profitHistoryEntryDate`; row ordering and ranks with same-day runs; fade share and OKLCH shading; `buildProfitHistoryResults` interpolation, selection filter, and same-day run dedupe; `profitHistoryCurrentRunIds` / `dropCurrentRunEntries` (per-chip current run, sparse later run), per-chip skip in `buildProfitHistoryResults`, `profitHistoryLegendKeys` (history-only chip kept while comparing), `profitHistoryMissing` (current date included).
- `ProfitEstimatorChart.test.ts`: dated `rowLabel`, `splitHistoryLabel`, tooltip run date, `xLabelLayout` with a date line.
- `profit-estimator.cy.ts`: fixtures gain `2026-07-15` (80% throughput, one run), `2026-08-10` (two runs at 85% and 92%, each with a changelog row), and `2026-08-31` (today, one run); `interceptProfitData` serves `?date=`, `?runId=&exactRun=true`, and `/api/v1/workflow-info?date=`. Cases: panel and option list; Max Range on two chips gives four TCO bars in the right order; URL hydration and clearing; Config Changelog lists three dates with notes and links, "Add to chart" pins `i_dates` and adds a bar, "Remove from chart" clears it; two-run date shows `#1` / `#2` blocks, adding run #1 adds a `~r<runId>` entry and a `2026-08-10 #1` bar, "Add all to chart" adds the rest with revenues rising oldest → newest; hydration from `?i_dates=…~r…` with range endpoints locked as "On chart"; `/zh` labels. Assertions are on the UI (trigger text, Add/Remove buttons, range picker, bar counts), not the address bar: `url-state.ts` keeps share params in memory and strips them from the address bar after load. Panel interactions wait for the first priced bar, since the options depend on the availability rows and the auto-resolved precision.
- `profit-estimator.cy.ts` (pre-existing, from #1002): the MiniMax → Kimi switch asserted a bare `/profit-estimator-per-gigawatt`, but `modelRoutePathnameRewrite` yields `/profit-estimator-per-gigawatt/kimi-k3` when leaving a per-model path (the GLM → Kimi case in the same file asserts exactly that). That shard was red on #1002's own CI; the expectation now matches the route behaviour.
- Local: `typecheck`, `lint`, `fmt`, `check:typography` clean; calculator + inference/ui vitest suites pass; `profit-estimator.cy.ts` passes locally against the fixture build (Cypress 15.21.1, `CI=true E2E_FIXTURES=1`).

## 中文说明

为 `/profit-estimator` 和 `/profit-estimator-per-gigawatt` 增加与 `/inference` 相同的"对比历史趋势"面板，包括配置变更日志与固定日期/运行。

- 面板位于自定义成本区块之下：芯片配置多选（最多 4 个，当前模型在自动精度下的 agentic 配置），选中后显示对比日期范围选择器。使用共享的 `i_gpus` / `i_dstart` / `i_dend` / `i_dates` URL 参数，`/inference` 上的对比链接可直接在估算器打开。
- 配置变更日志：复用 `/inference` 的 `ComparisonChangelog` 组件（仅新增可选的 `analyticsSection` 属性），选中芯片后显示于面板下方，数据来自 `useComparisonChangelogs`。保留相同的过滤规则、Git Commit / Workflow Run 链接、范围端点的"已在图表中"锁定、添加/移除、"全部添加到图表"以及多运行日期的逐运行区块（#1、#2…）。运行编号取自 `dataRunsForDate`；固定的单日日期若有多次运行会展开为逐运行条目。
- `useProfitHistory` 通过 `buildComparisonDates` 解析对比条目：普通日期按 `exact=true` 查询，运行条目按 `runId` + `exactRun` 查询（calculator 视图）。
- 柱形、提示框、说明文字与 CSV 均使用与变更日志一致的"日期 #n"标签；排序与颜色深浅按 `comparisonEntrySortValue`。
- 埋点：`profit_history_gpu_selected`、`profit_history_date_range_changed`，以及 `profit_changelog_*` / `profit_comparison_changelog_toggled`。
- 非官方运行叠加不适用：估算器未向 `useThroughputData` 传入叠加数据。
- 芯片选项为当前模型在有效精度下的全部 agentic 配置（与 `/inference` 一致）；固定主柱形所对应的运行不会产生重复柱形（按芯片记录当前运行 id：`profitHistoryCurrentRunIds` / `dropCurrentRunEntries`）；仅在历史日期有数据的芯片仍保留在图例中，并在说明文字中标注当日缺失；模型切换清空芯片选择时同时清空日期范围与固定条目。
- 测试：vitest 覆盖运行条目的键、标签、排序与分级，以及当前运行 id、图例键与缺失说明；Cypress 夹具新增双运行日期（含变更日志行）与 workflow-info 拦截，新增变更日志面板、固定日期、逐运行柱形与"全部添加"、URL 还原与锁定、`/zh` 镜像用例，断言基于界面而非地址栏。修正 #1002 中 MiniMax → Kimi 切换用例的路径期望（`/profit-estimator-per-gigawatt/kimi-k3`）。本地 typecheck / lint / fmt / typography 与 Cypress 用例通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI and data-layer change to profit estimation and shared comparison URL state, with many edge cases around run deduplication and chart merging, though behavior mirrors an existing `/inference` pattern and is heavily tested.
> 
> **Overview**
> Adds a **Compare history** flow to the profit estimator (including per-gigawatt), aligned with `/inference`: up to four agentic chip configs, a date range, and the shared **Config Changelog**, all driven by `i_gpus`, `i_dstart`, `i_dend`, and `i_dates`.
> 
> When a comparison is active, the chart shows only the selected chips—today’s bar plus one bar per range endpoint or changelog-pinned date/run—repriced with the same target, token prices, and TCO tier. Historical bars use lighter OKLCH shading, dated axis labels and tooltips, caption notes for missing runs, and a **Run date** CSV column. New `profit-history` / `useProfitHistory` modules fetch benchmarks (reusing `buildComparisonDates`) and interpolate history through the same path as current bars, including per-chip dedupe of the “current” run so pins do not duplicate today’s bar.
> 
> `ComparisonChangelog` gains an optional `analyticsSection` for profit-specific tracking. Cypress fixtures and e2e cover the panel, changelog pinning, multi-run days, URL hydration, and `/zh` labels; one model-switch test now expects `/profit-estimator-per-gigawatt/kimi-k3` after the per-model route rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0ff206040066c8bd025ef7ebf9935893b779bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->