### PR TITLE
[Video]: load H3 CI results automatically / 自动加载 H3 CI 结果

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "clsx": "^2.1.1",
         "d3": "^7.9.0",
         "dompurify": "^3.4.14",
+        "fflate": "^0.8.3",
         "gray-matter": "^4.0.3",
         "hast-util-from-html-isomorphic": "^2.0.0",
         "hast-util-to-text": "^4.0.2",

--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -40,6 +40,45 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.contains('a', '#10 · completed / failure').should('be.visible');
     cy.get('video').should('not.exist');
   });
+  it('keeps a direct selection and its download active when an older catalog arrives', () => {
+    let releaseList: (() => void) | undefined;
+    cy.intercept(
+      'GET',
+      '/api/video-runs?page=1',
+      (req) =>
+        new Promise<void>((resolve) => {
+          releaseList = () => {
+            req.reply({ runs: [run(20, 'success')], nextPage: null });
+            resolve();
+          };
+        }),
+    ).as('catalog');
+    cy.intercept('GET', '/api/video-runs?run=30', {
+      run: run(30, 'success'),
+      artifacts: [{ id: 40, name: 'h3-results-30-1', expired: false, size_in_bytes: 100 }],
+    }).as('direct');
+    cy.intercept('GET', '/api/video-runs?run=30&artifact=40', {
+      delay: 3000,
+      statusCode: 502,
+      body: { error: 'Synthetic download failure' },
+    }).as('zip');
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.wrap(null).should(() => expect(releaseList).to.be.a('function'));
+    cy.get('input[aria-label="GitHub run ID"]').type('30');
+    cy.contains('button', 'Open run').click();
+    cy.wait('@direct');
+    cy.get('select[aria-label="Result artifact"]').should('have.value', '40');
+    cy.then(() => releaseList?.());
+    cy.wait('@catalog');
+    cy.get('select[aria-label="CI run"]').should('have.value', '30');
+    cy.get('[role="status"]').should('contain', 'Loading CI results');
+    cy.wait('@zip');
+    cy.get('[role="alert"]').should('contain', 'Synthetic download failure');
+  });
   it('reports expiration without downloading or substituting another artifact', () => {
     cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });
     cy.intercept('GET', '/api/video-runs?run=30', {

--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -1,0 +1,95 @@
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
+import ResultPower from '@/components/video-benchmark/ResultPower';
+
+const run = (id: number, conclusion: string) => ({
+  id,
+  name: `H3 fixture ${id}`,
+  run_attempt: 1,
+  head_sha: 'a'.repeat(40),
+  created_at: '2026-09-09T00:00:00Z',
+  status: 'completed',
+  conclusion,
+  html_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`,
+});
+
+describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
+  beforeEach(() => {
+    cy.window().then((win) => win.history.replaceState(null, '', win.location.pathname));
+  });
+  it('loads the newest run automatically and switches to a failed run without inventing media', () => {
+    cy.intercept('GET', '/api/video-runs?page=1', {
+      runs: [run(20, 'success'), run(10, 'failure')],
+      nextPage: null,
+    });
+    cy.intercept('GET', '/api/video-runs?run=20', { run: run(20, 'success'), artifacts: [] }).as(
+      'latest',
+    );
+    cy.intercept('GET', '/api/video-runs?run=10', { run: run(10, 'failure'), artifacts: [] }).as(
+      'failed',
+    );
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.wait('@latest');
+    cy.contains('No result artifact for this run yet').should('be.visible');
+    cy.get('select[aria-label="CI run"]').select('10');
+    cy.wait('@failed');
+    cy.contains('a', '#10 · completed / failure').should('be.visible');
+    cy.get('video').should('not.exist');
+  });
+  it('reports expiration without downloading or substituting another artifact', () => {
+    cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });
+    cy.intercept('GET', '/api/video-runs?run=30', {
+      run: run(30, 'success'),
+      artifacts: [{ id: 40, name: 'h3-results-30-1', expired: true, size_in_bytes: 100 }],
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[role="alert"]').should('contain', 'Expired');
+    cy.get('video').should('not.exist');
+    cy.get('select[aria-label="Result artifact"]').should('have.value', '40');
+  });
+  it('withholds invalid generation measurements and separates warmup energy', () => {
+    const power = {
+      phases: {
+        measurement: {
+          valid: false,
+          status: 'invalid',
+          invalid_reasons: ['unbracketed'],
+          aggregate: { avg_power_w: 999 },
+        },
+        warmup: {
+          valid: true,
+          status: 'valid',
+          duration_seconds: 2,
+          aggregate: {
+            avg_power_w: 100,
+            energy_j: 200,
+            joules_per_valid_clip: 200,
+            observed_peak_power_w: 110,
+          },
+          per_gpu: { 'GPU-fixture': { avg_power_w: 100, observed_peak_power_w: 110 } },
+        },
+      },
+    };
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <ResultPower result={{ roles: { baseline: { power }, candidate: { power } } }} />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[data-testid="result-power"]')
+      .should('contain', 'unbracketed')
+      .and('not.contain', '999');
+    cy.get('select[aria-label="Power window"]').select('warmup');
+    cy.get('[data-testid="result-power"]')
+      .should('contain', '0.2')
+      .and('contain', 'GPU-fixture')
+      .and('not.contain', 'unbracketed');
+  });
+});

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -323,6 +323,9 @@ describe('TPUv7 launch banner', { testIsolation: true }, () => {
 });
 
 describe('H3 video artifact viewer', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/video-runs?page=*', { runs: [], nextPage: null });
+  });
   it('uses the shared unlock for navigation and keeps an empty viewer free of sample results', () => {
     cy.viewport(1440, 1000);
     cy.visit('/video', {
@@ -330,7 +333,7 @@ describe('H3 video artifact viewer', () => {
         win.localStorage.removeItem('inferencex-feature-gate');
       },
     });
-    cy.get('[data-testid="video-benchmark"]').should('contain', 'Open a real CI result to begin');
+    cy.get('[data-testid="video-ci-runs"]').should('contain', 'No H3 runs in this page');
     cy.get('video[data-role]').should('not.exist');
     cy.get('[data-testid="tab-trigger-hidden"]').should('not.exist');
     cy.get('body').type('{upArrow}{upArrow}{downArrow}{downArrow}');
@@ -340,13 +343,14 @@ describe('H3 video artifact viewer', () => {
   });
   it('shows a recoverable load error and the Chinese empty state', () => {
     cy.visit('/video');
+    cy.contains('summary', 'Local artifact tools').click();
     cy.get('[data-testid="video-benchmark"]').contains('summary', 'Manifest URL').click();
     cy.get('input[aria-label="Manifest URL"]').type('https://example.com/wrong.json');
     cy.contains('button', 'Load manifest').click();
     cy.get('[role="alert"]').should('contain', 'Could not load this bundle');
     cy.get('video[data-role]').should('not.exist');
     cy.visit('/zh/video');
-    cy.get('[data-testid="video-benchmark"]').should('contain', '打开真实 CI 结果开始查看');
+    cy.get('[data-testid="video-ci-runs"]').should('contain', '本页 GitHub 历史中没有 H3 运行');
     cy.get('head meta[name="robots"]').should('have.attr', 'content', 'noindex, nofollow');
   });
 });

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,6 +60,7 @@
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
     "dompurify": "^3.4.14",
+    "fflate": "^0.8.3",
     "gray-matter": "^4.0.3",
     "hast-util-from-html-isomorphic": "^2.0.0",
     "hast-util-to-text": "^4.0.2",

--- a/packages/app/src/app/(dashboard)/video/page.tsx
+++ b/packages/app/src/app/(dashboard)/video/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import VideoBenchmark from '@/components/video-benchmark/VideoBenchmark';
+import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
 import { tabMetadata } from '@/lib/tab-meta';
 
 export const metadata: Metadata = {
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 export default function VideoPage() {
-  return <VideoBenchmark />;
+  return <VideoCIRuns />;
 }

--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -6,7 +6,10 @@ const fetchMock = vi.fn<typeof fetch>();
 vi.stubGlobal('fetch', fetchMock);
 const response = (body: unknown, status = 200) => Response.json(body, { status });
 const request = (query = '') => new NextRequest(`http://localhost/api/video-runs${query}`);
-afterEach(() => fetchMock.mockReset());
+afterEach(() => {
+  fetchMock.mockReset();
+  vi.restoreAllMocks();
+});
 
 describe('H3 CI artifact access', () => {
   it('discovers benchmark runs without including branch-named unit jobs', async () => {
@@ -47,7 +50,11 @@ describe('H3 CI artifact access', () => {
     const result3 = await GET(request('?run=10&artifact=20'));
     expect(result3.status).toBe(410);
   });
-  it('streams the verified run artifact through a fixed GitHub API path', async () => {
+  it('streams the verified run artifact with a deadline longer than metadata requests', async () => {
+    const deadline = new AbortController().signal;
+    const timeout = vi
+      .spyOn(AbortSignal, 'timeout')
+      .mockImplementation((ms) => (ms === 110000 ? deadline : new AbortController().signal));
     fetchMock
       .mockResolvedValueOnce(response({ private: false }))
       .mockResolvedValueOnce(
@@ -60,6 +67,9 @@ describe('H3 CI artifact access', () => {
       )
       .mockResolvedValueOnce(new Response(new Uint8Array([80, 75, 3, 4])));
     const result = await GET(request('?run=10&artifact=20'));
+    expect(timeout).toHaveBeenCalledWith(110000);
+    expect(fetchMock.mock.calls[2][1]?.signal).toBe(deadline);
+    expect(fetchMock.mock.calls[0][1]?.signal).not.toBe(deadline);
     expect(result.headers.get('content-type')).toBe('application/zip');
     expect([...new Uint8Array(await result.arrayBuffer())]).toEqual([80, 75, 3, 4]);
     expect(String(fetchMock.mock.calls[2][0])).toBe(

--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from 'next/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+
+const fetchMock = vi.fn<typeof fetch>();
+vi.stubGlobal('fetch', fetchMock);
+const response = (body: unknown, status = 200) => Response.json(body, { status });
+const request = (query = '') => new NextRequest(`http://localhost/api/video-runs${query}`);
+afterEach(() => fetchMock.mockReset());
+
+describe('H3 CI artifact access', () => {
+  it('discovers benchmark runs without including branch-named unit jobs', async () => {
+    fetchMock.mockResolvedValueOnce(response({ private: false })).mockResolvedValueOnce(
+      response({
+        workflow_runs: [
+          { id: 1, name: 'e2e Test - h3-8s', path: '.github/workflows/e2e-tests.yml' },
+          { id: 2, name: 'Test H3 Video', path: '.github/workflows/test-h3-video.yml' },
+          { id: 3, name: 'H3 Video Smoke', path: '.github/workflows/h3-video.yml' },
+        ],
+      }),
+    );
+    const result = await GET(request());
+    const data = await result.json();
+    expect(data.runs.map((r: { id: number }) => r.id)).toEqual([1, 3]);
+    expect(result.headers.get('cache-control')).toContain('no-store');
+  });
+  it('refuses a private repository before reading any artifacts', async () => {
+    fetchMock.mockResolvedValueOnce(response({ private: true }));
+    const result1 = await GET(request('?run=10&artifact=20'));
+    expect(result1.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('rejects unrelated or mismatched artifact identities', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockResolvedValueOnce(response({ name: 'h3-video-11-1', workflow_run: { id: 11 } }));
+    const result2 = await GET(request('?run=10&artifact=20'));
+    expect(result2.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+  it('keeps expired artifacts explicit', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockResolvedValueOnce(
+        response({ name: 'h3-results-10-1', workflow_run: { id: 10 }, expired: true }),
+      );
+    const result3 = await GET(request('?run=10&artifact=20'));
+    expect(result3.status).toBe(410);
+  });
+  it('streams the verified run artifact through a fixed GitHub API path', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockResolvedValueOnce(
+        response({
+          name: 'h3-results-10-1',
+          workflow_run: { id: 10 },
+          size_in_bytes: 4,
+          archive_download_url: 'https://evil.example',
+        }),
+      )
+      .mockResolvedValueOnce(new Response(new Uint8Array([80, 75, 3, 4])));
+    const result = await GET(request('?run=10&artifact=20'));
+    expect(result.headers.get('content-type')).toBe('application/zip');
+    expect([...new Uint8Array(await result.arrayBuffer())]).toEqual([80, 75, 3, 4]);
+    expect(String(fetchMock.mock.calls[2][0])).toBe(
+      'https://api.github.com/repos/SemiAnalysisAI/InferenceX/actions/artifacts/20/zip',
+    );
+  });
+  it('rejects oversized artifacts before downloading', async () => {
+    fetchMock.mockResolvedValueOnce(response({ private: false })).mockResolvedValueOnce(
+      response({
+        name: 'h3-video-10-1',
+        workflow_run: { id: 10 },
+        size_in_bytes: 300 * 1024 ** 2,
+      }),
+    );
+    const result4 = await GET(request('?run=10&artifact=20'));
+    expect(result4.status).toBe(413);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+  it('shows a run with no result artifact without substituting another run', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockResolvedValueOnce(response({ id: 10, conclusion: 'failure' }))
+      .mockResolvedValueOnce(response({ artifacts: [{ id: 20, name: 'other-artifact' }] }));
+    const result = await GET(request('?run=10'));
+    expect(await result.json()).toEqual({
+      run: { id: 10, conclusion: 'failure' },
+      artifacts: [],
+    });
+  });
+  it('rejects invalid identifiers without making requests', async () => {
+    const result5 = await GET(request('?run=../secret'));
+    expect(result5.status).toBe(400);
+    const result6 = await GET(request('?artifact=123'));
+    expect(result6.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -10,7 +10,7 @@ const headers = { 'Cache-Control': 'private, no-store' };
 const id = (value: string) => /^[1-9]\d{0,19}$/u.test(value);
 const artifactName = /^h3-(?:results|video)-(?<runId>\d+)-(?<attempt>\d+)$/u;
 
-function github(path: string) {
+function github(path: string, signal = AbortSignal.timeout(30000)) {
   const token = getGithubToken();
   return fetch(`${ROOT}${path}`, {
     headers: {
@@ -18,7 +18,7 @@ function github(path: string) {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     cache: 'no-store',
-    signal: AbortSignal.timeout(30000),
+    signal,
   });
 }
 
@@ -32,6 +32,7 @@ export async function GET(request: NextRequest) {
       { error: 'Invalid CI run, artifact or page' },
       { status: 400, headers },
     );
+  const deadline = AbortSignal.timeout(110000);
   try {
     // This public viewer must never expose artifacts from a repository that becomes private.
     const repository = await github('');
@@ -65,7 +66,7 @@ export async function GET(request: NextRequest) {
           { error: 'Artifact exceeds the 256 MiB viewer limit' },
           { status: 413, headers },
         );
-      const zip = await github(`/actions/artifacts/${artifactId}/zip`);
+      const zip = await github(`/actions/artifacts/${artifactId}/zip`, deadline);
       if (!zip.ok || !zip.body)
         return NextResponse.json(
           { error: `Artifact download failed (${zip.status})` },

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -1,0 +1,128 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { GITHUB_API_BASE, GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
+import { getGithubToken } from '@/lib/github-artifacts';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 120;
+const ROOT = `${GITHUB_API_BASE}/repos/${GITHUB_OWNER}/${GITHUB_REPO}`;
+const MAX_BYTES = 256 * 1024 ** 2;
+const headers = { 'Cache-Control': 'private, no-store' };
+const id = (value: string) => /^[1-9]\d{0,19}$/u.test(value);
+const artifactName = /^h3-(?:results|video)-(?<runId>\d+)-(?<attempt>\d+)$/u;
+
+function github(path: string) {
+  const token = getGithubToken();
+  return fetch(`${ROOT}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    cache: 'no-store',
+    signal: AbortSignal.timeout(30000),
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const query = request.nextUrl.searchParams;
+  const runId = query.get('run');
+  const artifactId = query.get('artifact');
+  const page = query.get('page') ?? '1';
+  if ((runId && !id(runId)) || (artifactId && (!runId || !id(artifactId))) || !id(page))
+    return NextResponse.json(
+      { error: 'Invalid CI run, artifact or page' },
+      { status: 400, headers },
+    );
+  try {
+    // This public viewer must never expose artifacts from a repository that becomes private.
+    const repository = await github('');
+    const repo = repository.ok ? await repository.json() : null;
+    if (repo?.private !== false)
+      return NextResponse.json(
+        { error: 'Public H3 repository unavailable' },
+        { status: 503, headers },
+      );
+    if (artifactId) {
+      const metaResponse = await github(`/actions/artifacts/${artifactId}`);
+      if (!metaResponse.ok)
+        return NextResponse.json(
+          { error: 'Artifact unavailable' },
+          { status: metaResponse.status, headers },
+        );
+      const artifact = await metaResponse.json();
+      const name = artifactName.exec(artifact.name ?? '');
+      if (!name || name.groups?.runId !== runId || String(artifact.workflow_run?.id) !== runId)
+        return NextResponse.json(
+          { error: 'Artifact does not belong to this H3 run' },
+          { status: 404, headers },
+        );
+      if (artifact.expired)
+        return NextResponse.json(
+          { error: 'This GitHub artifact has expired' },
+          { status: 410, headers },
+        );
+      if (artifact.size_in_bytes > MAX_BYTES)
+        return NextResponse.json(
+          { error: 'Artifact exceeds the 256 MiB viewer limit' },
+          { status: 413, headers },
+        );
+      const zip = await github(`/actions/artifacts/${artifactId}/zip`);
+      if (!zip.ok || !zip.body)
+        return NextResponse.json(
+          { error: `Artifact download failed (${zip.status})` },
+          { status: 502, headers },
+        );
+      let bytes = 0;
+      const stream = zip.body.pipeThrough(
+        new TransformStream<Uint8Array, Uint8Array>({
+          transform(chunk, controller) {
+            bytes += chunk.byteLength;
+            if (bytes > MAX_BYTES) throw new Error('Artifact exceeds viewer limit');
+            controller.enqueue(chunk);
+          },
+        }),
+      );
+      return new Response(stream, { headers: { ...headers, 'Content-Type': 'application/zip' } });
+    }
+    if (runId) {
+      const runResponse = await github(`/actions/runs/${runId}`);
+      if (!runResponse.ok)
+        return NextResponse.json(
+          { error: 'CI run unavailable' },
+          { status: runResponse.status, headers },
+        );
+      const artifactsResponse = await github(`/actions/runs/${runId}/artifacts?per_page=100`);
+      if (!artifactsResponse.ok)
+        return NextResponse.json({ error: 'Cannot list CI artifacts' }, { status: 502, headers });
+      const data = await artifactsResponse.json();
+      const artifacts = (data.artifacts ?? []).filter((a: { name: string }) => {
+        const match = artifactName.exec(a.name);
+        return match?.groups?.runId === runId;
+      });
+      return NextResponse.json({ run: await runResponse.json(), artifacts }, { headers });
+    }
+    const response = await github(`/actions/runs?per_page=100&page=${page}`);
+    if (!response.ok)
+      return NextResponse.json(
+        { error: `GitHub run listing failed (${response.status})` },
+        { status: 502, headers },
+      );
+    const data = await response.json();
+    const runs = data.workflow_runs ?? [];
+    return NextResponse.json(
+      {
+        runs: runs.filter(
+          (run: { name: string; display_title: string; path: string }) =>
+            (run.path === '.github/workflows/e2e-tests.yml' && /\bh3\b/iu.test(run.name)) ||
+            run.path === '.github/workflows/h3-video.yml',
+        ),
+        nextPage: runs.length === 100 ? Number(page) + 1 : null,
+      },
+      { headers },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: 'GitHub is unavailable; retry shortly' },
+      { status: 502, headers },
+    );
+  }
+}

--- a/packages/app/src/app/zh/(dashboard)/video/page.tsx
+++ b/packages/app/src/app/zh/(dashboard)/video/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import VideoBenchmark from '@/components/video-benchmark/VideoBenchmark';
+import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
 import { tabMetadataZh } from '@/lib/tab-meta-zh';
 
 export const metadata: Metadata = {
@@ -7,5 +7,5 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 export default function VideoPage() {
-  return <VideoBenchmark />;
+  return <VideoCIRuns />;
 }

--- a/packages/app/src/components/video-benchmark/ResultPower.tsx
+++ b/packages/app/src/components/video-benchmark/ResultPower.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Heading } from '@/components/ui/heading';
+import { useLocale } from '@/lib/use-locale';
+import { at, entries, number, ROLES, rows, text, type Json } from './bundle';
+
+const STRINGS = {
+  en: {
+    title: 'Measured GPU power & energy',
+    phase: 'Power window',
+    startup: 'Startup',
+    warmup: 'Warmup',
+    measurement: 'Generation',
+    baseline: 'Baseline',
+    candidate: 'Candidate',
+    unavailable: 'Unavailable',
+    note: 'Generation power covers submission → observed provider completion, excluding download and local decoding. Startup and warmup are separate. Averages and energy are backend-validated, time-weighted board measurements; sampled peaks are not instantaneous peaks or whole-node power.',
+    mean: 'Mean aggregate power (W)',
+    peak: 'Observed aggregate peak (W)',
+    energy: 'Integrated energy (kJ)',
+    perClip: 'Energy / valid clip (kJ/clip)',
+    duration: 'Window duration (s)',
+    gpu: 'GPU UUID',
+    memory: 'Client memory peak, including warmup (MiB)',
+    meanGpu: 'Mean (W)',
+    peakGpu: 'Observed peak (W)',
+    ratio: 'Mean / specification TDP (%)',
+    windows: 'Window coverage and validity',
+    full: 'Full recorded result',
+    fullNote:
+      'Original contract fields, including configurations, timing sources, power limits, metric definitions and validity reasons. Missing values remain null. Reprocessing does not create a new GPU measurement.',
+    producer: 'Export CI run',
+    execution: 'Original execution CI run',
+    limits:
+      'Board power excludes CPU and facility energy. Specification TDP is separate from configured limits; later inventory does not establish historical settings.',
+  },
+  zh: {
+    title: '实测 GPU 功率与能耗',
+    phase: '功率统计时段',
+    startup: '启动',
+    warmup: 'Warmup',
+    measurement: '生成',
+    baseline: '基线',
+    candidate: '候选',
+    unavailable: '无数据',
+    note: '生成阶段功率覆盖从请求提交到观测到服务端完成为止，不含下载和本地解码。启动与 warmup 单独统计。平均功率与能耗由后端校验，基于板卡功率按时间加权计算；观测峰值取自离散采样，不是瞬时峰值，也不代表整机功率。',
+    mean: '合计平均功率（W）',
+    peak: '合计观测峰值（W）',
+    energy: '积分能耗（kJ）',
+    perClip: '每有效视频能耗（kJ/clip）',
+    duration: '时段时长（s）',
+    gpu: 'GPU UUID',
+    memory: '客户端显存采样峰值（含 warmup，MiB）',
+    meanGpu: '平均功率（W）',
+    peakGpu: '观测峰值（W）',
+    ratio: '平均功率 / 规格 TDP（%）',
+    windows: '时段覆盖与有效性',
+    full: '完整结果记录',
+    fullNote:
+      '原始契约字段全文，包括配置、计时来源、功率上限、指标定义和有效性判定原因。缺失值保持 null。重新处理不会产生新的 GPU 测量数据。',
+    producer: '导出产物的 CI 运行',
+    execution: '原始执行的 CI 运行',
+    limits:
+      '板卡功率不含 CPU 与设施能耗。规格 TDP 不等于运行时配置的功率上限；事后采集的硬件信息不能证明当时的实际设置。',
+  },
+};
+const kilo = (value: Json) => {
+  const n = number(value);
+  return n === null ? null : n / 1000;
+};
+
+export default function ResultPower({ result }: { result: Json }) {
+  const s = STRINGS[useLocale()];
+  const [phase, setPhase] = useState<'startup' | 'warmup' | 'measurement'>('measurement');
+  const fmt = (value: Json) => {
+    const n = number(value);
+    return n === null ? s.unavailable : n.toLocaleString('en-US', { maximumFractionDigits: 3 });
+  };
+  return (
+    <>
+      <Card className="gap-4" data-testid="result-power">
+        <Heading>{s.title}</Heading>
+        <p className="text-sm text-muted-foreground">{s.note}</p>
+        <label className="text-sm">
+          {s.phase}
+          <select
+            aria-label={s.phase}
+            className="ml-3 rounded border bg-background p-2"
+            value={phase}
+            onChange={(e) => setPhase(e.target.value as typeof phase)}
+          >
+            {(['startup', 'warmup', 'measurement'] as const).map((value) => (
+              <option key={value} value={value}>
+                {s[value]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="grid gap-6 lg:grid-cols-2">
+          {ROLES.map((role) => {
+            const power = at(result, 'roles', role, 'power');
+            const data = at(power, 'phases', phase);
+            const valid = at(data, 'valid') === true;
+            const value = (...keys: string[]) => (valid ? at(data, ...keys) : null);
+            const fraction = number(value('tdp_comparison', 'aggregate_average_fraction_of_tdp'));
+            return (
+              <div key={role} className="min-w-0 space-y-3">
+                <Heading level="card">
+                  {s[role]} · {text(at(data, 'status')) || s.unavailable}
+                </Heading>
+                <dl className="space-y-2 text-sm">
+                  {[
+                    [s.mean, value('aggregate', 'avg_power_w')],
+                    [s.peak, value('aggregate', 'observed_peak_power_w')],
+                    [s.energy, kilo(value('aggregate', 'energy_j'))],
+                    [s.perClip, kilo(value('aggregate', 'joules_per_valid_clip'))],
+                    [s.duration, value('duration_seconds')],
+                    [s.ratio, fraction === null ? null : fraction * 100],
+                  ].map(([label, n]) => (
+                    <div key={String(label)} className="flex justify-between gap-4">
+                      <dt>{String(label)}</dt>
+                      <dd>{fmt(n as Json)}</dd>
+                    </div>
+                  ))}
+                </dl>
+                {!valid && (
+                  <p className="break-words text-sm">
+                    {rows(at(data, 'invalid_reasons')).map(text).join(', ') || s.unavailable}
+                  </p>
+                )}
+                {valid && (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-left text-xs">
+                      <thead>
+                        <tr>
+                          <th>{s.gpu}</th>
+                          <th>{s.meanGpu}</th>
+                          <th>{s.peakGpu}</th>
+                          <th>{s.memory}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {entries(at(data, 'per_gpu')).map(([uuid, gpu]) => (
+                          <tr key={uuid}>
+                            <td className="max-w-48 break-all py-2 pr-3">{uuid}</td>
+                            <td>{fmt(at(gpu, 'avg_power_w'))}</td>
+                            <td>{fmt(at(gpu, 'observed_peak_power_w'))}</td>
+                            <td>
+                              {fmt(
+                                at(
+                                  result,
+                                  'roles',
+                                  role,
+                                  'metrics',
+                                  'gpu_memory',
+                                  'client_including_warmup_observed_peak_mib_by_gpu',
+                                  uuid,
+                                ),
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+                <details>
+                  <summary className="cursor-pointer text-sm">{s.memory}</summary>
+                  <dl className="mt-2 space-y-2 text-xs">
+                    {entries(
+                      at(
+                        result,
+                        'roles',
+                        role,
+                        'metrics',
+                        'gpu_memory',
+                        'client_including_warmup_observed_peak_mib_by_gpu',
+                      ),
+                    ).map(([uuid, mib]) => (
+                      <div key={uuid} className="flex justify-between gap-3">
+                        <dt className="break-all">{uuid}</dt>
+                        <dd>{fmt(mib)}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                </details>
+                <details>
+                  <summary className="cursor-pointer text-sm">{s.windows}</summary>
+                  <pre className="mt-2 overflow-auto whitespace-pre-wrap break-all text-xs">
+                    {JSON.stringify(
+                      rows(at(power, 'windows')).filter((w) => at(w, 'phase') === phase),
+                      null,
+                      2,
+                    )}
+                  </pre>
+                </details>
+              </div>
+            );
+          })}
+        </div>
+        <p className="text-sm text-muted-foreground">{s.limits}</p>
+      </Card>
+      <Card className="gap-3">
+        <Heading>{s.full}</Heading>
+        <p className="text-sm text-muted-foreground">{s.fullNote}</p>
+        {[
+          [s.execution, at(result, 'execution', 'ci', 'run_id')],
+          [s.producer, at(result, 'producer', 'ci', 'run_id')],
+        ].map(([label, id]) =>
+          /^[1-9]\d*$/u.test(text(id)) ? (
+            <a
+              key={String(label)}
+              className="text-sm text-primary underline"
+              href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${encodeURIComponent(text(id))}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {String(label)} · #{text(id)}
+            </a>
+          ) : (
+            <p key={String(label)} className="text-sm">
+              {String(label)} · {s.unavailable}
+            </p>
+          ),
+        )}
+        {entries(result).map(([key, value]) => (
+          <details key={key}>
+            <summary className="cursor-pointer font-mono text-sm">{key}</summary>
+            <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-all text-xs">
+              {JSON.stringify(value, null, 2)}
+            </pre>
+          </details>
+        ))}
+      </Card>
+    </>
+  );
+}

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Heading } from '@/components/ui/heading';
 import { useLocale } from '@/lib/use-locale';
 import { track } from '@/lib/analytics';
+import ResultPower from './ResultPower';
 import {
   at,
   entries,
@@ -270,7 +271,7 @@ const field = (label: string, value: string, change: (value: string) => void, ty
   </label>
 );
 
-export default function VideoBenchmark() {
+export default function VideoBenchmark({ reader }: { reader?: (path: string) => Promise<Blob> }) {
   const s = STRINGS[useLocale()];
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [loading, setLoading] = useState(false);
@@ -404,6 +405,11 @@ export default function VideoBenchmark() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (reader) void open(() => reader);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reader]);
+
   const b = loaded?.bundle;
   const participating = rows(
     at(b?.job, 'roles', 'baseline', 'telemetry_summary', 'gpu_identity'),
@@ -447,54 +453,60 @@ export default function VideoBenchmark() {
           </Heading>
           <p className="text-muted-foreground mt-2">{s.subtitle}</p>
         </div>
-        <div className="flex gap-2">
-          <Button onClick={() => input.current?.click()} disabled={loading}>
-            {s.open}
-          </Button>
-          {b && (
-            <Button variant="outline" onClick={clear}>
-              {s.clear}
+        {!reader && (
+          <div className="flex gap-2">
+            <Button onClick={() => input.current?.click()} disabled={loading}>
+              {s.open}
             </Button>
-          )}
-        </div>
+            {b && (
+              <Button variant="outline" onClick={clear}>
+                {s.clear}
+              </Button>
+            )}
+          </div>
+        )}
       </header>
-      <input
-        ref={input}
-        aria-label={s.open}
-        type="file"
-        multiple
-        {...{ webkitdirectory: '' }}
-        className="sr-only"
-        onChange={(e) => {
-          const files = [...(e.target.files ?? [])];
-          e.target.value = '';
-          if (files.length > 0) void open(() => folderReader(files));
-        }}
-      />
-      <details className="rounded-lg border p-4 text-sm">
-        <summary className="cursor-pointer">{s.source}</summary>
-        <form
-          className="mt-3 flex flex-wrap gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void open(() => httpReader(source));
-          }}
-        >
-          <Input
-            aria-label={s.source}
-            className="flex-1"
-            type="url"
-            value={source}
-            onChange={(e) => setSource(e.target.value)}
-            placeholder="https://…/manifest.json"
-            required
+      {!reader && (
+        <>
+          <input
+            ref={input}
+            aria-label={s.open}
+            type="file"
+            multiple
+            {...{ webkitdirectory: '' }}
+            className="sr-only"
+            onChange={(e) => {
+              const files = [...(e.target.files ?? [])];
+              e.target.value = '';
+              if (files.length > 0) void open(() => folderReader(files));
+            }}
           />
-          <Button type="submit" disabled={loading}>
-            {s.load}
-          </Button>
-        </form>
-        <p className="text-muted-foreground mt-3">{s.remote}</p>
-      </details>
+          <details className="rounded-lg border p-4 text-sm">
+            <summary className="cursor-pointer">{s.source}</summary>
+            <form
+              className="mt-3 flex flex-wrap gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void open(() => httpReader(source));
+              }}
+            >
+              <Input
+                aria-label={s.source}
+                className="flex-1"
+                type="url"
+                value={source}
+                onChange={(e) => setSource(e.target.value)}
+                placeholder="https://…/manifest.json"
+                required
+              />
+              <Button type="submit" disabled={loading}>
+                {s.load}
+              </Button>
+            </form>
+            <p className="text-muted-foreground mt-3">{s.remote}</p>
+          </details>
+        </>
+      )}
       {loading && <Card role="status">{s.loading}</Card>}
       {loadError && (
         <Card role="alert" className="border-destructive">
@@ -712,61 +724,65 @@ export default function VideoBenchmark() {
             })}
           </div>
           <p className="text-sm text-muted-foreground">{s.timing}</p>
-          <Card className="gap-4">
-            <Heading>{s.power}</Heading>
-            <p className="text-sm text-muted-foreground">{s.powerNote}</p>
-            <div className="grid gap-6 lg:grid-cols-2">
-              {ROLES.map((role) => {
-                const power = loaded.power[role];
-                return (
-                  <div key={role} className="space-y-3">
-                    <Heading level="card">{s[role]}</Heading>
-                    {table([
-                      [`${s.meanPower} (W)`, power?.watts],
-                      [`${s.energy} (kJ)`, power ? power.joules / 1000 : null],
-                      [`${s.coverage} (s)`, power?.seconds],
-                      [s.samples, power?.sampleCount],
-                    ])}
-                    {power && (
-                      <p className="break-all text-xs text-muted-foreground">
-                        {power.start} → {power.end}
-                      </p>
-                    )}
+          {b.result ? (
+            <ResultPower result={b.result} />
+          ) : (
+            <Card className="gap-4">
+              <Heading>{s.power}</Heading>
+              <p className="text-sm text-muted-foreground">{s.powerNote}</p>
+              <div className="grid gap-6 lg:grid-cols-2">
+                {ROLES.map((role) => {
+                  const power = loaded.power[role];
+                  return (
+                    <div key={role} className="space-y-3">
+                      <Heading level="card">{s[role]}</Heading>
+                      {table([
+                        [`${s.meanPower} (W)`, power?.watts],
+                        [`${s.energy} (kJ)`, power ? power.joules / 1000 : null],
+                        [`${s.coverage} (s)`, power?.seconds],
+                        [s.samples, power?.sampleCount],
+                      ])}
+                      {power && (
+                        <p className="break-all text-xs text-muted-foreground">
+                          {power.start} → {power.end}
+                        </p>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+              <Heading level="card">{s.memory}</Heading>
+              <p className="text-sm text-muted-foreground">{s.memoryNote}</p>
+              <div className="grid gap-6 lg:grid-cols-2">
+                {ROLES.map((role) => (
+                  <div key={role} className="space-y-2">
+                    <Heading level="label">{s[role]}</Heading>
+                    {entries(
+                      at(
+                        b.job,
+                        'roles',
+                        role,
+                        'telemetry_summary',
+                        'measurement_observed_memory_peak_mib_by_gpu',
+                      ),
+                    ).length > 0
+                      ? table(
+                          entries(
+                            at(
+                              b.job,
+                              'roles',
+                              role,
+                              'telemetry_summary',
+                              'measurement_observed_memory_peak_mib_by_gpu',
+                            ),
+                          ).map(([gpu, value]) => [gpu, `${fmt(value)} MiB`]),
+                        )
+                      : s.unavailable}
                   </div>
-                );
-              })}
-            </div>
-            <Heading level="card">{s.memory}</Heading>
-            <p className="text-sm text-muted-foreground">{s.memoryNote}</p>
-            <div className="grid gap-6 lg:grid-cols-2">
-              {ROLES.map((role) => (
-                <div key={role} className="space-y-2">
-                  <Heading level="label">{s[role]}</Heading>
-                  {entries(
-                    at(
-                      b.job,
-                      'roles',
-                      role,
-                      'telemetry_summary',
-                      'measurement_observed_memory_peak_mib_by_gpu',
-                    ),
-                  ).length > 0
-                    ? table(
-                        entries(
-                          at(
-                            b.job,
-                            'roles',
-                            role,
-                            'telemetry_summary',
-                            'measurement_observed_memory_peak_mib_by_gpu',
-                          ),
-                        ).map(([gpu, value]) => [gpu, `${fmt(value)} MiB`]),
-                      )
-                    : s.unavailable}
-                </div>
-              ))}
-            </div>
-          </Card>
+                ))}
+              </div>
+            </Card>
+          )}
           <Card className="gap-4">
             <Heading>{s.fidelity}</Heading>
             <p className="text-sm text-muted-foreground">{s.fidelityNote}</p>
@@ -925,7 +941,9 @@ export default function VideoBenchmark() {
           </Card>
           <Card className="gap-3">
             <Heading level="card">{s.missing}</Heading>
-            <p className="text-sm text-muted-foreground">{s.missingNote}</p>
+            <p className="text-sm text-muted-foreground">
+              {rows(at(b.result, 'limitations')).map(text).join('; ') || s.missingNote}
+            </p>
             {rows(at(b.report, 'acceptance_reasons')).map((reason, i) => (
               <p key={i} className="text-sm">
                 {text(reason)}

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -148,13 +148,15 @@ export default function VideoCIRuns() {
     }
   }
   async function list(page: number, auto = false) {
-    const selectionAtStart = request.current;
+    const current = ++request.current;
+    download.current?.abort();
     setLoading(true);
     setError('');
     try {
       const data: { runs: CIRun[]; nextPage: number | null } = await json(
         `/api/video-runs?page=${page}`,
       );
+      if (current !== request.current) return;
       setRuns((old) =>
         page === 1
           ? data.runs
@@ -171,15 +173,16 @@ export default function VideoCIRuns() {
         await list(data.nextPage, true);
         return;
       }
-      if (auto && selectionAtStart === request.current) {
+      if (auto) {
         const params = new URLSearchParams(location.search);
         const selected = params.get('run') ?? (data.runs[0] ? String(data.runs[0].id) : null);
         if (selected) await selectRun(selected, params.get('artifact'), params.get('source'));
       }
     } catch (error) {
-      setError(error instanceof Error ? error.message : String(error));
+      if (current === request.current)
+        setError(error instanceof Error ? error.message : String(error));
     } finally {
-      setLoading(false);
+      if (current === request.current) setLoading(false);
     }
   }
   useEffect(() => {

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Heading } from '@/components/ui/heading';
+import { Input } from '@/components/ui/input';
+import { useLocale } from '@/lib/use-locale';
+import VideoBenchmark from './VideoBenchmark';
+import { archiveSources, type CIArtifact, type CIRun } from './archive';
+
+const STRINGS = {
+  en: {
+    title: 'H3 CI runs',
+    error: 'Could not load CI results',
+    details: 'Technical details',
+    select: 'CI run',
+    refresh: 'Refresh',
+    older: 'Older runs',
+    loading: 'Loading CI results…',
+    source: 'Original GPU execution',
+    artifact: 'Result artifact',
+    none: 'No result artifact for this run yet. Failed runs may have only CI logs.',
+    empty: 'No H3 runs in this page of GitHub history. Load older runs or enter a run ID.',
+    retry: 'Retry',
+    direct: 'GitHub run ID',
+    open: 'Open run',
+    local: 'Local artifact tools',
+    note: 'Results load directly from GitHub CI. An export may contain earlier GPU executions; their original run identities are preserved. GitHub artifacts can expire.',
+    expired: 'Expired',
+    noMedia: 'Artifact unavailable',
+  },
+  zh: {
+    title: 'H3 CI 运行',
+    error: '无法加载 CI 结果',
+    details: '技术详情',
+    select: 'CI 运行',
+    refresh: '刷新',
+    older: '更早的运行',
+    loading: '正在加载 CI 结果…',
+    source: '原始 GPU 执行',
+    artifact: '结果产物',
+    none: '此次运行尚无结果产物。失败的运行可能仅保留 CI 日志。',
+    empty: '本页 GitHub 历史中没有 H3 运行。可加载更早的运行或输入运行 ID。',
+    retry: '重试',
+    direct: 'GitHub 运行 ID',
+    open: '查看运行',
+    local: '本地产物工具',
+    note: '结果直接从 GitHub CI 加载。导出产物可能包含更早的 GPU 执行，这些执行仍沿用各自原始运行的 ID。GitHub 产物可能过期。',
+    expired: '已过期',
+    noMedia: '产物不可用',
+  },
+};
+
+async function json(url: string) {
+  const response = await fetch(url, { cache: 'no-store' });
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error ?? `HTTP ${response.status}`);
+  return data;
+}
+
+function share(runId: number, artifactId?: number, source?: string) {
+  const url = new URL(location.href);
+  url.search = '';
+  url.searchParams.set('run', String(runId));
+  if (artifactId) url.searchParams.set('artifact', String(artifactId));
+  if (source) url.searchParams.set('source', source);
+  history.replaceState(null, '', url);
+}
+
+export default function VideoCIRuns() {
+  const s = STRINGS[useLocale()];
+  const [runs, setRuns] = useState<CIRun[]>([]);
+  const [run, setRun] = useState<CIRun | null>(null);
+  const [artifacts, setArtifacts] = useState<CIArtifact[]>([]);
+  const [artifact, setArtifact] = useState<CIArtifact | null>(null);
+  const [sources, setSources] = useState<Awaited<ReturnType<typeof archiveSources>>>([]);
+  const [sourceId, setSourceId] = useState('');
+  const [nextPage, setNextPage] = useState<number | null>(1);
+  const [loadError, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [direct, setDirect] = useState('');
+  const [manual, setManual] = useState(false);
+  const request = useRef(0);
+  const download = useRef<AbortController | null>(null);
+
+  async function loadArtifact(
+    selectedRun: CIRun,
+    selected: CIArtifact,
+    current: number,
+    source?: string,
+  ) {
+    setArtifact(selected);
+    setSources([]);
+    if (selected.expired) throw new Error(s.expired);
+    const controller = new AbortController();
+    download.current = controller;
+    const response = await fetch(`/api/video-runs?run=${selectedRun.id}&artifact=${selected.id}`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      const failure = await response.json();
+      throw new Error(failure.error ?? s.noMedia);
+    }
+    const found = await archiveSources(await response.blob(), selected);
+    if (current !== request.current) return;
+    const chosen =
+      found.find((item) => item.id === source) ??
+      found.toSorted((a, b) => Number(b.id) - Number(a.id))[0];
+    if (!chosen) throw new Error(s.none);
+    setSources(found);
+    setSourceId(chosen.id);
+    share(selectedRun.id, selected.id, chosen.id);
+  }
+  async function selectRun(runId: string, artifactId?: string | null, source?: string | null) {
+    const current = ++request.current;
+    download.current?.abort();
+    setLoading(true);
+    setError('');
+    setRun(null);
+    setSources([]);
+    setArtifact(null);
+    setArtifacts([]);
+    try {
+      const data: { run: CIRun; artifacts: CIArtifact[] } = await json(
+        `/api/video-runs?run=${encodeURIComponent(runId)}`,
+      );
+      if (current !== request.current) return;
+      setRun(data.run);
+      setArtifacts(data.artifacts);
+      setRuns((old) => (old.some((r) => r.id === data.run.id) ? old : [data.run, ...old]));
+      const selected =
+        data.artifacts.find((a) => String(a.id) === artifactId) ??
+        data.artifacts
+          .filter((a) => a.name.endsWith(`-${data.run.run_attempt}`))
+          .toSorted(
+            (a, b) =>
+              Number(b.name.startsWith('h3-results-')) - Number(a.name.startsWith('h3-results-')) ||
+              b.id - a.id,
+          )[0];
+      share(data.run.id);
+      if (selected) await loadArtifact(data.run, selected, current, source ?? undefined);
+    } catch (error) {
+      if (current === request.current)
+        setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      if (current === request.current) setLoading(false);
+    }
+  }
+  async function list(page: number, auto = false) {
+    const selectionAtStart = request.current;
+    setLoading(true);
+    setError('');
+    try {
+      const data: { runs: CIRun[]; nextPage: number | null } = await json(
+        `/api/video-runs?page=${page}`,
+      );
+      setRuns((old) =>
+        page === 1
+          ? data.runs
+          : [...old, ...data.runs.filter((r) => !old.some((o) => o.id === r.id))],
+      );
+      setNextPage(data.nextPage);
+      if (
+        auto &&
+        data.runs.length === 0 &&
+        data.nextPage &&
+        page < 10 &&
+        !new URLSearchParams(location.search).has('run')
+      ) {
+        await list(data.nextPage, true);
+        return;
+      }
+      if (auto && selectionAtStart === request.current) {
+        const params = new URLSearchParams(location.search);
+        const selected = params.get('run') ?? (data.runs[0] ? String(data.runs[0].id) : null);
+        if (selected) await selectRun(selected, params.get('artifact'), params.get('source'));
+      }
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => {
+    void list(1, true);
+    return () => {
+      request.current++;
+      download.current?.abort();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const selectedSource = sources.find((item) => item.id === sourceId);
+  return (
+    <div className="mx-auto min-w-0 w-full max-w-7xl space-y-4 py-6" data-testid="video-ci-runs">
+      <Card className="gap-4">
+        <Heading as="h1" level="page">
+          {s.title}
+        </Heading>
+        <p className="text-sm text-muted-foreground">{s.note}</p>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="min-w-0 flex-1 space-y-1 text-sm">
+            {s.select}
+            <select
+              aria-label={s.select}
+              className="w-full rounded border bg-background p-2"
+              value={run?.id ?? ''}
+              onChange={(e) => void selectRun(e.target.value)}
+            >
+              <option value="" disabled>
+                —
+              </option>
+              {runs.map((r) => (
+                <option key={r.id} value={r.id}>
+                  #{r.id} · {r.name} · {r.conclusion ?? r.status}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button variant="outline" disabled={loading} onClick={() => void list(1, true)}>
+            {s.refresh}
+          </Button>
+          {nextPage && (
+            <Button variant="outline" disabled={loading} onClick={() => void list(nextPage)}>
+              {s.older}
+            </Button>
+          )}
+        </div>
+        {runs.length === 0 && !loading && <p>{s.empty}</p>}
+        <form
+          className="flex flex-wrap gap-2"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void selectRun(direct);
+          }}
+        >
+          <Input
+            className="max-w-xs"
+            aria-label={s.direct}
+            placeholder={s.direct}
+            value={direct}
+            onChange={(e) => setDirect(e.target.value)}
+            pattern="[0-9]+"
+            required
+          />
+          <Button type="submit" variant="outline">
+            {s.open}
+          </Button>
+        </form>
+        {run && (
+          <a
+            className="break-all text-sm text-primary underline"
+            href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${run.id}`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            #{run.id} · {run.status} / {run.conclusion ?? '—'} · {run.created_at} ·{' '}
+            {run.head_sha.slice(0, 10)}
+          </a>
+        )}
+        {artifacts.length > 0 && (
+          <label className="text-sm">
+            {s.artifact}
+            <select
+              aria-label={s.artifact}
+              className="mt-1 w-full rounded border bg-background p-2"
+              value={artifact?.id ?? ''}
+              onChange={(e) => run && void selectRun(String(run.id), e.target.value)}
+            >
+              <option value="" disabled>
+                —
+              </option>
+              {artifacts.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                  {a.expired ? ` · ${s.expired}` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {sources.length > 1 && (
+          <label className="text-sm">
+            {s.source}
+            <select
+              aria-label={s.source}
+              className="mt-1 w-full rounded border bg-background p-2"
+              value={sourceId}
+              onChange={(e) => {
+                setSourceId(e.target.value);
+                if (run && artifact) share(run.id, artifact.id, e.target.value);
+              }}
+            >
+              {sources.map((item) => (
+                <option key={item.id} value={item.id}>
+                  #{item.id}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+        {loading && <p role="status">{s.loading}</p>}
+        {loadError && (
+          <div role="alert">
+            <p>{s.error}</p>
+            <details>
+              <summary className="cursor-pointer text-sm">{s.details}</summary>
+              <pre className="mt-2 whitespace-pre-wrap break-all text-xs">{loadError}</pre>
+            </details>
+            <Button
+              variant="outline"
+              onClick={() =>
+                run
+                  ? void selectRun(String(run.id), artifact ? String(artifact.id) : null)
+                  : void list(1, true)
+              }
+            >
+              {s.retry}
+            </Button>
+          </div>
+        )}
+        {run && !loading && !loadError && artifacts.length === 0 && <p>{s.none}</p>}
+      </Card>
+      {selectedSource && (
+        <VideoBenchmark key={`${artifact?.id}-${sourceId}`} reader={selectedSource.read} />
+      )}
+      <details onToggle={(event) => setManual(event.currentTarget.open)}>
+        <summary className="cursor-pointer text-sm text-muted-foreground">{s.local}</summary>
+        {manual && <VideoBenchmark />}
+      </details>
+    </div>
+  );
+}

--- a/packages/app/src/components/video-benchmark/archive.test.ts
+++ b/packages/app/src/components/video-benchmark/archive.test.ts
@@ -1,0 +1,95 @@
+import { createHash } from 'node:crypto';
+import { strToU8, zipSync } from 'fflate';
+import { describe, expect, it } from 'vitest';
+import { archiveSources } from './archive';
+import { loadBundle } from './bundle';
+const artifact = { id: 20, name: 'h3-video-10-1', expired: false, size_in_bytes: 0 };
+const hash = (value: string) => createHash('sha256').update(value).digest('hex');
+function archive(files: Record<string, string>) {
+  return new Blob([
+    zipSync(Object.fromEntries(Object.entries(files).map(([k, v]) => [k, strToU8(v)]))).buffer,
+  ]);
+}
+describe('CI ZIP import', () => {
+  it('verifies and opens a legacy CI artifact', async () => {
+    const manifest = JSON.stringify({
+      schema_version: 1,
+      run_id: '10',
+      run_attempt: '1',
+      git_commit: 'a'.repeat(40),
+      ci: { repository: 'SemiAnalysisAI/InferenceX' },
+    });
+    const blob = archive({
+      'manifest.json': manifest,
+      SHA256SUMS: `${hash(manifest)}  manifest.json\n`,
+    });
+    const [source] = await archiveSources(blob, artifact);
+    expect(source.id).toBe('10');
+    const bundle = await loadBundle(source.read);
+    expect(bundle.manifestSha256).toBe(hash(manifest));
+  });
+  it('preserves original execution identities in an exported archive', async () => {
+    const index = JSON.stringify({
+      schema_version: '1.0.0',
+      producer: { ci: { run_id: '10', run_attempt: '1' } },
+      results: [{ source_run_id: '9', manifest: 'source-9/result.json' }],
+    });
+    const files = {
+      'index.json': index,
+      'source-9/result.json': '{}',
+      'source-9/manifest.json': JSON.stringify({ run_id: '9' }),
+    };
+    const blob = archive({
+      ...files,
+      SHA256SUMS: Object.entries(files)
+        .map(([path, value]) => `${hash(value)}  ${path}`)
+        .join('\n'),
+    });
+    const [source] = await archiveSources(blob, { ...artifact, name: 'h3-results-10-1' });
+    expect(source.id).toBe('9');
+    const original = await source.read('manifest.json');
+    expect(JSON.parse(await original.text())).toEqual({ run_id: '9' });
+    await expect(archiveSources(blob, { ...artifact, name: 'h3-results-11-1' })).rejects.toThrow(
+      'different runs',
+    );
+  });
+  it('rejects a legacy manifest attributed to another CI run', async () => {
+    const manifest = JSON.stringify({ run_id: '11', run_attempt: '1' });
+    await expect(
+      archiveSources(
+        archive({
+          'manifest.json': manifest,
+          SHA256SUMS: `${hash(manifest)}  manifest.json`,
+        }),
+        artifact,
+      ),
+    ).rejects.toThrow('different runs');
+  });
+  it('rejects corrupted GitHub archive digests', async () => {
+    await expect(
+      archiveSources(archive({}), { ...artifact, digest: `sha256:${'0'.repeat(64)}` }),
+    ).rejects.toThrow('digest mismatch');
+  });
+  it('rejects unsafe paths and checksum mismatches', async () => {
+    await expect(archiveSources(archive({ '../secret': 'x' }), artifact)).rejects.toThrow('Unsafe');
+    await expect(
+      archiveSources(
+        archive({ SHA256SUMS: `${'0'.repeat(64)}  manifest.json`, 'manifest.json': '{}' }),
+        artifact,
+      ),
+    ).rejects.toThrow('checksum mismatch');
+  });
+  it('rejects unknown export schemas', async () => {
+    const index = JSON.stringify({
+      schema_version: '99',
+      producer: { ci: { run_id: '10', run_attempt: '1' } },
+      results: [],
+    });
+    await expect(
+      archiveSources(
+        archive({ 'index.json': index, SHA256SUMS: `${hash(index)}  index.json` }),
+        artifact,
+      ),
+    ).rejects.toThrow('Unsupported');
+  });
+});

--- a/packages/app/src/components/video-benchmark/archive.ts
+++ b/packages/app/src/components/video-benchmark/archive.ts
@@ -1,0 +1,99 @@
+import { at, rows, safePath, sha256, text, type Json } from './bundle';
+
+export interface CIArtifact {
+  id: number;
+  name: string;
+  expired: boolean;
+  size_in_bytes: number;
+  digest?: string;
+}
+export interface CIRun {
+  id: number;
+  name: string;
+  run_attempt: number;
+  head_sha: string;
+  created_at: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+}
+
+export async function archiveSources(blob: Blob, artifact: CIArtifact) {
+  if (blob.size > 256 * 1024 ** 2) throw new Error('Archive exceeds 256 MiB');
+  if (artifact.digest && artifact.digest !== `sha256:${await sha256(blob)}`)
+    throw new Error('GitHub artifact digest mismatch');
+  const { unzipSync } = await import('fflate');
+  let total = 0;
+  const names = new Set<string>();
+  const files = unzipSync(new Uint8Array(await blob.arrayBuffer()), {
+    filter(file) {
+      if (file.name.endsWith('/')) return false;
+      safePath(file.name);
+      if (names.has(file.name)) throw new Error('Duplicate archive path');
+      names.add(file.name);
+      total += file.originalSize;
+      if (names.size > 4000 || file.originalSize > 512 * 1024 ** 2 || total > 1024 ** 3)
+        throw new Error('Expanded archive exceeds browser memory limit');
+      return true;
+    },
+  });
+  const read = (path: string) => {
+    const bytes = files[safePath(path)];
+    if (!bytes) throw new Error(`Missing artifact file: ${path}`);
+    return new Blob([new Uint8Array(bytes).buffer]);
+  };
+  // Verify the outer export index and every contained source before selecting a result.
+  const sums = await read('SHA256SUMS').text();
+  const verified = new Set<string>();
+  for (const line of sums.trim().split('\n')) {
+    const match = /^(?<hash>[a-f0-9]{64})  (?<path>.+)$/u.exec(line);
+    if (
+      !match ||
+      verified.has(match.groups!.path) ||
+      (await sha256(read(match.groups!.path))) !== match.groups!.hash
+    )
+      throw new Error('Archive checksum mismatch');
+    verified.add(match.groups!.path);
+  }
+  if (!verified.has(files['index.json'] ? 'index.json' : 'manifest.json'))
+    throw new Error('Missing verified archive entry point');
+  const index: Json = files['index.json'] ? JSON.parse(await read('index.json').text()) : null;
+  const identity = /^h3-(?:video|results)-(?<run>\d+)-(?<attempt>\d+)$/u.exec(
+    artifact.name,
+  )?.groups;
+  if (!identity) throw new Error('Invalid H3 artifact identity');
+  if (
+    index &&
+    (at(index, 'producer', 'ci', 'run_id') !== identity.run ||
+      at(index, 'producer', 'ci', 'run_attempt') !== identity.attempt)
+  )
+    throw new Error('Export and GitHub artifact identify different runs');
+  if (index && at(index, 'schema_version') !== '1.0.0')
+    throw new Error('Unsupported H3 export index');
+  if (index)
+    return rows(at(index, 'results')).map((result) => {
+      const manifest = safePath(text(at(result, 'manifest')));
+      if (!manifest.endsWith('/result.json')) throw new Error('Invalid export result path');
+      const source = text(at(result, 'source_run_id'));
+      if (
+        !/^[1-9]\d*$/u.test(source) ||
+        manifest !== `source-${source}/result.json` ||
+        !verified.has(manifest)
+      )
+        throw new Error('Invalid export source identity');
+      const prefix = manifest.slice(0, -'result.json'.length);
+      const original: Json = JSON.parse(new TextDecoder().decode(files[`${prefix}manifest.json`]));
+      if (at(original, 'run_id') !== source)
+        throw new Error('Export source and original manifest identify different runs');
+      return {
+        id: text(at(result, 'source_run_id')),
+        read: (path: string) => Promise.resolve(read(prefix + safePath(path))),
+      };
+    });
+  const manifest: Json = JSON.parse(await read('manifest.json').text());
+  if (at(manifest, 'run_id') !== identity.run || at(manifest, 'run_attempt') !== identity.attempt)
+    throw new Error('Manifest and GitHub artifact identify different runs');
+  return [
+    { id: text(at(manifest, 'run_id')), read: (path: string) => Promise.resolve(read(path)) },
+  ];
+}

--- a/packages/app/src/components/video-benchmark/bundle.ts
+++ b/packages/app/src/components/video-benchmark/bundle.ts
@@ -41,6 +41,7 @@ export async function sha256(blob: Blob): Promise<string> {
 }
 export interface Bundle {
   manifest: Json;
+  result: Json;
   report: Json;
   job: Json;
   ci: Json;
@@ -109,8 +110,17 @@ export async function loadBundle(read: (path: string) => Promise<Blob>): Promise
         throw new Error(`Media identity mismatch: ${role}`);
     }
   }
+  const result = documents.get('result.json') ?? null;
+  if (
+    result &&
+    (at(result, 'schema_version') !== '1.0.0' ||
+      at(result, 'bundle_type') !== 'h3_benchmark_result' ||
+      at(result, 'execution', 'ci', 'run_id') !== at(manifest, 'run_id'))
+  )
+    throw new Error('Unsupported or mismatched H3 result contract');
   return {
     manifest,
+    result,
     report,
     job: documents.get('gpu/gpu-job.json') ?? null,
     ci: documents.get('ci.json') ?? null,

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
       zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
     },
-    sourceSha256: 'ef972983665a3fabb2c6552de0f5e4c31c76d5b967d23db50e76c8e78b7d9cf1',
+    sourceSha256: 'cfe8492e4612a3ad8597b3bce5e57bfc2b8aa4c4ca926fa4699f4640511f868a',
   },
   {
     source: 'src/app/api/unofficial-run/route.ts',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -68,6 +68,17 @@ export const apiRouteCatalog = [
     sourceSha256: '5ea5c034c837fda109ca3b7218db51a6ac78bca3eac545371de0f2a45880d533',
   },
   {
+    source: 'src/app/api/video-runs/route.ts',
+    path: '/api/video-runs',
+    method: 'GET',
+    classification: 'ui-artifact-read',
+    exclusionReason: {
+      en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
+      zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
+    },
+    sourceSha256: 'ef972983665a3fabb2c6552de0f5e4c31c76d5b967d23db50e76c8e78b7d9cf1',
+  },
+  {
     source: 'src/app/api/unofficial-run/route.ts',
     path: '/api/unofficial-run',
     method: 'GET',


### PR DESCRIPTION
## Summary

[Verified production demo](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829) · merged as `a540e790`.

The hidden H3 page now loads GitHub CI runs and their videos automatically, with no folder import. Users can select a run, result artifact and original GPU execution, then share that exact selection by URL.

- Reuse the backend's `result.json` 1.0.0 contract from InferenceX #2894, preserving original execution and exporter provenance and verifying archive checksums.
- Display videos with audio, all recorded configuration/metrics, and separate startup, warmup and generation power windows. Invalid power remains unavailable; complete raw results and reports are downloadable.
- Stream only H3 artifacts from the existing public InferenceX repository using the existing server-side GitHub credential. Keep the existing hidden production flag and bilingual pages. Artifacts remain subject to GitHub expiration; this does not add permanent storage.

## Testing

- Final head `ddd673e6`: all eight Chrome/Firefox E2E shards and all other checks passed; both reviews completed with no remaining findings. Firefox shard 2 passed after rerunning a browser-startup failure.
- Production verification passed: automatic real-result loading, baseline/candidate video and decoded audio, source switching, report playback, downloads, failed-run handling and Chinese mobile layout; no page errors.

- Full workspace unit suite, typecheck, lint, format and typography checks passed.
- Local Cypress smoke: 113 integration tests plus component smoke passed; navigation: 19 passed; new CI-viewer component tests: 4 passed.
- Real CI export [34298416664](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34298416664): automatic loading, both eight-second videos with decoded audio, original-source switching, invalid power, reload/share URL, report playback, result download and Chinese mobile layout passed. Failed run 34287417616 displays without media; no browser page errors.
- Synthetic test inputs are confined to tests. The manual browser check used real downloaded CI output.

## 中文说明

[已验证的生产演示](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829)；合并提交 `a540e790`。最终提交 `ddd673e6` 的八个 Chrome/Firefox E2E 分片及其他检查全部通过，两个审查均无遗留问题。Firefox 分片 2 的浏览器启动失败在重跑后通过。生产环境的自动加载、视频及音频、来源切换、报告播放、下载、失败运行和中文移动端均已验证，无页面错误。

隐藏的 H3 页面现在会自动加载 GitHub CI 运行及其视频，无需导入文件夹。用户可选择运行、结果产物和原始 GPU 执行，并通过 URL 分享当前选择。

复用 InferenceX #2894 的 `result.json` 1.0.0 契约，校验产物，保留原始执行与导出来源；展示带音频的视频、完整配置与指标，以及启动、warmup 和生成阶段的功率。无效功率显示为不可用，并提供原始结果和报告下载。沿用现有服务端 GitHub 凭据、隐藏功能开关和中英文页面。GitHub 产物仍可能过期，本次未增加永久存储。

完整工作区单元测试、类型检查、lint、格式与排版检查通过；本地 Cypress smoke 的 113 项集成测试及组件 smoke、19 项导航测试和 4 项新组件测试通过。使用真实 CI 产物验证了自动加载、双视频及音频播放、来源切换、无效功率、刷新与分享链接、报告播放、结果下载、中文移动端及失败运行状态；无浏览器页面错误。合成数据仅用于测试。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New server route proxies GitHub Actions artifacts with token auth and streaming ZIPs; validation and size caps reduce abuse, but it expands the attack surface for artifact handling and third-party API failures.
> 
> **Overview**
> The hidden **`/video`** experience is now **CI-first**: English and Chinese pages render **`VideoCIRuns`** instead of requiring a manual folder/manifest import. On load it lists filtered H3 workflow runs from GitHub, auto-selects the newest (or URL `run`/`artifact`/`source`), downloads result ZIPs through a new **`GET /api/video-runs`** proxy, and embeds **`VideoBenchmark`** via an injected **`reader`** so the same viewer shows real artifacts. Shareable query params and a collapsible **Local artifact tools** section keep manual loading available.
> 
> The API lists H3-related runs, returns per-run **`h3-results-*` / `h3-video-*`** artifacts only, refuses private repos and mismatched/expired/oversized artifacts, and streams ZIPs with size limits and longer download timeouts. Client-side **`archiveSources`** ( **`fflate`** ) verifies **`SHA256SUMS`**, supports legacy manifests and **`index.json`** exports with original execution IDs, and feeds **`loadBundle`**, which now accepts **`result.json`** 1.0.0. When present, **`ResultPower`** replaces the older telemetry power card with startup/warmup/generation windows and hides invalid measurement values.
> 
> Tests cover the route, archive parsing, Cypress navigation expectations, and new component scenarios (failed runs, racey catalog load, expiration, invalid power).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd673e681a886d27c69f911e1e77725b47b5940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


