### PR TITLE
[PowerX] use PUE 1.3 for air-cooled system estimates / 风冷系统功耗估算采用 PUE 1.3

### DIFF
--- a/docs/powerx-system-power.md
+++ b/docs/powerx-system-power.md
@@ -5,7 +5,7 @@ the non-agentic 8192-input/1024-output workload. The existing app transformation
 and the offline article exporter both call `modelSystemPower`; the API and
 benchmark producer continue returning their original measurements.
 
-`system-power-model.profiles.json` records the pinned Oren model revision,
+`system-power-model.profiles.json` records the pinned power model revision,
 component source hashes, hardware mapping, complete platform configuration, and
 fixed inference assumptions. Its profiles come from executing the original
 Python components. `system-power-model.ts` preserves their nonlinear fan curve,
@@ -25,8 +25,8 @@ PUE is applied after chassis AC, including the source's rounding order.
 
 The fixed README inference sweep uses `u_cpu=0.20`, `u_ram=0.20`, `u_pcie=0.05`,
 and `u_nvme=0.0`. The pinned Python model defaults to PUE `1.2`; PowerX uses
-`1.3` for its supported air-cooled chassis profiles, following Oren's updated
-policy: utility power = critical IT power × PUE (`1.3` air, `1.1` DLC).
+`1.3` for its supported air-cooled chassis profiles. Utility power = critical IT
+power × PUE (`1.3` air, `1.1` DLC).
 The factor applies after chassis AC; measured GPU power and chassis AC do not change.
 Cooling describes the modeled chassis, not verified benchmark-site cooling.
 The current profiles do not model DLC; `--pue` remains an explicit facility-factor
@@ -145,13 +145,13 @@ dropping that replicate.
 
 ## 中文说明
 
-PowerX 的系统功耗结果以实测 GPU 功率为输入，使用固定版本的 Oren 模型估算
+PowerX 的系统功耗结果以实测 GPU 功率为输入，使用固定版本的功耗模型估算
 8-GPU 机箱的 AC 输入功率，再单独应用 PUE 得到设施功率估计。CPU 和 DRAM 利用率
 均假设为 20%；这些是模型参数，不是实测利用率。完整平台配置、源码版本和校验和
 随导出结果保留。模型源码仍标记为待人工核验，数值一致性不代表完成了实机校准。
 
-固定版本的 Python 模型默认 PUE 为 1.2；PowerX 按 Oren 更新后的约定，对当前风冷
-机箱模型采用 1.3。市电侧功率 = IT 负载功率 × PUE，风冷取 1.3，直接液冷（DLC）
+固定版本的 Python 模型默认 PUE 为 1.2；PowerX 对当前风冷机箱模型
+采用 1.3。市电侧功率 = IT 负载功率 × PUE，风冷取 1.3，直接液冷（DLC）
 取 1.1。PUE 仅作用于机箱交流功率，不改变 GPU 实测功率或机箱交流功率。这里的
 冷却方式指建模机箱，并非已核实的测试站点配置。当前模型不支持 DLC；`--pue` 仅
 覆盖设施功率系数，不会把风冷机箱模型转换为液冷模型。

--- a/docs/powerx-system-power.md
+++ b/docs/powerx-system-power.md
@@ -24,7 +24,14 @@ board, fans, and PSU conversion losses. Facility power is a separate estimate:
 PUE is applied after chassis AC, including the source's rounding order.
 
 The fixed README inference sweep uses `u_cpu=0.20`, `u_ram=0.20`, `u_pcie=0.05`,
-and `u_nvme=0.0`. PUE defaults to `1.2`. Platform-specific network assumptions,
+and `u_nvme=0.0`. The pinned Python model defaults to PUE `1.2`; PowerX uses
+`1.3` for its supported air-cooled chassis profiles, following Oren's updated
+policy: utility power = critical IT power × PUE (`1.3` air, `1.1` DLC).
+The factor applies after chassis AC; measured GPU power and chassis AC do not change.
+Cooling describes the modeled chassis, not verified benchmark-site cooling.
+The current profiles do not model DLC; `--pue` remains an explicit facility-factor
+override and does not convert an air-cooled chassis model into a DLC model.
+Platform-specific network assumptions,
 fan control, component counts, and chassis defaults are preserved in the
 generated profile; every JSON export includes that profile and every CSV row
 includes its applicable assumptions and profile hash. These are model inputs,
