### PR TITLE
fix(embed): drop attribution row and metric tooltip in embeds / 嵌入图表移除署名行与指标提示

### DIFF
--- a/packages/app/src/app/embed/model/[slug]/page.tsx
+++ b/packages/app/src/app/embed/model/[slug]/page.tsx
@@ -26,5 +26,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function EmbedModelRoute({ params, searchParams }: Props) {
   const [{ slug }, query] = await Promise.all([params, searchParams]);
-  return <EmbedModelPage slug={slug} searchParams={query} locale="en" />;
+  return <EmbedModelPage slug={slug} searchParams={query} />;
 }

--- a/packages/app/src/app/zh/embed/model/[slug]/page.tsx
+++ b/packages/app/src/app/zh/embed/model/[slug]/page.tsx
@@ -20,5 +20,5 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function ZhEmbedModelRoute({ params, searchParams }: Props) {
   const [{ slug }, query] = await Promise.all([params, searchParams]);
-  return <EmbedModelPage slug={slug} searchParams={query} locale="zh" />;
+  return <EmbedModelPage slug={slug} searchParams={query} />;
 }

--- a/packages/app/src/components/embed/EmbedFrame.tsx
+++ b/packages/app/src/components/embed/EmbedFrame.tsx
@@ -10,20 +10,6 @@ import {
   type EmbedSkin,
   type EmbedTheme,
 } from '@/lib/embed';
-import type { Locale } from '@/lib/i18n';
-
-const STRINGS = {
-  en: {
-    attribution: 'Data from',
-    openDashboard: 'Open in InferenceX',
-    scope: (frameworks: string) => `Showing ${frameworks} results only`,
-  },
-  zh: {
-    attribution: '数据来源',
-    openDashboard: '在 InferenceX 中打开',
-    scope: (frameworks: string) => `仅显示 ${frameworks} 的结果`,
-  },
-} as const;
 
 /**
  * Client shell for `/embed/model/[slug]`.
@@ -41,7 +27,6 @@ const STRINGS = {
  *   picks them up too.
  * - Posts its rendered height to the parent window whenever it changes so the
  *   host can size the iframe without an inner scrollbar.
- * - Renders a compact attribution row with a link back to the dashboard.
  */
 /** CSS custom properties the skin fonts are published under (see embed layout). */
 const SKIN_FONT_VARS = ['--font-embed-sans', '--font-embed-mono'] as const;
