### PR TITLE
[AgentX] preserve physical GPU counts during ingestion / 保留正确的物理 GPU 数

### DIFF
--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -436,9 +436,10 @@ All normalizer logic lives in `packages/db/src/etl/normalizers.ts`. The function
 
 ### Schema Version Detection
 
-`mapBenchmarkRow()` detects which artifact schema version is present by checking for the `prefill_tp` field:
+`mapBenchmarkRow()` distinguishes legacy flat and role-shaped topology with the `prefill_tp` field, and recognizes modern AgentX single-node metadata separately:
 
 - **v1 (pre-2025-12-19)**: Only `tp`, `ep`, and `dp_attention` are present. These are copied symmetrically: `prefillTp = decodeTp = tp`, `prefillEp = decodeEp = ep`. Both `numPrefillGpu` and `numDecodeGpu` are set to `tp * ep`.
 - **v2 (2025-12-19+)**: Separate `prefill_tp` / `decode_tp` / `prefill_ep` / `decode_ep` / `prefill_dp_attention` / `decode_dp_attention` / `prefill_num_workers` / `decode_num_workers` / `num_prefill_gpu` / `num_decode_gpu` fields are present. These map directly; `num_prefill_gpu` / `num_decode_gpu` fall back to `tp * ep` if absent.
+- **v3 AgentX single-node**: Nested `request_metrics` with explicit `is_multinode: false` and `disagg: false` uses the producer's physical count, `tp * pp * pcp_size`, when `num_gpus` is absent. EP and DCP share TP devices. Explicit counts win; flat legacy rows and role-shaped multinode rows retain their existing rules. For example, Qwen3.8 H200 TP4/EP4 uses four GPUs, mirrored into both aggregate role columns. GPU counts participate in config identity, so correcting ingestion does not repair existing rows: historical data needs explicit reconciliation against retained artifacts rather than blind reingestion.
 
-Detection is a single `'prefill_tp' in row` check — no version field is required in the artifact.
+The v1/v2 role-shape check is `'prefill_tp' in row`; the v3 fallback additionally checks the nested metrics and explicit topology flags. No version field is required in the artifact.

