### PR TITLE
fix(skills): bind native point acceptance to installed recipe / 将原生单点验收绑定到已安装 recipe

### DIFF
--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1033,6 +1033,13 @@ def point_recipe(installed, selected_id):
     return matches[0].replace(needle, f"const selectedResultId = '{selected_id}';")
 
 
+def check_point_recipe(project, installed, label, selected_id):
+    script = project / f'{label}-recipe.mjs'
+    require(script.is_file() and not script.is_symlink() and
+            script.read_bytes() == point_recipe(installed, selected_id).encode(),
+            f'Native-agent point recipe changed beyond its selected ID: {label}')
+
+
 def run_point(node, installed, project, environment, label, selected_id, version, deadline=None):
     script = project / f'{label}-recipe.mjs'
     preload = project / f'{label}-capture.mjs'
@@ -1070,6 +1077,13 @@ def prompt(args, target, archive):
     raw = f' Keep only the exact returned model key {args.raw_model}; record this filter as scope.raw_model in lookup.json.' if args.raw_model else ''
     return f'''Use only the exact candidate archive and public HTTP data in this clean project.
 
+Before running any command, follow these acceptance boundaries:
+
+- This prepared project is the only writable boundary, even though it lives under system temp. Keep the working directory at {project}, and put every task-created temporary, log, response, script, and redirected-output file there. Never create, extract, or delete task files in `/tmp`, `$TMPDIR`, `$HOME`, or another directory.
+- Do not list or extract the candidate archive. The install, status, and preview commands below must be your first three shell commands; inspect only the installed skill afterward.
+- Do not run a connectivity or schema preflight with `curl` or any other tool. The task's first two HTTP requests must be the captured OpenAPI request and captured benchmark request; only after both response captures and lookup.json exist may an exporter or diagnostic make an HTTP request. Do not make a preliminary, uncaptured, retry, or evidence-only repeat request for lookup or diagnosis.
+- For each AgentX point, keep the installed recipe byte-for-byte except for its one selected-result-ID line. Put response capture only in a separate Node preload and save the recipe's own stdout by shell redirection.
+
 The prepared project root is {project}. The exact candidate archive is available at {archive}. Run all three install, status, and preview commands from that exact directory. Do not change directories or pass --dir or --cwd; do not select any other installation root. Run these commands in order:
 
 1. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target}
@@ -1077,8 +1091,6 @@ The prepared project root is {project}. The exact candidate archive is available
 3. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target} --force --dry-run --json > preview.json
 
 The installed skill must be exactly {installed}. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files.
-
-Keep every task-created working, temporary, log, response, and redirected-output file under {project}; do not write task files to `/tmp`, `$TMPDIR`, `$HOME`, or outside that project.
 
 For {args.model} {cutoff}, show five latest single-turn benchmark observations with {args.isl} input and {args.osl} output tokens, regardless of power validation. Save lookup.json using the installed lookup example's output shape.{raw} Do not introduce additional filters.
 
@@ -1090,7 +1102,7 @@ Attempt the same validated export for exactly {args.empty_isl} input and {args.e
 
 For {args.agentx_model} using the latest public observations, export AgentX summaries to agentx.csv and agentx.json with separate fresh evidence directories agentx-csv-evidence and agentx-json-evidence. Use only the display-model filter. Preserve every selected benchmark object, summary enrichment, missing state, zero, false value, request URL, and retrieval time. Also request the exact raw-model key {AGENTX_EXCLUDED_RAW_MODEL} as agentx-excluded.json with evidence in agentx-excluded-evidence, and explain the resulting empty or excluded selection without changing its scope.
 
-Run the installed one-point recipe as written for exactly result ID {args.agentx_point_id} and save its own stdout JSON as agentx-point.json. Run it separately as written for exactly result ID {args.agentx_no_trace_id} and save its own stdout JSON as agentx-second-point.json. Change only the recipe's selected result ID seam. Do not reimplement its request flow or reconstruct its JSON output. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
+Run the installed one-point recipe as written for both points. Extract it exactly from {installed / 'references/agentx.md'} into agentx-point-recipe.mjs for result ID {args.agentx_point_id} and agentx-second-point-recipe.mjs for result ID {args.agentx_no_trace_id}. In each file, change only the exact `const selectedResultId = '421';` line to its requested ID; every other recipe byte must remain identical. Run each recipe with a separate Node `--import` capture preload, and redirect that recipe process's stdout directly to agentx-point.json or agentx-second-point.json. The recipe files must not write their output or evidence, replace `response.json()`, replace `console.log()`, or contain capture logic. Do not reimplement the request flow or reconstruct the JSON output. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
 
 Build `metadata.requests` only after that run's final fetch has completed, with one item containing exactly `query_url` and `retrieved_at` for every manifest response in identical order (six for a traced run and three for a no-trace run); each `query_url` must match the corresponding manifest response `url`, and each `retrieved_at` must be the recipe's own request time for that fetch.
 
@@ -1100,9 +1112,11 @@ Every ordered responses item must contain exactly `operation`, `request_number`,
 
 The output record must contain exactly `format`, `destination`, `sha256`, and `source_request_numbers`. Use format json; set destination to the corresponding absolute resolved path {project / 'agentx-point.json'} or {project / 'agentx-second-point.json'}; hash the final output bytes; and set source_request_numbers to every one-based response number in order. While capture is pending, use sha256 null and an empty source_request_numbers list.
 
+In result.md, report `trace_availability.key_present` and `trace_availability.available` exactly as each point output records them. Do not describe an omitted availability key as an explicit `false` value.
+
 There is no repository or database access in this project. Do not read another checkout, call private services, install other dependencies, or run benchmarks. Save complete public responses and request URLs with retrieval times inside the prepared project. Do not assume row counts or reconstruct data from webpage summaries. Write the final explanation to result.md. Keep command output compact.
 
-The complete response files are required deliverables. Use the exporter's built-in --evidence-dir with separate fresh directories powerx-csv-evidence, powerx-json-evidence, and unavailable-evidence for the corresponding outputs. For every lookup and diagnostic request, finish reading the body before creating `retrieved_at`, then save and parse the same complete body bytes consumed by the output. Each request record must contain exactly query_url, status, retrieved_at, and sha256 of its saved body. Never use a pre-fetch timestamp. The benchmark response time must also be lookup.json's retrieved_at, and the diagnostic response time must be diagnostic.json's diagnostic.retrieved_at. Do not make a preliminary, uncaptured, retry, or evidence-only repeat request for lookup or diagnosis. The five-row lookup, selected export rows, and diagnostic summary are not substitutes for original responses. Before finishing, verify raw-responses contains exactly those six files alongside result.md.
+The complete response files are required deliverables. Use the exporter's built-in --evidence-dir with separate fresh directories powerx-csv-evidence, powerx-json-evidence, and unavailable-evidence for the corresponding outputs. For every lookup and diagnostic request, finish reading the body before creating `retrieved_at`, then save and parse the same complete body bytes consumed by the output. Each request record must contain exactly query_url, status, retrieved_at, and sha256 of its saved body. Never use a pre-fetch timestamp. The benchmark response time must also be lookup.json's retrieved_at, and the diagnostic response time must be diagnostic.json's diagnostic.retrieved_at. The five-row lookup, selected export rows, and diagnostic summary are not substitutes for original responses. Before finishing, verify raw-responses contains exactly those six files alongside result.md.
 
 Each lookup, CSV export, JSON export, empty export, and diagnostic must be traceable to the complete response from the very same HTTP request it consumed. A separate request to the same URL does not satisfy this requirement. Keep installed skill files unchanged. Matching row counts alone do not establish original-response capture.
 '''
