### PR TITLE
fix(inference): prevent model alias 500s / 修复推理模型别名导致的 500 错误

### DIFF
--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -1,6 +1,7 @@
 import { withPostHogConfig } from '@posthog/nextjs-config';
 import type { NextConfig } from 'next';
 import { allowedDevOriginsFromEnv } from './src/lib/allowed-dev-origins';
+import { INFERENCE_MODEL_ALIAS_REDIRECTS } from './src/lib/inference-model-redirects';
 
 const nextConfig: NextConfig = {
   // Allow a second, isolated dev server (e.g. a dump-mode instance on another
@@ -14,6 +15,7 @@ const nextConfig: NextConfig = {
   serverExternalPackages: ['shiki'],
   redirects() {
     return Promise.resolve([
+      ...INFERENCE_MODEL_ALIAS_REDIRECTS,
       {
         source: '/datasets/:path*',
         destination: '/agentx/:path*',

--- a/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/(dashboard)/inference/[model]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { notFound, permanentRedirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -26,7 +26,6 @@ import {
 
 interface Props {
   params: Promise<{ model: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams(): { model: string }[] {
@@ -58,26 +57,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function InferenceModelPage({ params, searchParams }: Props) {
+export default async function InferenceModelPage({ params }: Props) {
   const { model } = await params;
   const entry = getInferenceModelBySlug(model);
   if (!entry) notFound();
-  // Aliases (family names, superseded versions, raw `g_model` display names,
-  // uppercase variants) collapse onto the one canonical URL per model.
-  // Preserves the query string so share-link params like `?i_seq=` and
-  // `?i_prec=` survive the redirect — same treatment as the compare pages.
-  if (model !== entry.slug) {
-    const sp = await searchParams;
-    const qs = Object.entries(sp)
-      .flatMap(([k, v]) => {
-        if (Array.isArray(v)) return v.map((vv) => [k, vv] as const);
-        if (v === undefined) return [];
-        return [[k, v] as const];
-      })
-      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-      .join('&');
-    permanentRedirect(`${inferenceModelPath(entry.slug)}${qs ? `?${qs}` : ''}`);
-  }
+  // Known aliases are canonicalized in next.config.ts before this SSG route
+  // renders. Keeping redirects out of the page avoids a production-only
+  // DYNAMIC_SERVER_USAGE failure when an on-demand alias reads searchParams.
   return (
     <InferenceProvider activeTab="inference">
       <InferenceChartDisplay />

--- a/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/inference/[model]/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { notFound, permanentRedirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 
 import { AUTHOR_NAME, SITE_NAME, SITE_URL } from '@semianalysisai/inferencex-constants';
 
@@ -21,7 +21,6 @@ import {
 
 interface Props {
   params: Promise<{ model: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
 export function generateStaticParams(): { model: string }[] {
@@ -54,24 +53,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function ZhInferenceModelPage({ params, searchParams }: Props) {
+export default async function ZhInferenceModelPage({ params }: Props) {
   const { model } = await params;
   const entry = getInferenceModelBySlug(model);
   if (!entry) notFound();
-  // Preserves the query string so share-link params like `?i_seq=` and
-  // `?i_prec=` survive the redirect — same treatment as the compare pages.
-  if (model !== entry.slug) {
-    const sp = await searchParams;
-    const qs = Object.entries(sp)
-      .flatMap(([k, v]) => {
-        if (Array.isArray(v)) return v.map((vv) => [k, vv] as const);
-        if (v === undefined) return [];
-        return [[k, v] as const];
-      })
-      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
-      .join('&');
-    permanentRedirect(`${zhPath(inferenceModelPath(entry.slug))}${qs ? `?${qs}` : ''}`);
-  }
+  // Known aliases are canonicalized in next.config.ts before this SSG route
+  // renders. Next's config redirect also preserves the incoming query string.
   return (
     <>
       <ZhTabIntro tab="inference" />

--- a/packages/app/src/lib/inference-model-redirects.test.ts
+++ b/packages/app/src/lib/inference-model-redirects.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { INFERENCE_MODEL_ALIAS_REDIRECTS } from './inference-model-redirects';
+import { INFERENCE_MODEL_ALIASES } from './inference-model-slug';
+
+describe('INFERENCE_MODEL_ALIAS_REDIRECTS', () => {
+  it('redirects every known alias in both locale trees', () => {
+    expect(INFERENCE_MODEL_ALIAS_REDIRECTS).toHaveLength(
+      Object.keys(INFERENCE_MODEL_ALIASES).length * 2,
+    );
+
+    for (const [alias, canonical] of Object.entries(INFERENCE_MODEL_ALIASES)) {
+      for (const prefix of ['/inference', '/zh/inference']) {
+        expect(INFERENCE_MODEL_ALIAS_REDIRECTS).toContainEqual({
+          source: `${prefix}/${alias}`,
+          destination: `${prefix}/${canonical}`,
+          permanent: true,
+        });
+      }
+    }
+  });
+
+  it('keeps the GLM-5.2 share-link alias on a one-hop permanent redirect', () => {
+    expect(INFERENCE_MODEL_ALIAS_REDIRECTS).toContainEqual({
+      source: '/inference/glm-5-2',
+      destination: '/inference/glm-5-3',
+      permanent: true,
+    });
+  });
+
+  it('never redirects a canonical path to itself', () => {
+    for (const redirect of INFERENCE_MODEL_ALIAS_REDIRECTS) {
+      expect(redirect.destination).not.toBe(redirect.source);
+    }
+  });
+});

--- a/packages/app/src/lib/inference-model-redirects.ts
+++ b/packages/app/src/lib/inference-model-redirects.ts
@@ -1,0 +1,25 @@
+import { INFERENCE_MODEL_ALIASES } from './inference-model-slug';
+
+interface InferenceModelAliasRedirect {
+  source: string;
+  destination: string;
+  permanent: true;
+}
+
+const INFERENCE_ROUTE_PREFIXES = ['/inference', '/zh/inference'] as const;
+
+/**
+ * Static model aliases belong in Next's redirect table rather than the SSG
+ * page component. Reading `searchParams` while rendering an alias that was not
+ * returned by `generateStaticParams` fails with `DYNAMIC_SERVER_USAGE` in a
+ * production build. Config redirects run before the filesystem route and Next
+ * automatically carries the incoming query string to the destination.
+ */
+export const INFERENCE_MODEL_ALIAS_REDIRECTS: readonly InferenceModelAliasRedirect[] =
+  Object.entries(INFERENCE_MODEL_ALIASES).flatMap(([alias, canonical]) =>
+    INFERENCE_ROUTE_PREFIXES.map((prefix) => ({
+      source: `${prefix}/${alias}`,
+      destination: `${prefix}/${canonical}`,
+      permanent: true as const,
+    })),
+  );

--- a/packages/app/src/lib/inference-model-slug.ts
+++ b/packages/app/src/lib/inference-model-slug.ts
@@ -17,8 +17,8 @@
  * (e.g. `/inference/deepseek-v4-pro`), all 308-redirecting to the canonical
  * slug so exactly one URL per model is ever indexed.
  */
-import { COMPARE_MODEL_ALIASES, COMPARE_MODEL_SLUGS } from '@/lib/compare-slug';
-import { getModelCategory, Model } from '@/lib/data-mappings';
+import { COMPARE_MODEL_ALIASES, COMPARE_MODEL_SLUGS } from './compare-slug';
+import { getModelCategory, Model } from './data-mappings';
 
 export interface InferenceModelSlug {
   /** Canonical URL slug, e.g. 'kimi-k3'. Lowercase, matches the compare slug. */


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Routing and redirect-layer change for known inference aliases only; no auth or data-path changes, with tests locking the redirect table.
> 
> **Overview**
> Fixes production **500s** on inference model **alias URLs** (e.g. family names or lowercased `g_model` paths) by moving canonicalization out of the SSG `[model]` pages and into **Next.js config redirects**.
> 
> A new `INFERENCE_MODEL_ALIAS_REDIRECTS` table is built from `INFERENCE_MODEL_ALIASES` for both `/inference` and `/zh/inference`, wired into `next.config.ts` as permanent redirects. The English and Chinese model pages no longer call `permanentRedirect` or read `searchParams`, which had triggered **`DYNAMIC_SERVER_USAGE`** when an alias was hit outside `generateStaticParams`. Query strings on share links are still preserved via Next’s redirect behavior.
> 
> Vitest coverage asserts every alias maps in both locale trees, including the GLM-5.2 → GLM-5.3 one-hop case, and that no redirect is self-referential.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6aa5a2b3d5ddbc319d689aad3bc7ce81b706c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->