### PR TITLE
feat(skills): add AgentX exports and bounded point diagnostics / 添加 AgentX 导出与有限单点诊断

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -47,14 +47,14 @@ jobs:
         run: node --test packages/skills/test/*.test.mjs
       - name: Prepare the exact accepted archive
         run: node packages/skills/scripts/release.mjs prepare "$RELEASE_VERSION" "$RUNNER_TEMP/skills-release" "$REVIEWED_SHA256"
-      - name: Verify candidate installation and public API export
-        run: python3 packages/skills/scripts/verify-release.py candidate "$RUNNER_TEMP/skills-release/release.json" --model DeepSeek-V4-Pro --isl 8192 --osl 1024 --evidence "$RUNNER_TEMP/skills-candidate-verification"
+      - name: Verify candidate installation and public API behavior
+        run: python3 packages/skills/scripts/verify-release.py candidate "$RUNNER_TEMP/skills-release/release.json" --model DeepSeek-V4-Pro --isl 8192 --osl 1024 --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 --evidence "$RUNNER_TEMP/skills-candidate-verification"
       - name: Publish the verified archive with OIDC
         run: |
           node packages/skills/scripts/release.mjs check "$RUNNER_TEMP/skills-release/release.json" "$REVIEWED_SHA256"
           npm publish "$RUNNER_TEMP/skills-release/semianalysisai-inferencex-skills-${RELEASE_VERSION}.tgz" --access public --ignore-scripts --registry https://registry.npmjs.org
-      - name: Verify anonymous pinned public installation and export
-        run: python3 packages/skills/scripts/verify-release.py public "$RUNNER_TEMP/skills-release/release.json" --model DeepSeek-V4-Pro --isl 8192 --osl 1024 --evidence "$RUNNER_TEMP/skills-public-verification"
+      - name: Verify anonymous pinned public installation and behavior
+        run: python3 packages/skills/scripts/verify-release.py public "$RUNNER_TEMP/skills-release/release.json" --model DeepSeek-V4-Pro --isl 8192 --osl 1024 --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 --evidence "$RUNNER_TEMP/skills-public-verification"
       - name: Preserve release and verification evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/bun.lock
+++ b/bun.lock
@@ -139,7 +139,7 @@
     },
     "packages/skills": {
       "name": "@semianalysisai/inferencex-skills",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "bin": {
         "inferencex-skills": "bin/install.mjs",
       },

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -55,11 +55,11 @@ python3 packages/skills/scripts/verify-release.py candidate /tmp/inferencex-rele
   --evidence /tmp/inferencex-candidate-check-0.4.0
 ```
 
-The preparer rejects a version mismatch, an already published version, and an
-unavailable registry check. It packs once, checks the public file boundary, and
-records the source commit, whether the package source was dirty, file list, SHA-256,
-and npm integrity. A dirty-source preparation is useful for iteration but is not
-the final reviewed release candidate. Maintainer tools,
+The preparer requires and records a clean package source state. It rejects dirty
+source before registry access or candidate output, and also rejects a version
+mismatch, an already published version, or an unavailable registry check. It packs
+once, checks the public file boundary, and records the source commit,
+`source_dirty: false`, file list, SHA-256, and npm integrity. Maintainer tools,
 tests, credentials, and acceptance artifacts are outside the public package.
 The verifier creates two projects outside the repository with fresh npm caches,
 empty npm configuration, and an allowlisted environment. It installs the exact

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -37,21 +37,22 @@ the trust relationship.
 ## Prepare and review a candidate
 
 1. Modify the source, choose a new stable version, and update package metadata,
-   the exporter's standalone version, installation examples, and installed-version
+   both exporters' standalone versions, installation examples, and installed-version
    expectations together. Run the package tests and the relevant repository checks.
-   Review and commit the final source before preparing the accepted archive.
+   Merge the reviewed source before preparing the final accepted archive.
 2. Run the following from the repository root using Node 24/npm and Python 3 on
    Linux or macOS (the public verification deadline uses Unix process groups and timers).
    Choose a **new output directory for every attempt**. Substitute the intended
-   version. The `0.3.0` paths below record the accepted candidate used for this
-   release; preparation alone did not prove publication.
+   version. The `0.4.0` paths below describe this candidate; preparation alone
+   does not prove publication.
 
 ```bash
 node --test packages/skills/test/*.test.mjs
-node packages/skills/scripts/release.mjs prepare 0.3.0 /tmp/inferencex-release-0.3.0
-python3 packages/skills/scripts/verify-release.py candidate /tmp/inferencex-release-0.3.0/release.json \
+node packages/skills/scripts/release.mjs prepare 0.4.0 /tmp/inferencex-release-0.4.0
+python3 packages/skills/scripts/verify-release.py candidate /tmp/inferencex-release-0.4.0/release.json \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
-  --evidence /tmp/inferencex-candidate-check-0.3.0
+  --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
+  --evidence /tmp/inferencex-candidate-check-0.4.0
 ```
 
 The preparer rejects a version mismatch, an already published version, and an
@@ -62,9 +63,11 @@ the final reviewed release candidate. Maintainer tools,
 tests, credentials, and acceptance artifacts are outside the public package.
 The verifier creates two projects outside the repository with fresh npm caches,
 empty npm configuration, and an allowlisted environment. It installs the exact
-archive for Codex and Claude Code and checks every JSON row and CSV field against
-the complete public responses actually used by the installed exporter. Missing
-metrics stay missing and real zeroes remain zero. No new benchmarks run.
+archive for Codex and Claude Code. It checks PowerX and AgentX CSV/JSON against the
+complete public responses consumed by each exporter, exercises an exact excluded
+AgentX selection, and checks one traced and one no-trace point. Missing and null
+values remain missing; real `0` and `false` values remain explicit. No new
+benchmarks run.
 
 The live check uses the requested model/workload; there is no fixed date or expected
 row count. Use `--date YYYY-MM-DD` for a reproducible cutoff and `--raw-model KEY`
@@ -81,19 +84,21 @@ instructions, examples, installer behavior, or export semantics change, and befo
 accepting the archive for publication.
 
 ```bash
-python3 packages/skills/scripts/verify-release.py agents /tmp/inferencex-release-0.3.0/release.json \
+python3 packages/skills/scripts/verify-release.py agents /tmp/inferencex-release-0.4.0/release.json \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
-  --evidence /tmp/inferencex-agent-preparation-0.3.0
+  --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
+  --evidence /tmp/inferencex-agent-preparation-0.4.0
 ```
 
 The output identifies a new temporary root with `codex/` and `claude/` projects.
-Each contains only the installed skill, installation logs, and `prompt.txt` with a
-natural-language lookup, PowerX export, and exact empty-workload request. These are
-prepared projects, **not completed agent runs**. The prompt also requests installer
-JSON status and a forced dry-run using the exact candidate archive, while preserving
-the installed skill. Review these structured results and filesystem preservation
-independently; `check-agent` reports only its data checks. Their `acceptance.json` identifies
-the candidate archive. The empty workload defaults to 7/13 tokens; override
+Each initially contains only the exact candidate archive and `prompt.txt`; these are
+prepared projects, **not completed agent runs**. The prompt asks the agent to install
+the archive, inspect status, preview a forced reinstall, run the lookup and PowerX
+flows, export AgentX CSV and JSON, retain an exactly excluded AgentX selection, and
+inspect one traced and one no-trace point with complete same-request evidence.
+Review installer results and filesystem preservation independently; `check-agent`
+reports only its data checks. `acceptance.json` identifies both prepared targets and
+the candidate archive. The PowerX empty workload defaults to 7/13 tokens; override
 `--empty-isl` and `--empty-osl` if that scope ever acquires observations.
 
 Start a fresh Codex or Claude Code session inside the corresponding project and
@@ -110,10 +115,11 @@ into evidence or GitHub Actions secrets for this test.
 After each agent completes, independently check its generated files:
 
 ```bash
-python3 packages/skills/scripts/verify-release.py check-agent /tmp/inferencex-release-0.3.0/release.json \
+python3 packages/skills/scripts/verify-release.py check-agent /tmp/inferencex-release-0.4.0/release.json \
   --project /tmp/inferencex-skill-acceptance-REPLACE/codex \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
-  --evidence /tmp/inferencex-codex-result-check-0.3.0
+  --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
+  --evidence /tmp/inferencex-codex-result-check-0.4.0
 ```
 
 Repeat for Claude Code with a new evidence directory. Use the **same scope arguments**
@@ -135,6 +141,12 @@ different reviewer must inspect the transcript and explanation for:
   are not treated as proof that no benchmark jobs occurred on a date.
 - The empty result is retained, diagnosis keeps its exact scope, and uncertainty
   is explained if the diagnostic request fails.
+- AgentX filters remain exact and case-sensitive; an empty or excluded selection
+  makes no claims beyond its response. Aggregates, derived metrics and trace
+  availability are not presented as model-quality scores or rankings.
+- Each AgentX point flow uses only its selected safe-integer ID. A no-trace result
+  stops before timeline, histogram and server-metric requests; a traced result does
+  not expand to sibling IDs.
 - The installed skill actually supplied the workflow and the agent used no
   repository or private-data access. All claims have complete response evidence.
   Confirm that the agent retained its full unfiltered, strict-before-filtering,
@@ -182,9 +194,10 @@ metadata is not yet available), the version is already immutable. Inspect the
 saved failure and rerun **only the read-only verifier**, preserving a new attempt:
 
 ```bash
-python3 packages/skills/scripts/verify-release.py public /tmp/inferencex-release-0.3.0/release.json \
+python3 packages/skills/scripts/verify-release.py public /tmp/inferencex-release-0.4.0/release.json \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
-  --evidence /tmp/inferencex-public-check-0.3.0-attempt2
+  --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
+  --evidence /tmp/inferencex-public-check-0.4.0-attempt2
 ```
 
 Do not rerun publication or bump the version just to hide a failed verification.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -2,25 +2,29 @@
 
 One Agent Skill, `inferencex-api`, for querying the
 [InferenceX public API](https://inferencex.semianalysis.com/api) from Codex or Claude Code.
-It supports current OpenAPI discovery, basic benchmark lookups, and validated
-PowerX CSV/JSON exports for an exact single-turn workload, preserving measurement
-dates, model keys, and source links.
+It supports current OpenAPI discovery, benchmark, evaluation, dataset and history
+lookups, plus worked PowerX and AgentX exports that preserve request context,
+observation identity and source links.
 
 The [public API cookbook](skills/inferencex-api/references/public-api-examples.md)
 also provides evaluation lookups and dataset-to-conversation inspection, with
 request context, exact identifiers, missing values, and page/sample boundaries.
 It also covers benchmark history filtered by GPU, workload and observation-date range.
 
-The npm commands below pin version `0.3.0` and require that version to be published.
+The npm commands below pin version `0.4.0` and require that version to be published.
 For review before publication, use the local archive instructions below.
 
-## New in 0.3.0
+## New in 0.4.0
 
-PowerX exports can save their original consumed HTTP response with `--evidence-dir`.
-The installer adds machine-readable `--json` inspection and a read-only `--dry-run`
-preview. A history recipe retains configurations and original observation dates.
-The maintainer verifier retries only the exact package/version ETARGET
-installation failure, with bounded attempts and a total deadline.
+AgentX summaries now export existing observations as deterministic CSV by default
+or explicit JSON. Exact, case-sensitive configuration filters and a positive
+concurrency filter are reported as applied or omitted. The exporter joins only the
+four documented summary endpoint families and can save every consumed response
+with `--evidence-dir`; missing and null values remain missing, while `0` and `false`
+remain explicit. The AgentX cookbook also provides a bounded recipe for one selected
+result ID, including an early stop before heavy trace routes when availability is
+false or the selected key is absent. These workflows do not run benchmarks or
+evaluate answer quality.
 
 ## Prerequisites
 
@@ -35,10 +39,10 @@ Run the command for your agent from the project where it should discover the ski
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target claude
 ```
 
 | Target              | Skill location relative to the current project |
@@ -49,9 +53,9 @@ npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-s
 For an explicit skills-root directory or inspection:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --dir './my project/.agents/skills'
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills list
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills --help
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --dir './my project/.agents/skills'
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills list
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills --help
 ```
 
 `--dir` selects the parent skills directory; the installer appends `inferencex-api`.
@@ -64,7 +68,7 @@ To review a maintainer-supplied `.tgz` before publication, replace the path with
 actual archive and run from the target project. Use `--target claude` for Claude Code.
 
 ```bash
-INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.3.0.tgz'
+INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.4.0.tgz'
 npm exec --yes --offline --package "$INFERENCEX_SKILLS_TGZ" -- inferencex-skills install --target codex
 ```
 
@@ -87,7 +91,7 @@ Latest available data may contain historical measurements; the requested cutoff 
 each observation's date remain separate.
 
 The skill helps navigate the public API; the single-turn PowerX exporter below is
-its first worked export example, not the boundary of API lookup support.
+one worked export example, not the boundary of API lookup support.
 
 ### Export measured PowerX data
 
@@ -137,10 +141,51 @@ and a manifest linking its SHA-256 to the output, request context and extraction
 metadata. CSV, JSON, stdout and empty selections are supported. Evidence is optional;
 requested evidence-write failures fail the command. See the [capture contract](skills/inferencex-api/references/powerx.md#save-the-response-used-by-an-export).
 
+### Export AgentX summaries and inspect one point
+
+Ask the installed skill:
+
+> Use inferencex-api to export the latest AgentX summaries for DeepSeek-V4-Pro as
+> CSV and JSON. Save the complete response evidence, preserve missing, null, zero
+> and false values, and explain the exact filters and counts.
+
+Or run the installed Node 24 exporter directly:
+
+```bash
+# Codex installation: deterministic CSV (the default format)
+node .agents/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --output agentx.csv \
+  --evidence-dir ./agentx-csv-evidence 2> agentx-report.log
+
+# Claude Code installation: explicit JSON
+node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --format json --output agentx.json \
+  --evidence-dir ./agentx-json-evidence
+```
+
+Optional `--raw-model`, `--hardware`, `--framework`, `--precision`,
+`--spec-method`, and `--offload-mode` values match returned values exactly and
+case-sensitively; `--concurrency` requires an exact positive integer. The exporter
+reads `/api/v1/benchmarks` and the bounded `/api/v1/agentic-aggregates`,
+`/api/v1/derived-agentic-metrics`, and `/api/v1/trace-availability` enrichments.
+CSV leaves missing and null cells blank and preserves `0` and `false`; JSON keeps
+each selected benchmark object separate from its enrichment. Every evidence path
+must be new and contains the complete responses consumed by that export plus a
+manifest linking them to the output.
+
+`no_agentx_rows` means the benchmark response contained no AgentX observations;
+`no_matching_rows` means the requested exact filters excluded the AgentX rows in
+that response. Neither outcome describes jobs, artifacts, or data outside the
+response. After the user chooses one exact result ID, follow the bounded recipe in
+the [AgentX cookbook](skills/inferencex-api/references/agentx.md). It validates a
+positive JavaScript safe integer, keeps trace diagnostics bound to that ID, and
+stops before timeline, histogram, and server-metric requests when trace
+availability is false or omitted.
+
 ### Inspect the installed version
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills status --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills status --target codex
 ```
 
 Use `--target claude` or `--dir './my project/.agents/skills'` to inspect another
@@ -152,17 +197,19 @@ first; add npm's `--offline` when the selected package version is already cached
 
 Legacy installations without a version record, including `0.1.0`, report an
 unknown installed version. Invalid or unreadable records are also reported as
-unknown. The record must agree with the installed exporter's explicit version;
-a mismatch, missing exporter version, or unreadable exporter reports unknown.
-This catches older installers overwriting files while leaving a newer record.
-This limited check does not verify every file or detect all local edits.
+unknown. For `0.4.0` and later receipts, the record must agree with the static
+version declarations in both the PowerX and AgentX exporters. Earlier receipts
+are checked against PowerX only; a stale AgentX file left by a forced downgrade is
+ignored. Missing, unreadable, or disagreeing required declarations report unknown.
+`status` reads these declarations without executing either exporter. This limited
+check is not a full integrity check and cannot detect every local edit.
 `--version` reports only the invoking installer version, not the project's installed copy.
 
 ### JSON output and installation preview
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills status --target codex --json
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target codex --force --dry-run --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills status --target codex --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target codex --force --dry-run --json
 ```
 
 `--json` on `status` or `install` emits one JSON document to stdout; diagnostics go
@@ -198,11 +245,11 @@ without stale installation fields; use the exit code to determine success.
 ### Upgrade
 
 Repeated installation skips an existing skill. Add `--force` to reinstall a pinned
-version. To upgrade, replace `0.3.0` with the published version you intend to install:
+version. To upgrade, replace `0.4.0` with the published version you intend to install:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target codex --force
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target claude --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target codex --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target claude --force
 ```
 
 Force merges the packaged files into the existing skill and overwrites matching
@@ -213,20 +260,24 @@ skill directory. Keep a copy of local edits before choosing an overwrite.
 
 本包提供一个 Agent Skill（智能体技能）`inferencex-api`，供 Codex 或 Claude Code
 查询 [InferenceX 公开 API](https://inferencex.semianalysis.com/zh/api)。技能支持查阅
-实时 OpenAPI、基础基准测试查询，以及指定单轮请求工作负载下的已验证 PowerX CSV/JSON
-导出，并在结果中保留测量日期、原始模型键和来源链接。技能面向整个公开 API 的查询；
-单轮 PowerX 导出是首个完整示例，不代表技能只能查询这类数据。
+实时 OpenAPI，查询基准测试、评估、数据集和历史记录，并提供 PowerX 与 AgentX
+导出示例；导出结果保留请求上下文、观测数据标识和来源链接。技能面向整个公开 API，
+这些导出示例并不限定技能的查询范围。
 
 [公开 API 指南](skills/inferencex-api/references/public-api-examples.md) 还提供评估查询和
 数据集到会话详情的完整示例，说明如何保留请求上下文、原始标识符、缺失值，以及分页和
 抽样范围；还提供按 GPU、工作负载和观测日期范围筛选历史基准测试数据的示例。
 
-上面的 npm 命令固定使用 `0.3.0`，需在该版本发布后执行。发布前审阅请使用本地产物
+上面的 npm 命令固定使用 `0.4.0`，需在该版本发布后执行。发布前审阅请使用本地产物
 安装流程。
 
-0.3.0 新增 PowerX 原始响应保存选项 `--evidence-dir`、安装器机器可读 JSON 输出
-`--json` 和只读安装预览 `--dry-run`，以及保留配置和原始观测日期的历史查询示例。
-维护者的发布后验证仅对指定包及版本的 ETARGET 安装错误进行有限重试，并受总时限约束。
+0.4.0 新增 AgentX 汇总导出：默认生成行列顺序稳定的 CSV，也可显式选择 JSON；硬件、
+框架、精度、投机解码方式、offload 模式等配置筛选均区分大小写并要求精确匹配，并支持
+精确的正整数并发数筛选。导出器会标明每项筛选是已应用还是未指定，只从四类已记录的
+汇总接口补充数据，并可用 `--evidence-dir` 保存本次导出实际使用的全部响应。缺失值和
+`null` 保持缺失，`0` 与 `false` 保留原值。AgentX 指南还提供范围限定为一个已选结果
+ID 的诊断流程；trace availability 为 `false` 或未返回所选 ID 时，会在读取高开销
+trace 接口前停止。这些流程只读取现有观测数据，不运行基准测试，也不评估模型回答质量。
 
 需要 Node 24 或更新版本、npm，以及 Codex 或 Claude Code。从 npm 安装需要访问
 npm 仓库，查询需要访问公开 HTTPS 接口；安装后的技能无需检出本仓库，也不需要
@@ -288,16 +339,51 @@ worker/审计信息；CSV 将缺失指标留空，并保留真实零值。状态
 该选项支持 CSV、JSON、stdout 和空结果；默认不保存响应。显式请求保存证据后，写入失败
 会导致命令失败。详细字段和适用范围见 [PowerX 指南中的响应保存约定](skills/inferencex-api/references/powerx.md#save-the-response-used-by-an-export)。
 
+### 导出 AgentX 汇总并检查单个数据点
+
+可让已安装的技能导出 DeepSeek-V4-Pro 最新的 AgentX CSV 与 JSON 汇总：保存完整响应
+证据，保留缺失值、`null`、零值和 `false`，并说明精确筛选条件和数据条数。也可在项目
+目录中直接运行已安装的 Node 24 导出器：
+
+```bash
+# Codex 安装：默认生成行列顺序稳定的 CSV
+node .agents/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --output agentx.csv \
+  --evidence-dir ./agentx-csv-evidence 2> agentx-report.log
+
+# Claude Code 安装：显式选择 JSON
+node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --format json --output agentx.json \
+  --evidence-dir ./agentx-json-evidence
+```
+
+`--raw-model`、`--hardware`、`--framework`、`--precision`、`--spec-method` 和
+`--offload-mode` 均为可选筛选；一经提供，必须与响应中的值完全一致并区分大小写。
+`--concurrency` 必须是精确的正整数。导出器读取 `/api/v1/benchmarks`，并有限关联
+`/api/v1/agentic-aggregates`、`/api/v1/derived-agentic-metrics` 和
+`/api/v1/trace-availability`。CSV 中的缺失值和 `null` 留空，`0` 与 `false` 原样保留；
+JSON 将每条基准测试观测数据与其补充信息分开保存。每次使用的证据目录都必须尚未
+存在，其中包含本次导出实际使用的完整响应，以及将这些响应与输出关联起来的清单。
+
+`no_agentx_rows` 表示本次基准测试响应中没有 AgentX 观测数据；`no_matching_rows`
+表示精确筛选排除了响应中的 AgentX 数据。两者都不能说明响应以外的任务、产物或数据
+是否存在。用户选定一个结果 ID 后，再按照
+[AgentX 指南](skills/inferencex-api/references/agentx.md)中限定范围的单点流程检查。该
+流程先验证 ID 能够无损表示为正的 JavaScript 安全整数，并将后续 trace 诊断限定在该
+ID；如果 trace availability 为 `false` 或未返回对应键，则不会继续请求 timeline、
+histogram 和 server metrics。
+
 可执行上面的 `status --target codex` 命令查看项目内已安装的技能；其他目标使用
 `--target claude` 或 `--dir`。输出会分别列出本次调用的安装器版本、目标目录中上次成功
 安装的技能版本，以及技能目录的绝对路径。`status` 只读取本地文件，不会请求 API；但 npm 可能先
 下载安装器。如指定版本已经缓存，可给 npm 加上 `--offline`。
 
 包括 `0.1.0` 在内、没有版本记录的旧安装会显示版本未知。记录无效或无法读取时，同样
-显示为未知。版本记录还必须与已安装导出器中声明的版本一致；两者不一致、导出器缺少
-版本声明或无法读取时，也会显示未知。这能识别旧安装器覆盖文件后留下较新版本记录的
-情况。这项检查不会验证所有文件，也不能检测所有本地修改。`--version` 只显示本次调用
-的安装器版本，不显示项目中已安装技能的版本。
+显示为未知。对于 `0.4.0` 及更新版本，版本记录必须同时与 PowerX 和 AgentX 导出器中的
+静态版本声明一致；早于 `0.4.0` 的记录只核对 PowerX，强制降级后残留的 AgentX 文件不
+参与判断。需要核对的声明缺失、无法读取或版本不一致时，状态也会显示为未知。`status`
+只读取声明，不执行任何导出器。这项检查不是完整的文件完整性校验，也不能识别所有本地
+修改。`--version` 只显示本次调用的安装器版本，不显示项目中已安装技能的版本。
 
 `status` 和 `install` 支持 `--json`：stdout 只输出一个 JSON 文档，诊断信息写入
 stderr。不加该选项时保留原有文字输出。上表定义 `schema_version: 1` 的字段：
@@ -322,7 +408,7 @@ stderr。不加该选项时保留原有文字输出。上表定义 `schema_versi
 安装状态字段；请用退出码判断操作是否成功。
 
 重复安装默认跳过已有技能。添加 `--force` 可重新安装指定版本；需要升级时，将命令中
-的 `0.3.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
+的 `0.4.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
 同名文件；相邻的其他技能不受影响，技能目录中已不再随包提供的旧文件也不会被删除。
 覆盖前请自行备份本地修改。
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -165,9 +165,12 @@ node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
 
 Optional `--raw-model`, `--hardware`, `--framework`, `--precision`,
 `--spec-method`, and `--offload-mode` values match returned values exactly and
-case-sensitively; `--concurrency` requires an exact positive integer. The exporter
-reads `/api/v1/benchmarks` and the bounded `/api/v1/agentic-aggregates`,
-`/api/v1/derived-agentic-metrics`, and `/api/v1/trace-availability` enrichments.
+case-sensitively; `--concurrency` requires an exact positive integer. The optional
+`--date YYYY-MM-DD` applies an as-of cutoff; omitting it selects the latest available
+observations. The exporter reads `/api/v1/benchmarks` and locally selects rows whose
+`benchmark_type` is exactly `agentic_traces`. It adds enrichments only through the
+request-size-bounded `/api/v1/agentic-aggregates`,
+`/api/v1/derived-agentic-metrics`, and `/api/v1/trace-availability` endpoints.
 CSV leaves missing and null cells blank and preserves `0` and `false`; JSON keeps
 each selected benchmark object separate from its enrichment. Every evidence path
 must be new and contains the complete responses consumed by that export plus a
@@ -359,11 +362,14 @@ node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
 
 `--raw-model`、`--hardware`、`--framework`、`--precision`、`--spec-method` 和
 `--offload-mode` 均为可选筛选；一经提供，必须与响应中的值完全一致并区分大小写。
-`--concurrency` 必须是精确的正整数。导出器读取 `/api/v1/benchmarks`，并有限关联
+`--concurrency` 必须是精确的正整数。`--date YYYY-MM-DD` 为可选项，用于限定观测日期不
+晚于该日；省略时选择最新可用观测数据。导出器读取 `/api/v1/benchmarks`，并在本地仅选择
+`benchmark_type` 恰为 `agentic_traces` 的数据，再只通过有请求规模上限的
 `/api/v1/agentic-aggregates`、`/api/v1/derived-agentic-metrics` 和
-`/api/v1/trace-availability`。CSV 中的缺失值和 `null` 留空，`0` 与 `false` 原样保留；
-JSON 将每条基准测试观测数据与其补充信息分开保存。每次使用的证据目录都必须尚未
-存在，其中包含本次导出实际使用的完整响应，以及将这些响应与输出关联起来的清单。
+`/api/v1/trace-availability` 三个接口补充 AgentX 汇总与 trace availability 信息。CSV
+中的缺失值和 `null` 留空，`0` 与 `false` 原样保留；JSON 将每条基准测试观测数据与其
+补充信息分开保存。每次使用的证据目录都必须尚未存在，其中包含本次导出实际使用的完整
+响应，以及将这些响应与输出关联起来的清单。
 
 `no_agentx_rows` 表示本次基准测试响应中没有 AgentX 观测数据；`no_matching_rows`
 表示精确筛选排除了响应中的 AgentX 数据。两者都不能说明响应以外的任务、产物或数据

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -276,9 +276,9 @@ skill directory. Keep a copy of local edits before choosing an overwrite.
 
 0.4.0 新增 AgentX 汇总导出：默认生成行列顺序稳定的 CSV，也可显式选择 JSON；硬件、
 框架、精度、投机解码方式、offload 模式等配置筛选均区分大小写并要求精确匹配，并支持
-精确的正整数并发数筛选。导出器会标明每项筛选是已应用还是未指定，只从四类已记录的
-汇总接口补充数据，并可用 `--evidence-dir` 保存本次导出实际使用的全部响应。缺失值和
-`null` 保持缺失，`0` 与 `false` 保留原值。AgentX 指南还提供范围限定为一个已选结果
+按精确值匹配的正整数并发数筛选。导出器会标明每项筛选是已应用还是未指定，数据只来自
+文档中列明的四类汇总接口，并可用 `--evidence-dir` 保存本次导出实际使用的全部响应。
+缺失值和 `null` 保持缺失，`0` 与 `false` 保留原值。AgentX 指南还提供范围限定为一个已选结果
 ID 的诊断流程；trace availability 为 `false` 或未返回所选 ID 时，会在读取高开销
 trace 接口前停止。这些流程只读取现有观测数据，不运行基准测试，也不评估模型回答质量。
 
@@ -362,8 +362,9 @@ node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
 
 `--raw-model`、`--hardware`、`--framework`、`--precision`、`--spec-method` 和
 `--offload-mode` 均为可选筛选；一经提供，必须与响应中的值完全一致并区分大小写。
-`--concurrency` 必须是精确的正整数。可选的 `--date YYYY-MM-DD` 用于指定 as-of 快照
-截止日期；省略时使用最新可用快照。每条数据自身的观测日期仍按原响应保留。导出器读取
+`--concurrency` 必须是正整数，并按精确值匹配并发数。可选的
+`--date YYYY-MM-DD` 用于指定 as-of 快照截止日期；省略时使用最新可用快照。每条数据自身
+的观测日期仍按原响应保留。导出器读取
 `/api/v1/benchmarks`，并在本地仅选择 `benchmark_type` 恰为 `agentic_traces` 的数据，
 再只通过有请求规模上限的
 `/api/v1/agentic-aggregates`、`/api/v1/derived-agentic-metrics` 和
@@ -386,9 +387,9 @@ histogram 和 server metrics。
 下载安装器。如指定版本已经缓存，可给 npm 加上 `--offline`。
 
 包括 `0.1.0` 在内、没有版本记录的旧安装会显示版本未知。记录无效或无法读取时，同样
-显示为未知。对于 `0.4.0` 及更新版本，版本记录必须同时与 PowerX 和 AgentX 导出器中的
-静态版本声明一致；早于 `0.4.0` 的记录只核对 PowerX，强制降级后残留的 AgentX 文件不
-参与判断。需要核对的声明缺失、无法读取或版本不一致时，状态也会显示为未知。`status`
+显示为未知。版本记录为 `0.4.0` 或更新时，必须同时与 PowerX 和 AgentX 导出器中的静态
+版本声明一致；早于 `0.4.0` 的记录只核对 PowerX，强制降级后残留的 AgentX 文件不参与
+判断。需要核对的声明缺失、无法读取或版本不一致时，状态也会显示为未知。`status`
 只读取声明，不执行任何导出器。这项检查不是完整的文件完整性校验，也不能识别所有本地
 修改。`--version` 只显示本次调用的安装器版本，不显示项目中已安装技能的版本。
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -362,9 +362,10 @@ node .claude/skills/inferencex-api/scripts/export-agentx.mjs \
 
 `--raw-model`、`--hardware`、`--framework`、`--precision`、`--spec-method` 和
 `--offload-mode` 均为可选筛选；一经提供，必须与响应中的值完全一致并区分大小写。
-`--concurrency` 必须是精确的正整数。`--date YYYY-MM-DD` 为可选项，用于限定观测日期不
-晚于该日；省略时选择最新可用观测数据。导出器读取 `/api/v1/benchmarks`，并在本地仅选择
-`benchmark_type` 恰为 `agentic_traces` 的数据，再只通过有请求规模上限的
+`--concurrency` 必须是精确的正整数。可选的 `--date YYYY-MM-DD` 用于指定 as-of 快照
+截止日期；省略时使用最新可用快照。每条数据自身的观测日期仍按原响应保留。导出器读取
+`/api/v1/benchmarks`，并在本地仅选择 `benchmark_type` 恰为 `agentic_traces` 的数据，
+再只通过有请求规模上限的
 `/api/v1/agentic-aggregates`、`/api/v1/derived-agentic-metrics` 和
 `/api/v1/trace-availability` 三个接口补充 AgentX 汇总与 trace availability 信息。CSV
 中的缺失值和 `null` 留空，`0` 与 `false` 原样保留；JSON 将每条基准测试观测数据与其

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -62,17 +62,20 @@ function installedState(destination, packageName) {
   if (!entry?.isFile()) return unknownState('SKILL.md is missing or not a regular file');
 
   let metadata;
+  let versionMatch;
   try {
     const metadataPath = join(destination, INSTALL_METADATA);
     const file = lstatSync(metadataPath, { throwIfNoEntry: false });
     if (!file) return unknownState('no installation metadata; legacy or manually copied skill');
     if (!file.isFile()) return unknownState('installation metadata is not a regular file');
     metadata = JSON.parse(readFileSync(metadataPath, 'utf8'));
-    if (
-      metadata?.package !== packageName ||
-      typeof metadata.version !== 'string' ||
-      !/^\d+\.\d+\.\d+(?:-[\dA-Za-z.-]+)?(?:\+[\dA-Za-z.-]+)?$/.test(metadata.version)
-    ) {
+    versionMatch =
+      typeof metadata?.version === 'string'
+        ? /^(?<major>\d+)\.(?<minor>\d+)\.\d+(?:-[\dA-Za-z.-]+)?(?:\+[\dA-Za-z.-]+)?$/.exec(
+            metadata.version,
+          )
+        : null;
+    if (metadata?.package !== packageName || !versionMatch) {
       return unknownState('invalid installation metadata');
     }
   } catch (error) {
@@ -81,27 +84,40 @@ function installedState(destination, packageName) {
       : unknownState(`could not read installation metadata: ${error.code ?? 'read error'}`);
   }
 
-  // Legacy installers retain this receipt when overwriting the skill with older files.
-  try {
-    const scripts = join(destination, 'scripts');
-    const exporter = join(scripts, 'export-powerx.mjs');
-    if (
-      !lstatSync(scripts, { throwIfNoEntry: false })?.isDirectory() ||
-      !lstatSync(exporter, { throwIfNoEntry: false })?.isFile()
-    ) {
-      return unknownState('installed exporter is missing or not a regular file');
+  // Pre-0.4 receipts predate AgentX. Ignore any newer file retained by an older
+  // merge-style forced install while continuing to validate their PowerX exporter.
+  const requiresAgentX =
+    BigInt(versionMatch.groups.major) > 0n || BigInt(versionMatch.groups.minor) >= 4n;
+  const exporters = [
+    { file: 'export-powerx.mjs', name: 'exporter' },
+    ...(requiresAgentX ? [{ file: 'export-agentx.mjs', name: 'AgentX exporter' }] : []),
+  ];
+  const scripts = join(destination, 'scripts');
+  for (const exporter of exporters) {
+    try {
+      const path = join(scripts, exporter.file);
+      if (
+        !lstatSync(scripts, { throwIfNoEntry: false })?.isDirectory() ||
+        !lstatSync(path, { throwIfNoEntry: false })?.isFile()
+      ) {
+        return unknownState(`installed ${exporter.name} is missing or not a regular file`);
+      }
+      const version = readFileSync(path, 'utf8').match(
+        /^const PACKAGE_VERSION = ['"](?<version>[^'"\r\n]+)['"];$/mu,
+      )?.groups.version;
+      if (!version) return unknownState(`installed ${exporter.name} version is missing`);
+      if (version !== metadata.version) {
+        return unknownState(
+          `installation metadata disagrees with the installed ${exporter.name} version`,
+        );
+      }
+    } catch (error) {
+      return unknownState(
+        `could not read installed ${exporter.name}: ${error.code ?? 'read error'}`,
+      );
     }
-    const version = readFileSync(exporter, 'utf8').match(
-      /^const PACKAGE_VERSION = ['"](?<version>[^'"\r\n]+)['"];$/mu,
-    )?.groups.version;
-    if (!version) return unknownState('installed exporter version is missing');
-    if (version !== metadata.version) {
-      return unknownState('installation metadata disagrees with the installed exporter version');
-    }
-    return { installation_state: 'installed', installed_version: metadata.version, reason: null };
-  } catch (error) {
-    return unknownState(`could not read installed exporter: ${error.code ?? 'read error'}`);
   }
+  return { installation_state: 'installed', installed_version: metadata.version, reason: null };
 }
 
 function statusRecord(destination, packageInfo) {

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -102,10 +102,15 @@ function installedState(destination, packageName) {
       ) {
         return unknownState(`installed ${exporter.name} is missing or not a regular file`);
       }
-      const version = readFileSync(path, 'utf8').match(
-        /^const PACKAGE_VERSION = ['"](?<version>[^'"\r\n]+)['"];$/mu,
-      )?.groups.version;
-      if (!version) return unknownState(`installed ${exporter.name} version is missing`);
+      const declarations = [
+        ...readFileSync(path, 'utf8').matchAll(
+          /^const PACKAGE_VERSION = ['"](?<version>[^'"\r\n]+)['"];$/gmu,
+        ),
+      ];
+      if (declarations.length !== 1) {
+        return unknownState(`installed ${exporter.name} version is missing`);
+      }
+      const version = declarations[0].groups.version;
       if (version !== metadata.version) {
         return unknownState(
           `installation metadata disagrees with the installed ${exporter.name} version`,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Install the InferenceX public API skill for Codex and Claude Code.",
   "keywords": [
     "agent-skills",
+    "agentx",
     "api",
     "benchmarks",
     "claude",

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -5,7 +5,7 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 
@@ -26,13 +26,34 @@ const releaseFiles = [
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
 ];
+const stableVersion = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
+
+function verifyIdentity(record) {
+  assert.equal(record.name, PACKAGE, 'Unexpected package name');
+  assert.match(record.version, stableVersion, 'Release version must be an exact stable version');
+  assert.equal(
+    record.filename,
+    `semianalysisai-inferencex-skills-${record.version}.tgz`,
+    'Archive filename differs from release version',
+  );
+}
+
+function sourceState() {
+  return {
+    commit: execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+    }).trim(),
+    dirty:
+      execFileSync('git', ['status', '--porcelain', '--', '.'], {
+        cwd: packageRoot,
+        encoding: 'utf8',
+      }).trim().length > 0,
+  };
+}
 
 export async function requireUnpublished(version, manifest, request = fetch) {
-  assert.match(
-    version,
-    /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u,
-    'Use an exact stable version',
-  );
+  assert.match(version, stableVersion, 'Use an exact stable version');
   assert.equal(manifest.name, PACKAGE, 'Unexpected package name');
   assert.equal(version, manifest.version, 'Requested version differs from package.json');
   const response = await request(`${REGISTRY}/${encodeURIComponent(PACKAGE)}/${version}`, {
@@ -48,8 +69,7 @@ export async function requireUnpublished(version, manifest, request = fetch) {
 }
 
 export function verifyArchive(record, bytes, reviewedSha256) {
-  assert.equal(record.name, PACKAGE, 'Unexpected package name');
-  assert.equal(record.filename, basename(record.filename), 'Archive must be beside its manifest');
+  verifyIdentity(record);
   verifyContents(record.files);
   assert.equal(record.source_dirty, false, 'Package source must be clean');
   assert.match(
@@ -58,12 +78,13 @@ export function verifyArchive(record, bytes, reviewedSha256) {
     'Source commit must be a canonical Git object ID',
   );
   assert.equal(typeof record.prepared_at, 'string', 'Preparation time must be a string');
-  assert.match(
+  const preparedAt = new Date(record.prepared_at);
+  assert.ok(Number.isFinite(preparedAt.valueOf()), 'Preparation time must be valid');
+  assert.equal(
     record.prepared_at,
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u,
-    'Preparation time must be a timezone-qualified timestamp',
+    preparedAt.toISOString(),
+    'Preparation time must be a canonical UTC timestamp',
   );
-  assert.ok(Number.isFinite(Date.parse(record.prepared_at)), 'Preparation time must be valid');
   assert.equal(digest(bytes), record.sha256, 'Archive SHA-256 differs from release manifest');
   assert.equal(
     `sha512-${digest(bytes, 'sha512', 'base64')}`,
@@ -86,6 +107,7 @@ function main(args) {
   const [command, value, output, reviewedSha256] = args;
   if (command === 'check' && args.length >= 2 && args.length <= 3) {
     const record = JSON.parse(readFileSync(value, 'utf8'));
+    verifyIdentity(record);
     verifyArchive(record, readFileSync(join(dirname(value), record.filename)), output);
     console.log(`Verified ${record.name}@${record.version}: ${record.sha256}`);
     return;
@@ -101,16 +123,8 @@ function main(args) {
 
 async function prepare(version, output, reviewedSha256) {
   const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
-  const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
-    cwd: packageRoot,
-    encoding: 'utf8',
-  }).trim();
-  const sourceDirty =
-    execFileSync('git', ['status', '--porcelain', '--', '.'], {
-      cwd: packageRoot,
-      encoding: 'utf8',
-    }).trim().length > 0;
-  assert.equal(sourceDirty, false, 'Package source must be clean before preparing a release');
+  const source = sourceState();
+  assert.equal(source.dirty, false, 'Package source must be clean before preparing a release');
   await requireUnpublished(version, manifest);
   const destination = resolve(output);
   // A new directory preserves earlier attempts, including failures.
@@ -123,10 +137,12 @@ async function prepare(version, output, reviewedSha256) {
   );
   assert.equal(packed.length, 1, 'Expected exactly one archive');
   const [archive] = packed;
-  assert.equal(archive.name, PACKAGE);
-  assert.equal(archive.version, version);
+  verifyIdentity(archive);
   verifyContents(archive.files.map((file) => file.path));
   const bytes = readFileSync(join(destination, archive.filename));
+  const packedSource = sourceState();
+  assert.equal(packedSource.commit, source.commit, 'Package source commit changed while packing');
+  assert.equal(packedSource.dirty, false, 'Package source changed while packing');
   const record = {
     name: PACKAGE,
     version,
@@ -134,8 +150,8 @@ async function prepare(version, output, reviewedSha256) {
     sha256: digest(bytes),
     integrity: archive.integrity,
     files: archive.files.map((file) => file.path),
-    source_commit: sourceCommit,
-    source_dirty: sourceDirty,
+    source_commit: source.commit,
+    source_dirty: source.dirty,
     prepared_at: new Date().toISOString(),
   };
   verifyArchive(record, bytes, reviewedSha256);

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -14,6 +14,18 @@ export const REGISTRY = 'https://registry.npmjs.org';
 const packageRoot = resolve(import.meta.dirname, '..');
 const digest = (bytes, algorithm = 'sha256', encoding = 'hex') =>
   createHash(algorithm).update(bytes).digest(encoding);
+const releaseFiles = [
+  'LICENSE',
+  'README.md',
+  'bin/install.mjs',
+  'package.json',
+  'skills/inferencex-api/SKILL.md',
+  'skills/inferencex-api/references/agentx.md',
+  'skills/inferencex-api/references/powerx.md',
+  'skills/inferencex-api/references/public-api-examples.md',
+  'skills/inferencex-api/scripts/export-agentx.mjs',
+  'skills/inferencex-api/scripts/export-powerx.mjs',
+];
 
 export async function requireUnpublished(version, manifest, request = fetch) {
   assert.match(
@@ -38,6 +50,20 @@ export async function requireUnpublished(version, manifest, request = fetch) {
 export function verifyArchive(record, bytes, reviewedSha256) {
   assert.equal(record.name, PACKAGE, 'Unexpected package name');
   assert.equal(record.filename, basename(record.filename), 'Archive must be beside its manifest');
+  verifyContents(record.files);
+  assert.equal(record.source_dirty, false, 'Package source must be clean');
+  assert.match(
+    record.source_commit,
+    /^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u,
+    'Source commit must be a canonical Git object ID',
+  );
+  assert.equal(typeof record.prepared_at, 'string', 'Preparation time must be a string');
+  assert.match(
+    record.prepared_at,
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u,
+    'Preparation time must be a timezone-qualified timestamp',
+  );
+  assert.ok(Number.isFinite(Date.parse(record.prepared_at)), 'Preparation time must be valid');
   assert.equal(digest(bytes), record.sha256, 'Archive SHA-256 differs from release manifest');
   assert.equal(
     `sha512-${digest(bytes, 'sha512', 'base64')}`,
@@ -51,24 +77,9 @@ export function verifyArchive(record, bytes, reviewedSha256) {
 }
 
 export function verifyContents(files) {
-  const required = [
-    'package.json',
-    'README.md',
-    'LICENSE',
-    'bin/install.mjs',
-    'skills/inferencex-api/SKILL.md',
-  ];
-  for (const path of required) assert.ok(files.includes(path), `Archive is missing ${path}`);
-  for (const path of files) {
-    assert.ok(
-      !path.split('/').some((part) => part.startsWith('.')),
-      `Unexpected hidden file: ${path}`,
-    );
-    assert.ok(
-      required.includes(path) || path.startsWith('skills/inferencex-api/'),
-      `Maintainer files must not enter the public archive: ${path}`,
-    );
-  }
+  assert.ok(Array.isArray(files), 'Archive file list is missing');
+  assert.equal(new Set(files).size, files.length, 'Archive file list contains duplicates');
+  assert.deepEqual([...files].sort(), [...releaseFiles].sort(), 'Archive file list differs');
 }
 
 function main(args) {
@@ -90,6 +101,16 @@ function main(args) {
 
 async function prepare(version, output, reviewedSha256) {
   const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+  const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  }).trim();
+  const sourceDirty =
+    execFileSync('git', ['status', '--porcelain', '--', '.'], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+    }).trim().length > 0;
+  assert.equal(sourceDirty, false, 'Package source must be clean before preparing a release');
   await requireUnpublished(version, manifest);
   const destination = resolve(output);
   // A new directory preserves earlier attempts, including failures.
@@ -113,15 +134,8 @@ async function prepare(version, output, reviewedSha256) {
     sha256: digest(bytes),
     integrity: archive.integrity,
     files: archive.files.map((file) => file.path),
-    source_commit: execFileSync('git', ['rev-parse', 'HEAD'], {
-      cwd: packageRoot,
-      encoding: 'utf8',
-    }).trim(),
-    source_dirty:
-      execFileSync('git', ['status', '--porcelain', '--', '.'], {
-        cwd: packageRoot,
-        encoding: 'utf8',
-      }).trim().length > 0,
+    source_commit: sourceCommit,
+    source_dirty: sourceDirty,
     prepared_at: new Date().toISOString(),
   };
   verifyArchive(record, bytes, reviewedSha256);

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -27,6 +27,10 @@ from urllib.request import ProxyHandler, Request, build_opener
 PACKAGE = '@semianalysisai/inferencex-skills'
 REGISTRY = 'https://registry.npmjs.org'
 API = 'https://inferencex.semianalysis.com/api/v1/benchmarks'
+AGENTX_ORIGIN = 'https://inferencex.semianalysis.com'
+AGENTX_API = AGENTX_ORIGIN + '/api/v1/benchmarks'
+AGENTX_EXCLUDED_RAW_MODEL = '__inferencex_release_verification_no_match__'
+MAX_SAFE_INTEGER = 9_007_199_254_740_991
 # Only the exact-version npm ETARGET propagation symptom is retryable. No HTTP,
 # publication, data-validation, or candidate-install retries.
 PUBLIC_INSTALL_ATTEMPTS = 3
@@ -43,6 +47,37 @@ workflow_run_id run_started_at run_url curve_date curve_workflow_run_id curve_ru
 power_valid power_metric_schema_version avg_power_w prefill_avg_power_w decode_avg_power_w
 joules_per_successful_query joules_per_input_token joules_per_output_token joules_per_total_token
 prefill_joules_per_input_token decode_joules_per_output_token avg_temp_c peak_temp_c avg_util_pct avg_mem_used_mb'''.split()
+AGENTX_FILTERS = (
+    ('raw_model', 'model'), ('hardware', 'hardware'), ('framework', 'framework'),
+    ('precision', 'precision'), ('spec_method', 'spec_method'),
+    ('offload_mode', 'offload_mode'), ('concurrency', 'conc'))
+AGENTX_GROUPS = ('isl', 'osl', 'kvCacheUtil', 'prefixCacheHitRate')
+AGENTX_PERCENTILES = ('mean', 'p50', 'p75', 'p90', 'p95', 'p99')
+AGENTX_CONTEXT_COLUMNS = '''package_version query_url retrieved_at requested_model requested_date
+date_selection requested_benchmark_type filter.raw_model filter.hardware filter.framework filter.precision
+filter.spec_method filter.offload_mode filter.concurrency'''.split()
+AGENTX_BENCHMARK_COLUMNS = '''id model hardware framework image precision spec_method benchmark_type conc
+offload_mode recipe_fingerprint disagg is_multinode prefill_tp prefill_ep prefill_dp_attention
+prefill_num_workers decode_tp decode_ep decode_dp_attention decode_num_workers num_prefill_gpu
+num_decode_gpu isl osl date workflow_run_id run_started_at run_url curve_date curve_workflow_run_id
+curve_run_started_at'''.split()
+AGENTX_ENRICHMENT_COLUMNS = [
+    *[f'aggregate.{group}.{field}' for group in AGENTX_GROUPS for field in (*AGENTX_PERCENTILES, 'n')],
+    'derived.p75_e2e_norm_intvty', 'derived.p90_e2e_norm_intvty', 'trace.available',
+    'trace.response_key_present', 'enrichment.status', 'enrichment.aggregates_status',
+    'enrichment.derived_metrics_status', 'enrichment.trace_availability_status']
+AGENTX_REQUIRED_STRINGS = ('hardware', 'framework', 'model', 'precision', 'spec_method',
+                           'benchmark_type', 'offload_mode', 'date')
+AGENTX_REQUIRED_BOOLEANS = ('disagg', 'is_multinode', 'prefill_dp_attention', 'decode_dp_attention')
+AGENTX_REQUIRED_INTEGERS = ('prefill_tp', 'prefill_ep', 'prefill_num_workers', 'decode_tp', 'decode_ep',
+                            'decode_num_workers', 'num_prefill_gpu', 'num_decode_gpu', 'conc')
+POINT_OPERATIONS = (
+    ('openapi', '/api/openapi.json', None),
+    ('benchmark-siblings', '/api/v1/benchmark-siblings', 'id'),
+    ('trace-availability', '/api/v1/trace-availability', 'ids'),
+    ('request-timeline', '/api/v1/request-timeline', 'id'),
+    ('trace-histograms', '/api/v1/trace-histograms', 'ids'),
+    ('trace-server-metrics', '/api/v1/trace-server-metrics', 'id'))
 
 
 def now():
@@ -365,6 +400,638 @@ def check_empty_diagnostic(diagnostic, empty_metadata, returned_rows, args):
             and detail['measurement_counts'] == {'some_recorded': 0, 'missing': 0}, 'Diagnostic counts differ')
 
 
+def timestamp(value, message):
+    require(type(value) is str, message)
+    try:
+        parsed = datetime.fromisoformat(value.replace('Z', '+00:00'))
+    except ValueError as error:
+        raise ValueError(message) from error
+    require(parsed.tzinfo is not None, message)
+    return parsed
+
+
+def integer(value):
+    return finite(value) and float(value).is_integer()
+
+
+def safe_result_id(value):
+    if finite(value) and integer(value):
+        number = int(value)
+        return number if 0 < number <= MAX_SAFE_INTEGER else None
+    if type(value) is not str or re.fullmatch(r'[1-9]\d*', value) is None:
+        return None
+    number = int(value)
+    return number if number <= MAX_SAFE_INTEGER and str(number) == value else None
+
+
+def js_text(value):
+    if type(value) is bool:
+        return str(value).lower()
+    if integer(value):
+        return str(int(value))
+    return str(value)
+
+
+def js_sorted(values):
+    unique = []
+    for value in values:
+        if not any(type(value) is type(item) and value == item for item in unique):
+            unique.append(value)
+    return sorted(unique, key=lambda value: js_text(value).encode('utf-16-be', errors='surrogatepass'))
+
+
+def strict_json(body):
+    def reject(value):
+        raise ValueError(f'Non-standard JSON number: {value}')
+    return json.loads(body.decode('utf-8-sig'), parse_constant=reject)
+
+
+def same_json(actual, expected):
+    if finite(actual) and finite(expected):
+        return actual == expected
+    if type(actual) is not type(expected):
+        return False
+    if type(actual) is dict:
+        return actual.keys() == expected.keys() and all(same_json(actual[key], expected[key]) for key in actual)
+    if type(actual) is list:
+        return len(actual) == len(expected) and all(same_json(a, b) for a, b in zip(actual, expected))
+    return actual == expected
+
+
+def agentx_benchmark(row):
+    if type(row) is not dict or 'id' not in row or \
+            type(row['id']) is not str and safe_result_id(row['id']) is None:
+        return False
+    if not all(type(row.get(key)) is str for key in AGENTX_REQUIRED_STRINGS):
+        return False
+    if not all(type(row.get(key)) is bool for key in AGENTX_REQUIRED_BOOLEANS):
+        return False
+    if not all(integer(row.get(key)) for key in AGENTX_REQUIRED_INTEGERS):
+        return False
+    if not all(row.get(key) is None or finite(row.get(key)) for key in ('isl', 'osl')):
+        return False
+    if not all(row.get(key) is None or type(row.get(key)) is str for key in ('image', 'recipe_fingerprint', 'run_url')):
+        return False
+    if type(row.get('metrics')) is not dict:
+        return False
+    try:
+        return datetime.strptime(row['date'], '%Y-%m-%d').strftime('%Y-%m-%d') == row['date']
+    except ValueError:
+        return False
+
+
+def sanitized(value):
+    if type(value) is float and not math.isfinite(value):
+        return None, 1
+    if type(value) is list:
+        result, count = [], 0
+        for item in value:
+            clean, changed = sanitized(item)
+            result.append(clean)
+            count += changed
+        return result, count
+    if type(value) is dict:
+        result, count = {}, 0
+        for key, item in value.items():
+            clean, changed = sanitized(item)
+            result[key] = clean
+            count += changed
+        return result, count
+    return value, 0
+
+
+def agentx_scope(args, excluded=False):
+    raw_model = AGENTX_EXCLUDED_RAW_MODEL if excluded else None
+    requested = {
+        'display_model': args.agentx_model, 'date': None, 'date_selection': 'latest',
+        'raw_model': raw_model, 'hardware': None, 'framework': None, 'precision': None,
+        'spec_method': None, 'offload_mode': None, 'concurrency': None,
+        'benchmark_type': 'agentic_traces'}
+    applied = {
+        'display_model': {'status': 'applied', 'value': args.agentx_model},
+        'date': {'status': 'omitted', 'value': None},
+        'benchmark_type': {'status': 'applied', 'value': 'agentic_traces'}}
+    applied.update({name: {'status': 'applied' if value is not None else 'omitted', 'value': value}
+                    for name, value in ((name, requested[name]) for name, _field in AGENTX_FILTERS)})
+    filters = {name: applied[name] for name, _field in AGENTX_FILTERS}
+    return requested, applied, filters
+
+
+def agentx_response(evidence, record, number, operation, expected_url, chunk):
+    require(set(record) == {'operation', 'request_number', 'url', 'method', 'retrieved_at', 'http_status',
+                            'decoded_body_sha256', 'body_file', 'requested_chunk_ids', 'checksum_covers'},
+            f'AgentX response manifest is incomplete: {number}')
+    expected_file = f'response-{number:04d}-{operation}.json'
+    require(record['operation'] == operation and type(record['request_number']) is int and
+            record['request_number'] == number and record['method'] == 'GET' and
+            type(record['http_status']) is int and record['http_status'] == 200 and
+            same_json(record['requested_chunk_ids'], chunk) and record['body_file'] == expected_file and
+            record['checksum_covers'] == 'saved decoded response body' and
+            same_url(record['url'], expected_url), f'AgentX response identity differs: {number}')
+    timestamp(record['retrieved_at'], f'AgentX response time is invalid: {number}')
+    body = (evidence / expected_file).read_bytes()
+    require(hashlib.sha256(body).hexdigest() == record['decoded_body_sha256'],
+            f'AgentX response checksum differs: {number}')
+    return strict_json(body)
+
+
+def agentx_map(value, requested_ids, operation):
+    require(type(value) is dict, f'Unexpected {operation} response shape')
+    requested = set(requested_ids)
+    result = {}
+    for key, entry in value.items():
+        result_id = safe_result_id(key)
+        require(result_id is not None and str(result_id) == key and result_id in requested,
+                f'Unexpected {operation} result ID: {key}')
+        if operation == 'agentic-aggregates':
+            valid = type(entry) is dict and integer(entry.get('id')) and int(entry['id']) == result_id
+            for group in AGENTX_GROUPS:
+                group_value = entry.get(group)
+                valid = valid and group in entry and (group_value is None or
+                    type(group_value) is dict and
+                    all(finite(group_value.get(field)) for field in AGENTX_PERCENTILES) and
+                    integer(group_value.get('n')) and group_value['n'] >= 0)
+        elif operation == 'derived-agentic-metrics':
+            valid = type(entry) is dict and integer(entry.get('id')) and int(entry['id']) == result_id and all(
+                field in entry and (entry[field] is None or finite(entry[field]))
+                for field in ('p75_e2e_norm_intvty', 'p90_e2e_norm_intvty'))
+        else:
+            valid = type(entry) is bool
+        require(valid, f'Unexpected {operation} response shape for result ID: {key}')
+        result[result_id] = entry
+    return result
+
+
+def agentx_coverage(rows):
+    supported = [row for row in rows if row['agentx']['status'] != 'unsupported_id']
+    unsupported = len(rows) - len(supported)
+    aggregates = {}
+    for group in AGENTX_GROUPS:
+        aggregates[group] = {
+            'available_rows': sum(row['agentx']['aggregates']['status'] == 'available' and
+                                  row['agentx']['aggregates']['value'][group] is not None for row in supported),
+            'null_rows': sum(row['agentx']['aggregates']['status'] == 'available' and
+                             row['agentx']['aggregates']['value'][group] is None for row in supported),
+            'missing_entry_rows': sum(row['agentx']['aggregates']['status'] == 'not_returned' for row in supported),
+            'unsupported_id_rows': unsupported}
+    return {
+        'safe_id_rows': len(supported), 'unsupported_id_rows': unsupported,
+        'unique_safe_ids': len({row['agentx']['result_id'] for row in supported}),
+        'aggregates': aggregates,
+        'derived_metrics': {
+            'available_rows': sum(row['agentx']['derived_metrics']['status'] == 'available' for row in supported),
+            'missing_entry_rows': sum(row['agentx']['derived_metrics']['status'] == 'not_returned' for row in supported),
+            'unsupported_id_rows': unsupported},
+        'trace_availability': {
+            'stored_trace_rows': sum(row['agentx']['trace_availability']['value'] is True for row in supported),
+            'no_stored_trace_rows': sum(row['agentx']['trace_availability']['value'] is False for row in supported),
+            'response_key_rows': sum(row['agentx']['trace_availability']['response_key_present'] for row in supported),
+            'missing_key_rows': sum(not row['agentx']['trace_availability']['response_key_present'] for row in supported),
+            'unsupported_id_rows': unsupported}}
+
+
+def check_agentx_cell(cell, value, location):
+    if value is None:
+        require(cell == '', f'AgentX CSV value mismatch: {location}')
+    elif type(value) is bool:
+        require(cell == str(value).lower(), f'AgentX CSV value mismatch: {location}')
+    elif integer(value):
+        require(cell == str(int(value)), f'AgentX CSV value mismatch: {location}')
+    elif finite(value):
+        try:
+            equal = float(cell) == value
+        except ValueError:
+            equal = False
+        require(equal, f'AgentX CSV value mismatch: {location}')
+    else:
+        require(cell == str(value), f'AgentX CSV value mismatch: {location}')
+
+
+def check_agentx_capture(project, name, output, args, version, excluded=False):
+    evidence = project / name
+    capture = strict_json((evidence / 'manifest.json').read_bytes())
+    require(set(capture) == {'schema_version', 'package_version', 'status', 'started_at', 'finished_at',
+                            'outcome', 'requested_filters', 'applied_filters', 'counts', 'responses',
+                            'export', 'error'} and type(capture['schema_version']) is int and capture['schema_version'] == 1 and
+            capture['package_version'] == version and capture['status'] == 'complete' and capture['error'] is None,
+            'AgentX evidence manifest is incomplete or belongs to another version')
+    started = timestamp(capture['started_at'], 'AgentX evidence start time is invalid')
+    finished = timestamp(capture['finished_at'], 'AgentX evidence finish time is invalid')
+    require(finished >= started, 'AgentX evidence times are reversed')
+    requested, applied, filters = agentx_scope(args, excluded)
+    require(capture['requested_filters'] == requested and capture['applied_filters'] == applied,
+            'AgentX evidence filters differ')
+    responses = capture['responses']
+    require(type(responses) is list and responses, 'AgentX evidence has no complete response')
+    benchmark_url = AGENTX_API + '?' + urlencode({'model': args.agentx_model})
+    benchmarks = agentx_response(evidence, responses[0], 1, 'benchmarks', benchmark_url, None)
+    require(type(benchmarks) is list and all(agentx_benchmark(row) for row in benchmarks),
+            'Unexpected AgentX benchmark response shape')
+    agentx_rows = [row for row in benchmarks if row['benchmark_type'] == 'agentic_traces']
+    selected = [row for row in agentx_rows if all(requested[name] is None or row[field] == requested[name]
+                                                  for name, field in AGENTX_FILTERS)]
+    ids = []
+    for row in selected:
+        result_id = safe_result_id(row['id'])
+        if result_id is not None and result_id not in ids:
+            ids.append(result_id)
+    specs = [('benchmarks', benchmark_url, None)]
+    for operation, limit in (('agentic-aggregates', 200), ('derived-agentic-metrics', 200),
+                             ('trace-availability', 500)):
+        for offset in range(0, len(ids), limit):
+            chunk = ids[offset:offset + limit]
+            specs.append((operation, AGENTX_ORIGIN + f'/api/v1/{operation}?' +
+                          urlencode({'ids': ','.join(map(str, chunk))}), chunk))
+    require(len(responses) == len(specs), 'AgentX evidence response count differs from exact chunks')
+    joined = {operation: {} for operation in ('agentic-aggregates', 'derived-agentic-metrics', 'trace-availability')}
+    for number, (record, (operation, url, chunk)) in enumerate(zip(responses, specs), 1):
+        body = benchmarks if number == 1 else agentx_response(evidence, record, number, operation, url, chunk)
+        if number > 1:
+            joined[operation].update(agentx_map(body, chunk, operation))
+    actual_files = {str(path.relative_to(evidence)) for path in evidence.rglob('*') if path.is_file()}
+    expected_files = {'manifest.json', *(record['body_file'] for record in responses)}
+    require(actual_files == expected_files, 'Unexpected or missing AgentX evidence files')
+
+    rows, non_finite = [], 0
+    for row in selected:
+        benchmark, changed = sanitized(row)
+        non_finite += changed
+        result_id = safe_result_id(row['id'])
+        if result_id is None:
+            agentx = {
+                'status': 'unsupported_id', 'result_id': None,
+                'aggregates': {'status': 'unsupported_id', 'value': None},
+                'derived_metrics': {'status': 'unsupported_id', 'value': None},
+                'trace_availability': {'status': 'unsupported_id', 'value': None,
+                                       'response_key_present': None}}
+        else:
+            has_aggregates = result_id in joined['agentic-aggregates']
+            has_derived = result_id in joined['derived-agentic-metrics']
+            has_trace = result_id in joined['trace-availability']
+            available = joined['trace-availability'].get(result_id, False)
+            agentx = {
+                'status': 'complete' if has_aggregates and has_derived else 'partial',
+                'result_id': result_id,
+                'aggregates': {'status': 'available' if has_aggregates else 'not_returned',
+                               'value': joined['agentic-aggregates'].get(result_id)},
+                'derived_metrics': {'status': 'available' if has_derived else 'not_returned',
+                                    'value': joined['derived-agentic-metrics'].get(result_id)},
+                'trace_availability': {'status': 'stored_trace' if available else 'no_stored_trace',
+                                       'value': available, 'response_key_present': has_trace}}
+        rows.append({'benchmark': benchmark, 'agentx': agentx})
+    outcome = 'no_agentx_rows' if not agentx_rows else 'no_matching_rows' if not selected else 'selected_rows'
+    counts = {'returned_rows': len(benchmarks), 'returned_agentx_rows': len(agentx_rows),
+              'selected_rows': len(selected)}
+    require(capture['outcome'] == outcome and capture['counts'] == counts and
+            all(type(value) is int for value in capture['counts'].values()),
+            'AgentX evidence outcome or counts differ')
+    export = capture['export']
+    require(set(export) == {'format', 'destination', 'sha256', 'metadata', 'source_request_numbers'},
+            'AgentX export manifest is incomplete')
+    output_path = project / output
+    output_bytes = output_path.read_bytes()
+    expected_format = output_path.suffix.removeprefix('.')
+    require(export['format'] == expected_format and Path(export['destination']).is_absolute() and
+            Path(export['destination']).resolve() == output_path.resolve() and
+            export['sha256'] == hashlib.sha256(output_bytes).hexdigest() and
+            export['source_request_numbers'] == list(range(1, len(responses) + 1)) and
+            all(type(value) is int for value in export['source_request_numbers']),
+            'AgentX export link differs')
+    retrieved_at = export['metadata'].get('retrieved_at') if type(export['metadata']) is dict else None
+    retrieved = timestamp(retrieved_at, 'AgentX export retrieval time is invalid')
+    require(all(retrieved >= timestamp(record['retrieved_at'], 'AgentX response time is invalid')
+                for record in responses), 'AgentX export time predates a response')
+    require(finished >= retrieved and all(started <= timestamp(record['retrieved_at'], 'AgentX response time is invalid')
+                                          <= finished for record in responses),
+            'AgentX evidence times do not cover the requests and export')
+    available_values = {
+        'raw_model': js_sorted(row['model'] for row in agentx_rows),
+        'hardware': js_sorted(row['hardware'] for row in agentx_rows),
+        'framework': js_sorted(row['framework'] for row in agentx_rows),
+        'precision': js_sorted(row['precision'] for row in agentx_rows),
+        'spec_method': js_sorted(row['spec_method'] for row in agentx_rows),
+        'offload_mode': js_sorted(row['offload_mode'] for row in agentx_rows),
+        'concurrency': js_sorted(row['conc'] for row in agentx_rows)}
+    metadata = {
+        'package_version': version, 'retrieved_at': retrieved_at,
+        'request_urls': [{'operation': record['operation'], 'url': record['url']} for record in responses],
+        'requested_scope': requested, 'filters': filters, 'outcome': outcome,
+        **counts, 'available_filter_values': available_values,
+        'returned_model_keys': js_sorted(row['model'] for row in benchmarks),
+        'selected_model_keys': js_sorted(row['model'] for row in selected),
+        'enrichment_coverage': agentx_coverage(rows), 'non_finite_values': non_finite,
+        'observation_context': 'Existing observations were read; no new benchmark was run.'}
+    require(same_json(export['metadata'], metadata), 'AgentX export metadata differs from complete responses')
+    if expected_format == 'json':
+        document = strict_json(output_bytes)
+        require(set(document) == {'schema_version', 'metadata', 'rows'} and
+                type(document['schema_version']) is int and document['schema_version'] == 1 and
+                same_json(document['metadata'], metadata) and same_json(document['rows'], rows),
+                'AgentX JSON differs from complete responses')
+    else:
+        require(output_bytes.endswith(b'\r\n') and output_bytes.count(b'\n') == output_bytes.count(b'\r\n'),
+                'AgentX CSV must use CRLF records')
+        metric_columns = js_sorted(f'metrics.{key}' for row in rows for key, value in row['benchmark']['metrics'].items()
+                                   if value is None or type(value) in (str, int, float, bool))
+        columns = [*AGENTX_CONTEXT_COLUMNS, *AGENTX_BENCHMARK_COLUMNS, *metric_columns,
+                   *AGENTX_ENRICHMENT_COLUMNS]
+        with io.StringIO(output_bytes.decode()) as handle:
+            reader = csv.DictReader(handle)
+            require(reader.fieldnames == columns, 'AgentX CSV header differs from published contract')
+            records = list(reader)
+        require(len(records) == len(rows), 'AgentX CSV row count differs from complete response')
+        context = {
+            'package_version': version, 'query_url': responses[0]['url'], 'retrieved_at': retrieved_at,
+            'requested_model': args.agentx_model, 'requested_date': None, 'date_selection': 'latest',
+            'requested_benchmark_type': 'agentic_traces',
+            **{f'filter.{name}': requested[name] for name, _field in AGENTX_FILTERS}}
+        for record, row in zip(records, rows):
+            benchmark, agentx = row['benchmark'], row['agentx']
+            values = {**context, **{field: benchmark.get(field) for field in AGENTX_BENCHMARK_COLUMNS}}
+            values.update({column: benchmark['metrics'].get(column.removeprefix('metrics.'))
+                           if benchmark['metrics'].get(column.removeprefix('metrics.')) is None or
+                           type(benchmark['metrics'].get(column.removeprefix('metrics.'))) in (str, int, float, bool)
+                           else None for column in metric_columns})
+            for group in AGENTX_GROUPS:
+                for field in (*AGENTX_PERCENTILES, 'n'):
+                    group_value = (agentx['aggregates']['value'] or {}).get(group)
+                    values[f'aggregate.{group}.{field}'] = None if group_value is None else group_value.get(field)
+            derived = agentx['derived_metrics']['value'] or {}
+            values.update({
+                'derived.p75_e2e_norm_intvty': derived.get('p75_e2e_norm_intvty'),
+                'derived.p90_e2e_norm_intvty': derived.get('p90_e2e_norm_intvty'),
+                'trace.available': agentx['trace_availability']['value'],
+                'trace.response_key_present': agentx['trace_availability']['response_key_present'],
+                'enrichment.status': agentx['status'],
+                'enrichment.aggregates_status': agentx['aggregates']['status'],
+                'enrichment.derived_metrics_status': agentx['derived_metrics']['status'],
+                'enrichment.trace_availability_status': agentx['trace_availability']['status']})
+            for column in columns:
+                check_agentx_cell(record[column], values.get(column), f'{benchmark["id"]}/{column}')
+    require((outcome == 'no_matching_rows' and len(agentx_rows) > 0) if excluded else len(rows) > 0,
+            'AgentX verification scope no longer exercises the intended selection')
+    return {'selected_rows': len(rows), 'outcome': outcome, 'enrichment_coverage': metadata['enrichment_coverage']}
+
+
+POINT_CAPTURE_PRELOAD = r"""import { createHash } from 'node:crypto';
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const directory = process.env.INFERENCEX_POINT_EVIDENCE;
+const selectedResultId = process.env.INFERENCEX_POINT_ID;
+const destination = process.env.INFERENCEX_POINT_OUTPUT;
+const operations = new Map([
+  ['/api/openapi.json', 'openapi'],
+  ['/api/v1/benchmark-siblings', 'benchmark-siblings'],
+  ['/api/v1/trace-availability', 'trace-availability'],
+  ['/api/v1/request-timeline', 'request-timeline'],
+  ['/api/v1/trace-histograms', 'trace-histograms'],
+  ['/api/v1/trace-server-metrics', 'trace-server-metrics'],
+]);
+const manifest = {
+  schema_version: 1,
+  package_version: process.env.INFERENCEX_PACKAGE_VERSION,
+  selected_result_id: selectedResultId,
+  status: 'pending',
+  started_at: new Date().toISOString(),
+  finished_at: null,
+  responses: [],
+  output: { format: 'json', destination, sha256: null, source_request_numbers: [] },
+  error: null,
+};
+mkdirSync(directory);
+function save() {
+  const temporary = join(directory, 'manifest.tmp');
+  writeFileSync(temporary, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  renameSync(temporary, join(directory, 'manifest.json'));
+}
+save();
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async (input, init) => {
+  const url = new URL(input instanceof Request ? input.url : input).href;
+  const operation = operations.get(new URL(url).pathname);
+  if (!operation) throw new Error(`Unexpected point diagnostic request: ${url}`);
+  const response = await originalFetch(input, init);
+  const bytes = Buffer.from(await response.clone().arrayBuffer());
+  const requestNumber = manifest.responses.length + 1;
+  const bodyFile = `response-${String(requestNumber).padStart(4, '0')}-${operation}.json`;
+  writeFileSync(join(directory, bodyFile), bytes, { flag: 'wx' });
+  manifest.responses.push({
+    operation,
+    request_number: requestNumber,
+    url,
+    method: 'GET',
+    retrieved_at: new Date().toISOString(),
+    http_status: response.status,
+    decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
+    body_file: bodyFile,
+    checksum_covers: 'saved decoded response body',
+  });
+  save();
+  return response;
+};
+"""
+
+
+def point_url(path, parameter, selected_id):
+    return AGENTX_ORIGIN + path + ('' if parameter is None else '?' + urlencode({parameter: selected_id}))
+
+
+def point_response(evidence, record, number, operation, expected_url):
+    require(set(record) == {'operation', 'request_number', 'url', 'method', 'retrieved_at', 'http_status',
+                            'decoded_body_sha256', 'body_file', 'checksum_covers'},
+            f'Point response manifest is incomplete: {number}')
+    expected_file = f'response-{number:04d}-{operation}.json'
+    require(record['operation'] == operation and type(record['request_number']) is int and
+            record['request_number'] == number and record['method'] == 'GET' and
+            type(record['http_status']) is int and record['http_status'] == 200 and
+            record['body_file'] == expected_file and
+            record['checksum_covers'] == 'saved decoded response body' and
+            same_url(record['url'], expected_url), f'Point response identity differs: {number}')
+    timestamp(record['retrieved_at'], f'Point response time is invalid: {number}')
+    body = (evidence / expected_file).read_bytes()
+    require(hashlib.sha256(body).hexdigest() == record['decoded_body_sha256'],
+            f'Point response checksum differs: {number}')
+    return strict_json(body)
+
+
+def check_point_shapes(selected_id, timeline, histograms, server_metrics):
+    require(type(timeline) is dict and integer(timeline.get('version')) and integer(timeline.get('startNs')) and
+            integer(timeline.get('endNs')) and finite(timeline.get('durationS')) and
+            type(timeline.get('requests')) is list, 'Unexpected request timeline response')
+    for request in timeline['requests']:
+        valid = type(request) is dict and all(key in request for key in (
+            'cid', 'ti', 'wid', 'ad', 'phase', 'credit', 'start', 'ack', 'end', 'ttftMs', 'tpotMs',
+            'isl', 'osl', 'cancelled')) and type(request.get('cid')) is str and integer(request.get('ti')) and \
+            type(request.get('wid')) is str and integer(request.get('ad')) and type(request.get('phase')) is str and \
+            integer(request.get('credit')) and integer(request.get('start')) and \
+            (request.get('ack') is None or finite(request.get('ack'))) and integer(request.get('end')) and \
+            (request.get('ttftMs') is None or finite(request.get('ttftMs'))) and \
+            (request.get('tpotMs') is None or finite(request.get('tpotMs'))) and \
+            (request.get('isl') is None or finite(request.get('isl'))) and \
+            (request.get('osl') is None or finite(request.get('osl'))) and type(request.get('cancelled')) is bool
+        valid = valid and ('ri' not in request or integer(request['ri'])) and \
+            ('srcTrace' not in request or type(request['srcTrace']) is str) and \
+            ('srcOuter' not in request or integer(request['srcOuter'])) and \
+            ('srcInner' not in request or integer(request['srcInner'])) and \
+            ('srcKind' not in request or type(request['srcKind']) is str)
+        require(valid, 'Unexpected request timeline response')
+    require(type(histograms) is dict and set(histograms) == {selected_id},
+            'Unexpected one-result trace histogram response')
+    histogram = histograms[selected_id]
+    require(type(histogram) is dict and integer(histogram.get('id')) and int(histogram['id']) == int(selected_id) and
+            type(histogram.get('isl')) is list and all(finite(value) for value in histogram['isl']) and
+            type(histogram.get('osl')) is list and all(finite(value) for value in histogram['osl']),
+            'Unexpected one-result trace histogram response')
+    series = ('kvCacheUsage', 'prefixCacheHitRate', 'queueDepth', 'prefillTps', 'decodeTps',
+              'prefixCacheHitsTps', 'hostKvCacheUsage', 'kvCacheUsageByEngine')
+    valid_server = type(server_metrics) is dict and type(server_metrics.get('meta')) is dict and \
+        integer(server_metrics.get('startNs')) and integer(server_metrics.get('endNs')) and \
+        finite(server_metrics.get('durationS')) and integer(server_metrics.get('timeslicesCount')) and \
+        server_metrics['timeslicesCount'] >= 0 and all(type(server_metrics.get(key)) is list and
+        all(type(entry) is dict for entry in server_metrics[key]) for key in series) and \
+        type(server_metrics.get('promptTokensBySource')) is dict and all(type(entries) is list and
+        all(type(entry) is dict for entry in entries) for entries in server_metrics['promptTokensBySource'].values()) and \
+        'kvCachePoolTokens' in server_metrics and \
+        (server_metrics.get('kvCachePoolTokens') is None or finite(server_metrics.get('kvCachePoolTokens'))) and \
+        type(server_metrics.get('metricSources')) is list and \
+        all(type(entry) is dict for entry in server_metrics['metricSources'])
+    valid_server = valid_server and ('id' not in server_metrics['meta'] or
+                                     integer(server_metrics['meta']['id']) and
+                                     int(server_metrics['meta']['id']) == int(selected_id))
+    require(valid_server, 'Unexpected aggregate server metrics response')
+
+
+def check_agentx_point(project, name, output, selected_id, version):
+    require(type(selected_id) is str and safe_result_id(selected_id) is not None and
+            str(safe_result_id(selected_id)) == selected_id, 'Point result ID must be a canonical safe integer string')
+    evidence = project / name
+    capture = strict_json((evidence / 'manifest.json').read_bytes())
+    require(set(capture) == {'schema_version', 'package_version', 'selected_result_id', 'status', 'started_at',
+                            'finished_at', 'responses', 'output', 'error'} and
+            type(capture['schema_version']) is int and capture['schema_version'] == 1 and
+            capture['package_version'] == version and capture['selected_result_id'] == selected_id and
+            capture['status'] == 'complete' and capture['error'] is None,
+            'Point evidence manifest is incomplete or belongs to another selection')
+    started = timestamp(capture['started_at'], 'Point evidence start time is invalid')
+    finished = timestamp(capture['finished_at'], 'Point evidence finish time is invalid')
+    require(finished >= started, 'Point evidence times are reversed')
+    responses = capture['responses']
+    require(type(responses) is list and len(responses) >= 3, 'Point evidence is missing required responses')
+    first_specs = POINT_OPERATIONS[:3]
+    bodies = [point_response(evidence, record, number, operation,
+                             point_url(path, parameter, selected_id))
+              for number, (record, (operation, path, parameter)) in enumerate(zip(responses, first_specs), 1)]
+    openapi, siblings, availability = bodies
+    for _operation, path, parameter in POINT_OPERATIONS[1:]:
+        operation = openapi.get('paths', {}).get(path, {}).get('get') if type(openapi) is dict else None
+        require(type(operation) is dict and type(operation.get('parameters')) is list and any(
+            type(item) is dict and item.get('name') == parameter and item.get('in') == 'query' and
+            item.get('required') is True for item in operation['parameters']),
+            'Point OpenAPI contract is incomplete')
+    require(type(siblings) is dict and type(siblings.get('sku')) is dict and
+            type(siblings.get('siblings')) is list and all(type(row) is dict for row in siblings['siblings']),
+            'Unexpected benchmark sibling response')
+    selected = next((row for row in siblings['siblings'] if js_text(row.get('id')) == selected_id), None)
+    require(selected is not None, 'Sibling response does not identify the selected result')
+    require(type(availability) is dict and all(key == selected_id and type(value) is bool
+                                               for key, value in availability.items()),
+            'Unexpected trace availability response')
+    trace_available = availability.get(selected_id) is True
+    specs = POINT_OPERATIONS if trace_available else POINT_OPERATIONS[:3]
+    require(len(responses) == len(specs), 'Point recipe made an unexpected or missing request')
+    bodies = [point_response(evidence, record, number, operation,
+                             point_url(path, parameter, selected_id))
+              for number, (record, (operation, path, parameter)) in enumerate(zip(responses, specs), 1)]
+    actual_files = {str(path.relative_to(evidence)) for path in evidence.rglob('*') if path.is_file()}
+    require(actual_files == {'manifest.json', *(record['body_file'] for record in responses)},
+            'Unexpected or missing point evidence files')
+    export = capture['output']
+    output_path = project / output
+    output_bytes = output_path.read_bytes()
+    require(export == {'format': 'json', 'destination': str(output_path.resolve()),
+                       'sha256': hashlib.sha256(output_bytes).hexdigest(),
+                       'source_request_numbers': list(range(1, len(responses) + 1))} and
+            all(type(value) is int for value in export['source_request_numbers']),
+            'Point output link differs')
+    document = strict_json(output_bytes)
+    require(set(document) == {'schema_version', 'metadata', 'benchmark_siblings', 'selected_point',
+                              'trace_availability', 'outcome', 'timeline', 'histograms', 'server_metrics'} and
+            type(document['schema_version']) is int and document['schema_version'] == 1,
+            'Point diagnostic output shape differs')
+    metadata = document['metadata']
+    require(set(metadata) == {'selected_result_id', 'retrieved_at', 'requests', 'ran_new_benchmark',
+                              'event_timestamp_unit', 'event_timestamp_origin'} and
+            metadata['selected_result_id'] == selected_id and metadata['ran_new_benchmark'] is False and
+            metadata['event_timestamp_unit'] == 'nanoseconds' and
+            metadata['event_timestamp_origin'] == 'offset from timeline.startNs; not wall-clock' and
+            type(metadata['requests']) is list and len(metadata['requests']) == len(responses),
+            'Point diagnostic metadata differs')
+    completed = timestamp(metadata['retrieved_at'], 'Point diagnostic retrieval time is invalid')
+    for request, response in zip(metadata['requests'], responses):
+        require(set(request) == {'query_url', 'retrieved_at'} and same_url(request['query_url'], response['url']) and
+                timestamp(request['retrieved_at'], 'Point request time is invalid') >=
+                timestamp(response['retrieved_at'], 'Point capture time is invalid'),
+                'Point output is not linked to its captured request')
+    require(finished >= completed and all(started <= timestamp(record['retrieved_at'], 'Point response time is invalid')
+                                          <= finished for record in responses),
+            'Point evidence times do not cover the requests and output')
+    require(same_json(document['benchmark_siblings'], siblings) and same_json(document['selected_point'], selected) and
+            same_json(document['trace_availability'], {'response': availability,
+                                                       'key_present': selected_id in availability,
+                                                       'available': trace_available}),
+            'Point diagnostic differs from complete responses')
+    if trace_available:
+        timeline, histograms, server_metrics = bodies[3:]
+        check_point_shapes(selected_id, timeline, histograms, server_metrics)
+        require(document['outcome'] == 'trace_diagnostics' and same_json(document['timeline'], timeline) and
+                same_json(document['histograms'], histograms) and same_json(document['server_metrics'], server_metrics),
+                'Trace diagnostic differs from complete responses')
+    else:
+        require(document['outcome'] == 'trace_unavailable' and
+                all(document[field] is None for field in ('timeline', 'histograms', 'server_metrics')),
+                'No-trace diagnostic must stop before heavy responses')
+    return document['outcome']
+
+
+def point_recipe(installed, selected_id):
+    text = (installed / 'references/agentx.md').read_text()
+    matches = re.findall(r"```bash\nnode --input-type=module <<'JS'\n([\s\S]*?)\nJS\n```", text)
+    require(len(matches) == 1, 'Installed skill must contain exactly one maintained AgentX point recipe')
+    needle = "const selectedResultId = '421';"
+    require(matches[0].count(needle) == 1, 'Installed AgentX point recipe selection seam changed')
+    return matches[0].replace(needle, f"const selectedResultId = '{selected_id}';")
+
+
+def run_point(node, installed, project, environment, label, selected_id, version, deadline=None):
+    script = project / f'{label}-recipe.mjs'
+    preload = project / f'{label}-capture.mjs'
+    output = project / f'{label}.json'
+    evidence = project / f'{label}-evidence'
+    script.write_text(point_recipe(installed, selected_id))
+    preload.write_text(POINT_CAPTURE_PRELOAD)
+    point_environment = dict(environment)
+    point_environment.update(INFERENCEX_POINT_EVIDENCE=str(evidence), INFERENCEX_POINT_ID=selected_id,
+                             INFERENCEX_POINT_OUTPUT=str(output.resolve()), INFERENCEX_PACKAGE_VERSION=version)
+    stdout = run([node, '--import', preload.as_uri(), script], project, point_environment, label, deadline)
+    output.write_text(stdout)
+    strict_json(output.read_bytes())
+    capture = strict_json((evidence / 'manifest.json').read_bytes())
+    require(capture['status'] == 'pending', 'Point capture completed before verifier output validation')
+    capture['status'] = 'complete'
+    capture['finished_at'] = now()
+    capture['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+    capture['output']['source_request_numbers'] = list(range(1, len(capture['responses']) + 1))
+    save(evidence / 'manifest.json', capture)
+    return check_agentx_point(project, f'{label}-evidence', f'{label}.json', selected_id, version)
+
+
+def check_point_outcomes(outcomes):
+    require(outcomes == ['trace_diagnostics', 'trace_unavailable'],
+            'AgentX release verification must exercise one traced and one no-trace point')
+    return outcomes
+
+
 def prompt(args, target, archive):
     cutoff = f'as of {args.date}' if args.date else 'using the latest available observations'
     raw = f' Keep only the exact returned model key {args.raw_model}; record this filter as scope.raw_model in lookup.json.' if args.raw_model else ''
@@ -377,6 +1044,10 @@ For {args.model} {cutoff}, show five latest single-turn benchmark observations w
 Export validated measured PowerX data for that exact scope to powerx.csv and powerx.json. Explain mean watts per GPU, whole-deployment J/output token, prefill watts per GPU, missing requested metrics, exclusions, and extraction context. Preserve source/configuration details and real zeroes.
 
 Attempt the same validated export for exactly {args.empty_isl} input and {args.empty_osl} output tokens as unavailable.json; save its request report, retain the original result, and use the installed bounded diagnostic guidance to save diagnostic.json and explain availability without changing the requested scope.
+
+For {args.agentx_model} using the latest public observations, export AgentX summaries to agentx.csv and agentx.json with separate fresh evidence directories agentx-csv-evidence and agentx-json-evidence. Use only the display-model filter. Preserve every selected benchmark object, summary enrichment, missing state, zero, false value, request URL, and retrieval time. Also request the exact raw-model key {AGENTX_EXCLUDED_RAW_MODEL} as agentx-excluded.json with evidence in agentx-excluded-evidence, and explain the resulting empty or excluded selection without changing its scope.
+
+Use the maintained installed one-point AgentX recipe for exactly result ID {args.agentx_point_id} and save its JSON as agentx-point.json. Run it separately for exactly result ID {args.agentx_no_trace_id} and save that JSON as agentx-second-point.json. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. The complete manifest must record schema_version 1, the package version, selected_result_id, pending/complete status and times, every ordered GET URL/status/retrieval time/decoded-body SHA-256/body filename, and the JSON output destination/hash/source request numbers. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
 
 There is no repository or database access in this project. Do not read another checkout, call private services, install dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times locally. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
 
@@ -406,10 +1077,18 @@ def main():
     parser.add_argument('--raw-model')
     parser.add_argument('--empty-isl', type=int, default=7)
     parser.add_argument('--empty-osl', type=int, default=13)
+    parser.add_argument('--agentx-model', required=True)
+    parser.add_argument('--agentx-point-id', required=True)
+    parser.add_argument('--agentx-no-trace-id', required=True)
     parser.add_argument('--evidence', type=Path, required=True, help='New directory; previous attempts are never overwritten')
     parser.add_argument('--project', type=Path, help='Prepared native-agent project, for check-agent')
     args = parser.parse_args()
     require(args.isl > 0 and args.osl > 0 and args.empty_isl > 0 and args.empty_osl > 0, 'Token counts must be positive')
+    for option in ('agentx_point_id', 'agentx_no_trace_id'):
+        value = getattr(args, option)
+        require(type(value) is str and safe_result_id(value) is not None and str(safe_result_id(value)) == value,
+                f'--{option.replace("_", "-")} must be a canonical positive safe integer string')
+    require(args.agentx_point_id != args.agentx_no_trace_id, 'AgentX point IDs must be distinct')
     if args.date:
         require(datetime.strptime(args.date, '%Y-%m-%d').strftime('%Y-%m-%d') == args.date, 'Use a YYYY-MM-DD cutoff')
     record = json.loads(args.manifest.read_text())
@@ -432,7 +1111,9 @@ def main():
     args.strict_url = args.base_url + '&powerValid=strictV2'
     report = {'status': 'running', 'mode': args.mode, 'started_at': now(), 'candidate': record,
               'new_benchmark_runs': False, 'requests': [], 'targets': [],
-              'scope': {key: getattr(args, key) for key in ['model', 'date', 'isl', 'osl', 'raw_model', 'empty_isl', 'empty_osl']}}
+              'scope': {key: getattr(args, key) for key in ['model', 'date', 'isl', 'osl', 'raw_model', 'empty_isl',
+                                                           'empty_osl', 'agentx_model', 'agentx_point_id',
+                                                           'agentx_no_trace_id']}}
     deadline = time.monotonic() + PUBLIC_DEADLINE_SECONDS if args.mode == 'public' else None
     if deadline is not None:
         report['public_retry_policy'] = {'install_attempts_per_target': PUBLIC_INSTALL_ATTEMPTS,
@@ -466,7 +1147,18 @@ def main():
             diagnostic_source = captured_request(args.project, 'diagnostic', args.base_url, diagnostic['diagnostic'])
             require(not scoped(diagnostic_source, args.empty_isl, args.empty_osl, args.raw_model), 'Empty example has observations; review diagnostic manually')
             check_empty_diagnostic(diagnostic, empty['metadata'], len(diagnostic_source), args)
+            agentx = [
+                check_agentx_capture(args.project, 'agentx-json-evidence', 'agentx.json', args, record['version']),
+                check_agentx_capture(args.project, 'agentx-csv-evidence', 'agentx.csv', args, record['version']),
+                check_agentx_capture(args.project, 'agentx-excluded-evidence', 'agentx-excluded.json', args,
+                                     record['version'], excluded=True)]
+            points = check_point_outcomes([
+                check_agentx_point(args.project, 'agentx-point-evidence', 'agentx-point.json',
+                                   args.agentx_point_id, record['version']),
+                check_agentx_point(args.project, 'agentx-second-point-evidence', 'agentx-second-point.json',
+                                   args.agentx_no_trace_id, record['version'])])
             require((args.project / 'result.md').read_text().strip(), 'Native-agent narrative is missing')
+            result.update(agentx=agentx, agentx_points=points)
             report.update(status='data-checks-passed', narrative_review='required', targets=[result])
             return
         if args.mode == 'public':
@@ -500,6 +1192,26 @@ def main():
             sources = [captured_export(project, f'powerx-{fmt}-evidence', f'powerx.{fmt}', args, record['version'])
                        for fmt in ['json', 'csv']]
             result = check_exports(project, *sources, args, record['version'])
+            agentx = []
+            for output_format in ['json', 'csv']:
+                run([node, installed / 'scripts/export-agentx.mjs', '--model', args.agentx_model,
+                     '--format', output_format, '--output', f'agentx.{output_format}',
+                     '--evidence-dir', f'agentx-{output_format}-evidence'], project, env,
+                    f'agentx-{output_format}', deadline)
+                agentx.append(check_agentx_capture(project, f'agentx-{output_format}-evidence',
+                                                   f'agentx.{output_format}', args, record['version']))
+            run([node, installed / 'scripts/export-agentx.mjs', '--model', args.agentx_model,
+                 '--raw-model', AGENTX_EXCLUDED_RAW_MODEL, '--format', 'json',
+                 '--output', 'agentx-excluded.json', '--evidence-dir', 'agentx-excluded-evidence'],
+                project, env, 'agentx-excluded', deadline)
+            agentx.append(check_agentx_capture(project, 'agentx-excluded-evidence', 'agentx-excluded.json',
+                                               args, record['version'], excluded=True))
+            points = check_point_outcomes([
+                run_point(node, installed, project, env, 'agentx-point', args.agentx_point_id,
+                          record['version'], deadline),
+                run_point(node, installed, project, env, 'agentx-second-point', args.agentx_no_trace_id,
+                          record['version'], deadline)])
+            result.update(agentx=agentx, agentx_points=points)
             result.update(target=target, project=str(project))
             report['targets'].append(result)
         remaining_seconds(deadline, PUBLIC_DEADLINE_SECONDS)

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import tarfile
 import tempfile
@@ -28,7 +29,6 @@ PACKAGE = '@semianalysisai/inferencex-skills'
 REGISTRY = 'https://registry.npmjs.org'
 API = 'https://inferencex.semianalysis.com/api/v1/benchmarks'
 AGENTX_ORIGIN = 'https://inferencex.semianalysis.com'
-AGENTX_API = AGENTX_ORIGIN + '/api/v1/benchmarks'
 AGENTX_EXCLUDED_RAW_MODEL = '__inferencex_release_verification_no_match__'
 MAX_SAFE_INTEGER = 9_007_199_254_740_991
 # Only the exact-version npm ETARGET propagation symptom is retryable. No HTTP,
@@ -433,11 +433,7 @@ def js_text(value):
 
 
 def js_sorted(values):
-    unique = []
-    for value in values:
-        if not any(type(value) is type(item) and value == item for item in unique):
-            unique.append(value)
-    return sorted(unique, key=lambda value: js_text(value).encode('utf-16-be', errors='surrogatepass'))
+    return sorted(set(values), key=lambda value: js_text(value).encode('utf-16-be', errors='surrogatepass'))
 
 
 def strict_json(body):
@@ -623,7 +619,7 @@ def check_agentx_capture(project, name, output, args, version, excluded=False):
             'AgentX evidence filters differ')
     responses = capture['responses']
     require(type(responses) is list and responses, 'AgentX evidence has no complete response')
-    benchmark_url = AGENTX_API + '?' + urlencode({'model': args.agentx_model})
+    benchmark_url = API + '?' + urlencode({'model': args.agentx_model})
     benchmarks = agentx_response(evidence, responses[0], 1, 'benchmarks', benchmark_url, None)
     require(type(benchmarks) is list and all(agentx_benchmark(row) for row in benchmarks),
             'Unexpected AgentX benchmark response shape')
@@ -740,6 +736,9 @@ def check_agentx_capture(project, name, output, args, version, excluded=False):
             require(reader.fieldnames == columns, 'AgentX CSV header differs from published contract')
             records = list(reader)
         require(len(records) == len(rows), 'AgentX CSV row count differs from complete response')
+        require(all(None not in record and set(record) == set(columns) and
+                    all(value is not None for value in record.values()) for record in records),
+                'AgentX CSV row width differs from its header')
         context = {
             'package_version': version, 'query_url': responses[0]['url'], 'retrieved_at': retrieved_at,
             'requested_model': args.agentx_model, 'requested_date': None, 'date_selection': 'latest',
@@ -808,10 +807,14 @@ function save() {
 save();
 const originalFetch = globalThis.fetch;
 globalThis.fetch = async (input, init) => {
-  const url = new URL(input instanceof Request ? input.url : input).href;
+  const request = new Request(input, init);
+  if (request.method !== 'GET') {
+    throw new Error(`Point diagnostics allow only GET requests, received ${request.method}`);
+  }
+  const url = request.url;
   const operation = operations.get(new URL(url).pathname);
   if (!operation) throw new Error(`Unexpected point diagnostic request: ${url}`);
-  const response = await originalFetch(input, init);
+  const response = await originalFetch(request);
   const bytes = Buffer.from(await response.clone().arrayBuffer());
   const requestNumber = manifest.responses.length + 1;
   const bodyFile = `response-${String(requestNumber).padStart(4, '0')}-${operation}.json`;
@@ -820,7 +823,7 @@ globalThis.fetch = async (input, init) => {
     operation,
     request_number: requestNumber,
     url,
-    method: 'GET',
+    method: request.method,
     retrieved_at: new Date().toISOString(),
     http_status: response.status,
     decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
@@ -918,10 +921,10 @@ def check_agentx_point(project, name, output, selected_id, version):
     require(finished >= started, 'Point evidence times are reversed')
     responses = capture['responses']
     require(type(responses) is list and len(responses) >= 3, 'Point evidence is missing required responses')
-    first_specs = POINT_OPERATIONS[:3]
     bodies = [point_response(evidence, record, number, operation,
                              point_url(path, parameter, selected_id))
-              for number, (record, (operation, path, parameter)) in enumerate(zip(responses, first_specs), 1)]
+              for number, (record, (operation, path, parameter)) in
+              enumerate(zip(responses, POINT_OPERATIONS[:3]), 1)]
     openapi, siblings, availability = bodies
     for _operation, path, parameter in POINT_OPERATIONS[1:]:
         operation = openapi.get('paths', {}).get(path, {}).get('get') if type(openapi) is dict else None
@@ -940,9 +943,10 @@ def check_agentx_point(project, name, output, selected_id, version):
     trace_available = availability.get(selected_id) is True
     specs = POINT_OPERATIONS if trace_available else POINT_OPERATIONS[:3]
     require(len(responses) == len(specs), 'Point recipe made an unexpected or missing request')
-    bodies = [point_response(evidence, record, number, operation,
-                             point_url(path, parameter, selected_id))
-              for number, (record, (operation, path, parameter)) in enumerate(zip(responses, specs), 1)]
+    bodies.extend(point_response(evidence, record, number, operation,
+                                 point_url(path, parameter, selected_id))
+                  for number, (record, (operation, path, parameter)) in
+                  enumerate(zip(responses[3:], specs[3:]), 4))
     actual_files = {str(path.relative_to(evidence)) for path in evidence.rglob('*') if path.is_file()}
     require(actual_files == {'manifest.json', *(record['body_file'] for record in responses)},
             'Unexpected or missing point evidence files')
@@ -968,14 +972,21 @@ def check_agentx_point(project, name, output, selected_id, version):
             type(metadata['requests']) is list and len(metadata['requests']) == len(responses),
             'Point diagnostic metadata differs')
     completed = timestamp(metadata['retrieved_at'], 'Point diagnostic retrieval time is invalid')
+    captured_times = [timestamp(response['retrieved_at'], 'Point capture time is invalid')
+                      for response in responses]
+    request_times = []
     for request, response in zip(metadata['requests'], responses):
-        require(set(request) == {'query_url', 'retrieved_at'} and same_url(request['query_url'], response['url']) and
-                timestamp(request['retrieved_at'], 'Point request time is invalid') >=
-                timestamp(response['retrieved_at'], 'Point capture time is invalid'),
+        request_time = timestamp(request.get('retrieved_at'), 'Point request time is invalid') \
+            if type(request) is dict else None
+        require(type(request) is dict and set(request) == {'query_url', 'retrieved_at'} and
+                same_url(request['query_url'], response['url']) and request_time is not None,
                 'Point output is not linked to its captured request')
-    require(finished >= completed and all(started <= timestamp(record['retrieved_at'], 'Point response time is invalid')
-                                          <= finished for record in responses),
-            'Point evidence times do not cover the requests and output')
+        request_times.append(request_time)
+    ordered_times = [started]
+    for captured, requested in zip(captured_times, request_times):
+        ordered_times.extend((captured, requested))
+    ordered_times.extend((completed, finished))
+    require(ordered_times == sorted(ordered_times), 'Point evidence timestamps are not chronological')
     require(same_json(document['benchmark_siblings'], siblings) and same_json(document['selected_point'], selected) and
             same_json(document['trace_availability'], {'response': availability,
                                                        'key_present': selected_id in availability,
@@ -1035,9 +1046,9 @@ def check_point_outcomes(outcomes):
 def prompt(args, target, archive):
     cutoff = f'as of {args.date}' if args.date else 'using the latest available observations'
     raw = f' Keep only the exact returned model key {args.raw_model}; record this filter as scope.raw_model in lookup.json.' if args.raw_model else ''
-    return f'''Use only the installed inferencex-api skill and public HTTP data in this clean project.
+    return f'''Use only the exact candidate archive and public HTTP data in this clean project.
 
-The exact candidate archive is available at {archive}. Using its offline npm installer for target {target}, inspect the installed version with JSON output and save status.json. Preview a forced installation with JSON output and save preview.json. Do not perform the installation or change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files. The npm command is npm exec --yes --offline --package <archive> -- inferencex-skills <command>.
+The exact candidate archive is available at {archive}. Before any API work, independently install that local archive offline for target {target} with npm exec --yes --offline --package <archive> -- inferencex-skills install --target {target}. Then inspect the installed version with JSON output and save status.json. Preview a forced reinstall with JSON output and save preview.json. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files. Use {archive} for <archive> in every npm command.
 
 For {args.model} {cutoff}, show five latest single-turn benchmark observations with {args.isl} input and {args.osl} output tokens, regardless of power validation. Save lookup.json using the installed lookup example's output shape.{raw} Do not introduce additional filters.
 
@@ -1049,7 +1060,7 @@ For {args.agentx_model} using the latest public observations, export AgentX summ
 
 Use the maintained installed one-point AgentX recipe for exactly result ID {args.agentx_point_id} and save its JSON as agentx-point.json. Run it separately for exactly result ID {args.agentx_no_trace_id} and save that JSON as agentx-second-point.json. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. The complete manifest must record schema_version 1, the package version, selected_result_id, pending/complete status and times, every ordered GET URL/status/retrieval time/decoded-body SHA-256/body filename, and the JSON output destination/hash/source request numbers. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
 
-There is no repository or database access in this project. Do not read another checkout, call private services, install dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times locally. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
+There is no repository or database access in this project. Do not read another checkout, call private services, install other dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times locally. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
 
 The complete response files are required deliverables. Use the exporter's built-in --evidence-dir with separate fresh directories powerx-csv-evidence, powerx-json-evidence, and unavailable-evidence for the corresponding outputs. For lookup and diagnosis, save each complete consumed body as raw-responses/lookup.response.json and raw-responses/diagnostic.response.json before selecting rows. Beside each body save a .request.json record with query_url, status, retrieved_at, and sha256 of the saved body; use that same retrieved_at value in the corresponding lookup or diagnostic output. The five-row lookup, selected export rows, and diagnostic summary are not substitutes for original responses. Before finishing, verify these files exist alongside result.md.
 
@@ -1058,12 +1069,36 @@ Each lookup, CSV export, JSON export, empty export, and diagnostic must be trace
 
 
 def check_installed(installed, skill_files, version):
+    require(stat.S_ISDIR(installed.lstat().st_mode), 'Installed skill root must be a real directory')
+    actual_files, actual_dirs = set(), set()
+    pending = [installed]
+    while pending:
+        directory = pending.pop()
+        with os.scandir(directory) as entries:
+            for entry in entries:
+                entry_stat = entry.stat(follow_symlinks=False)
+                name = str(Path(entry.path).relative_to(installed))
+                require(not stat.S_ISLNK(entry_stat.st_mode), f'Installed entry must not be a symlink: {name}')
+                if stat.S_ISDIR(entry_stat.st_mode):
+                    actual_dirs.add(name)
+                    pending.append(Path(entry.path))
+                else:
+                    require(stat.S_ISREG(entry_stat.st_mode),
+                            f'Installed entry must be a regular file: {name}')
+                    actual_files.add(name)
+    expected_files = set(skill_files) | {'.inferencex-skills.json'}
+    expected_dirs = set()
+    for name in expected_files:
+        parent = Path(name).parent
+        while parent != Path('.'):
+            expected_dirs.add(str(parent))
+            parent = parent.parent
+    require(actual_files == expected_files and actual_dirs == expected_dirs,
+            'Unexpected installed files or directories')
     for name, content in skill_files.items():
         require((installed / name).read_bytes() == content, f'Installed file differs from archive: {name}')
     receipt = json.loads((installed / '.inferencex-skills.json').read_text())
     require(receipt == {'package': PACKAGE, 'version': version}, 'Installed-version receipt differs')
-    actual_files = {str(path.relative_to(installed)) for path in installed.rglob('*') if path.is_file()}
-    require(actual_files == set(skill_files) | {'.inferencex-skills.json'}, 'Unexpected installed files')
 
 
 def main():
@@ -1125,11 +1160,22 @@ def main():
         if args.mode == 'check-agent':
             require(args.project is not None, '--project is required for check-agent')
             prepared = json.loads((args.project.parent / 'acceptance.json').read_text())
-            require(prepared['candidate']['sha256'] == record['sha256'], 'Agent project belongs to another candidate')
+            require(prepared['candidate'] == record, 'Agent project belongs to another candidate')
             require(prepared['scope'] == report['scope'], 'Check scope differs from prepared prompt')
             matches = [target for target in prepared['targets'] if Path(target['project']).resolve() == args.project.resolve()]
             require(len(matches) == 1, 'Project was not prepared for this acceptance run')
-            installed = args.project / ('.agents' if matches[0]['target'] == 'codex' else '.claude') / 'skills/inferencex-api'
+            prepared_target = matches[0]
+            require(set(prepared_target) == {'target', 'project', 'status', 'prompt_sha256'} and
+                    prepared_target['target'] in {'codex', 'claude'} and
+                    prepared_target['status'] == 'awaiting-native-agent',
+                    'Prepared target identity differs')
+            local_archive = args.project / record['filename']
+            require(local_archive.read_bytes() == body, 'Native-agent archive differs from accepted candidate')
+            prompt_bytes = (args.project / 'prompt.txt').read_bytes()
+            require(prepared_target['prompt_sha256'] == hashlib.sha256(prompt_bytes).hexdigest() and
+                    prompt_bytes == prompt(args, prepared_target['target'], local_archive).encode(),
+                    'Native-agent prompt differs from prepared target')
+            installed = args.project / ('.agents' if prepared_target['target'] == 'codex' else '.claude') / 'skills/inferencex-api'
             check_installed(installed, skill_files, record['version'])
             json_source = captured_export(args.project, 'powerx-json-evidence', 'powerx.json', args, record['version'])
             csv_source = captured_export(args.project, 'powerx-csv-evidence', 'powerx.csv', args, record['version'])
@@ -1167,19 +1213,31 @@ def main():
                     metadata['dist']['integrity'] == record['integrity'], 'Public metadata differs from candidate')
             public = fetch_public(metadata['dist']['tarball'], args.evidence / 'public-package.tgz', report, deadline)
             require(public == body, 'Public tarball differs from the accepted archive')
-        node, npm = shutil.which('node'), shutil.which('npm')
-        require(node and npm, 'Node 24 and npm must be on PATH')
+        node = npm = None
+        if args.mode != 'agents':
+            node, npm = shutil.which('node'), shutil.which('npm')
+            require(node and npm, 'Node 24 and npm must be on PATH')
         clean_root = Path(tempfile.mkdtemp(prefix='inferencex-skill-acceptance-'))
         report['clean_root'] = str(clean_root)
         for target in ['codex', 'claude']:
+            if args.mode == 'agents':
+                project = clean_root / target
+                project.mkdir()
+                local_archive = project / record['filename']
+                local_archive.write_bytes(body)
+                prompt_bytes = prompt(args, target, local_archive).encode()
+                (project / 'prompt.txt').write_bytes(prompt_bytes)
+                require({path.name for path in project.iterdir()} == {record['filename'], 'prompt.txt'} and
+                        all(stat.S_ISREG(path.lstat().st_mode) for path in project.iterdir()),
+                        'Native-agent project is not a fresh prompt-and-archive boundary')
+                report['targets'].append({
+                    'target': target, 'project': str(project), 'status': 'awaiting-native-agent',
+                    'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()})
+                continue
             project, env = install_target(clean_root, target, node, npm, archive, record['version'],
                                           args.mode == 'public', report, deadline)
             installed = project / ('.agents' if target == 'codex' else '.claude') / 'skills/inferencex-api'
             check_installed(installed, skill_files, record['version'])
-            if args.mode == 'agents':
-                (project / 'prompt.txt').write_text(prompt(args, target, archive))
-                report['targets'].append({'target': target, 'project': str(project), 'status': 'awaiting-native-agent'})
-                continue
             for output_format in ['json', 'csv']:
                 flags = ['--model', args.model, '--isl', str(args.isl), '--osl', str(args.osl), '--format', output_format,
                          '--output', f'powerx.{output_format}', '--evidence-dir', f'powerx-{output_format}-evidence']
@@ -1211,6 +1269,7 @@ def main():
                           record['version'], deadline),
                 run_point(node, installed, project, env, 'agentx-second-point', args.agentx_no_trace_id,
                           record['version'], deadline)])
+            check_installed(installed, skill_files, record['version'])
             result.update(agentx=agentx, agentx_points=points)
             result.update(target=target, project=str(project))
             report['targets'].append(result)

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1162,15 +1162,22 @@ def main():
         if args.mode == 'check-agent':
             require(args.project is not None, '--project is required for check-agent')
             prepared = json.loads((args.project.parent / 'acceptance.json').read_text())
+            require(prepared.get('mode') == 'agents' and prepared.get('status') == 'prepared',
+                    'Acceptance preparation state differs')
             require(prepared['candidate'] == record, 'Agent project belongs to another candidate')
             require(prepared['scope'] == report['scope'], 'Check scope differs from prepared prompt')
-            matches = [target for target in prepared['targets'] if Path(target['project']).resolve() == args.project.resolve()]
+            targets = prepared.get('targets')
+            require(type(targets) is list and len(targets) == 2 and all(
+                type(target) is dict and set(target) == {'target', 'project', 'status', 'prompt_sha256'} and
+                target['target'] in {'codex', 'claude'} and target['status'] == 'awaiting-native-agent' and
+                type(target['project']) is str and type(target['prompt_sha256']) is str and
+                re.fullmatch(r'[0-9a-f]{64}', target['prompt_sha256']) is not None for target in targets) and
+                {target['target'] for target in targets} == {'codex', 'claude'} and
+                len({Path(target['project']).resolve() for target in targets}) == 2,
+                'Prepared target set differs')
+            matches = [target for target in targets if Path(target['project']).resolve() == args.project.resolve()]
             require(len(matches) == 1, 'Project was not prepared for this acceptance run')
             prepared_target = matches[0]
-            require(set(prepared_target) == {'target', 'project', 'status', 'prompt_sha256'} and
-                    prepared_target['target'] in {'codex', 'claude'} and
-                    prepared_target['status'] == 'awaiting-native-agent',
-                    'Prepared target identity differs')
             local_archive = args.project / record['filename']
             require(local_archive.read_bytes() == body, 'Native-agent archive differs from accepted candidate')
             prompt_bytes = (args.project / 'prompt.txt').read_bytes()

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -811,10 +811,14 @@ globalThis.fetch = async (input, init) => {
   if (request.method !== 'GET') {
     throw new Error(`Point diagnostics allow only GET requests, received ${request.method}`);
   }
+  if (request.redirect !== 'error') {
+    throw new Error('Point diagnostics must reject redirects');
+  }
   const url = request.url;
   const operation = operations.get(new URL(url).pathname);
   if (!operation) throw new Error(`Unexpected point diagnostic request: ${url}`);
   const response = await originalFetch(request);
+  if (response.url !== url) throw new Error(`Point diagnostic response URL changed: ${response.url}`);
   const bytes = Buffer.from(await response.clone().arrayBuffer());
   const requestNumber = manifest.responses.length + 1;
   const bodyFile = `response-${String(requestNumber).padStart(4, '0')}-${operation}.json`;

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1127,7 +1127,9 @@ def main():
     if args.date:
         require(datetime.strptime(args.date, '%Y-%m-%d').strftime('%Y-%m-%d') == args.date, 'Use a YYYY-MM-DD cutoff')
     record = json.loads(args.manifest.read_text())
-    require(Path(record['filename']).name == record['filename'], 'Archive must be beside its manifest')
+    require(type(record.get('filename')) is str and
+            re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._-]*\.tgz', record['filename']) is not None,
+            'Archive filename must be a safe .tgz basename')
     archive = args.manifest.resolve().parent / record['filename']
     body = archive.read_bytes()
     require(record['name'] == PACKAGE and hashlib.sha256(body).hexdigest() == record['sha256'], 'Candidate identity mismatch')

--- a/packages/skills/skills/inferencex-api/SKILL.md
+++ b/packages/skills/skills/inferencex-api/SKILL.md
@@ -31,6 +31,12 @@ Preserve raw topology fields with `disagg`; do not add prefill and decode GPU co
 on non-disaggregated rows, where the roles can share the same GPUs. Report raw
 configuration fields unless a requested derived total has verified allocation semantics.
 
+For **AgentX interpretation or one-point diagnostics**, read the
+[AgentX cookbook](references/agentx.md). Require the user to select one positive
+safe result ID before reading its timeline, histograms, or server metrics. Keep
+dataset and configuration identity with the result, and stop when trace availability
+does not list that ID.
+
 ## Query workflow
 
 1. Read the current OpenAPI operation before constructing a request. Use its exact

--- a/packages/skills/skills/inferencex-api/SKILL.md
+++ b/packages/skills/skills/inferencex-api/SKILL.md
@@ -31,11 +31,12 @@ Preserve raw topology fields with `disagg`; do not add prefill and decode GPU co
 on non-disaggregated rows, where the roles can share the same GPUs. Report raw
 configuration fields unless a requested derived total has verified allocation semantics.
 
-For **AgentX interpretation or one-point diagnostics**, read the
-[AgentX cookbook](references/agentx.md). Require the user to select one positive
-safe result ID before reading its timeline, histograms, or server metrics. Keep
-dataset and configuration identity with the result, and stop when trace availability
-does not list that ID.
+For **AgentX summary exports, interpretation, or one-point diagnostics**, read the
+[AgentX cookbook](references/agentx.md) and use the bundled
+[summary exporter](scripts/export-agentx.mjs). Require the user to select one
+positive safe result ID before reading its timeline, histograms, or server metrics.
+Keep dataset and configuration identity with the result, and stop when trace
+availability does not list that ID.
 
 ## Query workflow
 

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -109,7 +109,10 @@ const requests = [];
 
 async function read(path) {
   const query_url = new URL(path, base).href;
-  const response = await fetch(query_url, { signal: AbortSignal.timeout(30_000) });
+  const response = await fetch(query_url, {
+    redirect: 'error',
+    signal: AbortSignal.timeout(30_000),
+  });
   if (!response.ok) throw new Error(`HTTP ${response.status}: ${query_url}`);
   const data = await response.json();
   requests.push({ query_url, retrieved_at: new Date().toISOString() });

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -37,19 +37,41 @@ whole-deployment energy, or rank energy.
 Use the bundled Node 24 exporter to read the complete benchmark response, select
 AgentX observations, and join only the bounded summary enrichments. A display model
 is required; `--date` adds an as-of cutoff, and `--raw-model` selects one exact
-returned model key. The current exporter emits JSON.
+returned model key. CSV is the default; request JSON explicitly with `--format
+json`.
 
 ```bash
 node .agents/skills/inferencex-api/scripts/export-agentx.mjs \
-  --model DeepSeek-V4-Pro --output agentx.json
+  --model DeepSeek-V4-Pro --output agentx.csv
+
+node .agents/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --format json --output agentx.json
 ```
 
 For Claude Code, use `.claude/skills/inferencex-api/scripts/export-agentx.mjs`.
-The output retains every selected benchmark object separately from its `agentx`
-enrichment and records request URLs, retrieval context, row counts, missing
-enrichment entries, nullable groups, and trace availability. An unsupported raw ID
-remains in the export but is not sent to numeric enrichment endpoints. Do not use
-this summary workflow to bulk-read timelines, histograms, or server metrics.
+Optional `--hardware`, `--framework`, `--precision`, `--spec-method`,
+`--offload-mode`, and `--concurrency` filters use exact, case-sensitive returned
+values. Concurrency must be a positive integer. No aliases or fuzzy matching are
+applied. Metadata marks every filter as applied or omitted and lists values present
+in the returned AgentX rows so an empty exact selection can be diagnosed without
+making claims about jobs or artifacts outside that response.
+
+JSON retains every selected benchmark object separately from its `agentx`
+enrichment. CSV repeats package, request, and filter context on every row. Its
+`metrics.*` columns are the sorted union of scalar metric keys in the selected
+rows; arrays and objects are not embedded in cells. Missing and null cells stay
+blank, while real zero and `false` values remain explicit. Both formats record
+request URLs, retrieval context, row counts, missing enrichment entries, nullable
+groups, and trace availability. The first stderr line is machine-readable metadata,
+including for a header-only CSV. `no_agentx_rows` means the complete benchmark
+response contained no AgentX observations; `no_matching_rows` means exact local
+filters excluded the returned AgentX observations. Neither outcome says whether
+other benchmark jobs, failed runs, source artifacts, or data outside that response
+exist.
+
+An unsupported raw ID remains in the export but is not sent to numeric enrichment
+endpoints. Do not use this summary workflow to bulk-read timelines, histograms, or
+server metrics.
 
 ## Diagnose one explicitly selected point
 

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -32,6 +32,25 @@ them with the [PowerX validity and unit guidance](powerx.md): do not automatical
 apply `strictV2`, turn missing measurements into zero, mix per-GPU watts with
 whole-deployment energy, or rank energy.
 
+## Export AgentX summaries
+
+Use the bundled Node 24 exporter to read the complete benchmark response, select
+AgentX observations, and join only the bounded summary enrichments. A display model
+is required; `--date` adds an as-of cutoff, and `--raw-model` selects one exact
+returned model key. The current exporter emits JSON.
+
+```bash
+node .agents/skills/inferencex-api/scripts/export-agentx.mjs \
+  --model DeepSeek-V4-Pro --output agentx.json
+```
+
+For Claude Code, use `.claude/skills/inferencex-api/scripts/export-agentx.mjs`.
+The output retains every selected benchmark object separately from its `agentx`
+enrichment and records request URLs, retrieval context, row counts, missing
+enrichment entries, nullable groups, and trace availability. An unsupported raw ID
+remains in the export but is not sent to numeric enrichment endpoints. Do not use
+this summary workflow to bulk-read timelines, histograms, or server metrics.
+
 ## Diagnose one explicitly selected point
 
 Use this recipe only after the user has selected one result ID from a summary or

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -1,0 +1,205 @@
+# AgentX cookbook
+
+AgentX observations measure serving-system performance under concurrent,
+closed-loop agent clients. `conc` is the number of clients that issue their next
+request after the previous response; it is not a fixed request batch. Report
+throughput together with TTFT and interactivity rather than treating one metric as
+a complete result. P75 and p90 E2E Normalized Interactivity are slow-tail
+`1 / pXX(E2EL / OSL)`, in `tok/s/user`; they are not percentiles of per-request
+rates.
+
+The benchmark read is stable, while the current AgentX diagnostic operations are
+beta. Read the live OpenAPI document once per task and use the fetched contract for
+that task.
+
+Establish the replay dataset and configuration identity before comparing points.
+Match the supplied dataset slug, model, hardware, framework, precision, topology,
+offload mode, concurrency, image, observation, producer, and snapshot identities.
+Do not infer values that the response omits. Closed-loop systems can progress
+through different requests during the same run window, so workload mix can drift,
+especially at low concurrency. If identity cannot be confirmed, describe the
+comparison as incomplete.
+
+Public timelines contain sanitized replay structure. They do not expose original
+prompts, code, or tool payloads. Preserve every phase, replay-lane field, and
+cancellation state returned by the API; do not reduce the timeline to successful
+main-agent requests. Event fields such as `start`, `ack`, and `end` are nanosecond
+offsets from the timeline's documented `startNs`, not wall-clock timestamps.
+
+This workflow reads existing observations and runs no new benchmark. AgentX does
+not evaluate model answer quality. If AgentX rows contain power fields, interpret
+them with the [PowerX validity and unit guidance](powerx.md): do not automatically
+apply `strictV2`, turn missing measurements into zero, mix per-GPU watts with
+whole-deployment energy, or rank energy.
+
+## Diagnose one explicitly selected point
+
+Use this recipe only after the user has selected one result ID from a summary or
+other public response. Replace `421` with that exact decimal string. It must convert
+losslessly to a positive JavaScript safe integer for the diagnostic URLs; keep the
+original string in the output, never round a larger identifier, and never expand the
+selection to sibling IDs.
+
+The recipe reads the current OpenAPI document once, then fetches sibling identity
+and trace availability. A missing availability key returns `trace_unavailable` and
+stops before all heavy trace operations. If availability advertises a trace, it
+reads exactly one timeline, one-ID histogram data, and aggregate server metrics.
+An HTTP error, malformed JSON, or invalid required response after that advertisement
+is a trace inconsistency and fails the recipe.
+
+```bash
+node --input-type=module <<'JS'
+const base = 'https://inferencex.semianalysis.com';
+const selectedResultId = '421';
+const diagnosticId = /^(?:[1-9]\d*)$/u.test(selectedResultId) ? Number(selectedResultId) : null;
+if (!Number.isSafeInteger(diagnosticId) || diagnosticId <= 0 || String(diagnosticId) !== selectedResultId) {
+  throw new Error('Select one positive safe integer result ID before reading diagnostics');
+}
+
+const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const finite = (value) => typeof value === 'number' && Number.isFinite(value);
+const integer = (value) => finite(value) && Number.isInteger(value);
+const finiteOrNull = (value) => value === null || finite(value);
+const requests = [];
+
+async function read(path) {
+  const query_url = new URL(path, base).href;
+  const response = await fetch(query_url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) throw new Error(`HTTP ${response.status}: ${query_url}`);
+  const data = await response.json();
+  requests.push({ query_url, retrieved_at: new Date().toISOString() });
+  return data;
+}
+
+const openapi = await read('/api/openapi.json');
+const operations = {
+  '/api/v1/benchmark-siblings': 'id',
+  '/api/v1/trace-availability': 'ids',
+  '/api/v1/request-timeline': 'id',
+  '/api/v1/trace-histograms': 'ids',
+  '/api/v1/trace-server-metrics': 'id',
+};
+if (!object(openapi) || Object.entries(operations).some(([path, parameter]) => {
+  const operation = openapi.paths?.[path]?.get;
+  return !operation || !operation.parameters?.some((item) =>
+    item.name === parameter && item.in === 'query' && item.required === true);
+})) throw new Error('Inspect the current AgentX diagnostic operations in OpenAPI');
+
+const id = String(diagnosticId);
+const siblingResponse = await read(`/api/v1/benchmark-siblings?id=${id}`);
+if (!object(siblingResponse) || !object(siblingResponse.sku) ||
+    !Array.isArray(siblingResponse.siblings) ||
+    siblingResponse.siblings.some((row) => !object(row))) {
+  throw new Error('Unexpected benchmark sibling response');
+}
+const selectedPoint = siblingResponse.siblings.find((row) => String(row.id) === selectedResultId);
+if (!selectedPoint) throw new Error('Sibling response does not identify the selected result');
+
+const availability = await read(`/api/v1/trace-availability?ids=${id}`);
+if (!object(availability) || Object.entries(availability).some(([key, value]) =>
+  key !== id || typeof value !== 'boolean')) {
+  throw new Error('Unexpected trace availability response');
+}
+const traceKeyPresent = Object.hasOwn(availability, id);
+const traceAvailable = traceKeyPresent && availability[id] === true;
+const common = () => ({
+  schema_version: 1,
+  metadata: {
+    selected_result_id: selectedResultId,
+    retrieved_at: new Date().toISOString(),
+    requests,
+    ran_new_benchmark: false,
+    event_timestamp_unit: 'nanoseconds',
+    event_timestamp_origin: 'offset from timeline.startNs; not wall-clock',
+  },
+  benchmark_siblings: siblingResponse,
+  selected_point: selectedPoint,
+  trace_availability: {
+    response: availability,
+    key_present: traceKeyPresent,
+    available: traceAvailable,
+  },
+});
+
+if (!traceAvailable) {
+  console.log(JSON.stringify({
+    ...common(),
+    outcome: 'trace_unavailable',
+    timeline: null,
+    histograms: null,
+    server_metrics: null,
+  }, null, 2));
+} else {
+  try {
+    const timeline = await read(`/api/v1/request-timeline?id=${id}`);
+    if (!object(timeline) || !integer(timeline.version) || !integer(timeline.startNs) ||
+        !integer(timeline.endNs) || !finite(timeline.durationS) ||
+        !Array.isArray(timeline.requests) || timeline.requests.some((request) =>
+          !object(request) || typeof request.cid !== 'string' || !integer(request.ti) ||
+          typeof request.wid !== 'string' || !integer(request.ad) ||
+          typeof request.phase !== 'string' || !integer(request.credit) ||
+          !integer(request.start) || !finiteOrNull(request.ack) || !integer(request.end) ||
+          !finiteOrNull(request.ttftMs) || !finiteOrNull(request.tpotMs) ||
+          !finiteOrNull(request.isl) || !finiteOrNull(request.osl) ||
+          typeof request.cancelled !== 'boolean' ||
+          Object.hasOwn(request, 'ri') && !integer(request.ri) ||
+          Object.hasOwn(request, 'srcTrace') && typeof request.srcTrace !== 'string' ||
+          Object.hasOwn(request, 'srcOuter') && !integer(request.srcOuter) ||
+          Object.hasOwn(request, 'srcInner') && !integer(request.srcInner) ||
+          Object.hasOwn(request, 'srcKind') && typeof request.srcKind !== 'string')) {
+      throw new Error('Unexpected request timeline response');
+    }
+
+    const histograms = await read(`/api/v1/trace-histograms?ids=${id}`);
+    const histogram = object(histograms) ? histograms[id] : null;
+    if (!object(histogram) || Object.keys(histograms).length !== 1 ||
+        histogram.id !== diagnosticId ||
+        !Array.isArray(histogram.isl) || !histogram.isl.every(finite) ||
+        !Array.isArray(histogram.osl) || !histogram.osl.every(finite)) {
+      throw new Error('Unexpected one-result trace histogram response');
+    }
+
+    const serverMetrics = await read(`/api/v1/trace-server-metrics?id=${id}`);
+    const series = ['kvCacheUsage', 'prefixCacheHitRate', 'queueDepth', 'prefillTps',
+      'decodeTps', 'prefixCacheHitsTps', 'hostKvCacheUsage', 'kvCacheUsageByEngine'];
+    if (!object(serverMetrics) || !object(serverMetrics.meta) ||
+        !integer(serverMetrics.startNs) || !integer(serverMetrics.endNs) ||
+        !finite(serverMetrics.durationS) || !integer(serverMetrics.timeslicesCount) ||
+        serverMetrics.timeslicesCount < 0 ||
+        series.some((key) => !Array.isArray(serverMetrics[key]) ||
+          serverMetrics[key].some((entry) => !object(entry))) ||
+        !object(serverMetrics.promptTokensBySource) ||
+        Object.values(serverMetrics.promptTokensBySource).some((entries) =>
+          !Array.isArray(entries) || entries.some((entry) => !object(entry))) ||
+        !finiteOrNull(serverMetrics.kvCachePoolTokens) ||
+        !Array.isArray(serverMetrics.metricSources) ||
+        serverMetrics.metricSources.some((entry) => !object(entry)) ||
+        Object.hasOwn(serverMetrics.meta, 'id') && serverMetrics.meta.id !== diagnosticId) {
+      throw new Error('Unexpected aggregate server metrics response');
+    }
+
+    console.log(JSON.stringify({
+      ...common(),
+      outcome: 'trace_diagnostics',
+      timeline,
+      histograms,
+      server_metrics: serverMetrics,
+    }, null, 2));
+  } catch (error) {
+    throw new Error(
+      `Trace availability inconsistency for result ${id}: ${error.message}`,
+      { cause: error },
+    );
+  }
+}
+JS
+```
+
+Save the JSON output with the analysis. `benchmark_siblings.sku` and
+`selected_point` retain every identity field the API supplied; absence remains
+absence. `trace_unavailable` means only that the availability response omitted the
+selected key (or returned it as false). It does not mean the benchmark never ran or
+that a source artifact never existed. Do not call the page-owned
+`/api/v1/request-chart-data` or `/api/v1/trace-server-metric-source` operations.
+Do not repeat this recipe across a result set; ask the user to choose another single
+ID first.

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -56,6 +56,10 @@ applied. Metadata marks every filter as applied or omitted and lists values pres
 in the returned AgentX rows so an empty exact selection can be diagnosed without
 making claims about jobs or artifacts outside that response.
 
+Add `--evidence-dir agentx-evidence` with a path that does not exist to save every
+decoded response consumed by the export and an atomic manifest linking those
+responses to the output hash. Keep the evidence directory separate from `--output`.
+
 JSON retains every selected benchmark object separately from its `agentx`
 enrichment. CSV repeats package, request, and filter context on every row. Its
 `metrics.*` columns are the sorted union of scalar metric keys in the selected

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+// Installed skills run independently of package.json; release preparation updates this version.
+const PACKAGE_VERSION = '0.3.0';
+const API_ORIGIN = 'https://inferencex.semianalysis.com';
+const HELP = `export-agentx — export existing AgentX observations with summary enrichments
+
+Requires Node 24 or later.
+
+Usage:
+  node export-agentx.mjs --model <display-name> [options]
+
+Options:
+  --date <YYYY-MM-DD>  As-of cutoff; omission selects latest available observations
+  --raw-model <key>    Select an exact returned model key within the display bucket
+  --output <file>      Output JSON to a file; default stdout
+  --help               Show this help without making a request
+
+The benchmark response is filtered locally to benchmark_type=agentic_traces.
+The exporter reads existing observations; it does not run a benchmark.
+`;
+
+const REQUIRED_STRING_FIELDS = [
+  'hardware',
+  'framework',
+  'model',
+  'precision',
+  'spec_method',
+  'benchmark_type',
+  'offload_mode',
+  'date',
+];
+const REQUIRED_BOOLEAN_FIELDS = [
+  'disagg',
+  'is_multinode',
+  'prefill_dp_attention',
+  'decode_dp_attention',
+];
+const REQUIRED_INTEGER_FIELDS = [
+  'prefill_tp',
+  'prefill_ep',
+  'prefill_num_workers',
+  'decode_tp',
+  'decode_ep',
+  'decode_num_workers',
+  'num_prefill_gpu',
+  'num_decode_gpu',
+  'conc',
+];
+const AGGREGATE_GROUPS = ['isl', 'osl', 'kvCacheUtil', 'prefixCacheHitRate'];
+const PERCENTILE_FIELDS = ['mean', 'p50', 'p75', 'p90', 'p95', 'p99'];
+
+function object(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validDate(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function benchmarkRow(row) {
+  return (
+    object(row) &&
+    Object.hasOwn(row, 'id') &&
+    (typeof row.id === 'string' || (typeof row.id === 'number' && Number.isInteger(row.id))) &&
+    REQUIRED_STRING_FIELDS.every((key) => typeof row[key] === 'string') &&
+    REQUIRED_BOOLEAN_FIELDS.every((key) => typeof row[key] === 'boolean') &&
+    REQUIRED_INTEGER_FIELDS.every((key) => Number.isInteger(row[key])) &&
+    ['isl', 'osl'].every((key) => row[key] === null || Number.isFinite(row[key])) &&
+    ['image', 'recipe_fingerprint', 'run_url'].every(
+      (key) => row[key] === null || typeof row[key] === 'string',
+    ) &&
+    object(row.metrics) &&
+    validDate(row.date)
+  );
+}
+
+function safeResultId(value) {
+  if (typeof value === 'number') {
+    return Number.isSafeInteger(value) && value > 0 ? value : null;
+  }
+  if (typeof value !== 'string' || !/^[1-9]\d*$/u.test(value)) return null;
+  const number = Number(value);
+  return Number.isSafeInteger(number) && String(number) === value ? number : null;
+}
+
+function percentileGroup(value) {
+  return (
+    object(value) &&
+    PERCENTILE_FIELDS.every((key) => Number.isFinite(value[key])) &&
+    Number.isInteger(value.n) &&
+    value.n >= 0
+  );
+}
+
+function responseMap(value, requestedIds, operation, validateEntry) {
+  if (!object(value)) throw new Error(`Unexpected ${operation} response shape: expected an object`);
+  const result = new Map();
+  const requested = new Set(requestedIds);
+  for (const [key, entry] of Object.entries(value)) {
+    const id = safeResultId(key);
+    if (id === null || !requested.has(id)) {
+      throw new Error(`Unexpected ${operation} result ID ${JSON.stringify(key)}`);
+    }
+    if (!validateEntry(entry, id)) {
+      throw new Error(`Unexpected ${operation} response shape for result ID ${key}`);
+    }
+    result.set(id, entry);
+  }
+  return result;
+}
+
+function aggregateMap(value, requestedIds) {
+  return responseMap(
+    value,
+    requestedIds,
+    'agentic-aggregates',
+    (entry, id) =>
+      object(entry) &&
+      entry.id === id &&
+      AGGREGATE_GROUPS.every((group) => entry[group] === null || percentileGroup(entry[group])),
+  );
+}
+
+function derivedMap(value, requestedIds) {
+  return responseMap(
+    value,
+    requestedIds,
+    'derived-agentic-metrics',
+    (entry, id) =>
+      object(entry) &&
+      entry.id === id &&
+      ['p75_e2e_norm_intvty', 'p90_e2e_norm_intvty'].every(
+        (key) => entry[key] === null || Number.isFinite(entry[key]),
+      ),
+  );
+}
+
+function traceMap(value, requestedIds) {
+  return responseMap(
+    value,
+    requestedIds,
+    'trace-availability',
+    (entry) => typeof entry === 'boolean',
+  );
+}
+
+async function fetchJson(url, operation, requestUrls) {
+  requestUrls.push({ operation, url: url.href });
+  let response;
+  try {
+    response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  } catch (error) {
+    throw new Error(`${operation} request failed: ${error.message} (${url.href})`, {
+      cause: error,
+    });
+  }
+  let body;
+  try {
+    body = await response.text();
+  } catch (error) {
+    throw new Error(`Could not read ${operation} response body: ${error.message}`, {
+      cause: error,
+    });
+  }
+  if (!response.ok) {
+    let detail = '';
+    try {
+      const parsed = JSON.parse(body);
+      if (typeof parsed?.error === 'string') detail = `: ${parsed.error.slice(0, 300)}`;
+    } catch {
+      // The HTTP status is authoritative when an error body is not JSON.
+    }
+    throw new Error(`HTTP ${response.status}${detail} (${url.href})`);
+  }
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new Error(`Could not read ${operation} JSON: ${error.message}`, { cause: error });
+  }
+}
+
+async function fetchChunks(operation, ids, limit, validate, requestUrls) {
+  const joined = new Map();
+  for (let offset = 0; offset < ids.length; offset += limit) {
+    const chunk = ids.slice(offset, offset + limit);
+    const url = new URL(`/api/v1/${operation}`, API_ORIGIN);
+    url.searchParams.set('ids', chunk.join(','));
+    const entries = validate(await fetchJson(url, operation, requestUrls), chunk);
+    for (const [id, value] of entries) joined.set(id, value);
+  }
+  return joined;
+}
+
+function coverage(rows) {
+  const supported = rows.filter((row) => row.agentx.status !== 'unsupported_id');
+  const unsupported = rows.length - supported.length;
+  const aggregates = Object.fromEntries(
+    AGGREGATE_GROUPS.map((group) => [
+      group,
+      {
+        available_rows: supported.filter(
+          (row) =>
+            row.agentx.aggregates.status === 'available' &&
+            row.agentx.aggregates.value[group] !== null,
+        ).length,
+        null_rows: supported.filter(
+          (row) =>
+            row.agentx.aggregates.status === 'available' &&
+            row.agentx.aggregates.value[group] === null,
+        ).length,
+        missing_entry_rows: supported.filter(
+          (row) => row.agentx.aggregates.status === 'not_returned',
+        ).length,
+        unsupported_id_rows: unsupported,
+      },
+    ]),
+  );
+  return {
+    safe_id_rows: supported.length,
+    unsupported_id_rows: unsupported,
+    unique_safe_ids: new Set(supported.map((row) => row.agentx.result_id)).size,
+    aggregates,
+    derived_metrics: {
+      available_rows: supported.filter((row) => row.agentx.derived_metrics.status === 'available')
+        .length,
+      missing_entry_rows: supported.filter(
+        (row) => row.agentx.derived_metrics.status === 'not_returned',
+      ).length,
+      unsupported_id_rows: unsupported,
+    },
+    trace_availability: {
+      stored_trace_rows: supported.filter((row) => row.agentx.trace_availability.value === true)
+        .length,
+      no_stored_trace_rows: supported.filter((row) => row.agentx.trace_availability.value === false)
+        .length,
+      response_key_rows: supported.filter(
+        (row) => row.agentx.trace_availability.response_key_present,
+      ).length,
+      missing_key_rows: supported.filter(
+        (row) => !row.agentx.trace_availability.response_key_present,
+      ).length,
+      unsupported_id_rows: unsupported,
+    },
+  };
+}
+
+async function run(args = process.argv.slice(2)) {
+  const { values } = parseArgs({
+    args,
+    options: {
+      model: { type: 'string' },
+      date: { type: 'string' },
+      'raw-model': { type: 'string' },
+      output: { type: 'string' },
+      help: { type: 'boolean' },
+    },
+    allowPositionals: false,
+    strict: true,
+  });
+  if (values.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  if (!values.model?.trim()) throw new Error('--model requires a display model name');
+  if (values.date !== undefined && !validDate(values.date)) {
+    throw new Error('--date must be a valid YYYY-MM-DD date');
+  }
+  if (values['raw-model'] !== undefined && !values['raw-model'].trim()) {
+    throw new Error('--raw-model requires a returned model key');
+  }
+  if (values.output !== undefined && !values.output.trim()) {
+    throw new Error('--output requires a file path');
+  }
+
+  const requestUrls = [];
+  const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
+  benchmarkUrl.searchParams.set('model', values.model);
+  if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
+  const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls);
+  if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
+    throw new Error(
+      'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
+    );
+  }
+  const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
+  const selected = agentxRows.filter(
+    (row) => values['raw-model'] === undefined || row.model === values['raw-model'],
+  );
+  const ids = [...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null))];
+  const aggregates = await fetchChunks('agentic-aggregates', ids, 200, aggregateMap, requestUrls);
+  const derived = await fetchChunks('derived-agentic-metrics', ids, 200, derivedMap, requestUrls);
+  const traces = await fetchChunks('trace-availability', ids, 500, traceMap, requestUrls);
+  let nonFiniteValues = 0;
+  const rows = selected.map((row) => {
+    const benchmark = JSON.parse(
+      JSON.stringify(row, (_key, value) => {
+        if (typeof value === 'number' && !Number.isFinite(value)) {
+          nonFiniteValues++;
+          return null;
+        }
+        return value;
+      }),
+    );
+    const id = safeResultId(row.id);
+    if (id === null) {
+      return {
+        benchmark,
+        agentx: {
+          status: 'unsupported_id',
+          result_id: null,
+          aggregates: { status: 'unsupported_id', value: null },
+          derived_metrics: { status: 'unsupported_id', value: null },
+          trace_availability: {
+            status: 'unsupported_id',
+            value: null,
+            response_key_present: null,
+          },
+        },
+      };
+    }
+    const hasAggregates = aggregates.has(id);
+    const hasDerived = derived.has(id);
+    const hasTraceKey = traces.has(id);
+    const traceAvailable = hasTraceKey ? traces.get(id) : false;
+    return {
+      benchmark,
+      agentx: {
+        status: hasAggregates && hasDerived ? 'complete' : 'partial',
+        result_id: id,
+        aggregates: {
+          status: hasAggregates ? 'available' : 'not_returned',
+          value: hasAggregates ? aggregates.get(id) : null,
+        },
+        derived_metrics: {
+          status: hasDerived ? 'available' : 'not_returned',
+          value: hasDerived ? derived.get(id) : null,
+        },
+        trace_availability: {
+          status: traceAvailable ? 'stored_trace' : 'no_stored_trace',
+          value: traceAvailable,
+          response_key_present: hasTraceKey,
+        },
+      },
+    };
+  });
+  const metadata = {
+    package_version: PACKAGE_VERSION,
+    retrieved_at: new Date().toISOString(),
+    request_urls: requestUrls,
+    requested_scope: {
+      display_model: values.model,
+      date: values.date ?? null,
+      date_selection: values.date === undefined ? 'latest' : 'as-of',
+      raw_model: values['raw-model'] ?? null,
+      benchmark_type: 'agentic_traces',
+    },
+    outcome:
+      agentxRows.length === 0
+        ? 'no_agentx_rows'
+        : selected.length === 0
+          ? 'no_matching_rows'
+          : 'selected_rows',
+    returned_rows: benchmarks.length,
+    returned_agentx_rows: agentxRows.length,
+    selected_rows: rows.length,
+    returned_model_keys: [...new Set(benchmarks.map((row) => row.model))].toSorted(),
+    selected_model_keys: [...new Set(selected.map((row) => row.model))].toSorted(),
+    enrichment_coverage: coverage(rows),
+    non_finite_values: nonFiniteValues,
+    observation_context: 'Existing observations were read; no new benchmark was run.',
+  };
+  const output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
+  if (values.output === undefined) process.stdout.write(output);
+  else await writeFile(values.output, output, 'utf8');
+  process.stderr.write(`${JSON.stringify({ metadata })}\n`);
+  process.stderr.write(
+    `Selected ${metadata.selected_rows} AgentX rows from ${metadata.returned_rows} complete benchmark rows (${metadata.returned_agentx_rows} AgentX before raw-model selection).\n`,
+  );
+}
+
+run().catch((error) => {
+  process.stderr.write(`export-agentx: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -356,7 +356,10 @@ async function fetchJson(url, operation, requestUrls, evidence, requestedChunkId
   }
   let response;
   try {
-    response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+    response = await fetch(url, {
+      redirect: 'error',
+      signal: AbortSignal.timeout(30_000),
+    });
   } catch (error) {
     throw new Error(`${operation} request failed: ${error.message} (${url.href})`, {
       cause: error,

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { writeFile } from 'node:fs/promises';
+import { createHash, randomUUID } from 'node:crypto';
+import { lstat, mkdir, readlink, realpath, rename, rm, writeFile } from 'node:fs/promises';
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
 
@@ -25,6 +27,7 @@ Options:
   --concurrency <n>    Select an exact positive concurrency
   --format <format>    csv (default) or json
   --output <file>      Output file; default stdout
+  --evidence-dir <dir> Save consumed responses and a manifest in a new directory
   --help               Show this help without making a request
 
 The benchmark response is filtered locally to benchmark_type=agentic_traces.
@@ -159,6 +162,92 @@ function unique(values) {
   return [...new Set(values)].toSorted();
 }
 
+// Resolve existing symlink ancestors, including dangling output links, before creating evidence.
+async function physicalPath(path) {
+  try {
+    return await realpath(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    const entry = await lstat(path).catch((statError) => {
+      if (statError.code !== 'ENOENT') throw statError;
+      return null;
+    });
+    if (entry?.isSymbolicLink()) return physicalPath(resolve(dirname(path), await readlink(path)));
+    return join(await physicalPath(dirname(path)), basename(path));
+  }
+}
+
+function containsPath(parent, child) {
+  const path = relative(parent, child);
+  return path === '' || (path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path));
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+async function saveManifest(evidence) {
+  const temporary = join(evidence.directory, 'manifest.tmp');
+  await writeFile(temporary, `${JSON.stringify(evidence.manifest, null, 2)}\n`, 'utf8');
+  await rename(temporary, join(evidence.directory, 'manifest.json'));
+}
+
+async function writeStdout(bytes) {
+  // The callback reports a closed consumer after write() has accepted the buffer.
+  process.stdout.on('error', () => {});
+  await new Promise((resolveWrite, reject) => {
+    process.stdout.write(bytes, (error) => (error ? reject(error) : resolveWrite()));
+  });
+}
+
+async function stageFileOutput(destination, bytes) {
+  const target = resolve(destination);
+  const suffix = `${process.pid}-${randomUUID()}`;
+  const temporary = join(dirname(target), `.${basename(target)}.${suffix}.tmp`);
+  const backup = join(dirname(target), `.${basename(target)}.${suffix}.backup`);
+  try {
+    await writeFile(temporary, bytes, { flag: 'wx' });
+  } catch (error) {
+    await rm(temporary, { force: true }).catch(() => {});
+    throw error;
+  }
+  let installed = false;
+  let original = false;
+
+  return {
+    async commit() {
+      const entry = await lstat(target).catch((error) => {
+        if (error.code !== 'ENOENT') throw error;
+        return null;
+      });
+      if (entry?.isDirectory()) throw new Error(`--output must not name a directory: ${target}`);
+      if (entry) {
+        await rename(target, backup);
+        original = true;
+      }
+      await rename(temporary, target);
+      installed = true;
+    },
+    async rollback() {
+      const errors = [];
+      if (installed) {
+        await rm(target, { force: true }).catch((error) => errors.push(error));
+      }
+      if (original) {
+        await rename(backup, target).catch((error) => errors.push(error));
+      }
+      await rm(temporary, { force: true }).catch((error) => errors.push(error));
+      if (errors.length > 0) {
+        throw new Error(errors.map((error) => error.message).join('; '));
+      }
+    },
+    async finish() {
+      await rm(backup, { force: true }).catch(() => {});
+      await rm(temporary, { force: true }).catch(() => {});
+    },
+  };
+}
+
 function benchmarkRow(row) {
   return (
     object(row) &&
@@ -246,8 +335,26 @@ function traceMap(value, requestedIds) {
   );
 }
 
-async function fetchJson(url, operation, requestUrls) {
+async function fetchJson(url, operation, requestUrls, evidence, requestedChunkIds = null) {
+  const requestNumber = requestUrls.length + 1;
   requestUrls.push({ operation, url: url.href });
+  let record;
+  if (evidence) {
+    record = {
+      operation,
+      request_number: requestNumber,
+      url: url.href,
+      method: 'GET',
+      retrieved_at: null,
+      http_status: null,
+      decoded_body_sha256: null,
+      body_file: null,
+      requested_chunk_ids: requestedChunkIds,
+      checksum_covers: 'saved decoded response body',
+    };
+    evidence.manifest.responses.push(record);
+    await saveManifest(evidence);
+  }
   let response;
   try {
     response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
@@ -256,14 +363,27 @@ async function fetchJson(url, operation, requestUrls) {
       cause: error,
     });
   }
-  let body;
+  if (record) {
+    record.retrieved_at = new Date().toISOString();
+    record.http_status = response.status;
+  }
+  let bytes;
   try {
-    body = await response.text();
+    bytes = Buffer.from(await response.arrayBuffer());
   } catch (error) {
     throw new Error(`Could not read ${operation} response body: ${error.message}`, {
       cause: error,
     });
   }
+  if (record) {
+    const filename = `response-${String(requestNumber).padStart(4, '0')}-${operation}.json`;
+    await writeFile(join(evidence.directory, filename), bytes, { flag: 'wx' });
+    record.decoded_body_sha256 = sha256(bytes);
+    record.body_file = filename;
+    await saveManifest(evidence);
+  }
+  // Fetch has already decoded HTTP compression. Parse the same bytes saved above.
+  const body = new TextDecoder().decode(bytes);
   if (!response.ok) {
     let detail = '';
     try {
@@ -281,13 +401,13 @@ async function fetchJson(url, operation, requestUrls) {
   }
 }
 
-async function fetchChunks(operation, ids, limit, validate, requestUrls) {
+async function fetchChunks(operation, ids, limit, validate, requestUrls, evidence) {
   const joined = new Map();
   for (let offset = 0; offset < ids.length; offset += limit) {
     const chunk = ids.slice(offset, offset + limit);
     const url = new URL(`/api/v1/${operation}`, API_ORIGIN);
     url.searchParams.set('ids', chunk.join(','));
-    const entries = validate(await fetchJson(url, operation, requestUrls), chunk);
+    const entries = validate(await fetchJson(url, operation, requestUrls, evidence, chunk), chunk);
     for (const [id, value] of entries) joined.set(id, value);
   }
   return joined;
@@ -361,6 +481,7 @@ async function run(args = process.argv.slice(2)) {
       concurrency: { type: 'string' },
       format: { type: 'string', default: 'csv' },
       output: { type: 'string' },
+      'evidence-dir': { type: 'string' },
       help: { type: 'boolean' },
     },
     allowPositionals: false,
@@ -394,18 +515,10 @@ async function run(args = process.argv.slice(2)) {
   if (values.output !== undefined && !values.output.trim()) {
     throw new Error('--output requires a file path');
   }
-
-  const requestUrls = [];
-  const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
-  benchmarkUrl.searchParams.set('model', values.model);
-  if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
-  const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls);
-  if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
-    throw new Error(
-      'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
-    );
+  if (values['evidence-dir'] !== undefined && !values['evidence-dir'].trim()) {
+    throw new Error('--evidence-dir requires a new directory path');
   }
-  const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
+
   const requestedFilters = {
     raw_model: values['raw-model'],
     hardware: values.hardware,
@@ -415,188 +528,352 @@ async function run(args = process.argv.slice(2)) {
     offload_mode: values['offload-mode'],
     concurrency,
   };
-  const selected = agentxRows.filter((row) =>
-    FILTERS.every(
-      ([name, field]) =>
-        requestedFilters[name] === undefined || row[field] === requestedFilters[name],
-    ),
-  );
-  const ids = [...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null))];
-  const aggregates = await fetchChunks('agentic-aggregates', ids, 200, aggregateMap, requestUrls);
-  const derived = await fetchChunks('derived-agentic-metrics', ids, 200, derivedMap, requestUrls);
-  const traces = await fetchChunks('trace-availability', ids, 500, traceMap, requestUrls);
-  let nonFiniteValues = 0;
-  const rows = selected.map((row) => {
-    const benchmark = JSON.parse(
-      JSON.stringify(row, (_key, value) => {
-        if (typeof value === 'number' && !Number.isFinite(value)) {
-          nonFiniteValues++;
-          return null;
-        }
-        return value;
-      }),
-    );
-    const id = safeResultId(row.id);
-    if (id === null) {
-      return {
-        benchmark,
-        agentx: {
-          status: 'unsupported_id',
-          result_id: null,
-          aggregates: { status: 'unsupported_id', value: null },
-          derived_metrics: { status: 'unsupported_id', value: null },
-          trace_availability: {
-            status: 'unsupported_id',
-            value: null,
-            response_key_present: null,
-          },
-        },
-      };
-    }
-    const hasAggregates = aggregates.has(id);
-    const hasDerived = derived.has(id);
-    const hasTraceKey = traces.has(id);
-    const traceAvailable = hasTraceKey ? traces.get(id) : false;
-    return {
-      benchmark,
-      agentx: {
-        status: hasAggregates && hasDerived ? 'complete' : 'partial',
-        result_id: id,
-        aggregates: {
-          status: hasAggregates ? 'available' : 'not_returned',
-          value: hasAggregates ? aggregates.get(id) : null,
-        },
-        derived_metrics: {
-          status: hasDerived ? 'available' : 'not_returned',
-          value: hasDerived ? derived.get(id) : null,
-        },
-        trace_availability: {
-          status: traceAvailable ? 'stored_trace' : 'no_stored_trace',
-          value: traceAvailable,
-          response_key_present: hasTraceKey,
-        },
-      },
-    };
-  });
-  const retrievedAt = new Date().toISOString();
-  const benchmarkRequest = requestUrls[0].url;
   const filters = Object.fromEntries(
     Object.entries(requestedFilters).map(([name, value]) => [
       name,
       { status: value === undefined ? 'omitted' : 'applied', value: value ?? null },
     ]),
   );
-  const metadata = {
-    package_version: PACKAGE_VERSION,
-    retrieved_at: retrievedAt,
-    request_urls: requestUrls,
-    requested_scope: {
-      display_model: values.model,
-      date: values.date ?? null,
-      date_selection: values.date === undefined ? 'latest' : 'as-of',
-      raw_model: values['raw-model'] ?? null,
-      hardware: values.hardware ?? null,
-      framework: values.framework ?? null,
-      precision: values.precision ?? null,
-      spec_method: values['spec-method'] ?? null,
-      offload_mode: values['offload-mode'] ?? null,
-      concurrency: concurrency ?? null,
-      benchmark_type: 'agentic_traces',
+  const requestedScope = {
+    display_model: values.model,
+    date: values.date ?? null,
+    date_selection: values.date === undefined ? 'latest' : 'as-of',
+    raw_model: values['raw-model'] ?? null,
+    hardware: values.hardware ?? null,
+    framework: values.framework ?? null,
+    precision: values.precision ?? null,
+    spec_method: values['spec-method'] ?? null,
+    offload_mode: values['offload-mode'] ?? null,
+    concurrency: concurrency ?? null,
+    benchmark_type: 'agentic_traces',
+  };
+  const appliedFilters = {
+    display_model: { status: 'applied', value: values.model },
+    date: {
+      status: values.date === undefined ? 'omitted' : 'applied',
+      value: values.date ?? null,
     },
-    filters,
-    outcome:
+    benchmark_type: { status: 'applied', value: 'agentic_traces' },
+    ...filters,
+  };
+  const outputPath = values.output === undefined ? null : resolve(values.output);
+  let evidence;
+  let outputTransaction;
+
+  try {
+    if (values['evidence-dir'] !== undefined) {
+      const directory = resolve(values['evidence-dir']);
+      if (outputPath !== null) {
+        const physicalEvidencePath = await physicalPath(directory);
+        const physicalOutputPath = await physicalPath(outputPath);
+        const evidencePath = physicalEvidencePath.toLowerCase();
+        const physicalOutput = physicalOutputPath.toLowerCase();
+        if (
+          containsPath(evidencePath, physicalOutput) ||
+          containsPath(physicalOutput, evidencePath)
+        ) {
+          throw new Error('--output collides with the evidence directory');
+        }
+      }
+      await mkdir(dirname(directory), { recursive: true });
+      await mkdir(directory); // EEXIST also rejects empty directories and symlinks.
+      evidence = {
+        directory,
+        manifest: {
+          schema_version: 1,
+          package_version: PACKAGE_VERSION,
+          status: 'pending',
+          started_at: new Date().toISOString(),
+          finished_at: null,
+          outcome: null,
+          requested_filters: requestedScope,
+          applied_filters: appliedFilters,
+          counts: {
+            returned_rows: null,
+            returned_agentx_rows: null,
+            selected_rows: null,
+          },
+          responses: [],
+          export: {
+            format: values.format,
+            destination: outputPath ?? 'stdout',
+            sha256: null,
+            metadata: null,
+            source_request_numbers: [],
+          },
+          error: null,
+        },
+      };
+      await saveManifest(evidence);
+    }
+
+    const requestUrls = [];
+    const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
+    benchmarkUrl.searchParams.set('model', values.model);
+    if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
+    const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls, evidence);
+    if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
+      throw new Error(
+        'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
+      );
+    }
+    const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
+    const selected = agentxRows.filter((row) =>
+      FILTERS.every(
+        ([name, field]) =>
+          requestedFilters[name] === undefined || row[field] === requestedFilters[name],
+      ),
+    );
+    const outcome =
       agentxRows.length === 0
         ? 'no_agentx_rows'
         : selected.length === 0
           ? 'no_matching_rows'
-          : 'selected_rows',
-    returned_rows: benchmarks.length,
-    returned_agentx_rows: agentxRows.length,
-    selected_rows: rows.length,
-    available_filter_values: {
-      raw_model: unique(agentxRows.map((row) => row.model)),
-      hardware: unique(agentxRows.map((row) => row.hardware)),
-      framework: unique(agentxRows.map((row) => row.framework)),
-      precision: unique(agentxRows.map((row) => row.precision)),
-      spec_method: unique(agentxRows.map((row) => row.spec_method)),
-      offload_mode: unique(agentxRows.map((row) => row.offload_mode)),
-      concurrency: unique(agentxRows.map((row) => row.conc)),
-    },
-    returned_model_keys: unique(benchmarks.map((row) => row.model)),
-    selected_model_keys: unique(selected.map((row) => row.model)),
-    enrichment_coverage: coverage(rows),
-    non_finite_values: nonFiniteValues,
-    observation_context: 'Existing observations were read; no new benchmark was run.',
-  };
-  let output;
-  if (values.format === 'json') {
-    output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
-  } else {
-    const metricColumns = unique(
-      rows.flatMap(({ benchmark }) =>
-        Object.entries(benchmark.metrics)
-          .filter(([, value]) => scalar(value))
-          .map(([key]) => `metrics.${key}`),
-      ),
-    );
-    const columns = [
-      ...CSV_CONTEXT_COLUMNS,
-      ...CSV_BENCHMARK_COLUMNS,
-      ...metricColumns,
-      ...CSV_ENRICHMENT_COLUMNS,
+          : 'selected_rows';
+    if (evidence) {
+      evidence.manifest.outcome = outcome;
+      evidence.manifest.counts = {
+        returned_rows: benchmarks.length,
+        returned_agentx_rows: agentxRows.length,
+        selected_rows: selected.length,
+      };
+      await saveManifest(evidence);
+    }
+    const ids = [
+      ...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null)),
     ];
-    const context = {
+    const aggregates = await fetchChunks(
+      'agentic-aggregates',
+      ids,
+      200,
+      aggregateMap,
+      requestUrls,
+      evidence,
+    );
+    const derived = await fetchChunks(
+      'derived-agentic-metrics',
+      ids,
+      200,
+      derivedMap,
+      requestUrls,
+      evidence,
+    );
+    const traces = await fetchChunks(
+      'trace-availability',
+      ids,
+      500,
+      traceMap,
+      requestUrls,
+      evidence,
+    );
+    let nonFiniteValues = 0;
+    const rows = selected.map((row) => {
+      const benchmark = JSON.parse(
+        JSON.stringify(row, (_key, value) => {
+          if (typeof value === 'number' && !Number.isFinite(value)) {
+            nonFiniteValues++;
+            return null;
+          }
+          return value;
+        }),
+      );
+      const id = safeResultId(row.id);
+      if (id === null) {
+        return {
+          benchmark,
+          agentx: {
+            status: 'unsupported_id',
+            result_id: null,
+            aggregates: { status: 'unsupported_id', value: null },
+            derived_metrics: { status: 'unsupported_id', value: null },
+            trace_availability: {
+              status: 'unsupported_id',
+              value: null,
+              response_key_present: null,
+            },
+          },
+        };
+      }
+      const hasAggregates = aggregates.has(id);
+      const hasDerived = derived.has(id);
+      const hasTraceKey = traces.has(id);
+      const traceAvailable = hasTraceKey ? traces.get(id) : false;
+      return {
+        benchmark,
+        agentx: {
+          status: hasAggregates && hasDerived ? 'complete' : 'partial',
+          result_id: id,
+          aggregates: {
+            status: hasAggregates ? 'available' : 'not_returned',
+            value: hasAggregates ? aggregates.get(id) : null,
+          },
+          derived_metrics: {
+            status: hasDerived ? 'available' : 'not_returned',
+            value: hasDerived ? derived.get(id) : null,
+          },
+          trace_availability: {
+            status: traceAvailable ? 'stored_trace' : 'no_stored_trace',
+            value: traceAvailable,
+            response_key_present: hasTraceKey,
+          },
+        },
+      };
+    });
+    const retrievedAt = new Date().toISOString();
+    const benchmarkRequest = requestUrls[0].url;
+    const metadata = {
       package_version: PACKAGE_VERSION,
-      query_url: benchmarkRequest,
       retrieved_at: retrievedAt,
-      requested_model: values.model,
-      requested_date: values.date ?? null,
-      date_selection: values.date === undefined ? 'latest' : 'as-of',
-      requested_benchmark_type: 'agentic_traces',
-      ...Object.fromEntries(
-        Object.entries(requestedFilters).map(([name, value]) => [`filter.${name}`, value ?? null]),
-      ),
+      request_urls: requestUrls,
+      requested_scope: requestedScope,
+      filters,
+      outcome,
+      returned_rows: benchmarks.length,
+      returned_agentx_rows: agentxRows.length,
+      selected_rows: rows.length,
+      available_filter_values: {
+        raw_model: unique(agentxRows.map((row) => row.model)),
+        hardware: unique(agentxRows.map((row) => row.hardware)),
+        framework: unique(agentxRows.map((row) => row.framework)),
+        precision: unique(agentxRows.map((row) => row.precision)),
+        spec_method: unique(agentxRows.map((row) => row.spec_method)),
+        offload_mode: unique(agentxRows.map((row) => row.offload_mode)),
+        concurrency: unique(agentxRows.map((row) => row.conc)),
+      },
+      returned_model_keys: unique(benchmarks.map((row) => row.model)),
+      selected_model_keys: unique(selected.map((row) => row.model)),
+      enrichment_coverage: coverage(rows),
+      non_finite_values: nonFiniteValues,
+      observation_context: 'Existing observations were read; no new benchmark was run.',
     };
-    const lines = rows.map(({ benchmark, agentx }) => {
-      const aggregateCells = Object.fromEntries(
-        AGGREGATE_GROUPS.flatMap((group) =>
-          [...PERCENTILE_FIELDS, 'n'].map((field) => [
-            `aggregate.${group}.${field}`,
-            agentx.aggregates.value?.[group]?.[field],
-          ]),
+    let output;
+    if (values.format === 'json') {
+      output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
+    } else {
+      const metricColumns = unique(
+        rows.flatMap(({ benchmark }) =>
+          Object.entries(benchmark.metrics)
+            .filter(([, value]) => scalar(value))
+            .map(([key]) => `metrics.${key}`),
         ),
       );
-      const enrichment = {
-        ...aggregateCells,
-        'derived.p75_e2e_norm_intvty': agentx.derived_metrics.value?.p75_e2e_norm_intvty,
-        'derived.p90_e2e_norm_intvty': agentx.derived_metrics.value?.p90_e2e_norm_intvty,
-        'trace.available': agentx.trace_availability.value,
-        'trace.response_key_present': agentx.trace_availability.response_key_present,
-        'enrichment.status': agentx.status,
-        'enrichment.aggregates_status': agentx.aggregates.status,
-        'enrichment.derived_metrics_status': agentx.derived_metrics.status,
-        'enrichment.trace_availability_status': agentx.trace_availability.status,
+      const columns = [
+        ...CSV_CONTEXT_COLUMNS,
+        ...CSV_BENCHMARK_COLUMNS,
+        ...metricColumns,
+        ...CSV_ENRICHMENT_COLUMNS,
+      ];
+      const context = {
+        package_version: PACKAGE_VERSION,
+        query_url: benchmarkRequest,
+        retrieved_at: retrievedAt,
+        requested_model: values.model,
+        requested_date: values.date ?? null,
+        date_selection: values.date === undefined ? 'latest' : 'as-of',
+        requested_benchmark_type: 'agentic_traces',
+        ...Object.fromEntries(
+          Object.entries(requestedFilters).map(([name, value]) => [
+            `filter.${name}`,
+            value ?? null,
+          ]),
+        ),
       };
-      return [
-        ...CSV_CONTEXT_COLUMNS.map((column) => context[column]),
-        ...CSV_BENCHMARK_COLUMNS.map((column) => benchmark[column]),
-        ...metricColumns.map((column) => {
-          const value = benchmark.metrics[column.slice('metrics.'.length)];
-          return scalar(value) ? value : null;
-        }),
-        ...CSV_ENRICHMENT_COLUMNS.map((column) => enrichment[column]),
-      ]
-        .map(csvCell)
-        .join(',');
-    });
-    output = `${[columns.join(','), ...lines].join('\r\n')}\r\n`;
+      const lines = rows.map(({ benchmark, agentx }) => {
+        const aggregateCells = Object.fromEntries(
+          AGGREGATE_GROUPS.flatMap((group) =>
+            [...PERCENTILE_FIELDS, 'n'].map((field) => [
+              `aggregate.${group}.${field}`,
+              agentx.aggregates.value?.[group]?.[field],
+            ]),
+          ),
+        );
+        const enrichment = {
+          ...aggregateCells,
+          'derived.p75_e2e_norm_intvty': agentx.derived_metrics.value?.p75_e2e_norm_intvty,
+          'derived.p90_e2e_norm_intvty': agentx.derived_metrics.value?.p90_e2e_norm_intvty,
+          'trace.available': agentx.trace_availability.value,
+          'trace.response_key_present': agentx.trace_availability.response_key_present,
+          'enrichment.status': agentx.status,
+          'enrichment.aggregates_status': agentx.aggregates.status,
+          'enrichment.derived_metrics_status': agentx.derived_metrics.status,
+          'enrichment.trace_availability_status': agentx.trace_availability.status,
+        };
+        return [
+          ...CSV_CONTEXT_COLUMNS.map((column) => context[column]),
+          ...CSV_BENCHMARK_COLUMNS.map((column) => benchmark[column]),
+          ...metricColumns.map((column) => {
+            const value = benchmark.metrics[column.slice('metrics.'.length)];
+            return scalar(value) ? value : null;
+          }),
+          ...CSV_ENRICHMENT_COLUMNS.map((column) => enrichment[column]),
+        ]
+          .map(csvCell)
+          .join(',');
+      });
+      output = `${[columns.map(csvCell).join(','), ...lines].join('\r\n')}\r\n`;
+    }
+    const outputBytes = Buffer.from(output);
+    if (evidence) {
+      const sourceRequestNumbers = evidence.manifest.responses
+        .filter((record) => record.body_file !== null)
+        .map((record) => record.request_number);
+      if (sourceRequestNumbers.length !== evidence.manifest.responses.length) {
+        throw new Error('Cannot complete evidence with an uncaptured response');
+      }
+      evidence.manifest.export.metadata = metadata;
+      evidence.manifest.export.source_request_numbers = sourceRequestNumbers;
+      await saveManifest(evidence);
+    }
+    if (outputPath === null) {
+      await writeStdout(outputBytes);
+    } else {
+      outputTransaction = await stageFileOutput(outputPath, outputBytes);
+      await outputTransaction.commit();
+    }
+    if (evidence) {
+      evidence.manifest.export.sha256 = sha256(outputBytes);
+      evidence.manifest.status = 'complete';
+      evidence.manifest.finished_at = new Date().toISOString();
+      await saveManifest(evidence);
+    }
+    if (outputTransaction) {
+      await outputTransaction.finish();
+      outputTransaction = null;
+    }
+    process.stderr.write(`${JSON.stringify({ metadata })}\n`);
+    process.stderr.write(
+      `Selected ${metadata.selected_rows} AgentX rows from ${metadata.returned_rows} complete benchmark rows (${metadata.returned_agentx_rows} AgentX before exact-filter selection).\n`,
+    );
+  } catch (error) {
+    let failure = error;
+    if (outputTransaction) {
+      try {
+        await outputTransaction.rollback();
+      } catch (rollbackError) {
+        failure = new Error(
+          `${error.message}; could not restore the previous output: ${rollbackError.message}`,
+          { cause: error },
+        );
+      }
+    }
+    if (evidence) {
+      evidence.manifest.status = 'failed';
+      evidence.manifest.finished_at = new Date().toISOString();
+      evidence.manifest.outcome = 'failed';
+      evidence.manifest.error = failure.message;
+      evidence.manifest.export.sha256 = null;
+      evidence.manifest.export.source_request_numbers = [];
+      try {
+        await saveManifest(evidence);
+      } catch (writeError) {
+        throw new Error(
+          `${failure.message}; could not save failure evidence: ${writeError.message}`,
+          { cause: writeError },
+        );
+      }
+    }
+    throw failure;
   }
-  if (values.output === undefined) process.stdout.write(output);
-  else await writeFile(values.output, output, 'utf8');
-  process.stderr.write(`${JSON.stringify({ metadata })}\n`);
-  process.stderr.write(
-    `Selected ${metadata.selected_rows} AgentX rows from ${metadata.returned_rows} complete benchmark rows (${metadata.returned_agentx_rows} AgentX before raw-model selection).\n`,
-  );
 }
 
 run().catch((error) => {

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.3.0';
+const PACKAGE_VERSION = '0.4.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const HELP = `export-agentx — export existing AgentX observations with summary enrichments
 

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -68,7 +68,7 @@ function benchmarkRow(row) {
   return (
     object(row) &&
     Object.hasOwn(row, 'id') &&
-    (typeof row.id === 'string' || (typeof row.id === 'number' && Number.isInteger(row.id))) &&
+    (typeof row.id === 'string' || (typeof row.id === 'number' && Number.isSafeInteger(row.id))) &&
     REQUIRED_STRING_FIELDS.every((key) => typeof row[key] === 'string') &&
     REQUIRED_BOOLEAN_FIELDS.every((key) => typeof row[key] === 'boolean') &&
     REQUIRED_INTEGER_FIELDS.every((key) => Number.isInteger(row[key])) &&

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -243,7 +243,6 @@ async function stageFileOutput(destination, bytes) {
     },
     async finish() {
       await rm(backup, { force: true }).catch(() => {});
-      await rm(temporary, { force: true }).catch(() => {});
     },
   };
 }

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -17,7 +17,14 @@ Usage:
 Options:
   --date <YYYY-MM-DD>  As-of cutoff; omission selects latest available observations
   --raw-model <key>    Select an exact returned model key within the display bucket
-  --output <file>      Output JSON to a file; default stdout
+  --hardware <key>     Select an exact returned hardware key
+  --framework <key>    Select an exact returned framework key
+  --precision <key>    Select an exact returned precision key
+  --spec-method <key>  Select an exact returned speculative-method key
+  --offload-mode <key> Select an exact returned offload-mode key
+  --concurrency <n>    Select an exact positive concurrency
+  --format <format>    csv (default) or json
+  --output <file>      Output file; default stdout
   --help               Show this help without making a request
 
 The benchmark response is filtered locally to benchmark_type=agentic_traces.
@@ -53,6 +60,72 @@ const REQUIRED_INTEGER_FIELDS = [
 ];
 const AGGREGATE_GROUPS = ['isl', 'osl', 'kvCacheUtil', 'prefixCacheHitRate'];
 const PERCENTILE_FIELDS = ['mean', 'p50', 'p75', 'p90', 'p95', 'p99'];
+const FILTERS = [
+  ['raw_model', 'model'],
+  ['hardware', 'hardware'],
+  ['framework', 'framework'],
+  ['precision', 'precision'],
+  ['spec_method', 'spec_method'],
+  ['offload_mode', 'offload_mode'],
+  ['concurrency', 'conc'],
+];
+const CSV_CONTEXT_COLUMNS = [
+  'package_version',
+  'query_url',
+  'retrieved_at',
+  'requested_model',
+  'requested_date',
+  'date_selection',
+  'requested_benchmark_type',
+  ...FILTERS.map(([name]) => `filter.${name}`),
+];
+const CSV_BENCHMARK_COLUMNS = [
+  'id',
+  'model',
+  'hardware',
+  'framework',
+  'image',
+  'precision',
+  'spec_method',
+  'benchmark_type',
+  'conc',
+  'offload_mode',
+  'recipe_fingerprint',
+  'disagg',
+  'is_multinode',
+  'prefill_tp',
+  'prefill_ep',
+  'prefill_dp_attention',
+  'prefill_num_workers',
+  'decode_tp',
+  'decode_ep',
+  'decode_dp_attention',
+  'decode_num_workers',
+  'num_prefill_gpu',
+  'num_decode_gpu',
+  'isl',
+  'osl',
+  'date',
+  'workflow_run_id',
+  'run_started_at',
+  'run_url',
+  'curve_date',
+  'curve_workflow_run_id',
+  'curve_run_started_at',
+];
+const CSV_ENRICHMENT_COLUMNS = [
+  ...AGGREGATE_GROUPS.flatMap((group) =>
+    [...PERCENTILE_FIELDS, 'n'].map((field) => `aggregate.${group}.${field}`),
+  ),
+  'derived.p75_e2e_norm_intvty',
+  'derived.p90_e2e_norm_intvty',
+  'trace.available',
+  'trace.response_key_present',
+  'enrichment.status',
+  'enrichment.aggregates_status',
+  'enrichment.derived_metrics_status',
+  'enrichment.trace_availability_status',
+];
 
 function object(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -62,6 +135,28 @@ function validDate(value) {
   if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) return false;
   const date = new Date(`${value}T00:00:00Z`);
   return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
+function positiveInteger(value, option) {
+  const number = Number(value);
+  if (!value || !/^\d+$/u.test(value) || !Number.isSafeInteger(number) || number <= 0) {
+    throw new Error(`--${option} must be a positive integer`);
+  }
+  return number;
+}
+
+function csvCell(value) {
+  if (value === null || value === undefined) return '';
+  const text = String(value);
+  return /[",\r\n]/u.test(text) ? `"${text.replaceAll('"', '""')}"` : text;
+}
+
+function scalar(value) {
+  return value === null || ['string', 'number', 'boolean'].includes(typeof value);
+}
+
+function unique(values) {
+  return [...new Set(values)].toSorted();
 }
 
 function benchmarkRow(row) {
@@ -258,6 +353,13 @@ async function run(args = process.argv.slice(2)) {
       model: { type: 'string' },
       date: { type: 'string' },
       'raw-model': { type: 'string' },
+      hardware: { type: 'string' },
+      framework: { type: 'string' },
+      precision: { type: 'string' },
+      'spec-method': { type: 'string' },
+      'offload-mode': { type: 'string' },
+      concurrency: { type: 'string' },
+      format: { type: 'string', default: 'csv' },
       output: { type: 'string' },
       help: { type: 'boolean' },
     },
@@ -272,9 +374,23 @@ async function run(args = process.argv.slice(2)) {
   if (values.date !== undefined && !validDate(values.date)) {
     throw new Error('--date must be a valid YYYY-MM-DD date');
   }
-  if (values['raw-model'] !== undefined && !values['raw-model'].trim()) {
-    throw new Error('--raw-model requires a returned model key');
+  for (const [option, description] of [
+    ['raw-model', 'a returned model key'],
+    ['hardware', 'a returned hardware key'],
+    ['framework', 'a returned framework key'],
+    ['precision', 'a returned precision key'],
+    ['spec-method', 'a returned speculative-method key'],
+    ['offload-mode', 'a returned offload-mode key'],
+  ]) {
+    if (values[option] !== undefined && !values[option].trim()) {
+      throw new Error(`--${option} requires ${description}`);
+    }
   }
+  const concurrency =
+    values.concurrency === undefined
+      ? undefined
+      : positiveInteger(values.concurrency, 'concurrency');
+  if (!['csv', 'json'].includes(values.format)) throw new Error('--format must be csv or json');
   if (values.output !== undefined && !values.output.trim()) {
     throw new Error('--output requires a file path');
   }
@@ -290,8 +406,20 @@ async function run(args = process.argv.slice(2)) {
     );
   }
   const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
-  const selected = agentxRows.filter(
-    (row) => values['raw-model'] === undefined || row.model === values['raw-model'],
+  const requestedFilters = {
+    raw_model: values['raw-model'],
+    hardware: values.hardware,
+    framework: values.framework,
+    precision: values.precision,
+    spec_method: values['spec-method'],
+    offload_mode: values['offload-mode'],
+    concurrency,
+  };
+  const selected = agentxRows.filter((row) =>
+    FILTERS.every(
+      ([name, field]) =>
+        requestedFilters[name] === undefined || row[field] === requestedFilters[name],
+    ),
   );
   const ids = [...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null))];
   const aggregates = await fetchChunks('agentic-aggregates', ids, 200, aggregateMap, requestUrls);
@@ -350,17 +478,32 @@ async function run(args = process.argv.slice(2)) {
       },
     };
   });
+  const retrievedAt = new Date().toISOString();
+  const benchmarkRequest = requestUrls[0].url;
+  const filters = Object.fromEntries(
+    Object.entries(requestedFilters).map(([name, value]) => [
+      name,
+      { status: value === undefined ? 'omitted' : 'applied', value: value ?? null },
+    ]),
+  );
   const metadata = {
     package_version: PACKAGE_VERSION,
-    retrieved_at: new Date().toISOString(),
+    retrieved_at: retrievedAt,
     request_urls: requestUrls,
     requested_scope: {
       display_model: values.model,
       date: values.date ?? null,
       date_selection: values.date === undefined ? 'latest' : 'as-of',
       raw_model: values['raw-model'] ?? null,
+      hardware: values.hardware ?? null,
+      framework: values.framework ?? null,
+      precision: values.precision ?? null,
+      spec_method: values['spec-method'] ?? null,
+      offload_mode: values['offload-mode'] ?? null,
+      concurrency: concurrency ?? null,
       benchmark_type: 'agentic_traces',
     },
+    filters,
     outcome:
       agentxRows.length === 0
         ? 'no_agentx_rows'
@@ -370,13 +513,84 @@ async function run(args = process.argv.slice(2)) {
     returned_rows: benchmarks.length,
     returned_agentx_rows: agentxRows.length,
     selected_rows: rows.length,
-    returned_model_keys: [...new Set(benchmarks.map((row) => row.model))].toSorted(),
-    selected_model_keys: [...new Set(selected.map((row) => row.model))].toSorted(),
+    available_filter_values: {
+      raw_model: unique(agentxRows.map((row) => row.model)),
+      hardware: unique(agentxRows.map((row) => row.hardware)),
+      framework: unique(agentxRows.map((row) => row.framework)),
+      precision: unique(agentxRows.map((row) => row.precision)),
+      spec_method: unique(agentxRows.map((row) => row.spec_method)),
+      offload_mode: unique(agentxRows.map((row) => row.offload_mode)),
+      concurrency: unique(agentxRows.map((row) => row.conc)),
+    },
+    returned_model_keys: unique(benchmarks.map((row) => row.model)),
+    selected_model_keys: unique(selected.map((row) => row.model)),
     enrichment_coverage: coverage(rows),
     non_finite_values: nonFiniteValues,
     observation_context: 'Existing observations were read; no new benchmark was run.',
   };
-  const output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
+  let output;
+  if (values.format === 'json') {
+    output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
+  } else {
+    const metricColumns = unique(
+      rows.flatMap(({ benchmark }) =>
+        Object.entries(benchmark.metrics)
+          .filter(([, value]) => scalar(value))
+          .map(([key]) => `metrics.${key}`),
+      ),
+    );
+    const columns = [
+      ...CSV_CONTEXT_COLUMNS,
+      ...CSV_BENCHMARK_COLUMNS,
+      ...metricColumns,
+      ...CSV_ENRICHMENT_COLUMNS,
+    ];
+    const context = {
+      package_version: PACKAGE_VERSION,
+      query_url: benchmarkRequest,
+      retrieved_at: retrievedAt,
+      requested_model: values.model,
+      requested_date: values.date ?? null,
+      date_selection: values.date === undefined ? 'latest' : 'as-of',
+      requested_benchmark_type: 'agentic_traces',
+      ...Object.fromEntries(
+        Object.entries(requestedFilters).map(([name, value]) => [`filter.${name}`, value ?? null]),
+      ),
+    };
+    const lines = rows.map(({ benchmark, agentx }) => {
+      const aggregateCells = Object.fromEntries(
+        AGGREGATE_GROUPS.flatMap((group) =>
+          [...PERCENTILE_FIELDS, 'n'].map((field) => [
+            `aggregate.${group}.${field}`,
+            agentx.aggregates.value?.[group]?.[field],
+          ]),
+        ),
+      );
+      const enrichment = {
+        ...aggregateCells,
+        'derived.p75_e2e_norm_intvty': agentx.derived_metrics.value?.p75_e2e_norm_intvty,
+        'derived.p90_e2e_norm_intvty': agentx.derived_metrics.value?.p90_e2e_norm_intvty,
+        'trace.available': agentx.trace_availability.value,
+        'trace.response_key_present': agentx.trace_availability.response_key_present,
+        'enrichment.status': agentx.status,
+        'enrichment.aggregates_status': agentx.aggregates.status,
+        'enrichment.derived_metrics_status': agentx.derived_metrics.status,
+        'enrichment.trace_availability_status': agentx.trace_availability.status,
+      };
+      return [
+        ...CSV_CONTEXT_COLUMNS.map((column) => context[column]),
+        ...CSV_BENCHMARK_COLUMNS.map((column) => benchmark[column]),
+        ...metricColumns.map((column) => {
+          const value = benchmark.metrics[column.slice('metrics.'.length)];
+          return scalar(value) ? value : null;
+        }),
+        ...CSV_ENRICHMENT_COLUMNS.map((column) => enrichment[column]),
+      ]
+        .map(csvCell)
+        .join(',');
+    });
+    output = `${[columns.join(','), ...lines].join('\r\n')}\r\n`;
+  }
   if (values.output === undefined) process.stdout.write(output);
   else await writeFile(values.output, output, 'utf8');
   process.stderr.write(`${JSON.stringify({ metadata })}\n`);

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; the packed-artifact test checks this version.
-const PACKAGE_VERSION = '0.3.0';
+const PACKAGE_VERSION = '0.4.0';
 const HELP = `export-powerx — export validated single-turn PowerX observations
 
 Requires Node 24 or later.

--- a/packages/skills/test/agentx-point-diagnostics.test.mjs
+++ b/packages/skills/test/agentx-point-diagnostics.test.mjs
@@ -1,0 +1,338 @@
+import assert from 'node:assert/strict';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { packedSkillSuite } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const { environment, temporaryRoot } = suite;
+const base = 'https://inferencex.semianalysis.com';
+const installed = new Map();
+const preload = join(temporaryRoot, 'agentx-http-response.mjs');
+const operation = (parameter) => ({
+  get: { parameters: [{ name: parameter, in: 'query', required: true }] },
+});
+const openapi = {
+  paths: {
+    '/api/v1/benchmark-siblings': operation('id'),
+    '/api/v1/trace-availability': operation('ids'),
+    '/api/v1/request-timeline': operation('id'),
+    '/api/v1/trace-histograms': operation('ids'),
+    '/api/v1/trace-server-metrics': operation('id'),
+    '/api/v1/request-chart-data': operation('id'),
+    '/api/v1/trace-server-metric-source': operation('id'),
+  },
+};
+
+before(() => {
+  for (const target of ['codex', 'claude']) {
+    const root = suite.install(target);
+    const cookbook = readFileSync(join(root, 'references/agentx.md'), 'utf8');
+    const [snippet, ...extra] = cookbook.matchAll(
+      /```bash\nnode --input-type=module <<'JS'\n(?<code>[\s\S]*?)\nJS\n```/gu,
+    );
+    assert.ok(snippet, 'installed AgentX cookbook must contain the maintained recipe');
+    assert.equal(extra.length, 0, 'AgentX cookbook must have one maintained executable recipe');
+    installed.set(target, snippet.groups.code);
+  }
+  writeFileSync(
+    preload,
+    `
+import { appendFileSync, readFileSync } from 'node:fs';
+const fixtures = JSON.parse(readFileSync(process.env.INFERENCEX_AGENTX_FIXTURES, 'utf8'));
+globalThis.fetch = async (input) => {
+  const url = String(input.url ?? input);
+  appendFileSync(process.env.INFERENCEX_AGENTX_REQUESTS, JSON.stringify(url) + '\\n');
+  const response = fixtures[url];
+  if (!response) throw new Error('Unexpected request: ' + url);
+  return new Response(response.body, { status: response.status ?? 200 });
+};
+`,
+  );
+});
+
+const response = (value, status = 200) => ({ body: JSON.stringify(value), status });
+const siblingResponse = {
+  sku: {
+    hardware: 'h200_sxm',
+    framework: 'vllm',
+    model: 'dsr1',
+    precision: 'fp8',
+    spec_method: 'none',
+    benchmark_type: 'agentic_traces',
+    github_run_id: 123456789,
+    date: '2026-08-08',
+    dataset_slug: 'cc-traces-weka',
+    image: 'vllm:sha-123',
+    observation_id: 'observation-421',
+    producer: { workflow: 'agentx' },
+    snapshot: { date: '2026-08-09' },
+  },
+  siblings: [
+    {
+      id: 421,
+      conc: 32,
+      offload_mode: 'off',
+      decode_tp: 8,
+      decode_ep: 1,
+      decode_pp: null,
+      decode_dcp_size: 8,
+      decode_pcp_size: 1,
+      decode_dp_attention: false,
+      decode_num_workers: 1,
+      prefill_tp: 8,
+      prefill_ep: 1,
+      prefill_pp: null,
+      prefill_dcp_size: 8,
+      prefill_pcp_size: 1,
+      prefill_dp_attention: false,
+      prefill_num_workers: 1,
+      num_prefill_gpu: 0,
+      num_decode_gpu: 8,
+      disagg: false,
+      is_multinode: false,
+      tput_per_gpu: 128.4,
+      total_requests: 320,
+      is_current: true,
+      has_trace: true,
+    },
+  ],
+};
+const request = (phase, overrides = {}) => ({
+  cid: `trace-${phase}`,
+  ri: 0,
+  ti: 0,
+  wid: '7',
+  ad: 0,
+  phase,
+  credit: 0,
+  start: 1_200_000,
+  ack: 1_800_000,
+  end: 420_000_000,
+  ttftMs: 42.3,
+  tpotMs: 18.1,
+  isl: 18_320,
+  osl: 410,
+  cancelled: false,
+  ...overrides,
+});
+const timeline = {
+  version: 6,
+  startNs: 1_000_000_000,
+  endNs: 2_400_000_000,
+  durationS: 1.4,
+  requests: [
+    request('warmup'),
+    request('profiling'),
+    request('main-agent'),
+    request('subagent', { srcKind: 'subagent' }),
+    request('replay-lane', {
+      srcTrace: 'trace-018',
+      srcOuter: 2,
+      srcInner: 1,
+      srcKind: 'tool',
+      cancelled: true,
+      ack: null,
+      ttftMs: null,
+      tpotMs: null,
+      osl: null,
+    }),
+  ],
+};
+const histograms = { 421: { id: 421, isl: [18_220, 19_340], osl: [410, 380] } };
+const serverMetrics = {
+  meta: { id: 421, hardware: 'h200_sxm', framework: 'vllm', model: 'dsr1', conc: 32 },
+  startNs: 1_000_000_000,
+  endNs: 2_400_000_000,
+  durationS: 1.4,
+  timeslicesCount: 2,
+  kvCacheUsage: [{ t: 0, v: 0.44 }],
+  prefixCacheHitRate: [{ t: 0, v: 0 }],
+  queueDepth: [{ t: 0, v: 2 }],
+  promptTokensBySource: { agent: [{ t: 0, v: 100 }] },
+  prefillTps: [{ t: 0, v: 80 }],
+  decodeTps: [{ t: 0, v: 40 }],
+  prefixCacheHitsTps: [],
+  hostKvCacheUsage: [],
+  kvCacheUsageByEngine: [{ engine: '0', t: 0, v: 0.44 }],
+  kvCachePoolTokens: 983_040,
+  metricSources: [{ key: 'aggregate', label: 'Aggregate' }],
+};
+
+function run(
+  responses,
+  { target = 'codex', openapiResponse = response(openapi), replacement } = {},
+) {
+  const project = suite.project('agentx-request-');
+  const fixtures = { [`${base}/api/openapi.json`]: openapiResponse };
+  for (const [path, value] of Object.entries(responses)) fixtures[`${base}${path}`] = value;
+  const fixturesPath = join(project, 'responses.json');
+  const requestsPath = join(project, 'requests.jsonl');
+  writeFileSync(fixturesPath, JSON.stringify(fixtures));
+  let code = installed.get(target);
+  if (replacement) code = code.replace(...replacement);
+  const result = suite.node(['--import', pathToFileURL(preload).href, '--input-type=module'], {
+    cwd: project,
+    env: {
+      ...environment,
+      INFERENCEX_AGENTX_FIXTURES: fixturesPath,
+      INFERENCEX_AGENTX_REQUESTS: requestsPath,
+    },
+    input: code,
+  });
+  const logged = readFileSync(requestsPath, { encoding: 'utf8', flag: 'a+' }).trimEnd();
+  return { ...result, requests: logged ? logged.split('\n').map(JSON.parse) : [] };
+}
+
+const lightResponses = {
+  '/api/v1/benchmark-siblings?id=421': response(siblingResponse),
+  '/api/v1/trace-availability?ids=421': response({}),
+};
+const heavyResponses = {
+  '/api/v1/benchmark-siblings?id=421': response(siblingResponse),
+  '/api/v1/trace-availability?ids=421': response({ 421: true }),
+  '/api/v1/request-timeline?id=421': response(timeline),
+  '/api/v1/trace-histograms?ids=421': response(histograms),
+  '/api/v1/trace-server-metrics?id=421': response(serverMetrics),
+};
+
+test('installed recipe short-circuits an unavailable trace after preserving sibling identity', () => {
+  const result = run(lightResponses);
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.outcome, 'trace_unavailable');
+  assert.deepEqual(output.benchmark_siblings, siblingResponse);
+  assert.deepEqual(output.selected_point, siblingResponse.siblings[0]);
+  assert.deepEqual(output.trace_availability, {
+    response: {},
+    key_present: false,
+    available: false,
+  });
+  assert.equal(output.metadata.ran_new_benchmark, false);
+  assert.equal(output.metadata.event_timestamp_unit, 'nanoseconds');
+  assert.match(output.metadata.event_timestamp_origin, /timeline\.startNs; not wall-clock/u);
+  assert.equal(output.timeline, null);
+  assert.equal(output.histograms, null);
+  assert.equal(output.server_metrics, null);
+  assert.deepEqual(result.requests, [
+    `${base}/api/openapi.json`,
+    `${base}/api/v1/benchmark-siblings?id=421`,
+    `${base}/api/v1/trace-availability?ids=421`,
+  ]);
+});
+
+test('installed recipe reads one selected point and preserves every request phase and cancellation', () => {
+  const result = run(heavyResponses, { target: 'claude' });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.outcome, 'trace_diagnostics');
+  assert.deepEqual(output.timeline, timeline);
+  assert.deepEqual(
+    output.timeline.requests.map((item) => item.phase),
+    ['warmup', 'profiling', 'main-agent', 'subagent', 'replay-lane'],
+  );
+  assert.equal(output.timeline.requests.at(-1).cancelled, true);
+  assert.equal(output.timeline.requests.at(-1).srcTrace, 'trace-018');
+  assert.deepEqual(output.histograms, histograms);
+  assert.deepEqual(output.server_metrics, serverMetrics);
+  assert.deepEqual(result.requests, [
+    `${base}/api/openapi.json`,
+    `${base}/api/v1/benchmark-siblings?id=421`,
+    `${base}/api/v1/trace-availability?ids=421`,
+    `${base}/api/v1/request-timeline?id=421`,
+    `${base}/api/v1/trace-histograms?ids=421`,
+    `${base}/api/v1/trace-server-metrics?id=421`,
+  ]);
+  assert.ok(result.requests.every((url) => !url.includes('request-chart-data')));
+  assert.ok(result.requests.every((url) => !url.includes('trace-server-metric-source')));
+  assert.deepEqual(
+    output.metadata.requests.map((item) => item.query_url),
+    result.requests,
+  );
+  assert.ok(
+    output.metadata.requests.every((item) => Number.isFinite(Date.parse(item.retrieved_at))),
+  );
+});
+
+test('one positive safe result ID is required before any HTTP request', () => {
+  for (const value of ['0', '1.5', '9007199254740992', '0421']) {
+    const result = run(
+      {},
+      {
+        replacement: ["const selectedResultId = '421';", `const selectedResultId = '${value}';`],
+      },
+    );
+    assert.notEqual(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.deepEqual(result.requests, []);
+  }
+});
+
+test('the selected decimal ID remains a string in output while diagnostic URLs use it losslessly', () => {
+  const result = run(lightResponses);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).metadata.selected_result_id, '421');
+});
+
+test('advertised traces fail as inconsistencies on HTTP and malformed heavy responses', () => {
+  const failures = [
+    {
+      responses: {
+        ...heavyResponses,
+        '/api/v1/request-timeline?id=421': response({ error: 'Not found' }, 404),
+      },
+    },
+    {
+      responses: { ...heavyResponses, '/api/v1/request-timeline?id=421': { body: '{' } },
+    },
+    {
+      responses: {
+        ...heavyResponses,
+        '/api/v1/request-timeline?id=421': response({ ...timeline, requests: [{}] }),
+      },
+    },
+    {
+      responses: { ...heavyResponses, '/api/v1/trace-histograms?ids=421': response({}) },
+    },
+    {
+      responses: {
+        ...heavyResponses,
+        '/api/v1/trace-server-metrics?id=421': response({ ...serverMetrics, queueDepth: null }),
+      },
+    },
+  ];
+  for (const { responses } of failures) {
+    const result = run(responses);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /Trace availability inconsistency for result 421/u);
+  }
+});
+
+test('malformed light responses and missing live operations fail without heavy trace requests', () => {
+  for (const [responses, options = {}] of [
+    [{ '/api/v1/benchmark-siblings?id=421': { body: '{' } }],
+    [{ '/api/v1/benchmark-siblings?id=421': response({ sku: {}, siblings: [] }) }],
+    [
+      {
+        '/api/v1/benchmark-siblings?id=421': response(siblingResponse),
+        '/api/v1/trace-availability?ids=421': response({ 422: true }),
+      },
+    ],
+    [lightResponses, { openapiResponse: response({ paths: {} }) }],
+  ]) {
+    const result = run(responses, options);
+    assert.notEqual(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.ok(
+      result.requests.every(
+        (url) =>
+          !url.includes('request-timeline') &&
+          !url.includes('trace-histograms') &&
+          !url.includes('trace-server-metrics'),
+      ),
+    );
+  }
+});

--- a/packages/skills/test/agentx-point-diagnostics.test.mjs
+++ b/packages/skills/test/agentx-point-diagnostics.test.mjs
@@ -42,9 +42,10 @@ before(() => {
     `
 import { appendFileSync, readFileSync } from 'node:fs';
 const fixtures = JSON.parse(readFileSync(process.env.INFERENCEX_AGENTX_FIXTURES, 'utf8'));
-globalThis.fetch = async (input) => {
+globalThis.fetch = async (input, options) => {
   const url = String(input.url ?? input);
   appendFileSync(process.env.INFERENCEX_AGENTX_REQUESTS, JSON.stringify(url) + '\\n');
+  if (options?.redirect !== 'error') throw new Error('AgentX requests must reject redirects');
   const response = fixtures[url];
   if (!response) throw new Error('Unexpected request: ' + url);
   return new Response(response.body, { status: response.status ?? 200 });

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -69,11 +69,7 @@ function derived(id, value = id) {
   return { id, p75_e2e_norm_intvty: value, p90_e2e_norm_intvty: value };
 }
 
-function mapBody(entries) {
-  return `{${entries
-    .map(([key, value]) => `${JSON.stringify(String(key))}:${JSON.stringify(value)}`)
-    .join(',')}}`;
-}
+const mapBody = (entries) => JSON.stringify(Object.fromEntries(entries));
 
 const response = (body, status = 200) => ({ body, status });
 
@@ -405,6 +401,9 @@ test('malformed required shapes and unrelated enrichment IDs fail closed', () =>
   const failures = [
     { '/api/v1/benchmarks': [response('{}')] },
     { '/api/v1/benchmarks': [response('{')] },
+    {
+      '/api/v1/benchmarks': [response(JSON.stringify([observation(Number.MAX_SAFE_INTEGER + 1)]))],
+    },
     {
       ...routesFor([row], [1]),
       '/api/v1/agentic-aggregates': [response('[]')],

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -1,5 +1,13 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { before, test } from 'node:test';
 import { pathToFileURL } from 'node:url';
@@ -71,15 +79,18 @@ function derived(id, value = id) {
 
 const mapBody = (entries) => JSON.stringify(Object.fromEntries(entries));
 
-const response = (body, status = 200) => ({ body, status });
+const response = (body, status = 200, faults = {}) => ({ body, status, ...faults });
 
-function run(args, routes, cwd = project()) {
+function run(args, routes, cwdOrOptions = project()) {
+  const options = typeof cwdOrOptions === 'string' ? { cwd: cwdOrOptions } : cwdOrOptions;
+  const { cwd = project(), maxBuffer = 16 * 1024 * 1024, ...faults } = options;
   const fixtureRoot = project('agentx-response-');
   const fixturePath = join(fixtureRoot, 'responses.json');
   const requestPath = join(fixtureRoot, 'requests.txt');
-  writeFileSync(fixturePath, JSON.stringify({ routes }));
+  writeFileSync(fixturePath, JSON.stringify({ routes, ...faults }));
   const result = suite.node(['--import', pathToFileURL(preload).href, exporter, ...args], {
     cwd,
+    maxBuffer,
     env: {
       ...environment,
       INFERENCEX_TEST_RESPONSE: fixturePath,
@@ -110,23 +121,70 @@ function metadataFrom(result) {
 }
 
 function csvRecords(text) {
-  const [header, ...lines] = text
-    .trimEnd()
-    .split('\r\n')
-    .map((line) => line.split(','));
+  const records = [];
+  let record = [];
+  const matches = [...text.matchAll(/(?<cell>"(?:[^"]|"")*"|[^,"\r\n]*)(?<delimiter>,|\r\n)/gu)];
+  assert.equal(matches.map(([whole]) => whole).join(''), text, 'parse every CSV byte');
+  for (const [, raw, delimiter] of matches) {
+    record.push(raw.startsWith('"') ? raw.slice(1, -1).replaceAll('""', '"') : raw);
+    if (delimiter === '\r\n') {
+      records.push(record);
+      record = [];
+    }
+  }
+  const [header, ...lines] = records;
   return {
     header,
     rows: lines.map((line) => Object.fromEntries(header.map((key, index) => [key, line[index]]))),
   };
 }
 
+function captured(result, directory = 'evidence') {
+  const root = join(result.cwd, directory);
+  const manifest = JSON.parse(readFileSync(join(root, 'manifest.json'), 'utf8'));
+  const bodies = new Map(
+    manifest.responses
+      .filter((record) => record.body_file !== null)
+      .map((record) => [record.request_number, readFileSync(join(root, record.body_file))]),
+  );
+  return { root, manifest, bodies };
+}
+
+function chunks(values, size) {
+  return Array.from({ length: Math.ceil(values.length / size) }, (_, index) =>
+    values.slice(index * size, (index + 1) * size),
+  );
+}
+
 before(() => {
   writeFileSync(
     preload,
     `
-import { appendFileSync, readFileSync } from 'node:fs';
+import fs, { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+import { join } from 'node:path';
 const fixture = JSON.parse(readFileSync(process.env.INFERENCEX_TEST_RESPONSE, 'utf8'));
 const calls = {};
+const originalWriteFile = fs.promises.writeFile;
+let completeManifestFailure = fixture.failCompleteManifest;
+fs.promises.writeFile = async (path, data, ...rest) => {
+  const text = String(data);
+  if (String(path).endsWith('manifest.tmp')) {
+    if (completeManifestFailure && text.includes('"status": "complete"')) {
+      completeManifestFailure = false;
+      throw new Error('controlled complete manifest failure');
+    }
+    if (fixture.failFailureManifest && text.includes('"status": "failed"')) {
+      throw new Error('controlled failure-manifest failure');
+    }
+  }
+  return originalWriteFile(path, data, ...rest);
+};
+syncBuiltinESMExports();
+if (fixture.stdoutFailure) process.stdout.write = (_output, callback) => {
+  queueMicrotask(() => callback(Object.assign(new Error('broken pipe'), { code: 'EPIPE' })));
+  return false;
+};
 globalThis.fetch = async (input, options) => {
   const url = new URL(input.url ?? input);
   appendFileSync(process.env.INFERENCEX_TEST_REQUESTS, url.href + '\\n');
@@ -135,7 +193,19 @@ globalThis.fetch = async (input, options) => {
   calls[url.pathname] = index + 1;
   const reply = fixture.routes[url.pathname]?.[index];
   if (!reply) return new Response('{"error":"unexpected request"}', { status: 599 });
-  return new Response(reply.body, { status: reply.status, headers: { 'Content-Type': 'application/json' } });
+  if (reply.timeout) throw new DOMException('Timed out', 'TimeoutError');
+  if (reply.blockEvidenceFile) mkdirSync(join(fixture.evidenceDir, reply.blockEvidenceFile));
+  const headers = { 'Content-Type': 'application/json' };
+  if (reply.gzip) headers['Content-Encoding'] = 'gzip';
+  if (reply.bodyFailure) {
+    return new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"partial":'));
+        controller.error(new Error('body interrupted'));
+      },
+    }), { status: reply.status, headers });
+  }
+  return new Response(reply.body, { status: reply.status, headers });
 };
 `,
   );
@@ -465,7 +535,14 @@ test('all serving filters are independent, exact, case-sensitive, and composable
 test('default CSV has deterministic context, dynamic scalar metrics, and fixed enrichments', () => {
   const rows = [
     observation('2', {
-      metrics: { z_metric: null, alpha_metric: 2, nested_metric: { value: 3 } },
+      metrics: {
+        z_metric: null,
+        alpha_metric: 2,
+        'comma,key': 3,
+        'quote"key': 4,
+        'line\nkey': 5,
+        nested_metric: { value: 3 },
+      },
     }),
     observation('1', {
       metrics: {
@@ -527,7 +604,14 @@ test('default CSV has deterministic context, dynamic scalar metrics, and fixed e
   const csv = csvRecords(result.stdout);
   assert.deepEqual(
     csv.header.filter((column) => column.startsWith('metrics.')),
-    ['metrics.alpha_metric', 'metrics.beta_metric', 'metrics.z_metric'],
+    [
+      'metrics.alpha_metric',
+      'metrics.beta_metric',
+      'metrics.comma,key',
+      'metrics.line\nkey',
+      'metrics.quote"key',
+      'metrics.z_metric',
+    ],
   );
   assert.equal(csv.header.includes('metrics.array_metric'), false);
   assert.equal(csv.header.includes('metrics.nested_metric'), false);
@@ -561,6 +645,9 @@ test('default CSV has deterministic context, dynamic scalar metrics, and fixed e
     assert.equal(row['filter.raw_model'], '');
   }
   assert.equal(csv.rows[0]['metrics.z_metric'], '');
+  assert.equal(csv.rows[0]['metrics.comma,key'], '3');
+  assert.equal(csv.rows[0]['metrics.quote"key'], '4');
+  assert.equal(csv.rows[0]['metrics.line\nkey'], '5');
   assert.equal(csv.rows[0]['metrics.beta_metric'], '');
   assert.equal(csv.rows[1]['metrics.z_metric'], '0');
   assert.equal(csv.rows[1]['metrics.beta_metric'], 'false');
@@ -596,16 +683,19 @@ test('invalid arguments fail before HTTP or output writes; help is offline', () 
     ['--model', 'DeepSeek-V4-Pro', '--concurrency', '9007199254740992'],
     ['--model', 'DeepSeek-V4-Pro', '--format', 'yaml'],
     ['--model', 'DeepSeek-V4-Pro', '--output', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', ''],
     ['--model', 'DeepSeek-V4-Pro', '--unexpected'],
     ['--model', 'DeepSeek-V4-Pro', 'extra'],
   ];
   for (const args of invalid) {
     const cwd = project();
-    const result = run(
-      args.includes('--output') ? args : [...args, '--output', 'should-not-exist.json'],
-      {},
-      cwd,
-    );
+    const runArgs = args.includes('--output')
+      ? [...args]
+      : [...args, '--output', 'should-not-exist.json'];
+    if (!args.includes('--evidence-dir')) {
+      runArgs.push('--evidence-dir', 'should-not-exist-evidence');
+    }
+    const result = run(runArgs, {}, cwd);
     assert.notEqual(result.status, 0, args.join(' '));
     assert.equal(result.stdout, '');
     assert.equal(result.requests.length, 0);
@@ -660,5 +750,384 @@ test('malformed required shapes and unrelated enrichment IDs fail closed', () =>
     assert.equal(result.status, 1);
     assert.equal(result.stdout, '');
     assert.match(result.stderr, /Unexpected|JSON/);
+  }
+});
+
+test('evidence captures every decoded response chunk once and hashes stdout bytes', () => {
+  const ids = Array.from({ length: 501 }, (_, index) => index + 1);
+  const rows = ids.map((id) => observation(String(id)));
+  const benchmarkBody = `\uFEFF${JSON.stringify(rows, null, 2)} \n`;
+  const aggregateBodies = chunks(ids, 200).map(
+    (chunk) => ` ${mapBody(chunk.map((id) => [id, aggregate(id)]))}\n`,
+  );
+  const derivedBodies = chunks(ids, 200).map(
+    (chunk) => `${mapBody(chunk.map((id) => [id, derived(id)]))} \n`,
+  );
+  const traceBodies = chunks(ids, 500).map(
+    (chunk) => `${mapBody(chunk.map((id) => [id, true]))}\n`,
+  );
+  const routes = {
+    '/api/v1/benchmarks': [response(benchmarkBody, 200, { gzip: true })],
+    '/api/v1/agentic-aggregates': aggregateBodies.map((body) =>
+      response(body, 200, { gzip: true }),
+    ),
+    '/api/v1/derived-agentic-metrics': derivedBodies.map((body) =>
+      response(body, 200, { gzip: true }),
+    ),
+    '/api/v1/trace-availability': traceBodies.map((body) => response(body, 200, { gzip: true })),
+  };
+  const result = run(
+    [
+      '--model',
+      'DeepSeek-V4-Pro',
+      '--date',
+      '2026-09-04',
+      '--format',
+      'json',
+      '--evidence-dir',
+      'evidence',
+    ],
+    routes,
+  );
+  succeeded(result);
+
+  const { root, manifest, bodies } = captured(result);
+  const expectedBodies = [benchmarkBody, ...aggregateBodies, ...derivedBodies, ...traceBodies];
+  const expectedChunks = [null, ...chunks(ids, 200), ...chunks(ids, 200), ...chunks(ids, 500)];
+  assert.equal(result.requests.length, 9);
+  assert.equal(manifest.schema_version, 1);
+  assert.equal(manifest.package_version, packageInfo.version);
+  assert.equal(manifest.status, 'complete');
+  assert.equal(manifest.error, null);
+  assert.equal(manifest.outcome, 'selected_rows');
+  assert.ok(Number.isFinite(Date.parse(manifest.started_at)));
+  assert.ok(Number.isFinite(Date.parse(manifest.finished_at)));
+  assert.deepEqual(manifest.counts, {
+    returned_rows: 501,
+    returned_agentx_rows: 501,
+    selected_rows: 501,
+  });
+  assert.equal(manifest.requested_filters.display_model, 'DeepSeek-V4-Pro');
+  assert.deepEqual(manifest.applied_filters.hardware, { status: 'omitted', value: null });
+  assert.deepEqual(
+    manifest.responses.map((record) => record.operation),
+    [
+      'benchmarks',
+      'agentic-aggregates',
+      'agentic-aggregates',
+      'agentic-aggregates',
+      'derived-agentic-metrics',
+      'derived-agentic-metrics',
+      'derived-agentic-metrics',
+      'trace-availability',
+      'trace-availability',
+    ],
+  );
+  for (const [index, record] of manifest.responses.entries()) {
+    const requestNumber = index + 1;
+    const saved = bodies.get(requestNumber);
+    assert.equal(record.request_number, requestNumber);
+    assert.equal(record.url, result.requests[index]);
+    assert.equal(record.method, 'GET');
+    assert.equal(record.http_status, 200);
+    assert.ok(Number.isFinite(Date.parse(record.retrieved_at)));
+    assert.deepEqual(record.requested_chunk_ids, expectedChunks[index]);
+    assert.equal(
+      record.body_file,
+      `response-${String(requestNumber).padStart(4, '0')}-${record.operation}.json`,
+    );
+    assert.deepEqual(saved, Buffer.from(expectedBodies[index]));
+    assert.equal(record.decoded_body_sha256, createHash('sha256').update(saved).digest('hex'));
+    assert.equal(record.checksum_covers, 'saved decoded response body');
+  }
+  assert.deepEqual(manifest.export.source_request_numbers, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  assert.equal(manifest.export.destination, 'stdout');
+  assert.equal(manifest.export.format, 'json');
+  assert.equal(
+    manifest.export.sha256,
+    createHash('sha256').update(Buffer.from(result.stdout)).digest('hex'),
+  );
+  assert.deepEqual(manifest.export.metadata, JSON.parse(result.stdout).metadata);
+  assert.deepEqual(
+    readdirSync(root).sort(),
+    ['manifest.json', ...manifest.responses.map((record) => record.body_file)].sort(),
+  );
+});
+
+test('empty evidence exports are complete, distinct, and benchmark-only', () => {
+  for (const [rows, extraArgs, outcome, destination] of [
+    [[observation('1', { benchmark_type: 'single_turn' })], [], 'no_agentx_rows', null],
+    [[observation('1')], ['--hardware', 'b200'], 'no_matching_rows', 'empty.csv'],
+  ]) {
+    const args = ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence', ...extraArgs];
+    if (destination) args.push('--output', destination);
+    const body = `${JSON.stringify(rows, null, 2)}\n`;
+    const result = run(args, {
+      '/api/v1/benchmarks': [response(body, 200, { gzip: true })],
+    });
+    succeeded(result);
+    const { manifest, bodies } = captured(result);
+    const output = destination
+      ? readFileSync(join(result.cwd, destination))
+      : Buffer.from(result.stdout);
+    assert.equal(result.requests.length, 1);
+    assert.equal(manifest.status, 'complete');
+    assert.equal(manifest.outcome, outcome);
+    assert.equal(manifest.responses.length, 1);
+    assert.deepEqual(bodies.get(1), Buffer.from(body));
+    assert.deepEqual(manifest.export.source_request_numbers, [1]);
+    assert.equal(manifest.export.sha256, createHash('sha256').update(output).digest('hex'));
+    assert.equal(manifest.export.metadata.outcome, outcome);
+    assert.equal(manifest.counts.selected_rows, 0);
+    assert.equal(manifest.counts.returned_agentx_rows, outcome === 'no_agentx_rows' ? 0 : 1);
+  }
+});
+
+test('HTTP failures for every operation are captured and never replace an output', () => {
+  const operationForPath = {
+    '/api/v1/benchmarks': 'benchmarks',
+    '/api/v1/agentic-aggregates': 'agentic-aggregates',
+    '/api/v1/derived-agentic-metrics': 'derived-agentic-metrics',
+    '/api/v1/trace-availability': 'trace-availability',
+  };
+  for (const [path, operation] of Object.entries(operationForPath)) {
+    const routes = routesFor([observation('1')], [1]);
+    const failureBody = `{"error":"controlled ${operation} failure"}\n`;
+    routes[path][0] = response(failureBody, 503, { gzip: true });
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.json'), 'keep existing output');
+    const result = run(
+      [
+        '--model',
+        'DeepSeek-V4-Pro',
+        '--format',
+        'json',
+        '--output',
+        'agentx.json',
+        '--evidence-dir',
+        'evidence',
+      ],
+      routes,
+      { cwd },
+    );
+    assert.equal(result.status, 1, operation);
+    assert.match(result.stderr, /HTTP 503.*controlled/u, operation);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep existing output');
+    const { manifest, bodies } = captured(result);
+    const failed = manifest.responses.at(-1);
+    assert.equal(manifest.status, 'failed');
+    assert.equal(manifest.outcome, 'failed');
+    assert.equal(manifest.export.sha256, null);
+    assert.deepEqual(manifest.export.source_request_numbers, []);
+    assert.equal(failed.operation, operation);
+    assert.equal(failed.http_status, 503);
+    assert.deepEqual(bodies.get(failed.request_number), Buffer.from(failureBody));
+    assert.equal(
+      failed.decoded_body_sha256,
+      createHash('sha256').update(Buffer.from(failureBody)).digest('hex'),
+    );
+  }
+});
+
+test('transport, JSON, shape, and enrichment-ID failures leave auditable failed evidence', () => {
+  const row = observation('1');
+  const cases = [
+    {
+      routes: { '/api/v1/benchmarks': [response('', 200, { timeout: true })] },
+      error: /Timed out/u,
+      status: null,
+      body: null,
+    },
+    {
+      routes: { '/api/v1/benchmarks': [response('', 200, { bodyFailure: true, gzip: true })] },
+      error: /body interrupted/u,
+      status: 200,
+      body: null,
+    },
+    {
+      routes: { '/api/v1/benchmarks': [response('{')] },
+      error: /JSON/u,
+      status: 200,
+      body: '{',
+    },
+    {
+      routes: { '/api/v1/benchmarks': [response('{}')] },
+      error: /response shape/iu,
+      status: 200,
+      body: '{}',
+    },
+    {
+      routes: {
+        ...routesFor([row], [1]),
+        '/api/v1/agentic-aggregates': [response(mapBody([[2, aggregate(2)]]))],
+      },
+      error: /result ID/u,
+      status: 200,
+      body: mapBody([[2, aggregate(2)]]),
+    },
+  ];
+  for (const entry of cases) {
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.json'), 'keep existing output');
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--output', 'agentx.json', '--evidence-dir', 'evidence'],
+      entry.routes,
+      { cwd },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, entry.error);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep existing output');
+    const { manifest, bodies } = captured(result);
+    const failed = manifest.responses.at(-1);
+    assert.equal(manifest.status, 'failed');
+    assert.match(manifest.error, entry.error);
+    assert.equal(failed.http_status, entry.status);
+    if (entry.body === null) {
+      assert.equal(failed.body_file, null);
+      assert.equal(failed.decoded_body_sha256, null);
+      assert.equal(bodies.has(failed.request_number), false);
+    } else {
+      assert.deepEqual(bodies.get(failed.request_number), Buffer.from(entry.body));
+    }
+  }
+});
+
+test('fresh evidence preflight rejects reuse, aliases, and two-way containment before HTTP', () => {
+  const cwd = project();
+  mkdirSync(join(cwd, 'existing'));
+  writeFileSync(join(cwd, 'existing/keep'), 'untouched');
+  mkdirSync(join(cwd, 'empty'));
+  symlinkSync(join(cwd, 'existing'), join(cwd, 'directory-link'));
+  symlinkSync(join(cwd, 'evidence/manifest.json'), join(cwd, 'output-link'));
+  const failures = [
+    ['--evidence-dir', 'existing'],
+    ['--evidence-dir', 'empty'],
+    ['--evidence-dir', 'directory-link'],
+    ['--evidence-dir', 'evidence', '--output', 'evidence'],
+    ['--evidence-dir', 'evidence', '--output', 'evidence/export.csv'],
+    ['--evidence-dir', 'evidence', '--output', 'evidence/manifest.json'],
+    ['--evidence-dir', 'evidence', '--output', 'EVIDENCE/EXPORT.CSV'],
+    ['--evidence-dir', 'parent/child', '--output', 'parent'],
+    ['--evidence-dir', 'evidence', '--output', 'output-link'],
+  ];
+  for (const args of failures) {
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', ...args],
+      routesFor([observation('1')], [1]),
+      { cwd },
+    );
+    assert.equal(result.status, 1, args.join(' '));
+    assert.equal(result.requests.length, 0, args.join(' '));
+    assert.equal(result.stdout, '');
+    assert.equal(existsSync(join(cwd, 'evidence')), false);
+    assert.equal(existsSync(join(cwd, 'parent')), false);
+  }
+  assert.equal(readFileSync(join(cwd, 'existing/keep'), 'utf8'), 'untouched');
+  assert.deepEqual(readdirSync(join(cwd, 'empty')), []);
+});
+
+test('evidence, output, and stdout write failures never become complete', () => {
+  {
+    const cwd = project();
+    const evidenceDir = join(cwd, 'evidence');
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'],
+      {
+        '/api/v1/benchmarks': [
+          response(JSON.stringify([observation('1')]), 200, {
+            blockEvidenceFile: 'response-0001-benchmarks.json',
+          }),
+        ],
+      },
+      { cwd, evidenceDir },
+    );
+    assert.equal(result.status, 1);
+    const { manifest } = captured(result);
+    assert.equal(manifest.status, 'failed');
+    assert.equal(manifest.responses[0].body_file, null);
+  }
+
+  {
+    const cwd = project();
+    const evidenceDir = join(cwd, 'evidence');
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'],
+      {
+        '/api/v1/benchmarks': [
+          response(JSON.stringify([observation('1')]), 200, {
+            blockEvidenceFile: 'manifest.tmp',
+          }),
+        ],
+      },
+      { cwd, evidenceDir },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /could not save failure evidence/u);
+    assert.equal(captured(result).manifest.status, 'pending');
+  }
+
+  {
+    const cwd = project();
+    mkdirSync(join(cwd, 'output'));
+    writeFileSync(join(cwd, 'output/keep'), 'untouched');
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--output', 'output', '--evidence-dir', 'evidence'],
+      routesFor([observation('1')], [1]),
+      { cwd },
+    );
+    assert.equal(result.status, 1);
+    assert.equal(readFileSync(join(cwd, 'output/keep'), 'utf8'), 'untouched');
+    assert.equal(captured(result).manifest.status, 'failed');
+  }
+
+  {
+    const cwd = project();
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'],
+      routesFor([observation('1')], [1]),
+      { cwd, stdoutFailure: true },
+    );
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /broken pipe/u);
+    assert.equal(captured(result).manifest.status, 'failed');
+  }
+
+  {
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.json'), 'keep existing output');
+    const result = run(
+      [
+        '--model',
+        'DeepSeek-V4-Pro',
+        '--format',
+        'json',
+        '--output',
+        'agentx.json',
+        '--evidence-dir',
+        'evidence',
+      ],
+      routesFor([observation('1')], [1]),
+      { cwd, failCompleteManifest: true },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /controlled complete manifest failure/u);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep existing output');
+    assert.equal(captured(result).manifest.status, 'failed');
+    assert.deepEqual(
+      readdirSync(cwd).filter((file) => file.includes('.backup') || file.includes('.tmp')),
+      [],
+    );
+  }
+
+  {
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'],
+      routesFor([observation('1')], [1]),
+      { stdoutFailure: true, failFailureManifest: true },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /broken pipe.*could not save failure evidence/isu);
+    assert.equal(captured(result).manifest.status, 'pending');
   }
 });

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -932,6 +932,63 @@ test('native fetch evidence hashes decoded gzip response bytes', async () => {
   }
 });
 
+test('native fetch refuses redirects before reading or replacing output', async () => {
+  const requests = [];
+  const server = createServer((request, serverResponse) => {
+    requests.push(request.url);
+    if (request.url.startsWith('/api/v1/benchmarks?')) {
+      serverResponse.writeHead(302, { Location: '/redirected' });
+      serverResponse.end();
+      return;
+    }
+    serverResponse.writeHead(200, { 'Content-Type': 'application/json' });
+    serverResponse.end('[]');
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const cwd = project();
+  writeFileSync(join(cwd, 'agentx.json'), 'keep existing output');
+  try {
+    let failure;
+    try {
+      await runNative(
+        [
+          '--model',
+          'DeepSeek-V4-Pro',
+          '--format',
+          'json',
+          '--output',
+          'agentx.json',
+          '--evidence-dir',
+          'evidence',
+        ],
+        `http://127.0.0.1:${server.address().port}`,
+        cwd,
+      );
+    } catch (error) {
+      failure = error;
+    }
+    assert.ok(failure, 'the exporter must reject a redirect response');
+    assert.equal(failure.code, 1);
+    assert.match(failure.stderr, /benchmarks request failed/u);
+    assert.deepEqual(requests, ['/api/v1/benchmarks?model=DeepSeek-V4-Pro']);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep existing output');
+    const { manifest, bodies } = captured({ cwd });
+    assert.equal(manifest.status, 'failed');
+    assert.equal(manifest.responses.length, 1);
+    assert.equal(manifest.responses[0].http_status, null);
+    assert.equal(manifest.responses[0].body_file, null);
+    assert.equal(bodies.size, 0);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test('empty evidence exports are complete, distinct, and benchmark-only', () => {
   for (const [rows, extraArgs, outcome, destination] of [
     [[observation('1', { benchmark_type: 'single_turn' })], [], 'no_agentx_rows', null],

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
@@ -8,15 +9,20 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createServer } from 'node:http';
 import { join } from 'node:path';
 import { before, test } from 'node:test';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { gzipSync } from 'node:zlib';
 
 import { packageInfo, packedSkillSuite, succeeded } from './packed-skill.mjs';
 
 const suite = packedSkillSuite();
 const { environment, project, temporaryRoot } = suite;
 const preload = join(temporaryRoot, 'agentx-http-response.mjs');
+const redirectPreload = join(temporaryRoot, 'agentx-native-fetch-redirect.mjs');
+const execFileAsync = promisify(execFile);
 let exporter;
 
 function observation(id, overrides = {}) {
@@ -101,6 +107,21 @@ function run(args, routes, cwdOrOptions = project()) {
     ? readFileSync(requestPath, 'utf8').trimEnd().split('\n')
     : [];
   return { ...result, cwd, requests };
+}
+
+async function runNative(args, origin, cwd = project()) {
+  const result = await execFileAsync(
+    process.execPath,
+    ['--import', pathToFileURL(redirectPreload).href, exporter, ...args],
+    {
+      cwd,
+      env: { ...environment, INFERENCEX_TEST_ORIGIN: origin },
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+      timeout: 10_000,
+    },
+  );
+  return { ...result, status: 0, cwd };
 }
 
 function routesFor(rows, ids) {
@@ -206,6 +227,17 @@ globalThis.fetch = async (input, options) => {
     }), { status: reply.status, headers });
   }
   return new Response(reply.body, { status: reply.status, headers });
+};
+`,
+  );
+  writeFileSync(
+    redirectPreload,
+    `
+const nativeFetch = globalThis.fetch;
+globalThis.fetch = (input, options) => {
+  const requested = new URL(input.url ?? input);
+  const redirected = new URL(requested.pathname + requested.search, process.env.INFERENCEX_TEST_ORIGIN);
+  return nativeFetch(redirected, options);
 };
 `,
   );
@@ -852,6 +884,52 @@ test('evidence captures every decoded response chunk once and hashes stdout byte
     readdirSync(root).sort(),
     ['manifest.json', ...manifest.responses.map((record) => record.body_file)].sort(),
   );
+});
+
+test('native fetch evidence hashes decoded gzip response bytes', async () => {
+  const decoded = Buffer.from(`\uFEFF${JSON.stringify([], null, 2)} \n`);
+  const compressed = gzipSync(decoded);
+  const requests = [];
+  const server = createServer((request, serverResponse) => {
+    requests.push(request.url);
+    serverResponse.writeHead(200, {
+      'Content-Encoding': 'gzip',
+      'Content-Length': compressed.length,
+      'Content-Type': 'application/json',
+    });
+    serverResponse.end(compressed);
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  try {
+    const result = await runNative(
+      ['--model', 'DeepSeek-V4-Pro', '--format', 'json', '--evidence-dir', 'evidence'],
+      `http://127.0.0.1:${server.address().port}`,
+    );
+    succeeded(result);
+
+    const { manifest, bodies } = captured(result);
+    const saved = bodies.get(1);
+    assert.deepEqual(requests, ['/api/v1/benchmarks?model=DeepSeek-V4-Pro']);
+    assert.equal(manifest.status, 'complete');
+    assert.equal(manifest.responses.length, 1);
+    assert.deepEqual(saved, decoded);
+    assert.equal(
+      manifest.responses[0].decoded_body_sha256,
+      createHash('sha256').update(decoded).digest('hex'),
+    );
+    assert.notEqual(
+      manifest.responses[0].decoded_body_sha256,
+      createHash('sha256').update(compressed).digest('hex'),
+    );
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
 });
 
 test('empty evidence exports are complete, distinct, and benchmark-only', () => {

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -1,0 +1,427 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { packageInfo, packedSkillSuite, succeeded } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const { environment, project, temporaryRoot } = suite;
+const preload = join(temporaryRoot, 'agentx-http-response.mjs');
+let exporter;
+
+function observation(id, overrides = {}) {
+  return {
+    id,
+    hardware: 'b300',
+    framework: 'sglang',
+    model: 'dsv4',
+    precision: 'fp4',
+    spec_method: 'mtp',
+    disagg: false,
+    is_multinode: false,
+    prefill_tp: 8,
+    prefill_ep: 1,
+    prefill_dp_attention: false,
+    prefill_num_workers: 0,
+    decode_tp: 8,
+    decode_ep: 1,
+    decode_dp_attention: false,
+    decode_num_workers: 0,
+    num_prefill_gpu: 8,
+    num_decode_gpu: 8,
+    benchmark_type: 'agentic_traces',
+    isl: null,
+    osl: null,
+    conc: 1,
+    offload_mode: 'off',
+    image: 'lmsysorg/sglang:nightly-dev-cu13',
+    recipe_fingerprint: 'recipe-agentx',
+    metrics: { mean_ttft: 0, output_tput_per_gpu: 14.5 },
+    workers: null,
+    date: '2026-09-01',
+    workflow_run_id: '2390',
+    run_started_at: '2026-09-01 17:04:07+00',
+    run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33145139961',
+    curve_date: '2026-09-01',
+    curve_workflow_run_id: '2390',
+    curve_run_started_at: '2026-09-01 17:04:07+00',
+    ...overrides,
+  };
+}
+
+function percentiles(seed = 1) {
+  return { mean: seed, p50: seed, p75: seed, p90: seed, p95: seed, p99: seed, n: seed };
+}
+
+function aggregate(id, seed = id) {
+  return {
+    id,
+    isl: percentiles(seed),
+    osl: percentiles(seed),
+    kvCacheUtil: percentiles(seed),
+    prefixCacheHitRate: percentiles(seed),
+  };
+}
+
+function derived(id, value = id) {
+  return { id, p75_e2e_norm_intvty: value, p90_e2e_norm_intvty: value };
+}
+
+function mapBody(entries) {
+  return `{${entries
+    .map(([key, value]) => `${JSON.stringify(String(key))}:${JSON.stringify(value)}`)
+    .join(',')}}`;
+}
+
+const response = (body, status = 200) => ({ body, status });
+
+function run(args, routes, cwd = project()) {
+  const fixtureRoot = project('agentx-response-');
+  const fixturePath = join(fixtureRoot, 'responses.json');
+  const requestPath = join(fixtureRoot, 'requests.txt');
+  writeFileSync(fixturePath, JSON.stringify({ routes }));
+  const result = suite.node(['--import', pathToFileURL(preload).href, exporter, ...args], {
+    cwd,
+    env: {
+      ...environment,
+      INFERENCEX_TEST_RESPONSE: fixturePath,
+      INFERENCEX_TEST_REQUESTS: requestPath,
+    },
+  });
+  const requests = existsSync(requestPath)
+    ? readFileSync(requestPath, 'utf8').trimEnd().split('\n')
+    : [];
+  return { ...result, cwd, requests };
+}
+
+function routesFor(rows, ids) {
+  return {
+    '/api/v1/benchmarks': [response(JSON.stringify(rows))],
+    '/api/v1/agentic-aggregates': [
+      response(mapBody(ids.map((id) => [id, aggregate(id)]).toReversed())),
+    ],
+    '/api/v1/derived-agentic-metrics': [
+      response(mapBody(ids.map((id) => [id, derived(id)]).toReversed())),
+    ],
+    '/api/v1/trace-availability': [response(mapBody(ids.map((id) => [id, true]).toReversed()))],
+  };
+}
+
+before(() => {
+  writeFileSync(
+    preload,
+    `
+import { appendFileSync, readFileSync } from 'node:fs';
+const fixture = JSON.parse(readFileSync(process.env.INFERENCEX_TEST_RESPONSE, 'utf8'));
+const calls = {};
+globalThis.fetch = async (input, options) => {
+  const url = new URL(input.url ?? input);
+  appendFileSync(process.env.INFERENCEX_TEST_REQUESTS, url.href + '\\n');
+  options.signal.throwIfAborted();
+  const index = calls[url.pathname] ?? 0;
+  calls[url.pathname] = index + 1;
+  const reply = fixture.routes[url.pathname]?.[index];
+  if (!reply) return new Response('{"error":"unexpected request"}', { status: 599 });
+  return new Response(reply.body, { status: reply.status, headers: { 'Content-Type': 'application/json' } });
+};
+`,
+  );
+  const codex = suite.install('codex');
+  const claude = suite.install('claude');
+  exporter = join(codex, 'scripts/export-agentx.mjs');
+  assert.ok(existsSync(exporter), 'the actual npm archive installs the AgentX exporter for Codex');
+  assert.ok(
+    existsSync(join(claude, 'scripts/export-agentx.mjs')),
+    'the actual npm archive installs the AgentX exporter for Claude Code',
+  );
+  assert.ok(suite.packedFiles.includes('skills/inferencex-api/scripts/export-agentx.mjs'));
+});
+
+test('installed JSON exporter chunks and joins enrichments by safe result ID', () => {
+  const ids = Array.from({ length: 201 }, (_, index) => index + 1);
+  const safeRows = ids.map((id) => observation(String(id)));
+  const unsupportedRows = [observation('001'), observation('9007199254740993')];
+  const fixedSequence = observation('9999', { benchmark_type: 'single_turn' });
+  const rows = [fixedSequence, safeRows[0], ...unsupportedRows, ...safeRows.slice(1), safeRows[0]];
+  const aggregateEntries = ids
+    .filter((id) => id !== 2)
+    .map((id) => {
+      const value = aggregate(id, id === 4 ? 0 : id);
+      if (id === 3) value.isl = null;
+      return [id, value];
+    });
+  const derivedEntries = ids
+    .filter((id) => id !== 5)
+    .map((id) => [id, derived(id, id === 4 ? 0 : id)]);
+  const traceEntries = ids.filter((id) => id % 2 === 1 || id === 6).map((id) => [id, id !== 6]);
+  const routes = {
+    '/api/v1/benchmarks': [response(JSON.stringify(rows))],
+    '/api/v1/agentic-aggregates': [
+      response(mapBody(aggregateEntries.filter(([id]) => id <= 200).toReversed())),
+      response(mapBody(aggregateEntries.filter(([id]) => id > 200).toReversed())),
+    ],
+    '/api/v1/derived-agentic-metrics': [
+      response(mapBody(derivedEntries.filter(([id]) => id <= 200).toReversed())),
+      response(mapBody(derivedEntries.filter(([id]) => id > 200).toReversed())),
+    ],
+    '/api/v1/trace-availability': [response(mapBody(traceEntries.toReversed()))],
+  };
+  const result = run(['--model', 'DeepSeek-V4-Pro', '--date', '2026-09-04'], routes);
+  succeeded(result);
+
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.schema_version, 1);
+  assert.deepEqual(
+    output.rows.map((row) => row.benchmark.id),
+    rows.filter((row) => row.benchmark_type === 'agentic_traces').map((row) => row.id),
+    'complete benchmark objects retain response order and exact IDs',
+  );
+  assert.deepEqual(output.rows[0].benchmark, safeRows[0]);
+  assert.equal(output.rows[0].benchmark.metrics.mean_ttft, 0);
+  assert.equal(output.rows.at(-1).benchmark.id, '1');
+  assert.deepEqual(output.rows.at(-1).agentx, output.rows[0].agentx);
+
+  assert.deepEqual(output.metadata.requested_scope, {
+    display_model: 'DeepSeek-V4-Pro',
+    date: '2026-09-04',
+    date_selection: 'as-of',
+    raw_model: null,
+    benchmark_type: 'agentic_traces',
+  });
+  assert.equal(output.metadata.package_version, packageInfo.version);
+  assert.equal(output.metadata.returned_rows, rows.length);
+  assert.equal(output.metadata.returned_agentx_rows, rows.length - 1);
+  assert.equal(output.metadata.selected_rows, rows.length - 1);
+  assert.deepEqual(output.metadata.returned_model_keys, ['dsv4']);
+  assert.deepEqual(output.metadata.selected_model_keys, ['dsv4']);
+  assert.match(output.metadata.observation_context, /no new benchmark was run/i);
+  assert.ok(Number.isFinite(Date.parse(output.metadata.retrieved_at)));
+  assert.equal(output.metadata.request_urls.length, 6);
+  assert.deepEqual(
+    output.metadata.request_urls.map(({ operation }) => operation),
+    [
+      'benchmarks',
+      'agentic-aggregates',
+      'agentic-aggregates',
+      'derived-agentic-metrics',
+      'derived-agentic-metrics',
+      'trace-availability',
+    ],
+  );
+
+  const requests = result.requests.map((request) => new URL(request));
+  assert.deepEqual(Object.fromEntries(requests[0].searchParams), {
+    model: 'DeepSeek-V4-Pro',
+    date: '2026-09-04',
+  });
+  assert.equal(requests[0].pathname, '/api/v1/benchmarks');
+  for (const forbidden of ['exact', 'view', 'sequence', 'powerValid']) {
+    assert.equal(requests[0].searchParams.has(forbidden), false);
+  }
+  const requestedIds = requests
+    .slice(1)
+    .flatMap((request) => request.searchParams.get('ids').split(',').map(Number));
+  assert.equal(requestedIds.includes(9007199254740992), false);
+  assert.equal(requestedIds.includes(1), true);
+  for (const request of requests.filter((url) => url.pathname.endsWith('agentic-aggregates'))) {
+    assert.ok(request.searchParams.get('ids').split(',').length <= 200);
+  }
+  for (const request of requests.filter((url) =>
+    url.pathname.endsWith('derived-agentic-metrics'),
+  )) {
+    assert.ok(request.searchParams.get('ids').split(',').length <= 200);
+  }
+  for (const request of requests.filter((url) => url.pathname.endsWith('trace-availability'))) {
+    assert.ok(request.searchParams.get('ids').split(',').length <= 500);
+  }
+
+  const byId = new Map(output.rows.map((row) => [row.benchmark.id, row]));
+  assert.equal(byId.get('2').agentx.aggregates.status, 'not_returned');
+  assert.equal(byId.get('2').agentx.aggregates.value, null);
+  assert.equal(byId.get('3').agentx.aggregates.status, 'available');
+  assert.equal(byId.get('3').agentx.aggregates.value.isl, null);
+  assert.equal(byId.get('4').agentx.aggregates.value.isl.mean, 0);
+  assert.equal(byId.get('4').agentx.derived_metrics.value.p75_e2e_norm_intvty, 0);
+  assert.equal(byId.get('5').agentx.derived_metrics.status, 'not_returned');
+  assert.deepEqual(byId.get('2').agentx.trace_availability, {
+    status: 'no_stored_trace',
+    value: false,
+    response_key_present: false,
+  });
+  assert.deepEqual(byId.get('6').agentx.trace_availability, {
+    status: 'no_stored_trace',
+    value: false,
+    response_key_present: true,
+  });
+  for (const id of ['001', '9007199254740993']) {
+    assert.equal(byId.get(id).benchmark.id, id);
+    assert.equal(byId.get(id).agentx.status, 'unsupported_id');
+    assert.equal(byId.get(id).agentx.result_id, null);
+  }
+  assert.equal(output.metadata.enrichment_coverage.safe_id_rows, 202);
+  assert.equal(output.metadata.enrichment_coverage.unsupported_id_rows, 2);
+  assert.equal(output.metadata.enrichment_coverage.unique_safe_ids, 201);
+  assert.deepEqual(output.metadata.enrichment_coverage.aggregates.isl, {
+    available_rows: 200,
+    null_rows: 1,
+    missing_entry_rows: 1,
+    unsupported_id_rows: 2,
+  });
+  assert.deepEqual(output.metadata.enrichment_coverage.derived_metrics, {
+    available_rows: 201,
+    missing_entry_rows: 1,
+    unsupported_id_rows: 2,
+  });
+  assert.deepEqual(output.metadata.enrichment_coverage.trace_availability, {
+    stored_trace_rows: 102,
+    no_stored_trace_rows: 100,
+    response_key_rows: 103,
+    missing_key_rows: 99,
+    unsupported_id_rows: 2,
+  });
+});
+
+test('raw-model selection is exact and latest/as-of request context stays distinct', () => {
+  const rows = [
+    observation('10', { model: 'dsv4' }),
+    observation('11', { model: 'dsv4-next' }),
+    observation('12', { benchmark_type: 'single_turn' }),
+  ];
+  const cwd = project();
+  const result = run(
+    ['--model', 'DeepSeek-V4-Pro', '--raw-model', 'dsv4', '--output', 'agentx.json'],
+    routesFor(rows, [10]),
+    cwd,
+  );
+  succeeded(result);
+  assert.equal(result.stdout, '');
+  const output = JSON.parse(readFileSync(join(cwd, 'agentx.json'), 'utf8'));
+  assert.deepEqual(
+    output.rows.map((row) => row.benchmark.id),
+    ['10'],
+  );
+  assert.equal(output.metadata.requested_scope.date, null);
+  assert.equal(output.metadata.requested_scope.date_selection, 'latest');
+  assert.equal(output.metadata.requested_scope.raw_model, 'dsv4');
+  assert.equal(output.metadata.returned_rows, 3);
+  assert.equal(output.metadata.returned_agentx_rows, 2);
+  assert.equal(output.metadata.selected_rows, 1);
+  assert.deepEqual(output.metadata.returned_model_keys, ['dsv4', 'dsv4-next']);
+  assert.deepEqual(output.metadata.selected_model_keys, ['dsv4']);
+  assert.deepEqual(Object.fromEntries(new URL(result.requests[0]).searchParams), {
+    model: 'DeepSeek-V4-Pro',
+  });
+});
+
+test('response order cannot move enrichment values between result IDs', () => {
+  const ids = [5_000_000_001, 5_000_000_002];
+  const result = run(
+    ['--model', 'DeepSeek-V4-Pro'],
+    routesFor(
+      ids.map((id) => observation(String(id))),
+      ids,
+    ),
+  );
+  succeeded(result);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(
+    output.rows.map((row) => [
+      row.benchmark.id,
+      row.agentx.aggregates.value.id,
+      row.agentx.derived_metrics.value.id,
+    ]),
+    ids.map((id) => [String(id), id, id]),
+  );
+});
+
+test('empty AgentX selections succeed without enrichment requests', () => {
+  for (const [rows, args, outcome] of [
+    [[observation('1', { benchmark_type: 'single_turn' })], [], 'no_agentx_rows'],
+    [[observation('1')], ['--raw-model', 'different'], 'no_matching_rows'],
+  ]) {
+    const result = run(['--model', 'DeepSeek-V4-Pro', ...args], {
+      '/api/v1/benchmarks': [response(JSON.stringify(rows))],
+    });
+    succeeded(result);
+    const output = JSON.parse(result.stdout);
+    assert.equal(output.metadata.outcome, outcome);
+    assert.equal(output.metadata.returned_rows, 1);
+    assert.equal(output.metadata.selected_rows, 0);
+    assert.deepEqual(output.rows, []);
+    assert.equal(result.requests.length, 1);
+  }
+});
+
+test('invalid arguments fail before HTTP or output writes; help is offline', () => {
+  const invalid = [
+    [],
+    ['--model', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--date', '2026-02-30'],
+    ['--model', 'DeepSeek-V4-Pro', '--date', '2026-9-4'],
+    ['--model', 'DeepSeek-V4-Pro', '--raw-model', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--output', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--unexpected'],
+    ['--model', 'DeepSeek-V4-Pro', 'extra'],
+  ];
+  for (const args of invalid) {
+    const cwd = project();
+    const result = run(
+      args.includes('--output') ? args : [...args, '--output', 'should-not-exist.json'],
+      {},
+      cwd,
+    );
+    assert.notEqual(result.status, 0, args.join(' '));
+    assert.equal(result.stdout, '');
+    assert.equal(result.requests.length, 0);
+    assert.deepEqual(readdirSync(cwd), []);
+  }
+  const help = run(['--help'], {});
+  succeeded(help);
+  assert.match(help.stdout, /--model/);
+  assert.match(help.stdout, /does not run a benchmark/);
+  assert.equal(help.requests.length, 0);
+});
+
+test('every HTTP endpoint failure preserves an existing output', () => {
+  const row = observation('1');
+  const ok = routesFor([row], [1]);
+  for (const failingPath of Object.keys(ok)) {
+    const routes = structuredClone(ok);
+    routes[failingPath][0] = response('{"error":"controlled failure"}', 503);
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.json'), 'keep existing output');
+    const result = run(['--model', 'DeepSeek-V4-Pro', '--output', 'agentx.json'], routes, cwd);
+    assert.equal(result.status, 1, failingPath);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /HTTP 503.*controlled failure/);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep existing output');
+  }
+});
+
+test('malformed required shapes and unrelated enrichment IDs fail closed', () => {
+  const row = observation('1');
+  const failures = [
+    { '/api/v1/benchmarks': [response('{}')] },
+    { '/api/v1/benchmarks': [response('{')] },
+    {
+      ...routesFor([row], [1]),
+      '/api/v1/agentic-aggregates': [response('[]')],
+    },
+    {
+      ...routesFor([row], [1]),
+      '/api/v1/derived-agentic-metrics': [response(mapBody([[1, { id: 1 }]]))],
+    },
+    {
+      ...routesFor([row], [1]),
+      '/api/v1/trace-availability': [response(mapBody([[2, true]]))],
+    },
+  ];
+  for (const routes of failures) {
+    const result = run(['--model', 'DeepSeek-V4-Pro'], routes);
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /Unexpected|JSON/);
+  }
+});

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -105,6 +105,21 @@ function routesFor(rows, ids) {
   };
 }
 
+function metadataFrom(result) {
+  return JSON.parse(result.stderr.split('\n', 1)[0]).metadata;
+}
+
+function csvRecords(text) {
+  const [header, ...lines] = text
+    .trimEnd()
+    .split('\r\n')
+    .map((line) => line.split(','));
+  return {
+    header,
+    rows: lines.map((line) => Object.fromEntries(header.map((key, index) => [key, line[index]]))),
+  };
+}
+
 before(() => {
   writeFileSync(
     preload,
@@ -164,7 +179,10 @@ test('installed JSON exporter chunks and joins enrichments by safe result ID', (
     ],
     '/api/v1/trace-availability': [response(mapBody(traceEntries.toReversed()))],
   };
-  const result = run(['--model', 'DeepSeek-V4-Pro', '--date', '2026-09-04'], routes);
+  const result = run(
+    ['--model', 'DeepSeek-V4-Pro', '--date', '2026-09-04', '--format', 'json'],
+    routes,
+  );
   succeeded(result);
 
   const output = JSON.parse(result.stdout);
@@ -184,7 +202,22 @@ test('installed JSON exporter chunks and joins enrichments by safe result ID', (
     date: '2026-09-04',
     date_selection: 'as-of',
     raw_model: null,
+    hardware: null,
+    framework: null,
+    precision: null,
+    spec_method: null,
+    offload_mode: null,
+    concurrency: null,
     benchmark_type: 'agentic_traces',
+  });
+  assert.deepEqual(output.metadata.filters, {
+    raw_model: { status: 'omitted', value: null },
+    hardware: { status: 'omitted', value: null },
+    framework: { status: 'omitted', value: null },
+    precision: { status: 'omitted', value: null },
+    spec_method: { status: 'omitted', value: null },
+    offload_mode: { status: 'omitted', value: null },
+    concurrency: { status: 'omitted', value: null },
   });
   assert.equal(output.metadata.package_version, packageInfo.version);
   assert.equal(output.metadata.returned_rows, rows.length);
@@ -287,7 +320,16 @@ test('raw-model selection is exact and latest/as-of request context stays distin
   ];
   const cwd = project();
   const result = run(
-    ['--model', 'DeepSeek-V4-Pro', '--raw-model', 'dsv4', '--output', 'agentx.json'],
+    [
+      '--model',
+      'DeepSeek-V4-Pro',
+      '--raw-model',
+      'dsv4',
+      '--format',
+      'json',
+      '--output',
+      'agentx.json',
+    ],
     routesFor(rows, [10]),
     cwd,
   );
@@ -301,6 +343,7 @@ test('raw-model selection is exact and latest/as-of request context stays distin
   assert.equal(output.metadata.requested_scope.date, null);
   assert.equal(output.metadata.requested_scope.date_selection, 'latest');
   assert.equal(output.metadata.requested_scope.raw_model, 'dsv4');
+  assert.deepEqual(output.metadata.filters.raw_model, { status: 'applied', value: 'dsv4' });
   assert.equal(output.metadata.returned_rows, 3);
   assert.equal(output.metadata.returned_agentx_rows, 2);
   assert.equal(output.metadata.selected_rows, 1);
@@ -314,7 +357,7 @@ test('raw-model selection is exact and latest/as-of request context stays distin
 test('response order cannot move enrichment values between result IDs', () => {
   const ids = [5_000_000_001, 5_000_000_002];
   const result = run(
-    ['--model', 'DeepSeek-V4-Pro'],
+    ['--model', 'DeepSeek-V4-Pro', '--format', 'json'],
     routesFor(
       ids.map((id) => observation(String(id))),
       ids,
@@ -332,22 +375,206 @@ test('response order cannot move enrichment values between result IDs', () => {
   );
 });
 
-test('empty AgentX selections succeed without enrichment requests', () => {
+test('empty AgentX selections explain only the complete response and local filters', () => {
   for (const [rows, args, outcome] of [
     [[observation('1', { benchmark_type: 'single_turn' })], [], 'no_agentx_rows'],
     [[observation('1')], ['--raw-model', 'different'], 'no_matching_rows'],
   ]) {
-    const result = run(['--model', 'DeepSeek-V4-Pro', ...args], {
+    const result = run(['--model', 'DeepSeek-V4-Pro', '--format', 'json', ...args], {
       '/api/v1/benchmarks': [response(JSON.stringify(rows))],
     });
     succeeded(result);
     const output = JSON.parse(result.stdout);
     assert.equal(output.metadata.outcome, outcome);
     assert.equal(output.metadata.returned_rows, 1);
+    assert.equal(output.metadata.returned_agentx_rows, outcome === 'no_agentx_rows' ? 0 : 1);
     assert.equal(output.metadata.selected_rows, 0);
     assert.deepEqual(output.rows, []);
     assert.equal(result.requests.length, 1);
+    assert.deepEqual(
+      output.metadata.available_filter_values.hardware,
+      outcome === 'no_agentx_rows' ? [] : ['b300'],
+    );
+    assert.equal(output.metadata.filters.raw_model.status, args.length > 0 ? 'applied' : 'omitted');
+    assert.doesNotMatch(result.stderr, /failed run|source artifact|benchmark job/iu);
   }
+});
+
+test('all serving filters are independent, exact, case-sensitive, and composable', () => {
+  const cases = [
+    ['--raw-model', 'dsv4', { model: 'dsv4-next' }, 'raw_model'],
+    ['--hardware', 'b300', { hardware: 'b200' }, 'hardware'],
+    ['--framework', 'sglang', { framework: 'vllm' }, 'framework'],
+    ['--precision', 'fp4', { precision: 'fp8' }, 'precision'],
+    ['--spec-method', 'mtp', { spec_method: 'none' }, 'spec_method'],
+    ['--offload-mode', 'off', { offload_mode: 'on' }, 'offload_mode'],
+    ['--concurrency', '1', { conc: 2 }, 'concurrency'],
+  ];
+  for (const [option, value, differingField, metadataKey] of cases) {
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--format', 'json', option, value],
+      routesFor([observation('1'), observation('2', differingField)], [1]),
+    );
+    succeeded(result);
+    const output = JSON.parse(result.stdout);
+    assert.deepEqual(
+      output.rows.map((row) => row.benchmark.id),
+      ['1'],
+      option,
+    );
+    assert.equal(output.metadata.filters[metadataKey].status, 'applied');
+    assert.equal(String(output.metadata.filters[metadataKey].value), value);
+  }
+
+  const combined = [
+    '--model',
+    'DeepSeek-V4-Pro',
+    '--raw-model',
+    'dsv4',
+    '--hardware',
+    'b300',
+    '--framework',
+    'sglang',
+    '--precision',
+    'fp4',
+    '--spec-method',
+    'mtp',
+    '--offload-mode',
+    'off',
+    '--concurrency',
+    '1',
+    '--format',
+    'json',
+  ];
+  const result = run(combined, routesFor([observation('1'), observation('2', { conc: 2 })], [1]));
+  succeeded(result);
+  assert.deepEqual(
+    JSON.parse(result.stdout).rows.map((row) => row.benchmark.id),
+    ['1'],
+  );
+
+  const wrongCase = run(['--model', 'DeepSeek-V4-Pro', '--hardware', 'B300'], {
+    '/api/v1/benchmarks': [response(JSON.stringify([observation('1')]))],
+  });
+  succeeded(wrongCase);
+  assert.equal(wrongCase.stdout.trimEnd().split('\r\n').length, 1);
+  assert.equal(metadataFrom(wrongCase).outcome, 'no_matching_rows');
+  assert.equal(wrongCase.requests.length, 1);
+});
+
+test('default CSV has deterministic context, dynamic scalar metrics, and fixed enrichments', () => {
+  const rows = [
+    observation('2', {
+      metrics: { z_metric: null, alpha_metric: 2, nested_metric: { value: 3 } },
+    }),
+    observation('1', {
+      metrics: {
+        z_metric: 0,
+        beta_metric: false,
+        alpha_metric: null,
+        array_metric: [1, 2],
+      },
+    }),
+  ];
+  const routes = {
+    '/api/v1/benchmarks': [response(JSON.stringify(rows))],
+    '/api/v1/agentic-aggregates': [
+      response(
+        mapBody([
+          [2, aggregate(2)],
+          [1, aggregate(1, 0)],
+        ]),
+      ),
+    ],
+    '/api/v1/derived-agentic-metrics': [
+      response(
+        mapBody([
+          [2, derived(2)],
+          [1, derived(1, 0)],
+        ]),
+      ),
+    ],
+    '/api/v1/trace-availability': [
+      response(
+        mapBody([
+          [2, true],
+          [1, false],
+        ]),
+      ),
+    ],
+  };
+  const result = run(
+    [
+      '--model',
+      'DeepSeek-V4-Pro',
+      '--hardware',
+      'b300',
+      '--framework',
+      'sglang',
+      '--precision',
+      'fp4',
+      '--spec-method',
+      'mtp',
+      '--offload-mode',
+      'off',
+      '--concurrency',
+      '1',
+    ],
+    routes,
+  );
+  succeeded(result);
+
+  const csv = csvRecords(result.stdout);
+  assert.deepEqual(
+    csv.header.filter((column) => column.startsWith('metrics.')),
+    ['metrics.alpha_metric', 'metrics.beta_metric', 'metrics.z_metric'],
+  );
+  assert.equal(csv.header.includes('metrics.array_metric'), false);
+  assert.equal(csv.header.includes('metrics.nested_metric'), false);
+  assert.ok(csv.header.indexOf('metrics.alpha_metric') < csv.header.indexOf('aggregate.isl.mean'));
+  for (const fixed of [
+    'package_version',
+    'query_url',
+    'filter.hardware',
+    'id',
+    'recipe_fingerprint',
+    'num_decode_gpu',
+    'date',
+    'workflow_run_id',
+    'curve_date',
+    'aggregate.prefixCacheHitRate.p99',
+    'derived.p90_e2e_norm_intvty',
+    'trace.available',
+    'enrichment.status',
+  ]) {
+    assert.ok(csv.header.includes(fixed), fixed);
+  }
+  assert.deepEqual(
+    csv.rows.map((row) => row.id),
+    ['2', '1'],
+  );
+  for (const row of csv.rows) {
+    assert.equal(row.package_version, packageInfo.version);
+    assert.match(row.query_url, /\/api\/v1\/benchmarks\?model=DeepSeek-V4-Pro/u);
+    assert.equal(row.requested_model, 'DeepSeek-V4-Pro');
+    assert.equal(row['filter.hardware'], 'b300');
+    assert.equal(row['filter.raw_model'], '');
+  }
+  assert.equal(csv.rows[0]['metrics.z_metric'], '');
+  assert.equal(csv.rows[0]['metrics.beta_metric'], '');
+  assert.equal(csv.rows[1]['metrics.z_metric'], '0');
+  assert.equal(csv.rows[1]['metrics.beta_metric'], 'false');
+  assert.equal(csv.rows[1]['aggregate.isl.mean'], '0');
+  assert.equal(csv.rows[1]['derived.p75_e2e_norm_intvty'], '0');
+  assert.equal(csv.rows[1]['trace.available'], 'false');
+  assert.equal(metadataFrom(result).outcome, 'selected_rows');
+
+  const reordered = run(['--model', 'DeepSeek-V4-Pro'], {
+    ...routes,
+    '/api/v1/benchmarks': [response(JSON.stringify(rows.toReversed()))],
+  });
+  succeeded(reordered);
+  assert.deepEqual(csvRecords(reordered.stdout).header, csv.header);
 });
 
 test('invalid arguments fail before HTTP or output writes; help is offline', () => {
@@ -357,6 +584,17 @@ test('invalid arguments fail before HTTP or output writes; help is offline', () 
     ['--model', 'DeepSeek-V4-Pro', '--date', '2026-02-30'],
     ['--model', 'DeepSeek-V4-Pro', '--date', '2026-9-4'],
     ['--model', 'DeepSeek-V4-Pro', '--raw-model', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--hardware', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--framework', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--precision', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--spec-method', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--offload-mode', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--concurrency', ''],
+    ['--model', 'DeepSeek-V4-Pro', '--concurrency', '0'],
+    ['--model', 'DeepSeek-V4-Pro', '--concurrency', '-1'],
+    ['--model', 'DeepSeek-V4-Pro', '--concurrency', '1.5'],
+    ['--model', 'DeepSeek-V4-Pro', '--concurrency', '9007199254740992'],
+    ['--model', 'DeepSeek-V4-Pro', '--format', 'yaml'],
     ['--model', 'DeepSeek-V4-Pro', '--output', ''],
     ['--model', 'DeepSeek-V4-Pro', '--unexpected'],
     ['--model', 'DeepSeek-V4-Pro', 'extra'],

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -47,6 +47,16 @@ function jsonResult(result, expectedStatus = 0) {
   return output;
 }
 
+function assertDuplicateVersionsRejected(cwd, exporter, reason) {
+  const matching = `const PACKAGE_VERSION = '${packageInfo.version}';`;
+  for (const second of [matching, "const PACKAGE_VERSION = '9.9.9';"]) {
+    writeFileSync(exporter, `${matching}\n${second}\n`);
+    const status = run(['status'], cwd);
+    succeeded(status);
+    assert.ok(status.stdout.includes(`Installed version: unknown (${reason})\n`));
+  }
+}
+
 function snapshot(root) {
   return ['', ...readdirSync(root, { recursive: true })].sort().map((path) => {
     const fullPath = join(root, path);
@@ -217,6 +227,7 @@ test('status reads exporter versions without executing code and reports missing 
   const readOnly = run(['status'], cwd);
   succeeded(readOnly);
   assert.ok(readOnly.stdout.includes(`Installed version: ${packageInfo.version}\n`));
+  assertDuplicateVersionsRejected(cwd, exporter, 'installed exporter version is missing');
   writeFileSync(exporter, '// no identifiable version');
   const missingVersion = run(['status'], cwd);
   succeeded(missingVersion);
@@ -303,6 +314,11 @@ test('status reads the required AgentX version without executing it and diagnose
   const readOnly = run(['status'], cwd);
   succeeded(readOnly);
   assert.ok(readOnly.stdout.includes(`Installed version: ${packageInfo.version}\n`));
+  assertDuplicateVersionsRejected(
+    cwd,
+    exporter,
+    'installed AgentX exporter version is missing',
+  );
 
   for (const [name, mutate, reason, repairable] of [
     [

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -314,11 +314,7 @@ test('status reads the required AgentX version without executing it and diagnose
   const readOnly = run(['status'], cwd);
   succeeded(readOnly);
   assert.ok(readOnly.stdout.includes(`Installed version: ${packageInfo.version}\n`));
-  assertDuplicateVersionsRejected(
-    cwd,
-    exporter,
-    'installed AgentX exporter version is missing',
-  );
+  assertDuplicateVersionsRejected(cwd, exporter, 'installed AgentX exporter version is missing');
 
   for (const [name, mutate, reason, repairable] of [
     [

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -21,12 +21,8 @@ const suite = packedSkillSuite();
 const { project, run } = suite;
 const metadataName = '.inferencex-skills.json';
 
-function setInstalledVersion(destination, version) {
-  writeFileSync(
-    join(destination, metadataName),
-    JSON.stringify({ package: packageInfo.name, version }),
-  );
-  const exporter = join(destination, 'scripts/export-powerx.mjs');
+function setExporterVersion(destination, name, version) {
+  const exporter = join(destination, `scripts/export-${name}.mjs`);
   writeFileSync(
     exporter,
     readFileSync(exporter, 'utf8').replace(
@@ -34,6 +30,14 @@ function setInstalledVersion(destination, version) {
       `const PACKAGE_VERSION = '${version}';`,
     ),
   );
+}
+
+function setInstalledVersion(destination, version) {
+  writeFileSync(
+    join(destination, metadataName),
+    JSON.stringify({ package: packageInfo.name, version }),
+  );
+  setExporterVersion(destination, 'powerx', version);
 }
 
 function jsonResult(result, expectedStatus = 0) {
@@ -240,6 +244,137 @@ test('status reads exporter versions without executing code and reports missing 
     absent.stdout,
     /Installed version: unknown \(installed exporter is missing or not a regular file\)/u,
   );
+});
+
+test('pre-0.4 status requires only PowerX and ignores absent or stale AgentX files', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const agentx = join(destination, 'scripts/export-agentx.mjs');
+  setInstalledVersion(destination, '0.3.999+legacy');
+
+  for (const mutate of [
+    () => writeFileSync(agentx, `const PACKAGE_VERSION = '9.9.9';\nthrow new Error('stale');\n`),
+    () => rmSync(agentx),
+  ]) {
+    mutate();
+    const status = run(['status'], cwd);
+    succeeded(status);
+    assert.ok(status.stdout.includes('Installed version: 0.3.999+legacy\n'));
+  }
+
+  rmSync(join(destination, 'scripts/export-powerx.mjs'));
+  const missingPowerX = run(['status'], cwd);
+  succeeded(missingPowerX);
+  assert.match(
+    missingPowerX.stdout,
+    /Installed version: unknown \(installed exporter is missing or not a regular file\)/u,
+  );
+});
+
+test('0.4 prerelease and later receipts require matching AgentX versions', () => {
+  for (const version of ['0.4.0-rc.1+build.7', '1.0.0']) {
+    const cwd = project();
+    succeeded(run(['install'], cwd));
+    const destination = join(cwd, '.claude/skills/inferencex-api');
+    setInstalledVersion(destination, version);
+    const mismatch = run(['status'], cwd);
+    succeeded(mismatch);
+    assert.match(
+      mismatch.stdout,
+      /Installed version: unknown \(installation metadata disagrees with the installed AgentX exporter version\)/u,
+    );
+    setExporterVersion(destination, 'agentx', version);
+    const matching = run(['status'], cwd);
+    succeeded(matching);
+    assert.ok(matching.stdout.includes(`Installed version: ${version}\n`));
+  }
+});
+
+test('status reads the required AgentX version without executing it and diagnoses invalid files', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const exporter = join(destination, 'scripts/export-agentx.mjs');
+  writeFileSync(
+    exporter,
+    `const PACKAGE_VERSION = '${packageInfo.version}';\nthrow new Error('Do not execute status input');\n`,
+  );
+  const readOnly = run(['status'], cwd);
+  succeeded(readOnly);
+  assert.ok(readOnly.stdout.includes(`Installed version: ${packageInfo.version}\n`));
+
+  for (const [name, mutate, reason, repairable] of [
+    [
+      'missing',
+      () => rmSync(exporter),
+      'installed AgentX exporter is missing or not a regular file',
+      true,
+    ],
+    [
+      'directory',
+      () => {
+        rmSync(exporter);
+        mkdirSync(exporter);
+      },
+      'installed AgentX exporter is missing or not a regular file',
+      false,
+    ],
+    [
+      'symlink',
+      () => {
+        const neighbor = join(cwd, 'matching-agentx.mjs');
+        writeFileSync(neighbor, `const PACKAGE_VERSION = '${packageInfo.version}';\n`);
+        rmSync(exporter);
+        symlinkSync(neighbor, exporter);
+      },
+      'installed AgentX exporter is missing or not a regular file',
+      false,
+    ],
+    [
+      'missing declaration',
+      () => writeFileSync(exporter, '// no identifiable version'),
+      'installed AgentX exporter version is missing',
+      true,
+    ],
+    [
+      'mismatch',
+      () => writeFileSync(exporter, "const PACKAGE_VERSION = '9.9.9';\n"),
+      'installation metadata disagrees with the installed AgentX exporter version',
+      true,
+    ],
+  ]) {
+    if (name !== 'missing') {
+      rmSync(exporter, { recursive: true, force: true });
+      writeFileSync(exporter, `const PACKAGE_VERSION = '${packageInfo.version}';\n`);
+    }
+    mutate();
+    const invalid = run(['status'], cwd);
+    succeeded(invalid);
+    assert.ok(invalid.stdout.includes(`Installed version: unknown (${reason})\n`), name);
+    if (repairable) {
+      succeeded(run(['install', '--force'], cwd));
+      const repaired = run(['status'], cwd);
+      succeeded(repaired);
+      assert.ok(repaired.stdout.includes(`Installed version: ${packageInfo.version}\n`), name);
+    }
+  }
+
+  if (process.getuid?.() !== 0) {
+    rmSync(exporter, { recursive: true, force: true });
+    writeFileSync(exporter, `const PACKAGE_VERSION = '${packageInfo.version}';\n`);
+    chmodSync(exporter, 0o000);
+    try {
+      const unreadable = run(['status'], cwd);
+      succeeded(unreadable);
+      assert.match(
+        unreadable.stdout,
+        /Installed version: unknown \(could not read installed AgentX exporter: EACCES\)/u,
+      );
+    } finally {
+      chmodSync(exporter, 0o600);
+    }
+  }
 });
 
 test('status distinguishes absent, legacy, malformed, and unreadable installation metadata', () => {
@@ -574,9 +709,11 @@ test('dry-run and install reject matching packaged conflicts and symlinks before
   for (const [relative, type] of [
     ['scripts', 'file'],
     ['scripts/export-powerx.mjs', 'directory'],
+    ['scripts/export-agentx.mjs', 'directory'],
     [metadataName, 'directory'],
     ['SKILL.md', 'symlink'],
     ['scripts', 'symlink'],
+    ['scripts/export-agentx.mjs', 'symlink'],
     [metadataName, 'symlink'],
     ['', 'file'],
     ['', 'symlink'],

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -1,9 +1,34 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { resolve } from 'node:path';
+import {
+  cpSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { test } from 'node:test';
+import { pathToFileURL } from 'node:url';
 import { PACKAGE, requireUnpublished, verifyArchive, verifyContents } from '../scripts/release.mjs';
+
+const VERSION = '0.4.0';
+const EXPECTED_FILES = [
+  'LICENSE',
+  'README.md',
+  'bin/install.mjs',
+  'package.json',
+  'skills/inferencex-api/SKILL.md',
+  'skills/inferencex-api/references/agentx.md',
+  'skills/inferencex-api/references/powerx.md',
+  'skills/inferencex-api/references/public-api-examples.md',
+  'skills/inferencex-api/scripts/export-agentx.mjs',
+  'skills/inferencex-api/scripts/export-powerx.mjs',
+];
 
 test('read-only release verification rejects altered evidence and unsafe retries', () => {
   const result = spawnSync('python3', ['-B', 'test/verify-release.test.py'], {
@@ -16,7 +41,7 @@ test('read-only release verification rejects altered evidence and unsafe retries
 });
 
 test('release refuses mismatched or existing versions and registry failures', async () => {
-  const manifest = { name: PACKAGE, version: '0.3.0' };
+  const manifest = { name: PACKAGE, version: VERSION };
   let requests = 0;
   const request = () => {
     requests++;
@@ -25,14 +50,14 @@ test('release refuses mismatched or existing versions and registry failures', as
   await assert.rejects(requireUnpublished('0.1.0', manifest, request), /differs/);
   await assert.rejects(requireUnpublished('latest', manifest, request), /exact stable version/);
   assert.equal(requests, 0, 'Invalid versions must fail before network access');
-  await requireUnpublished('0.3.0', manifest, request);
+  await requireUnpublished(VERSION, manifest, request);
   for (const [status, message] of [
     [200, /already published/],
     [429, /Cannot establish/],
     [503, /Cannot establish/],
   ]) {
     await assert.rejects(
-      requireUnpublished('0.3.0', manifest, () => Promise.resolve(new Response(null, { status }))),
+      requireUnpublished(VERSION, manifest, () => Promise.resolve(new Response(null, { status }))),
       message,
     );
   }
@@ -42,7 +67,12 @@ test('release rejects changed bytes and a different reviewed archive', () => {
   const bytes = Buffer.from('exact reviewed archive');
   const record = {
     name: PACKAGE,
+    version: VERSION,
     filename: 'package.tgz',
+    files: EXPECTED_FILES,
+    source_commit: 'a'.repeat(40),
+    source_dirty: false,
+    prepared_at: '2026-09-05T00:00:00Z',
     sha256: createHash('sha256').update(bytes).digest('hex'),
     integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
   };
@@ -50,27 +80,116 @@ test('release rejects changed bytes and a different reviewed archive', () => {
   assert.throws(() => verifyArchive(record, Buffer.from('changed')), /SHA-256 differs/);
   assert.throws(() => verifyArchive(record, bytes, '0'.repeat(64)), /reviewed candidate/);
   assert.throws(() => verifyArchive({ ...record, filename: '../package.tgz' }, bytes), /beside/);
+  assert.throws(
+    () => verifyArchive({ ...record, files: EXPECTED_FILES.slice(1) }, bytes),
+    /differs/,
+  );
   assert.throws(() => verifyArchive({ ...record, integrity: 'sha512-other' }, bytes), /integrity/);
 });
 
-test('release content boundary excludes maintainer tools, tests and hidden files', () => {
-  const files = [
-    'package.json',
-    'README.md',
-    'LICENSE',
-    'bin/install.mjs',
-    'skills/inferencex-api/SKILL.md',
-  ];
-  verifyContents([...files, 'skills/inferencex-api/references/examples.md']);
+test('release content boundary is the exact independent ten-file contract', () => {
+  verifyContents(EXPECTED_FILES.toReversed());
+  for (const missing of EXPECTED_FILES) {
+    assert.throws(
+      () => verifyContents(EXPECTED_FILES.filter((path) => path !== missing)),
+      /differs/,
+    );
+  }
   for (const path of [
+    'credentials.json',
+    'skills/inferencex-api/DRAFT.md',
+    'skills/inferencex-api/SKILL.md.bak',
+    '.scratch/acceptance.json',
     'scripts/release.mjs',
     'test/release.test.mjs',
-    '.env',
-    'skills/inferencex-api/.secret',
   ]) {
-    assert.throws(() => verifyContents([...files, path]), /public archive|hidden file/);
+    assert.throws(() => verifyContents([...EXPECTED_FILES, path]), /differs/);
   }
-  assert.throws(() => verifyContents(files.slice(1)), /missing package.json/);
+  assert.throws(() => verifyContents([...EXPECTED_FILES, EXPECTED_FILES[0]]), /duplicates/);
+});
+
+test('release manifest provenance is clean, canonical and timezone-qualified', () => {
+  const bytes = Buffer.from('exact reviewed archive');
+  const record = {
+    name: PACKAGE,
+    version: VERSION,
+    filename: 'package.tgz',
+    files: EXPECTED_FILES,
+    source_commit: 'a'.repeat(40),
+    source_dirty: false,
+    prepared_at: '2026-09-05T00:00:00+00:00',
+    sha256: createHash('sha256').update(bytes).digest('hex'),
+    integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
+  };
+  verifyArchive(record, bytes);
+  verifyArchive({ ...record, source_commit: 'b'.repeat(64) }, bytes);
+  for (const source_dirty of [true, null, undefined]) {
+    assert.throws(() => verifyArchive({ ...record, source_dirty }, bytes), /source must be clean/);
+  }
+  for (const source_commit of ['A'.repeat(40), 'a'.repeat(39), 'a'.repeat(65), 'g'.repeat(40)]) {
+    assert.throws(() => verifyArchive({ ...record, source_commit }, bytes), /Git object ID/);
+  }
+  for (const prepared_at of [
+    null,
+    '2026-09-05Z',
+    '2026-09-05 00:00:00Z',
+    '2026-09-05T00:00:00',
+    'not-a-dateZ',
+    '2026-09-05T00:00:00+99:99',
+  ]) {
+    assert.throws(() => verifyArchive({ ...record, prepared_at }, bytes), /Preparation time/);
+  }
+});
+
+test('prepare rejects dirty package source and packs a clean real candidate', (context) => {
+  const temporary = mkdtempSync(join(realpathSync(tmpdir()), 'inferencex-release-test-'));
+  context.after(() => rmSync(temporary, { recursive: true, force: true }));
+  const source = resolve(import.meta.dirname, '..');
+  const packageRoot = join(temporary, 'skills');
+  cpSync(source, packageRoot, { recursive: true });
+  const packagePath = join(packageRoot, 'package.json');
+  const manifest = JSON.parse(readFileSync(packagePath, 'utf8'));
+  writeFileSync(packagePath, `${JSON.stringify({ ...manifest, version: VERSION }, null, 2)}\n`);
+  execFileSync('git', ['init', '--quiet'], { cwd: packageRoot });
+  execFileSync('git', ['config', 'user.email', 'release-test@example.com'], { cwd: packageRoot });
+  execFileSync('git', ['config', 'user.name', 'Release Test'], { cwd: packageRoot });
+  execFileSync('git', ['add', '.'], { cwd: packageRoot });
+  execFileSync('git', ['-c', 'commit.gpgSign=false', 'commit', '--quiet', '-m', 'fixture'], {
+    cwd: packageRoot,
+  });
+  const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  }).trim();
+  const preload = join(temporary, 'registry-404.mjs');
+  writeFileSync(preload, 'globalThis.fetch = async () => new Response(null, { status: 404 });\n');
+  const command = [
+    '--import',
+    pathToFileURL(preload).href,
+    join(packageRoot, 'scripts/release.mjs'),
+    'prepare',
+    VERSION,
+  ];
+
+  writeFileSync(
+    join(packageRoot, 'README.md'),
+    `${readFileSync(join(packageRoot, 'README.md'))}\ndirty\n`,
+  );
+  const dirtyOutput = join(temporary, 'dirty-candidate');
+  const dirty = spawnSync(process.execPath, [...command, dirtyOutput], { encoding: 'utf8' });
+  assert.notEqual(dirty.status, 0, `${dirty.stdout}\n${dirty.stderr}`);
+  assert.match(dirty.stderr, /source must be clean/);
+  assert.equal(existsSync(dirtyOutput), false);
+
+  execFileSync('git', ['checkout', '--quiet', '--', 'README.md'], { cwd: packageRoot });
+  const output = join(temporary, 'candidate');
+  const clean = spawnSync(process.execPath, [...command, output], { encoding: 'utf8' });
+  assert.equal(clean.status, 0, clean.stderr);
+  const record = JSON.parse(readFileSync(join(output, 'release.json'), 'utf8'));
+  assert.equal(record.source_commit, sourceCommit);
+  assert.equal(record.source_dirty, false);
+  assert.deepEqual([...record.files].sort(), [...EXPECTED_FILES].sort());
+  verifyArchive(record, readFileSync(join(output, record.filename)));
 });
 
 test('public verification decodes gzip HTTP JSON but preserves raw npm tarball bytes', () => {
@@ -152,7 +271,7 @@ args = SimpleNamespace(model='Example', date=None, isl=8192, osl=1024, raw_model
 row = {'id':'9007199254740993', 'model':'example', 'hardware':'h200', 'date':'2026-01-01',
        'benchmark_type':'single_turn', 'isl':8192, 'osl':1024,
        'metrics': {'power_valid':1, 'power_metric_schema_version':2, 'avg_power_w':0}}
-metadata = {'package_version':'0.3.0', 'query_url':url, 'requested_model':'Example',
+metadata = {'package_version':'0.4.0', 'query_url':url, 'requested_model':'Example',
             'requested_date':None, 'date_selection':'latest', 'benchmark_type':'single_turn',
             'isl':8192, 'osl':1024, 'raw_model':None, 'returned_rows':1, 'selected_rows':1,
             'returned_models':['example'], 'selected_models':['example'],
@@ -173,19 +292,19 @@ with tempfile.TemporaryDirectory() as directory:
             writer.writeheader()
             writer.writerow({key:record[key] for key in headers})
     write()
-    assert check.check_exports(root, [row], [row], args, '0.3.0')['selected_rows'] == 1
+    assert check.check_exports(root, [row], [row], args, '0.4.0')['selected_rows'] == 1
     for key, value in [('prefill_avg_power_w', 0), ('avg_power_w', 1), ('id', '9007199254740992')]:
         old = record[key]
         record[key] = value
         write()
         with assertions.assertRaises(ValueError, msg='Verifier accepted changed ' + key):
-            check.check_exports(root, [row], [row], args, '0.3.0')
+            check.check_exports(root, [row], [row], args, '0.4.0')
         record[key] = old
     for headers in [[key for key in columns if key != 'framework'], list(reversed(columns)), columns + ['extra']]:
         record['extra'] = 'not in the published contract'
         write(headers)
         with assertions.assertRaisesRegex(ValueError, 'CSV header', msg='Verifier accepted an incomplete or changed CSV contract'):
-            check.check_exports(root, [row], [row], args, '0.3.0')
+            check.check_exports(root, [row], [row], args, '0.4.0')
     assert not check.strict({'metrics': {'power_valid': True, 'power_metric_schema_version':2}})
     assert not check.same_url(url, url + '&date=2026-01-01')
     assert not check.same_url(url, url + '&date=')

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import { test } from 'node:test';
 import { PACKAGE, requireUnpublished, verifyArchive, verifyContents } from '../scripts/release.mjs';
 
-test('public verification retries only exact-version ETARGET within its deadline', () => {
+test('read-only release verification rejects altered evidence and unsafe retries', () => {
   const result = spawnSync('python3', ['-B', 'test/verify-release.test.py'], {
     cwd: resolve(import.meta.dirname, '..'),
     encoding: 'utf8',

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -5,6 +5,7 @@ import {
   cpSync,
   existsSync,
   mkdtempSync,
+  mkdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -17,6 +18,7 @@ import { pathToFileURL } from 'node:url';
 import { PACKAGE, requireUnpublished, verifyArchive, verifyContents } from '../scripts/release.mjs';
 
 const VERSION = '0.4.0';
+const ARCHIVE = `semianalysisai-inferencex-skills-${VERSION}.tgz`;
 const EXPECTED_FILES = [
   'LICENSE',
   'README.md',
@@ -68,18 +70,20 @@ test('release rejects changed bytes and a different reviewed archive', () => {
   const record = {
     name: PACKAGE,
     version: VERSION,
-    filename: 'package.tgz',
+    filename: ARCHIVE,
     files: EXPECTED_FILES,
     source_commit: 'a'.repeat(40),
     source_dirty: false,
-    prepared_at: '2026-09-05T00:00:00Z',
+    prepared_at: '2026-09-05T00:00:00.000Z',
     sha256: createHash('sha256').update(bytes).digest('hex'),
     integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
   };
   verifyArchive(record, bytes, record.sha256);
   assert.throws(() => verifyArchive(record, Buffer.from('changed')), /SHA-256 differs/);
   assert.throws(() => verifyArchive(record, bytes, '0'.repeat(64)), /reviewed candidate/);
-  assert.throws(() => verifyArchive({ ...record, filename: '../package.tgz' }, bytes), /beside/);
+  assert.throws(() => verifyArchive({ ...record, version: '0.4.0-rc.1' }, bytes), /stable version/);
+  assert.throws(() => verifyArchive({ ...record, version: '0.4.1' }, bytes), /filename/);
+  assert.throws(() => verifyArchive({ ...record, filename: '../package.tgz' }, bytes), /filename/);
   assert.throws(
     () => verifyArchive({ ...record, files: EXPECTED_FILES.slice(1) }, bytes),
     /differs/,
@@ -113,16 +117,17 @@ test('release manifest provenance is clean, canonical and timezone-qualified', (
   const record = {
     name: PACKAGE,
     version: VERSION,
-    filename: 'package.tgz',
+    filename: ARCHIVE,
     files: EXPECTED_FILES,
     source_commit: 'a'.repeat(40),
     source_dirty: false,
-    prepared_at: '2026-09-05T00:00:00+00:00',
+    prepared_at: '2026-09-05T00:00:00.000Z',
     sha256: createHash('sha256').update(bytes).digest('hex'),
     integrity: `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
   };
   verifyArchive(record, bytes);
   verifyArchive({ ...record, source_commit: 'b'.repeat(64) }, bytes);
+  verifyArchive({ ...record, prepared_at: '2024-02-29T23:59:59.999Z' }, bytes);
   for (const source_dirty of [true, null, undefined]) {
     assert.throws(() => verifyArchive({ ...record, source_dirty }, bytes), /source must be clean/);
   }
@@ -133,7 +138,11 @@ test('release manifest provenance is clean, canonical and timezone-qualified', (
     null,
     '2026-09-05Z',
     '2026-09-05 00:00:00Z',
+    '2026-09-05T00:00:00Z',
+    '2026-09-05T00:00:00.000+00:00',
     '2026-09-05T00:00:00',
+    '2025-02-29T00:00:00.000Z',
+    '2026-01-01T24:00:00.000Z',
     'not-a-dateZ',
     '2026-09-05T00:00:00+99:99',
   ]) {
@@ -141,7 +150,7 @@ test('release manifest provenance is clean, canonical and timezone-qualified', (
   }
 });
 
-test('prepare rejects dirty package source and packs a clean real candidate', (context) => {
+test('prepare rejects dirty or changing package source and packs one clean candidate', (context) => {
   const temporary = mkdtempSync(join(realpathSync(tmpdir()), 'inferencex-release-test-'));
   context.after(() => rmSync(temporary, { recursive: true, force: true }));
   const source = resolve(import.meta.dirname, '..');
@@ -161,8 +170,17 @@ test('prepare rejects dirty package source and packs a clean real candidate', (c
     cwd: packageRoot,
     encoding: 'utf8',
   }).trim();
+  const fetchCalls = join(temporary, 'fetch-calls.txt');
   const preload = join(temporary, 'registry-404.mjs');
-  writeFileSync(preload, 'globalThis.fetch = async () => new Response(null, { status: 404 });\n');
+  writeFileSync(
+    preload,
+    `import { appendFileSync } from 'node:fs';
+globalThis.fetch = async () => {
+  appendFileSync(${JSON.stringify(fetchCalls)}, 'fetch\\n');
+  return new Response(null, { status: 404 });
+};
+`,
+  );
   const command = [
     '--import',
     pathToFileURL(preload).href,
@@ -180,16 +198,84 @@ test('prepare rejects dirty package source and packs a clean real candidate', (c
   assert.notEqual(dirty.status, 0, `${dirty.stdout}\n${dirty.stderr}`);
   assert.match(dirty.stderr, /source must be clean/);
   assert.equal(existsSync(dirtyOutput), false);
+  assert.equal(existsSync(fetchCalls), false);
 
   execFileSync('git', ['checkout', '--quiet', '--', 'README.md'], { cwd: packageRoot });
   const output = join(temporary, 'candidate');
   const clean = spawnSync(process.execPath, [...command, output], { encoding: 'utf8' });
   assert.equal(clean.status, 0, clean.stderr);
+  assert.equal(readFileSync(fetchCalls, 'utf8'), 'fetch\n');
   const record = JSON.parse(readFileSync(join(output, 'release.json'), 'utf8'));
   assert.equal(record.source_commit, sourceCommit);
   assert.equal(record.source_dirty, false);
   assert.deepEqual([...record.files].sort(), [...EXPECTED_FILES].sort());
   verifyArchive(record, readFileSync(join(output, record.filename)));
+
+  const wrapperDirectory = join(temporary, 'bin');
+  mkdirSync(wrapperDirectory);
+  const npmWrapper = join(wrapperDirectory, 'npm');
+  writeFileSync(
+    npmWrapper,
+    `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+const packed = spawnSync(process.env.REAL_NPM, process.argv.slice(2), { encoding: 'utf8' });
+process.stdout.write(packed.stdout ?? '');
+process.stderr.write(packed.stderr ?? '');
+if (packed.error) throw packed.error;
+if (packed.status !== 0) process.exit(packed.status ?? 1);
+if (process.env.PACK_MUTATION === 'dirty') {
+  appendFileSync(process.env.SOURCE_ROOT + '/README.md', '\\npack mutation\\n');
+} else {
+  execFileSync('git', ['-c', 'commit.gpgSign=false', 'commit', '--allow-empty', '--quiet', '-m', 'pack mutation'], {
+    cwd: process.env.SOURCE_ROOT,
+    stdio: 'inherit',
+  });
+}
+`,
+    { mode: 0o755 },
+  );
+  const realNpm = execFileSync('which', ['npm'], { encoding: 'utf8' }).trim();
+  for (const mutation of ['dirty', 'head']) {
+    const mutationOutput = join(temporary, `${mutation}-during-pack`);
+    const mutated = spawnSync(process.execPath, [...command, mutationOutput], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${wrapperDirectory}:${process.env.PATH}`,
+        REAL_NPM: realNpm,
+        SOURCE_ROOT: packageRoot,
+        PACK_MUTATION: mutation,
+      },
+    });
+    assert.notEqual(mutated.status, 0, `${mutated.stdout}\n${mutated.stderr}`);
+    assert.match(mutated.stderr, mutation === 'dirty' ? /source changed/ : /commit changed/);
+    assert.equal(existsSync(join(mutationOutput, 'release.json')), false);
+    if (mutation === 'dirty') {
+      execFileSync('git', ['checkout', '--quiet', '--', 'README.md'], { cwd: packageRoot });
+    }
+  }
+});
+
+test('check validates version and archive filename before reading archive bytes', (context) => {
+  const temporary = mkdtempSync(join(realpathSync(tmpdir()), 'inferencex-release-check-'));
+  context.after(() => rmSync(temporary, { recursive: true, force: true }));
+  const manifest = join(temporary, 'release.json');
+  for (const [version, filename, message] of [
+    [VERSION, 'prompt.txt', /filename/],
+    [VERSION, '../outside.tgz', /filename/],
+    ['0.4.0-rc.1', 'missing.tgz', /stable version/],
+  ]) {
+    writeFileSync(manifest, JSON.stringify({ name: PACKAGE, version, filename }));
+    const checked = spawnSync(
+      process.execPath,
+      [resolve(import.meta.dirname, '../scripts/release.mjs'), 'check', manifest],
+      { encoding: 'utf8' },
+    );
+    assert.notEqual(checked.status, 0);
+    assert.match(checked.stderr, message);
+    assert.doesNotMatch(checked.stderr, /ENOENT/);
+  }
 });
 
 test('public verification decodes gzip HTTP JSON but preserves raw npm tarball bytes', () => {

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -767,6 +767,29 @@ class AgentXVerifierTests(unittest.TestCase):
         self.assertEqual(completed.returncode, 0, completed.stderr)
         self.assertEqual(json.loads((evidence / 'manifest.json').read_text())['responses'], [])
 
+    def test_point_capture_preload_requires_redirect_rejection(self):
+        node = check.shutil.which('node')
+        self.assertIsNotNone(node)
+        preload = self.root / 'capture.mjs'
+        script = self.root / 'redirect.mjs'
+        evidence = self.root / 'redirect-evidence'
+        preload.write_text(check.POINT_CAPTURE_PRELOAD)
+        script.write_text("""try {
+  await fetch('https://inferencex.semianalysis.com/api/openapi.json');
+  throw new Error('Default redirect handling was accepted');
+} catch (error) {
+  if (!String(error).includes('must reject redirects')) throw error;
+}
+""")
+        environment = dict(check.os.environ)
+        environment.update(INFERENCEX_POINT_EVIDENCE=str(evidence), INFERENCEX_POINT_ID='7',
+                           INFERENCEX_POINT_OUTPUT=str(self.root / 'point.json'),
+                           INFERENCEX_PACKAGE_VERSION=VERSION)
+        completed = subprocess.run([node, '--import', preload.as_uri(), script], env=environment,
+                                   capture_output=True, text=True, check=False)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads((evidence / 'manifest.json').read_text())['responses'], [])
+
     def test_installed_boundary_and_public_archive_bytes_are_exact(self):
         installed = self.root / 'installed'
         installed.mkdir()

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -20,7 +20,7 @@ spec = importlib.util.spec_from_file_location(
     'release_check', Path(__file__).resolve().parents[1] / 'scripts/verify-release.py')
 check = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(check)
-VERSION = '0.3.0'
+VERSION = '0.4.0'
 ETARGET = f'npm error code ETARGET\nnpm error notarget No matching version found for {check.PACKAGE}@{VERSION}.\n'
 
 
@@ -113,7 +113,7 @@ class RetryTests(unittest.TestCase):
             'npm error code E401\nAuthentication required',
             'npm error code E403\nForbidden',
             'npm error code EINTEGRITY\nIntegrity checksum failed',
-            ETARGET.replace(VERSION, '0.3.1'),
+            ETARGET.replace(VERSION, '0.4.1'),
             ETARGET.replace(check.PACKAGE, 'another-package'),
             ETARGET.replace('code ETARGET', 'code E404'),
             ETARGET + 'npm error code E401\n',

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -897,6 +897,19 @@ class AgentXVerifierTests(unittest.TestCase):
             self.assertIn(f'install --target {prepared["target"]}', prompt_text)
             self.assertIn(str(project / 'candidate.tgz'), prompt_text)
 
+    def test_agents_rejects_archive_filename_collision_before_creating_projects(self):
+        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'prompt.txt',
+                  'sha256': '0' * 64, 'integrity': 'sha512-invalid'}
+        check.save(self.root / 'unsafe-release.json', record)
+        command = ['verify-release.py', 'agents', str(self.root / 'unsafe-release.json'), '--model', 'Example',
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
+                   '--agentx-no-trace-id', '8', '--evidence', str(self.root / 'unsafe-verification')]
+        with patch.object(sys, 'argv', command), patch.object(check.tempfile, 'mkdtemp') as projects:
+            with self.assertRaisesRegex(ValueError, r'safe \.tgz basename'):
+                check.main()
+        projects.assert_not_called()
+        self.assertFalse((self.root / 'unsafe-verification').exists())
+
     def test_check_agent_runs_both_workload_and_point_oracles(self):
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w:gz') as packed:

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -930,10 +930,18 @@ class AgentXVerifierTests(unittest.TestCase):
         scope = {'model': 'Example', 'date': None, 'isl': 8192, 'osl': 1024, 'raw_model': None,
                  'empty_isl': 7, 'empty_osl': 13, 'agentx_model': 'Example',
                  'agentx_point_id': '7', 'agentx_no_trace_id': '8'}
-        check.save(project.parent / 'acceptance.json', {'candidate': record, 'scope': scope,
-                                                       'targets': [{'target': 'codex', 'project': str(project),
-                                                                    'status': 'awaiting-native-agent',
-                                                                    'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()}]})
+        claude_project = project.parent / 'claude'
+        claude_prompt = check.prompt(self.args, 'claude', claude_project / 'candidate.tgz').encode()
+        acceptance = {
+            'status': 'prepared', 'mode': 'agents', 'started_at': '2026-09-05T00:00:00Z',
+            'candidate': record, 'new_benchmark_runs': False, 'requests': [], 'scope': scope,
+            'clean_root': str(project.parent),
+            'targets': [
+                {'target': 'codex', 'project': str(project), 'status': 'awaiting-native-agent',
+                 'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()},
+                {'target': 'claude', 'project': str(claude_project), 'status': 'awaiting-native-agent',
+                 'prompt_sha256': hashlib.sha256(claude_prompt).hexdigest()}]}
+        check.save(project.parent / 'acceptance.json', acceptance)
         check.save(project / 'lookup.json', {})
         check.save(project / 'unavailable.json', {'metadata': {}, 'rows': []})
         check.save(project / 'diagnostic.json', {'diagnostic': {}})
@@ -942,6 +950,34 @@ class AgentXVerifierTests(unittest.TestCase):
                    '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
                    '--agentx-no-trace-id', '8', '--project', str(project),
                    '--evidence', str(self.root / 'check-agent')]
+        for mutation in ['missing-status', 'running-status', 'failed-status', 'wrong-mode',
+                         'changed-target', 'missing-target', 'changed-target-status', 'same-project']:
+            with self.subTest(mutation=mutation):
+                altered = json.loads(json.dumps(acceptance))
+                if mutation == 'missing-status':
+                    del altered['status']
+                elif mutation in {'running-status', 'failed-status'}:
+                    altered['status'] = mutation.removesuffix('-status')
+                elif mutation == 'wrong-mode':
+                    altered['mode'] = 'candidate'
+                elif mutation == 'changed-target':
+                    altered['targets'][1]['target'] = 'other'
+                elif mutation == 'missing-target':
+                    altered['targets'].pop()
+                elif mutation == 'changed-target-status':
+                    altered['targets'][1]['status'] = 'complete'
+                else:
+                    altered['targets'][1]['project'] = altered['targets'][0]['project']
+                check.save(project.parent / 'acceptance.json', altered)
+                rejected = command[:-1] + [str(self.root / f'rejected-{mutation}')]
+                message = 'preparation state' if mutation in {
+                    'missing-status', 'running-status', 'failed-status', 'wrong-mode'} else 'target set'
+                with patch.object(sys, 'argv', rejected), patch.object(check, 'check_installed') as installed, \
+                        patch('builtins.print'):
+                    with self.assertRaisesRegex(ValueError, message):
+                        check.main()
+                installed.assert_not_called()
+        check.save(project.parent / 'acceptance.json', acceptance)
         (project / 'prompt.txt').write_text('changed')
         tampered = command[:-1] + [str(self.root / 'tampered-check-agent')]
         with patch.object(sys, 'argv', tampered), patch.object(check, 'check_installed') as installed, \

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -1,4 +1,4 @@
-"""Offline retry/deadline regressions for the existing read-only verifier."""
+"""Offline evidence, orchestration, retry, and deadline regressions for the release verifier."""
 
 import base64
 import csv
@@ -234,7 +234,9 @@ class RetryTests(unittest.TestCase):
         (self.root / 'candidate.tgz').write_bytes(body)
         check.save(self.root / 'release.json', record)
         command = ['verify-release.py', 'public', str(self.root / 'release.json'), '--model', 'Example',
-                   '--isl', '8192', '--osl', '1024', '--evidence', str(self.root / 'evidence')]
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example',
+                   '--agentx-point-id', '7', '--agentx-no-trace-id', '8',
+                   '--evidence', str(self.root / 'evidence')]
         metadata = {'name': check.PACKAGE, 'version': VERSION, 'dist': {'integrity': 'wrong'}}
         with patch.object(sys, 'argv', command), patch.object(check, 'fetch_public', return_value=json.dumps(metadata)) as fetch, \
                 patch.object(check, 'install_target') as install, patch('builtins.print'):
@@ -300,6 +302,433 @@ class RetryTests(unittest.TestCase):
         self.assertEqual(check.captured_request(self.root, 'lookup', context['query_url'], context), [])
         with self.assertRaisesRegex(ValueError, 'original request context'):
             check.captured_request(self.root, 'lookup', context['query_url'], context | {'retrieved_at': '2026-09-06T00:00:00Z'})
+
+
+class AgentXVerifierTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.fixture_index = 0
+        self.args = SimpleNamespace(agentx_model='Example', agentx_point_id='7', agentx_no_trace_id='8',
+                                    model='Example', date=None, isl=8192, osl=1024, raw_model=None,
+                                    empty_isl=7, empty_osl=13)
+
+    @staticmethod
+    def row():
+        return {
+            'id': '7', 'model': 'model-a', 'hardware': 'h200', 'framework': 'vllm', 'image': None,
+            'precision': 'fp8', 'spec_method': 'none', 'benchmark_type': 'agentic_traces', 'conc': 1,
+            'offload_mode': 'off', 'recipe_fingerprint': None, 'disagg': False, 'is_multinode': False,
+            'prefill_tp': 1, 'prefill_ep': 1, 'prefill_dp_attention': False, 'prefill_num_workers': 1,
+            'decode_tp': 1, 'decode_ep': 1, 'decode_dp_attention': False, 'decode_num_workers': 1,
+            'num_prefill_gpu': 1, 'num_decode_gpu': 1, 'isl': 32, 'osl': 16, 'date': '2026-09-05',
+            'workflow_run_id': 'run-1', 'run_started_at': '2026-09-05T00:00:00Z', 'run_url': None,
+            'curve_date': None, 'curve_workflow_run_id': None, 'curve_run_started_at': None,
+            'metrics': {'z': 0, 'a': False, 'nullish': None, 'object': {'kept': True}, 'é': 1}}
+
+    @staticmethod
+    def scope(excluded):
+        raw_model = check.AGENTX_EXCLUDED_RAW_MODEL if excluded else None
+        requested = {
+            'display_model': 'Example', 'date': None, 'date_selection': 'latest', 'raw_model': raw_model,
+            'hardware': None, 'framework': None, 'precision': None, 'spec_method': None,
+            'offload_mode': None, 'concurrency': None, 'benchmark_type': 'agentic_traces'}
+        applied = {
+            'display_model': {'status': 'applied', 'value': 'Example'},
+            'date': {'status': 'omitted', 'value': None},
+            'benchmark_type': {'status': 'applied', 'value': 'agentic_traces'},
+            'raw_model': {'status': 'applied' if excluded else 'omitted', 'value': raw_model},
+            'hardware': {'status': 'omitted', 'value': None},
+            'framework': {'status': 'omitted', 'value': None},
+            'precision': {'status': 'omitted', 'value': None},
+            'spec_method': {'status': 'omitted', 'value': None},
+            'offload_mode': {'status': 'omitted', 'value': None},
+            'concurrency': {'status': 'omitted', 'value': None}}
+        return requested, applied
+
+    @staticmethod
+    def coverage(selected):
+        count = int(selected)
+        return {
+            'safe_id_rows': count, 'unsupported_id_rows': 0, 'unique_safe_ids': count,
+            'aggregates': {group: {'available_rows': 0, 'null_rows': count, 'missing_entry_rows': 0,
+                                   'unsupported_id_rows': 0} for group in check.AGENTX_GROUPS},
+            'derived_metrics': {'available_rows': count, 'missing_entry_rows': 0, 'unsupported_id_rows': 0},
+            'trace_availability': {'stored_trace_rows': 0, 'no_stored_trace_rows': count,
+                                   'response_key_rows': count, 'missing_key_rows': 0,
+                                   'unsupported_id_rows': 0}}
+
+    def write_summary(self, output_format, *, excluded=False):
+        self.fixture_index += 1
+        row = self.row()
+        requested, applied = self.scope(excluded)
+        selected = [] if excluded else [row]
+        benchmark_url = check.AGENTX_API + '?model=Example'
+        responses = [('benchmarks', benchmark_url, None, [row])]
+        if selected:
+            query = '?ids=7'
+            responses += [
+                ('agentic-aggregates', check.AGENTX_ORIGIN + '/api/v1/agentic-aggregates' + query, [7],
+                 {'7': {'id': 7, **dict.fromkeys(check.AGENTX_GROUPS)}}),
+                ('derived-agentic-metrics', check.AGENTX_ORIGIN + '/api/v1/derived-agentic-metrics' + query, [7],
+                 {'7': {'id': 7, 'p75_e2e_norm_intvty': 0, 'p90_e2e_norm_intvty': None}}),
+                ('trace-availability', check.AGENTX_ORIGIN + '/api/v1/trace-availability' + query, [7],
+                 {'7': False})]
+        suffix = f'{"excluded" if excluded else output_format}-{self.fixture_index}'
+        evidence = self.root / f'agentx-{suffix}-evidence'
+        evidence.mkdir()
+        records = []
+        for number, (operation, url, chunk, body) in enumerate(responses, 1):
+            body_bytes = json.dumps(body, ensure_ascii=False, separators=(',', ':')).encode()
+            filename = f'response-{number:04d}-{operation}.json'
+            (evidence / filename).write_bytes(body_bytes)
+            records.append({'operation': operation, 'request_number': number, 'url': url, 'method': 'GET',
+                            'retrieved_at': f'2026-09-05T00:00:0{number}Z', 'http_status': 200,
+                            'decoded_body_sha256': hashlib.sha256(body_bytes).hexdigest(), 'body_file': filename,
+                            'requested_chunk_ids': chunk,
+                            'checksum_covers': 'saved decoded response body'})
+        outcome = 'no_matching_rows' if excluded else 'selected_rows'
+        counts = {'returned_rows': 1, 'returned_agentx_rows': 1, 'selected_rows': len(selected)}
+        filters = {name: applied[name] for name, _field in check.AGENTX_FILTERS}
+        enriched = [] if excluded else [{
+            'benchmark': row,
+            'agentx': {
+                'status': 'complete', 'result_id': 7,
+                'aggregates': {'status': 'available', 'value': {'id': 7, **dict.fromkeys(check.AGENTX_GROUPS)}},
+                'derived_metrics': {'status': 'available', 'value': {
+                    'id': 7, 'p75_e2e_norm_intvty': 0, 'p90_e2e_norm_intvty': None}},
+                'trace_availability': {'status': 'no_stored_trace', 'value': False,
+                                       'response_key_present': True}}}]
+        metadata = {
+            'package_version': VERSION, 'retrieved_at': '2026-09-05T00:00:05Z',
+            'request_urls': [{'operation': item['operation'], 'url': item['url']} for item in records],
+            'requested_scope': requested, 'filters': filters, 'outcome': outcome, **counts,
+            'available_filter_values': {'raw_model': ['model-a'], 'hardware': ['h200'],
+                                        'framework': ['vllm'], 'precision': ['fp8'],
+                                        'spec_method': ['none'], 'offload_mode': ['off'], 'concurrency': [1]},
+            'returned_model_keys': ['model-a'], 'selected_model_keys': [] if excluded else ['model-a'],
+            'enrichment_coverage': self.coverage(not excluded), 'non_finite_values': 0,
+            'observation_context': 'Existing observations were read; no new benchmark was run.'}
+        output = self.root / f'agentx-{suffix}.{output_format}'
+        if output_format == 'json':
+            output.write_text(json.dumps({'schema_version': 1, 'metadata': metadata, 'rows': enriched},
+                                         ensure_ascii=False, indent=2) + '\n')
+        else:
+            metric_columns = ['metrics.a', 'metrics.nullish', 'metrics.z', 'metrics.é']
+            columns = [*check.AGENTX_CONTEXT_COLUMNS, *check.AGENTX_BENCHMARK_COLUMNS, *metric_columns,
+                       *check.AGENTX_ENRICHMENT_COLUMNS]
+            context = {'package_version': VERSION, 'query_url': benchmark_url,
+                       'retrieved_at': metadata['retrieved_at'], 'requested_model': 'Example',
+                       'requested_date': None, 'date_selection': 'latest',
+                       'requested_benchmark_type': 'agentic_traces',
+                       **{f'filter.{name}': requested[name] for name, _field in check.AGENTX_FILTERS}}
+            values = {**context, **{field: row.get(field) for field in check.AGENTX_BENCHMARK_COLUMNS},
+                      'metrics.a': False, 'metrics.nullish': None, 'metrics.z': 0, 'metrics.é': 1,
+                      **{f'aggregate.{group}.{field}': None for group in check.AGENTX_GROUPS
+                         for field in (*check.AGENTX_PERCENTILES, 'n')},
+                      'derived.p75_e2e_norm_intvty': 0, 'derived.p90_e2e_norm_intvty': None,
+                      'trace.available': False, 'trace.response_key_present': True,
+                      'enrichment.status': 'complete', 'enrichment.aggregates_status': 'available',
+                      'enrichment.derived_metrics_status': 'available',
+                      'enrichment.trace_availability_status': 'no_stored_trace'}
+            with output.open('w', newline='') as handle:
+                writer = csv.writer(handle, lineterminator='\r\n')
+                writer.writerow(columns)
+                writer.writerow(['' if values.get(column) is None else
+                                 str(values[column]).lower() if type(values.get(column)) is bool else
+                                 values[column] for column in columns])
+        manifest = {
+            'schema_version': 1, 'package_version': VERSION, 'status': 'complete',
+            'started_at': '2026-09-05T00:00:00Z', 'finished_at': '2026-09-05T00:00:06Z',
+            'outcome': outcome, 'requested_filters': requested, 'applied_filters': applied, 'counts': counts,
+            'responses': records,
+            'export': {'format': output_format, 'destination': str(output.resolve()),
+                       'sha256': hashlib.sha256(output.read_bytes()).hexdigest(), 'metadata': metadata,
+                       'source_request_numbers': list(range(1, len(records) + 1))},
+            'error': None}
+        check.save(evidence / 'manifest.json', manifest)
+        return evidence, output, manifest
+
+    @staticmethod
+    def point_openapi():
+        return {'paths': {path: {'get': {'parameters': [
+            {'name': parameter, 'in': 'query', 'required': True}]}}
+            for _operation, path, parameter in check.POINT_OPERATIONS[1:]}}
+
+    def write_point(self, *, trace):
+        self.fixture_index += 1
+        selected_id = '7'
+        siblings = {'sku': {'model': 'model-a'}, 'siblings': [{'id': selected_id, 'model': 'model-a'}]}
+        availability = {selected_id: True} if trace else {}
+        bodies = [self.point_openapi(), siblings, availability]
+        if trace:
+            timeline = {'version': 1, 'startNs': 0, 'endNs': 1, 'durationS': 1, 'requests': []}
+            histograms = {selected_id: {'id': 7, 'isl': [1], 'osl': [2]}}
+            server = {'meta': {'id': 7}, 'startNs': 0, 'endNs': 1, 'durationS': 1,
+                      'timeslicesCount': 0, 'kvCacheUsage': [], 'prefixCacheHitRate': [], 'queueDepth': [],
+                      'prefillTps': [], 'decodeTps': [], 'prefixCacheHitsTps': [], 'hostKvCacheUsage': [],
+                      'kvCacheUsageByEngine': [], 'promptTokensBySource': {}, 'kvCachePoolTokens': None,
+                      'metricSources': []}
+            bodies += [timeline, histograms, server]
+        specs = check.POINT_OPERATIONS if trace else check.POINT_OPERATIONS[:3]
+        name = f'{"trace" if trace else "no-trace"}-{self.fixture_index}'
+        evidence = self.root / f'{name}-evidence'
+        evidence.mkdir()
+        records = []
+        for number, ((operation, path, parameter), body) in enumerate(zip(specs, bodies), 1):
+            body_bytes = json.dumps(body, separators=(',', ':')).encode()
+            filename = f'response-{number:04d}-{operation}.json'
+            (evidence / filename).write_bytes(body_bytes)
+            records.append({'operation': operation, 'request_number': number,
+                            'url': check.point_url(path, parameter, selected_id), 'method': 'GET',
+                            'retrieved_at': f'2026-09-05T00:00:0{number}Z', 'http_status': 200,
+                            'decoded_body_sha256': hashlib.sha256(body_bytes).hexdigest(), 'body_file': filename,
+                            'checksum_covers': 'saved decoded response body'})
+        output = self.root / f'{name}.json'
+        requests = [{'query_url': record['url'], 'retrieved_at': f'2026-09-05T00:00:1{index}Z'}
+                    for index, record in enumerate(records, 1)]
+        document = {
+            'schema_version': 1,
+            'metadata': {'selected_result_id': selected_id, 'retrieved_at': '2026-09-05T00:00:20Z',
+                         'requests': requests, 'ran_new_benchmark': False,
+                         'event_timestamp_unit': 'nanoseconds',
+                         'event_timestamp_origin': 'offset from timeline.startNs; not wall-clock'},
+            'benchmark_siblings': siblings, 'selected_point': siblings['siblings'][0],
+            'trace_availability': {'response': availability, 'key_present': trace, 'available': trace},
+            'outcome': 'trace_diagnostics' if trace else 'trace_unavailable',
+            'timeline': bodies[3] if trace else None, 'histograms': bodies[4] if trace else None,
+            'server_metrics': bodies[5] if trace else None}
+        output.write_text(json.dumps(document, indent=2) + '\n')
+        manifest = {
+            'schema_version': 1, 'package_version': VERSION, 'selected_result_id': selected_id,
+            'status': 'complete', 'started_at': '2026-09-05T00:00:00Z',
+            'finished_at': '2026-09-05T00:00:21Z', 'responses': records,
+            'output': {'format': 'json', 'destination': str(output.resolve()),
+                       'sha256': hashlib.sha256(output.read_bytes()).hexdigest(),
+                       'source_request_numbers': list(range(1, len(records) + 1))}, 'error': None}
+        check.save(evidence / 'manifest.json', manifest)
+        return evidence, output, manifest, document
+
+    def test_summary_oracle_accepts_json_csv_and_excluded_selection(self):
+        for output_format, excluded in [('json', False), ('csv', False), ('json', True)]:
+            with self.subTest(output_format=output_format, excluded=excluded):
+                evidence, output, _manifest = self.write_summary(output_format, excluded=excluded)
+                result = check.check_agentx_capture(self.root, evidence.name, output.name, self.args,
+                                                    VERSION, excluded=excluded)
+                self.assertEqual(result['outcome'], 'no_matching_rows' if excluded else 'selected_rows')
+        self.assertIsNone(check.safe_result_id(True))
+        self.assertIsNone(check.safe_result_id('07'))
+        self.assertIsNone(check.safe_result_id(str(check.MAX_SAFE_INTEGER + 1)))
+        self.assertEqual(check.js_sorted(['\ue000', '😀']), ['😀', '\ue000'])
+
+    def test_summary_oracle_rejects_altered_values_ids_chunks_and_incomplete_evidence(self):
+        evidence, output, manifest = self.write_summary('json')
+        document = json.loads(output.read_text())
+        document['rows'][0]['benchmark']['metrics']['z'] = False
+        check.save(output, document)
+        manifest['export']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'AgentX JSON'):
+            check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
+        evidence, output, manifest = self.write_summary('csv')
+        with output.open(newline='') as handle:
+            rows = list(csv.reader(handle))
+        column = rows[0].index('derived.p75_e2e_norm_intvty')
+        rows[1][column] = '1'
+        with output.open('w', newline='') as handle:
+            csv.writer(handle, lineterminator='\r\n').writerows(rows)
+        manifest['export']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'AgentX CSV value'):
+            check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
+        for mutation, message in [('chunk', 'identity'), ('id', 'result ID'), ('manifest', 'manifest')]:
+            with self.subTest(mutation=mutation):
+                evidence, output, manifest = self.write_summary('json')
+                if mutation == 'chunk':
+                    manifest['responses'][1]['requested_chunk_ids'] = [8]
+                elif mutation == 'id':
+                    body_path = evidence / manifest['responses'][1]['body_file']
+                    body = json.loads(body_path.read_text())
+                    body['8'] = body.pop('7')
+                    body_path.write_text(json.dumps(body))
+                    manifest['responses'][1]['decoded_body_sha256'] = hashlib.sha256(body_path.read_bytes()).hexdigest()
+                else:
+                    del manifest['export']['source_request_numbers']
+                check.save(evidence / 'manifest.json', manifest)
+                with self.assertRaisesRegex((ValueError, KeyError), message):
+                    check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
+        evidence, output, manifest = self.write_summary('json')
+        (evidence / manifest['responses'][2]['body_file']).unlink()
+        with self.assertRaises(FileNotFoundError):
+            check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
+    def test_point_oracle_accepts_bounded_trace_and_no_trace_and_rejects_invalid_diagnostics(self):
+        for trace in [False, True]:
+            evidence, output, _manifest, _document = self.write_point(trace=trace)
+            self.assertEqual(check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION),
+                             'trace_diagnostics' if trace else 'trace_unavailable')
+        self.assertEqual(check.check_point_outcomes(['trace_diagnostics', 'trace_unavailable']),
+                         ['trace_diagnostics', 'trace_unavailable'])
+        with self.assertRaisesRegex(ValueError, 'one traced and one no-trace'):
+            check.check_point_outcomes(['trace_unavailable', 'trace_unavailable'])
+
+        evidence, output, manifest, document = self.write_point(trace=True)
+        document['timeline']['version'] = True
+        check.save(output, document)
+        manifest['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'Trace diagnostic differs'):
+            check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
+
+        evidence, output, manifest, document = self.write_point(trace=True)
+        timeline_record = manifest['responses'][3]
+        timeline_path = evidence / timeline_record['body_file']
+        timeline = json.loads(timeline_path.read_text())
+        timeline['version'] = True
+        timeline_path.write_text(json.dumps(timeline))
+        timeline_record['decoded_body_sha256'] = hashlib.sha256(timeline_path.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'timeline'):
+            check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
+
+        evidence, output, manifest, document = self.write_point(trace=False)
+        document['selected_point']['id'] = '8'
+        check.save(output, document)
+        manifest['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'differs from complete responses'):
+            check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
+
+    def test_installed_boundary_and_public_archive_bytes_are_exact(self):
+        installed = self.root / 'installed'
+        installed.mkdir()
+        (installed / 'SKILL.md').write_bytes(b'skill')
+        check.save(installed / '.inferencex-skills.json', {'package': check.PACKAGE, 'version': VERSION})
+        check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+        (installed / 'unexpected.txt').write_text('extra')
+        with self.assertRaisesRegex(ValueError, 'Unexpected installed files'):
+            check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode='w:gz') as packed:
+            entry = tarfile.TarInfo('package/skills/inferencex-api/SKILL.md')
+            entry.size = 5
+            packed.addfile(entry, io.BytesIO(b'skill'))
+        archive = stream.getvalue()
+        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'candidate.tgz',
+                  'sha256': hashlib.sha256(archive).hexdigest(),
+                  'integrity': 'sha512-' + base64.b64encode(hashlib.sha512(archive).digest()).decode()}
+        (self.root / 'candidate.tgz').write_bytes(archive)
+        check.save(self.root / 'release.json', record)
+        metadata = {'name': check.PACKAGE, 'version': VERSION,
+                    'dist': {'integrity': record['integrity'], 'tarball': check.REGISTRY + '/different.tgz'}}
+        command = ['verify-release.py', 'public', str(self.root / 'release.json'), '--model', 'Example',
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
+                   '--agentx-no-trace-id', '8', '--evidence', str(self.root / 'public-verification')]
+        with patch.object(sys, 'argv', command), \
+                patch.object(check, 'fetch_public', side_effect=[json.dumps(metadata).encode(), b'different']) as fetch, \
+                patch.object(check, 'install_target') as install, patch('builtins.print'):
+            with self.assertRaisesRegex(ValueError, 'Public tarball differs'):
+                check.main()
+        self.assertEqual(fetch.call_count, 2)
+        install.assert_not_called()
+
+    def test_candidate_orchestrates_powerx_and_agentx_for_both_targets(self):
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode='w:gz') as packed:
+            content = b'skill'
+            entry = tarfile.TarInfo('package/skills/inferencex-api/SKILL.md')
+            entry.size = len(content)
+            packed.addfile(entry, io.BytesIO(content))
+        body = stream.getvalue()
+        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'candidate.tgz',
+                  'sha256': hashlib.sha256(body).hexdigest(),
+                  'integrity': 'sha512-' + base64.b64encode(hashlib.sha512(body).digest()).decode()}
+        (self.root / 'candidate.tgz').write_bytes(body)
+        check.save(self.root / 'release.json', record)
+        command = ['verify-release.py', 'candidate', str(self.root / 'release.json'), '--model', 'Example',
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
+                   '--agentx-no-trace-id', '8', '--evidence', str(self.root / 'verification')]
+        projects = {}
+
+        def install(clean_root, target, *_args, **_kwargs):
+            project = Path(clean_root) / target
+            project.mkdir(parents=True)
+            projects[target] = project
+            return project, {}
+
+        with patch.object(sys, 'argv', command), patch.object(check, 'install_target', side_effect=install) as installs, \
+                patch.object(check, 'check_installed'), patch.object(check, 'run') as runs, \
+                patch.object(check, 'captured_export', return_value=[]), \
+                patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
+                patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}), \
+                patch.object(check, 'run_point', side_effect=['trace_diagnostics', 'trace_unavailable'] * 2), \
+                patch('builtins.print'):
+            check.main()
+        self.assertEqual([call.args[1] for call in installs.call_args_list], ['codex', 'claude'])
+        commands = [[str(part) for part in call.args[0]] for call in runs.call_args_list]
+        for target, project in projects.items():
+            target_commands = [command for command, call in zip(commands, runs.call_args_list)
+                               if call.args[1] == project]
+            self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in target_commands), 2, target)
+            self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in target_commands), 3, target)
+
+    def test_check_agent_runs_both_workload_and_point_oracles(self):
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode='w:gz') as packed:
+            entry = tarfile.TarInfo('package/skills/inferencex-api/SKILL.md')
+            entry.size = 5
+            packed.addfile(entry, io.BytesIO(b'skill'))
+        archive = stream.getvalue()
+        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'candidate.tgz',
+                  'sha256': hashlib.sha256(archive).hexdigest(),
+                  'integrity': 'sha512-' + base64.b64encode(hashlib.sha512(archive).digest()).decode()}
+        (self.root / 'candidate.tgz').write_bytes(archive)
+        check.save(self.root / 'release.json', record)
+        project = self.root / 'prepared/codex'
+        project.mkdir(parents=True)
+        scope = {'model': 'Example', 'date': None, 'isl': 8192, 'osl': 1024, 'raw_model': None,
+                 'empty_isl': 7, 'empty_osl': 13, 'agentx_model': 'Example',
+                 'agentx_point_id': '7', 'agentx_no_trace_id': '8'}
+        check.save(project.parent / 'acceptance.json', {'candidate': record, 'scope': scope,
+                                                       'targets': [{'target': 'codex', 'project': str(project)}]})
+        check.save(project / 'lookup.json', {})
+        check.save(project / 'unavailable.json', {'metadata': {}, 'rows': []})
+        check.save(project / 'diagnostic.json', {'diagnostic': {}})
+        (project / 'result.md').write_text('Checked both public workflows.')
+        command = ['verify-release.py', 'check-agent', str(self.root / 'release.json'), '--model', 'Example',
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
+                   '--agentx-no-trace-id', '8', '--project', str(project),
+                   '--evidence', str(self.root / 'check-agent')]
+        with patch.object(sys, 'argv', command), patch.object(check, 'check_installed'), \
+                patch.object(check, 'captured_export', return_value=[]), \
+                patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
+                patch.object(check, 'captured_request', return_value=[]), patch.object(check, 'check_lookup'), \
+                patch.object(check, 'check_metadata', return_value=[]), \
+                patch.object(check, 'check_empty_diagnostic'), \
+                patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}) as summaries, \
+                patch.object(check, 'check_agentx_point',
+                             side_effect=['trace_diagnostics', 'trace_unavailable']) as points, \
+                patch('builtins.print'):
+            check.main()
+        self.assertEqual(summaries.call_count, 3)
+        self.assertEqual(points.call_count, 2)
+        report = json.loads((self.root / 'check-agent/verification.json').read_text())
+        self.assertEqual(report['status'], 'data-checks-passed')
+
+    def test_workflow_gates_candidate_before_publish_and_public_after(self):
+        workflow = (Path(__file__).resolve().parents[3] / '.github/workflows/publish-skills.yml').read_text()
+        candidate = workflow.index('verify-release.py candidate')
+        publish = workflow.index('npm publish')
+        public = workflow.index('verify-release.py public')
+        self.assertLess(candidate, publish)
+        self.assertLess(publish, public)
+        for flag in ['--agentx-model', '--agentx-point-id', '--agentx-no-trace-id']:
+            self.assertEqual(workflow.count(flag), 2)
 
 
 if __name__ == '__main__':

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -364,7 +364,7 @@ class AgentXVerifierTests(unittest.TestCase):
         row = self.row()
         requested, applied = self.scope(excluded)
         selected = [] if excluded else [row]
-        benchmark_url = check.AGENTX_API + '?model=Example'
+        benchmark_url = check.API + '?model=Example'
         responses = [('benchmarks', benchmark_url, None, [row])]
         if selected:
             query = '?ids=7'
@@ -450,6 +450,92 @@ class AgentXVerifierTests(unittest.TestCase):
         check.save(evidence / 'manifest.json', manifest)
         return evidence, output, manifest
 
+    def write_multichunk_summary(self):
+        self.fixture_index += 1
+        rows = []
+        for result_id in range(1, 502):
+            row = self.row() | {'id': str(result_id)}
+            rows.append(row)
+        requested, applied = self.scope(False)
+        benchmark_url = check.API + '?model=Example'
+        responses = [('benchmarks', benchmark_url, None, rows)]
+        for operation, limit in [('agentic-aggregates', 200), ('derived-agentic-metrics', 200),
+                                 ('trace-availability', 500)]:
+            for offset in range(0, len(rows), limit):
+                chunk = list(range(offset + 1, min(offset + limit, len(rows)) + 1))
+                if operation == 'agentic-aggregates':
+                    body = {str(result_id): {'id': result_id, **dict.fromkeys(check.AGENTX_GROUPS)}
+                            for result_id in chunk if result_id != 2}
+                elif operation == 'derived-agentic-metrics':
+                    body = {str(result_id): {'id': result_id, 'p75_e2e_norm_intvty': 0,
+                                             'p90_e2e_norm_intvty': None}
+                            for result_id in chunk if result_id != 3}
+                else:
+                    body = {str(result_id): result_id == 1 for result_id in chunk if result_id != 4}
+                responses.append((operation, check.AGENTX_ORIGIN + f'/api/v1/{operation}?' +
+                                  check.urlencode({'ids': ','.join(map(str, chunk))}), chunk, body))
+        evidence = self.root / f'agentx-multichunk-{self.fixture_index}-evidence'
+        evidence.mkdir()
+        records = []
+        for number, (operation, url, chunk, body) in enumerate(responses, 1):
+            body_bytes = json.dumps(body, ensure_ascii=False, separators=(',', ':')).encode()
+            filename = f'response-{number:04d}-{operation}.json'
+            (evidence / filename).write_bytes(body_bytes)
+            records.append({'operation': operation, 'request_number': number, 'url': url, 'method': 'GET',
+                            'retrieved_at': f'2026-09-05T00:00:{number:02d}Z', 'http_status': 200,
+                            'decoded_body_sha256': hashlib.sha256(body_bytes).hexdigest(), 'body_file': filename,
+                            'requested_chunk_ids': chunk,
+                            'checksum_covers': 'saved decoded response body'})
+        enriched = []
+        for result_id, row in enumerate(rows, 1):
+            aggregates = None if result_id == 2 else {'id': result_id, **dict.fromkeys(check.AGENTX_GROUPS)}
+            derived = None if result_id == 3 else {
+                'id': result_id, 'p75_e2e_norm_intvty': 0, 'p90_e2e_norm_intvty': None}
+            trace_key = result_id != 4
+            trace = result_id == 1
+            enriched.append({'benchmark': row, 'agentx': {
+                'status': 'complete' if aggregates is not None and derived is not None else 'partial',
+                'result_id': result_id,
+                'aggregates': {'status': 'available' if aggregates is not None else 'not_returned',
+                               'value': aggregates},
+                'derived_metrics': {'status': 'available' if derived is not None else 'not_returned',
+                                    'value': derived},
+                'trace_availability': {'status': 'stored_trace' if trace else 'no_stored_trace',
+                                       'value': trace, 'response_key_present': trace_key}}})
+        counts = {'returned_rows': 501, 'returned_agentx_rows': 501, 'selected_rows': 501}
+        filters = {name: applied[name] for name, _field in check.AGENTX_FILTERS}
+        coverage = {
+            'safe_id_rows': 501, 'unsupported_id_rows': 0, 'unique_safe_ids': 501,
+            'aggregates': {group: {'available_rows': 0, 'null_rows': 500, 'missing_entry_rows': 1,
+                                   'unsupported_id_rows': 0} for group in check.AGENTX_GROUPS},
+            'derived_metrics': {'available_rows': 500, 'missing_entry_rows': 1, 'unsupported_id_rows': 0},
+            'trace_availability': {'stored_trace_rows': 1, 'no_stored_trace_rows': 500,
+                                   'response_key_rows': 500, 'missing_key_rows': 1,
+                                   'unsupported_id_rows': 0}}
+        metadata = {
+            'package_version': VERSION, 'retrieved_at': '2026-09-05T00:00:10Z',
+            'request_urls': [{'operation': record['operation'], 'url': record['url']} for record in records],
+            'requested_scope': requested, 'filters': filters, 'outcome': 'selected_rows', **counts,
+            'available_filter_values': {'raw_model': ['model-a'], 'hardware': ['h200'],
+                                        'framework': ['vllm'], 'precision': ['fp8'],
+                                        'spec_method': ['none'], 'offload_mode': ['off'], 'concurrency': [1]},
+            'returned_model_keys': ['model-a'], 'selected_model_keys': ['model-a'],
+            'enrichment_coverage': coverage, 'non_finite_values': 0,
+            'observation_context': 'Existing observations were read; no new benchmark was run.'}
+        output = self.root / f'agentx-multichunk-{self.fixture_index}.json'
+        check.save(output, {'schema_version': 1, 'metadata': metadata, 'rows': enriched})
+        manifest = {
+            'schema_version': 1, 'package_version': VERSION, 'status': 'complete',
+            'started_at': '2026-09-05T00:00:00Z', 'finished_at': '2026-09-05T00:00:11Z',
+            'outcome': 'selected_rows', 'requested_filters': requested, 'applied_filters': applied,
+            'counts': counts, 'responses': records,
+            'export': {'format': 'json', 'destination': str(output.resolve()),
+                       'sha256': hashlib.sha256(output.read_bytes()).hexdigest(), 'metadata': metadata,
+                       'source_request_numbers': list(range(1, len(records) + 1))},
+            'error': None}
+        check.save(evidence / 'manifest.json', manifest)
+        return evidence, output, manifest
+
     @staticmethod
     def point_openapi():
         return {'paths': {path: {'get': {'parameters': [
@@ -482,11 +568,11 @@ class AgentXVerifierTests(unittest.TestCase):
             (evidence / filename).write_bytes(body_bytes)
             records.append({'operation': operation, 'request_number': number,
                             'url': check.point_url(path, parameter, selected_id), 'method': 'GET',
-                            'retrieved_at': f'2026-09-05T00:00:0{number}Z', 'http_status': 200,
+                            'retrieved_at': f'2026-09-05T00:00:{number * 2 - 1:02d}Z', 'http_status': 200,
                             'decoded_body_sha256': hashlib.sha256(body_bytes).hexdigest(), 'body_file': filename,
                             'checksum_covers': 'saved decoded response body'})
         output = self.root / f'{name}.json'
-        requests = [{'query_url': record['url'], 'retrieved_at': f'2026-09-05T00:00:1{index}Z'}
+        requests = [{'query_url': record['url'], 'retrieved_at': f'2026-09-05T00:00:{index * 2:02d}Z'}
                     for index, record in enumerate(records, 1)]
         document = {
             'schema_version': 1,
@@ -544,6 +630,17 @@ class AgentXVerifierTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'AgentX CSV value'):
             check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
 
+        evidence, output, manifest = self.write_summary('csv')
+        with output.open(newline='') as handle:
+            rows = list(csv.reader(handle))
+        rows[1].append('surplus')
+        with output.open('w', newline='') as handle:
+            csv.writer(handle, lineterminator='\r\n').writerows(rows)
+        manifest['export']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'row width'):
+            check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
         for mutation, message in [('chunk', 'identity'), ('id', 'result ID'), ('manifest', 'manifest')]:
             with self.subTest(mutation=mutation):
                 evidence, output, manifest = self.write_summary('json')
@@ -564,6 +661,31 @@ class AgentXVerifierTests(unittest.TestCase):
         evidence, output, manifest = self.write_summary('json')
         (evidence / manifest['responses'][2]['body_file']).unlink()
         with self.assertRaises(FileNotFoundError):
+            check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+
+    def test_summary_oracle_joins_real_multichunk_responses_and_missing_states(self):
+        evidence, output, manifest = self.write_multichunk_summary()
+        operations = [record['operation'] for record in manifest['responses']]
+        self.assertEqual(operations.count('agentic-aggregates'), 3)
+        self.assertEqual(operations.count('derived-agentic-metrics'), 3)
+        self.assertEqual(operations.count('trace-availability'), 2)
+        result = check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
+        self.assertEqual(result['selected_rows'], 501)
+        rows = json.loads(output.read_text())['rows']
+        self.assertEqual(rows[1]['agentx']['aggregates']['status'], 'not_returned')
+        self.assertEqual(rows[2]['agentx']['derived_metrics']['status'], 'not_returned')
+        self.assertFalse(rows[3]['agentx']['trace_availability']['response_key_present'])
+
+        evidence, output, manifest = self.write_multichunk_summary()
+        first, second = manifest['responses'][1:3]
+        first_path, second_path = evidence / first['body_file'], evidence / second['body_file']
+        first_body, second_body = first_path.read_bytes(), second_path.read_bytes()
+        first_path.write_bytes(second_body)
+        second_path.write_bytes(first_body)
+        first['decoded_body_sha256'] = hashlib.sha256(second_body).hexdigest()
+        second['decoded_body_sha256'] = hashlib.sha256(first_body).hexdigest()
+        check.save(evidence / 'manifest.json', manifest)
+        with self.assertRaisesRegex(ValueError, 'Unexpected agentic-aggregates result ID'):
             check.check_agentx_capture(self.root, evidence.name, output.name, self.args, VERSION)
 
     def test_point_oracle_accepts_bounded_trace_and_no_trace_and_rejects_invalid_diagnostics(self):
@@ -603,6 +725,48 @@ class AgentXVerifierTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'differs from complete responses'):
             check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
 
+    def test_point_oracle_requires_one_chronological_capture_request_output_chain(self):
+        for mutation in ['capture-order', 'request-before-capture', 'output-before-request',
+                         'finish-before-output']:
+            with self.subTest(mutation=mutation):
+                evidence, output, manifest, document = self.write_point(trace=False)
+                if mutation == 'capture-order':
+                    manifest['responses'][0]['retrieved_at'] = '2026-09-05T00:00:04Z'
+                elif mutation == 'request-before-capture':
+                    document['metadata']['requests'][0]['retrieved_at'] = '2026-09-05T00:00:00Z'
+                elif mutation == 'output-before-request':
+                    document['metadata']['retrieved_at'] = '2026-09-05T00:00:05Z'
+                else:
+                    manifest['finished_at'] = '2026-09-05T00:00:19Z'
+                check.save(output, document)
+                manifest['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+                check.save(evidence / 'manifest.json', manifest)
+                with self.assertRaisesRegex(ValueError, 'timestamps are not chronological'):
+                    check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
+
+    def test_point_capture_preload_rejects_effective_post_request(self):
+        node = check.shutil.which('node')
+        self.assertIsNotNone(node)
+        preload = self.root / 'capture.mjs'
+        script = self.root / 'post.mjs'
+        evidence = self.root / 'post-evidence'
+        preload.write_text(check.POINT_CAPTURE_PRELOAD)
+        script.write_text("""try {
+  await fetch(new Request('https://inferencex.semianalysis.com/api/openapi.json', { method: 'POST' }));
+  throw new Error('POST was accepted');
+} catch (error) {
+  if (!String(error).includes('allow only GET requests')) throw error;
+}
+""")
+        environment = dict(check.os.environ)
+        environment.update(INFERENCEX_POINT_EVIDENCE=str(evidence), INFERENCEX_POINT_ID='7',
+                           INFERENCEX_POINT_OUTPUT=str(self.root / 'point.json'),
+                           INFERENCEX_PACKAGE_VERSION=VERSION)
+        completed = subprocess.run([node, '--import', preload.as_uri(), script], env=environment,
+                                   capture_output=True, text=True, check=False)
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads((evidence / 'manifest.json').read_text())['responses'], [])
+
     def test_installed_boundary_and_public_archive_bytes_are_exact(self):
         installed = self.root / 'installed'
         installed.mkdir()
@@ -612,6 +776,23 @@ class AgentXVerifierTests(unittest.TestCase):
         (installed / 'unexpected.txt').write_text('extra')
         with self.assertRaisesRegex(ValueError, 'Unexpected installed files'):
             check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+        (installed / 'unexpected.txt').unlink()
+        outside_file = self.root / 'outside.txt'
+        outside_file.write_text('outside')
+        (installed / 'file-link').symlink_to(outside_file)
+        with self.assertRaisesRegex(ValueError, 'symlink'):
+            check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+        (installed / 'file-link').unlink()
+        outside_directory = self.root / 'outside-directory'
+        outside_directory.mkdir()
+        (installed / 'directory-link').symlink_to(outside_directory, target_is_directory=True)
+        with self.assertRaisesRegex(ValueError, 'symlink'):
+            check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+        (installed / 'directory-link').unlink()
+        check.os.mkfifo(installed / 'named-pipe')
+        with self.assertRaisesRegex(ValueError, 'regular file'):
+            check.check_installed(installed, {'SKILL.md': b'skill'}, VERSION)
+        (installed / 'named-pipe').unlink()
 
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w:gz') as packed:
@@ -662,7 +843,7 @@ class AgentXVerifierTests(unittest.TestCase):
             return project, {}
 
         with patch.object(sys, 'argv', command), patch.object(check, 'install_target', side_effect=install) as installs, \
-                patch.object(check, 'check_installed'), patch.object(check, 'run') as runs, \
+                patch.object(check, 'check_installed') as installed_checks, patch.object(check, 'run') as runs, \
                 patch.object(check, 'captured_export', return_value=[]), \
                 patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
                 patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}), \
@@ -670,12 +851,51 @@ class AgentXVerifierTests(unittest.TestCase):
                 patch('builtins.print'):
             check.main()
         self.assertEqual([call.args[1] for call in installs.call_args_list], ['codex', 'claude'])
+        self.assertEqual(installed_checks.call_count, 4)
         commands = [[str(part) for part in call.args[0]] for call in runs.call_args_list]
         for target, project in projects.items():
             target_commands = [command for command, call in zip(commands, runs.call_args_list)
                                if call.args[1] == project]
             self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in target_commands), 2, target)
             self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in target_commands), 3, target)
+
+    def test_agents_prepares_only_exact_archive_and_hashed_target_prompt(self):
+        stream = io.BytesIO()
+        with tarfile.open(fileobj=stream, mode='w:gz') as packed:
+            entry = tarfile.TarInfo('package/skills/inferencex-api/SKILL.md')
+            entry.size = 5
+            packed.addfile(entry, io.BytesIO(b'skill'))
+        archive = stream.getvalue()
+        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'candidate.tgz',
+                  'sha256': hashlib.sha256(archive).hexdigest(),
+                  'integrity': 'sha512-' + base64.b64encode(hashlib.sha512(archive).digest()).decode()}
+        (self.root / 'candidate.tgz').write_bytes(archive)
+        check.save(self.root / 'release.json', record)
+        evidence = self.root / 'agents-verification'
+        command = ['verify-release.py', 'agents', str(self.root / 'release.json'), '--model', 'Example',
+                   '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
+                   '--agentx-no-trace-id', '8', '--evidence', str(evidence)]
+        with patch.object(sys, 'argv', command), patch.object(check, 'install_target') as install, \
+                patch.object(check.shutil, 'which') as which, patch('builtins.print'):
+            check.main()
+        install.assert_not_called()
+        which.assert_not_called()
+        report = json.loads((evidence / 'verification.json').read_text())
+        clean_root = Path(report['clean_root'])
+        self.addCleanup(check.shutil.rmtree, clean_root, True)
+        acceptance = json.loads((clean_root / 'acceptance.json').read_text())
+        self.assertEqual(acceptance['status'], 'prepared')
+        for prepared in acceptance['targets']:
+            project = Path(prepared['project'])
+            self.assertEqual({path.name for path in project.iterdir()}, {'candidate.tgz', 'prompt.txt'})
+            self.assertEqual((project / 'candidate.tgz').read_bytes(), archive)
+            prompt_bytes = (project / 'prompt.txt').read_bytes()
+            self.assertEqual(prepared, {'target': prepared['target'], 'project': str(project),
+                                        'status': 'awaiting-native-agent',
+                                        'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()})
+            prompt_text = prompt_bytes.decode()
+            self.assertIn(f'install --target {prepared["target"]}', prompt_text)
+            self.assertIn(str(project / 'candidate.tgz'), prompt_text)
 
     def test_check_agent_runs_both_workload_and_point_oracles(self):
         stream = io.BytesIO()
@@ -691,11 +911,16 @@ class AgentXVerifierTests(unittest.TestCase):
         check.save(self.root / 'release.json', record)
         project = self.root / 'prepared/codex'
         project.mkdir(parents=True)
+        (project / 'candidate.tgz').write_bytes(archive)
+        prompt_bytes = check.prompt(self.args, 'codex', project / 'candidate.tgz').encode()
+        (project / 'prompt.txt').write_bytes(prompt_bytes)
         scope = {'model': 'Example', 'date': None, 'isl': 8192, 'osl': 1024, 'raw_model': None,
                  'empty_isl': 7, 'empty_osl': 13, 'agentx_model': 'Example',
                  'agentx_point_id': '7', 'agentx_no_trace_id': '8'}
         check.save(project.parent / 'acceptance.json', {'candidate': record, 'scope': scope,
-                                                       'targets': [{'target': 'codex', 'project': str(project)}]})
+                                                       'targets': [{'target': 'codex', 'project': str(project),
+                                                                    'status': 'awaiting-native-agent',
+                                                                    'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()}]})
         check.save(project / 'lookup.json', {})
         check.save(project / 'unavailable.json', {'metadata': {}, 'rows': []})
         check.save(project / 'diagnostic.json', {'diagnostic': {}})
@@ -704,6 +929,14 @@ class AgentXVerifierTests(unittest.TestCase):
                    '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
                    '--agentx-no-trace-id', '8', '--project', str(project),
                    '--evidence', str(self.root / 'check-agent')]
+        (project / 'prompt.txt').write_text('changed')
+        tampered = command[:-1] + [str(self.root / 'tampered-check-agent')]
+        with patch.object(sys, 'argv', tampered), patch.object(check, 'check_installed') as installed, \
+                patch('builtins.print'):
+            with self.assertRaisesRegex(ValueError, 'prompt differs'):
+                check.main()
+        installed.assert_not_called()
+        (project / 'prompt.txt').write_bytes(prompt_bytes)
         with patch.object(sys, 'argv', command), patch.object(check, 'check_installed'), \
                 patch.object(check, 'captured_export', return_value=[]), \
                 patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \


### PR DESCRIPTION
## Summary

- Extend the existing `inferencex-api` skill with deterministic AgentX CSV/JSON summary exports, exact local filters, bounded ID enrichment, and complete request/response evidence.
- Add a one-ID diagnostic recipe that checks OpenAPI, sibling identity, and trace availability before reading timeline, histogram, or server metrics. It never performs bulk heavy reads.
- Harden `0.4.0` installation and release verification for Codex and Claude Code with PowerX/AgentX version checks, an exact ten-file archive boundary, clean-source provenance, redirect rejection, and candidate/public behavior gates.
- Use public HTTPS and existing observations only. These workflows run no benchmark, make no model-quality or winner claim, and preserve the existing PowerX validity and unit rules.

## Validation

- Node 24 packed package suite: **93/93 passed**
- Independent Python release-verifier suite: **25/25 passed**
- Workspace unit suites: app **5,011**, constants **53**, DB **685**, and MCP **25** passed
- Production build passed; local smoke passed component **46/46** and integration **113/113**
- API documentation synchronization, lint, format, typecheck, typography, and `git diff --check` passed
- Independent Standards/Spec and ponytail/security reviews found no remaining issue; Claude advisory findings on changed Chinese copy were applied and manually rechecked

## Release boundary

This PR prepares the `0.4.0` source and release gates only. `@semianalysisai/inferencex-skills@0.4.0` remains unpublished, and website install commands remain pinned to `0.3.0` until the merged source is repacked, independently accepted, published, and anonymously verified.

Closes #1025

## 中文说明

### 变更内容

- 扩展现有 `inferencex-api` 技能，新增结果稳定的 AgentX CSV/JSON 汇总导出、精确本地筛选、按 ID 分块的有限补充请求，以及完整的请求与响应证据。
- 新增限定为一个 ID 的诊断流程：先检查 OpenAPI、sibling identity 和 trace availability，再按需读取 timeline、histogram 或 server metrics，不会批量读取大体量数据。
- 加强 `0.4.0` 在 Codex 与 Claude Code 中的安装和发布验证，包括 PowerX/AgentX 版本检查、严格限制为十个文件的 archive、干净源码 provenance、拒绝 redirect，以及 candidate 与公开版本的行为门禁。
- 整个流程只通过公开 HTTPS 读取现有观测数据，不运行新的 benchmark，不判断模型回答质量或 winner，并沿用既有 PowerX 有效性与单位规则。

### 验证

- Node 24 打包产物测试：**93/93 通过**
- 独立 Python 发布验证测试：**25/25 通过**
- 工作区单元测试：app **5,011**、constants **53**、DB **685**、MCP **25** 项通过
- Production build 通过；本地 smoke 的 component **46/46**、integration **113/113** 通过
- API 文档同步、lint、格式、typecheck、字体规范和 `git diff --check` 全部通过
- 独立 Standards/Spec 与 ponytail/security 复核无遗留问题；已采纳 Claude 对变更中文文案的 advisory finding，并完成最终人工复核

### 发布边界

本 PR 只准备 `0.4.0` 源码与发布门禁。`@semianalysisai/inferencex-skills@0.4.0` 仍未发布；网站安装命令继续固定为 `0.3.0`，待合并后的源码重新打包、完成独立验收、发布并通过匿名公开验证后再更新。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the npm publish verification path and ships a large new exporter touching live public API behavior, though workflows remain read-only with heavy automated acceptance checks.
> 
> **Overview**
> Bumps **`@semianalysisai/inferencex-skills` to `0.4.0`** and adds **AgentX** as a first-class skill workflow: new **`export-agentx.mjs`** (deterministic CSV/JSON, exact filters, chunked enrichments, `--evidence-dir`), **`references/agentx.md`** (bounded one-ID trace diagnostics), and **SKILL.md** routing for agents.
> 
> **Installation and release** tighten for this version: **`install.mjs`** cross-checks static versions on **PowerX and AgentX** exporters for receipts ≥0.4; **`release.mjs`** refuses dirty package trees, pins a **fixed ten-file** public archive, and records clean provenance; **`verify-release.py`** and **`.github/workflows/publish-skills.yml`** now gate candidate/public installs on **PowerX plus AgentX** exports, an intentional empty filter case, and **one traced / one no-trace** point ID. Native-agent acceptance starts from **archive + prompt only** (agent installs offline) and validates the expanded deliverables.
> 
> Docs and examples move pinned install commands and release runbooks from **0.3.0 → 0.4.0**; tests add coverage for the installed point-diagnostic recipe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fae53a3dc623107bd7e393d09496321fb549a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->