### PR TITLE
fix(charts): keep line-label pills inside the plot

### DIFF
--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -60,9 +60,87 @@ export function horizontalShiftIntoBounds(rect: RectBounds, bounds: RectBounds):
   return 0;
 }
 
+/**
+ * Vertical shift that slides `rect` fully inside `bounds`, or `null` when it
+ * is taller than the bounds and cannot fit at any offset. Zero when it already
+ * fits; positive moves down, negative moves up.
+ */
+export function verticalShiftIntoBounds(rect: RectBounds, bounds: RectBounds): number | null {
+  if (rect.bottom - rect.top > bounds.bottom - bounds.top) return null;
+  if (rect.top < bounds.top) return bounds.top - rect.top;
+  if (rect.bottom > bounds.bottom) return bounds.bottom - rect.bottom;
+  return 0;
+}
+
 /** Whether `rect` lies fully inside `bounds` on the vertical axis. */
 export function fitsVertically(rect: RectBounds, bounds: RectBounds): boolean {
   return rect.top >= bounds.top && rect.bottom <= bounds.bottom;
+}
+
+/**
+ * Translation that keeps a line-label pill fully inside the plot.
+ *
+ * `rect` is the pill's background box in zoom-group coordinates, i.e. its
+ * group translate plus the `.ll-bg` offset. A pill that would spill past an
+ * edge slides back until it touches that edge; a pill larger than the plot on
+ * an axis (a very narrow or very short chart) is pinned to the plot's top-left
+ * on that axis so its start stays readable rather than being clipped at an
+ * arbitrary point.
+ */
+export function pillShiftIntoBounds(rect: RectBounds, bounds: RectBounds): CartesianPoint {
+  return {
+    x: horizontalShiftIntoBounds(rect, bounds) ?? bounds.left - rect.left,
+    y: verticalShiftIntoBounds(rect, bounds) ?? bounds.top - rect.top,
+  };
+}
+
+/**
+ * The `.ll-bg` box of a rendered pill, in the pill group's own coordinates, or
+ * `null` before the sizing pass has run (or when the rect is degenerate).
+ */
+function pillLocalBox(node: SVGGElement): RectBounds | null {
+  const background = node.querySelector<SVGRectElement>('.ll-bg');
+  if (!background) return null;
+  const x = Number(background.getAttribute('x'));
+  const y = Number(background.getAttribute('y'));
+  const width = Number(background.getAttribute('width'));
+  const height = Number(background.getAttribute('height'));
+  if (![x, y, width, height].every((value) => Number.isFinite(value))) return null;
+  if (!(width > 0) || !(height > 0)) return null;
+  return { left: x, top: y, right: x + width, bottom: y + height };
+}
+
+/**
+ * `translate(...)` for a pill anchored at (`x`, `y`) with the given offsets,
+ * shifted so the pill's `.ll-bg` box (if already sized) stays inside `bounds`.
+ * With no bounds — a chart that clips nothing — the anchor offset is used as
+ * is.
+ */
+function pillTransform(
+  node: SVGGElement,
+  x: number,
+  y: number,
+  offsetX: number,
+  offsetY: number,
+  bounds: RectBounds | null,
+): string {
+  let tx = x + offsetX;
+  let ty = y + offsetY;
+  const local = bounds ? pillLocalBox(node) : null;
+  if (bounds && local) {
+    const shift = pillShiftIntoBounds(
+      {
+        left: tx + local.left,
+        right: tx + local.right,
+        top: ty + local.top,
+        bottom: ty + local.bottom,
+      },
+      bounds,
+    );
+    tx += shift.x;
+    ty += shift.y;
+  }
+  return `translate(${tx},${ty})`;
 }
 
 /**
@@ -295,11 +373,18 @@ export function renderLineLabels(
       labelGroup: d3.Selection<SVGGElement, LineLabelPlacement, null, undefined>,
       label: LineLabelPlacement,
     ) => void;
+    /**
+     * Strict bounding box, in zoom-group coordinates, every pill must lie
+     * fully inside. Defaults to the plot's clip rect ({@link plotAreaBounds});
+     * pass `null` to skip the constraint (charts that clip nothing).
+     */
+    bounds?: RectBounds | null;
   },
 ): void {
   const opacity = options.opacity ?? 1;
   const offsetX = options.offsetX ?? 8;
   const offsetY = options.offsetY ?? -14;
+  const bounds = options.bounds === undefined ? plotAreaBounds(group) : options.bounds;
   const selection = group
     .selectAll<SVGGElement, LineLabelPlacement>('.line-label')
     .data(labels, (label) => label.key)
@@ -372,18 +457,31 @@ export function renderLineLabels(
       .attr('y', (d) => bbox.y + bbox.height / 2 - d.height / 2)
       .attr('width', (d) => d.width)
       .attr('height', (d) => d.height);
+
+    // Now that the pill has its final size, slide it back inside the plot if
+    // the anchor offset pushed any part of it past an edge — a label anchored
+    // on the last point of a line otherwise pokes out past the right edge and
+    // the clip path slices the run name in half.
+    labelGroup.attr('transform', pillTransform(node, label.x, label.y, offsetX, offsetY, bounds));
   }
 }
 
 export function updateRenderedLineLabels(
   group: d3.Selection<SVGGElement, unknown, null, undefined>,
   labels: readonly LineLabelPlacement[],
-  options: { opacity?: number; offsetX?: number; offsetY?: number } = {},
+  options: {
+    opacity?: number;
+    offsetX?: number;
+    offsetY?: number;
+    /** See {@link renderLineLabels}. */
+    bounds?: RectBounds | null;
+  } = {},
 ): void {
   const byKey = new Map(labels.map((label) => [label.key, label]));
   const opacity = options.opacity ?? 1;
   const offsetX = options.offsetX ?? 8;
   const offsetY = options.offsetY ?? -14;
+  const bounds = options.bounds === undefined ? plotAreaBounds(group) : options.bounds;
   group.selectAll<SVGGElement, unknown>('.line-label').each(function () {
     const element = d3.select(this);
     const label = byKey.get(element.attr('data-line-key'));
@@ -391,8 +489,10 @@ export function updateRenderedLineLabels(
       element.style('opacity', 0);
       return;
     }
+    // The pill keeps the size it was given on render, so the zoom pass only
+    // needs to move it — and keep it inside the plot while doing so.
     element
-      .attr('transform', `translate(${label.x + offsetX},${label.y + offsetY})`)
+      .attr('transform', pillTransform(this, label.x, label.y, offsetX, offsetY, bounds))
       .style('opacity', label.visible ? opacity : 0);
   });
 }

