### PR TITLE
[fix] harden skill CLI reliability for 0.9.0 / 加固技能 CLI 0.9.0 的可靠性

### DIFF
--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -79,6 +79,22 @@ AgentX selection, and checks one traced and one no-trace point. Missing and null
 values remain missing; real `0` and `false` values remain explicit. No new
 benchmarks run.
 
+From 0.9.0, candidate and public verification also run all four newer installed
+helpers for both targets. The provenance case selects result `416696` from logical
+run `26694739752`. The release case matches GLM-5.1/MI355X/SGLang observations from
+2026-05-30 and 2026-07-02 by their exact producer attempts and checks `median_ttft`
+arithmetic. The TCO case uses the 2026-09-06 DeepSeek-V4-Pro 8192x1024 snapshot at
+50 output tok/s/user with explicit **test assumptions** of $3.60/B200 GPU-hour and
+$1.80/MI355X GPU-hour; these are not market prices. CollectiveX discovers two
+measured runs and verifies retained run identities, source pointers and summary
+counts. No comparable CollectiveX rows is a valid, explicit outcome.
+
+These are live smoke checks, not exhaustive domain or native-agent acceptance.
+Missing provenance/logs, unavailable TCO points or missing historical comparison
+pairs fail and require reviewing the case. Do not weaken the gate to silently
+accept an empty positive example. The same public verification deadline covers
+these subprocesses, and failed output and command records remain preserved.
+
 The live check uses the requested model/workload; there is no fixed date or expected
 row count. Use `--date YYYY-MM-DD` for a reproducible cutoff and `--raw-model KEY`
 when intentionally selecting a particular returned model. A positive example that

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -10,10 +10,35 @@ also provides evaluation lookups and dataset-to-conversation inspection, with
 request context, exact identifiers, missing values, and page/sample boundaries.
 It also covers benchmark history filtered by GPU, workload and observation-date range.
 
-The npm commands below pin version `0.8.0` and require that version to be published.
+The npm commands below pin version `0.9.0` and require that version to be published.
 For review before publication, use the local archive instructions below.
 
-## New in 0.8.0
+## New in 0.9.0
+
+PowerX stages file output beside its destination and replaces it only after the
+write succeeds. Interrupted writes preserve the previous export. Existing output
+symlinks still address their target; evidence manifests and exports are separate
+files, not a single filesystem transaction. A failed manifest write can therefore
+coexist with a complete exported file and still produces a failing exit status.
+
+PowerX and AgentX now reject malformed UTF-8 and responses over **32 MiB of decoded
+bytes**. AgentX additionally limits all response bytes to **128 MiB** and its HTTP
+sequence to **120 seconds**, retaining the **30-second per-request timeout**.
+Limit failures do not return truncated success; completed evidence bodies remain
+available for diagnosis, while incomplete bodies have no complete-body hash.
+There are no automatic HTTP retries. Narrow the model/date scope if a limit is hit.
+
+All six installed helpers accept `--version` without network access or required
+query arguments. Existing successful JSON/CSV fields and calculations are unchanged.
+The installer checks the additional response reader when identifying 0.9+ installs.
+
+Release verification now exercises all six helpers from clean installations for
+both targets, including retained-source checks for the four newer workflows.
+These live smoke checks supplement fixture tests; they do not establish native
+agent discovery or narrative quality. Node 24/26 are checked on Linux in CI;
+macOS is checked locally. Windows compatibility is not yet qualified.
+
+## Included from 0.8.0
 
 [CollectiveX comparisons](skills/inferencex-api/references/collectivex.md) discover
 two existing communication runs or accept two exact run IDs, then export JSON
@@ -76,10 +101,10 @@ Run the command for your agent from the project where it should discover the ski
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target claude
 ```
 
 | Target              | Skill location relative to the current project |
@@ -90,9 +115,9 @@ npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-s
 For an explicit skills-root directory or inspection:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --dir './my project/.agents/skills'
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills list
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills --help
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --dir './my project/.agents/skills'
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills list
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills --help
 ```
 
 `--dir` selects the parent skills directory; the installer appends `inferencex-api`.
@@ -105,7 +130,7 @@ To review a maintainer-supplied `.tgz` before publication, replace the path with
 actual archive and run from the target project. Use `--target claude` for Claude Code.
 
 ```bash
-INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.8.0.tgz'
+INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.9.0.tgz'
 npm exec --yes --offline --package "$INFERENCEX_SKILLS_TGZ" -- inferencex-skills install --target codex
 ```
 
@@ -225,7 +250,7 @@ availability is false or omitted.
 ### Inspect the installed version
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills status --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills status --target codex
 ```
 
 Use `--target claude` or `--dir './my project/.agents/skills'` to inspect another
@@ -251,8 +276,8 @@ check is not a full integrity check and cannot detect every local edit.
 ### JSON output and installation preview
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills status --target codex --json
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex --force --dry-run --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills status --target codex --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex --force --dry-run --json
 ```
 
 `--json` on `status` or `install` emits one JSON document to stdout; diagnostics go
@@ -288,11 +313,11 @@ without stale installation fields; use the exit code to determine success.
 ### Upgrade
 
 Repeated installation skips an existing skill. Add `--force` to reinstall a pinned
-version. To upgrade, replace `0.8.0` with the published version you intend to install:
+version. To upgrade, replace `0.9.0` with the published version you intend to install:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex --force
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target claude --force
 ```
 
 Force merges the packaged files into the existing skill and overwrites matching
@@ -311,10 +336,28 @@ skill directory. Keep a copy of local edits before choosing an overwrite.
 数据集到会话详情的完整示例，说明如何保留请求上下文、原始标识符、缺失值，以及分页和
 抽样范围；还提供按 GPU、工作负载和观测日期范围筛选历史基准测试数据的示例。
 
-上面的 npm 命令固定使用 `0.8.0`，需在该版本发布后执行。发布前审阅请使用本地产物
+上面的 npm 命令固定使用 `0.9.0`，需在该版本发布后执行。发布前审阅请使用本地产物
 安装流程。
 
-0.8.0 新增 [CollectiveX 比较](skills/inferencex-api/references/collectivex.md)：发现两个现有的通信
+0.9.0 改进导出失败时的文件保护：PowerX 先在目标文件旁完整写入临时文件，写入成功后才
+替换目标；中途写入失败会保留旧结果。目标路径为符号链接时仍写入其指向的文件。导出文件
+和证据 manifest 是两个独立文件，不构成一次文件系统事务；manifest 写入失败时可能已存在
+完整导出文件，但命令仍以失败状态退出。
+
+PowerX 和 AgentX 会拒绝非法 UTF-8，以及解压后超过 **32 MiB** 的单次响应。AgentX 还将
+所有响应的总大小限制为 **128 MiB**，HTTP 请求序列限制为 **120 秒**；每个请求仍有
+**30 秒**超时。超限会明确失败，不会把截断结果当作成功导出。已完整收到的响应会保留在
+请求的证据目录中；未完整读取的响应不会记录完整响应哈希。HTTP 请求不自动重试，超限时
+可缩小模型或日期范围。
+
+六个 helper 均支持离线 `--version`，无需填写查询参数。成功导出的 JSON/CSV 字段和计算
+方法保持兼容。安装器识别 0.9+ 安装状态时，还会检查新增的响应读取模块。
+
+发布验收现覆盖两个目标的干净安装和全部六个 helper，并检查四个较新工作流保留的来源。
+这些实时 smoke 检查补充固定样本测试，不能证明原生 agent 的自动发现或解释质量。CI 在
+Linux 上检查 Node 24/26，macOS 在本地验证；Windows 兼容性尚未验收。
+
+保留 0.8.0 的 [CollectiveX 比较](skills/inferencex-api/references/collectivex.md)：发现两个现有的通信
 基准测试 run，或使用两个确切的 run ID，导出包含 EP/KV 匹配结果、单位、缺失与覆盖情况
 和完整响应证据的 JSON。匹配要求公开的操作、backend、精度和拓扑一致；EP 还需匹配 payload
 字节数，KV 还需匹配请求字节数。运行 attempt 和来源 revision 会明确保留。这些是观测差异，
@@ -478,7 +521,7 @@ stderr。不加该选项时保留原有文字输出。上表定义 `schema_versi
 安装状态字段；请用退出码判断操作是否成功。
 
 重复安装默认跳过已有技能。添加 `--force` 可重新安装指定版本；需要升级时，将命令中
