### PR TITLE
[fix] harden skill exports and test Node 24/26 / 加固技能导出并验证 Node 24/26

### DIFF
--- a/.github/workflows/tests-skills.yml
+++ b/.github/workflows/tests-skills.yml
@@ -1,0 +1,39 @@
+name: 'Tests (Skills)'
+
+on:
+  pull_request:
+    branches: [main, master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.github/workflows/tests-skills.yml'
+      - '.github/workflows/publish-skills.yml'
+      - 'packages/skills/**'
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  packed-skills:
+    name: Packed skills (Node ${{ matrix.node-version }})
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 10
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['24', '26']
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          package-manager-cache: false
+      - name: Test the packed interfaces
+        run: node --test packages/skills/test/*.test.mjs

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -36,6 +36,10 @@ the trust relationship.
 
 ## Prepare and review a candidate
 
+The [`Tests (Skills)` workflow](../.github/workflows/tests-skills.yml) runs the packed-install
+suite on Node 24 and 26 for package and skill-workflow changes. That suite also runs the
+Python release-verifier tests. Publication remains on Node 24 with one publisher runtime.
+
 1. Modify the source, choose a new stable version, and update package metadata,
    both exporters' standalone versions, installation examples, and installed-version
    expectations together. Run the package tests and the relevant repository checks.

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -259,6 +259,14 @@ function benchmarkRow(row) {
     ['image', 'recipe_fingerprint', 'run_url'].every(
       (key) => row[key] === null || typeof row[key] === 'string',
     ) &&
+    ['workflow_run_id', 'curve_workflow_run_id'].every(
+      (key) =>
+        row[key] === undefined || typeof row[key] === 'string' || Number.isSafeInteger(row[key]),
+    ) &&
+    ['run_started_at', 'curve_run_started_at'].every(
+      (key) => row[key] === undefined || row[key] === null || typeof row[key] === 'string',
+    ) &&
+    (row.curve_date === undefined || validDate(row.curve_date)) &&
     object(row.metrics) &&
     validDate(row.date)
   );

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -98,9 +98,14 @@ function object(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function validDate(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/u.test(value)) return false;
+  const date = new Date(`${value}T00:00:00Z`);
+  return Number.isFinite(date.getTime()) && date.toISOString().slice(0, 10) === value;
+}
+
 function benchmarkRow(row) {
   if (!object(row) || !object(row.metrics)) return false;
-  const date = new Date(`${row.date}T00:00:00Z`);
   return (
     (Number.isSafeInteger(row.id) || (typeof row.id === 'string' && row.id.trim().length > 0)) &&
     [
@@ -129,9 +134,15 @@ function benchmarkRow(row) {
     ].every((key) => Number.isInteger(row[key])) &&
     ['isl', 'osl'].every((key) => row[key] === null || Number.isFinite(row[key])) &&
     ['image', 'run_url'].every((key) => row[key] === null || typeof row[key] === 'string') &&
-    /^\d{4}-\d{2}-\d{2}$/u.test(row.date) &&
-    Number.isFinite(date.getTime()) &&
-    date.toISOString().slice(0, 10) === row.date
+    validDate(row.date) &&
+    (row.curve_date === undefined || validDate(row.curve_date)) &&
+    ['workflow_run_id', 'curve_workflow_run_id'].every(
+      (key) =>
+        row[key] === undefined || typeof row[key] === 'string' || Number.isSafeInteger(row[key]),
+    ) &&
+    ['run_started_at', 'curve_run_started_at'].every(
+      (key) => row[key] === undefined || row[key] === null || typeof row[key] === 'string',
+    )
   );
 }
 
@@ -180,15 +191,8 @@ async function run(args = process.argv.slice(2)) {
   if (!values.model?.trim()) throw new Error('--model requires a display model name');
   const isl = positiveInteger(values.isl, 'isl');
   const osl = positiveInteger(values.osl, 'osl');
-  if (values.date !== undefined) {
-    const date = new Date(`${values.date}T00:00:00Z`);
-    if (
-      !/^\d{4}-\d{2}-\d{2}$/u.test(values.date) ||
-      !Number.isFinite(date.getTime()) ||
-      date.toISOString().slice(0, 10) !== values.date
-    ) {
-      throw new Error('--date must be a valid YYYY-MM-DD date');
-    }
+  if (values.date !== undefined && !validDate(values.date)) {
+    throw new Error('--date must be a valid YYYY-MM-DD date');
   }
   if (values['raw-model'] !== undefined && !values['raw-model'].trim()) {
     throw new Error('--raw-model requires a returned model key');
@@ -281,7 +285,7 @@ async function run(args = process.argv.slice(2)) {
 }
 
 async function exportPowerx(values, isl, osl, url, evidence) {
-  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000), redirect: 'error' });
   let capturedBody;
   if (evidence) {
     const captured = {

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -1266,3 +1266,126 @@ test('evidence, output, and stdout write failures never become complete', () => 
     assert.equal(captured(result).manifest.status, 'pending');
   }
 });
+
+test('optional provenance fields retain absence, null, and exact string IDs', () => {
+  const omitted = observation('1');
+  for (const key of [
+    'workflow_run_id',
+    'run_started_at',
+    'curve_date',
+    'curve_workflow_run_id',
+    'curve_run_started_at',
+  ])
+    delete omitted[key];
+  const rows = [
+    omitted,
+    observation('2', {
+      workflow_run_id: '9007199254740993',
+      run_started_at: null,
+      curve_workflow_run_id: '0002390',
+      curve_run_started_at: null,
+    }),
+  ];
+  const routes = routesFor(rows, [1, 2]);
+  const json = run(['--model', 'DeepSeek-V4-Pro', '--format', 'json'], routes);
+  succeeded(json);
+  assert.deepEqual(
+    JSON.parse(json.stdout).rows.map((row) => row.benchmark),
+    rows,
+  );
+  const csv = run(['--model', 'DeepSeek-V4-Pro'], routes);
+  succeeded(csv);
+  const parsed = csvRecords(csv.stdout).rows;
+  assert.equal(parsed[0].workflow_run_id, '');
+  assert.equal(parsed[0].curve_date, '');
+  assert.equal(parsed[1].workflow_run_id, '9007199254740993');
+  assert.equal(parsed[1].curve_workflow_run_id, '0002390');
+  assert.equal(parsed[1].run_started_at, '');
+  assert.equal(parsed[1].curve_run_started_at, '');
+});
+
+test('malformed optional provenance cannot become a successful export', () => {
+  const cases = [
+    ['workflow_run_id', { id: '2390' }],
+    ['workflow_run_id', Number.MAX_SAFE_INTEGER + 1],
+    ['curve_workflow_run_id', ['2390']],
+    ['curve_workflow_run_id', Number.MAX_SAFE_INTEGER + 1],
+    ['run_started_at', { timestamp: '2026-09-01 17:04:07+00' }],
+    ['curve_run_started_at', false],
+    ['curve_date', '2026-02-30'],
+  ];
+  for (const [field, value] of cases) {
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.csv'), 'keep previous export');
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--output', 'agentx.csv', '--evidence-dir', 'evidence'],
+      routesFor([observation('1', { [field]: value })], [1]),
+      cwd,
+    );
+    assert.equal(result.status, 1, `${field}=${JSON.stringify(value)} must fail`);
+    assert.match(result.stderr, /Unexpected benchmarks response shape/u);
+    assert.equal(result.stdout, '');
+    assert.equal(readFileSync(join(cwd, 'agentx.csv'), 'utf8'), 'keep previous export');
+    assert.equal(result.requests.length, 1, 'reject bad provenance before enrichment');
+    assert.equal(captured(result).manifest.status, 'failed');
+  }
+});
+
+test('later enrichment chunk failures cannot publish a partial export', () => {
+  const ids = Array.from({ length: 501 }, (_, index) => index + 1);
+  const rows = ids.map((id) => observation(String(id)));
+  const chunksByOperation = {
+    'agentic-aggregates': chunks(ids, 200),
+    'derived-agentic-metrics': chunks(ids, 200),
+    'trace-availability': chunks(ids, 500),
+  };
+  const entries = {
+    'agentic-aggregates': (id) => aggregate(id),
+    'derived-agentic-metrics': (id) => derived(id),
+    'trace-availability': () => true,
+  };
+  for (const failingOperation of Object.keys(chunksByOperation)) {
+    const routes = {
+      '/api/v1/benchmarks': [response(JSON.stringify(rows))],
+      ...Object.fromEntries(
+        Object.entries(chunksByOperation).map(([operation, groups]) => [
+          `/api/v1/${operation}`,
+          groups.map((group) => response(mapBody(group.map((id) => [id, entries[operation](id)])))),
+        ]),
+      ),
+    };
+    routes[`/api/v1/${failingOperation}`][1] = response('{"error":"second chunk failed"}', 503);
+    const cwd = project();
+    writeFileSync(join(cwd, 'agentx.json'), 'keep previous export');
+    const result = run(
+      [
+        '--model',
+        'DeepSeek-V4-Pro',
+        '--format',
+        'json',
+        '--output',
+        'agentx.json',
+        '--evidence-dir',
+        'evidence',
+      ],
+      routes,
+      cwd,
+    );
+    assert.equal(result.status, 1, failingOperation);
+    assert.match(result.stderr, /HTTP 503: second chunk failed/u);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'keep previous export');
+    assert.equal(result.stdout, '');
+    const { manifest, bodies } = captured(result);
+    assert.equal(manifest.status, 'failed');
+    assert.equal(manifest.responses.at(-1).operation, failingOperation);
+    assert.deepEqual(
+      manifest.responses.at(-1).requested_chunk_ids,
+      chunksByOperation[failingOperation][1],
+    );
+    assert.equal(manifest.responses.at(-2).operation, failingOperation);
+    assert.equal(manifest.responses.at(-2).http_status, 200);
+    assert.equal(bodies.size, manifest.responses.length);
+    assert.equal(manifest.export.sha256, null);
+    assert.deepEqual(manifest.export.source_request_numbers, []);
+  }
+});

--- a/packages/skills/test/export-powerx.test.mjs
+++ b/packages/skills/test/export-powerx.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
@@ -8,9 +9,12 @@ import {
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
+import { createServer } from 'node:http';
 import { join } from 'node:path';
+import process from 'node:process';
 import { before, test } from 'node:test';
 import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 import { packageInfo, packedSkillSuite, succeeded } from './packed-skill.mjs';
 
@@ -499,6 +503,44 @@ test('every malformed required field fails before scope filtering and leaves the
   }
 });
 
+test('optional provenance preserves exact IDs and rejects malformed values before selection', () => {
+  const row = observation({
+    workflow_run_id: '900719925474099312345',
+    curve_workflow_run_id: '0002390',
+    run_started_at: null,
+    curve_run_started_at: null,
+  });
+  const valid = run([...requiredArgs, '--format', 'json'], [row]);
+  succeeded(valid);
+  assert.deepEqual(JSON.parse(valid.stdout).rows, [row]);
+  for (const [field, value] of [
+    ['workflow_run_id', { id: '2390' }],
+    ['curve_workflow_run_id', []],
+    ['workflow_run_id', Number.MAX_SAFE_INTEGER + 1],
+    ['curve_workflow_run_id', Number.MAX_SAFE_INTEGER + 1],
+    ['run_started_at', {}],
+    ['curve_run_started_at', false],
+    ['curve_date', '2026-02-30'],
+  ]) {
+    for (const format of ['json', 'csv']) {
+      const cwd = project();
+      writeFileSync(join(cwd, 'existing'), 'keep this file');
+      const result = run(
+        [...requiredArgs, '--format', format, '--output', 'existing', '--evidence-dir', 'evidence'],
+        [observation({ isl: 7, [field]: value })],
+        { cwd },
+      );
+      assert.equal(result.status, 1, `${field}: ${format}`);
+      assert.match(result.stderr, /response shape/u);
+      assert.equal(readFileSync(join(cwd, 'existing'), 'utf8'), 'keep this file');
+      const manifest = JSON.parse(readFileSync(join(cwd, 'evidence/manifest.json'), 'utf8'));
+      assert.equal(manifest.status, 'failed');
+      assert.equal(manifest.export.sha256, null);
+      assert.equal(result.requests.length, 1);
+    }
+  }
+});
+
 test('HTTP, malformed JSON and unexpected shapes fail without replacing an existing output', () => {
   const failures = [
     { status: 400, body: '{"error":"Unknown model"}', error: /HTTP 400.*Unknown model/ },
@@ -527,6 +569,72 @@ test('HTTP, malformed JSON and unexpected shapes fail without replacing an exist
     assert.doesNotMatch(result.stderr, /\{"metadata":|Selected \d+/);
     assert.equal(readFileSync(join(cwd, 'existing.json'), 'utf8'), 'keep this file');
     assert.deepEqual(readdirSync(cwd), ['existing.json']);
+  }
+});
+
+test('native fetch rejects redirects without attributing another response to the requested URL', async () => {
+  const requests = [];
+  const server = createServer((request, response) => {
+    requests.push(request.url);
+    if (request.url.startsWith('/api/v1/benchmarks?')) {
+      response.writeHead(302, { Location: '/different-scope' });
+      response.end();
+    } else {
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(JSON.stringify([observation()]));
+    }
+  });
+  await new Promise((resolveListen, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const cwd = project();
+  const nativePreload = join(cwd, 'native-fetch.mjs');
+  writeFileSync(
+    nativePreload,
+    `
+const nativeFetch = globalThis.fetch;
+globalThis.fetch = (input, options) => {
+  const url = new URL(input);
+  return nativeFetch(new URL(url.pathname + url.search, 'http://127.0.0.1:${server.address().port}'), options);
+};
+`,
+  );
+  try {
+    for (const evidence of [false, true]) {
+      requests.length = 0;
+      writeFileSync(join(cwd, 'existing.json'), 'preserve existing output');
+      await assert.rejects(
+        promisify(execFile)(
+          process.execPath,
+          [
+            '--import',
+            pathToFileURL(nativePreload).href,
+            exporter,
+            ...requiredArgs,
+            '--format',
+            'json',
+            '--output',
+            'existing.json',
+            ...(evidence ? ['--evidence-dir', 'evidence'] : []),
+          ],
+          { cwd, env: environment, timeout: 10_000 },
+        ),
+        { code: 1 },
+      );
+      assert.deepEqual(requests, ['/api/v1/benchmarks?model=GLM-5&powerValid=strictV2']);
+      assert.equal(readFileSync(join(cwd, 'existing.json'), 'utf8'), 'preserve existing output');
+      if (evidence) {
+        const manifest = JSON.parse(readFileSync(join(cwd, 'evidence/manifest.json'), 'utf8'));
+        assert.equal(manifest.status, 'failed');
+        assert.equal(manifest.response, null);
+        assert.equal(manifest.export.sha256, null);
+      }
+    }
+  } finally {
+    await new Promise((resolveClose, reject) => {
+      server.close((error) => (error ? reject(error) : resolveClose()));
+    });
   }
 });
 


### PR DESCRIPTION
Malformed optional provenance could be exported as valid data, and PowerX followed redirects while attributing the response to the original request URL. Validate provenance before selection, reject redirects, and preserve existing output plus failure evidence.

Add a focused Node 24/26 package-test matrix. Trusted publication remains on Node 24.

Testing: packed-package tests pass on both Node versions (100 each); Python verifier tests pass (28). Repository lint, format, typecheck, typography, 5,774 non-package unit tests and 159 Cypress smoke tests passed. Regression coverage includes later enrichment-chunk failures and exact string IDs. The candidate remains unpublished; native CLI release acceptance is still required.

## 中文说明

此前，可选溯源字段格式错误时仍可能作为有效数据导出；PowerX 还会跟随重定向，却将响应归因于原始请求 URL。本次在筛选前校验溯源字段、拒绝重定向，并保留原有输出和失败证据。

新增 Node 24/26 包测试矩阵，trusted publication 继续使用 Node 24。

验证：两个 Node 版本各通过 100 项包测试，Python 发布验证器通过 28 项测试。仓库 lint、format、typecheck、typography、5,774 项非包单元测试及 159 项 Cypress smoke 测试均通过。回归测试覆盖后续 enrichment 分批请求失败及字符串 ID 的原样保留。候选包尚未发布，仍需完成原生 CLI 发布验收。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live export scripts that validate API responses and fetch behavior; mistakes could block valid exports or change failure semantics, though behavior is heavily covered by new tests.
> 
> **Overview**
> **Hardens AgentX and PowerX exporters** so malformed optional provenance (`workflow_run_id`, run/curve timestamps and dates) fails during response-shape validation before row selection or enrichment, while absent/null values and exact string workflow IDs still export correctly. PowerX now uses shared `validDate` checks and **`fetch` with `redirect: 'error'`** so redirects cannot be treated as the originally requested benchmarks URL.
> 
> **Adds PR CI** via `Tests (Skills)`: packed-interface tests (`node --test packages/skills/test/*.test.mjs`) on Node **24** and **26** when `packages/skills/**` or related workflows change; release docs note that publication stays on Node 24.
> 
> **Regression tests** cover bad provenance, redirect rejection (native fetch), and AgentX cases where a later enrichment chunk fails without overwriting an existing export or publishing partial output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f44c77fe1f88f67de5a6db4d633303c569fff7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->