### PR TITLE
[PowerX] gate measured power profit estimates / 为实测功耗利润估算增加功能开关

### DIFF
--- a/docs/powerx-system-power.md
+++ b/docs/powerx-system-power.md
@@ -81,6 +81,41 @@ schema and reports `validated-unversioned-single-node`; it does not upgrade the
 source or admit unversioned disaggregated power. The article receipt additionally
 pins the producer checkout and retains each original audit artifact.
 
+## Profit Estimator power basis
+
+The per-GW Profit Estimator offers provisioned power, measured + modeled power,
+and a paired comparison in Benchmark Config. Provisioned remains the default.
+The alternative reuses the same hardware, P90 target, throughput frontier,
+token mix, prices, utilization, and per-GPU-hour costs. It changes only the
+facility kW/GPU used to calculate capacity per GW. Consequently, revenue,
+compute expense, license fee, and profit scale together; profit margin does not
+change. Electricity expense is not recomputed separately.
+
+This opt-in AgentX estimate requires validated schema-v2 telemetry and a complete
+single-node eight-GPU chassis supported by the pinned model. Partial allocations,
+unsupported GB200/GB300 chassis, and missing/invalid measurements stay unavailable.
+The ordinary 8K/1K transformation keeps its existing admission policy.
+
+At an exact frontier point, use that point's modeled power. Between points,
+estimate power linearly using the same two knots as the existing throughput
+interpolation; never select a different point to fill a power gap. The estimate
+uses PUE 1.3 and an additional 10% planning margin. These assumptions, including
+the fixed CPU/DRAM utilization above, are not validated peak-load provisioning or
+AgentX system calibration. The UI and CSV label the estimate and its assumptions.
+`c_power=modeled` and `c_power=compare` preserve the selection in share URLs.
+
+每 GW 利润估算器在基准测试配置中提供预配功耗、实测加建模功耗，以及两种方式的同口径
+对比；默认仍采用预配功耗。两种方式使用同一硬件、P90 目标、吞吐量前沿、token 比例、
+价格、利用率和每 GPU 小时成本，仅改变换算每 GW 容量时采用的设施功率。因此收入、
+计算成本、模型许可费和利润按相同比例变化，利润率不变；不会另行重新计算电费。
+
+AgentX 估算仅接纳通过验证的 schema-v2 功耗，且要求完整的单节点八卡机箱及适用模型。
+部分卡分配、GB200/GB300 等无匹配模型的机箱，以及缺失或无效功耗保持不可用。原有
+8K/1K 转换路径的接纳规则不变。精确前沿点使用自身的功耗；点间采用原吞吐量插值的
+同一对数据点线性估算功耗，不换用其他点填补缺失。PUE 取 1.3，另加 10% 功耗余量；
+这些假设和上述固定 CPU/DRAM 利用率尚未通过 AgentX 系统校准，也不构成峰值供电容量
+验证。界面与 CSV 会注明估算及其假设，分享链接通过 `c_power` 保留所选方式。
+
 ## Offline comparison export
 
 The exporter reads a local cohort envelope and writes a **new** output directory:

--- a/docs/powerx-system-power.md
+++ b/docs/powerx-system-power.md
@@ -85,6 +85,10 @@ pins the producer checkout and retains each original audit artifact.
 
 The per-GW Profit Estimator offers provisioned power, measured + modeled power,
 and a paired comparison in Benchmark Config. Provisioned remains the default.
+The control uses the existing insider feature gate and is hidden while locked.
+Unlock with ↑↑↓↓ (`inferencex-feature-gate=1` in local storage). While locked,
+`c_power` cannot activate an alternative calculation or fetch full power rows;
+relocking restores provisioned estimates immediately.
 The alternative reuses the same hardware, P90 target, throughput frontier,
 token mix, prices, utilization, and per-GPU-hour costs. It changes only the
 facility kW/GPU used to calculate capacity per GW. Consequently, revenue,
@@ -103,11 +107,17 @@ uses PUE 1.3 and an additional 10% planning margin. These assumptions, including
 the fixed CPU/DRAM utilization above, are not validated peak-load provisioning or
 AgentX system calibration. The UI and CSV label the estimate and its assumptions.
 `c_power=modeled` and `c_power=compare` preserve the selection in share URLs.
+Unavailable historical estimates use the hardware registry when a chip is absent
+from today's results and include the source date/run label.
 
 每 GW 利润估算器在基准测试配置中提供预配功耗、实测加建模功耗，以及两种方式的同口径
 对比；默认仍采用预配功耗。两种方式使用同一硬件、P90 目标、吞吐量前沿、token 比例、
 价格、利用率和每 GPU 小时成本，仅改变换算每 GW 容量时采用的设施功率。因此收入、
 计算成本、模型许可费和利润按相同比例变化，利润率不变；不会另行重新计算电费。
+
+该选项由现有内部功能开关控制，锁定时隐藏。按 ↑↑↓↓ 解锁（本地存储
+`inferencex-feature-gate=1`）。锁定时，`c_power` 不会启用其他估算方式或触发完整功耗
+数据请求；重新锁定后立即恢复预配功耗估算。
 
 AgentX 估算仅接纳通过验证的 schema-v2 功耗，且要求完整的单节点八卡机箱及适用模型。
 部分卡分配、GB200/GB300 等无匹配模型的机箱，以及缺失或无效功耗保持不可用。原有
@@ -115,6 +125,8 @@ AgentX 估算仅接纳通过验证的 schema-v2 功耗，且要求完整的单�
 同一对数据点线性估算功耗，不换用其他点填补缺失。PUE 取 1.3，另加 10% 功耗余量；
 这些假设和上述固定 CPU/DRAM 利用率尚未通过 AgentX 系统校准，也不构成峰值供电容量
 验证。界面与 CSV 会注明估算及其假设，分享链接通过 `c_power` 保留所选方式。
+历史估算不可用时，若当天结果不含该芯片，则从硬件注册表获取名称；提示会附上来源
+日期或运行标签，避免与当前结果混淆。
 
 ## Offline comparison export
 

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -36,6 +36,7 @@
 
 import {
   interceptProfitData,
+  profitBenchmarkRows,
   PROFIT_CHANGELOG_NOTES,
   PROFIT_DATE,
   PROFIT_HISTORY_DATE,
@@ -86,6 +87,65 @@ const chart = () => cy.get('[data-testid="profit-estimator-chart"]');
 /** The plot SVG itself, not the icon SVGs inside the export button. */
 const chartSvg = () => chart().find('svg').filter(':has(.chart-root)').first();
 const bars = () => chart().find('rect.bar');
+
+describe('Profit estimator power option', () => {
+  it('loads full telemetry and compares matching hardware when opened from a share URL', () => {
+    stubOpenRouter();
+    cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
+      const rows = profitBenchmarkRows();
+      if (req.query['view'] === 'calculator') {
+        req.reply({ body: rows });
+      } else {
+        req.alias = 'power-rows';
+        req.reply({
+          body: rows.map((row) => ({
+            ...row,
+            metrics: {
+              ...row.metrics,
+              power_valid: 1,
+              power_metric_schema_version: 2,
+              avg_power_w: 500,
+              avg_total_gpu_power_w: 4000,
+            },
+          })),
+        });
+      }
+    });
+    cy.visit('/profit-estimator-per-gigawatt?c_power=compare', { onBeforeLoad: suppressNudges });
+    cy.wait('@power-rows').its('request.query').should('not.have.property', 'view');
+    cy.get('#profit-power').should('contain', 'Compare both');
+    cy.get('#profit-target').should('have.value', '45');
+    chart().find('text.revenue-label').should('have.length', 6);
+    chart().should('contain', 'B200').and('contain', 'B300').and('contain', 'MI355X');
+    chart().should('contain', 'Measured + modeled').and('contain', 'Provisioned');
+    cy.get('[data-testid="profit-power-unavailable"]').should('contain', 'GB300');
+  });
+
+  it('keeps the benchmark settings and restores the original chart after unavailable power', () => {
+    stubOpenRouter();
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    bars().its('length').should('be.greaterThan', 0);
+    chart()
+      .invoke('text')
+      .then((original) => {
+        cy.get('#profit-power').click();
+        cy.get('[role="option"]').contains('Measured + modeled power').click();
+        // These existing fixtures intentionally have throughput but no validated power.
+        cy.get('[data-testid="profit-power-unavailable"]').should(
+          'contain',
+          'no usable measured power',
+        );
+        cy.get('#profit-target').should('have.value', '45');
+        cy.get('[data-testid="profit-model-selector"]').should('contain', 'Kimi K3');
+        cy.get('[data-testid="profit-price-source-selector"]').should('contain', 'Moonshot');
+        cy.get('[data-testid="profit-estimator-chart"]').should('not.exist');
+        cy.get('#profit-power').click();
+        cy.get('[role="option"]').contains('Provisioned power').click();
+        bars().its('length').should('be.greaterThan', 0);
+        chart().should('have.text', original);
+      });
+  });
+});
 // The formula fold is collapsed by default; open it (if it is not already) before
 // reading the text. Tests share one page, so a previous test may have opened it.
 const openFormulaNotes = () =>

