### PR TITLE
fix(current-image): list only actively benchmarked model-scenario pairs / 当前镜像页仅列出仍在基准测试中的模型×场景组合

### DIFF
--- a/packages/app/cypress/e2e/current-inferencex-image.cy.ts
+++ b/packages/app/cypress/e2e/current-inferencex-image.cy.ts
@@ -17,20 +17,20 @@ describe('Current InferenceX Image localized routes', () => {
       precision: 'fp8',
       spec_method: 'none',
       disagg: false,
-      isl: 1024,
+      isl: 8192,
       osl: 1024,
       benchmark_type: 'single_turn',
       image: 'lmsysorg/sglang:v0.5.2',
       date: today,
     },
     {
-      model: 'gptoss',
+      model: 'dsv4',
       hardware: 'b200',
       framework: 'vllm',
       precision: 'fp4',
       spec_method: 'mtp',
       disagg: false,
-      isl: 1024,
+      isl: 8192,
       osl: 1024,
       benchmark_type: 'single_turn',
       image: 'vllm/vllm-openai:v0.10.1',
@@ -209,6 +209,70 @@ describe('Current InferenceX Image localized routes', () => {
       .should('have.length', 1)
       .and('have.attr', 'style')
       .and('match', /oklch/u);
+  });
+
+  it('lists only model-scenario pairs that are still benchmarked', () => {
+    cy.viewport(1440, 900);
+    const retiredImage = 'lmsysorg/sglang:v0.4.9-minimax-8k1k-retired';
+    const activeMiniMaxImage = 'lmsysorg/sglang:v0.5.2-minimax-agentic';
+    const deprecatedModelImage = 'vllm/vllm-openai:v0.9.0-kimi-k2.5';
+    cy.intercept('GET', '**/api/v1/latest-images', [
+      ...imageRows,
+      // MiniMax M3 retired its 8K/1K sweep on 2026-08-04; AgentX stays active.
+      {
+        ...imageRows[0],
+        model: 'minimaxm3',
+        framework: 'sglang',
+        image: retiredImage,
+        date: '2026-08-04',
+      },
+      {
+        ...imageRows[0],
+        model: 'minimaxm3',
+        framework: 'sglang',
+        isl: null,
+        osl: null,
+        benchmark_type: 'agentic_traces',
+        image: activeMiniMaxImage,
+        date: today,
+      },
+      // Kimi K2.5 is a fully deprecated model: no scenario should surface it.
+      { ...imageRows[1], model: 'kimik2.5', image: deprecatedModelImage },
+      // The globally retired 1K/1K sweep must not surface for any model.
+      { ...imageRows[1], isl: 1024, osl: 1024, image: 'vllm/vllm-openai:v0.8.0-1k1k' },
+    ]);
+    cy.intercept('GET', '**/api/v1/framework-releases', {
+      sglang: 'v0.5.2',
+      vllm: 'v0.10.1',
+    });
+    cy.visit('/current-inferencex-image');
+
+    // Default 8K/1K view across all models: the still-swept rows only.
+    cy.get('[data-testid="current-image-result-count"]').should('contain.text', '2 configurations');
+    cy.get('table')
+      .should('contain.text', 'lmsysorg/sglang:v0.5.2')
+      .and('contain.text', 'vllm/vllm-openai:v0.10.1')
+      .and('not.contain.text', retiredImage)
+      .and('not.contain.text', deprecatedModelImage);
+
+    cy.get('#image-sequence-select').click();
+    cy.get('[data-slot="select-item"]').should('not.contain.text', '1k/1k');
+    cy.get('[data-slot="select-item"]').contains('8k/1k').click();
+
+    cy.get('#image-model-select').click();
+    cy.get('[data-slot="select-item"]').should('not.contain.text', 'Kimi-K2.5');
+    cy.get('[data-slot="select-item"]').contains('MiniMax-M3').click();
+
+    // Selecting MiniMax M3 removes 8K/1K from the scenario list and moves the
+    // table onto the model's only active scenario.
+    cy.get('#image-sequence-select').should('contain.text', 'Agentic');
+    cy.get('#image-sequence-select').click();
+    cy.get('[data-slot="select-item"]').should('have.length', 1).and('contain.text', 'Agentic');
+    cy.get('[data-slot="select-item"]').contains('Agentic').click();
+    cy.get('[data-testid="current-image-result-count"]').should('contain.text', '1 configuration');
+    cy.get('table')
+      .should('contain.text', activeMiniMaxImage)
+      .and('not.contain.text', retiredImage);
   });
 
   it('labels agentic rows with the reviewed Chinese scenario copy', () => {

--- a/packages/app/src/components/latest-image/latest-image-content.tsx
+++ b/packages/app/src/components/latest-image/latest-image-content.tsx
@@ -3,8 +3,6 @@
 import { ControlPanel } from '@/components/ui/control-panel';
 import { useMemo, useState } from 'react';
 
-import { DB_MODEL_TO_DISPLAY, rowToSequence } from '@semianalysisai/inferencex-constants';
-
 import { LabelWithTooltip } from '@/components/ui/label-with-tooltip';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -34,14 +32,20 @@ import {
   daysSince,
   getActualLatestTag,
   getCurrentImageNodeTypeTooltip,
+  imageRowDisplayModel,
+  imageRowSequence,
+  isActiveImageRow,
   isOutdated,
   isStaleAgentx,
+  resolveSelectedSequence,
+  sequenceOptionsForModel,
 } from './latest-image-utils';
 
 const STRINGS = {
   en: {
     title: 'Current InferenceX Image',
-    description: 'Docker image tags for each model and chip configuration.',
+    description:
+      'Docker image tags for each actively benchmarked model, scenario, and chip configuration. Retired models and scenarios are not listed.',
     benchmarkGroup: 'Configuration',
     runtimeGroup: 'Hardware & runtime',
     imageVersions: 'Images & versions',
@@ -93,7 +97,8 @@ const STRINGS = {
   },
   zh: {
     title: 'InferenceX 当前镜像',
-    description: '各模型与芯片配置的 Docker 镜像标签。',
+    description:
+      '仍在基准测试中的各模型、场景与芯片配置的 Docker 镜像标签，已停用的模型和场景不再列出。',
     benchmarkGroup: '配置',
     runtimeGroup: '硬件与运行环境',
     imageVersions: '镜像与版本',
@@ -146,33 +151,26 @@ const STRINGS = {
 
 type NodeType = 'single' | 'disagg' | 'all';
 
-/**
- * Scenario key for a row: 'agentic-traces' for AgentX rows (null isl/osl), the
- * mapped '1k/1k'-style string for fixed-sequence rows, raw `isl/osl` fallback
- * for unmapped fixed-sequence combos so they stay selectable rather than vanishing.
- */
-function rowSequence(row: LatestImageRow): string {
-  return rowToSequence(row) ?? `${row.isl}/${row.osl}`;
-}
-
 /** Human label for a scenario key — AgentX rows read "Agentic"/"智能体", never "null/null". */
 function sequenceOptionLabel(seq: string, locale: 'en' | 'zh'): string {
   return seq === Sequence.AgenticTraces ? getSequenceLabel(Sequence.AgenticTraces, locale) : seq;
 }
 
+/**
+ * Filter options from the active catalog. Scenarios are derived separately per
+ * selected model (`sequenceOptionsForModel`) so a retired model × scenario
+ * pair never appears in the ISL/OSL dropdown.
+ */
 function deriveOptions(data: LatestImageRow[]) {
   const models = new Set<string>();
   const precisions = new Set<string>();
-  const sequences = new Set<string>();
   const specMethods = new Set<string>();
   const hardwares = new Set<string>();
   const frameworks = new Set<string>();
 
   for (const row of data) {
-    const displayModel = DB_MODEL_TO_DISPLAY[row.model] ?? row.model;
-    models.add(displayModel);
+    models.add(imageRowDisplayModel(row));
     precisions.add(row.precision);
-    sequences.add(rowSequence(row));
     specMethods.add(row.spec_method);
     hardwares.add(row.hardware);
     frameworks.add(baseFramework(row.framework));
@@ -181,7 +179,6 @@ function deriveOptions(data: LatestImageRow[]) {
   return {
     models: [...models].toSorted(),
     precisions: [...precisions].toSorted(),
-    sequences: [...sequences].filter((s) => s !== '1k/8k').toSorted(),
     specMethods: [...specMethods].toSorted(),
     hardwares: [...hardwares].toSorted(),
     frameworks: [...frameworks].toSorted(),
@@ -205,7 +202,9 @@ export function CurrentImageContent() {
 
   const [selectedModel, setSelectedModel] = useState<string>('all');
   const [selectedPrecision, setSelectedPrecision] = useState<string>('all');
-  const [selectedSequence, setSelectedSequence] = useState<string>('1k/1k');
+  // 8K/1K is the fixed-sequence scenario still swept across models; 1K/1K and
+  // 1K/8K are retired, so they never reach the dropdown.
+  const [selectedSequence, setSelectedSequence] = useState<string>(Sequence.EightK_OneK);
   const [selectedSpecMethod, setSelectedSpecMethod] = useState<string>('all');
   const [selectedHardware, setSelectedHardware] = useState<string>('all');
   const [selectedNodeType, setSelectedNodeType] = useState<NodeType>('single');
@@ -213,21 +212,32 @@ export function CurrentImageContent() {
   // limits the table to rows whose base framework is in the set.
   const [selectedFrameworks, setSelectedFrameworks] = useState<string[]>([]);
 
-  const options = useMemo(() => (data ? deriveOptions(data) : null), [data]);
+  // Only model × scenario pairs InferenceX still benchmarks. Retired pairs keep
+  // their newest image in the DB, but that image is not a refresh candidate.
+  const activeRows = useMemo(() => data?.filter(isActiveImageRow), [data]);
+
+  const options = useMemo(() => (activeRows ? deriveOptions(activeRows) : null), [activeRows]);
+
+  // Scenario choices follow the selected model: picking MiniMax M3 offers
+  // Agentic only, because its 8K/1K sweep is retired.
+  const sequenceOptions = useMemo(
+    () => (activeRows ? sequenceOptionsForModel(activeRows, selectedModel) : []),
+    [activeRows, selectedModel],
+  );
+  // When the model does not run the chosen scenario, filter on the first one
+  // it does run instead of showing an empty table for a phantom selection.
+  const effectiveSequence = resolveSelectedSequence(sequenceOptions, selectedSequence);
 
   // Stable "today" per render — recomputed on each mount, which is fine for the
   // page's read-only display (no need to tick every minute).
   const today = useMemo(() => new Date(), []);
 
   const filtered = useMemo(() => {
-    if (!data) return [];
-    const rows = data.filter((row) => {
-      if (selectedModel !== 'all') {
-        const displayModel = DB_MODEL_TO_DISPLAY[row.model] ?? row.model;
-        if (displayModel !== selectedModel) return false;
-      }
+    if (!activeRows) return [];
+    const rows = activeRows.filter((row) => {
+      if (selectedModel !== 'all' && imageRowDisplayModel(row) !== selectedModel) return false;
       if (selectedPrecision !== 'all' && row.precision !== selectedPrecision) return false;
-      if (rowSequence(row) !== selectedSequence) return false;
+      if (imageRowSequence(row) !== effectiveSequence) return false;
       if (selectedSpecMethod !== 'all' && row.spec_method !== selectedSpecMethod) return false;
       if (selectedHardware !== 'all' && row.hardware !== selectedHardware) return false;
       if (selectedNodeType !== 'all') {
@@ -246,10 +256,10 @@ export function CurrentImageContent() {
     // users primarily care about "what hasn't been refreshed in a while".
     return rows.toSorted((a, b) => a.date.localeCompare(b.date));
   }, [
-    data,
+    activeRows,
     selectedModel,
     selectedPrecision,
-    selectedSequence,
+    effectiveSequence,
     selectedSpecMethod,
     selectedHardware,
     selectedNodeType,
@@ -322,6 +332,12 @@ export function CurrentImageContent() {
                     onValueChange={(v) => {
                       track('current_image_model_changed', { model: v });
                       setSelectedModel(v);
+                      // Commit the scenario fallback so it sticks when the user
+                      // later widens the model filter again.
+                      const next = sequenceOptionsForModel(activeRows ?? [], v);
+                      if (next.length > 0 && !next.includes(selectedSequence)) {
+                        setSelectedSequence(next[0]);
+                      }
                     }}
                   >
                     <SelectTrigger id="image-model-select" className="w-full min-w-0">
@@ -372,7 +388,7 @@ export function CurrentImageContent() {
                     tooltip={t.tooltipIslOsl}
                   />
                   <Select
-                    value={selectedSequence}
+                    value={effectiveSequence}
                     onValueChange={(v) => {
                       track('current_image_sequence_changed', { sequence: v });
                       setSelectedSequence(v);
@@ -382,7 +398,7 @@ export function CurrentImageContent() {
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {options.sequences.map((s) => (
+                      {sequenceOptions.map((s) => (
                         <SelectItem key={s} value={s}>
                           {sequenceOptionLabel(s, locale)}
                         </SelectItem>
@@ -502,7 +518,7 @@ export function CurrentImageContent() {
         </TooltipProvider>
       )}
 
-      {data && filtered.length === 0 && (
+      {activeRows && filtered.length === 0 && (
         <div className="py-12 text-center text-muted-foreground">{t.noMatch}</div>
       )}
 
@@ -555,7 +571,7 @@ export function CurrentImageContent() {
               </thead>
               <tbody>
                 {filtered.map((row, i) => {
-                  const displayModel = DB_MODEL_TO_DISPLAY[row.model] ?? row.model;
+                  const displayModel = imageRowDisplayModel(row);
                   const gpuLabel = row.hardware.toUpperCase();
                   const actualLatest = getActualLatestTag(row.framework, releases);
                   const outdated = isOutdated(row.image, actualLatest);

--- a/packages/app/src/components/latest-image/latest-image-utils.test.ts
+++ b/packages/app/src/components/latest-image/latest-image-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import { Model, Sequence } from '@/lib/data-mappings';
+
 import {
   AGE_MAX_RED_DAYS,
   AGENTX_MAX_AGE_DAYS,
@@ -9,8 +11,14 @@ import {
   daysSince,
   getActualLatestTag,
   getCurrentImageNodeTypeTooltip,
+  imageRowDisplayModel,
+  imageRowModel,
+  imageRowSequence,
+  isActiveImageRow,
   isOutdated,
   isStaleAgentx,
+  resolveSelectedSequence,
+  sequenceOptionsForModel,
 } from './latest-image-utils';
 
 const lightnessOf = (s: string) =>
@@ -181,5 +189,139 @@ describe('getCurrentImageNodeTypeTooltip', () => {
     expect(getCurrentImageNodeTypeTooltip('zh')).toBe(
       '单节点指非分离式推理；分离式配置使用独立的 prefill/decode 池，包括 Dynamo、MoRI 和 llm-d。',
     );
+  });
+});
+
+/** Fixed-sequence or agentic row shape the catalog helpers read. */
+function imageRow(
+  model: string,
+  scenario: 'agentic' | '1k/1k' | '1k/8k' | '8k/1k' | { isl: number; osl: number },
+) {
+  if (scenario === 'agentic') {
+    return { model, isl: null, osl: null, benchmark_type: 'agentic_traces' };
+  }
+  const islOsl =
+    typeof scenario === 'string'
+      ? { '1k/1k': [1024, 1024], '1k/8k': [1024, 8192], '8k/1k': [8192, 1024] }[scenario]
+      : [scenario.isl, scenario.osl];
+  return { model, isl: islOsl[0], osl: islOsl[1], benchmark_type: 'single_turn' };
+}
+
+describe('imageRowDisplayModel / imageRowModel', () => {
+  it('maps DB keys to the configured display model, grouping point releases', () => {
+    expect(imageRowDisplayModel({ model: 'minimaxm3' })).toBe('MiniMax-M3');
+    expect(imageRowModel({ model: 'minimaxm3' })).toBe(Model.MiniMax_M3);
+    expect(imageRowModel({ model: 'glm5.1' })).toBe(Model.GLM_5);
+    expect(imageRowModel({ model: 'kimik2.7-code' })).toBe(Model.Kimi_K2_5);
+  });
+
+  it('keeps unmapped DB keys as raw display names with no configured model', () => {
+    expect(imageRowDisplayModel({ model: 'brand-new-model' })).toBe('brand-new-model');
+    expect(imageRowModel({ model: 'brand-new-model' })).toBeNull();
+  });
+});
+
+describe('imageRowSequence', () => {
+  it('classifies agentic rows regardless of isl/osl and maps fixed sequences', () => {
+    expect(imageRowSequence(imageRow('dsv4', 'agentic'))).toBe(Sequence.AgenticTraces);
+    expect(imageRowSequence(imageRow('dsv4', '8k/1k'))).toBe(Sequence.EightK_OneK);
+    expect(imageRowSequence(imageRow('dsv4', '1k/1k'))).toBe(Sequence.OneK_OneK);
+  });
+
+  it('falls back to the raw isl/osl pair for unmapped fixed-sequence combos', () => {
+    expect(imageRowSequence(imageRow('dsv4', { isl: 4096, osl: 512 }))).toBe('4096/512');
+  });
+});
+
+describe('isActiveImageRow', () => {
+  it('keeps active models on scenarios they still sweep', () => {
+    expect(isActiveImageRow(imageRow('dsv4', '8k/1k'))).toBe(true);
+    expect(isActiveImageRow(imageRow('dsv4', 'agentic'))).toBe(true);
+    expect(isActiveImageRow(imageRow('qwen3.5', '8k/1k'))).toBe(true);
+    expect(isActiveImageRow(imageRow('minimaxm3', 'agentic'))).toBe(true);
+    // Maintenance is not deprecation: DeepSeek R1 stays listed on 8K/1K.
+    expect(isActiveImageRow(imageRow('dsr1', '8k/1k'))).toBe(true);
+  });
+
+  it('drops the per-model retired MiniMax M3 8K/1K sweep while keeping 8K/1K elsewhere', () => {
+    expect(isActiveImageRow(imageRow('minimaxm3', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('qwen3.5', '8k/1k'))).toBe(true);
+  });
+
+  it('drops globally retired 1K/1K and 1K/8K sweeps for every model', () => {
+    expect(isActiveImageRow(imageRow('dsv4', '1k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('qwen3.5', '1k/8k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('dsr1', '1k/1k'))).toBe(false);
+  });
+
+  it('drops deprecated models on every scenario, including point-release buckets', () => {
+    expect(isActiveImageRow(imageRow('kimik2.5', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('kimik2.6', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('minimaxm2.5', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('gptoss120b', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('glm5', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('glm5.1', 'agentic'))).toBe(false);
+  });
+
+  it('keeps unconfigured models, applying only the global scenario retirements', () => {
+    expect(isActiveImageRow(imageRow('brand-new-model', '8k/1k'))).toBe(true);
+    expect(isActiveImageRow(imageRow('brand-new-model', 'agentic'))).toBe(true);
+    expect(isActiveImageRow(imageRow('brand-new-model', '1k/1k'))).toBe(false);
+  });
+
+  it('keeps unmapped isl/osl combos so a new sweep shape is not silently hidden', () => {
+    expect(isActiveImageRow(imageRow('dsv4', { isl: 4096, osl: 512 }))).toBe(true);
+  });
+});
+
+describe('sequenceOptionsForModel', () => {
+  const rows = [
+    imageRow('dsv4', '8k/1k'),
+    imageRow('dsv4', 'agentic'),
+    imageRow('minimaxm3', 'agentic'),
+    imageRow('kimik3', 'agentic'),
+    imageRow('qwen3.5', '8k/1k'),
+  ];
+
+  it('unions every scenario across models for the all-models filter', () => {
+    expect(sequenceOptionsForModel(rows, 'all')).toEqual([
+      Sequence.EightK_OneK,
+      Sequence.AgenticTraces,
+    ]);
+  });
+
+  it('narrows to the scenarios the selected model runs', () => {
+    expect(sequenceOptionsForModel(rows, 'MiniMax-M3')).toEqual([Sequence.AgenticTraces]);
+    expect(sequenceOptionsForModel(rows, 'Kimi-K3')).toEqual([Sequence.AgenticTraces]);
+    expect(sequenceOptionsForModel(rows, 'DeepSeek-V4-Pro')).toEqual([
+      Sequence.EightK_OneK,
+      Sequence.AgenticTraces,
+    ]);
+  });
+
+  it('returns no options for a model with no rows', () => {
+    expect(sequenceOptionsForModel(rows, 'Qwen3.8-Flash-Next')).toEqual([]);
+    expect(sequenceOptionsForModel([], 'all')).toEqual([]);
+  });
+});
+
+describe('resolveSelectedSequence', () => {
+  it('honours the selection when the model still offers it', () => {
+    expect(
+      resolveSelectedSequence(
+        [Sequence.EightK_OneK, Sequence.AgenticTraces],
+        Sequence.AgenticTraces,
+      ),
+    ).toBe(Sequence.AgenticTraces);
+  });
+
+  it('falls back to the first offered scenario when the selection is retired for the model', () => {
+    expect(resolveSelectedSequence([Sequence.AgenticTraces], Sequence.EightK_OneK)).toBe(
+      Sequence.AgenticTraces,
+    );
+  });
+
+  it('returns the selection unchanged when nothing is offered so the empty state renders', () => {
+    expect(resolveSelectedSequence([], Sequence.EightK_OneK)).toBe(Sequence.EightK_OneK);
   });
 });

--- a/packages/app/src/components/latest-image/latest-image-utils.ts
+++ b/packages/app/src/components/latest-image/latest-image-utils.ts
@@ -1,6 +1,98 @@
 import type { CSSProperties } from 'react';
 
-import type { FrameworkReleases } from '@/lib/api';
+import { DB_MODEL_TO_DISPLAY, rowToSequence } from '@semianalysisai/inferencex-constants';
+
+import type { FrameworkReleases, LatestImageRow } from '@/lib/api';
+import {
+  Model,
+  Sequence,
+  getModelCategory,
+  getSequenceCategoryForModel,
+} from '@/lib/data-mappings';
+
+const MODEL_VALUES = new Set<string>(Object.values(Model));
+const SEQUENCE_VALUES = new Set<string>(Object.values(Sequence));
+
+/**
+ * Display name for an image row — the `Model` enum value when the DB key is
+ * mapped, otherwise the raw DB key so unconfigured models still render.
+ */
+export function imageRowDisplayModel(row: Pick<LatestImageRow, 'model'>): string {
+  return DB_MODEL_TO_DISPLAY[row.model] ?? row.model;
+}
+
+/** The configured `Model` behind an image row, or null for DB keys the app has no config for. */
+export function imageRowModel(row: Pick<LatestImageRow, 'model'>): Model | null {
+  const display = imageRowDisplayModel(row);
+  return MODEL_VALUES.has(display) ? (display as Model) : null;
+}
+
+/**
+ * Scenario key for a row: 'agentic-traces' for AgentX rows (null isl/osl), the
+ * mapped '1k/1k'-style string for fixed-sequence rows, raw `isl/osl` fallback
+ * for unmapped fixed-sequence combos so they stay selectable rather than vanishing.
+ */
+export function imageRowSequence(
+  row: Pick<LatestImageRow, 'isl' | 'osl' | 'benchmark_type'>,
+): string {
+  return rowToSequence(row) ?? `${row.isl}/${row.osl}`;
+}
+
+/**
+ * Whether an image row belongs to a model × scenario pair InferenceX still
+ * benchmarks. The latest-images query returns the newest image per config
+ * regardless of age, so without this gate retired combinations (every
+ * deprecated model, the globally retired 1K/1K and 1K/8K sweeps, and
+ * per-model retirements such as MiniMax M3's 8K/1K) keep presenting as live
+ * images that need refreshing. The rules mirror the scenario selector:
+ *
+ * - deprecated or hidden models are out on every scenario;
+ * - a scenario is out when `getSequenceCategoryForModel` marks it deprecated
+ *   for the row's model (or globally, when the model is unconfigured);
+ * - unconfigured models and unmapped isl/osl combos stay in, because nothing
+ *   in the app declares them retired and hiding a brand-new sweep would be
+ *   worse than showing it.
+ */
+export function isActiveImageRow(
+  row: Pick<LatestImageRow, 'model' | 'isl' | 'osl' | 'benchmark_type'>,
+): boolean {
+  const model = imageRowModel(row);
+  if (model) {
+    const category = getModelCategory(model);
+    if (category === 'deprecated' || category === 'hidden') return false;
+  }
+  const sequence = imageRowSequence(row);
+  if (!SEQUENCE_VALUES.has(sequence)) return true;
+  return getSequenceCategoryForModel(sequence as Sequence, model) !== 'deprecated';
+}
+
+/**
+ * Scenario keys offered for the model filter, sorted. `'all'` unions every
+ * active row; a specific display model narrows to the scenarios that model
+ * still runs, so MiniMax M3 offers Agentic only while Qwen3.5 offers 8K/1K and
+ * Agentic. Callers pass rows already filtered through `isActiveImageRow`.
+ */
+export function sequenceOptionsForModel(
+  rows: readonly Pick<LatestImageRow, 'model' | 'isl' | 'osl' | 'benchmark_type'>[],
+  selectedModel: string,
+): string[] {
+  const sequences = new Set<string>();
+  for (const row of rows) {
+    if (selectedModel !== 'all' && imageRowDisplayModel(row) !== selectedModel) continue;
+    sequences.add(imageRowSequence(row));
+  }
+  return [...sequences].toSorted();
+}
+
+/**
+ * The scenario the table actually filters on: the user's pick when the model
+ * still offers it, else the first offered scenario, else the pick itself so an
+ * empty catalog renders its no-match state rather than a phantom selection.
+ */
+export function resolveSelectedSequence(options: readonly string[], selected: string): string {
+  if (options.includes(selected)) return selected;
+  return options[0] ?? selected;
+}
 
 /** Map framework variants to their base framework for release lookup. */
 export const FRAMEWORK_TO_BASE: Record<string, string> = {


### PR DESCRIPTION
## Summary

`/current-inferencex-image` derives its catalog from the latest-images query, which returns the newest image per config regardless of age. Retired model × scenario pairs therefore kept presenting as live images that needed refreshing: every deprecated model (Kimi K2.5/2.6, MiniMax M2.5/2.7, GLM 5/5.1, gpt-oss, Llama), the globally retired 1K/1K and 1K/8K sweeps, and MiniMax M3's 8K/1K sweep retired on 2026-08-04 ([InferenceX#2493](https://github.com/SemiAnalysisAI/InferenceX/pull/2493), #966 in this repo). The page also defaulted to the retired 1K/1K scenario.

- **Active-pair gate**: new `isActiveImageRow` in `latest-image-utils.ts` filters the catalog before any option or table row is derived. It mirrors the scenario selector: deprecated/hidden models are out on every scenario; `getSequenceCategoryForModel` decides per-model retirement (MiniMax M3 8K/1K) and global retirement (1K/1K, 1K/8K). Unconfigured DB models and unmapped isl/osl combos stay in, since nothing declares them retired and hiding a brand-new sweep would be worse than showing it.
- **Model-scoped scenario dropdown**: `sequenceOptionsForModel` narrows ISL/OSL to what the selected model still runs, so choosing MiniMax M3 offers Agentic only. If the current scenario is not offered for the model, the selection falls back to the first offered one and is committed so it sticks when widening the model filter again.
- **Default scenario** moves from 1K/1K to 8K/1K, and the hardcoded `!== '1k/8k'` filter is replaced by the deprecation rules.
- **Copy**: the page description (EN/ZH) now says retired models and scenarios are not listed.

Not an inference/evaluation chart feature, so the `?unofficialrun=` overlay path does not apply.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run fmt`, `check-typography` — pass (pre-commit).
- `vitest run latest-image-utils.test.ts` — 45 tests pass, including new coverage for `imageRowModel`, `imageRowSequence`, `isActiveImageRow` (per-model, global, deprecated-model, unconfigured-model, unmapped isl/osl cases), `sequenceOptionsForModel`, and `resolveSelectedSequence`.
- `cypress run --spec cypress/e2e/current-inferencex-image.cy.ts` — 13 passing locally (Electron). Fixture rows move from the retired 1K/1K to 8K/1K; a new spec seeds MiniMax M3 8K/1K + Agentic, Kimi K2.5, and a 1K/1K row, then asserts the default view lists only the two active 8K/1K configs, the model dropdown omits Kimi K2.5, and selecting MiniMax M3 leaves Agentic as the only scenario with the retired 8K/1K image absent.
- `zh-objective-guard`, `zh-copy`, `tab-meta` unit suites pass.

## 中文说明

`/current-inferencex-image` 的目录来自 latest-images 查询，该查询无论时间多久都会返回每个配置的最新镜像，因此已停用的模型×场景组合（Kimi K2.5/2.6、MiniMax M2.5/2.7、GLM 5/5.1、gpt-oss、Llama 等已停用模型，全局停用的 1K/1K 与 1K/8K 场景，以及 MiniMax M3 于 2026-08-04 停用的 8K/1K 场景）一直被当作仍需刷新的在用镜像展示，页面默认场景也仍是已停用的 1K/1K。

- 新增 `isActiveImageRow`，在派生筛选项和表格行之前先过滤目录，规则与场景选择器一致：已停用/隐藏模型在所有场景下排除；`getSequenceCategoryForModel` 决定按模型停用（MiniMax M3 的 8K/1K）和全局停用（1K/1K、1K/8K）。未配置的模型和未映射的 isl/osl 组合保留，避免新 sweep 被静默隐藏。
- ISL/OSL 下拉框通过 `sequenceOptionsForModel` 随所选模型收窄，选择 MiniMax M3 时仅显示 Agentic；若当前场景对该模型不可用，则回退到第一个可用场景并写入状态。
- 默认场景由 1K/1K 改为 8K/1K，并移除硬编码的 `!== '1k/8k'` 过滤。
- 页面描述（中英文）注明已停用的模型和场景不再列出。

测试：typecheck/lint/fmt/typography 通过；单元测试 45 个通过；`current-inferencex-image.cy.ts` 端到端测试本地 13 个通过，新增用例覆盖上述停用组合的过滤行为。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and filter logic on a read-only dashboard page; behavior aligns with existing chart selector deprecation rules and is covered by unit and E2E tests.
> 
> **Overview**
> The **Current InferenceX Image** page no longer treats every row from `latest-images` as an active refresh target. Rows are gated with **`isActiveImageRow`** (deprecated/hidden models and retired scenarios via the same **`getSequenceCategoryForModel`** rules as the rest of the app) before filters and the table are built.
> 
> **Default scenario** moves from retired **1K/1K** to **8K/1K**. The ISL/OSL dropdown is **model-scoped** (`sequenceOptionsForModel`); choosing a model that no longer runs the current scenario **falls back** to the first valid scenario and persists that choice on model change. EN/ZH copy notes that retired models and scenarios are omitted.
> 
> Tests add Vitest coverage for the new helpers and a Cypress case for MiniMax M3 (Agentic only), Kimi K2.5, and global 1K/1K retirement; fixtures shift from 1K/1K to 8K/1K.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 876b57d6a4255ee7efb52dddd6217498d2e0970d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->