### PR TITLE
Add Google mark to AgentX hero and switch landing banner to TPUv7

### DIFF
--- a/packages/app/cypress/e2e/landing-performance.cy.ts
+++ b/packages/app/cypress/e2e/landing-performance.cy.ts
@@ -59,7 +59,7 @@ describe('Landing page performance', () => {
 
     cy.visit('/', {
       onBeforeLoad(win) {
-        win.localStorage.removeItem('inferencex-openai-rubin-banner-dismissed');
+        win.localStorage.removeItem('inferencex-tpuv7-banner-dismissed');
         observeLayoutShifts(win);
       },
     });
@@ -80,7 +80,7 @@ describe('Landing page performance', () => {
     cy.viewport(412, 823);
     cy.visit('/', {
       onBeforeLoad(win) {
-        win.localStorage.setItem('inferencex-openai-rubin-banner-dismissed', '1');
+        win.localStorage.setItem('inferencex-tpuv7-banner-dismissed', '1');
         observeLayoutShifts(win);
       },
     });

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -106,7 +106,7 @@ describe('First-load navigation', () => {
         // on first load, and its corner card would sit over the footer links
         // these specs click.
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
-        win.localStorage.removeItem('inferencex-openai-rubin-banner-dismissed');
+        win.localStorage.removeItem('inferencex-tpuv7-banner-dismissed');
       },
     });
 

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -14,7 +14,7 @@ function clearAllNudgeStorage(win: Cypress.AUTWindow) {
   const keys = [
     'inferencex-starred',
     'inferencex-star-modal-dismissed',
-    'inferencex-openai-rubin-banner-dismissed',
+    'inferencex-tpuv7-banner-dismissed',
     'inferencex-reproducibility-nudge-shown',
     'inferencex-star-nudge-shown',
     'inferencex-export-nudge-shown',
@@ -48,11 +48,8 @@ describe('Landing nudges — modals', () => {
     });
     cy.get('[data-testid="launch-banner"]')
       .should('be.visible')
-      .and('contain.text', "OpenAI's Latest In House Chip verus Rubin NVL72")
-      .and(
-        'contain.text',
-        'Compare Jalapeño (Teacup) with Vera Rubin (July) NVL72 on DeepSeek R1 at 8K / 1K.',
-      )
+      .and('contain.text', 'TPUv7 Inference Performance')
+      .and('contain.text', 'Compare TPUv7 versus Blackwell & Blackwell Ultra')
       .and('contain.text', 'View results');
     // Banner + header-nav badges, plus the six AgentX hero ledger rows — the
     // shared pill must render at the same fixed size everywhere it appears.
@@ -165,7 +162,7 @@ describe('Landing nudges — banner', () => {
     cy.get('[data-testid="launch-banner"]').should('be.visible');
     cy.window().then((win) => {
       // Only the X button should persist a dismissal — show alone must not.
-      expect(win.localStorage.getItem('inferencex-openai-rubin-banner-dismissed')).to.eq(null);
+      expect(win.localStorage.getItem('inferencex-tpuv7-banner-dismissed')).to.eq(null);
     });
   });
 
@@ -185,7 +182,7 @@ describe('Landing nudges — banner', () => {
     // Body click must not write the dismissal key — the banner should still
     // render on a fresh visit to landing.
     cy.window().then((win) => {
-      expect(win.localStorage.getItem('inferencex-openai-rubin-banner-dismissed')).to.eq(null);
+      expect(win.localStorage.getItem('inferencex-tpuv7-banner-dismissed')).to.eq(null);
     });
 
     cy.visit('/');
@@ -363,7 +360,7 @@ describe('Nudge scope isolation', () => {
       onBeforeLoad(win) {
         clearAllNudgeStorage(win);
         // Dismiss all landing nudges so nothing blocks visibility checks
-        win.localStorage.setItem('inferencex-openai-rubin-banner-dismissed', '1');
+        win.localStorage.setItem('inferencex-tpuv7-banner-dismissed', '1');
         win.localStorage.setItem('inferencex-starred', '1');
       },
     });

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -26,15 +26,17 @@ const MODEL_LOGOS: Record<string, string> = {
 
 /**
  * Full-color brand marks for the hero strip: the silicon platforms named
- * in the description (OpenAI, AMD, NVIDIA) followed by Meta, Microsoft,
- * and Oracle. The path data is copied from the shared brand assets under
+ * in the description (Google, OpenAI, AMD, NVIDIA) followed by Meta,
+ * Microsoft, and Oracle. The path data is copied from the shared brand assets under
  * `public/logos/` but inlined as SVG elements: the strip must add zero
  * `/logos/` image requests, because the mobile landing performance spec
  * budgets those fetches to the ledger's lazy `*-color.svg` model marks.
  * viewBoxes are cropped to the path content, so rendered sizes need no
  * canvas-padding compensation and the marks read optically equal.
  *
- * NVIDIA uses its official brand green (#76B900) as-is in both themes;
+ * Google is the four-color "G" in the official brand palette (blue
+ * #4285F4, red #EA4335, yellow #FBBC05, green #34A853), used as-is in both
+ * themes. NVIDIA uses its official brand green (#76B900) as-is in both themes;
  * the OpenAI and AMD marks are black by brand design (neither has a
  * color variant), so they render in `currentColor` via `text-foreground`,
  * which reproduces the official reversed-white treatment in dark mode.
@@ -63,6 +65,30 @@ const VENDOR_MARKS: readonly {
   /** Brand-color fills, or `currentColor` for marks that are monochrome by design. */
   paths: readonly { d: string; fill: string }[];
 }[] = [
+  {
+    name: 'Google',
+    viewBox: '0 0 48 48',
+    width: 22,
+    height: 22,
+    paths: [
+      {
+        d: 'M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z',
+        fill: '#EA4335',
+      },
+      {
+        d: 'M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z',
+        fill: '#4285F4',
+      },
+      {
+        d: 'M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z',
+        fill: '#FBBC05',
+      },
+      {
+        d: 'M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z',
+        fill: '#34A853',
+      },
+    ],
+  },
   {
     name: 'OpenAI',
     viewBox: '0 0 256 260',
@@ -344,7 +370,7 @@ const STRINGS = {
     eyebrow: 'AgentX / live results',
     title: 'Compare Realistic Agentic Inference Perf',
     description:
-      'Long Context Multi Turn Inference Performance. Compare Across OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv7/v8 & Rubin NVL72 & MI455X UALoE72',
+      'Long Context Multi Turn Inference Performance. Compare Across Google TPUv7 Ironwood, OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv8i & Rubin NVL72 & MI455X UALoE72',
     revenueCalculator: 'Token Revenue Calculator',
     dashboard: 'Dashboard',
     ledgerTitle: 'Models with AgentX results',
@@ -355,7 +381,7 @@ const STRINGS = {
     eyebrow: 'AgentX｜最新结果',
     title: '真实智能体工作负载下的推理性能对比',
     description:
-      '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 OpenAI Jalapeño、MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro，即将支持 TPUv7/v8、Rubin NVL72 与 MI455X UALoE72。',
+      '比较不同硬件平台在长上下文、多轮智能体工作负载下的推理性能，覆盖 Google TPUv7 Ironwood、OpenAI Jalapeño、MI355X、GB300 NVL72、GB200 NVL72、B200、H200、H100 和 RTX Pro，即将支持 TPUv8i、Rubin NVL72 与 MI455X UALoE72。',
     revenueCalculator: 'Token 收入计算器',
     dashboard: '仪表板',
     ledgerTitle: '已发布 AgentX 结果的模型',

--- a/packages/app/src/lib/nudges/landing-banner.ts
+++ b/packages/app/src/lib/nudges/landing-banner.ts
@@ -1,2 +1,2 @@
-export const LANDING_BANNER_STORAGE_KEY = 'inferencex-openai-rubin-banner-dismissed';
+export const LANDING_BANNER_STORAGE_KEY = 'inferencex-tpuv7-banner-dismissed';
 export const LANDING_BANNER_DISMISSED_ATTRIBUTE = 'data-landing-banner-dismissed';

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -76,9 +76,9 @@ describe('NUDGE_REGISTRY integrity', () => {
       'export',
       'filter-hint',
       'gradient-label',
-      'openai-rubin-comparison-banner',
       'reproducibility',
       'star-nudge',
+      'tpuv7-inference-banner',
     ]);
   });
 
@@ -102,27 +102,26 @@ describe('NUDGE_REGISTRY integrity', () => {
     reproducibility.content.action?.onClick();
     expect(location.href).toBe('/zh/about#reproducibility');
 
-    const banner = NUDGE_REGISTRY.find((nudge) => nudge.id === 'openai-rubin-comparison-banner');
+    const banner = NUDGE_REGISTRY.find((nudge) => nudge.id === 'tpuv7-inference-banner');
     if (banner?.type !== 'banner') throw new Error('Missing launch banner');
-    expect(banner.storageKey).toBe('inferencex-openai-rubin-banner-dismissed');
+    // New storage key so visitors who dismissed the previous launch banner
+    // see this one; cypress specs seed/clear this key and must stay in sync.
+    expect(banner.storageKey).toBe('inferencex-tpuv7-banner-dismissed');
     expect(banner.content.href).toBe(
-      '/inference?g_model=DeepSeek-R1-0528&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_outputTputPerMw',
+      'https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam',
     );
     expect(banner.analytics).toEqual({
-      shown: 'inference_rubin_comparison_banner_shown',
-      dismissed: 'inference_rubin_comparison_banner_dismissed',
-      action: 'inference_rubin_comparison_banner_clicked',
+      shown: 'inference_tpuv7_banner_shown',
+      dismissed: 'inference_tpuv7_banner_dismissed',
+      action: 'inference_tpuv7_banner_clicked',
       properties: {
-        banner_id: 'openai-rubin-comparison',
-        scenario: '8k/1k',
-        model: 'DeepSeek-R1-0528',
-        metric: 'y_outputTputPerMw',
+        banner_id: 'tpuv7-inference',
+        destination: 'newsletter',
       },
     });
+    // External destination: no locale prefix even from the Chinese tree.
     banner.content.onLinkClick?.();
-    expect(location.href).toBe(
-      '/zh/inference?g_model=DeepSeek-R1-0528&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_outputTputPerMw',
-    );
+    expect(location.href).toBe('https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam');
   });
 
   it('gives every coach mark an anchor to point at', () => {

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -52,6 +52,8 @@ function localizedNudgeHref(enPath: string): string {
   return localePath(enPath, isZhPathname(window.location.pathname) ? 'zh' : 'en');
 }
 
+const TPU_NEWSLETTER_URL = 'https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam';
+
 export const TELEMETRY_TUTORIAL_STORAGE_KEY = 'inferencex-agentx-telemetry-tutorial-dismissed';
 
 function telemetryTutorialHref(): string {
@@ -320,7 +322,7 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
   // dashboard scope is the only overlay star prompt.
   // -------------------------------------------------------------------------
   {
-    id: 'openai-rubin-comparison-banner',
+    id: 'tpuv7-inference-banner',
     type: 'banner',
     trigger: { type: 'immediate' },
     dismissal: { type: 'permanent' },
@@ -331,33 +333,29 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
     content: {
       icon: Sparkles,
       iconClassName: 'text-brand',
-      title: "OpenAI's Latest In House Chip verus Rubin NVL72",
-      titleZh: 'OpenAI 最新自研芯片对比 Rubin NVL72',
-      description:
-        'Compare Jalapeño (Teacup) with Vera Rubin (July) NVL72 on DeepSeek R1 at 8K / 1K.',
-      descriptionZh:
-        '对比 Jalapeño (Teacup) 与 Vera Rubin (July) NVL72 在 DeepSeek R1 8K / 1K 工作负载下的表现。',
+      title: 'TPUv7 Inference Performance',
+      titleZh: 'TPUv7 推理性能',
+      description: 'Compare TPUv7 versus Blackwell & Blackwell Ultra',
+      descriptionZh: '对比 TPUv7 与 Blackwell 及 Blackwell Ultra 的推理性能',
       testId: 'launch-banner',
       badge: 'New',
       badgeZh: '最新',
-      href: '/inference?g_model=DeepSeek-R1-0528&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_outputTputPerMw',
+      // External destination: the newsletter write-up rather than a dashboard
+      // route, so no locale prefixing applies.
+      href: TPU_NEWSLETTER_URL,
       linkLabel: 'View results',
       linkLabelZh: '查看结果',
       onLinkClick: () => {
-        window.location.href = localizedNudgeHref(
-          '/inference?g_model=DeepSeek-R1-0528&i_seq=8k%2F1k&i_prec=fp4&i_metric=y_outputTputPerMw',
-        );
+        window.location.href = TPU_NEWSLETTER_URL;
       },
     },
     analytics: {
-      shown: 'inference_rubin_comparison_banner_shown',
-      dismissed: 'inference_rubin_comparison_banner_dismissed',
-      action: 'inference_rubin_comparison_banner_clicked',
+      shown: 'inference_tpuv7_banner_shown',
+      dismissed: 'inference_tpuv7_banner_dismissed',
+      action: 'inference_tpuv7_banner_clicked',
       properties: {
-        banner_id: 'openai-rubin-comparison',
-        scenario: '8k/1k',
-        model: 'DeepSeek-R1-0528',
-        metric: 'y_outputTputPerMw',
+        banner_id: 'tpuv7-inference',
+        destination: 'newsletter',
       },
     },
   },


### PR DESCRIPTION
## What
- **Hero vendor strip**: inline the full-color Google "G" (official palette #4285F4/#EA4335/#FBBC05/#34A853) ahead of OpenAI. Order is now Google, OpenAI, AMD, NVIDIA, Meta, Microsoft, Oracle. Still zero `/logos/` image requests.
- **Hero description** (en + zh): "…Compare Across Google TPUv7 Ironwood, OpenAI Jalapeño, MI355X, GB300 NVL72, GB200 NVL72, B200, H200, H100, RTX Pro, and soon TPUv8i & Rubin NVL72 & MI455X UALoE72"
- **Landing banner**: "TPUv7 Inference Performance" / "Compare TPUv7 versus Blackwell & Blackwell Ultra", "View results" → https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam (external, so no locale prefixing).
- New banner id `tpuv7-inference-banner`, analytics events `inference_tpuv7_banner_*`, and storage key `inferencex-tpuv7-banner-dismissed` so people who dismissed the OpenAI/Rubin banner see this one.

## Checks
- `bun run fmt`, `bun run lint`, `bun run typecheck`, typography check clean
- `registry.test.ts` and `vendor-logos.test.ts` pass; cypress specs updated for the new copy and storage key

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing and nudge-registry changes with test updates; the new banner storage key only affects who sees the promo, not auth or data paths.
> 
> **Overview**
> Replaces the landing **OpenAI/Rubin** launch banner with a **TPUv7** campaign: new English/Chinese copy, **`tpuv7-inference-banner`** id, **`inference_tpuv7_banner_*`** analytics, and dismissal key **`inferencex-tpuv7-banner-dismissed`** so users who dismissed the old banner see this one. **View results** now goes to the SemiAnalysis newsletter URL (external, no locale prefix) instead of a pre-filled `/inference` dashboard link.
> 
> On the **AgentX compare hero**, adds an inlined four-color **Google** mark first in the vendor strip and updates en/zh descriptions to lead with **Google TPUv7 Ironwood** and **TPUv8i** in the “coming soon” line.
> 
> Cypress nudge/landing specs and **`registry.test.ts`** are aligned with the new banner text, storage key, and registry entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78452747e52484645b2dd34458c140ebba67298c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->