### PR TITLE
[Skills]: add command contracts and install recovery / 新增命令契约与安装恢复

### DIFF
--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -1,7 +1,7 @@
 # Releasing the InferenceX API skill
 
 The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0`,
-`0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`, and `0.8.0` are immutable
+`0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`, `0.8.0`, and `0.9.0` are immutable
 public releases. The website advertises the verified `0.8.0` release. For later
 releases, keep website commands pinned until publication and public verification
 succeed. The
@@ -243,6 +243,29 @@ Do not rerun publication or bump the version just to hide a failed verification.
 Announce availability only after the public verification passes. A prepared
 workflow, saved npm settings, and a successful upload each establish less than a
 successful end-to-end release.
+
+## Structured failures and recoverable upgrades from 0.10
+
+The six data helpers and installer share an opt-in `--error-format json`
+failure contract. Candidate and public verification deliberately run invalid
+arguments against every entry point for both installation targets. These checks
+retain command, stdout, stderr and exit code; they require exit 2, empty stdout,
+and the exact package/version/command identity with `INVALID_ARGUMENT`.
+PowerX JSON must also carry `schema_version: 1` from this version onward.
+
+Packed tests cover operational error categories, graceful cancellation and output
+rollback, the five-second stdout deadline, failed staging and receipt writes,
+interrupted activation/cleanup, and concurrent installation/recovery. Preserve
+failed attempts and inspect the exact archive after any package-byte change.
+A local source test or a successful installer invocation does not establish
+native skill discovery; run the natural-language acceptance separately.
+
+The installer stages a merged destination and receipt before activation, then
+recovers supported owned process-crash states on the next actual installation.
+`status` and `--dry-run` inspect recovery without changing files. These checks do
+not establish fsync/power-loss durability or repair arbitrary external edits.
+The installed [command cookbook](../packages/skills/skills/inferencex-api/references/cli-contract.md)
+defines the error envelope, exit policy, read-only inspection and recovery limits.
 
 ## User upgrades
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -10,10 +10,32 @@ also provides evaluation lookups and dataset-to-conversation inspection, with
 request context, exact identifiers, missing values, and page/sample boundaries.
 It also covers benchmark history filtered by GPU, workload and observation-date range.
 
-The npm commands below pin version `0.9.0` and require that version to be published.
+The npm commands below pin version `0.10.0` and require that version to be published.
 For review before publication, use the local archive instructions below.
 
-## New in 0.9.0
+## New in 0.10.0
+
+All six data helpers and the installer accept `--error-format json` for one
+structured failure document on stderr. In that mode, argument errors exit `2`,
+operational failures exit `1`, and graceful cancellation exits `130`. Successful
+empty selections still exit `0`. Default text behavior remains compatible;
+PowerX JSON adds `schema_version: 1` beside its existing metadata and rows.
+See the [command cookbook](skills/inferencex-api/references/cli-contract.md)
+for error codes, scheduler handling and output limits.
+
+Upgrades stage the complete merged directory and version receipt before activation.
+Detected failures preserve or restore the prior installation; the next real install
+recovers supported interrupted transactions. Concurrent installs are serialized.
+`status` and `--dry-run` report pending recovery without changing files. Unknown
+transaction data is preserved for inspection. Process-crash recovery does not
+promise durability after power loss.
+
+Graceful `SIGINT`/`SIGTERM` cancels active HTTP work. A stdout write must complete
+within five seconds; a stalled consumer produces `OUTPUT_ERROR`. Failed stdout
+may already contain partial bytes, so accept an export only after exit `0`.
+File exports and evidence manifests retain their separate-write limits.
+
+## Included from 0.9.0
 
 PowerX stages file output beside its destination and replaces it only after the
 write succeeds. Interrupted writes preserve the previous export. Existing output
@@ -101,10 +123,10 @@ Run the command for your agent from the project where it should discover the ski
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --target claude
 ```
 
 | Target              | Skill location relative to the current project |
@@ -115,9 +137,9 @@ npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-s
 For an explicit skills-root directory or inspection:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --dir './my project/.agents/skills'
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills list
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills --help
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --dir './my project/.agents/skills'
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills list
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills --help
 ```
 
 `--dir` selects the parent skills directory; the installer appends `inferencex-api`.
@@ -130,7 +152,7 @@ To review a maintainer-supplied `.tgz` before publication, replace the path with
 actual archive and run from the target project. Use `--target claude` for Claude Code.
 
 ```bash
-INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.9.0.tgz'
+INFERENCEX_SKILLS_TGZ='/absolute/path/semianalysisai-inferencex-skills-0.10.0.tgz'
 npm exec --yes --offline --package "$INFERENCEX_SKILLS_TGZ" -- inferencex-skills install --target codex
 ```
 
@@ -250,7 +272,7 @@ availability is false or omitted.
 ### Inspect the installed version
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills status --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills status --target codex
 ```
 
 Use `--target claude` or `--dir './my project/.agents/skills'` to inspect another
@@ -264,6 +286,8 @@ Legacy installations without a version record, including `0.1.0`, report an
 unknown installed version. Invalid or unreadable records are also reported as
 unknown. For `0.8.0` and later receipts, the record must agree with the static
 version declarations in PowerX, AgentX, provenance, TCO, release comparison, and CollectiveX helpers.
+Receipts from `0.10.0` and later additionally require the shared CLI contract declaration;
+`0.9.0` and later require the response reader.
 Receipts from `0.7.x` require the first five helpers.
 Receipts from `0.6.x` require the first four helpers.
 Receipts from `0.5.x` require the first three helpers.
@@ -276,8 +300,8 @@ check is not a full integrity check and cannot detect every local edit.
 ### JSON output and installation preview
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills status --target codex --json
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex --force --dry-run --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills status --target codex --json
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --target codex --force --dry-run --json
 ```
 
 `--json` on `status` or `install` emits one JSON document to stdout; diagnostics go
@@ -299,6 +323,14 @@ relative to `skill_path` and include the version receipt; skip writes nothing.
 A skipped install and a preview report the existing installation's state, not the
 version that the executing package would install.
 
+Pending transactions additionally expose `transaction_state` (`recovery_needed`,
+`busy`, or `blocked`), `transaction_phase`, and `transaction_had_destination`.
+They report `installation_state: "unknown"` and `installed_version: null` until
+recovery is complete. Recovery previews use `would_recover_then_install`,
+`would_recover_then_overwrite`, or `would_recover_then_skip`; active and blocked
+transactions use `would_wait_for_install` and `blocked_by_transaction`.
+Use the `write_paths` array itself when reporting the number of planned writes.
+
 `--dry-run` uses the same destination and conflict checks as installation, supports
 `--target`, `--dir`, and `--force`, and lists the packaged paths it would write.
 It changes no files, directories, receipts or permissions and makes no API request.
@@ -309,20 +341,25 @@ Exit codes: `0` for successful installation, skip, preview or inspection (includ
 unknown/absent installations); `2` for invalid arguments; `1` for operational
 failure. JSON failures use `{ "schema_version": 1, "outcome": "failed", "reason": "..." }`
 without stale installation fields; use the exit code to determine success.
+With `--error-format json`, failures instead use the shared stderr envelope and
+leave stdout empty. The success/status JSON contract above is unchanged.
 
 ### Upgrade
 
 Repeated installation skips an existing skill. Add `--force` to reinstall a pinned
-version. To upgrade, replace `0.9.0` with the published version you intend to install:
+version. To upgrade, replace `0.10.0` with the published version you intend to install:
 
 ```bash
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target codex --force
-npm exec --yes --package @semianalysisai/inferencex-skills@0.9.0 -- inferencex-skills install --target claude --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --target codex --force
+npm exec --yes --package @semianalysisai/inferencex-skills@0.10.0 -- inferencex-skills install --target claude --force
 ```
 
-Force merges the packaged files into the existing skill and overwrites matching
-files. It preserves unrelated neighboring skills and leaves obsolete files in the
-skill directory. Keep a copy of local edits before choosing an overwrite.
+Force stages the existing directory and overlays the packaged files before activation.
+It preserves unrelated neighboring skills and leaves obsolete files in the skill
+directory. Keep a copy of local edits before choosing an overwrite. For an interrupted
+transaction, preserve the transaction directory and rerun the real installer to recover
+it; `status` and `--dry-run` only inspect it. A live owner can be waited on, while
+malformed, foreign or unsafe transaction data blocks automatic recovery.
 
 ## 中文说明
 
@@ -336,10 +373,25 @@ skill directory. Keep a copy of local edits before choosing an overwrite.
 数据集到会话详情的完整示例，说明如何保留请求上下文、原始标识符、缺失值，以及分页和
 抽样范围；还提供按 GPU、工作负载和观测日期范围筛选历史基准测试数据的示例。
 
-上面的 npm 命令固定使用 `0.9.0`，需在该版本发布后执行。发布前审阅请使用本地产物
+上面的 npm 命令固定使用 `0.10.0`，需在该版本发布后执行。发布前审阅请使用本地产物
 安装流程。
 
-0.9.0 改进导出失败时的文件保护：PowerX 先在目标文件旁完整写入临时文件，写入成功后才
+0.10.0 为六个数据 helper 和安装器统一增加 `--error-format json`：失败时只向 stderr
+写入一个结构化错误文档。在该模式下，参数错误退出码为 `2`，操作失败为 `1`，正常处理
+取消信号后为 `130`；查询成功但没有符合条件的结果仍返回 `0`。默认的文本输出行为保持兼容，
+PowerX JSON 在已有 metadata 和 rows 之外增加 `schema_version: 1`。
+[命令使用指南](skills/inferencex-api/references/cli-contract.md) 说明错误码、在调度器中运行时的处理方式和输出限制。
+
+升级会先在暂存目录中准备好合并后的完整技能目录和版本记录，再切换到新安装。检测到失败时
+保留或恢复旧安装；下次实际安装会恢复支持的中断事务。并发安装按顺序执行。`status` 和
+`--dry-run` 只读取并报告待恢复状态，不修改文件；无法识别的事务数据会原样保留，供人工检查。
+这些保证针对进程中断，不承诺断电后的持久性。
+
+正常处理 `SIGINT`/`SIGTERM` 时会取消正在进行的 HTTP 请求。stdout 写入须在五秒内完成；
+下游停止读取导致超时后，命令返回 `OUTPUT_ERROR`。失败的 stdout 可能已有部分内容，
+因此只有退出码为 `0` 时才能接受导出结果。导出文件和证据 manifest 仍受分别写入的限制。
+
+保留 0.9.0 的导出保护：PowerX 先在目标文件旁完整写入临时文件，写入成功后才
 替换目标；中途写入失败会保留旧结果。目标路径为符号链接时仍写入其指向的文件。导出文件
 和证据 manifest 是两个独立文件，不构成一次文件系统事务；manifest 写入失败时可能已存在
 完整导出文件，但命令仍以失败状态退出。
@@ -493,7 +545,7 @@ histogram 和 server metrics。
 
 包括 `0.1.0` 在内、没有版本记录的旧安装会显示版本未知。记录无效或无法读取时，同样
 显示为未知。版本记录为 `0.8.0` 或更新时，必须与 PowerX、AgentX、溯源、TCO、框架版本比较和 CollectiveX
-脚本中的静态版本声明一致；`0.7.x` 记录核对前五项，`0.6.x` 核对前四项，`0.5.x` 核对前三项，`0.4.x` 核对 PowerX 和 AgentX，更早的记录只核对 PowerX。强制降级后
+脚本中的静态版本声明一致；`0.10.0` 起还需核对共享 CLI 契约模块中的版本声明，`0.9.0` 起需核对响应读取模块中的版本声明。`0.7.x` 记录核对前五项，`0.6.x` 核对前四项，`0.5.x` 核对前三项，`0.4.x` 核对 PowerX 和 AgentX，更早的记录只核对 PowerX。强制降级后
 残留的较新脚本不参与旧版本的检查。需要核对的声明缺失、无法读取或版本不一致时，状态也会显示为未知。`status`
 只读取声明，不执行任何脚本。这项检查不是完整的文件完整性校验，也不能识别所有本地
 修改。`--version` 只显示本次调用的安装器版本，不显示项目中已安装技能的版本。
@@ -510,6 +562,13 @@ stderr。不加该选项时保留原有文字输出。上表定义 `schema_versi
 `would_overwrite` 或 `would_skip`。`write_paths` 相对于技能目录，包含版本记录文件；
 跳过安装时为空。预览和跳过安装均报告目标目录的实际状态，不将安装器版本当作已安装版本。
 
+存在待处理事务时，还会返回 `transaction_state`（`recovery_needed`、`busy` 或 `blocked`）、
+`transaction_phase`、`transaction_had_destination`。恢复完成前，`installation_state` 为 `unknown`，
+`installed_version` 为 `null`。恢复预览使用 `would_recover_then_install`、
+`would_recover_then_overwrite` 或 `would_recover_then_skip`；活动事务与被阻止的事务分别使用
+`would_wait_for_install` 和 `blocked_by_transaction`。报告计划写入的文件数量时，直接统计
+`write_paths` 中的条目。
+
 `install --dry-run` 复用正式安装的目标路径与冲突检查，支持 `--target`、`--dir`、
 `--force` 和 `--json`。它列出将写入的路径，不创建目录、不改动文件、版本记录或权限，
 也不请求 API。不过 npm 可能在启动安装器前下载所选包。安装会保留其他文件和
@@ -518,12 +577,15 @@ stderr。不加该选项时保留原有文字输出。上表定义 `schema_versi
 退出码 `0` 表示操作成功，包括跳过、预览，以及对未安装或版本未知状态的正常检查；
 `2` 表示参数错误，`1` 表示操作失败。失败时的 JSON 为
 `{ "schema_version": 1, "outcome": "failed", "reason": "..." }`，不包含可能已失效的
-安装状态字段；请用退出码判断操作是否成功。
+安装状态字段；请用退出码判断操作是否成功。显式使用 `--error-format json` 后，失败改用
+共享的 stderr 错误文档，stdout 保持为空；成功和状态查询的 JSON 格式不变。
 
 重复安装默认跳过已有技能。添加 `--force` 可重新安装指定版本；需要升级时，将命令中
-的 `0.9.0` 改为计划安装的已发布版本。该选项会将包内文件合并进已有技能目录，并覆盖
-同名文件；相邻的其他技能不受影响，技能目录中已不再随包提供的旧文件也不会被删除。
-覆盖前请自行备份本地修改。
+的 `0.10.0` 改为计划安装的已发布版本。该选项先暂存已有目录，再合并包内文件并切换安装；
+同名文件会被覆盖，相邻的其他技能不受影响，已不再随包提供的旧文件也不会删除。
+覆盖前请自行备份本地修改。事务中断后，保留事务目录并重新执行实际安装以恢复；`status`
+和 `--dry-run` 只检查状态。事务仍有存活的持有进程时可以等待其完成；事务数据格式异常、
+归属不符或存在不安全内容时，会阻止自动恢复。
 
 ## License / 许可证
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -24,14 +24,19 @@ See the [command cookbook](skills/inferencex-api/references/cli-contract.md)
 for error codes, scheduler handling and output limits.
 
 Upgrades stage the complete merged directory and version receipt before activation.
-Detected failures preserve or restore the prior installation; the next real install
-recovers supported interrupted transactions. Concurrent installs are serialized.
+Before committed activation, detected failures preserve or restore the prior installation.
+After committed activation, cleanup failures retain the new installation. The next real
+install recovers supported interrupted transactions. Concurrent installs are serialized.
 `status` and `--dry-run` report pending recovery without changing files. Unknown
 transaction data is preserved for inspection. Process-crash recovery does not
 promise durability after power loss.
 
-Graceful `SIGINT`/`SIGTERM` cancels active HTTP work. A stdout write must complete
-within five seconds; a stalled consumer produces `OUTPUT_ERROR`. Failed stdout
+Graceful `SIGINT`/`SIGTERM` cancels active HTTP work. The installer observes cancellation
+between filesystem phases and while waiting for another installer; an in-progress
+synchronous filesystem operation finishes first. Cancellation before committed activation
+rolls back. After committed activation, the installer finishes cleanup and reports its result.
+A stdout write must complete within five seconds; a stalled consumer produces
+`OUTPUT_ERROR`. Failed stdout
 may already contain partial bytes, so accept an export only after exit `0`.
 File exports and evidence manifests retain their separate-write limits.
 
@@ -382,12 +387,15 @@ malformed, foreign or unsafe transaction data blocks automatic recovery.
 PowerX JSON 在已有 metadata 和 rows 之外增加 `schema_version: 1`。
 [命令使用指南](skills/inferencex-api/references/cli-contract.md) 说明错误码、在调度器中运行时的处理方式和输出限制。
 
-升级会先在暂存目录中准备好合并后的完整技能目录和版本记录，再切换到新安装。检测到失败时
-保留或恢复旧安装；下次实际安装会恢复支持的中断事务。并发安装按顺序执行。`status` 和
+升级会先在暂存目录中准备好合并后的完整技能目录和版本记录，再切换到新安装。切换正式生效前
+检测到失败时保留或恢复旧安装；生效之后清理失败则保留新安装。下次实际安装会恢复支持的
+中断事务。并发安装按顺序执行。`status` 和
 `--dry-run` 只读取并报告待恢复状态，不修改文件；无法识别的事务数据会原样保留，供人工检查。
 这些保证针对进程中断，不承诺断电后的持久性。
 
-正常处理 `SIGINT`/`SIGTERM` 时会取消正在进行的 HTTP 请求。stdout 写入须在五秒内完成；
+正常处理 `SIGINT`/`SIGTERM` 时会取消正在进行的 HTTP 请求。安装器在文件操作阶段之间，
+以及等待另一个安装进程时处理取消信号；正在执行的同步文件操作会先完成。切换正式生效前
+取消会回滚；生效之后收到取消信号则完成清理并报告安装结果。stdout 写入须在五秒内完成；
 下游停止读取导致超时后，命令返回 `OUTPUT_ERROR`。失败的 stdout 可能已有部分内容，
 因此只有退出码为 `0` 时才能接受导出结果。导出文件和证据 manifest 仍受分别写入的限制。
 

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -252,12 +252,17 @@ function moveToRecovery(destination, paths, record) {
   return pathsFor(destination, target, paths.markerName);
 }
 
-function cleanupOwnedTransaction(paths) {
+function removeOwnedContents(paths) {
   rmSync(paths.stage, { recursive: true, force: true });
   rmSync(paths.previous, { recursive: true, force: true });
   rmSync(paths.nextMarker, { force: true });
-  rmSync(paths.marker);
-  rmdirSync(paths.transaction);
+}
+
+function finishCleanup(destination, paths, record) {
+  removeOwnedContents(paths);
+  const recoveryPaths = moveToRecovery(destination, paths, record);
+  rmSync(recoveryPaths.marker);
+  rmdirSync(recoveryPaths.transaction);
 }
 
 function cleanupCommittedTransaction(destination, paths, record) {
@@ -267,7 +272,7 @@ function cleanupCommittedTransaction(destination, paths, record) {
   if (!destinationEntry || stageEntry || (!record.had_destination && previousEntry)) {
     failRecovery('activated transaction paths do not match the owned marker');
   }
-  cleanupOwnedTransaction(paths);
+  finishCleanup(destination, paths, record);
 }
 
 function recoverOwnedTransaction(destination, paths, record) {
@@ -296,7 +301,7 @@ function recoverOwnedTransaction(destination, paths, record) {
     }
     if (destinationExists) rmSync(destination, { recursive: true });
   }
-  cleanupOwnedTransaction(paths);
+  finishCleanup(destination, paths, record);
 }
 
 function claimRecovery(destination, packageName, skillName, state) {
@@ -332,8 +337,7 @@ function claimRecovery(destination, packageName, skillName, state) {
   }
   const record = { ...inspected.record, owner_pid: process.pid };
   updateMarker(inspected.paths, record);
-  const paths = moveToRecovery(destination, inspected.paths, record);
-  return { cleanupOnly: false, paths, record };
+  return { cleanupOnly: false, paths: inspected.paths, record };
 }
 
 function acquireTransaction(destination, packageName, skillName, waitMilliseconds) {
@@ -419,15 +423,16 @@ export function runInstallTransaction({
     const initialPlan = prepare();
     if (initialPlan.outcome === 'skipped') return initialPlan;
   }
-  let { paths, record } = acquireTransaction(destination, packageName, skillName, waitMilliseconds);
+  const acquired = acquireTransaction(destination, packageName, skillName, waitMilliseconds);
+  const { paths } = acquired;
+  let { record } = acquired;
   let destinationMoved = false;
   let stageMoved = false;
   let committed = false;
   try {
     const plan = prepare();
     if (plan.outcome === 'skipped') {
-      paths = moveToRecovery(destination, paths, record);
-      cleanupOwnedTransaction(paths);
+      finishCleanup(destination, paths, record);
       return plan;
     }
 
@@ -465,7 +470,6 @@ export function runInstallTransaction({
     record = { ...record, phase: 'activated' };
     updateMarker(paths, record);
     committed = true;
-    paths = moveToRecovery(destination, paths, record);
     cleanupCommittedTransaction(destination, paths, record);
     return plan;
   } catch (error) {
@@ -473,8 +477,7 @@ export function runInstallTransaction({
     try {
       if (stageMoved) rmSync(destination, { recursive: true });
       if (destinationMoved) renameSync(paths.previous, destination);
-      paths = moveToRecovery(destination, paths, record);
-      cleanupOwnedTransaction(paths);
+      finishCleanup(destination, paths, record);
     } catch (rollbackError) {
       throw new Error(`${error.message}; rollback failed: ${rollbackError.message}`, {
         cause: rollbackError,

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -1,0 +1,297 @@
+import {
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import process from 'node:process';
+
+const TRANSACTION_SUFFIX = '.inferencex-skills-transaction';
+const MARKER = 'transaction.json';
+const NEXT_MARKER = 'transaction.next.json';
+const STAGE = 'stage';
+const PREVIOUS = 'previous';
+const PHASES = new Set(['staging', 'staged', 'previous_moved', 'activated']);
+const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function pathsFor(destination) {
+  const transaction = `${destination}${TRANSACTION_SUFFIX}`;
+  return {
+    transaction,
+    marker: join(transaction, MARKER),
+    nextMarker: join(transaction, NEXT_MARKER),
+    stage: join(transaction, STAGE),
+    previous: join(transaction, PREVIOUS),
+  };
+}
+
+function blocked(reason) {
+  return { state: 'blocked', phase: null, had_destination: null, reason };
+}
+
+function failRecovery(reason) {
+  throw new Error(`Cannot recover installer transaction: ${reason}.`);
+}
+
+function processIsLive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code !== 'ESRCH';
+  }
+}
+
+export function inspectInstallTransaction(destination, packageName, skillName) {
+  const paths = pathsFor(destination);
+  const directory = lstatSync(paths.transaction, { throwIfNoEntry: false });
+  if (!directory) return { state: 'none', phase: null, had_destination: null, reason: null };
+  if (!directory.isDirectory() || directory.isSymbolicLink()) {
+    return blocked('installer transaction path is not an owned directory');
+  }
+
+  let marker;
+  try {
+    const entry = lstatSync(paths.marker, { throwIfNoEntry: false });
+    if (!entry?.isFile() || entry.isSymbolicLink()) {
+      return blocked('installer transaction marker is missing or not a regular file');
+    }
+    marker = JSON.parse(readFileSync(paths.marker, 'utf8'));
+  } catch (error) {
+    return blocked(
+      error instanceof SyntaxError
+        ? 'installer transaction marker is malformed'
+        : `could not read installer transaction marker: ${error.code ?? 'read error'}`,
+    );
+  }
+
+  if (
+    marker?.schema_version !== 1 ||
+    marker.package !== packageName ||
+    marker.skill !== skillName ||
+    marker.destination !== destination ||
+    !Number.isSafeInteger(marker.owner_pid) ||
+    marker.owner_pid <= 0 ||
+    !PHASES.has(marker.phase) ||
+    typeof marker.had_destination !== 'boolean'
+  ) {
+    return blocked('installer transaction marker is foreign or malformed');
+  }
+
+  const names = readdirSync(paths.transaction);
+  if (names.some((name) => ![MARKER, NEXT_MARKER, STAGE, PREVIOUS].includes(name))) {
+    return blocked('installer transaction contains unknown data');
+  }
+  for (const [name, path] of [
+    [STAGE, paths.stage],
+    [PREVIOUS, paths.previous],
+  ]) {
+    const entry = lstatSync(path, { throwIfNoEntry: false });
+    if (entry && (!entry.isDirectory() || entry.isSymbolicLink())) {
+      return blocked(`installer transaction ${name} path is not an owned directory`);
+    }
+  }
+  const next = lstatSync(paths.nextMarker, { throwIfNoEntry: false });
+  if (next && (!next.isFile() || next.isSymbolicLink())) {
+    return blocked('installer transaction update is not a regular file');
+  }
+
+  const live = processIsLive(marker.owner_pid);
+  return {
+    state: live ? 'busy' : 'recoverable',
+    phase: marker.phase,
+    had_destination: marker.had_destination,
+    reason: live
+      ? `installer transaction is owned by live process ${marker.owner_pid}`
+      : `interrupted installer transaction from process ${marker.owner_pid} needs recovery`,
+  };
+}
+
+function markerRecord(destination, packageName, skillName, phase, hadDestination) {
+  return {
+    schema_version: 1,
+    package: packageName,
+    skill: skillName,
+    destination,
+    owner_pid: process.pid,
+    phase,
+    had_destination: hadDestination,
+  };
+}
+
+function updateMarker(paths, record) {
+  rmSync(paths.nextMarker, { force: true });
+  writeFileSync(paths.nextMarker, `${JSON.stringify(record, null, 2)}\n`, {
+    flag: 'wx',
+    mode: 0o600,
+  });
+  renameSync(paths.nextMarker, paths.marker);
+}
+
+function recoverOwnedTransaction(destination, state) {
+  const paths = pathsFor(destination);
+  const destinationEntry = () => lstatSync(destination, { throwIfNoEntry: false });
+  const stageEntry = () => lstatSync(paths.stage, { throwIfNoEntry: false });
+  const previousEntry = () => lstatSync(paths.previous, { throwIfNoEntry: false });
+
+  if (state.state !== 'recoverable') failRecovery(state.reason);
+  const destinationExists = Boolean(destinationEntry());
+  const stageExists = Boolean(stageEntry());
+  const previousExists = Boolean(previousEntry());
+
+  if (state.phase === 'activated') {
+    if (!destinationExists || stageExists || previousExists !== state.had_destination) {
+      failRecovery('activated transaction paths do not match the owned marker');
+    }
+    rmSync(paths.transaction, { recursive: true });
+    return;
+  }
+
+  if (state.had_destination) {
+    if (previousExists) {
+      if (destinationExists && stageExists) {
+        failRecovery('both the destination and staged installation are present with a backup');
+      }
+      if (destinationExists) rmSync(destination, { recursive: true });
+      renameSync(paths.previous, destination);
+    } else if (!destinationExists) {
+      failRecovery('the previous installation is missing');
+    }
+  } else {
+    if (previousExists) failRecovery('an unexpected previous installation is present');
+    if (destinationExists && stageExists) {
+      failRecovery('both a destination and staged new installation are present');
+    }
+    if (destinationExists) rmSync(destination, { recursive: true });
+  }
+  rmSync(paths.transaction, { recursive: true });
+}
+
+function acquireTransaction(destination, packageName, skillName, waitMilliseconds) {
+  const paths = pathsFor(destination);
+  const deadline = Date.now() + waitMilliseconds;
+  let unmarkedDeadline;
+  mkdirSync(dirname(destination), { recursive: true });
+  for (;;) {
+    try {
+      mkdirSync(paths.transaction, { mode: 0o700 });
+      const hadDestination = Boolean(lstatSync(destination, { throwIfNoEntry: false }));
+      const record = markerRecord(destination, packageName, skillName, 'staging', hadDestination);
+      try {
+        writeFileSync(paths.marker, `${JSON.stringify(record, null, 2)}\n`, {
+          flag: 'wx',
+          mode: 0o600,
+        });
+      } catch (error) {
+        rmSync(paths.transaction, { recursive: true, force: true });
+        throw error;
+      }
+      return { paths, record };
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      const state = inspectInstallTransaction(destination, packageName, skillName);
+      if (state.state === 'blocked') {
+        if (state.reason === 'installer transaction marker is missing or not a regular file') {
+          unmarkedDeadline ??= Date.now() + 2_000;
+          if (Date.now() < Math.min(deadline, unmarkedDeadline)) {
+            Atomics.wait(sleepBuffer, 0, 0, 25);
+            continue;
+          }
+        }
+        throw new Error(state.reason, { cause: error });
+      }
+      if (state.state === 'recoverable') {
+        recoverOwnedTransaction(destination, state);
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for ${state.reason}.`, { cause: error });
+      }
+      Atomics.wait(sleepBuffer, 0, 0, 25);
+    }
+  }
+}
+
+export function runInstallTransaction({
+  source,
+  destination,
+  packageName,
+  packageVersion,
+  skillName,
+  receiptName,
+  prepare,
+  waitMilliseconds = 30_000,
+}) {
+  const pending = inspectInstallTransaction(destination, packageName, skillName);
+  if (pending.state === 'none') {
+    const initialPlan = prepare();
+    if (initialPlan.outcome === 'skipped') return initialPlan;
+  }
+  const { paths, record } = acquireTransaction(
+    destination,
+    packageName,
+    skillName,
+    waitMilliseconds,
+  );
+  let destinationMoved = false;
+  let stageMoved = false;
+  let committed = false;
+  try {
+    const plan = prepare();
+    if (plan.outcome === 'skipped') {
+      rmSync(paths.transaction, { recursive: true });
+      return plan;
+    }
+
+    if (record.had_destination) {
+      cpSync(destination, paths.stage, {
+        recursive: true,
+        preserveTimestamps: true,
+        verbatimSymlinks: true,
+      });
+    }
+    cpSync(source, paths.stage, {
+      recursive: true,
+      force: true,
+      preserveTimestamps: true,
+      verbatimSymlinks: true,
+    });
+    const stagedReceipt = join(paths.stage, receiptName);
+    rmSync(stagedReceipt, { force: true });
+    writeFileSync(
+      stagedReceipt,
+      `${JSON.stringify({ package: packageName, version: packageVersion }, null, 2)}\n`,
+      { flag: 'wx' },
+    );
+    updateMarker(paths, { ...record, phase: 'staged' });
+
+    if (record.had_destination) {
+      renameSync(destination, paths.previous);
+      destinationMoved = true;
+      updateMarker(paths, { ...record, phase: 'previous_moved' });
+    }
+    renameSync(paths.stage, destination);
+    stageMoved = true;
+    updateMarker(paths, { ...record, phase: 'activated' });
+    committed = true;
+    rmSync(paths.transaction, { recursive: true });
+    return plan;
+  } catch (error) {
+    if (committed) throw error;
+    try {
+      if (stageMoved) rmSync(destination, { recursive: true });
+      if (destinationMoved) renameSync(paths.previous, destination);
+      rmSync(paths.transaction, { recursive: true });
+    } catch (rollbackError) {
+      throw new Error(`${error.message}; rollback failed: ${rollbackError.message}`, {
+        cause: rollbackError,
+      });
+    }
+    throw error;
+  }
+}

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import {
   cpSync,
   lstatSync,
@@ -5,28 +6,78 @@ import {
   readFileSync,
   readdirSync,
   renameSync,
+  rmdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import process from 'node:process';
 
 const TRANSACTION_SUFFIX = '.inferencex-skills-transaction';
-const MARKER = 'transaction.json';
+const RECOVERY_SUFFIX = '.recovering-';
 const NEXT_MARKER = 'transaction.next.json';
 const STAGE = 'stage';
 const PREVIOUS = 'previous';
 const PHASES = new Set(['staging', 'staged', 'previous_moved', 'activated']);
+const UUID_PATTERN = '[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}';
+const OWNER_PATTERN = new RegExp(
+  `^owner-(?<transactionId>${UUID_PATTERN})-(?<pid>[1-9]\\d*)-(?<claimId>${UUID_PATTERN})\\.json$`,
+  'u',
+);
 const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
 
-function pathsFor(destination) {
-  const transaction = `${destination}${TRANSACTION_SUFFIX}`;
+function canonicalPath(destination) {
+  return `${destination}${TRANSACTION_SUFFIX}`;
+}
+
+function pathsFor(destination, transaction, markerFileName) {
   return {
     transaction,
-    marker: join(transaction, MARKER),
+    markerName: markerFileName,
+    marker: markerFileName === null ? null : join(transaction, markerFileName),
     nextMarker: join(transaction, NEXT_MARKER),
     stage: join(transaction, STAGE),
     previous: join(transaction, PREVIOUS),
+  };
+}
+
+function markerName(transactionId, ownerPid = process.pid) {
+  return `owner-${transactionId}-${ownerPid}-${randomUUID()}.json`;
+}
+
+function markerIdentity(name) {
+  const match = OWNER_PATTERN.exec(name);
+  if (!match || !Number.isSafeInteger(Number(match.groups.pid))) return null;
+  return {
+    transactionId: match.groups.transactionId,
+    ownerPid: Number(match.groups.pid),
+  };
+}
+
+function recoveryIdentity(name, prefix) {
+  const match = new RegExp(`^${prefix}(?<transactionId>${UUID_PATTERN})$`, 'u').exec(name);
+  return match?.groups.transactionId ?? null;
+}
+
+function transactionLocations(destination) {
+  const canonical = canonicalPath(destination);
+  const parent = dirname(destination);
+  const prefix = `${basename(canonical)}${RECOVERY_SUFFIX}`;
+  let names;
+  try {
+    names = readdirSync(parent);
+  } catch (error) {
+    if (error.code === 'ENOENT') return { canonical, recoveries: [] };
+    throw error;
+  }
+  return {
+    canonical,
+    recoveries: names
+      .filter((name) => name.startsWith(prefix))
+      .map((name) => ({
+        path: join(parent, name),
+        transactionId: recoveryIdentity(name, prefix),
+      })),
   };
 }
 
@@ -47,46 +98,37 @@ function processIsLive(pid) {
   }
 }
 
-export function inspectInstallTransaction(destination, packageName, skillName) {
-  const paths = pathsFor(destination);
-  const directory = lstatSync(paths.transaction, { throwIfNoEntry: false });
-  if (!directory) return { state: 'none', phase: null, had_destination: null, reason: null };
+function readTransaction(destination, transaction, recoveryTransactionId = null) {
+  const directory = lstatSync(transaction, { throwIfNoEntry: false });
+  if (!directory) return { state: 'missing' };
   if (!directory.isDirectory() || directory.isSymbolicLink()) {
     return blocked('installer transaction path is not an owned directory');
   }
 
-  let marker;
-  try {
-    const entry = lstatSync(paths.marker, { throwIfNoEntry: false });
-    if (!entry?.isFile() || entry.isSymbolicLink()) {
-      return blocked('installer transaction marker is missing or not a regular file');
-    }
-    marker = JSON.parse(readFileSync(paths.marker, 'utf8'));
-  } catch (error) {
-    return blocked(
-      error instanceof SyntaxError
-        ? 'installer transaction marker is malformed'
-        : `could not read installer transaction marker: ${error.code ?? 'read error'}`,
-    );
+  const names = readdirSync(transaction);
+  const markerNames = names.filter((name) => name.startsWith('owner-'));
+  if (markerNames.length === 0 && names.length === 0 && recoveryTransactionId !== null) {
+    return {
+      state: 'cleanup',
+      transaction,
+      transactionId: recoveryTransactionId,
+      projectedDestinationExists: Boolean(lstatSync(destination, { throwIfNoEntry: false })),
+    };
   }
-
+  if (markerNames.length !== 1) {
+    return blocked('installer transaction marker is missing or ambiguous');
+  }
+  const identity = markerIdentity(markerNames[0]);
   if (
-    marker?.schema_version !== 1 ||
-    marker.package !== packageName ||
-    marker.skill !== skillName ||
-    marker.destination !== destination ||
-    !Number.isSafeInteger(marker.owner_pid) ||
-    marker.owner_pid <= 0 ||
-    !PHASES.has(marker.phase) ||
-    typeof marker.had_destination !== 'boolean'
+    !identity ||
+    (recoveryTransactionId !== null && recoveryTransactionId !== identity.transactionId)
   ) {
     return blocked('installer transaction marker is foreign or malformed');
   }
-
-  const names = readdirSync(paths.transaction);
-  if (names.some((name) => ![MARKER, NEXT_MARKER, STAGE, PREVIOUS].includes(name))) {
+  if (names.some((name) => ![markerNames[0], NEXT_MARKER, STAGE, PREVIOUS].includes(name))) {
     return blocked('installer transaction contains unknown data');
   }
+  const paths = pathsFor(destination, transaction, markerNames[0]);
   for (const [name, path] of [
     [STAGE, paths.stage],
     [PREVIOUS, paths.previous],
@@ -101,20 +143,86 @@ export function inspectInstallTransaction(destination, packageName, skillName) {
     return blocked('installer transaction update is not a regular file');
   }
 
-  const live = processIsLive(marker.owner_pid);
+  let record;
+  try {
+    const marker = lstatSync(paths.marker, { throwIfNoEntry: false });
+    if (!marker?.isFile() || marker.isSymbolicLink()) {
+      return blocked('installer transaction marker is missing or not a regular file');
+    }
+    record = JSON.parse(readFileSync(paths.marker, 'utf8'));
+  } catch (error) {
+    return blocked(
+      error instanceof SyntaxError
+        ? 'installer transaction marker is malformed'
+        : `could not read installer transaction marker: ${error.code ?? 'read error'}`,
+    );
+  }
+  if (
+    record?.schema_version !== 1 ||
+    record.transaction_id !== identity.transactionId ||
+    typeof record.package !== 'string' ||
+    typeof record.skill !== 'string' ||
+    record.destination !== destination ||
+    !Number.isSafeInteger(record.owner_pid) ||
+    record.owner_pid <= 0 ||
+    !PHASES.has(record.phase) ||
+    typeof record.had_destination !== 'boolean'
+  ) {
+    return blocked('installer transaction marker is foreign or malformed');
+  }
+  return { state: 'valid', identity, paths, record };
+}
+
+export function inspectInstallTransaction(destination, packageName, skillName) {
+  const locations = transactionLocations(destination);
+  const canonicalEntry = lstatSync(locations.canonical, { throwIfNoEntry: false });
+  if ((canonicalEntry && locations.recoveries.length > 0) || locations.recoveries.length > 1) {
+    return blocked('multiple installer transaction paths require manual inspection');
+  }
+  const recovery = locations.recoveries[0];
+  if (recovery && recovery.transactionId === null) {
+    return blocked('installer recovery path is foreign or malformed');
+  }
+  const transaction = recovery?.path ?? locations.canonical;
+  const inspected = readTransaction(destination, transaction, recovery?.transactionId);
+  if (inspected.state === 'missing') {
+    return { state: 'none', phase: null, had_destination: null, reason: null };
+  }
+  if (inspected.state === 'blocked') return inspected;
+  if (inspected.state === 'cleanup') {
+    return {
+      state: 'recoverable',
+      phase: null,
+      had_destination: null,
+      transaction,
+      cleanup_only: true,
+      projected_destination_exists: inspected.projectedDestinationExists,
+      reason: 'interrupted installer transaction cleanup needs recovery',
+    };
+  }
+  if (inspected.record.package !== packageName || inspected.record.skill !== skillName) {
+    return blocked('installer transaction marker is foreign or malformed');
+  }
+  const live = processIsLive(inspected.identity.ownerPid);
   return {
     state: live ? 'busy' : 'recoverable',
-    phase: marker.phase,
-    had_destination: marker.had_destination,
+    phase: inspected.record.phase,
+    had_destination: inspected.record.had_destination,
+    projected_destination_exists:
+      inspected.record.phase === 'activated' || inspected.record.had_destination,
+    transaction,
+    marker_name: inspected.paths.markerName,
+    transaction_id: inspected.identity.transactionId,
     reason: live
-      ? `installer transaction is owned by live process ${marker.owner_pid}`
-      : `interrupted installer transaction from process ${marker.owner_pid} needs recovery`,
+      ? `installer transaction is owned by live process ${inspected.identity.ownerPid}`
+      : `interrupted installer transaction from process ${inspected.identity.ownerPid} needs recovery`,
   };
 }
 
-function markerRecord(destination, packageName, skillName, phase, hadDestination) {
+function markerRecord(destination, packageName, skillName, transactionId, phase, hadDestination) {
   return {
     schema_version: 1,
+    transaction_id: transactionId,
     package: packageName,
     skill: skillName,
     destination,
@@ -133,26 +241,45 @@ function updateMarker(paths, record) {
   renameSync(paths.nextMarker, paths.marker);
 }
 
-function recoverOwnedTransaction(destination, state) {
-  const paths = pathsFor(destination);
-  const destinationEntry = () => lstatSync(destination, { throwIfNoEntry: false });
-  const stageEntry = () => lstatSync(paths.stage, { throwIfNoEntry: false });
-  const previousEntry = () => lstatSync(paths.previous, { throwIfNoEntry: false });
+function recoveryPath(destination, transactionId) {
+  return `${canonicalPath(destination)}${RECOVERY_SUFFIX}${transactionId}`;
+}
 
-  if (state.state !== 'recoverable') failRecovery(state.reason);
-  const destinationExists = Boolean(destinationEntry());
-  const stageExists = Boolean(stageEntry());
-  const previousExists = Boolean(previousEntry());
+function moveToRecovery(destination, paths, record) {
+  const target = recoveryPath(destination, record.transaction_id);
+  if (paths.transaction === target) return paths;
+  renameSync(paths.transaction, target);
+  return pathsFor(destination, target, paths.markerName);
+}
 
-  if (state.phase === 'activated') {
-    if (!destinationExists || stageExists || previousExists !== state.had_destination) {
-      failRecovery('activated transaction paths do not match the owned marker');
-    }
-    rmSync(paths.transaction, { recursive: true });
+function cleanupOwnedTransaction(paths) {
+  rmSync(paths.stage, { recursive: true, force: true });
+  rmSync(paths.previous, { recursive: true, force: true });
+  rmSync(paths.nextMarker, { force: true });
+  rmSync(paths.marker);
+  rmdirSync(paths.transaction);
+}
+
+function cleanupCommittedTransaction(destination, paths, record) {
+  const destinationEntry = lstatSync(destination, { throwIfNoEntry: false });
+  const stageEntry = lstatSync(paths.stage, { throwIfNoEntry: false });
+  const previousEntry = lstatSync(paths.previous, { throwIfNoEntry: false });
+  if (!destinationEntry || stageEntry || (!record.had_destination && previousEntry)) {
+    failRecovery('activated transaction paths do not match the owned marker');
+  }
+  cleanupOwnedTransaction(paths);
+}
+
+function recoverOwnedTransaction(destination, paths, record) {
+  const destinationExists = Boolean(lstatSync(destination, { throwIfNoEntry: false }));
+  const stageExists = Boolean(lstatSync(paths.stage, { throwIfNoEntry: false }));
+  const previousExists = Boolean(lstatSync(paths.previous, { throwIfNoEntry: false }));
+
+  if (record.phase === 'activated') {
+    cleanupCommittedTransaction(destination, paths, record);
     return;
   }
-
-  if (state.had_destination) {
+  if (record.had_destination) {
     if (previousExists) {
       if (destinationExists && stageExists) {
         failRecovery('both the destination and staged installation are present with a backup');
@@ -169,51 +296,111 @@ function recoverOwnedTransaction(destination, state) {
     }
     if (destinationExists) rmSync(destination, { recursive: true });
   }
-  rmSync(paths.transaction, { recursive: true });
+  cleanupOwnedTransaction(paths);
+}
+
+function claimRecovery(destination, packageName, skillName, state) {
+  if (state.cleanup_only) {
+    try {
+      rmdirSync(state.transaction);
+    } catch (error) {
+      if (error.code === 'ENOENT') return null;
+      throw error;
+    }
+    return { cleanupOnly: true };
+  }
+
+  const claimedName = markerName(state.transaction_id);
+  try {
+    renameSync(join(state.transaction, state.marker_name), join(state.transaction, claimedName));
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+  const inspected = readTransaction(destination, state.transaction);
+  if (inspected.state !== 'valid' || inspected.paths.markerName !== claimedName) {
+    failRecovery(
+      inspected.reason ?? 'claimed installer transaction changed before it could be validated',
+    );
+  }
+  if (
+    inspected.identity.transactionId !== state.transaction_id ||
+    inspected.record.package !== packageName ||
+    inspected.record.skill !== skillName
+  ) {
+    failRecovery('claimed installer transaction identity does not match the observed owner token');
+  }
+  const record = { ...inspected.record, owner_pid: process.pid };
+  updateMarker(inspected.paths, record);
+  const paths = moveToRecovery(destination, inspected.paths, record);
+  return { cleanupOnly: false, paths, record };
 }
 
 function acquireTransaction(destination, packageName, skillName, waitMilliseconds) {
-  const paths = pathsFor(destination);
   const deadline = Date.now() + waitMilliseconds;
   let unmarkedDeadline;
   mkdirSync(dirname(destination), { recursive: true });
   for (;;) {
-    try {
-      mkdirSync(paths.transaction, { mode: 0o700 });
-      const hadDestination = Boolean(lstatSync(destination, { throwIfNoEntry: false }));
-      const record = markerRecord(destination, packageName, skillName, 'staging', hadDestination);
-      try {
-        writeFileSync(paths.marker, `${JSON.stringify(record, null, 2)}\n`, {
-          flag: 'wx',
-          mode: 0o600,
-        });
-      } catch (error) {
-        rmSync(paths.transaction, { recursive: true, force: true });
-        throw error;
-      }
-      return { paths, record };
-    } catch (error) {
-      if (error.code !== 'EEXIST') throw error;
-      const state = inspectInstallTransaction(destination, packageName, skillName);
-      if (state.state === 'blocked') {
-        if (state.reason === 'installer transaction marker is missing or not a regular file') {
-          unmarkedDeadline ??= Date.now() + 2_000;
-          if (Date.now() < Math.min(deadline, unmarkedDeadline)) {
-            Atomics.wait(sleepBuffer, 0, 0, 25);
-            continue;
-          }
+    const state = inspectInstallTransaction(destination, packageName, skillName);
+    if (state.state === 'blocked') {
+      if (
+        [
+          'installer transaction marker is missing or ambiguous',
+          'installer transaction marker is missing or not a regular file',
+        ].includes(state.reason)
+      ) {
+        unmarkedDeadline ??= Date.now() + 2_000;
+        if (Date.now() < Math.min(deadline, unmarkedDeadline)) {
+          Atomics.wait(sleepBuffer, 0, 0, 25);
+          continue;
         }
-        throw new Error(state.reason, { cause: error });
       }
-      if (state.state === 'recoverable') {
-        recoverOwnedTransaction(destination, state);
-        continue;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(`Timed out waiting for ${state.reason}.`, { cause: error });
-      }
-      Atomics.wait(sleepBuffer, 0, 0, 25);
+      throw new Error(state.reason);
     }
+    unmarkedDeadline = undefined;
+    if (state.state === 'recoverable') {
+      const claimed = claimRecovery(destination, packageName, skillName, state);
+      if (!claimed) continue;
+      if (!claimed.cleanupOnly) {
+        recoverOwnedTransaction(destination, claimed.paths, claimed.record);
+      }
+      continue;
+    }
+    if (state.state === 'busy') {
+      if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${state.reason}.`);
+      Atomics.wait(sleepBuffer, 0, 0, 25);
+      continue;
+    }
+
+    const transaction = canonicalPath(destination);
+    try {
+      mkdirSync(transaction, { mode: 0o700 });
+    } catch (error) {
+      if (error.code === 'EEXIST') continue;
+      throw error;
+    }
+    const transactionId = randomUUID();
+    const ownerName = markerName(transactionId);
+    const paths = pathsFor(destination, transaction, ownerName);
+    const hadDestination = Boolean(lstatSync(destination, { throwIfNoEntry: false }));
+    const record = markerRecord(
+      destination,
+      packageName,
+      skillName,
+      transactionId,
+      'staging',
+      hadDestination,
+    );
+    try {
+      writeFileSync(paths.marker, `${JSON.stringify(record, null, 2)}\n`, {
+        flag: 'wx',
+        mode: 0o600,
+      });
+    } catch (error) {
+      rmSync(transaction, { recursive: true, force: true });
+      throw error;
+    }
+    return { paths, record };
   }
 }
 
@@ -232,19 +419,15 @@ export function runInstallTransaction({
     const initialPlan = prepare();
     if (initialPlan.outcome === 'skipped') return initialPlan;
   }
-  const { paths, record } = acquireTransaction(
-    destination,
-    packageName,
-    skillName,
-    waitMilliseconds,
-  );
+  let { paths, record } = acquireTransaction(destination, packageName, skillName, waitMilliseconds);
   let destinationMoved = false;
   let stageMoved = false;
   let committed = false;
   try {
     const plan = prepare();
     if (plan.outcome === 'skipped') {
-      rmSync(paths.transaction, { recursive: true });
+      paths = moveToRecovery(destination, paths, record);
+      cleanupOwnedTransaction(paths);
       return plan;
     }
 
@@ -268,25 +451,30 @@ export function runInstallTransaction({
       `${JSON.stringify({ package: packageName, version: packageVersion }, null, 2)}\n`,
       { flag: 'wx' },
     );
-    updateMarker(paths, { ...record, phase: 'staged' });
+    record = { ...record, phase: 'staged' };
+    updateMarker(paths, record);
 
     if (record.had_destination) {
       renameSync(destination, paths.previous);
       destinationMoved = true;
-      updateMarker(paths, { ...record, phase: 'previous_moved' });
+      record = { ...record, phase: 'previous_moved' };
+      updateMarker(paths, record);
     }
     renameSync(paths.stage, destination);
     stageMoved = true;
-    updateMarker(paths, { ...record, phase: 'activated' });
+    record = { ...record, phase: 'activated' };
+    updateMarker(paths, record);
     committed = true;
-    rmSync(paths.transaction, { recursive: true });
+    paths = moveToRecovery(destination, paths, record);
+    cleanupCommittedTransaction(destination, paths, record);
     return plan;
   } catch (error) {
     if (committed) throw error;
     try {
       if (stageMoved) rmSync(destination, { recursive: true });
       if (destinationMoved) renameSync(paths.previous, destination);
-      rmSync(paths.transaction, { recursive: true });
+      paths = moveToRecovery(destination, paths, record);
+      cleanupOwnedTransaction(paths);
     } catch (rollbackError) {
       throw new Error(`${error.message}; rollback failed: ${rollbackError.message}`, {
         cause: rollbackError,

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -296,13 +296,17 @@ function removeOwnedContents(paths) {
   rmSync(paths.nextMarker, { force: true });
 }
 
+function finishTerminalCleanup(destination, paths, record) {
+  const recoveryPaths = moveToRecovery(destination, paths, record);
+  rmSync(recoveryPaths.marker);
+  rmdirSync(recoveryPaths.transaction);
+}
+
 function finishCleanup(destination, paths, record) {
   removeOwnedContents(paths);
   const terminalRecord = { ...record, phase: 'cleanup' };
   updateMarker(paths, terminalRecord);
-  const recoveryPaths = moveToRecovery(destination, paths, terminalRecord);
-  rmSync(recoveryPaths.marker);
-  rmdirSync(recoveryPaths.transaction);
+  finishTerminalCleanup(destination, paths, terminalRecord);
 }
 
 function cleanupCommittedTransaction(destination, paths, record) {
@@ -321,7 +325,7 @@ function recoverOwnedTransaction(destination, paths, record) {
   const previousExists = Boolean(lstatSync(paths.previous, { throwIfNoEntry: false }));
 
   if (record.phase === 'cleanup') {
-    finishCleanup(destination, paths, record);
+    finishTerminalCleanup(destination, paths, record);
     return;
   }
   if (record.phase === 'activated') {
@@ -379,12 +383,12 @@ function claimRecovery(destination, packageName, skillName, state) {
   ) {
     failRecovery('claimed installer transaction identity does not match the observed owner token');
   }
-  const record = { ...inspected.record, owner_pid: process.pid };
-  updateMarker(inspected.paths, record);
-  if (record.phase === 'cleanup') {
-    finishCleanup(destination, inspected.paths, record);
+  if (inspected.record.phase === 'cleanup') {
+    finishTerminalCleanup(destination, inspected.paths, inspected.record);
     return { cleanupOnly: true };
   }
+  const record = { ...inspected.record, owner_pid: process.pid };
+  updateMarker(inspected.paths, record);
   return { cleanupOnly: false, paths: inspected.paths, record };
 }
 

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -18,7 +18,7 @@ const RECOVERY_SUFFIX = '.recovering-';
 const NEXT_MARKER = 'transaction.next.json';
 const STAGE = 'stage';
 const PREVIOUS = 'previous';
-const PHASES = new Set(['staging', 'staged', 'previous_moved', 'activated']);
+const PHASES = new Set(['staging', 'staged', 'previous_moved', 'activated', 'cleanup']);
 const UUID_PATTERN = '[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}';
 const OWNER_PATTERN = new RegExp(
   `^owner-(?<transactionId>${UUID_PATTERN})-(?<pid>[1-9]\\d*)-(?<claimId>${UUID_PATTERN})\\.json$`,
@@ -170,21 +170,58 @@ function readTransaction(destination, transaction, recoveryTransactionId = null)
   ) {
     return blocked('installer transaction marker is foreign or malformed');
   }
+  if (record.phase === 'cleanup' && names.length !== 1) {
+    return blocked('terminal installer cleanup contains unexpected data');
+  }
   return { state: 'valid', identity, paths, record };
 }
 
 export function inspectInstallTransaction(destination, packageName, skillName) {
   const locations = transactionLocations(destination);
   const canonicalEntry = lstatSync(locations.canonical, { throwIfNoEntry: false });
-  if ((canonicalEntry && locations.recoveries.length > 0) || locations.recoveries.length > 1) {
+  const recoveries = [];
+  for (const recovery of locations.recoveries) {
+    if (recovery.transactionId === null) {
+      return blocked('installer recovery path is foreign or malformed');
+    }
+    const inspected = readTransaction(destination, recovery.path, recovery.transactionId);
+    if (inspected.state === 'missing') continue;
+    if (inspected.state === 'blocked') return inspected;
+    if (
+      inspected.state === 'valid' &&
+      (inspected.record.package !== packageName || inspected.record.skill !== skillName)
+    ) {
+      return blocked('installer transaction marker is foreign or malformed');
+    }
+    recoveries.push({ location: recovery, inspected });
+  }
+  let canonical;
+  if (canonicalEntry) {
+    canonical = readTransaction(destination, locations.canonical);
+    if (canonical.state === 'blocked') return canonical;
+    if (
+      canonical.state === 'valid' &&
+      (canonical.record.package !== packageName || canonical.record.skill !== skillName)
+    ) {
+      return blocked('installer transaction marker is foreign or malformed');
+    }
+  }
+  if (
+    ((canonical && recoveries.length > 0) || recoveries.length > 1) &&
+    recoveries.some(
+      ({ inspected }) => inspected.state !== 'cleanup' && inspected.record.phase !== 'cleanup',
+    )
+  ) {
     return blocked('multiple installer transaction paths require manual inspection');
   }
-  const recovery = locations.recoveries[0];
-  if (recovery && recovery.transactionId === null) {
-    return blocked('installer recovery path is foreign or malformed');
+  const selected =
+    recoveries[0] ??
+    (canonical ? { location: { path: locations.canonical }, inspected: canonical } : null);
+  if (!selected) {
+    return { state: 'none', phase: null, had_destination: null, reason: null };
   }
-  const transaction = recovery?.path ?? locations.canonical;
-  const inspected = readTransaction(destination, transaction, recovery?.transactionId);
+  const { inspected } = selected;
+  const transaction = selected.location.path;
   if (inspected.state === 'missing') {
     return { state: 'none', phase: null, had_destination: null, reason: null };
   }
@@ -196,21 +233,22 @@ export function inspectInstallTransaction(destination, packageName, skillName) {
       had_destination: null,
       transaction,
       cleanup_only: true,
+      marker_name: null,
       projected_destination_exists: inspected.projectedDestinationExists,
       reason: 'interrupted installer transaction cleanup needs recovery',
     };
   }
-  if (inspected.record.package !== packageName || inspected.record.skill !== skillName) {
-    return blocked('installer transaction marker is foreign or malformed');
-  }
   const live = processIsLive(inspected.identity.ownerPid);
+  const cleanupOnly = inspected.record.phase === 'cleanup';
   return {
     state: live ? 'busy' : 'recoverable',
     phase: inspected.record.phase,
     had_destination: inspected.record.had_destination,
-    projected_destination_exists:
-      inspected.record.phase === 'activated' || inspected.record.had_destination,
+    projected_destination_exists: cleanupOnly
+      ? Boolean(lstatSync(destination, { throwIfNoEntry: false }))
+      : inspected.record.phase === 'activated' || inspected.record.had_destination,
     transaction,
+    cleanup_only: cleanupOnly,
     marker_name: inspected.paths.markerName,
     transaction_id: inspected.identity.transactionId,
     reason: live
@@ -260,7 +298,9 @@ function removeOwnedContents(paths) {
 
 function finishCleanup(destination, paths, record) {
   removeOwnedContents(paths);
-  const recoveryPaths = moveToRecovery(destination, paths, record);
+  const terminalRecord = { ...record, phase: 'cleanup' };
+  updateMarker(paths, terminalRecord);
+  const recoveryPaths = moveToRecovery(destination, paths, terminalRecord);
   rmSync(recoveryPaths.marker);
   rmdirSync(recoveryPaths.transaction);
 }
@@ -280,6 +320,10 @@ function recoverOwnedTransaction(destination, paths, record) {
   const stageExists = Boolean(lstatSync(paths.stage, { throwIfNoEntry: false }));
   const previousExists = Boolean(lstatSync(paths.previous, { throwIfNoEntry: false }));
 
+  if (record.phase === 'cleanup') {
+    finishCleanup(destination, paths, record);
+    return;
+  }
   if (record.phase === 'activated') {
     cleanupCommittedTransaction(destination, paths, record);
     return;
@@ -305,7 +349,7 @@ function recoverOwnedTransaction(destination, paths, record) {
 }
 
 function claimRecovery(destination, packageName, skillName, state) {
-  if (state.cleanup_only) {
+  if (state.cleanup_only && state.marker_name === null) {
     try {
       rmdirSync(state.transaction);
     } catch (error) {
@@ -337,6 +381,10 @@ function claimRecovery(destination, packageName, skillName, state) {
   }
   const record = { ...inspected.record, owner_pid: process.pid };
   updateMarker(inspected.paths, record);
+  if (record.phase === 'cleanup') {
+    finishCleanup(destination, inspected.paths, record);
+    return { cleanupOnly: true };
+  }
   return { cleanupOnly: false, paths: inspected.paths, record };
 }
 

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -181,7 +181,12 @@ function readTransaction(destination, transaction, recoveryTransactionId = null)
   return { state: 'valid', identity, paths, record };
 }
 
-export function inspectInstallTransaction(destination, packageName, skillName) {
+export function inspectInstallTransaction(
+  destination,
+  packageName,
+  skillName,
+  { recoveriesFirst = false } = {},
+) {
   const locations = transactionLocations(destination);
   const canonicalEntry = lstatSync(locations.canonical, { throwIfNoEntry: false });
   const recoveries = [];
@@ -219,9 +224,15 @@ export function inspectInstallTransaction(destination, packageName, skillName) {
   ) {
     return blocked('multiple installer transaction paths require manual inspection');
   }
-  const selected =
-    recoveries[0] ??
-    (canonical ? { location: { path: locations.canonical }, inspected: canonical } : null);
+  const canonicalTransaction =
+    canonical?.state === 'valid'
+      ? { location: { path: locations.canonical }, inspected: canonical }
+      : null;
+  // Inspection describes the canonical generation; acquisition can drain older
+  // terminal cleanup before waiting on that generation.
+  const selected = recoveriesFirst
+    ? (recoveries[0] ?? canonicalTransaction)
+    : (canonicalTransaction ?? recoveries[0]);
   if (!selected) {
     return { state: 'none', phase: null, had_destination: null, reason: null };
   }
@@ -403,7 +414,9 @@ async function acquireTransaction(destination, packageName, skillName, waitMilli
   mkdirSync(dirname(destination), { recursive: true });
   for (;;) {
     await cancellationCheckpoint(signal);
-    const state = inspectInstallTransaction(destination, packageName, skillName);
+    const state = inspectInstallTransaction(destination, packageName, skillName, {
+      recoveriesFirst: true,
+    });
     if (state.state === 'blocked') {
       if (
         [

--- a/packages/skills/bin/install-transaction.mjs
+++ b/packages/skills/bin/install-transaction.mjs
@@ -12,6 +12,7 @@ import {
 } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import process from 'node:process';
+import { setImmediate, setTimeout } from 'node:timers/promises';
 
 const TRANSACTION_SUFFIX = '.inferencex-skills-transaction';
 const RECOVERY_SUFFIX = '.recovering-';
@@ -24,7 +25,11 @@ const OWNER_PATTERN = new RegExp(
   `^owner-(?<transactionId>${UUID_PATTERN})-(?<pid>[1-9]\\d*)-(?<claimId>${UUID_PATTERN})\\.json$`,
   'u',
 );
-const sleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+async function cancellationCheckpoint(signal) {
+  await setImmediate();
+  signal?.throwIfAborted();
+}
 
 function canonicalPath(destination) {
   return `${destination}${TRANSACTION_SUFFIX}`;
@@ -392,11 +397,12 @@ function claimRecovery(destination, packageName, skillName, state) {
   return { cleanupOnly: false, paths: inspected.paths, record };
 }
 
-function acquireTransaction(destination, packageName, skillName, waitMilliseconds) {
+async function acquireTransaction(destination, packageName, skillName, waitMilliseconds, signal) {
   const deadline = Date.now() + waitMilliseconds;
   let unmarkedDeadline;
   mkdirSync(dirname(destination), { recursive: true });
   for (;;) {
+    await cancellationCheckpoint(signal);
     const state = inspectInstallTransaction(destination, packageName, skillName);
     if (state.state === 'blocked') {
       if (
@@ -407,7 +413,7 @@ function acquireTransaction(destination, packageName, skillName, waitMillisecond
       ) {
         unmarkedDeadline ??= Date.now() + 2_000;
         if (Date.now() < Math.min(deadline, unmarkedDeadline)) {
-          Atomics.wait(sleepBuffer, 0, 0, 25);
+          await setTimeout(25);
           continue;
         }
       }
@@ -424,7 +430,7 @@ function acquireTransaction(destination, packageName, skillName, waitMillisecond
     }
     if (state.state === 'busy') {
       if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${state.reason}.`);
-      Atomics.wait(sleepBuffer, 0, 0, 25);
+      await setTimeout(25);
       continue;
     }
 
@@ -460,7 +466,7 @@ function acquireTransaction(destination, packageName, skillName, waitMillisecond
   }
 }
 
-export function runInstallTransaction({
+export async function runInstallTransaction({
   source,
   destination,
   packageName,
@@ -468,20 +474,29 @@ export function runInstallTransaction({
   skillName,
   receiptName,
   prepare,
+  signal,
   waitMilliseconds = 30_000,
 }) {
+  await cancellationCheckpoint(signal);
   const pending = inspectInstallTransaction(destination, packageName, skillName);
   if (pending.state === 'none') {
     const initialPlan = prepare();
     if (initialPlan.outcome === 'skipped') return initialPlan;
   }
-  const acquired = acquireTransaction(destination, packageName, skillName, waitMilliseconds);
+  const acquired = await acquireTransaction(
+    destination,
+    packageName,
+    skillName,
+    waitMilliseconds,
+    signal,
+  );
   const { paths } = acquired;
   let { record } = acquired;
   let destinationMoved = false;
   let stageMoved = false;
   let committed = false;
   try {
+    await cancellationCheckpoint(signal);
     const plan = prepare();
     if (plan.outcome === 'skipped') {
       finishCleanup(destination, paths, record);
@@ -494,6 +509,7 @@ export function runInstallTransaction({
         preserveTimestamps: true,
         verbatimSymlinks: true,
       });
+      await cancellationCheckpoint(signal);
     }
     cpSync(source, paths.stage, {
       recursive: true,
@@ -501,6 +517,7 @@ export function runInstallTransaction({
       preserveTimestamps: true,
       verbatimSymlinks: true,
     });
+    await cancellationCheckpoint(signal);
     const stagedReceipt = join(paths.stage, receiptName);
     rmSync(stagedReceipt, { force: true });
     writeFileSync(
@@ -510,19 +527,24 @@ export function runInstallTransaction({
     );
     record = { ...record, phase: 'staged' };
     updateMarker(paths, record);
+    await cancellationCheckpoint(signal);
 
     if (record.had_destination) {
       renameSync(destination, paths.previous);
       destinationMoved = true;
       record = { ...record, phase: 'previous_moved' };
       updateMarker(paths, record);
+      await cancellationCheckpoint(signal);
     }
     renameSync(paths.stage, destination);
     stageMoved = true;
+    await cancellationCheckpoint(signal);
     record = { ...record, phase: 'activated' };
     updateMarker(paths, record);
     committed = true;
+    await setImmediate();
     cleanupCommittedTransaction(destination, paths, record);
+    await setImmediate();
     return plan;
   } catch (error) {
     if (committed) throw error;

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 import {
   argumentError,
+  CliError,
   runCli,
   writeStdout,
 } from '../skills/inferencex-api/scripts/cli-contract.mjs';
@@ -211,6 +212,25 @@ function installationPlan(source, destination, force) {
   return { outcome: existing ? 'overwritten' : 'installed', write_paths: files.sort() };
 }
 
+function installTransaction(options) {
+  try {
+    return runInstallTransaction(options);
+  } catch (error) {
+    // Protocol failures are internal errors; Node filesystem failures carry these fields.
+    for (let cause = error; cause instanceof Error; cause = cause.cause) {
+      if (
+        Number.isInteger(cause.errno) &&
+        typeof cause.code === 'string' &&
+        typeof cause.syscall === 'string' &&
+        typeof cause.path === 'string'
+      ) {
+        throw new CliError('OUTPUT_ERROR', error.message, { cause: error });
+      }
+    }
+    throw error;
+  }
+}
+
 async function main(args, signal) {
   let command;
   let values;
@@ -299,7 +319,7 @@ async function main(args, signal) {
           (values.force || !recoveredDestinationExists)
         ? installationPlan(source, destination, true)
         : { outcome: 'skipped', write_paths: [] }
-    : runInstallTransaction({
+    : installTransaction({
         source,
         destination,
         packageName: packageInfo.name,

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -144,6 +144,11 @@ function statusRecord(destination, packageInfo) {
             transaction.state === 'recoverable' ? 'recovery_needed' : transaction.state,
           transaction_phase: transaction.phase,
           transaction_had_destination: transaction.had_destination,
+          ...(transaction.cleanup_only
+            ? {
+                transaction_projected_destination_exists: transaction.projected_destination_exists,
+              }
+            : {}),
         };
   return {
     schema_version: 1,
@@ -152,6 +157,14 @@ function statusRecord(destination, packageInfo) {
     skill_path: destination,
     ...installation,
   };
+}
+
+function recoveryLeavesDestination(record) {
+  return (
+    record.transaction_phase === 'activated' ||
+    record.transaction_had_destination === true ||
+    record.transaction_projected_destination_exists === true
+  );
 }
 
 function showStatus(record) {
@@ -278,11 +291,12 @@ async function main(args, signal) {
     return;
   }
   const dryRun = values['dry-run'] ?? false;
+  const recoveredDestinationExists = recoveryLeavesDestination(record);
   const plan = dryRun
     ? record.transaction_state === undefined
       ? installationPlan(source, destination, values.force)
       : record.transaction_state === 'recovery_needed' &&
-          (values.force || !record.transaction_had_destination)
+          (values.force || !recoveredDestinationExists)
         ? installationPlan(source, destination, true)
         : { outcome: 'skipped', write_paths: [] }
     : runInstallTransaction({
@@ -302,10 +316,10 @@ async function main(args, signal) {
       ? record.transaction_state === 'recovery_needed'
         ? `would_recover_then_${
             values.force
-              ? record.transaction_had_destination
+              ? recoveredDestinationExists
                 ? 'overwrite'
                 : 'install'
-              : record.transaction_had_destination
+              : recoveredDestinationExists
                 ? 'skip'
                 : 'install'
           }`

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -13,6 +13,11 @@ import {
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  runCli,
+  writeStdout,
+} from '../skills/inferencex-api/scripts/cli-contract.mjs';
 
 const SKILL_NAME = 'inferencex-api';
 const INSTALL_METADATA = '.inferencex-skills.json';
@@ -41,6 +46,7 @@ Install and status options:
   --json          Emit one JSON document (schema_version: 1), without prose
   --force         Install only: overwrite packaged files; retains obsolete files
   --dry-run       Install only: preview the same preflight without changing files
+  --error-format <mode> Failure diagnostics: text (default) or json
 
 Existing skills are skipped unless --force is supplied.
 Status reads local installation metadata without changing files or using the network.
@@ -94,6 +100,7 @@ function installedState(destination, packageName) {
     { file: 'compare-releases.mjs', name: 'release comparison helper', minor: 7n },
     { file: 'compare-collectivex.mjs', name: 'CollectiveX helper', minor: 8n },
     { file: 'response-budget.mjs', name: 'response reader', minor: 9n },
+    { file: 'cli-contract.mjs', name: 'CLI contract', minor: 10n },
   ].filter(
     ({ minor }) =>
       BigInt(versionMatch.groups.major) > 0n || BigInt(versionMatch.groups.minor) >= minor,
@@ -185,25 +192,12 @@ function installationPlan(source, destination, force) {
   return { outcome: existing ? 'overwritten' : 'installed', write_paths: files.sort() };
 }
 
-function fail(error, exitCode, json, command) {
-  const reason = error.message;
-  if (json) {
-    console.log(JSON.stringify({ schema_version: 1, outcome: 'failed', reason }));
-  }
-  console.error(
-    exitCode === 2
-      ? `${reason}\nRun inferencex-skills --help for usage.`
-      : `Could not ${command} the skill: ${reason}`,
-  );
-  process.exitCode = exitCode;
-}
-
-function main() {
+async function main(args, signal) {
   let command;
   let values;
-  const json = process.argv.slice(2).includes('--json');
   try {
     const parsed = parseArgs({
+      args,
       options: {
         help: { type: 'boolean', short: 'h' },
         version: { type: 'boolean' },
@@ -212,6 +206,7 @@ function main() {
         force: { type: 'boolean' },
         json: { type: 'boolean' },
         'dry-run': { type: 'boolean' },
+        'error-format': { type: 'string' },
       },
       allowPositionals: true,
     });
@@ -243,91 +238,103 @@ function main() {
       throw new Error('--json requires install or status without --help.');
     }
   } catch (error) {
-    fail(error, 2, json, command);
-    return;
+    throw argumentError(error.message, error);
   }
 
   if (command === 'help' || values.help) {
-    console.log(HELP);
+    await writeStdout(`${HELP}\n`, { signal });
     return;
   }
 
-  try {
-    if (Number(process.versions.node.split('.')[0]) < 24) {
-      throw new Error('Node 24 or later is required.');
-    }
-    const packageInfo = JSON.parse(
-      readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf8'),
-    );
-    if (command === 'version') {
-      console.log(`Installer version: ${packageInfo.version}`);
-      return;
-    }
-    const source = join(import.meta.dirname, '..', 'skills', SKILL_NAME);
-    readFileSync(join(source, 'SKILL.md'), 'utf8');
-    if (command === 'list') {
-      console.log(`Bundled InferenceX skill:\n  ${SKILL_NAME}`);
-      return;
-    }
+  if (Number(process.versions.node.split('.')[0]) < 24) {
+    throw new Error('Node 24 or later is required.');
+  }
+  const packageInfo = JSON.parse(
+    readFileSync(join(import.meta.dirname, '..', 'package.json'), 'utf8'),
+  );
+  if (command === 'version') {
+    await writeStdout(`Installer version: ${packageInfo.version}\n`, { signal });
+    return;
+  }
+  const source = join(import.meta.dirname, '..', 'skills', SKILL_NAME);
+  readFileSync(join(source, 'SKILL.md'), 'utf8');
+  if (command === 'list') {
+    await writeStdout(`Bundled InferenceX skill:\n  ${SKILL_NAME}\n`, { signal });
+    return;
+  }
 
-    const root = resolve(values.dir ?? TARGET_DIRS[values.target ?? 'claude']);
-    const destination = join(root, SKILL_NAME);
-    let record = statusRecord(destination, packageInfo);
-    if (command === 'status') {
-      if (values.json) console.log(JSON.stringify(record));
-      else showStatus(record);
-      return;
-    }
-    const plan = installationPlan(source, destination, values.force);
-    const dryRun = values['dry-run'] ?? false;
-    if (!dryRun && plan.outcome !== 'skipped') {
-      const metadataPath = join(destination, INSTALL_METADATA);
-      mkdirSync(root, { recursive: true });
-      // A failed overwrite must not leave a version stamp for partially replaced files.
-      rmSync(metadataPath, { force: true });
-      cpSync(source, destination, { recursive: true, force: true });
-      writeFileSync(
-        metadataPath,
-        `${JSON.stringify({ package: packageInfo.name, version: packageInfo.version }, null, 2)}\n`,
-        { flag: 'wx' },
-      );
-      record = statusRecord(destination, packageInfo);
-    }
-    const result = {
-      ...record,
-      dry_run: dryRun,
-      outcome: dryRun
-        ? { installed: 'would_install', overwritten: 'would_overwrite', skipped: 'would_skip' }[
-            plan.outcome
-          ]
-        : plan.outcome,
-      write_paths: plan.write_paths,
-      preserves_extra_files: true,
-    };
-    if (values.json) {
-      console.log(JSON.stringify(result));
-      return;
-    }
-    if (dryRun) {
-      console.log(
-        `Dry run: would ${{ installed: 'install', overwritten: 'overwrite', skipped: 'skip' }[plan.outcome]} ${SKILL_NAME} at ${destination}.`,
-      );
-      showStatus(record);
-      console.log(
-        `Files to write (relative to skill path, including the installation record):\n${plan.write_paths.map((path) => `  ${path}`).join('\n') || '  (none)'}`,
-      );
-      console.log('Unrelated and obsolete files remain untouched. No files were changed.');
-    } else {
-      console.log(
-        plan.outcome === 'skipped'
-          ? `Skipped ${SKILL_NAME}: already exists at ${destination}; use --force to overwrite.`
-          : `Installed ${SKILL_NAME} into ${destination}`,
-      );
-      showStatus(record);
-    }
-  } catch (error) {
-    fail(error, 1, json, command);
+  const root = resolve(values.dir ?? TARGET_DIRS[values.target ?? 'claude']);
+  const destination = join(root, SKILL_NAME);
+  let record = statusRecord(destination, packageInfo);
+  if (command === 'status') {
+    if (values.json) await writeStdout(`${JSON.stringify(record)}\n`, { signal });
+    else showStatus(record);
+    return;
+  }
+  const plan = installationPlan(source, destination, values.force);
+  const dryRun = values['dry-run'] ?? false;
+  if (!dryRun && plan.outcome !== 'skipped') {
+    const metadataPath = join(destination, INSTALL_METADATA);
+    mkdirSync(root, { recursive: true });
+    // A failed overwrite must not leave a version stamp for partially replaced files.
+    rmSync(metadataPath, { force: true });
+    cpSync(source, destination, { recursive: true, force: true });
+    writeFileSync(
+      metadataPath,
+      `${JSON.stringify({ package: packageInfo.name, version: packageInfo.version }, null, 2)}\n`,
+      { flag: 'wx' },
+    );
+    record = statusRecord(destination, packageInfo);
+  }
+  const result = {
+    ...record,
+    dry_run: dryRun,
+    outcome: dryRun
+      ? { installed: 'would_install', overwritten: 'would_overwrite', skipped: 'would_skip' }[
+          plan.outcome
+        ]
+      : plan.outcome,
+    write_paths: plan.write_paths,
+    preserves_extra_files: true,
+  };
+  if (values.json) {
+    await writeStdout(`${JSON.stringify(result)}\n`, { signal });
+    return;
+  }
+  if (dryRun) {
+    console.log(
+      `Dry run: would ${{ installed: 'install', overwritten: 'overwrite', skipped: 'skip' }[plan.outcome]} ${SKILL_NAME} at ${destination}.`,
+    );
+    showStatus(record);
+    console.log(
+      `Files to write (relative to skill path, including the installation record):\n${plan.write_paths.map((path) => `  ${path}`).join('\n') || '  (none)'}`,
+    );
+    console.log('Unrelated and obsolete files remain untouched. No files were changed.');
+  } else {
+    console.log(
+      plan.outcome === 'skipped'
+        ? `Skipped ${SKILL_NAME}: already exists at ${destination}; use --force to overwrite.`
+        : `Installed ${SKILL_NAME} into ${destination}`,
+    );
+    showStatus(record);
   }
 }
 
-main();
+const args = process.argv.slice(2);
+const command = args.find((arg) => ['install', 'status', 'list'].includes(arg)) ?? 'help';
+await runCli({
+  command: 'inferencex-skills',
+  args,
+  textUsageExitCode: 2,
+  textError(error) {
+    if (args.includes('--json')) {
+      process.stdout.write(
+        `${JSON.stringify({ schema_version: 1, outcome: 'failed', reason: error.message })}\n`,
+      );
+    }
+    return error.code === 'INVALID_ARGUMENT'
+      ? `${error.message}\nRun inferencex-skills --help for usage.`
+      : `Could not ${command} the skill: ${error.message}`;
+  },
+  run: ({ args: cliArgs, signal }) => main(cliArgs, signal),
+});

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -212,9 +212,9 @@ function installationPlan(source, destination, force) {
   return { outcome: existing ? 'overwritten' : 'installed', write_paths: files.sort() };
 }
 
-function installTransaction(options) {
+async function installTransaction(options) {
   try {
-    return runInstallTransaction(options);
+    return await runInstallTransaction(options);
   } catch (error) {
     // Protocol failures are internal errors; Node filesystem failures carry these fields.
     for (let cause = error; cause instanceof Error; cause = cause.cause) {
@@ -319,13 +319,14 @@ async function main(args, signal) {
           (values.force || !recoveredDestinationExists)
         ? installationPlan(source, destination, true)
         : { outcome: 'skipped', write_paths: [] }
-    : installTransaction({
+    : await installTransaction({
         source,
         destination,
         packageName: packageInfo.name,
         packageVersion: packageInfo.version,
         skillName: SKILL_NAME,
         receiptName: INSTALL_METADATA,
+        signal,
         prepare: () => installationPlan(source, destination, values.force),
       });
   if (!dryRun) record = statusRecord(destination, packageInfo);
@@ -357,7 +358,7 @@ async function main(args, signal) {
     preserves_extra_files: true,
   };
   if (values.json) {
-    await writeStdout(`${JSON.stringify(result)}\n`, { signal });
+    await writeStdout(`${JSON.stringify(result)}\n`, { signal: dryRun ? signal : undefined });
     return;
   }
   if (dryRun) {

--- a/packages/skills/bin/install.mjs
+++ b/packages/skills/bin/install.mjs
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 
-import {
-  cpSync,
-  lstatSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { lstatSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
@@ -18,6 +9,8 @@ import {
   runCli,
   writeStdout,
 } from '../skills/inferencex-api/scripts/cli-contract.mjs';
+
+import { inspectInstallTransaction, runInstallTransaction } from './install-transaction.mjs';
 
 const SKILL_NAME = 'inferencex-api';
 const INSTALL_METADATA = '.inferencex-skills.json';
@@ -50,6 +43,8 @@ Install and status options:
 
 Existing skills are skipped unless --force is supplied.
 Status reads local installation metadata without changing files or using the network.
+Interrupted owned installs recover on the next install; status and dry-run remain read-only.
+Recovery covers process crashes, without an fsync or power-loss durability guarantee.
 --version reports the executing installer, not an installed skill.
 Bundled skill: inferencex-api
 `;
@@ -139,12 +134,23 @@ function installedState(destination, packageName) {
 }
 
 function statusRecord(destination, packageInfo) {
+  const transaction = inspectInstallTransaction(destination, packageInfo.name, SKILL_NAME);
+  const installation =
+    transaction.state === 'none'
+      ? installedState(destination, packageInfo.name)
+      : {
+          ...unknownState(transaction.reason),
+          transaction_state:
+            transaction.state === 'recoverable' ? 'recovery_needed' : transaction.state,
+          transaction_phase: transaction.phase,
+          transaction_had_destination: transaction.had_destination,
+        };
   return {
     schema_version: 1,
     package: packageInfo.name,
     installer_version: packageInfo.version,
     skill_path: destination,
-    ...installedState(destination, packageInfo.name),
+    ...installation,
   };
 }
 
@@ -271,28 +277,47 @@ async function main(args, signal) {
     else showStatus(record);
     return;
   }
-  const plan = installationPlan(source, destination, values.force);
   const dryRun = values['dry-run'] ?? false;
-  if (!dryRun && plan.outcome !== 'skipped') {
-    const metadataPath = join(destination, INSTALL_METADATA);
-    mkdirSync(root, { recursive: true });
-    // A failed overwrite must not leave a version stamp for partially replaced files.
-    rmSync(metadataPath, { force: true });
-    cpSync(source, destination, { recursive: true, force: true });
-    writeFileSync(
-      metadataPath,
-      `${JSON.stringify({ package: packageInfo.name, version: packageInfo.version }, null, 2)}\n`,
-      { flag: 'wx' },
-    );
-    record = statusRecord(destination, packageInfo);
-  }
+  const plan = dryRun
+    ? record.transaction_state === undefined
+      ? installationPlan(source, destination, values.force)
+      : record.transaction_state === 'recovery_needed' &&
+          (values.force || !record.transaction_had_destination)
+        ? installationPlan(source, destination, true)
+        : { outcome: 'skipped', write_paths: [] }
+    : runInstallTransaction({
+        source,
+        destination,
+        packageName: packageInfo.name,
+        packageVersion: packageInfo.version,
+        skillName: SKILL_NAME,
+        receiptName: INSTALL_METADATA,
+        prepare: () => installationPlan(source, destination, values.force),
+      });
+  if (!dryRun) record = statusRecord(destination, packageInfo);
   const result = {
     ...record,
     dry_run: dryRun,
     outcome: dryRun
-      ? { installed: 'would_install', overwritten: 'would_overwrite', skipped: 'would_skip' }[
-          plan.outcome
-        ]
+      ? record.transaction_state === 'recovery_needed'
+        ? `would_recover_then_${
+            values.force
+              ? record.transaction_had_destination
+                ? 'overwrite'
+                : 'install'
+              : record.transaction_had_destination
+                ? 'skip'
+                : 'install'
+          }`
+        : record.transaction_state === 'busy'
+          ? 'would_wait_for_install'
+          : record.transaction_state === 'blocked'
+            ? 'blocked_by_transaction'
+            : {
+                installed: 'would_install',
+                overwritten: 'would_overwrite',
+                skipped: 'would_skip',
+              }[plan.outcome]
       : plan.outcome,
     write_paths: plan.write_paths,
     preserves_extra_files: true,
@@ -302,9 +327,17 @@ async function main(args, signal) {
     return;
   }
   if (dryRun) {
-    console.log(
-      `Dry run: would ${{ installed: 'install', overwritten: 'overwrite', skipped: 'skip' }[plan.outcome]} ${SKILL_NAME} at ${destination}.`,
-    );
+    const description = {
+      would_install: `would install ${SKILL_NAME} at ${destination}`,
+      would_overwrite: `would overwrite ${SKILL_NAME} at ${destination}`,
+      would_skip: `would skip ${SKILL_NAME} at ${destination}`,
+      would_recover_then_install: `would recover the interrupted transaction, then install ${SKILL_NAME} at ${destination}`,
+      would_recover_then_overwrite: `would recover the interrupted transaction, then overwrite ${SKILL_NAME} at ${destination}`,
+      would_recover_then_skip: `would recover the interrupted transaction, then skip ${SKILL_NAME} at ${destination}`,
+      would_wait_for_install: `would wait for the active installer transaction at ${destination}`,
+      blocked_by_transaction: `is blocked by untrusted installer transaction data at ${destination}`,
+    }[result.outcome];
+    console.log(`Dry run: ${description}.`);
     showStatus(record);
     console.log(
       `Files to write (relative to skill path, including the installation record):\n${plan.write_paths.map((path) => `  ${path}`).join('\n') || '  (none)'}`,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Install the InferenceX public API skill for Codex and Claude Code.",
   "keywords": [
     "agent-skills",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "bin/install.mjs",
+    "bin/install-transaction.mjs",
     "skills/inferencex-api",
     "README.md",
     "LICENSE"

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -27,6 +27,7 @@ const releaseFiles = [
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
   'skills/inferencex-api/references/collectivex.md',
+  'skills/inferencex-api/scripts/cli-contract.mjs',
   'skills/inferencex-api/scripts/response-budget.mjs',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -18,6 +18,7 @@ const releaseFiles = [
   'LICENSE',
   'README.md',
   'bin/install.mjs',
+  'bin/install-transaction.mjs',
   'package.json',
   'skills/inferencex-api/SKILL.md',
   'skills/inferencex-api/references/agentx.md',

--- a/packages/skills/scripts/release.mjs
+++ b/packages/skills/scripts/release.mjs
@@ -21,6 +21,7 @@ const releaseFiles = [
   'package.json',
   'skills/inferencex-api/SKILL.md',
   'skills/inferencex-api/references/agentx.md',
+  'skills/inferencex-api/references/cli-contract.md',
   'skills/inferencex-api/references/powerx.md',
   'skills/inferencex-api/references/public-api-examples.md',
   'skills/inferencex-api/references/provenance.md',

--- a/packages/skills/scripts/verify-release.py
+++ b/packages/skills/scripts/verify-release.py
@@ -79,6 +79,9 @@ POINT_OPERATIONS = (
     ('request-timeline', '/api/v1/request-timeline', 'id'),
     ('trace-histograms', '/api/v1/trace-histograms', 'ids'),
     ('trace-server-metrics', '/api/v1/trace-server-metrics', 'id'))
+DATA_HELPERS = (
+    'export-powerx', 'export-agentx', 'investigate-result', 'compare-tco',
+    'compare-releases', 'compare-collectivex')
 
 
 def now():
@@ -96,6 +99,69 @@ def finite(value):
 def require(condition, message):
     if not condition:
         raise ValueError(message)
+
+
+def structured_errors_required(version):
+    match = re.fullmatch(r'(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?', version)
+    require(match is not None, 'Package version must be semantic')
+    return tuple(map(int, match.groups())) >= (0, 10, 0)
+
+
+def check_powerx_schema(document, version):
+    if structured_errors_required(version):
+        require(set(document) == {'schema_version', 'metadata', 'rows'} and
+                type(document['schema_version']) is int and document['schema_version'] == 1,
+                'PowerX JSON schema version differs')
+
+
+def check_structured_error(error, command, version):
+    require(isinstance(error, subprocess.CalledProcessError) and error.returncode == 2,
+            f'{command} invalid argument must exit 2')
+    require(error.output == '', f'{command} invalid argument wrote to stdout')
+    stderr = error.stderr
+    require(type(stderr) is str and stderr.endswith('\n') and stderr.count('\n') == 1,
+            f'{command} stderr must contain exactly one JSON envelope')
+    try:
+        document = json.loads(stderr)
+    except json.JSONDecodeError as caught:
+        raise ValueError(f'{command} stderr is not one JSON envelope') from caught
+    require(type(document) is dict and
+            set(document) == {'schema_version', 'package', 'package_version', 'command', 'error'} and
+            type(document.get('schema_version')) is int and document['schema_version'] == 1 and
+            document['package'] == PACKAGE and document['package_version'] == version and
+            document['command'] == command,
+            f'{command} structured error identity differs')
+    detail = document['error']
+    require(type(detail) is dict and set(detail) == {'code', 'message'} and
+            detail['code'] == 'INVALID_ARGUMENT' and
+            type(detail['message']) is str and bool(detail['message'].strip()),
+            f'{command} structured error detail differs')
+    return document
+
+
+def check_structured_errors(node, npm, installed, project, environment, archive, version, public,
+                            deadline=None):
+    if not structured_errors_required(version):
+        return []
+    commands = [(name, [node, installed / f'scripts/{name}.mjs']) for name in DATA_HELPERS]
+    spec = f'{PACKAGE}@{version}' if public else str(archive)
+    commands.append(('inferencex-skills', [npm, 'exec', '--yes', '--offline', '--package', spec,
+                                           '--', 'inferencex-skills']))
+    evidence = []
+    for command_name, prefix in commands:
+        command = [*prefix, '--error-format', 'json', '--invalid-argument']
+        label = f'structured-error-{command_name}'
+        try:
+            run(command, project, environment, label, deadline)
+        except subprocess.CalledProcessError as error:
+            envelope = check_structured_error(error, command_name, version)
+        else:
+            raise ValueError(f'{command_name} invalid argument unexpectedly succeeded')
+        evidence.append({'command': [str(part) for part in command], 'exit_code': 2,
+                         'stdout_file': str(project / f'{label}.stdout.log'),
+                         'stderr_file': str(project / f'{label}.stderr.log'),
+                         'envelope': envelope})
+    return evidence
 
 
 def same_url(actual, expected):
@@ -291,6 +357,7 @@ def check_metadata(metadata, source, args, version, isl=None, osl=None):
 
 def check_exports(project, json_source, csv_source, args, version):
     document = json.loads((project / 'powerx.json').read_text())
+    check_powerx_schema(document, version)
     expected = check_metadata(document['metadata'], json_source, args, version)
     require(expected, 'Positive example has no validated observations; choose another documented workload')
     require(document['rows'] == expected, 'JSON observations differ from complete public response')
@@ -1478,6 +1545,9 @@ def main():
                                           args.mode == 'public', report, deadline)
             installed = project / ('.agents' if target == 'codex' else '.claude') / 'skills/inferencex-api'
             check_installed(installed, skill_files, record['version'])
+            structured_errors = check_structured_errors(
+                node, npm, installed, project, env, archive, record['version'],
+                args.mode == 'public', deadline)
             for output_format in ['json', 'csv']:
                 flags = ['--model', args.model, '--isl', str(args.isl), '--osl', str(args.osl), '--format', output_format,
                          '--output', f'powerx.{output_format}', '--evidence-dir', f'powerx-{output_format}-evidence']
@@ -1512,7 +1582,7 @@ def main():
             result['additional_workflows'] = run_additional_workflows(
                 node, installed, project, env, record['version'], deadline)
             check_installed(installed, skill_files, record['version'])
-            result.update(agentx=agentx, agentx_points=points)
+            result.update(agentx=agentx, agentx_points=points, structured_errors=structured_errors)
             result.update(target=target, project=str(project))
             report['targets'].append(result)
         remaining_seconds(deadline, PUBLIC_DEADLINE_SECONDS)

--- a/packages/skills/skills/inferencex-api/SKILL.md
+++ b/packages/skills/skills/inferencex-api/SKILL.md
@@ -63,6 +63,10 @@ read [the CollectiveX cookbook](references/collectivex.md) and use
 identities, preserve units and unmatched coverage, and retain full source responses.
 A run list is bounded discovery; differing attempts and revisions remain context.
 
+For **scheduled exports, machine-readable failures, cancellation, or installation
+recovery**, read [the command cookbook](references/cli-contract.md). Check the exit
+code before parsing output and retain failed attempts separately from complete exports.
+
 ## Query workflow
 
 1. Keep downloaded responses, temporary parsing files and exports inside the

--- a/packages/skills/skills/inferencex-api/SKILL.md
+++ b/packages/skills/skills/inferencex-api/SKILL.md
@@ -74,9 +74,10 @@ code before parsing output and retain failed attempts separately from complete e
    its own file; retain failed captures and count every actual HTTP request,
    including discovery and retries. Decode HTTP compression before parsing JSON
    (`fetch` does this; use `curl --compressed` with curl).
-   Read the current OpenAPI operation before constructing a request. Use its exact
-   parameter names, model enum, response shape, and authentication requirements.
-   Reuse the fetched schema during the task.
+   Before the first live data request, read the current OpenAPI operation, including
+   when using a bundled helper. Use its exact parameter names, model enum, response
+   shape, and authentication requirements. Reuse the fetched schema during the task;
+   offline commands do not require a schema request.
 2. Choose the operation and scope that answer the user's request. Its documented
    parameters and response schema determine how to select and interpret the data;
    different operations can have different date semantics and response shapes.

--- a/packages/skills/skills/inferencex-api/references/cli-contract.md
+++ b/packages/skills/skills/inferencex-api/references/cli-contract.md
@@ -97,7 +97,12 @@ PowerX JSON carries `schema_version: 1` from package 0.10.0; its `metadata` and
 their own schema and domain fields. CSV contracts are unchanged.
 
 Graceful `SIGINT`/`SIGTERM` cancellation aborts active HTTP work and follows the
-helper's existing output rollback. Stdout must finish writing within five seconds; a stalled consumer yields
+helper's existing output rollback. The installer checks cancellation between filesystem
+phases and while waiting for another installer; each synchronous filesystem operation
+finishes before cancellation is observed. Before committed activation, cancellation rolls
+back and exits 130. Once activation is committed, the installer finishes cleanup and reports
+the completed installation instead of reporting cancellation for an already installed version.
+Stdout must finish writing within five seconds; a stalled consumer yields
 `OUTPUT_ERROR`. A consumer may already
 have received part of a failed stdout stream: accept the export only after exit 0. A file export and its evidence manifest remain separate writes; verify both
 before treating an evidence bundle as complete. `SIGKILL` prevents immediate cleanup

--- a/packages/skills/skills/inferencex-api/references/cli-contract.md
+++ b/packages/skills/skills/inferencex-api/references/cli-contract.md
@@ -87,6 +87,8 @@ and fix the reported condition before choosing a fresh attempt.
 Before delivering an export command for a scheduler, run that exact command once
 with a fresh attempt path. Verify directory creation, child exit status and retained
 output files, including when the proposed command calls a wrapper you created.
+If a command was denied or only a different invocation ran, label the delivered
+command as unverified. Equivalent arguments do not prove its shell setup or wrapper ran.
 
 ## Output and cancellation limits
 
@@ -115,6 +117,13 @@ activation. Packaged files replace matching files; unrelated and obsolete files
 are retained. Supported interrupted activation is recovered by the next real
 installation. Keep transaction data intact when inspection reports a live owner,
 foreign metadata or an unsafe path; resolve that reported condition before retrying.
+
+Recovery follows the persisted commit state. Before committed activation, supported
+failure recovery restores the previous installation (or removes an unfinished first
+installation). After committed activation, cleanup failure keeps the new installation;
+a later real install finishes supported cleanup. An install error alone does not
+identify which version is active: inspect the pending state and recover it before
+claiming that the old or new version is installed.
 
 These guarantees cover detected failures and supported process interruption.
 They do not promise durability after power loss, repair arbitrary external edits,

--- a/packages/skills/skills/inferencex-api/references/cli-contract.md
+++ b/packages/skills/skills/inferencex-api/references/cli-contract.md
@@ -1,0 +1,116 @@
+# Command errors and unattended exports
+
+Read this when a scheduler consumes an InferenceX helper, a command fails, or an
+installed skill needs an upgrade. Domain selection, units and interpretation stay
+in the relevant PowerX, AgentX or comparison cookbook.
+
+## Keep success and failure separate
+
+All six data helpers and the installer accept `--error-format json`. This changes
+failure diagnostics, not the successful export format. A failed command writes
+one JSON document to stderr:
+
+```json
+{
+  "schema_version": 1,
+  "package": "@semianalysisai/inferencex-skills",
+  "package_version": "0.10.0",
+  "command": "export-powerx",
+  "error": {
+    "code": "INVALID_ARGUMENT",
+    "message": "--model requires a display model name"
+  }
+}
+```
+
+Branch on the exit code first. Parse stderr as this error envelope only when the
+command fails in JSON error mode. Successful commands may put domain coverage or
+status information on stderr. Read the successful export from its selected
+destination; an empty selection is a successful, scoped result.
+
+| Exit  | Meaning in JSON error mode                          |
+| ----- | --------------------------------------------------- |
+| `0`   | Command completed, including valid empty selections |
+| `2`   | Invalid arguments                                   |
+| `1`   | An operational or unexpected failure                |
+| `130` | Graceful cancellation                               |
+
+| `error.code`       | Meaning                                                             |
+| ------------------ | ------------------------------------------------------------------- |
+| `INVALID_ARGUMENT` | Invalid or missing command input                                    |
+| `HTTP_ERROR`       | The server returned a non-success status; `http_status` is included |
+| `NETWORK_ERROR`    | The HTTP request could not complete                                 |
+| `TIMEOUT`          | A request or HTTP sequence deadline expired                         |
+| `INVALID_RESPONSE` | The response failed decoding, shape or domain validation            |
+| `OUTPUT_ERROR`     | An export, evidence or output-stream write failed                   |
+| `CANCELLED`        | The process handled an interrupt or termination signal              |
+| `INTERNAL_ERROR`   | An unexpected failure outside the classified boundaries             |
+
+Use `error.code` and optional `http_status` for decisions; retain `message` for
+diagnosis. Human-readable wording is not a stable parsing interface. The default
+and `--error-format text` preserve the existing text diagnostics and argument exit
+behavior. The installer's existing `--json` controls its stdout result; explicit
+`--error-format json` takes precedence for failures and emits no legacy stdout
+error object.
+
+For example, run the installed PowerX helper and preserve each result separately:
+
+```python
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+attempt = Path("powerx-attempt-1")
+attempt.mkdir()  # A fresh directory preserves earlier successes and failures.
+command = [
+    "node", ".agents/skills/inferencex-api/scripts/export-powerx.mjs",
+    "--model", "DeepSeek-V4-Pro", "--isl", "8192", "--osl", "1024",
+    "--format", "json", "--output", str(attempt / "powerx.json"),
+    "--evidence-dir", str(attempt / "evidence"), "--error-format", "json",
+]
+result = subprocess.run(command, capture_output=True, text=True, check=False)
+(attempt / "stdout.txt").write_text(result.stdout)
+(attempt / "stderr.txt").write_text(result.stderr)
+(attempt / "exit-code.txt").write_text(f"{result.returncode}\n")
+if result.returncode:
+    failure = json.loads(result.stderr)
+    print(f"{failure['error']['code']}: {failure['error']['message']}", file=sys.stderr)
+    raise SystemExit(result.returncode)
+export = json.loads((attempt / "powerx.json").read_text())
+print(f"Selected observations: {len(export['rows'])}")
+```
+
+Use the `.claude/skills` path for a Claude installation. The helpers do not retry
+HTTP automatically. After an operational failure, inspect the retained evidence
+and fix the reported condition before choosing a fresh attempt.
+
+## Output and cancellation limits
+
+PowerX JSON carries `schema_version: 1` from package 0.10.0; its `metadata` and
+`rows` retain their existing meanings. AgentX and comparison payloads retain
+their own schema and domain fields. CSV contracts are unchanged.
+
+Graceful `SIGINT`/`SIGTERM` cancellation aborts active HTTP work and follows the
+helper's existing output rollback. Stdout must finish writing within five seconds; a stalled consumer yields
+`OUTPUT_ERROR`. A consumer may already
+have received part of a failed stdout stream: accept the export only after exit 0. A file export and its evidence manifest remain separate writes; verify both
+before treating an evidence bundle as complete. `SIGKILL` cannot run cleanup.
+
+## Inspect and recover an installation
+
+Run the pinned installer's `status --json` to inspect the destination and
+`install --force --dry-run --json` to preview the selected package. Both operations
+leave files unchanged and report pending recovery. The invoking installer version
+and the destination's installed version are separate facts. Count planned writes
+from the returned `write_paths` entries.
+
+An upgrade stages a complete merged skill directory and version receipt before
+activation. Packaged files replace matching files; unrelated and obsolete files
+are retained. Supported interrupted activation is recovered by the next real
+installation. Keep transaction data intact when inspection reports a live owner,
+foreign metadata or an unsafe path; resolve that reported condition before retrying.
+
+These guarantees cover detected failures and supported process interruption.
+They do not promise durability after power loss, repair arbitrary external edits,
+or replace a backup of local changes.

--- a/packages/skills/skills/inferencex-api/references/cli-contract.md
+++ b/packages/skills/skills/inferencex-api/references/cli-contract.md
@@ -84,6 +84,9 @@ print(f"Selected observations: {len(export['rows'])}")
 Use the `.claude/skills` path for a Claude installation. The helpers do not retry
 HTTP automatically. After an operational failure, inspect the retained evidence
 and fix the reported condition before choosing a fresh attempt.
+Before delivering an export command for a scheduler, run that exact command once
+with a fresh attempt path. Verify directory creation, child exit status and retained
+output files, including when the proposed command calls a wrapper you created.
 
 ## Output and cancellation limits
 
@@ -95,7 +98,9 @@ Graceful `SIGINT`/`SIGTERM` cancellation aborts active HTTP work and follows the
 helper's existing output rollback. Stdout must finish writing within five seconds; a stalled consumer yields
 `OUTPUT_ERROR`. A consumer may already
 have received part of a failed stdout stream: accept the export only after exit 0. A file export and its evidence manifest remain separate writes; verify both
-before treating an evidence bundle as complete. `SIGKILL` cannot run cleanup.
+before treating an evidence bundle as complete. `SIGKILL` prevents immediate cleanup
+in the killed process. A later installer invocation can still recover supported
+persisted installation transactions after `SIGKILL`, as described below.
 
 ## Inspect and recover an installation
 

--- a/packages/skills/skills/inferencex-api/references/powerx.md
+++ b/packages/skills/skills/inferencex-api/references/powerx.md
@@ -313,6 +313,10 @@ Preserve zero as a number and missing data as blank CSV cells or JSON null/absen
 The exporter replaces non-finite numeric values with null, leaves their CSV cells
 blank, and discloses their count. Strict eligibility does not guarantee every
 metric or optional audit field is populated, or prove a representative energy win.
+Scope claims about missing, null or zero measurements to the named metric fields
+and selected rows you checked. Request metadata, topology and coverage counts are
+separate: a zero count is not a measured zero, and unavailable metric keys do not
+imply that the rest of the JSON contains no null values.
 
 ## Export and provenance
 

--- a/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
@@ -1,0 +1,205 @@
+import process from 'node:process';
+
+const PACKAGE_VERSION = '0.9.0';
+export { PACKAGE_VERSION };
+export const PACKAGE_NAME = '@semianalysisai/inferencex-skills';
+
+const CODES = new Set([
+  'INVALID_ARGUMENT',
+  'HTTP_ERROR',
+  'NETWORK_ERROR',
+  'TIMEOUT',
+  'INVALID_RESPONSE',
+  'OUTPUT_ERROR',
+  'CANCELLED',
+  'INTERNAL_ERROR',
+]);
+
+export class CliError extends Error {
+  constructor(code, message, { cause, httpStatus } = {}) {
+    super(message, { cause });
+    if (!CODES.has(code)) throw new TypeError(`Unknown CLI error code: ${code}`);
+    this.name = 'CliError';
+    this.code = code;
+    if (httpStatus !== undefined) this.httpStatus = httpStatus;
+  }
+}
+
+export function argumentError(message, cause) {
+  return new CliError('INVALID_ARGUMENT', message, { cause });
+}
+
+export function httpError(status, message = `HTTP ${status}`) {
+  return new CliError('HTTP_ERROR', message, { httpStatus: status });
+}
+
+export function responseError(message, cause) {
+  return new CliError('INVALID_RESPONSE', message, { cause });
+}
+
+function cancellation(error, signal) {
+  if (error instanceof CliError) return error;
+  if (signal?.aborted && signal.reason instanceof CliError) return signal.reason;
+  if (signal?.aborted && signal.reason?.name === 'TimeoutError') {
+    return new CliError('TIMEOUT', signal.reason.message, { cause: error });
+  }
+  return null;
+}
+
+export async function requestBoundary(action, signal) {
+  try {
+    return await action();
+  } catch (error) {
+    const cancelled = cancellation(error, signal);
+    if (cancelled) throw cancelled;
+    throw new CliError(
+      error?.name === 'TimeoutError' ? 'TIMEOUT' : 'NETWORK_ERROR',
+      error instanceof Error ? error.message : String(error),
+      { cause: error },
+    );
+  }
+}
+
+export async function responseBoundary(action, signal) {
+  try {
+    signal?.throwIfAborted();
+    return await action();
+  } catch (error) {
+    const cancelled = cancellation(error, signal);
+    if (cancelled) throw cancelled;
+    if (error instanceof CliError) throw error;
+    throw new CliError(
+      error?.name === 'TimeoutError' ? 'TIMEOUT' : 'INVALID_RESPONSE',
+      error instanceof Error ? error.message : String(error),
+      { cause: error },
+    );
+  }
+}
+
+export async function outputBoundary(action, signal) {
+  try {
+    signal?.throwIfAborted();
+    return await action();
+  } catch (error) {
+    const cancelled = cancellation(error, signal);
+    if (cancelled) throw cancelled;
+    if (error instanceof CliError) throw error;
+    throw new CliError('OUTPUT_ERROR', error instanceof Error ? error.message : String(error), {
+      cause: error,
+    });
+  }
+}
+
+export function writeStdout(bytes, { signal, timeoutMs = 5_000 } = {}) {
+  return outputBoundary(
+    () =>
+      new Promise((resolve, reject) => {
+        let settled = false;
+        const finish = (error) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          signal?.removeEventListener('abort', abort);
+          if (error) reject(error);
+          else resolve();
+        };
+        const abort = () => {
+          process.stdout.destroy();
+          finish(signal.reason);
+        };
+        const timer = setTimeout(() => {
+          process.stdout.destroy();
+          finish(new Error(`stdout did not drain within ${timeoutMs}ms`));
+        }, timeoutMs);
+        signal?.addEventListener('abort', abort, { once: true });
+        process.stdout.on('error', () => {});
+        process.stdout.write(bytes, (error) => finish(error));
+      }),
+    signal,
+  );
+}
+
+function requestedErrorFormat(args) {
+  const values = [];
+  for (let index = 0; index < args.length; index++) {
+    const value = args[index];
+    if (value === '--error-format') values.push(args[++index]);
+    else if (value.startsWith('--error-format='))
+      values.push(value.slice('--error-format='.length));
+  }
+  if (values.length !== 1 && values.length > 0) {
+    throw argumentError('Specify --error-format only once; choose json or text.');
+  }
+  const [format = 'text'] = values;
+  if (!['json', 'text'].includes(format)) {
+    throw argumentError('--error-format must be json or text.');
+  }
+  return format;
+}
+
+export function diagnostic(error, command, packageVersion = PACKAGE_VERSION) {
+  return {
+    schema_version: 1,
+    package: PACKAGE_NAME,
+    package_version: packageVersion,
+    command,
+    error: {
+      code: error.code,
+      message: error.message,
+      ...(error.httpStatus === undefined ? {} : { http_status: error.httpStatus }),
+    },
+  };
+}
+
+function normalize(error) {
+  if (error instanceof CliError) return error;
+  if (typeof error?.code === 'string' && error.code.startsWith('ERR_PARSE_ARGS_')) {
+    return argumentError(error.message, error);
+  }
+  return new CliError('INTERNAL_ERROR', error instanceof Error ? error.message : String(error), {
+    cause: error,
+  });
+}
+
+export async function runCli({
+  command,
+  packageVersion = PACKAGE_VERSION,
+  args = process.argv.slice(2),
+  run,
+  textError = (error) => `${command}: ${error.message}`,
+  textUsageExitCode = 1,
+}) {
+  let format = 'text';
+  const controller = new AbortController();
+  const cancel = (signal) => {
+    if (!controller.signal.aborted) {
+      controller.abort(new CliError('CANCELLED', `Cancelled by ${signal}.`));
+    }
+  };
+  const onInterrupt = () => cancel('SIGINT');
+  const onTerminate = () => cancel('SIGTERM');
+  process.once('SIGINT', onInterrupt);
+  process.once('SIGTERM', onTerminate);
+  try {
+    format = requestedErrorFormat(args);
+    await run({ args, signal: controller.signal, errorFormat: format });
+  } catch (error) {
+    const normalized = normalize(error);
+    if (format === 'json') {
+      process.stderr.write(`${JSON.stringify(diagnostic(normalized, command, packageVersion))}\n`);
+    } else {
+      process.stderr.write(`${textError(normalized)}\n`);
+    }
+    process.exitCode =
+      normalized.code === 'CANCELLED'
+        ? 130
+        : format === 'json' && normalized.code === 'INVALID_ARGUMENT'
+          ? 2
+          : normalized.code === 'INVALID_ARGUMENT'
+            ? textUsageExitCode
+            : 1;
+  } finally {
+    process.removeListener('SIGINT', onInterrupt);
+    process.removeListener('SIGTERM', onTerminate);
+  }
+}

--- a/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
@@ -119,7 +119,7 @@ export function writeStdout(bytes, { signal, timeoutMs = 5_000 } = {}) {
   );
 }
 
-function requestedErrorFormat(args) {
+function requestedErrorFormats(args) {
   const values = [];
   for (let index = 0; index < args.length; index++) {
     const value = args[index];
@@ -127,14 +127,7 @@ function requestedErrorFormat(args) {
     else if (value.startsWith('--error-format='))
       values.push(value.slice('--error-format='.length));
   }
-  if (values.length !== 1 && values.length > 0) {
-    throw argumentError('Specify --error-format only once; choose json or text.');
-  }
-  const [format = 'text'] = values;
-  if (!['json', 'text'].includes(format)) {
-    throw argumentError('--error-format must be json or text.');
-  }
-  return format;
+  return values;
 }
 
 export function diagnostic(error, command, packageVersion = PACKAGE_VERSION) {
@@ -181,7 +174,22 @@ export async function runCli({
   process.once('SIGINT', onInterrupt);
   process.once('SIGTERM', onTerminate);
   try {
-    format = requestedErrorFormat(args);
+    const formats = requestedErrorFormats(args);
+    // Retain an explicit JSON request even when format validation itself fails.
+    if (
+      args.some(
+        (arg, index) =>
+          arg === '--error-format=json' || (arg === '--error-format' && args[index + 1] === 'json'),
+      )
+    ) {
+      format = 'json';
+    }
+    if (formats.length > 1) {
+      throw argumentError('Specify --error-format only once; choose json or text.');
+    }
+    if (formats.length === 1 && !['json', 'text'].includes(formats[0] ?? 'text')) {
+      throw argumentError('--error-format must be json or text.');
+    }
     await run({ args, signal: controller.signal, errorFormat: format });
   } catch (error) {
     const normalized = normalize(error);

--- a/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/cli-contract.mjs
@@ -1,6 +1,6 @@
 import process from 'node:process';
 
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 export { PACKAGE_VERSION };
 export const PACKAGE_NAME = '@semianalysisai/inferencex-skills';
 

--- a/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
@@ -15,7 +15,7 @@ import {
 } from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const ORIGIN = 'https://inferencex.semianalysis.com';
 const VERSION = 1;
 const BYTE_BUDGET = 32 * 1024 * 1024;

--- a/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
@@ -380,14 +380,19 @@ async function main(args, signal) {
     const outputPath = values.output === undefined ? null : resolve(values.output);
     if (outputPath !== null) {
       if (
-        await lstat(outputPath).catch((error) => {
-          if (error.code === 'ENOENT') return null;
-          throw error;
-        })
+        await outputBoundary(
+          () =>
+            lstat(outputPath).catch((error) => {
+              if (error.code === 'ENOENT') return null;
+              if (error.code === 'ENOTDIR') throw argumentError(error.message, error);
+              throw error;
+            }),
+          signal,
+        )
       ) {
         throw new Error('--output already exists; choose a new file');
       }
-      const parent = await stat(dirname(outputPath));
+      const parent = await outputBoundary(() => stat(dirname(outputPath)), signal);
       if (!parent.isDirectory()) throw new Error('--output parent must be a directory');
     }
     argumentsValidated = true;

--- a/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-collectivex.mjs
@@ -3,8 +3,16 @@
 import { createHash } from 'node:crypto';
 import { link, lstat, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
-import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  runCli,
+  writeStdout,
+} from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
 const PACKAGE_VERSION = '0.9.0';
@@ -26,6 +34,7 @@ At most four GETs: OpenAPI, optional run list, and two run details. No retries.
 Responses share a 32 MiB decoded-body budget; each request times out after 30s.
 --output creates a new file atomically and refuses to replace an existing path.
 Without --output, print JSON after all reads and validation succeed.
+--error-format <mode> selects text (default) or json failure diagnostics.
 --version prints the installed package version offline. --help makes no requests. See references/collectivex.md for matching and units.
 `;
 
@@ -319,213 +328,239 @@ function compare(left, right) {
   });
 }
 
-async function outputJson(output, path) {
+async function outputJson(output, path, signal) {
   const bytes = `${JSON.stringify(output, null, 2)}\n`;
   if (path === null) {
-    await new Promise((resolveWrite, reject) => {
-      process.stdout.once('error', reject);
-      process.stdout.write(bytes, (error) => (error ? reject(error) : resolveWrite()));
-    });
+    await writeStdout(bytes, { signal });
     return;
   }
-  const staging = await mkdtemp(join(dirname(path), '.collectivex-'));
+  await outputBoundary(async () => {
+    const staging = await mkdtemp(join(dirname(path), '.collectivex-'));
+    try {
+      const file = join(staging, 'export.json');
+      await writeFile(file, bytes, { flag: 'wx' });
+      signal.throwIfAborted();
+      await link(file, path); // Atomic publication; a racing file or symlink is never replaced.
+    } finally {
+      await rm(staging, { recursive: true, force: true });
+    }
+  }, signal);
+}
+
+async function main(args, signal) {
+  let argumentsValidated = false;
   try {
-    const file = join(staging, 'export.json');
-    await writeFile(file, bytes, { flag: 'wx' });
-    await link(file, path); // Atomic publication; a racing file or symlink is never replaced.
-  } finally {
-    await rm(staging, { recursive: true, force: true });
-  }
-}
-
-async function main() {
-  const { values } = parseArgs({
-    options: {
-      left: { type: 'string' },
-      right: { type: 'string' },
-      output: { type: 'string' },
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-    strict: true,
-    allowPositionals: false,
-  });
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) {
-    process.stdout.write(HELP);
-    return;
-  }
-  const explicit = values.left !== undefined || values.right !== undefined;
-  if (explicit && (!id(values.left) || !id(values.right) || values.left === values.right)) {
-    throw new Error('--left and --right require two distinct positive decimal run-ID strings');
-  }
-  if (values.output !== undefined && !text(values.output))
-    throw new Error('--output needs a new file path');
-  const outputPath = values.output === undefined ? null : resolve(values.output);
-  if (outputPath !== null) {
-    if (
-      await lstat(outputPath).catch((error) => {
-        if (error.code === 'ENOENT') return null;
-        throw error;
-      })
-    ) {
-      throw new Error('--output already exists; choose a new file');
-    }
-    const parent = await stat(dirname(outputPath));
-    if (!parent.isDirectory()) throw new Error('--output parent must be a directory');
-  }
-
-  const responses = [];
-  let remaining = BYTE_BUDGET;
-  async function read(path) {
-    const query_url = new URL(path, ORIGIN).href;
-    const response = await fetch(query_url, {
-      method: 'GET',
-      redirect: 'error',
-      signal: AbortSignal.timeout(30_000),
+    const { values } = parseArgs({
+      args,
+      options: {
+        left: { type: 'string' },
+        right: { type: 'string' },
+        output: { type: 'string' },
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
+      },
+      strict: true,
+      allowPositionals: false,
     });
-    if (response.redirected || (response.url && response.url !== query_url)) {
-      throw new Error('Unexpected CollectiveX response URL');
+    if (values.version) {
+      await writeStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
     }
-    const chunks = [];
-    for await (const chunk of response.body ?? []) {
-      remaining -= chunk.byteLength;
-      if (remaining < 0) throw new Error('CollectiveX reads exceeded the 32 MiB response budget');
-      chunks.push(chunk);
+    if (values.help) {
+      await writeStdout(HELP, { signal });
+      return;
     }
-    const bytes = Buffer.concat(chunks);
-    const body_text = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
-    if (!response.ok) throw new Error(`HTTP ${response.status}: ${query_url}`);
-    const body = JSON.parse(body_text);
-    const index = responses.length;
-    responses.push({
-      query_url,
-      retrieved_at: new Date().toISOString(),
-      http_status: response.status,
-      decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
-      body_text,
-    });
-    return { body, index };
-  }
-  const { body: schema } = await read('/api/openapi.json');
-  for (const path of ['/api/v1/collectivex/runs', '/api/v1/collectivex/runs/{runId}']) {
-    const operation = schema.paths?.[path]?.get;
-    if (
-      !operation?.parameters
-        ?.find((parameter) => parameter.name === 'version')
-        ?.schema?.enum?.includes(VERSION) ||
-      operation.parameters.some(
-        (parameter) => parameter.required && !['version', 'runId'].includes(parameter.name),
-      )
-    ) {
-      throw new Error(
-        'Inspect the current CollectiveX OpenAPI operations before using this version-1 helper',
-      );
+    const explicit = values.left !== undefined || values.right !== undefined;
+    if (explicit && (!id(values.left) || !id(values.right) || values.left === values.right)) {
+      throw new Error('--left and --right require two distinct positive decimal run-ID strings');
     }
-  }
-  let runIds = explicit ? [values.left, values.right] : [];
-  let discovery = null;
-  if (!explicit) {
-    const { body: list, index } = await read('/api/v1/collectivex/runs?version=1');
-    if (
-      !object(list) ||
-      list.version !== VERSION ||
-      typeof list.discovery_complete !== 'boolean' ||
-      !Array.isArray(list.runs) ||
-      list.runs.some((run) => !runIdentity(run) || !count(run.measured_cases)) ||
-      new Set(list.runs.map((run) => run.run_id)).size !== list.runs.length
-    ) {
-      throw new Error('Invalid CollectiveX run list; discovery coverage is unknown');
-    }
-    runIds = list.runs
-      .filter((run) => run.measured_cases > 0)
-      .toSorted((a, b) => (BigInt(a.run_id) < BigInt(b.run_id) ? 1 : -1))
-      .slice(0, 2)
-      .map((run) => run.run_id)
-      .toReversed();
-    discovery = {
-      response_index: index,
-      returned_runs: list.runs.length,
-      discovery_complete: list.discovery_complete,
-      history_complete: false,
-    };
-  }
-  const datasets = [];
-  if (runIds.length === 2) {
-    for (const runId of runIds) {
-      const response = await read(`/api/v1/collectivex/runs/${runId}?version=1`);
-      const data = response.body;
+    if (values.output !== undefined && !text(values.output))
+      throw new Error('--output needs a new file path');
+    const outputPath = values.output === undefined ? null : resolve(values.output);
+    if (outputPath !== null) {
       if (
-        !object(data) ||
-        data.version !== VERSION ||
-        !runIdentity(data.run) ||
-        data.run.run_id !== runId ||
-        !text(data.run.source_sha) ||
-        !Array.isArray(data.coverage) ||
-        !Array.isArray(data.series) ||
-        (data.kv !== undefined && !Array.isArray(data.kv))
+        await lstat(outputPath).catch((error) => {
+          if (error.code === 'ENOENT') return null;
+          throw error;
+        })
       ) {
-        throw new Error('Invalid or mismatched CollectiveX run dataset');
+        throw new Error('--output already exists; choose a new file');
       }
-      datasets.push(response);
+      const parent = await stat(dirname(outputPath));
+      if (!parent.isDirectory()) throw new Error('--output parent must be a directory');
     }
+    argumentsValidated = true;
+
+    await responseBoundary(async () => {
+      const responses = [];
+      let remaining = BYTE_BUDGET;
+      async function read(path) {
+        const query_url = new URL(path, ORIGIN).href;
+        const requestSignal = AbortSignal.any([AbortSignal.timeout(30_000), signal]);
+        const response = await requestBoundary(
+          () =>
+            fetch(query_url, {
+              method: 'GET',
+              redirect: 'error',
+              signal: requestSignal,
+            }),
+          requestSignal,
+        );
+        if (response.redirected || (response.url && response.url !== query_url)) {
+          throw new Error('Unexpected CollectiveX response URL');
+        }
+        if (!response.ok) throw httpError(response.status, `HTTP ${response.status}: ${query_url}`);
+        const { bytes, body_text } = await responseBoundary(async () => {
+          const chunks = [];
+          for await (const chunk of response.body ?? []) {
+            remaining -= chunk.byteLength;
+            if (remaining < 0)
+              throw new Error('CollectiveX reads exceeded the 32 MiB response budget');
+            chunks.push(chunk);
+          }
+          const responseBytes = Buffer.concat(chunks);
+          const responseText = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+            responseBytes,
+          );
+          return { bytes: responseBytes, body_text: responseText };
+        }, requestSignal);
+        const body = JSON.parse(body_text);
+        const index = responses.length;
+        responses.push({
+          query_url,
+          retrieved_at: new Date().toISOString(),
+          http_status: response.status,
+          decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
+          body_text,
+        });
+        return { body, index };
+      }
+      const { body: schema } = await read('/api/openapi.json');
+      for (const path of ['/api/v1/collectivex/runs', '/api/v1/collectivex/runs/{runId}']) {
+        const operation = schema.paths?.[path]?.get;
+        if (
+          !operation?.parameters
+            ?.find((parameter) => parameter.name === 'version')
+            ?.schema?.enum?.includes(VERSION) ||
+          operation.parameters.some(
+            (parameter) => parameter.required && !['version', 'runId'].includes(parameter.name),
+          )
+        ) {
+          throw new Error(
+            'Inspect the current CollectiveX OpenAPI operations before using this version-1 helper',
+          );
+        }
+      }
+      let runIds = explicit ? [values.left, values.right] : [];
+      let discovery = null;
+      if (!explicit) {
+        const { body: list, index } = await read('/api/v1/collectivex/runs?version=1');
+        if (
+          !object(list) ||
+          list.version !== VERSION ||
+          typeof list.discovery_complete !== 'boolean' ||
+          !Array.isArray(list.runs) ||
+          list.runs.some((run) => !runIdentity(run) || !count(run.measured_cases)) ||
+          new Set(list.runs.map((run) => run.run_id)).size !== list.runs.length
+        ) {
+          throw new Error('Invalid CollectiveX run list; discovery coverage is unknown');
+        }
+        runIds = list.runs
+          .filter((run) => run.measured_cases > 0)
+          .toSorted((a, b) => (BigInt(a.run_id) < BigInt(b.run_id) ? 1 : -1))
+          .slice(0, 2)
+          .map((run) => run.run_id)
+          .toReversed();
+        discovery = {
+          response_index: index,
+          returned_runs: list.runs.length,
+          discovery_complete: list.discovery_complete,
+          history_complete: false,
+        };
+      }
+      const datasets = [];
+      if (runIds.length === 2) {
+        for (const runId of runIds) {
+          const response = await read(`/api/v1/collectivex/runs/${runId}?version=1`);
+          const data = response.body;
+          if (
+            !object(data) ||
+            data.version !== VERSION ||
+            !runIdentity(data.run) ||
+            data.run.run_id !== runId ||
+            !text(data.run.source_sha) ||
+            !Array.isArray(data.coverage) ||
+            !Array.isArray(data.series) ||
+            (data.kv !== undefined && !Array.isArray(data.kv))
+          ) {
+            throw new Error('Invalid or mismatched CollectiveX run dataset');
+          }
+          datasets.push(response);
+        }
+      }
+      const comparisons =
+        datasets.length === 2
+          ? compare(
+              [
+                ...epRows(datasets[0].body, datasets[0].index),
+                ...kvRows(datasets[0].body, datasets[0].index),
+              ],
+              [
+                ...epRows(datasets[1].body, datasets[1].index),
+                ...kvRows(datasets[1].body, datasets[1].index),
+              ],
+            )
+          : [];
+      const summary = Object.fromEntries(
+        ['matched', 'only_left', 'only_right', 'ambiguous', 'incomparable'].map((status) => [
+          status,
+          comparisons.filter((row) => row.status === status).length,
+        ]),
+      );
+      await outputJson(
+        {
+          schema_version: 1,
+          package_version: PACKAGE_VERSION,
+          selection: {
+            mode: explicit ? 'explicit_run_ids' : 'newest_two_measured_from_one_list',
+            run_ids: runIds,
+          },
+          outcome:
+            datasets.length < 2
+              ? 'fewer_than_two_measured_runs'
+              : summary.matched
+                ? 'compared'
+                : 'no_comparable_rows',
+          discovery,
+          comparison_scope: {
+            contract_version: VERSION,
+            basis: 'exact_public_identity',
+            source_sha_equal:
+              datasets.length === 2
+                ? datasets[0].body.run.source_sha === datasets[1].body.run.source_sha
+                : null,
+          },
+          runs: datasets.map(({ body, index }) => ({ run: body.run, response_index: index })),
+          summary,
+          comparisons,
+          responses,
+          observation_context: 'Existing observations were read; no new benchmark was run.',
+        },
+        outputPath,
+        signal,
+      );
+    }, signal);
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
+    }
+    throw error;
   }
-  const comparisons =
-    datasets.length === 2
-      ? compare(
-          [
-            ...epRows(datasets[0].body, datasets[0].index),
-            ...kvRows(datasets[0].body, datasets[0].index),
-          ],
-          [
-            ...epRows(datasets[1].body, datasets[1].index),
-            ...kvRows(datasets[1].body, datasets[1].index),
-          ],
-        )
-      : [];
-  const summary = Object.fromEntries(
-    ['matched', 'only_left', 'only_right', 'ambiguous', 'incomparable'].map((status) => [
-      status,
-      comparisons.filter((row) => row.status === status).length,
-    ]),
-  );
-  await outputJson(
-    {
-      schema_version: 1,
-      package_version: PACKAGE_VERSION,
-      selection: {
-        mode: explicit ? 'explicit_run_ids' : 'newest_two_measured_from_one_list',
-        run_ids: runIds,
-      },
-      outcome:
-        datasets.length < 2
-          ? 'fewer_than_two_measured_runs'
-          : summary.matched
-            ? 'compared'
-            : 'no_comparable_rows',
-      discovery,
-      comparison_scope: {
-        contract_version: VERSION,
-        basis: 'exact_public_identity',
-        source_sha_equal:
-          datasets.length === 2
-            ? datasets[0].body.run.source_sha === datasets[1].body.run.source_sha
-            : null,
-      },
-      runs: datasets.map(({ body, index }) => ({ run: body.run, response_index: index })),
-      summary,
-      comparisons,
-      responses,
-      observation_context: 'Existing observations were read; no new benchmark was run.',
-    },
-    outputPath,
-  );
 }
 
-main().catch((error) => {
-  process.stderr.write(`compare-collectivex: ${error.message}\n`);
-  process.exitCode = 1;
+await runCli({
+  command: 'compare-collectivex',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => main(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
@@ -3,8 +3,16 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { link, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
-import process from 'node:process';
 import { isDeepStrictEqual, parseArgs } from 'node:util';
+import {
+  argumentError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  runCli,
+  writeStdout,
+} from './cli-contract.mjs';
 
 const PACKAGE_VERSION = '0.9.0';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
@@ -26,6 +34,7 @@ Each side requires an exact image, an exact producer run URL, or both:
   --before-image <text> / --after-image <text>   Match the returned image string exactly
   --raw-model <key>       Select one raw model within the requested display bucket
   --output <new-file>     Exclusively create a JSON file; default stdout
+  --error-format <mode>   Failure diagnostics: text (default) or json
   --version          Show the installed package version offline
   --help                 Show help offline
 
@@ -219,303 +228,332 @@ function compareMetric(before, after, name) {
   };
 }
 
-async function saveOutput(path, output) {
+async function saveOutput(path, output, signal) {
   if (path === undefined) {
-    process.stdout.on('error', () => {});
-    await new Promise((done, reject) => {
-      process.stdout.write(output, (error) => (error ? reject(error) : done()));
-    });
+    await writeStdout(output, { signal });
     return;
   }
   const target = resolve(path);
   const temporary = join(dirname(target), `.${basename(target)}.${randomUUID()}.tmp`);
+  await outputBoundary(async () => {
+    try {
+      await writeFile(temporary, output, { flag: 'wx' });
+      signal.throwIfAborted();
+      // Linking a complete sibling file installs it atomically and refuses existing targets/symlinks.
+      await link(temporary, target);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  }, signal);
+}
+
+async function run(args, signal) {
+  let argumentsValidated = false;
   try {
-    await writeFile(temporary, output, { flag: 'wx' });
-    // Linking a complete sibling file installs it atomically and refuses existing targets/symlinks.
-    await link(temporary, target);
-  } finally {
-    await rm(temporary, { force: true });
-  }
-}
-
-async function run() {
-  const { values, tokens } = parseArgs({
-    tokens: true,
-    options: {
-      ...Object.fromEntries(
-        [
-          'model',
-          'hardware',
-          'framework',
-          'isl',
-          'osl',
-          'metric',
-          'raw-model',
-          'before-date',
-          'after-date',
-          'before-image',
-          'after-image',
-          'before-run-url',
-          'after-run-url',
-          'output',
-        ].map((name) => [name, { type: 'string' }]),
-      ),
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-    allowPositionals: false,
-    strict: true,
-  });
-  const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
-  if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) {
-    await saveOutput(undefined, HELP);
-    return;
-  }
-  for (const [key, value] of Object.entries(values)) {
-    if (typeof value === 'string' && !value.trim())
-      throw new Error(`--${key} requires a nonempty value`);
-  }
-  for (const key of ['model', 'hardware', 'metric']) {
-    if (!values[key]) throw new Error(`--${key} is required`);
-  }
-  if (!PERFORMANCE_METRIC.test(values.metric)) {
-    throw new Error(
-      'Choose a metric retained by benchmark history (see --help); use the PowerX cookbook for validated power and energy',
-    );
-  }
-  if (!['vllm', 'sglang'].includes(values.framework))
-    throw new Error('--framework must be vllm or sglang');
-  for (const key of ['isl', 'osl']) {
-    if (
-      !/^\d+$/u.test(values[key]) ||
-      !Number.isSafeInteger(Number(values[key])) ||
-      Number(values[key]) <= 0
-    )
-      throw new Error(`--${key} requires a positive integer`);
-  }
-  for (const side of ['before', 'after']) {
-    if (!validDate(values[`${side}-date`]))
-      throw new Error(`--${side}-date requires a valid YYYY-MM-DD date`);
-    if (values[`${side}-image`] === undefined && values[`${side}-run-url`] === undefined)
-      throw new Error(`Provide --${side}-image or --${side}-run-url`);
-    if (values[`${side}-run-url`] !== undefined && !runUrl(values[`${side}-run-url`]))
-      throw new Error(`--${side}-run-url requires an exact GitHub Actions run URL`);
-  }
-  if (values['before-date'] > values['after-date'])
-    throw new Error('--before-date must not be after --after-date');
-  const url = new URL('https://inferencex.semianalysis.com/api/v1/benchmarks/history');
-  for (const name of ['model', 'isl', 'osl']) url.searchParams.set(name, values[name]);
-  const response = await fetch(url, { signal: AbortSignal.timeout(30_000), redirect: 'error' });
-  if (response.redirected || (response.url && response.url !== url.href))
-    throw new Error('Unexpected history response URL');
-  if (!response.ok) throw new Error(`HTTP ${response.status}: ${url.href}`);
-  const chunks = [];
-  let received = 0;
-  for await (const chunk of response.body ?? []) {
-    received += chunk.byteLength;
-    if (received > RESPONSE_BYTE_BUDGET)
-      throw new Error('Exceeded the 16 MiB response byte budget');
-    chunks.push(chunk);
-  }
-  const bytes = Buffer.concat(chunks);
-  const body = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
-  const evidence = [
-    {
-      operation: 'benchmark-history',
-      url: url.href,
-      http_status: response.status,
-      retrieved_at: new Date().toISOString(),
-      body_utf8: body,
-      decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
-      checksum_covers: 'exact decoded UTF-8 response body',
-    },
-  ];
-  const rows = JSON.parse(body.replace(/^\uFEFF/u, ''), (_key, value) => {
-    if (typeof value === 'number' && !Number.isFinite(value))
-      throw new Error('Unexpected benchmark response: non-finite number');
-    return value;
-  });
-  if (
-    !Array.isArray(rows) ||
-    rows.some(
-      (row) =>
-        !benchmarkRow(row) ||
-        (Object.hasOwn(row.metrics, values.metric) &&
-          row.metrics[values.metric] !== null &&
-          !Number.isFinite(row.metrics[values.metric])),
-    )
-  ) {
-    throw new Error(
-      'Unexpected benchmark response: invalid identity, configuration, date, or metric',
-    );
-  }
-  const originals = new Map();
-  for (const row of rows) {
-    const key = String(row.id);
-    const original = originalObservation(row);
-    if (originals.has(key) && !isDeepStrictEqual(originals.get(key), original))
-      throw new Error(`Conflicting observation for result ID ${key}`);
-    originals.set(key, original);
-  }
-  const scoped = rows.filter(
-    (row) =>
-      row.hardware === values.hardware &&
-      row.framework === values.framework &&
-      row.benchmark_type === 'single_turn' &&
-      row.isl === Number(values.isl) &&
-      row.osl === Number(values.osl) &&
-      (values['raw-model'] === undefined || row.model === values['raw-model']),
-  );
-  const selection = {};
-  const unique = {};
-  for (const side of ['before', 'after']) {
-    const selected = [];
-    const excluded = [];
-    for (const row of scoped.filter((candidate) => candidate.date === values[`${side}-date`])) {
-      const reasons = [];
-      if (values[`${side}-image`] !== undefined && row.image !== values[`${side}-image`])
-        reasons.push(row.image === null ? 'missing_image_identity' : 'image_mismatch');
-      if (values[`${side}-run-url`] !== undefined && row.run_url !== values[`${side}-run-url`])
-        reasons.push(row.run_url === null ? 'missing_run_identity' : 'run_url_mismatch');
-      if (reasons.length > 0) excluded.push({ row, reasons });
-      else selected.push(row);
-    }
-    unique[side] = [...new Map(selected.map((row) => [String(row.id), row])).values()];
-    selection[side] = {
-      rows: selected,
-      excluded,
-      unique_observations: unique[side].length,
-      snapshot_reuses: selected.length - unique[side].length,
-    };
-  }
-  const groups = Object.fromEntries(
-    ['before', 'after'].map((side) => [
-      side,
-      Map.groupBy(unique[side], (row) =>
-        JSON.stringify([
-          ...CONFIG_FIELDS.map((key) => row[key]),
-          ...CONFIG_METRICS.map((key) => [Object.hasOwn(row.metrics, key), row.metrics[key]]),
-        ]),
-      ),
-    ]),
-  );
-  const comparisons = [];
-  const unmatched = { before: [], after: [] };
-  for (const configKey of new Set([...groups.before.keys(), ...groups.after.keys()])) {
-    const before = groups.before.get(configKey) ?? [];
-    const after = groups.after.get(configKey) ?? [];
-    const reason =
-      before.length === 0 || after.length === 0
-        ? 'no_matching_configuration'
-        : before.length !== 1 || after.length !== 1
-          ? 'ambiguous_configuration'
-          : String(before[0].id) === String(after[0].id)
-            ? 'reused_observation'
-            : null;
-    if (reason) {
-      for (const [side, records] of [
-        ['before', before],
-        ['after', after],
-      ]) {
-        unmatched[side].push(...records.map((row) => ({ id: row.id, reason })));
-      }
-      continue;
-    }
-    const first = before[0];
-    const second = after[0];
-    const fingerprintMatch =
-      first.recipe_fingerprint && second.recipe_fingerprint
-        ? first.recipe_fingerprint === second.recipe_fingerprint
-        : null;
-    const unknownFields = CONFIG_METRICS.filter(
-      (key) => first.metrics[key] === null || first.metrics[key] === undefined,
-    ).map((key) => `metrics.${key}`);
-    const confounders = [
-      fingerprintMatch === false
-        ? 'recipe_fingerprint_changed_includes_image_and_unexposed_config'
-        : fingerprintMatch === null
-          ? 'recipe_fingerprint_unavailable'
-          : 'recipe_contents_not_independently_verified',
-    ];
-    if (first.image === null || second.image === null)
-      confounders.push('image_identity_unavailable');
-    if (first.run_url === null || second.run_url === null)
-      confounders.push('producer_run_identity_unavailable');
-    if (unknownFields.length > 0) confounders.push('optional_configuration_fields_unavailable');
-    comparisons.push({
-      before_id: first.id,
-      after_id: second.id,
-      configuration: Object.fromEntries(CONFIG_FIELDS.map((name) => [name, first[name]])),
-      configuration_metrics: Object.fromEntries(
-        CONFIG_METRICS.filter((key) => Object.hasOwn(first.metrics, key)).map((key) => [
-          key,
-          first.metrics[key],
-        ]),
-      ),
-      configuration_verification: 'public_fields_only',
-      configuration_completeness:
-        unknownFields.length > 0 ? 'incomplete_optional_fields' : 'known_fields_present',
-      configuration_unknown_fields: unknownFields,
-      producer: {
-        before: { image: first.image, run_url: first.run_url },
-        after: { image: second.image, run_url: second.run_url },
+    const { values, tokens } = parseArgs({
+      args,
+      tokens: true,
+      options: {
+        ...Object.fromEntries(
+          [
+            'model',
+            'hardware',
+            'framework',
+            'isl',
+            'osl',
+            'metric',
+            'raw-model',
+            'before-date',
+            'after-date',
+            'before-image',
+            'after-image',
+            'before-run-url',
+            'after-run-url',
+            'output',
+          ].map((name) => [name, { type: 'string' }]),
+        ),
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
       },
-      recipe_fingerprint_match: fingerprintMatch,
-      full_recipe_verified: false,
-      confounders,
-      metric: compareMetric(first, second, values.metric),
+      allowPositionals: false,
+      strict: true,
     });
-  }
-  const comparableValues = comparisons.filter(
-    ({ metric }) => Number.isFinite(metric.before) && Number.isFinite(metric.after),
-  ).length;
-  const output = `${JSON.stringify(
-    {
-      schema_version: 1,
-      metadata: {
-        package_version: PACKAGE_VERSION,
-        query_url: url.href,
-        retrieved_at: evidence[0].retrieved_at,
-        requested: values,
-        ran_new_benchmark: false,
-        returned_rows: rows.length,
-        outside_requested_scope: rows.length - scoped.length,
-        outside_selected_dates: scoped.filter(
-          (row) => ![values['before-date'], values['after-date']].includes(row.date),
-        ).length,
-        date_field: 'date',
-        metric_coverage: {
-          comparable_values: comparableValues,
-          missing_values: comparisons.length - comparableValues,
+    const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
+    if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
+    if (values.version) {
+      await writeStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
+    }
+    if (values.help) {
+      await saveOutput(undefined, HELP, signal);
+      return;
+    }
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value === 'string' && !value.trim())
+        throw new Error(`--${key} requires a nonempty value`);
+    }
+    for (const key of ['model', 'hardware', 'metric']) {
+      if (!values[key]) throw new Error(`--${key} is required`);
+    }
+    if (!PERFORMANCE_METRIC.test(values.metric)) {
+      throw new Error(
+        'Choose a metric retained by benchmark history (see --help); use the PowerX cookbook for validated power and energy',
+      );
+    }
+    if (!['vllm', 'sglang'].includes(values.framework))
+      throw new Error('--framework must be vllm or sglang');
+    for (const key of ['isl', 'osl']) {
+      if (
+        !/^\d+$/u.test(values[key]) ||
+        !Number.isSafeInteger(Number(values[key])) ||
+        Number(values[key]) <= 0
+      )
+        throw new Error(`--${key} requires a positive integer`);
+    }
+    for (const side of ['before', 'after']) {
+      if (!validDate(values[`${side}-date`]))
+        throw new Error(`--${side}-date requires a valid YYYY-MM-DD date`);
+      if (values[`${side}-image`] === undefined && values[`${side}-run-url`] === undefined)
+        throw new Error(`Provide --${side}-image or --${side}-run-url`);
+      if (values[`${side}-run-url`] !== undefined && !runUrl(values[`${side}-run-url`]))
+        throw new Error(`--${side}-run-url requires an exact GitHub Actions run URL`);
+    }
+    if (values['before-date'] > values['after-date'])
+      throw new Error('--before-date must not be after --after-date');
+    argumentsValidated = true;
+    const requestSignal = AbortSignal.any([AbortSignal.timeout(30_000), signal]);
+    await responseBoundary(async () => {
+      const url = new URL('https://inferencex.semianalysis.com/api/v1/benchmarks/history');
+      for (const name of ['model', 'isl', 'osl']) url.searchParams.set(name, values[name]);
+      const response = await requestBoundary(
+        () =>
+          fetch(url, {
+            signal: requestSignal,
+            redirect: 'error',
+          }),
+        requestSignal,
+      );
+      if (response.redirected || (response.url && response.url !== url.href))
+        throw new Error('Unexpected history response URL');
+      if (!response.ok) throw httpError(response.status, `HTTP ${response.status}: ${url.href}`);
+      const { bytes, body } = await responseBoundary(async () => {
+        const chunks = [];
+        let received = 0;
+        for await (const chunk of response.body ?? []) {
+          received += chunk.byteLength;
+          if (received > RESPONSE_BYTE_BUDGET)
+            throw new Error('Exceeded the 16 MiB response byte budget');
+          chunks.push(chunk);
+        }
+        const responseBytes = Buffer.concat(chunks);
+        const responseBody = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+          responseBytes,
+        );
+        return { bytes: responseBytes, body: responseBody };
+      }, requestSignal);
+      const evidence = [
+        {
+          operation: 'benchmark-history',
+          url: url.href,
+          http_status: response.status,
+          retrieved_at: new Date().toISOString(),
+          body_utf8: body,
+          decoded_body_sha256: createHash('sha256').update(bytes).digest('hex'),
+          checksum_covers: 'exact decoded UTF-8 response body',
         },
-        release_mapping: 'unknown',
-        causal_attribution: 'not_established',
-        statistical_verdict: 'not_established',
-      },
-      outcome: comparisons.length > 0 ? 'observed_comparisons' : 'no_comparable_pairs',
-      limitations: [
-        'Descriptive existing observations only; no causal or statistical regression verdict.',
-        'Dates select original observations; history contains latest attempts and carried curve snapshots, not every historical attempt.',
-        'Matching covers declared public configuration fields only; unavailable fields and recipe changes remain confounders.',
-        'Image strings and run URLs do not independently establish immutable images or framework release versions.',
-      ],
-      selection,
-      comparisons,
-      unmatched,
-      evidence,
-    },
-    null,
-    2,
-  )}\n`;
-  await saveOutput(values.output, output);
+      ];
+      const rows = JSON.parse(body.replace(/^\uFEFF/u, ''), (_key, value) => {
+        if (typeof value === 'number' && !Number.isFinite(value))
+          throw new Error('Unexpected benchmark response: non-finite number');
+        return value;
+      });
+      if (
+        !Array.isArray(rows) ||
+        rows.some(
+          (row) =>
+            !benchmarkRow(row) ||
+            (Object.hasOwn(row.metrics, values.metric) &&
+              row.metrics[values.metric] !== null &&
+              !Number.isFinite(row.metrics[values.metric])),
+        )
+      ) {
+        throw new Error(
+          'Unexpected benchmark response: invalid identity, configuration, date, or metric',
+        );
+      }
+      const originals = new Map();
+      for (const row of rows) {
+        const key = String(row.id);
+        const original = originalObservation(row);
+        if (originals.has(key) && !isDeepStrictEqual(originals.get(key), original))
+          throw new Error(`Conflicting observation for result ID ${key}`);
+        originals.set(key, original);
+      }
+      const scoped = rows.filter(
+        (row) =>
+          row.hardware === values.hardware &&
+          row.framework === values.framework &&
+          row.benchmark_type === 'single_turn' &&
+          row.isl === Number(values.isl) &&
+          row.osl === Number(values.osl) &&
+          (values['raw-model'] === undefined || row.model === values['raw-model']),
+      );
+      const selection = {};
+      const unique = {};
+      for (const side of ['before', 'after']) {
+        const selected = [];
+        const excluded = [];
+        for (const row of scoped.filter((candidate) => candidate.date === values[`${side}-date`])) {
+          const reasons = [];
+          if (values[`${side}-image`] !== undefined && row.image !== values[`${side}-image`])
+            reasons.push(row.image === null ? 'missing_image_identity' : 'image_mismatch');
+          if (values[`${side}-run-url`] !== undefined && row.run_url !== values[`${side}-run-url`])
+            reasons.push(row.run_url === null ? 'missing_run_identity' : 'run_url_mismatch');
+          if (reasons.length > 0) excluded.push({ row, reasons });
+          else selected.push(row);
+        }
+        unique[side] = [...new Map(selected.map((row) => [String(row.id), row])).values()];
+        selection[side] = {
+          rows: selected,
+          excluded,
+          unique_observations: unique[side].length,
+          snapshot_reuses: selected.length - unique[side].length,
+        };
+      }
+      const groups = Object.fromEntries(
+        ['before', 'after'].map((side) => [
+          side,
+          Map.groupBy(unique[side], (row) =>
+            JSON.stringify([
+              ...CONFIG_FIELDS.map((key) => row[key]),
+              ...CONFIG_METRICS.map((key) => [Object.hasOwn(row.metrics, key), row.metrics[key]]),
+            ]),
+          ),
+        ]),
+      );
+      const comparisons = [];
+      const unmatched = { before: [], after: [] };
+      for (const configKey of new Set([...groups.before.keys(), ...groups.after.keys()])) {
+        const before = groups.before.get(configKey) ?? [];
+        const after = groups.after.get(configKey) ?? [];
+        const reason =
+          before.length === 0 || after.length === 0
+            ? 'no_matching_configuration'
+            : before.length !== 1 || after.length !== 1
+              ? 'ambiguous_configuration'
+              : String(before[0].id) === String(after[0].id)
+                ? 'reused_observation'
+                : null;
+        if (reason) {
+          for (const [side, records] of [
+            ['before', before],
+            ['after', after],
+          ]) {
+            unmatched[side].push(...records.map((row) => ({ id: row.id, reason })));
+          }
+          continue;
+        }
+        const first = before[0];
+        const second = after[0];
+        const fingerprintMatch =
+          first.recipe_fingerprint && second.recipe_fingerprint
+            ? first.recipe_fingerprint === second.recipe_fingerprint
+            : null;
+        const unknownFields = CONFIG_METRICS.filter(
+          (key) => first.metrics[key] === null || first.metrics[key] === undefined,
+        ).map((key) => `metrics.${key}`);
+        const confounders = [
+          fingerprintMatch === false
+            ? 'recipe_fingerprint_changed_includes_image_and_unexposed_config'
+            : fingerprintMatch === null
+              ? 'recipe_fingerprint_unavailable'
+              : 'recipe_contents_not_independently_verified',
+        ];
+        if (first.image === null || second.image === null)
+          confounders.push('image_identity_unavailable');
+        if (first.run_url === null || second.run_url === null)
+          confounders.push('producer_run_identity_unavailable');
+        if (unknownFields.length > 0) confounders.push('optional_configuration_fields_unavailable');
+        comparisons.push({
+          before_id: first.id,
+          after_id: second.id,
+          configuration: Object.fromEntries(CONFIG_FIELDS.map((name) => [name, first[name]])),
+          configuration_metrics: Object.fromEntries(
+            CONFIG_METRICS.filter((key) => Object.hasOwn(first.metrics, key)).map((key) => [
+              key,
+              first.metrics[key],
+            ]),
+          ),
+          configuration_verification: 'public_fields_only',
+          configuration_completeness:
+            unknownFields.length > 0 ? 'incomplete_optional_fields' : 'known_fields_present',
+          configuration_unknown_fields: unknownFields,
+          producer: {
+            before: { image: first.image, run_url: first.run_url },
+            after: { image: second.image, run_url: second.run_url },
+          },
+          recipe_fingerprint_match: fingerprintMatch,
+          full_recipe_verified: false,
+          confounders,
+          metric: compareMetric(first, second, values.metric),
+        });
+      }
+      const comparableValues = comparisons.filter(
+        ({ metric }) => Number.isFinite(metric.before) && Number.isFinite(metric.after),
+      ).length;
+      const output = `${JSON.stringify(
+        {
+          schema_version: 1,
+          metadata: {
+            package_version: PACKAGE_VERSION,
+            query_url: url.href,
+            retrieved_at: evidence[0].retrieved_at,
+            requested: Object.fromEntries(
+              Object.entries(values).filter(([name]) => name !== 'error-format'),
+            ),
+            ran_new_benchmark: false,
+            returned_rows: rows.length,
+            outside_requested_scope: rows.length - scoped.length,
+            outside_selected_dates: scoped.filter(
+              (row) => ![values['before-date'], values['after-date']].includes(row.date),
+            ).length,
+            date_field: 'date',
+            metric_coverage: {
+              comparable_values: comparableValues,
+              missing_values: comparisons.length - comparableValues,
+            },
+            release_mapping: 'unknown',
+            causal_attribution: 'not_established',
+            statistical_verdict: 'not_established',
+          },
+          outcome: comparisons.length > 0 ? 'observed_comparisons' : 'no_comparable_pairs',
+          limitations: [
+            'Descriptive existing observations only; no causal or statistical regression verdict.',
+            'Dates select original observations; history contains latest attempts and carried curve snapshots, not every historical attempt.',
+            'Matching covers declared public configuration fields only; unavailable fields and recipe changes remain confounders.',
+            'Image strings and run URLs do not independently establish immutable images or framework release versions.',
+          ],
+          selection,
+          comparisons,
+          unmatched,
+          evidence,
+        },
+        null,
+        2,
+      )}\n`;
+      await saveOutput(values.output, output, signal);
+    }, signal);
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
+    }
+    throw error;
+  }
 }
 
-run().catch((error) => {
-  process.stderr.write(`compare-releases: ${error.message}\n`);
-  process.exitCode = 1;
+await runCli({
+  command: 'compare-releases',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => run(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-releases.mjs
@@ -14,7 +14,7 @@ import {
   writeStdout,
 } from './cli-contract.mjs';
 
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 // History omits mean/std latency and interactivity; QPS statistics are retained.
 const PERFORMANCE_METRIC =

--- a/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
@@ -15,7 +15,7 @@ import {
 } from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const HELP = `compare-tco — compare modeled GPU-hour cost at a fixed interactivity target
 
 Requires Node 24 or later. Output is JSON with the consumed API response and coverage.

--- a/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/compare-tco.mjs
@@ -3,8 +3,16 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { rename, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
-import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  runCli,
+  writeStdout,
+} from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
 const PACKAGE_VERSION = '0.9.0';
@@ -20,6 +28,7 @@ Usage:
 Options:
   --date <YYYY-MM-DD>  As-of cutoff; omission selects latest available data
   --output <file>      Atomically replace this local file; default stdout
+  --error-format <mode> Failure diagnostics: text (default) or json
   --version          Show the installed package version offline
   --help              Show help without making a request
 
@@ -159,179 +168,209 @@ function validateFeed(feed, values, workloads, target) {
   return points;
 }
 
-async function writeOutput(destination, bytes) {
+async function writeOutput(destination, bytes, signal) {
   if (destination === undefined) {
-    process.stdout.on('error', () => {});
-    await new Promise((resolveWrite, reject) => {
-      process.stdout.write(bytes, (error) => (error ? reject(error) : resolveWrite()));
-    });
+    await writeStdout(bytes, { signal });
     return;
   }
   const target = resolve(destination);
   const temporary = join(dirname(target), `.${basename(target)}.${randomUUID()}.tmp`);
+  await outputBoundary(async () => {
+    try {
+      await writeFile(temporary, bytes, { flag: 'wx' });
+      signal.throwIfAborted();
+      await rename(temporary, target);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  }, signal);
+}
+
+async function run(args, signal) {
+  let argumentsValidated = false;
   try {
-    await writeFile(temporary, bytes, { flag: 'wx' });
-    await rename(temporary, target);
-  } finally {
-    await rm(temporary, { force: true });
-  }
-}
-
-async function run() {
-  const { values, tokens } = parseArgs({
-    tokens: true,
-    options: {
-      model: { type: 'string' },
-      workloads: { type: 'string' },
-      target: { type: 'string' },
-      'gpu-hourly-prices': { type: 'string' },
-      date: { type: 'string' },
-      output: { type: 'string' },
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-  });
-  const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
-  if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) return writeOutput(undefined, HELP);
-  if (!values.model || values.model.trim() !== values.model || /\p{Cc}/u.test(values.model)) {
-    throw new Error('--model requires an exact API model key or display name');
-  }
-  if (values.date !== undefined && !validDate(values.date))
-    throw new Error('--date requires a real YYYY-MM-DD date');
-  if (values.output !== undefined && values.output.trim() === '')
-    throw new Error('--output must name a file');
-  const target = positiveDecimal(values.target, 'target');
-  if (target > 10_000) throw new Error('--target must be at most 10000');
-  const workloads = values.workloads?.split(',');
-  if (
-    !workloads ||
-    workloads.length > 8 ||
-    new Set(workloads).size !== workloads.length ||
-    workloads.some((workload) => !/^[1-9]\d{0,6}x[1-9]\d{0,6}$/u.test(workload))
-  ) {
-    throw new Error('--workloads requires 1 to 8 distinct positive <isl>x<osl> token pairs');
-  }
-  if (!values['gpu-hourly-prices'])
-    throw new Error('--gpu-hourly-prices requires explicit user prices');
-  const priceEntries = values['gpu-hourly-prices'].split(',').map((pair) => {
-    const [hardware, price] = pair.split('=');
-    if (pair.split('=').length !== 2 || !KEY.test(hardware))
-      throw new Error('Invalid hardware=price entry');
-    return [hardware, positiveDecimal(price, 'gpu-hourly-prices')];
-  });
-  const prices = Object.fromEntries(priceEntries);
-  if (Object.keys(prices).length !== priceEntries.length)
-    throw new Error('Specify each hardware price only once');
-  const url = new URL('/api/v1/tco-feed', 'https://inferencex.semianalysis.com');
-  url.search = new URLSearchParams({
-    model: values.model,
-    workloads: values.workloads,
-    tiers: String(target),
-    view: 'points',
-    format: 'json',
-    ...(values.date ? { date: values.date } : {}),
-  }).toString();
-  const response = await fetch(url, { redirect: 'error', signal: AbortSignal.timeout(30_000) });
-  if (!response.ok) throw new Error(`HTTP ${response.status}: ${url}`);
-  if (!/^application\/json(?:\s*;|$)/iu.test(response.headers.get('content-type') ?? '')) {
-    throw new Error('Expected an application/json TCO response');
-  }
-  if (!response.body) throw new Error('Missing TCO response body');
-  const chunks = [];
-  let bodyBytes = 0;
-  for await (const chunk of response.body) {
-    bodyBytes += chunk.byteLength;
-    if (bodyBytes > MAX_RESPONSE_BYTES) throw new Error('TCO response exceeds 4 MiB');
-    chunks.push(chunk);
-  }
-  const bytes = Buffer.concat(chunks);
-  // Fetch decodes HTTP compression. Strict UTF-8 keeps the recorded body reversible to these bytes.
-  const body = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
-  const feed = JSON.parse(body);
-  const points = validateFeed(feed, values, workloads, target);
-  const statusCounts = {
-    available: 0,
-    missing_point: 0,
-    clamped_low: 0,
-    unreachable: 0,
-    zero_throughput: 0,
-  };
-  const rows = priceEntries.flatMap(([hardware, price]) =>
-    workloads.map((workload) => {
-      const point = points.get(`${hardware}/${workload}`) ?? null;
-      const status =
-        point === null
-          ? 'missing_point'
-          : point.boundary === 'interpolated'
-            ? point.output_tput_per_gpu === 0
-              ? 'zero_throughput'
-              : 'available'
-            : point.boundary;
-      const cost =
-        status === 'available' ? (price * 1e6) / (point.output_tput_per_gpu * 3600) : null;
-      if (cost !== null && (!Number.isFinite(cost) || cost <= 0))
-        throw new Error('Modeled token cost exceeds numeric range');
-      statusCounts[status] += 1;
+    const { values, tokens } = parseArgs({
+      args,
+      tokens: true,
+      options: {
+        model: { type: 'string' },
+        workloads: { type: 'string' },
+        target: { type: 'string' },
+        'gpu-hourly-prices': { type: 'string' },
+        date: { type: 'string' },
+        output: { type: 'string' },
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
+      },
+    });
+    const options = tokens.filter((token) => token.kind === 'option').map((token) => token.name);
+    if (new Set(options).size !== options.length) throw new Error('Specify each option only once');
+    if (values.version) {
+      await writeStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
+    }
+    if (values.help) return writeOutput(undefined, HELP, signal);
+    if (!values.model || values.model.trim() !== values.model || /\p{Cc}/u.test(values.model)) {
+      throw new Error('--model requires an exact API model key or display name');
+    }
+    if (values.date !== undefined && !validDate(values.date))
+      throw new Error('--date requires a real YYYY-MM-DD date');
+    if (values.output !== undefined && values.output.trim() === '')
+      throw new Error('--output must name a file');
+    const target = positiveDecimal(values.target, 'target');
+    if (target > 10_000) throw new Error('--target must be at most 10000');
+    const workloads = values.workloads?.split(',');
+    if (
+      !workloads ||
+      workloads.length > 8 ||
+      new Set(workloads).size !== workloads.length ||
+      workloads.some((workload) => !/^[1-9]\d{0,6}x[1-9]\d{0,6}$/u.test(workload))
+    ) {
+      throw new Error('--workloads requires 1 to 8 distinct positive <isl>x<osl> token pairs');
+    }
+    if (!values['gpu-hourly-prices'])
+      throw new Error('--gpu-hourly-prices requires explicit user prices');
+    const priceEntries = values['gpu-hourly-prices'].split(',').map((pair) => {
+      const [hardware, price] = pair.split('=');
+      if (pair.split('=').length !== 2 || !KEY.test(hardware))
+        throw new Error('Invalid hardware=price entry');
+      return [hardware, positiveDecimal(price, 'gpu-hourly-prices')];
+    });
+    const prices = Object.fromEntries(priceEntries);
+    if (Object.keys(prices).length !== priceEntries.length)
+      throw new Error('Specify each hardware price only once');
+    argumentsValidated = true;
+    const url = new URL('/api/v1/tco-feed', 'https://inferencex.semianalysis.com');
+    url.search = new URLSearchParams({
+      model: values.model,
+      workloads: values.workloads,
+      tiers: String(target),
+      view: 'points',
+      format: 'json',
+      ...(values.date ? { date: values.date } : {}),
+    }).toString();
+    const requestSignal = AbortSignal.any([AbortSignal.timeout(30_000), signal]);
+    const response = await requestBoundary(
+      () =>
+        fetch(url, {
+          redirect: 'error',
+          signal: requestSignal,
+        }),
+      requestSignal,
+    );
+    if (!response.ok) throw httpError(response.status, `HTTP ${response.status}: ${url}`);
+    const { bytes, body, bodyBytes, feed, points } = await responseBoundary(async () => {
+      if (!/^application\/json(?:\s*;|$)/iu.test(response.headers.get('content-type') ?? '')) {
+        throw new Error('Expected an application/json TCO response');
+      }
+      if (!response.body) throw new Error('Missing TCO response body');
+      const chunks = [];
+      let receivedBytes = 0;
+      for await (const chunk of response.body) {
+        receivedBytes += chunk.byteLength;
+        if (receivedBytes > MAX_RESPONSE_BYTES) throw new Error('TCO response exceeds 4 MiB');
+        chunks.push(chunk);
+      }
+      const responseBytes = Buffer.concat(chunks);
+      // Fetch decodes HTTP compression. Strict UTF-8 keeps the recorded body reversible to these bytes.
+      const responseBody = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(
+        responseBytes,
+      );
+      const parsedFeed = JSON.parse(responseBody);
       return {
-        hardware,
-        workload,
-        status,
-        usd_per_gpu_hour: price,
-        usd_per_million_output_tokens: cost,
-        point,
+        bytes: responseBytes,
+        body: responseBody,
+        bodyBytes: receivedBytes,
+        feed: parsedFeed,
+        points: validateFeed(parsedFeed, values, workloads, target),
       };
-    }),
-  );
-  const document = {
-    schema_version: 1,
-    metadata: {
-      package_version: PACKAGE_VERSION,
-      requested_model: values.model,
-      db_model_keys: feed.db_model_keys,
-      requested_date: values.date ?? null,
-      date_selection: values.date ? 'as-of' : 'latest',
-      benchmark_type: 'single_turn',
-      workloads,
-      target_output_tokens_per_second_per_user: target,
-      interactivity_statistic: 'median',
-      gpu_hourly_prices_usd: prices,
-      price_source: 'user-supplied',
-      cost_unit: 'USD per million output tokens',
-      throughput_unit: 'output tokens per second per GPU',
-      formula: 'USD/GPU-hour * 1000000 / (output tokens/second/GPU * 3600)',
-      assumed_throughput_fraction: 1,
-      cost_scope: 'Supplied GPU hourly rate only; not total purchase or ownership cost',
-      frontier_scope:
-        'API frontier across frameworks, precisions, speculative methods and deployment configurations; no observation IDs or matched-configuration proof',
-    },
-    source: {
-      query_url: url.href,
-      retrieved_at: new Date().toISOString(),
-      http_status: response.status,
-      sha256: createHash('sha256').update(bytes).digest('hex'),
-      body_encoding: 'utf8',
-      body_bytes: bodyBytes,
-      body,
-    },
-    coverage: {
-      status: statusCounts.available === rows.length ? 'complete' : 'incomplete',
-      requested_points: rows.length,
-      returned_points: feed.rows.length,
-      available_points: statusCounts.available,
-      status_counts: statusCounts,
-      returned_hardware: [...new Set(feed.rows.map((row) => row.hardware))].toSorted(),
-    },
-    rows,
-  };
-  await writeOutput(values.output, `${JSON.stringify(document, null, 2)}\n`);
+    }, requestSignal);
+    const statusCounts = {
+      available: 0,
+      missing_point: 0,
+      clamped_low: 0,
+      unreachable: 0,
+      zero_throughput: 0,
+    };
+    const rows = priceEntries.flatMap(([hardware, price]) =>
+      workloads.map((workload) => {
+        const point = points.get(`${hardware}/${workload}`) ?? null;
+        const status =
+          point === null
+            ? 'missing_point'
+            : point.boundary === 'interpolated'
+              ? point.output_tput_per_gpu === 0
+                ? 'zero_throughput'
+                : 'available'
+              : point.boundary;
+        const cost =
+          status === 'available' ? (price * 1e6) / (point.output_tput_per_gpu * 3600) : null;
+        if (cost !== null && (!Number.isFinite(cost) || cost <= 0))
+          throw new Error('Modeled token cost exceeds numeric range');
+        statusCounts[status] += 1;
+        return {
+          hardware,
+          workload,
+          status,
+          usd_per_gpu_hour: price,
+          usd_per_million_output_tokens: cost,
+          point,
+        };
+      }),
+    );
+    const document = {
+      schema_version: 1,
+      metadata: {
+        package_version: PACKAGE_VERSION,
+        requested_model: values.model,
+        db_model_keys: feed.db_model_keys,
+        requested_date: values.date ?? null,
+        date_selection: values.date ? 'as-of' : 'latest',
+        benchmark_type: 'single_turn',
+        workloads,
+        target_output_tokens_per_second_per_user: target,
+        interactivity_statistic: 'median',
+        gpu_hourly_prices_usd: prices,
+        price_source: 'user-supplied',
+        cost_unit: 'USD per million output tokens',
+        throughput_unit: 'output tokens per second per GPU',
+        formula: 'USD/GPU-hour * 1000000 / (output tokens/second/GPU * 3600)',
+        assumed_throughput_fraction: 1,
+        cost_scope: 'Supplied GPU hourly rate only; not total purchase or ownership cost',
+        frontier_scope:
+          'API frontier across frameworks, precisions, speculative methods and deployment configurations; no observation IDs or matched-configuration proof',
+      },
+      source: {
+        query_url: url.href,
+        retrieved_at: new Date().toISOString(),
+        http_status: response.status,
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+        body_encoding: 'utf8',
+        body_bytes: bodyBytes,
+        body,
+      },
+      coverage: {
+        status: statusCounts.available === rows.length ? 'complete' : 'incomplete',
+        requested_points: rows.length,
+        returned_points: feed.rows.length,
+        available_points: statusCounts.available,
+        status_counts: statusCounts,
+        returned_hardware: [...new Set(feed.rows.map((row) => row.hardware))].toSorted(),
+      },
+      rows,
+    };
+    await writeOutput(values.output, `${JSON.stringify(document, null, 2)}\n`, signal);
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
+    }
+    throw error;
+  }
 }
 
-run().catch((error) => {
-  console.error(`compare-tco: ${error.message}`);
-  process.exitCode = 1;
+await runCli({
+  command: 'compare-tco',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => run(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -403,6 +403,7 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
   try {
     bytes = await responseBoundary(() => budget.read(response), requestSignal);
   } catch (error) {
+    if (error instanceof CliError && ['CANCELLED', 'TIMEOUT'].includes(error.code)) throw error;
     if (!response.ok) throw httpError(response.status, `HTTP ${response.status} (${url.href})`);
     if (error?.code) {
       throw new CliError(
@@ -443,11 +444,13 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
     }
     throw httpError(response.status, `HTTP ${response.status}${detail} (${url.href})`);
   }
-  try {
-    return await responseBoundary(() => JSON.parse(body), budget.signal);
-  } catch (error) {
-    throw responseError(`Could not read ${operation} JSON: ${error.message}`, error);
-  }
+  return responseBoundary(() => {
+    try {
+      return JSON.parse(body);
+    } catch (error) {
+      throw responseError(`Could not read ${operation} JSON: ${error.message}`, error);
+    }
+  }, budget.signal);
 }
 
 async function fetchChunks(operation, ids, limit, validate, requestUrls, evidence, budget) {

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -203,9 +203,11 @@ function sha256(bytes) {
 }
 
 async function saveManifest(evidence) {
-  const temporary = join(evidence.directory, 'manifest.tmp');
-  await writeFile(temporary, `${JSON.stringify(evidence.manifest, null, 2)}\n`, 'utf8');
-  await rename(temporary, join(evidence.directory, 'manifest.json'));
+  await outputBoundary(async () => {
+    const temporary = join(evidence.directory, 'manifest.tmp');
+    await writeFile(temporary, `${JSON.stringify(evidence.manifest, null, 2)}\n`, 'utf8');
+    await rename(temporary, join(evidence.directory, 'manifest.json'));
+  });
 }
 
 async function stageFileOutput(destination, bytes, signal) {
@@ -421,7 +423,10 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
   }
   if (record) {
     const filename = `response-${String(requestNumber).padStart(4, '0')}-${operation}.json`;
-    await writeFile(join(evidence.directory, filename), bytes, { flag: 'wx' });
+    await outputBoundary(
+      () => writeFile(join(evidence.directory, filename), bytes, { flag: 'wx' }),
+      budget.signal,
+    );
     record.decoded_body_sha256 = sha256(bytes);
     record.body_file = filename;
     await saveManifest(evidence);
@@ -629,19 +634,21 @@ async function run(args, signal) {
       if (values['evidence-dir'] !== undefined) {
         const directory = resolve(values['evidence-dir']);
         if (outputPath !== null) {
-          const physicalEvidencePath = await physicalPath(directory);
-          const physicalOutputPath = await physicalPath(outputPath);
+          const physicalEvidencePath = await outputBoundary(() => physicalPath(directory), signal);
+          const physicalOutputPath = await outputBoundary(() => physicalPath(outputPath), signal);
           const evidencePath = physicalEvidencePath.toLowerCase();
           const physicalOutput = physicalOutputPath.toLowerCase();
           if (
             containsPath(evidencePath, physicalOutput) ||
             containsPath(physicalOutput, evidencePath)
           ) {
-            throw new Error('--output collides with the evidence directory');
+            throw argumentError('--output collides with the evidence directory');
           }
         }
-        await mkdir(dirname(directory), { recursive: true });
-        await mkdir(directory); // EEXIST also rejects empty directories and symlinks.
+        await outputBoundary(async () => {
+          await mkdir(dirname(directory), { recursive: true });
+          await mkdir(directory); // EEXIST also rejects empty directories and symlinks.
+        }, signal);
         evidence = {
           directory,
           manifest: {
@@ -928,9 +935,10 @@ async function run(args, signal) {
         try {
           await outputTransaction.rollback();
         } catch (rollbackError) {
-          failure = new Error(
+          failure = new CliError(
+            error instanceof CliError ? error.code : 'INTERNAL_ERROR',
             `${error.message}; could not restore the previous output: ${rollbackError.message}`,
-            { cause: error },
+            { cause: error, httpStatus: error.httpStatus },
           );
         }
       }
@@ -944,9 +952,10 @@ async function run(args, signal) {
         try {
           await saveManifest(evidence);
         } catch (writeError) {
-          throw new Error(
+          throw new CliError(
+            failure instanceof CliError ? failure.code : 'INTERNAL_ERROR',
             `${failure.message}; could not save failure evidence: ${writeError.message}`,
-            { cause: writeError },
+            { cause: failure, httpStatus: failure.httpStatus },
           );
         }
       }

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -922,6 +922,7 @@ async function run(args, signal) {
         await saveManifest(evidence);
       }
       if (outputTransaction) {
+        signal.throwIfAborted();
         await outputTransaction.finish();
         outputTransaction = null;
       }

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -19,7 +19,7 @@ import {
 import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const HELP = `export-agentx — export existing AgentX observations with summary enrichments
 

--- a/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-agentx.mjs
@@ -5,6 +5,17 @@ import { lstat, mkdir, readlink, realpath, rename, rm, writeFile } from 'node:fs
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  CliError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  responseError,
+  runCli,
+  writeStdout as writeCliStdout,
+} from './cli-contract.mjs';
 import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
@@ -29,6 +40,7 @@ Options:
   --format <format>    csv (default) or json
   --output <file>      Output file; default stdout
   --evidence-dir <dir> Save consumed responses and a manifest in a new directory
+  --error-format <mode> Failure diagnostics: text (default) or json
   --version          Show the installed package version offline
   --help               Show this help without making a request
 
@@ -196,15 +208,7 @@ async function saveManifest(evidence) {
   await rename(temporary, join(evidence.directory, 'manifest.json'));
 }
 
-async function writeStdout(bytes) {
-  // The callback reports a closed consumer after write() has accepted the buffer.
-  process.stdout.on('error', () => {});
-  await new Promise((resolveWrite, reject) => {
-    process.stdout.write(bytes, (error) => (error ? reject(error) : resolveWrite()));
-  });
-}
-
-async function stageFileOutput(destination, bytes) {
+async function stageFileOutput(destination, bytes, signal) {
   const target = resolve(destination);
   const suffix = `${process.pid}-${randomUUID()}`;
   const temporary = join(dirname(target), `.${basename(target)}.${suffix}.tmp`);
@@ -229,6 +233,7 @@ async function stageFileOutput(destination, bytes) {
         await rename(target, backup);
         original = true;
       }
+      signal.throwIfAborted();
       await rename(temporary, target);
       installed = true;
     },
@@ -367,13 +372,25 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
     await saveManifest(evidence);
   }
   let response;
+  const requestSignal = AbortSignal.any([budget.signal, AbortSignal.timeout(30_000)]);
   try {
     budget.signal.throwIfAborted();
-    response = await fetch(url, {
-      redirect: 'error',
-      signal: AbortSignal.any([budget.signal, AbortSignal.timeout(30_000)]),
-    });
+    response = await requestBoundary(
+      () =>
+        fetch(url, {
+          redirect: 'error',
+          signal: requestSignal,
+        }),
+      requestSignal,
+    );
   } catch (error) {
+    if (error?.code) {
+      throw new CliError(
+        error.code,
+        `${operation} request failed: ${error.message} (${url.href})`,
+        { cause: error, httpStatus: error.httpStatus },
+      );
+    }
     throw new Error(`${operation} request failed: ${error.message} (${url.href})`, {
       cause: error,
     });
@@ -384,8 +401,19 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
   }
   let bytes;
   try {
-    bytes = await budget.read(response);
+    bytes = await responseBoundary(() => budget.read(response), requestSignal);
   } catch (error) {
+    if (!response.ok) throw httpError(response.status, `HTTP ${response.status} (${url.href})`);
+    if (error?.code) {
+      throw new CliError(
+        error.code,
+        `Could not read ${operation} response body: ${error.message}`,
+        {
+          cause: error,
+          httpStatus: error.httpStatus,
+        },
+      );
+    }
     throw new Error(`Could not read ${operation} response body: ${error.message}`, {
       cause: error,
     });
@@ -402,7 +430,8 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
   try {
     body = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
   } catch (error) {
-    throw new Error(`${operation} response is not valid UTF-8`, { cause: error });
+    if (response.ok) throw responseError(`${operation} response is not valid UTF-8`, error);
+    body = '';
   }
   if (!response.ok) {
     let detail = '';
@@ -412,12 +441,12 @@ async function fetchJson(url, operation, requestUrls, evidence, budget, requeste
     } catch {
       // The HTTP status is authoritative when an error body is not JSON.
     }
-    throw new Error(`HTTP ${response.status}${detail} (${url.href})`);
+    throw httpError(response.status, `HTTP ${response.status}${detail} (${url.href})`);
   }
   try {
-    return JSON.parse(body);
+    return await responseBoundary(() => JSON.parse(body), budget.signal);
   } catch (error) {
-    throw new Error(`Could not read ${operation} JSON: ${error.message}`, { cause: error });
+    throw responseError(`Could not read ${operation} JSON: ${error.message}`, error);
   }
 }
 
@@ -427,9 +456,10 @@ async function fetchChunks(operation, ids, limit, validate, requestUrls, evidenc
     const chunk = ids.slice(offset, offset + limit);
     const url = new URL(`/api/v1/${operation}`, API_ORIGIN);
     url.searchParams.set('ids', chunk.join(','));
-    const entries = validate(
-      await fetchJson(url, operation, requestUrls, evidence, budget, chunk),
-      chunk,
+    const entries = await responseBoundary(
+      async () =>
+        validate(await fetchJson(url, operation, requestUrls, evidence, budget, chunk), chunk),
+      budget.signal,
     );
     for (const [id, value] of entries) joined.set(id, value);
   }
@@ -489,430 +519,446 @@ function coverage(rows) {
   };
 }
 
-async function run(args = process.argv.slice(2)) {
-  const { values } = parseArgs({
-    args,
-    options: {
-      model: { type: 'string' },
-      date: { type: 'string' },
-      'raw-model': { type: 'string' },
-      hardware: { type: 'string' },
-      framework: { type: 'string' },
-      precision: { type: 'string' },
-      'spec-method': { type: 'string' },
-      'offload-mode': { type: 'string' },
-      concurrency: { type: 'string' },
-      format: { type: 'string', default: 'csv' },
-      output: { type: 'string' },
-      'evidence-dir': { type: 'string' },
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-    allowPositionals: false,
-    strict: true,
-  });
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) {
-    process.stdout.write(HELP);
-    return;
-  }
-  if (!values.model?.trim()) throw new Error('--model requires a display model name');
-  if (values.date !== undefined && !validDate(values.date)) {
-    throw new Error('--date must be a valid YYYY-MM-DD date');
-  }
-  for (const [option, description] of [
-    ['raw-model', 'a returned model key'],
-    ['hardware', 'a returned hardware key'],
-    ['framework', 'a returned framework key'],
-    ['precision', 'a returned precision key'],
-    ['spec-method', 'a returned speculative-method key'],
-    ['offload-mode', 'a returned offload-mode key'],
-  ]) {
-    if (values[option] !== undefined && !values[option].trim()) {
-      throw new Error(`--${option} requires ${description}`);
-    }
-  }
-  const concurrency =
-    values.concurrency === undefined
-      ? undefined
-      : positiveInteger(values.concurrency, 'concurrency');
-  if (!['csv', 'json'].includes(values.format)) throw new Error('--format must be csv or json');
-  if (values.output !== undefined && !values.output.trim()) {
-    throw new Error('--output requires a file path');
-  }
-  if (values['evidence-dir'] !== undefined && !values['evidence-dir'].trim()) {
-    throw new Error('--evidence-dir requires a new directory path');
-  }
-
-  const requestedFilters = {
-    raw_model: values['raw-model'],
-    hardware: values.hardware,
-    framework: values.framework,
-    precision: values.precision,
-    spec_method: values['spec-method'],
-    offload_mode: values['offload-mode'],
-    concurrency,
-  };
-  const filters = Object.fromEntries(
-    Object.entries(requestedFilters).map(([name, value]) => [
-      name,
-      { status: value === undefined ? 'omitted' : 'applied', value: value ?? null },
-    ]),
-  );
-  const requestedScope = {
-    display_model: values.model,
-    date: values.date ?? null,
-    date_selection: values.date === undefined ? 'latest' : 'as-of',
-    raw_model: values['raw-model'] ?? null,
-    hardware: values.hardware ?? null,
-    framework: values.framework ?? null,
-    precision: values.precision ?? null,
-    spec_method: values['spec-method'] ?? null,
-    offload_mode: values['offload-mode'] ?? null,
-    concurrency: concurrency ?? null,
-    benchmark_type: 'agentic_traces',
-  };
-  const appliedFilters = {
-    display_model: { status: 'applied', value: values.model },
-    date: {
-      status: values.date === undefined ? 'omitted' : 'applied',
-      value: values.date ?? null,
-    },
-    benchmark_type: { status: 'applied', value: 'agentic_traces' },
-    ...filters,
-  };
-  const outputPath = values.output === undefined ? null : resolve(values.output);
-  let evidence;
-  let outputTransaction;
-
+async function run(args, signal) {
+  let argumentsValidated = false;
   try {
-    if (values['evidence-dir'] !== undefined) {
-      const directory = resolve(values['evidence-dir']);
-      if (outputPath !== null) {
-        const physicalEvidencePath = await physicalPath(directory);
-        const physicalOutputPath = await physicalPath(outputPath);
-        const evidencePath = physicalEvidencePath.toLowerCase();
-        const physicalOutput = physicalOutputPath.toLowerCase();
-        if (
-          containsPath(evidencePath, physicalOutput) ||
-          containsPath(physicalOutput, evidencePath)
-        ) {
-          throw new Error('--output collides with the evidence directory');
-        }
-      }
-      await mkdir(dirname(directory), { recursive: true });
-      await mkdir(directory); // EEXIST also rejects empty directories and symlinks.
-      evidence = {
-        directory,
-        manifest: {
-          schema_version: 1,
-          package_version: PACKAGE_VERSION,
-          status: 'pending',
-          started_at: new Date().toISOString(),
-          finished_at: null,
-          outcome: null,
-          requested_filters: requestedScope,
-          applied_filters: appliedFilters,
-          counts: {
-            returned_rows: null,
-            returned_agentx_rows: null,
-            selected_rows: null,
-          },
-          responses: [],
-          export: {
-            format: values.format,
-            destination: outputPath ?? 'stdout',
-            sha256: null,
-            metadata: null,
-            source_request_numbers: [],
-          },
-          error: null,
-        },
-      };
-      await saveManifest(evidence);
-    }
-
-    const requestUrls = [];
-    const budget = createResponseBudget({
-      responseBytes: 32 * 1024 * 1024,
-      totalBytes: 128 * 1024 * 1024,
-      timeoutMs: 120_000,
+    const { values } = parseArgs({
+      args,
+      options: {
+        model: { type: 'string' },
+        date: { type: 'string' },
+        'raw-model': { type: 'string' },
+        hardware: { type: 'string' },
+        framework: { type: 'string' },
+        precision: { type: 'string' },
+        'spec-method': { type: 'string' },
+        'offload-mode': { type: 'string' },
+        concurrency: { type: 'string' },
+        format: { type: 'string', default: 'csv' },
+        output: { type: 'string' },
+        'evidence-dir': { type: 'string' },
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
+      },
+      allowPositionals: false,
+      strict: true,
     });
-    const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
-    benchmarkUrl.searchParams.set('model', values.model);
-    if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
-    const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls, evidence, budget);
-    if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
-      throw new Error(
-        'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
-      );
+    if (values.version) {
+      await writeCliStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
     }
-    const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
-    const selected = agentxRows.filter((row) =>
-      FILTERS.every(
-        ([name, field]) =>
-          requestedFilters[name] === undefined || row[field] === requestedFilters[name],
-      ),
-    );
-    const outcome =
-      agentxRows.length === 0
-        ? 'no_agentx_rows'
-        : selected.length === 0
-          ? 'no_matching_rows'
-          : 'selected_rows';
-    if (evidence) {
-      evidence.manifest.outcome = outcome;
-      evidence.manifest.counts = {
-        returned_rows: benchmarks.length,
-        returned_agentx_rows: agentxRows.length,
-        selected_rows: selected.length,
-      };
-      await saveManifest(evidence);
+    if (values.help) {
+      await writeCliStdout(HELP, { signal });
+      return;
     }
-    const ids = [
-      ...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null)),
-    ];
-    const aggregates = await fetchChunks(
-      'agentic-aggregates',
-      ids,
-      200,
-      aggregateMap,
-      requestUrls,
-      evidence,
-      budget,
+    if (!values.model?.trim()) throw new Error('--model requires a display model name');
+    if (values.date !== undefined && !validDate(values.date)) {
+      throw new Error('--date must be a valid YYYY-MM-DD date');
+    }
+    for (const [option, description] of [
+      ['raw-model', 'a returned model key'],
+      ['hardware', 'a returned hardware key'],
+      ['framework', 'a returned framework key'],
+      ['precision', 'a returned precision key'],
+      ['spec-method', 'a returned speculative-method key'],
+      ['offload-mode', 'a returned offload-mode key'],
+    ]) {
+      if (values[option] !== undefined && !values[option].trim()) {
+        throw new Error(`--${option} requires ${description}`);
+      }
+    }
+    const concurrency =
+      values.concurrency === undefined
+        ? undefined
+        : positiveInteger(values.concurrency, 'concurrency');
+    if (!['csv', 'json'].includes(values.format)) throw new Error('--format must be csv or json');
+    if (values.output !== undefined && !values.output.trim()) {
+      throw new Error('--output requires a file path');
+    }
+    if (values['evidence-dir'] !== undefined && !values['evidence-dir'].trim()) {
+      throw new Error('--evidence-dir requires a new directory path');
+    }
+    argumentsValidated = true;
+
+    const requestedFilters = {
+      raw_model: values['raw-model'],
+      hardware: values.hardware,
+      framework: values.framework,
+      precision: values.precision,
+      spec_method: values['spec-method'],
+      offload_mode: values['offload-mode'],
+      concurrency,
+    };
+    const filters = Object.fromEntries(
+      Object.entries(requestedFilters).map(([name, value]) => [
+        name,
+        { status: value === undefined ? 'omitted' : 'applied', value: value ?? null },
+      ]),
     );
-    const derived = await fetchChunks(
-      'derived-agentic-metrics',
-      ids,
-      200,
-      derivedMap,
-      requestUrls,
-      evidence,
-      budget,
-    );
-    const traces = await fetchChunks(
-      'trace-availability',
-      ids,
-      500,
-      traceMap,
-      requestUrls,
-      evidence,
-      budget,
-    );
-    let nonFiniteValues = 0;
-    const rows = selected.map((row) => {
-      const benchmark = JSON.parse(
-        JSON.stringify(row, (_key, value) => {
-          if (typeof value === 'number' && !Number.isFinite(value)) {
-            nonFiniteValues++;
-            return null;
+    const requestedScope = {
+      display_model: values.model,
+      date: values.date ?? null,
+      date_selection: values.date === undefined ? 'latest' : 'as-of',
+      raw_model: values['raw-model'] ?? null,
+      hardware: values.hardware ?? null,
+      framework: values.framework ?? null,
+      precision: values.precision ?? null,
+      spec_method: values['spec-method'] ?? null,
+      offload_mode: values['offload-mode'] ?? null,
+      concurrency: concurrency ?? null,
+      benchmark_type: 'agentic_traces',
+    };
+    const appliedFilters = {
+      display_model: { status: 'applied', value: values.model },
+      date: {
+        status: values.date === undefined ? 'omitted' : 'applied',
+        value: values.date ?? null,
+      },
+      benchmark_type: { status: 'applied', value: 'agentic_traces' },
+      ...filters,
+    };
+    const outputPath = values.output === undefined ? null : resolve(values.output);
+    let evidence;
+    let outputTransaction;
+
+    try {
+      if (values['evidence-dir'] !== undefined) {
+        const directory = resolve(values['evidence-dir']);
+        if (outputPath !== null) {
+          const physicalEvidencePath = await physicalPath(directory);
+          const physicalOutputPath = await physicalPath(outputPath);
+          const evidencePath = physicalEvidencePath.toLowerCase();
+          const physicalOutput = physicalOutputPath.toLowerCase();
+          if (
+            containsPath(evidencePath, physicalOutput) ||
+            containsPath(physicalOutput, evidencePath)
+          ) {
+            throw new Error('--output collides with the evidence directory');
           }
-          return value;
-        }),
+        }
+        await mkdir(dirname(directory), { recursive: true });
+        await mkdir(directory); // EEXIST also rejects empty directories and symlinks.
+        evidence = {
+          directory,
+          manifest: {
+            schema_version: 1,
+            package_version: PACKAGE_VERSION,
+            status: 'pending',
+            started_at: new Date().toISOString(),
+            finished_at: null,
+            outcome: null,
+            requested_filters: requestedScope,
+            applied_filters: appliedFilters,
+            counts: {
+              returned_rows: null,
+              returned_agentx_rows: null,
+              selected_rows: null,
+            },
+            responses: [],
+            export: {
+              format: values.format,
+              destination: outputPath ?? 'stdout',
+              sha256: null,
+              metadata: null,
+              source_request_numbers: [],
+            },
+            error: null,
+          },
+        };
+        await saveManifest(evidence);
+      }
+
+      const requestUrls = [];
+      const budget = createResponseBudget({
+        responseBytes: 32 * 1024 * 1024,
+        totalBytes: 128 * 1024 * 1024,
+        timeoutMs: 120_000,
+        signal,
+      });
+      const benchmarkUrl = new URL('/api/v1/benchmarks', API_ORIGIN);
+      benchmarkUrl.searchParams.set('model', values.model);
+      if (values.date !== undefined) benchmarkUrl.searchParams.set('date', values.date);
+      const benchmarks = await fetchJson(benchmarkUrl, 'benchmarks', requestUrls, evidence, budget);
+      if (!Array.isArray(benchmarks) || benchmarks.some((row) => !benchmarkRow(row))) {
+        throw responseError(
+          'Unexpected benchmarks response shape: expected complete rows with required identity, configuration, workload, date, run_url, and metrics fields',
+        );
+      }
+      const agentxRows = benchmarks.filter((row) => row.benchmark_type === 'agentic_traces');
+      const selected = agentxRows.filter((row) =>
+        FILTERS.every(
+          ([name, field]) =>
+            requestedFilters[name] === undefined || row[field] === requestedFilters[name],
+        ),
       );
-      const id = safeResultId(row.id);
-      if (id === null) {
+      const outcome =
+        agentxRows.length === 0
+          ? 'no_agentx_rows'
+          : selected.length === 0
+            ? 'no_matching_rows'
+            : 'selected_rows';
+      if (evidence) {
+        evidence.manifest.outcome = outcome;
+        evidence.manifest.counts = {
+          returned_rows: benchmarks.length,
+          returned_agentx_rows: agentxRows.length,
+          selected_rows: selected.length,
+        };
+        await saveManifest(evidence);
+      }
+      const ids = [
+        ...new Set(selected.map((row) => safeResultId(row.id)).filter((id) => id !== null)),
+      ];
+      const aggregates = await fetchChunks(
+        'agentic-aggregates',
+        ids,
+        200,
+        aggregateMap,
+        requestUrls,
+        evidence,
+        budget,
+      );
+      const derived = await fetchChunks(
+        'derived-agentic-metrics',
+        ids,
+        200,
+        derivedMap,
+        requestUrls,
+        evidence,
+        budget,
+      );
+      const traces = await fetchChunks(
+        'trace-availability',
+        ids,
+        500,
+        traceMap,
+        requestUrls,
+        evidence,
+        budget,
+      );
+      let nonFiniteValues = 0;
+      const rows = selected.map((row) => {
+        const benchmark = JSON.parse(
+          JSON.stringify(row, (_key, value) => {
+            if (typeof value === 'number' && !Number.isFinite(value)) {
+              nonFiniteValues++;
+              return null;
+            }
+            return value;
+          }),
+        );
+        const id = safeResultId(row.id);
+        if (id === null) {
+          return {
+            benchmark,
+            agentx: {
+              status: 'unsupported_id',
+              result_id: null,
+              aggregates: { status: 'unsupported_id', value: null },
+              derived_metrics: { status: 'unsupported_id', value: null },
+              trace_availability: {
+                status: 'unsupported_id',
+                value: null,
+                response_key_present: null,
+              },
+            },
+          };
+        }
+        const hasAggregates = aggregates.has(id);
+        const hasDerived = derived.has(id);
+        const hasTraceKey = traces.has(id);
+        const traceAvailable = hasTraceKey ? traces.get(id) : false;
         return {
           benchmark,
           agentx: {
-            status: 'unsupported_id',
-            result_id: null,
-            aggregates: { status: 'unsupported_id', value: null },
-            derived_metrics: { status: 'unsupported_id', value: null },
+            status: hasAggregates && hasDerived ? 'complete' : 'partial',
+            result_id: id,
+            aggregates: {
+              status: hasAggregates ? 'available' : 'not_returned',
+              value: hasAggregates ? aggregates.get(id) : null,
+            },
+            derived_metrics: {
+              status: hasDerived ? 'available' : 'not_returned',
+              value: hasDerived ? derived.get(id) : null,
+            },
             trace_availability: {
-              status: 'unsupported_id',
-              value: null,
-              response_key_present: null,
+              status: traceAvailable ? 'stored_trace' : 'no_stored_trace',
+              value: traceAvailable,
+              response_key_present: hasTraceKey,
             },
           },
         };
-      }
-      const hasAggregates = aggregates.has(id);
-      const hasDerived = derived.has(id);
-      const hasTraceKey = traces.has(id);
-      const traceAvailable = hasTraceKey ? traces.get(id) : false;
-      return {
-        benchmark,
-        agentx: {
-          status: hasAggregates && hasDerived ? 'complete' : 'partial',
-          result_id: id,
-          aggregates: {
-            status: hasAggregates ? 'available' : 'not_returned',
-            value: hasAggregates ? aggregates.get(id) : null,
-          },
-          derived_metrics: {
-            status: hasDerived ? 'available' : 'not_returned',
-            value: hasDerived ? derived.get(id) : null,
-          },
-          trace_availability: {
-            status: traceAvailable ? 'stored_trace' : 'no_stored_trace',
-            value: traceAvailable,
-            response_key_present: hasTraceKey,
-          },
-        },
-      };
-    });
-    const retrievedAt = new Date().toISOString();
-    const benchmarkRequest = requestUrls[0].url;
-    const metadata = {
-      package_version: PACKAGE_VERSION,
-      retrieved_at: retrievedAt,
-      request_urls: requestUrls,
-      requested_scope: requestedScope,
-      filters,
-      outcome,
-      returned_rows: benchmarks.length,
-      returned_agentx_rows: agentxRows.length,
-      selected_rows: rows.length,
-      available_filter_values: {
-        raw_model: unique(agentxRows.map((row) => row.model)),
-        hardware: unique(agentxRows.map((row) => row.hardware)),
-        framework: unique(agentxRows.map((row) => row.framework)),
-        precision: unique(agentxRows.map((row) => row.precision)),
-        spec_method: unique(agentxRows.map((row) => row.spec_method)),
-        offload_mode: unique(agentxRows.map((row) => row.offload_mode)),
-        concurrency: unique(agentxRows.map((row) => row.conc)),
-      },
-      returned_model_keys: unique(benchmarks.map((row) => row.model)),
-      selected_model_keys: unique(selected.map((row) => row.model)),
-      enrichment_coverage: coverage(rows),
-      non_finite_values: nonFiniteValues,
-      observation_context: 'Existing observations were read; no new benchmark was run.',
-    };
-    let output;
-    if (values.format === 'json') {
-      output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
-    } else {
-      const metricColumns = unique(
-        rows.flatMap(({ benchmark }) =>
-          Object.entries(benchmark.metrics)
-            .filter(([, value]) => scalar(value))
-            .map(([key]) => `metrics.${key}`),
-        ),
-      );
-      const columns = [
-        ...CSV_CONTEXT_COLUMNS,
-        ...CSV_BENCHMARK_COLUMNS,
-        ...metricColumns,
-        ...CSV_ENRICHMENT_COLUMNS,
-      ];
-      const context = {
+      });
+      const retrievedAt = new Date().toISOString();
+      const benchmarkRequest = requestUrls[0].url;
+      const metadata = {
         package_version: PACKAGE_VERSION,
-        query_url: benchmarkRequest,
         retrieved_at: retrievedAt,
-        requested_model: values.model,
-        requested_date: values.date ?? null,
-        date_selection: values.date === undefined ? 'latest' : 'as-of',
-        requested_benchmark_type: 'agentic_traces',
-        ...Object.fromEntries(
-          Object.entries(requestedFilters).map(([name, value]) => [
-            `filter.${name}`,
-            value ?? null,
-          ]),
-        ),
+        request_urls: requestUrls,
+        requested_scope: requestedScope,
+        filters,
+        outcome,
+        returned_rows: benchmarks.length,
+        returned_agentx_rows: agentxRows.length,
+        selected_rows: rows.length,
+        available_filter_values: {
+          raw_model: unique(agentxRows.map((row) => row.model)),
+          hardware: unique(agentxRows.map((row) => row.hardware)),
+          framework: unique(agentxRows.map((row) => row.framework)),
+          precision: unique(agentxRows.map((row) => row.precision)),
+          spec_method: unique(agentxRows.map((row) => row.spec_method)),
+          offload_mode: unique(agentxRows.map((row) => row.offload_mode)),
+          concurrency: unique(agentxRows.map((row) => row.conc)),
+        },
+        returned_model_keys: unique(benchmarks.map((row) => row.model)),
+        selected_model_keys: unique(selected.map((row) => row.model)),
+        enrichment_coverage: coverage(rows),
+        non_finite_values: nonFiniteValues,
+        observation_context: 'Existing observations were read; no new benchmark was run.',
       };
-      const lines = rows.map(({ benchmark, agentx }) => {
-        const aggregateCells = Object.fromEntries(
-          AGGREGATE_GROUPS.flatMap((group) =>
-            [...PERCENTILE_FIELDS, 'n'].map((field) => [
-              `aggregate.${group}.${field}`,
-              agentx.aggregates.value?.[group]?.[field],
-            ]),
+      let output;
+      if (values.format === 'json') {
+        output = `${JSON.stringify({ schema_version: 1, metadata, rows }, null, 2)}\n`;
+      } else {
+        const metricColumns = unique(
+          rows.flatMap(({ benchmark }) =>
+            Object.entries(benchmark.metrics)
+              .filter(([, value]) => scalar(value))
+              .map(([key]) => `metrics.${key}`),
           ),
         );
-        const enrichment = {
-          ...aggregateCells,
-          'derived.p75_e2e_norm_intvty': agentx.derived_metrics.value?.p75_e2e_norm_intvty,
-          'derived.p90_e2e_norm_intvty': agentx.derived_metrics.value?.p90_e2e_norm_intvty,
-          'trace.available': agentx.trace_availability.value,
-          'trace.response_key_present': agentx.trace_availability.response_key_present,
-          'enrichment.status': agentx.status,
-          'enrichment.aggregates_status': agentx.aggregates.status,
-          'enrichment.derived_metrics_status': agentx.derived_metrics.status,
-          'enrichment.trace_availability_status': agentx.trace_availability.status,
+        const columns = [
+          ...CSV_CONTEXT_COLUMNS,
+          ...CSV_BENCHMARK_COLUMNS,
+          ...metricColumns,
+          ...CSV_ENRICHMENT_COLUMNS,
+        ];
+        const context = {
+          package_version: PACKAGE_VERSION,
+          query_url: benchmarkRequest,
+          retrieved_at: retrievedAt,
+          requested_model: values.model,
+          requested_date: values.date ?? null,
+          date_selection: values.date === undefined ? 'latest' : 'as-of',
+          requested_benchmark_type: 'agentic_traces',
+          ...Object.fromEntries(
+            Object.entries(requestedFilters).map(([name, value]) => [
+              `filter.${name}`,
+              value ?? null,
+            ]),
+          ),
         };
-        return [
-          ...CSV_CONTEXT_COLUMNS.map((column) => context[column]),
-          ...CSV_BENCHMARK_COLUMNS.map((column) => benchmark[column]),
-          ...metricColumns.map((column) => {
-            const value = benchmark.metrics[column.slice('metrics.'.length)];
-            return scalar(value) ? value : null;
-          }),
-          ...CSV_ENRICHMENT_COLUMNS.map((column) => enrichment[column]),
-        ]
-          .map(csvCell)
-          .join(',');
-      });
-      output = `${[columns.map(csvCell).join(','), ...lines].join('\r\n')}\r\n`;
-    }
-    const outputBytes = Buffer.from(output);
-    if (evidence) {
-      const sourceRequestNumbers = evidence.manifest.responses
-        .filter((record) => record.body_file !== null)
-        .map((record) => record.request_number);
-      if (sourceRequestNumbers.length !== evidence.manifest.responses.length) {
-        throw new Error('Cannot complete evidence with an uncaptured response');
+        const lines = rows.map(({ benchmark, agentx }) => {
+          const aggregateCells = Object.fromEntries(
+            AGGREGATE_GROUPS.flatMap((group) =>
+              [...PERCENTILE_FIELDS, 'n'].map((field) => [
+                `aggregate.${group}.${field}`,
+                agentx.aggregates.value?.[group]?.[field],
+              ]),
+            ),
+          );
+          const enrichment = {
+            ...aggregateCells,
+            'derived.p75_e2e_norm_intvty': agentx.derived_metrics.value?.p75_e2e_norm_intvty,
+            'derived.p90_e2e_norm_intvty': agentx.derived_metrics.value?.p90_e2e_norm_intvty,
+            'trace.available': agentx.trace_availability.value,
+            'trace.response_key_present': agentx.trace_availability.response_key_present,
+            'enrichment.status': agentx.status,
+            'enrichment.aggregates_status': agentx.aggregates.status,
+            'enrichment.derived_metrics_status': agentx.derived_metrics.status,
+            'enrichment.trace_availability_status': agentx.trace_availability.status,
+          };
+          return [
+            ...CSV_CONTEXT_COLUMNS.map((column) => context[column]),
+            ...CSV_BENCHMARK_COLUMNS.map((column) => benchmark[column]),
+            ...metricColumns.map((column) => {
+              const value = benchmark.metrics[column.slice('metrics.'.length)];
+              return scalar(value) ? value : null;
+            }),
+            ...CSV_ENRICHMENT_COLUMNS.map((column) => enrichment[column]),
+          ]
+            .map(csvCell)
+            .join(',');
+        });
+        output = `${[columns.map(csvCell).join(','), ...lines].join('\r\n')}\r\n`;
       }
-      evidence.manifest.export.metadata = metadata;
-      evidence.manifest.export.source_request_numbers = sourceRequestNumbers;
-      await saveManifest(evidence);
-    }
-    if (outputPath === null) {
-      await writeStdout(outputBytes);
-    } else {
-      outputTransaction = await stageFileOutput(outputPath, outputBytes);
-      await outputTransaction.commit();
-    }
-    if (evidence) {
-      evidence.manifest.export.sha256 = sha256(outputBytes);
-      evidence.manifest.status = 'complete';
-      evidence.manifest.finished_at = new Date().toISOString();
-      await saveManifest(evidence);
-    }
-    if (outputTransaction) {
-      await outputTransaction.finish();
-      outputTransaction = null;
-    }
-    process.stderr.write(`${JSON.stringify({ metadata })}\n`);
-    process.stderr.write(
-      `Selected ${metadata.selected_rows} AgentX rows from ${metadata.returned_rows} complete benchmark rows (${metadata.returned_agentx_rows} AgentX before exact-filter selection).\n`,
-    );
-  } catch (error) {
-    let failure = error;
-    if (outputTransaction) {
-      try {
-        await outputTransaction.rollback();
-      } catch (rollbackError) {
-        failure = new Error(
-          `${error.message}; could not restore the previous output: ${rollbackError.message}`,
-          { cause: error },
-        );
-      }
-    }
-    if (evidence) {
-      evidence.manifest.status = 'failed';
-      evidence.manifest.finished_at = new Date().toISOString();
-      evidence.manifest.outcome = 'failed';
-      evidence.manifest.error = failure.message;
-      evidence.manifest.export.sha256 = null;
-      evidence.manifest.export.source_request_numbers = [];
-      try {
+      const outputBytes = Buffer.from(output);
+      if (evidence) {
+        const sourceRequestNumbers = evidence.manifest.responses
+          .filter((record) => record.body_file !== null)
+          .map((record) => record.request_number);
+        if (sourceRequestNumbers.length !== evidence.manifest.responses.length) {
+          throw new Error('Cannot complete evidence with an uncaptured response');
+        }
+        evidence.manifest.export.metadata = metadata;
+        evidence.manifest.export.source_request_numbers = sourceRequestNumbers;
         await saveManifest(evidence);
-      } catch (writeError) {
-        throw new Error(
-          `${failure.message}; could not save failure evidence: ${writeError.message}`,
-          { cause: writeError },
-        );
       }
+      if (outputPath === null) {
+        await writeCliStdout(outputBytes, { signal });
+      } else {
+        outputTransaction = await outputBoundary(
+          () => stageFileOutput(outputPath, outputBytes, signal),
+          signal,
+        );
+        await outputBoundary(() => outputTransaction.commit(), signal);
+      }
+      signal.throwIfAborted();
+      if (evidence) {
+        evidence.manifest.export.sha256 = sha256(outputBytes);
+        evidence.manifest.status = 'complete';
+        evidence.manifest.finished_at = new Date().toISOString();
+        await saveManifest(evidence);
+      }
+      if (outputTransaction) {
+        await outputTransaction.finish();
+        outputTransaction = null;
+      }
+      process.stderr.write(`${JSON.stringify({ metadata })}\n`);
+      process.stderr.write(
+        `Selected ${metadata.selected_rows} AgentX rows from ${metadata.returned_rows} complete benchmark rows (${metadata.returned_agentx_rows} AgentX before exact-filter selection).\n`,
+      );
+    } catch (error) {
+      let failure = error;
+      if (outputTransaction) {
+        try {
+          await outputTransaction.rollback();
+        } catch (rollbackError) {
+          failure = new Error(
+            `${error.message}; could not restore the previous output: ${rollbackError.message}`,
+            { cause: error },
+          );
+        }
+      }
+      if (evidence) {
+        evidence.manifest.status = 'failed';
+        evidence.manifest.finished_at = new Date().toISOString();
+        evidence.manifest.outcome = 'failed';
+        evidence.manifest.error = failure.message;
+        evidence.manifest.export.sha256 = null;
+        evidence.manifest.export.source_request_numbers = [];
+        try {
+          await saveManifest(evidence);
+        } catch (writeError) {
+          throw new Error(
+            `${failure.message}; could not save failure evidence: ${writeError.message}`,
+            { cause: writeError },
+          );
+        }
+      }
+      throw failure;
     }
-    throw failure;
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
+    }
+    throw error;
   }
 }
 
-run().catch((error) => {
-  process.stderr.write(`export-agentx: ${error.message}\n`);
-  process.exitCode = 1;
+await runCli({
+  command: 'export-agentx',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => run(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -330,7 +330,7 @@ async function exportPowerx(values, isl, osl, url, evidence, signal) {
   });
   const response = await requestBoundary(
     () => fetch(url, { signal: budget.signal, redirect: 'error' }),
-    signal,
+    budget.signal,
   );
   if (evidence) {
     const captured = {
@@ -345,7 +345,7 @@ async function exportPowerx(values, isl, osl, url, evidence, signal) {
   }
   let bytes;
   try {
-    bytes = await responseBoundary(() => budget.read(response), signal);
+    bytes = await responseBoundary(() => budget.read(response), budget.signal);
   } catch (error) {
     if (error instanceof CliError && ['CANCELLED', 'TIMEOUT'].includes(error.code)) throw error;
     if (!response.ok) throw httpError(response.status, `HTTP ${response.status} (${url.href})`);

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -5,6 +5,16 @@ import { lstat, mkdir, readlink, realpath, rename, rm, writeFile } from 'node:fs
 import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  responseError,
+  runCli,
+  writeStdout,
+} from './cli-contract.mjs';
 import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; the packed-artifact test checks this version.
@@ -22,6 +32,7 @@ Options:
   --format <format>   csv (default) or json
   --output <file>     Output file relative to the current directory; default stdout
   --evidence-dir <dir> Save the consumed response and manifest in a new directory
+  --error-format <mode> Failure diagnostics: text (default) or json
   --version          Show the installed package version offline
   --help             Show this help without making a request
 
@@ -171,135 +182,149 @@ async function saveManifest(evidence) {
   await rename(temporary, join(evidence.directory, 'manifest.json'));
 }
 
-async function run(args = process.argv.slice(2)) {
-  const { values } = parseArgs({
-    args,
-    options: {
-      model: { type: 'string' },
-      isl: { type: 'string' },
-      osl: { type: 'string' },
-      date: { type: 'string' },
-      'raw-model': { type: 'string' },
-      format: { type: 'string', default: 'csv' },
-      output: { type: 'string' },
-      'evidence-dir': { type: 'string' },
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-    allowPositionals: false,
-    strict: true,
-  });
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) {
-    process.stdout.write(HELP);
-    return;
-  }
-  if (!values.model?.trim()) throw new Error('--model requires a display model name');
-  const isl = positiveInteger(values.isl, 'isl');
-  const osl = positiveInteger(values.osl, 'osl');
-  if (values.date !== undefined && !validDate(values.date)) {
-    throw new Error('--date must be a valid YYYY-MM-DD date');
-  }
-  if (values['raw-model'] !== undefined && !values['raw-model'].trim()) {
-    throw new Error('--raw-model requires a returned model key');
-  }
-  if (!['csv', 'json'].includes(values.format)) throw new Error('--format must be csv or json');
-  if (values.output !== undefined && !values.output.trim()) {
-    throw new Error('--output requires a file path');
-  }
-  if (values['evidence-dir'] !== undefined && !values['evidence-dir'].trim()) {
-    throw new Error('--evidence-dir requires a new directory path');
-  }
-
-  const url = new URL('https://inferencex.semianalysis.com/api/v1/benchmarks');
-  url.searchParams.set('model', values.model);
-  if (values.date !== undefined) url.searchParams.set('date', values.date);
-  url.searchParams.set('powerValid', 'strictV2');
-  let evidence;
-  if (values['evidence-dir'] !== undefined) {
-    const directory = resolve(values['evidence-dir']);
-    if (values.output !== undefined) {
-      // Reserve case-only aliases too, so the export is safe on case-insensitive filesystems.
-      let evidencePath = await physicalPath(directory);
-      let outputPath = await physicalPath(resolve(values.output));
-      evidencePath = evidencePath.toLowerCase();
-      outputPath = outputPath.toLowerCase();
-      const withinEvidence = relative(evidencePath, outputPath);
-      if (
-        withinEvidence === '' ||
-        ['response.json', 'manifest.json', 'manifest.tmp'].some(
-          (file) => withinEvidence === file || withinEvidence.startsWith(`${file}${sep}`),
-        ) ||
-        evidencePath.startsWith(`${outputPath}${sep}`)
-      ) {
-        throw new Error(
-          '--output collides with the evidence directory or a reserved evidence file',
-        );
-      }
-    }
-    await mkdir(dirname(directory), { recursive: true });
-    await mkdir(directory); // EEXIST also refuses empty directories and symlinks.
-    evidence = {
-      directory,
-      manifest: {
-        schema_version: 1,
-        package_version: PACKAGE_VERSION,
-        status: 'pending',
-        request: {
-          url: url.href,
-          method: 'GET',
-          filters: {
-            model: values.model,
-            date: values.date ?? null,
-            powerValid: 'strictV2',
-            benchmark_type: 'single_turn',
-            isl,
-            osl,
-            raw_model: values['raw-model'] ?? null,
-          },
-        },
-        response: null,
-        export: {
-          format: values.format,
-          destination: values.output === undefined ? 'stdout' : resolve(values.output),
-          sha256: null,
-          metadata: null,
-        },
-      },
-    };
-    await saveManifest(evidence);
-  }
+async function run(args, signal) {
+  let argumentsValidated = false;
   try {
-    await exportPowerx(values, isl, osl, url, evidence);
-  } catch (error) {
-    if (evidence) {
-      evidence.manifest.status = 'failed';
-      evidence.manifest.error = error.message;
-      try {
-        await saveManifest(evidence);
-      } catch (writeError) {
-        throw new Error(
-          `${error.message}; could not save failure evidence: ${writeError.message}`,
-          {
-            cause: writeError,
-          },
-        );
+    const { values } = parseArgs({
+      args,
+      options: {
+        model: { type: 'string' },
+        isl: { type: 'string' },
+        osl: { type: 'string' },
+        date: { type: 'string' },
+        'raw-model': { type: 'string' },
+        format: { type: 'string', default: 'csv' },
+        output: { type: 'string' },
+        'evidence-dir': { type: 'string' },
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
+      },
+      allowPositionals: false,
+      strict: true,
+    });
+    if (values.version) {
+      await writeStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
+    }
+    if (values.help) {
+      await writeStdout(HELP, { signal });
+      return;
+    }
+    if (!values.model?.trim()) throw new Error('--model requires a display model name');
+    const isl = positiveInteger(values.isl, 'isl');
+    const osl = positiveInteger(values.osl, 'osl');
+    if (values.date !== undefined && !validDate(values.date)) {
+      throw new Error('--date must be a valid YYYY-MM-DD date');
+    }
+    if (values['raw-model'] !== undefined && !values['raw-model'].trim()) {
+      throw new Error('--raw-model requires a returned model key');
+    }
+    if (!['csv', 'json'].includes(values.format)) throw new Error('--format must be csv or json');
+    if (values.output !== undefined && !values.output.trim()) {
+      throw new Error('--output requires a file path');
+    }
+    if (values['evidence-dir'] !== undefined && !values['evidence-dir'].trim()) {
+      throw new Error('--evidence-dir requires a new directory path');
+    }
+    argumentsValidated = true;
+
+    const url = new URL('https://inferencex.semianalysis.com/api/v1/benchmarks');
+    url.searchParams.set('model', values.model);
+    if (values.date !== undefined) url.searchParams.set('date', values.date);
+    url.searchParams.set('powerValid', 'strictV2');
+    let evidence;
+    if (values['evidence-dir'] !== undefined) {
+      const directory = resolve(values['evidence-dir']);
+      if (values.output !== undefined) {
+        // Reserve case-only aliases too, so the export is safe on case-insensitive filesystems.
+        let evidencePath = await physicalPath(directory);
+        let outputPath = await physicalPath(resolve(values.output));
+        evidencePath = evidencePath.toLowerCase();
+        outputPath = outputPath.toLowerCase();
+        const withinEvidence = relative(evidencePath, outputPath);
+        if (
+          withinEvidence === '' ||
+          ['response.json', 'manifest.json', 'manifest.tmp'].some(
+            (file) => withinEvidence === file || withinEvidence.startsWith(`${file}${sep}`),
+          ) ||
+          evidencePath.startsWith(`${outputPath}${sep}`)
+        ) {
+          throw new Error(
+            '--output collides with the evidence directory or a reserved evidence file',
+          );
+        }
       }
+      await mkdir(dirname(directory), { recursive: true });
+      await mkdir(directory); // EEXIST also refuses empty directories and symlinks.
+      evidence = {
+        directory,
+        manifest: {
+          schema_version: 1,
+          package_version: PACKAGE_VERSION,
+          status: 'pending',
+          request: {
+            url: url.href,
+            method: 'GET',
+            filters: {
+              model: values.model,
+              date: values.date ?? null,
+              powerValid: 'strictV2',
+              benchmark_type: 'single_turn',
+              isl,
+              osl,
+              raw_model: values['raw-model'] ?? null,
+            },
+          },
+          response: null,
+          export: {
+            format: values.format,
+            destination: values.output === undefined ? 'stdout' : resolve(values.output),
+            sha256: null,
+            metadata: null,
+          },
+        },
+      };
+      await saveManifest(evidence);
+    }
+    try {
+      await exportPowerx(values, isl, osl, url, evidence, signal);
+    } catch (error) {
+      if (evidence) {
+        evidence.manifest.status = 'failed';
+        evidence.manifest.error = error.message;
+        try {
+          await saveManifest(evidence);
+        } catch (writeError) {
+          throw new Error(
+            `${error.message}; could not save failure evidence: ${writeError.message}`,
+            {
+              cause: writeError,
+            },
+          );
+        }
+      }
+      throw error;
+    }
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
     }
     throw error;
   }
 }
 
-async function exportPowerx(values, isl, osl, url, evidence) {
+async function exportPowerx(values, isl, osl, url, evidence, signal) {
   const budget = createResponseBudget({
     responseBytes: 32 * 1024 * 1024,
     totalBytes: 32 * 1024 * 1024,
     timeoutMs: 30_000,
+    signal,
   });
-  const response = await fetch(url, { signal: budget.signal, redirect: 'error' });
+  const response = await requestBoundary(
+    () => fetch(url, { signal: budget.signal, redirect: 'error' }),
+    signal,
+  );
   if (evidence) {
     const captured = {
       status: response.status,
@@ -311,7 +336,13 @@ async function exportPowerx(values, isl, osl, url, evidence) {
     evidence.manifest.response = captured;
     // fetch decodes HTTP compression; save and parse these same bytes, without refetching.
   }
-  const bytes = await budget.read(response);
+  let bytes;
+  try {
+    bytes = await responseBoundary(() => budget.read(response), signal);
+  } catch (error) {
+    if (!response.ok) throw httpError(response.status, `HTTP ${response.status} (${url.href})`);
+    throw error;
+  }
   if (evidence) {
     await writeFile(join(evidence.directory, 'response.json'), bytes, { flag: 'wx' });
     evidence.manifest.response.body_file = 'response.json';
@@ -321,7 +352,8 @@ async function exportPowerx(values, isl, osl, url, evidence) {
   try {
     capturedBody = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
   } catch (error) {
-    throw new Error('Benchmark response is not valid UTF-8', { cause: error });
+    if (response.ok) throw responseError('Benchmark response is not valid UTF-8', error);
+    capturedBody = '';
   }
   if (!response.ok) {
     let body;
@@ -331,19 +363,22 @@ async function exportPowerx(values, isl, osl, url, evidence) {
       body = null;
     }
     const detail = typeof body?.error === 'string' ? `: ${body.error.slice(0, 300)}` : '';
-    throw new Error(`HTTP ${response.status}${detail} (${url.href})`);
+    throw httpError(response.status, `HTTP ${response.status}${detail} (${url.href})`);
   }
-  let rows;
-  try {
-    rows = JSON.parse(capturedBody);
-  } catch (error) {
-    throw new Error(`Could not read benchmark JSON: ${error.message}`, { cause: error });
-  }
-  if (!Array.isArray(rows) || rows.some((row) => !benchmarkRow(row))) {
-    throw new Error(
-      'Unexpected response shape: expected benchmark rows with required identity, configuration, workload, date, run_url, and metrics fields',
-    );
-  }
+  const rows = await responseBoundary(() => {
+    let parsed;
+    try {
+      parsed = JSON.parse(capturedBody);
+    } catch (error) {
+      throw new Error(`Could not read benchmark JSON: ${error.message}`, { cause: error });
+    }
+    if (!Array.isArray(parsed) || parsed.some((row) => !benchmarkRow(row))) {
+      throw new Error(
+        'Unexpected response shape: expected benchmark rows with required identity, configuration, workload, date, run_url, and metrics fields',
+      );
+    }
+    return parsed;
+  }, signal);
   const scoped = rows.filter(
     (row) =>
       row.benchmark_type === 'single_turn' &&
@@ -395,7 +430,7 @@ async function exportPowerx(values, isl, osl, url, evidence) {
   };
   let output;
   if (values.format === 'json') {
-    output = `${JSON.stringify({ metadata, rows: observations }, null, 2)}\n`;
+    output = `${JSON.stringify({ schema_version: 1, metadata, rows: observations }, null, 2)}\n`;
   } else {
     const requestColumns = [
       'package_version',
@@ -428,10 +463,7 @@ async function exportPowerx(values, isl, osl, url, evidence) {
   }
   if (values.output === undefined) {
     // A closed consumer is a failed export, even if response capture already succeeded.
-    process.stdout.on('error', () => {});
-    await new Promise((resolveWrite, reject) => {
-      process.stdout.write(output, (error) => (error ? reject(error) : resolveWrite()));
-    });
+    await writeStdout(output, { signal });
   } else {
     // Follow existing output symlinks, preserving the previous writeFile destination semantics.
     const destination = await physicalPath(resolve(values.output));
@@ -444,14 +476,18 @@ async function exportPowerx(values, isl, osl, url, evidence) {
     } catch (error) {
       if (error.code !== 'ENOENT') throw error;
     }
-    try {
-      await writeFile(temporary, output, { encoding: 'utf8', flag: 'wx', mode });
-      await rename(temporary, destination);
-    } finally {
-      await rm(temporary, { force: true });
-    }
+    await outputBoundary(async () => {
+      try {
+        await writeFile(temporary, output, { encoding: 'utf8', flag: 'wx', mode });
+        signal.throwIfAborted();
+        await rename(temporary, destination);
+      } finally {
+        await rm(temporary, { force: true });
+      }
+    }, signal);
   }
   if (evidence) {
+    signal.throwIfAborted();
     evidence.manifest.status = 'complete';
     await saveManifest(evidence);
   }
@@ -477,7 +513,8 @@ async function exportPowerx(values, isl, osl, url, evidence) {
   }
 }
 
-run().catch((error) => {
-  process.stderr.write(`export-powerx: ${error.message}\n`);
-  process.exitCode = 1;
+await runCli({
+  command: 'export-powerx',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => run(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -19,7 +19,7 @@ import {
 import { createResponseBudget } from './response-budget.mjs';
 
 // Installed skills run independently of package.json; the packed-artifact test checks this version.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const HELP = `export-powerx — export validated single-turn PowerX observations
 
 Requires Node 24 or later.

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -178,9 +178,11 @@ async function physicalPath(path) {
 }
 
 async function saveManifest(evidence) {
-  const temporary = join(evidence.directory, 'manifest.tmp');
-  await writeFile(temporary, `${JSON.stringify(evidence.manifest, null, 2)}\n`, 'utf8');
-  await rename(temporary, join(evidence.directory, 'manifest.json'));
+  await outputBoundary(async () => {
+    const temporary = join(evidence.directory, 'manifest.tmp');
+    await writeFile(temporary, `${JSON.stringify(evidence.manifest, null, 2)}\n`, 'utf8');
+    await rename(temporary, join(evidence.directory, 'manifest.json'));
+  });
 }
 
 async function run(args, signal) {
@@ -239,8 +241,8 @@ async function run(args, signal) {
       const directory = resolve(values['evidence-dir']);
       if (values.output !== undefined) {
         // Reserve case-only aliases too, so the export is safe on case-insensitive filesystems.
-        let evidencePath = await physicalPath(directory);
-        let outputPath = await physicalPath(resolve(values.output));
+        let evidencePath = await outputBoundary(() => physicalPath(directory), signal);
+        let outputPath = await outputBoundary(() => physicalPath(resolve(values.output)), signal);
         evidencePath = evidencePath.toLowerCase();
         outputPath = outputPath.toLowerCase();
         const withinEvidence = relative(evidencePath, outputPath);
@@ -251,13 +253,15 @@ async function run(args, signal) {
           ) ||
           evidencePath.startsWith(`${outputPath}${sep}`)
         ) {
-          throw new Error(
+          throw argumentError(
             '--output collides with the evidence directory or a reserved evidence file',
           );
         }
       }
-      await mkdir(dirname(directory), { recursive: true });
-      await mkdir(directory); // EEXIST also refuses empty directories and symlinks.
+      await outputBoundary(async () => {
+        await mkdir(dirname(directory), { recursive: true });
+        await mkdir(directory); // EEXIST also refuses empty directories and symlinks.
+      }, signal);
       evidence = {
         directory,
         manifest: {
@@ -297,10 +301,12 @@ async function run(args, signal) {
         try {
           await saveManifest(evidence);
         } catch (writeError) {
-          throw new Error(
+          throw new CliError(
+            error instanceof CliError ? error.code : 'INTERNAL_ERROR',
             `${error.message}; could not save failure evidence: ${writeError.message}`,
             {
-              cause: writeError,
+              cause: error,
+              httpStatus: error.httpStatus,
             },
           );
         }
@@ -346,7 +352,10 @@ async function exportPowerx(values, isl, osl, url, evidence, signal) {
     throw error;
   }
   if (evidence) {
-    await writeFile(join(evidence.directory, 'response.json'), bytes, { flag: 'wx' });
+    await outputBoundary(
+      () => writeFile(join(evidence.directory, 'response.json'), bytes, { flag: 'wx' }),
+      signal,
+    );
     evidence.manifest.response.body_file = 'response.json';
     evidence.manifest.response.sha256 = createHash('sha256').update(bytes).digest('hex');
   }
@@ -463,31 +472,32 @@ async function exportPowerx(values, isl, osl, url, evidence, signal) {
     evidence.manifest.export.sha256 = createHash('sha256').update(output).digest('hex');
     evidence.manifest.export.metadata = metadata;
   }
-  if (values.output === undefined) {
-    // A closed consumer is a failed export, even if response capture already succeeded.
-    await writeStdout(output, { signal });
-  } else {
-    // Follow existing output symlinks, preserving the previous writeFile destination semantics.
-    const destination = await physicalPath(resolve(values.output));
-    const temporary = join(dirname(destination), `.${basename(destination)}.${randomUUID()}.tmp`);
-    let mode;
-    try {
-      const existing = await lstat(destination);
-      if (!existing.isFile()) throw new Error('--output must name a regular file');
-      mode = existing.mode & 0o777;
-    } catch (error) {
-      if (error.code !== 'ENOENT') throw error;
-    }
-    await outputBoundary(async () => {
-      try {
-        await writeFile(temporary, output, { encoding: 'utf8', flag: 'wx', mode });
-        signal.throwIfAborted();
-        await rename(temporary, destination);
-      } finally {
-        await rm(temporary, { force: true });
-      }
-    }, signal);
-  }
+  // A closed consumer is a failed export, even if response capture already succeeded.
+  await (values.output === undefined
+    ? writeStdout(output, { signal })
+    : outputBoundary(async () => {
+        // Follow existing output symlinks, preserving the previous writeFile destination semantics.
+        const destination = await physicalPath(resolve(values.output));
+        const temporary = join(
+          dirname(destination),
+          `.${basename(destination)}.${randomUUID()}.tmp`,
+        );
+        let mode;
+        try {
+          const existing = await lstat(destination);
+          if (!existing.isFile()) throw new Error('--output must name a regular file');
+          mode = existing.mode & 0o777;
+        } catch (error) {
+          if (error.code !== 'ENOENT') throw error;
+        }
+        try {
+          await writeFile(temporary, output, { encoding: 'utf8', flag: 'wx', mode });
+          signal.throwIfAborted();
+          await rename(temporary, destination);
+        } finally {
+          await rm(temporary, { force: true });
+        }
+      }, signal));
   if (evidence) {
     signal.throwIfAborted();
     evidence.manifest.status = 'complete';

--- a/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/export-powerx.mjs
@@ -7,6 +7,7 @@ import process from 'node:process';
 import { parseArgs } from 'node:util';
 import {
   argumentError,
+  CliError,
   httpError,
   outputBoundary,
   requestBoundary,
@@ -340,6 +341,7 @@ async function exportPowerx(values, isl, osl, url, evidence, signal) {
   try {
     bytes = await responseBoundary(() => budget.read(response), signal);
   } catch (error) {
+    if (error instanceof CliError && ['CANCELLED', 'TIMEOUT'].includes(error.code)) throw error;
     if (!response.ok) throw httpError(response.status, `HTTP ${response.status} (${url.href})`);
     throw error;
   }

--- a/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
@@ -6,6 +6,7 @@ import { basename, dirname, join, resolve } from 'node:path';
 import { parseArgs } from 'node:util';
 import {
   argumentError,
+  CliError,
   httpError,
   outputBoundary,
   requestBoundary,
@@ -195,6 +196,7 @@ async function fetchJson(path, query, operation, evidence, budget, signal, allow
       return Buffer.concat(chunks);
     }, requestSignal);
   } catch (error) {
+    if (error instanceof CliError && ['CANCELLED', 'TIMEOUT'].includes(error.code)) throw error;
     if (!response.ok && !(allowNotFound && response.status === 404)) {
       throw httpError(response.status, `${operation}: HTTP ${response.status} (${url.href})`);
     }

--- a/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
@@ -17,7 +17,7 @@ import {
 } from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 const API_ORIGIN = 'https://inferencex.semianalysis.com';
 const RESPONSE_BYTE_BUDGET = 16 * 1024 * 1024;
 const HELP = `investigate-result — collect existing benchmark provenance and one bounded log window

--- a/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/investigate-result.mjs
@@ -3,8 +3,17 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { rename, rm, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
-import process from 'node:process';
 import { parseArgs } from 'node:util';
+import {
+  argumentError,
+  httpError,
+  outputBoundary,
+  requestBoundary,
+  responseBoundary,
+  responseError,
+  runCli,
+  writeStdout,
+} from './cli-contract.mjs';
 
 // Installed skills run independently of package.json; release preparation updates this version.
 const PACKAGE_VERSION = '0.9.0';
@@ -24,6 +33,7 @@ Options:
   --log-offset <n>    Character offset, 0-2000000000 (default 0)
   --log-limit <n>     Characters to inspect, 1-262144 (default 16384)
   --output <file>     Save JSON atomically; default stdout
+  --error-format <mode> Failure diagnostics: text (default) or json
   --version          Show the installed package version offline
   --help             Show help without making requests
 
@@ -157,22 +167,46 @@ function githubRun(value) {
   };
 }
 
-async function fetchJson(path, query, operation, evidence, budget, allowNotFound = false) {
+async function fetchJson(path, query, operation, evidence, budget, signal, allowNotFound = false) {
   const url = new URL(path, API_ORIGIN);
   for (const [key, value] of Object.entries(query))
     if (value !== undefined) url.searchParams.set(key, String(value));
-  const response = await fetch(url, { redirect: 'error', signal: AbortSignal.timeout(30_000) });
+  const requestSignal = AbortSignal.any([AbortSignal.timeout(30_000), signal]);
+  const response = await requestBoundary(
+    () =>
+      fetch(url, {
+        redirect: 'error',
+        signal: requestSignal,
+      }),
+    requestSignal,
+  );
   if (response.redirected || (response.url && response.url !== url.href)) {
     throw new Error(`Unexpected response URL for ${operation}`);
   }
-  const chunks = [];
-  for await (const chunk of response.body ?? []) {
-    budget.remaining -= chunk.byteLength;
-    if (budget.remaining < 0) throw new Error('Exceeded the 16 MiB response byte budget');
-    chunks.push(chunk);
+  let bytes;
+  try {
+    bytes = await responseBoundary(async () => {
+      const chunks = [];
+      for await (const chunk of response.body ?? []) {
+        budget.remaining -= chunk.byteLength;
+        if (budget.remaining < 0) throw new Error('Exceeded the 16 MiB response byte budget');
+        chunks.push(chunk);
+      }
+      return Buffer.concat(chunks);
+    }, requestSignal);
+  } catch (error) {
+    if (!response.ok && !(allowNotFound && response.status === 404)) {
+      throw httpError(response.status, `${operation}: HTTP ${response.status} (${url.href})`);
+    }
+    throw error;
   }
-  const bytes = Buffer.concat(chunks);
-  const body = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+  let body;
+  try {
+    body = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(bytes);
+  } catch (error) {
+    if (response.ok) throw responseError(`${operation} response is not valid UTF-8`, error);
+    body = '';
+  }
   evidence.push({
     operation,
     url: url.href,
@@ -183,7 +217,7 @@ async function fetchJson(path, query, operation, evidence, budget, allowNotFound
     checksum_covers: 'exact decoded UTF-8 response body',
   });
   if (!response.ok && !(allowNotFound && response.status === 404)) {
-    throw new Error(`${operation}: HTTP ${response.status} (${url.href})`);
+    throw httpError(response.status, `${operation}: HTTP ${response.status} (${url.href})`);
   }
   let value;
   try {
@@ -299,186 +333,202 @@ function logWindow(value, id, offset, limit, file) {
   };
 }
 
-async function saveOutput(path, bytes) {
+async function saveOutput(path, bytes, signal) {
   if (path === undefined) {
-    process.stdout.on('error', () => {});
-    await new Promise((done, reject) => {
-      process.stdout.write(bytes, (error) => (error ? reject(error) : done()));
-    });
+    await writeStdout(bytes, { signal });
     return;
   }
   const target = resolve(path);
   const temporary = join(dirname(target), `.${basename(target)}.${randomUUID()}.tmp`);
+  await outputBoundary(async () => {
+    try {
+      await writeFile(temporary, bytes, { flag: 'wx' });
+      signal.throwIfAborted();
+      await rename(temporary, target);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+  }, signal);
+}
+
+async function main(args, signal) {
+  let argumentsValidated = false;
   try {
-    await writeFile(temporary, bytes, { flag: 'wx' });
-    await rename(temporary, target);
-  } finally {
-    await rm(temporary, { force: true });
+    const { values } = parseArgs({
+      args,
+      options: {
+        id: { type: 'string' },
+        model: { type: 'string' },
+        date: { type: 'string' },
+        'run-id': { type: 'string' },
+        'log-file': { type: 'string' },
+        'log-offset': { type: 'string', default: '0' },
+        'log-limit': { type: 'string', default: '16384' },
+        output: { type: 'string' },
+        version: { type: 'boolean' },
+        help: { type: 'boolean' },
+        'error-format': { type: 'string' },
+      },
+      strict: true,
+      allowPositionals: false,
+    });
+    if (values.version) {
+      await writeStdout(`${PACKAGE_VERSION}\n`, { signal });
+      return;
+    }
+    if (values.help) {
+      await saveOutput(undefined, HELP, signal);
+      return;
+    }
+    integerOption(values.id, 'id', 1, Number.MAX_SAFE_INTEGER);
+    if (!values.model?.trim()) throw new Error('--model requires a display model name');
+    if (values.date !== undefined && !validDate(values.date))
+      throw new Error('--date must be a valid YYYY-MM-DD date');
+    if (values['run-id'] !== undefined)
+      integerOption(values['run-id'], 'run-id', 1, Number.MAX_SAFE_INTEGER);
+    if (values.date !== undefined && values['run-id'] !== undefined)
+      throw new Error('cannot combine --date and --run-id');
+    const offset = integerOption(values['log-offset'], 'log-offset', 0, 2_000_000_000);
+    const limit = integerOption(values['log-limit'], 'log-limit', 1, 262_144);
+    const file = values['log-file'];
+    if (file !== undefined && (file.length === 0 || file.length > 1024 || file.includes('\0'))) {
+      throw new Error('--log-file must contain 1-1024 characters without NUL');
+    }
+    if (values.output !== undefined && !values.output.trim())
+      throw new Error('--output requires a file path');
+    argumentsValidated = true;
+    await responseBoundary(async () => {
+      const evidence = [];
+      const budget = { remaining: RESPONSE_BYTE_BUDGET };
+      const rows = await fetchJson(
+        '/api/v1/benchmarks',
+        {
+          model: values.model,
+          date: values.date,
+          runId: values['run-id'],
+          exactRun: values['run-id'] === undefined ? undefined : true,
+        },
+        'benchmarks',
+        evidence,
+        budget,
+        signal,
+      );
+      if (!Array.isArray(rows) || rows.some((row) => !benchmarkRow(row)))
+        throw new Error('Invalid benchmark row response');
+      const selected = rows.filter((row) => String(row.id) === values.id);
+      if (selected.length !== 1)
+        throw new Error(
+          `Expected exactly one result with ID ${values.id} in the supplied model/snapshot scope; found ${selected.length}`,
+        );
+      const row = selected[0];
+      if (
+        values.date !== undefined &&
+        (row.date > values.date || (row.curve_date !== undefined && row.curve_date > values.date))
+      ) {
+        throw new Error('Selected result contradicts the requested as-of cutoff');
+      }
+      if (row.curve_date !== undefined && row.curve_date < row.date) {
+        throw new Error('Selected curve snapshot predates its producer');
+      }
+      const identity = githubRun(row.run_url);
+      const limitations = [
+        'Existing public observations only; these records do not establish performance causality.',
+        'Log evidence covers one selected file window; other files and characters were not inspected.',
+        'workflow_run_id and curve_workflow_run_id are internal identities, not GitHub run IDs.',
+      ];
+      let producer = {
+        status: 'unresolved',
+        github_run_id: null,
+        run_attempt: null,
+        workflow_run: null,
+        run_configs: [],
+      };
+      if (identity) {
+        const info = await fetchJson(
+          '/api/v1/workflow-info',
+          {
+            date: row.date,
+            benchmarkType: row.benchmark_type === 'agentic_traces' ? 'agentic_traces' : undefined,
+          },
+          'workflow-info',
+          evidence,
+          budget,
+          signal,
+        );
+        const metadata = workflowMetadata(info, row, identity);
+        producer = {
+          status: metadata.workflow_run ? 'confirmed' : 'row_only',
+          github_run_id: identity.github_run_id,
+          run_attempt: identity.run_attempt,
+          ...metadata,
+        };
+        if (!metadata.workflow_run)
+          limitations.push(
+            'The public latest-attempt workflow listing did not confirm the producing attempt.',
+          );
+        if (metadata.run_configs.length === 0)
+          limitations.push(
+            'No matching producer config was confirmed in workflow-info; selected_result retains the original config and image.',
+          );
+      } else {
+        limitations.push(
+          'The selected run_url is null; the public response cannot identify its GitHub producer or attempt.',
+        );
+      }
+      if (row.image === null)
+        limitations.push('The selected row has no image; no image identity was inferred.');
+      const log = logWindow(
+        await fetchJson(
+          '/api/v1/server-log',
+          { id: values.id, offset, limit, file },
+          'server-log',
+          evidence,
+          budget,
+          signal,
+          true,
+        ),
+        values.id,
+        offset,
+        limit,
+        file,
+      );
+      const report = {
+        schema_version: 1,
+        metadata: {
+          package_version: PACKAGE_VERSION,
+          selected_result_id: values.id,
+          ran_new_benchmark: false,
+          scope: {
+            display_model: values.model,
+            date: values.date ?? null,
+            github_run_id: values['run-id'] ?? null,
+            selection:
+              values['run-id'] === undefined
+                ? values.date === undefined
+                  ? 'latest_snapshot'
+                  : 'as_of_snapshot'
+                : 'logical_run_snapshot',
+          },
+          log_window: { file: file ?? null, offset, limit, offset_unit: 'Unicode characters' },
+        },
+        selected_result: row,
+        producer,
+        log,
+        limitations,
+        evidence,
+      };
+      await saveOutput(values.output, `${JSON.stringify(report, null, 2)}\n`, signal);
+    }, signal);
+  } catch (error) {
+    if (!argumentsValidated && error?.code !== 'CANCELLED' && error?.code !== 'OUTPUT_ERROR') {
+      throw argumentError(error.message, error);
+    }
+    throw error;
   }
 }
 
-async function main() {
-  const { values } = parseArgs({
-    options: {
-      id: { type: 'string' },
-      model: { type: 'string' },
-      date: { type: 'string' },
-      'run-id': { type: 'string' },
-      'log-file': { type: 'string' },
-      'log-offset': { type: 'string', default: '0' },
-      'log-limit': { type: 'string', default: '16384' },
-      output: { type: 'string' },
-      version: { type: 'boolean' },
-      help: { type: 'boolean' },
-    },
-    strict: true,
-    allowPositionals: false,
-  });
-  if (values.version) {
-    process.stdout.write(`${PACKAGE_VERSION}\n`);
-    return;
-  }
-  if (values.help) {
-    await saveOutput(undefined, HELP);
-    return;
-  }
-  integerOption(values.id, 'id', 1, Number.MAX_SAFE_INTEGER);
-  if (!values.model?.trim()) throw new Error('--model requires a display model name');
-  if (values.date !== undefined && !validDate(values.date))
-    throw new Error('--date must be a valid YYYY-MM-DD date');
-  if (values['run-id'] !== undefined)
-    integerOption(values['run-id'], 'run-id', 1, Number.MAX_SAFE_INTEGER);
-  if (values.date !== undefined && values['run-id'] !== undefined)
-    throw new Error('cannot combine --date and --run-id');
-  const offset = integerOption(values['log-offset'], 'log-offset', 0, 2_000_000_000);
-  const limit = integerOption(values['log-limit'], 'log-limit', 1, 262_144);
-  const file = values['log-file'];
-  if (file !== undefined && (file.length === 0 || file.length > 1024 || file.includes('\0'))) {
-    throw new Error('--log-file must contain 1-1024 characters without NUL');
-  }
-  if (values.output !== undefined && !values.output.trim())
-    throw new Error('--output requires a file path');
-
-  const evidence = [];
-  const budget = { remaining: RESPONSE_BYTE_BUDGET };
-  const rows = await fetchJson(
-    '/api/v1/benchmarks',
-    {
-      model: values.model,
-      date: values.date,
-      runId: values['run-id'],
-      exactRun: values['run-id'] === undefined ? undefined : true,
-    },
-    'benchmarks',
-    evidence,
-    budget,
-  );
-  if (!Array.isArray(rows) || rows.some((row) => !benchmarkRow(row)))
-    throw new Error('Invalid benchmark row response');
-  const selected = rows.filter((row) => String(row.id) === values.id);
-  if (selected.length !== 1)
-    throw new Error(
-      `Expected exactly one result with ID ${values.id} in the supplied model/snapshot scope; found ${selected.length}`,
-    );
-  const row = selected[0];
-  if (
-    values.date !== undefined &&
-    (row.date > values.date || (row.curve_date !== undefined && row.curve_date > values.date))
-  ) {
-    throw new Error('Selected result contradicts the requested as-of cutoff');
-  }
-  if (row.curve_date !== undefined && row.curve_date < row.date) {
-    throw new Error('Selected curve snapshot predates its producer');
-  }
-  const identity = githubRun(row.run_url);
-  const limitations = [
-    'Existing public observations only; these records do not establish performance causality.',
-    'Log evidence covers one selected file window; other files and characters were not inspected.',
-    'workflow_run_id and curve_workflow_run_id are internal identities, not GitHub run IDs.',
-  ];
-  let producer = {
-    status: 'unresolved',
-    github_run_id: null,
-    run_attempt: null,
-    workflow_run: null,
-    run_configs: [],
-  };
-  if (identity) {
-    const info = await fetchJson(
-      '/api/v1/workflow-info',
-      {
-        date: row.date,
-        benchmarkType: row.benchmark_type === 'agentic_traces' ? 'agentic_traces' : undefined,
-      },
-      'workflow-info',
-      evidence,
-      budget,
-    );
-    const metadata = workflowMetadata(info, row, identity);
-    producer = {
-      status: metadata.workflow_run ? 'confirmed' : 'row_only',
-      github_run_id: identity.github_run_id,
-      run_attempt: identity.run_attempt,
-      ...metadata,
-    };
-    if (!metadata.workflow_run)
-      limitations.push(
-        'The public latest-attempt workflow listing did not confirm the producing attempt.',
-      );
-    if (metadata.run_configs.length === 0)
-      limitations.push(
-        'No matching producer config was confirmed in workflow-info; selected_result retains the original config and image.',
-      );
-  } else {
-    limitations.push(
-      'The selected run_url is null; the public response cannot identify its GitHub producer or attempt.',
-    );
-  }
-  if (row.image === null)
-    limitations.push('The selected row has no image; no image identity was inferred.');
-  const log = logWindow(
-    await fetchJson(
-      '/api/v1/server-log',
-      { id: values.id, offset, limit, file },
-      'server-log',
-      evidence,
-      budget,
-      true,
-    ),
-    values.id,
-    offset,
-    limit,
-    file,
-  );
-  const report = {
-    schema_version: 1,
-    metadata: {
-      package_version: PACKAGE_VERSION,
-      selected_result_id: values.id,
-      ran_new_benchmark: false,
-      scope: {
-        display_model: values.model,
-        date: values.date ?? null,
-        github_run_id: values['run-id'] ?? null,
-        selection:
-          values['run-id'] === undefined
-            ? values.date === undefined
-              ? 'latest_snapshot'
-              : 'as_of_snapshot'
-            : 'logical_run_snapshot',
-      },
-      log_window: { file: file ?? null, offset, limit, offset_unit: 'Unicode characters' },
-    },
-    selected_result: row,
-    producer,
-    log,
-    limitations,
-    evidence,
-  };
-  await saveOutput(values.output, `${JSON.stringify(report, null, 2)}\n`);
-}
-
-main().catch((error) => {
-  process.stderr.write(`investigate-result: ${error.message}\n`);
-  process.exitCode = 1;
+await runCli({
+  command: 'investigate-result',
+  packageVersion: PACKAGE_VERSION,
+  run: ({ args, signal }) => main(args, signal),
 });

--- a/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
@@ -1,5 +1,5 @@
 // Count decompressed bytes from fetch's stream; Content-Length may describe compressed data.
-const PACKAGE_VERSION = '0.9.0';
+const PACKAGE_VERSION = '0.10.0';
 export { PACKAGE_VERSION };
 
 export function createResponseBudget({

--- a/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
+++ b/packages/skills/skills/inferencex-api/scripts/response-budget.mjs
@@ -2,8 +2,15 @@
 const PACKAGE_VERSION = '0.9.0';
 export { PACKAGE_VERSION };
 
-export function createResponseBudget({ responseBytes, totalBytes, timeoutMs }) {
-  const signal = AbortSignal.timeout(timeoutMs);
+export function createResponseBudget({
+  responseBytes,
+  totalBytes,
+  timeoutMs,
+  signal: cancellation,
+}) {
+  const signal = cancellation
+    ? AbortSignal.any([AbortSignal.timeout(timeoutMs), cancellation])
+    : AbortSignal.timeout(timeoutMs);
   let total = 0;
   return {
     signal,

--- a/packages/skills/test/cli-contract.test.mjs
+++ b/packages/skills/test/cli-contract.test.mjs
@@ -1,0 +1,291 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { packageInfo, packedSkillSuite } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const preload = join(suite.temporaryRoot, 'cli-contract-preload.mjs');
+let scripts;
+
+const cases = [
+  ['export-powerx', ['--model', 'x', '--isl', '1', '--osl', '1']],
+  ['export-agentx', ['--model', 'x']],
+  ['investigate-result', ['--id', '1', '--model', 'x']],
+  [
+    'compare-tco',
+    ['--model', 'x', '--workloads', '1x1', '--target', '1', '--gpu-hourly-prices', 'b200=1'],
+  ],
+  [
+    'compare-releases',
+    [
+      '--model',
+      'x',
+      '--hardware',
+      'b200',
+      '--framework',
+      'sglang',
+      '--isl',
+      '1',
+      '--osl',
+      '1',
+      '--metric',
+      'median_ttft',
+      '--before-date',
+      '2026-09-01',
+      '--after-date',
+      '2026-09-02',
+      '--before-image',
+      'before',
+      '--after-image',
+      'after',
+    ],
+  ],
+  ['compare-collectivex', [], ['--left', '1']],
+];
+
+function run(name, args, mode = 'network') {
+  return suite.node(
+    ['--import', pathToFileURL(preload).href, scripts[name], ...args, '--error-format', 'json'],
+    {
+      env: { ...suite.environment, INFERENCEX_CLI_CONTRACT_MODE: mode },
+    },
+  );
+}
+
+function diagnostic(result, code, status = 1) {
+  assert.equal(result.status, status, `${result.stdout}\n${result.stderr}`);
+  assert.equal(result.stdout, '');
+  const value = JSON.parse(result.stderr);
+  assert.deepEqual(
+    {
+      schema_version: value.schema_version,
+      package: value.package,
+      package_version: value.package_version,
+      code: value.error.code,
+    },
+    {
+      schema_version: 1,
+      package: packageInfo.name,
+      package_version: packageInfo.version,
+      code,
+    },
+    value.command,
+  );
+  assert.equal(typeof value.command, 'string');
+  assert.ok(value.command.length > 0);
+  assert.equal(typeof value.error.message, 'string');
+  assert.ok(value.error.message.length > 0);
+  return value;
+}
+
+before(() => {
+  writeFileSync(
+    preload,
+    `
+import { writeFileSync } from 'node:fs';
+const mode = process.env.INFERENCEX_CLI_CONTRACT_MODE;
+if (mode === 'body-timeout') {
+  const timeout = AbortSignal.timeout;
+  AbortSignal.timeout = milliseconds => {
+    if (milliseconds !== 30_000) return timeout(milliseconds);
+    const controller = new AbortController();
+    setTimeout(
+      () => controller.abort(new DOMException('controlled body timeout', 'TimeoutError')),
+      40,
+    );
+    return controller.signal;
+  };
+}
+if (mode === 'stdout-error') {
+  process.stdout.write = (_bytes, callback) => {
+    queueMicrotask(() => callback(Object.assign(new Error('controlled broken pipe'), { code: 'EPIPE' })));
+    return false;
+  };
+}
+if (mode === 'stdout-stall') process.stdout.write = () => false;
+globalThis.fetch = async (_input, options) => {
+  if (mode === 'network') throw new TypeError('controlled network failure');
+  if (mode === 'timeout') throw new DOMException('controlled timeout', 'TimeoutError');
+  options.signal?.throwIfAborted();
+  if (mode === 'pending') {
+    return await new Promise((_resolve, reject) => {
+      const keepAlive = setInterval(() => {}, 1_000);
+      options.signal.addEventListener('abort', () => {
+        clearInterval(keepAlive);
+        reject(options.signal.reason);
+      }, { once: true });
+      writeFileSync(process.env.INFERENCEX_TEST_READY, 'ready');
+      if (options.signal.aborted) reject(options.signal.reason);
+    });
+  }
+  if (mode === 'body-timeout') {
+    return new Response(new ReadableStream({
+      start(controller) {
+        options.signal.addEventListener('abort', () => controller.error(options.signal.reason), {
+          once: true,
+        });
+      },
+    }), { headers: { 'Content-Type': 'application/json' } });
+  }
+  if (mode === 'http') return new Response('{"error":"unavailable"}', {
+    status: 503, headers: { 'Content-Type': 'application/json' },
+  });
+  if (mode === 'empty') return new Response('[]', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  return new Response('{not json', { headers: { 'Content-Type': 'application/json' } });
+};
+`,
+  );
+  const installed = suite.install('codex');
+  scripts = Object.fromEntries(
+    cases.map(([name]) => [name, join(installed, 'scripts', `${name}.mjs`)]),
+  );
+  scripts.installer = join(installed, '..', '..', '..', 'node_modules', '.bin', 'unused');
+});
+
+test('the packed shared contract exports the typed error and boundary helpers', async () => {
+  const contract = join(scripts['export-powerx'], '..', 'cli-contract.mjs');
+  assert.ok(existsSync(contract));
+  const module = await import(pathToFileURL(contract));
+  for (const name of [
+    'CliError',
+    'argumentError',
+    'diagnostic',
+    'httpError',
+    'requestBoundary',
+    'responseBoundary',
+    'outputBoundary',
+    'writeStdout',
+    'runCli',
+  ]) {
+    assert.equal(typeof module[name], 'function', name);
+  }
+});
+
+test('every packed entry point emits one structured INVALID_ARGUMENT diagnostic', () => {
+  for (const [name, _validArgs, invalidArgs = []] of cases) {
+    diagnostic(run(name, invalidArgs), 'INVALID_ARGUMENT', 2);
+  }
+  const cwd = suite.project();
+  const result = suite.run(['install', '--target', 'unknown', '--error-format', 'json'], cwd);
+  diagnostic(result, 'INVALID_ARGUMENT', 2);
+});
+
+test('every packed entry point rejects an unknown error format', () => {
+  for (const [name] of cases) {
+    const result = suite.node([scripts[name], '--error-format', 'yaml']);
+    assert.notEqual(result.status, 0, name);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /--error-format.*json.*text/iu, name);
+  }
+  const result = suite.run(['install', '--error-format', 'yaml'], suite.project());
+  assert.equal(result.status, 2);
+  assert.equal(result.stdout, '');
+  assert.match(result.stderr, /--error-format.*json.*text/iu);
+});
+
+test('every data helper classifies request, response, HTTP, and stdout boundaries', () => {
+  for (const [name, args] of cases) {
+    diagnostic(run(name, args, 'network'), 'NETWORK_ERROR');
+    diagnostic(run(name, args, 'timeout'), 'TIMEOUT');
+    diagnostic(run(name, args, 'invalid'), 'INVALID_RESPONSE');
+    const http = diagnostic(run(name, args, 'http'), 'HTTP_ERROR');
+    assert.equal(http.error.http_status, 503, name);
+    diagnostic(run(name, ['--help'], 'stdout-error'), 'OUTPUT_ERROR');
+  }
+});
+
+test('PowerX JSON success is additive and preserves a truthful empty selection', () => {
+  const result = run(
+    'export-powerx',
+    ['--model', 'x', '--isl', '1', '--osl', '1', '--format', 'json'],
+    'empty',
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.schema_version, 1);
+  assert.deepEqual(output.rows, []);
+  assert.equal(output.metadata.selected_rows, 0);
+});
+
+test('a timeout while reading a response body remains TIMEOUT', () => {
+  diagnostic(
+    run('export-powerx', ['--model', 'x', '--isl', '1', '--osl', '1'], 'body-timeout'),
+    'TIMEOUT',
+  );
+});
+
+test('stdout writes fail within a bounded interval when the consumer never drains', () => {
+  const started = Date.now();
+  const result = run('compare-tco', ['--help'], 'stdout-stall');
+  diagnostic(result, 'OUTPUT_ERROR');
+  assert.ok(Date.now() - started < 8_000, `stdout failure took ${Date.now() - started}ms`);
+});
+
+test('SIGTERM aborts an active request, preserves output, and leaves failed evidence', async () => {
+  const cwd = suite.project();
+  const ready = join(cwd, 'ready');
+  const output = join(cwd, 'power.json');
+  writeFileSync(output, 'previous complete export');
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      pathToFileURL(preload).href,
+      scripts['export-powerx'],
+      '--model',
+      'x',
+      '--isl',
+      '1',
+      '--osl',
+      '1',
+      '--format',
+      'json',
+      '--output',
+      output,
+      '--evidence-dir',
+      'evidence',
+      '--error-format',
+      'json',
+    ],
+    {
+      cwd,
+      env: {
+        ...suite.environment,
+        INFERENCEX_CLI_CONTRACT_MODE: 'pending',
+        INFERENCEX_TEST_READY: ready,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8').on('data', (chunk) => (stdout += chunk));
+  child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk));
+  const deadline = Date.now() + 2_000;
+  while (!existsSync(ready) && Date.now() < deadline) {
+    await new Promise((resolve) => {
+      setTimeout(resolve, 10);
+    });
+  }
+  assert.ok(existsSync(ready), 'request did not start');
+  const closed = new Promise((resolve) => {
+    child.once('close', (code, closedBy) => resolve([code, closedBy]));
+  });
+  child.kill('SIGTERM');
+  const [status, signal] = await closed;
+  assert.equal(signal, null, stderr);
+  assert.equal(status, 130, stderr);
+  assert.equal(stdout, '');
+  assert.equal(JSON.parse(stderr).error.code, 'CANCELLED');
+  assert.equal(readFileSync(output, 'utf8'), 'previous complete export');
+  const manifest = JSON.parse(readFileSync(join(cwd, 'evidence', 'manifest.json'), 'utf8'));
+  assert.equal(manifest.status, 'failed');
+  assert.match(manifest.error, /SIGTERM/u);
+  assert.equal(manifest.export.sha256, null);
+});

--- a/packages/skills/test/cli-contract.test.mjs
+++ b/packages/skills/test/cli-contract.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { before, test } from 'node:test';
 import { pathToFileURL } from 'node:url';
@@ -216,6 +216,100 @@ test('every packed entry point rejects an unknown error format', () => {
   assert.equal(result.status, 2);
   assert.equal(result.stdout, '');
   assert.match(result.stderr, /--error-format.*json.*text/iu);
+});
+
+test('an explicit JSON error format survives duplicate or conflicting format arguments', () => {
+  const formats = [
+    ['--error-format', 'json', '--error-format', 'json'],
+    ['--error-format=json', '--error-format=text'],
+    ['--error-format=text', '--error-format=json'],
+    ['--error-format=yaml', '--error-format=json'],
+    ['--error-format=json', '--error-format'],
+    ['--error-format', '--error-format=json'],
+    ['--error-format', '--error-format', 'json'],
+  ];
+  for (const args of formats) {
+    for (const [name] of cases) {
+      diagnostic(suite.node([scripts[name], '--help', ...args]), 'INVALID_ARGUMENT', 2);
+    }
+    diagnostic(suite.run(['install', ...args], suite.project()), 'INVALID_ARGUMENT', 2);
+  }
+});
+
+for (const [name, args] of cases.slice(0, 2)) {
+  test(`${name} classifies an unwritable evidence parent as OUTPUT_ERROR`, () => {
+    const parent = join(suite.project(), 'unwritable');
+    mkdirSync(parent, { mode: 0o500 });
+    try {
+      diagnostic(run(name, [...args, '--evidence-dir', join(parent, 'evidence')]), 'OUTPUT_ERROR');
+      assert.equal(existsSync(join(parent, 'evidence')), false);
+    } finally {
+      chmodSync(parent, 0o700);
+    }
+  });
+
+  test(`${name} classifies evidence/output collisions as INVALID_ARGUMENT`, () => {
+    const evidence = join(suite.project(), 'evidence');
+    diagnostic(
+      run(name, [...args, '--evidence-dir', evidence, '--output', join(evidence, 'manifest.json')]),
+      'INVALID_ARGUMENT',
+      2,
+    );
+    assert.equal(existsSync(evidence), false);
+  });
+}
+
+test('CollectiveX distinguishes output preflight I/O failures from invalid destinations', () => {
+  const cwd = suite.project();
+  diagnostic(
+    run('compare-collectivex', ['--output', join(cwd, 'missing/out.json')]),
+    'OUTPUT_ERROR',
+  );
+  const parent = join(cwd, 'inaccessible');
+  mkdirSync(parent, { mode: 0o000 });
+  try {
+    diagnostic(run('compare-collectivex', ['--output', join(parent, 'out.json')]), 'OUTPUT_ERROR');
+  } finally {
+    chmodSync(parent, 0o700);
+  }
+  writeFileSync(join(cwd, 'file'), 'untouched');
+  for (const output of ['file', 'file/out.json']) {
+    diagnostic(run('compare-collectivex', ['--output', join(cwd, output)]), 'INVALID_ARGUMENT', 2);
+  }
+  assert.equal(readFileSync(join(cwd, 'file'), 'utf8'), 'untouched');
+});
+
+test('installer filesystem write failures are OUTPUT_ERROR and retain the installed skill', () => {
+  const cwd = suite.project();
+  const installed = suite.install('codex', cwd);
+  const root = join(installed, '..');
+  const receipt = readFileSync(join(installed, '.inferencex-skills.json'));
+  writeFileSync(join(installed, 'keep.txt'), 'untouched');
+  chmodSync(root, 0o500);
+  try {
+    diagnostic(
+      suite.run(['install', '--target', 'codex', '--force', '--error-format', 'json'], cwd),
+      'OUTPUT_ERROR',
+    );
+    assert.deepEqual(readFileSync(join(installed, '.inferencex-skills.json')), receipt);
+    assert.equal(readFileSync(join(installed, 'keep.txt'), 'utf8'), 'untouched');
+    assert.equal(existsSync(`${installed}.inferencex-skills-transaction`), false);
+  } finally {
+    chmodSync(root, 0o700);
+  }
+});
+
+test('installer transaction protocol failures remain INTERNAL_ERROR', () => {
+  const cwd = suite.project();
+  const installed = suite.install('codex', cwd);
+  const transaction = `${installed}.inferencex-skills-transaction`;
+  mkdirSync(transaction);
+  writeFileSync(join(transaction, 'unknown'), 'untouched');
+  diagnostic(
+    suite.run(['install', '--target', 'codex', '--force', '--error-format', 'json'], cwd),
+    'INTERNAL_ERROR',
+  );
+  assert.equal(readFileSync(join(transaction, 'unknown'), 'utf8'), 'untouched');
 });
 
 test('every data helper classifies request, response, HTTP, and stdout boundaries', () => {

--- a/packages/skills/test/cli-contract.test.mjs
+++ b/packages/skills/test/cli-contract.test.mjs
@@ -89,10 +89,11 @@ before(() => {
 import { writeFileSync } from 'node:fs';
 const mode = process.env.INFERENCEX_CLI_CONTRACT_MODE;
 let parseTimeoutController;
-if (mode === 'body-timeout' || mode === 'http-body-timeout' || mode === 'parse-timeout') {
+if (mode === 'body-timeout' || mode === 'http-body-timeout' || mode === 'parse-timeout' || mode === 'request-abort') {
   const timeout = AbortSignal.timeout;
   AbortSignal.timeout = milliseconds => {
     const controlled =
+      mode === 'request-abort' ||
       (mode === 'parse-timeout' && milliseconds === 120_000) ||
       (mode !== 'parse-timeout' && milliseconds === 30_000);
     if (!controlled) return timeout(milliseconds);
@@ -129,6 +130,13 @@ globalThis.fetch = async (_input, options) => {
   if (mode === 'network') throw new TypeError('controlled network failure');
   if (mode === 'timeout') throw new DOMException('controlled timeout', 'TimeoutError');
   options.signal?.throwIfAborted();
+  if (mode === 'request-abort') {
+    return await new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => {
+        reject(new DOMException('fetch aborted', 'AbortError'));
+      }, { once: true });
+    });
+  }
   if (mode === 'pending') {
     return await new Promise((_resolve, reject) => {
       const keepAlive = setInterval(() => {}, 1_000);
@@ -203,6 +211,12 @@ test('every packed entry point emits one structured INVALID_ARGUMENT diagnostic'
   const cwd = suite.project();
   const result = suite.run(['install', '--target', 'unknown', '--error-format', 'json'], cwd);
   diagnostic(result, 'INVALID_ARGUMENT', 2);
+});
+
+test('request budgets classify a generic fetch AbortError as TIMEOUT', () => {
+  for (const [name, args] of cases) {
+    diagnostic(run(name, args, 'request-abort'), 'TIMEOUT');
+  }
 });
 
 test('every packed entry point rejects an unknown error format', () => {

--- a/packages/skills/test/cli-contract.test.mjs
+++ b/packages/skills/test/cli-contract.test.mjs
@@ -88,16 +88,34 @@ before(() => {
     `
 import { writeFileSync } from 'node:fs';
 const mode = process.env.INFERENCEX_CLI_CONTRACT_MODE;
-if (mode === 'body-timeout') {
+let parseTimeoutController;
+if (mode === 'body-timeout' || mode === 'http-body-timeout' || mode === 'parse-timeout') {
   const timeout = AbortSignal.timeout;
   AbortSignal.timeout = milliseconds => {
-    if (milliseconds !== 30_000) return timeout(milliseconds);
+    const controlled =
+      (mode === 'parse-timeout' && milliseconds === 120_000) ||
+      (mode !== 'parse-timeout' && milliseconds === 30_000);
+    if (!controlled) return timeout(milliseconds);
     const controller = new AbortController();
-    setTimeout(
-      () => controller.abort(new DOMException('controlled body timeout', 'TimeoutError')),
-      40,
-    );
+    if (mode === 'parse-timeout') parseTimeoutController = controller;
+    else {
+      setTimeout(
+        () => controller.abort(new DOMException('controlled body timeout', 'TimeoutError')),
+        40,
+      );
+    }
     return controller.signal;
+  };
+}
+if (mode === 'parse-cancel' || mode === 'parse-timeout') {
+  const decode = TextDecoder.prototype.decode;
+  TextDecoder.prototype.decode = function (...args) {
+    const body = decode.apply(this, args);
+    if (body === '[]') {
+      if (mode === 'parse-cancel') process.emit('SIGTERM');
+      else parseTimeoutController.abort(new DOMException('controlled parse timeout', 'TimeoutError'));
+    }
+    return body;
   };
 }
 if (mode === 'stdout-error') {
@@ -122,19 +140,30 @@ globalThis.fetch = async (_input, options) => {
       if (options.signal.aborted) reject(options.signal.reason);
     });
   }
-  if (mode === 'body-timeout') {
+  if (mode === 'body-timeout' || mode === 'http-body-timeout' || mode === 'http-body-pending') {
     return new Response(new ReadableStream({
       start(controller) {
+        if (mode === 'http-body-pending') {
+          const keepAlive = setInterval(() => {}, 1_000);
+          writeFileSync(process.env.INFERENCEX_TEST_READY, 'ready');
+          options.signal.addEventListener('abort', () => clearInterval(keepAlive), { once: true });
+        }
         options.signal.addEventListener('abort', () => controller.error(options.signal.reason), {
           once: true,
         });
       },
-    }), { headers: { 'Content-Type': 'application/json' } });
+    }), {
+      status: mode === 'body-timeout' ? 200 : 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
   if (mode === 'http') return new Response('{"error":"unavailable"}', {
     status: 503, headers: { 'Content-Type': 'application/json' },
   });
   if (mode === 'empty') return new Response('[]', {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (mode === 'parse-cancel' || mode === 'parse-timeout') return new Response('[]', {
     headers: { 'Content-Type': 'application/json' },
   });
   return new Response('{not json', { headers: { 'Content-Type': 'application/json' } });
@@ -220,6 +249,18 @@ test('a timeout while reading a response body remains TIMEOUT', () => {
   );
 });
 
+test('a non-2xx stalled response body preserves TIMEOUT in each affected reader', () => {
+  for (const [name, args] of cases.slice(0, 3)) {
+    diagnostic(run(name, args, 'http-body-timeout'), 'TIMEOUT');
+  }
+});
+
+test('AgentX preserves cancellation and timeout between body read and JSON parsing', () => {
+  const args = ['--model', 'x'];
+  diagnostic(run('export-agentx', args, 'parse-cancel'), 'CANCELLED', 130);
+  diagnostic(run('export-agentx', args, 'parse-timeout'), 'TIMEOUT');
+});
+
 test('stdout writes fail within a bounded interval when the consumer never drains', () => {
   const started = Date.now();
   const result = run('compare-tco', ['--help'], 'stdout-stall');
@@ -288,4 +329,42 @@ test('SIGTERM aborts an active request, preserves output, and leaves failed evid
   assert.equal(manifest.status, 'failed');
   assert.match(manifest.error, /SIGTERM/u);
   assert.equal(manifest.export.sha256, null);
+});
+
+test('SIGTERM after non-2xx headers remains CANCELLED in each affected reader', async () => {
+  for (const [name, args] of cases.slice(0, 3)) {
+    const cwd = suite.project();
+    const ready = join(cwd, `${name}-ready`);
+    const child = spawn(
+      process.execPath,
+      ['--import', pathToFileURL(preload).href, scripts[name], ...args, '--error-format', 'json'],
+      {
+        cwd,
+        env: {
+          ...suite.environment,
+          INFERENCEX_CLI_CONTRACT_MODE: 'http-body-pending',
+          INFERENCEX_TEST_READY: ready,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8').on('data', (chunk) => (stdout += chunk));
+    child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk));
+    const deadline = Date.now() + 2_000;
+    while (!existsSync(ready) && Date.now() < deadline) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+    }
+    assert.ok(existsSync(ready), `${name} response headers did not arrive`);
+    const closed = new Promise((resolve) => {
+      child.once('close', (code, closedBy) => resolve([code, closedBy]));
+    });
+    child.kill('SIGTERM');
+    const [status, signal] = await closed;
+    assert.equal(signal, null, stderr);
+    diagnostic({ status, stdout, stderr }, 'CANCELLED', 130);
+  }
 });

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -195,6 +195,7 @@ let completeManifestFailure = fixture.failCompleteManifest;
 fs.promises.writeFile = async (path, data, ...rest) => {
   const text = String(data);
   if (String(path).endsWith('manifest.tmp')) {
+    if (fixture.failInitialManifest) throw new Error('controlled initial manifest failure');
     if (completeManifestFailure && text.includes('"status": "complete"')) {
       completeManifestFailure = false;
       throw new Error('controlled complete manifest failure');
@@ -1336,6 +1337,71 @@ test('evidence, output, and stdout write failures never become complete', () => 
     );
     assert.equal(result.status, 1);
     assert.match(result.stderr, /broken pipe.*could not save failure evidence/isu);
+    assert.equal(captured(result).manifest.status, 'pending');
+  }
+});
+
+for (const fault of [
+  'initial-manifest',
+  'enrichment-response',
+  'enrichment-manifest',
+  'complete-manifest',
+]) {
+  test(`JSON diagnostics classify ${fault} evidence failures as OUTPUT_ERROR`, () => {
+    const cwd = project();
+    const evidenceDir = join(cwd, 'evidence');
+    const routes = routesFor([observation('1')], [1]);
+    const options = { cwd, evidenceDir };
+    if (fault === 'initial-manifest') options.failInitialManifest = true;
+    else if (fault === 'complete-manifest') options.failCompleteManifest = true;
+    else {
+      routes['/api/v1/agentic-aggregates'][0].blockEvidenceFile =
+        fault === 'enrichment-response' ? 'response-0002-agentic-aggregates.json' : 'manifest.tmp';
+    }
+    writeFileSync(join(cwd, 'agentx.json'), 'previous complete export');
+    const result = run(
+      [
+        '--model',
+        'DeepSeek-V4-Pro',
+        '--output',
+        'agentx.json',
+        '--evidence-dir',
+        'evidence',
+        '--error-format',
+        'json',
+      ],
+      routes,
+      options,
+    );
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(result.stdout, '');
+    assert.equal(JSON.parse(result.stderr).error.code, 'OUTPUT_ERROR', fault);
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'previous complete export');
+    if (fault !== 'initial-manifest') {
+      assert.equal(
+        captured(result).manifest.status,
+        fault === 'enrichment-manifest' ? 'pending' : 'failed',
+      );
+    }
+  });
+}
+
+test('failed evidence recording preserves the original AgentX HTTP and timeout codes', () => {
+  for (const [reply, code] of [
+    [response('unavailable', 503), 'HTTP_ERROR'],
+    [response('', 200, { timeout: true }), 'TIMEOUT'],
+  ]) {
+    const result = run(
+      ['--model', 'DeepSeek-V4-Pro', '--evidence-dir', 'evidence', '--error-format', 'json'],
+      { '/api/v1/benchmarks': [reply] },
+      { failFailureManifest: true },
+    );
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(result.stdout, '');
+    const error = JSON.parse(result.stderr).error;
+    assert.equal(error.code, code);
+    if (code === 'HTTP_ERROR') assert.equal(error.http_status, 503);
+    assert.match(error.message, /could not save failure evidence/u);
     assert.equal(captured(result).manifest.status, 'pending');
   }
 });

--- a/packages/skills/test/export-agentx.test.mjs
+++ b/packages/skills/test/export-agentx.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
   existsSync,
@@ -192,9 +192,18 @@ if (fixture.shortDeadline) {
 }
 const originalWriteFile = fs.promises.writeFile;
 let completeManifestFailure = fixture.failCompleteManifest;
+if (fixture.pauseCompleteManifest) process.once('SIGTERM', () => {
+  fs.writeFileSync(fixture.pauseCompleteManifest.received, 'received');
+});
 fs.promises.writeFile = async (path, data, ...rest) => {
   const text = String(data);
   if (String(path).endsWith('manifest.tmp')) {
+    if (fixture.pauseCompleteManifest && text.includes('"status": "complete"')) {
+      fs.writeFileSync(fixture.pauseCompleteManifest.ready, 'ready');
+      while (!fs.existsSync(fixture.pauseCompleteManifest.release)) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+    }
     if (fixture.failInitialManifest) throw new Error('controlled initial manifest failure');
     if (completeManifestFailure && text.includes('"status": "complete"')) {
       completeManifestFailure = false;
@@ -1338,6 +1347,93 @@ test('evidence, output, and stdout write failures never become complete', () => 
     assert.equal(result.status, 1);
     assert.match(result.stderr, /broken pipe.*could not save failure evidence/isu);
     assert.equal(captured(result).manifest.status, 'pending');
+  }
+});
+
+test('SIGTERM during the final manifest write restores output and records failed evidence', async () => {
+  const cwd = project();
+  const gate = Object.fromEntries(
+    ['ready', 'received', 'release'].map((name) => [name, join(cwd, name)]),
+  );
+  const fixturePath = join(cwd, 'fixture.json');
+  writeFileSync(
+    fixturePath,
+    JSON.stringify({
+      routes: { '/api/v1/benchmarks': [response('[]')] },
+      pauseCompleteManifest: gate,
+    }),
+  );
+  writeFileSync(join(cwd, 'agentx.json'), 'previous complete export');
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      pathToFileURL(preload).href,
+      exporter,
+      '--model',
+      'DeepSeek-V4-Pro',
+      '--output',
+      'agentx.json',
+      '--evidence-dir',
+      'evidence',
+      '--error-format',
+      'json',
+    ],
+    {
+      cwd,
+      env: {
+        ...environment,
+        INFERENCEX_TEST_RESPONSE: fixturePath,
+        INFERENCEX_TEST_REQUESTS: join(cwd, 'requests.txt'),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 10_000,
+      killSignal: 'SIGKILL',
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf8').on('data', (chunk) => (stdout += chunk));
+  child.stderr.setEncoding('utf8').on('data', (chunk) => (stderr += chunk));
+  const closed = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (status, signal) => resolve({ status, signal }));
+  });
+  async function waitForFile(path) {
+    const deadline = Date.now() + 5_000;
+    while (!existsSync(path) && Date.now() < deadline) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 10);
+      });
+    }
+    assert.ok(existsSync(path), `did not reach ${path}: ${stderr}`);
+  }
+  try {
+    await waitForFile(gate.ready);
+    assert.ok(readdirSync(cwd).some((name) => name.endsWith('.backup')));
+    assert.equal(child.kill('SIGTERM'), true);
+    await waitForFile(gate.received);
+    writeFileSync(gate.release, 'release');
+    const result = await closed;
+    assert.deepEqual(result, { status: 130, signal: null }, stderr);
+    assert.equal(stdout, '');
+    assert.equal(JSON.parse(stderr).error.code, 'CANCELLED');
+    assert.equal(readFileSync(join(cwd, 'agentx.json'), 'utf8'), 'previous complete export');
+    const { manifest, bodies } = captured({ cwd });
+    assert.equal(manifest.status, 'failed');
+    assert.match(manifest.error, /SIGTERM/u);
+    assert.equal(manifest.export.sha256, null);
+    assert.deepEqual(manifest.export.source_request_numbers, []);
+    assert.equal(bodies.size, 1);
+    assert.deepEqual(
+      readdirSync(cwd).filter((name) => /\.(?:backup|tmp)$/u.test(name)),
+      [],
+    );
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+      await closed;
+    }
   }
 });
 

--- a/packages/skills/test/export-powerx.test.mjs
+++ b/packages/skills/test/export-powerx.test.mjs
@@ -113,6 +113,12 @@ import { syncBuiltinESMExports } from 'node:module';
 import { join } from 'node:path';
 const fixture = JSON.parse(readFileSync(process.env.INFERENCEX_TEST_RESPONSE, 'utf8'));
 const write = fs.promises.writeFile;
+if (fixture.failInitialManifest || fixture.failFailureManifest) fs.promises.writeFile = async (path, data, ...rest) => {
+  if (String(path).endsWith('manifest.tmp') && (fixture.failInitialManifest || String(data).includes('"status": "failed"'))) {
+    throw new Error('controlled manifest failure');
+  }
+  return write(path, data, ...rest);
+};
 if (fixture.partialOutputWrite) fs.promises.writeFile = async (path, data, ...rest) => {
   if (String(path).includes('preserved.json')) {
     await write(path, String(data).slice(0, 5), ...rest);
@@ -1039,4 +1045,47 @@ test('requested evidence/output write failures and closed stdout never leave a s
   assert.equal(result.status, 1);
   assert.equal(result.requests.length, 0);
   assert.equal(readFileSync(join(cwd, 'parent-file'), 'utf8'), 'untouched');
+});
+
+for (const fault of ['initial-manifest', 'response.json', 'manifest.tmp', 'output']) {
+  test(`JSON diagnostics classify ${fault} filesystem failures as OUTPUT_ERROR`, () => {
+    const cwd = project();
+    const evidenceDir = join(cwd, 'evidence');
+    const args = [...requiredArgs, '--evidence-dir', evidenceDir, '--error-format', 'json'];
+    const options = { cwd, evidenceDir };
+    if (fault === 'initial-manifest') options.failInitialManifest = true;
+    else if (fault === 'output') {
+      mkdirSync(join(cwd, 'output'));
+      args.push('--output', 'output');
+    } else options.blockEvidenceFile = fault;
+    const result = run(args, [observation()], options);
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(JSON.parse(result.stderr).error.code, 'OUTPUT_ERROR', fault);
+    assert.equal(result.requests.length, fault === 'initial-manifest' ? 0 : 1);
+    if (fault !== 'initial-manifest') {
+      const manifest = JSON.parse(readFileSync(join(evidenceDir, 'manifest.json'), 'utf8'));
+      assert.equal(manifest.status, fault === 'manifest.tmp' ? 'pending' : 'failed');
+    }
+  });
+}
+
+test('failed evidence recording preserves the original PowerX HTTP and timeout codes', () => {
+  for (const [fault, code] of [
+    [{ status: 503 }, 'HTTP_ERROR'],
+    [{ timeout: true }, 'TIMEOUT'],
+  ]) {
+    const cwd = project();
+    const result = run(
+      [...requiredArgs, '--evidence-dir', 'evidence', '--error-format', 'json'],
+      [],
+      { cwd, ...fault, failFailureManifest: true },
+    );
+    assert.equal(result.status, 1, result.stderr);
+    assert.equal(result.stdout, '');
+    const error = JSON.parse(result.stderr).error;
+    assert.equal(error.code, code);
+    if (code === 'HTTP_ERROR') assert.equal(error.http_status, 503);
+    assert.match(error.message, /could not save failure evidence/u);
+    assert.equal(JSON.parse(readFileSync(join(cwd, 'evidence/manifest.json'))).status, 'pending');
+  }
 });

--- a/packages/skills/test/install-cancellation.test.mjs
+++ b/packages/skills/test/install-cancellation.test.mjs
@@ -1,0 +1,234 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { before, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+import { packageInfo, packedSkillSuite, succeeded } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const extracted = join(suite.temporaryRoot, 'extracted');
+const installer = join(extracted, 'package/bin/install.mjs');
+const source = join(extracted, 'package/skills/inferencex-api');
+
+before(() => {
+  mkdirSync(extracted);
+  succeeded(spawnSync('tar', ['-xzf', suite.archive, '-C', extracted], { encoding: 'utf8' }));
+});
+
+function snapshot(root) {
+  if (!existsSync(root)) return null;
+  return ['', ...readdirSync(root, { recursive: true })].sort().map((path) => {
+    const entry = lstatSync(join(root, path));
+    return {
+      path,
+      mode: entry.mode & 0o777,
+      contents: entry.isFile() ? readFileSync(join(root, path)).toString('base64') : null,
+      link: entry.isSymbolicLink() ? readlinkSync(join(root, path)) : null,
+    };
+  });
+}
+
+async function waitForFile(path, child) {
+  for (let attempt = 0; attempt < 250; attempt++) {
+    if (existsSync(path)) return;
+    if (child.exitCode !== null || child.signalCode !== null) {
+      throw new Error(`installer exited before ${path} was created`);
+    }
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+function spawnInstaller(cwd, gate, phase, ownerPid) {
+  mkdirSync(gate);
+  const ready = join(gate, 'ready');
+  const release = join(gate, 'release');
+  const acknowledged = join(gate, 'acknowledged');
+  const preload = join(gate, 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+const ready = ${JSON.stringify(ready)};
+const release = ${JSON.stringify(release)};
+const acknowledged = ${JSON.stringify(acknowledged)};
+let gated = false;
+function pause() {
+  if (gated) return;
+  gated = true;
+  fs.writeFileSync(ready, String(process.pid));
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(release)) {
+    if (Date.now() > deadline) throw new Error('test gate timed out');
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+  }
+}
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => fs.writeFileSync(acknowledged, signal));
+}
+if (${JSON.stringify(phase)} === 'staging') {
+  const copy = fs.cpSync;
+  fs.cpSync = (from, to, options) => {
+    const result = copy(from, to, options);
+    if (from === ${JSON.stringify(source)}) pause();
+    return result;
+  };
+} else if (${JSON.stringify(phase)} === 'activated') {
+  const rename = fs.renameSync;
+  fs.renameSync = (from, to) => {
+    const result = rename(from, to);
+    if (from.endsWith('/transaction.next.json') &&
+        JSON.parse(fs.readFileSync(to, 'utf8')).phase === 'activated') pause();
+    return result;
+  };
+} else {
+  const kill = process.kill;
+  process.kill = (pid, signal) => {
+    const result = kill(pid, signal);
+    if (pid === ${JSON.stringify(ownerPid)} && signal === 0 && !gated) {
+      gated = true;
+      fs.writeFileSync(ready, String(process.pid));
+    }
+    return result;
+  };
+}
+syncBuiltinESMExports();
+`,
+  );
+  const child = spawn(
+    process.execPath,
+    [
+      '--import',
+      pathToFileURL(preload).href,
+      installer,
+      'install',
+      '--dir',
+      'skills',
+      '--force',
+      '--json',
+      '--error-format',
+      'json',
+    ],
+    { cwd, detached: true, env: suite.environment, stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  const output = { stdout: '', stderr: '' };
+  child.stdout.on('data', (chunk) => (output.stdout += chunk));
+  child.stderr.on('data', (chunk) => (output.stderr += chunk));
+  return { child, output, ready, release, acknowledged, closed: once(child, 'close') };
+}
+
+async function finish(control) {
+  const timer = setTimeout(() => process.kill(-control.child.pid, 'SIGKILL'), 5_000);
+  try {
+    return await control.closed;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function cleanup(control) {
+  if (control.child.exitCode === null && control.child.signalCode === null) {
+    process.kill(-control.child.pid, 'SIGKILL');
+    await control.closed;
+  }
+}
+
+function cancelled(control, result, signal) {
+  assert.deepEqual(result, [130, null], JSON.stringify(control.output));
+  assert.equal(control.output.stdout, '');
+  const diagnostic = JSON.parse(control.output.stderr);
+  assert.equal(diagnostic.error.code, 'CANCELLED');
+  assert.equal(diagnostic.package_version, packageInfo.version);
+  assert.equal(readFileSync(control.acknowledged, 'utf8'), signal);
+}
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  for (const existing of [false, true]) {
+    test(`${signal} during staging cancels ${existing ? 'an upgrade' : 'a first install'} without partial files`, async () => {
+      const cwd = suite.project('cancel staging 中文-');
+      const destination = join(cwd, 'skills/inferencex-api');
+      if (existing) {
+        succeeded(suite.run(['install', '--dir', 'skills'], cwd));
+        writeFileSync(join(destination, 'SKILL.md'), 'previous skill bytes\n');
+        writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+        chmodSync(join(destination, 'local-notes.txt'), 0o400);
+      }
+      const previous = snapshot(destination);
+      const control = spawnInstaller(cwd, join(cwd, 'gate'), 'staging');
+      try {
+        await waitForFile(control.ready, control.child);
+        control.child.kill(signal);
+        writeFileSync(control.release, 'release');
+        cancelled(control, await finish(control), signal);
+        assert.deepEqual(snapshot(destination), previous);
+        assert.deepEqual(readdirSync(dirname(destination)), existing ? ['inferencex-api'] : []);
+      } finally {
+        await cleanup(control);
+      }
+    });
+  }
+}
+
+test('SIGTERM cancels a waiting installer without changing the live owner or destination', async () => {
+  const cwd = suite.project('cancel waiter-');
+  const destination = join(cwd, 'skills/inferencex-api');
+  succeeded(suite.run(['install', '--dir', 'skills'], cwd));
+  const previous = snapshot(destination);
+  const owner = spawnInstaller(cwd, join(cwd, 'owner'), 'staging');
+  let waiter;
+  try {
+    await waitForFile(owner.ready, owner.child);
+    const transaction = `${destination}.inferencex-skills-transaction`;
+    const pending = snapshot(transaction);
+    waiter = spawnInstaller(cwd, join(cwd, 'waiter'), 'waiting', owner.child.pid);
+    await waitForFile(waiter.ready, waiter.child);
+    waiter.child.kill('SIGTERM');
+    cancelled(waiter, await finish(waiter), 'SIGTERM');
+    assert.equal(owner.child.exitCode, null);
+    assert.deepEqual(snapshot(destination), previous);
+    assert.deepEqual(snapshot(transaction), pending);
+    writeFileSync(owner.release, 'release');
+    assert.deepEqual(await finish(owner), [0, null], JSON.stringify(owner.output));
+    assert.equal(JSON.parse(owner.output.stdout).outcome, 'overwritten');
+  } finally {
+    if (waiter) await cleanup(waiter);
+    await cleanup(owner);
+  }
+});
+
+test('SIGTERM after committed activation reports the completed installation', async () => {
+  const cwd = suite.project('cancel after commit-');
+  const destination = join(cwd, 'skills/inferencex-api');
+  const control = spawnInstaller(cwd, join(cwd, 'gate'), 'activated');
+  try {
+    await waitForFile(control.ready, control.child);
+    control.child.kill('SIGTERM');
+    writeFileSync(control.release, 'release');
+    assert.deepEqual(await finish(control), [0, null], JSON.stringify(control.output));
+    assert.equal(control.output.stderr, '');
+    assert.equal(JSON.parse(control.output.stdout).outcome, 'installed');
+    assert.equal(readFileSync(control.acknowledged, 'utf8'), 'SIGTERM');
+    assert.equal(
+      JSON.parse(readFileSync(join(destination, '.inferencex-skills.json'), 'utf8')).version,
+      packageInfo.version,
+    );
+    assert.deepEqual(readdirSync(dirname(destination)), ['inferencex-api']);
+  } finally {
+    await cleanup(control);
+  }
+});

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -924,7 +924,7 @@ test('a stale none contender can overlap only cleanup after recovery settles the
   assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
 });
 
-test('terminal first-install cleanup cannot delete a newer completed installation', async () => {
+test('terminal cleanup claim crashes cannot block or delete a newer installation', async () => {
   const cwd = project('terminal cleanup generation 中文 path-');
   const skillsRoot = join(cwd, '.agents/skills');
   const destination = join(skillsRoot, 'inferencex-api');
@@ -1045,6 +1045,50 @@ test('terminal first-install cleanup cannot delete a newer completed installatio
   process.kill(-cleanupOwner.child.pid, 'SIGKILL');
   await cleanupOwner.closed;
 
+  const terminalClaimReady = join(cwd, 'terminal-claim-interrupted');
+  const terminalClaimPreload = join(project('terminal claim crash preload-'), 'preload.mjs');
+  writeFileSync(
+    terminalClaimPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const originalWrite = fs.writeFileSync;
+      const originalRemove = fs.rmSync;
+      let paused = false;
+      const pause = () => {
+        if (paused) return;
+        paused = true;
+        originalWrite(${JSON.stringify(terminalClaimReady)}, 'ready');
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+      };
+      fs.writeFileSync = (path, data, options) => {
+        const result = originalWrite(path, data, options);
+        if (path === ${JSON.stringify(join(recovery, 'transaction.next.json'))}) pause();
+        return result;
+      };
+      fs.rmSync = (path, options) => {
+        if (
+          typeof path === 'string' &&
+          path.startsWith(${JSON.stringify(`${recovery}/owner-`)}) &&
+          path.endsWith('.json')
+        ) {
+          pause();
+        }
+        return originalRemove(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const terminalClaim = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(terminalClaimPreload).href)}`,
+  );
+  await waitForFile(terminalClaimReady, terminalClaim.child);
+  process.kill(-terminalClaim.child.pid, 'SIGKILL');
+  await terminalClaim.closed;
+  const interruptedClaimNames = readdirSync(recovery);
+
   const follower = spawnPackedInstaller(['install', '--target', 'codex', '--json'], cwd);
   for (let attempt = 0; attempt < 250 && existsSync(recovery); attempt++) {
     if (follower.child.exitCode !== null) break;
@@ -1052,11 +1096,18 @@ test('terminal first-install cleanup cannot delete a newer completed installatio
       setTimeout(resolve, 20);
     });
   }
-  assert.equal(lstatSync(recovery, { throwIfNoEntry: false }), undefined, follower.output.stderr);
-  assert.equal(follower.child.exitCode, null, follower.output.stderr);
+  const recoveryRemovedBeforeRelease = !lstatSync(recovery, { throwIfNoEntry: false });
+  const followerExitBeforeRelease = follower.child.exitCode;
   writeFileSync(releaseNewer, 'continue');
   const [[contenderCode], [followerCode]] = await Promise.all([contender.closed, follower.closed]);
 
+  assert.equal(
+    interruptedClaimNames.includes('transaction.next.json'),
+    false,
+    interruptedClaimNames.join(', '),
+  );
+  assert.equal(recoveryRemovedBeforeRelease, true, follower.output.stderr);
+  assert.equal(followerExitBeforeRelease, null, follower.output.stderr);
   assert.equal(contenderCode, 0, `${contender.output.stdout}\n${contender.output.stderr}`);
   assert.equal(JSON.parse(contender.output.stdout).outcome, 'installed');
   assert.equal(followerCode, 0, `${follower.output.stdout}\n${follower.output.stderr}`);
@@ -1066,6 +1117,116 @@ test('terminal first-install cleanup cannot delete a newer completed installatio
     readFileSync(join(destination, 'local-notes.txt'), 'utf8'),
     'keep newer installation',
   );
+  assert.deepEqual(readdirSync(skillsRoot), ['inferencex-api']);
+});
+
+test('terminal cleanup at the canonical path leaves an identifiable tombstone', async () => {
+  const cwd = project('canonical terminal cleanup 中文 path-');
+  const skillsRoot = join(cwd, '.agents/skills');
+  const destination = join(skillsRoot, 'inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+
+  const stageReady = join(cwd, 'first-stage-ready');
+  const stagePreload = join(project('canonical terminal stage preload-'), 'preload.mjs');
+  writeFileSync(
+    stagePreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.cpSync;
+      fs.cpSync = (source, target, options) => {
+        const result = original(source, target, options);
+        if (target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          fs.writeFileSync(${JSON.stringify(stageReady)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const firstOwner = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(stagePreload).href)}`,
+  );
+  await waitForFile(stageReady, firstOwner.child);
+  process.kill(-firstOwner.child.pid, 'SIGKILL');
+  await firstOwner.closed;
+
+  const terminalReady = join(cwd, 'canonical-terminal-ready');
+  const terminalPreload = join(project('canonical terminal marker preload-'), 'preload.mjs');
+  writeFileSync(
+    terminalPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      fs.renameSync = (source, target) => {
+        const result = original(source, target);
+        if (
+          source === ${JSON.stringify(join(transaction, 'transaction.next.json'))} &&
+          JSON.parse(fs.readFileSync(target, 'utf8')).phase === 'cleanup'
+        ) {
+          fs.writeFileSync(${JSON.stringify(terminalReady)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const cleanupOwner = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(terminalPreload).href)}`,
+  );
+  await waitForFile(terminalReady, cleanupOwner.child);
+  process.kill(-cleanupOwner.child.pid, 'SIGKILL');
+  await cleanupOwner.closed;
+
+  const terminalMarker = readdirSync(transaction).find((name) => name.startsWith('owner-'));
+  assert.ok(terminalMarker);
+  const terminalRecord = JSON.parse(readFileSync(join(transaction, terminalMarker), 'utf8'));
+  assert.equal(terminalRecord.phase, 'cleanup');
+  const recovery = `${transaction}.recovering-${terminalRecord.transaction_id}`;
+
+  const tokenRemoved = join(cwd, 'terminal-token-removed');
+  const tokenPreload = join(project('canonical terminal unlink preload-'), 'preload.mjs');
+  writeFileSync(
+    tokenPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.rmSync;
+      fs.rmSync = (path, options) => {
+        const result = original(path, options);
+        if (
+          typeof path === 'string' &&
+          (path.startsWith(${JSON.stringify(`${transaction}/owner-`)}) ||
+            path.startsWith(${JSON.stringify(`${recovery}/owner-`)})) &&
+          path.endsWith('.json')
+        ) {
+          fs.writeFileSync(${JSON.stringify(tokenRemoved)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const terminalClaim = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(tokenPreload).href)}`,
+  );
+  await waitForFile(tokenRemoved, terminalClaim.child);
+  process.kill(-terminalClaim.child.pid, 'SIGKILL');
+  await terminalClaim.closed;
+
+  const follower = run(['install', '--target', 'codex', '--json'], cwd);
+  assert.equal(follower.status, 0, `${follower.stdout}\n${follower.stderr}`);
+  assert.equal(JSON.parse(follower.stdout).outcome, 'installed');
   assert.deepEqual(readdirSync(skillsRoot), ['inferencex-api']);
 });
 

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -924,6 +924,151 @@ test('a stale none contender can overlap only cleanup after recovery settles the
   assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
 });
 
+test('terminal first-install cleanup cannot delete a newer completed installation', async () => {
+  const cwd = project('terminal cleanup generation 中文 path-');
+  const skillsRoot = join(cwd, '.agents/skills');
+  const destination = join(skillsRoot, 'inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+
+  const contenderReady = join(cwd, 'stale-none-before-mkdir');
+  const releaseContender = join(cwd, 'release-stale-none');
+  const newerReady = join(cwd, 'newer-canonical-ready');
+  const releaseNewer = join(cwd, 'release-newer-canonical');
+  const contenderPreload = join(project('terminal stale-none preload-'), 'preload.mjs');
+  writeFileSync(
+    contenderPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const originalMkdir = fs.mkdirSync;
+      const originalCopy = fs.cpSync;
+      let paused = false;
+      fs.mkdirSync = (path, options) => {
+        if (!paused && path === ${JSON.stringify(transaction)}) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(contenderReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseContender)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return originalMkdir(path, options);
+      };
+      fs.cpSync = (source, target, options) => {
+        const result = originalCopy(source, target, options);
+        if (target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          fs.writeFileSync(
+            ${JSON.stringify(join(transaction, 'stage/local-notes.txt'))},
+            'keep newer installation',
+          );
+          fs.writeFileSync(${JSON.stringify(newerReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseNewer)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const contender = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(contenderPreload).href)}`,
+  );
+  await waitForFile(contenderReady, contender.child);
+
+  const stageReady = join(cwd, 'first-install-stage-ready');
+  const stagePreload = join(project('first install crash preload-'), 'preload.mjs');
+  writeFileSync(
+    stagePreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.cpSync;
+      fs.cpSync = (source, target, options) => {
+        const result = original(source, target, options);
+        if (target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          fs.writeFileSync(${JSON.stringify(stageReady)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const crashedInstaller = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(stagePreload).href)}`,
+  );
+  await waitForFile(stageReady, crashedInstaller.child);
+  process.kill(-crashedInstaller.child.pid, 'SIGKILL');
+  await crashedInstaller.closed;
+
+  const ownerMarker = readdirSync(transaction).find((name) => name.startsWith('owner-'));
+  assert.ok(ownerMarker);
+  const interrupted = JSON.parse(readFileSync(join(transaction, ownerMarker), 'utf8'));
+  const recovery = `${transaction}.recovering-${interrupted.transaction_id}`;
+  const cleanupReady = join(cwd, 'terminal-cleanup-moved');
+  const cleanupPreload = join(project('terminal cleanup crash preload-'), 'preload.mjs');
+  writeFileSync(
+    cleanupPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      fs.renameSync = (source, target) => {
+        const result = original(source, target);
+        if (source === ${JSON.stringify(transaction)} && target === ${JSON.stringify(recovery)}) {
+          fs.writeFileSync(${JSON.stringify(cleanupReady)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const cleanupOwner = spawnPackedInstaller(
+    ['install', '--target', 'codex', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(cleanupPreload).href)}`,
+  );
+  await waitForFile(cleanupReady, cleanupOwner.child);
+  const terminalMarker = readdirSync(recovery).find((name) => name.startsWith('owner-'));
+  assert.ok(terminalMarker);
+  const terminalPhase = JSON.parse(readFileSync(join(recovery, terminalMarker), 'utf8')).phase;
+
+  writeFileSync(releaseContender, 'continue');
+  await waitForFile(newerReady, contender.child);
+  const coexistence = JSON.parse(run(['status', '--target', 'codex', '--json'], cwd).stdout);
+  assert.equal(coexistence.transaction_state, 'busy');
+  process.kill(-cleanupOwner.child.pid, 'SIGKILL');
+  await cleanupOwner.closed;
+
+  const follower = spawnPackedInstaller(['install', '--target', 'codex', '--json'], cwd);
+  for (let attempt = 0; attempt < 250 && existsSync(recovery); attempt++) {
+    if (follower.child.exitCode !== null) break;
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  assert.equal(lstatSync(recovery, { throwIfNoEntry: false }), undefined, follower.output.stderr);
+  assert.equal(follower.child.exitCode, null, follower.output.stderr);
+  writeFileSync(releaseNewer, 'continue');
+  const [[contenderCode], [followerCode]] = await Promise.all([contender.closed, follower.closed]);
+
+  assert.equal(contenderCode, 0, `${contender.output.stdout}\n${contender.output.stderr}`);
+  assert.equal(JSON.parse(contender.output.stdout).outcome, 'installed');
+  assert.equal(followerCode, 0, `${follower.output.stdout}\n${follower.output.stderr}`);
+  assert.equal(JSON.parse(follower.output.stdout).outcome, 'skipped');
+  assert.equal(terminalPhase, 'cleanup');
+  assert.equal(
+    readFileSync(join(destination, 'local-notes.txt'), 'utf8'),
+    'keep newer installation',
+  );
+  assert.deepEqual(readdirSync(skillsRoot), ['inferencex-api']);
+});
+
 test('malformed, foreign, and symlink transaction markers fail closed without deletion', () => {
   for (const kind of ['malformed', 'foreign', 'symlink']) {
     const cwd = project(`${kind} transaction-`);

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -446,7 +446,8 @@ test('a process killed after committed backup cleanup leaves its owner marker re
         if (
           !paused &&
           path.endsWith('/previous') &&
-          path.includes('.inferencex-skills-transaction.recovering-') &&
+          (path === ${JSON.stringify(join(transaction, 'previous'))} ||
+            path.includes('.inferencex-skills-transaction.recovering-')) &&
           options?.recursive
         ) {
           paused = true;
@@ -816,6 +817,111 @@ test('a stale recovery contender cannot claim a newer transaction at the reused 
   assert.equal(JSON.parse(stale.output.stdout).outcome, 'skipped');
   assert.deepEqual(snapshot(destination), before);
   assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+});
+
+test('a stale none contender can overlap only cleanup after recovery settles the destination', async () => {
+  const cwd = project('stale none recovery 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const before = snapshot(destination);
+
+  const contenderReady = join(cwd, 'contender-before-mkdir');
+  const releaseContender = join(cwd, 'release-contender');
+  const contenderPreload = join(project('stale none contender preload-'), 'preload.mjs');
+  writeFileSync(
+    contenderPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.mkdirSync;
+      let paused = false;
+      fs.mkdirSync = (path, options) => {
+        if (!paused && path === ${JSON.stringify(transaction)}) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(contenderReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseContender)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return original(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const contender = spawnPackedInstaller(
+    ['install', '--force', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(contenderPreload).href)}`,
+  );
+  await waitForFile(contenderReady, contender.child);
+
+  mkdirSync(transaction);
+  renameSync(destination, join(transaction, 'previous'));
+  cpSync(join(transaction, 'previous'), destination, { recursive: true });
+  writeFileSync(join(destination, 'SKILL.md'), 'interrupted candidate bytes\n');
+  const { record: deadRecord } = writeTransactionMarker(transaction, destination, {
+    phase: 'previous_moved',
+  });
+  const recovery = `${transaction}.recovering-${deadRecord.transaction_id}`;
+  const recoveryReady = join(cwd, 'recovery-entered-cleanup');
+  const releaseRecovery = join(cwd, 'release-recovery-cleanup');
+  const recoveryPreload = join(project('recovery cleanup boundary preload-'), 'preload.mjs');
+  writeFileSync(
+    recoveryPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      let paused = false;
+      fs.renameSync = (source, target) => {
+        const result = original(source, target);
+        if (
+          !paused &&
+          source === ${JSON.stringify(transaction)} &&
+          target === ${JSON.stringify(recovery)}
+        ) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(recoveryReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseRecovery)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const recoveryOwner = spawnPackedInstaller(
+    ['install', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(recoveryPreload).href)}`,
+  );
+  await waitForFile(recoveryReady, recoveryOwner.child);
+
+  const destinationAtCleanupBoundary = snapshot(destination);
+  const backupAtCleanupBoundary = lstatSync(join(recovery, 'previous'), {
+    throwIfNoEntry: false,
+  });
+  writeFileSync(releaseContender, 'continue');
+  await new Promise((resolve) => {
+    setTimeout(resolve, 100);
+  });
+  writeFileSync(releaseRecovery, 'continue');
+  const [[contenderCode], [recoveryCode]] = await Promise.all([
+    contender.closed,
+    recoveryOwner.closed,
+  ]);
+
+  assert.deepEqual(destinationAtCleanupBoundary, before);
+  assert.equal(backupAtCleanupBoundary, undefined);
+  assert.equal(contenderCode, 0, `${contender.output.stdout}\n${contender.output.stderr}`);
+  assert.equal(JSON.parse(contender.output.stdout).outcome, 'overwritten');
+  assert.equal(recoveryCode, 0, `${recoveryOwner.output.stdout}\n${recoveryOwner.output.stderr}`);
+  assert.equal(JSON.parse(recoveryOwner.output.stdout).outcome, 'skipped');
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
 });
 
 test('malformed, foreign, and symlink transaction markers fail closed without deletion', () => {

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -924,7 +924,7 @@ test('a stale none contender can overlap only cleanup after recovery settles the
   assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
 });
 
-test('terminal cleanup claim crashes cannot block or delete a newer installation', async () => {
+test('terminal cleanup claim crashes cannot block, delete, or hide a newer installation', async () => {
   const cwd = project('terminal cleanup generation 中文 path-');
   const skillsRoot = join(cwd, '.agents/skills');
   const destination = join(skillsRoot, 'inferencex-api');
@@ -1045,6 +1045,11 @@ test('terminal cleanup claim crashes cannot block or delete a newer installation
   process.kill(-cleanupOwner.child.pid, 'SIGKILL');
   await cleanupOwner.closed;
 
+  const beforeInspection = snapshot(skillsRoot);
+  const pendingStatus = run(['status', '--target', 'codex', '--json'], cwd);
+  const pendingPreview = run(['install', '--target', 'codex', '--dry-run', '--json'], cwd);
+  const afterInspection = snapshot(skillsRoot);
+
   const terminalClaimReady = join(cwd, 'terminal-claim-interrupted');
   const terminalClaimPreload = join(project('terminal claim crash preload-'), 'preload.mjs');
   writeFileSync(
@@ -1101,6 +1106,16 @@ test('terminal cleanup claim crashes cannot block or delete a newer installation
   writeFileSync(releaseNewer, 'continue');
   const [[contenderCode], [followerCode]] = await Promise.all([contender.closed, follower.closed]);
 
+  for (const result of [pendingStatus, pendingPreview]) {
+    const pending = JSON.parse(succeeded(result).stdout);
+    assert.equal(pending.transaction_state, 'busy', result.stdout);
+    assert.equal(pending.transaction_phase, 'staging');
+    assert.equal(pending.transaction_had_destination, false);
+  }
+  assert.equal(coexistence.transaction_phase, 'staging');
+  assert.equal(JSON.parse(pendingPreview.stdout).outcome, 'would_wait_for_install');
+  assert.deepEqual(JSON.parse(pendingPreview.stdout).write_paths, []);
+  assert.deepEqual(afterInspection, beforeInspection);
   assert.equal(
     interruptedClaimNames.includes('transaction.next.json'),
     false,

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { once } from 'node:events';
 import {
   chmodSync,
@@ -10,6 +11,7 @@ import {
   readFileSync,
   readdirSync,
   readlinkSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -23,6 +25,28 @@ import { packageInfo, packageRoot, packedSkillSuite, succeeded } from './packed-
 const suite = packedSkillSuite();
 const { project, run } = suite;
 const metadataName = '.inferencex-skills.json';
+
+function writeTransactionMarker(
+  transaction,
+  destination,
+  { ownerPid = 2_147_483_647, raw, ...overrides } = {},
+) {
+  const transactionId = randomUUID();
+  const record = {
+    schema_version: 1,
+    transaction_id: transactionId,
+    package: packageInfo.name,
+    skill: 'inferencex-api',
+    destination,
+    owner_pid: ownerPid,
+    phase: 'staged',
+    had_destination: true,
+    ...overrides,
+  };
+  const path = join(transaction, `owner-${transactionId}-${ownerPid}-${randomUUID()}.json`);
+  writeFileSync(path, raw ?? JSON.stringify(record));
+  return { path, record };
+}
 
 function snapshot(root) {
   return ['', ...readdirSync(root, { recursive: true })].sort().map((path) => {
@@ -204,11 +228,7 @@ test('a cleanup failure after activation keeps the complete new installation rec
       import { syncBuiltinESMExports } from 'node:module';
       const original = fs.rmSync;
       fs.rmSync = (path, options) => {
-        if (
-          path === ${JSON.stringify(transaction)} &&
-          options?.recursive &&
-          JSON.parse(fs.readFileSync(${JSON.stringify(join(transaction, 'transaction.json'))})).phase === 'activated'
-        ) {
+        if (path.endsWith('/previous') && options?.recursive) {
           throw new Error('injected cleanup failure');
         }
         return original(path, options);
@@ -268,18 +288,7 @@ test('status reports an interrupted transaction without claiming the old version
   const transaction = `${destination}.inferencex-skills-transaction`;
   mkdirSync(transaction);
   cpSync(destination, join(transaction, 'stage'), { recursive: true });
-  writeFileSync(
-    join(transaction, 'transaction.json'),
-    JSON.stringify({
-      schema_version: 1,
-      package: packageInfo.name,
-      skill: 'inferencex-api',
-      destination,
-      owner_pid: 2_147_483_647,
-      phase: 'staged',
-      had_destination: true,
-    }),
-  );
+  writeTransactionMarker(transaction, destination);
   const before = snapshot(cwd);
 
   const result = run(['status', '--json'], cwd);
@@ -301,18 +310,7 @@ test('dry-run reports required recovery without changing the transaction or inst
   const transaction = `${destination}.inferencex-skills-transaction`;
   mkdirSync(transaction);
   cpSync(destination, join(transaction, 'stage'), { recursive: true });
-  writeFileSync(
-    join(transaction, 'transaction.json'),
-    JSON.stringify({
-      schema_version: 1,
-      package: packageInfo.name,
-      skill: 'inferencex-api',
-      destination,
-      owner_pid: 2_147_483_647,
-      phase: 'staged',
-      had_destination: true,
-    }),
-  );
+  writeTransactionMarker(transaction, destination);
   const before = snapshot(cwd);
 
   const result = run(['install', '--force', '--dry-run', '--json'], cwd);
@@ -325,6 +323,33 @@ test('dry-run reports required recovery without changing the transaction or inst
   assert.equal(preview.transaction_state, 'recovery_needed');
   assert.ok(preview.write_paths.length > 0);
   assert.deepEqual(snapshot(cwd), before);
+});
+
+test('dry-run predicts a skip after recovering an activated first install', () => {
+  const cwd = project('activated first install preview 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const before = snapshot(destination);
+  mkdirSync(transaction);
+  writeTransactionMarker(transaction, destination, {
+    phase: 'activated',
+    had_destination: false,
+  });
+  const beforePreview = snapshot(cwd);
+
+  const previewResult = run(['install', '--dry-run', '--json'], cwd);
+  assert.equal(previewResult.status, 0, `${previewResult.stdout}\n${previewResult.stderr}`);
+  const preview = JSON.parse(previewResult.stdout);
+  assert.equal(preview.outcome, 'would_recover_then_skip');
+  assert.deepEqual(preview.write_paths, []);
+  assert.deepEqual(snapshot(cwd), beforePreview);
+
+  const installed = run(['install', '--json'], cwd);
+  assert.equal(installed.status, 0, `${installed.stdout}\n${installed.stderr}`);
+  assert.equal(JSON.parse(installed.stdout).outcome, 'skipped');
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
 });
 
 test('a process killed between activation renames is recovered by the next install', async () => {
@@ -400,6 +425,84 @@ test('a process killed between activation renames is recovered by the next insta
   rmSync(ready);
 });
 
+test('a process killed after committed backup cleanup leaves its owner marker recoverable', async () => {
+  const cwd = project('killed committed cleanup 中文 path-');
+  succeeded(run(['install'], cwd));
+  const skillsRoot = join(cwd, '.claude/skills');
+  const destination = join(skillsRoot, 'inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const ready = join(cwd, 'committed-backup-removed');
+  const preload = join(project('committed cleanup kill preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.rmSync;
+      let paused = false;
+      fs.rmSync = (path, options) => {
+        if (
+          !paused &&
+          path.endsWith('/previous') &&
+          path.includes('.inferencex-skills-transaction.recovering-') &&
+          options?.recursive
+        ) {
+          paused = true;
+          const result = original(path, options);
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+          return result;
+        }
+        if (!paused && path === ${JSON.stringify(transaction)} && options?.recursive) {
+          paused = true;
+          original(${JSON.stringify(join(transaction, 'previous'))}, {
+            recursive: true,
+            force: true,
+          });
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return original(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const { child, output, closed } = spawnPackedInstaller(
+    ['install', '--force', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, child);
+  process.kill(-child.pid, 'SIGKILL');
+  await closed;
+
+  const recoveryName = readdirSync(skillsRoot).find((name) =>
+    name.startsWith('inferencex-api.inferencex-skills-transaction.recovering-'),
+  );
+  const recovery = recoveryName ? join(skillsRoot, recoveryName) : transaction;
+  assert.ok(lstatSync(recovery, { throwIfNoEntry: false }), output.stderr);
+  const ownerMarker =
+    readdirSync(recovery).find((name) => name.startsWith('owner-')) ?? 'transaction.json';
+  assert.ok(ownerMarker);
+  assert.equal(JSON.parse(readFileSync(join(recovery, ownerMarker), 'utf8')).phase, 'activated');
+  assert.equal(lstatSync(join(recovery, 'previous'), { throwIfNoEntry: false }), undefined);
+
+  const pending = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(pending.transaction_state, 'recovery_needed');
+  assert.equal(pending.transaction_phase, 'activated');
+  const recovered = run(['install', '--json'], cwd);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  const record = JSON.parse(recovered.stdout);
+  assert.equal(record.outcome, 'skipped');
+  assert.equal(record.installation_state, 'installed');
+  assert.equal(record.installed_version, packageInfo.version);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.deepEqual(readdirSync(skillsRoot), ['inferencex-api']);
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
 test('simultaneous installs serialize and the second observes the first result', async () => {
   const cwd = project('concurrent install 中文 path-');
   const destination = join(cwd, 'custom skills/inferencex-api');
@@ -472,7 +575,7 @@ test('a contender waits while the transaction owner writes its initial marker', 
       import { syncBuiltinESMExports } from 'node:module';
       const original = fs.writeFileSync;
       fs.writeFileSync = (path, data, options) => {
-        if (path === ${JSON.stringify(join(transaction, 'transaction.json'))}) {
+        if (path.startsWith(${JSON.stringify(`${transaction}/owner-`)})) {
           fs.writeFileSync = original;
           original(${JSON.stringify(ready)}, 'ready');
           while (!fs.existsSync(${JSON.stringify(release)})) {
@@ -506,6 +609,215 @@ test('a contender waits while the transaction owner writes its initial marker', 
   assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
 });
 
+test('simultaneous recoverers atomically claim a dead transaction before restoring files', async () => {
+  const cwd = project('concurrent recovery 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const previous = join(transaction, 'previous');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const before = snapshot(destination);
+  mkdirSync(transaction);
+  renameSync(destination, previous);
+  cpSync(previous, destination, { recursive: true });
+  writeFileSync(join(destination, 'SKILL.md'), 'uncommitted staged destination\n');
+  writeTransactionMarker(transaction, destination, { phase: 'previous_moved' });
+  const ready = join(cwd, 'first-recoverer-ready');
+  const release = join(cwd, 'release-first-recoverer');
+  const preload = join(project('recovery race preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.rmSync;
+      let paused = false;
+      fs.rmSync = (path, options) => {
+        if (!paused && path === ${JSON.stringify(destination)} && options?.recursive) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(release)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return original(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const first = spawnPackedInstaller(
+    ['install', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, first.child);
+  const second = spawnPackedInstaller(['install', '--json'], cwd);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1_000);
+  });
+  const secondWasWaiting = second.child.exitCode === null;
+  writeFileSync(release, 'continue');
+  const [[firstCode], [secondCode]] = await Promise.all([first.closed, second.closed]);
+
+  assert.equal(secondWasWaiting, true, second.output.stderr);
+  assert.equal(firstCode, 0, `${first.output.stdout}\n${first.output.stderr}`);
+  assert.equal(secondCode, 0, `${second.output.stdout}\n${second.output.stderr}`);
+  assert.equal(JSON.parse(first.output.stdout).outcome, 'skipped');
+  assert.equal(JSON.parse(second.output.stdout).outcome, 'skipped');
+  assert.deepEqual(snapshot(destination), before);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
+});
+
+test('a killed recovery owner leaves its exact owner token reclaimable', async () => {
+  const cwd = project('killed recovery owner 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const previous = join(transaction, 'previous');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const before = snapshot(destination);
+  mkdirSync(transaction);
+  renameSync(destination, previous);
+  cpSync(previous, destination, { recursive: true });
+  writeFileSync(join(destination, 'SKILL.md'), 'uncommitted staged destination\n');
+  writeTransactionMarker(transaction, destination, { phase: 'previous_moved' });
+  const ready = join(cwd, 'recovery-owner-ready');
+  const preload = join(project('killed recovery owner preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.rmSync;
+      fs.rmSync = (path, options) => {
+        if (path === ${JSON.stringify(destination)} && options?.recursive) {
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return original(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const { child, output, closed } = spawnPackedInstaller(
+    ['install', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, child);
+  process.kill(-child.pid, 'SIGKILL');
+  await closed;
+
+  const pending = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(pending.transaction_state, 'recovery_needed', output.stderr);
+  assert.equal(pending.transaction_phase, 'previous_moved');
+  const recovered = run(['install', '--json'], cwd);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  assert.equal(JSON.parse(recovered.stdout).outcome, 'skipped');
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readdirSync(join(cwd, '.claude/skills')), ['inferencex-api']);
+});
+
+test('a stale recovery contender cannot claim a newer transaction at the reused canonical path', async () => {
+  const cwd = project('recovery generation ABA 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const previous = join(transaction, 'previous');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const before = snapshot(destination);
+  mkdirSync(transaction);
+  renameSync(destination, previous);
+  cpSync(previous, destination, { recursive: true });
+  writeFileSync(join(destination, 'SKILL.md'), 'uncommitted staged destination\n');
+  const { path: oldMarker } = writeTransactionMarker(transaction, destination, {
+    phase: 'previous_moved',
+  });
+
+  const staleReady = join(cwd, 'stale-contender-ready');
+  const releaseStale = join(cwd, 'release-stale-contender');
+  const stalePreload = join(project('stale contender preload-'), 'preload.mjs');
+  writeFileSync(
+    stalePreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      let paused = false;
+      fs.renameSync = (source, target) => {
+        if (!paused && source === ${JSON.stringify(oldMarker)}) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(staleReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseStale)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return original(source, target);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const stale = spawnPackedInstaller(
+    ['install', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(stalePreload).href)}`,
+  );
+  await waitForFile(staleReady, stale.child);
+
+  const recovered = run(['install', '--json'], cwd);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  assert.equal(JSON.parse(recovered.stdout).outcome, 'skipped');
+
+  const currentReady = join(cwd, 'current-owner-ready');
+  const releaseCurrent = join(cwd, 'release-current-owner');
+  const currentPreload = join(project('current owner preload-'), 'preload.mjs');
+  writeFileSync(
+    currentPreload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.cpSync;
+      let paused = false;
+      fs.cpSync = (source, target, options) => {
+        const result = original(source, target, options);
+        if (!paused && target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          paused = true;
+          fs.writeFileSync(${JSON.stringify(currentReady)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(releaseCurrent)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const current = spawnPackedInstaller(
+    ['install', '--force', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(currentPreload).href)}`,
+  );
+  await waitForFile(currentReady, current.child);
+  writeFileSync(releaseStale, 'continue');
+  await new Promise((resolve) => {
+    setTimeout(resolve, 500);
+  });
+
+  assert.equal(stale.child.exitCode, null, stale.output.stderr);
+  const busy = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(busy.transaction_state, 'busy');
+  writeFileSync(releaseCurrent, 'continue');
+  const [[staleCode], [currentCode]] = await Promise.all([stale.closed, current.closed]);
+
+  assert.equal(currentCode, 0, `${current.output.stdout}\n${current.output.stderr}`);
+  assert.equal(staleCode, 0, `${stale.output.stdout}\n${stale.output.stderr}`);
+  assert.equal(JSON.parse(current.output.stdout).outcome, 'overwritten');
+  assert.equal(JSON.parse(stale.output.stdout).outcome, 'skipped');
+  assert.deepEqual(snapshot(destination), before);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+});
+
 test('malformed, foreign, and symlink transaction markers fail closed without deletion', () => {
   for (const kind of ['malformed', 'foreign', 'symlink']) {
     const cwd = project(`${kind} transaction-`);
@@ -518,19 +830,12 @@ test('malformed, foreign, and symlink transaction markers fail closed without de
       symlinkSync(outside, transaction);
     } else {
       mkdirSync(transaction);
-      writeFileSync(
-        join(transaction, 'transaction.json'),
+      writeTransactionMarker(
+        transaction,
+        destination,
         kind === 'malformed'
-          ? '{broken json'
-          : JSON.stringify({
-              schema_version: 1,
-              package: 'foreign-package',
-              skill: 'inferencex-api',
-              destination: outside,
-              owner_pid: 2_147_483_647,
-              phase: 'staged',
-              had_destination: true,
-            }),
+          ? { raw: '{broken json' }
+          : { package: 'foreign-package', destination: outside },
       );
     }
     const beforeProject = snapshot(cwd);
@@ -559,18 +864,7 @@ test('status and dry-run leave a live owner transaction untouched', () => {
   const transaction = `${destination}.inferencex-skills-transaction`;
   mkdirSync(transaction);
   cpSync(destination, join(transaction, 'stage'), { recursive: true });
-  writeFileSync(
-    join(transaction, 'transaction.json'),
-    JSON.stringify({
-      schema_version: 1,
-      package: packageInfo.name,
-      skill: 'inferencex-api',
-      destination,
-      owner_pid: process.pid,
-      phase: 'staged',
-      had_destination: true,
-    }),
-  );
+  writeTransactionMarker(transaction, destination, { ownerPid: process.pid });
   const before = snapshot(cwd);
 
   const status = JSON.parse(run(['status', '--json'], cwd).stdout);

--- a/packages/skills/test/install-recovery.test.mjs
+++ b/packages/skills/test/install-recovery.test.mjs
@@ -1,0 +1,584 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { test } from 'node:test';
+
+import { packageInfo, packageRoot, packedSkillSuite, succeeded } from './packed-skill.mjs';
+
+const suite = packedSkillSuite();
+const { project, run } = suite;
+const metadataName = '.inferencex-skills.json';
+
+function snapshot(root) {
+  return ['', ...readdirSync(root, { recursive: true })].sort().map((path) => {
+    const entry = lstatSync(join(root, path));
+    return {
+      path,
+      mode: entry.mode & 0o777,
+      contents: entry.isFile() ? readFileSync(join(root, path)).toString('base64') : null,
+      link: entry.isSymbolicLink() ? readlinkSync(join(root, path)) : null,
+    };
+  });
+}
+
+function runWithPreload(args, cwd, source) {
+  const preload = join(project('installer preload-'), 'preload.mjs');
+  writeFileSync(preload, source);
+  const previous = suite.environment.NODE_OPTIONS;
+  suite.environment.NODE_OPTIONS = `--import=${JSON.stringify(pathToFileURL(preload).href)}`;
+  try {
+    return run(args, cwd);
+  } finally {
+    if (previous === undefined) delete suite.environment.NODE_OPTIONS;
+    else suite.environment.NODE_OPTIONS = previous;
+  }
+}
+
+async function waitForFile(path, child) {
+  for (let attempt = 0; attempt < 250; attempt++) {
+    if (existsSync(path)) return;
+    if (child.exitCode !== null) throw new Error(`installer exited before ${path} was created`);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error(`timed out waiting for ${path}`);
+}
+
+function spawnPackedInstaller(args, cwd, nodeOptions) {
+  const environment = { ...suite.environment };
+  if (nodeOptions === undefined) delete environment.NODE_OPTIONS;
+  else environment.NODE_OPTIONS = nodeOptions;
+  const child = spawn(
+    'npm',
+    ['exec', '--yes', '--offline', '--package', suite.archive, '--', 'inferencex-skills', ...args],
+    {
+      cwd,
+      detached: true,
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  const output = { stdout: '', stderr: '' };
+  child.stdout.on('data', (chunk) => (output.stdout += chunk));
+  child.stderr.on('data', (chunk) => (output.stderr += chunk));
+  return { child, output, closed: once(child, 'close') };
+}
+
+test('a staging copy failure preserves the existing installation byte for byte', () => {
+  const cwd = project('copy failure 中文 path-');
+  succeeded(run(['install', '--dir', 'custom skills'], cwd));
+  const destination = join(cwd, 'custom skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  chmodSync(join(destination, 'local-notes.txt'), 0o400);
+  const oldReceipt = readFileSync(join(destination, metadataName));
+  const before = snapshot(destination);
+
+  const failed = runWithPreload(
+    ['install', '--dir', 'custom skills', '--force', '--json'],
+    cwd,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.cpSync;
+      fs.cpSync = (source, target, options) => {
+        const result = original(source, target, options);
+        if (target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          throw new Error('injected staged copy failure');
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+
+  assert.equal(failed.status, 1, `${failed.stdout}\n${failed.stderr}`);
+  assert.match(failed.stderr, /injected staged copy failure/u);
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readFileSync(join(destination, metadataName)), oldReceipt);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('a staged receipt failure preserves the existing receipt and extra files', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const oldReceipt = readFileSync(join(destination, metadataName));
+  const before = snapshot(destination);
+
+  const failed = runWithPreload(
+    ['install', '--force', '--json'],
+    cwd,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.writeFileSync;
+      fs.writeFileSync = (path, data, options) => {
+        if (path === ${JSON.stringify(join(transaction, 'stage', metadataName))}) {
+          throw new Error('injected receipt failure');
+        }
+        return original(path, data, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+
+  assert.equal(failed.status, 1, `${failed.stdout}\n${failed.stderr}`);
+  assert.match(failed.stderr, /injected receipt failure/u);
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readFileSync(join(destination, metadataName)), oldReceipt);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('an activation rename failure restores the complete previous installation', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const before = snapshot(destination);
+
+  const failed = runWithPreload(
+    ['install', '--force', '--json'],
+    cwd,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      fs.renameSync = (source, target) => {
+        if (
+          source === ${JSON.stringify(join(transaction, 'stage'))} &&
+          target === ${JSON.stringify(destination)}
+        ) {
+          throw new Error('injected activation failure');
+        }
+        return original(source, target);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+
+  assert.equal(failed.status, 1, `${failed.stdout}\n${failed.stderr}`);
+  assert.match(failed.stderr, /injected activation failure/u);
+  assert.deepEqual(snapshot(destination), before);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('a cleanup failure after activation keeps the complete new installation recoverable', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+
+  const failed = runWithPreload(
+    ['install', '--force', '--json'],
+    cwd,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.rmSync;
+      fs.rmSync = (path, options) => {
+        if (
+          path === ${JSON.stringify(transaction)} &&
+          options?.recursive &&
+          JSON.parse(fs.readFileSync(${JSON.stringify(join(transaction, 'transaction.json'))})).phase === 'activated'
+        ) {
+          throw new Error('injected cleanup failure');
+        }
+        return original(path, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+
+  assert.equal(failed.status, 1, `${failed.stdout}\n${failed.stderr}`);
+  assert.match(failed.stderr, /injected cleanup failure/u);
+  assert.deepEqual(
+    readFileSync(join(destination, 'SKILL.md')),
+    readFileSync(join(packageRoot, 'skills/inferencex-api/SKILL.md')),
+  );
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  const pending = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(pending.transaction_state, 'recovery_needed');
+  assert.equal(pending.transaction_phase, 'activated');
+
+  const recovered = run(['install', '--json'], cwd);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  const record = JSON.parse(recovered.stdout);
+  assert.equal(record.outcome, 'skipped');
+  assert.equal(record.installation_state, 'installed');
+  assert.equal(record.installed_version, packageInfo.version);
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('a successful force install replaces packaged files and preserves extras and their modes', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const localNotes = join(destination, 'local-notes.txt');
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes\n');
+  writeFileSync(localNotes, 'keep me');
+  chmodSync(localNotes, 0o400);
+
+  const upgraded = run(['install', '--force', '--json'], cwd);
+
+  assert.equal(upgraded.status, 0, `${upgraded.stdout}\n${upgraded.stderr}`);
+  assert.deepEqual(
+    readFileSync(join(destination, 'SKILL.md')),
+    readFileSync(join(packageRoot, 'skills/inferencex-api/SKILL.md')),
+  );
+  assert.equal(readFileSync(localNotes, 'utf8'), 'keep me');
+  assert.equal(lstatSync(localNotes).mode & 0o777, 0o400);
+  assert.equal(
+    JSON.parse(readFileSync(join(destination, metadataName), 'utf8')).version,
+    packageInfo.version,
+  );
+});
+
+test('status reports an interrupted transaction without claiming the old version or writing', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  mkdirSync(transaction);
+  cpSync(destination, join(transaction, 'stage'), { recursive: true });
+  writeFileSync(
+    join(transaction, 'transaction.json'),
+    JSON.stringify({
+      schema_version: 1,
+      package: packageInfo.name,
+      skill: 'inferencex-api',
+      destination,
+      owner_pid: 2_147_483_647,
+      phase: 'staged',
+      had_destination: true,
+    }),
+  );
+  const before = snapshot(cwd);
+
+  const result = run(['status', '--json'], cwd);
+
+  assert.equal(result.status, 0, result.stderr);
+  const status = JSON.parse(result.stdout);
+  assert.equal(status.installation_state, 'unknown');
+  assert.equal(status.installed_version, null);
+  assert.equal(status.transaction_state, 'recovery_needed');
+  assert.equal(status.transaction_phase, 'staged');
+  assert.match(status.reason, /needs recovery/u);
+  assert.deepEqual(snapshot(cwd), before);
+});
+
+test('dry-run reports required recovery without changing the transaction or installation', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  mkdirSync(transaction);
+  cpSync(destination, join(transaction, 'stage'), { recursive: true });
+  writeFileSync(
+    join(transaction, 'transaction.json'),
+    JSON.stringify({
+      schema_version: 1,
+      package: packageInfo.name,
+      skill: 'inferencex-api',
+      destination,
+      owner_pid: 2_147_483_647,
+      phase: 'staged',
+      had_destination: true,
+    }),
+  );
+  const before = snapshot(cwd);
+
+  const result = run(['install', '--force', '--dry-run', '--json'], cwd);
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  const preview = JSON.parse(result.stdout);
+  assert.equal(preview.outcome, 'would_recover_then_overwrite');
+  assert.equal(preview.installation_state, 'unknown');
+  assert.equal(preview.installed_version, null);
+  assert.equal(preview.transaction_state, 'recovery_needed');
+  assert.ok(preview.write_paths.length > 0);
+  assert.deepEqual(snapshot(cwd), before);
+});
+
+test('a process killed between activation renames is recovered by the next install', async () => {
+  const cwd = project('killed activation 中文 path-');
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const receipt = join(destination, metadataName);
+  const powerx = join(destination, 'scripts/export-powerx.mjs');
+  writeFileSync(receipt, JSON.stringify({ package: packageInfo.name, version: '0.1.99' }));
+  writeFileSync(
+    powerx,
+    readFileSync(powerx, 'utf8').replace(
+      /^const PACKAGE_VERSION = .*;$/mu,
+      "const PACKAGE_VERSION = '0.1.99';",
+    ),
+  );
+  writeFileSync(join(destination, 'SKILL.md'), 'old skill bytes survive the killed process\n');
+  writeFileSync(join(destination, 'local-notes.txt'), 'keep me');
+  const oldReceipt = readFileSync(receipt);
+  const before = snapshot(destination);
+  const ready = join(cwd, 'activation-ready');
+  const preload = join(project('kill preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.renameSync;
+      fs.renameSync = (source, target) => {
+        if (
+          source === ${JSON.stringify(join(transaction, 'stage'))} &&
+          target === ${JSON.stringify(destination)}
+        ) {
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+        }
+        return original(source, target);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const { child, output, closed } = spawnPackedInstaller(
+    ['install', '--force'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, child);
+  process.kill(-child.pid, 'SIGKILL');
+  await closed;
+  assert.equal(lstatSync(destination, { throwIfNoEntry: false }), undefined, output.stderr);
+
+  const pending = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(pending.installation_state, 'unknown');
+  assert.equal(pending.transaction_state, 'recovery_needed');
+  assert.equal(pending.transaction_phase, 'previous_moved');
+  const beforePreview = snapshot(cwd);
+  const preview = JSON.parse(run(['install', '--dry-run', '--json'], cwd).stdout);
+  assert.equal(preview.outcome, 'would_recover_then_skip');
+  assert.deepEqual(preview.write_paths, []);
+  assert.deepEqual(snapshot(cwd), beforePreview);
+
+  const recovered = run(['install', '--json'], cwd);
+  assert.equal(recovered.status, 0, `${recovered.stdout}\n${recovered.stderr}`);
+  const recoveredRecord = JSON.parse(recovered.stdout);
+  assert.equal(recoveredRecord.outcome, 'skipped');
+  assert.equal(recoveredRecord.installation_state, 'installed');
+  assert.equal(recoveredRecord.installed_version, '0.1.99');
+  assert.deepEqual(snapshot(destination), before);
+  assert.deepEqual(readFileSync(receipt), oldReceipt);
+  assert.equal(readFileSync(join(destination, 'local-notes.txt'), 'utf8'), 'keep me');
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+  rmSync(ready);
+});
+
+test('simultaneous installs serialize and the second observes the first result', async () => {
+  const cwd = project('concurrent install 中文 path-');
+  const destination = join(cwd, 'custom skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const ready = join(cwd, 'stage-ready');
+  const release = join(cwd, 'release-first-installer');
+  const preload = join(project('concurrent preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.cpSync;
+      fs.cpSync = (source, target, options) => {
+        const result = original(source, target, options);
+        if (target === ${JSON.stringify(join(transaction, 'stage'))}) {
+          fs.writeFileSync(${JSON.stringify(ready)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(release)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return result;
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const first = spawnPackedInstaller(
+    ['install', '--dir', 'custom skills', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, first.child);
+  const busy = JSON.parse(run(['status', '--dir', 'custom skills', '--json'], cwd).stdout);
+  assert.equal(busy.installation_state, 'unknown');
+  assert.equal(busy.transaction_state, 'busy');
+
+  const second = spawnPackedInstaller(['install', '--dir', 'custom skills', '--json'], cwd);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 150);
+  });
+  assert.equal(second.child.exitCode, null, second.output.stderr);
+  writeFileSync(release, 'continue');
+  const [[firstCode], [secondCode]] = await Promise.all([first.closed, second.closed]);
+
+  assert.equal(firstCode, 0, `${first.output.stdout}\n${first.output.stderr}`);
+  assert.equal(secondCode, 0, `${second.output.stdout}\n${second.output.stderr}`);
+  assert.equal(JSON.parse(first.output.stdout).outcome, 'installed');
+  const secondRecord = JSON.parse(second.output.stdout);
+  assert.equal(secondRecord.outcome, 'skipped');
+  assert.equal(secondRecord.installation_state, 'installed');
+  assert.equal(secondRecord.installed_version, packageInfo.version);
+  assert.equal(
+    JSON.parse(readFileSync(join(destination, metadataName), 'utf8')).version,
+    packageInfo.version,
+  );
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('a contender waits while the transaction owner writes its initial marker', async () => {
+  const cwd = project();
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  const ready = join(cwd, 'transaction-directory-ready');
+  const release = join(cwd, 'release-marker-write');
+  const preload = join(project('marker preload-'), 'preload.mjs');
+  writeFileSync(
+    preload,
+    `
+      import fs from 'node:fs';
+      import { syncBuiltinESMExports } from 'node:module';
+      const original = fs.writeFileSync;
+      fs.writeFileSync = (path, data, options) => {
+        if (path === ${JSON.stringify(join(transaction, 'transaction.json'))}) {
+          fs.writeFileSync = original;
+          original(${JSON.stringify(ready)}, 'ready');
+          while (!fs.existsSync(${JSON.stringify(release)})) {
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 20);
+          }
+        }
+        return original(path, data, options);
+      };
+      syncBuiltinESMExports();
+    `,
+  );
+  const first = spawnPackedInstaller(
+    ['install', '--json'],
+    cwd,
+    `--import=${JSON.stringify(pathToFileURL(preload).href)}`,
+  );
+  await waitForFile(ready, first.child);
+  const second = spawnPackedInstaller(['install', '--json'], cwd);
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1_000);
+  });
+  const secondWasWaiting = second.child.exitCode === null;
+  writeFileSync(release, 'continue');
+  const [[firstCode], [secondCode]] = await Promise.all([first.closed, second.closed]);
+
+  assert.equal(secondWasWaiting, true, second.output.stderr);
+  assert.equal(firstCode, 0, `${first.output.stdout}\n${first.output.stderr}`);
+  assert.equal(secondCode, 0, `${second.output.stdout}\n${second.output.stderr}`);
+  assert.equal(JSON.parse(first.output.stdout).outcome, 'installed');
+  assert.equal(JSON.parse(second.output.stdout).outcome, 'skipped');
+  assert.equal(lstatSync(transaction, { throwIfNoEntry: false }), undefined);
+});
+
+test('malformed, foreign, and symlink transaction markers fail closed without deletion', () => {
+  for (const kind of ['malformed', 'foreign', 'symlink']) {
+    const cwd = project(`${kind} transaction-`);
+    succeeded(run(['install'], cwd));
+    const destination = join(cwd, '.claude/skills/inferencex-api');
+    const transaction = `${destination}.inferencex-skills-transaction`;
+    const outside = project(`${kind} foreign data-`);
+    writeFileSync(join(outside, 'sentinel.txt'), 'never delete me');
+    if (kind === 'symlink') {
+      symlinkSync(outside, transaction);
+    } else {
+      mkdirSync(transaction);
+      writeFileSync(
+        join(transaction, 'transaction.json'),
+        kind === 'malformed'
+          ? '{broken json'
+          : JSON.stringify({
+              schema_version: 1,
+              package: 'foreign-package',
+              skill: 'inferencex-api',
+              destination: outside,
+              owner_pid: 2_147_483_647,
+              phase: 'staged',
+              had_destination: true,
+            }),
+      );
+    }
+    const beforeProject = snapshot(cwd);
+    const beforeOutside = snapshot(outside);
+
+    const status = run(['status', '--json'], cwd);
+    assert.equal(status.status, 0, status.stderr);
+    const record = JSON.parse(status.stdout);
+    assert.equal(record.installation_state, 'unknown');
+    assert.equal(record.installed_version, null);
+    assert.equal(record.transaction_state, 'blocked');
+
+    const failed = run(['install', '--force', '--json'], cwd);
+    assert.equal(failed.status, 1, `${failed.stdout}\n${failed.stderr}`);
+    assert.equal(JSON.parse(failed.stdout).outcome, 'failed');
+    assert.deepEqual(snapshot(cwd), beforeProject);
+    assert.deepEqual(snapshot(outside), beforeOutside);
+    assert.equal(readFileSync(join(outside, 'sentinel.txt'), 'utf8'), 'never delete me');
+  }
+});
+
+test('status and dry-run leave a live owner transaction untouched', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const transaction = `${destination}.inferencex-skills-transaction`;
+  mkdirSync(transaction);
+  cpSync(destination, join(transaction, 'stage'), { recursive: true });
+  writeFileSync(
+    join(transaction, 'transaction.json'),
+    JSON.stringify({
+      schema_version: 1,
+      package: packageInfo.name,
+      skill: 'inferencex-api',
+      destination,
+      owner_pid: process.pid,
+      phase: 'staged',
+      had_destination: true,
+    }),
+  );
+  const before = snapshot(cwd);
+
+  const status = JSON.parse(run(['status', '--json'], cwd).stdout);
+  assert.equal(status.installation_state, 'unknown');
+  assert.equal(status.installed_version, null);
+  assert.equal(status.transaction_state, 'busy');
+  const preview = JSON.parse(run(['install', '--force', '--dry-run', '--json'], cwd).stdout);
+  assert.equal(preview.outcome, 'would_wait_for_install');
+  assert.equal(preview.transaction_state, 'busy');
+  assert.deepEqual(snapshot(cwd), before);
+});

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -317,6 +317,10 @@ test('0.4 prerelease and later receipts require matching AgentX versions', () =>
         join(destination, 'scripts/response-budget.mjs'),
         `const PACKAGE_VERSION = '${version}';\n`,
       );
+      writeFileSync(
+        join(destination, 'scripts/cli-contract.mjs'),
+        `const PACKAGE_VERSION = '${version}';\n`,
+      );
     }
     const matching = run(['status'], cwd);
     succeeded(matching);
@@ -330,6 +334,41 @@ test('0.9 status does not claim a usable installation when its response reader i
   const helper = join(cwd, '.claude/skills/inferencex-api/scripts/response-budget.mjs');
   rmSync(helper);
   assert.equal(jsonResult(run(['status', '--json'], cwd)).installation_state, 'unknown');
+});
+
+test('0.10 status requires the shared CLI contract with a matching package version', () => {
+  const cwd = project();
+  succeeded(run(['install'], cwd));
+  const destination = join(cwd, '.claude/skills/inferencex-api');
+  const scripts = join(destination, 'scripts');
+  const version = '0.10.0';
+  writeFileSync(
+    join(destination, metadataName),
+    JSON.stringify({ package: packageInfo.name, version }),
+  );
+  for (const name of readdirSync(scripts).filter((entry) => entry.endsWith('.mjs'))) {
+    const path = join(scripts, name);
+    writeFileSync(
+      path,
+      readFileSync(path, 'utf8').replace(
+        /^const PACKAGE_VERSION = .*;$/mu,
+        `const PACKAGE_VERSION = '${version}';`,
+      ),
+    );
+  }
+  const contract = join(scripts, 'cli-contract.mjs');
+  const source = readFileSync(contract);
+  rmSync(contract);
+  const missing = run(['status'], cwd);
+  succeeded(missing);
+  assert.match(
+    missing.stdout,
+    /Installed version: unknown \(installed CLI contract is missing or not a regular file\)/u,
+  );
+  writeFileSync(contract, source.toString().replace("'0.9.0'", `'${version}'`));
+  const matching = run(['status'], cwd);
+  succeeded(matching);
+  assert.match(matching.stdout, /Installed version: 0\.10\.0/u);
 });
 
 test('0.5 status verifies the provenance helper without executing it', () => {

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -82,12 +82,18 @@ test('the real npm archive installs the single skill with all bundled resources'
   assert.ok(suite.packedFiles.includes('README.md'));
   assert.ok(suite.packedFiles.includes('LICENSE'));
   assert.ok(suite.packedFiles.includes('bin/install.mjs'));
+  assert.ok(suite.packedFiles.includes('bin/install-transaction.mjs'));
   assert.ok(suite.packedFiles.includes('skills/inferencex-api/SKILL.md'));
   assert.ok(
     suite.packedFiles.every(
       (path) =>
-        ['package.json', 'README.md', 'LICENSE', 'bin/install.mjs'].includes(path) ||
-        path.startsWith('skills/inferencex-api/'),
+        [
+          'package.json',
+          'README.md',
+          'LICENSE',
+          'bin/install.mjs',
+          'bin/install-transaction.mjs',
+        ].includes(path) || path.startsWith('skills/inferencex-api/'),
     ),
   );
   for (const path of suite.packedFiles.filter((entry) => entry.startsWith('skills/'))) {
@@ -1000,10 +1006,11 @@ test('JSON usage failures stay one document and preserve exit code 2 without wri
   }
 });
 
-test('an operational copy failure removes the receipt instead of reporting a successful JSON installation', () => {
+test('an operational staging failure preserves the prior receipt and installed state', () => {
   const cwd = project();
   succeeded(run(['install'], cwd));
   const destination = join(cwd, '.claude/skills/inferencex-api');
+  const before = snapshot(destination);
   const preload = join(project(), 'fail-copy.mjs');
   writeFileSync(
     preload,
@@ -1012,8 +1019,11 @@ test('an operational copy failure removes the receipt instead of reporting a suc
     import { syncBuiltinESMExports } from 'node:module';
     const copy = fs.cpSync;
     fs.cpSync = (source, target, options) => {
-      if (target === ${JSON.stringify(destination)}) throw new Error('injected copy failure');
-      return copy(source, target, options);
+      const result = copy(source, target, options);
+      if (target === ${JSON.stringify(`${destination}.inferencex-skills-transaction/stage`)}) {
+        throw new Error('injected copy failure');
+      }
+      return result;
     };
     syncBuiltinESMExports();
   `,
@@ -1025,10 +1035,10 @@ test('an operational copy failure removes the receipt instead of reporting a suc
     const error = jsonResult(failed, 1);
     assert.equal(error.outcome, 'failed');
     assert.match(failed.stderr, /Could not install the skill: injected copy failure/);
-    assert.equal(lstatSync(join(destination, metadataName), { throwIfNoEntry: false }), undefined);
+    assert.deepEqual(snapshot(destination), before);
     const status = jsonResult(run(['status', '--json'], cwd));
-    assert.equal(status.installation_state, 'unknown');
-    assert.equal(status.installed_version, null);
+    assert.equal(status.installation_state, 'installed');
+    assert.equal(status.installed_version, packageInfo.version);
   } finally {
     if (priorOptions === undefined) delete suite.environment.NODE_OPTIONS;
     else suite.environment.NODE_OPTIONS = priorOptions;

--- a/packages/skills/test/install.test.mjs
+++ b/packages/skills/test/install.test.mjs
@@ -365,7 +365,7 @@ test('0.10 status requires the shared CLI contract with a matching package versi
     missing.stdout,
     /Installed version: unknown \(installed CLI contract is missing or not a regular file\)/u,
   );
-  writeFileSync(contract, source.toString().replace("'0.9.0'", `'${version}'`));
+  writeFileSync(contract, source);
   const matching = run(['status'], cwd);
   succeeded(matching);
   assert.match(matching.stdout, /Installed version: 0\.10\.0/u);

--- a/packages/skills/test/packed-skill.mjs
+++ b/packages/skills/test/packed-skill.mjs
@@ -65,6 +65,7 @@ export function packedSkillSuite() {
     );
     const [packed] = JSON.parse(result.stdout);
     archive = join(temporaryRoot, packed.filename);
+    suite.archive = archive;
     suite.packedFiles = packed.files.map((file) => file.path);
   });
   after(() => rmSync(temporaryRoot, { recursive: true, force: true }));

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -32,6 +32,7 @@ const EXPECTED_FILES = [
   'skills/inferencex-api/references/tco.md',
   'skills/inferencex-api/references/releases.md',
   'skills/inferencex-api/references/collectivex.md',
+  'skills/inferencex-api/scripts/cli-contract.mjs',
   'skills/inferencex-api/scripts/response-budget.mjs',
   'skills/inferencex-api/scripts/export-agentx.mjs',
   'skills/inferencex-api/scripts/export-powerx.mjs',
@@ -100,7 +101,7 @@ test('release rejects changed bytes and a different reviewed archive', () => {
   assert.throws(() => verifyArchive({ ...record, integrity: 'sha512-other' }, bytes), /integrity/);
 });
 
-test('release content boundary is the exact independent twelve-file contract', () => {
+test('release content boundary is the exact independent file contract', () => {
   verifyContents(EXPECTED_FILES.toReversed());
   for (const missing of EXPECTED_FILES) {
     assert.throws(

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -26,6 +26,7 @@ const EXPECTED_FILES = [
   'package.json',
   'skills/inferencex-api/SKILL.md',
   'skills/inferencex-api/references/agentx.md',
+  'skills/inferencex-api/references/cli-contract.md',
   'skills/inferencex-api/references/powerx.md',
   'skills/inferencex-api/references/public-api-examples.md',
   'skills/inferencex-api/references/provenance.md',

--- a/packages/skills/test/release.test.mjs
+++ b/packages/skills/test/release.test.mjs
@@ -23,6 +23,7 @@ const EXPECTED_FILES = [
   'LICENSE',
   'README.md',
   'bin/install.mjs',
+  'bin/install-transaction.mjs',
   'package.json',
   'skills/inferencex-api/SKILL.md',
   'skills/inferencex-api/references/agentx.md',

--- a/packages/skills/test/verify-release.test.py
+++ b/packages/skills/test/verify-release.test.py
@@ -338,6 +338,86 @@ class RetryTests(unittest.TestCase):
             check.captured_request(self.root, 'lookup', context['query_url'], context | {'retrieved_at': '2026-09-06T00:00:00Z'})
 
 
+class StructuredErrorVerifierTests(unittest.TestCase):
+    @staticmethod
+    def envelope(**changes):
+        document = {
+            'schema_version': 1,
+            'package': check.PACKAGE,
+            'package_version': '0.10.0',
+            'command': 'export-powerx',
+            'error': {'code': 'INVALID_ARGUMENT', 'message': 'Unknown option --invalid-argument'},
+        }
+        document.update(changes)
+        return document
+
+    @staticmethod
+    def failure(document, *, returncode=2, stdout='', extra_stderr=''):
+        return subprocess.CalledProcessError(
+            returncode,
+            ['node', 'export-powerx.mjs'],
+            output=stdout,
+            stderr=json.dumps(document, separators=(',', ':')) + '\n' + extra_stderr,
+        )
+
+    def test_structured_error_requires_exact_process_and_envelope_contract(self):
+        expected = self.envelope()
+        self.assertEqual(
+            check.check_structured_error(self.failure(expected), 'export-powerx', '0.10.0'),
+            expected,
+        )
+        mutations = [
+            ('missing schema', {key: value for key, value in self.envelope().items()
+                                if key != 'schema_version'}),
+            ('malformed schema', self.envelope(schema_version='1')),
+            ('wrong schema', self.envelope(schema_version=2)),
+            ('wrong version', self.envelope(package_version='0.10.1')),
+            ('wrong command', self.envelope(command='export-agentx')),
+            ('wrong code', self.envelope(error={'code': 'INTERNAL_ERROR', 'message': 'bad'})),
+            ('empty message', self.envelope(error={'code': 'INVALID_ARGUMENT', 'message': ''})),
+            ('extra envelope field', self.envelope(debug=True)),
+        ]
+        for name, document in mutations:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                check.check_structured_error(self.failure(document), 'export-powerx', '0.10.0')
+        for name, failure in [
+            ('nonempty stdout', self.failure(expected, stdout='diagnostic\n')),
+            ('extra stderr diagnostic', self.failure(expected, extra_stderr='debug\n')),
+            ('wrong exit code', self.failure(expected, returncode=1)),
+        ]:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                check.check_structured_error(failure, 'export-powerx', '0.10.0')
+
+    def test_structured_contract_is_explicitly_gated_to_0_10_and_later(self):
+        self.assertFalse(check.structured_errors_required('0.4.0'))
+        self.assertFalse(check.structured_errors_required('0.9.9'))
+        self.assertTrue(check.structured_errors_required('0.10.0'))
+        self.assertTrue(check.structured_errors_required('1.0.0'))
+
+    def test_powerx_schema_is_additive_from_0_10(self):
+        legacy = {'metadata': {'package_version': '0.9.9'}, 'rows': []}
+        check.check_powerx_schema(legacy, '0.9.9')
+        current = {'schema_version': 1, 'metadata': {'package_version': '0.10.0'}, 'rows': []}
+        check.check_powerx_schema(current, '0.10.0')
+        for name, document in [
+            ('missing', legacy),
+            ('malformed', current | {'schema_version': '1'}),
+            ('wrong', current | {'schema_version': 2}),
+            ('extra field', current | {'debug': True}),
+        ]:
+            with self.subTest(name=name), self.assertRaises(ValueError):
+                check.check_powerx_schema(document, '0.10.0')
+
+    def test_powerx_export_check_enforces_the_0_10_schema_before_payload_checks(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            project = Path(temporary)
+            check.save(project / 'powerx.json', {'metadata': {}, 'rows': []})
+            with patch.object(check, 'check_metadata') as metadata, \
+                    self.assertRaisesRegex(ValueError, 'PowerX JSON schema version'):
+                check.check_exports(project, [], [], SimpleNamespace(), '0.10.0')
+        metadata.assert_not_called()
+
+
 class AgentXVerifierTests(unittest.TestCase):
     def setUp(self):
         temporary = tempfile.TemporaryDirectory()
@@ -1032,6 +1112,7 @@ globalThis.fetch = async (input) => {{
         install.assert_not_called()
 
     def test_candidate_orchestrates_all_six_helpers_for_both_targets(self):
+        contract_version = '0.10.0'
         stream = io.BytesIO()
         with tarfile.open(fileobj=stream, mode='w:gz') as packed:
             content = b'skill'
@@ -1039,7 +1120,7 @@ globalThis.fetch = async (input) => {{
             entry.size = len(content)
             packed.addfile(entry, io.BytesIO(content))
         body = stream.getvalue()
-        record = {'name': check.PACKAGE, 'version': VERSION, 'filename': 'candidate.tgz',
+        record = {'name': check.PACKAGE, 'version': contract_version, 'filename': 'candidate.tgz',
                   'sha256': hashlib.sha256(body).hexdigest(),
                   'integrity': 'sha512-' + base64.b64encode(hashlib.sha512(body).digest()).decode()}
         (self.root / 'candidate.tgz').write_bytes(body)
@@ -1055,8 +1136,24 @@ globalThis.fetch = async (input) => {{
             projects[target] = project
             return project, {}
 
+        def execute(command, *_args):
+            command = [str(part) for part in command]
+            if '--invalid-argument' not in command:
+                return ''
+            helper = 'inferencex-skills' if 'inferencex-skills' in command else Path(command[1]).stem
+            envelope = {
+                'schema_version': 1,
+                'package': check.PACKAGE,
+                'package_version': contract_version,
+                'command': helper,
+                'error': {'code': 'INVALID_ARGUMENT', 'message': 'Unknown option --invalid-argument'},
+            }
+            raise subprocess.CalledProcessError(
+                2, command, output='', stderr=json.dumps(envelope, separators=(',', ':')) + '\n')
+
         with patch.object(sys, 'argv', command), patch.object(check, 'install_target', side_effect=install) as installs, \
-                patch.object(check, 'check_installed') as installed_checks, patch.object(check, 'run') as runs, \
+                patch.object(check, 'check_installed') as installed_checks, \
+                patch.object(check, 'run', side_effect=execute) as runs, \
                 patch.object(check, 'captured_export', return_value=[]), \
                 patch.object(check, 'check_exports', return_value={'selected_rows': 1}), \
                 patch.object(check, 'check_agentx_capture', return_value={'selected_rows': 1}), \
@@ -1070,10 +1167,24 @@ globalThis.fetch = async (input) => {{
         for target, project in projects.items():
             target_commands = [command for command, call in zip(commands, runs.call_args_list)
                                if call.args[1] == project]
-            self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in target_commands), 2, target)
-            self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in target_commands), 3, target)
+            positive_commands = [command for command in target_commands if '--invalid-argument' not in command]
+            self.assertEqual(sum('export-powerx.mjs' in ' '.join(command) for command in positive_commands), 2, target)
+            self.assertEqual(sum('export-agentx.mjs' in ' '.join(command) for command in positive_commands), 3, target)
             for helper in ['investigate-result', 'compare-tco', 'compare-releases', 'compare-collectivex']:
-                self.assertEqual(sum(f'{helper}.mjs' in ' '.join(command) for command in target_commands), 1, target)
+                self.assertEqual(sum(f'{helper}.mjs' in ' '.join(command) for command in positive_commands), 1, target)
+            negatives = [command for command in target_commands if '--invalid-argument' in command]
+            self.assertEqual(len(negatives), 7, target)
+            self.assertTrue(all(command[-3:] == ['--error-format', 'json', '--invalid-argument']
+                                for command in negatives), target)
+            helper_names = {
+                'inferencex-skills' if 'inferencex-skills' in command else Path(command[1]).stem
+                for command in negatives
+            }
+            self.assertEqual(helper_names, {
+                'export-powerx', 'export-agentx', 'investigate-result', 'compare-tco',
+                'compare-releases', 'compare-collectivex', 'inferencex-skills'}, target)
+            installer, = [command for command in negatives if 'inferencex-skills' in command]
+            self.assertIn('--offline', installer)
 
     def test_agents_prepares_canonical_projects_with_only_archive_and_hashed_prompt(self):
         stream = io.BytesIO()


### PR DESCRIPTION
Add opt-in `--error-format json` to all six installed data helpers and the installer: invalid arguments exit 2, operational failures exit 1, and graceful cancellation exits 130. Default text behavior remains compatible; PowerX JSON gains `schema_version: 1`.

Stage complete upgrades before activation and recover supported interrupted transactions. The installer handles cancellation between filesystem phases and while waiting: before activation commits it rolls back; after commit it finishes cleanup and reports the result. Status/preview report the active canonical transaction when older terminal cleanup also exists. PowerX correctly classifies request-budget timeouts even when fetch rejects with a generic AbortError.

Validation at `bc4b0c42`: Node 24/26 full packed suites (255/255 each), workspace unit tests (6,029), lint/format/typecheck, and independent real-signal/crash replays passed. The unchanged app previously passed 159 smoke checks. The exact archive passed live verification of all six helpers and clean Codex/Claude natural-language discovery tasks with unchanged installed files. Independent audits checked source responses, export bytes, command execution, and scoped final answers. Public installation will be verified anonymously after publication.

Accepted Node 24 archive SHA-256: `afbc939dc4956aa96ad58b908f3e8c45c390915f812e9cc3532872f22b3002c9`.

## 中文说明

为六个已安装的数据 helper 和安装器增加可选的 `--error-format json`：参数错误退出码为 2，运行失败为 1，正常响应取消信号为 130。默认文本行为保持兼容；PowerX JSON 增加 `schema_version: 1`。

升级时先准备完整技能目录再切换安装，并恢复支持的中断事务。安装器在文件操作阶段之间及等待期间处理取消信号：切换正式生效前回滚，生效之后则完成清理并报告结果。旧终态清理与当前事务并存时，状态和预览显示当前 canonical 事务。PowerX 即使收到通用 AbortError，也能正确识别请求超时。

`bc4b0c42` 已通过 Node 24/26 完整打包测试（各 255/255）、6,029 项工作区单元测试、lint、格式和类型检查，以及独立的真实信号和崩溃复现。未改动的应用此前已通过 159 项 smoke 检查。该安装包通过全部六个 helper 的真实 API 验证，以及干净项目中的 Codex/Claude 自然语言自动发现任务，安装文件保持不变。独立验收核对了源响应、导出字节、命令执行记录，以及最终答复的数据范围。发布后继续做匿名公开安装验收。

已验收的 Node 24 安装包 SHA-256：`afbc939dc4956aa96ad58b908f3e8c45c390915f812e9cc3532872f22b3002c9`。
