### PR TITLE
profit-estimator: DeepSeek V4 Pro opens on a 0% model license fee (MIT weights)

### DIFF
--- a/docs/tco-calculator.md
+++ b/docs/tco-calculator.md
@@ -1141,7 +1141,8 @@ and the two can be collapsed into one once both are on master.
   the speed DeepSeek's own API serves at, DeepSeek's peak-hour list price for
   `deepseek-v4-pro-0813` ($1.32 input / $0.044 cached / $3.96 output per M tok;
   the off-peak rate is half that, and the OpenRouter aggregate sits below both),
-  and a 5% model license fee. At 24 tok/s/user the B200, B300, and MI355X agentic curves are priced; the
+  and a 0% model license fee, since the weights ship under the MIT license. At 24
+  tok/s/user the B200, B300, and MI355X agentic curves are priced; the
   GB200, GB300, and H200 curves bottom out above it (their lowest measured
   points sit at roughly 40, 30, and 27 tok/s/user) and list as not priced until
   a lower-interactivity run lands. DeepSeek V4.1 Flash opens on 125 tok/s/user,

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -7,7 +7,7 @@
 //  - MiniMax M3 opens on 83 tok/s/user, the MiniMax list price, and a 20% license fee
 //    ($0.30 / $0.06 cached / $1.20);
 //  - DeepSeek V4 Pro opens on 24 tok/s/user, the DeepSeek peak list price
-//    ($1.32 / $0.044 cached / $3.96), and a 5% license fee;
+//    ($1.32 / $0.044 cached / $3.96), and a 0% license fee (MIT weights);
 //  - DeepSeek V4.1 Flash opens on 125 tok/s/user, the DeepSeek Flash peak list
 //    price ($0.30 / $0.006 cached / $1.20), and a 0% license fee (MIT weights);
 //  - utilization scales revenue only, so the revenue label moves and the
@@ -894,8 +894,8 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
     chart().should('exist');
     cy.location('pathname').should('eq', '/profit-estimator/deepseek-v4');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
-    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '5%');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '0');
+    cy.get('[data-testid="result-context-license-fee"]').should('have.text', '0%');
     cy.get('[data-testid="profit-caption"] h2').should(
       'contain.text',
       'DeepSeek V4 Pro 0813 1.6T Agentic Revenue & Profit Estimates per Chip per Hour at P90 24 tok/s/user Interactivity',
@@ -951,7 +951,7 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
       .should('contain.text', 'DeepSeek V4 Pro')
       .and('contain.text', '24 tok/s/user');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '0');
     cy.get('[data-testid="profit-selling-prices"]')
       .should('contain.text', 'Input: $1.32')
       .and('contain.text', '(DeepSeek list price)');
@@ -1038,7 +1038,7 @@ describe('Profit Estimator — DeepSeek V4.1 Flash', () => {
     cy.visit('/profit-estimator-per-gigawatt/deepseek-v4', { onBeforeLoad: suppressNudges });
     chart().should('exist');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '24');
-    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '5');
+    cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '0');
 
     // Both DeepSeek models share a vendor label, so the switch must land on the
     // Flash triple, not keep V4 Pro's.

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -610,8 +610,9 @@ function ProfitEstimatorInner({
   // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
   // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
   // list price at 20%; DeepSeek V4 Pro: 24 tok/s/user on the DeepSeek list
-  // price at 5%; DeepSeek V4.1 Flash: 125 tok/s/user on the DeepSeek Flash
-  // list price at 0%, MIT-licensed), so a model switch re-seeds all three. The ref keeps
+  // price at 0%, MIT-licensed; DeepSeek V4.1 Flash: 125 tok/s/user on the
+  // DeepSeek Flash list price at 0%, MIT-licensed), so a model switch re-seeds
+  // all three. The ref keeps
   // this to actual switches: re-renders with the same model leave the
   // reader's edits alone. Ignore disallowed models briefly restored by URL
   // hydration so normalizing a fixed-workload share link preserves its target.

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -381,10 +381,10 @@ describe('profitModelDefaults', () => {
     });
   });
 
