### PR TITLE
fix: preserve explicit deployment chip counts / 修复图表丢失显式部署芯片数量的问题

### DIFF
--- a/docs/data-transforms.md
+++ b/docs/data-transforms.md
@@ -53,7 +53,7 @@ Returns `{ chartData: InferenceData[][], hardwareConfig: HardwareConfig }`.
 **`createChartDataPoint(date, entry, xKey, yKey, hwKey, derivedFields?)`** spreads `entry` first, then overrides chart coordinates and metadata. The full transform passes precomputed derived fields; direct callers may omit them.
 
 - `x` / `y`: read directly from `entry[xKey]` and `entry[yKey]` (set per chart definition).
-- `tp`: for disaggregated configs, set to `num_prefill_gpu + num_decode_gpu` instead of `decode_tp`.
+- `tp` is the total chip count: disaggregated configs sum `num_prefill_gpu + num_decode_gpu`; aggregate configs prefer a positive `num_decode_gpu`, then `num_prefill_gpu`, falling back to TP × PP only when neither count is available. Aggregate role counts describe the same deployment and are not summed. The actual tensor-parallel width remains in `decode_tp`.
 - Boolean narrowing: `dp_attention`, `prefill_dp_attention`, `decode_dp_attention`, and `is_multinode` are coerced from `boolean | string` to `boolean | undefined`.
 - Disagg fields: `num_prefill_gpu` / `num_decode_gpu` are only set when `entry.disagg` is true; otherwise they are dropped.
 

--- a/docs/data-transforms.md
+++ b/docs/data-transforms.md
@@ -53,7 +53,7 @@ Returns `{ chartData: InferenceData[][], hardwareConfig: HardwareConfig }`.
 **`createChartDataPoint(date, entry, xKey, yKey, hwKey, derivedFields?)`** spreads `entry` first, then overrides chart coordinates and metadata. The full transform passes precomputed derived fields; direct callers may omit them.
 
 - `x` / `y`: read directly from `entry[xKey]` and `entry[yKey]` (set per chart definition).
-- `tp` is the total chip count: disaggregated configs sum `num_prefill_gpu + num_decode_gpu`; aggregate configs prefer a positive `num_decode_gpu`, then `num_prefill_gpu`, falling back to TP × PP only when neither count is available. Aggregate role counts describe the same deployment and are not summed. The actual tensor-parallel width remains in `decode_tp`.
+- `tp` is the total chip count: disaggregated configs sum `num_prefill_gpu + num_decode_gpu`; aggregate configs prefer a positive `num_decode_gpu`, then `num_prefill_gpu`, with TP × PP as a minimum even when a positive count is present. Legacy ingest defaults can populate counts as TP × EP without PP; this floor preserves pipeline parallelism for existing rows and unofficial overlays. Aggregate role counts describe the same deployment and are not summed. The actual tensor-parallel width remains in `decode_tp`.
 - Boolean narrowing: `dp_attention`, `prefill_dp_attention`, `decode_dp_attention`, and `is_multinode` are coerced from `boolean | string` to `boolean | undefined`.
 - Disagg fields: `num_prefill_gpu` / `num_decode_gpu` are only set when `entry.disagg` is true; otherwise they are dropped.
 

