### PR TITLE
fix(overlays): combine unofficial Pareto frontiers and add background toggle / 合并非官方运行的 Pareto 曲线并新增背景开关

### DIFF
--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -495,6 +495,110 @@ describe('ScatterGraph', () => {
     cy.get('.sidebar-legend label').should('have.length.greaterThan', 0);
   });
 
+  it('combines matching hardware across unofficial runs and recomputes after dismissal', () => {
+    const runUrls = [101, 102].map(
+      (id) => `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`,
+    );
+    const points = [
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        precision: Precision.FP4,
+        x: 8,
+        y: 320,
+        run_url: runUrls[0],
+      }),
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        precision: Precision.FP4,
+        x: 16,
+        y: 200,
+        run_url: runUrls[0],
+      }),
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        precision: Precision.FP4,
+        x: 16,
+        y: 280,
+        run_url: runUrls[1],
+      }),
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        precision: Precision.FP4,
+        x: 32,
+        y: 220,
+        run_url: runUrls[1],
+      }),
+    ];
+    function Harness() {
+      const [dismissed, setDismissed] = useState(false);
+      return (
+        <div style={{ width: 800, height: 600 }}>
+          <button onClick={() => setDismissed(true)}>Dismiss second run</button>
+          <ScatterGraph
+            chartId="combined-overlay"
+            modelLabel="DeepSeek R1"
+            data={[
+              createMockInferenceData({ hwKey: 'h100', precision: Precision.FP4, x: 8, y: 100 }),
+            ]}
+            xLabel="Interactivity"
+            yLabel="Throughput"
+            chartDefinition={createMockChartDefinition({
+              chartType: 'interactivity',
+              y_tpPerGpu_roofline: 'upper_left',
+            })}
+            overlayData={{
+              data: dismissed ? points.slice(0, 2) : points,
+              hardwareConfig: hwConfig,
+              label: 'combined',
+            }}
+          />
+        </div>
+      );
+    }
+    mountWithProviders(<Harness />, {
+      inference: {
+        hardwareConfig: hwConfig,
+        activeHwTypes: new Set(['h100']),
+        hwTypesWithData: new Set(['h100']),
+        selectedPrecisions: [Precision.FP4],
+        hideNonOptimal: true,
+      },
+      unofficial: {
+        activeOverlayHwTypes: new Set(['b200_trt']),
+        allOverlayHwTypes: new Set(['b200_trt']),
+        runIndexByUrl: { [runUrls[0]]: 0, [runUrls[1]]: 1 },
+      },
+    });
+    const curve = '#combined-overlay .overlay-roofline-path';
+    cy.get<SVGPathElement>(curve)
+      .should('have.length', 1)
+      .then(($paths) => {
+        const entry = (
+          $paths[0] as SVGPathElement & { __data__: { points: { x: number; y: number }[] } }
+        ).__data__;
+        expect(entry.points.map(({ x, y }) => [x, y])).to.deep.equal([
+          [8, 320],
+          [16, 280],
+          [32, 220],
+        ]);
+      });
+    cy.get('#combined-overlay .unofficial-overlay-pt').should(($points) => {
+      expect([...$points].filter((p) => p.style.opacity !== '0')).to.have.length(3);
+    });
+    cy.contains('button', 'Dismiss second run').click();
+    cy.get<SVGPathElement>(curve)
+      .should('have.length', 1)
+      .should(($paths) => {
+        const entry = (
+          $paths[0] as SVGPathElement & { __data__: { points: { x: number; y: number }[] } }
+        ).__data__;
+        expect(entry.points.map(({ x, y }) => [x, y])).to.deep.equal([
+          [8, 320],
+          [16, 200],
+        ]);
+      });
+  });
+
   it('renders line labels for both official and overlay (unofficial) rooflines', () => {
     const interactivityChartDef = createMockChartDefinition({
       chartType: 'interactivity',

--- a/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
+++ b/packages/app/cypress/e2e/overlay-optimal-only.cy.ts
@@ -83,4 +83,26 @@ describe('Overlay points follow Optimal Only on the selected axes', () => {
       expect(countVisible($pts), 'visible overlay X markers').to.eq(REAL_CONFIGS.length);
     });
   });
+  it('replaces the unofficial background and warning with the SemiAnalysis watermark', () => {
+    const chart = '[data-testid="inference-chart-display"] svg';
+    cy.get(`${chart} .unofficial-watermark-image`).should('exist');
+    cy.get(`${chart} pattern[id^="unofficial-pattern-"]`).should('exist');
+    cy.get('[data-testid="remove-unofficial-bg"]')
+      .click()
+      .should('have.attr', 'data-state', 'checked');
+    cy.get(`${chart} .unofficial-watermark-image`).should('not.exist');
+    cy.get(`${chart} pattern[id^="unofficial-pattern-"]`).should('not.exist');
+    cy.get(`${chart} pattern[id^="logo-pattern-"] image`).should(
+      'have.attr',
+      'href',
+      '/brand/logo-color.webp',
+    );
+    cy.get(`${chart} .unofficial-overlay-pt`).should('have.length', OVERLAY_CONFIGS.length);
+    cy.get('[data-testid="remove-unofficial-bg"]')
+      .click()
+      .should('have.attr', 'data-state', 'unchecked');
+    cy.get(`${chart} .unofficial-watermark-image`).should('exist');
+    cy.get(`${chart} pattern[id^="unofficial-pattern-"]`).should('exist');
+    cy.get(`${chart} pattern[id^="logo-pattern-"]`).should('not.exist');
+  });
 });