--- a/packages/db/src/etl/benchmark-mapper.test.ts
+++ b/packages/db/src/etl/benchmark-mapper.test.ts
@@ -1172,6 +1172,41 @@ function makeV3AgenticRow(overrides: Record<string, any> = {}): Record<string, a
 }
 
 describe('mapBenchmarkRow — v3 agentic nested agg schema', () => {
+  it.each<[Record<string, unknown>, number]>([
+    [{}, 4],
+    [{ tp: 8, ep: 8, pp: 2, dcp_size: 8 }, 16],
+    [{ pcp_size: 2 }, 8],
+    [{ tp: '4', ep: '4', pp: '1', pcp_size: '1' }, 4],
+    [{ num_gpus: 8 }, 8],
+    [{ num_gpus: true }, 16],
+    [{ is_multinode: undefined }, 16],
+    [{ disagg: true }, 16],
+    [{ framework: 'mori-sglang' }, 16],
+    [{ pp: true }, 16],
+    [{ pp: null }, 16],
+    [{ request_metrics: undefined }, 16],
+  ])('counts physical GPUs for the AgentX producer shape %j', (overrides, expected) => {
+    // Qwen3.8 H200 run 33038487711 uses TP4/EP4 on four GPUs, not sixteen.
+    const result = mapBenchmarkRow(
+      makeV3AgenticRow({
+        infmax_model_prefix: 'qwen3.8next',
+        hw: 'cluster:h200-dgxc',
+        framework: 'sglang',
+        precision: 'fp8',
+        tp: 4,
+        ep: 4,
+        pp: 1,
+        pcp_size: 1,
+        ...overrides,
+      }),
+      createSkipTracker(),
+    );
+
+    expect(result!.config.numPrefillGpu).toBe(expected);
+    expect(result!.config.numDecodeGpu).toBe(expected);
+    expect(result!.config.prefillEp).toBe(Number(overrides.ep ?? 4));
+  });
+
   it('maps identity/routing and flattens the nested containers', () => {
     const tracker = createSkipTracker();
     const result = mapBenchmarkRow(makeV3AgenticRow(), tracker);

--- a/packages/db/src/etl/benchmark-mapper.ts
+++ b/packages/db/src/etl/benchmark-mapper.ts
@@ -20,6 +20,7 @@ import {
   normalizePrecision,
   normalizeSpecMethod,
   parseBool,
+  parseOptionalBool,
   parseNum,
   parseInt2,
 } from './normalizers';
@@ -438,6 +439,25 @@ function resolveParallelism(row: Record<string, any>, frameworkDisagg: boolean):
   const tp = parseInt2(row.tp) ?? 1;
   const ep = parseInt2(row.ep) ?? 1;
   const dpAttn = parseBool(row.dp_attention);
+  let numGpus = physicalChipCount(row.num_gpus);
+  if (
+    row.num_gpus === undefined &&
+    !frameworkDisagg &&
+    String(row.scenario_type ?? '').startsWith('agentic') &&
+    row.request_metrics &&
+    typeof row.request_metrics === 'object' &&
+    !Array.isArray(row.request_metrics) &&
+    parseOptionalBool(row.is_multinode) === false &&
+    parseOptionalBool(row.disagg) === false
+  ) {
+    // Match the v3 AgentX producer's physical-device count. EP and DCP share
+    // TP devices; PP and PCP add devices. Legacy flat rows keep their fallback.
+    const physicalTp = physicalChipCount(row.tp);
+    const pp = physicalChipCount(row.pp === undefined ? 1 : row.pp);
+    const pcp = physicalChipCount(row.pcp_size === undefined ? 1 : row.pcp_size);
+    if (physicalTp && pp && pcp) numGpus = physicalChipCount(physicalTp * pp * pcp);
+  }
+  numGpus ??= tp * ep;
   return {
     prefillTp: tp,
     prefillEp: ep,
@@ -447,8 +467,8 @@ function resolveParallelism(row: Record<string, any>, frameworkDisagg: boolean):
     decodeEp: ep,
     decodeDpAttn: dpAttn,
     decodeNumWorkers: 0,
-    numPrefillGpu: physicalChipCount(row.num_gpus) ?? tp * ep,
-    numDecodeGpu: physicalChipCount(row.num_gpus) ?? tp * ep,
+    numPrefillGpu: numGpus,
+    numDecodeGpu: numGpus,
   };
 }
 


### PR DESCRIPTION
Modern single-node AgentX artifacts can omit `num_gpus` while EP shares TP devices. The ingestion fallback counted Qwen3.8 H200 TP4/EP4 as 16 GPUs, although the retained server command and power telemetry show four. Infer `TP × PP × PCP` only for the explicit modern single-node shape; preserve explicit counts, legacy rows and role-shaped artifacts.

On head `164780b35b924272fb8e94a144b5c91b49a2b585`, [typecheck/unit CI](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817312), [lint/format/typography CI](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817290), and [component plus all eight Chrome/Firefox E2E shards](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817414) passed. Claude and Bugbot checks passed with no unresolved review threads. Local validation passed 198 focused tests and 6,271 full-unit tests (3 skipped). Three unchanged FAQ/evaluation local smoke assertions failed, including a warm recheck; this remains a local validation limitation, with the full remote E2E suite passing on the same head.

The [retained artifact](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33038487711) now maps to four GPUs without changing measured energy or throughput. [Producer PR2923](https://github.com/SemiAnalysisAI/InferenceX/pull/2923) emits `num_gpus` directly. This mapper change applies to future ingestion: it does not rewrite existing rows or trigger a production backfill. Historical incorrect config identities require separate controlled reconciliation.

## 中文说明

现代单节点 AgentX 产物可能缺少 `num_gpus`，而 EP 与 TP 共享设备。此前摄取端将 Qwen3.8 H200 TP4/EP4 推断为16张 GPU，但原始服务命令和功耗遥测确认只有4张。本改动仅对明确的现代单节点格式按 `TP × PP × PCP` 推断物理设备数，保留显式计数、旧格式及按角色划分的多节点行为。

在版本 `164780b35b924272fb8e94a144b5c91b49a2b585` 上，[类型检查/单元测试 CI](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817312)、[lint/格式/排版 CI](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817290)、[component 及 Chrome/Firefox 共八个 E2E 分片](https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34387817414) 全部通过。Claude 与 Bugbot 检查通过，没有未解决的审查线程。本地198项定向测试及6,271项完整单元测试通过（3项跳过）；3项未改动的 FAQ/评估 smoke 断言在本地及 warm 复查中失败，仍作为本地验证限制保留，同一版本的完整远程 E2E 已通过。

[留存产物](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/33038487711) 现可正确映射为4张 GPU，实测能量与吞吐量保持不变。[配套 producer PR2923](https://github.com/SemiAnalysisAI/InferenceX/pull/2923) 直接输出 `num_gpus`。此映射修复适用于后续摄取，不重写现有记录，也不触发生产数据回填；历史错误配置身份仍须单独、受控地核对。
