### PR TITLE
Add a Cost Tier selector and collapse tiered Y-axis metrics / 新增成本层级选择器并合并分层 Y 轴指标

### DIFF
--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -77,26 +77,40 @@ describe('Inference ChartControls', () => {
     }
   });
 
-  it('lists locked rental tiers under each cost group and opens the TCO model dialog', () => {
+  it('hides the Cost Tier selector for metrics without a pricing basis', () => {
+    // Default mock: selectedYAxisMetric = y_tpPerGpu
+    cy.get('[data-testid="yaxis-metric-selector"]').should('be.visible');
+    cy.get('[data-testid="cost-tier-selector"]').should('not.exist');
+  });
+
+  it('lists each tiered metric once in the Y-axis selector, without the tier suffix', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.contains('Cost per Million Total Tokens')
-      .closest('[role="rowgroup"]')
-      .within(() => {
-        cy.get('[data-testid="locked-tier-badge"]').should('have.length', 5);
-        cy.get('[data-testid="yaxis-locked-rent_1_year-costr"]')
-          .should('contain.text', 'Cost per Million Total Tokens (Rent - 1 Year Commit)')
-          .scrollIntoView()
-          .click();
-      });
-    cy.get('[data-testid="tco-model-dialog"]')
-      .should('be.visible')
-      .and('contain.text', 'Rent - 1 Year Commit');
-    cy.get('[data-testid="tco-model-dialog-link"]')
-      .should('have.attr', 'href', 'https://semianalysis.com/ai-cloud-tco-model/')
-      .and('have.attr', 'target', '_blank');
-    cy.get('@setSelectedYAxisMetric').should('not.have.been.called');
-    cy.contains('button', 'Not now').click();
-    cy.get('[data-testid="tco-model-dialog"]').should('not.exist');
+    cy.get('[data-slot="select-item"]').then(($items) => {
+      const labels = [...$items].map((item) => item.textContent?.trim() ?? '');
+      expect(labels.filter((label) => label.startsWith('Total Tokens per $1 TCO'))).to.deep.equal([
+        'Total Tokens per $1 TCO',
+        'Total Tokens per $1 TCO (Custom User Values)',
+      ]);
+      expect(
+        labels.filter((label) => label.startsWith('Cost per Million Total Tokens')),
+      ).to.deep.equal([
+        'Cost per Million Total Tokens',
+        'Cost per Million Total Tokens (Custom User Values)',
+      ]);
+      expect(labels.some((label) => label.includes('Owning at Large Hyperscaler Volume'))).to.equal(
+        false,
+      );
+      expect(labels.some((label) => label.includes('Rent - 3 Year Commit'))).to.equal(false);
+    });
+    cy.get('[data-testid="locked-tier-badge"]').should('not.exist');
+  });
+
+  it('opens tiered metrics on the hyperscaler tier from an untiered metric', () => {
+    cy.get('[data-testid="yaxis-metric-selector"]').click('right');
+    cy.contains('[data-slot="select-item"]', /^Cost per Million Total Tokens$/u)
+      .scrollIntoView()
+      .click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_costh');
   });
 
   it('hides the GPU comparison section when no GPUs are selected', () => {
@@ -342,32 +356,68 @@ describe('Inference ChartControls cost metrics', () => {
 
   it('shows cost per million and tokens per dollar as separate Y-axis options', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-    ).should('exist');
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Total Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    ).should('exist');
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Output Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    ).should('exist');
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Input Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    ).should('exist');
+    for (const label of [
+      /^Cost per Million Total Tokens$/u,
+      /^Total Tokens per \$1 TCO$/u,
+      /^Output Tokens per \$1 TCO$/u,
+      /^Input Tokens per \$1 TCO$/u,
+    ]) {
+      cy.contains('[data-slot="select-item"]', label).should('exist');
+    }
     cy.get('[data-testid="cost-display-selector"]').should('not.exist');
   });
 
-  it('selects tokens per dollar through the Y-axis metric control', () => {
+  it('selects tokens per dollar through the Y-axis metric control on the active tier', () => {
+    // y_costh is selected, so other tiered metrics open on the hyperscaler tier.
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Total Tokens per $1 TCO (Rent - 3 Year Commit)',
-    ).click();
-    cy.get('@setSelectedYAxisMetric').should('have.been.calledWith', 'y_tokensPerDollarR');
+    cy.contains('[data-slot="select-item"]', /^Total Tokens per \$1 TCO$/u).click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledWith', 'y_tokensPerDollarH');
+  });
+
+  it('shows the Cost Tier selector with published tiers, custom values and locked rental terms', () => {
+    cy.get('[data-testid="cost-tier-selector"]')
+      .should('be.visible')
+      .and('contain.text', 'Owning at Large Hyperscaler Volume')
+      .click('right');
+    cy.get('[data-slot="select-item"]').then(($items) => {
+      const labels = [...$items].map((item) => item.textContent?.trim() ?? '');
+      expect(labels).to.deep.equal([
+        'Owning at Large Hyperscaler Volume',
+        'Rent - 3 Year Commit',
+        'Custom User Values',
+        // The lock badge carries a screen-reader "Locked" label.
+        'Rent - On DemandLocked',
+        'Rent - 1 Month CommitLocked',
+        'Rent - 6 Month CommitLocked',
+        'Rent - 1 Year CommitLocked',
+        'Rent - 2 Year CommitLocked',
+      ]);
+    });
+    cy.get('[data-testid="locked-tier-badge"]').should('have.length', 5);
+    cy.get('[data-testid="cost-tier-rental"]').click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_costr');
+  });
+
+  it('switches to the custom axis from the Cost Tier selector', () => {
+    cy.get('[data-testid="cost-tier-selector"]').click('right');
+    cy.get('[data-testid="cost-tier-custom"]').click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_costUser');
+  });
+
+  it('opens the TCO model dialog for locked rental tiers instead of changing the axis', () => {
+    cy.get('[data-testid="cost-tier-selector"]').click('right');
+    cy.get('[data-testid="cost-tier-locked-rent_1_year"]')
+      .should('contain.text', 'Rent - 1 Year Commit')
+      .click();
+    cy.get('[data-testid="tco-model-dialog"]')
+      .should('be.visible')
+      .and('contain.text', 'Rent - 1 Year Commit');
+    cy.get('[data-testid="tco-model-dialog-link"]')
+      .should('have.attr', 'href', 'https://semianalysis.com/ai-cloud-tco-model/')
+      .and('have.attr', 'target', '_blank');
+    cy.get('@setSelectedYAxisMetric').should('not.have.been.called');
+    cy.contains('button', 'Not now').click();
+    cy.get('[data-testid="tco-model-dialog"]').should('not.exist');
   });
 });
 
