### PR TITLE
fix(profit): order estimator bars by P&L instead of revenue

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -245,8 +245,9 @@ describe('Profit Estimator per GW', () => {
       .first()
       .invoke('text')
       .should((text) => {
-        // Bars re-sort by revenue, but halving utilization halves every bar, so
-        // the tallest bar is still the tallest and its label halves.
+        // Bars re-sort by P&L, but the fixture SKUs keep their profit order at
+        // 30% utilization, so the first bar is the same chip and its revenue
+        // label halves along with every other bar's.
         expect(parseCompactUsd(text)).to.be.closeTo(revenueAt60 / 2, revenueAt60 * 0.02);
       });
     // Y domain rescales, so compare TCO in data terms via the tooltip-free

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -247,23 +247,33 @@ describe('estimateSkuProfit', () => {
 });
 
 describe('estimateProfitRows', () => {
-  it('splits priced rows from skipped SKUs and sorts by revenue descending', () => {
+  it('splits priced rows from skipped SKUs and sorts by profit descending', () => {
     const specs: Record<string, { powerKwPerGpu: number; costPerGpuHour: number }> = {
       b200: B200,
       h200: { powerKwPerGpu: 1.37, costPerGpuHour: 1.22 },
+      // Same power as the B200 so it books less revenue per GW-year, but a
+      // fraction of the TCO, so it clears more P&L. Profit order must win.
+      cheap: { powerKwPerGpu: 1.71, costPerGpuHour: 0.4 },
       ghost: { powerKwPerGpu: 0, costPerGpuHour: 1 },
     };
     const { rows, skipped } = estimateProfitRows(
       [
         { hwKey: 'h200', resultKey: 'h200', value: 400 },
         { hwKey: 'b200', resultKey: 'b200', value: 1_000 },
+        { hwKey: 'cheap', resultKey: 'cheap', value: 600 },
         { hwKey: 'ghost', resultKey: 'ghost', value: 5_000 },
       ],
       (hwKey) => specs[hwKey]!,
       FLAT_PRICING,
       { utilizationPct: 60, labCutPct: 30, basis: 'gw-year' },
     );
-    expect(rows.map((r) => r.resultKey)).toEqual(['b200', 'h200']);
+    expect(rows.map((r) => r.resultKey)).toEqual(['cheap', 'b200', 'h200']);
+    // Revenue alone would have put the B200 first.
+    expect(rows.toSorted((a, b) => b.revenue - a.revenue).map((r) => r.resultKey)).toEqual([
+      'b200',
+      'cheap',
+      'h200',
+    ]);
     expect(skipped).toEqual([
       { hwKey: 'ghost', resultKey: 'ghost', precision: undefined, reason: 'no-power' },
     ]);

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -284,8 +284,10 @@ export function isProfitEstimatorRow(
 
 /**
  * Estimate every interpolated SKU, splitting priced rows from the ones that
- * had to be skipped. Rows come back sorted by revenue descending so the chart
- * reads left to right from the largest top line.
+ * had to be skipped. Rows come back sorted by profit (P&L) descending so the
+ * chart reads left to right from the most profitable SKU, not the largest top
+ * line: a high-revenue chip with a heavier TCO can sit to the right of a
+ * cheaper one that clears more after costs.
  */
 export function estimateProfitRows(
   results: readonly Parameters<typeof estimateSkuProfit>[0][],
@@ -300,7 +302,7 @@ export function estimateProfitRows(
     if (isProfitEstimatorRow(estimate)) rows.push(estimate);
     else skipped.push(estimate);
   }
-  rows.sort((a, b) => b.revenue - a.revenue || a.resultKey.localeCompare(b.resultKey));
+  rows.sort((a, b) => b.profit - a.profit || a.resultKey.localeCompare(b.resultKey));
   return { rows, skipped };
 }
 

--- a/packages/app/src/components/calculator/profit-history.ts
+++ b/packages/app/src/components/calculator/profit-history.ts
@@ -233,7 +233,7 @@ const entryOrder = (a: string, b: string): number => {
 
 /**
  * Order bars for the comparison view: chips in the order they already hold
- * (revenue descending, from `estimateProfitRows`), and within a chip its
+ * (profit descending, from `estimateProfitRows`), and within a chip its
  * entries oldest → newest (same-day runs in run order, as `/inference` sorts
  * them) so the current bar sits at the right of its group. Rows with no entry
  * are today's and sort last within their chip.


### PR DESCRIPTION
## Summary

Both `/profit-estimator` and `/profit-estimator-per-gigawatt` sorted the SKU bars by revenue descending, so the chip with the largest top line led the chart even when a cheaper chip clears more after TCO and the model license fee. Per raminer's feedback in #ext-amd-sw-engineering-semianalysis, the bars now sort by P&L (profit) descending, with the existing `resultKey` tiebreak.

- `estimateProfitRows` sorts on `profit` rather than `revenue`. Both routes and the zh mirrors share this function, so one change covers all four pages.
- Compare-history grouping already takes chip order from `estimateProfitRows`, so the history view follows the same rule; only the comment changed there.
- Unit test now includes a low-cost SKU whose revenue ranks second but whose profit ranks first, so the test distinguishes profit order from revenue order.
- The e2e fixture SKUs keep the same order under either sort (GB300 > B300 > B200 > MI355X at hyperscaler-tier costs and the intercepted OpenRouter prices), so the Cypress spec needs only a comment update.

## Test plan

- [x] `bunx vitest run` on `profit-estimator.test.ts` and `profit-history.test.ts`
- [x] `bun run typecheck`, `bun run lint`, `bun run fmt`
- [ ] CI e2e (`profit-estimator.cy.ts`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order change in shared sorting logic for the profit estimator charts; economics calculations are unchanged.
> 
> **Overview**
> Profit estimator SKU bars now sort by **profit (P&L) descending** instead of revenue, so the left-to-right chart order reflects what clears after TCO and the model license fee—not just the largest top line.
> 
> `estimateProfitRows` compares `profit` with the existing `resultKey` tiebreak; all profit-estimator routes that share this helper pick up the new order. Compare-history bar grouping already follows chip order from that function, so only its doc comment was updated.
> 
> Tests add a low-TCO SKU that ranks first on profit but second on revenue, and the Cypress utilization test comment was adjusted because fixture SKUs keep the same order under either sort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a255b692a54711afef0d73c53ebdd29ae139742a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->