### PR TITLE
[Video] show paired fidelity and server timing evidence / 展示配对保真度与服务端计时证据

### DIFF
--- a/packages/app/cypress/component/video-fidelity.cy.tsx
+++ b/packages/app/cypress/component/video-fidelity.cy.tsx
@@ -64,6 +64,7 @@ describe('Native paired fidelity UI (synthetic artifacts)', () => {
   it('rewrites report media/download links and removes scripts and external resources', () => {
     cy.then(() => fidelityFixture()).then((fixture) => {
       mount({ published: fixture.published, runId: fixture.runId });
+      cy.get('iframe').should('not.exist');
       cy.contains('summary', 'Original report').click();
       cy.get<HTMLIFrameElement>('iframe')
         .should('have.attr', 'sandbox', 'allow-same-origin allow-downloads')
@@ -81,6 +82,8 @@ describe('Native paired fidelity UI (synthetic artifacts)', () => {
           expect(doc.querySelector('img')?.hasAttribute('src')).to.equal(false);
           expect(doc.body.dataset.scriptRan).to.equal(undefined);
         });
+      cy.contains('summary', 'Original report').click();
+      cy.get('iframe').should('not.exist');
     });
   });
 

--- a/packages/app/cypress/component/video-fidelity.cy.tsx
+++ b/packages/app/cypress/component/video-fidelity.cy.tsx
@@ -1,0 +1,130 @@
+import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
+import FidelityResults from '@/components/video-benchmark/FidelityResults';
+import { fidelityFixture } from '@/components/video-benchmark/fidelity.fixture';
+import { at } from '@/components/video-benchmark/bundle';
+
+// Synthetic non-playable bytes validate controls, URL binding, and accounting only.
+// Actual decoded video/audio playback is verified separately using retained CI output.
+const mount = (props: React.ComponentProps<typeof FidelityResults>, locale = '/video') =>
+  cy.mount(
+    <PathnameContext.Provider value={locale}>
+      <FidelityResults {...props} />
+    </PathnameContext.Provider>,
+  );
+
+describe('Native paired fidelity UI (synthetic artifacts)', () => {
+  it('distinguishes valid media from 18 threshold failures and changes both selected videos', () => {
+    cy.then(() => fidelityFixture({ pairs: 20, failedPairs: 18 })).then((fixture) => {
+      mount({ published: fixture.published, runId: fixture.runId });
+      cy.contains('p', 'Matched valid pairs').next().should('have.text', '20');
+      cy.contains('p', 'Pairs outside fidelity thresholds').next().should('have.text', '18');
+      cy.contains('dt', 'Threshold calibration').next().should('have.text', 'Uncalibrated');
+      cy.contains('dt', 'Release qualified').next().should('have.text', 'No');
+      cy.contains('dt', 'Video/audio technical validity').next().should('have.text', 'Yes');
+      for (const role of ['Baseline', 'Candidate'])
+        cy.get(`video[aria-label="${role}"]`)
+          .should('have.prop', 'controls', true)
+          .and('have.prop', 'muted', false)
+          .and('have.attr', 'preload', 'metadata');
+      const initial = ['baseline', 'candidate'].map(
+        (role) => `report/${at(fixture.portable, 'slots', 0, role, 'artifact_path')}`,
+      );
+      const next = ['baseline', 'candidate'].map(
+        (role) => `report/${at(fixture.portable, 'slots', 1, role, 'artifact_path')}`,
+      );
+      for (const [index, role] of ['Baseline', 'Candidate'].entries())
+        cy.get(`video[aria-label="${role}"]`).should(
+          'have.attr',
+          'src',
+          fixture.published.assets.find(([path]) => path === initial[index])![1].url,
+        );
+      cy.get('[aria-label="Paired clip"]').click();
+      cy.get('[role="option"]').should('have.length', 20);
+      cy.contains('[role="option"]', 'synthetic-case-2').click();
+      for (const [index, role] of ['Baseline', 'Candidate'].entries())
+        cy.get(`video[aria-label="${role}"]`).should(
+          'have.attr',
+          'src',
+          fixture.published.assets.find(([path]) => path === next[index])![1].url,
+        );
+      cy.contains('Synthetic test prompt 2').should('be.visible');
+      cy.contains('a', 'Raw comparison JSON').should(
+        'have.attr',
+        'href',
+        fixture.published.assets.find(([path]) => path === 'comparison.json')![1].downloadUrl,
+      );
+      cy.contains('a', 'CI #101').should(
+        'have.attr',
+        'href',
+        'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/101',
+      );
+    });
+  });
+
+  it('rewrites report media/download links and removes scripts and external resources', () => {
+    cy.then(() => fidelityFixture()).then((fixture) => {
+      mount({ published: fixture.published, runId: fixture.runId });
+      cy.contains('summary', 'Original report').click();
+      cy.get<HTMLIFrameElement>('iframe')
+        .should('have.attr', 'sandbox', 'allow-same-origin allow-downloads')
+        .should(($iframe) => {
+          const doc = $iframe[0].contentDocument!;
+          const path = `report/${at(fixture.portable, 'slots', 0, 'baseline', 'artifact_path')}`;
+          expect(doc.querySelector('video')?.getAttribute('src')).to.equal(
+            fixture.published.assets.find(([key]) => key === path)![1].url,
+          );
+          expect(doc.querySelector('a')?.getAttribute('href')).to.equal(
+            fixture.published.assets.find(([key]) => key === 'report/index.comparison.json')![1]
+              .url,
+          );
+          expect(doc.querySelectorAll('script')).to.have.length(0);
+          expect(doc.querySelector('img')?.hasAttribute('src')).to.equal(false);
+          expect(doc.body.dataset.scriptRan).to.equal(undefined);
+        });
+    });
+  });
+
+  it('loads a raw sealed bundle and revokes owned object URLs when unmounted', () => {
+    cy.window().then((win) => {
+      cy.spy(win.URL, 'revokeObjectURL').as('revoke');
+    });
+    cy.then(() => fidelityFixture()).then((fixture) => {
+      mount({ reader: fixture.read, runId: fixture.runId });
+      cy.get('[data-testid="fidelity-results"]').should('be.visible');
+      cy.get('video[aria-label="Baseline"]')
+        .invoke('attr', 'src')
+        .then((url) => {
+          expect(url).to.match(/^blob:/u);
+          cy.mount(<p>Unmounted synthetic reader</p>);
+          cy.get('@revoke').should('have.been.calledWith', url);
+        });
+    });
+  });
+
+  it('clears old evidence and reports an invalid or empty comparison', () => {
+    cy.then(() => fidelityFixture()).then((fixture) => {
+      mount({ published: fixture.published, runId: fixture.runId });
+      cy.get('[data-testid="fidelity-results"]').should('be.visible');
+      const invalid = structuredClone(fixture.published);
+      for (const [path, value] of invalid.documents)
+        if (['comparison.json', 'report/index.comparison.json'].includes(path))
+          Object.assign(value!, { slots: [] });
+      mount({ published: invalid, runId: fixture.runId });
+      cy.contains('[role="alert"]', 'Could not load paired evidence').should('be.visible');
+      cy.get('[data-testid="fidelity-results"]').should('not.exist');
+      cy.get('video').should('not.exist');
+    });
+  });
+
+  it('renders Chinese status and original-audio controls without relabeling failures as invalid media', () => {
+    cy.then(() => fidelityFixture()).then((fixture) => {
+      mount({ published: fixture.published, runId: fixture.runId }, '/zh/video');
+      cy.contains('成对视频保真度').should('be.visible');
+      cy.contains('p', '超出保真度阈值的视频对').next().should('have.text', '1');
+      cy.contains('dt', '视频与音频技术有效性').next().should('have.text', '是');
+      cy.contains('dt', '阈值校准状态').next().should('have.text', '未校准');
+      cy.get('video[aria-label="基线"]').should('have.prop', 'muted', false);
+      cy.get('video[aria-label="候选"]').should('have.prop', 'controls', true);
+    });
+  });
+});

--- a/packages/app/cypress/component/video-serving-results.cy.tsx
+++ b/packages/app/cypress/component/video-serving-results.cy.tsx
@@ -206,6 +206,7 @@ describe('H3 serving results (synthetic fixtures)', () => {
       mount({
         html: `<img src="${blobUrl}" alt="Synthetic blob image"><a href="${blobUrl}" download="fixture.svg">Download synthetic blob</a><script>document.body.dataset.scriptRan='yes'</script>`,
       });
+      cy.get('iframe').should('not.exist');
       cy.contains('summary', 'Original report').click();
       cy.get<HTMLIFrameElement>('iframe')
         .should('have.attr', 'sandbox', 'allow-same-origin allow-downloads')
@@ -216,6 +217,8 @@ describe('H3 serving results (synthetic fixtures)', () => {
           expect(doc?.body.dataset.scriptRan).to.equal(undefined);
         })
         .then(() => win.URL.revokeObjectURL(blobUrl));
+      cy.contains('summary', 'Original report').click();
+      cy.get('iframe').should('not.exist');
     });
   });
 

--- a/packages/app/cypress/component/video-serving-results.cy.tsx
+++ b/packages/app/cypress/component/video-serving-results.cy.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 import ServingResults from '@/components/video-benchmark/ServingResults';
 import type { ServingCell } from '@/components/video-benchmark/serving';
-import type { Bundle } from '@/components/video-benchmark/bundle';
+import { at, entries, rows, type Bundle } from '@/components/video-benchmark/bundle';
 
 // Synthetic fixtures exercise the serving contract; they are never benchmark results.
 const cells: ServingCell[] = [1, 2, 4].map((concurrency) => {
@@ -261,6 +261,86 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('Candidate').should('not.exist');
   });
 