@@ -377,6 +427,15 @@ describe('Inference ChartControls infrastructure tokens per dollar', () => {
       inference: { selectedYAxisMetric: 'y_tokensPerDollarR' },
       globalFilters: {},
     });
+  });
+
+  it('keeps the rental tier when switching between tiered metrics', () => {
+    cy.get('[data-testid="cost-tier-selector"]').should('contain.text', 'Rent - 3 Year Commit');
+    cy.get('[data-testid="yaxis-metric-selector"]').click('right');
+    cy.contains('[data-slot="select-item"]', /^Cost per Million Output Tokens$/u)
+      .scrollIntoView()
+      .click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_costrOutput');
   });
 
   it('does not show the token sale-price source control', () => {
@@ -551,30 +610,30 @@ describe('Axis option help', () => {
 
   it('keeps hover help readable across the pointer gap without taking search focus', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.get('input[aria-label="Search options"]').type('Rent - 3 Year Commit');
+    cy.get('input[aria-label="Search options"]').type('Total Tokens per $1 TCO');
     cy.clock();
-    cy.get('[data-testid="option-help-y_tokensPerDollarR"]').trigger('pointerover', {
+    cy.get('[data-testid="option-help-y_tokensPerDollarH"]').trigger('pointerover', {
       pointerType: 'mouse',
     });
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]').should('be.visible');
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]').should('be.visible');
     cy.get('input[aria-label="Search options"]').should('have.focus');
-    cy.get('[data-testid="option-help-y_tokensPerDollarR"]').trigger('pointerout', {
+    cy.get('[data-testid="option-help-y_tokensPerDollarH"]').trigger('pointerout', {
       pointerType: 'mouse',
     });
     cy.tick(100);
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]').trigger('pointerover', {
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]').trigger('pointerover', {
       pointerType: 'mouse',
     });
     cy.tick(300);
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]')
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]')
       .should('be.visible')
       .and('contain.text', 'infrastructure spend')
       .trigger('pointerout', { pointerType: 'mouse' });
     cy.tick(300);
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]').should('not.exist');
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]').should('not.exist');
     cy.get('input[aria-label="Search options"]')
       .should('have.focus')
-      .and('have.value', 'Rent - 3 Year Commit');
+      .and('have.value', 'Total Tokens per $1 TCO');
     cy.get('@setSelectedYAxisMetric').should('not.have.been.called');
     cy.get('[data-testid="yaxis-metric-selector"]').should('have.attr', 'aria-expanded', 'true');
   });
@@ -641,20 +700,20 @@ describe('Axis option help', () => {
 
   it('opens descriptions and formulas without selecting an option or losing the search', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.get('input[aria-label="Search options"]').type('Rent - 3 Year Commit');
-    cy.get('[data-testid="option-help-y_tokensPerDollarR"]').click();
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]')
+    cy.get('input[aria-label="Search options"]').type('Total Tokens per $1 TCO');
+    cy.get('[data-testid="option-help-y_tokensPerDollarH"]').click();
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]')
       .should('be.visible')
       .and('contain.text', 'infrastructure spend')
       .find('code')
       .should('have.text', 'tok/$ = (total tok/s/chip × 3,600) ÷ all-in cost per chip-hour ($)');
     cy.get('@setSelectedYAxisMetric').should('not.have.been.called');
     cy.get('[data-testid="yaxis-metric-selector"]').should('have.attr', 'aria-expanded', 'true');
-    cy.get('[data-testid="option-help-content-y_tokensPerDollarR"]').type('{esc}');
-    cy.get('[data-testid="option-help-y_tokensPerDollarR"]').should('have.focus');
-    cy.get('input[aria-label="Search options"]').should('have.value', 'Rent - 3 Year Commit');
-    cy.get('[data-select-option][data-value="y_tokensPerDollarR"]').click();
-    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_tokensPerDollarR');
+    cy.get('[data-testid="option-help-content-y_tokensPerDollarH"]').type('{esc}');
+    cy.get('[data-testid="option-help-y_tokensPerDollarH"]').should('have.focus');
+    cy.get('input[aria-label="Search options"]').should('have.value', 'Total Tokens per $1 TCO');
+    cy.get('[data-select-option][data-value="y_tokensPerDollarH"]').click();
+    cy.get('@setSelectedYAxisMetric').should('have.been.calledOnceWith', 'y_tokensPerDollarH');
     cy.get('[data-testid="yaxis-metric-selector"]').should('have.attr', 'aria-expanded', 'false');
   });
 
@@ -696,10 +755,10 @@ describe('Axis option help', () => {
 
   it('exposes separate accessible selection and help actions', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
-    cy.get('[data-testid="option-help-y_tokensPerDollarR"]').click();
+    cy.get('[data-testid="option-help-y_tokensPerDollarH"]').click();
     cy.injectAxe();
     cy.checkA11y(
-      '[data-slot="select-content"], [data-testid="option-help-content-y_tokensPerDollarR"]',
+      '[data-slot="select-content"], [data-testid="option-help-content-y_tokensPerDollarH"]',
       {
         runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] },
       },

--- a/packages/app/cypress/e2e/gradient-labels.cy.ts
+++ b/packages/app/cypress/e2e/gradient-labels.cy.ts
@@ -103,7 +103,7 @@ describe('Gradient Labels Toggle', () => {
   });
 });
 
