### PR TITLE
[Video] connect and share H3 hardware comparisons / 连接并分享 H3 硬件对比

### DIFF
--- a/packages/app/cypress/component/video-ci-runs.cy.tsx
+++ b/packages/app/cypress/component/video-ci-runs.cy.tsx
@@ -2,48 +2,7 @@ import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.share
 import VideoCIRuns from '@/components/video-benchmark/VideoCIRuns';
 import ResultPower from '@/components/video-benchmark/ResultPower';
 import VideoSelect from '@/components/video-benchmark/VideoSelect';
-import { servingFixture } from '@/components/video-benchmark/serving.fixture';
-import type { StoredArtifact } from '@/components/video-benchmark/stored';
-
-function servingArtifact(): StoredArtifact {
-  const fixture = servingFixture();
-  fixture.documents.set('manifest.json', fixture.manifest);
-  fixture.documents.set('ci.json', fixture.ci);
-  fixture.checksums.set('manifest.json', 'a'.repeat(64));
-  return {
-    storageVersion: 1,
-    runId: '123',
-    artifact: { id: 40, name: 'h3-video-123-1', expired: false, size_in_bytes: 100, stored: true },
-    sources: [
-      {
-        id: '123',
-        documents: [...fixture.documents],
-        checksums: [...fixture.checksums],
-        texts: [],
-        assets: [...fixture.checksums.keys()]
-          .filter((path) => path.endsWith('.mp4'))
-          .map((path) => [
-            path,
-            {
-              url: `https://media.test/${path}`,
-              downloadUrl: `https://media.test/${path}?download=1`,
-            },
-          ]),
-      },
-    ],
-  };
-}
-
-const run = (id: number, conclusion: string) => ({
-  id,
-  name: `H3 fixture ${id}`,
-  run_attempt: 1,
-  head_sha: 'a'.repeat(40),
-  created_at: '2026-09-09T00:00:00Z',
-  status: 'completed',
-  conclusion,
-  html_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`,
-});
+import { servingArtifact, videoRun as run } from '../support/video-artifacts';
 
 describe('H3 automatic CI viewer (synthetic API fixtures)', () => {
   beforeEach(() => {

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -137,6 +137,29 @@ const matrix = (): TradeoffRun => ({
 });
 
 describe('Video serving matrix chart (synthetic contract fixture)', () => {
+  it('defaults to P90 when individual serving cells have enough samples', () => {
+    const formal = matrix();
+    formal.bundle = {
+      ...servingFixture('123', 'NVIDIA H200', 20),
+      result: null,
+      manifestSha256: 'synthetic-formal',
+    };
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[formal]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.get('[role="combobox"][aria-label="Latency axis · lower is better"]').should(
+      'contain',
+      'P90 client-ready latency (s)',
+    );
+    cy.get('circle.point').should('have.length', 3);
+    cy.get('tbody tr')
+      .should('have.length', 3)
+      .each((row) => {
+        cy.wrap(row).should('contain', '20 / 20 / 20');
+      });
+  });
   it('shows three labeled cell medians and opens the selected concurrency result', () => {
     const open = cy.stub().as('openCell');
     cy.mount(

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -172,6 +172,23 @@ describe('Video serving matrix chart (synthetic contract fixture)', () => {
       'Median client-ready latency (s)',
     );
     cy.get('circle.point').should('have.length', 3);
+    cy.get('path.line-path')
+      .should('have.length', 1)
+      .invoke('attr', 'd')
+      .should('match', /^M[^L]+L[^L]+L[^L]+$/u);
+    cy.contains('Lines connect measured concurrency settings').should('be.visible');
+    cy.get('path.line-path')
+      .invoke('attr', 'd')
+      .then((before) => {
+        cy.get('[data-testid="video-tradeoff-chart"] svg').trigger('wheel', {
+          deltaY: -200,
+          shiftKey: true,
+          clientX: 400,
+          clientY: 300,
+          force: true,
+        });
+        cy.get('path.line-path').invoke('attr', 'd').should('not.equal', before);
+      });
     cy.get('text.serving-point-label')
       .should('have.length', 3)
       .then((labels) => {
@@ -186,9 +203,11 @@ describe('Video serving matrix chart (synthetic contract fixture)', () => {
     cy.get('[role="combobox"][aria-label="Latency axis · lower is better"]').click();
     cy.contains('[role="option"]', 'P90 client-ready latency (s)').click();
     cy.get('circle.point').should('not.exist');
+    cy.get('path.line-path').should('not.exist');
     cy.contains('No points qualify for these axes yet.').should('be.visible');
     cy.contains('button', 'Show cell medians').click();
     cy.get('circle.point').should('have.length', 3);
+    cy.get('path.line-path').should('have.length', 1);
     cy.contains('tbody button', 'Client concurrency 4').click();
     cy.contains('button', 'Open videos and full result').click();
     cy.get('@openCell')
@@ -207,6 +226,8 @@ describe('Video serving matrix chart (synthetic contract fixture)', () => {
       '客户端就绪延迟中位数（秒）',
     );
     cy.get('circle.point').should('have.length', 3);
+    cy.get('path.line-path').should('have.length', 1);
+    cy.contains('各并发数的实测结果').should('be.visible');
     cy.contains('客户端并发数 2').should('be.visible');
     cy.contains('闭环冒烟测试 · 服务容量未经验证').should('be.visible');
   });

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -348,12 +348,14 @@ describe('H3 video artifact viewer', () => {
     cy.intercept('GET', 'https://media.test/**', { statusCode: 204 });
     cy.visit('/video?view=tradeoff&run=123&artifact=40&source=123&compare=123.40,456.41,789.42');
     cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.get('[data-testid="tradeoff-detail"]').should('contain', 'NVIDIA H200');
     cy.get('[data-testid="video-tradeoff"]')
       .should('contain', 'NVIDIA H200')
       .and('contain', 'NVIDIA B200');
     cy.get('[role="alert"]').should('contain', 'Some comparison results could not be loaded');
     cy.reload();
     cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.get('[data-testid="tradeoff-detail"]').should('contain', 'NVIDIA H200');
     cy.contains(
       '[data-testid="video-tradeoff"] tbody button',
       /NVIDIA B200.*Client concurrency 4/,

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -1,5 +1,6 @@
 import { SUPPLEMENTAL_BENCHMARK_ROWS } from '../../src/lib/supplemental-benchmarks';
 import { OVERLAY_RUN_ID, OVERLAY_RUN_URL } from '../support/overlay-fixtures';
+import { servingArtifact, videoRun } from '../support/video-artifacts';
 
 const datum = (el: Element) => (el as Element & { __data__: { x: number; y: number } }).__data__;
 
@@ -325,6 +326,44 @@ describe('TPUv7 launch banner', { testIsolation: true }, () => {
 describe('H3 video artifact viewer', () => {
   beforeEach(() => {
     cy.intercept('GET', '/api/video-runs?page=*', { runs: [], nextPage: null });
+  });
+  it('restores a cross-hardware comparison on reload and retains good results when one artifact fails', () => {
+    const h200 = servingArtifact(123, 40, 'NVIDIA H200');
+    const b200 = servingArtifact(456, 41, 'NVIDIA B200');
+    for (const saved of [h200, b200]) {
+      cy.intercept('GET', `/api/video-runs?run=${saved.runId}`, {
+        run: videoRun(Number(saved.runId), 'success'),
+        artifacts: [saved.artifact],
+      });
+      cy.intercept(
+        'GET',
+        `/api/video-runs?run=${saved.runId}&artifact=${saved.artifact.id}&format=media`,
+        saved,
+      );
+    }
+    cy.intercept('GET', '/api/video-runs?run=789&artifact=42&format=media', {
+      statusCode: 503,
+      body: { error: 'Synthetic unavailable artifact' },
+    });
+    cy.intercept('GET', 'https://media.test/**', { statusCode: 204 });
+    cy.visit('/video?view=tradeoff&run=123&artifact=40&source=123&compare=123.40,456.41,789.42');
+    cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.get('[data-testid="video-tradeoff"]')
+      .should('contain', 'NVIDIA H200')
+      .and('contain', 'NVIDIA B200');
+    cy.get('[role="alert"]').should('contain', 'Some comparison results could not be loaded');
+    cy.reload();
+    cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.contains(
+      '[data-testid="video-tradeoff"] tbody button',
+      /NVIDIA B200.*Client concurrency 4/,
+    ).click();
+    cy.contains('button', 'Open videos and full result').click();
+    cy.get('[data-testid="serving-selected-metrics"]').should('contain', 'C4');
+    cy.location('search').should('include', 'run=456').and('include', 'compare=');
+    cy.get('[data-testid="serving-media"] video')
+      .should('have.attr', 'src')
+      .and('include', '/gpu/c4/');
   });
   it('uses the shared unlock for navigation and keeps an empty viewer free of sample results', () => {
     cy.viewport(1440, 1000);

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -327,6 +327,39 @@ describe('H3 video artifact viewer', () => {
   beforeEach(() => {
     cy.intercept('GET', '/api/video-runs?page=*', { runs: [], nextPage: null });
   });
+  it('shares a comparison built by opening two CI runs through the page', () => {
+    for (const saved of [
+      servingArtifact(123, 40, 'NVIDIA H200'),
+      servingArtifact(456, 41, 'NVIDIA B200'),
+    ]) {
+      cy.intercept('GET', `/api/video-runs?run=${saved.runId}`, {
+        run: videoRun(Number(saved.runId), 'success'),
+        artifacts: [saved.artifact],
+      });
+      cy.intercept(
+        'GET',
+        `/api/video-runs?run=${saved.runId}&artifact=${saved.artifact.id}&format=media`,
+        saved,
+      );
+    }
+    cy.intercept('GET', 'https://media.test/**', { statusCode: 204 });
+    cy.visit('/video?view=tradeoff&run=123&artifact=40');
+    cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 3);
+    cy.contains('summary', 'Run details and artifact selection').click();
+    cy.get('[data-testid="video-ci-runs"] form input').type('456');
+    cy.get('[data-testid="video-ci-runs"] form').submit();
+    cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.location().should((location) => {
+      const params = new URLSearchParams(location.search);
+      expect(params.get('run')).to.equal('456');
+      expect(params.get('compare')).to.equal('123.40,456.41');
+    });
+    cy.reload();
+    cy.get('[data-testid="video-tradeoff"] tbody tr').should('have.length', 6);
+    cy.get('[data-testid="video-tradeoff"]')
+      .should('contain', 'NVIDIA H200')
+      .and('contain', 'NVIDIA B200');
+  });
   it('restores a cross-hardware comparison on reload and retains good results when one artifact fails', () => {
     const h200 = servingArtifact(123, 40, 'NVIDIA H200');
     const b200 = servingArtifact(456, 41, 'NVIDIA B200');

--- a/packages/app/cypress/support/video-artifacts.ts
+++ b/packages/app/cypress/support/video-artifacts.ts
@@ -1,0 +1,53 @@
+import { servingFixture } from '../../src/components/video-benchmark/serving.fixture';
+import type { StoredArtifact } from '../../src/components/video-benchmark/stored';
+
+// Synthetic CI artifacts; never benchmark evidence.
+export function servingArtifact(
+  id = 123,
+  artifactId = 40,
+  hardware = 'NVIDIA H200',
+): StoredArtifact {
+  const fixture = servingFixture(String(id), hardware);
+  fixture.documents.set('manifest.json', fixture.manifest);
+  fixture.documents.set('ci.json', fixture.ci);
+  fixture.checksums.set('manifest.json', String(id).padEnd(64, '0'));
+  return {
+    storageVersion: 1,
+    runId: String(id),
+    artifact: {
+      id: artifactId,
+      name: `h3-video-${id}-1`,
+      expired: false,
+      size_in_bytes: 100,
+      stored: true,
+    },
+    sources: [
+      {
+        id: String(id),
+        documents: [...fixture.documents],
+        checksums: [...fixture.checksums],
+        texts: [],
+        assets: [...fixture.checksums.keys()]
+          .filter((path) => path.endsWith('.mp4'))
+          .map((path) => [
+            path,
+            {
+              url: `https://media.test/${path}`,
+              downloadUrl: `https://media.test/${path}?download=1`,
+            },
+          ]),
+      },
+    ],
+  };
+}
+
+export const videoRun = (id: number, conclusion: string) => ({
+  id,
+  name: `H3 fixture ${id}`,
+  run_attempt: 1,
+  head_sha: 'a'.repeat(40),
+  created_at: '2026-09-09T00:00:00Z',
+  status: 'completed',
+  conclusion,
+  html_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`,
+});

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -9,6 +9,7 @@ import { track } from '@/lib/analytics';
 import VideoSelect from './VideoSelect';
 import { at, number, rows, safePath, text, type Bundle, type Json } from './bundle';
 import type { ServingCell } from './serving';
+import { allocatedGpus } from './allocation';
 
 const STRINGS = {
   en: {
@@ -278,10 +279,7 @@ export default function ServingResults({
   const warmup = at(record, 'phase') === 'warmup';
   const telemetry = at(job, 'roles', 'baseline', 'telemetry_summary');
   const devices = rows(at(telemetry, 'gpu_identity'));
-  const allocatedMatch = /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
-    text(at(bundle.ci, 'slurm_job', 'AllocTRES')),
-  );
-  const allocated = number(allocatedMatch ? Number(allocatedMatch.groups?.count) : null);
+  const allocated = allocatedGpus(bundle);
   const gpuRate = (value: Json) =>
     allocated !== null && allocated > 0 ? multiply(value, 3600 / allocated) : null;
   const powerData = at(power, 'phases', phase);

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -815,12 +815,7 @@ export default function VideoBenchmark({
               <Heading>{s.hardware}</Heading>
               {table([
                 [s.participating, participating > 0 ? participating : null],
-                [
-                  s.allocated,
-                  /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
-                    text(at(b.ci, 'slurm_job', 'AllocTRES')),
-                  )?.groups?.count,
-                ],
+                [s.allocated, allocatedGpus(b)],
                 ['Slurm', at(b.manifest, 'slurm_allocation', 'identity', 'JobId')],
                 [s.node, at(b.ci, 'slurm_job', 'NodeList')],
                 [s.model, at(b.manifest, 'workload_plan', 'model_id')],

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -14,6 +14,7 @@ import { servingCells, type ServingCell } from './serving';
 import { renderReportHtml } from './report';
 import { storedBundle, type StoredSource } from './stored';
 import ResultSummary from './ResultSummary';
+import { allocatedGpus } from './allocation';
 import {
   at,
   entries,
@@ -387,10 +388,8 @@ export default function VideoBenchmark({
         rows(at(bundle.report, 'roles', 'baseline', 'observations'))[0] ??
         rows(at(bundle.report, 'roles', 'candidate', 'observations'))[0];
       setSlot(text(at(first, 'slot_id')));
-      setBilled(
-        /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(text(at(bundle.ci, 'slurm_job', 'AllocTRES')))
-          ?.groups?.count ?? '',
-      );
+      const allocated = allocatedGpus(bundle);
+      setBilled(allocated === null ? '' : String(allocated));
       track('video_bundle_loaded');
     } catch (error) {
       urls.forEach(URL.revokeObjectURL);

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -15,6 +15,7 @@ import type { TradeoffRun } from './tradeoff';
 import { storedBundle, type StoredArtifact, type StoredSource } from './stored';
 import type { Bundle } from './bundle';
 import { archiveSources, type CIArtifact, type CIRun } from './archive';
+import { comparisonRefs, rememberComparison } from './comparison';
 
 const STRINGS = {
   en: {
@@ -43,6 +44,9 @@ const STRINGS = {
     note: 'Results preserve their original GitHub CI identities. Stored media loads separately from the benchmark data; unpublished artifacts use the CI archive fallback.',
     expired: 'Expired',
     noMedia: 'Artifact unavailable',
+    comparisonLoading: 'Loading the other CI results in this comparison…',
+    comparisonError:
+      'Some comparison results could not be loaded. Check the run IDs or retry. A shared comparison supports up to 8 CI artifacts.',
   },
   zh: {
     title: 'H3 视频基准测试',
@@ -70,6 +74,9 @@ const STRINGS = {
     note: '结果保留原始 GitHub CI 运行标识。已存储的媒体与基准测试数据分别加载；尚未发布的产物则回退为下载 CI 产物压缩包。',
     expired: '已过期',
     noMedia: '产物不可用',
+    comparisonLoading: '正在加载对比中的其他 CI 结果…',
+    comparisonError:
+      '部分对比结果未能加载，请检查运行 ID 或重试。一个分享链接最多可包含 8 份 CI 产物。',
   },
 };
 
@@ -83,8 +90,10 @@ async function json(url: string, signal?: AbortSignal) {
 function share(runId: number, artifactId?: number, source?: string, cell?: string) {
   const url = new URL(location.href);
   const view = url.searchParams.get('view');
+  const comparison = url.searchParams.get('compare');
   url.search = '';
   if (view === 'tradeoff') url.searchParams.set('view', view);
+  if (comparison) url.searchParams.set('compare', comparison);
   url.searchParams.set('run', String(runId));
   if (artifactId) url.searchParams.set('artifact', String(artifactId));
   if (source) url.searchParams.set('source', source);
@@ -111,6 +120,9 @@ export default function VideoCIRuns() {
   const [cellId, setCellId] = useState('');
   const [view, setView] = useState('results');
   const [compared, setCompared] = useState<TradeoffRun[]>([]);
+  const [comparisonLoading, setComparisonLoading] = useState(false);
+  const [comparisonError, setComparisonError] = useState(false);
+  const comparisonDownload = useRef<AbortController | null>(null);
   const changeView = (value: string) => {
     setView(value);
     const url = new URL(location.href);
@@ -120,6 +132,15 @@ export default function VideoCIRuns() {
   };
   const collect = useCallback((bundle: Bundle, exportRun: string, artifactId: string) => {
     servingCells(bundle);
+    try {
+      history.replaceState(
+        null,
+        '',
+        rememberComparison(new URL(location.href), exportRun, artifactId),
+      );
+    } catch {
+      setComparisonError(true);
+    }
     setCompared((old) =>
       old.some((item) => item.bundle.manifestSha256 === bundle.manifestSha256)
         ? old
@@ -148,6 +169,45 @@ export default function VideoCIRuns() {
   );
   const request = useRef(0);
   const download = useRef<AbortController | null>(null);
+
+  async function restoreComparison() {
+    comparisonDownload.current?.abort();
+    const controller = new AbortController();
+    comparisonDownload.current = controller;
+    const params = new URLSearchParams(location.search);
+    setComparisonError(false);
+    setComparisonLoading(true);
+    try {
+      const selected = `${params.get('run')}.${params.get('artifact')}`;
+      const refs = comparisonRefs(params.get('compare')).filter((ref) => ref !== selected);
+      const results = await Promise.allSettled(
+        refs.map(async (ref) => {
+          const [runId, artifactId] = ref.split('.');
+          const saved: StoredArtifact = await json(
+            `/api/video-runs?run=${runId}&artifact=${artifactId}&format=media`,
+            controller.signal,
+          );
+          if (
+            saved.storageVersion !== 1 ||
+            saved.runId !== runId ||
+            String(saved.artifact.id) !== artifactId ||
+            saved.sources.length === 0
+          )
+            throw new Error('Stored comparison identity mismatch');
+          const bundles = saved.sources.map(storedBundle);
+          for (const bundle of bundles) servingCells(bundle);
+          if (!controller.signal.aborted)
+            for (const bundle of bundles) collect(bundle, runId, artifactId);
+        }),
+      );
+      if (!controller.signal.aborted && results.some((result) => result.status === 'rejected'))
+        setComparisonError(true);
+    } catch {
+      if (!controller.signal.aborted) setComparisonError(true);
+    } finally {
+      if (!controller.signal.aborted) setComparisonLoading(false);
+    }
+  }
 
   async function loadArtifact(
     selectedRun: CIRun,
@@ -328,6 +388,7 @@ export default function VideoCIRuns() {
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.get('view') === 'tradeoff') setView('tradeoff');
+    if (params.has('compare')) void restoreComparison();
     const directRun = params.get('run');
     if (directRun)
       void selectRun(directRun, params.get('artifact'), params.get('source'), params.get('cell'));
@@ -335,6 +396,7 @@ export default function VideoCIRuns() {
     return () => {
       request.current++;
       download.current?.abort();
+      comparisonDownload.current?.abort();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -499,6 +561,19 @@ export default function VideoCIRuns() {
         </Button>
       </div>
       <div hidden={view !== 'tradeoff'}>
+        {comparisonLoading && (
+          <p role="status" className="mb-3 text-sm text-muted-foreground">
+            {s.comparisonLoading}
+          </p>
+        )}
+        {comparisonError && (
+          <div role="alert" className="mb-3 flex flex-wrap items-center gap-3 text-sm">
+            <p>{s.comparisonError}</p>
+            <Button variant="outline" size="sm" onClick={() => void restoreComparison()}>
+              {s.retry}
+            </Button>
+          </div>
+        )}
         <VideoTradeoff
           runs={compared}
           sourceId={sourceId}

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -196,7 +196,10 @@ export default function VideoTradeoff({
     ? workload
     : (all.find((p) => p.sourceId === sourceId)?.group ?? groups[0]?.[0]);
   const points = all.filter((p) => p.group === group);
-  const active = points.find((p) => p.id === selected) ?? points[0];
+  const active =
+    points.find((p) => p.id === selected) ??
+    points.find((p) => p.sourceId === sourceId) ??
+    points[0];
   const isServing = points.some((p) => p.role === 'serving');
   const xAxis =
     latencyAxis ??

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -197,7 +197,9 @@ export default function VideoTradeoff({
   const points = all.filter((p) => p.group === group);
   const active = points.find((p) => p.id === selected) ?? points[0];
   const isServing = points.some((p) => p.role === 'serving');
-  const xAxis = latencyAxis ?? (isServing ? 'median' : 'p90');
+  const xAxis =
+    latencyAxis ??
+    (isServing && !points.some((p) => latencyValue(p, 'p90') !== null) ? 'median' : 'p90');
   const plotted = points.flatMap((p) => {
     const x = latencyValue(p, xAxis),
       y = efficiencyValue(p, yAxis, costs[p.id]);

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { schemeTableau10, type Selection } from 'd3';
+import { curveLinear, schemeTableau10, type Selection } from 'd3';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -15,6 +15,7 @@ import { track } from '@/lib/analytics';
 import VideoSelect from './VideoSelect';
 import {
   tradeoffPoints,
+  tradeoffCurves,
   latencyValue,
   efficiencyValue,
   type TradeoffRun,
@@ -94,7 +95,8 @@ const STRINGS = {
     deliveryBoundary: 'Submission to downloaded media; local validation excluded',
     load: 'Load pattern',
     closedLoop: 'Closed loop',
-    observed: 'Observed points; no fitted frontier or hardware winner.',
+    observed:
+      'Lines connect measured concurrency settings for each hardware/runtime configuration. Select any dot for its videos, metrics and exact CI run.',
     controls:
       'Shift+scroll to zoom; drag to pan; double-click to reset. Select a point or table row for details.',
   },
@@ -167,7 +169,8 @@ const STRINGS = {
     deliveryBoundary: '从提交到媒体下载完成；不含本地验证',
     load: '负载模式',
     closedLoop: '闭环',
-    observed: '仅显示观测点，不拟合前沿曲线，也不判定硬件优胜者。',
+    observed:
+      '线条连接同一硬件与运行时配置下各并发数的实测结果。点击任意数据点，即可查看视频、指标及对应的 CI 运行。',
     controls: 'Shift+滚轮缩放，拖动平移，双击重置。选择数据点或表格行查看详情。',
   },
 };
@@ -209,6 +212,7 @@ export default function VideoTradeoff({
       y = efficiencyValue(p, yAxis, costs[p.id]);
     return p.completeWorkload && x !== null && y !== null ? [{ ...p, x, y }] : [];
   });
+  const curves = tradeoffCurves(plotted);
   const drawPointLabels = (
     labelGroup: Selection<SVGGElement, unknown, null, undefined>,
     x: ContinuousScale,
@@ -325,6 +329,16 @@ export default function VideoTradeoff({
               xAxis={{ label: s[xAxis], tickCount: 5 }}
               yAxis={{ label: s[yAxis], tickCount: 5 }}
               layers={[
+                {
+                  type: 'line',
+                  key: 'measured-curves',
+                  lines: curves,
+                  config: {
+                    getColor: (key) => color(curves[key][0]),
+                    strokeWidth: 2.5,
+                    curve: curveLinear,
+                  },
+                },
                 {
                   type: 'point',
                   data: plotted,

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -29,7 +29,7 @@ const STRINGS = {
     title: 'Video serving tradeoffs',
     subtitle: 'Compare identical workloads across hardware and runtime configurations.',
     scope:
-      'Runs you open are collected in this browser session. Reloading clears the comparison and cost assumptions.',
+      'Share this page’s link to reopen the same CI results. Cost assumptions stay in this browser session and reset on reload.',
     workload: 'Matched workload',
     x: 'Latency axis · lower is better',
     y: 'Efficiency axis · higher is better',
@@ -101,7 +101,8 @@ const STRINGS = {
   zh: {
     title: '视频服务延迟与效率权衡',
     subtitle: '在相同工作负载下比较硬件与运行时配置。',
-    scope: '打开的运行会加入当前浏览器会话；刷新页面将清除对比集合与成本假设。',
+    scope:
+      '分享当前页面链接即可重新打开同一组 CI 结果。成本假设仅保留在当前浏览器会话中，刷新后重置。',
     workload: '匹配的工作负载',
     x: '延迟轴 · 越低越好',
     y: '效率轴 · 越高越好',

--- a/packages/app/src/components/video-benchmark/allocation.ts
+++ b/packages/app/src/components/video-benchmark/allocation.ts
@@ -1,0 +1,33 @@
+import { at, rows, text, type Bundle } from './bundle';
+
+export function allocatedGpus(bundle: Partial<Pick<Bundle, 'ci' | 'documents'>>): number | null {
+  const job = at(bundle.ci, 'slurm_job');
+  const match = /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(text(at(job, 'AllocTRES')));
+  if (match) {
+    const count = Number(match.groups?.count);
+    return Number.isSafeInteger(count) && count > 0 ? count : null;
+  }
+  // AMD's granted full-node job omits GPU AllocTRES. Require the retained step
+  // binding and physical UUID inventory; requested GPU counts alone are insufficient.
+  if (
+    text(at(bundle.ci, 'site', 'cluster')) !== 'mi355x-amds' ||
+    text(at(job, 'OverSubscribe')) !== 'NO' ||
+    text(at(job, 'NumNodes')) !== '1' ||
+    text(at(job, 'TresPerNode')) !== 'gres/gpu:8'
+  )
+    return null;
+  const bound = text(
+    at(bundle.documents?.get('binding.json'), 'slurm', 'H3_AMD_ALLOCATION_UUIDS'),
+  ).split(',');
+  const physical = rows(bundle.documents?.get('amd-allocated-devices.json') ?? null).map((row) =>
+    text(at(row, 'uuid')),
+  );
+  const uuid = /^[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/u;
+  return bound.length === 8 &&
+    new Set(bound).size === 8 &&
+    physical.length === 8 &&
+    new Set(physical).size === 8 &&
+    bound.every((id) => uuid.test(id) && physical.includes(id))
+    ? 8
+    : null;
+}

--- a/packages/app/src/components/video-benchmark/bundle.test.ts
+++ b/packages/app/src/components/video-benchmark/bundle.test.ts
@@ -48,6 +48,23 @@ describe('H3 artifact contract', () => {
     expect(b.report).toBeNull();
     expect(b.files.size).toBe(3);
   });
+  it.each(['', '{"interrupted":'])(
+    'retains interrupted stdout without parsing it: %j',
+    async (log) => {
+      const path = 'gpu/c2/supervisor/baseline/client.stdout.json';
+      const f = await fixture({ [path]: log });
+      const b = await loadBundle(f.read);
+      expect(at(b.ci, 'phase')).toBe('failed');
+      expect(await b.files.get(path)!.text()).toBe(log);
+      expect(b.documents.has(path)).toBe(false);
+      f.files.set(path, new Blob(['changed after sealing']));
+      await expect(loadBundle(f.read)).rejects.toThrow(`SHA256 mismatch: ${path}`);
+    },
+  );
+  it('still rejects malformed structured result documents', async () => {
+    const f = await fixture({ 'gpu/c2/gpu-job.json': '{"status":' });
+    await expect(loadBundle(f.read)).rejects.toThrow(SyntaxError);
+  });
   it('rejects modified bytes and missing files', async () => {
     const f = await fixture();
     f.files.set('ci.json', new Blob(['tampered']));

--- a/packages/app/src/components/video-benchmark/bundle.ts
+++ b/packages/app/src/components/video-benchmark/bundle.ts
@@ -75,7 +75,10 @@ export async function loadBundle(read: (path: string) => Promise<Blob>): Promise
       throw new Error('Bundle exceeds browser memory limit');
     if ((await sha256(blob)) !== hash) throw new Error(`SHA256 mismatch: ${path}`);
     files.set(path, blob);
-    if (path.endsWith('.json')) documents.set(path, JSON.parse(await blob.text()));
+    // Supervisor stdout may be empty or truncated when a request is interrupted.
+    // Retain and verify those raw logs without treating them as result documents.
+    if (path.endsWith('.json') && !path.endsWith('.stdout.json'))
+      documents.set(path, JSON.parse(await blob.text()));
   }
   const manifest = documents.get('manifest.json') ?? null;
   if (

--- a/packages/app/src/components/video-benchmark/comparison.test.ts
+++ b/packages/app/src/components/video-benchmark/comparison.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { comparisonRefs, rememberComparison } from './comparison';
+
+describe('shared CI comparison identities', () => {
+  it('retains the previous artifact when another run is opened', () => {
+    const url = rememberComparison(
+      new URL('https://example.test/video?view=tradeoff&run=123&artifact=40&cell=c2'),
+      '456',
+      '41',
+    );
+    expect(url.searchParams.get('compare')).toBe('123.40,456.41');
+    expect(url.searchParams.get('view')).toBe('tradeoff');
+    expect(url.searchParams.get('cell')).toBe('c2');
+    expect(rememberComparison(url, '456', '41').searchParams.get('compare')).toBe('123.40,456.41');
+  });
+
+  it('does not turn one loaded artifact into a multi-run comparison', () => {
+    const url = rememberComparison(
+      new URL('https://example.test/video?run=123&artifact=40'),
+      '123',
+      '40',
+    );
+    expect(url.searchParams.has('compare')).toBe(false);
+    expect(comparisonRefs(null)).toEqual([]);
+  });
+
+  it.each([
+    '123',
+    '123.40,',
+    '0.40',
+    '123.40&run=999',
+    Array.from({ length: 9 }, (_, i) => `${i + 1}.40`).join(','),
+  ])('rejects malformed or oversized requests: %s', (value) => {
+    expect(() => comparisonRefs(value)).toThrow();
+  });
+});

--- a/packages/app/src/components/video-benchmark/comparison.test.ts
+++ b/packages/app/src/components/video-benchmark/comparison.test.ts
@@ -14,13 +14,13 @@ describe('shared CI comparison identities', () => {
     expect(rememberComparison(url, '456', '41').searchParams.get('compare')).toBe('123.40,456.41');
   });
 
-  it('does not turn one loaded artifact into a multi-run comparison', () => {
+  it('saves the first loaded artifact before navigation replaces its run identity', () => {
     const url = rememberComparison(
       new URL('https://example.test/video?run=123&artifact=40'),
       '123',
       '40',
     );
-    expect(url.searchParams.has('compare')).toBe(false);
+    expect(url.searchParams.get('compare')).toBe('123.40');
     expect(comparisonRefs(null)).toEqual([]);
   });
 

--- a/packages/app/src/components/video-benchmark/comparison.ts
+++ b/packages/app/src/components/video-benchmark/comparison.ts
@@ -16,6 +16,6 @@ export function rememberComparison(url: URL, run: string, artifact: string): URL
       `${run}.${artifact}`,
     ].join(','),
   );
-  if (refs.length > 1) url.searchParams.set('compare', refs.join(','));
+  url.searchParams.set('compare', refs.join(','));
   return url;
 }

--- a/packages/app/src/components/video-benchmark/comparison.ts
+++ b/packages/app/src/components/video-benchmark/comparison.ts
@@ -1,0 +1,21 @@
+const REF = /^[1-9]\d{0,19}\.[1-9]\d{0,19}$/;
+
+export function comparisonRefs(value: string | null): string[] {
+  const refs = [...new Set(value ? value.split(',') : [])];
+  if (refs.length > 8 || refs.some((ref) => !REF.test(ref)))
+    throw new Error('A comparison needs at most 8 valid CI run/artifact pairs');
+  return refs;
+}
+
+export function rememberComparison(url: URL, run: string, artifact: string): URL {
+  const previous = [url.searchParams.get('run'), url.searchParams.get('artifact')].join('.');
+  const refs = comparisonRefs(
+    [
+      ...comparisonRefs(url.searchParams.get('compare')),
+      ...(REF.test(previous) ? [previous] : []),
+      `${run}.${artifact}`,
+    ].join(','),
+  );
+  if (refs.length > 1) url.searchParams.set('compare', refs.join(','));
+  return url;
+}

--- a/packages/app/src/components/video-benchmark/serving.fixture.ts
+++ b/packages/app/src/components/video-benchmark/serving.fixture.ts
@@ -3,7 +3,11 @@ import type { Bundle, Json } from './bundle';
 const hash = (name: string) => name.padEnd(64, '0');
 
 // Synthetic contract data, shaped after the C1/C2/C4 backend artifact.
-export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'manifest' | 'ci'> {
+export function servingFixture(
+  runId = '123',
+  hardware = 'NVIDIA H200',
+  requests = 4,
+): Pick<Bundle, 'documents' | 'checksums' | 'manifest' | 'ci'> {
   const plan = {
     model_id: 'MiniMaxAI/MiniMax-H3',
     model_revision: 'a'.repeat(40),
@@ -21,7 +25,7 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
       audio_flow_shift: 3,
     },
     cases: [{ case_id: 'drum-taps', prompt: 'A drummer taps a snare drum.', seed: 11 }],
-    repetitions: 4,
+    repetitions: requests,
     warmup_runs: 1,
   };
   const runtime = {
@@ -38,12 +42,12 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
   };
   const cells = [1, 2, 4].map((concurrency) => {
     const root = `gpu/c${concurrency}`;
-    const latencies =
-      concurrency === 1
-        ? [120, 120, 120, 120]
-        : concurrency === 2
-          ? [120, 240, 240, 240]
-          : [120, 240, 360, 480];
+    const latencies = Array.from(
+      { length: requests },
+      (_, i) => Math.min(i + 1, concurrency) * 120,
+    );
+    const median =
+      (latencies[Math.floor((requests - 1) / 2)] + latencies[Math.ceil((requests - 1) / 2)]) / 2;
     const serving = {
       concurrency,
       mode: 'closed_loop',
@@ -51,34 +55,38 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
       peak_client_in_flight: concurrency,
       valid_video_seconds_per_second: 107 / 24 / 120,
       client_ready_latency_seconds: {
-        p50: concurrency === 4 ? 300 : 120 * concurrency,
-        p90: null,
+        p50: median,
+        p90: requests >= 10 ? latencies[Math.ceil(requests * 0.9) - 1] : null,
         p95: null,
-        sample_count: 4,
+        sample_count: requests,
         values: latencies,
       },
     };
     const measurement = {
       concurrency,
       boundary: 'submit_to_downloaded_media',
-      wall_seconds: 480,
+      wall_seconds: requests * 120,
       warmup_runs: 1,
       warmup_qualified: true,
     };
     const completion = {
-      scheduled: 4,
-      attempted: 4,
-      completed: 4,
-      valid: 4,
+      scheduled: requests,
+      attempted: requests,
+      completed: requests,
+      valid: requests,
       failed: 0,
       not_started: 0,
     };
     const phases = {
       measurement: {
         valid: true,
-        valid_clips: 4,
-        duration_seconds: 480,
-        aggregate: { avg_power_w: 1400, energy_j: 672000, joules_per_valid_clip: 168000 },
+        valid_clips: requests,
+        duration_seconds: requests * 120,
+        aggregate: {
+          avg_power_w: 1400,
+          energy_j: 168000 * requests,
+          joules_per_valid_clip: 168000,
+        },
       },
     };
     const runHash = hash(`a${concurrency}`),
@@ -88,10 +96,10 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
     const runPath = `${root}/baseline/run.json`;
     const records = [
       'warmup-001',
-      'measurement-r001-c001',
-      'measurement-r002-c001',
-      'measurement-r003-c001',
-      'measurement-r004-c001',
+      ...Array.from(
+        { length: requests },
+        (_, i) => `measurement-r${String(i + 1).padStart(3, '0')}-c001`,
+      ),
     ].map((slot, index) => {
       const mediaHash = hash(`e${concurrency}${index}`);
       checksums.set(`${root}/baseline/artifacts/${slot}.mp4`, mediaHash);
@@ -149,7 +157,7 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
       {
         schema_version: '0.1.0',
         bundle_type: 'controlled_serving_smoke',
-        job_id: `github-123-1-c${concurrency}`,
+        job_id: `github-${runId}-1-c${concurrency}`,
         spec_sha256: specHash,
         plan_sha256: hash('f'),
         status: 'complete',
@@ -160,9 +168,9 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
           baseline: {
             run_path: 'baseline/run.json',
             run_sha256: runHash,
-            gpu_before: { gpus: devices.map((uuid) => ({ uuid, name: 'NVIDIA H200' })) },
+            gpu_before: { gpus: devices.map((uuid) => ({ uuid, name: hardware })) },
             telemetry_summary: {
-              gpu_identity: devices.map((uuid) => ({ uuid, name: 'NVIDIA H200' })),
+              gpu_identity: devices.map((uuid) => ({ uuid, name: hardware })),
             },
           },
         },
@@ -204,7 +212,7 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
     checksums,
     manifest: {
       mode: 'serving-smoke',
-      run_id: '123',
+      run_id: runId,
       run_attempt: '1',
       git_commit: 'c'.repeat(40),
       workload_plan: plan,
@@ -212,7 +220,7 @@ export function servingFixture(): Pick<Bundle, 'documents' | 'checksums' | 'mani
     },
     ci: {
       mode: 'serving-smoke',
-      run_id: '123',
+      run_id: runId,
       run_attempt: '1',
       source_sha: 'c'.repeat(40),
       slurm_job: { AllocTRES: 'cpu=32,mem=512G,node=1,gres/gpu=2' },

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -222,10 +222,39 @@ describe('Serving matrix tradeoff metrics (synthetic contract fixture)', () => {
     const initial = tradeoffPoints(run)[0].group;
     const server = at(run.bundle.documents!.get('gpu/c2/spec.json'), 'server');
     replace(server, 'ulysses_degree', 4);
+    replace(server, 'attention_backend', 'aiter');
     expect(tradeoffPoints(run)[1].group).toBe(initial);
     replace(server, 'performance_mode', 'quality');
     expect(tradeoffPoints(run)[1].group).not.toBe(initial);
     expect(tradeoffPoints(run)[1].server).toEqual(server);
+  });
+  it('counts all eight AMD allocations only with a matching physical step inventory', () => {
+    const run = matrixFixture();
+    const ids = Array.from(
+      { length: 8 },
+      (_, i) => `75ff75a3-0000-1000-80e3-${String(i).padStart(12, '0')}`,
+    );
+    replace(run.bundle.ci ?? null, 'site', { cluster: 'mi355x-amds' });
+    replace(run.bundle.ci ?? null, 'slurm_job', {
+      AllocTRES: 'cpu=128,mem=512G,node=1,billing=128',
+      TresPerNode: 'gres/gpu:8',
+      OverSubscribe: 'NO',
+      NumNodes: '1',
+    });
+    run.bundle.documents!.set('binding.json', {
+      slurm: { H3_AMD_ALLOCATION_UUIDS: ids.join(',') },
+    });
+    run.bundle.documents!.set(
+      'amd-allocated-devices.json',
+      ids.map((uuid) => ({ uuid })),
+    );
+    expect(tradeoffPoints(run)[0].allocated).toBe(8);
+    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsGpu')).toBe(3.75);
+    run.bundle.documents!.set(
+      'amd-allocated-devices.json',
+      ids.slice(1).map((uuid) => ({ uuid })),
+    );
+    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsGpu')).toBeNull();
   });
   it('withholds incomplete latency data and invalid power without dropping their cells', () => {
     const run = matrixFixture();

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   tradeoffPoints,
+  tradeoffCurves,
   latencyValue,
   efficiencyValue,
   costValue,
@@ -79,6 +80,42 @@ function fixture(
   };
 }
 const cost = { hourly: '2', source: 'Synthetic all-in cost', date: '2026-09-09' };
+
+it('connects measured load settings within a known configuration, including dominated points', () => {
+  const base = { ...tradeoffPoints(fixture())[0], revision: 'synthetic-runtime' };
+  const c1 = { ...base, id: 'c1', concurrency: 1, x: 119.5, y: 15.062 };
+  const c2 = { ...base, id: 'c2', concurrency: 2, x: 237.7, y: 15.129 };
+  const c4 = { ...base, id: 'c4', concurrency: 4, x: 297.7, y: 15.134 };
+  const points = [
+    c4,
+    { ...c2, id: 'slower', x: 280 },
+    { ...c1, id: 'less-efficient', y: 14 },
+    c1,
+    c2,
+    { ...c4, id: 'tied-efficiency', x: 320 },
+  ];
+  expect(Object.values(tradeoffCurves(points))).toEqual([
+    [points[2], c1, c2, points[1], c4, points[5]],
+  ]);
+  expect(points[0]).toBe(c4);
+  for (const change of [
+    { hardware: 'Other GPU' },
+    { revision: 'other-runtime' },
+    { group: 'other-workload' },
+    { allocated: 16 },
+    { participating: 2 },
+    { server: { tp_size: 2 } },
+    { hardware: '' },
+    { revision: '' },
+  ]) {
+    expect(tradeoffCurves([c1, { ...c2, ...change }])).toEqual({});
+  }
+  const flat = { ...c2, y: c1.y };
+  expect(Object.values(tradeoffCurves([c1, flat]))).toEqual([[c1, flat]]);
+  const splitRun = { ...c4, sourceId: 'another-ci-run' };
+  expect(Object.values(tradeoffCurves([c1, c2, splitRun]))).toEqual([[c1, c2, splitRun]]);
+  expect(tradeoffCurves([])).toEqual({});
+});
 
 describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
   it('uses nearest-rank P90 and excludes warmup while preserving failures', () => {

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -234,6 +234,33 @@ export function tradeoffPoints(run: TradeoffRun): TradeoffPoint[] {
   return serving.length > 0 ? serving : pairedTradeoffPoints(run);
 }
 
+export function tradeoffCurves<T extends TradeoffPoint & { x: number; y: number }>(
+  points: T[],
+): Record<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const p of points) {
+    if (!p.hardware || !p.revision) continue;
+    const key = canonical({
+      workload: p.group,
+      hardware: p.hardware,
+      revision: p.revision,
+      role: p.role,
+      allocated: p.allocated,
+      participating: p.participating,
+      server: p.server,
+    });
+    const group = groups.get(key);
+    if (group) group.push(p);
+    else groups.set(key, [p]);
+  }
+  return Object.fromEntries(
+    [...groups.values()].flatMap((group, index) => {
+      const curve = group.toSorted((a, b) => a.x - b.x);
+      return curve.length > 1 ? [[`curve-${index}`, curve]] : [];
+    }),
+  );
+}
+
 export function latencyValue(point: TradeoffPoint, axis: LatencyAxis): number | null {
   const a = point.latencies;
   // Ten samples is a display floor, not statistical or release qualification.

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -1,5 +1,6 @@
 import { at, entries, number, ROLES, rows, text, type Bundle, type Json } from './bundle';
 import { servingCells } from './serving';
+import { allocatedGpus } from './allocation';
 
 export interface TradeoffRun {
   bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'> &
@@ -155,10 +156,7 @@ function servingTradeoffPoints(run: TradeoffRun) {
     manifest: b.manifest,
     ci: b.ci ?? null,
   });
-  const allocatedMatch = /(?:^|,)gres\/gpu=(?<count>\d+)(?:,|$)/u.exec(
-    text(at(b.ci, 'slurm_job', 'AllocTRES')),
-  );
-  const allocated = allocatedMatch ? positive(Number(allocatedMatch.groups?.count)) : null;
+  const allocated = allocatedGpus(b);
   return cells.map((item) => {
     const measurement = at(item.run, 'measurement');
     const server = at(item.spec, 'server');
@@ -187,7 +185,13 @@ function servingTradeoffPoints(run: TradeoffRun) {
       server: Object.fromEntries(
         entries(server).filter(
           ([key]) =>
-            !['tp_size', 'ulysses_degree', 'encoder_parallel', 'dit_cpu_offload'].includes(key),
+            ![
+              'tp_size',
+              'ulysses_degree',
+              'encoder_parallel',
+              'dit_cpu_offload',
+              'attention_backend',
+            ].includes(key),
         ),
       ),
     });

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -23,7 +23,7 @@ vi.mock('@vercel/blob', async (original) => ({
 }));
 const artifact = { id: 20, name: 'h3-video-10-1', size_in_bytes: 100, expired: false };
 const digest = (s: string) => createHash('sha256').update(s).digest('hex');
-function archive(corrupt = false) {
+function archive(corrupt = false, extra: Record<string, string> = {}) {
   const files = {
     'manifest.json': JSON.stringify({
       schema_version: 1,
@@ -33,6 +33,7 @@ function archive(corrupt = false) {
       ci: { repository: 'SemiAnalysisAI/InferenceX' },
     }),
     'synthetic.mp4': 'Synthetic test bytes, not a playable benchmark clip',
+    ...extra,
   };
   const sums = Object.entries(files)
     .map(([path, body]) => `${digest(body)}  ${path}`)
@@ -92,6 +93,48 @@ describe('persistent H3 media', () => {
     const bundle = storedBundle(source);
     expect(bundle.manifestSha256).toHaveLength(64);
     expect(bundle.files.has('synthetic.mp4')).toBe(false);
+  });
+  it('keeps serving telemetry downloadable without embedding it in the page data', async () => {
+    const serving = 'gpu/c1/supervisor/baseline/telemetry.jsonl';
+    const legacy = 'gpu/supervisor/baseline/telemetry.jsonl';
+    const result = await storeVideoArtifact(
+      '10',
+      artifact,
+      archive(false, { [serving]: 'synthetic serving log', [legacy]: 'synthetic legacy log' }),
+      new AbortController().signal,
+    );
+    expect(result.sources[0].texts).toEqual([[legacy, 'synthetic legacy log']]);
+    expect(result.sources[0].assets.some(([path]) => path === serving)).toBe(true);
+    expect(result.sources[0].checksums).toContainEqual([serving, digest('synthetic serving log')]);
+  });
+  it('removes embedded serving logs from existing indexes while preserving downloads', async () => {
+    vi.stubEnv('BLOB_READ_WRITE_TOKEN', 'synthetic-test-token');
+    const path = 'gpu/c2/supervisor/baseline/telemetry.jsonl';
+    const assets = [
+      [path, { url: 'https://media.test/raw', downloadUrl: 'https://media.test/raw?download=1' }],
+    ];
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json({
+        storageVersion: 1,
+        runId: '10',
+        artifact,
+        sources: [
+          {
+            id: '10',
+            documents: [],
+            checksums: [],
+            assets,
+            texts: [
+              [path, 'old embedded log'],
+              ['report/index.html', '<p>Report</p>'],
+            ],
+          },
+        ],
+      }),
+    );
+    const result = await readStoredArtifact('10', artifact);
+    expect(result?.sources[0].texts).toEqual([['report/index.html', '<p>Report</p>']]);
+    expect(result?.sources[0].assets).toEqual(assets);
   });
   it('reuses an immutable object regardless of SDK conflict wording', async () => {
     vi.mocked(put).mockRejectedValueOnce(new Error('Different SDK conflict wording'));

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -7,6 +7,8 @@ import type { StoredArtifact, StoredSource } from '@/components/video-benchmark/
 const PREFIX = 'h3-video-media/v1';
 export const videoStorageEnabled = () => Boolean(process.env.BLOB_READ_WRITE_TOKEN);
 const runPrefix = (runId: string) => `${PREFIX}/runs/${runId}/`;
+const legacyTelemetry = (path: string) =>
+  /^gpu\/supervisor\/(?:baseline|candidate)\/telemetry\.jsonl$/u.test(path);
 
 export async function storedArtifacts(runId: string): Promise<CIArtifact[]> {
   if (!videoStorageEnabled()) return [];
@@ -48,6 +50,12 @@ export async function readStoredArtifact(
     const result: StoredArtifact = await response.json();
     if (result.storageVersion !== 1 || result.runId !== runId || result.artifact.id !== artifact.id)
       throw new Error('Stored artifact identity mismatch');
+    // Serving cells already carry verified power and memory summaries. Older
+    // indexes embedded their full logs; keep those in downloadable assets only.
+    for (const source of result.sources)
+      source.texts = source.texts.filter(
+        ([path]) => path === 'report/index.html' || legacyTelemetry(path),
+      );
     return result;
   } catch (error) {
     if (error instanceof BlobNotFoundError) return null;
@@ -113,7 +121,7 @@ export async function storeVideoArtifact(
     }
     const texts: StoredSource['texts'] = [];
     for (const [path, body] of bundle.files) {
-      if (path === 'report/index.html' || (!bundle.result && path.endsWith('/telemetry.jsonl')))
+      if (path === 'report/index.html' || (!bundle.result && legacyTelemetry(path)))
         texts.push([path, await body.text()]);
     }
     sources.push({


### PR DESCRIPTION
H3 hardware comparisons previously disappeared on reload and displayed isolated points. Preserve exact CI run/artifact pairs in shared URLs and connect measured concurrency settings for each matching hardware/runtime configuration. All measured points remain selectable, including settings with lower throughput; H100 C1/C2 and C4 can connect across separate CI runs. Use P90 when samples are available and median for small smoke runs.

Keep verified cells viewable when another cell is interrupted. Empty or truncated client telemetry remains downloadable and checksum-bound without being parsed as result JSON. Avoid inlining unused telemetry into stored page data, and derive allocated GPU counts from verified scheduler evidence, including the supported AMD full-node allocation records. Hidden navigation and media access retain their existing controls.

Validation: workspace unit tests, typecheck, lint/format, and seven targeted chart component tests passed. Coverage includes flat/decreasing throughput, configuration separation, split CI runs, zoom, point drilldown, P90 gating, and Chinese labels. The local smoke suite passed 111/113 integration tests; two unrelated Chinese blog checks failed after the existing Next.js development-mode negative-timestamp exception on a Chinese 404. CI checks use a production build.

The [preview](https://inferencemax-app-git-fix-h3-interrupted-results-semianalysisai.vercel.app/video?view=tradeoff&run=34336635063&artifact=10103071687&source=34336635063&compare=34336635063.10103071687,34344378350.10106004321,34342452354.10107476604,34341996789.10104690935) displays three connected H100/H200/B200 series with nine real points, each with 20/20 valid requests. Verified fresh-page restoration, desktop and Chinese mobile rendering, and the H100 C4 video playing through eight seconds with audio enabled. These remain exploratory measurements; no sustained-capacity or hardware-winner claim is added. The preview requires the existing Vercel access authorization.

## 中文说明

H3 硬件对比此前在刷新后丢失，而且图表只显示独立数据点。现在分享链接会保留准确的 CI 运行与产物标识，并连接同一硬件和运行时配置下各并发数的实测结果。所有实测点仍可点击，包括吞吐量略低的配置；分开运行的 H100 C1/C2 与 C4 也能连成一条线。样本足够时使用 P90，小样本冒烟测试仍显示中位数。

部分配置中断时，已验证的配置仍可查看。空白或截断的客户端日志继续保留下载链接和校验值，只排除结构化结果解析。存储页面不再内联不需要的采样日志；已分配 GPU 数由经过验证的调度记录确定，包含已支持的 AMD 整节点记录。隐藏导航与媒体访问控制保持现有行为。

工作区单元测试、类型检查、lint/格式检查及七项图表组件测试通过，覆盖吞吐量持平或下降、不同配置分组、跨 CI 运行连线、缩放、数据点入口、P90 门槛和中文标签。本地冒烟测试的 113 项集成检查中有 111 项通过；两个无关的中文博客检查在中文 404 页面触发现有 Next.js 开发模式负时间戳异常后失败。CI 使用生产构建。

预览已显示 H100/H200/B200 三条连线和九个真实数据点，每点均为 20/20 个有效请求。已验证重新打开链接恢复完整对比、桌面及中文移动端展示，以及 H100 C4 视频完整播放八秒且未静音。结果仍用于探索，不代表持续服务容量验证，也不据此判定硬件优胜者。预览继续使用现有 Vercel 访问授权。
