### PR TITLE
feat(app): add DeepSeek V4.1 Flash to the profit estimators with DeepSeek Flash list-price defaults / 利润估算器新增 DeepSeek V4.1 Flash 并默认采用 DeepSeek 官方定价

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1107,7 +1107,7 @@ and the two can be collapsed into one once both are on master.
   no scenario selector and no precision selector (precision stays in auto mode, the
   densest measured run set). The interactivity target is a typed number in the same
   row as utilization and the license fee.
-- **Kimi K3, GLM 5.2/5.3, MiniMax M3, and DeepSeek V4 Pro.** The model selector offers the tab's route allow-list
+- **Kimi K3, GLM 5.2/5.3, MiniMax M3, DeepSeek V4 Pro, and DeepSeek V4.1 Flash.** The model selector offers the tab's route allow-list
   (`MODEL_ROUTE_TAB_MODELS['profit-estimator']` and
   `['profit-estimator-per-gigawatt']` in `model-routes.ts`) intersected with the
   models that have an agentic run. Each bare path opens on Kimi K3
@@ -1116,7 +1116,9 @@ and the two can be collapsed into one once both are on master.
   GLM 5.2/5.3 page (one data bucket, one slug, as on the rest of the site),
   `/minimax-m3` is the MiniMax M3 page, `/deepseek-v4` is the DeepSeek V4 Pro
   page (the app-wide default elsewhere, but a slugged page here since the bare
-  path is Kimi K3), aliases 308 to the canonical slug, and any model outside the
+  path is Kimi K3), `/deepseek-v41-flash` is the DeepSeek V4.1 Flash page (its
+  own slug and `dsv41flash` bucket: a different architecture, not a V4 Pro point
+  release), aliases 308 to the canonical slug, and any model outside the
   allow-list 404s. Widening
   the pages to more models is one list edit, a `profitModelDefaults` entry, and
   fixture rows.
@@ -1142,7 +1144,13 @@ and the two can be collapsed into one once both are on master.
   and a 5% model license fee. At 24 tok/s/user the B200, B300, and MI355X agentic curves are priced; the
   GB200, GB300, and H200 curves bottom out above it (their lowest measured
   points sit at roughly 40, 30, and 27 tok/s/user) and list as not priced until
