### PR TITLE
[Video] compare participating GPU and measured power efficiency / 比较参与计算 GPU 与实测功率效率

### DIFF
--- a/packages/app/cypress/component/video-serving-results.cy.tsx
+++ b/packages/app/cypress/component/video-serving-results.cy.tsx
@@ -63,6 +63,24 @@ const cells: ServingCell[] = [1, 2, 4].map((concurrency) => {
     job: {
       roles: {
         baseline: {
+          power_configuration_before: {
+            status: 'recorded',
+            observed_at: '2026-09-09T01:00:00Z',
+            gpus: ['GPU-test', 'GPU-test-2'].map((uuid) => ({
+              uuid,
+              configured_limit_w: 700,
+              enforced_limit_w: 700,
+            })),
+          },
+          power_configuration_after: {
+            status: 'recorded',
+            observed_at: '2026-09-09T02:00:00Z',
+            gpus: ['GPU-test', 'GPU-test-2'].map((uuid) => ({
+              uuid,
+              configured_limit_w: 700,
+              enforced_limit_w: 700,
+            })),
+          },
           telemetry_summary: {
             gpu_identity: [{ name: 'Synthetic GPU', uuid: 'GPU-test' }],
             measurement_observed_memory_peak_mib_by_gpu: { 'GPU-test': 100000 },
@@ -72,6 +90,7 @@ const cells: ServingCell[] = [1, 2, 4].map((concurrency) => {
     },
     spec: { gpu_uuids: ['GPU-test', 'GPU-test-2'], server: { ulysses_degree: 2, tp_size: 1 } },
     power: {
+      semantics: { power_unit: 'W' },
       phases: {
         measurement: {
           valid: true,
@@ -82,7 +101,10 @@ const cells: ServingCell[] = [1, 2, 4].map((concurrency) => {
             energy_j: 656721,
             joules_per_valid_clip: 164180,
           },
-          per_gpu: { 'GPU-test': { avg_power_w: 687, observed_peak_power_w: 697 } },
+          per_gpu: {
+            'GPU-test': { avg_power_w: 687, observed_peak_power_w: 697 },
+            'GPU-test-2': { avg_power_w: 687, observed_peak_power_w: 697 },
+          },
         },
         startup: {
           valid: false,
@@ -99,7 +121,7 @@ const bundle: Bundle = {
     git_commit: 'synthetic-backend-sha',
     resources: { requested: { gpus: 8 } },
   },
-  ci: { slurm_job: { AllocTRES: 'cpu=32,mem=512G,gres/gpu=2' } },
+  ci: { slurm_job: { AllocTRES: 'cpu=32,mem=512G,gres/gpu=8' } },
   result: null,
   job: null,
   report: null,
@@ -197,15 +219,24 @@ describe('H3 serving results (synthetic fixtures)', () => {
     });
   });
 
-  it('shows each concurrency without manufacturing a candidate and uses allocated GPU count', () => {
+  it('shows each concurrency without manufacturing a candidate and separates participating and allocated GPU counts', () => {
     const change = cy.stub().as('change');
     mount({ onCellChange: change });
     cy.get('[data-testid="serving-matrix"] tbody tr').should('have.length', 3);
+    cy.get('[data-testid="serving-matrix"]').within(() => {
+      cy.contains('th', 'Energy / valid clip (kJ/clip)').should('be.visible');
+      cy.contains('td', '164.18').should('be.visible');
+      cy.contains('th', 'Mean / enforced limit (%)').should('be.visible');
+      cy.contains('td', '98.14').should('be.visible');
+    });
     cy.get('[data-testid="serving-selected-metrics"]').within(() => {
       cy.contains('120 s').should('be.visible');
       cy.contains('p', '15').should('be.visible');
       cy.contains('dt', 'P90 delivery latency').next().should('have.text', 'Unavailable');
     });
+    cy.get('[aria-label="GPU normalization"]').click();
+    cy.contains('[role="option"]', 'All allocated GPUs').click();
+    cy.get('[data-testid="serving-selected-metrics"]').contains('p', '3.75').should('be.visible');
     cy.get('video')
       .should('have.attr', 'src', 'https://media.example.test/c1/measurement-r001-c001.mp4')
       .and('have.prop', 'muted', false);
@@ -241,6 +272,7 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('[role="option"]', 'Startup').click();
     cy.get('[data-testid="serving-power"]').within(() => {
       cy.contains('dt', 'Aggregate mean (W)').next().should('have.text', 'Unavailable');
+      cy.contains('dt', 'Mean / enforced limit (%)').next().should('have.text', 'Unavailable');
       cy.contains('Synthetic missing telemetry').should('be.visible');
       cy.contains('999,999').should('not.exist');
     });
@@ -264,6 +296,7 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('dt', 'Measurement verified').next().should('have.text', 'No');
     cy.get('[data-testid="serving-power"]').within(() => {
       cy.contains('dt', 'Aggregate mean (W)').next().should('have.text', 'Unavailable');
+      cy.contains('dt', 'Mean / enforced limit (%)').next().should('have.text', 'Unavailable');
     });
   });
 
@@ -272,6 +305,9 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('并发服务测试结果').should('be.visible');
     cy.contains('此请求暂无可用媒体。').should('be.visible');
     cy.get('video').should('not.exist');
+    cy.contains('p', '有效视频 / 参与计算 GPU 小时').next().should('have.text', '15');
+    cy.get('[aria-label="GPU 归一化口径"]').click();
+    cy.contains('[role="option"]', '所有已分配 GPU').click();
     cy.contains('p', '有效视频 / 已分配 GPU 小时').next().should('have.text', '无数据');
     mount({ cells: [{ ...cells[0], run: null, job: null, spec: null, power: null }] });
     cy.contains('No request records are available for this configuration.').should('be.visible');

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -51,7 +51,7 @@ const run: TradeoffRun = {
 };
 
 describe('Video tradeoff chart (synthetic fixtures)', () => {
-  it('plots allocated GPU efficiency by default and requires assumptions for the cost axis', () => {
+  it('plots participating GPU efficiency by default and requires assumptions for the cost axis', () => {
     const open = cy.stub().as('open');
     cy.mount(
       <PathnameContext.Provider value="/video">
@@ -60,9 +60,12 @@ describe('Video tradeoff chart (synthetic fixtures)', () => {
     );
     cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').should(
       'contain',
-      'Valid clips / allocated GPU-hour',
+      'Valid clips / participating GPU-hour',
     );
     cy.get('[data-testid="video-tradeoff-chart"] circle.point').should('have.length', 2);
+    cy.contains('td', '2.5').should('be.visible');
+    cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();
+    cy.contains('[role="option"]', 'Valid clips / allocated GPU-hour').click();
     cy.contains('td', '1.25').should('be.visible');
     cy.contains('dd', '8 / 4').should('be.visible');
     cy.get('[role="combobox"][aria-label="Efficiency axis · higher is better"]').click();

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -10,6 +10,7 @@ import VideoSelect from './VideoSelect';
 import { at, number, rows, safePath, text, type Bundle, type Json } from './bundle';
 import type { ServingCell } from './serving';
 import { allocatedGpus } from './allocation';
+import { powerLimitComparison } from './power-limit';
 
 const STRINGS = {
   en: {
@@ -21,8 +22,13 @@ const STRINGS = {
     valid: 'Valid / scheduled',
     median: 'Median delivery latency',
     hour: 'Valid clips / deployment-hour',
-    gpuHour: 'Valid clips / allocated GPU-hour',
-    secondsHour: 'Video seconds / allocated GPU-hour',
+    gpuHour: 'Valid clips / participating GPU-hour',
+    allocatedGpuHour: 'Valid clips / allocated GPU-hour',
+    gpuBasis: 'GPU normalization',
+    allocatedBasis: 'All allocated GPUs',
+    participatingBasis: 'Participating GPUs',
+    secondsHour: 'Video seconds / participating GPU-hour',
+    allocatedSecondsHour: 'Video seconds / allocated GPU-hour',
     wall: 'Delivery measurement window',
     rate: 'Valid clips / second',
     samples: 'Valid latency samples',
@@ -75,6 +81,12 @@ const STRINGS = {
     energy: 'Integrated energy (kJ)',
     perClip: 'Energy / valid clip (kJ/clip)',
     powerWindow: 'Power window duration (s)',
+    limitRatio: 'Mean / enforced limit (%)',
+    limitWatts: 'Total enforced power limit (W)',
+    limitNote:
+      'Power-limit ratios require matching participating GPU UUIDs and unchanged prelaunch/postcleanup enforced limits. These snapshots do not prove continuous stability; TDP and later inventories are never substituted.',
+    gpuNote:
+      'Participating GPUs measure hardware efficiency. The allocated view includes idle allocations; full deployment costs must include all billed resources.',
     powerNote:
       'Generation power covers first submission → last observed provider completion. Intervening idle time, downloads and validation are included; overlapping requests are integrated once. Startup and warmup are separate. Time-weighted board measurements exclude the host and facility; sampled peaks are not instantaneous electrical peaks.',
     gpu: 'GPU',
@@ -120,8 +132,13 @@ const STRINGS = {
     valid: '有效 / 计划请求',
     median: '交付延迟中位数',
     hour: '有效视频 / 部署小时',
-    gpuHour: '有效视频 / 已分配 GPU 小时',
-    secondsHour: '视频秒数 / 已分配 GPU 小时',
+    gpuHour: '有效视频 / 参与计算 GPU 小时',
+    allocatedGpuHour: '有效视频 / 已分配 GPU 小时',
+    gpuBasis: 'GPU 归一化口径',
+    allocatedBasis: '所有已分配 GPU',
+    participatingBasis: '参与计算的 GPU',
+    secondsHour: '视频秒数 / 参与计算 GPU 小时',
+    allocatedSecondsHour: '视频秒数 / 已分配 GPU 小时',
     wall: '交付测量时段',
     rate: '有效视频 / 秒',
     samples: '有效延迟样本数',
@@ -173,6 +190,12 @@ const STRINGS = {
     energy: '积分能耗（kJ）',
     perClip: '每有效视频能耗（kJ/clip）',
     powerWindow: '功率统计时段时长（s）',
+    limitRatio: '平均功率 / 实际生效上限（%）',
+    limitWatts: '实际生效功率上限合计（W）',
+    limitNote:
+      '功率占比要求参与计算 GPU 的 UUID 匹配，且启动前与清理后记录的实际生效上限一致。这不能证明期间上限始终不变；不以规格 TDP 或事后硬件信息替代。',
+    gpuNote:
+      '按参与计算 GPU 数衡量硬件效率；按已分配 GPU 数统计时包含空闲分配。完整部署成本须包含所有计费资源。',
     powerNote:
       '生成阶段功率覆盖首次提交到最后一次观测到服务端完成为止，包含期间的空闲、下载与校验时间；并发请求重叠时段只积分一次。启动与 warmup 单独统计。板卡功率按时间加权，不含主机与设施能耗；采样峰值不是瞬时电气峰值。',
     gpu: 'GPU',
@@ -183,7 +206,7 @@ const STRINGS = {
       '客户端工作负载期间的设备已用显存，包含 warmup。MiB = 2²⁰ 字节；采样可能遗漏峰值，也不等同于框架分配器统计的峰值。',
     hardware: '硬件与执行配置',
     allocated: '已分配 GPU 数',
-    participating: '参与测试 GPU 数',
+    participating: '参与计算 GPU 数',
     model: '模型',
     modelRevision: '模型版本',
     runtimeRevision: '运行时版本',
@@ -249,6 +272,7 @@ export default function ServingResults({
   const s = STRINGS[useLocale()];
   const [selected, setSelected] = useState(initialCell ?? '');
   const [slot, setSlot] = useState('');
+  const [gpuBasis, setGpuBasis] = useState<'participating' | 'allocated'>('participating');
   const [phase, setPhase] = useState<'measurement' | 'startup' | 'warmup'>('measurement');
   const [failedMedia, setFailedMedia] = useState('');
   const selectedId = onCellChange ? (initialCell ?? selected) : selected;
@@ -280,9 +304,24 @@ export default function ServingResults({
   const telemetry = at(job, 'roles', 'baseline', 'telemetry_summary');
   const devices = rows(at(telemetry, 'gpu_identity'));
   const allocated = allocatedGpus(bundle);
+  const gpuUuids = rows(at(spec, 'gpu_uuids')).map(text);
+  const participating =
+    gpuUuids.length > 0 && gpuUuids.every(Boolean) && new Set(gpuUuids).size === gpuUuids.length
+      ? gpuUuids.length
+      : null;
+  const gpuCount = gpuBasis === 'participating' ? participating : allocated;
   const gpuRate = (value: Json) =>
-    allocated !== null && allocated > 0 ? multiply(value, 3600 / allocated) : null;
+    gpuCount !== null && gpuCount > 0 ? multiply(value, 3600 / gpuCount) : null;
   const powerData = at(power, 'phases', phase);
+  const limitComparison = verified
+    ? powerLimitComparison(
+        powerData,
+        at(job, 'roles', 'baseline', 'power_configuration_before'),
+        at(job, 'roles', 'baseline', 'power_configuration_after'),
+        at(spec, 'gpu_uuids'),
+        at(power, 'semantics', 'power_unit'),
+      )
+    : null;
   const powerValue = (...keys: string[]) =>
     verified && at(powerData, 'valid') === true ? at(powerData, ...keys) : null;
   let mediaPath = '';
@@ -327,10 +366,18 @@ export default function ServingResults({
           </span>
         </div>
         <div className="overflow-x-auto">
-          <table className="w-full text-left text-sm" data-testid="serving-matrix">
+          <table className="w-full min-w-3xl text-left text-sm" data-testid="serving-matrix">
             <thead className="text-xs text-muted-foreground">
               <tr>
-                {[s.concurrency, s.valid, `${s.median} (s)`, s.hour].map((label) => (
+                {[
+                  s.concurrency,
+                  s.valid,
+                  `${s.median} (s)`,
+                  s.hour,
+                  s.mean,
+                  s.perClip,
+                  s.limitRatio,
+                ].map((label) => (
                   <th key={label} className="px-3 py-2 font-medium">
                     {label}
                   </th>
@@ -338,44 +385,69 @@ export default function ServingResults({
               </tr>
             </thead>
             <tbody className="tabular-nums">
-              {cells.map((item) => (
-                <tr
-                  key={item.id}
-                  className={item.id === current.id ? 'bg-primary/10' : 'border-t border-border/40'}
-                >
-                  <td className="px-3 py-2">
-                    <Button
-                      size="sm"
-                      variant={item.id === current.id ? 'default' : 'outline'}
-                      aria-pressed={item.id === current.id}
-                      onClick={() => chooseCell(item.id)}
-                    >
-                      C{item.concurrency}
-                    </Button>
-                  </td>
-                  <td className="px-3 py-2">
-                    {fmt(at(item.cell, 'completion', 'valid'))} /{' '}
-                    {fmt(at(item.cell, 'completion', 'scheduled'))}
-                  </td>
-                  <td className="px-3 py-2">
-                    {fmt(
-                      at(item.cell, 'verified') === true
-                        ? at(item.cell, 'metrics', 'client_ready_p50_seconds')
-                        : null,
-                    )}
-                  </td>
-                  <td className="px-3 py-2">
-                    {fmt(
-                      multiply(
+              {cells.map((item) => {
+                const measuredPower =
+                  at(item.cell, 'verified') === true &&
+                  at(item.power, 'phases', 'measurement', 'valid') === true
+                    ? at(item.power, 'phases', 'measurement')
+                    : null;
+                const limits = powerLimitComparison(
+                  measuredPower,
+                  at(item.job, 'roles', 'baseline', 'power_configuration_before'),
+                  at(item.job, 'roles', 'baseline', 'power_configuration_after'),
+                  at(item.spec, 'gpu_uuids'),
+                  at(item.power, 'semantics', 'power_unit'),
+                );
+                return (
+                  <tr
+                    key={item.id}
+                    className={
+                      item.id === current.id ? 'bg-primary/10' : 'border-t border-border/40'
+                    }
+                  >
+                    <td className="px-3 py-2">
+                      <Button
+                        size="sm"
+                        variant={item.id === current.id ? 'default' : 'outline'}
+                        aria-pressed={item.id === current.id}
+                        onClick={() => chooseCell(item.id)}
+                      >
+                        C{item.concurrency}
+                      </Button>
+                    </td>
+                    <td className="px-3 py-2">
+                      {fmt(at(item.cell, 'completion', 'valid'))} /{' '}
+                      {fmt(at(item.cell, 'completion', 'scheduled'))}
+                    </td>
+                    <td className="px-3 py-2">
+                      {fmt(
                         at(item.cell, 'verified') === true
-                          ? at(item.cell, 'metrics', 'valid_clips_per_second')
+                          ? at(item.cell, 'metrics', 'client_ready_p50_seconds')
                           : null,
-                        3600,
-                      ),
-                    )}
-                  </td>
-                </tr>
-              ))}
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {fmt(
+                        multiply(
+                          at(item.cell, 'verified') === true
+                            ? at(item.cell, 'metrics', 'valid_clips_per_second')
+                            : null,
+                          3600,
+                        ),
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {fmt(at(measuredPower, 'aggregate', 'avg_power_w'))}
+                    </td>
+                    <td className="px-3 py-2">
+                      {fmt(
+                        multiply(at(measuredPower, 'aggregate', 'joules_per_valid_clip'), 0.001),
+                      )}
+                    </td>
+                    <td className="px-3 py-2">{fmt(limits?.percent ?? null)}</td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
@@ -503,13 +575,27 @@ export default function ServingResults({
       </Card>
 
       <Card className="gap-4" data-testid="serving-selected-metrics">
+        <div className="w-full max-w-sm">
+          <VideoSelect
+            label={s.gpuBasis}
+            value={gpuBasis}
+            onValueChange={(value) => setGpuBasis(value as typeof gpuBasis)}
+            options={[
+              { value: 'participating', label: s.participatingBasis },
+              { value: 'allocated', label: s.allocatedBasis },
+            ]}
+          />
+        </div>
         <Heading level="card">
           C{current.concurrency} · {s.closedLoop}
         </Heading>
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           {[
             [s.median, `${fmt(at(metrics, 'client_ready_p50_seconds'))} s`],
-            [s.gpuHour, fmt(gpuRate(at(metrics, 'valid_clips_per_second')))],
+            [
+              gpuBasis === 'participating' ? s.gpuHour : s.allocatedGpuHour,
+              fmt(gpuRate(at(metrics, 'valid_clips_per_second'))),
+            ],
             [s.valid, `${fmt(at(completion, 'valid'))} / ${fmt(at(completion, 'scheduled'))}`],
             [s.wall, `${fmt(at(metrics, 'measurement', 'wall_seconds'))} s`],
           ].map(([label, value]) => (
@@ -524,7 +610,10 @@ export default function ServingResults({
             [s.status, at(cell, 'status') === 'complete' ? s.complete : s.incomplete],
             [s.verified, verified ? s.yes : s.no],
             [s.rate, fmt(at(metrics, 'valid_clips_per_second'), 6)],
-            [s.secondsHour, fmt(gpuRate(at(serving, 'valid_video_seconds_per_second')))],
+            [
+              gpuBasis === 'participating' ? s.secondsHour : s.allocatedSecondsHour,
+              fmt(gpuRate(at(serving, 'valid_video_seconds_per_second'))),
+            ],
             [
               s.p90,
               p90 !== null && p90 >= 10
@@ -536,6 +625,7 @@ export default function ServingResults({
           ]}
         />
         <p className="text-xs text-muted-foreground">{s.p90Note}</p>
+        <p className="text-xs text-muted-foreground">{s.gpuNote}</p>
       </Card>
 
       <Card className="gap-4" data-testid="serving-power">
@@ -561,6 +651,8 @@ export default function ServingResults({
             [s.energy, fmt(multiply(powerValue('aggregate', 'energy_j'), 0.001))],
             [s.perClip, fmt(multiply(powerValue('aggregate', 'joules_per_valid_clip'), 0.001))],
             [s.powerWindow, fmt(powerValue('duration_seconds'))],
+            [s.limitRatio, fmt(limitComparison?.percent ?? null)],
+            [s.limitWatts, fmt(limitComparison?.watts ?? null)],
           ]}
         />
         {at(powerData, 'valid') !== true && (
@@ -569,6 +661,7 @@ export default function ServingResults({
           </p>
         )}
         <p className="text-xs leading-relaxed text-muted-foreground">{s.powerNote}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{s.limitNote}</p>
         <div className="overflow-x-auto">
           <table className="w-full text-left text-xs">
             <thead>
@@ -616,12 +709,7 @@ export default function ServingResults({
             [s.runtimeRevision, scalar(at(run, 'configuration', 'runtime_revision'))],
             [s.sourceHash, scalar(at(spec, 'baseline', 'source_sha256'))],
             [s.allocated, fmt(allocated)],
-            [
-              s.participating,
-              rows(at(spec, 'gpu_uuids')).length > 0
-                ? fmt(rows(at(spec, 'gpu_uuids')).length)
-                : s.unavailable,
-            ],
+            [s.participating, fmt(participating)],
             [s.observed, fmt(at(serving, 'observed_submission_rate_per_second'), 6)],
           ]}
         />

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -37,13 +37,15 @@ const STRINGS = {
     p90: 'P90 client-ready latency (s)',
     median: 'Median client-ready latency (s)',
     dollar: 'Valid clips / USD',
-    clipsGpu: 'Valid clips / allocated GPU-hour',
-    secondsGpu: 'Video seconds / allocated GPU-hour',
+    clipsGpu: 'Valid clips / participating GPU-hour',
+    clipsAllocatedGpu: 'Valid clips / allocated GPU-hour',
+    secondsGpu: 'Video seconds / participating GPU-hour',
+    secondsAllocatedGpu: 'Video seconds / allocated GPU-hour',
     energy: 'Valid clips / GPU-board kWh',
     latencyNote:
       'Client-ready = submission to fully downloaded media, including polling; local validation is excluded from latency. P90 uses nearest rank and requires at least 10 complete valid-request samples here. This display floor does not establish tail-latency reliability. Failed requests stay visible in the counts.',
     throughputNote:
-      'Throughput uses the recorded measurement wall window, including failed attempts and client overhead. Serial runs are diagnostics, not demonstrated serving capacity. GPU-hour views charge every reserved GPU, including idle allocations.',
+      'Throughput uses the recorded measurement wall window, including failed attempts and client overhead. Serial runs are diagnostics, not demonstrated serving capacity.',
     qualityNote:
       'Matching fixes the model revision, generation settings and prompt/seed/input workload. Precision, caching and runtime changes still require fidelity review. Technical validity does not establish perceptual quality; uncalibrated points are not qualified winners.',
     energyNote:
@@ -70,7 +72,14 @@ const STRINGS = {
     allocated: 'Allocated / participating GPUs',
     window: 'Measurement window (s)',
     power: 'Mean total participating-board power (W)',
-    energyClip: 'GPU-board energy / valid clip (J)',
+    energyClip: 'GPU-board energy / valid clip (kJ)',
+    meanPower: 'Total mean board power (W)',
+    gpuNote:
+      'Participating-GPU views measure hardware efficiency; allocated-GPU views include idle allocations. Deployment costs include all billed resources.',
+    limitRatio: 'Mean / enforced limit (%)',
+    limitWatts: 'Total enforced power limit (W)',
+    limitNote:
+      'Power-limit ratios use matching prelaunch/postcleanup enforced limits for the participating GPU UUIDs. Snapshots must agree; they do not prove continuous stability. TDP and later inventories are never substituted.',
     powerWindow: 'Measured power window (s)',
     batch: 'Replica layout / actual batch size / offered arrival rate',
     queue: 'Queue delay / server-ready timestamp / deadline attainment',
@@ -111,13 +120,15 @@ const STRINGS = {
     p90: 'P90 客户端就绪延迟（秒）',
     median: '客户端就绪延迟中位数（秒）',
     dollar: '有效视频数 / USD',
-    clipsGpu: '有效视频数 / 已分配 GPU 小时',
-    secondsGpu: '生成视频秒数 / 已分配 GPU 小时',
+    clipsGpu: '有效视频数 / 参与计算 GPU 小时',
+    clipsAllocatedGpu: '有效视频数 / 已分配 GPU 小时',
+    secondsGpu: '生成视频秒数 / 参与计算 GPU 小时',
+    secondsAllocatedGpu: '生成视频秒数 / 已分配 GPU 小时',
     energy: '有效视频数 / GPU 板卡 kWh',
     latencyNote:
       '客户端就绪指从提交到媒体完整下载完成，包含轮询等待，不包含本地验证。P90 使用最近秩法，此处至少需要 10 个完整的有效请求样本；这只是显示门槛，不代表尾延迟估计具有统计可靠性。失败请求仍保留在计数中。',
     throughputNote:
-      '吞吐量使用记录的测量墙钟时间窗口，包含失败尝试与客户端开销。串行运行仅用于诊断，不能证明服务容量。GPU 小时指标计入所有预留 GPU，包括空闲的已分配资源。',
+      '吞吐量使用记录的测量墙钟时间窗口，包含失败尝试与客户端开销。串行运行仅用于诊断，不能证明服务容量。',
     qualityNote:
       '工作负载匹配固定了模型版本、生成设置以及 prompt、seed 和输入工作负载。精度、缓存和运行时变更仍需审查保真度。技术有效性不代表感知质量；未校准的点不能作为合格的性能优胜结果。',
     energyNote:
@@ -144,7 +155,14 @@ const STRINGS = {
     allocated: '已分配 / 参与计算的 GPU 数',
     window: '测量时段（秒）',
     power: '参与计算板卡总功率均值（W）',
-    energyClip: '每有效视频 GPU 板卡能耗（J）',
+    energyClip: '每有效视频 GPU 板卡能耗（kJ）',
+    meanPower: '板卡总功率均值（W）',
+    gpuNote:
+      '按参与计算 GPU 数衡量硬件效率；按已分配 GPU 数统计时包含空闲分配。完整部署成本须包含所有计费资源。',
+    limitRatio: '平均功率 / 实际生效上限（%）',
+    limitWatts: '实际生效功率上限合计（W）',
+    limitNote:
+      '功率占比使用参与计算 GPU 启动前与清理后记录的实际生效功率上限，并按 UUID 匹配。两次记录必须一致，但不能证明期间上限始终不变；不以规格 TDP 或事后硬件信息替代。',
     powerWindow: '功率测量窗口（秒）',
     batch: '副本布局 / 实际批次大小 / 施加的请求到达率',
     queue: '排队延迟 / 服务端就绪时间戳 / 时限达标情况',
@@ -282,7 +300,16 @@ export default function VideoTradeoff({
               label={s.y}
               value={yAxis}
               onValueChange={(value) => setY(value as EfficiencyAxis)}
-              options={(['dollar', 'clipsGpu', 'secondsGpu', 'energy'] as const).map((value) => ({
+              options={(
+                [
+                  'clipsGpu',
+                  'secondsGpu',
+                  'clipsAllocatedGpu',
+                  'secondsAllocatedGpu',
+                  'energy',
+                  'dollar',
+                ] as const
+              ).map((value) => ({
                 value,
                 label: s[value],
               }))}
@@ -403,6 +430,7 @@ export default function VideoTradeoff({
             <summary className="cursor-pointer font-medium">{s.methods}</summary>
             <p>{s.latencyNote}</p>
             <p>{isServing ? s.servingNote : s.throughputNote}</p>
+            <p>{s.gpuNote}</p>
             <p>{s.qualityNote}</p>
             {yAxis === 'energy' && <p>{s.energyNote}</p>}
           </details>
@@ -416,6 +444,9 @@ export default function VideoTradeoff({
                   <th className="p-2">{s.failed}</th>
                   <th className="p-2">{s[xAxis]}</th>
                   <th className="p-2">{s[yAxis]}</th>
+                  <th className="p-2">{s.meanPower}</th>
+                  <th className="p-2">{s.energyClip}</th>
+                  <th className="p-2">{s.limitRatio}</th>
                   <th className="p-2">{s.status}</th>
                 </tr>
               </thead>
@@ -438,6 +469,9 @@ export default function VideoTradeoff({
                     <td className="p-2">{fmt(p.failed)}</td>
                     <td className="p-2">{fmt(latencyValue(p, xAxis))}</td>
                     <td className="p-2">{fmt(efficiencyValue(p, yAxis, costs[p.id]))}</td>
+                    <td className="p-2">{fmt(p.power)}</td>
+                    <td className="p-2">{fmt(p.energy === null ? null : p.energy / 1000)}</td>
+                    <td className="p-2">{fmt(p.powerLimit?.percent ?? null)}</td>
                     <td className="p-2 text-xs">
                       {plotted.some((q) => q.id === p.id) ? s.plotted : s.missing}
                     </td>
@@ -465,7 +499,9 @@ export default function VideoTradeoff({
                       : []),
                     [s.window, fmt(active.wall)],
                     [s.power, fmt(active.power)],
-                    [s.energyClip, fmt(active.energy)],
+                    [s.energyClip, fmt(active.energy === null ? null : active.energy / 1000)],
+                    [s.limitRatio, fmt(active.powerLimit?.percent ?? null)],
+                    [s.limitWatts, fmt(active.powerLimit?.watts ?? null)],
                     [s.powerWindow, fmt(active.powerWindow)],
                     [s.batch, s.unavailable],
                     [s.queue, s.unavailable],
@@ -489,6 +525,7 @@ export default function VideoTradeoff({
                     {s.ci}
                   </a>
                 </div>
+                <p className="text-xs text-muted-foreground">{s.limitNote}</p>
                 <details>
                   <summary className="cursor-pointer text-xs">{s.workload}</summary>
                   <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all text-xs">

--- a/packages/app/src/components/video-benchmark/power-limit.test.ts
+++ b/packages/app/src/components/video-benchmark/power-limit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { powerLimitComparison } from './power-limit';
+import type { Json } from './bundle';
+
+// Synthetic recorded snapshots; deliberately different configured and enforced limits.
+function fixture() {
+  const gpus = ['GPU-a', 'GPU-b'].map((uuid) => ({
+    uuid,
+    configured_limit_w: 750,
+    enforced_limit_w: 700,
+  }));
+  return {
+    phase: {
+      valid: true,
+      aggregate: { avg_power_w: 1260 },
+      per_gpu: { 'GPU-a': { avg_power_w: 650 }, 'GPU-b': { avg_power_w: 610 } },
+    },
+    before: { status: 'recorded', observed_at: '2026-09-09T01:00:00Z', gpus },
+    after: { status: 'recorded', observed_at: '2026-09-09T02:00:00Z', gpus: structuredClone(gpus) },
+    uuids: ['GPU-a', 'GPU-b'],
+    unit: 'W',
+  };
+}
+function compare(input: ReturnType<typeof fixture>) {
+  return powerLimitComparison(input.phase, input.before, input.after, input.uuids, input.unit);
+}
+
+describe('Recorded power-limit comparison', () => {
+  it('uses enforced watts for the exact participating devices without depending on row order', () => {
+    const input = fixture();
+    input.after.gpus.reverse();
+    expect(compare(input)).toEqual({ watts: 1400, percent: 90 });
+  });
+  it('withholds mismatched device sets, units, invalid power and changed limits', () => {
+    const changes: ((input: ReturnType<typeof fixture>) => void)[] = [
+      (input) => {
+        input.phase.valid = false;
+      },
+      (input) => {
+        input.unit = 'kW';
+      },
+      (input) => {
+        input.uuids = ['GPU-a', 'GPU-a'];
+      },
+      (input) => {
+        input.uuids = [];
+      },
+      (input) => {
+        input.before.gpus.pop();
+      },
+      (input) => {
+        input.after.gpus[1].uuid = 'GPU-a';
+      },
+      (input) => {
+        input.after.gpus[1].uuid = 'GPU-other';
+      },
+      (input) => {
+        input.after.gpus[0].enforced_limit_w = 650;
+      },
+      (input) => {
+        input.after.gpus[0].configured_limit_w = 700;
+      },
+      (input) => {
+        input.before.gpus[0].enforced_limit_w = Number.NaN;
+      },
+      (input) => {
+        input.before.gpus[0].configured_limit_w = 0;
+      },
+      (input) => {
+        input.after.status = 'unavailable';
+      },
+      (input) => {
+        input.after.observed_at = '2026-09-08T23:00:00Z';
+      },
+      (input) => {
+        input.before.observed_at = '';
+      },
+      (input) => {
+        input.phase.per_gpu['GPU-a'].avg_power_w = -1;
+      },
+      (input) => {
+        input.phase.aggregate.avg_power_w = 650;
+      },
+    ];
+    for (const change of changes) {
+      const input = fixture();
+      change(input);
+      expect(compare(input)).toBeNull();
+    }
+  });
+  it('does not replace absent enforced limits with configured/default/TDP watts', () => {
+    const input = fixture();
+    const before: Json = {
+      ...input.before,
+      gpus: input.before.gpus.map(({ uuid }) => ({
+        uuid,
+        configured_limit_w: 700,
+        default_limit_w: 700,
+        tdp_w: 700,
+      })),
+    };
+    expect(powerLimitComparison(input.phase, before, input.after, input.uuids, 'W')).toBeNull();
+    expect(
+      powerLimitComparison(input.phase, input.before, input.after, input.uuids, null),
+    ).toBeNull();
+    expect(powerLimitComparison(null, null, null, null, null)).toBeNull();
+  });
+});

--- a/packages/app/src/components/video-benchmark/power-limit.ts
+++ b/packages/app/src/components/video-benchmark/power-limit.ts
@@ -1,0 +1,63 @@
+import { at, entries, number, rows, text, type Json } from './bundle';
+
+/** Compare measured board watts only with the same devices' recorded enforced limits. */
+export function powerLimitComparison(
+  phase: Json,
+  before: Json,
+  after: Json,
+  gpuUuids: Json,
+  powerUnit: Json,
+): { watts: number; percent: number } | null {
+  const uuids = rows(gpuUuids).map(text);
+  const mean = number(at(phase, 'aggregate', 'avg_power_w'));
+  const start = Date.parse(text(at(before, 'observed_at')));
+  const end = Date.parse(text(at(after, 'observed_at')));
+  if (
+    at(phase, 'valid') !== true ||
+    powerUnit !== 'W' ||
+    mean === null ||
+    mean < 0 ||
+    uuids.length === 0 ||
+    uuids.some((uuid) => !uuid) ||
+    new Set(uuids).size !== uuids.length ||
+    at(before, 'status') !== 'recorded' ||
+    at(after, 'status') !== 'recorded' ||
+    !Number.isFinite(start) ||
+    !Number.isFinite(end) ||
+    end < start
+  )
+    return null;
+  const snapshots = [before, after].map((snapshot) => rows(at(snapshot, 'gpus')));
+  if (
+    snapshots.some((devices) => {
+      const ids = devices.map((device) => text(at(device, 'uuid')));
+      return (
+        ids.length !== uuids.length ||
+        new Set(ids).size !== ids.length ||
+        ids.some((id) => !uuids.includes(id))
+      );
+    })
+  )
+    return null;
+  const measurements = entries(at(phase, 'per_gpu'));
+  if (measurements.length !== uuids.length || measurements.some(([id]) => !uuids.includes(id)))
+    return null;
+  let watts = 0;
+  let boardMean = 0;
+  for (const uuid of uuids) {
+    const first = snapshots[0].find((device) => at(device, 'uuid') === uuid);
+    const last = snapshots[1].find((device) => at(device, 'uuid') === uuid);
+    for (const key of ['configured_limit_w', 'enforced_limit_w']) {
+      const limit = number(at(first, key));
+      if (limit === null || limit <= 0 || limit !== number(at(last, key))) return null;
+    }
+    const measured = number(at(phase, 'per_gpu', uuid, 'avg_power_w'));
+    if (measured === null || measured < 0) return null;
+    watts += number(at(first, 'enforced_limit_w'))!;
+    boardMean += measured;
+  }
+  // Reject a partial or mismatched aggregate instead of silently normalizing it.
+  if (!Number.isFinite(watts) || Math.abs(boardMean - mean) > Math.max(1, mean) * 1e-6) return null;
+  const percent = (mean / watts) * 100;
+  return Number.isFinite(percent) ? { watts, percent } : null;
+}

--- a/packages/app/src/components/video-benchmark/tradeoff.test.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.test.ts
@@ -105,6 +105,7 @@ it('connects measured load settings within a known configuration, including domi
     { allocated: 16 },
     { participating: 2 },
     { server: { tp_size: 2 } },
+    { powerLimit: { watts: 1000, percent: 90 } },
     { hardware: '' },
     { revision: '' },
   ]) {
@@ -147,13 +148,17 @@ describe('H3 tradeoff metrics (synthetic result-contract fixtures)', () => {
     expect(latencyValue(p, 'p90')).toBeNull();
     expect(latencyValue(p, 'median')).toBe(149);
   });
-  it('uses all allocated GPUs and actual valid video durations', () => {
+  it('distinguishes participating and allocated GPUs with actual valid video durations', () => {
     const p = tradeoffPoints(fixture())[0];
-    expect(efficiencyValue(p, 'clipsGpu')).toBe(1.25);
-    expect(efficiencyValue(p, 'secondsGpu')).toBe(10);
+    expect(efficiencyValue(p, 'clipsGpu')).toBe(2.5);
+    expect(efficiencyValue(p, 'clipsAllocatedGpu')).toBe(1.25);
+    expect(efficiencyValue(p, 'secondsGpu')).toBe(20);
+    expect(efficiencyValue(p, 'secondsAllocatedGpu')).toBe(10);
     expect(efficiencyValue(p, 'dollar', cost)).toBe(5);
     expect(efficiencyValue(p, 'energy')).toBe(10);
-    expect(efficiencyValue({ ...p, allocated: null }, 'clipsGpu')).toBeNull();
+    expect(efficiencyValue({ ...p, allocated: null }, 'clipsAllocatedGpu')).toBeNull();
+    expect(efficiencyValue({ ...p, participating: null }, 'clipsGpu')).toBeNull();
+    expect(efficiencyValue({ ...p, participating: 0.5 }, 'clipsGpu')).toBeNull();
     expect(efficiencyValue({ ...p, energy: null }, 'energy')).toBeNull();
   });
   it('rejects incomplete latency populations instead of reporting a fast subset', () => {
@@ -248,7 +253,7 @@ describe('Serving matrix tradeoff metrics (synthetic contract fixture)', () => {
   it('does not substitute requested or participating GPUs for missing allocation evidence', () => {
     const run = matrixFixture();
     replace(at(run.bundle.ci, 'slurm_job'), 'AllocTRES', 'cpu=32,mem=512G,node=1');
-    expect(tradeoffPoints(run).map((p) => efficiencyValue(p, 'clipsGpu'))).toEqual([
+    expect(tradeoffPoints(run).map((p) => efficiencyValue(p, 'clipsAllocatedGpu'))).toEqual([
       null,
       null,
       null,
@@ -286,12 +291,13 @@ describe('Serving matrix tradeoff metrics (synthetic contract fixture)', () => {
       ids.map((uuid) => ({ uuid })),
     );
     expect(tradeoffPoints(run)[0].allocated).toBe(8);
-    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsGpu')).toBe(3.75);
+    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsGpu')).toBe(15);
+    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsAllocatedGpu')).toBe(3.75);
     run.bundle.documents!.set(
       'amd-allocated-devices.json',
       ids.slice(1).map((uuid) => ({ uuid })),
     );
-    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsGpu')).toBeNull();
+    expect(efficiencyValue(tradeoffPoints(run)[0], 'clipsAllocatedGpu')).toBeNull();
   });
   it('withholds incomplete latency data and invalid power without dropping their cells', () => {
     const run = matrixFixture();
@@ -362,6 +368,8 @@ it.skipIf(!process.env.H3_SERVING_ARTIFACT_DIR)(
     }
     expect(new Set(points.map((p) => p.group)).size).toBe(1);
     expect(points[0].energy).toBeCloseTo(164180.49905077327);
+    expect(points[0].powerLimit?.watts).toBe(1400);
+    expect(points[0].powerLimit?.percent).toBeCloseTo(98.133354354);
     expect(efficiencyValue(points[0], 'clipsGpu')).toBeCloseTo(15.0621776301);
   },
 );

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -1,6 +1,7 @@
 import { at, entries, number, ROLES, rows, text, type Bundle, type Json } from './bundle';
 import { servingCells } from './serving';
 import { allocatedGpus } from './allocation';
+import { powerLimitComparison } from './power-limit';
 
 export interface TradeoffRun {
   bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'> &
@@ -9,7 +10,13 @@ export interface TradeoffRun {
   artifact: string;
 }
 export type LatencyAxis = 'p90' | 'median';
-export type EfficiencyAxis = 'dollar' | 'clipsGpu' | 'secondsGpu' | 'energy';
+export type EfficiencyAxis =
+  | 'dollar'
+  | 'clipsGpu'
+  | 'secondsGpu'
+  | 'clipsAllocatedGpu'
+  | 'secondsAllocatedGpu'
+  | 'energy';
 export interface DeploymentCost {
   hourly: string;
   source: string;
@@ -116,6 +123,14 @@ function pairedTradeoffPoints(run: TradeoffRun) {
         ? positive(at(phase, 'aggregate', 'joules_per_valid_clip'))
         : null;
     const devices = rows(at(result, 'hardware', 'devices'));
+    const limits = at(result, 'hardware', 'configured_power_limits', 'by_role', role);
+    const powerLimit = powerLimitComparison(
+      phase,
+      at(limits, 'before'),
+      at(limits, 'after'),
+      at(result, 'hardware', 'gpu_uuids'),
+      at(result, 'definitions', 'gpu_power', 'unit'),
+    );
     return {
       id: `${b.manifestSha256}:${role}`,
       role,
@@ -139,6 +154,7 @@ function pairedTradeoffPoints(run: TradeoffRun) {
       allocated: positive(at(result, 'hardware', 'reserved_gpu_count')),
       participating: positive(at(result, 'hardware', 'selected_gpu_count')),
       energy,
+      powerLimit,
       power: at(phase, 'valid') === true ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
       powerWindow: at(phase, 'valid') === true ? number(at(phase, 'duration_seconds')) : null,
       server: at(result, 'workload', 'server'),
@@ -218,6 +234,15 @@ function servingTradeoffPoints(run: TradeoffRun) {
       energy: powerValid ? positive(at(phase, 'aggregate', 'joules_per_valid_clip')) : null,
       power: powerValid ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
       powerWindow: powerValid ? number(at(phase, 'duration_seconds')) : null,
+      powerLimit: powerValid
+        ? powerLimitComparison(
+            phase,
+            at(item.job, 'roles', 'baseline', 'power_configuration_before'),
+            at(item.job, 'roles', 'baseline', 'power_configuration_after'),
+            at(item.spec, 'gpu_uuids'),
+            at(item.power, 'semantics', 'power_unit'),
+          )
+        : null,
       server,
       fidelity: null,
       policy: at(item.spec, 'policy'),
@@ -248,6 +273,7 @@ export function tradeoffCurves<T extends TradeoffPoint & { x: number; y: number 
       allocated: p.allocated,
       participating: p.participating,
       server: p.server,
+      enforcedPowerLimitWatts: p.powerLimit?.watts ?? null,
     });
     const group = groups.get(key);
     if (group) group.push(p);
@@ -287,10 +313,26 @@ export function efficiencyValue(
     const hourly = costValue(cost);
     if (point.rate !== null && hourly !== null) value = point.rate / hourly;
   }
-  if (axis === 'clipsGpu' && point.rate !== null && point.allocated !== null)
-    value = point.rate / point.allocated;
-  if (axis === 'secondsGpu' && point.secondsRate !== null && point.allocated !== null)
-    value = point.secondsRate / point.allocated;
+  const gpuCount =
+    axis === 'clipsAllocatedGpu' || axis === 'secondsAllocatedGpu'
+      ? point.allocated
+      : point.participating;
+  if (
+    (axis === 'clipsGpu' || axis === 'clipsAllocatedGpu') &&
+    point.rate !== null &&
+    gpuCount !== null &&
+    Number.isSafeInteger(gpuCount) &&
+    gpuCount > 0
+  )
+    value = point.rate / gpuCount;
+  if (
+    (axis === 'secondsGpu' || axis === 'secondsAllocatedGpu') &&
+    point.secondsRate !== null &&
+    gpuCount !== null &&
+    Number.isSafeInteger(gpuCount) &&
+    gpuCount > 0
+  )
+    value = point.secondsRate / gpuCount;
   if (axis === 'energy' && point.energy !== null) value = 3600000 / point.energy;
   return value !== null && Number.isFinite(value) ? value : null;
 }


### PR DESCRIPTION
## Summary

Video hardware efficiency currently uses allocated GPUs, so a four-GPU workload on an eight-GPU allocation appears half as efficient. Default the chart and serving results to participating GPUs, retain allocated-GPU choices, and keep full deployment cost separate.

Show measured mean board power, kJ per valid clip, and mean power as a percentage of the recorded enforced limit in the result tables. The percentage requires matching unique GPU UUIDs, watts, matching aggregate measurements, and unchanged before/after configured and enforced limits; missing or inconsistent evidence stays unavailable. Snapshots do not establish continuous limit stability or substitute for TDP.

## Testing

- `bun run test:unit` — 6,274 passed, 3 skipped across the monorepo.
- `E2E_FIXTURES=1 CYPRESS_BASE_URL=http://127.0.0.1:3002 bun run test:e2e` — 46 component and 113 integration tests passed; focused video component coverage also passed (13 tests).
- Typecheck, lint, formatting, typography, and Claude Chinese-copy review passed; terminology advisory addressed.
- Localhost UI with real production video API/media: nine formal H100/H200/B200 points, GPU denominator switching, unavailable USD without cost inputs, English/Chinese desktop/mobile, 12 video/audio checks, and all four reports/downloads passed. H200 C1 reports 2,727.485 W / 2,800 W = 97.410%; B200 C1 reports 3,856.017 W / 4,000 W = 96.400%.

Formal CI evidence: [H200](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34342452354), [B200](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34341996789), [H100 C1/C2](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34336635063), [H100 C4](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34344378350). These remain closed-loop smoke results; serving capacity and paired fidelity are not established.

## 中文说明

原有硬件效率按已分配 GPU 数计算，四卡工作负载占用八卡分配时会显示为一半效率。图表与服务测试结果现默认按参与计算 GPU 数归一化，同时保留已分配 GPU 口径；完整部署成本仍单独填写。

结果表直接展示板卡平均功率、每有效视频能耗（kJ）及平均功率占实际生效上限的比例。比例仅使用 UUID 唯一且匹配、单位为 W、汇总功率一致、前后配置及实际生效上限均未变化的原始记录；证据不足则显示无数据。两次记录不能证明期间上限始终不变，也不能用规格 TDP 替代。

验证通过：全仓 6,274 项单元测试（3 项跳过）；本地 smoke 覆盖 46 项组件测试和 113 项集成测试，另有 13 项视频组件测试；类型、lint、格式、排版及 Claude 中文审校通过，术语建议已采纳。使用真实产物验证九个硬件数据点、GPU 口径切换、成本缺失状态、中英文桌面和移动端、12 次视频与音频播放，以及四份报告与下载链接。H200 C1 的上限占比为 97.410%，B200 C1 为 96.400%。这些仍是闭环 smoke 数据，尚不证明持续服务容量或配对保真度。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and derived-metric logic in the video benchmark UI only; no auth, APIs, or persistence changes, though default efficiency numbers will shift for partially utilized allocations.
> 
> **Overview**
> Video serving and tradeoff views now **default GPU-hour efficiency to participating GPUs** (from `spec.gpu_uuids`) instead of Slurm-allocated counts, with an explicit **GPU normalization** control in serving results and separate **participating vs allocated** efficiency axes on the tradeoff chart.
> 
> **Serving matrix** gains generation-phase columns for aggregate mean power, energy per valid clip (kJ), and **mean power / enforced limit (%)**. The power panel adds the same limit ratio and total enforced limit (W), with copy explaining when ratios are withheld.
> 
> New **`powerLimitComparison`** derives the percentage only when measurement power is valid, unit is W, participating UUIDs are unique and match before/after `power_configuration_*` snapshots with stable configured/enforced limits, and per-GPU means reconcile with the aggregate; otherwise the UI shows unavailable (no TDP/configured fallbacks). Tradeoff points carry `powerLimit`, curve grouping includes enforced limit watts, and the results table shows mean power, kJ/clip, and limit %.
> 
> Cypress and Vitest fixtures/tests were updated for the new defaults and stricter GPU-count rules for efficiency axes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 399932a646f95d74111ba62ab4a39647ab5b9401. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->