### PR TITLE
[fix] validate retained AgentX response text / 修复 AgentX 响应原文验收

### DIFF
--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -457,15 +457,17 @@ def strict_json(body):
     return json.loads(body.decode('utf-8-sig'), parse_constant=reject)
 
 
-def same_json(actual, expected):
+def same_json(actual, expected, *, javascript_numbers=False):
     if finite(actual) and finite(expected):
-        return actual == expected
+        return float(actual) == float(expected) if javascript_numbers else actual == expected
     if type(actual) is not type(expected):
         return False
     if type(actual) is dict:
-        return actual.keys() == expected.keys() and all(same_json(actual[key], expected[key]) for key in actual)
+        return actual.keys() == expected.keys() and all(
+            same_json(actual[key], expected[key], javascript_numbers=javascript_numbers) for key in actual)
     if type(actual) is list:
-        return len(actual) == len(expected) and all(same_json(a, b) for a, b in zip(actual, expected))
+        return len(actual) == len(expected) and all(
+            same_json(a, b, javascript_numbers=javascript_numbers) for a, b in zip(actual, expected))
     return actual == expected
 
 
@@ -877,6 +879,16 @@ def point_response(evidence, record, number, operation, expected_url):
     return strict_json(body)
 
 
+def point_request(request, response, evidence):
+    require(type(request) is dict and set(request) == {'query_url', 'retrieved_at', 'body_utf8'} and
+            same_url(request['query_url'], response['url']),
+            'Point output request identity differs from its capture')
+    require(type(request['body_utf8']) is str and
+            request['body_utf8'].encode('utf-8') == (evidence / response['body_file']).read_bytes(),
+            'Point output raw response text differs from its capture')
+    return timestamp(request['retrieved_at'], 'Point request time is invalid')
+
+
 def check_point_shapes(selected_id, timeline, histograms, server_metrics):
     require(type(timeline) is dict and integer(timeline.get('version')) and integer(timeline.get('startNs')) and
             integer(timeline.get('endNs')) and finite(timeline.get('durationS')) and
@@ -993,16 +1005,15 @@ def check_agentx_point(project, name, output, selected_id, version):
     completed = timestamp(metadata['retrieved_at'], 'Point diagnostic retrieval time is invalid')
     request_times = []
     for request, response in zip(metadata['requests'], responses):
-        request_time = timestamp(request.get('retrieved_at'), 'Point request time is invalid') \
-            if type(request) is dict else None
-        require(type(request) is dict and set(request) == {'query_url', 'retrieved_at'} and
-                same_url(request['query_url'], response['url']) and request_time is not None and
-                request['retrieved_at'] == response['retrieved_at'],
+        request_time = point_request(request, response, evidence)
+        require(request['retrieved_at'] == response['retrieved_at'],
                 'Point output is not linked to its captured request')
         request_times.append(request_time)
     ordered_times = [started, *request_times, completed, finished]
     require(ordered_times == sorted(ordered_times), 'Point evidence timestamps are not chronological')
-    require(same_json(document['benchmark_siblings'], siblings) and same_json(document['selected_point'], selected) and
+    # Exact source integers are pinned by body_utf8 above; the parsed views use JavaScript Number.
+    require(same_json(document['benchmark_siblings'], siblings, javascript_numbers=True) and
+            same_json(document['selected_point'], selected, javascript_numbers=True) and
             same_json(document['trace_availability'], {'response': availability,
                                                        'key_present': selected_id in availability,
                                                        'available': trace_available}),
@@ -1010,8 +1021,10 @@ def check_agentx_point(project, name, output, selected_id, version):
     if trace_available:
         timeline, histograms, server_metrics = bodies[3:]
         check_point_shapes(selected_id, timeline, histograms, server_metrics)
-        require(document['outcome'] == 'trace_diagnostics' and same_json(document['timeline'], timeline) and
-                same_json(document['histograms'], histograms) and same_json(document['server_metrics'], server_metrics),
+        require(document['outcome'] == 'trace_diagnostics' and
+                same_json(document['timeline'], timeline, javascript_numbers=True) and
+                same_json(document['histograms'], histograms, javascript_numbers=True) and
+                same_json(document['server_metrics'], server_metrics, javascript_numbers=True),
                 'Trace diagnostic differs from complete responses')
     else:
         require(document['outcome'] == 'trace_unavailable' and
@@ -1055,10 +1068,7 @@ def run_point(node, installed, project, environment, label, selected_id, version
     require(type(requests) is list and len(requests) == len(capture['responses']),
             'Point output request list differs from its capture')
     for request, response in zip(requests, capture['responses']):
-        require(type(request) is dict and set(request) == {'query_url', 'retrieved_at'} and
-                same_url(request['query_url'], response['url']),
-                'Point output request identity differs from its capture')
-        timestamp(request['retrieved_at'], 'Point request time is invalid')
+        point_request(request, response, evidence)
         response['retrieved_at'] = request['retrieved_at']
     capture['status'] = 'complete'
     capture['finished_at'] = now()
@@ -1120,7 +1130,7 @@ For {args.agentx_model} using the latest public observations, export AgentX summ
 
 Run the installed one-point recipe as written for both points. Extract it exactly from {installed / 'references/agentx.md'} into agentx-point-recipe.mjs for result ID {args.agentx_point_id} and agentx-second-point-recipe.mjs for result ID {args.agentx_no_trace_id}. Extract only the bytes after the `node --input-type=module <<'JS'` line through the final `}}` before the `JS` delimiter; the file must end at that final `}}` byte with no trailing newline or other byte. Do not create an outside-project scratch copy while extracting or comparing the recipe files. In each file, change only the exact `const selectedResultId = '421';` line to its requested ID; every other recipe byte must remain identical. Run each recipe with a separate Node `--import` capture preload, and redirect that recipe process's stdout directly to agentx-point.json or agentx-second-point.json. The recipe files must not write their output or evidence, replace `response.json()`, replace `console.log()`, or contain capture logic. Do not reimplement the request flow or reconstruct the JSON output. Do not expand either selection to sibling IDs or make bulk diagnostic reads. For each run, transparently clone the same public fetch responses consumed by the recipe into agentx-point-evidence or agentx-second-point-evidence. Keep the full OpenAPI, sibling, availability, and any recipe-requested diagnostic response bodies; a later request to the same URL is not evidence for the recipe output.
 
-Build `metadata.requests` only after that run's final fetch has completed, with one item containing exactly `query_url` and `retrieved_at` for every manifest response in identical order (six for a traced run and three for a no-trace run); each `query_url` must match the corresponding manifest response `url`, and each manifest response `retrieved_at` must equal the recipe output's corresponding `metadata.requests` value byte-for-byte. Keep the manifest pending until the redirected recipe output exists, then finalize it using those recipe-owned request times rather than a parallel capture timestamp.
+Read the recipe-owned `metadata.requests` only after that run's final fetch has completed. Each item contains exactly `query_url`, `retrieved_at`, and `body_utf8` for every manifest response in identical order (six for a traced run and three for a no-trace run); each `query_url` must match the corresponding manifest response `url`, and each manifest response `retrieved_at` must equal the recipe output's corresponding `metadata.requests` value byte-for-byte. Preserve `body_utf8` exactly: its UTF-8 bytes must equal the captured response file, including large-integer digits and whitespace. Do not rebuild it from parsed JSON. Keep the manifest pending until the redirected recipe output exists, then finalize it using those recipe-owned request times rather than a parallel capture timestamp.
 
 Each point evidence directory must contain manifest.json with exactly these top-level fields: `schema_version`, `package_version`, `selected_result_id`, `status`, `started_at`, `finished_at`, `responses`, `output`, and `error`. Start capture with schema_version 1, the exact package version and selected ID, `status: "pending"`, `finished_at: null`, and `error: null`. The final manifest is accepted only with `status: "complete"` and `error: null`; set finished_at only after the output is complete. Do not add or rename fields, and never relabel a failed or incomplete run as complete.
 

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -606,7 +606,8 @@ class AgentXVerifierTests(unittest.TestCase):
                             'decoded_body_sha256': hashlib.sha256(body_bytes).hexdigest(), 'body_file': filename,
                             'checksum_covers': 'saved decoded response body'})
         output = self.root / f'{name}.json'
-        requests = [{'query_url': record['url'], 'retrieved_at': record['retrieved_at']}
+        requests = [{'query_url': record['url'], 'retrieved_at': record['retrieved_at'],
+                     'body_utf8': (evidence / record['body_file']).read_text()}
                     for record in records]
         document = {
             'schema_version': 1,
@@ -747,6 +748,9 @@ class AgentXVerifierTests(unittest.TestCase):
         timeline['version'] = True
         timeline_path.write_text(json.dumps(timeline))
         timeline_record['decoded_body_sha256'] = hashlib.sha256(timeline_path.read_bytes()).hexdigest()
+        document['metadata']['requests'][3]['body_utf8'] = timeline_path.read_text()
+        check.save(output, document)
+        manifest['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
         check.save(evidence / 'manifest.json', manifest)
         with self.assertRaisesRegex(ValueError, 'timeline'):
             check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
@@ -852,6 +856,83 @@ JS
             [response['retrieved_at'] for response in manifest['responses']],
             [request['retrieved_at'] for request in document['metadata']['requests']],
         )
+
+    def run_shipped_point(self, *, trace):
+        source_evidence, _output, source_manifest, _document = self.write_point(trace=trace)
+        fixtures = {}
+        for response in source_manifest['responses']:
+            body = (source_evidence / response['body_file']).read_text()
+            if response['operation'] == 'benchmark-siblings':
+                body = body.replace('"sku":{', '"sku":{"recorded_ns":9007199254740993,')
+            elif response['operation'] == 'request-timeline':
+                body = body.replace('"startNs":0', '"startNs":1000000000000000128')
+            fixtures[response['url']] = body
+        preload = self.root / f'fixture-{self.fixture_index}.mjs'
+        preload.write_text(f"""const bodies = {json.dumps(fixtures)};
+globalThis.fetch = async (input) => {{
+  const url = input instanceof Request ? input.url : String(input);
+  if (!Object.hasOwn(bodies, url)) throw new Error(`Unexpected fixture request: ${{url}}`);
+  const response = new Response(bodies[url], {{ status: 200 }});
+  Object.defineProperty(response, 'url', {{ value: url }});
+  return response;
+}};
+""")
+        installed = Path(__file__).resolve().parents[1] / 'skills/inferencex-api'
+        environment = dict(check.os.environ, NODE_OPTIONS=f'--import={preload.as_uri()}')
+        label = f'shipped-point-{self.fixture_index}'
+        outcome = check.run_point(check.shutil.which('node'), installed, self.root,
+                                  environment, label, '7', VERSION)
+        evidence, output = self.root / f'{label}-evidence', self.root / f'{label}.json'
+        return outcome, evidence, output, json.loads((evidence / 'manifest.json').read_text())
+
+    def test_shipped_point_recipe_preserves_exact_text_despite_javascript_number_rounding(self):
+        for trace in [False, True]:
+            with self.subTest(trace=trace):
+                outcome, evidence, output, capture = self.run_shipped_point(trace=trace)
+                self.assertEqual(outcome, 'trace_diagnostics' if trace else 'trace_unavailable')
+                self.assertEqual(check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION), outcome)
+                document = json.loads(output.read_text())
+                for request, response in zip(document['metadata']['requests'], capture['responses']):
+                    self.assertEqual(set(request), {'query_url', 'retrieved_at', 'body_utf8'})
+                    self.assertEqual(request['body_utf8'].encode(), (evidence / response['body_file']).read_bytes())
+                self.assertIn('9007199254740993', document['metadata']['requests'][1]['body_utf8'])
+                self.assertEqual(document['benchmark_siblings']['sku']['recorded_ns'], 9007199254740992)
+                if trace:
+                    self.assertIn('1000000000000000128', document['metadata']['requests'][3]['body_utf8'])
+                    self.assertEqual(document['timeline']['startNs'], 1000000000000000100)
+
+    def test_point_verifiers_reject_missing_or_changed_recipe_response_text(self):
+        original_run = check.run
+        for interface in ['run_point', 'check_agentx_point']:
+            for mutation in ['missing', 'not-text', 'whitespace', 'rounded-integer']:
+                with self.subTest(interface=interface, mutation=mutation):
+                    def change(stdout):
+                        document = json.loads(stdout)
+                        request = document['metadata']['requests'][1]
+                        if mutation == 'missing':
+                            del request['body_utf8']
+                        elif mutation == 'not-text':
+                            request['body_utf8'] = 1
+                        elif mutation == 'whitespace':
+                            request['body_utf8'] += ' '
+                        else:
+                            request['body_utf8'] = request['body_utf8'].replace('9007199254740993', '9007199254740992')
+                        return json.dumps(document)
+
+                    error = 'request identity differs' if mutation == 'missing' else 'raw response text differs'
+                    if interface == 'run_point':
+                        with patch.object(check, 'run', side_effect=lambda *args: change(original_run(*args))):
+                            with self.assertRaisesRegex(ValueError, error):
+                                self.run_shipped_point(trace=False)
+                        capture = self.root / f'shipped-point-{self.fixture_index}-evidence/manifest.json'
+                        self.assertEqual(json.loads(capture.read_text())['status'], 'pending')
+                    else:
+                        _outcome, evidence, output, capture = self.run_shipped_point(trace=False)
+                        output.write_text(change(output.read_text()))
+                        capture['output']['sha256'] = hashlib.sha256(output.read_bytes()).hexdigest()
+                        check.save(evidence / 'manifest.json', capture)
+                        with self.assertRaisesRegex(ValueError, error):
+                            check.check_agentx_point(self.root, evidence.name, output.name, '7', VERSION)
 
     def test_point_capture_preload_rejects_effective_post_request(self):
         node = check.shutil.which('node')
@@ -1142,8 +1223,10 @@ JS
                 "redirect that recipe process's stdout directly",
                 'must not write their output or evidence, replace `response.json()`, replace `console.log()`',
                 'Do not reimplement the request flow or reconstruct the JSON output',
-                "Build `metadata.requests` only after that run's final fetch has completed",
-                'one item containing exactly `query_url` and `retrieved_at`',
+                "Read the recipe-owned `metadata.requests` only after that run's final fetch has completed",
+                'Each item contains exactly `query_url`, `retrieved_at`, and `body_utf8`',
+                'its UTF-8 bytes must equal the captured response file, including large-integer digits and whitespace',
+                'Do not rebuild it from parsed JSON',
                 'for every manifest response in identical order (six for a traced run and three for a no-trace run)',
                 'each `query_url` must match the corresponding manifest response `url`',
                 "each manifest response `retrieved_at` must equal the recipe output's corresponding `metadata.requests` value byte-for-byte",


### PR DESCRIPTION
## Summary

The 0.5.0 release workflow stopped before npm upload because its maintainer verifier still expected two request metadata fields after the AgentX recipe added `body_utf8`. Accept the recipe’s current shape and require its raw UTF-8 bytes to match each captured response. Compare parsed diagnostic numbers using JavaScript Number semantics while retaining exact source integers in the raw response.

Update native acceptance guidance and exercise the actual shipped recipe for both traced and unavailable points. No npm-shipped files change; the reviewed 0.5.0 archive remains identical.

## Testing

- Full Python release-verifier suite, including the reproduced failure and rejection of missing or modified response text.
- Node 24 packed package interface suite.
- Candidate installation and public API verification against the original reviewed 0.5.0 archive.
- Failed publication before upload: https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34063845158

## 中文说明

0.5.0 的发布流程在上传 npm 前停止：AgentX 示例已增加 `body_utf8`，但维护者验收器仍只接受旧的两个请求字段。此次修复同步字段约定，并逐字节核对响应原文与捕获文件。解析后的诊断数值按 JavaScript Number 语义比较，原始大整数仍完整保存在响应原文中。

同时更新原生 agent 的验收说明，使用实际打包的示例覆盖有 trace 和无 trace 两条路径，并验证原文缺失或被改写时会拒绝验收。npm 包内文件没有变化，0.5.0 已审阅安装包的哈希保持不变。

验证包括完整 Python 验收器测试、Node 24 打包接口测试，以及原安装包的安装与公开 API 验收。首次发布未执行 npm 上传。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release-gate validation for AgentX point evidence; incorrect logic could block or wrongly pass publishes, but scope is limited to the Python verifier and tests, not runtime API behavior.
> 
> **Overview**
> Unblocks release verification after the AgentX point recipe started emitting **`body_utf8`** on each `metadata.requests` entry. The maintainer verifier no longer expects only `query_url` and `retrieved_at`; it centralizes checks in **`point_request`** and requires each `body_utf8` string’s UTF-8 bytes to match the corresponding captured response file (no re-serializing from parsed JSON).
> 
> Parsed diagnostic payloads are compared with **`same_json(..., javascript_numbers=True)`** so integers beyond `Number.MAX_SAFE_INTEGER` can round in the recipe output while **`body_utf8`** still pins the exact wire text. Native-agent acceptance copy is updated to match, and tests exercise the shipped recipe (traced and no-trace) plus reject missing, mistyped, whitespace, or rounded `body_utf8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8124e791ff9bf2b8144ddc2efd9536f2cf37b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->