### PR TITLE
feat(profit): default GLM 5.2/5.3 model license fee to 10%

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -1,8 +1,9 @@
 // /profit-estimator: one stacked bar per SKU, US$ per all-in GW per year.
 // Behaviours worth locking down:
 //  - defaults are Kimi K3, 45 tok/s/user, 60% utilization, 30% model license fee;
-//  - GLM 5.2/5.3 has its own defaults, 100 tok/s/user and the Z.ai list price
-//    ($1.40 / $0.26 cached / $4.40), and a model switch re-seeds both;
+//  - GLM 5.2/5.3 has its own defaults, 100 tok/s/user, the Z.ai list price
+//    ($1.40 / $0.26 cached / $4.40), and a 10% license fee; a model switch
+//    re-seeds all three;
 //  - MiniMax M3 opens on 83 tok/s/user, the MiniMax list price, and a 20% license fee
 //    ($0.30 / $0.06 cached / $1.20);
 //  - utilization scales revenue only, so the revenue label moves and the
@@ -635,6 +636,8 @@ describe('Profit Estimator — GLM 5.2/5.3', () => {
     chart().should('exist');
     cy.location('pathname').should('eq', '/profit-estimator/glm-5-3');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '10');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '10%');
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'GLM5.2/GLM5.3 744B Agentic Revenue & Profit Estimates per Chip per Hour at P90 100 tok/s/user Interactivity',
@@ -779,7 +782,7 @@ describe('Profit Estimator — MiniMax M3', () => {
     cy.visit('/profit-estimator-per-gigawatt/glm-5-3', { onBeforeLoad: suppressNudges });
     chart().should('exist');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '10');
 
     cy.get('[data-testid="profit-model-selector"]').click();
     cy.contains('[role="option"]', 'MiniMax M3').click();

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -553,7 +553,7 @@ function ProfitEstimatorInner({
   );
   // Each model has its own operating point, price source, and license fee
   // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
-  // on the Z.ai list price at 30%; MiniMax M3: 83 tok/s/user on the MiniMax
+  // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
   // list price at 20%), so a model switch re-seeds all three. The ref keeps
   // this to actual switches: re-renders with the same model leave the
   // reader's edits alone.

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -339,10 +339,10 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('opens GLM 5.2/5.3 on 100 tok/s/user and the Z.ai list price', () => {
+  it('opens GLM 5.2/5.3 on 100 tok/s/user, the Z.ai list price, and a 10% license fee', () => {
     const defaults = profitModelDefaults(Model.GLM_5_2);
     expect(defaults.interactivity).toBe(100);
-    expect(defaults.labCutPct).toBe(DEFAULT_LAB_CUT_PCT);
+    expect(defaults.labCutPct).toBe(10);
     expect(defaults.listPricing).toEqual({
       vendor: 'Z.ai',
       inputPerMillion: 1.4,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -71,8 +71,8 @@ export interface ProfitModelDefaults {
  * aggregate also sits below it, and on 83 tok/s/user, the speed MiniMax's own
  * API serves at; the B200/B300/GB200/MI355X agentic curves all cover that
  * point, and the Hopper and MI300-series curves top out below it and list as
- * not priced. MiniMax M3 also opens on a 20% model license fee instead of the
- * 30% the other models assume.
+ * not priced. GLM 5.2/5.3 opens on a 10% model license fee and MiniMax M3 on
+ * 20%, instead of the 30% the other models assume.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   [Model.Kimi_K3]: {
@@ -82,7 +82,7 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   },
   [Model.GLM_5_2]: {
     interactivity: 100,
-    labCutPct: DEFAULT_LAB_CUT_PCT,
+    labCutPct: 10,
     listPricing: {
       vendor: 'Z.ai',
       inputPerMillion: 1.4,


### PR DESCRIPTION
GLM 5.2/5.3 estimator routes (`/profit-estimator/glm-5-3` and the per-gigawatt page) now open on a **10%** model license fee instead of inheriting the 30% fallback.

- `PROFIT_MODEL_DEFAULTS[Model.GLM_5_2].labCutPct` 30 → 10
- Kimi K3 stays at 30%, MiniMax M3 at 20%; model switches still re-seed the field
- Unit test and Cypress expectations updated; comments in `profit-estimator.ts` / `ProfitEstimatorDisplay.tsx` updated to match

Local: oxfmt, oxlint, tsc, and `profit-estimator.test.ts` all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized default for a calculator input; users can still edit the license fee, and no auth, billing, or data-pipeline paths change.
> 
> **Overview**
> GLM 5.2/5.3 profit estimator routes now **open with a 10% model license fee** instead of the shared **30%** fallback (`PROFIT_MODEL_DEFAULTS[Model.GLM_5_2].labCutPct`). Kimi K3 remains at 30% and MiniMax M3 at 20%; switching models still re-seeds interactivity, price source, and license fee via existing logic.
> 
> Cypress and `profitModelDefaults` unit tests assert the new default on `/profit-estimator/glm-5-3` and when leaving GLM for MiniMax; inline comments in `profit-estimator.ts` and `ProfitEstimatorDisplay.tsx` document the per-model fee split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa80900e523cf9ff95bc9d13b9f4bb06f78b4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->