### PR TITLE
[docs] activate skills 0.4.0 on API pages / 在 API 页面启用 skills 0.4.0

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -1,6 +1,6 @@
 # InferenceX API skill examples
 
-Use the public `@semianalysisai/inferencex-skills@0.3.0` package to query existing
+Use the public `@semianalysisai/inferencex-skills@0.4.0` package to query existing
 observations; these requests do not run new benchmarks. The skill covers the
 public API, with single-turn PowerX export as its first worked example. Read the
 [current API contract](https://inferencex.semianalysis.com/api/openapi.json) before
@@ -12,10 +12,10 @@ With Node 24 or later and npm, run the command for your agent from your project:
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.4.0 -- inferencex-skills install --target claude
 ```
 
 Start an agent session in that project. Queries need public HTTPS access, with no

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -1,7 +1,7 @@
 # Releasing the InferenceX API skill
 
 The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0`,
-`0.2.0`, and `0.3.0` are immutable public releases. Keep website commands pinned
+`0.2.0`, `0.3.0`, and `0.4.0` are immutable public releases. Keep website commands pinned
 to the last verified public version until publication and public verification
 succeed. The
 [`publish-skills.yml`](../.github/workflows/publish-skills.yml) workflow prepares

--- a/packages/app/cypress/e2e/api-documentation.cy.ts
+++ b/packages/app/cypress/e2e/api-documentation.cy.ts
@@ -1,8 +1,8 @@
 import type { BenchmarkRow } from '@semianalysisai/inferencex-db/queries/benchmarks';
+// The website advertises the verified public release, which can lag the source candidate.
+import PUBLISHED_SKILL from '../../src/lib/published-inferencex-skills.json';
 
 const SITE_URL = 'https://inferencex.semianalysis.com';
-// The website advertises the verified public release, which can lag the source candidate.
-const PUBLISHED_SKILL = { name: '@semianalysisai/inferencex-skills', version: '0.3.0' };
 
 describe('API documentation', () => {
   for (const locale of [

--- a/packages/app/src/components/api-documentation/api-reference-page.tsx
+++ b/packages/app/src/components/api-documentation/api-reference-page.tsx
@@ -5,6 +5,7 @@ import { JsonLd } from '@/components/json-ld';
 import { ApiAgentExamplesLink } from './api-agent-examples-link';
 import { getApiDocumentation, type ApiDocumentationLocale } from '@/lib/api-documentation';
 import { ZH_LANG_TAG } from '@/lib/i18n';
+import PUBLISHED_SKILL from '@/lib/published-inferencex-skills.json';
 import { AUTHOR_NAME, AUTHOR_URL, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
 const UI_COPY = {
@@ -24,7 +25,7 @@ const UI_COPY = {
     agentSkill: 'Use the API with your agent',
     agentSkillDescription:
       'The inferencex-api skill helps your agent navigate the public API: benchmarks, provenance, datasets, CollectiveX, and diagnostics. Validated single-turn PowerX export is the first worked example.',
-    agentVersion: 'Skill version · 0.3.0',
+    agentVersion: `Skill version · ${PUBLISHED_SKILL.version}`,
     agentPrerequisites:
       'Requires Node 24 or later with npm and Codex or Claude Code. Installation and API queries require internet access.',
     agentInstall: 'Install in your project',
@@ -101,7 +102,7 @@ const UI_COPY = {
     agentSkill: '通过智能体使用 API',
     agentSkillDescription:
       'inferencex-api 技能帮助智能体查找和使用公开 API，涵盖基准测试、溯源、数据集、CollectiveX 和诊断接口。已验证的单轮请求 PowerX 导出是首个完整示例。',
-    agentVersion: '技能版本 · 0.3.0',
+    agentVersion: `技能版本 · ${PUBLISHED_SKILL.version}`,
     agentPrerequisites:
       '需要 Node 24 或更新版本、npm，以及 Codex 或 Claude Code。安装和 API 查询均需联网。',
     agentInstall: '安装到项目',
@@ -332,7 +333,7 @@ export function ApiReferencePage({ locale }: { locale: ApiDocumentationLocale })
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 {copy.agentSkillDescription}
               </p>
-              <p className="mt-3 break-all font-mono text-xs">@semianalysisai/inferencex-skills</p>
+              <p className="mt-3 break-all font-mono text-xs">{PUBLISHED_SKILL.name}</p>
               <p className="mt-2 text-sm leading-6 text-muted-foreground">
                 {copy.agentPrerequisites}
               </p>
@@ -350,7 +351,7 @@ export function ApiReferencePage({ locale }: { locale: ApiDocumentationLocale })
                     locale={locale}
                     label={target === 'codex' ? 'Codex' : 'Claude Code'}
                   >
-                    {`npm exec --yes --package @semianalysisai/inferencex-skills@0.3.0 -- inferencex-skills install --target ${target}`}
+                    {`npm exec --yes --package ${PUBLISHED_SKILL.name}@${PUBLISHED_SKILL.version} -- inferencex-skills install --target ${target}`}
                   </CopyableCodeBlock>
                 </div>
               ))}

--- a/packages/app/src/lib/published-inferencex-skills.json
+++ b/packages/app/src/lib/published-inferencex-skills.json
@@ -1,0 +1,4 @@
+{
+  "name": "@semianalysisai/inferencex-skills",
+  "version": "0.4.0"
+}


### PR DESCRIPTION
The API pages still advertise 0.3.0 after the verified 0.4.0 release. Read one published-version manifest for the English/Chinese badges, Codex/Claude installation commands, and their browser assertions. Update the linked usage guide's three installation references to the same public release.

Activation evidence: [npm 0.4.0](https://www.npmjs.com/package/@semianalysisai/inferencex-skills/v/0.4.0), [successful publication and anonymous verification](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34021086120). The accepted, CI-repacked, and public archives have SHA-256 `2f0915fd3b935ef1decd618955f5415d71751df3ffc4c32963ee26b38f533ffe`; `npm audit signatures` verified the registry signature and provenance attestation.

Validation: lint, format, typography, typecheck; 5,774 repository unit tests and 100 package tests; 159 Cypress smoke tests and 6 API-page tests covering both locales, exact clipboard commands, and mobile layout. Native Claude Chinese-copy advisory found no fidelity or naturalness issues. Chinese badge wording is unchanged apart from the explicitly requested version update; source and desktop/mobile displays were rechecked. Package content is unchanged.

## 中文说明

0.4.0 已发布并完成公开验证，API 页面仍展示 0.3.0。本次让中英文版本徽标、Codex/Claude 安装命令和浏览器测试共用一份已发布版本信息，并将链接到的使用示例中的三处安装版本同步为 0.4.0。

上方 npm 链接和发布 workflow 记录了激活依据。已验收包、CI 重新打包产物和公开下载包的 SHA-256 完全一致，npm 签名及 provenance 也已验证。

验证通过：lint、格式、字体规范、类型检查，5,774 项仓库单元测试、100 项包测试、159 项 Cypress smoke 测试及 6 项 API 页面测试。专项测试覆盖两个语言版本、复制命令和移动端布局。原生 Claude 中文专项复核未发现语义或自然度问题。中文徽标仅按本次发布要求更新版本号，已复核源码及桌面、移动端显示；本次未修改包内容。