-const selectMetricAndEnableGradient = (metricLabel: string) => {
+const selectMetricAndEnableGradient = (metricLabel: string | RegExp) => {
   // Switch to the target Y-axis metric
   cy.get('[data-testid="yaxis-metric-selector"]').click('right', { force: true });
   cy.contains('[data-slot="select-item"]', metricLabel).click({ force: true });
@@ -132,9 +132,7 @@ describe('Gradient Labels with non-default Y-axis metrics', () => {
   });
 
   it('gradient defs render for cost metric (lower_right roofline)', () => {
-    selectMetricAndEnableGradient(
-      'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-    );
+    selectMetricAndEnableGradient(/^Cost per Million Total Tokens$/u);
 
     // SVG must contain at least one linearGradient used for roofline coloring
     cy.get(
@@ -163,9 +161,7 @@ describe('Gradient Labels with non-default Y-axis metrics', () => {
 
   it('pill labels render for cost metric', () => {
     cy.get('#scatter-gradient-labels').click();
-    selectMetricAndEnableGradient(
-      'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-    );
+    selectMetricAndEnableGradient(/^Cost per Million Total Tokens$/u);
 
     // Parallelism pill labels should be present
     cy.get('[data-testid="scatter-graph"] svg g.parallelism-label').should(

--- a/packages/app/cypress/e2e/inference-chart.cy.ts
+++ b/packages/app/cypress/e2e/inference-chart.cy.ts
@@ -201,9 +201,12 @@ describe('Inference Chart', () => {
     );
     cy.wait('@unofficialRun');
 
-    cy.get('[data-testid="yaxis-metric-selector"]').should(
+    cy.get('[data-testid="yaxis-metric-selector"]')
+      .should('contain.text', 'Total Tokens per $1 TCO')
+      .and('not.contain.text', '(Owning');
+    cy.get('[data-testid="cost-tier-selector"]').should(
       'contain.text',
-      'Total Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
+      'Owning at Large Hyperscaler Volume',
     );
     cy.get('[data-testid="token-revenue-price-source"]').should('not.exist');
     cy.get('[data-testid="chart-figure"]')
@@ -301,10 +304,10 @@ describe('Inference Chart', () => {
     );
     cy.wait('@unofficialRun');
 
-    cy.get('[data-testid="yaxis-metric-selector"]').should(
-      'contain.text',
-      '每 1 美元 TCO 对应的总 token 数（自有 - 超大规模云大批量）',
-    );
+    cy.get('[data-testid="yaxis-metric-selector"]')
+      .should('contain.text', '每 1 美元 TCO 对应的总 token 数')
+      .and('not.contain.text', '（自有');
+    cy.get('[data-testid="cost-tier-selector"]').should('contain.text', '自有 - 超大规模云大批量');
     cy.get('[data-testid="token-revenue-price-source"]').should('not.exist');
     cy.get('[data-testid="chart-figure"]')
       .first()

--- a/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
+++ b/packages/app/cypress/e2e/overlay-legend-remove.cy.ts
@@ -105,10 +105,7 @@ describe('Official legend X works while an unofficial overlay is loaded', () => 
 
   it('keeps the official SKU hidden when chart metrics change', () => {
     cy.get('[data-testid="yaxis-metric-selector"]').click('right', { force: true });
-    cy.contains(
-      '[data-slot="select-item"]',
-      'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-    ).click({
+    cy.contains('[data-slot="select-item"]', /^Cost per Million Total Tokens$/u).click({
       force: true,
     });
 

--- a/packages/app/cypress/e2e/tokens-per-currency.cy.ts
+++ b/packages/app/cypress/e2e/tokens-per-currency.cy.ts
@@ -16,7 +16,11 @@ describe('Tokens per dollar and agentic controls', () => {
     cy.visit('/inference');
     cy.get('[data-testid="yaxis-metric-selector"]').should(
       'contain.text',
-      'Total Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
+      'Total Tokens per $1 TCO',
+    );
+    cy.get('[data-testid="cost-tier-selector"]').should(
+      'contain.text',
+      'Owning at Large Hyperscaler Volume',
     );
     // The default axis derives from measured throughput and TCO alone, so the
     // token sale price source does not apply and stays hidden.

--- a/packages/app/cypress/e2e/url-params.cy.ts
+++ b/packages/app/cypress/e2e/url-params.cy.ts
@@ -114,10 +114,9 @@ describe('URL Parameter Persistence', () => {
         .then(($inputs) => [...$inputs].map((input) => input.id).toSorted())
         .then((before) => {
           cy.get('[data-testid="yaxis-metric-selector"]').click('right', { force: true });
-          cy.contains(
-            '[data-select-option]',
-            'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-          ).click({ force: true });
+          cy.contains('[data-select-option]', /^Cost per Million Total Tokens$/u).click({
+            force: true,
+          });
 
           cy.get('[data-testid="scatter-quick-filters"]').click();
           cy.get('[data-testid="quick-filter-best-per-sku"]').should(
@@ -175,7 +174,11 @@ describe('URL Parameter Persistence', () => {
 
       cy.get('[data-testid="yaxis-metric-selector"]').should(
         'contain.text',
-        'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
+        'Cost per Million Total Tokens',
+      );
+      cy.get('[data-testid="cost-tier-selector"]').should(
+        'contain.text',
+        'Owning at Large Hyperscaler Volume',
       );
 
       cy.get('[data-testid="scatter-graph"]')
@@ -195,10 +198,7 @@ describe('URL Parameter Persistence', () => {
         .should('contain.text', 'Total Tokens per $1 TCO');
 
       cy.get('[data-testid="yaxis-metric-selector"]').click('right', { force: true });
-      cy.contains(
-        '[data-select-option]',
-        'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-      ).click({
+      cy.contains('[data-select-option]', /^Cost per Million Total Tokens$/u).click({
         force: true,
       });
 
@@ -213,7 +213,11 @@ describe('URL Parameter Persistence', () => {
 
       cy.get('[data-testid="yaxis-metric-selector"]').should(
         'contain.text',
-        'Total Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
+        'Total Tokens per $1 TCO',
+      );
+      cy.get('[data-testid="cost-tier-selector"]').should(
+        'contain.text',
+        'Owning at Large Hyperscaler Volume',
       );
       cy.get('[data-testid="scatter-graph"]')
         .first()

--- a/packages/app/cypress/e2e/yaxis-metrics-render.cy.ts
+++ b/packages/app/cypress/e2e/yaxis-metrics-render.cy.ts
@@ -4,32 +4,37 @@
  * Catches bugs where custom-value metrics (costUser, powerUser) require clicking
  * "Calculate" before data appears.
  */
+const exact = (label: string) =>
+  new RegExp(`^${label.replaceAll(/[$()]/gu, (char) => `\\${char}`)}$`, 'u');
+
 describe('Y-Axis Metrics All Render Data', () => {
-  const metrics = [
-    'Token Throughput per Chip',
-    'Input Token Throughput per Chip',
-    'Output Token Throughput per Chip',
-    'Token Throughput per All in Utility MW',
-    'Input Token Throughput per All in Utility MW',
-    'Output Token Throughput per All in Utility MW',
-    'Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)',
-    'Cost per Million Total Tokens (Rent - 3 Year Commit)',
-    'Cost per Million Output Tokens (Owning at Large Hyperscaler Volume)',
-    'Cost per Million Output Tokens (Rent - 3 Year Commit)',
-    'Cost per Million Input Tokens (Owning at Large Hyperscaler Volume)',
-    'Cost per Million Input Tokens (Rent - 3 Year Commit)',
-    'Total Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    'Total Tokens per $1 TCO (Rent - 3 Year Commit)',
-    'Output Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    'Output Tokens per $1 TCO (Rent - 3 Year Commit)',
-    'Input Tokens per $1 TCO (Owning at Large Hyperscaler Volume)',
-    'Input Tokens per $1 TCO (Rent - 3 Year Commit)',
-    'Cost per Million Total Tokens (Custom User Values)',
-    'Total Tokens per $1 TCO (Custom User Values)',
-    'Token Throughput per All in Utility MW (Custom User Values)',
-    'All-in Provisioned Joules per Total Token',
-    'All-in Provisioned Joules per Output Token',
-    'All-in Provisioned Joules per Input Token',
+  // Tiered metrics are one Y-axis option each; the Cost Tier selector picks
+  // the pricing basis, so those entries name the tier option to click.
+  const metrics: { label: string; tier?: 'hyperscaler' | 'rental' }[] = [
+    { label: 'Token Throughput per Chip' },
+    { label: 'Input Token Throughput per Chip' },
+    { label: 'Output Token Throughput per Chip' },
+    { label: 'Token Throughput per All in Utility MW' },
+    { label: 'Input Token Throughput per All in Utility MW' },
+    { label: 'Output Token Throughput per All in Utility MW' },
+    { label: 'Cost per Million Total Tokens', tier: 'hyperscaler' },
+    { label: 'Cost per Million Total Tokens', tier: 'rental' },
+    { label: 'Cost per Million Output Tokens', tier: 'hyperscaler' },
+    { label: 'Cost per Million Output Tokens', tier: 'rental' },
+    { label: 'Cost per Million Input Tokens', tier: 'hyperscaler' },
+    { label: 'Cost per Million Input Tokens', tier: 'rental' },
+    { label: 'Total Tokens per $1 TCO', tier: 'hyperscaler' },
+    { label: 'Total Tokens per $1 TCO', tier: 'rental' },
+    { label: 'Output Tokens per $1 TCO', tier: 'hyperscaler' },
+    { label: 'Output Tokens per $1 TCO', tier: 'rental' },
+    { label: 'Input Tokens per $1 TCO', tier: 'hyperscaler' },
+    { label: 'Input Tokens per $1 TCO', tier: 'rental' },
+    { label: 'Cost per Million Total Tokens (Custom User Values)' },
+    { label: 'Total Tokens per $1 TCO (Custom User Values)' },
+    { label: 'Token Throughput per All in Utility MW (Custom User Values)' },
+    { label: 'All-in Provisioned Joules per Total Token' },
+    { label: 'All-in Provisioned Joules per Output Token' },
+    { label: 'All-in Provisioned Joules per Input Token' },
   ];
 
   before(() => {
@@ -43,10 +48,15 @@ describe('Y-Axis Metrics All Render Data', () => {
       .should('have.length.greaterThan', 0);
   });
 
-  metrics.forEach((label) => {
-    it(`"${label}" renders scatter points without extra interaction`, () => {
+  metrics.forEach(({ label, tier }) => {
+    const name = tier ? `${label} [${tier}]` : label;
+    it(`"${name}" renders scatter points without extra interaction`, () => {
       cy.get('[data-testid="yaxis-metric-selector"]').click('right', { force: true });
-      cy.get('[data-slot="select-item"]').contains(label).click({ force: true });
+      cy.get('[data-slot="select-item"]').contains(exact(label)).click({ force: true });
+      if (tier) {
+        cy.get('[data-testid="cost-tier-selector"]').click('right', { force: true });
+        cy.get(`[data-testid="cost-tier-${tier}"]`).click({ force: true });
+      }
       cy.get('[data-testid="scatter-graph"]')
         .first()
         .find('svg .dot-group')

--- a/packages/app/src/components/inference/metric-registry.test.ts
+++ b/packages/app/src/components/inference/metric-registry.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   chartDefinitions,
+  COST_METRIC_FAMILIES,
+  costMetricFamily,
   costTierLabel,
+  costTiersForFamily,
   DEFAULT_METRIC_CONFIG_KEY,
   isBenchmarkMetricKey,
   isMeasuredEnergyConfigKey,
@@ -13,6 +16,7 @@ import {
   METRIC_REGISTRY,
   metricChartTitle,
   metricCostTier,
+  metricForCostTier,
   metricOptionTitle,
   resolveMetricConfigKey,
   tokenMetricTypeForConfigKey,
@@ -102,7 +106,7 @@ describe('metric registry', () => {
           metricKeys.includes(metric.slice(2) as (typeof metricKeys)[number]),
       ),
     );
-    expect(tcoGroups).toHaveLength(3);
+    expect(tcoGroups).toHaveLength(1);
     for (const group of tcoGroups) {
       expect(group.label).toContain(' TCO');
       expect(group.labelZh).toContain(' TCO ');
@@ -154,6 +158,44 @@ describe('metric registry', () => {
     expect(interactivity.y_tokensPerDollarH_chartTitle).toBe('Total Tokens per $1 TCO');
     expect(interactivity.y_tokensPerDollarH_costTier).toBe('hyperscaler');
     expect(interactivity.y_tpPerGpu_costTier).toBeUndefined();
+  });
+
+  it('groups tiered metrics into families the Cost Tier selector can swap between', () => {
+    // Every family member carries the tier it is filed under, and every tiered
+    // registry metric belongs to exactly one family.
+    const familyMembers = new Set<string>();
+    for (const [family, members] of Object.entries(COST_METRIC_FAMILIES)) {
+      for (const [tier, metricKey] of Object.entries(members)) {
+        expect(metricCostTier(metricKey), `${family}.${tier}`).toBe(tier);
+        expect(costMetricFamily(metricKey), metricKey).toBe(family);
+        expect(familyMembers.has(metricKey), `${metricKey} listed twice`).toBe(false);
+        familyMembers.add(metricKey);
+      }
+    }
+    for (const metricKey of Object.keys(METRIC_REGISTRY)) {
+      const tiered = metricCostTier(metricKey as keyof typeof METRIC_REGISTRY) !== undefined;
+      expect(familyMembers.has(metricKey), metricKey).toBe(tiered);
+    }
+
+    expect(costMetricFamily('tpPerGpu')).toBeUndefined();
+    expect(costMetricFamily('costUser')).toBe('cost');
+
+    // Selector order: published tiers first, custom last; families without a
+    // custom axis stop at rental.
+    expect(costTiersForFamily('tokensPerDollar')).toEqual(['hyperscaler', 'rental', 'custom']);
+    expect(costTiersForFamily('costOutput')).toEqual(['hyperscaler', 'rental']);
+    expect(metricForCostTier('cost', 'rental')).toBe('costr');
+    expect(metricForCostTier('costInput', 'custom')).toBeUndefined();
+
+    // Family members share a chart title, so the y-axis option can drop the tier.
+    for (const members of Object.values(COST_METRIC_FAMILIES)) {
+      const titles = new Set(
+        Object.entries(members)
+          .filter(([tier]) => tier !== 'custom')
+          .map(([, metricKey]) => metricChartTitle(metricKey, 'en')),
+      );
+      expect(titles.size).toBe(1);
+    }
   });
 
   it('keeps the Measured Energy key list in lockstep with the registry', () => {

--- a/packages/app/src/components/inference/metric-registry.ts
+++ b/packages/app/src/components/inference/metric-registry.ts
@@ -6,8 +6,9 @@ export type RooflineDirection = 'upper_right' | 'upper_left' | 'lower_left' | 'l
 /**
  * Pricing basis behind a cost or purchasing-power metric. The chart heading
  * shows only the metric (`title`); the tier is spelled out separately in the
- * caption's "Cost Tier" line and appended to the y-axis option label so the
- * two variants stay distinguishable in the selector.
+ * caption's "Cost Tier" line and in the Cost Tier selector that sits beside
+ * the y-axis selector. `metricOptionTitle` still appends it for surfaces that
+ * name a single metric out of context (explanations, share text).
  */
 export type CostTier = 'hyperscaler' | 'rental' | 'custom';
 
@@ -400,6 +401,65 @@ export function metricCostTier(metricKey: MetricKey): CostTier | undefined {
   return metric.costTier;
 }
 
+/**
+ * Metrics that price the same quantity at different cost tiers. The y-axis
+ * selector lists one option per family and the Cost Tier selector swaps
+ * between its members, so the tier is not repeated in every option label.
+ * Tiers are listed in selector order.
+ */
+export const COST_METRIC_FAMILIES = {
+  tokensPerDollar: {
+    hyperscaler: 'tokensPerDollarH',
+    rental: 'tokensPerDollarR',
+    custom: 'tokensPerDollarUser',
+  },
+  outputTokensPerDollar: {
+    hyperscaler: 'outputTokensPerDollarH',
+    rental: 'outputTokensPerDollarR',
+  },
+  inputTokensPerDollar: {
+    hyperscaler: 'inputTokensPerDollarH',
+    rental: 'inputTokensPerDollarR',
+  },
+  cost: { hyperscaler: 'costh', rental: 'costr', custom: 'costUser' },
+  costOutput: { hyperscaler: 'costhOutput', rental: 'costrOutput' },
+  costInput: { hyperscaler: 'costhi', rental: 'costri' },
+} as const satisfies Record<string, Partial<Record<CostTier, MetricKey>>>;
+
+export type CostMetricFamilyId = keyof typeof COST_METRIC_FAMILIES;
+
+export const COST_TIER_ORDER: readonly CostTier[] = ['hyperscaler', 'rental', 'custom'];
+
+const COST_METRIC_FAMILY_BY_METRIC: ReadonlyMap<MetricKey, CostMetricFamilyId> = new Map(
+  (
+    Object.entries(COST_METRIC_FAMILIES) as [
+      CostMetricFamilyId,
+      Partial<Record<CostTier, MetricKey>>,
+    ][]
+  ).flatMap(([family, members]) =>
+    Object.values(members).map((metricKey) => [metricKey, family] as const),
+  ),
+);
+
+/** Family a tiered metric belongs to, or `undefined` for untiered metrics. */
+export function costMetricFamily(metricKey: MetricKey): CostMetricFamilyId | undefined {
+  return COST_METRIC_FAMILY_BY_METRIC.get(metricKey);
+}
+
+/** The family member priced at `tier`, or `undefined` when it publishes none. */
+export function metricForCostTier(
+  family: CostMetricFamilyId,
+  tier: CostTier,
+): MetricKey | undefined {
+  const members: Partial<Record<CostTier, MetricKey>> = COST_METRIC_FAMILIES[family];
+  return members[tier];
+}
+
+/** Tiers a family publishes, in selector order. */
+export function costTiersForFamily(family: CostMetricFamilyId): CostTier[] {
+  return COST_TIER_ORDER.filter((tier) => metricForCostTier(family, tier) !== undefined);
+}
+
 /** Caption "Cost Tier" value for a tier. */
 export function costTierLabel(tier: CostTier, locale: 'en' | 'zh'): string {
   return locale === 'zh' ? COST_TIER_LABELS[tier].labelZh : COST_TIER_LABELS[tier].label;
@@ -540,35 +600,25 @@ export const METRIC_CONTROL_GROUPS: readonly MetricControlGroup[] = [
     labelZh: '每 GPU 小时 token 收入',
     metrics: ['y_tokenRevenuePerGpuHour'],
   },
+  // Tiered metrics list both published tiers here so every registry key stays
+  // reachable from the controls; the y-axis selector shows one option per
+  // metric family and the Cost Tier selector picks the tier.
   {
-    label: 'Total Tokens per $1 TCO',
-    labelZh: '每 1 美元 TCO 对应的总 token 数',
-    metrics: ['y_tokensPerDollarH', 'y_tokensPerDollarR'],
+    label: 'Tokens per $1 TCO',
+    labelZh: '每 1 美元 TCO 对应的 token 数',
+    metrics: [
+      'y_tokensPerDollarH',
+      'y_tokensPerDollarR',
+      'y_outputTokensPerDollarH',
+      'y_outputTokensPerDollarR',
+      'y_inputTokensPerDollarH',
+      'y_inputTokensPerDollarR',
+    ],
   },
   {
-    label: 'Output Tokens per $1 TCO',
-    labelZh: '每 1 美元 TCO 对应的输出 token 数',
-    metrics: ['y_outputTokensPerDollarH', 'y_outputTokensPerDollarR'],
-  },
-  {
-    label: 'Input Tokens per $1 TCO',
-    labelZh: '每 1 美元 TCO 对应的输入 token 数',
-    metrics: ['y_inputTokensPerDollarH', 'y_inputTokensPerDollarR'],
-  },
-  {
-    label: 'Cost per Million Total Tokens',
-    labelZh: '每百万总 token 成本',
-    metrics: ['y_costh', 'y_costr'],
-  },
-  {
-    label: 'Cost per Million Output Tokens',
-    labelZh: '每百万输出 token 成本',
-    metrics: ['y_costhOutput', 'y_costrOutput'],
-  },
-  {
-    label: 'Cost per Million Input Tokens',
-    labelZh: '每百万输入 token 成本',
-    metrics: ['y_costhi', 'y_costri'],
+    label: 'Cost per Million Tokens',
+    labelZh: '每百万 token 成本',
+    metrics: ['y_costh', 'y_costr', 'y_costhOutput', 'y_costrOutput', 'y_costhi', 'y_costri'],
   },
   {
     label: 'All-in Provisioned Energy per Token',

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -38,11 +38,18 @@ import { SearchableSelect } from '@/components/ui/searchable-select';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { MobileControlSection } from '@/components/ui/mobile-control-section';
 import {
+  COST_TIER_LABELS,
   METRIC_CONTROL_GROUPS,
   METRIC_REGISTRY,
+  costMetricFamily,
+  costTiersForFamily,
+  isMetricKey,
   metricChartTitle,
   metricCostTier,
+  metricForCostTier,
   metricOptionTitle,
+  type CostMetricFamilyId,
+  type CostTier,
   type MetricKey,
 } from '@/components/inference/metric-registry';
 import { lockedTierLabel, lockedTierValue } from '@/components/ui/locked-rent-tiers';
@@ -75,6 +82,9 @@ const STRINGS = {
     yAxisMetric: 'Y-Axis Metric',
     yAxisMetricTooltip:
       "The performance metric displayed on the chart's Y-axis. Options include throughput, token revenue per GPU hour, cost per million tokens, tokens per $1 TCO, and custom user-defined values.",
+    costTier: 'Cost Tier',
+    costTierTooltip:
+      'The $/chip/hr pricing basis behind cost and tokens-per-dollar metrics. InferenceX publishes Owning at Large Hyperscaler Volume and Rent - 3 Year Commit; the shorter rental terms are priced in the SemiAnalysis AI Cloud TCO Model.',
     xAxisMetric: 'X-Axis Metric',
     xAxisMetricTooltip:
       "The latency metric displayed on the chart's X-axis: P90 Time To First Token.",
@@ -117,6 +127,9 @@ const STRINGS = {
     yAxisMetric: 'Y 轴指标',
     yAxisMetricTooltip:
       '图表 Y 轴显示的性能指标，包括吞吐量、每 GPU 小时 token 收入、每百万 token 成本、每 1 美元 TCO 对应的 token 数以及自定义值。',
+    costTier: '成本层级',
+    costTierTooltip:
+      '成本类和每美元 token 数指标所依据的 $/芯片/小时 价格口径。InferenceX 公开自有（超大规模云大批量）与租赁 - 3 年承诺两档；更短租期的价格收录在 SemiAnalysis AI Cloud TCO 模型中。',
     xAxisMetric: 'X 轴指标',
     xAxisMetricTooltip: '图表 X 轴显示的延迟指标：P90 Time To First Token。',
     xAxisScale: 'X 轴刻度',
@@ -152,8 +165,10 @@ const STRINGS = {
 
 const METRIC_GROUPS = METRIC_CONTROL_GROUPS;
 
-// Option labels carry the cost tier ("… (Owning at Large Hyperscaler Volume)") so the
-// pricing variants read apart in the selector; the chart heading drops it.
+// Full option titles carry the cost tier ("… (Owning at Large Hyperscaler
+// Volume)"). The y-axis selector collapses the published tiers of a metric
+// into one option and hands the tier to the Cost Tier selector, so these maps
+// serve analytics labels and the Custom User Values entries.
 const METRIC_TITLE_MAP = new Map(
   (Object.keys(METRIC_REGISTRY) as MetricKey[]).map((key) => [
     `y_${key}`,
@@ -245,46 +260,86 @@ export default function ChartControls({
   );
   // Locked rental tiers open the TCO model dialog instead of changing the axis.
   const { interceptLocked: interceptLockedTier, dialog: tcoModelDialog } =
-    useLockedTierDialog('yaxis_metric');
+    useLockedTierDialog('yaxis_cost_tier');
+
+  const selectedMetricKey = selectedYAxisMetric.replace(/^y_/u, '');
+  const selectedFamily: CostMetricFamilyId | undefined = isMetricKey(selectedMetricKey)
+    ? costMetricFamily(selectedMetricKey)
+    : undefined;
+  const selectedTier: CostTier | undefined = isMetricKey(selectedMetricKey)
+    ? metricCostTier(selectedMetricKey)
+    : undefined;
+  // Switching metric keeps the published tier the reader is on. Custom values
+  // keep their own y-axis entries, so from there other metrics open on the
+  // dashboard default tier.
+  const carriedTier: CostTier =
+    selectedTier && selectedTier !== 'custom' ? selectedTier : 'hyperscaler';
+
   const groupedYAxisOptions = useMemo(
     () =>
       visibleGroups
         .map((group) => {
-          const options = group.metrics
-            .filter((m) => METRIC_TITLE_MAP.has(m))
-            .map((m) => ({
-              value: m,
-              help: <MetricExplanation metricKey={m.replace(/^y_/u, '') as MetricKey} />,
-              label:
-                (locale === 'zh' ? METRIC_TITLE_ZH_MAP.get(m) : undefined) ??
-                METRIC_TITLE_MAP.get(m)!,
-            }));
-          // Groups that publish a Rent - 3 Year Commit axis also list the
-          // shorter-commit rental tiers, locked, so readers can see which
-          // pricing bases exist and where they are published.
-          const rentalMetric = group.metrics
-            .map((m) => m.replace(/^y_/u, '') as MetricKey)
-            .find((key) => METRIC_TITLE_MAP.has(`y_${key}`) && metricCostTier(key) === 'rental');
-          const lockedOptions = rentalMetric
-            ? LOCKED_RENT_TIERS.map((tier) => {
-                const title = metricChartTitle(rentalMetric, locale);
-                const tierLabel = lockedTierLabel(tier, locale);
-                return {
-                  value: lockedTierValue(tier.id, rentalMetric),
-                  label: locale === 'zh' ? `${title}（${tierLabel}）` : `${title} (${tierLabel})`,
-                  badge: <LockedTierBadge className="mt-0.5" />,
-                  testId: `yaxis-locked-${tier.id}-${rentalMetric}`,
-                };
-              })
-            : [];
+          const seenFamilies = new Set<CostMetricFamilyId>();
+          const options = group.metrics.flatMap((m) => {
+            if (!METRIC_TITLE_MAP.has(m)) return [];
+            const key = m.replace(/^y_/u, '') as MetricKey;
+            const family = costMetricFamily(key);
+            if (family && metricCostTier(key) !== 'custom') {
+              // Published tiers collapse into one option per metric family.
+              // The option tracks the tier in force so the selection
+              // highlight follows the metric; the Cost Tier selector
+              // beside this one changes the pricing basis.
+              if (seenFamilies.has(family)) return [];
+              seenFamilies.add(family);
+              const tieredKey = metricForCostTier(family, carriedTier) ?? key;
+              return [
+                {
+                  value: `y_${tieredKey}`,
+                  help: <MetricExplanation metricKey={tieredKey} />,
+                  label: metricChartTitle(key, locale),
+                },
+              ];
+            }
+            return [
+              {
+                value: m,
+                help: <MetricExplanation metricKey={key} />,
+                label:
+                  (locale === 'zh' ? METRIC_TITLE_ZH_MAP.get(m) : undefined) ??
+                  METRIC_TITLE_MAP.get(m)!,
+              },
+            ];
+          });
           return {
             groupLabel: locale === 'zh' ? group.labelZh : group.label,
-            options: [...options, ...lockedOptions],
+            options,
           };
         })
         .filter((g) => g.options.length > 0),
-    [visibleGroups, locale],
+    [visibleGroups, locale, carriedTier],
   );
+
+  // Cost Tier options for the selected metric family: the published tiers
+  // first, in registry order, then the shorter rental terms locked behind the
+  // TCO model dialog.
+  const costTierOptions = useMemo(() => {
+    if (!selectedFamily) return [];
+    const published = costTiersForFamily(selectedFamily).map((tier) => ({
+      value: `y_${metricForCostTier(selectedFamily, tier)!}`,
+      label: locale === 'zh' ? COST_TIER_LABELS[tier].optionZh : COST_TIER_LABELS[tier].option,
+      testId: `cost-tier-${tier}`,
+    }));
+    const rentalMetric = metricForCostTier(selectedFamily, 'rental');
+    const locked = rentalMetric
+      ? LOCKED_RENT_TIERS.map((tier) => ({
+          value: lockedTierValue(tier.id, rentalMetric),
+          label: lockedTierLabel(tier, locale),
+          badge: <LockedTierBadge className="mt-0.5" />,
+          testId: `cost-tier-locked-${tier.id}`,
+        }))
+      : [];
+    return [...published, ...locked];
+  }, [selectedFamily, locale]);
 
   const trackCombinedFilters = () => {
     if (selectedModel && selectedSequence && selectedPrecisions.length > 0 && selectedYAxisMetric) {
@@ -340,6 +395,20 @@ export default function ChartControls({
       metric: value,
       metric_label: METRIC_TITLE_MAP.get(value) ?? value,
       metric_group: metricGroupMap.get(value) ?? 'Unknown',
+    });
+    setTimeout(trackCombinedFilters, 0);
+  };
+
+  const costTierVisible = mounted && selectedFamily !== undefined;
+
+  const handleCostTierChange = (value: string) => {
+    if (interceptLockedTier(value)) return;
+    setSelectedYAxisMetric(value);
+    const tierKey = value.replace(/^y_/u, '');
+    track('inference_cost_tier_selected', {
+      metric: value,
+      cost_tier: (isMetricKey(tierKey) ? metricCostTier(tierKey) : undefined) ?? 'unknown',
+      metric_label: METRIC_TITLE_MAP.get(value) ?? value,
     });
     setTimeout(trackCombinedFilters, 0);
   };
@@ -494,6 +563,34 @@ export default function ChartControls({
                 <div className="flex min-w-0 w-full max-w-48 flex-col gap-1.5 sm:col-span-2 xl:col-span-1">
                   <LabelWithTooltip label={t.tcoBasis} tooltip={t.tcoBasisTooltip} />
                   <TcoBasisToggle source={tcoSource} className="md:h-9" />
+                </div>
+              )}
+
+              {/* Cost Tier swaps the selected metric between its pricing
+                bases. It sits under the y-axis selector, in its column, so it
+                reads as part of the metric choice. It only appears for tiered
+                metrics, so it waits for mount like the Token Price Source
+                block: the selected metric resolves client-side from the URL
+                and persisted state. */}
+              {costTierVisible && (
+                <div
+                  className={`flex min-w-0 max-w-sm flex-col space-y-1.5 ${showXAxisMode ? 'sm:col-start-2' : 'sm:col-span-2'}`}
+                >
+                  <LabelWithTooltip
+                    htmlFor="cost-tier-select"
+                    label={t.costTier}
+                    tooltip={t.costTierTooltip}
+                  />
+                  <SearchableSelect
+                    triggerId="cost-tier-select"
+                    triggerTestId="cost-tier-selector"
+                    value={selectedYAxisMetric}
+                    onValueChange={handleCostTierChange}
+                    placeholder={t.costTier}
+                    searchable={false}
+                    trackPrefix="cost_tier"
+                    groups={[{ label: '', options: costTierOptions }]}
+                  />
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

The Y-Axis Metric dropdown on `/inference` listed every pricing basis as its own entry: `Cost per Million Total Tokens (Owning at Large Hyperscaler Volume)`, `(Rent - 3 Year Commit)`, five locked rental terms, and the same again for output, input, and the three tokens-per-dollar metrics. That was 40+ rows for what is really 6 metrics times a pricing basis.

This PR collapses each tiered metric into a single Y-axis option and moves the pricing basis into a `Cost Tier` selector directly under the Y-axis control.

### Behaviour

- `Cost Tier` appears only when the selected metric has a pricing basis (cost per million tokens, tokens per $1 TCO). It stays hidden for throughput, latency, energy, and other untiered metrics.
- Options, in order: `Owning at Large Hyperscaler Volume`, `Rent - 3 Year Commit`, `Custom User Values`, then the five locked rental terms with the existing lock badge. Picking a locked term opens the TCO model dialog and leaves the axis unchanged (same flow as #1074).
- The tier carries across metrics: on `Total Tokens per $1 TCO` at `Rent - 3 Year Commit`, switching to `Cost per Million Output Tokens` lands on `y_costrOutput`. Coming from an untiered metric or a custom axis opens on the hyperscaler tier, which matches the previous default.
- Metric keys, `i_metric` URL params, chart captions, and the `Cost Tier: ...` chart subtitle are unchanged. Only the dropdown structure changes.
- The six single-option cost groups in the Y-axis menu are merged into two (`Tokens per $1 TCO`, `Cost per Million Tokens`) so the menu no longer shows a heading per option.

### Implementation

- `metric-registry.ts`: adds `COST_METRIC_FAMILIES`, `COST_TIER_ORDER`, `costMetricFamily()`, `metricForCostTier()`, and `costTiersForFamily()`. Existing metric keys and `COST_TIER_LABELS` are reused.
- `ChartControls.tsx`: `groupedYAxisOptions` emits one option per family (value follows the active tier); new `Cost Tier` `SearchableSelect` with `data-testid="cost-tier-selector"` and per-option ids `cost-tier-hyperscaler|rental|custom|locked-<id>`. Locked-tier dialog source renamed `yaxis_metric` to `yaxis_cost_tier`; new analytics event `inference_cost_tier_selected`.
- Removed test ids: `yaxis-locked-<tier>-<metric>`.

### Tests

- `metric-registry.test.ts`: family/tier round-trip coverage (33 tests pass).
- `inference-chart-controls.cy.tsx`: 55 component tests pass, including tier order, lock dialog, custom axis, and tier carry-over.
- e2e updated for the new labels: `yaxis-metrics-render`, `url-params`, `inference-chart`, `tokens-per-currency`, `gradient-labels`, `overlay-legend-remove` (106 tests pass against `E2E_FIXTURES=1`).
- `bun run fmt`, `lint`, `typecheck`, `check:typography` clean.

## 中文说明

`/inference` 页面的 Y 轴指标下拉菜单此前把每个成本层级都列为独立选项（自有 - 超大规模云大批量、租赁 - 3 年承诺、五个锁定的租赁期限），六个成本类指标合计 40 多行。

本 PR 把每个分层指标合并为一个 Y 轴选项，并在 Y 轴控件下方新增「成本层级」选择器来切换计价基准。

- 仅当所选指标带有计价基准（每百万 token 成本、每 1 美元 TCO 对应的 token 数）时显示「成本层级」；吞吐量、延迟、能耗等指标不显示。
- 选项顺序：自有 - 超大规模云大批量、租赁 - 3 年承诺、自定义值，然后是五个带锁定标记的租赁期限。选择锁定期限会打开 TCO 模型对话框，Y 轴不变。
- 切换指标时保留当前层级；从无层级指标或自定义轴切换时默认进入超大规模云层级。
- 指标 key、`i_metric` URL 参数、图表标题和「成本层级：…」副标题均不变。
- 单元测试、组件测试、端到端测试已同步更新并通过；fmt、lint、typecheck、check:typography 均通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core inference chart filter state and metric selection UX on a high-traffic page, though persisted metric keys and URL params stay the same.
> 
> **Overview**
> **Splits pricing basis from the Y-axis metric** on `/inference`: tiered cost and tokens-per-dollar axes now appear once in the Y-axis dropdown (no hyperscaler/rental suffix), with a new **Cost Tier** control under the metric selector for hyperscaler, 3-year rent, custom values, and locked shorter rental terms (still opening the TCO model dialog without changing the axis).
> 
> **`metric-registry`** adds `COST_METRIC_FAMILIES` and helpers (`costMetricFamily`, `metricForCostTier`, `costTiersForFamily`) and **merges six TCO menu groups into two** (`Tokens per $1 TCO`, `Cost per Million Tokens`). **`ChartControls`** builds collapsed Y-axis options from families (preserving the active tier when switching metrics), wires `cost-tier-selector`, moves locked-tier interception from the Y-axis to cost tier, and emits `inference_cost_tier_selected`.
> 
> **Metric keys, `i_metric` URLs, chart titles, and caption cost-tier lines are unchanged**; Cypress component/e2e and `metric-registry.test.ts` are updated for the new selectors and labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c4621cb4368f364f577e79f0a83152a1caafac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->