### PR TITLE
[H3 Video]: use styled selector menus and compact run controls / 统一选择菜单样式并收紧运行控件布局

### DIFF
--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -1,6 +1,7 @@
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
 import ResultPower from '@/components/video-benchmark/ResultPower';
+import VideoSelect from '@/components/video-benchmark/VideoSelect';
 
 const run = (id: number, conclusion: string) => ({
   id,
@@ -17,6 +18,35 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
   beforeEach(() => {
     cy.intercept('GET', '**/api/video-runs*format=media', { statusCode: 204 });
     cy.window().then((win) => win.history.replaceState(null, '', win.location.pathname));
+  });
+  it('keeps an open long-label menu within mobile bounds and supports keyboard selection', () => {
+    cy.viewport(390, 844);
+    const change = cy.stub().as('selection');
+    cy.mount(
+      <div className="p-4">
+        <VideoSelect
+          label="Synthetic artifact"
+          value="first"
+          onValueChange={change}
+          options={[
+            { value: 'first', label: `h3-results-${'1234567890'.repeat(12)}` },
+            { value: 'second', label: 'Second synthetic artifact' },
+          ]}
+        />
+      </div>,
+    );
+    cy.get('[role="combobox"]').focus().type('{enter}');
+    cy.get('[role="listbox"]')
+      .should('be.visible')
+      .then(($menu) => {
+        const rect = $menu[0].getBoundingClientRect();
+        expect(rect.left).to.be.at.least(0);
+        expect(rect.right).to.be.at.most(390);
+      });
+    cy.get('[role="option"]').last().focus().type('{enter}');
+    cy.get('@selection').should('have.been.calledWith', 'second');
+    cy.get('[role="listbox"]').should('not.exist');
+    cy.get('[role="combobox"]').should('have.focus');
   });
   it('loads the newest run automatically and switches to a failed run without inventing media', () => {
     cy.intercept('GET', '/api/video-runs?page=1', {
@@ -36,7 +66,8 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     );
     cy.wait('@latest');
     cy.contains('No result artifact for this run yet').should('be.visible');
-    cy.get('select[aria-label="CI run"]').select('10');
+    cy.get('[role="combobox"][aria-label="CI run"]').click();
+    cy.contains('[role="option"]', '#10 · failure').click();
     cy.wait('@failed');
     cy.contains('summary', 'Run details and artifact selection').click();
     cy.contains('a', '#10 · completed / failure').should('be.visible');
@@ -101,14 +132,13 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       </PathnameContext.Provider>,
     );
     cy.wait('@shared');
-    cy.get('select[aria-label="CI run"]').should('have.value', '30');
+    cy.get('[role="combobox"][aria-label="CI run"]').should('contain.text', '#30');
     cy.contains('button', 'Older runs').should('not.exist');
     cy.contains('button', 'Browse CI runs').click();
     cy.wait('@browse');
-    cy.get('select[aria-label="CI run"]')
-      .should('have.value', '30')
-      .find('option[value="20"]')
-      .should('exist');
+    cy.get('[role="combobox"][aria-label="CI run"]').should('contain.text', '#30').click();
+    cy.contains('[role="option"]', '#20 · success').should('be.visible');
+    cy.get('[role="listbox"]').type('{esc}');
     cy.contains('button', 'Older runs').should('be.visible');
     cy.location('search').should('contain', 'run=30');
   });
@@ -144,10 +174,13 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.get('input[aria-label="GitHub run ID"]').type('30');
     cy.contains('button', 'Open run').click();
     cy.wait('@direct');
-    cy.get('select[aria-label="Result artifact"]').should('have.value', '40');
+    cy.get('[role="combobox"][aria-label="Result artifact"]').should(
+      'contain.text',
+      'h3-results-30-1',
+    );
     cy.then(() => releaseList?.());
     cy.wait('@catalog');
-    cy.get('select[aria-label="CI run"]').should('have.value', '30');
+    cy.get('[role="combobox"][aria-label="CI run"]').should('contain.text', '#30');
     cy.get('[role="status"]').should('be.visible');
     cy.wait('@zip');
     cy.get('[role="alert"]').should('contain', 'Synthetic download failure');
@@ -230,7 +263,10 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     );
     cy.get('[role="alert"]').should('contain', 'Expired');
     cy.get('video').should('not.exist');
-    cy.get('select[aria-label="Result artifact"]').should('have.value', '40');
+    cy.get('[role="combobox"][aria-label="Result artifact"]').should(
+      'contain.text',
+      'h3-results-30-1',
+    );
   });
   it('withholds invalid generation measurements and separates warmup energy', () => {
     const power = {
@@ -263,7 +299,8 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
     cy.get('[data-testid="result-power"]')
       .should('contain', 'unbracketed')
       .and('not.contain', '999');
-    cy.get('select[aria-label="Power window"]').select('warmup');
+    cy.get('[role="combobox"][aria-label="Power window"]').click();
+    cy.contains('[role="option"]', 'Warmup').click();
     cy.get('[data-testid="result-power"]')
       .should('contain', '0.2')
       .and('contain', 'GPU-fixture')

--- a/packages/app/src/components/video-benchmark/ResultPower.tsx
+++ b/packages/app/src/components/video-benchmark/ResultPower.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import VideoSelect from './VideoSelect';
 import { Card } from '@/components/ui/card';
 import { Heading } from '@/components/ui/heading';
 import { useLocale } from '@/lib/use-locale';
@@ -83,21 +84,17 @@ export default function ResultPower({ result }: { result: Json }) {
       <Card className="gap-4" data-testid="result-power">
         <Heading>{s.title}</Heading>
         <p className="text-sm text-muted-foreground">{s.note}</p>
-        <label className="text-sm">
-          {s.phase}
-          <select
-            aria-label={s.phase}
-            className="ml-3 rounded border bg-background p-2"
+        <div className="w-full max-w-xs">
+          <VideoSelect
+            label={s.phase}
             value={phase}
-            onChange={(e) => setPhase(e.target.value as typeof phase)}
-          >
-            {(['startup', 'warmup', 'measurement'] as const).map((value) => (
-              <option key={value} value={value}>
-                {s[value]}
-              </option>
-            ))}
-          </select>
-        </label>
+            onValueChange={(value) => setPhase(value as typeof phase)}
+            options={(['startup', 'warmup', 'measurement'] as const).map((value) => ({
+              value,
+              label: s[value],
+            }))}
+          />
+        </div>
         <div className="grid gap-6 lg:grid-cols-2">
           {ROLES.map((role) => {
             const power = at(result, 'roles', role, 'power');

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -8,6 +8,7 @@ import { Heading } from '@/components/ui/heading';
 import { useLocale } from '@/lib/use-locale';
 import { track } from '@/lib/analytics';
 import ResultPower from './ResultPower';
+import VideoSelect from './VideoSelect';
 import { storedBundle, type StoredSource } from './stored';
 import ResultSummary from './ResultSummary';
 import {
@@ -679,21 +680,15 @@ export default function VideoBenchmark({
               <p className="text-xs text-muted-foreground">{s.audio}</p>
               {slots.length > 0 && (
                 <Card className="gap-4">
-                  <label className="text-sm font-medium">
-                    {s.slot}
-                    <select
-                      className="mt-2 block h-11 w-full min-w-0 max-w-full rounded-md border border-input bg-background px-3 text-sm font-normal"
-                      value={slot}
-                      onChange={(e) => setSlot(e.target.value)}
-                    >
-                      {slots.map((o) => (
-                        <option key={text(at(o, 'slot_id'))} value={text(at(o, 'slot_id'))}>
-                          {at(o, 'phase') === 'warmup' ? s.warmup : s.measured} ·{' '}
-                          {text(at(o, 'slot_id'))}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
+                  <VideoSelect
+                    label={s.slot}
+                    value={slot}
+                    onValueChange={setSlot}
+                    options={slots.map((o) => ({
+                      value: text(at(o, 'slot_id')),
+                      label: `${at(o, 'phase') === 'warmup' ? s.warmup : s.measured} · ${text(at(o, 'slot_id'))}`,
+                    }))}
+                  />
                   <div>
                     <p className="mb-2 break-words text-sm font-medium">
                       {text(at(clip, 'case_id'))}

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
+import VideoSelect from './VideoSelect';
 import type { StoredArtifact, StoredSource } from './stored';
 import { archiveSources, type CIArtifact, type CIRun } from './archive';
 
@@ -269,7 +270,7 @@ export default function VideoCIRuns() {
   const selectedSource = sources.find((item) => item.id === sourceId);
   return (
     <div className="mx-auto min-w-0 w-full max-w-7xl space-y-4 py-2" data-testid="video-ci-runs">
-      <Card className="min-w-0 gap-3 p-4">
+      <Card className="min-w-0 gap-3 p-4 md:p-4">
         <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
           <Heading as="h1" level="section">
             {s.title}
@@ -296,57 +297,39 @@ export default function VideoCIRuns() {
           </div>
         </div>
 
-        <div className="grid min-w-0 gap-4 sm:grid-cols-2">
-          <label className="min-w-0 space-y-2 text-sm font-medium">
-            {s.select}
-            <select
-              aria-label={s.select}
-              className="h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm font-normal focus-visible:ring-2 focus-visible:ring-ring"
-              value={run?.id ?? ''}
-              onChange={(e) => void selectRun(e.target.value)}
-            >
-              <option value="" disabled>
-                —
-              </option>
-              {runs.map((r) => (
-                <option key={r.id} value={r.id}>
-                  #{r.id} · {r.conclusion ?? r.status}
-                </option>
-              ))}
-            </select>
-          </label>
+        <div className="grid min-w-0 gap-3 md:grid-cols-2">
+          <VideoSelect
+            label={s.select}
+            value={run ? String(run.id) : ''}
+            onValueChange={(value) => void selectRun(value)}
+            options={runs.map((r) => ({
+              value: String(r.id),
+              label: `#${r.id} · ${r.conclusion ?? r.status}`,
+            }))}
+          />
           {sources.length > 1 && (
-            <label className="min-w-0 space-y-2 text-sm font-medium">
-              {s.source}
-              <select
-                aria-label={s.source}
-                className="h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm font-normal focus-visible:ring-2 focus-visible:ring-ring"
-                value={sourceId}
-                onChange={(e) => {
-                  setSourceId(e.target.value);
-                  if (run && artifact) share(run.id, artifact.id, e.target.value);
-                }}
-              >
-                {sources.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    #{item.id}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <VideoSelect
+              label={s.source}
+              value={sourceId}
+              onValueChange={(value) => {
+                setSourceId(value);
+                if (run && artifact) share(run.id, artifact.id, value);
+              }}
+              options={sources.map((item) => ({ value: item.id, label: `#${item.id}` }))}
+            />
           )}
         </div>
         {run && (
           <p
-            className="min-w-0 break-words text-sm text-muted-foreground"
+            className="min-w-0 break-words text-xs text-muted-foreground"
             data-testid="selected-run-title"
           >
             {run.name}
           </p>
         )}
         {runs.length === 0 && !loading && <p>{s.empty}</p>}
-        <details>
-          <summary className="cursor-pointer text-sm text-muted-foreground">{s.advanced}</summary>
+        <details className="border-t border-border/40 pt-3 [&[open]>form]:mb-3 [&[open]>a]:mb-3 [&[open]>a]:block">
+          <summary className="cursor-pointer text-xs text-muted-foreground">{s.advanced}</summary>
           <p className="my-3 text-xs text-muted-foreground">{s.note}</p>
           <form
             className="flex flex-wrap gap-2"
@@ -380,25 +363,17 @@ export default function VideoCIRuns() {
             </a>
           )}
           {artifacts.length > 0 && (
-            <label className="text-sm">
-              {s.artifact}
-              <select
-                aria-label={s.artifact}
-                className="mt-2 h-11 w-full min-w-0 rounded-md border border-input bg-background px-3 text-sm"
-                value={artifact?.id ?? ''}
-                onChange={(e) => run && void selectRun(String(run.id), e.target.value)}
-              >
-                <option value="" disabled>
-                  —
-                </option>
-                {artifacts.map((a) => (
-                  <option key={a.id} value={a.id}>
-                    {a.name}
-                    {a.expired ? ` · ${s.expired}` : ''}
-                  </option>
-                ))}
-              </select>
-            </label>
+            <VideoSelect
+              label={s.artifact}
+              value={artifact ? String(artifact.id) : ''}
+              onValueChange={(value) => {
+                if (run) void selectRun(String(run.id), value);
+              }}
+              options={artifacts.map((a) => ({
+                value: String(a.id),
+                label: `${a.name}${a.expired ? ` · ${s.expired}` : ''}`,
+              }))}
+            />
           )}
         </details>
         {loading && (

--- a/packages/app/src/components/video-benchmark/VideoSelect.tsx
+++ b/packages/app/src/components/video-benchmark/VideoSelect.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useId } from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+export default function VideoSelect({
+  label,
+  value,
+  onValueChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  const id = useId();
+  return (
+    <div className="flex min-w-0 flex-col gap-1.5">
+      <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
+        {label}
+      </label>
+      <Select value={value} onValueChange={onValueChange} disabled={options.length === 0}>
+        <SelectTrigger
+          id={id}
+          aria-label={label}
+          className="w-full focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <SelectValue placeholder="—" />
+        </SelectTrigger>
+        <SelectContent className="w-(--radix-select-trigger-width) max-w-[calc(100vw-2rem)]">
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              className="whitespace-normal break-all"
+            >
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Opening an H3 selector currently shows the operating system's native popup, which does not match the dashboard and looks oversized when zoomed. Reuse the existing styled Select for run, source, artifact, clip and power-window controls. Keep menus within the viewport, retain keyboard focus, and reduce header padding with a separate advanced-controls row.

## Testing

- Eight H3 component tests passed, including mobile long-label menus, keyboard selection, focus restoration and existing loading/error paths.
- Real CI media verified locally across eight EN/ZH open-menu layouts (390–1440 px), all five menus, and source switching. Local UI used the production API; fixtures are confined to component tests.
- Typecheck, lint, formatting and typography checks passed. Full workspace unit tests passed. CI passed all eight Chrome/Firefox E2E shards, component tests, typecheck/unit tests, lint/format, and Bugbot.
- Production verification on `ef1b951eb22aa54a5ecf10028e79d2b5812fd212` passed: all five selectors, eight EN/ZH open-menu layouts, keyboard focus, real media loading and source switching. [Live benchmark](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829).
- Existing hidden feature flag, media storage and loading behavior unchanged. No new UI copy or dependencies.

## 中文说明

H3 选择器展开时使用操作系统原生菜单，与仪表板样式不一致，在放大页面时显得过大。此更改复用现有 Select 组件，统一运行、来源、产物、视频和功率时段选择器，限制菜单宽度并保留键盘焦点；同时减少顶部留白，将高级控件单独分隔。

8 项 H3 组件测试通过，覆盖移动端长标签、键盘选择、焦点恢复和既有加载及错误路径。使用真实 CI 媒体验证了 390–1440 px 的 8 种中英文展开菜单布局、全部五类菜单和来源切换；本地页面连接生产 API，合成数据仅用于组件测试。类型、lint、格式及排版检查通过，完整工作区单元测试通过。CI 的 8 个 Chrome/Firefox E2E 分片、组件测试、类型及单元测试、lint 和格式检查，以及 Bugbot 均通过。未改变隐藏功能开关、媒体存储或加载逻辑，也未新增界面文案或依赖。

生产部署提交 `ef1b951e` 已验证：五类选择器、8 种中英文展开菜单布局、键盘焦点、真实媒体加载及来源切换均通过。
