### PR TITLE
fix(skills): validate native acceptance evidence / 校验原生验收证据

### DIFF
--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -29,6 +29,7 @@ PACKAGE = '@semianalysisai/inferencex-skills'
 REGISTRY = 'https://registry.npmjs.org'
 API = 'https://inferencex.semianalysis.com/api/v1/benchmarks'
 AGENTX_ORIGIN = 'https://inferencex.semianalysis.com'
+OPENAPI = f'{AGENTX_ORIGIN}/api/openapi.json'
 AGENTX_EXCLUDED_RAW_MODEL = '__inferencex_release_verification_no_match__'
 MAX_SAFE_INTEGER = 9_007_199_254_740_991
 # Only the exact-version npm ETARGET propagation symptom is retryable. No HTTP,
@@ -354,16 +355,30 @@ def captured_export(project, name, output, args, version, isl=None, osl=None):
     return rows
 
 
-def captured_request(project, name, expected_url, metadata):
+def captured_request(project, name, expected_url, metadata=None):
     context = json.loads((project / 'raw-responses' / f'{name}.request.json').read_text())
     body = (project / 'raw-responses' / f'{name}.response.json').read_bytes()
-    require(context['status'] == 200 and same_url(context['query_url'], expected_url) and
+    require(type(context) is dict and set(context) == {'query_url', 'status', 'retrieved_at', 'sha256'} and
+            context['status'] == 200 and same_url(context['query_url'], expected_url) and
             context['sha256'] == hashlib.sha256(body).hexdigest(), 'Original request evidence differs')
-    require(datetime.fromisoformat(context['retrieved_at'].replace('Z', '+00:00')).tzinfo,
-            'Missing original response retrieval timezone')
-    require(same_url(metadata['query_url'], context['query_url']) and
-            metadata['retrieved_at'] == context['retrieved_at'], 'Output and original request context differ')
+    timestamp(context['retrieved_at'], 'Missing original response retrieval timezone')
+    if metadata is not None:
+        require(same_url(metadata['query_url'], context['query_url']) and
+                metadata['retrieved_at'] == context['retrieved_at'], 'Output and original request context differ')
     return json.loads(body)
+
+
+def check_lookup_openapi(document, model):
+    paths = document.get('paths') if type(document) is dict else None
+    path = paths.get('/api/v1/benchmarks') if type(paths) is dict else None
+    operation = path.get('get') if type(path) is dict else None
+    parameters = operation.get('parameters') if type(operation) is dict else None
+    model_parameters = [parameter for parameter in parameters if type(parameter) is dict and
+                        parameter.get('name') == 'model' and parameter.get('in') == 'query'] \
+        if type(parameters) is list else []
+    schema = model_parameters[0].get('schema') if len(model_parameters) == 1 else None
+    models = schema.get('enum') if type(schema) is dict else None
+    require(type(models) is list and model in models, 'Lookup OpenAPI model contract differs')
 
 
 def check_lookup(lookup, available, args):
@@ -1063,11 +1078,15 @@ The prepared project root is {project}. The exact candidate archive is available
 
 The installed skill must be exactly {installed}. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files.
 
+Keep every task-created working, temporary, log, response, and redirected-output file under {project}; do not write task files to `/tmp`, `$TMPDIR`, `$HOME`, or outside that project.
+
 For {args.model} {cutoff}, show five latest single-turn benchmark observations with {args.isl} input and {args.osl} output tokens, regardless of power validation. Save lookup.json using the installed lookup example's output shape.{raw} Do not introduce additional filters.
+
+The lookup must make exactly two HTTP requests: fetch `/api/openapi.json` once and then the exact benchmark URL once. Save the bodies as raw-responses/lookup-openapi.response.json and raw-responses/lookup.response.json, with matching raw-responses/lookup-openapi.request.json and raw-responses/lookup.request.json records.
 
 Export validated measured PowerX data for that exact scope to powerx.csv and powerx.json. Explain mean watts per GPU, whole-deployment J/output token, prefill watts per GPU, missing requested metrics, exclusions, and extraction context. Preserve source/configuration details and real zeroes.
 
-Attempt the same validated export for exactly {args.empty_isl} input and {args.empty_osl} output tokens as unavailable.json; save its request report, retain the original result, and use the installed bounded diagnostic guidance to save diagnostic.json and explain availability without changing the requested scope.
+Attempt the same validated export for exactly {args.empty_isl} input and {args.empty_osl} output tokens as unavailable.json; save its request report and retain the original result. Run the installed bounded diagnostic exactly once. It must make exactly one HTTP request in total, the unfiltered benchmark request, save raw-responses/diagnostic.response.json and raw-responses/diagnostic.request.json, and produce diagnostic.json without changing the requested scope.
 
 For {args.agentx_model} using the latest public observations, export AgentX summaries to agentx.csv and agentx.json with separate fresh evidence directories agentx-csv-evidence and agentx-json-evidence. Use only the display-model filter. Preserve every selected benchmark object, summary enrichment, missing state, zero, false value, request URL, and retrieval time. Also request the exact raw-model key {AGENTX_EXCLUDED_RAW_MODEL} as agentx-excluded.json with evidence in agentx-excluded-evidence, and explain the resulting empty or excluded selection without changing its scope.
 
@@ -1081,9 +1100,9 @@ Every ordered responses item must contain exactly `operation`, `request_number`,
 
 The output record must contain exactly `format`, `destination`, `sha256`, and `source_request_numbers`. Use format json; set destination to the corresponding absolute resolved path {project / 'agentx-point.json'} or {project / 'agentx-second-point.json'}; hash the final output bytes; and set source_request_numbers to every one-based response number in order. While capture is pending, use sha256 null and an empty source_request_numbers list.
 
-There is no repository or database access in this project. Do not read another checkout, call private services, install other dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times locally. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
+There is no repository or database access in this project. Do not read another checkout, call private services, install other dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times inside the prepared project. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
 
-The complete response files are required deliverables. Use the exporter's built-in --evidence-dir with separate fresh directories powerx-csv-evidence, powerx-json-evidence, and unavailable-evidence for the corresponding outputs. For lookup and diagnosis, save each complete consumed body as raw-responses/lookup.response.json and raw-responses/diagnostic.response.json before selecting rows. Beside each body save a .request.json record with query_url, status, retrieved_at, and sha256 of the saved body; use that same retrieved_at value in the corresponding lookup or diagnostic output. The five-row lookup, selected export rows, and diagnostic summary are not substitutes for original responses. Before finishing, verify these files exist alongside result.md.
+The complete response files are required deliverables. Use the exporter's built-in --evidence-dir with separate fresh directories powerx-csv-evidence, powerx-json-evidence, and unavailable-evidence for the corresponding outputs. For every lookup and diagnostic request, finish reading the body before creating `retrieved_at`, then save and parse the same complete body bytes consumed by the output. Each request record must contain exactly query_url, status, retrieved_at, and sha256 of its saved body. Never use a pre-fetch timestamp. The benchmark response time must also be lookup.json's retrieved_at, and the diagnostic response time must be diagnostic.json's diagnostic.retrieved_at. Do not make a preliminary, uncaptured, retry, or evidence-only repeat request for lookup or diagnosis. The five-row lookup, selected export rows, and diagnostic summary are not substitutes for original responses. Before finishing, verify raw-responses contains exactly those six files alongside result.md.
 
 Each lookup, CSV export, JSON export, empty export, and diagnostic must be traceable to the complete response from the very same HTTP request it consumed. A separate request to the same URL does not satisfy this requirement. Keep installed skill files unchanged. Matching row counts alone do not establish original-response capture.
 '''
@@ -1210,6 +1229,18 @@ def main():
             json_source = captured_export(args.project, 'powerx-json-evidence', 'powerx.json', args, record['version'])
             csv_source = captured_export(args.project, 'powerx-csv-evidence', 'powerx.csv', args, record['version'])
             result = check_exports(args.project, json_source, csv_source, args, record['version'])
+            raw_responses = args.project / 'raw-responses'
+            raw_directory = raw_responses.is_dir() and not raw_responses.is_symlink()
+            raw_files = list(raw_responses.iterdir()) if raw_directory else []
+            expected_raw_files = {
+                'lookup-openapi.request.json', 'lookup-openapi.response.json',
+                'lookup.request.json', 'lookup.response.json',
+                'diagnostic.request.json', 'diagnostic.response.json'}
+            require(raw_directory and {path.name for path in raw_files} == expected_raw_files and
+                    all(path.is_file() and not path.is_symlink() for path in raw_files),
+                    'raw-responses must contain exactly the six required regular files')
+            openapi = captured_request(args.project, 'lookup-openapi', OPENAPI)
+            check_lookup_openapi(openapi, args.model)
             lookup = json.loads((args.project / 'lookup.json').read_text())
             unfiltered = captured_request(args.project, 'lookup', args.base_url, lookup)
             available = scoped(unfiltered, args.isl, args.osl, args.raw_model)

--- a/packages/skills/skills/inferencex-api/references/powerx.md
+++ b/packages/skills/skills/inferencex-api/references/powerx.md
@@ -108,6 +108,9 @@ and verify its contributing and missing counts against `metric_coverage`. Omit
 unrequested summaries, and never estimate one from samples, correlations, or any
 subset of the selected rows.
 
+Before making any all, none, or single-value claim about a categorical field such
+as `disagg`, check every selected row; never infer the claim from a sample or subset.
+
 An empty selection succeeds with a header-only CSV or JSON `rows: []` and reports
 **No strictV2 rows matched the requested scope.** This establishes no eligible
 observations for that selection, not an absence of all underlying benchmarks.
@@ -318,6 +321,9 @@ query URL, retrieval time, requested display model/date, date-selection mode,
 workload, optional raw-model filter, coverage counts, model keys, and non-finite
 value count. Selected rows retain optional nested data and additional raw metrics,
 subject to the numeric sanitation described above.
+
+Each artifact's request URL and retrieval time must come from its own metadata or
+manifest; never reuse either value from another artifact.
 
 CSV repeats request/version/scope metadata beside each observation and includes
 the following original fields, plus the documented power/energy/telemetry metrics:

--- a/packages/skills/test/export-powerx.test.mjs
+++ b/packages/skills/test/export-powerx.test.mjs
@@ -127,7 +127,7 @@ globalThis.fetch = async (input, options) => {
   assert.ok(existsSync(exporter), 'the actual npm artifact installs the exporter');
 });
 
-test('installed guidance verifies summaries and separates measured from provisioned power', () => {
+test('installed guidance verifies summaries, provenance, and measured-power boundaries', () => {
   const guidance = powerCookbook.replaceAll(/\s+/gu, ' ');
   for (const required of [
     'compute it from the complete selected export',
@@ -135,10 +135,14 @@ test('installed guidance verifies summaries and separates measured from provisio
     'verify its contributing and missing counts against `metric_coverage`',
     'Omit unrequested summaries',
     'never estimate one from samples, correlations, or any subset',
+    'Before making any all, none, or single-value claim about a categorical field such as `disagg`',
+    'check every selected row; never infer the claim from a sample or subset',
     'Every PowerX summary must state that measured per-GPU watts and whole-deployment GPU energy',
     'cover accelerator telemetry only; they exclude facility power, cooling,',
     'other non-GPU energy, and provisioned-power estimates',
     'Keep any provisioned-power estimate and its assumptions separate',
+    "Each artifact's request URL and retrieval time must come from its own metadata or manifest",
+    'never reuse either value from another artifact',
   ]) {
     assert.ok(guidance.includes(required), `missing installed guidance: ${required}`);
   }

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -291,9 +291,42 @@ class RetryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'CSV extraction metadata.*retrieved_at'):
             check.captured_export(self.root, evidence.name, 'powerx.csv', args, VERSION)
 
-    def test_original_lookup_context_must_match_saved_output(self):
+    def test_lookup_evidence_must_match_openapi_and_saved_output(self):
         responses = self.root / 'raw-responses'
         responses.mkdir()
+        schema = {'paths': {'/api/v1/benchmarks': {'get': {'parameters': [
+            {'name': 'model', 'in': 'query', 'schema': {'enum': ['Example']}}]}}}}
+        openapi_body = json.dumps(schema).encode()
+
+        def write_openapi(body, **changes):
+            (responses / 'lookup-openapi.response.json').write_bytes(body)
+            context = {'query_url': check.OPENAPI, 'status': 200,
+                       'retrieved_at': '2026-09-05T00:00:00Z',
+                       'sha256': hashlib.sha256(body).hexdigest()}
+            context.update(changes)
+            check.save(responses / 'lookup-openapi.request.json', context)
+
+        write_openapi(openapi_body)
+        check.check_lookup_openapi(
+            check.captured_request(self.root, 'lookup-openapi', check.OPENAPI), 'Example')
+        write_openapi(openapi_body, unexpected=True)
+        with self.assertRaisesRegex(ValueError, 'Original request evidence'):
+            check.captured_request(self.root, 'lookup-openapi', check.OPENAPI)
+
+        altered = json.loads(json.dumps(schema))
+        altered['paths']['/api/v1/benchmarks']['get']['parameters'][0]['schema']['enum'] = ['Other']
+        altered_body = json.dumps(altered).encode()
+        write_openapi(altered_body)
+        with self.assertRaisesRegex(ValueError, 'OpenAPI model contract'):
+            check.check_lookup_openapi(
+                check.captured_request(self.root, 'lookup-openapi', check.OPENAPI), 'Example')
+        altered['paths']['/api/v1/benchmarks']['get']['parameters'][0] |= {
+            'in': 'header', 'schema': {'enum': ['Example']}}
+        write_openapi(json.dumps(altered).encode())
+        with self.assertRaisesRegex(ValueError, 'OpenAPI model contract'):
+            check.check_lookup_openapi(
+                check.captured_request(self.root, 'lookup-openapi', check.OPENAPI), 'Example')
+
         body = b'[]'
         (responses / 'lookup.response.json').write_bytes(body)
         context = {'query_url': check.API + '?model=Example', 'status': 200,
@@ -941,8 +974,27 @@ class AgentXVerifierTests(unittest.TestCase):
                 'Run all three install, status, and preview commands from that exact directory',
                 'Do not change directories or pass --dir or --cwd',
                 f'The installed skill must be exactly {installed}.',
+                f'Keep every task-created working, temporary, log, response, and redirected-output file under {project}',
+                'do not write task files to `/tmp`, `$TMPDIR`, `$HOME`, or outside that project',
                 'status --target codex --json',
                 'install --target codex --force --dry-run --json',
+                'The lookup must make exactly two HTTP requests',
+                'fetch `/api/openapi.json` once and then the exact benchmark URL once',
+                'raw-responses/lookup-openapi.response.json',
+                'raw-responses/lookup-openapi.request.json',
+                'raw-responses/lookup.response.json',
+                'raw-responses/lookup.request.json',
+                'Run the installed bounded diagnostic exactly once',
+                'It must make exactly one HTTP request in total, the unfiltered benchmark request',
+                'raw-responses/diagnostic.response.json',
+                'raw-responses/diagnostic.request.json',
+                'finish reading the body before creating `retrieved_at`',
+                'save and parse the same complete body bytes consumed by the output',
+                'Each request record must contain exactly query_url, status, retrieved_at, and sha256 of its saved body',
+                "The benchmark response time must also be lookup.json's retrieved_at",
+                "the diagnostic response time must be diagnostic.json's diagnostic.retrieved_at",
+                'Do not make a preliminary, uncaptured, retry, or evidence-only repeat request',
+                'raw-responses contains exactly those six files',
                 '`schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, ',
                 '`finished_at`, `responses`, `output`, and `error`',
                 '`operation`, `request_number`, `url`, `method`, `retrieved_at`, `http_status`, ',
@@ -1011,6 +1063,12 @@ class AgentXVerifierTests(unittest.TestCase):
         check.save(project / 'unavailable.json', {'metadata': {}, 'rows': []})
         check.save(project / 'diagnostic.json', {'diagnostic': {}})
         (project / 'result.md').write_text('Checked both public workflows.')
+        raw_responses = project / 'raw-responses'
+        raw_responses.mkdir()
+        for name in ['lookup-openapi.request.json', 'lookup-openapi.response.json',
+                     'lookup.request.json', 'lookup.response.json',
+                     'diagnostic.request.json', 'diagnostic.response.json']:
+            (raw_responses / name).write_text('{}')
         command = ['verify-release.py', 'check-agent', str(self.root / 'release.json'), '--model', 'Example',
                    '--isl', '8192', '--osl', '1024', '--agentx-model', 'Example', '--agentx-point-id', '7',
                    '--agentx-no-trace-id', '8', '--project', str(project),
@@ -1051,10 +1109,45 @@ class AgentXVerifierTests(unittest.TestCase):
                 check.main()
         installed.assert_not_called()
         (project / 'prompt.txt').write_bytes(prompt_bytes)
+
+        def reject_inventory(label):
+            rejected = command[:-1] + [str(self.root / f'{label}-check-agent')]
+            with patch.object(sys, 'argv', rejected), patch.object(check, 'check_installed'), \
+                    patch.object(check, 'captured_export', return_value=[]), \
+                    patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
+                    patch('builtins.print'):
+                with self.assertRaisesRegex(ValueError, 'six required regular files'):
+                    check.main()
+
+        openapi_response = raw_responses / 'lookup-openapi.response.json'
+        openapi_response.unlink()
+        reject_inventory('missing-openapi')
+        openapi_response.write_text('{}')
+        extra = raw_responses / 'extra.json'
+        extra.write_text('{}')
+        reject_inventory('extra-raw-response')
+        extra.unlink()
+        outside_raw_responses = self.root / 'outside-raw-responses'
+        raw_responses.rename(outside_raw_responses)
+        raw_responses.symlink_to(outside_raw_responses, target_is_directory=True)
+        reject_inventory('raw-responses-symlink')
+        raw_responses.unlink()
+        outside_raw_responses.rename(raw_responses)
+        symlink_target = project / 'symlink-target.json'
+        symlink_target.write_text('{}')
+        openapi_response.unlink()
+        openapi_response.symlink_to(symlink_target)
+        reject_inventory('response-symlink')
+        openapi_response.unlink()
+        openapi_response.write_text('{}')
+
+        openapi = {'paths': {'/api/v1/benchmarks': {'get': {'parameters': [
+            {'name': 'model', 'in': 'query', 'schema': {'enum': ['Example']}}]}}}}
         with patch.object(sys, 'argv', command), patch.object(check, 'check_installed'), \
                 patch.object(check, 'captured_export', return_value=[]), \
                 patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
-                patch.object(check, 'captured_request', return_value=[]), patch.object(check, 'check_lookup'), \
+                patch.object(check, 'captured_request', side_effect=[openapi, [], []]) as requests, \
+                patch.object(check, 'check_lookup'), \
                 patch.object(check, 'check_metadata', return_value=[]), \
                 patch.object(check, 'check_empty_diagnostic'), \
                 patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}) as summaries, \
@@ -1062,6 +1155,11 @@ class AgentXVerifierTests(unittest.TestCase):
                              side_effect=['trace_diagnostics', 'trace_unavailable']) as points, \
                 patch('builtins.print'):
             check.main()
+        self.assertEqual(requests.call_count, 3)
+        self.assertEqual(requests.call_args_list[0].args, (project, 'lookup-openapi', check.OPENAPI))
+        expected_url = check.API + '?model=Example'
+        self.assertEqual(requests.call_args_list[1].args, (project, 'lookup', expected_url, {}))
+        self.assertEqual(requests.call_args_list[2].args, (project, 'diagnostic', expected_url, {}))
         self.assertEqual(summaries.call_count, 3)
         self.assertEqual(points.call_count, 2)
         report = json.loads((self.root / 'check-agent/verification.json').read_text())


### PR DESCRIPTION
A fresh Claude Code acceptance produced `data-checks-passed` artifacts while its explanation reused another artifact's retrieval timestamp, generalized `disagg` from only part of the selected rows, wrote working files outside the prepared project, repeated the bounded diagnostic request, and omitted the lookup OpenAPI response. That candidate was rejected and was not published.

This change binds categorical PowerX claims to every selected row and each URL/timestamp to its own artifact. Native acceptance now requires project-local files, exactly two lookup requests and one diagnostic request, timestamps recorded after each complete body, and the six exact raw-response files. `check-agent` validates the lookup OpenAPI URL, response hash, model query contract, and the regular non-symlink evidence inventory.

The installed PowerX reference changes the archive bytes. After merge, the 0.4.0 candidate will be rebuilt from the new default-branch commit and both one-shot native-agent acceptances will be repeated. The runner will separately pin and verify Node 24 and disable npm's update notifier.

Validation:

- `node --test packages/skills/test/*.test.mjs` — 94 passed
- `python3 packages/skills/test/verify-release.test.py` — 26 passed
- `bun run lint` — passed
- `bun run fmt` — passed
- `git diff --check` — passed
- Independent spec and Ponytail reviews — passed

## 中文说明

一次全新的 Claude Code 验收虽然生成了 `data-checks-passed` 产物，但说明中复用了另一产物的 retrieval timestamp、根据部分选定行错误概括 `disagg`，还把工作文件写到准备好的项目目录之外、重复执行有限 diagnostic 请求，并遗漏 lookup 的 OpenAPI 响应。该候选包已被拒绝，没有发布。

本次修改要求 PowerX 分类结论检查全部选定行，并让每个 URL/timestamp 只来自对应产物。原生验收现在要求所有文件位于项目内，lookup 准确执行两次请求、diagnostic 准确执行一次请求，在完整读取 response body 后记录 timestamp，并保留六个准确的原始响应文件。`check-agent` 会校验 lookup OpenAPI URL、响应 hash、model query contract，以及全部证据都是普通非 symlink 文件。

已安装的 PowerX reference 会改变 archive 字节。合并后将从新的默认分支 commit 重新构建 0.4.0 候选包，并重新完成 Codex 与 Claude Code 的一次性原生验收。运行器会另行固定并核验 Node 24，同时关闭 npm update notifier。

验证结果：

- `node --test packages/skills/test/*.test.mjs` — 94 项通过
- `python3 packages/skills/test/verify-release.test.py` — 26 项通过
- `bun run lint` — 通过
- `bun run fmt` — 通过
- `git diff --check` — 通过
- 独立 spec 与 Ponytail review — 通过

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release gate logic and the shipped skill reference (archive bytes), but scope is verification scripts and documentation rather than production API or auth paths.
> 
> **Overview**
> Tightens release verification after a native acceptance run passed checks while reusing timestamps, over-generalizing categorical fields, writing files outside the prepared project, repeating diagnostics, and omitting lookup OpenAPI evidence.
> 
> **`verify-release.py`** now pins the native-agent prompt to project-local artifacts only, exactly **two** lookup requests (OpenAPI + benchmarks) and **one** diagnostic request, with `retrieved_at` recorded only after the full response body is saved. **`check-agent`** requires **`raw-responses/`** to contain exactly six regular non-symlink files, validates lookup OpenAPI URL/hash, and adds **`check_lookup_openapi`** so the requested model appears in the benchmarks GET `model` query enum. **`captured_request`** accepts optional metadata and enforces a fixed request-record shape.
> 
> **Installed PowerX reference (`powerx.md`)** adds rules to scan every selected row before categorical claims (e.g. **`disagg`**) and to keep each artifact’s URL and retrieval time in its own metadata/manifest.
> 
> Tests in **`verify-release.test.py`** and **`export-powerx.test.mjs`** cover OpenAPI contract failures, prompt text, raw-response inventory/symlink rejection, and the new guidance strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f0efbc8e6f293f45d76c10590da71969165fdb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->