### PR TITLE
feat(glossary): add 26 TPU Ironwood terms from the TPU InferenceX article / 术语表新增 26 条来自 TPU InferenceX 文章的 Ironwood 术语

### DIFF
--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -1642,6 +1642,379 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
     benchmarkContext:
       'InferenceX 配置钉住的引擎镜像在不同版本和硬件后端上的融合库存不同，这是逐日追踪中硬件不变而曲线移动的常见原因：面向新模型和新精度的融合 kernel 落地了。',
   },
+  tpu: {
+    term: 'TPU（张量处理单元）',
+    aliases: ['TPU', 'Tensor Processing Unit', 'Google TPU', 'Cloud TPU'],
+    plainEnglish:
+      'TPU 是 Google 为自家 AI 负载设计的加速器，现在也开始对外出售或出租，用于其他公司的推理服务。',
+    definition:
+      'TPU（Tensor Processing Unit）是 Google 自研的加速器，核心由大尺寸 systolic 矩阵单元、片上向量存储（VMEM）、处理不规则计算的 SparseCore，以及名为 ICI 的芯片间互连组成。',
+    explanation:
+      'Google 内部的搜索、广告、YouTube 和每一代 Gemini 都运行在 TPU 上。每颗芯片包含负责矩阵乘法的 TensorCore（内部是 MXU systolic 阵列）和负责 embedding 查表与数据搬运的 SparseCore。XLA 编译器在这些单元之间调度计算，编译器切分不好的算子则由 Pallas kernel 补齐。芯片之间通过 ICI 直接互连，组成数千颗芯片的 pod，数据不经过主机 CPU。Ironwood（TPUv7）是 Google 第一代面向外部推理客户的产品，TPUv8 则拆分为训练用的 8t 和推理用的 8i。',
+    significance:
+      '这种设计用单芯片峰值换取系统级成本优势。宽矩阵单元、低延迟 torus 网络和编译器驱动的调度，让 Google 的每 token 成本低于规格表的推算；但 tile 几何会惩罚填不满阵列的模型形状。TPU 能否被外部广泛采用，取决于 PyTorch 原生的 TorchTPU 栈能否在 vLLM 和 SGLang 中追平 CUDA 生态。',
+    benchmarkContext:
+      'InferenceX Official Preview 发布了首批第三方 TPUv7 结果，在 FP8 聚合服务下与 B200、B300 对比，Ironwood 的每美元性能最高高出 50%。TorchTPU 栈开源后，AgentX 和 TPU 分离式服务的结果也会陆续发布。',
+  },
+  'tpuv7-ironwood': {
+    term: 'TPUv7 Ironwood',
+    aliases: ['Ironwood', 'TPU v7', 'TPUv7', 'v7x'],
+    plainEnglish:
+      'Ironwood 是第七代 TPU，也是 Google 第一款卖给其他公司、让它们跑自己推理业务的 TPU。',
+    definition:
+      'TPUv7 Ironwood 是 Google 的加速器，每颗芯片有两个独立计算 die、原生 FP8 硬件、256x256 的 MXU、约为 Trillium 六倍的 HBM 容量，以及 3D torus 结构的 ICI 网络。',
+    explanation:
+      'Ironwood 放弃了 TPU v4 和 v5p 的 MegaCore 设计，后者把两个核心融合为共享同一内存空间的单个逻辑设备。Ironwood 的两个 die 各自作为独立逻辑设备运行，通过 die-to-die 链路相连，因此框架看到的是每颗芯片两个设备。每颗芯片有 2 个 TensorCore 和 4 个第三代 SparseCore。pod 的基本单元是 4x4x4 共 64 颗芯片的立方体，再通过光电路交换机拼接成 9,216 颗芯片的 superpod。Ironwood 没有原生 FP4，因此目前与 NVIDIA 的对比两边都使用 FP8。',
+    significance:
+      '这是 Google 第一次用可直接购买或租用的芯片，去争夺外部推理负载。仅 Anthropic 就承诺采购超过一百万颗 TPU。在 TPUv8i 加入原生 FP4 之前，只有 FP8 的计算路径限制了它与 Blackwell 的对比范围。',
+    benchmarkContext:
+      '在 InferenceX Official Preview 中，Ironwood 以 FP8 服务 Qwen3.5 397B，在每用户 100 tok/s 的交互性下每百万 token 成本约 0.181 美元，B200 为 0.222 美元，B300 为 0.276 美元。在每用户 20 tok/s 下，按外部 TCO 计算，它的每美元 token 数比 B200 高 50.4%，比 B300 高 96.0%。',
+    measurement: {
+      label: '每用户 100 tok/s、FP8 8k1k 下的成本',
+      value: '每百万 token 0.181 美元，B200 为 0.222 美元，B300 为 0.276 美元',
+    },
+  },
+  mxu: {
+    term: 'MXU（矩阵乘法单元）',
+    aliases: ['MXU', 'Matrix Multiply Unit', 'systolic array', '脉动阵列'],
+    plainEnglish: 'MXU 是 TPU 内部做矩阵运算的乘加单元网格，只有每个单元都有真实计算时才能跑满。',
+    definition:
+      'MXU（Matrix Multiply Unit）是 TPU TensorCore 核心的 systolic 阵列，一个二维乘加单元网格，权重固定在阵列中，激活值从边缘流入。',
+    explanation:
+      '权重加载进阵列后保持不动，激活值从一侧进入，部分和逐格向前传递并累加，最终结果从另一侧流出，中途不经过内存。TPU v5 及之前使用 128x128 阵列，每周期 16,384 次 MAC；从 v6e 开始直到 Ironwood，阵列扩大到 256x256，每周期 65,536 次 MAC。XLA 编译器会把小于阵列边长的矩阵维度补齐到整块 tile，而每个补齐的单元在那个周期同样占用一个 MAC。',
+    significance:
+      '更宽的阵列只有填满时才没有代价。在 256 宽的 MXU 上，head dim 为 128 会让注意力矩阵乘法的利用率上限只有 50%，head dim 为 64 则在写任何 kernel 代码之前就被限制在 25%。GPU 矩阵核心消费的是小 tile，同样的形状在 H100 或 B200 上几乎没有损耗。在 GPU 上随意选择的模型超参数，在 TPU 上会直接变成吞吐量损失。',
+    benchmarkContext:
+      'TPU 上的模型 bring-up 成本取决于模型与 MXU 的匹配程度，而不是模型的流行程度。Qwen3.5 被选为 TorchTPU 的第一个 bring-up 模型，部分原因就是它的形状匹配得比较干净；InferenceX Official Preview 描述的 Pallas kernel 工作，核心目标也是让阵列保持满载。',
+  },
+  sparsecore: {
+    term: 'SparseCore',
+    aliases: ['SparseCore', 'SparseCores', 'TPU SparseCore', 'SC'],
+    plainEnglish:
+      'SparseCore 是 TPU 芯片上的辅助核心，负责 gather、数据搬运等不规则任务，让矩阵单元专心做乘法。',
+    definition:
+      'SparseCore 是 TPU 上专门处理稀疏和不规则操作的核心，负责 embedding 查表、gather、permute 和数据搬运，与同一芯片上的稠密 TensorCore 并行运行。',
+    explanation:
+      'Ironwood 每颗芯片有 4 个第三代 SparseCore 和 2 个 TensorCore。稠密矩阵引擎处理不规则访问模式时效率很低，因此 TPU 团队把这类工作交给 SparseCore。在外部推理栈中，把每个专家的 token 收集成连续分组的 MoE permute、ragged gather-reduce 路径中的 top-k 权重 gather，以及 ReduceScatter 集合通信都在 SparseCore 上运行。TensorCore 继续执行专家矩阵乘法，SparseCore 同时重排数据并搬运部分和，双缓冲让两者重叠。',
+    significance:
+      'offload 并非没有代价。能装进 VMEM 的小集合通信放到 SparseCore 上可能因为启动开销而更慢，所以 Qwen3.5 用一个由 VMEM 容量推导出的阈值来决定哪些 all-reduce 和 all-gather 需要迁移。这个分工的调优是逐层延迟收益的常见来源。',
+    benchmarkContext:
+      'SparseCore MoE permute 重写在 Ironwood 上使 8k1k 服务吞吐量提高 12%，同时降低了 TTFT 和 TPOT。把 top-k 权重 gather 迁移过去后，DeepSeek-V3 微基准中 TensorCore 开销从 29 微秒降到 14 微秒；集合通信阈值在并发 64 和 128 下分别带来 2.7% 和 5.7% 的收益。',
+  },
+  vmem: {
+    term: 'VMEM（向量存储）',
+    aliases: ['VMEM', 'vector memory', 'TPU 片上存储'],
+    plainEnglish:
+      'VMEM 是 TPU kernel 直接读写的片上高速暂存区，kernel 占用多少 VMEM 决定了它能提前预取多远。',
+    definition:
+      'VMEM 是 TPU TensorCore 上由软件管理的片上向量存储，Pallas kernel 从 HBM 往这里加载数据并在此计算，作用类似 GPU 的 shared memory。',
+    explanation:
+      'Pallas kernel 通过双缓冲隐藏 HBM 延迟：在当前块计算时把下一块预取进 VMEM，所以两个块必须同时放得下，计算块的大小决定了预取深度。向量单元按最后一维为 128 lane 的 tile 读取 VMEM，末维更小的数组会被补齐。Gated DeltaNet 层的循环状态在 HBM 中以 BF16 存储，但在 VMEM 内仍以 FP32 计算，这使 HBM 占用减半而算术精度不变。',
+    significance:
+      'VMEM 压力会在意想不到的地方表现为性能回退。为异步 GDN 状态传输增加第二组缓冲区时，一度导致数据并行注意力回退，直到复用了 scratch buffer 才恢复。集合通信是否 offload 到 SparseCore 也以消息能否装进 VMEM 为门槛。TPU kernel 作者预算 VMEM 的方式，与 GPU kernel 作者预算 shared memory 和寄存器一样。',
+    benchmarkContext:
+      'ragged paged attention v3 的修复把 KV 计算块与预取块分开，预取块保持 16k token，计算块缩到 4k，为预取缓冲释放出 VMEM，使 Qwen3-0.6B 的 decode 吞吐量从每秒 64.9k token 提高到 96.3k。VMEM 容量恢复后，异步 GDN 状态传输在并发 512 下带来 11.3% 的收益。',
+  },
+  ici: {
+    term: 'ICI（芯片间互连）',
+    aliases: ['ICI', 'Inter-Chip Interconnect', 'TPU 互连', 'ICI fabric'],
+    plainEnglish: 'ICI 是 TPU 专用的网络，让整个 pod 内的芯片直接交换数据，不需要经过主机 CPU。',
+    definition:
+      'ICI（Inter-Chip Interconnect）是 Google 为 TPU 设计的芯片间互连，一种点对点网络，直接在芯片之间传输激活值、梯度和 KV cache，不经过 PCIe 或通用网卡。',
+    explanation:
+      '每颗 TPU 通过 ICI 链路连接 torus 中的邻居：v2 和 v3 的 2D torus 有 4 个邻居，v4 起的 3D torus 有 6 个。光电路交换机把 64 芯片立方体拼接成数千颗芯片的 pod，同时保留 wraparound 链路。结果是整个 pod 范围内都有 NVLink 级别的带宽，而不是局限在 8 个或 72 个设备之间。TPU 8i 把 ICI 带宽翻倍到每芯片 19.2 Tb/s，并从 torus 改为 Boardfly 拓扑。',
+    significance:
+      'pod 级带宽改变了哪些并行策略可行。DeepSeek-V3 规模的模型可以用张量并行、专家并行和数据并行切分到整个 pod 上，不需要流水线阶段；超过 1,000 颗芯片的 Ironwood pod 还能运行 NVL72 域做不到的分离式服务和超宽专家并行。torus 的跳数比单跳 NVSwitch 多，延迟取决于消息大小和拓扑。',
+    benchmarkContext:
+      'InferenceX Official Preview 提到，即将发布的 CollectiveX 和 NetworkingX 结果显示，对于 MoE decode 产生的小尺寸专家并行消息，TPU torus 的延迟常常低于单跳 NVSwitch。SparseCore 上的 ReduceScatter 也是在 ICI 网络上重叠 die-to-die 与芯片间传输。',
+  },
+  'torus-topology': {
+    term: 'Torus 拓扑',
+    aliases: ['torus topology', '3D torus', 'twisted torus', '环面拓扑'],
+    plainEnglish: 'torus 是一种边缘首尾相连的网格网络，最远的芯片也不会超过网格的一半距离。',
+    definition:
+      'torus 拓扑让每颗芯片沿每个轴连接最近邻居，并在每行两端增加 wraparound 链路形成环，把普通 mesh 的最坏跳数减半。',
+    explanation:
+      'TPU v2 和 v3 使用每芯片 4 个邻居的 2D torus。从 v4 起，Google 改用沿 X、Y、Z 正负方向各有邻居、共 6 个邻居的 3D torus，Ironwood 沿用这一布局。基本单元是按一个机柜设计的 4x4x4 共 64 颗芯片立方体。twisted torus 通过偏移 wraparound 进一步降低平均跳数。光电路交换机在连接立方体时保留 wraparound 特性，让 Google 能在几秒内绕过故障芯片或链路。跨越多跳的流量在每一跳都付出延迟，因此集合通信会尽量安排在本地。',
+    significance:
+      '在 NVL72 机柜出现之前，放不进 8 卡节点的模型必须使用流水线并行，因为节点间 InfiniBand 太慢。TPU torus 早了好几年就在整个 pod 内提供了 NVLink 级别带宽。代价是跳数：1,024 颗芯片的 torus 直径约 16 跳，这也是 TPU 8i 为推理改用更扁平的 Boardfly 网络的原因。',
+    benchmarkContext:
+      'CollectiveX 和 NetworkingX 直接测量集合通信延迟。InferenceX Official Preview 报告，尽管跳数更多，TPU torus 在 MoE decode 主要产生的小尺寸专家并行消息上，延迟常常优于单跳 NVSwitch。',
+  },
+  'optical-circuit-switch': {
+    term: '光电路交换机',
+    aliases: ['OCS', 'optical circuit switch', '光交换', 'MEMS 光交换机'],
+    plainEnglish:
+      '光电路交换机用微小的反射镜在光纤之间改变光路，让 Google 不碰一根线缆就能重新布线 TPU pod。',
+    definition:
+      '光电路交换机（OCS）用可动反射镜在光纤端口之间转向光信号，建立可重新配置的点对点链路，不做光电转换，也不检查数据包。',
+    explanation:
+      'Google 用 OCS 把 4x4x4 的 TPU 立方体拼接成更大的 pod，并在整个拓扑中保留 torus 的 wraparound 链路。由于交换机只是改变光路而不路由数据包，它几乎不增加延迟，没有逐包处理开销，且可以通过软件重新配置。Ironwood pod 以此方式扩展到 9,216 颗芯片的 superpod，聚合算力达到 42.5 FP8 exaflops。同一机制还允许运营方把 pod 切成任意形状的小片给不同任务使用。',
+    significance:
+      '运维上的收益是容错。芯片或链路故障时，移动反射镜几秒内就能绕开，不需要派技术人员到运行中的数据中心重新熔接铜缆。可重配置也意味着物理 pod 不决定逻辑拓扑，任务可以申请自己想要的 torus 维度。',
+    benchmarkContext:
+      'OCS 是 InferenceX 按 pod 内每芯片而非固定机柜单元报告 TPU 结果的原因。Official Preview 比较的是 TPUv7 聚合服务与 B200、B300 节点，pod 级分离式服务与 NVL72 的对比留待后续文章。',
+  },
+  boardfly: {
+    term: 'Boardfly',
+    aliases: ['Boardfly', 'Boardfly topology', 'TPU 8i 网络', 'TPUv8i Boardfly'],
+    plainEnglish:
+      'Boardfly 是 Google 推理专用 TPU 8i 的新型扁平网络，芯片间跳数比 torus 大约减半。',
+    definition:
+      'Boardfly 是 TPU 8i 的高基数分层互连拓扑，取代最近邻的 3D torus，名字来源于超算领域的 dragonfly 网络家族。',
+    explanation:
+      '训练芯片 TPU 8t 保留 3D torus，推理芯片 TPU 8i 改用 Boardfly，由高基数交换机组成，而不是邻居直连的 mesh。在 1,024 到 1,152 芯片的可比规模下，网络直径从约 16 跳降到约 7 跳。TPU 8i 同时配备 19.2 Tb/s 的 ICI 带宽（上一代的两倍）和 384 MB 片上 SRAM（上一代的三倍），专门用来把推理和智能体模型的 KV cache 放在片上。它还带来了 Ironwood 缺少的原生 FP4 计算。',
+    significance:
+      '更少的跳数意味着集合通信的尾延迟更低，这在 token 跨 MoE 层路由、或多轮智能体会话把每一跳累积成用户可感知延迟时尤其重要。Boardfly 也改变了每芯片的网络连接 capex。这是 Google 第一次把训练和推理拆成不同的架构。',
+    benchmarkContext:
+      'SemiAnalysis 预期 TPUv8i Boardfly 能与 Rubin NVL72 竞争。TPUv8i 登陆 InferenceX 和 AgentX 后，与 NVIDIA 的对比将从 FP8 对 FP8 变为 FP4 对 FP4，消除当前 Ironwood 结果中的精度不对称。',
+  },
+  'tile-padding': {
+    term: 'Tile 补齐',
+    aliases: ['tile padding', 'shape padding', 'MXU padding', 'lane padding'],
+    plainEnglish: 'tile 补齐指矩阵维度小于硬件 tile 时用零填满所浪费的计算。',
+    definition:
+      'tile 补齐是把张量维度向上取整到计算单元或向量单元原生 tile 尺寸的过程，被补齐的单元占用硬件周期却不贡献结果。',
+    explanation:
+      'TPU 的 MXU 边长在旧代为 128，在 v6e 和 v7 为 256，向量单元处理的 tile 末维为 128 lane。XLA 会把更小的轴补齐到整个 tile。Llama 3 8B 的 head dim 为 128，正好是 256 宽 MXU 的一半，两个注意力矩阵乘法的利用率上限因此只有 50%。gpt-oss 的 head dim 为 64，上限降到 25%。DeepSeek MLA 把 query-key 维度拆成 128 加 64 共 192，在任何 2 的幂阵列上都不合适。在 batched attention kernel 中，每设备单个 FP8 KV head 曾让每个 tile 一半是填充，直到 sequence-on-lane 布局把 token 放到 128 lane 轴上。',
+    significance:
+      'GPU 矩阵核心消费小 tile，因此 head dim 64 或 128 以及切分后奇怪的 KV head 数在 H100 或 B200 上都接近峰值。在 TPU 上，同样的选择在写任何 kernel 之前就是直接的吞吐量损失。因此 bring-up 成本取决于模型与 tile 几何的匹配度，而不是模型的流行度。',
+    benchmarkContext:
+      'sequence-on-lane KV 布局在报告的 Ironwood 配置中把可用 KV page 从 5,141 翻倍到 10,283，并发 128 下 8k1k 吞吐量提高 16.5%，中位 TTFT 下降 95%。ragged paged attention 中显式的 packing 维度就是为了绕开 XLA 的默认切分。',
+  },
+  torchtpu: {
+    term: 'TorchTPU',
+    aliases: ['TorchTPU', 'TorchTPU backend', 'PyTorch 原生 TPU', 'torch device tpu'],
+    plainEnglish:
+      'TorchTPU 让 TPU 表现为一个普通的 PyTorch 设备，vLLM 和 SGLang 可以直接在 Google 芯片上运行现有 PyTorch 代码。',
+    definition:
+      'TorchTPU 是 Google 基于 PrivateUse1 扩展点构建的 PyTorch 原生 TPU 后端，在 device tpu 上暴露真正的 torch.Tensor，并通过 StableHLO 和 XLA 下沉编译图。',
+    explanation:
+      'PyTorch dispatcher 把 ATen 操作直接路由到 TPU 后端，而不是翻译成 JAX。开发者可以 eager 执行用于 bring-up 和调试，也可以调用 torch.compile：TorchDynamo 和 AOTAutograd 生成 FX 图，TorchTPU 下沉为 StableHLO，XLA 生成 TPU 可执行文件，不使用 Inductor 和 Triton。原生范围覆盖张量、dispatch、eager 执行、编译入口和分布式 API，包括 DDP、FSDP2、DTensor 以及 SPMD 和 MPMD。kernel 层仍然是 TPU 专用的：TorchTPU 可以调用 Pallas 和 JAX 自定义 kernel，因此为 TorchAX 栈编写的 kernel 可以迁移而不必重写。',
+    significance:
+      'vLLM 和 SGLang 可以复用上游的模型代码、调度器、continuous batching 和功能逻辑，不必跨 PyTorch 到 JAX 的边界重建。这降低了新模型 bring-up 的成本，让 TPU 朝着与 NVIDIA 同步的 day-0 支持靠近。TorchTPU 将取代即将弃用的 TorchAX。',
+    benchmarkContext:
+      'InferenceX Official Preview 中的 TPUv7 结果来自原生 TorchTPU vLLM 栈以 FP8 服务 Qwen3.5 397B。截至 2026 年 9 月初 TorchTPU 仍处于私有测试阶段，预计 10 月中旬 PyTorch Conference 前后开源，届时 SemiAnalysis 会把 TPU 基准测试从 fork 迁移到公开的 InferenceX 仓库。',
+  },
+  torchax: {
+    term: 'TorchAX',
+    aliases: ['TorchAX', 'torchax', 'tpu-inference 后端', 'PyTorch 到 JAX 翻译层'],
+    plainEnglish:
+      'TorchAX 通过把每个操作悄悄翻译成 JAX，让 PyTorch 模型代码能在 TPU 上运行，这种方式正被 TorchTPU 取代。',
+    definition:
+      'TorchAX 是一个翻译层，通过 __torch_dispatch__ 钩子拦截 PyTorch 的 ATen 操作并以 JAX 操作执行，每个 torchax.tensor.Tensor 背后都是一个 jax.Array。',
+    explanation:
+      'vLLM 的 TPU 支持经历了三个阶段。最初的原型使用 PyTorch/XLA 的惰性执行，把操作收集成图交给 XLA。当前公开的 tpu-inference 后端在有 TPU 优化的 JAX 模型时直接使用，否则通过 TorchAX 运行 PyTorch 模型。权重和 KV cache 等状态通过 functionalization 显式暴露给 JAX，让 jax.jit 能捕获每一步，vLLM 因此绕过了自己常规的 torch.compile 路径，因为 JAX 流水线已经负责图捕获。SGLang-JAX 是一个独立的 JAX 原生引擎，做了类似取舍。Google 当时选择 JAX，是因为它有更成熟的 TPU 原语和并行支持。',
+    significance:
+      '跨两个框架翻译在底层优化、paged attention 以及让 vLLM 的 worker 模型适配 TPU 执行方面反复出问题，还迫使引擎功能在 JAX 侧重新实现。这些代价促使 Google、PyTorch、vLLM 和 SGLang 转而构建 TorchTPU。',
+    benchmarkContext:
+      '在 TorchAX 下开发的 Pallas kernel，包括 InferenceX Official Preview 中描述的 MoE、GDN 和 paged attention 工作，都可以延续到 TorchTPU，因为两套栈都能调用 Pallas 和 JAX kernel。TorchTPU 发布后，TorchAX 本身将被弃用。',
+  },
+  pallas: {
+    term: 'Pallas',
+    aliases: ['Pallas', 'Pallas kernel', 'JAX Pallas', 'TPU 自定义 kernel'],
+    plainEnglish: 'Pallas 是工程师在编译器调度不够好时，为 TPU 手写调优 kernel 的方式。',
+    definition:
+      'Pallas 是 JAX 的扩展，用于编写 TPU 和 GPU 的自定义 kernel，可以显式控制切分、HBM 与 VMEM 之间的数据搬运，以及 MXU 和向量单元的工作调度。',
+    explanation:
+      'XLA 处理模型的大部分，但 ragged paged attention、分组 MoE 矩阵乘法和 Gated DeltaNet 循环等性能关键操作需要显式控制块大小、双缓冲和 lane 布局，Pallas 在 Python 中提供这种控制。Official Preview 中的 TPU 推理优化大多是 Pallas kernel：GDN v3 把 Conv1D 和 GDN 融合为一个 kernel，grouped matmul 对专家权重做三缓冲，attention kernel 采用 sequence-on-lane 布局。Helion 的 TPU 后端也生成 Pallas。TorchTPU 可以从原生 PyTorch 调用 Pallas kernel，因此为 TorchAX 写的 kernel 只需调整 wrapper 和布局即可迁移。',
+    significance:
+      'Pallas 在 TPU 上的角色相当于 NVIDIA 上的 CUDA C++、CUTLASS 和 Triton。原生 PyTorch 支持并不消除对它的需求，张量形状和布局仍然要为 MXU 调优。生态编写新模型 Pallas kernel 的速度，决定了 TPU 外部化的节奏。',
+    benchmarkContext:
+      'Ironwood 上报告的 Pallas kernel 收益包括：GDN v3 在 kernel 层面 decode 加速 1.41 倍、prefill 1.60 倍、混合 batch 2.14 倍；异步状态传输在并发 512 下吞吐量提高 11.3%；拆分 attention 预取块与计算块使 decode 吞吐量提高 49%。',
+  },
+  xla: {
+    term: 'XLA',
+    aliases: ['XLA', 'Accelerated Linear Algebra', 'StableHLO', 'XLA 编译器'],
+    plainEnglish:
+      'XLA 是把模型计算图编译成 TPU 机器码的编译器，决定每个操作如何切分、补齐、融合和调度。',
+    definition:
+      'XLA 是面向线性代数的领域专用编译器，接收 StableHLO 图并为 TPU 和其他加速器生成可执行代码，负责融合、布局、切分和调度。',
+    explanation:
+      '每条 TPU 服务路径最终都落到 XLA。在 JAX 路径中，jax.jit 捕获一步计算后交给 XLA；在 TorchTPU 中，TorchDynamo 和 AOTAutograd 生成 FX 图，下沉为标准化中间表示 StableHLO，再由 XLA 编译。两种情况下编译器都是 XLA，不涉及 Inductor 和 Triton。编译器会把小于 MXU tile 的维度补齐、选择默认布局并融合逐元素操作，这对规则形状很高效，对与 tile 几何冲突的形状则代价高昂。Pallas 就是为 XLA 默认行为不够好的场景准备的。',
+    significance:
+      '编译器与硬件的协同设计是 Google 每 token 成本优势的重要来源：芯片、网络和编译器一起设计，计算和通信可以作为一个系统来优化。同样的紧耦合也意味着模型形状和编译 shape bucket 对性能有超出寻常的影响。',
+    benchmarkContext:
+      'Official Preview 中的多项优化是在引导 XLA 而不是替代它，例如把专家 ID 和 token 索引打包成一个排序键，让 XLA 执行更简单的排序，排序延迟从 106.6 微秒降到 21.7 微秒，同时启用了 FP8 all-gather。',
+  },
+  jax: {
+    term: 'JAX',
+    aliases: ['JAX', 'JAX 框架', 'jax.jit', 'Google JAX'],
+    plainEnglish:
+      'JAX 是 Google 的 Python 数组计算框架，通过 XLA 编译函数，一直是编程 TPU 的原生方式。',
+    definition:
+      'JAX 是一个 Python 库，在 NumPy 风格数组上提供 jit、grad、vmap 等可组合的函数变换，经 XLA 编译，是 TPU 的主要第一方框架。',
+    explanation:
+      'JAX 程序是函数式的：模型权重和 KV cache 等状态显式传入传出，jax.jit 才能把一步计算追踪成图。这种模型与 XLA 契合，让 JAX 成为 TPU 原语和并行支持最成熟的路径，也是第一个外部 vLLM TPU 后端通过 TorchAX 把 PyTorch 翻译成 JAX、以及 SGLang-JAX 作为独立 JAX 原生引擎存在的原因。TorchTPU 改变了这一关系：PyTorch 成为面向用户的框架，但底层仍可调用 JAX 自定义 kernel 和 Pallas，TPU-Sync 也原生支持 JAX 和 TorchTPU。',
+    significance:
+      '开源推理生态是用 PyTorch 写的。要求引擎跨越 PyTorch 到 JAX 的边界拖慢了 TPU 上的功能对齐和模型 bring-up，因此 Google 把推理栈迁向 PyTorch 原生，同时把 JAX 和 Pallas 保留给 kernel 和内部负载。',
+    benchmarkContext:
+      'Qwen3.5 最初的 TPU 支持先添加了 causal Conv1D 和 Gated DeltaNet 的纯 JAX 实现，之后才由 Pallas kernel 优化。InferenceX Official Preview 的数据来自 TorchTPU vLLM 栈，而不是经 JAX 翻译的 tpu-inference 后端。',
+  },
+  'tpu-sync': {
+    term: 'TPU-Sync',
+    aliases: ['TPU-Sync', 'TPU-raiden', 'tpu-sync', 'TPU KV 传输库'],
+    plainEnglish:
+      'TPU-Sync 是 Google 用来在 TPU 之间以及向主机内存搬运 KV cache 的库，是分离式服务和 offload 所需的底层管道。',
+    definition:
+      'TPU-Sync（原名 TPU-raiden）是 Google 开源的 TPU 分离式 KV cache 传输库，通过提取原生 PJRTBuffer 硬件描述符实现零拷贝传输。',
+    explanation:
+      'prefill-decode 分离需要一条快速通路，把完成 prefill 的 KV cache 从一组芯片搬到另一组；KV cache offload 需要 HBM 与主机 DRAM 之间的往返通路。TPU-Sync 同时提供两者。它原生支持 JAX 和 TorchTPU 栈，并支持原生 TPU KV cache DRAM offload，用于 HBM 放不下所有用户 cache 的大模型和中大 batch 场景。Google 内部为 Gemini 运行分离式服务已有多年，对外开放的工作在 Official Preview 发布前几个月才开始，与 llm-d 的 TPU 支持同步推进。',
+    significance:
+      '没有传输库，TPU 外部服务只能停留在聚合模式，这正是当前结果所处的位置，也是 GB200 和 GB300 NVL72 分离式服务目前在部分曲线上领先的原因。SemiAnalysis 预期 TPU 上的 Mooncake Store 支持会基于 TPU-Sync 的原语实现。',
+    benchmarkContext:
+      'InferenceX Official Preview 比较的是 TPUv7 聚合服务与 B200、B300 聚合服务。基于 TPU-Sync 的分离式服务在外部栈中优化完成后，TPUv7 分离式与 GB200、GB300 NVL72 分离式的对比将在后续文章发布。',
+  },
+  'mooncake-store': {
+    term: 'Mooncake Store',
+    aliases: ['Mooncake Store', 'Mooncake', 'Mooncake KV 存储', 'P2P KV 池化'],
+    plainEnglish:
+      'Mooncake Store 把多台服务器的主机内存和 NVMe 盘汇聚成一个共享的 KV cache 存储，集群内任何加速器都能读取。',
+    definition:
+      'Mooncake Store 是 Mooncake 项目的开源分布式 KV cache 存储层，把各服务节点的 DRAM 和 NVMe 聚合成一个支持点对点访问的逻辑池。',
+    explanation:
+      '通过 P2P 池化，每台主机上的 KV cache 存储被呈现为一个逻辑内存池，任意服务器上的加速器都可以读取其他服务器写入的 cache，而不只是本机的。Mooncake Store 还能跨服务器池化 NVMe，并支持 WEKA、VAST 等分布式文件系统后端。它在 GPU 上已与 vLLM 和 SGLang 配合使用，是业界标准的 offload 存储；Google 正在添加 TPU 支持和 DRAM P2P 池化模式，很可能基于 TPU-Sync 原语实现。',
+    significance:
+      '智能体和多轮负载会在大量请求和 sub-agent 突发之间复用长前缀。集群级的池把 KV cache 命中率提升到远超单机 DRAM 所能达到的水平，这是 HBM 耗尽后高并发智能体服务仍然经济的原因。',
+    benchmarkContext:
+      'GPU 上的 AgentX 结果已经依赖 offload 行为，计划中的 AgentX TPU 结果将在 Ironwood 上实际使用 Mooncake Store 和 TPU-Sync。InferenceX Official Preview 把 Mooncake 支持列为分离式服务之后的下一步外部化工作。',
+  },
+  'llm-d': {
+    term: 'llm-d',
+    aliases: ['llm-d', 'llm-d 项目', 'Kubernetes LLM 服务', '分布式推理编排'],
+    plainEnglish:
+      'llm-d 是一个 Kubernetes 原生框架，在多节点上运行 vLLM，提供智能路由、前缀感知调度和 prefill 与 decode 分离。',
+    definition:
+      'llm-d 是基于 Kubernetes 和 vLLM 构建的开源分布式推理服务框架，为大模型部署提供 KV 感知路由、prefill-decode 分离和多节点调度。',
+    explanation:
+      '单个 vLLM 实例只服务一个副本。生产部署需要一层把每个请求路由到最可能缓存了其前缀的副本，把 prefill 和 decode 拆到不同的池，并独立扩缩这些池。llm-d 提供这种编排，由 Red Hat、Google 等贡献者支持。llm-d 的 TPU 支持是 Google 外部化 prefill-decode 分离工作的一部分，与 TPU-Sync 传输库配套，让外部 TPU 客户能运行 Google 内部为 Gemini 使用的同一种分离式拓扑。',
+    significance:
+      '分离式服务和 KV 感知路由是 TPU 剩余每美元性能收益的主要来源，而它们只存在于引擎之上。让这些功能在 Google 之外可用，在广泛使用的编排层中提供 TPU 支持与引擎后端同样重要。',
+    benchmarkContext:
+      'InferenceX 的单节点聚合结果不涉及 llm-d。计划中的 TPUv7 分离式与 GB200、GB300 NVL72 的对比，取决于 llm-d 和 TPU-Sync 的工作在外部栈中落地。',
+  },
+  'double-buffering': {
+    term: '双缓冲',
+    aliases: ['double buffering', 'triple buffering', '三缓冲', '预取流水线', 'DMA 重叠'],
+    plainEnglish: '双缓冲在芯片还在计算当前数据块时就预取下一块，把内存延迟藏在有效计算之后。',
+    definition:
+      '双缓冲是一种 kernel 技术，分配两个片上缓冲区，让向其中一个的 DMA 传输与另一个上的计算重叠；三缓冲把同样的思路扩展为更深的流水线。',
+    explanation:
+      '在 TPU 上，Pallas kernel 通过在 MXU 处理当前块时把下一块预取进 VMEM 来隐藏 HBM 延迟。两个块必须同时放进 VMEM，因此计算块大小决定了预取能跑多远。SparseCore 上的 ReduceScatter 用双缓冲在传输一个 chunk 的同时累加另一个，把本地归约和 die-to-die 传输与更慢的芯片间流量重叠。grouped matmul 对专家权重做三缓冲，让下一组的权重在当前组计算时已在途。异步 GDN 状态传输使用同样的模式，起初占用了额外 VMEM，直到复用 scratch buffer 才解决。',
+    significance:
+      '报告的 TPU kernel 收益中，很大一部分来自重叠而不是更快的算术。缓冲预算不当会表现为暴露的内存延迟，或者 kernel 其他部分的 VMEM 回退。',
+    benchmarkContext:
+      '把 ragged paged attention 的计算块与预取块分开，为预取流水线留出空间，Qwen3-0.6B 的 decode 吞吐量提高 49%。VMEM 恢复后，异步 GDN 状态传输在 8k1k 并发 512 下带来 11.3% 收益。batched ragged paged attention 采用三缓冲来减少填充并改善流水线。',
+  },
+  'shape-bucketing': {
+    term: 'Shape 分桶',
+    aliases: ['shape bucketing', '编译 shape bucket', 'padding bucket', 'token bucket'],
+    plainEnglish:
+      'shape 分桶把每个 batch 向上取整到少数几个预编译尺寸之一，编译器就不必为每种请求数重新构建程序。',
+    definition:
+      'shape 分桶是为固定的一组张量形状编译 kernel 或计算图，并把每个实际 batch 补齐到最近的桶，以少量浪费换取避免重新编译。',
+    explanation:
+      'XLA 等提前编译器针对静态形状特化，推理引擎不可能为每种请求数和序列长度组合编译新程序，因此改用桶。当桶按数百个并发请求调优、而实际只有 4 或 8 个请求在飞行时，元数据按配置的最大值分配，padding token 触发无效的专家计算，调度开销占据主导。TPU 栈现在按活跃请求数对请求元数据分桶，为并发 4 增加专用 attention 桶，降低最小 token 桶，并把 padding token 路由到 0 号专家以免加载额外的专家权重。',
+    significance:
+      'InferenceX 的工作点正好落在这些低并发上，因此桶的调优直接改变报告的曲线。GPU 上的对应问题是 CUDA graph 的捕获尺寸，TPU 版本更严格，因为 XLA 按形状编译整个计算图。',
+    benchmarkContext:
+      '按活跃请求分桶元数据后，8k1k 并发 64 下 GDN 调度开销从 283 微秒降到 97 微秒，吞吐量从每芯片每秒 2,328 token 提高到 2,516。Qwen3.5 的 InferenceX 调优在并发 4 下 8k1k 提高 13.3%、1k1k 提高 15.5%，后续一轮在并发 4 下 1k1k 再提高 22.9%。',
+  },
+  'gated-deltanet': {
+    term: 'Gated DeltaNet',
+    aliases: ['Gated DeltaNet', 'GDN', 'Gated Delta Net', 'delta rule 注意力'],
+    plainEnglish:
+      'Gated DeltaNet 是一种线性注意力层，为每个请求保留固定大小的运行状态，而不是随 token 增长的 KV cache。',
+    definition:
+      'Gated DeltaNet 是一种循环式线性注意力机制：每一步先用门控衰减运行状态，再用 rank-one 的 delta rule 修正更新，最后与 query 相乘得到输出。',
+    explanation:
+      'Qwen3.5 把 GDN 层与分组查询注意力层交错排列，是一个有两种状态的混合模型：GQA 层累积不断增长的 KV 历史，GDN 层为每个请求保存固定大小的循环状态。在 TPU 上，循环计算被调度到 MXU、VPU、VMEM 和 HBM 之间。一项优化重排了输出投影的代数，让 MXU 直接计算衰减状态与 query 的乘积，同时 VPU 构建下一步的状态，把状态更新从 MXU 的依赖链上移走；当前 token 的贡献只是每个 head 一个标量点积加一次小的向量加法。其他改动包括在 decode 循环中切片 Q 和 K 以减少寄存器溢出、状态在 HBM 中以 BF16 存储而在计算时用 FP32，以及把 Conv1D 与 GDN 融合成一个 kernel。',
+    significance:
+      '固定大小的状态让长上下文在内存上很便宜，但让 prefix caching 变复杂，因为缓存前缀末尾的循环状态通常在请求继续时就被覆盖。混合模型的 prefix caching 为 GDN 提供分开的槽位，分别读取 checkpoint 和写入实时状态，并与 KV block 边界对齐。',
+    benchmarkContext:
+      'Ironwood 上 Qwen3.5 报告的收益包括：代数重排在并发 512 下吞吐量提高 4.48%，异步状态传输提高 11.3%，BF16 状态存储使 1k8k 提高 15%，GDN v3 在 kernel 层面 decode 加速 1.41 倍、prefill 1.60 倍、混合 batch 2.14 倍。',
+  },
+  'aggregated-serving': {
+    term: '聚合服务',
+    aliases: ['aggregated serving', 'agg serving', 'prefill 与 decode 同置', '非分离式服务'],
+    plainEnglish:
+      '聚合服务把 prefill 和 decode 放在同一组芯片上运行，是引擎加入 prefill-decode 分离之前的默认部署形态。',
+    definition:
+      '聚合服务是每个副本在同一组加速器上同时处理每个请求的 prefill 和 decode 阶段的部署模式，与使用独立 prefill 池和 decode 池的分离式服务相对。',
+    explanation:
+      '在聚合模式下，调度器在一组设备上交错执行提示词处理和 token 生成，通常配合 chunked prefill 以免长提示词阻塞 decode。它不需要在池之间传输 KV cache，运维更简单，但 prefill 和 decode 争用同一份算力和内存带宽，两个阶段也无法独立扩缩或调优。分离式服务把两者分开，在机柜级系统的高并发下通常更优，代价是需要 NVIDIA 上的 NIXL 或 TPU 上的 TPU-Sync 这样的快速传输通路。外部 TPU 栈目前只支持聚合模式。',
+    significance:
+      '拿聚合与分离式对比属于 apples to bananas：它把部署模式的差异混进了硬件对比。InferenceX 在每条曲线上标注模式，让读者能把两者分开。',
+    benchmarkContext:
+      'InferenceX Official Preview 比较 TPUv7 聚合 FP8 服务与 B200、B300 聚合 FP8 服务，Ironwood 的每美元性能最高高出 50%。与 GB300 NVL72 分离式服务相比，TPUv7 聚合在低延迟和高延迟端具有竞争力，但在曲线中段落后约 30%，直到 TPU 的分离式服务优化完成。',
+  },
+  'ragged-paged-attention': {
+    term: 'Ragged paged attention',
+    aliases: ['ragged paged attention', 'RPA', 'RPA v3', 'batched ragged paged attention'],
+    plainEnglish:
+      'ragged paged attention 是 TPU 的注意力 kernel，在一次启动中处理长度各异的一批请求，从分页 KV cache 读取数据。',
+    definition:
+      'ragged paged attention（RPA）是 TPU 的 Pallas 注意力 kernel，处理通过 block table 寻址的分页 KV cache 中的变长序列，预先计算 page 元数据并在 batch 内流水线化 page 读取。',
+    explanation:
+      '一批在飞行的请求长度参差不齐，它们的 KV page 散布在 HBM 各处。kernel 把序列打包在一起，预先计算 page 元数据，并对 page 读取做三缓冲，在减少填充的同时让 MXU 保持满载。布局很关键：原始 kernel 沿 head 维度打包 key 和 value，每设备单个 FP8 KV head 时每个 128 lane tile 有一半浪费。sequence-on-lane 布局把 token 放到 lane 轴、head 维度放到 sublane 轴，可用 page 翻倍，并允许 head dim 为 64。另一项修复把 KV 计算块与预取块分开，让预取流水线有 VMEM 可以跑在 MXU 前面。移除混合模型的 page 尺寸对齐约束后，batched attention 可以使用 256 token 的 page。',
+    significance:
+      '对分页 cache 的注意力计算是 TPU tile 几何与 VMEM 预算冲突最直接的地方。这一个 kernel 中的布局和块大小决策，在硬件不变的情况下让可用 KV 容量、TTFT 和 decode 吞吐量变动了数十个百分点。',
+    benchmarkContext:
+      'sequence-on-lane 布局把可用 KV page 从 5,141 提高到 10,283，并发 128 下 8k1k 吞吐量提高 16.5%，中位 TTFT 下降 95%。块大小拆分使 Qwen3-0.6B 的 decode 吞吐量从每秒 64.9k token 提高到 96.3k，256 token page 在并发 512 下为 1k8k 带来约 7% 收益。',
+  },
+  'grouped-gemm': {
+    term: 'Grouped GEMM',
+    aliases: ['grouped GEMM', 'grouped matmul', 'GroupedGEMM', '分组矩阵乘法', 'ragged matmul'],
+    plainEnglish:
+      'grouped GEMM 在一次启动中执行多个小矩阵乘法，每个专家一个，让 MoE 层不必为每个专家单独付出开销。',
+    definition:
+      'grouped GEMM 是在一次启动中执行一组行数各不相同的独立矩阵乘法的 kernel，用于 MoE 层中每个专家接收一组不规则路由 token 的场景。',
+    explanation:
+      'MoE 层为每个专家产生不规则的 token 分组，这些 ragged 分组必须重排成矩阵单元能高效消费的形状。TPU 上第二版 grouped matmul 移除了冗余的 tile 计算，按有效行数而非补齐后的最大值确定传输量，对专家权重做三缓冲让下一组在当前组计算时已在途，并把分组元数据的生成融合进 kernel。不规则的 token permute 迁移到了 SparseCore。小 batch 下，专用路径构建 one-hot 矩阵并用普通矩阵乘法完成 token 的 permute 和 unpermute，因为通用 ragged 路径的开销超过了它所整理的计算本身。在 DP attention 与专家并行下，kernel 先 all-gather token 激活值和路由元数据，再用 reduce-scatter 把加权输出送回各自的 attention rank。',
+    significance:
+      '任何加速器上的 MoE 效率都归结为 grouped GEMM 对不规则分组大小的容忍度，以及能隐藏多少路由工作。TPU 上多出的约束是 MXU tile 几何，因此专家宽度和 token 数也需要填满 256 宽的 tile。',
+    benchmarkContext:
+      'SparseCore permute 重写在 Ironwood 上使 8k1k 吞吐量提高 12%，小 batch one-hot 路径在并发 64 和 128 下分别提高 7.3% 和 5.1%，合并路由 all-gather 每层节省约 80 微秒，在 DeepSeek-V3 的 58 层上每次前向约节省 4.64 毫秒。',
+  },
+  'apples-to-apples-comparison': {
+    term: 'Apples-to-apples 对比',
+    aliases: ['apples-to-apples comparison', 'apples to apples', 'apples to bananas', '同条件对比'],
+    plainEnglish:
+      'apples-to-apples 对比把精度、服务模式和负载保持一致，结果差异才能归因于硬件本身。',
+    definition:
+      '在 InferenceX 中，apples-to-apples 对比要求各系统在数值精度、聚合或分离式服务模式、投机解码设置和负载形状上一致，只有硬件及其软件栈不同。',
+    explanation:
+      '一边 FP8、一边 FP4 不算 apples to apples，因为 FP4 相对 FP8 有质量损失，每个权重读取的字节也只有一半。一边聚合、一边分离式，则把部署模式的优势混进了结果。单 token 预测对 MTP 在投机解码上也是同样的问题。InferenceX 把这种不匹配的情况称为 apples to bananas，并在标注后照常发布，因为买家确实面临这些选择，但头条结论来自匹配的设置。Ironwood 没有原生 FP4，因此目前公平的对比是 FP8 对 FP8 Blackwell；TPUv8i 将以 FP4 对 FP4 比较。',
+    significance:
+      '大量厂商性能声明建立在不匹配的设置之上。坚持匹配精度和服务模式，才能让每美元性能的比值成为关于芯片的陈述，而不是关于营销幻灯片所选方案的陈述。',
+    benchmarkContext:
+      'InferenceX Official Preview 的头条结论，即 TPUv7 每美元性能最高高出 50%，是与 B200、B300 在 FP8 聚合单 token 设置下的 apples-to-apples 对比。GB300 NVL72 分离式对 TPUv7 聚合的图表被明确标注为 apples to bananas，曲线中段 GB300 领先约 30%。',
+  },
+  'internal-vs-external-tco': {
+    term: '内部 TCO 与外部 TCO',
+    aliases: [
+      'internal vs external TCO',
+      'internal TCO',
+      'external TCO',
+      '内部 TCO',
+      '外部 TCO',
+      '超大规模厂商 TCO',
+    ],
+    plainEnglish:
+      '内部 TCO 是芯片设计方自己运行它的成本，外部 TCO 是客户购买或租用它付出的成本，两者可能相差很大。',
+    definition:
+      '内部 TCO 是设计并运营芯片的公司自身的每小时成本，外部 TCO 是第三方购买或租用同一芯片的成本，包含厂商的利润。',
+    explanation:
+      'Google 既为 Gemini 运行 TPU，也向 Anthropic 等客户出售或出租 TPU。SemiAnalysis TCO 模型估算 Ironwood 的内部 TCO 约为每芯片小时 1.03 美元，外部 TCO 更高，反映超大规模实验室购买 TPU 的实际支出。用哪个数字取决于问题：内部 TCO 描述 Google 自己的服务经济性，外部 TCO 描述客户是否应该选 TPU 而不是 B200 或 B300。NVIDIA GPU 从买家角度只有外部 TCO，因为 NVIDIA 不把它们作为服务来运营。',
+    significance:
+      '每美元性能的排名随 TCO 基准而变。同时公布两个数字，可以把硬件的成本结构与厂商的定价决策分开，也显示出 Google 在选择降低外部定价时有多大空间。',
+    benchmarkContext:
+      '按外部 TCO，InferenceX Official Preview 中 Ironwood 在并发 256 下每美元 token 数比 B200 高 50.4%，比 B300 高 96.0%；按内部 TCO，同一数据点变为 76.7% 和 130.2%。文章的头条对比使用外部 TCO，与 GB300 NVL72 分离式服务的 apples-to-bananas 图表则使用内部 TCO。',
+    measurement: {
+      label: 'Ironwood 内部 TCO',
+      value: '每芯片小时 1.03 美元（SemiAnalysis TCO 模型）',
+    },
+  },
 };
 
 const entries = getAllGlossaryEntries().map((entry) => {

--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -1717,10 +1717,10 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
   },
   ici: {
     term: 'ICI（芯片间互连）',
-    aliases: ['ICI', 'Inter-Chip Interconnect', 'TPU 互连', 'ICI fabric'],
+    aliases: ['ICI', 'TPU 互连', 'ICI fabric'],
     plainEnglish: 'ICI 是 TPU 专用的网络，让整个 pod 内的芯片直接交换数据，不需要经过主机 CPU。',
     definition:
-      'ICI（Inter-Chip Interconnect）是 Google 为 TPU 设计的芯片间互连，一种点对点网络，直接在芯片之间传输激活值、梯度和 KV cache，不经过 PCIe 或通用网卡。',
+      'ICI 是 Google 为 TPU 设计的芯片间互连，一种点对点网络，直接在芯片之间传输激活值、梯度和 KV cache，不经过 PCIe 或通用网卡。',
     explanation:
       '每颗 TPU 通过 ICI 链路连接 torus 中的邻居：v2 和 v3 的 2D torus 有 4 个邻居，v4 起的 3D torus 有 6 个。光电路交换机把 64 芯片立方体拼接成数千颗芯片的 pod，同时保留 wraparound 链路。结果是整个 pod 范围内都有 NVLink 级别的带宽，而不是局限在 8 个或 72 个设备之间。TPU 8i 把 ICI 带宽翻倍到每芯片 19.2 Tb/s，并从 torus 改为 Boardfly 拓扑。',
     significance:

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -61,6 +61,7 @@ const AGENTX_QWEN_B300 = 'qwen3-5-397b-agentx-b300-fp4-vs-h100';
 const AGENTX_GLM_SGLANG = 'glm-5-3-agentx-nvidia-vs-amd-sglang-150-toks';
 const AGENTX_GLM_ATOM = 'glm-5-3-agentx-mi355x-atom-vs-gb300-nvl72';
 const JALAPENO = 'openai-jalapeno-better-than-nvidia';
+const TPU_IRONWOOD = 'tpu-inferencex-full-steam';
 
 const entries = [
   {
@@ -2523,6 +2524,571 @@ const entries = [
       'inference-engine',
     ],
     articleSlugs: [MI355X_KIMI, SGLANG_056],
+  },
+  {
+    slug: 'tpu',
+    term: 'Tensor Processing Unit',
+    abbreviation: 'TPU',
+    aliases: ['TPU', 'Google TPU', 'Cloud TPU'],
+    category: 'Hardware',
+    plainEnglish:
+      'A TPU is the accelerator Google designs for its own AI workloads and now sells or rents to other companies for inference.',
+    definition:
+      'A Tensor Processing Unit is a Google-designed accelerator built around large systolic matrix units, an on-chip vector memory, SparseCores for irregular work, and a chip-to-chip fabric called ICI.',
+    explanation:
+      'TPUs run Search, Ads, YouTube, and every Gemini generation inside Google. Each chip pairs TensorCores, whose MXU systolic arrays do the matrix multiplies, with SparseCores that handle embedding lookups and data movement. The XLA compiler schedules work across those units, and Pallas kernels cover operations the compiler does not tile well. Chips connect through ICI into pods of thousands of devices without passing through a host CPU. Ironwood (TPUv7) is the first generation Google offers for outside inference customers, and the TPUv8 lineup splits into 8t for training and 8i for inference.',
+    significance:
+      'The design trades single-chip peak for system-level cost. Wide matrix units, a low-latency torus, and compiler-driven scheduling give Google a lower cost per token than a spec sheet would predict, but tile geometry punishes model shapes that do not fill the array. External adoption depends on the PyTorch-native TorchTPU stack reaching parity with the CUDA ecosystem in vLLM and SGLang.',
+    benchmarkContext:
+      'The InferenceX Official Preview publishes the first third-party TPUv7 results, comparing FP8 aggregated serving against B200 and B300. Ironwood reaches up to 50% better performance per dollar in that comparison, and AgentX and disaggregated TPU results follow once the TorchTPU stack is open sourced.',
+    relatedTerms: ['tpuv7-ironwood', 'mxu', 'sparsecore', 'ici', 'torchtpu', 'xla'],
+    articleSlugs: [TPU_IRONWOOD, VR_RUBIN],
+  },
+  {
+    slug: 'tpuv7-ironwood',
+    term: 'TPUv7 Ironwood',
+    aliases: ['Ironwood', 'TPU v7', 'TPUv7', 'v7x'],
+    category: 'Hardware',
+    plainEnglish:
+      'Ironwood is the seventh-generation TPU and the first one Google sells for other companies to run their own inference on.',
+    definition:
+      'TPUv7 Ironwood is the Google accelerator with two independent compute dies per chip, native FP8 hardware, a 256x256 MXU, roughly six times the HBM of Trillium, and a 3D torus ICI fabric.',
+    explanation:
+      'Ironwood drops the MegaCore convention of TPU v4 and v5p, where two cores shared one memory space. Its two dies run as separate logical devices joined by a die-to-die link, so frameworks see two devices per chip. Each chip carries two TensorCores and four third-generation SparseCores. The base pod unit is a 4x4x4 cube of 64 chips, and optical circuit switches stitch cubes into a 9,216-chip superpod. Ironwood has no native FP4, so the current comparison against NVIDIA uses FP8 on both sides.',
+    significance:
+      'This is the first generation where Google competes for outside inference workloads with chips that can be bought outright or rented. Anthropic alone committed to more than one million TPUs. The FP8-only compute path caps the comparison against Blackwell until TPUv8i adds native FP4.',
+    benchmarkContext:
+      'In the InferenceX Official Preview, Ironwood serving Qwen3.5 397B in FP8 costs about $0.181 per million tokens at 100 tokens per second per user, against $0.222 for B200 and $0.276 for B300. At 20 tokens per second per user it delivers 50.4% more tokens per dollar than B200 and 96.0% more than B300 using external TCO.',
+    measurement: {
+      label: 'Cost at 100 tok/s/user, FP8 8k1k',
+      value: '$0.181 per million tokens vs $0.222 (B200) and $0.276 (B300)',
+    },
+    relatedTerms: ['tpu', 'mxu', 'sparsecore', 'ici', 'fp8', 'performance-per-dollar'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'mxu',
+    term: 'Matrix Multiply Unit',
+    abbreviation: 'MXU',
+    aliases: ['MXU', 'systolic array', 'TPU matrix unit'],
+    category: 'Hardware',
+    plainEnglish:
+      'The MXU is the grid of multiply-accumulate cells inside a TPU that does the matrix math, and it only runs at full speed when every cell has real work.',
+    definition:
+      'The Matrix Multiply Unit is the systolic array at the center of a TPU TensorCore, a two-dimensional grid of multiply-accumulate cells that holds weights stationary while activations stream through.',
+    explanation:
+      'Weights load into the array and stay put. Activations enter from one edge, partial sums ripple across the grid cell by cell, and the finished result streams out the far side without touching memory mid-computation. TPU generations through v5 used a 128x128 array, or 16,384 MACs per cycle. From v6e onward, including Ironwood, the array is 256x256, or 65,536 MACs per cycle. The XLA compiler pads any matrix dimension smaller than the array side up to fill the tile, and every padded cell still consumes a MAC that cycle.',
+    significance:
+      'A wider array is only free when it stays full. A head dimension of 128 on a 256-wide MXU caps the attention matmuls at 50% utilization, and a head dimension of 64 caps them at 25% before any kernel code is written. GPU matrix cores consume small tiles, so the same shapes cost almost nothing on an H100 or B200. Model hyperparameters that were arbitrary on GPUs become a direct throughput tax on TPUs.',
+    benchmarkContext:
+      'Bring-up cost on TPU correlates with how well a model fits the MXU rather than with how popular the model is. Qwen3.5 was chosen as the first TorchTPU bring-up model partly because its shapes fall out cleanly, and the Pallas kernel work described in the InferenceX Official Preview centers on keeping the array fed.',
+    relatedTerms: ['tpu', 'tile-padding', 'gemm', 'vmem', 'pallas', 'arithmetic-intensity'],
+    articleSlugs: [TPU_IRONWOOD, JALAPENO],
+  },
+  {
+    slug: 'sparsecore',
+    term: 'SparseCore',
+    aliases: ['SparseCores', 'TPU SparseCore', 'SC'],
+    category: 'Hardware',
+    plainEnglish:
+      'SparseCores are small helper cores on a TPU chip that handle irregular jobs such as gathers and data movement so the matrix units can keep multiplying.',
+    definition:
+      'A SparseCore is a specialized TPU core for sparse and irregular operations such as embedding lookups, gathers, permutations, and data movement, running alongside the dense TensorCores on the same chip.',
+    explanation:
+      'Ironwood has four third-generation SparseCores per chip next to two TensorCores. Dense matrix engines choke on ragged access patterns, so the TPU team moves that work to SparseCores. In the external serving stack, the MoE token permutation that gathers each expert’s tokens into contiguous groups, the top-k weight gather in the ragged gather-reduce path, and the ReduceScatter collective all run on SparseCore. The TensorCore keeps executing expert matmuls while the SparseCore rearranges data and moves partial sums, and double buffering overlaps the two.',
+    significance:
+      'Offload is not free. A collective that fits in VMEM can be slower on SparseCore than on the TensorCore because of launch overhead, so Qwen3.5 uses a VMEM-derived threshold to decide which all-reduce and all-gather operations move. Getting the split right is a recurring source of per-layer latency wins.',
+    benchmarkContext:
+      'The SparseCore MoE permutation rewrite reported 12% higher 8k1k serving throughput on Ironwood along with lower TTFT and TPOT. Moving the top-k weight gather cut TensorCore overhead from 29 to 14 microseconds in a DeepSeek-V3 microbenchmark, and the collective threshold gained 2.7% at concurrency 64 and 5.7% at concurrency 128.',
+    relatedTerms: ['tpu', 'mxu', 'vmem', 'mixture-of-experts', 'reduce-scatter', 'grouped-gemm'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'vmem',
+    term: 'Vector memory',
+    abbreviation: 'VMEM',
+    aliases: ['VMEM', 'TPU on-chip memory', 'vector memory'],
+    category: 'Hardware',
+    plainEnglish:
+      'VMEM is the fast on-chip scratch memory a TPU kernel works from, and how much of it a kernel uses decides how far ahead it can prefetch.',
+    definition:
+      'VMEM is the software-managed on-chip vector memory of a TPU TensorCore, the staging area that Pallas kernels fill from HBM and compute against, analogous to shared memory on a GPU.',
+    explanation:
+      'A Pallas kernel hides HBM latency by double buffering: it fetches the next block into VMEM while computing on the current one, so both blocks must fit at once. The size of the compute block therefore determines how deep the prefetch can be. The vector unit reads VMEM in tiles whose last dimension is 128 lanes wide, so arrays with a smaller trailing dimension are padded up. Recurrent state for Gated DeltaNet layers stays in FP32 inside VMEM even when it is stored in BF16 in HBM, which halves the HBM footprint without changing the arithmetic.',
+    significance:
+      'VMEM pressure shows up as regressions in unexpected places. Adding a second buffer set for asynchronous GDN state transfers initially broke data-parallel attention until scratch buffers were reused. Collective offload to SparseCore is gated on whether the message fits in VMEM. Kernel authors on TPU budget VMEM the way GPU kernel authors budget shared memory and registers.',
+    benchmarkContext:
+      'The ragged paged attention v3 fix split the KV compute block from the fetch block, keeping the fetch at 16k tokens while reducing compute to 4k, which freed VMEM for the prefetch buffer and lifted decode throughput from 64.9k to 96.3k tokens per second on Qwen3-0.6B. The asynchronous GDN state transfer gained 11.3% at concurrency 512 once VMEM capacity was recovered.',
+    relatedTerms: ['mxu', 'pallas', 'double-buffering', 'high-bandwidth-memory', 'sparsecore'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'ici',
+    term: 'Inter-Chip Interconnect',
+    abbreviation: 'ICI',
+    aliases: ['ICI', 'TPU interconnect', 'ICI fabric'],
+    category: 'Hardware',
+    plainEnglish:
+      'ICI is the custom network that lets TPU chips exchange data directly with each other across a whole pod without going through the host CPU.',
+    definition:
+      'ICI is Google’s chip-to-chip interconnect for TPUs, a point-to-point fabric that carries activations, gradients, and KV-cache traffic between chips without routing through PCIe or a general-purpose NIC.',
+    explanation:
+      'Each TPU has ICI links to its torus neighbors: four on the 2D torus of v2 and v3, six on the 3D torus from v4 onward. Optical circuit switches join 64-chip cubes into pods of thousands of chips while preserving the wraparound links. The result is NVLink-class bandwidth across an entire pod rather than across eight or 72 devices. TPU 8i doubles ICI bandwidth to 19.2 Tb/s per chip and moves from the torus to the Boardfly topology.',
+    significance:
+      'Pod-wide bandwidth changes what parallelism is practical. A DeepSeek-V3-scale model can be sharded across a pod with tensor, expert, and data parallelism without pipeline stages, and Ironwood pods scaling past 1,000 chips can run disaggregated serving and ultra-wide expert parallelism that an NVL72 domain cannot. A torus has more hops than a single-hop NVSwitch, so latency depends on message size and topology.',
+    benchmarkContext:
+      'The InferenceX Official Preview notes that upcoming CollectiveX and NetworkingX results show the TPU torus often has lower latency than a single-hop NVSwitch for the small expert-parallel messages MoE decode produces. The ICI fabric is also where the SparseCore ReduceScatter overlaps die-to-die and chip-to-chip transfers.',
+    relatedTerms: [
+      'torus-topology',
+      'optical-circuit-switch',
+      'boardfly',
+      'nvlink',
+      'scale-up-vs-scale-out',
+      'tpu',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'torus-topology',
+    term: 'Torus topology',
+    aliases: ['3D torus', 'twisted torus', 'torus network'],
+    category: 'Hardware',
+    plainEnglish:
+      'A torus is a grid network whose edges wrap around and connect to each other, so the farthest chip is never more than half the grid away.',
+    definition:
+      'A torus topology connects each chip to its nearest neighbors along every axis and adds wraparound links between the ends of each row, forming rings that halve the worst-case hop distance of a plain mesh.',
+    explanation:
+      'TPU v2 and v3 used a 2D torus with four neighbors per chip. From v4 onward Google uses a 3D torus with six neighbors along the plus and minus X, Y, and Z axes, and Ironwood keeps that layout. The building block is a 4x4x4 cube of 64 chips sized to one rack. A twisted torus offsets the wraparound to shave the average hop count further. Optical circuit switches connect cubes while preserving the wraparound property, which lets Google rewire around a failed chip or link in seconds. Traffic that crosses many hops pays latency at each one, so collectives are scheduled to stay local where possible.',
+    significance:
+      'Before NVL72 racks, any model that did not fit in an eight-GPU node needed pipeline parallelism because inter-node InfiniBand was slow. The TPU torus gave NVLink-class bandwidth across an entire pod years earlier. The tradeoff is hop count: a 1,024-chip torus has a diameter around 16 hops, which is why TPU 8i moves to the flatter Boardfly network for inference.',
+    benchmarkContext:
+      'CollectiveX and NetworkingX measure collective latency directly. The InferenceX Official Preview reports that the TPU torus often beats a single-hop NVSwitch on latency for the small expert-parallel messages that dominate MoE decode, even though it has more hops.',
+    relatedTerms: ['ici', 'optical-circuit-switch', 'boardfly', 'all-to-all', 'expert-parallelism'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'optical-circuit-switch',
+    term: 'Optical circuit switch',
+    abbreviation: 'OCS',
+    aliases: ['OCS', 'optical switching', 'MEMS optical switch'],
+    category: 'Hardware',
+    plainEnglish:
+      'An optical circuit switch uses tiny mirrors to redirect light between fibers, letting Google rewire a TPU pod without touching a cable.',
+    definition:
+      'An optical circuit switch is a device that steers optical signals between fiber ports with movable mirrors, creating reconfigurable point-to-point links without converting the signal to electrical form or inspecting packets.',
+    explanation:
+      'Google uses OCS to stitch 4x4x4 TPU cubes into larger pods while preserving the torus wraparound links across the whole topology. Because the switch redirects light rather than routing packets, it adds negligible latency and no per-packet processing, and it can be reconfigured in software. Ironwood pods scale this way to a 9,216-chip superpod with 42.5 FP8 exaflops of aggregate compute. The same mechanism lets an operator carve a pod into smaller slices of arbitrary shape for different jobs.',
+    significance:
+      'The operational payoff is fault tolerance. A dead chip or failed link is bypassed in seconds by moving mirrors instead of sending a technician to re-splice copper in a live datacenter. Reconfigurability also means the physical pod does not dictate the logical topology, so a job can request the torus dimensions it wants.',
+    benchmarkContext:
+      'OCS is why TPU results in InferenceX are reported per chip within a pod rather than per fixed rack unit. The Official Preview compares aggregated TPUv7 serving against B200 and B300 nodes, with disaggregated pod-scale comparisons against NVL72 reserved for a follow-up.',
+    relatedTerms: ['torus-topology', 'ici', 'tpu', 'scale-up-vs-scale-out', 'infiniband'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'boardfly',
+    term: 'Boardfly',
+    aliases: ['Boardfly topology', 'TPU 8i network', 'TPUv8i Boardfly'],
+    category: 'Hardware',
+    plainEnglish:
+      'Boardfly is the new flatter network in Google’s inference-only TPU 8i that cuts the number of hops between chips roughly in half compared with a torus.',
+    definition:
+      'Boardfly is the high-radix, hierarchical interconnect topology of TPU 8i that replaces the nearest-neighbor 3D torus, named after the dragonfly family of supercomputer networks.',
+    explanation:
+      'TPU 8t, the training chip, keeps the 3D torus. TPU 8i, the inference chip, switches to Boardfly, a fabric of high-radix switches rather than a mesh of direct neighbor links. At comparable scale in the 1,024 to 1,152 chip range, network diameter falls from roughly 16 hops to about 7. TPU 8i pairs this with 19.2 Tb/s of ICI bandwidth, double the prior generation, and 384 MB of on-chip SRAM, three times the prior generation, sized to hold the KV cache of reasoning and agentic models on chip. It also brings native FP4 compute, which Ironwood lacks.',
+    significance:
+      'Fewer hops mean lower tail latency on collectives, which matters when tokens route across MoE layers or when a multi-turn agent session compounds every extra hop into user-visible latency. Boardfly also changes networking attachment capex per chip. This is the first time Google has split training and inference into separate architectures.',
+    benchmarkContext:
+      'SemiAnalysis expects TPUv8i Boardfly to be competitive with Rubin NVL72. When TPUv8i lands on InferenceX and AgentX, the comparison against NVIDIA moves from FP8 versus FP8 to FP4 versus FP4, removing the quality asymmetry in the current Ironwood results.',
+    relatedTerms: ['ici', 'torus-topology', 'tpu', 'tail-latency', 'fp4', 'all-to-all'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'tile-padding',
+    term: 'Tile padding',
+    aliases: ['shape padding', 'MXU padding', 'lane padding'],
+    category: 'Hardware',
+    plainEnglish:
+      'Tile padding is the wasted work a chip does when a matrix dimension is smaller than its hardware tile and gets filled with zeros to fit.',
+    definition:
+      'Tile padding is the rounding up of a tensor dimension to the native tile size of a compute or vector unit, with the padded cells occupying hardware cycles while contributing nothing to the result.',
+    explanation:
+      'On TPU the MXU side length is 128 on older generations and 256 on v6e and v7, and the vector unit works on tiles whose trailing dimension is 128 lanes. XLA pads any smaller axis to fill the tile. Llama 3 8B has a head dimension of 128, exactly half of a 256-wide MXU, which caps its two attention matmuls at 50% utilization. gpt-oss ships head dimension 64 and caps at 25%. DeepSeek MLA splits its query-key dimension into 128 plus 64 for 192, awkward against any power-of-two array. In the batched attention kernel, a single FP8 KV head per device left half of every tile as padding until a sequence-on-lane layout put tokens on the 128-lane axis instead.',
+    significance:
+      'GPU matrix cores consume small tiles, so head dimensions of 64 or 128 and odd post-sharding KV head counts land near peak on H100 or B200. On TPU the same choices are a direct throughput tax before any kernel is written. Bring-up cost therefore tracks how well a model fits the tile geometry rather than how popular it is.',
+    benchmarkContext:
+      'The sequence-on-lane KV layout doubled usable KV pages from 5,141 to 10,283 in the reported Ironwood configuration and lifted 8k1k throughput 16.5% at concurrency 128 while cutting median TTFT by 95%. Explicit packing dimensions in ragged paged attention exist to work around XLA default tiling.',
+    relatedTerms: [
+      'mxu',
+      'ragged-paged-attention',
+      'grouped-query-attention',
+      'gpu-utilization',
+      'xla',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'torchtpu',
+    term: 'TorchTPU',
+    aliases: ['TorchTPU backend', 'native PyTorch TPU', 'torch device tpu'],
+    category: 'Software',
+    plainEnglish:
+      'TorchTPU makes a TPU look like an ordinary PyTorch device, so vLLM and SGLang can run their existing PyTorch code on Google chips.',
+    definition:
+      'TorchTPU is Google’s PyTorch-native TPU backend, built on the PrivateUse1 extension point, that exposes a real torch.Tensor on device tpu and lowers compiled graphs through StableHLO and XLA.',
+    explanation:
+      'The PyTorch dispatcher routes ATen operations to the TPU backend directly instead of translating them into JAX. Developers can run eagerly for bring-up and debugging, or call torch.compile, where TorchDynamo and AOTAutograd produce an FX graph, TorchTPU lowers it to StableHLO, and XLA emits the TPU executable. Inductor and Triton are not used. Native scope covers tensors, dispatch, eager execution, compile entrypoints, and distributed APIs including DDP, FSDP2, DTensor, and both SPMD and MPMD. The kernel layer stays TPU-specific: TorchTPU can call Pallas and JAX-backed custom kernels, so kernels written for the TorchAX stack migrate rather than restart.',
+    significance:
+      'vLLM and SGLang can reuse upstream model code, schedulers, continuous batching, and feature logic instead of rebuilding them across a PyTorch-to-JAX boundary. That lowers the cost of bringing up new models and moves TPU toward day-zero support alongside NVIDIA. TorchTPU replaces TorchAX, which will be deprecated.',
+    benchmarkContext:
+      'The TPUv7 results in the InferenceX Official Preview come from the native TorchTPU vLLM stack serving Qwen3.5 397B in FP8. TorchTPU is in private beta as of early September 2026 and is expected to be open sourced around mid-October at the PyTorch Conference, at which point SemiAnalysis moves TPU benchmarking from its fork to the public InferenceX repo.',
+    relatedTerms: ['torchax', 'xla', 'pallas', 'vllm', 'sglang', 'tpu'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'torchax',
+    term: 'TorchAX',
+    aliases: ['torchax', 'tpu-inference backend', 'PyTorch to JAX translation'],
+    category: 'Software',
+    plainEnglish:
+      'TorchAX let PyTorch model code run on TPUs by secretly translating each operation into JAX, an approach TorchTPU is now replacing.',
+    definition:
+      'TorchAX is a translation layer that intercepts PyTorch ATen operations through the __torch_dispatch__ hook and executes them as JAX operations, backing each torchax.tensor.Tensor with a jax.Array.',
+    explanation:
+      'vLLM TPU support went through three stages. The first prototype used PyTorch/XLA lazy execution to collect operations into graphs for XLA. The current public tpu-inference backend uses a TPU-optimized JAX model when one exists and otherwise runs the PyTorch model through TorchAX. State such as weights and the KV cache is exposed to JAX explicitly through functionalization so jax.jit can capture each step, and vLLM bypasses its usual torch.compile path because the JAX pipeline already handles graph capture. SGLang-JAX is a separate JAX-native engine that made a similar trade. Google chose JAX because it had more mature TPU primitives and parallelism support at the time.',
+    significance:
+      'Translating across two frameworks caused recurring issues with low-level optimization, paged attention, and fitting vLLM’s worker model to TPU execution, and it forced engine features to be reimplemented on the JAX side. Those costs prompted Google, PyTorch, vLLM, and SGLang to build TorchTPU instead.',
+    benchmarkContext:
+      'The Pallas kernels developed under TorchAX, including the MoE, GDN, and paged attention work described in the InferenceX Official Preview, carry over to TorchTPU because both stacks can invoke Pallas and JAX kernels. TorchAX itself is scheduled for deprecation once TorchTPU ships.',
+    relatedTerms: ['torchtpu', 'jax', 'xla', 'pallas', 'vllm'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'pallas',
+    term: 'Pallas',
+    aliases: ['Pallas kernels', 'JAX Pallas', 'TPU custom kernels'],
+    category: 'Software',
+    plainEnglish:
+      'Pallas is the way engineers write hand-tuned kernels for TPUs when the compiler alone does not schedule an operation well enough.',
+    definition:
+      'Pallas is the JAX extension for writing custom TPU and GPU kernels that control tiling, memory movement between HBM and VMEM, and the scheduling of MXU and vector unit work explicitly.',
+    explanation:
+      'XLA handles most of a model, but performance-critical operations such as ragged paged attention, grouped MoE matmuls, and Gated DeltaNet recurrences need explicit control over block sizes, double buffering, and lane layout. Pallas provides that control in Python. The TPU inference optimizations in the Official Preview are mostly Pallas kernels: GDN v3 fuses Conv1D and GDN into one kernel, the grouped matmul triple-buffers expert weights, and the attention kernel adopts a sequence-on-lane layout. Helion’s TPU backend also emits Pallas. TorchTPU can call Pallas kernels from native PyTorch, so kernels written for TorchAX transfer with wrapper and layout adjustments.',
+    significance:
+      'Pallas plays the role that CUDA C++, CUTLASS, and Triton play on NVIDIA. Native PyTorch support does not remove the need for it; tensor shapes and layouts still have to be tuned to feed the MXU. How fast the ecosystem writes Pallas kernels for new models sets the pace of TPU externalization.',
+    benchmarkContext:
+      'Reported Pallas kernel wins on Ironwood include GDN v3 speedups of 1.41x decode, 1.60x prefill, and 2.14x mixed batches at the kernel level, an 11.3% throughput gain at concurrency 512 from asynchronous state transfers, and a 49% decode throughput gain from splitting attention fetch and compute block sizes.',
+    relatedTerms: ['xla', 'jax', 'torchtpu', 'vmem', 'kernel-fusion', 'triton'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'xla',
+    term: 'XLA',
+    abbreviation: 'XLA',
+    aliases: ['Accelerated Linear Algebra', 'StableHLO', 'XLA compiler'],
+    category: 'Software',
+    plainEnglish:
+      'XLA is the compiler that turns a model graph into TPU machine code, deciding how to tile, pad, fuse, and schedule every operation.',
+    definition:
+      'XLA is the domain-specific compiler for linear algebra that consumes a StableHLO graph and produces executable code for TPUs and other accelerators, handling fusion, layout, tiling, and scheduling.',
+    explanation:
+      'Every TPU serving path ends in XLA. In the JAX path, jax.jit captures a step and hands it to XLA. In TorchTPU, TorchDynamo and AOTAutograd produce an FX graph that is lowered to StableHLO, the standardized intermediate representation, and XLA compiles it. XLA is the compiler in both cases; Inductor and Triton are not involved. The compiler pads any dimension smaller than the MXU tile, picks default layouts, and fuses elementwise work, which is efficient for regular shapes and costly for shapes that fight the tile geometry. Pallas exists for the cases where XLA’s defaults are not good enough.',
+    significance:
+      'Co-design between the compiler and the hardware is a large part of Google’s cost-per-token advantage: the chip, fabric, and compiler are designed together so computation and communication can be optimized as one system. The same tight coupling means model shapes and compiled shape buckets have outsized performance effects.',
+    benchmarkContext:
+      'Several Official Preview optimizations are about steering XLA rather than replacing it, including packing expert ID and token index into one sort key so XLA performs a simpler sort, which cut sort latency from 106.6 to 21.7 microseconds and enabled an FP8 all-gather.',
+    relatedTerms: ['torchtpu', 'jax', 'pallas', 'tile-padding', 'shape-bucketing', 'cuda-graphs'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'jax',
+    term: 'JAX',
+    aliases: ['JAX framework', 'jax.jit', 'Google JAX'],
+    category: 'Software',
+    plainEnglish:
+      'JAX is Google’s Python framework for array computing that compiles functions through XLA and has been the native way to program TPUs.',
+    definition:
+      'JAX is a Python library for composable function transformations such as jit, grad, and vmap over NumPy-style arrays, compiled through XLA and used as the primary first-party framework for TPUs.',
+    explanation:
+      'JAX programs are functional: state such as model weights and the KV cache is passed in and out explicitly so jax.jit can trace a step into a graph. That model fits XLA well and made JAX the mature path for TPU primitives and parallelism, which is why the first external vLLM TPU backend translated PyTorch into JAX through TorchAX and why SGLang-JAX exists as a separate JAX-native engine. TorchTPU changes the relationship: PyTorch becomes the user-facing framework, but JAX-backed custom kernels and Pallas remain callable underneath, and TPU-Sync works natively with both JAX and TorchTPU.',
+    significance:
+      'The open-source serving ecosystem is written in PyTorch. Requiring engines to cross a PyTorch-to-JAX boundary slowed feature parity and model bring-up on TPU, so Google is moving the serving stack to PyTorch-native while keeping JAX and Pallas for kernels and for its own internal workloads.',
+    benchmarkContext:
+      'Initial Qwen3.5 TPU support added pure JAX implementations of causal Conv1D and Gated DeltaNet before later Pallas kernels optimized them. The InferenceX Official Preview numbers come from the TorchTPU vLLM stack rather than the JAX-translated tpu-inference backend.',
+    relatedTerms: ['xla', 'torchax', 'torchtpu', 'pallas', 'tpu'],
+    articleSlugs: [TPU_IRONWOOD, INFERENCEX_V2],
+  },
+  {
+    slug: 'tpu-sync',
+    term: 'TPU-Sync',
+    aliases: ['TPU-raiden', 'tpu-sync', 'TPU KV transfer library'],
+    category: 'Software',
+    plainEnglish:
+      'TPU-Sync is Google’s library for moving KV cache between TPUs and out to host memory, the plumbing that disaggregated serving and offloading need.',
+    definition:
+      'TPU-Sync, formerly TPU-raiden, is Google’s open-sourced disaggregated KV-cache transfer library for TPUs that performs zero-copy transfers by extracting native PJRTBuffer hardware descriptors.',
+    explanation:
+      'Prefill-decode disaggregation needs a fast path to move a finished prefill’s KV cache from one pool of chips to another, and KV-cache offloading needs a path from HBM to host DRAM and back. TPU-Sync supplies both. It works natively with JAX and with the TorchTPU stack, and it supports native TPU KV-cache DRAM offloading for large models and medium-to-large batches where HBM cannot hold every user’s cache. Google has run disaggregation internally for Gemini for years; externalizing it began only a couple of months before the Official Preview, alongside TPU support in llm-d.',
+    significance:
+      'Without a transfer library, TPU external serving is limited to aggregated mode, which is where the current results sit and where GB200 and GB300 NVL72 disaggregated serving currently leads on part of the curve. SemiAnalysis expects Mooncake Store support on TPU to be built on TPU-Sync primitives.',
+    benchmarkContext:
+      'The InferenceX Official Preview compares aggregated TPUv7 against aggregated B200 and B300. A TPUv7 disaggregated versus GB200 and GB300 NVL72 disaggregated comparison is planned for a follow-up once TPU-Sync-based disaggregation is optimized in the external stack.',
+    relatedTerms: [
+      'disaggregated-inference',
+      'kv-cache-offload',
+      'cpu-offloading',
+      'mooncake-store',
+      'llm-d',
+      'torchtpu',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'mooncake-store',
+    term: 'Mooncake Store',
+    aliases: ['Mooncake', 'Mooncake KV store', 'P2P KV pooling'],
+    category: 'Software',
+    plainEnglish:
+      'Mooncake Store pools the host memory and NVMe drives across many servers into one shared KV-cache store that any accelerator in the cluster can read.',
+    definition:
+      'Mooncake Store is the open-source distributed KV-cache storage layer from the Mooncake project that aggregates DRAM and NVMe across serving nodes into a single logical pool with peer-to-peer access.',
+    explanation:
+      'With P2P pooling, the KV-cache storage on each host is presented as one logical memory pool, so an accelerator on any server can fetch cache written by any other server instead of only its own host. Mooncake Store also pools NVMe across servers and supports distributed filesystem backends such as WEKA and VAST. It is used with vLLM and SGLang on GPUs as the industry-standard offloading store, and Google is adding TPU support along with the DRAM P2P pooling mode, likely implemented on TPU-Sync primitives.',
+    significance:
+      'Agentic and multi-turn workloads reuse long prefixes across many requests and across sub-agent bursts. A cluster-wide pool raises the KV-cache hit rate well beyond what a single host’s DRAM allows, which is what makes high-concurrency agent serving economical once HBM is exhausted.',
+    benchmarkContext:
+      'AgentX results on GPUs already depend on offloading behavior, and the planned AgentX TPU results will exercise Mooncake Store and TPU-Sync on Ironwood. The InferenceX Official Preview lists Mooncake support as one of the next externalization steps after disaggregation.',
+    relatedTerms: [
+      'kv-cache-offload',
+      'nvme-offloading',
+      'cpu-offloading',
+      'tpu-sync',
+      'prefix-cache-hit-rate',
+      'kv-cache-manager',
+    ],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3, KIMI_K3],
+  },
+  {
+    slug: 'llm-d',
+    term: 'llm-d',
+    aliases: ['llm-d project', 'Kubernetes LLM serving', 'distributed inference orchestrator'],
+    category: 'Software',
+    plainEnglish:
+      'llm-d is a Kubernetes-native framework that runs vLLM across many nodes with smart routing, prefix-aware scheduling, and disaggregated prefill and decode.',
+    definition:
+      'llm-d is an open-source distributed inference serving framework built on Kubernetes and vLLM that provides KV-aware routing, prefill-decode disaggregation, and multi-node scheduling for large model deployments.',
+    explanation:
+      'A single vLLM instance serves one replica. Production deployments need a layer that routes each request to the replica most likely to hold its prefix in cache, splits prefill and decode across separate pools, and scales those pools independently. llm-d supplies that orchestration, backed by Red Hat, Google, and other contributors. TPU support in llm-d is part of Google’s externalization work for prefill-decode disaggregation, alongside the TPU-Sync transfer library, so external TPU customers can run the same disaggregated topology Google uses internally for Gemini.',
+    significance:
+      'Disaggregation and KV-aware routing are where much of the remaining performance-per-dollar gain sits for TPU, and they only exist above the engine. Shipping TPU support in a widely used orchestrator matters as much as the engine backend for making those features usable outside Google.',
+    benchmarkContext:
+      'InferenceX single-node aggregated results do not exercise llm-d. The planned TPUv7 disaggregated comparison against GB200 and GB300 NVL72 depends on the llm-d and TPU-Sync work landing in the external stack.',
+    relatedTerms: [
+      'disaggregated-inference',
+      'kv-aware-routing',
+      'tpu-sync',
+      'vllm',
+      'nvidia-dynamo',
+    ],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'double-buffering',
+    term: 'Double buffering',
+    aliases: ['triple buffering', 'prefetch pipelining', 'DMA overlap'],
+    category: 'Software',
+    plainEnglish:
+      'Double buffering fetches the next chunk of data while the chip is still computing on the current one, so memory latency is hidden behind useful work.',
+    definition:
+      'Double buffering is a kernel technique that allocates two on-chip buffers so a DMA transfer into one overlaps computation on the other, with triple buffering extending the same idea to a deeper pipeline.',
+    explanation:
+      'On TPU a Pallas kernel hides HBM latency by fetching the next block into VMEM while the MXU works on the current block. Both blocks must fit in VMEM, so compute block size sets how far ahead the prefetch can run. The SparseCore ReduceScatter uses double buffering to transfer one chunk while accumulating another, overlapping local reductions and die-to-die transfers with slower chip-to-chip traffic. The grouped matmul triple-buffers expert weights so the next group’s weights are in flight while the current group computes. Asynchronous GDN state transfers use the same pattern, which initially cost VMEM until scratch buffers were reused.',
+    significance:
+      'Much of the reported TPU kernel gain comes from overlap rather than from faster arithmetic. Getting the buffer budget wrong shows up as either exposed memory latency or VMEM regressions elsewhere in the kernel.',
+    benchmarkContext:
+      'Splitting the ragged paged attention compute block from the fetch block gave the prefetch pipeline room and raised decode throughput 49% on Qwen3-0.6B. Asynchronous GDN state transfers gained 11.3% on 8k1k at concurrency 512 once VMEM was recovered. Batched ragged paged attention triple-buffers to reduce padding and improve pipelining.',
+    relatedTerms: [
+      'vmem',
+      'pallas',
+      'kernel-fusion',
+      'memory-bandwidth',
+      'memory-bound-vs-compute-bound',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'shape-bucketing',
+    term: 'Shape bucketing',
+    aliases: ['compiled shape buckets', 'padding buckets', 'token buckets'],
+    category: 'Software',
+    plainEnglish:
+      'Shape bucketing rounds each batch up to one of a few precompiled sizes so the compiler does not have to build a new program for every request count.',
+    definition:
+      'Shape bucketing is the practice of compiling a kernel or graph for a fixed set of tensor shapes and padding each live batch up to the nearest bucket, trading some wasted work for avoiding recompilation.',
+    explanation:
+      'Ahead-of-time compilers such as XLA specialize on static shapes, so a serving engine cannot compile a fresh program for every combination of request count and sequence length. It picks buckets instead. When the buckets are tuned for hundreds of concurrent requests and only four or eight are in flight, metadata is sized for the configured maximum, padding tokens trigger dummy expert work, and scheduling overhead dominates. The TPU stack now buckets request metadata by active request count, adds a dedicated attention bucket for concurrency four, reduces the minimum token bucket, and routes padding tokens to expert zero so they do not load extra expert weights.',
+    significance:
+      'InferenceX operating points sit at exactly these low concurrencies, so bucket tuning directly changes reported curves. The same issue appears on GPUs as CUDA graph capture sizes; the TPU version is stricter because XLA compiles whole graphs per shape.',
+    benchmarkContext:
+      'Bucketing metadata by active requests cut GDN scheduling overhead from 283 to 97 microseconds on 8k1k at concurrency 64 and raised throughput from 2,328 to 2,516 tokens per chip per second. Qwen3.5 InferenceX tuning gained 13.3% on 8k1k and 15.5% on 1k1k at concurrency four, and a further round gained 22.9% on 1k1k at concurrency four.',
+    relatedTerms: ['xla', 'cuda-graphs', 'concurrency', 'tile-padding', 'continuous-batching'],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3],
+  },
+  {
+    slug: 'gated-deltanet',
+    term: 'Gated DeltaNet',
+    abbreviation: 'GDN',
+    aliases: ['GDN', 'Gated Delta Net', 'delta rule attention'],
+    category: 'Model architecture',
+    plainEnglish:
+      'Gated DeltaNet is a linear attention layer that keeps a fixed-size running state per request instead of a KV cache that grows with every token.',
+    definition:
+      'Gated DeltaNet is a recurrent linear attention mechanism in which, at each step, the running state is decayed by a gate, updated with a rank-one delta-rule correction, and projected by the query to produce the output.',
+    explanation:
+      'Qwen3.5 interleaves GDN layers with grouped-query attention layers, making it a hybrid model with two kinds of state: GQA layers accumulate a growing KV history while GDN layers hold a fixed-size recurrent state per request. On TPU the recurrence is scheduled across the MXU, VPU, VMEM, and HBM. One optimization rearranges the output projection algebra so the MXU computes the decayed state times the query while the VPU builds the next state, removing the state update from the MXU dependency path; the current token’s contribution is a scalar dot product per head plus a small vector add. Other changes slice Q and K in the decode loop to cut register spills, store state in BF16 in HBM while computing in FP32, and fuse Conv1D with GDN into one kernel.',
+    significance:
+      'Fixed-size state makes long contexts cheap in memory but complicates prefix caching, because the recurrent state at the end of a cached prefix is normally overwritten as the request continues. Hybrid prefix caching gives GDN separate slots for reading a checkpoint and writing live state, aligned to KV block boundaries.',
+    benchmarkContext:
+      'Reported Ironwood gains on Qwen3.5 include 4.48% throughput at concurrency 512 from the algebra rearrangement, 11.3% from asynchronous state transfers, 15% on 1k8k from BF16 state storage, and kernel-level speedups of 1.41x decode, 1.60x prefill, and 2.14x mixed batches from GDN v3.',
+    relatedTerms: [
+      'linear-attention',
+      'hybrid-attention',
+      'prefix-caching',
+      'grouped-query-attention',
+      'kv-cache',
+      'vmem',
+    ],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3, KIMI_K3, MI355X_QWEN, AGENTX_QWEN_SGLANG],
+  },
+  {
+    slug: 'aggregated-serving',
+    term: 'Aggregated serving',
+    aliases: ['agg serving', 'colocated prefill and decode', 'non-disaggregated serving'],
+    category: 'Serving',
+    plainEnglish:
+      'Aggregated serving runs prefill and decode on the same set of chips, the default deployment shape before an engine adds prefill-decode disaggregation.',
+    definition:
+      'Aggregated serving is the deployment mode in which each replica handles both the prefill and decode phases of every request on the same accelerators, as opposed to disaggregated serving with separate prefill and decode pools.',
+    explanation:
+      'In aggregated mode a scheduler interleaves prompt processing and token generation on one set of devices, usually with chunked prefill so long prompts do not stall decode. It needs no KV-cache transfer between pools and is simpler to operate, but prefill and decode compete for the same compute and memory bandwidth, and neither phase can be scaled or tuned independently. Disaggregation separates them and typically wins at high concurrency on rack-scale systems, at the cost of a fast transfer path such as NIXL on NVIDIA or TPU-Sync on TPU. The external TPU stack currently serves in aggregated mode only.',
+    significance:
+      'Comparing aggregated against disaggregated is an apples-to-bananas comparison: it mixes a deployment-mode difference into a hardware comparison. InferenceX labels the mode on every curve so readers can separate the two.',
+    benchmarkContext:
+      'The InferenceX Official Preview compares TPUv7 aggregated FP8 serving against B200 and B300 aggregated FP8 serving, where Ironwood reaches up to 50% better performance per dollar. Against GB300 NVL72 disaggregated serving, TPUv7 aggregated is competitive at low and high end-to-end latency but trails by about 30% in the middle of the curve until TPU disaggregation is optimized.',
+    relatedTerms: [
+      'disaggregated-inference',
+      'chunked-prefill',
+      'prefill',
+      'decode',
+      'apples-to-apples-comparison',
+      'tpu-sync',
+    ],
+    articleSlugs: [TPU_IRONWOOD, GB200_R1, GB300_DSV4],
+  },
+  {
+    slug: 'ragged-paged-attention',
+    term: 'Ragged paged attention',
+    abbreviation: 'RPA',
+    aliases: ['RPA', 'RPA v3', 'batched ragged paged attention'],
+    category: 'Serving',
+    plainEnglish:
+      'Ragged paged attention is the TPU attention kernel that handles a batch of requests with different lengths reading from a paged KV cache in one launch.',
+    definition:
+      'Ragged paged attention is the Pallas attention kernel for TPU that processes variable-length sequences from a block-table-addressed KV cache, precomputing page metadata and pipelining page fetches across a batch.',
+    explanation:
+      'A batch of in-flight requests has ragged lengths, and their KV pages are scattered across HBM. The kernel batches sequences together, precomputes page metadata, and triple-buffers page fetches to keep the MXU fed while reducing padding. Layout matters: the original kernel packed keys and values along the head dimension, which wasted half of every 128-lane tile for a single FP8 KV head per device. The sequence-on-lane layout puts tokens on the lane axis and the head dimension on sublanes, doubling usable pages and admitting head dimension 64. A separate fix split the KV compute block from the fetch block so the prefetch pipeline had VMEM to run ahead of the MXU. Removing a hybrid page-size alignment constraint let batched attention use a 256-token page.',
+    significance:
+      'Attention over the paged cache is where TPU tile geometry and VMEM budget collide most directly. Layout and block-size decisions in this one kernel moved usable KV capacity, TTFT, and decode throughput by tens of percent on unchanged hardware.',
+    benchmarkContext:
+      'The sequence-on-lane layout raised usable KV pages from 5,141 to 10,283 and lifted 8k1k throughput 16.5% at concurrency 128 with a 95% cut in median TTFT. The block-size split raised decode throughput from 64.9k to 96.3k tokens per second on Qwen3-0.6B, and the 256-token page gave about 7% on 1k8k at concurrency 512.',
+    relatedTerms: [
+      'paged-attention',
+      'kv-cache',
+      'pallas',
+      'tile-padding',
+      'vmem',
+      'double-buffering',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'grouped-gemm',
+    term: 'Grouped GEMM',
+    aliases: ['grouped matmul', 'GroupedGEMM', 'ragged matmul'],
+    category: 'Software',
+    plainEnglish:
+      'A grouped GEMM runs many small matrix multiplies, one per expert, in a single launch so a mixture-of-experts layer does not pay per-expert overhead.',
+    definition:
+      'A grouped GEMM is a kernel that executes a set of independent matrix multiplications with different row counts in one launch, used in MoE layers where each expert receives a ragged group of routed tokens.',
+    explanation:
+      'A mixture-of-experts layer produces irregular groups of tokens for each expert, and those ragged groups must be reshaped into something the matrix units can consume efficiently. On TPU the second grouped matmul version removes redundant tile computation, sizes transfers to the number of valid rows rather than the padded maximum, triple-buffers expert weights so the next group is in flight while the current one computes, and fuses group metadata generation into the kernel. The irregular token permutation moved to SparseCore. For small batches a dedicated path builds one-hot matrices and uses ordinary matmuls to permute and unpermute tokens because the general ragged path costs more than the work it arranges. With DP attention and expert parallelism, the kernel all-gathers token activations and routing metadata first and reduce-scatters weighted outputs back to each attention rank.',
+    significance:
+      'MoE efficiency on any accelerator reduces to how well the grouped GEMM tolerates ragged group sizes and how much of the routing work can be hidden. On TPU the added constraint is MXU tile geometry, so expert widths and token counts also need to fill 256-wide tiles.',
+    benchmarkContext:
+      'The SparseCore permutation rewrite reported 12% higher 8k1k throughput on Ironwood, the small-batch one-hot path gained 7.3% at concurrency 64 and 5.1% at 128, and merging the routing all-gathers saved roughly 80 microseconds per layer, about 4.64 ms per forward pass across DeepSeek-V3’s 58 layers.',
+    relatedTerms: [
+      'gemm',
+      'mixture-of-experts',
+      'expert-parallelism',
+      'sparsecore',
+      'all-gather',
+      'reduce-scatter',
+    ],
+    articleSlugs: [TPU_IRONWOOD, DEEPSEEK_V4],
+  },
+  {
+    slug: 'apples-to-apples-comparison',
+    term: 'Apples-to-apples comparison',
+    aliases: ['apples to apples', 'apples to bananas', 'like-for-like comparison'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'An apples-to-apples comparison holds precision, serving mode, and workload constant so a difference in results can be attributed to the hardware.',
+    definition:
+      'An apples-to-apples comparison in InferenceX matches numerical precision, aggregated or disaggregated serving mode, speculative decoding settings, and workload shape across systems so that only the hardware and its software stack differ.',
+    explanation:
+      'FP8 on one side and FP4 on the other is not apples to apples, because FP4 carries a quality loss relative to FP8 and reads half the bytes per weight. Aggregated on one side and disaggregated on the other mixes a deployment-mode advantage into the result. Single-token prediction against MTP does the same for speculative decoding. InferenceX calls the mismatched case apples to bananas and still publishes it, labeled, because buyers face those choices, but headline claims come from matched settings. Ironwood has no native FP4, so its fair comparison today is FP8 versus FP8 Blackwell; TPUv8i will be compared FP4 versus FP4.',
+    significance:
+      'A large share of vendor performance claims rest on mismatched settings. Insisting on matched precision and serving mode is what makes a performance-per-dollar ratio a statement about the chip rather than about the recipe chosen for the marketing slide.',
+    benchmarkContext:
+      'The InferenceX Official Preview headline, up to 50% better performance per dollar for TPUv7, is an apples-to-apples FP8 aggregated single-token comparison against B200 and B300. The GB300 NVL72 disaggregated versus TPUv7 aggregated chart is explicitly labeled apples to bananas and shows about a 30% GB300 advantage mid-curve.',
+    relatedTerms: [
+      'performance-per-dollar',
+      'pareto-frontier',
+      'aggregated-serving',
+      'disaggregated-inference',
+      'fp8',
+      'fp4',
+      'recipe',
+    ],
+    articleSlugs: [TPU_IRONWOOD, INFERENCEMAX, VR_RUBIN, JALAPENO],
+  },
+  {
+    slug: 'internal-vs-external-tco',
+    term: 'Internal vs external TCO',
+    aliases: ['internal TCO', 'external TCO', 'hyperscaler TCO'],
+    category: 'Benchmark metrics',
+    plainEnglish:
+      'Internal TCO is what a chip costs its own designer to run; external TCO is what a customer pays to buy or rent it, and the two can differ a lot.',
+    definition:
+      'Internal TCO is the hourly cost of a chip to the company that designs and operates it, while external TCO is the cost to a third party buying or renting the same chip, including the vendor’s margin.',
+    explanation:
+      'Google both runs TPUs for Gemini and sells or rents them to customers such as Anthropic. The SemiAnalysis TCO Model estimates Ironwood internal TCO at about $1.03 per chip-hour and a higher external TCO that reflects what a hyperscaler lab pays to buy TPUs. Which number to use depends on the question: internal TCO describes Google’s own serving economics, external TCO describes whether a customer should choose TPU over B200 or B300. NVIDIA GPUs only have an external TCO from the buyer’s point of view because NVIDIA does not operate them as a service.',
+    significance:
+      'Performance-per-dollar rankings move with the TCO basis. Publishing both numbers separates the hardware’s cost structure from the vendor’s pricing decision, and it shows how much room Google has to cut external pricing if it chooses to.',
+    benchmarkContext:
+      'On external TCO, Ironwood delivers 50.4% more tokens per dollar than B200 and 96.0% more than B300 at concurrency 256 in the InferenceX Official Preview. On internal TCO the same datapoint becomes 76.7% and 130.2%. The article uses external TCO for its headline comparison and internal TCO for the apples-to-bananas chart against GB300 NVL72 disaggregated serving.',
+    measurement: {
+      label: 'Ironwood internal TCO',
+      value: '$1.03 per chip-hour (SemiAnalysis TCO Model)',
+    },
+    relatedTerms: [
+      'total-cost-of-ownership',
+      'performance-per-dollar',
+      'tokens-per-dollar',
+      'cost-per-million-tokens',
+      'tpuv7-ironwood',
+    ],
+    articleSlugs: [TPU_IRONWOOD, VR_RUBIN],
   },
 ] as const satisfies readonly GlossaryEntry[];
 


### PR DESCRIPTION
## Summary

Reads the newly ported [TPU Inference Externalization Full Steam Ahead](https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam) post and adds 26 bilingual glossary entries for the terminology it introduces. Also links that post from the glossary, which fixes the `glossary.test.ts` article-coverage assertion that has failed on master since #1065 added the post without a glossary reference.

### New terms

- **Hardware:** Tensor Processing Unit (TPU), TPUv7 Ironwood, Matrix Multiply Unit (MXU), SparseCore, Vector memory (VMEM), Inter-Chip Interconnect (ICI), Torus topology, Optical circuit switch (OCS), Boardfly, Tile padding
- **Software:** TorchTPU, TorchAX, Pallas, XLA, JAX, TPU-Sync, Mooncake Store, llm-d, Double buffering, Shape bucketing, Grouped GEMM
- **Model architecture:** Gated DeltaNet (GDN)
- **Serving:** Aggregated serving, Ragged paged attention (RPA)
- **Benchmark metrics:** Apples-to-apples comparison, Internal vs external TCO

Every entry carries the numbers the article reports (e.g. $0.181 vs $0.222 vs $0.276 per million tokens at 100 tok/s/user, 5,141 to 10,283 usable KV pages from the sequence-on-lane layout, 64.9k to 96.3k decode tok/s from the RPA block split) in `benchmarkContext`, and cross-links into existing entries such as `disaggregated-inference`, `paged-attention`, `gemm`, `linear-attention`, and `hybrid-attention`. `TPUv7 Ironwood` and `Internal vs external TCO` include a `measurement` block.

### Checks run locally

- `bun run fmt`, `bun run lint`, `bun run typecheck`, `bun run check:typography`
- `vitest run src/lib/glossary.test.ts src/lib/chip-pages.test.ts src/app/sitemap.test.ts` (28 passed; the glossary coverage test now passes)

## 中文说明

阅读刚移植的《TPU Inference Externalization Full Steam Ahead》一文，为其中出现的术语新增 26 条中英双语术语表条目，并让术语表引用该文章，修复自 #1065 起在 master 上失败的 `glossary.test.ts` 文章覆盖断言。

新增术语：

- **硬件：** TPU、TPUv7 Ironwood、MXU、SparseCore、VMEM、ICI、torus 拓扑、光电路交换机（OCS）、Boardfly、tile 补齐
- **软件栈：** TorchTPU、TorchAX、Pallas、XLA、JAX、TPU-Sync、Mooncake Store、llm-d、双缓冲、shape 分桶、grouped GEMM
- **模型架构：** Gated DeltaNet（GDN）
- **推理服务：** 聚合服务、ragged paged attention（RPA）
- **基准指标：** apples-to-apples 对比、内部 TCO 与外部 TCO

每条条目的 `benchmarkContext` 都保留了文章报告的具体数字，并与 `disaggregated-inference`、`paged-attention`、`gemm`、`linear-attention`、`hybrid-attention` 等现有条目互相链接。中文条目按 `docs/chinese-copy.md` 的技术散文语域撰写，保留产品名、SKU、框架名和行业惯用英文术语。

本地已运行 fmt、lint、typecheck、check:typography，以及术语表、chip-pages 和 sitemap 的单元测试（28 项通过）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only changes to glossary data and translations; no runtime serving or auth paths affected.
> 
> **Overview**
> Adds **26 new glossary entries** (English in `glossary.ts`, Chinese in `glossary-zh.ts`) for terminology from the TPU InferenceX Ironwood article—hardware (TPU, Ironwood, MXU, SparseCore, VMEM, ICI, torus/OCS/Boardfly, tile padding), software (TorchTPU, TorchAX, Pallas, XLA, JAX, TPU-Sync, Mooncake Store, llm-d, double buffering, shape bucketing, grouped GEMM), architecture (Gated DeltaNet), serving (aggregated serving, ragged paged attention), and benchmark framing (apples-to-apples, internal vs external TCO).
> 
> Each entry includes **article-sourced numbers** in `benchmarkContext`, **`relatedTerms`** cross-links to existing glossary slugs, and **`articleSlugs`** pointing at `tpu-inferencex-full-steam` (plus related posts where noted). **Ironwood** and **internal vs external TCO** also get `measurement` blocks.
> 
> Introduces the **`TPU_IRONWOOD`** article constant so the new terms reference that post, which **satisfies the glossary test** that every published article must appear in `articleSlugs`—fixing the failure after the post landed without a glossary link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57c42d2988823d4fc4eafe1aadf6f3b7e166d4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->