### PR TITLE
Add DeepSeek-V4.1-Flash / 新增 DeepSeek-V4.1-Flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,7 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 | ---------------------- | ----- | ----------- | ----------------------------------- | ---------------------------------- |
 | DeepSeek-R1-0528       | 671B  | 37B         | `deepseek-ai/DeepSeek-R1-0528`      | HF model card                      |
 | DeepSeek-V4-Pro        | 1.6T  | 49B         | `deepseek-ai/DeepSeek-V4-Pro`       | HF model card                      |
+| DeepSeek-V4.1-Flash    | 552B  | 8B / 16B    | `deepseek-ai/DeepSeek-V4.1-Flash`   | HF model card                      |
 | Kimi-K2.5              | 1T    | 32B         | `moonshotai/Kimi-K2.5`              | HF model card                      |
 | Kimi-K2.6              | 1T    | 32B         | `moonshotai/Kimi-K2.6`              | HF model card                      |
 | Kimi-K2.7-Code         | 1T    | 32B         | `moonshotai/Kimi-K2.7-Code`         | HF model card                      |
@@ -236,6 +237,15 @@ Authoritative total / active parameter counts for every model in the dashboard. 
 
 **Common mislabel traps** (have all bitten this repo at least once — do not repeat):
 
+- **DeepSeek-V4.1-Flash is 552B, and its active count is two numbers.** The
+  Causal Encoder-Decoder split means 8B activates during prefill and 16B during
+  decode — quoting a single "active" figure loses that. The 196B Engram
+  conditional-memory table is excluded from the 552B backbone total: it is
+  sparsely accessed by token lookup, not resident per-token compute, so it is
+  treated like a separate MTP head rather than like Qwen3.8's n-gram embedding
+  table (which IS counted). Hugging Face safetensors metadata says 485B, which
+  matches neither figure. Do not fold it into the `dsv4` bucket — V4.1-Flash is
+  a different architecture (CED + CSA2), not a V4-Pro point release.
 - **Qwen3.8-Flash-Next is 176B, not 125B.** The model card leads with "125B with 6B activated", but that is the main model only; the 51B n-gram embedding table brings the total to 176B. The separate 4B MTP head sits outside both figures. It is a Qwen4-architecture preview (GatedDeltaNet + Qwen Sparse Attention, 512 experts, 10 routed + 1 shared), not a Qwen3.5 point release, so it gets its own DB bucket.
 - **GLM-5 ≠ 355B.** 355B is GLM-4.5. GLM-5 jumped to 744B / 40B active (256-expert MoE with DSA).
 - **MiniMax-M2.5/M2.7 ≠ 456B.** 456B is the older MiniMax-Text-01 / M1 (32 large experts). The M2 series is a different architecture: 230B / 10B active, 256 small experts.

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -5,6 +5,7 @@ import { TCO_SOURCE_TITLE, TCO_SOURCE_URL } from '@semianalysisai/inferencex-con
 // rows follow.
 const MODEL_LABELS = [
   'DeepSeek V4 Pro 0813 1.6T',
+  'DeepSeek V4.1 Flash 552B',
   'Kimi K3 2.8T',
   'MiniMax M3 428B',
   'GLM5.2/GLM5.3',
@@ -22,11 +23,13 @@ const PLATFORM_HEADERS = [
 ];
 
 const SINGLE_TURN = 'single_turn_8k1k';
-/** Six models: one with both a single-turn and an AgentX row (Qwen3.5),
- *  three curated AgentX-only (Kimi K3, GLM 5.2, Qwen3.8-Flash-Next), and two
- *  AgentX-only by retirement: MiniMax M3's 8k1k sweep stopped on 2026-08-04
- *  (InferenceX#2493) and DeepSeek V4 Pro's on 2026-09-08 (InferenceX#2728). */
-const MATRIX_ROWS = 7;
+/** Seven models: one with both a single-turn and an AgentX row (Qwen3.5),
+ *  four curated AgentX-only (Kimi K3, GLM 5.2, Qwen3.8-Flash-Next, and
+ *  DeepSeek V4.1 Flash, which entered the fleet on AgentX only in
+ *  InferenceX#2961), and two AgentX-only by retirement: MiniMax M3's 8k1k
+ *  sweep stopped on 2026-08-04 (InferenceX#2493) and DeepSeek V4 Pro's on
+ *  2026-09-08 (InferenceX#2728). */
+const MATRIX_ROWS = 8;
 const AGENTX = 'agentx';
 const AGENTX_LABEL = 'Long Context Multi-Turn Realistic Agentic Scenario (AgentX)';
 const AGENTX_LABEL_ZH = '长上下文、多轮交互的真实智能体场景（AgentX）';
@@ -1265,7 +1268,13 @@ describe('Overview page', () => {
     for (const label of MODEL_LABELS) {
       cy.get('[data-testid="overview-desktop-matrix"]').should('contain.text', label);
     }
-    for (const model of ['DeepSeek-V4-Pro', 'Kimi-K3', 'GLM-5.2', 'MiniMax-M3']) {
+    for (const model of [
+      'DeepSeek-V4-Pro',
+      'DeepSeek-V4.1-Flash',
+      'Kimi-K3',
+      'GLM-5.2',
+      'MiniMax-M3',
+    ]) {
       desktopModel(model).within(() => {
         expectAgentxScenario(AGENTX_LABEL);
       });

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -679,11 +679,10 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    // Reviewed for the DeepSeek V4 Pro single-turn 8k1k retirement
-    // (InferenceX#2728): OVERVIEW_MODEL_SCENARIOS drops the model's 8K/1K
-    // matrix row and overviewScenarioForModel falls back to AgentX. No
-    // parameter or OverviewPageData shape change, so the docs stand.
-    sourceSha256: '3b0a8ee4f9b9a50fd34688357dca82e55bf433c9b3a6bdcd23ef18c9bf192078',
+    // Reviewed for the DeepSeek-V4.1-Flash addition (InferenceX#2961): the
+    // model joins OVERVIEW_MODEL_SCENARIOS as AgentX-only. Curated scenario
+    // data, no parameter or OverviewPageData shape change, so the docs stand.
+    sourceSha256: 'PLACEHOLDER_OVERVIEW',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',
@@ -702,7 +701,7 @@ export const apiContractSourceDigests = [
     // Reviewed again for the release-date corrections: values inside
     // MODEL_RELEASE_DATES only. No published model name, alias, or parameter enum
     // is touched, and no endpoint exposes a release date, so the docs stand.
-    sourceSha256: '9faf1ed1ed1712ee04741b6aa2291d42b2c202c2dadbb1a2681b5391da555e6c',
+    sourceSha256: '37a7dc5e2aeb2fda93f17563eb0fd3d6db401080a4d31d6619625d96a6ef8dae',
     reviewArea: {
       en: 'Published benchmark and TCO model names, aliases, and parameter enums.',
       zh: '已发布基准与 TCO 模型名称、别名和参数枚举。',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -682,7 +682,7 @@ export const apiContractSourceDigests = [
     // Reviewed for the DeepSeek-V4.1-Flash addition (InferenceX#2961): the
     // model joins OVERVIEW_MODEL_SCENARIOS as AgentX-only. Curated scenario
     // data, no parameter or OverviewPageData shape change, so the docs stand.
-    sourceSha256: 'PLACEHOLDER_OVERVIEW',
+    sourceSha256: '18ffcb420cc933479c67025415848966294a8ebd28c084471cd58474ce96133f',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -701,7 +701,7 @@ export const apiContractSourceDigests = [
     // Reviewed again for the release-date corrections: values inside
     // MODEL_RELEASE_DATES only. No published model name, alias, or parameter enum
     // is touched, and no endpoint exposes a release date, so the docs stand.
-    sourceSha256: '37a7dc5e2aeb2fda93f17563eb0fd3d6db401080a4d31d6619625d96a6ef8dae',
+    sourceSha256: 'bb58d43160c2b83ce61e7c34326a6d316fd751e435c6819f1991ed69e4f1b45c',
     reviewArea: {
       en: 'Published benchmark and TCO model names, aliases, and parameter enums.',
       zh: '已发布基准与 TCO 模型名称、别名和参数枚举。',

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -8,6 +8,8 @@ import {
   FEATURED_AGENTX_MODELS,
 } from './compare-agentx';
 import { COMPARE_MODEL_SLUGS } from './compare-slug';
+import { Model } from './data-mappings';
+import { overviewScenariosForModel } from './overview-data';
 
 describe('AgentX comparison links', () => {
   it('keeps the live AgentX models in the editorial order', () => {
@@ -42,6 +44,45 @@ describe('AgentX comparison links', () => {
   it('routes every featured model to a registered inference page without query params', () => {
     for (const model of FEATURED_AGENTX_MODELS) {
       expect(agentxDashboardHref('en', model)).toBe(`/inference/${model.slug}`);
+    }
+  });
+
+  it('routes an AgentX-only model to AgentX without promoting it to the hero', () => {
+    // DeepSeek V4.1 Flash has no 8K/1K sweep, so the 8K/1K fallback would SSR
+    // an empty compare page. Scenario and editorial placement are separate
+    // decisions: it gets the right workload, and stays out of the hero ledger
+    // and the NEW badge set.
+    const flash = COMPARE_MODEL_SLUGS.find((model) => model.slug === 'deepseek-v41-flash')!;
+    expect(comparisonScenarioForModel(flash)).toEqual({
+      label: 'AgentX',
+      sequence: 'agentic-traces',
+    });
+    expect(comparisonPairHref('en', 'deepseek-v41-flash-gb300-vs-b200', flash)).toBe(
+      '/compare/deepseek-v41-flash-gb300-vs-b200/agentic',
+    );
+    expect(
+      comparisonPairHref('zh', 'deepseek-v41-flash-gb300-vs-b200', flash, 'compare-per-dollar'),
+    ).toBe('/zh/compare-per-dollar/deepseek-v41-flash-gb300-vs-b200/agentic');
+    expect(FEATURED_AGENTX_MODELS.map((model) => model.slug)).not.toContain('deepseek-v41-flash');
+    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES.has('DeepSeek-V4.1-Flash')).toBe(false);
+  });
+
+  it('agrees with the overview matrix about which models are AgentX-only', () => {
+    // Two modules encode the same fact — the compare scenario set here and
+    // OVERVIEW_MODEL_SCENARIOS in overview-data.ts. This pins the agreement so
+    // curating one without the other fails here instead of silently SSRing an
+    // empty compare page. compare-agentx.ts cannot import the overview module
+    // directly: ChartControls is a client component, and the import would drag
+    // the matrix builder into the browser bundle.
+    const modelValues = new Set<string>(Object.values(Model));
+    for (const entry of COMPARE_MODEL_SLUGS) {
+      if (!modelValues.has(entry.displayName)) continue;
+      const scenarios = overviewScenariosForModel(entry.displayName as Model);
+      if (!scenarios.includes('agentx') || scenarios.includes('single_turn_8k1k')) continue;
+      expect(comparisonScenarioForModel(entry), `${entry.slug} is AgentX-only`).toEqual({
+        label: 'AgentX',
+        sequence: 'agentic-traces',
+      });
     }
   });
 

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -12,7 +12,30 @@ const FEATURED_AGENTX_MODEL_SLUGS = [
   'qwen-3-8-flash-next',
 ] as const;
 
-const FEATURED_AGENTX_MODEL_SET = new Set<string>(FEATURED_AGENTX_MODEL_SLUGS);
+/**
+ * AgentX-only models that are NOT part of the editorial featured set above.
+ *
+ * The featured list is an editorial ordering — it drives the compare hero
+ * ledger and the NEW badge in the /inference model selector. Which workload a
+ * model actually has data for is a separate, factual question, and the two
+ * stopped coinciding with DeepSeek V4.1 Flash: it entered the fleet on AgentX
+ * only (InferenceX#2961), so defaulting it to 8K/1K renders an empty compare
+ * page, but promoting it into the hero is a product decision this list
+ * deliberately does not make.
+ *
+ * Keep this in sync with OVERVIEW_MODEL_SCENARIOS in `overview-data.ts` — that
+ * map is the same fact for the overview matrix. `compare-agentx.test.ts` pins
+ * the agreement rather than importing the overview module here, which would
+ * pull the matrix builder into the client bundle through ChartControls.
+ */
+const AGENTX_ONLY_MODEL_SLUGS = ['deepseek-v41-flash'] as const;
+
+/** Every model whose default compare workload is AgentX: the editorial
+ *  featured set plus the AgentX-only models kept out of it. */
+const AGENTX_SCENARIO_MODEL_SET = new Set<string>([
+  ...FEATURED_AGENTX_MODEL_SLUGS,
+  ...AGENTX_ONLY_MODEL_SLUGS,
+]);
 
 export interface ComparisonScenario {
   label: 'AgentX' | '8K/1K';
@@ -58,7 +81,7 @@ export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug
 }
 
 export function comparisonScenarioForModel(model: CompareModelSlug): ComparisonScenario {
-  return FEATURED_AGENTX_MODEL_SET.has(model.slug)
+  return AGENTX_SCENARIO_MODEL_SET.has(model.slug)
     ? { label: 'AgentX', sequence: 'agentic-traces' }
     : { label: '8K/1K', sequence: '8k/1k' };
 }

--- a/packages/app/src/lib/compare-slug.test.ts
+++ b/packages/app/src/lib/compare-slug.test.ts
@@ -265,6 +265,7 @@ describe('compareModelSeoName', () => {
   // slashes, no param-count suffix, no fully-qualified checkpoint id.
   const EXPECTED: Record<string, string> = {
     'deepseek-v4': 'DeepSeek V4 Pro',
+    'deepseek-v41-flash': 'DeepSeek V4.1 Flash',
     'deepseek-r1': 'DeepSeek R1',
     'kimi-k3': 'Kimi K3',
     'kimi-k26': 'Kimi K2.6',

--- a/packages/app/src/lib/compare-slug.ts
+++ b/packages/app/src/lib/compare-slug.ts
@@ -54,6 +54,15 @@ export const COMPARE_MODEL_SLUGS: CompareModelSlug[] = [
     seoName: 'DeepSeek V4 Pro',
   },
   {
+    slug: 'deepseek-v41-flash',
+    displayName: 'DeepSeek-V4.1-Flash',
+    // Causal Encoder-Decoder + CSA2 architecture, not a V4-Pro point release,
+    // so it gets its own slug and DB bucket rather than joining deepseek-v4.
+    dbKeys: ['dsv41flash'],
+    label: 'DeepSeek V4.1 Flash 552B',
+    seoName: 'DeepSeek V4.1 Flash',
+  },
+  {
     slug: 'deepseek-r1',
     displayName: 'DeepSeek-R1-0528',
     dbKeys: ['dsr1'],

--- a/packages/app/src/lib/compare-ssr.ts
+++ b/packages/app/src/lib/compare-ssr.ts
@@ -56,6 +56,7 @@ export const KNOWN_MODELS = new Set([
   'GLM-5',
   'GLM-5.2',
   'DeepSeek-V4-Pro',
+  'DeepSeek-V4.1-Flash',
 ]);
 export const KNOWN_SEQUENCES = new Set(['1k/1k', '1k/8k', '8k/1k', 'agentic-traces']);
 export const KNOWN_PRECISIONS = new Set(['fp4', 'fp4fp8', 'fp8', 'bf16', 'int4', 'nvfp4', 'mxfp4']);

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -14,6 +14,7 @@ export enum Model {
   GLM_5 = 'GLM-5',
   GLM_5_2 = 'GLM-5.2',
   DeepSeek_V4_Pro = 'DeepSeek-V4-Pro',
+  DeepSeek_V4_1_Flash = 'DeepSeek-V4.1-Flash',
 }
 
 export type CategoryTag = 'default' | 'experimental' | 'maintenance' | 'deprecated' | 'hidden';
@@ -141,6 +142,18 @@ const MODEL_CONFIG: Record<Model, ModelConfig> = {
     openRouterModelId: 'deepseek/deepseek-v4-pro-0813',
     logo: 'deepseek-color.svg',
     exclusion: MTP_ENGINE_EXCLUSION,
+  },
+  [Model.DeepSeek_V4_1_Flash]: {
+    // Separate architecture from V4-Pro (Causal Encoder-Decoder + CSA2), not a
+    // point release, so it keeps its own DB bucket and dropdown entry. Label
+    // carries the 552B backbone total; the 196B Engram conditional-memory table
+    // is sparsely accessed via token lookup and is excluded, matching how the
+    // separate MTP head is excluded elsewhere.
+    label: 'DeepSeek V4.1 Flash 552B',
+    prefix: 'dsv41flash',
+    category: 'default',
+    openRouterModelId: 'deepseek/deepseek-v4.1-flash',
+    logo: 'deepseek-color.svg',
   },
   [Model.Kimi_K3]: {
     // K3 is a separate 2.8T KDA/MLA-hybrid architecture, not a K2 point release,

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -1348,6 +1348,7 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     // above the 8K/1K row, each group in MODEL_CONFIG declaration order.
     expect(page.models.map((m) => `${m.model}/${m.scenario}`)).toEqual([
       `${Model.DeepSeek_V4_Pro}/agentx`,
+      `${Model.DeepSeek_V4_1_Flash}/agentx`,
       `${Model.Kimi_K3}/agentx`,
       `${Model.MiniMax_M3}/agentx`,
       `${Model.GLM_5_2}/agentx`,

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -374,6 +374,9 @@ const OVERVIEW_MODEL_SCENARIOS: Partial<Record<Model, readonly OverviewScenario[
   [Model.Kimi_K3]: ['agentx'],
   [Model.GLM_5_2]: ['agentx'],
   [Model.Qwen3_8_Flash_Next]: ['agentx'],
+  // V4.1 Flash entered the fleet on AgentX only (first sweep 2026-09-10,
+  // InferenceX#2961, GB300 agentic traces); no 8K/1K sweep exists yet.
+  [Model.DeepSeek_V4_1_Flash]: ['agentx'],
 };
 
 /** The scenarios this model gets a row for. Unlisted models keep the single

--- a/packages/app/src/lib/rankings.test.ts
+++ b/packages/app/src/lib/rankings.test.ts
@@ -67,7 +67,7 @@ describe('rankings registry', () => {
   it('has one page per (kind, model) pair', () => {
     const entries = getAllRankingPageEntries();
     expect(entries.length).toBe(RANKING_KINDS.length * INFERENCE_MODEL_SLUGS.length);
-    expect(entries.length).toBe(24);
+    expect(entries.length).toBe(26);
   });
 
   it('has unique, well-formed slugs', () => {

--- a/packages/app/src/lib/run-pages.test.ts
+++ b/packages/app/src/lib/run-pages.test.ts
@@ -35,7 +35,7 @@ describe('run pages registry', () => {
   it('has one candidate per (model, chip) pair', () => {
     const entries = getAllRunPageEntries();
     expect(entries.length).toBe(INFERENCE_MODEL_SLUGS.length * getAllChipPages().length);
-    expect(entries.length).toBe(108);
+    expect(entries.length).toBe(117);
   });
 
   it('has unique, well-formed slugs', () => {

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -27,6 +27,9 @@ export const DB_MODEL_TO_DISPLAY: Record<string, string> = {
   'glm5.1': 'GLM-5',
   'glm5.2': 'GLM-5.2',
   dsv4: 'DeepSeek-V4-Pro',
+  // V4.1-Flash is a separate CED/CSA2 architecture (552B backbone, 8B prefill /
+  // 16B decode active), not a V4-Pro point release, so it gets its own bucket.
+  dsv41flash: 'DeepSeek-V4.1-Flash',
 };
 
 /**
@@ -127,6 +130,11 @@ export const MODEL_RELEASE_DATES: Record<string, string> = {
   // license. The 2026-06-01 launch shipped API access only; the arXiv report
   // followed on 2026-06-11. sweep: 2026-06-12.
   'MiniMax-M3': '2026-06-07',
+  // DeepSeek-V4.1-Flash — MIT weights published at deepseek-ai/DeepSeek-V4.1-Flash
+  // on 2026-09-10 UTC (HF repo initial commit 02:17Z, tech report 05:34Z). The
+  // vLLM bring-up image is tagged `deepseekv41-flash-0909`, a day earlier, but
+  // that is the image build date, not the weights date. sweep: 2026-09-10 — day zero.
+  'DeepSeek-V4.1-Flash': '2026-09-10',
   // V4 Preview — V4-Pro (1.6T total / 49B active) and V4-Flash (284B/13B)
   // published together under MIT on Hugging Face, the API and chat.deepseek.com.
   // V4-Pro-0813 went GA on 2026-08-13, but the Hugging Face repo still hosts the

--- a/packages/constants/src/models.ts
+++ b/packages/constants/src/models.ts
@@ -115,6 +115,11 @@ export const MODEL_RELEASE_DATES: Record<string, string> = {
   // InferenceX benchmark — recorded so the "cannot predate its own weights"
   // invariant above is checkable by eye at review time.
   //
+  // DeepSeek-V4.1-Flash — MIT weights published at deepseek-ai/DeepSeek-V4.1-Flash
+  // on 2026-09-10 UTC (HF repo initial commit 02:17Z, tech report 05:34Z). The
+  // vLLM bring-up image is tagged `deepseekv41-flash-0909`, a day earlier, but
+  // that is the image build date, not the weights date. sweep: 2026-09-10 — day zero.
+  'DeepSeek-V4.1-Flash': '2026-09-10',
   // Weights published on Hugging Face 2026-07-27 under the Kimi K3 License,
   // eleven days after the 2026-07-16 product launch; the gap was to let vLLM,
   // NVIDIA and AMD prepare day-zero support. sweep: 2026-07-27 — day zero.
@@ -130,11 +135,6 @@ export const MODEL_RELEASE_DATES: Record<string, string> = {
   // license. The 2026-06-01 launch shipped API access only; the arXiv report
   // followed on 2026-06-11. sweep: 2026-06-12.
   'MiniMax-M3': '2026-06-07',
-  // DeepSeek-V4.1-Flash — MIT weights published at deepseek-ai/DeepSeek-V4.1-Flash
-  // on 2026-09-10 UTC (HF repo initial commit 02:17Z, tech report 05:34Z). The
-  // vLLM bring-up image is tagged `deepseekv41-flash-0909`, a day earlier, but
-  // that is the image build date, not the weights date. sweep: 2026-09-10 — day zero.
-  'DeepSeek-V4.1-Flash': '2026-09-10',
   // V4 Preview — V4-Pro (1.6T total / 49B active) and V4-Flash (284B/13B)
   // published together under MIT on Hugging Face, the API and chat.deepseek.com.
   // V4-Pro-0813 went GA on 2026-08-13, but the Hugging Face repo still hosts the

--- a/packages/db/src/etl/normalizers.ts
+++ b/packages/db/src/etl/normalizers.ts
@@ -119,6 +119,8 @@ export const MODEL_TO_KEY: Record<string, string> = {
   'zai-org/GLM-5.2-FP8': 'glm5.2',
   // DeepSeek-V4-Pro
   'deepseek-ai/DeepSeek-V4-Pro': 'dsv4',
+  // DeepSeek-V4.1-Flash
+  'deepseek-ai/DeepSeek-V4.1-Flash': 'dsv41flash',
 };
 
 /**


### PR DESCRIPTION
## Summary

Registers **DeepSeek-V4.1-Flash** as a dashboard model, sourced from the GB300 AgentX sweep in [SemiAnalysisAI/InferenceX#2961](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34463351592) — DB key `dsv41flash`, HF path `deepseek-ai/DeepSeek-V4.1-Flash`, FP4 / vLLM / TP4 / MTP on `gb300-nv`, concurrencies 1–128.

Preview of the source run: https://inferencex.semianalysis.com/inference?unofficialRun=34463351592

### Changes

| File | Change |
| --- | --- |
| `packages/constants/src/models.ts` | `dsv41flash → 'DeepSeek-V4.1-Flash'` + release date `2026-09-10` |
| `packages/db/src/etl/normalizers.ts` | `'deepseek-ai/DeepSeek-V4.1-Flash' → 'dsv41flash'` |
| `packages/app/src/lib/data-mappings.ts` | `Model` enum member + `MODEL_CONFIG` entry |
| `packages/app/src/lib/compare-slug.ts` | `deepseek-v41-flash` slug |
| `packages/app/src/lib/compare-ssr.ts` | `KNOWN_MODELS` entry so `?g_model=` validates |
| `packages/app/src/lib/overview-data.ts` | curated AgentX-only in the overview matrix |
| `packages/app/src/lib/api-route-catalog.ts` | refreshed two shared-source digests |
| 4 test files | updated pinned expectations (see below) |

### Decisions worth reviewing

- **Own DB bucket, not a `dsv4` point release.** V4.1-Flash is a Causal Encoder-Decoder architecture with CSA2 sparse attention — structurally different from V4-Pro, so grouping them under one display name would misrepresent both. Same treatment as `kimik3` vs the K2 series and `minimaxm3` vs the M2 series.
- **Label reads 552B, not 748B.** The HF card gives a 552B backbone (8B active in prefill, 16B in decode) plus a 196B Engram conditional-memory table. Engram is sparsely accessed via token lookup rather than being resident per-token compute, so it is excluded — consistent with excluding separate MTP heads elsewhere. Flagging this explicitly because the Qwen3.8-Flash-Next precedent went the *other* way (its 51B n-gram embedding table **is** folded into the 176B total). If you read Engram as the same kind of thing, the label should become 748B.
- **Release date 2026-09-10.** Hugging Face repo initial commit at 02:17Z today; tech report uploaded 05:34Z. The `deepseekv41-flash-0909` container tag is a day earlier, but that is the image build date, not the weights date. First sweep is same-day — day zero.
- **AgentX-only in the overview matrix.** Only agentic-traces rows exist; curating it this way keeps the matrix from showing an 8K/1K row that will never fill. Remove the `OVERVIEW_MODEL_SCENARIOS` entry once a fixed-sequence sweep lands.
- **The compare-slug entry is structurally required, not scope creep.** `INFERENCE_MODEL_SLUGS`, `MODEL_ROUTES`, `/rankings` and `/run` all derive from `COMPARE_MODEL_SLUGS`, and their tests demand coverage for every non-hidden model. As a side effect the model now appears on `/compare`, `/compare-per-dollar`, `/inference/deepseek-v41-flash`, `/calculator/…`, `/historical/…` and the sitemap. The hardcoded `DESCRIPTION` catalog blurbs on `/compare` and `/compare-per-dollar` were left alone — say the word if it should be named there.
- **OpenRouter id verified**, not guessed: `deepseek/deepseek-v4.1-flash` exists in the live `/api/v1/models` catalog.

### Deliberately not in this PR

- `MODEL_ARCHITECTURES` — no diagram renders until added; wants verified `config.json` values.
- The `MTP_ENGINE_EXCLUSION` that V4-Pro carries. Only vLLM MTP has swept this model, so the guard has nothing to separate yet. It should be added the moment an SGLang MTP run lands on the same SKU.

### Test expectation updates

All four are mechanical consequences of one more visible model, not behavior changes: the compare-slug SEO-name map, the overview fixture row order, `/rankings` 24 → 26 pages, `/run` 108 → 117 candidates. The two `api-route-catalog` digests were refreshed after confirming the docs need no copy change — both `SUPPORTED_TCO_MODELS` and the overview scenario curation are derived from the data, not hand-written into the reference.

### Chinese pages

No `/zh` page authoring needed. Model names, hardware SKUs and framework names stay English per the translation quality bar, and every affected surface (`/zh/compare/[slug]`, `/zh/inference/[model]`, `/zh/calculator/[model]`, …) is a dynamic route that picks the new model up from the same registries.

### Verification

`bun run typecheck`, `bun run lint`, `bun run fmt`, and `bun run test:unit` (5297 passed, 4 skipped) all pass locally.

> ⚠️ **Deploy order matters.** Per `docs/adding-entities.md`, the `packages/db` and `packages/constants` changes must be merged and deployed **before** the next ingest — otherwise `dsv41flash` rows resolve to `null` and are silently skipped.

## 中文说明

将 **DeepSeek-V4.1-Flash** 注册为仪表板模型，数据来自 [SemiAnalysisAI/InferenceX#2961](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34463351592) 的 GB300 AgentX sweep —— DB key 为 `dsv41flash`，HF 路径 `deepseek-ai/DeepSeek-V4.1-Flash`，在 `gb300-nv` 上以 FP4 / vLLM / TP4 / MTP 运行，并发 1–128。

### 需要评审的几个判断

- **单独建桶，而非 `dsv4` 的小版本更新。** V4.1-Flash 采用 Causal Encoder-Decoder 架构与 CSA2 稀疏注意力，与 V4-Pro 在结构上不同，合并显示会同时误导两者。处理方式与 `kimik3`（相对 K2 系列）、`minimaxm3`（相对 M2 系列）一致。
- **标签写 552B，而不是 748B。** HF model card 给出 552B backbone（prefill 激活 8B，decode 激活 16B），另有 196B 的 Engram 条件记忆表。Engram 通过 token 查表稀疏访问，并非每 token 常驻计算，因此不计入总量 —— 与此前排除独立 MTP head 的口径一致。这里特别标注出来，是因为 Qwen3.8-Flash-Next 的先例恰好相反：其 51B n-gram embedding 表**是**计入 176B 总量的。如果认为 Engram 属于同一类，标签应改为 748B。
- **发布日期 2026-09-10。** 依据 Hugging Face 仓库今日 02:17Z 的首次提交，技术报告于 05:34Z 上传。容器 tag 中的 `0909` 早一天，但那是镜像构建日期而非权重发布日期。首次 sweep 与发布同日，属于 day zero。
- **overview 矩阵中标记为仅 AgentX。** 目前只有 agentic traces 数据，这样标记可以避免矩阵中出现永远不会填充的 8K/1K 行。待定长序列 sweep 上线后移除该 `OVERVIEW_MODEL_SCENARIOS` 条目。
- **compare-slug 条目是结构性必需项，并非范围扩张。** `INFERENCE_MODEL_SLUGS`、`MODEL_ROUTES`、`/rankings` 与 `/run` 均由 `COMPARE_MODEL_SLUGS` 派生，相关测试要求覆盖每个非 hidden 模型。因此该模型会同时出现在 `/compare`、`/compare-per-dollar`、`/inference/deepseek-v41-flash`、`/calculator/…`、`/historical/…` 以及 sitemap 中。`/compare` 与 `/compare-per-dollar` 中硬编码的 `DESCRIPTION` 文案未改动，如需在其中列出该模型请告知。
- **OpenRouter id 已核实**（非猜测）：`deepseek/deepseek-v4.1-flash` 存在于线上 `/api/v1/models` 目录中。

### 本 PR 有意未包含

- `MODEL_ARCHITECTURES`：缺失时不渲染架构图，需要经核实的 `config.json` 数值。
- V4-Pro 所带的 `MTP_ENGINE_EXCLUSION`：目前只有 vLLM MTP 跑过该模型，该保护规则尚无可区分的对象。一旦同一 SKU 上出现 SGLang MTP 运行，应立即补上。

### 测试预期更新

四处改动都只是"多了一个可见模型"的机械结果，并非行为变更：compare-slug 的 SEO 名称映射、overview fixture 行序、`/rankings` 24 → 26 个页面、`/run` 108 → 117 个候选。两处 `api-route-catalog` digest 是在确认文档无需改动文案后刷新的 —— `SUPPORTED_TCO_MODELS` 与 overview 场景 curation 都由数据派生，并非手写进 API 参考。

### 中文页面

无需新增 `/zh` 页面。按翻译质量标准，模型名称、硬件 SKU 与框架名称保持英文；所有受影响的页面（`/zh/compare/[slug]`、`/zh/inference/[model]`、`/zh/calculator/[model]` 等）都是动态路由，会自动从同一批注册表中读取新模型。

### 验证

本地 `bun run typecheck`、`bun run lint`、`bun run fmt`、`bun run test:unit`（5297 通过，4 跳过）全部通过。

> ⚠️ **注意部署顺序。** 依据 `docs/adding-entities.md`，`packages/db` 与 `packages/constants` 的改动必须在下一次 ingest **之前**合并并部署，否则 `dsv41flash` 行会解析为 `null` 并被静默跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad but additive registry wiring across app, constants, and DB ETL; wrong deploy order before ingest would drop rows, and AgentX-only curation must stay aligned with compare routing.
> 
> **Overview**
> Adds **DeepSeek-V4.1-Flash** end-to-end as its own model (DB key `dsv41flash`, compare slug `deepseek-v41-flash`), separate from **DeepSeek-V4-Pro**, with labels anchored on the **552B** backbone and AgentX-only curation until an 8K/1K sweep exists.
> 
> **Data & ingest:** `packages/constants` and `packages/db` ETL map `deepseek-ai/DeepSeek-V4.1-Flash` → `dsv41flash` and record release date **2026-09-10**. **App registries:** `Model` / `MODEL_CONFIG`, `COMPARE_MODEL_SLUGS`, compare SSR `KNOWN_MODELS`, and `/overview` `OVERVIEW_MODEL_SCENARIOS` (AgentX row after V4 Pro). **Compare behavior:** `compare-agentx` splits *editorial* featured AgentX models from *factual* AgentX-only slugs so V4.1 Flash links to `/…/agentic` without joining the hero ledger or NEW badges; tests lock that agreement with the overview matrix.
> 
> **Docs & QA:** `AGENTS.md` parameter table and a new mislabel trap for CED/Engram sizing; Cypress overview expectations (8 matrix rows); bumped rankings/run page counts; refreshed `api-route-catalog` digests after confirming no public API doc copy change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e68f2ae44a6d044fc9f7601c67328fb0f5a754b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->