### PR TITLE
docs(skills): require verified PowerX summaries / 要求经过核验的 PowerX 汇总

### DIFF
--- a/packages/skills/skills/inferencex-api/references/powerx.md
+++ b/packages/skills/skills/inferencex-api/references/powerx.md
@@ -102,6 +102,12 @@ unavailable values. Keep eligible rows, state which requested measurements are
 unavailable, and avoid zero filling or energy-advantage
 claims. Partial metric coverage alone needs no additional diagnostic request.
 
+For any reported measurement count, range, mean, or trend, compute it from the
+complete selected export, using every selected row where that metric is finite,
+and verify its contributing and missing counts against `metric_coverage`. Omit
+unrequested summaries, and never estimate one from samples, correlations, or any
+subset of the selected rows.
+
 An empty selection succeeds with a header-only CSV or JSON `rows: []` and reports
 **No strictV2 rows matched the requested scope.** This establishes no eligible
 observations for that selection, not an absence of all underlying benchmarks.
@@ -295,9 +301,10 @@ as well as in the exported field name.
 The whole-deployment meanings above require schema version 2, including for
 disaggregated deployments. Role-prefixed energy remains role-local. Preserve the
 producer's values; dividing whole-deployment joules by GPU count changes the metric.
-Measured GPU energy does not include a measurement of facility power, cooling, or
-other non-GPU energy. Keep provisioned-power estimates and their assumptions
-separate from these measured fields.
+Every PowerX summary must state that measured per-GPU watts and whole-deployment
+GPU energy cover accelerator telemetry only; they exclude facility power, cooling,
+other non-GPU energy, and provisioned-power estimates. Keep any provisioned-power
+estimate and its assumptions separate.
 
 Preserve zero as a number and missing data as blank CSV cells or JSON null/absence.
 The exporter replaces non-finite numeric values with null, leaves their CSV cells

--- a/packages/skills/test/export-powerx.test.mjs
+++ b/packages/skills/test/export-powerx.test.mjs
@@ -20,6 +20,7 @@ const preload = join(temporaryRoot, 'http-response.mjs');
 const requiredArgs = ['--model', 'GLM-5', '--isl', '8192', '--osl', '1024'];
 const version = packageInfo.version;
 let exporter;
+let powerCookbook;
 
 function observation(overrides = {}) {
   return {
@@ -120,8 +121,27 @@ globalThis.fetch = async (input, options) => {
 };
 `,
   );
-  exporter = join(suite.install('codex'), 'scripts/export-powerx.mjs');
+  const installed = suite.install('codex');
+  exporter = join(installed, 'scripts/export-powerx.mjs');
+  powerCookbook = readFileSync(join(installed, 'references/powerx.md'), 'utf8');
   assert.ok(existsSync(exporter), 'the actual npm artifact installs the exporter');
+});
+
+test('installed guidance verifies summaries and separates measured from provisioned power', () => {
+  const guidance = powerCookbook.replaceAll(/\s+/gu, ' ');
+  for (const required of [
+    'compute it from the complete selected export',
+    'using every selected row where that metric is finite',
+    'verify its contributing and missing counts against `metric_coverage`',
+    'Omit unrequested summaries',
+    'never estimate one from samples, correlations, or any subset',
+    'Every PowerX summary must state that measured per-GPU watts and whole-deployment GPU energy',
+    'cover accelerator telemetry only; they exclude facility power, cooling,',
+    'other non-GPU energy, and provisioned-power estimates',
+    'Keep any provisioned-power estimate and its assumptions separate',
+  ]) {
+    assert.ok(guidance.includes(required), `missing installed guidance: ${required}`);
+  }
 });
 
 test('installed JSON exporter preserves request, model, measurement and snapshot identities', () => {


### PR DESCRIPTION
Two independent native-agent acceptance runs produced machine-valid PowerX artifacts but narrated ranges from incomplete subsets and omitted the accelerator-only measurement boundary. This change makes the installed PowerX guidance require every reported aggregate to use the complete selected export, reconcile contributing and missing counts with `metric_coverage`, and state that measured watts and joules exclude facility power, cooling, other non-GPU energy, and provisioned-power estimates.

The archive contents change because the installed reference changes. After merge, the 0.4.0 candidate will be rebuilt from the new default-branch commit and both Codex and Claude Code acceptance runs will be repeated in clean projects before publication.

Validation:

- `node --test packages/skills/test/*.test.mjs` — 94 passed
- `python3 packages/skills/test/verify-release.test.py` — 26 passed
- `bun run lint` — passed
- `bun run fmt` — passed
- `git diff --check` — passed
- Independent correctness and Ponytail reviews found no need to change the exporter, release verifier, manifest, or package boundary

## 中文说明

两次相互独立的原生 agent 验收都生成了通过机器校验的 PowerX 产物，但在说明中根据不完整子集给出了范围，并遗漏了“测量仅覆盖加速器”的边界。本次修改要求已安装的 PowerX 指南在报告任何汇总统计时使用完整选定结果，通过 `metric_coverage` 核对参与统计和缺失值数量，并明确说明测得的 watts 与 joules 不包含机房供电、制冷、其他非 GPU 能耗和配置功率估算。

由于已安装 reference 发生变化，archive 内容也会改变。合并后将从新的默认分支 commit 重新构建 0.4.0 候选包，并在全新项目中重新完成 Codex 与 Claude Code 验收，全部通过后才会发布。

验证结果：

- `node --test packages/skills/test/*.test.mjs` — 94 项通过
- `python3 packages/skills/test/verify-release.test.py` — 26 项通过
- `bun run lint` — 通过
- `bun run fmt` — 通过
- `git diff --check` — 通过
- 独立 correctness 与 Ponytail review 确认无需修改 exporter、release verifier、manifest 或 package boundary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no exporter, API, or runtime behavior changes.
> 
> **Overview**
> **Tightens installed PowerX agent guidance** so narrated stats cannot come from partial exports or hand-wavy estimates.
> 
> The PowerX reference now requires any reported count, range, mean, or trend to be computed from the **full** selected export (every row with a finite value for that metric), with contributing and missing counts checked against `metric_coverage`, and forbids unrequested summaries or estimates from samples, correlations, or row subsets.
> 
> It also upgrades the measurement boundary from optional prose to a **mandatory disclosure**: every PowerX summary must state that per-GPU watts and whole-deployment GPU energy are accelerator telemetry only—excluding facility power, cooling, other non-GPU energy, and provisioned-power estimates, which must stay separate with their assumptions.
> 
> A new export-powerx test loads `references/powerx.md` from the installed Codex skill artifact and asserts those phrases are present, so the shipped archive cannot drift from the contract without failing CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a760c11ec11cff30202fd2d6d3f268185a92d991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->