### PR TITLE
fix(skills): make native acceptance reproducible / 使原生技能验收可复现

### DIFF
--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -105,6 +105,11 @@ Start a fresh Codex or Claude Code session inside the corresponding project and
 submit `prompt.txt` without adding repository context. Use the installed agent
 runtime's current supported CLI invocation or UI; record its version, exact command
 (or UI invocation), model, prompt, exit status, transcript, and final `result.md`.
+When using the Codex CLI with `workspace-write`, pass the canonical prepared project
+to `-C`, add `--skip-git-repo-check` for this non-Git project, and allow only its
+project-level skill directory with `--add-dir <canonical-prepared-project>/.agents`.
+Codex otherwise protects `.agents` from workspace writes; do not broaden the sandbox
+or install the skill under a different directory.
 Disable inherited MCP/private-data connectors and custom global instructions or
 record any unavoidable contamination. Give the agent only project files and public
 HTTP access; no repository checkout, database credentials, or previous answers.

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1048,11 +1048,20 @@ def check_point_outcomes(outcomes):
 
 
 def prompt(args, target, archive):
+    archive = archive.resolve()
+    project = archive.parent
+    installed = project / ('.agents' if target == 'codex' else '.claude') / 'skills/inferencex-api'
     cutoff = f'as of {args.date}' if args.date else 'using the latest available observations'
     raw = f' Keep only the exact returned model key {args.raw_model}; record this filter as scope.raw_model in lookup.json.' if args.raw_model else ''
     return f'''Use only the exact candidate archive and public HTTP data in this clean project.
 
-The exact candidate archive is available at {archive}. Before any API work, independently install that local archive offline for target {target} with npm exec --yes --offline --package <archive> -- inferencex-skills install --target {target}. Then inspect the installed version with JSON output and save status.json. Preview a forced reinstall with JSON output and save preview.json. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files. Use {archive} for <archive> in every npm command.
+The prepared project root is {project}. The exact candidate archive is available at {archive}. Run all three install, status, and preview commands from that exact directory. Do not change directories or pass --dir or --cwd; do not select any other installation root. Run these commands in order:
+
+1. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target}
+2. npm exec --yes --offline --package {archive} -- inferencex-skills status --target {target} --json > status.json
+3. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target} --force --dry-run --json > preview.json
+
+The installed skill must be exactly {installed}. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files.
 
 For {args.model} {cutoff}, show five latest single-turn benchmark observations with {args.isl} input and {args.osl} output tokens, regardless of power validation. Save lookup.json using the installed lookup example's output shape.{raw} Do not introduce additional filters.
 
@@ -1062,7 +1071,13 @@ Attempt the same validated export for exactly {args.empty_isl} input and {args.e
 
 For {args.agentx_model} using the latest public observations, export AgentX summaries to agentx.csv and agentx.json with separate fresh evidence directories agentx-csv-evidence and agentx-json-evidence. Use only the display-model filter. Preserve every selected benchmark object, summary enrichment, missing state, zero, false value, request URL, and retrieval time. Also request the exact raw-model key {AGENTX_EXCLUDED_RAW_MODEL} as agentx-excluded.json with evidence in agentx-excluded-evidence, and explain the resulting empty or excluded selection without changing its scope.
 
-Use the maintained installed one-point AgentX recipe for exactly result ID {args.agentx_point_id} and save its JSON as agentx-point.json. Run it separately for exactly result ID {args.agentx_no_trace_id} and save that JSON as agentx-second-point.json. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. The complete manifest must record schema_version 1, the package version, selected_result_id, pending/complete status and times, every ordered GET URL/status/retrieval time/decoded-body SHA-256/body filename, and the JSON output destination/hash/source request numbers. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
+Use the maintained installed one-point AgentX recipe for exactly result ID {args.agentx_point_id} and save its JSON as agentx-point.json. Run it separately for exactly result ID {args.agentx_no_trace_id} and save that JSON as agentx-second-point.json. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
+
+Each point evidence directory must contain manifest.json with exactly these top-level fields: `schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, `finished_at`, `responses`, `output`, and `error`. Start capture with schema_version 1, the exact package version and selected ID, `status: "pending"`, `finished_at: null`, and `error: null`. The final manifest is accepted only with `status: "complete"` and `error: null`; set finished_at only after the output is complete. Do not add or rename fields, and never relabel a failed or incomplete run as complete.
+
+Every ordered responses item must contain exactly `operation`, `request_number`, `url`, `method`, `retrieved_at`, `http_status`, `decoded_body_sha256`, `body_file`, and `checksum_covers`. Use one-based request numbers, method GET, integer http_status 200, and checksum_covers `saved decoded response body`. The body filename must be `response-NNNN-<operation>.json`: the first three are `response-0001-openapi.json`, `response-0002-benchmark-siblings.json`, and `response-0003-trace-availability.json`; when trace data is available, continue with `response-0004-request-timeline.json`, `response-0005-trace-histograms.json`, and `response-0006-trace-server-metrics.json`. A no-trace run must stop after response 3.
+
+The output record must contain exactly `format`, `destination`, `sha256`, and `source_request_numbers`. Use format json; set destination to the corresponding absolute resolved path {project / 'agentx-point.json'} or {project / 'agentx-second-point.json'}; hash the final output bytes; and set source_request_numbers to every one-based response number in order. While capture is pending, use sha256 null and an empty source_request_numbers list.
 
 There is no repository or database access in this project. Do not read another checkout, call private services, install other dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times locally. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
 
@@ -1230,13 +1245,13 @@ def main():
         if args.mode != 'agents':
             node, npm = shutil.which('node'), shutil.which('npm')
             require(node and npm, 'Node 24 and npm must be on PATH')
-        clean_root = Path(tempfile.mkdtemp(prefix='inferencex-skill-acceptance-'))
+        clean_root = Path(tempfile.mkdtemp(prefix='inferencex-skill-acceptance-')).resolve()
         report['clean_root'] = str(clean_root)
         for target in ['codex', 'claude']:
             if args.mode == 'agents':
-                project = clean_root / target
+                project = (clean_root / target).resolve()
                 project.mkdir()
-                local_archive = project / record['filename']
+                local_archive = (project / record['filename']).resolve()
                 local_archive.write_bytes(body)
                 prompt_bytes = prompt(args, target, local_archive).encode()
                 (project / 'prompt.txt').write_bytes(prompt_bytes)

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -943,9 +943,9 @@ class AgentXVerifierTests(unittest.TestCase):
                 f'The installed skill must be exactly {installed}.',
                 'status --target codex --json',
                 'install --target codex --force --dry-run --json',
-                '`schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, '
+                '`schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, ',
                 '`finished_at`, `responses`, `output`, and `error`',
-                '`operation`, `request_number`, `url`, `method`, `retrieved_at`, `http_status`, '
+                '`operation`, `request_number`, `url`, `method`, `retrieved_at`, `http_status`, ',
                 '`decoded_body_sha256`, `body_file`, and `checksum_covers`',
                 '`response-0001-openapi.json`',
                 '`response-NNNN-<operation>.json`',

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -882,7 +882,7 @@ class AgentXVerifierTests(unittest.TestCase):
             self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in target_commands), 2, target)
             self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in target_commands), 3, target)
 
-    def test_agents_prepares_only_exact_archive_and_hashed_target_prompt(self):
+    def test_agents_prepares_canonical_projects_with_only_archive_and_hashed_prompt(self):
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w:gz') as packed:
             entry = tarfile.TarInfo('package/skills/inferencex-api/SKILL.md')
@@ -895,21 +895,29 @@ class AgentXVerifierTests(unittest.TestCase):
         (self.root / 'candidate.tgz').write_bytes(archive)
         check.save(self.root / 'release.json', record)
         evidence = self.root / 'agents-verification'
+        canonical_root = self.root / 'canonical-acceptance'
+        canonical_root.mkdir()
+        alias_root = self.root / 'aliased-acceptance'
+        alias_root.symlink_to(canonical_root, target_is_directory=True)
         command = ['verify-release.py', 'agents', str(self.root / 'release.json'), '--model', 'Example',
                    '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
                    '--agentx-no-trace-id', '8', '--evidence', str(evidence)]
-        with patch.object(sys, 'argv', command), patch.object(check, 'install_target') as install, \
+        with patch.object(sys, 'argv', command), \
+                patch.object(check.tempfile, 'mkdtemp', return_value=str(alias_root)), \
+                patch.object(check, 'install_target') as install, \
                 patch.object(check.shutil, 'which') as which, patch('builtins.print'):
             check.main()
         install.assert_not_called()
         which.assert_not_called()
         report = json.loads((evidence / 'verification.json').read_text())
         clean_root = Path(report['clean_root'])
+        self.assertEqual(clean_root, canonical_root.resolve())
         self.addCleanup(check.shutil.rmtree, clean_root, True)
         acceptance = json.loads((clean_root / 'acceptance.json').read_text())
         self.assertEqual(acceptance['status'], 'prepared')
         for prepared in acceptance['targets']:
             project = Path(prepared['project'])
+            self.assertEqual(project, project.resolve())
             self.assertEqual({path.name for path in project.iterdir()}, {'candidate.tgz', 'prompt.txt'})
             self.assertEqual((project / 'candidate.tgz').read_bytes(), archive)
             prompt_bytes = (project / 'prompt.txt').read_bytes()
@@ -918,7 +926,34 @@ class AgentXVerifierTests(unittest.TestCase):
                                         'prompt_sha256': hashlib.sha256(prompt_bytes).hexdigest()})
             prompt_text = prompt_bytes.decode()
             self.assertIn(f'install --target {prepared["target"]}', prompt_text)
-            self.assertIn(str(project / 'candidate.tgz'), prompt_text)
+            self.assertIn(str((project / 'candidate.tgz').resolve()), prompt_text)
+            skill_root = '.agents' if prepared['target'] == 'codex' else '.claude'
+            self.assertIn(f'The installed skill must be exactly {project / skill_root}/skills/inferencex-api.',
+                          prompt_text)
+
+    def test_agent_prompt_pins_project_commands_and_exact_point_manifest_contract(self):
+        project = (self.root / 'prepared/codex').resolve()
+        archive = project / 'candidate.tgz'
+        prompt_text = check.prompt(self.args, 'codex', archive)
+        installed = project / '.agents/skills/inferencex-api'
+        for required in [
+                f'The prepared project root is {project}.',
+                'Run all three install, status, and preview commands from that exact directory',
+                'Do not change directories or pass --dir or --cwd',
+                f'The installed skill must be exactly {installed}.',
+                'status --target codex --json',
+                'install --target codex --force --dry-run --json',
+                '`schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, '
+                '`finished_at`, `responses`, `output`, and `error`',
+                '`operation`, `request_number`, `url`, `method`, `retrieved_at`, `http_status`, '
+                '`decoded_body_sha256`, `body_file`, and `checksum_covers`',
+                '`response-0001-openapi.json`',
+                '`response-NNNN-<operation>.json`',
+                '`format`, `destination`, `sha256`, and `source_request_numbers`',
+                'The final manifest is accepted only with `status: "complete"` and `error: null`',
+        ]:
+            with self.subTest(required=required):
+                self.assertIn(required, prompt_text)
 
     def test_agents_rejects_archive_filename_collision_before_creating_projects(self):
         record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'prompt.txt',


### PR DESCRIPTION
## Summary

- Canonicalize native-agent preparation paths so the generated project, archive, prompt, and acceptance record share one stable identity.
- Pin install, status, preview, and AgentX point evidence to the exact paths and schema enforced by `check-agent`.
- Document the narrow Codex `workspace-write` invocation required for a non-Git prepared project: `--skip-git-repo-check` plus `--add-dir <canonical-project>/.agents`.

## Why

The required pre-publication native acceptance exposed two harness gaps after #1028 merged. Codex correctly protected the project-level `.agents` directory without an explicit narrow write grant, and Codex and Claude created semantically complete point evidence using different field names because the prompt did not state the checker's exact schema. Both attempts were rejected and `0.4.0` remains unpublished.

This follow-up changes only the maintainer release verifier, its tests, and release documentation. The public npm package contents are unchanged. A fresh candidate and fresh one-shot Codex and Claude acceptance will run from the merged default branch.

## Validation

- `python3 packages/skills/test/verify-release.test.py` — 26 passed
- `node --test packages/skills/test/*.test.mjs` with Node 24.20.0 — 93 passed
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run check:typography`
- Independent Standards/Spec review — clean
- Independent Ponytail/security review — clean

Follow-up to #1025 and #1028.

## 中文说明

### 变更内容

- 对 native-agent 验收准备路径进行 canonical 化，确保生成的 project、archive、prompt 与验收记录使用同一稳定路径。
- 将安装、状态检查、预览以及 AgentX 单点证据固定到 `check-agent` 实际校验的准确路径与 schema。
- 记录 Codex 在非 Git 准备项目中使用 `workspace-write` 时所需的最小启动参数：`--skip-git-repo-check` 与 `--add-dir <canonical-project>/.agents`。

### 原因

#1028 合并后的发布前原生验收发现两处 harness 缺口：未明确授予目录写权限时，Codex 会保护项目级 `.agents` 目录；同时，旧 prompt 没有列出 checker 要求的准确字段名，导致 Codex 与 Claude 虽然保存了语义完整的单点证据，却采用了不同 schema。两次验收均已被拒绝，`0.4.0` 仍未发布。

本 PR 仅修改维护者使用的 release verifier、对应测试和发布文档，不改变公开 npm package 内容。合并后将从 default branch 重新生成 candidate，并重新执行一次性的 Codex 与 Claude 原生验收。

### 验证

- `python3 packages/skills/test/verify-release.test.py` — 26 项通过
- 使用 Node 24.20.0 运行 `node --test packages/skills/test/*.test.mjs` — 93 项通过
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run check:typography`
- 独立 Standards/Spec review — clean
- 独立 Ponytail/security review — clean

这是 #1025 与 #1028 的后续修复。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to maintainer release verification, documentation, and tests; the published npm package behavior is unchanged.
> 
> **Overview**
> **Native-agent release acceptance** is tightened so prepared projects, prompts, and `acceptance.json` all use **resolved canonical paths** (including when `mkdtemp` returns a symlink alias), and the generated `prompt.txt` embeds those absolute paths for the archive, project root, and expected skill install location (`.agents` vs `.claude`).
> 
> The **agent prompt** now spells out a fixed **install → status → preview** command sequence run only from the prepared root (no `--dir`/`--cwd`), and documents the **exact AgentX one-point `manifest.json` schema**—top-level fields, per-response keys, `response-NNNN-<operation>.json` naming, trace vs no-trace response counts, and `output` record rules—that `check-agent` enforces.
> 
> **Release docs** add the minimal **Codex `workspace-write`** invocation for non-Git prepared projects: `-C` on the canonical project, `--skip-git-repo-check`, and a narrow `--add-dir` grant for `<project>/.agents` only.
> 
> Tests cover canonical `clean_root` resolution and assert the new prompt strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d9a910663d67afcf57016b72ea2aa04c46e8cde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->