### PR TITLE
fix(export): drop duplicate logo layer from PNG exports / 导出 PNG 移除重复 logo 水印

### DIFF
--- a/packages/app/src/hooks/useChartExport.test.ts
+++ b/packages/app/src/hooks/useChartExport.test.ts
@@ -13,9 +13,6 @@ vi.mock('@jpinsonneau/html-to-image', () => ({
 import {
   getExportCaptureDimensions,
   getExportFontFamily,
-  getLogoWatermarkLayout,
-  getLogoWatermarkOpacity,
-  getLogoWatermarkSrc,
   normalizeChartSvgWidthsForExport,
   useChartExport,
 } from './useChartExport';
@@ -157,38 +154,5 @@ describe('normalizeChartSvgWidthsForExport', () => {
     expect(root.querySelector<SVGElement>('svg[data-testid="legend-info-icon"]')?.style.width).toBe(
       '14px',
     );
-  });
-});
-
-describe('logo watermark', () => {
-  it('uses the white logo on dark themes and the color logo on light themes', () => {
-    expect(getLogoWatermarkSrc(true)).toBe('/brand/logo-white.png');
-    expect(getLogoWatermarkSrc(false)).toBe('/brand/logo-color.png');
-  });
-
-  it('keeps the logo faint so plotted data stays legible', () => {
-    expect(getLogoWatermarkOpacity(false)).toBeLessThan(0.15);
-    expect(getLogoWatermarkOpacity(true)).toBeLessThan(0.15);
-  });
-
-  it('centers the logo and caps its width for wide captures', () => {
-    const layout = getLogoWatermarkLayout(
-      { width: 2000, height: 1200 },
-      { width: 1920, height: 825 },
-    );
-    // Width-bound: 60% of 2000 = 1200 wide, aspect preserved
-    expect(layout.width).toBe(1200);
-    expect(layout.height).toBe(Math.round(825 * (1200 / 1920)));
-    expect(layout.x).toBe((2000 - layout.width) / 2);
-    expect(layout.y).toBe(Math.round((1200 - layout.height) / 2));
-  });
-
-  it('caps the logo height for tall, narrow captures', () => {
-    const layout = getLogoWatermarkLayout(
-      { width: 800, height: 600 },
-      { width: 1000, height: 1000 },
-    );
-    // Height-bound: 60% of 600 = 360 tall square logo
-    expect(layout).toEqual({ x: 220, y: 120, width: 360, height: 360 });
   });
 });

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -204,41 +204,6 @@ function watermarkFont(size: number): string {
   return `bold ${size}px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif`;
 }
 
-/** Fraction of the chart capture the background logo may span (width and height). */
-const LOGO_WATERMARK_MAX_FRACTION = 0.6;
-
-/** Public path of the SemiAnalysis logo to tile behind the chart, per theme. */
-export function getLogoWatermarkSrc(isDark: boolean): string {
-  return isDark ? '/brand/logo-white.png' : '/brand/logo-color.png';
-}
-
-/** Opacity of the background logo, per theme (kept faint so data stays legible). */
-export function getLogoWatermarkOpacity(isDark: boolean): number {
-  return isDark ? 0.09 : 0.08;
-}
-
-/**
- * Fit the logo inside the chart capture, centered, preserving aspect ratio and
- * capped to a fraction of the capture so it reads as a background mark rather
- * than a foreground element.
- */
-export function getLogoWatermarkLayout(
-  capture: { width: number; height: number },
-  logo: { width: number; height: number },
-): { x: number; y: number; width: number; height: number } {
-  const maxWidth = capture.width * LOGO_WATERMARK_MAX_FRACTION;
-  const maxHeight = capture.height * LOGO_WATERMARK_MAX_FRACTION;
-  const scale = Math.min(maxWidth / logo.width, maxHeight / logo.height);
-  const width = Math.round(logo.width * scale);
-  const height = Math.round(logo.height * scale);
-  return {
-    x: Math.round((capture.width - width) / 2),
-    y: Math.round((capture.height - height) / 2),
-    width,
-    height,
-  };
-}
-
 function loadImage(src: string): Promise<HTMLImageElement | null> {
   return new Promise((resolve) => {
     const img = new Image();
@@ -249,10 +214,9 @@ function loadImage(src: string): Promise<HTMLImageElement | null> {
 }
 
 /**
- * Compose the final export: theme background, a faint SemiAnalysis logo
- * behind the chart, the (transparent) chart capture on top, and the branded
- * footer bar. The chart is captured without a background so the logo really
- * sits behind the plot instead of tinting the data on top.
+ * Compose the final export: theme background, the (transparent) chart capture
+ * on top, and the branded footer bar. The chart's own SVG logo watermark is
+ * the only background mark, so nothing else is painted behind the plot.
  */
 async function addWatermark(chartDataUrl: string, bgColor: string): Promise<string> {
   const img = await loadImage(chartDataUrl);
@@ -274,21 +238,7 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
   ctx.fillStyle = bgColor || (isDark ? '#131416' : '#eaebec');
   ctx.fillRect(0, 0, canvas.width, img.height);
 
-  // Faint SemiAnalysis logo centered behind the chart. Skip silently if the
-  // asset fails to load so export never blocks on branding.
-  const logo = await loadImage(getLogoWatermarkSrc(isDark));
-  if (logo && logo.naturalWidth > 0 && logo.naturalHeight > 0) {
-    const layout = getLogoWatermarkLayout(
-      { width: img.width, height: img.height },
-      { width: logo.naturalWidth, height: logo.naturalHeight },
-    );
-    ctx.save();
-    ctx.globalAlpha = getLogoWatermarkOpacity(isDark);
-    ctx.drawImage(logo, layout.x, layout.y, layout.width, layout.height);
-    ctx.restore();
-  }
-
-  // Draw chart capture over the background + logo
+  // Draw chart capture over the background
   ctx.drawImage(img, 0, 0);
 
   // Draw watermark bar
@@ -535,7 +485,7 @@ export function useChartExport({
       }
       const captureDimensions = getExportCaptureDimensions(exportElement);
       // Capture without a background: addWatermark paints the theme background
-      // and the SemiAnalysis logo underneath, then layers this capture on top.
+      // and layers this capture on top.
       const chartDataUrl = await toPng(exportElement, {
         ...captureDimensions,
         quality: 1,
@@ -551,7 +501,7 @@ export function useChartExport({
         },
       });
 
-      // Compose background + SemiAnalysis logo watermark + chart + footer bar
+      // Compose background + chart + footer bar
       const dataUrl = await addWatermark(chartDataUrl, bgColor);
 
       const link = document.createElement('a');


### PR DESCRIPTION
## Summary
PNG exports currently show two SemiAnalysis logos stacked at different sizes: the chart SVG's own logo watermark plus a second logo that `addWatermark` painted on the canvas behind the capture (added in #977). This keeps only the in-chart SVG watermark.

- `addWatermark` now composes theme background, chart capture, footer bar. No canvas logo.
- Removed `getLogoWatermarkSrc`, `getLogoWatermarkOpacity`, `getLogoWatermarkLayout` and their unit tests (nothing else referenced them).

## Checks
- `bun run typecheck`, `bun run lint`, `bun run fmt` clean
- `useChartExport.test.ts` passes (7 tests)

中文：导出 PNG 时图表 SVG 自带 logo 水印与 canvas 再绘制的 logo 重叠，现仅保留图表内水印，移除多余的 canvas logo 及相关辅助函数和测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export-only branding change with no auth or data impact; behavior is simpler and matches the in-chart watermark.
> 
> **Overview**
> **Fixes double SemiAnalysis logos in exported PNGs** by stopping `addWatermark` from drawing a second, centered background logo on the canvas. Exports now rely on the **chart SVG’s existing logo watermark** only, with the footer bar and theme background unchanged.
> 
> Removes the unused helpers **`getLogoWatermarkSrc`**, **`getLogoWatermarkOpacity`**, and **`getLogoWatermarkLayout`**, plus their unit tests in `useChartExport.test.ts`. Comments in the export path are updated to describe the slimmer compose step (background → chart capture → footer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f0e133179d52c8efa4d3a373988d07e383c74a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->