--- a/packages/app/src/components/inference/replay/__tests__/buildReplayTimeline.test.ts
+++ b/packages/app/src/components/inference/replay/__tests__/buildReplayTimeline.test.ts
@@ -233,8 +233,8 @@ describe('buildReplayTimeline', () => {
     expect(timeline.dates).toEqual(['2025-01-01']);
     expect(timeline.configs).toHaveLength(2);
     expect(timeline.configs.map(({ configId }) => configId).toSorted()).toEqual([
-      'h100_trt|fp4|0|32|0|0|0|recipe-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      'h100_trt|fp4|0|32|0|0|0|recipe-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      'h100_trt|fp4|8|32|0|0|0|recipe-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'h100_trt|fp4|8|32|0|0|0|recipe-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     ]);
     expect(timeline.configs.map(({ stepValues }) => stepValues[0].y).toSorted()).toEqual([
       400, 500,
@@ -263,8 +263,8 @@ describe('buildReplayTimeline', () => {
     expect(t.configs).toHaveLength(2);
     expect(new Set(t.configs.map((config) => config.hwKey))).toEqual(new Set(['h100_trt']));
     expect(t.configs.map((config) => config.configId).toSorted()).toEqual([
-      'h100_trt|fp4|0|32|0|0|0|spec-mtp',
-      'h100_trt|fp4|0|32|0|0|0|spec-none',
+      'h100_trt|fp4|8|32|0|0|0|spec-mtp',
+      'h100_trt|fp4|8|32|0|0|0|spec-none',
     ]);
   });
 

--- a/packages/app/src/components/unofficial-run-provider.test.ts
+++ b/packages/app/src/components/unofficial-run-provider.test.ts
@@ -249,6 +249,29 @@ describe('buildChartData', () => {
     expect(group.interactivity.data[0].x).toBe(150);
   });
 
+  it('includes pipeline stages when an unofficial artifact omits GPU counts', () => {
+    const raw = rawPowerArtifact({
+      disagg: false,
+      prefill_tp: 4,
+      decode_tp: 4,
+      prefill_pp: 2,
+      decode_pp: 2,
+    });
+    delete raw.num_prefill_gpu;
+    delete raw.num_decode_gpu;
+    const rows = normalizeArtifactRows([raw], '2026-08-12');
+    // Reproduce the ingest default that used to bypass the chart's PP fallback.
+    expect(rows[0].num_decode_gpu).toBe(4);
+    expect(rows[0].num_prefill_gpu).toBe(4);
+    const group = buildChartData(rows)['DeepSeek-R1-0528_1k/1k'];
+    for (const chart of [group.e2e, group.interactivity]) {
+      expect(chart.data[0].tp).toBe(8);
+      expect(chart.data[0].decode_tp).toBe(4);
+      expect(chart.data[0].pp).toBe(2);
+      expect(chart.data[0].tpPerGpu.y).toBe(100.5);
+    }
+  });
+
   it('preserves all data points for disagg configs with different parallelism but same tp', () => {
     // Two configs: same hwKey/precision/tp/conc but different decode_ep/dp_attention.
     // Both must survive buildChartData; D3 dedup is a rendering concern, not a data one.

--- a/packages/app/src/lib/benchmark-transform.test.ts
+++ b/packages/app/src/lib/benchmark-transform.test.ts
@@ -832,7 +832,13 @@ describe('transformBenchmarkRows', () => {
     // (buildChartData → transformBenchmarkRows), so it exercises the overlay
     // rendering path for PP configs end to end.
     const base = makeRow();
-    const rows = [makeRow({ metrics: { ...base.metrics, prefill_pp: 2, decode_pp: 2 } })];
+    const rows = [
+      makeRow({
+        num_prefill_gpu: 0,
+        num_decode_gpu: 0,
+        metrics: { ...base.metrics, prefill_pp: 2, decode_pp: 2 },
+      }),
+    ];
     const { chartData } = transformBenchmarkRows(rows);
     const point = chartData.find((d) => d.length > 0)![0];
     // tp8 × pp2 = 16 total GPUs

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -437,9 +437,16 @@ export function createChartDataPoint(
     x: (entry[xKey] ?? 0) as number,
     y: (entry[yKey] ?? 0) as number,
     hwKey: currentHwKey,
+    // Aggregate role counts describe the same deployment, so never sum them.
+    // TP alone is not the chip count (e.g. Jalapeño TP1/EP8 uses eight chips).
+    // Keep TP × PP only as a fallback for older artifacts without chip counts.
     tp: entry.disagg
       ? entry.num_prefill_gpu + entry.num_decode_gpu
-      : entry.tp * (entry.pp && entry.pp > 1 ? entry.pp : 1),
+      : entry.num_decode_gpu > 0
+        ? entry.num_decode_gpu
+        : entry.num_prefill_gpu > 0
+          ? entry.num_prefill_gpu
+          : entry.tp * (entry.pp && entry.pp > 1 ? entry.pp : 1),
     image: entry.image ?? undefined,
     dp_attention:
       entry.dp_attention !== null && entry.dp_attention !== undefined

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -439,14 +439,18 @@ export function createChartDataPoint(
     hwKey: currentHwKey,
     // Aggregate role counts describe the same deployment, so never sum them.
     // TP alone is not the chip count (e.g. Jalapeño TP1/EP8 uses eight chips).
-    // Keep TP × PP only as a fallback for older artifacts without chip counts.
+    // Ingested legacy counts can default to TP × EP without PP. Keep TP × PP
+    // as a floor even when counts are positive, including for unofficial overlays.
     tp: entry.disagg
       ? entry.num_prefill_gpu + entry.num_decode_gpu
-      : entry.num_decode_gpu > 0
-        ? entry.num_decode_gpu
-        : entry.num_prefill_gpu > 0
-          ? entry.num_prefill_gpu
-          : entry.tp * (entry.pp && entry.pp > 1 ? entry.pp : 1),
+      : Math.max(
+          entry.num_decode_gpu > 0
+            ? entry.num_decode_gpu
+            : entry.num_prefill_gpu > 0
+              ? entry.num_prefill_gpu
+              : 0,
+          entry.tp * (entry.pp && entry.pp > 1 ? entry.pp : 1),
+        ),
     image: entry.image ?? undefined,
     dp_attention:
       entry.dp_attention !== null && entry.dp_attention !== undefined

--- a/packages/app/src/lib/chip-count.test.ts
+++ b/packages/app/src/lib/chip-count.test.ts
@@ -70,6 +70,33 @@ describe('explicit deployment chip counts', () => {
     expect(chartData[0][0].tp).toBe(expected);
   });
 
+  it.each([
+    { decode: 4, prefill: 4, expected: 8 },
+    { decode: 0, prefill: 4, expected: 8 },
+    { decode: 0, prefill: 0, expected: 8 },
+    { decode: 16, prefill: 16, expected: 16 },
+  ])('keeps the PP floor for counts $decode / $prefill', ({ decode, prefill, expected }) => {
+    // Stored legacy rows already contain positive TP × EP defaults, without PP.
+    const { chartData } = transformBenchmarkRows([
+      {
+        ...source,
+        prefill_tp: 4,
+        decode_tp: 4,
+        prefill_ep: 1,
+        decode_ep: 1,
+        num_decode_gpu: decode,
+        num_prefill_gpu: prefill,
+        metrics: { ...source.metrics, prefill_pp: 2, decode_pp: 2 },
+      },
+    ]);
+    for (const series of chartData) {
+      expect(series[0].tp).toBe(expected);
+      expect(series[0].decode_tp).toBe(4);
+      expect(series[0].pp).toBe(2);
+      expect(series[0].tpPerGpu.y).toBe(source.metrics.tput_per_gpu);
+    }
+  });
+
   it('preserves every supplied GPT-OSS topology, including single-chip points', () => {
     const rows = SUPPLEMENTAL_BENCHMARK_ROWS.filter((row) => row.model === 'gptoss120b');
     const { chartData } = transformBenchmarkRows(rows);

--- a/packages/app/src/lib/chip-count.test.ts
+++ b/packages/app/src/lib/chip-count.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generateTooltipContent,
+  generateGPUGraphTooltipContent,
+  generateOverlayTooltipContent,
+} from '@/components/inference/utils/tooltipUtils';
+import { transformBenchmarkRows } from './benchmark-transform';
+import { SUPPLEMENTAL_BENCHMARK_ROWS } from './supplemental-benchmarks';
+
+// C256-N8 in the supplied 2026-08-22 GPT-OSS throughput.json:
+// chip_count=8, tp=1, ep=8, median_tpot_ms=3.284620495235133.
+const source = SUPPLEMENTAL_BENCHMARK_ROWS.find(
+  (row) => row.model === 'gptoss120b' && row.conc === 256,
+)!;
+
+describe('explicit deployment chip counts', () => {
+  it.each(['en', 'zh'] as const)('renders the supplied EP8 point in every %s tooltip', (locale) => {
+    const { chartData, hardwareConfig } = transformBenchmarkRows([source]);
+    const point = chartData[0][0];
+    expect(point.tp).toBe(8);
+    expect(point.decode_tp).toBe(1);
+    expect(point.ep).toBe(8);
+    expect(point.median_intvty).toBeCloseTo(304.449175);
+    expect(point.tpPerGpu.y).toBeCloseTo(325426.1649993376 / 8);
+    const config = {
+      data: point,
+      hardwareConfig,
+      isPinned: false,
+      xLabel: 'Interactivity',
+      yLabel: 'Throughput',
+      selectedYAxisMetric: 'y_tpPerGpu',
+      locale,
+    };
+    // The overlay consumes the same transform, but has its own tooltip renderer.
+    const htmls = [
+      generateTooltipContent(config),
+      generateGPUGraphTooltipContent(config),
+      generateOverlayTooltipContent({
+        ...config,
+        overlayData: { data: chartData[0], hardwareConfig, label: 'test-run' },
+      }),
+    ];
+    for (const html of htmls) {
+      expect(html).toContain(
+        `${locale === 'en' ? 'Total Chips' : '芯片总数'}${locale === 'en' ? ':' : '：'}</strong> 8`,
+      );
+      expect(html).toContain(
+        `${locale === 'en' ? 'Tensor Parallelism' : '张量并行 (TP)'}${locale === 'en' ? ':' : '：'}</strong> 1`,
+      );
+      expect(html).toContain(
+        `${locale === 'en' ? 'Expert Parallelism' : '专家并行 (EP)'}${locale === 'en' ? ':' : '：'}</strong> 8`,
+      );
+    }
+  });
+
+  it.each([
+    { decode: 8, prefill: 8, expected: 8 },
+    { decode: 8, prefill: 0, expected: 8 },
+    { decode: 0, prefill: 8, expected: 8 },
+    { decode: 0, prefill: 0, expected: 1 },
+  ])('handles aggregate counts $decode / $prefill', ({ decode, prefill, expected }) => {
+    const { chartData } = transformBenchmarkRows([
+      {
+        ...source,
+        num_decode_gpu: decode,
+        num_prefill_gpu: prefill,
+      },
+    ]);
+    expect(chartData[0][0].tp).toBe(expected);
+  });
+
+  it('preserves every supplied GPT-OSS topology, including single-chip points', () => {
+    const rows = SUPPLEMENTAL_BENCHMARK_ROWS.filter((row) => row.model === 'gptoss120b');
+    const { chartData } = transformBenchmarkRows(rows);
+    expect(chartData[0].map((p) => [p.tp, p.decode_tp, p.ep])).toEqual([
+      [4, 4, 1],
+      [2, 2, 1],
+      [1, 1, 1],
+      [1, 1, 1],
+      ...Array.from({ length: 6 }, () => [8, 1, 8]),
+    ]);
+  });
+});


### PR DESCRIPTION
Jalapeño GPT-OSS results with TP=1, EP=8 and an explicit eight-chip deployment appeared as “Total Chips: 1” because the chart replaced the supplied count with TP × PP. Preserve positive aggregate chip counts (decode, then prefill), using TP × PP as a minimum even when legacy ingest has populated a positive count that omits pipeline stages. Disaggregated deployments still sum their separate prefill and decode counts; the actual TP width and per-chip performance metrics remain intact.

Regression coverage uses the supplied August 22 C256-N8 point (304.449 tok/s/user) and all ten GPT-OSS snapshot topologies. It covers official, date-comparison and `?unofficialrun=` overlay tooltip renderers in English and Chinese, plus legacy count fallback and replay identities. Overlay support is verified through unit tests and the browser smoke suite; a live unofficial run was not manually verified at a preview URL.

Validation: all workspace unit tests; browser smoke suite (46 component + 113 integration tests); typecheck; lint; formatting; typography pre-commit guard.

## 中文说明

Jalapeño GPT-OSS 结果明确记录了 8 颗芯片、TP=1、EP=8，但图表使用 TP × PP 覆盖了原始芯片数量，导致提示框显示“芯片总数：1”。本次修复优先采用聚合部署中的有效芯片数量（先 decode，后 prefill），同时以 TP × PP 作为下限，避免历史数据自动填充的芯片数量遗漏流水线并行。分离式部署仍将预填充和解码的芯片数量相加；实际 TP 配置和每芯片性能指标保持不变。

回归测试覆盖 8 月 22 日提供的 C256-N8 数据点（304.449 tok/s/user）及全部 10 个 GPT-OSS 快照配置，并验证官方结果、日期对比和 `?unofficialrun=` 非官方运行叠加的中英文提示框，以及历史数据的数量回退逻辑和回放配置标识。叠加路径已通过单元测试和浏览器冒烟测试验证；尚未在预览 URL 上手动加载实际非官方运行进行验证。

验证通过：全部工作区单元测试、浏览器冒烟测试（46 项组件测试和 113 项集成测试）、类型检查、lint、格式检查和提交前 typography 检查。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core chart metadata used in tooltips, labels, replay identity, and per-GPU math denominators; wrong logic would skew displayed topology and throughput-per-chip across official and overlay data.
> 
> **Overview**
> Fixes chart points that showed **Total Chips: 1** when deployments recorded eight chips with **TP=1 / EP=8**, because aggregate configs computed `tp` only as **TP × PP** instead of honoring supplied counts.
> 
> **`createChartDataPoint`** now treats **`tp` as total chip count**: disaggregated rows still sum **`num_prefill_gpu + num_decode_gpu`**; aggregate rows take the better of a positive **`num_decode_gpu`** (then **`num_prefill_gpu`**) and a **TP × PP floor**, so legacy ingest defaults (**TP × EP** without PP) and unofficial overlays still get correct PP scaling without double-counting prefill/decode role fields on the same deployment. **`decode_tp`** and per-GPU derived metrics are unchanged.
> 
> Docs in **`data-transforms.md`** describe the new rules. Regression coverage adds **`chip-count.test.ts`** (GPT-OSS C256-N8 tooltips EN/ZH, PP floor, all snapshot topologies), an unofficial-run test when GPU counts are omitted, tighter overlay/benchmark-transform cases, and updated replay **`configId`** expectations where chip count is embedded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22460dc3da78e28deb005ed517d7726b50dbe1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->