--- a/packages/app/src/components/inference/ui/line-label-layer.ts
+++ b/packages/app/src/components/inference/ui/line-label-layer.ts
@@ -38,6 +38,11 @@ export function rectsOverlap(a: RectBounds, b: RectBounds): boolean {
   return !(a.right < b.left || a.left > b.right || a.bottom < b.top || a.top > b.bottom);
 }
 
+/** Like {@link rectsOverlap}, but rectangles that only share an edge do not count. */
+export function rectsStrictlyOverlap(a: RectBounds, b: RectBounds): boolean {
+  return a.right > b.left && a.left < b.right && a.bottom > b.top && a.top < b.bottom;
+}
+
 export function firstNonCollidingRect(
   candidates: readonly RectBounds[],
   placed: readonly RectBounds[],
@@ -110,37 +115,90 @@ function pillLocalBox(node: SVGGElement): RectBounds | null {
   return { left: x, top: y, right: x + width, bottom: y + height };
 }
 
+/** A pill's local `.ll-bg` box moved to the group translate (`tx`, `ty`). */
+function pillBoxAt(local: RectBounds, tx: number, ty: number): RectBounds {
+  return {
+    left: tx + local.left,
+    right: tx + local.right,
+    top: ty + local.top,
+    bottom: ty + local.bottom,
+  };
+}
+
+/** A pill group together with the placement that anchors it this frame. */
+interface PillLayoutItem {
+  node: SVGGElement;
+  label: LineLabelPlacement;
+}
+
 /**
- * `translate(...)` for a pill anchored at (`x`, `y`) with the given offsets,
- * shifted so the pill's `.ll-bg` box (if already sized) stays inside `bounds`.
- * With no bounds — a chart that clips nothing — the anchor offset is used as
- * is.
+ * Position every pill in `items`: anchor offset first, slid back inside
+ * `bounds`, then checked against the pills already placed this frame.
+ *
+ * `placeLineLabels` only knows anchor points and a nominal collision width,
+ * so two pills that cleared its check can still end up on top of each other
+ * once one of them is clamped to an edge (the default upward offset makes the
+ * top edge the usual culprit: a pill slid down lands on the neighbour just
+ * below it). Each pill therefore tries, in order: its default spot, the
+ * mirror image below/above its anchor, the mirror image on the other side of
+ * its anchor, and both mirrors together. Every candidate is clamped into
+ * `bounds` before the overlap test, so nothing leaves the plot. When every
+ * candidate collides the default spot is kept: an overlapped label is still
+ * better than a missing one, and the fallback matches what the anchor pass
+ * already tolerates for pinned anchors.
+ *
+ * With no bounds — a chart that clips nothing — the anchor offset is applied
+ * unchanged and the collision pass is skipped, preserving that chart's
+ * existing layout.
+ *
+ * Hidden pills get their default transform and occupy no space, so a label
+ * that later becomes visible reappears where the anchor pass put it.
  */
-function pillTransform(
-  node: SVGGElement,
-  x: number,
-  y: number,
+function layoutPills(
+  items: readonly PillLayoutItem[],
   offsetX: number,
   offsetY: number,
   bounds: RectBounds | null,
-): string {
-  let tx = x + offsetX;
-  let ty = y + offsetY;
-  const local = bounds ? pillLocalBox(node) : null;
-  if (bounds && local) {
-    const shift = pillShiftIntoBounds(
-      {
-        left: tx + local.left,
-        right: tx + local.right,
-        top: ty + local.top,
-        bottom: ty + local.bottom,
-      },
-      bounds,
-    );
-    tx += shift.x;
-    ty += shift.y;
+  obstacles: readonly RectBounds[],
+): void {
+  const placed: RectBounds[] = [...obstacles];
+
+  for (const { node, label } of items) {
+    const tx0 = label.x + offsetX;
+    const ty0 = label.y + offsetY;
+    const local = bounds ? pillLocalBox(node) : null;
+    if (!bounds || !local || !label.visible) {
+      node.setAttribute('transform', `translate(${tx0},${ty0})`);
+      continue;
+    }
+
+    // Mirror the pill's box across the anchor on each axis: the pill's far
+    // edge ends up as close to the anchor as its near edge was.
+    const mirrorX = 2 * label.x - tx0 - local.left - local.right;
+    const mirrorY = 2 * label.y - ty0 - local.top - local.bottom;
+    const candidates: [number, number][] = [
+      [tx0, ty0],
+      [tx0, mirrorY],
+      [mirrorX, ty0],
+      [mirrorX, mirrorY],
+    ];
+
+    const clamped = candidates.map(([cx, cy]) => {
+      const shift = pillShiftIntoBounds(pillBoxAt(local, cx, cy), bounds);
+      const tx = cx + shift.x;
+      const ty = cy + shift.y;
+      return { tx, ty, box: pillBoxAt(local, tx, ty) };
+    });
+    // Pills that merely share an edge are fine: the anchor pass spaces rows
+    // exactly one collision height apart, so touching is its normal output.
+    const chosen =
+      clamped.find(
+        (candidate) => !placed.some((other) => rectsStrictlyOverlap(candidate.box, other)),
+      ) ?? clamped[0];
+
+    node.setAttribute('transform', `translate(${chosen.tx},${chosen.ty})`);
+    placed.push(chosen.box);
   }
-  return `translate(${tx},${ty})`;
 }
 
 /**
@@ -202,9 +260,10 @@ export function parallelismLabelBoxes(root: SVGGElement | null): PlacedBox[] {
  */
 function pillObstacles(
   zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  selector = '.line-label, .parallelism-label',
 ): RectBounds[] {
   const boxes: RectBounds[] = [];
-  zoomGroup.selectAll<SVGGElement, unknown>('.line-label, .parallelism-label').each(function () {
+  zoomGroup.selectAll<SVGGElement, unknown>(selector).each(function () {
     // A hidden pill is still in the DOM but covers nothing.
     if (this.style.opacity === '0') return;
     const match = /translate\((?<tx>[^,]+),(?<ty>[^)]+)\)/u.exec(
@@ -457,13 +516,20 @@ export function renderLineLabels(
       .attr('y', (d) => bbox.y + bbox.height / 2 - d.height / 2)
       .attr('width', (d) => d.width)
       .attr('height', (d) => d.height);
-
-    // Now that the pill has its final size, slide it back inside the plot if
-    // the anchor offset pushed any part of it past an edge — a label anchored
-    // on the last point of a line otherwise pokes out past the right edge and
-    // the clip path slices the run name in half.
-    labelGroup.attr('transform', pillTransform(node, label.x, label.y, offsetX, offsetY, bounds));
   }
+
+  // Now that every pill has its final size, slide each back inside the plot
+  // if the anchor offset pushed any part of it past an edge — a label anchored
+  // on the last point of a line otherwise pokes out past the right edge and
+  // the clip path slices the run name in half — and keep the shifted pills
+  // off one another and off the parallelism chips.
+  layoutPills(
+    measured.map(({ node, label }) => ({ node, label })),
+    offsetX,
+    offsetY,
+    bounds,
+    bounds ? pillObstacles(group, '.parallelism-label') : [],
+  );
 }
 
 export function updateRenderedLineLabels(
@@ -482,6 +548,7 @@ export function updateRenderedLineLabels(
   const offsetX = options.offsetX ?? 8;
   const offsetY = options.offsetY ?? -14;
   const bounds = options.bounds === undefined ? plotAreaBounds(group) : options.bounds;
+  const items: PillLayoutItem[] = [];
   group.selectAll<SVGGElement, unknown>('.line-label').each(function () {
     const element = d3.select(this);
     const label = byKey.get(element.attr('data-line-key'));
@@ -489,12 +556,22 @@ export function updateRenderedLineLabels(
       element.style('opacity', 0);
       return;
     }
-    // The pill keeps the size it was given on render, so the zoom pass only
-    // needs to move it — and keep it inside the plot while doing so.
-    element
-      .attr('transform', pillTransform(this, label.x, label.y, offsetX, offsetY, bounds))
-      .style('opacity', label.visible ? opacity : 0);
+    element.style('opacity', label.visible ? opacity : 0);
+    items.push({ node: this, label });
   });
+  // The pills keep the size they were given on render, so the zoom pass only
+  // needs to move them — inside the plot and off one another, as on render.
+  // Lay them out in the placement order the anchor pass produced (top-most
+  // series first), not DOM order, so both passes resolve ties the same way.
+  const order = new Map(labels.map((label, index) => [label.key, index]));
+  items.sort((a, b) => (order.get(a.label.key) ?? 0) - (order.get(b.label.key) ?? 0));
+  layoutPills(
+    items,
+    offsetX,
+    offsetY,
+    bounds,
+    bounds ? pillObstacles(group, '.parallelism-label') : [],
+  );
 }
 
 /**

--- a/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
@@ -4,10 +4,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   pillShiftIntoBounds,
+  rectsStrictlyOverlap,
   renderLineLabels,
   updateRenderedLineLabels,
   verticalShiftIntoBounds,
   type LineLabelPlacement,
+  type RectBounds,
 } from './line-label-layer';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -77,6 +79,30 @@ function pillBox(zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
   return { left: tx + x, top: ty + y, right: tx + x + width, bottom: ty + y + height, tx, ty };
 }
 
+const overlaps = (a: RectBounds, b: RectBounds) => rectsStrictlyOverlap(a, b);
+
+/** Add a parallelism chip the way the roofline layer draws one, centred on (x, y). */
+function addParallelismChip(
+  zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>,
+  x: number,
+  y: number,
+  width = 40,
+  height = 16,
+) {
+  const chip = zoomGroup
+    .append('g')
+    .attr('class', 'parallelism-label')
+    .attr('transform', `translate(${x},${y})`);
+  chip
+    .append('rect')
+    .attr('class', 'pl-bg')
+    .attr('x', -width / 2)
+    .attr('y', -height / 2)
+    .attr('width', width)
+    .attr('height', height);
+  return { left: x - width / 2, right: x + width / 2, top: y - height / 2, bottom: y + height / 2 };
+}
+
 const expectInsidePlot = (box: ReturnType<typeof pillBox>) => {
   expect(box.left).toBeGreaterThanOrEqual(0);
   expect(box.top).toBeGreaterThanOrEqual(0);
@@ -130,6 +156,105 @@ describe('pill bounding box primitives', () => {
       x: -20,
       y: 0,
     });
+  });
+
+  it('does not count a shared edge as an overlap', () => {
+    const upper = { left: 0, right: 80, top: 0, bottom: 18 };
+    expect(rectsStrictlyOverlap(upper, { left: 0, right: 80, top: 18, bottom: 36 })).toBe(false);
+    expect(rectsStrictlyOverlap(upper, { left: 0, right: 80, top: 17, bottom: 35 })).toBe(true);
+  });
+});
+
+describe('clamped pills do not stack on their neighbours', () => {
+  it('flips a pill below its anchor when the neighbour above was slid down onto it', () => {
+    // Bugbot's case: `placeLineLabels` cleared these two anchors (they are
+    // 26px apart, more than one collision height), but the top pill has to
+    // slide 19px down to stay in the plot, which puts it on the second one.
+    const { zoomGroup } = renderChart();
+    renderLineLabels(
+      zoomGroup,
+      [placement('top', 200, 4, 'GB200 (Dynamo)'), placement('next', 210, 30, 'B300 (vLLM)')],
+      { seriesAttribute: 'data-hw-key' },
+    );
+
+    const top = pillBox(zoomGroup, 'top');
+    const next = pillBox(zoomGroup, 'next');
+    expect(top.top).toBe(0);
+    expect(overlaps(top, next)).toBe(false);
+    // The second pill kept its x and moved to the mirror slot below its anchor.
+    expect(next.tx).toBe(218);
+    expect(next.top).toBeGreaterThan(30);
+    expectInsidePlot(top);
+    expectInsidePlot(next);
+  });
+
+  it('moves a pill to the other side of its anchor when the row above and below are taken', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(
+      zoomGroup,
+      [
+        placement('a', 300, 4, 'GB200 (Dynamo)'),
+        placement('b', 310, 30, 'B300 (vLLM)'),
+        placement('c', 320, 56, 'MI355X (SGLang)'),
+      ],
+      { seriesAttribute: 'data-hw-key' },
+    );
+
+    const boxes = ['a', 'b', 'c'].map((key) => pillBox(zoomGroup, key));
+    for (const box of boxes) expectInsidePlot(box);
+    expect(overlaps(boxes[0], boxes[1])).toBe(false);
+    expect(overlaps(boxes[1], boxes[2])).toBe(false);
+    expect(overlaps(boxes[0], boxes[2])).toBe(false);
+  });
+
+  it('keeps pills off a parallelism chip that the clamp would slide them onto', () => {
+    const { zoomGroup } = renderChart();
+    const chip = addParallelismChip(zoomGroup, 240, 12);
+    renderLineLabels(zoomGroup, [placement('top', 200, 4, 'GB200 (Dynamo)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+
+    const top = pillBox(zoomGroup, 'top');
+    expect(overlaps(top, chip)).toBe(false);
+    expectInsidePlot(top);
+  });
+
+  it('resolves the same stacking on the zoom path', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(
+      zoomGroup,
+      [placement('top', 200, 150, 'GB200 (Dynamo)'), placement('next', 210, 176, 'B300 (vLLM)')],
+      { seriesAttribute: 'data-hw-key' },
+    );
+    // Zoom drags both anchors to the top edge.
+    updateRenderedLineLabels(zoomGroup, [
+      placement('top', 200, 4, 'GB200 (Dynamo)'),
+      placement('next', 210, 30, 'B300 (vLLM)'),
+    ]);
+
+    const top = pillBox(zoomGroup, 'top');
+    const next = pillBox(zoomGroup, 'next');
+    expect(top.top).toBe(0);
+    expect(overlaps(top, next)).toBe(false);
+    expectInsidePlot(top);
+    expectInsidePlot(next);
+  });
+
+  it('leaves a hidden pill out of the collision pass', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(
+      zoomGroup,
+      [
+        placement('top', 200, 4, 'GB200 (Dynamo)', false),
+        placement('next', 210, 30, 'B300 (vLLM)'),
+      ],
+      { seriesAttribute: 'data-hw-key' },
+    );
+
+    // Nothing visible sits above it, so the second pill keeps its default slot.
+    const next = pillBox(zoomGroup, 'next');
+    expect(next.tx).toBe(218);
+    expect(next.ty).toBe(16);
   });
 });
 

--- a/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
+++ b/packages/app/src/components/inference/ui/line-label-pill-bounds.test.ts
@@ -1,0 +1,221 @@
+// @vitest-environment jsdom
+import * as d3 from 'd3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  pillShiftIntoBounds,
+  renderLineLabels,
+  updateRenderedLineLabels,
+  verticalShiftIntoBounds,
+  type LineLabelPlacement,
+} from './line-label-layer';
+
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const PLOT = { width: 400, height: 300 };
+const CLIP_ID = 'clip-test-chart';
+
+/** Stubbed text metrics: 6px per character, 12px tall, centred on the baseline. */
+const CHAR_WIDTH = 6;
+const TEXT_HEIGHT = 12;
+
+/**
+ * A chart skeleton shaped like `setupChartStructure` builds it: a clipPath
+ * in <defs> sized to the plot and a `.zoom-group` that references it.
+ */
+function renderChart(clip = true) {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  const defs = document.createElementNS(SVG_NS, 'defs');
+  svg.append(defs);
+  if (clip) {
+    const clipPath = document.createElementNS(SVG_NS, 'clipPath');
+    clipPath.setAttribute('id', CLIP_ID);
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('width', String(PLOT.width));
+    rect.setAttribute('height', String(PLOT.height));
+    clipPath.append(rect);
+    defs.append(clipPath);
+  }
+  const root = document.createElementNS(SVG_NS, 'g');
+  root.setAttribute('class', 'chart-root');
+  svg.append(root);
+  const zoomGroupEl = document.createElementNS(SVG_NS, 'g');
+  zoomGroupEl.setAttribute('class', 'zoom-group');
+  if (clip) zoomGroupEl.setAttribute('clip-path', `url(#${CLIP_ID})`);
+  root.append(zoomGroupEl);
+  return { svg, zoomGroup: d3.select(zoomGroupEl) };
+}
+
+const placement = (
+  key: string,
+  x: number,
+  y: number,
+  label = key,
+  visible = true,
+): LineLabelPlacement => ({
+  key,
+  seriesId: key,
+  label,
+  color: '#0f0',
+  x,
+  y,
+  visible,
+});
+
+/** The pill's `.ll-bg` box in zoom-group coordinates, as the clip path sees it. */
+function pillBox(zoomGroup: d3.Selection<SVGGElement, unknown, null, undefined>, key: string) {
+  const node = zoomGroup.select<SVGGElement>(`.line-label[data-line-key="${key}"]`).node()!;
+  const match = /translate\((?<tx>[^,]+),(?<ty>[^)]+)\)/u.exec(
+    node.getAttribute('transform') ?? '',
+  );
+  const tx = Number(match!.groups!.tx);
+  const ty = Number(match!.groups!.ty);
+  const bg = node.querySelector('.ll-bg')!;
+  const x = Number(bg.getAttribute('x'));
+  const y = Number(bg.getAttribute('y'));
+  const width = Number(bg.getAttribute('width'));
+  const height = Number(bg.getAttribute('height'));
+  return { left: tx + x, top: ty + y, right: tx + x + width, bottom: ty + y + height, tx, ty };
+}
+
+const expectInsidePlot = (box: ReturnType<typeof pillBox>) => {
+  expect(box.left).toBeGreaterThanOrEqual(0);
+  expect(box.top).toBeGreaterThanOrEqual(0);
+  expect(box.right).toBeLessThanOrEqual(PLOT.width);
+  expect(box.bottom).toBeLessThanOrEqual(PLOT.height);
+};
+
+// jsdom has no layout engine; give every text a deterministic box derived
+// from its content so the pill width tracks the label the way it does in a
+// browser.
+let originalGetBBox: PropertyDescriptor | undefined;
+beforeEach(() => {
+  originalGetBBox = Object.getOwnPropertyDescriptor(SVGElement.prototype, 'getBBox');
+  Object.defineProperty(SVGElement.prototype, 'getBBox', {
+    configurable: true,
+    value(this: SVGElement) {
+      const x = Number(this.getAttribute('x') ?? 0);
+      const width = (this.textContent ?? '').length * CHAR_WIDTH;
+      return new DOMRect(x, -TEXT_HEIGHT / 2, width, TEXT_HEIGHT);
+    },
+  });
+});
+afterEach(() => {
+  if (originalGetBBox) Object.defineProperty(SVGElement.prototype, 'getBBox', originalGetBBox);
+  else delete (SVGElement.prototype as { getBBox?: unknown }).getBBox;
+});
+
+describe('pill bounding box primitives', () => {
+  const bounds = { left: 0, top: 0, right: 400, bottom: 300 };
+
+  it('needs no vertical shift when the rect already sits inside the plot', () => {
+    expect(verticalShiftIntoBounds({ left: 0, right: 10, top: 40, bottom: 60 }, bounds)).toBe(0);
+  });
+
+  it('slides a rect that spills past the top edge back down', () => {
+    expect(verticalShiftIntoBounds({ left: 0, right: 10, top: -8, bottom: 12 }, bounds)).toBe(8);
+  });
+
+  it('slides a rect that spills past the bottom edge back up', () => {
+    expect(verticalShiftIntoBounds({ left: 0, right: 10, top: 290, bottom: 310 }, bounds)).toBe(
+      -10,
+    );
+  });
+
+  it('gives up on a rect taller than the plot', () => {
+    expect(verticalShiftIntoBounds({ left: 0, right: 10, top: 0, bottom: 301 }, bounds)).toBeNull();
+  });
+
+  it('pins an oversized pill to the plot origin instead of leaving it half clipped', () => {
+    expect(pillShiftIntoBounds({ left: 20, right: 520, top: 30, bottom: 50 }, bounds)).toEqual({
+      x: -20,
+      y: 0,
+    });
+  });
+});
+
+describe('line-label pills stay inside the plot bounding box', () => {
+  it('leaves a pill with room at its anchor offset', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('mi355x', 200, 150, 'MI355X (SGLang)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+
+    const box = pillBox(zoomGroup, 'mi355x');
+    expect(box.tx).toBe(208);
+    expect(box.ty).toBe(136);
+    expectInsidePlot(box);
+  });
+
+  it('slides a pill anchored on the last point of a line back from the right edge', () => {
+    // The regression: a run whose label landed on its final point was drawn
+    // with the pill's right half past the plot, where the clip path cut it to
+    // "B300 (v".
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('b300', 390, 150, 'B300 (vLLM)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+
+    const box = pillBox(zoomGroup, 'b300');
+    expect(box.right).toBe(PLOT.width);
+    expect(box.tx).toBeLessThan(398);
+    expectInsidePlot(box);
+  });
+
+  it('slides a pill anchored near the top of the plot back down', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('gb200', 200, 4, 'GB200 (Dynamo)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+
+    const box = pillBox(zoomGroup, 'gb200');
+    expect(box.top).toBe(0);
+    expectInsidePlot(box);
+  });
+
+  it('accounts for the vendor icon chip when sizing the pill against the edge', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('b300', 390, 150, 'B300 (vLLM)')], {
+      seriesAttribute: 'data-hw-key',
+      iconFor: () => ({ href: 'nvidia.svg', width: 14, height: 10 }),
+    });
+
+    const box = pillBox(zoomGroup, 'b300');
+    expect(box.right).toBe(PLOT.width);
+    expectInsidePlot(box);
+  });
+
+  it('keeps a pill inside the plot while a zoom drags its anchor past the edge', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('b300', 200, 150, 'B300 (vLLM)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+    // A zoomed-in scale can push the anchor itself past the plot edge.
+    updateRenderedLineLabels(zoomGroup, [placement('b300', 395, 310, 'B300 (vLLM)')]);
+
+    const box = pillBox(zoomGroup, 'b300');
+    expect(box.right).toBe(PLOT.width);
+    expect(box.bottom).toBe(PLOT.height);
+    expectInsidePlot(box);
+  });
+
+  it('uses the anchor offset unchanged when the chart clips nothing', () => {
+    const { zoomGroup } = renderChart(false);
+    renderLineLabels(zoomGroup, [placement('b300', 390, 150, 'B300 (vLLM)')], {
+      seriesAttribute: 'data-hw-key',
+    });
+
+    const box = pillBox(zoomGroup, 'b300');
+    expect(box.tx).toBe(398);
+    expect(box.ty).toBe(136);
+  });
+
+  it('honours an explicit bounds override', () => {
+    const { zoomGroup } = renderChart();
+    renderLineLabels(zoomGroup, [placement('b300', 190, 150, 'B300 (vLLM)')], {
+      seriesAttribute: 'data-hw-key',
+      bounds: { left: 0, top: 0, right: 200, bottom: 300 },
+    });
+
+    expect(pillBox(zoomGroup, 'b300').right).toBe(200);
+  });
+});


### PR DESCRIPTION
## Problem

Run-name pills on the scatter and compare charts are placed at a fixed offset (+8, -14) from their anchor point and never checked against the plot area. When the anchor lands on the last point of a line, the pill runs past the right edge and the zoom group's clip path slices it, so a "B300 (vLLM)" label renders as "B300 (v" (see the screenshot in the Slack thread that prompted this).

Point labels already avoid this (`placePointLabels` slides them back inside `plotAreaBounds`), so line labels were the one label type still allowed to leave the plot.

## Fix

`packages/app/src/components/inference/ui/line-label-layer.ts`

- `renderLineLabels`: after the `.ll-bg` rect is sized from the measured text (icon chip included), shift the group so the whole pill lies inside the plot's clip rect. A pill that spills past an edge now hugs that edge.
- `updateRenderedLineLabels`: apply the same shift on every zoom frame, reading the pill size the render pass left on `.ll-bg`, so a zoom cannot drag a pill out either.
- Both take a `bounds` option that defaults to `plotAreaBounds(zoomGroup)`; charts that clip nothing (`clipContent: false`) resolve to `null` and keep the plain anchor offset.
- New pure helpers `verticalShiftIntoBounds` and `pillShiftIntoBounds` alongside the existing `horizontalShiftIntoBounds`. A pill wider or taller than the plot is pinned to the plot's left/top so its start stays readable.

`parallelismLabelBoxes` and `pillObstacles` read the pill transform from the DOM, so point-label collision avoidance sees the shifted position automatically.

### Follow-up (Bugbot): clamped pills stay off their neighbours

The anchor pass only knows anchor points and a nominal collision width, so a pill clamped into the plot could land on a neighbour that had cleared that check (a pill slid down from the top edge onto the one below it). Both render and zoom passes now lay pills out through one `layoutPills` routine: each pill tries its default spot, then the mirror slot below/above its anchor, then the other side of the anchor, then both. Every candidate is clamped into the plot before a strict overlap test (`rectsStrictlyOverlap`, shared edges allowed) against the pills already placed and the parallelism chips. If every candidate collides the default spot is kept, which is what the anchor pass already tolerates for pinned anchors. Hidden pills keep their default transform and occupy no space.

## Tests

`line-label-pill-bounds.test.ts` (jsdom, stubbed `getBBox`): pill with room is untouched; pill on the last point hugs the right edge (the screenshot case); pill near the top slides down; icon chip width counts toward the edge; zoom keeps the pill inside; no-clip chart is left alone; explicit `bounds` override is honoured. Plus unit tests for the two new shift helpers, and a "clamped pills do not stack on their neighbours" block: top-edge slide-down onto the row below, three stacked rows near the top edge, a parallelism chip in the way, the same on the zoom path, and hidden pills not reserving space.

Ran locally: the five `line-label-*` / `point-label-placement` vitest files (59 tests pass), `tsc` on the changed files, `oxfmt --write`, `oxlint` with the repo config (0 warnings). The full `bun install` did not complete in my sandbox, so CI is the first full-suite run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to inference chart SVG label positioning with defaults preserving no-clip charts; behavior is covered by new vitest cases.
> 
> **Overview**
> **Line-label run-name pills** are no longer placed only at a fixed anchor offset: after text/icon sizing, **`layoutPills`** clamps each pill inside the plot clip rect (default **`plotAreaBounds`**) and picks among mirrored anchor positions so edge slides do not stack pills on neighbors or **parallelism** chips. **`renderLineLabels`** and **`updateRenderedLineLabels`** share this pass; optional **`bounds`** (`null` skips clamping for non-clipping charts).
> 
> New helpers **`verticalShiftIntoBounds`**, **`pillShiftIntoBounds`**, and **`rectsStrictlyOverlap`** (edge-touching rects allowed) support that layout. **`pillObstacles`** accepts a selector so line labels avoid parallelism labels only during line-label layout.
> 
> **`line-label-pill-bounds.test.ts`** covers edge clamping, zoom updates, collision flipping, icons, and no-clip / explicit bounds behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14eb6eb40a30227913a35fbaf478be1288e22612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