-的 `0.8.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
+的 `0.9.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
 同名文件；相邻的其他技能不受影响，技能目录中已不再随包提供的旧文件也不会被删除。
 覆盖前请自行备份本地修改。
 

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -93,6 +93,7 @@ function installedState(destination, packageName) {
     { file: 'compare-tco.mjs', name: 'TCO helper', minor: 6n },
     { file: 'compare-releases.mjs', name: 'release comparison helper', minor: 7n },
     { file: 'compare-collectivex.mjs', name: 'CollectiveX helper', minor: 8n },
+    { file: 'response-budget.mjs', name: 'response reader', minor: 9n },
   ].filter(
     ({ minor }) =>
       BigInt(versionMatch.groups.major) > 0n || BigInt(versionMatch.groups.minor) >= minor,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Install the InferenceX public API skill for Codex and Claude Code.",
   "keywords": [
     "agent-skills",

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -27,6 +27,7 @@ const releaseFiles = [
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
   'skills/inferencex-api/references/collectivex.md',
+  'skills/inferencex-api/scripts/response-budget.mjs',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
   'skills/inferencex-api/scripts/investigate-result.mjs',

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -1181,6 +1181,143 @@ def check_installed(installed, skill_files, version):
     require(receipt == {'package': PACKAGE, 'version': version}, 'Installed-version receipt differs')
 
 
+def workflow_identity(document, version):
+    require(document.get('schema_version') == 1, 'Workflow schema version differs')
+    actual = document.get('metadata', document).get('package_version')
+    require(actual == version, 'Workflow package version differs')
+
+
+def workflow_source(source, expected_url, body_key='body_utf8', hash_key='decoded_body_sha256',
+                    url_key='url', statuses=(200,)):
+    require(source[url_key] == expected_url, 'Workflow source URL differs')
+    require(source['http_status'] in statuses, 'Workflow source HTTP status differs')
+    datetime.fromisoformat(source['retrieved_at'].replace('Z', '+00:00'))
+    raw = source[body_key].encode('utf-8')
+    require(hashlib.sha256(raw).hexdigest() == source[hash_key], 'Workflow source checksum differs')
+    return json.loads(source[body_key].removeprefix('\ufeff'))
+
+
+def check_additional_workflows(project, version):
+    """Live smoke invariants; fixture suites cover the full domain contracts separately."""
+    documents = {name: json.loads((project / f'{name}.json').read_text())
+                 for name in ('provenance', 'tco', 'releases', 'collectivex')}
+    for document in documents.values():
+        workflow_identity(document, version)
+    provenance = documents['provenance']
+    sources = {}
+    for source in provenance['evidence']:
+        url = urlsplit(source['url'])
+        require(url.scheme == 'https' and url.netloc == 'inferencex.semianalysis.com' and
+                url.path == '/api/v1/' + source['operation'], 'Unexpected provenance endpoint')
+        sources[source['operation']] = workflow_source(source, source['url'], statuses=(200, 404))
+    selected = provenance['selected_result']
+    require(str(selected['id']) == '416696' and selected in sources['benchmarks'],
+            'Provenance result differs from consumed benchmark')
+    require(selected['date'] == '2026-05-30' and
+            selected['run_url'] == 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26694739752/attempts/1',
+            'Provenance producer identity differs')
+    require(provenance['metadata']['ran_new_benchmark'] is False and
+            provenance['producer']['github_run_id'] == '26694739752', 'Provenance scope differs')
+    require(provenance['log']['status'] == 'available' and
+            provenance['log']['response'] == sources['server-log'], 'Provenance log evidence differs')
+
+    tco = documents['tco']
+    url = AGENTX_ORIGIN + '/api/v1/tco-feed?' + urlencode(dict(
+        model='DeepSeek-V4-Pro', workloads='8192x1024', tiers='50', view='points', format='json', date='2026-09-06'))
+    source = tco['source']
+    # Query order is irrelevant; the complete parameter set and value multiplicity are not.
+    require(urlsplit(source['query_url'])._replace(query='') == urlsplit(url)._replace(query='') and
+            parse_qs(urlsplit(source['query_url']).query) == parse_qs(urlsplit(url).query), 'TCO query differs')
+    feed = workflow_source(source, source['query_url'], 'body', 'sha256', 'query_url')
+    require(source['body_bytes'] == len(source['body'].encode('utf-8')), 'TCO body length differs')
+    prices = {'b200': 3.6, 'mi355x': 1.8}  # Explicit test assumptions, not market prices.
+    require(len(tco['rows']) == 2 and {row['hardware'] for row in tco['rows']} == set(prices),
+            'TCO requested hardware coverage differs')
+    for row in tco['rows']:
+        point = row['point']
+        require(point in feed['rows'] and point['hardware'] == row['hardware'] and
+                point['workload'] == row['workload'] == '8192x1024' and point['tier'] == 50,
+                'TCO point differs from consumed feed')
+        require(row['status'] == 'available' and point['boundary'] == 'interpolated' and
+                point['output_tput_per_gpu'] > 0, 'TCO smoke point is no longer available; review scope')
+        expected = prices[row['hardware']] * 1e6 / (point['output_tput_per_gpu'] * 3600)
+        require(row['usd_per_gpu_hour'] == prices[row['hardware']] and
+                math.isclose(row['usd_per_million_output_tokens'], expected, rel_tol=1e-12), 'TCO cost differs')
+    require(tco['coverage']['available_points'] == 2, 'TCO coverage differs')
+
+    releases = documents['releases']
+    history = workflow_source(releases['evidence'][0],
+                              API + '/history?model=GLM-5&isl=8192&osl=1024')
+    require(releases['outcome'] == 'observed_comparisons' and releases['comparisons'],
+            'Release smoke pair is no longer available; review scope')
+    for side, date, run_id in [('before', '2026-05-30', '26694739752'), ('after', '2026-07-02', '28571158239')]:
+        expected_rows = [row for row in history if row['model'] == 'glm5.1' and
+                         row['hardware'] == 'mi355x' and row['framework'] == 'sglang' and
+                         row['benchmark_type'] == 'single_turn' and row['isl'] == 8192 and row['osl'] == 1024 and
+                         row['date'] == date and row['run_url'] ==
+                         f'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/{run_id}/attempts/1']
+        require(releases['selection'][side]['rows'] == expected_rows and expected_rows,
+                'Release selection differs from consumed history')
+    for pair in releases['comparisons']:
+        before = next(row for row in releases['selection']['before']['rows'] if row['id'] == pair['before_id'])
+        after = next(row for row in releases['selection']['after']['rows'] if row['id'] == pair['after_id'])
+        require(all(before[key] == after[key] == value for key, value in pair['configuration'].items()),
+                'Release public configuration differs')
+        b, a = before['metrics']['median_ttft'], after['metrics']['median_ttft']
+        metric = pair['metric']
+        require(metric['name'] == 'median_ttft' and metric['before'] == b and metric['after'] == a and
+                math.isclose(metric['delta'], a - b, rel_tol=1e-12) and
+                math.isclose(metric['percent_change'], (a - b) / b * 100, rel_tol=1e-12),
+                'Release metric arithmetic differs')
+    require(releases['metadata']['causal_attribution'] == 'not_established', 'Release overclaims causality')
+
+    collective = documents['collectivex']
+    bodies = []
+    for source in collective['responses']:
+        url = urlsplit(source['query_url'])
+        require(url.scheme == 'https' and url.netloc == 'inferencex.semianalysis.com' and
+                (url.path == '/api/openapi.json' or url.path.startswith('/api/v1/collectivex/runs')),
+                'Unexpected CollectiveX endpoint')
+        bodies.append(workflow_source(source, source['query_url'], 'body_text', url_key='query_url'))
+    require(len(collective['runs']) == 2 and len(set(collective['selection']['run_ids'])) == 2,
+            'CollectiveX smoke requires two measured runs; review scope')
+    for entry in collective['runs']:
+        require(entry['run'] == bodies[entry['response_index']]['run'], 'CollectiveX run evidence differs')
+    require(collective['comparisons'], 'CollectiveX smoke produced no rows')
+    for status, count in collective['summary'].items():
+        require(count == sum(row['status'] == status for row in collective['comparisons']),
+                'CollectiveX summary differs')
+    # Resolve every exported source pointer; a successful export must not cite nonexistent data.
+    for row in collective['comparisons']:
+        for pointer in row['left'] + row['right']:
+            value = bodies[pointer['response_index']]
+            for key in pointer['json_pointer'].split('/')[1:]:
+                key = key.replace('~1', '/').replace('~0', '~')
+                value = value[int(key)] if isinstance(value, list) else value[key]
+            require(value is not None or row['status'] == 'incomparable',
+                    'CollectiveX null source must remain incomparable')
+    return {'status': 'passed', 'provenance_result_id': str(selected['id']), 'tco_points': 2,
+            'release_pairs': len(releases['comparisons']), 'collectivex_summary': collective['summary']}
+
+
+def run_additional_workflows(node, installed, project, env, version, deadline):
+    examples = {
+        'provenance': ('investigate-result', ['--id', '416696', '--model', 'GLM-5', '--run-id', '26694739752']),
+        'tco': ('compare-tco', ['--model', 'DeepSeek-V4-Pro', '--workloads', '8192x1024', '--target', '50',
+                              '--gpu-hourly-prices', 'b200=3.6,mi355x=1.8', '--date', '2026-09-06']),
+        'releases': ('compare-releases', ['--model', 'GLM-5', '--raw-model', 'glm5.1', '--hardware', 'mi355x',
+            '--framework', 'sglang', '--isl', '8192', '--osl', '1024', '--metric', 'median_ttft',
+            '--before-date', '2026-05-30', '--after-date', '2026-07-02',
+            '--before-run-url', 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/26694739752/attempts/1',
+            '--after-run-url', 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/28571158239/attempts/1']),
+        'collectivex': ('compare-collectivex', []),
+    }
+    for name, (helper, flags) in examples.items():
+        run([node, installed / f'scripts/{helper}.mjs', *flags, '--output', f'{name}.json'],
+            project, env, name, deadline)
+    return check_additional_workflows(project, version)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('mode', choices=['candidate', 'public', 'agents', 'check-agent'])
@@ -1372,6 +1509,8 @@ def main():
                           record['version'], deadline),
                 run_point(node, installed, project, env, 'agentx-second-point', args.agentx_no_trace_id,
                           record['version'], deadline)])
+            result['additional_workflows'] = run_additional_workflows(
+                node, installed, project, env, record['version'], deadline)
             check_installed(installed, skill_files, record['version'])
             result.update(agentx=agentx, agentx_points=points)
             result.update(target=target, project=str(project))

--- a/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const ORIGIN = 'https://inferencex.semianalysis.com';
 const VERSION = 1;
 const BYTE_BUDGET = 32 * 1024 * 1024;
@@ -26,7 +26,7 @@ At most four GETs: OpenAPI, optional run list, and two run details. No retries.
 Responses share a 32 MiB decoded-body budget; each request times out after 30s.
 --output creates a new file atomically and refuses to replace an existing path.
 Without --output, print JSON after all reads and validation succeed.
---help makes no requests. See references/collectivex.md for matching and units.
+--version prints the installed package version offline. --help makes no requests. See references/collectivex.md for matching and units.
 `;
 
 const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -344,11 +344,16 @@ async function main() {
       left: { type: 'string' },
       right: { type: 'string' },
       output: { type: 'string' },
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
     strict: true,
     allowPositionals: false,
   });
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) {
     process.stdout.write(HELP);
     return;

--- a/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
@@ -6,7 +6,7 @@ import { basename, dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { isDeepStrictEqual, parseArgs } from 'node:util';
 
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 // History omits mean/std latency and interactivity; QPS statistics are retained.
 const PERFORMANCE_METRIC =
@@ -26,6 +26,7 @@ Each side requires an exact image, an exact producer run URL, or both:
   --before-image <text> / --after-image <text>   Match the returned image string exactly
   --raw-model <key>       Select one raw model within the requested display bucket
   --output <new-file>     Exclusively create a JSON file; default stdout
+  --version          Show the installed package version offline
   --help                 Show help offline
 
 Dates select original observation date, never curve_date. Makes one history request.
@@ -259,6 +260,7 @@ async function run() {
           'output',
         ].map((name) => [name, { type: 'string' }]),
       ),
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
     allowPositionals: false,
@@ -266,6 +268,10 @@ async function run() {
   });
   const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
   if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) {
     await saveOutput(undefined, HELP);
     return;

--- a/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const HELP = `compare-tco — compare modeled GPU-hour cost at a fixed interactivity target
 
 Requires Node 24 or later. Output is JSON with the consumed API response and coverage.
@@ -20,6 +20,7 @@ Usage:
 Options:
   --date <YYYY-MM-DD>  As-of cutoff; omission selects latest available data
   --output <file>      Atomically replace this local file; default stdout
+  --version          Show the installed package version offline
   --help              Show help without making a request
 
 Price keys select exact, case-sensitive API hardware identifiers. Prices must be
@@ -186,11 +187,16 @@ async function run() {
       'gpu-hourly-prices': { type: 'string' },
       date: { type: 'string' },
       output: { type: 'string' },
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
   });
   const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
   if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) return writeOutput(undefined, HELP);
   if (!values.model || values.model.trim() !== values.model || /\p{Cc}/u.test(values.model)) {
     throw new Error('--model requires an exact API model key or display name');

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -5,9 +5,10 @@ import { lstat, mkdir, readlink, realpath, rename, rm, writeFile } from 'node:fs
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
+import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const HELP = `export-agentx — export existing AgentX observations with summary enrichments
 
@@ -28,10 +29,13 @@ Options:
   --format <format>    csv (default) or json
   --output <file>      Output file; default stdout
   --evidence-dir <dir> Save consumed responses and a manifest in a new directory
+  --version          Show the installed package version offline
   --help               Show this help without making a request
 
 The benchmark response is filtered locally to benchmark_type=agentic_traces.
 The exporter reads existing observations; it does not run a benchmark.
+Strict UTF-8; 32 MiB per response, 128 MiB total decoded bytes.
+HTTP sequence deadline: 120s; each request: 30s. No HTTP retries.
 `;
 
 const REQUIRED_STRING_FIELDS = [
@@ -342,7 +346,7 @@ function traceMap(value, requestedIds) {
   );
 }
 
-async function fetchJson(url, operation, requestUrls, evidence, requestedChunkIds = null) {
+async function fetchJson(url, operation, requestUrls, evidence, budget, requestedChunkIds = null) {
   const requestNumber = requestUrls.length + 1;
   requestUrls.push({ operation, url: url.href });
   let record;
@@ -364,9 +368,10 @@ async function fetchJson(url, operation, requestUrls, evidence, requestedChunkId
   }
   let response;
   try {
+    budget.signal.throwIfAborted();
     response = await fetch(url, {
       redirect: 'error',
-      signal: AbortSignal.timeout(30_000),
+      signal: AbortSignal.any([budget.signal, AbortSignal.timeout(30_000)]),
     });
   } catch (error) {
     throw new Error(`${operation} request failed: ${error.message} (${url.href})`, {
@@ -379,7 +384,7 @@ async function fetchJson(url, operation, requestUrls, evidence, requestedChunkId
   }
   let bytes;
   try {
-    bytes = Buffer.from(await response.arrayBuffer());
+    bytes = await budget.read(response);
   } catch (error) {
     throw new Error(`Could not read ${operation} response body: ${error.message}`, {
       cause: error,
@@ -393,7 +398,12 @@ async function fetchJson(url, operation, requestUrls, evidence, requestedChunkId
     await saveManifest(evidence);
   }
   // Fetch has already decoded HTTP compression. Parse the same bytes saved above.
-  const body = new TextDecoder().decode(bytes);
+  let body;
+  try {
+    body = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw new Error(`${operation} response is not valid UTF-8`, { cause: error });
+  }
   if (!response.ok) {
     let detail = '';
     try {
@@ -411,13 +421,16 @@ async function fetchJson(url, operation, requestUrls, evidence, requestedChunkId
   }
 }
 
-async function fetchChunks(operation, ids, limit, validate, requestUrls, evidence) {
+async function fetchChunks(operation, ids, limit, validate, requestUrls, evidence, budget) {
   const joined = new Map();
   for (let offset = 0; offset < ids.length; offset += limit) {
     const chunk = ids.slice(offset, offset + limit);
     const url = new URL(`/api/v1/${operation}`, API_ORIGIN);
     url.searchParams.set('ids', chunk.join(','));
-    const entries = validate(await fetchJson(url, operation, requestUrls, evidence, chunk), chunk);
+    const entries = validate(
+      await fetchJson(url, operation, requestUrls, evidence, budget, chunk),
+      chunk,
+    );
     for (const [id, value] of entries) joined.set(id, value);
   }
   return joined;
@@ -492,11 +505,16 @@ async function run(args = process.argv.slice(2)) {
       format: { type: 'string', default: 'csv' },
       output: { type: 'string' },
       'evidence-dir': { type: 'string' },
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
     allowPositionals: false,
     strict: true,
   });
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) {
     process.stdout.write(HELP);
     return;
@@ -618,10 +636,15 @@ async function run(args = process.argv.slice(2)) {
     }
 
     const requestUrls = [];
+    const budget = createResponseBudget({
+      responseBytes: 32 * 1024 * 1024,
+      totalBytes: 128 * 1024 * 1024,
+      timeoutMs: 120_000,
+    });
     const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
     benchmarkUrl.searchParams.set('model', values.model);
     if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
-    const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls, evidence);
+    const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls, evidence, budget);
     if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
       throw new Error(
         'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
@@ -659,6 +682,7 @@ async function run(args = process.argv.slice(2)) {
       aggregateMap,
       requestUrls,
       evidence,
+      budget,
     );
     const derived = await fetchChunks(
       'derived-agentic-metrics',
@@ -667,6 +691,7 @@ async function run(args = process.argv.slice(2)) {
       derivedMap,
       requestUrls,
       evidence,
+      budget,
     );
     const traces = await fetchChunks(
       'trace-availability',
@@ -675,6 +700,7 @@ async function run(args = process.argv.slice(2)) {
       traceMap,
       requestUrls,
       evidence,
+      budget,
     );
     let nonFiniteValues = 0;
     const rows = selected.map((row) => {

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
-import { createHash } from 'node:crypto';
-import { lstat, mkdir, readlink, realpath, rename, writeFile } from 'node:fs/promises';
+import { createHash, randomUUID } from 'node:crypto';
+import { lstat, mkdir, readlink, realpath, rename, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
+import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; the packed-artifact test checks this version.
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const HELP = `export-powerx — export validated single-turn PowerX observations
 
 Requires Node 24 or later.
@@ -21,10 +22,13 @@ Options:
   --format <format>   csv (default) or json
   --output <file>     Output file relative to the current directory; default stdout
   --evidence-dir <dir> Save the consumed response and manifest in a new directory
+  --version          Show the installed package version offline
   --help             Show this help without making a request
 
 Requests powerValid=strictV2 and selects the exact single-turn workload locally.
 Data goes to stdout or --output; request metadata and coverage go to stderr.
+One 30s request; at most 32 MiB decoded bytes; strict UTF-8. No HTTP retries.
+File output is staged before replacing its destination; failed writes preserve old output.
 `;
 
 const ROW_COLUMNS = [
@@ -179,11 +183,16 @@ async function run(args = process.argv.slice(2)) {
       format: { type: 'string', default: 'csv' },
       output: { type: 'string' },
       'evidence-dir': { type: 'string' },
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
     allowPositionals: false,
     strict: true,
   });
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) {
     process.stdout.write(HELP);
     return;
@@ -285,8 +294,12 @@ async function run(args = process.argv.slice(2)) {
 }
 
 async function exportPowerx(values, isl, osl, url, evidence) {
-  const response = await fetch(url, { signal: AbortSignal.timeout(30_000), redirect: 'error' });
-  let capturedBody;
+  const budget = createResponseBudget({
+    responseBytes: 32 * 1024 * 1024,
+    totalBytes: 32 * 1024 * 1024,
+    timeoutMs: 30_000,
+  });
+  const response = await fetch(url, { signal: budget.signal, redirect: 'error' });
   if (evidence) {
     const captured = {
       status: response.status,
@@ -297,16 +310,23 @@ async function exportPowerx(values, isl, osl, url, evidence) {
     };
     evidence.manifest.response = captured;
     // fetch decodes HTTP compression; save and parse these same bytes, without refetching.
-    const bytes = Buffer.from(await response.arrayBuffer());
+  }
+  const bytes = await budget.read(response);
+  if (evidence) {
     await writeFile(join(evidence.directory, 'response.json'), bytes, { flag: 'wx' });
-    captured.body_file = 'response.json';
-    captured.sha256 = createHash('sha256').update(bytes).digest('hex');
-    capturedBody = new TextDecoder().decode(bytes);
+    evidence.manifest.response.body_file = 'response.json';
+    evidence.manifest.response.sha256 = createHash('sha256').update(bytes).digest('hex');
+  }
+  let capturedBody;
+  try {
+    capturedBody = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch (error) {
+    throw new Error('Benchmark response is not valid UTF-8', { cause: error });
   }
   if (!response.ok) {
     let body;
     try {
-      body = capturedBody === undefined ? await response.json() : JSON.parse(capturedBody);
+      body = JSON.parse(capturedBody);
     } catch {
       body = null;
     }
@@ -315,7 +335,7 @@ async function exportPowerx(values, isl, osl, url, evidence) {
   }
   let rows;
   try {
-    rows = capturedBody === undefined ? await response.json() : JSON.parse(capturedBody);
+    rows = JSON.parse(capturedBody);
   } catch (error) {
     throw new Error(`Could not read benchmark JSON: ${error.message}`, { cause: error });
   }
@@ -406,14 +426,31 @@ async function exportPowerx(values, isl, osl, url, evidence) {
     evidence.manifest.export.sha256 = createHash('sha256').update(output).digest('hex');
     evidence.manifest.export.metadata = metadata;
   }
-  if (values.output === undefined && evidence) {
+  if (values.output === undefined) {
     // A closed consumer is a failed export, even if response capture already succeeded.
     process.stdout.on('error', () => {});
     await new Promise((resolveWrite, reject) => {
       process.stdout.write(output, (error) => (error ? reject(error) : resolveWrite()));
     });
-  } else if (values.output === undefined) process.stdout.write(output);
-  else await writeFile(values.output, output, 'utf8');
+  } else {
+    // Follow existing output symlinks, preserving the previous writeFile destination semantics.
+    const destination = await physicalPath(resolve(values.output));
+    const temporary = join(dirname(destination), `.${basename(destination)}.${randomUUID()}.tmp`);
+    let mode;
+    try {
+      const existing = await lstat(destination);
+      if (!existing.isFile()) throw new Error('--output must name a regular file');
+      mode = existing.mode & 0o777;
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
+    try {
+      await writeFile(temporary, output, { encoding: 'utf8', flag: 'wx', mode });
+      await rename(temporary, destination);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  }
   if (evidence) {
     evidence.manifest.status = 'complete';
     await saveManifest(evidence);

--- a/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
@@ -7,7 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.8.0';
+const PACKAGE_VERSION = '0.9.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 const HELP = `investigate-result — collect existing benchmark provenance and one bounded log window
@@ -24,6 +24,7 @@ Options:
   --log-offset <n>    Character offset, 0-2000000000 (default 0)
   --log-limit <n>     Characters to inspect, 1-262144 (default 16384)
   --output <file>     Save JSON atomically; default stdout
+  --version          Show the installed package version offline
   --help             Show help without making requests
 
 There is no full benchmark-row-by-ID endpoint. Supply the model and a scope
@@ -327,11 +328,16 @@ async function main() {
       'log-offset': { type: 'string', default: '0' },
       'log-limit': { type: 'string', default: '16384' },
       output: { type: 'string' },
+      version: { type: 'boolean' },
       help: { type: 'boolean' },
     },
     strict: true,
     allowPositionals: false,
   });
+  if (values.version) {
+    process.stdout.write(`${PACKAGE_VERSION}\n`);
+    return;
+  }
   if (values.help) {
     await saveOutput(undefined, HELP);
     return;

--- a/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
@@ -1,0 +1,45 @@
+// Count decompressed bytes from fetch's stream; Content-Length may describe compressed data.
+const PACKAGE_VERSION = '0.9.0';
+export { PACKAGE_VERSION };
+
+export function createResponseBudget({ responseBytes, totalBytes, timeoutMs }) {
+  const signal = AbortSignal.timeout(timeoutMs);
+  let total = 0;
+  return {
+    signal,
+    async read(response) {
+      signal.throwIfAborted();
+      if (!response.body) return Buffer.alloc(0);
+      const reader = response.body.getReader();
+      // Cancel settles a pending reader.read(); check the signal before treating done as success.
+      const abort = () => {
+        void reader.cancel(signal.reason).catch(() => {});
+      };
+      signal.addEventListener('abort', abort, { once: true });
+      let size = 0;
+      const chunks = [];
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          signal.throwIfAborted();
+          if (done) break;
+          size += value.byteLength;
+          total += value.byteLength;
+          if (size > responseBytes || total > totalBytes) {
+            const message =
+              size > responseBytes
+                ? `Response exceeds ${responseBytes}-byte budget`
+                : `Operation exceeds total ${totalBytes}-byte budget`;
+            void reader.cancel(message).catch(() => {});
+            throw new Error(message);
+          }
+          chunks.push(value);
+        }
+        return Buffer.concat(chunks, size);
+      } finally {
+        signal.removeEventListener('abort', abort);
+        reader.releaseLock();
+      }
+    },
+  };
+}

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -186,6 +186,10 @@ import { syncBuiltinESMExports } from 'node:module';
 import { join } from 'node:path';
 const fixture = JSON.parse(readFileSync(process.env.INFERENCEX_TEST_RESPONSE, 'utf8'));
 const calls = {};
+if (fixture.shortDeadline) {
+  const timeout = AbortSignal.timeout;
+  AbortSignal.timeout = ms => timeout(ms === 120_000 ? 40 : ms);
+}
 const originalWriteFile = fs.promises.writeFile;
 let completeManifestFailure = fixture.failCompleteManifest;
 fs.promises.writeFile = async (path, data, ...rest) => {
@@ -214,6 +218,8 @@ globalThis.fetch = async (input, options) => {
   calls[url.pathname] = index + 1;
   const reply = fixture.routes[url.pathname]?.[index];
   if (!reply) return new Response('{"error":"unexpected request"}', { status: 599 });
+  if (reply.delay) await new Promise(resolve => setTimeout(resolve, reply.delay));
+  options.signal.throwIfAborted();
   if (reply.timeout) throw new DOMException('Timed out', 'TimeoutError');
   if (reply.blockEvidenceFile) mkdirSync(join(fixture.evidenceDir, reply.blockEvidenceFile));
   const headers = { 'Content-Type': 'application/json' };
@@ -226,7 +232,8 @@ globalThis.fetch = async (input, options) => {
       },
     }), { status: reply.status, headers });
   }
-  return new Response(reply.body, { status: reply.status, headers });
+  const body = reply.invalidUtf8 ? Buffer.from(reply.body.replace('dsv4', 'BADBYTE')).map(byte => byte === 66 ? 255 : byte) : reply.body;
+  return new Response(reply.oversized ? ' '.repeat(32 * 1024 * 1024) + '{}' : reply.padding ? ' '.repeat(reply.padding) + body : body, { status: reply.status, headers });
 };
 `,
   );
@@ -250,6 +257,72 @@ globalThis.fetch = (input, options) => {
     'the actual npm archive installs the AgentX exporter for Claude Code',
   );
   assert.ok(suite.packedFiles.includes('skills/inferencex-api/scripts/export-agentx.mjs'));
+});
+
+test('AgentX rejects invalid UTF-8 in the captured benchmark body before enrichment', () => {
+  const routes = routesFor([observation(1)], [1]);
+  routes['/api/v1/benchmarks'][0].invalidUtf8 = true;
+  const result = run(['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'], routes);
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /UTF-8/);
+  assert.equal(result.requests.length, 1);
+  const { manifest, bodies } = captured(result);
+  assert.equal(manifest.status, 'failed');
+  assert.ok(bodies.get(1).includes(255));
+});
+
+test('AgentX fails an oversized enrichment without overwriting a previous export', () => {
+  const cwd = project();
+  writeFileSync(join(cwd, 'previous.json'), 'previous complete export');
+  const routes = routesFor([observation(1)], [1]);
+  routes['/api/v1/derived-agentic-metrics'][0].oversized = true;
+  const result = run(
+    ['--model', 'DeepSeek-V4-Pro', '--output', 'previous.json', '--evidence-dir', 'evidence'],
+    routes,
+    cwd,
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /byte budget/);
+  assert.equal(readFileSync(join(cwd, 'previous.json'), 'utf8'), 'previous complete export');
+  const { manifest } = captured(result);
+  assert.equal(manifest.status, 'failed');
+  assert.equal(manifest.responses.at(-1).decoded_body_sha256, null);
+  assert.equal(result.requests.length, 3);
+});
+
+test('AgentX bounds total bytes across individually valid enrichment chunks', () => {
+  const ids = Array.from({ length: 201 }, (_, i) => i + 1);
+  const routes = routesFor(
+    ids.map((id) => observation(id)),
+    ids,
+  );
+  routes['/api/v1/agentic-aggregates'] = chunks(ids, 200).map((group) =>
+    response(mapBody(group.map((id) => [id, aggregate(id)]))),
+  );
+  routes['/api/v1/derived-agentic-metrics'] = chunks(ids, 200).map((group) =>
+    response(mapBody(group.map((id) => [id, derived(id)]))),
+  );
+  for (const replies of Object.values(routes))
+    for (const reply of replies) reply.padding = 31 * 1024 * 1024;
+  const result = run(['--model', 'DeepSeek-V4-Pro', '--output', 'must-not-exist.json'], routes);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /total.*byte budget/);
+  assert.equal(result.requests.length, 5);
+  assert.equal(existsSync(join(result.cwd, 'must-not-exist.json')), false);
+});
+
+test('AgentX total deadline stops enrichment even when each request is within its own timeout', () => {
+  const routes = routesFor([observation(1)], [1]);
+  for (const replies of Object.values(routes)) for (const reply of replies) reply.delay = 25;
+  const result = run(['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence'], routes, {
+    shortDeadline: true,
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /timed out|timeout/i);
+  assert.equal(result.stdout, '');
+  assert.ok(result.requests.length < 4);
+  assert.equal(captured(result).manifest.status, 'failed');
 });
 
 test('installed JSON exporter chunks and joins enrichments by safe result ID', () => {

--- a/packages/skills/test/export-powerx.test.mjs
+++ b/packages/skills/test/export-powerx.test.mjs
@@ -3,6 +3,8 @@ import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
+  chmodSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -106,9 +108,19 @@ before(() => {
   writeFileSync(
     preload,
     `
-import { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import fs, { appendFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
 import { join } from 'node:path';
 const fixture = JSON.parse(readFileSync(process.env.INFERENCEX_TEST_RESPONSE, 'utf8'));
+const write = fs.promises.writeFile;
+if (fixture.partialOutputWrite) fs.promises.writeFile = async (path, data, ...rest) => {
+  if (String(path).includes('preserved.json')) {
+    await write(path, String(data).slice(0, 5), ...rest);
+    throw new Error('controlled disk full after partial write');
+  }
+  return write(path, data, ...rest);
+};
+syncBuiltinESMExports();
 let calls = 0;
 if (fixture.timeout) AbortSignal.timeout = () => AbortSignal.abort(new DOMException('Timed out', 'TimeoutError'));
 if (fixture.stdoutFailure) process.stdout.write = (_output, callback) => {
@@ -121,7 +133,8 @@ globalThis.fetch = async (input, options) => {
   if (fixture.blockEvidenceFile) mkdirSync(join(fixture.evidenceDir, fixture.blockEvidenceFile));
   if (fixture.bodyFailure) return new Response(new ReadableStream({ start(controller) { controller.error(new Error('body interrupted')); } }));
   const body = calls++ === 0 ? fixture.body : fixture.secondBody ?? '[]';
-  return new Response(body, { status: fixture.status, headers: { 'Content-Type': 'application/json', 'Content-Encoding': 'gzip' } });
+  const bytes = fixture.invalidUtf8 ? Buffer.from(body.replace('glm5', 'BADBYTE')).map(byte => byte === 66 ? 255 : byte) : body;
+  return new Response(fixture.oversized ? ' '.repeat(32 * 1024 * 1024) + '[]' : bytes, { status: fixture.status, headers: { 'Content-Type': 'application/json', 'Content-Encoding': 'gzip' } });
 };
 `,
   );
@@ -129,6 +142,68 @@ globalThis.fetch = async (input, options) => {
   exporter = join(installed, 'scripts/export-powerx.mjs');
   powerCookbook = readFileSync(join(installed, 'references/powerx.md'), 'utf8');
   assert.ok(existsSync(exporter), 'the actual npm artifact installs the exporter');
+});
+
+test('partial destination writes preserve an existing PowerX export and remove staging files', () => {
+  const cwd = project();
+  writeFileSync(join(cwd, 'preserved.json'), 'previous complete export');
+  const result = run(
+    [...requiredArgs, '--output', 'preserved.json', '--evidence-dir', 'evidence'],
+    [observation()],
+    { cwd, partialOutputWrite: true },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /disk full/);
+  assert.equal(readFileSync(join(cwd, 'preserved.json'), 'utf8'), 'previous complete export');
+  assert.deepEqual(readdirSync(cwd).sort(), ['evidence', 'preserved.json']);
+  assert.equal(JSON.parse(readFileSync(join(cwd, 'evidence/manifest.json'))).status, 'failed');
+});
+
+test('PowerX atomic replacement retains a symlink and its target file permissions', () => {
+  const cwd = project();
+  const target = join(cwd, 'target.json');
+  writeFileSync(target, 'previous complete export');
+  chmodSync(target, 0o600);
+  symlinkSync('target.json', join(cwd, 'alias.json'));
+  const result = run(
+    [...requiredArgs, '--format', 'json', '--output', 'alias.json'],
+    [observation()],
+    { cwd },
+  );
+  succeeded(result);
+  assert.ok(lstatSync(join(cwd, 'alias.json')).isSymbolicLink());
+  assert.equal(lstatSync(target).mode & 0o777, 0o600);
+  assert.equal(JSON.parse(readFileSync(target)).rows.length, 1);
+  assert.deepEqual(readdirSync(cwd).sort(), ['alias.json', 'target.json']);
+});
+
+test('PowerX rejects invalid UTF-8 while preserving original response bytes for diagnosis', () => {
+  for (const evidence of [false, true]) {
+    const result = run(
+      [...requiredArgs, '--format', 'json', ...(evidence ? ['--evidence-dir', 'evidence'] : [])],
+      [observation()],
+      { invalidUtf8: true },
+    );
+    assert.equal(result.status, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /UTF-8/);
+    if (evidence) {
+      const root = join(result.cwd, 'evidence');
+      const manifest = JSON.parse(readFileSync(join(root, 'manifest.json')));
+      assert.equal(manifest.status, 'failed');
+      assert.ok(readFileSync(join(root, 'response.json')).includes(255));
+    }
+  }
+});
+
+test('PowerX rejects an oversized decoded body instead of exporting a truncated or empty success', () => {
+  const result = run([...requiredArgs, '--evidence-dir', 'evidence'], [], { oversized: true });
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /byte budget/);
+  const manifest = JSON.parse(readFileSync(join(result.cwd, 'evidence/manifest.json')));
+  assert.equal(manifest.status, 'failed');
+  assert.equal(manifest.response.sha256, null);
 });
 
 test('installed guidance verifies summaries, provenance, and measured-power boundaries', () => {

--- a/packages/skills/test/helper-version.test.mjs
+++ b/packages/skills/test/helper-version.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+import { packageInfo, packedSkillSuite, succeeded } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+let installed;
+const guard = join(suite.temporaryRoot, 'offline.mjs');
+before(() => {
+  installed = suite.install('codex');
+  writeFileSync(
+    guard,
+    "globalThis.fetch = () => { throw new Error('version must be offline'); };\n",
+  );
+});
+[
+  'export-powerx',
+  'export-agentx',
+  'investigate-result',
+  'compare-tco',
+  'compare-releases',
+  'compare-collectivex',
+].forEach((name) => {
+  test(`${name} reports the installed package version offline without required arguments or output files`, () => {
+    const cwd = suite.project();
+    const result = succeeded(
+      suite.node(
+        [
+          '--import',
+          pathToFileURL(guard).href,
+          join(installed, `scripts/${name}.mjs`),
+          '--version',
+        ],
+        { cwd },
+      ),
+    );
+    assert.equal(result.stdout, `${packageInfo.version}\n`);
+    assert.equal(result.stderr, '');
+    assert.deepEqual(readdirSync(cwd), []);
+  });
+});

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -313,11 +313,23 @@ test('0.4 prerelease and later receipts require matching AgentX versions', () =>
         join(destination, 'scripts/compare-collectivex.mjs'),
         `const PACKAGE_VERSION = '${version}';\n`,
       );
+      writeFileSync(
+        join(destination, 'scripts/response-budget.mjs'),
+        `const PACKAGE_VERSION = '${version}';\n`,
+      );
     }
     const matching = run(['status'], cwd);
     succeeded(matching);
     assert.ok(matching.stdout.includes(`Installed version: ${version}\n`));
   }
+});
+
+test('0.9 status does not claim a usable installation when its response reader is missing', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const helper = join(cwd, '.claude/skills/inferencex-api/scripts/response-budget.mjs');
+  rmSync(helper);
+  assert.equal(jsonResult(run(['status', '--json'], cwd)).installation_state, 'unknown');
 });
 
 test('0.5 status verifies the provenance helper without executing it', () => {

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -32,6 +32,7 @@ const EXPECTED_FILES = [
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
   'skills/inferencex-api/references/collectivex.md',
+  'skills/inferencex-api/scripts/response-budget.mjs',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
   'skills/inferencex-api/scripts/investigate-result.mjs',

--- a/packages/skills/test/response-budget.test.mjs
+++ b/packages/skills/test/response-budget.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { setTimeout } from 'node:timers/promises';
+import { test } from 'node:test';
+import { createResponseBudget } from '../skills/inferencex-api/scripts/response-budget.mjs';
+
+test('response limits count streamed bytes, not Content-Length, and cancel overflow', async () => {
+  let canceled = false;
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new Uint8Array(8));
+      controller.enqueue(new Uint8Array(1));
+    },
+    cancel() {
+      canceled = true;
+    },
+  });
+  const budget = createResponseBudget({ responseBytes: 8, totalBytes: 12, timeoutMs: 1000 });
+  await assert.rejects(
+    budget.read(new Response(body, { headers: { 'content-length': '1' } })),
+    /byte budget/,
+  );
+  assert.equal(canceled, true);
+});
+
+test('aggregate limit rejects many individually valid responses', async () => {
+  const budget = createResponseBudget({ responseBytes: 8, totalBytes: 12, timeoutMs: 1000 });
+  const first = await budget.read(new Response('12345678'));
+  const second = await budget.read(new Response('1234'));
+  assert.equal(first.length, 8);
+  assert.equal(second.length, 4);
+  await assert.rejects(budget.read(new Response('5')), /total.*byte budget/);
+});
+
+test('a stalled response read is bounded by the operation deadline', async () => {
+  let canceled = false;
+  const budget = createResponseBudget({ responseBytes: 8, totalBytes: 12, timeoutMs: 20 });
+  const stalled = new Response(
+    new ReadableStream({
+      cancel() {
+        canceled = true;
+      },
+    }),
+  );
+  // An unref'ed AbortSignal timer must not be the only handle in the unit test.
+  await Promise.all([assert.rejects(budget.read(stalled), /timed out|timeout/i), setTimeout(40)]);
+  assert.equal(canceled, true);
+  assert.equal(budget.signal.aborted, true);
+});

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -1031,7 +1031,7 @@ globalThis.fetch = async (input) => {{
         self.assertEqual(fetch.call_count, 2)
         install.assert_not_called()
 
-    def test_candidate_orchestrates_powerx_and_agentx_for_both_targets(self):
+    def test_candidate_orchestrates_all_six_helpers_for_both_targets(self):
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w:gz') as packed:
             content = b'skill'
@@ -1060,6 +1060,7 @@ globalThis.fetch = async (input) => {{
                 patch.object(check, 'captured_export', return_value=[]), \
                 patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
                 patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}), \
+                patch.object(check, 'check_additional_workflows', return_value={'status': 'passed'}), \
                 patch.object(check, 'run_point', side_effect=['trace_diagnostics', 'trace_unavailable'] * 2), \
                 patch('builtins.print'):
             check.main()
@@ -1071,6 +1072,8 @@ globalThis.fetch = async (input) => {{
                                if call.args[1] == project]
             self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in target_commands), 2, target)
             self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in target_commands), 3, target)
+            for helper in ['investigate-result', 'compare-tco', 'compare-releases', 'compare-collectivex']:
+                self.assertEqual(sum(f'{helper}.mjs' in ' '.join(command) for command in target_commands), 1, target)
 
     def test_agents_prepares_canonical_projects_with_only_archive_and_hashed_prompt(self):
         stream = io.BytesIO()
@@ -1413,6 +1416,26 @@ globalThis.fetch = async (input) => {{
         self.assertLess(publish, public)
         for flag in ['--agentx-model', '--agentx-point-id', '--agentx-no-trace-id']:
             self.assertEqual(workflow.count(flag), 2)
+
+
+class AdditionalWorkflowEvidenceTests(unittest.TestCase):
+    def test_same_response_hash_url_status_and_time_are_required(self):
+        body = '{"observations":[1,2]}'
+        source = dict(body_utf8=body, decoded_body_sha256=hashlib.sha256(body.encode()).hexdigest(),
+                      url=check.OPENAPI, http_status=200, retrieved_at='2026-09-06T00:00:00Z')
+        self.assertEqual(check.workflow_source(source, check.OPENAPI), {'observations': [1, 2]})
+        for key, value in [('body_utf8', '{}'), ('decoded_body_sha256', '0' * 64),
+                           ('url', check.API), ('http_status', 500), ('retrieved_at', 'invalid')]:
+            with self.subTest(key=key), self.assertRaises((AssertionError, ValueError)):
+                check.workflow_source({**source, key: value}, check.OPENAPI)
+
+    def test_new_workflow_identity_cannot_be_missing_or_from_another_archive(self):
+        document = {'schema_version': 1, 'metadata': {'package_version': VERSION}}
+        check.workflow_identity(document, VERSION)
+        for changed in [{}, {'schema_version': 2, 'metadata': document['metadata']},
+                        {'schema_version': 1, 'metadata': {'package_version': 'wrong'}}]:
+            with self.assertRaises(ValueError):
+                check.workflow_identity(changed, VERSION)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

PowerX could truncate an existing export when a file write failed, and PowerX/AgentX accepted unbounded responses and invalid UTF-8. Version 0.9.0 stages PowerX output, validates decoded bytes, and bounds AgentX HTTP work while preserving successful output fields and calculations.

All six helpers now support offline `--version`; installation status checks the new shared reader. Candidate/public verification now runs provenance, TCO, release investigation and CollectiveX as well as PowerX/AgentX, checking retained evidence and domain invariants. The website stays pinned to published 0.8.0 until the new release is verified.

## Validation

- Node 24.20.0 and 26.8.1: 197 package/packed tests passed each, including partial writes, UTF-8, byte/deadline limits and offline versions.
- Relevant lint/format, root typecheck, typography and `git diff --check` passed.
- Public source smoke: selected provenance/logs, two explicit test-price TCO points, ten history pairs, and two CollectiveX runs checked. No new benchmarks run.
- Fresh native Codex/Claude acceptance and independent Claude Chinese-copy review were not run because this execution context prohibits subagents. Existing skill routing and cookbook recipes are unchanged. This limitation is retained in the release record; previous native results are not counted as current acceptance.
- Windows compatibility remains unqualified. File output and its evidence manifest are separate writes.

## 中文说明

PowerX 写入失败时可能截断已有导出文件；PowerX/AgentX 也缺少响应大小限制，并会静默接受非法 UTF-8。0.9.0 改为完整写入临时文件后再替换 PowerX 输出，严格检查编码和响应大小，并限制 AgentX 的请求总量与时长。成功导出的字段和计算方法保持兼容。

六个 helper 新增离线 `--version`，安装状态检查涵盖新增的响应读取模块。发布前后的干净安装验收补齐溯源、TCO、版本调查和 CollectiveX，核对保留的来源与关键计算。网站仍固定使用已发布的 0.8.0，待新版本发布并验证后再更新。

Node 24/26 各通过 197 项测试，相关 lint、格式、类型、typography 和空白检查通过。实时 smoke 核对了溯源与日志、两个明确测试价格下的 TCO 点、十对历史观测及两次 CollectiveX run；没有启动新基准测试。本次执行环境禁止子代理，未重跑原生 Codex/Claude 验收或独立 Claude 中文审阅，不将历史结果视为本次通过记录。技能路由和 cookbook 流程未变。Windows 尚未验收；导出文件和证据 manifest 不是一次原子事务。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live export file semantics and HTTP read limits for PowerX/AgentX; release gates now depend on fixed live API smoke cases that can fail when upstream data moves.
> 
> **Overview**
> Bumps `@semianalysisai/inferencex-skills` to **0.9.0** and documents the release pin across README and release docs.
> 
> **PowerX and AgentX** are hardened: PowerX writes exports via a temp file then `rename` so failed writes keep the prior file (including through symlinks); both exporters use a new shared `response-budget.mjs` to stream-count decoded bytes, enforce strict UTF-8, and fail instead of returning truncated success. AgentX adds a **128 MiB** total body budget and **120 s** operation deadline on top of per-response **32 MiB** and **30 s** per-request limits.
> 
> All **six** CLI helpers gain offline **`--version`**. The installer treats **`response-budget.mjs`** as required for 0.9+ `status` checks. Candidate/public **`verify-release.py`** now live-smokes provenance, TCO, release comparison, and CollectiveX (retained evidence and key arithmetic), in addition to PowerX/AgentX. Tests cover partial writes, limits, UTF-8, offline versions, and the expanded verifier orchestration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e455f6b841a1175005163a2307572f5a10050280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->