### PR TITLE
fix(skills): make native setup order unambiguous / 明确 native 安装命令顺序

### DIFF
--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1075,20 +1075,27 @@ def prompt(args, target, archive):
     installed = project / ('.agents' if target == 'codex' else '.claude') / 'skills/inferencex-api'
     cutoff = f'as of {args.date}' if args.date else 'using the latest available observations'
     raw = f' Keep only the exact returned model key {args.raw_model}; record this filter as scope.raw_model in lookup.json.' if args.raw_model else ''
-    return f'''Use only the exact candidate archive and public HTTP data in this clean project.
+    install_command = f'npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target}'
+    status_command = f'npm exec --yes --offline --package {archive} -- inferencex-skills status --target {target} --json > status.json'
+    preview_command = f'npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target} --force --dry-run --json > preview.json'
+    return f'''Your first three tool calls must be shell calls containing exactly these commands, one per call, in this order:
+
+1. {install_command}
+2. {status_command}
+3. {preview_command}
+
+Make exactly one shell tool call at a time, and wait for it to finish successfully before issuing the next. Until all three finish, make no tool calls except the next required shell call; in particular, do not call Read, Glob, Grep, or Skill. Do not prefix, suffix, or combine the commands with `pwd`, `ls`, `cat`, `&&`, `;`, a pipe, or any other command.
+
+Use only the exact candidate archive and public HTTP data in this clean project.
 
 Before running any command, follow these acceptance boundaries:
 
 - This prepared project is the only writable boundary, even though it lives under system temp. Keep the working directory at {project}, and put every task-created temporary, log, response, script, and redirected-output file there. Never create, extract, or delete task files in `/tmp`, `$TMPDIR`, `$HOME`, or another directory.
-- Do not list or extract the candidate archive. The install, status, and preview commands below must be your first three shell commands; inspect only the installed skill afterward.
+- Do not list or extract the candidate archive. Inspect only the installed skill after the three required commands finish.
 - Do not run a connectivity or schema preflight with `curl` or any other tool. The task's first two HTTP requests must be the captured OpenAPI request and captured benchmark request; only after both response captures and lookup.json exist may an exporter or diagnostic make an HTTP request. Do not make a preliminary, uncaptured, retry, or evidence-only repeat request for lookup or diagnosis.
 - For each AgentX point, keep the installed recipe byte-for-byte except for its one selected-result-ID line. Put response capture only in a separate Node preload and save the recipe's own stdout by shell redirection.
 
-The prepared project root is {project}. The exact candidate archive is available at {archive}. Run all three install, status, and preview commands from that exact directory. Do not change directories or pass --dir or --cwd; do not select any other installation root. Run these commands in order:
-
-1. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target}
-2. npm exec --yes --offline --package {archive} -- inferencex-skills status --target {target} --json > status.json
-3. npm exec --yes --offline --package {archive} -- inferencex-skills install --target {target} --force --dry-run --json > preview.json
+The prepared project root is {project}. The exact candidate archive is available at {archive}. Run the required install, status, and preview commands from that exact directory. Do not change directories or pass --dir or --cwd; do not select any other installation root.
 
 The installed skill must be exactly {installed}. Do not apply the forced reinstall or manually change the installed skill files. Explain the executing package version, installed version, proposed writes, and preserved files.
 
@@ -1102,7 +1109,7 @@ Attempt the same validated export for exactly {args.empty_isl} input and {args.e
 
 For {args.agentx_model} using the latest public observations, export AgentX summaries to agentx.csv and agentx.json with separate fresh evidence directories agentx-csv-evidence and agentx-json-evidence. Use only the display-model filter. Preserve every selected benchmark object, summary enrichment, missing state, zero, false value, request URL, and retrieval time. Also request the exact raw-model key {AGENTX_EXCLUDED_RAW_MODEL} as agentx-excluded.json with evidence in agentx-excluded-evidence, and explain the resulting empty or excluded selection without changing its scope.
 
-Run the installed one-point recipe as written for both points. Extract it exactly from {installed / 'references/agentx.md'} into agentx-point-recipe.mjs for result ID {args.agentx_point_id} and agentx-second-point-recipe.mjs for result ID {args.agentx_no_trace_id}. In each file, change only the exact `const selectedResultId = '421';` line to its requested ID; every other recipe byte must remain identical. Run each recipe with a separate Node `--import` capture preload, and redirect that recipe process's stdout directly to agentx-point.json or agentx-second-point.json. The recipe files must not write their output or evidence, replace `response.json()`, replace `console.log()`, or contain capture logic. Do not reimplement the request flow or reconstruct the JSON output. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
+Run the installed one-point recipe as written for both points. Extract it exactly from {installed / 'references/agentx.md'} into agentx-point-recipe.mjs for result ID {args.agentx_point_id} and agentx-second-point-recipe.mjs for result ID {args.agentx_no_trace_id}. Extract only the bytes after the `node --input-type=module <<'JS'` line through the final `}}` before the `JS` delimiter; the file must end at that final `}}` byte with no trailing newline or other byte. In each file, change only the exact `const selectedResultId = '421';` line to its requested ID; every other recipe byte must remain identical. Run each recipe with a separate Node `--import` capture preload, and redirect that recipe process's stdout directly to agentx-point.json or agentx-second-point.json. The recipe files must not write their output or evidence, replace `response.json()`, replace `console.log()`, or contain capture logic. Do not reimplement the request flow or reconstruct the JSON output. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
 
 Build `metadata.requests` only after that run's final fetch has completed, with one item containing exactly `query_url` and `retrieved_at` for every manifest response in identical order (six for a traced run and three for a no-trace run); each `query_url` must match the corresponding manifest response `url`, and each `retrieved_at` must be the recipe's own request time for that fetch.
 

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -995,6 +995,26 @@ JS
                           prompt_text)
 
     def test_agent_prompt_pins_project_commands_and_exact_point_manifest_contract(self):
