### PR TITLE
fix(skills): sequence native acceptance commands / 固定原生验收命令顺序

### DIFF
--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1091,6 +1091,10 @@ def prompt(args, target, archive):
 
 Make exactly one shell tool call at a time, and wait for it to finish successfully before issuing the next. Until all three finish, make no tool calls except the next required shell call; in particular, do not call Read, Glob, Grep, or Skill. Do not prefix, suffix, or combine the commands with `pwd`, `ls`, `cat`, `&&`, `;`, a pipe, or any other command.
 
+After those three calls, run every later shell call directly in the existing working directory. Every shell already starts in {project}; a shell call containing `cd` or a redirection to `/dev/null` fails acceptance even when `cd` names this exact project, so start each call with the actual operation and never prepend a project-root setup line.
+
+Perform HTTP-producing work strictly in this order: lookup; PowerX CSV; PowerX JSON; unavailable PowerX; diagnostic; AgentX CSV; AgentX JSON; excluded AgentX; traced point; no-trace point. Run each HTTP-producing operation only once. If one fails, stop and preserve the failure; do not retry it, delete its evidence, or replace its output.
+
 Use only the exact candidate archive and public HTTP data in this clean project.
 
 Before running any command, follow these acceptance boundaries:

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -1092,7 +1092,7 @@ JS
                 "The task's first two HTTP requests must be the captured OpenAPI request and captured benchmark request",
                 'only after both response captures and lookup.json exist may an exporter or diagnostic make an HTTP request',
                 'Do not make a preliminary, uncaptured, retry, or evidence-only repeat request',
-                'Perform HTTP-producing work strictly in this order: lookup; PowerX CSV; PowerX JSON; '
+                'Perform HTTP-producing work strictly in this order: lookup; PowerX CSV; PowerX JSON; ' +
                 'unavailable PowerX; diagnostic; AgentX CSV; AgentX JSON; excluded AgentX; traced point; no-trace point',
                 'Run each HTTP-producing operation only once',
                 'If one fails, stop and preserve the failure; do not retry it, delete its evidence, or replace its output',

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -1059,6 +1059,13 @@ JS
                     f'The installed skill must be exactly {target_project / install_root}/skills/inferencex-api.',
                     target_prompt,
                 )
+                direct_shell = (
+                    f'Every shell already starts in {target_project}; a shell call containing `cd` or a redirection '
+                    'to `/dev/null` fails acceptance even when `cd` names this exact project'
+                )
+                self.assertIn(direct_shell, target_prompt)
+                self.assertLess(target_prompt.index(direct_shell),
+                                target_prompt.index('Use only the exact candidate archive'))
 
         project = (self.root / 'prepared/codex').resolve()
         archive = project / 'candidate.tgz'
@@ -1085,6 +1092,10 @@ JS
                 "The task's first two HTTP requests must be the captured OpenAPI request and captured benchmark request",
                 'only after both response captures and lookup.json exist may an exporter or diagnostic make an HTTP request',
                 'Do not make a preliminary, uncaptured, retry, or evidence-only repeat request',
+                'Perform HTTP-producing work strictly in this order: lookup; PowerX CSV; PowerX JSON; '
+                'unavailable PowerX; diagnostic; AgentX CSV; AgentX JSON; excluded AgentX; traced point; no-trace point',
+                'Run each HTTP-producing operation only once',
+                'If one fails, stop and preserve the failure; do not retry it, delete its evidence, or replace its output',
                 'The lookup must make exactly two HTTP requests',
                 'fetch `/api/openapi.json` once and then the exact benchmark URL once',
                 'raw-responses/lookup-openapi.response.json',


### PR DESCRIPTION
## Summary

A clean Claude Code acceptance run produced machine-valid final artifacts but executed PowerX and the diagnostic before lookup, retried the diagnostic after deleting its first evidence, and prefixed later shell calls with redundant `cd` commands. The 0.4.0 candidate remained unpublished.

Place command discipline immediately after the three setup calls: use the existing working directory, never redirect to `/dev/null`, run HTTP-producing stages in the required order, and stop while preserving evidence if a stage fails.

## Validation

- `python3 packages/skills/test/verify-release.test.py` — 28 passed
- `bun run lint`
- `bun run fmt`
- Independent correctness and Ponytail reviews: pass

Part of #1025.

## 中文说明

一次干净的 Claude Code 验收生成了通过机器校验的最终产物，但实际先执行 PowerX 和诊断、后执行 lookup；在删除首次证据后重跑诊断，并在后续 shell 调用前重复添加 `cd`。0.4.0 候选包仍未发布。

本改动将命令纪律紧跟在三条 setup 命令之后：直接使用现有工作目录，不得重定向到 `/dev/null`，按规定顺序执行会产生 HTTP 请求的阶段，并在阶段失败时停止且保留证据。

## 验证

- `python3 packages/skills/test/verify-release.test.py` — 28 项通过
- `bun run lint`
- `bun run fmt`
- 独立 correctness 和 Ponytail review：通过

属于 #1025 的后续工作。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only acceptance prompt text and matching unit tests; no runtime verifier logic or release workflow behavior.
> 
> **Overview**
> Native agent acceptance prompts now spell out **command discipline immediately after** the three required install/status/preview shell calls, addressing runs that reordered HTTP work, retried diagnostics after deleting evidence, or prefixed shells with redundant `cd`.
> 
> Agents must run later shells **in the existing project cwd** (no `cd`, no `/dev/null` redirects). **HTTP-producing stages** must run once, in fixed order: lookup → PowerX (CSV, JSON, unavailable) → diagnostic → AgentX (CSV, JSON, excluded) → traced and no-trace points; failures must be **stopped and left intact**—no retries or evidence replacement.
> 
> Tests assert the new wording is present and that the direct-shell guidance appears **before** the archive-only boundary section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c66c1ce76c3741b0cfb037366492dcc4ce7c0103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->