### PR TITLE
Theme InferenceX wordmark for the September 11 memorial (25th anniversary)

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -41,21 +41,21 @@
   content: none;
 }
 
-/* September theme for the InferenceX wordmark — Childhood Cancer Awareness Month
-   ("Go Gold"). The gold awareness ribbon's palette painted onto the brand text
-   via a clipped gradient, running from deep goldenrod through bright gold and
-   back. The darker anchors keep the clipped wordmark legible on the light
-   header, the same treatment the earlier flag themes used. Fixed colors,
-   independent of the theme tokens, so it renders the same in light, dark, and
-   minecraft modes. */
+/* September 11 memorial theme for the InferenceX wordmark, marking the 25th
+   anniversary of the 2001 attacks. Palette is drawn from the Tribute in Light
+   memorial: two pale beams rising out of a night sky, so the gradient runs
+   deep midnight navy at the edges into a soft light-blue glow at the center.
+   Dark anchors keep the clipped wordmark legible on the light header, the same
+   treatment as the earlier awareness themes. Fixed colors, independent of the
+   theme tokens, so it renders the same in light, dark, and minecraft modes. */
 .pride-wordmark {
   background-image: linear-gradient(
     90deg,
-    #9a6a00 0%,
-    #d4a017 30%,
-    #ffd700 50%,
-    #d4a017 70%,
-    #9a6a00 100%
+    #14295c 0%,
+    #2a4f96 30%,
+    #a6cdf4 50%,
+    #2a4f96 70%,
+    #14295c 100%
   );
   background-clip: text;
   -webkit-background-clip: text;


### PR DESCRIPTION
September 11, 2026 marks the 25th anniversary of the 2001 attacks. This retheme of the header **InferenceX** wordmark is a memorial treatment for the week of the anniversary.

## What changed
- `.pride-wordmark` gradient in `globals.css` moves from the Childhood Cancer Awareness gold palette to a palette drawn from the **Tribute in Light** memorial: deep midnight navy at the edges rising into a soft light-blue glow at the center, evoking the two beams against the night sky.
- Comment updated to document the September 11 memorial theme.

## Notes
- CSS-only, no component or markup changes. Same pattern as #583 and #961, only the gradient behind the existing `.pride-wordmark` class used in `header.tsx`.
- Anchors are kept dark enough to stay legible on the light header; fixed colors so it renders the same in light, dark, and minecraft modes.
- Intended as a respectful remembrance palette only. Revert to the prior gold theme after the anniversary week if desired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only cosmetic change to a header gradient; no auth, data, or behavioral impact.
> 
> **Overview**
> Swaps the header **InferenceX** wordmark (`.pride-wordmark` in `globals.css`) from the prior September Childhood Cancer Awareness gold gradient to a **September 11 memorial** palette for the 25th anniversary: midnight navy at the edges into a soft light-blue center, inspired by Tribute in Light. The comment documents the memorial theme; clipping and fixed hex colors are unchanged so legibility and appearance stay consistent across light, dark, and minecraft modes. No markup or component changes—only the gradient stops behind the existing class in `header.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e72a0e8f28e892b4284652d817a7a1f073486cfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->