### PR TITLE
feat(charts): drop vertical grid lines on profit estimator charts / 移除利润估算图表的垂直网格线

### DIFF
--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -850,6 +850,9 @@ export default function ProfitEstimatorChart({
 
   const xAxisConfig = useMemo(
     () => ({
+      // Categorical bars: a vertical line through each bar centre adds nothing,
+      // so only the horizontal $ grid lines are drawn.
+      grid: false,
       tickFormat: (d: d3.AxisDomain) => labelMap.get(String(d)) ?? String(d),
       customize: (axisGroup: d3.Selection<SVGGElement, unknown, null, undefined>) => {
         const fontPx = CHART_TYPE.axisLabelSub;

--- a/packages/app/src/lib/d3-chart/D3Chart/types.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/types.ts
@@ -134,6 +134,12 @@ export interface AxisConfig {
   tickCount?: number;
   /** Explicit ticks or a domain-aware generator, useful for geometric and sparse log axes. */
   tickValues?: (number | Date)[] | ((scale: AnyScale) => (number | Date)[]);
+  /**
+   * Draw grid lines at this axis's ticks. Defaults to true. Set to false to
+   * drop the lines running perpendicular to the axis (e.g. `xAxis.grid: false`
+   * removes vertical grid lines while keeping the horizontal ones).
+   */
+  grid?: boolean;
   /** Post-render callback for custom axis label formatting (e.g., multi-line tspan). */
   customize?: (axisGroup: d3.Selection<SVGGElement, unknown, null, undefined>) => void;
 }

--- a/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/useD3ChartRenderer.ts
@@ -8,7 +8,7 @@ import {
   invalidateTooltipGeometry,
 } from '../layers/scatter-points';
 import { setupChartStructure } from '../chart-setup';
-import { renderAxes, renderGrid, type AnyScale } from '../chart-update';
+import { renderAxes, renderGrid, type AnyScale, type GridVisibility } from '../chart-update';
 import type { ChartLayout, ContinuousScale } from '../types';
 
 import { buildScale, isBandScale, type BuiltScale } from './scale-builders';
@@ -73,6 +73,12 @@ function resolveTickValues(
   if (!tickValues) return undefined;
   return typeof tickValues === 'function' ? tickValues(scale) : tickValues;
 }
+
+/** Map per-axis `grid` flags onto the grid renderer's visibility options. */
+function gridVisibility(xAxis?: AxisConfig, yAxis?: AxisConfig): GridVisibility {
+  return { x: xAxis?.grid ?? true, y: yAxis?.grid ?? true };
+}
+
 export interface ZoomFrameBatcher {
   schedule: (work: () => void) => void;
   flush: () => void;
@@ -397,6 +403,8 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
           0,
           xTickValues,
           yTickValues,
+          'both',
+          gridVisibility(xAxisConfig, yAxisConfig),
         );
         renderAxes(layout, xScale as AnyScale, yScale as any, {
           xTickFormat: xAxisConfig?.tickFormat,
@@ -708,6 +716,7 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
                   xTickValues,
                   yTickValues,
                   currentZoomAxes,
+                  gridVisibility(zoomXAxisConfig, zoomYAxisConfig),
                 );
                 for (const layer of zoomLayers) {
                   updateLayerDecorationOnZoom(
@@ -841,6 +850,7 @@ export function useD3ChartRenderer<T>(props: D3ChartProps<T>, deps: RendererDeps
         xTickValues,
         yTickValues,
         updateAxes,
+        gridVisibility(xAxisConfig, yAxisConfig),
       );
       renderAxes(layout, currentXScale as AnyScale, yAxisScale, {
         xTickFormat: xAxisConfig?.tickFormat,

--- a/packages/app/src/lib/d3-chart/chart-update.test.ts
+++ b/packages/app/src/lib/d3-chart/chart-update.test.ts
@@ -473,6 +473,44 @@ describe('renderGrid', () => {
     });
   });
 
+  describe('visibility', () => {
+    it('skips vertical lines when x grid is disabled but keeps horizontal ones', () => {
+      const layout = makeLayout();
+      const domain = ['A', 'B', 'C', 'D'];
+      const xScale = d3.scaleBand().domain(domain).range([0, layout.width]).padding(0.1);
+      const yScale = d3.scaleLinear().domain([0, 50]).range([layout.height, 0]);
+
+      renderGrid(layout, xScale, yScale, 5, 0, undefined, undefined, 'both', { x: false });
+
+      expect(layout.gridGroup.select('.grid-v').selectAll('line').size()).toBe(0);
+      expect(layout.gridGroup.select('.grid-h').selectAll('line').size()).toBeGreaterThan(0);
+    });
+
+    it('removes previously drawn vertical lines when x grid is turned off', () => {
+      const layout = makeLayout();
+      const xScale = d3.scaleLinear().domain([0, 100]).range([0, layout.width]);
+      const yScale = d3.scaleLinear().domain([0, 50]).range([layout.height, 0]);
+
+      renderGrid(layout, xScale, yScale);
+      expect(layout.gridGroup.select('.grid-v').selectAll('line').size()).toBeGreaterThan(0);
+
+      renderGrid(layout, xScale, yScale, 5, 0, undefined, undefined, 'both', { x: false });
+      expect(layout.gridGroup.select('.grid-v').selectAll('line').size()).toBe(0);
+      expect(layout.gridGroup.select('.grid-h').selectAll('line').size()).toBeGreaterThan(0);
+    });
+
+    it('skips horizontal lines when y grid is disabled', () => {
+      const layout = makeLayout();
+      const xScale = d3.scaleLinear().domain([0, 100]).range([0, layout.width]);
+      const yScale = d3.scaleLinear().domain([0, 50]).range([layout.height, 0]);
+
+      renderGrid(layout, xScale, yScale, 5, 0, undefined, undefined, 'both', { y: false });
+
+      expect(layout.gridGroup.select('.grid-h').selectAll('line').size()).toBe(0);
+      expect(layout.gridGroup.select('.grid-v').selectAll('line').size()).toBeGreaterThan(0);
+    });
+  });
+
   describe('with band scales', () => {
     it('creates vertical lines at band centers for band x-scale', () => {
       const layout = makeLayout();

--- a/packages/app/src/lib/d3-chart/chart-update.ts
+++ b/packages/app/src/lib/d3-chart/chart-update.ts
@@ -85,6 +85,14 @@ export function renderAxes(
 }
 
 /** Render or update grid lines with current scales. */
+/** Which grid line sets to draw; each defaults to true when omitted. */
+export interface GridVisibility {
+  /** Vertical lines at x-axis ticks. */
+  x?: boolean;
+  /** Horizontal lines at y-axis ticks. */
+  y?: boolean;
+}
+
 export function renderGrid(
   layout: ChartLayout,
   xScale: AnyScale,
@@ -94,13 +102,20 @@ export function renderGrid(
   xTickValues?: (number | Date)[],
   yTickValues?: (number | Date)[],
   axes: 'x' | 'y' | 'both' = 'both',
+  visible: GridVisibility = {},
 ): void {
   const { width, height, gridGroup } = layout;
   const dur = transitionDuration;
   const updateX = axes === 'x' || axes === 'both';
   const updateY = axes === 'y' || axes === 'both';
+  const showX = visible.x ?? true;
+  const showY = visible.y ?? true;
 
-  if (updateX) {
+  if (updateX && !showX) {
+    // Vertical grid lines disabled: drop any lines from a previous render so
+    // toggling the flag at runtime does not leave stale lines behind.
+    gridGroup.select('.grid-v').selectAll('line').remove();
+  } else if (updateX) {
     let vGroup = gridGroup.select<SVGGElement>('.grid-v');
     if (vGroup.empty()) vGroup = gridGroup.append('g').attr('class', 'grid-v');
 
@@ -142,7 +157,9 @@ export function renderGrid(
     }
   }
 
-  if (updateY) {
+  if (updateY && !showY) {
+    gridGroup.select('.grid-h').selectAll('line').remove();
+  } else if (updateY) {
     let hGroup = gridGroup.select<SVGGElement>('.grid-h');
     if (hGroup.empty()) hGroup = gridGroup.append('g').attr('class', 'grid-h');
 


### PR DESCRIPTION
## Summary

Removes the vertical grid lines from the bar chart on `/profit-estimator` and `/profit-estimator-per-gigawatt` (and the `/zh` siblings, which share `ProfitEstimatorChart`). The x-axis is categorical (one bar per SKU), so a vertical line through each bar centre carried no information; the horizontal $ grid lines are kept.

- `AxisConfig` gains an optional `grid?: boolean` (default `true`). Setting `xAxis.grid: false` drops vertical lines, `yAxis.grid: false` drops horizontal ones.
- `renderGrid` takes a `GridVisibility` option and removes any previously drawn lines for a disabled set, so toggling at runtime does not leave stale lines behind. Wired through all three `renderGrid` call sites in `useD3ChartRenderer` (initial render, zoom frame, metric update).
- `ProfitEstimatorChart` sets `grid: false` on its x-axis config.
- Unit tests: 3 new cases in `chart-update.test.ts` (x off keeps y, y off keeps x, stale vertical lines removed on re-render).

No other chart changes behaviour: the flag defaults to `true`.

## Verification

- `bun run typecheck` clean
- `oxlint` / `oxfmt --check` clean on touched files
- `vitest run` on `chart-update.test.ts`, `useD3ChartRenderer.test.ts`, `ProfitEstimatorChart.test.ts`: 88 passed

## 中文说明

移除 `/profit-estimator` 与 `/profit-estimator-per-gigawatt`（以及共用 `ProfitEstimatorChart` 的 `/zh` 页面）柱状图中的垂直网格线。x 轴是分类轴（每个 SKU 一根柱子），穿过柱子中心的垂直线没有信息量；水平的美元网格线保留。

- `AxisConfig` 新增可选的 `grid?: boolean`（默认 `true`）。`xAxis.grid: false` 去掉垂直线，`yAxis.grid: false` 去掉水平线。
- `renderGrid` 接受 `GridVisibility` 参数，并在某组网格线被关闭时清理之前渲染的线条，运行时切换不会残留。已接入 `useD3ChartRenderer` 中三处 `renderGrid` 调用（首次渲染、缩放帧、指标更新）。
- `ProfitEstimatorChart` 在 x 轴配置上设置 `grid: false`。
- 单元测试：`chart-update.test.ts` 新增 3 个用例。

其他图表行为不变：该开关默认为 `true`。typecheck、lint、fmt 均通过，相关 vitest 88 个用例全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visualization-only change with backward-compatible defaults; only ProfitEstimatorChart opts out of vertical grids.
> 
> **Overview**
> Adds **per-axis control** over D3 chart grid lines via optional `grid` on `AxisConfig` (defaults to on). `renderGrid` now accepts `GridVisibility` so vertical and horizontal lines can be toggled independently, and **clears** lines for a disabled direction on re-render so toggling does not leave stale SVG.
> 
> The shared renderer maps `xAxis.grid` / `yAxis.grid` through all initial, zoom, and metric-update grid passes. **Profit estimator** bar charts set `xAxis.grid: false` because the categorical SKU x-axis only needed horizontal dollar grids; other charts are unchanged.
> 
> Three unit tests cover x-only off, y-only off, and removal of vertical lines after turning x grid off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ee6d04b3c95f2fc39c785d32811f8d2bc7803d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->