### PR TITLE
Halloween jumpscare within 10 s of the first interaction / 首次交互后 10 秒内触发的万圣节惊吓彩蛋

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 @import './motion.css';
+@import '../components/jumpscare/jumpscare.css';
 @plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *, .minecraft *));

--- a/packages/app/src/app/layout.tsx
+++ b/packages/app/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { Footer } from '@/components/footer/footer';
 import { Header } from '@/components/header/header';
 import { RouteTransition } from '@/components/motion/route-transition';
 import { JsonLd } from '@/components/json-ld';
+import { Jumpscare } from '@/components/jumpscare/jumpscare';
 import { CircuitBackground } from '@/components/circuit-background';
 import { MinecraftBackgroundLazy } from '@/components/minecraft/minecraft-background-lazy';
 import { MinecraftDecorations } from '@/components/minecraft/minecraft-decorations';
@@ -230,6 +231,7 @@ export default async function RootLayout({
                 <RouteTransition>{children}</RouteTransition>
               </div>
               <Footer starCount={starCount} />
+              <Jumpscare />
             </ThemeProvider>
           </QueryProvider>
           {process.env.VERCEL && <Analytics />}

--- a/packages/app/src/components/jumpscare/jumpscare-face.tsx
+++ b/packages/app/src/components/jumpscare/jumpscare-face.tsx
@@ -1,0 +1,102 @@
+/**
+ * The thing that lunges at you. Hand-drawn SVG so the scare ships with no
+ * image asset: a gaunt, off-white face with hollowed sockets, pinpoint red
+ * pupils, and a grin that is far too wide. Rendered three times by the overlay
+ * (base + two tinted glitch ghosts), so it takes an optional className only.
+ */
+export function JumpscareFace({
+  className,
+  'data-tint': tint,
+}: {
+  className?: string;
+  'data-tint'?: 'red' | 'cyan';
+}) {
+  const suffix = tint ? `-${tint}` : '';
+  const gradientId = `jumpscare-skin${suffix}`;
+  const glowId = `jumpscare-glow${suffix}`;
+  return (
+    <svg
+      className={className}
+      data-tint={tint}
+      viewBox="0 0 400 480"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <defs>
+        <radialGradient id={gradientId} cx="50%" cy="38%" r="68%">
+          <stop offset="0%" stopColor="#ece4d6" />
+          <stop offset="55%" stopColor="#c9bfae" />
+          <stop offset="100%" stopColor="#5a4f46" />
+        </radialGradient>
+        <filter id={glowId} x="-100%" y="-100%" width="300%" height="300%">
+          <feGaussianBlur stdDeviation="6" />
+        </filter>
+      </defs>
+
+      {/* Skull-like head, slightly asymmetric on purpose. */}
+      <path
+        d="M200 18 C 96 18, 46 96, 50 196 C 53 276, 82 336, 118 386 C 146 426, 168 462, 200 466 C 236 462, 258 424, 286 384 C 322 334, 352 272, 352 194 C 354 96, 304 18, 200 18 Z"
+        fill={`url(#${gradientId})`}
+      />
+
+      {/* Cracks */}
+      <g stroke="#2a221d" strokeWidth="2.5" fill="none" strokeLinecap="round" opacity="0.85">
+        <path d="M118 72 L 138 104 L 128 128 L 146 150" />
+        <path d="M296 60 L 280 98 L 292 118" />
+        <path d="M84 250 L 112 262 L 104 290" />
+        <path d="M322 236 L 300 258 L 312 284 L 296 300" />
+      </g>
+
+      {/* Eye sockets */}
+      <ellipse cx="136" cy="186" rx="52" ry="58" fill="#050505" />
+      <ellipse cx="266" cy="176" rx="58" ry="66" fill="#050505" />
+
+      {/* Red pupils */}
+      <g className="jumpscare-eye-glow">
+        <circle cx="138" cy="190" r="16" fill="#ff1010" filter={`url(#${glowId})`} />
+        <circle cx="268" cy="182" r="19" fill="#ff1010" filter={`url(#${glowId})`} />
+      </g>
+      <circle cx="138" cy="190" r="6" fill="#ff5c5c" />
+      <circle cx="268" cy="182" r="7" fill="#ff5c5c" />
+
+      {/* Nose slits */}
+      <path d="M190 262 L 182 296 L 194 302 Z" fill="#0a0806" />
+      <path d="M212 262 L 220 296 L 208 302 Z" fill="#0a0806" />
+
+      {/* Grin — mouth cavity */}
+      <path
+        d="M78 322 C 120 300, 280 300, 328 322 C 312 392, 262 428, 200 434 C 138 428, 92 392, 78 322 Z"
+        fill="#050303"
+      />
+
+      {/* Upper teeth */}
+      <g fill="#efe7d8">
+        <polygon points="92,326 110,322 108,352" />
+        <polygon points="114,320 134,316 130,366" />
+        <polygon points="140,315 160,313 156,378" />
+        <polygon points="166,312 186,311 182,388" />
+        <polygon points="192,311 212,311 206,392" />
+        <polygon points="218,311 238,312 232,386" />
+        <polygon points="244,313 264,316 258,376" />
+        <polygon points="270,317 290,321 284,362" />
+        <polygon points="296,323 312,328 306,350" />
+      </g>
+
+      {/* Lower teeth */}
+      <g fill="#d8cfbe">
+        <polygon points="118,404 134,412 138,372" />
+        <polygon points="146,414 166,422 168,378" />
+        <polygon points="176,424 196,428 198,384" />
+        <polygon points="204,428 224,424 222,384" />
+        <polygon points="232,422 252,414 248,378" />
+        <polygon points="260,412 278,402 272,372" />
+      </g>
+
+      {/* Blood at the corners */}
+      <g fill="#8f0a0a">
+        <path d="M84 330 C 80 356, 72 380, 84 402 C 92 386, 92 358, 84 330 Z" />
+        <path d="M318 328 C 326 354, 332 376, 322 400 C 312 384, 312 356, 318 328 Z" />
+      </g>
+    </svg>
+  );
+}

--- a/packages/app/src/components/jumpscare/jumpscare.css
+++ b/packages/app/src/components/jumpscare/jumpscare.css
@@ -1,0 +1,287 @@
+/* Jumpscare overlay — Halloween easter egg. Mounted only while firing (≈1.9 s),
+ * so none of this costs anything on a normal page. Deliberately breaks the
+ * "transform/opacity only" motion rule: it is supposed to feel wrong.
+ * Reduced-motion users never reach this code path (gated in jumpscare.ts). */
+
+.jumpscare-root {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483000;
+  overflow: hidden;
+  background: #000;
+  pointer-events: none;
+  animation: jumpscare-root 1.9s linear forwards;
+  contain: strict;
+}
+
+@keyframes jumpscare-root {
+  0%,
+  82% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.jumpscare-static {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0.32;
+  image-rendering: pixelated;
+  mix-blend-mode: screen;
+}
+
+.jumpscare-flash {
+  position: absolute;
+  inset: 0;
+  background: #fff;
+  animation: jumpscare-flash 1.9s steps(1, end) forwards;
+}
+
+@keyframes jumpscare-flash {
+  0% {
+    opacity: 1;
+    background: #fff;
+  }
+  4% {
+    opacity: 0;
+  }
+  9% {
+    opacity: 0.9;
+    background: #ff0a0a;
+  }
+  13% {
+    opacity: 0;
+  }
+  21% {
+    opacity: 0.7;
+    background: #fff;
+  }
+  24% {
+    opacity: 0;
+  }
+  46% {
+    opacity: 0.55;
+    background: #ff0a0a;
+  }
+  49% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.jumpscare-vignette {
+  position: absolute;
+  inset: -10%;
+  background: radial-gradient(ellipse at center, transparent 35%, rgba(0, 0, 0, 0.92) 78%);
+}
+
+.jumpscare-stage {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  animation: jumpscare-shake 0.09s steps(2, jump-none) infinite;
+}
+
+@keyframes jumpscare-shake {
+  0% {
+    transform: translate(-14px, 9px) rotate(-1.2deg);
+  }
+  25% {
+    transform: translate(11px, -13px) rotate(0.8deg);
+  }
+  50% {
+    transform: translate(-9px, -6px) rotate(1.4deg);
+  }
+  75% {
+    transform: translate(13px, 10px) rotate(-0.7deg);
+  }
+  100% {
+    transform: translate(-14px, 9px) rotate(-1.2deg);
+  }
+}
+
+.jumpscare-face-wrap {
+  position: relative;
+  width: min(78vmin, 640px);
+  aspect-ratio: 5 / 6;
+  animation: jumpscare-lunge 1.9s cubic-bezier(0.1, 1.4, 0.3, 1) forwards;
+  transform-origin: 50% 45%;
+  filter: drop-shadow(0 0 40px rgba(255, 0, 0, 0.55));
+}
+
+@keyframes jumpscare-lunge {
+  0% {
+    transform: translateY(45%) scale(0.08);
+    opacity: 0;
+  }
+  3% {
+    opacity: 1;
+  }
+  14% {
+    transform: translateY(0) scale(1.22);
+  }
+  30% {
+    transform: translateY(-2%) scale(1.1);
+  }
+  80% {
+    transform: translateY(-4%) scale(1.3);
+  }
+  100% {
+    transform: translateY(-12%) scale(1.7);
+  }
+}
+
+.jumpscare-face {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+/* Chromatic-aberration ghosts: same SVG, tinted, sliced and shoved sideways. */
+.jumpscare-face-ghost {
+  mix-blend-mode: screen;
+  opacity: 0.85;
+}
+
+.jumpscare-face-ghost[data-tint='red'] {
+  filter: sepia(1) saturate(12) hue-rotate(-40deg) brightness(0.9);
+  animation: jumpscare-glitch-red 0.35s steps(1, end) infinite;
+}
+
+.jumpscare-face-ghost[data-tint='cyan'] {
+  filter: sepia(1) saturate(10) hue-rotate(140deg) brightness(0.9);
+  animation: jumpscare-glitch-cyan 0.41s steps(1, end) infinite;
+}
+
+@keyframes jumpscare-glitch-red {
+  0% {
+    transform: translate(-12px, 0);
+    clip-path: inset(8% 0 62% 0);
+  }
+  20% {
+    transform: translate(9px, 3px);
+    clip-path: inset(44% 0 12% 0);
+  }
+  40% {
+    transform: translate(-6px, -4px);
+    clip-path: inset(0 0 78% 0);
+  }
+  60% {
+    transform: translate(14px, 2px);
+    clip-path: inset(66% 0 4% 0);
+  }
+  80% {
+    transform: translate(-10px, 5px);
+    clip-path: inset(22% 0 40% 0);
+  }
+  100% {
+    transform: translate(-12px, 0);
+    clip-path: inset(8% 0 62% 0);
+  }
+}
+
+@keyframes jumpscare-glitch-cyan {
+  0% {
+    transform: translate(11px, 2px);
+    clip-path: inset(50% 0 20% 0);
+  }
+  25% {
+    transform: translate(-8px, -3px);
+    clip-path: inset(10% 0 70% 0);
+  }
+  50% {
+    transform: translate(13px, 4px);
+    clip-path: inset(30% 0 45% 0);
+  }
+  75% {
+    transform: translate(-13px, 0);
+    clip-path: inset(72% 0 0 0);
+  }
+  100% {
+    transform: translate(11px, 2px);
+    clip-path: inset(50% 0 20% 0);
+  }
+}
+
+.jumpscare-eye-glow {
+  animation: jumpscare-eye 0.18s ease-in-out infinite alternate;
+}
+
+@keyframes jumpscare-eye {
+  from {
+    opacity: 0.55;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.jumpscare-scanlines {
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 0 2px,
+    rgba(0, 0, 0, 0.45) 2px 4px
+  );
+  animation: jumpscare-scan 0.3s linear infinite;
+}
+
+@keyframes jumpscare-scan {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(4px);
+  }
+}
+
+.jumpscare-text {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: clamp(24px, 8vh, 96px);
+  padding: 0 6vw;
+  text-align: center;
+  text-wrap: balance;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', 'Noto Sans Mono CJK SC',
+    monospace;
+  font-weight: 700;
+  font-size: clamp(1rem, 2.6vw, 2.1rem);
+  line-height: 1.25;
+  letter-spacing: 0.08em;
+  color: #ff1a1a;
+  text-shadow:
+    0 0 12px #f00,
+    3px 0 0 rgba(0, 255, 255, 0.7),
+    -3px 0 0 rgba(255, 0, 0, 0.9);
+  animation: jumpscare-text 1.9s steps(1, end) forwards;
+}
+
+@keyframes jumpscare-text {
+  0%,
+  17% {
+    opacity: 0;
+  }
+  18%,
+  26% {
+    opacity: 1;
+  }
+  27%,
+  30% {
+    opacity: 0;
+  }
+  31%,
+  100% {
+    opacity: 1;
+  }
+}

--- a/packages/app/src/components/jumpscare/jumpscare.test.tsx
+++ b/packages/app/src/components/jumpscare/jumpscare.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Jumpscare } from '@/components/jumpscare/jumpscare';
+import {
+  JUMPSCARE_DURATION_MS,
+  JUMPSCARE_MAX_DELAY_MS,
+  JUMPSCARE_MIN_DELAY_MS,
+  JUMPSCARE_STORAGE_KEY,
+} from '@/lib/jumpscare';
+
+const localeState = vi.hoisted(() => ({ pathname: '/' }));
+const analytics = vi.hoisted(() => ({ track: vi.fn() }));
+const audio = vi.hoisted(() => ({
+  unlockJumpscareAudio: vi.fn(() => null),
+  playJumpscareSound: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => localeState.pathname,
+}));
+vi.mock('@/lib/analytics', () => analytics);
+vi.mock('@/lib/jumpscare-audio', () => audio);
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setReducedMotion(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) =>
+      ({
+        matches: query.includes('reduced-motion') ? matches : false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  });
+}
+
+function setSearch(search: string) {
+  window.history.replaceState(null, '', `${localeState.pathname}${search}`);
+}
+
+function overlay() {
+  return document.querySelector('[data-testid="jumpscare"]');
+}
+
+function interact() {
+  act(() => {
+    document.body.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  localeState.pathname = '/';
+  setSearch('');
+  setReducedMotion(false);
+  localStorage.clear();
+  analytics.track.mockClear();
+  audio.unlockJumpscareAudio.mockClear();
+  audio.playJumpscareSound.mockClear();
+  Object.defineProperty(navigator, 'webdriver', { configurable: true, value: false });
+  // jsdom has no canvas backend; the overlay must cope with a null 2D context.
+  HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as never;
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function mount() {
+  act(() => root.render(<Jumpscare />));
+}
+
+const MID_DELAY = Math.round((JUMPSCARE_MIN_DELAY_MS + JUMPSCARE_MAX_DELAY_MS) / 2);
+
+describe('Jumpscare', () => {
+  it('renders nothing until the visitor interacts, then fires within ten seconds', () => {
+    mount();
+    expect(overlay()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(overlay()).toBeNull();
+    expect(audio.unlockJumpscareAudio).not.toHaveBeenCalled();
+
+    interact();
+    expect(audio.unlockJumpscareAudio).toHaveBeenCalledTimes(1);
+    expect(overlay()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(MID_DELAY - 1);
+    });
+    expect(overlay()).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    const node = overlay();
+    expect(node).not.toBeNull();
+    expect(node?.getAttribute('aria-hidden')).toBe('true');
+    expect(node?.querySelector('svg')).not.toBeNull();
+    expect(node?.querySelector('[data-testid="jumpscare-caption"]')?.textContent).toContain(
+      'IT IS BEHIND YOU',
+    );
+    expect(audio.playJumpscareSound).toHaveBeenCalledTimes(1);
+    expect(analytics.track).toHaveBeenCalledWith(
+      'jumpscare_fired',
+      expect.objectContaining({ forced: false, pathname: '/' }),
+    );
+    expect(localStorage.getItem(JUMPSCARE_STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('tears itself down after the animation and does not re-arm', () => {
+    mount();
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(MID_DELAY);
+    });
+    expect(overlay()).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(JUMPSCARE_DURATION_MS);
+    });
+    expect(overlay()).toBeNull();
+
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(JUMPSCARE_MAX_DELAY_MS + 1);
+    });
+    expect(overlay()).toBeNull();
+    expect(analytics.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('only listens for the first activation gesture', () => {
+    mount();
+    interact();
+    interact();
+    act(() => {
+      document.body.dispatchEvent(new Event('keydown', { bubbles: true }));
+    });
+    expect(audio.unlockJumpscareAudio).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the Chinese caption on /zh pages', () => {
+    localeState.pathname = '/zh';
+    setSearch('');
+    mount();
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(MID_DELAY);
+    });
+    expect(overlay()?.querySelector('[data-testid="jumpscare-caption"]')?.textContent).toContain(
+      '它就在你身后',
+    );
+  });
+
+  const quietCases: [string, () => void][] = [
+    ['on cooldown', () => localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(Date.now()))],
+    ['under reduced motion', () => setReducedMotion(true)],
+    [
+      'inside a partner embed',
+      () => {
+        localeState.pathname = '/embed/inference';
+        setSearch('');
+      },
+    ],
+    [
+      'under browser automation',
+      () => Object.defineProperty(navigator, 'webdriver', { configurable: true, value: true }),
+    ],
+  ];
+
+  it.each(quietCases)('stays quiet %s', (_name, arrange) => {
+    arrange();
+    mount();
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(JUMPSCARE_MAX_DELAY_MS + 1);
+    });
+    expect(overlay()).toBeNull();
+    expect(audio.unlockJumpscareAudio).not.toHaveBeenCalled();
+  });
+
+  it('?jumpscare=1 forces it past the cooldown and ?jumpscare=0 disables it', () => {
+    localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(Date.now()));
+    setSearch('?jumpscare=1');
+    mount();
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(MID_DELAY);
+    });
+    expect(overlay()).not.toBeNull();
+    expect(analytics.track).toHaveBeenCalledWith(
+      'jumpscare_fired',
+      expect.objectContaining({ forced: true }),
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    localStorage.clear();
+    analytics.track.mockClear();
+    setSearch('?jumpscare=0');
+    mount();
+    interact();
+    act(() => {
+      vi.advanceTimersByTime(JUMPSCARE_MAX_DELAY_MS + 1);
+    });
+    expect(overlay()).toBeNull();
+    expect(analytics.track).not.toHaveBeenCalled();
+  });
+
+  it('skips a hidden tab without spending the cooldown', () => {
+    mount();
+    interact();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    act(() => {
+      vi.advanceTimersByTime(MID_DELAY);
+    });
+    expect(overlay()).toBeNull();
+    expect(localStorage.getItem(JUMPSCARE_STORAGE_KEY)).toBeNull();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+  });
+});

