### PR TITLE
fix(embed): restore 380px embed plot / 嵌入图表恢复 380px

### DIFF
--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -69,11 +69,11 @@ export const EMBED_DEFAULT_Y_AXIS_METRIC = 'y_tpPerGpu';
 
 /**
  * Plot height (px) for embedded charts. The dashboard draws at 600px; embeds
- * sit inside a host page that also shows a heading, a caption and a link
- * under the frame, and the whole section should fit a MacBook viewport
- * (about 730px below the host's sticky header) without scrolling.
+ * sit inside a host page that also shows a heading, a caption and a
+ * dashboard link above the frame; 380px keeps the section readable on a
+ * MacBook viewport without cramping the point labels.
  */
-export const EMBED_CHART_HEIGHT = 340;
+export const EMBED_CHART_HEIGHT = 380;
 
 const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
 const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);


### PR DESCRIPTION
Follow-up to #1014. The vLLM recipes page now places the "Open the full interactive dashboard on InferenceX" link between the caption and the iframe, so the extra 40px trimmed in #1014 is no longer needed. `EMBED_CHART_HEIGHT` returns to 380; the zoom/pan hint stays hidden in embeds. Dashboard unchanged.

## 中文说明

#1014 的后续修改。vLLM recipes 页面已把 "Open the full interactive dashboard on InferenceX" 链接放在说明与 iframe 之间，#1014 额外削减的 40px 不再需要。`EMBED_CHART_HEIGHT` 恢复为 380；嵌入时仍不显示缩放提示。仪表板不变。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant and comment change for embed chart sizing; no auth, data, or API impact.
> 
> **Overview**
> **Restores embedded plot height** from 340px back to **380px** via `EMBED_CHART_HEIGHT` in `embed.ts`.
> 
> The comment is updated to match the vLLM recipes layout: heading, caption, and dashboard link now sit **above** the iframe, so the extra shrink from #1014 is unnecessary and the taller frame avoids cramped point labels. **Dashboard charts stay at 600px**; embed-only behavior (e.g. hidden zoom/pan hint) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f210555ee45b3a0c2e5836c9d4221a3794a3217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->