### PR TITLE
Default TCO basis to Internal and show the selector only for Qwen3.5 8K/1K / TCO 口径默认改为内部，仅在 Qwen3.5 8K/1K 显示切换

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -2,11 +2,13 @@
 
 ## TCO basis
 
-The global **TCO Basis** control switches between external customer pricing (the default)
-and internal owner cost. TPUv7 uses **$1.21/chip/hour external** and **$1.03/chip/hour internal**;
+The global **TCO Basis** control switches between internal owner cost (the default) and
+external customer pricing. TPUv7 uses **$1.03/chip/hour internal** and **$1.21/chip/hour external**;
 other hardware retains its existing rates. The selection is shared across inference, historical
 trends, the TCO calculator, fleet lifecycle, and the profit estimator, and is encoded as
-`g_tco=internal` in share links. Explicit custom hourly costs remain user-controlled.
+`g_tco=external` in share links. The selector itself is only rendered for model/scenario pairs
+listed in `MODEL_TCO_BASIS_SELECTOR` (`data-mappings.ts`), currently Qwen3.5 on 8K/1K, since it
+only reprices hardware benchmarked there. Explicit custom hourly costs remain user-controlled.
 
 The basis changes cost per token and tokens per dollar, including unofficial overlays, without
 changing measured throughput or energy assumptions. TPUv7's Qwen3.5 snapshot uses four physical

--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -1,6 +1,6 @@
 import 'cypress-axe';
 import WorkflowInfoDisplay from '@/components/inference/ui/WorkflowInfoDisplay';
