### PR TITLE
feat(profit): open /profit-estimator on Rent - 3 Year Commit

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -16,6 +16,8 @@
 //    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3 and
 //    MiniMax M3 only, and the target interactivity is a typed number, not a slider;
 //  - the cost provider has a custom $/GPU/hr option with one input per chip;
+//  - the per-GW page opens on Owning at Large Hyperscaler Volume while the
+//    per chip-hour page opens on Rent - 3 Year Commit;
 //  - the heading reads like /inference, the subtitle names the utilization, and
 //    the formula folds away under the chart;
 //  - /profit-estimator/<model> is the per-model route; switching models
@@ -103,7 +105,8 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-utilization-input"]').should('have.value', '60');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     bars().should('have.length.greaterThan', 0);
-    // Cost tiers carry the same names as the /inference y-axis selector.
+    // Cost tiers carry the same names as the /inference y-axis selector. The
+    // GW-year basis models a fleet owner, so it opens on the owning tier.
     cy.get('button#profit-cost')
       .should('contain.text', 'Owning at Large Hyperscaler Volume')
       .click();
@@ -845,7 +848,7 @@ describe('Profit Estimator (per chip-hour)', () => {
   before(() => {
     stubOpenRouter();
     // Tall enough for the 720px chart, so the thin compute-expense segment
-    // ($2.31 of $32.72) still has room for its name.
+    // still has room for its name.
     cy.viewport(1280, 1000);
     cy.visit('/profit-estimator', { onBeforeLoad: suppressNudges });
     chart().should('exist');
@@ -864,6 +867,13 @@ describe('Profit Estimator (per chip-hour)', () => {
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'Kimi K3 2.8T Agentic Revenue & Profit Estimates per Chip per Hour at P90 45 tok/s/user Interactivity',
+    );
+    // The chip-hour basis reads like a renter's P&L, so it opens on the
+    // 3-year-commit rental tier rather than the owning tier the GW-year page uses.
+    cy.get('button#profit-cost').should('contain.text', 'Rent - 3 Year Commit');
+    cy.get('[data-testid="result-context-cost-tier"]').should(
+      'contain.text',
+      'Rent - 3 Year Commit',
     );
     cy.get('[data-testid="profit-formula-notes"]').should(
       'contain.text',

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -145,6 +145,15 @@ const COST_PROVIDER_OPTIONS: { value: ProfitCostProvider; label: string; labelZh
 /** Tier the custom inputs are seeded from, and the tier interpolation runs on. */
 const CUSTOM_COST_SEED: CostProvider = 'costh';
 
+// Each basis opens on a different published tier. Per chip-hour is the view
+// an operator renting capacity reads, so it opens on Rent - 3 Year Commit;
+// per GW-year models a fleet owner, so it stays on Owning at Large
+// Hyperscaler Volume.
+const DEFAULT_COST_PROVIDER: Record<ProfitBasis, CostProvider> = {
+  'chip-hour': 'costr',
+  'gw-year': 'costh',
+};
+
 /** Base GPU (`h200`, `gb300`) of a legend key like `gb300_dynamo-sglang`. */
 function baseGpuOf(hwKey: string): string {
   return hwKey.split('_')[0] ?? hwKey;
@@ -534,7 +543,9 @@ function ProfitEstimatorInner({
   }, [sequenceResolved, effectiveSequence, setSelectedSequence]);
   const mode = 'interactivity_to_throughput' as const;
 
-  const [costProvider, setCostProvider] = useState<ProfitCostProvider>('costh');
+  const [costProvider, setCostProvider] = useState<ProfitCostProvider>(
+    DEFAULT_COST_PROVIDER[basis],
+  );
   const [priceSource, setPriceSource] = useState<PriceSource>(() =>
     defaultPriceSource(selectedModel),
   );
@@ -795,8 +806,8 @@ function ProfitEstimatorInner({
   const loading = throughputLoading || history.loading;
 
   // Per-base-GPU $/GPU/hr typed by the reader; seeded from the hyperscaler
-  // tier the first time each chip appears so the custom view starts identical
-  // to the default one.
+  // tier the first time each chip appears so the custom view starts from the
+  // published owning rate on either basis.
   const [customCosts, setCustomCosts] = useState<Record<string, string>>({});
   const customCostBases = useMemo(
     () =>


### PR DESCRIPTION
`/profit-estimator` (per chip-hour) now opens on the **Rent - 3 Year Commit** cost tier. `/profit-estimator-per-gigawatt` keeps **Owning at Large Hyperscaler Volume**.

- `DEFAULT_COST_PROVIDER` in `ProfitEstimatorDisplay.tsx` maps `chip-hour → costr`, `gw-year → costh`; the `costProvider` state seeds from it by `basis`
- Custom $/GPU/hr inputs still seed from the hyperscaler tier (unchanged); comment adjusted
- Cypress: the chip-hour spec asserts the selector and result-context cost tier read `Rent - 3 Year Commit`; the per-GW spec keeps its owning-tier assertion

Local: oxfmt, oxlint, tsc, check-typography, and the profit-estimator / profit-history unit tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default UI state only; pricing logic and custom-cost seeding behavior are unchanged aside from the initial tier selection.
> 
> **Overview**
> The profit estimator now picks a **default TCO cost tier from the page basis** instead of always opening on hyperscaler owning.
> 
> **Per chip-hour** (`/profit-estimator`) defaults to **Rent - 3 Year Commit**; **per GW-year** (`/profit-estimator-per-gigawatt`) still defaults to **Owning at Large Hyperscaler Volume**. `ProfitEstimatorDisplay` seeds `costProvider` from a new `DEFAULT_COST_PROVIDER` map keyed by `ProfitBasis`.
> 
> **Custom $/GPU/hr** still seeds chip inputs from the hyperscaler tier; only the comment was clarified. Cypress documents the split and asserts the chip-hour page shows the rental tier in the cost selector and result context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1950889e6f46f3e8c3713d2ef539c60a7373430e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->