### PR TITLE
fix(profit): open Kimi K3 on Moonshot's $3 / $0.30 / $15 list price / 修复：Kimi K3 利润估算器默认使用 Moonshot 官方定价

### DIFF
--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -1163,6 +1163,15 @@ describe('Profit Estimator (per chip-hour)', () => {
       .invoke('text')
       .should('match', /^\$\d+\.\d{2}/u)
       .and('not.match', /[BMk]/u);
+    // At Moonshot's list price the rental TCO is a few percent of revenue, so
+    // the thin Compute Expense segment is drawn but drops its name by design;
+    // the license-fee segment is tall enough to keep its label.
+    chart().find('rect.bar-tco').should('have.length', 4);
+    chart().should('contain.text', 'Model License Fee');
+    // The catalog price is a fraction of the list price, so the Compute
+    // Expense segment grows tall enough to carry its name.
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'OpenRouter').click();
     chart().should('contain.text', 'Compute Expense').and('contain.text', 'Model License Fee');
     chart().find('image.bar-vendor-mark').should('have.length', 4);
     cy.get('[data-testid="tab-trigger-profit-estimator"]')

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -1,6 +1,7 @@
 // /profit-estimator: one stacked bar per SKU, US$ per all-in GW per year.
 // Behaviours worth locking down:
-//  - defaults are Kimi K3, 45 tok/s/user, 60% utilization, 30% model license fee;
+//  - defaults are Kimi K3, 45 tok/s/user, the Moonshot list price
+//    ($3.00 / $0.30 cached / $15.00), 60% utilization, 30% model license fee;
 //  - GLM 5.2/5.3 has its own defaults, 100 tok/s/user, the Z.ai list price
 //    ($1.40 / $0.26 cached / $4.40), and a 10% license fee; a model switch
 //    re-seeds all three;
@@ -14,8 +15,8 @@
 //    TCO segment does not;
 //  - the SKU legend is the filter for which bars are drawn;
 //  - a loss is drawn below the zero line as a hatched segment, not as a new colour;
-//  - the OpenRouter catalog is the default price source and a custom triple
-//    (input, cached input, output) can replace it;
+//  - the OpenRouter catalog is one click away from the list price and a
+//    custom triple (input, cached input, output) can replace either;
 //  - the workload is pinned to agentic traces, so there is no scenario or
 //    precision selector, the model selector offers Kimi K3, GLM 5.2/5.3,
 //    MiniMax M3, DeepSeek V4 Pro and DeepSeek V4.1 Flash only, and the target
@@ -45,9 +46,9 @@ import {
 } from '../support/profit-fixtures';
 
 // Kimi K3 is the page default; the DeepSeek row proves the page prices the
-// routed model, not the first catalog entry. The GLM, MiniMax, and DeepSeek
-// rows sit below their labs' list prices, as the real aggregates do, so the
-// spec can tell the two sources apart.
+// routed model, not the first catalog entry. Every row sits below its lab's
+// list price, as the real aggregates do, so the spec can tell the two sources
+// apart.
 const OPENROUTER_MODELS = {
   data: [
     {
@@ -171,11 +172,14 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-caption"]').should('contain.text', 'TCO $/chip/hr');
     cy.get('[data-testid="profit-caption"] h2').should('contain.text', 'Kimi K3');
     cy.get('[data-testid="profit-selling-prices"]')
-      .should('contain.text', 'Input: $0.6')
-      .and('contain.text', 'Cached Input: $0.1')
-      .and('contain.text', 'Output: $2.5')
-      .and('contain.text', '(OpenRouter)')
+      .should('contain.text', 'Input: $3')
+      .and('contain.text', 'Cached Input: $0.3')
+      .and('contain.text', 'Output: $15')
+      .and('contain.text', '(Moonshot list price)')
       .and('not.contain.text', 'moonshotai');
+    cy.get('[data-testid="profit-list-price-source"]')
+      .should('have.attr', 'href', 'https://platform.kimi.ai/docs/pricing/chat-k3')
+      .and('contain.text', 'Moonshot');
     cy.location('pathname').should('eq', '/profit-estimator-per-gigawatt');
     cy.get('[data-testid="profit-precision-selector"]').should('not.exist');
     cy.get('[data-testid="profit-model-selector"]').should('contain.text', 'Kimi K3').click();
@@ -187,9 +191,13 @@ describe('Profit Estimator per GW', () => {
       .and('contain.text', 'DeepSeek V4 Pro')
       .and('contain.text', 'DeepSeek V4.1 Flash');
     cy.get('body').type('{esc}');
-    // Kimi K3 has no list price, so the selector offers the catalog and custom only.
+    // Kimi K3 opens on the Moonshot list price; the catalog and custom stay one click away.
     cy.get('button#profit-price-source').click();
-    cy.get('[role="option"]').should('have.length', 2).and('not.contain.text', 'list price');
+    cy.get('[role="option"]')
+      .should('have.length', 3)
+      .and('contain.text', 'OpenRouter')
+      .and('contain.text', 'Moonshot list price')
+      .and('contain.text', 'Custom $/M tok');
     cy.get('body').type('{esc}');
     cy.get('[data-testid="profit-custom-costs"]').should('not.exist');
     // The badges are the custom-cost entry, so each one carries an input.
@@ -343,7 +351,18 @@ describe('Profit Estimator per GW', () => {
       });
   });
 
-  it('lets a custom price pair replace the OpenRouter catalog', () => {
+  it('lets the OpenRouter catalog or a custom price pair replace the list price', () => {
+    // The catalog reads the Kimi row, which sits below Moonshot's list price.
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'OpenRouter').click();
+    cy.get('[data-testid="profit-selling-prices"]')
+      .should('contain.text', 'Input: $0.6')
+      .and('contain.text', 'Cached Input: $0.1')
+      .and('contain.text', 'Output: $2.5')
+      .and('contain.text', '(OpenRouter)');
+    cy.get('[data-testid="profit-list-price-source"]').should('not.exist');
+
+    // Custom seeds from the price in force, here the catalog.
     cy.get('button#profit-price-source').click();
     cy.contains('[role="option"]', 'Custom $/M tok').click();
     cy.get('[data-testid="profit-custom-prices"]').should('exist');
@@ -355,10 +374,10 @@ describe('Profit Estimator per GW', () => {
     cy.get('[data-testid="profit-selling-prices"]').should('contain.text', '(custom)');
 
     cy.get('button#profit-price-source').click();
-    cy.contains('[role="option"]', 'OpenRouter').click();
+    cy.contains('[role="option"]', 'Moonshot list price').click();
     cy.get('[data-testid="profit-input-price"]').should('not.exist');
     cy.get('[data-testid="profit-cached-price"]').should('not.exist');
-    cy.get('[data-testid="profit-selling-prices"]').should('contain.text', 'Output: $2.5');
+    cy.get('[data-testid="profit-selling-prices"]').should('contain.text', 'Output: $15');
   });
 
   it('lets a custom $/GPU/hr per chip replace the TCO tier', () => {
@@ -419,6 +438,11 @@ describe('Profit Estimator per GW', () => {
     interceptProfitData();
     cy.intercept('GET', 'https://openrouter.ai/api/v1/models', { data: [] }).as('openrouter-empty');
     cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    // The list price does not depend on the catalog, so the page opens priced.
+    chart().should('exist');
+    cy.get('[data-testid="profit-pricing-notice"]').should('not.exist');
+    cy.get('button#profit-price-source').click();
+    cy.contains('[role="option"]', 'OpenRouter').click();
     cy.get('[data-testid="profit-pricing-notice"]').should(
       'contain.text',
       'OpenRouter has no price',
@@ -765,8 +789,8 @@ describe('Profit Estimator — GLM 5.2/5.3', () => {
       .and('contain.text', '45 tok/s/user');
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
     cy.get('[data-testid="profit-selling-prices"]')
-      .should('contain.text', 'Input: $0.6')
-      .and('contain.text', '(OpenRouter)');
+      .should('contain.text', 'Input: $3')
+      .and('contain.text', '(Moonshot list price)');
 
     cy.get('[data-testid="profit-model-selector"]').click();
     cy.contains('[role="option"]', 'GLM5.2/GLM5.3').click();

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -892,8 +892,8 @@ describe('Profit Estimator — MiniMax M3', () => {
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')
-      .should('contain.text', 'Input: $0.6')
-      .and('contain.text', '(OpenRouter)');
+      .should('contain.text', 'Input: $3')
+      .and('contain.text', '(Moonshot list price)');
   });
 
   it('serves the Chinese mirror with the list price named in Chinese', () => {
@@ -988,8 +988,8 @@ describe('Profit Estimator — DeepSeek V4 Pro', () => {
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')
-      .should('contain.text', 'Input: $0.6')
-      .and('contain.text', '(OpenRouter)');
+      .should('contain.text', 'Input: $3')
+      .and('contain.text', '(Moonshot list price)');
   });
 
   it('serves the Chinese mirror with the list price named in Chinese', () => {
@@ -1085,8 +1085,8 @@ describe('Profit Estimator — DeepSeek V4.1 Flash', () => {
     cy.get('[data-testid="profit-target-input"]').should('have.value', '45');
     cy.get('[data-testid="profit-lab-cut-input"]').should('have.value', '30');
     cy.get('[data-testid="profit-selling-prices"]')
-      .should('contain.text', 'Input: $0.6')
-      .and('contain.text', '(OpenRouter)');
+      .should('contain.text', 'Input: $3')
+      .and('contain.text', '(Moonshot list price)');
   });
 
   it('serves the Chinese mirror with the list price named in Chinese', () => {

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -607,7 +607,7 @@ function ProfitEstimatorInner({
     'profit_lab_cut_set',
   );
   // Each model has its own operating point, price source, and license fee
-  // (Kimi K3: 45 tok/s/user on OpenRouter at 30%; GLM 5.2/5.3: 100 tok/s/user
+  // (Kimi K3: 45 tok/s/user on the Moonshot list price at 30%; GLM 5.2/5.3: 100 tok/s/user
   // on the Z.ai list price at 10%; MiniMax M3: 83 tok/s/user on the MiniMax
   // list price at 20%; DeepSeek V4 Pro: 24 tok/s/user on the DeepSeek list
   // price at 0%, MIT-licensed; DeepSeek V4.1 Flash: 125 tok/s/user on the

--- a/packages/app/src/components/calculator/profit-estimator.test.ts
+++ b/packages/app/src/components/calculator/profit-estimator.test.ts
@@ -341,11 +341,22 @@ describe('parseTokenPriceInput', () => {
 });
 
 describe('profitModelDefaults', () => {
-  it('opens Kimi K3 on 45 tok/s/user, the OpenRouter catalog, and a 30% license fee', () => {
-    expect(profitModelDefaults(Model.Kimi_K3)).toEqual({
-      interactivity: DEFAULT_PROFIT_INTERACTIVITY,
-      listPricing: null,
-      labCutPct: DEFAULT_LAB_CUT_PCT,
+  it('opens Kimi K3 on 45 tok/s/user, the Moonshot list price, and a 30% license fee', () => {
+    const defaults = profitModelDefaults(Model.Kimi_K3);
+    expect(defaults.interactivity).toBe(DEFAULT_PROFIT_INTERACTIVITY);
+    expect(defaults.labCutPct).toBe(DEFAULT_LAB_CUT_PCT);
+    expect(defaults.listPricing).toEqual({
+      vendor: 'Moonshot',
+      inputPerMillion: 3,
+      cachedInputPerMillion: 0.3,
+      outputPerMillion: 15,
+      sourceUrl: 'https://platform.kimi.ai/docs/pricing/chat-k3',
+    });
+    expect(listPricingToTokenRevenuePricing(defaults.listPricing!)).toEqual({
+      source: 'normalized',
+      inputPerMillion: 3,
+      cachedInputPerMillion: 0.3,
+      outputPerMillion: 15,
     });
   });
 

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -60,8 +60,10 @@ export interface ProfitModelDefaults {
 }
 
 /**
- * Per-model defaults. Kimi K3 opens on 45 tok/s/user and OpenRouter, where
- * Moonshot's price holds across hosts. GLM 5.2/5.3 opens on Z.ai's list price
+ * Per-model defaults. Kimi K3 opens on 45 tok/s/user and Moonshot's list
+ * price ($3.00 / $0.30 cached / $15.00 per M tok, flat at any context length)
+ * because third-party hosts undercut it on OpenRouter, where the catalog
+ * aggregate sits near $1.80 / $9.00. GLM 5.2/5.3 opens on Z.ai's list price
  * ($1.40 / $0.26 cached / $4.40 per M tok) because third-party hosts undercut
  * it on OpenRouter, and on 100 tok/s/user: Z.ai serves at 48 tok/s/user, but
  * no priced SKU has a measured point that low yet, so the nearest round
@@ -112,8 +114,14 @@ const PROFIT_MODEL_DEFAULTS: Partial<Record<Model, ProfitModelDefaults>> = {
   },
   [Model.Kimi_K3]: {
     interactivity: DEFAULT_PROFIT_INTERACTIVITY,
-    listPricing: null,
     labCutPct: DEFAULT_LAB_CUT_PCT,
+    listPricing: {
+      vendor: 'Moonshot',
+      inputPerMillion: 3,
+      cachedInputPerMillion: 0.3,
+      outputPerMillion: 15,
+      sourceUrl: 'https://platform.kimi.ai/docs/pricing/chat-k3',
+    },
   },
   [Model.GLM_5_2]: {
     interactivity: 100,


### PR DESCRIPTION
## Summary

`/profit-estimator-per-gigawatt/kimi-k3` (and `/profit-estimator/kimi-k3`) opened Kimi K3 on the OpenRouter catalog aggregate, which currently reads **$1.7955 in / $0.2052 cached / $9.006 out** per M tok because third-party hosts undercut Moonshot. Every other model in the estimator already opens on its lab's published rate, so this PR gives Kimi K3 the same treatment.

- Seed a **Moonshot list price of $3.00 / $0.30 cached / $15.00 per M tok**, sourced from [platform.kimi.ai/docs/pricing/chat-k3](https://platform.kimi.ai/docs/pricing/chat-k3) (flat at any context length). The estimator now opens on it; OpenRouter stays one click away in the Token Price selector, and Custom seeds from whichever price is in force.
- Interactivity (45 tok/s/user) and the 30% model license fee are unchanged.
- Update the `profitModelDefaults` unit test, the price-source comments in `profit-estimator.ts` and `ProfitEstimatorDisplay.tsx`, and the `profit-estimator.cy.ts` e2e spec: the default caption reads `(Moonshot list price)` with a source link, the selector offers three sources, and an empty OpenRouter catalog no longer blanks the default page (the notice appears only after switching to OpenRouter).

No user-visible Chinese strings changed; the `/zh` mirror renders `Moonshot 官方定价` through the existing `${vendor} 官方定价` template.

## Test plan

- [x] `bun vitest run src/components/calculator` — 464 tests pass
- [x] `bun run typecheck`, `bun run lint`, `bun run fmt`, `bun run check:typography` (pre-commit)
- [ ] CI e2e: `profit-estimator.cy.ts` on Chrome and Firefox
- [ ] Vercel preview: `/profit-estimator-per-gigawatt/kimi-k3` shows `Input: $3 · Cached Input: $0.3 · Output: $15 (Moonshot list price)`

## 中文说明

`/profit-estimator-per-gigawatt/kimi-k3`（以及 `/profit-estimator/kimi-k3`）此前默认使用 OpenRouter 目录聚合价（约 $1.7955 / $0.2052 缓存 / $9.006，每百万 token），该价格因第三方托管方压价而低于 Moonshot 官方定价。估算器中其他模型均已默认使用各自厂商的官方定价，本 PR 让 Kimi K3 保持一致。

- 新增 Moonshot 官方定价 **$3.00 / $0.30 缓存 / $15.00（每百万 token）**，来源为 [platform.kimi.ai/docs/pricing/chat-k3](https://platform.kimi.ai/docs/pricing/chat-k3)。页面默认使用该价格；OpenRouter 仍可在 Token 售价选择器中一键切换，自定义价格以当前生效价格为初始值。
- 交互速度目标（45 tok/s/user）和 30% 模型授权费保持不变。
- 同步更新单元测试、注释与 e2e 用例：默认标题显示「Moonshot 官方定价」并附来源链接，选择器提供三个来源，OpenRouter 目录为空时默认页面不再显示空白图表。

未新增用户可见中文字符串；`/zh` 页面通过现有的 `${vendor} 官方定价` 模板渲染为「Moonshot 官方定价」。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default revenue assumptions and price-source behavior for Kimi K3 in the profit estimator; financial outputs shift until users switch back to OpenRouter.
> 
> **Overview**
> **Kimi K3** in the profit estimator now opens on **Moonshot’s published list price** ($3.00 / $0.30 cached / $15.00 per M tok) with a link to Moonshot pricing docs, matching GLM, MiniMax, and DeepSeek instead of defaulting to the lower **OpenRouter** aggregate.
> 
> `profitModelDefaults` for `Model.Kimi_K3` gains a `listPricing` block (was `null`). Interactivity (45 tok/s/user) and the 30% license fee are unchanged. The token price selector offers **Moonshot list price**, **OpenRouter**, and **Custom**; custom still seeds from whichever source is active. If OpenRouter has no listing, the page still renders at list price until the user picks OpenRouter.
> 
> Unit tests, inline comments, and Cypress expectations are updated (including chart label behavior when list vs catalog prices change revenue/TCO mix on the per chip-hour view).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37bb91dad134656663208f5b609caca9cf1161a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->