### PR TITLE
[Video] reuse published H3 results in local development / 本地开发复用已发布的 H3 结果

### DIFF
--- a/packages/app/src/app/api/video-runs/route.test.ts
+++ b/packages/app/src/app/api/video-runs/route.test.ts
@@ -1,7 +1,12 @@
 import { NextRequest } from 'next/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GET } from './route';
-import { readStoredArtifact, storedArtifacts, videoStorageEnabled } from '@/lib/video-storage';
+import {
+  readStoredArtifact,
+  storedArtifacts,
+  storeVideoArtifact,
+  videoStorageEnabled,
+} from '@/lib/video-storage';
 
 vi.mock('@/lib/video-storage', () => ({
   videoStorageEnabled: vi.fn(() => false),
@@ -18,6 +23,8 @@ afterEach(() => {
   vi.mocked(videoStorageEnabled).mockReturnValue(false);
   vi.mocked(storedArtifacts).mockResolvedValue([]);
   vi.mocked(readStoredArtifact).mockReset();
+  vi.mocked(storeVideoArtifact).mockClear();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -62,6 +69,7 @@ describe('H3 CI artifact access', () => {
     expect(result3.status).toBe(410);
   });
   it('streams the verified run artifact with a deadline longer than metadata requests', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
     const deadline = new AbortController().signal;
     const timeout = vi
       .spyOn(AbortSignal, 'timeout')
@@ -117,6 +125,7 @@ describe('H3 CI artifact access', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
   it('serves a persisted result without fetching an expired GitHub artifact', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
     vi.mocked(videoStorageEnabled).mockReturnValue(true);
     const artifact = {
       id: 20,
@@ -173,5 +182,109 @@ describe('H3 CI artifact access', () => {
     const result6 = await GET(request('?artifact=123'));
     expect(result6.status).toBe(400);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('H3 published results in development', () => {
+  const saved = {
+    storageVersion: 1,
+    runId: '10',
+    artifact: { id: 20, name: 'h3-fidelity-10-1', stored: true },
+    sources: [
+      {
+        id: '10',
+        kind: 'fidelity',
+        assets: [['clip.mp4', { url: 'https://cdn.example/clip.mp4' }]],
+      },
+    ],
+  };
+
+  it('reuses the published result without a ZIP download or forwarded credentials', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    fetchMock.mockResolvedValueOnce(response(saved));
+    const result = await GET(
+      new NextRequest(
+        'http://localhost/api/video-runs?run=10&artifact=20&format=media&origin=https://evil.example',
+        { headers: { authorization: 'Bearer local-only', cookie: 'session=local-only' } },
+      ),
+    );
+    expect(result.status).toBe(200);
+    expect(await result.json()).toEqual(saved);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(String(url)).toBe(
+      'https://inferencex.semianalysis.com/api/video-runs?run=10&artifact=20&format=published',
+    );
+    expect(options).toMatchObject({ credentials: 'omit', redirect: 'error', cache: 'no-store' });
+    expect(options?.headers).toBeUndefined();
+    expect(options?.signal).toBeInstanceOf(AbortSignal);
+    expect(storeVideoArtifact).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['?run=10', { run: { id: 10 }, artifacts: [saved.artifact] }, '?run=10'],
+    ['?page=2', { runs: [{ id: 10 }], nextPage: 3 }, '?page=2'],
+  ])(
+    'reuses published discovery for %s, including retained artifacts',
+    async (query, data, upstream) => {
+      vi.stubEnv('NODE_ENV', 'development');
+      fetchMock.mockResolvedValueOnce(response(data));
+      const result = await GET(request(query));
+      expect(await result.json()).toEqual(data);
+      expect(String(fetchMock.mock.calls[0][0])).toBe(
+        `https://inferencex.semianalysis.com/api/video-runs${upstream}`,
+      );
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('keeps cache misses available for the existing local ZIP fallback', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(result.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeVideoArtifact).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...saved, runId: '11' },
+    { ...saved, artifact: { id: 21 } },
+    { ...saved, sources: [] },
+  ])('rejects a mismatched or incomplete published result', async (data) => {
+    vi.stubEnv('NODE_ENV', 'development');
+    fetchMock.mockResolvedValueOnce(response(data));
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(result.status).toBe(502);
+    expect(storeVideoArtifact).not.toHaveBeenCalled();
+  });
+
+  it('refuses an old deployment ZIP response instead of consuming it as stored media', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const zip = new Response('not JSON', { headers: { 'Content-Type': 'application/zip' } });
+    const cancel = vi.spyOn(zip.body!, 'cancel');
+    fetchMock.mockResolvedValueOnce(zip);
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(result.status).toBe(502);
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the production visibility failure without trying an archive', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    fetchMock.mockResolvedValueOnce(response({ error: 'Public H3 repository unavailable' }, 503));
+    const result = await GET(request('?run=10&artifact=20&format=media'));
+    expect(result.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never publishes an uncached artifact through the production published-only mode', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.mocked(videoStorageEnabled).mockReturnValue(true);
+    fetchMock.mockResolvedValueOnce(response({ private: false }));
+    const result = await GET(request('?run=10&artifact=20&format=published'));
+    expect(result.status).toBe(204);
+    expect(storedArtifacts).toHaveBeenCalledWith('10');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(storeVideoArtifact).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/app/api/video-runs/route.ts
+++ b/packages/app/src/app/api/video-runs/route.ts
@@ -1,5 +1,10 @@
 import { type NextRequest, NextResponse } from 'next/server';
-import { GITHUB_API_BASE, GITHUB_OWNER, GITHUB_REPO } from '@semianalysisai/inferencex-constants';
+import {
+  GITHUB_API_BASE,
+  GITHUB_OWNER,
+  GITHUB_REPO,
+  SITE_URL,
+} from '@semianalysisai/inferencex-constants';
 import { getGithubToken } from '@/lib/github-artifacts';
 import {
   readStoredArtifact,
@@ -33,6 +38,8 @@ export async function GET(request: NextRequest) {
   const runId = query.get('run');
   const artifactId = query.get('artifact');
   const page = query.get('page') ?? '1';
+  const publishedOnly = query.get('format') === 'published';
+  const media = query.get('format') === 'media' || publishedOnly;
   if ((runId && !id(runId)) || (artifactId && (!runId || !id(artifactId))) || !id(page))
     return NextResponse.json(
       { error: 'Invalid CI run, artifact or page' },
@@ -40,6 +47,50 @@ export async function GET(request: NextRequest) {
     );
   const deadline = AbortSignal.timeout(270000);
   try {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      !videoStorageEnabled() &&
+      (!artifactId || media)
+    ) {
+      // Production checks repository visibility; local reads must never publish on a cache miss.
+      const url = new URL('/api/video-runs', SITE_URL);
+      if (runId) url.searchParams.set('run', runId);
+      if (artifactId) {
+        url.searchParams.set('artifact', artifactId);
+        url.searchParams.set('format', 'published');
+      } else if (!runId) url.searchParams.set('page', page);
+      const response = await fetch(url, {
+        cache: 'no-store',
+        credentials: 'omit',
+        redirect: 'error',
+        signal: AbortSignal.timeout(30000),
+      });
+      if (response.status === 204) return new Response(null, { status: 204, headers });
+      if (!response.headers.get('content-type')?.includes('application/json')) {
+        await response.body?.cancel();
+        throw new Error('Published result unavailable');
+      }
+      const data = await response.json();
+      if (response.ok) {
+        if (artifactId) {
+          if (
+            data.storageVersion !== 1 ||
+            data.runId !== runId ||
+            data.artifact?.id !== Number(artifactId) ||
+            !Array.isArray(data.sources) ||
+            data.sources.length === 0
+          )
+            throw new Error('Published artifact identity mismatch');
+        } else if (
+          runId
+            ? String(data.run?.id) !== runId || !Array.isArray(data.artifacts)
+            : !Array.isArray(data.runs)
+        ) {
+          throw new Error('Published run identity mismatch');
+        }
+      }
+      return NextResponse.json(data, { status: response.status, headers });
+    }
     // This public viewer must never expose artifacts from a repository that becomes private.
     const repository = await github('');
     const repo = repository.ok ? await repository.json() : null;
@@ -49,7 +100,6 @@ export async function GET(request: NextRequest) {
         { status: 503, headers },
       );
     if (artifactId) {
-      const media = query.get('format') === 'media';
       if (media && !videoStorageEnabled()) return new Response(null, { status: 204, headers });
       if (media) {
         const saved = await storedArtifacts(runId!);
@@ -58,6 +108,7 @@ export async function GET(request: NextRequest) {
           const result = await readStoredArtifact(runId!, stored);
           if (result) return NextResponse.json(result, { headers });
         }
+        if (publishedOnly) return new Response(null, { status: 204, headers });
       }
       const metaResponse = await github(`/actions/artifacts/${artifactId}`);
       if (!metaResponse.ok)

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -76,7 +76,7 @@ export const apiRouteCatalog = [
       en: 'Hidden H3 viewer transport for live public CI runs and checksum-verified artifact ZIPs; uses the backend result contract rather than a published data API.',
       zh: '供隐藏的 H3 查看器实时读取公开 CI 运行及校验和已验证的产物 ZIP；依赖后端结果契约，不作为公开数据 API 发布。',
     },
-    sourceSha256: '33a7dec3e6d9077fe23493ed472a4ea7753254f742d676f184fd1bf41ff6b645',
+    sourceSha256: '51278d05e223947e6a9c7b89b5f79a67afcd941ca091dbd794d3816c26805327',
   },
   {
     source: 'src/app/api/unofficial-run/route.ts',


### PR DESCRIPTION
Without `BLOB_READ_WRITE_TOKEN`, the local H3 viewer downloaded and unpacked the complete CI archive on every load. Development now reads published result metadata and CDN media URLs through the fixed production endpoint, including persisted artifacts in run discovery and comparison links.

The new `format=published` mode returns 204 on a cache miss before any archive download or publication. The development proxy forwards no credentials, rejects redirects and mismatched result identities, and cancels non-JSON responses from older deployments. Explicit local ZIP access and production's existing media-loading behavior remain available. Local discovery now depends on production availability. The API catalog remains classified as a hidden UI transport; its review digest is updated.

Validation:
- Regression tests: nine new failures before the fix; all 22 route tests pass after the fix.
- `bun run test:unit`: 6,008 Vitest checks plus 295 CLI checks passed, four skipped.
- `bun run test:e2e`: 46 component and 113 integration smoke checks passed.
- Lint, format, typecheck, typography and diff checks passed; independent read-only review found no blockers.
- Deployed merge commit `a8fa4c8c` (production deployment `6361382867`). Direct localhost first load, reload, Chinese playback/audio and all nine hardware comparison points passed with zero CI ZIP requests and zero page errors. Production published-only cache hit/miss returned 200/204; regular media loading returned 200. Full Chrome/Firefox CI passed: https://github.com/SemiAnalysisAI/InferenceX-app/actions/runs/34416994094.

## 中文说明

未配置 `BLOB_READ_WRITE_TOKEN` 时，本地 H3 页面每次加载都会下载并解压完整 CI 产物。开发环境现在通过固定的生产地址读取已发布的结果元数据和 CDN 视频地址，运行选择及比较链接也可复用持久化产物。

新增 `format=published` 只读模式：缓存未命中时直接返回 204，不下载归档或发布产物。开发代理不转发本地凭据，拒绝重定向及身份不匹配的结果，并取消旧版部署返回的非 JSON 响应。本地显式 ZIP 下载和生产环境原有媒体加载逻辑保留；本地运行列表依赖生产服务可用。API 目录仍将该接口归类为隐藏界面传输，仅更新审核摘要。

验证：修复前新增测试中九项失败，修复后全部 22 项路由测试通过；全量单元测试通过 6,008 项 Vitest 检查和 295 项 CLI 检查，四项跳过；本地 smoke 的 46 项组件和 113 项集成检查通过；lint、格式、类型、排版及 diff 检查通过，独立只读检查未发现阻塞问题。合并提交 `a8fa4c8c` 已部署（生产部署 `6361382867`）。本地直接访问的首次加载、刷新、中文视频及音频播放和九个硬件对比点均通过，CI ZIP 请求及页面错误均为零。生产只读缓存命中/未命中分别返回 200/204，常规媒体加载返回 200；完整 Chrome/Firefox CI 通过。