@@ -1259,6 +1273,8 @@ def main():
                 check_agentx_capture(args.project, 'agentx-csv-evidence', 'agentx.csv', args, record['version']),
                 check_agentx_capture(args.project, 'agentx-excluded-evidence', 'agentx-excluded.json', args,
                                      record['version'], excluded=True)]
+            check_point_recipe(args.project, installed, 'agentx-point', args.agentx_point_id)
+            check_point_recipe(args.project, installed, 'agentx-second-point', args.agentx_no_trace_id)
             points = check_point_outcomes([
                 check_agentx_point(args.project, 'agentx-point-evidence', 'agentx-point.json',
                                    args.agentx_point_id, record['version']),

--- a/packages/skills/skills/inferencex-api/references/agentx.md
+++ b/packages/skills/skills/inferencex-api/references/agentx.md
@@ -245,9 +245,11 @@ JS
 
 Save the JSON output with the analysis. `benchmark_siblings.sku` and
 `selected_point` retain every identity field the API supplied; absence remains
-absence. `trace_unavailable` means only that the availability response omitted the
-selected key (or returned it as false). It does not mean the benchmark never ran or
-that a source artifact never existed. Do not call the page-owned
+absence. Preserve the distinction inside `trace_availability`: `key_present: false`
+means the response omitted the selected ID, while `key_present: true` with
+`available: false` means it explicitly returned `false`. Both produce
+`trace_unavailable`; neither means the benchmark never ran or that a source artifact
+never existed. Do not call the page-owned
 `/api/v1/request-chart-data` or `/api/v1/trace-server-metric-source` operations.
 Do not repeat this recipe across a result set; ask the user to choose another single
 ID first.

--- a/packages/skills/test/agentx-point-diagnostics.test.mjs
+++ b/packages/skills/test/agentx-point-diagnostics.test.mjs
@@ -35,6 +35,8 @@ before(() => {
     );
     assert.ok(snippet, 'installed AgentX cookbook must contain the maintained recipe');
     assert.equal(extra.length, 0, 'AgentX cookbook must have one maintained executable recipe');
+    assert.match(cookbook, /`key_present: false`\s+means the response omitted the selected ID/u);
+    assert.match(cookbook, /`key_present: true` with\s+`available: false`/u);
     installed.set(target, snippet.groups.code);
   }
   writeFileSync(
@@ -222,6 +224,21 @@ test('installed recipe short-circuits an unavailable trace after preserving sibl
     `${base}/api/v1/benchmark-siblings?id=421`,
     `${base}/api/v1/trace-availability?ids=421`,
   ]);
+});
+
+test('installed recipe preserves explicit false separately from an omitted availability key', () => {
+  const result = run({
+    ...lightResponses,
+    '/api/v1/trace-availability?ids=421': response({ 421: false }),
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.outcome, 'trace_unavailable');
+  assert.deepEqual(output.trace_availability, {
+    response: { 421: false },
+    key_present: true,
+    available: false,
+  });
 });
 
 test('installed recipe reads one selected point and preserves every request phase and cancellation', () => {

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -758,6 +758,36 @@ class AgentXVerifierTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'differs from complete responses'):
             check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
 
+    def test_native_point_recipe_allows_only_the_selected_id_seam(self):
+        installed = self.root / 'installed'
+        reference = installed / 'references'
+        reference.mkdir(parents=True)
+        reference.joinpath('agentx.md').write_text("""```bash
+node --input-type=module <<'JS'
+const selectedResultId = '421';
+console.log(selectedResultId);
+JS
+```
+""")
+        expected = check.point_recipe(installed, '7').encode()
+        script = self.root / 'agentx-point-recipe.mjs'
+        script.write_bytes(expected)
+        check.check_point_recipe(self.root, installed, 'agentx-point', '7')
+
+        for mutation in [expected + b'\n', expected.replace(b'\n', b'\r\n'),
+                         expected.replace(b'console.log', b'process.stdout.write')]:
+            with self.subTest(mutation=mutation):
+                script.write_bytes(mutation)
+                with self.assertRaisesRegex(ValueError, 'changed beyond its selected ID'):
+                    check.check_point_recipe(self.root, installed, 'agentx-point', '7')
+
+        outside = self.root / 'outside.mjs'
+        outside.write_bytes(expected)
+        script.unlink()
+        script.symlink_to(outside)
+        with self.assertRaisesRegex(ValueError, 'changed beyond its selected ID'):
+            check.check_point_recipe(self.root, installed, 'agentx-point', '7')
+
     def test_point_oracle_requires_one_chronological_capture_request_output_chain(self):
         for mutation in ['capture-order', 'request-before-capture', 'output-before-request',
                          'finish-before-output']:
@@ -971,13 +1001,19 @@ class AgentXVerifierTests(unittest.TestCase):
         installed = project / '.agents/skills/inferencex-api'
         for required in [
                 f'The prepared project root is {project}.',
+                'This prepared project is the only writable boundary',
+                'Never create, extract, or delete task files in `/tmp`, `$TMPDIR`, `$HOME`, or another directory',
+                'Do not list or extract the candidate archive',
+                'must be your first three shell commands',
                 'Run all three install, status, and preview commands from that exact directory',
                 'Do not change directories or pass --dir or --cwd',
                 f'The installed skill must be exactly {installed}.',
-                f'Keep every task-created working, temporary, log, response, and redirected-output file under {project}',
-                'do not write task files to `/tmp`, `$TMPDIR`, `$HOME`, or outside that project',
                 'status --target codex --json',
                 'install --target codex --force --dry-run --json',
+                'Do not run a connectivity or schema preflight with `curl` or any other tool',
+                "The task's first two HTTP requests must be the captured OpenAPI request and captured benchmark request",
+                'only after both response captures and lookup.json exist may an exporter or diagnostic make an HTTP request',
+                'Do not make a preliminary, uncaptured, retry, or evidence-only repeat request',
                 'The lookup must make exactly two HTTP requests',
                 'fetch `/api/openapi.json` once and then the exact benchmark URL once',
                 'raw-responses/lookup-openapi.response.json',
@@ -993,7 +1029,6 @@ class AgentXVerifierTests(unittest.TestCase):
                 'Each request record must contain exactly query_url, status, retrieved_at, and sha256 of its saved body',
                 "The benchmark response time must also be lookup.json's retrieved_at",
                 "the diagnostic response time must be diagnostic.json's diagnostic.retrieved_at",
-                'Do not make a preliminary, uncaptured, retry, or evidence-only repeat request',
                 'raw-responses contains exactly those six files',
                 '`schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, ',
                 '`finished_at`, `responses`, `output`, and `error`',
@@ -1004,12 +1039,19 @@ class AgentXVerifierTests(unittest.TestCase):
                 '`format`, `destination`, `sha256`, and `source_request_numbers`',
                 'The final manifest is accepted only with `status: "complete"` and `error: null`',
                 'Run the installed one-point recipe as written',
-                'Do not reimplement its request flow or reconstruct its JSON output',
+                'agentx-point-recipe.mjs',
+                'agentx-second-point-recipe.mjs',
+                'every other recipe byte must remain identical',
+                'separate Node `--import` capture preload',
+                "redirect that recipe process's stdout directly",
+                'must not write their output or evidence, replace `response.json()`, replace `console.log()`',
+                'Do not reimplement the request flow or reconstruct the JSON output',
                 "Build `metadata.requests` only after that run's final fetch has completed",
                 'one item containing exactly `query_url` and `retrieved_at`',
                 'for every manifest response in identical order (six for a traced run and three for a no-trace run)',
                 'each `query_url` must match the corresponding manifest response `url`',
                 "each `retrieved_at` must be the recipe's own request time for that fetch",
+                'Do not describe an omitted availability key as an explicit `false` value',
         ]:
             with self.subTest(required=required):
                 self.assertIn(required, prompt_text)
@@ -1151,6 +1193,7 @@ class AgentXVerifierTests(unittest.TestCase):
                 patch.object(check, 'check_metadata', return_value=[]), \
                 patch.object(check, 'check_empty_diagnostic'), \
                 patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}) as summaries, \
