### PR TITLE
feat(power): gate Measured Energy, Modeled System Power, and Power planning comparison behind ↑↑↓↓ / 将实测能耗、系统功耗估算与功耗规划对比置于 ↑↑↓↓ 功能开关之后

### DIFF
--- a/packages/app/cypress/component/inference-chart-controls.cy.tsx
+++ b/packages/app/cypress/component/inference-chart-controls.cy.tsx
@@ -67,9 +67,35 @@ describe('Modeled system-power table', () => {
   });
 });
 
+/**
+ * Measured Energy and Modeled System Power sit behind the ↑↑↓↓ feature gate
+ * while power telemetry is WIP. Unlock it and remount so the gated groups are
+ * listed; the gate hook reads localStorage on mount.
+ */
+function mountWithPowerGroupsUnlocked() {
+  cy.window().then((win) => win.localStorage.setItem('inferencex-feature-gate', '1'));
+  mountWithProviders(<InferenceChartControls showXAxisMode />, { inference: {} });
+}
+
 describe('Inference ChartControls', () => {
   beforeEach(() => {
     mountWithProviders(<InferenceChartControls showXAxisMode />, { inference: {} });
+  });
+
+  afterEach(() => {
+    cy.window().then((win) => win.localStorage.removeItem('inferencex-feature-gate'));
+  });
+
+  it('hides the Measured Energy and Modeled System Power groups while the gate is locked', () => {
+    cy.get('[data-testid="yaxis-metric-selector"]').click('right');
+    cy.get('[data-slot="select-content"]').should('exist');
+    cy.contains('Throughput').should('exist');
+    cy.contains('Measured Energy').should('not.exist');
+    cy.contains('Modeled System Power').should('not.exist');
+    cy.contains('[data-slot="select-item"]', 'Measured Average Power per Chip').should('not.exist');
+    cy.contains('[data-slot="select-item"]', 'Modeled Chassis AC Power per GPU (8k1k)').should(
+      'not.exist',
+    );
   });
 
   it('renders the model selector with the current model', () => {
@@ -109,6 +135,7 @@ describe('Inference ChartControls', () => {
   });
 
   it('lists and selects the schema-v2 derived axes in the Measured Energy group', () => {
+    mountWithPowerGroupsUnlocked();
     const options = [
       {
         key: 'y_measuredJPerSuccessfulQuery',
@@ -139,6 +166,7 @@ describe('Inference ChartControls', () => {
   });
 
   it('offers modeled chassis power separately and explains its measurement boundary', () => {
+    mountWithPowerGroupsUnlocked();
     cy.get('[data-testid="yaxis-metric-selector"]').click('right');
     cy.get('input[aria-label="Search options"]').type('Modeled Chassis');
     cy.contains('Modeled System Power')

--- a/packages/app/cypress/e2e/certified-power-filter.cy.ts
+++ b/packages/app/cypress/e2e/certified-power-filter.cy.ts
@@ -86,6 +86,8 @@ function visitCertifiedPowerChart(extraParams = '') {
   cy.visit(`/inference?g_model=DeepSeek-V4-Pro&i_seq=8k/1k&i_prec=fp4${extraParams}`, {
     onBeforeLoad(win) {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+      // Measured Energy sits behind the ↑↑↓↓ gate while power telemetry is WIP.
+      win.localStorage.setItem('inferencex-feature-gate', '1');
     },
   });
   cy.wait(['@availability', '@benchmarks']);

--- a/packages/app/cypress/e2e/measured-power-overlay.cy.ts
+++ b/packages/app/cypress/e2e/measured-power-overlay.cy.ts
@@ -8,6 +8,8 @@ describe('Measured power on unofficial-run overlay', () => {
     cy.visit('/inference?unofficialrun=26312107787', {
       onBeforeLoad(win) {
         win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
+        // Measured Energy sits behind the ↑↑↓↓ gate while power telemetry is WIP.
+        win.localStorage.setItem('inferencex-feature-gate', '1');
       },
     });
     cy.get('[data-testid="inference-chart-display"]', { timeout: 30_000 }).should('exist');

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -83,6 +83,15 @@ function suppressNudges(win: Cypress.AUTWindow): void {
   win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
 }
 
+/**
+ * The Power planning comparison card sits behind the ↑↑↓↓ feature gate while
+ * measured power is WIP; specs that assert on it unlock the gate up front.
+ */
+function unlockPowerPlanning(win: Cypress.AUTWindow): void {
+  suppressNudges(win);
+  win.localStorage.setItem('inferencex-feature-gate', '1');
+}
+
 const chart = () => cy.get('[data-testid="profit-estimator-chart"]');
 /** The plot SVG itself, not the icon SVGs inside the export button. */
 const chartSvg = () => chart().find('svg').filter(':has(.chart-root)').first();
@@ -1278,7 +1287,7 @@ describe('Fixed 8k/1k power planning', () => {
 
   it('prices the exact fixed point, exports modeled capacity, and switches back to AgentX', () => {
     cy.visit('/profit-estimator-per-gigawatt/qwen-3-5?i_seq=8k%2F1k&c_profit_target=100', {
-      onBeforeLoad: suppressNudges,
+      onBeforeLoad: unlockPowerPlanning,
     });
     cy.get('#profit-scenario')
       .invoke('text')
@@ -1322,7 +1331,7 @@ describe('Fixed 8k/1k power planning', () => {
     it(`preserves the shared fixed target when ${path} needs the Qwen model`, () => {
       const separator = path.includes('?') ? '&' : '?';
       cy.visit(`${path}${separator}i_seq=8k%2F1k&c_profit_target=100`, {
-        onBeforeLoad: suppressNudges,
+        onBeforeLoad: unlockPowerPlanning,
       });
       cy.get('#profit-model').should('contain.text', 'Qwen3.5');
       cy.get('[data-testid="profit-target-input"]').should('have.value', '100');
@@ -1343,7 +1352,7 @@ describe('Fixed 8k/1k power planning', () => {
 
   it('preserves the fixed scenario on the Chinese route', () => {
     cy.visit('/zh/profit-estimator-per-gigawatt/qwen-3-5?i_seq=8k%2F1k&c_profit_target=100', {
-      onBeforeLoad: suppressNudges,
+      onBeforeLoad: unlockPowerPlanning,
     });
     cy.get('#profit-scenario')
       .invoke('text')

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -1879,7 +1879,9 @@ function ProfitEstimatorInner({
           {t.fixedWorkloadNote}
         </p>
       )}
-      {!loading && powerComparisons.length > 0 && (
+      {/* Power planning stays behind the ↑↑↓↓ gate while the measured-power
+          inputs and the chassis model that consumes them are still WIP. */}
+      {!loading && featureGateUnlocked && powerComparisons.length > 0 && (
         <MeasuredProfitComparison
           comparisons={powerComparisons}
           settings={{

--- a/packages/app/src/components/inference/metric-registry.ts
+++ b/packages/app/src/components/inference/metric-registry.ts
@@ -667,15 +667,20 @@ export const METRIC_CONTROL_GROUPS: readonly MetricControlGroup[] = [
     labelZh: '每 token 全电源配置能耗',
     metrics: ['y_jTotal', 'y_jOutput', 'y_jInput'],
   },
+  // Runner power telemetry and the chassis model built on it are still being
+  // validated, so both groups stay behind the ↑↑↓↓ feature gate until the
+  // measurements are stable enough to publish.
   {
     label: 'Measured Energy',
     labelZh: '实测能耗',
     metrics: MEASURED_ENERGY_METRIC_CONFIG_KEYS,
+    gated: true,
   },
   {
     label: 'Modeled System Power',
     labelZh: '系统功耗估算',
     metrics: [MODELED_SYSTEM_POWER_METRIC_CONFIG_KEY],
+    gated: true,
   },
   {
     label: 'Custom User Values',

--- a/packages/app/src/components/inference/ui/ChartControls.tsx
+++ b/packages/app/src/components/inference/ui/ChartControls.tsx
@@ -232,11 +232,20 @@ export default function ChartControls({
   } = useInferenceActions();
 
   // Y-axis options come from the canonical registry and need no API data.
-  // Gated groups appear only after the feature gate unlocks.
+  // Gated groups appear only after the feature gate unlocks. A gated metric
+  // that arrived through a shared URL keeps its own group visible while the
+  // gate is locked so the selector never shows an option it cannot name;
+  // this mirrors how tab-nav keeps a gated route's tab for the current page.
   const featureGateUnlocked = useFeatureGate();
   const visibleGroups = useMemo(
-    () => METRIC_GROUPS.filter((g) => !g.gated || featureGateUnlocked),
-    [featureGateUnlocked],
+    () =>
+      METRIC_GROUPS.filter(
+        (g) =>
+          !g.gated ||
+          featureGateUnlocked ||
+          (g.metrics as readonly string[]).includes(selectedYAxisMetric),
+      ),
+    [featureGateUnlocked, selectedYAxisMetric],
   );
   const metricGroupMap = useMemo(
     () =>


### PR DESCRIPTION
## What

The measured-power work is still WIP, so this hides it from the public surface until the ↑↑↓↓ feature gate is unlocked:

- **Y-axis selector** (`/inference` and every chart that uses `ChartControls`): the **Measured Energy** group (Prefill/Decode/Average/P75/P90 power per chip, Joules per input/output/total token, Joules and Wh per successful query, Average Power as % of TDP) and the **Modeled System Power** group (Modeled Chassis AC Power per GPU, 8k1k) now carry `gated: true` in `METRIC_CONTROL_GROUPS`. `ChartControls` already filtered gated groups; no group had used the flag before.
- **Profit estimator**: the **Power planning comparison** card (`MeasuredProfitComparison`) renders only when `featureGateUnlocked` is true.

## Shared links

A URL that already carries a gated metric (for example `y_measuredAvgPower`) keeps rendering, and the selector keeps that one group visible while locked so the control never shows a value it cannot name. Same behavior tab-nav uses for a gated route that is the current page. Nothing else is exposed while locked.

## Not changed

- The `isMeasuredEnergyConfigKey` / `isModeledSystemPowerConfigKey` decorations (legacy-power rings, tooltip tier line, table columns) are untouched; they only activate once one of these axes is selected.
- Views API, AI chart, and embed paths take the metric key directly and are unaffected.

## Verification

- `bun run fmt`, `bun run lint`, `bun run typecheck`, and the typography check pass (pre-commit hook).
- `metric-registry.test.ts` passes (34 tests).
- Cypress specs that exercise these surfaces (`measured-power-overlay`, `certified-power-filter`, the `Fixed 8k/1k power planning` block in `profit-estimator`, and the `inference-chart-controls` component spec) now unlock the gate via localStorage before visiting or mounting. A new component test asserts both groups stay hidden while locked.

Context: Slack thread in #gta6-research-inference asking @Wenyao Gao to flag the WIP power surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI visibility gating only; deep links for gated metrics still work, and no API or auth paths change.
> 
> **Overview**
> Hides WIP measured-power surfaces behind the **↑↑↓↓** (`inferencex-feature-gate`) until unlocked.
> 
> **Inference charts:** **Measured Energy** and **Modeled System Power** Y-axis groups are marked `gated: true` in the metric registry. `ChartControls` still omits gated groups when locked, but **keeps the group that contains the current `selectedYAxisMetric`** so shared URLs with a power metric stay renderable and the selector can still name the active axis.
> 
> **Profit estimator:** The **Power planning comparison** card (`MeasuredProfitComparison`) only mounts when the feature gate is unlocked.
> 
> **Tests:** Cypress gains a locked-gate assertion for chart controls, unlock helpers / `localStorage` seeding for specs that touch power UI, and cleanup of the gate key after component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d4cbb84122083084cfca57996355b19a6d6010. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->