+        for target, install_root in [('codex', '.agents'), ('claude', '.claude')]:
+            target_project = (self.root / f'prepared/{target}').resolve()
+            target_archive = target_project / 'candidate.tgz'
+            target_prompt = check.prompt(self.args, target, target_archive)
+            commands = [
+                f'npm exec --yes --offline --package {target_archive} -- inferencex-skills install --target {target}',
+                f'npm exec --yes --offline --package {target_archive} -- inferencex-skills status --target {target} --json > status.json',
+                f'npm exec --yes --offline --package {target_archive} -- inferencex-skills install --target {target} --force --dry-run --json > preview.json',
+            ]
+            with self.subTest(target=target):
+                self.assertTrue(target_prompt.startswith(
+                    'Your first three tool calls must be shell calls containing exactly these commands, one per call, in this order:\n'))
+                self.assertEqual([line[3:] for line in target_prompt.splitlines()[2:5]], commands)
+                for number, command in enumerate(commands, 1):
+                    self.assertEqual(target_prompt.count(f'\n{number}. {command}\n'), 1)
+                self.assertIn(
+                    f'The installed skill must be exactly {target_project / install_root}/skills/inferencex-api.',
+                    target_prompt,
+                )
+
         project = (self.root / 'prepared/codex').resolve()
         archive = project / 'candidate.tgz'
         prompt_text = check.prompt(self.args, 'codex', archive)
@@ -1004,8 +1024,10 @@ JS
                 'This prepared project is the only writable boundary',
                 'Never create, extract, or delete task files in `/tmp`, `$TMPDIR`, `$HOME`, or another directory',
                 'Do not list or extract the candidate archive',
-                'must be your first three shell commands',
-                'Run all three install, status, and preview commands from that exact directory',
+                'Make exactly one shell tool call at a time, and wait for it to finish successfully before issuing the next',
+                'Until all three finish, make no tool calls except the next required shell call',
+                'Do not prefix, suffix, or combine the commands with `pwd`, `ls`, `cat`, `&&`, `;`, a pipe, or any other command',
+                'Run the required install, status, and preview commands from that exact directory',
                 'Do not change directories or pass --dir or --cwd',
                 f'The installed skill must be exactly {installed}.',
                 'status --target codex --json',
@@ -1042,6 +1064,7 @@ JS
                 'agentx-point-recipe.mjs',
                 'agentx-second-point-recipe.mjs',
                 'every other recipe byte must remain identical',
+                'the file must end at that final `}` byte with no trailing newline or other byte',
                 'separate Node `--import` capture preload',
                 "redirect that recipe process's stdout directly",
                 'must not write their output or evidence, replace `response.json()`, replace `console.log()`',


### PR DESCRIPTION
## Summary

A clean Claude Code acceptance run inspected the project before installation, and a clean Codex run appended a newline while extracting the installed point recipe. Both behaviors correctly failed the 0.4.0 release gate.

Move the three exact setup commands to the start of the maintained prompt, require sequential standalone tool calls, and define the fenced recipe's final byte. The existing verifier remains the byte-level authority for both point scripts.

## Validation

- `python3 packages/skills/test/verify-release.test.py` — 27 passed
- `node --test packages/skills/test/*.test.mjs` — 95 passed
- `bun run lint`
- `bun run fmt`
- Independent spec/correctness review: pass
- Independent Ponytail review: pass

Part of #1025.

## 中文说明

干净的 Claude Code 验收在安装前先检查了项目目录；另一轮干净的 Codex 验收在提取已安装的单点 recipe 时附加了尾随换行。0.4.0 发布门禁正确拒绝了这两种行为。

本改动将三条准确的准备命令移到维护版 prompt 的开头，要求逐条串行执行，并明确 fenced recipe 的最后一个字节。现有 verifier 继续作为两个单点脚本的逐字节验收标准。

## 验证

- `python3 packages/skills/test/verify-release.test.py` — 27 项通过
- `node --test packages/skills/test/*.test.mjs` — 95 项通过
- `bun run lint`
- `bun run fmt`
- 独立 spec/correctness review：通过
- 独立 Ponytail review：通过

属于 #1025 的后续工作。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only release-verification prompt text and test expectations; no runtime install or API behavior.
> 
> **Overview**
> Tightens the **native-agent release acceptance prompt** so install/status/preview cannot be skipped or reordered by exploratory tool use.
> 
> The generated prompt now **opens with the three exact `npm exec` commands** (install, status, dry-run preview) and requires them as **three separate shell calls in order**, with no `Read`/`Grep`/other tools until all succeed and no command chaining or wrappers. Mid-body duplicate command lists are removed in favor of that upfront block.
> 
> **AgentX point recipe extraction** is spelled out: copy only the fenced `node --input-type=module` script through the closing `}}`, with **no trailing newline** after the final brace—matching the byte-level checks agents were failing in 0.4.0 gates.
> 
> Tests assert the new prompt shape for both **codex** and **claude** targets and pin the updated wording (sequential shells, recipe end byte).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8b5e62329096060de1f9faa40c373419920dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->