### PR TITLE
[docs] activate verified skills 0.8.0 / 在 API 页面启用已验证的 skills 0.8.0

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -8,10 +8,10 @@ constructing requests.
 
 ## Install
 
-Until 0.8.0 is published, install the reviewed local archive using the
-[package README](../packages/skills/README.md#review-a-local-archive). The npm
-commands below apply after publication; the website continues to advertise the
-last published version until its release has been verified.
+The commands below install the verified public 0.8.0 release advertised on
+[/api](https://inferencex.semianalysis.com/api) and
+[/zh/api](https://inferencex.semianalysis.com/zh/api). For a future unpublished
+candidate, use the [local archive instructions](../packages/skills/README.md#review-a-local-archive).
 
 With Node 24 or later and npm, run the command for your agent from your project:
 

--- a/docs/inferencex-skills-discovery.md
+++ b/docs/inferencex-skills-discovery.md
@@ -92,5 +92,6 @@ project, an explicit-use run, or unreviewed model prose as accepted discovery.
 - 0.7.0: framework-update investigation with matched observations and confounders.
 - 0.8.0: CollectiveX discovery, comparison and export cookbook.
 
-This candidate is 0.8.0 and includes the preceding three releases. Keep each
-version on its separate local branch and validate its exact archive. A local candidate does not establish npm publication.
+Versions 0.5.0 through 0.8.0 are published releases. Version 0.8.0 includes all
+four capability groups above. For future candidates, validate the exact archive;
+local acceptance alone does not establish npm publication.

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -1,8 +1,9 @@
 # Releasing the InferenceX API skill
 
 The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0`,
-`0.2.0`, `0.3.0`, and `0.4.0` are immutable public releases. Keep website commands pinned
-to the last verified public version until publication and public verification
+`0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`, and `0.8.0` are immutable
+public releases. The website advertises the verified `0.8.0` release. For later
+releases, keep website commands pinned until publication and public verification
 succeed. The
 [`publish-skills.yml`](../.github/workflows/publish-skills.yml) workflow prepares
 future releases; it does not run on application tags or database-backup releases.
@@ -41,22 +42,27 @@ suite on Node 24 and 26 for package and skill-workflow changes. That suite also 
 Python release-verifier tests. Publication remains on Node 24 with one publisher runtime.
 
 1. Modify the source, choose a new stable version, and update package metadata,
-   both exporters' standalone versions, installation examples, and installed-version
+   all shipped helpers' standalone versions, installation examples, and installed-version
    expectations together. Run the package tests and the relevant repository checks.
    Merge the reviewed source before preparing the final accepted archive.
 2. Run the following from the repository root using Node 24/npm and Python 3 on
    Linux or macOS (the public verification deadline uses Unix process groups and timers).
-   Choose a **new output directory for every attempt**. Substitute the intended
-   version. The `0.4.0` paths below describe this candidate; preparation alone
-   does not prove publication.
+   Choose a **new output directory for every attempt**. The commands read the
+   version from the source package after its version bump; it must be an unused
+   stable version, not an already published release. Keep these shell variables
+   for the later checks. Preparation alone does not prove publication.
 
 ```bash
+skills_release_version="$(node -p "require('./packages/skills/package.json').version")"
+skills_release_attempt="$(mktemp -d "${TMPDIR:-/tmp}/inferencex-release.XXXXXX")"
+skills_release_dir="$skills_release_attempt/candidate"
+
 node --test packages/skills/test/*.test.mjs
-node packages/skills/scripts/release.mjs prepare 0.4.0 /tmp/inferencex-release-0.4.0
-python3 packages/skills/scripts/verify-release.py candidate /tmp/inferencex-release-0.4.0/release.json \
+node packages/skills/scripts/release.mjs prepare "$skills_release_version" "$skills_release_dir"
+python3 packages/skills/scripts/verify-release.py candidate "$skills_release_dir/release.json" \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
   --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
-  --evidence /tmp/inferencex-candidate-check-0.4.0
+  --evidence "$skills_release_attempt/candidate-check"
 ```
 
 The preparer requires and records a clean package source state. It rejects dirty
@@ -93,10 +99,12 @@ instructions, examples, installer behavior, or export semantics change, and befo
 accepting the archive for publication.
 
 ```bash
-python3 packages/skills/scripts/verify-release.py agents /tmp/inferencex-release-0.4.0/release.json \
+python3 packages/skills/scripts/verify-release.py agents "$skills_release_dir/release.json" \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
   --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
-  --evidence /tmp/inferencex-agent-preparation-0.4.0
+  --evidence "$skills_release_attempt/agent-preparation"
+
+skills_agent_root="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["clean_root"])' "$skills_release_attempt/agent-preparation/verification.json")"
 ```
 
 The output identifies a new temporary root with `codex/` and `claude/` projects.
@@ -129,11 +137,11 @@ into evidence or GitHub Actions secrets for this test.
 After each agent completes, independently check its generated files:
 
 ```bash
-python3 packages/skills/scripts/verify-release.py check-agent /tmp/inferencex-release-0.4.0/release.json \
-  --project /tmp/inferencex-skill-acceptance-REPLACE/codex \
+python3 packages/skills/scripts/verify-release.py check-agent "$skills_release_dir/release.json" \
+  --project "$skills_agent_root/codex" \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
   --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
-  --evidence /tmp/inferencex-codex-result-check-0.4.0
+  --evidence "$skills_release_attempt/codex-result-check"
 ```
 
 Repeat for Claude Code with a new evidence directory. Use the **same scope arguments**
@@ -208,10 +216,11 @@ metadata is not yet available), the version is already immutable. Inspect the
 saved failure and rerun **only the read-only verifier**, preserving a new attempt:
 
 ```bash
-python3 packages/skills/scripts/verify-release.py public /tmp/inferencex-release-0.4.0/release.json \
+skills_public_attempt="$(mktemp -d "${TMPDIR:-/tmp}/inferencex-public-check.XXXXXX")"
+python3 packages/skills/scripts/verify-release.py public "$skills_release_dir/release.json" \
   --model DeepSeek-V4-Pro --isl 8192 --osl 1024 \
   --agentx-model DeepSeek-V4-Pro --agentx-point-id 441083 --agentx-no-trace-id 440998 \
-  --evidence /tmp/inferencex-public-check-0.4.0-attempt2
+  --evidence "$skills_public_attempt/evidence"
 ```
 
 Do not rerun publication or bump the version just to hide a failed verification.

--- a/packages/app/src/lib/published-inferencex-skills.json
+++ b/packages/app/src/lib/published-inferencex-skills.json
@@ -1,4 +1,4 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.4.0"
+  "version": "0.8.0"
 }


### PR DESCRIPTION
## Summary

Update `/api` and `/zh/api` from skills 0.4.0 to the verified 0.8.0 release, including the version badge and copied Codex/Claude install commands. Align the linked installation, discovery and release guides with the published 0.5–0.8 capabilities, and derive future release examples from the bumped package version.

Versions 0.5.0, 0.6.0, 0.7.0 and 0.8.0 were published and publicly verified in that order. The [0.8.0 release workflow](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34066271635) passed candidate and anonymous public-install checks. Independent npm signature and provenance verification confirmed the accepted archive, source commit and workflow run. This change touches four website/documentation files and does not alter the published package.

## Testing

- Lint, formatting, typecheck, typography and API documentation guards passed.
- Workspace unit and packed suites: 5,953 passed, including 179 skills tests.
- Cypress smoke: 46 component and 113 integration tests passed.
- Explicit `api-documentation.cy.ts`: 6 passed, including exact clipboard commands in both languages and mobile overflow checks.
- Desktop/mobile screenshots and rendered text reviewed for both installation cards; Chinese review and manual checks passed.

## 中文说明

将 `/api` 和 `/zh/api` 的技能版本从 0.4.0 更新为已验证的 0.8.0，同步版本徽标及可复制的 Codex/Claude 安装命令。更新相关安装、功能发现和发布文档，涵盖已发布的 0.5–0.8 功能；后续发布示例从完成版本更新的包元数据读取版本号。

0.5.0、0.6.0、0.7.0 和 0.8.0 已依次发布并完成公开验证。上述 0.8.0 工作流已通过候选包及匿名公开安装检查，独立的 npm 签名和溯源检查也确认了安装包、源提交与发布工作流一致。本次仅修改四个网站及文档文件，不改动已发布的 npm 包。

Lint、格式、类型、字体规范及 API 文档校验均通过；单元和打包测试共 5,953 项通过，其中技能测试 179 项。浏览器冒烟测试通过 46 项组件测试和 113 项集成测试；API 页面专项测试 6 项通过，覆盖中英文完整安装命令复制和手机端横向滚动。两种语言的桌面及手机截图已人工检查，中文文案也完成 Claude 与人工检查。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and a single published-version JSON constant only; no runtime logic, auth, or npm package changes.
> 
> **Overview**
> **Promotes the public API skill from 0.4.0 to the verified 0.8.0 release** by updating `published-inferencex-skills.json`, which drives the version badge and Codex/Claude `npm exec` install snippets on `/api` and `/zh/api`.
> 
> **Documentation now treats 0.5.0–0.8.0 as published** instead of describing 0.8.0 as an unpublished candidate: install examples point at the live site commands, discovery notes cover all four capability groups in 0.8.0, and the release guide lists the full immutable version range with the site pinned to 0.8.0.
> 
> **Future release runbooks** replace hardcoded `0.4.0` paths with shell variables that read `packages/skills/package.json`, use `mktemp` attempt directories, and wire agent/public verification to those paths (including parsing `clean_root` from agent preparation output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cfce1dc0c3056a1a32e5dbfa255cf7cfacbe1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->