### PR TITLE
feat(export): footer shows source route instead of GitHub link

### DIFF
--- a/packages/app/src/components/inference/replay/exportMp4.ts
+++ b/packages/app/src/components/inference/replay/exportMp4.ts
@@ -1,5 +1,7 @@
 import type { ArrayBufferTarget as ArrayBufferTargetType, Muxer as MuxerType } from 'mp4-muxer';
 
+import { getExportFooterText } from '@/lib/export-footer';
+
 export type Mp4ExportStage = 'init' | 'render' | 'encode' | 'flush' | 'mux';
 
 // Brand check on the `name` field — `instanceof` is unreliable here because
@@ -61,7 +63,6 @@ interface ExportOptions {
 
 const CSS_VAR_RE = /var\(--(?<varName>[^)]+)\)/u;
 const WATERMARK_HEIGHT = 48;
-const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
 
 // Mutates the supplied root in place — call only on a clone; baking onto the
 // live panel would freeze it on current theme.
@@ -147,7 +148,7 @@ function expandLegendForExport(cloneRoot: HTMLElement) {
 const skipNoExport = (node: Node) =>
   !((node as Element).classList && (node as Element).classList.contains('no-export'));
 
-/** Draw the panel canvas onto a slightly taller canvas with an InferenceX watermark bar. */
+/** Draw the panel canvas onto a slightly taller canvas with a footer bar naming the source route. */
 function drawWithWatermark(
   source: HTMLCanvasElement,
   bgColor: string,
@@ -167,7 +168,7 @@ function drawWithWatermark(
   ctx.font = 'bold 16px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(WATERMARK_TEXT, out.width / 2, source.height + WATERMARK_HEIGHT / 2);
+  ctx.fillText(getExportFooterText(), out.width / 2, source.height + WATERMARK_HEIGHT / 2);
   return out;
 }
 

--- a/packages/app/src/hooks/useChartExport.ts
+++ b/packages/app/src/hooks/useChartExport.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { CHART_FONT_MINECRAFT, CHART_FONT_SANS } from '@/lib/d3-chart/typography';
+import { getExportFooterText } from '@/lib/export-footer';
 import { useLocale } from '@/lib/use-locale';
 
 const STRINGS = {
@@ -245,12 +246,13 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
   ctx.fillStyle = isDark ? '#1a1a2e' : '#f5f5f5';
   ctx.fillRect(0, img.height, canvas.width, WATERMARK_HEIGHT);
 
-  // Draw watermark text (shrink to fit on narrow exports)
-  const WATERMARK_TEXT = 'InferenceX — github.com/SemiAnalysisAI/InferenceX';
+  // Draw footer text: the page route this export came from (shrink to fit on
+  // narrow exports), e.g. "inferencex.semianalysis.com/inference/kimi-k3".
+  const footerText = getExportFooterText();
   let fontSize = 40;
   ctx.font = watermarkFont(fontSize);
   const maxTextWidth = canvas.width - 48;
-  const textWidth = ctx.measureText(WATERMARK_TEXT).width;
+  const textWidth = ctx.measureText(footerText).width;
   if (textWidth > maxTextWidth) {
     fontSize = Math.max(16, Math.floor((fontSize * maxTextWidth) / textWidth));
     ctx.font = watermarkFont(fontSize);
@@ -258,7 +260,7 @@ async function addWatermark(chartDataUrl: string, bgColor: string): Promise<stri
   ctx.fillStyle = isDark ? '#aaa' : '#555';
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(WATERMARK_TEXT, canvas.width / 2, img.height + WATERMARK_HEIGHT / 2);
+  ctx.fillText(footerText, canvas.width / 2, img.height + WATERMARK_HEIGHT / 2);
 
   return canvas.toDataURL('image/png');
 }

--- a/packages/app/src/lib/export-footer.test.ts
+++ b/packages/app/src/lib/export-footer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import { EXPORT_FOOTER_FALLBACK_HOST, getExportFooterText } from './export-footer';
+
+describe('getExportFooterText', () => {
+  it('joins the current hostname with the route path', () => {
+    expect(
+      getExportFooterText({
+        hostname: 'inferencex.semianalysis.com',
+        pathname: '/inference/kimi-k3',
+      }),
+    ).toBe('inferencex.semianalysis.com/inference/kimi-k3');
+  });
+
+  it('keeps nested estimator routes intact', () => {
+    expect(
+      getExportFooterText({
+        hostname: 'inferencex.semianalysis.com',
+        pathname: '/profit-estimator-per-gigawatt/minimax-m3',
+      }),
+    ).toBe('inferencex.semianalysis.com/profit-estimator-per-gigawatt/minimax-m3');
+  });
+
+  it('drops the trailing slash on the root route', () => {
+    expect(getExportFooterText({ hostname: 'inferencex.semianalysis.com', pathname: '/' })).toBe(
+      'inferencex.semianalysis.com',
+    );
+  });
+
+  it('strips trailing slashes on nested routes', () => {
+    expect(
+      getExportFooterText({ hostname: 'inferencex.semianalysis.com', pathname: '/zh/inference/' }),
+    ).toBe('inferencex.semianalysis.com/zh/inference');
+  });
+
+  it('preserves preview and alternate hostnames', () => {
+    expect(getExportFooterText({ hostname: 'inferencex.com', pathname: '/inference' })).toBe(
+      'inferencex.com/inference',
+    );
+    expect(
+      getExportFooterText({
+        hostname: 'inferencex-app-git-feature.vercel.app',
+        pathname: '/compare',
+      }),
+    ).toBe('inferencex-app-git-feature.vercel.app/compare');
+  });
+
+  it('falls back to the production host for local development', () => {
+    expect(getExportFooterText({ hostname: 'localhost', pathname: '/inference/kimi-k3' })).toBe(
+      `${EXPORT_FOOTER_FALLBACK_HOST}/inference/kimi-k3`,
+    );
+    expect(getExportFooterText({ hostname: '127.0.0.1', pathname: '/model/glm-5.3' })).toBe(
+      `${EXPORT_FOOTER_FALLBACK_HOST}/model/glm-5.3`,
+    );
+  });
+
+  it('falls back to the production host when no location is available', () => {
+    expect(getExportFooterText({ hostname: '', pathname: '/inference' })).toBe(
+      `${EXPORT_FOOTER_FALLBACK_HOST}/inference`,
+    );
+  });
+
+  it('reads window.location in a browser environment', () => {
+    // jsdom exposes window.location; under the node environment this exercises the fallback.
+    const text = getExportFooterText();
+    expect(text.startsWith(EXPORT_FOOTER_FALLBACK_HOST) || text.includes('/')).toBe(true);
+  });
+});

--- a/packages/app/src/lib/export-footer.ts
+++ b/packages/app/src/lib/export-footer.ts
@@ -1,0 +1,31 @@
+/**
+ * Footer text stamped on exported PNGs and MP4s.
+ *
+ * Exports point back to the page they were taken from (e.g.
+ * `inferencex.semianalysis.com/inference/kimi-k3`) so a chart shared out of
+ * context can be traced to its live route. Local and non-browser contexts fall
+ * back to the production hostname so dev exports still read as shareable.
+ */
+
+export const EXPORT_FOOTER_FALLBACK_HOST = 'inferencex.semianalysis.com';
+
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]']);
+
+export interface ExportFooterLocation {
+  hostname: string;
+  pathname: string;
+}
+
+export function getExportFooterText(location?: ExportFooterLocation | null): string {
+  const loc =
+    location ?? (typeof window !== 'undefined' && window.location ? window.location : null);
+
+  const rawHost = loc?.hostname?.trim().toLowerCase() ?? '';
+  const host = rawHost && !LOCAL_HOSTNAMES.has(rawHost) ? rawHost : EXPORT_FOOTER_FALLBACK_HOST;
+
+  let path = loc?.pathname ?? '/';
+  if (!path.startsWith('/')) path = `/${path}`;
+  path = path.replace(/\/+$/u, '');
+
+  return `${host}${path}`;
+}


### PR DESCRIPTION
## What

Exported PNG charts (and replay MP4s, which used the same hardcoded string) now stamp the page route they were taken from in the footer bar, instead of the fixed `InferenceX — github.com/SemiAnalysisAI/InferenceX` text.

| Exported from | Footer |
|---|---|
| `/inference/kimi-k3` | `inferencex.semianalysis.com/inference/kimi-k3` |
| `/profit-estimator-per-gigawatt/minimax-m3` | `inferencex.semianalysis.com/profit-estimator-per-gigawatt/minimax-m3` |
| `/` | `inferencex.semianalysis.com` |

## How

- New `packages/app/src/lib/export-footer.ts` with `getExportFooterText()`: `window.location.hostname + pathname`, trailing slash trimmed, query string excluded. `localhost` / `127.0.0.1` fall back to `inferencex.semianalysis.com` so dev exports still read as shareable. Preview and alternate hosts (`inferencex.com`, `*.vercel.app`) are kept as-is.
- `useChartExport.addWatermark()` and `exportMp4.drawWithWatermark()` both call it; the shared `WATERMARK_TEXT` constants are gone.
- Footer bar height, colors, and shrink-to-fit sizing are unchanged.

## Tests

- `export-footer.test.ts`: nested routes, root, trailing slashes, preview hosts, local fallback, missing location.
- `bun run typecheck` and `bun run lint` clean; pre-commit hooks (typography, format, typecheck, lint) passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic export footer text only; no changes to auth, APIs, or data handling.
> 
> **Overview**
> Exported **PNG charts** and **replay MP4s** no longer stamp the fixed `InferenceX — github.com/...` string in the footer bar. Both paths now call shared **`getExportFooterText()`**, which renders **`hostname + pathname`** (no query string), with trailing slashes trimmed so `/` becomes just the host.
> 
> **Local dev** (`localhost`, `127.0.0.1`, etc.) substitutes **`inferencex.semianalysis.com`** so exports still look shareable; preview/alternate hosts are left as-is. Footer bar styling and chart PNG shrink-to-fit behavior are unchanged.
> 
> Adds **`export-footer.ts`** plus **`export-footer.test.ts`** covering routes, slashes, host fallback, and missing location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9591a0421bac529627b1bb24d85e79a1c1db22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->