@@ -85,7 +92,7 @@ bun packages/app/scripts/export-modeled-system-power.ts \
 
 bun packages/app/scripts/export-modeled-system-power.ts \
   --input /path/to/qwen35-current.input.json \
-  --output /path/to/new-current-qwen-comparison --pue 1.2
+  --output /path/to/new-current-qwen-comparison --pue 1.3
 ```
 
 The maintained input shape is `ComparisonInput` in the script:
@@ -142,6 +149,12 @@ PowerX 的系统功耗结果以实测 GPU 功率为输入，使用固定版本�
 8-GPU 机箱的 AC 输入功率，再单独应用 PUE 得到设施功率估计。CPU 和 DRAM 利用率
 均假设为 20%；这些是模型参数，不是实测利用率。完整平台配置、源码版本和校验和
 随导出结果保留。模型源码仍标记为待人工核验，数值一致性不代表完成了实机校准。
+
+固定版本的 Python 模型默认 PUE 为 1.2；PowerX 按 Oren 更新后的约定，对当前风冷
+机箱模型采用 1.3。市电侧功率 = IT 负载功率 × PUE，风冷取 1.3，直接液冷（DLC）
+取 1.1。PUE 仅作用于机箱交流功率，不改变 GPU 实测功率或机箱交流功率。这里的
+冷却方式指建模机箱，并非已核实的测试站点配置。当前模型不支持 DLC；`--pue` 仅
+覆盖设施功率系数，不会把风冷机箱模型转换为液冷模型。
 
 仅使用部分 GPU 的机箱（单台主机上实测 1–7 张 GPU）按实测每卡功率 × 8 建模，
 与模型源码 sweep 脚本喂给各机箱模型的 `n_gpu × W/GPU` 输入一致，并假设未实测的

--- a/packages/app/scripts/export-modeled-system-power.ts
+++ b/packages/app/scripts/export-modeled-system-power.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import type { BenchmarkRow } from '../src/lib/api';
-import { modelSystemPower } from '../src/lib/modeled-system-power';
+import { AIR_COOLED_SYSTEM_PUE, modelSystemPower } from '../src/lib/modeled-system-power';
 import profileData from '../src/lib/system-power-model.profiles.json';
 
 interface PowerAudit {
@@ -119,7 +119,7 @@ function estimatedEnergy(
   };
 }
 
-export function buildComparison(input: ComparisonInput, pue = profileData.assumptions.pue) {
+export function buildComparison(input: ComparisonInput, pue = AIR_COOLED_SYSTEM_PUE) {
   if (!input || typeof input.cohort !== 'string' || !Array.isArray(input.rows)) {
     throw new Error(
       'Expected a cohort envelope with a rows array. See docs/powerx-system-power.md.',
@@ -321,7 +321,7 @@ async function main() {
   });
   if (!values.input || !values.output)
     throw new Error(
-      'Usage: bun packages/app/scripts/export-modeled-system-power.ts --input cohort.json --output NEW_DIRECTORY [--pue 1.2]',
+      'Usage: bun packages/app/scripts/export-modeled-system-power.ts --input cohort.json --output NEW_DIRECTORY [--pue 1.3]',
     );
   const inputBytes = await readFile(values.input);
   const result = buildComparison(

--- a/packages/app/src/lib/modeled-system-power-export.test.ts
+++ b/packages/app/src/lib/modeled-system-power-export.test.ts
@@ -86,6 +86,11 @@ describe('offline modeled PowerX comparisons', () => {
     const source = input();
     const before = structuredClone(source);
     const result = buildComparison(source);
+    expect(result.metadata.pue).toBe(1.3);
+    expect(result.metadata.model.assumptions.pue).toBe(1.2);
+    expect(result.rows[0].modeled).toMatchObject({ pue: 1.3 });
+    expect(result.rows[0].assumptions).toMatchObject({ pue: 1.3 });
+    expect(buildComparison(source, 1.1).rows[0].modeled).toMatchObject({ pue: 1.1 });
     expect(result.rows[0].estimated_energy).toMatchObject({
       status: 'estimated',
       output_tokens: 9303,
@@ -124,7 +129,7 @@ describe('offline modeled PowerX comparisons', () => {
     });
     const result = buildComparison(source);
     const row = result.rows[0];
-    const reference = estimateChassisPower('h200', entry.benchmark.metrics.avg_power_w * 8)!;
+    const reference = estimateChassisPower('h200', entry.benchmark.metrics.avg_power_w * 8, 1.3)!;
     expect(row.modeled).toMatchObject({
       status: 'supported',
       gpuCount: 4,

--- a/packages/app/src/lib/modeled-system-power.test.ts
+++ b/packages/app/src/lib/modeled-system-power.test.ts
@@ -50,12 +50,28 @@ function row(overrides: Partial<BenchmarkRow> = {}): BenchmarkRow {
 }
 
 describe('modeled system power admission and accounting', () => {
+  it('defaults air-cooled chassis to PUE 1.3 and preserves explicit facility overrides', () => {
+    // Pinned Python b200_chassis_power, fixed README utilization inputs.
+    expect(modelSystemPower(row())).toMatchObject({
+      pue: 1.3,
+      chassisAcWatts: 4837.2,
+      facilityWatts: 6288.4,
+      measuredGpuWattsPerGpu: 349.859,
+    });
+    expect(modelSystemPower(row(), 1.1)).toMatchObject({
+      pue: 1.1,
+      chassisAcWatts: 4837.2,
+      facilityWatts: 5320.9,
+      measuredGpuWattsPerGpu: 349.859,
+    });
+  });
+
   it('uses the validated physical count without summing aggregate aliases or multiplying by EP', () => {
     const source = row({ num_prefill_gpu: 64, num_decode_gpu: 64, prefill_ep: 8, decode_ep: 8 });
     const result = modelSystemPower(source);
     expect(result.status).toBe('supported');
     if (result.status !== 'supported') throw new Error(result.reason);
-    const reference = estimateChassisPower('b200', 2798.868)!;
+    const reference = estimateChassisPower('b200', 2798.868, 1.3)!;
     expect(result).toMatchObject({
       gpuCount: 8,
       chassisCount: 1,
@@ -132,7 +148,7 @@ describe('modeled system power admission and accounting', () => {
     expect(result.status).toBe('supported');
     if (result.status !== 'supported') throw new Error(result.reason);
     // The source sweep's input for the whole chassis: n_gpu × W/GPU.
-    const reference = estimateChassisPower('b200', 349.859 * 8)!;
+    const reference = estimateChassisPower('b200', 349.859 * 8, 1.3)!;
     expect(result).toMatchObject({
       gpuCount: 4,
       chassisCount: 1,
@@ -182,8 +198,8 @@ describe('modeled system power admission and accounting', () => {
         decode_avg_power_w: 700,
       },
     });
-    const prefill = estimateChassisPower('b200', 2400)!;
-    const decode = estimateChassisPower('b200', 5600)!;
+    const prefill = estimateChassisPower('b200', 2400, 1.3)!;
+    const decode = estimateChassisPower('b200', 5600, 1.3)!;
     expect(modelSystemPower(source)).toMatchObject({
       status: 'supported',
       gpuCount: 12,
@@ -369,8 +385,8 @@ describe('modeled system power admission and accounting', () => {
       },
     });
     const result = modelSystemPower(source);
-    const prefill = estimateChassisPower('b200', 2400)!;
-    const decode = estimateChassisPower('b200', 5600)!;
+    const prefill = estimateChassisPower('b200', 2400, 1.3)!;
+    const decode = estimateChassisPower('b200', 5600, 1.3)!;
     expect(result).toMatchObject({
       status: 'supported',
       gpuCount: 16,

--- a/packages/app/src/lib/modeled-system-power.ts
+++ b/packages/app/src/lib/modeled-system-power.ts
@@ -2,9 +2,11 @@ import type { BenchmarkRow } from '@/lib/api';
 import {
   estimateChassisPower,
   SUPPORTED_SYSTEM_POWER_HARDWARE,
-  SYSTEM_POWER_ASSUMPTIONS,
   SYSTEM_POWER_MODEL_REVISION,
 } from '@/lib/system-power-model';
+
+// Application policy for the air-cooled chassis profiles; the pinned Python default stays 1.2.
+export const AIR_COOLED_SYSTEM_PUE = 1.3;
 
 /** Every supported chassis model describes one complete eight-GPU HGX/OAM system. */
 const CHASSIS_GPU_COUNT = 8;
@@ -89,7 +91,7 @@ function unavailable(reason: SystemPowerUnsupportedReason): SystemPowerEstimate 
  */
 export function modelSystemPower(
   row: BenchmarkRow,
-  pue: number = SYSTEM_POWER_ASSUMPTIONS.pue,
+  pue: number = AIR_COOLED_SYSTEM_PUE,
 ): SystemPowerEstimate {
   if (row.benchmark_type !== 'single_turn' || row.isl !== 8192 || row.osl !== 1024) {
     return unavailable('workload');


### PR DESCRIPTION
## Summary

Default PowerX system estimates and the shared JSON/CSV exporter to PUE 1.3 for the existing air-cooled chassis profiles. Apply the multiplier after chassis AC; measured GPU power and modeled IT-side power retain their values.

The pinned Python model and its original 1.2 reference default remain unchanged. Explicit PUE overrides still work. Document the 1.1 DLC policy without claiming DLC chassis support or inferring actual site cooling from a GPU identity.

## Validation

- 50 focused model/accounting/export tests pass, including the pinned Python reference matrix.
- Explicit 1.3 and 1.1 B200 outputs match Python; exporter records the effective PUE separately from source defaults.
- Typecheck, lint, formatting and typography checks pass. CI pending.

## 中文说明

PowerX 当前风冷机箱估算及共用 JSON/CSV 导出默认采用 PUE 1.3。系数仅作用于机箱交流功率；GPU 实测功率与 IT 侧功率不变。固定版本的 Python 模型及原始 1.2 默认值保持不变，仍可显式覆盖 PUE。说明 DLC 的 1.1 系数，但不声称支持液冷机箱模型，也不从 GPU 型号推断实际站点的冷却方式。

50 项定向测试通过，1.3 和 1.1 的 B200 输出与 Python 一致；类型、lint、格式和排版检查通过，CI 尚待完成。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Policy change to facility-power multipliers only; chassis modeling and telemetry paths are untouched, with tests locking expected wattages.
> 
> **Overview**
> PowerX **air-cooled** chassis facility estimates now default to **PUE 1.3** via a new `AIR_COOLED_SYSTEM_PUE` constant on `modelSystemPower` and the offline `buildComparison` exporter (replacing the pinned profile’s **1.2** Python default). **Chassis AC** and measured GPU power are unchanged; only **facility** watts scale with the multiplier, and explicit `--pue` / argument overrides still apply.
> 
> Docs (EN + 中文) clarify the split: Python reference stays at 1.2, PowerX uses 1.3 for supported air-cooled profiles, documents a **1.1 DLC policy** without modeling DLC chassis, and notes that `--pue` is a facility-factor override—not a cooling-mode switch. Tests and exporter examples were updated to assert the new default while keeping `metadata.model.assumptions.pue` at 1.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5c92965f251c3d71505fd53bbba4343523e44b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

