### PR TITLE
Fix July 2026 3-year-commit rental rates in HW_REGISTRY / 修正 HW_REGISTRY 中 2026 年 7 月 3 年承诺租赁价格

### DIFF
--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -230,15 +230,15 @@ describe('getHardwareConfig', () => {
 
   it('uses the July 2026 TCO rates for modeled datacenter GPUs', () => {
     const expectedRates = {
-      h100: [1.17, 1.78],
-      h200: [1.22, 2.05],
-      b200: [1.73, 2.6],
-      b300: [2.26, 3],
-      gb200: [1.86, 2.6],
-      gb300: [2.31, 3.3],
+      h100: [1.17, 2],
+      h200: [1.22, 2.9],
+      b200: [1.73, 3.7],
+      b300: [2.26, 4.25],
+      gb200: [1.86, 4],
+      gb300: [2.31, 5],
       mi300x: [0.95, 1.3],
       mi325x: [1.1, 1.6],
-      mi355x: [1.5, 2.1],
+      mi355x: [1.5, 2.9],
     } as const;
 
     for (const [gpu, [costh, costr]] of Object.entries(expectedRates)) {
@@ -256,7 +256,7 @@ describe('getGpuSpecs', () => {
     expect(specs.tdp).toBe(700);
     expect(specs.power).toBe(1.37);
     expect(specs.costh).toBe(1.17);
-    expect(specs.costr).toBe(1.78);
+    expect(specs.costr).toBe(2);
   });
 
   it('extracts base from compound key (e.g. h100_vllm)', () => {

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -211,13 +211,13 @@ describe('overview engine scope and scenario selection', () => {
   });
 
   it('prices from HW_REGISTRY costh — not the retail costr tier', () => {
-    // b200: costh 1.73 vs costr 2.60 — the two tiers disagree, so a costr
+    // b200: costh 1.73 vs costr 3.70 — the two tiers disagree, so a costr
     // regression cannot pass this assertion.
     expect(overviewCostPerMtok('b200', 7200)).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / (7200 * 3600),
       9,
     );
-    expect(overviewCostPerMtok('b200', 7200)).not.toBeCloseTo(2_600_000 / (7200 * 3600), 9);
+    expect(overviewCostPerMtok('b200', 7200)).not.toBeCloseTo(3_700_000 / (7200 * 3600), 9);
     expect(overviewCostPerMtok('mi355x', 9000)).toBeCloseTo(
       (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) / (9000 * 3600),
       9,

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -40,7 +40,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 700,
     power: 1.37,
     costh: 1.17,
-    costr: 1.78,
+    costr: 2,
   },
   h200: {
     vendor: 'NVIDIA',
@@ -50,7 +50,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 700,
     power: 1.37,
     costh: 1.22,
-    costr: 2.05,
+    costr: 2.9,
   },
   b200: {
     vendor: 'NVIDIA',
@@ -60,7 +60,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1000,
     power: 1.71,
     costh: 1.73,
-    costr: 2.6,
+    costr: 3.7,
   },
   b300: {
     vendor: 'NVIDIA',
@@ -70,7 +70,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1200,
     power: 1.9,
     costh: 2.26,
-    costr: 3,
+    costr: 4.25,
   },
   gb200: {
     vendor: 'NVIDIA',
@@ -80,7 +80,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1200,
     power: 1.87,
     costh: 1.86,
-    costr: 2.6,
+    costr: 4,
   },
   gb300: {
     vendor: 'NVIDIA',
@@ -90,7 +90,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1400,
     power: 2.12,
     costh: 2.31,
-    costr: 3.3,
+    costr: 5,
   },
   mi300x: {
     vendor: 'AMD',
@@ -120,7 +120,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1400,
     power: 2.09,
     costh: 1.5,
-    costr: 2.1,
+    costr: 2.9,
   },
   // NVIDIA RTX PRO 6000 Blackwell Server Edition (GB202, PCIe Gen5, 96 GB GDDR7).
   // A workstation-class PCIe card benchmarked in 8× TP configs (no NVLink/NVSwitch);


### PR DESCRIPTION
## Summary

#659 updated the owning-at-large-hyperscaler-volume tier (`costh`) to the July 2026 TCO model but did not update the **Rent - 3 Year Commit** tier (`costr`). This PR corrects `costr` in `packages/constants/src/gpu-keys.ts` to the July 2026 rental prices (per the TCO model / #gta6-research-inference thread):

| GPU | Old `costr` | New `costr` ($/GPU/hr) |
| --- | --- | --- |
| H100 | 1.78 | 2.00 |
| H200 | 2.05 | 2.90 |
| B200 | 2.60 | 3.70 |
| GB200 NVL72 | 2.60 | 4.00 |
| B300 | 3.00 | 4.25 |
| GB300 NVL72 | 3.30 | 5.00 |
| MI355X | 2.10 | 2.90 |

`costh`, MI300X, MI325X, RTX PRO 6000 and the TPU entries are unchanged.

## Tests

- `constants.test.ts`: re-pinned `expectedRates` and the `getGpuSpecs('h100')` costr assertion.
- `overview-data.test.ts`: updated the costr regression guard comment/value (2.60 → 3.70) so the overview still asserts it prices from `costh`, not `costr`.
- `vitest run` on `constants`, `overview-data`, `gpu-specs`, `chip-pages` suites: 230 passed.

## 中文说明

#659 将 hyperscaler 档位（`costh`）更新到 2026 年 7 月 TCO 模型，但「租赁 - 3 年承诺」档位（`costr`）未同步更新。本 PR 将 `packages/constants/src/gpu-keys.ts` 中 H100、H200、B200、GB200 NVL72、B300、GB300 NVL72 与 MI355X 的 `costr` 修正为 2026 年 7 月租赁价格（见上表）。`costh`、MI300X、MI325X、RTX PRO 6000 与 TPU 条目保持不变。

测试：同步更新 `constants.test.ts` 中的 `expectedRates` 与 `getGpuSpecs('h100')` 断言，并更新 `overview-data.test.ts` 中 costr 回归守卫的数值（2.60 → 3.70）；相关 vitest 套件 230 个用例全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Published pricing constants and test expectations only; overview cost math still uses costh, with rental-tier impact limited to calculator/UI paths that select costr.
> 
> **Overview**
> Aligns **`costr`** (3-year commit rental $/GPU/hr) in `HW_REGISTRY` with the July 2026 TCO model, after **`costh`** was updated in #659 without the rental tier. **H100, H200, B200, B300, GB200, GB300, and MI355X** get higher `costr` values; **`costh`** and other GPUs are unchanged.
> 
> Tests re-pin expected `[costh, costr]` pairs in `constants.test.ts` and bump the overview regression guard so **`overviewCostPerMtok`** still proves pricing uses **`costh`**, not the new rental numbers (B200 example: 3.70 vs 1.73).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea9c982f8fcdd37ac9d726556b022ed42504d680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->