-  it('opens DeepSeek V4 Pro on 24 tok/s/user, the DeepSeek peak list price, and a 5% license fee', () => {
+  it('opens DeepSeek V4 Pro on 24 tok/s/user, the DeepSeek peak list price, and a 0% (MIT) license fee', () => {
     const defaults = profitModelDefaults(Model.DeepSeek_V4_Pro);
     expect(defaults.interactivity).toBe(24);
-    expect(defaults.labCutPct).toBe(5);
+    expect(defaults.labCutPct).toBe(0);
     expect(defaults.listPricing).toEqual({
       vendor: 'DeepSeek',
       inputPerMillion: 1.32,

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -75,22 +75,22 @@ export interface ProfitModelDefaults {
  * 20%, instead of the 30% the other models assume. DeepSeek V4 Pro opens on
  * DeepSeek's peak-hour list price ($1.32 / $0.044 cached / $3.96 per M tok;
  * off-peak is half that) because third-party hosts undercut it on OpenRouter,
- * on 24 tok/s/user, the speed DeepSeek's own API serves at, and on a 5% model
- * license fee. The B200, B300, and MI355X agentic curves reach that point; the
+ * on 24 tok/s/user, the speed DeepSeek's own API serves at, and on a 0% model
+ * license fee: the weights ship under the MIT license, so there is no lab cut
+ * to model. The B200, B300, and MI355X agentic curves reach that point; the
  * GB200, GB300, and H200 curves bottom out above it and list as not priced
  * until a lower-interactivity run lands. DeepSeek V4.1 Flash opens on the
  * `deepseek-flash` peak-hour list price ($0.30 / $0.006 cached / $1.20 per M
  * tok; off-peak is half that) from the same pricing page, on 125 tok/s/user,
- * the speed DeepSeek's own API serves the Flash tier at, and on a 0% model
- * license fee: the weights ship under the MIT license, so there is no lab cut
- * to model. It entered the fleet on AgentX only, so the
+ * the speed DeepSeek's own API serves the Flash tier at, and on the same 0%
+ * MIT license fee. It entered the fleet on AgentX only, so the
  * estimator serves it from day zero; SKUs whose curves stop short of 125
  * tok/s/user list as not priced rather than extrapolated.
  */
 const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   [Model.DeepSeek_V4_Pro]: {
     interactivity: 24,
-    labCutPct: 5,
+    labCutPct: 0,
     listPricing: {
       vendor: 'DeepSeek',
       inputPerMillion: 1.32,


### PR DESCRIPTION
## Summary
DeepSeek V4 Pro's default model license fee in the AgentX profit estimator drops from 5% to 0%.

The V4 Pro weights are MIT-licensed ([deepseek-ai/DeepSeek-V4-Pro LICENSE](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/LICENSE)), so the operator owes no lab cut on tokens sold, the same treatment V4.1 Flash already gets (#1120).

## Changes
- `profit-estimator.ts`: `PROFIT_MODEL_DEFAULTS[DeepSeek_V4_Pro].labCutPct` 5 → 0; header comment updated.
- `profit-estimator.test.ts`: V4 Pro defaults test expects 0%.
- `profit-estimator.cy.ts`: three V4 Pro lab-cut assertions (`/profit-estimator/deepseek-v4` open, switch from Kimi K3, switch to Flash) expect `0` / `0%`; header comment updated.
- `ProfitEstimatorDisplay.tsx`: re-seed comment updated.
- `docs/tco-calculator.md`: V4 Pro paragraph updated.

The fee remains an editable caption input; only the opening default changes.

## Verification
- `vitest run profit-estimator.test.ts`: 28/28 pass
- pre-commit: lint, typography, format, typecheck all green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-only change for one model’s profit estimator assumptions; users can still edit the license fee, and no auth or data-path changes.
> 
> **Overview**
> **DeepSeek V4 Pro** in the profit estimator now opens with a **0% model license fee** instead of 5%, matching **V4.1 Flash** because the V4 Pro weights ship under the **MIT license** (no lab royalty modeled by default).
> 
> The change is in `PROFIT_MODEL_DEFAULTS[DeepSeek_V4_Pro].labCutPct` in `profit-estimator.ts`, with aligned comments in `ProfitEstimatorDisplay.tsx`, unit tests, Cypress expectations on `/profit-estimator/deepseek-v4` and model-switch flows, and the V4 Pro paragraph in `docs/tco-calculator.md`. **Interactivity (24 tok/s/user), DeepSeek list pricing, and the editable license-fee control are unchanged**—only the seeded default when you land on or switch to V4 Pro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03667993dc73caff9d14f53169a9d1d59cebd13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->