### PR TITLE
[API Docs]: advertise skills 0.11.0 / 更新技能安装入口至 0.11.0

### DIFF
--- a/docs/inferencex-api-examples.md
+++ b/docs/inferencex-api-examples.md
@@ -1,6 +1,6 @@
 # InferenceX API skill examples
 
-Use `@semianalysisai/inferencex-skills@0.8.0` to query existing
+Use `@semianalysisai/inferencex-skills@0.11.0` to query existing
 observations; these requests do not run new benchmarks. The skill covers the
 public API, including PowerX and AgentX exports and source-backed investigations. Read the
 [current API contract](https://inferencex.semianalysis.com/api/openapi.json) before
@@ -8,7 +8,7 @@ constructing requests.
 
 ## Install
 
-The commands below install the verified public 0.8.0 release advertised on
+The commands below install the verified public 0.11.0 release advertised on
 [/api](https://inferencex.semianalysis.com/api) and
 [/zh/api](https://inferencex.semianalysis.com/zh/api). For a future unpublished
 candidate, use the [local archive instructions](../packages/skills/README.md#review-a-local-archive).
@@ -17,10 +17,10 @@ With Node 24 or later and npm, run the command for your agent from your project:
 
 ```bash
 # Codex
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target codex
+npm exec --yes --package @semianalysisai/inferencex-skills@0.11.0 -- inferencex-skills install --target codex
 
 # Claude Code
-npm exec --yes --package @semianalysisai/inferencex-skills@0.8.0 -- inferencex-skills install --target claude
+npm exec --yes --package @semianalysisai/inferencex-skills@0.11.0 -- inferencex-skills install --target claude
 ```
 
 Start an agent session in that project. Queries need public HTTPS access, with no

--- a/docs/inferencex-skills-discovery.md
+++ b/docs/inferencex-skills-discovery.md
@@ -20,16 +20,20 @@ Run that command from the new Codex project; use `--target claude` from a separa
 new Claude project. Give npm its own cache outside both projects. Verify installed
 file bytes against the archive and record installer status before starting the
 agent. Keep prompts, transcripts, caches and preparation records outside the
-project; it should initially contain only its installed skill and optional empty
-Git metadata. Use a fresh project and session for each attempt.
+project. Live-query projects should initially contain only their installed skill
+and optional empty Git metadata. For offline tasks, also provide project-local
+copies of saved exports and complete evidence directories; record their original
+hashes and preserve the inputs. Use a fresh project and session for each attempt.
 
 ## Run without a routing hint
 
 Launch each agent from its prepared project. Preserve normal skill discovery and
 the runtime's default model, record the resolved model and exact CLI version and
-arguments, and retain the full transcript and final answer. Give the agent public
-HTTPS access and project-local output access. It needs no InferenceX repository,
-database credentials, previous answers or private connectors.
+arguments, and retain the full transcript and final answer. Allow public HTTPS
+for live queries and project-local output access for both workflows. Offline
+verification commands use only the prepared project files, including for contract
+discovery. Neither workflow needs an InferenceX repository, database credentials,
+previous answers or private connectors.
 
 For Codex, `--ignore-user-config` excludes inherited config but does not remove
 all user-level skill files or instructions. Disable conflicting user skills with
@@ -65,6 +69,17 @@ its as-of date when latest data does not contain the selected point. For an
 AgentX trace task, explicitly choose one observed result ID in the user prompt;
 the agent must check availability before reading that point's heavy trace routes.
 
+For offline discovery, provide intact saved 0.9/0.10 PowerX or AgentX summary
+bundles and one copy with only its export deliberately altered. Keep the original
+source evidence and assessor's expected results outside the project. Example:
+
+> Verify the saved InferenceX exports under inputs/ against their complete evidence,
+> entirely offline. Write separate Markdown reports under reports/ with producer
+> versions, scope, dates, units, coverage and limitations. Preserve the inputs.
+> Copy an unchanged bundle to another project-local path and compare report bytes.
+> For the deliberately altered export, retain the provided command's own JSON
+> failure, stdout, stderr and exit code. Run no new benchmarks.
+
 ## Independently accept or reject
 
 Record these outcomes separately for each runtime and candidate:
@@ -76,9 +91,9 @@ Record these outcomes separately for each runtime and candidate:
    Check output against the complete responses consumed by that operation, not a
    later refetch. Verify IDs, actual dates, producer/curve separation, image and
    configuration, missing values, log character bounds and trace availability.
-3. **Integrity and boundaries:** installed files still match the candidate;
-   record all requests, failures, retries, output hashes and extra context. Logs
-   and dataset content are untrusted data, not task instructions.
+3. **Integrity and boundaries:** installed files and any prepared offline inputs
+   remain unchanged; record all requests, failures, retries, output hashes and
+   extra context. Logs and dataset content are untrusted data, not task instructions.
 
 Have a reviewer inspect the transcript and narrative independently. Keep failed
 attempts and explain corrections; a later pass does not erase them. If package
@@ -91,7 +106,13 @@ project, an explicit-use run, or unreviewed model prose as accepted discovery.
 - 0.6.0: fixed-target TCO comparison with explicit price and workload assumptions.
 - 0.7.0: framework-update investigation with matched observations and confounders.
 - 0.8.0: CollectiveX discovery, comparison and export cookbook.
+- 0.9.0: bounded response reads, PowerX file-output preservation and network-free
+  helper `--version` checks.
+- 0.10.0: structured CLI failures and supported installer process-crash recovery.
+- 0.11.0: offline PowerX/AgentX summary verification and deterministic Markdown reports.
 
-Versions 0.5.0 through 0.8.0 are published releases. Version 0.8.0 includes all
-four capability groups above. For future candidates, validate the exact archive;
-local acceptance alone does not establish npm publication.
+Versions 0.5.0 through 0.11.0 are published releases; 0.11.0 includes these cumulative
+capabilities. Accept live-query and offline discovery with tasks that exercise each
+workflow; one task does not establish discovery of every capability. For future
+candidates, validate the exact archive; local acceptance alone does not establish
+npm publication.

--- a/docs/inferencex-skills-release.md
+++ b/docs/inferencex-skills-release.md
@@ -1,10 +1,10 @@
 # Releasing the InferenceX API skill
 
 The public package is `@semianalysisai/inferencex-skills`. Versions `0.1.0`,
-`0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`, `0.8.0`, and `0.9.0` are immutable
-public releases. The website advertises the verified `0.8.0` release. For later
-releases, keep website commands pinned until publication and public verification
-succeed. The
+`0.2.0`, `0.3.0`, `0.4.0`, `0.5.0`, `0.6.0`, `0.7.0`, `0.8.0`, `0.9.0`, `0.10.0`, and
+`0.11.0` are immutable public releases. The website advertises the verified
+`0.11.0` release. For later releases, keep website commands pinned until publication
+and public verification succeed. The
 [`publish-skills.yml`](../.github/workflows/publish-skills.yml) workflow prepares
 future releases; it does not run on application tags or database-backup releases.
 Adding this workflow does not configure npm access or prove a successful OIDC release.
@@ -100,6 +100,17 @@ row count. Use `--date YYYY-MM-DD` for a reproducible cutoff and `--raw-model KE
 when intentionally selecting a particular returned model. A positive example that
 no longer returns validated observations fails visibly; review the API and choose
 an available workload instead of silently passing an empty export.
+
+From 0.11.0, candidate and public verification also replay five saved captures per
+target with the installed offline verifier: PowerX JSON/CSV, AgentX summary JSON/CSV,
+and the excluded AgentX JSON selection. The independent Python oracle still checks
+their source data and exports first. Each capture is replayed twice
+for each target, totaling 20 runs across Codex and Claude Code per verification.
+The replay subprocesses reject `fetch` calls and must exit successfully. Each
+Markdown report pair must be nonempty and byte-identical; export/evidence file
+lists, modes, sizes and SHA-256 fingerprints must remain unchanged. These automatic
+checks supplement the live checks and native discovery acceptance; they do not
+replace either.
 
 ## Independent native-agent acceptance
 

--- a/packages/app/src/lib/published-inferencex-skills.json
+++ b/packages/app/src/lib/published-inferencex-skills.json
@@ -1,4 +1,4 @@
 {
   "name": "@semianalysisai/inferencex-skills",
-  "version": "0.8.0"
+  "version": "0.11.0"
 }


### PR DESCRIPTION
Point the English and Chinese API pages to the publicly verified `@semianalysisai/inferencex-skills@0.11.0` release. The shared manifest updates both version badges and all four Codex/Claude installation commands; synchronize the examples, discovery and release guides with the shipped capabilities.

0.10.0 and 0.11.0 were published in order. The 0.11.0 public archive matches the accepted bytes, and anonymous installation, live helpers, offline replays, npm signatures and source provenance passed in [the release workflow](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34092471127) and independent registry verification.

Testing: workspace unit tests (6,056), smoke (159), API documentation guards (14) and API Cypress tests (6) pass, as do lint, format, typography and typecheck. Inspected both locales at desktop/mobile widths and checked the copied installation commands. Changes are limited to the advertised-version manifest and three guides; no API contract or package changes.

## 中文说明

将英文和中文 API 页面同步至已公开验证的 `@semianalysisai/inferencex-skills@0.11.0`。共享版本配置更新两处版本标识与四条 Codex/Claude 安装命令，同时同步示例、技能发现和发布指南中的已交付能力。

0.10.0、0.11.0 已按顺序发布。0.11.0 公开包与已验收产物逐字节一致，匿名安装、真实 API 辅助命令、离线重放、npm 签名及源码来源证明均已通过发布流程和独立 registry 校验。

验证：6,056 项工作区单元测试、159 项 smoke、14 项 API 文档检查、6 项 API 页面测试全部通过，lint、格式、字体规范与类型检查通过。已检查中英文桌面及手机页面，并核对复制出的安装命令。仅修改公开版本配置和三份指南，不修改 API 契约或技能包。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a single version manifest only; no API contract or skills package code changes.
> 
> **Overview**
> **Bumps the advertised `@semianalysisai/inferencex-skills` release from `0.8.0` to `0.11.0`** via `published-inferencex-skills.json`, which feeds the English/Chinese API install commands and version badges.
> 
> **Docs are aligned with shipped 0.9–0.11 behavior:** examples and install snippets use `0.11.0`; the discovery guide adds **offline** acceptance (saved PowerX/AgentX bundles, altered-export failure handling, integrity of prepared inputs) alongside live HTTPS tasks; the release guide documents **0.10.0/0.11.0** as published and adds **0.11.0 offline verifier replays** (five saved captures per target, deterministic Markdown report checks) as part of candidate/public verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a57c0b1c79893952f504c1f0a357b2846b9bd60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->