### PR TITLE
[PowerX] show power curves and correct TDP filtering / 显示功耗曲线并修正 TDP 筛选

### DIFF
--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -73,6 +73,14 @@ Different metrics need different "optimal" directions:
 
 The metric registry declares whether higher or lower values are preferable. Chart definitions derive the concrete corner from that polarity and the chart's x-axis direction, which keeps the choice in data rather than rendering code.
 
+## Power curves and optimal filtering
+
+Power axes use the same Pareto directions as other metrics while **Optimal Only** is on. A frontier can legitimately contain one point: the fastest measured configuration can also draw the least power. Turning the switch off connects the concurrency measurements for each serving configuration, date, and run with straight segments. These operating curves do not represent a Pareto frontier and must never connect unrelated configurations or runs.
+
+Measured power as a percentage of TDP has no preferred direction, so it always shows all measurements and operating curves; its optimal switch is hidden. Charts preserve the saved optimal preference when switching to another metric. Energy per token retains its existing Pareto behavior.
+
+Operating curves use linear interpolation, including after zoom, and disable gradient strategy labels and the performance ruler. Repeated conflicting measurements at the same concurrency break a curve rather than choosing a winner or bridging the conflict. The same grouping applies to unofficial-run overlays.
+
 ## Gradient Roofline Labels
 
 Parallelism strategy labels (TP4, TEP8, DPAEP4) are rendered as gradient stops along roofline paths, not as individual text labels. The reasoning:

--- a/packages/app/cypress/component/gpu-graph.cy.tsx
+++ b/packages/app/cypress/component/gpu-graph.cy.tsx
@@ -1,9 +1,12 @@
 import GPUGraph from '@/components/inference/ui/GPUGraph';
+import { InferenceContextsProvider } from '@/components/inference/InferenceContext';
+import { useState } from 'react';
 import { mountWithProviders } from '../support/test-utils';
 import {
   createMockInferenceData,
   createMockChartDefinition,
   createMockHardwareConfig,
+  createMockInferenceContextValues,
 } from '../support/mock-data';
 import { Precision, Sequence } from '@/lib/data-mappings';
 import { PathnameContext } from 'next/dist/shared/lib/hooks-client-context.shared-runtime';
