### PR TITLE
docs(api): point skill onboarding to 0.3.0 / 将技能安装指引更新至 0.3.0

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -1,6 +1,6 @@
 # InferenceX API skill examples
 
-Use the public `@semianalysisai/inferencex-skills@0.2.0` package to query existing
+Use the public `@semianalysisai/inferencex-skills@0.3.0` package to query existing
 observations; these requests do not run new benchmarks. The skill covers the
 public API, with single-turn PowerX export as its first worked example. Read the
 [current API contract](https://inferencex.semianalysis.com/api/openapi.json) before
@@ -12,10 +12,10 @@ With Node 24 or later and npm, run the command for your agent from your project:
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target claude
 ```
 
 Start an agent session in that project. Queries need public HTTPS access, with no

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -1,9 +1,9 @@
 # Releasing the InferenceX API skill
 
-The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0` and
-`0.2.0` are immutable public releases. `0.3.0` commands below prepare a candidate;
-keep website commands pinned to the last verified public version until publication
-and public verification succeed. The
+The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0`,
+`0.2.0`, and `0.3.0` are immutable public releases. Keep website commands pinned
+to the last verified public version until publication and public verification
+succeed. The
 [`publish-skills.yml`](../.github/workflows/publish-skills.yml) workflow prepares
 future releases; it does not run on application tags or database-backup releases.
 Adding this workflow does not configure npm access or prove a successful OIDC release.
@@ -43,7 +43,8 @@ the trust relationship.
 2. Run the following from the repository root using Node 24/npm and Python 3 on
    Linux or macOS (the public verification deadline uses Unix process groups and timers).
    Choose a **new output directory for every attempt**. Substitute the intended
-   version; `0.3.0` below is a candidate, not a claim that it is published.
+   version. The `0.3.0` paths below record the accepted candidate used for this
+   release; preparation alone did not prove publication.
 
 ```bash
 node --test packages/skills/test/*.test.mjs

--- a/packages/app/cypress/e2e/api-documentation.cy.ts
+++ b/packages/app/cypress/e2e/api-documentation.cy.ts
@@ -2,7 +2,7 @@ import type { BenchmarkRow } from '@semianalysisai/inferencex-db/queries/benchma
 
 const SITE_URL = 'https://inferencex.semianalysis.com';
 // The website advertises the verified public release, which can lag the source candidate.
-const PUBLISHED_SKILL = { name: '@semianalysisai/inferencex-skills', version: '0.2.0' };
+const PUBLISHED_SKILL = { name: '@semianalysisai/inferencex-skills', version: '0.3.0' };
 
 describe('API documentation', () => {
   for (const locale of [

--- a/packages/app/src/components/api-documentation/api-reference-page.tsx
+++ b/packages/app/src/components/api-documentation/api-reference-page.tsx
@@ -24,7 +24,7 @@ const UI_COPY = {
     agentSkill: 'Use the API with your agent',
     agentSkillDescription:
       'The inferencex-api skill helps your agent navigate the public API: benchmarks, provenance, datasets, CollectiveX, and diagnostics. Validated single-turn PowerX export is the first worked example.',
-    agentVersion: 'Skill version · 0.2.0',
+    agentVersion: 'Skill version · 0.3.0',
     agentPrerequisites:
       'Requires Node 24 or later with npm and Codex or Claude Code. Installation and API queries require internet access.',
     agentInstall: 'Install in your project',
@@ -101,7 +101,7 @@ const UI_COPY = {
     agentSkill: '通过智能体使用 API',
     agentSkillDescription:
       'inferencex-api 技能帮助智能体查找和使用公开 API，涵盖基准测试、溯源、数据集、CollectiveX 和诊断接口。已验证的单轮请求 PowerX 导出是首个完整示例。',
-    agentVersion: '技能版本 · 0.2.0',
+    agentVersion: '技能版本 · 0.3.0',
     agentPrerequisites:
       '需要 Node 24 或更新版本、npm，以及 Codex 或 Claude Code。安装和 API 查询均需联网。',
     agentInstall: '安装到项目',
@@ -350,7 +350,7 @@ export function ApiReferencePage({ locale }: { locale: ApiDocumentationLocale })
                     locale={locale}
                     label={target === 'codex' ? 'Codex' : 'Claude Code'}
                   >
-                    {`npm exec --yes --package @semianalysisai/inferencex-skills@0.2.0 -- inferencex-skills install --target ${target}`}
+                    {`npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target ${target}`}
                   </CopyableCodeBlock>
                 </div>
               ))}


### PR DESCRIPTION
The website still advertises `@semianalysisai/inferencex-skills@0.2.0` after the verified `0.3.0` release. Point `/api`, `/zh/api`, and the linked examples to `0.3.0`, and update the release guide so it records the published state instead of calling this version a candidate.

Public npm metadata, provenance, the exact tarball digest, and anonymous Codex/Claude installation and export were verified before updating these pins. Package and API behavior are unchanged.

## Testing

- API documentation Cypress spec: 6 passed
- Local smoke suite: 159 passed
- Workspace unit tests: 5,827 passed
- Lint, format, typecheck, and typography checks passed
- Claude and manual review found no issue in the version-only Chinese UI change

## 中文说明

`@semianalysisai/inferencex-skills@0.3.0` 已完成验证并发布，但网站仍显示 `0.2.0`。本 PR 将 `/api`、`/zh/api` 及链接中的示例更新为 `0.3.0`，并同步修正发布指南，不再把该版本称为尚未发布的候选包。

更新版本号前，已核对公开 npm metadata、provenance、tarball 摘要，以及 Codex 和 Claude 的匿名安装与导出结果。本 PR 不改变包内容或 API 行为。

## 验证

- API 文档 Cypress 测试：6 项通过
- 本地 smoke 测试：159 项通过
- 工作区单元测试：5,827 项通过
- lint、格式、类型和字体规范检查通过
- Claude 与人工审查未发现仅涉及版本号的中文界面文案问题

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, UI strings, and e2e expectations only; no runtime API or package behavior changes.
> 
> **Overview**
> After verified publication of `@semianalysisai/inferencex-skills@0.3.0`, this PR **replaces every `0.2.0` pin** with `0.3.0` so onboarding matches npm.
> 
> **Docs:** `inferencex-api-examples.md` install commands and the package mention now use `0.3.0`. `inferencex-skills-release.md` treats `0.3.0` as an immutable public release (not a candidate) and clarifies that the documented `/tmp/...0.3.0` paths record the accepted release archive, not proof of publication by preparation alone.
> 
> **App:** English and Chinese API reference copy (`agentVersion`), Codex/Claude `npm exec` blocks on `/api` and `/zh/api`, and the Cypress `PUBLISHED_SKILL` constant align with the verified public package. No API or skill package code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bdbe43529bc8a0813d9f55442f27638de295772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->