### PR TITLE
[H3 Video]: simplify results and persist CI media / 简化结果展示并持久化 CI 媒体

### DIFF
--- a/.github/workflows/h3-media.yml
+++ b/.github/workflows/h3-media.yml
@@ -1,0 +1,35 @@
+name: 'Publish H3 media'
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Optional InferenceX CI run ID to persist'
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: h3-media-publication
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: 'Publish H3 media'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version-file: package.json
+      - name: Persist completed H3 artifacts
+        env:
+          H3_RUN_ID: ${{ inputs.run_id }}
+        run: bun packages/app/scripts/warm-video-results.ts

--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -15,6 +15,7 @@ const run = (id: number, conclusion: string) => ({
 
 describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
   beforeEach(() => {
+    cy.intercept('GET', '**/api/video-runs*format=media', { statusCode: 204 });
     cy.window().then((win) => win.history.replaceState(null, '', win.location.pathname));
   });
   it('loads the newest run automatically and switches to a failed run without inventing media', () => {
@@ -37,6 +38,7 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.contains('No result artifact for this run yet').should('be.visible');
     cy.get('select[aria-label="CI run"]').select('10');
     cy.wait('@failed');
+    cy.contains('summary', 'Run details and artifact selection').click();
     cy.contains('a', '#10 · completed / failure').should('be.visible');
     cy.get('video').should('not.exist');
   });
@@ -68,6 +70,7 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       </PathnameContext.Provider>,
     );
     cy.wrap(null).should(() => expect(releaseList).to.be.a('function'));
+    cy.contains('summary', 'Run details and artifact selection').click();
     cy.get('input[aria-label="GitHub run ID"]').type('30');
     cy.contains('button', 'Open run').click();
     cy.wait('@direct');
@@ -75,9 +78,74 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.then(() => releaseList?.());
     cy.wait('@catalog');
     cy.get('select[aria-label="CI run"]').should('have.value', '30');
-    cy.get('[role="status"]').should('contain', 'Loading CI results');
+    cy.get('[role="status"]').should('be.visible');
     cy.wait('@zip');
     cy.get('[role="alert"]').should('contain', 'Synthetic download failure');
+  });
+  it('shows stored measurements without downloading the archive', () => {
+    const artifact = {
+      id: 40,
+      name: 'h3-results-30-1',
+      expired: false,
+      size_in_bytes: 100,
+      stored: true,
+    };
+    cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });
+    cy.intercept('GET', '/api/video-runs?run=30', {
+      run: run(30, 'success'),
+      artifacts: [artifact],
+    });
+    cy.intercept('GET', '/api/video-runs?run=30&artifact=40', () => {
+      throw new Error('Stored results must not fetch the ZIP');
+    });
+    cy.intercept('GET', '**/api/video-runs*format=media', {
+      storageVersion: 1,
+      runId: '30',
+      artifact,
+      sources: [
+        {
+          id: '30',
+          assets: [],
+          texts: [],
+          checksums: [['manifest.json', 'a'.repeat(64)]],
+          documents: [
+            ['manifest.json', { run_id: '30' }],
+            [
+              'ci.json',
+              { phase: 'complete', regression_status: 'inconclusive', release_qualified: false },
+            ],
+            [
+              'report/evidence.json',
+              {
+                policy: { calibration_status: 'uncalibrated' },
+                roles: {
+                  baseline: {
+                    summary: { latency_median_seconds: 150, valid_clips_per_second: 0.01 },
+                  },
+                  candidate: {
+                    summary: { latency_median_seconds: 120, valid_clips_per_second: 0.02 },
+                  },
+                },
+              },
+            ],
+          ],
+        },
+      ],
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[data-testid="result-summary"]')
+      .should('contain', 'Media stored for direct playback')
+      .and('contain', 'uncalibrated');
+    cy.contains('tr', 'Latency')
+      .should('contain', '150')
+      .and('contain', '120')
+      .and('contain', '-20%');
+    cy.contains('tr', 'Valid clips').should('contain', '36').and('contain', '72');
+    cy.contains('tr', 'Mean GPU power').should('contain', 'Unavailable');
   });
   it('reports expiration without downloading or substituting another artifact', () => {
     cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });

--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -42,6 +42,33 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.contains('a', '#10 · completed / failure').should('be.visible');
     cy.get('video').should('not.exist');
   });