+                patch.object(check, 'check_point_recipe') as recipes, \
                 patch.object(check, 'check_agentx_point',
                              side_effect=['trace_diagnostics', 'trace_unavailable']) as points, \
                 patch('builtins.print'):
@@ -1161,6 +1204,7 @@ class AgentXVerifierTests(unittest.TestCase):
         self.assertEqual(requests.call_args_list[1].args, (project, 'lookup', expected_url, {}))
         self.assertEqual(requests.call_args_list[2].args, (project, 'diagnostic', expected_url, {}))
         self.assertEqual(summaries.call_count, 3)
+        self.assertEqual(recipes.call_count, 2)
         self.assertEqual(points.call_count, 2)
         report = json.loads((self.root / 'check-agent/verification.json').read_text())
         self.assertEqual(report['status'], 'data-checks-passed')


### PR DESCRIPTION
## Summary

A native AgentX acceptance run could pass response and output checks while rewriting the installed one-point recipe, issuing preliminary uncaptured requests, or collapsing a missing availability key into explicit `false`.

This change:

- requires both native point recipe files to match the installed cookbook byte-for-byte, except for the selected result ID line;
- places the project-only filesystem boundary, first-three-command order, and first-two-HTTP-request order before the task;
- documents and tests the distinction between an omitted trace-availability key and an explicit `false`.

