### PR TITLE
feat: locked rental tiers with AI Cloud TCO Model dialog in y-axis and Cost Provider selectors

### DIFF
--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -77,6 +77,28 @@ describe('Inference ChartControls', () => {
     }
   });
 
+  it('lists locked rental tiers under each cost group and opens the TCO model dialog', () => {
+    cy.get('[data-testid="yaxis-metric-selector"]').click('right');
+    cy.contains('Cost per Million Total Tokens')
+      .closest('[role="rowgroup"]')
+      .within(() => {
+        cy.get('[data-testid="locked-tier-badge"]').should('have.length', 5);
+        cy.get('[data-testid="yaxis-locked-rent_1_year-costr"]')
+          .should('contain.text', 'Cost per Million Total Tokens (Rent - 1 Year Commit)')
+          .scrollIntoView()
+          .click();
+      });
+    cy.get('[data-testid="tco-model-dialog"]')
+      .should('be.visible')
+      .and('contain.text', 'Rent - 1 Year Commit');
+    cy.get('[data-testid="tco-model-dialog-link"]')
+      .should('have.attr', 'href', 'https://semianalysis.com/ai-cloud-tco-model/')
+      .and('have.attr', 'target', '_blank');
+    cy.get('@setSelectedYAxisMetric').should('not.have.been.called');
+    cy.contains('button', 'Not now').click();
+    cy.get('[data-testid="tco-model-dialog"]').should('not.exist');
+  });
+
   it('hides the GPU comparison section when no GPUs are selected', () => {
     // Default mock: selectedGPUs = [] — GPU date range pickers should not render
     cy.contains('Comparison Date Range').should('not.exist');

--- a/packages/app/cypress/e2e/throughput-calculator.cy.ts
+++ b/packages/app/cypress/e2e/throughput-calculator.cy.ts
@@ -373,14 +373,41 @@ describe('TCO Calculator', () => {
       cy.get('#calc-sequence').should('be.focused');
     });
 
-    it('cost provider selector appears and has both options', () => {
+    it('cost provider selector lists both published tiers and five locked rental tiers', () => {
       cy.get('[data-testid="calculator-controls"]').within(() => {
         cy.get('#calc-cost').click();
       });
-      cy.get('[role="option"]').should('have.length', 2);
+      cy.get('[role="option"]').should('have.length', 7);
       cy.get('[role="option"]').eq(0).should('contain.text', 'Owning at Large Hyperscaler Volume');
       cy.get('[role="option"]').eq(1).should('contain.text', 'Rent - 3 Year Commit');
+      cy.get('[role="option"]').eq(2).should('contain.text', 'Rent - On Demand');
+      cy.get('[role="option"]').eq(3).should('contain.text', 'Rent - 1 Month Commit');
+      cy.get('[role="option"]').eq(4).should('contain.text', 'Rent - 6 Month Commit');
+      cy.get('[role="option"]').eq(5).should('contain.text', 'Rent - 1 Year Commit');
+      cy.get('[role="option"]').eq(6).should('contain.text', 'Rent - 2 Year Commit');
+      cy.get('[role="option"] [data-testid="locked-tier-badge"]').should('have.length', 5);
       cy.get('body').type('{esc}');
+    });
+
+    it('picking a locked rental tier opens the TCO model dialog without changing the provider', () => {
+      cy.get('#calc-cost').invoke('text').as('providerBefore');
+      cy.get('[data-testid="calculator-controls"]').within(() => {
+        cy.get('#calc-cost').click();
+      });
+      cy.get('[data-testid="cost-provider-locked-rent_1_year"]').click();
+      cy.get('[data-testid="tco-model-dialog"]')
+        .should('be.visible')
+        .and('contain.text', 'Rent - 1 Year Commit');
+      cy.get('[data-testid="tco-model-dialog-link"]').should(
+        'have.attr',
+        'href',
+        'https://semianalysis.com/ai-cloud-tco-model/',
+      );
+      cy.contains('button', 'Not now').click();
+      cy.get('[data-testid="tco-model-dialog"]').should('not.exist');
+      cy.get<string>('@providerBefore').then((before) => {
+        cy.get('#calc-cost').should('have.text', before);
+      });
     });
 
     it('token type selector has Total, Input, and Output options', () => {

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -32,6 +32,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { MultiSelect } from '@/components/ui/multi-select';
+import { lockedCostProviderOptions, useLockedTierDialog } from '@/components/ui/tco-model-dialog';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -75,7 +76,7 @@ const STRINGS = {
       'Pick the model, workload, and target interactivity. The projection below sizes a fixed fleet of each chip against a facility power budget and reads the full run history at this operating point — see the section itself for what the lines mean.',
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
-      'The pricing tier used for the fleet cost line. Owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit.',
+      'The pricing tier used for the fleet cost line. Owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit. Locked rental terms (on demand through 2 year commit) are published in the SemiAnalysis AI Cloud TCO Model.',
     costProviderPlaceholder: 'Cost provider',
     tokenTypeLabel: 'Token Type',
     tokenTypeTooltip:
@@ -97,7 +98,7 @@ const STRINGS = {
       '选择模型、工作负载和目标交互性。下方会根据设施功率预算，分别确定各款芯片的固定集群规模，并按目标交互性读取历次运行的数据。各条曲线的含义见下方说明。',
     costProviderLabel: '成本供应商',
     costProviderTooltip:
-      '集群成本线采用的定价层级。按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁。',
+      '集群成本线采用的定价层级。按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁。带锁的租赁期限（按需至 2 年承诺）收录于 SemiAnalysis AI Cloud TCO 模型。',
     costProviderPlaceholder: '成本供应商',
     tokenTypeLabel: 'Token 类型',
     tokenTypeTooltip:
@@ -140,6 +141,10 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
   const t = STRINGS[locale];
   const { setUrlParam } = useUrlState();
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown();
+  // Shorter-commit rental tiers are listed but locked; picking one opens the
+  // TCO model dialog instead of changing the cost provider.
+  const { interceptLocked: interceptLockedTier, dialog: tcoModelDialog } =
+    useLockedTierDialog('fleet_cost_provider');
 
   const {
     selectedModel,
@@ -416,14 +421,18 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                   <div data-testid="fleet-cost-selector">
                     <MultiSelect
                       triggerId="fleet-cost"
-                      options={COST_PROVIDER_OPTIONS.map((provider) => ({
-                        value: provider.value,
-                        label: locale === 'zh' ? provider.labelZh : provider.label,
-                      }))}
+                      options={[
+                        ...COST_PROVIDER_OPTIONS.map((provider) => ({
+                          value: provider.value,
+                          label: locale === 'zh' ? provider.labelZh : provider.label,
+                        })),
+                        ...lockedCostProviderOptions(locale),
+                      ]}
                       value={[costProvider]}
                       onChange={(values) => {
                         const next = values[0];
                         if (!next) return;
+                        if (interceptLockedTier(next)) return;
                         setCostProvider(next as CostProvider);
                         track('fleet_cost_provider_changed', { provider: next });
                       }}
@@ -613,6 +622,7 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
           colorResolver={resolveColor}
         />
       )}
+      {tcoModelDialog}
     </div>
   );
 }

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -55,6 +55,7 @@ import { Label } from '@/components/ui/label';
 import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { ModelLogo } from '@/components/ui/model-logo';
 import { MultiSelect } from '@/components/ui/multi-select';
+import { lockedCostProviderOptions, useLockedTierDialog } from '@/components/ui/tco-model-dialog';
 import { ResultContext } from '@/components/ui/result-context';
 import { Skeleton } from '@/components/ui/skeleton';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -187,7 +188,7 @@ const STRINGS = {
     },
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
-      'The TCO tier used for the compute-expense segment: owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit, in $/GPU/hr from the SemiAnalysis AI Cloud TCO Model. Custom lets you type your own $/GPU/hr per chip.',
+      'The TCO tier used for the compute-expense segment: owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit, in $/GPU/hr from the SemiAnalysis AI Cloud TCO Model. Custom lets you type your own $/GPU/hr per chip. Locked rental terms (on demand through 2 year commit) are published in the TCO model.',
     customCostLabel: (gpu: string) => `${gpu} $/GPU/hr`,
     costProviderPlaceholder: 'Cost provider',
     priceSourceLabel: 'Token Price',
@@ -287,7 +288,7 @@ const STRINGS = {
     },
     costProviderLabel: '成本供应商',
     costProviderTooltip:
-      '算力支出分段采用的 TCO 层级：按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁，单位为 $/GPU/hr，来自 SemiAnalysis AI Cloud TCO 模型。选择自定义可为每种芯片输入自己的 $/GPU/hr。',
+      '算力支出分段采用的 TCO 层级：按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁，单位为 $/GPU/hr，来自 SemiAnalysis AI Cloud TCO 模型。选择自定义可为每种芯片输入自己的 $/GPU/hr。带锁的租赁期限（按需至 2 年承诺）收录于 TCO 模型。',
     customCostLabel: (gpu: string) => `${gpu} $/GPU/hr`,
     costProviderPlaceholder: '成本供应商',
     priceSourceLabel: 'Token 售价',
@@ -494,6 +495,10 @@ function ProfitEstimatorInner({
   const { setUrlParam, getUrlParam } = useUrlState();
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown();
   const { resolvedTheme } = useTheme();
+  // Shorter-commit rental tiers are listed but locked; picking one opens the
+  // TCO model dialog instead of changing the cost provider.
+  const { interceptLocked: interceptLockedTier, dialog: tcoModelDialog } =
+    useLockedTierDialog('profit_cost_provider');
 
   // Precision is not a control here: `effectivePrecisions` stays in auto mode,
   // which resolves to the densest measured precision per model, so the bars
@@ -1312,14 +1317,26 @@ function ProfitEstimatorInner({
                   <div data-testid="profit-cost-selector">
                     <MultiSelect
                       triggerId="profit-cost"
-                      options={COST_PROVIDER_OPTIONS.map((provider) => ({
-                        value: provider.value,
-                        label: locale === 'zh' ? provider.labelZh : provider.label,
-                      }))}
+                      options={[
+                        ...COST_PROVIDER_OPTIONS.filter((p) => p.value !== 'custom').map(
+                          (provider) => ({
+                            value: provider.value,
+                            label: locale === 'zh' ? provider.labelZh : provider.label,
+                          }),
+                        ),
+                        ...lockedCostProviderOptions(locale),
+                        ...COST_PROVIDER_OPTIONS.filter((p) => p.value === 'custom').map(
+                          (provider) => ({
+                            value: provider.value,
+                            label: locale === 'zh' ? provider.labelZh : provider.label,
+                          }),
+                        ),
+                      ]}
                       value={[costProvider]}
                       onChange={(values) => {
                         const next = values[0];
                         if (!next) return;
+                        if (interceptLockedTier(next)) return;
                         setCostProvider(next as ProfitCostProvider);
                         track('profit_cost_provider_changed', { provider: next });
                       }}
@@ -1693,6 +1710,7 @@ function ProfitEstimatorInner({
           )}
         </Card>
       )}
+      {tcoModelDialog}
     </div>
   );
 }

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -57,6 +57,7 @@ import { DEFAULT_FLEET_MW, readUrlParams, writeUrlParams } from '@/lib/url-state
 import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MultiSelect } from '@/components/ui/multi-select';
+import { lockedCostProviderOptions, useLockedTierDialog } from '@/components/ui/tco-model-dialog';
 import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/segmented-toggle';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
@@ -191,7 +192,7 @@ const STRINGS = {
       'Set a target interactivity (tokens/sec/user) and compare the throughput and cost across all chips. Values are interpolated from real benchmark data.',
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
-      'The pricing tier used to calculate cost per million tokens. Owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit.',
+      'The pricing tier used to calculate cost per million tokens. Owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit. Locked rental terms (on demand through 2 year commit) are published in the SemiAnalysis AI Cloud TCO Model.',
     costProviderPlaceholder: 'Cost provider',
     tokenTypeLabel: 'Token Type',
     tokenTypeTooltip:
@@ -252,7 +253,7 @@ const STRINGS = {
       '设定目标交互性（tokens/sec/user），比较所有芯片的吞吐量和成本。数值基于真实基准测试数据插值计算。',
     costProviderLabel: '计价方式',
     costProviderTooltip:
-      '用于计算每百万 token 成本的定价层级。按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁。',
+      '用于计算每百万 token 成本的定价层级。按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁。带锁的租赁期限（按需至 2 年承诺）收录于 SemiAnalysis AI Cloud TCO 模型。',
     costProviderPlaceholder: '计价方式',
     tokenTypeLabel: 'token 类型',
     tokenTypeTooltip: '选择显示总 token、仅输入 token 还是仅输出 token 的成本。',
@@ -355,6 +356,11 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
   const t = STRINGS[locale];
   const { setUrlParam } = useUrlState();
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown();
+  // Shorter-commit rental tiers are listed but locked; picking one opens the
+  // TCO model dialog instead of changing the cost provider.
+  const { interceptLocked: interceptLockedTier, dialog: tcoModelDialog } = useLockedTierDialog(
+    'calculator_cost_provider',
+  );
 
   const {
     selectedModel,
@@ -984,14 +990,18 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                   <div data-testid="calc-cost-selector">
                     <MultiSelect
                       triggerId="calc-cost"
-                      options={COST_PROVIDER_OPTIONS.map((provider) => ({
-                        value: provider.value,
-                        label: locale === 'zh' ? provider.labelZh : provider.label,
-                      }))}
+                      options={[
+                        ...COST_PROVIDER_OPTIONS.map((provider) => ({
+                          value: provider.value,
+                          label: locale === 'zh' ? provider.labelZh : provider.label,
+                        })),
+                        ...lockedCostProviderOptions(locale),
+                      ]}
                       value={[costProvider]}
                       onChange={(values) => {
                         const next = values[0];
                         if (!next) return;
+                        if (interceptLockedTier(next)) return;
                         handleCostProviderChange(next);
                       }}
                       open={openDropdown === 'costProvider'}
@@ -1471,6 +1481,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
           </Card>
         </section>
       )}
+      {tcoModelDialog}
     </div>
   );
 }

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -37,9 +37,17 @@ import { MobileControlSection } from '@/components/ui/mobile-control-section';
 import {
   METRIC_CONTROL_GROUPS,
   METRIC_REGISTRY,
+  metricChartTitle,
+  metricCostTier,
   metricOptionTitle,
   type MetricKey,
 } from '@/components/inference/metric-registry';
+import { lockedTierLabel, lockedTierValue } from '@/components/ui/locked-rent-tiers';
+import {
+  LOCKED_RENT_TIERS,
+  LockedTierBadge,
+  useLockedTierDialog,
+} from '@/components/ui/tco-model-dialog';
 import {
   cachedInputPricePerMillion,
   formatTokenPrice,
@@ -223,12 +231,14 @@ export default function ChartControls({
       ),
     [visibleGroups],
   );
+  // Locked rental tiers open the TCO model dialog instead of changing the axis.
+  const { interceptLocked: interceptLockedTier, dialog: tcoModelDialog } =
+    useLockedTierDialog('yaxis_metric');
   const groupedYAxisOptions = useMemo(
     () =>
       visibleGroups
-        .map((group) => ({
-          groupLabel: locale === 'zh' ? group.labelZh : group.label,
-          options: group.metrics
+        .map((group) => {
+          const options = group.metrics
             .filter((m) => METRIC_TITLE_MAP.has(m))
             .map((m) => ({
               value: m,
@@ -236,8 +246,30 @@ export default function ChartControls({
               label:
                 (locale === 'zh' ? METRIC_TITLE_ZH_MAP.get(m) : undefined) ??
                 METRIC_TITLE_MAP.get(m)!,
-            })),
-        }))
+            }));
+          // Groups that publish a Rent - 3 Year Commit axis also list the
+          // shorter-commit rental tiers, locked, so readers can see which
+          // pricing bases exist and where they are published.
+          const rentalMetric = group.metrics
+            .map((m) => m.replace(/^y_/u, '') as MetricKey)
+            .find((key) => METRIC_TITLE_MAP.has(`y_${key}`) && metricCostTier(key) === 'rental');
+          const lockedOptions = rentalMetric
+            ? LOCKED_RENT_TIERS.map((tier) => {
+                const title = metricChartTitle(rentalMetric, locale);
+                const tierLabel = lockedTierLabel(tier, locale);
+                return {
+                  value: lockedTierValue(tier.id, rentalMetric),
+                  label: locale === 'zh' ? `${title}（${tierLabel}）` : `${title} (${tierLabel})`,
+                  badge: <LockedTierBadge className="mt-0.5" />,
+                  testId: `yaxis-locked-${tier.id}-${rentalMetric}`,
+                };
+              })
+            : [];
+          return {
+            groupLabel: locale === 'zh' ? group.labelZh : group.label,
+            options: [...options, ...lockedOptions],
+          };
+        })
         .filter((g) => g.options.length > 0),
     [visibleGroups, locale],
   );
@@ -290,6 +322,7 @@ export default function ChartControls({
   };
 
   const handleYAxisMetricChange = (value: string) => {
+    if (interceptLockedTier(value)) return;
     setSelectedYAxisMetric(value);
     track('inference_y_axis_metric_selected', {
       metric: value,
@@ -603,6 +636,7 @@ export default function ChartControls({
           )}
         </MobileControlSection>
       </div>
+      {tcoModelDialog}
     </TooltipProvider>
   );
 }

--- a/packages/app/src/components/ui/locked-rent-tiers.test.ts
+++ b/packages/app/src/components/ui/locked-rent-tiers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOCKED_RENT_TIERS,
+  lockedTierLabel,
+  lockedTierValue,
+  parseLockedTierValue,
+} from '@/components/ui/locked-rent-tiers';
+
+describe('locked rent tiers', () => {
+  it('lists the five unpublished rental terms from shortest to longest commit', () => {
+    expect(LOCKED_RENT_TIERS.map((tier) => tier.label)).toEqual([
+      'Rent - On Demand',
+      'Rent - 1 Month Commit',
+      'Rent - 6 Month Commit',
+      'Rent - 1 Year Commit',
+      'Rent - 2 Year Commit',
+    ]);
+  });
+
+  it('round-trips a bare tier value', () => {
+    const value = lockedTierValue('rent_1_year');
+    expect(value).toBe('locked:rent_1_year');
+    expect(parseLockedTierValue(value)?.id).toBe('rent_1_year');
+  });
+
+  it('round-trips a tier value scoped to a metric key', () => {
+    const value = lockedTierValue('rent_6_month', 'costr');
+    expect(value).toBe('locked:rent_6_month:costr');
+    expect(parseLockedTierValue(value)?.id).toBe('rent_6_month');
+  });
+
+  it('returns null for real metric keys and cost providers', () => {
+    expect(parseLockedTierValue('y_costr')).toBeNull();
+    expect(parseLockedTierValue('costh')).toBeNull();
+    expect(parseLockedTierValue('custom')).toBeNull();
+    expect(parseLockedTierValue('locked:not_a_tier')).toBeNull();
+  });
+
+  it('localizes labels', () => {
+    const tier = LOCKED_RENT_TIERS[0];
+    expect(lockedTierLabel(tier, 'en')).toBe('Rent - On Demand');
+    expect(lockedTierLabel(tier, 'zh')).toBe('租赁 - 按需');
+  });
+});

--- a/packages/app/src/components/ui/locked-rent-tiers.ts
+++ b/packages/app/src/components/ui/locked-rent-tiers.ts
@@ -1,0 +1,56 @@
+import type { Locale } from '@/lib/i18n';
+
+/**
+ * Rental pricing tiers that InferenceX does not publish. The public
+ * dashboards carry two TCO tiers (Owning at Large Hyperscaler Volume and
+ * Rent - 3 Year Commit); the shorter-commit rental rates live in the
+ * SemiAnalysis AI Cloud TCO Model. These entries render as locked options in
+ * the y-axis and Cost Provider selectors, and picking one opens the TCO
+ * model dialog instead of changing the chart.
+ */
+export type LockedRentTierId =
+  | 'rent_on_demand'
+  | 'rent_1_month'
+  | 'rent_6_month'
+  | 'rent_1_year'
+  | 'rent_2_year';
+
+export interface LockedRentTier {
+  id: LockedRentTierId;
+  label: string;
+  labelZh: string;
+}
+
+/** Ordered by commitment length so the selector reads as a pricing ladder. */
+export const LOCKED_RENT_TIERS: readonly LockedRentTier[] = [
+  { id: 'rent_on_demand', label: 'Rent - On Demand', labelZh: '租赁 - 按需' },
+  { id: 'rent_1_month', label: 'Rent - 1 Month Commit', labelZh: '租赁 - 1 个月承诺' },
+  { id: 'rent_6_month', label: 'Rent - 6 Month Commit', labelZh: '租赁 - 6 个月承诺' },
+  { id: 'rent_1_year', label: 'Rent - 1 Year Commit', labelZh: '租赁 - 1 年承诺' },
+  { id: 'rent_2_year', label: 'Rent - 2 Year Commit', labelZh: '租赁 - 2 年承诺' },
+];
+
+const LOCKED_TIER_BY_ID = new Map<string, LockedRentTier>(
+  LOCKED_RENT_TIERS.map((tier) => [tier.id, tier]),
+);
+
+/**
+ * Selector values for locked tiers carry this prefix so a handler can tell
+ * them apart from real metric keys / cost providers before touching state.
+ */
+export const LOCKED_TIER_VALUE_PREFIX = 'locked:';
+
+export function lockedTierValue(id: LockedRentTierId, suffix?: string): string {
+  return suffix ? `${LOCKED_TIER_VALUE_PREFIX}${id}:${suffix}` : `${LOCKED_TIER_VALUE_PREFIX}${id}`;
+}
+
+/** Resolves a selector value back to its locked tier, or null for real options. */
+export function parseLockedTierValue(value: string): LockedRentTier | null {
+  if (!value.startsWith(LOCKED_TIER_VALUE_PREFIX)) return null;
+  const id = value.slice(LOCKED_TIER_VALUE_PREFIX.length).split(':')[0] ?? '';
+  return LOCKED_TIER_BY_ID.get(id) ?? null;
+}
+
+export function lockedTierLabel(tier: LockedRentTier, locale: Locale): string {
+  return locale === 'zh' ? tier.labelZh : tier.label;
+}

--- a/packages/app/src/components/ui/searchable-select.tsx
+++ b/packages/app/src/components/ui/searchable-select.tsx
@@ -39,6 +39,8 @@ export interface SearchableSelectOption {
   label: string;
   help?: React.ReactNode;
   testId?: string;
+  /** Optional trailing visual (e.g. a lock glyph) rendered after the label. */
+  badge?: React.ReactNode;
 }
 
 export interface SearchableSelectGroup {
@@ -439,6 +441,7 @@ export function SearchableSelect({
                             )}
                           >
                             <span className="min-w-0 flex-1">{option.label}</span>
+                            {option.badge}
                             {isSelected && (
                               <CheckIcon
                                 aria-hidden="true"
@@ -493,6 +496,7 @@ export function SearchableSelect({
                         {isSelected && <CheckIcon className="size-4 text-primary" />}
                       </span>
                       <span>{option.label}</span>
+                      {option.badge}
                     </div>
                   );
                 })}

--- a/packages/app/src/components/ui/tco-model-dialog.tsx
+++ b/packages/app/src/components/ui/tco-model-dialog.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { TCO_MODEL_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-constants';
+import { ArrowUpRight, Lock } from 'lucide-react';
+import { useCallback, useState, type ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { track } from '@/lib/analytics';
+import { useLocale } from '@/lib/use-locale';
+import { cn } from '@/lib/utils';
+
+import type { Locale } from '@/lib/i18n';
+
+import {
+  LOCKED_RENT_TIERS,
+  lockedTierLabel,
+  lockedTierValue,
+  parseLockedTierValue,
+  type LockedRentTier,
+} from './locked-rent-tiers';
+
+const STRINGS = {
+  en: {
+    lockedTitle: 'Available in the SemiAnalysis AI Cloud TCO Model',
+    locked: 'Locked',
+    title: (tier: string) => `${tier} pricing is in the ${TCO_MODEL_TITLE}`,
+    lead: (tier: string) =>
+      `InferenceX publishes two TCO tiers: Owning at Large Hyperscaler Volume and Rent - 3 Year Commit. ${tier} and the other rental terms come from the same source, the SemiAnalysis ${TCO_MODEL_TITLE}.`,
+    includesHeading: 'What the model covers',
+    includes: [
+      'Current market GPU rental prices and their variation across on-demand, 1 month, 6 month, 1 year, 2 year and 3 year terms.',
+      'All-in $/GPU/hr cost of ownership built from server capex, networking, colocation, power and cost of capital, per accelerator across NVIDIA, AMD, TPU and Trainium.',
+      'Forward rental price scenarios from supply-demand analysis and the cost curve of upcoming accelerator generations.',
+      'A cluster finance suite: NPV, residual value, IRR, and a full three-statement model that the rental scenarios feed into.',
+    ],
+    delivery:
+      'Delivered as an Excel workbook with dashboard access, one year of quarterly updates, and onboarding and ad-hoc analyst calls. Sold separately from the SemiAnalysis newsletter.',
+    cta: 'Explore the AI Cloud TCO Model',
+    dismiss: 'Not now',
+  },
+  zh: {
+    lockedTitle: '包含在 SemiAnalysis AI Cloud TCO 模型中',
+    locked: '已锁定',
+    title: (tier: string) => `${tier}价格包含在 ${TCO_MODEL_TITLE} 中`,
+    lead: (tier: string) =>
+      `InferenceX 公开两档 TCO：自有（超大规模云大批量）与租赁 - 3 年承诺。${tier}及其他租赁期限的价格来自同一来源：SemiAnalysis ${TCO_MODEL_TITLE}。`,
+    includesHeading: '模型包含的内容',
+    includes: [
+      '当前市场 GPU 租赁价格及其在按需、1 个月、6 个月、1 年、2 年和 3 年期限之间的差异。',
+      '按加速器计算的全口径 $/GPU/hr 拥有成本，涵盖服务器资本开支、网络、托管、电力和资金成本，覆盖 NVIDIA、AMD、TPU 与 Trainium。',
+      '基于供需分析和下一代加速器成本曲线的租赁价格前瞻情景。',
+      '集群财务套件：NPV、残值、IRR，以及由租赁情景驱动的完整三表模型。',
+    ],
+    delivery:
+      '以 Excel 工作簿加仪表板形式交付，含一年季度更新、上手培训以及按需分析师沟通。与 SemiAnalysis 通讯订阅分开销售。',
+    cta: '了解 AI Cloud TCO 模型',
+    dismiss: '暂不需要',
+  },
+} as const;
+
+/** Trailing lock glyph for selector options whose pricing lives in the TCO model. */
+export function LockedTierBadge({ className }: { className?: string }) {
+  const t = STRINGS[useLocale()];
+  return (
+    <span
+      className={cn('inline-flex shrink-0 items-center text-muted-foreground', className)}
+      title={t.lockedTitle}
+      data-testid="locked-tier-badge"
+    >
+      <Lock aria-hidden="true" className="size-3.5" />
+      <span className="sr-only">{t.locked}</span>
+    </span>
+  );
+}
+
+interface TcoModelDialogProps {
+  /** Tier the reader clicked; null keeps the dialog closed. */
+  tier: LockedRentTier | null;
+  onClose: () => void;
+  /** Analytics surface, e.g. "yaxis_metric" or "profit_cost_provider". */
+  source: string;
+}
+
+/**
+ * Modal that opens when a locked rental tier is picked. It plugs the
+ * SemiAnalysis AI Cloud TCO Model, where those rental rates are published.
+ */
+export function TcoModelDialog({ tier, onClose, source }: TcoModelDialogProps) {
+  const locale = useLocale();
+  const t = STRINGS[locale];
+  const tierLabel = tier ? lockedTierLabel(tier, locale) : '';
+
+  return (
+    <Dialog open={tier !== null} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-xl" data-testid="tco-model-dialog">
+        <DialogHeader>
+          <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <Lock aria-hidden="true" className="size-3.5" />
+            SemiAnalysis
+          </div>
+          <DialogTitle>{t.title(tierLabel)}</DialogTitle>
+          <DialogDescription>{t.lead(tierLabel)}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3 text-sm">
+          <p className="font-medium">{t.includesHeading}</p>
+          <ul className="list-disc space-y-1.5 pl-5 text-muted-foreground">
+            {t.includes.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <p className="text-muted-foreground">{t.delivery}</p>
+        </div>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button type="button" variant="outline" onClick={onClose}>
+            {t.dismiss}
+          </Button>
+          <Button asChild>
+            <a
+              href={TCO_SOURCE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              data-testid="tco-model-dialog-link"
+              onClick={() =>
+                track('tco_model_dialog_link_clicked', { source, tier: tier?.id ?? null })
+              }
+            >
+              {t.cta}
+              <ArrowUpRight aria-hidden="true" />
+            </a>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * State for a selector that mixes real options with locked rental tiers.
+ * `interceptLocked(value)` returns true (and opens the dialog) when the value
+ * is a locked tier, so callers can bail before writing to their own state.
+ */
+export function useLockedTierDialog(source: string): {
+  lockedTier: LockedRentTier | null;
+  interceptLocked: (value: string) => boolean;
+  dialog: ReactNode;
+} {
+  const [lockedTier, setLockedTier] = useState<LockedRentTier | null>(null);
+  const interceptLocked = useCallback(
+    (value: string) => {
+      const tier = parseLockedTierValue(value);
+      if (!tier) return false;
+      setLockedTier(tier);
+      track('tco_model_dialog_opened', { source, tier: tier.id });
+      return true;
+    },
+    [source],
+  );
+  const close = useCallback(() => setLockedTier(null), []);
+  return {
+    lockedTier,
+    interceptLocked,
+    dialog: <TcoModelDialog tier={lockedTier} onClose={close} source={source} />,
+  };
+}
+
+/**
+ * Locked rental tiers shaped as `MultiSelect` options for the calculator
+ * Cost Provider selectors. The caller runs `interceptLocked` in `onChange`.
+ */
+export function lockedCostProviderOptions(locale: Locale): {
+  value: string;
+  label: string;
+  badge: ReactNode;
+  testId: string;
+}[] {
+  return LOCKED_RENT_TIERS.map((tier) => ({
+    value: lockedTierValue(tier.id),
+    label: lockedTierLabel(tier, locale),
+    badge: <LockedTierBadge />,
+    testId: `cost-provider-locked-${tier.id}`,
+  }));
+}
+
+export { LOCKED_RENT_TIERS };


### PR DESCRIPTION
## What

Adds five rental pricing tiers as locked options next to the existing `Rent - 3 Year Commit` entries, and a dialog that points readers to the SemiAnalysis AI Cloud TCO Model where those rates are published.

Locked tiers, in commit-length order: `Rent - On Demand`, `Rent - 1 Month Commit`, `Rent - 6 Month Commit`, `Rent - 1 Year Commit`, `Rent - 2 Year Commit`. Each shows a lock glyph in the option row.

Where they appear:
- `/inference` Y-Axis Metric selector: every group that has a `Rent - 3 Year Commit` metric (Cost per Million Total/Output/Input Tokens, Total/Output/Input Tokens per $1 TCO) lists the five locked variants after the published options, e.g. `Cost per Million Total Tokens (Rent - 1 Year Commit)`.
- Cost Provider selector on the Throughput Calculator, Fleet Lifecycle and Profit Estimator: listed after `Rent - 3 Year Commit` and before `Custom $/GPU/hr`.

Selecting a locked option does not change the chart or the cost provider. It opens `TcoModelDialog`, which names the selected tier, summarizes what the TCO model contains (market rental prices across terms, all-in $/GPU/hr COO per accelerator, forward rental scenarios, cluster finance suite; delivered as an Excel workbook with dashboard and quarterly updates) and links to https://semianalysis.com/ai-cloud-tco-model/. EN and ZH copy included. Cost Provider tooltips gained one sentence noting where the locked terms are published.

Analytics: `tco_model_dialog_opened` and `tco_model_dialog_link_clicked`, both with `{ source, tier }`. Sources: `yaxis_metric`, `calculator_cost_provider`, `fleet_cost_provider`, `profit_cost_provider`.

## How

- `ui/locked-rent-tiers.ts`: tier list, `locked:<tier>[:<metric>]` value encoding, `parseLockedTierValue`, locale labels.
- `ui/tco-model-dialog.tsx`: `LockedTierBadge`, `TcoModelDialog` (Radix `Dialog`), `useLockedTierDialog(source)` returning `{ interceptLocked, dialog }`, and `lockedCostProviderOptions(locale)` for the `MultiSelect` consumers.
- `ui/searchable-select.tsx`: options accept an optional `badge` node, rendered in both the listbox and the grid (option-help) layouts.
- `ChartControls.tsx` and the three calculator displays: append the locked options, early-return from the change handler when `interceptLocked(value)` is true, render the dialog.

No registry, URL-state or data changes. The value prefix keeps locked ids out of `MetricKey` and `CostProvider` types.

## Screenshots

Screenshots of the y-axis selector with locked rows and of the dialog (captured from the component test run) are posted in the Slack thread that requested this change.

## Testing

- `bun run fmt:fix`, `bun run lint`, `bun run typecheck`, `bun run check:typography`: clean.
- New unit test `locked-rent-tiers.test.ts` (value round-trip, label locale, tier order).
- New Cypress component case in `inference-chart-controls.cy.tsx`: five lock badges per cost group, clicking a locked row opens the dialog with the correct href and `target="_blank"`, `setSelectedYAxisMetric` is not called, `Not now` closes it. Full spec: 44 passing.
- Existing e2e specs that match `Rent - 3 Year Commit` labels by substring are unaffected (`Rent - 1 Year Commit` does not contain that substring).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only selector and dialog changes with no URL state, registry, or pricing data changes; locked values are intercepted before state updates.
> 
> **Overview**
> Adds **five locked rental pricing tiers** (on demand through 2-year commit) beside the published **Rent - 3 Year Commit** options in the inference **Y-Axis Metric** dropdown and in **Cost Provider** selectors on the TCO Calculator, Fleet Lifecycle, and Profit Estimator. Locked rows show a lock badge; choosing one **does not** update chart state or cost provider—it opens **`TcoModelDialog`** with EN/ZH copy and a link to the SemiAnalysis AI Cloud TCO Model.
> 
> New **`locked-rent-tiers`** module encodes selector values as `locked:<tier>[:<metric>]` so they stay out of real metric/cost-provider types. **`useLockedTierDialog`** intercepts those values and fires analytics (`tco_model_dialog_opened`, `tco_model_dialog_link_clicked`). **`SearchableSelect`** and **`MultiSelect`** consumers gain optional option **badges**; Profit Estimator keeps **Custom** after the locked tiers.
> 
> Cost provider tooltips note where locked terms are published. Coverage: Vitest for tier encoding/labels, Cypress component test for y-axis locked rows + dialog, and e2e for calculator provider list and no-op selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451b5f0e4ed0ae4530e04acee65698384c2c9c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->