### PR TITLE
[PowerX] show boundary dots by default / 默认仅显示功耗边界上的数据点

### DIFF
--- a/docs/d3-charts.md
+++ b/docs/d3-charts.md
@@ -75,11 +75,11 @@ The metric registry declares whether higher or lower values are preferable. Char
 
 ## Power curves and optimal filtering
 
-Power axes use the same Pareto directions as other metrics while **Optimal Only** is on. A frontier can legitimately contain one point: the fastest measured configuration can also draw the least power. Turning the switch off connects the concurrency measurements for each serving configuration, date, and run with straight segments. These operating curves do not represent a Pareto frontier and must never connect unrelated configurations or runs.
+Power axes use the same Pareto directions as other metrics while **Optimal Only** is on. A frontier can legitimately contain one point: the fastest measured configuration can also draw the least power. Turning the switch off draws a smooth upper power boundary across tested configurations, grouped by hardware, precision and date (and by run for unofficial overlays). This boundary does not represent an efficiency frontier.
 
-Measured power as a percentage of TDP has no preferred direction, so it always shows all measurements and operating curves; its optimal switch is hidden. Charts preserve the saved optimal preference when switching to another metric. Energy per token retains its existing Pareto behavior.
+Power-boundary views show only the measurements forming that boundary by default. **Show all measurements** reveals the remaining dots without changing the curves, axis domains or zoom. This display preference is independent of **Optimal Only**, defaults off, and is shared through `i_allpoints=1`. Historical rings remain attached to visible historical points; tables and data exports retain their existing selection rules.
 
-Operating curves use linear interpolation, including after zoom, and disable gradient strategy labels and the performance ruler. Repeated conflicting measurements at the same concurrency break a curve rather than choosing a winner or bridging the conflict. The same grouping applies to unofficial-run overlays.
+Measured power as a percentage of TDP has no preferred direction, so it always uses the upper boundary; its optimal switch is hidden. Charts preserve both display preferences when switching metrics. Energy per token retains its existing Pareto behavior. Power boundaries disable gradient strategy labels and the performance ruler.
 
 ## Gradient Roofline Labels
 