The existing independent transcript review remains the proof of which script the native agent executed.

## Validation

- `python3 packages/skills/test/verify-release.test.py` — 27 passed
- `node --test packages/skills/test/*.test.mjs` — 95 passed
- `bun run lint`
- `bun run fmt`
- Independent spec/correctness review — pass
- Independent Ponytail review — pass

Relates to #1025.

## 中文说明

原生 AgentX 验收曾出现一种缺口：response 与 output 检查可以通过，但代理仍可能改写已安装的单点 recipe、提前发送未保存的请求，或把缺失的 availability key 误述为明确的 `false`。

本次修改：

- 要求两个 native point recipe 文件与已安装 cookbook 逐字节一致，唯一允许的变化是选定 result ID；
- 将项目内文件边界、前三条命令顺序和前两个 HTTP 请求顺序前置；
- 在文档和测试中明确区分缺失 trace-availability key 与明确返回 `false`。

独立 transcript review 继续负责确认 native agent 实际执行了哪个脚本。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect skills release verification prompts and offline checks only; no runtime API or auth behavior is modified.
> 
> **Overview**
> Tightens **native-agent release acceptance** so AgentX single-point runs cannot pass while rewriting the installed cookbook, skipping capture order, or misreporting trace availability.
> 
> **Verifier (`verify-release.py`)** adds `check_point_recipe`, which requires `agentx-point-recipe.mjs` and `agentx-second-point-recipe.mjs` to match the script extracted from `references/agentx.md` **byte-for-byte**, with only the `const selectedResultId = '421';` line swapped for the requested ID (no symlinks or other edits). `check-agent` runs this before existing point evidence checks. The generated agent prompt is expanded with upfront boundaries: project-only writes, install/status/preview as the first three commands, lookup OpenAPI + benchmark as the first two HTTP calls (no curl preflight or duplicate evidence fetches), explicit recipe file names, separate Node `--import` capture preload, stdout redirection, and accurate `result.md` reporting of `trace_availability.key_present` / `available`.
> 
> **Cookbook (`agentx.md`)** documents that omitted availability keys (`key_present: false`) differ from an explicit `false` (`key_present: true`, `available: false`), even though both yield `trace_unavailable`.
> 
> **Tests** cover recipe-byte enforcement, the explicit-false recipe behavior, prompt string pins, and wiring of `check_point_recipe` in the check-agent flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8c4f428470559462547c6bd543b93a6154166e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->