@@ -484,5 +487,105 @@ describe('GPUGraph', () => {
     cy.get('.sidebar-legend').should('exist');
     // Legend should show at least one entry (date + GPU combo)
     cy.get('.sidebar-legend label').should('have.length.greaterThan', 0);
+  });
+});
+
+describe('GPU comparison power curves', () => {
+  function PowerComparison() {
+    const [optimal, setOptimal] = useState(true);
+    const [metric, setMetric] = useState('y_measuredAvgPower');
+    const [activeDates, setActiveDates] = useState(new Set(['2026-09-09_h100', '2026-09-10_h100']));
+    const rows = ['2026-09-09', '2026-09-10'].flatMap((date) =>
+      [4, 8].flatMap((tp) =>
+        [1, 8, 32].map((conc, index) =>
+          createMockInferenceData({
+            hwKey: 'h100',
+            precision: Precision.FP8,
+            date,
+            tp,
+            conc,
+            x: 200 - index * 70,
+            y: metric === 'y_measuredJPerOutputToken' ? 4 - index : 350 + index * 200 + tp,
+            run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${date}`,
+            power_tier: 'certified',
+          }),
+        ),
+      ),
+    );
+    const value = createMockInferenceContextValues({
+      selectedYAxisMetric: metric,
+      hideNonOptimal: optimal,
+      setHideNonOptimal: setOptimal,
+      selectedGPUs: ['h100'],
+      selectedDates: ['2026-09-09', '2026-09-10'],
+      selectedDateRange: { startDate: '', endDate: '' },
+      activeDates,
+      selectedPrecisions: [Precision.FP8],
+      hardwareConfig: hwConfig,
+      showLineLabels: true,
+    });
+    return (
+      <InferenceContextsProvider data={value} filters={value} display={value} actions={value}>
+        <button onClick={() => setMetric('y_measuredPowerPercentTdp')}>Percent TDP</button>
+        <button onClick={() => setMetric('y_measuredJPerOutputToken')}>Energy</button>
+        <button onClick={() => setActiveDates(new Set(['2026-09-10_h100']))}>
+          Hide older date
+        </button>
+        <div style={{ width: 1000, height: 600 }}>
+          <GPUGraph
+            chartId="gpu-power-curves"
+            modelLabel="Qwen3.5 397B"
+            data={rows}
+            xLabel="Interactivity"
+            yLabel="Power"
+            chartDefinition={createMockChartDefinition({
+              chartType: 'interactivity',
+              y_measuredAvgPower_roofline: 'lower_right',
+              y_measuredJPerOutputToken_roofline: 'lower_right',
+            })}
+          />
+        </div>
+      </InferenceContextsProvider>
+    );
+  }
+
+  it('shows isolated power sweeps when Optimal Only is off and respects date visibility', () => {
+    mountWithProviders(<PowerComparison />);
+    cy.get('#gpu-power-curves .roofline-path').should('not.exist');
+    cy.get('[data-testid="power-curve-description"]').should('contain', 'single point');
+    cy.get('#gpu-hide-non-optimal').click({ force: true });
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+    cy.get('#gpu-power-curves .roofline-path')
+      .should('have.length', 4)
+      .each(($path) => {
+        expect($path.attr('d')).to.match(/^M[^C]+L/u);
+        expect($path.attr('stroke')).not.to.equal('#6b7280');
+      });
+    cy.get('#gpu-power-curves .line-label').should('have.length', 2);
+    cy.get('[data-testid="legend-advanced-toggle"]').click();
+    cy.get('#gpu-perf-ruler').should('not.exist');
+    cy.contains('button', 'Hide older date').click();
+    cy.get('#gpu-power-curves .roofline-path').should('have.length', 2);
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
+    cy.get('#gpu-power-curves .line-label').should('have.length', 1);
+  });
+
+  it('bypasses %TDP filtering without changing the saved Optimal Only preference for energy', () => {
+    mountWithProviders(
+      <PathnameContext.Provider value="/zh/inference">
+        <PowerComparison />
+      </PathnameContext.Provider>,
+    );
+    cy.contains('button', 'Percent TDP').click();
+    cy.get('#gpu-hide-non-optimal').should('not.exist');
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+    cy.get('#gpu-power-curves .roofline-path').should('have.length', 4);
+    cy.get('[data-testid="power-curve-description"]').should('contain', '不代表 Pareto 前沿');
+    cy.contains('button', 'Energy').click();
+    cy.get('#gpu-hide-non-optimal').should('have.attr', 'data-state', 'checked');
+    cy.get('#gpu-power-curves .roofline-path')
+      .should('have.length', 2)
+      .each(($path) => expect($path.attr('d')).to.contain('C'));
+    cy.get('[data-testid="power-curve-description"]').should('not.exist');
   });
 });

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -2145,3 +2145,202 @@ describe('ChartDisplay engine comparison guard', () => {
     cy.get('#chart-0 svg .unofficial-overlay-pt').should('not.exist');
   });
 });
+
+// Reproduces Qwen3.5 power sweeps: fastest is also lowest watts, so the true
+// Pareto frontier is one point, but show-all must draw the measured load curve.
+describe('Power operating curves', () => {
+  for (const optimal of [false, true]) {
+    it(`${optimal ? 'preserves Pareto' : 'suppresses cross-configuration'} clipping continuations with Optimal Only ${optimal ? 'on' : 'off'}`, () => {
+      const runUrl = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/102';
+      const visible = createMockInferenceData({
+        hwKey: 'b200_trt',
+        tp: 4,
+        conc: 1,
+        x: 100,
+        y: 600,
+        run_url: runUrl,
+      });
+      const clipped = { ...visible, tp: 8, conc: 8, x: 1500, y: 300 };
+      mountWithProviders(
+        <div style={{ width: 1000, height: 600 }}>
+          <ScatterGraph
+            chartId="power-clipped"
+            modelLabel="Qwen3.5 397B"
+            data={[visible]}
+            clippedData={[{ point: clipped, reasons: ['latency'] }]}
+            xLabel="TTFT"
+            yLabel="Power"
+            chartDefinition={createMockChartDefinition({
+              y_measuredAvgPower_roofline: 'lower_left',
+              y_latency_limit: 1000,
+            })}
+            overlayData={{
+              data: [visible],
+              clippedData: [{ point: clipped, reasons: ['latency'] }],
+              hardwareConfig: hwConfig,
+              label: 'Power replay',
+              runUrl,
+            }}
+            transitionDuration={0}
+          />
+        </div>,
+        {
+          inference: {
+            selectedYAxisMetric: 'y_measuredAvgPower',
+            hideNonOptimal: optimal,
+            selectedPrecisions: [Precision.FP4],
+            hardwareConfig: hwConfig,
+            activeHwTypes: new Set(['b200_trt']),
+            hwTypesWithData: new Set(['b200_trt']),
+          },
+          unofficial: {
+            activeOverlayHwTypes: new Set(['b200_trt']),
+            allOverlayHwTypes: new Set(['b200_trt']),
+            runIndexByUrl: { [runUrl]: 0, '102': 0 },
+          },
+        },
+      );
+      cy.get('#power-clipped .dot-group').should('have.length', 1);
+      if (optimal) {
+        cy.get('#power-clipped .official-overflow-continuation').should('have.length', 1);
+        cy.get('#power-clipped .overlay-overflow-continuation').should('have.length', 1);
+      } else {
+        cy.get('#power-clipped .overflow-continuation').should('not.exist');
+      }
+    });
+  }
+
+  function PowerHarness() {
+    const [optimal, setOptimal] = useState(true);
+    const [metric, setMetric] = useState('y_measuredAvgPower');
+    const power = metric !== 'y_measuredJPerOutputToken';
+    const rows = [1, 8, 32].map((conc, i) =>
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        conc,
+        x: 100 - i * 30,
+        y: power ? 400 + i * 200 : 4 - i,
+        measuredAvgPower: { y: 400 + i * 200, roof: false },
+        measuredPowerPercentTdp: { y: 40 + i * 20, roof: false },
+        measuredJPerOutputToken: { y: 4 - i, roof: false },
+        run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/100',
+        power_tier: 'certified',
+      }),
+    );
+    const value = createMockInferenceContextValues({
+      selectedYAxisMetric: metric,
+      hideNonOptimal: optimal,
+      setHideNonOptimal: setOptimal,
+      selectedPrecisions: [Precision.FP4],
+      hardwareConfig: hwConfig,
+      activeHwTypes: new Set(['b200_trt']),
+      hwTypesWithData: new Set(['b200_trt']),
+    });
+    const definition = createMockChartDefinition({
+      chartType: 'interactivity',
+      y_measuredAvgPower_roofline: 'lower_right',
+      y_measuredJPerOutputToken_roofline: 'lower_right',
+    });
+    return (
+      <InferenceContextsProvider data={value} filters={value} display={value} actions={value}>
+        <button onClick={() => setMetric('y_measuredPowerPercentTdp')}>Percent TDP</button>
+        <button onClick={() => setMetric('y_measuredJPerOutputToken')}>Energy</button>
+        <div style={{ width: 1000, height: 600 }}>
+          <ScatterGraph
+            chartId="power-sweep"
+            modelLabel="Qwen3.5 397B"
+            data={rows}
+            xLabel="Interactivity"
+            yLabel="Power"
+            chartDefinition={definition}
+            transitionDuration={0}
+          />
+        </div>
+      </InferenceContextsProvider>
+    );
+  }
+
+  it('draws the full power sweep when Optimal Only is off and preserves energy frontiers', () => {
+    mountWithProviders(<PowerHarness />, { unofficial: {} });
+    cy.get('#power-sweep .roofline-path').should('not.exist');
+    cy.get('[data-testid="power-curve-description"]').should('contain', 'single point');
+    cy.get('#scatter-hide-non-optimal').click({ force: true });
+    cy.get('#power-sweep .roofline-path[data-curve-kind="operating"]')
+      .should('have.length', 1)
+      .invoke('attr', 'd')
+      .should('match', /^M[^C]+L/u);
+    cy.get('#power-sweep .dot-group')
+      .should('have.length', 3)
+      .each(($point) => cy.wrap($point).should('have.css', 'opacity', '1'));
+    cy.get('#scatter-hide-non-optimal').click({ force: true });
+    cy.get('#power-sweep .roofline-path').should('not.exist');
+    cy.contains('button', 'Percent TDP').click();
+    cy.get('#scatter-hide-non-optimal').should('not.exist');
+    cy.get('#power-sweep .roofline-path[data-curve-kind="operating"]').should('have.length', 1);
+    cy.get('#power-sweep .dot-group').each(($point) =>
+      cy.wrap($point).should('have.css', 'opacity', '1'),
+    );
+    cy.contains('button', 'Energy').click();
+    cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'checked');
+    cy.get('#power-sweep .roofline-path[data-curve-kind="pareto"]').should('have.length', 1);
+    cy.get('[data-testid="power-curve-description"]').should('not.exist');
+  });
+
+  it('keeps official and unofficial serving configurations on separate operating curves', () => {
+    const runUrl = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/101';
+    const rows = [4, 8].flatMap((tp) =>
+      [1, 8, 32].map((conc, i) =>
+        createMockInferenceData({
+          hwKey: 'b200_trt',
+          tp,
+          conc,
+          x: 100 - i * 30,
+          y: 400 + i * 200 + tp,
+          measuredAvgPower: { y: 400 + i * 200 + tp, roof: false },
+          run_url: runUrl,
+        }),
+      ),
+    );
+    mountWithProviders(
+      <div style={{ width: 1000, height: 600 }}>
+        <ScatterGraph
+          chartId="power-overlay"
+          modelLabel="Qwen3.5 397B"
+          data={rows}
+          xLabel="Interactivity"
+          yLabel="Power"
+          chartDefinition={createMockChartDefinition({
+            chartType: 'interactivity',
+            y_measuredAvgPower_roofline: 'lower_right',
+          })}
+          overlayData={{ data: rows, hardwareConfig: hwConfig, label: 'Power replay', runUrl }}
+          transitionDuration={0}
+        />
+      </div>,
+      {
+        inference: {
+          selectedYAxisMetric: 'y_measuredAvgPower',
+          hideNonOptimal: false,
+          selectedPrecisions: [Precision.FP4],
+          hardwareConfig: hwConfig,
+          activeHwTypes: new Set(['b200_trt']),
+          hwTypesWithData: new Set(['b200_trt']),
+        },
+        unofficial: {
+          activeOverlayHwTypes: new Set(['b200_trt']),
+          allOverlayHwTypes: new Set(['b200_trt']),
+          runIndexByUrl: { [runUrl]: 0, '101': 0 },
+        },
+      },
+    );
+    cy.get('#power-overlay .roofline-path[data-curve-kind="operating"]').should('have.length', 2);
+    cy.get('#power-overlay .overlay-roofline-path[data-curve-kind="operating"]')
+      .should('have.length', 2)
+      .each(($path) =>
+        cy
+          .wrap($path)
+          .invoke('attr', 'd')
+          .should('match', /^M[^C]+L/u),
+      );
+  });
+});

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -41,12 +41,12 @@ import {
   getShapeKeyForPrecision,
   logTickFormat,
 } from '@/lib/chart-rendering';
+import type { ParetoDirection } from '@/lib/chart-utils';
 import {
-  isFrontierEligible,
-  paretoFrontForDirection,
-  type ParetoDirection,
-} from '@/lib/chart-utils';
-import { canonicalParetoIntersection } from '@/components/inference/utils/canonicalFrontier';
+  chartFrontier,
+  groupOperatingCurvePoints,
+  isPowerCurveMetric,
+} from '@/components/inference/utils/powerCurves';
 import type {
   ChartDefinition,
   InferenceData,
@@ -147,6 +147,10 @@ const GPU_STRINGS = {
     logScale: 'Log Scale',
     highContrast: 'High Contrast',
     optimalOnly: 'Optimal Only',
+    powerCurves:
+      'Lines connect concurrency measurements within the same serving configuration and run; they are power curves, not Pareto frontiers.',
+    powerOptimal:
+      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show power curves across concurrency levels.',
     labels: 'Labels',
     parallelismLabels: 'Parallelism Labels',
     concurrencyLabels: '# Concurrent Sessions',
@@ -166,6 +170,9 @@ const GPU_STRINGS = {
     logScale: '对数缩放',
     highContrast: '高对比度',
     optimalOnly: '仅最优',
+    powerCurves:
+      '曲线连接同一次运行、同一推理配置在不同并发数下的测量点，表示功耗变化，不代表 Pareto 前沿。',
+    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看不同并发数下的功耗曲线。',
     labels: '标签',
     parallelismLabels: '并行配置标签',
     concurrencyLabels: '并发会话数',
@@ -208,7 +215,7 @@ const GPUGraph = React.memo(
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
-      hideNonOptimal,
+      hideNonOptimal: savedHideNonOptimal,
       showPointLabels,
       logScale,
       isLegendExpanded,
@@ -238,6 +245,12 @@ const GPUGraph = React.memo(
     } = useInferenceActions();
     const locale = useLocale();
     const legendT = GPU_STRINGS[locale];
+    const frontierDirection = chartDefinition[
+      `${selectedYAxisMetric}_roofline` as keyof ChartDefinition
+    ] as ParetoDirection | undefined;
+    const hideNonOptimal = Boolean(frontierDirection) && savedHideNonOptimal;
+    const powerCurveMetric = isPowerCurveMetric(selectedYAxisMetric);
+    const operatingCurves = powerCurveMetric && !hideNonOptimal;
     const isMeasuredEnergyAxis = isMeasuredEnergyConfigKey(selectedYAxisMetric);
     const noDataHint = isRoleLocalMeasuredEnergyConfigKey(selectedYAxisMetric)
       ? legendT.noRoleEnergyDataHint
@@ -403,27 +416,35 @@ const GPUGraph = React.memo(
       return ids;
     }, [groupedData]);
 
-    const rooflines = useMemo(() => {
+    const paretoRooflines = useMemo(() => {
       const result: Record<string, InferenceData[]> = {};
-      const rooflineKey = `${selectedYAxisMetric}_roofline` as keyof ChartDefinition;
-      const dir = chartDefinition[rooflineKey] as ParetoDirection | undefined;
-      const frontier = paretoFrontForDirection(dir ?? 'lower_right');
       for (const key of Object.keys(groupedData)) {
-        const canonicalPoints = canonicalParetoIntersection(groupedData[key], dir ?? 'lower_right');
-        result[key] = (
-          canonicalPoints ?? frontier(groupedData[key].filter(isFrontierEligible))
-        ).toSorted((a, b) => a.x - b.x);
+        result[key] = chartFrontier(groupedData[key], frontierDirection).toSorted(
+          (a, b) => a.x - b.x,
+        );
       }
       return result;
-    }, [groupedData, selectedYAxisMetric, chartDefinition]);
+    }, [groupedData, frontierDirection]);
+
+    const rooflines = useMemo(() => {
+      if (!operatingCurves) return paretoRooflines;
+      const result: Record<string, InferenceData[]> = {};
+      for (const [key, points] of Object.entries(groupedData)) {
+        let index = 0;
+        for (const segment of groupOperatingCurvePoints(points).values()) {
+          result[`${key}__operating${index++}`] = segment;
+        }
+      }
+      return result;
+    }, [operatingCurves, groupedData, paretoRooflines]);
 
     const optimalPointKeys = useMemo(() => {
       const keys = new Set<string>();
-      Object.values(rooflines).forEach((pts) =>
+      Object.values(paretoRooflines).forEach((pts) =>
         pts.forEach((p) => keys.add(`${p.date}_${p.hwKey}_${p.precision}-${p.x}-${p.y}`)),
       );
       return keys;
-    }, [rooflines]);
+    }, [paretoRooflines]);
 
     const filteredData = useMemo(() => {
       let pts = Object.values(groupedData)
@@ -580,6 +601,7 @@ const GPUGraph = React.memo(
           useAdvancedLabels ? 'advanced-labels' : 'basic-labels',
           showConcurrencyLabels ? 'conc-labels' : 'no-conc-labels',
           selectedYAxisMetric,
+          operatingCurves ? 'operating-curves' : 'pareto-curves',
           `linear:${xExtent.join(',')}`,
           `${logScale ? 'log' : 'linear'}:${yDomain.join(',')}`,
           ...filteredData.map(
@@ -590,6 +612,7 @@ const GPUGraph = React.memo(
           .join('|'),
       [
         selectedYAxisMetric,
+        operatingCurves,
         useAdvancedLabels,
         showConcurrencyLabels,
         xExtent,
@@ -612,19 +635,18 @@ const GPUGraph = React.memo(
 
     const getRooflineColor = useMemo(
       () => (key: string) => {
-        const graphId = key.split('_').slice(0, -1).join('_');
-        const graphIndex = allGraphs.findIndex((d) => d.id === graphId);
-        return graphIndex === -1 ? '#6b7280' : allGraphs[graphIndex].color;
+        const point = rooflines[key]?.[0];
+        return point ? getColor(point) : '#6b7280';
       },
-      [allGraphs],
+      [rooflines, getColor],
     );
 
     const isRooflineVisible = useMemo(
       () => (key: string) => {
-        const graphId = key.split('_').slice(0, -1).join('_');
-        return activeDates.has(graphId);
+        const point = rooflines[key]?.[0];
+        return point !== undefined && activeDates.has(`${point.date}_${point.hwKey}`);
       },
-      [activeDates],
+      [activeDates, rooflines],
     );
 
     // ── Line labels (date along each roofline) ──
@@ -640,7 +662,7 @@ const GPUGraph = React.memo(
         >();
         for (const [key, points] of Object.entries(rooflines)) {
           if (points.length < 2 || !isRooflineVisible(key)) continue;
-          const graphId = key.slice(0, key.lastIndexOf('_'));
+          const graphId = `${points[0].date}_${points[0].hwKey}`;
           const previous = bestByGraph.get(graphId);
           if (!previous || points.length > previous.points.length) {
             bestByGraph.set(graphId, { key, graphId, points });
@@ -730,7 +752,8 @@ const GPUGraph = React.memo(
     // Any two curves may be paired — two dates of the same chip config, two
     // chip configs on the same date, or a mix — which is the point of this
     // view: quantify the multiple between comparison series at a glance.
-    const [perfRulerMode, setPerfRulerMode] = useState(false);
+    const [savedPerfRulerMode, setPerfRulerMode] = useState(false);
+    const perfRulerMode = savedPerfRulerMode && !operatingCurves;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass (no lingering frame).
@@ -1139,8 +1162,8 @@ const GPUGraph = React.memo(
         .selectAll<SVGGElement, InferenceData>('.dot-group')
         .style('opacity', (d) => (`${d.date}_${d.hwKey}` === seriesId ? 1 : 0.15));
       root.selectAll<SVGPathElement, unknown>('.roofline-path').style('opacity', function () {
-        const key = (d3.select(this).datum() as { key: string } | null)?.key ?? '';
-        const series = key.slice(0, key.lastIndexOf('_'));
+        const point = (d3.select(this).datum() as { points: InferenceData[] } | null)?.points[0];
+        const series = point ? `${point.date}_${point.hwKey}` : '';
         return series === seriesId ? null : '0.15';
       });
     }, []);
@@ -1209,15 +1232,22 @@ const GPUGraph = React.memo(
         testId="gpu-graph"
         grabCursor={true}
         caption={
-          isMeasuredEnergyAxis ? (
+          isMeasuredEnergyAxis || powerCurveMetric ? (
             <>
               {caption}
-              <MeasuredPowerSummary
-                total={powerTierCounts.total}
-                visible={powerTierCounts.visible}
-                bestPerSku={false}
-                optimalOnly={hideNonOptimal}
-              />
+              {isMeasuredEnergyAxis && (
+                <MeasuredPowerSummary
+                  total={powerTierCounts.total}
+                  visible={powerTierCounts.visible}
+                  bestPerSku={false}
+                  optimalOnly={hideNonOptimal}
+                />
+              )}
+              {powerCurveMetric && (
+                <p data-testid="power-curve-description" className="text-muted-foreground text-sm">
+                  {operatingCurves ? legendT.powerCurves : legendT.powerOptimal}
+                </p>
+              )}
             </>
           ) : (
             caption
@@ -1243,6 +1273,7 @@ const GPUGraph = React.memo(
             config: {
               getColor: getRooflineColor,
               isVisible: isRooflineVisible,
+              curve: operatingCurves ? d3.curveLinear : d3.curveMonotoneX,
             },
           },
           {
@@ -1484,15 +1515,19 @@ const GPUGraph = React.memo(
                   track('interactivity_high_contrast_toggled', { enabled: c });
                 },
               },
-              {
-                id: 'gpu-hide-non-optimal',
-                label: legendT.optimalOnly,
-                checked: hideNonOptimal,
-                onCheckedChange: (c) => {
-                  setHideNonOptimal(c);
-                  track('interactivity_hide_non_optimal_toggled', { enabled: c });
-                },
-              },
+              ...(frontierDirection
+                ? [
+                    {
+                      id: 'gpu-hide-non-optimal',
+                      label: legendT.optimalOnly,
+                      checked: hideNonOptimal,
+                      onCheckedChange: (c: boolean) => {
+                        setHideNonOptimal(c);
+                        track('interactivity_hide_non_optimal_toggled', { enabled: c });
+                      },
+                    },
+                  ]
+                : []),
               {
                 id: 'gpu-point-labels',
                 label: legendT.labels,
@@ -1539,24 +1574,28 @@ const GPUGraph = React.memo(
                   if (c && !showPointLabels) setShowPointLabels(true);
                 },
               },
-              {
-                id: 'gpu-perf-ruler',
-                label: legendT.perfRuler,
-                advanced: true,
-                checked: perfRulerMode,
-                infoTooltip: legendT.perfRulerInfo,
-                onCheckedChange: (c) => {
-                  setPerfRulerMode(c);
-                  // Clear synchronously with the mode flip so the rulers vanish
-                  // in the same layout pass (the effect below also clears, for
-                  // programmatic mode changes).
-                  if (!c) setPerfRulerState(clearPerfRulers);
-                  track('gpu_timeseries_perf_ruler_toggled', { enabled: c });
-                },
-              },
+              ...(operatingCurves
+                ? []
+                : [
+                    {
+                      id: 'gpu-perf-ruler',
+                      label: legendT.perfRuler,
+                      advanced: true,
+                      checked: perfRulerMode,
+                      infoTooltip: legendT.perfRulerInfo,
+                      onCheckedChange: (c: boolean) => {
+                        setPerfRulerMode(c);
+                        // Clear synchronously with the mode flip so the rulers vanish
+                        // in the same layout pass (the effect below also clears, for
+                        // programmatic mode changes).
+                        if (!c) setPerfRulerState(clearPerfRulers);
+                        track('gpu_timeseries_perf_ruler_toggled', { enabled: c });
+                      },
+                    },
+                  ]),
             ]}
             actions={[
-              ...(perfRulerState.rulers.length > 0
+              ...(perfRulerMode && perfRulerState.rulers.length > 0
                 ? [
                     {
                       id: 'gpu-clear-perf-rulers',

--- a/packages/app/src/components/inference/ui/ScatterGraph.test-harness.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.test-harness.tsx
@@ -104,7 +104,10 @@ export const HARDWARE_CONFIG = {
   b200: { name: 'B200', label: 'B200', gpu: 'B200' },
 };
 
-const CHART_DEFINITION = { chartType: 'interactivity' } as unknown as ChartDefinition;
+const CHART_DEFINITION = {
+  chartType: 'interactivity',
+  y_roofline: 'lower_right',
+} as unknown as ChartDefinition;
 export const noop = () => {};
 
 export function baseInferenceState() {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -97,12 +97,12 @@ import {
   getShapeKeyForPrecision,
 } from '@/lib/chart-rendering';
 import { useThemeColors } from '@/hooks/useThemeColors';
+import { type ParetoDirection } from '@/lib/chart-utils';
 import {
-  isFrontierEligible,
-  paretoFrontForDirection,
-  type ParetoDirection,
-} from '@/lib/chart-utils';
-import { canonicalParetoIntersection } from '@/components/inference/utils/canonicalFrontier';
+  chartFrontier,
+  groupOperatingCurvePoints,
+  isPowerCurveMetric,
+} from '@/components/inference/utils/powerCurves';
 import type {
   ChartDefinition,
   ClippedInferenceData,
@@ -367,6 +367,10 @@ const SCATTER_STRINGS = {
     logScale: 'Log Scale',
     optimalOnly: 'Optimal Only',
     optimalInfo: 'Optimal points form the Pareto frontier for the selected axes.',
+    powerCurves:
+      'Lines connect concurrency measurements within the same serving configuration and run; they are power curves, not Pareto frontiers.',
+    powerOptimal:
+      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show power curves across concurrency levels.',
     labels: 'Labels',
     highContrast: 'High Contrast',
     parallelismLabels: 'Parallelism Labels',
@@ -395,6 +399,9 @@ const SCATTER_STRINGS = {
     logScale: '对数缩放',
     optimalOnly: '仅最优',
     optimalInfo: '最优点构成当前所选坐标轴的 Pareto 前沿。',
+    powerCurves:
+      '曲线连接同一次运行、同一推理配置在不同并发数下的测量点，表示功耗变化，不代表 Pareto 前沿。',
+    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看不同并发数下的功耗曲线。',
     labels: '标签',
     highContrast: '高对比度',
     parallelismLabels: '并行配置标签',
@@ -458,7 +465,7 @@ const ScatterGraph = React.memo(
     } = useInferenceFilters();
     const {
       selectedYAxisMetric,
-      hideNonOptimal,
+      hideNonOptimal: preferOptimalOnly,
       showPointLabels,
       highContrast,
       logScale,
@@ -466,7 +473,7 @@ const ScatterGraph = React.memo(
       isLegendExpanded,
       useAdvancedLabels,
       showConcurrencyLabels,
-      showGradientLabels,
+      showGradientLabels: preferGradientLabels,
       showLineLabels,
     } = useInferenceDisplay();
     const {
@@ -490,6 +497,16 @@ const ScatterGraph = React.memo(
       setQuickFilterSpec,
       setQuickFilterPower,
     } = useInferenceActions();
+    const paretoDirection = chartDefinition[`${selectedYAxisMetric}_roofline`] as
+      | ParetoDirection
+      | undefined;
+    const hideNonOptimal = preferOptimalOnly && Boolean(paretoDirection);
+    const isPowerAxis = isPowerCurveMetric(selectedYAxisMetric);
+    const showOperatingCurves = isPowerAxis && !hideNonOptimal;
+    const showGradientLabels = preferGradientLabels && !showOperatingCurves;
+    const groupDisplayedPoints = showOperatingCurves
+      ? groupOperatingCurvePoints
+      : groupPointsByDate;
     const locale = useLocale();
     const legendT = SCATTER_STRINGS[locale];
     const ephemeralUrlState = useEphemeralUrlState();
@@ -750,15 +767,13 @@ const ScatterGraph = React.memo(
       const result: Record<string, InferenceData[]> = {};
       const rooflineKey = `${selectedYAxisMetric}_roofline` as keyof ChartDefinition;
       const dir = chartDefinition[rooflineKey] as ParetoDirection | undefined;
-      const frontierFn = paretoFrontForDirection(dir ?? 'lower_right');
       for (const hwKey of Object.keys(groupedData)) {
         const combined: InferenceData[] = [];
         for (const datePoints of groupPointsByDate(groupedData[hwKey]).values()) {
           // Agentic modes intersect the selected-axis Pareto frontier with the
           // normalized north-star frontier. This keeps every drawn curve a true
           // Pareto frontier without admitting a non-canonical winner.
-          const canonicalPoints = canonicalParetoIntersection(datePoints, dir ?? 'lower_right');
-          const front = canonicalPoints ?? frontierFn(datePoints.filter(isFrontierEligible));
+          const front = chartFrontier(datePoints, dir);
           if (front.length === 0) continue;
           combined.push(...front);
         }
@@ -767,6 +782,8 @@ const ScatterGraph = React.memo(
       }
       return result;
     }, [groupedData, selectedYAxisMetric, chartDefinition]);
+
+    const displayedRooflines = showOperatingCurves ? groupedData : rooflines;
 
     const optimalPointKeys = useMemo(() => {
       const keys = new Set<string>();
@@ -845,6 +862,9 @@ const ScatterGraph = React.memo(
     }, [overlayData, selectedPrecisions, quickFilters, activeOverlayHwTypes]);
 
     const officialOverflowContinuations = useMemo((): OverflowContinuationEntry[] => {
+      // Pareto continuations can cross serving configurations; they are not
+      // extensions of the configuration-local power operating curves.
+      if (showOperatingCurves) return [];
       interface Bucket {
         hw: string;
         precision: string;
@@ -888,9 +908,10 @@ const ScatterGraph = React.memo(
         );
       }
       return result;
-    }, [data, clippedData, selectedYAxisMetric, chartDefinition]);
+    }, [data, clippedData, selectedYAxisMetric, chartDefinition, showOperatingCurves]);
 
     const overlayOverflowContinuations = useMemo((): OverflowContinuationEntry[] => {
+      if (showOperatingCurves) return [];
       interface Bucket {
         hw: string;
         precision: string;
@@ -946,6 +967,7 @@ const ScatterGraph = React.memo(
       selectedYAxisMetric,
       chartDefinition,
       runIndexByUrl,
+      showOperatingCurves,
     ]);
 
     // Warning annotations for visible series (official + unofficial overlay)
@@ -1001,7 +1023,7 @@ const ScatterGraph = React.memo(
       locale,
     ]);
 
-    const overlayRooflines = useMemo(() => {
+    const overlayGroups = useMemo(() => {
       interface Entry {
         hwKey: string;
         runIndex: number;
@@ -1020,18 +1042,33 @@ const ScatterGraph = React.memo(
         },
         {} as Record<string, Entry>,
       );
-      const rooflineKey = `${selectedYAxisMetric}_roofline` as keyof ChartDefinition;
-      const dir = chartDefinition[rooflineKey] as ParetoDirection | undefined;
-      const frontierFn = paretoFrontForDirection(dir ?? 'lower_right');
-      const result: Record<string, Entry> = {};
-      for (const [key, group] of Object.entries(grouped)) {
-        const canonicalPoints = canonicalParetoIntersection(group.points, dir ?? 'lower_right');
-        const front = canonicalPoints ?? frontierFn(group.points.filter(isFrontierEligible));
-        front.sort((a, b) => a.x - b.x);
-        result[key] = { hwKey: group.hwKey, runIndex: group.runIndex, points: front };
-      }
-      return result;
-    }, [processedOverlayData, selectedYAxisMetric, chartDefinition, runIndexByUrl]);
+      return grouped;
+    }, [processedOverlayData, runIndexByUrl]);
+
+    const overlayRooflines = useMemo(
+      () =>
+        Object.fromEntries(
+          Object.entries(overlayGroups).map(([key, group]) => [
+            key,
+            {
+              ...group,
+              points: chartFrontier(group.points, paretoDirection).toSorted((a, b) => a.x - b.x),
+            },
+          ]),
+        ),
+      [overlayGroups, paretoDirection],
+    );
+    const displayedOverlayRooflines = useMemo(() => {
+      if (!showOperatingCurves) return overlayRooflines;
+      return Object.fromEntries(
+        Object.entries(overlayGroups).flatMap(([key, group]) =>
+          [...groupOperatingCurvePoints(group.points)].map(([segment, points]) => [
+            `${key}__${encodeURIComponent(segment)}`,
+            { ...group, points },
+          ]),
+        ),
+      );
+    }, [showOperatingCurves, overlayRooflines, overlayGroups]);
 
     // Overlay counterpart of `optimalPointKeys`: the points on any overlay
     // run's drawn roofline (already e2e-restricted for agentic non-e2e modes).
@@ -1286,6 +1323,7 @@ const ScatterGraph = React.memo(
     const metricIdentity = useMemo(
       () =>
         [
+          showOperatingCurves ? 'operating-curves' : 'pareto-curves',
           useAdvancedLabels ? 'advanced-labels' : 'basic-labels',
           showConcurrencyLabels ? 'conc-labels' : 'no-conc-labels',
           selectedYAxisMetric,
@@ -1303,6 +1341,7 @@ const ScatterGraph = React.memo(
           .toSorted()
           .join('|'),
       [
+        showOperatingCurves,
         selectedYAxisMetric,
         useAdvancedLabels,
         showConcurrencyLabels,
@@ -1425,7 +1464,8 @@ const ScatterGraph = React.memo(
     // the curves' rendered paths at the iso-x — neither end needs to be a
     // data point. Multiple rulers accumulate (capped in the pure module);
     // completing one immediately allows starting the next.
-    const [perfRulerMode, setPerfRulerMode] = useState(false);
+    const [preferPerfRulerMode, setPerfRulerMode] = useState(false);
+    const perfRulerMode = preferPerfRulerMode && !showOperatingCurves;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass — lines/labels must never
@@ -2012,7 +2052,7 @@ const ScatterGraph = React.memo(
             .line<InferenceData>()
             .x((d) => xScale(d.x))
             .y((d) => yScale(d.y))
-            .curve(d3.curveMonotoneX);
+            .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
 
           // Ensure rooflines layer exists before dot-groups
           let rooflinesLayer = zoomGroup.select<SVGGElement>('.rooflines-layer');
@@ -2038,7 +2078,7 @@ const ScatterGraph = React.memo(
           const entries: Entry[] = [];
           const activeGradientIds = new Set<string>();
 
-          Object.entries(rooflines).forEach(([key, pts]) => {
+          Object.entries(displayedRooflines).forEach(([key, pts]) => {
             const hw = key.split('_').slice(0, -1).join('_');
             const precision = key.split('_').pop()!;
             const visible =
@@ -2047,11 +2087,11 @@ const ScatterGraph = React.memo(
 
             // Split into per-date sub-paths so the line never crosses dates.
             // (When only one date is present the loop runs once with the full set.)
-            const byDate = groupPointsByDate(pts);
+            const byDate = groupDisplayedPoints(pts);
             const singleDate = byDate.size === 1;
 
             for (const [date, datePoints] of byDate) {
-              const entryKey = singleDate ? key : `${key}__${date}`;
+              const entryKey = singleDate ? key : `${key}__${encodeURIComponent(date)}`;
               let stroke = baseStroke;
 
               // Gradient labels only apply in the single-date case; mapping the
@@ -2111,6 +2151,7 @@ const ScatterGraph = React.memo(
             )
             .join('path')
             .attr('class', (d) => `roofline-path roofline-${d.key}`)
+            .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
             .attr('data-hw-key', (d) => d.hw)
             .attr('data-precision', (d) => d.precision)
             .attr('fill', 'none')
@@ -2205,6 +2246,7 @@ const ScatterGraph = React.memo(
               (exit) => exit.remove(),
             )
             .attr('data-seg-key', (d) => d.segKey)
+            .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
             .attr('data-hw-key', (d) => d.hw)
             .attr('data-precision', (d) => d.precision)
             .attr('transform', (d) => `translate(${d.x},${d.y})`)
@@ -2259,7 +2301,7 @@ const ScatterGraph = React.memo(
               keepVisibleOnCollision: entry.points.length === 1,
             }));
             const overlaySeries: LineLabelSeries<InferenceData>[] = Object.entries(
-              overlayRooflines,
+              displayedOverlayRooflines,
             ).flatMap(([overlayKey, group]) => {
               if (!ir.activeOverlayHwTypes.has(group.hwKey)) return [];
               const info = unofficialRunInfos[group.runIndex];
@@ -2397,17 +2439,19 @@ const ScatterGraph = React.memo(
             .line<InferenceData>()
             .x((d) => newXScale(d.x))
             .y((d) => newYScale(d.y))
-            .curve(d3.curveMonotoneX);
+            .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
 
           // Update roofline paths — must split per-date so the zoom redraw
           // matches the per-date sub-paths created in the initial render.
-          Object.entries(rooflines).forEach(([key, pts]) => {
+          Object.entries(displayedRooflines).forEach(([key, pts]) => {
             if (pts.length < 2) return;
-            const byDate = groupPointsByDate(pts);
+            const byDate = groupDisplayedPoints(pts);
             const singleDate = byDate.size === 1;
             for (const [date, datePoints] of byDate) {
               if (datePoints.length < 2) continue;
-              const cls = singleDate ? `roofline-${key}` : `roofline-${key}__${date}`;
+              const cls = singleDate
+                ? `roofline-${key}`
+                : `roofline-${key}__${encodeURIComponent(date)}`;
               const sel = zoomGroup.select<SVGPathElement>(`.${CSS.escape(cls)}`);
               if (!sel.empty()) sel.attr('d', lineGen(datePoints) as string);
             }
@@ -2471,7 +2515,7 @@ const ScatterGraph = React.memo(
               string,
               { key: string; seriesId: string; points: InferenceData[] }
             >();
-            for (const [key, points] of Object.entries(rooflines)) {
+            for (const [key, points] of Object.entries(displayedRooflines)) {
               const hardware = key.split('_').slice(0, -1).join('_');
               const precision = key.split('_').pop()!;
               if (
@@ -2480,10 +2524,10 @@ const ScatterGraph = React.memo(
               ) {
                 continue;
               }
-              const pointsByDate = groupPointsByDate(points);
+              const pointsByDate = groupDisplayedPoints(points);
               const singleDate = pointsByDate.size === 1;
               for (const [date, datePoints] of pointsByDate) {
-                const entryKey = singleDate ? key : `${key}__${date}`;
+                const entryKey = singleDate ? key : `${key}__${encodeURIComponent(date)}`;
                 const groupKey = multiPrecision ? entryKey : hardware;
                 const previous = bestByGroup.get(groupKey);
                 if (!previous || datePoints.length > previous.points.length) {
@@ -2504,7 +2548,7 @@ const ScatterGraph = React.memo(
               }),
             );
             const overlaySeries: LineLabelSeries<InferenceData>[] = Object.entries(
-              overlayRooflines,
+              displayedOverlayRooflines,
             ).flatMap(([overlayKey, group]) =>
               ir.activeOverlayHwTypes.has(group.hwKey)
                 ? [
@@ -2579,7 +2623,7 @@ const ScatterGraph = React.memo(
                 .line<InferenceData>()
                 .x((d) => xScale(d.x))
                 .y((d) => yScale(d.y))
-                .curve(d3.curveMonotoneX);
+                .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
 
               interface OvEntry {
                 key: string;
@@ -2588,7 +2632,7 @@ const ScatterGraph = React.memo(
                 runIndex: number;
               }
               const ovEntries: OvEntry[] = [];
-              Object.entries(overlayRooflines).forEach(([key, group]) => {
+              Object.entries(displayedOverlayRooflines).forEach(([key, group]) => {
                 const hwCfg = overlayData.hardwareConfig[group.hwKey];
                 if (hwCfg && group.points.length > 1) {
                   ovEntries.push({
@@ -2610,6 +2654,7 @@ const ScatterGraph = React.memo(
                 .data(ovEntries, (d) => d.key)
                 .join('path')
                 .attr('class', (d) => `overlay-roofline-path overlay-roofline-${d.key}`)
+                .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
                 .attr('fill', 'none')
                 .attr('stroke', (d) => d.stroke)
                 .attr('stroke-width', 2)
@@ -2783,11 +2828,13 @@ const ScatterGraph = React.memo(
                 .line<InferenceData>()
                 .x((d) => newXScale(d.x))
                 .y((d) => newYScale(d.y))
-                .curve(d3.curveMonotoneX);
+                .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
 
-              Object.entries(overlayRooflines).forEach(([key, group]) => {
+              Object.entries(displayedOverlayRooflines).forEach(([key, group]) => {
                 if (group.points.length < 2) return;
-                const sel = zoomGroup.select<SVGPathElement>(`.overlay-roofline-${key}`);
+                const sel = zoomGroup.select<SVGPathElement>(
+                  `.${CSS.escape(`overlay-roofline-${key}`)}`,
+                );
                 if (!sel.empty()) sel.attr('d', lineGen(group.points) as string);
               });
 
@@ -3010,7 +3057,9 @@ const ScatterGraph = React.memo(
       // existing DOM when it changes. Only data/structure changes recreate
       // the layers (and with them, the full chart render).
     }, [
-      rooflines,
+      displayedRooflines,
+      groupDisplayedPoints,
+      showOperatingCurves,
       allPointLabelsByKey,
       showGradientLabels,
       showLineLabels,
@@ -3024,7 +3073,7 @@ const ScatterGraph = React.memo(
       buildPointId,
       overlayData,
       processedOverlayData,
-      overlayRooflines,
+      displayedOverlayRooflines,
       officialOverflowContinuations,
       overlayOverflowContinuations,
       unofficialRunInfos,
@@ -3595,21 +3644,25 @@ const ScatterGraph = React.memo(
                         },
                       },
                     ]),
-                {
-                  id: 'scatter-hide-non-optimal',
-                  label: legendT.optimalOnly,
-                  checked: hideNonOptimal,
-                  onCheckedChange: (checked: boolean) => {
-                    setHideNonOptimal(checked);
-                    track('latency_hide_non_optimal_toggled', { enabled: checked });
-                  },
-                  // Every agentic axis shares the normalized north-star set.
-                  ...(selectedSequence === Sequence.AgenticTraces
-                    ? {
-                        infoTooltip: legendT.optimalInfo,
-                      }
-                    : {}),
-                },
+                ...(paretoDirection
+                  ? [
+                      {
+                        id: 'scatter-hide-non-optimal',
+                        label: legendT.optimalOnly,
+                        checked: hideNonOptimal,
+                        onCheckedChange: (checked: boolean) => {
+                          setHideNonOptimal(checked);
+                          track('latency_hide_non_optimal_toggled', { enabled: checked });
+                        },
+                        // Every agentic axis shares the normalized north-star set.
+                        ...(selectedSequence === Sequence.AgenticTraces
+                          ? {
+                              infoTooltip: legendT.optimalInfo,
+                            }
+                          : {}),
+                      },
+                    ]
+                  : []),
                 {
                   id: 'scatter-point-labels',
                   label: legendT.labels,
@@ -3641,7 +3694,7 @@ const ScatterGraph = React.memo(
                     // Parallelism labels are point labels; turning them on is
                     // pointless if labels are hidden, so auto-enable Labels.
                     if (checked && !showPointLabels) setShowPointLabels(true);
-                    if (checked && !showGradientLabels) {
+                    if (checked && !showGradientLabels && !showOperatingCurves) {
                       window.dispatchEvent(
                         new CustomEvent(GRADIENT_NUDGE_EVENT, {
                           detail: {
@@ -3659,15 +3712,19 @@ const ScatterGraph = React.memo(
                     }
                   },
                 },
-                {
-                  id: 'scatter-gradient-labels',
-                  label: legendT.gradientLabels,
-                  checked: showGradientLabels,
-                  onCheckedChange: (checked: boolean) => {
-                    setShowGradientLabels(checked);
-                    track('latency_gradient_labels_toggled', { enabled: checked });
-                  },
-                },
+                ...(showOperatingCurves
+                  ? []
+                  : [
+                      {
+                        id: 'scatter-gradient-labels',
+                        label: legendT.gradientLabels,
+                        checked: showGradientLabels,
+                        onCheckedChange: (checked: boolean) => {
+                          setShowGradientLabels(checked);
+                          track('latency_gradient_labels_toggled', { enabled: checked });
+                        },
+                      },
+                    ]),
                 {
                   id: 'scatter-line-labels',
                   label: legendT.lineLabels,
@@ -3678,22 +3735,26 @@ const ScatterGraph = React.memo(
                     track('latency_line_labels_toggled', { enabled: checked });
                   },
                 },
-                {
-                  id: 'scatter-perf-ruler',
-                  label: legendT.perfRuler,
-                  advanced: true,
-                  checked: perfRulerMode,
-                  infoTooltip: legendT.perfRulerInfo,
-                  onCheckedChange: (checked: boolean) => {
-                    setPerfRulerMode(checked);
-                    // Toggle-off clears ALL rulers in the same state batch —
-                    // the pre-paint decoration effect then removes the rulers
-                    // and the curve hit strokes before the next frame (no
-                    // lingering lines after toggle-off).
-                    if (!checked) setPerfRulerState(clearPerfRulers);
-                    track('latency_perf_ruler_toggled', { enabled: checked });
-                  },
-                },
+                ...(showOperatingCurves
+                  ? []
+                  : [
+                      {
+                        id: 'scatter-perf-ruler',
+                        label: legendT.perfRuler,
+                        advanced: true,
+                        checked: perfRulerMode,
+                        infoTooltip: legendT.perfRulerInfo,
+                        onCheckedChange: (checked: boolean) => {
+                          setPerfRulerMode(checked);
+                          // Toggle-off clears ALL rulers in the same state batch —
+                          // the pre-paint decoration effect then removes the rulers
+                          // and the curve hit strokes before the next frame (no
+                          // lingering lines after toggle-off).
+                          if (!checked) setPerfRulerState(clearPerfRulers);
+                          track('latency_perf_ruler_toggled', { enabled: checked });
+                        },
+                      },
+                    ]),
                 {
                   id: 'scatter-concurrency-labels',
                   label: legendT.concurrencyLabels,
@@ -3756,6 +3817,14 @@ const ScatterGraph = React.memo(
             />
           }
         />
+        {isPowerAxis && (
+          <p
+            data-testid="power-curve-description"
+            className="mt-2 px-1 text-2xs text-muted-foreground"
+          >
+            {showOperatingCurves ? legendT.powerCurves : legendT.powerOptimal}
+          </p>
+        )}
         {isMeasuredEnergyAxis && (
           <MeasuredPowerSummary
             total={powerTierCounts.total}

--- a/packages/app/src/components/inference/utils/powerCurves.test.ts
+++ b/packages/app/src/components/inference/utils/powerCurves.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import type { InferenceData } from '@/components/inference/types';
+
+import { chartFrontier, groupOperatingCurvePoints, isPowerCurveMetric } from './powerCurves';
+
+function point(conc: number, x: number, y: number, overrides: Partial<InferenceData> = {}) {
+  return {
+    hwKey: 'b200_sglang',
+    precision: 'fp8',
+    date: '2026-09-10',
+    tp: 8,
+    conc,
+    x,
+    y,
+    tpPerGpu: { y: 100, roof: false },
+    tpPerMw: { y: 100, roof: false },
+    costh: { y: 1, roof: false },
+    costr: { y: 1, roof: false },
+    costhi: { y: 1, roof: false },
+    costri: { y: 1, roof: false },
+    ...overrides,
+  } satisfies InferenceData;
+}
+
+describe('power operating curves', () => {
+  it('connects the power sweep while retaining the single true Pareto winner', () => {
+    const fast = point(1, 200, 350);
+    const medium = point(8, 100, 700);
+    const slow = point(32, 50, 950);
+    const input = Object.freeze([slow, fast, medium]);
+    const segments = [...groupOperatingCurvePoints(input).values()];
+
+    expect(segments).toEqual([[fast, medium, slow]]);
+    expect(segments[0][0]).toBe(fast);
+    expect(input).toEqual([slow, fast, medium]);
+    expect(chartFrontier([...input], 'lower_right')).toEqual([fast]);
+    expect(chartFrontier([...input], undefined)).toEqual([]);
+  });
+
+  it('keeps concurrency order when measured interactivity is non-monotonic', () => {
+    const points = [point(1, 200, 350), point(8, 80, 700), point(32, 90, 950)];
+    expect([...groupOperatingCurvePoints(points).values()]).toEqual([points]);
+  });
+
+  it.each<Partial<InferenceData>>([
+    { tp: 4 },
+    { precision: 'fp4' },
+    { hwKey: 'b200_sglang_mtp' },
+    { date: '2026-09-09' },
+    { run_url: 'https://github.com/o/r/actions/runs/2' },
+    { decode_ep: 8 },
+    { prefill_tp: 4 },
+    { prefill_ep: 4 },
+    { disagg: true, num_prefill_gpu: 4, num_decode_gpu: 8 },
+    { physicalChips: 16 },
+    { dp: 2 },
+    { offload_mode: 'on' },
+    { recipe_fingerprint: 'another-recipe' },
+    { benchmark_type: 'agentic_traces', spec_decoding: 'mtp' },
+  ])('never joins different configuration/date/run identities: %j', (overrides) => {
+    const base = [point(1, 200, 350), point(8, 100, 700)];
+    const different = [point(1, 210, 400, overrides), point(8, 110, 750, overrides)];
+    expect([...groupOperatingCurvePoints([...base, ...different]).values()]).toEqual([
+      base,
+      different,
+    ]);
+  });
+
+  it('deduplicates identical vertices but breaks curves at ambiguous repeated concurrency', () => {
+    const first = point(1, 200, 350);
+    const ambiguous = [point(8, 100, 700), point(8, 110, 710)];
+    const tail = [point(16, 80, 800), point(32, 50, 950)];
+    expect([
+      ...groupOperatingCurvePoints([first, { ...first }, ...ambiguous, ...tail]).values(),
+    ]).toEqual([[first], [ambiguous[0]], [ambiguous[1]], tail]);
+  });
+
+  it('excludes unusable coordinates and concurrency from line vertices', () => {
+    const valid = [point(1, 200, 350), point(8, 100, 700)];
+    const invalid = [point(16, 0, 800), point(32, 50, NaN), point(NaN, 50, 950)];
+    expect([...groupOperatingCurvePoints([...valid, ...invalid]).values()]).toEqual([valid]);
+  });
+
+  it('selects power gauges without changing energy chart semantics', () => {
+    expect(isPowerCurveMetric('y_measuredAvgPower')).toBe(true);
+    expect(isPowerCurveMetric('y_measuredP90Power')).toBe(true);
+    expect(isPowerCurveMetric('y_measuredPowerPercentTdp')).toBe(true);
+    expect(isPowerCurveMetric('y_modeledChassisPowerPerGpu')).toBe(true);
+    expect(isPowerCurveMetric('y_measuredJPerOutputToken')).toBe(false);
+    expect(isPowerCurveMetric('y_tpPerGpu')).toBe(false);
+    const points = [point(1, 200, 4), point(8, 100, 1)];
+    expect(chartFrontier(points, 'lower_right')).toEqual(points);
+  });
+
+  it('preserves the canonical agentic restriction on Pareto membership', () => {
+    const canonical = point(8, 100, 1, { isOnNormalizedInteractivityFrontier: true });
+    const nonCanonical = point(1, 200, 4, { isOnNormalizedInteractivityFrontier: false });
+    expect(chartFrontier([canonical, nonCanonical], 'lower_right')).toEqual([canonical]);
+  });
+});

--- a/packages/app/src/components/inference/utils/powerCurves.ts
+++ b/packages/app/src/components/inference/utils/powerCurves.ts
@@ -1,0 +1,95 @@
+import type { InferenceData } from '@/components/inference/types';
+import {
+  isFrontierEligible,
+  paretoFrontForDirection,
+  type ParetoDirection,
+} from '@/lib/chart-utils';
+
+import { canonicalParetoIntersection } from './canonicalFrontier';
+import { scatterPointConfigId } from './point-identity';
+
+const POWER_CURVE_METRICS: ReadonlySet<string> = new Set([
+  'y_measuredAvgPower',
+  'y_measuredP90Power',
+  'y_measuredPrefillAvgPower',
+  'y_measuredDecodeAvgPower',
+  'y_measuredPowerPercentTdp',
+  'y_modeledChassisPowerPerGpu',
+]);
+
+export function isPowerCurveMetric(metric: string): boolean {
+  return POWER_CURVE_METRICS.has(metric);
+}
+
+/** No declared direction means there is no Pareto frontier to draw or filter by. */
+export function chartFrontier(
+  points: InferenceData[],
+  direction: ParetoDirection | undefined,
+): InferenceData[] {
+  if (!direction) return [];
+  return (
+    canonicalParetoIntersection(points, direction) ??
+    paretoFrontForDirection(direction)(points.filter(isFrontierEligible))
+  );
+}
+
+/**
+ * Connect concurrency sweeps only within one dated serving configuration/run.
+ * These are operating curves, not optimality claims. Input points are unchanged.
+ * Conflicting measurements at one concurrency break a curve rather than invent
+ * an ordering between repeated observations; exact duplicate vertices collapse.
+ */
+export function groupOperatingCurvePoints(
+  points: readonly InferenceData[],
+): Map<string, InferenceData[]> {
+  const groups = new Map<string, InferenceData[]>();
+  for (const point of points) {
+    if (
+      !isFrontierEligible(point) ||
+      !Number.isFinite(point.y) ||
+      !Number.isFinite(point.conc) ||
+      point.conc <= 0
+    ) {
+      continue;
+    }
+    const key = JSON.stringify([
+      point.date,
+      point.run_url ?? null,
+      scatterPointConfigId({ ...point, conc: 0 }),
+    ]);
+    const group = groups.get(key) ?? [];
+    group.push(point);
+    groups.set(key, group);
+  }
+
+  const segments = new Map<string, InferenceData[]>();
+  for (const [key, group] of groups) {
+    const sorted = group.toSorted((a, b) => a.conc - b.conc || a.x - b.x || a.y - b.y);
+    let segment: InferenceData[] = [];
+    let segmentIndex = 0;
+    const flush = () => {
+      if (segment.length > 0) segments.set(`${key}:${segmentIndex++}`, segment);
+      segment = [];
+    };
+    for (let i = 0; i < sorted.length;) {
+      const sameConcurrency: InferenceData[] = [];
+      const concurrency = sorted[i].conc;
+      while (i < sorted.length && sorted[i].conc === concurrency) {
+        const point = sorted[i++];
+        if (!sameConcurrency.some((other) => other.x === point.x && other.y === point.y)) {
+          sameConcurrency.push(point);
+        }
+      }
+      if (sameConcurrency.length === 1) {
+        segment.push(sameConcurrency[0]);
+      } else {
+        flush();
+        for (const point of sameConcurrency) {
+          segments.set(`${key}:${segmentIndex++}`, [point]);
+        }
+      }
+    }
+    flush();
+  }
+  return segments;
+}

--- a/packages/app/src/lib/d3-chart/D3Chart/layer-renderer.ts
+++ b/packages/app/src/lib/d3-chart/D3Chart/layer-renderer.ts
@@ -211,6 +211,7 @@ export function updateLayerDecorationOnZoom<T>(
         layer.rooflines,
         newXScale as ContinuousScale,
         newYScale as ContinuousScale,
+        layer.config.curve,
       );
       break;
     }

--- a/packages/app/src/lib/d3-chart/layers/rooflines.test.ts
+++ b/packages/app/src/lib/d3-chart/layers/rooflines.test.ts
@@ -267,6 +267,32 @@ describe('renderRooflines', () => {
 // ── updateRooflinesOnZoom ────────────────────────────────────────────
 
 describe('updateRooflinesOnZoom', () => {
+  it('keeps explicitly linear operating curves straight after zooming', () => {
+    const group = createMockGroup();
+    const { xScale, yScale } = makeScales();
+    renderRooflines(
+      group as any,
+      SAMPLE_ROOFLINES,
+      xScale,
+      yScale,
+      makeConfig({ curve: d3.curveLinear }),
+    );
+    const paths = group.selectAll('.roofline-path');
+    const before = paths.elements.map((element) => String(element.attrs.d));
+    expect(before.every((path) => path.includes('L') && !path.includes('C'))).toBe(true);
+
+    updateRooflinesOnZoom(
+      group as any,
+      SAMPLE_ROOFLINES,
+      xScale.copy().range([0, 1000]),
+      yScale,
+      d3.curveLinear,
+    );
+    const after = paths.elements.map((element) => String(element.attrs.d));
+    expect(after).not.toEqual(before);
+    expect(after.every((path) => path.includes('L') && !path.includes('C'))).toBe(true);
+  });
+
   it('does not throw on empty group', () => {
     const group = createMockGroup();
     const { xScale, yScale } = makeScales();

--- a/packages/app/src/lib/d3-chart/layers/rooflines.ts
+++ b/packages/app/src/lib/d3-chart/layers/rooflines.ts
@@ -8,6 +8,7 @@ export interface RooflineConfig {
   isVisible?: (key: string) => boolean;
   strokeWidth?: number;
   strokeDasharray?: string;
+  curve?: d3.CurveFactory;
 }
 
 interface RooflineEntry<T> {
@@ -31,7 +32,7 @@ export function renderRooflines<T extends { x: number; y: number }>(
     .line<T>()
     .x((d) => xScale(d.x))
     .y((d) => yScale(d.y))
-    .curve(d3.curveMonotoneX);
+    .curve(config.curve ?? d3.curveMonotoneX);
 
   const entries: RooflineEntry<T>[] = Object.entries(rooflines)
     .filter(([key, points]) => points.length >= 2 && (!isVisible || isVisible(key)))
@@ -95,12 +96,13 @@ export function updateRooflinesOnZoom<T extends { x: number; y: number }>(
   rooflines: Record<string, T[]>,
   newXScale: ContinuousScale,
   newYScale: ContinuousScale,
+  curve: d3.CurveFactory = d3.curveMonotoneX,
 ): void {
   const lineGenerator = d3
     .line<T>()
     .x((d) => newXScale(d.x))
     .y((d) => newYScale(d.y))
-    .curve(d3.curveMonotoneX);
+    .curve(curve);
 
   Object.entries(rooflines).forEach(([key, points]) => {
     if (points.length < 2) return;


### PR DESCRIPTION
## Summary

Turning off **Optimal Only** now connects power measurements across concurrency within the same serving configuration, date, and run. These are straight operating curves; the true power Pareto frontier remains available and may contain one point. Energy-per-token behavior is unchanged.

Measured power as a percentage of TDP has no optimization direction, so it shows every measurement and hides the inapplicable optimal control. Saved preferences are restored on other metrics. Both chart views and unofficial-run overlays use the same grouping; zoom preserves straight segments, and unrelated configurations never receive a clipped Pareto continuation in operating mode.

## Validation

- Cypress scatter/chart-button smoke component tests: 50 passed, including power toggles, %TDP, separate configurations, overlays, and clipped axes. GPU component tests: 12 passed.
- Shared roofline tests: 21 passed. Affected decoration/overlay tests: 24 passed after giving their fixture an explicit Pareto direction.
- The initial full app run passed 5,311 tests with 7 failures: four depended on that fixture, and three Chinese-copy checks timed out under concurrent load. All seven passed their targeted reruns (53 Chinese-copy tests passed).
- Final full workspace rerun: 6,392 unit tests passed (4 skipped), including the separate skills-package suite. Smoke integration: 113 passed, in addition to the 50 component checks above. Typecheck, lint, formatting, and typography passed. Current-head CI and production verification remain pending. Local browser checks use fixture data; live checks use the public Qwen3.5 8k/1k FP8 view.

## 中文说明

关闭“仅最优”后，功耗图按同一推理配置、日期和运行，用直线连接不同并发数的测量点。这些线表示功耗变化；原有的功耗 Pareto 前沿仍可查看，且可能只有一个点。每 token 能耗指标的行为不变。

实测功耗占 TDP 百分比没有优劣方向，因此保留所有测量点，并隐藏不适用的最优筛选。切换其他指标时恢复已保存的偏好。两种图表和非官方运行叠加使用相同分组；缩放后仍保留直线，功耗曲线模式下不会用裁剪延长线连接无关配置。

Cypress 散点图及图表按钮组件测试 50 项通过，GPU 图组件测试 12 项通过，共用曲线测试 21 项通过。明确测试数据的 Pareto 方向后，相关装饰和叠加测试 24 项通过。首次完整应用测试通过 5,311 项，失败 7 项：4 项依赖旧测试数据的隐式方向，3 项中文检查在并发负载下超时；针对性重跑均通过，其中中文检查 53 项通过。最终完整工作区重跑通过 6,392 项单元测试（4 项跳过），包含独立 skills 包测试；smoke 集成测试另有 113 项通过，类型、lint、格式和排版检查通过。合并及交付前继续检查当前提交的 CI 和线上行为。本地使用测试数据，线上使用公开的 Qwen3.5 8k/1k FP8 数据。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core chart rendering, Pareto filtering, and legend toggles across scatter and GPU comparison views; behavior is heavily tested but mis-grouping could mislead users about optimality vs load sweeps.
> 
> **Overview**
> **Power charts** now distinguish Pareto frontiers from **operating curves**: with **Optimal Only** on, power axes still use the declared Pareto direction (often a single point when fastest is also lowest watts). Turning it off draws **straight line segments** linking concurrency points within the same serving configuration, date, and run—never across configs or runs.
> 
> A shared **`powerCurves`** helper centralizes frontier computation (`chartFrontier`), metric detection, and grouping (conflicting duplicate concurrency breaks the curve). **ScatterGraph** and **GPUGraph** both use it, including unofficial overlays; operating mode turns off perf ruler, gradient labels, and clipped Pareto continuations, and adds EN/ZH copy explaining curves vs frontiers.
> 
> **% of TDP** has no Pareto direction: the optimal toggle is hidden, all points and operating curves always show, and the saved **Optimal Only** preference is restored when switching back to metrics like average power or energy per token (unchanged Pareto behavior).
> 
> The D3 **roofline** layer accepts an optional **linear** curve so operating paths stay straight after zoom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15efcb452efd90abc318484a5b5ac96f6983be2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->