### PR TITLE
fix(profit): anchor above-bar labels to the drawn stack on loss bars / 亏损柱上方标签锚定到实际绘制的堆叠顶部

### DIFF
--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -26,6 +26,7 @@ import {
   stackHeadroomPx,
   rowLabel,
   segmentLabelLines,
+  stackTopValue,
 } from './ProfitEstimatorChart';
 
 function row(overrides: Partial<ProfitEstimatorRow> = {}): ProfitEstimatorRow {
@@ -88,6 +89,25 @@ describe('barMarkHeight', () => {
     expect(stackHeadroomPx(BAR_ICON_MAX_HEIGHT) - STACK_HEADROOM_PX).toBe(
       BAR_ICON_MAX_HEIGHT - BAR_ICON_MIN_HEIGHT,
     );
+  });
+});
+
+describe('stackTopValue', () => {
+  it('is revenue for a profitable bar, whose stack ends at revenue', () => {
+    expect(stackTopValue(row())).toBe(1000);
+  });
+
+  it('is TCO plus the license fee for a loss bar, so above-bar labels clear the drawn stack', () => {
+    // Kimi K3 per-GW case: $4.4B revenue against $9.5B TCO and a $1.3B license
+    // fee. Anchoring the revenue figure to max(revenue, tco) put it inside the
+    // license-fee segment, on top of that segment's own label.
+    const loss = row({ revenue: 4.4, tco: 9.5, grossMargin: -5.1, labCut: 1.3, profit: -6.4 });
+    expect(stackTopValue(loss)).toBeCloseTo(10.8);
+    expect(stackTopValue(loss)).toBeGreaterThan(Math.max(loss.revenue, loss.tco));
+  });
+
+  it('is TCO for a loss bar with no license fee', () => {
+    expect(stackTopValue(row({ revenue: 300, tco: 400, labCut: 0, profit: -100 }))).toBe(400);
   });
 });
 

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -373,6 +373,16 @@ export function buildProfitSegments(rows: readonly ProfitEstimatorRow[]): Profit
 }
 
 /**
+ * Top of a bar's positive stack in data units. A profitable bar tops out at
+ * revenue (TCO + license fee + profit); a loss bar still draws TCO and the
+ * license fee above the axis, and that sum exceeds revenue, so the labels
+ * above the bar must clear it rather than the revenue figure.
+ */
+export function stackTopValue(row: ProfitEstimatorRow): number {
+  return Math.max(row.revenue, row.tco + row.labCut);
+}
+
+/**
  * Pixels the tallest stack needs above it: the revenue figure and margin line
  * (REVENUE_LABEL_GAP covers both), then a vendor mark `iconHeightPx` tall and its gap.
  */