@@ -49,23 +34,14 @@ const SKIN_FONT_VARS = ['--font-embed-sans', '--font-embed-mono'] as const;
 export default function EmbedFrame({
   theme,
   skin,
-  locale,
-  dashboardHref,
-  frameworkLabels,
   children,
 }: {
   theme: EmbedTheme;
   skin: EmbedSkin | undefined;
-  locale: Locale;
-  dashboardHref: string;
-  /** Human labels for the locked framework families, if any. */
-  frameworkLabels: readonly string[];
   children: ReactNode;
 }) {
   const { setTheme } = useTheme();
   const rootRef = useRef<HTMLDivElement>(null);
-  const t = STRINGS[locale];
-
   useEffect(() => {
     setTheme(theme);
   }, [setTheme, theme]);
@@ -124,32 +100,6 @@ export default function EmbedFrame({
     <div ref={rootRef} data-testid="embed-frame" className="flex flex-col gap-2 p-2 sm:p-3">
       <script dangerouslySetInnerHTML={{ __html: embedBootScript(theme, skin) }} />
       {children}
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-1 text-xs text-muted-foreground">
-        <span data-testid="embed-scope">
-          {frameworkLabels.length > 0 ? t.scope(frameworkLabels.join(', ')) : null}
-        </span>
-        <span>
-          {t.attribution}{' '}
-          <a
-            href={dashboardHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
-            data-testid="embed-dashboard-link"
-          >
-            InferenceX
-          </a>
-          {' · '}
-          <a
-            href={dashboardHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline underline-offset-2 hover:text-primary"
-          >
-            {t.openDashboard}
-          </a>
-        </span>
-      </div>
     </div>
   );
 }

--- a/packages/app/src/components/embed/EmbedModelPage.tsx
+++ b/packages/app/src/components/embed/EmbedModelPage.tsx
@@ -2,11 +2,9 @@ import { notFound } from 'next/navigation';
 
 import EmbedFrame from '@/components/embed/EmbedFrame';
 import EmbeddedModelDashboard from '@/components/model/EmbeddedModelDashboard';
-import { FRAMEWORK_FAMILIES } from '@/components/inference/utils/quickFilters';
 import { comparisonScenarioForModel } from '@/lib/compare-agentx';
 import { getCompareModelBySlug } from '@/lib/compare-slug';
 import { parseEmbedOptions } from '@/lib/embed';
-import { localePath, type Locale } from '@/lib/i18n';
 
 export type EmbedSearchParams = Record<string, string | string[] | undefined>;
 
@@ -20,37 +18,18 @@ export type EmbedSearchParams = Record<string, string | string[] | undefined>;
 export default function EmbedModelPage({
   slug,
   searchParams,
-  locale,
 }: {
   slug: string;
   searchParams: EmbedSearchParams;
-  locale: Locale;
 }) {
   const entry = getCompareModelBySlug(slug);
   if (!entry) notFound();
 
   const options = parseEmbedOptions(searchParams);
   const sequence = options.sequence ?? comparisonScenarioForModel(entry).sequence;
-  const frameworkLabels = FRAMEWORK_FAMILIES.filter((f) => options.frameworks.includes(f.key)).map(
-    (f) => f.label,
-  );
-
-  const dashboardQuery = new URLSearchParams({
-    g_model: entry.displayName,
-    i_seq: sequence,
-    i_optimal: '1',
-  });
-  if (options.frameworks.length > 0) dashboardQuery.set('i_fw', options.frameworks.join(','));
-  const dashboardHref = `${localePath('/inference', locale)}?${dashboardQuery.toString()}`;
 
   return (
-    <EmbedFrame
-      theme={options.theme}
-      skin={options.skin}
-      locale={locale}
-      dashboardHref={dashboardHref}
-      frameworkLabels={frameworkLabels}
-    >
+    <EmbedFrame theme={options.theme} skin={options.skin}>
       <EmbeddedModelDashboard
         displayName={entry.displayName}
         sequence={sequence}

--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -1003,7 +1003,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                                 return locale === 'zh' ? zhHeading(String(configured)) : configured;
                               })()}
                             </Heading>
-                            {embedded && (
+                            {embedded && !minimalChrome && (
                               <OptionInfo
                                 label={metricRowLabel(
                                   selectedYAxisMetric.replace(/^y_/u, '') as MetricKey,


### PR DESCRIPTION
Follow-up to #1008 for the vLLM recipes embed.

- Removes the attribution row under the embedded chart ("Showing vLLM results only" / "Data from InferenceX · Open in InferenceX"). The host page carries its own caption and dashboard link, so this repeated it. `EmbedFrame` drops the `locale`, `dashboardHref` and `frameworkLabels` props; `EmbedModelPage` and both route files drop `locale`.
- Hides the metric ⓘ popover next to the chart title when `minimalChrome` is on.

Verify: `/embed/model/kimi-k3?framework=vllm&theme=vllm-light` and `/zh/embed/model/kimi-k3?...` render the chart and legend only, nothing below the chart, no ⓘ after the title.

## 中文说明

#1008 的后续修改，服务 vLLM recipes 的嵌入场景。

- 移除嵌入图表下方的署名行（"仅显示 vLLM 结果" / "数据来源 InferenceX · 在 InferenceX 中打开"），宿主页面已有自己的说明与回链。`EmbedFrame` 移除 `locale`、`dashboardHref`、`frameworkLabels` props；`EmbedModelPage` 及两个路由文件移除 `locale`。
- `minimalChrome` 下隐藏图表标题旁的指标 ⓘ 提示。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to embed UI and chart chrome; no auth, API, or data-path changes.
> 
> **Overview**
> **Strips duplicate chrome from model embed iframes** so host pages (e.g. vLLM recipes) can own captions and dashboard links.
> 
> `EmbedFrame` no longer renders the bottom attribution row (framework scope text, “Data from InferenceX”, “Open in InferenceX”) and drops the `locale`, `dashboardHref`, and `frameworkLabels` props along with localized strings. `EmbedModelPage` and the English/Chinese embed routes stop passing `locale` and no longer build inference dashboard URLs for that footer.
> 
> In `ChartDisplay`, the metric **ⓘ** popover beside the chart title is suppressed when **`minimalChrome`** is on (embeds already set this), not merely when `embedded` is true—so embeds show chart + legend without the extra help UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c7a07e4586cf1214a78d8290140b3e11c21b1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->