--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -547,6 +547,7 @@ export function createMockUnofficialRunContext(
 ): UnofficialRunContextType {
   return {
     isUnofficialRun: false,
+    removeUnofficialBg: false,
     unofficialRunInfo: null,
     unofficialRunInfos: [],
     runIndexByUrl: {},

--- a/packages/app/src/components/evaluation/ui/BarChartD3.tsx
+++ b/packages/app/src/components/evaluation/ui/BarChartD3.tsx
@@ -381,6 +381,7 @@ export default function EvalBarChartD3({ caption }: { caption?: ReactNode }) {
   const legendT = EVAL_STRINGS[locale];
   const {
     isUnofficialRun,
+    removeUnofficialBg,
     unofficialRunInfo,
     unofficialRunInfos,
     activeOverlayHwTypes,
@@ -1243,7 +1244,7 @@ export default function EvalBarChartD3({ caption }: { caption?: ReactNode }) {
       displayIdentity={displayIdentity}
       height={chartHeight}
       margin={chartMargin}
-      watermark={getChartWatermark(isUnofficialRun)}
+      watermark={getChartWatermark(isUnofficialRun, removeUnofficialBg)}
       grabCursor={false}
       caption={caption}
       xScale={xScaleConfig}

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -492,6 +492,7 @@ const ScatterGraph = React.memo(
 
     const {
       isUnofficialRun,
+      removeUnofficialBg,
       activeOverlayHwTypes: providerActiveOverlayHwTypes,
       localOfficialOverride,
       resetOverlaySelection,
@@ -904,7 +905,7 @@ const ScatterGraph = React.memo(
       const buckets = new Map<string, Bucket>();
       const getBucket = (point: InferenceData) => {
         const runIndex = overlayRunIndex(point.run_url ?? null, runIndexByUrl);
-        const key = `${point.hwKey}|${point.precision}|${point.date}|run${runIndex}`;
+        const key = `${point.hwKey}|${point.precision}`;
         let bucket = buckets.get(key);
         if (!bucket) {
           bucket = {
@@ -1011,12 +1012,12 @@ const ScatterGraph = React.memo(
         points: InferenceData[];
       }
       if (processedOverlayData.length === 0) return {} as Record<string, Entry>;
-      // Group by hwKey + precision + runIndex so overlay rooflines from different
-      // unofficial runs stay separate and can be styled with per-run hue shifts.
+      // Combine matching hardware and precision across unofficial runs. Keep
+      // the first contributing run’s style; individual points retain their provenance.
       const grouped = processedOverlayData.reduce(
         (acc, p) => {
           const runIndex = overlayRunIndex(p.run_url ?? null, runIndexByUrl);
-          const key = `${p.hwKey}_${p.precision}_run${runIndex}`;
+          const key = `${p.hwKey}_${p.precision}`;
           if (!acc[key]) acc[key] = { hwKey: String(p.hwKey), runIndex, points: [] };
           acc[key].points.push(p);
           return acc;
@@ -1037,7 +1038,7 @@ const ScatterGraph = React.memo(
     }, [processedOverlayData, selectedYAxisMetric, chartDefinition, runIndexByUrl]);
 
     // Overlay counterpart of `optimalPointKeys`: the points on any overlay
-    // run's drawn roofline (already e2e-restricted for agentic non-e2e modes).
+    // hardware's drawn roofline (already e2e-restricted for agentic non-e2e modes).
     // Frontier arrays hold the same object references as `processedOverlayData`
     // items — the pareto fns return the refs they're handed — so identity
     // membership is exact, and unlike composite string keys it can't collide
@@ -1051,7 +1052,7 @@ const ScatterGraph = React.memo(
     }, [overlayRooflines]);
 
     // Overlay points respect the Optimal Only toggle exactly like official
-    // points do — "optimal" = on the overlay run's drawn roofline. Without
+    // points do — "optimal" = on the combined overlay hardware roofline. Without
     // this, an e2e-dominated overlay config (hidden on the official side) kept
     // its X marker sitting on the dashed roofline and read as a pareto point.
     // Hardware/precision/quick filters are applied upstream in
@@ -1525,9 +1526,7 @@ const ScatterGraph = React.memo(
         const base = `${String(point.hwKey)}_${point.precision}`;
         const candidates =
           source === 'overlay'
-            ? [
-                `overlay-roofline-${base}_run${overlayRunIndex(point.run_url ?? null, runIndexByUrl)}`,
-              ]
+            ? [`overlay-roofline-${base}`]
             : [`roofline-${base}`, `roofline-${base}__${point.date}`];
         const curve = candidates.find(
           (cls) => !ctx.zoomGroup.select(`.${CSS.escape(cls)}`).empty(),
@@ -1540,7 +1539,7 @@ const ScatterGraph = React.memo(
         chartRef.current?.dismissTooltip();
         chartRef.current?.hideTooltip();
       },
-      [runIndexByUrl, clampPerfRulerIsoXToOverlap],
+      [clampPerfRulerIsoXToOverlap],
     );
 
     // Read by long-lived D3 click closures (official tooltip config + overlay
@@ -1588,7 +1587,7 @@ const ScatterGraph = React.memo(
           .each(function () {
             // The identity token is the curve-specific class, e.g.
             // `roofline-H100_fp8`, `roofline-H100_fp8__2026-01-01`, or
-            // `overlay-roofline-H100_fp8_run0`.
+            // `overlay-roofline-H100_fp8`.
             const curve = [...this.classList].find(
               (cls) => cls !== 'roofline-path' && cls !== 'overlay-roofline-path',
             );
@@ -3444,7 +3443,7 @@ const ScatterGraph = React.memo(
           dataIdentity={dataIdentity}
           metricIdentity={metricIdentity}
           margin={CHART_MARGIN}
-          watermark={getChartWatermark(isUnofficialRun)}
+          watermark={getChartWatermark(isUnofficialRun, removeUnofficialBg)}
           testId="scatter-graph"
           grabCursor={true}
           caption={caption}

--- a/packages/app/src/components/ui/unofficial-banner.tsx
+++ b/packages/app/src/components/ui/unofficial-banner.tsx
@@ -2,6 +2,9 @@
 
 import { AlertTriangle, ExternalLink, X } from 'lucide-react';
 
+import { useLocale } from '@/lib/use-locale';
+import { Switch } from '@/components/ui/switch';
+
 import { track } from '@/lib/analytics';
 import { overlayRunColor } from '@/lib/overlay-run-style';
 
@@ -16,11 +19,18 @@ interface RunInfo {
 
 interface UnofficialBannerProps {
   runs: RunInfo[];
+  removeUnofficialBg?: boolean;
+  onRemoveUnofficialBgChange?: (checked: boolean) => void;
   /** Remove a single run from the URL + state. */
   onDismissRun?: (runId: string) => void;
   /** Clear all runs at once. Surfaced as "Dismiss all" when `runs.length > 1`. */
   onDismissAll?: () => void;
 }
+
+const STRINGS = {
+  en: { removeUnofficialBg: 'Remove unofficial BG' },
+  zh: { removeUnofficialBg: '移除非官方背景' },
+};
 
 /**
  * Compact banner that advertises that the page is showing unofficial run data.
@@ -32,7 +42,14 @@ interface UnofficialBannerProps {
  * run rendered its OWN full-width banner and the dismiss button cleared every
  * run, which both wasted vertical space and made partial dismissal impossible.
  */
-export function UnofficialBanner({ runs, onDismissRun, onDismissAll }: UnofficialBannerProps) {
+export function UnofficialBanner({
+  runs,
+  onDismissRun,
+  onDismissAll,
+  removeUnofficialBg = false,
+  onRemoveUnofficialBgChange,
+}: UnofficialBannerProps) {
+  const locale = useLocale();
   if (runs.length === 0) return null;
   const multiple = runs.length > 1;
 
@@ -60,6 +77,20 @@ export function UnofficialBanner({ runs, onDismissRun, onDismissAll }: Unofficia
             </div>
           </div>
         </div>
+        {onRemoveUnofficialBgChange && (
+          <label className="flex items-center gap-2 text-xs cursor-pointer">
+            <Switch
+              data-testid="remove-unofficial-bg"
+              checked={removeUnofficialBg}
+              onCheckedChange={(checked) => {
+                track('unofficial_background_toggled', { removed: checked });
+                onRemoveUnofficialBgChange(checked);
+              }}
+              aria-label={STRINGS[locale].removeUnofficialBg}
+            />
+            {STRINGS[locale].removeUnofficialBg}
+          </label>
+        )}
         {multiple && onDismissAll && (
           <button
             type="button"

--- a/packages/app/src/components/unofficial-run-provider.tsx
+++ b/packages/app/src/components/unofficial-run-provider.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   useMemo,
   useReducer,
+  useState,
 } from 'react';
 
 import type { ChartDefinition, HardwareConfig, InferenceData } from '@/components/inference/types';
@@ -78,6 +79,7 @@ export interface OverlayScopeInput {
 
 export interface UnofficialRunContextType {
   isUnofficialRun: boolean;
+  removeUnofficialBg: boolean;
   unofficialRunInfo: UnofficialRunInfo | null;
   unofficialRunInfos: UnofficialRunInfo[];
   runIndexByUrl: Record<string, number>;
@@ -365,6 +367,7 @@ async function fetchUnofficialRuns(
 }
 
 export function UnofficialRunProvider({ children }: { children: ReactNode }) {
+  const [removeUnofficialBg, setRemoveUnofficialBg] = useState(false);
   const queryClient = useQueryClient();
   const search = useClientSearch();
   const runIds = useMemo(() => parseUnofficialRunIds(search), [search]);
@@ -478,6 +481,7 @@ export function UnofficialRunProvider({ children }: { children: ReactNode }) {
   const contextValue = useMemo<UnofficialRunContextType>(
     () => ({
       isUnofficialRun: unofficialRunInfos.length > 0,
+      removeUnofficialBg,
       unofficialRunInfo,
       unofficialRunInfos,
       runIndexByUrl,
@@ -498,6 +502,7 @@ export function UnofficialRunProvider({ children }: { children: ReactNode }) {
       resetOverlaySelection,
     }),
     [
+      removeUnofficialBg,
       unofficialRunInfos,
       unofficialRunInfo,
       runIndexByUrl,
@@ -524,6 +529,8 @@ export function UnofficialRunProvider({ children }: { children: ReactNode }) {
       {unofficialRunInfos.length > 0 && (
         <UnofficialBanner
           runs={unofficialRunInfos}
+          removeUnofficialBg={removeUnofficialBg}
+          onRemoveUnofficialBgChange={setRemoveUnofficialBg}
           onDismissRun={dismissRun}
           onDismissAll={clearUnofficialRun}
         />

--- a/packages/app/src/lib/d3-chart/D3Chart/types.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/types.ts
@@ -258,7 +258,7 @@ export interface D3ChartProps<T = any> {
   data: T[];
   height?: number;
   margin?: ChartMargin;
-  watermark?: 'logo' | 'unofficial' | 'none';
+  watermark?: 'logo' | 'logo-always' | 'unofficial' | 'none';
   testId?: string;
   grabCursor?: boolean;
   instructions?: string;

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -318,9 +318,14 @@ export function hasExclusion(model: Model | string | null | undefined): boolean 
 
 /**
  * Pick the chart watermark for a given run state. Unofficial-run charts get
- * the red unofficial-run warning; everything else gets the logo.
+ * the red unofficial-run warning unless the viewer explicitly replaces it with
+ * the SemiAnalysis logo. Other charts retain the default domain-aware logo.
  */
-export function getChartWatermark(isUnofficialRun = false): 'logo' | 'unofficial' {
+export function getChartWatermark(
+  isUnofficialRun = false,
+  removeUnofficialBg = false,
+): 'logo' | 'logo-always' | 'unofficial' {
+  if (isUnofficialRun && removeUnofficialBg) return 'logo-always';
   return isUnofficialRun ? 'unofficial' : 'logo';
 }
 

--- a/packages/app/src/lib/unofficial-domain.test.ts
+++ b/packages/app/src/lib/unofficial-domain.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { getChartWatermark } from './data-mappings';
 
 import {
   getDomainAwareChartWatermark,
@@ -20,5 +21,14 @@ describe('unofficial domain branding', () => {
   it('preserves non-logo watermark modes on unofficial domains', () => {
     expect(getDomainAwareChartWatermark('unofficial', 'preview.example.com')).toBe('unofficial');
     expect(getDomainAwareChartWatermark('none', 'preview.example.com')).toBe('none');
+  });
+  it('honors the explicit unofficial background override on every hostname', () => {
+    for (const hostname of [OFFICIAL_HOSTNAME, 'localhost', 'preview.example.com']) {
+      expect(getDomainAwareChartWatermark(getChartWatermark(true, true), hostname)).toBe('logo');
+      expect(getDomainAwareChartWatermark(getChartWatermark(true, false), hostname)).toBe(
+        'unofficial',
+      );
+    }
+    expect(getDomainAwareChartWatermark(getChartWatermark(false, true), 'localhost')).toBe('none');
   });
 });

--- a/packages/app/src/lib/unofficial-domain.ts
+++ b/packages/app/src/lib/unofficial-domain.ts
@@ -9,8 +9,9 @@ export function isUnofficialHostname(hostname: string): boolean {
 }
 
 export function getDomainAwareChartWatermark(
-  watermark: ChartWatermark,
+  watermark: ChartWatermark | 'logo-always',
   hostname: string,
 ): ChartWatermark {
+  if (watermark === 'logo-always') return 'logo';
   return watermark === 'logo' && isUnofficialHostname(hostname) ? 'none' : watermark;
 }


### PR DESCRIPTION
## Summary

Unofficial runs with the same hardware and precision now share one Pareto roofline and one Optimal Only frontier. The curve updates when a run is dismissed, while individual points keep their run colors. A banner switch replaces the red unofficial chart background with the SemiAnalysis watermark in inference and evaluation charts.

Merged current `master` and reconciled its power-envelope, perf-ruler, and banner-layout changes with the overlay behavior. Works for both official data and `?unofficialrun=` overlays.

## Validation

- `bun run typecheck`, `bun run lint`, `bun run fmt`, and `bun run check:typography`
- Focused Vitest overlay/domain tests: 12 passed
- Cypress component scatter and banner specs: 51 passed
- Cypress `overlay-optimal-only` browser spec: 4 passed

## 中文说明

相同硬件、相同精度的多个非官方运行现在共用一条 Pareto 曲线和一组“仅显示最优”边界。移除某个运行后，曲线会重新计算；各数据点仍保留所属运行的颜色。横幅新增开关，可将推理和评估图表中的红色非官方背景切换为 SemiAnalysis 水印。

已合并最新 `master`，并将其中的功耗边界、性能标尺和横幅布局改动与非官方运行叠加逻辑衔接。官方数据及 `?unofficialrun=` 叠加数据均可正常使用。

验证：类型检查、lint、格式和排版检查通过；相关 Vitest 测试 12 项、Cypress 组件测试 51 项、浏览器测试 4 项全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how unofficial multi-run overlays compute Pareto visibility and rooflines, which affects chart interpretation; watermark toggle is UI-only but touches shared chart rendering paths.
> 
> **Overview**
> **Unofficial overlay charts now merge rooflines and Pareto logic by hardware + precision across multiple preview runs**, instead of drawing separate curves per run. Optimal Only, power envelopes, and perf-ruler curve IDs follow the combined frontier; dismissing a run shrinks the merged set and recomputes the path.
> 
> **A new “Remove unofficial BG” control** on the unofficial banner toggles chart watermarks: the red unofficial pattern/warning is replaced by the SemiAnalysis logo (`logo-always`, including on unofficial hostnames). State lives in `UnofficialRunProvider` and flows through scatter and evaluation charts via `getChartWatermark`.
> 
> Tests cover combined overlay behavior, watermark switching in e2e, and updated expectations where two overlay runs now share one envelope curve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 250052d4e22766cebe69231bce0c54747b02a22c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->