### PR TITLE
Retire the DeepSeek V4 Pro single-turn 8k1k scenario / 停用 DeepSeek V4 Pro 单轮 8k1k 场景

### DIFF
--- a/packages/app/cypress/component/chart-selectors.cy.tsx
+++ b/packages/app/cypress/component/chart-selectors.cy.tsx
@@ -619,6 +619,28 @@ describe('Chart Selectors', () => {
         .should('have.text', '8K / 1K (deprecated)');
     });
 
+    it('marks 8K/1K retired for DeepSeek V4 Pro while AgentX stays active', () => {
+      // DeepSeek V4 Pro's single-turn 8k1k sweep ran for the last time on
+      // 2026-09-08 (InferenceX#2728, MODELS.md): the fixed-length option
+      // carries the deprecated status, the agentic option does not.
+      cy.mount(
+        <TooltipProvider delayDuration={0}>
+          <ScenarioSelector
+            value={Sequence.AgenticTraces}
+            onChange={() => {}}
+            availableSequences={[Sequence.EightK_OneK, Sequence.AgenticTraces]}
+            model={Model.DeepSeek_V4_Pro}
+            data-testid="scenario-selector"
+          />
+        </TooltipProvider>,
+      );
+      cy.get('[data-testid="scenario-selector"]').click();
+      cy.contains('[data-select-option]', '8K / 1K (deprecated)').should('be.visible');
+      cy.contains('[data-select-option]', 'Agentic')
+        .should('be.visible')
+        .and('not.contain.text', 'deprecated');
+    });
+
     for (const locale of ['en', 'zh']) {
       it(`keeps retired choices selectable in one fixed-length group with inline status (${locale})`, () => {
         cy.viewport(390, 720);
@@ -634,7 +656,7 @@ describe('Chart Selectors', () => {
                     Sequence.EightK_OneK,
                     Sequence.OneK_OneK,
                   ]}
-                  model={Model.DeepSeek_V4_Pro}
+                  model={Model.Qwen3_5}
                   data-testid="scenario-selector"
                 />
               </div>
@@ -694,7 +716,7 @@ describe('Chart Selectors', () => {
             value={Sequence.AgenticTraces}
             onChange={() => {}}
             availableSequences={[Sequence.EightK_OneK, Sequence.AgenticTraces]}
-            model={Model.DeepSeek_V4_Pro}
+            model={Model.Qwen3_5}
             data-testid="scenario-selector"
           />
         </TooltipProvider>,

--- a/packages/app/cypress/e2e/current-inferencex-image.cy.ts
+++ b/packages/app/cypress/e2e/current-inferencex-image.cy.ts
@@ -23,8 +23,10 @@ describe('Current InferenceX Image localized routes', () => {
       image: 'lmsysorg/sglang:v0.5.2',
       date: today,
     },
+    // A model still sweeping 8K/1K. DeepSeek V4 Pro retired its 8k1k sweep on
+    // 2026-09-08 (InferenceX#2728), so it no longer qualifies here.
     {
-      model: 'dsv4',
+      model: 'qwen3.5',
       hardware: 'b200',
       framework: 'vllm',
       precision: 'fp4',
@@ -214,10 +216,13 @@ describe('Current InferenceX Image localized routes', () => {
   it('lists only model-scenario pairs that are still benchmarked', () => {
     cy.viewport(1440, 900);
     const retiredImage = 'lmsysorg/sglang:v0.4.9-minimax-8k1k-retired';
+    const retiredDeepSeekImage = 'vllm/vllm-openai:v0.10.0-dsv4-8k1k-retired';
     const activeMiniMaxImage = 'lmsysorg/sglang:v0.5.2-minimax-agentic';
     const deprecatedModelImage = 'vllm/vllm-openai:v0.9.0-kimi-k2.5';
     cy.intercept('GET', '**/api/v1/latest-images', [
       ...imageRows,
+      // DeepSeek V4 Pro retired its 8K/1K sweep on 2026-09-08 (InferenceX#2728).
+      { ...imageRows[1], model: 'dsv4', image: retiredDeepSeekImage, date: '2026-09-08' },
       // MiniMax M3 retired its 8K/1K sweep on 2026-08-04; AgentX stays active.
       {
         ...imageRows[0],
@@ -253,6 +258,7 @@ describe('Current InferenceX Image localized routes', () => {
       .should('contain.text', 'lmsysorg/sglang:v0.5.2')
       .and('contain.text', 'vllm/vllm-openai:v0.10.1')
       .and('not.contain.text', retiredImage)
+      .and('not.contain.text', retiredDeepSeekImage)
       .and('not.contain.text', deprecatedModelImage);
 
     cy.get('#image-sequence-select').click();

--- a/packages/app/cypress/e2e/overview.cy.ts
+++ b/packages/app/cypress/e2e/overview.cy.ts
@@ -22,11 +22,11 @@ const PLATFORM_HEADERS = [
 ];
 
 const SINGLE_TURN = 'single_turn_8k1k';
-/** Six models: two with both a single-turn and an AgentX row (DeepSeek,
- *  Qwen3.5), and four curated AgentX-only (Kimi K3, GLM 5.2,
- *  Qwen3.8-Flash-Next, and MiniMax M3, whose 8k1k sweep was retired on
- *  2026-08-04 in InferenceX#2493). */
-const MATRIX_ROWS = 8;
+/** Six models: one with both a single-turn and an AgentX row (Qwen3.5),
+ *  three curated AgentX-only (Kimi K3, GLM 5.2, Qwen3.8-Flash-Next), and two
+ *  AgentX-only by retirement: MiniMax M3's 8k1k sweep stopped on 2026-08-04
+ *  (InferenceX#2493) and DeepSeek V4 Pro's on 2026-09-08 (InferenceX#2728). */
+const MATRIX_ROWS = 7;
 const AGENTX = 'agentx';
 const AGENTX_LABEL = 'Long Context Multi-Turn Realistic Agentic Scenario (AgentX)';
 const AGENTX_LABEL_ZH = '长上下文、多轮交互的真实智能体场景（AgentX）';
@@ -487,7 +487,7 @@ describe('Overview page', () => {
     desktopModel('DeepSeek-R1-0528')
       .find('[data-testid="overview-model-category-badge"]')
       .should('have.attr', 'data-category', 'maintenance');
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN)
+    desktopModel('DeepSeek-V4-Pro', AGENTX)
       .find('[data-testid="overview-model-category-badge"]')
       .should('not.exist');
     cy.get('[data-testid="overview-desktop-model"]').then(([...rows]) => {
@@ -834,9 +834,8 @@ describe('Overview page', () => {
       platform('b200')
         .find('[data-testid="overview-cost-delta"]')
         .should('have.attr', 'data-history-status', 'comparable');
-      platform('mi355x')
-        .find('[data-testid="overview-cost-delta"]')
-        .should('have.attr', 'data-history-status', 'comparable');
+      // MI355X has a baseline but no exact @50 read today: nothing to compare.
+      platform('mi355x').find('[data-testid="overview-cost-delta"]').should('not.exist');
     });
 
     cy.contains(
@@ -1074,7 +1073,7 @@ describe('Overview page', () => {
       platform('mi355x').should('not.contain.text', 'STP');
     });
 
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       // Speculative decode is the expected case and goes unlabelled; the stack
       // badge stops at framework and precision.
       cy.contains('SGLang · FP4').should('exist');
@@ -1142,7 +1141,7 @@ describe('Overview page', () => {
       expectCellTint('mi355x', 'rgba(16, 185, 129,');
     });
 
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       platform('gb200')
         .find('[data-testid="overview-cost-delta"]')
         .should('contain.text', '+71%')
@@ -1249,8 +1248,8 @@ describe('Overview page', () => {
             expect(getComputedStyle(header).fontSize).to.equal('14px');
           }
         });
-        // One row per curated (model, scenario) pair: six models, two of
-        // which (DeepSeek, Qwen3.5) carry a second single-turn row.
+        // One row per curated (model, scenario) pair: six models, one of
+        // which (Qwen3.5) carries a second single-turn row.
         cy.get('[data-testid="overview-desktop-model"]').should('have.length', MATRIX_ROWS);
         cy.get('[data-testid="overview-platform"]').should('have.length', MATRIX_ROWS * 5);
         cy.get('[data-testid="overview-model-coverage-note"]').should('not.exist');
@@ -1266,43 +1265,35 @@ describe('Overview page', () => {
     for (const label of MODEL_LABELS) {
       cy.get('[data-testid="overview-desktop-matrix"]').should('contain.text', label);
     }
-    for (const model of ['Kimi-K3', 'GLM-5.2', 'MiniMax-M3']) {
+    for (const model of ['DeepSeek-V4-Pro', 'Kimi-K3', 'GLM-5.2', 'MiniMax-M3']) {
       desktopModel(model).within(() => {
         expectAgentxScenario(AGENTX_LABEL);
       });
     }
-    for (const model of ['DeepSeek-V4-Pro', 'Qwen-3.5-397B-A17B']) {
-      desktopModel(model, SINGLE_TURN)
-        .find('[data-testid="overview-model-scenario"]')
-        .should('have.text', '8K/1K');
-    }
+    desktopModel('Qwen-3.5-397B-A17B', SINGLE_TURN)
+      .find('[data-testid="overview-model-scenario"]')
+      .should('have.text', '8K/1K');
   });
 
   it('gives a model benchmarked on both scenarios one row each, priced independently', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
-    cy.get('[data-testid="overview-desktop-model"][data-model="DeepSeek-V4-Pro"]').should(
+    cy.get('[data-testid="overview-desktop-model"][data-model="Qwen-3.5-397B-A17B"]').should(
       'have.length',
       2,
     );
     // The AgentX row sits in the leading AgentX group; the single-turn row
     // follows in the 8K/1K group below it, both under the same label.
-    cy.get('[data-testid="overview-desktop-model"][data-model="DeepSeek-V4-Pro"]').then(($rows) => {
-      expect([...$rows].map((row) => row.dataset.scenario)).to.deep.equal([AGENTX, SINGLE_TURN]);
-    });
+    cy.get('[data-testid="overview-desktop-model"][data-model="Qwen-3.5-397B-A17B"]').then(
+      ($rows) => {
+        expect([...$rows].map((row) => row.dataset.scenario)).to.deep.equal([AGENTX, SINGLE_TURN]);
+      },
+    );
 
-    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
+    desktopModel('Qwen-3.5-397B-A17B', AGENTX).within(() => {
       expectAgentxScenario(AGENTX_LABEL);
-      cy.contains('DeepSeek V4 Pro 0813 1.6T').should('exist');
-      // Priced from the AgentX rows alone — the single-turn sweep never leaks in.
-      cy.get(
-        '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
-      ).should('have.text', '$0.064');
-      cy.get(
-        '[data-testid="overview-pair-value"][data-hardware="mi355x"] [data-testid="overview-cost-evidence-link"]',
-      ).should('have.text', '$0.069');
-      cy.get('[data-testid="overview-pair-missing"]').should('have.length', 3);
+      cy.contains('Qwen3.5 397B').should('exist');
       // Its detail link points at the agentic-traces workload, not 8K→1K.
       cy.contains('a', 'View details')
         .should('have.attr', 'href')
@@ -1312,15 +1303,34 @@ describe('Overview page', () => {
       cy.contains('a', 'View details').should(
         'have.attr',
         'aria-label',
-        `View details: DeepSeek V4 Pro 0813 1.6T · ${AGENTX_LABEL}`,
+        `View details: Qwen3.5 397B · ${AGENTX_LABEL}`,
       );
     });
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('Qwen-3.5-397B-A17B', SINGLE_TURN).within(() => {
       cy.contains('a', 'View details').should(
         'have.attr',
         'aria-label',
-        'View details: DeepSeek V4 Pro 0813 1.6T · 8K/1K',
+        'View details: Qwen3.5 397B · 8K/1K',
       );
+    });
+
+    // DeepSeek V4 Pro retired its single-turn 8k1k sweep on 2026-09-08
+    // (InferenceX#2728): only the AgentX row remains, and it is priced from
+    // the agentic-trace rows — no stale 8K/1K row lingers below it.
+    cy.get('[data-testid="overview-desktop-model"][data-model="DeepSeek-V4-Pro"]').should(
+      'have.length',
+      1,
+    );
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
+      expectAgentxScenario(AGENTX_LABEL);
+      cy.contains('DeepSeek V4 Pro 0813 1.6T').should('exist');
+      cy.get(
+        '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
+      ).should('have.text', '$0.059');
+      cy.get('[data-testid="overview-pair-missing"]').should('have.length', 3);
+      cy.contains('a', 'View details')
+        .should('have.attr', 'href')
+        .and('include', 'i_seq=agentic-traces');
     });
   });
 
@@ -1395,7 +1405,7 @@ describe('Overview page', () => {
       });
     });
 
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       // A cell without a read at the tier carries no evidence link either.
       platform('gb300').within(() => {
         cy.get('[data-testid="overview-cost-evidence-link"]').should('not.exist');
@@ -1408,7 +1418,7 @@ describe('Overview page', () => {
     cy.viewport(1280, 900);
     cy.visit('/overview');
 
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       platform('mi355x').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="mi355x"]')
           .should('contain.text', '—')
@@ -1521,7 +1531,7 @@ describe('Overview page', () => {
     });
 
     cy.visit('/overview?tier=30');
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       platform('b300').within(() => {
         cy.get('[data-testid="overview-pair-missing"][data-hardware="b300"]')
           .should('contain.text', '—')
@@ -1581,7 +1591,7 @@ describe('Overview page', () => {
           ).should('have.text', '$0.062');
         });
       });
-      mobileModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+      mobileModel('DeepSeek-V4-Pro', AGENTX).within(() => {
         cy.get(
           '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
         ).should('have.text', '$0.059');
@@ -1602,7 +1612,7 @@ describe('Overview page', () => {
       cy.viewport(width, 844);
       cy.visit('/overview');
 
-      mobileModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+      mobileModel('DeepSeek-V4-Pro', AGENTX).within(() => {
         cy.get('[data-testid="overview-mobile-platform-row"]')
           .should('have.length', 5)
           .then(($rows) => {
@@ -1631,7 +1641,7 @@ describe('Overview page', () => {
       cy.viewport(width, 900);
       cy.visit('/overview');
 
-      mobileModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+      mobileModel('DeepSeek-V4-Pro', AGENTX).within(() => {
         cy.get('[data-testid="overview-mobile-platform-row"]').then(($rows) => {
           const rows = [...$rows];
           expect(rows).to.have.length(5);
@@ -1793,7 +1803,7 @@ describe('Overview page', () => {
       .and('not.match', /不会外推/);
     cy.get('body').should('not.contain.text', '≈');
     expectNoVisibleDatesOrSnapshot();
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN)
+    desktopModel('DeepSeek-V4-Pro', AGENTX)
       .find(
         '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
       )
@@ -1809,7 +1819,7 @@ describe('Overview page', () => {
       .should('have.attr', 'href')
       .and('include', '/zh/inference?')
       .and('include', 'g_model=DeepSeek-V4-Pro');
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN)
+    desktopModel('DeepSeek-V4-Pro', AGENTX)
       .find('[data-testid="overview-pair-missing"][data-hardware="gb300"]')
       .should('contain.text', '—')
       .and('contain.text', '无精确 @50 结果');
@@ -1825,7 +1835,7 @@ describe('Overview page', () => {
       platform('gb300').should('contain.text', 'SGLang · FP8 · STP');
       platform('b200').find('[data-testid="overview-cost-delta"]').should('not.exist');
     });
-    desktopModel('DeepSeek-V4-Pro', SINGLE_TURN).within(() => {
+    desktopModel('DeepSeek-V4-Pro', AGENTX).within(() => {
       platform('b200').should('contain.text', 'SGLang · FP4').and('not.contain.text', 'STP');
     });
     desktopModel('MiniMax-M3', AGENTX).within(() => {
@@ -1846,7 +1856,7 @@ describe('Overview page', () => {
       expectAgentxScenario(AGENTX_LABEL_ZH);
       cy.get(
         '[data-testid="overview-pair-value"][data-hardware="b200"] [data-testid="overview-cost-evidence-link"]',
-      ).should('have.text', '$0.064');
+      ).should('have.text', '$0.059');
     });
     cy.contains('如果某款芯片没有可用的 FP4 投机解码配置，则改用次优配置。').should('exist');
 

--- a/packages/app/cypress/fixtures/api/_manifest.json
+++ b/packages/app/cypress/fixtures/api/_manifest.json
@@ -66,9 +66,9 @@
       "topLevel": "object"
     },
     "overview-rows": {
-      "bytes": 22206,
+      "bytes": 21611,
       "capturedAt": null,
-      "sha256": "ca6cb56cae88b928cc9bba01916bbf640b4579ac42c34a8cc8621db62072c72c",
+      "sha256": "9c903a976f423d96847764e045d930790592d8c992215448e1f9ac603eb0ea30",
       "source": null,
       "topLevel": "object"
     },

--- a/packages/app/cypress/fixtures/api/overview-rows.json
+++ b/packages/app/cypress/fixtures/api/overview-rows.json
@@ -19,13 +19,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "tput_per_gpu": 11700, "output_tput_per_gpu": 1300 },
+      "metrics": {
+        "p90_itl": 0.03333333333333333,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 11700,
+        "output_tput_per_gpu": 1300
+      },
       "date": "2026-06-24",
       "run_url": null
     },
@@ -48,13 +53,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "tput_per_gpu": 9000, "output_tput_per_gpu": 1000 },
+      "metrics": {
+        "p90_itl": 0.014285714285714285,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 9000,
+        "output_tput_per_gpu": 1000
+      },
       "date": "2026-07-04",
       "run_url": null
     },
@@ -77,13 +87,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 40, "tput_per_gpu": 9450, "output_tput_per_gpu": 1050 },
+      "metrics": {
+        "p90_itl": 0.025,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 9450,
+        "output_tput_per_gpu": 1050
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -106,13 +121,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 110, "tput_per_gpu": 2700, "output_tput_per_gpu": 300 },
+      "metrics": {
+        "p90_itl": 0.00909090909090909,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 2700,
+        "output_tput_per_gpu": 300
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -135,13 +155,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 60, "tput_per_gpu": 6840, "output_tput_per_gpu": 760 },
+      "metrics": {
+        "p90_itl": 0.016666666666666666,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 6840,
+        "output_tput_per_gpu": 760
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -164,13 +189,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 45, "tput_per_gpu": 9450, "output_tput_per_gpu": 1050 },
+      "metrics": {
+        "p90_itl": 0.022222222222222223,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 9450,
+        "output_tput_per_gpu": 1050
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -193,13 +223,18 @@
       "decode_num_workers": 2,
       "num_prefill_gpu": 16,
       "num_decode_gpu": 16,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 60, "tput_per_gpu": 6750, "output_tput_per_gpu": 750 },
+      "metrics": {
+        "p90_itl": 0.016666666666666666,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 6750,
+        "output_tput_per_gpu": 750
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -222,13 +257,18 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
+      "benchmark_type": "agentic_traces",
+      "isl": null,
+      "osl": null,
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "tput_per_gpu": 7200, "output_tput_per_gpu": 800 },
+      "metrics": {
+        "p90_itl": 0.03333333333333333,
+        "p90_ttlt": 120,
+        "tput_per_gpu": 7200,
+        "output_tput_per_gpu": 800
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -251,35 +291,6 @@
       "decode_num_workers": 1,
       "num_prefill_gpu": 8,
       "num_decode_gpu": 8,
-      "benchmark_type": "single_turn",
-      "isl": 8192,
-      "osl": 1024,
-      "conc": 8,
-      "offload_mode": "off",
-      "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 5100, "output_tput_per_gpu": 600 },
-      "date": "2026-07-18",
-      "run_url": null
-    },
-    {
-      "id": 28,
-      "hardware": "b200",
-      "framework": "sglang",
-      "model": "dsv4",
-      "precision": "fp4",
-      "spec_method": "mtp",
-      "disagg": false,
-      "is_multinode": false,
-      "prefill_tp": 8,
-      "prefill_ep": 1,
-      "prefill_dp_attention": false,
-      "prefill_num_workers": 1,
-      "decode_tp": 8,
-      "decode_ep": 1,
-      "decode_dp_attention": false,
-      "decode_num_workers": 1,
-      "num_prefill_gpu": 8,
-      "num_decode_gpu": 8,
       "benchmark_type": "agentic_traces",
       "isl": null,
       "osl": null,
@@ -289,42 +300,8 @@
       "metrics": {
         "p90_itl": 0.02,
         "p90_ttlt": 120,
-        "tput_per_gpu": 7500,
-        "output_tput_per_gpu": 830
-      },
-      "date": "2026-07-18",
-      "run_url": null
-    },
-    {
-      "id": 29,
-      "hardware": "mi355x",
-      "framework": "sglang",
-      "model": "dsv4",
-      "precision": "fp4",
-      "spec_method": "mtp",
-      "disagg": false,
-      "is_multinode": false,
-      "prefill_tp": 8,
-      "prefill_ep": 1,
-      "prefill_dp_attention": false,
-      "prefill_num_workers": 1,
-      "decode_tp": 8,
-      "decode_ep": 1,
-      "decode_dp_attention": false,
-      "decode_num_workers": 1,
-      "num_prefill_gpu": 8,
-      "num_decode_gpu": 8,
-      "benchmark_type": "agentic_traces",
-      "isl": null,
-      "osl": null,
-      "conc": 8,
-      "offload_mode": "off",
-      "image": null,
-      "metrics": {
-        "p90_itl": 0.02,
-        "p90_ttlt": 130,
-        "tput_per_gpu": 6000,
-        "output_tput_per_gpu": 670
+        "tput_per_gpu": 5100,
+        "output_tput_per_gpu": 600
       },
       "date": "2026-07-18",
       "run_url": null
@@ -356,7 +333,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "tput_per_gpu": 12880, "output_tput_per_gpu": 1400 },
+      "metrics": {
+        "median_intvty": 30,
+        "tput_per_gpu": 12880,
+        "output_tput_per_gpu": 1400
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -385,7 +366,11 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "tput_per_gpu": 9016, "output_tput_per_gpu": 980 },
+      "metrics": {
+        "median_intvty": 70,
+        "tput_per_gpu": 9016,
+        "output_tput_per_gpu": 980
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -414,7 +399,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 40, "tput_per_gpu": 7200, "output_tput_per_gpu": 800 },
+      "metrics": {
+        "median_intvty": 40,
+        "tput_per_gpu": 7200,
+        "output_tput_per_gpu": 800
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -443,7 +432,11 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 80, "tput_per_gpu": 5400, "output_tput_per_gpu": 600 },
+      "metrics": {
+        "median_intvty": 80,
+        "tput_per_gpu": 5400,
+        "output_tput_per_gpu": 600
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -472,7 +465,11 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 8100, "output_tput_per_gpu": 900 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 8100,
+        "output_tput_per_gpu": 900
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -501,7 +498,11 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 6688, "output_tput_per_gpu": 760 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 6688,
+        "output_tput_per_gpu": 760
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -530,7 +531,11 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 120, "tput_per_gpu": 2700, "output_tput_per_gpu": 300 },
+      "metrics": {
+        "median_intvty": 120,
+        "tput_per_gpu": 2700,
+        "output_tput_per_gpu": 300
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -559,7 +564,11 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 120, "tput_per_gpu": 5280, "output_tput_per_gpu": 600 },
+      "metrics": {
+        "median_intvty": 120,
+        "tput_per_gpu": 5280,
+        "output_tput_per_gpu": 600
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -588,7 +597,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 40, "tput_per_gpu": 7000, "output_tput_per_gpu": 778 },
+      "metrics": {
+        "median_intvty": 40,
+        "tput_per_gpu": 7000,
+        "output_tput_per_gpu": 778
+      },
       "date": "2026-06-15",
       "run_url": null
     },
@@ -617,7 +630,11 @@
       "conc": 24,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 80, "tput_per_gpu": 5250, "output_tput_per_gpu": 583 },
+      "metrics": {
+        "median_intvty": 80,
+        "tput_per_gpu": 5250,
+        "output_tput_per_gpu": 583
+      },
       "date": "2026-06-15",
       "run_url": null
     },
@@ -646,7 +663,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 8460, "output_tput_per_gpu": 900 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 8460,
+        "output_tput_per_gpu": 900
+      },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -677,7 +698,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 6993, "output_tput_per_gpu": 777 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 6993,
+        "output_tput_per_gpu": 777
+      },
       "date": "2026-07-18",
       "run_url": null
     }
@@ -708,7 +733,11 @@
       "conc": 8,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 30, "tput_per_gpu": 7380, "output_tput_per_gpu": 820 },
+      "metrics": {
+        "median_intvty": 30,
+        "tput_per_gpu": 7380,
+        "output_tput_per_gpu": 820
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -737,7 +766,11 @@
       "conc": 16,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 70, "tput_per_gpu": 5040, "output_tput_per_gpu": 560 },
+      "metrics": {
+        "median_intvty": 70,
+        "tput_per_gpu": 5040,
+        "output_tput_per_gpu": 560
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -766,7 +799,11 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 5785, "output_tput_per_gpu": 650 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 5785,
+        "output_tput_per_gpu": 650
+      },
       "date": "2026-07-18",
       "run_url": null
     },
@@ -795,7 +832,11 @@
       "conc": 12,
       "offload_mode": "off",
       "image": null,
-      "metrics": { "median_intvty": 50, "tput_per_gpu": 5400, "output_tput_per_gpu": 600 },
+      "metrics": {
+        "median_intvty": 50,
+        "tput_per_gpu": 5400,
+        "output_tput_per_gpu": 600
+      },
       "date": "2026-07-18",
       "run_url": null
     },

--- a/packages/app/src/components/latest-image/latest-image-utils.test.ts
+++ b/packages/app/src/components/latest-image/latest-image-utils.test.ts
@@ -235,16 +235,17 @@ describe('imageRowSequence', () => {
 
 describe('isActiveImageRow', () => {
   it('keeps active models on scenarios they still sweep', () => {
-    expect(isActiveImageRow(imageRow('dsv4', '8k/1k'))).toBe(true);
     expect(isActiveImageRow(imageRow('dsv4', 'agentic'))).toBe(true);
     expect(isActiveImageRow(imageRow('qwen3.5', '8k/1k'))).toBe(true);
+    expect(isActiveImageRow(imageRow('qwen3.5', 'agentic'))).toBe(true);
     expect(isActiveImageRow(imageRow('minimaxm3', 'agentic'))).toBe(true);
     // Maintenance is not deprecation: DeepSeek R1 stays listed on 8K/1K.
     expect(isActiveImageRow(imageRow('dsr1', '8k/1k'))).toBe(true);
   });
 
-  it('drops the per-model retired MiniMax M3 8K/1K sweep while keeping 8K/1K elsewhere', () => {
+  it('drops the per-model retired MiniMax M3 and DeepSeek V4 Pro 8K/1K sweeps while keeping 8K/1K elsewhere', () => {
     expect(isActiveImageRow(imageRow('minimaxm3', '8k/1k'))).toBe(false);
+    expect(isActiveImageRow(imageRow('dsv4', '8k/1k'))).toBe(false);
     expect(isActiveImageRow(imageRow('qwen3.5', '8k/1k'))).toBe(true);
   });
 

--- a/packages/app/src/lib/api-route-catalog.ts
+++ b/packages/app/src/lib/api-route-catalog.ts
@@ -679,10 +679,11 @@ export const apiContractSourceDigests = [
   },
   {
     source: 'src/lib/overview-data.ts',
-    // Reviewed for the Neocloud cost-tier removal: only a comment describing
-    // the hyperscaler-volume cost basis changed — no parameter or
-    // OverviewPageData shape change, so the docs stand.
-    sourceSha256: '16c1cf933ebb09c4421a30417de8d7107ebc5e71dab750f6d849dc11127f989d',
+    // Reviewed for the DeepSeek V4 Pro single-turn 8k1k retirement
+    // (InferenceX#2728): OVERVIEW_MODEL_SCENARIOS drops the model's 8K/1K
+    // matrix row and overviewScenarioForModel falls back to AgentX. No
+    // parameter or OverviewPageData shape change, so the docs stand.
+    sourceSha256: '3b0a8ee4f9b9a50fd34688357dca82e55bf433c9b3a6bdcd23ef18c9bf192078',
     reviewArea: {
       en: 'Overview BFF tier, engine, comparison-window, reference, and model-scope parameters plus the OverviewPageData response shape.',
       zh: '概览 BFF 的档位、引擎、对比时间窗口、参考硬件和模型范围参数，以及 OverviewPageData 响应结构。',

--- a/packages/app/src/lib/data-mappings.test.ts
+++ b/packages/app/src/lib/data-mappings.test.ts
@@ -238,11 +238,16 @@ describe('isSequenceDeprecatedForModel / getSequenceCategoryForModel', () => {
     expect(getSequenceCategoryForModel(Sequence.EightK_OneK, Model.MiniMax_M3)).toBe('deprecated');
   });
 
-  it('keeps 8K/1K default for models still sweeping it', () => {
-    expect(isSequenceDeprecatedForModel(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK)).toBe(false);
+  it('marks 8K/1K deprecated for DeepSeek V4 Pro (last sweep 2026-09-08, InferenceX#2728)', () => {
+    expect(isSequenceDeprecatedForModel(Model.DeepSeek_V4_Pro, Sequence.EightK_OneK)).toBe(true);
     expect(getSequenceCategoryForModel(Sequence.EightK_OneK, Model.DeepSeek_V4_Pro)).toBe(
-      'default',
+      'deprecated',
     );
+  });
+
+  it('keeps 8K/1K default for models still sweeping it', () => {
+    expect(isSequenceDeprecatedForModel(Model.Qwen3_5, Sequence.EightK_OneK)).toBe(false);
+    expect(getSequenceCategoryForModel(Sequence.EightK_OneK, Model.Qwen3_5)).toBe('default');
   });
 
   it('does not un-deprecate globally deprecated sequences', () => {
@@ -260,6 +265,13 @@ describe('isSequenceDeprecatedForModel / getSequenceCategoryForModel', () => {
   it('leaves MiniMax M3 agentic traces active', () => {
     expect(isSequenceDeprecatedForModel(Model.MiniMax_M3, Sequence.AgenticTraces)).toBe(false);
     expect(getSequenceCategoryForModel(Sequence.AgenticTraces, Model.MiniMax_M3)).toBe('default');
+  });
+
+  it('leaves DeepSeek V4 Pro agentic traces active', () => {
+    expect(isSequenceDeprecatedForModel(Model.DeepSeek_V4_Pro, Sequence.AgenticTraces)).toBe(false);
+    expect(getSequenceCategoryForModel(Sequence.AgenticTraces, Model.DeepSeek_V4_Pro)).toBe(
+      'default',
+    );
   });
 });
 

--- a/packages/app/src/lib/data-mappings.ts
+++ b/packages/app/src/lib/data-mappings.ts
@@ -509,9 +509,14 @@ export function getSequenceCategory(sequence: Sequence): CategoryTag {
  * MiniMax M3: the Single-turn 8k1k sweep was removed on 2026-08-04
  * (InferenceX#2493, per MODELS.md "Scenario and precision retirements");
  * Agentic coding is the model's only active scenario.
+ *
+ * DeepSeek V4 Pro: 2026-09-08 was the last day of its Single-turn 8k1k sweep
+ * (InferenceX#2728, per MODELS.md "Deprecation Notice"); Agentic coding,
+ * including the MTP and DSpark arms, stays active and the model is not retired.
  */
 const MODEL_DEPRECATED_SEQUENCES: Partial<Record<Model, ReadonlySet<Sequence>>> = {
   [Model.MiniMax_M3]: new Set([Sequence.EightK_OneK]),
+  [Model.DeepSeek_V4_Pro]: new Set([Sequence.EightK_OneK]),
 };
 
 /** Whether this model retired the scenario even though it is globally active. */

--- a/packages/app/src/lib/overview-data.test.ts
+++ b/packages/app/src/lib/overview-data.test.ts
@@ -177,7 +177,7 @@ describe('overview engine scope and scenario selection', () => {
   it('assigns each active model to its configured scenario', () => {
     expect(overviewScenarioForModel(Model.Kimi_K3)).toBe('agentx');
     expect(overviewScenarioForModel(Model.GLM_5_2)).toBe('agentx');
-    expect(overviewScenarioForModel(Model.DeepSeek_V4_Pro)).toBe('single_turn_8k1k');
+    expect(overviewScenarioForModel(Model.DeepSeek_V4_Pro)).toBe('agentx');
     expect(overviewScenarioForModel(Model.Kimi_K2_5)).toBe('single_turn_8k1k');
     expect(overviewScenarioForModel(Model.MiniMax_M3)).toBe('agentx');
     expect(overviewScenarioForModel(Model.Qwen3_5)).toBe('single_turn_8k1k');
@@ -1336,16 +1336,16 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       overviewRowsFixture as unknown as Record<string, BenchmarkRow[]>,
     );
 
-    // Curated scenarios: DeepSeek and Qwen3.5 each get both rows, Kimi K3 and
-    // GLM are AgentX-only. Kimi K2.5 is absent — deprecated models are not
-    // default models, and the matrix is built from DEFAULT_MODELS.
+    // Curated scenarios: Qwen3.5 gets both rows; Kimi K3 and GLM are
+    // AgentX-only. Kimi K2.5 is absent — deprecated models are not default
+    // models, and the matrix is built from DEFAULT_MODELS.
     // Qwen3.8-Flash-Next is curated AgentX-only, like Kimi K3 and GLM: the
     // model is benchmarked on agentic traces, so it must not claim a
-    // fixed-sequence row it will never fill. MiniMax M3 is AgentX-only too,
-    // but by retirement: its single-turn 8k1k sweep stopped on 2026-08-04
-    // (InferenceX#2493), so the matrix must not keep a row that never
-    // refreshes. AgentX rows group above the 8K/1K rows, each group in
-    // MODEL_CONFIG declaration order.
+    // fixed-sequence row it will never fill. MiniMax M3 and DeepSeek V4 Pro
+    // are AgentX-only by retirement: their single-turn 8k1k sweeps stopped on
+    // 2026-08-04 (InferenceX#2493) and after 2026-09-08 (InferenceX#2728), so
+    // the matrix must not keep rows that never refresh. AgentX rows group
+    // above the 8K/1K row, each group in MODEL_CONFIG declaration order.
     expect(page.models.map((m) => `${m.model}/${m.scenario}`)).toEqual([
       `${Model.DeepSeek_V4_Pro}/agentx`,
       `${Model.Kimi_K3}/agentx`,
@@ -1353,19 +1353,19 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
       `${Model.GLM_5_2}/agentx`,
       `${Model.Qwen3_5}/agentx`,
       `${Model.Qwen3_8_Flash_Next}/agentx`,
-      `${Model.DeepSeek_V4_Pro}/single_turn_8k1k`,
       `${Model.Qwen3_5}/single_turn_8k1k`,
     ]);
     expect(page.models.length).toBeGreaterThan(DEFAULT_MODELS.size);
     expect(page).not.toHaveProperty('datasetThroughDate');
     expect(page.tier).toBe(50);
 
-    // DeepSeek: only each series' latest-date sweep survives. B300 and MI355X
-    // therefore have no exact @50 read; GB200's independent FP8 remains visible.
-    // GB300's points are single-node and multi-node aggregate deployments, so
-    // they must not be interpolated into one synthetic serving curve.
+    // DeepSeek (AgentX): only each series' latest-date sweep survives. B300
+    // and MI355X therefore have no exact @50 read; GB200's independent FP8
+    // remains visible. GB300's points are single-node and multi-node
+    // aggregate deployments, so they must not be interpolated into one
+    // synthetic serving curve.
     const deepseek = page.models.find(
-      (m) => m.model === Model.DeepSeek_V4_Pro && m.scenario === 'single_turn_8k1k',
+      (m) => m.model === Model.DeepSeek_V4_Pro && m.scenario === 'agentx',
     )!;
     const dsB300 = headlinePairOf(deepseek, 'b300-vs-b200')!;
     expect(dsB300.baseline.read.value).toBeCloseTo(8101.968);
@@ -1391,35 +1391,13 @@ describe('assembleOverviewPageData over the overview-rows fixture', () => {
     expect(dsGb300.candidate.read.evidenceTopologies).toEqual([]);
     expect(dsGb300.candidate.missingReason).toBe('no_exact_at_tier');
 
-    // DeepSeek's AgentX row is priced from its agentic-trace rows alone — the
-    // single-turn sweeps never leak into it, so only the two benchmarked
-    // platforms carry a read.
-    const deepseekAgentx = page.models.find(
-      (m) => m.model === Model.DeepSeek_V4_Pro && m.scenario === 'agentx',
-    )!;
-    const dsxB200 = deepseekAgentx.platforms.find((p) => p.hardware === 'b200')!;
-    expect(dsxB200.read.value).toBe(7500);
-    expect(dsxB200.costPerMtok).toBeCloseTo(
-      (JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / (7500 * 3600),
-      6,
-    );
-    // Distinct from this model's single-turn B200 read (8101.968), so a
-    // regression that fed single-turn rows into this row would land there.
-    expect(dsxB200.read.value).not.toBeCloseTo(8101.968, 3);
-    const dsxMi355x = deepseekAgentx.platforms.find((p) => p.hardware === 'mi355x')!;
-    expect(dsxMi355x.read.value).toBe(6000);
-    expect(dsxMi355x.costVsReferencePct).toBeCloseTo(
-      (JULY_2026_HYPERSCALER_TCO.mi355x * 1e6) /
-        6000 /
-        ((JULY_2026_HYPERSCALER_TCO.b200 * 1e6) / 7500) -
-        1,
-      6,
-    );
+    // DeepSeek's retired single-turn 8k1k scenario gets no matrix row even
+    // though historical 8K/1K rows would still be queryable.
     expect(
-      deepseekAgentx.platforms
-        .filter((p) => ['b300', 'gb200', 'gb300'].includes(p.hardware))
-        .map((p) => p.missingReason),
-    ).toEqual(['no_scenario_data', 'no_scenario_data', 'no_scenario_data']);
+      page.models.some(
+        (m) => m.model === Model.DeepSeek_V4_Pro && m.scenario === 'single_turn_8k1k',
+      ),
+    ).toBe(false);
 
     // MiniMax: the platform result remains visible when B200 has no AgentX
     // data — priced, but with no percentage baseline (the UI's ∞ badge state).

--- a/packages/app/src/lib/overview-data.ts
+++ b/packages/app/src/lib/overview-data.ts
@@ -343,11 +343,13 @@ export function overviewScenarioForModel(
   }
   if (rows.some((row) => row.benchmark_type === 'agentic_traces')) return 'agentx';
   // AgentX-only models: Kimi K3, GLM 5.2 and Qwen3.8 Flash Next never swept
-  // 8K/1K; MiniMax M3 retired it on 2026-08-04 (InferenceX#2493, MODELS.md).
+  // 8K/1K; MiniMax M3 retired it on 2026-08-04 (InferenceX#2493, MODELS.md)
+  // and DeepSeek V4 Pro after 2026-09-08 (InferenceX#2728, MODELS.md).
   return model === Model.Kimi_K3 ||
     model === Model.GLM_5_2 ||
     model === Model.Qwen3_8_Flash_Next ||
-    model === Model.MiniMax_M3
+    model === Model.MiniMax_M3 ||
+    model === Model.DeepSeek_V4_Pro
     ? 'agentx'
     : 'single_turn_8k1k';
 }
@@ -359,7 +361,11 @@ export function overviewScenarioForModel(
  * both get one matrix row each, in OVERVIEW_SCENARIOS order.
  */
 const OVERVIEW_MODEL_SCENARIOS: Partial<Record<Model, readonly OverviewScenario[]>> = {
-  [Model.DeepSeek_V4_Pro]: ['single_turn_8k1k', 'agentx'],
+  // DeepSeek V4 Pro's single-turn 8k1k sweep ran for the last time on
+  // 2026-09-08 (InferenceX#2728, MODELS.md Deprecation Notice). Historical
+  // 8K/1K rows stay queryable, but the matrix must not keep a fixed-sequence
+  // row that will never refresh; AgentX is the model's only active scenario.
+  [Model.DeepSeek_V4_Pro]: ['agentx'],
   // MiniMax M3's single-turn 8k1k sweep was retired on 2026-08-04
   // (InferenceX#2493, MODELS.md), so the matrix must not keep a fixed-sequence
   // row that will never refresh; AgentX is the model's only active scenario.


### PR DESCRIPTION
## Summary

Tuesday **2026-09-08** was the last day of the single-turn 8k1k sweep on DeepSeek-V4-Pro 1.6T ([InferenceX#2728](https://github.com/SemiAnalysisAI/InferenceX/pull/2728), recorded under the [MODELS.md Deprecation Notice](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md)). Agentic coding, including the MTP and DSpark arms, keeps running, so this is a per-model scenario retirement in the same shape as MiniMax M3 (#966), not a model deprecation. The app still shows 8K/1K as a live DeepSeek V4 Pro scenario; this PR retires it.

- **Scenario retirement**: `MODEL_DEPRECATED_SEQUENCES` gains `DeepSeek_V4_Pro → {8K/1K}`. Scenario selectors, chart controls, the TCO calculator, the fleet lifecycle page and the latest-images gate already read `getSequenceCategoryForModel`, so 8K/1K shows as `(deprecated)` for DeepSeek V4 Pro with no component changes.
- **Overview matrix**: `OVERVIEW_MODEL_SCENARIOS[DeepSeek_V4_Pro]` is now `['agentx']` and the no-rows fallback in `overviewScenarioForModel` points at AgentX. The default matrix drops from 8 to 7 rows; Qwen3.5 is the only model left with both rows.
- **Fixtures and tests**: the DeepSeek rows in `overview-rows.json` are converted from single-turn to agentic traces (`p90_itl = 1/median_intvty`, same throughput and dates), replacing the two old conc-8 AgentX rows, so the B200 estimate, GB200 FP8 fallback, GB300 single/multi-node split and B300 latest-date pruning keep their coverage on the live row. Fixture manifest and the `overview-data.ts` docs-review digest are refreshed. Unit, component and e2e expectations follow the AgentX row (`$0.059` on B200, `+71%` on GB200, three platforms with no exact @50 result).

The hidden `dsv4-launch` favorite presets still point at 8k1k; historical 8K/1K rows remain queryable, as with MiniMax M3. Upstream enactment PR [InferenceX#2921](https://github.com/SemiAnalysisAI/InferenceX/pull/2921) removes the configs.

## Test plan

- `bun run typecheck`, `bun run lint`, `bun run fmt`: clean
- `bun run test:unit`: 4,794 passing; the one failure is the pre-existing `Object.groupBy` case on the sandbox's Node 20 runtime, unrelated (same as #966)
- Cypress component and e2e specs updated; CI runs them

## 中文说明

**2026-09-08**（周二）是 DeepSeek-V4-Pro 1.6T 单轮 8k1k 场景的最后一个运行日（[InferenceX#2728](https://github.com/SemiAnalysisAI/InferenceX/pull/2728)，见 [MODELS.md 停用通知](https://github.com/SemiAnalysisAI/InferenceX/blob/main/MODELS.md)）。智能体编程（含 MTP 与 DSpark）继续运行，因此这与 MiniMax M3（#966）一样是按模型的场景停用，而非整模型弃用。仪表板目前仍将 8K/1K 展示为 DeepSeek V4 Pro 的在用场景，本 PR 将其停用。

- **场景停用**：`MODEL_DEPRECATED_SEQUENCES` 新增 `DeepSeek_V4_Pro → {8K/1K}`。场景选择器、图表控件、TCO 计算器、机群生命周期页面和最新镜像过滤已使用 `getSequenceCategoryForModel`，因此 DeepSeek V4 Pro 的 8K/1K 直接显示为「已弃用」，无需修改组件。
- **概览矩阵**：`OVERVIEW_MODEL_SCENARIOS[DeepSeek_V4_Pro]` 改为 `['agentx']`，`overviewScenarioForModel` 的无数据回退指向 AgentX。默认矩阵从 8 行减至 7 行；Qwen3.5 成为唯一同时拥有两行的模型。
- **夹具与测试**：`overview-rows.json` 中的 DeepSeek 行由单轮转换为智能体轨迹（`p90_itl = 1/median_intvty`，吞吐与日期不变），替换原有两条 conc-8 AgentX 行，使 B200 估算、GB200 FP8 回退、GB300 单机/多机拆分和 B300 最新日期裁剪的覆盖保留在在用行上。刷新夹具清单和 `overview-data.ts` 文档审查摘要。单元、组件和端到端测试的预期随 AgentX 行更新（B200 `$0.059`，GB200 `+71%`，三个平台无精确 @50 结果）。

隐藏的 `dsv4-launch` 收藏预设仍指向 8k1k；与 MiniMax M3 一样，历史 8K/1K 数据仍可查询。上游落地 PR [InferenceX#2921](https://github.com/SemiAnalysisAI/InferenceX/pull/2921) 负责移除配置。

## 测试计划

- `bun run typecheck`、`bun run lint`、`bun run fmt`：通过
- `bun run test:unit`：4,794 项通过；唯一失败为沙箱 Node 20 运行时既有的 `Object.groupBy` 用例，与本改动无关（与 #966 相同）
- Cypress 组件与端到端测试已更新，由 CI 执行

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scenario and overview curation changes with broad test coverage; historical 8K/1K data stays queryable and no auth or API contract changes.
> 
> **Overview**
> **Retires DeepSeek V4 Pro’s single-turn 8K/1K scenario** (last sweep 2026-09-08, InferenceX#2728) while keeping Agentic coding active—same per-model pattern as MiniMax M3.
> 
> `MODEL_DEPRECATED_SEQUENCES` now marks 8K/1K deprecated for DeepSeek V4 Pro, so existing `getSequenceCategoryForModel` consumers show `(deprecated)` without UI changes. The overview matrix drops DeepSeek’s fixed-sequence row (`OVERVIEW_MODEL_SCENARIOS` → AgentX only, 7 rows; Qwen3.5 remains the sole dual-scenario model). Latest-images filtering treats `dsv4` 8K/1K rows as inactive.
> 
> **Tests and fixtures** realign: `overview-rows.json` DeepSeek entries become `agentic_traces`; Cypress/component/unit expectations move “still sweeping 8K/1K” cases to Qwen3.5 and add coverage that DeepSeek shows deprecated 8K/1K but active Agentic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d448382ad9f41a6e3566f0886416af0a29a6d632. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->