### PR TITLE
Move Historical Trends from the nav bar to the footer / 将「历史趋势」从导航栏移至页脚

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1052,8 +1052,10 @@ tabs differ only in the denominator (`ProfitBasis`):
 
 In the nav both sit between Inference Performance and Accuracy Evals. TCO
 Calculator and Fleet Lifecycle moved out of the tab bar into the footer's "More" column
-(`navGroup: 'footer-only'`, `footer-link-calculator` / `footer-link-fleet`); their
-pages, `/zh` mirrors and sitemap entries are unchanged.
+(`navGroup: 'footer-only'`, `footer-link-calculator` / `footer-link-fleet`), and
+Historical Trends followed (`footer-link-historical`) since the compare-by-date
+flow on the inference dashboard covers the same question; their pages, `/zh`
+mirrors and sitemap entries are unchanged.
 
 ### The arithmetic
 

--- a/packages/app/cypress/component/tab-nav.cy.tsx
+++ b/packages/app/cypress/component/tab-nav.cy.tsx
@@ -126,15 +126,16 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
     mountTabNav({});
     cy.get('[data-testid="tab-trigger-overview"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-evaluation"]').should('have.attr', 'href', '/evaluation');
-    cy.get('[data-testid="tab-trigger-historical"]').should('have.attr', 'href', '/historical');
     cy.get('[data-testid="tab-trigger-profit-estimator"]').should(
       'have.attr',
       'href',
       '/profit-estimator',
     );
-    // TCO Calculator and Fleet Lifecycle live in the footer, not the tab bar.
+    // TCO Calculator, Fleet Lifecycle, and Historical Trends live in the
+    // footer, not the tab bar.
     cy.get('[data-testid="tab-trigger-calculator"]').should('not.exist');
     cy.get('[data-testid="tab-trigger-fleet"]').should('not.exist');
