### PR TITLE
[H3 Video]: add workload-matched serving tradeoff charts / 新增按工作负载匹配的视频服务权衡图

### DIFF
--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -116,6 +116,59 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       'Synthetic ZIP fallback',
     );
   });
+  it('keeps navigation and bundle validation errors visible on an empty tradeoff link', () => {
+    cy.window().then((win) =>
+      win.history.replaceState(
+        null,
+        '',
+        `${win.location.pathname}?run=30&artifact=40&view=tradeoff`,
+      ),
+    );
+    cy.intercept('GET', '/api/video-runs?run=30', {
+      run: run(30, 'success'),
+      artifacts: [{ id: 40, name: 'h3-results-30-1', expired: false, size_in_bytes: 100 }],
+    });
+    cy.intercept('GET', '**/api/video-runs*format=media', {
+      storageVersion: 1,
+      runId: '30',
+      artifact: { id: 40, name: 'h3-results-30-1', expired: false, size_in_bytes: 100 },
+      sources: [
+        {
+          id: '30',
+          assets: [],
+          checksums: [['manifest.json', 'synthetic']],
+          texts: [['gpu/supervisor/baseline/telemetry.jsonl', 'broken JSON']],
+          documents: [
+            ['manifest.json', { run_id: '30' }],
+            [
+              'gpu/gpu-job.json',
+              {
+                roles: {
+                  baseline: {
+                    telemetry_summary: {
+                      qualified: true,
+                      requested_interval_seconds: 1,
+                      gpu_identity: [{ uuid: 'GPU-synthetic' }],
+                    },
+                  },
+                },
+              },
+            ],
+          ],
+        },
+      ],
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('button', 'Videos & result').should('be.visible');
+    cy.contains('[role="alert"]', 'JSON').should('be.visible');
+    cy.contains('button', 'Videos & result').click();
+    cy.get('[data-testid="video-tradeoff"]').should('not.be.visible');
+    cy.contains('[role="alert"]', 'JSON').should('be.visible');
+  });
   it('keeps the shared run selected when browsing the first catalog page', () => {
     cy.window().then((win) =>
       win.history.replaceState(null, '', `${win.location.pathname}?run=30`),

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -1,6 +1,7 @@
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 import VideoTradeoff from '@/components/video-benchmark/VideoTradeoff';
 import type { TradeoffRun } from '@/components/video-benchmark/tradeoff';
+import type { Json } from '@/components/video-benchmark/bundle';
 
 const role = {
   metrics: {
@@ -83,5 +84,24 @@ describe('Video tradeoff chart (synthetic fixtures)', () => {
     );
     cy.contains('Open a CI result').should('be.visible');
     cy.get('circle.point').should('not.exist');
+  });
+  it('distinguishes groups with the same short label and exposes their full workload', () => {
+    const other = structuredClone(run);
+    other.bundle.manifestSha256 = 'different-synthetic-workload';
+    const result = other.bundle.result as {
+      workload: { plan: { generation: Record<string, Json> } };
+    };
+    result.workload.plan.generation.guidance_scale = 4;
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[run, other]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[role="combobox"][aria-label="Matched workload"]').click();
+    cy.get('[role="option"]').should('have.length', 2);
+    cy.contains('[role="option"]', '#1').should('be.visible');
+    cy.contains('[role="option"]', '#2').click();
+    cy.contains('summary', 'Matched workload').click();
+    cy.get('[data-testid="tradeoff-detail"] pre').first().should('contain', '"guidance_scale": 4');
   });
 });

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -1,0 +1,87 @@
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import VideoTradeoff from '@/components/video-benchmark/VideoTradeoff';
+import type { TradeoffRun } from '@/components/video-benchmark/tradeoff';
+
+const role = {
+  metrics: {
+    status: 'valid',
+    measurement: { wall_seconds: 3600, concurrency: 2 },
+    completion: { valid: 10, completed: 10, scheduled: 11, failed: 1 },
+  },
+  records: Array.from({ length: 10 }, (_, i) => ({
+    phase: 'measurement',
+    status: 'succeeded',
+    submit_to_media_seconds: i + 1,
+    media: { valid: true, video: { duration_seconds: 8 } },
+  })),
+};
+const run: TradeoffRun = {
+  exportRun: '20',
+  artifact: '30',
+  bundle: {
+    manifest: { run_id: '10' },
+    manifestSha256: 'synthetic-only',
+    result: {
+      schema_version: '1.0.0',
+      bundle_type: 'h3_benchmark_result',
+      workload: {
+        plan: {
+          model_id: 'synthetic',
+          model_revision: 'synthetic-revision',
+          generation: {
+            width: 1280,
+            height: 720,
+            fps: 24,
+            duration_seconds: 8,
+            num_inference_steps: 50,
+          },
+          cases: [{ prompt: 'Synthetic test only', seed: 1 }],
+        },
+      },
+      hardware: {
+        reserved_gpu_count: 8,
+        selected_gpu_count: 4,
+        devices: [{ name: 'Synthetic GPU' }],
+      },
+      roles: { baseline: role, candidate: role },
+    },
+  },
+};
+
+describe('Video tradeoff chart (synthetic fixtures)', () => {
+  it('withholds missing cost, plots measured axes and drills into the original run', () => {
+    const open = cy.stub().as('open');
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[run]} onOpen={open} />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('No points qualify for these axes yet.').should('be.visible');
+    cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();
+    cy.contains('[role="option"]', 'Valid clips / allocated GPU-hour').click();
+    cy.get('[data-testid="video-tradeoff-chart"] circle.point').should('have.length', 2);
+    cy.contains('td', '1.25').should('be.visible');
+    cy.contains('dd', '8 / 4').should('be.visible');
+    cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();
+    cy.contains('[role="option"]', 'Valid clips / USD').click();
+    cy.get('input[aria-label="Whole deployment cost (USD/hour)"]').type('2');
+    cy.get('circle.point').should('not.exist');
+    cy.get('input[aria-label="Cost source and included items"]').type(
+      'Synthetic complete-deployment cost',
+    );
+    cy.get('input[aria-label="Cost as of"]').type('2026-09-09');
+    cy.get('circle.point').should('have.length', 1);
+    cy.contains('td', '5').should('be.visible');
+    cy.contains('button', 'Open videos and full result').click();
+    cy.get('@open').should('have.been.calledOnce');
+  });
+  it('shows an empty state without inventing fixture results', () => {
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('Open a CI result').should('be.visible');
+    cy.get('circle.point').should('not.exist');
+  });
+});

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -279,10 +279,12 @@ export default function VideoBenchmark({
   reader,
   published,
   onLoaded,
+  onError,
 }: {
   reader?: (path: string) => Promise<Blob>;
   published?: StoredSource;
   onLoaded?: (bundle: Bundle) => void;
+  onError?: () => void;
 }) {
   const s = STRINGS[useLocale()];
   const [loaded, setLoaded] = useState<Loaded | null>(null);
@@ -404,8 +406,10 @@ export default function VideoBenchmark({
       track('video_bundle_loaded');
     } catch (error) {
       urls.forEach(URL.revokeObjectURL);
-      if (current === generation.current)
+      if (current === generation.current) {
         setError(error instanceof Error ? error.message : String(error));
+        onError?.();
+      }
     } finally {
       if (current === generation.current) setLoading(false);
     }

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -278,9 +278,11 @@ const field = (label: string, value: string, change: (value: string) => void, ty
 export default function VideoBenchmark({
   reader,
   published,
+  onLoaded,
 }: {
   reader?: (path: string) => Promise<Blob>;
   published?: StoredSource;
+  onLoaded?: (bundle: Bundle) => void;
 }) {
   const s = STRINGS[useLocale()];
   const [loaded, setLoaded] = useState<Loaded | null>(null);
@@ -431,6 +433,9 @@ export default function VideoBenchmark({
   }, [reader, published]);
 
   const b = loaded?.bundle;
+  useEffect(() => {
+    if (b) onLoaded?.(b);
+  }, [b, onLoaded]);
   const participating = rows(
     at(b?.job, 'roles', 'baseline', 'telemetry_summary', 'gpu_identity'),
   ).length;

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Heading } from '@/components/ui/heading';
@@ -9,12 +9,18 @@ import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
 import VideoSelect from './VideoSelect';
-import type { StoredArtifact, StoredSource } from './stored';
+import VideoTradeoff from './VideoTradeoff';
+import type { TradeoffRun } from './tradeoff';
+import { storedBundle, type StoredArtifact, type StoredSource } from './stored';
+import type { Bundle } from './bundle';
 import { archiveSources, type CIArtifact, type CIRun } from './archive';
 
 const STRINGS = {
   en: {
     title: 'H3 video benchmark',
+    results: 'Videos & result',
+    tradeoffs: 'Hardware tradeoffs',
+    view: 'Benchmark view',
     preparing: 'Loading results and preparing media. The first publication of a run takes longer.',
     downloading: 'Downloading CI archive',
     advanced: 'Run details and artifact selection',
@@ -39,6 +45,9 @@ const STRINGS = {
   },
   zh: {
     title: 'H3 视频基准测试',
+    results: '视频与结果',
+    tradeoffs: '硬件延迟与效率权衡',
+    view: '基准测试视图',
     preparing: '正在加载结果并准备媒体。首次发布该运行的产物需要更多时间。',
     downloading: '正在下载 CI 产物',
     advanced: '运行详情与产物选择',
@@ -72,7 +81,9 @@ async function json(url: string, signal?: AbortSignal) {
 
 function share(runId: number, artifactId?: number, source?: string) {
   const url = new URL(location.href);
+  const view = url.searchParams.get('view');
   url.search = '';
+  if (view === 'tradeoff') url.searchParams.set('view', view);
   url.searchParams.set('run', String(runId));
   if (artifactId) url.searchParams.set('artifact', String(artifactId));
   if (source) url.searchParams.set('source', source);
@@ -95,6 +106,39 @@ export default function VideoCIRuns() {
   const [progress, setProgress] = useState('');
   const [direct, setDirect] = useState('');
   const [manual, setManual] = useState(false);
+  const [view, setView] = useState('results');
+  const [compared, setCompared] = useState<TradeoffRun[]>([]);
+  const changeView = (value: string) => {
+    setView(value);
+    const url = new URL(location.href);
+    if (value === 'tradeoff') url.searchParams.set('view', 'tradeoff');
+    else url.searchParams.delete('view');
+    history.replaceState(null, '', url);
+  };
+  const collect = useCallback((bundle: Bundle, exportRun: string, artifactId: string) => {
+    setCompared((old) =>
+      old.some((item) => item.bundle.manifestSha256 === bundle.manifestSha256)
+        ? old
+        : [
+            ...old,
+            {
+              bundle: {
+                manifest: bundle.manifest,
+                result: bundle.result,
+                manifestSha256: bundle.manifestSha256,
+              },
+              exportRun,
+              artifact: artifactId,
+            },
+          ],
+    );
+  }, []);
+  const collectLoaded = useCallback(
+    (bundle: Bundle) => {
+      if (run && artifact) collect(bundle, String(run.id), String(artifact.id));
+    },
+    [run, artifact, collect],
+  );
   const request = useRef(0);
   const download = useRef<AbortController | null>(null);
 
@@ -156,6 +200,10 @@ export default function VideoCIRuns() {
       found = await archiveSources(new Blob(chunks), selected);
     }
     if (current !== request.current) return;
+    for (const item of found) {
+      if (item.stored)
+        collect(storedBundle(item.stored), String(selectedRun.id), String(selected.id));
+    }
     const chosen =
       found.find((item) => item.id === source) ??
       found.toSorted((a, b) => Number(b.id) - Number(a.id))[0];
@@ -258,6 +306,7 @@ export default function VideoCIRuns() {
   }
   useEffect(() => {
     const params = new URLSearchParams(location.search);
+    if (params.get('view') === 'tradeoff') setView('tradeoff');
     const directRun = params.get('run');
     if (directRun) void selectRun(directRun, params.get('artifact'), params.get('source'));
     else void list(1, true);
@@ -410,12 +459,43 @@ export default function VideoCIRuns() {
           <Skeleton className="aspect-video" />
         </div>
       )}
-      {selectedSource && (
-        <VideoBenchmark
-          key={`${artifact?.id}-${sourceId}`}
-          reader={selectedSource.read}
-          published={selectedSource.stored}
+      {compared.length > 0 && (
+        <div className="flex flex-wrap gap-2" role="group" aria-label={s.view}>
+          <Button
+            variant={view === 'results' ? 'default' : 'outline'}
+            aria-pressed={view === 'results'}
+            onClick={() => changeView('results')}
+          >
+            {s.results}
+          </Button>
+          <Button
+            variant={view === 'tradeoff' ? 'default' : 'outline'}
+            aria-pressed={view === 'tradeoff'}
+            onClick={() => changeView('tradeoff')}
+          >
+            {s.tradeoffs}
+          </Button>
+        </div>
+      )}
+      <div hidden={view !== 'tradeoff'}>
+        <VideoTradeoff
+          runs={compared}
+          sourceId={sourceId}
+          onOpen={(point) => {
+            changeView('results');
+            void selectRun(point.run.exportRun, point.run.artifact, point.sourceId);
+          }}
         />
+      </div>
+      {selectedSource && (
+        <div hidden={view !== 'results'}>
+          <VideoBenchmark
+            key={`${artifact?.id}-${sourceId}`}
+            reader={selectedSource.read}
+            published={selectedSource.stored}
+            onLoaded={collectLoaded}
+          />
+        </div>
       )}
       <details onToggle={(event) => setManual(event.currentTarget.open)}>
         <summary className="cursor-pointer text-sm text-muted-foreground">{s.local}</summary>

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -459,24 +459,22 @@ export default function VideoCIRuns() {
           <Skeleton className="aspect-video" />
         </div>
       )}
-      {compared.length > 0 && (
-        <div className="flex flex-wrap gap-2" role="group" aria-label={s.view}>
-          <Button
-            variant={view === 'results' ? 'default' : 'outline'}
-            aria-pressed={view === 'results'}
-            onClick={() => changeView('results')}
-          >
-            {s.results}
-          </Button>
-          <Button
-            variant={view === 'tradeoff' ? 'default' : 'outline'}
-            aria-pressed={view === 'tradeoff'}
-            onClick={() => changeView('tradeoff')}
-          >
-            {s.tradeoffs}
-          </Button>
-        </div>
-      )}
+      <div className="flex flex-wrap gap-2" role="group" aria-label={s.view}>
+        <Button
+          variant={view === 'results' ? 'default' : 'outline'}
+          aria-pressed={view === 'results'}
+          onClick={() => changeView('results')}
+        >
+          {s.results}
+        </Button>
+        <Button
+          variant={view === 'tradeoff' ? 'default' : 'outline'}
+          aria-pressed={view === 'tradeoff'}
+          onClick={() => changeView('tradeoff')}
+        >
+          {s.tradeoffs}
+        </Button>
+      </div>
       <div hidden={view !== 'tradeoff'}>
         <VideoTradeoff
           runs={compared}
@@ -494,6 +492,7 @@ export default function VideoCIRuns() {
             reader={selectedSource.read}
             published={selectedSource.stored}
             onLoaded={collectLoaded}
+            onError={() => changeView('results')}
           />
         </div>
       )}

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -92,7 +92,7 @@ const STRINGS = {
     title: '视频服务延迟与效率权衡',
     subtitle: '在相同工作负载下比较硬件与运行时配置。',
     scope: '打开的运行会加入当前浏览器会话；刷新页面将清除对比集合与成本假设。',
-    workload: '匹配工作负载',
+    workload: '匹配的工作负载',
     x: '延迟轴 · 越低越好',
     y: '效率轴 · 越高越好',
     p90: 'P90 客户端就绪延迟（秒）',
@@ -100,7 +100,7 @@ const STRINGS = {
     dollar: '有效视频数 / USD',
     clipsGpu: '有效视频数 / 已分配 GPU 小时',
     secondsGpu: '生成视频秒数 / 已分配 GPU 小时',
-    energy: '有效视频数 / GPU 板卡千瓦时',
+    energy: '有效视频数 / GPU 板卡 kWh',
     latencyNote:
       '客户端就绪指从提交到媒体完整下载完成，包含轮询等待，不包含本地验证。P90 使用最近秩法，此处至少需要 10 个完整的有效请求样本；这只是显示门槛，不代表尾延迟估计具有统计可靠性。失败请求仍保留在计数中。',
     throughputNote:
@@ -130,7 +130,7 @@ const STRINGS = {
     concurrency: '客户端并发数',
     allocated: '已分配 / 参与计算的 GPU 数',
     window: '测量时段（秒）',
-    power: '参与计算板卡平均总功率（W）',
+    power: '参与计算板卡总功率均值（W）',
     energyClip: '每有效视频 GPU 板卡能耗（J）',
     powerWindow: '生成阶段功率测量窗口（秒）',
     batch: '副本布局 / 实际批次大小 / 施加的请求到达率',

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -214,7 +214,10 @@ export default function VideoTradeoff({
             label={s.workload}
             value={group ?? ''}
             onValueChange={setWorkload}
-            options={groups.map(([value, name]) => ({ value, label: name }))}
+            options={groups.map(([value, name], index) => ({
+              value,
+              label: `#${index + 1} · ${name}`,
+            }))}
           />
           <div className="grid gap-3 md:grid-cols-2">
             <VideoSelect
@@ -402,6 +405,12 @@ export default function VideoTradeoff({
                     {s.ci}
                   </a>
                 </div>
+                <details>
+                  <summary className="cursor-pointer text-xs">{s.workload}</summary>
+                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all text-xs">
+                    {JSON.stringify(active.workload, null, 2)}
+                  </pre>
+                </details>
                 <details>
                   <summary className="cursor-pointer text-xs">{s.server}</summary>
                   <pre className="mt-2 whitespace-pre-wrap break-all text-xs">

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -1,0 +1,447 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { schemeTableau10 } from 'd3';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Heading } from '@/components/ui/heading';
+import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import { useLocale } from '@/lib/use-locale';
+import { escapeHtml } from '@/lib/utils';
+import { track } from '@/lib/analytics';
+import VideoSelect from './VideoSelect';
+import {
+  tradeoffPoints,
+  latencyValue,
+  efficiencyValue,
+  type TradeoffRun,
+  type TradeoffPoint,
+  type LatencyAxis,
+  type EfficiencyAxis,
+  type DeploymentCost,
+} from './tradeoff';
+
+const STRINGS = {
+  en: {
+    title: 'Video serving tradeoffs',
+    subtitle: 'Compare identical workloads across hardware and runtime configurations.',
+    scope:
+      'Runs you open are collected in this browser session. Reloading clears the comparison and cost assumptions.',
+    workload: 'Matched workload',
+    x: 'Latency axis · lower is better',
+    y: 'Efficiency axis · higher is better',
+    p90: 'P90 client-ready latency (s)',
+    median: 'Median client-ready latency (s)',
+    dollar: 'Valid clips / USD',
+    clipsGpu: 'Valid clips / allocated GPU-hour',
+    secondsGpu: 'Video seconds / allocated GPU-hour',
+    energy: 'Valid clips / GPU-board kWh',
+    latencyNote:
+      'Client-ready = submission to fully downloaded media, including polling; local validation is excluded from latency. P90 uses nearest rank and requires at least 10 complete valid-request samples here. This display floor does not establish tail-latency reliability. Failed requests stay visible in the counts.',
+    throughputNote:
+      'Throughput uses the recorded measurement wall window, including failed attempts and client overhead. Serial runs are diagnostics, not demonstrated serving capacity. GPU-hour views charge every reserved GPU, including idle allocations.',
+    qualityNote:
+      'Matching fixes the model revision, generation settings and prompt/seed/input workload. Precision, caching and runtime changes still require fidelity review. Technical validity does not establish perceptual quality; uncalibrated points are not qualified winners.',
+    energyNote:
+      'Energy efficiency uses the backend generation-window joules per valid clip. It covers participating GPU boards only, excluding other allocated GPUs, CPUs, cooling and storage. It is not facility efficiency.',
+    noPoints: 'No points qualify for these axes yet.',
+    diagnose: 'Inspect available serial results',
+    empty: 'Open a CI result to add its baseline and candidate.',
+    requirements:
+      'Choose median latency for single-request diagnostics. Cost plots also need a full deployment cost, source and date for each point.',
+    point: 'Point',
+    baseline: 'Baseline',
+    candidate: 'Candidate',
+    samples: 'Valid latency samples',
+    counts: 'Valid / completed / scheduled',
+    failed: 'Failed or invalid',
+    status: 'Plot status',
+    missing: 'Missing workload, latency samples, GPU count, energy or cost assumptions',
+    plotted: 'Shown',
+    details: 'Selected point',
+    hardware: 'Hardware',
+    runtime: 'Runtime revision',
+    model: 'Model revision',
+    concurrency: 'Client concurrency',
+    allocated: 'Allocated / participating GPUs',
+    window: 'Measurement window (s)',
+    power: 'Mean total participating-board power (W)',
+    energyClip: 'GPU-board energy / valid clip (J)',
+    powerWindow: 'Generation power window (s)',
+    batch: 'Replica layout / actual batch size / offered arrival rate',
+    queue: 'Queue delay / server-ready timestamp / deadline attainment',
+    unavailable: 'Unavailable in this result contract',
+    server: 'Recorded server settings',
+    fidelity: 'Recorded fidelity and policy',
+    open: 'Open videos and full result',
+    ci: 'Exact CI run',
+    costTitle: 'Cost assumptions for this point',
+    hourly: 'Whole deployment cost (USD/hour)',
+    source: 'Cost source and included items',
+    date: 'Cost as of',
+    costNote:
+      'Enter the total hourly cost of the complete deployment, including all billed GPUs and host, power, cooling, network, storage and operating costs. Clips/USD = valid clips/hour ÷ deployment USD/hour. User-entered estimates; no selling price or profit is implied.',
+    methods: 'Measurement definitions and comparison limits',
+    diagnostic: 'Serial diagnostics · serving capacity not measured',
+    observed: 'Observed points; no fitted frontier or hardware winner.',
+    controls:
+      'Shift+scroll to zoom; drag to pan; double-click to reset. Select a point or table row for details.',
+  },
+  zh: {
+    title: '视频服务延迟与效率权衡',
+    subtitle: '在相同工作负载下比较硬件与运行时配置。',
+    scope: '打开的运行会加入当前浏览器会话；刷新页面将清除对比集合与成本假设。',
+    workload: '匹配工作负载',
+    x: '延迟轴 · 越低越好',
+    y: '效率轴 · 越高越好',
+    p90: 'P90 客户端就绪延迟（秒）',
+    median: '客户端就绪延迟中位数（秒）',
+    dollar: '有效视频数 / USD',
+    clipsGpu: '有效视频数 / 已分配 GPU 小时',
+    secondsGpu: '生成视频秒数 / 已分配 GPU 小时',
+    energy: '有效视频数 / GPU 板卡千瓦时',
+    latencyNote:
+      '客户端就绪指从提交到媒体完整下载完成，包含轮询等待，不包含本地验证。P90 使用最近秩法，此处至少需要 10 个完整的有效请求样本；这只是显示门槛，不代表尾延迟估计具有统计可靠性。失败请求仍保留在计数中。',
+    throughputNote:
+      '吞吐量使用记录的测量墙钟时间窗口，包含失败尝试与客户端开销。串行运行仅用于诊断，不能证明服务容量。GPU 小时指标计入所有预留 GPU，包括空闲的已分配资源。',
+    qualityNote:
+      '工作负载匹配固定了模型版本、生成设置以及 prompt、seed 和输入工作负载。精度、缓存和运行时变更仍需审查保真度。技术有效性不代表感知质量；未校准的点不能作为合格的性能优胜结果。',
+    energyNote:
+      '能效使用后端生成时段内每个有效视频的 GPU 板卡能耗（焦耳），仅涵盖参与计算的 GPU 板卡，不含其他已分配 GPU、CPU、散热或存储，也不代表设施能效。',
+    noPoints: '当前坐标轴下尚无满足条件的数据点。',
+    diagnose: '查看已有串行诊断结果',
+    empty: '打开 CI 结果即可加入基线与候选数据。',
+    requirements:
+      '单请求诊断请选择延迟中位数。成本视图还需要为每个点填写完整部署成本、来源与日期。',
+    point: '数据点',
+    baseline: '基线',
+    candidate: '候选',
+    samples: '有效延迟样本数',
+    counts: '有效 / 已完成 / 已调度',
+    failed: '失败或无效',
+    status: '绘图状态',
+    missing: '缺少工作负载、延迟样本、GPU 数量、能耗或成本假设',
+    plotted: '已显示',
+    details: '所选数据点',
+    hardware: '硬件',
+    runtime: '运行时版本',
+    model: '模型版本',
+    concurrency: '客户端并发数',
+    allocated: '已分配 / 参与计算的 GPU 数',
+    window: '测量时段（秒）',
+    power: '参与计算板卡平均总功率（W）',
+    energyClip: '每有效视频 GPU 板卡能耗（J）',
+    powerWindow: '生成阶段功率测量窗口（秒）',
+    batch: '副本布局 / 实际批次大小 / 施加的请求到达率',
+    queue: '排队延迟 / 服务端就绪时间戳 / 时限达标情况',
+    unavailable: '此结果格式未提供',
+    server: '已记录的服务端设置',
+    fidelity: '已记录的保真度与判定策略',
+    open: '打开视频与完整结果',
+    ci: '对应的 CI 运行',
+    costTitle: '此数据点的成本假设',
+    hourly: '完整部署成本（USD/小时）',
+    source: '成本来源及涵盖项目',
+    date: '成本基准日期',
+    costNote:
+      '填写完整部署每小时总成本，涵盖所有计费 GPU、主机、电力、散热、网络、存储和运营成本。有效视频数/USD = 每小时有效视频数 ÷ 部署每小时 USD 成本。数值为用户填写的估算，不代表售价或利润。',
+    methods: '测量定义与比较限制',
+    diagnostic: '串行诊断 · 尚未测量服务容量',
+    observed: '仅显示观测点，不拟合前沿曲线，也不判定硬件优胜者。',
+    controls: 'Shift+滚轮缩放，拖动平移，双击重置。选择数据点或表格行查看详情。',
+  },
+};
+const fmt = (n: number | null) =>
+  n === null ? '—' : n.toLocaleString('en-US', { maximumFractionDigits: 3 });
+const blankCost: DeploymentCost = { hourly: '', source: '', date: '' };
+
+export default function VideoTradeoff({
+  runs,
+  onOpen,
+  sourceId,
+}: {
+  runs: TradeoffRun[];
+  onOpen: (point: TradeoffPoint) => void;
+  sourceId?: string;
+}) {
+  const s = STRINGS[useLocale()];
+  const all = useMemo(() => runs.flatMap(tradeoffPoints), [runs]);
+  const [workload, setWorkload] = useState('');
+  const [xAxis, setX] = useState<LatencyAxis>('p90');
+  const [yAxis, setY] = useState<EfficiencyAxis>('dollar');
+  const [selected, setSelected] = useState('');
+  const [costs, setCosts] = useState<Record<string, DeploymentCost>>({});
+  const groups = [...new Map(all.map((p) => [p.group, p.workloadLabel])).entries()];
+  const group = groups.some(([key]) => key === workload)
+    ? workload
+    : (all.find((p) => p.sourceId === sourceId)?.group ?? groups[0]?.[0]);
+  const points = all.filter((p) => p.group === group);
+  const active = points.find((p) => p.id === selected) ?? points[0];
+  const plotted = points.flatMap((p) => {
+    const x = latencyValue(p, xAxis),
+      y = efficiencyValue(p, yAxis, costs[p.id]);
+    return p.completeWorkload && x !== null && y !== null ? [{ ...p, x, y }] : [];
+  });
+  const hardware = [...new Set(all.map((p) => p.hardware))].sort();
+  const color = (p: TradeoffPoint) =>
+    schemeTableau10[hardware.indexOf(p.hardware) % schemeTableau10.length];
+  const label = (p: TradeoffPoint) => `${p.hardware || '—'} · ${s[p.role]} · #${p.sourceId}`;
+  const choose = (p: TradeoffPoint) => {
+    setSelected(p.id);
+    track('video_tradeoff_point_selected', { role: p.role, source: p.sourceId });
+  };
+  const cost = active ? (costs[active.id] ?? blankCost) : blankCost;
+  const costInput = (key: keyof DeploymentCost, value: string) => {
+    if (active)
+      setCosts((old) => ({
+        ...old,
+        [active.id]: { ...(old[active.id] ?? blankCost), [key]: value },
+      }));
+  };
+  return (
+    <Card className="ph-no-capture ph-mask gap-4" data-testid="video-tradeoff">
+      <div>
+        <Heading level="section">{s.title}</Heading>
+        <p className="mt-1 text-sm text-muted-foreground">{s.subtitle}</p>
+      </div>
+      <p className="text-xs text-muted-foreground">{s.scope}</p>
+      {all.length === 0 ? (
+        <p role="status">{s.empty}</p>
+      ) : (
+        <>
+          <VideoSelect
+            label={s.workload}
+            value={group ?? ''}
+            onValueChange={setWorkload}
+            options={groups.map(([value, name]) => ({ value, label: name }))}
+          />
+          <div className="grid gap-3 md:grid-cols-2">
+            <VideoSelect
+              label={s.x}
+              value={xAxis}
+              onValueChange={(value) => setX(value as LatencyAxis)}
+              options={(['p90', 'median'] as const).map((value) => ({ value, label: s[value] }))}
+            />
+            <VideoSelect
+              label={s.y}
+              value={yAxis}
+              onValueChange={(value) => setY(value as EfficiencyAxis)}
+              options={(['dollar', 'clipsGpu', 'secondsGpu', 'energy'] as const).map((value) => ({
+                value,
+                label: s[value],
+              }))}
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs">
+            {[...new Set(points.map((p) => p.hardware))].filter(Boolean).map((name) => (
+              <span key={name} className="inline-flex items-center gap-2">
+                <span
+                  className="size-2.5 rounded-full"
+                  style={{
+                    backgroundColor:
+                      schemeTableau10[hardware.indexOf(name) % schemeTableau10.length],
+                  }}
+                />
+                {name}
+              </span>
+            ))}
+            {points.every((p) => p.concurrency === 1) && (
+              <span className="rounded-md border px-2 py-1 text-muted-foreground">
+                {s.diagnostic}
+              </span>
+            )}
+          </div>
+          {plotted.length > 0 ? (
+            <D3Chart
+              chartId="video-tradeoff"
+              testId="video-tradeoff-chart"
+              data={plotted}
+              height={420}
+              margin={{ top: 20, right: 24, bottom: 80, left: 85 }}
+              watermark="logo"
+              transitionDuration={0}
+              xScale={{
+                type: 'linear',
+                domain: [0, Math.max(...plotted.map((p) => p.x)) * 1.12 || 1],
+                nice: true,
+              }}
+              yScale={{
+                type: 'linear',
+                domain: [0, Math.max(...plotted.map((p) => p.y)) * 1.15 || 1],
+                nice: true,
+              }}
+              xAxis={{ label: s[xAxis], tickCount: 5 }}
+              yAxis={{ label: s[yAxis], tickCount: 5 }}
+              layers={[
+                {
+                  type: 'point',
+                  data: plotted,
+                  config: {
+                    getCx: () => 0,
+                    getCy: () => 0,
+                    getX: (p) => p.x,
+                    getY: (p) => p.y,
+                    getColor: color,
+                    getRadius: () => 6,
+                    stroke: 'var(--foreground)',
+                    strokeWidth: 1,
+                    keyFn: (p) => p.id,
+                  },
+                },
+              ]}
+              tooltip={{
+                rulerType: 'none',
+                content: (p) =>
+                  `<div class="p-3 text-sm">${escapeHtml(label(p))}<br/>${escapeHtml(s[xAxis])}: ${fmt(p.x)}<br/>${escapeHtml(s[yAxis])}: ${fmt(p.y)}<br/>n=${p.latencies.length}</div>`,
+                onPointClick: choose,
+              }}
+              zoom={{ enabled: true, axes: 'both', scaleExtent: [1, 20] }}
+              instructions={s.controls}
+              caption={<p className="text-xs text-muted-foreground">{s.observed}</p>}
+            />
+          ) : (
+            <div
+              className="flex min-h-48 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-6 text-center"
+              role="status"
+            >
+              <p className="font-medium">{s.noPoints}</p>
+              <p className="max-w-2xl text-sm text-muted-foreground">{s.requirements}</p>
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setX('median');
+                  setY('clipsGpu');
+                }}
+              >
+                {s.diagnose}
+              </Button>
+            </div>
+          )}
+          <details className="space-y-2 text-xs text-muted-foreground">
+            <summary className="cursor-pointer font-medium">{s.methods}</summary>
+            <p>{s.latencyNote}</p>
+            <p>{s.throughputNote}</p>
+            <p>{s.qualityNote}</p>
+            {yAxis === 'energy' && <p>{s.energyNote}</p>}
+          </details>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="p-2">{s.point}</th>
+                  <th className="p-2">{s.samples}</th>
+                  <th className="p-2">{s.counts}</th>
+                  <th className="p-2">{s.failed}</th>
+                  <th className="p-2">{s[xAxis]}</th>
+                  <th className="p-2">{s[yAxis]}</th>
+                  <th className="p-2">{s.status}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {points.map((p) => (
+                  <tr key={p.id} className={`border-b ${active?.id === p.id ? 'bg-muted/50' : ''}`}>
+                    <td className="p-2">
+                      <button
+                        type="button"
+                        className="text-left text-primary underline"
+                        onClick={() => choose(p)}
+                      >
+                        {label(p)}
+                      </button>
+                    </td>
+                    <td className="p-2">{p.latencies.length}</td>
+                    <td className="whitespace-nowrap p-2">
+                      {fmt(p.valid)} / {fmt(p.completed)} / {fmt(p.scheduled)}
+                    </td>
+                    <td className="p-2">{fmt(p.failed)}</td>
+                    <td className="p-2">{fmt(latencyValue(p, xAxis))}</td>
+                    <td className="p-2">{fmt(efficiencyValue(p, yAxis, costs[p.id]))}</td>
+                    <td className="p-2 text-xs">
+                      {plotted.some((q) => q.id === p.id) ? s.plotted : s.missing}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {active && (
+            <div className="grid gap-5 border-t pt-4 lg:grid-cols-2" data-testid="tradeoff-detail">
+              <div className="space-y-3">
+                <Heading>{s.details}</Heading>
+                <p className="text-sm font-medium">{label(active)}</p>
+                <dl className="grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)] gap-x-4 gap-y-2 text-xs">
+                  {[
+                    [s.runtime, active.revision || '—'],
+                    [s.model, active.modelRevision || '—'],
+                    [s.allocated, `${fmt(active.allocated)} / ${fmt(active.participating)}`],
+                    [s.concurrency, fmt(active.concurrency)],
+                    [s.window, fmt(active.wall)],
+                    [s.power, fmt(active.power)],
+                    [s.energyClip, fmt(active.energy)],
+                    [s.powerWindow, fmt(active.powerWindow)],
+                    [s.batch, s.unavailable],
+                    [s.queue, s.unavailable],
+                  ].map(([name, value]) => (
+                    <div key={name} className="contents">
+                      <dt className="text-muted-foreground">{name}</dt>
+                      <dd className="break-all">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button variant="outline" onClick={() => onOpen(active)}>
+                    {s.open}
+                  </Button>
+                  <a
+                    className="text-sm text-primary underline"
+                    href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${active.sourceId}`}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {s.ci}
+                  </a>
+                </div>
+                <details>
+                  <summary className="cursor-pointer text-xs">{s.server}</summary>
+                  <pre className="mt-2 whitespace-pre-wrap break-all text-xs">
+                    {JSON.stringify(active.server, null, 2)}
+                  </pre>
+                </details>
+                <details>
+                  <summary className="cursor-pointer text-xs">{s.fidelity}</summary>
+                  <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all text-xs">
+                    {JSON.stringify({ fidelity: active.fidelity, policy: active.policy }, null, 2)}
+                  </pre>
+                </details>
+              </div>
+              <div className="space-y-3">
+                <Heading>{s.costTitle}</Heading>
+                <p className="text-xs text-muted-foreground">{s.costNote}</p>
+                {(
+                  [
+                    ['hourly', s.hourly, 'number'],
+                    ['source', s.source, 'text'],
+                    ['date', s.date, 'date'],
+                  ] as const
+                ).map(([key, name, type]) => (
+                  <label key={key} className="flex flex-col gap-1.5 text-xs">
+                    {name}
+                    <Input
+                      aria-label={name}
+                      type={type}
+                      min={key === 'hourly' ? 0 : undefined}
+                      step={key === 'hourly' ? 'any' : undefined}
+                      value={cost[key]}
+                      onChange={(event) => costInput(key, event.target.value)}
+                    />
+                  </label>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </Card>
+  );
+}

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -144,6 +144,7 @@ describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
     result.workload.plan.plan_id = 'renamed';
     result.workload.plan.repetitions = 20;
     expect(tradeoffPoints(a)[0].group).toBe(tradeoffPoints(b)[0].group);
+    expect(tradeoffPoints(a)[0].workloadLabel).toBe(tradeoffPoints(b)[0].workloadLabel);
     result.workload.plan.model_revision = 'changed';
     expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);
   });
@@ -153,6 +154,7 @@ describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
     const result = b.bundle.result as { workload: { plan: Record<string, Json> } };
     result.workload.plan.cases = [{ prompt: 'Synthetic fixture', seed: 2 }];
     expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);
+    expect(tradeoffPoints(a)[0].workloadLabel).not.toBe(tradeoffPoints(b)[0].workloadLabel);
     result.workload.plan.cases = [{ prompt: 'Synthetic fixture', seed: 1 }];
     result.workload.plan.generation = { width: 1920, height: 1080 };
     expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  tradeoffPoints,
+  latencyValue,
+  efficiencyValue,
+  costValue,
+  type TradeoffRun,
+} from './tradeoff';
+import type { Json } from './bundle';
+
+function fixture(
+  records: Json[] = Array.from({ length: 10 }, (_, i) => ({
+    phase: 'measurement',
+    status: 'succeeded',
+    submit_to_media_seconds: i + 1,
+    media: { valid: true, video: { duration_seconds: 8 } },
+  })),
+): TradeoffRun {
+  return {
+    exportRun: '20',
+    artifact: '30',
+    bundle: {
+      manifest: { run_id: '10' },
+      manifestSha256: 'synthetic',
+      result: {
+        schema_version: '1.0.0',
+        bundle_type: 'h3_benchmark_result',
+        workload: {
+          plan: {
+            model_id: 'synthetic-model',
+            model_revision: 'frozen',
+            plan_id: 'synthetic-plan',
+            generation: {
+              width: 1280,
+              height: 720,
+              duration_seconds: 8,
+              fps: 24,
+              num_inference_steps: 50,
+            },
+            cases: [{ prompt: 'Synthetic fixture', seed: 1 }],
+            repetitions: 10,
+            warmup_runs: 1,
+          },
+        },
+        hardware: {
+          reserved_gpu_count: 8,
+          selected_gpu_count: 4,
+          devices: [{ name: 'Synthetic GPU' }],
+        },
+        roles: {
+          baseline: {
+            records,
+            metrics: {
+              status: 'valid',
+              completion: {
+                valid: records.length,
+                completed: records.length,
+                scheduled: records.length + 1,
+                failed: 1,
+              },
+              measurement: {
+                wall_seconds: 3600,
+                concurrency: 1,
+                boundary: 'submit_to_validated_media',
+              },
+            },
+            power: {
+              phases: {
+                measurement: { valid: true, aggregate: { joules_per_valid_clip: 360000 } },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+const cost = { hourly: '2', source: 'Synthetic all-in cost', date: '2026-09-09' };
+
+describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
+  it('uses nearest-rank P90 and excludes warmup while preserving failures', () => {
+    const run = fixture();
+    const data = run.bundle.result as { roles: { baseline: { records: Json[] } } };
+    data.roles.baseline.records.push({
+      phase: 'warmup',
+      status: 'succeeded',
+      submit_to_media_seconds: 1000,
+      media: { valid: true },
+    });
+    const p = tradeoffPoints(run)[0];
+    expect(latencyValue(p, 'p90')).toBe(9);
+    expect(latencyValue(p, 'median')).toBe(5.5);
+    expect(p.failed).toBe(1);
+    expect(p.rate).toBe(10);
+  });
+  it('does not call a single measured request P90', () => {
+    const p = tradeoffPoints(
+      fixture([
+        {
+          phase: 'measurement',
+          status: 'succeeded',
+          submit_to_media_seconds: 149,
+          media: { valid: true, video: { duration_seconds: 8 } },
+        },
+      ]),
+    )[0];
+    expect(latencyValue(p, 'p90')).toBeNull();
+    expect(latencyValue(p, 'median')).toBe(149);
+  });
+  it('uses all allocated GPUs and actual valid video durations', () => {
+    const p = tradeoffPoints(fixture())[0];
+    expect(efficiencyValue(p, 'clipsGpu')).toBe(1.25);
+    expect(efficiencyValue(p, 'secondsGpu')).toBe(10);
+    expect(efficiencyValue(p, 'dollar', cost)).toBe(5);
+    expect(efficiencyValue(p, 'energy')).toBe(10);
+    expect(efficiencyValue({ ...p, allocated: null }, 'clipsGpu')).toBeNull();
+    expect(efficiencyValue({ ...p, energy: null }, 'energy')).toBeNull();
+  });
+  it('rejects incomplete latency populations instead of reporting a fast subset', () => {
+    const run = fixture([{ phase: 'measurement', status: 'succeeded', media: { valid: true } }]);
+    expect(tradeoffPoints(run)[0].latencies).toEqual([]);
+  });
+  it('requires finite full deployment cost with a real date and source', () => {
+    for (const invalid of [
+      { ...cost, hourly: '' },
+      { ...cost, hourly: '-1' },
+      { ...cost, hourly: 'Infinity' },
+      { ...cost, source: ' ' },
+      { ...cost, date: '2026-02-30' },
+    ])
+      expect(costValue(invalid)).toBeNull();
+    expect(costValue(cost)).toBe(2);
+    expect(
+      efficiencyValue({ ...tradeoffPoints(fixture())[0], rate: Number.MAX_VALUE }, 'dollar', {
+        ...cost,
+        hourly: '0.0001',
+      }),
+    ).toBeNull();
+  });
+  it('groups workload identity independently of plan names and repetition counts', () => {
+    const a = fixture();
+    const b = fixture();
+    const result = b.bundle.result as { workload: { plan: Record<string, Json> } };
+    result.workload.plan.plan_id = 'renamed';
+    result.workload.plan.repetitions = 20;
+    expect(tradeoffPoints(a)[0].group).toBe(tradeoffPoints(b)[0].group);
+    result.workload.plan.model_revision = 'changed';
+    expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);
+  });
+  it('does not mix shape or seed changes and rejects non-result input', () => {
+    const a = fixture(),
+      b = fixture();
+    const result = b.bundle.result as { workload: { plan: Record<string, Json> } };
+    result.workload.plan.cases = [{ prompt: 'Synthetic fixture', seed: 2 }];
+    expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);
+    result.workload.plan.cases = [{ prompt: 'Synthetic fixture', seed: 1 }];
+    result.workload.plan.generation = { width: 1920, height: 1080 };
+    expect(tradeoffPoints(a)[0].group).not.toBe(tradeoffPoints(b)[0].group);
+    expect(tradeoffPoints(b)[0].completeWorkload).toBe(false);
+    b.bundle.result = null;
+    expect(tradeoffPoints(b)).toEqual([]);
+  });
+});

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -1,0 +1,158 @@
+import { at, entries, number, ROLES, rows, text, type Bundle, type Json } from './bundle';
+
+export interface TradeoffRun {
+  bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'>;
+  exportRun: string;
+  artifact: string;
+}
+export type LatencyAxis = 'p90' | 'median';
+export type EfficiencyAxis = 'dollar' | 'clipsGpu' | 'secondsGpu' | 'energy';
+export interface DeploymentCost {
+  hourly: string;
+  source: string;
+  date: string;
+}
+
+function canonical(value: Json): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value !== null && typeof value === 'object')
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(',')}}`;
+  return JSON.stringify(value);
+}
+const positive = (value: Json) => {
+  const n = number(value);
+  return n !== null && n > 0 ? n : null;
+};
+
+export function tradeoffPoints(run: TradeoffRun) {
+  const b = run.bundle,
+    result = b.result;
+  if (
+    at(result, 'schema_version') !== '1.0.0' ||
+    at(result, 'bundle_type') !== 'h3_benchmark_result'
+  )
+    return [];
+  const plan = at(result, 'workload', 'plan');
+  const workload = Object.fromEntries(
+    entries(plan).filter(([key]) => !['plan_id', 'repetitions', 'warmup_runs'].includes(key)),
+  );
+  const generation = at(plan, 'generation');
+  const cases = rows(at(plan, 'cases'));
+  const completeWorkload =
+    text(at(plan, 'model_id')) &&
+    text(at(plan, 'model_revision')) &&
+    ['width', 'height', 'duration_seconds', 'fps', 'num_inference_steps'].every(
+      (key) => positive(at(generation, key)) !== null,
+    ) &&
+    cases.length > 0 &&
+    cases.every((item) => text(at(item, 'prompt')) && Number.isInteger(number(at(item, 'seed'))));
+  const group = completeWorkload ? canonical(workload) : `unknown:${b.manifestSha256}`;
+  const workloadLabel = [
+    `${number(at(generation, 'width')) ?? '?'} × ${number(at(generation, 'height')) ?? '?'}`,
+    `${number(at(generation, 'duration_seconds')) ?? '?'} s`,
+    `${number(at(generation, 'fps')) ?? '?'} fps`,
+    `${number(at(generation, 'num_inference_steps')) ?? '?'} steps`,
+    text(at(plan, 'plan_id')),
+  ].join(' · ');
+  return ROLES.map((role) => {
+    const metrics = at(result, 'roles', role, 'metrics');
+    const records = rows(at(result, 'roles', role, 'records')).filter(
+      (r) => at(r, 'phase') === 'measurement',
+    );
+    const valid = records.filter(
+      (r) => at(r, 'status') === 'succeeded' && at(r, 'media', 'valid') === true,
+    );
+    const count = number(at(metrics, 'completion', 'valid'));
+    const scheduled = number(at(metrics, 'completion', 'scheduled'));
+    const accounted =
+      count !== null && count === valid.length && scheduled !== null && scheduled >= count;
+    const times = valid.map((r) => positive(at(r, 'submit_to_media_seconds')));
+    const latencies =
+      accounted && times.every((n): n is number => n !== null) ? times.sort((a, z) => a - z) : [];
+    const durations = valid.map((r) => positive(at(r, 'media', 'video', 'duration_seconds')));
+    const wall = positive(at(metrics, 'measurement', 'wall_seconds'));
+    const rate =
+      accounted && wall !== null && at(metrics, 'status') === 'valid'
+        ? (count! * 3600) / wall
+        : null;
+    const secondsRate =
+      rate !== null && wall !== null && durations.every((n): n is number => n !== null)
+        ? (durations.reduce((sum, n) => sum + n, 0) * 3600) / wall
+        : null;
+    const phase = at(result, 'roles', role, 'power', 'phases', 'measurement');
+    const energy =
+      at(phase, 'valid') === true
+        ? positive(at(phase, 'aggregate', 'joules_per_valid_clip'))
+        : null;
+    const devices = rows(at(result, 'hardware', 'devices'));
+    return {
+      id: `${b.manifestSha256}:${role}`,
+      role,
+      run,
+      group,
+      workloadLabel,
+      completeWorkload: Boolean(completeWorkload),
+      sourceId: text(at(b.manifest, 'run_id')),
+      model: text(at(plan, 'model_id')),
+      modelRevision: text(at(plan, 'model_revision')),
+      hardware: [...new Set(devices.map((d) => text(at(d, 'name'))).filter(Boolean))].join(', '),
+      revision: text(at(result, 'execution', 'runtime', role, 'revision')),
+      concurrency: number(at(metrics, 'measurement', 'concurrency')),
+      boundary: text(at(metrics, 'measurement', 'boundary')),
+      allocated: positive(at(result, 'hardware', 'reserved_gpu_count')),
+      participating: positive(at(result, 'hardware', 'selected_gpu_count')),
+      latencies,
+      rate,
+      secondsRate,
+      energy,
+      scheduled,
+      valid: count,
+      completed: number(at(metrics, 'completion', 'completed')),
+      failed: number(at(metrics, 'completion', 'failed')),
+      wall,
+      power: at(phase, 'valid') === true ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
+      powerWindow: at(phase, 'valid') === true ? number(at(phase, 'duration_seconds')) : null,
+      server: at(result, 'workload', 'server'),
+      fidelity: at(result, 'paired_fidelity'),
+      policy: at(result, 'policy'),
+    };
+  });
+}
+export type TradeoffPoint = ReturnType<typeof tradeoffPoints>[number];
+
+export function latencyValue(point: TradeoffPoint, axis: LatencyAxis): number | null {
+  const a = point.latencies;
+  // Ten samples is a display floor, not statistical or release qualification.
+  if (axis === 'p90') return a.length >= 10 ? a[Math.ceil(a.length * 0.9) - 1] : null;
+  if (a.length === 0) return null;
+  const middle = Math.floor(a.length / 2);
+  return a.length % 2 ? a[middle] : (a[middle - 1] + a[middle]) / 2;
+}
+export function costValue(cost?: DeploymentCost): number | null {
+  if (!cost || !cost.source.trim() || !/^\d{4}-\d{2}-\d{2}$/u.test(cost.date)) return null;
+  const date = new Date(`${cost.date}T00:00:00Z`);
+  if (!Number.isFinite(date.getTime()) || date.toISOString().slice(0, 10) !== cost.date)
+    return null;
+  const n = Number(cost.hourly);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+export function efficiencyValue(
+  point: TradeoffPoint,
+  axis: EfficiencyAxis,
+  cost?: DeploymentCost,
+): number | null {
+  let value: number | null = null;
+  if (axis === 'dollar') {
+    const hourly = costValue(cost);
+    if (point.rate !== null && hourly !== null) value = point.rate / hourly;
+  }
+  if (axis === 'clipsGpu' && point.rate !== null && point.allocated !== null)
+    value = point.rate / point.allocated;
+  if (axis === 'secondsGpu' && point.secondsRate !== null && point.allocated !== null)
+    value = point.secondsRate / point.allocated;
+  if (axis === 'energy' && point.energy !== null) value = 3600000 / point.energy;
+  return value !== null && Number.isFinite(value) ? value : null;
+}

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -55,7 +55,9 @@ export function tradeoffPoints(run: TradeoffRun) {
     `${number(at(generation, 'duration_seconds')) ?? '?'} s`,
     `${number(at(generation, 'fps')) ?? '?'} fps`,
     `${number(at(generation, 'num_inference_steps')) ?? '?'} steps`,
-    text(at(plan, 'plan_id')),
+    `${text(at(plan, 'model_id'))} @ ${text(at(plan, 'model_revision')).slice(0, 12)}`,
+    `seed ${cases.map((item) => number(at(item, 'seed')) ?? '?').join(', ')}`,
+    text(at(cases[0], 'prompt')).slice(0, 80),
   ].join(' · ');
   return ROLES.map((role) => {
     const metrics = at(result, 'roles', role, 'metrics');
@@ -94,6 +96,7 @@ export function tradeoffPoints(run: TradeoffRun) {
       run,
       group,
       workloadLabel,
+      workload,
       completeWorkload: Boolean(completeWorkload),
       sourceId: text(at(b.manifest, 'run_id')),
       model: text(at(plan, 'model_id')),


### PR DESCRIPTION
## Summary

Add a hidden video tradeoff view over the existing H3 result contract. Match model revision, generation settings and prompt/seed/inputs before comparing hardware; keep different video durations separate. Points open their original CI run and playable results.

The latency axis offers client-ready P90 or diagnostic median. Current real runs have one measured request per role, so P90 remains unavailable; ten complete valid-request samples is only a display floor. Efficiency axes show valid clips/USD, clips or decoded video seconds per allocated GPU-hour, and clips per measured GPU-board kWh. Dollar plots require a user-entered whole-deployment hourly cost, source and date. Reserved GPUs count even when idle; GPU-board energy is not facility energy or full profit.

Runs accumulate in the browser session, and switching views preserves chart controls and cost assumptions. Existing hidden-feature navigation and media storage remain unchanged. Queue delay, actual batch/replica layout, offered arrival rate and deadline attainment remain unavailable until the backend supplies them. No GPU experiments or public documentation are added. Inference/AgentX unofficial overlays do not apply: this view consumes H3 CI bundles directly.

## Validation

- Merged as `d0286eb8` after all eight Chrome/Firefox shards, component/unit tests, Claude and Bugbot passed with no unresolved threads. [Production chart](https://inferencex.semianalysis.com/video?run=34298416664&artifact=10084002812&source=34293342829&view=tradeoff) passed the real-data verification after deployment, including video drilldown, cost-state retention and six layouts with no page errors.
- Local workspace units: 6,193 passed, 1 skipped; focused metric tests cover percentile samples, warmup exclusion, missing data, workload isolation and denominators.
- Cypress: 12 component tests passed across the new chart and existing CI viewer.
- Typecheck, lint, formatting and typography checks passed.
- Real published CI output: workload isolation, missing P90/cost states, cost gating, original video playback, and English/Chinese layouts at 1440, 768 and 390 px passed. Synthetic test fixtures are labeled.
- Chinese copy received read-only Claude feedback and a manual fidelity/naturalness review, including rendered mobile context.

## 中文说明

在现有隐藏视频页面中新增服务延迟与效率权衡图，直接复用 H3 CI 结果格式。比较前匹配模型版本、生成设置、prompt、seed 和输入，不混合不同时长的工作负载；数据点可回到对应 CI 运行及可播放视频。

延迟轴支持客户端就绪 P90 与诊断用中位数。当前真实运行每个角色只有一个测量请求，因此不展示 P90；十个完整有效样本仅是显示门槛。效率轴支持有效视频数/USD、每个已分配 GPU 小时的有效视频数或实际解码视频秒数，以及每 GPU 板卡千瓦时的有效视频数。成本图必须填写完整部署每小时成本、来源与日期。空闲预留 GPU 仍计入分母，板卡能耗不代表设施总能耗或完整利润。

当前会话中打开的运行会加入对比，切换视频与图表保留控件和成本假设。排队延迟、实际批次和副本布局、施加的请求到达率及时限达标情况，在后端提供之前保持不可用。未新增 GPU 实验、公开文档或部署权限变更；H3 直接读取 CI 产物，不使用 Inference/AgentX unofficial overlay 数据路径。

本地单元测试 6,193 项通过、1 项跳过；12 项浏览器组件测试通过。已使用真实 CI 结果验证视频回溯、缺失数据与成本门槛，以及中英文桌面和移动布局。类型、lint、格式和排版检查通过。中文经过 Claude 只读反馈及人工语义、自然度和实际页面复核。

八个 Chrome/Firefox 分片及组件、单元测试全部通过，Claude 和 Bugbot 复核通过且无未解决讨论，已合并为 `d0286eb8`。生产部署完成后再次使用真实数据验证图表、视频回溯、成本状态保留及六种布局，未发现页面错误。
