### PR TITLE
feat(quick-filters): add Google (TPU) vendor pill

### DIFF
--- a/packages/app/cypress/component/quick-filters-dialog.cy.tsx
+++ b/packages/app/cypress/component/quick-filters-dialog.cy.tsx
@@ -248,6 +248,9 @@ describe('QuickFiltersDialog', () => {
     cy.get('[data-testid="quick-filter-vendor-NVIDIA"]')
       .should('be.disabled')
       .and('have.attr', 'title', 'No data for the current selection');
+    cy.get('[data-testid="quick-filter-vendor-Google"]')
+      .should('be.disabled')
+      .and('have.attr', 'title', 'No data for the current selection');
     cy.get('[data-testid="quick-filter-vendor-AMD"]').click();
     cy.get('@setQuickFilterVendors').should('have.been.calledWith', []);
   });

--- a/packages/app/cypress/component/quick-filters-dialog.cy.tsx
+++ b/packages/app/cypress/component/quick-filters-dialog.cy.tsx
@@ -6,7 +6,7 @@ import { Sequence } from '@/lib/data-mappings';
 import { mountWithProviders } from '../support/test-utils';
 
 const availableQuickFilters: QuickFilters = {
-  vendors: ['NVIDIA', 'AMD'],
+  vendors: ['NVIDIA', 'AMD', 'Google'],
   frameworks: ['vllm', 'sglang'],
   deployment: ['single-node', 'multi-node', 'disagg'],
   spec: ['mtp', 'stp'],
@@ -168,8 +168,11 @@ describe('QuickFiltersDialog', () => {
     cy.get('[data-testid="quick-filter-vendor-options"]')
       .should('have.attr', 'role', 'group')
       .find('button')
-      .should('have.length', 2);
+      .should('have.length', 3);
     cy.get('[data-testid="quick-filter-vendor-AMD"]').should('have.attr', 'aria-pressed', 'true');
+    cy.get('[data-testid="quick-filter-vendor-Google"]')
+      .should('have.attr', 'aria-pressed', 'false')
+      .and('be.enabled');
     cy.get('[data-testid="quick-filter-vendor-NVIDIA"]')
       .should('have.attr', 'aria-pressed', 'false')
       .focus()

--- a/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
+++ b/packages/app/src/components/inference/ui/QuickFiltersDialog.tsx
@@ -42,7 +42,7 @@ const STRINGS = {
       'Selects the best configuration line for each chip SKU using the current chart metrics. Where curves overlap, performance is compared across their shared measured range rather than one peak point. Official and unofficial runs are evaluated separately; eligible TileRT configurations remain visible.',
     vendor: 'Vendor',
     vendorHelp:
-      'Filter by the company that makes the chip, such as NVIDIA or AMD. Select one or more vendors; leave the group empty to include all.',
+      'Filter by the company that makes the chip, such as NVIDIA, AMD, or Google (TPU). Select one or more vendors; leave the group empty to include all.',
     framework: 'Framework',
     frameworkHelp:
       'Filter by the serving engine family. Variants such as Dynamo vLLM are included with vLLM, and MoRI SGLang with SGLang.',
@@ -82,7 +82,8 @@ const STRINGS = {
     bestPerSkuHelp:
       '按当前图表指标，为每款芯片选择表现最佳的配置曲线。曲线范围重叠时，会比较共同实测范围内的整体表现，而不是只看单个峰值点。官方与非官方运行分别评估；符合条件的 TileRT 配置仍会保留。',
     vendor: '厂商',
-    vendorHelp: '按芯片制造商筛选，例如 NVIDIA 或 AMD。可选择一个或多个厂商；不选则显示全部。',
+    vendorHelp:
+      '按芯片制造商筛选，例如 NVIDIA、AMD 或 Google（TPU）。可选择一个或多个厂商；不选则显示全部。',
     framework: '框架',
     frameworkHelp:
       '按推理引擎系列筛选。各系列包含其变体，例如 Dynamo vLLM 归入 vLLM，MoRI SGLang 归入 SGLang。',
@@ -111,9 +112,14 @@ const STRINGS = {
   },
 } as const;
 
+/**
+ * Vendor pills, in display order. Values must match `HW_REGISTRY` vendors so
+ * `pointVendor` can resolve them. Google covers the TPU series (TPU7x).
+ */
 const VENDORS = [
   { value: 'NVIDIA', label: 'NVIDIA' },
   { value: 'AMD', label: 'AMD' },
+  { value: 'Google', label: 'Google' },
 ] as const;
 const DEPLOYMENT_MODES: DeploymentMode[] = ['single-node', 'multi-node', 'disagg'];
 const SPEC_MODES: { value: SpecMode; label: string }[] = [

--- a/packages/app/src/components/inference/utils/quickFilters.test.ts
+++ b/packages/app/src/components/inference/utils/quickFilters.test.ts
@@ -26,6 +26,7 @@ describe('pointVendor', () => {
   it('resolves vendor from the base GPU in the hardware key', () => {
     expect(pointVendor('h100_vllm_mtp')).toBe('NVIDIA');
     expect(pointVendor('mi300x_sglang')).toBe('AMD');
+    expect(pointVendor('tpuv7_vllm')).toBe('Google');
   });
 
   it('returns undefined for an unknown GPU base', () => {
@@ -145,6 +146,13 @@ describe('matchesQuickFilters', () => {
     const f = filters({ vendors: ['NVIDIA'] });
     expect(matchesQuickFilters(point({ hwKey: 'h100_vllm' }), f)).toBe(true);
     expect(matchesQuickFilters(point({ hwKey: 'mi300x_sglang' }), f)).toBe(false);
+    expect(matchesQuickFilters(point({ hwKey: 'tpuv7_vllm' }), f)).toBe(false);
+  });
+
+  it('filters TPU points under the Google vendor', () => {
+    const f = filters({ vendors: ['Google'] });
+    expect(matchesQuickFilters(point({ hwKey: 'tpuv7_vllm' }), f)).toBe(true);
+    expect(matchesQuickFilters(point({ hwKey: 'h100_vllm' }), f)).toBe(false);
   });
 
   it('treats multiple vendors as OR', () => {


### PR DESCRIPTION
## Summary
The Quick Filters vendor group only offered NVIDIA and AMD, so TPU7x points on Qwen3.5 (and any other model with TPU data) could not be isolated by vendor even though `VENDOR_ORDER` and `HW_REGISTRY` already resolve `tpuv7_*` to Google.

- Add a `Google` pill to `VENDORS` in `QuickFiltersDialog`. It follows the existing availability rule: enabled where the current model/scenario has TPU data, disabled with the "No data for the current selection" title elsewhere.
- Update the en/zh vendor help text to mention Google (TPU).
- Tests: `pointVendor('tpuv7_vllm')` resolves to Google, vendor matching includes and excludes TPU points correctly, and the component test asserts the Google pill disables when unavailable.

No changes to URL state: `i_vendor=Google` already round-trips through the existing string list.

## Verification
- `bun run fmt`, `bun run lint`, `bun run typecheck`, `bun run check:typography` clean
- `vitest` quickFilters + quick-filter-summary: 26 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and copy plus test updates on top of existing vendor resolution; no auth, data pipeline, or URL contract changes.
> 
> **Overview**
> Adds a **Google** vendor option to Quick Filters so users can narrow inference charts to TPU data (e.g. `tpuv7_*`), matching existing `HW_REGISTRY` / `pointVendor` behavior that was not exposed in the dialog.
> 
> `QuickFiltersDialog` extends the ordered `VENDORS` list with Google, documents it in English and Chinese vendor help (including TPU), and documents that pill values must align with `HW_REGISTRY`. Cypress coverage expects three vendor buttons, Google enabled when data exists, and the same disabled “No data for the current selection” state when vendors are unavailable. Unit tests assert `pointVendor` and `matchesQuickFilters` for Google vs NVIDIA/AMD.
> 
> No URL or filter-state changes: `i_vendor=Google` continues to use the existing string list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c6b2d02ce7ba35b2fdcbb2ce062af4cd05d9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->