### PR TITLE
fix(calculator): hide disagg throughput caveat on Total token type

### DIFF
--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -555,20 +555,36 @@ describe('TCO Calculator', () => {
     // Metric-specific disclaimers (fresh visit to reset accumulated state)
     // -------------------------------------------------------------------------
 
-    it('shows disaggregated throughput disclaimer for throughput metric', () => {
+    // A disagg config's input/output throughput is reported per prefill or per
+    // decode chip — divided by fewer chips, it reads high on those token types.
+    // The total-token throughput divides by the whole chip count — the same
+    // denominator an aggregated config uses, and the note's own text says as
+    // much ("Total throughput is unaffected") — so it must not carry the
+    // caveat. This mirrors the cost-note test below and PR #862 on the inference
+    // chart.
+    it('shows the disaggregated throughput disclaimer only for per-token-type throughput', () => {
       cy.visit('/calculator');
       cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length.greaterThan', 0);
-      cy.get('[data-testid="calculator-chart-section"]').should(
-        'contain.text',
-        'Disaggregated inference configurations',
-      );
-      cy.get('[data-testid="calculator-chart-section"]')
-        // The direction is the point of the warning, not the phrasing: on these
-        // token types a disaggregated config reads high. Asserting the old wording
-        // alone let the note be reworded into something that no longer said which
-        // way it was wrong.
-        .should('contain.text', 'per prefill chip and per decode chip')
-        .and('contain.text', 'reads faster per chip than it is');
+
+      // Token type defaults to Total Tokens.
+      cy.get('[data-testid="calculator-disagg-throughput-note"]').should('not.be.visible');
+
+      for (const tokenType of ['Output Tokens', 'Input Tokens']) {
+        cy.get('[data-testid="calc-cost-type-selector"]').click();
+        cy.contains('[role="option"]', tokenType).click();
+        cy.get('body').type('{esc}');
+        cy.get('[data-testid="calculator-disagg-throughput-note"]')
+          .should('be.visible')
+          .and('contain.text', 'per prefill chip and per decode chip')
+          // Faster, specifically — the flattering direction is what a reader
+          // comparing throughput needs told.
+          .and('contain.text', 'reads faster per chip than it is');
+      }
+
+      cy.get('[data-testid="calc-cost-type-selector"]').click();
+      cy.contains('[role="option"]', 'Total Tokens').click();
+      cy.get('body').type('{esc}');
+      cy.get('[data-testid="calculator-disagg-throughput-note"]').should('not.be.visible');
     });
 
     // A disagg config's input/output cost is attributed to only its prefill or
@@ -601,15 +617,31 @@ describe('TCO Calculator', () => {
       cy.get('[data-testid="calculator-disagg-cost-note"]').should('not.be.visible');
     });
 
-    it('shows disaggregated throughput disclaimer for power metric', () => {
+    // The tok/s/MW (power) metric inherits the same per-token-type split as
+    // throughput: total tok/s/MW is per chip overall and needs no caveat, while
+    // the input/output token types do.
+    it('shows the disaggregated throughput disclaimer only for per-token-type power', () => {
+      cy.visit('/calculator');
+      cy.get('[data-testid="calculator-bar-chart"] svg .bar').should('have.length.greaterThan', 0);
       cy.get('[data-testid="calculator-metric-power"]').click();
-      cy.get('[data-testid="calculator-chart-section"]')
-        // The direction is the point of the warning, not the phrasing: on these
-        // token types a disaggregated config reads high. Asserting the old wording
-        // alone let the note be reworded into something that no longer said which
-        // way it was wrong.
-        .should('contain.text', 'per prefill chip and per decode chip')
-        .and('contain.text', 'reads faster per chip than it is');
+
+      // Token type defaults to Total Tokens.
+      cy.get('[data-testid="calculator-disagg-throughput-note"]').should('not.be.visible');
+
+      for (const tokenType of ['Output Tokens', 'Input Tokens']) {
+        cy.get('[data-testid="calc-cost-type-selector"]').click();
+        cy.contains('[role="option"]', tokenType).click();
+        cy.get('body').type('{esc}');
+        cy.get('[data-testid="calculator-disagg-throughput-note"]')
+          .should('be.visible')
+          .and('contain.text', 'per prefill chip and per decode chip')
+          .and('contain.text', 'reads faster per chip than it is');
+      }
+
+      cy.get('[data-testid="calc-cost-type-selector"]').click();
+      cy.contains('[role="option"]', 'Total Tokens').click();
+      cy.get('body').type('{esc}');
+      cy.get('[data-testid="calculator-disagg-throughput-note"]').should('not.be.visible');
     });
   });
 

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -1306,11 +1306,15 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                             </p>
                           </>
                         )}
-                        {/* Per-token-type cost only: the input- and output-token
-                          costs are attributed to one side of a disagg config's
-                          prefill/decode split, while the total-token cost uses
+                        {/* Per-token-type only: the input- and output-token
+                          figures are attributed to one side of a disagg config's
+                          prefill/decode split, while the total-token figure uses
                           the whole chip count — the same denominator an
-                          aggregated config uses — so it needs no caveat. */}
+                          aggregated config uses — so it needs no caveat. This
+                          mirrors the cost note's `costType !== 'total'` gate and
+                          the inference chart's total tok/s/MW split (PR #862); the
+                          throughput note's own text says as much: "Total throughput
+                          is unaffected: both kinds report it per chip overall." */}
                         <div
                           className={`overflow-hidden transition-all duration-200 ease-in-out ${
                             barMetric === 'cost' && costType !== 'total'
@@ -1328,12 +1332,16 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                         </div>
                         <div
                           className={`overflow-hidden transition-all duration-200 ease-in-out ${
-                            barMetric === 'throughput' || barMetric === 'power'
+                            (barMetric === 'throughput' || barMetric === 'power') &&
+                            costType !== 'total'
                               ? 'max-h-20 opacity-100'
                               : 'max-h-0 opacity-0'
                           }`}
                         >
-                          <p className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1">
+                          <p
+                            data-testid="calculator-disagg-throughput-note"
+                            className="text-muted-foreground text-xs mt-2 border-l-2 border-amber-500 pl-2 bg-amber-500/5 py-1"
+                          >
                             <strong>{t.note}</strong>
                             {t.disaggThroughput}
                           </p>


### PR DESCRIPTION
## Problem

The disaggregated-throughput disclaimer in the TCO calculator was shown whenever the **throughput** or **tok/s/MW (power)** metric was selected, regardless of the selected token type:

> Note: Disaggregated inference configurations (e.g., MoRI SGLang, Dynamo TRTLLM) report input and output throughput per prefill chip and per decode chip rather than per chip overall — divided by fewer chips, so on the Input and Output token types a disaggregated config reads faster per chip than it is … Total throughput is unaffected: both kinds report it per chip overall.

So it appeared even when **Total Tokens** was selected, even though the note's own text says total throughput is unaffected.

## Why it's wrong

A disaggregated run only skews the **per-token-type** (Input/Output) figures — those are reported per prefill or per decode chip, so they read high. The **Total** figure divides by the whole chip count, the same denominator an aggregated config uses, so the caveat does not apply.

This is the exact split the cost note a few lines above already makes (`barMetric === 'cost' && costType !== 'total'`), and the same split PR #862 made on the inference chart for total tok/s/MW. The throughput note was the lone holdout: it gated on `barMetric` alone and ignored `costType`.

## Fix

Gate the throughput/power disclaimer by `costType !== 'total'`, mirroring the cost note:

```diff
- barMetric === 'throughput' || barMetric === 'power'
+ (barMetric === 'throughput' || barMetric === 'power') && costType !== 'total'
```

Also adds a `calculator-disagg-throughput-note` `data-testid` to the throughput note so the behavior is testable on equal footing with the cost note.

## Tests

Updated the Cypress `throughput-calculator` suite so the throughput and power disclaimers are now asserted hidden on Total Tokens and visible only on Input/Output — mirroring the existing cost-note test structure (Total hidden, then loop Input/Output expecting visible, then back to Total expecting hidden).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only disclaimer gating and e2e assertions; no calculation or API changes.
> 
> **Overview**
> Fixes misleading UX in the TCO calculator: the **disaggregated throughput** amber note no longer appears when **Total Tokens** is selected on **Throughput** or **tok/s/MW (power)** metrics.
> 
> Visibility now matches the existing cost disclaimer—only **Input** and **Output** token types show the caveat, because per-type figures use prefill/decode chip denominators while totals use full chip count (as the note text already states). The throughput note also gets `data-testid="calculator-disagg-throughput-note"` for Cypress.
> 
> **Tests** rewrite the throughput and power disclaimer specs to assert hidden on Total, visible on Input/Output with the expected warning copy, then hidden again after switching back—parallel to the cost-note test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3540791db5f16b0f2a36e81cc8e756b84aa7424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->