--- a/packages/app/cypress/component/gpu-graph.cy.tsx
+++ b/packages/app/cypress/component/gpu-graph.cy.tsx
@@ -493,6 +493,7 @@ describe('GPUGraph', () => {
 describe('GPU comparison power envelopes', () => {
   function PowerComparison({ latency = false }: { latency?: boolean }) {
     const [optimal, setOptimal] = useState(true);
+    const [showAllMeasurements, setShowAllMeasurements] = useState(false);
     const [metric, setMetric] = useState('y_measuredAvgPower');
     const [activeDates, setActiveDates] = useState(new Set(['2026-09-09_h100', '2026-09-10_h100']));
     const rows = ['2026-09-09', '2026-09-10'].flatMap((date) =>
@@ -511,7 +512,7 @@ describe('GPU comparison power envelopes', () => {
             x: latency ? 1000 / interactivity : interactivity,
             y: metric === 'y_measuredJPerOutputToken' ? 4 - index : 350 + index * 200 + tp,
             run_url: `https://github.com/SemiAnalysisAI/InferenceX/actions/runs/${date}`,
-            power_tier: 'certified',
+            power_tier: tp === 4 ? 'legacy' : 'certified',
           });
         }),
       ),
@@ -520,6 +521,8 @@ describe('GPU comparison power envelopes', () => {
       selectedYAxisMetric: metric,
       hideNonOptimal: optimal,
       setHideNonOptimal: setOptimal,
+      showAllMeasurements,
+      setShowAllMeasurements,
       selectedGPUs: ['h100'],
       selectedDates: ['2026-09-09', '2026-09-10'],
       selectedDateRange: { startDate: '', endDate: '' },
@@ -553,32 +556,67 @@ describe('GPU comparison power envelopes', () => {
     );
   }
 
-  it('shows one smooth power envelope per date while preserving all configurations and date visibility', () => {
+  it('reveals off-boundary measurements and historical rings without changing power envelopes or axes', () => {
     mountWithProviders(<PowerComparison />);
     cy.get('#gpu-power-curves .roofline-path').should('not.exist');
+    cy.get('#gpu-show-all-measurements').should('not.exist');
     cy.get('[data-testid="power-curve-description"]').should('contain', 'single point');
     cy.get('#gpu-hide-non-optimal').click({ force: true });
-    cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+    cy.get('#gpu-show-all-measurements').should('have.attr', 'data-state', 'unchecked');
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
+    cy.get('#gpu-power-curves .legacy-power-ring').should('have.length', 2);
+    cy.get('[data-testid="measured-power-summary"]')
+      .should('contain.text', 'Showing 6 of 12 measured points')
+      .and('contain.text', '4/6 validated')
+      .and('contain.text', '2/6 historical');
     cy.get('#gpu-power-curves .roofline-path')
       .should('have.length', 2)
       .each(($path) => {
         expect($path.attr('d')).to.contain('C');
         expect($path.attr('stroke')).not.to.equal('#6b7280');
       });
+    cy.get('#gpu-power-curves svg').then(($svg) => {
+      const paths = Array.from($svg[0].querySelectorAll('.roofline-path'), (p) =>
+        p.getAttribute('d'),
+      );
+      const axes = Array.from(
+        $svg[0].querySelectorAll('.x-axis, .y-axis'),
+        (axis) => axis.innerHTML,
+      );
+      cy.get('#gpu-show-all-measurements').click({ force: true });
+      cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+      cy.get('#gpu-power-curves .legacy-power-ring').should('have.length', 6);
+      cy.get('[data-testid="measured-power-summary"]').should(
+        'contain.text',
+        'Showing 12 of 12 measured points',
+      );
+      cy.get('#gpu-hide-non-optimal').should('have.attr', 'data-state', 'unchecked');
+      cy.get('#gpu-power-curves svg').should(($current) => {
+        expect(
+          Array.from($current[0].querySelectorAll('.roofline-path'), (p) => p.getAttribute('d')),
+        ).to.deep.equal(paths);
+        expect(
+          Array.from($current[0].querySelectorAll('.x-axis, .y-axis'), (axis) => axis.innerHTML),
+        ).to.deep.equal(axes);
+      });
+      cy.get('#gpu-show-all-measurements').click({ force: true });
+      cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
+      cy.get('#gpu-power-curves .legacy-power-ring').should('have.length', 2);
+    });
     cy.get('#gpu-power-curves .line-label').should('have.length', 2);
     cy.get('[data-testid="legend-advanced-toggle"]').click();
     cy.get('#gpu-perf-ruler').should('not.exist');
     cy.contains('button', 'Hide older date').click();
     cy.get('#gpu-power-curves .roofline-path').should('have.length', 1);
-    cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 3);
     cy.get('#gpu-power-curves .line-label').should('have.length', 1);
   });
 
-  it('draws the smooth upper boundary toward lower latency and keeps all measured dots', () => {
+  it('keeps boundary measurements by default toward lower latency', () => {
     mountWithProviders(<PowerComparison latency />);
     cy.get('#gpu-power-curves .roofline-path').should('not.exist');
     cy.get('#gpu-hide-non-optimal').click({ force: true });
-    cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
     cy.get('#gpu-power-curves .roofline-path')
       .should('have.length', 2)
       .each(($path) => expect($path.attr('d')).to.contain('C'));
@@ -587,7 +625,7 @@ describe('GPU comparison power envelopes', () => {
       .and('contain.text', 'not efficiency frontiers');
   });
 
-  it('bypasses %TDP filtering without changing the saved Optimal Only preference for energy', () => {
+  it('localizes the %TDP measurement toggle without changing the saved Optimal Only preference for energy', () => {
     mountWithProviders(
       <PathnameContext.Provider value="/zh/inference">
         <PowerComparison />
@@ -595,10 +633,14 @@ describe('GPU comparison power envelopes', () => {
     );
     cy.contains('button', 'Percent TDP').click();
     cy.get('#gpu-hide-non-optimal').should('not.exist');
+    cy.get('#gpu-power-curves .dot-group').should('have.length', 6);
+    cy.contains('显示全部测量点').should('be.visible');
+    cy.get('#gpu-show-all-measurements').click({ force: true });
     cy.get('#gpu-power-curves .dot-group').should('have.length', 12);
     cy.get('#gpu-power-curves .roofline-path').should('have.length', 2);
     cy.get('[data-testid="power-curve-description"]').should('contain', '不代表能效 Pareto 前沿');
     cy.contains('button', 'Energy').click();
+    cy.get('#gpu-show-all-measurements').should('not.exist');
     cy.get('#gpu-hide-non-optimal').should('have.attr', 'data-state', 'checked');
     cy.get('#gpu-power-curves .roofline-path')
       .should('have.length', 2)

--- a/packages/app/cypress/component/scatter-graph.cy.tsx
+++ b/packages/app/cypress/component/scatter-graph.cy.tsx
@@ -2212,6 +2212,7 @@ describe('Power envelopes', () => {
 
   function PowerHarness() {
     const [optimal, setOptimal] = useState(true);
+    const [showAllMeasurements, setShowAllMeasurements] = useState(false);
     const [metric, setMetric] = useState('y_measuredAvgPower');
     const power = metric !== 'y_measuredJPerOutputToken';
     const rows = [1, 8, 32].map((conc, i) =>
@@ -2224,13 +2225,27 @@ describe('Power envelopes', () => {
         measuredPowerPercentTdp: { y: 40 + i * 20, roof: false },
         measuredJPerOutputToken: { y: 4 - i, roof: false },
         run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/100',
-        power_tier: 'certified',
+        power_tier: i === 1 ? 'legacy' : 'certified',
+      }),
+    );
+    rows.push(
+      createMockInferenceData({
+        hwKey: 'b200_trt',
+        conc: 16,
+        x: 60,
+        y: power ? 500 : 3.5,
+        measuredAvgPower: { y: 500, roof: false },
+        measuredPowerPercentTdp: { y: 50, roof: false },
+        measuredJPerOutputToken: { y: 3.5, roof: false },
+        power_tier: 'legacy',
       }),
     );
     const value = createMockInferenceContextValues({
       selectedYAxisMetric: metric,
       hideNonOptimal: optimal,
       setHideNonOptimal: setOptimal,
+      showAllMeasurements,
+      setShowAllMeasurements,
       selectedPrecisions: [Precision.FP4],
       hardwareConfig: hwConfig,
       activeHwTypes: new Set(['b200_trt']),
@@ -2270,23 +2285,53 @@ describe('Power envelopes', () => {
       .invoke('attr', 'd')
       .should('match', /^M[^C]+C/u);
     cy.get('#power-sweep .dot-group')
+      .filter((_, element) => element.style.opacity !== '0')
       .should('have.length', 3)
       .each(($point) => cy.wrap($point).should('have.css', 'opacity', '1'));
+    cy.get('#scatter-show-all-measurements').should('have.attr', 'data-state', 'unchecked');
+    cy.get('[data-testid="measured-power-summary"]')
+      .should('contain.text', 'Showing 3 of 4 measured points')
+      .and('contain.text', '1/2 historical');
+    cy.get('#power-sweep .dot-group')
+      .filter((_, element) => element.style.opacity !== '0')
+      .find('.legacy-power-ring')
+      .should('have.length', 1);
+    cy.get('#power-sweep .dot-group')
+      .filter((_, element) => element.style.opacity === '0')
+      .should('have.css', 'pointer-events', 'none');
+    cy.get('#power-sweep .roofline-path')
+      .invoke('attr', 'd')
+      .then((boundary) => {
+        cy.get('#scatter-show-all-measurements').click({ force: true });
+        cy.get('#power-sweep .dot-group')
+          .should('have.length', 4)
+          .each(($point) => cy.wrap($point).should('have.css', 'opacity', '1'));
+        cy.get('#power-sweep .roofline-path').should('have.attr', 'd', boundary);
+        cy.get('[data-testid="measured-power-summary"]').should(
+          'contain.text',
+          'Showing 4 of 4 measured points',
+        );
+        cy.get('#power-sweep .legacy-power-ring').should('have.length', 2);
+        cy.get('#scatter-show-all-measurements').click({ force: true });
+        cy.get('#power-sweep .roofline-path').should('have.attr', 'd', boundary);
+      });
     cy.get('#scatter-hide-non-optimal').click({ force: true });
     cy.get('#power-sweep .roofline-path').should('not.exist');
+    cy.get('#scatter-show-all-measurements').should('not.exist');
     cy.contains('button', 'Percent TDP').click();
     cy.get('#scatter-hide-non-optimal').should('not.exist');
     cy.get('#power-sweep .roofline-path[data-curve-kind="power-envelope"]')
       .should('have.length', 1)
       .invoke('attr', 'd')
       .should('match', /^M[^C]+C/u);
-    cy.get('#power-sweep .dot-group').each(($point) =>
-      cy.wrap($point).should('have.css', 'opacity', '1'),
-    );
+    cy.get('#power-sweep .dot-group')
+      .filter((_, element) => element.style.opacity !== '0')
+      .should('have.length', 3);
     cy.contains('button', 'Energy').click();
     cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'checked');
     cy.get('#power-sweep .roofline-path[data-curve-kind="pareto"]').should('have.length', 1);
     cy.get('[data-testid="power-curve-description"]').should('not.exist');
+    cy.get('#scatter-show-all-measurements').should('not.exist');
   });
 
   for (const metric of ['measuredAvgPower', 'measuredP75Power'] as const) {
@@ -2397,9 +2442,12 @@ describe('Power envelopes', () => {
       cy.get(overlaySelector).should('have.length', 2);
       cy.get('#power-overlay .dot-group').should('have.length', 9);
       cy.get('#power-overlay .unofficial-overlay-pt').should('have.length', 12);
-      cy.get('#power-overlay .dot-group, #power-overlay .unofficial-overlay-pt').each(($point) =>
-        cy.wrap($point).should('have.css', 'opacity', '1'),
-      );
+      cy.get('#power-overlay .dot-group')
+        .filter((_, element) => element.style.opacity !== '0')
+        .should('have.length', 6);
+      cy.get('#power-overlay .unofficial-overlay-pt')
+        .filter((_, element) => element.style.opacity !== '0')
+        .should('have.length', 9);
       assertEnvelopes();
       cy.get(officialSelector)
         .invoke('attr', 'd')

--- a/packages/app/cypress/e2e/certified-power-filter.cy.ts
+++ b/packages/app/cypress/e2e/certified-power-filter.cy.ts
@@ -95,6 +95,9 @@ function visitCertifiedPowerChart(extraParams = '') {
   cy.get('[data-testid="chart-figure"]').should('have.length.at.least', 1);
 }
 
+const visiblePowerPoints = () =>
+  cy.get<SVGGElement>('.dot-group').filter((_, element) => element.style.opacity !== '0');
+
 describe('Validated vs historical measured power', () => {
   beforeEach(() => {
     // Firefox can defer resize notifications while the Radix metric menu
@@ -179,5 +182,27 @@ describe('Validated vs historical measured power', () => {
       'true',
     );
     cy.get('[data-testid="quick-filters-selected-count"]').should('contain.text', '1 selected');
+  });
+
+  it('defaults to boundary measurements and restores the independent show-all preference', () => {
+    const powerView = '&i_metric=y_measuredAvgPower&i_optimal=0&i_best=0';
+    visitCertifiedPowerChart(powerView);
+    cy.get('#scatter-show-all-measurements').should('have.attr', 'data-state', 'unchecked');
+    visiblePowerPoints().should('have.length', 2);
+    cy.get('[data-testid="measured-power-summary"]').should(
+      'contain.text',
+      'Showing 2 of 6 measured points',
+    );
+
+    cy.get('#scatter-show-all-measurements').click();
+    visiblePowerPoints().should('have.length', 6);
+    cy.get('#scatter-hide-non-optimal').should('have.attr', 'data-state', 'unchecked');
+
+    visitCertifiedPowerChart(`${powerView}&i_allpoints=1`);
+    cy.get('#scatter-show-all-measurements').should('have.attr', 'data-state', 'checked');
+    visiblePowerPoints().should('have.length', 6);
+    cy.get('#scatter-show-all-measurements').click();
+    visiblePowerPoints().should('have.length', 2);
+    visiblePowerPoints().find('.legacy-power-ring').should('have.length', 1);
   });
 });

--- a/packages/app/cypress/e2e/reliability-chart.cy.ts
+++ b/packages/app/cypress/e2e/reliability-chart.cy.ts
@@ -1,9 +1,15 @@
+function visitReliability(path: string) {
+  // Keep the June snapshot inside its date windows regardless of when CI runs.
+  cy.clock(Date.UTC(2026, 5, 15, 12), ['Date']);
+  cy.visit(path);
+}
+
 describe('Reliability Chart', () => {
   before(() => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/reliability');
+    visitReliability('/reliability');
     cy.get('[data-testid="reliability-chart-display"]').should('exist');
   });
 
@@ -60,7 +66,7 @@ describe('Reliability Chart — Content & Interactions', () => {
     cy.window().then((win) => {
       win.localStorage.setItem('inferencex-star-modal-dismissed', String(Date.now()));
     });
-    cy.visit('/reliability');
+    visitReliability('/reliability');
     cy.get('[data-testid="reliability-chart-display"]').should('be.visible');
   });
 
@@ -77,12 +83,7 @@ describe('Reliability Chart — Content & Interactions', () => {
         cy.get('[data-testid="reliability-date-range"]').click();
         cy.contains('[role="option"]', 'Last 7 days').click();
 
-        // "Last 7 days" may have fewer bars or no bars at all (empty overlay shown).
-        cy.get('#reliability-chart svg').should('exist');
-        cy.document().then((doc) => {
-          const newCount = doc.querySelectorAll('#reliability-chart svg rect.bar').length;
-          expect(newCount !== initialCount || newCount === 0).to.equal(true);
-        });
+        cy.get('#reliability-chart svg rect.bar').should('have.length.lessThan', initialCount);
 
         // Reset back to All time so subsequent tests have data
         cy.get('[data-testid="reliability-date-range"]').click();
@@ -169,7 +170,7 @@ describe('Reliability Chart — Content & Interactions', () => {
 describe('Reliability Chart — Chinese route and settled states', () => {
   it('localizes chart chrome, SVG labels, and accessibility text', () => {
     cy.viewport(1440, 900);
-    cy.visit('/zh/reliability');
+    visitReliability('/zh/reliability');
     cy.get('[data-testid="reliability-chart-display"]').should('be.visible');
     cy.contains('h2', '芯片可靠性').should('be.visible');
     cy.get('#reliability-chart svg').should('contain.text', '成功率（%）');
@@ -185,7 +186,7 @@ describe('Reliability Chart — Chinese route and settled states', () => {
 
   it('shows a Chinese empty state only after an empty response settles', () => {
     cy.intercept('GET', '**/api/v1/reliability', []).as('emptyReliability');
-    cy.visit('/zh/reliability');
+    visitReliability('/zh/reliability');
     cy.wait('@emptyReliability');
     cy.contains('所选时间范围内暂无可靠性数据。').should('be.visible');
     cy.contains('正在加载可靠性数据……').should('not.exist');
@@ -205,7 +206,7 @@ describe('Reliability Chart — Chinese route and settled states', () => {
         );
       }).as('retryReliability');
     });
-    cy.visit('/zh/reliability');
+    visitReliability('/zh/reliability');
     cy.wait('@retryReliability');
     cy.wait('@retryReliability');
     cy.get('[data-testid="reliability-error"]')
@@ -223,7 +224,7 @@ describe('Reliability Chart — Chinese route and settled states', () => {
 
   it('keeps controls reachable without body overflow at 375px', () => {
     cy.viewport(375, 844);
-    cy.visit('/zh/reliability');
+    visitReliability('/zh/reliability');
     cy.get('[data-testid="reliability-date-range"]').should('be.visible').click();
     cy.contains('[role="option"]', '全部时间').should('be.visible');
     cy.document().then((doc) => {

--- a/packages/app/cypress/support/mock-data.ts
+++ b/packages/app/cypress/support/mock-data.ts
@@ -242,6 +242,8 @@ export function createMockInferenceContextValues(
     setIsLegendExpanded: namedStub('setIsLegendExpanded'),
     hideNonOptimal: false,
     setHideNonOptimal: namedStub('setHideNonOptimal'),
+    showAllMeasurements: false,
+    setShowAllMeasurements: namedStub('setShowAllMeasurements'),
     showPointLabels: false,
     setShowPointLabels: namedStub('setShowPointLabels'),
     highContrast: false,

--- a/packages/app/src/components/inference/InferenceContext.tsx
+++ b/packages/app/src/components/inference/InferenceContext.tsx
@@ -545,6 +545,9 @@ export function InferenceProvider({
   });
 
   const [hideNonOptimal, setHideNonOptimal] = useState(() => getUrlParam('i_optimal') !== '0');
+  const [showAllMeasurements, setShowAllMeasurements] = useState(
+    () => getUrlParam('i_allpoints') === '1',
+  );
   // `i_best` records an explicit reader choice ('0' off, '1' on). Absent, the
   // mode follows the model + scenario default, so charts that open with every
   // configuration (MODEL_BEST_PER_SKU_DEFAULT_OFF) need no URL flag and the
@@ -1543,6 +1546,7 @@ export function InferenceProvider({
       i_dstart: selectedDateRange.startDate,
       i_dend: selectedDateRange.endDate,
       i_optimal: hideNonOptimal ? '' : '0',
+      i_allpoints: showAllMeasurements ? '1' : '',
       i_best:
         bestPerSkuChoice === null || bestPerSkuChoice === bestPerSkuDefault
           ? ''
@@ -1579,6 +1583,7 @@ export function InferenceProvider({
       selectedDates,
       selectedDateRange,
       hideNonOptimal,
+      showAllMeasurements,
       bestPerSkuChoice,
       bestPerSkuDefault,
       showPointLabels,
@@ -1810,6 +1815,7 @@ export function InferenceProvider({
       scaleType,
       isLegendExpanded,
       hideNonOptimal,
+      showAllMeasurements,
       showPointLabels,
       highContrast,
       logScale,
@@ -1832,6 +1838,7 @@ export function InferenceProvider({
       scaleType,
       isLegendExpanded,
       hideNonOptimal,
+      showAllMeasurements,
       showPointLabels,
       highContrast,
       logScale,
@@ -1868,6 +1875,7 @@ export function InferenceProvider({
     setQuickFilterPower,
     setIsLegendExpanded,
     setHideNonOptimal,
+    setShowAllMeasurements,
     setShowPointLabels,
     setHighContrast,
     setLogScale,

--- a/packages/app/src/components/inference/types.ts
+++ b/packages/app/src/components/inference/types.ts
@@ -652,6 +652,7 @@ export interface InferenceDisplayContextType {
   scaleType: 'auto' | 'linear' | 'log';
   isLegendExpanded: boolean;
   hideNonOptimal: boolean;
+  showAllMeasurements: boolean;
   showPointLabels: boolean;
   highContrast: boolean;
   logScale: boolean;
@@ -697,6 +698,7 @@ export interface InferenceActionsContextType {
   setQuickFilterPower: (tiers: PowerTier[]) => void;
   setIsLegendExpanded: (expanded: boolean) => void;
   setHideNonOptimal: (hide: boolean) => void;
+  setShowAllMeasurements: (show: boolean) => void;
   setShowPointLabels: (show: boolean) => void;
   setHighContrast: (highContrast: boolean) => void;
   setLogScale: (logScale: boolean) => void;

--- a/packages/app/src/components/inference/ui/GPUGraph.tsx
+++ b/packages/app/src/components/inference/ui/GPUGraph.tsx
@@ -147,6 +147,7 @@ const GPU_STRINGS = {
     logScale: 'Log Scale',
     highContrast: 'High Contrast',
     optimalOnly: 'Optimal Only',
+    showAllMeasurements: 'Show all measurements',
     powerCurves:
       'Smooth lines trace the upper power boundary across tested configurations. Dots are measured; lines are interpolated, not efficiency frontiers.',
     powerOptimal:
@@ -170,6 +171,7 @@ const GPU_STRINGS = {
     logScale: '对数缩放',
     highContrast: '高对比度',
     optimalOnly: '仅最优',
+    showAllMeasurements: '显示全部测量点',
     powerCurves:
       '平滑曲线勾勒各测试配置的功耗上边界。数据点来自实测，曲线通过插值得到，不代表能效 Pareto 前沿。',
     powerOptimal: '功耗的 Pareto 前沿可能只有一个点。关闭“仅最优”即可查看功耗上边界。',
@@ -216,6 +218,7 @@ const GPUGraph = React.memo(
     const {
       selectedYAxisMetric,
       hideNonOptimal: savedHideNonOptimal,
+      showAllMeasurements,
       showPointLabels,
       logScale,
       isLegendExpanded,
@@ -229,6 +232,7 @@ const GPUGraph = React.memo(
       toggleActiveDate,
       removeActiveDate,
       setHideNonOptimal,
+      setShowAllMeasurements,
       setShowPointLabels,
       setLogScale,
       setIsLegendExpanded,
@@ -435,24 +439,32 @@ const GPUGraph = React.memo(
       return result;
     }, [powerEnvelopeMode, groupedData, paretoRooflines, chartDefinition.chartType]);
 
-    const optimalPointKeys = useMemo(() => {
+    const boundaryPointKeys = useMemo(() => {
       const keys = new Set<string>();
-      Object.values(paretoRooflines).forEach((pts) =>
+      Object.values(rooflines).forEach((pts) =>
         pts.forEach((p) => keys.add(`${p.date}_${p.hwKey}_${p.precision}-${p.x}-${p.y}`)),
       );
       return keys;
-    }, [paretoRooflines]);
+    }, [rooflines]);
+
+    const activeData = useMemo(
+      () =>
+        Object.values(groupedData)
+          .flat()
+          .filter((p) => activeDates.has(`${p.date}_${p.hwKey}`)),
+      [groupedData, activeDates],
+    );
 
     const filteredData = useMemo(() => {
-      let pts = Object.values(groupedData)
-        .flat()
-        .filter((p) => activeDates.has(`${p.date}_${p.hwKey}`));
-      if (hideNonOptimal)
-        pts = pts.filter((p) =>
-          optimalPointKeys.has(`${p.date}_${p.hwKey}_${p.precision}-${p.x}-${p.y}`),
+      if (hideNonOptimal || (powerEnvelopeMode && !showAllMeasurements))
+        return activeData.filter((p) =>
+          boundaryPointKeys.has(`${p.date}_${p.hwKey}_${p.precision}-${p.x}-${p.y}`),
         );
-      return pts;
-    }, [groupedData, activeDates, hideNonOptimal, optimalPointKeys]);
+      return activeData;
+    }, [activeData, hideNonOptimal, powerEnvelopeMode, showAllMeasurements, boundaryPointKeys]);
+
+    // Keep domains fixed so revealing off-boundary dots cannot move power curves.
+    const scaleData = powerEnvelopeMode ? activeData : filteredData;
 
     const powerTierCounts = useMemo(
       () => ({
@@ -561,14 +573,14 @@ const GPUGraph = React.memo(
 
     // Compute scale domains
     const xExtent = useMemo(() => {
-      if (filteredData.length === 0) return [0, 100] as [number, number];
-      const ext = d3.extent(filteredData, (d) => d.x) as [number, number];
+      if (scaleData.length === 0) return [0, 100] as [number, number];
+      const ext = d3.extent(scaleData, (d) => d.x) as [number, number];
       return [0, ext[1] * 1.05] as [number, number];
-    }, [filteredData]);
+    }, [scaleData]);
 
     const yDomain = useMemo(() => {
-      if (filteredData.length === 0) return [0, 100] as [number, number];
-      const yExtent = d3.extent(filteredData, (d) => d.y) as [number, number];
+      if (scaleData.length === 0) return [0, 100] as [number, number];
+      const yExtent = d3.extent(scaleData, (d) => d.y) as [number, number];
       const yRange = yExtent[1] - yExtent[0];
       let yMin: number;
       if (logScale) {
@@ -579,7 +591,7 @@ const GPUGraph = React.memo(
         yMin = Math.max(0, yExtent[0] - yRange * 0.05);
       }
       return [yMin, yExtent[1] * 1.05] as [number, number];
-    }, [filteredData, logScale]);
+    }, [scaleData, logScale]);
 
     const dataIdentity = useMemo(
       () =>
@@ -1144,7 +1156,14 @@ const GPUGraph = React.memo(
     // Dismiss on filter changes
     useEffect(() => {
       chartRef.current?.dismissTooltip();
-    }, [selectedPrecisions, selectedYAxisMetric, selectedGPUs, selectedDates, selectedDateRange]);
+    }, [
+      selectedPrecisions,
+      selectedYAxisMetric,
+      selectedGPUs,
+      selectedDates,
+      selectedDateRange,
+      showAllMeasurements,
+    ]);
 
     // Hover dimming animates via the inline `transition: opacity 150ms ease`
     // onRender puts on dots and rooflines — a single style write per node. A
@@ -1521,6 +1540,19 @@ const GPUGraph = React.memo(
                       onCheckedChange: (c: boolean) => {
                         setHideNonOptimal(c);
                         track('interactivity_hide_non_optimal_toggled', { enabled: c });
+                      },
+                    },
+                  ]
+                : []),
+              ...(powerEnvelopeMode
+                ? [
+                    {
+                      id: 'gpu-show-all-measurements',
+                      label: legendT.showAllMeasurements,
+                      checked: showAllMeasurements,
+                      onCheckedChange: (c: boolean) => {
+                        setShowAllMeasurements(c);
+                        track('gpu_timeseries_show_all_measurements_toggled', { enabled: c });
                       },
                     },
                   ]

--- a/packages/app/src/components/inference/ui/ScatterGraph.overlay.test.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.overlay.test.tsx
@@ -17,7 +17,83 @@ import {
   rebuildCount,
 } from './ScatterGraph.test-harness';
 
+const measurements = (offset: number, runUrl?: string): InferenceData[] => [
+  { ...point('h100', 'fp8', 10, 900 + offset, 1), power_tier: 'legacy', run_url: runUrl },
+  { ...point('h100', 'fp8', 20, 200 + offset, 2), power_tier: 'legacy', run_url: runUrl },
+  { ...point('h100', 'fp8', 30, 700 + offset, 4), power_tier: 'certified', run_url: runUrl },
+];
+
 describe('ScatterGraph unofficial overlays', () => {
+  it('toggles off-boundary power markers for official data and each overlay without moving curves', () => {
+    const runUrls = [
+      'https://github.com/o/r/actions/runs/123',
+      'https://github.com/o/r/actions/runs/456',
+    ];
+    inferenceState.current = {
+      ...baseInferenceState(),
+      selectedYAxisMetric: 'y_measuredAvgPower',
+    };
+    overlayState.current = {
+      ...baseOverlayState(),
+      isUnofficialRun: true,
+      activeOverlayHwTypes: new Set(['h100']),
+      allOverlayHwTypes: new Set(['h100']),
+      runIndexByUrl: { [runUrls[0]]: 0, [runUrls[1]]: 1 },
+      unofficialRunInfos: runUrls.map((url, index) => ({
+        id: index === 0 ? '123' : '456',
+        branch: `power-${index}`,
+        url,
+      })),
+    };
+
+    const { container, rerender, unmount } = mountChart({
+      data: measurements(0),
+      overlayData: {
+        data: [...measurements(-100, runUrls[0]), ...measurements(100, runUrls[1])],
+        hardwareConfig: { h100: { ...HARDWARE_CONFIG.h100, suffix: '' } },
+        label: 'power comparison',
+      },
+    });
+    const buildsAfterMount = rebuildCount();
+    const groups = [
+      ...container.querySelectorAll<SVGGElement>('.dot-group, .unofficial-overlay-pt'),
+    ];
+    const curves = [...container.querySelectorAll('.roofline-path, .overlay-roofline-path')];
+    const paths = curves.map((curve) => curve.getAttribute('d'));
+    const axes = [...container.querySelectorAll('.x-axis, .y-axis')];
+    const axisGeometry = axes.map((axis) => axis.innerHTML);
+    const positions = groups.map((group) => group.getAttribute('transform'));
+    expect(groups).toHaveLength(9);
+    expect(curves).toHaveLength(3);
+    expect(paths.every(Boolean)).toBe(true);
+
+    for (const showAllMeasurements of [false, true, false]) {
+      inferenceState.current = { ...inferenceState.current, showAllMeasurements };
+      rerender();
+      for (const group of groups) {
+        const datum = (group as SVGGElement & { __data__: InferenceData }).__data__;
+        const visible = showAllMeasurements || datum.x !== 20;
+        expect(group.style.opacity).toBe(visible ? '1' : '0');
+        expect(group.style.pointerEvents).toBe(visible ? 'auto' : 'none');
+        expect(Boolean(group.querySelector('.legacy-power-ring'))).toBe(
+          datum.power_tier === 'legacy',
+        );
+      }
+      expect(
+        container.querySelector('[data-testid="measured-power-summary"]')?.textContent,
+      ).toContain(
+        showAllMeasurements
+          ? 'Showing 9 of 9 measured points: 3/3 validated · 6/6 historical.'
+          : 'Showing 6 of 9 measured points: 3/3 validated · 3/6 historical.',
+      );
+      expect(curves.map((curve) => curve.getAttribute('d'))).toEqual(paths);
+      expect(axes.map((axis) => axis.innerHTML)).toEqual(axisGeometry);
+      expect(groups.map((group) => group.getAttribute('transform'))).toEqual(positions);
+      expect(rebuildCount()).toBe(buildsAfterMount);
+    }
+    unmount();
+  });
+
   it('includes unofficial measured points in the validated/historical coverage summary', () => {
     const runUrl = 'https://github.com/o/r/actions/runs/123';
     const overlayPoints = [

--- a/packages/app/src/components/inference/ui/ScatterGraph.test-harness.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.test-harness.tsx
@@ -142,6 +142,8 @@ export function baseInferenceState() {
     selectedRunId: '',
     hideNonOptimal: false,
     setHideNonOptimal: noop,
+    showAllMeasurements: false,
+    setShowAllMeasurements: noop,
     hidePointLabels: false,
     setHidePointLabels: noop,
     selectAllHwTypes: noop,

--- a/packages/app/src/components/inference/ui/ScatterGraph.tsx
+++ b/packages/app/src/components/inference/ui/ScatterGraph.tsx
@@ -366,6 +366,7 @@ const SCATTER_STRINGS = {
   en: {
     logScale: 'Log Scale',
     optimalOnly: 'Optimal Only',
+    showAllMeasurements: 'Show all measurements',
     optimalInfo: 'Optimal points form the Pareto frontier for the selected axes.',
     powerCurves:
       'Smooth lines trace the upper power boundary across tested configurations. Dots are measured; lines are interpolated, not efficiency frontiers.',
@@ -398,6 +399,7 @@ const SCATTER_STRINGS = {
   zh: {
     logScale: '对数缩放',
     optimalOnly: '仅最优',
+    showAllMeasurements: '显示全部测量点',
     optimalInfo: '最优点构成当前所选坐标轴的 Pareto 前沿。',
     powerCurves:
       '平滑曲线勾勒各测试配置的功耗上边界。数据点来自实测，曲线通过插值得到，不代表能效 Pareto 前沿。',
@@ -466,6 +468,7 @@ const ScatterGraph = React.memo(
     const {
       selectedYAxisMetric,
       hideNonOptimal: preferOptimalOnly,
+      showAllMeasurements,
       showPointLabels,
       highContrast,
       logScale,
@@ -482,6 +485,7 @@ const ScatterGraph = React.memo(
       removeHwType,
       resolveComparisonSelection,
       setHideNonOptimal,
+      setShowAllMeasurements,
       setShowPointLabels,
       selectAllHwTypes,
       setHighContrast,
@@ -794,6 +798,18 @@ const ScatterGraph = React.memo(
 
     const displayedRooflines = showPowerEnvelope ? groupedData : rooflines;
 
+    const powerEnvelopePointKeys = useMemo(() => {
+      const keys = new Set<string>();
+      if (showPowerEnvelope) {
+        for (const points of Object.values(groupedData)) {
+          for (const segment of groupDisplayedPoints(points).values()) {
+            for (const point of segment) keys.add(optimalPointKey(point));
+          }
+        }
+      }
+      return keys;
+    }, [showPowerEnvelope, groupedData, groupDisplayedPoints]);
+
     const optimalPointKeys = useMemo(() => {
       const keys = new Set<string>();
       Object.values(rooflines).forEach((pts) => pts.forEach((p) => keys.add(optimalPointKey(p))));
@@ -1093,15 +1109,26 @@ const ScatterGraph = React.memo(
       return set;
     }, [overlayRooflines]);
 
+    const overlayEnvelopePoints = useMemo(
+      () => new Set(Object.values(displayedOverlayRooflines).flatMap((group) => group.points)),
+      [displayedOverlayRooflines],
+    );
+
     // Overlay points respect the Optimal Only toggle exactly like official
     // points do — "optimal" = on the overlay run's drawn roofline. Without
     // this, an e2e-dominated overlay config (hidden on the official side) kept
     // its X marker sitting on the dashed roofline and read as a pareto point.
-    // Hardware/precision/quick filters are applied upstream in
-    // `processedOverlayData`, so optimality is the only condition here.
     const isOverlayPointVisible = useCallback(
-      (d: InferenceData) => !hideNonOptimal || overlayOptimalPoints.has(d),
-      [hideNonOptimal, overlayOptimalPoints],
+      (d: InferenceData) =>
+        (!hideNonOptimal || overlayOptimalPoints.has(d)) &&
+        (!showPowerEnvelope || showAllMeasurements || overlayEnvelopePoints.has(d)),
+      [
+        hideNonOptimal,
+        overlayOptimalPoints,
+        showPowerEnvelope,
+        showAllMeasurements,
+        overlayEnvelopePoints,
+      ],
     );
 
     // All official points for rendering (unfiltered — visibility via opacity)
@@ -1160,8 +1187,7 @@ const ScatterGraph = React.memo(
       if (pointsTableTarget.kind === 'official') {
         const { hwKey } = pointsTableTarget;
         const hwConfig = hardwareConfig[hwKey];
-        // Same visibility filters the chart applies (precision, Optimal Only),
-        // scoped to the clicked series.
+        // Keep hidden measurements accessible in the per-series table.
         const pts = pointsData.filter(
           (p) =>
             p.hwKey === hwKey &&
@@ -1177,13 +1203,11 @@ const ScatterGraph = React.memo(
         };
       }
       const { runIndex, runId, branch } = pointsTableTarget;
-      // Overlay series: this run's points, respecting the overlay hw toggles
-      // and Optimal Only (same visibility filters as the official branch above).
       const pts = processedOverlayData.filter(
         (p) =>
           overlayRunIndex(p.run_url ?? null, runIndexByUrl) === runIndex &&
           activeOverlayHwTypes.has(p.hwKey as string) &&
-          isOverlayPointVisible(p),
+          (!hideNonOptimal || overlayOptimalPoints.has(p)),
       );
       return {
         hw: `overlay-run-${runId}`,
@@ -1199,7 +1223,7 @@ const ScatterGraph = React.memo(
       selectedPrecisions,
       hideNonOptimal,
       optimalPointKeys,
-      isOverlayPointVisible,
+      overlayOptimalPoints,
       resolveColor,
       processedOverlayData,
       runIndexByUrl,
@@ -1246,14 +1270,17 @@ const ScatterGraph = React.memo(
       }
       // Overlay points hidden by Optimal Only are excluded from the domain too
       // so hidden outliers don't stretch the axes.
-      const overlayPts = processedOverlayData.filter(isOverlayPointVisible);
+      // Marker visibility must not rescale or move the power boundary.
+      const overlayPts = processedOverlayData.filter(
+        (point) => !hideNonOptimal || overlayOptimalPoints.has(point),
+      );
       return overlayPts.length > 0 ? [...pts, ...overlayPts] : pts;
     }, [
       filteredData,
       processedOverlayData,
       hideNonOptimal,
       optimalPointKeys,
-      isOverlayPointVisible,
+      overlayOptimalPoints,
     ]);
 
     const isInputTputMetric = selectedYAxisMetric === 'y_inputTputPerGpu';
@@ -1391,8 +1418,19 @@ const ScatterGraph = React.memo(
       (d: InferenceData) =>
         effectiveActiveHwTypes.has(d.hwKey as string) &&
         selectedPrecisions.includes(d.precision) &&
-        (!hideNonOptimal || optimalPointKeys.has(optimalPointKey(d))),
-      [effectiveActiveHwTypes, selectedPrecisions, hideNonOptimal, optimalPointKeys],
+        (!hideNonOptimal || optimalPointKeys.has(optimalPointKey(d))) &&
+        (!showPowerEnvelope ||
+          showAllMeasurements ||
+          powerEnvelopePointKeys.has(optimalPointKey(d))),
+      [
+        effectiveActiveHwTypes,
+        selectedPrecisions,
+        hideNonOptimal,
+        optimalPointKeys,
+        showPowerEnvelope,
+        showAllMeasurements,
+        powerEnvelopePointKeys,
+      ],
     );
 
     const powerTierCounts = useMemo(() => {
@@ -3416,7 +3454,14 @@ const ScatterGraph = React.memo(
     // Dismiss tooltip on filter changes
     useEffect(() => {
       chartRef.current?.dismissTooltip();
-    }, [selectedPrecisions, selectedYAxisMetric, hideNonOptimal, overlayData, chartId]);
+    }, [
+      selectedPrecisions,
+      selectedYAxisMetric,
+      hideNonOptimal,
+      showAllMeasurements,
+      overlayData,
+      chartId,
+    ]);
 
     // Dismiss when pinned point's hardware becomes hidden
     useEffect(() => {
@@ -3683,6 +3728,19 @@ const ScatterGraph = React.memo(
                               infoTooltip: legendT.optimalInfo,
                             }
                           : {}),
+                      },
+                    ]
+                  : []),
+                ...(showPowerEnvelope
+                  ? [
+                      {
+                        id: 'scatter-show-all-measurements',
+                        label: legendT.showAllMeasurements,
+                        checked: showAllMeasurements,
+                        onCheckedChange: (checked: boolean) => {
+                          setShowAllMeasurements(checked);
+                          track('latency_show_all_measurements_toggled', { enabled: checked });
+                        },
                       },
                     ]
                   : []),

--- a/packages/app/src/lib/url-state.test.ts
+++ b/packages/app/src/lib/url-state.test.ts
@@ -445,6 +445,33 @@ describe('writeUrlParams + buildShareUrl', () => {
 
     expect(readUrlParams().g_model).toBeUndefined();
   });
+
+  it('preserves all-measurement visibility across metric changes and shared links', async () => {
+    const { location } = setupWindow('?i_optimal=0', '/inference');
+    const { readUrlParams, writeUrlParams, buildShareUrl, refreshUrlParams } =
+      await import('@/lib/url-state');
+
+    expect(readUrlParams().i_allpoints).toBeUndefined();
+    expect(buildShareUrl()).not.toContain('i_allpoints');
+
+    writeUrlParams({ i_allpoints: '1', i_metric: 'y_measuredAvgPower' });
+    const powerUrl = new URL(buildShareUrl());
+    expect(powerUrl.searchParams.get('i_allpoints')).toBe('1');
+    expect(powerUrl.searchParams.get('i_optimal')).toBe('0');
+
+    writeUrlParams({ i_metric: 'y_tpPerGpu' });
+    location.search = new URL(buildShareUrl()).search;
+    expect(refreshUrlParams()).toMatchObject({
+      i_allpoints: '1',
+      i_metric: 'y_tpPerGpu',
+      i_optimal: '0',
+    });
+
+    writeUrlParams({ i_allpoints: '' });
+    expect(buildShareUrl()).not.toContain('i_allpoints');
+    expect(readUrlParams().i_allpoints).toBeUndefined();
+    expect(readUrlParams().i_optimal).toBe('0');
+  });
 });
 
 describe('SSR safety', () => {

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -38,6 +38,7 @@ const URL_STATE_KEYS = [
   'i_dstart',
   'i_dend',
   'i_optimal',
+  'i_allpoints',
   'i_best',
   'i_label',
   // Legacy alias of `i_label` with inverted semantics — read-only on load so
@@ -148,6 +149,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   i_dstart: '',
   i_dend: '',
   i_optimal: '',
+  i_allpoints: '',
   i_best: '',
   i_label: '',
   i_nolabel: '',


### PR DESCRIPTION
Power-boundary charts currently show every measured dot, including those away from the line. This defaults them to boundary dots and adds **Show all measurements** to reveal the rest without changing the curve, axes, or Optimal Only setting.

The preference works in the main chart, GPU history, and unofficial overlays, and is preserved in shared links. Visible historical points retain their dotted rings; tables and data exports keep their existing selection rules. Includes English and Chinese controls.

The reliability E2E spec pins its clock to the saved fixture period, preventing a UTC date rollover from aging all rows out of the default 90-day window. Its date-filter assertion waits for the updated bars.

## Testing

- `bun run test:unit`
- `bun run test:e2e` — 51 component and 114 integration tests passed.
- Focused GPU-history component tests (13) and measured-power/shared-link integration tests (3) passed.
- Lint, formatting, typecheck, and typography checks.
- Browser inspection of desktop English and mobile Chinese controls using local fixture data.

## 中文说明

功耗上边界图目前会显示全部测量点，包含不在曲线上的散点。本次改为默认仅显示边界上的数据点，并增加“显示全部测量点”开关；打开后显示其余点，曲线、坐标轴和“仅最优”设置保持不变。

该设置支持主图、GPU 历史对比和非官方结果叠加，并随分享链接保存。可见历史测量点保留虚线圆环，表格和数据导出沿用现有筛选规则。

可靠性 E2E 测试将时钟固定在测试数据对应的日期，避免 UTC 日期切换后全部数据超出默认 90 天窗口；时间筛选断言会等待柱状图更新。

验证：单元测试、本地 smoke 测试、GPU 历史对比及测量点开关专项测试，以及 lint、格式、类型和排版检查；使用本地测试数据检查了英文桌面端和中文移动端界面。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default chart visibility, URL state, and axis domain logic for measured-power metrics across scatter, GPU history, and overlays; broad test coverage but user-visible behavior shifts on shared links.
> 
> **Overview**
> Power-boundary charts (**measured power** and **% TDP**) now **default to boundary measurements only** instead of every dot. A new **Show all measurements** control (EN/ZH) reveals off-boundary points via opacity without moving the smooth upper power envelope, rescaling axes, or changing **Optimal Only**.
> 
> The preference is wired through inference context and shareable URL param **`i_allpoints=1`**, and applies on the main scatter chart, GPU comparison history, and unofficial overlays (hidden markers get `pointer-events: none`). Measured-power summaries reflect visible vs total counts; legacy rings stay on visible historical points. Docs in `d3-charts.md` are updated to match boundary vs Pareto behavior.
> 
> Reliability Cypress specs are stabilized with a fixed **June 2026** clock and a stricter bar-count assertion when switching to “Last 7 days.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a42990a9ab6400c430d3c37b3e6bcadce9bf48f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->