### PR TITLE
fix: align profit and fleet page styling / 统一利润估算与集群生命周期页面样式

### DIFF
--- a/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
+++ b/packages/app/cypress/e2e/fleet-lifecycle.cy.ts
@@ -214,6 +214,37 @@ describe('Fleet — Fleet Lifecycle', () => {
     cy.get('[data-testid="calculator-lifecycle-empty"]').should('not.exist');
   });
 
+  it('keeps benchmark and chart controls inside their panels on phones and desktops', () => {
+    for (const width of [375, 1440]) {
+      cy.viewport(width, 900);
+      cy.get('[data-testid="fleet-benchmark-panel"]').within(() => {
+        cy.get('legend').should('have.text', 'Benchmark Config');
+        cy.get('#fleet-model').should('exist');
+        cy.get('#fleet-sequence').should('exist');
+        cy.get('#fleet-precision').should('exist');
+      });
+      cy.get('[data-testid="fleet-chart-panel"]').within(() => {
+        cy.get('legend').should('have.text', 'Chart Config');
+        cy.get('#fleet-cost').should('exist');
+        cy.get('#fleet-cost-type').should('exist');
+        cy.get('#fleet-target').should('exist');
+      });
+      cy.get('[data-testid="fleet-controls"] fieldset').should(($panels) => {
+        for (const panel of $panels) {
+          const bounds = panel.getBoundingClientRect();
+          expect(bounds.left).to.be.at.least(0);
+          expect(bounds.right).to.be.at.most(width);
+          for (const control of panel.querySelectorAll('input, button[role="combobox"]')) {
+            const rect = control.getBoundingClientRect();
+            expect(rect.left, `${control.id} left`).to.be.at.least(bounds.left);
+            expect(rect.right, `${control.id} right`).to.be.at.most(bounds.right);
+          }
+        }
+      });
+      assertFleetControlLabels();
+    }
+  });
+
   it('keeps fleet economics inputs together in the assumptions group', () => {
     cy.viewport(1280, 900);
     cy.get('[data-testid="calculator-lifecycle-section"] fieldset').should('have.length', 2);
@@ -1043,6 +1074,8 @@ describe('Fleet — Fleet Lifecycle in Chinese', () => {
 
   it('translates the section, including the table headers and notes', () => {
     assertFleetControlLabels('zh');
+    cy.get('[data-testid="fleet-benchmark-panel"] legend').should('have.text', '基准测试配置');
+    cy.get('[data-testid="fleet-chart-panel"] legend').should('have.text', '图表配置');
     cy.get('[data-testid="calculator-lifecycle-section"]')
       .should('contain.text', '集群生命周期')
       .and('contain.text', '设施功率 (MW)');

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -838,6 +838,8 @@ describe('Profit Estimator per GW — Chinese mirror', () => {
     cy.get('label[for="profit-lab-cut"]').should('contain.text', '模型许可费');
     cy.get('[data-testid="result-context-utilization"]').should('have.text', '60%');
     chart().should('contain.text', '模型许可费').and('contain.text', '利润');
+    cy.get('[data-testid="profit-benchmark-panel"] legend').should('have.text', '基准测试配置');
+    cy.get('[data-testid="profit-pricing-panel"] legend').should('have.text', '定价配置');
     cy.get('[data-testid="profit-caption"] h2').should('contain.text', '每吉瓦每年收入与利润估算');
     openFormulaNotes();
     cy.get('[data-testid="profit-formula-notes"]').should('contain.text', '利用率');
@@ -914,4 +916,65 @@ describe('Profit Estimator (per chip-hour)', () => {
       .should('have.attr', 'href', '/zh/calculator')
       .and('contain.text', 'TCO 计算器');
   });
+});
+
+describe('Profit Estimator — responsive control panels', () => {
+  beforeEach(stubOpenRouter);
+
+  for (const route of ['/profit-estimator', '/profit-estimator-per-gigawatt']) {
+    for (const width of [375, 1440]) {
+      it(`keeps benchmark and pricing controls grouped on ${route} at ${width}px`, () => {
+        cy.viewport(width, 1000);
+        cy.visit(route, { onBeforeLoad: suppressNudges });
+        chart().should('exist');
+        cy.get('[data-testid="profit-benchmark-panel"]').within(() => {
+          cy.get('legend').should('have.text', 'Benchmark Config');
+          cy.get('#profit-model').should('contain.text', 'Kimi K3');
+          cy.get('#profit-target').should('have.value', '45');
+        });
+        cy.get('[data-testid="profit-pricing-panel"]').within(() => {
+          cy.get('legend').should('have.text', 'Pricing Config');
+          cy.get('#profit-utilization').should('have.value', '60');
+          cy.get('#profit-lab-cut').should('have.value', '30');
+          cy.get('#profit-price-source').click();
+        });
+        cy.contains('[role="option"]', 'Custom $/M tok').click();
+        cy.get('#profit-cost').click();
+        cy.contains('[role="option"]', 'Custom $/GPU/hr').click();
+        cy.get('[data-testid="profit-pricing-panel"] [data-testid="profit-custom-prices"]')
+          .find('input')
+          .should('have.length', 3);
+        cy.get(
+          '[data-testid="profit-pricing-panel"] [data-testid="profit-custom-costs"] input',
+        ).should('have.length.greaterThan', 0);
+        cy.get('[data-testid="profit-controls"]').should(($controls) => {
+          const benchmark = $controls
+            .find('[data-testid="profit-benchmark-panel"]')[0]!
+            .getBoundingClientRect();
+          const pricing = $controls
+            .find('[data-testid="profit-pricing-panel"]')[0]!
+            .getBoundingClientRect();
+          if (width >= 1280) {
+            expect(Math.abs(benchmark.top - pricing.top), 'aligned panel tops').to.be.lessThan(2);
+            expect(pricing.left - benchmark.right, 'space between panels').to.be.at.least(15);
+          } else {
+            expect(pricing.top - benchmark.bottom, 'stacked panels').to.be.at.least(15);
+          }
+          for (const panel of $controls.find('fieldset')) {
+            const bounds = panel.getBoundingClientRect();
+            expect(bounds.left).to.be.at.least(0);
+            expect(bounds.right).to.be.at.most(width);
+            for (const control of panel.querySelectorAll('input, button[role="combobox"]')) {
+              const rect = control.getBoundingClientRect();
+              expect(rect.left, `${control.id} left`).to.be.at.least(bounds.left);
+              expect(rect.right, `${control.id} right`).to.be.at.most(bounds.right);
+              expect(rect.height, `${control.id} height`).to.be.at.least(width < 768 ? 44 : 36);
+            }
+          }
+        });
+        cy.get('#profit-utilization').clear().type('50').blur();
+        cy.get('[data-testid="result-context-utilization"]').should('have.text', '50%');
+      });
+    }
+  }
 });

--- a/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
+++ b/packages/app/src/components/calculator/FleetLifecycleDisplay.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/GlobalFilterContext';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { ControlPanel } from '@/components/ui/control-panel';
 import { DashboardSectionHeader } from '@/components/ui/dashboard-section-header';
 import ChartLegendItem from '@/components/ui/chart-legend-item';
 import { ChartShareActions } from '@/components/ui/chart-display-helpers';
@@ -76,6 +77,8 @@ const STRINGS = {
     title: 'Fleet Lifecycle',
     description:
       'Pick the model, workload, and target interactivity. The projection below sizes a fixed fleet of each chip against a facility power budget and reads the full run history at this operating point — see the section itself for what the lines mean.',
+    benchmarkGroup: 'Benchmark Config',
+    chartGroup: 'Chart Config',
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
       'The pricing tier used for the fleet cost line. Owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit. Locked rental terms (on demand through 2 year commit) are published in the SemiAnalysis AI Cloud TCO Model.',
@@ -98,6 +101,8 @@ const STRINGS = {
     title: '集群生命周期',
     description:
       '选择模型、工作负载和目标交互性。下方会根据设施功率预算，分别确定各款芯片的固定集群规模，并按目标交互性读取历次运行的数据。各条曲线的含义见下方说明。',
+    benchmarkGroup: '基准测试配置',
+    chartGroup: '图表配置',
     costProviderLabel: '成本供应商',
     costProviderTooltip:
       '集群成本线采用的定价层级。按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁。带锁的租赁期限（按需至 2 年承诺）收录于 SemiAnalysis AI Cloud TCO 模型。',
@@ -375,20 +380,24 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
             />
 
             <TooltipProvider delayDuration={0}>
-              <div
-                className={`grid grid-cols-1 md:grid-cols-2 gap-4 ${
-                  isAgenticSequence ? 'lg:grid-cols-6' : 'lg:grid-cols-5'
+              <ControlPanel
+                legend={t.benchmarkGroup}
+                data-testid="fleet-benchmark-panel"
+                className={`grid-cols-1 md:grid-cols-2 ${
+                  isAgenticSequence && featureGateUnlocked ? 'lg:grid-cols-5' : 'lg:grid-cols-4'
                 }`}
               >
-                <ModelSelector
-                  id="fleet-model"
-                  data-testid="fleet-model-selector"
-                  value={selectedModel}
-                  onChange={handleModelChange}
-                  open={openDropdown === 'model'}
-                  onOpenChange={handleDropdownOpenChange('model')}
-                  availableModels={availableModels}
-                />
+                <div className="min-w-0 md:col-span-2">
+                  <ModelSelector
+                    id="fleet-model"
+                    data-testid="fleet-model-selector"
+                    value={selectedModel}
+                    onChange={handleModelChange}
+                    open={openDropdown === 'model'}
+                    onOpenChange={handleDropdownOpenChange('model')}
+                    availableModels={availableModels}
+                  />
+                </div>
                 <ScenarioSelector
                   id="fleet-sequence"
                   data-testid="fleet-sequence-selector"
@@ -416,8 +425,13 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                   onOpenChange={handleDropdownOpenChange('precision')}
                   availablePrecisions={availablePrecisions}
                 />
-
-                <div className="flex flex-col space-y-1.5 lg:col-span-1">
+              </ControlPanel>
+              <ControlPanel
+                legend={t.chartGroup}
+                data-testid="fleet-chart-panel"
+                className="grid-cols-1 md:grid-cols-2 xl:grid-cols-3"
+              >
+                <div className="flex min-w-0 flex-col space-y-1.5 lg:col-span-1">
                   <LabelWithTooltip
                     htmlFor="fleet-cost"
                     label={t.costProviderLabel}
@@ -454,7 +468,7 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                   </div>
                 </div>
 
-                <div className="flex flex-col space-y-1.5 lg:col-span-1">
+                <div className="flex min-w-0 flex-col space-y-1.5 lg:col-span-1">
                   <LabelWithTooltip
                     htmlFor="fleet-cost-type"
                     label={t.tokenTypeLabel}
@@ -486,91 +500,92 @@ function FleetLifecycleInner({ initialPercentile }: { initialPercentile: Percent
                     />
                   </div>
                 </div>
-              </div>
+                {showsTcoBasis && (
+                  <div className="flex min-w-0 max-w-48 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
+                      tooltip={
+                        locale === 'zh'
+                          ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
+                          : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
+                      }
+                    />
+                    <TcoBasisToggle source="fleet" className="md:h-9" />
+                  </div>
+                )}
 
-              {showsTcoBasis && (
-                <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
-                    tooltip={
-                      locale === 'zh'
-                        ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
-                        : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
-                    }
-                  />
-                  <TcoBasisToggle source="fleet" className="h-9" />
-                </div>
-              )}
-
-              {/* Target value slider + input */}
-              {!loading && hasData && (
-                <div className="space-y-2">
-                  <LabelWithTooltip
-                    htmlFor="fleet-target"
-                    label={
-                      isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
-                    }
-                    tooltip={
-                      isAgenticSequence ? t.targetAgenticTooltip(percentileLabel) : t.targetTooltip
-                    }
-                  />
-                  <div className="flex items-center gap-4">
-                    <div className="flex-1">
-                      <input
-                        id="fleet-target"
-                        type="range"
-                        min={currentRange.min}
-                        max={currentRange.max}
-                        step={1}
-                        value={targetValue}
-                        onChange={handleSliderChange}
-                        onPointerUp={() =>
-                          track('fleet_target_slider_set', { mode, value: targetValue })
-                        }
-                        className="w-full h-2 appearance-none rounded-full bg-secondary cursor-pointer
+                {/* Target value slider + input */}
+                {!loading && hasData && (
+                  <div className="space-y-2 md:col-span-2 xl:col-span-3">
+                    <LabelWithTooltip
+                      htmlFor="fleet-target"
+                      label={
+                        isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
+                      }
+                      tooltip={
+                        isAgenticSequence
+                          ? t.targetAgenticTooltip(percentileLabel)
+                          : t.targetTooltip
+                      }
+                    />
+                    <div className="flex items-center gap-4">
+                      <div className="min-w-0 flex-1">
+                        <input
+                          id="fleet-target"
+                          type="range"
+                          min={currentRange.min}
+                          max={currentRange.max}
+                          step={1}
+                          value={targetValue}
+                          onChange={handleSliderChange}
+                          onPointerUp={() =>
+                            track('fleet_target_slider_set', { mode, value: targetValue })
+                          }
+                          className="w-full h-2 appearance-none rounded-full bg-secondary cursor-pointer
                         [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-4
                         [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:rounded-full
                         [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:cursor-pointer
                         [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:h-4
                         [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary
                         [&::-moz-range-thumb]:cursor-pointer [&::-moz-range-thumb]:border-0"
-                      />
-                      <div
-                        className="relative h-4 text-xs text-muted-foreground"
-                        style={{ marginLeft: 8, marginRight: 8 }}
-                      >
-                        {Array.from({ length: 6 }, (_, i) => (
-                          <span
-                            key={i}
-                            className="absolute -translate-x-1/2"
-                            style={{ left: `${(i / 5) * 100}%` }}
-                          >
-                            {Math.round(
-                              currentRange.min + (currentRange.max - currentRange.min) * (i / 5),
-                            )}
-                          </span>
-                        ))}
+                        />
+                        <div
+                          className="relative h-4 text-xs text-muted-foreground"
+                          style={{ marginLeft: 8, marginRight: 8 }}
+                        >
+                          {Array.from({ length: 6 }, (_, i) => (
+                            <span
+                              key={i}
+                              className="absolute -translate-x-1/2"
+                              style={{ left: `${(i / 5) * 100}%` }}
+                            >
+                              {Math.round(
+                                currentRange.min + (currentRange.max - currentRange.min) * (i / 5),
+                              )}
+                            </span>
+                          ))}
+                        </div>
                       </div>
+                      <Input
+                        type="number"
+                        aria-label={
+                          isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
+                        }
+                        value={resolveCalculatorTargetInputValue(
+                          inputValue,
+                          targetValue,
+                          isTargetInputFocused,
+                        )}
+                        onFocus={handleInputFocus}
+                        onChange={handleInputChange}
+                        onBlur={handleInputBlur}
+                        className="w-24 shrink-0"
+                        min={0}
+                      />
                     </div>
-                    <Input
-                      type="number"
-                      aria-label={
-                        isAgenticSequence ? t.targetAgenticLabel(percentileLabel) : t.targetLabel
-                      }
-                      value={resolveCalculatorTargetInputValue(
-                        inputValue,
-                        targetValue,
-                        isTargetInputFocused,
-                      )}
-                      onFocus={handleInputFocus}
-                      onChange={handleInputChange}
-                      onBlur={handleInputBlur}
-                      className="w-24"
-                      min={0}
-                    />
                   </div>
-                </div>
-              )}
+                )}
+              </ControlPanel>
             </TooltipProvider>
 
             {!loading && legendItems.length > 0 && (

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -197,6 +197,8 @@ const STRINGS = {
       'gw-year': 'Revenue & Profit Estimator per GigaWatt',
       'chip-hour': 'Revenue & Profit Estimator',
     },
+    benchmarkGroup: 'Benchmark Config',
+    pricingGroup: 'Pricing Config',
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
       'The TCO tier used for the compute-expense segment: owning at large hyperscaler purchasing volume (e.g. AWS/GCP) or renting on a 3-year commit, in $/GPU/hr from the SemiAnalysis AI Cloud TCO Model. Custom lets you type your own $/GPU/hr per chip. Locked rental terms (on demand through 2 year commit) are published in the TCO model.',
@@ -297,6 +299,8 @@ const STRINGS = {
       'gw-year': '每吉瓦收入与利润估算器',
       'chip-hour': '收入与利润估算器',
     },
+    benchmarkGroup: '基准测试配置',
+    pricingGroup: '定价配置',
     costProviderLabel: '成本供应商',
     costProviderTooltip:
       '算力支出分段采用的 TCO 层级：按超大规模云厂商大批量采购价自有（如 AWS/GCP）或 3 年承诺租赁，单位为 $/GPU/hr，来自 SemiAnalysis AI Cloud TCO 模型。选择自定义可为每种芯片输入自己的 $/GPU/hr。带锁的租赁期限（按需至 2 年承诺）收录于 TCO 模型。',
@@ -1300,296 +1304,305 @@ function ProfitEstimatorInner({
             <DashboardSectionHeader title={t.title[basis]} actions={<ChartShareActions />} />
 
             <TooltipProvider delayDuration={0}>
-              <div
-                className={`grid grid-cols-1 md:grid-cols-2 gap-4 ${
-                  featureGateUnlocked ? 'lg:grid-cols-5' : 'lg:grid-cols-4'
-                }`}
-              >
-                <div className="md:col-span-2">
-                  <ModelSelector
-                    id="profit-model"
-                    data-testid="profit-model-selector"
-                    value={selectedModel}
-                    onChange={handleModelChange}
-                    open={openDropdown === 'model'}
-                    onOpenChange={handleDropdownOpenChange('model')}
-                    availableModels={agenticModels}
-                  />
-                </div>
-                {featureGateUnlocked && (
-                  <PercentileSelector
-                    id="profit-percentile"
-                    data-testid="profit-percentile-selector"
-                    value={selectedPercentile}
-                    onChange={handlePercentileChange}
-                  />
-                )}
-                <div className="flex flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    htmlFor="profit-cost"
-                    label={t.costProviderLabel}
-                    tooltip={t.costProviderTooltip}
-                  />
-                  <div data-testid="profit-cost-selector">
-                    <MultiSelect
-                      triggerId="profit-cost"
-                      options={[
-                        ...COST_PROVIDER_OPTIONS.filter((p) => p.value !== 'custom').map(
-                          (provider) => ({
-                            value: provider.value,
-                            label: locale === 'zh' ? provider.labelZh : provider.label,
-                          }),
-                        ),
-                        ...lockedCostProviderOptions(locale),
-                        ...COST_PROVIDER_OPTIONS.filter((p) => p.value === 'custom').map(
-                          (provider) => ({
-                            value: provider.value,
-                            label: locale === 'zh' ? provider.labelZh : provider.label,
-                          }),
-                        ),
-                      ]}
-                      value={[costProvider]}
-                      onChange={(values) => {
-                        const next = values[0];
-                        if (!next) return;
-                        if (interceptLockedTier(next)) return;
-                        setCostProvider(next as ProfitCostProvider);
-                        track('profit_cost_provider_changed', { provider: next });
-                      }}
-                      open={openDropdown === 'costProvider'}
-                      onOpenChange={handleDropdownOpenChange('costProvider')}
-                      placeholder={t.costProviderPlaceholder}
-                      minSelections={1}
-                      maxSelections={1}
-                      showClearAll={false}
-                      searchable={false}
-                      plainSelectedText
-                      showSelectionSummary={false}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 lg:grid-cols-4">
-                <div className="flex flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    htmlFor="profit-target"
-                    label={t.targetAgenticLabel(percentileLabel)}
-                    tooltip={t.targetAgenticTooltip(percentileLabel)}
-                  />
-                  <Input
-                    id="profit-target"
-                    data-testid="profit-target-input"
-                    type="number"
-                    onWheel={blurOnWheel}
-                    inputMode="decimal"
-                    min={1}
-                    step={1}
-                    value={targetRaw}
-                    onChange={handleTargetChange}
-                    onBlur={handleTargetBlur}
-                  />
-                </div>
-                <div className="flex flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    htmlFor="profit-price-source"
-                    label={t.priceSourceLabel}
-                    tooltip={t.priceSourceTooltip}
-                  />
-                  <div data-testid="profit-price-source-selector">
-                    <MultiSelect
-                      triggerId="profit-price-source"
-                      options={priceSourceOptions(listPricing?.vendor ?? null).map((option) => ({
-                        value: option.value,
-                        label: locale === 'zh' ? option.labelZh : option.label,
-                      }))}
-                      value={[effectivePriceSource]}
-                      onChange={(values) => {
-                        const next = values[0];
-                        if (!next) return;
-                        // Seed the custom fields from the price in force (list or
-                        // live catalog) so switching over starts from a real price
-                        // instead of $1/M.
-                        if (next === 'custom' && pricing) {
-                          setCustomInputPrice(formatTokenPrice(pricing.inputPerMillion));
-                          setCustomCachedPrice(
-                            formatTokenPrice(cachedInputPricePerMillion(pricing)),
-                          );
-                          setCustomOutputPrice(formatTokenPrice(pricing.outputPerMillion));
-                        }
-                        setPriceSource(next as PriceSource);
-                        track('profit_price_source_changed', { source: next });
-                      }}
-                      open={openDropdown === 'priceSource'}
-                      onOpenChange={handleDropdownOpenChange('priceSource')}
-                      placeholder={t.priceSourcePlaceholder}
-                      minSelections={1}
-                      maxSelections={1}
-                      showClearAll={false}
-                      searchable={false}
-                      plainSelectedText
-                      showSelectionSummary={false}
-                    />
-                  </div>
-                </div>
-                <div className="flex flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    htmlFor="profit-utilization"
-                    label={t.utilizationLabel}
-                    tooltip={t.utilizationTooltip}
-                  />
-                  <Input
-                    id="profit-utilization"
-                    data-testid="profit-utilization-input"
-                    type="number"
-                    onWheel={blurOnWheel}
-                    inputMode="decimal"
-                    min={0}
-                    max={100}
-                    step={1}
-                    value={utilization.raw}
-                    onChange={(e) => utilization.onChange(e.target.value)}
-                    onBlur={utilization.onBlur}
-                  />
-                </div>
-                <div className="flex flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    htmlFor="profit-lab-cut"
-                    label={t.labCutLabel}
-                    tooltip={t.labCutTooltip}
-                  />
-                  <Input
-                    id="profit-lab-cut"
-                    data-testid="profit-lab-cut-input"
-                    type="number"
-                    onWheel={blurOnWheel}
-                    inputMode="decimal"
-                    min={0}
-                    max={100}
-                    step={1}
-                    value={labCut.raw}
-                    onChange={(e) => labCut.onChange(e.target.value)}
-                    onBlur={labCut.onBlur}
-                  />
-                </div>
-              </div>
-
-              {/* Custom token prices get their own row so the main controls keep their width. */}
-              {effectivePriceSource === 'custom' && (
-                <div
-                  data-testid="profit-custom-prices"
-                  className="grid grid-cols-1 md:grid-cols-3 gap-4"
+              <div className="grid min-w-0 items-start gap-4 xl:grid-cols-5">
+                <ControlPanel
+                  legend={t.benchmarkGroup}
+                  data-testid="profit-benchmark-panel"
+                  className="grid-cols-1 md:grid-cols-2 xl:col-span-2"
                 >
-                  <div className="flex flex-col space-y-1.5">
-                    <Label htmlFor="profit-input-price">{t.inputPriceLabel}</Label>
+                  <div className="min-w-0 md:col-span-2">
+                    <ModelSelector
+                      id="profit-model"
+                      data-testid="profit-model-selector"
+                      value={selectedModel}
+                      onChange={handleModelChange}
+                      open={openDropdown === 'model'}
+                      onOpenChange={handleDropdownOpenChange('model')}
+                      availableModels={agenticModels}
+                    />
+                  </div>
+                  {featureGateUnlocked && (
+                    <div className="min-w-0 md:col-span-2">
+                      <PercentileSelector
+                        id="profit-percentile"
+                        data-testid="profit-percentile-selector"
+                        value={selectedPercentile}
+                        onChange={handlePercentileChange}
+                      />
+                    </div>
+                  )}
+                  <div className="flex min-w-0 flex-col space-y-1.5 md:col-span-2">
+                    <LabelWithTooltip
+                      htmlFor="profit-target"
+                      label={t.targetAgenticLabel(percentileLabel)}
+                      tooltip={t.targetAgenticTooltip(percentileLabel)}
+                    />
                     <Input
-                      id="profit-input-price"
-                      data-testid="profit-input-price"
+                      id="profit-target"
+                      data-testid="profit-target-input"
                       type="number"
                       onWheel={blurOnWheel}
                       inputMode="decimal"
-                      min={0}
-                      step={0.01}
-                      value={customInputPrice}
-                      onChange={(e) => setCustomInputPrice(e.target.value)}
-                      onBlur={() =>
-                        track('profit_custom_price_set', {
-                          stream: 'input',
-                          value: customInputPrice,
-                        })
-                      }
+                      min={1}
+                      step={1}
+                      value={targetRaw}
+                      onChange={handleTargetChange}
+                      onBlur={handleTargetBlur}
                     />
                   </div>
-                  <div className="flex flex-col space-y-1.5">
-                    <Label htmlFor="profit-cached-price">{t.cachedPriceLabel}</Label>
-                    <Input
-                      id="profit-cached-price"
-                      data-testid="profit-cached-price"
-                      type="number"
-                      onWheel={blurOnWheel}
-                      inputMode="decimal"
-                      min={0}
-                      step={0.001}
-                      value={customCachedPrice}
-                      onChange={(e) => setCustomCachedPrice(e.target.value)}
-                      onBlur={() =>
-                        track('profit_custom_price_set', {
-                          stream: 'cached',
-                          value: customCachedPrice,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="flex flex-col space-y-1.5">
-                    <Label htmlFor="profit-output-price">{t.outputPriceLabel}</Label>
-                    <Input
-                      id="profit-output-price"
-                      data-testid="profit-output-price"
-                      type="number"
-                      onWheel={blurOnWheel}
-                      inputMode="decimal"
-                      min={0}
-                      step={0.01}
-                      value={customOutputPrice}
-                      onChange={(e) => setCustomOutputPrice(e.target.value)}
-                      onBlur={() =>
-                        track('profit_custom_price_set', {
-                          stream: 'output',
-                          value: customOutputPrice,
-                        })
-                      }
-                    />
-                  </div>
-                </div>
-              )}
-
-              {showsTcoBasis && (
-                <div className="mt-3 flex min-w-0 max-w-sm flex-col space-y-1.5">
-                  <LabelWithTooltip
-                    label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
-                    tooltip={
-                      locale === 'zh'
-                        ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
-                        : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
-                    }
-                  />
-                  <TcoBasisToggle source="profit" className="h-9" />
-                </div>
-              )}
-
-              {costProvider === 'custom' && customCostBases.length > 0 && (
-                <div
-                  data-testid="profit-custom-costs"
-                  className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6"
+                </ControlPanel>
+                <ControlPanel
+                  legend={t.pricingGroup}
+                  data-testid="profit-pricing-panel"
+                  className="grid-cols-1 md:grid-cols-2 xl:col-span-3"
                 >
-                  {customCostBases.map((base) => {
-                    const label = HW_REGISTRY[base]?.badgeLabel ?? base.toUpperCase();
-                    return (
-                      <div key={base} className="flex flex-col space-y-1.5">
-                        <Label htmlFor={`profit-custom-cost-${base}`}>
-                          {t.customCostLabel(label)}
-                        </Label>
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      htmlFor="profit-cost"
+                      label={t.costProviderLabel}
+                      tooltip={t.costProviderTooltip}
+                    />
+                    <div data-testid="profit-cost-selector">
+                      <MultiSelect
+                        triggerId="profit-cost"
+                        options={[
+                          ...COST_PROVIDER_OPTIONS.filter((p) => p.value !== 'custom').map(
+                            (provider) => ({
+                              value: provider.value,
+                              label: locale === 'zh' ? provider.labelZh : provider.label,
+                            }),
+                          ),
+                          ...lockedCostProviderOptions(locale),
+                          ...COST_PROVIDER_OPTIONS.filter((p) => p.value === 'custom').map(
+                            (provider) => ({
+                              value: provider.value,
+                              label: locale === 'zh' ? provider.labelZh : provider.label,
+                            }),
+                          ),
+                        ]}
+                        value={[costProvider]}
+                        onChange={(values) => {
+                          const next = values[0];
+                          if (!next) return;
+                          if (interceptLockedTier(next)) return;
+                          setCostProvider(next as ProfitCostProvider);
+                          track('profit_cost_provider_changed', { provider: next });
+                        }}
+                        open={openDropdown === 'costProvider'}
+                        onOpenChange={handleDropdownOpenChange('costProvider')}
+                        placeholder={t.costProviderPlaceholder}
+                        minSelections={1}
+                        maxSelections={1}
+                        showClearAll={false}
+                        searchable={false}
+                        plainSelectedText
+                        showSelectionSummary={false}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      htmlFor="profit-price-source"
+                      label={t.priceSourceLabel}
+                      tooltip={t.priceSourceTooltip}
+                    />
+                    <div data-testid="profit-price-source-selector">
+                      <MultiSelect
+                        triggerId="profit-price-source"
+                        options={priceSourceOptions(listPricing?.vendor ?? null).map((option) => ({
+                          value: option.value,
+                          label: locale === 'zh' ? option.labelZh : option.label,
+                        }))}
+                        value={[effectivePriceSource]}
+                        onChange={(values) => {
+                          const next = values[0];
+                          if (!next) return;
+                          // Seed the custom fields from the price in force (list or
+                          // live catalog) so switching over starts from a real price
+                          // instead of $1/M.
+                          if (next === 'custom' && pricing) {
+                            setCustomInputPrice(formatTokenPrice(pricing.inputPerMillion));
+                            setCustomCachedPrice(
+                              formatTokenPrice(cachedInputPricePerMillion(pricing)),
+                            );
+                            setCustomOutputPrice(formatTokenPrice(pricing.outputPerMillion));
+                          }
+                          setPriceSource(next as PriceSource);
+                          track('profit_price_source_changed', { source: next });
+                        }}
+                        open={openDropdown === 'priceSource'}
+                        onOpenChange={handleDropdownOpenChange('priceSource')}
+                        placeholder={t.priceSourcePlaceholder}
+                        minSelections={1}
+                        maxSelections={1}
+                        showClearAll={false}
+                        searchable={false}
+                        plainSelectedText
+                        showSelectionSummary={false}
+                      />
+                    </div>
+                  </div>
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      htmlFor="profit-utilization"
+                      label={t.utilizationLabel}
+                      tooltip={t.utilizationTooltip}
+                    />
+                    <Input
+                      id="profit-utilization"
+                      data-testid="profit-utilization-input"
+                      type="number"
+                      onWheel={blurOnWheel}
+                      inputMode="decimal"
+                      min={0}
+                      max={100}
+                      step={1}
+                      value={utilization.raw}
+                      onChange={(e) => utilization.onChange(e.target.value)}
+                      onBlur={utilization.onBlur}
+                    />
+                  </div>
+                  <div className="flex min-w-0 flex-col space-y-1.5">
+                    <LabelWithTooltip
+                      htmlFor="profit-lab-cut"
+                      label={t.labCutLabel}
+                      tooltip={t.labCutTooltip}
+                    />
+                    <Input
+                      id="profit-lab-cut"
+                      data-testid="profit-lab-cut-input"
+                      type="number"
+                      onWheel={blurOnWheel}
+                      inputMode="decimal"
+                      min={0}
+                      max={100}
+                      step={1}
+                      value={labCut.raw}
+                      onChange={(e) => labCut.onChange(e.target.value)}
+                      onBlur={labCut.onBlur}
+                    />
+                  </div>
+                  {/* Custom token prices get their own row so the main controls keep their width. */}
+                  {effectivePriceSource === 'custom' && (
+                    <div
+                      data-testid="profit-custom-prices"
+                      className="grid min-w-0 gap-4 md:col-span-2 md:grid-cols-3"
+                    >
+                      <div className="flex min-w-0 flex-col space-y-1.5">
+                        <Label htmlFor="profit-input-price">{t.inputPriceLabel}</Label>
                         <Input
-                          id={`profit-custom-cost-${base}`}
-                          data-testid={`profit-custom-cost-${base}`}
+                          id="profit-input-price"
+                          data-testid="profit-input-price"
                           type="number"
                           onWheel={blurOnWheel}
                           inputMode="decimal"
                           min={0}
                           step={0.01}
-                          value={customCosts[base] ?? ''}
-                          onChange={(e) =>
-                            setCustomCosts((prev) => ({ ...prev, [base]: e.target.value }))
-                          }
+                          value={customInputPrice}
+                          onChange={(e) => setCustomInputPrice(e.target.value)}
                           onBlur={() =>
-                            track('profit_custom_cost_set', { gpu: base, value: customCosts[base] })
+                            track('profit_custom_price_set', {
+                              stream: 'input',
+                              value: customInputPrice,
+                            })
                           }
                         />
                       </div>
-                    );
-                  })}
-                </div>
-              )}
+                      <div className="flex min-w-0 flex-col space-y-1.5">
+                        <Label htmlFor="profit-cached-price">{t.cachedPriceLabel}</Label>
+                        <Input
+                          id="profit-cached-price"
+                          data-testid="profit-cached-price"
+                          type="number"
+                          onWheel={blurOnWheel}
+                          inputMode="decimal"
+                          min={0}
+                          step={0.001}
+                          value={customCachedPrice}
+                          onChange={(e) => setCustomCachedPrice(e.target.value)}
+                          onBlur={() =>
+                            track('profit_custom_price_set', {
+                              stream: 'cached',
+                              value: customCachedPrice,
+                            })
+                          }
+                        />
+                      </div>
+                      <div className="flex min-w-0 flex-col space-y-1.5">
+                        <Label htmlFor="profit-output-price">{t.outputPriceLabel}</Label>
+                        <Input
+                          id="profit-output-price"
+                          data-testid="profit-output-price"
+                          type="number"
+                          onWheel={blurOnWheel}
+                          inputMode="decimal"
+                          min={0}
+                          step={0.01}
+                          value={customOutputPrice}
+                          onChange={(e) => setCustomOutputPrice(e.target.value)}
+                          onBlur={() =>
+                            track('profit_custom_price_set', {
+                              stream: 'output',
+                              value: customOutputPrice,
+                            })
+                          }
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {showsTcoBasis && (
+                    <div className="flex min-w-0 max-w-48 flex-col space-y-1.5 md:col-span-2">
+                      <LabelWithTooltip
+                        label={locale === 'zh' ? 'TCO 口径' : 'TCO Basis'}
+                        tooltip={
+                          locale === 'zh'
+                            ? '外部客户价格或内部持有成本；目前仅影响 TPUv7。'
+                            : 'External customer pricing or internal owner cost; currently affects only TPUv7.'
+                        }
+                      />
+                      <TcoBasisToggle source="profit" className="md:h-9" />
+                    </div>
+                  )}
+
+                  {costProvider === 'custom' && customCostBases.length > 0 && (
+                    <div
+                      data-testid="profit-custom-costs"
+                      className="grid min-w-0 grid-cols-1 gap-4 sm:grid-cols-2 md:col-span-2 xl:grid-cols-3"
+                    >
+                      {customCostBases.map((base) => {
+                        const label = HW_REGISTRY[base]?.badgeLabel ?? base.toUpperCase();
+                        return (
+                          <div key={base} className="flex min-w-0 flex-col space-y-1.5">
+                            <Label htmlFor={`profit-custom-cost-${base}`}>
+                              {t.customCostLabel(label)}
+                            </Label>
+                            <Input
+                              id={`profit-custom-cost-${base}`}
+                              data-testid={`profit-custom-cost-${base}`}
+                              type="number"
+                              onWheel={blurOnWheel}
+                              inputMode="decimal"
+                              min={0}
+                              step={0.01}
+                              value={customCosts[base] ?? ''}
+                              onChange={(e) =>
+                                setCustomCosts((prev) => ({ ...prev, [base]: e.target.value }))
+                              }
+                              onBlur={() =>
+                                track('profit_custom_cost_set', {
+                                  gpu: base,
+                                  value: customCosts[base],
+                                })
+                              }
+                            />
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                </ControlPanel>
+              </div>
 
               <ControlPanel legend={t.compareHistory} data-testid="profit-history-panel">
                 <div className="grid min-w-0 gap-3 md:grid-cols-2">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation and layout-only changes to calculator control chrome, with no changes to pricing logic or APIs; regression risk is mainly visual layout on fleet and profit pages.
> 
> **Overview**
> **Fleet Lifecycle** and **Profit Estimator** control areas now use shared **`ControlPanel`** fieldsets instead of flat grids, so related inputs stay visually grouped and aligned with each other.
> 
> On **Fleet Lifecycle**, controls split into **Benchmark Config** (model, scenario, precision, optional percentile) and **Chart Config** (cost provider, token type, optional TCO basis, target slider). The target interactivity slider and TCO basis toggle move into the chart panel; layout uses **`min-w-0`** and updated breakpoints so panels do not overflow on narrow viewports.
> 
> On **Profit Estimator**, **Benchmark Config** holds model, percentile, and target; **Pricing Config** holds cost tier, token price source, utilization, license fee, and nested custom price/cost fields. Desktop layouts place the two panels side-by-side; mobile stacks them with spacing assertions in tests.
> 
> English and Chinese **`legend`** strings are added for each panel. **Cypress** gains responsive layout tests (375px / 1440px) that check panel grouping, control bounds inside fieldsets, and translated legends on `/zh` routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bbdcacc7b3b97eb57be6e89e39312866755b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->