### PR TITLE
[H3 Video]: overlap result loading and fix responsive controls / 并行加载结果并修复响应式控件

### DIFF
--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -42,6 +42,49 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.contains('a', '#10 · completed / failure').should('be.visible');
     cy.get('video').should('not.exist');
   });
+  it('starts shared-artifact loading before run metadata finishes', () => {
+    let releaseRun: (() => void) | undefined;
+    let mediaStarted = false;
+    cy.window().then((win) =>
+      win.history.replaceState(null, '', `${win.location.pathname}?run=30&artifact=40`),
+    );
+    cy.intercept(
+      'GET',
+      '/api/video-runs?run=30',
+      (req) =>
+        new Promise<void>((resolve) => {
+          releaseRun = () => {
+            req.reply({
+              run: run(30, 'success'),
+              artifacts: [{ id: 40, name: 'h3-results-30-1', expired: false, size_in_bytes: 100 }],
+            });
+            resolve();
+          };
+        }),
+    );
+    cy.intercept('GET', '**/api/video-runs*format=media', (req) => {
+      mediaStarted = true;
+      req.reply({ statusCode: 204 });
+    });
+    cy.intercept('GET', '/api/video-runs?run=30&artifact=40', {
+      statusCode: 502,
+      body: { error: 'Synthetic ZIP fallback' },
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.wrap(null).should(() => {
+      expect(mediaStarted).to.equal(true);
+      expect(releaseRun).to.be.a('function');
+    });
+    cy.then(() => releaseRun?.());
+    cy.get('[data-testid="video-ci-runs"] [role="alert"]').should(
+      'contain',
+      'Synthetic ZIP fallback',
+    );
+  });
   it('keeps the shared run selected when browsing the first catalog page', () => {
     cy.window().then((win) =>
       win.history.replaceState(null, '', `${win.location.pathname}?run=30`),
@@ -172,7 +215,7 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       .and('contain', '120')
       .and('contain', '-20%');
     cy.contains('tr', 'Valid clips').should('contain', '36').and('contain', '72');
-    cy.contains('tr', 'Mean GPU power').should('contain', 'Unavailable');
+    cy.contains('tr', 'Mean GPU power').find('[aria-label="Unavailable"]').should('have.length', 2);
   });
   it('reports expiration without downloading or substituting another artifact', () => {
     cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });

--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -149,6 +149,23 @@ describe('H3 CI artifact access', () => {
     const data = await result.json();
     expect(data.artifacts).toEqual([artifact]);
   });
+  it('loads independent run lookups together after checking repository visibility', async () => {
+    let finishRun!: (response: Response) => void;
+    fetchMock
+      .mockResolvedValueOnce(response({ private: false }))
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          finishRun = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(response({ artifacts: [] }));
+    const pending = GET(request('?run=10'));
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    expect(String(fetchMock.mock.calls[2][0])).toContain('/actions/runs/10/artifacts');
+    finishRun(response({ id: 10 }));
+    const result = await pending;
+    expect(result.status).toBe(200);
+  });
   it('rejects invalid identifiers without making requests', async () => {
     const result5 = await GET(request('?run=../secret'));
     expect(result5.status).toBe(400);

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -110,17 +110,19 @@ export async function GET(request: NextRequest) {
       return new Response(stream, { headers: { ...headers, 'Content-Type': 'application/zip' } });
     }
     if (runId) {
-      const runResponse = await github(`/actions/runs/${runId}`);
+      const [runResponse, artifactsResponse, saved] = await Promise.all([
+        github(`/actions/runs/${runId}`),
+        github(`/actions/runs/${runId}/artifacts?per_page=100`),
+        storedArtifacts(runId).catch(() => []),
+      ]);
       if (!runResponse.ok)
         return NextResponse.json(
           { error: 'CI run unavailable' },
           { status: runResponse.status, headers },
         );
-      const artifactsResponse = await github(`/actions/runs/${runId}/artifacts?per_page=100`);
       if (!artifactsResponse.ok)
         return NextResponse.json({ error: 'Cannot list CI artifacts' }, { status: 502, headers });
       const data = await artifactsResponse.json();
-      const saved = await storedArtifacts(runId).catch(() => []);
       const artifacts = (data.artifacts ?? []).filter((a: { name: string }) => {
         const match = artifactName.exec(a.name);
         return match?.groups?.runId === runId;

--- a/packages/app/src/components/video-benchmark/ResultSummary.tsx
+++ b/packages/app/src/components/video-benchmark/ResultSummary.tsx
@@ -68,10 +68,11 @@ const STRINGS = {
     counts: '计数仅涵盖正式测量时段，不含 warmup。',
   },
 };
+const fmt = (v: number | null, digits = 2) =>
+  v === null ? '—' : v.toLocaleString('en-US', { maximumFractionDigits: digits });
+
 export default function ResultSummary({ bundle: b, stored }: { bundle: Bundle; stored: boolean }) {
   const s = STRINGS[useLocale()];
-  const fmt = (v: number | null, digits = 2) =>
-    v === null ? s.missing : v.toLocaleString('en-US', { maximumFractionDigits: digits });
   const roleMetric = (role: string, metric: string): number | null => {
     const summary = at(b.report, 'roles', role, 'summary');
     const phase = at(b.result, 'roles', role, 'power', 'phases', 'measurement');
@@ -173,9 +174,9 @@ export default function ResultSummary({ bundle: b, stored }: { bundle: Bundle; s
           <thead>
             <tr className="border-b text-xs text-muted-foreground">
               <th className="pb-2 font-normal">{s.metric}</th>
-              <th className="pb-2 text-right font-normal">{s.baseline}</th>
-              <th className="pb-2 text-right font-normal">{s.candidate}</th>
-              <th className="pb-2 text-right font-normal">{s.change}</th>
+              <th className="pb-2 pl-3 text-right font-normal">{s.baseline}</th>
+              <th className="pb-2 pl-3 text-right font-normal">{s.candidate}</th>
+              <th className="pb-2 pl-3 text-right font-normal">{s.change}</th>
             </tr>
           </thead>
           <tbody>
@@ -196,16 +197,23 @@ export default function ResultSummary({ bundle: b, stored }: { bundle: Bundle; s
                   : null;
               return (
                 <tr key={metric} className="border-b last:border-0">
-                  <th className="py-2 pr-3 font-normal">
+                  <th className="py-2 pr-3 font-normal" title={hint || undefined}>
                     <span className="font-medium">{label}</span>
-                    <span className="mt-0.5 block text-xs text-muted-foreground">
-                      {unit}
-                      {hint ? ` · ${hint}` : ''}
-                    </span>
+                    <span className="mt-0.5 block text-xs text-muted-foreground">{unit}</span>
                   </th>
-                  <td className="px-2 py-2 text-right">{fmt(baseline)}</td>
-                  <td className="px-2 py-2 text-right font-semibold">{fmt(candidate)}</td>
-                  <td className="pl-2 py-2 text-right text-muted-foreground">
+                  <td
+                    className="whitespace-nowrap px-2 py-2 text-right"
+                    aria-label={baseline === null ? s.missing : undefined}
+                  >
+                    {baseline === null ? '—' : fmt(baseline)}
+                  </td>
+                  <td
+                    className="whitespace-nowrap px-2 py-2 text-right font-semibold"
+                    aria-label={candidate === null ? s.missing : undefined}
+                  >
+                    {candidate === null ? '—' : fmt(candidate)}
+                  </td>
+                  <td className="whitespace-nowrap pl-2 py-2 text-right text-muted-foreground">
                     {change === null ? '—' : `${change > 0 ? '+' : ''}${fmt(change)}%`}
                   </td>
                 </tr>
@@ -221,7 +229,11 @@ export default function ResultSummary({ bundle: b, stored }: { bundle: Bundle; s
         </table>
       </div>
       <p className="text-xs text-muted-foreground">
-        {s.counts} {s.noClaim}
+        — = {s.missing}
+        <br />
+        {s.counts}
+        <br />
+        {s.noClaim}
       </p>
       <details>
         <summary className="cursor-pointer text-xs text-muted-foreground">

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -550,7 +550,7 @@ export default function VideoBenchmark({
       )}
       {b && loaded && (
         <>
-          <div className="grid items-start gap-5 xl:grid-cols-[minmax(320px,0.9fr)_minmax(0,1.8fr)]">
+          <div className="grid items-start gap-5 xl:grid-cols-[minmax(400px,1fr)_minmax(0,1.5fr)]">
             <ResultSummary bundle={b} stored={Boolean(published)} />
             <div className="min-w-0 space-y-4">
               <div className="grid gap-5 lg:grid-cols-2">
@@ -593,9 +593,7 @@ export default function VideoBenchmark({
                               if (node) node.textContent = s.mediaError;
                             }}
                           />
-                          <p role="status" className="text-xs text-muted-foreground">
-                            {s.audio}
-                          </p>
+                          <p role="status" className="text-xs text-destructive empty:hidden" />
                           <a
                             download={`${role}-${slot}.mp4`}
                             className="text-sm text-primary underline"
@@ -678,18 +676,18 @@ export default function VideoBenchmark({
                   );
                 })}
               </div>
+              <p className="text-xs text-muted-foreground">{s.audio}</p>
               {slots.length > 0 && (
                 <Card className="gap-4">
                   <label className="text-sm font-medium">
                     {s.slot}
                     <select
-                      className="mt-2 block w-full max-w-full rounded-md sm:ml-3 sm:mt-0 sm:inline-block sm:w-auto border bg-background p-2"
+                      className="mt-2 block h-11 w-full min-w-0 max-w-full rounded-md border border-input bg-background px-3 text-sm font-normal"
                       value={slot}
                       onChange={(e) => setSlot(e.target.value)}
                     >
                       {slots.map((o) => (
                         <option key={text(at(o, 'slot_id'))} value={text(at(o, 'slot_id'))}>
-                          {text(at(o, 'case_id'))} ·{' '}
                           {at(o, 'phase') === 'warmup' ? s.warmup : s.measured} ·{' '}
                           {text(at(o, 'slot_id'))}
                         </option>
@@ -697,6 +695,9 @@ export default function VideoBenchmark({
                     </select>
                   </label>
                   <div>
+                    <p className="mb-2 break-words text-sm font-medium">
+                      {text(at(clip, 'case_id'))}
+                    </p>
                     <span className="text-xs text-muted-foreground">
                       {s.prompt} · {s.seed} {fmt(at(clip, 'seed'))}
                     </span>

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Heading } from '@/components/ui/heading';
+import { Skeleton } from '@/components/ui/skeleton';
 import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
@@ -61,8 +62,8 @@ const STRINGS = {
   },
 };
 
-async function json(url: string) {
-  const response = await fetch(url, { cache: 'no-store' });
+async function json(url: string, signal?: AbortSignal) {
+  const response = await fetch(url, { signal, cache: 'no-store' });
   const data = await response.json();
   if (!response.ok) throw new Error(data.error ?? `HTTP ${response.status}`);
   return data;
@@ -100,20 +101,22 @@ export default function VideoCIRuns() {
     selectedRun: CIRun,
     selected: CIArtifact,
     current: number,
+    controller: AbortController,
     source?: string,
+    prepared?: Promise<Response | null>,
   ) {
     setArtifact(selected);
     setSources([]);
-    const controller = new AbortController();
-    download.current = controller;
     setProgress(s.preparing);
     const endpoint = `/api/video-runs?run=${selectedRun.id}&artifact=${selected.id}`;
     let found:
       | { id: string; read?: (path: string) => Promise<Blob>; stored?: StoredSource }[]
       | null = null;
     try {
-      const response = await fetch(`${endpoint}&format=media`, { signal: controller.signal });
-      if (response.ok && response.status !== 204) {
+      const response = prepared
+        ? await prepared
+        : await fetch(`${endpoint}&format=media`, { signal: controller.signal });
+      if (response?.ok && response.status !== 204) {
         const saved: StoredArtifact = await response.json();
         if (
           saved.storageVersion !== 1 ||
@@ -170,9 +173,18 @@ export default function VideoCIRuns() {
     setSources([]);
     setArtifact(null);
     setArtifacts([]);
+    const controller = new AbortController();
+    download.current = controller;
+    const prepared = artifactId
+      ? fetch(
+          `/api/video-runs?run=${encodeURIComponent(runId)}&artifact=${encodeURIComponent(artifactId)}&format=media`,
+          { signal: controller.signal },
+        ).catch(() => null)
+      : undefined;
     try {
       const data: { run: CIRun; artifacts: CIArtifact[] } = await json(
         `/api/video-runs?run=${encodeURIComponent(runId)}`,
+        controller.signal,
       );
       if (current !== request.current) return;
       setRun(data.run);
@@ -188,7 +200,15 @@ export default function VideoCIRuns() {
               b.id - a.id,
           )[0];
       share(data.run.id);
-      if (selected) await loadArtifact(data.run, selected, current, source ?? undefined);
+      if (selected)
+        await loadArtifact(
+          data.run,
+          selected,
+          current,
+          controller,
+          source ?? undefined,
+          String(selected.id) === artifactId ? prepared : undefined,
+        );
     } catch (error) {
       if (current === request.current)
         setError(error instanceof Error ? error.message : String(error));
@@ -248,18 +268,40 @@ export default function VideoCIRuns() {
   }, []);
   const selectedSource = sources.find((item) => item.id === sourceId);
   return (
-    <div className="mx-auto min-w-0 w-full max-w-7xl space-y-4 py-6" data-testid="video-ci-runs">
-      <Card className="gap-3 p-4">
-        <Heading as="h1" level="section">
-          {s.title}
-        </Heading>
+    <div className="mx-auto min-w-0 w-full max-w-7xl space-y-4 py-2" data-testid="video-ci-runs">
+      <Card className="min-w-0 gap-3 p-4">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
+          <Heading as="h1" level="section">
+            {s.title}
+          </Heading>
+          <div className="flex w-full min-w-0 flex-wrap gap-2 sm:w-auto">
+            <Button
+              className="min-w-0 flex-1 sm:flex-none"
+              variant="outline"
+              disabled={loading}
+              onClick={() => void list(1, true)}
+            >
+              {s.refresh}
+            </Button>
+            {nextPage && (
+              <Button
+                className="min-w-0 flex-1 sm:flex-none"
+                variant="outline"
+                disabled={loading}
+                onClick={() => void list(nextPage)}
+              >
+                {nextPage === 1 ? s.browse : s.older}
+              </Button>
+            )}
+          </div>
+        </div>
 
-        <div className="flex flex-wrap items-end gap-3">
-          <label className="min-w-0 flex-1 space-y-1 text-sm">
+        <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+          <label className="min-w-0 space-y-2 text-sm font-medium">
             {s.select}
             <select
               aria-label={s.select}
-              className="w-full rounded border bg-background p-2"
+              className="h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm font-normal focus-visible:ring-2 focus-visible:ring-ring"
               value={run?.id ?? ''}
               onChange={(e) => void selectRun(e.target.value)}
             >
@@ -268,17 +310,17 @@ export default function VideoCIRuns() {
               </option>
               {runs.map((r) => (
                 <option key={r.id} value={r.id}>
-                  #{r.id} · {r.name} · {r.conclusion ?? r.status}
+                  #{r.id} · {r.conclusion ?? r.status}
                 </option>
               ))}
             </select>
           </label>
           {sources.length > 1 && (
-            <label className="w-full min-w-0 space-y-1 text-sm sm:w-52">
+            <label className="min-w-0 space-y-2 text-sm font-medium">
               {s.source}
               <select
                 aria-label={s.source}
-                className="w-full rounded border bg-background p-2"
+                className="h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm font-normal focus-visible:ring-2 focus-visible:ring-ring"
                 value={sourceId}
                 onChange={(e) => {
                   setSourceId(e.target.value);
@@ -293,15 +335,15 @@ export default function VideoCIRuns() {
               </select>
             </label>
           )}
-          <Button variant="outline" disabled={loading} onClick={() => void list(1, true)}>
-            {s.refresh}
-          </Button>
-          {nextPage && (
-            <Button variant="outline" disabled={loading} onClick={() => void list(nextPage)}>
-              {nextPage === 1 ? s.browse : s.older}
-            </Button>
-          )}
         </div>
+        {run && (
+          <p
+            className="min-w-0 break-words text-sm text-muted-foreground"
+            data-testid="selected-run-title"
+          >
+            {run.name}
+          </p>
+        )}
         {runs.length === 0 && !loading && <p>{s.empty}</p>}
         <details>
           <summary className="cursor-pointer text-sm text-muted-foreground">{s.advanced}</summary>
@@ -342,7 +384,7 @@ export default function VideoCIRuns() {
               {s.artifact}
               <select
                 aria-label={s.artifact}
-                className="mt-1 w-full rounded border bg-background p-2"
+                className="mt-2 h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm"
                 value={artifact?.id ?? ''}
                 onChange={(e) => run && void selectRun(String(run.id), e.target.value)}
               >
@@ -386,6 +428,13 @@ export default function VideoCIRuns() {
         )}
         {run && !loading && !loadError && artifacts.length === 0 && <p>{s.none}</p>}
       </Card>
+      {loading && !selectedSource && (
+        <div className="grid gap-4 lg:grid-cols-3" aria-hidden="true">
+          <Skeleton className="h-72" />
+          <Skeleton className="aspect-video" />
+          <Skeleton className="aspect-video" />
+        </div>
+      )}
       {selectedSource && (
         <VideoBenchmark
           key={`${artifact?.id}-${sourceId}`}

--- a/packages/app/src/components/video-benchmark/archive.ts
+++ b/packages/app/src/components/video-benchmark/archive.ts
@@ -7,6 +7,7 @@ export interface CIArtifact {
   size_in_bytes: number;
   digest?: string;
   stored?: boolean;
+  indexUrl?: string;
 }
 export interface CIRun {
   id: number;

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
       zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
     },
-    sourceSha256: 'f78f1d5fb6af0989adede754e8a25a34c8b945ae8b502f5453bb39b2de286eba',
+    sourceSha256: '73966329a42f1e3a62ca3c6215cc5e9786d9217d2d47ee512e9a81270b2ba17c',
   },
   {
     source: 'src/app/api/unofficial-run/route.ts',

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -1,9 +1,9 @@
 import { createHash } from 'node:crypto';
 import { strToU8, zipSync } from 'fflate';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { head, put } from '@vercel/blob';
 import type * as BlobSdk from '@vercel/blob';
-import { storeVideoArtifact } from './video-storage';
+import { readStoredArtifact, storeVideoArtifact } from './video-storage';
 import { storedBundle } from '@/components/video-benchmark/stored';
 
 vi.mock('@vercel/blob', async (original) => ({
@@ -53,7 +53,22 @@ beforeEach(() => {
   vi.mocked(put).mockClear();
   vi.mocked(head).mockClear();
 });
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
 describe('persistent H3 media', () => {
+  it('reads the trusted listed index URL without a redundant HEAD request', async () => {
+    vi.stubEnv('BLOB_READ_WRITE_TOKEN', 'synthetic-test-token');
+    const indexUrl =
+      'https://test.public.blob.vercel-storage.com/h3-video-media/v1/runs/10/h3-video-10-1_20.json';
+    const saved = { storageVersion: 1, runId: '10', artifact, sources: [] };
+    const fetcher = vi.spyOn(globalThis, 'fetch').mockResolvedValue(Response.json(saved));
+    expect(await readStoredArtifact('10', { ...artifact, indexUrl })).toEqual(saved);
+    expect(head).not.toHaveBeenCalled();
+    expect(fetcher).toHaveBeenCalledWith(indexUrl, { signal: expect.any(AbortSignal) });
+  });
+
   it('publishes verified files before the index and restores metadata without media bytes', async () => {
     const result = await storeVideoArtifact(
       '10',

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -25,6 +25,7 @@ export async function storedArtifacts(runId: string): Promise<CIArtifact[]> {
           expired: false,
           size_in_bytes: 0,
           stored: true,
+          indexUrl: blob.url,
         });
     }
     cursor = page.hasMore ? page.cursor : undefined;
@@ -37,8 +38,12 @@ export async function readStoredArtifact(
 ): Promise<StoredArtifact | null> {
   if (!videoStorageEnabled()) return null;
   try {
-    const meta = await head(`${runPrefix(runId)}${artifact.name}_${artifact.id}.json`);
-    const response = await fetch(meta.url);
+    let url = artifact.indexUrl;
+    if (!url) {
+      const meta = await head(`${runPrefix(runId)}${artifact.name}_${artifact.id}.json`);
+      url = meta.url;
+    }
+    const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
     if (!response.ok) throw new Error('Stored result unavailable');
     const result: StoredArtifact = await response.json();
     if (result.storageVersion !== 1 || result.runId !== runId || result.artifact.id !== artifact.id)


### PR DESCRIPTION
## Summary

Deep links currently wait for run metadata before requesting stored results. Start those reads together, overlap independent server lookups, and reuse the stored index URL to avoid an extra storage request.

Move actions above responsive run selectors, show the complete run title beneath them, and give the comparison table more room. Add loading placeholders and a clear unavailable-value legend. The existing hidden feature flag and persistent media storage remain in use.

## Testing

- Full workspace unit tests, typecheck, lint, formatting and typography checks passed.
- Seven video viewer component tests passed, including concurrent loading and ZIP fallback.
- Real stored CI data and playable videos verified in eight English/Chinese layouts (390–1440 px), without page overflow.
- CI: all eight Chrome/Firefox E2E shards, component tests, typecheck/unit tests and lint/format passed. Local smoke passed 46 component tests and 111 integration tests; Chinese blog checks encountered development-only timing/missing-content failures, while the corresponding production-build CI suite passed.
- Production verification passed: baseline/candidate playback with audible audio, seeking, HTTP 206 media ranges, original report playback, exact result download SHA256, source switching, reload, real failed/missing runs, and eight EN/ZH responsive layouts.
- Three fresh Chrome sessions per version, same production CI link: median results 2.558 → 1.897 s; both videos ready 3.209 → 2.559 s (20.3% faster). Playback ranges: before 3.196–3.596 s, after 2.117–4.728 s. The first post-deployment observation was slowest; this small network-dependent sample is not a latency guarantee.
- Deployed commit: `7f24980a8c37908ba353d720932933ff0983697d`. [Live benchmark](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829).

## 中文说明

目前分享链接会先读取运行信息，再请求已存储的结果。此更改让两者并行加载，同时并行处理服务端的独立查询，并复用存储索引地址，减少一次存储请求。

操作按钮移至选择器上方，完整运行标题单独换行显示，为指标表格增加空间，并补充加载占位和无数据说明。继续使用现有隐藏功能开关和持久化媒体存储。

完整单元测试、类型检查、lint、格式和排版检查通过；7 项视频组件测试通过。使用真实 CI 数据验证了中英文共 8 种布局。CI 的 8 个 Chrome/Firefox E2E 分片、组件测试、单元测试及静态检查全部通过。本地冒烟测试的 46 项组件测试和 111 项集成测试通过；中文博客检查在开发模式下出现计时或内容缺失问题，对应的生产构建 CI 测试已通过。生产环境的双侧视频与音频播放、拖动定位、HTTP 206 分段读取、原始报告、下载文件 SHA256、切换运行、刷新、真实失败和缺失运行，以及 8 种中英文布局均已验证。相同生产链接在每版各 3 个全新 Chrome 会话中，结果显示时间中位数从 2.558 秒降至 1.897 秒，双侧视频就绪时间从 3.209 秒降至 2.559 秒，约快 20.3%。更新后的范围为 2.117–4.728 秒，首次部署后的访问最慢；小样本受网络影响，不代表延迟保证。
