### PR TITLE
feat(landing): make Token Revenue Calculator the primary hero CTA / 首页主按钮改为 Token 收入计算器

### DIFF
--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -15,11 +15,11 @@ describe('Compare precision index page', () => {
         'href',
         '/inference/kimi-k3',
       );
-      cy.get('[data-testid="compare-agentx-overview-link"]')
-        .should('contain.text', 'Overview')
-        .and('have.attr', 'href', '/overview');
+      cy.get('[data-testid="compare-agentx-revenue-calculator-link"]')
+        .should('contain.text', 'Token Revenue Calculator')
+        .and('have.attr', 'href', '/profit-estimator-per-gigawatt');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
-        .should('contain.text', 'Full dashboard')
+        .should('have.text', 'Dashboard')
         .and('have.attr', 'href', '/inference/kimi-k3');
       cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
     });
@@ -58,11 +58,11 @@ describe('Compare precision index page', () => {
         'href',
         '/zh/inference/deepseek-v4',
       );
-      cy.get('[data-testid="compare-agentx-overview-link"]')
-        .should('contain.text', '总览')
-        .and('have.attr', 'href', '/zh/overview');
+      cy.get('[data-testid="compare-agentx-revenue-calculator-link"]')
+        .should('contain.text', 'Token 收入计算器')
+        .and('have.attr', 'href', '/zh/profit-estimator-per-gigawatt');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
-        .should('contain.text', '查看完整仪表板')
+        .should('have.text', '仪表板')
         .and('have.attr', 'href', '/zh/inference/kimi-k3');
       cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
     });

