### PR TITLE
[H3 Video] show concurrency results and playable CI media / 展示并发测试结果与 CI 视频

### DIFF
--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -2,6 +2,37 @@ import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.share
 import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
 import ResultPower from '@/components/video-benchmark/ResultPower';
 import VideoSelect from '@/components/video-benchmark/VideoSelect';
+import { servingFixture } from '@/components/video-benchmark/serving.fixture';
+import type { StoredArtifact } from '@/components/video-benchmark/stored';
+
+function servingArtifact(): StoredArtifact {
+  const fixture = servingFixture();
+  fixture.documents.set('manifest.json', fixture.manifest);
+  fixture.documents.set('ci.json', fixture.ci);
+  fixture.checksums.set('manifest.json', 'a'.repeat(64));
+  return {
+    storageVersion: 1,
+    runId: '123',
+    artifact: { id: 40, name: 'h3-video-123-1', expired: false, size_in_bytes: 100, stored: true },
+    sources: [
+      {
+        id: '123',
+        documents: [...fixture.documents],
+        checksums: [...fixture.checksums],
+        texts: [],
+        assets: [...fixture.checksums.keys()]
+          .filter((path) => path.endsWith('.mp4'))
+          .map((path) => [
+            path,
+            {
+              url: `https://media.test/${path}`,
+              downloadUrl: `https://media.test/${path}?download=1`,
+            },
+          ]),
+      },
+    ],
+  };
+}
 
 const run = (id: number, conclusion: string) => ({
   id,
@@ -302,6 +333,91 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       .and('contain', '-20%');
     cy.contains('tr', 'Valid clips').should('contain', '36').and('contain', '72');
     cy.contains('tr', 'Mean GPU power').find('[aria-label="Unavailable"]').should('have.length', 2);
+  });
+  it('opens the shared serving cell and switches from the chart without reloading the CI artifact', () => {
+    const saved = servingArtifact();
+    cy.window().then((win) =>
+      win.history.replaceState(
+        null,
+        '',
+        `${win.location.pathname}?run=123&artifact=40&source=123&cell=c4`,
+      ),
+    );
+    cy.intercept('GET', '/api/video-runs?run=123', {
+      run: run(123, 'success'),
+      artifacts: [saved.artifact],
+    }).as('servingRun');
+    cy.intercept('GET', '**/api/video-runs*format=media', saved).as('servingMedia');
+    cy.intercept('GET', 'https://media.test/**', { statusCode: 204 });
+    cy.intercept('GET', '/api/video-runs?run=123&artifact=40', () => {
+      throw new Error('Stored serving results must not fetch the ZIP');
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.wait(['@servingRun', '@servingMedia']);
+    cy.get('[data-testid="serving-selected-metrics"]')
+      .should('contain', 'C4')
+      .and('contain', '300 s');
+    cy.get('[data-testid="serving-media"] video').should(
+      'have.attr',
+      'src',
+      'https://media.test/gpu/c4/baseline/artifacts/measurement-r001-c001.mp4',
+    );
+    cy.contains('button', 'Hardware tradeoffs').click();
+    cy.get('[data-testid="video-tradeoff"] tbody tr')
+      .should('have.length', 3)
+      .first()
+      .find('button')
+      .click();
+    cy.contains('button', 'Open videos and full result').click();
+    cy.get('[data-testid="serving-selected-metrics"]')
+      .should('be.visible')
+      .and('contain', 'C1')
+      .and('contain', '120 s');
+    cy.get('[data-testid="serving-media"] video').should(
+      'have.attr',
+      'src',
+      'https://media.test/gpu/c1/baseline/artifacts/measurement-r001-c001.mp4',
+    );
+    cy.location('search').should('contain', 'cell=c1');
+    cy.get('@servingRun.all').should('have.length', 1);
+    cy.get('@servingMedia.all').should('have.length', 1);
+    cy.get('[data-testid="result-summary"]').should('not.exist');
+  });
+  it('shows a malformed serving matrix error instead of empty paired results', () => {
+    const saved = servingArtifact();
+    const source = saved.sources[0];
+    source.documents = source.documents.map(([path, document]) => [
+      path,
+      path === 'serving-smoke.json'
+        ? { schema_version: '9.0.0', bundle_type: 'h3_serving_smoke_matrix' }
+        : document,
+    ]);
+    cy.window().then((win) =>
+      win.history.replaceState(
+        null,
+        '',
+        `${win.location.pathname}?run=123&artifact=40&view=tradeoff`,
+      ),
+    );
+    cy.intercept('GET', '/api/video-runs?run=123', {
+      run: run(123, 'success'),
+      artifacts: [saved.artifact],
+    });
+    cy.intercept('GET', '**/api/video-runs*format=media', saved);
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoCIRuns />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('[role="alert"]', 'Invalid H3 serving matrix: unsupported matrix contract').should(
+      'be.visible',
+    );
+    cy.get('[data-testid="serving-results"], [data-testid="result-summary"]').should('not.exist');
+    cy.get('video').should('not.exist');
   });
   it('reports expiration without downloading or substituting another artifact', () => {
     cy.intercept('GET', '/api/video-runs?page=1', { runs: [run(30, 'success')], nextPage: null });

--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -366,6 +366,13 @@ describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
       'src',
       'https://media.test/gpu/c4/baseline/artifacts/measurement-r001-c001.mp4',
     );
+    cy.get('[data-testid="serving-media"] [aria-label="Clip / request"]').click();
+    cy.contains('[role="option"]', 'Warmup').click();
+    cy.get('[data-testid="serving-media"] video').should(
+      'have.attr',
+      'src',
+      'https://media.test/gpu/c4/baseline/artifacts/warmup-001.mp4',
+    );
     cy.contains('button', 'Hardware tradeoffs').click();
     cy.get('[data-testid="video-tradeoff"] tbody tr')
       .should('have.length', 3)

--- a/packages/app/cypress/component/video-serving-results.cy.tsx
+++ b/packages/app/cypress/component/video-serving-results.cy.tsx
@@ -158,6 +158,9 @@ describe('H3 serving results (synthetic fixtures)', () => {
   it('follows chart-driven cell changes while the result remains mounted', () => {
     cy.mount(<LinkedSelection />);
     cy.contains('button', 'C1').should('have.attr', 'aria-pressed', 'true');
+    cy.get('[aria-label="Clip / request"]').click();
+    cy.contains('[role="option"]', 'Warmup').click();
+    cy.get('video').should('have.attr', 'src', 'https://media.example.test/c1/warmup-001.mp4');
     cy.contains('button', 'Open C4 from chart').click();
     cy.contains('button', /^C4$/u).should('have.attr', 'aria-pressed', 'true');
     cy.get('video').should(
@@ -168,6 +171,32 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('button', 'C2').click();
     cy.contains('button', 'C2').should('have.attr', 'aria-pressed', 'true');
   });
+  it('renders a parent-created blob in the report while keeping scripts disabled', () => {
+    cy.window().then((win) => {
+      const blobUrl = win.URL.createObjectURL(
+        new Blob(
+          [
+            '<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"><rect width="2" height="2" fill="red"/></svg>',
+          ],
+          { type: 'image/svg+xml' },
+        ),
+      );
+      mount({
+        html: `<img src="${blobUrl}" alt="Synthetic blob image"><a href="${blobUrl}" download="fixture.svg">Download synthetic blob</a><script>document.body.dataset.scriptRan='yes'</script>`,
+      });
+      cy.contains('summary', 'Original report').click();
+      cy.get<HTMLIFrameElement>('iframe')
+        .should('have.attr', 'sandbox', 'allow-same-origin allow-downloads')
+        .should(($frame) => {
+          const doc = $frame[0].contentDocument;
+          expect(doc?.querySelector('img')?.naturalWidth).to.equal(2);
+          expect(doc?.querySelector('a')?.getAttribute('href')).to.equal(blobUrl);
+          expect(doc?.body.dataset.scriptRan).to.equal(undefined);
+        })
+        .then(() => win.URL.revokeObjectURL(blobUrl));
+    });
+  });
+
   it('shows each concurrency without manufacturing a candidate and uses allocated GPU count', () => {
     const change = cy.stub().as('change');
     mount({ onCellChange: change });

--- a/packages/app/cypress/component/video-serving-results.cy.tsx
+++ b/packages/app/cypress/component/video-serving-results.cy.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import ServingResults from '@/components/video-benchmark/ServingResults';
+import type { ServingCell } from '@/components/video-benchmark/serving';
+import type { Bundle } from '@/components/video-benchmark/bundle';
+
+// Synthetic fixtures exercise the serving contract; they are never benchmark results.
+const cells: ServingCell[] = [1, 2, 4].map((concurrency) => {
+  const id = `c${concurrency}`;
+  const request = (phase: string, slot: string) => ({
+    phase,
+    slot_id: slot,
+    artifact_path: `artifacts/${slot}.mp4`,
+    prompt: 'Synthetic test prompt only',
+    seed: 11,
+    submit_to_media_seconds: 120 * concurrency,
+    media_validation_seconds: 0.6,
+    media: {
+      valid: true,
+      video: { duration_seconds: 4.4583, width: 1344, height: 768, frame_count: 107, fps: 24 },
+      audio: { sample_rate_hz: 32000, channels: 2 },
+      checks: [{ name: 'media.decode', status: 'passed' }],
+    },
+  });
+  return {
+    id,
+    concurrency,
+    runPath: `gpu/${id}/baseline/run.json`,
+    jobPath: `gpu/${id}/gpu-job.json`,
+    powerPath: `gpu/${id}/power.json`,
+    specPath: `gpu/${id}/spec.json`,
+    cell: {
+      status: 'complete',
+      verified: true,
+      completion: {
+        valid: 4,
+        scheduled: 4,
+        completed: 4,
+        failed: 0,
+        not_started: 0,
+        unfinished: 0,
+      },
+      metrics: {
+        client_ready_p50_seconds: 120 * concurrency,
+        valid_clips_per_second: 1 / 120,
+        measurement: { wall_seconds: 480 },
+        serving: {
+          client_ready_latency_seconds: { sample_count: 4, p90: null },
+          valid_video_seconds_per_second: 4.4583 / 120,
+          peak_client_in_flight: concurrency,
+        },
+      },
+    },
+    run: {
+      records: [request('warmup', 'warmup-001'), request('measurement', 'measurement-r001-c001')],
+      plan: { generation: { duration_seconds: 4, frame_count: 107, num_inference_steps: 50 } },
+      configuration: {
+        model_id: 'Synthetic model',
+        model_revision: 'synthetic-model-revision',
+        runtime_revision: 'synthetic-runtime-revision',
+      },
+    },
+    job: {
+      roles: {
+        baseline: {
+          telemetry_summary: {
+            gpu_identity: [{ name: 'Synthetic GPU', uuid: 'GPU-test' }],
+            measurement_observed_memory_peak_mib_by_gpu: { 'GPU-test': 100000 },
+          },
+        },
+      },
+    },
+    spec: { gpu_uuids: ['GPU-test', 'GPU-test-2'], server: { ulysses_degree: 2, tp_size: 1 } },
+    power: {
+      phases: {
+        measurement: {
+          valid: true,
+          duration_seconds: 479.9,
+          aggregate: {
+            avg_power_w: 1374,
+            observed_peak_power_w: 1394,
+            energy_j: 656721,
+            joules_per_valid_clip: 164180,
+          },
+          per_gpu: { 'GPU-test': { avg_power_w: 687, observed_peak_power_w: 697 } },
+        },
+        startup: {
+          valid: false,
+          invalid_reasons: ['Synthetic missing telemetry'],
+          aggregate: { avg_power_w: 999999 },
+        },
+      },
+    },
+  };
+});
+const bundle: Bundle = {
+  manifest: {
+    run_id: '123',
+    git_commit: 'synthetic-backend-sha',
+    resources: { requested: { gpus: 8 } },
+  },
+  ci: { slurm_job: { AllocTRES: 'cpu=32,mem=512G,gres/gpu=2' } },
+  result: null,
+  job: null,
+  report: null,
+  comparison: null,
+  documents: new Map(),
+  files: new Map(),
+  checksums: new Map(),
+  manifestSha256: 'synthetic-manifest-sha',
+};
+const urls = new Map(
+  cells.flatMap((cell) =>
+    ['measurement-r001-c001', 'warmup-001'].map((slot): [string, string] => [
+      `gpu/${cell.id}/baseline/artifacts/${slot}.mp4`,
+      `https://media.example.test/${cell.id}/${slot}.mp4`,
+    ]),
+  ),
+);
+
+function mount(
+  props: Partial<React.ComponentProps<typeof ServingResults>> = {},
+  locale = '/video',
+) {
+  cy.mount(
+    <PathnameContext.Provider value={locale}>
+      <ServingResults
+        bundle={bundle}
+        cells={cells}
+        urls={urls}
+        downloads={new Map()}
+        html=""
+        {...props}
+      />
+    </PathnameContext.Provider>,
+  );
+}
+
+function LinkedSelection() {
+  const [cell, setCell] = useState('c1');
+  return (
+    <PathnameContext.Provider value="/video">
+      <button onClick={() => setCell('c4')}>Open C4 from chart</button>
+      <ServingResults
+        bundle={bundle}
+        cells={cells}
+        urls={urls}
+        downloads={new Map()}
+        html=""
+        initialCell={cell}
+        onCellChange={setCell}
+      />
+    </PathnameContext.Provider>
+  );
+}
+
+describe('H3 serving results (synthetic fixtures)', () => {
+  it('follows chart-driven cell changes while the result remains mounted', () => {
+    cy.mount(<LinkedSelection />);
+    cy.contains('button', 'C1').should('have.attr', 'aria-pressed', 'true');
+    cy.contains('button', 'Open C4 from chart').click();
+    cy.contains('button', /^C4$/u).should('have.attr', 'aria-pressed', 'true');
+    cy.get('video').should(
+      'have.attr',
+      'src',
+      'https://media.example.test/c4/measurement-r001-c001.mp4',
+    );
+    cy.contains('button', 'C2').click();
+    cy.contains('button', 'C2').should('have.attr', 'aria-pressed', 'true');
+  });
+  it('shows each concurrency without manufacturing a candidate and uses allocated GPU count', () => {
+    const change = cy.stub().as('change');
+    mount({ onCellChange: change });
+    cy.get('[data-testid="serving-matrix"] tbody tr').should('have.length', 3);
+    cy.get('[data-testid="serving-selected-metrics"]').within(() => {
+      cy.contains('120 s').should('be.visible');
+      cy.contains('p', '15').should('be.visible');
+      cy.contains('dt', 'P90 delivery latency').next().should('have.text', 'Unavailable');
+    });
+    cy.get('video')
+      .should('have.attr', 'src', 'https://media.example.test/c1/measurement-r001-c001.mp4')
+      .and('have.prop', 'muted', false);
+    cy.contains('button', /^C4$/u).click();
+    cy.get('@change').should('have.been.calledWith', 'c4');
+    cy.get('[data-testid="serving-selected-metrics"]').should('contain', '480 s');
+    cy.get('video').should(
+      'have.attr',
+      'src',
+      'https://media.example.test/c4/measurement-r001-c001.mp4',
+    );
+    cy.get('[aria-label="Clip / request"]').click();
+    cy.contains('[role="option"]', 'Warmup').click();
+    cy.get('video').should('have.attr', 'src', 'https://media.example.test/c4/warmup-001.mp4');
+    cy.get('[data-testid="serving-selected-metrics"]').should('contain', '4 / 4');
+    cy.contains('a', 'Download original MP4').should(
+      'have.attr',
+      'href',
+      'https://media.example.test/c4/warmup-001.mp4',
+    );
+    cy.contains('Baseline').should('not.exist');
+    cy.contains('Candidate').should('not.exist');
+  });
+
+  it('distinguishes requested and decoded duration and withholds invalid power', () => {
+    mount();
+    cy.contains('dt', 'Requested duration (s)').next().should('have.text', '4');
+    cy.contains('dt', 'Decoded video duration (s)').next().should('have.text', '4.4583');
+    cy.get('[data-testid="serving-power"]').within(() => {
+      cy.contains('dt', 'Energy / valid clip (kJ/clip)').next().should('have.text', '164.18');
+      cy.get('[aria-label="Power window"]').click();
+    });
+    cy.contains('[role="option"]', 'Startup').click();
+    cy.get('[data-testid="serving-power"]').within(() => {
+      cy.contains('dt', 'Aggregate mean (W)').next().should('have.text', 'Unavailable');
+      cy.contains('Synthetic missing telemetry').should('be.visible');
+      cy.contains('999,999').should('not.exist');
+    });
+  });
+
+  it('withholds headline metrics and power for an unverified configuration', () => {
+    mount({
+      cells: [
+        {
+          ...cells[0],
+          cell: {
+            verified: false,
+            status: 'failed',
+            metrics: { client_ready_p50_seconds: 999999, valid_clips_per_second: 999999 },
+          },
+        },
+      ],
+    });
+    cy.get('[data-testid="serving-selected-metrics"]').should('not.contain', '999,999');
+    cy.get('[data-testid="serving-matrix"]').should('not.contain', '999,999');
+    cy.contains('dt', 'Measurement verified').next().should('have.text', 'No');
+    cy.get('[data-testid="serving-power"]').within(() => {
+      cy.contains('dt', 'Aggregate mean (W)').next().should('have.text', 'Unavailable');
+    });
+  });
+
+  it('supports Chinese copy and missing request, media, and allocation data', () => {
+    mount({ urls: new Map(), bundle: { ...bundle, ci: null } }, '/zh/video');
+    cy.contains('并发服务测试结果').should('be.visible');
+    cy.contains('此请求暂无可用媒体。').should('be.visible');
+    cy.get('video').should('not.exist');
+    cy.contains('p', '有效视频 / 已分配 GPU 小时').next().should('have.text', '无数据');
+    mount({ cells: [{ ...cells[0], run: null, job: null, spec: null, power: null }] });
+    cy.contains('No request records are available for this configuration.').should('be.visible');
+  });
+});

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -2,6 +2,7 @@ import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.share
 import VideoTradeoff from '@/components/video-benchmark/VideoTradeoff';
 import type { TradeoffRun } from '@/components/video-benchmark/tradeoff';
 import type { Json } from '@/components/video-benchmark/bundle';
+import { servingFixture } from '@/components/video-benchmark/serving.fixture';
 
 const role = {
   metrics: {
@@ -126,5 +127,64 @@ describe('Video tradeoff chart (synthetic fixtures)', () => {
     cy.contains('[role="option"]', '#2').click();
     cy.contains('summary', 'Matched workload').click();
     cy.get('[data-testid="tradeoff-detail"] pre').first().should('contain', '"guidance_scale": 4');
+  });
+});
+
+const matrix = (): TradeoffRun => ({
+  exportRun: '123',
+  artifact: '456',
+  bundle: { ...servingFixture(), result: null, manifestSha256: 'synthetic-serving' },
+});
+
+describe('Video serving matrix chart (synthetic contract fixture)', () => {
+  it('shows three labeled cell medians and opens the selected concurrency result', () => {
+    const open = cy.stub().as('openCell');
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[matrix()]} onOpen={open} />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[role="combobox"][aria-label="Latency axis · lower is better"]').should(
+      'contain',
+      'Median client-ready latency (s)',
+    );
+    cy.get('circle.point').should('have.length', 3);
+    cy.get('text.serving-point-label')
+      .should('have.length', 3)
+      .then((labels) => {
+        expect([...labels].map((label) => label.textContent)).to.deep.equal(['C1', 'C2', 'C4']);
+      });
+    cy.contains('Closed-loop smoke · serving capacity not qualified').should('be.visible');
+    cy.get('tbody tr')
+      .should('have.length', 3)
+      .each((row) => {
+        cy.wrap(row).should('contain', '4 / 4 / 4').and('contain', '15');
+      });
+    cy.get('[role="combobox"][aria-label="Latency axis · lower is better"]').click();
+    cy.contains('[role="option"]', 'P90 client-ready latency (s)').click();
+    cy.get('circle.point').should('not.exist');
+    cy.contains('No points qualify for these axes yet.').should('be.visible');
+    cy.contains('button', 'Show cell medians').click();
+    cy.get('circle.point').should('have.length', 3);
+    cy.contains('tbody button', 'Client concurrency 4').click();
+    cy.contains('button', 'Open videos and full result').click();
+    cy.get('@openCell')
+      .should('have.been.calledOnce')
+      .its('firstCall.args.0.cellId')
+      .should('equal', 'c4');
+  });
+  it('shows the Chinese serving labels with per-cell medians', () => {
+    cy.mount(
+      <PathnameContext.Provider value="/zh/video">
+        <VideoTradeoff runs={[matrix()]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[role="combobox"][aria-label="延迟轴 · 越低越好"]').should(
+      'contain',
+      '客户端就绪延迟中位数（秒）',
+    );
+    cy.get('circle.point').should('have.length', 3);
+    cy.contains('客户端并发数 2').should('be.visible');
+    cy.contains('闭环冒烟测试 · 尚未通过服务容量验证').should('be.visible');
   });
 });

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -185,6 +185,6 @@ describe('Video serving matrix chart (synthetic contract fixture)', () => {
     );
     cy.get('circle.point').should('have.length', 3);
     cy.contains('客户端并发数 2').should('be.visible');
-    cy.contains('闭环冒烟测试 · 尚未通过服务容量验证').should('be.visible');
+    cy.contains('闭环冒烟测试 · 服务容量未经验证').should('be.visible');
   });
 });

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -50,21 +50,23 @@ const run: TradeoffRun = {
 };
 
 describe('Video tradeoff chart (synthetic fixtures)', () => {
-  it('withholds missing cost, plots measured axes and drills into the original run', () => {
+  it('plots allocated GPU efficiency by default and requires assumptions for the cost axis', () => {
     const open = cy.stub().as('open');
     cy.mount(
       <PathnameContext.Provider value="/video">
         <VideoTradeoff runs={[run]} onOpen={open} />
       </PathnameContext.Provider>,
     );
-    cy.contains('No points qualify for these axes yet.').should('be.visible');
-    cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();
-    cy.contains('[role="option"]', 'Valid clips / allocated GPU-hour').click();
+    cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').should(
+      'contain',
+      'Valid clips / allocated GPU-hour',
+    );
     cy.get('[data-testid="video-tradeoff-chart"] circle.point').should('have.length', 2);
     cy.contains('td', '1.25').should('be.visible');
     cy.contains('dd', '8 / 4').should('be.visible');
     cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();
     cy.contains('[role="option"]', 'Valid clips / USD').click();
+    cy.contains('No points qualify for these axes yet.').should('be.visible');
     cy.get('input[aria-label="Whole deployment cost (USD/hour)"]').type('2');
     cy.get('circle.point').should('not.exist');
     cy.get('input[aria-label="Cost source and included items"]').type(
@@ -75,6 +77,27 @@ describe('Video tradeoff chart (synthetic fixtures)', () => {
     cy.contains('td', '5').should('be.visible');
     cy.contains('button', 'Open videos and full result').click();
     cy.get('@open').should('have.been.calledOnce');
+  });
+  it('still withholds P90 for single-request results until median diagnostics are selected', () => {
+    const single = structuredClone(run);
+    const result = single.bundle.result as { roles: Record<string, typeof role> };
+    for (const point of Object.values(result.roles)) {
+      point.records = point.records.slice(0, 1);
+      point.metrics.completion = { valid: 1, completed: 1, scheduled: 1, failed: 0 };
+    }
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[single]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('No points qualify for these axes yet.').should('be.visible');
+    cy.get('circle.point').should('not.exist');
+    cy.contains('button', 'Inspect available serial results').click();
+    cy.get('[role="combobox"][aria-label="Latency axis · lower is better"]').should(
+      'contain',
+      'Median client-ready latency (s)',
+    );
+    cy.get('circle.point').should('have.length', 2);
   });
   it('shows an empty state without inventing fixture results', () => {
     cy.mount(

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -1,0 +1,712 @@
+'use client';
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Heading } from '@/components/ui/heading';
+import { useLocale } from '@/lib/use-locale';
+import { track } from '@/lib/analytics';
+import VideoSelect from './VideoSelect';
+import { at, number, rows, safePath, text, type Bundle, type Json } from './bundle';
+import type { ServingCell } from './serving';
+
+const STRINGS = {
+  en: {
+    title: 'Serving results',
+    smoke: 'Exploratory serving smoke test',
+    intro:
+      'Compare client concurrency on the same deployment. Select a configuration to inspect its requests and generated media.',
+    concurrency: 'Client concurrency',
+    valid: 'Valid / scheduled',
+    median: 'Median delivery latency',
+    hour: 'Valid clips / deployment-hour',
+    gpuHour: 'Valid clips / allocated GPU-hour',
+    secondsHour: 'Video seconds / allocated GPU-hour',
+    wall: 'Delivery measurement window',
+    rate: 'Valid clips / second',
+    samples: 'Valid latency samples',
+    p90: 'P90 delivery latency',
+    p90Note:
+      'P90 is unavailable below 10 valid latency samples per configuration. That display threshold does not establish statistical confidence or sustainable capacity.',
+    timing:
+      'Latency runs from submission to the complete downloaded video, including polling and transfer. Throughput uses the closed-loop delivery window; startup, warmup and subsequent local validation are excluded. Hourly rates extrapolate that measured window.',
+    closedLoop: 'Closed-loop client load',
+    status: 'Execution status',
+    verified: 'Measurement verified',
+    yes: 'Yes',
+    no: 'No',
+    unavailable: 'Unavailable',
+    complete: 'Complete',
+    incomplete: 'Incomplete',
+    measured: 'Measured',
+    warmup: 'Warmup · excluded from measured metrics',
+    slot: 'Clip / request',
+    prompt: 'Prompt',
+    seed: 'Seed',
+    requestLatency: 'This request: submission → downloaded media',
+    validation: 'Subsequent local validation',
+    settings: 'Generation settings',
+    requestedDuration: 'Requested duration (s)',
+    decodedDuration: 'Decoded video duration (s)',
+    resolution: 'Decoded resolution',
+    frames: 'Decoded frames / FPS',
+    audio: 'Audio sample rate / channels',
+    listen: 'Play to hear the original audio. Playback starts only when you press play.',
+    download: 'Download original MP4',
+    noMedia: 'No media available for this request.',
+    mediaError:
+      'The video could not be loaded or decoded. Download the original MP4 to inspect it.',
+    noRequests: 'No request records are available for this configuration.',
+    integrity: 'Video & audio integrity',
+    passed: 'Passed',
+    failed: 'Failed',
+    integrityNote:
+      'Technical validity checks decoding, geometry, timing and audio continuity. It does not establish prompt adherence, perceptual quality or lip sync. This smoke test has no paired fidelity or calibrated regression result.',
+    checks: 'All recorded integrity checks',
+    request: 'Full request record',
+    power: 'Measured GPU power & energy',
+    phase: 'Power window',
+    measurement: 'Generation',
+    startup: 'Startup',
+    warmupPhase: 'Warmup',
+    mean: 'Aggregate mean (W)',
+    peak: 'Observed aggregate peak (W)',
+    energy: 'Integrated energy (kJ)',
+    perClip: 'Energy / valid clip (kJ/clip)',
+    powerWindow: 'Power window duration (s)',
+    powerNote:
+      'Generation power covers first submission → last observed provider completion. Intervening idle time, downloads and validation are included; overlapping requests are integrated once. Startup and warmup are separate. Time-weighted board measurements exclude the host and facility; sampled peaks are not instantaneous electrical peaks.',
+    gpu: 'GPU',
+    meanGpu: 'Mean power (W)',
+    peakGpu: 'Observed peak (W)',
+    memory: 'Sampled memory peak (MiB)',
+    memoryNote:
+      'Device-used VRAM during the client workload, including warmup. MiB = 2²⁰ bytes; sampling may miss peaks. These are not framework allocator peaks.',
+    hardware: 'Hardware & execution',
+    allocated: 'Allocated GPUs',
+    participating: 'Participating GPUs',
+    model: 'Model',
+    modelRevision: 'Model revision',
+    runtimeRevision: 'Runtime revision',
+    sourceHash: 'Runtime source SHA256',
+    server: 'Server configuration',
+    observed: 'Observed submission rate (requests/s)',
+    inFlight: 'Peak client requests in flight',
+    missing: 'Unavailable serving measurements',
+    missingNote:
+      'Server-side queue delay, server-ready latency, observed batch sizes and fixed offered arrival rate are not supplied. Closed-loop concurrency is not server batch size. Costs and prices require separate, dated assumptions.',
+    outcome: 'Completion accounting',
+    completed: 'Completed',
+    failedCount: 'Failed / invalid',
+    notStarted: 'Not started',
+    unfinished: 'Unfinished',
+    provenance: 'Provenance & downloads',
+    ci: 'Exact CI run',
+    manifest: 'Manifest SHA256',
+    source: 'Backend commit',
+    raw: 'Raw result files',
+    report: 'Original report',
+    reportNote: 'Original report in a sandbox. Scripts and external requests are disabled.',
+    limits:
+      'Exploratory measurements only. This result is not release qualified or a sustained-capacity comparison.',
+    noCells: 'No verified serving configurations are available.',
+  },
+  zh: {
+    title: '并发服务测试结果',
+    smoke: '探索性服务冒烟测试',
+    intro: '在同一部署上比较客户端并发数。选择配置，查看逐请求数据与生成的视频。',
+    concurrency: '客户端并发数',
+    valid: '有效 / 计划请求',
+    median: '交付延迟中位数',
+    hour: '有效视频 / 部署小时',
+    gpuHour: '有效视频 / 已分配 GPU 小时',
+    secondsHour: '视频秒数 / 已分配 GPU 小时',
+    wall: '交付测量时段',
+    rate: '有效视频 / 秒',
+    samples: '有效延迟样本数',
+    p90: 'P90 交付延迟',
+    p90Note:
+      '每个配置不足 10 个有效延迟样本时不显示 P90。达到显示门槛也不代表具备统计置信度或已验证持续服务容量。',
+    timing:
+      '延迟从提交请求计时，到完整视频下载完成为止，包含轮询与传输。吞吐量按闭环交付测量时段计算，不含启动、warmup 和随后进行的本地校验。每小时指标由该测量时段外推得出。',
+    closedLoop: '闭环客户端负载',
+    status: '执行状态',
+    verified: '测量结果已验证',
+    yes: '是',
+    no: '否',
+    unavailable: '无数据',
+    complete: '已完成',
+    incomplete: '未完成',
+    measured: '正式测量',
+    warmup: 'Warmup · 不计入正式测量指标',
+    slot: '视频 / 请求',
+    prompt: 'Prompt',
+    seed: 'Seed',
+    requestLatency: '当前请求：提交 → 视频下载完成',
+    validation: '随后进行的本地校验',
+    settings: '生成配置',
+    requestedDuration: '请求的视频时长（s）',
+    decodedDuration: '解码后视频时长（s）',
+    resolution: '解码后分辨率',
+    frames: '解码帧数 / FPS',
+    audio: '音频采样率 / 声道数',
+    listen: '点击播放可听到原始音频；视频不会自动播放。',
+    download: '下载原始 MP4',
+    noMedia: '此请求暂无可用媒体。',
+    mediaError: '视频加载或解码失败。请下载原始 MP4 查看。',
+    noRequests: '此配置暂无逐请求记录。',
+    integrity: '视频与音频完整性',
+    passed: '通过',
+    failed: '未通过',
+    integrityNote:
+      '技术有效性检查涵盖解码、画面尺寸、时间戳与音频连续性，不代表符合 prompt、感知质量良好或音画同步。此冒烟测试未提供成对保真度或经过校准的回归结论。',
+    checks: '全部完整性检查记录',
+    request: '完整请求记录',
+    power: '实测 GPU 功率与能耗',
+    phase: '功率统计时段',
+    measurement: '生成',
+    startup: '启动',
+    warmupPhase: 'Warmup',
+    mean: '合计平均功率（W）',
+    peak: '合计观测峰值（W）',
+    energy: '积分能耗（kJ）',
+    perClip: '每有效视频能耗（kJ/clip）',
+    powerWindow: '功率统计时段时长（s）',
+    powerNote:
+      '生成阶段功率覆盖首次提交到最后一次观测到服务端完成为止，包含期间的空闲、下载与校验时间；并发请求重叠时段只积分一次。启动与 warmup 单独统计。板卡功率按时间加权，不含主机与设施能耗；采样峰值不是瞬时电气峰值。',
+    gpu: 'GPU',
+    meanGpu: '平均功率（W）',
+    peakGpu: '观测峰值（W）',
+    memory: '显存采样峰值（MiB）',
+    memoryNote:
+      '客户端工作负载期间的设备已用显存，包含 warmup。MiB = 2²⁰ 字节；采样可能遗漏峰值，也不等同于框架分配器统计的峰值。',
+    hardware: '硬件与执行配置',
+    allocated: '已分配 GPU 数',
+    participating: '参与测试 GPU 数',
+    model: '模型',
+    modelRevision: '模型版本',
+    runtimeRevision: '运行时版本',
+    sourceHash: '运行时源码 SHA256',
+    server: '服务端配置',
+    observed: '观测提交速率（requests/s）',
+    inFlight: '客户端在途请求峰值',
+    missing: '尚未提供的服务指标',
+    missingNote:
+      '尚无服务端排队时长、服务端完成延迟、实际 batch size 或固定请求到达速率。闭环客户端并发数不等于服务端 batch size。成本与价格需要另行提供注明日期的假设。',
+    outcome: '请求完成情况',
+    completed: '已完成',
+    failedCount: '失败 / 无效',
+    notStarted: '未开始',
+    unfinished: '未结束',
+    provenance: '来源与下载',
+    ci: '对应 CI 运行',
+    manifest: 'Manifest SHA256',
+    source: '后端提交',
+    raw: '原始结果文件',
+    report: '原始报告',
+    reportNote: '原始报告在沙盒中显示，已禁用脚本与外部请求。',
+    limits: '仅供探索性分析，不属于发布验收结果，也不构成持续服务容量比较。',
+    noCells: '暂无已验证的服务测试配置。',
+  },
+};
+
+function multiply(value: Json, by: number) {
+  const n = number(value);
+  return n === null ? null : n * by;
+}
+
+function Data({ values }: { values: [string, string][] }) {
+  return (
+    <dl className="grid gap-3 text-sm sm:grid-cols-2">
+      {values.map(([label, value]) => (
+        <div key={label} className="min-w-0 space-y-1">
+          <dt className="text-xs text-muted-foreground">{label}</dt>
+          <dd className="break-all font-medium tabular-nums">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export default function ServingResults({
+  bundle,
+  cells,
+  urls,
+  downloads,
+  html,
+  initialCell,
+  onCellChange,
+}: {
+  bundle: Bundle;
+  cells: ServingCell[];
+  urls: Map<string, string>;
+  downloads: Map<string, string>;
+  html: string;
+  initialCell?: string;
+  onCellChange?: (id: string) => void;
+}) {
+  const s = STRINGS[useLocale()];
+  const [selected, setSelected] = useState(initialCell ?? '');
+  const [slot, setSlot] = useState('');
+  const [phase, setPhase] = useState<'measurement' | 'startup' | 'warmup'>('measurement');
+  const [failedMedia, setFailedMedia] = useState('');
+  const selectedId = onCellChange ? (initialCell ?? selected) : selected;
+  const current = cells.find((cell) => cell.id === selectedId) ?? cells[0];
+  const fmt = (value: Json, digits = 2): string => {
+    const n = number(value);
+    return n === null
+      ? s.unavailable
+      : n.toLocaleString('en-US', { maximumFractionDigits: digits });
+  };
+  const scalar = (value: Json) =>
+    text(value) || (number(value) === null ? s.unavailable : fmt(value));
+  if (!current) return <Card>{s.noCells}</Card>;
+  const { cell, run, job, spec, power } = current;
+  const verified = at(cell, 'verified') === true;
+  const metrics = verified ? at(cell, 'metrics') : null;
+  const serving = at(metrics, 'serving');
+  const completion = at(cell, 'completion');
+  const records = rows(at(run, 'records'));
+  const record =
+    records.find((row) => text(at(row, 'slot_id')) === slot) ??
+    records.find((row) => at(row, 'phase') === 'measurement') ??
+    records[0];
+  const media = at(record, 'media');
+  const warmup = at(record, 'phase') === 'warmup';
+  const telemetry = at(job, 'roles', 'baseline', 'telemetry_summary');
+  const devices = rows(at(telemetry, 'gpu_identity'));
+  const allocatedMatch = /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
+    text(at(bundle.ci, 'slurm_job', 'AllocTRES')),
+  );
+  const allocated = number(allocatedMatch ? Number(allocatedMatch.groups?.count) : null);
+  const gpuRate = (value: Json) =>
+    allocated !== null && allocated > 0 ? multiply(value, 3600 / allocated) : null;
+  const powerData = at(power, 'phases', phase);
+  const powerValue = (...keys: string[]) =>
+    verified && at(powerData, 'valid') === true ? at(powerData, ...keys) : null;
+  let mediaPath = '';
+  try {
+    const path = text(at(record, 'artifact_path'));
+    if (path)
+      mediaPath = safePath(
+        `${current.runPath.slice(0, current.runPath.lastIndexOf('/') + 1)}${safePath(path)}`,
+      );
+  } catch {
+    // Invalid manifest paths never become media URLs.
+  }
+  const mediaUrl = urls.get(mediaPath);
+  const chooseCell = (id: string) => {
+    setSelected(id);
+    setSlot('');
+    onCellChange?.(id);
+    track('video_serving_configuration_selected', { configuration: id });
+  };
+  const p90 = number(at(serving, 'client_ready_latency_seconds', 'sample_count'));
+  const ciId = text(at(bundle.manifest, 'run_id'));
+  const rawPaths = [
+    'serving-smoke.json',
+    current.runPath,
+    current.jobPath,
+    current.powerPath,
+    current.specPath,
+    'manifest.json',
+    'SHA256SUMS',
+  ];
+
+  return (
+    <div className="space-y-4" data-testid="serving-results">
+      <Card className="gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <Heading>{s.title}</Heading>
+            <p className="text-sm text-muted-foreground">{s.intro}</p>
+          </div>
+          <span className="rounded-full border px-3 py-1 text-xs text-muted-foreground">
+            {s.smoke}
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm" data-testid="serving-matrix">
+            <thead className="text-xs text-muted-foreground">
+              <tr>
+                {[s.concurrency, s.valid, `${s.median} (s)`, s.hour].map((label) => (
+                  <th key={label} className="px-3 py-2 font-medium">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="tabular-nums">
+              {cells.map((item) => (
+                <tr
+                  key={item.id}
+                  className={item.id === current.id ? 'bg-primary/10' : 'border-t border-border/40'}
+                >
+                  <td className="px-3 py-2">
+                    <Button
+                      size="sm"
+                      variant={item.id === current.id ? 'default' : 'outline'}
+                      aria-pressed={item.id === current.id}
+                      onClick={() => chooseCell(item.id)}
+                    >
+                      C{item.concurrency}
+                    </Button>
+                  </td>
+                  <td className="px-3 py-2">
+                    {fmt(at(item.cell, 'completion', 'valid'))} /{' '}
+                    {fmt(at(item.cell, 'completion', 'scheduled'))}
+                  </td>
+                  <td className="px-3 py-2">
+                    {fmt(
+                      at(item.cell, 'verified') === true
+                        ? at(item.cell, 'metrics', 'client_ready_p50_seconds')
+                        : null,
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    {fmt(
+                      multiply(
+                        at(item.cell, 'verified') === true
+                          ? at(item.cell, 'metrics', 'valid_clips_per_second')
+                          : null,
+                        3600,
+                      ),
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">{s.timing}</p>
+      </Card>
+
+      <Card className="gap-5" data-testid="serving-media">
+        {record ? (
+          <>
+            <div className="max-w-lg">
+              <VideoSelect
+                label={s.slot}
+                value={text(at(record, 'slot_id'))}
+                onValueChange={setSlot}
+                options={records.map((item) => ({
+                  value: text(at(item, 'slot_id')),
+                  label: `${at(item, 'phase') === 'warmup' ? s.warmup : s.measured} · ${text(at(item, 'slot_id'))}`,
+                }))}
+              />
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="min-w-0 space-y-3">
+                {mediaUrl ? (
+                  <video
+                    key={mediaUrl}
+                    src={mediaUrl}
+                    controls
+                    playsInline
+                    preload="metadata"
+                    aria-label={`${s.slot} ${text(at(record, 'slot_id'))}`}
+                    className="aspect-video w-full rounded-lg bg-black"
+                    onError={() => setFailedMedia(mediaUrl)}
+                  />
+                ) : (
+                  <div className="flex aspect-video items-center justify-center rounded-lg bg-muted p-5 text-sm text-muted-foreground">
+                    {s.noMedia}
+                  </div>
+                )}
+                {failedMedia === mediaUrl && (
+                  <p role="alert" className="text-sm text-destructive">
+                    {s.mediaError}
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">{s.listen}</p>
+                {mediaUrl && (
+                  <a
+                    href={downloads.get(mediaPath) ?? mediaUrl}
+                    download
+                    className="text-sm text-primary underline"
+                  >
+                    {s.download}
+                  </a>
+                )}
+                <Data
+                  values={[
+                    [s.requestLatency, `${fmt(at(record, 'submit_to_media_seconds'))} s`],
+                    [s.validation, `${fmt(at(record, 'media_validation_seconds'))} s`],
+                    [s.seed, scalar(at(record, 'seed'))],
+                    [
+                      s.integrity,
+                      at(media, 'valid') === true
+                        ? s.passed
+                        : at(media, 'valid') === false
+                          ? s.failed
+                          : s.unavailable,
+                    ],
+                  ]}
+                />
+                {warmup && (
+                  <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
+                    {s.warmup}
+                  </p>
+                )}
+              </div>
+              <div className="min-w-0 space-y-5">
+                <div className="space-y-2">
+                  <Heading level="label">{s.prompt}</Heading>
+                  <p className="whitespace-pre-wrap break-words text-sm leading-relaxed">
+                    {text(at(record, 'prompt')) || s.unavailable}
+                  </p>
+                </div>
+                <Data
+                  values={[
+                    [s.requestedDuration, fmt(at(run, 'plan', 'generation', 'duration_seconds'))],
+                    [s.decodedDuration, fmt(at(media, 'video', 'duration_seconds'), 4)],
+                    [
+                      s.resolution,
+                      `${fmt(at(media, 'video', 'width'))} × ${fmt(at(media, 'video', 'height'))}`,
+                    ],
+                    [
+                      s.frames,
+                      `${fmt(at(media, 'video', 'frame_count'))} / ${fmt(at(media, 'video', 'fps'))}`,
+                    ],
+                    [
+                      s.audio,
+                      `${fmt(at(media, 'audio', 'sample_rate_hz'))} Hz / ${fmt(at(media, 'audio', 'channels'))}`,
+                    ],
+                  ]}
+                />
+                <details>
+                  <summary className="cursor-pointer text-sm">{s.settings}</summary>
+                  <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap break-all text-xs">
+                    {JSON.stringify(at(run, 'plan', 'generation'), null, 2)}
+                  </pre>
+                </details>
+              </div>
+            </div>
+            <p className="text-xs leading-relaxed text-muted-foreground">{s.integrityNote}</p>
+            <details>
+              <summary className="cursor-pointer text-sm">{s.checks}</summary>
+              <pre className="mt-3 max-h-96 overflow-auto whitespace-pre-wrap break-all text-xs">
+                {JSON.stringify(at(media, 'checks'), null, 2)}
+              </pre>
+            </details>
+            <details>
+              <summary className="cursor-pointer text-sm">{s.request}</summary>
+              <pre className="mt-3 max-h-96 overflow-auto whitespace-pre-wrap break-all text-xs">
+                {JSON.stringify(record, null, 2)}
+              </pre>
+            </details>
+          </>
+        ) : (
+          <p>{s.noRequests}</p>
+        )}
+      </Card>
+
+      <Card className="gap-4" data-testid="serving-selected-metrics">
+        <Heading level="card">
+          C{current.concurrency} · {s.closedLoop}
+        </Heading>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          {[
+            [s.median, `${fmt(at(metrics, 'client_ready_p50_seconds'))} s`],
+            [s.gpuHour, fmt(gpuRate(at(metrics, 'valid_clips_per_second')))],
+            [s.valid, `${fmt(at(completion, 'valid'))} / ${fmt(at(completion, 'scheduled'))}`],
+            [s.wall, `${fmt(at(metrics, 'measurement', 'wall_seconds'))} s`],
+          ].map(([label, value]) => (
+            <div key={label} className="min-w-0 space-y-2">
+              <p className="text-xs text-muted-foreground">{label}</p>
+              <p className="text-2xl font-semibold tabular-nums">{value}</p>
+            </div>
+          ))}
+        </div>
+        <Data
+          values={[
+            [s.status, at(cell, 'status') === 'complete' ? s.complete : s.incomplete],
+            [s.verified, verified ? s.yes : s.no],
+            [s.rate, fmt(at(metrics, 'valid_clips_per_second'), 6)],
+            [s.secondsHour, fmt(gpuRate(at(serving, 'valid_video_seconds_per_second')))],
+            [
+              s.p90,
+              p90 !== null && p90 >= 10
+                ? fmt(at(serving, 'client_ready_latency_seconds', 'p90'))
+                : s.unavailable,
+            ],
+            [s.samples, fmt(at(serving, 'client_ready_latency_seconds', 'sample_count'))],
+            [s.inFlight, fmt(at(serving, 'peak_client_in_flight'))],
+          ]}
+        />
+        <p className="text-xs text-muted-foreground">{s.p90Note}</p>
+      </Card>
+
+      <Card className="gap-4" data-testid="serving-power">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <Heading>{s.power}</Heading>
+          <div className="w-full sm:w-52">
+            <VideoSelect
+              label={s.phase}
+              value={phase}
+              onValueChange={(value) => setPhase(value as typeof phase)}
+              options={[
+                { value: 'measurement', label: s.measurement },
+                { value: 'startup', label: s.startup },
+                { value: 'warmup', label: s.warmupPhase },
+              ]}
+            />
+          </div>
+        </div>
+        <Data
+          values={[
+            [s.mean, fmt(powerValue('aggregate', 'avg_power_w'))],
+            [s.peak, fmt(powerValue('aggregate', 'observed_peak_power_w'))],
+            [s.energy, fmt(multiply(powerValue('aggregate', 'energy_j'), 0.001))],
+            [s.perClip, fmt(multiply(powerValue('aggregate', 'joules_per_valid_clip'), 0.001))],
+            [s.powerWindow, fmt(powerValue('duration_seconds'))],
+          ]}
+        />
+        {at(powerData, 'valid') !== true && (
+          <p className="text-sm text-muted-foreground">
+            {rows(at(powerData, 'invalid_reasons')).map(text).join(', ') || s.unavailable}
+          </p>
+        )}
+        <p className="text-xs leading-relaxed text-muted-foreground">{s.powerNote}</p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-xs">
+            <thead>
+              <tr>
+                {[s.gpu, s.meanGpu, s.peakGpu, s.memory].map((label) => (
+                  <th key={label} className="py-2 pr-4 font-medium text-muted-foreground">
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {devices.map((device) => {
+                const uuid = text(at(device, 'uuid'));
+                return (
+                  <tr key={uuid} className="border-t border-border/40">
+                    <td className="max-w-64 py-3 pr-4">
+                      <p>{text(at(device, 'name'))}</p>
+                      <p className="break-all text-muted-foreground">{uuid}</p>
+                    </td>
+                    <td className="pr-4 tabular-nums">
+                      {fmt(powerValue('per_gpu', uuid, 'avg_power_w'))}
+                    </td>
+                    <td className="pr-4 tabular-nums">
+                      {fmt(powerValue('per_gpu', uuid, 'observed_peak_power_w'))}
+                    </td>
+                    <td className="tabular-nums">
+                      {fmt(at(telemetry, 'measurement_observed_memory_peak_mib_by_gpu', uuid))}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-muted-foreground">{s.memoryNote}</p>
+      </Card>
+
+      <Card className="gap-4">
+        <Heading>{s.hardware}</Heading>
+        <Data
+          values={[
+            [s.model, scalar(at(run, 'configuration', 'model_id'))],
+            [s.modelRevision, scalar(at(run, 'configuration', 'model_revision'))],
+            [s.runtimeRevision, scalar(at(run, 'configuration', 'runtime_revision'))],
+            [s.sourceHash, scalar(at(spec, 'baseline', 'source_sha256'))],
+            [s.allocated, fmt(allocated)],
+            [
+              s.participating,
+              rows(at(spec, 'gpu_uuids')).length > 0
+                ? fmt(rows(at(spec, 'gpu_uuids')).length)
+                : s.unavailable,
+            ],
+            [s.observed, fmt(at(serving, 'observed_submission_rate_per_second'), 6)],
+          ]}
+        />
+        <details>
+          <summary className="cursor-pointer text-sm">{s.server}</summary>
+          <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(at(spec, 'server'), null, 2)}
+          </pre>
+        </details>
+        <details>
+          <summary className="cursor-pointer text-sm">{s.outcome}</summary>
+          <div className="mt-3">
+            <Data
+              values={[
+                [s.completed, fmt(at(completion, 'completed'))],
+                [s.failedCount, fmt(at(completion, 'failed'))],
+                [s.notStarted, fmt(at(completion, 'not_started'))],
+                [s.unfinished, fmt(at(completion, 'unfinished'))],
+              ]}
+            />
+          </div>
+          <pre className="mt-3 max-h-72 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(at(serving, 'outcomes'), null, 2)}
+          </pre>
+        </details>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          <span className="font-medium">{s.missing}: </span>
+          {s.missingNote}
+        </p>
+        <p className="text-xs text-muted-foreground">{s.limits}</p>
+      </Card>
+
+      <Card className="gap-4">
+        <Heading>{s.provenance}</Heading>
+        {/^[1-9]\d*$/u.test(ciId) && (
+          <a
+            href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${ciId}`}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm text-primary underline"
+          >
+            {s.ci} · #{ciId}
+          </a>
+        )}
+        <Data
+          values={[
+            [s.source, scalar(at(bundle.manifest, 'git_commit'))],
+            [s.manifest, bundle.manifestSha256],
+          ]}
+        />
+        <details>
+          <summary className="cursor-pointer text-sm">{s.raw}</summary>
+          <div className="mt-3 flex flex-col gap-2">
+            {rawPaths
+              .filter((path) => urls.has(path))
+              .map((path) => (
+                <a
+                  key={path}
+                  href={downloads.get(path) ?? urls.get(path)}
+                  download
+                  className="break-all font-mono text-xs text-primary underline"
+                >
+                  {path}
+                </a>
+              ))}
+          </div>
+        </details>
+        {html && (
+          <details>
+            <summary className="cursor-pointer text-sm">{s.report}</summary>
+            <p className="my-3 text-xs text-muted-foreground">{s.reportNote}</p>
+            <iframe
+              title={s.report}
+              srcDoc={html}
+              sandbox="allow-downloads"
+              className="h-[640px] w-full rounded-lg border bg-white"
+            />
+          </details>
+        )}
+        <details>
+          <summary className="cursor-pointer text-sm">{s.hardware} · JSON</summary>
+          <pre className="mt-3 max-h-96 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(job, null, 2)}
+          </pre>
+        </details>
+      </Card>
+    </div>
+  );
+}

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Heading } from '@/components/ui/heading';
@@ -252,6 +252,9 @@ export default function ServingResults({
   const [failedMedia, setFailedMedia] = useState('');
   const selectedId = onCellChange ? (initialCell ?? selected) : selected;
   const current = cells.find((cell) => cell.id === selectedId) ?? cells[0];
+  useEffect(() => {
+    setSlot('');
+  }, [current?.id]);
   const fmt = (value: Json, digits = 2): string => {
     const n = number(value);
     return n === null
@@ -695,7 +698,7 @@ export default function ServingResults({
             <iframe
               title={s.report}
               srcDoc={html}
-              sandbox="allow-downloads"
+              sandbox="allow-same-origin allow-downloads"
               className="h-[640px] w-full rounded-lg border bg-white"
             />
           </details>

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -9,6 +9,9 @@ import { useLocale } from '@/lib/use-locale';
 import { track } from '@/lib/analytics';
 import ResultPower from './ResultPower';
 import VideoSelect from './VideoSelect';
+import ServingResults from './ServingResults';
+import { servingCells, type ServingCell } from './serving';
+import { renderReportHtml } from './report';
 import { storedBundle, type StoredSource } from './stored';
 import ResultSummary from './ResultSummary';
 import {
@@ -257,6 +260,7 @@ interface Loaded {
   downloads: Map<string, string>;
   power: Record<string, ReturnType<typeof sampledPower>>;
   html: string;
+  cells: ServingCell[];
 }
 const REF_RUN = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34293342829';
 const REF_ARTIFACT = `${REF_RUN}/artifacts/10082823150`;
@@ -280,11 +284,15 @@ export default function VideoBenchmark({
   published,
   onLoaded,
   onError,
+  initialCell,
+  onCellChange,
 }: {
   reader?: (path: string) => Promise<Blob>;
   published?: StoredSource;
   onLoaded?: (bundle: Bundle) => void;
   onError?: () => void;
+  initialCell?: string;
+  onCellChange?: (id: string) => void;
 }) {
   const s = STRINGS[useLocale()];
   const [loaded, setLoaded] = useState<Loaded | null>(null);
@@ -325,6 +333,7 @@ export default function VideoBenchmark({
     const urls = new Map<string, string>();
     try {
       const bundle = saved ? storedBundle(saved) : await loadBundle(read!());
+      const cells = servingCells(bundle);
       const power: Loaded['power'] = {};
       for (const role of ROLES) {
         const file = bundle.files.get(`gpu/supervisor/${role}/telemetry.jsonl`);
@@ -358,29 +367,7 @@ export default function VideoBenchmark({
         );
       }
       const rawHtml = await bundle.files.get('report/index.html')?.text();
-      let html = '';
-      if (rawHtml) {
-        const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
-        doc
-          .querySelectorAll('script,base,iframe,object,embed,link,meta[http-equiv],form')
-          .forEach((n) => n.remove());
-        doc.querySelectorAll('[src], [href]').forEach((n) => {
-          for (const attr of ['src', 'href']) {
-            const value = n.getAttribute(attr);
-            if (value) {
-              const url = urls.get(`report/${value}`);
-              if (url) n.setAttribute(attr, url);
-              else n.removeAttribute(attr);
-            }
-          }
-        });
-        const csp = doc.createElement('meta');
-        csp.httpEquiv = 'Content-Security-Policy';
-        csp.content =
-          "default-src 'none'; media-src blob: https:; img-src blob: data:; style-src 'unsafe-inline'; form-action 'none'; base-uri 'none'";
-        doc.head.prepend(csp);
-        html = doc.documentElement.outerHTML;
-      }
+      const html = rawHtml ? renderReportHtml(rawHtml, urls) : '';
       if (current !== generation.current) {
         urls.forEach(URL.revokeObjectURL);
         return;
@@ -388,6 +375,7 @@ export default function VideoBenchmark({
       activeUrls.current = [...urls.values()].filter((url) => url.startsWith('blob:'));
       setLoaded({
         bundle,
+        cells,
         urls,
         power,
         html,
@@ -558,7 +546,18 @@ export default function VideoBenchmark({
           </a>
         </Card>
       )}
-      {b && loaded && (
+      {b && loaded && loaded.cells.length > 0 && (
+        <ServingResults
+          bundle={b}
+          cells={loaded.cells}
+          urls={loaded.urls}
+          downloads={loaded.downloads}
+          html={loaded.html}
+          initialCell={initialCell}
+          onCellChange={onCellChange}
+        />
+      )}
+      {b && loaded && loaded.cells.length === 0 && (
         <>
           <div className="grid items-start gap-5 xl:grid-cols-[minmax(400px,1fr)_minmax(0,1.5fr)]">
             <ResultSummary bundle={b} stored={Boolean(published)} />
@@ -927,7 +926,7 @@ export default function VideoBenchmark({
                 <p className="my-3 text-sm text-muted-foreground">{s.reportNote}</p>
                 <iframe
                   title={s.report}
-                  sandbox="allow-same-origin"
+                  sandbox="allow-same-origin allow-downloads"
                   referrerPolicy="no-referrer"
                   className="h-[70vh] w-full rounded-lg border bg-white"
                   srcDoc={loaded.html}

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
 import VideoSelect from './VideoSelect';
+import { servingCells } from './serving';
 import VideoTradeoff from './VideoTradeoff';
 import type { TradeoffRun } from './tradeoff';
 import { storedBundle, type StoredArtifact, type StoredSource } from './stored';
@@ -79,7 +80,7 @@ async function json(url: string, signal?: AbortSignal) {
   return data;
 }
 
-function share(runId: number, artifactId?: number, source?: string) {
+function share(runId: number, artifactId?: number, source?: string, cell?: string) {
   const url = new URL(location.href);
   const view = url.searchParams.get('view');
   url.search = '';
@@ -87,6 +88,7 @@ function share(runId: number, artifactId?: number, source?: string) {
   url.searchParams.set('run', String(runId));
   if (artifactId) url.searchParams.set('artifact', String(artifactId));
   if (source) url.searchParams.set('source', source);
+  if (cell) url.searchParams.set('cell', cell);
   history.replaceState(null, '', url);
 }
 
@@ -106,6 +108,7 @@ export default function VideoCIRuns() {
   const [progress, setProgress] = useState('');
   const [direct, setDirect] = useState('');
   const [manual, setManual] = useState(false);
+  const [cellId, setCellId] = useState('');
   const [view, setView] = useState('results');
   const [compared, setCompared] = useState<TradeoffRun[]>([]);
   const changeView = (value: string) => {
@@ -116,6 +119,7 @@ export default function VideoCIRuns() {
     history.replaceState(null, '', url);
   };
   const collect = useCallback((bundle: Bundle, exportRun: string, artifactId: string) => {
+    servingCells(bundle);
     setCompared((old) =>
       old.some((item) => item.bundle.manifestSha256 === bundle.manifestSha256)
         ? old
@@ -126,6 +130,9 @@ export default function VideoCIRuns() {
                 manifest: bundle.manifest,
                 result: bundle.result,
                 manifestSha256: bundle.manifestSha256,
+                documents: bundle.documents,
+                checksums: bundle.checksums,
+                ci: bundle.ci,
               },
               exportRun,
               artifact: artifactId,
@@ -149,6 +156,7 @@ export default function VideoCIRuns() {
     controller: AbortController,
     source?: string,
     prepared?: Promise<Response | null>,
+    preferredCell?: string,
   ) {
     setArtifact(selected);
     setSources([]);
@@ -210,15 +218,21 @@ export default function VideoCIRuns() {
     if (!chosen) throw new Error(s.none);
     setSources(found);
     setSourceId(chosen.id);
-    share(selectedRun.id, selected.id, chosen.id);
+    share(selectedRun.id, selected.id, chosen.id, preferredCell);
   }
-  async function selectRun(runId: string, artifactId?: string | null, source?: string | null) {
+  async function selectRun(
+    runId: string,
+    artifactId?: string | null,
+    source?: string | null,
+    selectedCell?: string | null,
+  ) {
     const current = ++request.current;
     download.current?.abort();
     setLoading(true);
     setProgress('');
     setError('');
     setRun(null);
+    setCellId(selectedCell ?? '');
     setSources([]);
     setArtifact(null);
     setArtifacts([]);
@@ -257,6 +271,7 @@ export default function VideoCIRuns() {
           controller,
           source ?? undefined,
           String(selected.id) === artifactId ? prepared : undefined,
+          selectedCell ?? undefined,
         );
     } catch (error) {
       if (current === request.current)
@@ -295,7 +310,13 @@ export default function VideoCIRuns() {
       if (auto) {
         const params = new URLSearchParams(location.search);
         const selected = params.get('run') ?? (data.runs[0] ? String(data.runs[0].id) : null);
-        if (selected) await selectRun(selected, params.get('artifact'), params.get('source'));
+        if (selected)
+          await selectRun(
+            selected,
+            params.get('artifact'),
+            params.get('source'),
+            params.get('cell'),
+          );
       }
     } catch (error) {
       if (current === request.current)
@@ -308,7 +329,8 @@ export default function VideoCIRuns() {
     const params = new URLSearchParams(location.search);
     if (params.get('view') === 'tradeoff') setView('tradeoff');
     const directRun = params.get('run');
-    if (directRun) void selectRun(directRun, params.get('artifact'), params.get('source'));
+    if (directRun)
+      void selectRun(directRun, params.get('artifact'), params.get('source'), params.get('cell'));
     else void list(1, true);
     return () => {
       request.current++;
@@ -362,6 +384,7 @@ export default function VideoCIRuns() {
               value={sourceId}
               onValueChange={(value) => {
                 setSourceId(value);
+                setCellId('');
                 if (run && artifact) share(run.id, artifact.id, value);
               }}
               options={sources.map((item) => ({ value: item.id, label: `#${item.id}` }))}
@@ -481,7 +504,15 @@ export default function VideoCIRuns() {
           sourceId={sourceId}
           onOpen={(point) => {
             changeView('results');
-            void selectRun(point.run.exportRun, point.run.artifact, point.sourceId);
+            if (
+              String(run?.id) === point.run.exportRun &&
+              String(artifact?.id) === point.run.artifact &&
+              sourceId === point.sourceId
+            ) {
+              setCellId(point.cellId ?? '');
+              share(run!.id, artifact!.id, sourceId, point.cellId);
+            } else
+              void selectRun(point.run.exportRun, point.run.artifact, point.sourceId, point.cellId);
           }}
         />
       </div>
@@ -491,6 +522,11 @@ export default function VideoCIRuns() {
             key={`${artifact?.id}-${sourceId}`}
             reader={selectedSource.read}
             published={selectedSource.stored}
+            initialCell={cellId}
+            onCellChange={(id) => {
+              setCellId(id);
+              if (run && artifact) share(run.id, artifact.id, sourceId, id);
+            }}
             onLoaded={collectLoaded}
             onError={() => changeView('results')}
           />

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -169,7 +169,7 @@ export default function VideoTradeoff({
   const all = useMemo(() => runs.flatMap(tradeoffPoints), [runs]);
   const [workload, setWorkload] = useState('');
   const [xAxis, setX] = useState<LatencyAxis>('p90');
-  const [yAxis, setY] = useState<EfficiencyAxis>('dollar');
+  const [yAxis, setY] = useState<EfficiencyAxis>('clipsGpu');
   const [selected, setSelected] = useState('');
   const [costs, setCosts] = useState<Record<string, DeploymentCost>>({});
   const groups = [...new Map(all.map((p) => [p.group, p.workloadLabel])).entries()];

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { schemeTableau10 } from 'd3';
+import { schemeTableau10, type Selection } from 'd3';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Heading } from '@/components/ui/heading';
 import { D3Chart } from '@/lib/d3-chart/D3Chart';
+import type { ContinuousScale } from '@/lib/d3-chart/types';
+import { CHART_TYPE, px } from '@/lib/d3-chart/typography';
 import { useLocale } from '@/lib/use-locale';
 import { escapeHtml } from '@/lib/utils';
 import { track } from '@/lib/analytics';
@@ -44,7 +46,7 @@ const STRINGS = {
     qualityNote:
       'Matching fixes the model revision, generation settings and prompt/seed/input workload. Precision, caching and runtime changes still require fidelity review. Technical validity does not establish perceptual quality; uncalibrated points are not qualified winners.',
     energyNote:
-      'Energy efficiency uses the backend generation-window joules per valid clip. It covers participating GPU boards only, excluding other allocated GPUs, CPUs, cooling and storage. It is not facility efficiency.',
+      'Energy efficiency uses the backend measurement-phase joules per valid clip. It covers participating GPU boards only, excluding other allocated GPUs, CPUs, cooling and storage. It is not facility efficiency.',
     noPoints: 'No points qualify for these axes yet.',
     diagnose: 'Inspect available serial results',
     empty: 'Open a CI result to add its baseline and candidate.',
@@ -68,7 +70,7 @@ const STRINGS = {
     window: 'Measurement window (s)',
     power: 'Mean total participating-board power (W)',
     energyClip: 'GPU-board energy / valid clip (J)',
-    powerWindow: 'Generation power window (s)',
+    powerWindow: 'Measured power window (s)',
     batch: 'Replica layout / actual batch size / offered arrival rate',
     queue: 'Queue delay / server-ready timestamp / deadline attainment',
     unavailable: 'Unavailable in this result contract',
@@ -84,6 +86,14 @@ const STRINGS = {
       'Enter the total hourly cost of the complete deployment, including all billed GPUs and host, power, cooling, network, storage and operating costs. Clips/USD = valid clips/hour ÷ deployment USD/hour. User-entered estimates; no selling price or profit is implied.',
     methods: 'Measurement definitions and comparison limits',
     diagnostic: 'Serial diagnostics · serving capacity not measured',
+    servingSmoke: 'Closed-loop smoke · serving capacity not qualified',
+    servingNote:
+      'Each point is one concurrency cell. Latency samples are never pooled across cells; P90 needs at least 10 valid samples in that cell. Throughput covers submission to fully downloaded media, including failures and transfer; local validation runs afterwards. GPU-board energy integrates the shared measurement envelope once, without summing overlapping request windows.',
+    servingMedian: 'Show cell medians',
+    boundary: 'Throughput measurement boundary',
+    deliveryBoundary: 'Submission to downloaded media; local validation excluded',
+    load: 'Load pattern',
+    closedLoop: 'Closed loop',
     observed: 'Observed points; no fitted frontier or hardware winner.',
     controls:
       'Shift+scroll to zoom; drag to pan; double-click to reset. Select a point or table row for details.',
@@ -108,7 +118,7 @@ const STRINGS = {
     qualityNote:
       '工作负载匹配固定了模型版本、生成设置以及 prompt、seed 和输入工作负载。精度、缓存和运行时变更仍需审查保真度。技术有效性不代表感知质量；未校准的点不能作为合格的性能优胜结果。',
     energyNote:
-      '能效使用后端生成时段内每个有效视频的 GPU 板卡能耗（焦耳），仅涵盖参与计算的 GPU 板卡，不含其他已分配 GPU、CPU、散热或存储，也不代表设施能效。',
+      '能效使用后端测量阶段每个有效视频的 GPU 板卡能耗（焦耳），仅涵盖参与计算的 GPU 板卡，不含其他已分配 GPU、CPU、散热或存储，也不代表设施能效。',
     noPoints: '当前坐标轴下尚无满足条件的数据点。',
     diagnose: '查看已有串行诊断结果',
     empty: '打开 CI 结果即可加入基线与候选数据。',
@@ -118,7 +128,7 @@ const STRINGS = {
     baseline: '基线',
     candidate: '候选',
     samples: '有效延迟样本数',
-    counts: '有效 / 已完成 / 已调度',
+    counts: '有效 / 已完成 / 计划',
     failed: '失败或无效',
     status: '绘图状态',
     missing: '缺少工作负载、延迟样本、GPU 数量、能耗或成本假设',
@@ -132,7 +142,7 @@ const STRINGS = {
     window: '测量时段（秒）',
     power: '参与计算板卡总功率均值（W）',
     energyClip: '每有效视频 GPU 板卡能耗（J）',
-    powerWindow: '生成阶段功率测量窗口（秒）',
+    powerWindow: '功率测量窗口（秒）',
     batch: '副本布局 / 实际批次大小 / 施加的请求到达率',
     queue: '排队延迟 / 服务端就绪时间戳 / 时限达标情况',
     unavailable: '此结果格式未提供',
@@ -148,6 +158,14 @@ const STRINGS = {
       '填写完整部署每小时总成本，涵盖所有计费 GPU、主机、电力、散热、网络、存储和运营成本。有效视频数/USD = 每小时有效视频数 ÷ 部署每小时 USD 成本。数值为用户填写的估算，不代表售价或利润。',
     methods: '测量定义与比较限制',
     diagnostic: '串行诊断 · 尚未测量服务容量',
+    servingSmoke: '闭环冒烟测试 · 服务容量未经验证',
+    servingNote:
+      '每个点对应一个并发配置，延迟样本按配置独立统计；P90 要求该配置至少有 10 个有效样本。吞吐量窗口从提交到媒体完整下载，涵盖失败请求和传输，本地验证在此后执行。GPU 板卡能耗仅对共享测量窗口积分一次，不累加相互重叠的请求窗口。',
+    servingMedian: '显示各配置的延迟中位数',
+    boundary: '吞吐量测量边界',
+    deliveryBoundary: '从提交到媒体下载完成；不含本地验证',
+    load: '负载模式',
+    closedLoop: '闭环',
     observed: '仅显示观测点，不拟合前沿曲线，也不判定硬件优胜者。',
     controls: 'Shift+滚轮缩放，拖动平移，双击重置。选择数据点或表格行查看详情。',
   },
@@ -168,7 +186,7 @@ export default function VideoTradeoff({
   const s = STRINGS[useLocale()];
   const all = useMemo(() => runs.flatMap(tradeoffPoints), [runs]);
   const [workload, setWorkload] = useState('');
-  const [xAxis, setX] = useState<LatencyAxis>('p90');
+  const [latencyAxis, setX] = useState<LatencyAxis | null>(null);
   const [yAxis, setY] = useState<EfficiencyAxis>('clipsGpu');
   const [selected, setSelected] = useState('');
   const [costs, setCosts] = useState<Record<string, DeploymentCost>>({});
@@ -178,15 +196,39 @@ export default function VideoTradeoff({
     : (all.find((p) => p.sourceId === sourceId)?.group ?? groups[0]?.[0]);
   const points = all.filter((p) => p.group === group);
   const active = points.find((p) => p.id === selected) ?? points[0];
+  const isServing = points.some((p) => p.role === 'serving');
+  const xAxis = latencyAxis ?? (isServing ? 'median' : 'p90');
   const plotted = points.flatMap((p) => {
     const x = latencyValue(p, xAxis),
       y = efficiencyValue(p, yAxis, costs[p.id]);
     return p.completeWorkload && x !== null && y !== null ? [{ ...p, x, y }] : [];
   });
+  const drawPointLabels = (
+    labelGroup: Selection<SVGGElement, unknown, null, undefined>,
+    x: ContinuousScale,
+    y: ContinuousScale,
+  ) => {
+    labelGroup
+      .selectAll<SVGTextElement, (typeof plotted)[number]>('text.serving-point-label')
+      .data(
+        plotted.filter((p) => p.role === 'serving'),
+        (p) => p.id,
+      )
+      .join('text')
+      .attr('class', 'serving-point-label')
+      .attr('x', (p) => x(p.x) + 10)
+      .attr('y', (p) => y(p.y) - 10)
+      .attr('font-size', px(CHART_TYPE.axisLabel))
+      .attr('font-weight', 600)
+      .attr('fill', 'var(--foreground)')
+      .attr('pointer-events', 'none')
+      .text((p) => `C${p.concurrency}`);
+  };
   const hardware = [...new Set(all.map((p) => p.hardware))].sort();
   const color = (p: TradeoffPoint) =>
     schemeTableau10[hardware.indexOf(p.hardware) % schemeTableau10.length];
-  const label = (p: TradeoffPoint) => `${p.hardware || '—'} · ${s[p.role]} · #${p.sourceId}`;
+  const label = (p: TradeoffPoint) =>
+    `${p.hardware || '—'} · ${p.role === 'serving' ? `${s.concurrency} ${p.concurrency}` : s[p.role]} · #${p.sourceId}`;
   const choose = (p: TradeoffPoint) => {
     setSelected(p.id);
     track('video_tradeoff_point_selected', { role: p.role, source: p.sourceId });
@@ -249,9 +291,9 @@ export default function VideoTradeoff({
                 {name}
               </span>
             ))}
-            {points.every((p) => p.concurrency === 1) && (
+            {(isServing || points.every((p) => p.concurrency === 1)) && (
               <span className="rounded-md border px-2 py-1 text-muted-foreground">
-                {s.diagnostic}
+                {isServing ? s.servingSmoke : s.diagnostic}
               </span>
             )}
           </div>
@@ -292,6 +334,22 @@ export default function VideoTradeoff({
                     keyFn: (p) => p.id,
                   },
                 },
+                {
+                  type: 'custom',
+                  key: 'serving-point-labels',
+                  render: (labelGroup, ctx) =>
+                    drawPointLabels(
+                      labelGroup,
+                      (ctx.renderedXScale ?? ctx.xScale) as ContinuousScale,
+                      (ctx.renderedYScale ?? ctx.yScale) as ContinuousScale,
+                    ),
+                  onZoom: (labelGroup, ctx) =>
+                    drawPointLabels(
+                      labelGroup,
+                      ctx.newXScale as ContinuousScale,
+                      ctx.newYScale as ContinuousScale,
+                    ),
+                },
               ]}
               tooltip={{
                 rulerType: 'none',
@@ -317,14 +375,14 @@ export default function VideoTradeoff({
                   setY('clipsGpu');
                 }}
               >
-                {s.diagnose}
+                {isServing ? s.servingMedian : s.diagnose}
               </Button>
             </div>
           )}
           <details className="space-y-2 text-xs text-muted-foreground">
             <summary className="cursor-pointer font-medium">{s.methods}</summary>
             <p>{s.latencyNote}</p>
-            <p>{s.throughputNote}</p>
+            <p>{isServing ? s.servingNote : s.throughputNote}</p>
             <p>{s.qualityNote}</p>
             {yAxis === 'energy' && <p>{s.energyNote}</p>}
           </details>
@@ -379,6 +437,12 @@ export default function VideoTradeoff({
                     [s.model, active.modelRevision || '—'],
                     [s.allocated, `${fmt(active.allocated)} / ${fmt(active.participating)}`],
                     [s.concurrency, fmt(active.concurrency)],
+                    ...(active.role === 'serving'
+                      ? [
+                          [s.load, s.closedLoop],
+                          [s.boundary, s.deliveryBoundary],
+                        ]
+                      : []),
                     [s.window, fmt(active.wall)],
                     [s.power, fmt(active.power)],
                     [s.energyClip, fmt(active.energy)],

--- a/packages/app/src/components/video-benchmark/report.test.ts
+++ b/packages/app/src/components/video-benchmark/report.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from 'vitest';
+import { reportPath, renderReportHtml } from './report';
+
+describe('verified artifact report links', () => {
+  it('resolves both paired-export and serving-matrix media within the artifact', () => {
+    expect(reportPath('media/baseline.mp4')).toBe('report/media/baseline.mp4');
+    expect(reportPath('../gpu/c2/baseline/artifacts/measurement-r001-c001.mp4')).toBe(
+      'gpu/c2/baseline/artifacts/measurement-r001-c001.mp4',
+    );
+    expect(reportPath('../serving-smoke.json')).toBe('serving-smoke.json');
+  });
+  it.each([
+    '../../outside.mp4',
+    '/gpu/clip.mp4',
+    '//remote.test/clip.mp4',
+    'https://remote.test/clip.mp4',
+    '%2e%2e/media.mp4',
+    String.raw`..\media.mp4`,
+    'clip.mp4?token=x',
+  ])('rejects unsafe report reference %s', (path) => {
+    expect(reportPath(path)).toBeNull();
+  });
+  it('rewrites only known assets and removes active content and unknown external references', () => {
+    const html = renderReportHtml(
+      '<script>alert(1)</script><base href="https://remote.test"><video src="../gpu/c1/clip.mp4"></video><a href="../serving-smoke.json">Data</a><img src="https://remote.test/x"><a href="../../outside">Outside</a>',
+      new Map([
+        ['gpu/c1/clip.mp4', 'https://storage.test/verified.mp4'],
+        ['serving-smoke.json', 'blob:verified-json'],
+      ]),
+    );
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    expect(doc.querySelector('video')?.getAttribute('src')).toBe(
+      'https://storage.test/verified.mp4',
+    );
+    expect(doc.querySelector('a')?.getAttribute('href')).toBe('blob:verified-json');
+    expect(doc.querySelector('img')?.hasAttribute('src')).toBe(false);
+    expect(doc.querySelectorAll('a')[1].hasAttribute('href')).toBe(false);
+    expect(doc.querySelector('script,base')).toBeNull();
+    expect(doc.querySelector('meta')?.content).toContain("default-src 'none'");
+  });
+});

--- a/packages/app/src/components/video-benchmark/report.ts
+++ b/packages/app/src/components/video-benchmark/report.ts
@@ -1,0 +1,43 @@
+import { safePath } from './bundle';
+
+// Report links are relative to report/index.html and may traverse within the bundle.
+export function reportPath(value: string): string | null {
+  if (value.startsWith('/') || /[\\:%?#]/u.test(value)) return null;
+  const parts = ['report'];
+  for (const part of value.split('/')) {
+    if (part === '.') continue;
+    if (part === '..') {
+      if (parts.length === 0) return null;
+      parts.pop();
+    } else parts.push(part);
+  }
+  try {
+    return safePath(parts.join('/'));
+  } catch {
+    return null;
+  }
+}
+
+export function renderReportHtml(rawHtml: string, urls: Map<string, string>): string {
+  const doc = new DOMParser().parseFromString(rawHtml, 'text/html');
+  doc
+    .querySelectorAll('script,base,iframe,object,embed,link,meta[http-equiv],form')
+    .forEach((node) => node.remove());
+  doc.querySelectorAll('[src], [href]').forEach((node) => {
+    for (const attr of ['src', 'href']) {
+      const value = node.getAttribute(attr);
+      if (value !== null) {
+        const path = reportPath(value);
+        const url = path ? urls.get(path) : undefined;
+        if (url) node.setAttribute(attr, url);
+        else node.removeAttribute(attr);
+      }
+    }
+  });
+  const csp = doc.createElement('meta');
+  csp.httpEquiv = 'Content-Security-Policy';
+  csp.content =
+    "default-src 'none'; media-src blob: https:; img-src blob: data:; style-src 'unsafe-inline'; form-action 'none'; base-uri 'none'";
+  doc.head.prepend(csp);
+  return doc.documentElement.outerHTML;
+}

--- a/packages/app/src/components/video-benchmark/serving.fixture.ts
+++ b/packages/app/src/components/video-benchmark/serving.fixture.ts
@@ -1,0 +1,221 @@
+import type { Bundle, Json } from './bundle';
+
+const hash = (name: string) => name.padEnd(64, '0');
+
+// Synthetic contract data, shaped after the C1/C2/C4 backend artifact.
+export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'manifest' | 'ci'> {
+  const plan = {
+    model_id: 'MiniMaxAI/MiniMax-H3',
+    model_revision: 'a'.repeat(40),
+    generation: {
+      duration_seconds: 4,
+      width: 1344,
+      height: 768,
+      fps: 24,
+      frame_count: 107,
+      num_inference_steps: 50,
+      aspect_ratio: '16:9',
+      audio_sample_rate_hz: 32000,
+      audio_channels: 2,
+      flow_shift: 12,
+      audio_flow_shift: 3,
+    },
+    cases: [{ case_id: 'drum-taps', prompt: 'A drummer taps a snare drum.', seed: 11 }],
+    repetitions: 4,
+    warmup_runs: 1,
+  };
+  const runtime = {
+    revision: 'b'.repeat(40),
+    source: '/runtime/sglang',
+    python: '/usr/bin/python3',
+  };
+  const devices = ['GPU-first', 'GPU-second'];
+  const documents = new Map<string, Json>();
+  const checksums = new Map<string, string>();
+  const save = (path: string, value: Json, digest: string) => {
+    documents.set(path, structuredClone(value));
+    checksums.set(path, digest);
+  };
+  const cells = [1, 2, 4].map((concurrency) => {
+    const root = `gpu/c${concurrency}`;
+    const latencies =
+      concurrency === 1
+        ? [120, 120, 120, 120]
+        : concurrency === 2
+          ? [120, 240, 240, 240]
+          : [120, 240, 360, 480];
+    const serving = {
+      concurrency,
+      mode: 'closed_loop',
+      capacity_qualified: false,
+      peak_client_in_flight: concurrency,
+      valid_video_seconds_per_second: 107 / 24 / 120,
+      client_ready_latency_seconds: {
+        p50: concurrency === 4 ? 300 : 120 * concurrency,
+        p90: null,
+        p95: null,
+        sample_count: 4,
+        values: latencies,
+      },
+    };
+    const measurement = {
+      concurrency,
+      boundary: 'submit_to_downloaded_media',
+      wall_seconds: 480,
+      warmup_runs: 1,
+      warmup_qualified: true,
+    };
+    const completion = {
+      scheduled: 4,
+      attempted: 4,
+      completed: 4,
+      valid: 4,
+      failed: 0,
+      not_started: 0,
+    };
+    const phases = {
+      measurement: {
+        valid: true,
+        valid_clips: 4,
+        duration_seconds: 480,
+        aggregate: { avg_power_w: 1400, energy_j: 672000, joules_per_valid_clip: 168000 },
+      },
+    };
+    const runHash = hash(`a${concurrency}`),
+      jobHash = hash(`b${concurrency}`),
+      powerHash = hash(`c${concurrency}`),
+      specHash = hash(`d${concurrency}`);
+    const runPath = `${root}/baseline/run.json`;
+    const records = [
+      'warmup-001',
+      'measurement-r001-c001',
+      'measurement-r002-c001',
+      'measurement-r003-c001',
+      'measurement-r004-c001',
+    ].map((slot, index) => {
+      const mediaHash = hash(`e${concurrency}${index}`);
+      checksums.set(`${root}/baseline/artifacts/${slot}.mp4`, mediaHash);
+      return {
+        slot_id: slot,
+        phase: index === 0 ? 'warmup' : 'measurement',
+        status: 'succeeded',
+        attempted: true,
+        artifact_path: `artifacts/${slot}.mp4`,
+        sha256: mediaHash,
+        submit_to_media_seconds: index === 0 ? 120 : latencies[index - 1],
+        media: { valid: true, video: { duration_seconds: 107 / 24 } },
+      };
+    });
+    save(
+      runPath,
+      {
+        bundle_type: 'mvp_run',
+        bundle_version: '0.1.0',
+        evidence_kind: 'operator_endpoint',
+        status: 'complete',
+        plan,
+        plan_sha256: hash('f'),
+        measurement,
+        serving,
+        records,
+        configuration: {
+          runtime_revision: runtime.revision,
+          model_revision: plan.model_revision,
+          serving,
+        },
+        summary: { ...completion, valid_clips_per_second: 1 / 120 },
+      },
+      runHash,
+    );
+    save(
+      `${root}/spec.json`,
+      {
+        plan,
+        gpu_uuids: devices,
+        baseline: runtime,
+        serving,
+        server: {
+          tp_size: 1,
+          ulysses_degree: 2,
+          dit_cpu_offload: false,
+          performance_mode: 'speed',
+          encoder_parallel: 'auto',
+        },
+      },
+      specHash,
+    );
+    save(
+      `${root}/gpu-job.json`,
+      {
+        schema_version: '0.1.0',
+        bundle_type: 'controlled_serving_smoke',
+        job_id: `github-123-1-c${concurrency}`,
+        spec_sha256: specHash,
+        plan_sha256: hash('f'),
+        status: 'complete',
+        measurement_verified: true,
+        cleanup_status: 'clean',
+        evidence_kind: 'controlled_h3_gpu',
+        roles: {
+          baseline: {
+            run_path: 'baseline/run.json',
+            run_sha256: runHash,
+            gpu_before: { gpus: devices.map((uuid) => ({ uuid, name: 'NVIDIA H200' })) },
+            telemetry_summary: {
+              gpu_identity: devices.map((uuid) => ({ uuid, name: 'NVIDIA H200' })),
+            },
+          },
+        },
+      },
+      jobHash,
+    );
+    save(`${root}/power.json`, { schema_version: '1.0.0', phases }, powerHash);
+    return {
+      concurrency,
+      status: 'complete',
+      verified: true,
+      completion,
+      metrics: {
+        measurement,
+        serving,
+        client_ready_p50_seconds: serving.client_ready_latency_seconds.p50,
+        valid_clips_per_second: 1 / 120,
+      },
+      run: { path: runPath, sha256: runHash },
+      receipt: { path: `${root}/gpu-job.json`, sha256: jobHash },
+      power: { path: `${root}/power.json`, sha256: powerHash, phases },
+    };
+  });
+  save(
+    'serving-smoke.json',
+    {
+      schema_version: '1.0.0',
+      bundle_type: 'h3_serving_smoke_matrix',
+      status: 'complete',
+      plan,
+      runtime,
+      gpu_uuids: devices,
+      cells,
+    },
+    hash('f1'),
+  );
+  return structuredClone({
+    documents,
+    checksums,
+    manifest: {
+      mode: 'serving-smoke',
+      run_id: '123',
+      run_attempt: '1',
+      git_commit: 'c'.repeat(40),
+      workload_plan: plan,
+      evidence: { 'serving-smoke.json': hash('f1') },
+    },
+    ci: {
+      mode: 'serving-smoke',
+      run_id: '123',
+      run_attempt: '1',
+      source_sha: 'c'.repeat(40),
+      slurm_job: { AllocTRES: 'cpu=32,mem=512G,node=1,gres/gpu=2' },
+    },
+  });
+}

--- a/packages/app/src/components/video-benchmark/serving.test.ts
+++ b/packages/app/src/components/video-benchmark/serving.test.ts
@@ -1,0 +1,113 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { at, loadBundle, type Json } from './bundle';
+import { servingFixture as fixture } from './serving.fixture';
+import { servingCells } from './serving';
+
+function set(value: Json, key: string, replacement: Json) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Expected object');
+  value[key] = replacement;
+}
+
+describe('H3 serving matrix', () => {
+  it('loads three single-runtime cells, preserves unavailable P90 and resolves original media', () => {
+    const b = fixture();
+    const cells = servingCells(b);
+    expect(cells.map(({ id, concurrency }) => [id, concurrency])).toEqual([
+      ['c1', 1],
+      ['c2', 2],
+      ['c4', 4],
+    ]);
+    expect(cells[2].runPath).toBe('gpu/c4/baseline/run.json');
+    expect(at(cells[2].run, 'records', 1, 'artifact_path')).toBe(
+      'artifacts/measurement-r001-c001.mp4',
+    );
+    expect(at(cells[2].run, 'serving', 'client_ready_latency_seconds', 'p90')).toBeNull();
+    expect(at(cells[2].job, 'roles', 'candidate')).toBeNull();
+    expect(at(cells[2].power, 'phases', 'measurement', 'aggregate', 'joules_per_valid_clip')).toBe(
+      168000,
+    );
+  });
+  it('leaves old artifacts alone and retains unstarted cells without invented results', () => {
+    const b = fixture();
+    const matrix = b.documents.get('serving-smoke.json')!;
+    const last = at(matrix, 'cells', 2);
+    set(last, 'status', 'not_started');
+    set(last, 'verified', false);
+    set(last, 'run', null);
+    set(last, 'receipt', null);
+    set(last, 'power', null);
+    for (const path of b.documents.keys()) if (path.startsWith('gpu/c4/')) b.documents.delete(path);
+    expect(servingCells(b)[2]).toMatchObject({
+      id: 'c4',
+      run: null,
+      job: null,
+      power: null,
+      spec: null,
+    });
+    b.documents.delete('serving-smoke.json');
+    expect(servingCells(b)).toEqual([]);
+  });
+  it.each([
+    'version',
+    'duplicate',
+    'ci',
+    'plan',
+    'hardware',
+    'concurrency',
+    'job',
+    'fixture',
+    'metrics',
+    'p50',
+  ])('rejects inconsistent %s identity or accounting', (defect) => {
+    const b = fixture();
+    const matrix = b.documents.get('serving-smoke.json')!;
+    const cell = at(matrix, 'cells', 0);
+    const run = b.documents.get('gpu/c1/baseline/run.json')!;
+    const job = b.documents.get('gpu/c1/gpu-job.json')!;
+    const spec = b.documents.get('gpu/c1/spec.json')!;
+    if (defect === 'version') set(matrix, 'schema_version', '2.0.0');
+    if (defect === 'duplicate') set(at(matrix, 'cells', 1), 'concurrency', 1);
+    if (defect === 'ci') set(b.ci, 'source_sha', 'd'.repeat(40));
+    if (defect === 'plan') set(at(run, 'plan'), 'model_revision', 'e'.repeat(40));
+    if (defect === 'hardware') set(spec, 'gpu_uuids', ['GPU-other']);
+    if (defect === 'concurrency') set(at(run, 'measurement'), 'concurrency', 4);
+    if (defect === 'job') set(job, 'job_id', 'github-999-1-c1');
+    if (defect === 'fixture') set(run, 'evidence_kind', 'fixture');
+    if (defect === 'metrics') set(at(cell, 'completion'), 'valid', 3);
+    if (defect === 'p50') set(at(cell, 'metrics'), 'client_ready_p50_seconds', 1);
+    expect(() => servingCells(b)).toThrow('Invalid H3 serving matrix:');
+  });
+  it.each(['reference', 'missing', 'spec', 'media', 'traversal', 'power'])(
+    'rejects broken %s bindings',
+    (defect) => {
+      const b = fixture();
+      const cell = at(b.documents.get('serving-smoke.json'), 'cells', 0);
+      const record = at(b.documents.get('gpu/c1/baseline/run.json'), 'records', 1);
+      if (defect === 'reference') set(at(cell, 'run'), 'sha256', '0'.repeat(64));
+      if (defect === 'missing') b.documents.delete('gpu/c1/baseline/run.json');
+      if (defect === 'spec') b.checksums.set('gpu/c1/spec.json', '0'.repeat(64));
+      if (defect === 'media') set(record, 'sha256', '0'.repeat(64));
+      if (defect === 'traversal') set(record, 'artifact_path', '../candidate/movie.mp4');
+      if (defect === 'power')
+        set(at(b.documents.get('gpu/c1/power.json'), 'phases', 'measurement'), 'valid', false);
+      expect(() => servingCells(b)).toThrow();
+    },
+  );
+});
+
+it.skipIf(!process.env.H3_SERVING_ARTIFACT_DIR)(
+  'reads the original checksum-sealed concurrency CI artifact',
+  async () => {
+    const b = await loadBundle(
+      async (path) => new Blob([await readFile(join(process.env.H3_SERVING_ARTIFACT_DIR!, path))]),
+    );
+    const cells = servingCells(b);
+    expect(cells.map(({ concurrency }) => concurrency)).toEqual([1, 2, 4]);
+    expect(cells.map(({ cell }) => at(cell, 'completion', 'valid'))).toEqual([4, 4, 4]);
+    expect(at(cells[0].run, 'records', 1, 'media', 'audio', 'channels')).toBe(2);
+    expect(at(cells[2].cell, 'metrics', 'client_ready_p50_seconds')).toBeCloseTo(297.686668);
+  },
+);

--- a/packages/app/src/components/video-benchmark/serving.ts
+++ b/packages/app/src/components/video-benchmark/serving.ts
@@ -1,0 +1,185 @@
+import { at, rows, safePath, text, type Bundle, type Json } from './bundle';
+
+export interface ServingCell {
+  id: string;
+  concurrency: number;
+  cell: Json;
+  run: Json;
+  job: Json;
+  power: Json;
+  spec: Json;
+  runPath: string;
+  jobPath: string;
+  powerPath: string;
+  specPath: string;
+}
+
+function requireValue(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Invalid H3 serving matrix: ${message}`);
+}
+
+function canonical(value: Json): string {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value !== null && typeof value === 'object')
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(',')}}`;
+  return JSON.stringify(value);
+}
+
+/** Read the backend's single-runtime matrix without manufacturing paired results. */
+export function servingCells(
+  bundle: Pick<Bundle, 'documents' | 'checksums' | 'manifest' | 'ci'>,
+): ServingCell[] {
+  const { documents, checksums, manifest, ci } = bundle;
+  if (!documents.has('serving-smoke.json')) return [];
+  const matrix = documents.get('serving-smoke.json') ?? null;
+  const cells = at(matrix, 'cells');
+  requireValue(
+    at(matrix, 'schema_version') === '1.0.0' &&
+      at(matrix, 'bundle_type') === 'h3_serving_smoke_matrix' &&
+      ['running', 'failed', 'complete'].includes(text(at(matrix, 'status'))) &&
+      Array.isArray(cells) &&
+      cells.length > 0 &&
+      cells.length <= 3,
+    'unsupported matrix contract',
+  );
+  requireValue(
+    at(manifest, 'mode') === 'serving-smoke' &&
+      at(ci, 'mode') === 'serving-smoke' &&
+      at(ci, 'run_id') === at(manifest, 'run_id') &&
+      at(ci, 'run_attempt') === at(manifest, 'run_attempt') &&
+      at(ci, 'source_sha') === at(manifest, 'git_commit'),
+    'CI identity does not match the manifest',
+  );
+  requireValue(
+    checksums.has('serving-smoke.json') &&
+      checksums.get('serving-smoke.json') === at(manifest, 'evidence', 'serving-smoke.json'),
+    'summary is not bound to the manifest',
+  );
+  const plan = at(matrix, 'plan');
+  const devices = rows(at(matrix, 'gpu_uuids'));
+  requireValue(
+    plan !== null &&
+      canonical(plan) === canonical(at(manifest, 'workload_plan')) &&
+      devices.length > 0 &&
+      new Set(devices).size === devices.length &&
+      devices.every((device) => typeof device === 'string' && device.startsWith('GPU-')),
+    'workload or GPU identity is missing or inconsistent',
+  );
+  const seen = new Set<number>();
+  return cells.map((cell): ServingCell => {
+    const concurrency = at(cell, 'concurrency');
+    requireValue(
+      typeof concurrency === 'number' && [1, 2, 4].includes(concurrency) && !seen.has(concurrency),
+      'invalid or duplicate concurrency',
+    );
+    seen.add(concurrency);
+    const id = `c${concurrency}`;
+    const root = `gpu/${id}`;
+    const runPath = `${root}/baseline/run.json`;
+    const jobPath = `${root}/gpu-job.json`;
+    const powerPath = `${root}/power.json`;
+    const specPath = `${root}/spec.json`;
+    const linked = (field: string, path: string): Json => {
+      const reference = at(cell, field);
+      if (reference === null) return null;
+      requireValue(
+        at(reference, 'path') === path &&
+          checksums.has(path) &&
+          checksums.get(path) === at(reference, 'sha256') &&
+          documents.has(path),
+        `${id} ${field} reference or SHA256 does not match`,
+      );
+      return documents.get(path) ?? null;
+    };
+    const run = linked('run', runPath);
+    const job = linked('receipt', jobPath);
+    const power = linked('power', powerPath);
+    const spec = documents.get(specPath) ?? null;
+    requireValue(
+      ['not_started', 'running', 'failed', 'complete'].includes(text(at(cell, 'status'))) &&
+        typeof at(cell, 'verified') === 'boolean',
+      `${id} has an invalid execution status`,
+    );
+    if (at(cell, 'verified') === true)
+      requireValue(
+        run && job && spec && at(cell, 'status') === 'complete',
+        `${id} verified evidence is missing`,
+      );
+    if (job) {
+      requireValue(
+        at(job, 'schema_version') === '0.1.0' &&
+          at(job, 'bundle_type') === 'controlled_serving_smoke' &&
+          at(job, 'job_id') ===
+            `github-${text(at(manifest, 'run_id'))}-${text(at(manifest, 'run_attempt'))}-${id}` &&
+          spec &&
+          checksums.has(specPath) &&
+          at(job, 'spec_sha256') === checksums.get(specPath) &&
+          canonical(at(spec, 'plan')) === canonical(plan) &&
+          canonical(at(spec, 'gpu_uuids')) === canonical(devices) &&
+          canonical(at(spec, 'baseline')) === canonical(at(matrix, 'runtime')) &&
+          at(spec, 'serving', 'concurrency') === concurrency &&
+          at(spec, 'serving', 'mode') === 'closed_loop',
+        `${id} supervisor, workload or hardware identity does not match`,
+      );
+      if (at(cell, 'verified') === true)
+        requireValue(
+          at(job, 'measurement_verified') === true &&
+            at(job, 'status') === 'complete' &&
+            at(job, 'cleanup_status') === 'clean' &&
+            at(job, 'evidence_kind') === 'controlled_h3_gpu',
+          `${id} does not contain verified, complete GPU execution`,
+        );
+    }
+    if (run) {
+      requireValue(
+        job &&
+          at(job, 'roles', 'baseline', 'run_path') === 'baseline/run.json' &&
+          at(job, 'roles', 'baseline', 'run_sha256') === checksums.get(runPath) &&
+          at(run, 'bundle_type') === 'mvp_run' &&
+          at(run, 'bundle_version') === '0.1.0' &&
+          ['operator_endpoint', 'live_h3'].includes(text(at(run, 'evidence_kind'))) &&
+          canonical(at(run, 'plan')) === canonical(plan) &&
+          at(run, 'plan_sha256') === at(job, 'plan_sha256') &&
+          at(run, 'configuration', 'runtime_revision') === at(matrix, 'runtime', 'revision') &&
+          at(run, 'configuration', 'model_revision') === at(plan, 'model_revision') &&
+          at(run, 'measurement', 'boundary') === 'submit_to_downloaded_media' &&
+          at(run, 'measurement', 'concurrency') === concurrency &&
+          at(run, 'configuration', 'serving', 'concurrency') === concurrency,
+        `${id} request run does not match its execution`,
+      );
+      if (at(cell, 'verified') === true)
+        requireValue(
+          canonical(at(run, 'measurement')) === canonical(at(cell, 'metrics', 'measurement')) &&
+            canonical(at(run, 'serving')) === canonical(at(cell, 'metrics', 'serving')) &&
+            at(run, 'serving', 'client_ready_latency_seconds', 'p50') ===
+              at(cell, 'metrics', 'client_ready_p50_seconds') &&
+            at(run, 'summary', 'valid_clips_per_second') ===
+              at(cell, 'metrics', 'valid_clips_per_second') &&
+            ['scheduled', 'completed', 'valid', 'failed'].every(
+              (key) => at(run, 'summary', key) === at(cell, 'completion', key),
+            ),
+          `${id} matrix metrics differ from the raw request run`,
+        );
+      for (const record of rows(at(run, 'records'))) {
+        const relative = text(at(record, 'artifact_path'));
+        if (relative) {
+          const mediaPath = `${root}/baseline/${safePath(relative)}`;
+          requireValue(
+            checksums.has(mediaPath) && checksums.get(mediaPath) === at(record, 'sha256'),
+            `${id} media identity does not match`,
+          );
+        }
+      }
+    }
+    if (power)
+      requireValue(
+        at(power, 'schema_version') === '1.0.0' &&
+          canonical(at(power, 'phases')) === canonical(at(cell, 'power', 'phases')),
+        `${id} power summary does not match the recorded phases`,
+      );
+    return { id, concurrency, cell, run, job, power, spec, runPath, jobPath, powerPath, specPath };
+  });
+}

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   tradeoffPoints,
@@ -6,7 +8,8 @@ import {
   costValue,
   type TradeoffRun,
 } from './tradeoff';
-import type { Json } from './bundle';
+import { at, loadBundle, type Json } from './bundle';
+import { servingFixture } from './serving.fixture';
 
 function fixture(
   records: Json[] = Array.from({ length: 10 }, (_, i) => ({
@@ -163,3 +166,136 @@ describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
     expect(tradeoffPoints(b)).toEqual([]);
   });
 });
+
+function matrixFixture(): TradeoffRun {
+  return {
+    exportRun: '123',
+    artifact: '456',
+    bundle: { ...servingFixture(), result: null, manifestSha256: 'synthetic-serving' },
+  };
+}
+function replace(value: Json, key: string, replacement: Json) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value))
+    throw new Error('Expected object');
+  value[key] = replacement;
+}
+
+describe('Serving matrix tradeoff metrics (synthetic contract fixture)', () => {
+  it('plots one point per concurrency and never pools twelve requests into P90', () => {
+    const points = tradeoffPoints(matrixFixture());
+    expect(points.map((p) => [p.cellId, p.concurrency, p.role, p.latencies.length])).toEqual([
+      ['c1', 1, 'serving', 4],
+      ['c2', 2, 'serving', 4],
+      ['c4', 4, 'serving', 4],
+    ]);
+    expect(points.map((p) => latencyValue(p, 'median'))).toEqual([120, 240, 300]);
+    expect(points.map((p) => latencyValue(p, 'p90'))).toEqual([null, null, null]);
+    expect(new Set(points.map((p) => p.group)).size).toBe(1);
+    expect(points.every((p) => p.completeWorkload)).toBe(true);
+  });
+  it('uses the delivery window, all allocated GPUs, actual durations and one shared power envelope', () => {
+    const points = tradeoffPoints(matrixFixture());
+    for (const p of points) {
+      expect(p.boundary).toBe('submit_to_downloaded_media');
+      expect(p.allocated).toBe(2);
+      expect(p.participating).toBe(2);
+      expect(p.rate).toBe(30);
+      expect(efficiencyValue(p, 'clipsGpu')).toBe(15);
+      expect(efficiencyValue(p, 'secondsGpu')).toBeCloseTo(66.875);
+      expect(p.power).toBe(1400);
+      expect(p.energy).toBe(168000);
+      expect(efficiencyValue(p, 'energy')).toBeCloseTo(3600000 / 168000);
+      expect(p.powerWindow).toBe(480);
+    }
+  });
+  it('does not substitute requested or participating GPUs for missing allocation evidence', () => {
+    const run = matrixFixture();
+    replace(at(run.bundle.ci, 'slurm_job'), 'AllocTRES', 'cpu=32,mem=512G,node=1');
+    expect(tradeoffPoints(run).map((p) => efficiencyValue(p, 'clipsGpu'))).toEqual([
+      null,
+      null,
+      null,
+    ]);
+  });
+  it('keeps changed quality semantics separate while allowing parallel layout comparisons', () => {
+    const run = matrixFixture();
+    const initial = tradeoffPoints(run)[0].group;
+    const server = at(run.bundle.documents!.get('gpu/c2/spec.json'), 'server');
+    replace(server, 'ulysses_degree', 4);
+    expect(tradeoffPoints(run)[1].group).toBe(initial);
+    replace(server, 'performance_mode', 'quality');
+    expect(tradeoffPoints(run)[1].group).not.toBe(initial);
+    expect(tradeoffPoints(run)[1].server).toEqual(server);
+  });
+  it('withholds incomplete latency data and invalid power without dropping their cells', () => {
+    const run = matrixFixture();
+    replace(
+      at(run.bundle.documents!.get('gpu/c1/baseline/run.json'), 'records', 1),
+      'submit_to_media_seconds',
+      null,
+    );
+    const phase = at(run.bundle.documents!.get('gpu/c2/power.json'), 'phases', 'measurement');
+    replace(phase, 'valid', false);
+    replace(
+      at(
+        run.bundle.documents!.get('serving-smoke.json'),
+        'cells',
+        1,
+        'power',
+        'phases',
+        'measurement',
+      ),
+      'valid',
+      false,
+    );
+    const points = tradeoffPoints(run);
+    expect(points).toHaveLength(3);
+    expect(points[0].latencies).toEqual([]);
+    expect(points[1].energy).toBeNull();
+    expect(points[1].power).toBeNull();
+    expect(points[2].energy).toBe(168000);
+  });
+  it('withholds stale latency and power for an unverified cell while retaining verified siblings', () => {
+    const run = matrixFixture();
+    const matrix = run.bundle.documents!.get('serving-smoke.json');
+    replace(matrix!, 'status', 'failed');
+    replace(at(matrix, 'cells', 0), 'status', 'failed');
+    replace(at(matrix, 'cells', 0), 'verified', false);
+    const points = tradeoffPoints(run);
+    expect(points).toHaveLength(3);
+    expect(points[0].valid).toBe(4);
+    expect(points[0].completeWorkload).toBe(false);
+    expect(latencyValue(points[0], 'median')).toBeNull();
+    expect(points[0].rate).toBeNull();
+    expect(points[0].energy).toBeNull();
+    expect(points[0].power).toBeNull();
+    expect(points[0].powerWindow).toBeNull();
+    expect(latencyValue(points[1], 'median')).toBe(240);
+    expect(points[1].completeWorkload).toBe(true);
+    expect(points[1].energy).toBe(168000);
+  });
+});
+
+it.skipIf(!process.env.H3_SERVING_ARTIFACT_DIR)(
+  'extracts three measured points from the original serving CI artifact',
+  async () => {
+    const bundle = await loadBundle(
+      async (path) => new Blob([await readFile(join(process.env.H3_SERVING_ARTIFACT_DIR!, path))]),
+    );
+    const points = tradeoffPoints({ bundle, exportRun: '34318467752', artifact: 'original' });
+    expect(points).toHaveLength(3);
+    const expected = [119.5026524469722, 237.67639482504455, 297.68666791851865];
+    for (const [index, p] of points.entries()) {
+      expect(latencyValue(p, 'median')).toBeCloseTo(expected[index]);
+      expect(latencyValue(p, 'p90')).toBeNull();
+      expect(p.valid).toBe(4);
+      expect(p.hardware).toBe('NVIDIA H200');
+      expect(p.allocated).toBe(2);
+      expect(p.participating).toBe(2);
+      expect(p.completeWorkload).toBe(true);
+    }
+    expect(new Set(points.map((p) => p.group)).size).toBe(1);
+    expect(points[0].energy).toBeCloseTo(164180.49905077327);
+    expect(efficiencyValue(points[0], 'clipsGpu')).toBeCloseTo(15.0621776301);
+  },
+);

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -1,7 +1,9 @@
 import { at, entries, number, ROLES, rows, text, type Bundle, type Json } from './bundle';
+import { servingCells } from './serving';
 
 export interface TradeoffRun {
-  bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'>;
+  bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'> &
+    Partial<Pick<Bundle, 'documents' | 'checksums' | 'ci'>>;
   exportRun: string;
   artifact: string;
 }
@@ -27,15 +29,7 @@ const positive = (value: Json) => {
   return n !== null && n > 0 ? n : null;
 };
 
-export function tradeoffPoints(run: TradeoffRun) {
-  const b = run.bundle,
-    result = b.result;
-  if (
-    at(result, 'schema_version') !== '1.0.0' ||
-    at(result, 'bundle_type') !== 'h3_benchmark_result'
-  )
-    return [];
-  const plan = at(result, 'workload', 'plan');
+function workloadInfo(plan: Json, identity: string, semantics: Json) {
   const workload = Object.fromEntries(
     entries(plan).filter(([key]) => !['plan_id', 'repetitions', 'warmup_runs'].includes(key)),
   );
@@ -49,7 +43,7 @@ export function tradeoffPoints(run: TradeoffRun) {
     ) &&
     cases.length > 0 &&
     cases.every((item) => text(at(item, 'prompt')) && Number.isInteger(number(at(item, 'seed'))));
-  const group = completeWorkload ? canonical(workload) : `unknown:${b.manifestSha256}`;
+  const group = completeWorkload ? canonical({ plan: workload, semantics }) : `unknown:${identity}`;
   const workloadLabel = [
     `${number(at(generation, 'width')) ?? '?'} × ${number(at(generation, 'height')) ?? '?'}`,
     `${number(at(generation, 'duration_seconds')) ?? '?'} s`,
@@ -59,31 +53,62 @@ export function tradeoffPoints(run: TradeoffRun) {
     `seed ${cases.map((item) => number(at(item, 'seed')) ?? '?').join(', ')}`,
     text(at(cases[0], 'prompt')).slice(0, 80),
   ].join(' · ');
+  return {
+    group,
+    workloadLabel,
+    workload,
+    completeWorkload: Boolean(completeWorkload),
+    model: text(at(plan, 'model_id')),
+    modelRevision: text(at(plan, 'model_revision')),
+  };
+}
+
+function measurementInfo(
+  recordsInput: Json,
+  completion: Json,
+  measurement: Json,
+  validStatus: boolean,
+) {
+  const records = rows(recordsInput).filter((r) => at(r, 'phase') === 'measurement');
+  const valid = records.filter(
+    (r) => at(r, 'status') === 'succeeded' && at(r, 'media', 'valid') === true,
+  );
+  const count = number(at(completion, 'valid'));
+  const scheduled = number(at(completion, 'scheduled'));
+  const accounted =
+    count !== null && count === valid.length && scheduled !== null && scheduled >= count;
+  const times = valid.map((r) => positive(at(r, 'submit_to_media_seconds')));
+  const latencies =
+    accounted && times.every((n): n is number => n !== null) ? times.sort((a, z) => a - z) : [];
+  const durations = valid.map((r) => positive(at(r, 'media', 'video', 'duration_seconds')));
+  const wall = positive(at(measurement, 'wall_seconds'));
+  const rate = accounted && wall !== null && validStatus ? (count! * 3600) / wall : null;
+  const secondsRate =
+    rate !== null && wall !== null && durations.every((n): n is number => n !== null)
+      ? (durations.reduce((sum, n) => sum + n, 0) * 3600) / wall
+      : null;
+  return {
+    latencies,
+    wall,
+    rate,
+    secondsRate,
+    scheduled,
+    valid: count,
+    completed: number(at(completion, 'completed')),
+    failed: number(at(completion, 'failed')),
+  };
+}
+
+function pairedTradeoffPoints(run: TradeoffRun) {
+  const b = run.bundle,
+    result = b.result;
+  if (
+    at(result, 'schema_version') !== '1.0.0' ||
+    at(result, 'bundle_type') !== 'h3_benchmark_result'
+  )
+    return [];
   return ROLES.map((role) => {
     const metrics = at(result, 'roles', role, 'metrics');
-    const records = rows(at(result, 'roles', role, 'records')).filter(
-      (r) => at(r, 'phase') === 'measurement',
-    );
-    const valid = records.filter(
-      (r) => at(r, 'status') === 'succeeded' && at(r, 'media', 'valid') === true,
-    );
-    const count = number(at(metrics, 'completion', 'valid'));
-    const scheduled = number(at(metrics, 'completion', 'scheduled'));
-    const accounted =
-      count !== null && count === valid.length && scheduled !== null && scheduled >= count;
-    const times = valid.map((r) => positive(at(r, 'submit_to_media_seconds')));
-    const latencies =
-      accounted && times.every((n): n is number => n !== null) ? times.sort((a, z) => a - z) : [];
-    const durations = valid.map((r) => positive(at(r, 'media', 'video', 'duration_seconds')));
-    const wall = positive(at(metrics, 'measurement', 'wall_seconds'));
-    const rate =
-      accounted && wall !== null && at(metrics, 'status') === 'valid'
-        ? (count! * 3600) / wall
-        : null;
-    const secondsRate =
-      rate !== null && wall !== null && durations.every((n): n is number => n !== null)
-        ? (durations.reduce((sum, n) => sum + n, 0) * 3600) / wall
-        : null;
     const phase = at(result, 'roles', role, 'power', 'phases', 'measurement');
     const energy =
       at(phase, 'valid') === true
@@ -93,29 +118,26 @@ export function tradeoffPoints(run: TradeoffRun) {
     return {
       id: `${b.manifestSha256}:${role}`,
       role,
+      cellId: undefined,
       run,
-      group,
-      workloadLabel,
-      workload,
-      completeWorkload: Boolean(completeWorkload),
+      ...workloadInfo(at(result, 'workload', 'plan'), b.manifestSha256, {
+        boundary: at(metrics, 'measurement', 'boundary'),
+        mode: 'paired_serial',
+      }),
+      ...measurementInfo(
+        at(result, 'roles', role, 'records'),
+        at(metrics, 'completion'),
+        at(metrics, 'measurement'),
+        at(metrics, 'status') === 'valid',
+      ),
       sourceId: text(at(b.manifest, 'run_id')),
-      model: text(at(plan, 'model_id')),
-      modelRevision: text(at(plan, 'model_revision')),
       hardware: [...new Set(devices.map((d) => text(at(d, 'name'))).filter(Boolean))].join(', '),
       revision: text(at(result, 'execution', 'runtime', role, 'revision')),
       concurrency: number(at(metrics, 'measurement', 'concurrency')),
       boundary: text(at(metrics, 'measurement', 'boundary')),
       allocated: positive(at(result, 'hardware', 'reserved_gpu_count')),
       participating: positive(at(result, 'hardware', 'selected_gpu_count')),
-      latencies,
-      rate,
-      secondsRate,
       energy,
-      scheduled,
-      valid: count,
-      completed: number(at(metrics, 'completion', 'completed')),
-      failed: number(at(metrics, 'completion', 'failed')),
-      wall,
       power: at(phase, 'valid') === true ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
       powerWindow: at(phase, 'valid') === true ? number(at(phase, 'duration_seconds')) : null,
       server: at(result, 'workload', 'server'),
@@ -124,7 +146,89 @@ export function tradeoffPoints(run: TradeoffRun) {
     };
   });
 }
-export type TradeoffPoint = ReturnType<typeof tradeoffPoints>[number];
+function servingTradeoffPoints(run: TradeoffRun) {
+  const b = run.bundle;
+  if (!b.documents || !b.checksums) return [];
+  const cells = servingCells({
+    documents: b.documents,
+    checksums: b.checksums,
+    manifest: b.manifest,
+    ci: b.ci ?? null,
+  });
+  const allocatedMatch = /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
+    text(at(b.ci, 'slurm_job', 'AllocTRES')),
+  );
+  const allocated = allocatedMatch ? positive(Number(allocatedMatch.groups?.count)) : null;
+  return cells.map((item) => {
+    const measurement = at(item.run, 'measurement');
+    const server = at(item.spec, 'server');
+    const mode = at(item.run, 'serving', 'mode');
+    const boundary = at(measurement, 'boundary');
+    const complete =
+      at(item.cell, 'verified') === true &&
+      at(item.job, 'measurement_verified') === true &&
+      at(item.run, 'status') === 'complete';
+    const metrics = measurementInfo(
+      at(item.run, 'records'),
+      at(item.run, 'summary'),
+      measurement,
+      complete,
+    );
+    const phase = at(item.power, 'phases', 'measurement');
+    const powerValid =
+      complete && at(phase, 'valid') === true && number(at(phase, 'valid_clips')) === metrics.valid;
+    const uuids = rows(at(item.spec, 'gpu_uuids')).map(text).filter(Boolean);
+    const devices = rows(at(item.job, 'roles', 'baseline', 'gpu_before', 'gpus')).filter((d) =>
+      uuids.includes(text(at(d, 'uuid'))),
+    );
+    const info = workloadInfo(at(item.run, 'plan'), `${b.manifestSha256}:${item.id}`, {
+      boundary,
+      mode,
+      server: Object.fromEntries(
+        entries(server).filter(
+          ([key]) =>
+            !['tp_size', 'ulysses_degree', 'encoder_parallel', 'dit_cpu_offload'].includes(key),
+        ),
+      ),
+    });
+    return {
+      id: `${b.manifestSha256}:${item.id}`,
+      cellId: item.id,
+      role: 'serving' as const,
+      run,
+      ...info,
+      ...metrics,
+      latencies: complete ? metrics.latencies : [],
+      completeWorkload:
+        info.completeWorkload &&
+        complete &&
+        mode === 'closed_loop' &&
+        boundary === 'submit_to_downloaded_media',
+      sourceId: text(at(b.manifest, 'run_id')),
+      hardware: [...new Set(devices.map((d) => text(at(d, 'name'))).filter(Boolean))].join(', '),
+      revision: text(at(item.run, 'configuration', 'runtime_revision')),
+      concurrency: item.concurrency,
+      boundary: text(boundary),
+      allocated,
+      participating: uuids.length > 0 && new Set(uuids).size === uuids.length ? uuids.length : null,
+      energy: powerValid ? positive(at(phase, 'aggregate', 'joules_per_valid_clip')) : null,
+      power: powerValid ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
+      powerWindow: powerValid ? number(at(phase, 'duration_seconds')) : null,
+      server,
+      fidelity: null,
+      policy: at(item.spec, 'policy'),
+    };
+  });
+}
+
+export type TradeoffPoint =
+  | ReturnType<typeof pairedTradeoffPoints>[number]
+  | ReturnType<typeof servingTradeoffPoints>[number];
+
+export function tradeoffPoints(run: TradeoffRun): TradeoffPoint[] {
+  const serving = servingTradeoffPoints(run);
+  return serving.length > 0 ? serving : pairedTradeoffPoints(run);
+}
 
 export function latencyValue(point: TradeoffPoint, axis: LatencyAxis): number | null {
   const a = point.latencies;


### PR DESCRIPTION
## Summary

The hidden video viewer now reads the backend's `h3_serving_smoke_matrix` contract. [CI run 34318467752](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34318467752) displays separate C1/C2/C4 points and opens the matching requests, videos with audio, integrity checks, GPU memory, measured power/energy, revisions and source downloads.

The chart defaults to median submission-to-downloaded-media latency and valid clips per allocated GPU-hour. Each configuration retains its own four samples, so P90 stays unavailable. Unverified measurements stay unavailable; paired-result compatibility and the existing hidden-production flag remain. Media reuse the existing persistent store, and report links resolve within the verified artifact.

## Validation

- Full workspace unit suite and local smoke suite passed; 23 focused video component tests passed.
- Real artifact: 15 videos played with audio decoding (12 measured, 3 separate warmups); report playback/downloads from both stored media and local ZIPs, warmup-reset chart drilldown, P90/cost gating and six EN/ZH desktop/tablet/mobile layouts verified without page errors or page overflow.
- Typecheck, lint, formatting and typography checks passed. Synthetic test fixtures are labeled.

## 中文说明

隐藏的视频查看器现已支持后端 `h3_serving_smoke_matrix` 契约。真实 CI 结果按 C1/C2/C4 分别显示；选择数据点可查看对应的请求、带音频视频、完整性检查、GPU 显存、实测功率与能耗、版本及原始产物链接。

图表默认显示提交到视频下载完成的延迟中位数，以及每个已分配 GPU 小时的有效视频数。每档四个样本独立统计，P90 和未验证指标保持无数据。保留成对结果兼容性与现有生产隐藏开关；视频复用持久化存储，报告链接限定在已校验的产物内。

完整单元测试、本地 smoke 测试及 23 项视频组件测试通过。真实产物的 15 个视频均已验证播放与音频解码（12 个正式测量、3 个独立 warmup）；持久化媒体与本地 ZIP 的报告播放/下载、warmup 选择重置及图表跳转、P90/成本门槛及六种中英文布局检查通过，无页面错误或页面溢出。类型、lint、格式与排版检查通过；合成测试数据均有标注。