-  a lower-interactivity run lands. A
+  a lower-interactivity run lands. DeepSeek V4.1 Flash opens on 125 tok/s/user,
+  the speed DeepSeek's own API serves the Flash tier at, DeepSeek's peak-hour
+  list price for `deepseek-flash` ($0.30 input / $0.006 cached / $1.20 output
+  per M tok; off-peak is half that), and the same 5% model license fee as V4
+  Pro. It entered the fleet on AgentX only (InferenceX#2961), so the page is
+  wired ahead of the first published rows; SKUs whose agentic curves stop short
+  of 125 tok/s/user list as not priced rather than extrapolated. A
   model with a list price gets a third Token Price option, `<vendor> list
 price`, next to OpenRouter and Custom; the caption names the source in force and
   links the lab's pricing page when the list price is used. Switching to Custom

--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1147,8 +1147,8 @@ and the two can be collapsed into one once both are on master.
   a lower-interactivity run lands. DeepSeek V4.1 Flash opens on 125 tok/s/user,
   the speed DeepSeek's own API serves the Flash tier at, DeepSeek's peak-hour
   list price for `deepseek-flash` ($0.30 input / $0.006 cached / $1.20 output
-  per M tok; off-peak is half that), and the same 5% model license fee as V4
-  Pro. It entered the fleet on AgentX only (InferenceX#2961), so the page is
+  per M tok; off-peak is half that), and a 0% model license fee, since the
+  weights ship under the MIT license. It entered the fleet on AgentX only (InferenceX#2961), so the page is
   wired ahead of the first published rows; SKUs whose agentic curves stop short
   of 125 tok/s/user list as not priced rather than extrapolated. A
   model with a list price gets a third Token Price option, `<vendor> list

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -9,7 +9,7 @@
 //  - DeepSeek V4 Pro opens on 24 tok/s/user, the DeepSeek peak list price
 //    ($1.32 / $0.044 cached / $3.96), and a 5% license fee;
 //  - DeepSeek V4.1 Flash opens on 125 tok/s/user, the DeepSeek Flash peak list
-//    price ($0.30 / $0.006 cached / $1.20), and a 5% license fee;
+//    price ($0.30 / $0.006 cached / $1.20), and a 0% license fee (MIT weights);
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
@@ -990,8 +990,8 @@ describe('Profit Estimator — DeepSeek V4.1 Flash', () => {
     chart().should('exist');
     cy.location('pathname').should('eq', '/profit-estimator/deepseek-v41-flash');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '125');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
-    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '5%');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '0');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '0%');
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'DeepSeek V4.1 Flash 552B Agentic Revenue & Profit Estimates per Chip per Hour at P90 125 tok/s/user Interactivity',
@@ -1049,7 +1049,7 @@ describe('Profit Estimator — DeepSeek V4.1 Flash', () => {
       .should('contain.text', 'DeepSeek V4.1 Flash')
       .and('contain.text', '125 tok/s/user');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '125');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '0');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $0.3')
       .and('contain.text', 'Output: $1.2')

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -8,6 +8,8 @@
 //    ($0.30 / $0.06 cached / $1.20);
 //  - DeepSeek V4 Pro opens on 24 tok/s/user, the DeepSeek peak list price
 //    ($1.32 / $0.044 cached / $3.96), and a 5% license fee;
+//  - DeepSeek V4.1 Flash opens on 125 tok/s/user, the DeepSeek Flash peak list
+//    price ($0.30 / $0.006 cached / $1.20), and a 5% license fee;
 //  - utilization scales revenue only, so the revenue label moves and the
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
@@ -16,8 +18,8 @@
 //    (input, cached input, output) can replace it;
 //  - the workload is pinned to agentic traces, so there is no scenario or
 //    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3,
-//    MiniMax M3 and DeepSeek V4 Pro only, and the target interactivity is a
-//    typed number, not a slider;
+//    MiniMax M3, DeepSeek V4 Pro and DeepSeek V4.1 Flash only, and the target
+//    interactivity is a typed number, not a slider;
 //  - the cost tier, utilization and license fee are edited in the caption line
 //    under the title; custom $/GPU/hr is typed into the TCO badges there;
 //  - the per-GW page opens on Owning at Large Hyperscaler Volume while the
@@ -63,6 +65,10 @@ const OPENROUTER_MODELS = {
     {
       id: 'deepseek/deepseek-v4-pro-0813',
       pricing: { prompt: '0.00000066', completion: '0.00000198', input_cache_read: '0.000000022' },
+    },
+    {
+      id: 'deepseek/deepseek-v4.1-flash',
+      pricing: { prompt: '0.00000015', completion: '0.0000006', input_cache_read: '0.000000003' },
     },
   ],
 };
@@ -174,11 +180,12 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-precision-selector"]').should('not.exist');
     cy.get('[data-testid="profit-model-selector"]').should('contain.text', 'Kimi K3').click();
     cy.get('[role="option"]')
-      .should('have.length', 4)
+      .should('have.length', 5)
       .and('contain.text', 'Kimi K3')
       .and('contain.text', 'GLM5.2/GLM5.3')
       .and('contain.text', 'MiniMax M3')
-      .and('contain.text', 'DeepSeek V4 Pro');
+      .and('contain.text', 'DeepSeek V4 Pro')
+      .and('contain.text', 'DeepSeek V4.1 Flash');
     cy.get('body').type('{esc}');
     // Kimi K3 has no list price, so the selector offers the catalog and custom only.
     cy.get('button#profit-price-source').click();
@@ -967,6 +974,105 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', '输入：$1.32')
+      .and('contain.text', 'DeepSeek 官方定价');
+    cy.get('button#profit-price-source').should('contain.text', 'DeepSeek 官方定价');
+  });
+});
+
+describe('Profit Estimator — DeepSeek V4.1 Flash', () => {
+  beforeEach(() => {
+    stubOpenRouter();
+    cy.viewport(1280, 1000);
+  });
+
+  it('opens /profit-estimator/deepseek-v41-flash on 125 tok/s/user and the DeepSeek Flash list price', () => {
+    cy.visit('/profit-estimator/deepseek-v41-flash', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.location('pathname').should('eq', '/profit-estimator/deepseek-v41-flash');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '125');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '5%');
+    cy.get('[data-testid="profit-caption"] h2').should(
+      'contain.text',
+      'DeepSeek V4.1 Flash 552B Agentic Revenue & Profit Estimates per Chip per Hour at P90 125 tok/s/user Interactivity',
+    );
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.3')
+      .and('contain.text', 'Cached Input: $0.006')
+      .and('contain.text', 'Output: $1.2')
+      .and('contain.text', '(DeepSeek list price)');
+    cy.get('[data-testid="profit-list-price-source"]')
+      .should('have.attr', 'href', 'https://api-docs.deepseek.com/quick_start/pricing/')
+      .and('contain.text', 'DeepSeek');
+    // 125 tok/s/user sits inside the wide curve (top 130) but past the H200
+    // curve's 38 tok/s/user top, so H200 lists as not priced.
+    chart().find('image.bar-vendor-mark').should('have.length', 4);
+    chart().should('not.contain.text', 'H200');
+    cy.get('[data-testid="profit-pricing-notice"]').should('not.exist');
+
+    // The catalog stays one click away and reads the Flash row, not V4 Pro's.
+    cy.get('button#profit-price-source').click();
+    cy.get('[role="option"]')
+      .should('have.length', 3)
+      .and('contain.text', 'OpenRouter')
+      .and('contain.text', 'DeepSeek list price')
+      .and('contain.text', 'Custom $/M tok');
+    cy.contains('[role="option"]', 'OpenRouter').click();
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.15')
+      .and('contain.text', 'Output: $0.6')
+      .and('contain.text', '(OpenRouter)');
+    cy.get('[data-testid="profit-list-price-source"]').should('not.exist');
+
+    // Custom seeds from the price in force, here the list price.
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'DeepSeek list price').click();
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'Custom $/M tok').click();
+    cy.get('[data-testid="profit-input-price"]').should('have.value', '0.3');
+    cy.get('[data-testid="profit-cached-price"]').should('have.value', '0.006');
+    cy.get('[data-testid="profit-output-price"]').should('have.value', '1.2');
+  });
+
+  it('re-seeds the operating point and price source when switching from DeepSeek V4 Pro', () => {
+    cy.visit('/profit-estimator-per-gigawatt/deepseek-v4', { onBeforeLoad: suppressNudges });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+
+    // Both DeepSeek models share a vendor label, so the switch must land on the
+    // Flash triple, not keep V4 Pro's.
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'DeepSeek V4.1 Flash').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/deepseek-v41-flash');
+    cy.get('[data-testid="profit-caption"] h2')
+      .should('contain.text', 'DeepSeek V4.1 Flash')
+      .and('contain.text', '125 tok/s/user');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '125');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.3')
+      .and('contain.text', 'Output: $1.2')
+      .and('contain.text', '(DeepSeek list price)');
+
+    cy.get('[data-testid="profit-model-selector"]').click();
+    cy.contains('[role="option"]', 'Kimi K3').click();
+    cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt/kimi-k3');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.6')
+      .and('contain.text', '(OpenRouter)');
+  });
+
+  it('serves the Chinese mirror with the list price named in Chinese', () => {
+    cy.visit('/zh/profit-estimator-per-gigawatt/deepseek-v41-flash', {
+      onBeforeLoad: suppressNudges,
+    });
+    chart().should('exist');
+    cy.get('[data-testid="profit-target-input"]').should('have.value', '125');
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', '输入：$0.3')
       .and('contain.text', 'DeepSeek 官方定价');
     cy.get('button#profit-price-source').should('contain.text', 'DeepSeek 官方定价');
   });

--- a/packages/app/cypress/support/profit-fixtures.ts
+++ b/packages/app/cypress/support/profit-fixtures.ts
@@ -1,7 +1,7 @@
 /**
  * Synthetic agentic rows for the `/profit-estimator` e2e spec, one identical
  * SKU set per model the estimator serves (Kimi K3, GLM 5.2/5.3, MiniMax M3,
- * DeepSeek V4 Pro).
+ * DeepSeek V4 Pro, DeepSeek V4.1 Flash).
  *
  * The captured API fixtures carry no `agentic_traces` rows, and the estimator
  * is pinned to that workload, so the spec intercepts availability and
@@ -14,7 +14,9 @@
  * wide curve reaches 130 tok/s/user so GLM's 100 and MiniMax M3's 83 tok/s/user
  * defaults are reads, not clamps, on every other SKU. Both curves start below
  * DeepSeek V4 Pro's 24 tok/s/user default, so every SKU, H200 included, is
- * priced there.
+ * priced there. DeepSeek V4.1 Flash's 125 tok/s/user default sits just inside
+ * the wide curve's 130 tok/s/user top, so the four wide-curve SKUs are priced
+ * and H200 is not, as on the Kimi, GLM, and MiniMax defaults.
  */
 import { metricsFor } from './overlay-fixtures';
 
@@ -22,12 +24,14 @@ export const PROFIT_MODEL_DB_KEY = 'kimik3';
 export const PROFIT_GLM_DB_KEY = 'glm5.2';
 export const PROFIT_MINIMAX_DB_KEY = 'minimaxm3';
 export const PROFIT_DEEPSEEK_DB_KEY = 'dsv4';
+export const PROFIT_DEEPSEEK_FLASH_DB_KEY = 'dsv41flash';
 /** `?model=` display key the benchmarks request carries → DB key of its rows. */
 const PROFIT_DB_KEY_BY_DISPLAY_MODEL: Record<string, string> = {
   'Kimi-K3': PROFIT_MODEL_DB_KEY,
   'GLM-5.2': PROFIT_GLM_DB_KEY,
   'MiniMax-M3': PROFIT_MINIMAX_DB_KEY,
   'DeepSeek-V4-Pro': PROFIT_DEEPSEEK_DB_KEY,
+  'DeepSeek-V4.1-Flash': PROFIT_DEEPSEEK_FLASH_DB_KEY,
 };
 const PROFIT_DB_KEYS = Object.values(PROFIT_DB_KEY_BY_DISPLAY_MODEL);
 export const PROFIT_DATE = '2026-08-31';

--- a/packages/app/src/app/sitemap.test.ts
+++ b/packages/app/src/app/sitemap.test.ts
@@ -84,8 +84,8 @@ describe('sitemap locale parity', () => {
       for (const route of MODEL_ROUTES) {
         // The default model's page canonicalizes to the bare tab path, which
         // the dashboard-route loop above already covers. Models a tab does not
-        // serve (the profit estimator is Kimi K3, GLM 5.2/5.3, MiniMax M3 and
-        // DeepSeek V4 Pro only) 404 and stay out.
+        // serve (the profit estimator is Kimi K3, GLM 5.2/5.3, MiniMax M3,
+        // DeepSeek V4 Pro and DeepSeek V4.1 Flash only) 404 and stay out.
         const expected = served.has(route.model) && route.model !== defaultRouteModel(tab);
         const enPath = modelRoutePath(tab, route.slug);
         expect(urls.has(`${SITE_URL}${enPath}`)).toBe(expected);

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -610,7 +610,8 @@ function ProfitEstimatorInner({
   // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
   // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
   // list price at 20%; DeepSeek V4 Pro: 24 tok/s/user on the DeepSeek list
-  // price at 5%), so a model switch re-seeds all three. The ref keeps
+  // price at 5%; DeepSeek V4.1 Flash: 125 tok/s/user on the DeepSeek Flash
+  // list price at 5%), so a model switch re-seeds all three. The ref keeps
   // this to actual switches: re-renders with the same model leave the
   // reader's edits alone. Ignore disallowed models briefly restored by URL
   // hydration so normalizing a fixed-workload share link preserves its target.

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -611,7 +611,7 @@ function ProfitEstimatorInner({
   // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
   // list price at 20%; DeepSeek V4 Pro: 24 tok/s/user on the DeepSeek list
   // price at 5%; DeepSeek V4.1 Flash: 125 tok/s/user on the DeepSeek Flash
-  // list price at 5%), so a model switch re-seeds all three. The ref keeps
+  // list price at 0%, MIT-licensed), so a model switch re-seeds all three. The ref keeps
   // this to actual switches: re-renders with the same model leave the
   // reader's edits alone. Ignore disallowed models briefly restored by URL
   // hydration so normalizing a fixed-workload share link preserves its target.

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -400,6 +400,25 @@ describe('profitModelDefaults', () => {
     });
   });
 
+  it('opens DeepSeek V4.1 Flash on 125 tok/s/user, the DeepSeek Flash peak list price, and a 5% license fee', () => {
+    const defaults = profitModelDefaults(Model.DeepSeek_V4_1_Flash);
+    expect(defaults.interactivity).toBe(125);
+    expect(defaults.labCutPct).toBe(5);
+    expect(defaults.listPricing).toEqual({
+      vendor: 'DeepSeek',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.006,
+      outputPerMillion: 1.2,
+      sourceUrl: 'https://api-docs.deepseek.com/quick_start/pricing/',
+    });
+    expect(listPricingToTokenRevenuePricing(defaults.listPricing!)).toEqual({
+      source: 'normalized',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.006,
+      outputPerMillion: 1.2,
+    });
+  });
+
   it('falls back to 45 tok/s/user, OpenRouter, and a 30% license fee for models without an entry', () => {
     expect(profitModelDefaults(Model.DeepSeek_R1)).toEqual({
       interactivity: DEFAULT_PROFIT_INTERACTIVITY,

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -400,10 +400,10 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('opens DeepSeek V4.1 Flash on 125 tok/s/user, the DeepSeek Flash peak list price, and a 5% license fee', () => {
+  it('opens DeepSeek V4.1 Flash on 125 tok/s/user, the DeepSeek Flash peak list price, and a 0% (MIT) license fee', () => {
     const defaults = profitModelDefaults(Model.DeepSeek_V4_1_Flash);
     expect(defaults.interactivity).toBe(125);
-    expect(defaults.labCutPct).toBe(5);
+    expect(defaults.labCutPct).toBe(0);
     expect(defaults.listPricing).toEqual({
       vendor: 'DeepSeek',
       inputPerMillion: 0.3,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -81,8 +81,9 @@ export interface ProfitModelDefaults {
  * until a lower-interactivity run lands. DeepSeek V4.1 Flash opens on the
  * `deepseek-flash` peak-hour list price ($0.30 / $0.006 cached / $1.20 per M
  * tok; off-peak is half that) from the same pricing page, on 125 tok/s/user,
- * the speed DeepSeek's own API serves the Flash tier at, and on the same 5%
- * model license fee as V4 Pro. It entered the fleet on AgentX only, so the
+ * the speed DeepSeek's own API serves the Flash tier at, and on a 0% model
+ * license fee: the weights ship under the MIT license, so there is no lab cut
+ * to model. It entered the fleet on AgentX only, so the
  * estimator serves it from day zero; SKUs whose curves stop short of 125
  * tok/s/user list as not priced rather than extrapolated.
  */
@@ -100,7 +101,7 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   },
   [Model.DeepSeek_V4_1_Flash]: {
     interactivity: 125,
-    labCutPct: 5,
+    labCutPct: 0,
     listPricing: {
       vendor: 'DeepSeek',
       inputPerMillion: 0.3,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -78,7 +78,13 @@ export interface ProfitModelDefaults {
  * on 24 tok/s/user, the speed DeepSeek's own API serves at, and on a 5% model
  * license fee. The B200, B300, and MI355X agentic curves reach that point; the
  * GB200, GB300, and H200 curves bottom out above it and list as not priced
- * until a lower-interactivity run lands.
+ * until a lower-interactivity run lands. DeepSeek V4.1 Flash opens on the
+ * `deepseek-flash` peak-hour list price ($0.30 / $0.006 cached / $1.20 per M
+ * tok; off-peak is half that) from the same pricing page, on 125 tok/s/user,
+ * the speed DeepSeek's own API serves the Flash tier at, and on the same 5%
+ * model license fee as V4 Pro. It entered the fleet on AgentX only, so the
+ * estimator serves it from day zero; SKUs whose curves stop short of 125
+ * tok/s/user list as not priced rather than extrapolated.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   [Model.DeepSeek_V4_Pro]: {
@@ -89,6 +95,17 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
       inputPerMillion: 1.32,
       cachedInputPerMillion: 0.044,
       outputPerMillion: 3.96,
+      sourceUrl: 'https://api-docs.deepseek.com/quick_start/pricing/',
+    },
+  },
+  [Model.DeepSeek_V4_1_Flash]: {
+    interactivity: 125,
+    labCutPct: 5,
+    listPricing: {
+      vendor: 'DeepSeek',
+      inputPerMillion: 0.3,
+      cachedInputPerMillion: 0.006,
+      outputPerMillion: 1.2,
       sourceUrl: 'https://api-docs.deepseek.com/quick_start/pricing/',
     },
   },

--- a/packages/app/src/lib/model-routes.test.ts
+++ b/packages/app/src/lib/model-routes.test.ts
@@ -183,14 +183,20 @@ describe('modelRoutePathnameRewrite', () => {
 });
 
 describe('modelRoutesForTab', () => {
-  it('serves Kimi K3, GLM 5.2/5.3, MiniMax M3 and DeepSeek V4 Pro on the profit estimators and every model elsewhere', () => {
+  it('serves Kimi K3, GLM 5.2/5.3, MiniMax M3, DeepSeek V4 Pro and DeepSeek V4.1 Flash on the profit estimators and every model elsewhere', () => {
     for (const tab of ['profit-estimator', 'profit-estimator-per-gigawatt'] as const) {
       // `MODEL_ROUTES` order (the dashboard selector's), not allow-list order.
       expect(
         modelRoutesForTab(tab)
           .map((route) => route.model)
           .filter((model) => model !== Model.Qwen3_5),
-      ).toEqual([Model.DeepSeek_V4_Pro, Model.Kimi_K3, Model.MiniMax_M3, Model.GLM_5_2]);
+      ).toEqual([
+        Model.DeepSeek_V4_Pro,
+        Model.DeepSeek_V4_1_Flash,
+        Model.Kimi_K3,
+        Model.MiniMax_M3,
+        Model.GLM_5_2,
+      ]);
       expect(modelRouteAvailableForTab(tab, Model.Qwen3_5)).toBe(
         tab === 'profit-estimator-per-gigawatt',
       );
@@ -203,6 +209,12 @@ describe('modelRoutesForTab', () => {
       expect(
         modelRoutesForTab(tab).find((route) => route.model === Model.DeepSeek_V4_Pro)?.slug,
       ).toBe('deepseek-v4');
+      // V4.1 Flash is its own architecture and DB bucket, so it gets its own
+      // slug rather than joining the V4 Pro page.
+      expect(modelRouteAvailableForTab(tab, Model.DeepSeek_V4_1_Flash)).toBe(true);
+      expect(
+        modelRoutesForTab(tab).find((route) => route.model === Model.DeepSeek_V4_1_Flash)?.slug,
+      ).toBe('deepseek-v41-flash');
       // GLM 5.2 and 5.3 share one data bucket; the slug follows the current
       // release, as on the rest of the site, and `glm-5-2` 308s to it.
       expect(modelRoutesForTab(tab).find((route) => route.model === Model.GLM_5_2)?.slug).toBe(

--- a/packages/app/src/lib/model-routes.ts
+++ b/packages/app/src/lib/model-routes.ts
@@ -71,15 +71,17 @@ export function defaultRouteModel(tab: ModelRouteTab): Model {
 /**
  * Tabs that expose only a subset of `MODEL_ROUTES`. The profit estimators
  * serve the agentic models whose coverage spans every SKU we price: Kimi K3
- * (the default), GLM 5.2/5.3, MiniMax M3, and DeepSeek V4 Pro. The per-GW
- * view also offers Qwen3.5 fixed 8k/1k power planning. Other slugs 404 there
- * and stay out of the sitemap. Tabs absent from this map offer every model.
+ * (the default), GLM 5.2/5.3, MiniMax M3, DeepSeek V4 Pro, and DeepSeek V4.1
+ * Flash. The per-GW view also offers Qwen3.5 fixed 8k/1k power planning.
+ * Other slugs 404 there and stay out of the sitemap. Tabs absent from this
+ * map offer every model.
  */
 const PROFIT_ESTIMATOR_MODELS: readonly Model[] = [
   Model.Kimi_K3,
   Model.GLM_5_2,
   Model.MiniMax_M3,
   Model.DeepSeek_V4_Pro,
+  Model.DeepSeek_V4_1_Flash,
 ];
 const MODEL_ROUTE_TAB_MODELS: Partial<Record<ModelRouteTab, readonly Model[]>> = {
   'profit-estimator': PROFIT_ESTIMATOR_MODELS,


### PR DESCRIPTION
## Summary

Adds DeepSeek V4.1 Flash (`DeepSeek V4.1 Flash 552B`, registered in #1109) to `/profit-estimator` and `/profit-estimator-per-gigawatt`, plus the `/zh` mirrors, following the pattern from #1007 (DeepSeek V4 Pro).

- **Routes:** `/profit-estimator/deepseek-v41-flash` and `/profit-estimator-per-gigawatt/deepseek-v41-flash` (`PROFIT_ESTIMATOR_MODELS` in `model-routes.ts`; the slug is the site-wide `deepseek-v41-flash` from the compare registry). Kimi K3 stays the bare-path default. Models outside the allow-list still 404 and stay out of the sitemap. Selector order is now DeepSeek V4 Pro, DeepSeek V4.1 Flash, Kimi K3, MiniMax M3, GLM 5.2.
- **Per-model defaults** (`profitModelDefaults(Model.DeepSeek_V4_1_Flash)`):
  - **125 tok/s/user**, the speed DeepSeek serves Flash at.
  - **DeepSeek list price $0.3 input / $0.006 cached / $1.2 output per M tok**, the peak-hour rate for `deepseek-flash` on the [DeepSeek pricing page](https://api-docs.deepseek.com/quick_start/pricing/) (off-peak is 50% of that: $0.15 / $0.003 / $0.6; peak is 01:00-04:00 and 06:00-10:00 UTC on weekdays). The same page says `deepseek-v4-pro` requests route to V4.1 Flash at the Flash price from Sep 14 until V4.1 Pro ships. OpenRouter and Custom remain one click away; the caption links the DeepSeek pricing page when the list price is in force.
  - **0% model license fee.** The V4.1 Flash weights ship under the MIT license, so there is no lab cut to model (V4 Pro stays on 5%).
- **Data:** the live `/api/v1/availability` has no `dsv41flash` agentic rows yet (the model entered the fleet AgentX-only via InferenceX#2961), so the in-page selector, which intersects the allow-list with models that have agentic data, will not list it in production until those rows land. The slugged routes exist now and will populate without a code change. Any curve whose P90 interactivity range does not straddle 125 will list under Not priced, per the existing clamp-skip behaviour.
- **Model switch** re-seeds interactivity, price source, and license fee in every direction (V4 Pro 24/list/5%, Flash 125/list/0%, Kimi 45/OpenRouter/30%).
- Docs: `docs/tco-calculator.md` profit-estimator section.

## Tests

- Unit (vitest): `profitModelDefaults(Model.DeepSeek_V4_1_Flash)` and its list to revenue-pricing conversion. `modelRoutesForTab` expects `[DeepSeek V4 Pro, DeepSeek V4.1 Flash, Kimi K3, MiniMax M3, GLM 5.2]` in `MODEL_ROUTES` order, the `deepseek-v41-flash` slug, and Kimi K3 as the tab default. `bun run typecheck`, `bun run lint`, `bun run fmt`, `bun run check:typography`, and the full vitest suite pass locally (the one pre-existing `benchmark-transform.test.ts` failure reproduces on `master` and is unrelated, same as noted in #1007).
- E2E (Cypress): fixtures now emit `dsv41flash` agentic rows keyed by `?model=DeepSeek-V4.1-Flash`. The wide fixture curve tops out at 130 tok/s/user so B200/B300/GB300/MI355X price at 125; the H200 curve tops at 38, so the new spec asserts H200 lands under Not priced. New specs cover the `/deepseek-v41-flash` route defaults, caption, and pricing-source link; Custom seeding from the list price; V4 Pro to Flash to Kimi model-switch re-seeding with the expected pathnames; and the `/zh` mirror label (`输入：$0.3`, `DeepSeek 官方定价`). The OpenRouter stub gains a `deepseek/deepseek-v4.1-flash` row and the selector assertion now expects five models. Ran `profit-estimator.cy.ts` locally in Electron: 45/45 pass on the final commit (an earlier run hit an order-dependent flake in `per GW › switches to custom $/GPU/hr when a caption badge is edited` that also reproduces on `master` and passes in isolation).

Screenshots from the fixture-backed local run are posted in the Slack thread.

## 中文说明

在 `/profit-estimator` 与 `/profit-estimator-per-gigawatt`（含 `/zh` 镜像）新增 DeepSeek V4.1 Flash（`DeepSeek V4.1 Flash 552B`，模型本身由 #1109 注册），路径为 `/deepseek-v41-flash`，沿用 #1007（DeepSeek V4 Pro）的模式。Kimi K3 仍为默认模型，其他模型继续返回 404。

- **按模型的默认值**：默认 **125 tok/s/user**（DeepSeek 官方 API 对 Flash 的实际服务速度），并采用 **DeepSeek 官方定价：输入 $0.3 / 缓存输入 $0.006 / 输出 $1.2（每百万 token）**，即[官方定价页](https://api-docs.deepseek.com/quick_start/pricing/)上 `deepseek-flash` 的高峰时段价格（非高峰为 5 折：$0.15 / $0.003 / $0.6）。OpenRouter 与自定义仍可一键切换。模型许可费默认 0%（权重采用 MIT 许可，无需计入实验室分成；V4 Pro 仍为 5%）。
- **数据**：线上 `/api/v1/availability` 目前还没有 `dsv41flash` 的 agentic 数据（模型通过 InferenceX#2961 仅以 AgentX 形式进入 fleet），因此页面内的模型选择器在数据落地前不会显示该模型；带 slug 的路由已就位，数据到达后无需改代码。
- **切换模型**时会重置交互性目标、价格来源与许可费。
- 同步更新 `docs/tco-calculator.md`。

**测试**：新增 vitest 单元测试（默认值、官方定价换算、路由白名单与 slug）；Cypress fixture 新增 `dsv41flash` agentic 数据并按 `?model=` 参数返回，新增路由默认值（H200 在 125 tok/s/user 下列为未计价）、自定义价格初始化、V4 Pro → Flash → Kimi 切换重置与中文镜像的 e2e 用例。本地已通过 typecheck / lint / fmt / typography、完整单元测试，以及 `profit-estimator.cy.ts`（45/45）。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive profit-estimator allowlist and defaults with tests and docs; no auth or shared calculator math changes.
> 
> **Overview**
> Adds **DeepSeek V4.1 Flash** to the profit estimator tabs (`/profit-estimator` and `/profit-estimator-per-gigawatt`, including `/zh`), using the existing per-model route pattern.
> 
> The model is included in `PROFIT_ESTIMATOR_MODELS` with slug **`/deepseek-v41-flash`** and its own `dsv41flash` data bucket (separate from V4 Pro). **`profitModelDefaults`** opens Flash at **125 tok/s/user**, **DeepSeek peak list pricing** ($0.30 / $0.006 cached / $1.20 per M tok), and **0% model license fee** (MIT weights). Switching models still re-seeds interactivity, price source, and license fee; SKUs whose agentic curves do not reach 125 tok/s/user stay **not priced** (no extrapolation).
> 
> Coverage includes unit tests for defaults and routing, Cypress fixtures and specs (selector now five models, H200 excluded at 125, V4 Pro → Flash → Kimi), sitemap test comment, and **`docs/tco-calculator.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a40c9632e25764b8c8d7eb965bef658ba3b07ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->