### PR TITLE
feat(compare): feature DeepSeek V4.1 Flash under Kimi K3 and retire NEW pills on V4 Pro, MiniMax M3, Qwen 3.5 / AgentX 榜单新增 DeepSeek V4.1 Flash 并调整“新”标记

### DIFF
--- a/packages/app/cypress/e2e/compare-precision.cy.ts
+++ b/packages/app/cypress/e2e/compare-precision.cy.ts
@@ -9,7 +9,7 @@ describe('Compare precision index page', () => {
     cy.visit('/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       cy.get('h1').should('have.text', 'Compare Realistic Agentic Inference Perf');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 7);
       cy.get('[data-testid="compare-agentx-model-kimi-k3"]').should(
         'have.attr',
         'href',
@@ -52,7 +52,7 @@ describe('Compare precision index page', () => {
     cy.visit('/zh/compare');
     cy.get('[data-testid="compare-agentx-primary"]').within(() => {
       cy.get('h1').should('have.text', '真实智能体工作负载下的推理性能对比');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 7);
       cy.get('[data-testid="compare-agentx-model-deepseek-v4"]').should(
         'have.attr',
         'href',

--- a/packages/app/cypress/e2e/dropdown-switching.cy.ts
+++ b/packages/app/cypress/e2e/dropdown-switching.cy.ts
@@ -53,16 +53,45 @@ describe('Dropdown one-click switching', () => {
     cy.get('[data-slot="select-content"]').should('not.exist');
   });
 
-  it('marks the featured AgentX models with a NEW pill in the dropdown', () => {
+  it('marks only the still-new AgentX models with a NEW pill in the dropdown', () => {
+    // The availability fixture predates DeepSeek V4.1 Flash, so splice one
+    // agentic row in: the dropdown only lists models with availability rows.
+    cy.fixture('api/availability.json').then((rows: Record<string, unknown>[]) => {
+      cy.intercept('GET', '/api/v1/availability', {
+        body: [
+          ...rows,
+          {
+            model: 'dsv41flash',
+            isl: null,
+            osl: null,
+            precision: 'fp4',
+            hardware: 'gb300',
+            framework: 'vllm',
+            spec_method: 'mtp',
+            disagg: false,
+            date: '2026-09-10',
+          },
+        ],
+      }).as('availability');
+    });
+    cy.visit('/inference');
+    cy.wait('@availability');
+    cy.get('[data-testid="inference-chart-display"]').should('exist');
     cy.get('[data-testid="model-selector"]').click();
 
-    // A featured AgentX model carries the pill… (MiniMax M3 rather than the
-    // Kimi K3 default because the availability fixtures don't ship kimik3 rows)
-    cy.contains('[role="option"]', 'MiniMax M3 428B')
+    // A NEW AgentX model carries the pill…
+    cy.contains('[role="option"]', 'DeepSeek V4.1 Flash 552B')
       .find('[data-new-badge="model-option"]')
       .should('be.visible')
       .and('have.text', 'NEW');
-    // …while non-featured models render without one.
+    // …featured models whose launch pill has retired render without one…
+    cy.contains('[role="option"]', 'MiniMax M3 428B')
+      .find('[data-new-badge="model-option"]')
+      .should('not.exist');
+    cy.contains('[role="option"]', 'DeepSeek V4 Pro 0813 1.6T')
+      .find('[data-new-badge="model-option"]')
+      .should('not.exist');
+    // …as do models that were never featured.
     cy.contains('[role="option"]', 'DeepSeek R1 0528 671B')
       .find('[data-new-badge="model-option"]')
       .should('not.exist');

--- a/packages/app/cypress/e2e/navigation.cy.ts
+++ b/packages/app/cypress/e2e/navigation.cy.ts
@@ -166,7 +166,7 @@ describe('First-load navigation', () => {
         .should('have.text', 'Dashboard')
         .and('have.attr', 'href', '/inference/kimi-k3');
       cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
-      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 6);
+      cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 7);
       // Editorial order, not alphabetical — see FEATURED_AGENTX_MODEL_SLUGS.
       cy.get('[data-testid^="compare-agentx-model-"]').then(($rows) => {
         const slugs = [...$rows].map((row) =>
@@ -174,6 +174,7 @@ describe('First-load navigation', () => {
         );
         expect(slugs).to.deep.equal([
           'kimi-k3',
+          'deepseek-v41-flash',
           'deepseek-v4',
           'glm-5-3',
           'minimax-m3',
@@ -181,10 +182,23 @@ describe('First-load navigation', () => {
           'qwen-3-8-flash-next',
         ]);
       });
-      // Every featured ledger row carries the NEW pill.
+      // Only the still-new rows carry the NEW pill — see AGENTX_NEW_MODEL_SLUGS.
       cy.get('[data-testid^="compare-agentx-model-"] [data-new-badge="agentx-ledger"]')
-        .should('have.length', 6)
+        .should('have.length', 4)
         .each(($badge) => expect($badge.text()).to.equal('NEW'));
+      for (const slug of ['kimi-k3', 'deepseek-v41-flash', 'glm-5-3', 'qwen-3-8-flash-next']) {
+        cy.get(
+          `[data-testid="compare-agentx-model-${slug}"] [data-new-badge="agentx-ledger"]`,
+        ).should('exist');
+      }
+      for (const slug of ['deepseek-v4', 'minimax-m3', 'qwen-3-5']) {
+        cy.get(
+          `[data-testid="compare-agentx-model-${slug}"] [data-new-badge="agentx-ledger"]`,
+        ).should('not.exist');
+      }
+      cy.get('[data-testid="compare-agentx-model-deepseek-v41-flash"]')
+        .should('have.attr', 'href', '/inference/deepseek-v41-flash')
+        .and('contain.text', 'DeepSeek V4.1 Flash 552B');
     });
     cy.get('[data-testid="compare-agentx-revenue-calculator-link"]').click();
     cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');

--- a/packages/app/cypress/e2e/nudge-system.cy.ts
+++ b/packages/app/cypress/e2e/nudge-system.cy.ts
@@ -51,10 +51,11 @@ describe('Landing nudges — modals', { testIsolation: true }, () => {
       .and('contain.text', 'TPUv7 Inference Performance')
       .and('contain.text', 'Compare TPUv7 versus Blackwell & Blackwell Ultra')
       .and('contain.text', 'View results');
-    // Banner + header-nav badges, plus the six AgentX hero ledger rows — the
-    // shared pill must render at the same fixed size everywhere it appears.
+    // Banner + header-nav badges, plus the four still-new AgentX hero ledger
+    // rows (AGENTX_NEW_MODEL_SLUGS) — the shared pill must render at the same
+    // fixed size everywhere it appears.
     cy.get('[data-new-badge]')
-      .should('have.length', 8)
+      .should('have.length', 6)
       .then(($badges) => {
         const sizes = [...$badges].map((badge) => {
           const rect = badge.getBoundingClientRect();

--- a/packages/app/cypress/e2e/zh-pages.cy.ts
+++ b/packages/app/cypress/e2e/zh-pages.cy.ts
@@ -42,8 +42,9 @@ describe('Chinese (/zh) pages', () => {
           .and('have.attr', 'href', '/zh/inference/kimi-k3');
         cy.get('[data-testid="compare-agentx-methodology-link"]').should('not.exist');
         // Ledger NEW pills localize to 新 on the Chinese landing page.
+        cy.get('[data-testid^="compare-agentx-model-"]').should('have.length', 7);
         cy.get('[data-testid^="compare-agentx-model-"] [data-new-badge="agentx-ledger"]')
-          .should('have.length', 6)
+          .should('have.length', 4)
           .each(($badge) => expect($badge.text()).to.equal('新'));
       });
     });

--- a/packages/app/src/components/compare/agentx-compare-hero.tsx
+++ b/packages/app/src/components/compare/agentx-compare-hero.tsx
@@ -3,7 +3,11 @@ import { ArrowRight } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { MinecraftSplash } from '@/components/minecraft/minecraft-splash';
 import { NewBadge } from '@/components/ui/new-badge';
-import { agentxDashboardHref, FEATURED_AGENTX_MODELS } from '@/lib/compare-agentx';
+import {
+  agentxDashboardHref,
+  FEATURED_AGENTX_MODELS,
+  isNewAgentxModel,
+} from '@/lib/compare-agentx';
 
 import { CompareIndexTrackedLink } from './compare-index-tracked-link';
 
@@ -15,6 +19,7 @@ import { CompareIndexTrackedLink } from './compare-index-tracked-link';
  */
 const MODEL_LOGOS: Record<string, string> = {
   'kimi-k3': '/logos/kimi-color.svg',
+  'deepseek-v41-flash': '/logos/deepseek-color.svg',
   'deepseek-v4': '/logos/deepseek-color.svg',
   // GLM ships under the Z.ai product brand, so the ledger shows the Z.ai
   // mark rather than the Zhipu corporate dot cluster.
@@ -555,7 +560,9 @@ export function AgentXCompareHero({
                     <span className="min-w-0">
                       <span className="flex items-center gap-1.5 text-sm font-semibold leading-tight text-foreground group-hover:text-brand">
                         <span className="min-w-0">{model.label}</span>
-                        <NewBadge data-new-badge="agentx-ledger">{t.newModel}</NewBadge>
+                        {isNewAgentxModel(model) && (
+                          <NewBadge data-new-badge="agentx-ledger">{t.newModel}</NewBadge>
+                        )}
                       </span>
                       <span className="mt-1 block font-mono text-3xs tracking-eyebrow text-brand uppercase">
                         AgentX

--- a/packages/app/src/components/favorites/favorite-presets.ts
+++ b/packages/app/src/components/favorites/favorite-presets.ts
@@ -171,7 +171,7 @@ export const FAVORITE_PRESETS: FavoritePreset[] = [
     description:
       'First benchmarks of MiniMax M3 across every available chip. New configurations appear here as they come online.',
     descriptionZh: '涵盖所有可用芯片的 MiniMax M3 首批基准测试结果。新配置上线后将在此同步更新。',
-    tags: ['MiniMax', 'M3', 'New'],
+    tags: ['MiniMax', 'M3'],
     category: 'comparison',
     wide: true,
     hidden: true,
@@ -191,7 +191,7 @@ export const FAVORITE_PRESETS: FavoritePreset[] = [
     title: 'DeepSeek V4 Pro — First Look',
     description:
       'First benchmarks of DeepSeek V4 Pro across every available chip. New configurations appear here as they come online.',
-    tags: ['DeepSeek', 'V4-Pro', 'New'],
+    tags: ['DeepSeek', 'V4-Pro'],
     category: 'comparison',
     wide: true,
     hidden: true,
@@ -210,7 +210,7 @@ export const FAVORITE_PRESETS: FavoritePreset[] = [
     title: 'DeepSeek V4 Pro — NVIDIA First Look',
     description:
       'First benchmarks of DeepSeek V4 Pro on NVIDIA chips. New configurations appear here as they come online.',
-    tags: ['DeepSeek', 'V4-Pro', 'NVIDIA', 'New'],
+    tags: ['DeepSeek', 'V4-Pro', 'NVIDIA'],
     category: 'comparison',
     wide: true,
     hidden: true,

--- a/packages/app/src/lib/compare-agentx.test.ts
+++ b/packages/app/src/lib/compare-agentx.test.ts
@@ -6,6 +6,7 @@ import {
   comparisonPairHref,
   comparisonScenarioForModel,
   FEATURED_AGENTX_MODELS,
+  isNewAgentxModel,
 } from './compare-agentx';
 import { COMPARE_MODEL_SLUGS } from './compare-slug';
 import { Model } from './data-mappings';
@@ -15,6 +16,7 @@ describe('AgentX comparison links', () => {
   it('keeps the live AgentX models in the editorial order', () => {
     expect(FEATURED_AGENTX_MODELS.map((model) => model.slug)).toEqual([
       'kimi-k3',
+      'deepseek-v41-flash',
       'deepseek-v4',
       'glm-5-3',
       'minimax-m3',
@@ -23,22 +25,34 @@ describe('AgentX comparison links', () => {
     ]);
   });
 
-  it('marks exactly the featured models as NEW for the dashboard selector', () => {
+  it('marks only the still-new featured models for the dashboard selector', () => {
+    // DeepSeek V4 Pro, MiniMax M3, and Qwen 3.5 stay in the ledger but their
+    // launch pills have retired; V4.1 Flash picks one up on arrival.
     expect(AGENTX_NEW_MODEL_DISPLAY_NAMES).toEqual(
-      new Set([
-        'Kimi-K3',
-        'DeepSeek-V4-Pro',
-        'GLM-5.2',
-        'MiniMax-M3',
-        'Qwen-3.5-397B-A17B',
-        'Qwen3.8-Flash-Next',
-      ]),
+      new Set(['Kimi-K3', 'DeepSeek-V4.1-Flash', 'GLM-5.2', 'Qwen3.8-Flash-Next']),
     );
+    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES.has('DeepSeek-V4-Pro')).toBe(false);
+    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES.has('MiniMax-M3')).toBe(false);
+    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES.has('Qwen-3.5-397B-A17B')).toBe(false);
+  });
+
+  it('keeps the ledger pill and the selector pill on the same list', () => {
+    const ledgerNew = FEATURED_AGENTX_MODELS.filter(isNewAgentxModel).map(
+      (model) => model.displayName,
+    );
+    expect(new Set(ledgerNew)).toEqual(AGENTX_NEW_MODEL_DISPLAY_NAMES);
+    // Every NEW model is a featured row — the pill never marks a model the
+    // ledger does not show.
+    for (const model of COMPARE_MODEL_SLUGS) {
+      if (AGENTX_NEW_MODEL_DISPLAY_NAMES.has(model.displayName)) {
+        expect(FEATURED_AGENTX_MODELS).toContain(model);
+      }
+    }
   });
 
   it('opens the bare model subroute — Agentic + Optimal Only are already the defaults', () => {
     expect(agentxDashboardHref('en', FEATURED_AGENTX_MODELS[0])).toBe('/inference/kimi-k3');
-    expect(agentxDashboardHref('zh', FEATURED_AGENTX_MODELS[1])).toBe('/zh/inference/deepseek-v4');
+    expect(agentxDashboardHref('zh', FEATURED_AGENTX_MODELS[2])).toBe('/zh/inference/deepseek-v4');
   });
 
   it('routes every featured model to a registered inference page without query params', () => {
@@ -47,11 +61,10 @@ describe('AgentX comparison links', () => {
     }
   });
 
-  it('routes an AgentX-only model to AgentX without promoting it to the hero', () => {
-    // DeepSeek V4.1 Flash has no 8K/1K sweep, so the 8K/1K fallback would SSR
-    // an empty compare page. Scenario and editorial placement are separate
-    // decisions: it gets the right workload, and stays out of the hero ledger
-    // and the NEW badge set.
+  it('routes DeepSeek V4.1 Flash to AgentX from the featured ledger', () => {
+    // V4.1 Flash has no 8K/1K sweep, so the 8K/1K fallback would SSR an empty
+    // compare page. It is now a featured row (second, under Kimi K3), and its
+    // compare cards still point at the agentic workload.
     const flash = COMPARE_MODEL_SLUGS.find((model) => model.slug === 'deepseek-v41-flash')!;
     expect(comparisonScenarioForModel(flash)).toEqual({
       label: 'AgentX',
@@ -63,8 +76,9 @@ describe('AgentX comparison links', () => {
     expect(
       comparisonPairHref('zh', 'deepseek-v41-flash-gb300-vs-b200', flash, 'compare-per-dollar'),
     ).toBe('/zh/compare-per-dollar/deepseek-v41-flash-gb300-vs-b200/agentic');
-    expect(FEATURED_AGENTX_MODELS.map((model) => model.slug)).not.toContain('deepseek-v41-flash');
-    expect(AGENTX_NEW_MODEL_DISPLAY_NAMES.has('DeepSeek-V4.1-Flash')).toBe(false);
+    expect(FEATURED_AGENTX_MODELS[1]).toBe(flash);
+    expect(agentxDashboardHref('en', flash)).toBe('/inference/deepseek-v41-flash');
+    expect(isNewAgentxModel(flash)).toBe(true);
   });
 
   it('agrees with the overview matrix about which models are AgentX-only', () => {

--- a/packages/app/src/lib/compare-agentx.ts
+++ b/packages/app/src/lib/compare-agentx.ts
@@ -2,8 +2,16 @@ import { scenarioSegmentForSequence } from '@/lib/compare-scenario-route';
 import { COMPARE_MODEL_SLUGS, type CompareModelSlug } from '@/lib/compare-slug';
 import { getInferenceModelBySlug, inferenceModelPath } from '@/lib/inference-model-slug';
 
+/**
+ * Editorial ordering of the AgentX hero ledger on `/compare` and the landing
+ * page. Every model here has AgentX data and a registered `/inference/<slug>`
+ * page; the order is a product call, not alphabetical or by launch date.
+ */
 const FEATURED_AGENTX_MODEL_SLUGS = [
   'kimi-k3',
+  // V4.1 Flash sits directly under Kimi K3, ahead of the V4 Pro flagship it
+  // post-dates (InferenceX#2961).
+  'deepseek-v41-flash',
   'deepseek-v4',
   'glm-5-3',
   'minimax-m3',
@@ -13,22 +21,36 @@ const FEATURED_AGENTX_MODEL_SLUGS = [
 ] as const;
 
 /**
+ * Featured models that still carry the NEW pill — in the hero ledger and in
+ * the /inference model selector. Presence in the ledger and the NEW badge are
+ * separate editorial decisions: a model stays featured for as long as its
+ * AgentX results matter, while the pill retires once the launch is old news.
+ * DeepSeek V4 Pro, MiniMax M3, and Qwen 3.5 keep their rows without the pill.
+ */
+const AGENTX_NEW_MODEL_SLUGS = [
+  'kimi-k3',
+  'deepseek-v41-flash',
+  'glm-5-3',
+  'qwen-3-8-flash-next',
+] as const satisfies readonly (typeof FEATURED_AGENTX_MODEL_SLUGS)[number][];
+
+/**
  * AgentX-only models that are NOT part of the editorial featured set above.
  *
  * The featured list is an editorial ordering — it drives the compare hero
- * ledger and the NEW badge in the /inference model selector. Which workload a
- * model actually has data for is a separate, factual question, and the two
- * stopped coinciding with DeepSeek V4.1 Flash: it entered the fleet on AgentX
- * only (InferenceX#2961), so defaulting it to 8K/1K renders an empty compare
- * page, but promoting it into the hero is a product decision this list
- * deliberately does not make.
+ * ledger. Which workload a model actually has data for is a separate, factual
+ * question, and the two can diverge: a model that enters the fleet on AgentX
+ * only would render an empty compare page if it defaulted to 8K/1K, but
+ * promoting it into the hero is a product decision this list deliberately
+ * does not make. The list is empty today (DeepSeek V4.1 Flash was promoted
+ * into the featured set); the mechanism stays for the next day-zero model.
  *
  * Keep this in sync with OVERVIEW_MODEL_SCENARIOS in `overview-data.ts` — that
  * map is the same fact for the overview matrix. `compare-agentx.test.ts` pins
  * the agreement rather than importing the overview module here, which would
  * pull the matrix builder into the client bundle through ChartControls.
  */
-const AGENTX_ONLY_MODEL_SLUGS = ['deepseek-v41-flash'] as const;
+const AGENTX_ONLY_MODEL_SLUGS: readonly string[] = [];
 
 /** Every model whose default compare workload is AgentX: the editorial
  *  featured set plus the AgentX-only models kept out of it. */
@@ -50,14 +72,21 @@ export const FEATURED_AGENTX_MODELS: readonly CompareModelSlug[] = FEATURED_AGEN
   },
 );
 
+const AGENTX_NEW_MODEL_SLUG_SET: ReadonlySet<string> = new Set(AGENTX_NEW_MODEL_SLUGS);
+
+/** Whether a featured ledger row carries the NEW pill. */
+export function isNewAgentxModel(model: CompareModelSlug): boolean {
+  return AGENTX_NEW_MODEL_SLUG_SET.has(model.slug);
+}
+
 /**
- * `Model` enum values (the dashboard's model identifiers) for the featured
- * AgentX set. The landing/compare hero ledger and the /inference model
- * selector both mark these models with a NEW badge, so the badge follows the
- * single featured list instead of maintaining a second one.
+ * `Model` enum values (the dashboard's model identifiers) for the models that
+ * carry the NEW badge. The landing/compare hero ledger and the /inference
+ * model selector both read from this one list, so the pill retires (or
+ * arrives) everywhere in a single edit.
  */
 export const AGENTX_NEW_MODEL_DISPLAY_NAMES: ReadonlySet<string> = new Set(
-  FEATURED_AGENTX_MODELS.map((model) => model.displayName),
+  FEATURED_AGENTX_MODELS.filter(isNewAgentxModel).map((model) => model.displayName),
 );
 
 export function agentxDashboardHref(locale: 'en' | 'zh', model: CompareModelSlug): string {


### PR DESCRIPTION
## Summary

- **DeepSeek V4.1 Flash joins the AgentX hero ledger** (landing page + `/compare`, English and Chinese), placed directly under Kimi K3 and ahead of DeepSeek V4 Pro 0813. It renders with the DeepSeek mark and links to `/inference/deepseek-v41-flash`.
- **NEW pill everywhere for V4.1 Flash**: the hero ledger and the `/inference` model selector now both mark it.
- **NEW pill removed from DeepSeek V4 Pro 0813, MiniMax M3, and Qwen 3.5 397B** in the ledger and the model selector. Their rows stay in the ledger; only the pill retires. The hidden `dsv4-launch*` / `minimax-m3-launch` presets also lose their `New` tag.
- The pill no longer follows ledger membership. `compare-agentx.ts` now has two lists: `FEATURED_AGENTX_MODEL_SLUGS` (order) and `AGENTX_NEW_MODEL_SLUGS` (pill), with `isNewAgentxModel()` and `AGENTX_NEW_MODEL_DISPLAY_NAMES` derived from the second. `AGENTX_ONLY_MODEL_SLUGS` is empty now that V4.1 Flash is featured; the mechanism stays for the next day-zero model.

Ledger after this PR: Kimi K3 (NEW) → DeepSeek V4.1 Flash (NEW) → DeepSeek V4 Pro 0813 → GLM 5.3 (NEW) → MiniMax M3 → Qwen 3.5 → Qwen 3.8 Flash Next (NEW).

## Tests

- `compare-agentx.test.ts`: new order, exact NEW set, ledger/selector agreement, V4.1 Flash routed to AgentX from the featured set.
- Cypress: `navigation`, `zh-pages`, `compare-precision` expect 7 rows / 4 pills with per-row assertions; `dropdown-switching` splices a `dsv41flash` availability row via intercept (the fixture predates the model) and checks the pill on V4.1 Flash and its absence on MiniMax M3 / V4 Pro; `nudge-system` badge count 8 → 6.
- Local: `fmt`, `lint`, `typecheck` clean; `navigation`, `compare-precision`, `dropdown-switching` green against a fixture-mode dev server. Remaining local failures in `zh-pages` (dev-mode `performance.measure` error on the 404 route) and `nudge-system` (toast timing under Turbopack dev) are unrelated to this change; the badge-size test in `nudge-system` passes.

## 中文说明

- **DeepSeek V4.1 Flash 加入 AgentX 首页榜单**（首页与 `/compare`，中英文），位于 Kimi K3 之下、DeepSeek V4 Pro 0813 之上，使用 DeepSeek 图标并链接到 `/inference/deepseek-v41-flash`。
- V4.1 Flash 在榜单和 `/inference` 模型选择器中均显示“新”标记。
- **移除 DeepSeek V4 Pro 0813、MiniMax M3、Qwen 3.5 397B 的“新”标记**（榜单与模型选择器），其榜单行保留；隐藏的 `dsv4-launch*` / `minimax-m3-launch` 预设同步去掉 `New` 标签。
- “新”标记不再与榜单成员绑定：`FEATURED_AGENTX_MODEL_SLUGS` 决定顺序，`AGENTX_NEW_MODEL_SLUGS` 决定标记，两处 UI 读取同一列表。
- 测试：单元测试与 Cypress 用例更新为 7 行榜单 / 4 个标记；`dropdown-switching` 通过 intercept 注入一条 `dsv41flash` 可用性数据来验证选择器中的标记。本地 `fmt`、`lint`、`typecheck` 通过。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Editorial compare/landing configuration and badge logic only; behavior is covered by updated unit and E2E tests with no auth or data-path changes.
> 
> **Overview**
> Adds **DeepSeek V4.1 Flash** to the AgentX hero ledger on the landing page and `/compare` (EN/ZH), **second under Kimi K3**, with logo and links to `/inference/deepseek-v41-flash`.
> 
> **NEW pills are decoupled from ledger membership.** `compare-agentx.ts` now maintains `FEATURED_AGENTX_MODEL_SLUGS` (order) and `AGENTX_NEW_MODEL_SLUGS` (pill), with `isNewAgentxModel()` driving the hero ledger; `AGENTX_NEW_MODEL_DISPLAY_NAMES` (still used by the inference model selector) is derived from the latter. V4.1 Flash gets NEW; **DeepSeek V4 Pro, MiniMax M3, and Qwen 3.5** keep their rows but lose the pill. `AGENTX_ONLY_MODEL_SLUGS` is cleared now that V4.1 Flash is featured.
> 
> Hidden launch presets drop `New` from tags for retired MiniMax M3 / DeepSeek V4 Pro presets. Unit and Cypress tests expect **7 ledger rows / 4 NEW badges**, per-slug pill checks, and availability intercept for the dropdown case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61de22c3da8ce7601fd4b7111ea09ce109392814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->