+    cy.get('[data-testid="tab-trigger-historical"]').should('not.exist');
   });
 
   it('appends unofficialruns to every tab href when the URL has the param', () => {
@@ -154,11 +155,6 @@ describe('TabNav — unofficialrun URL preservation (issue #319)', () => {
       'have.attr',
       'href',
       '/submissions?unofficialruns=12345',
-    );
-    cy.get('[data-testid="tab-trigger-historical"]').should(
-      'have.attr',
-      'href',
-      '/historical?unofficialruns=12345',
     );
   });
 

--- a/packages/app/cypress/e2e/csv-export.cy.ts
+++ b/packages/app/cypress/e2e/csv-export.cy.ts
@@ -58,7 +58,7 @@ describe('CSV Export', () => {
   });
 
   it('historical trends chart has CSV export option', () => {
-    cy.get('[data-testid="tab-trigger-historical"]').click();
+    cy.get('[data-testid="footer-link-historical"]').scrollIntoView().click();
     cy.get('[data-testid="historical-trend-figure"]').should('exist');
 
     cy.get('[data-testid="export-button"]').first().click();

--- a/packages/app/cypress/e2e/historical-trends.cy.ts
+++ b/packages/app/cypress/e2e/historical-trends.cy.ts
@@ -41,8 +41,11 @@ describe('Historical Trends Tab', () => {
     cy.get('[data-testid="historical-trends-display"]').find('svg').should('exist');
   });
 
-  it('tab trigger is visible in desktop navigation', () => {
-    cy.get('[data-testid="tab-trigger-historical"]').should('contain.text', 'Historical Trends');
+  it('is reachable from the footer, not the tab bar', () => {
+    cy.get('[data-testid="tab-trigger-historical"]').should('not.exist');
+    cy.get('[data-testid="footer-link-historical"]')
+      .should('have.attr', 'href', '/historical')
+      .and('contain.text', 'Historical Trends');
   });
 });
 

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -19,9 +19,6 @@ describe('Chart Section Tabs — E2E', () => {
     cy.get('[data-testid="tab-trigger-evaluation"]').click();
     cy.url().should('include', '/evaluation');
 
-    cy.get('[data-testid="tab-trigger-historical"]').click();
-    cy.url().should('include', '/historical');
-
     cy.get('[data-testid="tab-trigger-profit-estimator-per-gigawatt"]').click();
     cy.url().should('include', '/profit-estimator-per-gigawatt');
 
@@ -34,6 +31,14 @@ describe('Chart Section Tabs — E2E', () => {
 
     cy.get('[data-testid="tab-trigger-inference"]').click();
     cy.url().should('include', '/inference');
+  });
+
+  it('opens Historical Trends from the footer link', () => {
+    cy.get('[data-testid="tab-trigger-historical"]').should('not.exist');
+
+    cy.get('[data-testid="footer-link-historical"]').scrollIntoView().click();
+    cy.url().should('include', '/historical');
+    cy.get('[data-testid="historical-trends-display"]').should('exist');
   });
 
   it('opens the TCO Calculator and Fleet Lifecycle from the footer links', () => {

--- a/packages/app/src/components/footer/footer.tsx
+++ b/packages/app/src/components/footer/footer.tsx
@@ -33,6 +33,7 @@ const STRINGS = {
     telemetry: 'Telemetry',
     articles: 'Articles',
     apiReference: 'API Reference',
+    historicalTrends: 'Historical Trends',
     tcoCalculator: 'TCO Calculator',
     fleetLifecycle: 'Fleet Lifecycle',
     gpuReliability: 'Chip Reliability',
@@ -66,6 +67,7 @@ const STRINGS = {
     agentx: 'AgentX',
     telemetry: '遥测数据',
     articles: '技术文章',
+    historicalTrends: '历史趋势',
     tcoCalculator: 'TCO 计算器',
     fleetLifecycle: '集群生命周期',
     gpuReliability: '芯片可靠性',
@@ -263,6 +265,14 @@ export const Footer = ({ starCount }: { starCount?: number | null }) => {
                   className="inline-flex min-h-11 items-center rounded-sm py-1 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4 focus-visible:outline-none md:min-h-8"
                 >
                   {t.apiReference}
+                </Link>
+                <Link
+                  data-testid="footer-link-historical"
+                  href={`${prefix}/historical`}
+                  className="inline-flex min-h-11 items-center rounded-sm py-1 text-sm leading-snug text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4 focus-visible:outline-none md:min-h-8"
+                  onClick={() => track('footer_historical_clicked')}
+                >
+                  {t.historicalTrends}
                 </Link>
                 <Link
                   data-testid="footer-link-calculator"

--- a/packages/app/src/lib/dashboard-routes.test.ts
+++ b/packages/app/src/lib/dashboard-routes.test.ts
@@ -42,6 +42,13 @@ describe('dashboard route registry', () => {
     expect(getDashboardRoute('fleet').indexable).toBe(true);
   });
 
+  it('moves Historical Trends to the footer but keeps it indexed and locale-mirrored', () => {
+    expect(getDashboardRoute('historical').navGroup).toBe('footer-only');
+    expect(getDashboardRoute('historical').indexable).toBe(true);
+    expect(getDashboardRoute('historical').localeMirrored).toBe(true);
+    expect(dashboardRouteForPathname('/historical/kimi-k3')?.key).toBe('historical');
+  });
+
   it('puts both profit estimators between Inference Performance and Accuracy Evals', () => {
     const primary = DASHBOARD_ROUTES.filter((route) => route.navGroup === 'primary').map(
       (route) => route.key,
@@ -54,6 +61,7 @@ describe('dashboard route registry', () => {
     ]);
     expect(primary).not.toContain('calculator');
     expect(primary).not.toContain('fleet');
+    expect(primary).not.toContain('historical');
     expect(dashboardRouteForPathname('/profit-estimator-per-gigawatt/kimi-k3')?.key).toBe(
       'profit-estimator-per-gigawatt',
     );

--- a/packages/app/src/lib/dashboard-routes.ts
+++ b/packages/app/src/lib/dashboard-routes.ts
@@ -131,11 +131,14 @@ export const DASHBOARD_ROUTES = [
     providers: FILTERED_DASHBOARD_PROVIDERS,
     shareParamScopes: ['g_', 'e_'],
   },
+  // Historical Trends moved to the footer as well: almost nobody opened the
+  // view, and people compare curves across dates on the inference dashboard
+  // instead. The route, canonical, /zh mirror, and sitemap entry stay.
   {
     key: 'historical',
     path: '/historical',
     canonicalPath: '/historical',
-    navGroup: 'primary',
+    navGroup: 'footer-only',
     indexable: true,
     localeMirrored: true,
     providers: FILTERED_DASHBOARD_PROVIDERS,


### PR DESCRIPTION
## Summary

Historical Trends drew almost no traffic; people answer the same question by comparing curves across dates on the inference dashboard. This moves the entry point out of the primary tab bar and into the footer "More" column, next to TCO Calculator and Fleet Lifecycle.

- `dashboard-routes.ts`: `historical` → `navGroup: 'footer-only'`. Route, canonical, `/zh` mirror, and sitemap entry are unchanged.
- `footer.tsx`: new `footer-link-historical` link (EN "Historical Trends" / ZH "历史趋势") with `footer_historical_clicked` tracking.
- Tests: registry unit test asserts the new group; `navigation`, `historical-trends`, `csv-export`, and the `tab-nav` component spec now reach the view through the footer and assert the tab trigger is gone.
- `docs/tco-calculator.md`: nav note updated.

Checks run locally: `typecheck`, `lint`, `fmt`, and the `dashboard-routes` / `model-routes` vitest files pass.

## 中文说明

「历史趋势」视图几乎无人访问，用户通常直接在推理仪表板上按日期对比曲线。本 PR 将其入口从顶部标签栏移至页脚「更多」栏，与 TCO 计算器、集群生命周期并列。

- `dashboard-routes.ts`：`historical` 改为 `navGroup: 'footer-only'`，页面路由、canonical、`/zh` 镜像与 sitemap 保持不变。
- `footer.tsx`：新增 `footer-link-historical` 链接（英文 "Historical Trends" / 中文「历史趋势」），带 `footer_historical_clicked` 埋点。
- 测试：路由注册表单元测试断言新分组；`navigation`、`historical-trends`、`csv-export` 及 `tab-nav` 组件测试改为通过页脚进入该视图，并断言标签栏中不再有该入口。
- `docs/tco-calculator.md`：更新导航说明。

本地已通过 `typecheck`、`lint`、`fmt`，以及 `dashboard-routes` / `model-routes` 的 vitest 用例。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and footer link only; no route, auth, or data logic changes.
> 
> **Overview**
> **Historical Trends** is removed from the primary dashboard tab bar and exposed only from the footer **More** column, alongside TCO Calculator and Fleet Lifecycle. The `/historical` route, SEO/indexing, `/zh` mirror, and sitemap behavior are unchanged.
> 
> In `dashboard-routes.ts`, the `historical` route’s `navGroup` changes from `primary` to `footer-only` (with a short rationale comment). `footer.tsx` adds `footer-link-historical` with EN/ZH labels and `footer_historical_clicked` analytics.
> 
> Tests and docs follow the new entry point: Cypress and component specs assert `tab-trigger-historical` is absent, navigation goes through the footer, and `unofficialruns` is no longer appended to a historical tab href. The route registry unit test confirms `historical` stays indexed and locale-mirrored but is excluded from primary tabs. `docs/tco-calculator.md` notes the nav change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434146ef25f0272c002a6131cd0144ac6e8589f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->