### PR TITLE
feat(glossary): add 20 more TPU Ironwood terms from the TPU InferenceX article / 术语表再增 20 条来自 TPU InferenceX 文章的 Ironwood 术语

### DIFF
--- a/packages/app/src/lib/glossary-zh.ts
+++ b/packages/app/src/lib/glossary-zh.ts
@@ -2015,6 +2015,299 @@ const translations: Readonly<Record<string, GlossaryTranslation>> = {
       value: '每芯片小时 1.03 美元（SemiAnalysis TCO 模型）',
     },
   },
+  tensorcore: {
+    term: 'TensorCore（TPU）',
+    aliases: ['TensorCore', 'TPU TensorCore', 'TC'],
+    plainEnglish:
+      'TensorCore 是 TPU 芯片里的主计算模块，包含矩阵单元、向量单元和片上存储，负责模型的稠密计算。',
+    definition:
+      'TPU TensorCore 是 TPU die 上的稠密计算模块，把一个或多个 MXU systolic 阵列、一个向量处理单元（VPU），以及它们读写的 VMEM 暂存区组合在一起。',
+    explanation:
+      'Ironwood 每颗芯片有 2 个 TensorCore，每个计算 die 一个，另外还有 4 个第三代 SparseCore。TensorCore 内部的 MXU 负责矩阵乘法，VPU 负责逐元素和归约运算，VMEM 把操作数放在两者旁边。Google 的 TPU 文档用 TensorCore 指这一模块，它与 NVIDIA GPU 流式多处理器里的 Tensor Core 无关。当集合通信或 gather 在 TensorCore 上运行时，占用的是 MXU 和 VPU 本可以用于模型计算的周期。',
+    significance:
+      'Ironwood 的多项优化都在把不规则工作从 TensorCore 挪到 SparseCore 上，让稠密单元持续运转。把 ReduceScatter 移到 SparseCore 释放了 TensorCore 的执行时间；把 ragged gather-reduce 路径中的 top-k 权重 gather 移过去之后，DeepSeek-V3 微基准中的 TensorCore 开销从 29 微秒降到 14 微秒。',
+    benchmarkContext:
+      'TPU InferenceX 预览把 Qwen3.5 397B 在 8k1k 上的部分收益归因于让 TensorCore 保持空闲：SparseCore 上的专家输入重排把服务吞吐量比原始 kernel 提高了 12%，而一个基于 VMEM 容量推导的阈值会在 SparseCore 卸载反而更慢时，把小集合通信留在 TensorCore 上。',
+  },
+  vpu: {
+    term: 'VPU（向量处理单元）',
+    aliases: ['VPU', 'Vector Processing Unit', 'TPU 向量单元', '向量单元'],
+    plainEnglish:
+      'VPU 是 TPU 中负责逐元素计算的部件，处理激活函数、softmax 和状态更新等，与矩阵单元协同工作。',
+    definition:
+      'VPU（Vector Processing Unit）是 TPU TensorCore 内的 SIMD 引擎，在末维为 128 lane 的 tile 上执行逐元素、归约和数据重排操作。',
+    explanation:
+      'MXU 负责矩阵乘法，VPU 负责矩阵乘法周围的一切：激活函数、归一化、softmax、rank-one 状态更新，以及把 kernel 各阶段拼接起来的缩放向量加法。VPU 处理的 tile 末维是 128 lane、8 sublane，末维更小的数组会被补齐。MXU 和 VPU 的工作相互重叠时 kernel 更快，一方等待另一方时更慢；同时存活的值太多时还会导致向量寄存器溢出到 VMEM。',
+    significance:
+      'Gated DeltaNet 输出投影的改写完全是为了让两个单元重叠。原先 VPU 先执行 rank-one 更新，MXU 再把更新后的状态乘以 query，MXU 只能等待。重排代数式后，MXU 可以直接用衰减后的状态计算 Sq，VPU 同时构建下一个 token 的状态，本次更新对输出的贡献则用每个 head 一个标量乘向量的方式单独加上。',
+    benchmarkContext:
+      '这一重叠让 Qwen3.5 397B 在 8k1k 上的吞吐量在并发 64 下提高 2.79%，在并发 512 下提高 4.48%。后续改动在 decode 循环内对 Q 和 K 切片以减少向量寄存器溢出，decode-64 kernel 快了约 20%，端到端收益在并发 512 下为 8k1k 0.8%、1k8k 3.8%。',
+  },
+  'systolic-array': {
+    term: 'Systolic 阵列',
+    aliases: ['systolic array', 'systolic 阵列', '脉动阵列', 'weight-stationary 阵列'],
+    plainEnglish:
+      'Systolic 阵列是由大量乘加单元组成的网格，数据像脉搏一样在单元之间逐格传递，矩阵乘法中途不需要访问内存。',
+    definition:
+      'Systolic 阵列是一个二维乘加单元网格，其中一个操作数固定驻留，另一个操作数流过网格，部分和在每个时钟周期传递给相邻单元。',
+    explanation:
+      '在 TPU 的 MXU 中，权重加载进阵列后保持不动。激活值从一条边进入，每个单元把输入乘以自己存储的权重，再加上邻居传来的部分和，最终结果从另一边流出，中间值从不写入内存。阵列边长固定：TPU v5 及之前是 128，v6e 起是 256，小于边长的矩阵维度都会被补齐。GPU 的 tensor core 则从寄存器读取小 tile，因此对不规则形状更宽容。',
+    significance:
+      'Systolic 设计在单位硅面积和功耗下提供极高的每周期 MAC 数，这是 Google 能把 Ironwood 的每 token 价格压到 Blackwell 以下的部分原因。代价是刚性：Ironwood 的 256x256 阵列只有在两个矩阵维度都是 256 的倍数时才能交付 65,536 MAC/周期，head 维度为 128 时注意力矩阵乘法的利用率上限只有 50%。',
+    benchmarkContext:
+      'TPU InferenceX 预览和 OpenAI Jalapeno 分析都把 systolic 阵列几何视为模型 bring-up 成本差异的主要原因。形状能填满阵列的模型只需要数周调优，与阵列冲突的模型则需要先写新的 Pallas kernel 才能追平。',
+  },
+  megacore: {
+    term: 'MegaCore',
+    aliases: ['MegaCore', 'Megacore 模式', '融合 TPU 核心'],
+    plainEnglish:
+      'MegaCore 是 TPU v4 和 v5p 的设计，把两个物理核心融合成一个共享同一内存空间的逻辑加速器。',
+    definition:
+      'MegaCore 是 TPU v4 和 v5p 的约定：一颗芯片上的两个物理 TensorCore 以单个逻辑设备的形式呈现给软件，共用一个统一的 HBM 地址空间。',
+    explanation:
+      '在 MegaCore 下，编译器和框架看到的是每颗芯片一个大设备，两个核心在幕后分摊工作。Ironwood 放弃了这一设计：两个计算 die 各自作为独立逻辑设备运行，拥有各自的内存，通过高带宽 die-to-die 链路相连而不是统一内存结构，因此 JAX 和 TorchTPU 看到的是每颗芯片两个设备。Ironwood 上的 TP8 配置因此跨越 4 颗芯片上的 8 个逻辑设备。',
+    significance:
+      '这一变化把协调工作从硬件移到了软件。集合通信现在分成经 die-to-die 链路的片内阶段和经 ICI 的片间阶段，kernel 可以让两者重叠。这也意味着基准测试中的每芯片数字聚合了两个设备，在与单 die GPU 比较每芯片每秒 token 数时需要注意。',
+    benchmarkContext:
+      'Ironwood 在 SparseCore 上实现的 ReduceScatter 先通过 die-to-die 链路合并芯片内的贡献，再在芯片之间交换部分和，这只有在两个 die 是独立设备时才可行。InferenceX 按每芯片报告 Ironwood 吞吐量，因此在每用户 20 tok/s 下的 9,364 tok/s/chip 覆盖了两个 die。',
+  },
+  'die-to-die-link': {
+    term: 'Die-to-die 链路',
+    aliases: ['die-to-die link', 'D2D 链路', '片内链路', 'inter-die link'],
+    plainEnglish:
+      'Die-to-die 链路连接同一封装内的两个计算 die，速度快于芯片之间的网络，但两个 die 不共享内存空间。',
+    definition:
+      'Die-to-die 链路是 Ironwood 封装内连接两个计算 die 的高带宽互连，让每个 die 作为独立逻辑设备运行，同时以快于芯片间 ICI 网络的速度交换数据。',
+    explanation:
+      'Ironwood 每个封装内有两个 die，各自带有 TensorCore、HBM 和 SparseCore。Die-to-die 链路在两者之间传输数据，不经过 ICI。因为这条链路比 ICI 快，集合通信被组织成层次结构：先在芯片内归约，再在芯片之间交换部分和。GPU 上也有类似思路，Blackwell 用 NV-HBI 连接两个 die，但 Blackwell 对外呈现为一个设备，Ironwood 呈现为两个。',
+    significance:
+      '两级集合通信让 kernel 可以把一个 microbatch 的快速片内阶段与另一个 microbatch 的慢速片间阶段重叠。在 Ironwood 的 ReduceScatter kernel 中，microbatch 1 的片内 DMA ScatterReduce 与 microbatch 0 沿 ICI 维度的 ScatterReduce 并发执行，缩短了集合通信的端到端时间。',
+    benchmarkContext:
+      '使用 die-to-die 链路的 SparseCore ReduceScatter 是 DP attention 加 EP8 服务配置的一部分，该配置产出了 InferenceX Official Preview 中的 Qwen3.5 397B 结果。Google 把每芯片双设备布局作为相对 MegaCore 的设计变化来报告，而不是单独的基准测试项。',
+  },
+  'twisted-torus': {
+    term: 'Twisted torus（扭转环面）',
+    aliases: ['twisted torus', '扭转 torus', 'twisted 3D torus', 'Mobius torus'],
+    plainEnglish:
+      'Twisted torus 是把 wraparound 链路错位连接的 torus 网络，像莫比乌斯带一样，进一步减少芯片之间的平均跳数。',
+    definition:
+      'Twisted torus 是一种 torus 拓扑，其一个或多个维度上的 wraparound 连接不是把一行直接接回自身，而是错位接到相邻行，从而在同等规模下比普通 torus 拥有更低的平均跳数和最坏跳数。',
+    explanation:
+      '普通 torus 把每一行的两端连接起来，把直线变成环，最坏距离从 N 减半到 N/2。Twisted torus 把 wraparound 错开，让一行连到另一侧的相邻行，流量分散到更多路径，平均距离再次下降。Google 在 TPU pod 中使用这一变体：pod 由 4x4x4 共 64 颗芯片的立方体组成，再通过光电路交换机拼接，并在整个 pod 范围内保留 wraparound 特性。',
+    significance:
+      '跳数决定小集合通信消息的延迟，扭转在不增加硬件的情况下换来几个百分点的延迟收益。TPU 8i 的 Boardfly 拓扑走得更远，直接放弃 torus，改用高基数层次化网络，把 1,024 到 1,152 颗芯片规模下的网络直径从约 16 跳降到约 7 跳。',
+    benchmarkContext:
+      'TPU InferenceX 预览指出，对小尺寸专家并行消息，TPU torus 在很多情况下延迟低于单跳 NVSwitch，详细结果留给 CollectiveX 和 NetworkingX 测试线。',
+  },
+  superpod: {
+    term: 'TPU superpod',
+    aliases: ['superpod', 'TPU pod', 'Ironwood superpod', '完整 pod'],
+    plainEnglish:
+      'Superpod 是接入同一个 ICI 网络的最大 TPU 单元，Ironwood 最多 9,216 颗芯片，可以当作一台机器使用。',
+    definition:
+      'TPU superpod 是一代 TPU 中通过 ICI 互连的最大域，由 64 芯片立方体经光电路交换机拼接而成；Ironwood 的 superpod 达到 9,216 颗芯片，约 42.5 FP8 exaflops。',
+    explanation:
+      '每个 4x4x4 共 64 颗芯片的立方体占满一个机柜。光电路交换机在保留 torus wraparound 的前提下连接各立方体，整个 pod 表现为一个大型 twisted torus。由于 ICI 绕过主机 CPU，并在整个 pod 范围内提供 NVLink 级别的带宽，模型可以用张量并行、专家并行和数据并行切分到数千颗芯片上，不需要流水线阶段。客户租用的是 pod 的切片而不是整个 pod，OCS 层还能让 Google 在几秒内绕开故障芯片。',
+    significance:
+      'Pod 是 TPU 服务策略不同于 GPU 的根本原因。NVL72 域把 scale-up 组限制在 72 颗 GPU，而 Ironwood pod 能把超过 1,000 颗芯片放进一个低延迟域，从而支持机柜级 NVIDIA 系统无法复制的超宽专家并行和大模型分离式服务。',
+    benchmarkContext:
+      'InferenceX Official Preview 在小切片上运行聚合服务，但文章认为 pod 才是让 TPUv7 分离式服务能与 GB200 和 GB300 NVL72 竞争的关键，相关结果将在后续文章发布。',
+  },
+  stablehlo: {
+    term: 'StableHLO',
+    aliases: ['StableHLO', 'HLO', 'MHLO'],
+    plainEnglish:
+      'StableHLO 是一种标准化的中间表示，PyTorch、JAX 等框架把程序输出成这种格式，再由 XLA 编译器转成 TPU 机器码。',
+    definition:
+      'StableHLO 是基于 MLIR 的可移植、带版本的算子集，在高层张量运算的层面描述机器学习程序，作为框架与 XLA 编译器之间的交接格式。',
+    explanation:
+      '在 TorchTPU 的编译路径中，TorchDynamo 和 AOTAutograd 捕获 FX 图，TorchTPU 把它降级为 StableHLO，XLA 再把它编译成 TPU 可执行文件。在 JAX 路径中，jax.jit 把程序追踪为同一种表示。由于 StableHLO 跨版本稳定，序列化后的程序可以稍后编译，或由不同版本的框架编译。它位于硬件之上、框架之下，因此不包含 MXU tile 尺寸的信息，padding 和布局决策由 XLA 之后再加。',
+    significance:
+      '共享的 IR 让 vLLM 和 SGLang 无论模型来自 PyTorch 还是 JAX，都能复用同一套编译器栈。这也意味着绕过 StableHLO 做手工调优的 Pallas kernel 必须以 custom call 的形式显式调用，编译器不会自动发现它们。',
+    benchmarkContext:
+      'TPU InferenceX 预览中所有 Qwen3.5 397B 结果都经过 StableHLO 到 XLA 的路径。文章把它与 GPU PyTorch 路径对比，后者的 torch.compile 降级到 Inductor 和 Triton。',
+  },
+  'privateuse1-backend': {
+    term: 'PrivateUse1 后端',
+    aliases: ['PrivateUse1', 'PyTorch out-of-tree 后端', '自定义设备后端'],
+    plainEnglish:
+      'PrivateUse1 是 PyTorch 允许厂商接入新设备类型的钩子，让张量可以像放在 CUDA 上一样放在 device="tpu" 上。',
+    definition:
+      'PrivateUse1 是 PyTorch 中预留的 dispatch key 和设备类型，允许 out-of-tree 后端注册自己的张量、内存分配器和算子实现，使框架把新加速器当作一等设备处理。',
+    explanation:
+      'TorchTPU 用 PrivateUse1 暴露一个位于 device="tpu" 上的普通 torch.Tensor，而不是由 JAX 数组支撑的包装对象。PyTorch dispatcher 把 ATen 操作路由到 TPU 后端，后端既可以在 bring-up 和调试时 eager 执行，也可以通过 torch.compile 捕获图。DDP、FSDP2 和 DTensor 等分布式 API 通过同一机制工作。此前的 TorchAX 方案则通过 __torch_dispatch__ 拦截每个操作并翻译成 JAX 调用。',
+    significance:
+      '这个后端钩子让"原生"一词有了具体含义。服务引擎可以复用上游的模型代码、调度器、continuous batching 和功能逻辑，不需要 PyTorch 到 JAX 的翻译层，从而降低每个新模型和引擎功能登陆 TPU 的成本。',
+    benchmarkContext:
+      'TPU InferenceX 预览的结果来自基于该后端构建的 TorchTPU vLLM 栈。Google 预计在 10 月中旬的 PyTorch Conference 前后结束私测并开源，之后 SemiAnalysis 会把 TPU 基准测试从自己的 fork 迁移到公开的 InferenceX 仓库。',
+  },
+  'torch-compile': {
+    term: 'torch.compile',
+    aliases: ['torch.compile', 'TorchDynamo', 'AOTAutograd', 'Inductor'],
+    plainEnglish:
+      'torch.compile 是 PyTorch 的编译入口，把模型捕获成图交给编译器后端，而不是逐个执行每个操作。',
+    definition:
+      'torch.compile 是 PyTorch 的 API，用 TorchDynamo 把 Python 层的模型代码捕获为 FX 图，用 AOTAutograd 追踪前向和反向，再由 Inductor 或 XLA 等可插拔后端生成设备代码。',
+    explanation:
+      '在 NVIDIA GPU 上，vLLM 使用 torch.compile 配合 Inductor，输出 Triton kernel。在 TPU 上，TorchTPU 保留同一入口但更换后端：FX 图被降级为 StableHLO，由 XLA 编译。Google 明确了这一编译器选择，用 XLA 而不是 Inductor 和 Triton。此前的 TorchAX 路径完全绕过 torch.compile，因为 jax.jit 已经负责图捕获和编译。编译后的图按张量形状特化，因此服务引擎需要对请求形状分桶以限制重编译。',
+    significance:
+      '保留 torch.compile 作为入口，意味着 TPU 专用的编译藏在 vLLM 和 SGLang 已经在调用的 API 后面。针对 PyTorch 编译路径编写的引擎功能可以直接沿用，而 XLA 的形状敏感性意味着分桶和 padding 仍然需要针对 TPU 调优。',
+    benchmarkContext:
+      'TPU InferenceX 预览中的 Qwen3.5 397B 数据都经过 torch.compile 进入 XLA。低并发调优把请求元数据按活跃请求数而非配置上限分桶，让 GDN 调度开销从 283 微秒降到 97 微秒，8k1k 吞吐量在并发 64 下从每芯片每秒 2,328 token 提高到 2,516。',
+  },
+  functionalization: {
+    term: '函数化（functionalization）',
+    aliases: ['functionalization', '函数化', '显式状态传递', 'explicit state'],
+    plainEnglish:
+      '函数化把原地修改对象的代码改写成以状态为输入、返回新状态的代码，这样编译器才能追踪它。',
+    definition:
+      '函数化是一种程序变换，把对 Python 对象的原地修改（例如写入 KV cache）转换为纯函数的显式输入和输出，使 jax.jit 这类追踪式编译器能把程序捕获为计算图。',
+    explanation:
+      'vLLM 管理着每一步都在变化的状态，最重要的是 KV cache。在 TorchAX 路径中，模型包装器把权重和 KV cache 作为显式状态交给 JAX：每个推理步骤接收旧 cache，返回更新后的 cache。jax.jit 因此可以只捕获一次，然后反复执行编译好的图。PyTorch 在 AOTAutograd 内部也有自己的函数化 pass，为 torch.compile 提供同样的作用，这是 TorchTPU 路径能复用编译管线的原因之一。',
+    significance:
+      '这一变换在正常工作时不可见，出问题时却很棘手。服务引擎在编写时假定 Python 对象可变，它们与函数式编译器之间的不匹配是翻译层问题之一，正是这类问题推动 Google 从 TorchAX 转向原生 TorchTPU 后端。',
+    benchmarkContext:
+      'TPU InferenceX 预览把函数化描述为此前 tpu-inference 后端把 vLLM 搬到 JAX 上的手段之一。TorchTPU 路径用 PyTorch dispatch 取代了这种手写的状态传递，因此 Qwen3.5 397B 的结果依赖编译器在内部处理它。',
+  },
+  'sglang-jax': {
+    term: 'SGLang-JAX',
+    aliases: ['SGLang-JAX', 'sgl-jax', 'SGL-torchtpu'],
+    plainEnglish:
+      'SGLang-JAX 是 SGLang 服务引擎面向 TPU 的 JAX 原生版本，独立于基于 PyTorch 的 SGLang 运行时。',
+    definition:
+      'SGLang-JAX 是一个 JAX 原生的服务引擎，把 SGLang 风格的调度和 prefix caching 与 JAX 模型实现及 TPU 专用 kernel 结合，而不是把 PyTorch 版 SGLang 运行时翻译到 TPU 上。',
+    explanation:
+      'vLLM 通过 TorchAX 翻译登陆 TPU，SGLang 则选择了另一条路，用 JAX 重新实现了引擎。这样可以直接使用成熟的 TPU 原语，代价是维护一套与上游 SGLang 分叉的第二代码库。Google 和 RadixArk 已宣布基于 TorchTPU 的 PyTorch 原生替代方案 SGL-torchtpu，它能让 TPU 上的 SGLang 重新共享上游代码路径。',
+    significance:
+      '两个引擎采用两种不同的 TPU 策略，说明生态尚未定型。TorchTPU 的目标是让两者收敛：vLLM 和 SGLang 都获得原生 PyTorch 设备，Pallas kernel 工作可以共享，模型的 day-0 支持也能与 NVIDIA、AMD 同步登陆 TPU。',
+    benchmarkContext:
+      'TPU InferenceX 预览的结果使用 TorchTPU vLLM。TorchTPU SGLang 开源后会补上 TPU 上的 SGLang 结果，届时 SemiAnalysis 会把 TPU 基准测试迁入公开的 InferenceX 仓库。',
+  },
+  pjrt: {
+    term: 'PJRT',
+    aliases: ['PJRT', 'PJRT buffer', 'PJRT 插件'],
+    plainEnglish:
+      'PJRT 是位于 JAX、TorchTPU 等框架与 TPU 硬件之间的运行时接口，负责管理设备内存缓冲区和执行。',
+    definition:
+      'PJRT 是基于 XLA 的框架用来分配设备缓冲区、启动编译后可执行文件和传输数据的插件式运行时 API，PJRTBuffer 对象封装了张量在设备上的原始硬件内存描述符。',
+    explanation:
+      'TPU 上的 JAX 数组和 TorchTPU 张量都由 PJRT 缓冲区支撑。能够提取原生 PJRTBuffer 硬件描述符的库可以在设备之间直接搬运数据，不经过框架中转，TPU-Sync 正是这样为分离式服务实现零拷贝 KV cache 传输的。由于 JAX 和 TorchTPU 都使用 PJRT，一个传输库可以同时服务两套栈。',
+    significance:
+      '运行时层是分离式服务和 offload 管道所在的位置。零拷贝传输省去了每个 KV block 一次额外的 HBM 往返，当 prefill 池以高请求速率向 decode 池发送大量 cache 时尤为重要。同样的描述符很可能也是 TPU 上 Mooncake Store 支持的底层基础。',
+    benchmarkContext:
+      'TPU InferenceX 预览描述 TPU-Sync（原名 TPU-raiden）通过提取原生 PJRTBuffer 描述符实现零拷贝传输，并支持 DRAM offload。基于它的 TPUv7 分离式服务结果将在后续文章发布。',
+  },
+  'triple-buffering': {
+    term: '三缓冲（triple buffering）',
+    aliases: ['triple buffering', '三缓冲', '三级预取', '更深的流水线'],
+    plainEnglish:
+      '三缓冲同时让三个数据块在途，一个在计算、两个在读取，让计算单元几乎不用等待内存。',
+    definition:
+      '三缓冲是一种 kernel 流水线技术，分配三个片上缓冲区，在处理当前块的同时从 HBM 预取接下来的两个块，比双缓冲多一级。',
+    explanation:
+      '双缓冲通过在计算第 N 块时读取第 N+1 块来隐藏 HBM 延迟。三缓冲再加上第 N+2 块，在传输时间波动、或某一块的读取比另一块的计算更长时更有帮助。代价是 VMEM：三个缓冲区必须与 kernel 其他存活数据一起放得下。在 Ironwood 上，grouped matmul 第二版对专家权重做三缓冲，让下一组专家的权重在计算当前组时已经在途；批量 ragged paged attention 也对 page 数据做三缓冲，以减少 padding 并改善流水线。',
+    significance:
+      '更深的流水线用稀缺的 VMEM 换 MXU 利用率。取舍取决于块大小，这正是 RPA v3 修复把 KV 读取块与 KV 计算块分开的原因：把计算块缩到 4k token、读取块保持 16k，为预取缓冲腾出了空间。',
+    benchmarkContext:
+      '带三缓冲专家权重的 grouped matmul v2 属于 MoE kernel 工作的一部分，这些工作支撑了 TPU InferenceX 预览中的 Qwen3.5 397B 结果。批量 RPA 的改动在 Qwen3-32B 上测量，其数字与 397B 的对比分开呈现。',
+  },
+  'sequence-on-lane-layout': {
+    term: 'Sequence-on-lane 布局',
+    aliases: ['sequence-on-lane', 'lane 优先 KV 布局', 'token-on-lane 布局'],
+    plainEnglish:
+      'Sequence-on-lane 是一种 KV cache 布局，把一页 token 放在 128 宽的向量 lane 轴上而不是 head 维度上，减少浪费在 padding 上的内存。',
+    definition:
+      'Sequence-on-lane 布局是一种 TPU KV cache 排布方式，把一个 page 的 token 映射到 128 lane 的末维、把 head 维度映射到 sublane 轴，避免小 head 维度放在 lane 轴上时产生的 padding。',
+    explanation:
+      'TPU 向量单元处理的 tile 末维是 128 lane，末维更小的数组都会被补齐。批量 attention kernel 原先沿 head 维度打包 key 和 value，FP8 下打包因子为 4。每个设备只有一个 KV head 的模型只有两样东西可打包，因此每个 tile 有一半是 padding。把 token 放到 lane 轴上后，无论 head 数量多少 tile 都能填满，head 维度也只需是 32 的倍数而不是 128，head 维度为 64 的模型也能使用该 kernel。',
+    significance:
+      '在高并发下，KV 容量就是 decode 吞吐量。这种布局在低并发下每 token 延迟约增加 3%，但在大 batch 时避免了请求排队等待 KV 空间。它还扩大了无需定制工作就能运行在共享 attention kernel 上的模型范围。',
+    benchmarkContext:
+      '在报告的 Ironwood 配置中，可用 KV page 从 5,141 翻倍到 10,283。在并发 128 的 8k1k 上，额外容量把吞吐量提高 16.5%，中位 TTFT 降低 95%，因为请求不再等待 KV 空间。',
+    measurement: {
+      label: 'FP8、每设备单 KV head 下的可用 KV page',
+      value: '5,141 到 10,283 页；并发 128 的 8k1k 上吞吐量 +16.5%，中位 TTFT -95%',
+    },
+  },
+  'collective-offload': {
+    term: 'SparseCore 集合通信卸载',
+    aliases: ['collective offload', '集合通信卸载', 'SparseCore 卸载阈值', 'SC collective'],
+    plainEnglish:
+      '集合通信卸载把 all-reduce 等通信操作放到 TPU 的 SparseCore 上运行而不是 TensorCore，但只在消息足够大、值得这么做时才卸载。',
+    definition:
+      'SparseCore 集合通信卸载是 Ironwood 的一种技术，在 SparseCore 上执行 all-reduce、all-gather 和 reduce-scatter，让 TensorCore 专注矩阵计算，并用一个尺寸阈值把小于阈值的集合通信留在 TensorCore 上。',
+    explanation:
+      'SparseCore 为不规则数据搬运而设计，天然适合承载集合通信。Google 在 SparseCore 上实现了 ReduceScatter，采用两级方案：先通过 die-to-die 链路在芯片内归约，再经 ICI 在芯片间交换，并用双缓冲让各阶段重叠。卸载并非免费：在 SparseCore 上启动有开销，对于能放进 VMEM 的小消息，TensorCore 完成得更快。对 Qwen3.5，一个由 VMEM 容量推导的阈值逐个集合通信地决定由哪个单元执行。',
+    significance:
+      '这个阈值提醒我们，把工作从关键单元上挪走也可能适得其反。某些情况下把集合通信卸载到 SparseCore 会让性能变差，收益来自按消息大小逐个选择，而不是把卸载当成一刀切的策略。它也说明 TPU 服务优化会触及 GPU 栈交给 NCCL 处理的调度决策。',
+    benchmarkContext:
+      '基于阈值的卸载让 Qwen3.5 397B 在 8k1k 上的吞吐量在并发 64 下提高 2.7%，在并发 128 下提高 5.7%。把专家 ID 和路由权重的两个独立 all-gather 合并为一个，每层节省约 80 微秒，按 DeepSeek-V3 的 58 层计算，每次前向传播约节省 4.64 毫秒。',
+  },
+  'kv-head-replication': {
+    term: 'KV head 复制',
+    aliases: ['KV head replication', 'KV head 复制', '复制 KV head', 'KV head 冗余'],
+    plainEnglish:
+      'KV head 复制在模型的 KV head 数量少于所切分的设备数量时，把相同的 key-value head 复制到多个张量并行 rank 上。',
+    definition:
+      'KV head 复制是一种张量并行策略：当张量并行度超过 grouped-query attention 层的 KV head 数量时，把 key 和 value head 复制到各个 rank 上，让每个 rank 无需通信就能拿到本地 query head 所需的 KV 数据。',
+    explanation:
+      'Qwen3.5 有 32 个 query head 和 2 个共享 KV head。TP8 下每个设备分到 4 个 query head，但 2 个 KV head 无法均分到 8 个设备：每个 KV head 被 16 个 query head 共享，因此有 4 个设备需要同一份 KV 数据。在每个 rank 上复制两个 KV head 可以避免对 KV 张量做 all-to-all 交换，代价是每个 rank 都重复保存 KV cache。vLLM 早已支持这一行为，TPU 后端需要一个兼容性修复来启用它。',
+    significance:
+      '高并发下的替代方案是 DP attention：每个设备处理不同的请求子集，并为这些请求保存两个 KV head，这样 KV 内存不会在 rank 之间重复，而体积更大的专家权重仍通过专家并行切分。Ironwood 服务在低并发下使用 TP8 attention，在高并发下使用 DP8 加 EP8。',
+    benchmarkContext:
+      '启用复制消除了 Qwen3.5 397B TorchTPU bring-up 中不必要的 All-to-All 通信。切换到 TP8 attention 加专家并行的低并发调优让 1k1k 在并发 4 下提高 22.9%，在并发 8 下提高 18.1%。',
+  },
+  'recurrent-state': {
+    term: '循环状态（recurrent state）',
+    aliases: ['recurrent state', '循环状态', 'GDN 状态', '线性注意力状态', 'SSM 状态'],
+    plainEnglish:
+      '循环状态是线性注意力或 SSM 层为每个请求保存的固定大小内存，不像 KV cache 那样随每个 token 增长。',
+    definition:
+      '循环状态是 Gated DeltaNet 等线性注意力层在每一步更新的、每个请求固定大小的张量，取代了 softmax 注意力层按 token 存储且不断增长的 key-value 历史。',
+    explanation:
+      '在 Qwen3.5 这样的混合模型中，GQA 层累积随上下文增长的 KV 历史，GDN 层则为每个请求保存一个固定大小的状态，每个 token 都对它衰减、施加 rank-one 更新并读出。服务引擎必须为这个状态分配 slot、决定其存储精度，并为 prefix caching 处理 checkpoint，因为请求一旦继续，实时状态就会被覆盖。在 Ironwood 上，状态最初按每个层组 num_blocks 个 slot 分配，浪费了 HBM，后来压缩为大约每个活跃请求一个 slot。',
+    significance:
+      '循环状态改变了内存预算：它不随上下文增长，这正是混合架构的意义所在，但它必须存放在某处，并且每一步都要在 VMEM 和 HBM 之间搬运。以 BF16 存储、以 FP32 计算可以把它的占用减半。混合模型的 prefix caching 需要分开的读写 slot，缓存的 checkpoint 才能保留下来。',
+    benchmarkContext:
+      '紧凑分配回收了约 76 GiB HBM，把 attention block 池扩大了 71%，让 Qwen3.5 397B 在 1k8k 上的吞吐量在并发 64 下提高 18%。BF16 状态存储在并发 512 的 1k8k 上再带来 15% 的收益。',
+    measurement: {
+      label: 'Qwen3.5 397B 的紧凑循环状态分配',
+      value: '回收约 76 GiB HBM，attention block 池 +71%，并发 64 的 1k8k 吞吐量 +18%',
+    },
+  },
+  'hybrid-prefix-caching': {
+    term: '混合模型 prefix caching',
+    aliases: [
+      'hybrid prefix caching',
+      '混合 prefix caching',
+      'GDN checkpoint 缓存',
+      '对齐 checkpoint 模式',
+    ],
+    plainEnglish:
+      '混合模型 prefix caching 让同时包含注意力层和线性注意力层的模型能复用缓存的 prompt，方法是把循环状态与 KV block 一起保存。',
+    definition:
+      '混合模型 prefix caching 是一种服务技术，为共享的 prompt 前缀同时保存注意力层的 KV block 和线性注意力层循环状态的 checkpoint，使新请求可以从该前缀继续而无需重新计算。',
+    explanation:
+      '对纯注意力模型，缓存前缀就是保留它的 KV block。对混合模型，前缀末尾的 GDN 循环状态也必须保留，但实时状态通常会随着请求继续而被覆盖。Ironwood 的实现给 GDN 分开的 slot 用于读取 checkpoint 和写入实时状态，状态地址从已经用于定位 KV block 的 block table 推导，checkpoint 按对齐的缓存粒度保存，使保存的状态总是落在 KV block 边界上。这种模式需要完整的 checkpoint 池而不是紧凑的按请求分配，用 HBM 换取跨请求复用。',
+    significance:
+      '智能体和多轮负载会复用很长的系统提示词和对话历史，混合模型只有在循环状态也被缓存时才能受益。取舍很明确：混合模型的 prefix caching 会消耗紧凑分配省下的 HBM，因此只有在前缀确实被共享时才划算。',
+    benchmarkContext:
+      'TPU InferenceX 预览中的 Qwen3.5 397B 数字来自随机输入的 8k1k 运行，请求之间没有任何共享，因此没有经过这条路径。带 DP 支持的混合模型 prefix caching 是 Google 客户所要求的 AgentX TPU 结果的基础工作。',
+  },
+  'kv-cache-p2p-pooling': {
+    term: 'KV cache DRAM P2P 池化',
+    aliases: ['P2P pooling', 'P2P 池化', 'DRAM 池化', '共享 KV 池'],
+    plainEnglish:
+      'P2P 池化把多台服务器的主机内存合并成一个逻辑 KV cache 存储，任何服务器上的加速器都能从其他服务器拉取缓存的上下文。',
+    definition:
+      'KV cache DRAM P2P 池化是一种 offload 架构，把集群中每个节点贡献的主机 DRAM 聚合为单个逻辑内存池，让任意加速器通过网络读取其他节点写入的 KV cache。',
+    explanation:
+      '单节点 offload 在 HBM 满时把 KV block 从 HBM 移到本地主机 DRAM。池化更进一步：Mooncake Store 把每台 TPU 主机上的 DRAM 统一为一个共享池，还能把多台服务器的 NVMe 池化，或者接入 WEKA、VAST 这类分布式文件系统后端。被路由到与计算前缀的服务器不同的机器上的请求仍然可以命中缓存。Google 正通过 TPU-Sync 对外开放其原生 TPU offload 栈，并支持 Mooncake Store，后者很可能基于 TPU-Sync 的原语实现。',
+    significance:
+      '池化提高了智能体负载可达到的 prefix cache 命中率，这类负载的会话会运行数百轮，子智能体还会带着全新上下文突发出现。没有池化，命中率就受限于单节点能容纳多少内容，以及路由器能否把会话固定在一台机器上。',
+    benchmarkContext:
+      'TPU-Sync DRAM offload 和 Mooncake Store 池化被列为 TPU InferenceX 预览的后续步骤，排在 AgentX TPU 结果之前。NVIDIA 和 AMD 的 AgentX 文章已经表明，KV 工作集大小和 offload 容量决定智能体负载的每 token 成本。',
+  },
 };
 
 const entries = getAllGlossaryEntries().map((entry) => {

--- a/packages/app/src/lib/glossary.ts
+++ b/packages/app/src/lib/glossary.ts
@@ -3090,6 +3090,449 @@ const entries = [
     ],
     articleSlugs: [TPU_IRONWOOD, VR_RUBIN],
   },
+  {
+    slug: 'tensorcore',
+    term: 'TensorCore (TPU)',
+    aliases: ['TensorCore', 'TPU TensorCore', 'TC'],
+    category: 'Hardware',
+    plainEnglish:
+      'A TensorCore is the main compute block inside a TPU chip, holding the matrix units, vector units, and on-chip memory that run dense model math.',
+    definition:
+      'A TPU TensorCore is the dense compute block on a TPU die that groups one or more MXU systolic arrays, a vector processing unit, and the VMEM scratchpad those units read from and write to.',
+    explanation:
+      'Ironwood carries two TensorCores per chip, one per compute die, alongside four third-generation SparseCores. The MXUs inside a TensorCore do matrix multiplies, the VPU does elementwise and reduction work, and VMEM stages operands next to both. Google TPU documentation uses the name TensorCore for this block, which is unrelated to the Tensor Cores inside NVIDIA GPU streaming multiprocessors. When a collective or gather runs on the TensorCore, it occupies cycles the MXU and VPU could otherwise spend on the model.',
+    significance:
+      'Several Ironwood optimizations move irregular work off the TensorCore and onto SparseCores so the dense units keep running. Moving ReduceScatter to SparseCore frees TensorCore execution for other operations, and moving the top-k weight gather in the ragged gather-reduce path cut TensorCore overhead from 29 microseconds to 14 in a DeepSeek-V3 microbenchmark.',
+    benchmarkContext:
+      'The TPU InferenceX preview attributes part of its 8k1k gains on Qwen3.5 397B to keeping the TensorCore free: the SparseCore expert-input rearrangement raised serving throughput 12% over the original kernels, and a VMEM-derived threshold keeps small collectives on the TensorCore when SparseCore offload would be slower.',
+    relatedTerms: ['tpu', 'mxu', 'vpu', 'sparsecore', 'vmem', 'tpuv7-ironwood'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'vpu',
+    term: 'Vector Processing Unit',
+    abbreviation: 'VPU',
+    aliases: ['VPU', 'TPU vector unit', 'vector unit'],
+    category: 'Hardware',
+    plainEnglish:
+      'The VPU is the part of a TPU that handles elementwise math like activations, softmax, and state updates, working alongside the matrix unit.',
+    definition:
+      'The Vector Processing Unit is the SIMD engine inside a TPU TensorCore that performs elementwise, reduction, and data-rearrangement operations on tiles whose last dimension is 128 lanes wide.',
+    explanation:
+      'The MXU handles matrix multiplies and the VPU handles everything around them: activation functions, normalization, softmax, rank-one state updates, and the scaled-vector additions that stitch kernel stages together. The VPU works on tiles with a 128-lane trailing dimension and 8 sublanes, so arrays with a smaller trailing dimension get padded up. Kernels get faster when MXU and VPU work overlap instead of waiting on each other, and slower when too many live values force vector-register spills to VMEM.',
+    significance:
+      'The Gated DeltaNet output-projection rewrite exists purely to overlap the two units. Previously the VPU applied the rank-one update and the MXU then multiplied the updated state by the query, so the MXU waited. Rearranging the algebra lets the MXU compute Sq from the decayed state while the VPU builds the next state, with the update contribution added as a per-head scalar times a vector.',
+    benchmarkContext:
+      'That overlap gave 8k1k throughput gains of 2.79% at concurrency 64 and 4.48% at concurrency 512 on Qwen3.5 397B. A follow-up sliced Q and K inside the decode loop to reduce vector-register spills, making the decode-64 kernel about 20% faster with end-to-end gains of 0.8% on 8k1k and 3.8% on 1k8k at concurrency 512.',
+    relatedTerms: ['mxu', 'tensorcore', 'vmem', 'gated-deltanet', 'pallas', 'tile-padding'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'systolic-array',
+    term: 'Systolic array',
+    aliases: ['systolic array', 'weight-stationary array', 'systolic matrix unit'],
+    category: 'Hardware',
+    plainEnglish:
+      'A systolic array is a grid of tiny multiply-add cells where data flows cell to cell like a heartbeat, so a matrix multiply never touches memory mid-computation.',
+    definition:
+      'A systolic array is a two-dimensional grid of multiply-accumulate cells in which one operand is held stationary while the other streams through, with partial sums passed between neighbors on every clock cycle.',
+    explanation:
+      'In a TPU MXU, weights load into the array and stay put. Activations enter from one edge, each cell multiplies its input by its stored weight and adds the partial sum arriving from its neighbor, and the finished result exits the far side. No intermediate value is written to memory. The array has a fixed side length, 128 on TPU generations through v5 and 256 from v6e onward, and any matrix dimension smaller than that is padded to fill it. GPU tensor cores instead consume small tiles fed from registers, which is why they tolerate odd shapes better.',
+    significance:
+      'A systolic design gives very high MACs per cycle per unit of silicon and power, which is part of why Google can price Ironwood below Blackwell per token. The trade is rigidity: the 256x256 Ironwood array delivers 65,536 MACs per cycle only when both matrix dimensions are multiples of 256, and a head dimension of 128 caps attention matmuls at 50% utilization.',
+    benchmarkContext:
+      'The TPU InferenceX preview and the OpenAI Jalapeno analysis both treat systolic-array geometry as the main reason bring-up cost varies by model. Models whose shapes fill the array need weeks of tuning; models that fight it need new Pallas kernels before reaching parity.',
+    relatedTerms: ['mxu', 'tile-padding', 'gemm', 'model-flops-utilization', 'tensorcore'],
+    articleSlugs: [TPU_IRONWOOD, JALAPENO],
+  },
+  {
+    slug: 'megacore',
+    term: 'MegaCore',
+    aliases: ['MegaCore', 'Megacore mode', 'fused TPU cores'],
+    category: 'Hardware',
+    plainEnglish:
+      'MegaCore was the TPU v4 and v5p design that fused two physical cores into one logical accelerator sharing a single memory space.',
+    definition:
+      'MegaCore is the TPU v4 and v5p convention in which two physical TensorCores on a chip are presented to software as a single logical device with one unified HBM address space.',
+    explanation:
+      'Under MegaCore, the compiler and framework saw one large device per chip, and the two cores split work behind the scenes. Ironwood drops this. Its two compute dies each run as an independent logical device with its own memory, joined by a high-bandwidth die-to-die link rather than a unified memory fabric, so JAX and TorchTPU expose two devices per chip. A TP8 configuration on Ironwood therefore spans eight logical devices on four chips.',
+    significance:
+      'The change moves coordination from hardware into software. Collectives now have an intra-chip stage across the die-to-die link and an inter-chip stage across ICI, and kernels can overlap the two. It also means per-chip figures in benchmarks aggregate two devices, which matters when comparing tokens per second per chip against a single-die GPU.',
+    benchmarkContext:
+      'The Ironwood ReduceScatter implementation on SparseCore combines contributions within each chip over the die-to-die link before exchanging partial sums across chips, which is only possible because the dies are separate devices. InferenceX reports Ironwood throughput per chip, so its 9,364 tokens per second per chip at 20 tokens per second per user covers both dies.',
+    relatedTerms: [
+      'tpuv7-ironwood',
+      'die-to-die-link',
+      'tensorcore',
+      'tensor-parallelism',
+      'high-bandwidth-memory',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'die-to-die-link',
+    term: 'Die-to-die link',
+    abbreviation: 'D2D',
+    aliases: ['die-to-die link', 'D2D link', 'intra-chip link', 'inter-die link'],
+    category: 'Hardware',
+    plainEnglish:
+      'A die-to-die link connects two compute dies inside the same chip package, faster than the network between chips but separate from a shared memory space.',
+    definition:
+      'A die-to-die link is the high-bandwidth interconnect that joins the two compute dies inside an Ironwood package, letting each die run as its own logical device while exchanging data faster than the chip-to-chip ICI network.',
+    explanation:
+      'Ironwood packages two dies, each with a TensorCore, HBM, and SparseCores. The die-to-die link carries traffic between them without going through ICI. Because the link is faster than ICI, collectives are structured hierarchically: reduce within the chip first, then exchange partial sums between chips. The same idea appears on GPUs, where Blackwell joins two dies with NV-HBI, but Blackwell presents one device while Ironwood presents two.',
+    significance:
+      'Two-level collectives let kernels overlap the fast intra-chip stage of one microbatch with the slow inter-chip stage of another. In the Ironwood ReduceScatter kernel, the intra-chip DMA ScatterReduce for microbatch 1 runs concurrently with the ICI-dimension ScatterReduce for microbatch 0, shortening end-to-end collective time.',
+    benchmarkContext:
+      'The SparseCore ReduceScatter that uses the die-to-die link is part of the DP attention plus EP8 serving configuration that produced the Qwen3.5 397B results in the InferenceX Official Preview. Google reports the two-device-per-chip layout as a design change from MegaCore rather than as a separate benchmark line.',
+    relatedTerms: [
+      'megacore',
+      'ici',
+      'reduce-scatter',
+      'double-buffering',
+      'scale-up-vs-scale-out',
+      'tpuv7-ironwood',
+    ],
+    articleSlugs: [TPU_IRONWOOD, VR_RUBIN],
+  },
+  {
+    slug: 'twisted-torus',
+    term: 'Twisted torus',
+    aliases: ['twisted torus', 'twisted 3D torus', 'Mobius torus'],
+    category: 'Hardware',
+    plainEnglish:
+      'A twisted torus is a torus network whose wraparound links are shifted, like a Mobius strip, so the average number of hops between chips drops further.',
+    definition:
+      'A twisted torus is a torus topology in which the wraparound connections along one or more dimensions are offset rather than joining a row directly to itself, which lowers the average and worst-case hop count compared with a plain torus of the same size.',
+    explanation:
+      'A plain torus connects the two ends of each row, turning a line into a ring and halving the worst-case distance from N to N/2. A twisted torus shifts the wraparound so a row connects to a neighboring row on the far side, spreading traffic across more paths and reducing the average distance again. Google uses this variant in TPU pods, built from 4x4x4 cubes of 64 chips and stitched together by optical circuit switches that preserve the wraparound property across the whole pod.',
+    significance:
+      'Hop count sets latency for small collective messages, and the twist buys a few percent of latency without new hardware. The TPU 8i Boardfly topology goes further by abandoning the torus for a high-radix hierarchical fabric, cutting diameter from roughly 16 hops to about 7 at 1,024 to 1,152 chips.',
+    benchmarkContext:
+      'The TPU InferenceX preview notes that in many cases the TPU torus has lower latency than a single-hop NVSwitch for small expert-parallel messages, with detailed results deferred to the CollectiveX and NetworkingX lanes.',
+    relatedTerms: ['torus-topology', 'ici', 'optical-circuit-switch', 'boardfly', 'all-to-all'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'superpod',
+    term: 'TPU superpod',
+    aliases: ['superpod', 'TPU pod', 'Ironwood superpod', 'full pod'],
+    category: 'Hardware',
+    plainEnglish:
+      'A superpod is the largest unit of TPUs wired into one ICI network, up to 9,216 Ironwood chips that can be treated as a single machine.',
+    definition:
+      'A TPU superpod is the maximum ICI-connected domain of a TPU generation, assembled from 64-chip cubes joined through optical circuit switches; for Ironwood it reaches 9,216 chips and about 42.5 FP8 exaflops.',
+    explanation:
+      'Each 4x4x4 cube of 64 chips fills one rack. Optical circuit switches link cubes while preserving torus wraparound, so the pod behaves as one large twisted torus. Because ICI bypasses the host CPU and delivers NVLink-class bandwidth across the pod, a model can be sharded across thousands of chips with tensor, expert, and data parallelism without pipeline stages. Customers rent slices of a pod rather than the whole thing, and the OCS layer lets Google route around a failed chip in seconds.',
+    significance:
+      'The pod is the reason TPU serving strategies differ from GPU ones. An NVL72 domain caps a scale-up group at 72 GPUs, while an Ironwood pod can put more than 1,000 chips in one low-latency domain, which enables ultra-wide expert parallelism and large-model disaggregation that a rack-scale NVIDIA system cannot replicate.',
+    benchmarkContext:
+      'The InferenceX Official Preview ran aggregated serving on small slices, but the article argues the pod is what will let TPUv7 disaggregated serving compete with GB200 and GB300 NVL72, with those results promised in a follow-up.',
+    relatedTerms: [
+      'tpu',
+      'ici',
+      'optical-circuit-switch',
+      'torus-topology',
+      'nvl72',
+      'wide-expert-parallelism',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'stablehlo',
+    term: 'StableHLO',
+    aliases: ['StableHLO', 'HLO', 'MHLO'],
+    category: 'Software',
+    plainEnglish:
+      'StableHLO is a standardized intermediate representation that frameworks like PyTorch and JAX emit so the XLA compiler can turn it into TPU machine code.',
+    definition:
+      'StableHLO is a portable, versioned operation set built on MLIR that describes a machine learning program at the level of high-level tensor operations, serving as the handoff format between frameworks and the XLA compiler.',
+    explanation:
+      'In the TorchTPU compiled path, TorchDynamo and AOTAutograd capture an FX graph, TorchTPU lowers it to StableHLO, and XLA compiles that into a TPU executable. In the JAX path, jax.jit traces the program to the same representation. Because StableHLO is stable across versions, a serialized program can be compiled later or by a different framework release. It sits above hardware and below the framework, so it carries no knowledge of MXU tile sizes; XLA adds padding and layout decisions afterward.',
+    significance:
+      'A shared IR is what lets vLLM and SGLang reuse one compiler stack whether the model arrived through PyTorch or JAX. It also means Pallas kernels, which bypass StableHLO for hand-tuned operations, must be called explicitly as custom calls rather than discovered by the compiler.',
+    benchmarkContext:
+      'All Qwen3.5 397B results in the TPU InferenceX preview flow through StableHLO to XLA. The article contrasts this with the GPU PyTorch path where torch.compile lowers to Inductor and Triton instead.',
+    relatedTerms: ['xla', 'torchtpu', 'jax', 'pallas', 'torch-compile'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'privateuse1-backend',
+    term: 'PrivateUse1 backend',
+    aliases: ['PrivateUse1', 'PyTorch out-of-tree backend', 'custom device backend'],
+    category: 'Software',
+    plainEnglish:
+      'PrivateUse1 is the PyTorch hook that lets a vendor plug in a new device type, so a tensor can live on device="tpu" just like it would on CUDA.',
+    definition:
+      'PrivateUse1 is the reserved dispatch key and device type in PyTorch that lets an out-of-tree backend register its own tensors, memory allocator, and operator implementations so the framework treats a new accelerator as a first-class device.',
+    explanation:
+      'TorchTPU uses PrivateUse1 to expose an ordinary torch.Tensor on device="tpu" rather than a wrapper backed by a JAX array. The PyTorch dispatcher routes ATen operations to the TPU backend, which can execute eagerly for bring-up and debugging or capture graphs through torch.compile. Distributed APIs such as DDP, FSDP2, and DTensor work through the same mechanism. The earlier TorchAX approach instead intercepted operations through __torch_dispatch__ and translated each one into JAX calls.',
+    significance:
+      'The backend hook is what makes the word native concrete. Serving engines can reuse upstream model code, schedulers, continuous batching, and feature logic without a PyTorch-to-JAX translation layer, which lowers the cost of bringing each new model and engine feature to TPU.',
+    benchmarkContext:
+      'The TPU InferenceX preview results come from the TorchTPU vLLM stack built on this backend. Google expects to leave private beta and open source it around mid-October at the PyTorch Conference, after which SemiAnalysis moves TPU benchmarking from its fork to the public InferenceX repo.',
+    relatedTerms: ['torchtpu', 'torchax', 'torch-compile', 'vllm', 'sglang'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'torch-compile',
+    term: 'torch.compile',
+    aliases: ['torch.compile', 'TorchDynamo', 'AOTAutograd', 'Inductor'],
+    category: 'Software',
+    plainEnglish:
+      'torch.compile is the PyTorch entry point that captures a model into a graph and hands it to a compiler backend instead of running each operation one at a time.',
+    definition:
+      'torch.compile is the PyTorch API that uses TorchDynamo to capture Python-level model code into an FX graph, AOTAutograd to trace forward and backward, and a pluggable backend such as Inductor or XLA to generate device code.',
+    explanation:
+      'On NVIDIA GPUs, vLLM uses torch.compile with Inductor, which emits Triton kernels. On TPU, TorchTPU keeps the same entry point but swaps the backend: the FX graph is lowered to StableHLO and compiled by XLA. Google made that compiler choice explicit, XLA rather than Inductor and Triton. The earlier TorchAX path bypassed torch.compile entirely because jax.jit already performed graph capture and compilation. Compiled graphs are specialized on tensor shapes, so serving engines bucket request shapes to limit recompilation.',
+    significance:
+      'Keeping torch.compile as the entry point means TPU-specific compilation hides behind an API vLLM and SGLang already call. Engine features written against the PyTorch compile path carry over, while shape sensitivity from XLA means bucketing and padding still need TPU-specific tuning.',
+    benchmarkContext:
+      'The Qwen3.5 397B numbers in the TPU InferenceX preview run through torch.compile into XLA. Low-concurrency tuning that bucketed request metadata by active requests rather than the configured maximum cut GDN scheduling overhead from 283 to 97 microseconds and raised 8k1k throughput from 2,328 to 2,516 tokens per chip per second at concurrency 64.',
+    relatedTerms: ['torchtpu', 'xla', 'stablehlo', 'shape-bucketing', 'cuda-graphs', 'triton'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'functionalization',
+    term: 'Functionalization',
+    aliases: ['functionalization', 'functional state threading', 'explicit state'],
+    category: 'Software',
+    plainEnglish:
+      'Functionalization rewrites code that mutates objects in place into code that takes state as input and returns new state, so a compiler can trace it.',
+    definition:
+      'Functionalization is the transformation that converts in-place mutations of Python objects, such as writes into a KV cache, into explicit inputs and outputs of a pure function so that a tracing compiler like jax.jit can capture the program as a graph.',
+    explanation:
+      'vLLM manages state that changes every step, most importantly the KV cache. In the TorchAX path, the model wrapper presents weights and KV cache to JAX as explicit state; each inference step takes the old cache in and returns the updated cache. jax.jit can then capture the step once and replay the compiled graph. PyTorch has its own functionalization pass inside AOTAutograd that serves the same purpose for torch.compile, which is one reason the TorchTPU path can reuse the compile pipeline.',
+    significance:
+      'The transformation is invisible when it works and painful when it does not. Serving engines were written assuming mutable Python objects, and the mismatch with a functional compiler is one of the translation-layer problems that pushed Google from TorchAX toward the native TorchTPU backend.',
+    benchmarkContext:
+      'The TPU InferenceX preview describes functionalization as part of how the previous tpu-inference backend got vLLM onto JAX. The TorchTPU path replaces that hand-written state threading with PyTorch dispatch, so the Qwen3.5 397B results depend on the compiler handling it internally.',
+    relatedTerms: ['jax', 'torchax', 'torch-compile', 'kv-cache', 'kv-cache-manager'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'sglang-jax',
+    term: 'SGLang-JAX',
+    aliases: ['SGLang-JAX', 'sgl-jax', 'SGL-torchtpu'],
+    category: 'Software',
+    plainEnglish:
+      'SGLang-JAX is the JAX-native version of the SGLang serving engine for TPUs, separate from the PyTorch SGLang runtime.',
+    definition:
+      'SGLang-JAX is a JAX-native serving engine that pairs SGLang-style scheduling and prefix caching with JAX model implementations and TPU-specific kernels, rather than translating the PyTorch SGLang runtime onto TPU.',
+    explanation:
+      'Where vLLM reached TPU through TorchAX translation, SGLang took a different route and reimplemented its engine in JAX. That gave clean access to mature TPU primitives at the cost of maintaining a second codebase that diverges from upstream SGLang. Google and RadixArk have announced SGL-torchtpu as a PyTorch-native alternative built on TorchTPU, which would let SGLang on TPU share upstream code paths again.',
+    significance:
+      'Two engines with two different TPU strategies is a sign the ecosystem had not settled. TorchTPU is meant to converge them: both vLLM and SGLang get a native PyTorch device, so kernel work in Pallas can be shared and day-0 model support can land on TPU alongside NVIDIA and AMD.',
+    benchmarkContext:
+      'The TPU InferenceX preview results use TorchTPU vLLM. SGLang on TPU results will follow once TorchTPU SGLang is open sourced, at which point SemiAnalysis moves TPU benchmarking into the public InferenceX repo.',
+    relatedTerms: ['sglang', 'jax', 'torchtpu', 'torchax', 'vllm'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'pjrt',
+    term: 'PJRT',
+    aliases: ['PJRT', 'PJRT buffer', 'PJRT plugin'],
+    category: 'Software',
+    plainEnglish:
+      'PJRT is the runtime interface that sits between a framework like JAX or TorchTPU and the TPU hardware, managing device memory buffers and execution.',
+    definition:
+      'PJRT is the plugin runtime API that XLA-based frameworks use to allocate device buffers, launch compiled executables, and transfer data, with PJRTBuffer objects wrapping the raw hardware memory descriptors for a tensor on a device.',
+    explanation:
+      'JAX arrays and TorchTPU tensors on TPU are backed by PJRT buffers. A library that can extract the native PJRTBuffer hardware descriptor can move data directly between devices without staging through the framework, which is how TPU-Sync performs zero-copy KV cache transfers for disaggregated serving. Because both JAX and TorchTPU speak PJRT, one transfer library serves both stacks.',
+    significance:
+      'The runtime layer is where disaggregation and offload plumbing lives. Zero-copy transfers avoid an extra HBM round trip per KV block, which matters when a prefill pool ships large caches to decode pools at high request rates. The same descriptors are the likely substrate for Mooncake Store support on TPU.',
+    benchmarkContext:
+      'The TPU InferenceX preview describes TPU-Sync, formerly TPU-raiden, as extracting native PJRTBuffer descriptors for zero-copy transfers and supporting DRAM offload. Disaggregated TPUv7 results built on it are promised in a follow-up article.',
+    relatedTerms: ['tpu-sync', 'jax', 'torchtpu', 'xla', 'disaggregated-inference'],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'triple-buffering',
+    term: 'Triple buffering',
+    aliases: ['triple buffering', 'three-stage prefetch', 'deeper pipelining'],
+    category: 'Software',
+    plainEnglish:
+      'Triple buffering keeps three data blocks in flight at once, one being computed and two being fetched, so the compute unit rarely waits on memory.',
+    definition:
+      'Triple buffering is a kernel pipelining technique that allocates three on-chip buffers so the next two blocks of data can be prefetched from HBM while the current block is processed, extending double buffering by one stage.',
+    explanation:
+      'Double buffering hides HBM latency by fetching block N+1 while computing block N. Triple buffering adds block N+2, which helps when transfer time varies or when the fetch of one block is longer than the compute on another. The cost is VMEM: three buffers must fit alongside everything else the kernel keeps live. On Ironwood the second version of the grouped matmul triple-buffers expert weights so the next expert group is already in flight while the current one is computed, and batched ragged paged attention triple-buffers page data to reduce padding and improve pipelining.',
+    significance:
+      'Deeper pipelining trades scarce VMEM for MXU utilization. The choice depends on block size, which is why the RPA v3 fix separated the KV fetch block from the KV compute block: shrinking compute to 4k tokens while keeping fetch at 16k freed room for the prefetch buffers.',
+    benchmarkContext:
+      'The grouped matmul v2 with triple-buffered expert weights is part of the MoE kernel work that fed the Qwen3.5 397B results in the TPU InferenceX preview. The batched RPA change was measured on Qwen3-32B, so its numbers are kept separate from the 397B comparison.',
+    relatedTerms: [
+      'double-buffering',
+      'vmem',
+      'grouped-gemm',
+      'ragged-paged-attention',
+      'pallas',
+      'memory-bandwidth',
+    ],
+    articleSlugs: [TPU_IRONWOOD, INFERENCEX_V2],
+  },
+  {
+    slug: 'sequence-on-lane-layout',
+    term: 'Sequence-on-lane layout',
+    aliases: ['sequence-on-lane', 'lane-major KV layout', 'token-on-lane layout'],
+    category: 'Software',
+    plainEnglish:
+      'Sequence-on-lane is a KV cache layout that puts a page of tokens along the 128-wide vector lane axis instead of the head dimension, so less memory is wasted on padding.',
+    definition:
+      'Sequence-on-lane layout is a TPU KV cache arrangement that maps the tokens of a page onto the 128-lane trailing dimension and the head dimension onto the sublane axis, avoiding the padding that occurs when a small head dimension is placed on the lane axis.',
+    explanation:
+      'The TPU vector unit works on tiles whose last dimension is 128 lanes, so any array with a smaller trailing dimension is padded up. The batched attention kernel originally packed keys and values along the head dimension, and for FP8 the packing factor is four. A model with one KV head per device only has two things to pack, so half of every tile was padding. Putting tokens on the lane axis fills tiles regardless of head count, and the head dimension only needs to be a multiple of 32 rather than 128, which lets models with a head dimension of 64 use the kernel.',
+    significance:
+      'KV capacity is decode throughput at high concurrency. The layout costs about 3% per-token latency at low concurrency but stops requests from queuing for KV space when the batch is large. It also widens the set of models that run on the shared attention kernel without custom work.',
+    benchmarkContext:
+      'In the reported Ironwood configuration usable KV pages doubled from 5,141 to 10,283. At concurrency 128 on 8k1k the extra capacity lifted throughput 16.5% and cut median TTFT by 95% because requests no longer waited for KV space.',
+    measurement: {
+      label: 'Usable KV pages, FP8, one KV head per device',
+      value:
+        '5,141 to 10,283 pages; +16.5% throughput and -95% median TTFT at concurrency 128 on 8k1k',
+    },
+    relatedTerms: [
+      'tile-padding',
+      'paged-attention',
+      'ragged-paged-attention',
+      'kv-cache',
+      'vpu',
+      'grouped-query-attention',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'collective-offload',
+    term: 'SparseCore collective offload',
+    aliases: ['collective offload', 'SparseCore offload threshold', 'SC collective'],
+    category: 'Software',
+    plainEnglish:
+      'Collective offload runs communication operations like all-reduce on the TPU SparseCore instead of the TensorCore, but only when the message is big enough to be worth it.',
+    definition:
+      'SparseCore collective offload is the Ironwood technique of executing all-reduce, all-gather, and reduce-scatter collectives on SparseCores so the TensorCore stays free for matrix work, gated by a size threshold below which the collective stays on the TensorCore.',
+    explanation:
+      'SparseCores are built for irregular data movement, which makes them a natural home for collectives. Google implemented ReduceScatter on SparseCore with a two-level scheme that reduces within a chip over the die-to-die link before exchanging across ICI, using double buffering to overlap stages. Offload is not free: launching on SparseCore has overhead, and for small messages that fit in VMEM the TensorCore finishes faster. For Qwen3.5 a threshold derived from VMEM capacity decides per collective which unit runs it.',
+    significance:
+      'The threshold is a reminder that moving work off the critical unit can backfire. In some cases offloading a collective to SparseCore worsens performance, so the gain comes from choosing per message size rather than from offload as a blanket policy. It also shows how TPU serving optimization touches scheduling decisions that GPU stacks leave to NCCL.',
+    benchmarkContext:
+      'The threshold-based offload gave Qwen3.5 397B 8k1k throughput gains of 2.7% at concurrency 64 and 5.7% at concurrency 128. Merging two separate all-gathers of expert IDs and routing weights into one saved about 80 microseconds per layer, or roughly 4.64 milliseconds per forward pass over DeepSeek-V3 style 58 layers.',
+    relatedTerms: [
+      'sparsecore',
+      'tensorcore',
+      'all-reduce',
+      'all-gather',
+      'reduce-scatter',
+      'vmem',
+      'nccl',
+    ],
+    articleSlugs: [TPU_IRONWOOD],
+  },
+  {
+    slug: 'kv-head-replication',
+    term: 'KV head replication',
+    aliases: ['KV head replication', 'replicated KV heads', 'KV head duplication'],
+    category: 'Parallelism',
+    plainEnglish:
+      'KV head replication copies the same key-value heads onto several tensor-parallel ranks when a model has fewer KV heads than the devices it is split across.',
+    definition:
+      'KV head replication is the tensor-parallel strategy of duplicating key and value heads across ranks when the tensor-parallel degree exceeds the number of KV heads in a grouped-query attention layer, so each rank has the KV data its local query heads need without a communication step.',
+    explanation:
+      'Qwen3.5 has 32 query heads and 2 shared KV heads. With TP8 each device gets 4 query heads, but 2 KV heads do not divide across 8 devices; each KV head is shared by 16 query heads, so four devices need the same KV data. Replicating both KV heads on every rank avoids an all-to-all exchange of KV tensors at the cost of duplicating KV cache memory on each rank. vLLM already supported this, and the TPU backend needed a compatibility fix to activate the existing behavior.',
+    significance:
+      'The alternative for high concurrency is DP attention: each device handles a different subset of requests and holds both KV heads for those requests, so KV memory is not duplicated across ranks while the much larger expert weights stay sharded with expert parallelism. Ironwood serving uses TP8 attention at low concurrency and DP8 plus EP8 at high concurrency.',
+    benchmarkContext:
+      'Activating replication removed unnecessary All-to-All communication in the Qwen3.5 397B TorchTPU bring-up. The low-concurrency tuning round that switched to TP8 attention plus expert parallelism gave 1k1k gains of 22.9% at concurrency four and 18.1% at eight.',
+    relatedTerms: [
+      'grouped-query-attention',
+      'tensor-parallelism',
+      'dp-attention',
+      'expert-parallelism',
+      'all-to-all',
+      'kv-cache',
+    ],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3],
+  },
+  {
+    slug: 'recurrent-state',
+    term: 'Recurrent state',
+    aliases: ['recurrent state', 'GDN state', 'linear attention state', 'SSM state'],
+    category: 'Model architecture',
+    plainEnglish:
+      'Recurrent state is the fixed-size memory a linear-attention or SSM layer keeps per request, unlike a KV cache that grows with every token.',
+    definition:
+      'Recurrent state is the fixed-size per-request tensor that a linear attention layer such as Gated DeltaNet updates at each step, replacing the growing per-token key-value history that softmax attention layers store.',
+    explanation:
+      'In a hybrid model like Qwen3.5, GQA layers accumulate a KV history that grows with context while GDN layers hold a fixed-size state per request that is decayed, updated with a rank-one term, and read out each token. Serving engines must allocate slots for this state, decide its storage precision, and handle checkpoints for prefix caching, because the live state is overwritten as soon as the request continues. On Ironwood the state was initially allocated as num_blocks slots per layer group, which wasted HBM, then compacted to roughly one slot per active request.',
+    significance:
+      'Recurrent state changes the memory budget: it does not grow with context, which is the whole point of hybrid architectures, but it must be stored somewhere and moved between VMEM and HBM every step. Storing it in BF16 while computing in FP32 halves its footprint. Prefix caching for hybrids needs separate read and write slots so a cached checkpoint survives.',
+    benchmarkContext:
+      'Compact allocation reclaimed about 76 GiB of HBM and expanded the attention block pool 71%, improving Qwen3.5 397B 1k8k throughput 18% at concurrency 64. BF16 state storage gave a further 15% on 1k8k at concurrency 512.',
+    measurement: {
+      label: 'Compact recurrent-state allocation, Qwen3.5 397B',
+      value:
+        'About 76 GiB HBM reclaimed, attention block pool +71%, 1k8k throughput +18% at concurrency 64',
+    },
+    relatedTerms: [
+      'gated-deltanet',
+      'linear-attention',
+      'hybrid-attention',
+      'kv-cache',
+      'hybrid-prefix-caching',
+      'bf16',
+    ],
+    articleSlugs: [TPU_IRONWOOD, KIMI_K3, AGENTX_V3],
+  },
+  {
+    slug: 'hybrid-prefix-caching',
+    term: 'Hybrid prefix caching',
+    aliases: ['hybrid prefix caching', 'GDN checkpoint caching', 'aligned checkpoint mode'],
+    category: 'Serving',
+    plainEnglish:
+      'Hybrid prefix caching lets a model with both attention and linear-attention layers reuse a cached prompt by saving the recurrent state alongside the KV blocks.',
+    definition:
+      'Hybrid prefix caching is the serving technique that stores, for a shared prompt prefix, both the KV blocks of the attention layers and a checkpoint of the recurrent state of the linear-attention layers, so a new request can resume from the prefix without recomputing it.',
+    explanation:
+      'For a plain attention model, caching a prefix means keeping its KV blocks. For a hybrid, the GDN recurrent state at the end of the prefix must also survive, but the live state is normally overwritten as the request continues. The Ironwood implementation gives GDN separate slots for reading a checkpoint and writing the live state, derives state addresses from the block table that already locates KV blocks, and takes checkpoints at an aligned cache granularity so a saved state always lines up with a KV block boundary. This mode needs a full checkpoint pool rather than the compact per-request allocation, trading HBM for reuse.',
+    significance:
+      'Agentic and multi-turn workloads reuse long system prompts and conversation histories, and hybrid models cannot benefit unless the recurrent state is cached too. The trade is explicit: prefix caching for hybrids costs the HBM that compact allocation had saved, so the mode pays off only when prefixes are actually shared.',
+    benchmarkContext:
+      'The Qwen3.5 397B numbers in the TPU InferenceX preview are random-input 8k1k runs with nothing shared between requests, so they do not exercise this path. Hybrid prefix caching with DP support is the groundwork for the AgentX TPU results Google customers have asked for.',
+    relatedTerms: [
+      'prefix-caching',
+      'recurrent-state',
+      'gated-deltanet',
+      'hybrid-attention',
+      'kv-cache-manager',
+      'agentic-inference',
+    ],
+    articleSlugs: [TPU_IRONWOOD, KIMI_K3, AGENTIC_WORKLOADS],
+  },
+  {
+    slug: 'kv-cache-p2p-pooling',
+    term: 'KV cache DRAM P2P pooling',
+    aliases: ['P2P pooling', 'DRAM pooling', 'pooled KV storage', 'shared KV pool'],
+    category: 'Serving',
+    plainEnglish:
+      'P2P pooling joins the host memory of many servers into one logical KV cache store, so an accelerator on any server can pull cached context from any other.',
+    definition:
+      'KV cache DRAM P2P pooling is an offload architecture in which the host DRAM contributed by every node in a cluster is aggregated into a single logical memory pool, letting any accelerator read KV cache written by any other node over the network.',
+    explanation:
+      'Single-node offload moves KV blocks from HBM to the local host DRAM when HBM fills. Pooling goes further: Mooncake Store unifies the DRAM on every TPU host into one shared pool, and can pool NVMe from multiple servers as well or back onto distributed filesystems like WEKA and VAST. A request routed to a different server than the one that computed its prefix can still hit in cache. Google is externalizing its native TPU offload stack through TPU-Sync and supporting Mooncake Store, likely built on TPU-Sync primitives.',
+    significance:
+      'Pooling raises the achievable prefix cache hit rate for agentic workloads, where sessions run hundreds of turns and sub-agents burst with fresh context. Without it, hit rate is capped by what one node can hold and by how well the router keeps a session on one machine.',
+    benchmarkContext:
+      'TPU-Sync DRAM offload and Mooncake Store pooling are listed as next steps in the TPU InferenceX preview, ahead of AgentX TPU results. The AgentX articles on NVIDIA and AMD already show that KV working set size and offload capacity decide agentic cost per token.',
+    relatedTerms: [
+      'kv-cache-offload',
+      'mooncake-store',
+      'tpu-sync',
+      'cpu-offloading',
+      'nvme-offloading',
+      'prefix-cache-hit-rate',
+      'kv-aware-routing',
+    ],
+    articleSlugs: [TPU_IRONWOOD, AGENTX_V3, AGENTIC_WORKLOADS],
+  },
 ] as const satisfies readonly GlossaryEntry[];
 
 export type GlossaryPreview = Pick<


### PR DESCRIPTION
## Summary

Second batch of glossary entries from [TPU Inference Externalization Full Steam Ahead](https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam), following #1067. These 20 terms are the hardware blocks, compiler layers, and serving mechanics that the first batch's entries referenced by name but did not define.

### New terms

- **Hardware:** TensorCore (TPU), Vector Processing Unit (VPU), Systolic array, MegaCore, Die-to-die link, Twisted torus, TPU superpod
- **Software:** StableHLO, PrivateUse1 backend, torch.compile, Functionalization, SGLang-JAX, PJRT, Triple buffering, Sequence-on-lane layout, SparseCore collective offload
- **Parallelism:** KV head replication
- **Model architecture:** Recurrent state
- **Serving:** Hybrid prefix caching, KV cache DRAM P2P pooling

Each entry keeps the article's numbers in `benchmarkContext` (e.g. TensorCore gather overhead 29 to 14 us, recurrent-state compaction reclaiming ~76 GiB HBM and +71% block pool, sequence-on-lane doubling usable KV pages 5,141 to 10,283, GDN scheduling overhead 283 to 97 us). `sequence-on-lane-layout` and `recurrent-state` carry a `measurement` block. Cross-links go both ways into the #1067 entries (`mxu`, `vmem`, `sparsecore`, `gated-deltanet`, `torchtpu`, `tpu-sync`, `mooncake-store`) and older ones (`grouped-query-attention`, `prefix-caching`, `kv-cache-offload`, `cuda-graphs`, `nccl`).

Glossary count: 147 to 167 entries.

### Checks run locally

- `bun run fmt`, `bun run lint`, `bun run typecheck`, `bun run check:typography`
- `vitest run src/lib/glossary.test.ts src/lib/zh-copy.test.ts src/lib/chip-pages.test.ts src/app/sitemap.test.ts` (54 passed)

## 中文说明

继 #1067 之后，来自《TPU Inference Externalization Full Steam Ahead》的第二批术语表条目。这 20 条术语是第一批条目中提及但尚未单独定义的硬件模块、编译器层和服务机制。

新增术语：

- **硬件：** TensorCore（TPU）、VPU、systolic 阵列、MegaCore、die-to-die 链路、twisted torus、TPU superpod
- **软件栈：** StableHLO、PrivateUse1 后端、torch.compile、函数化、SGLang-JAX、PJRT、三缓冲、sequence-on-lane 布局、SparseCore 集合通信卸载
- **并行策略：** KV head 复制
- **模型架构：** 循环状态
- **推理服务：** 混合模型 prefix caching、KV cache DRAM P2P 池化

每条条目的 `benchmarkContext` 保留文章中的具体数字，`sequence-on-lane-layout` 和 `recurrent-state` 带有 `measurement` 块。条目与 #1067 新增的 `mxu`、`vmem`、`sparsecore`、`gated-deltanet`、`torchtpu`、`tpu-sync`、`mooncake-store` 以及更早的 `grouped-query-attention`、`prefix-caching`、`kv-cache-offload` 等条目互相链接。中文条目按 `docs/chinese-copy.md` 的技术散文语域撰写，保留产品名、框架名和行业惯用英文术语。

术语表条目数从 147 增至 167。本地已运行 fmt、lint、typecheck、check:typography，以及术语表、zh-copy、chip-pages 和 sitemap 单元测试（54 项通过）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only glossary data with paired EN/ZH entries; no runtime logic changes beyond expanded term lists and cross-links.
> 
> **Overview**
> Adds **20 glossary entries** (English in `glossary.ts`, Chinese in `glossary-zh.ts`) for concepts from the TPU InferenceX / Ironwood article that earlier entries referenced but did not define. Coverage spans **hardware** (TPU TensorCore, VPU, systolic array, MegaCore, die-to-die link, twisted torus, superpod), **software stack** (StableHLO, PrivateUse1, `torch.compile`, functionalization, SGLang-JAX, PJRT, triple buffering, sequence-on-lane layout, SparseCore collective offload), **parallelism** (KV head replication), **model architecture** (recurrent state), and **serving** (hybrid prefix caching, KV cache DRAM P2P pooling).
> 
> Each entry follows the existing shape (`plainEnglish`, `definition`, `explanation`, `significance`, `benchmarkContext`, `relatedTerms`, `articleSlugs`). Article metrics stay in `benchmarkContext`; **`sequence-on-lane-layout`** and **`recurrent-state`** also include `measurement` blocks. New slugs link back to prior TPU terms (`mxu`, `vmem`, `sparsecore`, `torchtpu`, etc.). Glossary size increases from **147 to 167** entries; zh translations must stay in sync via the existing `getAllGlossaryEntries()` merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5f8a81404ab1b72a281576789655ef83bbc012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->