### PR TITLE
[PowerX] draw smooth power envelopes / 绘制平滑功耗上边界

### DIFF
--- a/packages/app/cypress/component/gpu-graph.cy.tsx
+++ b/packages/app/cypress/component/gpu-graph.cy.tsx
@@ -490,26 +490,30 @@ describe('GPUGraph', () => {
   });
 });
 
-describe('GPU comparison power curves', () => {
-  function PowerComparison() {
+describe('GPU comparison power envelopes', () => {
+  function PowerComparison({ latency = false }: { latency?: boolean }) {
     const [optimal, setOptimal] = useState(true);
     const [metric, setMetric] = useState('y_measuredAvgPower');
     const [activeDates, setActiveDates] = useState(new Set(['2026-09-09_h100', '2026-09-10_h100']));
     const rows = ['2026-09-09', '2026-09-10'].flatMap((date) =>
       [4, 8].flatMap((tp) =>
-        [1, 8, 32].map((conc, index) =>
-          createMockInferenceData({
+        [1, 8, 32].map((conc, index) => {
+          const interactivity =
+            metric === 'y_measuredJPerOutputToken' || tp === 8
+              ? 200 - index * 70
+              : [200, 120, 130][index];
+          return createMockInferenceData({
             hwKey: 'h100',
             precision: Precision.FP8,
             date,
             tp,
             conc,
-            x: 200 - index * 70,
+            x: latency ? 1000 / interactivity : interactivity,
             y: metric === 'y_measuredJPerOutputToken' ? 4 - index : 350 + index * 200 + tp,
             run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${date}`,
             power_tier: 'certified',
-          }),
-        ),
+          });
+        }),
       ),
     );
     const value = createMockInferenceContextValues({
@@ -536,12 +540,12 @@ describe('GPU comparison power curves', () => {
             chartId="gpu-power-curves"
             modelLabel="Qwen3.5 397B"
             data={rows}
-            xLabel="Interactivity"
+            xLabel={latency ? 'Latency' : 'Interactivity'}
             yLabel="Power"
             chartDefinition={createMockChartDefinition({
-              chartType: 'interactivity',
-              y_measuredAvgPower_roofline: 'lower_right',
-              y_measuredJPerOutputToken_roofline: 'lower_right',
+              chartType: latency ? 'e2e' : 'interactivity',
+              y_measuredAvgPower_roofline: latency ? 'lower_left' : 'lower_right',
+              y_measuredJPerOutputToken_roofline: latency ? 'lower_left' : 'lower_right',
             })}
           />
         </div>
@@ -549,25 +553,38 @@ describe('GPU comparison power curves', () => {
     );
   }
 
-  it('shows isolated power sweeps when Optimal Only is off and respects date visibility', () => {
+  it('shows one smooth power envelope per date while preserving all configurations and date visibility', () => {
     mountWithProviders(<PowerComparison />);
     cy.get('#gpu-power-curves .roofline-path').should('not.exist');
     cy.get('[data-testid="power-curve-description"]').should('contain', 'single point');
     cy.get('#gpu-hide-non-optimal').click({ force: true });
     cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
     cy.get('#gpu-power-curves .roofline-path')
-      .should('have.length', 4)
+      .should('have.length', 2)
       .each(($path) => {
-        expect($path.attr('d')).to.match(/^M[^C]+L/u);
+        expect($path.attr('d')).to.contain('C');
         expect($path.attr('stroke')).not.to.equal('#6b7280');
       });
     cy.get('#gpu-power-curves .line-label').should('have.length', 2);
     cy.get('[data-testid="legend-advanced-toggle"]').click();
     cy.get('#gpu-perf-ruler').should('not.exist');
     cy.contains('button', 'Hide older date').click();
-    cy.get('#gpu-power-curves .roofline-path').should('have.length', 2);
+    cy.get('#gpu-power-curves .roofline-path').should('have.length', 1);
     cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
     cy.get('#gpu-power-curves .line-label').should('have.length', 1);
+  });
+
+  it('draws the smooth upper boundary toward lower latency and keeps all measured dots', () => {
+    mountWithProviders(<PowerComparison latency />);
+    cy.get('#gpu-power-curves .roofline-path').should('not.exist');
+    cy.get('#gpu-hide-non-optimal').click({ force: true });
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+    cy.get('#gpu-power-curves .roofline-path')
+      .should('have.length', 2)
+      .each(($path) => expect($path.attr('d')).to.contain('C'));
+    cy.get('#gpu-power-curves [data-testid="power-curve-description"]')
+      .should('contain.text', 'upper power boundary')
+      .and('contain.text', 'not efficiency frontiers');
   });
 
   it('bypasses %TDP filtering without changing the saved Optimal Only preference for energy', () => {
@@ -579,8 +596,8 @@ describe('GPU comparison power curves', () => {
     cy.contains('button', 'Percent TDP').click();
     cy.get('#gpu-hide-non-optimal').should('not.exist');
     cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
-    cy.get('#gpu-power-curves .roofline-path').should('have.length', 4);
-    cy.get('[data-testid="power-curve-description"]').should('contain', '不代表 Pareto 前沿');
+    cy.get('#gpu-power-curves .roofline-path').should('have.length', 2);
+    cy.get('[data-testid="power-curve-description"]').should('contain', '不代表能效 Pareto 前沿');
     cy.contains('button', 'Energy').click();
     cy.get('#gpu-hide-non-optimal').should('have.attr', 'data-state', 'checked');
     cy.get('#gpu-power-curves .roofline-path')

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -2147,10 +2147,10 @@ describe('ChartDisplay engine comparison guard', () => {
 });
 
 // Reproduces Qwen3.5 power sweeps: fastest is also lowest watts, so the true
-// Pareto frontier is one point, but show-all must draw the measured load curve.
-describe('Power operating curves', () => {
+// Pareto frontier is one point, but show-all still draws a smooth power envelope.
+describe('Power envelopes', () => {
   for (const optimal of [false, true]) {
-    it(`${optimal ? 'preserves Pareto' : 'suppresses cross-configuration'} clipping continuations with Optimal Only ${optimal ? 'on' : 'off'}`, () => {
+    it(`${optimal ? 'preserves Pareto' : 'suppresses power-envelope'} clipping continuations with Optimal Only ${optimal ? 'on' : 'off'}`, () => {
       const runUrl = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/102';
       const visible = createMockInferenceData({
         hwKey: 'b200_trt',
@@ -2260,15 +2260,15 @@ describe('Power operating curves', () => {
     );
   }
 
-  it('draws the full power sweep when Optimal Only is off and preserves energy frontiers', () => {
+  it('draws a smooth power envelope when Optimal Only is off and preserves energy frontiers', () => {
     mountWithProviders(<PowerHarness />, { unofficial: {} });
     cy.get('#power-sweep .roofline-path').should('not.exist');
     cy.get('[data-testid="power-curve-description"]').should('contain', 'single point');
     cy.get('#scatter-hide-non-optimal').click({ force: true });
-    cy.get('#power-sweep .roofline-path[data-curve-kind="operating"]')
+    cy.get('#power-sweep .roofline-path[data-curve-kind="power-envelope"]')
       .should('have.length', 1)
       .invoke('attr', 'd')
-      .should('match', /^M[^C]+L/u);
+      .should('match', /^M[^C]+C/u);
     cy.get('#power-sweep .dot-group')
       .should('have.length', 3)
       .each(($point) => cy.wrap($point).should('have.css', 'opacity', '1'));
@@ -2276,7 +2276,10 @@ describe('Power operating curves', () => {
     cy.get('#power-sweep .roofline-path').should('not.exist');
     cy.contains('button', 'Percent TDP').click();
     cy.get('#scatter-hide-non-optimal').should('not.exist');
-    cy.get('#power-sweep .roofline-path[data-curve-kind="operating"]').should('have.length', 1);
+    cy.get('#power-sweep .roofline-path[data-curve-kind="power-envelope"]')
+      .should('have.length', 1)
+      .invoke('attr', 'd')
+      .should('match', /^M[^C]+C/u);
     cy.get('#power-sweep .dot-group').each(($point) =>
       cy.wrap($point).should('have.css', 'opacity', '1'),
     );
@@ -2286,20 +2289,47 @@ describe('Power operating curves', () => {
     cy.get('[data-testid="power-curve-description"]').should('not.exist');
   });
 
-  it('keeps official and unofficial serving configurations on separate operating curves', () => {
+  it('smooths nonmonotonic measurements across configurations and preserves overlay runs through zoom', () => {
     const runUrl = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/101';
-    const rows = [4, 8].flatMap((tp) =>
-      [1, 8, 32].map((conc, i) =>
-        createMockInferenceData({
-          hwKey: 'b200_trt',
-          tp,
-          conc,
-          x: 100 - i * 30,
-          y: 400 + i * 200 + tp,
-          measuredAvgPower: { y: 400 + i * 200 + tp, roof: false },
-          run_url: runUrl,
-        }),
-      ),
+    const secondRunUrl = 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/102';
+    // The H100 Qwen3.5 8k/1k measurements that produced loops when joined
+    // in concurrency order. EP1 and EP8 contribute to the same upper boundary.
+    const rows = [
+      [16, 62.737, 399.728, 8],
+      [32, 55.742, 448.775, 8],
+      [64, 20.506, 344.948, 8],
+      [128, 25.686, 502.536, 8],
+      [256, 4.645, 372.904, 8],
+      [1, 172.488, 252.217, 1],
+      [2, 149.322, 291.378, 1],
+      [4, 121.477, 318.845, 1],
+      [8, 65.346, 283.477, 1],
+    ].map(([conc, x, y, ep]) =>
+      createMockInferenceData({
+        hwKey: 'h100',
+        model: Model.Qwen3_5,
+        precision: Precision.FP8,
+        date: '2026-07-05',
+        ep,
+        conc,
+        x,
+        y,
+        measuredAvgPower: { y, roof: false },
+        run_url: runUrl,
+      }),
+    );
+    const secondRunRows = [1, 8, 32].map((conc, i) =>
+      createMockInferenceData({
+        hwKey: 'h100',
+        model: Model.Qwen3_5,
+        precision: Precision.FP8,
+        date: '2026-07-05',
+        conc,
+        x: 100 - i * 30,
+        y: 400 + i * 200,
+        measuredAvgPower: { y: 400 + i * 200, roof: false },
+        run_url: secondRunUrl,
+      }),
     );
     mountWithProviders(
       <div style={{ width: 1000, height: 600 }}>
@@ -2313,7 +2343,12 @@ describe('Power operating curves', () => {
             chartType: 'interactivity',
             y_measuredAvgPower_roofline: 'lower_right',
           })}
-          overlayData={{ data: rows, hardwareConfig: hwConfig, label: 'Power replay', runUrl }}
+          overlayData={{
+            data: [...rows, ...secondRunRows],
+            hardwareConfig: hwConfig,
+            label: 'Power replay',
+            runUrl,
+          }}
           transitionDuration={0}
         />
       </div>,
@@ -2321,26 +2356,69 @@ describe('Power operating curves', () => {
         inference: {
           selectedYAxisMetric: 'y_measuredAvgPower',
           hideNonOptimal: false,
-          selectedPrecisions: [Precision.FP4],
+          selectedModel: Model.Qwen3_5,
+          selectedSequence: Sequence.EightK_OneK,
+          selectedPrecisions: [Precision.FP8],
           hardwareConfig: hwConfig,
-          activeHwTypes: new Set(['b200_trt']),
-          hwTypesWithData: new Set(['b200_trt']),
+          activeHwTypes: new Set(['h100']),
+          hwTypesWithData: new Set(['h100']),
         },
         unofficial: {
-          activeOverlayHwTypes: new Set(['b200_trt']),
-          allOverlayHwTypes: new Set(['b200_trt']),
-          runIndexByUrl: { [runUrl]: 0, '101': 0 },
+          activeOverlayHwTypes: new Set(['h100']),
+          allOverlayHwTypes: new Set(['h100']),
+          runIndexByUrl: { [runUrl]: 0, '101': 0, [secondRunUrl]: 1, '102': 1 },
         },
       },
     );
-    cy.get('#power-overlay .roofline-path[data-curve-kind="operating"]').should('have.length', 2);
-    cy.get('#power-overlay .overlay-roofline-path[data-curve-kind="operating"]')
-      .should('have.length', 2)
-      .each(($path) =>
-        cy
-          .wrap($path)
-          .invoke('attr', 'd')
-          .should('match', /^M[^C]+L/u),
-      );
+    const officialSelector = '#power-overlay .roofline-path[data-curve-kind="power-envelope"]';
+    const overlaySelector =
+      '#power-overlay .overlay-roofline-path[data-curve-kind="power-envelope"]';
+    function assertEnvelopes() {
+      cy.get<SVGPathElement>(`${officialSelector}, ${overlaySelector}`)
+        .should('have.length', 3)
+        .should(($paths) => {
+          const segmentCounts = [...$paths].map((path) => {
+            const segments = path.getAttribute('d')!.match(/C/gu) ?? [];
+            const length = path.getTotalLength();
+            let previous = path.getPointAtLength(0);
+            for (let step = 1; step <= 20; step++) {
+              const point = path.getPointAtLength((length * step) / 20);
+              expect(point.x, 'interactivity never reverses').to.be.at.least(previous.x);
+              expect(point.y, 'upper boundary never turns back').to.be.at.least(previous.y);
+              previous = point;
+            }
+            return segments.length;
+          });
+          expect(segmentCounts).to.have.members([5, 5, 2]);
+        });
+    }
+    cy.get(officialSelector).should('have.length', 1);
+    cy.get(overlaySelector).should('have.length', 2);
+    cy.get('#power-overlay .dot-group').should('have.length', 9);
+    cy.get('#power-overlay .unofficial-overlay-pt').should('have.length', 12);
+    cy.get('#power-overlay .dot-group, #power-overlay .unofficial-overlay-pt').each(($point) =>
+      cy.wrap($point).should('have.css', 'opacity', '1'),
+    );
+    assertEnvelopes();
+    cy.get(officialSelector)
+      .invoke('attr', 'd')
+      .then((beforeZoom) => {
+        cy.get('#power-overlay svg').then(($svg) => {
+          const svg = $svg[0];
+          const bounds = svg.getBoundingClientRect();
+          svg.dispatchEvent(
+            new WheelEvent('wheel', {
+              deltaY: -240,
+              clientX: bounds.x + bounds.width / 2,
+              clientY: bounds.y + bounds.height / 2,
+              shiftKey: true,
+              bubbles: true,
+              cancelable: true,
+            }),
+          );
+        });
+        cy.get(officialSelector).invoke('attr', 'd').should('not.equal', beforeZoom);
+      });
+    assertEnvelopes();
   });
 });

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -44,7 +44,7 @@ import {
 import type { ParetoDirection } from '@/lib/chart-utils';
 import {
   chartFrontier,
-  groupOperatingCurvePoints,
+  upperPowerEnvelope,
   isPowerCurveMetric,
 } from '@/components/inference/utils/powerCurves';
 import type {
@@ -148,9 +148,9 @@ const GPU_STRINGS = {
     highContrast: 'High Contrast',
     optimalOnly: 'Optimal Only',
     powerCurves:
-      'Lines connect concurrency measurements within the same serving configuration and run; they are power curves, not Pareto frontiers.',
+      'Smooth lines trace the upper power boundary across tested configurations. Dots are measured; lines are interpolated, not efficiency frontiers.',
     powerOptimal:
-      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show power curves across concurrency levels.',
+      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show the upper power boundary.',
     labels: 'Labels',
     parallelismLabels: 'Parallelism Labels',
     concurrencyLabels: '# Concurrent Sessions',
@@ -171,8 +171,8 @@ const GPU_STRINGS = {
     highContrast: '高对比度',
     optimalOnly: '仅最优',
     powerCurves:
-      '曲线连接同一次运行、同一推理配置在不同并发数下的测量点，表示功耗变化，不代表 Pareto 前沿。',
-    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看不同并发数下的功耗曲线。',
+      '平滑曲线勾勒各测试配置的功耗上边界。数据点来自实测，曲线通过插值得到，不代表能效 Pareto 前沿。',
+    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看功耗上边界。',
     labels: '标签',
     parallelismLabels: '并行配置标签',
     concurrencyLabels: '并发会话数',
@@ -250,7 +250,7 @@ const GPUGraph = React.memo(
     ] as ParetoDirection | undefined;
     const hideNonOptimal = Boolean(frontierDirection) && savedHideNonOptimal;
     const powerCurveMetric = isPowerCurveMetric(selectedYAxisMetric);
-    const operatingCurves = powerCurveMetric && !hideNonOptimal;
+    const powerEnvelopeMode = powerCurveMetric && !hideNonOptimal;
     const isMeasuredEnergyAxis = isMeasuredEnergyConfigKey(selectedYAxisMetric);
     const noDataHint = isRoleLocalMeasuredEnergyConfigKey(selectedYAxisMetric)
       ? legendT.noRoleEnergyDataHint
@@ -427,16 +427,13 @@ const GPUGraph = React.memo(
     }, [groupedData, frontierDirection]);
 
     const rooflines = useMemo(() => {
-      if (!operatingCurves) return paretoRooflines;
+      if (!powerEnvelopeMode) return paretoRooflines;
       const result: Record<string, InferenceData[]> = {};
       for (const [key, points] of Object.entries(groupedData)) {
-        let index = 0;
-        for (const segment of groupOperatingCurvePoints(points).values()) {
-          result[`${key}__operating${index++}`] = segment;
-        }
+        result[key] = upperPowerEnvelope(points, chartDefinition.chartType !== 'e2e');
       }
       return result;
-    }, [operatingCurves, groupedData, paretoRooflines]);
+    }, [powerEnvelopeMode, groupedData, paretoRooflines, chartDefinition.chartType]);
 
     const optimalPointKeys = useMemo(() => {
       const keys = new Set<string>();
@@ -601,7 +598,7 @@ const GPUGraph = React.memo(
           useAdvancedLabels ? 'advanced-labels' : 'basic-labels',
           showConcurrencyLabels ? 'conc-labels' : 'no-conc-labels',
           selectedYAxisMetric,
-          operatingCurves ? 'operating-curves' : 'pareto-curves',
+          powerEnvelopeMode ? 'power-envelope' : 'pareto-curves',
           `linear:${xExtent.join(',')}`,
           `${logScale ? 'log' : 'linear'}:${yDomain.join(',')}`,
           ...filteredData.map(
@@ -612,7 +609,7 @@ const GPUGraph = React.memo(
           .join('|'),
       [
         selectedYAxisMetric,
-        operatingCurves,
+        powerEnvelopeMode,
         useAdvancedLabels,
         showConcurrencyLabels,
         xExtent,
@@ -753,7 +750,7 @@ const GPUGraph = React.memo(
     // chip configs on the same date, or a mix — which is the point of this
     // view: quantify the multiple between comparison series at a glance.
     const [savedPerfRulerMode, setPerfRulerMode] = useState(false);
-    const perfRulerMode = savedPerfRulerMode && !operatingCurves;
+    const perfRulerMode = savedPerfRulerMode && !powerEnvelopeMode;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass (no lingering frame).
@@ -1245,7 +1242,7 @@ const GPUGraph = React.memo(
               )}
               {powerCurveMetric && (
                 <p data-testid="power-curve-description" className="text-muted-foreground text-sm">
-                  {operatingCurves ? legendT.powerCurves : legendT.powerOptimal}
+                  {powerEnvelopeMode ? legendT.powerCurves : legendT.powerOptimal}
                 </p>
               )}
             </>
@@ -1273,7 +1270,7 @@ const GPUGraph = React.memo(
             config: {
               getColor: getRooflineColor,
               isVisible: isRooflineVisible,
-              curve: operatingCurves ? d3.curveLinear : d3.curveMonotoneX,
+              curve: d3.curveMonotoneX,
             },
           },
           {
@@ -1574,7 +1571,7 @@ const GPUGraph = React.memo(
                   if (c && !showPointLabels) setShowPointLabels(true);
                 },
               },
-              ...(operatingCurves
+              ...(powerEnvelopeMode
                 ? []
                 : [
                     {

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -100,7 +100,7 @@ import { useThemeColors } from '@/hooks/useThemeColors';
 import { type ParetoDirection } from '@/lib/chart-utils';
 import {
   chartFrontier,
-  groupOperatingCurvePoints,
+  upperPowerEnvelope,
   isPowerCurveMetric,
 } from '@/components/inference/utils/powerCurves';
 import type {
@@ -368,9 +368,9 @@ const SCATTER_STRINGS = {
     optimalOnly: 'Optimal Only',
     optimalInfo: 'Optimal points form the Pareto frontier for the selected axes.',
     powerCurves:
-      'Lines connect concurrency measurements within the same serving configuration and run; they are power curves, not Pareto frontiers.',
+      'Smooth lines trace the upper power boundary across tested configurations. Dots are measured; lines are interpolated, not efficiency frontiers.',
     powerOptimal:
-      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show power curves across concurrency levels.',
+      'A power Pareto frontier can contain a single point. Turn off Optimal Only to show the upper power boundary.',
     labels: 'Labels',
     highContrast: 'High Contrast',
     parallelismLabels: 'Parallelism Labels',
@@ -400,8 +400,8 @@ const SCATTER_STRINGS = {
     optimalOnly: '仅最优',
     optimalInfo: '最优点构成当前所选坐标轴的 Pareto 前沿。',
     powerCurves:
-      '曲线连接同一次运行、同一推理配置在不同并发数下的测量点，表示功耗变化，不代表 Pareto 前沿。',
-    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看不同并发数下的功耗曲线。',
+      '平滑曲线勾勒各测试配置的功耗上边界。数据点来自实测，曲线通过插值得到，不代表能效 Pareto 前沿。',
+    powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看功耗上边界。',
     labels: '标签',
     highContrast: '高对比度',
     parallelismLabels: '并行配置标签',
@@ -502,11 +502,20 @@ const ScatterGraph = React.memo(
       | undefined;
     const hideNonOptimal = preferOptimalOnly && Boolean(paretoDirection);
     const isPowerAxis = isPowerCurveMetric(selectedYAxisMetric);
-    const showOperatingCurves = isPowerAxis && !hideNonOptimal;
-    const showGradientLabels = preferGradientLabels && !showOperatingCurves;
-    const groupDisplayedPoints = showOperatingCurves
-      ? groupOperatingCurvePoints
-      : groupPointsByDate;
+    const showPowerEnvelope = isPowerAxis && !hideNonOptimal;
+    const showGradientLabels = preferGradientLabels && !showPowerEnvelope;
+    const groupDisplayedPoints = useCallback(
+      (points: InferenceData[]) => {
+        const groups = groupPointsByDate(points);
+        if (showPowerEnvelope) {
+          for (const [date, samples] of groups) {
+            groups.set(date, upperPowerEnvelope(samples, chartDefinition.chartType !== 'e2e'));
+          }
+        }
+        return groups;
+      },
+      [showPowerEnvelope, chartDefinition.chartType],
+    );
     const locale = useLocale();
     const legendT = SCATTER_STRINGS[locale];
     const ephemeralUrlState = useEphemeralUrlState();
@@ -783,7 +792,7 @@ const ScatterGraph = React.memo(
       return result;
     }, [groupedData, selectedYAxisMetric, chartDefinition]);
 
-    const displayedRooflines = showOperatingCurves ? groupedData : rooflines;
+    const displayedRooflines = showPowerEnvelope ? groupedData : rooflines;
 
     const optimalPointKeys = useMemo(() => {
       const keys = new Set<string>();
@@ -863,8 +872,8 @@ const ScatterGraph = React.memo(
 
     const officialOverflowContinuations = useMemo((): OverflowContinuationEntry[] => {
       // Pareto continuations can cross serving configurations; they are not
-      // extensions of the configuration-local power operating curves.
-      if (showOperatingCurves) return [];
+      // extensions of the measured power envelope.
+      if (showPowerEnvelope) return [];
       interface Bucket {
         hw: string;
         precision: string;
@@ -908,10 +917,10 @@ const ScatterGraph = React.memo(
         );
       }
       return result;
-    }, [data, clippedData, selectedYAxisMetric, chartDefinition, showOperatingCurves]);
+    }, [data, clippedData, selectedYAxisMetric, chartDefinition, showPowerEnvelope]);
 
     const overlayOverflowContinuations = useMemo((): OverflowContinuationEntry[] => {
-      if (showOperatingCurves) return [];
+      if (showPowerEnvelope) return [];
       interface Bucket {
         hw: string;
         precision: string;
@@ -967,7 +976,7 @@ const ScatterGraph = React.memo(
       selectedYAxisMetric,
       chartDefinition,
       runIndexByUrl,
-      showOperatingCurves,
+      showPowerEnvelope,
     ]);
 
     // Warning annotations for visible series (official + unofficial overlay)
@@ -1059,16 +1068,16 @@ const ScatterGraph = React.memo(
       [overlayGroups, paretoDirection],
     );
     const displayedOverlayRooflines = useMemo(() => {
-      if (!showOperatingCurves) return overlayRooflines;
+      if (!showPowerEnvelope) return overlayRooflines;
       return Object.fromEntries(
         Object.entries(overlayGroups).flatMap(([key, group]) =>
-          [...groupOperatingCurvePoints(group.points)].map(([segment, points]) => [
+          [...groupDisplayedPoints(group.points)].map(([segment, points]) => [
             `${key}__${encodeURIComponent(segment)}`,
             { ...group, points },
           ]),
         ),
       );
-    }, [showOperatingCurves, overlayRooflines, overlayGroups]);
+    }, [showPowerEnvelope, overlayRooflines, overlayGroups, groupDisplayedPoints]);
 
     // Overlay counterpart of `optimalPointKeys`: the points on any overlay
     // run's drawn roofline (already e2e-restricted for agentic non-e2e modes).
@@ -1323,7 +1332,7 @@ const ScatterGraph = React.memo(
     const metricIdentity = useMemo(
       () =>
         [
-          showOperatingCurves ? 'operating-curves' : 'pareto-curves',
+          showPowerEnvelope ? 'power-envelopes' : 'pareto-curves',
           useAdvancedLabels ? 'advanced-labels' : 'basic-labels',
           showConcurrencyLabels ? 'conc-labels' : 'no-conc-labels',
           selectedYAxisMetric,
@@ -1341,7 +1350,7 @@ const ScatterGraph = React.memo(
           .toSorted()
           .join('|'),
       [
-        showOperatingCurves,
+        showPowerEnvelope,
         selectedYAxisMetric,
         useAdvancedLabels,
         showConcurrencyLabels,
@@ -1465,7 +1474,7 @@ const ScatterGraph = React.memo(
     // data point. Multiple rulers accumulate (capped in the pure module);
     // completing one immediately allows starting the next.
     const [preferPerfRulerMode, setPerfRulerMode] = useState(false);
-    const perfRulerMode = preferPerfRulerMode && !showOperatingCurves;
+    const perfRulerMode = preferPerfRulerMode && !showPowerEnvelope;
     const [perfRulerState, setPerfRulerState] = useState<PerfRulerState>(EMPTY_PERF_RULER_STATE);
     // Draw passes read mode/state through refs so toggling off clears the
     // rulers in the same pre-paint layout pass — lines/labels must never
@@ -2052,7 +2061,7 @@ const ScatterGraph = React.memo(
             .line<InferenceData>()
             .x((d) => xScale(d.x))
             .y((d) => yScale(d.y))
-            .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
+            .curve(d3.curveMonotoneX);
 
           // Ensure rooflines layer exists before dot-groups
           let rooflinesLayer = zoomGroup.select<SVGGElement>('.rooflines-layer');
@@ -2151,7 +2160,7 @@ const ScatterGraph = React.memo(
             )
             .join('path')
             .attr('class', (d) => `roofline-path roofline-${d.key}`)
-            .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
+            .attr('data-curve-kind', showPowerEnvelope ? 'power-envelope' : 'pareto')
             .attr('data-hw-key', (d) => d.hw)
             .attr('data-precision', (d) => d.precision)
             .attr('fill', 'none')
@@ -2246,7 +2255,7 @@ const ScatterGraph = React.memo(
               (exit) => exit.remove(),
             )
             .attr('data-seg-key', (d) => d.segKey)
-            .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
+            .attr('data-curve-kind', showPowerEnvelope ? 'power-envelope' : 'pareto')
             .attr('data-hw-key', (d) => d.hw)
             .attr('data-precision', (d) => d.precision)
             .attr('transform', (d) => `translate(${d.x},${d.y})`)
@@ -2439,7 +2448,7 @@ const ScatterGraph = React.memo(
             .line<InferenceData>()
             .x((d) => newXScale(d.x))
             .y((d) => newYScale(d.y))
-            .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
+            .curve(d3.curveMonotoneX);
 
           // Update roofline paths — must split per-date so the zoom redraw
           // matches the per-date sub-paths created in the initial render.
@@ -2623,7 +2632,7 @@ const ScatterGraph = React.memo(
                 .line<InferenceData>()
                 .x((d) => xScale(d.x))
                 .y((d) => yScale(d.y))
-                .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
+                .curve(d3.curveMonotoneX);
 
               interface OvEntry {
                 key: string;
@@ -2654,7 +2663,7 @@ const ScatterGraph = React.memo(
                 .data(ovEntries, (d) => d.key)
                 .join('path')
                 .attr('class', (d) => `overlay-roofline-path overlay-roofline-${d.key}`)
-                .attr('data-curve-kind', showOperatingCurves ? 'operating' : 'pareto')
+                .attr('data-curve-kind', showPowerEnvelope ? 'power-envelope' : 'pareto')
                 .attr('fill', 'none')
                 .attr('stroke', (d) => d.stroke)
                 .attr('stroke-width', 2)
@@ -2828,7 +2837,7 @@ const ScatterGraph = React.memo(
                 .line<InferenceData>()
                 .x((d) => newXScale(d.x))
                 .y((d) => newYScale(d.y))
-                .curve(showOperatingCurves ? d3.curveLinear : d3.curveMonotoneX);
+                .curve(d3.curveMonotoneX);
 
               Object.entries(displayedOverlayRooflines).forEach(([key, group]) => {
                 if (group.points.length < 2) return;
@@ -3059,7 +3068,7 @@ const ScatterGraph = React.memo(
     }, [
       displayedRooflines,
       groupDisplayedPoints,
-      showOperatingCurves,
+      showPowerEnvelope,
       allPointLabelsByKey,
       showGradientLabels,
       showLineLabels,
@@ -3501,7 +3510,21 @@ const ScatterGraph = React.memo(
           watermark={getChartWatermark(isUnofficialRun)}
           testId="scatter-graph"
           grabCursor={true}
-          caption={caption}
+          caption={
+            isPowerAxis ? (
+              <>
+                {caption}
+                <p
+                  data-testid="power-curve-description"
+                  className="mt-2 text-2xs text-muted-foreground"
+                >
+                  {showPowerEnvelope ? legendT.powerCurves : legendT.powerOptimal}
+                </p>
+              </>
+            ) : (
+              caption
+            )
+          }
           xScale={xScaleConfig}
           yScale={yScaleConfig}
           xAxis={xAxisConfig}
@@ -3694,7 +3717,7 @@ const ScatterGraph = React.memo(
                     // Parallelism labels are point labels; turning them on is
                     // pointless if labels are hidden, so auto-enable Labels.
                     if (checked && !showPointLabels) setShowPointLabels(true);
-                    if (checked && !showGradientLabels && !showOperatingCurves) {
+                    if (checked && !showGradientLabels && !showPowerEnvelope) {
                       window.dispatchEvent(
                         new CustomEvent(GRADIENT_NUDGE_EVENT, {
                           detail: {
@@ -3712,7 +3735,7 @@ const ScatterGraph = React.memo(
                     }
                   },
                 },
-                ...(showOperatingCurves
+                ...(showPowerEnvelope
                   ? []
                   : [
                       {
@@ -3735,7 +3758,7 @@ const ScatterGraph = React.memo(
                     track('latency_line_labels_toggled', { enabled: checked });
                   },
                 },
-                ...(showOperatingCurves
+                ...(showPowerEnvelope
                   ? []
                   : [
                       {
@@ -3817,14 +3840,6 @@ const ScatterGraph = React.memo(
             />
           }
         />
-        {isPowerAxis && (
-          <p
-            data-testid="power-curve-description"
-            className="mt-2 px-1 text-2xs text-muted-foreground"
-          >
-            {showOperatingCurves ? legendT.powerCurves : legendT.powerOptimal}
-          </p>
-        )}
         {isMeasuredEnergyAxis && (
           <MeasuredPowerSummary
             total={powerTierCounts.total}

--- a/packages/app/src/components/inference/utils/powerCurves.test.ts
+++ b/packages/app/src/components/inference/utils/powerCurves.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { InferenceData } from '@/components/inference/types';
 
-import { chartFrontier, groupOperatingCurvePoints, isPowerCurveMetric } from './powerCurves';
+import { chartFrontier, isPowerCurveMetric, upperPowerEnvelope } from './powerCurves';
 
 function point(conc: number, x: number, y: number, overrides: Partial<InferenceData> = {}) {
   return {
@@ -23,65 +23,7 @@ function point(conc: number, x: number, y: number, overrides: Partial<InferenceD
   } satisfies InferenceData;
 }
 
-describe('power operating curves', () => {
-  it('connects the power sweep while retaining the single true Pareto winner', () => {
-    const fast = point(1, 200, 350);
-    const medium = point(8, 100, 700);
-    const slow = point(32, 50, 950);
-    const input = Object.freeze([slow, fast, medium]);
-    const segments = [...groupOperatingCurvePoints(input).values()];
-
-    expect(segments).toEqual([[fast, medium, slow]]);
-    expect(segments[0][0]).toBe(fast);
-    expect(input).toEqual([slow, fast, medium]);
-    expect(chartFrontier([...input], 'lower_right')).toEqual([fast]);
-    expect(chartFrontier([...input], undefined)).toEqual([]);
-  });
-
-  it('keeps concurrency order when measured interactivity is non-monotonic', () => {
-    const points = [point(1, 200, 350), point(8, 80, 700), point(32, 90, 950)];
-    expect([...groupOperatingCurvePoints(points).values()]).toEqual([points]);
-  });
-
-  it.each<Partial<InferenceData>>([
-    { tp: 4 },
-    { precision: 'fp4' },
-    { hwKey: 'b200_sglang_mtp' },
-    { date: '2026-09-09' },
-    { run_url: 'https://github.com/o/r/actions/runs/2' },
-    { decode_ep: 8 },
-    { prefill_tp: 4 },
-    { prefill_ep: 4 },
-    { disagg: true, num_prefill_gpu: 4, num_decode_gpu: 8 },
-    { physicalChips: 16 },
-    { dp: 2 },
-    { offload_mode: 'on' },
-    { recipe_fingerprint: 'another-recipe' },
-    { benchmark_type: 'agentic_traces', spec_decoding: 'mtp' },
-  ])('never joins different configuration/date/run identities: %j', (overrides) => {
-    const base = [point(1, 200, 350), point(8, 100, 700)];
-    const different = [point(1, 210, 400, overrides), point(8, 110, 750, overrides)];
-    expect([...groupOperatingCurvePoints([...base, ...different]).values()]).toEqual([
-      base,
-      different,
-    ]);
-  });
-
-  it('deduplicates identical vertices but breaks curves at ambiguous repeated concurrency', () => {
-    const first = point(1, 200, 350);
-    const ambiguous = [point(8, 100, 700), point(8, 110, 710)];
-    const tail = [point(16, 80, 800), point(32, 50, 950)];
-    expect([
-      ...groupOperatingCurvePoints([first, { ...first }, ...ambiguous, ...tail]).values(),
-    ]).toEqual([[first], [ambiguous[0]], [ambiguous[1]], tail]);
-  });
-
-  it('excludes unusable coordinates and concurrency from line vertices', () => {
-    const valid = [point(1, 200, 350), point(8, 100, 700)];
-    const invalid = [point(16, 0, 800), point(32, 50, NaN), point(NaN, 50, 950)];
-    expect([...groupOperatingCurvePoints([...valid, ...invalid]).values()]).toEqual([valid]);
-  });
-
+describe('power chart semantics', () => {
   it('selects power gauges without changing energy chart semantics', () => {
     expect(isPowerCurveMetric('y_measuredAvgPower')).toBe(true);
     expect(isPowerCurveMetric('y_measuredP90Power')).toBe(true);
@@ -97,5 +39,54 @@ describe('power operating curves', () => {
     const canonical = point(8, 100, 1, { isOnNormalizedInteractivityFrontier: true });
     const nonCanonical = point(1, 200, 4, { isOnNormalizedInteractivityFrontier: false });
     expect(chartFrontier([canonical, nonCanonical], 'lower_right')).toEqual([canonical]);
+  });
+});
+
+describe('upper power envelope', () => {
+  it('removes concurrency backtracking across configurations without changing measurements', () => {
+    // H100-style sweep: more concurrency can move both left and right on X.
+    const fast = point(1, 172.49, 252.22, { tp: 8 });
+    const middle = point(2, 149.32, 291.38);
+    const peak = point(128, 25.69, 502.54, { decode_ep: 8 });
+    const dominated = point(64, 20.51, 344.95, { decode_ep: 8 });
+    const slower = point(256, 4.65, 372.9, { decode_ep: 8 });
+    const input = Object.freeze([fast, middle, dominated, peak, slower]);
+    expect(upperPowerEnvelope(input, true)).toEqual([peak, middle, fast]);
+    expect(input).toEqual([fast, middle, dominated, peak, slower]);
+    expect(chartFrontier([...input], 'lower_right')).toEqual([fast]);
+  });
+
+  it('mirrors the boundary for latency and resolves tied coordinates deterministically', () => {
+    const fast = point(1, 1, 350);
+    const middle = point(8, 2, 700);
+    const slow = point(32, 4, 950);
+    const samples = [slow, point(16, 3, 700), point(4, 2, 500), middle, { ...middle }, fast];
+    expect(upperPowerEnvelope(samples, false)).toEqual([fast, middle, slow]);
+    expect(
+      upperPowerEnvelope(
+        samples.map((p) => ({ ...p, x: 1000 / p.x })),
+        true,
+      ).map((p) => p.y),
+    ).toEqual([950, 700, 350]);
+  });
+
+  it('uses only finite positive coordinates and preserves singleton boundaries', () => {
+    const valid = point(1, 200, 350);
+    expect(upperPowerEnvelope([], true)).toEqual([]);
+    expect(
+      upperPowerEnvelope(
+        [
+          point(1, 0, 900),
+          point(1, NaN, 900),
+          point(1, Infinity, 900),
+          point(1, 10, Infinity),
+          point(1, 10, NaN),
+          point(1, 10, 0),
+          point(1, 10, -1),
+          valid,
+        ],
+        true,
+      ),
+    ).toEqual([valid]);
   });
 });

--- a/packages/app/src/components/inference/utils/powerCurves.ts
+++ b/packages/app/src/components/inference/utils/powerCurves.ts
@@ -6,7 +6,6 @@ import {
 } from '@/lib/chart-utils';
 
 import { canonicalParetoIntersection } from './canonicalFrontier';
-import { scatterPointConfigId } from './point-identity';
 
 const POWER_CURVE_METRICS: ReadonlySet<string> = new Set([
   'y_measuredAvgPower',
@@ -34,62 +33,22 @@ export function chartFrontier(
 }
 
 /**
- * Connect concurrency sweeps only within one dated serving configuration/run.
- * These are operating curves, not optimality claims. Input points are unchanged.
- * Conflicting measurements at one concurrency break a curve rather than invent
- * an ordering between repeated observations; exact duplicate vertices collapse.
+ * Higher-power outer boundary across tested configurations, not an efficiency
+ * frontier. Unique X vertices avoid concurrency backtracking during smoothing.
+ * Callers scope the samples by hardware, precision, date and overlay run.
  */
-export function groupOperatingCurvePoints(
+export function upperPowerEnvelope(
   points: readonly InferenceData[],
-): Map<string, InferenceData[]> {
-  const groups = new Map<string, InferenceData[]>();
-  for (const point of points) {
-    if (
-      !isFrontierEligible(point) ||
-      !Number.isFinite(point.y) ||
-      !Number.isFinite(point.conc) ||
-      point.conc <= 0
-    ) {
-      continue;
-    }
-    const key = JSON.stringify([
-      point.date,
-      point.run_url ?? null,
-      scatterPointConfigId({ ...point, conc: 0 }),
-    ]);
-    const group = groups.get(key) ?? [];
-    group.push(point);
-    groups.set(key, group);
-  }
-
-  const segments = new Map<string, InferenceData[]>();
-  for (const [key, group] of groups) {
-    const sorted = group.toSorted((a, b) => a.conc - b.conc || a.x - b.x || a.y - b.y);
-    let segment: InferenceData[] = [];
-    let segmentIndex = 0;
-    const flush = () => {
-      if (segment.length > 0) segments.set(`${key}:${segmentIndex++}`, segment);
-      segment = [];
-    };
-    for (let i = 0; i < sorted.length;) {
-      const sameConcurrency: InferenceData[] = [];
-      const concurrency = sorted[i].conc;
-      while (i < sorted.length && sorted[i].conc === concurrency) {
-        const point = sorted[i++];
-        if (!sameConcurrency.some((other) => other.x === point.x && other.y === point.y)) {
-          sameConcurrency.push(point);
-        }
-      }
-      if (sameConcurrency.length === 1) {
-        segment.push(sameConcurrency[0]);
-      } else {
-        flush();
-        for (const point of sameConcurrency) {
-          segments.set(`${key}:${segmentIndex++}`, [point]);
-        }
-      }
-    }
-    flush();
-  }
-  return segments;
+  maximizeX: boolean,
+): InferenceData[] {
+  const sorted = points
+    .filter((point) => isFrontierEligible(point) && Number.isFinite(point.y) && point.y > 0)
+    .sort((a, b) => (maximizeX ? b.x - a.x : a.x - b.x) || b.y - a.y);
+  let maxY = -Infinity;
+  const envelope = sorted.filter((point) => {
+    if (point.y <= maxY) return false;
+    maxY = point.y;
+    return true;
+  });
+  return maximizeX ? envelope.toReversed() : envelope;
 }


### PR DESCRIPTION
## Summary

Power charts currently connect measurements in concurrency order, producing zigzags when interactivity moves backwards. With Optimal Only off, both inference chart views now draw a smooth upper power envelope across tested configurations. All measured dots remain visible; the true efficiency Pareto filter and energy-per-token charts keep their existing behavior.

Envelopes stay separate by hardware, precision and date, with unofficial overlays also separated by run. Latency reverses the X direction. Zoom preserves monotone interpolation, and English/Chinese explanations are included in exported images so the power boundary is not presented as an efficiency frontier. No benchmark values or API/export data are changed.

## Validation

- Local smoke: 63 Cypress component tests and 113 integration tests passed, including nonmonotonic H100 measurements, unofficial overlays, date separation, zoom, metric switching and saved Optimal Only behavior.
- Workspace unit suite passed; final focused power/direction suite: 23 passed after removing the unused concurrency-grouping helper.
- Typecheck, lint, formatting and typography passed. Production build and full Chrome/Firefox coverage run in CI; live verification follows deployment.

## 中文说明

原有功耗图按并发数连接测量点，交互速度不单调时会出现折返。现在关闭“仅最优”后，两种推理图表都会根据不同测试配置绘制平滑的功耗上边界，同时保留全部实测点。原有能效最优筛选和每 token 能耗图的行为不变。

不同硬件、精度和日期的曲线保持独立，非官方叠加还按运行区分。延迟视图反转横轴方向，缩放后仍使用单调插值。导出图片包含中英文说明，明确功耗上边界不代表能效最优前沿；基准测试数值和 API、数据导出内容均未修改。

本地通过 63 项 Cypress 组件测试、113 项 smoke 集成测试及工作区单元测试；删除不再使用的并发分组函数后，23 项功耗与方向测试通过。类型、lint、格式和排版检查通过。生产构建及完整 Chrome/Firefox 测试由 CI 执行，部署后继续验证线上页面。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inference chart rendering semantics for power axes when Optimal Only is off, affecting how users interpret curves; benchmark data and APIs are untouched but visual interpretation risk is moderate.
> 
> **Overview**
> When **Optimal Only** is off on power metrics, `GPUGraph` and `ScatterGraph` no longer draw per-configuration concurrency “operating curves.” They compute one **upper power envelope** per scoped series (hardware/precision/date, separate overlay runs) via new `upperPowerEnvelope`, then render it with **monotone smooth** paths (`data-curve-kind="power-envelope"`) instead of linear segment chains.
> 
> The envelope aggregates points across configurations (fixing zigzags/loops from nonmonotonic interactivity), with X direction flipped for latency/`e2e` charts. **Pareto filtering**, energy-per-token frontiers, %TDP behavior, and all measured dots are unchanged; perf ruler / gradient labels stay disabled in envelope mode.
> 
> Copy updates (EN/ZH) and Scatter’s power disclaimer move into the chart caption so exports clarify the line is an interpolated upper boundary, not an efficiency frontier. Cypress and unit tests were rewritten for envelope counts, smooth paths, zoom, overlays, and real H100 Qwen3.5 fixtures; `groupOperatingCurvePoints` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e31ea8be9a89c6d49f7e7c9b1982da03d21b84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->