### PR TITLE
fix(embed): 380px chart height in embeds / 嵌入图表高度降至 380px

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { track } from '@/lib/analytics';
+import { EMBED_CHART_HEIGHT } from '@/lib/embed';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
@@ -1197,6 +1198,7 @@ const GPUGraph = React.memo(
     return (
       <D3Chart<InferenceData>
         ref={chartRef}
+        height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
         chartId={chartId}
         dataIdentity={dataIdentity}
         metricIdentity={metricIdentity}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { track } from '@/lib/analytics';
+import { EMBED_CHART_HEIGHT } from '@/lib/embed';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
@@ -3439,6 +3440,7 @@ const ScatterGraph = React.memo(
       <>
         <D3Chart<InferenceData>
           ref={chartRef}
+          height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
           chartId={chartId}
           // Stable across toggles: the render effect keys on this for "data
           // changed" rebuilds; scale domains come from x/yScaleConfig (computed

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Sequence } from './data-mappings';
 import {
+  EMBED_CHART_HEIGHT,
   EMBED_DEFAULT_Y_AXIS_METRIC,
   EMBED_SKIN_HEADER,
   EMBED_THEME_HEADER,
@@ -135,5 +136,10 @@ describe('isEmbedResizeMessage', () => {
     expect(script).toContain('h.classList.add("light")');
     expect(script).toContain('h.style.colorScheme="light"');
     expect(embedBootScript('dark', undefined)).toContain('var s=null');
+  });
+
+  it('draws embedded charts shorter than the 600px dashboard default', () => {
+    expect(EMBED_CHART_HEIGHT).toBeLessThan(600);
+    expect(EMBED_CHART_HEIGHT).toBeGreaterThanOrEqual(320);
   });
 });

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -67,6 +67,14 @@ export interface EmbedOptions {
 /** `y_tpPerGpu`: total token throughput per chip (tok/s/chip). */
 export const EMBED_DEFAULT_Y_AXIS_METRIC = 'y_tpPerGpu';
 
+/**
+ * Plot height (px) for embedded charts. The dashboard draws at 600px; embeds
+ * sit inside a host page that also shows a heading, a caption and a link
+ * under the frame, and the whole section should fit a MacBook viewport
+ * (about 800px of page height) without scrolling.
+ */
+export const EMBED_CHART_HEIGHT = 380;
+
 const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
 const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);
 


### PR DESCRIPTION
Follow-up to #1008 / #1012 for the vLLM recipes embed.

The recipes page shows a section heading and caption above the iframe and an "Open the full interactive dashboard on InferenceX" link below it. With the dashboard's default 600px plot the link fell below a MacBook viewport. Under `minimalChrome`, `ScatterGraph` and `GPUGraph` now pass `EMBED_CHART_HEIGHT` (380px, `lib/embed.ts`) to `D3Chart`; the embed frame drops from ~860px to ~605px. The dashboard itself is unchanged.

Verify: `/embed/model/kimi-k3?framework=vllm&theme=vllm-light` renders a 380px-tall plot; `/inference` still renders at 600px.

## 中文说明

#1008 / #1012 的后续修改。recipes 页面在 iframe 上方有标题与说明、下方有 "Open the full interactive dashboard on InferenceX" 链接，600px 的图表会把链接挤出 MacBook 视口。`minimalChrome` 下 `ScatterGraph` 与 `GPUGraph` 向 `D3Chart` 传入 `EMBED_CHART_HEIGHT`（380px），嵌入框架高度约从 860px 降至 605px；仪表板本身不变。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to embed/minimalChrome chart sizing; no auth, data, or dashboard behavior changes.
> 
> **Overview**
> Embedded inference charts were using the dashboard’s default **600px** plot height, which pushed the “open full dashboard” link below a typical MacBook viewport when the host page adds a heading and caption around the iframe.
> 
> This PR introduces **`EMBED_CHART_HEIGHT` (380px)** in `lib/embed.ts` and passes it to **`D3Chart`** from **`ScatterGraph`** and **`GPUGraph`** only when **`minimalChrome`** is on (embed routes). The full **`/inference`** dashboard still omits `height` and keeps **600px**. A unit test asserts the embed height is **≥320** and **&lt;600**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1643620c3ce78ca875df91086791f05e8790c7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->