--- a/packages/app/src/components/jumpscare/jumpscare.test.tsx
+++ b/packages/app/src/components/jumpscare/jumpscare.test.tsx
@@ -8,7 +8,6 @@ import {
   JUMPSCARE_DURATION_MS,
   JUMPSCARE_MAX_DELAY_MS,
   JUMPSCARE_MIN_DELAY_MS,
-  JUMPSCARE_STORAGE_KEY,
 } from '@/lib/jumpscare';
 
 const localeState = vi.hoisted(() => ({ pathname: '/' }));
@@ -65,7 +64,6 @@ beforeEach(() => {
   localeState.pathname = '/';
   setSearch('');
   setReducedMotion(false);
-  localStorage.clear();
   analytics.track.mockClear();
   audio.unlockJumpscareAudio.mockClear();
   audio.playJumpscareSound.mockClear();
@@ -125,10 +123,9 @@ describe('Jumpscare', () => {
       'jumpscare_fired',
       expect.objectContaining({ forced: false, pathname: '/' }),
     );
-    expect(localStorage.getItem(JUMPSCARE_STORAGE_KEY)).not.toBeNull();
   });
 
-  it('tears itself down after the animation and does not re-arm', () => {
+  it('tears itself down after the animation and does not re-arm within the same mount', () => {
     mount();
     interact();
     act(() => {
@@ -173,7 +170,6 @@ describe('Jumpscare', () => {
   });
 
   const quietCases: [string, () => void][] = [
-    ['on cooldown', () => localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(Date.now()))],
     ['under reduced motion', () => setReducedMotion(true)],
     [
       'inside a partner embed',
@@ -199,8 +195,26 @@ describe('Jumpscare', () => {
     expect(audio.unlockJumpscareAudio).not.toHaveBeenCalled();
   });
 
-  it('?jumpscare=1 forces it past the cooldown and ?jumpscare=0 disables it', () => {
-    localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(Date.now()));
+  function remount() {
+    act(() => root.unmount());
+    root = createRoot(container);
+  }
+
+  it('fires again on a fresh mount — there is no cooldown', () => {
+    for (let visit = 0; visit < 3; visit++) {
+      mount();
+      interact();
+      act(() => {
+        vi.advanceTimersByTime(MID_DELAY);
+      });
+      expect(overlay()).not.toBeNull();
+      remount();
+    }
+    expect(analytics.track).toHaveBeenCalledTimes(3);
+  });
+
+  it('?jumpscare=1 forces it past reduced motion and ?jumpscare=0 disables it', () => {
+    setReducedMotion(true);
     setSearch('?jumpscare=1');
     mount();
     interact();
@@ -213,9 +227,8 @@ describe('Jumpscare', () => {
       expect.objectContaining({ forced: true }),
     );
 
-    act(() => root.unmount());
-    root = createRoot(container);
-    localStorage.clear();
+    remount();
+    setReducedMotion(false);
     analytics.track.mockClear();
     setSearch('?jumpscare=0');
     mount();
@@ -225,17 +238,5 @@ describe('Jumpscare', () => {
     });
     expect(overlay()).toBeNull();
     expect(analytics.track).not.toHaveBeenCalled();
-  });
-
-  it('skips a hidden tab without spending the cooldown', () => {
-    mount();
-    interact();
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
-    act(() => {
-      vi.advanceTimersByTime(MID_DELAY);
-    });
-    expect(overlay()).toBeNull();
-    expect(localStorage.getItem(JUMPSCARE_STORAGE_KEY)).toBeNull();
-    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
   });
 });

--- a/packages/app/src/components/jumpscare/jumpscare.tsx
+++ b/packages/app/src/components/jumpscare/jumpscare.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { track } from '@/lib/analytics';
+import {
+  getJumpscareEligibility,
+  JUMPSCARE_ACTIVATION_EVENTS,
+  JUMPSCARE_DURATION_MS,
+  JUMPSCARE_STORAGE_KEY,
+  pickJumpscareDelayMs,
+} from '@/lib/jumpscare';
+import { playJumpscareSound, unlockJumpscareAudio } from '@/lib/jumpscare-audio';
+import { useLocale } from '@/lib/use-locale';
+
+import { JumpscareFace } from './jumpscare-face';
+
+const STRINGS = {
+  en: {
+    caption: 'CUDA ERROR: DEVICE-SIDE ASSERT. IT IS BEHIND YOU.',
+    label: 'Jumpscare',
+  },
+  zh: {
+    caption: 'CUDA ERROR: DEVICE-SIDE ASSERT。它就在你身后。',
+    label: '惊吓彩蛋',
+  },
+} as const;
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/** Low-res noise canvas; CSS scales it up with `image-rendering: pixelated`. */
+const STATIC_W = 160;
+const STATIC_H = 96;
+
+function isAutomatedBrowser(): boolean {
+  if (typeof navigator !== 'undefined' && navigator.webdriver) return true;
+  return typeof window !== 'undefined' && 'Cypress' in window;
+}
+
+function readLastFired(): string | null {
+  try {
+    return localStorage.getItem(JUMPSCARE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeLastFired(now: number): void {
+  try {
+    localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(now));
+  } catch {
+    // Storage unavailable — the scare just isn't remembered.
+  }
+}
+
+/**
+ * Halloween easter egg: within ten seconds of a visitor's first click, tap, or
+ * keypress, the page goes black, a face lunges at the camera, and a synthesized
+ * scream plays. Mounted once in the root layout. Scheduling rules live in
+ * `@/lib/jumpscare` so they stay testable; this component owns the DOM.
+ */
+export function Jumpscare() {
+  const locale = useLocale();
+  const [active, setActive] = useState(false);
+  const audioRef = useRef<AudioContext | null>(null);
+  const staticRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const eligibility = getJumpscareEligibility({
+      search: window.location.search,
+      pathname: window.location.pathname,
+      reducedMotion: window.matchMedia(REDUCED_MOTION_QUERY).matches,
+      automated: isAutomatedBrowser(),
+      lastFired: readLastFired(),
+      now: Date.now(),
+    });
+    if (!eligibility.eligible) return;
+
+    let fireTimer: ReturnType<typeof setTimeout> | null = null;
+    let hideTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const removeListeners = () => {
+      for (const type of JUMPSCARE_ACTIVATION_EVENTS) {
+        document.removeEventListener(type, onActivate, true);
+      }
+    };
+
+    const fire = () => {
+      fireTimer = null;
+      // Don't waste the one scare on a background tab; they'll get it next visit.
+      if (document.visibilityState !== 'visible') return;
+      const now = Date.now();
+      writeLastFired(now);
+      track('jumpscare_fired', {
+        forced: eligibility.forced,
+        pathname: window.location.pathname,
+        audio_unlocked: audioRef.current !== null,
+      });
+      playJumpscareSound(audioRef.current);
+      setActive(true);
+      hideTimer = setTimeout(() => {
+        hideTimer = null;
+        setActive(false);
+      }, JUMPSCARE_DURATION_MS);
+    };
+
+    function onActivate() {
+      removeListeners();
+      // Must happen synchronously inside the gesture so the browser unlocks audio.
+      audioRef.current = unlockJumpscareAudio(audioRef.current);
+      fireTimer = setTimeout(fire, pickJumpscareDelayMs());
+    }
+
+    for (const type of JUMPSCARE_ACTIVATION_EVENTS) {
+      document.addEventListener(type, onActivate, { capture: true, passive: true });
+    }
+
+    return () => {
+      removeListeners();
+      if (fireTimer !== null) clearTimeout(fireTimer);
+      if (hideTimer !== null) clearTimeout(hideTimer);
+      audioRef.current?.close().catch(() => {});
+      audioRef.current = null;
+    };
+  }, []);
+
+  // TV static: redraw random grey pixels every other frame while active.
+  useEffect(() => {
+    if (!active) return;
+    const canvas = staticRef.current;
+    const g = canvas?.getContext('2d');
+    if (!canvas || !g) return;
+    const image = g.createImageData(STATIC_W, STATIC_H);
+    const data = image.data;
+    let frame = 0;
+    let raf = 0;
+    const draw = () => {
+      if (frame++ % 2 === 0) {
+        for (let i = 0; i < data.length; i += 4) {
+          const v = Math.random() < 0.5 ? 0 : 140 + Math.floor(Math.random() * 115);
+          data[i] = v;
+          data[i + 1] = v;
+          data[i + 2] = v;
+          data[i + 3] = 255;
+        }
+        g.putImageData(image, 0, 0);
+      }
+      raf = requestAnimationFrame(draw);
+    };
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, [active]);
+
+  if (!active) return null;
+
+  const strings = STRINGS[locale];
+
+  return (
+    <div
+      className="jumpscare-root"
+      role="presentation"
+      aria-hidden="true"
+      data-testid="jumpscare"
+      data-label={strings.label}
+    >
+      <canvas ref={staticRef} className="jumpscare-static" width={STATIC_W} height={STATIC_H} />
+      <div className="jumpscare-stage">
+        <div className="jumpscare-face-wrap">
+          <JumpscareFace className="jumpscare-face jumpscare-face-ghost" data-tint="red" />
+          <JumpscareFace className="jumpscare-face jumpscare-face-ghost" data-tint="cyan" />
+          <JumpscareFace className="jumpscare-face" />
+        </div>
+      </div>
+      <div className="jumpscare-vignette" />
+      <div className="jumpscare-scanlines" />
+      <div className="jumpscare-flash" />
+      <p className="jumpscare-text" data-testid="jumpscare-caption">
+        {strings.caption}
+      </p>
+    </div>
+  );
+}

--- a/packages/app/src/components/jumpscare/jumpscare.tsx
+++ b/packages/app/src/components/jumpscare/jumpscare.tsx
@@ -7,7 +7,6 @@ import {
   getJumpscareEligibility,
   JUMPSCARE_ACTIVATION_EVENTS,
   JUMPSCARE_DURATION_MS,
-  JUMPSCARE_STORAGE_KEY,
   pickJumpscareDelayMs,
 } from '@/lib/jumpscare';
 import { playJumpscareSound, unlockJumpscareAudio } from '@/lib/jumpscare-audio';
@@ -37,26 +36,11 @@ function isAutomatedBrowser(): boolean {
   return typeof window !== 'undefined' && 'Cypress' in window;
 }
 
-function readLastFired(): string | null {
-  try {
-    return localStorage.getItem(JUMPSCARE_STORAGE_KEY);
-  } catch {
-    return null;
-  }
-}
-
-function writeLastFired(now: number): void {
-  try {
-    localStorage.setItem(JUMPSCARE_STORAGE_KEY, String(now));
-  } catch {
-    // Storage unavailable — the scare just isn't remembered.
-  }
-}
-
 /**
  * Halloween easter egg: within ten seconds of a visitor's first click, tap, or
  * keypress, the page goes black, a face lunges at the camera, and a synthesized
- * scream plays. Mounted once in the root layout. Scheduling rules live in
+ * scream plays. No cooldown: every page load gets one. Mounted once in the
+ * root layout. Scheduling rules live in
  * `@/lib/jumpscare` so they stay testable; this component owns the DOM.
  */
 export function Jumpscare() {
@@ -71,8 +55,6 @@ export function Jumpscare() {
       pathname: window.location.pathname,
       reducedMotion: window.matchMedia(REDUCED_MOTION_QUERY).matches,
       automated: isAutomatedBrowser(),
-      lastFired: readLastFired(),
-      now: Date.now(),
     });
     if (!eligibility.eligible) return;
 
@@ -87,10 +69,6 @@ export function Jumpscare() {
 
     const fire = () => {
       fireTimer = null;
-      // Don't waste the one scare on a background tab; they'll get it next visit.
-      if (document.visibilityState !== 'visible') return;
-      const now = Date.now();
-      writeLastFired(now);
       track('jumpscare_fired', {
         forced: eligibility.forced,
         pathname: window.location.pathname,

--- a/packages/app/src/lib/jumpscare-audio.ts
+++ b/packages/app/src/lib/jumpscare-audio.ts
@@ -1,0 +1,145 @@
+/**
+ * Synthesized jumpscare sound — no audio asset to license or ship.
+ *
+ * Three layers, all built from Web Audio primitives:
+ *   1. Sub impact: a sine dropping 70 Hz → 28 Hz. Felt more than heard.
+ *   2. Scream: three detuned sawtooths sweeping up through a resonant bandpass,
+ *      with a fast vibrato and hard waveshaper distortion so it tears.
+ *   3. Static burst: white noise through a highpass, snapping in and decaying.
+ *
+ * A compressor on the master bus stops the sum from clipping while keeping
+ * the transient loud. Total length ≈ 1.7 s to match the overlay.
+ */
+
+const SCREAM_LENGTH_S = 1.7;
+
+function makeDistortionCurve(amount: number): Float32Array<ArrayBuffer> {
+  const samples = 2048;
+  const curve = new Float32Array(samples);
+  const k = amount;
+  for (let i = 0; i < samples; i++) {
+    const x = (i * 2) / samples - 1;
+    curve[i] = ((3 + k) * x * 20 * (Math.PI / 180)) / (Math.PI + k * Math.abs(x));
+  }
+  return curve;
+}
+
+function makeNoiseBuffer(ctx: BaseAudioContext, seconds: number): AudioBuffer {
+  const length = Math.floor(ctx.sampleRate * seconds);
+  const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i++) data[i] = Math.random() * 2 - 1;
+  return buffer;
+}
+
+/**
+ * Create (or reuse) an AudioContext from inside a user-activation handler so
+ * the browser lets it play later. Returns `null` when Web Audio is missing.
+ */
+export function unlockJumpscareAudio(existing: AudioContext | null): AudioContext | null {
+  if (typeof window === 'undefined' || typeof window.AudioContext !== 'function') return null;
+  const ctx = existing ?? new window.AudioContext();
+  if (ctx.state === 'suspended') {
+    ctx.resume().catch(() => {});
+  }
+  return ctx;
+}
+
+/** Fire the scream. Safe to call when the context failed to unlock; it just no-ops. */
+export function playJumpscareSound(ctx: AudioContext | null, volume = 0.9): void {
+  if (!ctx) return;
+  try {
+    const t0 = ctx.currentTime + 0.01;
+    const tEnd = t0 + SCREAM_LENGTH_S;
+
+    const master = ctx.createGain();
+    master.gain.setValueAtTime(volume, t0);
+    master.gain.setValueAtTime(volume, tEnd - 0.25);
+    master.gain.linearRampToValueAtTime(0, tEnd);
+
+    const compressor = ctx.createDynamicsCompressor();
+    compressor.threshold.setValueAtTime(-18, t0);
+    compressor.knee.setValueAtTime(12, t0);
+    compressor.ratio.setValueAtTime(8, t0);
+    compressor.attack.setValueAtTime(0.002, t0);
+    compressor.release.setValueAtTime(0.15, t0);
+
+    master.connect(compressor).connect(ctx.destination);
+
+    // 1. Sub impact ---------------------------------------------------------
+    const sub = ctx.createOscillator();
+    sub.type = 'sine';
+    sub.frequency.setValueAtTime(70, t0);
+    sub.frequency.exponentialRampToValueAtTime(28, t0 + 0.6);
+    const subGain = ctx.createGain();
+    subGain.gain.setValueAtTime(0, t0);
+    subGain.gain.linearRampToValueAtTime(1.1, t0 + 0.015);
+    subGain.gain.exponentialRampToValueAtTime(0.001, t0 + 1.1);
+    sub.connect(subGain).connect(master);
+    sub.start(t0);
+    sub.stop(t0 + 1.2);
+
+    // 2. Scream -------------------------------------------------------------
+    const shaper = ctx.createWaveShaper();
+    shaper.curve = makeDistortionCurve(180);
+    shaper.oversample = '4x';
+
+    const band = ctx.createBiquadFilter();
+    band.type = 'bandpass';
+    band.Q.setValueAtTime(3.5, t0);
+    band.frequency.setValueAtTime(600, t0);
+    band.frequency.exponentialRampToValueAtTime(2400, t0 + 0.35);
+    band.frequency.exponentialRampToValueAtTime(1400, tEnd);
+
+    const screamGain = ctx.createGain();
+    screamGain.gain.setValueAtTime(0, t0);
+    screamGain.gain.linearRampToValueAtTime(0.8, t0 + 0.03);
+    screamGain.gain.setValueAtTime(0.8, t0 + 0.9);
+    screamGain.gain.exponentialRampToValueAtTime(0.001, tEnd);
+
+    shaper.connect(band).connect(screamGain).connect(master);
+
+    const vibrato = ctx.createOscillator();
+    vibrato.type = 'sine';
+    vibrato.frequency.setValueAtTime(9, t0);
+    vibrato.frequency.linearRampToValueAtTime(16, tEnd);
+    const vibratoDepth = ctx.createGain();
+    vibratoDepth.gain.setValueAtTime(40, t0);
+    vibrato.connect(vibratoDepth);
+    vibrato.start(t0);
+    vibrato.stop(tEnd);
+
+    for (const detune of [-18, 0, 23]) {
+      const osc = ctx.createOscillator();
+      osc.type = 'sawtooth';
+      osc.detune.setValueAtTime(detune, t0);
+      osc.frequency.setValueAtTime(320, t0);
+      osc.frequency.exponentialRampToValueAtTime(1350, t0 + 0.28);
+      osc.frequency.exponentialRampToValueAtTime(980, t0 + 0.9);
+      osc.frequency.exponentialRampToValueAtTime(1500, tEnd);
+      vibratoDepth.connect(osc.frequency);
+      osc.connect(shaper);
+      osc.start(t0);
+      osc.stop(tEnd);
+    }
+
+    // 3. Static burst -------------------------------------------------------
+    const noise = ctx.createBufferSource();
+    noise.buffer = makeNoiseBuffer(ctx, SCREAM_LENGTH_S);
+    const hp = ctx.createBiquadFilter();
+    hp.type = 'highpass';
+    hp.frequency.setValueAtTime(1800, t0);
+    const noiseGain = ctx.createGain();
+    noiseGain.gain.setValueAtTime(0, t0);
+    noiseGain.gain.linearRampToValueAtTime(0.7, t0 + 0.01);
+    noiseGain.gain.exponentialRampToValueAtTime(0.08, t0 + 0.4);
+    noiseGain.gain.setValueAtTime(0.08, tEnd - 0.3);
+    noiseGain.gain.linearRampToValueAtTime(0.5, tEnd - 0.2);
+    noiseGain.gain.exponentialRampToValueAtTime(0.001, tEnd);
+    noise.connect(hp).connect(noiseGain).connect(master);
+    noise.start(t0);
+    noise.stop(tEnd);
+  } catch {
+    // Audio is a garnish; never let it break the page.
+  }
+}

--- a/packages/app/src/lib/jumpscare.test.ts
+++ b/packages/app/src/lib/jumpscare.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getJumpscareEligibility,
+  isJumpscareEmbedPath,
+  isJumpscareOnCooldown,
+  JUMPSCARE_COOLDOWN_MS,
+  JUMPSCARE_MAX_DELAY_MS,
+  JUMPSCARE_MIN_DELAY_MS,
+  pickJumpscareDelayMs,
+  readJumpscareOverride,
+  type JumpscareEligibilityInput,
+} from './jumpscare';
+
+const NOW = 1_800_000_000_000;
+
+function input(overrides: Partial<JumpscareEligibilityInput> = {}): JumpscareEligibilityInput {
+  return {
+    search: '',
+    pathname: '/',
+    reducedMotion: false,
+    automated: false,
+    lastFired: null,
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe('readJumpscareOverride', () => {
+  it('returns null when the param is absent', () => {
+    expect(readJumpscareOverride('')).toBeNull();
+    expect(readJumpscareOverride('?model=dsv4')).toBeNull();
+  });
+
+  it('treats 0 / false / off as disable and anything else as force', () => {
+    expect(readJumpscareOverride('?jumpscare=0')).toBe('disable');
+    expect(readJumpscareOverride('?jumpscare=false')).toBe('disable');
+    expect(readJumpscareOverride('?jumpscare=off')).toBe('disable');
+    expect(readJumpscareOverride('?jumpscare=1')).toBe('force');
+    expect(readJumpscareOverride('?jumpscare')).toBe('force');
+    expect(readJumpscareOverride('?model=dsv4&jumpscare=now')).toBe('force');
+  });
+});
+
+describe('isJumpscareEmbedPath', () => {
+  it('matches English and Chinese embed routes only', () => {
+    expect(isJumpscareEmbedPath('/embed')).toBe(true);
+    expect(isJumpscareEmbedPath('/embed/inference')).toBe(true);
+    expect(isJumpscareEmbedPath('/zh/embed/inference')).toBe(true);
+    expect(isJumpscareEmbedPath('/')).toBe(false);
+    expect(isJumpscareEmbedPath('/inference')).toBe(false);
+    expect(isJumpscareEmbedPath('/embedded-systems')).toBe(false);
+  });
+});
+
+describe('isJumpscareOnCooldown', () => {
+  it('is false with no record or a corrupt record', () => {
+    expect(isJumpscareOnCooldown(null, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
+    expect(isJumpscareOnCooldown('garbage', NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
+  });
+
+  it('is true inside the window and false once it lapses', () => {
+    const recent = String(NOW - JUMPSCARE_COOLDOWN_MS + 1);
+    const stale = String(NOW - JUMPSCARE_COOLDOWN_MS);
+    expect(isJumpscareOnCooldown(recent, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(true);
+    expect(isJumpscareOnCooldown(stale, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
+  });
+});
+
+describe('getJumpscareEligibility', () => {
+  it('is eligible by default on a fresh browser', () => {
+    expect(getJumpscareEligibility(input())).toEqual({ eligible: true, forced: false });
+  });
+
+  it('never fires inside partner embeds, even when forced', () => {
+    expect(getJumpscareEligibility(input({ pathname: '/embed/inference' }))).toEqual({
+      eligible: false,
+      reason: 'embed',
+    });
+    expect(
+      getJumpscareEligibility(input({ pathname: '/zh/embed/inference', search: '?jumpscare=1' })),
+    ).toEqual({ eligible: false, reason: 'embed' });
+  });
+
+  it('skips automated browsers unless a spec forces it explicitly', () => {
+    expect(getJumpscareEligibility(input({ automated: true }))).toEqual({
+      eligible: false,
+      reason: 'automated',
+    });
+    expect(getJumpscareEligibility(input({ automated: true, search: '?jumpscare=1' }))).toEqual({
+      eligible: true,
+      forced: true,
+    });
+  });
+
+  it('respects reduced motion and the cooldown', () => {
+    expect(getJumpscareEligibility(input({ reducedMotion: true }))).toEqual({
+      eligible: false,
+      reason: 'reduced-motion',
+    });
+    expect(getJumpscareEligibility(input({ lastFired: String(NOW - 1000) }))).toEqual({
+      eligible: false,
+      reason: 'cooldown',
+    });
+  });
+
+  it('?jumpscare=1 overrides reduced motion and cooldown; ?jumpscare=0 wins over everything', () => {
+    expect(
+      getJumpscareEligibility(
+        input({ search: '?jumpscare=1', reducedMotion: true, lastFired: String(NOW - 1000) }),
+      ),
+    ).toEqual({ eligible: true, forced: true });
+    expect(getJumpscareEligibility(input({ search: '?jumpscare=0' }))).toEqual({
+      eligible: false,
+      reason: 'disabled-by-query',
+    });
+  });
+});
+
+describe('pickJumpscareDelayMs', () => {
+  it('stays inside the first ten seconds of interaction', () => {
+    expect(JUMPSCARE_MAX_DELAY_MS).toBeLessThan(10_000);
+    expect(pickJumpscareDelayMs(() => 0)).toBe(JUMPSCARE_MIN_DELAY_MS);
+    expect(pickJumpscareDelayMs(() => 1)).toBe(JUMPSCARE_MAX_DELAY_MS);
+    expect(pickJumpscareDelayMs(() => 0.5)).toBe(
+      Math.round((JUMPSCARE_MIN_DELAY_MS + JUMPSCARE_MAX_DELAY_MS) / 2),
+    );
+  });
+
+  it('clamps out-of-range random sources', () => {
+    expect(pickJumpscareDelayMs(() => -3)).toBe(JUMPSCARE_MIN_DELAY_MS);
+    expect(pickJumpscareDelayMs(() => 7)).toBe(JUMPSCARE_MAX_DELAY_MS);
+  });
+});

--- a/packages/app/src/lib/jumpscare.test.ts
+++ b/packages/app/src/lib/jumpscare.test.ts
@@ -3,8 +3,6 @@ import { describe, expect, it } from 'vitest';
 import {
   getJumpscareEligibility,
   isJumpscareEmbedPath,
-  isJumpscareOnCooldown,
-  JUMPSCARE_COOLDOWN_MS,
   JUMPSCARE_MAX_DELAY_MS,
   JUMPSCARE_MIN_DELAY_MS,
   pickJumpscareDelayMs,
@@ -12,16 +10,12 @@ import {
   type JumpscareEligibilityInput,
 } from './jumpscare';
 
-const NOW = 1_800_000_000_000;
-
 function input(overrides: Partial<JumpscareEligibilityInput> = {}): JumpscareEligibilityInput {
   return {
     search: '',
     pathname: '/',
     reducedMotion: false,
     automated: false,
-    lastFired: null,
-    now: NOW,
     ...overrides,
   };
 }
@@ -53,20 +47,6 @@ describe('isJumpscareEmbedPath', () => {
   });
 });
 
-describe('isJumpscareOnCooldown', () => {
-  it('is false with no record or a corrupt record', () => {
-    expect(isJumpscareOnCooldown(null, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
-    expect(isJumpscareOnCooldown('garbage', NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
-  });
-
-  it('is true inside the window and false once it lapses', () => {
-    const recent = String(NOW - JUMPSCARE_COOLDOWN_MS + 1);
-    const stale = String(NOW - JUMPSCARE_COOLDOWN_MS);
-    expect(isJumpscareOnCooldown(recent, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(true);
-    expect(isJumpscareOnCooldown(stale, NOW, JUMPSCARE_COOLDOWN_MS)).toBe(false);
-  });
-});
-
 describe('getJumpscareEligibility', () => {
   it('is eligible by default on a fresh browser', () => {
     expect(getJumpscareEligibility(input())).toEqual({ eligible: true, forced: false });
@@ -93,23 +73,17 @@ describe('getJumpscareEligibility', () => {
     });
   });
 
-  it('respects reduced motion and the cooldown', () => {
+  it('respects reduced motion', () => {
     expect(getJumpscareEligibility(input({ reducedMotion: true }))).toEqual({
       eligible: false,
       reason: 'reduced-motion',
     });
-    expect(getJumpscareEligibility(input({ lastFired: String(NOW - 1000) }))).toEqual({
-      eligible: false,
-      reason: 'cooldown',
-    });
   });
 
-  it('?jumpscare=1 overrides reduced motion and cooldown; ?jumpscare=0 wins over everything', () => {
-    expect(
-      getJumpscareEligibility(
-        input({ search: '?jumpscare=1', reducedMotion: true, lastFired: String(NOW - 1000) }),
-      ),
-    ).toEqual({ eligible: true, forced: true });
+  it('?jumpscare=1 overrides reduced motion; ?jumpscare=0 wins over everything', () => {
+    expect(getJumpscareEligibility(input({ search: '?jumpscare=1', reducedMotion: true }))).toEqual(
+      { eligible: true, forced: true },
+    );
     expect(getJumpscareEligibility(input({ search: '?jumpscare=0' }))).toEqual({
       eligible: false,
       reason: 'disabled-by-query',

--- a/packages/app/src/lib/jumpscare.ts
+++ b/packages/app/src/lib/jumpscare.ts
@@ -6,21 +6,16 @@
  * both decisions can be unit-tested without a DOM.
  *
  * Rules:
- *   - Fires once per browser per cooldown window (localStorage timestamp).
+ *   - No cooldown. Every page load is fair game once the visitor interacts.
  *   - Fires between `MIN_DELAY_MS` and `MAX_DELAY_MS` after the visitor's first
  *     activation gesture (pointerdown / keydown / touchstart), which keeps it
  *     inside the first ten seconds of interaction and also unlocks audio.
- *   - `?jumpscare=1` forces it (ignores cooldown, reduced motion, and the
- *     automation guard so a deliberate E2E spec can exercise it);
+ *   - `?jumpscare=1` forces it (ignores reduced motion and the automation
+ *     guard so a deliberate E2E spec can exercise it);
  *     `?jumpscare=0` disables it.
  *   - Otherwise skipped for reduced-motion users and automated browsers, so the
  *     Cypress suites never meet it by accident. Partner embeds never fire.
  */
-
-export const JUMPSCARE_STORAGE_KEY = 'inferencex-jumpscare-last-fired';
-
-/** One scare per browser per day is plenty. */
-export const JUMPSCARE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 
 /** Earliest the scare can fire after the first interaction. */
 export const JUMPSCARE_MIN_DELAY_MS = 2_500;
@@ -45,16 +40,13 @@ export interface JumpscareEligibilityInput {
   reducedMotion: boolean;
   /** `navigator.webdriver === true` or `'Cypress' in window` */
   automated: boolean;
-  /** Raw `localStorage` value for `JUMPSCARE_STORAGE_KEY`, if any. */
-  lastFired: string | null;
-  now: number;
 }
 
 export type JumpscareEligibility =
   | { eligible: true; forced: boolean }
   | {
       eligible: false;
-      reason: 'disabled-by-query' | 'embed' | 'reduced-motion' | 'automated' | 'cooldown';
+      reason: 'disabled-by-query' | 'embed' | 'reduced-motion' | 'automated';
     };
 
 export function readJumpscareOverride(search: string): 'force' | 'disable' | null {
@@ -70,13 +62,6 @@ export function isJumpscareEmbedPath(pathname: string): boolean {
   );
 }
 
-export function isJumpscareOnCooldown(lastFired: string | null, now: number, cooldownMs: number) {
-  if (lastFired === null) return false;
-  const firedAt = Number(lastFired);
-  if (Number.isNaN(firedAt)) return false;
-  return now - firedAt < cooldownMs;
-}
-
 export function getJumpscareEligibility(input: JumpscareEligibilityInput): JumpscareEligibility {
   const override = readJumpscareOverride(input.search);
   if (override === 'disable') return { eligible: false, reason: 'disabled-by-query' };
@@ -84,9 +69,6 @@ export function getJumpscareEligibility(input: JumpscareEligibilityInput): Jumps
   if (override === 'force') return { eligible: true, forced: true };
   if (input.automated) return { eligible: false, reason: 'automated' };
   if (input.reducedMotion) return { eligible: false, reason: 'reduced-motion' };
-  if (isJumpscareOnCooldown(input.lastFired, input.now, JUMPSCARE_COOLDOWN_MS)) {
-    return { eligible: false, reason: 'cooldown' };
-  }
   return { eligible: true, forced: false };
 }
 

--- a/packages/app/src/lib/jumpscare.ts
+++ b/packages/app/src/lib/jumpscare.ts
@@ -1,0 +1,101 @@
+/**
+ * Jumpscare scheduling — the pure, testable half of the Halloween easter egg.
+ *
+ * The overlay itself lives in `@/components/jumpscare/jumpscare.tsx`. This
+ * module decides *whether* a visit is eligible and *when* the scare fires so
+ * both decisions can be unit-tested without a DOM.
+ *
+ * Rules:
+ *   - Fires once per browser per cooldown window (localStorage timestamp).
+ *   - Fires between `MIN_DELAY_MS` and `MAX_DELAY_MS` after the visitor's first
+ *     activation gesture (pointerdown / keydown / touchstart), which keeps it
+ *     inside the first ten seconds of interaction and also unlocks audio.
+ *   - `?jumpscare=1` forces it (ignores cooldown, reduced motion, and the
+ *     automation guard so a deliberate E2E spec can exercise it);
+ *     `?jumpscare=0` disables it.
+ *   - Otherwise skipped for reduced-motion users and automated browsers, so the
+ *     Cypress suites never meet it by accident. Partner embeds never fire.
+ */
+
+export const JUMPSCARE_STORAGE_KEY = 'inferencex-jumpscare-last-fired';
+
+/** One scare per browser per day is plenty. */
+export const JUMPSCARE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+
+/** Earliest the scare can fire after the first interaction. */
+export const JUMPSCARE_MIN_DELAY_MS = 2_500;
+
+/** Latest the scare can fire after the first interaction — well inside 10 s. */
+export const JUMPSCARE_MAX_DELAY_MS = 8_500;
+
+/** How long the overlay stays mounted, including the fade-out tail. */
+export const JUMPSCARE_DURATION_MS = 1_900;
+
+export const JUMPSCARE_QUERY_PARAM = 'jumpscare';
+
+/** Activation events that both count as "interacting" and unlock Web Audio. */
+export const JUMPSCARE_ACTIVATION_EVENTS = ['pointerdown', 'keydown', 'touchstart'] as const;
+
+export interface JumpscareEligibilityInput {
+  /** `location.search`, including the leading `?`. */
+  search: string;
+  /** Current pathname — partner embeds must never scare anyone. */
+  pathname: string;
+  /** `matchMedia('(prefers-reduced-motion: reduce)').matches` */
+  reducedMotion: boolean;
+  /** `navigator.webdriver === true` or `'Cypress' in window` */
+  automated: boolean;
+  /** Raw `localStorage` value for `JUMPSCARE_STORAGE_KEY`, if any. */
+  lastFired: string | null;
+  now: number;
+}
+
+export type JumpscareEligibility =
+  | { eligible: true; forced: boolean }
+  | {
+      eligible: false;
+      reason: 'disabled-by-query' | 'embed' | 'reduced-motion' | 'automated' | 'cooldown';
+    };
+
+export function readJumpscareOverride(search: string): 'force' | 'disable' | null {
+  const value = new URLSearchParams(search).get(JUMPSCARE_QUERY_PARAM);
+  if (value === null) return null;
+  if (value === '0' || value === 'false' || value === 'off') return 'disable';
+  return 'force';
+}
+
+export function isJumpscareEmbedPath(pathname: string): boolean {
+  return (
+    pathname === '/embed' || pathname.startsWith('/embed/') || pathname.startsWith('/zh/embed')
+  );
+}
+
+export function isJumpscareOnCooldown(lastFired: string | null, now: number, cooldownMs: number) {
+  if (lastFired === null) return false;
+  const firedAt = Number(lastFired);
+  if (Number.isNaN(firedAt)) return false;
+  return now - firedAt < cooldownMs;
+}
+
+export function getJumpscareEligibility(input: JumpscareEligibilityInput): JumpscareEligibility {
+  const override = readJumpscareOverride(input.search);
+  if (override === 'disable') return { eligible: false, reason: 'disabled-by-query' };
+  if (isJumpscareEmbedPath(input.pathname)) return { eligible: false, reason: 'embed' };
+  if (override === 'force') return { eligible: true, forced: true };
+  if (input.automated) return { eligible: false, reason: 'automated' };
+  if (input.reducedMotion) return { eligible: false, reason: 'reduced-motion' };
+  if (isJumpscareOnCooldown(input.lastFired, input.now, JUMPSCARE_COOLDOWN_MS)) {
+    return { eligible: false, reason: 'cooldown' };
+  }
+  return { eligible: true, forced: false };
+}
+
+/**
+ * Delay between the first interaction and the scare. `random` is injected so
+ * tests can pin the bounds; production passes `Math.random`.
+ */
+export function pickJumpscareDelayMs(random: () => number = Math.random): number {
+  const span = JUMPSCARE_MAX_DELAY_MS - JUMPSCARE_MIN_DELAY_MS;
+  const r = Math.min(Math.max(random(), 0), 1);
+  return Math.round(JUMPSCARE_MIN_DELAY_MS + r * span);
+}


### PR DESCRIPTION
## Summary

Halloween easter egg. Within ten seconds of a visitor's first click, tap, or keypress on inferencex.com, the page goes black, a face lunges at the camera with a synthesized scream, and the site comes back 1.9 s later as if nothing happened.

Requested in #gta6-research-inference. Blame Cam.

### What fires

- **Trigger**: the first `pointerdown` / `keydown` / `touchstart` arms a timer for a random 2.5–8.5 s. Those are activation events, so the same gesture unlocks Web Audio and the scream actually plays. Scrolling alone does not arm it.
- **Visual**: TV-static canvas, white → red → white strobe, screen shake, a hand-drawn SVG face (`jumpscare-face.tsx`) that scales from 8 % to 170 % with red/cyan glitch ghosts sliced by `clip-path`, scanlines, vignette, and a flickering red caption. All CSS keyframes, mounted only while firing.
- **Sound**: `jumpscare-audio.ts` synthesizes it with Web Audio, so there is no audio asset to license or ship: a 70 → 28 Hz sub impact, three detuned sawtooths swept through a resonant bandpass with vibrato and a waveshaper, a highpassed noise burst, all through a compressor.
- **Caption** is bilingual via the usual `STRINGS = { en, zh }` + `useLocale()` pattern: `CUDA ERROR: DEVICE-SIDE ASSERT. IT IS BEHIND YOU.` / `CUDA ERROR: DEVICE-SIDE ASSERT。它就在你身后。`

### Guardrails

- No cooldown. Every page load is eligible again after the first interaction.
- Never fires on `/embed/*` or `/zh/embed/*`, forced or not. Partners embedding charts do not get scared.
- Skipped under `prefers-reduced-motion: reduce`.
- Skipped when `navigator.webdriver` is set or `window.Cypress` exists, so the existing E2E suites never meet it by accident.
- `?jumpscare=1` forces it (overrides reduced motion and the automation guard so a deliberate spec can exercise it). `?jumpscare=0` disables it.
- `pointer-events: none` on the overlay; nothing underneath is blocked.
- Analytics: `jumpscare_fired` with `forced`, `pathname`, `audio_unlocked`.

### Files

- `packages/app/src/lib/jumpscare.ts` — eligibility + delay logic (pure, tested)
- `packages/app/src/lib/jumpscare-audio.ts` — Web Audio scream
- `packages/app/src/components/jumpscare/{jumpscare,jumpscare-face}.tsx`, `jumpscare.css`
- `packages/app/src/app/layout.tsx` mounts `<Jumpscare />` inside `ThemeProvider`; `globals.css` imports the stylesheet

### Tests

- `src/lib/jumpscare.test.ts` — 10 cases: query override parsing, embed matching, eligibility ordering, delay bounds stay under 10 s.
- `src/components/jumpscare/jumpscare.test.tsx` — 9 jsdom cases: nothing renders without interaction, fires after the first gesture, plays audio + tracks, tears down after `JUMPSCARE_DURATION_MS` and does not re-arm within a mount, fires again on every fresh mount (no cooldown), only the first gesture unlocks audio, Chinese caption on `/zh`, stays quiet on reduced motion / embed / automation, `?jumpscare=1` and `?jumpscare=0`.
- Full unit suite: 319 files / 5,253 tests green. `bun run lint`, `bun run fmt`, `bun run typecheck`, `bun run check:typography` clean. `zh-copy` and `zh-objective-guard` pass.
- Verified in headless Chromium on `/?jumpscare=1` and `/zh?jumpscare=1`: overlay appeared 5.35 s after the first click, the audio graph built (1 context, 5 oscillators, 1 noise source), overlay detached after the animation, no console errors.

Not a chart feature, so `?unofficialrun=` overlays are not applicable.

## 中文说明

万圣节彩蛋。访客在 inferencex.com 上第一次点击、触摸或按键后的十秒内，页面会突然变黑，一张脸伴随合成的尖叫声冲向镜头，1.9 秒后网站恢复如常。

来自 #gta6-research-inference 的需求。

### 触发与效果

- **触发**：首次 `pointerdown` / `keydown` / `touchstart` 会启动一个 2.5–8.5 秒的随机计时器。这些都是激活事件（activation events），同一手势也会解锁 Web Audio，尖叫声才能真正播放。仅滚动页面不会触发。
- **视觉**：电视雪花噪点 canvas、白→红→白闪烁、屏幕震动、手绘 SVG 脸（`jumpscare-face.tsx`）从 8% 放大到 170%，配合 `clip-path` 切片的红/青色故障残影、扫描线、暗角和闪烁的红色字幕。全部为 CSS 关键帧动画，只在触发时挂载。
- **声音**：`jumpscare-audio.ts` 用 Web Audio 实时合成，无需任何音频素材：70→28 Hz 的低频冲击、三路失谐锯齿波经共振带通滤波器加颤音和波形失真、高通噪声爆发，最后经压缩器输出。
- **字幕**采用惯用的 `STRINGS = { en, zh }` + `useLocale()` 模式，中英双语。

### 保护措施

- 无冷却时间。每次页面加载后，只要访客交互就会再次触发。
- 在 `/embed/*` 和 `/zh/embed/*` 路径下永不触发，即使强制参数也无效，嵌入图表的合作伙伴不受影响。
- 尊重 `prefers-reduced-motion: reduce`。
- 检测到 `navigator.webdriver` 或 `window.Cypress` 时跳过，现有 E2E 测试不会意外碰到。
- `?jumpscare=1` 强制触发（覆盖减少动态效果和自动化检测，便于专门的 E2E 用例测试）；`?jumpscare=0` 关闭。
- 覆盖层为 `pointer-events: none`，不会阻挡下方任何交互。
- 埋点：`jumpscare_fired`，携带 `forced`、`pathname`、`audio_unlocked`。

### 测试

- `src/lib/jumpscare.test.ts`：10 个用例，覆盖查询参数解析、embed 路径匹配、资格判定顺序、延迟上限低于 10 秒。
- `src/components/jumpscare/jumpscare.test.tsx`：9 个 jsdom 用例，覆盖未交互不渲染、首次手势后触发、播放音频 + 埋点、动画结束后卸载且同一挂载内不再重新触发、每次重新挂载都会再次触发（无冷却）、只有首次手势解锁音频、`/zh` 页面显示中文字幕、减少动态 / embed / 自动化下保持静默、`?jumpscare=1` 与 `?jumpscare=0`。
- 完整单元测试：319 个文件 / 5,253 个用例全部通过。`bun run lint`、`bun run fmt`、`bun run typecheck`、`bun run check:typography` 均无问题，`zh-copy` 与 `zh-objective-guard` 通过。
- 在无头 Chromium 中验证了 `/?jumpscare=1` 和 `/zh?jumpscare=1`：首次点击后 5.35 秒出现覆盖层，音频图正常构建，动画结束后覆盖层移除，控制台无报错。

与图表无关，`?unofficialrun=` 叠加数据不适用。
