### PR TITLE
fix(profit): list Custom $/GPU/hr before locked rent tiers / 修复：将自定义 $/GPU/hr 排在锁定租赁档位之前

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -117,6 +117,15 @@ describe('Profit Estimator per GW', () => {
         'Rent - 3 Year Commit',
         'Custom $/GPU/hr',
       ]);
+      // Custom $/GPU/hr sits directly after the published tiers, ahead of the
+      // locked rent tiers that only open the TCO model dialog.
+      const customIdx = labels.indexOf('Custom $/GPU/hr');
+      expect(customIdx).to.equal(labels.indexOf('Rent - 3 Year Commit') + 1);
+      const lockedIdx = [...$opts].flatMap((el, i) =>
+        el.dataset.testid?.startsWith('cost-provider-locked-') ? [i] : [],
+      );
+      expect(lockedIdx).to.have.length.greaterThan(0);
+      expect(Math.min(...lockedIdx)).to.be.greaterThan(customIdx);
     });
     cy.get('body').type('{esc}');
     // Segments are labelled in place; there is no separate key under the title.

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -1366,19 +1366,14 @@ function ProfitEstimatorInner({
                       <MultiSelect
                         triggerId="profit-cost"
                         options={[
-                          ...COST_PROVIDER_OPTIONS.filter((p) => p.value !== 'custom').map(
-                            (provider) => ({
-                              value: provider.value,
-                              label: locale === 'zh' ? provider.labelZh : provider.label,
-                            }),
-                          ),
+                          // Unlocked tiers first, then Custom $/GPU/hr, then the locked
+                          // rent tiers so the free-form option is never buried below
+                          // rows that only open the TCO model dialog.
+                          ...COST_PROVIDER_OPTIONS.map((provider) => ({
+                            value: provider.value,
+                            label: locale === 'zh' ? provider.labelZh : provider.label,
+                          })),
                           ...lockedCostProviderOptions(locale),
-                          ...COST_PROVIDER_OPTIONS.filter((p) => p.value === 'custom').map(
-                            (provider) => ({
-                              value: provider.value,
-                              label: locale === 'zh' ? provider.labelZh : provider.label,
-                            }),
-                          ),
                         ]}
                         value={[costProvider]}
                         onChange={(values) => {


### PR DESCRIPTION
## Summary

In the profit estimator's **Cost Provider** dropdown, `Custom $/GPU/hr` was appended after the five locked rent tiers (On Demand, 1 Month, 6 Month, 1 Year, 2 Year Commit). The one option a visitor can actually type a price into sat below five rows that only open the TCO model dialog.

New order:

1. Owning at Large Hyperscaler Volume
2. Rent - 3 Year Commit
3. Custom $/GPU/hr
4. Locked rent tiers (unchanged)

## Changes

- `ProfitEstimatorDisplay.tsx`: drop the two `filter()` passes that split `COST_PROVIDER_OPTIONS` around `lockedCostProviderOptions(locale)`; spread the options once, then the locked tiers. Matches how `ThroughputCalculatorDisplay` and `FleetLifecycleDisplay` already build the list.
- `profit-estimator.cy.ts`: the defaults smoke test now asserts `Custom $/GPU/hr` sits directly after `Rent - 3 Year Commit` and that every `cost-provider-locked-*` option comes after it.

## Verification

- `bun run fmt`, `bun run lint`, `tsc --noEmit` in `packages/app`: clean.

## 中文说明

利润估算器的 **Cost Provider** 下拉菜单此前把「自定义 $/GPU/hr」追加在五个锁定租赁档位（按需、1 个月、6 个月、1 年、2 年承诺）之后。唯一可以手动输入价格的选项被压在五行只会打开 TCO 模型对话框的条目下方。

新的顺序：

1. 超大规模云大批量自有（Owning at Large Hyperscaler Volume）
2. 租赁 3 年承诺（Rent - 3 Year Commit）
3. 自定义 $/GPU/hr
4. 锁定的租赁档位（不变）

改动：

- `ProfitEstimatorDisplay.tsx`：移除把 `COST_PROVIDER_OPTIONS` 拆到 `lockedCostProviderOptions(locale)` 两侧的两次 `filter()`，改为一次展开选项再接锁定档位，与 `ThroughputCalculatorDisplay` 和 `FleetLifecycleDisplay` 的写法一致。
- `profit-estimator.cy.ts`：默认值冒烟测试新增断言，要求「自定义 $/GPU/hr」紧跟在「租赁 3 年承诺」之后，且所有 `cost-provider-locked-*` 选项都排在其后。

验证：`bun run fmt`、`bun run lint`、`packages/app` 下的 `tsc --noEmit` 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dropdown ordering and e2e assertions; no pricing logic or selection behavior changes beyond list order.
> 
> **Overview**
> **Reorders the profit estimator Cost Provider dropdown** so **Custom $/GPU/hr** appears right after the two selectable published tiers (Owning at Large Hyperscaler Volume, Rent - 3 Year Commit), instead of below the locked rent options that only open the TCO model dialog.
> 
> `ProfitEstimatorDisplay` now builds the list with one spread of `COST_PROVIDER_OPTIONS` followed by `lockedCostProviderOptions`, matching throughput and fleet lifecycle calculators. Cypress defaults smoke test asserts **Custom $/GPU/hr** is immediately after **Rent - 3 Year Commit** and that every `cost-provider-locked-*` row comes later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f077ffb0f7560ba79cfeff301dc4cecd79803e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->