### PR TITLE
[fix] use the latest supported Node releases for skills / 技能流程使用最新受支持 Node 版本

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          check-latest: true
           package-manager-cache: false
       - name: Check the npm OIDC runtime
         run: |

--- a/.github/workflows/tests-skills.yml
+++ b/.github/workflows/tests-skills.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: true
           package-manager-cache: false
       - name: Test the packed interfaces
         run: node --test packages/skills/test/*.test.mjs


### PR DESCRIPTION
The Node 24 package job resolved to cached 24.13.0. Enable `setup-node`’s `check-latest` for the Node 24/26 package matrix and Node 24 publisher so both resolve the latest matching release before using the cache.

Validation: workflow formatting and pre-commit checks passed. Package bytes are unchanged; CI verifies the resolved runtimes with all 100 packed-package tests.

## 中文说明

Node 24 包测试任务实际选中了缓存中的 24.13.0。本次为 Node 24/26 包测试矩阵和 Node 24 发布流程启用 `check-latest`，先解析对应主版本的最新发行版，再使用缓存。

验证：工作流格式和 pre-commit 检查通过。包内容未变，CI 会在实际解析出的运行时上执行全部 100 项包测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input change with no application code, package contents, or publishing logic modified.
> 
> **Overview**
> Skills CI and publish jobs were pinning Node via `setup-node` without refreshing to the newest patch within the requested major line (e.g. Node 24 stuck on cached **24.13.0**).
> 
> This PR sets **`check-latest: true`** on `actions/setup-node` in **`tests-skills.yml`** (matrix **24** and **26**) and **`publish-skills.yml`** (Node **24** publisher), so runners resolve the latest matching release before applying the package-manager cache. **Packed skill artifacts and test commands are unchanged**—only which Node/npm patch versions run the existing `node --test` and publish steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d16b8d0ec9264592a1a36f775a68b751583d45d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->