### PR TITLE
chore(tco): set Jalapeño cost to $1.27/GPU/hr for both tiers / 将 Jalapeño TCO 统一设为 $1.27/GPU/hr

### DIFF
--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -149,8 +149,8 @@ describe('getHardwareConfig', () => {
     expect(getGpuSpecs('jalapeno_teacup')).toEqual({
       tdp: 700,
       power: 1.125,
-      costh: 1.47,
-      costr: 1.79,
+      costh: 1.27,
+      costr: 1.27,
     });
     expect(getGpuSpecs('vr200_coreweave-vera-rubin')).toEqual({
       tdp: 1800,

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -144,8 +144,8 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     sort: 10,
     tdp: 700,
     power: 1.125,
-    costh: 1.47,
-    costr: 1.79,
+    costh: 1.27,
+    costr: 1.27,
   },
   tpuv7: {
     vendor: 'Google',


### PR DESCRIPTION
## Summary

Jalapeño now uses a single published cost rate of **\$1.27/GPU/hr** across both cost tiers in `HW_REGISTRY`:

- `costh` (owning at large hyperscaler volume): \$1.47 → \$1.27
- `costr` (rent / retail tier): \$1.79 → \$1.27

Test expectations in `packages/app/src/lib/constants.test.ts` updated to match (44 tests pass).

No UI strings changed, so no `/zh` page updates are required.

## 中文说明

Jalapeño 的成本在 `HW_REGISTRY` 中统一为 **\$1.27/GPU/hr**，两个成本层级使用同一发布费率：

- `costh`（大型 hyperscaler 自建成本）：\$1.47 → \$1.27
- `costr`（租用/零售层级）：\$1.79 → \$1.27

同步更新 `packages/app/src/lib/constants.test.ts` 中的测试断言（44 项测试全部通过）。

本次改动不涉及任何用户可见文案，因此无需更新 `/zh` 页面。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constants-only TCO rate adjustment with matching tests; no auth, API, or user-facing copy changes.
> 
> **Overview**
> Updates published **Jalapeño** TCO assumptions in `HW_REGISTRY` so both cost tiers use **$1.27/GPU/hr**: `costh` drops from $1.47 and `costr` from $1.79 to that single rate. Power and TDP for Jalapeño are unchanged.
> 
> Test expectations for `getGpuSpecs('jalapeno_teacup')` in `constants.test.ts` are aligned with the new registry values so TCO-derived UI/calculations pick up the revised assumptions automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe639c3f7e5d34a3d38242aef1d404512371fe05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->