### PR TITLE
fix(embed): drop EMBED_CHART_HEIGHT and hide request stats in embeds / 嵌入移除 EMBED_CHART_HEIGHT 并隐藏请求统计行

### DIFF
--- a/packages/app/src/components/inference/ui/ChartDisplay.tsx
+++ b/packages/app/src/components/inference/ui/ChartDisplay.tsx
@@ -851,7 +851,7 @@ export default function ChartDisplay({ embedded = false }: { embedded?: boolean 
                       <AtomEngineFootnote className="min-w-0 flex-[1_1_24rem] text-xs leading-5" />
                     )}
                   </div>
-                  {residentSequenceLengths && (
+                  {residentSequenceLengths && !minimalChrome && (
                     <p
                       className="text-3xs leading-tight text-muted-foreground/70"
                       data-testid="resident-sequence-lengths"

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { track } from '@/lib/analytics';
-import { EMBED_CHART_HEIGHT } from '@/lib/embed';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
@@ -1198,7 +1197,6 @@ const GPUGraph = React.memo(
     return (
       <D3Chart<InferenceData>
         ref={chartRef}
-        height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
         // Embeds drop the zoom/pan hint line; the host page has its own caption.
         instructions={minimalChrome ? '' : undefined}
         chartId={chartId}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { track } from '@/lib/analytics';
-import { EMBED_CHART_HEIGHT } from '@/lib/embed';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { useEphemeralUrlState } from '@/hooks/useUrlState';
 import { rememberChartStateInUrl } from '@/lib/url-state';
@@ -3440,7 +3439,6 @@ const ScatterGraph = React.memo(
       <>
         <D3Chart<InferenceData>
           ref={chartRef}
-          height={minimalChrome ? EMBED_CHART_HEIGHT : undefined}
           // Embeds drop the zoom/pan hint line; the host page has its own caption.
           instructions={minimalChrome ? '' : undefined}
           chartId={chartId}

--- a/packages/app/src/lib/embed.test.ts
+++ b/packages/app/src/lib/embed.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 
 import { Sequence } from './data-mappings';
 import {
-  EMBED_CHART_HEIGHT,
   EMBED_DEFAULT_Y_AXIS_METRIC,
   EMBED_SKIN_HEADER,
   EMBED_THEME_HEADER,
@@ -136,10 +135,5 @@ describe('isEmbedResizeMessage', () => {
     expect(script).toContain('h.classList.add("light")');
     expect(script).toContain('h.style.colorScheme="light"');
     expect(embedBootScript('dark', undefined)).toContain('var s=null');
-  });
-
-  it('draws embedded charts shorter than the 600px dashboard default', () => {
-    expect(EMBED_CHART_HEIGHT).toBeLessThan(600);
-    expect(EMBED_CHART_HEIGHT).toBeGreaterThanOrEqual(320);
   });
 });

--- a/packages/app/src/lib/embed.ts
+++ b/packages/app/src/lib/embed.ts
@@ -67,14 +67,6 @@ export interface EmbedOptions {
 /** `y_tpPerGpu`: total token throughput per chip (tok/s/chip). */
 export const EMBED_DEFAULT_Y_AXIS_METRIC = 'y_tpPerGpu';
 
-/**
- * Plot height (px) for embedded charts. The dashboard draws at 600px; embeds
- * sit inside a host page that also shows a heading, a caption and a
- * dashboard link above the frame; 380px keeps the section readable on a
- * MacBook viewport without cramping the point labels.
- */
-export const EMBED_CHART_HEIGHT = 380;
-
 const FRAMEWORK_KEYS = new Set<string>(FRAMEWORK_FAMILIES.map((f) => f.key));
 const Y_AXIS_METRIC_KEYS = new Set<string>(Y_AXIS_METRICS);
 


### PR DESCRIPTION
Reverts 4a082df (#1013). Embedded charts draw at the dashboard's 600px again; `EMBED_CHART_HEIGHT`, the `height` props on `ScatterGraph`/`GPUGraph` and its test are removed. The vLLM recipes page now places its dashboard link above the iframe, so the shorter plot is not needed.

Also, under `minimalChrome`, `ChartDisplay` no longer renders the "Completed requests across all resident points (n=…) · ISL p50 … | OSL p50 …" footer line. The zoom hint stays hidden (#1014). Dashboard unchanged.

Verify: `/embed/model/kimi-k3?framework=vllm&theme=vllm-light` shows a 600px plot with no request-stats line; `/inference` still shows both.

## 中文说明

回退 4a082df（#1013）。嵌入图表恢复仪表板的 600px 高度，删除 `EMBED_CHART_HEIGHT`、`ScatterGraph`/`GPUGraph` 上的 `height` 属性及对应测试；vLLM recipes 页面已将仪表板链接移至 iframe 上方，不再需要更矮的图表。

同时 `minimalChrome` 下 `ChartDisplay` 不再渲染“Completed requests across all resident points (n=…) · ISL … | OSL …”页脚行。缩放提示仍隐藏（#1014）。仪表板不变。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes for embed routes; full dashboard chart height and footers are unchanged.
> 
> **Overview**
> **Reverts the shorter embedded plot height** from #1013: `EMBED_CHART_HEIGHT` (380px) is removed, and `ScatterGraph` / `GPUGraph` no longer pass a fixed `height` when `minimalChrome` is on, so iframe charts use the same **600px default** as the dashboard. The related unit test in `embed.test.ts` is deleted.
> 
> For **embed / minimal-chrome** views, `ChartDisplay` also **suppresses the agentic footer** that lists completed request counts and ISL/OSL percentiles (`resident-sequence-lengths`), while the dashboard still shows it when `minimalChrome` is false. Zoom/pan hint behavior for embeds is unchanged (still empty `instructions`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbb3deb6a87e6203decbbd28ade9b97feea73e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->