@@ -396,7 +406,7 @@ export function profitYDomain(
   if (rows.length === 0) return [0, 1];
   // A loss bar stacks TCO and the license fee above the axis, and that sum can
   // exceed both revenue and TCO, so size the top to the tallest positive stack.
-  const top = Math.max(0, ...rows.map((row) => Math.max(row.revenue, row.tco + row.labCut)));
+  const top = Math.max(0, ...rows.map(stackTopValue));
   const bottom = Math.min(0, ...rows.map((row) => row.profit));
   const span = top - bottom;
   const headroom =
@@ -674,7 +684,10 @@ export default function ProfitEstimatorChart({
         // sits below the bar when the stack dips under zero. The vendor's
         // full-color mark sits above the revenue figure.
         const labelData = segments.filter((d) => d.kind === 'tco');
-        const stackTopPx = (d: ProfitSegment) => yScale(Math.max(d.row.revenue, d.row.tco));
+        // Anchor to the drawn stack, not `max(revenue, tco)`: a loss bar's
+        // license-fee segment sits above both, and the revenue figure and
+        // margin line used to land inside it, on top of its in-bar label.
+        const stackTopPx = (d: ProfitSegment) => yScale(stackTopValue(d.row));
         const revenueBaselineY = (d: ProfitSegment) => stackTopPx(d) - REVENUE_LABEL_GAP;
         // Same size the y domain reserved headroom for (both derive from the band width).
         const iconHeight = barMarkHeight(bandwidth);


### PR DESCRIPTION
## Summary

Fixes the label pile-up Afzal flagged on the Kimi K3 per-GW profit chart (#gta6-research-inference): the revenue total `$4.4B`, the `-145.6% margin` line, and the in-bar `Model License Fee $1.3B` label were all drawn on top of each other.

**Root cause.** The revenue figure and margin line above each bar were anchored to `max(revenue, tco)`. A loss bar still draws TCO plus the license fee above the zero line, and that sum exceeds both revenue and TCO, so the anchor landed inside the license-fee segment. `profitYDomain` already sized the y headroom to `tco + labCut`; the label anchor did not.

**Fix.** New pure helper `stackTopValue(row) = max(revenue, tco + labCut)` in `ProfitEstimatorChart.tsx`, shared by `profitYDomain` and the above-bar label anchor (`stackTopPx`), so the revenue figure, margin line, and vendor mark always clear whatever is drawn. Profitable bars are unchanged: their stack already ends at revenue.

**Tests.** `stackTopValue` unit tests covering the profitable case, the Kimi K3 loss case (revenue 4.4 / TCO 9.5 / license fee 1.3 → 10.8), and a loss bar with no license fee. Lint, format, typecheck, and the 43 tests in `ProfitEstimatorChart.test.ts` pass locally.

**Before**: the screenshot in the Slack thread (production, 2026-09-08) shows the revenue and margin text inside the license-fee segment.

## 中文说明

修复 Afzal 在 #gta6-research-inference 指出的 Kimi K3 每 GW 利润图表标签重叠问题：收入总额 `$4.4B`、`-145.6% margin` 行以及柱内的「Model License Fee $1.3B」标签叠在一起。

**原因。** 柱上方的收入数字与利润率行锚定在 `max(revenue, tco)`。亏损柱在零轴上方仍绘制 TCO 加模型许可费，其和高于收入与 TCO，因此锚点落进了许可费分段内部。`profitYDomain` 早已按 `tco + labCut` 预留 y 轴顶部空间，但标签锚点没有同步。

**修复。** 在 `ProfitEstimatorChart.tsx` 中新增纯函数 `stackTopValue(row) = max(revenue, tco + labCut)`，由 `profitYDomain` 与柱上方标签锚点（`stackTopPx`）共用，确保收入数字、利润率行与厂商标识始终位于实际绘制的堆叠之上。盈利柱的堆叠顶部本就是收入，行为不变。

**测试。** 为 `stackTopValue` 新增单元测试，覆盖盈利情形、Kimi K3 亏损情形（收入 4.4 / TCO 9.5 / 许可费 1.3 → 10.8）以及无许可费的亏损柱。本地 lint、format、typecheck 与 `ProfitEstimatorChart.test.ts` 的 43 个测试全部通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chart layout/label positioning only in ProfitEstimatorChart; logic is extracted and covered by new unit tests with no API or data-path changes.
> 
> **Overview**
> Fixes overlapping above-bar labels on **loss** bars in the profit estimator chart (revenue total, margin %, and vendor mark were drawn inside the license-fee segment).
> 
> Introduces **`stackTopValue(row)`** as `max(revenue, tco + labCut)` so anchoring matches the drawn stack (TCO + license fee above zero can exceed revenue). **`profitYDomain`** and **`stackTopPx`** (revenue, margin, vendor mark) now both use this helper instead of `max(revenue, tco)` for label placement.
> 
> Adds **`stackTopValue`** unit tests for profitable bars, the Kimi K3–style loss case, and loss without a license fee.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e1fd9dcb0e8c83f30940301fcf6a3d0439a4904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
