### PR TITLE
[feat] add CollectiveX comparisons in skill 0.8.0 / 技能 0.8.0 新增 CollectiveX 比较

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -1,6 +1,6 @@
 # InferenceX API skill examples
 
-Use `@semianalysisai/inferencex-skills@0.7.0` to query existing
+Use `@semianalysisai/inferencex-skills@0.8.0` to query existing
 observations; these requests do not run new benchmarks. The skill covers the
 public API, including PowerX and AgentX exports and source-backed investigations. Read the
 [current API contract](https://inferencex.semianalysis.com/api/openapi.json) before
@@ -8,7 +8,7 @@ constructing requests.
 
 ## Install
 
-Until 0.7.0 is published, install the reviewed local archive using the
+Until 0.8.0 is published, install the reviewed local archive using the
 [package README](../packages/skills/README.md#review-a-local-archive). The npm
 commands below apply after publication; the website continues to advertise the
 last published version until its release has been verified.
@@ -17,10 +17,10 @@ With Node 24 or later and npm, run the command for your agent from your project:
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude
 ```
 
 Start an agent session in that project. Queries need public HTTPS access, with no
@@ -150,3 +150,15 @@ and confounders without assigning a causal or statistical regression verdict.
 > between two SGLang images. Discover the exact dates and producer identities,
 > preserve raw model keys, match workload and public configuration, and save
 > descriptive median TTFT differences with the source evidence and limitations.
+
+## Compare two CollectiveX runs
+
+The [CollectiveX cookbook](../packages/skills/skills/inferencex-api/references/collectivex.md)
+discovers existing communication runs and exports exact EP/KV configuration
+comparisons with source bodies, run attempts, revision context, units and coverage.
+It distinguishes missing or unmatched data from zero metrics and never launches a sweep.
+
+> Find two existing CollectiveX communication runs on InferenceX and save their
+> comparison as JSON. Match the operation, backend, precision, topology and byte
+> counts. Explain source revisions, missing coverage, latency and rate units;
+> do not interpret unmatched cases as zero performance.

--- a/docs/inferencex-skills-discovery.md
+++ b/docs/inferencex-skills-discovery.md
@@ -92,5 +92,5 @@ project, an explicit-use run, or unreviewed model prose as accepted discovery.
 - 0.7.0: framework-update investigation with matched observations and confounders.
 - 0.8.0: CollectiveX discovery, comparison and export cookbook.
 
-This candidate is 0.7.0 and includes 0.5.0 and 0.6.0. Version 0.8.0 remains a planned
-separate release. A local candidate does not establish npm publication.
+This candidate is 0.8.0 and includes the preceding three releases. Keep each
+version on its separate local branch and validate its exact archive. A local candidate does not establish npm publication.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -10,10 +10,20 @@ also provides evaluation lookups and dataset-to-conversation inspection, with
 request context, exact identifiers, missing values, and page/sample boundaries.
 It also covers benchmark history filtered by GPU, workload and observation-date range.
 
-The npm commands below pin version `0.7.0` and require that version to be published.
+The npm commands below pin version `0.8.0` and require that version to be published.
 For review before publication, use the local archive instructions below.
 
-## New in 0.7.0
+## New in 0.8.0
+
+[CollectiveX comparisons](skills/inferencex-api/references/collectivex.md) discover
+two existing communication runs or accept two exact run IDs, then export JSON
+with EP/KV matches, units, missingness, coverage and complete response evidence.
+Matching requires the same public operation, backend, precision and topology,
+plus EP payload byte counts or KV request byte counts for the respective family. Run attempts and source revisions remain explicit; these are
+observed differences, not controlled experiments. Discovery is bounded and does
+not establish complete workflow history. No communication sweep is launched.
+
+## Included from 0.7.0
 
 [Framework update investigations](skills/inferencex-api/references/releases.md)
 compare latency, interactivity or throughput between exact observation dates
@@ -66,10 +76,10 @@ Run the command for your agent from the project where it should discover the ski
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude
 ```
 
 | Target              | Skill location relative to the current project |
@@ -80,9 +90,9 @@ npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-s
 For an explicit skills-root directory or inspection:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --dir './my project/.agents/skills'
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills list
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills --help
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --dir './my project/.agents/skills'
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills list
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills --help
 ```
 
 `--dir` selects the parent skills directory; the installer appends `inferencex-api`.
@@ -95,7 +105,7 @@ To review a maintainer-supplied `.tgz` before publication, replace the path with
 actual archive and run from the target project. Use `--target claude` for Claude Code.
 
 ```bash
-INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.7.0.tgz'
+INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.8.0.tgz'
 npm exec --yes --offline --package "$INFERENCEX_SKILLS_TGZ" -- inferencex-skills install --target codex
 ```
 
@@ -215,7 +225,7 @@ availability is false or omitted.
 ### Inspect the installed version
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills status --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills status --target codex
 ```
 
 Use `--target claude` or `--dir './my project/.agents/skills'` to inspect another
@@ -227,8 +237,9 @@ first; add npm's `--offline` when the selected package version is already cached
 
 Legacy installations without a version record, including `0.1.0`, report an
 unknown installed version. Invalid or unreadable records are also reported as
-unknown. For `0.7.0` and later receipts, the record must agree with the static
-version declarations in PowerX, AgentX, provenance, TCO, and release comparison helpers.
+unknown. For `0.8.0` and later receipts, the record must agree with the static
+version declarations in PowerX, AgentX, provenance, TCO, release comparison, and CollectiveX helpers.
+Receipts from `0.7.x` require the first five helpers.
 Receipts from `0.6.x` require the first four helpers.
 Receipts from `0.5.x` require the first three helpers.
 Receipts from `0.4.x` require PowerX and AgentX; earlier receipts require PowerX
@@ -240,8 +251,8 @@ check is not a full integrity check and cannot detect every local edit.
 ### JSON output and installation preview
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills status --target codex --json
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target codex --force --dry-run --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills status --target codex --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex --force --dry-run --json
 ```
 
 `--json` on `status` or `install` emits one JSON document to stdout; diagnostics go
@@ -277,11 +288,11 @@ without stale installation fields; use the exit code to determine success.
 ### Upgrade
 
 Repeated installation skips an existing skill. Add `--force` to reinstall a pinned
-version. To upgrade, replace `0.7.0` with the published version you intend to install:
+version. To upgrade, replace `0.8.0` with the published version you intend to install:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target codex --force
-npm exec --yes --package @semianalysisai/inferencex-skills@0.7.0 -- inferencex-skills install --target claude --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude --force
 ```
 
 Force merges the packaged files into the existing skill and overwrites matching
@@ -300,10 +311,16 @@ skill directory. Keep a copy of local edits before choosing an overwrite.
 数据集到会话详情的完整示例，说明如何保留请求上下文、原始标识符、缺失值，以及分页和
 抽样范围；还提供按 GPU、工作负载和观测日期范围筛选历史基准测试数据的示例。
 
-上面的 npm 命令固定使用 `0.7.0`，需在该版本发布后执行。发布前审阅请使用本地产物
+上面的 npm 命令固定使用 `0.8.0`，需在该版本发布后执行。发布前审阅请使用本地产物
 安装流程。
 
-0.7.0 新增[框架版本调查](skills/inferencex-api/references/releases.md)：按确切的观测日期和
+0.8.0 新增 [CollectiveX 比较](skills/inferencex-api/references/collectivex.md)：发现两个现有的通信
+基准测试 run，或使用两个确切的 run ID，导出包含 EP/KV 匹配结果、单位、缺失与覆盖情况
+和完整响应证据的 JSON。匹配要求公开的操作、backend、精度和拓扑一致；EP 还需匹配 payload
+字节数，KV 还需匹配请求字节数。运行 attempt 和来源 revision 会明确保留。这些是观测差异，
+不能视为受控实验。发现范围有限，并不构成完整的工作流历史。本流程不启动通信基准测试。
+
+保留 0.7.0 的[框架版本调查](skills/inferencex-api/references/releases.md)：按确切的观测日期和
 产生数据的 image/run，比较延迟、interactivity 或吞吐量。脚本会匹配公开的工作负载和配置，
 报告缺失或存在多个候选的数据对，并保存完整来源响应。recipe 证据发生变化或无法获取，仍是混杂因素；观测差异不足以得出因果或统计意义上的回归
 结论。功耗和能耗比较需要使用单独的 PowerX 验证流程。
@@ -432,8 +449,8 @@ histogram 和 server metrics。
 下载安装器。如指定版本已经缓存，可给 npm 加上 `--offline`。
 
 包括 `0.1.0` 在内、没有版本记录的旧安装会显示版本未知。记录无效或无法读取时，同样
-显示为未知。版本记录为 `0.7.0` 或更新时，必须与 PowerX、AgentX、溯源、TCO 和框架版本比较脚本中的静态
-版本声明一致；`0.6.x` 记录核对前四项，`0.5.x` 核对前三项，`0.4.x` 核对 PowerX 和 AgentX，更早的记录只核对 PowerX。强制降级后
+显示为未知。版本记录为 `0.8.0` 或更新时，必须与 PowerX、AgentX、溯源、TCO、框架版本比较和 CollectiveX
+脚本中的静态版本声明一致；`0.7.x` 记录核对前五项，`0.6.x` 核对前四项，`0.5.x` 核对前三项，`0.4.x` 核对 PowerX 和 AgentX，更早的记录只核对 PowerX。强制降级后
 残留的较新脚本不参与旧版本的检查。需要核对的声明缺失、无法读取或版本不一致时，状态也会显示为未知。`status`
 只读取声明，不执行任何脚本。这项检查不是完整的文件完整性校验，也不能识别所有本地
 修改。`--version` 只显示本次调用的安装器版本，不显示项目中已安装技能的版本。
@@ -461,7 +478,7 @@ stderr。不加该选项时保留原有文字输出。上表定义 `schema_versi
 安装状态字段；请用退出码判断操作是否成功。
 
 重复安装默认跳过已有技能。添加 `--force` 可重新安装指定版本；需要升级时，将命令中
-的 `0.7.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
+的 `0.8.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
 同名文件；相邻的其他技能不受影响，技能目录中已不再随包提供的旧文件也不会被删除。
 覆盖前请自行备份本地修改。
 

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -92,6 +92,7 @@ function installedState(destination, packageName) {
     { file: 'investigate-result.mjs', name: 'provenance helper', minor: 5n },
     { file: 'compare-tco.mjs', name: 'TCO helper', minor: 6n },
     { file: 'compare-releases.mjs', name: 'release comparison helper', minor: 7n },
+    { file: 'compare-collectivex.mjs', name: 'CollectiveX helper', minor: 8n },
   ].filter(
     ({ minor }) =>
       BigInt(versionMatch.groups.major) > 0n || BigInt(versionMatch.groups.minor) >= minor,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Install the InferenceX public API skill for Codex and Claude Code.",
   "keywords": [
     "agent-skills",
@@ -9,6 +9,7 @@
     "benchmarks",
     "claude",
     "codex",
+    "collectivex",
     "inferencex",
     "powerx",
     "tco"

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -26,11 +26,13 @@ const releaseFiles = [
   'skills/inferencex-api/references/provenance.md',
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
+  'skills/inferencex-api/references/collectivex.md',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
   'skills/inferencex-api/scripts/investigate-result.mjs',
   'skills/inferencex-api/scripts/compare-tco.mjs',
   'skills/inferencex-api/scripts/compare-releases.mjs',
+  'skills/inferencex-api/scripts/compare-collectivex.mjs',
 ];
 const stableVersion = /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/u;
 

--- a/packages/skills/skills/inferencex-api/SKILL.md
+++ b/packages/skills/skills/inferencex-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: inferencex-api
-description: Query InferenceX benchmarks, PowerX measured energy, AgentX traces, evaluations, and datasets. Trace a selected result to its producing run, configuration, image, and bounded logs using the public API. Compare fixed-target GPU-rate costs with explicit prices. Investigate vLLM or SGLang changes between matched observations. Also supports CollectiveX lookups.
+description: Query InferenceX benchmarks, PowerX measured energy, AgentX traces, evaluations, and datasets. Trace a selected result to its producing run, configuration, image, and bounded logs using the public API. Compare fixed-target GPU-rate costs with explicit prices. Investigate vLLM or SGLang changes between matched observations. Discover, compare and export CollectiveX communication benchmarks.
 ---
 
 # InferenceX API
@@ -56,6 +56,12 @@ For **vLLM/SGLang updates, before/after changes, or regression investigation**, 
 dates and producer identities, keep unmatched or ambiguous configurations, and
 report descriptive performance changes with confounders. Power and energy tasks
 use the PowerX workflow above. Image tags alone do not prove a release or a cause.
+
+For **CollectiveX communication benchmarks, two-run comparisons, or JSON exports**,
+read [the CollectiveX cookbook](references/collectivex.md) and use
+[the comparison helper](scripts/compare-collectivex.mjs). Compare exact public EP/KV
+identities, preserve units and unmatched coverage, and retain full source responses.
+A run list is bounded discovery; differing attempts and revisions remain context.
 
 ## Query workflow
 

--- a/packages/skills/skills/inferencex-api/references/collectivex.md
+++ b/packages/skills/skills/inferencex-api/references/collectivex.md
@@ -1,0 +1,161 @@
+# Compare existing CollectiveX runs
+
+Use this cookbook to discover public communication sweeps, compare two returned
+runs, and export the evidence. These are existing observations; no new benchmark
+is run. Public GETs can populate the service's documented lazy cache from existing
+GitHub artifacts. No database credentials, admin operations, or launch tools are
+needed.
+
+## 1. Discover and export
+
+Example request: "Find two recent measured communication runs and compare their
+matching configurations. Save the complete source responses, include unavailable
+cases, and explain which observations cannot be compared."
+
+Run from a project with the npm skill installed for Codex:
+
+```bash
+node .agents/skills/inferencex-api/scripts/compare-collectivex.mjs --output collectivex-comparison.json
+```
+
+For Claude Code, use the corresponding installed path:
+
+```bash
+node .claude/skills/inferencex-api/scripts/compare-collectivex.mjs --output collectivex-comparison.json
+```
+
+Requires Node 24+. The helper checks the current OpenAPI operations, reads the run
+list **once**, and selects its two newest runs with `measured_cases > 0`, ordered
+by numeric run ID. The older selection is `left`; the newer is `right`. This is a
+bounded example selection, not a representative sample. A cancelled or failed
+workflow can still contain measured cases; its conclusion remains in the export.
+
+For a requested pair, supply both exact string IDs from discovery:
+
+```bash
+node .agents/skills/inferencex-api/scripts/compare-collectivex.mjs --left <left-run-id> --right <right-run-id> --output collectivex-pair.json
+```
+
+The explicit pair makes three GETs; discovery makes at most four. Each request has
+a 30-second timeout, and all decoded responses share a 32 MiB budget. There are no
+retries or polling. The output is JSON only. `--output` requires an existing parent
+directory and a **new file path**; it refuses to overwrite a file, directory, or
+symlink. It publishes the file only after every read and comparison succeeds.
+Omitting `--output` writes to stdout; shell redirection can truncate a destination
+before the helper runs, so use `--output` when preserving files matters.
+
+The public operations require `version=1`:
+
+| Operation                                                                                        | Meaning                                                                          |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| [`/collectivex/latest`](https://inferencex.semianalysis.com/api/v1/collectivex/latest?version=1) | Newest available run by run ID; it need not contain measurements.                |
+| [`/collectivex/runs`](https://inferencex.semianalysis.com/api/v1/collectivex/runs?version=1)     | Retained summaries and `discovery_complete`; the helper uses this for selection. |
+| `/collectivex/runs/{runId}`                                                                      | One run dataset, possibly refreshed to a newer attempt.                          |
+
+All paths above are under `/api/v1`. Consult the [public API reference](https://inferencex.semianalysis.com/api)
+and [OpenAPI document](https://inferencex.semianalysis.com/api/openapi.json) for the
+current contract. A missing/unsupported version is HTTP 400. HTTP 404, an upstream
+502/503, malformed data, a redirect, or an interrupted response is a failed read,
+not an empty comparison. The helper exits nonzero and publishes no export on
+those failures; it never substitutes a different run.
+
+`discovery_complete=false` means further bounded discovery passes may reveal more
+runs. Report that flag even when two selections were available. The route has no
+documented `limit`, `offset`, or cursor: do not invent pagination parameters. If
+fewer than two measured summaries were returned, the helper exports
+`fewer_than_two_measured_runs` and makes no detail requests. Further discovery, if
+needed, should have an explicit small request budget and retain each response.
+
+Even `discovery_complete=true` does **not** mean complete workflow history. Recent
+discovery has a bounded upstream window, artifacts expire, and retained runs can
+outlive their artifacts. The export therefore always sets `history_complete=false`.
+Stored fallback data can also be served when upstream refresh fails. Compare each
+detail's returned `run_attempt` with its discovery summary; a later attempt is a
+different snapshot, even under the same run ID.
+
+## 2. Check comparability before interpreting differences
+
+The helper creates groups using exact returned identities, with no interpolation,
+aggregation, best-of selection, or hardware ranking:
+
+| Suite       | Required matching identity                                                                                                                                                                                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| EP          | Full series configuration, including `series_id`, backend, phase, kernel mode, precision (dtype), hardware/vendor, and every `system` topology field; operation; `tokens_per_rank`; `global_tokens`; component `payload_bytes`.                                                      |
+| KV-transfer | Case configuration including `case_id`, backend, hardware/vendor, fabric, workload, precision, and topology; row `kind`, `isl`, `page_tokens`, `batch`, `op`, `descs`, and `req_bytes`. Cosmetic labels and outcome/reason text are retained as evidence but excluded from matching. |
+
+Topology includes EP/rank count (`ep_size`), nodes, GPUs per node, scale-up domain,
+scale-up and scale-out transports, and topology class. Keep a declared null
+scale-out transport distinct from a missing topology field. Tokens per rank alone
+do not identify a message size; EP compares the returned aggregate payload bytes
+as well. KV keeps bytes per request separate from burst size (`batch`). Comparing
+different SKUs, backends, dtypes, operations, or topologies requires a separate,
+explicitly qualified analysis; this helper leaves them unmatched.
+
+Read every comparison status:
+
+- `matched`: exactly one observation on each side has the same complete public
+  identity. Only these groups receive metric differences and ratios.
+- `only_left` / `only_right`: no exact counterpart was returned. This does not
+  prove the other system failed, is unsupported, or has zero performance.
+- `ambiguous`: an identity occurs more than once on either side. All source
+  pointers remain; the helper selects none of the duplicates.
+- `incomparable`: an identity field or byte count is missing/invalid, an EP
+  component is unavailable, or a KV case/verification is not successful.
+
+`summary` counts comparison groups, including EP operation groups, not runs or
+requested cases. Cases with **no measured rows** have no comparison group. Inspect
+the complete datasets' `coverage` and optional `kv` arrays for their outcome,
+disposition, reason, detail, and per-point terminal status. Retain pending,
+unsupported, failed, invalid, diagnostic, and unavailable cases in the answer's
+coverage statement. A successful workflow does not imply complete measurement
+coverage; absence of the optional `kv` field does not imply a failed KV suite.
+
+Matching is deliberately conservative: a changed case ID remains unmatched even
+if visible labels look alike. `comparison_scope.basis=exact_public_identity`
+describes the fields exposed by this API, not proof of a controlled experiment.
+The API returns an **assembled dataset**, not the original matrix/shard artifacts,
+software build manifests, or every runtime setting. Preserve each `source_sha`;
+`source_sha_equal=false` is a revision difference, not evidence of its causal
+effect. Equal SHAs also do not establish identical runtime conditions.
+
+## 3. Preserve units, missing values, and sources
+
+| Metric family                                        | Meaning and unit                                                                                                                              |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| EP `latency_us`                                      | Operation latency in microseconds. Compare the same percentile.                                                                               |
+| EP `activation_data_rate_gbps_at_latency_percentile` | Aggregate activation-data rate in **GB/s**, excluding FP8 scale bytes.                                                                        |
+| EP `payload_data_rate_gbps_at_latency_percentile`    | Full payload rate in **GB/s per GPU**, including recorded scale bytes. `payload_bytes` is aggregate bytes across the EP world.                |
+| EP `roundtrip_token_rate_at_latency_percentile`      | Aggregate tokens/s at the named latency percentile.                                                                                           |
+| KV `latency_ms` / `request_ms`                       | Whole-burst latency / per-request completion latency in milliseconds; `n` is sample count. A missing `request_ms` is not whole-burst latency. |
+| KV `prep_ms`, `gbps_p50`, `gbps_p50_incl_prep`       | Preparation time in ms per burst, GB/s excluding preparation, and GB/s including preparation.                                                 |
+
+The spelling `gbps` in field names does not mean gigabits/s. Rate-at-latency-p99 is
+a rate derived at p99 latency, not an independently measured p99 bandwidth.
+Keep EP microseconds and KV milliseconds distinct. The reader can use wire-byte
+provenance when present and legacy logical/activation-byte fallbacks otherwise;
+the public dataset does not expose all of that provenance. Equal reported bytes
+alone do not prove equal physical wire traffic. Describe reported payload rates,
+not link saturation, bus bandwidth, or a reconstructed raw message distribution.
+
+Each metric retains `status: value`, `null`, or `missing`; real zero is a value.
+`difference_right_minus_left` and `ratio_right_over_left` use only two finite
+values. A zero left denominator yields a null ratio. Null ratios/differences do
+not mean equality. Raw response text preserves omitted fields and additional
+returned fields without inventing defaults. The server's shared reader has its
+own compatibility fallbacks, so returned defaults are not independently verified
+artifact provenance.
+
+Save the JSON beside the answer. `responses[]` contains each exact request URL,
+HTTP status, retrieval timestamp, SHA-256 of the decoded response bytes, and
+complete `body_text`, including the OpenAPI response. Parse `body_text` to inspect
+the original dataset; comparison source pointers identify a response index and
+JSON Pointer within that parsed body. Run IDs remain exact strings, and
+`runs[].run` retains the returned attempt, `generated_at`, conclusion, and source
+SHA. Retrieval time and generated time describe different events. Cite URLs and
+timestamps from **this export**, never from another selection or an older example.
+
+Report the selected runs and attempts, discovery coverage, matched/unmatched/
+ambiguous/incomparable counts, the specific metric/percentile and units, and
+relevant unmeasured coverage. Summarize numerical differences only from the
+complete requested set of `matched` groups. Keep the result scoped to the two
+returned snapshots and state that no new benchmarks were run.

--- a/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
@@ -1,0 +1,526 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { link, lstat, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { parseArgs } from 'node:util';
+
+// Installed skills run independently of package.json; release preparation updates this version.
+const PACKAGE_VERSION = '0.8.0';
+const ORIGIN = 'https://inferencex.semianalysis.com';
+const VERSION = 1;
+const BYTE_BUDGET = 32 * 1024 * 1024;
+const PERCENTILES = ['p50', 'p90', 'p95', 'p99'];
+const HELP = `compare-collectivex — compare two existing public communication sweeps
+
+Requires Node 24+. No credentials or new benchmarks. JSON output only.
+
+Usage:
+  node compare-collectivex.mjs [--left <run-id> --right <run-id>] [--output <new-file>]
+
+With no IDs, read the run list once and select its two newest measured runs by
+numeric run ID (older = left). This is a bounded example selection, not history.
+Explicit IDs must be distinct positive decimal strings. Contract version: 1.
+At most four GETs: OpenAPI, optional run list, and two run details. No retries.
+Responses share a 32 MiB decoded-body budget; each request times out after 30s.
+--output creates a new file atomically and refuses to replace an existing path.
+Without --output, print JSON after all reads and validation succeed.
+--help makes no requests. See references/collectivex.md for matching and units.
+`;
+
+const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const text = (value) => typeof value === 'string' && value.trim().length > 0;
+const id = (value) => typeof value === 'string' && /^[1-9]\d*$/u.test(value);
+const positive = (value) => Number.isSafeInteger(value) && value > 0;
+const count = (value) => Number.isSafeInteger(value) && value >= 0;
+const canonical = (value) =>
+  JSON.stringify(value, (_key, item) => {
+    if (
+      typeof item === 'number' &&
+      (!Number.isFinite(item) || (Number.isInteger(item) && !Number.isSafeInteger(item)))
+    ) {
+      throw new Error('Comparison identity contains an unrepresentable number');
+    }
+    return object(item)
+      ? Object.fromEntries(
+          Object.keys(item)
+            .sort()
+            .map((key) => [key, item[key]]),
+        )
+      : item;
+  });
+
+function validTimestamp(value) {
+  const match =
+    typeof value === 'string' &&
+    /^(?<date>\d{4}-\d{2}-\d{2})[T ](?<hour>\d{2}):(?<minute>\d{2}):(?<second>\d{2})(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u.exec(
+      value,
+    );
+  if (!match || !Number.isFinite(Date.parse(value))) return false;
+  const date = new Date(`${match.groups.date}T00:00:00Z`);
+  return (
+    Number.isFinite(date.getTime()) &&
+    date.toISOString().slice(0, 10) === match.groups.date &&
+    Number(match.groups.hour) < 24 &&
+    Number(match.groups.minute) < 60 &&
+    Number(match.groups.second) < 60
+  );
+}
+
+function runIdentity(run) {
+  return (
+    object(run) &&
+    id(run.run_id) &&
+    positive(run.run_attempt) &&
+    validTimestamp(run.generated_at) &&
+    (run.conclusion === null || typeof run.conclusion === 'string')
+  );
+}
+
+function topologyIssues(topology) {
+  if (!object(topology)) return ['missing_topology'];
+  const issues = [];
+  for (const key of ['ep_size', 'nodes', 'gpus_per_node', 'scale_up_domain']) {
+    if (!positive(topology[key])) issues.push(`missing_or_invalid_${key}`);
+  }
+  for (const key of ['scale_up_transport', 'topology_class']) {
+    if (!text(topology[key])) issues.push(`missing_or_invalid_${key}`);
+  }
+  if (!(topology.scale_out_transport === null || text(topology.scale_out_transport))) {
+    issues.push('missing_or_invalid_scale_out_transport');
+  }
+  return issues;
+}
+
+function metric(value) {
+  if (value === undefined) return { status: 'missing' };
+  if (value === null) return { status: 'null', value: null };
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(
+      'Invalid metric: expected a finite nonnegative number, null, or an omitted field',
+    );
+  }
+  return { status: 'value', value };
+}
+
+function percentiles(target, name, unit, values, keys = PERCENTILES) {
+  if (values !== undefined && values !== null && !object(values)) {
+    throw new Error(`Invalid ${name} percentile object`);
+  }
+  for (const key of keys) {
+    target.push({
+      name: `${name}.${key}`,
+      unit,
+      ...metric(values === null ? null : values?.[key]),
+    });
+  }
+}
+
+function epRows(dataset, responseIndex) {
+  const rows = [];
+  dataset.series.forEach((series, seriesIndex) => {
+    if (!object(series) || !Array.isArray(series.points)) throw new Error('Invalid EP series');
+    const { points, ...configuration } = series;
+    const issues = topologyIssues(series.system);
+    for (const key of ['series_id', 'phase', 'mode', 'precision', 'backend']) {
+      if (!text(series[key])) issues.push(`missing_or_invalid_${key}`);
+    }
+    if (!text(series.system?.sku) || !['nvidia', 'amd'].includes(series.system?.vendor)) {
+      issues.push('missing_hardware_identity');
+    }
+    points.forEach((point, pointIndex) => {
+      if (!object(point) || !object(point.components)) throw new Error('Invalid EP point');
+      const {
+        components: _components,
+        roundtrip_token_rate_at_latency_percentile: _rate,
+        ...pointConfiguration
+      } = point;
+      for (const operation of ['dispatch', 'stage', 'combine', 'roundtrip']) {
+        const component = point.components[operation];
+        if (component !== undefined && component !== null && !object(component)) {
+          throw new Error('Invalid EP component');
+        }
+        const problems = [...issues];
+        if (!positive(point.tokens_per_rank) || !positive(point.global_tokens)) {
+          problems.push('missing_or_invalid_token_counts');
+        }
+        if (!component) problems.push('unavailable_component');
+        if (!count(component?.payload_bytes)) problems.push('missing_or_invalid_payload_bytes');
+        const metrics = [];
+        percentiles(metrics, 'latency_us', 'us', component?.latency_us);
+        percentiles(
+          metrics,
+          'activation_data_rate_gbps_at_latency_percentile',
+          'GB/s aggregate activation',
+          component?.activation_data_rate_gbps_at_latency_percentile,
+        );
+        percentiles(
+          metrics,
+          'payload_data_rate_gbps_at_latency_percentile',
+          'GB/s per GPU payload',
+          component?.payload_data_rate_gbps_at_latency_percentile,
+        );
+        if (operation === 'roundtrip') {
+          percentiles(
+            metrics,
+            'roundtrip_token_rate_at_latency_percentile',
+            'tokens/s aggregate',
+            point.roundtrip_token_rate_at_latency_percentile,
+          );
+        }
+        rows.push({
+          identity: {
+            suite: 'ep',
+            configuration,
+            operation,
+            ...pointConfiguration,
+            payload_bytes: component?.payload_bytes,
+          },
+          issues: problems,
+          metrics,
+          source: {
+            response_index: responseIndex,
+            json_pointer: `/series/${seriesIndex}/points/${pointIndex}/components/${operation}`,
+          },
+        });
+      }
+    });
+  });
+  return rows;
+}
+
+function kvRows(dataset, responseIndex) {
+  return (dataset.kv ?? []).flatMap((kase, caseIndex) => {
+    if (!object(kase) || !Array.isArray(kase.rows)) throw new Error('Invalid KV case');
+    const {
+      rows,
+      label: _label,
+      disposition: _disposition,
+      outcome: _outcome,
+      reason: _reason,
+      detail: _detail,
+      ...configuration
+    } = kase;
+    const issues = topologyIssues(kase.topology);
+    for (const key of ['case_id', 'sku', 'backend', 'fabric', 'workload', 'precision']) {
+      if (!text(kase[key])) issues.push(`missing_or_invalid_${key}`);
+    }
+    if (!['nvidia', 'amd'].includes(kase.vendor)) issues.push('missing_hardware_identity');
+    if (kase.outcome !== 'success' || kase.disposition !== 'runnable')
+      issues.push('kv_case_not_successful');
+    return rows.map((row, rowIndex) => {
+      if (!object(row)) throw new Error('Invalid KV row');
+      const problems = [...issues];
+      // Unknown future row fields remain part of identity rather than silently broadening a match.
+      const {
+        prep_ms: _prep,
+        latency_ms: _latency,
+        request_ms: _request,
+        gbps_p50: _gbps,
+        gbps_p50_incl_prep: _coldGbps,
+        verify_passed: _verified,
+        ...identity
+      } = row;
+      if (!['paged', 'bulk'].includes(row.kind) || !['push', 'pull'].includes(row.op)) {
+        problems.push('missing_or_invalid_kv_operation');
+      }
+      for (const key of ['isl', 'batch', 'descs', 'req_bytes']) {
+        if (!(key === 'req_bytes' ? count(row[key]) : positive(row[key]))) {
+          problems.push(`missing_or_invalid_${key}`);
+        }
+      }
+      if (!((row.page_tokens === null && row.kind === 'bulk') || positive(row.page_tokens))) {
+        problems.push('missing_or_invalid_page_tokens');
+      }
+      if (row.verify_passed !== true) problems.push('kv_verification_not_passed');
+      const metrics = [];
+      for (const [key, unit] of [
+        ['latency_ms', 'ms per burst'],
+        ['request_ms', 'ms per request'],
+      ]) {
+        percentiles(metrics, key, unit, row[key], ['p50', 'p95', 'min', 'max']);
+        metrics.push({
+          name: `${key}.n`,
+          unit: 'samples',
+          ...metric(row[key] === null ? null : row[key]?.n),
+        });
+      }
+      for (const [key, unit] of [
+        ['prep_ms', 'ms per burst'],
+        ['gbps_p50', 'GB/s'],
+        ['gbps_p50_incl_prep', 'GB/s including prep'],
+      ]) {
+        metrics.push({ name: key, unit, ...metric(row[key]) });
+      }
+      return {
+        identity: { suite: 'kv', configuration, row: identity },
+        issues: problems,
+        metrics,
+        source: {
+          response_index: responseIndex,
+          json_pointer: `/kv/${caseIndex}/rows/${rowIndex}`,
+        },
+      };
+    });
+  });
+}
+
+function compare(left, right) {
+  const groups = new Map();
+  for (const [side, rows] of [
+    ['left', left],
+    ['right', right],
+  ]) {
+    for (const row of rows) {
+      const key = canonical(row.identity);
+      if (!groups.has(key)) groups.set(key, { identity: row.identity, left: [], right: [] });
+      groups.get(key)[side].push(row);
+    }
+  }
+  return [...groups.values()].map(({ identity, left: a, right: b }) => {
+    const issues = [...new Set([...a, ...b].flatMap((row) => row.issues))];
+    const status =
+      a.length > 1 || b.length > 1
+        ? 'ambiguous'
+        : issues.length > 0
+          ? 'incomparable'
+          : a.length === 0
+            ? 'only_right'
+            : b.length === 0
+              ? 'only_left'
+              : 'matched';
+    const metrics =
+      status === 'matched'
+        ? a[0].metrics.map(({ name, unit, ...leftValue }, index) => {
+            const { name: _name, unit: _unit, ...rightValue } = b[0].metrics[index];
+            const numeric = leftValue.status === 'value' && rightValue.status === 'value';
+            const difference = numeric ? rightValue.value - leftValue.value : null;
+            const ratio =
+              numeric && leftValue.value !== 0 ? rightValue.value / leftValue.value : null;
+            return {
+              name,
+              unit,
+              left: leftValue,
+              right: rightValue,
+              difference_right_minus_left: Number.isFinite(difference) ? difference : null,
+              ratio_right_over_left: Number.isFinite(ratio) ? ratio : null,
+            };
+          })
+        : [];
+    return {
+      identity,
+      status,
+      issues,
+      left: a.map((row) => row.source),
+      right: b.map((row) => row.source),
+      metrics,
+    };
+  });
+}
+
+async function outputJson(output, path) {
+  const bytes = `${JSON.stringify(output, null, 2)}\n`;
+  if (path === null) {
+    await new Promise((resolveWrite, reject) => {
+      process.stdout.once('error', reject);
+      process.stdout.write(bytes, (error) => (error ? reject(error) : resolveWrite()));
+    });
+    return;
+  }
+  const staging = await mkdtemp(join(dirname(path), '.collectivex-'));
+  try {
+    const file = join(staging, 'export.json');
+    await writeFile(file, bytes, { flag: 'wx' });
+    await link(file, path); // Atomic publication; a racing file or symlink is never replaced.
+  } finally {
+    await rm(staging, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const { values } = parseArgs({
+    options: {
+      left: { type: 'string' },
+      right: { type: 'string' },
+      output: { type: 'string' },
+      help: { type: 'boolean' },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+  if (values.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+  const explicit = values.left !== undefined || values.right !== undefined;
+  if (explicit && (!id(values.left) || !id(values.right) || values.left === values.right)) {
+    throw new Error('--left and --right require two distinct positive decimal run-ID strings');
+  }
+  if (values.output !== undefined && !text(values.output))
+    throw new Error('--output needs a new file path');
+  const outputPath = values.output === undefined ? null : resolve(values.output);
+  if (outputPath !== null) {
+    if (
+      await lstat(outputPath).catch((error) => {
+        if (error.code === 'ENOENT') return null;
+        throw error;
+      })
+    ) {
+      throw new Error('--output already exists; choose a new file');
+    }
+    const parent = await stat(dirname(outputPath));
+    if (!parent.isDirectory()) throw new Error('--output parent must be a directory');
+  }
+
+  const responses = [];
+  let remaining = BYTE_BUDGET;
+  async function read(path) {
+    const query_url = new URL(path, ORIGIN).href;
+    const response = await fetch(query_url, {
+      method: 'GET',
+      redirect: 'error',
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (response.redirected || (response.url && response.url !== query_url)) {
+      throw new Error('Unexpected CollectiveX response URL');
+    }
+    const chunks = [];
+    for await (const chunk of response.body ?? []) {
+      remaining -= chunk.byteLength;
+      if (remaining < 0) throw new Error('CollectiveX reads exceeded the 32 MiB response budget');
+      chunks.push(chunk);
+    }
+    const bytes = Buffer.concat(chunks);
+    const body_text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+    if (!response.ok) throw new Error(`HTTP ${response.status}: ${query_url}`);
+    const body = JSON.parse(body_text);
+    const index = responses.length;
+    responses.push({
+      query_url,
+      retrieved_at: new Date().toISOString(),
+      http_status: response.status,
+      decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
+      body_text,
+    });
+    return { body, index };
+  }
+  const { body: schema } = await read('/api/openapi.json');
+  for (const path of ['/api/v1/collectivex/runs', '/api/v1/collectivex/runs/{runId}']) {
+    const operation = schema.paths?.[path]?.get;
+    if (
+      !operation?.parameters
+        ?.find((parameter) => parameter.name === 'version')
+        ?.schema?.enum?.includes(VERSION) ||
+      operation.parameters.some(
+        (parameter) => parameter.required && !['version', 'runId'].includes(parameter.name),
+      )
+    ) {
+      throw new Error(
+        'Inspect the current CollectiveX OpenAPI operations before using this version-1 helper',
+      );
+    }
+  }
+  let runIds = explicit ? [values.left, values.right] : [];
+  let discovery = null;
+  if (!explicit) {
+    const { body: list, index } = await read('/api/v1/collectivex/runs?version=1');
+    if (
+      !object(list) ||
+      list.version !== VERSION ||
+      typeof list.discovery_complete !== 'boolean' ||
+      !Array.isArray(list.runs) ||
+      list.runs.some((run) => !runIdentity(run) || !count(run.measured_cases)) ||
+      new Set(list.runs.map((run) => run.run_id)).size !== list.runs.length
+    ) {
+      throw new Error('Invalid CollectiveX run list; discovery coverage is unknown');
+    }
+    runIds = list.runs
+      .filter((run) => run.measured_cases > 0)
+      .toSorted((a, b) => (BigInt(a.run_id) < BigInt(b.run_id) ? 1 : -1))
+      .slice(0, 2)
+      .map((run) => run.run_id)
+      .toReversed();
+    discovery = {
+      response_index: index,
+      returned_runs: list.runs.length,
+      discovery_complete: list.discovery_complete,
+      history_complete: false,
+    };
+  }
+  const datasets = [];
+  if (runIds.length === 2) {
+    for (const runId of runIds) {
+      const response = await read(`/api/v1/collectivex/runs/${runId}?version=1`);
+      const data = response.body;
+      if (
+        !object(data) ||
+        data.version !== VERSION ||
+        !runIdentity(data.run) ||
+        data.run.run_id !== runId ||
+        !text(data.run.source_sha) ||
+        !Array.isArray(data.coverage) ||
+        !Array.isArray(data.series) ||
+        (data.kv !== undefined && !Array.isArray(data.kv))
+      ) {
+        throw new Error('Invalid or mismatched CollectiveX run dataset');
+      }
+      datasets.push(response);
+    }
+  }
+  const comparisons =
+    datasets.length === 2
+      ? compare(
+          [
+            ...epRows(datasets[0].body, datasets[0].index),
+            ...kvRows(datasets[0].body, datasets[0].index),
+          ],
+          [
+            ...epRows(datasets[1].body, datasets[1].index),
+            ...kvRows(datasets[1].body, datasets[1].index),
+          ],
+        )
+      : [];
+  const summary = Object.fromEntries(
+    ['matched', 'only_left', 'only_right', 'ambiguous', 'incomparable'].map((status) => [
+      status,
+      comparisons.filter((row) => row.status === status).length,
+    ]),
+  );
+  await outputJson(
+    {
+      schema_version: 1,
+      package_version: PACKAGE_VERSION,
+      selection: {
+        mode: explicit ? 'explicit_run_ids' : 'newest_two_measured_from_one_list',
+        run_ids: runIds,
+      },
+      outcome:
+        datasets.length < 2
+          ? 'fewer_than_two_measured_runs'
+          : summary.matched
+            ? 'compared'
+            : 'no_comparable_rows',
+      discovery,
+      comparison_scope: {
+        contract_version: VERSION,
+        basis: 'exact_public_identity',
+        source_sha_equal:
+          datasets.length === 2
+            ? datasets[0].body.run.source_sha === datasets[1].body.run.source_sha
+            : null,
+      },
+      runs: datasets.map(({ body, index }) => ({ run: body.run, response_index: index })),
+      summary,
+      comparisons,
+      responses,
+      observation_context: 'Existing observations were read; no new benchmark was run.',
+    },
+    outputPath,
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`compare-collectivex: ${error.message}\n`);
+  process.exitCode = 1;
+});

--- a/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
@@ -6,7 +6,7 @@ import { basename, dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { isDeepStrictEqual, parseArgs } from 'node:util';
 
-const PACKAGE_VERSION = '0.7.0';
+const PACKAGE_VERSION = '0.8.0';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 // History omits mean/std latency and interactivity; QPS statistics are retained.
 const PERFORMANCE_METRIC =

--- a/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.7.0';
+const PACKAGE_VERSION = '0.8.0';
 const HELP = `compare-tco — compare modeled GPU-hour cost at a fixed interactivity target
 
 Requires Node 24 or later. Output is JSON with the consumed API response and coverage.

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.7.0';
+const PACKAGE_VERSION = '0.8.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const HELP = `export-agentx — export existing AgentX observations with summary enrichments
 

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; the packed-artifact test checks this version.
-const PACKAGE_VERSION = '0.7.0';
+const PACKAGE_VERSION = '0.8.0';
 const HELP = `export-powerx — export validated single-turn PowerX observations
 
 Requires Node 24 or later.

--- a/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.7.0';
+const PACKAGE_VERSION = '0.8.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 const HELP = `investigate-result — collect existing benchmark provenance and one bounded log window

--- a/packages/skills/test/compare-collectivex.test.mjs
+++ b/packages/skills/test/compare-collectivex.test.mjs
@@ -1,0 +1,719 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+import { packedSkillSuite, succeeded } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const base = 'https://inferencex.semianalysis.com';
+const preload = join(suite.temporaryRoot, 'collectivex-http.mjs');
+const installed = new Map();
+const ids = ['90071992547409930001', '90071992547409930002'];
+const paths = ['/api/v1/collectivex/runs', '/api/v1/collectivex/runs/{runId}'];
+const schema = {
+  paths: Object.fromEntries(
+    paths.map((path) => [
+      path,
+      {
+        get: { parameters: [{ name: 'version', required: true, schema: { enum: [1] } }] },
+      },
+    ]),
+  ),
+};
+const percentiles = (p50 = 20) => ({ p50, p90: 30, p95: 40, p99: 50 });
+const topology = {
+  ep_size: 8,
+  nodes: 1,
+  gpus_per_node: 8,
+  scale_up_domain: 8,
+  scale_up_transport: 'NVLink',
+  scale_out_transport: null,
+  topology_class: 'scale-up',
+};
+function dataset(id, latency = 20) {
+  return {
+    version: 1,
+    run: {
+      run_id: id,
+      run_attempt: 2,
+      generated_at: '2026-09-01T12:00:00Z',
+      conclusion: null,
+      source_sha: `sha-${id}`,
+      requested_cases: 1,
+      terminal_cases: 1,
+      measured_cases: 1,
+      unsupported_cases: 0,
+      failed_cases: 0,
+      requested_points: 1,
+      terminal_points: 1,
+      measured_points: 1,
+      covered_skus: ['h200_sxm'],
+    },
+    coverage: [{ case_id: 'case-a', outcome: 'success', reason: null, detail: 'raw coverage' }],
+    series: [
+      {
+        series_id: 'case-a',
+        phase: 'decode',
+        mode: 'normal',
+        precision: 'bf16',
+        backend: 'deepep',
+        system: { ...topology, sku: 'h200_sxm', vendor: 'nvidia' },
+        points: [
+          {
+            tokens_per_rank: 32,
+            global_tokens: 256,
+            components: {
+              dispatch: {
+                payload_bytes: 8192,
+                latency_us: percentiles(latency),
+                activation_data_rate_gbps_at_latency_percentile: null,
+                payload_data_rate_gbps_at_latency_percentile: percentiles(0),
+              },
+              stage: null,
+              combine: null,
+              roundtrip: null,
+            },
+            roundtrip_token_rate_at_latency_percentile: percentiles(0),
+          },
+        ],
+      },
+    ],
+  };
+}
+const body = (value, extra = {}) => ({ body: JSON.stringify(value), ...extra });
+
+before(() => {
+  for (const target of ['codex', 'claude']) installed.set(target, suite.install(target));
+  writeFileSync(
+    preload,
+    `
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+const fixture = JSON.parse(readFileSync(process.env.COLLECTIVEX_FIXTURE, 'utf8'));
+if (fixture.stdoutFailure) process.stdout.write = (_bytes, callback) => {
+  queueMicrotask(() => callback(new Error('broken pipe'))); return false;
+};
+globalThis.fetch = async (input, options) => {
+  const url = String(input);
+  appendFileSync(process.env.COLLECTIVEX_REQUESTS, JSON.stringify({ url, redirect: options.redirect }) + '\\n');
+  const response = fixture.responses[url];
+  if (!response) throw Error('Unexpected request: ' + url);
+  if (response.throw) throw Error(response.throw);
+  if (response.raceOutputPath) writeFileSync(response.raceOutputPath, 'concurrent output');
+  if (response.oversized) return new Response(new ReadableStream({
+    pull(c) { c.enqueue(new Uint8Array(8 * 1024 * 1024)); },
+  }));
+  if (response.lateChunk) return new Response(new ReadableStream({
+    start(c) { c.enqueue(new TextEncoder().encode('{"version":1')); },
+    pull(c) { c.error(new Error('late body failure')); },
+  }));
+  const result = new Response(response.body, { status: response.status ?? 200 });
+  if (response.redirected !== undefined) Object.defineProperty(result, 'redirected', { value: response.redirected });
+  if (response.url !== undefined) Object.defineProperty(result, 'url', { value: response.url });
+  return result;
+};
+`,
+  );
+});
+
+function run(left = dataset(ids[0]), right = dataset(ids[1], 10), options = {}) {
+  const cwd = options.cwd ?? suite.project();
+  const requestsPath = join(cwd, 'requests.jsonl');
+  const responses = {
+    [`${base}/api/openapi.json`]: body(schema),
+    [`${base}/api/v1/collectivex/runs?version=1`]: body({
+      version: 1,
+      discovery_complete: false,
+      runs: [
+        right.run,
+        { ...left.run, run_id: '90071992547409930003', measured_cases: 0 },
+        left.run,
+      ],
+    }),
+    [`${base}/api/v1/collectivex/runs/${ids[0]}?version=1`]: body(left),
+    [`${base}/api/v1/collectivex/runs/${ids[1]}?version=1`]: body(right),
+    ...options.responses,
+  };
+  const fixture = join(cwd, 'fixture.json');
+  writeFileSync(fixture, JSON.stringify({ responses, stdoutFailure: options.stdoutFailure }));
+  const result = suite.node(
+    [
+      '--import',
+      pathToFileURL(preload).href,
+      join(installed.get(options.target ?? 'codex'), 'scripts/compare-collectivex.mjs'),
+      ...(options.args ?? ['--left', ids[0], '--right', ids[1]]),
+    ],
+    {
+      cwd,
+      env: {
+        ...suite.environment,
+        COLLECTIVEX_FIXTURE: fixture,
+        COLLECTIVEX_REQUESTS: requestsPath,
+      },
+    },
+  );
+  return {
+    ...result,
+    cwd,
+    responses,
+    requests: existsSync(requestsPath)
+      ? readFileSync(requestsPath, 'utf8').trim().split('\n').map(JSON.parse)
+      : [],
+  };
+}
+function success(result) {
+  succeeded(result);
+  return JSON.parse(result.stdout);
+}
+
+test('packed helper compares exact EP identities and retains complete source bodies and large string IDs', () => {
+  for (const target of ['codex', 'claude']) {
+    const result = run(undefined, undefined, { target });
+    const output = success(result);
+    assert.equal(result.requests.length, 3);
+    assert.ok(result.requests.every((request) => request.redirect === 'error'));
+    assert.deepEqual(output.selection.run_ids, ids);
+    assert.equal(output.comparison_scope.source_sha_equal, false);
+    const matched = output.comparisons.find((row) => row.status === 'matched');
+    assert.equal(matched.identity.suite, 'ep');
+    assert.equal(matched.identity.operation, 'dispatch');
+    const latency = matched.metrics.find((metric) => metric.name === 'latency_us.p50');
+    assert.deepEqual(latency, {
+      name: 'latency_us.p50',
+      unit: 'us',
+      left: { status: 'value', value: 20 },
+      right: { status: 'value', value: 10 },
+      difference_right_minus_left: -10,
+      ratio_right_over_left: 0.5,
+    });
+    assert.equal(output.summary.matched, 1);
+    assert.equal(output.summary.incomparable, 3);
+    for (const response of output.responses) {
+      assert.equal(response.body_text, result.responses[response.query_url].body);
+      assert.equal(
+        response.decoded_body_sha256,
+        createHash('sha256').update(response.body_text).digest('hex'),
+      );
+      assert.ok(Number.isFinite(Date.parse(response.retrieved_at)));
+    }
+    assert.deepEqual(JSON.parse(output.responses[1].body_text), dataset(ids[0]));
+  }
+});
+
+function kvDataset(id, latency = 4) {
+  const result = dataset(id);
+  result.series = [];
+  result.coverage = [];
+  result.kv = [
+    {
+      case_id: 'kv-a',
+      label: 'H200 transfer',
+      disposition: 'runnable',
+      sku: 'h200_sxm',
+      vendor: 'nvidia',
+      backend: 'nixl',
+      fabric: 'rdma',
+      workload: 'kv-dsv4',
+      precision: 'bf16',
+      topology: {
+        ...topology,
+        ep_size: 2,
+        nodes: 2,
+        gpus_per_node: 1,
+        scale_up_domain: 1,
+        scale_out_transport: 'InfiniBand',
+        topology_class: 'scale-out',
+      },
+      outcome: 'success',
+      reason: null,
+      detail: null,
+      rows: [
+        {
+          kind: 'paged',
+          isl: 1024,
+          page_tokens: 16,
+          batch: 4,
+          op: 'pull',
+          descs: 64,
+          req_bytes: 1000000,
+          prep_ms: 0,
+          latency_ms: { p50: latency, p95: 8, min: 2, max: 10, n: 30 },
+          gbps_p50: 1,
+          verify_passed: true,
+        },
+      ],
+    },
+  ];
+  return result;
+}
+
+test('KV matches request bytes, burst configuration and topology while distinguishing burst and request latency', () => {
+  const left = kvDataset(ids[0]);
+  const right = kvDataset(ids[1], 2);
+  right.kv[0].label = 'cosmetic label changed';
+  right.kv[0].rows[0].request_ms = { p50: 0.5, p95: 1, min: 0.2, max: 2, n: 120 };
+  const output = success(run(left, right));
+  const matched = output.comparisons[0];
+  assert.equal(matched.status, 'matched');
+  assert.equal(matched.identity.suite, 'kv');
+  assert.equal(matched.identity.row.req_bytes, 1000000);
+  assert.equal(
+    matched.metrics.find((metric) => metric.name === 'latency_ms.p50').difference_right_minus_left,
+    -2,
+  );
+  const request = matched.metrics.find((metric) => metric.name === 'request_ms.p50');
+  assert.deepEqual(request.left, { status: 'missing' });
+  assert.deepEqual(request.right, { status: 'value', value: 0.5 });
+  assert.equal(request.ratio_right_over_left, null);
+  assert.equal(request.unit, 'ms per request');
+  assert.equal(matched.metrics.find((metric) => metric.name === 'prep_ms').left.value, 0);
+  for (const change of [
+    (data) => {
+      data.kv[0].rows[0].req_bytes = 2000000;
+    },
+    (data) => {
+      data.kv[0].rows[0].batch = 8;
+    },
+    (data) => {
+      data.kv[0].rows[0].op = 'push';
+    },
+    (data) => {
+      data.kv[0].rows[0].page_tokens = 32;
+    },
+    (data) => {
+      data.kv[0].fabric = 'mnnvl';
+    },
+    (data) => {
+      data.kv[0].workload = 'kv-other';
+    },
+    (data) => {
+      data.kv[0].rows[0].future_configuration = 'different';
+    },
+  ]) {
+    const altered = structuredClone(right);
+    change(altered);
+    const result = success(run(left, altered));
+    assert.equal(result.summary.matched, 0);
+    assert.equal(result.summary.only_left, 1);
+    assert.equal(result.summary.only_right, 1);
+  }
+  const failed = structuredClone(right);
+  failed.kv[0].rows[0].verify_passed = false;
+  const result = success(run(left, failed));
+  assert.equal(result.comparisons[0].status, 'incomparable');
+  assert.deepEqual(result.comparisons[0].issues, ['kv_verification_not_passed']);
+  assert.deepEqual(result.comparisons[0].metrics, []);
+});
+
+test('unsafe numeric configuration cannot alias into an equal comparison identity', () => {
+  for (const values of [
+    ['1e400', '2e400'],
+    ['9007199254740992', '9007199254740993'],
+  ]) {
+    const responses = Object.fromEntries(
+      ids.map((runId, index) => {
+        const data = dataset(runId);
+        data.series[0].future_configuration = 'REPLACE';
+        return [
+          `${base}/api/v1/collectivex/runs/${runId}?version=1`,
+          {
+            body: JSON.stringify(data).replace('"REPLACE"', values[index]),
+          },
+        ];
+      }),
+    );
+    const result = run(undefined, undefined, { responses });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unrepresentable number/u);
+    assert.equal(result.stdout, '');
+  }
+});
+
+test('redirected or foreign final responses cannot be attributed to the requested source', () => {
+  for (const overrides of [
+    { redirected: true },
+    { url: 'https://foreign.example/api/openapi.json' },
+  ]) {
+    const result = run(undefined, undefined, {
+      responses: {
+        [`${base}/api/openapi.json`]: body(schema, overrides),
+      },
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /response URL/u);
+    assert.equal(result.stdout, '');
+    assert.equal(result.requests.length, 1);
+  }
+});
+
+test('one discovery pass selects by exact numeric run ID and never claims exhaustive history', () => {
+  const result = run(undefined, undefined, { args: [] });
+  const output = success(result);
+  assert.equal(result.requests.length, 4);
+  assert.deepEqual(output.selection.run_ids, ids);
+  assert.equal(output.discovery.returned_runs, 3);
+  assert.equal(output.discovery.discovery_complete, false);
+  assert.equal(output.discovery.history_complete, false);
+  for (const complete of [false, true]) {
+    const listed = body({ version: 1, runs: [dataset(ids[0]).run], discovery_complete: complete });
+    const empty = run(undefined, undefined, {
+      args: [],
+      responses: {
+        [`${base}/api/v1/collectivex/runs?version=1`]: listed,
+      },
+    });
+    const data = success(empty);
+    assert.equal(data.outcome, 'fewer_than_two_measured_runs');
+    assert.equal(data.discovery.discovery_complete, complete);
+    assert.equal(data.discovery.history_complete, false);
+    assert.equal(empty.requests.length, 2);
+    assert.deepEqual(data.comparisons, []);
+  }
+});
+
+test('EP rejects cross-operation, configuration, dtype, message-size, rank and topology pairing', () => {
+  for (const change of [
+    (series) => {
+      series.backend = 'uccl';
+    },
+    (series) => {
+      series.precision = 'fp8';
+    },
+    (series) => {
+      series.phase = 'prefill';
+    },
+    (series) => {
+      series.mode = 'low-latency';
+    },
+    (series) => {
+      series.series_id = 'different-case';
+    },
+    (series) => {
+      series.system.sku = 'b200';
+    },
+    (series) => {
+      series.system.ep_size = 16;
+      series.points[0].global_tokens = 512;
+    },
+    (series) => {
+      series.system.nodes = 2;
+    },
+    (series) => {
+      series.system.scale_up_transport = 'different-fabric';
+    },
+    (series) => {
+      series.points[0].tokens_per_rank = 64;
+      series.points[0].global_tokens = 512;
+    },
+    (series) => {
+      series.points[0].components.dispatch.payload_bytes = 16384;
+    },
+    (series) => {
+      series.points[0].future_configuration = 'different';
+    },
+    (series) => {
+      series.points[0].components.combine = series.points[0].components.dispatch;
+      series.points[0].components.dispatch = null;
+    },
+  ]) {
+    const right = dataset(ids[1]);
+    change(right.series[0]);
+    const output = success(run(dataset(ids[0]), right));
+    assert.equal(output.summary.matched, 0);
+    assert.equal(output.summary.only_left, 1);
+    assert.equal(output.summary.only_right, 1);
+    assert.ok(output.comparisons.every((row) => row.metrics.length === 0));
+  }
+});
+
+test('duplicate identities, absent components and missing configuration are explicit instead of arbitrarily paired', () => {
+  const right = dataset(ids[1]);
+  right.series.push(structuredClone(right.series[0]));
+  const duplicate = success(run(dataset(ids[0]), right));
+  assert.equal(duplicate.summary.ambiguous, 4);
+  assert.ok(duplicate.comparisons.every((row) => row.metrics.length === 0));
+  assert.deepEqual(
+    duplicate.comparisons[0].right.map((source) => source.json_pointer),
+    ['/series/0/points/0/components/dispatch', '/series/1/points/0/components/dispatch'],
+  );
+  for (const change of [
+    (data) => {
+      data.series[0].points[0].components.dispatch.payload_bytes = null;
+    },
+    (data) => {
+      delete data.series[0].system.scale_out_transport;
+    },
+    (data) => {
+      data.series[0].system = null;
+    },
+  ]) {
+    const left = dataset(ids[0]);
+    const modifiedRight = dataset(ids[1]);
+    change(left);
+    change(modifiedRight);
+    const output = success(run(left, modifiedRight));
+    assert.equal(output.summary.matched, 0);
+    assert.equal(output.summary.incomparable, 4);
+    assert.ok(output.comparisons[0].issues.length > 0);
+  }
+});
+
+test('null, missing and zero metrics retain their meanings and zero denominators have no ratio', () => {
+  const left = dataset(ids[0], 0);
+  const right = dataset(ids[1], 10);
+  left.series[0].points[0].components.dispatch.latency_us.p90 = null;
+  delete left.series[0].points[0].components.dispatch.latency_us.p95;
+  const output = success(run(left, right));
+  const metrics = output.comparisons.find((row) => row.status === 'matched').metrics;
+  assert.deepEqual(
+    metrics.find((row) => row.name === 'latency_us.p50'),
+    {
+      name: 'latency_us.p50',
+      unit: 'us',
+      left: { status: 'value', value: 0 },
+      right: { status: 'value', value: 10 },
+      difference_right_minus_left: 10,
+      ratio_right_over_left: null,
+    },
+  );
+  assert.deepEqual(metrics.find((row) => row.name === 'latency_us.p90').left, {
+    status: 'null',
+    value: null,
+  });
+  assert.deepEqual(metrics.find((row) => row.name === 'latency_us.p95').left, {
+    status: 'missing',
+  });
+  assert.equal(
+    metrics.find((row) => row.name === 'latency_us.p90').difference_right_minus_left,
+    null,
+  );
+});
+
+test('failed detail requests, redirects, malformed identity and late body failure produce no partial export', () => {
+  const path = `${base}/api/v1/collectivex/runs/${ids[1]}?version=1`;
+  const malformed = dataset(ids[1]);
+  malformed.series[0].points[0].components.dispatch.latency_us.p50 = '10';
+  for (const response of [
+    body({ error: 'Not found' }, { status: 404 }),
+    body({ error: 'Unavailable' }, { status: 503 }),
+    body({}, { status: 302 }),
+    { body: '{' },
+    { body: `\uFEFF${JSON.stringify(dataset(ids[1]))}` },
+    { lateChunk: true },
+    body(dataset(ids[0])),
+    body({ ...dataset(ids[1]), version: 2 }),
+    body({ ...dataset(ids[1]), run: { ...dataset(ids[1]).run, run_id: 9007199254740992 } }),
+    body({
+      ...dataset(ids[1]),
+      run: { ...dataset(ids[1]).run, generated_at: '2026-02-30T12:00:00Z' },
+    }),
+    body({
+      ...dataset(ids[1]),
+      run: { ...dataset(ids[1]).run, generated_at: '2026-09-01T24:00:00Z' },
+    }),
+    body(malformed),
+  ]) {
+    const result = run(undefined, undefined, {
+      args: ['--left', ids[0], '--right', ids[1], '--output', 'result.json'],
+      responses: { [path]: response },
+    });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.stdout, '');
+    assert.equal(existsSync(join(result.cwd, 'result.json')), false);
+    assert.ok(readdirSync(result.cwd).every((file) => !file.startsWith('.collectivex-')));
+  }
+});
+
+test('invalid selection and unsupported schema stop before guessing IDs or requesting details', () => {
+  for (const args of [
+    ['--left', ids[0]],
+    ['--left', ids[0], '--right', ids[0]],
+    ['--left', '01', '--right', ids[1]],
+    ['--left', '1e3', '--right', ids[1]],
+    ['--left', 'https://example.org', '--right', ids[1]],
+    ['--version', '2'],
+  ]) {
+    const result = run(undefined, undefined, { args });
+    assert.notEqual(result.status, 0);
+    assert.deepEqual(result.requests, []);
+  }
+  const unsupported = run(undefined, undefined, {
+    responses: { [`${base}/api/openapi.json`]: body({ paths: {} }) },
+  });
+  assert.notEqual(unsupported.status, 0);
+  assert.equal(unsupported.requests.length, 1);
+  for (const runs of [
+    [dataset(ids[0]).run, dataset(ids[0]).run],
+    [{ ...dataset(ids[0]).run, measured_cases: null }],
+  ]) {
+    const result = run(undefined, undefined, {
+      args: [],
+      responses: {
+        [`${base}/api/v1/collectivex/runs?version=1`]: body({
+          version: 1,
+          discovery_complete: true,
+          runs,
+        }),
+      },
+    });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.requests.length, 2);
+  }
+});
+
+test('atomic file publication preserves existing files, symlinks and directories and reports output failure', () => {
+  const result = run(undefined, undefined, {
+    args: ['--left', ids[0], '--right', ids[1], '--output', 'result.json'],
+  });
+  succeeded(result);
+  assert.equal(result.stdout, '');
+  assert.equal(
+    JSON.parse(readFileSync(join(result.cwd, 'result.json'), 'utf8')).summary.matched,
+    1,
+  );
+  assert.ok(readdirSync(result.cwd).every((file) => !file.startsWith('.collectivex-')));
+  for (const type of ['file', 'directory', 'symlink']) {
+    const cwd = suite.project();
+    const destination = join(cwd, 'result.json');
+    if (type === 'file') writeFileSync(destination, 'keep');
+    if (type === 'directory') mkdirSync(destination);
+    if (type === 'symlink') {
+      writeFileSync(join(cwd, 'original'), 'keep');
+      symlinkSync('original', destination);
+    }
+    const failed = run(undefined, undefined, { cwd, args: ['--output', 'result.json'] });
+    assert.notEqual(failed.status, 0);
+    assert.deepEqual(failed.requests, []);
+    if (type !== 'directory') assert.equal(readFileSync(destination, 'utf8'), 'keep');
+  }
+  const broken = run(undefined, undefined, { stdoutFailure: true });
+  assert.notEqual(broken.status, 0);
+  assert.equal(broken.stdout, '');
+  assert.match(broken.stderr, /broken pipe/u);
+});
+
+test('response budget and a concurrent output file fail closed after successful earlier reads', () => {
+  const path = `${base}/api/v1/collectivex/runs/${ids[1]}?version=1`;
+  const oversized = run(undefined, undefined, { responses: { [path]: { oversized: true } } });
+  assert.notEqual(oversized.status, 0);
+  assert.equal(oversized.stdout, '');
+  assert.equal(oversized.requests.length, 3);
+  assert.match(oversized.stderr, /32 MiB response budget/u);
+  const race = run(undefined, undefined, {
+    args: ['--left', ids[0], '--right', ids[1], '--output', 'result.json'],
+    responses: { [path]: body(dataset(ids[1]), { raceOutputPath: 'result.json' }) },
+  });
+  assert.notEqual(race.status, 0);
+  assert.equal(race.stdout, '');
+  assert.equal(readFileSync(join(race.cwd, 'result.json'), 'utf8'), 'concurrent output');
+  assert.ok(readdirSync(race.cwd).every((file) => !file.startsWith('.collectivex-')));
+});
+
+test('native fetch refuses a redirected second run and never reaches the replacement scope', async () => {
+  const requests = [];
+  const server = createServer((request, response) => {
+    requests.push(request.url);
+    if (request.url === `/api/v1/collectivex/runs/${ids[1]}?version=1`) {
+      response.writeHead(302, { Location: '/different-run' });
+      response.end();
+      return;
+    }
+    response.setHeader('Content-Type', 'application/json');
+    response.end(JSON.stringify(request.url === '/api/openapi.json' ? schema : dataset(ids[0])));
+  });
+  await new Promise((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const cwd = suite.project();
+  const nativePreload = join(cwd, 'native-fetch.mjs');
+  writeFileSync(
+    nativePreload,
+    `
+const native = globalThis.fetch;
+globalThis.fetch = async (input, options) => {
+ const url = new URL(input);
+ const response = await native(new URL(url.pathname + url.search, 'http://127.0.0.1:${server.address().port}'), options);
+ // Restore the requested origin after routing through the local fixture; native redirect handling stays active.
+ Object.defineProperty(response, 'url', { value: String(input) });
+ return response;
+};
+`,
+  );
+  try {
+    await assert.rejects(
+      promisify(execFile)(
+        process.execPath,
+        [
+          '--import',
+          pathToFileURL(nativePreload).href,
+          join(installed.get('codex'), 'scripts/compare-collectivex.mjs'),
+          '--left',
+          ids[0],
+          '--right',
+          ids[1],
+          '--output',
+          'result.json',
+        ],
+        { cwd, env: suite.environment, timeout: 10000 },
+      ),
+      { code: 1, stdout: '' },
+    );
+    assert.deepEqual(requests, [
+      '/api/openapi.json',
+      `/api/v1/collectivex/runs/${ids[0]}?version=1`,
+      `/api/v1/collectivex/runs/${ids[1]}?version=1`,
+    ]);
+    assert.equal(existsSync(join(cwd, 'result.json')), false);
+  } finally {
+    await new Promise((resolveClose) => {
+      server.close(resolveClose);
+    });
+  }
+});
+
+test('both packed cookbooks execute their installed discovery commands and retain coverage guidance', () => {
+  for (const target of ['codex', 'claude']) {
+    const root = installed.get(target);
+    const cookbook = readFileSync(join(root, 'references/collectivex.md'), 'utf8');
+    const prefix = target === 'codex' ? '.agents' : '.claude';
+    const commands = [...cookbook.matchAll(/```bash\n(?<command>node [^\n]+)\n```/gu)].map(
+      (match) => match.groups.command,
+    );
+    const command = commands.find((line) => line.includes(prefix) && !line.includes('--left'));
+    assert.ok(command);
+    const [, script, ...args] = command.split(' ');
+    assert.equal(resolve(root, '../../../', script), join(root, 'scripts/compare-collectivex.mjs'));
+    const result = run(undefined, undefined, { target, cwd: resolve(root, '../../..'), args });
+    succeeded(result);
+    const output = JSON.parse(
+      readFileSync(join(result.cwd, 'collectivex-comparison.json'), 'utf8'),
+    );
+    assert.equal(output.discovery.discovery_complete, false);
+    assert.equal(output.summary.matched, 1);
+    assert.equal(output.responses.length, 4);
+    const guidance = cookbook.replaceAll(/\s+/gu, ' ');
+    for (const required of [
+      'Cases with **no measured rows** have no comparison group.',
+      "complete datasets' `coverage` and optional `kv` arrays",
+      'not proof of a controlled experiment',
+      'Even `discovery_complete=true` does **not** mean complete workflow history.',
+      'Rate-at-latency-p99 is a rate derived at p99 latency',
+      'A zero left denominator yields a null ratio.',
+      'no new benchmarks were run',
+    ])
+      assert.ok(guidance.includes(required), required);
+  }
+});

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -309,6 +309,10 @@ test('0.4 prerelease and later receipts require matching AgentX versions', () =>
         join(destination, 'scripts/compare-releases.mjs'),
         `const PACKAGE_VERSION = '${version}';\n`,
       );
+      writeFileSync(
+        join(destination, 'scripts/compare-collectivex.mjs'),
+        `const PACKAGE_VERSION = '${version}';\n`,
+      );
     }
     const matching = run(['status'], cwd);
     succeeded(matching);
@@ -398,6 +402,39 @@ test('0.7 receipts require the release helper, while older receipts ignore retai
     assert.equal(
       jsonResult(run(['status', '--json'], cwd)).installed_version,
       version.startsWith('0.7.') ? null : version,
+    );
+  }
+});
+
+test('0.8 receipts require CollectiveX and retain compatibility with forced downgrades', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const helper = join(destination, 'scripts/compare-collectivex.mjs');
+  for (const version of ['0.8.0-rc.1', '0.7.9']) {
+    setInstalledVersion(destination, version);
+    for (const file of [
+      'export-agentx.mjs',
+      'investigate-result.mjs',
+      'compare-tco.mjs',
+      'compare-releases.mjs',
+    ]) {
+      writeFileSync(join(destination, 'scripts', file), `const PACKAGE_VERSION = '${version}';\n`);
+    }
+    writeFileSync(
+      helper,
+      `const PACKAGE_VERSION = '${version}';\nthrow new Error('must not execute');\n`,
+    );
+    assert.equal(jsonResult(run(['status', '--json'], cwd)).installed_version, version);
+    writeFileSync(helper, "const PACKAGE_VERSION = '0.1.0';\n");
+    assert.equal(
+      jsonResult(run(['status', '--json'], cwd)).installation_state,
+      version.startsWith('0.8.') ? 'unknown' : 'installed',
+    );
+    rmSync(helper);
+    assert.equal(
+      jsonResult(run(['status', '--json'], cwd)).installed_version,
+      version.startsWith('0.8.') ? null : version,
     );
   }
 });

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -31,11 +31,13 @@ const EXPECTED_FILES = [
   'skills/inferencex-api/references/provenance.md',
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
+  'skills/inferencex-api/references/collectivex.md',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
   'skills/inferencex-api/scripts/investigate-result.mjs',
   'skills/inferencex-api/scripts/compare-tco.mjs',
   'skills/inferencex-api/scripts/compare-releases.mjs',
+  'skills/inferencex-api/scripts/compare-collectivex.mjs',
 ];
 
 test('read-only release verification rejects altered evidence and unsafe retries', () => {


### PR DESCRIPTION
## Summary

CollectiveX communication comparisons previously required manual response assembly. Version 0.8.0 adds bounded run discovery and a JSON exporter for two existing runs. EP/KV pairing preserves public operation, backend, precision, topology and the respective payload/request byte counts, with units, missingness, coverage and complete response bodies.

The helper rejects numeric identity aliases and incorrect final response attribution, prevents partial output files and leaves ambiguous pairs uncompared. Attempts and source revisions remain evidence rather than proof of a controlled experiment. Installer status and the eighteen-file release archive include the cookbook and helper; no communication benchmark is launched.

## Testing

- Node 24.20.0 and Node 26.8.1: 179 packed-package tests passed on the accepted candidate source.
- Lint, formatting, typecheck, typography, skill validation and exact archive/link checks passed. API catalog and TCO contract checks: 53 passed.
- Independent packed pressure reviews reproduced defects and verified fixes. Fresh Codex/Claude projects discovered the corrected installed skill from unhinted tasks; all comparisons were independently recomputed from consumed responses. Transcript and access-boundary review passed. Original Claude delivery remains qualified for one omitted pre-HTTP permission denial and loose final wording; a separate corrected reviewer copy and all attempts are retained. Candidate installation and public API verification passed on the corrected archive.
- Accepted artifact source `8dfd2a6262106d8729ffc3e7a15c673f9c9cefbd`; archive SHA-256 `25a9e320c0b8134a99fa5b8ba88bae72e6d5b00e4bcde10b7014994233f0ff77`.

Release 0.8.0 through the existing default-branch OIDC workflow after checks. Website installation commands remain on the currently verified public version. No new benchmark was run; remote CI will validate this PR.

## 中文说明

原先需要手动拼接 CollectiveX 响应才能比较通信基准测试。0.8.0 新增限定范围的运行发现与 JSON 导出流程，用于比较两次现有运行。EP/KV 匹配保留公开的操作、backend、精度、拓扑，以及各自的 payload 或请求字节数，并输出单位、缺失情况、覆盖范围和完整响应。

脚本会拒绝数值精度造成的错误身份匹配、最终响应来源不符和不完整写入；存在多个候选时不会任意配对。attempt 与来源 revision 仅作为证据保留，不能证明受控实验。安装状态检查和十八文件产物包含指南与脚本；本流程不启动通信基准测试。

最终源码在 Node 24.20.0 与 Node 26.8.1 上各通过 179 项打包测试；lint、格式、类型、typography、技能结构和产物文件/链接检查通过，API 目录与 TCO 合约检查通过 53 项。独立压力测试发现的问题已修复并复测，所有尝试均保留。全新 Codex/Claude 项目已通过不提示技能名称的任务发现修正后的安装技能，比较结果已按实际使用的响应独立重算。执行记录和访问范围复查通过。Claude 原始交付中漏述了一次请求前的权限拒绝，结尾措辞也需限定；另附审阅后的修订副本，并保留原件与所有尝试。修正安装包的安装与公开 API 验证通过。

检查完成后通过现有主分支 OIDC 工作流发布 0.8.0。网站安装命令仍使用已经公开验证的版本。本次不运行新基准测试，PR 将运行远程 CI。
