### PR TITLE
fix: preserve agentic eval samples during ingestion

### DIFF
--- a/packages/db/src/etl/eval-ingest.test.ts
+++ b/packages/db/src/etl/eval-ingest.test.ts
@@ -1,0 +1,87 @@
+import { PGlite } from '@electric-sql/pglite';
+import { readFileSync } from 'node:fs';
+import type postgres from 'postgres';
+import { afterAll, beforeAll, beforeEach, expect, it } from 'vitest';
+import { ingestEvalRow, type EvalPersistenceInput } from './eval-ingest';
+
+type Sql = postgres.Sql;
+let db: PGlite;
+let sql: Sql;
+
+function queryClient(database: Pick<PGlite, 'query'>) {
+  return Object.assign(
+    async (strings: TemplateStringsArray, ...values: unknown[]) => {
+      const query = strings.reduce((text, part, i) => text + (i ? `$${i}` : '') + part, '');
+      const result = await database.query(query, values);
+      return result.rows;
+    },
+    { json: JSON.stringify },
+  );
+}
+
+beforeAll(async () => {
+  db = await PGlite.create();
+  for (const name of ['001_initial_schema.sql', '002_eval_samples.sql']) {
+    await db.exec(readFileSync(new URL(`../../migrations/${name}`, import.meta.url), 'utf8'));
+  }
+  sql = Object.assign(queryClient(db), {
+    begin: (fn: (tx: Sql) => Promise<unknown>) =>
+      db.transaction((tx) => fn(queryClient(tx) as unknown as Sql)),
+  }) as unknown as Sql;
+}, 20_000);
+
+beforeEach(async () => {
+  await db.exec(`TRUNCATE workflow_runs, configs RESTART IDENTITY CASCADE;
+    INSERT INTO workflow_runs (id, github_run_id, run_attempt, name, status, conclusion, created_at, date)
+    VALUES (1, 1, 1, 'Run Sweep', 'completed', 'success', '2026-09-11', '2026-09-11');
+    INSERT INTO configs (id, model, hardware, framework, precision, spec_method, disagg,
+      prefill_tp, decode_tp, num_prefill_gpu, num_decode_gpu)
+    VALUES (1, 'minimaxm3', 'gb200', 'dynamo-trt', 'fp4', 'mtp', false, 4, 4, 4, 4);`);
+});
+
+afterAll(async () => {
+  await db?.close();
+});
+
+const input: EvalPersistenceInput = {
+  task: 'gsm8k',
+  isl: null,
+  osl: null,
+  conc: 5,
+  lmEvalVersion: null,
+  metrics: { em_strict: 0.95 },
+};
+
+it('reuses the aggregate eval identity and preserves samples on nullable-key replay', async () => {
+  const original = await ingestEvalRow(sql, 1, input, 1, '2026-09-11');
+  await db.query('INSERT INTO eval_samples (eval_result_id, doc_id, metrics) VALUES ($1, 0, $2)', [
+    original.id,
+    '{}',
+  ]);
+  const replay = await ingestEvalRow(
+    sql,
+    1,
+    { ...input, metrics: { em_strict: 0.96 } },
+    1,
+    '2026-09-11',
+  );
+  expect(replay).toEqual({ outcome: 'dup', id: original.id });
+  const evalRows = await db.query('SELECT metrics FROM eval_results');
+  expect(evalRows.rows).toEqual([{ metrics: { em_strict: 0.96 } }]);
+  const sampleRows = await db.query('SELECT eval_result_id FROM eval_samples');
+  expect(sampleRows.rows).toEqual([{ eval_result_id: original.id }]);
+  const other = await ingestEvalRow(sql, 1, { ...input, conc: 10 }, 1, '2026-09-11');
+  expect(other.id).not.toBe(original.id);
+});
+
+it('retains fixed-length upserts and rejects invalid negative lengths', async () => {
+  const fixed = { ...input, isl: 1024, osl: 8192 };
+  const original = await ingestEvalRow(sql, 1, fixed, 1, '2026-09-11');
+  expect(await ingestEvalRow(sql, 1, fixed, 1, '2026-09-11')).toEqual({
+    outcome: 'dup',
+    id: original.id,
+  });
+  await expect(ingestEvalRow(sql, 1, { ...input, isl: -1 }, 1, '2026-09-11')).rejects.toThrow(
+    'eval_results_isl_positive',
+  );
+});

--- a/packages/db/src/etl/eval-ingest.ts
+++ b/packages/db/src/etl/eval-ingest.ts
@@ -4,7 +4,7 @@
 
 import type postgres from 'postgres';
 
