### PR TITLE
fix(embed): 340px plot and no zoom hint in embeds / 嵌入图表 340px 并移除缩放提示

### DIFF
--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -1199,6 +1199,8 @@ const GPUGraph = React.memo(
       <D3Chart<InferenceData>
         ref={chartRef}
         height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
+        // Embeds drop the zoom/pan hint line; the host page has its own caption.
+        instructions={minimalChrome ? '' : undefined}
         chartId={chartId}
         dataIdentity={dataIdentity}
         metricIdentity={metricIdentity}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -3441,6 +3441,8 @@ const ScatterGraph = React.memo(
         <D3Chart<InferenceData>
           ref={chartRef}
           height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
+          // Embeds drop the zoom/pan hint line; the host page has its own caption.
+          instructions={minimalChrome ? '' : undefined}
           chartId={chartId}
           // Stable across toggles: the render effect keys on this for "data
           // changed" rebuilds; scale domains come from x/yScaleConfig (computed

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -71,9 +71,9 @@ export const EMBED_DEFAULT_Y_AXIS_METRIC = 'y_tpPerGpu';
  * Plot height (px) for embedded charts. The dashboard draws at 600px; embeds
  * sit inside a host page that also shows a heading, a caption and a link
  * under the frame, and the whole section should fit a MacBook viewport
- * (about 800px of page height) without scrolling.
+ * (about 730px below the host's sticky header) without scrolling.
  */
-export const EMBED_CHART_HEIGHT = 380;
+export const EMBED_CHART_HEIGHT = 340;
 
 const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
 const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);


### PR DESCRIPTION
Follow-up to #1013 for the vLLM recipes embed.

At 380px the recipes section (heading, caption, iframe, "Open the full interactive dashboard on InferenceX" link) measured 776px, about 50px more than a MacBook shows below the recipes sticky header. `EMBED_CHART_HEIGHT` drops to 340 and, under `minimalChrome`, `ScatterGraph` and `GPUGraph` pass an empty `instructions` string to `D3Chart` so the "Shift+Scroll to zoom • Drag to pan …" line is not drawn in embeds. The host page carries its own caption. The dashboard is unchanged.

Verify: `/embed/model/kimi-k3?framework=vllm&theme=vllm-light` renders a 340px plot with no hint line; `/inference` still shows the 600px plot and the hint.

## 中文说明

#1013 的后续修改。380px 时 recipes 区块（标题、说明、iframe、仪表板链接）为 776px，比 MacBook 在 recipes 固定页头下方的可见高度多出约 50px。`EMBED_CHART_HEIGHT` 降为 340；`minimalChrome` 下 `ScatterGraph` 与 `GPUGraph` 向 `D3Chart` 传入空的 `instructions`，嵌入时不再绘制“Shift+Scroll 缩放 • 拖动平移 …”提示行。仪表板不变。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Embed-only UI sizing and caption behavior; dashboard charts are unaffected.
> 
> **Overview**
> Tightens embedded chart layout so recipe-style host pages fit below a sticky header without scrolling.
> 
> **`EMBED_CHART_HEIGHT`** drops from **380px** to **340px**, with the embed comment updated to target ~**730px** of usable height under the host header. When **`minimalChrome`** is on, **`ScatterGraph`** and **`GPUGraph`** pass **`instructions=""`** into **`D3Chart`** so the default “Shift+Scroll to zoom • Drag to pan …” line is not shown (the embed host supplies its own caption). Full **`/inference`** charts are unchanged: default height and instructions still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc7ba0d70e7426271ce80b5f136c0e57a9f4ded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->