--- a/packages/app/cypress/e2e/landing-dashboard-navigation.cy.ts
+++ b/packages/app/cypress/e2e/landing-dashboard-navigation.cy.ts
@@ -1,5 +1,5 @@
 /**
- * Regression: the landing "Full dashboard" CTA must navigate in exactly one
+ * Regression: the landing "Dashboard" CTA must navigate in exactly one
  * transition — one router commit, one new history entry, no URL revert.
  *
  * One click used to: commit /inference/kimi-k3, get reverted to `/` by a

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -148,11 +148,11 @@ describe('First-load navigation', () => {
       // The hero owns /compare's h1; on the landing page it is a section heading.
       cy.get('h2').should('have.text', 'Compare Realistic Agentic Inference Perf');
       cy.get('h1').should('not.exist');
-      cy.get('[data-testid="compare-agentx-overview-link"]')
-        .should('contain.text', 'Overview')
-        .and('have.attr', 'href', '/overview');
+      cy.get('[data-testid="compare-agentx-revenue-calculator-link"]')
+        .should('contain.text', 'Token Revenue Calculator')
+        .and('have.attr', 'href', '/profit-estimator-per-gigawatt');
       cy.get('[data-testid="compare-agentx-dashboard-link"]')
-        .should('contain.text', 'Full dashboard')
+        .should('have.text', 'Dashboard')
         .and('have.attr', 'href', '/inference/kimi-k3');
       cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
       cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
@@ -175,8 +175,8 @@ describe('First-load navigation', () => {
         .should('have.length', 6)
         .each(($badge) => expect($badge.text()).to.equal('NEW'));
     });
-    cy.get('[data-testid="compare-agentx-overview-link"]').click();
-    cy.location('pathname').should('eq', '/overview');
+    cy.get('[data-testid="compare-agentx-revenue-calculator-link"]').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
   });
 
   it('navigates to submissions from the landing CTA', () => {

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -34,9 +34,12 @@ describe('Chinese (/zh) pages', () => {
     it('renders the AgentX hero on the Chinese landing page', () => {
       cy.get('[data-testid="compare-agentx-primary"]').within(() => {
         cy.get('h2').should('have.text', '真实智能体工作负载下的推理性能对比');
-        cy.get('[data-testid="compare-agentx-overview-link"]')
-          .should('contain.text', '总览')
-          .and('have.attr', 'href', '/zh/overview');
+        cy.get('[data-testid="compare-agentx-revenue-calculator-link"]')
+          .should('contain.text', 'Token 收入计算器')
+          .and('have.attr', 'href', '/zh/profit-estimator-per-gigawatt');
+        cy.get('[data-testid="compare-agentx-dashboard-link"]')
+          .should('have.text', '仪表板')
+          .and('have.attr', 'href', '/zh/inference/kimi-k3');
         cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
         // Ledger NEW pills localize to 新 on the Chinese landing page.
         cy.get('[data-testid^="compare-agentx-model-"] [data-new-badge="agentx-ledger"]')

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -345,8 +345,8 @@ const STRINGS = {
     title: 'Compare Realistic Agentic Inference Perf',
     description:
       'Long Context Multi Turn Inference Performance. Compare Across OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv7/v8 & Rubin NVL72 & MI455X UALoE72',
-    overview: 'Overview',
-    dashboard: 'Full dashboard',
+    revenueCalculator: 'Token Revenue Calculator',
+    dashboard: 'Dashboard',
     ledgerTitle: 'Models with AgentX results',
     modelAction: 'View results',
     newModel: 'NEW',
@@ -356,8 +356,8 @@ const STRINGS = {
     title: '真实智能体工作负载下的推理性能对比',
     description:
       '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 OpenAI Jalapeño、MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro，即将支持 TPUv7/v8、Rubin NVL72 与 MI455X UALoE72。',
-    overview: '总览',
-    dashboard: '查看完整仪表板',
+    revenueCalculator: 'Token 收入计算器',
+    dashboard: '仪表板',
     ledgerTitle: '已发布 AgentX 结果的模型',
     modelAction: '查看结果',
     newModel: '新',
@@ -444,14 +444,14 @@ export function AgentXCompareHero({
             </div>
             <div className="mt-5 flex flex-wrap gap-3">
               <CompareIndexTrackedLink
-                data-testid="compare-agentx-overview-link"
-                href={`${prefix}/overview`}
-                analyticsEvent="compare_agentx_overview_clicked"
+                data-testid="compare-agentx-revenue-calculator-link"
+                href={`${prefix}/profit-estimator-per-gigawatt`}
+                analyticsEvent="compare_agentx_revenue_calculator_clicked"
                 analyticsSurface={surface}
                 appNavigation
                 className="group motion-press inline-flex min-h-11 items-center gap-2 rounded-md bg-brand px-5 py-2.5 font-semibold text-primary-foreground shadow-sm transition-colors hover:bg-brand/90"
               >
-                {t.overview}
+                {t.revenueCalculator}
                 <ArrowRight
                   aria-hidden="true"
                   className="size-4 motion-safe:transition-transform motion-safe:duration-200 motion-safe:group-hover:translate-x-0.5"

--- a/packages/app/src/components/compare/compare-index-tracked-link.tsx
+++ b/packages/app/src/components/compare/compare-index-tracked-link.tsx
@@ -8,7 +8,7 @@ import { navigateInApp } from '@/lib/client-navigation';
 
 interface CompareIndexTrackedLinkProps extends React.ComponentProps<typeof Link> {
   analyticsEvent:
-    | 'compare_agentx_overview_clicked'
+    | 'compare_agentx_revenue_calculator_clicked'
     | 'compare_agentx_dashboard_clicked'
     | 'compare_agentx_model_clicked';
   analyticsTarget?: string;


### PR DESCRIPTION
## Summary

- Primary hero CTA on `/` and `/compare` is now **Token Revenue Calculator** → `/profit-estimator-per-gigawatt` (was "Overview" → `/overview`).
- Secondary CTA is relabelled **Dashboard** (was "Full dashboard"); it still goes to `/inference/kimi-k3`.
- `/zh` hero mirrors both labels: `Token 收入计算器` / `仪表板`, pointing at the `/zh/…` siblings.
- Analytics event renamed `compare_agentx_overview_clicked` → `compare_agentx_revenue_calculator_clicked`; test id renamed to `compare-agentx-revenue-calculator-link`.
- Cypress specs (`navigation`, `compare-precision`, `zh-pages`, `landing-dashboard-navigation`) updated for the new labels and hrefs.

Overlay support: n/a — landing/compare hero links only, no chart data path.

## Test plan

- [x] `bun run typecheck`, `bun run lint`, `bun run fmt`
- [x] `vitest run src/lib/zh-objective-guard.test.ts src/lib/zh-copy.test.ts src/lib/client-navigation.test.ts`
- [ ] CI e2e (`navigation`, `compare-precision`, `zh-pages`, `landing-dashboard-navigation` cover the CTAs)

## 中文说明

- 首页与 `/compare` 的 AgentX 主视觉区主按钮改为 **Token 收入计算器**，链接到 `/profit-estimator-per-gigawatt`（原为“总览”→ `/overview`）。
- 次按钮由“查看完整仪表板”改为 **仪表板**，仍指向 `/inference/kimi-k3`。
- `/zh` 页面同步更新两处文案并指向对应的 `/zh/…` 路由。
- 埋点事件更名为 `compare_agentx_revenue_calculator_clicked`，测试 id 同步调整。
- 更新相关 Cypress 测试以匹配新文案与链接。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/navigation and analytics renames on the compare hero only; no auth, data, or core inference logic changes.
> 
> **Overview**
> The AgentX hero on **`/`**, **`/compare`**, and **`/zh`** variants swaps the **primary** CTA from Overview (`/overview`) to **Token Revenue Calculator** (`/profit-estimator-per-gigawatt`, with `/zh/…` siblings). The secondary button is shortened to **Dashboard** (was “Full dashboard” / Chinese equivalent) and still routes to the featured inference dashboard (`/inference/kimi-k3`).
> 
> `agentx-compare-hero.tsx` updates EN/ZH copy, link targets, `data-testid`, and analytics (`compare_agentx_revenue_calculator_clicked`). `compare-index-tracked-link.tsx` narrows the analytics event union accordingly. Cypress specs (`navigation`, `compare-precision`, `zh-pages`, plus a comment in `landing-dashboard-navigation`) assert the new labels, hrefs, and primary-click navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf7b50cb3357e2d5eab44bc84a39aa8b207b783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->