### PR TITLE
fix: set VR200 three-year rental to $8.50 / 将 VR200 三年租赁价格设为 8.50 美元

### DIFF
--- a/packages/app/src/lib/constants.test.ts
+++ b/packages/app/src/lib/constants.test.ts
@@ -156,7 +156,7 @@ describe('getHardwareConfig', () => {
       tdp: 1800,
       power: 3.3,
       costh: 3.61,
-      costr: 3.61,
+      costr: 8.5,
     });
   });
 

--- a/packages/constants/src/gpu-keys.ts
+++ b/packages/constants/src/gpu-keys.ts
@@ -30,7 +30,7 @@ export const HW_REGISTRY: Record<string, HwEntry> = {
     tdp: 1800,
     power: 3.3,
     costh: 3.61,
-    costr: 3.61,
+    costr: 8.5,
   },
   h100: {
     vendor: 'NVIDIA',


### PR DESCRIPTION
Set the VR200 three-year rental price to $8.50 per GPU-hour and update the existing pricing test expectation.

Validation: 44 pricing/configuration tests; typecheck, lint, formatting, and local smoke tests.

## 中文说明

将 VR200 三年租赁价格设为每 GPU 每小时 8.50 美元，并更新现有价格测试的预期值。

验证：44 项价格和配置测试；类型检查、lint、格式检查及本地冒烟测试。