--- a/packages/app/cypress/e2e/profit-estimator.cy.ts
+++ b/packages/app/cypress/e2e/profit-estimator.cy.ts
@@ -83,12 +83,96 @@ function suppressNudges(win: Cypress.AUTWindow): void {
   win.sessionStorage.setItem('inferencex-reproducibility-nudge-shown', '1');
 }
 
+function unlockPowerGate(win: Cypress.AUTWindow): void {
+  suppressNudges(win);
+  win.localStorage.setItem('inferencex-feature-gate', '1');
+}
+
 const chart = () => cy.get('[data-testid="profit-estimator-chart"]');
 /** The plot SVG itself, not the icon SVGs inside the export button. */
 const chartSvg = () => chart().find('svg').filter(':has(.chart-root)').first();
 const bars = () => chart().find('rect.bar');
 
 describe('Profit estimator power option', () => {
+  it('ignores power URL overrides while locked and returns to provisioned estimates on relock', () => {
+    stubOpenRouter();
+    let rawRequests = 0;
+    cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
+      if (req.query['view'] !== 'calculator') rawRequests++;
+      req.reply({
+        body: profitBenchmarkRows().map((row) => ({
+          ...row,
+          metrics: {
+            ...row.metrics,
+            power_valid: 1,
+            power_metric_schema_version: 2,
+            avg_power_w: 500,
+            avg_total_gpu_power_w: 4000,
+          },
+        })),
+      });
+    });
+    cy.visit('/profit-estimator-per-gigawatt?c_power=compare', {
+      onBeforeLoad: (win) => {
+        suppressNudges(win);
+        win.localStorage.removeItem('inferencex-feature-gate');
+      },
+    });
+    chart().find('text.revenue-label').should('have.length', 4);
+    cy.get('#profit-power').should('not.exist');
+    cy.get('[data-testid="profit-power-note"]').should('not.exist');
+    cy.then(() => expect(rawRequests).to.equal(0));
+    cy.get('body').type('{uparrow}{uparrow}{downarrow}{downarrow}');
+    cy.get('#profit-power').should('contain', 'Compare both');
+    chart().find('text.revenue-label').should('have.length', 6);
+    cy.window().then((win) => {
+      win.localStorage.removeItem('inferencex-feature-gate');
+      win.dispatchEvent(new Event('inferencex:feature-gate:locked'));
+    });
+    cy.get('#profit-power').should('not.exist');
+    cy.get('[data-testid="profit-power-note"]').should('not.exist');
+    chart().find('text.revenue-label').should('have.length', 4);
+  });
+
+  for (const currentValid of [true, false]) {
+    it(`dates historical power skips without current hardware metadata (${currentValid ? 'with current bars' : 'empty chart'})`, () => {
+      stubOpenRouter();
+      cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
+        const historical = req.query['date'] === PROFIT_HISTORY_DATE;
+        const rows = profitBenchmarkRows(
+          'kimik3',
+          historical ? PROFIT_HISTORY_DATE : PROFIT_DATE,
+        ).filter((row) => row.hardware === 'b200' || (historical && row.hardware === 'b300'));
+        req.reply({
+          body: rows.map((row) => ({
+            ...row,
+            metrics: {
+              ...row.metrics,
+              power_valid: !historical && currentValid ? 1 : 0,
+              power_metric_schema_version: 2,
+              avg_power_w: 500,
+              avg_total_gpu_power_w: 4000,
+            },
+          })),
+        });
+      });
+      cy.visit(
+        `/profit-estimator-per-gigawatt?c_power=compare&i_gpus=b200_sglang,b300_vllm&i_dstart=${PROFIT_HISTORY_DATE}&i_dend=${PROFIT_HISTORY_DATE}`,
+        { onBeforeLoad: unlockPowerGate },
+      );
+      cy.get('[data-testid="profit-power-unavailable"]').should(
+        'contain',
+        `B300 (vLLM) (FP4) • ${PROFIT_HISTORY_DATE}`,
+      );
+      cy.get('[data-testid="profit-power-unavailable"]').should(
+        'contain',
+        `B200 (SGLang) (FP4) • ${PROFIT_HISTORY_DATE}`,
+      );
+      if (currentValid) chart().find('text.revenue-label').should('have.length', 2);
+      else cy.get('[data-testid="profit-estimator-chart"]').should('not.exist');
+    });
+  }
+
   it('loads full telemetry and compares matching hardware when opened from a share URL', () => {
     stubOpenRouter();
     cy.intercept('GET', '/api/v1/benchmarks*', (req) => {
@@ -111,7 +195,7 @@ describe('Profit estimator power option', () => {
         });
       }
     });
-    cy.visit('/profit-estimator-per-gigawatt?c_power=compare', { onBeforeLoad: suppressNudges });
+    cy.visit('/profit-estimator-per-gigawatt?c_power=compare', { onBeforeLoad: unlockPowerGate });
     cy.wait('@power-rows').its('request.query').should('not.have.property', 'view');
     cy.get('#profit-power').should('contain', 'Compare both');
     cy.get('#profit-target').should('have.value', '45');
@@ -123,7 +207,7 @@ describe('Profit estimator power option', () => {
 
   it('keeps the benchmark settings and restores the original chart after unavailable power', () => {
     stubOpenRouter();
-    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: suppressNudges });
+    cy.visit('/profit-estimator-per-gigawatt', { onBeforeLoad: unlockPowerGate });
     bars().its('length').should('be.greaterThan', 0);
     chart()
       .invoke('text')

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.test.ts
@@ -168,6 +168,17 @@ describe('rowLabel', () => {
       'H200 (FP8) • 2026-06-14',
     );
   });
+
+  it('labels a historical omission without current hardware metadata or pricing', () => {
+    const skipped = {
+      hwKey: 'b300_vllm',
+      precision: 'fp8',
+      reason: 'no-measured-power',
+      date: '2026-06-14',
+      dateLabel: '2026-06-14 (run 2)',
+    };
+    expect(rowLabel(skipped, hardwareConfig)).toBe('B300 (vLLM) (FP8) • 2026-06-14 (run 2)');
+  });
 });
 
 describe('splitHistoryLabel', () => {

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -416,7 +416,10 @@ export function profitYDomain(
   return [bottom * 1.12, top === 0 ? 1 : top + headroom];
 }
 
-export function rowLabel(row: ProfitEstimatorRow, hardwareConfig: HardwareConfig): string {
+export function rowLabel(
+  row: Pick<ProfitEstimatorRow, 'hwKey' | 'precision' | 'powerLabel' | 'date' | 'dateLabel'>,
+  hardwareConfig: HardwareConfig,
+): string {
   const config = hardwareConfig[row.hwKey] || getHardwareConfig(row.hwKey);
   const base = config ? getDisplayLabel(config) : row.hwKey;
   const precisionLabel = row.precision ? `${base} (${row.precision.toUpperCase()})` : base;

--- a/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorChart.tsx
@@ -230,6 +230,7 @@ export function lossPatternId(resultKey: string): string {
 
 const STRINGS = {
   en: {
+    yAxisModeled: 'Revenue per all-in utility GW per year ($ USD)',
     yAxis: {
       'gw-year': 'Revenue per all-in provisioned utility GW per year ($ USD)',
       'chip-hour': 'Revenue per chip per hour ($ USD)',
@@ -255,6 +256,7 @@ const STRINGS = {
     noData: 'No SKU can be priced for the current selection.',
   },
   zh: {
+    yAxisModeled: '每吉瓦设施总功耗对应的年收入（美元）',
     yAxis: {
       'gw-year': '每全电源配置吉瓦每年收入（美元）',
       'chip-hour': '每芯片每小时收入（美元）',
@@ -417,7 +419,8 @@ export function profitYDomain(
 export function rowLabel(row: ProfitEstimatorRow, hardwareConfig: HardwareConfig): string {
   const config = hardwareConfig[row.hwKey] || getHardwareConfig(row.hwKey);
   const base = config ? getDisplayLabel(config) : row.hwKey;
-  const withPrecision = row.precision ? `${base} (${row.precision.toUpperCase()})` : base;
+  const precisionLabel = row.precision ? `${base} (${row.precision.toUpperCase()})` : base;
+  const withPrecision = row.powerLabel ? `${precisionLabel} (${row.powerLabel})` : precisionLabel;
   // A compare-history bar names the run date (and run number, when the day had
   // several) it was priced on, as the `/inference` legend does for its
   // "config • date" series.
@@ -917,11 +920,16 @@ export default function ProfitEstimatorChart({
   // chart uses the short form.
   const yAxisConfig = useMemo(
     () => ({
-      label: compact ? t.yAxisCompact[basis] : t.yAxis[basis],
+      label:
+        basis === 'gw-year' && assumptions.powerBasis && assumptions.powerBasis !== 'provisioned'
+          ? t.yAxisModeled
+          : compact
+            ? t.yAxisCompact[basis]
+            : t.yAxis[basis],
       tickFormat: (d: d3.AxisDomain) => formatProfitUsd(Number(d), basis, 0),
       tickCount: 8,
     }),
-    [compact, basis, t.yAxis, t.yAxisCompact],
+    [compact, basis, assumptions.powerBasis, t.yAxis, t.yAxisCompact, t.yAxisModeled],
   );
 
   const onRender = useMemo(

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -209,7 +209,7 @@ const STRINGS = {
     powerOptions: {
       provisioned: 'Provisioned power',
       modeled: 'Measured + modeled power',
-      compare: 'Compare both (apples-to-apples)',
+      compare: 'Compare both',
     },
     powerBarLabels: { provisioned: 'Provisioned', modeled: 'Measured + modeled' },
     powerPreview:
@@ -324,7 +324,7 @@ const STRINGS = {
     powerOptions: {
       provisioned: '预配功耗',
       modeled: '实测 GPU + 系统功耗估算',
-      compare: '同口径对比两种估算方式',
+      compare: '对比两种估算方式',
     },
     powerBarLabels: { provisioned: '预配功耗', modeled: '实测 + 估算' },
     powerPreview:

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -309,7 +309,7 @@ const STRINGS = {
     dateRangePlaceholder: 'Select date range',
     historyNote: (dates: string) =>
       `Compare history: lighter bars are the same chip configs priced on ${dates}, using the same target, prices, and TCO tier.`,
-    historyNoData: (entries: string) => `No run at the target on ${entries}.`,
+    historyNoData: (entries: string) => `No estimate at the target on ${entries}.`,
     csvDateHeader: 'Run date',
   },
   zh: {
@@ -423,7 +423,7 @@ const STRINGS = {
     dateRangePlaceholder: '选择日期范围',
     historyNote: (dates: string) =>
       `对比历史趋势：较浅的柱形为同一芯片配置在 ${dates} 的估价，目标、价格与 TCO 层级保持一致。`,
-    historyNoData: (entries: string) => `${entries} 在目标处无运行结果。`,
+    historyNoData: (entries: string) => `${entries} 在目标交互性下无法估算。`,
     csvDateHeader: '运行日期',
   },
 } as const;
@@ -599,7 +599,10 @@ function ProfitEstimatorInner({
     () => profitModelDefaults(selectedModel).interactivity,
   );
   const [targetRaw, setTargetRaw] = useState<string>(() => String(targetValue));
-  const [powerBasis, setPowerBasis] = useState<ProfitPowerBasis>('provisioned');
+  const featureGateUnlocked = useFeatureGate();
+  const powerControlsEnabled = basis === 'gw-year' && featureGateUnlocked;
+  const [requestedPowerBasis, setPowerBasis] = useState<ProfitPowerBasis>('provisioned');
+  const powerBasis = powerControlsEnabled ? requestedPowerBasis : 'provisioned';
   useEffect(() => {
     const value = getUrlParam('c_power');
     setPowerBasis(value === 'modeled' || value === 'compare' ? value : 'provisioned');
@@ -933,7 +936,6 @@ function ProfitEstimatorInner({
     track('profit_custom_cost_set', { gpu: base, value: raw });
   }, []);
 
-  const featureGateUnlocked = useFeatureGate();
   const percentileLabel = selectedPercentile.toUpperCase();
 
   const openRouterModelId = getOpenRouterModelId(selectedModel);
@@ -1338,6 +1340,22 @@ function ProfitEstimatorInner({
     historyCurrentRunIds,
   ]);
 
+  const powerUnavailable = useMemo(
+    () =>
+      t.skipped(
+        fullEstimate.skipped
+          .map((row) => {
+            const label = rowLabel(
+              { ...row, dateLabel: row.date ? historyEntryLabel(row.date) : undefined },
+              hardwareConfig,
+            );
+            return `${label}: ${t.skipReason[row.reason]}`;
+          })
+          .join('; '),
+      ),
+    [fullEstimate.skipped, hardwareConfig, historyEntryLabel, t],
+  );
+
   // Rendered as the chart's figcaption so it is part of the PNG export.
   const caption = useMemo(() => {
     if (!pricing) return null;
@@ -1354,7 +1372,7 @@ function ProfitEstimatorInner({
             targetValue,
           )}
         </Heading>
-        {basis === 'gw-year' && (
+        {powerControlsEnabled && (
           <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-power-note">
             {t.powerLabel}: {t.powerOptions[powerBasis]}
             {powerBasis !== 'provisioned' && <>. {t.powerPreview}</>}
@@ -1362,14 +1380,7 @@ function ProfitEstimatorInner({
         )}
         {basis === 'gw-year' && powerBasis !== 'provisioned' && fullEstimate.skipped.length > 0 && (
           <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-power-unavailable">
-            {t.skipped(
-              fullEstimate.skipped
-                .map(
-                  (row) =>
-                    `${getDisplayLabel(hardwareConfig[row.hwKey])}: ${t.skipReason[row.reason]}`,
-                )
-                .join('; '),
-            )}
+            {powerUnavailable}
           </p>
         )}
         <ResultContext
@@ -1447,6 +1458,8 @@ function ProfitEstimatorInner({
   }, [
     pricing,
     powerBasis,
+    powerControlsEnabled,
+    powerUnavailable,
     fullEstimate.skipped,
     hardwareConfig,
     effectivePriceSource,
@@ -1497,7 +1510,7 @@ function ProfitEstimatorInner({
     const [sku, precision, ...rest] = t.csvHeaders[basis];
     exportToCsv(exportFileName, [sku, precision, t.csvDateHeader, ...rest], rows, [
       t.captionFormula[basis](assumptions.utilizationPct, assumptions.labCutPct),
-      ...(basis === 'gw-year'
+      ...(powerControlsEnabled
         ? [
             `${t.powerLabel}: ${t.powerOptions[powerBasis]}`,
             ...(powerBasis === 'provisioned' ? [] : [t.powerPreview]),
@@ -1513,6 +1526,7 @@ function ProfitEstimatorInner({
     basis,
     selectedRunDate,
     powerBasis,
+    powerControlsEnabled,
   ]);
 
   if (!loading && error) {
@@ -1580,7 +1594,7 @@ function ProfitEstimatorInner({
                       onBlur={handleTargetBlur}
                     />
                   </div>
-                  {basis === 'gw-year' && (
+                  {powerControlsEnabled && (
                     <div className="flex min-w-0 flex-col space-y-1.5 md:col-span-2">
                       <LabelWithTooltip
                         htmlFor="profit-power"
@@ -1870,15 +1884,7 @@ function ProfitEstimatorInner({
                     className="mb-3 text-xs text-muted-foreground"
                     data-testid="profit-power-unavailable"
                   >
-                    {t.powerPreview}{' '}
-                    {t.skipped(
-                      fullEstimate.skipped
-                        .map(
-                          (row) =>
-                            `${getDisplayLabel(hardwareConfig[row.hwKey])}: ${t.skipReason[row.reason]}`,
-                        )
-                        .join('; '),
-                    )}
+                    {t.powerPreview} {powerUnavailable}
                   </p>
                 )}
               <ChartButtons

--- a/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
+++ b/packages/app/src/components/calculator/ProfitEstimatorDisplay.tsx
@@ -84,7 +84,6 @@ import { getDisplayLabel } from '@/lib/utils';
 import {
   clampPercent,
   DEFAULT_UTILIZATION_PCT,
-  estimateProfitRows,
   listPricingToTokenRevenuePricing,
   modelsWithAgenticData,
   parseTokenPriceInput,
@@ -94,6 +93,7 @@ import {
   type ProfitEstimatorSkipReason,
 } from './profit-estimator';
 import { profitEstimatorChartStrings, rowLabel } from './ProfitEstimatorChart';
+import { estimateProfitByPower, type ProfitPowerBasis } from './profit-power';
 import {
   buildProfitHistoryResults,
   historyFadeShare,
@@ -203,6 +203,17 @@ const STRINGS = {
       'chip-hour': 'Revenue & Profit Estimator',
     },
     benchmarkGroup: 'Benchmark Config',
+    powerLabel: 'Power Estimation',
+    powerTooltip:
+      'Change only the power budget used to scale the same benchmark result to one GW. Pricing, throughput, utilization and unit costs stay the same.',
+    powerOptions: {
+      provisioned: 'Provisioned power',
+      modeled: 'Measured + modeled power',
+      compare: 'Compare both (apples-to-apples)',
+    },
+    powerBarLabels: { provisioned: 'Provisioned', modeled: 'Measured + modeled' },
+    powerPreview:
+      'PowerX estimate · Same target, throughput, pricing and unit costs. GPU power comes from the same serving-frontier points; power between them is estimated linearly. Server overhead is modeled, with PUE 1.3 and 10% headroom. AgentX system power is not yet qualified.',
     pricingGroup: 'Pricing Config',
     costProviderLabel: 'Cost Provider',
     costProviderTooltip:
@@ -283,6 +294,8 @@ const STRINGS = {
     skipReason: {
       'outside-measured-range': 'no measured point at the target interactivity',
       'no-power': 'no all-in power figure',
+      'no-measured-power':
+        'no usable measured power or supported system model for these benchmark points',
       'no-cost': 'no TCO for this tier',
       'no-token-mix': 'no input/output token mix recorded',
     } satisfies Record<ProfitEstimatorSkipReason, string>,
@@ -305,6 +318,17 @@ const STRINGS = {
       'chip-hour': '收入与利润估算器',
     },
     benchmarkGroup: '基准测试配置',
+    powerLabel: '功耗估算方式',
+    powerTooltip:
+      '仅更改将同一基准测试结果换算为每 GW 收益时采用的功耗预算。价格、吞吐量、利用率和单位成本保持不变。',
+    powerOptions: {
+      provisioned: '预配功耗',
+      modeled: '实测 GPU + 系统功耗估算',
+      compare: '同口径对比两种估算方式',
+    },
+    powerBarLabels: { provisioned: '预配功耗', modeled: '实测 + 估算' },
+    powerPreview:
+      'PowerX 估算 · 两种方式采用相同的目标交互性、吞吐量、价格和单位成本。GPU 功耗取自同一组性能前沿数据点，点间功耗采用线性估算。服务器开销由模型估算，PUE 为 1.3，功耗余量为 10%。AgentX 系统功耗模型尚未完成验证。',
     pricingGroup: '定价配置',
     costProviderLabel: '成本供应商',
     costProviderTooltip:
@@ -385,6 +409,7 @@ const STRINGS = {
     skipReason: {
       'outside-measured-range': '未在该交互性下实测',
       'no-power': '缺少全电源配置功率数据',
+      'no-measured-power': '同一组基准测试数据点缺少有效功耗或适用的系统模型',
       'no-cost': '该层级无 TCO 数据',
       'no-token-mix': '未记录输入/输出 token 比例',
     } satisfies Record<ProfitEstimatorSkipReason, string>,
@@ -574,6 +599,11 @@ function ProfitEstimatorInner({
     () => profitModelDefaults(selectedModel).interactivity,
   );
   const [targetRaw, setTargetRaw] = useState<string>(() => String(targetValue));
+  const [powerBasis, setPowerBasis] = useState<ProfitPowerBasis>('provisioned');
+  useEffect(() => {
+    const value = getUrlParam('c_power');
+    setPowerBasis(value === 'modeled' || value === 'compare' ? value : 'provisioned');
+  }, [getUrlParam]);
   const utilization = usePercentField(DEFAULT_UTILIZATION_PCT, 'profit_utilization_set');
   const labCut = usePercentField(
     profitModelDefaults(selectedModel).labCutPct,
@@ -625,6 +655,7 @@ function ProfitEstimatorInner({
     true,
     'total',
     tcoBasis,
+    basis === 'gw-year' && powerBasis !== 'provisioned',
   );
 
   // ── Compare history ───────────────────────────────────────────────────────
@@ -780,6 +811,7 @@ function ProfitEstimatorInner({
     currentRunDate: selectedRunDate,
     currentRunIds: historyCurrentRunIds,
     enabled: hasData,
+    includePower: basis === 'gw-year' && powerBasis !== 'provisioned',
   });
   const historyActive = history.comparisonDates.length > 0;
   const historyRunNumbering = useMemo(() => {
@@ -937,8 +969,8 @@ function ProfitEstimatorInner({
   ]);
 
   const assumptions = useMemo(
-    () => ({ utilizationPct: utilization.value, labCutPct: labCut.value, basis }),
-    [utilization.value, labCut.value, basis],
+    () => ({ utilizationPct: utilization.value, labCutPct: labCut.value, basis, powerBasis }),
+    [utilization.value, labCut.value, basis, powerBasis],
   );
 
   // Price every SKU first, then build the legend from the ones that produced a
@@ -965,7 +997,7 @@ function ProfitEstimatorInner({
           }),
         ]
       : current;
-    const estimated = estimateProfitRows(
+    const estimated = estimateProfitByPower(
       results,
       (hwKey) => ({
         powerKwPerGpu: getGpuSpecs(hwKey).power,
@@ -973,6 +1005,9 @@ function ProfitEstimatorInner({
       }),
       pricing,
       assumptions,
+      powerBasis,
+      targetValue,
+      t.powerBarLabels,
     );
     if (!historyActive) return estimated;
     return {
@@ -985,6 +1020,8 @@ function ProfitEstimatorInner({
     hasData,
     pricing,
     getResults,
+    powerBasis,
+    t.powerBarLabels,
     targetValue,
     mode,
     interpolationCostProvider,
@@ -1317,6 +1354,24 @@ function ProfitEstimatorInner({
             targetValue,
           )}
         </Heading>
+        {basis === 'gw-year' && (
+          <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-power-note">
+            {t.powerLabel}: {t.powerOptions[powerBasis]}
+            {powerBasis !== 'provisioned' && <>. {t.powerPreview}</>}
+          </p>
+        )}
+        {basis === 'gw-year' && powerBasis !== 'provisioned' && fullEstimate.skipped.length > 0 && (
+          <p className="mb-2 text-xs text-muted-foreground" data-testid="profit-power-unavailable">
+            {t.skipped(
+              fullEstimate.skipped
+                .map(
+                  (row) =>
+                    `${getDisplayLabel(hardwareConfig[row.hwKey])}: ${t.skipReason[row.reason]}`,
+                )
+                .join('; '),
+            )}
+          </p>
+        )}
         <ResultContext
           locale={locale}
           costTier={costTier}
@@ -1391,6 +1446,9 @@ function ProfitEstimatorInner({
     );
   }, [
     pricing,
+    powerBasis,
+    fullEstimate.skipped,
+    hardwareConfig,
     effectivePriceSource,
     listPricing,
     selectedModel,
@@ -1439,8 +1497,23 @@ function ProfitEstimatorInner({
     const [sku, precision, ...rest] = t.csvHeaders[basis];
     exportToCsv(exportFileName, [sku, precision, t.csvDateHeader, ...rest], rows, [
       t.captionFormula[basis](assumptions.utilizationPct, assumptions.labCutPct),
+      ...(basis === 'gw-year'
+        ? [
+            `${t.powerLabel}: ${t.powerOptions[powerBasis]}`,
+            ...(powerBasis === 'provisioned' ? [] : [t.powerPreview]),
+          ]
+        : []),
     ]);
-  }, [estimate.rows, hardwareConfig, exportFileName, t, assumptions, basis, selectedRunDate]);
+  }, [
+    estimate.rows,
+    hardwareConfig,
+    exportFileName,
+    t,
+    assumptions,
+    basis,
+    selectedRunDate,
+    powerBasis,
+  ]);
 
   if (!loading && error) {
     console.error(error);
@@ -1507,6 +1580,41 @@ function ProfitEstimatorInner({
                       onBlur={handleTargetBlur}
                     />
                   </div>
+                  {basis === 'gw-year' && (
+                    <div className="flex min-w-0 flex-col space-y-1.5 md:col-span-2">
+                      <LabelWithTooltip
+                        htmlFor="profit-power"
+                        label={t.powerLabel}
+                        tooltip={t.powerTooltip}
+                      />
+                      <div data-testid="profit-power-selector">
+                        <MultiSelect
+                          triggerId="profit-power"
+                          options={Object.entries(t.powerOptions).map(([value, label]) => ({
+                            value,
+                            label,
+                          }))}
+                          value={[powerBasis]}
+                          onChange={(values) => {
+                            const next = values[0];
+                            if (next !== 'provisioned' && next !== 'modeled' && next !== 'compare')
+                              return;
+                            setPowerBasis(next);
+                            setUrlParam('c_power', next === 'provisioned' ? '' : next);
+                            track('profit_power_basis_changed', { basis: next });
+                          }}
+                          open={openDropdown === 'power'}
+                          onOpenChange={handleDropdownOpenChange('power')}
+                          minSelections={1}
+                          maxSelections={1}
+                          showClearAll={false}
+                          searchable={false}
+                          plainSelectedText
+                          showSelectionSummary={false}
+                        />
+                      </div>
+                    </div>
+                  )}
                 </ControlPanel>
                 <ControlPanel
                   legend={t.pricingGroup}
@@ -1755,6 +1863,24 @@ function ProfitEstimatorInner({
           )}
           {pricing ? (
             <figure data-testid="profit-figure" className="relative rounded-lg">
+              {basis === 'gw-year' &&
+                estimate.rows.length === 0 &&
+                powerBasis !== 'provisioned' && (
+                  <p
+                    className="mb-3 text-xs text-muted-foreground"
+                    data-testid="profit-power-unavailable"
+                  >
+                    {t.powerPreview}{' '}
+                    {t.skipped(
+                      fullEstimate.skipped
+                        .map(
+                          (row) =>
+                            `${getDisplayLabel(hardwareConfig[row.hwKey])}: ${t.skipReason[row.reason]}`,
+                        )
+                        .join('; '),
+                    )}
+                  </p>
+                )}
               <ChartButtons
                 chartId="profit-estimator-chart"
                 analyticsPrefix="profit_estimator"

--- a/packages/app/src/components/calculator/profit-estimator.ts
+++ b/packages/app/src/components/calculator/profit-estimator.ts
@@ -178,6 +178,7 @@ export const DEFAULT_UTILIZATION_PCT = 60;
 export type ProfitBasis = 'chip-hour' | 'gw-year';
 
 export interface ProfitEstimatorAssumptions {
+  powerBasis?: 'provisioned' | 'modeled' | 'compare';
   /** 0–100. Revenue is scaled by this share; TCO is not. */
   utilizationPct: number;
   /** 0–100. Share of revenue paid to the model lab. */
@@ -186,6 +187,8 @@ export interface ProfitEstimatorAssumptions {
 }
 
 export interface ProfitEstimatorRow {
+  /** Distinguish identical hardware bars when both power budgets are shown. */
+  powerLabel?: string;
   hwKey: string;
   resultKey: string;
   precision?: string;
@@ -223,6 +226,7 @@ export interface ProfitEstimatorRow {
  * for the same reason.
  */
 export type ProfitEstimatorSkipReason =
+  | 'no-measured-power'
   | 'outside-measured-range'
   | 'no-power'
   | 'no-cost'

--- a/packages/app/src/components/calculator/profit-power.test.ts
+++ b/packages/app/src/components/calculator/profit-power.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BenchmarkRow } from '@/lib/api';
+import { modelSystemPower } from '@/lib/modeled-system-power';
+import { Percentile, Sequence } from '@/lib/data-mappings';
+import { buildGpuGroups, interpolateForGPU } from './useThroughputData';
+import { estimateProfitRows } from './profit-estimator';
+import { estimateProfitByPower, modeledPowerAtTarget } from './profit-power';
+import type { GPUDataPoint, InterpolatedResult } from './types';
+
+// Power telemetry from MI355X Kimi K3 source row 441385; the target/rates below
+// are controlled inputs so the test isolates a denominator change.
+const source: BenchmarkRow = {
+  id: 441385,
+  model: 'kimik3',
+  hardware: 'mi355x',
+  framework: 'atom',
+  precision: 'fp4',
+  spec_method: 'mtp',
+  disagg: false,
+  is_multinode: false,
+  prefill_tp: 8,
+  prefill_ep: 1,
+  prefill_dp_attention: false,
+  prefill_num_workers: 0,
+  decode_tp: 8,
+  decode_ep: 1,
+  decode_dp_attention: false,
+  decode_num_workers: 0,
+  num_prefill_gpu: 8,
+  num_decode_gpu: 8,
+  benchmark_type: 'agentic_traces',
+  isl: null,
+  osl: null,
+  conc: 16,
+  offload_mode: 'off',
+  image: 'test',
+  date: '2026-09-10',
+  run_url: 'https://github.com/SemiAnalysisAI/InferenceX/actions/runs/34349642428/attempts/1',
+  metrics: {
+    power_valid: 1,
+    power_metric_schema_version: 2,
+    avg_power_w: 796.131,
+    avg_total_gpu_power_w: 6369.045,
+  },
+};
+const point: GPUDataPoint = {
+  sourceRow: source,
+  hwKey: 'mi355x_atom',
+  interactivity: 45,
+  throughput: 6000,
+  inputThroughput: 5940,
+  outputThroughput: 60,
+  concurrency: 16,
+  tp: 8,
+  precision: 'fp4',
+  costh: 1,
+  costr: 2,
+  costhi: 1,
+  costri: 2,
+  costhOutput: 1,
+  costrOutput: 2,
+  tpPerMw: 1,
+  inputTpPerMw: 1,
+  outputTpPerMw: 1,
+};
+const result: InterpolatedResult = {
+  hwKey: point.hwKey,
+  resultKey: point.hwKey,
+  value: 6000,
+  inputTputValue: 5940,
+  outputTputValue: 60,
+  inputTokenShare: 0.99,
+  cacheHitRate: 0.9,
+  cost: 1,
+  costInput: 1,
+  costOutput: 1,
+  tpPerMw: 1,
+  inputTpPerMw: 1,
+  outputTpPerMw: 1,
+  concurrency: 16,
+  nearestPoints: [point],
+};
+const pricing = {
+  source: 'normalized' as const,
+  inputPerMillion: 3,
+  cachedInputPerMillion: 0.3,
+  outputPerMillion: 15,
+};
+const assumptions = { basis: 'gw-year' as const, utilizationPct: 60, labCutPct: 30 };
+const specs = () => ({ powerKwPerGpu: 2.09, costPerGpuHour: 1.5 });
+const labels = { provisioned: 'Provisioned', modeled: 'Measured + modeled' };
+
+describe('profit power basis preview', () => {
+  it('keeps raw power attached through official and run-keyed frontier construction', () => {
+    const row = {
+      ...source,
+      metrics: {
+        ...source.metrics,
+        p90_itl: 1 / 45,
+        tput_per_gpu: 6000,
+        input_tput_per_gpu: 5940,
+        output_tput_per_gpu: 60,
+      },
+    };
+    for (const suffix of ['', '__run1']) {
+      const { grouped } = buildGpuGroups([row], {
+        sequence: Sequence.AgenticTraces,
+        precisions: ['fp4'],
+        percentile: Percentile.P90,
+        classify: (hwKey) => ({ key: `${hwKey}${suffix}`, meta: { hwKey } }),
+      });
+      const points = Object.values(grouped)[0];
+      expect(points[0].sourceRow).toBe(row);
+      const interpolated = interpolateForGPU(points, 45, 'interactivity_to_throughput', 'costh');
+      expect(interpolated).not.toBeNull();
+      expect(modeledPowerAtTarget(interpolated!, 45)).toBeCloseTo(1.5976675, 8);
+    }
+  });
+
+  it('rejects partial chassis and unsupported rack hardware despite valid telemetry', () => {
+    for (const hardware of ['gb200', 'gb300']) {
+      expect(
+        modeledPowerAtTarget(
+          { ...result, nearestPoints: [{ ...point, sourceRow: { ...source, hardware } }] },
+          45,
+        ),
+      ).toBeNull();
+    }
+    const partial = {
+      ...source,
+      prefill_tp: 4,
+      decode_tp: 4,
+      metrics: { ...source.metrics, avg_power_w: 500, avg_total_gpu_power_w: 2000 },
+    };
+    expect(modelSystemPower(partial, undefined, true)).toMatchObject({
+      status: 'supported',
+      chassisBasis: 'extrapolated',
+    });
+    expect(
+      modeledPowerAtTarget({ ...result, nearestPoints: [{ ...point, sourceRow: partial }] }, 45),
+    ).toBeNull();
+  });
+
+  it('leaves the default estimator and default AgentX model gate unchanged', () => {
+    expect(
+      estimateProfitByPower([result], specs, pricing, assumptions, 'provisioned', 45, labels),
+    ).toEqual(estimateProfitRows([result], specs, pricing, assumptions));
+    expect(modelSystemPower(source)).toMatchObject({ status: 'unsupported', reason: 'workload' });
+  });
+
+  it('only changes GPU-hours in the paired calculation, preserving unit economics and margin', () => {
+    expect(modeledPowerAtTarget(result, 45)).toBeCloseTo(1.5976675, 8);
+    const output = estimateProfitByPower(
+      [result],
+      specs,
+      pricing,
+      assumptions,
+      'compare',
+      45,
+      labels,
+    );
+    expect(output.skipped).toEqual([]);
+    const [baseline, modeled] = output.rows;
+    expect(modeled.revenuePerGpuHour).toBe(baseline.revenuePerGpuHour);
+    const ratio = 2.09 / 1.5976675;
+    for (const field of ['gpuHours', 'revenue', 'tco', 'labCut', 'profit'] as const) {
+      expect(modeled[field] / baseline[field]).toBeCloseTo(ratio, 10);
+    }
+    expect(modeled.profit / modeled.revenue).toBeCloseTo(baseline.profit / baseline.revenue, 12);
+    expect(new Set(output.rows.map((r) => r.resultKey)).size).toBe(2);
+    expect(result.nearestPoints).toEqual([point]);
+  });
+
+  it('never fills a missing power knot with a different measurement or provisioned watts', () => {
+    const missing = {
+      ...point,
+      interactivity: 60,
+      sourceRow: { ...source, metrics: { ...source.metrics, power_valid: 0 } },
+    };
+    const bracket = { ...result, nearestPoints: [{ ...point, interactivity: 30 }, missing] };
+    expect(modeledPowerAtTarget(bracket, 45)).toBeNull();
+    expect(
+      estimateProfitByPower([bracket], specs, pricing, assumptions, 'compare', 45, labels),
+    ).toMatchObject({ rows: [], skipped: [{ reason: 'no-measured-power' }] });
+    expect(modeledPowerAtTarget({ ...result, nearestPoints: [point, missing] }, 45)).toBeCloseTo(
+      1.5976675,
+      8,
+    );
+    expect(modeledPowerAtTarget({ ...result, clamped: true }, 45)).toBeNull();
+  });
+
+  it('estimates power only inside the same valid bracket and scales losses too', () => {
+    const bracket = {
+      ...result,
+      nearestPoints: [
+        { ...point, interactivity: 30 },
+        { ...point, interactivity: 60 },
+      ],
+    };
+    expect(modeledPowerAtTarget(bracket, 45)).toBeCloseTo(1.5976675, 8);
+    expect(modeledPowerAtTarget(bracket, 75)).toBeNull();
+    const [a, b] = estimateProfitByPower(
+      [result],
+      specs,
+      pricing,
+      { ...assumptions, utilizationPct: 0 },
+      'compare',
+      45,
+      labels,
+    ).rows;
+    expect(a.revenue).toBe(0);
+    expect(b.revenue).toBe(0);
+    expect(b.profit).toBeLessThan(a.profit);
+  });
+});

--- a/packages/app/src/components/calculator/profit-power.ts
+++ b/packages/app/src/components/calculator/profit-power.ts
@@ -1,0 +1,106 @@
+import { modelSystemPower } from '@/lib/modeled-system-power';
+import type { TokenRevenuePricing } from '@/components/inference/types';
+
+import {
+  estimateProfitRows,
+  estimateSkuProfit,
+  isProfitEstimatorRow,
+  type ProfitEstimatorAssumptions,
+  type ProfitEstimatorOutput,
+  type ProfitEstimatorSpecs,
+} from './profit-estimator';
+import type { GPUDataPoint, InterpolatedResult } from './types';
+
+export type ProfitPowerBasis = 'provisioned' | 'modeled' | 'compare';
+
+function planningKwPerGpu(point: GPUDataPoint): number | null {
+  const row = point.sourceRow;
+  if (!row || row.metrics.power_metric_schema_version !== 2) return null;
+  const estimate = modelSystemPower(row, undefined, true);
+  if (
+    estimate.status !== 'supported' ||
+    estimate.gpuCount !== 8 ||
+    estimate.topologyBasis !== 'single-node' ||
+    estimate.chassisBasis !== 'full'
+  )
+    return null;
+  return (estimate.deploymentFacilityWatts / estimate.gpuCount / 1000) * 1.1;
+}
+
+/** Reusing the original frontier prevents the power choice from changing throughput. */
+export function modeledPowerAtTarget(result: InterpolatedResult, target: number): number | null {
+  if (result.clamped) return null;
+  const exact = result.nearestPoints.find((p) => Math.abs(p.interactivity - target) < 1e-9);
+  if (exact) return planningKwPerGpu(exact);
+  const [left, right] = result.nearestPoints;
+  if (!left || !right || target < left.interactivity || target > right.interactivity) return null;
+  const lower = planningKwPerGpu(left),
+    upper = planningKwPerGpu(right);
+  if (lower === null || upper === null || right.interactivity <= left.interactivity) return null;
+  return (
+    lower +
+    ((upper - lower) * (target - left.interactivity)) / (right.interactivity - left.interactivity)
+  );
+}
+
+export function estimateProfitByPower(
+  results: readonly (InterpolatedResult & { date?: string })[],
+  specsFor: (hwKey: string) => ProfitEstimatorSpecs,
+  pricing: TokenRevenuePricing,
+  assumptions: ProfitEstimatorAssumptions,
+  powerBasis: ProfitPowerBasis,
+  target: number,
+  labels: { provisioned: string; modeled: string },
+): ProfitEstimatorOutput {
+  if (powerBasis === 'provisioned' || assumptions.basis === 'chip-hour') {
+    return estimateProfitRows(results, specsFor, pricing, assumptions);
+  }
+  const output: ProfitEstimatorOutput = { rows: [], skipped: [] };
+  for (const result of results) {
+    const specs = specsFor(result.hwKey);
+    const baseline = estimateSkuProfit(result, specs, pricing, assumptions);
+    if (!isProfitEstimatorRow(baseline)) {
+      output.skipped.push(baseline);
+      continue;
+    }
+    const power = modeledPowerAtTarget(result, target);
+    if (power === null) {
+      output.skipped.push({
+        hwKey: result.hwKey,
+        resultKey: result.resultKey,
+        precision: result.precision,
+        date: result.date,
+        reason: 'no-measured-power',
+      });
+      continue;
+    }
+    const modeled = estimateSkuProfit(
+      result,
+      { ...specs, powerKwPerGpu: power },
+      pricing,
+      assumptions,
+    );
+    if (!isProfitEstimatorRow(modeled)) {
+      output.skipped.push(modeled);
+      continue;
+    }
+    if (powerBasis === 'compare') {
+      output.rows.push(
+        {
+          ...baseline,
+          resultKey: `${baseline.resultKey}__provisioned`,
+          powerLabel: labels.provisioned,
+        },
+        {
+          ...modeled,
+          resultKey: `${modeled.resultKey}__modeled`,
+          powerLabel: labels.modeled,
+        },
+      );
+    } else output.rows.push(modeled);
+  }
+  // Sorting paired rows by profit would separate estimates of the same configuration.
+  if (powerBasis !== 'compare')
+    output.rows.sort((a, b) => b.profit - a.profit || a.resultKey.localeCompare(b.resultKey));
+  return output;
+}

--- a/packages/app/src/components/calculator/types.ts
+++ b/packages/app/src/components/calculator/types.ts
@@ -1,3 +1,5 @@
+import type { BenchmarkRow } from '@/lib/api';
+
 export type CalculatorMode = 'interactivity_to_throughput' | 'throughput_to_interactivity';
 
 export type CostProvider = 'costh' | 'costr';
@@ -7,6 +9,8 @@ export type CostType = 'total' | 'input' | 'output';
 export type BarMetric = 'throughput' | 'power' | 'cost';
 
 export interface GPUDataPoint {
+  /** Preserve the source of each frontier knot for paired power estimates. */
+  sourceRow?: BenchmarkRow;
   hwKey: string;
   interactivity: number; // tokens/sec/user (median_intvty = x in interactivity chart)
   /**

--- a/packages/app/src/components/calculator/useProfitHistory.ts
+++ b/packages/app/src/components/calculator/useProfitHistory.ts
@@ -33,6 +33,7 @@ export function useProfitHistory(options: {
   /** Per chip, the run behind its main bar; a pin that adds no bar is dropped. */
   currentRunIds?: Readonly<Record<string, string>>;
   enabled?: boolean;
+  includePower?: boolean;
 }): {
   /** Comparison entries in fetch order (dates or `date~r<runId>` runs). */
   comparisonDates: string[];
@@ -49,6 +50,7 @@ export function useProfitHistory(options: {
     currentRunDate,
     currentRunIds = EMPTY_RUN_IDS,
     enabled = true,
+    includePower = false,
   } = options;
 
   const comparisonDates = useMemo(
@@ -61,7 +63,10 @@ export function useProfitHistory(options: {
     [selectedGPUs, selectedDates, dateRange, currentRunDate, currentRunIds],
   );
 
-  const view = useMemo(() => ({ type: 'calculator' as const, sequence }), [sequence]);
+  const view = useMemo(
+    () => (includePower ? undefined : { type: 'calculator' as const, sequence }),
+    [sequence, includePower],
+  );
 
   const queries = useQueries({
     queries: comparisonDates.map((entry) => {

--- a/packages/app/src/components/calculator/useThroughputData.ts
+++ b/packages/app/src/components/calculator/useThroughputData.ts
@@ -213,6 +213,7 @@ export function buildGpuGroups<M extends GroupMeta>(
     groupMeta[groupKey] = meta;
 
     grouped[groupKey].push({
+      sourceRow: row,
       hwKey,
       interactivity:
         sequence === Sequence.AgenticTraces
@@ -274,6 +275,7 @@ export function useThroughputData(
   enabled = true,
   selectedTokenType: CostType = 'total',
   tcoBasis: TcoBasis = DEFAULT_TCO_BASIS,
+  includePower = false,
 ) {
   const initialCacheScope = useMemo(
     () =>
@@ -293,12 +295,15 @@ export function useThroughputData(
     enabled,
     undefined,
     undefined,
-    {
-      type: 'calculator',
-      sequence: selectedSequence,
-      ...(initialCacheScope ? { cacheScope: initialCacheScope } : {}),
-    },
-    initialRows,
+    includePower
+      ? undefined
+      : {
+          type: 'calculator',
+          sequence: selectedSequence,
+          ...(initialCacheScope ? { cacheScope: initialCacheScope } : {}),
+        },
+    // A calculator projection cannot seed the raw-power query cache.
+    includePower ? undefined : initialRows,
   );
 
   const loading = queryLoading || !allRows;

--- a/packages/app/src/lib/modeled-system-power.ts
+++ b/packages/app/src/lib/modeled-system-power.ts
@@ -92,8 +92,13 @@ function unavailable(reason: SystemPowerUnsupportedReason): SystemPowerEstimate 
 export function modelSystemPower(
   row: BenchmarkRow,
   pue: number = AIR_COOLED_SYSTEM_PUE,
+  /** Opt in so AgentX estimates do not widen the ordinary 8K/1K chart policy. */
+  allowAgenticPreview = false,
 ): SystemPowerEstimate {
-  if (row.benchmark_type !== 'single_turn' || row.isl !== 8192 || row.osl !== 1024) {
+  if (
+    !(allowAgenticPreview && row.benchmark_type === 'agentic_traces') &&
+    (row.benchmark_type !== 'single_turn' || row.isl !== 8192 || row.osl !== 1024)
+  ) {
     return unavailable('workload');
   }
   if (typeof row.hardware !== 'string') return unavailable('hardware');

--- a/packages/app/src/lib/url-state.ts
+++ b/packages/app/src/lib/url-state.ts
@@ -94,6 +94,7 @@ const URL_STATE_KEYS = [
   'c_mtbi',
   'c_rec',
   'c_life',
+  'c_power',
 ] as const;
 
 export type UrlStateKey = (typeof URL_STATE_KEYS)[number];
@@ -186,6 +187,7 @@ export const PARAM_DEFAULTS: Record<UrlStateKey, string> = {
   c_price: '',
   c_oprice: '',
   c_life: '',
+  c_power: 'provisioned',
   // Empty means the default y metric (margin).
   c_ly: '',
   c_ramp: DEFAULT_LIFECYCLE_RAMP_MONTHS,


### PR DESCRIPTION
## Summary

The per-GW Profit Estimator currently sizes every fleet using provisioned power. Add a **Power Estimation** option behind the existing insider feature gate inside Benchmark Config: provisioned (default), measured + modeled, or a matched comparison. Keep the model, P90 target, original throughput frontier, token mix, pricing, utilization and per-GPU-hour costs unchanged.

- Hide the control, extra power metadata and alternative calculations while locked, including `c_power` share links. Unlock with ↑↑↓↓; relock to immediately restore provisioned estimates.
- Label historical omissions using the hardware registry plus source date/run, so history-only chips cannot crash either the caption or empty chart.
- Use full benchmark rows for power calculations, retaining source power through the existing current/history mapper. Between targets, estimate power from the same two original frontier knots; never replace missing power with another operating point.
- Require validated schema-v2 telemetry and a supported, complete eight-GPU single-node chassis. Preserve unavailable configurations, paired labels, CSV assumptions and `c_power` share links in English and Chinese.
- Reuse the pinned system model with PUE 1.3 and 10% planning headroom. This is a labeled estimate, **not calibrated AgentX system power or validated peak-load provisioning**. Existing unit costs scale with capacity; electricity expense is not recalculated separately. The ordinary 8K/1K path and per-chip-hour estimator retain their behavior.

## Existing-data coverage

Read all eight published AgentX model buckets on **2026-09-12 00:03 UTC**: 703 rows, including 292 with valid schema-v2 power. Checked the actual app frontier and verified all five estimator models in the browser with live API data.

| Estimator model | Default P90 target (tok/s/user) | Matching configurations at that target |
|---|---:|---|
| Kimi K3 | 45 | MI355X / vLLM |
| GLM 5.2/5.3 (`GLM-5.2` API bucket) | 100 | B200 / SGLang; B300 / SGLang |
| DeepSeek V4 Pro | 24 | B200 / vLLM; B300 / SGLang; MI355X / vLLM, ATOM, SGLang |
| DeepSeek V4.1 Flash | 125 | H200 / vLLM |
| MiniMax M3 | 83 | None at the default target |

MiniMax has usable rows at other targets on H100, H200, MI300X, and B200/B300 TensorRT-LLM. Qwen3.5/H200 and Qwen3.8/H100 also have usable data but are outside the existing estimator model list. GB200/GB300 still need matching system models; other gaps include partial allocations, unsupported topology, invalid original knots and missing telemetry. This PR does not backfill data or expand the model list.

The shared mapper preserves power for run-keyed rows, covered by a unit test. The current Profit Estimator does not render unofficial-run overlays; this PR retains that boundary.

## Validation

- Final head `d428460f`: all eight Chrome/Firefox E2E shards, component tests, unit tests/typecheck, lint/format, CodeQL, Vercel preview and automated reviews passed. Both review threads are resolved.
- Syncing master includes the reliability fixture-clock fix from #1130. The original seven Reliability failures in each browser are resolved in CI.
- Local Profit Estimator suite: **47 passed**; focused unit suites: **91 passed**. The local demo uses live API data, so its Reliability bar-count assertion differs from CI's saved fixture (9→9 versus 9→7); the fixture-backed CI suite passes.
- Live API browser checks confirmed **nine matched pairs across four models**, MiniMax's unavailable default, unchanged targets and no browser exceptions. The final automated review also verified the locked/unlocked control and paired Kimi bars against the read-only database.
- English/Chinese controls, captions, unavailable messages and documentation were checked for matching meaning.

## 中文说明

在现有每 GW 利润估算器的基准测试配置中增加由内部功能开关控制的功耗估算方式：预配功耗（默认）、实测加建模功耗，以及同口径对比。模型、P90 目标、原吞吐量前沿、token 比例、价格、利用率和每 GPU 小时成本保持不变。

锁定时隐藏选项和额外功耗说明，分享链接中的 `c_power` 也不会启用其他计算或请求完整功耗数据。按 ↑↑↓↓ 解锁；重新锁定后立即恢复预配功耗估算。历史估算不可用时，通过硬件注册表获取缺失的芯片名称，并附上来源日期或运行标签，避免图注和空图状态崩溃或与当前结果混淆。

功耗计算读取完整基准数据，当前结果和历史结果都保留原数据点的功耗。点间使用原前沿的同一对数据点估算功耗，不换用其他点填补缺失。仅接纳通过验证的 schema-v2 功耗和有适用模型的完整单节点八卡机箱。缺失或不支持的配置保持不可用，图表、CSV 和分享链接均标明所选方式。

沿用固定版本的系统模型，PUE 取 1.3，另加 10% 功耗余量。这是明确标注假设的估算，尚未完成 AgentX 系统校准或峰值供电容量验证。单位成本随容量同比例换算，不另行重新计算电费。原 8K/1K 路径和每芯片小时估算器行为不变。

本次检查覆盖八个已发布的 AgentX 模型数据桶，共 703 行，其中 292 行具有有效 schema-v2 功耗。按现有默认 P90 目标，Kimi K3 可用 MI355X/vLLM；GLM 5.2/5.3 可用 B200、B300/SGLang；DeepSeek V4 Pro 可用 B200/vLLM、B300/SGLang 及 MI355X 的 vLLM、ATOM、SGLang；DeepSeek V4.1 Flash 可用 H200/vLLM。MiniMax M3 在默认 83 tok/s/user 下没有匹配结果，但在其他目标范围有 H100、H200、MI300X 和 B200/B300 TensorRT-LLM 数据。Qwen3.5/H200、Qwen3.8/H100 也有可用数据，但不属于当前估算器模型列表。本 PR 不回填数据、不扩展模型列表，也不新增非正式运行叠加显示。

最终提交 `d428460f` 的八组 Chrome/Firefox E2E 测试、组件测试、单元测试、类型检查、lint、格式、CodeQL、Vercel 预览及自动审查均通过，两条审查讨论已解决。同步 master 后纳入 #1130 的测试时钟修复，原先两种浏览器各七项 Reliability 测试失败已在 CI 中消除。

本地利润估算器的 47 项 Cypress 测试、91 项针对性单元测试通过。本地演示使用真实 API 数据，Reliability 的柱数从 9 保持为 9；CI 保存的数据则从 9 减至 7，因此该断言以使用保存数据的 CI 结果为准。真实数据浏览器检查确认四个模型共九组匹配对比；最终自动审查也验证了功能开关和 Kimi 配对柱形。中英文文案含义已核对。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes profit scaling and benchmark API fetch paths for an opt-in gated feature; core provisioned and chip-hour estimators are unchanged, but modeled power admission rules affect which SKUs render.
> 
> **Overview**
> The per-GW Profit Estimator gains an insider-gated **Power Estimation** control (provisioned vs measured+modeled vs side-by-side compare). Only the kW/GPU used to scale benchmarks to one GW changes—throughput, pricing, utilization, and $/GPU-hr stay fixed, so revenue, TCO, license fee, and profit scale together while margin stays the same.
> 
> When unlocked, the UI loads full benchmark rows (not the calculator projection), keeps `sourceRow` on frontier knots, and derives facility kW/GPU via `modelSystemPower` on validated schema-v2 AgentX telemetry for complete eight-GPU single-node chassis (with PUE 1.3 and 10% headroom). Power between knots is linearly interpolated on the same bracket as throughput; invalid or partial configs surface as `no-measured-power` with registry-backed labels for history. Share URLs persist `c_power`; locked mode ignores overrides and skips extra fetches. Documentation and EN/ZH copy describe assumptions; Cypress and unit tests cover gating, compare mode, and calculation invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d428460f18f31205c283bcf8d11fc948fdef01dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->