-import { Sequence } from '@/lib/data-mappings';
+import { Model, Sequence } from '@/lib/data-mappings';
 import InferenceChartControls from '@/components/inference/ui/ChartControls';
 import { SearchableSelect } from '@/components/ui/searchable-select';
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
@@ -239,8 +239,26 @@ describe('Inference ChartControls cost metrics', () => {
   beforeEach(() => {
     mountWithProviders(<InferenceChartControls showXAxisMode />, {
       inference: { selectedYAxisMetric: 'y_costh' },
-      globalFilters: {},
+      // The TCO Basis selector is scoped to Qwen3.5 on 8K/1K.
+      globalFilters: { selectedModel: Model.Qwen3_5, effectiveSequence: Sequence.EightK_OneK },
     });
+  });
+
+  it('hides the TCO basis toggle for other models and scenarios', () => {
+    mountWithProviders(<InferenceChartControls showXAxisMode />, {
+      inference: { selectedYAxisMetric: 'y_costh' },
+      globalFilters: {
+        selectedModel: Model.DeepSeek_V4_Pro,
+        effectiveSequence: Sequence.EightK_OneK,
+      },
+    });
+    cy.get('[data-testid="yaxis-metric-selector"]').should('exist');
+    cy.get('[data-testid="tco-basis-toggle"]').should('not.exist');
+    mountWithProviders(<InferenceChartControls showXAxisMode />, {
+      inference: { selectedYAxisMetric: 'y_costh' },
+      globalFilters: { selectedModel: Model.Qwen3_5, effectiveSequence: Sequence.AgenticTraces },
+    });
+    cy.get('[data-testid="tco-basis-toggle"]').should('not.exist');
   });
 
   it('sizes the TCO basis toggle to its buttons on desktop and mobile', () => {

--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -887,7 +887,7 @@ describe('Fleet — self-contained lifecycle regressions', () => {
 
     readCapturedLifecycleCsv().then((csv) => {
       const header = csv.split('\n').find((line) => line.startsWith('Chip,'));
-      expect(csv).to.contain('TCO basis external');
+      expect(csv).to.contain('TCO basis internal');
       const dataLines = csv.split('\n').filter((line) => line && !line.startsWith('#'));
       for (const line of dataLines.slice(1)) {
         // The current fleet fixture has no commas inside cell values.
@@ -899,13 +899,9 @@ describe('Fleet — self-contained lifecycle regressions', () => {
         'Chip,Config Now,First Run,Latest Best,Improvements,Gain,Chips,tok/s/MW now,Concurrent Users now,Revenue $/day,Cost $/day,Margin $/day,Payback,Cumulative Margin,Availability',
       );
     });
-    cy.get('[data-testid="tco-basis-internal"]').click();
-    exportMenu().click();
-    cy.get('[data-testid="export-csv-button"]').click();
-    readCapturedLifecycleCsv().then((csv) => {
-      expect(csv).to.contain('TCO basis internal');
-    });
-    cy.get('[data-testid="tco-basis-external"]').click();
+    // The TCO Basis selector is scoped to Qwen3.5 8K/1K; the fleet fixture
+    // runs DeepSeek on agentic traces, so it stays on the internal default.
+    cy.get('[data-testid="tco-basis-toggle"]').should('not.exist');
   });
 });
 

--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -1096,7 +1096,7 @@ describe('Fleet — Fleet Lifecycle in Chinese', () => {
       readCapturedLifecycleCsv().then((csv) => {
         expect(csv.split('\n').find((line) => line.startsWith('芯片,'))).to.contain(header);
         expect(csv.split('\n').find((line) => line.startsWith('# 假设：'))).to.equal(
-          '# 假设：输入价格 $1.25/M tok，输出价格 $3.5/M tok，爬坡期 2 个月，平均中断间隔（MTBI）12 天，恢复时间 6 小时，测算期 18 个月，设施功率 4 MW，TCO 口径：外部',
+          '# 假设：输入价格 $1.25/M tok，输出价格 $3.5/M tok，爬坡期 2 个月，平均中断间隔（MTBI）12 天，恢复时间 6 小时，测算期 18 个月，设施功率 4 MW，TCO 口径：内部',
         );
         expect(csv).not.to.contain('# Assumptions:');
       });

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -220,27 +220,29 @@ describe('TPUv7 launch banner', { testIsolation: true }, () => {
       });
       const dots = '.dot-group[data-hw-key^="tpuv7"]';
 
+      // Internal owner cost is the default basis; External is the opt-in.
+      cy.get('[data-testid="tco-basis-internal"]').should('have.attr', 'aria-pressed', 'true');
       cy.get(dots)
         .first()
         .then(($point) => {
-          const external = { ...datum($point[0]) };
-          cy.get('[data-testid="tco-basis-internal"]').click();
+          const internal = { ...datum($point[0]) };
+          cy.get('[data-testid="tco-basis-external"]').click();
           cy.get(dots)
             .first()
-            .should(($internal) => {
-              expect(datum($internal[0]).y).to.be.closeTo((external.y * 1.03) / 1.21, 1e-8);
-              expect(datum($internal[0]).x).to.equal(external.x);
+            .should(($external) => {
+              expect(datum($external[0]).y).to.be.closeTo((internal.y * 1.21) / 1.03, 1e-8);
+              expect(datum($external[0]).x).to.equal(internal.x);
             });
           cy.get('[data-testid="share-button"]').first().click();
           cy.get('[data-testid="share-url-input"]')
             .invoke('val')
-            .should('include', 'g_tco=internal')
+            .should('include', 'g_tco=external')
             .then((url) => cy.visit(String(url)));
-          cy.get('[data-testid="tco-basis-internal"]').should('have.attr', 'aria-pressed', 'true');
+          cy.get('[data-testid="tco-basis-external"]').should('have.attr', 'aria-pressed', 'true');
           cy.get(dots)
             .first()
-            .should(($internal) => {
-              expect(datum($internal[0]).y).to.be.closeTo((external.y * 1.03) / 1.21, 1e-8);
+            .should(($external) => {
+              expect(datum($external[0]).y).to.be.closeTo((internal.y * 1.21) / 1.03, 1e-8);
             });
           cy.get('[data-testid="tco-basis-toggle"]').scrollIntoView();
           cy.screenshot(`tco-basis-${locale ? 'zh' : 'en'}-desktop`, { capture: 'viewport' });
@@ -248,11 +250,11 @@ describe('TPUv7 launch banner', { testIsolation: true }, () => {
           cy.get('[data-testid="inference-secondary-controls"] > button').click();
           cy.get('[data-testid="tco-basis-toggle"]').scrollIntoView().should('be.visible');
           cy.screenshot(`tco-basis-${locale ? 'zh' : 'en'}-mobile`, { capture: 'viewport' });
-          cy.get('[data-testid="tco-basis-external"]').click();
+          cy.get('[data-testid="tco-basis-internal"]').click();
           cy.get(dots)
             .first()
             .should(($restored) => {
-              expect(datum($restored[0]).y).to.be.closeTo(external.y, 1e-8);
+              expect(datum($restored[0]).y).to.be.closeTo(internal.y, 1e-8);
             });
         });
     });
@@ -292,20 +294,30 @@ describe('TPUv7 launch banner', { testIsolation: true }, () => {
     cy.get(points)
       .first()
       .then(($point) => {
-        const external = { ...datum($point[0]) };
-        cy.get('[data-testid="tco-basis-internal"]').click();
-        cy.get(points)
-          .first()
-          .should(($internal) => {
-            expect(datum($internal[0]).y).to.be.closeTo((external.y * 1.03) / 1.21, 1e-8);
-            expect(datum($internal[0]).x).to.equal(external.x);
-          });
+        const internal = { ...datum($point[0]) };
         cy.get('[data-testid="tco-basis-external"]').click();
         cy.get(points)
           .first()
+          .should(($external) => {
+            expect(datum($external[0]).y).to.be.closeTo((internal.y * 1.21) / 1.03, 1e-8);
+            expect(datum($external[0]).x).to.equal(internal.x);
+          });
+        cy.get('[data-testid="tco-basis-internal"]').click();
+        cy.get(points)
+          .first()
           .should(($restored) => {
-            expect(datum($restored[0]).y).to.be.closeTo(external.y, 1e-8);
+            expect(datum($restored[0]).y).to.be.closeTo(internal.y, 1e-8);
           });
       });
+  });
+  it('hides the TCO basis selector outside Qwen3.5 8K/1K', () => {
+    cy.visit('/inference?g_model=DeepSeek-V4-Pro&i_seq=8k/1k&i_metric=y_costh', {
+      onBeforeLoad(win) {
+        win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      },
+    });
+    cy.get('[data-testid="inference-chart-display"]').should('be.visible');
+    cy.get('[data-testid="yaxis-metric-selector"]').should('exist');
+    cy.get('[data-testid="tco-basis-toggle"]').should('not.exist');
   });
 });

--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -473,7 +473,7 @@ export function createMockGlobalFilterContexts(
     setSelectedSequence: namedStub('setSelectedSequence_global'),
     selectedPrecisions: [Precision.FP4],
     setSelectedPrecisions: namedStub('setSelectedPrecisions_global'),
-    tcoBasis: 'external' as const,
+    tcoBasis: 'internal' as const,
     setTcoBasis: namedStub('setTcoBasis_global'),
     effectiveSequence: Sequence.EightK_OneK,
     sequenceResolved: true,

--- a/packages/app/src/components/GlobalFilterContext.tsx
+++ b/packages/app/src/components/GlobalFilterContext.tsx
@@ -44,7 +44,7 @@ import { computeAutoSwitchDecision } from '@/lib/unofficial-run-auto-switch';
 import { countCurvesByPrecision, resolveEffectivePrecisions } from '@/lib/default-precisions';
 import { resolveEffectiveSequence } from '@/lib/default-sequence';
 import type { AvailabilityRow, WorkflowInfoResponse } from '@/lib/api';
-import type { TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, type TcoBasis } from '@/lib/constants';
 
 const RUNDATE_RE = /^\d{4}-\d{2}-\d{2}$/u;
 const RUNID_RE = /^[A-Za-z0-9_-]{1,64}$/u;
@@ -319,7 +319,7 @@ export function GlobalFilterProvider({
   );
 
   const [requestedRunId, setRequestedRunId] = useState<string>(() => initialRunId ?? '');
-  const [tcoBasis, setTcoBasis] = useState<TcoBasis>('external');
+  const [tcoBasis, setTcoBasis] = useState<TcoBasis>(DEFAULT_TCO_BASIS);
 
   // Apply URL param overrides synchronously after the first commit. Runs only
   // on the client (useEffect on server is a no-op). Updates state before paint
@@ -418,7 +418,7 @@ export function GlobalFilterProvider({
     // cannot fight a user changing filters in place. A param-only navigation
     // within /inference is therefore not picked up — no in-app link does that
     // today, and covering it would mean the Suspense bailout above.
-    setTcoBasis(getUrlParam('g_tco') === 'internal' ? 'internal' : 'external');
+    setTcoBasis(getUrlParam('g_tco') === 'external' ? 'external' : DEFAULT_TCO_BASIS);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TcoBasisToggle } from '@/components/ui/tco-basis-toggle';
+import { TcoBasisToggle, useShowsTcoBasisSelector } from '@/components/ui/tco-basis-toggle';
 
 import { useCallback, useMemo, useState } from 'react';
 
@@ -149,6 +149,7 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
     effectiveSequence: selectedSequence,
     effectivePrecisions: selectedPrecisions,
   } = useGlobalFilterSelection();
+  const showsTcoBasis = useShowsTcoBasisSelector();
   const { setSelectedModel, setSelectedSequence, setSelectedPrecisions } = useGlobalFilterActions();
   const { selectedRunDate } = useGlobalFilterRun();
   const { availablePrecisions, availableSequences, availableModels } =
@@ -478,17 +479,19 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                 </div>
               </div>
 
-              <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
-                <LabelWithTooltip
-                  label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
-                  tooltip={
-                    locale === 'zh'
-                      ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
-                      : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
-                  }
-                />
-                <TcoBasisToggle source="fleet" className="h-9" />
-              </div>
+              {showsTcoBasis && (
+                <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
+                  <LabelWithTooltip
+                    label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
+                    tooltip={
+                      locale === 'zh'
+                        ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
+                        : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
+                    }
+                  />
+                  <TcoBasisToggle source="fleet" className="h-9" />
+                </div>
+              )}
 
               {/* Target value slider + input */}
               {!loading && hasData && (

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TcoBasisToggle } from '@/components/ui/tco-basis-toggle';
+import { TcoBasisToggle, useShowsTcoBasisSelector } from '@/components/ui/tco-basis-toggle';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -516,6 +516,7 @@ function ProfitEstimatorInner({
     sequenceResolved,
     effectivePrecisions: selectedPrecisions,
   } = useGlobalFilterSelection();
+  const showsTcoBasis = useShowsTcoBasisSelector();
   const { setSelectedModel, setSelectedSequence } = useGlobalFilterActions();
   const { selectedRunDate } = useGlobalFilterRun();
   const { availableModels, availabilityRows } = useGlobalFilterAvailability();
@@ -1525,17 +1526,19 @@ function ProfitEstimatorInner({
                 </div>
               )}
 
-              <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
-                <LabelWithTooltip
-                  label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
-                  tooltip={
-                    locale === 'zh'
-                      ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
-                      : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
-                  }
-                />
-                <TcoBasisToggle source="profit" className="h-9" />
-              </div>
+              {showsTcoBasis && (
+                <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
+                  <LabelWithTooltip
+                    label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
+                    tooltip={
+                      locale === 'zh'
+                        ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
+                        : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
+                    }
+                  />
+                  <TcoBasisToggle source="profit" className="h-9" />
+                </div>
+              )}
 
               {costProvider === 'custom' && customCostBases.length > 0 && (
                 <div

--- a/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ThroughputCalculatorDisplay.tsx
@@ -58,7 +58,7 @@ import { Switch } from '@/components/ui/switch';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MultiSelect } from '@/components/ui/multi-select';
 import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/segmented-toggle';
-import { TcoBasisToggle } from '@/components/ui/tco-basis-toggle';
+import { TcoBasisToggle, useShowsTcoBasisSelector } from '@/components/ui/tco-basis-toggle';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   Percentile,
@@ -369,6 +369,7 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
     effectivePrecisions: selectedPrecisions,
     tcoBasis,
   } = useGlobalFilterSelection();
+  const showsTcoBasis = useShowsTcoBasisSelector();
   const { setSelectedModel, setSelectedSequence, setSelectedPrecisions } = useGlobalFilterActions();
   const { selectedRunDate, selectedRunId } = useGlobalFilterRun();
   const { availablePrecisions, availableSequences, availableModels } =
@@ -1047,10 +1048,12 @@ function ThroughputCalculatorInner({ initialPercentile }: { initialPercentile: P
                     />
                   </div>
                 </div>
-                <div className="flex min-w-0 flex-col space-y-1.5">
-                  <LabelWithTooltip label={t.tcoBasisLabel} tooltip={t.tcoBasisTooltip} />
-                  <TcoBasisToggle source="calculator" className="h-9" />
-                </div>
+                {showsTcoBasis && (
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip label={t.tcoBasisLabel} tooltip={t.tcoBasisTooltip} />
+                    <TcoBasisToggle source="calculator" className="h-9" />
+                  </div>
+                )}
               </ControlPanel>
 
               <MobileControlSection

--- a/packages/app/src/components/calculator/historical-best.ts
+++ b/packages/app/src/components/calculator/historical-best.ts
@@ -29,7 +29,7 @@
  */
 
 import type { BenchmarkRow } from '@/lib/api';
-import type { TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, type TcoBasis } from '@/lib/constants';
 import { Percentile, type Sequence } from '@/lib/data-mappings';
 
 import { interpolateForGPU, paretoFrontUpperLeft } from './interpolation';
@@ -136,7 +136,7 @@ export function groupHistoryByHwKeyAndDate(options: GroupHistoryOptions): Histor
     precisions,
     percentile = Percentile.P90,
     tokenType = 'total',
-    tcoBasis = 'external',
+    tcoBasis = DEFAULT_TCO_BASIS,
     visibleHwKeys,
   } = options;
   if (rows.length === 0 || precisions.length === 0) {

--- a/packages/app/src/components/calculator/useHistoricalBest.ts
+++ b/packages/app/src/components/calculator/useHistoricalBest.ts
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { sequenceToIslOsl } from '@semianalysisai/inferencex-constants';
 
 import { useBenchmarkHistory } from '@/hooks/api/use-benchmark-history';
-import type { TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, type TcoBasis } from '@/lib/constants';
 import { useStableValue } from '@/hooks/useStableValue';
 import { Percentile, type Model, type Sequence } from '@/lib/data-mappings';
 
@@ -62,7 +62,7 @@ export function useHistoricalBest(options: UseHistoricalBestOptions): UseHistori
     costProvider,
     costType,
     percentile = Percentile.P90,
-    tcoBasis = 'external',
+    tcoBasis = DEFAULT_TCO_BASIS,
     enabled,
   } = options;
 

--- a/packages/app/src/components/calculator/useThroughputData.test.ts
+++ b/packages/app/src/components/calculator/useThroughputData.test.ts
@@ -1363,7 +1363,9 @@ describe('buildGpuGroups', () => {
       precisions: ['fp8'],
       classify: singlePrecisionClassify,
     };
-    const external = Object.values(buildGpuGroups([row], options).grouped)[0][0];
+    const external = Object.values(
+      buildGpuGroups([row], { ...options, tcoBasis: 'external' }).grouped,
+    )[0][0];
     const internal = Object.values(
       buildGpuGroups([row], { ...options, tcoBasis: 'internal' }).grouped,
     )[0][0];

--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -10,7 +10,13 @@ import type { BenchmarkRow } from '@/lib/api';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import { pricingCacheHitRate } from '@/lib/cache-pricing';
 import { getHardwareKey } from '@/lib/chart-utils';
-import { getModelSortIndex, getHardwareConfig, getGpuSpecs, type TcoBasis } from '@/lib/constants';
+import {
+  DEFAULT_TCO_BASIS,
+  getModelSortIndex,
+  getHardwareConfig,
+  getGpuSpecs,
+  type TcoBasis,
+} from '@/lib/constants';
 import { Percentile, Sequence, type Model } from '@/lib/data-mappings';
 import { overlayRunIndex } from '@/lib/overlay-run-style';
 import { supportsTokenMetric } from '@/lib/supplemental-benchmarks';
@@ -171,7 +177,7 @@ export function buildGpuGroups<M extends GroupMeta>(
     precisions,
     percentile = Percentile.P90,
     tokenType = 'total',
-    tcoBasis = 'external',
+    tcoBasis = DEFAULT_TCO_BASIS,
     classify,
   } = options;
   const grouped: Record<string, GPUDataPoint[]> = {};
@@ -266,7 +272,7 @@ export function useThroughputData(
   initialRows?: BenchmarkRow[],
   enabled = true,
   selectedTokenType: CostType = 'total',
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ) {
   const initialCacheScope = useMemo(
     () =>

--- a/packages/app/src/components/inference/hooks/useChartData.ts
+++ b/packages/app/src/components/inference/hooks/useChartData.ts
@@ -28,6 +28,7 @@ import {
 import { useBenchmarks, benchmarkQueryOptions } from '@/hooks/api/use-benchmarks';
 import type { BenchmarkRow } from '@/lib/api';
 import {
+  DEFAULT_TCO_BASIS,
   GPU_ALIAS_TO_CANONICAL,
   getModelSortIndex,
   hardwareKeyMatchesAnyBase,
@@ -266,7 +267,7 @@ export function useChartData(
   },
   benchmarkQueryScope?: string,
   initialBenchmarkRows?: BenchmarkRow[],
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ) {
   // When the selected date is the latest available, use '' (empty string) to match
   // the initial no-date query key, reusing the eagerly-fetched benchmarks from the

--- a/packages/app/src/components/inference/hooks/useInterpolatedTrendData.test.ts
+++ b/packages/app/src/components/inference/hooks/useInterpolatedTrendData.test.ts
@@ -74,7 +74,7 @@ describe('rowToLightweightPoint', () => {
   it('uses the selected TPU cost basis for historical cost and tokens per dollar', () => {
     const row = makeBenchmarkRow({ hardware: 'tpuv7', framework: 'vllm' });
     const metrics = ['costhOutput', 'outputTokensPerDollarH', 'tpPerMw'] as const;
-    const external = rowToLightweightPoint(row, metrics)!;
+    const external = rowToLightweightPoint(row, metrics, undefined, 'external')!;
     const internal = rowToLightweightPoint(row, metrics, undefined, 'internal')!;
     expect(internal.costhOutput!.y).toBeCloseTo((external.costhOutput!.y * 1.03) / 1.21);
     expect(internal.outputTokensPerDollarH!.y).toBeCloseTo(

--- a/packages/app/src/components/inference/hooks/useInterpolatedTrendData.ts
+++ b/packages/app/src/components/inference/hooks/useInterpolatedTrendData.ts
@@ -28,7 +28,7 @@ import {
 } from '@/components/calculator/useThroughputData';
 import { useBenchmarkHistory } from '@/hooks/api/use-benchmark-history';
 import { buildDerivedChartFields, getHardwareKey, type DerivedMetricKey } from '@/lib/chart-utils';
-import { isKnownGpu, type TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, isKnownGpu, type TcoBasis } from '@/lib/constants';
 import { rowToAggDataEntry } from '@/lib/benchmark-transform';
 import type { BenchmarkRow } from '@/lib/api';
 import { benchmarkCurveDate, dedupeAgenticHistoryRuns } from '@/lib/benchmark-run-selection';
@@ -50,7 +50,7 @@ export function rowToLightweightPoint(
   row: BenchmarkRow,
   requestedMetrics: readonly DerivedMetricKey[],
   tokenRevenuePricing: TokenRevenuePricing | null = NORMALIZED_TOKEN_REVENUE_PRICING,
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ): InferenceData | null {
   const entry = rowToAggDataEntry(row);
   const hwKey = getHardwareKey(entry);
@@ -339,7 +339,7 @@ export function useInterpolatedTrendData({
   targetInteractivity,
   tokenRevenuePricing = NORMALIZED_TOKEN_REVENUE_PRICING,
   enabled,
-  tcoBasis = 'external',
+  tcoBasis = DEFAULT_TCO_BASIS,
 }: UseInterpolatedTrendDataParams): UseInterpolatedTrendDataResult {
   const seqIslOsl = useMemo(() => sequenceToIslOsl(selectedSequence), [selectedSequence]);
 

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TcoBasisToggle } from '@/components/ui/tco-basis-toggle';
+import { TcoBasisToggle, useShowsTcoBasisSelector } from '@/components/ui/tco-basis-toggle';
 
 import { ControlPanel } from '@/components/ui/control-panel';
 import { useEffect, useMemo, useState } from 'react';
@@ -183,6 +183,7 @@ export default function ChartControls({
   useEffect(() => setMounted(true), []);
 
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown<string>();
+  const showsTcoBasis = useShowsTcoBasisSelector();
 
   const { selectedModel, selectedSequence, selectedPrecisions, selectedGPUs, selectedDateRange } =
     useInferenceFilters();
@@ -448,7 +449,7 @@ export default function ChartControls({
                 />
               </div>
 
-              {mounted && isCostMetric(selectedYAxisMetric) && (
+              {mounted && showsTcoBasis && isCostMetric(selectedYAxisMetric) && (
                 <div className="flex min-w-0 flex-col space-y-1.5 sm:col-span-2">
                   <LabelWithTooltip label={t.tcoBasis} tooltip={t.tcoBasisTooltip} />
                   <TcoBasisToggle source={tcoSource} className="h-9" />

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -168,6 +168,30 @@ interface ChartControlsProps {
   showXAxisMode?: boolean;
 }
 
+/**
+ * TCO basis control for cost metrics. Reads the global model/scenario
+ * selection only when rendered, so ChartControls itself does not need a
+ * GlobalFilterProvider unless a cost metric is active.
+ */
+function TcoBasisField({
+  source,
+  label,
+  tooltip,
+}: {
+  source: 'inference' | 'historical';
+  label: string;
+  tooltip: string;
+}) {
+  const showsTcoBasis = useShowsTcoBasisSelector();
+  if (!showsTcoBasis) return null;
+  return (
+    <div className="flex min-w-0 flex-col space-y-1.5 sm:col-span-2">
+      <LabelWithTooltip label={label} tooltip={tooltip} />
+      <TcoBasisToggle source={source} className="h-9" />
+    </div>
+  );
+}
+
 export default function ChartControls({
   hideGpuComparison = false,
   tcoSource = 'inference',
@@ -183,8 +207,6 @@ export default function ChartControls({
   useEffect(() => setMounted(true), []);
 
   const { openDropdown, handleDropdownOpenChange } = useOpenDropdown<string>();
-  const showsTcoBasis = useShowsTcoBasisSelector();
-
   const { selectedModel, selectedSequence, selectedPrecisions, selectedGPUs, selectedDateRange } =
     useInferenceFilters();
   const {
@@ -449,11 +471,8 @@ export default function ChartControls({
                 />
               </div>
 
-              {mounted && showsTcoBasis && isCostMetric(selectedYAxisMetric) && (
-                <div className="flex min-w-0 flex-col space-y-1.5 sm:col-span-2">
-                  <LabelWithTooltip label={t.tcoBasis} tooltip={t.tcoBasisTooltip} />
-                  <TcoBasisToggle source={tcoSource} className="h-9" />
-                </div>
+              {mounted && isCostMetric(selectedYAxisMetric) && (
+                <TcoBasisField source={tcoSource} label={t.tcoBasis} tooltip={t.tcoBasisTooltip} />
               )}
               {mounted && usesTokenSalePricing(selectedYAxisMetric) && (
                 <div className="flex min-w-0 flex-col space-y-1.5 sm:col-span-2">

--- a/packages/app/src/components/ui/chart-display-helpers.tsx
+++ b/packages/app/src/components/ui/chart-display-helpers.tsx
@@ -14,7 +14,7 @@ import { ExternalLinkIcon } from '@/components/ui/external-link-icon';
 import { ShareButton } from '@/components/ui/share-button';
 import { useLocale } from '@/lib/use-locale';
 import type { Locale } from '@/lib/i18n';
-import { getGpuSpecs, type TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, getGpuSpecs, type TcoBasis } from '@/lib/constants';
 
 // Keep these metric-key groups in sync with chart-utils/chart configs when new source-backed
 // metrics are added; this helper owns which caption notes and caveats appear for each family.
@@ -179,7 +179,7 @@ export function MetricAssumptionNotes({
   activeHwKeys,
   includeAllPowerThroughputMetrics = true,
   includePowerThroughputCaveat = true,
-  tcoBasis = 'external',
+  tcoBasis = DEFAULT_TCO_BASIS,
 }: {
   selectedYAxisMetric: string;
   /**

--- a/packages/app/src/components/ui/tco-basis-toggle.tsx
+++ b/packages/app/src/components/ui/tco-basis-toggle.tsx
@@ -6,6 +6,7 @@ import { useGlobalFilterSelection, useGlobalFilterActions } from '@/components/G
 import { SegmentedToggle, type SegmentedToggleOption } from '@/components/ui/segmented-toggle';
 import { track } from '@/lib/analytics';
 import type { TcoBasis } from '@/lib/constants';
+import { showsTcoBasisSelector } from '@/lib/data-mappings';
 import { useLocale } from '@/lib/use-locale';
 import { cn } from '@/lib/utils';
 
@@ -13,6 +14,16 @@ const LABELS = {
   en: { external: 'External', internal: 'Internal', aria: 'TCO basis' },
   zh: { external: '外部', internal: '内部', aria: 'TCO 口径' },
 } as const;
+
+/**
+ * Whether the current model/scenario exposes the TCO Basis selector. The basis
+ * state itself is global; only the control is scoped to scenarios that
+ * benchmark hardware with a distinct internal owner cost.
+ */
+export function useShowsTcoBasisSelector(): boolean {
+  const { selectedModel, effectiveSequence } = useGlobalFilterSelection();
+  return showsTcoBasisSelector(selectedModel, effectiveSequence);
+}
 
 /** Global external customer pricing versus internal owner cost selection. */
 export function TcoBasisToggle({ source, className }: { source: string; className?: string }) {

--- a/packages/app/src/components/unofficial-run-provider.test.ts
+++ b/packages/app/src/components/unofficial-run-provider.test.ts
@@ -198,6 +198,27 @@ describe('buildChartData', () => {
     expect(Object.keys(result)).toEqual(['DeepSeek-R1-0528_8k/1k']);
   });
 
+  it('prices TPUv7 overlay points on the external basis for later repricing', () => {
+    // processOverlayChartDataWithClipping reprices from external at render
+    // time, so the source overlay data must not already carry the internal
+    // owner cost even though internal is the app default.
+    const rows = [
+      stubRow({
+        model: 'qwen3.5-397b',
+        hardware: 'tpuv7',
+        framework: 'vllm',
+        isl: 8192,
+        osl: 1024,
+      }),
+    ];
+    const result = buildChartData(rows);
+    const [key] = Object.keys(result);
+    const point = result[key].interactivity.data[0];
+    expect(point.hwKey.startsWith('tpuv7')).toBe(true);
+    expect(point.costh!.y).toBeCloseTo(1.21 / (100 * 3600 * 1e-6));
+    expect(point.costh!.y).not.toBeCloseTo(1.03 / (100 * 3600 * 1e-6));
+  });
+
   it('skips rows with unmapped ISL/OSL', () => {
     const rows = [stubRow({ model: 'dsr1', isl: 4096, osl: 4096 })];
     const result = buildChartData(rows);

--- a/packages/app/src/components/unofficial-run-provider.tsx
+++ b/packages/app/src/components/unofficial-run-provider.tsx
@@ -135,7 +135,11 @@ export function buildChartData(benchmarks: BenchmarkRow[]): UnofficialChartData 
 
   const result: UnofficialChartData = {};
   for (const [key, rows] of groups) {
-    const { chartData, hardwareConfig } = transformBenchmarkRows(rows);
+    // Overlay points are always priced on the external basis here;
+    // `processOverlayChartDataWithClipping` reprices them to the selected
+    // basis at render time, so seeding them with the app default would
+    // double-apply the internal/external ratio.
+    const { chartData, hardwareConfig } = transformBenchmarkRows(rows, 'median', 'external');
     const e2eIdx = (chartDefinitions as ChartDefinition[]).findIndex((d) => d.chartType === 'e2e');
     const interactivityIdx = (chartDefinitions as ChartDefinition[]).findIndex(
       (d) => d.chartType === 'interactivity',

--- a/packages/app/src/lib/benchmark-transform.ts
+++ b/packages/app/src/lib/benchmark-transform.ts
@@ -17,7 +17,7 @@ import {
   getHardwareKey,
   type DerivedChartFields,
 } from '@/lib/chart-utils';
-import { getHardwareConfig, type TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, getHardwareConfig, type TcoBasis } from '@/lib/constants';
 import { isPersistedBenchmarkId } from '@/lib/benchmark-id';
 import { resolvePowerTier } from '@/lib/power-tier';
 import type { BenchmarkRow } from '@/lib/api';
@@ -385,7 +385,7 @@ export function mergeRunScopedRows(
 export function transformBenchmarkRows(
   rows: BenchmarkRow[],
   percentile = 'median',
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ): {
   chartData: InferenceData[][];
   hardwareConfig: HardwareConfig;

--- a/packages/app/src/lib/chart-utils.ts
+++ b/packages/app/src/lib/chart-utils.ts
@@ -17,7 +17,7 @@ import {
   BENCHMARK_METRIC_CONFIG_KEYS,
   type BenchmarkMetricKey,
 } from '@/components/inference/metric-registry';
-import { getGpuSpecs, isKnownGpu, type TcoBasis } from '@/lib/constants';
+import { DEFAULT_TCO_BASIS, getGpuSpecs, isKnownGpu, type TcoBasis } from '@/lib/constants';
 import { getVendor, type Vendor } from '@/lib/dynamic-colors';
 import type { Locale } from '@/lib/i18n';
 
@@ -315,7 +315,7 @@ export function buildDerivedChartFields(
   entry: AggDataEntry,
   currentHwKey: string,
   requestedMetrics?: readonly DerivedMetricKey[],
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ): Partial<DerivedChartFields> {
   const requested = requestedMetrics ? new Set<DerivedMetricKey>(requestedMetrics) : null;
   const wants = (key: DerivedMetricKey) => requested === null || requested.has(key);

--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { HW_REGISTRY } from '@semianalysisai/inferencex-constants';
 
 import {
+  DEFAULT_TCO_BASIS,
   GPU_ALIAS_TO_CANONICAL,
   GPU_KEY_ALIASES,
   getGpuSpecs,
@@ -278,9 +279,9 @@ describe('getGpuSpecs', () => {
     expect(specs.costr).toBe(0);
   });
 
-  it('returns correct specs for all base GPUs in HW_REGISTRY', () => {
+  it('returns registry external rates for all base GPUs in HW_REGISTRY', () => {
     for (const [base, entry] of Object.entries(HW_REGISTRY)) {
-      const result = getGpuSpecs(base);
+      const result = getGpuSpecs(base, 'external');
       expect(result.power).toBe(entry.power);
       expect(result.tdp).toBe(entry.tdp);
       expect(result.costh).toBe(entry.costh);
@@ -301,6 +302,12 @@ describe('getGpuSpecs', () => {
       costh: 1.03,
       costr: 1.03,
     });
+  });
+
+  it('defaults to the internal owner cost basis', () => {
+    expect(DEFAULT_TCO_BASIS).toBe('internal');
+    expect(getGpuSpecs('tpuv7_vllm')).toEqual(getGpuSpecs('tpuv7_vllm', 'internal'));
+    expect(getGpuSpecs('tpuv7_vllm').costh).toBe(1.03);
   });
 
   it('keeps hardware without an owner cost on external rates', () => {

--- a/packages/app/src/lib/constants.ts
+++ b/packages/app/src/lib/constants.ts
@@ -23,13 +23,16 @@ export interface GpuSpecs {
 
 export type TcoBasis = 'external' | 'internal';
 
+/** App-wide TCO basis when no explicit selection or share-link param is present. */
+export const DEFAULT_TCO_BASIS: TcoBasis = 'internal';
+
 const DEFAULT_SPECS: GpuSpecs = { tdp: 0, power: 0, costh: 0, costr: 0 };
 
 /**
  * Look up power/cost specs for a hardware key by extracting the base GPU name.
  * Splits on '_' or '-' to get the base (e.g. "h100_vllm" -> "h100").
  */
-export function getGpuSpecs(hwKey: string, basis: TcoBasis = 'external'): GpuSpecs {
+export function getGpuSpecs(hwKey: string, basis: TcoBasis = DEFAULT_TCO_BASIS): GpuSpecs {
   const base = hwKey.split(/[-_]/u)[0];
   const entry = HW_REGISTRY[base];
   if (!entry) return DEFAULT_SPECS;

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -20,6 +20,7 @@ import {
   isSequenceDeprecatedForModel,
   getSequenceCategoryForModel,
   isBestPerSkuDefaultOff,
+  showsTcoBasisSelector,
   Model,
   Sequence,
   Precision,
@@ -280,6 +281,23 @@ describe('isBestPerSkuDefaultOff', () => {
   it('treats a missing model or scenario as the global default', () => {
     expect(isBestPerSkuDefaultOff(null, Sequence.EightK_OneK)).toBe(false);
     expect(isBestPerSkuDefaultOff(Model.Qwen3_5, undefined)).toBe(false);
+  });
+});
+
+// ===========================================================================
+// per-model TCO Basis selector
+// ===========================================================================
+describe('showsTcoBasisSelector', () => {
+  it('shows the selector only for Qwen3.5 on 8K/1K', () => {
+    expect(showsTcoBasisSelector(Model.Qwen3_5, Sequence.EightK_OneK)).toBe(true);
+    expect(showsTcoBasisSelector(Model.Qwen3_5, Sequence.AgenticTraces)).toBe(false);
+    expect(showsTcoBasisSelector(Model.Qwen3_5, Sequence.OneK_OneK)).toBe(false);
+    expect(showsTcoBasisSelector(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK)).toBe(false);
+  });
+
+  it('hides the selector when the model or scenario is unknown', () => {
+    expect(showsTcoBasisSelector(null, Sequence.EightK_OneK)).toBe(false);
+    expect(showsTcoBasisSelector(Model.Qwen3_5, undefined)).toBe(false);
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -551,6 +551,24 @@ export function isBestPerSkuDefaultOff(
   return MODEL_BEST_PER_SKU_DEFAULT_OFF[model]?.has(sequence) ?? false;
 }
 
+/**
+ * Model/scenario pairs that expose the external/internal TCO Basis selector.
+ * The basis only reprices hardware with a distinct owner cost (TPUv7 today),
+ * so the control is shown only where that hardware is benchmarked.
+ */
+const MODEL_TCO_BASIS_SELECTOR: Partial<Record<Model, ReadonlySet<Sequence>>> = {
+  [Model.Qwen3_5]: new Set([Sequence.EightK_OneK]),
+};
+
+/** Whether the TCO Basis selector is shown for this model and scenario. */
+export function showsTcoBasisSelector(
+  model: Model | null | undefined,
+  sequence: Sequence | null | undefined,
+): boolean {
+  if (!model || !sequence) return false;
+  return MODEL_TCO_BASIS_SELECTOR[model]?.has(sequence) ?? false;
+}
+
 export function getSequenceLabel(sequence: Sequence, locale: 'en' | 'zh' = 'en'): string {
   const config = SEQUENCE_CONFIG[sequence];
   if (!config) return sequence;

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -33,7 +33,7 @@ describe('PARAM_DEFAULTS', () => {
 
   it('defaults TCO to External so only Internal is share-link state', async () => {
     const { PARAM_DEFAULTS } = await import('@/lib/url-state');
-    expect(PARAM_DEFAULTS.g_tco).toBe('external');
+    expect(PARAM_DEFAULTS.g_tco).toBe('internal');
   });
 
   it('has an EMPTY default for i_seq so the selected scenario is always written', async () => {

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -123,7 +123,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   g_model: 'DeepSeek-V4-Pro',
   g_rundate: '',
   g_runid: '',
-  g_tco: 'external',
+  g_tco: 'internal',
   // No strippable default: per-route `initialSequence` seeds (e.g. the /compare
   // pages) make the no-param resolution route-dependent, so stripping '8k/1k'
   // (the global default) would revert an explicit 8K/1K pick back to the route's

--- a/packages/app/src/lib/utils.ts
+++ b/packages/app/src/lib/utils.ts
@@ -4,7 +4,7 @@ import { extendTailwindMerge } from 'tailwind-merge';
 import type { AggDataEntry, InferenceData, RunInfo } from '@/components/inference/types';
 import { FRAMEWORK_LABELS } from '@semianalysisai/inferencex-constants';
 
-import { getGpuSpecs, type TcoBasis } from './constants';
+import { DEFAULT_TCO_BASIS, getGpuSpecs, type TcoBasis } from './constants';
 
 // Custom letter-spacing tokens from globals.css. tailwind-merge only knows the
 // built-in tracking scale (tighter…widest), so without this, e.g.
@@ -208,7 +208,7 @@ export function getDisplayLabel(config: { label: string; suffix?: string }): str
  */
 export function computeOutputCostFields(
   data: InferenceData[],
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ): InferenceData[] {
   return data.map((item) => {
     if (
@@ -382,7 +382,7 @@ export function computeEnergyFields(data: InferenceData[]): InferenceData[] {
 
 export function computeInputCostFields(
   data: InferenceData[],
-  tcoBasis: TcoBasis = 'external',
+  tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
 ): InferenceData[] {
   return data.map((item) => {
     if (item.costhi && item.costri && item.inputTokensPerDollarH && item.inputTokensPerDollarR) {


### PR DESCRIPTION
## Summary

Follow-up to #1072.

- **Internal is now the default TCO basis** everywhere. New `DEFAULT_TCO_BASIS = 'internal'` in `lib/constants.ts` seeds `GlobalFilterContext`, `PARAM_DEFAULTS.g_tco`, `getGpuSpecs()`, and every helper that previously fell back to `'external'` (chart-utils, benchmark-transform, useThroughputData, useHistoricalBest, historical-best, useInterpolatedTrendData, useChartData, MetricAssumptionNotes, utils). SSR compare-per-dollar pages and overview data therefore also quote TPUv7 at $1.03/chip/hr.
- **Share links**: `g_tco=external` is the opt-in param; `g_tco=internal` is stripped as the default. Existing `?g_tco=internal` links keep working.
- **Selector scoped to Qwen3.5 8K/1K**. New `MODEL_TCO_BASIS_SELECTOR` table + `showsTcoBasisSelector(model, sequence)` in `data-mappings.ts` (same shape as `MODEL_BEST_PER_SKU_DEFAULT_OFF`), exposed to components through `useShowsTcoBasisSelector()` in `tco-basis-toggle.tsx`. The External/Internal control on `/inference`, `/historical`, `/calculator`, `/fleet`, and `/profit-estimator` renders only for that model/scenario. Basis state stays global; only the control is hidden, since it is a no-op for hardware without an owner cost.

## Tests

- Unit: `showsTcoBasisSelector` cases, `DEFAULT_TCO_BASIS` / `getGpuSpecs` default, `PARAM_DEFAULTS.g_tco`, explicit `'external'` where tests relied on the old implicit default.
- Cypress E2E: TPUv7 banner flow and unofficial overlay flow now start from Internal, opt into External, and assert `g_tco=external` in the share URL; new `hides the TCO basis selector outside Qwen3.5 8K/1K`; fleet CSV asserts `TCO basis internal` by default and that the toggle is absent for DeepSeek agentic.
- Cypress component: `ChartControls` cost-metric suite mounts with Qwen3.5 8K/1K; new case asserts the toggle is absent for DeepSeek V4 Pro and Qwen3.5 agentic.
- Local: `oxfmt`, `oxlint`, `tsc`, `check:typography` clean; affected vitest files pass (the only local failure is `Object.groupBy` on Node 20, unrelated).

Docs: `docs/tco-calculator.md` updated.

## 中文说明

- **TCO 口径默认改为内部持有成本**。新增 `DEFAULT_TCO_BASIS = 'internal'`，统一驱动 `GlobalFilterContext`、`PARAM_DEFAULTS.g_tco`、`getGpuSpecs()` 以及所有原本回退到 `'external'` 的辅助函数；SSR 对比页和总览数据同样按 TPUv7 $1.03/芯片/小时 计算。
- **分享链接**：`g_tco=external` 表示显式选择外部口径，`g_tco=internal` 作为默认值不再写入 URL；旧的 `?g_tco=internal` 链接仍然有效。
- **切换控件仅在 Qwen3.5 8K/1K 显示**。`data-mappings.ts` 新增 `MODEL_TCO_BASIS_SELECTOR` 表和 `showsTcoBasisSelector()`，组件通过 `useShowsTcoBasisSelector()` 决定是否渲染。口径状态仍为全局，只是在没有独立持有成本硬件的场景下隐藏控件。
- 同步更新了单元测试、Cypress E2E/组件测试和 `docs/tco-calculator.md`。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default cost/revenue math across inference, calculators, and exports; mis-scoped selector visibility or overlay repricing could show wrong TPUv7 economics without obvious UI cues.
> 
> **Overview**
> **Internal owner cost is now the default TCO basis** app-wide via `DEFAULT_TCO_BASIS`. That constant drives global filter state, URL defaults (`g_tco=internal`, with `g_tco=external` as the share-link opt-in), `getGpuSpecs()`, and all chart/calculator helpers that previously defaulted to external pricing—so TPUv7 cost metrics show at $1.03/chip/hr unless the user picks external.
> 
> The **External/Internal toggle is only shown for Qwen3.5 on 8K/1K** (`MODEL_TCO_BASIS_SELECTOR` + `useShowsTcoBasisSelector`). Inference, historical, calculator, fleet, and profit views hide the control elsewhere; global basis state still applies where hardware has no separate internal rate.
> 
> **Unofficial overlay chart data** is built with an explicit external basis so render-time repricing does not double-apply the internal/external ratio. Docs and Cypress/unit tests are updated for the new default, URL behavior, and conditional UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afb0c7e5cde52c292e43628c9d524f5356827138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->