+  it('shows server stages separately from delivery and retains partial coverage', () => {
+    const distribution = {
+      values: [1, 2, 3, 4],
+      sample_count: 4,
+      valid_clip_count: 4,
+      missing_count: 0,
+      p50: 2.5,
+      p90: null,
+      p95: null,
+    };
+    const original = cells[0];
+    const record = rows(at(original.run, 'records'))[1];
+    const timed = {
+      ...original,
+      run: {
+        ...Object.fromEntries(entries(original.run)),
+        summary: { valid: 4 },
+        serving: {
+          queue_delay_seconds: distribution,
+          server_ready_latency_seconds: {
+            ...distribution,
+            values: [120, 121],
+            sample_count: 2,
+            missing_count: 2,
+            p50: 999999,
+          },
+          observed_batch_sizes: [1, 1, 1, 1],
+          observed_replica_ids: [0],
+        },
+        records: [
+          {
+            ...Object.fromEntries(entries(record)),
+            job_id: 'synthetic-request',
+            server_timings: {
+              schema_version: '1.0.0',
+              status: 'complete',
+              request_id: 'synthetic-request',
+              instance_id: 'synthetic-instance',
+              clock_id: 'synthetic-clock',
+              clock: 'time.monotonic_ns; same Linux boot and time namespace; nanoseconds',
+              observed_batch_size: 1,
+              replica_id: 0,
+              server_ready_latency_seconds: 119,
+              prequeue_seconds: 1,
+              queue_delay_seconds: 0,
+              execution_seconds: 117,
+              postprocess_seconds: 1,
+            },
+          },
+        ],
+      },
+    };
+    mount({ cells: [timed] });
+    cy.get('[data-testid="serving-server-timing"]').within(() => {
+      cy.contains('tr', 'Queue delay').should('contain', '2.5').and('contain', '4 / 4 / 0');
+      cy.contains('tr', 'Received → media ready')
+        .should('contain', 'Unavailable')
+        .and('contain', '2 / 4 / 2')
+        .and('not.contain', '999,999');
+      cy.contains('dt', 'Observed batch sizes').next().should('have.text', '1');
+      cy.contains('dt', 'Observed replica IDs').next().should('have.text', '0');
+    });
+    cy.get('[data-testid="request-server-timing"]').within(() => {
+      cy.get('summary').click();
+      cy.contains('dt', 'Queue delay').next().should('have.text', '0 s');
+      cy.contains('dt', 'Received → media ready').next().should('have.text', '119 s');
+      cy.contains('time.monotonic_ns').should('be.visible');
+    });
+    cy.contains('dt', 'This request: submission → downloaded media')
+      .next()
+      .should('have.text', '120 s');
+    mount({ cells: [timed] }, '/zh/video');
+    cy.get('[data-testid="serving-server-timing"]').within(() => {
+      cy.contains('tr', '排队时长').should('contain', '2.5');
+      cy.contains('tr', '接收请求 → 媒体就绪')
+        .should('contain', '无数据')
+        .and('contain', '2 / 4 / 2');
+    });
+  });
+
   it('distinguishes requested and decoded duration and withholds invalid power', () => {
     mount();
     cy.contains('dt', 'Requested duration (s)').next().should('have.text', '4');
@@ -305,6 +385,7 @@ describe('H3 serving results (synthetic fixtures)', () => {
     cy.contains('并发服务测试结果').should('be.visible');
     cy.contains('此请求暂无可用媒体。').should('be.visible');
     cy.get('video').should('not.exist');
+    cy.get('[data-testid="serving-server-timing"]').should('contain', '无数据');
     cy.contains('p', '有效视频 / 参与计算 GPU 小时').next().should('have.text', '15');
     cy.get('[aria-label="GPU 归一化口径"]').click();
     cy.contains('[role="option"]', '所有已分配 GPU').click();

--- a/packages/app/cypress/component/video-tradeoff.cy.tsx
+++ b/packages/app/cypress/component/video-tradeoff.cy.tsx
@@ -1,7 +1,7 @@
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
 import VideoTradeoff from '@/components/video-benchmark/VideoTradeoff';
 import type { TradeoffRun } from '@/components/video-benchmark/tradeoff';
-import type { Json } from '@/components/video-benchmark/bundle';
+import { at, entries, rows, type Json } from '@/components/video-benchmark/bundle';
 import { servingFixture } from '@/components/video-benchmark/serving.fixture';
 
 const role = {
@@ -140,6 +140,59 @@ const matrix = (): TradeoffRun => ({
 });
 
 describe('Video serving matrix chart (synthetic contract fixture)', () => {
+  it('shows server coverage in point details without changing the client latency axis', () => {
+    const timed = matrix();
+    const documents = timed.bundle.documents!;
+    const runPath = 'gpu/c1/baseline/run.json';
+    const source = documents.get(runPath)!;
+    const serving = {
+      ...Object.fromEntries(entries(at(source, 'serving'))),
+      observed_batch_sizes: [1, 1, 1, 1],
+      observed_replica_ids: [0],
+      queue_delay_seconds: {
+        values: [0, 1, 2, 3],
+        sample_count: 4,
+        valid_clip_count: 4,
+        missing_count: 0,
+        p50: 1.5,
+        p90: null,
+        p95: null,
+      },
+    };
+    documents.set(runPath, { ...Object.fromEntries(entries(source)), serving });
+    const matrixDoc = documents.get('serving-smoke.json')!;
+    documents.set('serving-smoke.json', {
+      ...Object.fromEntries(entries(matrixDoc)),
+      cells: rows(at(matrixDoc, 'cells')).map((cell, index) =>
+        index
+          ? cell
+          : {
+              ...Object.fromEntries(entries(cell)),
+              metrics: { ...Object.fromEntries(entries(at(cell, 'metrics'))), serving },
+            },
+      ),
+    });
+    cy.mount(
+      <PathnameContext.Provider value="/video">
+        <VideoTradeoff runs={[timed]} onOpen={() => undefined} />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('dt', 'Observed batch sizes').next().should('have.text', '1');
+    cy.contains('dt', 'Observed replica IDs').next().should('have.text', '0');
+    cy.get('[data-testid="tradeoff-server-timing"]').within(() => {
+      cy.get('summary').click();
+      cy.contains('dt', 'Queue delay')
+        .next()
+        .should('contain', '1.5 / — / —')
+        .and('contain', '4 / 4 / 0');
+    });
+    cy.get('[aria-label="Latency axis · lower is better"]').should(
+      'contain',
+      'Median client-ready latency (s)',
+    );
+    cy.get('circle.point').should('have.length', 3);
+  });
+
   it('defaults to P90 when individual serving cells have enough samples', () => {
     const formal = matrix();
     formal.bundle = {

--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -29,12 +29,13 @@ describe('H3 CI artifact access', () => {
           { id: 1, name: 'e2e Test - h3-8s', path: '.github/workflows/e2e-tests.yml' },
           { id: 2, name: 'Test H3 Video', path: '.github/workflows/test-h3-video.yml' },
           { id: 3, name: 'H3 Video Smoke', path: '.github/workflows/h3-video.yml' },
+          { id: 4, name: 'H3 retained-media fidelity', path: '.github/workflows/h3-fidelity.yml' },
         ],
       }),
     );
     const result = await GET(request());
     const data = await result.json();
-    expect(data.runs.map((r: { id: number }) => r.id)).toEqual([1, 3]);
+    expect(data.runs.map((r: { id: number }) => r.id)).toEqual([1, 3, 4]);
     expect(result.headers.get('cache-control')).toContain('no-store');
   });
   it('refuses a private repository before reading any artifacts', async () => {

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -14,7 +14,7 @@ const ROOT = `${GITHUB_API_BASE}/repos/${GITHUB_OWNER}/${GITHUB_REPO}`;
 const MAX_BYTES = 256 * 1024 ** 2;
 const headers = { 'Cache-Control': 'private, no-store' };
 const id = (value: string) => /^[1-9]\d{0,19}$/u.test(value);
-const artifactName = /^h3-(?:results|video)-(?<runId>\d+)-(?<attempt>\d+)$/u;
+const artifactName = /^h3-(?:results|video|fidelity)-(?<runId>\d+)-(?<attempt>\d+)$/u;
 
 function github(path: string, signal = AbortSignal.timeout(30000)) {
   const token = getGithubToken();
@@ -147,7 +147,8 @@ export async function GET(request: NextRequest) {
         runs: runs.filter(
           (run: { name: string; display_title: string; path: string }) =>
             (run.path === '.github/workflows/e2e-tests.yml' && /\bh3\b/iu.test(run.name)) ||
-            run.path === '.github/workflows/h3-video.yml',
+            run.path === '.github/workflows/h3-video.yml' ||
+            run.path === '.github/workflows/h3-fidelity.yml',
         ),
         nextPage: runs.length === 100 ? Number(page) + 1 : null,
       },

--- a/packages/app/src/components/video-benchmark/FidelityResults.tsx
+++ b/packages/app/src/components/video-benchmark/FidelityResults.tsx
@@ -152,6 +152,7 @@ export default function FidelityResults({
   const [loadError, setError] = useState('');
   const [slotId, setSlotId] = useState('');
   const [mediaError, setMediaError] = useState(false);
+  const [reportOpen, setReportOpen] = useState(false);
   useEffect(() => {
     let cancelled = false;
     const created: string[] = [];
@@ -459,14 +460,16 @@ export default function FidelityResults({
           </a>
         )}
         {loaded.html && (
-          <details>
+          <details onToggle={(event) => setReportOpen(event.currentTarget.open)}>
             <summary className="cursor-pointer text-sm">{s.report}</summary>
-            <iframe
-              title={s.report}
-              sandbox="allow-same-origin allow-downloads"
-              srcDoc={loaded.html}
-              className="mt-3 h-[36rem] w-full rounded-lg border"
-            />
+            {reportOpen && (
+              <iframe
+                title={s.report}
+                sandbox="allow-same-origin allow-downloads"
+                srcDoc={loaded.html}
+                className="mt-3 h-[36rem] w-full rounded-lg border"
+              />
+            )}
           </details>
         )}
         <details>

--- a/packages/app/src/components/video-benchmark/FidelityResults.tsx
+++ b/packages/app/src/components/video-benchmark/FidelityResults.tsx
@@ -1,0 +1,490 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card } from '@/components/ui/card';
+import { Heading } from '@/components/ui/heading';
+import { useLocale } from '@/lib/use-locale';
+import { track } from '@/lib/analytics';
+import VideoSelect from './VideoSelect';
+import { at, ROLES, rows, text, type Json } from './bundle';
+import { fidelitySource, loadFidelityBundle, type FidelityBundle } from './fidelity';
+import { storedFidelityBundle, type StoredSource } from './stored';
+import { renderReportHtml } from './report';
+
+const STRINGS = {
+  en: {
+    title: 'Paired video fidelity',
+    intro: 'CPU comparison of retained C1 videos. No new video generation.',
+    pairs: 'Matched valid pairs',
+    outside: 'Pairs outside fidelity thresholds',
+    inconclusive: 'Inconclusive pairs',
+    calibration: 'Threshold calibration',
+    qualification: 'Release qualified',
+    unavailable: 'Unavailable',
+    uncalibrated: 'Uncalibrated',
+    yes: 'Yes',
+    no: 'No',
+    note: 'Technical validity covers decoding, geometry and continuity. Paired pixel/audio comparisons measure output drift using exploratory thresholds; they do not establish perceptual quality, prompt adherence or a hardware quality winner.',
+    loading: 'Loading and verifying paired evidence…',
+    error: 'Could not load paired evidence',
+    slot: 'Paired clip',
+    baseline: 'Baseline',
+    candidate: 'Candidate',
+    prompt: 'Prompt',
+    seed: 'Seed',
+    audio: 'Play one side at a time to compare original audio.',
+    download: 'Download original MP4',
+    noMedia: 'No media for this observation',
+    mediaError: 'The browser could not play this media. Download the original MP4 to inspect it.',
+    latency: 'Submission to downloaded media (s)',
+    integrity: 'Video/audio technical validity',
+    details: 'Generation settings and revisions',
+    runtime: 'Runtime revision',
+    model: 'Model revision',
+    metrics: 'Measured fidelity',
+    psnr: 'Video PSNR (dB)',
+    mae: 'Video MAE (normalized 0–1)',
+    identical: 'Identical frames; finite PSNR undefined',
+    spectral: 'Audio spectral cosine',
+    rms: 'Audio RMS ratio (candidate / baseline)',
+    waveform: 'Audio waveform MAE (PCM amplitude)',
+    frames: 'Compared / total video frames',
+    videoCoverage: 'Video sample coverage (fraction)',
+    audioCoverage: 'Audio sample coverage (fraction)',
+    audioSamples: 'Compared audio samples / channel',
+    checks: 'Recorded checks and thresholds',
+    check: 'Check',
+    status: 'Recorded status',
+    observed: 'Observed',
+    threshold: 'Threshold',
+    unit: 'Unit',
+    timing:
+      'Delivery latency is descriptive and includes polling and download. These cross-hardware results are not a calibrated performance regression or serving-capacity claim.',
+    sources: 'Original GPU runs and evidence',
+    originalResult: 'Original serving result and runtime log',
+    runtimeNote:
+      'Resolved attention backends and runtime settings can differ across sources. Consult the original runtime logs before attributing output differences to hardware.',
+    producer: 'CPU comparison CI',
+    artifact: 'Download CI artifact',
+    digest: 'Comparison SHA256',
+    raw: 'Raw comparison JSON',
+    report: 'Original report',
+    limitations: 'Backend policy and limitations',
+  },
+  zh: {
+    title: '成对视频保真度',
+    intro: '使用保留的 C1 视频在 CPU 上进行对比，未重新生成视频。',
+    pairs: '匹配的有效视频对',
+    outside: '超出保真度阈值的视频对',
+    inconclusive: '无法判定的视频对',
+    calibration: '阈值校准状态',
+    qualification: '是否通过发布验收',
+    unavailable: '无数据',
+    uncalibrated: '未校准',
+    yes: '是',
+    no: '否',
+    note: '技术有效性涵盖解码、画面尺寸与连续性。像素与音频配对比较采用探索性阈值，衡量的是输出偏差，不能证明感知质量或 prompt 遵循程度，也不能据此判定哪种硬件的视频质量更好。',
+    loading: '正在加载并校验配对证据…',
+    error: '无法加载配对证据',
+    slot: '配对视频',
+    baseline: '基线',
+    candidate: '候选',
+    prompt: 'Prompt',
+    seed: 'Seed',
+    audio: '每次只播放一侧，以便对比原始音频。',
+    download: '下载原始 MP4',
+    noMedia: '此侧暂无可用媒体',
+    mediaError: '浏览器无法播放此媒体，请下载原始 MP4 检查。',
+    latency: '提交到视频下载完成（秒）',
+    integrity: '视频与音频技术有效性',
+    details: '生成设置与版本',
+    runtime: '运行时版本',
+    model: '模型版本',
+    metrics: '实测保真度',
+    psnr: '视频 PSNR（dB）',
+    mae: '视频 MAE（归一化 0–1）',
+    identical: '帧完全一致，PSNR 无有限值',
+    spectral: '音频频谱余弦相似度',
+    rms: '音频 RMS 比值（候选 / 基线）',
+    waveform: '音频波形 MAE（PCM 幅度）',
+    frames: '已比较 / 总视频帧数',
+    videoCoverage: '视频采样覆盖比例',
+    audioCoverage: '音频采样覆盖比例',
+    audioSamples: '每声道已比较音频采样数',
+    checks: '已记录的检查与阈值',
+    check: '检查项',
+    status: '已记录状态',
+    observed: '观测值',
+    threshold: '阈值',
+    unit: '单位',
+    timing:
+      '交付延迟仅作描述，包含轮询与下载时间。这些跨硬件数据不构成已校准的性能回归或持续服务容量结论。',
+    sources: '原始 GPU 运行与证据',
+    originalResult: '原始服务测试结果与运行时日志',
+    runtimeNote:
+      '各来源实际使用的 attention backend 与运行时设置可能不同。判断输出差异的原因时，请核对原始运行时日志，不要直接归因于硬件。',
+    producer: 'CPU 对比 CI',
+    artifact: '下载 CI 产物',
+    digest: '对比结果 SHA256',
+    raw: '原始对比 JSON',
+    report: '原始报告',
+    limitations: '后端策略与局限',
+  },
+};
+
+export default function FidelityResults({
+  reader,
+  published,
+  runId,
+}: {
+  reader?: (path: string) => Promise<Blob>;
+  published?: StoredSource;
+  runId: string;
+}) {
+  const locale = useLocale();
+  const s = STRINGS[locale];
+  const [loaded, setLoaded] = useState<{
+    bundle: FidelityBundle;
+    urls: Map<string, string>;
+    downloads: Map<string, string>;
+    html: string;
+  } | null>(null);
+  const [loadError, setError] = useState('');
+  const [slotId, setSlotId] = useState('');
+  const [mediaError, setMediaError] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    const created: string[] = [];
+    setLoaded(null);
+    setError('');
+    setSlotId('');
+    setMediaError(false);
+    void (async () => {
+      try {
+        const bundle = published
+          ? storedFidelityBundle(published)
+          : await loadFidelityBundle(reader!, runId);
+        if (cancelled) return;
+        const urls = new Map(published?.assets.map(([path, asset]) => [path, asset.url]));
+        if (!published)
+          for (const [path, blob] of bundle.files) {
+            const url = URL.createObjectURL(
+              new Blob([blob], {
+                type: path.endsWith('.mp4') ? 'video/mp4' : 'application/octet-stream',
+              }),
+            );
+            created.push(url);
+            urls.set(path, url);
+          }
+        const raw = await bundle.files.get('report/index.html')?.text();
+        if (cancelled) return;
+        setLoaded({
+          bundle,
+          urls,
+          downloads: published
+            ? new Map(published.assets.map(([path, asset]) => [path, asset.downloadUrl]))
+            : urls,
+          html: raw ? renderReportHtml(raw, urls) : '',
+        });
+      } catch (error) {
+        if (!cancelled) setError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+    return () => {
+      cancelled = true;
+      created.forEach(URL.revokeObjectURL);
+    };
+  }, [reader, published, runId]);
+  const fmt = (value: Json | undefined) =>
+    typeof value === 'number'
+      ? value.toLocaleString('en-US', { maximumFractionDigits: 4 })
+      : value === true
+        ? s.yes
+        : value === false
+          ? s.no
+          : value === null || value === undefined || value === ''
+            ? s.unavailable
+            : typeof value === 'string'
+              ? value
+              : JSON.stringify(value);
+  if (loadError)
+    return (
+      <Card role="alert">
+        <Heading>{s.error}</Heading>
+        <p className="break-all text-sm">{loadError}</p>
+      </Card>
+    );
+  if (!loaded) return <Card role="status">{s.loading}</Card>;
+  const { bundle, urls, downloads } = loaded;
+  const comparison = bundle.comparison;
+  const slots = rows(at(bundle.portable, 'slots'));
+  const slot = slots.find((item) => at(item, 'slot_id') === slotId) ?? slots[0];
+  const metrics = at(slot, 'metrics');
+  const table = (values: [string, Json | undefined][]) => (
+    <dl className="grid grid-cols-2 gap-x-5 gap-y-2 text-sm">
+      {values.map(([label, value]) => (
+        <div key={label} className="contents">
+          <dt className="text-muted-foreground">{label}</dt>
+          <dd className="min-w-0 break-all tabular-nums">{fmt(value)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+  return (
+    <div className="space-y-4" data-testid="fidelity-results">
+      <Card className="gap-4">
+        <div>
+          <Heading>{s.title}</Heading>
+          <p className="mt-2 text-sm text-muted-foreground">{s.intro}</p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {[
+            [s.pairs, at(comparison, 'summary', 'matched_valid_pairs')],
+            [
+              s.outside,
+              slots.filter((item) =>
+                rows(at(item, 'checks')).some(
+                  (check) =>
+                    text(at(check, 'name')).startsWith('fidelity.') &&
+                    at(check, 'status') === 'fail',
+                ),
+              ).length,
+            ],
+            [s.inconclusive, at(comparison, 'summary', 'inconclusive_slots')],
+          ].map(([label, value]) => (
+            <div key={String(label)}>
+              <p className="text-xs text-muted-foreground">{String(label)}</p>
+              <p className="text-2xl font-semibold tabular-nums">{fmt(value)}</p>
+            </div>
+          ))}
+        </div>
+        {table([
+          [
+            s.calibration,
+            at(comparison, 'policy', 'calibration_status') === 'uncalibrated'
+              ? s.uncalibrated
+              : at(comparison, 'policy', 'calibration_status'),
+          ],
+          [s.qualification, at(comparison, 'release_qualified')],
+        ])}
+        <p className="text-sm text-muted-foreground">{s.note}</p>
+        <p className="text-xs text-muted-foreground">{s.runtimeNote}</p>
+      </Card>
+      <Card className="gap-4">
+        <div className="max-w-lg">
+          <VideoSelect
+            label={s.slot}
+            value={text(at(slot, 'slot_id'))}
+            onValueChange={(value) => {
+              setSlotId(value);
+              setMediaError(false);
+              track('video_fidelity_clip_selected', { slot: value });
+            }}
+            options={slots.map((item) => ({
+              value: text(at(item, 'slot_id')),
+              label: `${text(at(item, 'slot_id'))} · ${text(at(item, 'case_id'))}`,
+            }))}
+          />
+        </div>
+        <p className="text-sm">
+          <span className="font-medium">{s.prompt}: </span>
+          {text(at(slot, 'prompt'))}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {s.seed}: {fmt(at(slot, 'seed'))} · {s.audio}
+        </p>
+        <div className="grid gap-5 lg:grid-cols-2">
+          {ROLES.map((role) => {
+            const observation = at(slot, role);
+            const path = text(at(observation, 'artifact_path'));
+            const source = fidelitySource(bundle, role);
+            const sourceId = at(source, 'ci', 'databaseId');
+            const ci = bundle.documents.get(`sources/${sourceId}/ci.json`);
+            return (
+              <div key={role} className="min-w-0 space-y-3">
+                <Heading level="card">
+                  {s[role]} · {fmt(at(ci, 'site', 'gpu_model'))}
+                </Heading>
+                {urls.get(`report/${path}`) ? (
+                  <video
+                    key={path}
+                    src={urls.get(`report/${path}`)}
+                    controls
+                    playsInline
+                    preload="metadata"
+                    aria-label={s[role]}
+                    className="aspect-video w-full rounded-lg bg-black"
+                    onError={() => setMediaError(true)}
+                  />
+                ) : (
+                  <p>{s.noMedia}</p>
+                )}
+                {downloads.get(`report/${path}`) && (
+                  <a
+                    className="text-sm text-primary underline"
+                    href={downloads.get(`report/${path}`)}
+                    download
+                  >
+                    {s.download}
+                  </a>
+                )}
+                {table([
+                  [s.latency, at(observation, 'latency_seconds')],
+                  [s.integrity, at(observation, 'media', 'valid')],
+                  [s.runtime, at(comparison, role, 'configuration', 'runtime_revision')],
+                  [s.model, at(comparison, role, 'configuration', 'model_revision')],
+                ])}
+              </div>
+            );
+          })}
+        </div>
+        {mediaError && <p role="alert">{s.mediaError}</p>}
+        <p className="text-xs text-muted-foreground">{s.timing}</p>
+        <details>
+          <summary className="cursor-pointer text-sm">{s.details}</summary>
+          <pre className="mt-3 max-h-80 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(
+              {
+                generation: at(comparison, 'plan', 'generation'),
+                baseline: at(comparison, 'baseline', 'configuration'),
+                candidate: at(comparison, 'candidate', 'configuration'),
+              },
+              null,
+              2,
+            )}
+          </pre>
+        </details>
+      </Card>
+      <Card className="gap-4">
+        <Heading>{s.metrics}</Heading>
+        {table([
+          [
+            s.psnr,
+            at(metrics, 'video_identical') === true ? s.identical : at(metrics, 'video_psnr_db'),
+          ],
+          [s.mae, at(metrics, 'video_mae')],
+          [s.spectral, at(metrics, 'audio_spectral_cosine')],
+          [s.rms, at(metrics, 'audio_rms_ratio')],
+          [s.waveform, at(metrics, 'audio_waveform_mae')],
+          [
+            s.frames,
+            `${fmt(at(metrics, 'video_compared_frames'))} / ${fmt(at(metrics, 'video_total_frames'))}`,
+          ],
+          [s.videoCoverage, at(metrics, 'video_sample_coverage_fraction')],
+          [s.audioCoverage, at(metrics, 'audio_sample_coverage_fraction')],
+          [s.audioSamples, at(metrics, 'audio_compared_samples_per_channel')],
+        ])}
+        <details>
+          <summary className="cursor-pointer text-sm">{s.checks}</summary>
+          <div className="mt-3 overflow-x-auto">
+            <table className="w-full min-w-2xl text-left text-xs">
+              <thead>
+                <tr>
+                  {[s.check, s.status, s.observed, s.threshold, s.unit].map((label) => (
+                    <th key={label} className="p-2">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows(at(slot, 'checks')).map((check, index) => (
+                  <tr key={index} className="border-t">
+                    {['name', 'status', 'observed', 'threshold', 'unit'].map((key) => (
+                      <td key={key} className="p-2">
+                        {fmt(at(check, key))}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      </Card>
+      <Card className="gap-4">
+        <Heading>{s.sources}</Heading>
+        <div className="flex flex-wrap gap-4 text-sm">
+          {ROLES.map((role) => {
+            const source = fidelitySource(bundle, role);
+            const id = at(source, 'ci', 'databaseId');
+            const artifact = at(source, 'artifact', 'id');
+            return (
+              <div key={role} className="space-y-1">
+                <p>{s[role]}</p>
+                <a
+                  className="text-primary underline"
+                  href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  CI #{String(id)}
+                </a>
+                <br />
+                <a
+                  className="text-primary underline"
+                  href={`https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}/artifacts/${artifact}`}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {s.artifact}
+                </a>
+                <br />
+                <a
+                  className="text-primary underline"
+                  href={`${locale === 'zh' ? '/zh' : ''}/video?run=${id}&artifact=${artifact}&source=${id}&cell=c1`}
+                >
+                  {s.originalResult}
+                </a>
+              </div>
+            );
+          })}
+        </div>
+        <a
+          className="text-sm text-primary underline"
+          href={text(at(comparison, 'producer', 'run_url'))}
+          target="_blank"
+          rel="noreferrer"
+        >
+          {s.producer} #{runId}
+        </a>
+        {table([[s.digest, bundle.comparisonSha256]])}
+        {downloads.get('comparison.json') && (
+          <a
+            className="text-sm text-primary underline"
+            href={downloads.get('comparison.json')}
+            download
+          >
+            {s.raw}
+          </a>
+        )}
+        {loaded.html && (
+          <details>
+            <summary className="cursor-pointer text-sm">{s.report}</summary>
+            <iframe
+              title={s.report}
+              sandbox="allow-same-origin allow-downloads"
+              srcDoc={loaded.html}
+              className="mt-3 h-[36rem] w-full rounded-lg border"
+            />
+          </details>
+        )}
+        <details>
+          <summary className="cursor-pointer text-sm">{s.limitations}</summary>
+          <pre className="mt-3 max-h-80 overflow-auto whitespace-pre-wrap break-all text-xs">
+            {JSON.stringify(
+              {
+                policy: at(comparison, 'policy'),
+                measurement: at(comparison, 'measurement'),
+                limitations: at(comparison, 'limitations'),
+                release_qualification_reason: at(comparison, 'release_qualification_reason'),
+              },
+              null,
+              2,
+            )}
+          </pre>
+        </details>
+      </Card>
+    </div>
+  );
+}

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -278,6 +278,7 @@ export default function ServingResults({
   const [gpuBasis, setGpuBasis] = useState<'participating' | 'allocated'>('participating');
   const [phase, setPhase] = useState<'measurement' | 'startup' | 'warmup'>('measurement');
   const [failedMedia, setFailedMedia] = useState('');
+  const [reportOpen, setReportOpen] = useState(false);
   const selectedId = onCellChange ? (initialCell ?? selected) : selected;
   const current = cells.find((cell) => cell.id === selectedId) ?? cells[0];
   useEffect(() => {
@@ -860,15 +861,17 @@ export default function ServingResults({
           </div>
         </details>
         {html && (
-          <details>
+          <details onToggle={(event) => setReportOpen(event.currentTarget.open)}>
             <summary className="cursor-pointer text-sm">{s.report}</summary>
             <p className="my-3 text-xs text-muted-foreground">{s.reportNote}</p>
-            <iframe
-              title={s.report}
-              srcDoc={html}
-              sandbox="allow-same-origin allow-downloads"
-              className="h-[640px] w-full rounded-lg border bg-white"
-            />
+            {reportOpen && (
+              <iframe
+                title={s.report}
+                srcDoc={html}
+                sandbox="allow-same-origin allow-downloads"
+                className="h-[640px] w-full rounded-lg border bg-white"
+              />
+            )}
           </details>
         )}
         <details>

--- a/packages/app/src/components/video-benchmark/ServingResults.tsx
+++ b/packages/app/src/components/video-benchmark/ServingResults.tsx
@@ -11,6 +11,7 @@ import { at, number, rows, safePath, text, type Bundle, type Json } from './bund
 import type { ServingCell } from './serving';
 import { allocatedGpus } from './allocation';
 import { powerLimitComparison } from './power-limit';
+import { requestServerTiming, serverTimingSummary, SERVER_TIMING_COPY } from './server-timing';
 
 const STRINGS = {
   en: {
@@ -105,9 +106,9 @@ const STRINGS = {
     server: 'Server configuration',
     observed: 'Observed submission rate (requests/s)',
     inFlight: 'Peak client requests in flight',
-    missing: 'Unavailable serving measurements',
+    missing: 'Serving measurement scope',
     missingNote:
-      'Server-side queue delay, server-ready latency, observed batch sizes and fixed offered arrival rate are not supplied. Closed-loop concurrency is not server batch size. Costs and prices require separate, dated assumptions.',
+      'Closed-loop tests do not fix the offered arrival rate. Missing server measurements are shown as unavailable. Costs and prices require separate, dated assumptions.',
     outcome: 'Completion accounting',
     completed: 'Completed',
     failedCount: 'Failed / invalid',
@@ -214,9 +215,9 @@ const STRINGS = {
     server: '服务端配置',
     observed: '观测提交速率（requests/s）',
     inFlight: '客户端在途请求峰值',
-    missing: '尚未提供的服务指标',
+    missing: '服务测量范围',
     missingNote:
-      '尚无服务端排队时长、服务端完成延迟、实际 batch size 或固定请求到达速率。闭环客户端并发数不等于服务端 batch size。成本与价格需要另行提供注明日期的假设。',
+      '闭环测试不固定请求到达速率。缺失的服务端指标显示为无数据。成本与价格需要另行提供注明日期的假设。',
     outcome: '请求完成情况',
     completed: '已完成',
     failedCount: '失败 / 无效',
@@ -269,7 +270,9 @@ export default function ServingResults({
   initialCell?: string;
   onCellChange?: (id: string) => void;
 }) {
-  const s = STRINGS[useLocale()];
+  const locale = useLocale();
+  const s = STRINGS[locale];
+  const t = SERVER_TIMING_COPY[locale];
   const [selected, setSelected] = useState(initialCell ?? '');
   const [slot, setSlot] = useState('');
   const [gpuBasis, setGpuBasis] = useState<'participating' | 'allocated'>('participating');
@@ -299,6 +302,8 @@ export default function ServingResults({
     records.find((row) => text(at(row, 'slot_id')) === slot) ??
     records.find((row) => at(row, 'phase') === 'measurement') ??
     records[0];
+  const serverTiming = serverTimingSummary(run, verified);
+  const requestTiming = requestServerTiming(record ?? null, verified);
   const media = at(record, 'media');
   const warmup = at(record, 'phase') === 'warmup';
   const telemetry = at(job, 'roles', 'baseline', 'telemetry_summary');
@@ -349,6 +354,7 @@ export default function ServingResults({
     current.jobPath,
     current.powerPath,
     current.specPath,
+    `gpu/${current.id}/supervisor/baseline/runtime.stdout.log`,
     'manifest.json',
     'SHA256SUMS',
   ];
@@ -516,6 +522,31 @@ export default function ServingResults({
                     ],
                   ]}
                 />
+                <details data-testid="request-server-timing">
+                  <summary className="cursor-pointer text-sm">{t.title}</summary>
+                  <div className="mt-3 space-y-3">
+                    <Data
+                      values={[
+                        [
+                          t.status,
+                          requestTiming
+                            ? requestTiming.status === 'complete'
+                              ? t.complete
+                              : t.partial
+                            : t.unavailable,
+                        ],
+                        ...t.stages.map((label, index): [string, string] => [
+                          label,
+                          `${fmt(requestTiming?.stages[index] ?? null)} s`,
+                        ]),
+                        [t.batch, fmt(requestTiming?.batchSize ?? null)],
+                        [t.replicas, fmt(requestTiming?.replicaId ?? null)],
+                        [t.identity, requestTiming?.identity ?? t.unavailable],
+                      ]}
+                    />
+                    <p className="text-xs leading-relaxed text-muted-foreground">{t.clock}</p>
+                  </div>
+                </details>
                 {warmup && (
                   <p className="text-sm font-medium text-amber-600 dark:text-amber-400">
                     {s.warmup}
@@ -626,6 +657,57 @@ export default function ServingResults({
         />
         <p className="text-xs text-muted-foreground">{s.p90Note}</p>
         <p className="text-xs text-muted-foreground">{s.gpuNote}</p>
+      </Card>
+
+      <Card className="gap-4" data-testid="serving-server-timing">
+        <Heading>{t.title}</Heading>
+        {serverTiming.stages.some(Boolean) || serverTiming.batchSizes || serverTiming.replicaIds ? (
+          <>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-xl text-left text-sm">
+                <thead className="text-xs text-muted-foreground">
+                  <tr>
+                    {[t.title, 'P50 (s)', 'P90 (s)', 'P95 (s)', t.coverage].map((label) => (
+                      <th key={label} className="px-3 py-2 font-medium">
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="tabular-nums">
+                  {t.stages.map((label, index) => {
+                    const timing = serverTiming.stages[index];
+                    return (
+                      <tr key={label} className="border-t border-border/40">
+                        <th className="px-3 py-2 font-medium">{label}</th>
+                        {[timing?.p50, timing?.p90, timing?.p95].map((value, i) => (
+                          <td key={i} className="px-3 py-2">
+                            {fmt(value ?? null)}
+                          </td>
+                        ))}
+                        <td className="px-3 py-2">
+                          {timing
+                            ? `${timing.samples} / ${timing.valid} / ${timing.missing}`
+                            : t.unavailable}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <Data
+              values={[
+                [t.batch, serverTiming.batchSizes?.join(', ') ?? t.unavailable],
+                [t.replicas, serverTiming.replicaIds?.join(', ') ?? t.unavailable],
+              ]}
+            />
+          </>
+        ) : (
+          <p className="text-sm text-muted-foreground">{t.unavailable}</p>
+        )}
+        <p className="text-xs leading-relaxed text-muted-foreground">{t.note}</p>
+        <p className="text-xs leading-relaxed text-muted-foreground">{t.layoutNote}</p>
       </Card>
 
       <Card className="gap-4" data-testid="serving-power">

--- a/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
+++ b/packages/app/src/components/video-benchmark/VideoBenchmark.tsx
@@ -306,6 +306,7 @@ export default function VideoBenchmark({
   const [billed, setBilled] = useState('');
   const [assumption, setAssumption] = useState('');
   const [date, setDate] = useState('');
+  const [reportOpen, setReportOpen] = useState(false);
   const generation = useRef(0);
   const input = useRef<HTMLInputElement>(null);
   const activeUrls = useRef<string[]>([]);
@@ -326,6 +327,7 @@ export default function VideoBenchmark({
     setError('');
     setLoading(false);
     setSlot('');
+    setReportOpen(false);
   }
   async function open(read?: () => (path: string) => Promise<Blob>, saved?: StoredSource) {
     clear();
@@ -915,16 +917,18 @@ export default function VideoBenchmark({
             </a>
             {table([[s.manifest, b.manifestSha256]])}
             {loaded.html && (
-              <details>
+              <details onToggle={(event) => setReportOpen(event.currentTarget.open)}>
                 <summary className="cursor-pointer">{s.report}</summary>
                 <p className="my-3 text-sm text-muted-foreground">{s.reportNote}</p>
-                <iframe
-                  title={s.report}
-                  sandbox="allow-same-origin allow-downloads"
-                  referrerPolicy="no-referrer"
-                  className="h-[70vh] w-full rounded-lg border bg-white"
-                  srcDoc={loaded.html}
-                />
+                {reportOpen && (
+                  <iframe
+                    title={s.report}
+                    sandbox="allow-same-origin allow-downloads"
+                    referrerPolicy="no-referrer"
+                    className="h-[70vh] w-full rounded-lg border bg-white"
+                    srcDoc={loaded.html}
+                  />
+                )}
               </details>
             )}
             <details>

--- a/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
+++ b/packages/app/src/components/video-benchmark/VideoCIRuns.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Input } from '@/components/ui/input';
 import { useLocale } from '@/lib/use-locale';
 import VideoBenchmark from './VideoBenchmark';
+import FidelityResults from './FidelityResults';
 import VideoSelect from './VideoSelect';
 import { servingCells } from './serving';
 import VideoTradeoff from './VideoTradeoff';
@@ -108,7 +109,12 @@ export default function VideoCIRuns() {
   const [artifacts, setArtifacts] = useState<CIArtifact[]>([]);
   const [artifact, setArtifact] = useState<CIArtifact | null>(null);
   const [sources, setSources] = useState<
-    { id: string; read?: (path: string) => Promise<Blob>; stored?: StoredSource }[]
+    {
+      id: string;
+      kind?: 'fidelity';
+      read?: (path: string) => Promise<Blob>;
+      stored?: StoredSource;
+    }[]
   >([]);
   const [sourceId, setSourceId] = useState('');
   const [nextPage, setNextPage] = useState<number | null>(1);
@@ -194,7 +200,7 @@ export default function VideoCIRuns() {
             saved.sources.length === 0
           )
             throw new Error('Stored comparison identity mismatch');
-          const bundles = saved.sources.map(storedBundle);
+          const bundles = saved.sources.filter((source) => !source.kind).map(storedBundle);
           for (const bundle of bundles) servingCells(bundle);
           if (!controller.signal.aborted)
             for (const bundle of bundles) collect(bundle, runId, artifactId);
@@ -223,7 +229,12 @@ export default function VideoCIRuns() {
     setProgress(s.preparing);
     const endpoint = `/api/video-runs?run=${selectedRun.id}&artifact=${selected.id}`;
     let found:
-      | { id: string; read?: (path: string) => Promise<Blob>; stored?: StoredSource }[]
+      | {
+          id: string;
+          kind?: 'fidelity';
+          read?: (path: string) => Promise<Blob>;
+          stored?: StoredSource;
+        }[]
       | null = null;
     try {
       const response = prepared
@@ -237,7 +248,7 @@ export default function VideoCIRuns() {
           saved.artifact.id !== selected.id
         )
           throw new Error('Stored artifact identity mismatch');
-        found = saved.sources.map((item) => ({ id: item.id, stored: item }));
+        found = saved.sources.map((item) => ({ id: item.id, kind: item.kind, stored: item }));
       }
     } catch (error) {
       if (controller.signal.aborted) throw error;
@@ -269,7 +280,7 @@ export default function VideoCIRuns() {
     }
     if (current !== request.current) return;
     for (const item of found) {
-      if (item.stored)
+      if (item.stored && !item.kind)
         collect(storedBundle(item.stored), String(selectedRun.id), String(selected.id));
     }
     const chosen =
@@ -278,6 +289,7 @@ export default function VideoCIRuns() {
     if (!chosen) throw new Error(s.none);
     setSources(found);
     setSourceId(chosen.id);
+    if (chosen.kind === 'fidelity') changeView('results');
     share(selectedRun.id, selected.id, chosen.id, preferredCell);
   }
   async function selectRun(
@@ -593,18 +605,27 @@ export default function VideoCIRuns() {
       </div>
       {selectedSource && (
         <div hidden={view !== 'results'}>
-          <VideoBenchmark
-            key={`${artifact?.id}-${sourceId}`}
-            reader={selectedSource.read}
-            published={selectedSource.stored}
-            initialCell={cellId}
-            onCellChange={(id) => {
-              setCellId(id);
-              if (run && artifact) share(run.id, artifact.id, sourceId, id);
-            }}
-            onLoaded={collectLoaded}
-            onError={() => changeView('results')}
-          />
+          {selectedSource.kind === 'fidelity' ? (
+            <FidelityResults
+              key={`${artifact?.id}-${sourceId}`}
+              reader={selectedSource.read}
+              published={selectedSource.stored}
+              runId={sourceId}
+            />
+          ) : (
+            <VideoBenchmark
+              key={`${artifact?.id}-${sourceId}`}
+              reader={selectedSource.read}
+              published={selectedSource.stored}
+              initialCell={cellId}
+              onCellChange={(id) => {
+                setCellId(id);
+                if (run && artifact) share(run.id, artifact.id, sourceId, id);
+              }}
+              onLoaded={collectLoaded}
+              onError={() => changeView('results')}
+            />
+          )}
         </div>
       )}
       <details onToggle={(event) => setManual(event.currentTarget.open)}>

--- a/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
+++ b/packages/app/src/components/video-benchmark/VideoTradeoff.tsx
@@ -13,6 +13,7 @@ import { useLocale } from '@/lib/use-locale';
 import { escapeHtml } from '@/lib/utils';
 import { track } from '@/lib/analytics';
 import VideoSelect from './VideoSelect';
+import { SERVER_TIMING_COPY } from './server-timing';
 import {
   tradeoffPoints,
   tradeoffCurves,
@@ -81,8 +82,7 @@ const STRINGS = {
     limitNote:
       'Power-limit ratios use matching prelaunch/postcleanup enforced limits for the participating GPU UUIDs. Snapshots must agree; they do not prove continuous stability. TDP and later inventories are never substituted.',
     powerWindow: 'Measured power window (s)',
-    batch: 'Replica layout / actual batch size / offered arrival rate',
-    queue: 'Queue delay / server-ready timestamp / deadline attainment',
+    offered: 'Offered arrival rate / deadline attainment',
     unavailable: 'Unavailable in this result contract',
     server: 'Recorded server settings',
     fidelity: 'Recorded fidelity and policy',
@@ -164,8 +164,7 @@ const STRINGS = {
     limitNote:
       '功率占比使用参与计算 GPU 启动前与清理后记录的实际生效功率上限，并按 UUID 匹配。两次记录必须一致，但不能证明期间上限始终不变；不以规格 TDP 或事后硬件信息替代。',
     powerWindow: '功率测量窗口（秒）',
-    batch: '副本布局 / 实际批次大小 / 施加的请求到达率',
-    queue: '排队延迟 / 服务端就绪时间戳 / 时限达标情况',
+    offered: '施加的请求到达率 / 时限达标情况',
     unavailable: '此结果格式未提供',
     server: '已记录的服务端设置',
     fidelity: '已记录的保真度与判定策略',
@@ -205,7 +204,9 @@ export default function VideoTradeoff({
   onOpen: (point: TradeoffPoint) => void;
   sourceId?: string;
 }) {
-  const s = STRINGS[useLocale()];
+  const locale = useLocale();
+  const s = STRINGS[locale];
+  const t = SERVER_TIMING_COPY[locale];
   const all = useMemo(() => runs.flatMap(tradeoffPoints), [runs]);
   const [workload, setWorkload] = useState('');
   const [latencyAxis, setX] = useState<LatencyAxis | null>(null);
@@ -503,8 +504,9 @@ export default function VideoTradeoff({
                     [s.limitRatio, fmt(active.powerLimit?.percent ?? null)],
                     [s.limitWatts, fmt(active.powerLimit?.watts ?? null)],
                     [s.powerWindow, fmt(active.powerWindow)],
-                    [s.batch, s.unavailable],
-                    [s.queue, s.unavailable],
+                    [t.batch, active.timing.batchSizes?.join(', ') ?? s.unavailable],
+                    [t.replicas, active.timing.replicaIds?.join(', ') ?? s.unavailable],
+                    [s.offered, s.unavailable],
                   ].map(([name, value]) => (
                     <div key={name} className="contents">
                       <dt className="text-muted-foreground">{name}</dt>
@@ -526,6 +528,32 @@ export default function VideoTradeoff({
                   </a>
                 </div>
                 <p className="text-xs text-muted-foreground">{s.limitNote}</p>
+                <details data-testid="tradeoff-server-timing" className="space-y-3">
+                  <summary className="cursor-pointer text-xs">{t.title}</summary>
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                    {t.stages.map((name, index) => {
+                      const timing = active.timing.stages[index];
+                      return (
+                        <div key={name} className="contents">
+                          <dt className="text-muted-foreground">{name} · P50 / P90 / P95 (s)</dt>
+                          <dd>
+                            {fmt(timing?.p50 ?? null)} / {fmt(timing?.p90 ?? null)} /{' '}
+                            {fmt(timing?.p95 ?? null)}
+                            <br />
+                            <span className="text-muted-foreground">
+                              {t.coverage}:{' '}
+                              {timing
+                                ? `${timing.samples} / ${timing.valid} / ${timing.missing}`
+                                : s.unavailable}
+                            </span>
+                          </dd>
+                        </div>
+                      );
+                    })}
+                  </dl>
+                  <p className="text-xs text-muted-foreground">{t.note}</p>
+                  <p className="text-xs text-muted-foreground">{t.layoutNote}</p>
+                </details>
                 <details>
                   <summary className="cursor-pointer text-xs">{s.workload}</summary>
                   <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-all text-xs">

--- a/packages/app/src/components/video-benchmark/archive.test.ts
+++ b/packages/app/src/components/video-benchmark/archive.test.ts
@@ -65,6 +65,33 @@ describe('CI ZIP import', () => {
       ),
     ).rejects.toThrow('different runs');
   });
+  it('binds fidelity processing provenance to GitHub metadata when available', async () => {
+    const comparison = JSON.stringify({
+      producer: { run_id: '10', run_attempt: '1', git_commit: 'a'.repeat(40) },
+    });
+    const blob = archive({
+      'comparison.json': comparison,
+      SHA256SUMS: `${hash(comparison)}  comparison.json`,
+    });
+    const fidelity = { ...artifact, name: 'h3-fidelity-10-1' };
+    const [source] = await archiveSources(blob, {
+      ...fidelity,
+      workflow_run: { id: 10, head_sha: 'a'.repeat(40) },
+    });
+    expect(source.id).toBe('10');
+    await expect(
+      archiveSources(blob, {
+        ...fidelity,
+        workflow_run: { id: 10, head_sha: 'b'.repeat(40) },
+      }),
+    ).rejects.toThrow('different runs');
+    await expect(
+      archiveSources(blob, {
+        ...fidelity,
+        workflow_run: { id: 11, head_sha: 'a'.repeat(40) },
+      }),
+    ).rejects.toThrow('different runs');
+  });
   it('rejects corrupted GitHub archive digests', async () => {
     await expect(
       archiveSources(archive({}), { ...artifact, digest: `sha256:${'0'.repeat(64)}` }),

--- a/packages/app/src/components/video-benchmark/archive.ts
+++ b/packages/app/src/components/video-benchmark/archive.ts
@@ -57,13 +57,33 @@ export async function archiveSources(blob: Blob, artifact: CIArtifact) {
       throw new Error('Archive checksum mismatch');
     verified.add(match.groups!.path);
   }
-  if (!verified.has(files['index.json'] ? 'index.json' : 'manifest.json'))
+  const fidelity = artifact.name.startsWith('h3-fidelity-');
+  if (
+    !verified.has(
+      fidelity ? 'comparison.json' : files['index.json'] ? 'index.json' : 'manifest.json',
+    )
+  )
     throw new Error('Missing verified archive entry point');
   const index: Json = files['index.json'] ? JSON.parse(await read('index.json').text()) : null;
-  const identity = /^h3-(?:video|results)-(?<run>\d+)-(?<attempt>\d+)$/u.exec(
+  const identity = /^h3-(?:video|results|fidelity)-(?<run>\d+)-(?<attempt>\d+)$/u.exec(
     artifact.name,
   )?.groups;
   if (!identity) throw new Error('Invalid H3 artifact identity');
+  if (fidelity) {
+    const comparison: Json = JSON.parse(await read('comparison.json').text());
+    if (
+      at(comparison, 'producer', 'run_id') !== identity.run ||
+      at(comparison, 'producer', 'run_attempt') !== identity.attempt
+    )
+      throw new Error('Comparison and GitHub artifact identify different runs');
+    return [
+      {
+        id: identity.run,
+        kind: 'fidelity' as const,
+        read: (path: string) => Promise.resolve(read(path)),
+      },
+    ];
+  }
   if (
     index &&
     (at(index, 'producer', 'ci', 'run_id') !== identity.run ||

--- a/packages/app/src/components/video-benchmark/archive.ts
+++ b/packages/app/src/components/video-benchmark/archive.ts
@@ -6,6 +6,7 @@ export interface CIArtifact {
   expired: boolean;
   size_in_bytes: number;
   digest?: string;
+  workflow_run?: { id: number; head_sha: string };
   stored?: boolean;
   indexUrl?: string;
 }
@@ -73,7 +74,10 @@ export async function archiveSources(blob: Blob, artifact: CIArtifact) {
     const comparison: Json = JSON.parse(await read('comparison.json').text());
     if (
       at(comparison, 'producer', 'run_id') !== identity.run ||
-      at(comparison, 'producer', 'run_attempt') !== identity.attempt
+      at(comparison, 'producer', 'run_attempt') !== identity.attempt ||
+      (artifact.workflow_run !== undefined &&
+        (String(artifact.workflow_run.id) !== identity.run ||
+          artifact.workflow_run.head_sha !== at(comparison, 'producer', 'git_commit')))
     )
       throw new Error('Comparison and GitHub artifact identify different runs');
     return [

--- a/packages/app/src/components/video-benchmark/bundle.ts
+++ b/packages/app/src/components/video-benchmark/bundle.ts
@@ -51,7 +51,10 @@ export interface Bundle {
   checksums: Map<string, string>;
   manifestSha256: string;
 }
-export async function loadBundle(read: (path: string) => Promise<Blob>): Promise<Bundle> {
+export async function readVerifiedFiles(
+  read: (path: string) => Promise<Blob>,
+  entryPoint: 'manifest.json' | 'comparison.json',
+) {
   const sums = await read('SHA256SUMS');
   if (sums.size > 1024 * 1024) throw new Error('Checksum inventory exceeds 1 MiB');
   const checksums = new Map<string, string>();
@@ -62,8 +65,8 @@ export async function loadBundle(read: (path: string) => Promise<Blob>): Promise
       throw new Error('Malformed or duplicate SHA256SUMS entry');
     checksums.set(safePath(match.groups!.path), match.groups!.hash);
   }
-  if (!checksums.has('manifest.json') || checksums.size > 2000)
-    throw new Error('Missing manifest or oversized inventory');
+  if (!checksums.has(entryPoint) || checksums.size > 2000)
+    throw new Error('Missing artifact entry point or oversized inventory');
   const files = new Map<string, Blob>([['SHA256SUMS', sums]]);
   const documents = new Map<string, Json>();
   let total = 0;
@@ -80,6 +83,11 @@ export async function loadBundle(read: (path: string) => Promise<Blob>): Promise
     if (path.endsWith('.json') && !path.endsWith('.stdout.json'))
       documents.set(path, JSON.parse(await blob.text()));
   }
+  return { files, documents, checksums };
+}
+
+export async function loadBundle(read: (path: string) => Promise<Blob>): Promise<Bundle> {
+  const { files, documents, checksums } = await readVerifiedFiles(read, 'manifest.json');
   const manifest = documents.get('manifest.json') ?? null;
   if (
     at(manifest, 'schema_version') !== 1 ||

--- a/packages/app/src/components/video-benchmark/fidelity.fixture.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.fixture.ts
@@ -1,0 +1,254 @@
+import { at, entries, ROLES, rows, sha256, text, type Json } from './bundle';
+import { servingFixture } from './serving.fixture';
+import type { CIArtifact } from './archive';
+import type { StoredArtifact, StoredSource } from './stored';
+
+const object = (value: Json) => Object.fromEntries(entries(value));
+const asset = (id: string, path: string) => ({
+  url: `https://synthetic.public.blob.vercel-storage.com/${id}/${path}`,
+  downloadUrl: `https://synthetic.public.blob.vercel-storage.com/${id}/${path}?download=1`,
+});
+
+// Every byte is synthetic test data. The .mp4 bodies are deliberately not playable media.
+export async function fidelityFixture({ pairs = 2, failedPairs = 1 } = {}) {
+  const runId = '789';
+  const artifact: CIArtifact = {
+    id: 987,
+    name: `h3-fidelity-${runId}-1`,
+    expired: false,
+    size_in_bytes: 1,
+  };
+  const files = new Map<string, Blob>();
+  const originals: StoredArtifact[] = [];
+  const originalFiles = new Map<string, Map<string, Blob>>();
+  const sourceArtifacts: Json[] = [];
+  const roleResults: Record<string, Json> = {};
+  const observations: Record<string, Json[]> = {};
+  for (const [index, role] of ROLES.entries()) {
+    const id = String(101 + index);
+    const original = servingFixture(id, `Synthetic ${role} GPU`, pairs);
+    const sourceFiles = new Map<string, Blob>();
+    const sourceChecksums = new Map<string, string>();
+    const save = async (path: string, value: Json | Blob) => {
+      const blob = value instanceof Blob ? value : new Blob([JSON.stringify(value)]);
+      sourceFiles.set(path, blob);
+      const hash = await sha256(blob);
+      sourceChecksums.set(path, hash);
+      return hash;
+    };
+    const root = 'gpu/c1';
+    const requestRun = object(original.documents.get(`${root}/baseline/run.json`)!);
+    const records = rows(at(requestRun, 'records'));
+    for (const [n, record] of records.entries()) {
+      const path = `${root}/baseline/${text(at(record, 'artifact_path'))}`;
+      const blob = new Blob([`Synthetic non-playable ${role} clip ${n}; test fixture only`]);
+      const hash = await save(path, blob);
+      Object.assign(record!, { sha256: hash, prompt: `Synthetic test prompt ${n}`, seed: n });
+      if (at(record, 'phase') === 'measurement') files.set(`report/index_assets/${hash}.mp4`, blob);
+    }
+    const runHash = await save(`${root}/baseline/run.json`, requestRun);
+    const specHash = await save(`${root}/spec.json`, original.documents.get(`${root}/spec.json`)!);
+    const job = object(original.documents.get(`${root}/gpu-job.json`)!);
+    job.spec_sha256 = specHash;
+    Object.assign(at(job, 'roles', 'baseline')!, { run_sha256: runHash });
+    const jobHash = await save(`${root}/gpu-job.json`, job);
+    const powerHash = await save(
+      `${root}/power.json`,
+      original.documents.get(`${root}/power.json`)!,
+    );
+    const matrix = object(original.documents.get('serving-smoke.json')!);
+    const cell = object(rows(at(matrix, 'cells'))[0]);
+    Object.assign(at(cell, 'run')!, { sha256: runHash });
+    Object.assign(at(cell, 'receipt')!, { sha256: jobHash });
+    Object.assign(at(cell, 'power')!, { sha256: powerHash });
+    matrix.cells = [cell];
+    const matrixHash = await save('serving-smoke.json', matrix);
+    const manifest = {
+      ...object(original.manifest),
+      evidence: { 'serving-smoke.json': matrixHash },
+    };
+    const ci = { ...object(original.ci), site: { gpu_model: `Synthetic ${role} GPU` } };
+    await save('manifest.json', manifest);
+    await save('ci.json', ci);
+    const seal = new Blob([
+      [...sourceChecksums].map(([path, hash]) => `${hash}  ${path}`).join('\n'),
+    ]);
+    sourceFiles.set('SHA256SUMS', seal);
+    const sealHash = await sha256(seal);
+    const sourceArtifact = {
+      id: 201 + index,
+      name: `h3-video-${id}-1`,
+      expired: false,
+      size_in_bytes: 1,
+      digest: `sha256:${sealHash}`,
+      workflow_run: { id: Number(id), head_sha: at(manifest, 'git_commit') },
+    };
+    sourceArtifacts.push({
+      ci: {
+        databaseId: Number(id),
+        headSha: at(manifest, 'git_commit'),
+        runAttempt: 1,
+        status: 'completed',
+        conclusion: 'success',
+        url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}`,
+      },
+      artifact: sourceArtifact,
+      source_seal_sha256: sealHash,
+    });
+    for (const [sourcePath, target] of [
+      ['manifest.json', 'manifest.json'],
+      ['ci.json', 'ci.json'],
+      ['serving-smoke.json', 'serving-smoke.json'],
+      [`${root}/baseline/run.json`, 'c1-run.json'],
+      ['SHA256SUMS', 'original-SHA256SUMS'],
+    ])
+      files.set(`sources/${id}/${target}`, sourceFiles.get(sourcePath)!);
+    const sourceDocuments: [string, Json][] = [];
+    for (const [path, blob] of sourceFiles)
+      if (path.endsWith('.json')) sourceDocuments.push([path, JSON.parse(await blob.text())]);
+    originals.push({
+      storageVersion: 1,
+      runId: id,
+      artifact: sourceArtifact,
+      sources: [
+        {
+          id,
+          documents: sourceDocuments,
+          checksums: [...sourceChecksums],
+          assets: [...sourceFiles.keys()].map((path) => [path, asset(id, path)]),
+          texts: [],
+        },
+      ],
+    });
+    originalFiles.set(id, sourceFiles);
+    roleResults[role] = {
+      run_id: `synthetic-${role}`,
+      configuration: at(requestRun, 'configuration'),
+      run_bundle_sha256: runHash,
+      summary: at(requestRun, 'summary'),
+    };
+    observations[role] = records
+      .filter((record) => at(record, 'phase') === 'measurement')
+      .map((record) => {
+        const path = `/synthetic-runner/${id}/${text(at(record, 'artifact_path'))}`;
+        return {
+          status: 'succeeded',
+          attempted: true,
+          artifact_path: path,
+          sha256: at(record, 'sha256'),
+          latency_seconds: 120 - index * 10,
+          latency_boundary: 'submit_to_downloaded_media',
+          media: { ...object(at(record, 'media')), path, sha256: at(record, 'sha256') },
+        };
+      });
+  }
+  const comparison: Json = {
+    bundle_type: 'mvp_comparison',
+    bundle_version: '0.1.0',
+    producer: {
+      run_id: runId,
+      run_attempt: '1',
+      git_commit: 'd'.repeat(40),
+      run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${runId}`,
+      mode: 'Synthetic CPU comparison fixture; no generation',
+    },
+    source_artifacts: sourceArtifacts,
+    ...roleResults,
+    plan: { generation: { duration_seconds: 8, width: 1344, height: 768, fps: 24 } },
+    policy: { calibration_status: 'uncalibrated', min_video_psnr_db: 30 },
+    overall_status: failedPairs ? 'fail' : 'pass',
+    release_qualified: false,
+    release_qualification_reason: 'Synthetic fixture; not a benchmark or release qualification.',
+    measurement: { performance_mode: 'descriptive_only', boundary: 'submit_to_downloaded_media' },
+    limitations: ['Synthetic test data; media bytes are not playable.'],
+    summary: {
+      measurement_slots: pairs,
+      matched_valid_pairs: pairs,
+      passed_slots: pairs - failedPairs,
+      failed_slots: failedPairs,
+      inconclusive_slots: 0,
+    },
+    slots: Array.from({ length: pairs }, (_, index): Json => ({
+      slot_id: `measurement-r${String(index + 1).padStart(3, '0')}-c001`,
+      case_id: `synthetic-case-${index + 1}`,
+      prompt: `Synthetic test prompt ${index + 1}`,
+      seed: index + 1,
+      status: index < failedPairs ? 'fail' : 'pass',
+      baseline: observations.baseline[index],
+      candidate: observations.candidate[index],
+      metrics: {
+        video_psnr_db: index < failedPairs ? 27 : 35,
+        video_mae: 0.02,
+        audio_spectral_cosine: 0.96,
+        audio_rms_ratio: 1,
+        audio_waveform_mae: 0.03,
+        video_compared_frames: 192,
+        video_total_frames: 192,
+        video_sample_coverage_fraction: 1,
+        audio_sample_coverage_fraction: 1,
+        audio_compared_samples_per_channel: 256000,
+      },
+      checks: [
+        { name: 'baseline.media_validity', status: 'pass' },
+        { name: 'candidate.media_validity', status: 'pass' },
+        {
+          name: 'fidelity.video_psnr',
+          status: index < failedPairs ? 'fail' : 'pass',
+          observed: index < failedPairs ? 27 : 35,
+          threshold: 30,
+          unit: 'dB',
+        },
+      ],
+    })),
+  };
+  const portable = object(structuredClone(comparison));
+  portable.report = { html: 'index.html', portable_assets: 'index_assets', scripts: false };
+  for (const slot of rows(at(portable, 'slots')))
+    for (const role of ROLES) {
+      const observation = at(slot, role);
+      const path = `index_assets/${at(observation, 'sha256')}.mp4`;
+      Object.assign(observation!, { artifact_path: path, artifact_path_base: 'report_directory' });
+      Object.assign(at(observation, 'media')!, { path });
+    }
+  const firstMedia = text(at(portable, 'slots', 0, 'baseline', 'artifact_path'));
+  const html = `<h1>Synthetic report only</h1><video controls src="${firstMedia}"></video><a href="index.comparison.json" download>Raw portable comparison</a><script>document.body.dataset.scriptRan='yes'</script><img src="https://outside.example.test/tracker.png">`;
+  files.set('comparison.json', new Blob([JSON.stringify(comparison)]));
+  files.set('report/index.comparison.json', new Blob([JSON.stringify(portable)]));
+  files.set('report/index.html', new Blob([html]));
+  const checksums = new Map<string, string>();
+  const documents = new Map<string, Json>();
+  for (const [path, blob] of files) {
+    checksums.set(path, await sha256(blob));
+    if (path.endsWith('.json')) documents.set(path, JSON.parse(await blob.text()));
+  }
+  files.set(
+    'SHA256SUMS',
+    new Blob([[...checksums].map(([path, hash]) => `${hash}  ${path}`).join('\n')]),
+  );
+  const published: StoredSource = {
+    id: runId,
+    kind: 'fidelity',
+    documents: [...documents],
+    checksums: [...checksums],
+    assets: [...files.keys()].map((path) => [path, asset(runId, path)]),
+    texts: [['report/index.html', html]],
+  };
+  const read = (path: string) => {
+    const file = files.get(path);
+    if (!file) throw new Error(`Missing synthetic fixture file: ${path}`);
+    return Promise.resolve(file);
+  };
+  return {
+    runId,
+    artifact,
+    files,
+    read,
+    documents,
+    checksums,
+    published,
+    originals,
+    originalFiles,
+    comparison,
+    portable,
+  };
+}

--- a/packages/app/src/components/video-benchmark/fidelity.fixture.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.fixture.ts
@@ -81,7 +81,7 @@ export async function fidelityFixture({ pairs = 2, failedPairs = 1 } = {}) {
       expired: false,
       size_in_bytes: 1,
       digest: `sha256:${sealHash}`,
-      workflow_run: { id: Number(id), head_sha: at(manifest, 'git_commit') },
+      workflow_run: { id: Number(id), head_sha: text(at(manifest, 'git_commit')) },
     };
     sourceArtifacts.push({
       ci: {
@@ -225,13 +225,17 @@ export async function fidelityFixture({ pairs = 2, failedPairs = 1 } = {}) {
     'SHA256SUMS',
     new Blob([[...checksums].map(([path, hash]) => `${hash}  ${path}`).join('\n')]),
   );
+  const texts: StoredSource['texts'] = [['report/index.html', html]];
+  for (const [path, file] of files)
+    if (/^sources\/[1-9]\d*\/original-SHA256SUMS$/u.test(path))
+      texts.push([path, await file.text()]);
   const published: StoredSource = {
     id: runId,
     kind: 'fidelity',
     documents: [...documents],
     checksums: [...checksums],
     assets: [...files.keys()].map((path) => [path, asset(runId, path)]),
-    texts: [['report/index.html', html]],
+    texts,
   };
   const read = (path: string) => {
     const file = files.get(path);

--- a/packages/app/src/components/video-benchmark/fidelity.test.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
-import { at, type Json } from './bundle';
+import { at, sha256, text, type Json } from './bundle';
 import { fidelityEvidence, fidelitySource, loadFidelityBundle } from './fidelity';
 import { fidelityFixture } from './fidelity.fixture';
 import { storedBundle, storedFidelityBundle } from './stored';
@@ -15,6 +15,12 @@ const changed = () => ({
   documents: structuredClone(fixture.documents),
   checksums: new Map(fixture.checksums),
 });
+const verify = (
+  documents: Map<string, Json>,
+  checksums: Map<string, string>,
+  runId?: string,
+  seals = new Map(fixture.published.texts),
+) => fidelityEvidence(documents, checksums, runId, seals);
 const both = (documents: Map<string, Json>, mutate: (value: Json) => void) => {
   for (const path of ['comparison.json', 'report/index.comparison.json'])
     mutate(documents.get(path)!);
@@ -33,22 +39,20 @@ describe('native H3 fidelity evidence (synthetic fixtures)', () => {
       expect(servingCells(storedBundle(original.sources[0]))).toHaveLength(1);
   });
   it('rejects producer and original source identity substitutions', () => {
-    expect(() => fidelityEvidence(fixture.documents, fixture.checksums, '790')).toThrow(
-      'Unsupported',
-    );
+    expect(() => verify(fixture.documents, fixture.checksums, '790')).toThrow('Unsupported');
     const { documents, checksums } = changed();
     both(documents, (value) =>
       Object.assign(at(value, 'source_artifacts', 0, 'artifact', 'workflow_run')!, {
         head_sha: 'f'.repeat(40),
       }),
     );
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('source snapshots');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('source snapshots');
     const invalidProducer = changed();
     both(invalidProducer.documents, (value) =>
       Object.assign(at(value, 'producer')!, { run_url: 'https://untrusted.example.test/run' }),
     );
     expect(() =>
-      fidelityEvidence(invalidProducer.documents, invalidProducer.checksums, fixture.runId),
+      verify(invalidProducer.documents, invalidProducer.checksums, fixture.runId),
     ).toThrow('Unsupported');
   });
   it('rejects portable metric changes while allowing only documented media path rewrites', () => {
@@ -56,27 +60,73 @@ describe('native H3 fidelity evidence (synthetic fixtures)', () => {
     Object.assign(at(documents.get('report/index.comparison.json'), 'slots', 0, 'metrics')!, {
       video_psnr_db: 999,
     });
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('disagrees');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('disagrees');
   });
   it('rejects substituted media hashes and missing verified entry points', () => {
     const extra = changed();
     extra.checksums.set('report/index_assets/unreferenced.mp4', 'e'.repeat(64));
-    expect(() => fidelityEvidence(extra.documents, extra.checksums, fixture.runId)).toThrow(
-      'Unreferenced',
-    );
+    expect(() => verify(extra.documents, extra.checksums, fixture.runId)).toThrow('Unreferenced');
     const { documents, checksums } = changed();
     const path = `report/${at(documents.get('report/index.comparison.json'), 'slots', 0, 'baseline', 'artifact_path')}`;
     checksums.set(path, 'f'.repeat(64));
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('media identity');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('media identity');
     checksums.delete('report/index.html');
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('unverified');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('unverified');
   });
   it('rejects mismatched source seals and an empty comparison', () => {
     const { documents, checksums } = changed();
     checksums.set('sources/101/original-SHA256SUMS', 'f'.repeat(64));
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('source snapshots');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('source snapshots');
     both(documents, (value) => Object.assign(value!, { slots: [] }));
-    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('slots');
+    expect(() => verify(documents, checksums, fixture.runId)).toThrow('slots');
+  });
+  it('rejects copied hardware metadata changed and resealed only in the comparison artifact', async () => {
+    const files = new Map(fixture.files);
+    const { documents, checksums } = changed();
+    const path = 'sources/101/ci.json';
+    Object.assign(at(documents.get(path), 'site')!, { gpu_model: 'Substituted hardware' });
+    const altered = new Blob([JSON.stringify(documents.get(path))]);
+    files.set(path, altered);
+    checksums.set(path, await sha256(altered));
+    files.set(
+      'SHA256SUMS',
+      new Blob([[...checksums].map(([name, hash]) => `${hash}  ${name}`).join('\n')]),
+    );
+    await expect(
+      loadFidelityBundle((name) => Promise.resolve(files.get(name)!), fixture.runId),
+    ).rejects.toThrow('snapshot differs from original inventory: ci.json');
+    expect(() =>
+      storedFidelityBundle({
+        ...fixture.published,
+        documents: [...documents],
+        checksums: [...checksums],
+      }),
+    ).toThrow('snapshot differs from original inventory: ci.json');
+  });
+  it('binds all retained snapshot hashes and requires a well-formed original inventory', () => {
+    const sample = fixture;
+    for (const path of ['manifest.json', 'serving-smoke.json', 'c1-run.json']) {
+      const { documents, checksums } = changed();
+      checksums.set(`sources/101/${path}`, 'f'.repeat(64));
+      expect(() => verify(documents, checksums, sample.runId)).toThrow(
+        /source snapshots|original inventory/u,
+      );
+    }
+    expect(() => verify(sample.documents, sample.checksums, sample.runId, new Map())).toThrow(
+      'Missing original',
+    );
+    const sourcePath = 'sources/101/original-SHA256SUMS';
+    const original = new Map(sample.published.texts).get(sourcePath)!;
+    for (const invalid of [
+      'not a checksum',
+      `${original}\n${original.split('\n')[0]}`,
+      `${'f'.repeat(64)}  ../escape.json`,
+    ]) {
+      const seals = new Map<string, string>([...sample.published.texts, [sourcePath, invalid]]);
+      expect(() => verify(sample.documents, sample.checksums, sample.runId, seals)).toThrow(
+        /inventory|Unsafe artifact path/u,
+      );
+    }
   });
   it('checks actual bytes before rendering any evidence', async () => {
     await expect(
@@ -100,5 +150,18 @@ it.skipIf(!realDirectory)(
     expect(at(bundle.comparison, 'summary', 'matched_valid_pairs')).toBe(20);
     expect(fidelitySource(bundle, 'baseline')).not.toBeNull();
     expect(fidelitySource(bundle, 'candidate')).not.toBeNull();
+    const texts: [string, string][] = [];
+    for (const [path, file] of bundle.files)
+      if (path === 'report/index.html' || path.endsWith('/original-SHA256SUMS'))
+        texts.push([path, await file.text()]);
+    const stored = storedFidelityBundle({
+      id: text(at(bundle.comparison, 'producer', 'run_id')),
+      kind: 'fidelity',
+      documents: [...bundle.documents],
+      checksums: [...bundle.checksums],
+      assets: [],
+      texts,
+    });
+    expect(stored.comparisonSha256).toBe(bundle.comparisonSha256);
   },
 );

--- a/packages/app/src/components/video-benchmark/fidelity.test.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.test.ts
@@ -1,0 +1,104 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { at, type Json } from './bundle';
+import { fidelityEvidence, fidelitySource, loadFidelityBundle } from './fidelity';
+import { fidelityFixture } from './fidelity.fixture';
+import { storedBundle, storedFidelityBundle } from './stored';
+import { servingCells } from './serving';
+
+let fixture: Awaited<ReturnType<typeof fidelityFixture>>;
+beforeAll(async () => {
+  fixture = await fidelityFixture();
+});
+const changed = () => ({
+  documents: structuredClone(fixture.documents),
+  checksums: new Map(fixture.checksums),
+});
+const both = (documents: Map<string, Json>, mutate: (value: Json) => void) => {
+  for (const path of ['comparison.json', 'report/index.comparison.json'])
+    mutate(documents.get(path)!);
+};
+
+describe('native H3 fidelity evidence (synthetic fixtures)', () => {
+  it('loads the sealed native artifact and restores stored media references without a fake manifest', async () => {
+    const loaded = await loadFidelityBundle(fixture.read, fixture.runId);
+    expect(loaded.comparisonSha256).toBe(fixture.checksums.get('comparison.json'));
+    expect(at(loaded.comparison, 'summary', 'matched_valid_pairs')).toBe(2);
+    expect(loaded.documents.has('manifest.json')).toBe(false);
+    expect(storedFidelityBundle(fixture.published).comparison).toEqual(loaded.comparison);
+    expect(at(fidelitySource(loaded, 'baseline'), 'ci', 'databaseId')).toBe(101);
+    expect(at(fidelitySource(loaded, 'candidate'), 'ci', 'databaseId')).toBe(102);
+    for (const original of fixture.originals)
+      expect(servingCells(storedBundle(original.sources[0]))).toHaveLength(1);
+  });
+  it('rejects producer and original source identity substitutions', () => {
+    expect(() => fidelityEvidence(fixture.documents, fixture.checksums, '790')).toThrow(
+      'Unsupported',
+    );
+    const { documents, checksums } = changed();
+    both(documents, (value) =>
+      Object.assign(at(value, 'source_artifacts', 0, 'artifact', 'workflow_run')!, {
+        head_sha: 'f'.repeat(40),
+      }),
+    );
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('source snapshots');
+    const invalidProducer = changed();
+    both(invalidProducer.documents, (value) =>
+      Object.assign(at(value, 'producer')!, { run_url: 'https://untrusted.example.test/run' }),
+    );
+    expect(() =>
+      fidelityEvidence(invalidProducer.documents, invalidProducer.checksums, fixture.runId),
+    ).toThrow('Unsupported');
+  });
+  it('rejects portable metric changes while allowing only documented media path rewrites', () => {
+    const { documents, checksums } = changed();
+    Object.assign(at(documents.get('report/index.comparison.json'), 'slots', 0, 'metrics')!, {
+      video_psnr_db: 999,
+    });
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('disagrees');
+  });
+  it('rejects substituted media hashes and missing verified entry points', () => {
+    const extra = changed();
+    extra.checksums.set('report/index_assets/unreferenced.mp4', 'e'.repeat(64));
+    expect(() => fidelityEvidence(extra.documents, extra.checksums, fixture.runId)).toThrow(
+      'Unreferenced',
+    );
+    const { documents, checksums } = changed();
+    const path = `report/${at(documents.get('report/index.comparison.json'), 'slots', 0, 'baseline', 'artifact_path')}`;
+    checksums.set(path, 'f'.repeat(64));
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('media identity');
+    checksums.delete('report/index.html');
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('unverified');
+  });
+  it('rejects mismatched source seals and an empty comparison', () => {
+    const { documents, checksums } = changed();
+    checksums.set('sources/101/original-SHA256SUMS', 'f'.repeat(64));
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('source snapshots');
+    both(documents, (value) => Object.assign(value!, { slots: [] }));
+    expect(() => fidelityEvidence(documents, checksums, fixture.runId)).toThrow('slots');
+  });
+  it('checks actual bytes before rendering any evidence', async () => {
+    await expect(
+      loadFidelityBundle(
+        (path) =>
+          path === 'comparison.json' ? Promise.resolve(new Blob(['{}'])) : fixture.read(path),
+        fixture.runId,
+      ),
+    ).rejects.toThrow('SHA256 mismatch');
+  });
+});
+
+const realDirectory = process.env.H3_FIDELITY_ARTIFACT_DIR;
+it.skipIf(!realDirectory)(
+  'loads an explicitly supplied real compact artifact without copying it into fixtures',
+  async () => {
+    const bundle = await loadFidelityBundle(
+      async (path) => new Blob([await readFile(join(realDirectory!, path))]),
+    );
+    expect(at(bundle.comparison, 'bundle_type')).toBe('mvp_comparison');
+    expect(at(bundle.comparison, 'summary', 'matched_valid_pairs')).toBe(20);
+    expect(fidelitySource(bundle, 'baseline')).not.toBeNull();
+    expect(fidelitySource(bundle, 'candidate')).not.toBeNull();
+  },
+);

--- a/packages/app/src/components/video-benchmark/fidelity.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.ts
@@ -1,0 +1,157 @@
+import { at, number, readVerifiedFiles, ROLES, rows, safePath, text, type Json } from './bundle';
+
+export interface FidelityBundle {
+  comparison: Json;
+  portable: Json;
+  comparisonSha256: string;
+  documents: Map<string, Json>;
+  checksums: Map<string, string>;
+  files: Map<string, Blob>;
+}
+const hash = (value: Json) => /^[a-f0-9]{64}$/u.test(text(value));
+const canonical = (value: Json): string => {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  if (value !== null && typeof value === 'object')
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(',')}}`;
+  return JSON.stringify(value);
+};
+
+export function fidelityEvidence(
+  documents: Map<string, Json>,
+  checksums: Map<string, string>,
+  runId?: string,
+) {
+  const comparison = documents.get('comparison.json') ?? null;
+  const portable = documents.get('report/index.comparison.json') ?? null;
+  const producer = at(comparison, 'producer');
+  const id = text(at(producer, 'run_id'));
+  if (
+    at(comparison, 'bundle_type') !== 'mvp_comparison' ||
+    at(comparison, 'bundle_version') !== '0.1.0' ||
+    !/^[1-9]\d*$/u.test(id) ||
+    (runId !== undefined && runId !== id) ||
+    !/^[1-9]\d*$/u.test(text(at(producer, 'run_attempt'))) ||
+    !/^[a-f0-9]{40}$/u.test(text(at(producer, 'git_commit'))) ||
+    at(producer, 'run_url') !== `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${id}` ||
+    !['comparison.json', 'report/index.comparison.json', 'report/index.html'].every((path) =>
+      checksums.has(path),
+    ) ||
+    !portable ||
+    typeof portable !== 'object' ||
+    Array.isArray(portable)
+  )
+    throw new Error('Unsupported or unverified H3 fidelity artifact');
+  const normalized = structuredClone(portable);
+  delete normalized.report;
+  const originalSlots = rows(at(comparison, 'slots'));
+  const slots = rows(at(normalized, 'slots'));
+  const mediaPaths = new Set<string>();
+  if (
+    slots.length === 0 ||
+    slots.length !== originalSlots.length ||
+    new Set(slots.map((slot) => text(at(slot, 'slot_id')))).size !== slots.length
+  )
+    throw new Error('Missing or inconsistent fidelity slots');
+  for (let index = 0; index < slots.length; index++) {
+    for (const role of ROLES) {
+      const observation = at(slots[index], role);
+      const original = at(originalSlots[index], role);
+      if (observation === null || typeof observation !== 'object' || Array.isArray(observation))
+        throw new Error('Missing fidelity observation');
+      const media = at(observation, 'media');
+      const path = text(at(observation, 'artifact_path'));
+      if (path) {
+        const sha = at(observation, 'sha256');
+        if (
+          !hash(sha) ||
+          path !== `index_assets/${sha}.mp4` ||
+          at(observation, 'artifact_path_base') !== 'report_directory' ||
+          at(media, 'path') !== path ||
+          at(media, 'sha256') !== sha ||
+          at(original, 'sha256') !== sha ||
+          checksums.get(`report/${safePath(path)}`) !== sha
+        )
+          throw new Error('Fidelity media identity mismatch');
+        mediaPaths.add(`report/${path}`);
+        observation.artifact_path = at(original, 'artifact_path');
+        delete observation.artifact_path_base;
+        if (media !== null && typeof media === 'object' && !Array.isArray(media))
+          media.path = at(original, 'media', 'path');
+      }
+    }
+  }
+  if ([...checksums.keys()].some((path) => path.endsWith('.mp4') && !mediaPaths.has(path)))
+    throw new Error('Unreferenced fidelity media');
+  if (canonical(normalized) !== canonical(comparison))
+    throw new Error('Portable report disagrees with the original comparison');
+  for (const role of ROLES)
+    if (!hash(at(comparison, role, 'run_bundle_sha256')))
+      throw new Error('Missing original role identity');
+  const sources = rows(at(comparison, 'source_artifacts'));
+  if (
+    sources.length !== 2 ||
+    new Set(sources.map((source) => at(source, 'ci', 'databaseId'))).size !== 2
+  )
+    throw new Error('Missing original CI sources');
+  const matchedRoles = new Set<string>();
+  for (const source of sources) {
+    const sourceId = number(at(source, 'ci', 'databaseId'));
+    const attempt = number(at(source, 'ci', 'runAttempt'));
+    const revision = text(at(source, 'ci', 'headSha'));
+    const prefix = `sources/${sourceId}/`;
+    const manifest = documents.get(`${prefix}manifest.json`);
+    const ci = documents.get(`${prefix}ci.json`);
+    const role = ROLES.find(
+      (candidateRole) =>
+        at(comparison, candidateRole, 'run_bundle_sha256') ===
+        checksums.get(`${prefix}c1-run.json`),
+    );
+    if (
+      !Number.isSafeInteger(sourceId) ||
+      !sourceId ||
+      !Number.isSafeInteger(attempt) ||
+      !attempt ||
+      !/^[a-f0-9]{40}$/u.test(revision) ||
+      at(source, 'ci', 'url') !==
+        `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${sourceId}` ||
+      at(source, 'artifact', 'name') !== `h3-video-${sourceId}-${attempt}` ||
+      at(source, 'artifact', 'workflow_run', 'id') !== sourceId ||
+      at(source, 'artifact', 'workflow_run', 'head_sha') !== revision ||
+      !Number.isSafeInteger(number(at(source, 'artifact', 'id'))) ||
+      (number(at(source, 'artifact', 'id')) ?? 0) <= 0 ||
+      !/^sha256:[a-f0-9]{64}$/u.test(text(at(source, 'artifact', 'digest'))) ||
+      !hash(at(source, 'source_seal_sha256')) ||
+      checksums.get(`${prefix}original-SHA256SUMS`) !== at(source, 'source_seal_sha256') ||
+      at(manifest, 'run_id') !== String(sourceId) ||
+      at(manifest, 'git_commit') !== revision ||
+      at(ci, 'run_id') !== String(sourceId) ||
+      at(ci, 'source_sha') !== revision ||
+      !role ||
+      matchedRoles.has(role)
+    )
+      throw new Error('Fidelity source snapshots do not match original CI identities');
+    matchedRoles.add(role);
+  }
+  return { comparison, portable, comparisonSha256: checksums.get('comparison.json')! };
+}
+
+export function fidelitySource(bundle: FidelityBundle, role: (typeof ROLES)[number]) {
+  return (
+    rows(at(bundle.comparison, 'source_artifacts')).find(
+      (source) =>
+        bundle.checksums.get(`sources/${at(source, 'ci', 'databaseId')}/c1-run.json`) ===
+        at(bundle.comparison, role, 'run_bundle_sha256'),
+    ) ?? null
+  );
+}
+
+export async function loadFidelityBundle(
+  read: (path: string) => Promise<Blob>,
+  runId?: string,
+): Promise<FidelityBundle> {
+  const data = await readVerifiedFiles(read, 'comparison.json');
+  return { ...data, ...fidelityEvidence(data.documents, data.checksums, runId) };
+}

--- a/packages/app/src/components/video-benchmark/fidelity.ts
+++ b/packages/app/src/components/video-benchmark/fidelity.ts
@@ -23,6 +23,7 @@ export function fidelityEvidence(
   documents: Map<string, Json>,
   checksums: Map<string, string>,
   runId?: string,
+  originalSeals = new Map<string, string>(),
 ) {
   const comparison = documents.get('comparison.json') ?? null;
   const portable = documents.get('report/index.comparison.json') ?? null;
@@ -133,6 +134,25 @@ export function fidelityEvidence(
       matchedRoles.has(role)
     )
       throw new Error('Fidelity source snapshots do not match original CI identities');
+    const seal = originalSeals.get(`${prefix}original-SHA256SUMS`);
+    if (!seal) throw new Error('Missing original fidelity checksum inventory');
+    const originalHashes = new Map<string, string>();
+    for (const line of seal.trim().split('\n')) {
+      const match = /^(?<hash>[a-f0-9]{64})  (?<path>.+)$/u.exec(line);
+      if (!match || originalHashes.has(match.groups!.path))
+        throw new Error('Malformed or duplicate original fidelity checksum inventory');
+      originalHashes.set(safePath(match.groups!.path), match.groups!.hash);
+    }
+    for (const [snapshot, originalPath] of [
+      ['manifest.json', 'manifest.json'],
+      ['ci.json', 'ci.json'],
+      ['serving-smoke.json', 'serving-smoke.json'],
+      ['c1-run.json', 'gpu/c1/baseline/run.json'],
+    ]) {
+      const expected = originalHashes.get(originalPath);
+      if (!expected || checksums.get(`${prefix}${snapshot}`) !== expected)
+        throw new Error(`Fidelity source snapshot differs from original inventory: ${snapshot}`);
+    }
     matchedRoles.add(role);
   }
   return { comparison, portable, comparisonSha256: checksums.get('comparison.json')! };
@@ -153,5 +173,9 @@ export async function loadFidelityBundle(
   runId?: string,
 ): Promise<FidelityBundle> {
   const data = await readVerifiedFiles(read, 'comparison.json');
-  return { ...data, ...fidelityEvidence(data.documents, data.checksums, runId) };
+  const originalSeals = new Map<string, string>();
+  for (const [path, file] of data.files)
+    if (/^sources\/[1-9]\d*\/original-SHA256SUMS$/u.test(path))
+      originalSeals.set(path, await file.text());
+  return { ...data, ...fidelityEvidence(data.documents, data.checksums, runId, originalSeals) };
 }

--- a/packages/app/src/components/video-benchmark/server-timing.test.ts
+++ b/packages/app/src/components/video-benchmark/server-timing.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import {
+  observedIntegers,
+  requestServerTiming,
+  serverTimingSummary,
+  timingDistribution,
+} from './server-timing';
+
+// Synthetic timing records test the contract; no server timing was measured here.
+const distribution = {
+  values: [0, 1, 2, 3],
+  sample_count: 4,
+  valid_clip_count: 4,
+  missing_count: 0,
+  p50: 1.5,
+  p90: 3,
+  p95: 3,
+};
+const timing = {
+  schema_version: '1.0.0',
+  status: 'complete',
+  request_id: 'request-1',
+  instance_id: 'launch-1',
+  clock_id: 'linux:synthetic:time:1',
+  clock: 'time.monotonic_ns; same Linux boot and time namespace; nanoseconds',
+  observed_batch_size: 1,
+  replica_id: 0,
+  server_ready_latency_seconds: 4,
+  prequeue_seconds: 1,
+  queue_delay_seconds: 0,
+  execution_seconds: 2,
+  postprocess_seconds: 1,
+};
+
+describe('server timing contract', () => {
+  it('retains complete coverage and zero durations while applying percentile sample floors', () => {
+    expect(timingDistribution(distribution, 4)).toEqual({
+      samples: 4,
+      valid: 4,
+      missing: 0,
+      p50: 1.5,
+      p90: null,
+      p95: null,
+    });
+    const full = {
+      ...distribution,
+      values: Array.from({ length: 20 }, () => 1),
+      sample_count: 20,
+      valid_clip_count: 20,
+      p50: 1,
+      p90: 1,
+      p95: 1,
+    };
+    expect(timingDistribution(full, 20)).toMatchObject({ p50: 1, p90: 1, p95: 1 });
+  });
+  it('retains partial counts but withholds all percentiles, even if supplied', () => {
+    expect(
+      timingDistribution({ ...distribution, values: [0, 1], sample_count: 2, missing_count: 2 }, 4),
+    ).toEqual({ samples: 2, valid: 4, missing: 2, p50: null, p90: null, p95: null });
+  });
+  it('rejects malformed coverage and unavailable historical fields', () => {
+    for (const value of [
+      null,
+      { ...distribution, missing_count: 1 },
+      { ...distribution, sample_count: 4.5 },
+      { ...distribution, values: [0, -1, 2, 3] },
+    ])
+      expect(timingDistribution(value, 4)).toBeNull();
+    expect(timingDistribution(distribution, 5)).toBeNull();
+    expect(
+      serverTimingSummary(
+        { serving: { queue_delay_seconds: distribution }, summary: { valid: 4 } },
+        false,
+      ).stages.every((stage) => stage === null),
+    ).toBe(true);
+  });
+  it('reads repeated observed batches without treating concurrency as a batch size', () => {
+    expect(observedIntegers([1, 1, 1, 1], 1)).toEqual([1]);
+    expect(observedIntegers([0], 0)).toEqual([0]);
+    expect(observedIntegers([1, 1.5], 1)).toBeNull();
+    expect(serverTimingSummary({ serving: { concurrency: 4 } }, true).batchSizes).toBeNull();
+  });
+  it('requires verified request-correlated timing and preserves partial per-request stages', () => {
+    const record = { job_id: 'request-1', server_timings: timing };
+    expect(requestServerTiming(record, true)).toMatchObject({
+      stages: [4, 1, 0, 2, 1],
+      batchSize: 1,
+      replicaId: 0,
+    });
+    expect(requestServerTiming({ ...record, job_id: 'other' }, true)).toBeNull();
+    expect(requestServerTiming(record, false)).toBeNull();
+    for (const status of ['invalid', 'unknown'])
+      expect(
+        requestServerTiming({ ...record, server_timings: { ...timing, status } }, true),
+      ).toBeNull();
+    expect(
+      requestServerTiming(
+        { ...record, server_timings: { ...timing, status: 'partial', execution_seconds: null } },
+        true,
+      )?.stages,
+    ).toEqual([4, 1, 0, null, 1]);
+    expect(
+      requestServerTiming({ ...record, server_timings: { ...timing, clock_id: '' } }, true),
+    ).toBeNull();
+    expect(
+      requestServerTiming(
+        { ...record, server_timings: { ...timing, execution_seconds: null } },
+        true,
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/app/src/components/video-benchmark/server-timing.ts
+++ b/packages/app/src/components/video-benchmark/server-timing.ts
@@ -1,0 +1,129 @@
+import { at, number, text, type Json } from './bundle';
+
+export const SERVER_STAGES = [
+  ['server_ready_latency_seconds', 'server_ready_latency_seconds'],
+  ['server_prequeue_seconds', 'prequeue_seconds'],
+  ['queue_delay_seconds', 'queue_delay_seconds'],
+  ['server_execution_seconds', 'execution_seconds'],
+  ['server_postprocess_seconds', 'postprocess_seconds'],
+] as const;
+
+export const SERVER_TIMING_COPY = {
+  en: {
+    title: 'Server timing',
+    stages: [
+      'Received → media ready',
+      'Before queue admission',
+      'Queue delay',
+      'Execution',
+      'Postprocessing',
+    ],
+    coverage: 'Samples / valid clips / missing',
+    batch: 'Observed batch sizes',
+    replicas: 'Observed replica IDs',
+    note: 'Seconds on the server’s monotonic clock, separate from client delivery latency. Percentiles require timing coverage for every valid measured clip; warmup is excluded. P90 requires 10 samples and P95 requires 20.',
+    clock:
+      'Server stages use time.monotonic_ns within the same Linux boot and time namespace. They exclude client transfer and validation; execution includes server work, not just GPU kernels.',
+    status: 'Timing status',
+    complete: 'Complete',
+    partial: 'Partial',
+    unavailable: 'Unavailable',
+    identity: 'Request / instance / clock identity',
+    layoutNote:
+      'Observed batch sizes and replica IDs come from server records. Client concurrency does not establish batching or replica layout.',
+  },
+  zh: {
+    title: '服务端计时',
+    stages: ['接收请求 → 媒体就绪', '入队前耗时', '排队时长', '执行时长', '后处理时长'],
+    coverage: '计时样本 / 有效视频 / 缺失样本',
+    batch: '观测到的 batch size',
+    replicas: '观测到的副本 ID',
+    note: '单位为秒，使用服务端单调时钟，与客户端交付延迟分开统计。只有正式测量阶段的全部有效视频都有计时数据时才显示分位数；warmup 不计入。P90 至少需要 10 个样本，P95 至少需要 20 个。',
+    clock:
+      '服务端各阶段使用同一次 Linux 启动、同一时间命名空间内的 time.monotonic_ns 计时，不含客户端传输与校验；执行时长包含服务端工作，不仅是 GPU kernel 时间。',
+    status: '计时状态',
+    complete: '完整',
+    partial: '部分可用',
+    unavailable: '无数据',
+    identity: '请求 / 实例 / 时钟标识',
+    layoutNote:
+      '观测到的 batch size 和副本 ID 来自服务端记录，不能用客户端并发数推断 batch size 或副本布局。',
+  },
+};
+
+const nonnegative = (value: Json) => {
+  const n = number(value);
+  return n !== null && n >= 0 ? n : null;
+};
+const count = (value: Json) => {
+  const n = nonnegative(value);
+  return n !== null && Number.isSafeInteger(n) ? n : null;
+};
+
+export function timingDistribution(value: Json, validClips: Json) {
+  const samples = count(at(value, 'sample_count'));
+  const valid = count(at(value, 'valid_clip_count'));
+  const missing = count(at(value, 'missing_count'));
+  const values = at(value, 'values');
+  if (
+    samples === null ||
+    valid === null ||
+    missing === null ||
+    valid !== validClips ||
+    samples + missing !== valid ||
+    !Array.isArray(values) ||
+    values.length !== samples ||
+    values.some((v) => nonnegative(v) === null)
+  )
+    return null;
+  const complete = valid > 0 && missing === 0;
+  return {
+    samples,
+    valid,
+    missing,
+    p50: complete ? nonnegative(at(value, 'p50')) : null,
+    p90: complete && samples >= 10 ? nonnegative(at(value, 'p90')) : null,
+    p95: complete && samples >= 20 ? nonnegative(at(value, 'p95')) : null,
+  };
+}
+
+export function observedIntegers(value: Json, minimum: number): number[] | null {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const values = value.map(count);
+  return values.every((n): n is number => n !== null && n >= minimum) ? [...new Set(values)] : null;
+}
+
+export function serverTimingSummary(run: Json, verified: boolean) {
+  const serving = verified ? at(run, 'serving') : null;
+  return {
+    stages: SERVER_STAGES.map(([key]) =>
+      timingDistribution(at(serving, key), at(run, 'summary', 'valid')),
+    ),
+    batchSizes: observedIntegers(at(serving, 'observed_batch_sizes'), 1),
+    replicaIds: observedIntegers(at(serving, 'observed_replica_ids'), 0),
+  };
+}
+
+export function requestServerTiming(record: Json, verified: boolean) {
+  const timing = at(record, 'server_timings');
+  if (
+    !verified ||
+    at(timing, 'schema_version') !== '1.0.0' ||
+    at(timing, 'request_id') !== at(record, 'job_id') ||
+    !['complete', 'partial'].includes(text(at(timing, 'status'))) ||
+    !['request_id', 'instance_id', 'clock_id'].every((key) => text(at(timing, key))) ||
+    at(timing, 'clock') !== 'time.monotonic_ns; same Linux boot and time namespace; nanoseconds'
+  )
+    return null;
+  const stages = SERVER_STAGES.map(([, key]) => nonnegative(at(timing, key)));
+  if (at(timing, 'status') === 'complete' && stages.some((value) => value === null)) return null;
+  return {
+    status: text(at(timing, 'status')),
+    stages,
+    batchSize: observedIntegers([at(timing, 'observed_batch_size')], 1)?.[0] ?? null,
+    replicaId: observedIntegers([at(timing, 'replica_id')], 0)?.[0] ?? null,
+    identity: ['request_id', 'instance_id', 'clock_id']
+      .map((key) => text(at(timing, key)))
+      .join(' / '),
+  };
+}

--- a/packages/app/src/components/video-benchmark/stored.ts
+++ b/packages/app/src/components/video-benchmark/stored.ts
@@ -15,7 +15,7 @@ export function storedFidelityBundle(source: StoredSource): FidelityBundle {
   const documents = new Map(source.documents);
   const checksums = new Map(source.checksums);
   return {
-    ...fidelityEvidence(documents, checksums, source.id),
+    ...fidelityEvidence(documents, checksums, source.id, new Map(source.texts)),
     documents,
     checksums,
     files: new Map(source.texts.map(([path, value]) => [path, new Blob([value])])),

--- a/packages/app/src/components/video-benchmark/stored.ts
+++ b/packages/app/src/components/video-benchmark/stored.ts
@@ -1,12 +1,25 @@
 import { at, type Bundle, type Json } from './bundle';
 import type { CIArtifact } from './archive';
+import { fidelityEvidence, type FidelityBundle } from './fidelity';
 
 export interface StoredSource {
   id: string;
+  kind?: 'fidelity';
   documents: [string, Json][];
   checksums: [string, string][];
   assets: [string, { url: string; downloadUrl: string }][];
   texts: [string, string][];
+}
+export function storedFidelityBundle(source: StoredSource): FidelityBundle {
+  if (source.kind !== 'fidelity') throw new Error('Not a fidelity source');
+  const documents = new Map(source.documents);
+  const checksums = new Map(source.checksums);
+  return {
+    ...fidelityEvidence(documents, checksums, source.id),
+    documents,
+    checksums,
+    files: new Map(source.texts.map(([path, value]) => [path, new Blob([value])])),
+  };
 }
 export interface StoredArtifact {
   storageVersion: 1;

--- a/packages/app/src/components/video-benchmark/tradeoff.ts
+++ b/packages/app/src/components/video-benchmark/tradeoff.ts
@@ -2,6 +2,7 @@ import { at, entries, number, ROLES, rows, text, type Bundle, type Json } from '
 import { servingCells } from './serving';
 import { allocatedGpus } from './allocation';
 import { powerLimitComparison } from './power-limit';
+import { serverTimingSummary } from './server-timing';
 
 export interface TradeoffRun {
   bundle: Pick<Bundle, 'manifest' | 'result' | 'manifestSha256'> &
@@ -155,6 +156,7 @@ function pairedTradeoffPoints(run: TradeoffRun) {
       participating: positive(at(result, 'hardware', 'selected_gpu_count')),
       energy,
       powerLimit,
+      timing: serverTimingSummary(null, false),
       power: at(phase, 'valid') === true ? number(at(phase, 'aggregate', 'avg_power_w')) : null,
       powerWindow: at(phase, 'valid') === true ? number(at(phase, 'duration_seconds')) : null,
       server: at(result, 'workload', 'server'),
@@ -244,6 +246,7 @@ function servingTradeoffPoints(run: TradeoffRun) {
           )
         : null,
       server,
+      timing: serverTimingSummary(item.run, complete),
       fidelity: null,
       policy: at(item.spec, 'policy'),
     };

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
       zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
     },
-    sourceSha256: '73966329a42f1e3a62ca3c6215cc5e9786d9217d2d47ee512e9a81270b2ba17c',
+    sourceSha256: '33a7dec3e6d9077fe23493ed472a4ea7753254f742d676f184fd1bf41ff6b645',
   },
   {
     source: 'src/app/api/unofficial-run/route.ts',

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -5,6 +5,7 @@ import { head, put } from '@vercel/blob';
 import type * as BlobSdk from '@vercel/blob';
 import { readStoredArtifact, storeVideoArtifact } from './video-storage';
 import { storedBundle } from '@/components/video-benchmark/stored';
+import { fidelityFixture } from '@/components/video-benchmark/fidelity.fixture';
 
 vi.mock('@vercel/blob', async (original) => ({
   ...(await original<typeof BlobSdk>()),
@@ -59,6 +60,89 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 describe('persistent H3 media', () => {
+  it('publishes native fidelity metadata while reusing already published original videos', async () => {
+    vi.stubEnv('BLOB_READ_WRITE_TOKEN', 'synthetic-test-token');
+    const fixture = await fidelityFixture();
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = String(input);
+      const original = fixture.originals.find((item) => url.includes(`/runs/${item.runId}/`));
+      if (original) return Promise.resolve(Response.json(original));
+      for (const [id, files] of fixture.originalFiles)
+        if (url.endsWith(`/${id}/SHA256SUMS`))
+          return Promise.resolve(new Response(files.get('SHA256SUMS')));
+      throw new Error(`Unexpected synthetic URL: ${url}`);
+    });
+    const zip = new Blob([
+      zipSync(
+        Object.fromEntries(
+          await Promise.all(
+            [...fixture.files].map(async ([path, blob]) => [
+              path,
+              new Uint8Array(await blob.arrayBuffer()),
+            ]),
+          ),
+        ),
+      ).buffer,
+    ]);
+    const result = await storeVideoArtifact(
+      fixture.runId,
+      fixture.artifact,
+      zip,
+      new AbortController().signal,
+    );
+    expect(result.sources[0].kind).toBe('fidelity');
+    expect(result.sources[0].assets.filter(([path]) => path.endsWith('.mp4'))).toHaveLength(4);
+    expect(result.sources[0].assets.find(([path]) => path.endsWith('.mp4'))?.[1].url).toContain(
+      '/101/gpu/c1/baseline/artifacts/',
+    );
+    expect(vi.mocked(put).mock.calls.some((call) => call[2]?.contentType === 'video/mp4')).toBe(
+      false,
+    );
+    expect(vi.mocked(put).mock.calls.at(-1)?.[0]).toBe(
+      'h3-video-media/v1/runs/789/h3-fidelity-789-1_987.json',
+    );
+  });
+
+  it.each(['missing', 'digest', 'seal', 'media'])(
+    'does not publish fidelity with an unaccepted original source: %s',
+    async (failure) => {
+      vi.stubEnv('BLOB_READ_WRITE_TOKEN', 'synthetic-test-token');
+      const fixture = await fidelityFixture();
+      if (failure === 'missing') fixture.originals[0].sources = [];
+      if (failure === 'digest') fixture.originals[0].artifact.digest = `sha256:${'0'.repeat(64)}`;
+      if (failure === 'media')
+        fixture.originals[0].sources[0].assets = fixture.originals[0].sources[0].assets.filter(
+          ([path]) => !path.endsWith('.mp4'),
+        );
+      vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+        const url = String(input);
+        const original = fixture.originals.find((item) => url.includes(`/runs/${item.runId}/`));
+        if (original) return Promise.resolve(Response.json(original));
+        for (const [id, files] of fixture.originalFiles)
+          if (url.endsWith(`/${id}/SHA256SUMS`))
+            return Promise.resolve(
+              new Response(failure === 'seal' ? 'Changed source seal' : files.get('SHA256SUMS')),
+            );
+        throw new Error(`Unexpected synthetic URL: ${url}`);
+      });
+      const zip = new Blob([
+        zipSync(
+          Object.fromEntries(
+            await Promise.all(
+              [...fixture.files].map(async ([path, blob]) => [
+                path,
+                new Uint8Array(await blob.arrayBuffer()),
+              ]),
+            ),
+          ),
+        ).buffer,
+      ]);
+      await expect(
+        storeVideoArtifact(fixture.runId, fixture.artifact, zip, new AbortController().signal),
+      ).rejects.toThrow();
+      expect(put).not.toHaveBeenCalled();
+    },
+  );
   it('reads the trusted listed index URL without a redundant HEAD request', async () => {
     vi.stubEnv('BLOB_READ_WRITE_TOKEN', 'synthetic-test-token');
     const indexUrl =

--- a/packages/app/src/lib/video-storage.test.ts
+++ b/packages/app/src/lib/video-storage.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { head, put } from '@vercel/blob';
 import type * as BlobSdk from '@vercel/blob';
 import { readStoredArtifact, storeVideoArtifact } from './video-storage';
-import { storedBundle } from '@/components/video-benchmark/stored';
+import { storedBundle, storedFidelityBundle } from '@/components/video-benchmark/stored';
 import { fidelityFixture } from '@/components/video-benchmark/fidelity.fixture';
 
 vi.mock('@vercel/blob', async (original) => ({
@@ -91,6 +91,11 @@ describe('persistent H3 media', () => {
       new AbortController().signal,
     );
     expect(result.sources[0].kind).toBe('fidelity');
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json(result));
+    const saved = await readStoredArtifact(fixture.runId, fixture.artifact);
+    expect(storedFidelityBundle(saved!.sources[0]).comparisonSha256).toBe(
+      fixture.checksums.get('comparison.json'),
+    );
     expect(result.sources[0].assets.filter(([path]) => path.endsWith('.mp4'))).toHaveLength(4);
     expect(result.sources[0].assets.find(([path]) => path.endsWith('.mp4'))?.[1].url).toContain(
       '/101/gpu/c1/baseline/artifacts/',

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -21,6 +21,7 @@ import { servingCells } from '@/components/video-benchmark/serving';
 const PREFIX = 'h3-video-media/v1';
 export const videoStorageEnabled = () => Boolean(process.env.BLOB_READ_WRITE_TOKEN);
 const runPrefix = (runId: string) => `${PREFIX}/runs/${runId}/`;
+const sourceSeal = (path: string) => /^sources\/[1-9]\d*\/original-SHA256SUMS$/u.test(path);
 const legacyTelemetry = (path: string) =>
   /^gpu\/supervisor\/(?:baseline|candidate)\/telemetry\.jsonl$/u.test(path);
 
@@ -134,7 +135,7 @@ export async function readStoredArtifact(
     // indexes embedded their full logs; keep those in downloadable assets only.
     for (const source of result.sources)
       source.texts = source.texts.filter(
-        ([path]) => path === 'report/index.html' || legacyTelemetry(path),
+        ([path]) => path === 'report/index.html' || legacyTelemetry(path) || sourceSeal(path),
       );
     return result;
   } catch (error) {
@@ -213,6 +214,7 @@ export async function storeVideoArtifact(
     for (const [path, body] of bundle.files) {
       if (
         path === 'report/index.html' ||
+        (fidelity && sourceSeal(path)) ||
         (!('result' in bundle && bundle.result) && legacyTelemetry(path))
       )
         texts.push([path, await body.text()]);

--- a/packages/app/src/lib/video-storage.ts
+++ b/packages/app/src/lib/video-storage.ts
@@ -1,7 +1,21 @@
 import { head, list, put, BlobNotFoundError } from '@vercel/blob';
 import { archiveSources, type CIArtifact } from '@/components/video-benchmark/archive';
-import { loadBundle, sha256 } from '@/components/video-benchmark/bundle';
-import type { StoredArtifact, StoredSource } from '@/components/video-benchmark/stored';
+import {
+  at,
+  loadBundle,
+  number,
+  ROLES,
+  rows,
+  sha256,
+  text,
+} from '@/components/video-benchmark/bundle';
+import { loadFidelityBundle, type FidelityBundle } from '@/components/video-benchmark/fidelity';
+import {
+  storedBundle,
+  type StoredArtifact,
+  type StoredSource,
+} from '@/components/video-benchmark/stored';
+import { servingCells } from '@/components/video-benchmark/serving';
 
 // Media must survive the dashboard cache's prefix-wide purge.
 const PREFIX = 'h3-video-media/v1';
@@ -17,7 +31,7 @@ export async function storedArtifacts(runId: string): Promise<CIArtifact[]> {
   do {
     const page = await list({ prefix: runPrefix(runId), cursor });
     for (const blob of page.blobs) {
-      const match = /\/(?<name>h3-(?:results|video)-\d+-\d+)_(?<id>\d+)\.json$/u.exec(
+      const match = /\/(?<name>h3-(?:results|video|fidelity)-\d+-\d+)_(?<id>\d+)\.json$/u.exec(
         blob.pathname,
       );
       if (match?.groups)
@@ -33,6 +47,72 @@ export async function storedArtifacts(runId: string): Promise<CIArtifact[]> {
     cursor = page.hasMore ? page.cursor : undefined;
   } while (cursor);
   return result;
+}
+
+async function verifyPublishedSources(bundle: FidelityBundle, signal: AbortSignal) {
+  const comparison = bundle.comparison;
+  const roles = new Set<string>();
+  const media = new Map<string, StoredSource['assets'][number][1]>();
+  for (const reference of rows(at(comparison, 'source_artifacts'))) {
+    const id = number(at(reference, 'ci', 'databaseId'));
+    const artifactId = number(at(reference, 'artifact', 'id'));
+    const name = text(at(reference, 'artifact', 'name'));
+    if (
+      !Number.isSafeInteger(id) ||
+      !id ||
+      !Number.isSafeInteger(artifactId) ||
+      !artifactId ||
+      !new RegExp(`^h3-video-${id}-[1-9]\\d*$`, 'u').test(name)
+    )
+      throw new Error('Invalid original fidelity artifact');
+    const saved = await readStoredArtifact(String(id), {
+      id: artifactId,
+      name,
+      expired: false,
+      size_in_bytes: 0,
+    });
+    const source = saved?.sources.find((item) => item.id === String(id) && !item.kind);
+    if (!source || saved?.artifact.digest !== at(reference, 'artifact', 'digest'))
+      throw new Error('Fidelity media requires an already published original source');
+    const original = storedBundle(source);
+    servingCells(original);
+    const revision = at(original.manifest, 'git_commit');
+    if (
+      revision !== at(reference, 'ci', 'headSha') ||
+      revision !== at(reference, 'artifact', 'workflow_run', 'head_sha') ||
+      at(reference, 'artifact', 'workflow_run', 'id') !== id
+    )
+      throw new Error('Fidelity original source revision mismatch');
+    const sealUrl = source.assets.find(([path]) => path === 'SHA256SUMS')?.[1].url;
+    if (!sealUrl) throw new Error('Original source seal unavailable');
+    const seal = await fetch(sealUrl, { signal });
+    if (!seal.ok || (await sha256(await seal.blob())) !== at(reference, 'source_seal_sha256'))
+      throw new Error('Fidelity original source seal mismatch');
+    const role = ROLES.find(
+      (candidateRole) =>
+        at(comparison, candidateRole, 'run_bundle_sha256') ===
+        original.checksums.get('gpu/c1/baseline/run.json'),
+    );
+    if (!role || roles.has(role))
+      throw new Error('Fidelity roles do not match the original C1 runs');
+    roles.add(role);
+    const hashes = new Set<string>();
+    for (const [path, hash] of original.checksums) {
+      if (!/^gpu\/c1\/baseline\/artifacts\/[^/]+\.mp4$/u.test(path)) continue;
+      const asset = source.assets.find(([assetPath]) => assetPath === path)?.[1];
+      if (asset) {
+        hashes.add(hash);
+        media.set(hash, asset);
+      }
+    }
+    for (const slot of rows(at(comparison, 'slots'))) {
+      const hash = at(slot, role, 'sha256');
+      if (text(at(slot, role, 'artifact_path')) && !hashes.has(text(hash)))
+        throw new Error('Fidelity media was not published in the original C1 source');
+    }
+  }
+  if (roles.size !== 2) throw new Error('Both original fidelity sources are required');
+  return media;
 }
 export async function readStoredArtifact(
   runId: string,
@@ -94,13 +174,23 @@ export async function storeVideoArtifact(
   const sources: StoredSource[] = [];
   const uploads = new Map<string, Promise<{ url: string; downloadUrl: string }>>();
   for (const source of await archiveSources(zip, artifact)) {
-    const bundle = await loadBundle(source.read);
+    const fidelity = 'kind' in source && source.kind === 'fidelity';
+    const fidelityBundle = fidelity ? await loadFidelityBundle(source.read, source.id) : null;
+    const bundle = fidelityBundle ?? (await loadBundle(source.read));
+    const publishedMedia = fidelityBundle
+      ? await verifyPublishedSources(fidelityBundle, signal)
+      : null;
     const assets: StoredSource['assets'] = [];
     const files = [...bundle.files];
     for (let start = 0; start < files.length; start += 8) {
       const batch = await Promise.allSettled(
         files.slice(start, start + 8).map(async ([path, body]) => {
           const hash = bundle.checksums.get(path) ?? (await sha256(body));
+          const original = path.endsWith('.mp4') ? publishedMedia?.get(hash) : undefined;
+          if (original) {
+            assets.push([path, original]);
+            return;
+          }
           const key = `${PREFIX}/objects/${hash}/${path.split('/').at(-1)}`;
           let upload = uploads.get(key);
           if (!upload) {
@@ -121,11 +211,15 @@ export async function storeVideoArtifact(
     }
     const texts: StoredSource['texts'] = [];
     for (const [path, body] of bundle.files) {
-      if (path === 'report/index.html' || (!bundle.result && legacyTelemetry(path)))
+      if (
+        path === 'report/index.html' ||
+        (!('result' in bundle && bundle.result) && legacyTelemetry(path))
+      )
         texts.push([path, await body.text()]);
     }
     sources.push({
       id: source.id,
+      ...(fidelity ? { kind: 'fidelity' as const } : {}),
       documents: [...bundle.documents],
       checksums: [...bundle.checksums],
       assets,


### PR DESCRIPTION
Opening a compact `h3-fidelity-*` CI artifact now shows the native paired comparison, playable original video/audio, per-pair fidelity checks, source runs and downloads. The stored viewer reuses already published, checksum-matched C1 media URLs; it rejects unpublished or mismatched original sources and keeps the existing 256 MiB archive limit.

The fidelity, serving and legacy paired report iframes are mounted only after expansion. A fresh local browser with real artifact metadata and original CDN URLs requested 2 distinct MP4s initially, versus 40 before the fix.

Serving results and tradeoff details now display recorded server queue/stage timings, coverage, observed batch sizes and replica IDs. Historical missing timings remain unavailable; client delivery and server monotonic-clock measurements stay separate. These hidden H3 artifact views do not use the dashboard `?unofficialrun=` overlay data path.

Validation:
- `bun run test:unit`: 6,290 passed, 4 skipped; required local smoke: 46 component and 113 integration checks passed.
- Focused Chrome component checks: 31 passed. After the provenance fixes, lint, format, typecheck, 27 focused fidelity/archive/storage unit checks and 5 fidelity component checks passed; both real compact loaders also passed. The final serving/legacy report change passed 18 focused component/CI-viewer checks.
- Real compact [H200/B200 CI](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34410724145) and [H200/H100 CI](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34410729828): verified checksums, 20 pairs, both original videos/audio, report playback and raw downloads in English/Chinese desktop and mobile views.
- Chinese copy received local Claude and manual rendered review. New server timings are covered by clearly labeled synthetic fixtures; measured GPU timing output is not available yet.

Both real comparisons contain 20 technically valid pairs and 18 pairs outside **uncalibrated** fidelity thresholds. This is output-drift evidence, not a hardware quality winner or release qualification. Runtime/attention settings may differ across original runs.

## 中文说明

打开 `h3-fidelity-*` CI 产物后，可直接查看原生成对比较数据、原始视频与音频、逐对保真度检查、来源 CI 和下载链接。持久化展示复用已经发布且校验和一致的 C1 媒体地址；原始来源未发布或身份不匹配时拒绝发布，保留现有 256 MiB 归档上限。

保真度、服务测试及旧版配对结果的原始报告均在展开后才挂载。使用真实产物元数据和原始 CDN 地址的新浏览器会话验证：初始页面请求的视频由修改前的 40 个降至 2 个。

服务测试结果与效率图详情支持展示后端记录的排队及各阶段耗时、计时覆盖数量、batch size 和副本 ID。历史结果缺失的计时仍显示为无数据；客户端交付延迟与服务端单调时钟测量分别展示。隐藏的 H3 产物页面不使用仪表板的 `?unofficialrun=` 数据叠加路径。

验证：
- 全量单元测试 6,290 项通过、4 项跳过；必需的本地 smoke 检查通过 46 项组件测试和 113 项集成测试。
- 31 项重点 Chrome 组件测试通过；加强来源验证后，lint、格式、类型检查、27 项保真度/归档/存储单元测试及 5 项保真度组件测试通过，两个真实压缩产物的加载验证也通过。最后的服务测试与旧版报告修改通过 18 项重点组件及 CI 展示检查。
- 使用上述两个真实 CI 的压缩产物，在中英文桌面与移动端验证校验和、20 对视频、两侧音频播放、报告播放和原始数据下载。
- 中文文案经过本地 Claude 与页面人工检查。新增服务端计时仅使用明确标注的合成测试数据验证，尚无 GPU 实测计时产物。

两个真实比较均有 20 对技术有效的视频，其中 18 对超出未校准的保真度阈值。该结果用于查看输出偏差，不能据此判定硬件视频质量优劣或通过发布验收；原始运行的 attention backend 与配置也可能不同。