-type Sql = ReturnType<typeof postgres>;
+type Sql = postgres.Sql;
 
 export interface EvalPersistenceInput {
   task: string;
@@ -19,6 +19,8 @@ export interface EvalPersistenceInput {
  * Insert a single `eval_results` row for an already resolved config id.
  * On conflict `(workflow_run_id, config_id, task, isl, osl, conc)` the metrics
  * are overwritten with the latest values.
+ * Nullable identities reuse the existing row under a per-run transaction lock,
+ * since PostgreSQL's ordinary UNIQUE constraint treats NULL values as distinct.
  *
  * @param sql - Active `postgres` connection.
  * @param configId - Resolved `configs.id` for this result.
@@ -28,8 +30,40 @@ export interface EvalPersistenceInput {
  * @returns Outcome (`'new'` or `'dup'`) and the inserted/updated row's `id`,
  *   so the caller can attach related data (e.g. `eval_samples`) to it.
  */
-export async function ingestEvalRow(
+export function ingestEvalRow(
   sql: Sql,
+  configId: number,
+  p: EvalPersistenceInput,
+  workflowRunId: number,
+  date: string,
+): Promise<{ outcome: 'new' | 'dup'; id: number }> {
+  if (p.isl !== null && p.osl !== null && p.conc !== null) {
+    return insertEvalRow(sql, configId, p, workflowRunId, date);
+  }
+
+  return sql.begin(async (tx) => {
+    // Serialize nullable-key writers for this run without changing historical rows.
+    await tx`select id from workflow_runs where id = ${workflowRunId} for update`;
+    const [existing] = await tx<{ id: number }[]>`
+      update eval_results set metrics = ${tx.json(p.metrics)}
+      where id = (
+        select id from eval_results
+        where workflow_run_id = ${workflowRunId} and config_id = ${configId}
+          and task = ${p.task}
+          and isl is not distinct from ${p.isl}
+          and osl is not distinct from ${p.osl}
+          and conc is not distinct from ${p.conc}
+        order by id limit 1
+      )
+      returning id
+    `;
+    if (existing) return { outcome: 'dup' as const, id: existing.id };
+    return insertEvalRow(tx, configId, p, workflowRunId, date);
+  });
+}
+
+async function insertEvalRow(
+  sql: Sql | postgres.TransactionSql,
   configId: number,
   p: EvalPersistenceInput,
   workflowRunId: number,

--- a/packages/db/src/etl/eval-mapper.test.ts
+++ b/packages/db/src/etl/eval-mapper.test.ts
@@ -172,6 +172,27 @@ describe('mapEvalRow', () => {
     expect(result[0].conc).toBeNull();
   });
 
+  it('maps AgentX zero-length sentinels to the aggregate eval identity', () => {
+    const [individual] = mapEvalRow(
+      makeMeta({ isl: '0', osl: 0 }),
+      makeResults(),
+      createSkipTracker(),
+    );
+    const aggregate = mapAggEvalRow(
+      makeAggRow({ source: 'eval_dsr1_agentic/results.json', conc: 64 }),
+      createSkipTracker(),
+    )!;
+
+    expect([individual.isl, individual.osl]).toEqual([null, null]);
+    expect([individual.task, individual.isl, individual.osl, individual.conc]).toEqual([
+      aggregate.task,
+      aggregate.isl,
+      aggregate.osl,
+      aggregate.conc,
+    ]);
+    expect(configCacheKey(individual.config)).toBe(configCacheKey(aggregate.config));
+  });
+
   it('returns null lmEvalVersion when missing from results', () => {
     const tracker = createSkipTracker();
     const results = makeResults();

--- a/packages/db/src/etl/eval-mapper.ts
+++ b/packages/db/src/etl/eval-mapper.ts
@@ -108,6 +108,9 @@ export function mapEvalRow(
   );
 
   const nSamples = results['n-samples'] as Record<string, any> | undefined;
+  // AgentX uses zero for variable sequence lengths; eval rows represent these as NULL.
+  const isl = parseInt2(meta.isl) ?? null;
+  const osl = parseInt2(meta.osl) ?? null;
 
   return taskEntries.map(([taskName, rawMetrics]) => {
     // Collect numeric metrics; rename lm-eval keys to standardized names.
@@ -128,8 +131,8 @@ export function mapEvalRow(
     return {
       config,
       task: taskName.toLowerCase(),
-      isl: parseInt2(meta.isl) ?? null,
-      osl: parseInt2(meta.osl) ?? null,
+      isl: isl === 0 ? null : isl,
+      osl: osl === 0 ? null : osl,
       conc: parseInt2(meta.conc) ?? null,
       lmEvalVersion,
       metrics,


### PR DESCRIPTION
## Changes
- Normalize AgentX zero ISL/OSL sentinels to NULL in per-config eval metadata.
- Reuse nullable eval identities under a per-run transaction lock so artifact replay attaches samples to existing aggregate rows without creating duplicates.
- Keep fixed-length upserts and positive-length database constraints unchanged.

## Verification
- 64 targeted tests pass, including real PostgreSQL regression coverage for nullable-key replay, sample identity preservation, and invalid-length rejection.
- TypeScript typecheck and scoped lint pass.
- The original MiniMax c5 artifact now maps to NULL sequence lengths with concurrency 5 and 1319 samples.
- Production read-only baseline confirms 12 existing eval rows for source runs 34436606041 and 34511705667, with 15828 expected samples and none currently imported.

After merge, recover the two runs using the existing Recover Reused Ingest workflow and verify the same eval IDs contain all expected samples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eval row deduplication and identity for nullable ISL/OSL keys under transactional locking; incorrect matching could merge or split eval results during CI re-ingest.
> 
> **Overview**
> Fixes agentic eval ingestion so per-config artifacts and aggregate rows share the same **eval identity** when sequence lengths are variable, preventing duplicate `eval_results` rows that would orphan `eval_samples`.
> 
> **Mapping:** `mapEvalRow` now treats AgentX **ISL/OSL `0` sentinels as `NULL`**, aligning individual ZIP metadata with aggregate rows that already use null lengths.
> 
> **Persistence:** `ingestEvalRow` keeps the existing **ON CONFLICT upsert** when `isl`, `osl`, and `conc` are all non-null. For **nullable keys**, it runs inside a transaction that **locks the workflow run**, finds a matching row with `IS NOT DISTINCT FROM`, **updates metrics in place** and returns the same `id` (`dup`), or inserts if none exists—working around PostgreSQL treating NULLs as distinct in unique constraints.
> 
> **Tests:** New PGlite coverage for nullable-key replay (metrics refresh, samples stay attached), fixed-length dedup, and negative ISL rejection; mapper test asserts zero sentinels match aggregate identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de51dee5d2aaf1d096fb4f6869dc70578795b44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->