### PR TITLE
Add TPUv7 results and link the launch banner / 新增 TPUv7 结果并更新首页横幅跳转

### DIFF
--- a/packages/app/cypress/e2e/certified-power-filter.cy.ts
+++ b/packages/app/cypress/e2e/certified-power-filter.cy.ts
@@ -89,11 +89,22 @@ function visitCertifiedPowerChart(extraParams = '') {
     },
   });
   cy.wait(['@availability', '@benchmarks']);
-  cy.get('[data-testid="inference-chart-display"]', { timeout: 30_000 }).should('exist');
+  cy.get('[data-testid="inference-chart-display"]').should('exist');
   cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
 }
 
 describe('Validated vs historical measured power', () => {
+  beforeEach(() => {
+    // Firefox can defer resize notifications while the Radix metric menu
+    // changes layout. Keep the chart assertions active; ignore only this
+    // browser-generated delivery notification, not application exceptions.
+    cy.on('uncaught:exception', (error) => {
+      if (error.message === 'ResizeObserver loop completed with undelivered notifications.') {
+        return false;
+      }
+    });
+  });
+
   it('rings legacy points on a measured axis and filters them via Quick Filters', () => {
     visitCertifiedPowerChart();
 

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -184,3 +184,26 @@ describe('First-load navigation', () => {
     cy.location('pathname').should('eq', '/submissions');
   });
 });
+
+describe('TPUv7 launch banner', { testIsolation: true }, () => {
+  for (const locale of ['', '/zh']) {
+    it(`opens the TPUv7 FP8 results from ${locale || '/'} landing page`, () => {
+      cy.visit(locale || '/', {
+        onBeforeLoad(win) {
+          win.localStorage.removeItem('inferencex-tpuv7-banner-dismissed');
+          win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        },
+      });
+      cy.get('[data-testid="launch-banner"]')
+        .should(
+          'have.attr',
+          'href',
+          `${locale}/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k/1k&i_prec=fp8`,
+        )
+        .click();
+      cy.location('pathname').should('eq', `${locale}/inference`);
+      cy.get('[data-testid="inference-chart-display"]').should('be.visible');
+      cy.get('.dot-group[data-hw-key^="tpuv7"]').should('have.length.at.least', 1);
+    });
+  }
+});

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -176,10 +176,10 @@ describe('Landing nudges — banner', { testIsolation: true }, () => {
     cy.get('.dot-group[data-hw-key^="tpuv7"]').should('have.length.at.least', 1);
 
     // Body click must not write the dismissal key — the banner should still
-    // render on a fresh visit to landing. Reset the document first so dev
-    // server hot reloads cannot restore the outgoing chart route.
-    cy.visit('about:blank');
-    cy.visit('/');
+    // render after returning home and reloading the landing page.
+    cy.get('[data-testid="nav-link-home"]').click();
+    cy.location('pathname').should('eq', '/');
+    cy.reload();
     cy.window().then((win) => {
       expect(win.localStorage.getItem('inferencex-tpuv7-banner-dismissed')).to.eq(null);
     });

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -10,11 +10,6 @@
 // Helpers
 // ---------------------------------------------------------------------------
 
-// Mirrors `TPU_NEWSLETTER_URL` in `src/lib/nudges/registry.tsx`; the unit test
-// there pins the registry side, this spec pins the rendered banner.
-const TPU_NEWSLETTER_ORIGIN = 'https://newsletter.semianalysis.com';
-const TPU_NEWSLETTER_PATH = '/p/tpu-inferencex-full-steam';
-
 function clearAllNudgeStorage(win: Cypress.AUTWindow) {
   const keys = [
     'inferencex-starred',
@@ -46,7 +41,7 @@ beforeEach(() => {
 // Landing — modal priority & dismissal
 // ---------------------------------------------------------------------------
 
-describe('Landing nudges — modals', () => {
+describe('Landing nudges — modals', { testIsolation: true }, () => {
   it('shows the launch banner on fresh first load', () => {
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
@@ -128,7 +123,7 @@ describe('Landing nudges — modals', () => {
 // Landing — banner
 // ---------------------------------------------------------------------------
 
-describe('Landing nudges — banner', () => {
+describe('Landing nudges — banner', { testIsolation: true }, () => {
   it('shows launch banner on landing page', () => {
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
@@ -169,30 +164,21 @@ describe('Landing nudges — banner', () => {
   });
 
   it('clicking the banner body navigates without persisting dismissal', () => {
-    // The TPUv7 banner points off-site at the newsletter write-up. Stub the
-    // destination so the spec never depends on Substack being reachable, then
-    // follow the navigation through `cy.origin` to assert where we landed.
-    cy.intercept('GET', `${TPU_NEWSLETTER_ORIGIN}${TPU_NEWSLETTER_PATH}`, {
-      statusCode: 200,
-      headers: { 'content-type': 'text/html' },
-      body: '<!doctype html><html><body><h1>newsletter stub</h1></body></html>',
-    }).as('newsletter');
-
     cy.visit('/', {
       onBeforeLoad: clearAllNudgeStorage,
     });
     cy.get('[data-testid="launch-banner"]')
       .should('be.visible')
-      .and('have.attr', 'href', `${TPU_NEWSLETTER_ORIGIN}${TPU_NEWSLETTER_PATH}`);
+      .and('have.attr', 'href', '/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k/1k&i_prec=fp8');
     cy.get('[data-testid="launch-banner"]').click();
 
-    cy.wait('@newsletter', { timeout: 10000 });
-    cy.origin(TPU_NEWSLETTER_ORIGIN, { args: { path: TPU_NEWSLETTER_PATH } }, ({ path }) => {
-      cy.location('pathname', { timeout: 10000 }).should('eq', path);
-    });
+    cy.location('pathname').should('eq', '/inference');
+    cy.get('.dot-group[data-hw-key^="tpuv7"]').should('have.length.at.least', 1);
 
     // Body click must not write the dismissal key — the banner should still
-    // render on a fresh visit to landing.
+    // render on a fresh visit to landing. Reset the document first so dev
+    // server hot reloads cannot restore the outgoing chart route.
+    cy.visit('about:blank');
     cy.visit('/');
     cy.window().then((win) => {
       expect(win.localStorage.getItem('inferencex-tpuv7-banner-dismissed')).to.eq(null);

--- a/packages/app/src/lib/chart-utils.test.ts
+++ b/packages/app/src/lib/chart-utils.test.ts
@@ -249,6 +249,15 @@ function isNotGreenish(rgb: [number, number, number]): boolean {
 }
 
 describe('generateHighContrastColors', () => {
+  it.each(['light', 'dark'])(
+    'gives TPUv7 a gold high-contrast color alongside Blackwell (%s)',
+    (theme) => {
+      const colors = generateHighContrastColors(['tpuv7_vllm', 'b200_vllm', 'b300_vllm'], theme);
+      expect(colors.tpuv7_vllm).toBe('#F4B400');
+      expect(new Set(Object.values(colors)).size).toBe(3);
+    },
+  );
+
   /** Assert every pair has at least `min` RGB distance. */
   function assertMinDist(colors: Record<string, string>, min: number) {
     const rgbs = Object.values(colors).map(parseRgb);

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -4,7 +4,7 @@
  * They do NOT import Node.js-specific modules (fs, path) or build-time dependencies.
  */
 
-import { resolveFrameworkAlias } from '@semianalysisai/inferencex-constants';
+import { GOOGLE_YELLOW, resolveFrameworkAlias } from '@semianalysisai/inferencex-constants';
 import iwanthue from 'iwanthue';
 
 import type {
@@ -35,6 +35,7 @@ const BANNED_HUE_TEST: Record<Vendor, ((hue: number) => boolean) | null> = {
   nvidia: (hue) => hue >= 320 || hue <= 40, // red/rose/pink zone
   amd: (hue) => hue >= 120 && hue <= 195, // green zone
   teacup: (hue) => hue < 170 || hue > 300, // keep the blue/cyan zone
+  google: (hue) => hue < 55 || hue > 100, // keep gold separate from red, green, and blue
   unknown: null,
 };
 
@@ -49,6 +50,7 @@ const PREFERRED_ZONE: Record<
   nvidia: { hmin: 100, hmax: 195 }, // greens/teals
   amd: { hmin: 20, hmax: 50, cmin: 70, lmin: 50 }, // vivid reds/oranges
   teacup: { hmin: 190, hmax: 280 }, // cyans/blues
+  google: { hmin: 70, hmax: 95 }, // golds
   unknown: null,
 };
 
@@ -118,6 +120,10 @@ export const generateHighContrastColors = (
 
   for (const [vendor, vendorKeys] of groups) {
     const count = vendorKeys.length;
+    if (vendor === 'google' && count === 1) {
+      colors[vendorKeys[0]] = GOOGLE_YELLOW;
+      continue;
+    }
     const isBanned = BANNED_HUE_TEST[vendor] ?? null;
     const preferred = PREFERRED_ZONE[vendor] ?? null;
 

--- a/packages/app/src/lib/dynamic-colors.test.ts
+++ b/packages/app/src/lib/dynamic-colors.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { hsl } from 'd3';
 
-import { VENDOR_OKLCH_ZONES } from '@semianalysisai/inferencex-constants';
+import { VENDOR_OKLCH_ZONES, VENDOR_HSL_ZONES } from '@semianalysisai/inferencex-constants';
 
 import {
   generateHighContrastGpuDateColors,
+  generateGpuDateColors,
   generateVendorColors,
   getVendor,
 } from './dynamic-colors';
@@ -19,6 +21,8 @@ describe('getVendor', () => {
     expect(getVendor('h100_vllm')).toBe('nvidia');
     expect(getVendor('mi300x_sglang')).toBe('amd');
     expect(getVendor('jalapeno_teacup')).toBe('teacup');
+    expect(getVendor('tpuv7')).toBe('google');
+    expect(getVendor('tpuv7_vllm')).toBe('google');
   });
 
   it('classifies keys that lead with a literal vendor token', () => {
@@ -26,6 +30,7 @@ describe('getVendor', () => {
     // registered GPU key (their SKUs, e.g. "h200-dgxc", are not registry keys).
     expect(getVendor('nvidia_h200-dgxc_normal_ep8')).toBe('nvidia');
     expect(getVendor('amd_mi355x-oam_normal_ep8')).toBe('amd');
+    expect(getVendor('google_ironwood_normal_tp8')).toBe('google');
   });
 
   it('falls back to unknown for unclassifiable keys', () => {
@@ -112,5 +117,37 @@ describe('generateHighContrastGpuDateColors', () => {
     const colors = generateHighContrastGpuDateColors({ gpu: 'var(--foreground)' }, 2, 'light');
     expect(colors['0_gpu']).toBe('var(--foreground)');
     expect(colors['1_gpu']).toBe('var(--foreground)');
+  });
+});
+
+describe('TPUv7 vendor colors', () => {
+  it.each(['light', 'dark'] as const)(
+    'keeps Google distinct across normal and historical charts (%s)',
+    (theme) => {
+      const keys = ['tpuv7_vllm', 'b200_vllm', 'b300_vllm', 'mystery_series'];
+      const colors = generateVendorColors(keys, theme);
+      expect(colors.tpuv7_vllm).toBe('#F4B400');
+      expect(colors.tpuv7_vllm).not.toBe(colors.mystery_series);
+      const historical = generateGpuDateColors(keys, 2, theme);
+      const hue = hueOf(historical['0_tpuv7_vllm']);
+      expect(hue).toBeGreaterThan(80);
+      expect(hue).toBeLessThan(90);
+      expect(generateGpuDateColors(keys, 1, theme)['0_tpuv7_vllm']).toBe('#F4B400');
+      expect(hueOf(historical['1_tpuv7_vllm'])).toBe(hue);
+      expect(historical['0_tpuv7_vllm']).not.toBe(historical['1_tpuv7_vllm']);
+    },
+  );
+
+  it('reserves a separate Google HSL band', () => {
+    const hue = hsl('#F4B400').h;
+    expect(
+      VENDOR_HSL_ZONES.google.some(({ start, span }) => hue >= start && hue < start + span),
+    ).toBe(true);
+    for (const [vendor, segments] of Object.entries(VENDOR_HSL_ZONES)) {
+      if (vendor === 'google') continue;
+      for (const segment of segments) {
+        expect(segment.start >= 60 || segment.start + segment.span <= 40).toBe(true);
+      }
+    }
   });
 });

--- a/packages/app/src/lib/dynamic-colors.ts
+++ b/packages/app/src/lib/dynamic-colors.ts
@@ -7,14 +7,18 @@
  * → more perceptual distance between colors → easier to distinguish.
  */
 
-import { GPU_VENDORS, VENDOR_OKLCH_ZONES } from '@semianalysisai/inferencex-constants';
+import {
+  GOOGLE_YELLOW,
+  GPU_VENDORS,
+  VENDOR_OKLCH_ZONES,
+} from '@semianalysisai/inferencex-constants';
 import { getModelSortIndex } from '@/lib/constants';
 
 // ---------------------------------------------------------------------------
 // Vendor detection
 // ---------------------------------------------------------------------------
 
-export type Vendor = 'nvidia' | 'amd' | 'teacup' | 'unknown';
+export type Vendor = 'nvidia' | 'amd' | 'teacup' | 'google' | 'unknown';
 
 /** Determine vendor from a hardware key by looking up GPU_VENDORS. */
 export function getVendor(hwKey: string): Vendor {
@@ -22,11 +26,12 @@ export function getVendor(hwKey: string): Vendor {
   const base = hwKey.split('_')[0];
   // Keys whose dataset carries an explicit vendor (e.g. CollectiveX series) lead
   // with the vendor name itself rather than a registered GPU key.
-  if (base === 'nvidia' || base === 'amd' || base === 'teacup') return base;
+  if (base === 'nvidia' || base === 'amd' || base === 'teacup' || base === 'google') return base;
   const vendor = GPU_VENDORS[base];
   if (vendor === 'NVIDIA') return 'nvidia';
   if (vendor === 'AMD') return 'amd';
   if (vendor === 'Teacup') return 'teacup';
+  if (vendor === 'Google') return 'google';
   return 'unknown';
 }
 
@@ -65,7 +70,7 @@ function pickLightness(index: number, count: number, theme: 'light' | 'dark'): n
  *
  * @param activeKeys - The hardware keys that are currently checked / visible.
  * @param theme      - 'light' or 'dark'.
- * @returns Map of hwKey → `oklch(L C H)` string.
+ * @returns Map of hwKey → CSS color; a single Google series uses its exact brand hex.
  */
 export function generateVendorColors(
   activeKeys: string[],
@@ -93,6 +98,10 @@ export function generateVendorColors(
     const zone = VENDOR_OKLCH_ZONES[vendor];
     const chroma = zone.chroma[theme];
     const count = keys.length;
+    if (vendor === 'google' && count === 1) {
+      result[keys[0]] = GOOGLE_YELLOW;
+      continue;
+    }
 
     for (let i = 0; i < count; i++) {
       // Evenly space hues, with padding at the edges so the first and last
@@ -148,19 +157,24 @@ export function generateGpuDateColors(
     const zone = VENDOR_OKLCH_ZONES[vendor];
     const chroma = zone.chroma[theme];
     const gpuCount = keys.length;
+    const googleBase = vendor === 'google' && gpuCount === 1 ? hexToOklch(GOOGLE_YELLOW) : null;
 
     for (let gi = 0; gi < gpuCount; gi++) {
       const hue =
-        gpuCount <= 1
+        googleBase?.[2] ??
+        (gpuCount <= 1
           ? (zone.start + zone.end) / 2
-          : zone.start + ((gi + 0.5) / gpuCount) * (zone.end - zone.start);
+          : zone.start + ((gi + 0.5) / gpuCount) * (zone.end - zone.start));
 
       for (let di = 0; di < dateCount; di++) {
         // Oldest date = lightest, newest = darkest
         const lightness =
           dateCount <= 1 ? (lMin + lMax) / 2 : lMax - (di / (dateCount - 1)) * (lMax - lMin);
         const compositeKey = `${di}_${keys[gi]}`;
-        result[compositeKey] = `oklch(${lightness.toFixed(3)} ${chroma} ${hue.toFixed(1)})`;
+        result[compositeKey] =
+          googleBase && dateCount === 1
+            ? GOOGLE_YELLOW
+            : `oklch(${lightness.toFixed(3)} ${googleBase?.[1] ?? chroma} ${hue.toFixed(1)})`;
       }
     }
   }

--- a/packages/app/src/lib/nudges/registry.test.ts
+++ b/packages/app/src/lib/nudges/registry.test.ts
@@ -108,7 +108,7 @@ describe('NUDGE_REGISTRY integrity', () => {
     // see this one; cypress specs seed/clear this key and must stay in sync.
     expect(banner.storageKey).toBe('inferencex-tpuv7-banner-dismissed');
     expect(banner.content.href).toBe(
-      'https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam',
+      '/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k/1k&i_prec=fp8',
     );
     expect(banner.analytics).toEqual({
       shown: 'inference_tpuv7_banner_shown',
@@ -116,12 +116,12 @@ describe('NUDGE_REGISTRY integrity', () => {
       action: 'inference_tpuv7_banner_clicked',
       properties: {
         banner_id: 'tpuv7-inference',
-        destination: 'newsletter',
+        destination: 'inference',
       },
     });
-    // External destination: no locale prefix even from the Chinese tree.
+    // Clicks preserve the Chinese locale as well as the TPU workload filters.
     banner.content.onLinkClick?.();
-    expect(location.href).toBe('https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam');
+    expect(location.href).toBe('/zh/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k/1k&i_prec=fp8');
   });
 
   it('gives every coach mark an anchor to point at', () => {

--- a/packages/app/src/lib/nudges/registry.tsx
+++ b/packages/app/src/lib/nudges/registry.tsx
@@ -52,7 +52,7 @@ function localizedNudgeHref(enPath: string): string {
   return localePath(enPath, isZhPathname(window.location.pathname) ? 'zh' : 'en');
 }
 
-const TPU_NEWSLETTER_URL = 'https://newsletter.semianalysis.com/p/tpu-inferencex-full-steam';
+const TPU_RESULTS_URL = '/inference?g_model=Qwen-3.5-397B-A17B&i_seq=8k/1k&i_prec=fp8';
 
 export const TELEMETRY_TUTORIAL_STORAGE_KEY = 'inferencex-agentx-telemetry-tutorial-dismissed';
 
@@ -340,13 +340,12 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       testId: 'launch-banner',
       badge: 'New',
       badgeZh: '最新',
-      // External destination: the newsletter write-up rather than a dashboard
-      // route, so no locale prefixing applies.
-      href: TPU_NEWSLETTER_URL,
+      // Select the model, workload, and precision used by the TPUv7 snapshot.
+      href: TPU_RESULTS_URL,
       linkLabel: 'View results',
       linkLabelZh: '查看结果',
       onLinkClick: () => {
-        window.location.href = TPU_NEWSLETTER_URL;
+        window.location.href = localizedNudgeHref(TPU_RESULTS_URL);
       },
     },
     analytics: {
@@ -355,7 +354,7 @@ export const NUDGE_REGISTRY: NudgeDefinition[] = [
       action: 'inference_tpuv7_banner_clicked',
       properties: {
         banner_id: 'tpuv7-inference',
-        destination: 'newsletter',
+        destination: 'inference',
       },
     },
   },

--- a/packages/app/src/lib/supplemental-benchmarks.test.ts
+++ b/packages/app/src/lib/supplemental-benchmarks.test.ts
@@ -10,8 +10,8 @@ import {
 } from './supplemental-benchmarks';
 
 describe('supplemental benchmark snapshots', () => {
-  it('ships every supplied Jalapeño and July VR200 point', () => {
-    expect(SUPPLEMENTAL_BENCHMARK_ROWS).toHaveLength(50);
+  it('ships every supplied Jalapeño, July VR200, and TPUv7 point', () => {
+    expect(SUPPLEMENTAL_BENCHMARK_ROWS).toHaveLength(57);
     expect(SUPPLEMENTAL_BENCHMARK_ROWS.filter((row) => row.hardware === 'jalapeno')).toHaveLength(
       36,
     );
@@ -27,6 +27,40 @@ describe('supplemental benchmark snapshots', () => {
         'https://www.coreweave.com/blog/nvidia-vera-rubin-nvl72-on-coreweave-10x-more-tokens-per-megawatt-than-blackwell',
       ]),
     );
+  });
+
+  it('keeps TPUv7 FP8 rows and availability separate from legacy FP4 snapshots', () => {
+    const rows = withSupplementalBenchmarks([], { model: 'Qwen-3.5-397B-A17B' }).filter(
+      (row) => row.hardware === 'tpuv7',
+    );
+    expect(rows.map((row) => row.conc)).toEqual([4, 8, 16, 32, 64, 128, 256]);
+    for (const row of rows) {
+      expect(row).toMatchObject({
+        precision: 'fp8',
+        isl: 8192,
+        osl: 1024,
+        date: '2026-08-26',
+        framework: 'vllm',
+      });
+    }
+    expect(rows[0].metrics.output_tput_per_gpu).toBeCloseTo(123.001518);
+    expect(withSupplementalAvailability([]).find((row) => row.hardware === 'tpuv7')).toMatchObject({
+      model: 'qwen3.5',
+      precision: 'fp8',
+      isl: 8192,
+      osl: 1024,
+    });
+    expect(
+      SUPPLEMENTAL_BENCHMARK_ROWS.filter((row) => row.hardware !== 'tpuv7').every(
+        (row) => row.precision === 'fp4',
+      ),
+    ).toBe(true);
+    const history = withSupplementalBenchmarkHistory([], {
+      model: 'qwen3.5',
+      isl: 8192,
+      osl: 1024,
+    });
+    expect(history.filter((row) => row.hardware === 'tpuv7')).toHaveLength(7);
   });
 
   it('resolves the newest snapshot independently per hardware curve', () => {
@@ -54,8 +88,8 @@ describe('supplemental benchmark snapshots', () => {
     );
 
     const availability = withSupplementalAvailability([]);
-    expect(availability).toHaveLength(5);
-    expect(withSupplementalAvailability(availability)).toHaveLength(5);
+    expect(availability).toHaveLength(6);
+    expect(withSupplementalAvailability(availability)).toHaveLength(6);
   });
 
   it('limits only the July VR200 snapshot to output-token metrics', () => {

--- a/packages/app/src/lib/supplemental-benchmarks.ts
+++ b/packages/app/src/lib/supplemental-benchmarks.ts
@@ -28,6 +28,8 @@ interface SupplementalDataset {
   points: readonly PointTuple[];
   /** Omitted means the snapshot is valid for every token metric. */
   supportedTokenMetrics?: readonly TokenMetricType[];
+  /** Defaults to 'fp4' when omitted, matching every pre-existing snapshot. */
+  precision?: string;
 }
 
 const dsr1August17: readonly PointTuple[] = [
@@ -203,6 +205,41 @@ const vrJuly: readonly PointTuple[] = [
   [72, 1, 72, 400, 115.5, 183.535, 0, 400, 0, 0],
 ];
 
+// Single 8-chip TPU v7 (Ironwood) node, Qwen3.5-397B-A17B-FP8 on vLLM.
+// Lower concurrencies (4-64) ran TP8/DP1; the top two (128, 256) ran TP1/DP8
+// internally — this tuple format only tracks a single "tp" slot, so all rows
+// report tp=8 to reflect the constant 8-chip node footprint used throughout.
+const tpuv7Qwen35August26: readonly PointTuple[] = [
+  [
+    8, 1, 8, 4, 1106.0144106246432, 123.00151802118774, 983.0128926034555, 131.64888705609664,
+    0.26892674050759524, 7.2218290029559284,
+  ],
+  [
+    8, 1, 8, 8, 1760.9681874834419, 197.90875854244936, 1563.0594289409926, 103.64793571613815,
+    0.268642965471372, 9.27846261439845,
+  ],
+  [
+    8, 1, 8, 16, 2456.9772869226604, 272.17218266716407, 2184.805104255496, 71.32828540050576,
+    0.26853204250801355, 13.109142028028145,
+  ],
+  [
+    8, 1, 8, 32, 3350.562835186429, 374.5752548238647, 2975.987580362564, 48.44853301283267,
+    0.28178216295782477, 19.436007942887954,
+  ],
+  [
+    8, 1, 8, 64, 4334.590748533495, 480.7467788137091, 3853.8439697197855, 30.776144689201782,
+    0.45816936204209924, 30.521604063455015,
+  ],
+  [
+    8, 1, 8, 128, 6469.928720561886, 716.3928663552701, 5753.535854206615, 24.48557067862354,
+    2.732123397407122, 39.73736083658878,
+  ],
+  [
+    8, 1, 8, 256, 9363.824997632008, 1040.5862153469675, 8323.23878228504, 17.90952197535618,
+    3.6078880773857236, 54.9554339585593,
+  ],
+];
+
 const DATASETS: readonly SupplementalDataset[] = [
   {
     id: 'jalapeno-dsr1-2026-08-17',
@@ -241,6 +278,16 @@ const DATASETS: readonly SupplementalDataset[] = [
     points: kimiAugust22,
   },
   {
+    id: 'tpuv7-qwen3.5-2026-08-26',
+    model: 'qwen3.5',
+    modelAliases: ['qwen3.5', 'Qwen-3.5-397B-A17B'],
+    date: '2026-08-26',
+    hardware: 'tpuv7',
+    framework: 'vllm',
+    precision: 'fp8',
+    points: tpuv7Qwen35August26,
+  },
+  {
     id: 'vr200-dsr1-2026-07-01',
     model: 'dsr1',
     modelAliases: ['dsr1', 'DeepSeek-R1-0528'],
@@ -268,7 +315,7 @@ function toBenchmarkRow(dataset: SupplementalDataset, point: PointTuple): Benchm
     hardware: dataset.hardware,
     framework: dataset.framework,
     model: dataset.model,
-    precision: 'fp4',
+    precision: dataset.precision ?? 'fp4',
     spec_method: 'none',
     disagg: false,
     is_multinode: chips > 8,
@@ -409,7 +456,7 @@ export function withSupplementalAvailability(rows: AvailabilityRow[]): Availabil
     model: dataset.model,
     isl: 8192,
     osl: 1024,
-    precision: 'fp4',
+    precision: dataset.precision ?? 'fp4',
     hardware: dataset.hardware,
     framework: dataset.framework,
     spec_method: 'none',

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -147,6 +147,16 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     costh: 1.47,
     costr: 1.79,
   },
+  tpuv7: {
+    vendor: 'Google',
+    arch: 'Ironwood',
+    label: 'TPU7x',
+    sort: 11,
+    tdp: 980,
+    power: 1.207,
+    costh: 1.21,
+    costr: 1.21,
+  },
 };
 
 /** Canonical set of GPU key strings used across all packages. */

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -174,6 +174,9 @@ export const GPU_VENDORS: Record<string, string> = Object.fromEntries(
 // zones to both maps below (OKLch for normal mode, HSL for high-contrast).
 // ---------------------------------------------------------------------------
 
+/** Google yellow, used unchanged for a single Google hardware series. */
+export const GOOGLE_YELLOW = '#F4B400';
+
 /**
  * OKLch hue zones for normal-mode vendor-aware colors.
  * Narrow, precise bands for assigning brand-matching color shades.
@@ -181,9 +184,13 @@ export const GPU_VENDORS: Record<string, string> = Object.fromEntries(
  * Layout (approximate):
  *   0-12    (gap)
  *   12-42   AMD reds/oranges
- *   42-120  (gap)
+ *   42-80   (gap)
+ *   80-105  Google golds
+ *   105-120 (gap)
  *   120-170 NVIDIA greens
- *   170-275 (gap)
+ *   170-235 (gap)
+ *   235-270 Teacup blues
+ *   270-275 (gap)
  *   275-330 unknown / fallback (purples)
  *   330-360 (gap)
  */
@@ -194,6 +201,7 @@ export const VENDOR_OKLCH_ZONES: Record<
   amd: { start: 12, end: 42, chroma: { light: 0.18, dark: 0.22 } },
   nvidia: { start: 120, end: 170, chroma: { light: 0.15, dark: 0.15 } },
   teacup: { start: 235, end: 270, chroma: { light: 0.14, dark: 0.16 } },
+  google: { start: 80, end: 105, chroma: { light: 0.14, dark: 0.16 } },
   unknown: { start: 275, end: 330, chroma: { light: 0.14, dark: 0.16 } },
 };
 
@@ -206,8 +214,9 @@ export const VENDOR_OKLCH_ZONES: Record<
  * expands symmetrically — these are preferred zones, not hard constraints.
  *
  * Layout (360° wheel):
+ *   Google:  40–60 (20°) — golds
  *   NVIDIA:  60–195  (135°) — greens through cyans
- *   AMD:     300–360 + 0–60  (120°, wraps) — magentas through oranges
+ *   AMD:     300–360 + 0–40  (100°, wraps) — magentas through oranges
  *   Teacup:  195–240 (45°) — cyan/blues
  *   unknown: 240–300 (60°) — blues/purples
  *
@@ -219,7 +228,8 @@ export const VENDOR_HSL_ZONES: Record<string, { start: number; span: number }[]>
   teacup: [{ start: 195, span: 45 }],
   amd: [
     { start: 300, span: 60 },
-    { start: 0, span: 60 },
+    { start: 0, span: 40 },
   ],
+  google: [{ start: 40, span: 20 }],
   unknown: [{ start: 240, span: 60 }],
 };


### PR DESCRIPTION
## Summary

Register Google TPUv7 (Ironwood) with its TCO/power values and a seven-point Qwen3.5 FP8 benchmark sweep dated 2026-08-26. Supplemental datasets support an explicit precision while existing snapshots retain FP4.

The TPUv7 landing banner now opens the inference results graph with Qwen3.5, FP8, and 8k input / 1k output selected. English and Chinese links preserve their locale, including normal clicks and opening the link in a new tab. Click analytics now identify the inference destination.

Update the stale snapshot/availability test counts and add regression coverage for TPUv7 precision, throughput, history, availability, and banner navigation. The measured-power Firefox spec ignores only the exact browser ResizeObserver delivery notification; application exceptions and chart assertions remain active.

Google hardware is recognized throughout vendor color grouping. TPUv7 uses Google yellow `#F4B400` in normal and high-contrast views, with the same yellow hue across historical dates. The older nudge-system integration spec now checks the results destination and confirms that clicking the banner does not persist dismissal.

## Validation

- All workspace unit tests passed (5,025 app tests).
- Typecheck, lint, formatting, and typography checks passed.
- Updated nudge-system spec: 20/20 passed in Firefox, including results navigation and dismissal persistence.
- Firefox navigation and measured-power regression specs: 17/17 passed, including rendered TPUv7 points after both English and Chinese banner clicks.
- Local smoke suite: component tests passed; integration tests were 111/113. Two evaluation-chart assertions failed because `#evaluation-chart` was absent; the focused evaluation rerun reproduced those failures.

## 中文说明

新增 Google TPUv7（Ironwood）的 TCO（总拥有成本）与功耗配置，以及 2026-08-26 的 Qwen3.5 FP8 基准测试数据，共七个并发点。补充数据集可显式指定精度，已有快照仍默认为 FP4。

首页 TPUv7 横幅现在直接打开推理结果图表，预选 Qwen3.5、FP8 和 8k 输入 / 1k 输出。英文与中文页面均保留当前语言，普通点击和在新标签页打开均指向对应结果页；点击事件也记录新的推理页面目标。

修正因新增数据而失效的快照与可用性数量断言，并补充 TPUv7 精度、吞吐量、历史数据、可用性及横幅跳转的回归测试。实测功耗的 Firefox 测试仅忽略浏览器特定的 ResizeObserver 通知延迟消息，仍检查应用异常和图表行为。

Google 硬件现在能在厂商配色逻辑中正确识别。TPUv7 在常规和高对比度视图中使用 Google 黄色 `#F4B400`，历史日期对比保留相同黄色色相。旧的 nudge-system 集成测试已更新为验证结果页跳转，并继续确认点击横幅不会持久化关闭状态。

验证：所有工作区单元测试通过（其中应用测试 5,025 项）；类型检查、lint、格式与排版检查通过。更新后的 nudge-system spec 在 Firefox 中 20 项全部通过，包含结果页跳转与关闭状态持久化检查。Firefox 导航与实测功耗回归测试 17 项全部通过，包含英文与中文横幅点击后 TPUv7 数据点的实际渲染。本地 smoke suite 的组件测试通过；集成测试通过 111/113 项。两项评估图表断言因 `#evaluation-chart` 缺失而失败，单独重跑该 spec 仍可复现。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing navigation and chart coloring plus bundled benchmark data; no auth or server API contract changes beyond supplemental merge behavior.
> 
> **Overview**
> Adds **Google TPUv7 (Ironwood)** to the hardware registry with TCO/power metadata, **Google gold** chart styling (`#F4B400`), and a **seven-point Qwen3.5 FP8** supplemental benchmark sweep (2026-08-26). Supplemental snapshots can set **`precision`** explicitly; older rows still default to **fp4**.
> 
> The **TPUv7 launch banner** no longer goes to the newsletter—it opens **`/inference`** with Qwen-3.5, FP8, and 8k/1k preselected. **`localizedNudgeHref`** keeps **en/zh** on click; analytics **`destination`** is **`inference`**.
> 
> **Cypress** covers EN/zh banner → chart with TPUv7 dots, updates nudge banner expectations, enables **test isolation** on landing nudge suites, and in the measured-power spec ignores only Firefox’s **ResizeObserver** loop message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1787b538e7de1eb2e0483770b14fa7879de4d353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
