### PR TITLE
docs: update API skill onboarding to 0.2.0 / 更新 API 技能 0.2.0 安装指引

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -1,6 +1,6 @@
 # InferenceX API skill examples
 
-Use the public `@semianalysisai/inferencex-skills@0.1.0` package to query existing
+Use the public `@semianalysisai/inferencex-skills@0.2.0` package to query existing
 observations; these requests do not run new benchmarks. The skill covers the
 public API, with single-turn PowerX export as its first worked example. Read the
 [current API contract](https://inferencex.semianalysis.com/api/openapi.json) before
@@ -12,10 +12,10 @@ With Node 24 or later and npm, run the command for your agent from your project:
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.1.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.1.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target claude
 ```
 
 Start an agent session in that project. Queries need public HTTPS access, with no

--- a/packages/app/cypress/e2e/api-documentation.cy.ts
+++ b/packages/app/cypress/e2e/api-documentation.cy.ts
@@ -2,7 +2,7 @@ import type { BenchmarkRow } from '@semianalysisai/inferencex-db/queries/benchma
 
 const SITE_URL = 'https://inferencex.semianalysis.com';
 // The website advertises the verified public release, which can lag the source candidate.
-const PUBLISHED_SKILL = { name: '@semianalysisai/inferencex-skills', version: '0.1.0' };
+const PUBLISHED_SKILL = { name: '@semianalysisai/inferencex-skills', version: '0.2.0' };
 
 describe('API documentation', () => {
   for (const locale of [
@@ -18,6 +18,7 @@ describe('API documentation', () => {
       copy: 'Copy',
       copied: 'Copied',
       upgrade: 'replace the version in the installation command',
+      status: 'replace install with status',
       examples: 'Usage examples',
     },
     {
@@ -32,6 +33,7 @@ describe('API documentation', () => {
       copy: '复制',
       copied: '已复制',
       upgrade: '新的已发布版本',
+      status: 'install 改为 status',
       examples: '使用示例（英文）',
     },
   ]) {
@@ -73,6 +75,12 @@ describe('API documentation', () => {
       cy.get('[data-testid="api-agent-upgrade"]')
         .should('contain.text', locale.upgrade)
         .and('contain.text', '--force');
+      cy.get('[data-testid="api-agent-status"]')
+        .should('contain.text', locale.status)
+        .and('contain.text', '--target')
+        .and('contain.text', 'Installer version')
+        .and('contain.text', 'Installed version')
+        .and('contain.text', 'unknown');
       cy.get('[data-testid="api-agent-examples"]')
         .should('have.text', locale.examples)
         .and(

--- a/packages/app/src/components/api-documentation/api-reference-page.tsx
+++ b/packages/app/src/components/api-documentation/api-reference-page.tsx
@@ -24,7 +24,7 @@ const UI_COPY = {
     agentSkill: 'Use the API with your agent',
     agentSkillDescription:
       'The inferencex-api skill helps your agent navigate the public API: benchmarks, provenance, datasets, CollectiveX, and diagnostics. Validated single-turn PowerX export is the first worked example.',
-    agentVersion: 'Skill version · 0.1.0',
+    agentVersion: 'Skill version · 0.2.0',
     agentPrerequisites:
       'Requires Node 24 or later with npm and Codex or Claude Code. Installation and API queries require internet access.',
     agentInstall: 'Install in your project',
@@ -32,6 +32,8 @@ const UI_COPY = {
       'Run the command for your agent from your project directory, then start an agent session in that project.',
     agentUpgrade:
       'To upgrade, replace the version in the installation command with a new published version and rerun it with --force. Existing skills are otherwise skipped. Save local edits first: --force overwrites matching files and retains obsolete files.',
+    agentStatus:
+      'To check the copied skill version, replace install with status in the command above and keep the same --target. Installer version identifies the installer; Installed version identifies the copied skill. Older installations may report unknown.',
     agentExamples: 'Usage examples',
     agentAccess:
       'Queries use the public API without database credentials. The separate MCP server has its own setup; this skill does not require or reconfigure it.',
@@ -99,13 +101,15 @@ const UI_COPY = {
     agentSkill: '通过智能体使用 API',
     agentSkillDescription:
       'inferencex-api 技能帮助智能体查找和使用公开 API，涵盖基准测试、溯源、数据集、CollectiveX 和诊断接口。已验证的单轮请求 PowerX 导出是首个完整示例。',
-    agentVersion: '技能版本 · 0.1.0',
+    agentVersion: '技能版本 · 0.2.0',
     agentPrerequisites:
       '需要 Node 24 或更新版本、npm，以及 Codex 或 Claude Code。安装和 API 查询均需联网。',
     agentInstall: '安装到项目',
     agentInstallDescription: '在项目目录中执行对应智能体的安装命令，然后在该项目中启动智能体会话。',
     agentUpgrade:
       '升级时，将安装命令中的版本号改为新的已发布版本，并加上 --force 重新执行。默认会跳过已有技能。请先保存本地修改：--force 会覆盖同名文件，但保留不再随包提供的旧文件。',
+    agentStatus:
+      '检查已复制的技能版本时，将上方命令中的 install 改为 status，并保留相同的 --target。Installer version 表示安装器版本，Installed version 表示项目内已复制技能的版本。旧版安装可能显示 unknown。',
     agentExamples: '使用示例（英文）',
     agentAccess:
       '查询通过公开 API 完成，无需数据库凭据。独立的 MCP server 有自己的配置流程；本技能不依赖它，也不会改动它的配置。',
@@ -346,7 +350,7 @@ export function ApiReferencePage({ locale }: { locale: ApiDocumentationLocale })
                     locale={locale}
                     label={target === 'codex' ? 'Codex' : 'Claude Code'}
                   >
-                    {`npm exec --yes --package @semianalysisai/inferencex-skills@0.1.0 -- inferencex-skills install --target ${target}`}
+                    {`npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target ${target}`}
                   </CopyableCodeBlock>
                 </div>
               ))}
@@ -357,6 +361,12 @@ export function ApiReferencePage({ locale }: { locale: ApiDocumentationLocale })
               className="mt-3 text-sm leading-6 text-muted-foreground"
             >
               {copy.agentUpgrade}
+            </p>
+            <p
+              data-testid="api-agent-status"
+              className="mt-3 text-sm leading-6 text-muted-foreground"
+            >
+              {copy.agentStatus}
             </p>
             <ApiAgentExamplesLink label={copy.agentExamples} locale={locale} />
 


### PR DESCRIPTION
Update `/api`, `/zh/api`, and the linked examples to the published `0.2.0` package. Explain how `status` distinguishes the installer version from the skill copied into the project; older installations may report `unknown`.

Testing: 5,810 unit tests, 159 smoke tests, 6 API-page tests, and lint/format/typecheck/typography pass. Claude and manual copy review found no issues. Anonymous public installation and export pass for both targets after a read-only retry of the initial npm `ETARGET` response. Package contents are unchanged. Full CI passed after rerunning one Firefox chart test that hit a ResizeObserver exception; no code or assertions changed.

## 中文说明

将 `/api`、`/zh/api` 及链接中的安装示例更新为已发布的 `0.2.0`。说明如何通过 `status` 区分安装器版本和项目内已复制技能的版本；旧版安装可能显示 `unknown`。

验证：5,810 项单元测试、159 项 smoke 测试、6 项 API 页面测试及 lint、格式、类型、字体规范检查通过。Claude 和人工文案审查未发现问题。首次 npm 安装返回 `ETARGET`，只读重试后两个目标的匿名安装和导出均通过。包内容未改变。完整 CI 已通过；一个 Firefox 图表测试首次遇到 ResizeObserver 异常，按原代码和断言重跑后通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, UI copy, and e2e expectations only; no API, auth, or runtime behavior changes.
> 
> **Overview**
> **Pins public agent onboarding to `@semianalysisai/inferencex-skills@0.2.0`** on `/api`, `/zh/api`, and `docs/inferencex-api-examples.md`, including copyable `npm exec` install commands and the displayed skill version badge.
> 
> **Adds guidance for verifying what is installed** via `inferencex-skills status` (swap `install` for `status`, keep `--target`), clarifying **Installer version** vs **Installed version** and that older installs may show `unknown`. Cypress coverage asserts the new `api-agent-status` block in English and Chinese.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c899d736146a3016bbc8ed0036835977fb177894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