+  it('keeps the shared run selected when browsing the first catalog page', () => {
+    cy.window().then((win) =>
+      win.history.replaceState(null, '', `${win.location.pathname}?run=30`),
+    );
+    cy.intercept('GET', '/api/video-runs?run=30', { run: run(30, 'success'), artifacts: [] }).as(
+      'shared',
+    );
+    cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(20, 'success')], nextPage: 2 }).as(
+      'browse',
+    );
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.wait('@shared');
+    cy.get('select[aria-label="CI run"]').should('have.value', '30');
+    cy.contains('button', 'Older runs').should('not.exist');
+    cy.contains('button', 'Browse CI runs').click();
+    cy.wait('@browse');
+    cy.get('select[aria-label="CI run"]')
+      .should('have.value', '30')
+      .find('option[value="20"]')
+      .should('exist');
+    cy.contains('button', 'Older runs').should('be.visible');
+    cy.location('search').should('contain', 'run=30');
+  });
   it('keeps a direct selection and its download active when an older catalog arrives', () => {
     let releaseList: (() => void) | undefined;
     cy.intercept(

--- a/packages/app/scripts/warm-video-results.ts
+++ b/packages/app/scripts/warm-video-results.ts
@@ -1,0 +1,26 @@
+import { env } from 'node:process';
+const productionOrigin = 'https://inferencex.semianalysis.com';
+async function get(path: string) {
+  const response = await fetch(`${productionOrigin}/api/video-runs${path}`, {
+    signal: AbortSignal.timeout(290000),
+  });
+  if (!response.ok) throw new Error(`H3 publication failed: HTTP ${response.status}`);
+  if (response.status === 204)
+    throw new Error('BLOB_READ_WRITE_TOKEN is not configured on the frontend');
+  return response.json();
+}
+const runId = env.H3_RUN_ID;
+if (runId && !/^[1-9]\d*$/u.test(runId)) throw new Error('Invalid H3_RUN_ID');
+const catalog = runId ? { runs: [{ id: runId }] } : await get('?page=1');
+const runs: { id: number | string }[] = catalog.runs;
+for (const run of runs) {
+  const data = await get(`?run=${run.id}`);
+  for (const artifact of data.artifacts) {
+    if (artifact.stored || artifact.expired) continue;
+    const result = await get(`?run=${run.id}&artifact=${artifact.id}&format=media`);
+    if (result.storageVersion !== 1) throw new Error('Unexpected H3 storage response');
+    console.log(
+      `Stored H3 run ${run.id}, artifact ${artifact.id}, ${result.sources.length} executions`,
+    );
+  }
+}

--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -1,13 +1,23 @@
 import { NextRequest } from 'next/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
+import { readStoredArtifact, storedArtifacts, videoStorageEnabled } from '@/lib/video-storage';
 
+vi.mock('@/lib/video-storage', () => ({
+  videoStorageEnabled: vi.fn(() => false),
+  storedArtifacts: vi.fn(() => Promise.resolve([])),
+  readStoredArtifact: vi.fn(),
+  storeVideoArtifact: vi.fn(),
+}));
 const fetchMock = vi.fn<typeof fetch>();
 vi.stubGlobal('fetch', fetchMock);
 const response = (body: unknown, status = 200) => Response.json(body, { status });
 const request = (query = '') => new NextRequest(`http://localhost/api/video-runs${query}`);
 afterEach(() => {
   fetchMock.mockReset();
+  vi.mocked(videoStorageEnabled).mockReturnValue(false);
+  vi.mocked(storedArtifacts).mockResolvedValue([]);
+  vi.mocked(readStoredArtifact).mockReset();
   vi.restoreAllMocks();
 });
 
@@ -54,7 +64,7 @@ describe('H3 CI artifact access', () => {
     const deadline = new AbortController().signal;
     const timeout = vi
       .spyOn(AbortSignal, 'timeout')
-      .mockImplementation((ms) => (ms === 110000 ? deadline : new AbortController().signal));
+      .mockImplementation((ms) => (ms === 270000 ? deadline : new AbortController().signal));
     fetchMock
       .mockResolvedValueOnce(response({ private: false }))
       .mockResolvedValueOnce(
@@ -67,7 +77,7 @@ describe('H3 CI artifact access', () => {
       )
       .mockResolvedValueOnce(new Response(new Uint8Array([80, 75, 3, 4])));
     const result = await GET(request('?run=10&artifact=20'));
-    expect(timeout).toHaveBeenCalledWith(110000);
+    expect(timeout).toHaveBeenCalledWith(270000);
     expect(fetchMock.mock.calls[2][1]?.signal).toBe(deadline);
     expect(fetchMock.mock.calls[0][1]?.signal).not.toBe(deadline);
     expect(result.headers.get('content-type')).toBe('application/zip');
@@ -98,6 +108,46 @@ describe('H3 CI artifact access', () => {
       run: { id: 10, conclusion: 'failure' },
       artifacts: [],
     });
+  });
+  it('falls back to the CI ZIP when object storage is not configured', async () => {
+    fetchMock.mockResolvedValueOnce(response({ private: false }));
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(result.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('serves a persisted result without fetching an expired GitHub artifact', async () => {
+    vi.mocked(videoStorageEnabled).mockReturnValue(true);
+    const artifact = {
+      id: 20,
+      name: 'h3-results-10-1',
+      expired: false,
+      size_in_bytes: 4,
+      stored: true,
+    };
+    const saved = { storageVersion: 1 as const, runId: '10', artifact, sources: [] };
+    vi.mocked(storedArtifacts).mockResolvedValue([artifact]);
+    vi.mocked(readStoredArtifact).mockResolvedValue(saved);
+    fetchMock.mockResolvedValueOnce(response({ private: false }));
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(await result.json()).toEqual(saved);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('retains stored artifacts after GitHub removes them from the run', async () => {
+    const artifact = {
+      id: 20,
+      name: 'h3-results-10-1',
+      expired: false,
+      size_in_bytes: 0,
+      stored: true,
+    };
+    vi.mocked(storedArtifacts).mockResolvedValue([artifact]);
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockResolvedValueOnce(response({ id: 10, conclusion: 'success' }))
+      .mockResolvedValueOnce(response({ artifacts: [] }));
+    const result = await GET(request('?run=10'));
+    const data = await result.json();
+    expect(data.artifacts).toEqual([artifact]);
   });
   it('rejects invalid identifiers without making requests', async () => {
     const result5 = await GET(request('?run=../secret'));

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -1,9 +1,15 @@
 import { type NextRequest, NextResponse } from 'next/server';
 import { GITHUB_API_BASE, GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
 import { getGithubToken } from '@/lib/github-artifacts';
+import {
+  readStoredArtifact,
+  storedArtifacts,
+  storeVideoArtifact,
+  videoStorageEnabled,
+} from '@/lib/video-storage';
 
 export const dynamic = 'force-dynamic';
-export const maxDuration = 120;
+export const maxDuration = 300;
 const ROOT = `${GITHUB_API_BASE}/repos/${GITHUB_OWNER}/${GITHUB_REPO}`;
 const MAX_BYTES = 256 * 1024 ** 2;
 const headers = { 'Cache-Control': 'private, no-store' };
@@ -32,7 +38,7 @@ export async function GET(request: NextRequest) {
       { error: 'Invalid CI run, artifact or page' },
       { status: 400, headers },
     );
-  const deadline = AbortSignal.timeout(110000);
+  const deadline = AbortSignal.timeout(270000);
   try {
     // This public viewer must never expose artifacts from a repository that becomes private.
     const repository = await github('');
@@ -43,6 +49,16 @@ export async function GET(request: NextRequest) {
         { status: 503, headers },
       );
     if (artifactId) {
+      const media = query.get('format') === 'media';
+      if (media && !videoStorageEnabled()) return new Response(null, { status: 204, headers });
+      if (media) {
+        const saved = await storedArtifacts(runId!);
+        const stored = saved.find((a) => String(a.id) === artifactId);
+        if (stored) {
+          const result = await readStoredArtifact(runId!, stored);
+          if (result) return NextResponse.json(result, { headers });
+        }
+      }
       const metaResponse = await github(`/actions/artifacts/${artifactId}`);
       if (!metaResponse.ok)
         return NextResponse.json(
@@ -82,6 +98,15 @@ export async function GET(request: NextRequest) {
           },
         }),
       );
+      if (media) {
+        const result = await storeVideoArtifact(
+          runId!,
+          artifact,
+          await new Response(stream).blob(),
+          deadline,
+        );
+        return NextResponse.json(result, { headers });
+      }
       return new Response(stream, { headers: { ...headers, 'Content-Type': 'application/zip' } });
     }
     if (runId) {
@@ -95,10 +120,16 @@ export async function GET(request: NextRequest) {
       if (!artifactsResponse.ok)
         return NextResponse.json({ error: 'Cannot list CI artifacts' }, { status: 502, headers });
       const data = await artifactsResponse.json();
+      const saved = await storedArtifacts(runId).catch(() => []);
       const artifacts = (data.artifacts ?? []).filter((a: { name: string }) => {
         const match = artifactName.exec(a.name);
         return match?.groups?.runId === runId;
       });
+      for (const stored of saved) {
+        const index = artifacts.findIndex((a: { id: number }) => a.id === stored.id);
+        if (index === -1) artifacts.push(stored);
+        else artifacts[index] = { ...artifacts[index], expired: false, stored: true };
+      }
       return NextResponse.json({ run: await runResponse.json(), artifacts }, { headers });
     }
     const response = await github(`/actions/runs?per_page=100&page=${page}`);

--- a/packages/app/src/components/video-benchmark/ResultSummary.tsx
+++ b/packages/app/src/components/video-benchmark/ResultSummary.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { Heading } from '@/components/ui/heading';
+import { useLocale } from '@/lib/use-locale';
+import { at, entries, number, ROLES, rows, text, type Bundle } from './bundle';
+
+const STRINGS = {
+  en: {
+    title: 'Benchmark result',
+    baseline: 'Baseline',
+    candidate: 'Candidate',
+    change: 'Observed change',
+    metric: 'Metric',
+    latency: 'Latency',
+    throughput: 'Valid clips',
+    completion: 'Completed / scheduled',
+    memory: 'Peak GPU memory',
+    power: 'Mean GPU power',
+    energy: 'Energy / valid clip',
+    missing: 'Unavailable',
+    lower: 'Lower is better',
+    higher: 'Higher is better',
+    noClaim:
+      'Descriptive comparison. Calibration and release qualification are separate; small differences do not establish a performance improvement.',
+    aa: 'Same-runtime A/A check',
+    comparison: 'Comparison',
+    execution: 'Execution',
+    calibration: 'Calibration',
+    qualified: 'Release qualified',
+    yes: 'Yes',
+    no: 'No',
+    chips: 'participating GPUs',
+    verified: 'CI checksums verified',
+    stored: 'Media stored for direct playback',
+    memoryNote:
+      'Maximum sampled memory across participating GPUs, including warmup. Power is the participating-GPU average during generation; energy excludes CPU and facility power.',
+    counts: 'Counts are for the measured block; warmup is excluded.',
+  },
+  zh: {
+    title: '基准测试结果',
+    baseline: '基线',
+    candidate: '候选',
+    change: '观测变化',
+    metric: '指标',
+    latency: '延迟',
+    throughput: '有效视频数',
+    completion: '已完成 / 计划',
+    memory: 'GPU 显存峰值',
+    power: 'GPU 平均功率',
+    energy: '每有效视频能耗',
+    missing: '无数据',
+    lower: '越低越好',
+    higher: '越高越好',
+    noClaim: '此处仅描述观测差异。校准与发布资格单独判定，微小差异不能证明性能提升。',
+    aa: '同运行时 A/A 检查',
+    comparison: '对比状态',
+    execution: '执行状态',
+    calibration: '校准状态',
+    qualified: '具备发布资格',
+    yes: '是',
+    no: '否',
+    chips: '个 GPU 参与计算',
+    verified: 'CI 校验和已验证',
+    stored: '媒体已存储，可直接播放',
+    memoryNote:
+      '显存为参与计算的 GPU 中最高的采样值，包含 warmup。功率取生成阶段各参与计算 GPU 的平均值；能耗不含 CPU 与设施用电。',
+    counts: '计数仅涵盖正式测量时段，不含 warmup。',
+  },
+};
+export default function ResultSummary({ bundle: b, stored }: { bundle: Bundle; stored: boolean }) {
+  const s = STRINGS[useLocale()];
+  const fmt = (v: number | null, digits = 2) =>
+    v === null ? s.missing : v.toLocaleString('en-US', { maximumFractionDigits: digits });
+  const roleMetric = (role: string, metric: string): number | null => {
+    const summary = at(b.report, 'roles', role, 'summary');
+    const phase = at(b.result, 'roles', role, 'power', 'phases', 'measurement');
+    if (metric === 'latency') return number(at(summary, 'latency_median_seconds'));
+    if (metric === 'throughput') {
+      const rate = number(at(summary, 'valid_clips_per_second'));
+      return rate === null ? null : rate * 3600;
+    }
+    if (metric === 'memory') {
+      const values = entries(
+        at(
+          b.result,
+          'roles',
+          role,
+          'metrics',
+          'gpu_memory',
+          'client_including_warmup_observed_peak_mib_by_gpu',
+        ),
+      )
+        .map(([, v]) => number(v))
+        .filter((v): v is number => v !== null);
+      return values.length > 0 ? Math.max(...values) / 1024 : null;
+    }
+    if (at(phase, 'valid') !== true) return null;
+    if (metric === 'energy') {
+      const joules = number(at(phase, 'aggregate', 'joules_per_valid_clip'));
+      return joules === null ? null : joules / 1000;
+    }
+    const values = entries(at(phase, 'per_gpu')).map(([, gpu]) => number(at(gpu, 'avg_power_w')));
+    return values.length > 0 && values.every((v): v is number => v !== null)
+      ? values.reduce((sum, v) => sum + v, 0) / values.length
+      : null;
+  };
+  const runtime = ROLES.map((r) => at(b.report, 'roles', r, 'source_identity', 'source_sha256'));
+  const configs = ROLES.map((r) =>
+    at(b.documents.get(`gpu/${r}/run.json`), 'configuration', 'configuration_sha256'),
+  );
+  const sameRuntime =
+    configs[0] !== null &&
+    configs[0] === configs[1] &&
+    runtime[0] !== null &&
+    runtime[0] === runtime[1] &&
+    at(b.report, 'same_workload') === true &&
+    at(b.report, 'same_gpu_uuid_set') === true;
+  const gpus = rows(at(b.job, 'roles', 'baseline', 'telemetry_summary', 'gpu_identity'));
+  const gpuNames = [...new Set(gpus.map((gpu) => text(at(gpu, 'name'))).filter(Boolean))].join(
+    ', ',
+  );
+  const runId = text(at(b.manifest, 'run_id'));
+  const completion = (role: string) => {
+    const summary = at(b.documents.get(`gpu/${role}/run.json`), 'summary');
+    const scheduled = number(at(b.report, 'roles', role, 'summary', 'scheduled'));
+    return `${fmt(number(at(summary, 'completed')), 0)} / ${fmt(scheduled, 0)}`;
+  };
+  return (
+    <Card className="min-w-0 gap-4" data-testid="result-summary">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <Heading level="section">{s.title}</Heading>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <a
+              className="text-primary underline"
+              href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId}`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              CI #{runId}
+            </a>
+            {' · '}
+            {gpus.length > 0 ? gpus.length : '—'} {s.chips}
+            {gpuNames ? ` (${gpuNames})` : ''}
+            {sameRuntime ? ` · ${s.aa}` : ''}
+          </p>
+        </div>
+        <span className="rounded-full border px-3 py-1 text-xs">
+          {stored ? s.stored : s.verified}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+        <p>
+          {s.execution}: <strong>{text(at(b.ci, 'phase')) || s.missing}</strong>
+        </p>
+        <p>
+          {s.comparison}: <strong>{text(at(b.ci, 'regression_status')) || s.missing}</strong>
+        </p>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {s.calibration}: {text(at(b.report, 'policy', 'calibration_status')) || s.missing}
+        {' · '}
+        {s.qualified}:{' '}
+        {at(b.ci, 'release_qualified') === true
+          ? s.yes
+          : at(b.ci, 'release_qualified') === false
+            ? s.no
+            : s.missing}
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm tabular-nums">
+          <thead>
+            <tr className="border-b text-xs text-muted-foreground">
+              <th className="pb-2 font-normal">{s.metric}</th>
+              <th className="pb-2 text-right font-normal">{s.baseline}</th>
+              <th className="pb-2 text-right font-normal">{s.candidate}</th>
+              <th className="pb-2 text-right font-normal">{s.change}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(
+              [
+                ['latency', s.latency, 's', s.lower],
+                ['throughput', s.throughput, 'clips/h', s.higher],
+                ['memory', s.memory, 'GiB/GPU', s.lower],
+                ['power', s.power, 'W/GPU', ''],
+                ['energy', s.energy, 'kJ/clip', s.lower],
+              ] as const
+            ).map(([metric, label, unit, hint]) => {
+              const baseline = roleMetric('baseline', metric),
+                candidate = roleMetric('candidate', metric);
+              const change =
+                baseline !== null && baseline > 0 && candidate !== null
+                  ? (candidate / baseline - 1) * 100
+                  : null;
+              return (
+                <tr key={metric} className="border-b last:border-0">
+                  <th className="py-2 pr-3 font-normal">
+                    <span className="font-medium">{label}</span>
+                    <span className="mt-0.5 block text-xs text-muted-foreground">
+                      {unit}
+                      {hint ? ` · ${hint}` : ''}
+                    </span>
+                  </th>
+                  <td className="px-2 py-2 text-right">{fmt(baseline)}</td>
+                  <td className="px-2 py-2 text-right font-semibold">{fmt(candidate)}</td>
+                  <td className="pl-2 py-2 text-right text-muted-foreground">
+                    {change === null ? '—' : `${change > 0 ? '+' : ''}${fmt(change)}%`}
+                  </td>
+                </tr>
+              );
+            })}
+            <tr>
+              <th className="pt-3 font-normal">{s.completion}</th>
+              <td className="pt-3 text-right">{completion('baseline')}</td>
+              <td className="pt-3 text-right font-semibold">{completion('candidate')}</td>
+              <td />
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {s.counts} {s.noClaim}
+      </p>
+      <details>
+        <summary className="cursor-pointer text-xs text-muted-foreground">
+          {s.memory} / {s.power}
+        </summary>
+        <p className="mt-2 text-xs text-muted-foreground">{s.memoryNote}</p>
+      </details>
+    </Card>
+  );
+}

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -8,6 +8,8 @@ import { Heading } from '@/components/ui/heading';
 import { useLocale } from '@/lib/use-locale';
 import { track } from '@/lib/analytics';
 import ResultPower from './ResultPower';
+import { storedBundle, type StoredSource } from './stored';
+import ResultSummary from './ResultSummary';
 import {
   at,
   entries,
@@ -251,6 +253,7 @@ const STRINGS = {
 interface Loaded {
   bundle: Bundle;
   urls: Map<string, string>;
+  downloads: Map<string, string>;
   power: Record<string, ReturnType<typeof sampledPower>>;
   html: string;
 }
@@ -271,7 +274,13 @@ const field = (label: string, value: string, change: (value: string) => void, ty
   </label>
 );
 
-export default function VideoBenchmark({ reader }: { reader?: (path: string) => Promise<Blob> }) {
+export default function VideoBenchmark({
+  reader,
+  published,
+}: {
+  reader?: (path: string) => Promise<Blob>;
+  published?: StoredSource;
+}) {
   const s = STRINGS[useLocale()];
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [loading, setLoading] = useState(false);
@@ -304,13 +313,13 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
     setLoading(false);
     setSlot('');
   }
-  async function open(read: () => (path: string) => Promise<Blob>) {
+  async function open(read?: () => (path: string) => Promise<Blob>, saved?: StoredSource) {
     clear();
     const current = generation.current;
     setLoading(true);
     const urls = new Map<string, string>();
     try {
-      const bundle = await loadBundle(read());
+      const bundle = saved ? storedBundle(saved) : await loadBundle(read!());
       const power: Loaded['power'] = {};
       for (const role of ROLES) {
         const file = bundle.files.get(`gpu/supervisor/${role}/telemetry.jsonl`);
@@ -332,7 +341,8 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
             : null;
       }
       if (current !== generation.current) return;
-      for (const [path, file] of bundle.files) {
+      for (const [path, asset] of saved?.assets ?? []) urls.set(path, asset.url);
+      for (const [path, file] of saved ? [] : bundle.files) {
         urls.set(
           path,
           URL.createObjectURL(
@@ -362,7 +372,7 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
         const csp = doc.createElement('meta');
         csp.httpEquiv = 'Content-Security-Policy';
         csp.content =
-          "default-src 'none'; media-src blob:; img-src blob: data:; style-src 'unsafe-inline'; form-action 'none'; base-uri 'none'";
+          "default-src 'none'; media-src blob: https:; img-src blob: data:; style-src 'unsafe-inline'; form-action 'none'; base-uri 'none'";
         doc.head.prepend(csp);
         html = doc.documentElement.outerHTML;
       }
@@ -370,8 +380,16 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
         urls.forEach(URL.revokeObjectURL);
         return;
       }
-      activeUrls.current = [...urls.values()];
-      setLoaded({ bundle, urls, power, html });
+      activeUrls.current = [...urls.values()].filter((url) => url.startsWith('blob:'));
+      setLoaded({
+        bundle,
+        urls,
+        power,
+        html,
+        downloads: saved
+          ? new Map(saved.assets.map(([path, asset]) => [path, asset.downloadUrl]))
+          : urls,
+      });
       const first =
         rows(at(bundle.report, 'roles', 'baseline', 'observations'))[0] ??
         rows(at(bundle.report, 'roles', 'candidate', 'observations'))[0];
@@ -406,9 +424,10 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
   }, []);
 
   useEffect(() => {
-    if (reader) void open(() => reader);
+    if (published) void open(undefined, published);
+    else if (reader) void open(() => reader);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reader]);
+  }, [reader, published]);
 
   const b = loaded?.bundle;
   const participating = rows(
@@ -443,17 +462,17 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
 
   return (
     <section
-      className="ph-no-capture ph-mask mx-auto min-w-0 w-full max-w-7xl space-y-6 py-6"
+      className={`ph-no-capture ph-mask mx-auto min-w-0 w-full max-w-7xl space-y-6 ${reader || published ? '' : 'py-6'}`}
       data-testid="video-benchmark"
     >
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <Heading as="h1" level="page">
-            {s.title}
-          </Heading>
-          <p className="text-muted-foreground mt-2">{s.subtitle}</p>
-        </div>
-        {!reader && (
+      {!reader && !published && (
+        <header className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <Heading as="h1" level="page">
+              {s.title}
+            </Heading>
+            <p className="text-muted-foreground mt-2">{s.subtitle}</p>
+          </div>
           <div className="flex gap-2">
             <Button onClick={() => input.current?.click()} disabled={loading}>
               {s.open}
@@ -464,9 +483,9 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
               </Button>
             )}
           </div>
-        )}
-      </header>
-      {!reader && (
+        </header>
+      )}
+      {!reader && !published && (
         <>
           <input
             ref={input}
@@ -531,369 +550,356 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
       )}
       {b && loaded && (
         <>
-          <Card className="gap-4">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <span className="text-sm text-muted-foreground">
-                GitHub #{text(at(b.manifest, 'run_id'))} · {fmt(at(b.manifest, 'run_attempt'))} ·{' '}
-                {fmt(at(b.ci, 'finished_at'))}
-              </span>
-              <span className="rounded-full border px-3 py-1 text-xs">
-                {s.verified} · {b.checksums.size}
-              </span>
-            </div>
-            {at(b.report, 'same_workload') === true &&
-              at(b.report, 'same_gpu_uuid_set') === true &&
-              at(
-                b.documents.get('gpu/baseline/run.json'),
-                'configuration',
-                'configuration_sha256',
-              ) !== null &&
-              at(
-                b.documents.get('gpu/baseline/run.json'),
-                'configuration',
-                'configuration_sha256',
-              ) ===
-                at(
-                  b.documents.get('gpu/candidate/run.json'),
-                  'configuration',
-                  'configuration_sha256',
-                ) &&
-              at(b.report, 'roles', 'baseline', 'source_identity', 'source_sha256') !== null &&
-              at(b.report, 'roles', 'baseline', 'source_identity', 'source_sha256') ===
-                at(b.report, 'roles', 'candidate', 'source_identity', 'source_sha256') && (
-                <p className="text-sm font-medium">{s.aa}</p>
-              )}
-            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-              {[
-                [s.execution, at(b.ci, 'phase')],
-                [s.comparison, at(b.ci, 'regression_status')],
-                [s.calibration, at(b.report, 'policy', 'calibration_status')],
-                [s.qualification, at(b.ci, 'release_qualified')],
-              ].map(([label, value]) => (
-                <div key={String(label)}>
-                  <p className="text-sm text-muted-foreground">{fmt(label)}</p>
-                  <p className="mt-1 text-lg font-semibold">{fmt(value)}</p>
-                </div>
-              ))}
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {s.sameWorkload}: {fmt(at(b.report, 'same_workload'))}. {s.trust}
-            </p>
-          </Card>
-          {slots.length > 0 && (
-            <Card className="gap-4">
-              <label className="text-sm font-medium">
-                {s.slot}
-                <select
-                  className="mt-2 block w-full max-w-full rounded-md sm:ml-3 sm:mt-0 sm:inline-block sm:w-auto border bg-background p-2"
-                  value={slot}
-                  onChange={(e) => setSlot(e.target.value)}
-                >
-                  {slots.map((o) => (
-                    <option key={text(at(o, 'slot_id'))} value={text(at(o, 'slot_id'))}>
-                      {text(at(o, 'case_id'))} ·{' '}
-                      {at(o, 'phase') === 'warmup' ? s.warmup : s.measured} ·{' '}
-                      {text(at(o, 'slot_id'))}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <div>
-                <span className="text-xs text-muted-foreground">
-                  {s.prompt} · {s.seed} {fmt(at(clip, 'seed'))}
-                </span>
-                <p className="mt-2 leading-relaxed">{fmt(at(clip, 'prompt'))}</p>
-              </div>
-              <details>
-                <summary className="cursor-pointer text-sm">{s.settings}</summary>
-                <div className="mt-3">
-                  {table(entries(at(b.manifest, 'workload_plan', 'generation')))}
-                </div>
-              </details>
-            </Card>
-          )}
-          <div className="grid gap-5 lg:grid-cols-2">
-            {ROLES.map((role) => {
-              const o = selected(role);
-              const r = at(b.report, 'roles', role);
-              const summary = at(r, 'summary');
-              const mediaUrl = loaded.urls.get(`report/${text(at(o, 'artifact_path'))}`);
-              const run = b.documents.get(`gpu/${role}/run.json`);
-              const rawSummary = at(run, 'summary');
-              return (
-                <Card key={role} className="gap-4">
-                  <div className="flex justify-between">
-                    <Heading level="section">{s[role]}</Heading>
-                    <span className="text-sm text-muted-foreground">{fmt(at(o, 'status'))}</span>
-                  </div>
-                  {mediaUrl ? (
-                    <>
-                      <video
-                        key={mediaUrl + slot}
-                        data-role={role}
-                        className="aspect-video w-full rounded-lg bg-black"
-                        controls
-                        playsInline
-                        preload="auto"
-                        src={mediaUrl}
-                        aria-label={`${s[role]} ${s.slot}`}
-                        onPlay={(e) => {
-                          document
-                            .querySelectorAll<HTMLVideoElement>('[data-role]')
-                            .forEach((v) => {
-                              if (v !== e.currentTarget) v.pause();
-                            });
-                        }}
-                        onError={(e) => {
-                          const node = e.currentTarget.nextElementSibling;
-                          if (node) node.textContent = s.mediaError;
-                        }}
-                      />
-                      <p role="status" className="text-xs text-muted-foreground">
-                        {s.audio}
-                      </p>
-                      <a
-                        download={`${role}-${slot}.mp4`}
-                        className="text-sm text-primary underline"
-                        href={mediaUrl}
-                      >
-                        {s.download}
-                      </a>
-                    </>
-                  ) : (
-                    <div className="flex aspect-video items-center justify-center rounded-lg bg-muted p-6 text-muted-foreground">
-                      {s.noMedia}
-                    </div>
-                  )}
-                  <p className="text-xs text-muted-foreground">{s.statsNote}</p>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <p className="text-xs text-muted-foreground">{s.latency}</p>
-                      <p className="text-2xl font-semibold tabular-nums">
-                        {fmt(at(summary, 'latency_median_seconds'))}{' '}
-                        <span className="text-sm">s</span>
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground">{s.throughput}</p>
-                      <p className="text-2xl font-semibold tabular-nums">
-                        {fmt(at(summary, 'valid_clips_per_second'), 5)}
-                      </p>
-                    </div>
-                  </div>
-                  {table([
-                    [s.scheduled, at(summary, 'scheduled')],
-                    [s.completed, at(rawSummary, 'completed')],
-                    [s.valid, at(summary, 'valid')],
-                    [s.failed, at(rawSummary, 'failed')],
-                    [`${s.window} (s)`, at(summary, 'wall_seconds')],
-                    [
-                      s.warmup,
-                      `${fmt(at(summary, 'warmups_valid'))} / ${fmt(at(summary, 'warmups_scheduled'))}`,
-                    ],
-                  ])}
-                  <details>
-                    <summary className="cursor-pointer text-sm">{s.integrity}</summary>
-                    <div className="mt-3 space-y-3">
-                      {table([
-                        ...entries(at(o, 'media', 'video')).map(([k, v]): [string, Json] => [
-                          `video.${k}`,
-                          v,
-                        ]),
-                        ...entries(at(o, 'media', 'audio')).map(([k, v]): [string, Json] => [
-                          `audio.${k}`,
-                          v,
-                        ]),
-                      ])}
-                      {rows(
-                        at(
-                          rows(at(run, 'records')).find((record) => at(record, 'slot_id') === slot),
-                          'media',
-                          'checks',
-                        ),
-                      ).map((check, i) => (
-                        <p className="break-words text-xs" key={i}>
-                          {text(at(check, 'name'))}: <strong>{fmt(at(check, 'status'))}</strong> —{' '}
-                          {text(at(check, 'detail'))}
-                        </p>
-                      ))}
-                    </div>
-                  </details>
-                </Card>
-              );
-            })}
-          </div>
-          <p className="text-sm text-muted-foreground">{s.timing}</p>
-          {b.result ? (
-            <ResultPower result={b.result} />
-          ) : (
-            <Card className="gap-4">
-              <Heading>{s.power}</Heading>
-              <p className="text-sm text-muted-foreground">{s.powerNote}</p>
-              <div className="grid gap-6 lg:grid-cols-2">
+          <div className="grid items-start gap-5 xl:grid-cols-[minmax(320px,0.9fr)_minmax(0,1.8fr)]">
+            <ResultSummary bundle={b} stored={Boolean(published)} />
+            <div className="min-w-0 space-y-4">
+              <div className="grid gap-5 lg:grid-cols-2">
                 {ROLES.map((role) => {
-                  const power = loaded.power[role];
+                  const o = selected(role);
+                  const r = at(b.report, 'roles', role);
+                  const summary = at(r, 'summary');
+                  const mediaUrl = loaded.urls.get(`report/${text(at(o, 'artifact_path'))}`);
+                  const run = b.documents.get(`gpu/${role}/run.json`);
+                  const rawSummary = at(run, 'summary');
                   return (
-                    <div key={role} className="space-y-3">
-                      <Heading level="card">{s[role]}</Heading>
-                      {table([
-                        [`${s.meanPower} (W)`, power?.watts],
-                        [`${s.energy} (kJ)`, power ? power.joules / 1000 : null],
-                        [`${s.coverage} (s)`, power?.seconds],
-                        [s.samples, power?.sampleCount],
-                      ])}
-                      {power && (
-                        <p className="break-all text-xs text-muted-foreground">
-                          {power.start} → {power.end}
-                        </p>
+                    <Card key={role} className="gap-4">
+                      <div className="flex justify-between">
+                        <Heading level="section">{s[role]}</Heading>
+                        <span className="text-sm text-muted-foreground">
+                          {fmt(at(o, 'status'))}
+                        </span>
+                      </div>
+                      {mediaUrl ? (
+                        <>
+                          <video
+                            key={mediaUrl + slot}
+                            data-role={role}
+                            className="aspect-video w-full rounded-lg bg-black"
+                            controls
+                            crossOrigin="anonymous"
+                            playsInline
+                            preload="auto"
+                            src={mediaUrl}
+                            aria-label={`${s[role]} ${s.slot}`}
+                            onPlay={(e) => {
+                              document
+                                .querySelectorAll<HTMLVideoElement>('[data-role]')
+                                .forEach((v) => {
+                                  if (v !== e.currentTarget) v.pause();
+                                });
+                            }}
+                            onError={(e) => {
+                              const node = e.currentTarget.nextElementSibling;
+                              if (node) node.textContent = s.mediaError;
+                            }}
+                          />
+                          <p role="status" className="text-xs text-muted-foreground">
+                            {s.audio}
+                          </p>
+                          <a
+                            download={`${role}-${slot}.mp4`}
+                            className="text-sm text-primary underline"
+                            href={
+                              loaded.downloads.get(`report/${text(at(o, 'artifact_path'))}`) ??
+                              mediaUrl
+                            }
+                          >
+                            {s.download}
+                          </a>
+                        </>
+                      ) : (
+                        <div className="flex aspect-video items-center justify-center rounded-lg bg-muted p-6 text-muted-foreground">
+                          {s.noMedia}
+                        </div>
                       )}
-                    </div>
+                      <details>
+                        <summary className="cursor-pointer text-sm">
+                          {s.settings} · {s.integrity}
+                        </summary>
+                        <p className="my-3 text-xs text-muted-foreground">{s.statsNote}</p>
+                        <div className="grid grid-cols-2 gap-4">
+                          <div>
+                            <p className="text-xs text-muted-foreground">{s.latency}</p>
+                            <p className="text-2xl font-semibold tabular-nums">
+                              {fmt(at(summary, 'latency_median_seconds'))}{' '}
+                              <span className="text-sm">s</span>
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-xs text-muted-foreground">{s.throughput}</p>
+                            <p className="text-2xl font-semibold tabular-nums">
+                              {fmt(at(summary, 'valid_clips_per_second'), 5)}
+                            </p>
+                          </div>
+                        </div>
+                        {table([
+                          [s.scheduled, at(summary, 'scheduled')],
+                          [s.completed, at(rawSummary, 'completed')],
+                          [s.valid, at(summary, 'valid')],
+                          [s.failed, at(rawSummary, 'failed')],
+                          [`${s.window} (s)`, at(summary, 'wall_seconds')],
+                          [
+                            s.warmup,
+                            `${fmt(at(summary, 'warmups_valid'))} / ${fmt(at(summary, 'warmups_scheduled'))}`,
+                          ],
+                        ])}
+                        <details>
+                          <summary className="cursor-pointer text-sm">{s.integrity}</summary>
+                          <div className="mt-3 space-y-3">
+                            {table([
+                              ...entries(at(o, 'media', 'video')).map(([k, v]): [string, Json] => [
+                                `video.${k}`,
+                                v,
+                              ]),
+                              ...entries(at(o, 'media', 'audio')).map(([k, v]): [string, Json] => [
+                                `audio.${k}`,
+                                v,
+                              ]),
+                            ])}
+                            {rows(
+                              at(
+                                rows(at(run, 'records')).find(
+                                  (record) => at(record, 'slot_id') === slot,
+                                ),
+                                'media',
+                                'checks',
+                              ),
+                            ).map((check, i) => (
+                              <p className="break-words text-xs" key={i}>
+                                {text(at(check, 'name'))}:{' '}
+                                <strong>{fmt(at(check, 'status'))}</strong> —{' '}
+                                {text(at(check, 'detail'))}
+                              </p>
+                            ))}
+                          </div>
+                        </details>
+                      </details>
+                    </Card>
                   );
                 })}
               </div>
-              <Heading level="card">{s.memory}</Heading>
-              <p className="text-sm text-muted-foreground">{s.memoryNote}</p>
+              {slots.length > 0 && (
+                <Card className="gap-4">
+                  <label className="text-sm font-medium">
+                    {s.slot}
+                    <select
+                      className="mt-2 block w-full max-w-full rounded-md sm:ml-3 sm:mt-0 sm:inline-block sm:w-auto border bg-background p-2"
+                      value={slot}
+                      onChange={(e) => setSlot(e.target.value)}
+                    >
+                      {slots.map((o) => (
+                        <option key={text(at(o, 'slot_id'))} value={text(at(o, 'slot_id'))}>
+                          {text(at(o, 'case_id'))} ·{' '}
+                          {at(o, 'phase') === 'warmup' ? s.warmup : s.measured} ·{' '}
+                          {text(at(o, 'slot_id'))}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <div>
+                    <span className="text-xs text-muted-foreground">
+                      {s.prompt} · {s.seed} {fmt(at(clip, 'seed'))}
+                    </span>
+                    <details className="mt-1">
+                      <summary className="cursor-pointer text-sm leading-relaxed">
+                        {text(at(clip, 'prompt')).slice(0, 150)}
+                        {text(at(clip, 'prompt')).length > 150 ? '…' : ''}
+                      </summary>
+                      <p className="mt-2 text-sm leading-relaxed">{fmt(at(clip, 'prompt'))}</p>
+                    </details>
+                  </div>
+                  <details>
+                    <summary className="cursor-pointer text-sm">{s.settings}</summary>
+                    <div className="mt-3">
+                      {table(entries(at(b.manifest, 'workload_plan', 'generation')))}
+                    </div>
+                  </details>
+                </Card>
+              )}
+            </div>
+          </div>
+          <details className="space-y-4 rounded-lg border p-5">
+            <summary className="cursor-pointer font-medium">
+              {s.power} · {s.fidelity} · {s.hardware}
+            </summary>
+            <p className="text-sm text-muted-foreground">{s.timing}</p>
+            {b.result ? (
+              <ResultPower result={b.result} />
+            ) : (
+              <Card className="gap-4">
+                <Heading>{s.power}</Heading>
+                <p className="text-sm text-muted-foreground">{s.powerNote}</p>
+                <div className="grid gap-6 lg:grid-cols-2">
+                  {ROLES.map((role) => {
+                    const power = loaded.power[role];
+                    return (
+                      <div key={role} className="space-y-3">
+                        <Heading level="card">{s[role]}</Heading>
+                        {table([
+                          [`${s.meanPower} (W)`, power?.watts],
+                          [`${s.energy} (kJ)`, power ? power.joules / 1000 : null],
+                          [`${s.coverage} (s)`, power?.seconds],
+                          [s.samples, power?.sampleCount],
+                        ])}
+                        {power && (
+                          <p className="break-all text-xs text-muted-foreground">
+                            {power.start} → {power.end}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+                <Heading level="card">{s.memory}</Heading>
+                <p className="text-sm text-muted-foreground">{s.memoryNote}</p>
+                <div className="grid gap-6 lg:grid-cols-2">
+                  {ROLES.map((role) => (
+                    <div key={role} className="space-y-2">
+                      <Heading level="label">{s[role]}</Heading>
+                      {entries(
+                        at(
+                          b.job,
+                          'roles',
+                          role,
+                          'telemetry_summary',
+                          'measurement_observed_memory_peak_mib_by_gpu',
+                        ),
+                      ).length > 0
+                        ? table(
+                            entries(
+                              at(
+                                b.job,
+                                'roles',
+                                role,
+                                'telemetry_summary',
+                                'measurement_observed_memory_peak_mib_by_gpu',
+                              ),
+                            ).map(([gpu, value]) => [gpu, `${fmt(value)} MiB`]),
+                          )
+                        : s.unavailable}
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            )}
+            <Card className="gap-4">
+              <Heading>{s.fidelity}</Heading>
+              <p className="text-sm text-muted-foreground">{s.fidelityNote}</p>
+              {table([
+                [
+                  s.videoPsnr,
+                  at(pair, 'metrics', 'video_identical') === true
+                    ? s.identical
+                    : at(pair, 'metrics', 'video_psnr_db'),
+                ],
+                [s.videoMae, at(pair, 'metrics', 'video_mae')],
+                [s.audioSpectral, at(pair, 'metrics', 'audio_spectral_cosine')],
+                [s.audioRms, at(pair, 'metrics', 'audio_rms_ratio')],
+                [s.audioMae, at(rawPair, 'metrics', 'audio_waveform_mae')],
+                [s.videoCoverage, at(rawPair, 'metrics', 'video_sample_coverage_fraction')],
+                [s.audioCoverage, at(rawPair, 'metrics', 'audio_sample_coverage_fraction')],
+              ])}
+              <details>
+                <summary className="cursor-pointer text-sm">{s.checks}</summary>
+                {rows(at(pair, 'checks')).map((c, i) => (
+                  <p key={i} className="mt-2 break-words text-xs">
+                    {text(at(c, 'name'))} · {fmt(at(c, 'status'))} · {text(at(c, 'reason'))}
+                  </p>
+                ))}
+              </details>
+            </Card>
+            <Card className="gap-4">
+              <Heading>{s.hardware}</Heading>
+              {table([
+                [s.participating, participating > 0 ? participating : null],
+                [
+                  s.allocated,
+                  /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
+                    text(at(b.ci, 'slurm_job', 'AllocTRES')),
+                  )?.groups?.count,
+                ],
+                ['Slurm', at(b.manifest, 'slurm_allocation', 'identity', 'JobId')],
+                [s.node, at(b.ci, 'slurm_job', 'NodeList')],
+                [s.model, at(b.manifest, 'workload_plan', 'model_id')],
+                [s.modelRevision, at(b.manifest, 'workload_plan', 'model_revision')],
+              ])}
               <div className="grid gap-6 lg:grid-cols-2">
                 {ROLES.map((role) => (
-                  <div key={role} className="space-y-2">
-                    <Heading level="label">{s[role]}</Heading>
-                    {entries(
-                      at(
-                        b.job,
-                        'roles',
-                        role,
-                        'telemetry_summary',
-                        'measurement_observed_memory_peak_mib_by_gpu',
-                      ),
-                    ).length > 0
-                      ? table(
-                          entries(
-                            at(
-                              b.job,
-                              'roles',
-                              role,
-                              'telemetry_summary',
-                              'measurement_observed_memory_peak_mib_by_gpu',
-                            ),
-                          ).map(([gpu, value]) => [gpu, `${fmt(value)} MiB`]),
-                        )
-                      : s.unavailable}
+                  <div key={role} className="space-y-3">
+                    <Heading level="card">{s[role]}</Heading>
+                    {table([
+                      [
+                        s.runtimeRevision,
+                        at(b.report, 'roles', role, 'configuration', 'runtime_revision'),
+                      ],
+                      [
+                        s.sourceHash,
+                        at(b.report, 'roles', role, 'source_identity', 'source_sha256'),
+                      ],
+                      [
+                        'GPU',
+                        rows(at(b.job, 'roles', role, 'telemetry_summary', 'gpu_identity'))
+                          .map((g) => text(at(g, 'name')))
+                          .join(', '),
+                      ],
+                    ])}
+                    <details>
+                      <summary className="cursor-pointer text-sm">{s.settings}</summary>
+                      <pre className="mt-3 overflow-auto whitespace-pre-wrap break-all text-xs">
+                        {JSON.stringify(at(b.job, 'roles', role, 'launch_argv'), null, 2)}
+                      </pre>
+                    </details>
                   </div>
                 ))}
               </div>
             </Card>
-          )}
-          <Card className="gap-4">
-            <Heading>{s.fidelity}</Heading>
-            <p className="text-sm text-muted-foreground">{s.fidelityNote}</p>
-            {table([
-              [
-                s.videoPsnr,
-                at(pair, 'metrics', 'video_identical') === true
-                  ? s.identical
-                  : at(pair, 'metrics', 'video_psnr_db'),
-              ],
-              [s.videoMae, at(pair, 'metrics', 'video_mae')],
-              [s.audioSpectral, at(pair, 'metrics', 'audio_spectral_cosine')],
-              [s.audioRms, at(pair, 'metrics', 'audio_rms_ratio')],
-              [s.audioMae, at(rawPair, 'metrics', 'audio_waveform_mae')],
-              [s.videoCoverage, at(rawPair, 'metrics', 'video_sample_coverage_fraction')],
-              [s.audioCoverage, at(rawPair, 'metrics', 'audio_sample_coverage_fraction')],
-            ])}
-            <details>
-              <summary className="cursor-pointer text-sm">{s.checks}</summary>
-              {rows(at(pair, 'checks')).map((c, i) => (
-                <p key={i} className="mt-2 break-words text-xs">
-                  {text(at(c, 'name'))} · {fmt(at(c, 'status'))} · {text(at(c, 'reason'))}
-                </p>
-              ))}
-            </details>
-          </Card>
-          <Card className="gap-4">
-            <Heading>{s.hardware}</Heading>
-            {table([
-              [s.participating, participating > 0 ? participating : null],
-              [
-                s.allocated,
-                /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
-                  text(at(b.ci, 'slurm_job', 'AllocTRES')),
-                )?.groups?.count,
-              ],
-              ['Slurm', at(b.manifest, 'slurm_allocation', 'identity', 'JobId')],
-              [s.node, at(b.ci, 'slurm_job', 'NodeList')],
-              [s.model, at(b.manifest, 'workload_plan', 'model_id')],
-              [s.modelRevision, at(b.manifest, 'workload_plan', 'model_revision')],
-            ])}
-            <div className="grid gap-6 lg:grid-cols-2">
-              {ROLES.map((role) => (
-                <div key={role} className="space-y-3">
-                  <Heading level="card">{s[role]}</Heading>
-                  {table([
-                    [
-                      s.runtimeRevision,
-                      at(b.report, 'roles', role, 'configuration', 'runtime_revision'),
-                    ],
-                    [s.sourceHash, at(b.report, 'roles', role, 'source_identity', 'source_sha256')],
-                    [
-                      'GPU',
-                      rows(at(b.job, 'roles', role, 'telemetry_summary', 'gpu_identity'))
-                        .map((g) => text(at(g, 'name')))
-                        .join(', '),
-                    ],
-                  ])}
-                  <details>
-                    <summary className="cursor-pointer text-sm">{s.settings}</summary>
-                    <pre className="mt-3 overflow-auto whitespace-pre-wrap break-all text-xs">
-                      {JSON.stringify(at(b.job, 'roles', role, 'launch_argv'), null, 2)}
-                    </pre>
-                  </details>
-                </div>
-              ))}
-            </div>
-          </Card>
-          <Card className="gap-4">
-            <Heading>{s.economics}</Heading>
-            <p className="text-sm text-muted-foreground">{s.economicsNote}</p>
-            <div className="grid gap-4 md:grid-cols-3">
-              {field(s.price, price, setPrice)}
-              {field(s.cost, cost, setCost)}
-              {field(s.billed, billed, setBilled)}
-              {field(s.assumption, assumption, setAssumption, 'text')}
-              {field(s.date, date, setDate, 'date')}
-            </div>
-            <p className="text-xs text-muted-foreground">{s.needAssumptions}</p>
-            <div className="grid gap-6 lg:grid-cols-2">
-              {ROLES.map((role) => {
-                const summary = at(b.report, 'roles', role, 'summary');
-                const count = rows(
-                  at(b.job, 'roles', role, 'telemetry_summary', 'gpu_identity'),
-                ).length;
-                const e =
-                  assumption.trim() && date
-                    ? estimateEconomics(
-                        number(at(summary, 'valid_clips_per_second')),
-                        count || null,
-                        parseInput(billed),
-                        parseInput(price),
-                        parseInput(cost),
-                      )
-                    : null;
-                return (
-                  <div key={role} className="space-y-3">
-                    <Heading level="card">
-                      {s[role]} · {s.estimate} (USD)
-                    </Heading>
-                    {table([
-                      [s.revenueParticipant, e?.revenuePerParticipating],
-                      [s.revenueBilled, e?.revenuePerBilled],
-                      [s.profitParticipant, e?.profitPerParticipating],
-                      [s.profitBilled, e?.profitPerBilled],
-                    ])}
-                  </div>
-                );
-              })}
-            </div>
-          </Card>
+          </details>
+          <details className="rounded-lg border p-5">
+            <summary className="cursor-pointer font-medium">{s.economics}</summary>
+            <Card className="mt-4 gap-4">
+              <Heading>{s.economics}</Heading>
+              <p className="text-sm text-muted-foreground">{s.economicsNote}</p>
+              <div className="grid gap-4 md:grid-cols-3">
+                {field(s.price, price, setPrice)}
+                {field(s.cost, cost, setCost)}
+                {field(s.billed, billed, setBilled)}
+                {field(s.assumption, assumption, setAssumption, 'text')}
+                {field(s.date, date, setDate, 'date')}
+              </div>
+              <p className="text-xs text-muted-foreground">{s.needAssumptions}</p>
+              <div className="grid gap-6 lg:grid-cols-2">
+                {ROLES.map((role) => {
+                  const summary = at(b.report, 'roles', role, 'summary');
+                  const count = rows(
+                    at(b.job, 'roles', role, 'telemetry_summary', 'gpu_identity'),
+                  ).length;
+                  const e =
+                    assumption.trim() && date
+                      ? estimateEconomics(
+                          number(at(summary, 'valid_clips_per_second')),
+                          count || null,
+                          parseInput(billed),
+                          parseInput(price),
+                          parseInput(cost),
+                        )
+                      : null;
+                  return (
+                    <div key={role} className="space-y-3">
+                      <Heading level="card">
+                        {s[role]} · {s.estimate} (USD)
+                      </Heading>
+                      {table([
+                        [s.revenueParticipant, e?.revenuePerParticipating],
+                        [s.revenueBilled, e?.revenuePerBilled],
+                        [s.profitParticipant, e?.profitPerParticipating],
+                        [s.profitBilled, e?.profitPerBilled],
+                      ])}
+                    </div>
+                  );
+                })}
+              </div>
+            </Card>
+          </details>
           <Card className="gap-4">
             <Heading>{s.provenance}</Heading>
             {ciUrl && (
@@ -930,7 +936,7 @@ export default function VideoBenchmark({ reader }: { reader?: (path: string) => 
                   <a
                     className="break-all text-xs text-primary underline"
                     key={path}
-                    href={url}
+                    href={loaded.downloads.get(path) ?? url}
                     download={path.replaceAll('/', '__')}
                   >
                     {path}

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -7,11 +7,15 @@ import { Heading } from '@/components/ui/heading';
 import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
+import type { StoredArtifact, StoredSource } from './stored';
 import { archiveSources, type CIArtifact, type CIRun } from './archive';
 
 const STRINGS = {
   en: {
-    title: 'H3 CI runs',
+    title: 'H3 video benchmark',
+    preparing: 'Loading results and preparing media. The first publication of a run takes longer.',
+    downloading: 'Downloading CI archive',
+    advanced: 'Run details and artifact selection',
     error: 'Could not load CI results',
     details: 'Technical details',
     select: 'CI run',
@@ -26,19 +30,22 @@ const STRINGS = {
     direct: 'GitHub run ID',
     open: 'Open run',
     local: 'Local artifact tools',
-    note: 'Results load directly from GitHub CI. An export may contain earlier GPU executions; their original run identities are preserved. GitHub artifacts can expire.',
+    note: 'Results preserve their original GitHub CI identities. Stored media loads separately from the benchmark data; unpublished artifacts use the CI archive fallback.',
     expired: 'Expired',
     noMedia: 'Artifact unavailable',
   },
   zh: {
-    title: 'H3 CI 运行',
+    title: 'H3 视频基准测试',
+    preparing: '正在加载结果并准备媒体。首次发布该运行的产物需要更多时间。',
+    downloading: '正在下载 CI 产物',
+    advanced: '运行详情与产物选择',
     error: '无法加载 CI 结果',
     details: '技术详情',
     select: 'CI 运行',
     refresh: '刷新',
     older: '更早的运行',
     loading: '正在加载 CI 结果…',
-    source: '原始 GPU 执行',
+    source: '原始 GPU 运行',
     artifact: '结果产物',
     none: '此次运行尚无结果产物。失败的运行可能仅保留 CI 日志。',
     empty: '本页 GitHub 历史中没有 H3 运行。可加载更早的运行或输入运行 ID。',
@@ -46,7 +53,7 @@ const STRINGS = {
     direct: 'GitHub 运行 ID',
     open: '查看运行',
     local: '本地产物工具',
-    note: '结果直接从 GitHub CI 加载。导出产物可能包含更早的 GPU 执行，这些执行仍沿用各自原始运行的 ID。GitHub 产物可能过期。',
+    note: '结果保留原始 GitHub CI 运行标识。已存储的媒体与基准测试数据分别加载；尚未发布的产物则回退为下载 CI 产物压缩包。',
     expired: '已过期',
     noMedia: '产物不可用',
   },
@@ -74,11 +81,14 @@ export default function VideoCIRuns() {
   const [run, setRun] = useState<CIRun | null>(null);
   const [artifacts, setArtifacts] = useState<CIArtifact[]>([]);
   const [artifact, setArtifact] = useState<CIArtifact | null>(null);
-  const [sources, setSources] = useState<Awaited<ReturnType<typeof archiveSources>>>([]);
+  const [sources, setSources] = useState<
+    { id: string; read?: (path: string) => Promise<Blob>; stored?: StoredSource }[]
+  >([]);
   const [sourceId, setSourceId] = useState('');
   const [nextPage, setNextPage] = useState<number | null>(1);
   const [loadError, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [progress, setProgress] = useState('');
   const [direct, setDirect] = useState('');
   const [manual, setManual] = useState(false);
   const request = useRef(0);
@@ -92,17 +102,53 @@ export default function VideoCIRuns() {
   ) {
     setArtifact(selected);
     setSources([]);
-    if (selected.expired) throw new Error(s.expired);
     const controller = new AbortController();
     download.current = controller;
-    const response = await fetch(`/api/video-runs?run=${selectedRun.id}&artifact=${selected.id}`, {
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      const failure = await response.json();
-      throw new Error(failure.error ?? s.noMedia);
+    setProgress(s.preparing);
+    const endpoint = `/api/video-runs?run=${selectedRun.id}&artifact=${selected.id}`;
+    let found:
+      | { id: string; read?: (path: string) => Promise<Blob>; stored?: StoredSource }[]
+      | null = null;
+    try {
+      const response = await fetch(`${endpoint}&format=media`, { signal: controller.signal });
+      if (response.ok && response.status !== 204) {
+        const saved: StoredArtifact = await response.json();
+        if (
+          saved.storageVersion !== 1 ||
+          saved.runId !== String(selectedRun.id) ||
+          saved.artifact.id !== selected.id
+        )
+          throw new Error('Stored artifact identity mismatch');
+        found = saved.sources.map((item) => ({ id: item.id, stored: item }));
+      }
+    } catch (error) {
+      if (controller.signal.aborted) throw error;
     }
-    const found = await archiveSources(await response.blob(), selected);
+    if (!found) {
+      if (selected.expired) throw new Error(s.expired);
+      const response = await fetch(endpoint, { signal: controller.signal });
+      if (!response.ok) {
+        const failure = await response.json();
+        throw new Error(failure.error ?? s.noMedia);
+      }
+      const stream = response.body?.getReader();
+      if (!stream) throw new Error(s.noMedia);
+      const chunks: Uint8Array<ArrayBuffer>[] = [];
+      let bytes = 0;
+      for (;;) {
+        const chunk = await stream.read();
+        if (chunk.done) break;
+        bytes += chunk.value.byteLength;
+        if (bytes > 256 * 1024 ** 2) {
+          await stream.cancel();
+          throw new Error('Archive exceeds 256 MiB');
+        }
+        chunks.push(new Uint8Array(chunk.value));
+        if (current === request.current)
+          setProgress(`${s.downloading} · ${(bytes / 1024 ** 2).toFixed(1)} MiB`);
+      }
+      found = await archiveSources(new Blob(chunks), selected);
+    }
     if (current !== request.current) return;
     const chosen =
       found.find((item) => item.id === source) ??
@@ -116,6 +162,7 @@ export default function VideoCIRuns() {
     const current = ++request.current;
     download.current?.abort();
     setLoading(true);
+    setProgress('');
     setError('');
     setRun(null);
     setSources([]);
@@ -151,6 +198,7 @@ export default function VideoCIRuns() {
     const current = ++request.current;
     download.current?.abort();
     setLoading(true);
+    setProgress('');
     setError('');
     try {
       const data: { runs: CIRun[]; nextPage: number | null } = await json(
@@ -186,7 +234,10 @@ export default function VideoCIRuns() {
     }
   }
   useEffect(() => {
-    void list(1, true);
+    const params = new URLSearchParams(location.search);
+    const directRun = params.get('run');
+    if (directRun) void selectRun(directRun, params.get('artifact'), params.get('source'));
+    else void list(1, true);
     return () => {
       request.current++;
       download.current?.abort();
@@ -196,11 +247,11 @@ export default function VideoCIRuns() {
   const selectedSource = sources.find((item) => item.id === sourceId);
   return (
     <div className="mx-auto min-w-0 w-full max-w-7xl space-y-4 py-6" data-testid="video-ci-runs">
-      <Card className="gap-4">
-        <Heading as="h1" level="page">
+      <Card className="gap-3 p-4">
+        <Heading as="h1" level="section">
           {s.title}
         </Heading>
-        <p className="text-sm text-muted-foreground">{s.note}</p>
+
         <div className="flex flex-wrap items-end gap-3">
           <label className="min-w-0 flex-1 space-y-1 text-sm">
             {s.select}
@@ -220,6 +271,26 @@ export default function VideoCIRuns() {
               ))}
             </select>
           </label>
+          {sources.length > 1 && (
+            <label className="w-full min-w-0 space-y-1 text-sm sm:w-52">
+              {s.source}
+              <select
+                aria-label={s.source}
+                className="w-full rounded border bg-background p-2"
+                value={sourceId}
+                onChange={(e) => {
+                  setSourceId(e.target.value);
+                  if (run && artifact) share(run.id, artifact.id, e.target.value);
+                }}
+              >
+                {sources.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    #{item.id}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
           <Button variant="outline" disabled={loading} onClick={() => void list(1, true)}>
             {s.refresh}
           </Button>
@@ -230,79 +301,68 @@ export default function VideoCIRuns() {
           )}
         </div>
         {runs.length === 0 && !loading && <p>{s.empty}</p>}
-        <form
-          className="flex flex-wrap gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void selectRun(direct);
-          }}
-        >
-          <Input
-            className="max-w-xs"
-            aria-label={s.direct}
-            placeholder={s.direct}
-            value={direct}
-            onChange={(e) => setDirect(e.target.value)}
-            pattern="[0-9]+"
-            required
-          />
-          <Button type="submit" variant="outline">
-            {s.open}
-          </Button>
-        </form>
-        {run && (
-          <a
-            className="break-all text-sm text-primary underline"
-            href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${run.id}`}
-            target="_blank"
-            rel="noreferrer"
+        <details>
+          <summary className="cursor-pointer text-sm text-muted-foreground">{s.advanced}</summary>
+          <p className="my-3 text-xs text-muted-foreground">{s.note}</p>
+          <form
+            className="flex flex-wrap gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void selectRun(direct);
+            }}
           >
-            #{run.id} · {run.status} / {run.conclusion ?? '—'} · {run.created_at} ·{' '}
-            {run.head_sha.slice(0, 10)}
-          </a>
-        )}
-        {artifacts.length > 0 && (
-          <label className="text-sm">
-            {s.artifact}
-            <select
-              aria-label={s.artifact}
-              className="mt-1 w-full rounded border bg-background p-2"
-              value={artifact?.id ?? ''}
-              onChange={(e) => run && void selectRun(String(run.id), e.target.value)}
+            <Input
+              className="max-w-xs"
+              aria-label={s.direct}
+              placeholder={s.direct}
+              value={direct}
+              onChange={(e) => setDirect(e.target.value)}
+              pattern="[0-9]+"
+              required
+            />
+            <Button type="submit" variant="outline">
+              {s.open}
+            </Button>
+          </form>
+          {run && (
+            <a
+              className="break-all text-sm text-primary underline"
+              href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${run.id}`}
+              target="_blank"
+              rel="noreferrer"
             >
-              <option value="" disabled>
-                —
-              </option>
-              {artifacts.map((a) => (
-                <option key={a.id} value={a.id}>
-                  {a.name}
-                  {a.expired ? ` · ${s.expired}` : ''}
+              #{run.id} · {run.status} / {run.conclusion ?? '—'} · {run.created_at} ·{' '}
+              {run.head_sha.slice(0, 10)}
+            </a>
+          )}
+          {artifacts.length > 0 && (
+            <label className="text-sm">
+              {s.artifact}
+              <select
+                aria-label={s.artifact}
+                className="mt-1 w-full rounded border bg-background p-2"
+                value={artifact?.id ?? ''}
+                onChange={(e) => run && void selectRun(String(run.id), e.target.value)}
+              >
+                <option value="" disabled>
+                  —
                 </option>
-              ))}
-            </select>
-          </label>
+                {artifacts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.name}
+                    {a.expired ? ` · ${s.expired}` : ''}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+        </details>
+        {loading && (
+          <div role="status" className="space-y-2">
+            <p className="text-sm">{progress || s.loading}</p>
+            <progress className="h-1 w-full" aria-label={s.loading} />
+          </div>
         )}
-        {sources.length > 1 && (
-          <label className="text-sm">
-            {s.source}
-            <select
-              aria-label={s.source}
-              className="mt-1 w-full rounded border bg-background p-2"
-              value={sourceId}
-              onChange={(e) => {
-                setSourceId(e.target.value);
-                if (run && artifact) share(run.id, artifact.id, e.target.value);
-              }}
-            >
-              {sources.map((item) => (
-                <option key={item.id} value={item.id}>
-                  #{item.id}
-                </option>
-              ))}
-            </select>
-          </label>
-        )}
-        {loading && <p role="status">{s.loading}</p>}
         {loadError && (
           <div role="alert">
             <p>{s.error}</p>
@@ -325,7 +385,11 @@ export default function VideoCIRuns() {
         {run && !loading && !loadError && artifacts.length === 0 && <p>{s.none}</p>}
       </Card>
       {selectedSource && (
-        <VideoBenchmark key={`${artifact?.id}-${sourceId}`} reader={selectedSource.read} />
+        <VideoBenchmark
+          key={`${artifact?.id}-${sourceId}`}
+          reader={selectedSource.read}
+          published={selectedSource.stored}
+        />
       )}
       <details onToggle={(event) => setManual(event.currentTarget.open)}>
         <summary className="cursor-pointer text-sm text-muted-foreground">{s.local}</summary>

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -21,6 +21,7 @@ const STRINGS = {
     select: 'CI run',
     refresh: 'Refresh',
     older: 'Older runs',
+    browse: 'Browse CI runs',
     loading: 'Loading CI results…',
     source: 'Original GPU execution',
     artifact: 'Result artifact',
@@ -44,6 +45,7 @@ const STRINGS = {
     select: 'CI 运行',
     refresh: '刷新',
     older: '更早的运行',
+    browse: '浏览 CI 运行',
     loading: '正在加载 CI 结果…',
     source: '原始 GPU 运行',
     artifact: '结果产物',
@@ -207,7 +209,7 @@ export default function VideoCIRuns() {
       if (current !== request.current) return;
       setRuns((old) =>
         page === 1
-          ? data.runs
+          ? [...(run && !data.runs.some((r) => r.id === run.id) ? [run] : []), ...data.runs]
           : [...old, ...data.runs.filter((r) => !old.some((o) => o.id === r.id))],
       );
       setNextPage(data.nextPage);
@@ -296,7 +298,7 @@ export default function VideoCIRuns() {
           </Button>
           {nextPage && (
             <Button variant="outline" disabled={loading} onClick={() => void list(nextPage)}>
-              {s.older}
+              {nextPage === 1 ? s.browse : s.older}
             </Button>
           )}
         </div>

--- a/packages/app/src/components/video-benchmark/archive.ts
+++ b/packages/app/src/components/video-benchmark/archive.ts
@@ -6,6 +6,7 @@ export interface CIArtifact {
   expired: boolean;
   size_in_bytes: number;
   digest?: string;
+  stored?: boolean;
 }
 export interface CIRun {
   id: number;

--- a/packages/app/src/components/video-benchmark/stored.ts
+++ b/packages/app/src/components/video-benchmark/stored.ts
@@ -1,0 +1,35 @@
+import { at, type Bundle, type Json } from './bundle';
+import type { CIArtifact } from './archive';
+
+export interface StoredSource {
+  id: string;
+  documents: [string, Json][];
+  checksums: [string, string][];
+  assets: [string, { url: string; downloadUrl: string }][];
+  texts: [string, string][];
+}
+export interface StoredArtifact {
+  storageVersion: 1;
+  runId: string;
+  artifact: CIArtifact;
+  sources: StoredSource[];
+}
+export function storedBundle(source: StoredSource): Bundle {
+  const documents = new Map(source.documents);
+  const checksums = new Map(source.checksums);
+  const manifest = documents.get('manifest.json') ?? null;
+  if (at(manifest, 'run_id') !== source.id || !checksums.has('manifest.json'))
+    throw new Error('Stored result identity mismatch');
+  return {
+    manifest,
+    result: documents.get('result.json') ?? null,
+    report: documents.get('report/evidence.json') ?? null,
+    job: documents.get('gpu/gpu-job.json') ?? null,
+    ci: documents.get('ci.json') ?? null,
+    comparison: documents.get('gpu/comparison.json') ?? null,
+    documents,
+    checksums,
+    files: new Map(source.texts.map(([path, value]) => [path, new Blob([value])])),
+    manifestSha256: checksums.get('manifest.json')!,
+  };
+}

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
       zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
     },
-    sourceSha256: 'cfe8492e4612a3ad8597b3bce5e57bfc2b8aa4c4ca926fa4699f4640511f868a',
+    sourceSha256: 'f78f1d5fb6af0989adede754e8a25a34c8b945ae8b502f5453bb39b2de286eba',
   },
   {
     source: 'src/app/api/unofficial-run/route.ts',

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -1,13 +1,19 @@
 import { createHash } from 'node:crypto';
 import { strToU8, zipSync } from 'fflate';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { put } from '@vercel/blob';
+import { head, put } from '@vercel/blob';
 import type * as BlobSdk from '@vercel/blob';
 import { storeVideoArtifact } from './video-storage';
 import { storedBundle } from '@/components/video-benchmark/stored';
 
 vi.mock('@vercel/blob', async (original) => ({
   ...(await original<typeof BlobSdk>()),
+  head: vi.fn((path: string) =>
+    Promise.resolve({
+      url: `https://test.public.blob.vercel-storage.com/${path}`,
+      downloadUrl: `https://test.public.blob.vercel-storage.com/${path}?download=1`,
+    }),
+  ),
   put: vi.fn((path: string) =>
     Promise.resolve({
       url: `https://test.public.blob.vercel-storage.com/${path}`,
@@ -43,7 +49,10 @@ function archive(corrupt = false) {
     ).buffer,
   ]);
 }
-beforeEach(() => vi.mocked(put).mockClear());
+beforeEach(() => {
+  vi.mocked(put).mockClear();
+  vi.mocked(head).mockClear();
+});
 describe('persistent H3 media', () => {
   it('publishes verified files before the index and restores metadata without media bytes', async () => {
     const result = await storeVideoArtifact(
@@ -68,6 +77,25 @@ describe('persistent H3 media', () => {
     const bundle = storedBundle(source);
     expect(bundle.manifestSha256).toHaveLength(64);
     expect(bundle.files.has('synthetic.mp4')).toBe(false);
+  });
+  it('reuses an immutable object regardless of SDK conflict wording', async () => {
+    vi.mocked(put).mockRejectedValueOnce(new Error('Different SDK conflict wording'));
+    const result = await storeVideoArtifact(
+      '10',
+      artifact,
+      archive(),
+      new AbortController().signal,
+    );
+    expect(result.artifact.stored).toBe(true);
+    expect(head).toHaveBeenCalledTimes(1);
+  });
+  it('preserves upload failures when no immutable object exists', async () => {
+    vi.mocked(put).mockRejectedValueOnce(new Error('Storage upload failed'));
+    vi.mocked(head).mockRejectedValueOnce(new Error('Object missing'));
+    await expect(
+      storeVideoArtifact('10', artifact, archive(), new AbortController().signal),
+    ).rejects.toThrow('Storage upload failed');
+    expect(vi.mocked(put).mock.calls.some(([path]) => path.includes('/runs/'))).toBe(false);
   });
   it('does not publish unverified bytes', async () => {
     await expect(

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto';
+import { strToU8, zipSync } from 'fflate';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { put } from '@vercel/blob';
+import type * as BlobSdk from '@vercel/blob';
+import { storeVideoArtifact } from './video-storage';
+import { storedBundle } from '@/components/video-benchmark/stored';
+
+vi.mock('@vercel/blob', async (original) => ({
+  ...(await original<typeof BlobSdk>()),
+  put: vi.fn((path: string) =>
+    Promise.resolve({
+      url: `https://test.public.blob.vercel-storage.com/${path}`,
+      downloadUrl: `https://test.public.blob.vercel-storage.com/${path}?download=1`,
+    }),
+  ),
+}));
+const artifact = { id: 20, name: 'h3-video-10-1', size_in_bytes: 100, expired: false };
+const digest = (s: string) => createHash('sha256').update(s).digest('hex');
+function archive(corrupt = false) {
+  const files = {
+    'manifest.json': JSON.stringify({
+      schema_version: 1,
+      run_id: '10',
+      run_attempt: '1',
+      git_commit: 'a'.repeat(40),
+      ci: { repository: 'SemiAnalysisAI/InferenceX' },
+    }),
+    'synthetic.mp4': 'Synthetic test bytes, not a playable benchmark clip',
+  };
+  const sums = Object.entries(files)
+    .map(([path, body]) => `${digest(body)}  ${path}`)
+    .join('\n');
+  return new Blob([
+    zipSync(
+      Object.fromEntries(
+        Object.entries({
+          ...files,
+          'synthetic.mp4': corrupt ? 'changed' : files['synthetic.mp4'],
+          SHA256SUMS: sums,
+        }).map(([path, body]) => [path, strToU8(body)]),
+      ),
+    ).buffer,
+  ]);
+}
+beforeEach(() => vi.mocked(put).mockClear());
+describe('persistent H3 media', () => {
+  it('publishes verified files before the index and restores metadata without media bytes', async () => {
+    const result = await storeVideoArtifact(
+      '10',
+      artifact,
+      archive(),
+      new AbortController().signal,
+    );
+    const calls = vi.mocked(put).mock.calls;
+    expect(calls.at(-1)?.[0]).toBe('h3-video-media/v1/runs/10/h3-video-10-1_20.json');
+    const video = calls.find(([path]) => path.endsWith('/synthetic.mp4'))!;
+    expect(video[0]).toContain(digest('Synthetic test bytes, not a playable benchmark clip'));
+    expect(video[2]).toMatchObject({
+      access: 'public',
+      contentType: 'video/mp4',
+      allowOverwrite: false,
+    });
+    const source = result.sources[0];
+    expect(source.assets.find(([path]) => path === 'synthetic.mp4')?.[1].downloadUrl).toContain(
+      'download=1',
+    );
+    const bundle = storedBundle(source);
+    expect(bundle.manifestSha256).toHaveLength(64);
+    expect(bundle.files.has('synthetic.mp4')).toBe(false);
+  });
+  it('does not publish unverified bytes', async () => {
+    await expect(
+      storeVideoArtifact('10', artifact, archive(true), new AbortController().signal),
+    ).rejects.toThrow('checksum mismatch');
+    expect(put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -1,0 +1,131 @@
+import { head, list, put, BlobNotFoundError } from '@vercel/blob';
+import { archiveSources, type CIArtifact } from '@/components/video-benchmark/archive';
+import { loadBundle, sha256 } from '@/components/video-benchmark/bundle';
+import type { StoredArtifact, StoredSource } from '@/components/video-benchmark/stored';
+
+// Media must survive the dashboard cache's prefix-wide purge.
+const PREFIX = 'h3-video-media/v1';
+export const videoStorageEnabled = () => Boolean(process.env.BLOB_READ_WRITE_TOKEN);
+const runPrefix = (runId: string) => `${PREFIX}/runs/${runId}/`;
+
+export async function storedArtifacts(runId: string): Promise<CIArtifact[]> {
+  if (!videoStorageEnabled()) return [];
+  const result: CIArtifact[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await list({ prefix: runPrefix(runId), cursor });
+    for (const blob of page.blobs) {
+      const match = /\/(?<name>h3-(?:results|video)-\d+-\d+)_(?<id>\d+)\.json$/u.exec(
+        blob.pathname,
+      );
+      if (match?.groups)
+        result.push({
+          id: Number(match.groups.id),
+          name: match.groups.name,
+          expired: false,
+          size_in_bytes: 0,
+          stored: true,
+        });
+    }
+    cursor = page.hasMore ? page.cursor : undefined;
+  } while (cursor);
+  return result;
+}
+export async function readStoredArtifact(
+  runId: string,
+  artifact: CIArtifact,
+): Promise<StoredArtifact | null> {
+  if (!videoStorageEnabled()) return null;
+  try {
+    const meta = await head(`${runPrefix(runId)}${artifact.name}_${artifact.id}.json`);
+    const response = await fetch(meta.url);
+    if (!response.ok) throw new Error('Stored result unavailable');
+    const result: StoredArtifact = await response.json();
+    if (result.storageVersion !== 1 || result.runId !== runId || result.artifact.id !== artifact.id)
+      throw new Error('Stored artifact identity mismatch');
+    return result;
+  } catch (error) {
+    if (error instanceof BlobNotFoundError) return null;
+    throw error;
+  }
+}
+async function immutable(
+  path: string,
+  body: Blob | string,
+  contentType: string,
+  signal: AbortSignal,
+) {
+  try {
+    return await put(path, body, {
+      access: 'public',
+      addRandomSuffix: false,
+      allowOverwrite: false,
+      contentType,
+      cacheControlMaxAge: 31536000,
+      abortSignal: signal,
+    });
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('already exists')) return head(path);
+    throw error;
+  }
+}
+export async function storeVideoArtifact(
+  runId: string,
+  artifact: CIArtifact,
+  zip: Blob,
+  signal: AbortSignal,
+): Promise<StoredArtifact> {
+  const sources: StoredSource[] = [];
+  const uploads = new Map<string, Promise<{ url: string; downloadUrl: string }>>();
+  for (const source of await archiveSources(zip, artifact)) {
+    const bundle = await loadBundle(source.read);
+    const assets: StoredSource['assets'] = [];
+    const files = [...bundle.files];
+    for (let start = 0; start < files.length; start += 8) {
+      await Promise.all(
+        files.slice(start, start + 8).map(async ([path, body]) => {
+          const hash = bundle.checksums.get(path) ?? (await sha256(body));
+          const key = `${PREFIX}/objects/${hash}/${path.split('/').at(-1)}`;
+          let upload = uploads.get(key);
+          if (!upload) {
+            upload = immutable(
+              key,
+              body,
+              path.endsWith('.mp4') ? 'video/mp4' : 'application/octet-stream',
+              signal,
+            );
+            uploads.set(key, upload);
+          }
+          const saved = await upload;
+          assets.push([path, { url: saved.url, downloadUrl: saved.downloadUrl }]);
+        }),
+      );
+    }
+    const texts: StoredSource['texts'] = [];
+    for (const [path, body] of bundle.files) {
+      if (path === 'report/index.html' || (!bundle.result && path.endsWith('/telemetry.jsonl')))
+        texts.push([path, await body.text()]);
+    }
+    sources.push({
+      id: source.id,
+      documents: [...bundle.documents],
+      checksums: [...bundle.checksums],
+      assets,
+      texts,
+    });
+  }
+  const result: StoredArtifact = {
+    storageVersion: 1,
+    runId,
+    artifact: { ...artifact, stored: true },
+    sources,
+  };
+  // Publish the index last so readers cannot observe partially uploaded bundles.
+  await immutable(
+    `${runPrefix(runId)}${artifact.name}_${artifact.id}.json`,
+    JSON.stringify(result),
+    'application/json',
+    signal,
+  );
+  return result;
+}

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -65,8 +65,11 @@ async function immutable(
       abortSignal: signal,
     });
   } catch (error) {
-    if (error instanceof Error && error.message.includes('already exists')) return head(path);
-    throw error;
+    try {
+      return await head(path);
+    } catch {
+      throw error;
+    }
   }
 }
 export async function storeVideoArtifact(
@@ -82,7 +85,7 @@ export async function storeVideoArtifact(
     const assets: StoredSource['assets'] = [];
     const files = [...bundle.files];
     for (let start = 0; start < files.length; start += 8) {
-      await Promise.all(
+      const batch = await Promise.allSettled(
         files.slice(start, start + 8).map(async ([path, body]) => {
           const hash = bundle.checksums.get(path) ?? (await sha256(body));
           const key = `${PREFIX}/objects/${hash}/${path.split('/').at(-1)}`;
@@ -100,6 +103,8 @@ export async function storeVideoArtifact(
           assets.push([path, { url: saved.url, downloadUrl: saved.downloadUrl }]);
         }),
       );
+      const failed = batch.find((result) => result.status === 'rejected');
+      if (failed) throw failed.reason;
     }
     const texts: StoredSource['texts'] = [];
     for (const [path, body] of bundle.files) {


### PR DESCRIPTION
## Summary

The H3 viewer currently downloads and verifies the full CI ZIP before showing results. This puts the videos and the important measurements too far down the page and makes every new visit wait for the archive.

Show one baseline/candidate comparison table beside both players, with observed deltas, execution/calibration status, and release qualification visible. Keep prompt, generation settings, full measurements, provenance, and original downloads available below.

Persist checksum-verified artifacts in the existing Vercel Blob store, outside the dashboard cache purge prefix. Publish an immutable run index only after every file is uploaded; load result data separately and stream MP4s directly. A scheduled/manual workflow prepares new CI results, and the existing ZIP path remains available when storage is unavailable. The hidden production feature flag is unchanged.

## Testing

- Full workspace unit suite passed; H3 component suite: 6/6; local smoke: 113 integration tests passed plus the component smoke suite.
- Typecheck, lint, formatting, typography, and local GitHub Actions audit passed.
- Chinese copy reviewed with the repository Claude review workflow and a manual fidelity/naturalness pass.
- Real eight-second H200 output: localhost baseline/candidate playback, nonzero audio, report playback, original result download, and Chinese mobile layout passed.
- Object publication order, checksum rejection, retry/dedup behavior, stored-result loading, and survival after GitHub artifact expiry tested.
- Final head `76ecd34eec109503524a2d9134c3cc5c4c449343`: all eight Chrome/Firefox E2E shards, component/unit tests, static checks, Claude review, and Bugbot passed; no unresolved review threads.
- Merged as `650e79a793c07d683edf3aff2863bb0a084ee58f`. Production deployment succeeded. [Media publication run](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34308202217) persisted both executions in the real export.
- [Production demo](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829): both videos/audio, original report playback, Chinese mobile layout, HTTP 206 byte ranges, and checksum-identical result download passed.
- One fresh-browser observation before/after publication: first playable video 11.208 s → 5.039 s. The 22.1 MB CI archive request was replaced by 123 KB of metadata plus independently streamed media; this is a single-session observation, not a statistical performance claim.

## 中文说明

H3 页面现在把基线、候选视频与关键指标放在一起，直接展示观测差异、执行和校准状态及发布资格。提示词、生成设置、完整测量结果、来源信息和原始文件仍可展开查看。

复用现有 Vercel Blob 存储，按内容校验和持久化保存 CI 产物。所有文件上传完成后才发布不可变的运行索引，页面分别加载结果数据和视频。定时或手动工作流提前准备产物；对象存储不可用时仍可读取 CI ZIP。生产环境的隐藏功能开关保持原样。

完整单元测试、本地浏览器 smoke 测试及 6 项 H3 组件测试通过；真实 H200 视频的画面、音频、报告、下载链接和中文移动端布局已在本地验证。生产对象存储发布、视频与音频播放、原始报告、中文移动端布局、HTTP 206 分段读取及下载校验和均已验证。最终提交的八组 Chrome/Firefox E2E 测试及两项自动审核全部通过。单次全新浏览器会话的首个可播放画面等待时间由 11.208 秒降至 5.039 秒；该记录不代表统计意义上的性能结论。
