### PR TITLE
chore(db): purge run 34512984806 — GB300 DSv4.1 Flash vLLM server got 1 CPU core / 清除 run 34512984806：GB300 vLLM server 仅分配 1 个 CPU 核心

### DIFF
--- a/packages/db/src/etl/run-overrides.ts
+++ b/packages/db/src/etl/run-overrides.ts
@@ -93,6 +93,7 @@ export const PURGED_RUNS: ReadonlySet<number> = new Set([
   30405836523, // 2026-07-28 | Reason: No non-DSpark — kimik3-fp4-b300-vllm-agentic AgentX points run without speculative decoding, and Kimi-K3 agentic coding is published DSpark-only (source run of the PR #2397 sweep-reuse ingest)
   32695861783, // 2026-08-24 | Reason: dev image — the dsv4-fp4-b300-sglang-agentic-hicache-mtp AgentX sweep ran on lmsysorg/sglang-staging:dev-cu13-pr-35880, built from the unmerged SGLang draft PR sgl-project/sglang#35880 (source run of the PR #2701 sweep-reuse ingest)
   32863999669, // 2026-08-25 | Reason: incomplete failing run — Run Sweep on main for #2687 ([Power] Require GB multinode telemetry) failed 30 of 125 jobs (GB200/GB300 multi-node dyn-sgl arms), leaving partial data
+  34512984806, // 2026-09-10 | Reason: wrong results — the dsv41flash-fp4-gb300-vllm-agentic-dspark AgentX sweep for PR #2961 launched the vLLM server via srun without --cpus-per-task, and the GB300 Slurm cluster default allocated only 1 CPU core to the entire vLLM server, crippling throughput; infra launch bug on our side, not a vLLM or NVIDIA recipe issue. Fixed by #3017 (--cpus-per-task=144); results to be re-run
 ]);
 
 export const PURGED_RUN_ATTEMPTS: ReadonlyMap<number, ReadonlySet<number>> = new Map([


### PR DESCRIPTION
Adds run [34512984806](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34512984806) to `PURGED_RUNS` so it is skipped on ingest and deleted from the DB.

**Reason: wrong results.** This is the `dsv41flash-fp4-gb300-vllm-agentic-dspark` AgentX sweep for [InferenceX #2961](https://github.com/SemiAnalysisAI/InferenceX/pull/2961) (Add GB300 DeepSeek V4.1 Flash AgentX). The `srun` launch command did not pass `--cpus-per-task`, and the GB300 Slurm cluster default allocated only **1 CPU core to the entire vLLM server**, so the ingested throughput/interactivity points are not representative. Root cause is an infra launch bug on our side, not a vLLM or NVIDIA recipe issue. Fixed by [InferenceX #3017](https://github.com/SemiAnalysisAI/InferenceX/pull/3017) (`--cpus-per-task=144`); the config will be re-run once that lands and the GB300 cluster is out of maintenance.

Ran `oxfmt --check` and `oxlint` on the changed file locally (clean). CI applies the override to production, then verifies, invalidates, and warms the cache.

## 中文说明

将 run [34512984806](https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34512984806) 加入 `PURGED_RUNS`，ingest 时跳过并从数据库中删除。

**原因：结果不正确。** 该 run 是 [InferenceX #2961](https://github.com/SemiAnalysisAI/InferenceX/pull/2961)（新增 GB300 DeepSeek V4.1 Flash AgentX）的 `dsv41flash-fp4-gb300-vllm-agentic-dspark` AgentX sweep。`srun` 启动命令缺少 `--cpus-per-task`，GB300 Slurm 集群默认**只给整个 vLLM server 分配了 1 个 CPU 核心**，因此已入库的吞吐量/交互性数据点不具代表性。根因是我们自身的基础设施启动 bug，与 vLLM 或 NVIDIA 配方无关。[InferenceX #3017](https://github.com/SemiAnalysisAI/InferenceX/pull/3017) 已通过 `--cpus-per-task=144` 修复；待其合并且 GB300 集群维护结束后重新运行该配置。

本地已对改动文件运行 `oxfmt --check` 与 `oxlint`（均通过）。CI 会将此覆盖应用到生产环境，随后进行数据库验证、缓存失效与缓存预热。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single audited purge entry in the ingest override ledger; removes bad benchmark data without changing application logic.
> 
> **Overview**
> Adds GitHub Actions run **34512984806** to `PURGED_RUNS` in `run-overrides.ts` so the ETL pipeline **skips ingest** for that workflow and **removes any already-stored benchmark rows** when overrides are applied (CI on merge).
> 
> The run is the `dsv41flash-fp4-gb300-vllm-agentic-dspark` AgentX sweep tied to PR #2961. Metrics are **not representative**: the vLLM server was started with `srun` without `--cpus-per-task`, so Slurm defaulted to **one CPU core** for the whole server and throughput/interactivity collapsed. That is documented as an infra launch bug (fix in #3017 with `--cpus-per-task=144`); a re-run is expected after that lands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a15e16e2a148065de523fb620d93d76c72865a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->