### PR TITLE
feat(inference): default Best per SKU off for Qwen3.5 8K/1K and Agentic

### DIFF
--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -63,6 +63,7 @@ import { getHardwareConfig, getModelSortIndex, isKnownGpu } from '@/lib/constant
 import { frameworkFamily } from '@/lib/framework-family';
 import {
   getOpenRouterModelId,
+  isBestPerSkuDefaultOff,
   MODEL_PREFIX_MAPPING,
   Sequence,
   sequenceKind,
@@ -544,9 +545,17 @@ export function InferenceProvider({
   });
 
   const [hideNonOptimal, setHideNonOptimal] = useState(() => getUrlParam('i_optimal') !== '0');
-  const [bestPerSku, setBestPerSku] = useState(
-    () => activeTab === 'inference' && getUrlParam('i_best') !== '0',
-  );
+  // `i_best` records an explicit reader choice ('0' off, '1' on). Absent, the
+  // mode follows the model + scenario default, so charts that open with every
+  // configuration (MODEL_BEST_PER_SKU_DEFAULT_OFF) need no URL flag and the
+  // default can change later without breaking share links.
+  const [bestPerSkuChoice, setBestPerSku] = useState<boolean | null>(() => {
+    if (activeTab !== 'inference') return false;
+    const raw = getUrlParam('i_best');
+    return raw === '0' ? false : raw === '1' ? true : null;
+  });
+  const bestPerSkuDefault = !isBestPerSkuDefaultOff(selectedModel, effectiveSequence);
+  const bestPerSku = bestPerSkuChoice ?? bestPerSkuDefault;
   const labelScenarioKind = sequenceKind(effectiveSequence);
   const initialLabelState = useMemo(
     () =>
@@ -1533,7 +1542,12 @@ export function InferenceProvider({
       i_dstart: selectedDateRange.startDate,
       i_dend: selectedDateRange.endDate,
       i_optimal: hideNonOptimal ? '' : '0',
-      i_best: bestPerSku ? '' : '0',
+      i_best:
+        bestPerSkuChoice === null || bestPerSkuChoice === bestPerSkuDefault
+          ? ''
+          : bestPerSkuChoice
+            ? '1'
+            : '0',
       i_label: serializedLabelState.i_label,
       i_hc: highContrast ? '1' : '',
       i_log: logScale ? '1' : '',
@@ -1564,7 +1578,8 @@ export function InferenceProvider({
       selectedDates,
       selectedDateRange,
       hideNonOptimal,
-      bestPerSku,
+      bestPerSkuChoice,
+      bestPerSkuDefault,
       showPointLabels,
       highContrast,
       logScale,

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -19,6 +19,7 @@ import {
   isSequenceDeprecated,
   isSequenceDeprecatedForModel,
   getSequenceCategoryForModel,
+  isBestPerSkuDefaultOff,
   Model,
   Sequence,
   Precision,
@@ -258,6 +259,27 @@ describe('isSequenceDeprecatedForModel / getSequenceCategoryForModel', () => {
   it('leaves MiniMax M3 agentic traces active', () => {
     expect(isSequenceDeprecatedForModel(Model.MiniMax_M3, Sequence.AgenticTraces)).toBe(false);
     expect(getSequenceCategoryForModel(Sequence.AgenticTraces, Model.MiniMax_M3)).toBe('default');
+  });
+});
+
+// ===========================================================================
+// per-model Best per SKU default
+// ===========================================================================
+describe('isBestPerSkuDefaultOff', () => {
+  it('opens Qwen3.5 8K/1K and agentic charts with every configuration', () => {
+    expect(isBestPerSkuDefaultOff(Model.Qwen3_5, Sequence.EightK_OneK)).toBe(true);
+    expect(isBestPerSkuDefaultOff(Model.Qwen3_5, Sequence.AgenticTraces)).toBe(true);
+  });
+
+  it('keeps Best per SKU on for other Qwen3.5 scenarios and other models', () => {
+    expect(isBestPerSkuDefaultOff(Model.Qwen3_5, Sequence.OneK_OneK)).toBe(false);
+    expect(isBestPerSkuDefaultOff(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK)).toBe(false);
+    expect(isBestPerSkuDefaultOff(Model.Qwen3_8_Flash_Next, Sequence.AgenticTraces)).toBe(false);
+  });
+
+  it('treats a missing model or scenario as the global default', () => {
+    expect(isBestPerSkuDefaultOff(null, Sequence.EightK_OneK)).toBe(false);
+    expect(isBestPerSkuDefaultOff(Model.Qwen3_5, undefined)).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -530,6 +530,27 @@ export function getSequenceCategoryForModel(sequence: Sequence, model?: Model | 
   return getSequenceCategory(sequence);
 }
 
+/**
+ * Model + scenario pairs where Best per SKU starts switched off. The Quick
+ * Filters toggle stays available and an explicit `i_best` URL value still wins;
+ * only the default for readers who have not chosen changes, so these charts
+ * open with every configuration visible.
+ *
+ * Qwen3.5 397B: both the 8K/1K sweep and Agentic coding open with all configs.
+ */
+const MODEL_BEST_PER_SKU_DEFAULT_OFF: Partial<Record<Model, ReadonlySet<Sequence>>> = {
+  [Model.Qwen3_5]: new Set([Sequence.EightK_OneK, Sequence.AgenticTraces]),
+};
+
+/** Whether Best per SKU defaults to off for this model and scenario. */
+export function isBestPerSkuDefaultOff(
+  model: Model | null | undefined,
+  sequence: Sequence | null | undefined,
+): boolean {
+  if (!model || !sequence) return false;
+  return MODEL_BEST_PER_SKU_DEFAULT_OFF[model]?.has(sequence) ?? false;
+}
+
 export function getSequenceLabel(sequence: Sequence, locale: 'en' | 'zh' = 'en'): string {
   const config = SEQUENCE_CONFIG[sequence];
   if (!config) return sequence;


### PR DESCRIPTION
## Summary

Best per SKU now starts switched off on the Qwen3.5 397B charts for the 8K/1K sweep and Agentic coding. Both open with every configuration visible. The Quick Filters toggle stays available, so readers can still turn the mode on.

## Changes

- `data-mappings.ts`: new `MODEL_BEST_PER_SKU_DEFAULT_OFF` table and `isBestPerSkuDefaultOff(model, sequence)`, following the shape of the per-model scenario retirement table. Qwen3.5 lists `8k/1k` and `agentic-traces`.
- `InferenceContext.tsx`: `i_best` now records an explicit reader choice only (`0` off, `1` on). When absent, the mode follows the model + scenario default. The URL flag is omitted whenever the choice matches the current default, so the new default needs no URL parameter and old `i_best=0` share links behave as before.
- Unit tests for the new helper.

## Behavior

| Chart | Before | After |
| --- | --- | --- |
| Qwen3.5 8K/1K | Best per SKU on | off (all configs shown) |
| Qwen3.5 Agentic | Best per SKU on | off (all configs shown) |
| Qwen3.5 with `i_best=1` | on | on |
| Every other model/scenario | on | on (unchanged) |
| Existing `i_best=0` links | off | off (unchanged) |

## Verification

- `bun run typecheck`, `bun run lint`, `bun run fmt`, `bun run check:typography` pass.
- `data-mappings.test.ts` and `url-state.test.ts` pass (130 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart display defaults and URL serialization for one filter; no auth, data, or API changes. Explicit `i_best` URLs and manual toggles still override defaults.
> 
> **Overview**
> **Best per SKU** now defaults **off** for **Qwen3.5 397B** on the **8K/1K** and **Agentic** scenarios so those charts open with every chip configuration visible. Other models and Qwen3.5 scenarios still default to on. The Quick Filters toggle is unchanged.
> 
> A new per-model/scenario table in `data-mappings` (`isBestPerSkuDefaultOff`) drives that default, similar to per-model scenario retirement.
> 
> **URL behavior (`i_best`)** is refactored: the param stores an **explicit reader choice** (`0` / `1`) only. When it is missing, the effective mode follows the model+scenario default. The flag is **omitted from share URLs** when the current choice matches that default, so Qwen3.5 links stay short and defaults can evolve without breaking old `i_best=0` links that meant “show all configs.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f676f7ea99680506b7c7170717058f7324be7ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->