### PR TITLE
Fix nudge-system E2E spec for the TPUv7 newsletter banner

### DIFF
--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -10,6 +10,11 @@
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Mirrors `TPU_NEWSLETTER_URL` in `src/lib/nudges/registry.tsx`; the unit test
+// there pins the registry side, this spec pins the rendered banner.
+const TPU_NEWSLETTER_ORIGIN = 'https://newsletter.semianalysis.com';
+const TPU_NEWSLETTER_PATH = '/p/tpu-inferencex-full-steam';
+
 function clearAllNudgeStorage(win: Cypress.AUTWindow) {
   const keys = [
     'inferencex-starred',
@@ -95,17 +100,14 @@ describe('Landing nudges — modals', () => {
       });
   });
 
-  it('localizes the Rubin comparison banner title in Chinese', () => {
+  it('localizes the TPUv7 banner title in Chinese', () => {
     cy.visit('/zh', {
       onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]')
       .should('be.visible')
-      .and('contain.text', 'OpenAI 最新自研芯片对比 Rubin NVL72')
-      .and(
-        'contain.text',
-        '对比 Jalapeño (Teacup) 与 Vera Rubin (July) NVL72 在 DeepSeek R1 8K / 1K 工作负载下的表现。',
-      )
+      .and('contain.text', 'TPUv7 推理性能')
+      .and('contain.text', '对比 TPUv7 与 Blackwell 及 Blackwell Ultra 的推理性能')
       .and('contain.text', '查看结果');
   });
 
@@ -167,25 +169,34 @@ describe('Landing nudges — banner', () => {
   });
 
   it('clicking the banner body navigates without persisting dismissal', () => {
+    // The TPUv7 banner points off-site at the newsletter write-up. Stub the
+    // destination so the spec never depends on Substack being reachable, then
+    // follow the navigation through `cy.origin` to assert where we landed.
+    cy.intercept('GET', `${TPU_NEWSLETTER_ORIGIN}${TPU_NEWSLETTER_PATH}`, {
+      statusCode: 200,
+      headers: { 'content-type': 'text/html' },
+      body: '<!doctype html><html><body><h1>newsletter stub</h1></body></html>',
+    }).as('newsletter');
+
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
     });
-    cy.get('[data-testid="launch-banner"]').should('be.visible');
+    cy.get('[data-testid="launch-banner"]')
+      .should('be.visible')
+      .and('have.attr', 'href', `${TPU_NEWSLETTER_ORIGIN}${TPU_NEWSLETTER_PATH}`);
     cy.get('[data-testid="launch-banner"]').click();
-    cy.location('pathname', { timeout: 10000 }).should('eq', '/inference');
-    cy.location('search')
-      .should('include', 'g_model=DeepSeek-R1-0528')
-      .and('include', 'i_seq=8k%2F1k')
-      .and('include', 'i_prec=fp4')
-      .and('include', 'i_metric=y_outputTputPerMw');
+
+    cy.wait('@newsletter', { timeout: 10000 });
+    cy.origin(TPU_NEWSLETTER_ORIGIN, { args: { path: TPU_NEWSLETTER_PATH } }, ({ path }) => {
+      cy.location('pathname', { timeout: 10000 }).should('eq', path);
+    });
 
     // Body click must not write the dismissal key — the banner should still
     // render on a fresh visit to landing.
+    cy.visit('/');
     cy.window().then((win) => {
       expect(win.localStorage.getItem('inferencex-tpuv7-banner-dismissed')).to.eq(null);
     });
-
-    cy.visit('/');
     cy.get('[data-testid="launch-banner"]').should('be.visible');
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #1062 / #1063. E2E shard 1 (chrome + firefox) has been red on `nudge-system.cy.ts` since the landing banner switched from the OpenAI/Rubin comparison to TPUv7; two assertions still described the old banner.

## Changes
- `localizes the ... banner title in Chinese`: now asserts the TPUv7 zh title and description from `registry.tsx` (`TPUv7 推理性能` / `对比 TPUv7 与 Blackwell 及 Blackwell Ultra 的推理性能`).
- `clicking the banner body navigates without persisting dismissal`: the banner now links off-site to the newsletter post, so the old `/inference?g_model=...` expectations can never hold. The test now asserts the rendered `href`, stubs the newsletter URL with `cy.intercept` so CI never depends on Substack, follows the navigation via `cy.origin` to check the landing pathname, then returns to `/` and verifies the dismissal key was not written and the banner still renders.

No product code changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cypress E2E-only changes; no production behavior or nudge registry logic is modified.
> 
> **Overview**
> Updates **`nudge-system.cy.ts`** so landing-banner E2E expectations match the current TPUv7 launch banner (no app code changes).
> 
> The Chinese localization test now checks **TPUv7** copy instead of the retired OpenAI/Rubin comparison strings. The banner click test no longer expects in-app navigation to `/inference` with query params; it asserts the banner **`href`** against newsletter URL constants (documented to mirror `TPU_NEWSLETTER_URL` in the nudge registry), **stubs** the Substack GET with `cy.intercept`, and uses **`cy.origin`** to verify the off-site pathname. It still confirms that a body click does **not** set `inferencex-tpuv7-banner-dismissed` and that the banner reappears on a fresh visit to `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f59f151fc500080767fd7eca1296c5764bd8d948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->