### PR TITLE
feat(tco): set TPUv7 3-year rental rate to $2/chip-hour / 将 TPUv7 三年承诺租赁价格设为每芯片小时 $2

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -3,8 +3,10 @@
 ## TCO basis
 
 The global **TCO Basis** control switches between internal owner cost (the default) and
-external customer pricing. TPUv7 uses **$1.03/chip/hour internal** and **$1.21/chip/hour external**;
-other hardware retains its existing rates. The selection is shared across inference, historical
+external customer pricing. TPUv7 uses **$1.03/chip/hour internal** and **$1.21/chip/hour external**
+for the owning tier; its **Rent - 3 Year Commit** tier is **$2.00/chip/hour** on both bases, since
+renting from GCP is a customer price that does not change with who owns the chip. Other hardware
+retains its existing rates. The selection is shared across inference, historical
 trends, the TCO calculator, fleet lifecycle, and the profit estimator, and is encoded as
 `g_tco=external` in share links. The selector itself is only rendered for model/scenario pairs
 listed in `MODEL_TCO_BASIS_SELECTOR` (`data-mappings.ts`), currently Qwen3.5 on 8K/1K, since it

--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -297,13 +297,18 @@ describe('getGpuSpecs', () => {
     expect(external).toMatchObject({
       power: 1.207,
       costh: 1.21,
-      costr: 1.21,
+      costr: 2,
     });
     expect(internal).toMatchObject({
       power: 1.207,
       costh: 1.03,
-      costr: 1.03,
+      costr: 2,
     });
+  });
+
+  it('keeps the TPUv7 3-year rental rate at $2/hr on both bases', () => {
+    expect(getGpuSpecs('tpuv7_vllm', 'external').costr).toBe(2);
+    expect(getGpuSpecs('tpuv7_vllm', 'internal').costr).toBe(2);
   });
 
   it('defaults to the internal owner cost basis', () => {

--- a/packages/app/src/lib/constants.ts
+++ b/packages/app/src/lib/constants.ts
@@ -36,12 +36,15 @@ export function getGpuSpecs(hwKey: string, basis: TcoBasis = DEFAULT_TCO_BASIS):
   const base = hwKey.split(/[-_]/u)[0];
   const entry = HW_REGISTRY[base];
   if (!entry) return DEFAULT_SPECS;
+  // The TCO basis only reprices the owning tier: Google's internal owner cost vs
+  // what an external buyer pays. The rental tier is a customer renting from GCP
+  // at the 3-year commit rate, which does not change with the basis.
   const internalCost = base === 'tpuv7' ? 1.03 : undefined;
   return {
     tdp: entry.tdp,
     power: entry.power,
     costh: basis === 'internal' ? (internalCost ?? entry.costh) : entry.costh,
-    costr: basis === 'internal' ? (internalCost ?? entry.costr) : entry.costr,
+    costr: entry.costr,
   };
 }
 

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -155,7 +155,8 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 980,
     power: 1.207,
     costh: 1.21,
-    costr: 1.21,
+    /** GCP 3-year commit rental rate per chip-hour (SemiAnalysis AI Cloud TCO Model). */
+    costr: 2,
   },
 };
 


### PR DESCRIPTION
## Summary

Sets the **Rent - 3 Year Commit** (`costr`) rate for TPUv7 (Ironwood / TPU7x) to **$2.00 per chip-hour**, per the SemiAnalysis AI Cloud TCO Model (previously it mirrored the $1.21 external owning TCO).

- `packages/constants/src/gpu-keys.ts`: `tpuv7.costr` 1.21 → 2
- `packages/app/src/lib/constants.ts`: the internal/external **TCO basis** now reprices only the owning tier (`costh`, $1.03 internal / $1.21 external). The rental tier is what a customer pays GCP under a 3-year commit, so it stays at $2 on both bases. Previously the internal basis also dropped `costr` to $1.03.
- `docs/tco-calculator.md`: documents the rental rate and basis behavior.
- Unit tests updated; added a case pinning `costr` to $2 on both bases.

Every surface that derives from `getGpuSpecs` / `HW_REGISTRY` picks this up automatically: `y_costr` / `y_costrOutput` / `y_costri` and tokens-per-$ (rent) metrics on the inference and trend charts, the TCO calculator, fleet lifecycle, profit estimator rent tier, compare SSR, rankings, and the TPU7x chip page copy ("$2.00/hr at the retail tier").

## Testing

- `vitest run` in `packages/app`: 4581 passed, 1 failed. The one failure (`benchmark-transform.test.ts` › "keeps one mixed-spec agentic series identity across comparison dates") also fails on `master` and is unrelated to this change.
- `bun run lint` and `bun run fmt` clean.

## 中文说明

将 TPUv7（Ironwood / TPU7x）的 **租赁 - 3 年承诺**（`costr`）价格设为 **每芯片小时 $2.00**，依据 SemiAnalysis AI Cloud TCO 模型（此前沿用了 $1.21 的外部自有 TCO）。

- `gpu-keys.ts`：`tpuv7.costr` 从 1.21 改为 2
- `constants.ts`：内部/外部 TCO 基准切换现在只影响自有档（`costh`，内部 $1.03 / 外部 $1.21）。租赁档是客户向 GCP 支付的 3 年承诺价格，与谁持有芯片无关，因此两种基准下均为 $2。此前内部基准会把 `costr` 也降到 $1.03。
- `docs/tco-calculator.md`：补充租赁价格与基准行为说明。
- 更新单元测试，并新增用例固定两种基准下 `costr` 均为 $2。

所有基于 `getGpuSpecs` / `HW_REGISTRY` 的页面会自动生效：推理与趋势图表的租赁成本/每美元 token 指标、TCO 计算器、fleet lifecycle、利润估算器的租赁档、compare SSR、rankings，以及 TPU7x 芯片页文案。

测试：`vitest run` 4581 通过、1 失败，该失败用例（`benchmark-transform.test.ts`）在 `master` 上同样失败，与本次改动无关；lint 与 fmt 通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pricing constant and lookup-rule change only; downstream surfaces already read `getGpuSpecs`/`HW_REGISTRY` and will show updated rent-tier economics without auth or data-path changes.
> 
> **Overview**
> **TPUv7 Rent – 3 Year Commit** (`costr`) is updated from **$1.21** to **$2.00 per chip-hour** in `HW_REGISTRY`, aligned with the SemiAnalysis AI Cloud TCO model (it had previously matched the external owning rate).
> 
> **TCO basis behavior** in `getGpuSpecs` is narrowed so internal vs external only reprices the **owning** tier (`costh`: $1.03 internal / $1.21 external for TPUv7). **Rental** always uses registry `costr` and stays **$2** on both bases, since 3-year GCP rent is a customer price independent of internal vs external owner cost.
> 
> Docs in `tco-calculator.md` describe this split; unit tests assert the new rental rate and that basis no longer lowers TPUv7 `costr` on internal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aae3ae28f2edb307fd49227c5b1a56130799d982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->